### PR TITLE
add op + for unary expressions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -866,6 +866,10 @@ class ExpressionChecker:
                                                               operand_type, e)
             result, method_type = self.check_call(method_type, [], [], e)
             e.method_type = method_type
+        elif op == '+':
+            return e.expr.accept(self)
+        else:
+            raise NotImplementedError(op)
         return result
     
     def visit_index_expr(self, e: IndexExpr) -> Type:


### PR DESCRIPTION
Running the typechecker on code like

```
def foo():
  return +1
```

will result in an exception.
