### PR TITLE
create empty stub dir if it does not exist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ stubs = []
 
 for version in ['3.4', '3.3', '3.2', '2.7']:
     base = os.path.join('stubs', version)
+    if not os.path.exists(base):
+        os.mkdir(base)
+
     stub_dirs = [''] + [name for name in os.listdir(base)
                         if os.path.isdir(os.path.join(base, name))]
     for stub_dir in stub_dirs:


### PR DESCRIPTION
I get the error:

``` python
Traceback (most recent call last):
  File "setup.py", line 29, in <module>
    stub_dirs = [''] + [name for name in os.listdir(base)
FileNotFoundError: [Errno 2] No such file or directory: 'stubs/3.3'
```

This is because 3.3 doesn't exist (either because its empty or was omitted).
I considered just skipping it, but it appears in build.py that it is implicitly assumed to exist.
