### PR TITLE
Fix #413.Do not allow implicit access to internal definitions in builtins.

### DIFF
--- a/stubs/3.2/builtins.py
+++ b/stubs/3.2/builtins.py
@@ -25,7 +25,7 @@ staticmethod = object() # Only valid as a decorator.
 classmethod = object() # Only valid as a decorator.
 property = object()
 
-_byte_types = Union[bytes, bytearray]
+_byte_types = typevar('_byte_types', values=(bytes, bytearray))
 
 
 @builtinclass


### PR DESCRIPTION
Fix #413.Do not allow implicit access to internal definitions in builtins.
