### PR TITLE
Fix #413.Do not allow implicit access to internal definitions in builtins

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1351,6 +1351,9 @@ class SemanticAnalyzer(NodeVisitor):
         if b:
             table = cast(MypyFile, b.node).names
             if name in table:
+                if name[0] == "_" and name[1] != "_":
+                    self.name_not_defined(name, ctx)
+                    return None
                 node = table[name]
                 # Only succeed if we are not using a type alias such List -- these must be
                 # be accessed via the typing module.


### PR DESCRIPTION
Filtering out names that start with only one underscore when looking them up.
