### PR TITLE
Move Python 2 evaluation tests into python2eval.test

### DIFF
--- a/mypy/test/data/python2eval.test
+++ b/mypy/test/data/python2eval.test
@@ -234,3 +234,16 @@ if 1 == 2: # Only type check, do not execute
 print 'ok'
 [out]
 ok
+
+[case testUnionType_python2]
+from typing import Undefined, Union
+y = Undefined(Union[int, str])
+def f(x): # type: (Union[int, str]) -> str
+    if isinstance(x, int):
+        x = str(x)
+    return x
+print f(12)
+print f('ab')
+[out]
+12
+ab

--- a/mypy/test/data/pythoneval.test
+++ b/mypy/test/data/pythoneval.test
@@ -897,19 +897,6 @@ f(tuple())
 [out]
 ()
 
-[case testUnionType_python2]
-from typing import Undefined, Union
-y = Undefined(Union[int, str])
-def f(x): # type: (Union[int, str]) -> str
-    if isinstance(x, int):
-        x = str(x)
-    return x
-print f(12)
-print f('ab')
-[out]
-12
-ab
-
 [case testMapWithLambdaSpecialCase]
 from typing import List, Iterator
 a = [[1], [3]]


### PR DESCRIPTION
Moves all tests that have '*_python2' in their names from mypy/test/data/pythoneval.test to mypy/test/data/python2eval.test.

Is this acceptable as a solution for issue #356?
