### PR TITLE
Add missing types for testSubtypingFunctionTypes in check-functions.test

### DIFF
--- a/mypy/test/data/check-functions.test
+++ b/mypy/test/data/check-functions.test
@@ -30,7 +30,7 @@ class B(A): pass
 f = Undefined(Function[[B], A])
 g = Undefined(Function[[A], A])  # subtype of f
 h = Undefined(Function[[B], B])  # subtype of f
-g = h  # E: Incompatible types in assignment (expression has type , variable has type )
+g = h  # E: Incompatible types in assignment (expression has type Function[[A], A], variable has type Function[[B], B])
 h = f  # E: Incompatible types in assignment (expression has type , variable has type )
 h = g  # E: Incompatible types in assignment (expression has type , variable has type )
 g = f  # E: Incompatible types in assignment (expression has type , variable has type )


### PR DESCRIPTION
This is based on what is available in testCallingVariableWithFunctionType, I hope I got it right.

There are quite a few types missing from mypy/test/data/check-functions.test, is this acceptable as a start towards resolving issue #426?
