### PR TITLE
Fixes type inference of type var from context

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -153,7 +153,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
     # Non-trivial leaf type
 
     def visit_type_var(self, template: TypeVar) -> List[Constraint]:
-        return [Constraint(template.id, SUPERTYPE_OF, self.actual)]
+        return [Constraint(template.id, self.direction, self.actual)]
 
     # Non-leaf types
 


### PR DESCRIPTION
For type vars, `ConstraintBuilderVisitor` always created a constraint in the `SUPERTYPE_OF` direction for type vars, irrespective of its `direction` field, which is wrong. This fixes both issue #360 as well as the errors reported by Travis in #443.

Currently, 15 tests are failing because the error messages changed due to the fix. Sometimes they became more accurate; sometimes they became wrong (reporting incompatible types of an _assignment_ instead of _arguments_). Before I fix the messages and test cases, I'd like someone to look at the fix and confirm that it is indeed correct now.

The following example (extension of the one from #360) shows that this pull request fixes that issue and correctly reports a type error in the last line.

``` python
from typing import AnyStr

def f(x: AnyStr) -> AnyStr:
    if isinstance(x, str):
        return 'foo'
    else:
        return b'zar'

def g(s: str): pass

f('')  # OK
repr(f(''))   # OK: repr expect object and get str. Used to give an incorrect type error

g(f('string'))
g(f(b'bytes'))   # E: Argument 1 to "g" has incompatible type "bytes"; expected "str"
```
