### PR TITLE
Added semanal error message for assignment to empty tuple

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -797,6 +797,8 @@ class SemanticAnalyzer(NodeVisitor):
         elif (isinstance(lval, TupleExpr) or
               isinstance(lval, ListExpr)) and not nested:
             items = (Any(lval)).items
+            if len(items) == 0 and isinstance(lval, TupleExpr):
+                self.fail("Can't assign to ()", lval)
             for i in items:
                 self.analyse_lvalue(i, nested=True, add_global=add_global,
                                     explicit_type = explicit_type)

--- a/mypy/test/data/semanal-errors.test
+++ b/mypy/test/data/semanal-errors.test
@@ -353,11 +353,13 @@ main, line 2: 'yield' outside function
 (1) = 1
 (1, 1) = 1
 [1, 1] = 1
+() = 1
 [out]
 main, line 1: Invalid assignment target
 main, line 2: Invalid assignment target
 main, line 3: Invalid assignment target
 main, line 4: Invalid assignment target
+main, line 5: Can't assign to ()
 
 [case testInvalidLvalues2]
 x = y = z = 1


### PR DESCRIPTION
For this snippet:

``` python
() = 1
```

mypy used to report `Incompatible types in assignment`, which is not very accurate.

With this PR, the message becomes `Can't assign to ()`, which is in line with Pythons error message.
