### PR TITLE
Make the AST classes not ABCs

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -14,7 +14,7 @@ from mypy.visitor import NodeVisitor
 from mypy.util import dump_tagged, short_type
 
 
-class Context(metaclass=ABCMeta):
+class Context:
     """Base type for objects that are valid as error message locations."""
     @abstractmethod
     def get_line(self) -> int: pass


### PR DESCRIPTION
This results in roughly a 20% speedup on the non-parsing steps.
Here are the timings I got from running mypy on itself:

Before the change:
```
3861.8ms (49.0%) SemanticallyAnalyzedFile
2760.3ms (35.0%) UnprocessedFile
1111.8ms (14.1%) ParsedFile
 142.8ms ( 1.8%) PartiallySemanticallyAnalyzedFile
```

After the change:
```
3086.1ms (45.1%) SemanticallyAnalyzedFile
2665.1ms (39.0%) UnprocessedFile
 945.1ms (13.8%) ParsedFile
 139.6ms ( 2.0%) PartiallySemanticallyAnalyzedFile
```

I've never used ABCs before so I can't really comment on how much is lost by switching away from them.

Closes #1274