### PR TITLE
Add `--disallow-untyped-functions`

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -54,6 +54,8 @@ SILENT_IMPORTS = 'silent-imports'  # Silence imports of .py files
 FAST_PARSER = 'fast-parser'      # Use experimental fast parser
 # Disallow calling untyped functions from typed ones
 DISALLOW_UNTYPED_CALLS = 'disallow-untyped-calls'
+# Disallow defining untyped (or incompletely typed) functions
+DISALLOW_UNTYPED_FUNCS = 'disallow-untyped-funcs'
 
 # State ids. These describe the states a source file / module can be in a
 # build.
@@ -383,7 +385,8 @@ class BuildManager:
         self.type_checker = TypeChecker(self.errors,
                                         modules,
                                         self.pyversion,
-                                        DISALLOW_UNTYPED_CALLS in self.flags)
+                                        DISALLOW_UNTYPED_CALLS in self.flags,
+                                        DISALLOW_UNTYPED_FUNCS in self.flags)
         self.states = []  # type: List[State]
         self.module_files = {}  # type: Dict[str, str]
         self.module_deps = {}  # type: Dict[Tuple[str, str], bool]

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -55,7 +55,7 @@ FAST_PARSER = 'fast-parser'      # Use experimental fast parser
 # Disallow calling untyped functions from typed ones
 DISALLOW_UNTYPED_CALLS = 'disallow-untyped-calls'
 # Disallow defining untyped (or incompletely typed) functions
-DISALLOW_UNTYPED_FUNCS = 'disallow-untyped-funcs'
+DISALLOW_UNTYPED_DEFS = 'disallow-untyped-defs'
 
 # State ids. These describe the states a source file / module can be in a
 # build.
@@ -386,7 +386,7 @@ class BuildManager:
                                         modules,
                                         self.pyversion,
                                         DISALLOW_UNTYPED_CALLS in self.flags,
-                                        DISALLOW_UNTYPED_FUNCS in self.flags)
+                                        DISALLOW_UNTYPED_DEFS in self.flags)
         self.states = []  # type: List[State]
         self.module_files = {}  # type: Dict[str, str]
         self.module_deps = {}  # type: Dict[Tuple[str, str], bool]

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -367,11 +367,11 @@ class TypeChecker(NodeVisitor[Type]):
     # This makes it an error to call an untyped function from a typed one
     disallow_untyped_calls = False
     # This makes it an error to define an untyped or partially-typed function
-    disallow_untyped_funcs = False
+    disallow_untyped_defs = False
 
     def __init__(self, errors: Errors, modules: Dict[str, MypyFile],
                  pyversion: Tuple[int, int] = defaults.PYTHON3_VERSION,
-                 disallow_untyped_calls=False, disallow_untyped_funcs=False) -> None:
+                 disallow_untyped_calls=False, disallow_untyped_defs=False) -> None:
         """Construct a type checker.
 
         Use errors to report type check errors. Assume symtable has been
@@ -395,7 +395,7 @@ class TypeChecker(NodeVisitor[Type]):
         self.pass_num = 0
         self.current_node_deferred = False
         self.disallow_untyped_calls = disallow_untyped_calls
-        self.disallow_untyped_funcs = disallow_untyped_funcs
+        self.disallow_untyped_defs = disallow_untyped_defs
 
     def visit_file(self, file_node: MypyFile, path: str) -> None:
         """Type check a mypy file with the given path."""
@@ -661,7 +661,7 @@ class TypeChecker(NodeVisitor[Type]):
                     self.fail(messages.INIT_MUST_HAVE_NONE_RETURN_TYPE,
                               item.type)
 
-                if self.disallow_untyped_funcs:
+                if self.disallow_untyped_defs:
                     # Check for functions with unspecified/not fully specified types.
                     def is_implicit_any(t: Type) -> bool:
                         return isinstance(t, AnyType) and t.implicit

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -181,6 +181,9 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
         elif args[0] == '--disallow-untyped-calls':
             options.build_flags.append(build.DISALLOW_UNTYPED_CALLS)
             args = args[1:]
+        elif args[0] == '--disallow-untyped-functions':
+            options.build_flags.append(build.DISALLOW_UNTYPED_FUNCS)
+            args = args[1:]
         elif args[0] in ('--version', '-V'):
             ver = True
             args = args[1:]
@@ -316,6 +319,8 @@ Options:
   -s, --silent-imports  don't follow imports to .py files
   --disallow-untyped-calls  disallow calling functions without type annotations
                             from functions with type annotations
+  --disallow-untyped-funcs  disallow defining functions without type annotations
+                            or with incomplete type annotations
   --implicit-any     behave as though all functions were annotated with Any
   -f, --dirty-stubs  don't warn if typeshed is out of sync
   --pdb              invoke pdb on fatal error

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -181,8 +181,8 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
         elif args[0] == '--disallow-untyped-calls':
             options.build_flags.append(build.DISALLOW_UNTYPED_CALLS)
             args = args[1:]
-        elif args[0] == '--disallow-untyped-functions':
-            options.build_flags.append(build.DISALLOW_UNTYPED_FUNCS)
+        elif args[0] == '--disallow-untyped-defs':
+            options.build_flags.append(build.DISALLOW_UNTYPED_DEFS)
             args = args[1:]
         elif args[0] in ('--version', '-V'):
             ver = True
@@ -319,7 +319,7 @@ Options:
   -s, --silent-imports  don't follow imports to .py files
   --disallow-untyped-calls  disallow calling functions without type annotations
                             from functions with type annotations
-  --disallow-untyped-funcs  disallow defining functions without type annotations
+  --disallow-untyped-defs   disallow defining functions without type annotations
                             or with incomplete type annotations
   --implicit-any     behave as though all functions were annotated with Any
   -f, --dirty-stubs  don't warn if typeshed is out of sync

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -73,6 +73,9 @@ GENERIC_TYPE_NOT_VALID_AS_EXPRESSION = \
 RETURN_TYPE_CANNOT_BE_CONTRAVARIANT = "Cannot use a contravariant type variable as return type"
 FUNCTION_PARAMETER_CANNOT_BE_COVARIANT = "Cannot use a covariant type variable as a parameter"
 INCOMPATIBLE_IMPORT_OF = "Incompatible import of"
+FUNCTION_TYPE_EXPECTED = "Function is missing a type annotation"
+RETURN_TYPE_EXPECTED = "Function is missing a return type annotation"
+ARGUMENT_TYPE_EXPECTED = "Function is missing a type annotation for one or more arguments"
 
 
 class MessageBuilder:

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -477,8 +477,8 @@ class Parser:
                 if is_method and name == '__init__':
                     ret_type = UnboundType('None', [])
                 else:
-                    ret_type = AnyType()
-                typ = CallableType([AnyType() for _ in args],
+                    ret_type = AnyType(implicit=True)
+                typ = CallableType([AnyType(implicit=True) for _ in args],
                                    arg_kinds,
                                    [a.variable.name() for a in args],
                                    ret_type,
@@ -812,9 +812,9 @@ class Parser:
         arg_types = [arg.type_annotation for arg in args]
         for i in range(len(arg_types)):
             if arg_types[i] is None:
-                arg_types[i] = AnyType()
+                arg_types[i] = AnyType(implicit=True)
         if ret_type is None:
-            ret_type = AnyType()
+            ret_type = AnyType(implicit=True)
         arg_kinds = [arg.kind for arg in args]
         arg_names = [arg.variable.name() for arg in args]
         return CallableType(arg_types, arg_kinds, arg_names, ret_type, None, name=None,

--- a/mypy/test/data/check-flags.test
+++ b/mypy/test/data/check-flags.test
@@ -1,0 +1,32 @@
+# test cases for --disallow-untyped-defs
+
+[case testUnannotatedFunction]
+# flags: disallow-untyped-defs
+def f(x): pass
+[out]
+main: note: In function "f":
+main:2: error: Function is missing a type annotation
+
+[case testUnannotatedArgument]
+# flags: disallow-untyped-defs
+def f(x) -> int: pass
+[out]
+main: note: In function "f":
+main:2: error: Function is missing a type annotation for one or more arguments
+
+[case testNoArgumentFunction]
+# flags: disallow-untyped-defs
+def f() -> int: pass
+[out]
+
+[case testUnannotatedReturn]
+# flags: disallow-untyped-defs
+def f(x: int): pass
+[out]
+main: note: In function "f":
+main:2: error: Function is missing a return type annotation
+
+[case testLambda]
+# flags: disallow-untyped-defs
+lambda x: x
+[out]

--- a/mypy/test/data/lib-stub/builtins.py
+++ b/mypy/test/data/lib-stub/builtins.py
@@ -1,8 +1,10 @@
+class Any: pass
+
 class object:
     def __init__(self) -> None: pass
 
 class type:
-    def __init__(self, x) -> None: pass
+    def __init__(self, x: Any) -> None: pass
 
 # These are provided here for convenience.
 class int: pass

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -102,6 +102,10 @@ class TypeList(Type):
 class AnyType(Type):
     """The type 'Any'."""
 
+    def __init__(self, implicit=False, line: int = -1) -> None:
+        super().__init__(line)
+        self.implicit = implicit
+
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_any(self)
 


### PR DESCRIPTION
This is something we want to add sooner or later, so I figured I'd just add it now that someone's explicitly asked for it.  This catches ~10 incomplete signatures in `builtins.pyi` and `typing.pyi`, which would need to be fixed up in a separate typeshed PR.

Fixes #1282.