### PR TITLE
Cut disused attribute FuncItem.is_implicit

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -319,7 +319,6 @@ class FuncItem(FuncBase):
     # Maximum number of positional arguments, -1 if no explicit limit (*args not included)
     max_pos = 0
     body = None  # type: Block
-    is_implicit = False    # Implicit dynamic types?
     # Is this an overload variant of function with more than one overload variant?
     is_overload = False
     is_generator = False   # Contains a yield statement?

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -127,7 +127,6 @@ class TransformVisitor(NodeVisitor[Node]):
         new.info = original.info
         new.min_args = original.min_args
         new.max_pos = original.max_pos
-        new.is_implicit = original.is_implicit
         new.is_overload = original.is_overload
         new.is_generator = original.is_generator
 


### PR DESCRIPTION
This stopped being used in 6dca530 "Remove obsolete transform-related code",
in Sep 2014.