### PR TITLE
Rename --implicit-any to --check-untyped-defs and do some cleanup

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -56,6 +56,8 @@ FAST_PARSER = 'fast-parser'      # Use experimental fast parser
 DISALLOW_UNTYPED_CALLS = 'disallow-untyped-calls'
 # Disallow defining untyped (or incompletely typed) functions
 DISALLOW_UNTYPED_DEFS = 'disallow-untyped-defs'
+# Type check unannotated functions
+CHECK_UNTYPED_DEFS = 'check-untyped-defs'
 
 # State ids. These describe the states a source file / module can be in a
 # build.
@@ -124,7 +126,6 @@ def build(sources: List[BuildSource],
           bin_dir: str = None,
           pyversion: Tuple[int, int] = defaults.PYTHON3_VERSION,
           custom_typing_module: str = None,
-          implicit_any: bool = False,
           report_dirs: Dict[str, str] = None,
           flags: List[str] = None,
           python_path: bool = False) -> BuildResult:
@@ -144,7 +145,6 @@ def build(sources: List[BuildSource],
         directories; if omitted, use '.' as the data directory
       pyversion: Python version (major, minor)
       custom_typing_module: if not None, use this module id as an alias for typing
-      implicit_any: if True, add implicit Any signatures to all functions
       flags: list of build options (e.g. COMPILE_ONLY)
     """
     report_dirs = report_dirs or {}
@@ -194,7 +194,6 @@ def build(sources: List[BuildSource],
                            pyversion=pyversion, flags=flags,
                            ignore_prefix=os.getcwd(),
                            custom_typing_module=custom_typing_module,
-                           implicit_any=implicit_any,
                            reports=reports)
 
     # Construct information that describes the initial files. __main__ is the
@@ -366,7 +365,6 @@ class BuildManager:
                  flags: List[str],
                  ignore_prefix: str,
                  custom_typing_module: str,
-                 implicit_any: bool,
                  reports: Reports) -> None:
         self.data_dir = data_dir
         self.errors = Errors()
@@ -376,7 +374,6 @@ class BuildManager:
         self.pyversion = pyversion
         self.flags = flags
         self.custom_typing_module = custom_typing_module
-        self.implicit_any = implicit_any
         self.reports = reports
         self.semantic_analyzer = SemanticAnalyzer(lib_path, self.errors,
                                                   pyversion=pyversion)
@@ -386,7 +383,8 @@ class BuildManager:
                                         modules,
                                         self.pyversion,
                                         DISALLOW_UNTYPED_CALLS in self.flags,
-                                        DISALLOW_UNTYPED_DEFS in self.flags)
+                                        DISALLOW_UNTYPED_DEFS in self.flags,
+                                        CHECK_UNTYPED_DEFS in self.flags)
         self.states = []  # type: List[State]
         self.module_files = {}  # type: Dict[str, str]
         self.module_deps = {}  # type: Dict[Tuple[str, str], bool]
@@ -853,7 +851,6 @@ class UnprocessedFile(State):
         tree = parse.parse(source_text, fnam, self.errors(),
                            pyversion=self.manager.pyversion,
                            custom_typing_module=self.manager.custom_typing_module,
-                           implicit_any=self.manager.implicit_any,
                            fast_parser=FAST_PARSER in self.manager.flags)
         tree._fullname = self.id
         if self.errors().num_messages() != num_errs:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -33,7 +33,7 @@ T = TypeVar('T')
 
 def parse(source: Union[str, bytes], fnam: str = None, errors: Errors = None,
           pyversion: Tuple[int, int] = defaults.PYTHON3_VERSION,
-          custom_typing_module: str = None, implicit_any: bool = False) -> MypyFile:
+          custom_typing_module: str = None) -> MypyFile:
     """Parse a source file, without doing any semantic analysis.
 
     Return the parse tree. If errors is not provided, raise ParseError

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -25,7 +25,6 @@ class Options:
         self.build_flags = []  # type: List[str]
         self.pyversion = defaults.PYTHON3_VERSION
         self.custom_typing_module = None  # type: str
-        self.implicit_any = False
         self.report_dirs = {}  # type: Dict[str, str]
         self.python_path = False
         self.dirty_stubs = False
@@ -91,7 +90,6 @@ def type_check_only(sources: List[BuildSource],
                 bin_dir=bin_dir,
                 pyversion=options.pyversion,
                 custom_typing_module=options.custom_typing_module,
-                implicit_any=options.implicit_any,
                 report_dirs=options.report_dirs,
                 flags=options.build_flags,
                 python_path=options.python_path)
@@ -135,8 +133,8 @@ def process_options() -> Tuple[List[BuildSource], Options]:
     parser.add_argument('--disallow-untyped-defs', action='store_true',
                         help="disallow defining functions without type annotations"
                         " or with incomplete type annotations")
-    parser.add_argument('--implicit-any', action='store_true',
-                        help="behave as though all functions were annotated with Any")
+    parser.add_argument('--check-untyped-defs', action='store_true',
+                        help="type check the interior of functions without type annotations")
     parser.add_argument('--fast-parser', action='store_true',
                         help="enable experimental fast parser")
     parser.add_argument('-f', '--dirty-stubs', action='store_true',
@@ -187,7 +185,6 @@ def process_options() -> Tuple[List[BuildSource], Options]:
     options.dirty_stubs = args.dirty_stubs
     options.python_path = args.use_python_path
     options.pdb = args.pdb
-    options.implicit_any = args.implicit_any
     options.custom_typing_module = args.custom_typing
 
     # Set build flags.
@@ -211,6 +208,9 @@ def process_options() -> Tuple[List[BuildSource], Options]:
 
     if args.disallow_untyped_defs:
         options.build_flags.append(build.DISALLOW_UNTYPED_DEFS)
+
+    if args.check_untyped_defs:
+        options.build_flags.append(build.CHECK_UNTYPED_DEFS)
 
     # experimental
     if args.fast_parser:

--- a/mypy/test/data/check-flags.test
+++ b/mypy/test/data/check-flags.test
@@ -1,5 +1,3 @@
-# test cases for --disallow-untyped-defs
-
 [case testUnannotatedFunction]
 # flags: disallow-untyped-defs
 def f(x): pass
@@ -30,3 +28,11 @@ main:2: error: Function is missing a return type annotation
 # flags: disallow-untyped-defs
 lambda x: x
 [out]
+
+[case testUntypedDef]
+# flags: disallow-untyped-defs
+def f():
+    1 + "str"
+[out]
+main: note: In function "f":
+main:2: error: Function is missing a type annotation


### PR DESCRIPTION
- Use a build flag instead of adding a bool in Options.
- Change the typing mode instead of adding implicit Any's to function
  definitions.
- Add test.

Fixes #1233.