### PR TITLE
A decorator returning Callable[..., T] should work on a method.

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -231,8 +231,8 @@ def lookup_member_var_or_accessor(info: TypeInfo, name: str,
 def check_method_type(functype: FunctionLike, itype: Instance,
                       context: Context, msg: MessageBuilder) -> None:
     for item in functype.items():
-        if not item.arg_types or item.arg_kinds[0] != ARG_POS:
-            # No positional first (self) argument.
+        if not item.arg_types or item.arg_kinds[0] not in (ARG_POS, ARG_STAR):
+            # No positional first (self) argument (*args is okay).
             msg.invalid_method_type(item, context)
         else:
             # Check that self argument has type 'Any' or valid instance type.

--- a/mypy/test/data/check-varargs.test
+++ b/mypy/test/data/check-varargs.test
@@ -557,3 +557,15 @@ x = f
 x = g # E: Incompatible types in assignment (expression has type Callable[[str], None], variable has type Callable[[int], None])
 [builtins fixtures/list.py]
 [out]
+
+
+-- Decorated method where self is implied by *args
+-- -----------------------------------------------
+
+[case testVarArgsCallableSelf]
+from typing import Callable
+def cm(func) -> Callable[..., None]: pass
+class C:
+    @cm
+    def foo(self) -> None: pass
+C().foo()


### PR DESCRIPTION
 Fixes #1301.