### PR TITLE
Allow semantic analyzer errors to be suppressed with # type: ignore

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2357,7 +2357,9 @@ class ThirdPass(TraverserVisitor[None]):
 
     def visit_file(self, file_node: MypyFile, fnam: str) -> None:
         self.errors.set_file(fnam)
+        self.errors.set_ignored_lines(file_node.ignored_lines)
         file_node.accept(self)
+        self.errors.set_ignored_lines(set())
 
     def visit_func_def(self, fdef: FuncDef) -> None:
         self.errors.push_function(fdef.name())

--- a/mypy/test/data/check-ignore.test
+++ b/mypy/test/data/check-ignore.test
@@ -146,3 +146,26 @@ if 1:  # type: ignore
     # blah
     pass
 [out]
+
+[case testIgnoreTooManyTypeArguments]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+U = TypeVar('U')
+
+class Base(Generic[T, U]):
+  pass
+
+class PartialBase(Base[T, int], Generic[T]):
+  pass
+
+class Child(PartialBase[str, int]):  # type: ignore
+  pass
+
+
+def foo(x: Base[str, int]) -> None: pass
+foo(Child())
+
+def bar(x: Base[str, str]) -> None: pass
+bar(Child())
+[out]
+main:19: error: Argument 1 to "bar" has incompatible type "Child"; expected Base[str, str]


### PR DESCRIPTION
This lets users work around #1304 for now by repeating the full concretization of parent types in child subclasses and adding a # type: ignore.