### PR TITLE
Add a line-count report

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,19 @@ To run the linter:
     $ ./runtests.py lint
 
 
+Coverage reports
+----------------
+
+There is an experimental feature to generate coverage reports.  To use
+this feature, you need to `pip install lxml`.  This is an extension
+module and requires various library headers to install; on a
+Debian-derived system the command
+  apt-get install python3-dev libxml2-dev libxslt1-dev
+may provide the necessary dependencies.
+
+To use the feature, pass e.g. `--txt-report "$(mktemp -d)"`.
+
+
 Development status
 ------------------
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -182,9 +182,7 @@ def build(sources: List[BuildSource],
     if alt_lib_path:
         lib_path.insert(0, alt_lib_path)
 
-    # TODO Reports is global to a build manager but only supports a single "main file"
-    # Fix this.
-    reports = Reports(sources[0].effective_path, data_dir, report_dirs)
+    reports = Reports(sources, data_dir, report_dirs)
 
     # Construct a build manager object that performs all the stages of the
     # build in the correct order.

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -120,6 +120,33 @@ class BuildSource:
         return self.path or '<string>'
 
 
+class BuildSourceSet:
+    """Efficiently test a file's membership in the set of build sources."""
+
+    def __init__(self, sources: List[BuildSource]) -> None:
+        self.source_text_present = False
+        self.source_modules = set()  # type: Set[str]
+        self.source_paths = set()  # type: Set[str]
+
+        for source in sources:
+            if source.text is not None:
+                self.source_text_present = True
+            elif source.path:
+                self.source_paths.add(source.path)
+            else:
+                self.source_modules.add(source.module)
+
+    def is_source(self, file: MypyFile) -> bool:
+        if file.path and file.path in self.source_paths:
+            return True
+        elif file._fullname in self.source_modules:
+            return True
+        elif file.path is None and self.source_text_present:
+            return True
+        else:
+            return False
+
+
 def build(sources: List[BuildSource],
           target: int,
           alt_lib_path: str = None,
@@ -184,6 +211,8 @@ def build(sources: List[BuildSource],
 
     reports = Reports(sources, data_dir, report_dirs)
 
+    source_set = BuildSourceSet(sources)
+
     # Construct a build manager object that performs all the stages of the
     # build in the correct order.
     #
@@ -192,6 +221,7 @@ def build(sources: List[BuildSource],
                            pyversion=pyversion, flags=flags,
                            ignore_prefix=os.getcwd(),
                            custom_typing_module=custom_typing_module,
+                           source_set=source_set,
                            reports=reports)
 
     # Construct information that describes the initial files. __main__ is the
@@ -363,6 +393,7 @@ class BuildManager:
                  flags: List[str],
                  ignore_prefix: str,
                  custom_typing_module: str,
+                 source_set: BuildSourceSet,
                  reports: Reports) -> None:
         self.data_dir = data_dir
         self.errors = Errors()
@@ -372,6 +403,7 @@ class BuildManager:
         self.pyversion = pyversion
         self.flags = flags
         self.custom_typing_module = custom_typing_module
+        self.source_set = source_set
         self.reports = reports
         self.semantic_analyzer = SemanticAnalyzer(lib_path, self.errors,
                                                   pyversion=pyversion)
@@ -576,6 +608,10 @@ class BuildManager:
             pass  # Nothing to do.
         else:
             raise RuntimeError('Unsupported target %d' % self.target)
+
+    def report_file(self, file: MypyFile) -> None:
+        if self.source_set.is_source(file):
+            self.reports.file(file, type_map=self.type_checker.type_map)
 
     def log(self, message: str) -> None:
         if VERBOSE in self.flags:
@@ -929,7 +965,7 @@ class SemanticallyAnalyzedFile(ParsedFile):
             if DUMP_INFER_STATS in self.manager.flags:
                 stats.dump_type_stats(self.tree, self.tree.path, inferred=True,
                                       typemap=self.manager.type_checker.type_map)
-            self.manager.reports.file(self.tree, type_map=self.manager.type_checker.type_map)
+            self.manager.report_file(self.tree)
 
         # FIX remove from active state list to speed up processing
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -209,7 +209,7 @@ def build(sources: List[BuildSource],
     if alt_lib_path:
         lib_path.insert(0, alt_lib_path)
 
-    reports = Reports(sources, data_dir, report_dirs)
+    reports = Reports(data_dir, report_dirs)
 
     source_set = BuildSourceSet(sources)
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -155,6 +155,7 @@ def process_options() -> Tuple[List[BuildSource], Options]:
     report_group.add_argument('--xml-report', metavar='DIR')
     report_group.add_argument('--txt-report', metavar='DIR')
     report_group.add_argument('--xslt-txt-report', metavar='DIR')
+    report_group.add_argument('--linecount-report', metavar='DIR')
 
     code_group = parser.add_argument_group(title='How to specify the code to type check')
     code_group.add_argument('-m', '--module', help="type-check module (may be a dotted name)")

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -7,7 +7,6 @@ import shutil
 
 from typing import Callable, Dict, List, Tuple, cast
 
-import mypy.build
 from mypy.nodes import MypyFile, Node, FuncDef
 from mypy import stats
 from mypy.traverser import TraverserVisitor
@@ -18,9 +17,7 @@ reporter_classes = {}  # type: Dict[str, Callable[[Reports, str], AbstractReport
 
 
 class Reports:
-    def __init__(self, sources: List['mypy.build.BuildSource'],
-                 data_dir: str, report_dirs: Dict[str, str]) -> None:
-        self.sources = sources
+    def __init__(self, data_dir: str, report_dirs: Dict[str, str]) -> None:
         self.data_dir = data_dir
         self.reporters = []  # type: List[AbstractReporter]
         self.named_reporters = {}  # type: Dict[str, AbstractReporter]
@@ -144,7 +141,6 @@ class MemoryXmlReporter(AbstractReporter):
 
         super().__init__(reports, output_dir)
 
-        self.report_name = reports.sources[0].effective_path
         self.xslt_html_path = os.path.join(reports.data_dir, 'xml', 'mypy-html.xslt')
         self.xslt_txt_path = os.path.join(reports.data_dir, 'xml', 'mypy-txt.xslt')
         self.css_html_path = os.path.join(reports.data_dir, 'xml', 'mypy-html.css')
@@ -197,7 +193,7 @@ class MemoryXmlReporter(AbstractReporter):
         # index_path = os.path.join(self.output_dir, 'index.xml')
         output_files = sorted(self.files, key=lambda x: x.module)
 
-        root = etree.Element('mypy-report-index', name=self.report_name)
+        root = etree.Element('mypy-report-index', name='index')
         doc = etree.ElementTree(root)
 
         for file_info in output_files:

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -7,6 +7,7 @@ import shutil
 
 from typing import Callable, Dict, List, cast
 
+import mypy.build
 from mypy.types import Type
 from mypy.nodes import MypyFile, Node
 from mypy import stats
@@ -16,8 +17,8 @@ reporter_classes = {}  # type: Dict[str, Callable[[Reports, str], AbstractReport
 
 
 class Reports:
-    def __init__(self, main_file: str, data_dir: str, report_dirs: Dict[str, str]) -> None:
-        self.main_file = main_file
+    def __init__(self, sources: List['mypy.build.BuildSource'], data_dir: str, report_dirs: Dict[str, str]) -> None:
+        self.sources = sources
         self.data_dir = data_dir
         self.reporters = []  # type: List[AbstractReporter]
         self.named_reporters = {}  # type: Dict[str, AbstractReporter]
@@ -97,7 +98,7 @@ class MemoryXmlReporter(AbstractReporter):
 
         super().__init__(reports, output_dir)
 
-        self.main_file = reports.main_file
+        self.report_name = reports.sources[0].effective_path
         self.xslt_html_path = os.path.join(reports.data_dir, 'xml', 'mypy-html.xslt')
         self.xslt_txt_path = os.path.join(reports.data_dir, 'xml', 'mypy-txt.xslt')
         self.css_html_path = os.path.join(reports.data_dir, 'xml', 'mypy-html.css')
@@ -150,7 +151,7 @@ class MemoryXmlReporter(AbstractReporter):
         # index_path = os.path.join(self.output_dir, 'index.xml')
         output_files = sorted(self.files, key=lambda x: x.module)
 
-        root = etree.Element('mypy-report-index', name=self.main_file)
+        root = etree.Element('mypy-report-index', name=self.report_name)
         doc = etree.ElementTree(root)
 
         for file_info in output_files:

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -18,7 +18,8 @@ reporter_classes = {}  # type: Dict[str, Callable[[Reports, str], AbstractReport
 
 
 class Reports:
-    def __init__(self, sources: List['mypy.build.BuildSource'], data_dir: str, report_dirs: Dict[str, str]) -> None:
+    def __init__(self, sources: List['mypy.build.BuildSource'],
+                 data_dir: str, report_dirs: Dict[str, str]) -> None:
         self.sources = sources
         self.data_dir = data_dir
         self.reporters = []  # type: List[AbstractReporter]
@@ -60,7 +61,6 @@ class AbstractReporter(metaclass=ABCMeta):
         pass
 
 
-
 class FuncCounterVisitor(TraverserVisitor):
     def __init__(self) -> None:
         super().__init__()
@@ -88,10 +88,12 @@ class LineCountReporter(AbstractReporter):
         imputed_annotated_lines = (physical_lines * annotated_funcs // total_funcs
                                    if total_funcs else physical_lines)
 
-        self.counts[tree._fullname] = (imputed_annotated_lines, physical_lines, annotated_funcs, total_funcs)
+        self.counts[tree._fullname] = (imputed_annotated_lines, physical_lines,
+                                       annotated_funcs, total_funcs)
 
     def on_finish(self) -> None:
-        counts = sorted(((c, p) for p, c in self.counts.items()), reverse=True)  # type: List[Tuple[tuple, str]]
+        counts = sorted(((c, p) for p, c in self.counts.items()),
+                        reverse=True)  # type: List[Tuple[tuple, str]]
         total_counts = tuple(sum(c[i] for c, p in counts)
                              for i in range(4))
         with open(os.path.join(self.output_dir, 'linecount.txt'), 'w') as f:

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -5,12 +5,13 @@ import cgi
 import os
 import shutil
 
-from typing import Callable, Dict, List, cast
+from typing import Callable, Dict, List, Tuple, cast
 
 import mypy.build
-from mypy.types import Type
-from mypy.nodes import MypyFile, Node
+from mypy.nodes import MypyFile, Node, FuncDef
 from mypy import stats
+from mypy.traverser import TraverserVisitor
+from mypy.types import Type
 
 
 reporter_classes = {}  # type: Dict[str, Callable[[Reports, str], AbstractReporter]]
@@ -57,6 +58,49 @@ class AbstractReporter(metaclass=ABCMeta):
     @abstractmethod
     def on_finish(self) -> None:
         pass
+
+
+
+class FuncCounterVisitor(TraverserVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.counts = [0, 0]
+
+    def visit_func_def(self, defn: FuncDef):
+        self.counts[defn.type is not None] += 1
+
+
+class LineCountReporter(AbstractReporter):
+    def __init__(self, reports: Reports, output_dir: str) -> None:
+        super().__init__(reports, output_dir)
+        self.counts = {}  # type: Dict[str, Tuple[int, int, int, int]]
+
+        stats.ensure_dir_exists(output_dir)
+
+    def on_file(self, tree: MypyFile, type_map: Dict[Node, Type]) -> None:
+        physical_lines = len(open(tree.path).readlines())
+
+        func_counter = FuncCounterVisitor()
+        tree.accept(func_counter)
+        unannotated_funcs, annotated_funcs = func_counter.counts
+        total_funcs = annotated_funcs + unannotated_funcs
+
+        imputed_annotated_lines = (physical_lines * annotated_funcs // total_funcs
+                                   if total_funcs else physical_lines)
+
+        self.counts[tree._fullname] = (imputed_annotated_lines, physical_lines, annotated_funcs, total_funcs)
+
+    def on_finish(self) -> None:
+        counts = sorted(((c, p) for p, c in self.counts.items()), reverse=True)  # type: List[Tuple[tuple, str]]
+        total_counts = tuple(sum(c[i] for c, p in counts)
+                             for i in range(4))
+        with open(os.path.join(self.output_dir, 'linecount.txt'), 'w') as f:
+            f.write('{:7} {:7} {:6} {:6} total\n'.format(*total_counts))
+            for c, p in counts:
+                f.write('{:7} {:7} {:6} {:6} {}\n'.format(
+                    c[0], c[1], c[2], c[3], p))
+
+reporter_classes['linecount'] = LineCountReporter
 
 
 class OldHtmlReporter(AbstractReporter):


### PR DESCRIPTION
This report is aimed at measuring the total adoption of type annotations in the codebase being type-checked.  The bottom-line output is the "number of lines of annotated code, as physical LOC."

More details in individual commit messages.
