### PR TITLE
add Gentoo path to default_data_dir

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -285,6 +285,9 @@ def default_data_dir(bin_dir: str) -> str:
     elif base == 'python3':
         # Assume we installed python3 with brew on os x
         return os.path.join(os.path.dirname(dir), 'lib', 'mypy')
+    elif dir.endswith('python-exec'):
+        # Gentoo uses a python wrapper in /usr/lib to which mypy is a symlink.
+        return os.path.join(os.path.dirname(dir), 'mypy')
     else:
         # Don't know where to find the data files!
         raise RuntimeError("Broken installation: can't determine base dir")


### PR DESCRIPTION
Gentoo uses a wrapper around pythons to handle their dynamic default
python selection on a system with many versions of python installed
simultaneously.  Due to this mypy's script is a symlink to a file in
/usr/lib/python-exec/python3.5.  This means that the search path needs
to check if python-exec is being used and return the appropriate path
(usually '/usr/lib').  This patch works successfully on my Gentoo system.

Fixes #653.