### PR TITLE
fixing use of '--fast-parse' option

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -177,8 +177,7 @@ def process_options() -> Tuple[List[BuildSource], Options]:
         parser.error('Python version 2 (or --py2) specified, '
                      'but --use-python-path will search in sys.path of Python 3')
 
-    if args.fast_parser and (args.py2 or
-                             args.python_version and args.python_version[0] == 2):
+    if args.fast_parser and args.python_version and args.python_version[0] == 2:
         parser.error('The experimental fast parser is only compatible with Python 3, '
                      'but Python 2 specified.')
 

--- a/runtests.py
+++ b/runtests.py
@@ -154,7 +154,8 @@ def add_basic(driver: Driver) -> None:
     driver.add_flake8('legacy entry script', 'scripts/mypy')
     driver.add_mypy('legacy myunit script', 'scripts/myunit')
     driver.add_flake8('legacy myunit script', 'scripts/myunit')
-    driver.add_mypy('fast-parse', '--fast-parse', 'samples/hello.py')
+    # needs typed_ast installed:
+    # driver.add_mypy('fast-parse', '--fast-parse', 'samples/hello.py')
 
 
 def add_selftypecheck(driver: Driver) -> None:

--- a/runtests.py
+++ b/runtests.py
@@ -154,6 +154,7 @@ def add_basic(driver: Driver) -> None:
     driver.add_flake8('legacy entry script', 'scripts/mypy')
     driver.add_mypy('legacy myunit script', 'scripts/myunit')
     driver.add_flake8('legacy myunit script', 'scripts/myunit')
+    driver.add_mypy('fast-parse', '--fast-parse', 'samples/hello.py')
 
 
 def add_selftypecheck(driver: Driver) -> None:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,1 @@
 flake8
--e git+git://github.com/ddfisher/typed_ast.git#egg=typed_ast

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
 flake8
+-e git+git://github.com/ddfisher/typed_ast.git#egg=typed_ast


### PR DESCRIPTION
The option `args.py2` doesn't exist (has been renamed?) so using the `--fast-parse` option failed immediately at the command line argument parsing stage.

The test seems a bit heavy weight just to test the command line parsing, but I couldn't see another way.

~~Also I think you have pull request building switched off in travis?~~ building now I've actually created the pull request.