### PR TITLE
Get type information from isinstance assertions

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1709,6 +1709,16 @@ class TypeChecker(NodeVisitor[Type]):
     def visit_assert_stmt(self, s: AssertStmt) -> Type:
         self.accept(s.expr)
 
+        # If this is asserting some isinstance check, bind that type in the following code
+        true_map, _ = find_isinstance_check(
+            s.expr, self.type_map,
+            self.typing_mode_weak()
+        )
+
+        if true_map:
+            for var, type in true_map.items():
+                self.binder.push(var, type)
+
     def visit_raise_stmt(self, s: RaiseStmt) -> Type:
         """Type check a raise statement."""
         self.breaking_out = True

--- a/mypy/test/data/check-isinstance.test
+++ b/mypy/test/data/check-isinstance.test
@@ -817,3 +817,10 @@ def f(x: Union[A, B]) -> None:
     if not isinstance(x, B):
         f(x)
 [builtins fixtures/isinstance.py]
+
+[case testAssertIsinstance]
+def f(x: object):
+    assert isinstance(x, int)
+    y = 0 # type: int
+    y = x
+[builtins fixtures/isinstance.py]


### PR DESCRIPTION
Fixes #475.

Should probably be reviewed by someone who understands the checker's `self.binder`.