### PR TITLE
Allow overloading to succeed if an arg is an instance of a class derived from Any. Fix #1363.

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1626,7 +1626,7 @@ def overload_arg_similarity(actual: Type, formal: Type) -> int:
     if (isinstance(actual, NoneTyp) or isinstance(actual, AnyType) or
             isinstance(formal, AnyType) or isinstance(formal, TypeVarType) or
             isinstance(formal, CallableType) or
-            isinstance(actual, Instance) and actual.type.fallback_to_any):
+            (isinstance(actual, Instance) and actual.type.fallback_to_any)):
         # These could match anything at runtime.
         return 2
     if isinstance(actual, UnionType):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1625,7 +1625,8 @@ def overload_arg_similarity(actual: Type, formal: Type) -> int:
     """
     if (isinstance(actual, NoneTyp) or isinstance(actual, AnyType) or
             isinstance(formal, AnyType) or isinstance(formal, TypeVarType) or
-            isinstance(formal, CallableType)):
+            isinstance(formal, CallableType) or
+            isinstance(actual, Instance) and actual.type.fallback_to_any):
         # These could match anything at runtime.
         return 2
     if isinstance(actual, UnionType):

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -95,6 +95,8 @@ class SubtypeVisitor(TypeVisitor[bool]):
         return True
 
     def visit_instance(self, left: Instance) -> bool:
+        if left.type.fallback_to_any:
+            return True
         right = self.right
         if isinstance(right, Instance):
             if left.type._promote and is_subtype(left.type._promote,

--- a/mypy/test/data/check-overloading.test
+++ b/mypy/test/data/check-overloading.test
@@ -580,6 +580,6 @@ class C:
 
 class Derived(Base):
     def to_dict(self) -> C:
-        return C(self)  # fails without the hack
+        return C(self)  # fails without the fix for #1363
 C(Derived())  # fails without the hack
 C(Base())  # Always ok

--- a/mypy/test/data/check-overloading.test
+++ b/mypy/test/data/check-overloading.test
@@ -567,3 +567,19 @@ f(y=[''], x=0)() # E: "int" not callable
 a = f(y=[['']], x=0) # E: List item 0 has incompatible type List[str]
 a() # E: "int" not callable
 [builtins fixtures/list.py]
+
+[case testOverloadWithDerivedFromAny]
+from typing import Any, overload
+Base = None  # type: Any
+
+class C:
+    @overload
+    def __init__(self, a: str) -> None: pass
+    @overload
+    def __init__(self, a: int) -> None: pass
+
+class Derived(Base):
+    def to_dict(self) -> C:
+        return C(self)  # fails without the hack
+C(Derived())  # fails without the hack
+C(Base())  # Always ok


### PR DESCRIPTION
This has some tests that simulate the reported problem, and the hack makes them pass; but the reported case still fails outside the test harness (probably because fixtures/dict.py doesn't overload `__init__`).