### PR TITLE
Don't let -s silence .py imports from stubs. Fix #1364.

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -969,12 +969,18 @@ class State:
                 file_id = '__builtin__'
             path = find_module(file_id, manager.lib_path)
             if path:
-                # In silent mode, don't import .py files.
+                # In silent mode, don't import .py files, except from stubs.
                 if (SILENT_IMPORTS in manager.flags and
                         path.endswith('.py') and (caller_state or is_ancestor)):
-                    path = None
-                    manager.missing_modules.add(id)
-                    raise ModuleNotFound
+                    # (Never silence builtins, even if it's a .py file;
+                    # this can happen in tests!)
+                    if (id != 'builtins' and
+                        not ((caller_state and
+                              caller_state.tree and
+                              caller_state.tree.is_stub))):
+                        path = None
+                        manager.missing_modules.add(id)
+                        raise ModuleNotFound
             else:
                 # Could not find a module.  Typically the reason is a
                 # misspelled module name, missing stub, module not in

--- a/mypy/test/data/check-modules.test
+++ b/mypy/test/data/check-modules.test
@@ -698,3 +698,21 @@ class C(B):
     pass
 [out]
 tmp/bar.py:1: error: Module has no attribute 'B'
+
+[case testStubImportNonStubWhileSilent]
+# cmd: mypy -m main
+[file main.py]
+# flags: silent-imports
+from stub import x # Permitted
+from other import y # Disallowed
+x + '' # Error here
+y + '' # But not here
+[file stub.pyi]
+from non_stub import x
+[file non_stub.py]
+x = 42
+[file other.py]
+y = 42
+[builtins fixtures/module.py]
+[out]
+tmp/main.py:4: error: Unsupported left operand type for + ("int")


### PR DESCRIPTION
Implement the idea in the issue by Ben Darnell.  (However, this
implementation still silences the case where main.py -> stub.pyi ->
x.py -> y.py. Hopefully that doesn't matter.)