### PR TITLE
(Unrelated) Make `mypy -h` look a little prettier.

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -113,8 +113,8 @@ def process_options() -> Tuple[List[BuildSource], Options]:
     """
 
     # Make the help output a little less jarring.
-    help_factory = (lambda *a, **k:
-                    argparse.RawDescriptionHelpFormatter(max_help_position=28, *a, **k))
+    help_factory = (lambda prog:
+                    argparse.RawDescriptionHelpFormatter(prog=prog, max_help_position=28))
     parser = argparse.ArgumentParser(prog='mypy', epilog=FOOTER,
                                      formatter_class=help_factory)
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -112,8 +112,11 @@ def process_options() -> Tuple[List[BuildSource], Options]:
             parsed flags)
     """
 
+    # Make the help output a little less jarring.
+    help_factory = (lambda *a, **k:
+                    argparse.RawDescriptionHelpFormatter(max_help_position=28, *a, **k))
     parser = argparse.ArgumentParser(prog='mypy', epilog=FOOTER,
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+                                     formatter_class=help_factory)
 
     def parse_version(v):
         m = re.match(r'\A(\d)\.(\d+)\Z', v)


### PR DESCRIPTION
@ddfisher what do you think? This improves the awkward formatting of --help output a bit.

Before (excerpt):
```
  -s, --silent-imports  don't follow imports to .py files
  --silent              deprecated name for --silent-imports
  --almost-silent       like --silent-imports but reports the imports as
                        errors
  --disallow-untyped-calls
                        disallow calling functions without type annotations
                        from functions with type annotations
  --disallow-untyped-defs
                        disallow defining functions without type annotations
                        or with incomplete type annotations
  --check-untyped-defs  type check the interior of functions without type
                        annotations
```
After:
```
  -s, --silent-imports      don't follow imports to .py files
  --silent                  deprecated name for --silent-imports
  --almost-silent           like --silent-imports but reports the imports as
                            errors
  --disallow-untyped-calls  disallow calling functions without type
                            annotations from functions with type annotations
  --disallow-untyped-defs   disallow defining functions without type
                            annotations or with incomplete type annotations
  --check-untyped-defs      type check the interior of functions without type
                            annotations
```
