### PR TITLE
parse extra keyword args in class definition

### DIFF
--- a/mypy/test/data/parse.test
+++ b/mypy/test/data/parse.test
@@ -2523,6 +2523,32 @@ MypyFile:1(
         NameExpr(x)))
     PassStmt:1()))
 
+[case testClassKeywordArgs]
+class Foo(_root=None): pass
+[out]
+MypyFile:1(
+  ClassDef:1(
+    Foo
+    PassStmt:1()))
+
+[case testClassKeywordArgsBeforeMeta]
+class Foo(_root=None, metaclass=Bar): pass
+[out]
+MypyFile:1(
+  ClassDef:1(
+    Foo
+    Metaclass(Bar)
+    PassStmt:1()))
+
+[case testClassKeywordArgsAfterMeta]
+class Foo(metaclass=Bar, _root=None): pass
+[out]
+MypyFile:1(
+  ClassDef:1(
+    Foo
+    Metaclass(Bar)
+    PassStmt:1()))
+
 [case testNamesThatAreNoLongerKeywords]
 any = interface
 [out]


### PR DESCRIPTION
mypy cannot parse the classes defined in typing.py, such as:

    class Tuple(Final, metaclass=TupleMeta, _root=True): ...

Instead, it stops with a parse error at the comma following metaclass=TupleMeta.  The original code assumed that there would be a list of superclasses, possibly followed by metaclass=....  This patch generalizes the parsing to an arbitrary set of keyword arguments, popping the metaclass out of the list when it is complete.

I updated the ClassDef node in nodes.py to hold on to the keyword arguments and serialize to and from json, but I don't know how to trigger the serialization code, so this is not tested.