### PR TITLE
Support calling dict() with positional arguments and keyword arguments or **kwargs

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -423,11 +423,14 @@ class ExpressionChecker:
                     callee_type, args, arg_kinds, formal_to_actual,
                     inferred_args, context)
 
-            if inferred_args and callee_type.special_sig == 'dict' and (
+            if callee_type.special_sig == 'dict' and len(inferred_args) == 2 and (
                     ARG_NAMED in arg_kinds or ARG_STAR2 in arg_kinds):
                 # HACK: Infer str key type for dict(...) with keyword args. The type system
                 #       can't represent this so we special case it, as this is a pretty common
-                #       thing.
+                #       thing. This doesn't quite work with all possible subclasses of dict
+                #       if they shuffle type variables around, as we assume that there is a 1-1
+                #       correspondence with dict type variables. This is a marginal issue and
+                #       a little tricky to fix so it's left unfixed for now.
                 if isinstance(inferred_args[0], NoneTyp):
                     inferred_args[0] = self.named_type('builtins.str')
                 elif not is_subtype(self.named_type('builtins.str'), inferred_args[0]):

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -45,7 +45,6 @@ def infer_constraints_for_callable(
 
     Return a list of constraints.
     """
-
     constraints = []  # type: List[Constraint]
     tuple_counter = [0]
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -79,6 +79,8 @@ INCOMPATIBLE_IMPORT_OF = "Incompatible import of"
 FUNCTION_TYPE_EXPECTED = "Function is missing a type annotation"
 RETURN_TYPE_EXPECTED = "Function is missing a return type annotation"
 ARGUMENT_TYPE_EXPECTED = "Function is missing a type annotation for one or more arguments"
+KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE = \
+    'Keyword argument only valid with "str" key type in call to "dict"'
 
 
 class MessageBuilder:

--- a/mypy/test/data/check-expressions.test
+++ b/mypy/test/data/check-expressions.test
@@ -1445,3 +1445,27 @@ class dict(Generic[T, S]):
     def __init__(self, x: T, **kwargs: T) -> None: pass
 dict(1, y=1)
 [builtins fixtures/dict.py]
+
+[case testSpecialSignatureForSubclassOfDict]
+from typing import TypeVar, Dict, Generic
+T = TypeVar('T')
+S = TypeVar('S')
+class D1(dict): pass # Implicit base class Dict[Any, Any]
+D1([(1, 2)], x=1)
+class D2(Dict[T, S], Generic[T, S]): pass
+da = D2([('x', 2)], x=1)
+da() # E: D2[str, int] not callable
+D2([(1, 2)], x=1) # E: Keyword argument only valid with "str" key type in call to "dict"
+db = D2(x=1)
+db() # E: D2[str, int] not callable
+[builtins fixtures/dict.py]
+
+[case testOverridingSpecialSignatureInSubclassOfDict]
+from typing import TypeVar, Dict, Generic
+T = TypeVar('T')
+S = TypeVar('S')
+class D(Dict[T, S], Generic[T, S]):
+    def __init__(self, x: S, y: T) -> None: pass
+d = D(1, y='')
+d() # E: D[str, int] not callable
+[builtins fixtures/dict.py]

--- a/mypy/test/data/check-expressions.test
+++ b/mypy/test/data/check-expressions.test
@@ -1460,6 +1460,13 @@ db = D2(x=1)
 db() # E: D2[str, int] not callable
 [builtins fixtures/dict.py]
 
+[case testSpecialSignatureForSubclassOfDict2]
+from typing import TypeVar, Dict, Generic
+T = TypeVar('T')
+class D(Dict[str, T], Generic[T]): pass
+D([('x', 1)], x=1)
+[builtins fixtures/dict.py]
+
 [case testOverridingSpecialSignatureInSubclassOfDict]
 from typing import TypeVar, Dict, Generic
 T = TypeVar('T')

--- a/mypy/test/data/check-expressions.test
+++ b/mypy/test/data/check-expressions.test
@@ -1340,7 +1340,6 @@ def f(x: int) -> Iterator[None]:
 -- ----------------
 
 
-
 [case testYieldFromIteratorHasNoValue]
 from typing import Iterator
 def f() -> Iterator[int]:
@@ -1362,12 +1361,14 @@ def g() -> Iterator[int]:
 [out]
 
 
+-- dict(...)
+-- ---------
 
--- dict(x=y, ...)
--- --------------
 
+-- Note that the stub used in unit tests does not have all overload
+-- variants, but it should not matter.
 
-[case testDictWithKeywordArgs]
+[case testDictWithKeywordArgsOnly]
 from typing import Dict, Any
 d1 = dict(a=1, b=2) # type: Dict[str, int]
 d2 = dict(a=1, b='') # type: Dict[str, int] # E: List item 1 has incompatible type "Tuple[str, str]"
@@ -1378,7 +1379,69 @@ d5 = dict(a=1, b='') # type: Dict[str, Any]
 [builtins fixtures/dict.py]
 
 [case testDictWithoutKeywordArgs]
-dict(undefined)
+from typing import Dict
+d = dict() # E: Need type annotation for variable
+d2 = dict() # type: Dict[int, str]
+dict(undefined) # E: Name 'undefined' is not defined
 [builtins fixtures/dict.py]
-[out]
-main:1: error: Name 'undefined' is not defined
+
+[case testDictFromList]
+from typing import Dict
+d = dict([(1, 'x'), (2, 'y')])
+d() # E: Dict[int, str] not callable
+d2 = dict([(1, 'x')]) # type: Dict[str, str] # E: List item 0 has incompatible type "Tuple[int, str]"
+[builtins fixtures/dict.py]
+
+[case testDictFromIterableAndKeywordArg]
+from typing import Dict
+it = [('x', 1)]
+
+d = dict(it, x=1)
+d() # E: Dict[str, int] not callable
+
+d2 = dict(it, x='') # E: Cannot infer type argument 2 of "dict"
+d2() # E: Dict[Any, Any] not callable
+
+d3 = dict(it, x='') # type: Dict[str, int] # E: Argument 2 to "dict" has incompatible type "str"; expected "int"
+[builtins fixtures/dict.py]
+
+[case testDictFromIterableAndKeywordArg2]
+it = [(1, 'x')]
+dict(it, x='y') # E: Keyword argument only valid with "str" key type in call to "dict"
+[builtins fixtures/dict.py]
+
+[case testDictFromIterableAndKeywordArg3]
+d = dict([], x=1)
+d() # E: Dict[str, int] not callable
+[builtins fixtures/dict.py]
+
+[case testDictFromIterableAndStarStarArgs]
+from typing import Dict
+it = [('x', 1)]
+
+kw = {'x': 1}
+d = dict(it, **kw)
+d() # E: Dict[str, int] not callable
+
+kw2 = {'x': ''}
+d2 = dict(it, **kw2) # E: Cannot infer type argument 2 of "dict"
+d2() # E: Dict[Any, Any] not callable
+
+d3 = dict(it, **kw2) # type: Dict[str, int] # E: Argument 2 to "dict" has incompatible type **Dict[str, str]; expected "int"
+[builtins fixtures/dict.py]
+
+[case testDictFromIterableAndStarStarArgs2]
+it = [(1, 'x')]
+kw = {'x': 'y'}
+d = dict(it, **kw) # E: Keyword argument only valid with "str" key type in call to "dict"
+d() # E: Dict[int, str] not callable
+[builtins fixtures/dict.py]
+
+[case testUserDefinedClassNamedDict]
+from typing import Generic, TypeVar
+T = TypeVar('T')
+S = TypeVar('S')
+class dict(Generic[T, S]):
+    def __init__(self, x: T, **kwargs: T) -> None: pass
+dict(1, y=1)
+[builtins fixtures/dict.py]

--- a/mypy/test/data/fixtures/dict.py
+++ b/mypy/test/data/fixtures/dict.py
@@ -1,22 +1,29 @@
 # Builtins stub used in dictionary-related test cases.
 
-from typing import TypeVar, Generic, Iterable, Iterator, Tuple
+from typing import TypeVar, Generic, Iterable, Iterator, Tuple, overload
 
 T = TypeVar('T')
-S = TypeVar('S')
+KT = TypeVar('KT')
+VT = TypeVar('VT')
 
 class object:
     def __init__(self) -> None: pass
 
 class type: pass
 
-class dict(Iterable[T], Generic[T, S]):
-    def __init__(self, arg: Iterable[Tuple[T, S]] = None) -> None: pass
-    def __setitem__(self, k: T, v: S) -> None: pass
-    def __iter__(self) -> Iterator[T]: pass
-    def update(self, a: 'dict[T, S]') -> None: pass
+class dict(Iterable[KT], Generic[KT, VT]):
+    @overload
+    def __init__(self, **kwargs: VT) -> None: pass
+    @overload
+    def __init__(self, arg: Iterable[Tuple[KT, VT]], **kwargs: VT) -> None: pass
+    def __setitem__(self, k: KT, v: VT) -> None: pass
+    def __iter__(self) -> Iterator[KT]: pass
+    def update(self, a: 'dict[KT, VT]') -> None: pass
+
 class int: pass # for convenience
+
 class str: pass # for keyword argument key type
+
 class list(Iterable[T], Generic[T]): # needed by some test cases
     def __iter__(self) -> Iterator[T]: pass
     def __mul__(self, x: int) -> list[T]: pass

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -405,6 +405,9 @@ class CallableType(FunctionLike):
     is_classmethod_class = False
     # Was this type implicitly generated instead of explicitly specified by the user?
     implicit = False
+    # Defined for signatures that require special handling (currently only value is 'dict'
+    # for a signature similar to 'dict')
+    special_sig = None  # type: Optional[str]
 
     def __init__(self,
                  arg_types: List[Type],
@@ -419,6 +422,7 @@ class CallableType(FunctionLike):
                  is_ellipsis_args: bool = False,
                  implicit=False,
                  is_classmethod_class=False,
+                 special_sig=None,
                  ) -> None:
         if variables is None:
             variables = []
@@ -435,6 +439,7 @@ class CallableType(FunctionLike):
         self.variables = variables
         self.is_ellipsis_args = is_ellipsis_args
         self.implicit = implicit
+        self.special_sig = special_sig
         super().__init__(line)
 
     def copy_modified(self,
@@ -447,7 +452,8 @@ class CallableType(FunctionLike):
                       definition: SymbolNode = _dummy,
                       variables: List[TypeVarDef] = _dummy,
                       line: int = _dummy,
-                      is_ellipsis_args: bool = _dummy) -> 'CallableType':
+                      is_ellipsis_args: bool = _dummy,
+                      special_sig: Optional[str] = _dummy) -> 'CallableType':
         return CallableType(
             arg_types=arg_types if arg_types is not _dummy else self.arg_types,
             arg_kinds=arg_kinds if arg_kinds is not _dummy else self.arg_kinds,
@@ -462,6 +468,7 @@ class CallableType(FunctionLike):
                 is_ellipsis_args if is_ellipsis_args is not _dummy else self.is_ellipsis_args),
             implicit=self.implicit,
             is_classmethod_class=self.is_classmethod_class,
+            special_sig=special_sig if special_sig is not _dummy else self.special_sig,
         )
 
     def is_type_obj(self) -> bool:


### PR DESCRIPTION
Also inherit special signature of `dict`. Some special cases (that are likely very rare) are not handled well. I'll create a separate issue for those. The implementation is a hack but it mostly does the right thing and is fairly simple, and a clean solution would be much more complicated (for example, a plugin system or constraint based type inference system for function signatures), so I think this is okay for now.