### PR TITLE
Make argument types in function type inference explicitly Optional

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -405,7 +405,7 @@ class ExpressionChecker:
             arg_pass_nums = self.get_arg_infer_passes(
                 callee_type.arg_types, formal_to_actual, len(args))
 
-            pass1_args = []  # type: List[Type]
+            pass1_args = []  # type: List[Optional[Type]]
             for i, arg in enumerate(arg_types):
                 if arg_pass_nums[i] > 1:
                     pass1_args.append(None)

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -1,6 +1,6 @@
 """Type inference constraints."""
 
-from typing import List, cast
+from typing import List, Optional, cast
 
 from mypy.types import (
     CallableType, Type, TypeVisitor, UnboundType, AnyType, Void, NoneTyp, TypeVarType,
@@ -39,7 +39,7 @@ class Constraint:
 
 
 def infer_constraints_for_callable(
-        callee: CallableType, arg_types: List[Type], arg_kinds: List[int],
+        callee: CallableType, arg_types: List[Optional[Type]], arg_kinds: List[int],
         formal_to_actual: List[List[int]]) -> List[Constraint]:
     """Infer type variable constraints for a callable and actual arguments.
 
@@ -51,6 +51,9 @@ def infer_constraints_for_callable(
 
     for i, actuals in enumerate(formal_to_actual):
         for actual in actuals:
+            if arg_types[actual] is None:
+                continue
+
             actual_type = get_actual_type(arg_types[actual], arg_kinds[actual],
                                           tuple_counter)
             c = infer_constraints(callee.arg_types[i], actual_type,

--- a/mypy/infer.py
+++ b/mypy/infer.py
@@ -1,6 +1,6 @@
 """Utilities for type argument inference."""
 
-from typing import List
+from typing import List, Optional
 
 from mypy.constraints import infer_constraints, infer_constraints_for_callable
 from mypy.types import Type, CallableType
@@ -9,7 +9,7 @@ from mypy.constraints import SUBTYPE_OF
 
 
 def infer_function_type_arguments(callee_type: CallableType,
-                                  arg_types: List[Type],
+                                  arg_types: List[Optional[Type]],
                                   arg_kinds: List[int],
                                   formal_to_actual: List[List[int]],
                                   strict: bool = True) -> List[Type]:
@@ -21,7 +21,8 @@ def infer_function_type_arguments(callee_type: CallableType,
 
     Arguments:
       callee_type: the target generic function
-      arg_types: argument types at the call site
+      arg_types: argument types at the call site (each optional; if None,
+                 we are not considering this argument in the current pass)
       arg_kinds: nodes.ARG_* values for arg_types
       formal_to_actual: mapping from formal to actual variable indices
     """


### PR DESCRIPTION
The old version happened to work because an argument would only be
omitted when the corresponding formal argument has a Callable type,
and in that case constraint generation does isinstance checks on the
actual argument type. But calling infer_constraints with actual=None
is not really good.

(I noticed this while experimenting with moving some Union argument
types to the second pass of function type inference.)