### PR TITLE
Recompute class MROs in ThirdPass, to handle import loops

### DIFF
--- a/mypy/test/data/check-modules.test
+++ b/mypy/test/data/check-modules.test
@@ -739,3 +739,33 @@ y = 42
 [builtins fixtures/module.py]
 [out]
 tmp/main.py:4: error: Unsupported left operand type for + ("int")
+
+[case testSuperclassInImportCycle]
+import a
+import d
+a.A().f(d.D())
+[file a.py]
+if 0:
+    import d
+class B: pass
+class C(B): pass
+class A:
+    def f(self, x: B) -> None: pass
+[file d.py]
+import a
+class D(a.C): pass
+
+[case testSuperclassInImportCycleReversedImports]
+import d
+import a
+a.A().f(d.D())
+[file a.py]
+if 0:
+    import d
+class B: pass
+class C(B): pass
+class A:
+    def f(self, x: B) -> None: pass
+[file d.py]
+import a
+class D(a.C): pass


### PR DESCRIPTION
Fixes #1394. This is a bit of a hack, but at least it's simple.