### PR TITLE
Empty list unification

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1,6 +1,7 @@
 """Mypy type checker."""
 
 import itertools
+import contextlib
 
 from typing import (
     Any, Dict, Set, List, cast, Tuple, TypeVar, Union, Optional, NamedTuple
@@ -294,6 +295,12 @@ class ConditionalTypeBinder:
 
     def pop_loop_frame(self):
         self.loop_frames.pop()
+
+    def __enter__(self) -> None:
+        self.push_frame()
+
+    def __exit__(self, *args: Any) -> None:
+        self.pop_frame()
 
 
 def meet_frames(*frames: Frame) -> Frame:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1421,7 +1421,7 @@ class ExpressionChecker:
                     self.chk.binder.push(var, type)
             if_type = self.accept(e.if_expr, context=ctx)
 
-        if has_unfinished_types(if_type):
+        if not mypy.checker.is_valid_inferred_type(if_type):
             # Analyze the right branch disregarding the left branch.
             with self.chk.binder:
                 if else_map:
@@ -1522,19 +1522,6 @@ class ExpressionChecker:
         pass or report an error.
         """
         self.chk.handle_cannot_determine_type(name, context)
-
-
-# TODO: What's a good name for this function?
-def has_unfinished_types(t: Type) -> bool:
-    """Check whether t has type variables replaced with 'None'.
-
-    This can happen when `[]` is evaluated without sufficient context.
-    """
-    if isinstance(t, NoneTyp):
-        return True
-    if isinstance(t, Instance):
-        return any(has_unfinished_types(arg) for arg in t.args)
-    return False
 
 
 def map_actuals_to_formals(caller_kinds: List[int],

--- a/mypy/test/data/check-inference.test
+++ b/mypy/test/data/check-inference.test
@@ -1643,20 +1643,20 @@ a2.foo2()
 [case testUnificationEmptyListLeft]
 def f(): pass
 a = [] if f() else [0]
-a.append(0)
+a() # E: List[int] not callable
 [builtins fixtures/list.py]
 
 [case testUnificationEmptyListRight]
 def f(): pass
 a = [0] if f() else []
-a.append(0)
+a() # E: List[int] not callable
 [builtins fixtures/list.py]
 
 [case testUnificationEmptyListLeftInContext]
 from typing import List
 def f(): pass
 a = [] if f() else [0] # type: List[int]
-a.append(0)
+a() # E: List[int] not callable
 [builtins fixtures/list.py]
 
 [case testUnificationEmptyListRightInContext]
@@ -1664,35 +1664,35 @@ a.append(0)
 from typing import List
 def f(): pass
 a = [0] if f() else [] # type: List[int]
-a.append(0)
+a() # E: List[int] not callable
 [builtins fixtures/list.py]
 
 [case testUnificationEmptySetLeft]
 def f(): pass
 a = set() if f() else {0}
-a.add(0)
+a() # E: Set[int] not callable
 [builtins fixtures/set.py]
 
 [case testUnificationEmptyDictLeft]
 def f(): pass
 a = {} if f() else {0: 0}
-a.update({0: 0})
+a() # E: Dict[int, int] not callable
 [builtins fixtures/dict.py]
 
 [case testUnificationEmptyDictRight]
 def f(): pass
 a = {0: 0} if f() else {}
-a.update({0: 0})
+a() # E: Dict[int, int] not callable
 [builtins fixtures/dict.py]
 
 [case testUnificationDictWithEmptyListLeft]
 def f(): pass
 a = {0: []} if f() else {0: [0]}
-a.update({0: [0]})
+a() # E: Dict[int, List[int]] not callable
 [builtins fixtures/dict.py]
 
 [case testUnificationDictWithEmptyListRight]
 def f(): pass
 a = {0: [0]} if f() else {0: []}
-a.update({0: [0]})
+a() # E: Dict[int, List[int]] not callable
 [builtins fixtures/dict.py]

--- a/mypy/test/data/check-inference.test
+++ b/mypy/test/data/check-inference.test
@@ -1639,3 +1639,60 @@ a1 = D1() if f() else D2()
 a1.foo1()
 a2 = D2() if f() else D1()
 a2.foo2()
+
+[case testUnificationEmptyListLeft]
+def f(): pass
+a = [] if f() else [0]
+a.append(0)
+[builtins fixtures/list.py]
+
+[case testUnificationEmptyListRight]
+def f(): pass
+a = [0] if f() else []
+a.append(0)
+[builtins fixtures/list.py]
+
+[case testUnificationEmptyListLeftInContext]
+from typing import List
+def f(): pass
+a = [] if f() else [0] # type: List[int]
+a.append(0)
+[builtins fixtures/list.py]
+
+[case testUnificationEmptyListRightInContext]
+# TODO Find an example that really needs the context
+from typing import List
+def f(): pass
+a = [0] if f() else [] # type: List[int]
+a.append(0)
+[builtins fixtures/list.py]
+
+[case testUnificationEmptySetLeft]
+def f(): pass
+a = set() if f() else {0}
+a.add(0)
+[builtins fixtures/set.py]
+
+[case testUnificationEmptyDictLeft]
+def f(): pass
+a = {} if f() else {0: 0}
+a.update({0: 0})
+[builtins fixtures/dict.py]
+
+[case testUnificationEmptyDictRight]
+def f(): pass
+a = {0: 0} if f() else {}
+a.update({0: 0})
+[builtins fixtures/dict.py]
+
+[case testUnificationDictWithEmptyListLeft]
+def f(): pass
+a = {0: []} if f() else {0: [0]}
+a.update({0: [0]})
+[builtins fixtures/dict.py]
+
+[case testUnificationDictWithEmptyListRight]
+def f(): pass
+a = {0: [0]} if f() else {0: []}
+a.update({0: [0]})
+[builtins fixtures/dict.py]


### PR DESCRIPTION
There are three TODOs left:
- Suppress errors of first attempt if we analyze the left branch a second time (needs a reproducing example)
- Pick a better name for has_unfinished_types()
- Find an example where the overall context is required for `([x] if ... else [])` (and that works with the limited test fixtures)