### PR TITLE
Take type variable value restrictions into account in overloading

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1644,9 +1644,9 @@ def overload_arg_similarity(actual: Type, formal: Type) -> int:
     # parameters, so no need to handle type variables occuring within
     # a type.
     if isinstance(actual, TypeVarType):
-        actual = actual.upper_bound
+        actual = actual.erase_to_union_or_bound()
     if isinstance(formal, TypeVarType):
-        formal = formal.upper_bound
+        formal = formal.erase_to_union_or_bound()
     if (isinstance(actual, NoneTyp) or isinstance(actual, AnyType) or
             isinstance(formal, AnyType) or isinstance(formal, CallableType) or
             (isinstance(actual, Instance) and actual.type.fallback_to_any)):

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -66,9 +66,9 @@ def is_overlapping_types(t: Type, s: Type, use_promotions: bool = False) -> bool
     # Since we are effectively working with the erased types, we only
     # need to handle occurrences of TypeVarType at the top level.
     if isinstance(t, TypeVarType):
-        t = t.upper_bound
+        t = t.erase_to_union_or_bound()
     if isinstance(s, TypeVarType):
-        s = s.upper_bound
+        s = s.erase_to_union_or_bound()
     if isinstance(t, Instance):
         if isinstance(s, Instance):
             # Only consider two classes non-disjoint if one is included in the mro

--- a/mypy/test/data/check-overloading.test
+++ b/mypy/test/data/check-overloading.test
@@ -631,6 +631,43 @@ def f(x: Sequence[int]) -> int: pass
 [out]
 main:4: error: Overloaded function signatures 1 and 2 overlap with incompatible return types
 
+[case testOverlapWithTypeVarsWithValues]
+from typing import overload, TypeVar
+AnyStr = TypeVar('AnyStr', bytes, str)
+
+@overload
+def f(x: int) -> int: pass
+@overload
+def f(x: AnyStr) -> str: pass
+
+f(1)() # E: "int" not callable
+f('1')() # E: "str" not callable
+f(b'1')() # E: "str" not callable
+f(1.0) # E: No overload variant of "f" matches argument types [builtins.float]
+
+@overload
+def g(x: AnyStr, *a: AnyStr) -> None: pass
+@overload
+def g(x: int, *a: AnyStr) -> None: pass
+
+g('foo')
+g('foo', 'bar')
+g('foo', b'bar') # E: Type argument 1 of "g" has incompatible value "object"
+g(1)
+g(1, 'foo')
+g(1, 'foo', b'bar') # E: Type argument 1 of "g" has incompatible value "object"
+[builtins fixtures/primitives.py]
+
+[case testBadOverlapWithTypeVarsWithValues]
+from typing import overload, TypeVar
+AnyStr = TypeVar('AnyStr', bytes, str)
+
+@overload
+def f(x: AnyStr) -> None: pass # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+@overload
+def f(x: str) -> bool: pass
+[builtins fixtures/primitives.py]
+
 [case testOverlappingOverloadCounting]
 from typing import overload
 class A: pass

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -339,6 +339,12 @@ class TypeVarType(Type):
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_type_var(self)
 
+    def erase_to_union_or_bound(self) -> Type:
+        if self.values:
+            return UnionType.make_simplified_union(self.values)
+        else:
+            return self.upper_bound
+
     def serialize(self) -> JsonDict:
         return {'.class': 'TypeVarType',
                 'name': self.name,


### PR DESCRIPTION
Addresses part of #1241. We could do something more precise (see
discussion on that issue) but this should address most common cases.