### PR TITLE
adding "--silent-imports" suggestion to error message

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -463,7 +463,7 @@ class BuildManager:
         else:
             self.errors.report(line, "Cannot find module named '{}'".format(id))
             self.errors.report(line, '(Perhaps setting MYPYPATH '
-                                     'or using the "--silent" flag would help)',
+                                     'or using the "--silent-imports" flag would help)',
                                severity='note', only_once=True)
 
     def report_file(self, file: MypyFile) -> None:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -462,8 +462,9 @@ class BuildManager:
             self.errors.report(line, stub_msg, severity='note', only_once=True)
         else:
             self.errors.report(line, "Cannot find module named '{}'".format(id))
-            self.errors.report(line, "(Perhaps setting MYPYPATH would help)", severity='note',
-                               only_once=True)
+            self.errors.report(line, '(Perhaps setting MYPYPATH '
+                                     'or using the "--silent" flag would help)',
+                               severity='note', only_once=True)
 
     def report_file(self, file: MypyFile) -> None:
         if self.source_set.is_source(file):

--- a/mypy/test/data/check-modules.test
+++ b/mypy/test/data/check-modules.test
@@ -203,7 +203,7 @@ import nonexistent
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:2: error: Unsupported left operand type for + (None)
 
 [case testTypeCheckWithUnknownModule2]
@@ -215,7 +215,7 @@ m.x = ''
 x = 1
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:2: error: Unsupported left operand type for + (None)
 main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
@@ -228,7 +228,7 @@ m.x = ''
 x = 1
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:2: error: Unsupported left operand type for + (None)
 main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
@@ -237,7 +237,7 @@ import nonexistent, another
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:1: error: Cannot find module named 'another'
 main:2: error: Unsupported left operand type for + (None)
 
@@ -246,7 +246,7 @@ import nonexistent as x
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:2: error: Unsupported left operand type for + (None)
 
 [case testTypeCheckWithUnknownModuleUsingFromImport]
@@ -254,7 +254,7 @@ from nonexistent import x
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:2: error: Unsupported left operand type for + (None)
 
 [case testTypeCheckWithUnknownModuleUsingImportStar]
@@ -262,7 +262,7 @@ from nonexistent import *
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:2: error: Unsupported left operand type for + (None)
 
 [case testAccessingUnknownModule]
@@ -271,7 +271,7 @@ xyz.foo()
 xyz()
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 
 [case testAccessingUnknownModule2]
 import xyz, bar
@@ -279,7 +279,7 @@ xyz.foo()
 bar()
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:1: error: Cannot find module named 'bar'
 
 [case testAccessingUnknownModule3]
@@ -288,7 +288,7 @@ xyz.foo()
 z()
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:2: error: Name 'xyz' is not defined
 
 [case testAccessingNameImportedFromUnknownModule]
@@ -297,14 +297,14 @@ y.foo()
 z()
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 
 [case testAccessingNameImportedFromUnknownModule2]
 from xyz import *
 y
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:2: error: Name 'y' is not defined
 
 [case testAccessingNameImportedFromUnknownModule3]
@@ -313,7 +313,7 @@ y
 z
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:2: error: Name 'y' is not defined
 
 [case testUnknownModuleRedefinition]
@@ -321,7 +321,7 @@ import xab
 def xab(): pass
 [out]
 main:1: error: Cannot find module named 'xab'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 
 [case testAccessingUnknownModuleFromOtherModule]
 import x
@@ -333,7 +333,7 @@ import nonexistent
 [out]
 main:1: note: In module imported here:
 tmp/x.py:1: error: Cannot find module named 'nonexistent'
-tmp/x.py:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+tmp/x.py:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:3: error: "module" has no attribute "z"
 
 [case testUnknownModuleImportedWithinFunction]
@@ -343,7 +343,7 @@ def foobar(): pass
 foobar('')
 [out]
 main:2: error: Cannot find module named 'foobar'
-main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:4: error: Too many arguments for "foobar"
 
 [case testUnknownModuleImportedWithinFunction2]
@@ -353,7 +353,7 @@ def x(): pass
 x('')
 [out]
 main:2: error: Cannot find module named 'foobar'
-main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:4: error: Too many arguments for "x"
 
 [case testRelativeImports]

--- a/mypy/test/data/check-modules.test
+++ b/mypy/test/data/check-modules.test
@@ -203,7 +203,7 @@ import nonexistent
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:2: error: Unsupported left operand type for + (None)
 
 [case testTypeCheckWithUnknownModule2]
@@ -215,7 +215,7 @@ m.x = ''
 x = 1
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:2: error: Unsupported left operand type for + (None)
 main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
@@ -228,7 +228,7 @@ m.x = ''
 x = 1
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:2: error: Unsupported left operand type for + (None)
 main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
@@ -237,7 +237,7 @@ import nonexistent, another
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:1: error: Cannot find module named 'another'
 main:2: error: Unsupported left operand type for + (None)
 
@@ -246,7 +246,7 @@ import nonexistent as x
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:2: error: Unsupported left operand type for + (None)
 
 [case testTypeCheckWithUnknownModuleUsingFromImport]
@@ -254,7 +254,7 @@ from nonexistent import x
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:2: error: Unsupported left operand type for + (None)
 
 [case testTypeCheckWithUnknownModuleUsingImportStar]
@@ -262,7 +262,7 @@ from nonexistent import *
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:2: error: Unsupported left operand type for + (None)
 
 [case testAccessingUnknownModule]
@@ -271,7 +271,7 @@ xyz.foo()
 xyz()
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 
 [case testAccessingUnknownModule2]
 import xyz, bar
@@ -279,7 +279,7 @@ xyz.foo()
 bar()
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:1: error: Cannot find module named 'bar'
 
 [case testAccessingUnknownModule3]
@@ -288,7 +288,7 @@ xyz.foo()
 z()
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:2: error: Name 'xyz' is not defined
 
 [case testAccessingNameImportedFromUnknownModule]
@@ -297,14 +297,14 @@ y.foo()
 z()
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 
 [case testAccessingNameImportedFromUnknownModule2]
 from xyz import *
 y
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:2: error: Name 'y' is not defined
 
 [case testAccessingNameImportedFromUnknownModule3]
@@ -313,7 +313,7 @@ y
 z
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:2: error: Name 'y' is not defined
 
 [case testUnknownModuleRedefinition]
@@ -321,7 +321,7 @@ import xab
 def xab(): pass
 [out]
 main:1: error: Cannot find module named 'xab'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 
 [case testAccessingUnknownModuleFromOtherModule]
 import x
@@ -333,7 +333,7 @@ import nonexistent
 [out]
 main:1: note: In module imported here:
 tmp/x.py:1: error: Cannot find module named 'nonexistent'
-tmp/x.py:1: note: (Perhaps setting MYPYPATH would help)
+tmp/x.py:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:3: error: "module" has no attribute "z"
 
 [case testUnknownModuleImportedWithinFunction]
@@ -343,7 +343,7 @@ def foobar(): pass
 foobar('')
 [out]
 main:2: error: Cannot find module named 'foobar'
-main:2: note: (Perhaps setting MYPYPATH would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:4: error: Too many arguments for "foobar"
 
 [case testUnknownModuleImportedWithinFunction2]
@@ -353,7 +353,7 @@ def x(): pass
 x('')
 [out]
 main:2: error: Cannot find module named 'foobar'
-main:2: note: (Perhaps setting MYPYPATH would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:4: error: Too many arguments for "x"
 
 [case testRelativeImports]

--- a/mypy/test/data/check-python2.test
+++ b/mypy/test/data/check-python2.test
@@ -136,7 +136,7 @@ import asyncio
 import Bastion
 [out]
 main:1: error: Cannot find module named 'asyncio'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:2: error: No library stub file for standard library module 'Bastion'
 main:2: note: (Stub files are from https://github.com/python/typeshed)
 

--- a/mypy/test/data/check-python2.test
+++ b/mypy/test/data/check-python2.test
@@ -136,7 +136,7 @@ import asyncio
 import Bastion
 [out]
 main:1: error: Cannot find module named 'asyncio'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:2: error: No library stub file for standard library module 'Bastion'
 main:2: note: (Stub files are from https://github.com/python/typeshed)
 

--- a/mypy/test/data/check-semanal-error.test
+++ b/mypy/test/data/check-semanal-error.test
@@ -19,7 +19,7 @@ m.x = m.y
 1() # E
 [out]
 main:1: error: Cannot find module named 'm'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:4: error: "int" not callable
 
 [case testMissingModuleImport2]
@@ -29,7 +29,7 @@ x.a = x.b
 1() # E
 [out]
 main:1: error: Cannot find module named 'm'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:4: error: "int" not callable
 
 [case testMissingModuleImport3]
@@ -38,7 +38,7 @@ x # E
 1() # E
 [out]
 main:1: error: Cannot find module named 'm'
-main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:2: error: Name 'x' is not defined
 main:3: error: "int" not callable
 

--- a/mypy/test/data/check-semanal-error.test
+++ b/mypy/test/data/check-semanal-error.test
@@ -19,7 +19,7 @@ m.x = m.y
 1() # E
 [out]
 main:1: error: Cannot find module named 'm'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:4: error: "int" not callable
 
 [case testMissingModuleImport2]
@@ -29,7 +29,7 @@ x.a = x.b
 1() # E
 [out]
 main:1: error: Cannot find module named 'm'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:4: error: "int" not callable
 
 [case testMissingModuleImport3]
@@ -38,7 +38,7 @@ x # E
 1() # E
 [out]
 main:1: error: Cannot find module named 'm'
-main:1: note: (Perhaps setting MYPYPATH would help)
+main:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:2: error: Name 'x' is not defined
 main:3: error: "int" not callable
 

--- a/mypy/test/data/check-unreachable-code.test
+++ b/mypy/test/data/check-unreachable-code.test
@@ -79,7 +79,7 @@ else:
 [builtins fixtures/bool.py]
 [out]
 main:6: error: Cannot find module named 'pow123'
-main:6: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:6: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 
 [case testMypyConditional]
 import typing

--- a/mypy/test/data/check-unreachable-code.test
+++ b/mypy/test/data/check-unreachable-code.test
@@ -79,7 +79,7 @@ else:
 [builtins fixtures/bool.py]
 [out]
 main:6: error: Cannot find module named 'pow123'
-main:6: note: (Perhaps setting MYPYPATH would help)
+main:6: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 
 [case testMypyConditional]
 import typing

--- a/mypy/test/data/semanal-errors.test
+++ b/mypy/test/data/semanal-errors.test
@@ -231,21 +231,21 @@ import typing
 import m
 [out]
 main:2: error: Cannot find module named 'm'
-main:2: note: (Perhaps setting MYPYPATH would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 
 [case testMissingModule2]
 import typing
 from m import x
 [out]
 main:2: error: Cannot find module named 'm'
-main:2: note: (Perhaps setting MYPYPATH would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 
 [case testMissingModule3]
 import typing
 from m import *
 [out]
 main:2: error: Cannot find module named 'm'
-main:2: note: (Perhaps setting MYPYPATH would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 
 [case testMissingModuleRelativeImport]
 import typing
@@ -255,7 +255,7 @@ from .x import y
 [out]
 main:2: note: In module imported here:
 tmp/m/__init__.py:1: error: Cannot find module named 'm.x'
-tmp/m/__init__.py:1: note: (Perhaps setting MYPYPATH would help)
+tmp/m/__init__.py:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 
 [case testMissingModuleRelativeImport2]
 import typing
@@ -266,7 +266,7 @@ from .x import y
 [out]
 main:2: note: In module imported here:
 tmp/m/a.py:1: error: Cannot find module named 'm.x'
-tmp/m/a.py:1: note: (Perhaps setting MYPYPATH would help)
+tmp/m/a.py:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 
 [case testModuleNotImported]
 import typing
@@ -317,7 +317,7 @@ import typing
 import m.n
 [out]
 main:2: error: Cannot find module named 'm.n'
-main:2: note: (Perhaps setting MYPYPATH would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 
 [case testMissingPackage]
 import typing
@@ -325,7 +325,7 @@ from m.n import x
 from a.b import *
 [out]
 main:2: error: Cannot find module named 'm.n'
-main:2: note: (Perhaps setting MYPYPATH would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 main:3: error: Cannot find module named 'a.b'
 
 [case testErrorInImportedModule]
@@ -358,7 +358,7 @@ m.n.x
 x = 1
 [out]
 main:2: error: Cannot find module named 'm.n'
-main:2: note: (Perhaps setting MYPYPATH would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
 
 [case testBreakOutsideLoop]
 break

--- a/mypy/test/data/semanal-errors.test
+++ b/mypy/test/data/semanal-errors.test
@@ -231,21 +231,21 @@ import typing
 import m
 [out]
 main:2: error: Cannot find module named 'm'
-main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 
 [case testMissingModule2]
 import typing
 from m import x
 [out]
 main:2: error: Cannot find module named 'm'
-main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 
 [case testMissingModule3]
 import typing
 from m import *
 [out]
 main:2: error: Cannot find module named 'm'
-main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 
 [case testMissingModuleRelativeImport]
 import typing
@@ -255,7 +255,7 @@ from .x import y
 [out]
 main:2: note: In module imported here:
 tmp/m/__init__.py:1: error: Cannot find module named 'm.x'
-tmp/m/__init__.py:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+tmp/m/__init__.py:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 
 [case testMissingModuleRelativeImport2]
 import typing
@@ -266,7 +266,7 @@ from .x import y
 [out]
 main:2: note: In module imported here:
 tmp/m/a.py:1: error: Cannot find module named 'm.x'
-tmp/m/a.py:1: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+tmp/m/a.py:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 
 [case testModuleNotImported]
 import typing
@@ -317,7 +317,7 @@ import typing
 import m.n
 [out]
 main:2: error: Cannot find module named 'm.n'
-main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 
 [case testMissingPackage]
 import typing
@@ -325,7 +325,7 @@ from m.n import x
 from a.b import *
 [out]
 main:2: error: Cannot find module named 'm.n'
-main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:3: error: Cannot find module named 'a.b'
 
 [case testErrorInImportedModule]
@@ -358,7 +358,7 @@ m.n.x
 x = 1
 [out]
 main:2: error: Cannot find module named 'm.n'
-main:2: note: (Perhaps setting MYPYPATH or using the "--silent" flag would help)
+main:2: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 
 [case testBreakOutsideLoop]
 break


### PR DESCRIPTION
As I suggested in #1339 alter `module_not_found` suggestion to "(Perhaps setting MYPYPATH or using the "--silent" flag would help)".