### PR TITLE
Correctly type check redefinitions in try's else clause.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1758,6 +1758,7 @@ class TypeChecker(NodeVisitor[Type]):
         self.binder.try_frames.add(len(self.binder.frames) - 2)
         self.accept(s.body)
         self.binder.try_frames.remove(len(self.binder.frames) - 2)
+        self.breaking_out = False
         changed, frame_on_completion = self.binder.pop_frame()
         completed_frames.append(frame_on_completion)
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1758,9 +1758,6 @@ class TypeChecker(NodeVisitor[Type]):
         self.binder.try_frames.add(len(self.binder.frames) - 2)
         self.accept(s.body)
         self.binder.try_frames.remove(len(self.binder.frames) - 2)
-        if s.else_body:
-            self.accept(s.else_body)
-        self.breaking_out = False
         changed, frame_on_completion = self.binder.pop_frame()
         completed_frames.append(frame_on_completion)
 
@@ -1790,6 +1787,14 @@ class TypeChecker(NodeVisitor[Type]):
                 var.type = DeletedType(source=source)
                 self.binder.cleanse(s.vars[i])
 
+            self.breaking_out = False
+            changed, frame_on_completion = self.binder.pop_frame()
+            completed_frames.append(frame_on_completion)
+
+        # Do the else block similar to the way we do except blocks.
+        if s.else_body:
+            self.binder.push_frame()
+            self.accept(s.else_body)
             self.breaking_out = False
             changed, frame_on_completion = self.binder.pop_frame()
             completed_frames.append(frame_on_completion)

--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -516,6 +516,24 @@ else:
   object(None) # E: Too many arguments for "object"
 [builtins fixtures/exception.py]
 
+[case testRedefinedFunctionInTryWithElse]
+def f() -> None: pass
+try:
+    pass
+except BaseException:
+    f2 = f
+else:
+    def f2() -> str: pass
+try:
+    pass
+except BaseException:
+    f3 = f
+else:
+    def f3() -> None: pass
+[builtins fixtures/exception.py]
+[out]
+main:7: error: Incompatible redefinition (original type Callable[[], None], redefinition with type Callable[[], str])
+
 [case testExceptWithoutType]
 import typing
 try:


### PR DESCRIPTION
Fixes #1289. After a diff in the issue by @brodie.