### PR TITLE
Skip arg count checks for dynamic functions.

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -132,11 +132,7 @@ class ExpressionChecker:
             # It's really a special form that only looks like a call.
             return self.accept(e.analyzed, self.chk.type_context[-1])
         self.try_infer_partial_type(e)
-        self.accept(e.callee)
-        # Access callee type directly, since accept may return the Any type
-        # even if the type is known (in a dynamically typed function). This
-        # way we get a more precise callee in dynamically typed functions.
-        callee_type = self.chk.type_map[e.callee]
+        callee_type = self.accept(e.callee)
         if (self.chk.disallow_untyped_calls and
                 self.chk.typing_mode_full() and
                 isinstance(callee_type, CallableType)
@@ -238,9 +234,8 @@ class ExpressionChecker:
             arg_types = self.infer_arg_types_in_context2(
                 callee, args, arg_kinds, formal_to_actual)
 
-            if not self.chk.typing_mode_none():
-                self.check_argument_count(callee, arg_types, arg_kinds,
-                                          arg_names, formal_to_actual, context, self.msg)
+            self.check_argument_count(callee, arg_types, arg_kinds,
+                                      arg_names, formal_to_actual, context, self.msg)
 
             self.check_argument_types(arg_types, arg_kinds, callee,
                                       formal_to_actual, context,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -238,8 +238,9 @@ class ExpressionChecker:
             arg_types = self.infer_arg_types_in_context2(
                 callee, args, arg_kinds, formal_to_actual)
 
-            self.check_argument_count(callee, arg_types, arg_kinds,
-                                      arg_names, formal_to_actual, context, self.msg)
+            if self.chk.typing_mode_full():
+                self.check_argument_count(callee, arg_types, arg_kinds,
+                                          arg_names, formal_to_actual, context, self.msg)
 
             self.check_argument_types(arg_types, arg_kinds, callee,
                                       formal_to_actual, context,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -238,7 +238,7 @@ class ExpressionChecker:
             arg_types = self.infer_arg_types_in_context2(
                 callee, args, arg_kinds, formal_to_actual)
 
-            if self.chk.typing_mode_full():
+            if not self.chk.typing_mode_none():
                 self.check_argument_count(callee, arg_types, arg_kinds,
                                           arg_names, formal_to_actual, context, self.msg)
 

--- a/mypy/test/data/check-dynamic-typing.test
+++ b/mypy/test/data/check-dynamic-typing.test
@@ -655,3 +655,25 @@ class A(B):
         x()
 [out]
 main: note: In class "A":
+
+
+-- Don't complain about too few/many arguments in dynamic functions
+-- ----------------------------------------------------------------
+
+[case testTooManyArgsInDynamic]
+def f() -> None: pass
+def g():
+    f(1) # Silent
+[out]
+
+[case testTooFewArgsInDynamic]
+def f(a: int) -> None: pass
+def g():
+    f() # Silent
+[out]
+
+[case testJustRightInDynamic]
+def f(a: int) -> None: pass
+def g():
+    f('') # Silent
+[out]

--- a/mypy/test/data/typexport-basic.test
+++ b/mypy/test/data/typexport-basic.test
@@ -510,7 +510,7 @@ def f():
 def g(a: object) -> object: pass
 o = None # type: object
 [out]
-CallExpr(3) : builtins.object
+CallExpr(3) : Any
 NameExpr(3) : def (a: builtins.object) -> builtins.object
 NameExpr(3) : builtins.object
 
@@ -549,8 +549,8 @@ def f():
   A()
 class A(Generic[T]): pass
 [out]
-CallExpr(4) : A[Any]
-NameExpr(4) : def () -> A[Any]
+CallExpr(4) : Any
+NameExpr(4) : def [T] () -> A[T`-1]
 
 [case testGenericCallInDynamicallyTypedFunction2]
 from typing import TypeVar, Generic
@@ -560,8 +560,8 @@ def f():
 class A(Generic[T]):
     def __init__(self, x: T) -> None: pass
 [out]
-CallExpr(4) : A[Any]
-NameExpr(4) : def (x: Any) -> A[Any]
+CallExpr(4) : Any
+NameExpr(4) : def [T] (x: T`-1) -> A[T`-1]
 NameExpr(4) : def () -> Any
 
 [case testGenericCallInDynamicallyTypedFunction3]
@@ -572,7 +572,7 @@ def f():
 def g(x: t) -> t: pass
 [out]
 CallExpr(4) : Any
-NameExpr(4) : def (x: Any) -> Any
+NameExpr(4) : def [t] (x: t`-1) -> t`-1
 
 
 -- Generic types and type inference


### PR DESCRIPTION
Another followup for #1415 (fixing #1334).

I'm not at all sure this is the right thing to do. But we should honor the simple promise implied by the docs and by PEP 484 (even if not made very explicit) that the body of dynamic (unannotated) functions is not checked.

There are probably many other errors that are produced by the type checker for dynamic functions. But suppressing this one and #1431 are on at the top of the wishlist of our internal customers.