### PR TITLE
Check for subtype, not supertype, when redefining a function.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -598,10 +598,10 @@ class TypeChecker(NodeVisitor[Type]):
                         self.fail(messages.INCOMPATIBLE_REDEFINITION, defn)
                 else:
                     # TODO: Update conditional type binder.
-                    self.check_subtype(orig_type, new_type, defn,
+                    self.check_subtype(new_type, orig_type, defn,
                                        messages.INCOMPATIBLE_REDEFINITION,
-                                       'original type',
-                                       'redefinition with type')
+                                       'redefinition with type',
+                                       'original type')
 
     def check_func_item(self, defn: FuncItem,
                         type_override: CallableType = None,

--- a/mypy/test/data/check-functions.test
+++ b/mypy/test/data/check-functions.test
@@ -1146,7 +1146,23 @@ main: note: In function "g":
 def g(): pass
 f = g
 if g():
-    def f(x): pass  # E: Incompatible redefinition (original type Callable[[], Any], redefinition with type Callable[[Any], Any])
+    def f(x): pass  # E: Incompatible redefinition (redefinition with type Callable[[Any], Any], original type Callable[[], Any])
+
+[case testRedefineFunctionDefinedAsVariableWithVariance1]
+class B: pass
+class C(B): pass
+def g(x: C) -> B: pass
+f = g
+if g(C()):
+    def f(x: C) -> C: pass
+
+[case testRedefineFunctionDefinedAsVariableWithVariance2]
+class B: pass
+class C(B): pass
+def g(x: C) -> B: pass
+f = g
+if g(C()):
+    def f(x: B) -> B: pass
 
 [case testRedefineFunctionDefinedAsVariableInitializedToEmptyList]
 f = [] # E: Need type annotation for variable


### PR DESCRIPTION
Fix #1434.