### PR TITLE
Avoid another crash in partial type inference. Fix #1269.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1528,7 +1528,7 @@ class TypeChecker(NodeVisitor[Type]):
     def try_infer_partial_type_from_indexed_assignment(
             self, lvalue: IndexExpr, rvalue: Node) -> None:
         # TODO: Should we share some of this with try_infer_partial_type?
-        if isinstance(lvalue.base, RefExpr):
+        if isinstance(lvalue.base, RefExpr) and isinstance(lvalue.base.node, Var):
             var = cast(Var, lvalue.base.node)
             if var is not None and isinstance(var.type, PartialType):
                 type_type = var.type.type

--- a/mypy/test/data/check-inference.test
+++ b/mypy/test/data/check-inference.test
@@ -1696,3 +1696,12 @@ def f(): pass
 a = {0: [0]} if f() else {0: []}
 a() # E: Dict[int, List[int]] not callable
 [builtins fixtures/dict.py]
+
+[case testMisguidedSetItem]
+from typing import Generic, Sequence, TypeVar
+T = TypeVar('T')
+class C(Sequence[T], Generic[T]): pass
+C[0] = 0
+[out]
+main:4: error: Type expected within [...]
+main:4: error: Unsupported target for indexed assignment


### PR DESCRIPTION
Also fixes #1245.