### PR TITLE
Remove some unnecessary checks for None

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -163,10 +163,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
     # Non-trivial leaf type
 
     def visit_type_var(self, template: TypeVarType) -> List[Constraint]:
-        if self.actual:
-            return [Constraint(template.id, self.direction, self.actual)]
-        else:
-            return []
+        return [Constraint(template.id, self.direction, self.actual)]
 
     # Non-leaf types
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1776,7 +1776,7 @@ class TypeInfo(SymbolNode):
 
     def is_generic(self) -> bool:
         """Is the type generic (i.e. does it have type variables)?"""
-        return self.type_vars is not None and len(self.type_vars) > 0
+        return len(self.type_vars) > 0
 
     def get(self, name: str) -> 'SymbolTableNode':
         for cls in self.mro:


### PR DESCRIPTION
I find extraneous checks of this kind confusing; suggesting that `None` is expected as a possible value when in fact it has no meaning and is (or is expected to be) impossible.