### PR TITLE
Allow substituting typevar-with-values for typevar-with-values

### DIFF
--- a/mypy/test/data/check-typevar-values.test
+++ b/mypy/test/data/check-typevar-values.test
@@ -465,3 +465,17 @@ def g(x: str) -> str: return x
 main: note: In function "f":
 main:7: error: Incompatible types in assignment (expression has type "object", variable has type "int")
 main:7: error: Incompatible types in assignment (expression has type "object", variable has type "str")
+
+[case testGenericFunctionSubtypingWithTypevarValues]
+from typing import TypeVar
+class A: pass
+T = TypeVar('T', int, str)
+U = TypeVar('U', str, A, int)
+def f(x: T) -> T: pass
+def g(x: U) -> U: pass
+a = f
+a = f
+a = g
+b = g
+b = g
+b = f # E: Incompatible types in assignment (expression has type Callable[[T], T], variable has type Callable[[U], U])


### PR DESCRIPTION
This is needed for subtyping of generic function with type variables
with values to work correctly, which will be needed for #1261.