### PR TITLE
Add reveal_type()

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -15,7 +15,7 @@ from mypy.nodes import (
     TupleExpr, ListExpr, ExpressionStmt, ReturnStmt, IfStmt,
     WhileStmt, OperatorAssignmentStmt, WithStmt, AssertStmt,
     RaiseStmt, TryStmt, ForStmt, DelStmt, CallExpr, IntExpr, StrExpr,
-    BytesExpr, UnicodeExpr, FloatExpr, OpExpr, UnaryExpr, CastExpr, SuperExpr,
+    BytesExpr, UnicodeExpr, FloatExpr, OpExpr, UnaryExpr, CastExpr, RevealTypeExpr, SuperExpr,
     TypeApplication, DictExpr, SliceExpr, FuncExpr, TempNode, SymbolTableNode,
     Context, ListComprehension, ConditionalExpr, GeneratorExpr,
     Decorator, SetExpr, TypeVarExpr, PrintStmt,
@@ -2068,6 +2068,9 @@ class TypeChecker(NodeVisitor[Type]):
 
     def visit_cast_expr(self, e: CastExpr) -> Type:
         return self.expr_checker.visit_cast_expr(e)
+
+    def visit_reveal_type_expr(self, e: RevealTypeExpr) -> Type:
+        return self.expr_checker.visit_reveal_type_expr(e)
 
     def visit_super_expr(self, e: SuperExpr) -> Type:
         return self.expr_checker.visit_super_expr(e)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1175,7 +1175,7 @@ class ExpressionChecker:
     def visit_reveal_type_expr(self, expr: RevealTypeExpr) -> Type:
         """Type check a reveal_type expression."""
         revealed_type = self.accept(expr.expr)
-        self.msg.reveal_type(expr.expr, revealed_type, expr)
+        self.msg.reveal_type(revealed_type, expr)
         return revealed_type
 
     def visit_type_application(self, tapp: TypeApplication) -> Type:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -10,7 +10,7 @@ from mypy.types import (
 from mypy.nodes import (
     NameExpr, RefExpr, Var, FuncDef, OverloadedFuncDef, TypeInfo, CallExpr,
     Node, MemberExpr, IntExpr, StrExpr, BytesExpr, UnicodeExpr, FloatExpr,
-    OpExpr, UnaryExpr, IndexExpr, CastExpr, TypeApplication, ListExpr,
+    OpExpr, UnaryExpr, IndexExpr, CastExpr, RevealTypeExpr, TypeApplication, ListExpr,
     TupleExpr, DictExpr, FuncExpr, SuperExpr, SliceExpr, Context,
     ListComprehension, GeneratorExpr, SetExpr, MypyFile, Decorator,
     ConditionalExpr, ComparisonExpr, TempNode, SetComprehension,
@@ -1171,6 +1171,12 @@ class ExpressionChecker:
         return (isinstance(target_type, AnyType) or
                 (not isinstance(source_type, Void) and
                  not isinstance(target_type, Void)))
+
+    def visit_reveal_type_expr(self, expr: RevealTypeExpr) -> Type:
+        """Type check a reveal_type expression."""
+        revealed_type = self.accept(expr.expr)
+        self.msg.reveal_type(expr.expr, revealed_type, expr)
+        return revealed_type
 
     def visit_type_application(self, tapp: TypeApplication) -> Type:
         """Type check a type application (expr[type, ...])."""

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -14,7 +14,7 @@ from mypy.types import (
     Overloaded, FunctionLike, DeletedType
 )
 from mypy.nodes import (
-    TypeInfo, Context, MypyFile, op_methods, FuncDef, reverse_type_aliases, Node,
+    TypeInfo, Context, MypyFile, op_methods, FuncDef, reverse_type_aliases,
     ARG_STAR, ARG_STAR2
 )
 
@@ -818,8 +818,8 @@ class MessageBuilder:
     def invalid_signature(self, func_type: Type, context: Context) -> None:
         self.fail('Invalid signature "{}"'.format(func_type), context)
 
-    def reveal_type(self, expr: Node, typ: Type, context: Context) -> None:
-        self.fail('Type of "{}" is \'{}\''.format(expr, typ), context)
+    def reveal_type(self, typ: Type, context: Context) -> None:
+        self.fail('Revealed type is \'{}\''.format(typ), context)
 
 
 def capitalize(s: str) -> str:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -14,7 +14,7 @@ from mypy.types import (
     Overloaded, FunctionLike, DeletedType
 )
 from mypy.nodes import (
-    TypeInfo, Context, MypyFile, op_methods, FuncDef, reverse_type_aliases,
+    TypeInfo, Context, MypyFile, op_methods, FuncDef, reverse_type_aliases, Node,
     ARG_STAR, ARG_STAR2
 )
 
@@ -817,6 +817,9 @@ class MessageBuilder:
 
     def invalid_signature(self, func_type: Type, context: Context) -> None:
         self.fail('Invalid signature "{}"'.format(func_type), context)
+
+    def reveal_type(self, expr: Node, typ: Type, context: Context) -> None:
+        self.fail('Type of "{}" is \'{}\''.format(expr, typ), context)
 
 
 def capitalize(s: str) -> str:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1368,6 +1368,18 @@ class CastExpr(Node):
         return visitor.visit_cast_expr(self)
 
 
+class RevealTypeExpr(Node):
+    """Reveal type expression reveal_type(expr)."""
+
+    expr = None  # type: Node
+
+    def __init__(self, expr: Node) -> None:
+        self.expr = expr
+
+    def accept(self, visitor: NodeVisitor[T]) -> T:
+        return visitor.visit_reveal_type_expr(self)
+
+
 class SuperExpr(Node):
     """Expression super().name"""
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1795,7 +1795,7 @@ class SemanticAnalyzer(NodeVisitor):
             expr.analyzed = CastExpr(expr.args[1], target)
             expr.analyzed.line = expr.line
             expr.analyzed.accept(self)
-        elif refers_to_fullname(expr.callee, None) and expr.callee.name == 'reveal_type':
+        elif refers_to_fullname(expr.callee, 'builtins.reveal_type'):
             if not self.check_fixed_args(expr, 1, 'reveal_type'):
                 return
             expr.analyzed = RevealTypeExpr(expr.args[0])
@@ -2293,6 +2293,8 @@ class FirstPass(NodeVisitor):
         if mod_id == 'builtins':
             literal_types = [
                 ('None', NoneTyp()),
+                # reveal_type is a mypy-only function that gives an error with the type of its arg
+                ('reveal_type', AnyType()),
             ]  # type: List[Tuple[str, Type]]
 
             # TODO(ddfisher): This guard is only needed because mypy defines
@@ -2585,7 +2587,7 @@ def set_callable_name(sig: Type, fdef: FuncDef) -> Type:
         return sig
 
 
-def refers_to_fullname(node: Node, fullname: Optional[str]) -> bool:
+def refers_to_fullname(node: Node, fullname: str) -> bool:
     """Is node a name or member expression with the given full name?"""
     return isinstance(node, RefExpr) and node.fullname == fullname
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1795,7 +1795,7 @@ class SemanticAnalyzer(NodeVisitor):
             expr.analyzed = CastExpr(expr.args[1], target)
             expr.analyzed.line = expr.line
             expr.analyzed.accept(self)
-        elif expr.callee.fullname is None and expr.callee.name == 'reveal_type':
+        elif refers_to_fullname(expr.callee, None) and expr.callee.name == 'reveal_type':
             if not self.check_fixed_args(expr, 1, 'reveal_type'):
                 return
             expr.analyzed = RevealTypeExpr(expr.args[0])
@@ -2585,7 +2585,7 @@ def set_callable_name(sig: Type, fdef: FuncDef) -> Type:
         return sig
 
 
-def refers_to_fullname(node: Node, fullname: str) -> bool:
+def refers_to_fullname(node: Node, fullname: Optional[str]) -> bool:
     """Is node a name or member expression with the given full name?"""
     return isinstance(node, RefExpr) and node.fullname == fullname
 

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -372,6 +372,9 @@ class StrConv(NodeVisitor[str]):
     def visit_cast_expr(self, o):
         return self.dump([o.expr, o.type], o)
 
+    def visit_reveal_type_expr(self, o):
+        return self.dump([o.expr], o)
+
     def visit_unary_expr(self, o):
         return self.dump([o.op, o.expr], o)
 

--- a/mypy/test/data/check-expressions.test
+++ b/mypy/test/data/check-expressions.test
@@ -1476,3 +1476,11 @@ class D(Dict[T, S], Generic[T, S]):
 d = D(1, y='')
 d() # E: D[str, int] not callable
 [builtins fixtures/dict.py]
+
+[case testUserDefinedRevealType]
+def reveal_type(x: int) -> None: pass
+reveal_type("foo") # E: Argument 1 to "reveal_type" has incompatible type "str"; expected "int"
+
+[case testRevealTypeVar]
+reveal_type = 1
+1 + "foo" # E: Unsupported left operand type for + ("int")

--- a/mypy/test/data/check-expressions.test
+++ b/mypy/test/data/check-expressions.test
@@ -1477,6 +1477,15 @@ d = D(1, y='')
 d() # E: D[str, int] not callable
 [builtins fixtures/dict.py]
 
+[case testRevealType]
+reveal_type(1) # E: Revealed type is 'builtins.int'
+
+[case testUndefinedRevealType]
+reveal_type(x)
+[out]
+main:1: error: Name 'x' is not defined
+main:1: error: Revealed type is 'Any'
+
 [case testUserDefinedRevealType]
 def reveal_type(x: int) -> None: pass
 reveal_type("foo") # E: Argument 1 to "reveal_type" has incompatible type "str"; expected "int"

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -7,7 +7,7 @@ from mypy.nodes import (
     Block, MypyFile, FuncItem, CallExpr, ClassDef, Decorator, FuncDef,
     ExpressionStmt, AssignmentStmt, OperatorAssignmentStmt, WhileStmt,
     ForStmt, ReturnStmt, AssertStmt, DelStmt, IfStmt, RaiseStmt,
-    TryStmt, WithStmt, MemberExpr, OpExpr, SliceExpr, CastExpr,
+    TryStmt, WithStmt, MemberExpr, OpExpr, SliceExpr, CastExpr, RevealTypeExpr,
     UnaryExpr, ListExpr, TupleExpr, DictExpr, SetExpr, IndexExpr,
     GeneratorExpr, ListComprehension, ConditionalExpr, TypeApplication,
     FuncExpr, ComparisonExpr, OverloadedFuncDef, YieldFromExpr,
@@ -167,6 +167,9 @@ class TraverserVisitor(NodeVisitor[T], Generic[T]):
             o.stride.accept(self)
 
     def visit_cast_expr(self, o: CastExpr) -> T:
+        o.expr.accept(self)
+
+    def visit_reveal_type_expr(self, o: RevealTypeExpr) -> T:
         o.expr.accept(self)
 
     def visit_unary_expr(self, o: UnaryExpr) -> T:

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -11,7 +11,7 @@ from mypy.nodes import (
     OperatorAssignmentStmt, ExpressionStmt, AssignmentStmt, ReturnStmt,
     RaiseStmt, AssertStmt, DelStmt, BreakStmt, ContinueStmt,
     PassStmt, GlobalDecl, WhileStmt, ForStmt, IfStmt, TryStmt, WithStmt,
-    CastExpr, TupleExpr, GeneratorExpr, ListComprehension, ListExpr,
+    CastExpr, RevealTypeExpr, TupleExpr, GeneratorExpr, ListComprehension, ListExpr,
     ConditionalExpr, DictExpr, SetExpr, NameExpr, IntExpr, StrExpr, BytesExpr,
     UnicodeExpr, FloatExpr, CallExpr, SuperExpr, MemberExpr, IndexExpr,
     SliceExpr, OpExpr, UnaryExpr, FuncExpr, TypeApplication, PrintStmt,
@@ -362,6 +362,9 @@ class TransformVisitor(NodeVisitor[Node]):
     def visit_cast_expr(self, node: CastExpr) -> Node:
         return CastExpr(self.node(node.expr),
                         self.type(node.type))
+
+    def visit_reveal_type_expr(self, node: RevealTypeExpr) -> Node:
+        return RevealTypeExpr(self.node(node.expr))
 
     def visit_super_expr(self, node: SuperExpr) -> Node:
         new = SuperExpr(node.name)

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -165,6 +165,9 @@ class NodeVisitor(Generic[T]):
     def visit_cast_expr(self, o: 'mypy.nodes.CastExpr') -> T:
         pass
 
+    def visit_reveal_type_expr(self, o: 'mypy.nodes.RevealTypeExpr') -> T:
+        pass
+
     def visit_super_expr(self, o: 'mypy.nodes.SuperExpr') -> T:
         pass
 


### PR DESCRIPTION
Fixes #1466.

This is a mostly complete PR which implement `reveal_type`.  There 3 things that need to happen before this PR is merged:

1) Final consensus on a name.  (This discussion should probably happen on #1466.)
2) Currently it prints out mypy's internal representation of the expression, instead of in Python format (i.e. `IntExpr(1)` instead of `1`).  Is there some function that will print out Nodes in Python format instead?
3) Currently it emits an additional `error: Name 'reveal_type' is not defined`, due to trying and failing to look up `reveal_type` at an earlier stage in the static analyzer.  It's not clear to me what a good, non-hacky way to fix this is.  Thoughts?