### PR TITLE
Windows test fixes and CI with AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+environment:
+  matrix:
+  - PYTHON: C:\\Python33
+  - PYTHON: C:\\Python34
+  - PYTHON: C:\\Python35
+  - PYTHON: C:\\Python33-x64
+  - PYTHON: C:\\Python34-x64
+  - PYTHON: C:\\Python35-x64
+install:
+  - "git submodule update --init typeshed"
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;C:\\Python27;%PATH%"
+  - "REN C:\\Python27\\python.exe python2.exe"
+  - "python --version"
+  - "python2 --version"
+build_script:
+  - "pip install -r test-requirements.txt"
+  - "python setup.py install"
+test_script:
+- cmd: python runtests.py -v

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -762,10 +762,14 @@ def write_cache(id: str, path: str, tree: MypyFile,
     with open(meta_json_tmp, 'w') as f:
         json.dump(meta, f, sort_keys=True)
         f.write('\n')
-    # TODO: On Windows, os.rename() may not be atomic, and we could
-    # use os.replace().  However that's new in Python 3.3.
-    os.rename(data_json_tmp, data_json)
-    os.rename(meta_json_tmp, meta_json)
+    # TODO: This is a temporary change until Python 3.2 support is dropped, see #1504
+    # os.rename will raise an exception rather than replace files on Windows
+    try:
+        replace = os.replace
+    except AttributeError:
+        replace = os.rename
+    replace(data_json_tmp, data_json)
+    replace(meta_json_tmp, meta_json)
 
 
 """Dependency manager.

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -65,6 +65,8 @@ def parse_test_cases(
             tcout = []  # type: List[str]
             if i < len(p) and p[i].id == 'out':
                 tcout = p[i].data
+                if p[i].arg == 'pathfix':
+                    tcout = [s.replace('/', os.path.sep) for s in tcout]
                 ok = True
                 i += 1
             elif optional_out:

--- a/mypy/test/data/cmdline.test
+++ b/mypy/test/data/cmdline.test
@@ -18,7 +18,7 @@ undef
 [file pkg/subpkg/a.py]
 undef
 import pkg.subpkg.a
-[out]
+[out pathfix]
 pkg/a.py:1: error: Name 'undef' is not defined
 pkg/subpkg/a.py:1: error: Name 'undef' is not defined
 
@@ -31,7 +31,7 @@ undef
 [file pkg/subpkg/a.py]
 undef
 import pkg.subpkg.a
-[out]
+[out pathfix]
 pkg/a.py:1: error: Name 'undef' is not defined
 pkg/subpkg/a.py:1: error: Name 'undef' is not defined
 
@@ -41,7 +41,7 @@ pkg/subpkg/a.py:1: error: Name 'undef' is not defined
 undef
 [file dir/subdir/a.py]
 undef
-[out]
+[out pathfix]
 dir/a.py:1: error: Name 'undef' is not defined
 
 [case testCmdlineNonPackageSlash]
@@ -50,7 +50,7 @@ dir/a.py:1: error: Name 'undef' is not defined
 undef
 [file dir/subdir/a.py]
 undef
-[out]
+[out pathfix]
 dir/a.py:1: error: Name 'undef' is not defined
 
 [case testCmdlinePackageContainingSubdir]
@@ -60,7 +60,7 @@ dir/a.py:1: error: Name 'undef' is not defined
 undef
 [file pkg/subdir/a.py]
 undef
-[out]
+[out pathfix]
 pkg/a.py:1: error: Name 'undef' is not defined
 
 [case testCmdlineNonPackageContainingPackage]
@@ -71,6 +71,6 @@ import subpkg.a
 [file dir/subpkg/__init__.py]
 [file dir/subpkg/a.py]
 undef
-[out]
+[out pathfix]
 dir/subpkg/a.py:1: error: Name 'undef' is not defined
 dir/a.py:1: error: Name 'undef' is not defined

--- a/mypy/test/data/pythoneval.test
+++ b/mypy/test/data/pythoneval.test
@@ -16,7 +16,7 @@ import re
 from typing import Sized, Sequence, Iterator, Iterable, Mapping, AbstractSet
 
 def check(o, t):
-    rep = re.sub('0x[0-9a-f]+', '0x...', repr(o))
+    rep = re.sub('0x[0-9a-fA-F]+', '0x...', repr(o))
     rep = rep.replace('sequenceiterator', 'str_iterator')
     trep = str(t).replace('_abcoll.Sized', 'collections.abc.Sized')
     print(rep, trep, isinstance(o, t))

--- a/mypy/test/data/semanal-modules.test
+++ b/mypy/test/data/semanal-modules.test
@@ -770,7 +770,7 @@ import m.x
 [file m/__init__.py]
 [file m/x.py]
 from .x import nonexistent
-[out]
+[out pathfix]
 main:1: note: In module imported here:
 tmp/m/x.py:1: error: Module has no attribute 'nonexistent'
 
@@ -779,7 +779,7 @@ import m.x
 [file m/__init__.py]
 [file m/x.py]
 from m.x import nonexistent
-[out]
+[out pathfix]
 main:1: note: In module imported here:
 tmp/m/x.py:1: error: Module has no attribute 'nonexistent'
 
@@ -846,7 +846,7 @@ import m
 x
 [file m.py]
 y
-[out]
+[out pathfix]
 main:1: note: In module imported here:
 tmp/m.py:1: error: Name 'y' is not defined
 main:2: error: Name 'x' is not defined

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -152,7 +152,8 @@ class TypeCheckSuite(Suite):
         for line in a:
             m = re.match(r'([^\s:]+):\d+: error:', line)
             if m:
-                hits.add(m.group(1))
+                p = m.group(1).replace('/', os.path.sep)
+                hits.add(p)
         return hits
 
     def find_module_files(self) -> Dict[str, str]:


### PR DESCRIPTION
I noticed in #1353 that testing for the new parser is needed on Windows. I thought I'd get that started with some CI from AppVeyor. It turned out to be a bit more complicated than that.

* util.try_find_python2_interpreter() doesn't work well on Windows. I cheat in appveyor.yml by renaming Python 2.7's python.exe to python2.exe. I'm not sure how you could find multiple interpreters in the path on Windows since those handy version symlinks (python3, python35, etc) don't exist.
* waiter, the parallel execution task runner, used some posix tricks to run multiple processes at once and wait for the first one to return. I replaced all that clever code with some much uglier and stupider polling that works on both Windows and saner OSes.
* waiter also tried to open a file that was already open. On Windows, this is impossible. It's okay, though, because NamedTemporaryFile (and TemporaryFile) give you a file-like object with a file already open in binary mode. It looks like the stub generation test cases are failing with a similar issue.

This is what the tests look like on Windows: https://ci.appveyor.com/project/jtatum/mypy/build/1.0.16

Still to-do:

- [x] Fix failing tests on Windows. Most look like path differences (forward vs. backslash) and NamedTempFile. A couple seem a bit more mysterious.
- [x] Add os.replace() to typeshed