### PR TITLE
Treat bare Callable as Callable[..., Any]

### DIFF
--- a/mypy/test/data/check-functions.test
+++ b/mypy/test/data/check-functions.test
@@ -1531,6 +1531,11 @@ from typing import Callable, Any
 
 def foo(f: Callable) -> bool:
     return f()
+
+def f1() -> bool:
+    return False
+
+foo(f1)
 [builtins fixtures/bool.py]
 
 [case testFunctionNestedWithinWith]

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -210,12 +210,13 @@ class TypeAnalyser(TypeVisitor[Type]):
     def analyze_callable_type(self, t: UnboundType) -> Type:
         fallback = self.builtin_type('builtins.function')
         if len(t.args) == 0:
-            # Callable (bare)
+            # Callable (bare). Treat as Callable[..., Any].
             return CallableType([AnyType(), AnyType()],
                                 [nodes.ARG_STAR, nodes.ARG_STAR2],
                                 [None, None],
                                 ret_type=AnyType(),
-                                fallback=fallback)
+                                fallback=fallback,
+                                is_ellipsis_args=True)
         elif len(t.args) == 2:
             ret_type = t.args[1].accept(self)
             if isinstance(t.args[0], TypeList):


### PR DESCRIPTION
The old definition of Callable was the type of a function defined as

    def f(*args: Any, **kwargs: Any) -> Any: ...

which is not the form of a general function, only one that can accept
an arbitrary number of arguments.

Fixes #1501.