### PR TITLE
Test that isinstance doesn't lose generic class parameter info

### DIFF
--- a/mypy/test/data/check-isinstance.test
+++ b/mypy/test/data/check-isinstance.test
@@ -824,3 +824,13 @@ def f(x: object):
     y = 0 # type: int
     y = x
 [builtins fixtures/isinstance.py]
+
+[case testIsinstanceOfGenericClassRetainsParameters]
+from typing import List, Union
+def f(x: Union[List[int], str]) -> None:
+    if isinstance(x, list):
+        x[0]()
+[builtins fixtures/isinstancelist.py]
+[out]
+main: note: In function "f":
+main:4: error: "int" not callable


### PR DESCRIPTION
A potential change that Jukka and I were discussing today (making
meet_types return Any if either parameter is Any) broke a complicated
version of this in stdlib-samples, but didn't break any of the type
checker test cases.