### PR TITLE
remove use of io.TextIOWrapper(write_through)

### DIFF
--- a/stdlib-samples/3.2/subprocess.py
+++ b/stdlib-samples/3.2/subprocess.py
@@ -738,7 +738,7 @@ class Popen(object):
         if p2cwrite != -1:
             self.stdin = io.open(p2cwrite, 'wb', bufsize)
             if self.universal_newlines:
-                self.stdin = io.TextIOWrapper(self.stdin, write_through=True)
+                self.stdin = io.TextIOWrapper(self.stdin)
         if c2pread != -1:
             self.stdout = io.open(c2pread, 'rb', bufsize)
             if universal_newlines:


### PR DESCRIPTION
Based on the [documentation](https://docs.python.org/3.3/library/io.html#io.TextIOWrapper) The `write_through` argument to `io.TextIOWrapper` was only added in python 3.3, but it is used in `stdlib-samples/3.2/subprocess.py` which is python 3.2.