### PR TITLE
Added better IntEnum support for #1172

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1725,6 +1725,8 @@ class TypeInfo(SymbolNode):
     names = None  # type: SymbolTable      # Names defined directly in this type
     is_abstract = False                    # Does the class have any abstract attributes?
     abstract_attributes = None  # type: List[str]
+    # Classes inheriting from Enum shadow their true members with a __getattr__, so we
+    # have to treat them as a special case.
     is_enum = False
     # If true, any unknown attributes should have type 'Any' instead
     # of generating a type error.  This would be true if there is a

--- a/mypy/test/data/pythoneval-enum.test
+++ b/mypy/test/data/pythoneval-enum.test
@@ -74,6 +74,19 @@ def takes_int(i: int):
 takes_int(SomeIntEnum.x)
 takes_int(2)
 
+[case testIntEnum_functionReturningIntEnum]
+from enum import IntEnum
+class SomeIntEnum(IntEnum):
+    x = 1
+def returns_some_int_enum() -> SomeIntEnum:
+    return SomeIntEnum.x
+an_int = 1
+an_int = returns_some_int_enum()
+
+an_enum = SomeIntEnum.x
+an_enum = returns_some_int_enum()
+[out]
+
 [case testEnumMethods]
 from enum import Enum
 

--- a/mypy/test/data/pythoneval-enum.test
+++ b/mypy/test/data/pythoneval-enum.test
@@ -41,17 +41,38 @@ x = E.x
 [out]
 _program.py:7: error: Incompatible types in assignment (expression has type "E", variable has type "int")
 
-[case testIntEnum]
+[case testIntEnum_assignToIntVariable]
 from enum import IntEnum
 class N(IntEnum):
     x = 1
     y = 1
 n = 1
-n = N.x
+n = N.x  # Subclass of int, so it's okay
 s = ''
 s = N.y
 [out]
-_program.py:8: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+_program.py:8: error: Incompatible types in assignment (expression has type "N", variable has type "str")
+
+[case testIntEnum_functionTakingIntEnum]
+from enum import IntEnum
+class SomeIntEnum(IntEnum):
+    x = 1
+def takes_some_int_enum(n: SomeIntEnum):
+    pass
+takes_some_int_enum(SomeIntEnum.x)
+takes_some_int_enum(1)  # Error
+takes_some_int_enum(SomeIntEnum(1))  # How to deal with the above
+[out]
+_program.py:7: error: Argument 1 to "takes_some_int_enum" has incompatible type "int"; expected "SomeIntEnum"
+
+[case testIntEnum_functionTakingInt]
+from enum import IntEnum
+class SomeIntEnum(IntEnum):
+    x = 1
+def takes_int(i: int):
+    pass
+takes_int(SomeIntEnum.x)
+takes_int(2)
 
 [case testEnumMethods]
 from enum import Enum


### PR DESCRIPTION
 #1172 says IntEnum members are treated as ints. This diff treats SomeIntEnum.x as both an instance of SomeIntEnum and int.

It'd be great to not have to do this hardcoded list of Enum-like classes, but seeing as that's how Enum is already done, I just decided to jack into it.

Only concern: this iteration over a list of size 2 is going to happen for _every instance_, it might be worth worrying about optimizing the branch prediction on it. (9/10 times, instances aren't going to be Enum.)