### PR TITLE
Fix how the fast parser interprets string literals in Python 2

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -103,7 +103,7 @@ def find(f: Callable[[T], bool], seq: Sequence[T]) -> T:
 class ASTConverter(ast35.NodeTransformer):
     def __init__(self,
                  pyversion: Tuple[int, int],
-                 is_stub,
+                 is_stub: bool,
                  custom_typing_module: str = None) -> None:
         self.class_nesting = 0
         self.imports = []  # type: List[ImportBase]

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -649,7 +649,7 @@ class ASTConverter(ast35.NodeTransformer):
 
         raise RuntimeError('num not implemented for ' + str(type(n.n)))
 
-    # Str(string s) -- need to specify raw, unicode, etc?
+    # Str(string s)
     @with_line
     def visit_Str(self, n: ast35.Str) -> Node:
         if self.pyversion[0] >= 3 or self.is_stub:
@@ -666,11 +666,14 @@ class ASTConverter(ast35.NodeTransformer):
     # Bytes(bytes s)
     @with_line
     def visit_Bytes(self, n: ast35.Bytes) -> Node:
-        # TODO: this is kind of hacky
+        # The following line is a bit hacky, but is the best way to maintain
+        # compatibility with how mypy currently parses the contents of bytes literals.
+        contents = str(n.s)[2:-1]
+
         if self.pyversion[0] >= 3:
-            return BytesExpr(str(n.s)[2:-1])
+            return BytesExpr(contents)
         else:
-            return StrExpr(str(n.s)[2:-1])
+            return StrExpr(contents)
 
     # NameConstant(singleton value)
     def visit_NameConstant(self, n: ast35.NameConstant) -> Node:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -961,6 +961,17 @@ class IntExpr(Node):
         return visitor.visit_int_expr(self)
 
 
+# How mypy uses StrExpr, BytesExpr, and UnicodeExpr:
+# In Python 2 mode:
+# b'x', 'x' -> StrExpr
+# u'x' -> UnicodeExpr
+# BytesExpr is unused
+#
+# In Python 3 mode:
+# b'x' -> BytesExpr
+# 'x', u'x' -> StrExpr
+# UnicodeExpr is unused
+
 class StrExpr(Node):
     """String literal"""
 


### PR DESCRIPTION
Fix #1540.