### PR TITLE
Removed bare-string Error#report severity in favor of a Severity enum

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -28,7 +28,12 @@ from mypy.nodes import (MypyFile, Node, Import, ImportFrom, ImportAll,
                         SymbolTableNode, MODULE_REF)
 from mypy.semanal import FirstPass, SemanticAnalyzer, ThirdPass
 from mypy.checker import TypeChecker
-from mypy.errors import Errors, CompileError, report_internal_error
+from mypy.errors import (
+    CompileError,
+    Errors,
+    Severity,
+    report_internal_error,
+)
 from mypy import fixup
 from mypy.report import Reports
 from mypy import defaults
@@ -460,15 +465,15 @@ class BuildManager:
                 (self.pyversion[0] >= 3 and moduleinfo.is_py3_std_lib_module(id))):
             self.errors.report(
                 line, "No library stub file for standard library module '{}'".format(id))
-            self.errors.report(line, stub_msg, severity='note', only_once=True)
+            self.errors.report(line, stub_msg, severity=Severity.NOTE, only_once=True)
         elif moduleinfo.is_third_party_module(id):
             self.errors.report(line, "No library stub file for module '{}'".format(id))
-            self.errors.report(line, stub_msg, severity='note', only_once=True)
+            self.errors.report(line, stub_msg, severity=Severity.NOTE, only_once=True)
         else:
             self.errors.report(line, "Cannot find module named '{}'".format(id))
             self.errors.report(line, '(Perhaps setting MYPYPATH '
                                      'or using the "--silent-imports" flag would help)',
-                               severity='note', only_once=True)
+                               severity=Severity.NOTE, only_once=True)
 
     def report_file(self, file: MypyFile) -> None:
         if self.source_set.is_source(file):
@@ -1115,11 +1120,11 @@ class State:
         manager.errors.set_import_context([])
         manager.errors.set_file(ancestor_for.xpath)
         manager.errors.report(-1, "Ancestor package '%s' silently ignored" % (id,),
-                              severity='note', only_once=True)
+                              severity=Severity.NOTE, only_once=True)
         manager.errors.report(-1, "(Using --silent-imports, submodule passed on command line)",
-                              severity='note', only_once=True)
+                              severity=Severity.NOTE, only_once=True)
         manager.errors.report(-1, "(This note brought to you by --almost-silent)",
-                              severity='note', only_once=True)
+                              severity=Severity.NOTE, only_once=True)
 
     def skipping_module(self, id: str, path: str) -> None:
         assert self.caller_state, (id, path)
@@ -1129,11 +1134,11 @@ class State:
         manager.errors.set_file(self.caller_state.xpath)
         line = self.caller_line
         manager.errors.report(line, "Import of '%s' silently ignored" % (id,),
-                              severity='note')
+                              severity=Severity.NOTE)
         manager.errors.report(line, "(Using --silent-imports, module not passed on command line)",
-                              severity='note', only_once=True)
+                              severity=Severity.NOTE, only_once=True)
         manager.errors.report(line, "(This note courtesy of --almost-silent)",
-                              severity='note', only_once=True)
+                              severity=Severity.NOTE, only_once=True)
         manager.errors.set_import_context(save_import_context)
 
     def add_ancestors(self) -> None:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -161,7 +161,7 @@ class Errors:
             line: line number of error
             message: message to report
             blocker: if True, don't continue analysis after this error
-            severity: 'error', 'note' or 'warning'
+            severity: a level of severity, as defined in the Severity enum
             file: if non-None, override current file as context
             only_once: if True, only report this exact message once per build
         """

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import os
 import os.path
 import sys
@@ -8,6 +9,10 @@ from typing import Tuple, List, TypeVar, Set
 
 T = TypeVar('T')
 
+class Severity(Enum):
+    WARNING = "warning"
+    ERROR = "error"
+    NOTE = "note"
 
 class ErrorInfo:
     """Representation of a single error message."""
@@ -28,8 +33,8 @@ class ErrorInfo:
     # The line number related to this error within file.
     line = 0     # -1 if unknown
 
-    # Either 'error' or 'note'.
-    severity = ''
+    # The severity of this error.
+    severity = Severity.NOTE
 
     # The error message.
     message = ''
@@ -41,7 +46,7 @@ class ErrorInfo:
     only_once = False
 
     def __init__(self, import_ctx: List[Tuple[str, int]], file: str, typ: str,
-                 function_or_member: str, line: int, severity: str, message: str,
+                 function_or_member: str, line: int, severity: Severity, message: str,
                  blocker: bool, only_once: bool) -> None:
         self.import_ctx = import_ctx
         self.file = file
@@ -148,7 +153,8 @@ class Errors:
         self.import_ctx = ctx[:]
 
     def report(self, line: int, message: str, blocker: bool = False,
-               severity: str = 'error', file: str = None, only_once: bool = False) -> None:
+               severity: Severity = Severity.ERROR, file: str = None,
+               only_once: bool = False) -> None:
         """Report message at the given line using the current error context.
 
         Args:
@@ -279,7 +285,7 @@ class Errors:
                     result.append((e.file, -1, 'note',
                                    'In class "{}":'.format(e.type)))
 
-            result.append((e.file, e.line, e.severity, e.message))
+            result.append((e.file, e.line, e.severity.value, e.message))
 
             prev_import_context = e.import_ctx
             prev_function_or_member = e.function_or_member

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -8,7 +8,7 @@ import difflib
 
 from typing import cast, List, Dict, Any, Sequence, Iterable, Tuple
 
-from mypy.errors import Errors
+from mypy.errors import Errors, Severity
 from mypy.types import (
     Type, CallableType, Instance, TypeVarType, TupleType, UnionType, Void, NoneTyp, AnyType,
     Overloaded, FunctionLike, DeletedType
@@ -137,18 +137,18 @@ class MessageBuilder:
     def is_errors(self) -> bool:
         return self.errors.is_errors()
 
-    def report(self, msg: str, context: Context, severity: str, file: str = None) -> None:
+    def report(self, msg: str, context: Context, severity: Severity, file: str = None) -> None:
         """Report an error or note (unless disabled)."""
         if self.disable_count <= 0:
             self.errors.report(context.get_line(), msg.strip(), severity=severity, file=file)
 
     def fail(self, msg: str, context: Context, file: str = None) -> None:
         """Report an error message (unless disabled)."""
-        self.report(msg, context, 'error', file=file)
+        self.report(msg, context, Severity.ERROR, file=file)
 
     def note(self, msg: str, context: Context, file: str = None) -> None:
         """Report an error message (unless disabled)."""
-        self.report(msg, context, 'note', file=file)
+        self.report(msg, context, Severity.NOTE, file=file)
 
     def format(self, typ: Type, verbosity: int = 0) -> str:
         """Convert a type to a relatively short string that is suitable for error messages.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -67,7 +67,11 @@ from mypy.nodes import (
 )
 from mypy.visitor import NodeVisitor
 from mypy.traverser import TraverserVisitor
-from mypy.errors import Errors, report_internal_error
+from mypy.errors import (
+    Errors,
+    Severity,
+    report_internal_error,
+)
 from mypy.types import (
     NoneTyp, CallableType, Overloaded, Instance, Type, TypeVarType, AnyType,
     FunctionLike, UnboundType, TypeList, ErrorType, TypeVarDef,
@@ -2239,7 +2243,7 @@ class SemanticAnalyzer(NodeVisitor):
                 self.function_stack and
                 self.function_stack[-1].is_dynamic()):
             return
-        self.errors.report(ctx.get_line(), msg, severity='note')
+        self.errors.report(ctx.get_line(), msg, severity=Severity.NOTE)
 
     def undefined_name_extra_info(self, fullname: str) -> Optional[str]:
         if fullname in obsolete_name_mapping:


### PR DESCRIPTION
(No behavior change. This is strictly a style preference, so no worries if it's rejected.)

While working on adding warnings for potential typos ( #1528 ) I realized that severity was just a pure string, which bothered me me.

Benefits of this approach:
* Avoid potential typos
* We get the benefit of exhaustive checking from an Enum; we know all possible values that might be passed in.