### PR TITLE
Improve handling of "lambda: None"

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1347,6 +1347,11 @@ class ExpressionChecker:
             if e.expr() not in self.chk.type_map:
                 self.accept(e.expr())
             ret_type = self.chk.type_map[e.expr()]
+            if isinstance(ret_type, NoneTyp):
+                # For "lambda ...: None", just use type from the context.
+                # Important when the context is Callable[..., None] which
+                # really means Void. See #1425.
+                return inferred_type
             return replace_callable_return_type(inferred_type, ret_type)
 
     def infer_lambda_type_using_context(self, e: FuncExpr) -> CallableType:

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -611,6 +611,13 @@ T = TypeVar('T')
 def foo(arg: Callable[..., T]) -> None: pass
 foo(lambda: 1)
 
+[case testLambdaNoneInContext]
+from typing import Callable
+def f(x: Callable[[], None]) -> None: pass
+def g(x: Callable[[], int]) -> None: pass
+f(lambda: None)
+g(lambda: None)
+
 
 -- Overloads + generic functions
 -- -----------------------------

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1041,6 +1041,17 @@ y = f(lambda x: x, 1) # Fail
 main:4: error: Cannot infer type argument 1 of "f"
 main:4: error: Argument 2 to "f" has incompatible type "int"; expected "str"
 
+[case testInferLambdaNone]
+from typing import Callable
+def f(x: Callable[[], None]) -> None: pass
+def g(x: Callable[[], int]) -> None: pass
+a = lambda: None
+f(a) # E: Argument 1 to "f" has incompatible type Callable[[], None]; expected Callable[[], None]
+g(a)
+b = lambda: None  # type: Callable[[], None]
+f(b)
+g(b) # E: Argument 1 to "g" has incompatible type Callable[[], None]; expected Callable[[], int]
+
 
 -- Boolean operators
 -- -----------------


### PR DESCRIPTION
"lambda: None" might be used either where a function returning an
Optional[T] is expected, or where a function not returning a value is
expected. Previously it would always treated as the former; now the
context is used to decide.

When no context is available, the lambda is now treated as a function
not returning a value. This seems more consistent with the fact that
you can't define a variable 'a = None' without a type annotation or
declare a function to return NoneTyp. (If really desperate for the
other meaning of "lambda: None", you can write a generic function.)

Fixes #1425.