### PR TITLE
Don't consider inner functions to override methods of the same name

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -468,7 +468,6 @@ class SemanticAnalyzer(NodeVisitor):
             defn.type = self.anal_type(defn.type)
             self.check_function_signature(defn)
             if isinstance(defn, FuncDef):
-                defn.info = self.type
                 defn.type = set_callable_name(defn.type, defn)
         for arg in defn.arguments:
             if arg.initializer:

--- a/mypy/test/data/check-classes.test
+++ b/mypy/test/data/check-classes.test
@@ -307,6 +307,14 @@ class B(A):
     def __new__(cls) -> int:
         return 1
 
+[case testInnerFunctionNotOverriding]
+class A:
+    def f(self) -> int: pass
+
+class B(A):
+    def g(self) -> None:
+        def f(self) -> str: pass
+
 
 -- Constructors
 -- ------------

--- a/mypy/test/data/check-functions.test
+++ b/mypy/test/data/check-functions.test
@@ -455,7 +455,7 @@ class A:
 main: note: In function "g":
 main:6: error: Incompatible types in assignment (expression has type "int", variable has type "A")
 main: note: In member "f" of class "A":
-main:8: error: Argument 1 to "g" of "A" has incompatible type "A"; expected "int"
+main:8: error: Argument 1 to "g" has incompatible type "A"; expected "int"
 
 [case testMutuallyRecursiveNestedFunctions]
 def f() -> None:

--- a/mypy/test/data/check-generics.test
+++ b/mypy/test/data/check-generics.test
@@ -635,6 +635,20 @@ a = A().g(1)
 a = 1
 a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
+[case testGenericClassInnerFunctionTypeVariable]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class A(Generic[T]):
+    def __init__(self, a: T) -> None:
+        self.a = a
+    def f(self, n: int) -> None:
+        def g(a: T):
+            self.a = a
+        g(self.a)
+        g(n) # E: Argument 1 to "g" has incompatible type "int"; expected "T"
+[out]
+main: note: In member "f" of class "A":
+
 
 -- Callable subtyping with generic functions
 -- -----------------------------------------


### PR DESCRIPTION
defn.info should only be set for class methods and not for inner
functions within them. It is already set correctly in visit_func_def
in the first phase of function analysis and doesn't need to be set
again in analyze_function. Fixes #1423.