### PR TITLE
Improve type comment parsing

### DIFF
--- a/mypy/lex.py
+++ b/mypy/lex.py
@@ -829,7 +829,7 @@ class Lexer:
         self.pre_whitespace += s
         self.i += len(s)
 
-    type_ignore_exp = re.compile(r'[ \t]*#[ \t]*type:[ \t]*ignore\b')
+    type_ignore_exp = re.compile(r'[ \t]*#[^#]*\btype:[ \t]*ignore\b')
 
     def add_token(self, tok: Token) -> None:
         """Store a token.

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -1907,7 +1907,11 @@ class Parser:
             raise ParseError()
         return typ
 
-    annotation_prefix_re = re.compile(r'#\s*type:')
+    # The type comment can either be prefixed by a singular `#`
+    # followed by anything and at least one whitepace character or a
+    # singular `#`.
+    annotation_prefix_re = re.compile(r'(#[^#]*\s+|#)type:')
+    type_annotation_re = re.compile(r'(?:#[^#]*\s+|#)type:([^;]*);{0,1}')
     ignore_prefix_re = re.compile(r'ignore\b')
 
     def parse_type_comment(self, token: Token, signature: bool) -> Type:
@@ -1918,7 +1922,7 @@ class Parser:
         """
         whitespace_or_comments = token.rep().strip()
         if self.annotation_prefix_re.match(whitespace_or_comments):
-            type_as_str = whitespace_or_comments.split(':', 1)[1].strip()
+            type_as_str = self.type_annotation_re.match(whitespace_or_comments).group(1).strip()
             if self.ignore_prefix_re.match(type_as_str):
                 # Actually a "# type: ignore" annotation -> not a type.
                 return None

--- a/mypy/test/data/parse.test
+++ b/mypy/test/data/parse.test
@@ -395,6 +395,20 @@ MypyFile:1(
       Block:2(
         PassStmt:3()))))
 
+[case testAdditionalComments]
+x = 0 # additional comment type: int
+y = 0 # type: int; additional comment
+[out]
+MypyFile:1(
+  AssignmentStmt:1(
+    NameExpr(x)
+    IntExpr(0)
+    int?)
+  AssignmentStmt:2(
+    NameExpr(y)
+    IntExpr(0)
+    int?))
+
 [case testGlobalVarWithType]
 x = 0 # type: int
 y = False # type: bool


### PR DESCRIPTION
Whilst trying to use mypy in production I've found that it doesn't play nice with flake8 and pylint comments, for example it doesn't recognise `# noqa type: int` or `# pylint: disable=something type: int` as type comments. This pull request is an attempt to rectify this by allowing additional comments before and after the `type: something`. This introduces an additional feature that type comments should end with a `;` if there is to be an additional comment after e.g. `# type: int; pylint: disable=something`. The text below is a copy of the commit message.


The lex module ignored lines regex is altered to allow other comments
before the `type: ignore`. For example `# noqa type: ignore` is now
recognised as a line that should be ignored by mypy.

The parse module type annotation parsing has also been altered to
allow for other comments before and after the `type: [something]`. To
allow for trailing comments the pylint usage of a `;` has been adopted
so that (for example) `# type: Any; pylint: disable=something` is
allowed. Equally comments such as
`# noqa pylint: disable=something; type: ignore` are now recognised.

Note that the existing feature of commenting out type comments via
additional `#` before the type is retained for example `# # type: int`
will result in the type comment being ignored.