### PR TITLE
explicit type got from dict.get

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -204,7 +204,7 @@ class ConditionalTypeBinder:
         """
         result = self.frames.pop()
 
-        options = self.frames_on_escape.pop(len(self.frames) - 1, [])
+        options = self.frames_on_escape.pop(len(self.frames) - 1, [])  # type: List[Frame]
         if canskip:
             options.append(self.frames[-1])
         if fallthrough:

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -23,7 +23,7 @@ def solve_constraints(vars: List[int], constraints: List[Constraint],
     # Collect a list of constraints for each type variable.
     cmap = {}  # type: Dict[int, List[Constraint]]
     for con in constraints:
-        a = cmap.get(con.type_var, [])
+        a = cmap.get(con.type_var, [])  # type: List[Constraint]
         a.append(con)
         cmap[con.type_var] = a
 


### PR DESCRIPTION
When trying to fix [Mapping and MutableMapping definition in mypy](https://github.com/python/typeshed/pull/223), I got an error stating that it can't add a `List[None]` to a `List[Frame]` (or `List[Constaint]`), having these comments allow it to work.

Not much related, shouldn't it be infered as a `List[Any]` instead?