### PR TITLE
allow to warn if missing annotation in typeshed

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -66,6 +66,8 @@ DISALLOW_UNTYPED_CALLS = 'disallow-untyped-calls'
 DISALLOW_UNTYPED_DEFS = 'disallow-untyped-defs'
 # Type check unannotated functions
 CHECK_UNTYPED_DEFS = 'check-untyped-defs'
+# Also check typeshed for missing annotations
+WARN_INCOMPLETE_STUB = 'warn-incomplete-stub'
 
 PYTHON_EXTENSIONS = ['.pyi', '.py']
 
@@ -381,7 +383,8 @@ class BuildManager:
                                         self.pyversion,
                                         DISALLOW_UNTYPED_CALLS in self.flags,
                                         DISALLOW_UNTYPED_DEFS in self.flags,
-                                        check_untyped_defs)
+                                        check_untyped_defs,
+                                        WARN_INCOMPLETE_STUB in self.flags)
         self.missing_modules = set()  # type: Set[str]
 
     def all_imported_modules_in_file(self,

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -149,6 +149,9 @@ def process_options() -> Tuple[List[BuildSource], Options]:
                         " or with incomplete type annotations")
     parser.add_argument('--check-untyped-defs', action='store_true',
                         help="type check the interior of functions without type annotations")
+    parser.add_argument('--warn-incomplete-stub', action='store_true',
+                        help="warn if missing type annotation in typeshed, only relevant with"
+                        " --check-untyped-defs enabled")
     parser.add_argument('--fast-parser', action='store_true',
                         help="enable experimental fast parser")
     parser.add_argument('-i', '--incremental', action='store_true',
@@ -242,6 +245,9 @@ def process_options() -> Tuple[List[BuildSource], Options]:
 
     if args.check_untyped_defs:
         options.build_flags.append(build.CHECK_UNTYPED_DEFS)
+
+    if args.warn_incomplete_stub:
+        options.build_flags.append(build.WARN_INCOMPLETE_STUB)
 
     # experimental
     if args.fast_parser:


### PR DESCRIPTION
#1554 remove the warnings about missing annotation in typeshed, which was an useful feature to know what to document, which modules' annotation were missing (one can also use `--stat` and look for `Any` definition, but there is much false positive). 

This PR add `--warn-incomplete-stub` option to allow to show these again (off by default).