### PR TITLE
Implicitly assign class type to the first parameter of its methods (#1514)

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2140,8 +2140,14 @@ def function_type(func: FuncBase, fallback: 'mypy.types.Instance') -> 'mypy.type
         for arg in fdef.arguments:
             names.append(arg.variable.name())
 
+        if fdef.is_method() and not fdef.is_static and not fdef.is_class:
+            self_arg = [mypy.types.Instance(func.info, [])]  # type: List[mypy.types.Type]
+            arg_types = self_arg + ([mypy.types.AnyType()] * (len(fdef.arguments) - 1))
+        else:
+            arg_types = [mypy.types.AnyType()] * len(fdef.arguments)
+
         return mypy.types.CallableType(
-            [mypy.types.AnyType()] * len(fdef.arguments),
+            arg_types,
             [arg.kind for arg in fdef.arguments],
             names,
             mypy.types.AnyType(),

--- a/mypy/test/data/typexport-basic.test
+++ b/mypy/test/data/typexport-basic.test
@@ -890,7 +890,7 @@ class A:
     def f(self): pass
 A.f
 [out]
-MemberExpr(5) : def (self: Any) -> Any
+MemberExpr(5) : def (self: A) -> Any
 
 [case testOverloadedUnboundMethod]
 ## MemberExpr
@@ -914,7 +914,7 @@ class A:
     def f(self, x): pass
 A.f
 [out]
-MemberExpr(8) : Overload(def (self: Any) -> Any, def (self: Any, x: Any) -> Any)
+MemberExpr(8) : Overload(def (self: A) -> Any, def (self: A, x: Any) -> Any)
 
 [case testUnboundMethodWithInheritance]
 ## MemberExpr
@@ -977,7 +977,7 @@ class A(Generic[t]):
     def f(self, x): pass
 A.f(None, None)
 [out]
-MemberExpr(7) : def (self: Any, x: Any) -> Any
+MemberExpr(7) : def (self: A, x: Any) -> Any
 
 [case testGenericMethodOfGenericClass]
 ## MemberExpr


### PR DESCRIPTION
Issue #1514 . When running with `--check-untyped-defs`, this patch implicitly assigns the class type as the type of the first parameter (i.e. `self`) of it's methods instead of assigning `Any`.

I could not implement the same for `@classmethod`s in time. I tracked the construction of types of classes to `SemanticAnalyzer.class_type()`, but I couldn't figure out how to trivially call it from nodes.py's `function_type()` nor how/where to refactor it to.