### PR TITLE
Stop sending build notifications to IRC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,3 @@ install:
 
 script:
   - python runtests.py -v
-
-notifications:
-  irc:
-    channels:
-      - "chat.freenode.net#python-mypy"
-    use_notice: true


### PR DESCRIPTION
I don't think anyone's been getting value from these,
and we get much more well-targeted notifications on the
GitHub pull-request threads.  So just leave the IRC channel
quiet for any human activity.  (Which is itself sparse,
because our forum for technical discussion remains GitHub
issues and pull requests.)