### PR TITLE
[conflict] Implicitly assign class type to self parameter (#1514)

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -375,7 +375,7 @@ class BuildManager:
                                                   pyversion=pyversion,
                                                   check_untyped_defs=check_untyped_defs)
         self.modules = self.semantic_analyzer.modules
-        self.semantic_analyzer_pass3 = ThirdPass(self.modules, self.errors)
+        self.semantic_analyzer_pass3 = ThirdPass(self.modules, self.errors, check_untyped_defs)
         self.type_checker = TypeChecker(self.errors,
                                         self.modules,
                                         self.pyversion,

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2338,10 +2338,11 @@ class TypeChecker(NodeVisitor[Type]):
         return iterable.args[0]
 
     def function_type(self, func: FuncBase) -> FunctionLike:
-        return function_type(func, self.named_type('builtins.function'))
+        return function_type(self.check_untyped_defs, func, self.named_type('builtins.function'))
 
     def method_type(self, func: FuncBase) -> FunctionLike:
-        return method_type_with_fallback(func, self.named_type('builtins.function'))
+        return method_type_with_fallback(self.check_untyped_defs,
+                                         func, self.named_type('builtins.function'))
 
 
 def find_isinstance_check(node: Node,

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2125,7 +2125,8 @@ class SymbolTable(Dict[str, SymbolTableNode]):
         return st
 
 
-def function_type(func: FuncBase, fallback: 'mypy.types.Instance') -> 'mypy.types.FunctionLike':
+def function_type(check_untyped_defs: bool, func: FuncBase,
+                  fallback: 'mypy.types.Instance') -> 'mypy.types.FunctionLike':
     if func.type:
         assert isinstance(func.type, mypy.types.FunctionLike)
         return cast(mypy.types.FunctionLike, func.type)
@@ -2140,8 +2141,15 @@ def function_type(func: FuncBase, fallback: 'mypy.types.Instance') -> 'mypy.type
         for arg in fdef.arguments:
             names.append(arg.variable.name())
 
+        if check_untyped_defs and len(names) > 0 and names[0] == 'self' and\
+           fdef.is_method() and not fdef.is_static and not fdef.is_class:
+            self_arg = [mypy.types.Instance(func.info, [])]  # type: List[mypy.types.Type]
+            arg_types = self_arg + ([mypy.types.AnyType()] * (len(fdef.arguments) - 1))
+        else:
+            arg_types = [mypy.types.AnyType()] * len(fdef.arguments)
+
         return mypy.types.CallableType(
-            [mypy.types.AnyType()] * len(fdef.arguments),
+            arg_types,
             [arg.kind for arg in fdef.arguments],
             names,
             mypy.types.AnyType(),
@@ -2151,10 +2159,10 @@ def function_type(func: FuncBase, fallback: 'mypy.types.Instance') -> 'mypy.type
         )
 
 
-def method_type_with_fallback(func: FuncBase,
+def method_type_with_fallback(check_untyped_defs: bool, func: FuncBase,
                               fallback: 'mypy.types.Instance') -> 'mypy.types.FunctionLike':
     """Return the signature of a method (omit self)."""
-    return method_type(function_type(func, fallback))
+    return method_type(function_type(check_untyped_defs, func, fallback))
 
 
 def method_type(sig: 'mypy.types.FunctionLike') -> 'mypy.types.FunctionLike':

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -411,7 +411,7 @@ class SemanticAnalyzer(NodeVisitor):
             item.is_overload = True
             item.func.is_overload = True
             item.accept(self)
-            t.append(cast(CallableType, function_type(item.func,
+            t.append(cast(CallableType, function_type(self.check_untyped_defs, item.func,
                                                   self.builtin_type('builtins.function'))))
             if item.func.is_property and i == 0:
                 # This defines a property, probably with a setter and/or deleter.
@@ -841,7 +841,8 @@ class SemanticAnalyzer(NodeVisitor):
     def class_type(self, info: TypeInfo) -> Type:
         # Construct a function type whose fallback is cls.
         from mypy import checkmember  # To avoid import cycle.
-        leading_type = checkmember.type_object_type(info, self.builtin_type)
+        leading_type = checkmember.type_object_type(self.check_untyped_defs,
+                                                    info, self.builtin_type)
         if isinstance(leading_type, Overloaded):
             # Overloaded __init__ is too complex to handle.  Plus it's stubs only.
             return AnyType()
@@ -2445,9 +2446,11 @@ class ThirdPass(TraverserVisitor[None]):
     straightforward type inference.
     """
 
-    def __init__(self, modules: Dict[str, MypyFile], errors: Errors) -> None:
+    def __init__(self, modules: Dict[str, MypyFile], errors: Errors,
+                 check_untyped_defs: bool) -> None:
         self.modules = modules
         self.errors = errors
+        self.check_untyped_defs = check_untyped_defs
 
     def visit_file(self, file_node: MypyFile, fnam: str) -> None:
         self.errors.set_file(fnam)
@@ -2519,7 +2522,8 @@ class ThirdPass(TraverserVisitor[None]):
         if decorator_preserves_type:
             # No non-identity decorators left. We can trivially infer the type
             # of the function here.
-            dec.var.type = function_type(dec.func, self.builtin_type('function'))
+            dec.var.type = function_type(self.check_untyped_defs, dec.func,
+                                         self.builtin_type('function'))
         if dec.decorators:
             if returns_any_if_called(dec.decorators[0]):
                 # The outermost decorator will return Any so we know the type of the
@@ -2529,7 +2533,8 @@ class ThirdPass(TraverserVisitor[None]):
             if sig:
                 # The outermost decorator always returns the same kind of function,
                 # so we know that this is the type of the decoratored function.
-                orig_sig = function_type(dec.func, self.builtin_type('function'))
+                orig_sig = function_type(self.check_untyped_defs, dec.func,
+                                         self.builtin_type('function'))
                 sig.name = orig_sig.items()[0].name
                 dec.var.type = sig
 


### PR DESCRIPTION
Follow up on PR #1586: only assign the class type to first parameter of it's dynamic method if `--check-untyped-defs` is enabled and if the parameter variable is named "self".