### PR TITLE
Enum: deal with subclasses of Enum or IntEnum

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -56,6 +56,9 @@ LITERAL_YES = 2
 LITERAL_TYPE = 1
 LITERAL_NO = 0
 
+# Hard coded name of Enum baseclass.
+ENUM_BASECLASS = "enum.Enum"
+
 node_kinds = {
     LDEF: 'Ldef',
     GDEF: 'Gdef',
@@ -1873,6 +1876,18 @@ class TypeInfo(SymbolNode):
         mro = linearize_hierarchy(self)
         assert mro, "Could not produce a MRO at all for %s" % (self,)
         self.mro = mro
+        self.is_enum = self._calculate_is_enum()
+
+    def _calculate_is_enum(self) -> bool:
+        """
+        If this is "enum.Enum" itself, then yes, it's an enum.
+        If the flag .is_enum has been set on anything in the MRO, it's an enum.
+        """
+        if self.fullname() == ENUM_BASECLASS:
+            return True
+        if self.mro:
+            return any(type_info.is_enum for type_info in self.mro)
+        return False
 
     def has_base(self, fullname: str) -> bool:
         """Return True if type has a base type with the specified name.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -127,11 +127,8 @@ TYPE_PROMOTIONS_PYTHON2.update({
     'builtins.bytearray': 'builtins.str',
 })
 
-# Hard coded list of Enum baseclasses.
-ENUM_BASECLASSES = [
-    'enum.Enum',
-    'enum.IntEnum',
-]
+# Hard coded name of Enum baseclasses.
+ENUM_BASECLASS = 'enum.Enum'
 
 # When analyzing a function, should we analyze the whole function in one go, or
 # should we only perform one phase of the analysis? The latter is used for
@@ -832,8 +829,9 @@ class SemanticAnalyzer(NodeVisitor):
 
     def decide_is_enum(self, instance: Instance) -> bool:
         """Decide if a TypeInfo should be marked as .is_enum=True"""
-        fullname = instance.type.fullname()
-        return fullname in ENUM_BASECLASSES
+        if not instance.type.mro:
+            return False
+        return any(t._fullname == ENUM_BASECLASS for t in instance.type.mro)
 
     def analyze_metaclass(self, defn: ClassDef) -> None:
         if defn.metaclass:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -831,7 +831,7 @@ class SemanticAnalyzer(NodeVisitor):
         """Decide if a TypeInfo should be marked as .is_enum=True"""
         if not instance.type.mro:
             return False
-        return any(t._fullname == ENUM_BASECLASS for t in instance.type.mro)
+        return any(t.fullname() == ENUM_BASECLASS for t in instance.type.mro)
 
     def analyze_metaclass(self, defn: ClassDef) -> None:
         if defn.metaclass:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -127,9 +127,6 @@ TYPE_PROMOTIONS_PYTHON2.update({
     'builtins.bytearray': 'builtins.str',
 })
 
-# Hard coded name of Enum baseclasses.
-ENUM_BASECLASS = 'enum.Enum'
-
 # When analyzing a function, should we analyze the whole function in one go, or
 # should we only perform one phase of the analysis? The latter is used for
 # nested functions. In the first phase we add the function to the symbol table
@@ -762,8 +759,6 @@ class SemanticAnalyzer(NodeVisitor):
                 defn.info.fallback_to_any = True
             elif not isinstance(base, UnboundType):
                 self.fail('Invalid base class', base_expr)
-            if isinstance(base, Instance):
-                defn.info.is_enum = self.decide_is_enum(base)
         # Add 'object' as implicit base if there is no other base class.
         if (not defn.base_types and defn.fullname != 'builtins.object'):
             obj = self.object_type()
@@ -826,12 +821,6 @@ class SemanticAnalyzer(NodeVisitor):
                     worklist.append(base.type)
                     visited.add(base.type)
         return False
-
-    def decide_is_enum(self, instance: Instance) -> bool:
-        """Decide if a TypeInfo should be marked as .is_enum=True"""
-        if not instance.type.mro:
-            return False
-        return any(t.fullname() == ENUM_BASECLASS for t in instance.type.mro)
 
     def analyze_metaclass(self, defn: ClassDef) -> None:
         if defn.metaclass:

--- a/mypy/test/data/pythoneval-enum.test
+++ b/mypy/test/data/pythoneval-enum.test
@@ -103,3 +103,18 @@ Color.m2('')
 [out]
 _program.py:11: error: Argument 1 to "m" of "Color" has incompatible type "str"; expected "int"
 _program.py:12: error: Argument 1 to "m2" of "Color" has incompatible type "str"; expected "int"
+
+[case testIntEnum_ExtendedIntEnum_functionTakingExtendedIntEnum]
+from enum import IntEnum
+class ExtendedIntEnum(IntEnum):
+    pass
+class SomeExtIntEnum(ExtendedIntEnum):
+    x = 1
+
+def takes_int(i: int):
+    pass
+takes_int(SomeExtIntEnum.x)
+
+def takes_some_ext_int_enum(s: SomeExtIntEnum):
+    pass
+takes_some_ext_int_enum(SomeExtIntEnum.x)


### PR DESCRIPTION
I previously committed #1535 so that IntEnums would behave better, but I figured out that it breaks if you subclass the IntEnum (a real use case in the Dropbox codebase). Same with Enum.

That is to say, the allowed sample in [Enum docs 8.3.19](https://docs.python.org/3/library/enum.html#restricted-subclassing-of-enumerations) does not work, because Bar is not a direct subclass of Enum; Bar is-a Foo is-a Enum.

Iterating the MRO isn't the cheapest operation, and I'd be happy to discuss other solutions. Perhaps setting a special flag during the calculate_mro iteration.