### PR TITLE
Only accept a flat tuple of types in exception handler clauses

### DIFF
--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -559,6 +559,11 @@ try:
 except (E1, E2): pass
 except (E1, object): pass # E: Exception type must be derived from BaseException
 except (object, E2): pass # E: Exception type must be derived from BaseException
+except (E1, (E2,)): pass  # E: Exception type must be derived from BaseException
+
+except (E1, E2): pass
+except ((E1, E2)): pass
+except (((E1, E2))): pass
 [builtins fixtures/exception.py]
 
 [case testExceptWithMultipleTypes2]
@@ -656,6 +661,10 @@ except exs2 as e2:
     a = e2 # type: E1
     b = e2 # type: E1_1 # E: Incompatible types in assignment (expression has type "Union[E1_1, E1_2]", variable has type "E1_1")
     c = e2 # type: E1_2 # E: Incompatible types in assignment (expression has type "Union[E1_1, E1_2]", variable has type "E1_2")
+
+exs3 = (E1, (E1_1, (E1_2,)))
+try: pass
+except exs3 as e3: pass  # E: Exception type must be derived from BaseException
 [builtins fixtures/exception.py]
 
 [case testInvalidTupleValueAsExceptionType]


### PR DESCRIPTION
Follow-up to new handling from #1610, as suggested by @gnprice.