### PR TITLE
Clarify Ellipsis usage in the docs (#683)

### DIFF
--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -140,7 +140,7 @@ the builtins contains a definition like this for ``chr``:
 
     def chr(code: int) -> str: ...
 
-In stub files we don't care about the function bodies. `pass <https://docs.python.org/3/tutorial/controlflow.html#pass-statements>`_ statements, or the three dot literal (ie. `...`) of `Ellipsis <https://docs.python.org/3/library/constants.html#Ellipsis>`_ can be used interchangeably to make the stub files valid python. 
+In stub files we don't care about the function bodies. `pass <https://docs.python.org/3/tutorial/controlflow.html#pass-statements>`_ statements, or the three dot literal (ie. ``...``) of `Ellipsis <https://docs.python.org/3/library/constants.html#Ellipsis>`_ can be used interchangeably to make the stub files valid python. 
 
 .. _library-stubs-missing:
 

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -140,8 +140,13 @@ the builtins contains a definition like this for ``chr``:
 
     def chr(code: int) -> str: ...
 
-In stubs we don't care about the function bodies, so we use an
-ellipsis instead. That ``...`` is three literal dots!
+In stub files we don't care about the function bodies. `pass <https://docs.python.org/3/tutorial/controlflow.html#pass-statements>`_ statements, the built-in
+`Ellipsis <https://docs.python.org/3/library/constants.html#Ellipsis>`_ constant, or the short-form literal of Ellipsis (just three dots: ``...``) can be used interchangeably to make the stub files valid python. The short-form literal is the most succinct.
+
+.. _library-stubs-missing:
+
+Missing Stub Files
+******************
 
 Mypy complains if it can't find a stub (or a real module) for a
 library module that you import. You can create a stub easily; here is

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -140,7 +140,10 @@ the builtins contains a definition like this for ``chr``:
 
     def chr(code: int) -> str: ...
 
-In stub files we don't care about the function bodies. `pass <https://docs.python.org/3/tutorial/controlflow.html#pass-statements>`_ statements, or the three dot literal (ie. ``...``) of `Ellipsis <https://docs.python.org/3/library/constants.html#Ellipsis>`_ can be used interchangeably to make the stub files valid python. 
+The stub files, being for annotation-purposes only, don't include
+redundant information about a function. In the example above, the
+three dot literal (ie. ``...``) is used to make the stub files valid 
+python.  The pass statement can be used as an alternative to ``...``. 
 
 .. _library-stubs-missing:
 

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -140,10 +140,8 @@ the builtins contains a definition like this for ``chr``:
 
     def chr(code: int) -> str: ...
 
-The stub files, being for annotation-purposes only, don't include
-redundant information about a function. In the example above, the
-three dot literal (ie. ``...``) is used to make the stub files valid 
-python.  The pass statement can be used as an alternative to ``...``. 
+In stub files we don't care about the function bodies, so we use 
+an ellipsis instead.  That ``...`` is three literal dots!
 
 Mypy complains if it can't find a stub (or a real module) for a
 library module that you import. You can create a stub easily; here is

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -145,11 +145,6 @@ redundant information about a function. In the example above, the
 three dot literal (ie. ``...``) is used to make the stub files valid 
 python.  The pass statement can be used as an alternative to ``...``. 
 
-.. _library-stubs-missing:
-
-Missing Stub Files
-******************
-
 Mypy complains if it can't find a stub (or a real module) for a
 library module that you import. You can create a stub easily; here is
 an overview:

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -140,8 +140,7 @@ the builtins contains a definition like this for ``chr``:
 
     def chr(code: int) -> str: ...
 
-In stub files we don't care about the function bodies. `pass <https://docs.python.org/3/tutorial/controlflow.html#pass-statements>`_ statements, the built-in
-`Ellipsis <https://docs.python.org/3/library/constants.html#Ellipsis>`_ constant, or the short-form literal of Ellipsis (just three dots: ``...``) can be used interchangeably to make the stub files valid python. The short-form literal is the most succinct.
+In stub files we don't care about the function bodies. `pass <https://docs.python.org/3/tutorial/controlflow.html#pass-statements>`_ statements, or the three dot literal (ie. `...`) of `Ellipsis <https://docs.python.org/3/library/constants.html#Ellipsis>`_ can be used interchangeably to make the stub files valid python. 
 
 .. _library-stubs-missing:
 

--- a/docs/source/class_basics.rst
+++ b/docs/source/class_basics.rst
@@ -137,7 +137,7 @@ base classes using the ``abc.ABCMeta`` metaclass and the
 
    class B(A):
        def foo(self, x: int) -> None: ...
-       def bar(self -> str:
+       def bar(self) -> str:
            return 'x'
 
    a = A() # Error: A is abstract

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -94,6 +94,8 @@ The ``Any`` type is discussed in more detail in section :ref:`dynamic_typing`.
   This makes it easier to migrate legacy Python code to mypy, as
   mypy won't complain about dynamically typed functions.
 
+.. _tuple-types:
+
 Tuple types
 ***********
 
@@ -131,6 +133,8 @@ purpose. Example:
    ``Tuple[...]`` is not valid as a base class outside stub files. This is a
    limitation of the ``typing`` module. One way to work around
    this is to use a named tuple as a base class (see section :ref:`named-tuples`).
+
+.. _callable-types:
 
 Callable types (and lambdas)
 ****************************

--- a/docs/source/type_inference_and_annotations.rst
+++ b/docs/source/type_inference_and_annotations.rst
@@ -153,40 +153,18 @@ Types in stub files
 
 Recall the introductory note about the usage of stub files (See :ref:`library-stubs`) 
 as an alternative approach to annotate types.  Stub files are valid
-python 3 files, which mirror the python modules, but omit the 
-the business logic of variable initialization, function bodies and
-default arguments.  
-
-The Ellipsis literal ``...`` or pass statement is used to articulate the
-omission, in the stub file.
-
-An example of variable instantiation omission:
+Python 3 files, which mirror the python modules but leave out the 
+runtime logic like variable initialization, function bodies and
+default arguments.  For example:
 
 .. code-block:: python
 
     x = ... # type: int
-
-An example of function body omission:
-
-.. code-block:: python
-
     def afunc(code: str) -> int: ...
-
-An example of default argument omission:
-
-.. code-block:: python
-
     def afunc(a: int, b: int=...) -> int: pass
 
-Since stub files may be incomplete, the following can be included to indicate
-to the type checker the annotations for the un-annotated.
-
-.. code-block:: python
-
-    def __getattr__(name) -> Any: ...
-
+The literal ``...`` is all that's necessary!
 
 .. note::
 
-   The cases discussed above should not be confused with the uses of ``...``
-   in Type defintion, for instance ``Callable[...]``.
+    The ``...`` is also used with a different meaning in the :ref:`Callable <callable-types>` and :ref:`Tuple <tuple-types>` types.

--- a/docs/source/type_inference_and_annotations.rst
+++ b/docs/source/type_inference_and_annotations.rst
@@ -147,3 +147,14 @@ to be annotated with a starred type:
     p, q, *rs = 1, 2  # type: int, int, *List[int]
 
 Here, the type of ``rs`` is set to ``List[int]``.
+
+Stub Files usage of Ellipsis
+****************************
+
+Similar to how functions can be annoted with stub files, so can variables. 
+The stub files don't include business logic, so they can use
+the Ellipsis literal ``...`` instead:
+
+.. code-block:: python
+
+    x = ... # type: int

--- a/docs/source/type_inference_and_annotations.rst
+++ b/docs/source/type_inference_and_annotations.rst
@@ -148,13 +148,45 @@ to be annotated with a starred type:
 
 Here, the type of ``rs`` is set to ``List[int]``.
 
-Stub Files usage of Ellipsis
-****************************
+Types in stub files
+*******************
 
-Similar to how functions can be annoted with stub files, so can variables. 
-The stub files don't include business logic, so they can use
-the Ellipsis literal ``...`` instead:
+Recall the introductory note about the usage of stub files (See :ref:`library-stubs`) 
+as an alternative approach to annotate types.  Stub files are valid
+python 3 files, which mirror the python modules, but omit the 
+the business logic of variable initialization, function bodies and
+default arguments.  
+
+The Ellipsis literal ``...`` or pass statement is used to articulate the
+omission, in the stub file.
+
+An example of variable instantiation omission:
 
 .. code-block:: python
 
     x = ... # type: int
+
+An example of function body omission:
+
+.. code-block:: python
+
+    def afunc(code: str) -> int: ...
+
+An example of default argument omission:
+
+.. code-block:: python
+
+    def afunc(a: int, b: int=...) -> int: pass
+
+Since stub files may be incomplete, the following can be included to indicate
+to the type checker the annotations for the un-annotated.
+
+.. code-block:: python
+
+    def __getattr__(name) -> Any: ...
+
+
+.. note::
+
+   The cases discussed above should not be confused with the uses of ``...``
+   in Type defintion, for instance ``Callable[...]``.


### PR DESCRIPTION
Minor clarification and addition of links to the docs, just to close #683. 

#683 could have probably been closed before this PR, but if somebody had a different idea of where this should go in the docs, I could modify this PR.

As rendered:
http://imgur.com/a/FSTpP