### PR TITLE
[WIP] nonconsecutive overload errors

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -308,7 +308,7 @@ class OverloadedFuncDef(FuncBase):
         self.set_line(items[0].line)
 
     def name(self) -> str:
-        return self.items[1].func.name()
+        return self.items[0].func.name()
 
     def accept(self, visitor: NodeVisitor[T]) -> T:
         return visitor.visit_overloaded_func_def(self)

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -892,7 +892,8 @@ class Parser:
             fdef = cast(Decorator, s)
             n = fdef.func.name()
             if (isinstance(stmt[-1], OverloadedFuncDef) and
-                    (cast(OverloadedFuncDef, stmt[-1])).name() == n):
+                    (cast(OverloadedFuncDef, stmt[-1])).name() == n and
+                    any(d.name == 'overload' for d in fdef.decorators)):
                 (cast(OverloadedFuncDef, stmt[-1])).items.append(fdef)
                 return True
         return False

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -321,7 +321,12 @@ class Parser:
                 if is_simple:
                     self.expect_break()
                 if defn is not None:
-                    if not self.try_combine_overloads(defn, defs):
+                    if self.try_combine_overloads(defn, defs):
+                        pass
+                    elif (isinstance(defn, Decorator) and defn.decorators and
+                          any(d.name == 'overload' for d in defn.decorators)):
+                        defs.append(OverloadedFuncDef([defn]))
+                    else:
                         defs.append(defn)
             except ParseError:
                 pass
@@ -867,7 +872,12 @@ class Parser:
                     if is_simple:
                         self.expect_break()
                     if stmt is not None:
-                        if not self.try_combine_overloads(stmt, stmt_list):
+                        if self.try_combine_overloads(stmt, stmt_list):
+                            pass
+                        elif (isinstance(stmt, Decorator) and stmt.decorators and
+                              any(d.name == 'overload' for d in stmt.decorators)):
+                            stmt_list.append(OverloadedFuncDef([stmt]))
+                        else:
                             stmt_list.append(stmt)
                 except ParseError:
                     pass
@@ -881,11 +891,7 @@ class Parser:
         if isinstance(s, Decorator) and stmt:
             fdef = cast(Decorator, s)
             n = fdef.func.name()
-            if (isinstance(stmt[-1], Decorator) and
-                    (cast(Decorator, stmt[-1])).func.name() == n):
-                stmt[-1] = OverloadedFuncDef([cast(Decorator, stmt[-1]), fdef])
-                return True
-            elif (isinstance(stmt[-1], OverloadedFuncDef) and
+            if (isinstance(stmt[-1], OverloadedFuncDef) and
                     (cast(OverloadedFuncDef, stmt[-1])).name() == n):
                 (cast(OverloadedFuncDef, stmt[-1])).items.append(fdef)
                 return True


### PR DESCRIPTION
Here's the gist of a proposal:

* classify all functions with the overload decorator as `OverloadedFuncDef`s in parse.py
* check that `OverloadedFuncDef`s have multiple definitions later (not implemented in PR yet)
* special message for two `OverloadedFuncDefs` being global

This would make some error messages worse, particularly "expected overload decorator" errors turning into "name already defined" errors.

The code has a lot of problems still like looking for overload decorators by name, and there are a lot of tests to fix; just posting to better describe the approach.