### PR TITLE
Allow defining type aliases for Optional[T]

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1052,14 +1052,15 @@ class SemanticAnalyzer(NodeVisitor):
             allow_tuple_literal = isinstance(s.lvalues[-1], (TupleExpr, ListExpr))
             s.type = self.anal_type(s.type, allow_tuple_literal)
         else:
-            # For simple assignments, allow binding type aliases.
+            # For simple assignments at top level, allow binding type aliases.
             if (s.type is None and len(s.lvalues) == 1 and
-                    isinstance(s.lvalues[0], NameExpr)):
+                    isinstance(s.lvalues[0], NameExpr) and
+                    not self.is_func_scope() and not self.type):
                 res = analyze_type_alias(s.rvalue,
                                          self.lookup_qualified,
                                          self.lookup_fully_qualified,
                                          self.fail)
-                if res and (not isinstance(res, Instance) or cast(Instance, res).args):
+                if res:
                     # TODO: What if this gets reassigned?
                     name = cast(NameExpr, s.lvalues[0])
                     node = self.lookup(name.name, name)

--- a/mypy/test/data/check-type-aliases.test
+++ b/mypy/test/data/check-type-aliases.test
@@ -13,6 +13,14 @@ f(1)
 f('')
 f(()) # E: Argument 1 to "f" has incompatible type "Tuple[]"; expected "Union[int, str]"
 
+[case testOptionalTypeAlias]
+from typing import Optional
+O = Optional[int]
+def f(x: O) -> None: pass
+f(1)
+f(None)
+f(()) # E: Argument 1 to "f" has incompatible type "Tuple[]"; expected "int"
+
 [case testTupleTypeAlias]
 from typing import Tuple
 T = Tuple[int, str]

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -18,7 +18,8 @@ from mypy.subtypes import satisfies_upper_bound
 from mypy import nodes
 
 
-type_constructors = ['typing.Tuple', 'typing.Union', 'typing.Callable']
+type_constructors = ['typing.Tuple', 'typing.Union', 'typing.Optional',
+                     'typing.Callable']
 
 
 def analyze_type_alias(node: Node,


### PR DESCRIPTION
This required some follow-on changes that I don't totally understand,
but seem like simplifications.