### PR TITLE
Cut the attribute ClassDef.base_types

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -627,8 +627,6 @@ class ClassDef(Node):
     type_vars = None  # type: List[mypy.types.TypeVarDef]
     # Base class expressions (not semantically analyzed -- can be arbitrary expressions)
     base_type_exprs = None  # type: List[Node]
-    # Semantically analyzed base types, derived from base_type_exprs during semantic analysis
-    base_types = None  # type: List[mypy.types.Instance]
     info = None  # type: TypeInfo  # Related TypeInfo
     metaclass = ''
     decorators = None  # type: List[Node]
@@ -645,7 +643,6 @@ class ClassDef(Node):
         self.defs = defs
         self.type_vars = type_vars or []
         self.base_type_exprs = base_type_exprs or []
-        self.base_types = []  # Not yet semantically analyzed --> don't know base types
         self.metaclass = metaclass
         self.decorators = []
 
@@ -661,7 +658,6 @@ class ClassDef(Node):
                 'name': self.name,
                 'fullname': self.fullname,
                 'type_vars': [v.serialize() for v in self.type_vars],
-                'base_types': [t.serialize() for t in self.base_types],
                 'metaclass': self.metaclass,
                 'is_builtinclass': self.is_builtinclass,
                 }
@@ -675,7 +671,6 @@ class ClassDef(Node):
                        metaclass=data['metaclass'],
                        )
         res.fullname = data['fullname']
-        res.base_types = [mypy.types.Instance.deserialize(t) for t in data['base_types']]
         res.is_builtinclass = data['is_builtinclass']
         return res
 

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -130,10 +130,11 @@ class StrConv(NodeVisitor[str]):
         a = [o.name, o.defs.body]
         # Display base types unless they are implicitly just builtins.object
         # (in this case base_type_exprs is empty).
-        if o.base_types and o.base_type_exprs:
-            a.insert(1, ('BaseType', o.base_types))
-        elif len(o.base_type_exprs) > 0:
-            a.insert(1, ('BaseTypeExpr', o.base_type_exprs))
+        if o.base_type_exprs:
+            if o.info and o.info.bases:
+                a.insert(1, ('BaseType', o.info.bases))
+            else:
+                a.insert(1, ('BaseTypeExpr', o.base_type_exprs))
         if o.type_vars:
             a.insert(1, ('TypeVars', o.type_vars))
         if o.metaclass:

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -160,9 +160,6 @@ class TransformVisitor(NodeVisitor[Node]):
                        node.metaclass)
         new.fullname = node.fullname
         new.info = node.info
-        new.base_types = []
-        for base in node.base_types:
-            new.base_types.append(cast(Instance, self.type(base)))
         new.decorators = [decorator.accept(self)
                           for decorator in node.decorators]
         new.is_builtinclass = node.is_builtinclass


### PR DESCRIPTION
This seems to be always equivalent to `bases` on the corresponding
TypeInfo, so keep the information in just one place.

This is part of clearing out the old branches I've had lying around
on my local clone of the repo -- back in December I was studying how
we handle the MRO, found this confusing, and had a note that this
attribute seemed to be redundant.  Further investigation bears that
out: in particular, the fact that the tests pass after this change
which cuts it out entirely.