### PR TITLE
Slightly clarify logic in analyzing base classes

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -765,6 +765,12 @@ class SemanticAnalyzer(NodeVisitor):
                 defn.info.fallback_to_any = True
             elif not isinstance(base, UnboundType):
                 self.fail('Invalid base class', base_expr)
+            else:
+                # TODO(gregprice) why is this not an error?  We're ignoring this base class --
+                # seems doomed to produce some kind of wrong result.
+                # print('analyze', 'unbound', base, base_expr)
+                # assert False
+                pass
         # Add 'object' as implicit base if there is no other base class.
         if (not base_types and defn.fullname != 'builtins.object'):
             obj = self.object_type()

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -738,15 +738,16 @@ class SemanticAnalyzer(NodeVisitor):
         related to the base classes: defn.info.bases, defn.info.mro, and
         miscellaneous others (at least tuple_type, fallback_to_any, and is_enum.)
         """
+
         base_types = []
         for base_expr in defn.base_type_exprs:
-            # The base class is originally an expression; convert it to a type.
             try:
                 base = self.expr_to_analyzed_type(base_expr)
             except TypeTranslationError:
                 self.fail('Invalid base class', base_expr)
                 defn.info.mro = []
                 return
+
             if isinstance(base, TupleType):
                 if defn.info.tuple_type:
                     self.fail("Class has two incompatible bases derived from tuple", defn)
@@ -755,6 +756,7 @@ class SemanticAnalyzer(NodeVisitor):
                 if (not self.is_stub_file and not defn.info.is_named_tuple and
                         base.type.fullname() == 'builtins.tuple'):
                     self.fail("Tuple[...] not supported as a base class outside a stub file", defn)
+
             if isinstance(base, Instance):
                 base_types.append(base)
             elif isinstance(base, TupleType):
@@ -771,11 +773,14 @@ class SemanticAnalyzer(NodeVisitor):
                 # print('analyze', 'unbound', base, base_expr)
                 # assert False
                 pass
+
         # Add 'object' as implicit base if there is no other base class.
         if (not base_types and defn.fullname != 'builtins.object'):
             obj = self.object_type()
             base_types.insert(0, obj)
+
         defn.info.bases = base_types
+
         # Calculate the MRO. It might be incomplete at this point if
         # the bases of defn include classes imported from other
         # modules in an import loop. We'll recompute it in ThirdPass.

--- a/test-data/unit/check-semanal-error.test
+++ b/test-data/unit/check-semanal-error.test
@@ -52,7 +52,7 @@ A().x = '' # E: Incompatible types in assignment (expression has type "str", var
 X = 1
 class A(X): # E
     x = 1
-A().foo(1) # E
+A().foo(1)
 A().x = '' # E
 [out]
 main:2: error: Invalid type "__main__.X"

--- a/test-data/unit/check-semanal-error.test
+++ b/test-data/unit/check-semanal-error.test
@@ -50,10 +50,15 @@ A().x = '' # E: Incompatible types in assignment (expression has type "str", var
 
 [case testInvalidBaseClass2]
 X = 1
-class A(X): # E: Invalid type "__main__.X"
+class A(X): # E
     x = 1
-A().foo(1) # E: "A" has no attribute "foo"
-A().x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+A().foo(1) # E
+A().x = '' # E
+[out]
+main:2: error: Invalid type "__main__.X"
+main:2: error: Invalid base class
+main:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
 
 [case testInvalidNumberOfTypeArgs]
 from typing import TypeVar


### PR DESCRIPTION
This is (a finished version of) another change/question I've had lying
around in my local clone for a few months.  It worried me that this
if/elif chain didn't end in an `else` -- if we fall off the end, surely
that's a bug either in the code we're typechecking or in mypy itself, no?
Or if somehow it's OK, then in any event that should be explicit here.
So put an `else` case on it, and while we're here combine that chain
and the TupleType conditional above it into one, reducing the number of
potential control flows for the reader to consider.

Part of understanding this code turned out to be realizing that
`base.fallback` is an `Instance` -- so make that explicit by putting
an explicit type annotation on the `base_types` local.  This seems to
be one of those occasions where the doctrine of "annotate function
signatures and wherever it's not obvious" counsels annotating a local
variable even though mypy is capable of inferring the type.

Two small semantic changes, both in error cases: when we can't make
sense of a base class, log an error but then treat it the same as we
would a base of Any and move on to the other base classes.  (In one
case we didn't report anything here, and in the other we panicked
harder.)  This regularizes our logic -- one fewer edge case where we
leave `info.mro` empty -- and should let us move on without reporting
extraneous errors down the line.  In the new `else` case, this changes
which error messages we emit for one test case, so update that test.

Also put each of the branches of our new unified if/elif/else chain in
the same form to make them a bit easier to follow and compare: first
report errors, if any, then record our conclusions for what it means
about the types.
