### PR TITLE
Implement is_same_type for ErasedType

### DIFF
--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -74,8 +74,11 @@ class SameTypeVisitor(TypeVisitor[bool]):
         return isinstance(self.right, UninhabitedType)
 
     def visit_erased_type(self, left: ErasedType) -> bool:
-        # Should not get here.
-        raise RuntimeError()
+        # We can get here when isinstance is used inside a lambda
+        # whose type is being inferred. In any event, we have no reason
+        # to think that an ErasedType will end up being the same as
+        # any other type, even another ErasedType.
+        return False
 
     def visit_deleted_type(self, left: DeletedType) -> bool:
         return isinstance(self.right, DeletedType)

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -618,6 +618,22 @@ def g(x: Callable[[], int]) -> None: pass
 f(lambda: None)
 g(lambda: None)
 
+[case testIsinstanceInInferredLambda]
+from typing import TypeVar, Callable
+T = TypeVar('T')
+S = TypeVar('S')
+class A: pass
+class B(A): pass
+class C(A): pass
+def f(func: Callable[[T], S], *z: T, r: S = None) -> S: pass
+f(lambda x: 0 if isinstance(x, B) else 1) # E: Cannot infer type argument 1 of "f"
+f(lambda x: 0 if isinstance(x, B) else 1, A())() # E: "int" not callable
+f(lambda x: x if isinstance(x, B) else B(), A(), r=B())() # E: "B" not callable
+f( # E: Argument 1 to "f" has incompatible type Callable[[A], A]; expected Callable[[A], B]
+    lambda x: B() if isinstance(x, B) else x, # E: Incompatible return value type (got "A", expected "B")
+    A(), r=B())
+[builtins fixtures/isinstance.py]
+
 
 -- Overloads + generic functions
 -- -----------------------------


### PR DESCRIPTION
During generic function type inference, the arguments of a lambda may
have type ErasedType. If the body of the lambda does isinstance checks
on its arguments, mypy would crash inside is_same_type.

Fixes #1607.