### PR TITLE
Use isinstance information when type checking 'or' expressions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1078,16 +1078,19 @@ class ExpressionChecker:
         left_type = self.accept(e.left, ctx)
 
         if e.op == 'and':
-            # else_map unused
-            if_map, else_map = \
+            right_map, _ = \
+                mypy.checker.find_isinstance_check(e.left, self.chk.type_map,
+                                                   self.chk.typing_mode_weak())
+        elif e.op == 'or':
+            _, right_map = \
                 mypy.checker.find_isinstance_check(e.left, self.chk.type_map,
                                                    self.chk.typing_mode_weak())
         else:
-            if_map = None
+            right_map = None
 
         self.chk.binder.push_frame()
-        if if_map:
-            for var, type in if_map.items():
+        if right_map:
+            for var, type in right_map.items():
                 self.chk.binder.push(var, type)
 
         right_type = self.accept(e.right, left_type)

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -731,6 +731,12 @@ x = B() # type: A
 
 if isinstance(x, B) and x.flag:
     pass
+if isinstance(x, B) or x.flag: # E: "A" has no attribute "flag"
+    pass
+if not isinstance(x, B) or x.flag:
+    pass
+if not isinstance(x, B) and x.flag: # E: "A" has no attribute "flag"
+    pass
 [builtins fixtures/isinstancelist.py]
 [case testIsinstanceExpression]
 class A:


### PR DESCRIPTION
Note: This is not the same as #942. It does address a pattern which
occurs at least once in mypy itself though:
```py
if res and (not isinstance(res, Instance) or cast(Instance, res).args):
```