### PR TITLE
Make 'break' outside loop and similar errors blockers

### DIFF
--- a/test-data/unit/check-semanal-error.test
+++ b/test-data/unit/check-semanal-error.test
@@ -66,3 +66,16 @@ T = TypeVar('T')
 class C:  # Forgot to add type params here
     def __init__(self, t: T) -> None: pass
 c = C(t=3)  # type: C[int]  # E: "C" expects no type arguments, but 1 given
+
+[case testBreakOutsideLoop]
+break # E: 'break' outside loop
+
+[case testContinueOutsideLoop]
+continue # E: 'continue' outside loop
+
+[case testYieldOutsideFunction]
+yield # E: 'yield' outside function
+
+[case testYieldFromOutsideFunction]
+x = 1
+yield from x # E: 'yield from' outside function


### PR DESCRIPTION
The type checker isn't equipped to deal with such errors currently,
and having it ignore these errors silently on the basis that they
should have been caught by semantic analysis is a bit sketchy.

Fixes #1571.