### PR TITLE
Check all blocks for overloads in the fast parser

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -176,7 +176,7 @@ class ASTConverter(ast35.NodeTransformer):
     def as_block(self, stmts: List[ast35.stmt], lineno: int) -> Block:
         b = None
         if stmts:
-            b = Block(self.visit_list(stmts))
+            b = Block(self.fix_function_overloads(self.visit_list(stmts)))
             b.set_line(lineno)
         return b
 
@@ -353,7 +353,7 @@ class ASTConverter(ast35.NodeTransformer):
             metaclass = self.stringify_name(metaclass_arg.value)
 
         cdef = ClassDef(n.name,
-                        Block(self.fix_function_overloads(self.visit_list(n.body))),
+                        self.as_block(n.body, n.lineno),
                         None,
                         self.visit_list(n.bases),
                         metaclass=metaclass)

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -23,3 +23,22 @@ def f():  # E: syntax error in type comment
 def f():  # E: invalid type comment
   # type: (a + b) -> None
   pass
+
+[case testFastParseProperty]
+# flags: fast-parser
+class C:
+  @property
+  def x(self) -> str: pass
+  @x.setter
+  def x(self, value: str) -> None: pass
+[builtins fixtures/property.py]
+
+[case testFastParseConditionalProperty]
+# flags: fast-parser
+class C:
+  if 1:
+    @property
+    def x(self) -> str: pass
+    @x.setter
+    def x(self, value: str) -> None: pass
+[builtins fixtures/property.py]


### PR DESCRIPTION
Fix #1708.