### PR TITLE
Support per-argument type comment syntax

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -254,7 +254,8 @@ class ASTConverter(ast35.NodeTransformer):
             # for ellipsis arg
             if (len(func_type_ast.argtypes) == 1 and
                     isinstance(func_type_ast.argtypes[0], ast35.Ellipsis)):
-                arg_types = [AnyType() for a in args]
+                arg_types = [a.type_annotation if a.type_annotation is not None else AnyType()
+                             for a in args]
             else:
                 arg_types = [a if a is not None else AnyType() for
                             a in TypeConverter(line=n.lineno).visit_list(func_type_ast.argtypes)]

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -94,3 +94,25 @@ def f(a,        # type: A
 [builtins fixtures/dict.py]
 [out]
 main: note: In function "f":
+
+[case testFastParsePerArgumentAnnotationsWithAnnotatedBareStar]
+# flags: fast-parser
+def f(*, # type: int  # E: bare * has associated type comment
+      x  # type: str
+      ):
+      # type: (...) -> int
+    pass
+[builtins fixtures/dict.py]
+[out]
+
+[case testFastParsePerArgumentAnnotationsWithReturnAndBareStar]
+# flags: fast-parser
+def f(*,
+      x  # type: str
+      ):
+      # type: (...) -> int
+    reveal_type(x) # E: Revealed type is 'builtins.str'
+    return "not an int"  # E: Incompatible return value type (got "str", expected "int")
+[builtins fixtures/dict.py]
+[out]
+main: note: In function "f":

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -116,3 +116,41 @@ def f(*,
 [builtins fixtures/dict.py]
 [out]
 main: note: In function "f":
+
+[case testFastParsePerArgumentAnnotations_python2]
+# flags: fast-parser
+class A: pass
+class B: pass
+class C: pass
+class D: pass
+def f(a,        # type: A
+      b = None, # type: B
+      *args     # type: C
+      # kwargs not tested due to lack of 2.7 dict fixtures
+      ):
+    reveal_type(a)      # E: Revealed type is '__main__.A'
+    reveal_type(b)      # E: Revealed type is '__main__.B'
+    reveal_type(args)   # E: Revealed type is 'builtins.tuple[__main__.C]'
+[builtins fixtures/dict.py]
+[out]
+main: note: In function "f":
+
+[case testFastParsePerArgumentAnnotationsWithReturn_python2]
+# flags: fast-parser
+class A: pass
+class B: pass
+class C: pass
+class D: pass
+def f(a,        # type: A
+      b = None, # type: B
+      *args     # type: C
+      # kwargs not tested due to lack of 2.7 dict fixtures
+      ):
+      # type: (...) -> int
+    reveal_type(a)      # E: Revealed type is '__main__.A'
+    reveal_type(b)      # E: Revealed type is '__main__.B'
+    reveal_type(args)   # E: Revealed type is 'builtins.tuple[__main__.C]'
+    return "not an int"  # E: Incompatible return value type (got "str", expected "int")
+[builtins fixtures/dict.py]
+[out]
+main: note: In function "f":

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -42,3 +42,55 @@ class C:
     @x.setter
     def x(self, value: str) -> None: pass
 [builtins fixtures/property.py]
+
+[case testFastParsePerArgumentAnnotations]
+# flags: fast-parser
+class A: pass
+class B: pass
+class C: pass
+class D: pass
+class E: pass
+class F: pass
+def f(a,        # type: A
+      b = None, # type: B
+      *args,    # type: C
+      d = None, # type: D
+      e,        # type: E
+      **kwargs  # type: F
+      ):
+    reveal_type(a)      # E: Revealed type is '__main__.A'
+    reveal_type(b)      # E: Revealed type is '__main__.B'
+    reveal_type(args)   # E: Revealed type is 'builtins.tuple[__main__.C]'
+    reveal_type(d)      # E: Revealed type is '__main__.D'
+    reveal_type(e)      # E: Revealed type is '__main__.E'
+    reveal_type(kwargs) # E: Revealed type is 'builtins.dict[builtins.str, __main__.F]'
+[builtins fixtures/dict.py]
+[out]
+main: note: In function "f":
+
+[case testFastParsePerArgumentAnnotationsWithReturn]
+# flags: fast-parser
+class A: pass
+class B: pass
+class C: pass
+class D: pass
+class E: pass
+class F: pass
+def f(a,        # type: A
+      b = None, # type: B
+      *args,    # type: C
+      d = None, # type: D
+      e,        # type: E
+      **kwargs  # type: F
+      ):
+      # type: (...) -> int
+    reveal_type(a)      # E: Revealed type is '__main__.A'
+    reveal_type(b)      # E: Revealed type is '__main__.B'
+    reveal_type(args)   # E: Revealed type is 'builtins.tuple[__main__.C]'
+    reveal_type(d)      # E: Revealed type is '__main__.D'
+    reveal_type(e)      # E: Revealed type is '__main__.E'
+    reveal_type(kwargs) # E: Revealed type is 'builtins.dict[builtins.str, __main__.F]'
+    return "not an int"  # E: Incompatible return value type (got "str", expected "int")
+[builtins fixtures/dict.py]
+[out]
+main: note: In function "f":

--- a/test-data/unit/lib-stub/__builtin__.py
+++ b/test-data/unit/lib-stub/__builtin__.py
@@ -1,8 +1,14 @@
+class Any: pass
+
 class object:
-    def __init__(self) -> None: pass
+    def __init__(self):
+        # type: () -> None
+        pass
 
 class type:
-    def __init__(self, x) -> None: pass
+    def __init__(self, x):
+        # type: (Any) -> None
+        pass
 
 # These are provided here for convenience.
 class int: pass


### PR DESCRIPTION
This will allow mypy to support the per-argument type comment syntax with the fast parser once https://github.com/dropbox/typed_ast/pull/5 lands.

Python 2.7 per-argument type comments will be converted to Python 3 annotations in the typed_ast's conversion module -- this allows them to be mixed with the `# type: (...) -> None` syntax.

Fixes #1102.