### PR TITLE
Add tests for the behavior of `# type: ignore` on import statements

### DIFF
--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -32,6 +32,21 @@ from xyz_m import * # type: ignore
 x   # E: Name 'x' is not defined
 1() # E: "int" not callable
 
+[case testIgnoreImportBadModule]
+import m # type: ignore
+from m import a # type: ignore
+[file m.py]
++ # A parse error, but we shouldn't even parse m.py
+[out]
+
+[case testIgnoreImportStarFromBadModule]
+from m import * # type: ignore
+[file m.py]
++
+[out]
+main:1: note: In module imported here:
+tmp/m.py:1: error: Parse error before end of line
+
 [case testIgnoreAssignmentTypeError]
 x = 1
 x = '' # type: ignore


### PR DESCRIPTION
These should cause mypy to skip processing the imported module
entirely, which I tried to break in #1737.