### PR TITLE
Infer variable types from simple literals in semanal.py

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -391,7 +391,8 @@ class BuildManager:
         check_untyped_defs = CHECK_UNTYPED_DEFS in self.flags
         self.semantic_analyzer = SemanticAnalyzer(lib_path, self.errors,
                                                   pyversion=pyversion,
-                                                  check_untyped_defs=check_untyped_defs)
+                                                  check_untyped_defs=check_untyped_defs,
+                                                  lightweight_type_check=(target >= TYPE_CHECK))
         self.modules = self.semantic_analyzer.modules
         self.semantic_analyzer_pass3 = ThirdPass(self.modules, self.errors)
         self.type_checker = TypeChecker(self.errors,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -173,7 +173,7 @@ class SemanticAnalyzer(NodeVisitor):
     # Do weak type checking in this file
     weak_opts = set()        # type: Set[str]
     # Do lightweight type checking
-    lightweight_type_check = False # type: bool
+    lightweight_type_check = False  # type: bool
 
     # Stack of functions being analyzed
     function_stack = None  # type: List[FuncItem]

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1083,10 +1083,14 @@ class SemanticAnalyzer(NodeVisitor):
 
     def analyze_simple_literal_type(self, rvalue: Node) -> Optional[Type]:
         """Return builtins.int if rvalue is an int literal, etc."""
-        if self.weak_opts or not self.lightweight_type_check:
+        if self.weak_opts or not self.lightweight_type_check or self.function_stack:
             # Skip this if any weak options are set.
             # Also skip if lightweight type check not requested.
             # This is mostly to avoid breaking unit tests.
+            # Also skip inside a function; this is to avoid confusing
+            # the code that handles dead code due to isinstance()
+            # inside type variables with value restrictions (like
+            # AnyStr).
             return None
         if isinstance(rvalue, IntExpr):
             return self.named_type_or_none('builtins.int')

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -575,8 +575,9 @@ A.B = None # E: Cannot assign to a type
 
 [case testAccessingClassAttributeWithTypeInferenceIssue]
 x = C.x # E: Cannot determine type of 'x'
+def f() -> int: return 1
 class C:
-    x = 1
+    x = f()
 [builtins fixtures/list.py]
 
 [case testAccessingClassAttributeWithTypeInferenceIssue2]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1492,4 +1492,4 @@ reveal_type("foo") # E: Argument 1 to "reveal_type" has incompatible type "str";
 
 [case testRevealTypeVar]
 reveal_type = 1
-1 + "foo" # E: Unsupported left operand type for + ("int")
+1 + "foo" # E: Unsupported operand types for + ("int" and "str")

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1043,7 +1043,7 @@ f('x') # fail
 [out]
 main: note: In function "f":
 main:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:9: error: Unsupported left operand type for + ("int")
+main:9: error: Unsupported operand types for + ("int" and "str")
 main: note: At top level:
 main:12: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 
@@ -1064,7 +1064,7 @@ def top() -> None:
 [out]
 main: note: In function "f":
 main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:10: error: Unsupported left operand type for + ("int")
+main:10: error: Unsupported operand types for + ("int" and "str")
 main: note: In function "top":
 main:13: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 
@@ -1227,7 +1227,7 @@ A().f('x') # fail
 [out]
 main: note: In member "f" of class "A":
 main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:10: error: Unsupported left operand type for + ("int")
+main:10: error: Unsupported operand types for + ("int" and "str")
 main: note: At top level:
 main:13: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
 
@@ -1272,7 +1272,7 @@ def f(x: Callable[..., int]) -> None:
     x()
     x(1)
     x(z=1)
-    x() + '' # E: Unsupported left operand type for + ("int")
+    x() + '' # E: Unsupported operand types for + ("int" and "str")
 [out]
 main: note: In function "f":
 
@@ -1285,7 +1285,7 @@ def f(x: Callable[..., int]) -> None:
 [case testCastWithCallableAndArbitraryArgs]
 from typing import Callable, cast
 f = cast(Callable[..., int], None)
-f(x=4) + '' # E: Unsupported left operand type for + ("int")
+f(x=4) + '' # E: Unsupported operand types for + ("int" and "str")
 
 [case testCallableWithArbitraryArgsInErrorMessage]
 from typing import Callable

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1523,7 +1523,7 @@ main: note: In member "f" of class "A":
 [case testMultipassAndTopLevelVariable]
 y = x # E: Cannot determine type of 'x'
 y()
-x = 1
+x = 1+0
 [out]
 
 [case testMultipassAndDecoratedMethod]

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1118,11 +1118,10 @@ def f(x: Union[str, int]):
 from typing import Any
 def f(x: Any):
     assert isinstance(x, int)  # this should narrow x to type int
-    x + "foo"
+    x + "foo"  # E: Unsupported operand types for + ("int" and "str")
 [builtins fixtures/isinstance.py]
 [out]
 main: note: In function "f":
-main:4: error: Unsupported left operand type for + ("int")
 
 [case testIsinstanceOfGenericClassRetainsParameters]
 from typing import List, Union

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -815,12 +815,11 @@ x = 0
 -- Test stability under import cycles
 -- ----------------------------------
 
--- The first two tests are identical except one main has 'import x' and the other 'import y'.
--- Previously (before build.order_ascc() was added) one of these would fail because the
--- imports were processed in the (reverse) order in which the files were encountered.
---
--- The third one isn't fixed by order_ascc(), but is fixed by the lightweight type
--- inference added to semanal.py (analyze_simple_literal_type()).
+-- The first two tests are identical except one main has 'import x'
+-- and the other 'import y'.  Previously (before build.order_ascc()
+-- was added) one of these would fail because the imports were
+-- processed in the (reverse) order in which the files were
+-- encountered.
 
 [case testImportCycleStability1]
 import x
@@ -850,6 +849,10 @@ class Sub(x.Base):
     attr = x.Base.attr
 [out]
 
+-- This case isn't fixed by order_ascc(), but is fixed by the
+-- lightweight type inference added to semanal.py
+-- (analyze_simple_literal_type()).
+
 [case testImportCycleStability3]
 import y
 [file x.py]
@@ -863,3 +866,22 @@ import x
 class Sub(x.Base):
     attr = 0
 [out]
+
+-- This case has a symmetrical cycle, so it doesn't matter in what
+-- order the files are processed.  It depends on the lightweight type
+-- interference.
+
+[case testImportCycleStability4]
+import x
+[file x.py]
+import y
+class C:
+    attr = ''
+def foo() -> int:
+    return y.D.attr
+[file y.py]
+import x
+class D:
+    attr = 0
+def bar() -> str:
+    return x.C.attr

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -860,12 +860,17 @@ class Base:
     pass
 def foo() -> int:
     import y
+    reveal_type(y.Sub.attr)
     return y.Sub.attr
 [file y.py]
 import x
 class Sub(x.Base):
     attr = 0
 [out]
+tmp/y.py:1: note: In module imported here,
+main:1: note: ... from here:
+tmp/x.py: note: In function "foo":
+tmp/x.py:5: error: Revealed type is 'builtins.int'
 
 -- This case has a symmetrical cycle, so it doesn't matter in what
 -- order the files are processed.  It depends on the lightweight type
@@ -927,3 +932,30 @@ class Sub(x.Base):
     sattr = ''
     uattr = u''
 [out]
+
+-- This case tests module-level variables.
+
+[case testImportCycleStability7]
+import x
+[file x.py]
+def foo() -> int:
+    import y
+    reveal_type(y.value)
+    return y.value
+[file y.py]
+import x
+value = 12
+[out]
+main:1: note: In module imported here:
+tmp/x.py: note: In function "foo":
+tmp/x.py:3: error: Revealed type is 'builtins.int'
+
+-- This is not really cycle-related but still about the lightweight
+-- type checker.
+
+[case testImportCycleStability8]
+x = 1  # type: str
+reveal_type(x)
+[out]
+main:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+main:2: error: Revealed type is 'builtins.str'

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -815,9 +815,12 @@ x = 0
 -- Test stability under import cycles
 -- ----------------------------------
 
--- The two tests are identical except one main has 'import x' and the other 'import y'.
+-- The first two tests are identical except one main has 'import x' and the other 'import y'.
 -- Previously (before build.order_ascc() was added) one of these would fail because the
 -- imports were processed in the (reverse) order in which the files were encountered.
+--
+-- The third one isn't fixed by order_ascc(), but is fixed by the lightweight type
+-- inference added to semanal.py (analyze_simple_literal_type()).
 
 [case testImportCycleStability1]
 import x
@@ -845,4 +848,18 @@ def foo():
 import x
 class Sub(x.Base):
     attr = x.Base.attr
+[out]
+
+[case testImportCycleStability3]
+import y
+[file x.py]
+class Base:
+    pass
+def foo() -> int:
+    import y
+    return y.Sub.attr
+[file y.py]
+import x
+class Sub(x.Base):
+    attr = 0
 [out]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -486,13 +486,12 @@ x = 1
 x = 1
 
 [case testAssignToFuncDefViaImport]
-from m import *
-# TODO: This is bad, we don't see what's coming from m.
+from m import *  # E: Incompatible import of "x" (imported name has type "int", local name has type "str")
 f = None # E: Need type annotation for variable
 x = ''
 [file m.py]
 def f(): pass
-x = 1
+x = 1+0
 [out]
 
 

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -885,3 +885,45 @@ class D:
     attr = 0
 def bar() -> str:
     return x.C.attr
+
+-- These cases test all supported literal types.
+
+[case testImportCycleStability5]
+import y
+[file x.py]
+class Base:
+    pass
+def foo() -> None:
+    import y
+    i = y.Sub.iattr  # type: int
+    f = y.Sub.fattr  # type: float
+    s = y.Sub.sattr  # type: str
+    b = y.Sub.battr  # type: bytes
+[file y.py]
+import x
+class Sub(x.Base):
+    iattr = 0
+    fattr = 0.0
+    sattr = ''
+    battr = b''
+[out]
+
+[case testImportCycleStability6_python2]
+import y
+[file x.py]
+class Base:
+    pass
+def foo() -> None:
+    import y
+    i = y.Sub.iattr  # type: int
+    f = y.Sub.fattr  # type: float
+    s = y.Sub.sattr  # type: str
+    u = y.Sub.uattr  # type: unicode
+[file y.py]
+import x
+class Sub(x.Base):
+    iattr = 0
+    fattr = 0.0
+    sattr = ''
+    uattr = u''
+[out]

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -145,9 +145,9 @@ from typing import TypeVar
 T = TypeVar('T', int, str)
 def f(x: T) -> T:
     if isinstance(x, int):
-        y = 1+0
+        y = 1
     else:
-        y = ''+''
+        y = ''
     return y
 [builtins fixtures/isinstance.py]
 
@@ -156,7 +156,7 @@ from typing import TypeVar
 T = TypeVar('T', int, str)
 def f(x: T) -> T:
     if isinstance(x, int):
-        y = 1+0
+        y = 1
     else:
         y = object()
     return y # E: Incompatible return value type (got "object", expected "str")

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -145,9 +145,9 @@ from typing import TypeVar
 T = TypeVar('T', int, str)
 def f(x: T) -> T:
     if isinstance(x, int):
-        y = 1
+        y = 1+0
     else:
-        y = ''
+        y = ''+''
     return y
 [builtins fixtures/isinstance.py]
 
@@ -156,7 +156,7 @@ from typing import TypeVar
 T = TypeVar('T', int, str)
 def f(x: T) -> T:
     if isinstance(x, int):
-        y = 1
+        y = 1+0
     else:
         y = object()
     return y # E: Incompatible return value type (got "object", expected "str")

--- a/test-data/unit/check-weak-typing.test
+++ b/test-data/unit/check-weak-typing.test
@@ -120,7 +120,7 @@ main: note: In function "f":
 [case testWeakFunction3]
 # mypy: weak
 def f():
-    1 + 'a' # E: Unsupported left operand type for + ("int")
+    1 + 'a' # E: Unsupported operand types for + ("int" and "str")
 [out]
 main: note: In function "f":
 [case testWeakFunctionCall]

--- a/test-data/unit/fixtures/isinstance.py
+++ b/test-data/unit/fixtures/isinstance.py
@@ -14,7 +14,9 @@ class function: pass
 
 def isinstance(x: object, t: Union[type, Tuple[type, ...]]) -> bool: pass
 
-class int: pass
+class int:
+    def __add__(self, other: 'int') -> 'int': pass
 class float: pass
 class bool(int): pass
-class str: pass
+class str:
+    def __add__(self, other: 'str') -> 'str': pass

--- a/test-data/unit/lib-stub/__builtin__.py
+++ b/test-data/unit/lib-stub/__builtin__.py
@@ -12,7 +12,10 @@ class type:
 
 # These are provided here for convenience.
 class int: pass
+class float: pass
+
 class str: pass
+class unicode: pass
 
 class tuple: pass
 class function: pass

--- a/test-data/unit/lib-stub/builtins.py
+++ b/test-data/unit/lib-stub/builtins.py
@@ -9,8 +9,11 @@ class type:
 # These are provided here for convenience.
 class int:
     def __add__(self, other: 'int') -> 'int': pass
+class float: pass
+
 class str:
     def __add__(self, other: 'str') -> 'str': pass
+class bytes: pass
 
 class tuple: pass
 class function: pass

--- a/test-data/unit/lib-stub/builtins.py
+++ b/test-data/unit/lib-stub/builtins.py
@@ -7,8 +7,10 @@ class type:
     def __init__(self, x: Any) -> None: pass
 
 # These are provided here for convenience.
-class int: pass
-class str: pass
+class int:
+    def __add__(self, other: 'int') -> 'int': pass
+class str:
+    def __add__(self, other: 'str') -> 'str': pass
 
 class tuple: pass
 class function: pass

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -268,11 +268,11 @@ NameExpr(4) : builtins.bool
 
 [case testInferSingleType]
 import typing
-x = 1
+x = ()
 [builtins fixtures/primitives.py]
 [out]
-IntExpr(2) : builtins.int
-NameExpr(2) : builtins.int
+NameExpr(2) : Tuple[]
+TupleExpr(2) : Tuple[]
 
 [case testInferTwoTypes]
 ## NameExpr
@@ -287,11 +287,11 @@ NameExpr(4) : builtins.int
 [case testInferSingleLocalVarType]
 import typing
 def f() -> None:
-    x = 1
+    x = ()
 [builtins fixtures/primitives.py]
 [out]
-IntExpr(3) : builtins.int
-NameExpr(3) : builtins.int
+NameExpr(3) : Tuple[]
+TupleExpr(3) : Tuple[]
 
 
 -- Basic generics


### PR DESCRIPTION
This implements another partial approach to #1530. The cases in our internal repo where my previous PR (#1736) caused regressions are all fixed by this.

However I'm not fully convinced that this is the right way to go about it. Some of the tests I had to fix make me wonder. Example:
```
def foo(s: AnyStr) -> AnyStr:
    if isinstance(s, str):
        x = '/'
    else:
        x = b'/'
    return x
```
If I understand what I had to fix in posixpath.py correctly, this used to pass silently while now I have to add `# type: AnyStr` to the first assignment to x.