### PR TITLE
Make Type[T] work with overloaded functions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1764,8 +1764,8 @@ def overload_arg_similarity(actual: Type, formal: Type) -> int:
                    for item in actual.items)
     if isinstance(formal, TypeType):
         if isinstance(actual, TypeType):
-            # If both actual and formal are Type[T], and since Type[T] is
-            # covariant, check if actual=Type[A] is a subtype of formal=Type[F].
+            # Since Type[T] is covariant, check if actual = Type[A] is
+            # a subtype of formal = Type[F].
             return overload_arg_similarity(actual.item, formal.item)
         elif isinstance(actual, CallableType) and actual.is_type_obj():
             # Check if the actual is a constructor of some sort.
@@ -1793,9 +1793,7 @@ def overload_arg_similarity(actual: Type, formal: Type) -> int:
             else:
                 return 0
         elif isinstance(actual, TypeType):
-            allowable = {"builtins.object", "builtins.type"}
-            if isinstance(formal, Instance) and formal.type.fullname() in allowable:
-                # Type[T] is always an instance of object or type
+            if formal.type.fullname() in {"builtins.object", "builtins.type"}:
                 return 2
             else:
                 return 0

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1762,6 +1762,9 @@ def overload_arg_similarity(actual: Type, formal: Type) -> int:
     if isinstance(actual, UnionType):
         return max(overload_arg_similarity(item, formal)
                    for item in actual.items)
+    if isinstance(formal, UnionType):
+        return max(overload_arg_similarity(actual, item)
+                   for item in formal.items)
     if isinstance(formal, TypeType):
         if isinstance(actual, TypeType):
             # Since Type[T] is covariant, check if actual = Type[A] is
@@ -1769,13 +1772,10 @@ def overload_arg_similarity(actual: Type, formal: Type) -> int:
             return overload_arg_similarity(actual.item, formal.item)
         elif isinstance(actual, CallableType) and actual.is_type_obj():
             # Check if the actual is a constructor of some sort.
-            # TODO: is this unsound, since we don't check the __init__ signature?
+            # Note that this is this unsound, since we don't check the __init__ signature.
             return overload_arg_similarity(actual.ret_type, formal.item)
         else:
             return 0
-    if isinstance(formal, UnionType):
-        return max(overload_arg_similarity(actual, item)
-                   for item in formal.items)
     if isinstance(formal, Instance):
         if isinstance(actual, CallableType):
             actual = actual.fallback

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1762,6 +1762,17 @@ def overload_arg_similarity(actual: Type, formal: Type) -> int:
     if isinstance(actual, UnionType):
         return max(overload_arg_similarity(item, formal)
                    for item in actual.items)
+    if isinstance(formal, TypeType):
+        if isinstance(actual, TypeType):
+            # If both actual and formal are Type[T], and since Type[T] is
+            # covariant, check if actual=Type[A] is a subtype of formal=Type[F].
+            return overload_arg_similarity(actual.item, formal.item)
+        elif isinstance(actual, CallableType) and actual.is_type_obj():
+            # Check if the actual is a constructor of some sort.
+            # TODO: is this unsound, since we don't check the __init__ signature?
+            return overload_arg_similarity(actual.ret_type, formal.item)
+        else:
+            return 0
     if isinstance(formal, UnionType):
         return max(overload_arg_similarity(actual, item)
                    for item in formal.items)
@@ -1779,6 +1790,13 @@ def overload_arg_similarity(actual: Type, formal: Type) -> int:
                 return 2
             elif actual.type._promote and is_subtype(actual, formal):
                 return 1
+            else:
+                return 0
+        elif isinstance(actual, TypeType):
+            allowable = {"builtins.object", "builtins.type"}
+            if isinstance(formal, Instance) and formal.type.fullname() in allowable:
+                # Type[T] is always an instance of object or type
+                return 2
             else:
                 return 0
         else:

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -67,7 +67,6 @@ def is_overlapping_types(t: Type, s: Type, use_promotions: bool = False) -> bool
 
     TODO: Don't consider tuples always overlapping.
     TODO: Don't consider callables always overlapping.
-    TODO: Don't consider type variables with values always overlapping.
     """
     # Since we are effectively working with the erased types, we only
     # need to handle occurrences of TypeVarType at the top level.

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -67,6 +67,7 @@ def is_overlapping_types(t: Type, s: Type, use_promotions: bool = False) -> bool
 
     TODO: Don't consider tuples always overlapping.
     TODO: Don't consider callables always overlapping.
+    TODO: Don't consider type variables with values always overlapping.
     """
     # Since we are effectively working with the erased types, we only
     # need to handle occurrences of TypeVarType at the top level.

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -98,9 +98,13 @@ def is_overlapping_types(t: Type, s: Type, use_promotions: bool = False) -> bool
         # If both types are TypeType, compare their inner types.
         return is_overlapping_types(t.item, s.item, use_promotions)
     elif isinstance(t, TypeType) or isinstance(s, TypeType):
-        # If exactly only one of t or s is a TypeType, we consider
-        # the types to not be overlapping.
-        return False
+        # If exactly only one of t or s is a TypeType, check if one of them
+        # is an `object` or a `type` and otherwise assume no overlap.
+        other = s if isinstance(t, TypeType) else t
+        if isinstance(other, Instance):
+            return other.type.fullname() in {'builtins.object', 'builtins.type'}
+        else:
+            return False
     if experiments.STRICT_OPTIONAL:
         if isinstance(t, NoneTyp) != isinstance(s, NoneTyp):
             # NoneTyp does not overlap with other non-Union types under strict Optional checking

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1918,3 +1918,32 @@ reveal_type(f(BChild()))  # E: Revealed type is '__main__.B'
 [builtins fixtures/classmethod.py]
 [out]
 
+[case testTypeTypeOverlapsWithObjectAndType]
+from typing import Type, overload
+
+class User: pass
+
+@overload
+def f(a: Type[User]) -> int: pass  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+@overload
+def f(a: object) -> str: pass
+
+@overload
+def g(a: Type[User]) -> int: pass  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+@overload
+def g(a: type) -> str: pass
+[builtins fixtures/classmethod.py]
+[out]
+
+[case testTypeOverlapsWithObject]
+from typing import Type, overload
+
+class User: pass
+
+@overload
+def f(a: type) -> int: pass  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+@overload
+def f(a: object) -> str: pass
+[builtins fixtures/classmethod.py]
+[out]
+

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1731,12 +1731,12 @@ class User: pass
 UserType = User  # type: Type[User]
 
 @overload
-def f(a: object) -> None: pass
+def f(a: object) -> int: pass
 @overload
-def f(a: int) -> None: pass
+def f(a: int) -> str: pass
 
-f(User)
-f(UserType)
+reveal_type(f(User))  # E: Revealed type is 'builtins.int'
+reveal_type(f(UserType))  # E: Revealed type is 'builtins.int'
 [builtins fixtures/classmethod.py]
 [out]
 
@@ -1755,6 +1755,7 @@ def f(a: int) -> str:
 
 reveal_type(f(User))  # E: Revealed type is 'builtins.int'
 reveal_type(f(UserType))  # E: Revealed type is 'builtins.int'
+reveal_type(f(1))  # E: Revealed type is 'builtins.str'
 [builtins fixtures/classmethod.py]
 [out]
 
@@ -1765,8 +1766,8 @@ class User: pass
 UserType = User  # type: Type[User]
 
 @overload
-def f(a: User) -> bool:
-    return True
+def f(a: User) -> User:
+    return User() 
 @overload
 def f(a: Type[User]) -> int:
     return 1
@@ -1776,7 +1777,33 @@ def f(a: int) -> str:
 
 reveal_type(f(User))  # E: Revealed type is 'builtins.int'
 reveal_type(f(UserType))  # E: Revealed type is 'builtins.int'
-reveal_type(f(User()))  # E: Revealed type is 'builtins.bool'
+reveal_type(f(User()))  # E: Revealed type is '__main__.User'
+reveal_type(f(1))  # E: Revealed type is 'builtins.str'
+[builtins fixtures/classmethod.py]
+[out]
+
+[case testMixingTypeTypeInOverloadedFunctions]
+from typing import Type, overload
+
+class User: pass
+
+@overload
+def f(a: User) -> Type[User]:
+    return User
+@overload
+def f(a: Type[User]) -> User:
+    return a()
+@overload
+def f(a: int) -> Type[User]: 
+    return User
+@overload
+def f(a: str) -> User:
+    return User()
+
+reveal_type(f(User()))  # E: Revealed type is 'Type[__main__.User]'
+reveal_type(f(User))  # E: Revealed type is '__main__.User'
+reveal_type(f(3))  # E: Revealed type is 'Type[__main__.User]'
+reveal_type(f("hi"))  # E: Revealed type is '__main__.User'
 [builtins fixtures/classmethod.py]
 [out]
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1723,3 +1723,61 @@ def foo(c: Type[C], d: Type[D]) -> None:
 [out]
 main: note: In function "foo":
 main:7: error: Revealed type is 'builtins.list[Type[__main__.B]]'
+
+[case testTypeMatchesOverloadedFunctions]
+from typing import Type, overload, cast
+class User: pass
+@overload
+def f(a: object) -> None: pass
+@overload
+def f(a: int) -> None: pass
+f(User)
+f(cast(Type[User], User))
+[builtins fixtures/classmethod.py]
+[out]
+
+[case testTypeMatchesGeneralTypeInOverloadedFunctions]
+from typing import Type, overload, cast
+class User: pass
+@overload
+def f(a: type) -> None: pass
+@overload
+def f(a: int) -> None: pass
+f(User)
+f(cast(Type[User], User))
+[builtins fixtures/classmethod.py]
+[out]
+
+[case testGeneralTypeDoesNotMatchSpecificTypeInOverloadedFunctions]
+from typing import Type, overload, cast
+class User: pass
+@overload
+def f(a: Type[User]) -> None: pass
+@overload
+def f(a: int) -> None: pass
+f(User)
+f(type(User))
+[builtins fixtures/classmethod.py]
+[out]
+main:8: error: No overload variant of "f" matches argument types [builtins.type]
+
+[case testTypeCovarianceWithOverloadedFunctions]
+from typing import Type, overload, cast
+class A: pass
+class B(A): pass
+class C(B): pass
+@overload
+def f(a: Type[B]) -> None: pass
+@overload
+def f(a: int) -> None: pass
+f(A)
+f(B)
+f(C)
+f(cast(Type[A], type(A)))
+f(cast(Type[B], type(B)))
+f(cast(Type[C], type(C)))
+[builtins fixtures/classmethod.py]
+[out]
+main:9: error: No overload variant of "f" matches argument types [def () -> __main__.A]
+main:12: error: No overload variant of "f" matches argument types [Type[__main__.A]]
+

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1725,59 +1725,169 @@ main: note: In function "foo":
 main:7: error: Revealed type is 'builtins.list[Type[__main__.B]]'
 
 [case testTypeMatchesOverloadedFunctions]
-from typing import Type, overload, cast
+from typing import Type, overload, Union
+
 class User: pass
+UserType = User  # type: Type[User]
+
 @overload
 def f(a: object) -> None: pass
 @overload
 def f(a: int) -> None: pass
+
 f(User)
-f(cast(Type[User], User))
+f(UserType)
 [builtins fixtures/classmethod.py]
 [out]
 
 [case testTypeMatchesGeneralTypeInOverloadedFunctions]
-from typing import Type, overload, cast
+from typing import Type, overload
+
 class User: pass
+UserType = User  # type: Type[User]
+
 @overload
-def f(a: type) -> None: pass
+def f(a: type) -> int:
+    return 1
 @overload
-def f(a: int) -> None: pass
-f(User)
-f(cast(Type[User], User))
+def f(a: int) -> str: 
+    return "a" 
+
+reveal_type(f(User))  # E: Revealed type is 'builtins.int'
+reveal_type(f(UserType))  # E: Revealed type is 'builtins.int'
+[builtins fixtures/classmethod.py]
+[out]
+
+[case testTypeMatchesSpecificTypeInOverloadedFunctions]
+from typing import Type, overload
+
+class User: pass
+UserType = User  # type: Type[User]
+
+@overload
+def f(a: User) -> bool:
+    return True
+@overload
+def f(a: Type[User]) -> int:
+    return 1
+@overload
+def f(a: int) -> str: 
+    return "a" 
+
+reveal_type(f(User))  # E: Revealed type is 'builtins.int'
+reveal_type(f(UserType))  # E: Revealed type is 'builtins.int'
+reveal_type(f(User()))  # E: Revealed type is 'builtins.bool'
 [builtins fixtures/classmethod.py]
 [out]
 
 [case testGeneralTypeDoesNotMatchSpecificTypeInOverloadedFunctions]
-from typing import Type, overload, cast
+from typing import Type, overload
+
 class User: pass
+
 @overload
 def f(a: Type[User]) -> None: pass
 @overload
 def f(a: int) -> None: pass
+
 f(User)
-f(type(User))
+f(type(User))  # E: No overload variant of "f" matches argument types [builtins.type]
 [builtins fixtures/classmethod.py]
 [out]
-main:8: error: No overload variant of "f" matches argument types [builtins.type]
+
+[case testNonTypeDoesNotMatchOverloadedFunctions]
+from typing import Type, overload
+
+class User: pass
+
+@overload
+def f(a: Type[User]) -> None: pass
+@overload
+def f(a: type) -> None: pass
+
+f(3)  # E: No overload variant of "f" matches argument types [builtins.int]
+[builtins fixtures/classmethod.py]
+[out]
+
+[case testInstancesDoNotMatchTypeInOverloadedFunctions]
+from typing import Type, overload
+
+class User: pass
+
+@overload
+def f(a: Type[User]) -> None: pass
+@overload
+def f(a: int) -> None: pass
+
+f(User)
+f(User())  # E: No overload variant of "f" matches argument types [__main__.User]
+[builtins fixtures/classmethod.py]
+[out]
 
 [case testTypeCovarianceWithOverloadedFunctions]
-from typing import Type, overload, cast
+from typing import Type, overload
+
 class A: pass
 class B(A): pass
 class C(B): pass
+AType = A  # type: Type[A]
+BType = B  # type: Type[B]
+CType = C  # type: Type[C]
+
 @overload
 def f(a: Type[B]) -> None: pass
 @overload
 def f(a: int) -> None: pass
-f(A)
+
+f(A)  # E: No overload variant of "f" matches argument types [def () -> __main__.A]
 f(B)
 f(C)
-f(cast(Type[A], type(A)))
-f(cast(Type[B], type(B)))
-f(cast(Type[C], type(C)))
+f(AType)  # E: No overload variant of "f" matches argument types [Type[__main__.A]]
+f(BType)
+f(CType)
 [builtins fixtures/classmethod.py]
 [out]
-main:9: error: No overload variant of "f" matches argument types [def () -> __main__.A]
-main:12: error: No overload variant of "f" matches argument types [Type[__main__.A]]
+
+
+[case testOverloadedCovariantTypesFail]
+from typing import Type, overload
+
+class A: pass
+class B(A): pass
+
+@overload
+def f(a: Type[A]) -> int: pass  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+@overload
+def f(a: Type[B]) -> str: pass
+[builtins fixtures/classmethod.py]
+[out]
+
+[case testDistinctOverloadedCovariantTypesSucceed]
+from typing import Type, overload
+
+class A: pass
+class AChild(A): pass
+class B: pass
+class BChild(B): pass
+
+@overload
+def f(a: Type[A]) -> int: pass 
+@overload
+def f(a: Type[B]) -> str: pass
+@overload
+def f(a: A) -> A: pass
+@overload
+def f(a: B) -> B: pass
+
+reveal_type(f(A))  # E: Revealed type is 'builtins.int'
+reveal_type(f(AChild))  # E: Revealed type is 'builtins.int'
+reveal_type(f(B))  # E: Revealed type is 'builtins.str'
+reveal_type(f(BChild))  # E: Revealed type is 'builtins.str'
+
+reveal_type(f(A()))  # E: Revealed type is '__main__.A'
+reveal_type(f(AChild()))  # E: Revealed type is '__main__.A'
+reveal_type(f(B()))  # E: Revealed type is '__main__.B'
+reveal_type(f(BChild()))  # E: Revealed type is '__main__.B'
+[builtins fixtures/classmethod.py]
+[out]
 


### PR DESCRIPTION
Previously, `Type[T]` did not seem to respect overloaded functions. For example, in the following snippit of code:

```python
from typing import Type, cast

class Foo: pass
print(str(cast(Type[Foo], Foo)))
```

...mypy would report the following error:

    error: No overload variant of "str" matches argument types [Type[test.Foo]]

...because `str` was defined to have the following type signatures:

```python
class str(Sequence[str]):
    @overload
    def __init__(self) -> None: ...
    @overload
    def __init__(self, o: object) -> None: ...
    @overload
    def __init__(self, o: bytes, encoding: str = None, errors: str = 'strict') -> None: ...
```

I previously thought the issue was that mypy did not recognize that `Type[T]` was a subclass of object, but the actual problem was that the code to check the type signatures of overloaded functions was not updated to work with `Type[T]`.

I attempted to to update `checkexpr.overload_arg_similarity` accordingly, but since I'm still pretty new to the codebase, I'm not sure if I did it correctly -- any feedback would be appreciated!