### PR TITLE
Make TraverserVisitor not generic

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2466,7 +2466,7 @@ class FirstPass(NodeVisitor):
         self.sem.analyze_lvalue(lvalue, add_global=True, explicit_type=explicit_type)
 
 
-class ThirdPass(TraverserVisitor[None]):
+class ThirdPass(TraverserVisitor):
     """The third and final pass of semantic analysis.
 
     Check type argument counts and values of generic types, and perform some

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -18,7 +18,7 @@ from mypy.nodes import (
 T = TypeVar('T')
 
 
-class TraverserVisitor(NodeVisitor[T], Generic[T]):
+class TraverserVisitor(NodeVisitor[None]):
     """A parse tree visitor that traverses the parse tree during visiting.
 
     It does not peform any actions outside the traversal. Subclasses
@@ -29,15 +29,15 @@ class TraverserVisitor(NodeVisitor[T], Generic[T]):
 
     # Visit methods
 
-    def visit_mypy_file(self, o: MypyFile) -> T:
+    def visit_mypy_file(self, o: MypyFile) -> None:
         for d in o.defs:
             d.accept(self)
 
-    def visit_block(self, block: Block) -> T:
+    def visit_block(self, block: Block) -> None:
         for s in block.body:
             s.accept(self)
 
-    def visit_func(self, o: FuncItem) -> T:
+    def visit_func(self, o: FuncItem) -> None:
         for arg in o.arguments:
             init = arg.initialization_statement
             if init is not None:
@@ -48,60 +48,60 @@ class TraverserVisitor(NodeVisitor[T], Generic[T]):
 
         o.body.accept(self)
 
-    def visit_func_def(self, o: FuncDef) -> T:
+    def visit_func_def(self, o: FuncDef) -> None:
         self.visit_func(o)
 
-    def visit_overloaded_func_def(self, o: OverloadedFuncDef) -> T:
+    def visit_overloaded_func_def(self, o: OverloadedFuncDef) -> None:
         for item in o.items:
             item.accept(self)
 
-    def visit_class_def(self, o: ClassDef) -> T:
+    def visit_class_def(self, o: ClassDef) -> None:
         o.defs.accept(self)
 
-    def visit_decorator(self, o: Decorator) -> T:
+    def visit_decorator(self, o: Decorator) -> None:
         o.func.accept(self)
         o.var.accept(self)
         for decorator in o.decorators:
             decorator.accept(self)
 
-    def visit_expression_stmt(self, o: ExpressionStmt) -> T:
+    def visit_expression_stmt(self, o: ExpressionStmt) -> None:
         o.expr.accept(self)
 
-    def visit_assignment_stmt(self, o: AssignmentStmt) -> T:
+    def visit_assignment_stmt(self, o: AssignmentStmt) -> None:
         o.rvalue.accept(self)
         for l in o.lvalues:
             l.accept(self)
 
-    def visit_operator_assignment_stmt(self, o: OperatorAssignmentStmt) -> T:
+    def visit_operator_assignment_stmt(self, o: OperatorAssignmentStmt) -> None:
         o.rvalue.accept(self)
         o.lvalue.accept(self)
 
-    def visit_while_stmt(self, o: WhileStmt) -> T:
+    def visit_while_stmt(self, o: WhileStmt) -> None:
         o.expr.accept(self)
         o.body.accept(self)
         if o.else_body:
             o.else_body.accept(self)
 
-    def visit_for_stmt(self, o: ForStmt) -> T:
+    def visit_for_stmt(self, o: ForStmt) -> None:
         o.index.accept(self)
         o.expr.accept(self)
         o.body.accept(self)
         if o.else_body:
             o.else_body.accept(self)
 
-    def visit_return_stmt(self, o: ReturnStmt) -> T:
+    def visit_return_stmt(self, o: ReturnStmt) -> None:
         if o.expr is not None:
             o.expr.accept(self)
 
-    def visit_assert_stmt(self, o: AssertStmt) -> T:
+    def visit_assert_stmt(self, o: AssertStmt) -> None:
         if o.expr is not None:
             o.expr.accept(self)
 
-    def visit_del_stmt(self, o: DelStmt) -> T:
+    def visit_del_stmt(self, o: DelStmt) -> None:
         if o.expr is not None:
             o.expr.accept(self)
 
-    def visit_if_stmt(self, o: IfStmt) -> T:
+    def visit_if_stmt(self, o: IfStmt) -> None:
         for e in o.expr:
             e.accept(self)
         for b in o.body:
@@ -109,13 +109,13 @@ class TraverserVisitor(NodeVisitor[T], Generic[T]):
         if o.else_body:
             o.else_body.accept(self)
 
-    def visit_raise_stmt(self, o: RaiseStmt) -> T:
+    def visit_raise_stmt(self, o: RaiseStmt) -> None:
         if o.expr is not None:
             o.expr.accept(self)
         if o.from_expr is not None:
             o.from_expr.accept(self)
 
-    def visit_try_stmt(self, o: TryStmt) -> T:
+    def visit_try_stmt(self, o: TryStmt) -> None:
         o.body.accept(self)
         for i in range(len(o.types)):
             if o.types[i]:
@@ -126,39 +126,39 @@ class TraverserVisitor(NodeVisitor[T], Generic[T]):
         if o.finally_body is not None:
             o.finally_body.accept(self)
 
-    def visit_with_stmt(self, o: WithStmt) -> T:
+    def visit_with_stmt(self, o: WithStmt) -> None:
         for i in range(len(o.expr)):
             o.expr[i].accept(self)
             if o.target[i] is not None:
                 o.target[i].accept(self)
         o.body.accept(self)
 
-    def visit_member_expr(self, o: MemberExpr) -> T:
+    def visit_member_expr(self, o: MemberExpr) -> None:
         o.expr.accept(self)
 
-    def visit_yield_from_expr(self, o: YieldFromExpr) -> T:
+    def visit_yield_from_expr(self, o: YieldFromExpr) -> None:
         o.expr.accept(self)
 
-    def visit_yield_expr(self, o: YieldExpr) -> T:
+    def visit_yield_expr(self, o: YieldExpr) -> None:
         if o.expr:
             o.expr.accept(self)
 
-    def visit_call_expr(self, o: CallExpr) -> T:
+    def visit_call_expr(self, o: CallExpr) -> None:
         for a in o.args:
             a.accept(self)
         o.callee.accept(self)
         if o.analyzed:
             o.analyzed.accept(self)
 
-    def visit_op_expr(self, o: OpExpr) -> T:
+    def visit_op_expr(self, o: OpExpr) -> None:
         o.left.accept(self)
         o.right.accept(self)
 
-    def visit_comparison_expr(self, o: ComparisonExpr) -> T:
+    def visit_comparison_expr(self, o: ComparisonExpr) -> None:
         for operand in o.operands:
             operand.accept(self)
 
-    def visit_slice_expr(self, o: SliceExpr) -> T:
+    def visit_slice_expr(self, o: SliceExpr) -> None:
         if o.begin_index is not None:
             o.begin_index.accept(self)
         if o.end_index is not None:
@@ -166,39 +166,39 @@ class TraverserVisitor(NodeVisitor[T], Generic[T]):
         if o.stride is not None:
             o.stride.accept(self)
 
-    def visit_cast_expr(self, o: CastExpr) -> T:
+    def visit_cast_expr(self, o: CastExpr) -> None:
         o.expr.accept(self)
 
-    def visit_reveal_type_expr(self, o: RevealTypeExpr) -> T:
+    def visit_reveal_type_expr(self, o: RevealTypeExpr) -> None:
         o.expr.accept(self)
 
-    def visit_unary_expr(self, o: UnaryExpr) -> T:
+    def visit_unary_expr(self, o: UnaryExpr) -> None:
         o.expr.accept(self)
 
-    def visit_list_expr(self, o: ListExpr) -> T:
+    def visit_list_expr(self, o: ListExpr) -> None:
         for item in o.items:
             item.accept(self)
 
-    def visit_tuple_expr(self, o: TupleExpr) -> T:
+    def visit_tuple_expr(self, o: TupleExpr) -> None:
         for item in o.items:
             item.accept(self)
 
-    def visit_dict_expr(self, o: DictExpr) -> T:
+    def visit_dict_expr(self, o: DictExpr) -> None:
         for k, v in o.items:
             k.accept(self)
             v.accept(self)
 
-    def visit_set_expr(self, o: SetExpr) -> T:
+    def visit_set_expr(self, o: SetExpr) -> None:
         for item in o.items:
             item.accept(self)
 
-    def visit_index_expr(self, o: IndexExpr) -> T:
+    def visit_index_expr(self, o: IndexExpr) -> None:
         o.base.accept(self)
         o.index.accept(self)
         if o.analyzed:
             o.analyzed.accept(self)
 
-    def visit_generator_expr(self, o: GeneratorExpr) -> T:
+    def visit_generator_expr(self, o: GeneratorExpr) -> None:
         for index, sequence, conditions in zip(o.indices, o.sequences,
                                                o.condlists):
             sequence.accept(self)
@@ -207,16 +207,16 @@ class TraverserVisitor(NodeVisitor[T], Generic[T]):
                 cond.accept(self)
         o.left_expr.accept(self)
 
-    def visit_list_comprehension(self, o: ListComprehension) -> T:
+    def visit_list_comprehension(self, o: ListComprehension) -> None:
         o.generator.accept(self)
 
-    def visit_conditional_expr(self, o: ConditionalExpr) -> T:
+    def visit_conditional_expr(self, o: ConditionalExpr) -> None:
         o.cond.accept(self)
         o.if_expr.accept(self)
         o.else_expr.accept(self)
 
-    def visit_type_application(self, o: TypeApplication) -> T:
+    def visit_type_application(self, o: TypeApplication) -> None:
         o.expr.accept(self)
 
-    def visit_func_expr(self, o: FuncExpr) -> T:
+    def visit_func_expr(self, o: FuncExpr) -> None:
         self.visit_func(o)


### PR DESCRIPTION
None of the existing uses of TraverserVisitor use the ability to
return a value from the visit_* methods, and it's hard to imagine how
one could use that ability without overriding almost all of the
methods of TraverserVisitor. And the old code would be totally wrong
under strict optional checking.