### PR TITLE
Make type function return Type[T]

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -250,6 +250,11 @@ class ExpressionChecker:
             self.check_argument_types(arg_types, arg_kinds, callee,
                                       formal_to_actual, context,
                                       messages=arg_messages)
+
+            ret_val_is_type_obj = is_equivalent(callee.ret_type, self.named_type('builtins.type'))
+            if callee.is_type_obj() and (len(arg_types) == 1) and ret_val_is_type_obj:
+                callee.ret_type = TypeType(arg_types[0])
+
             if callable_node:
                 # Store the inferred callable type.
                 self.chk.store_type(callable_node, callee)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1818,8 +1818,10 @@ def f(a: Type[User]) -> None: pass
 @overload
 def f(a: int) -> None: pass
 
+def mock() -> type: return User
+
 f(User)
-f(type(User))  # E: No overload variant of "f" matches argument types [builtins.type]
+f(mock())  # E: No overload variant of "f" matches argument types [builtins.type]
 [builtins fixtures/classmethod.py]
 [out]
 
@@ -1946,5 +1948,61 @@ def f(a: type) -> int: pass  # E: Overloaded function signatures 1 and 2 overlap
 @overload
 def f(a: object) -> str: pass
 [builtins fixtures/classmethod.py]
+[out]
+
+[case testTypeConstructorReturnsTypeType]
+class User:
+    @classmethod
+    def test_class_method(cls) -> int: pass
+    @staticmethod
+    def test_static_method() -> str: pass
+    def test_instance_method(self) -> None: pass
+
+u = User()
+
+reveal_type(type(u))  # E: Revealed type is 'Type[__main__.User]'
+reveal_type(type(u).test_class_method())  # E: Revealed type is 'builtins.int'
+reveal_type(type(u).test_static_method())  # E: Revealed type is 'builtins.str'
+type(u).test_instance_method()  # E: Too few arguments for "test_instance_method" of "User"
+[builtins fixtures/classmethod.py]
+[out]
+
+[case testObfuscatedTypeConstructorReturnsTypeType]
+from typing import TypeVar
+class User: pass
+
+f1 = type
+
+A = TypeVar('A')
+def f2(func: A) -> A:
+    return func
+
+u = User()
+
+reveal_type(f1(u))  # E: Revealed type is 'Type[__main__.User]'
+reveal_type(f2(type)(u))  # E: Revealed type is 'Type[__main__.User]'
+[builtins fixtures/classmethod.py]
+[out]
+
+[case testTypeConstructorLookalikeFails]
+class User: pass
+
+def fake1(a: object) -> type:
+    return User
+def fake2(a: int) -> type:
+    return User
+
+reveal_type(type(User()))  # E: Revealed type is 'Type[__main__.User]'
+reveal_type(fake1(User()))  # E: Revealed type is 'builtins.type'
+reveal_type(fake2(3))  # E: Revealed type is 'builtins.type'
+[builtins fixtures/classmethod.py]
+[out]
+
+[case testOtherTypeConstructorsSucceed]
+def foo(self) -> int: return self.attr
+
+User = type('User', (object,), {'foo': foo, 'attr': 3})
+reveal_type(User)  # E: Revealed type is 'builtins.type'
+[builtins fixtures/args.py]
 [out]
 

--- a/test-data/unit/fixtures/args.py
+++ b/test-data/unit/fixtures/args.py
@@ -1,6 +1,6 @@
 # Builtins stub used to support *args, **kwargs.
 
-from typing import TypeVar, Generic, Iterable
+from typing import TypeVar, Generic, Iterable, Tuple, Dict, Any, overload
 
 Tco = TypeVar('Tco', covariant=True)
 T = TypeVar('T')
@@ -9,7 +9,12 @@ S = TypeVar('S')
 class object:
     def __init__(self) -> None: pass
 
-class type: pass
+class type:
+    @overload
+    def __init__(self, o: object) -> None: pass
+    @overload
+    def __init__(self, name: str, bases: Tuple[type, ...], dict: Dict[str, Any]) -> None: pass
+
 class tuple(Iterable[Tco], Generic[Tco]): pass
 class dict(Generic[T, S]): pass
 

--- a/test-data/unit/fixtures/classmethod.py
+++ b/test-data/unit/fixtures/classmethod.py
@@ -9,7 +9,9 @@ class type:
 
 class function: pass
 
-classmethod = object() # Dummy definition.
+# Dummy definitions.
+classmethod = object()
+staticmethod = object()
 
 class int:
     @classmethod


### PR DESCRIPTION
This commit is a fix for #1758 -- it special-cases the single constructor `type` builtin function within mypy so it returns an instance of `typing.Type` rather then just the generic `type` object.

It adds a special case within mypy rather then modifying the definition within Typeshed, but since `type` is defined to be a class and not a function definition in Typeshed, it was unclear how I could implement this change by only modifying Typeshed.

This commit doesn't handle the  `x.__class__` attribute -- it still returns `type`.