### PR TITLE
Add a requirements file for building docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,15 +5,17 @@ What's this?
 ------------
 
 This directory contains the source code for Mypy documentation (under `source/`)
-and build scripts. The documentation uses Sphinx and reStructuredText.
+and build scripts. The documentation uses Sphinx and reStructuredText. We use
+`sphinx-rtd-theme` as the documentation theme.
 
 Building the documentation
 --------------------------
 
-We use `sphinx_rtd_theme` as the theme. You should install it first:
+Install Sphinx and other dependencies (i.e. theme) needed for the documentation.
+From the `docs` directory, use `pip`:
 
 ```
-$ pip install sphinx_rtd_theme
+$ pip install -r requirements-docs.txt
 ```
 
 Build the documentation like this:
@@ -21,3 +23,27 @@ Build the documentation like this:
 ```
 $ make html
 ```
+
+The built documentation will be placed in the `docs/build` directory. Open
+`docs/build/index.html` to view the documentation.
+
+Helpful documentation build commands
+------------------------------------
+
+Clean the documentation build:
+
+```
+$ make clean
+```
+
+Test and check the links found in the documentation:
+
+```
+$ make linkcheck
+```
+
+Documentation on Read The Docs
+------------------------------
+
+The mypy documentation is hosted on Read The Docs, and the latest version
+can be found at https://mypy.readthedocs.io/en/latest.

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,2 @@
+Sphinx >= 1.4.4
+sphinx-rtd-theme >= 0.1.9


### PR DESCRIPTION
In preparation of addressing some of the open documentation issues, this PR gives contributors a simple way to set up an environment for working on the docs.

Additional text added to docs README about testing links in the documentation.