### PR TITLE
Correct errors and warnings in doc build

### DIFF
--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -132,7 +132,7 @@ For example, consider this code:
 Without a library stub, the type checker would have no way of
 inferring the type of ``x`` and checking that the argument to ``chr``
 has a valid type. Mypy incorporates the `typeshed
-<http://github.com/python/typeshed>`_ project, which contains library
+<https://github.com/python/typeshed>`_ project, which contains library
 stubs for the Python builtins and the standard library. The stub for
 the builtins contains a definition like this for ``chr``:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -135,7 +135,7 @@ else:
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -105,9 +105,9 @@ Why not use structural subtyping?
 *********************************
 
 Mypy primarily uses `nominal subtyping
-<http://en.wikipedia.org/wiki/Nominative_type_system>`_ instead of
+<https://en.wikipedia.org/wiki/Nominative_type_system>`_ instead of
 `structural subtyping
-<http://en.wikipedia.org/wiki/Structural_type_system>`_. Some argue
+<https://en.wikipedia.org/wiki/Structural_type_system>`_. Some argue
 that structural subtyping is better suited for languages with duck
 typing such as Python.
 
@@ -176,7 +176,7 @@ mypy programs.
 How is mypy different from Cython?
 **********************************
 
-`Cython <http://www.cython.org>`_ is a variant of Python that supports
+`Cython <http://cython.org/>`_ is a variant of Python that supports
 compilation to CPython C modules. It can give major speedups to
 certain classes of programs compared to CPython, and it provides
 static typing (though this is different from mypy). Mypy differs in

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,8 @@
 Welcome to Mypy documentation!
 ==============================
 
+Mypy is a static type checker for Python.
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ Welcome to Mypy documentation!
    planned_features
    command_line
    faq
+   cheat_sheet
    revision_history
 
 Indices and tables

--- a/docs/source/python2.rst
+++ b/docs/source/python2.rst
@@ -76,5 +76,5 @@ Additional notes
   within comments.
 
 - Mypy uses a separate set of library stub files in `typeshed
-  <http://github.com/python/typeshed>`_ for Python 2. Library support
+  <https://github.com/python/typeshed>`_ for Python 2. Library support
   may vary between Python 2 and Python 3.


### PR DESCRIPTION
This PR fixes errors and warnings found when running ``make build`` and ``make linkcheck``. 