### PR TITLE
Move [de]serialize() methods to SymbolNode.

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1778,7 +1778,7 @@ class SemanticAnalyzer(NodeVisitor):
                           "context".format(expr.name), expr)
             else:
                 expr.kind = n.kind
-                expr.node = (cast(Node, n.node))
+                expr.node = n.node
                 expr.fullname = n.fullname
 
     def visit_super_expr(self, expr: SuperExpr) -> None:


### PR DESCRIPTION
Reid's recent #1785 inspired me to move the (near) abstract base methods [de]serialize() from Node to SymbolNode, with no ill effect. I think the key was changing the type of RefExpr.node from Node to SymbolNode -- running mypy on itself suggested that this is how it's used, except for one cast that now disappeared!