### PR TITLE
Disallow ignoring blocking errors

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -188,7 +188,9 @@ class Errors:
         self.add_error_info(info)
 
     def add_error_info(self, info: ErrorInfo) -> None:
-        if info.file in self.ignored_lines and info.line in self.ignored_lines[info.file]:
+        if (info.file in self.ignored_lines and
+                info.line in self.ignored_lines[info.file] and
+                not info.blocker):
             # Annotation requests us to ignore all errors on this line.
             self.used_ignored_lines[info.file].add(info.line)
             return

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -195,3 +195,6 @@ def f() -> None: pass
 [out]
 main:3: error: Unexpected keyword argument "kw" for "f"
 tmp/m.py:2: note: "f" defined here
+
+[case testCannotIgnoreBlockingError]
+yield  # type: ignore  # E: 'yield' outside function


### PR DESCRIPTION
Users should not be able to # type: ignore blocking errors.  If mypy can't continue type checking, it should always fail and clearly say why.