### PR TITLE
Extend tests to check if mypy re-checks specific files during incremental mode

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -55,7 +55,6 @@ class BuildResult:
       files:   Dictionary from module name to related AST node.
       types:   Dictionary from parse tree node to its inferred type.
       errors:  List of error messages.
-      stale:   Set of stale modules that were rechecked
     """
 
     def __init__(self, manager: 'BuildManager') -> None:
@@ -63,7 +62,6 @@ class BuildResult:
         self.files = manager.modules
         self.types = manager.type_checker.type_map
         self.errors = manager.errors.messages()
-        self.stale = manager.stale_modules
 
 
 class BuildSource:

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -6,7 +6,7 @@ import re
 from os import remove, rmdir
 import shutil
 
-from typing import Callable, List, Tuple, Set
+from typing import Callable, List, Tuple, Set, Optional
 
 from mypy.myunit import TestCase, SkipTestCaseException
 

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -41,7 +41,7 @@ def parse_test_cases(
             i += 1
 
             files = []  # type: List[Tuple[str, str]] # path and contents
-            stale_modules = set(["__main__"])  # type: Set[str]  # module names
+            stale_modules = None  # type: Optional[Set[str]]  # module names
             while i < len(p) and p[i].id not in ['out', 'case']:
                 if p[i].id == 'file':
                     # Record an extra file needed for the test case.
@@ -58,8 +58,11 @@ def parse_test_cases(
                         fnam = '__builtin__.py'
                     files.append((os.path.join(base_path, fnam), f.read()))
                     f.close()
-                elif p[i].id in ('expectStale', 'expectstale'):
-                    stale_modules.update({item.strip() for item in p[i].arg.split(',')})
+                elif p[i].id == 'stale':
+                    if p[i].arg is None:
+                        stale_modules = set()
+                    else:
+                        stale_modules = {item.strip() for item in p[i].arg.split(',')}
                 else:
                     raise ValueError(
                         'Invalid section header {} in {} at line {}'.format(
@@ -103,7 +106,7 @@ class DataDrivenTestCase(TestCase):
 
     # (file path, file content) tuples
     files = None  # type: List[Tuple[str, str]]
-    expected_stale_modules = None  # type: Set[str]
+    expected_stale_modules = None  # type: Optional[Set[str]]
 
     clean_up = None  # type: List[Tuple[bool, str]]
 

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -6,7 +6,7 @@ import re
 from os import remove, rmdir
 import shutil
 
-from typing import Callable, List, Tuple
+from typing import Callable, List, Tuple, Set
 
 from mypy.myunit import TestCase, SkipTestCaseException
 
@@ -41,6 +41,7 @@ def parse_test_cases(
             i += 1
 
             files = []  # type: List[Tuple[str, str]] # path and contents
+            stale_modules = set(["__main__"])  # type: Set[str]  # module names
             while i < len(p) and p[i].id not in ['out', 'case']:
                 if p[i].id == 'file':
                     # Record an extra file needed for the test case.
@@ -57,6 +58,8 @@ def parse_test_cases(
                         fnam = '__builtin__.py'
                     files.append((os.path.join(base_path, fnam), f.read()))
                     f.close()
+                elif p[i].id in ('expectStale', 'expectstale'):
+                    stale_modules.update({item.strip() for item in p[i].arg.split(',')})
                 else:
                     raise ValueError(
                         'Invalid section header {} in {} at line {}'.format(
@@ -78,7 +81,8 @@ def parse_test_cases(
                 expand_errors(input, tcout, 'main')
                 lastline = p[i].line if i < len(p) else p[i - 1].line + 9999
                 tc = DataDrivenTestCase(p[i0].arg, input, tcout, path,
-                                        p[i0].line, lastline, perform, files)
+                                        p[i0].line, lastline, perform,
+                                        files, stale_modules)
                 out.append(tc)
         if not ok:
             raise ValueError(
@@ -99,11 +103,12 @@ class DataDrivenTestCase(TestCase):
 
     # (file path, file content) tuples
     files = None  # type: List[Tuple[str, str]]
+    expected_stale_modules = None  # type: Set[str]
 
     clean_up = None  # type: List[Tuple[bool, str]]
 
     def __init__(self, name, input, output, file, line, lastline,
-                 perform, files):
+                 perform, files, expected_stale_modules):
         super().__init__(name)
         self.input = input
         self.output = output
@@ -112,6 +117,7 @@ class DataDrivenTestCase(TestCase):
         self.line = line
         self.perform = perform
         self.files = files
+        self.expected_stale_modules = expected_stale_modules
 
     def set_up(self) -> None:
         super().set_up()

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -145,6 +145,11 @@ class TypeCheckSuite(Suite):
 
         if incremental and res:
             self.verify_cache(module_name, program_name, a, res.manager)
+            if incremental == 2:
+                assert_string_arrays_equal(
+                    list(sorted(testcase.expected_stale_modules)),
+                    list(sorted(res.stale)),
+                    'Set of stale modules does not match expected set')
 
     def verify_cache(self, module_name: str, program_name: str, a: List[str],
                      manager: build.BuildManager) -> None:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -4,6 +4,7 @@ import os.path
 import re
 import shutil
 import sys
+import time
 
 from typing import Tuple, List, Dict, Set
 
@@ -80,8 +81,10 @@ class TypeCheckSuite(Suite):
         if incremental:
             # Incremental tests are run once with a cold cache, once with a warm cache.
             # Expect success on first run, errors from testcase.output (if any) on second run.
+            # We briefly sleep to make sure file timestamps are distinct.
             self.clear_cache()
             self.run_test_once(testcase, 1)
+            time.sleep(0.1)
             self.run_test_once(testcase, 2)
         elif optional:
             try:
@@ -145,10 +148,10 @@ class TypeCheckSuite(Suite):
 
         if incremental and res:
             self.verify_cache(module_name, program_name, a, res.manager)
-            if incremental == 2:
+            if testcase.expected_stale_modules is not None and incremental == 2:
                 assert_string_arrays_equal(
                     list(sorted(testcase.expected_stale_modules)),
-                    list(sorted(res.stale)),
+                    list(sorted(res.manager.stale_modules.difference({"__main__"}))),
                     'Set of stale modules does not match expected set')
 
     def verify_cache(self, module_name: str, program_name: str, a: List[str],

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -53,17 +53,6 @@ def func2() -> None: mod3.func3()
 [file mod3.py]
 def func3() -> None: pass
 
-[file mod1.py.next]
-import mod2
-def func1() -> None: mod2.func2()
-
-[file mod2.py.next]
-import mod3
-def func2() -> None: mod3.func3()
-
-[file mod3.py.next]
-def func3() -> None: pass
-
 [out]
 
 
@@ -81,14 +70,6 @@ def func2() -> None: mod3.func3()
 
 [file mod3.py]
 def func3() -> None: pass
-
-[file mod1.py.next]
-import mod2
-def func1() -> None: mod2.func2()
-
-[file mod2.py.next]
-import mod3
-def func2() -> None: mod3.func3()
 
 [file mod3.py.next]
 def func3() -> int: return 2

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5,10 +5,10 @@
 -- The second time it must produce the errors given in the [out] section, if any.
 --
 -- Any files that we expect to be stale and rechecked should be annotated in
--- the [expectStale] section. The test suite will automatically assume that
+-- the [stale] annotation. The test suite will automatically assume that
 -- __main__ is stale so we can avoid constantly having to annotate it.
--- The list of stale files can be in any arbitrary order. You can have multiple
--- [expectStale] annotations per case: the test suite will union them together.
+-- The list of stale files can be in any arbitrary order, or can be left empty
+-- if no files should be stale.
 
 [case testIncrementalEmpty]
 [out]
@@ -21,7 +21,7 @@ def foo():
 [file m.py.next]
 def foo() -> None:
     pass
-[expectStale m]
+[stale m]
 [out]
 
 [case testIncrementalError]
@@ -32,7 +32,7 @@ def foo() -> None:
 [file m.py.next]
 def foo() -> None:
     bar()
-[expectStale m]
+[stale m]
 [out]
 main:1: note: In module imported here:
 tmp/m.py: note: In function "foo":
@@ -53,6 +53,7 @@ def func2() -> None: mod3.func3()
 [file mod3.py]
 def func3() -> None: pass
 
+[stale]
 [out]
 
 
@@ -74,7 +75,7 @@ def func3() -> None: pass
 [file mod3.py.next]
 def func3() -> int: return 2
 
-[expectStale mod1, mod2, mod3]
+[stale mod1, mod2, mod3]
 [out]
 
 [case testIncrementalSimpleBranchingModules]
@@ -90,9 +91,7 @@ def func() -> None: pass
 [file mod1.py.next]
 def func() -> int: return 1
 
-[file mod2.py.next]
-def func() -> None: pass
-
-[expectStale mod1]
+[stale mod1]
 [out]
+
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3,6 +3,12 @@
 -- The first time it must pass.
 -- Before it is run the second time, any *.py.next files are copied to *.py.
 -- The second time it must produce the errors given in the [out] section, if any.
+--
+-- Any files that we expect to be stale and rechecked should be annotated in
+-- the [expectStale] section. The test suite will automatically assume that
+-- __main__ is stale so we can avoid constantly having to annotate it.
+-- The list of stale files can be in any arbitrary order. You can have multiple
+-- [expectStale] annotations per case: the test suite will union them together.
 
 [case testIncrementalEmpty]
 [out]
@@ -15,6 +21,7 @@ def foo():
 [file m.py.next]
 def foo() -> None:
     pass
+[expectStale m]
 [out]
 
 [case testIncrementalError]
@@ -25,7 +32,86 @@ def foo() -> None:
 [file m.py.next]
 def foo() -> None:
     bar()
+[expectStale m]
 [out]
 main:1: note: In module imported here:
 tmp/m.py: note: In function "foo":
 tmp/m.py:2: error: Name 'bar' is not defined
+
+[case testIncrementalSimpleImportSequence]
+import mod1
+mod1.func1()
+
+[file mod1.py]
+import mod2
+def func1() -> None: mod2.func2()
+
+[file mod2.py]
+import mod3
+def func2() -> None: mod3.func3()
+
+[file mod3.py]
+def func3() -> None: pass
+
+[file mod1.py.next]
+import mod2
+def func1() -> None: mod2.func2()
+
+[file mod2.py.next]
+import mod3
+def func2() -> None: mod3.func3()
+
+[file mod3.py.next]
+def func3() -> None: pass
+
+[out]
+
+
+[case testIncrementalSimpleImportCascade]
+import mod1
+mod1.func1()
+
+[file mod1.py]
+import mod2
+def func1() -> None: mod2.func2()
+
+[file mod2.py]
+import mod3
+def func2() -> None: mod3.func3()
+
+[file mod3.py]
+def func3() -> None: pass
+
+[file mod1.py.next]
+import mod2
+def func1() -> None: mod2.func2()
+
+[file mod2.py.next]
+import mod3
+def func2() -> None: mod3.func3()
+
+[file mod3.py.next]
+def func3() -> int: return 2
+
+[expectStale mod1, mod2, mod3]
+[out]
+
+[case testIncrementalSimpleBranchingModules]
+import mod1
+import mod2
+
+[file mod1.py]
+def func() -> None: pass
+
+[file mod2.py]
+def func() -> None: pass
+
+[file mod1.py.next]
+def func() -> int: return 1
+
+[file mod2.py.next]
+def func() -> None: pass
+
+[expectStale mod1]
+[out]
+


### PR DESCRIPTION
This commit adds an `[expectStale ...]` annotation which, when added to incremental tests, will make sure that only the files listed in the annotation are rechecked by mypy during the second run in incremental mode.