### PR TITLE
Fix crash when function annotation has more args than function with fast parser

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -542,7 +542,7 @@ class SemanticAnalyzer(NodeVisitor):
             extra_anys = [AnyType()] * (len(fdef.arguments) - len(sig.arg_types))
             sig.arg_types.extend(extra_anys)
         elif len(sig.arg_types) > len(fdef.arguments):
-            self.fail('Type signature has too many arguments', fdef)
+            self.fail('Type signature has too many arguments', fdef, blocker=True)
 
     def visit_class_def(self, defn: ClassDef) -> None:
         self.clean_up_bases_and_infer_type_variables(defn)

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -154,3 +154,19 @@ def f(a,        # type: A
 [builtins fixtures/dict.py]
 [out]
 main: note: In function "f":
+
+[case testFasterParseTooManyArgumentsAnnotation]
+# options: fast_parser
+def f():  # E: Type signature has too many arguments
+    # type: (int) -> None
+    pass
+[out]
+main: note: In function "f":
+
+[case testFasterParseTooFewArgumentsAnnotation]
+# options: fast_parser
+def f(x):  # E: Type signature has too few arguments
+    # type: () -> None
+    pass
+[out]
+main: note: In function "f":


### PR DESCRIPTION
We currently crash when we have a function type comment that has more arguments than the function itself when running with the fast parser.  We actually already check for this error in two places: in the normal parser (which doesn't affect this case) and in the semantic analysis phase.  When the error is caught in the normal parser, this aborts further processing (because it's considered a parse error).  This PR makes the check in the semantic analysis phase produce a blocking error, which aborts further processing and prevents the crash later down the line (where the number of arguments is assumed to match).