### PR TITLE
Fix most errors reported by --disallow-untyped-defs/calls.

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -507,7 +507,7 @@ find_module_dir_cache = {}  # type: Dict[Tuple[str, Tuple[str, ...]], List[str]]
 find_module_listdir_cache = {}  # type: Dict[str, Optional[List[str]]]
 
 
-def find_module_clear_caches():
+def find_module_clear_caches() -> None:
     find_module_cache.clear()
     find_module_dir_cache.clear()
     find_module_listdir_cache.clear()
@@ -546,12 +546,11 @@ def is_file(path: str) -> bool:
     return os.path.isfile(path)
 
 
-def find_module(id: str, lib_path: Iterable[str]) -> str:
+def find_module(id: str, lib_path_arg: Iterable[str]) -> str:
     """Return the path of the module source file, or None if not found."""
-    if not isinstance(lib_path, tuple):
-        lib_path = tuple(lib_path)
+    lib_path = tuple(lib_path_arg)
 
-    def find():
+    def find() -> Optional[str]:
         # If we're looking for a module like 'foo.bar.baz', it's likely that most of the
         # many elements of lib_path don't even have a subdirectory 'foo/bar'.  Discover
         # that only once and cache it for when we look for modules like 'foo.bar.blah'
@@ -767,7 +766,7 @@ OPTIONS_AFFECTING_CACHE = [
 ]
 
 
-def random_string():
+def random_string() -> str:
     return binascii.hexlify(os.urandom(8)).decode('ascii')
 
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -167,7 +167,7 @@ class TypeChecker(NodeVisitor[Type]):
                 self.fail(messages.ALL_MUST_BE_SEQ_STR.format(str_seq_s, all_s),
                           all_.node)
 
-    def check_second_pass(self):
+    def check_second_pass(self) -> None:
         """Run second pass of type checking which goes through deferred nodes."""
         self.pass_num = 1
         for node, type_name in self.deferred_nodes:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1192,7 +1192,7 @@ class ExpressionChecker:
             e.method_type = method_type
             return result
 
-    def visit_tuple_slice_helper(self, left_type: TupleType, slic: SliceExpr):
+    def visit_tuple_slice_helper(self, left_type: TupleType, slic: SliceExpr) -> Type:
         begin = None  # type: int
         end = None  # type: int
         stride = None  # type:int
@@ -1469,7 +1469,7 @@ class ExpressionChecker:
         return self.check_call(constructor,
                                [gen.left_expr], [nodes.ARG_POS], gen)[0]
 
-    def visit_dictionary_comprehension(self, e: DictionaryComprehension):
+    def visit_dictionary_comprehension(self, e: DictionaryComprehension) -> Type:
         """Type check a dictionary comprehension."""
         self.check_for_comp(e)
 

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -25,10 +25,10 @@ class ConversionSpecifier:
         self.precision = precision
         self.type = type
 
-    def has_key(self):
+    def has_key(self) -> bool:
         return self.key is not None
 
-    def has_star(self):
+    def has_star(self) -> bool:
         return self.width == '*' or self.precision == '*'
 
 

--- a/mypy/docstring.py
+++ b/mypy/docstring.py
@@ -83,7 +83,7 @@ known_patterns = [
 
 
 class DocstringTypes(object):
-    def __init__(self):
+    def __init__(self) -> None:
         self.args = OrderedDict()  # type: Dict[str, Optional[str]]
         self.rettype = None  # type: Optional[str]
 
@@ -91,7 +91,7 @@ class DocstringTypes(object):
         return ('(' + ','.join([v or 'Any' for v in self.args.values()]) +
                 ') -> ' + (self.rettype or 'Any'))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr({'args': self.args, 'return': self.rettype})
 
 

--- a/mypy/docstring.py
+++ b/mypy/docstring.py
@@ -99,7 +99,7 @@ def wsprefix(s: str) -> str:
     return s[:len(s) - len(s.lstrip())]
 
 
-def scrubtype(typestr: Optional[str], only_known=False) -> Optional[str]:
+def scrubtype(typestr: Optional[str], only_known: bool =False) -> Optional[str]:
     if typestr is None:
         return typestr
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -597,16 +597,12 @@ class ASTConverter(ast35.NodeTransformer):
     # ListComp(expr elt, comprehension* generators)
     @with_line
     def visit_ListComp(self, n: ast35.ListComp) -> Node:
-        g = self.visit_GeneratorExp(cast(ast35.GeneratorExp, n))
-        assert isinstance(g, GeneratorExpr)
-        return ListComprehension(g)
+        return ListComprehension(self.visit_GeneratorExp(cast(ast35.GeneratorExp, n)))
 
     # SetComp(expr elt, comprehension* generators)
     @with_line
     def visit_SetComp(self, n: ast35.SetComp) -> Node:
-        g = self.visit_GeneratorExp(cast(ast35.GeneratorExp, n))
-        assert isinstance(g, GeneratorExpr)
-        return SetComprehension(g)
+        return SetComprehension(self.visit_GeneratorExp(cast(ast35.GeneratorExp, n)))
 
     # DictComp(expr key, expr value, comprehension* generators)
     @with_line

--- a/mypy/git.py
+++ b/mypy/git.py
@@ -70,7 +70,7 @@ def warn_no_git_executable() -> None:
           "git executable not in path.", file=sys.stderr)
 
 
-def warn_dirty(dir) -> None:
+def warn_dirty(dir: str) -> None:
     print("Warning: git module '{}' has uncommitted changes.".format(dir),
           file=sys.stderr)
     print("Go to the directory", file=sys.stderr)
@@ -78,7 +78,7 @@ def warn_dirty(dir) -> None:
     print("and commit or reset your changes", file=sys.stderr)
 
 
-def warn_extra_files(dir) -> None:
+def warn_extra_files(dir: str) -> None:
     print("Warning: git module '{}' has untracked files.".format(dir),
           file=sys.stderr)
     print("Go to the directory", file=sys.stderr)
@@ -86,7 +86,7 @@ def warn_extra_files(dir) -> None:
     print("and add & commit your new files.", file=sys.stderr)
 
 
-def chdir_prefix(dir) -> str:
+def chdir_prefix(dir: str) -> str:
     """Return the command to change to the target directory, plus '&&'."""
     if os.path.relpath(dir) != ".":
         return "cd " + pipes.quote(dir) + " && "

--- a/mypy/lex.py
+++ b/mypy/lex.py
@@ -142,7 +142,7 @@ class LexError(Token):
         self.type = type
         self.message = message
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.message:
             return 'LexError(%s)' % self.message
         else:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -86,7 +86,7 @@ MYPYPATH     additional module search path"""
 
 
 class SplitNamespace:
-    def __init__(self, standard_namespace, alt_namespace, alt_prefix) -> None:
+    def __init__(self, standard_namespace: object, alt_namespace: object, alt_prefix: str) -> None:
         self.__dict__['_standard_namespace'] = standard_namespace
         self.__dict__['_alt_namespace'] = alt_namespace
         self.__dict__['_alt_prefix'] = alt_prefix
@@ -121,7 +121,7 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
     parser = argparse.ArgumentParser(prog='mypy', epilog=FOOTER,
                                      formatter_class=help_factory)
 
-    def parse_version(v) -> Tuple[int, int]:
+    def parse_version(v: str) -> Tuple[int, int]:
         m = re.match(r'\A(\d)\.(\d+)\Z', v)
         if m:
             return int(m.group(1)), int(m.group(2))

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 
-from typing import Optional, Dict, List, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from mypy import build
 from mypy import defaults
@@ -86,21 +86,21 @@ MYPYPATH     additional module search path"""
 
 
 class SplitNamespace:
-    def __init__(self, standard_namespace, alt_namespace, alt_prefix):
+    def __init__(self, standard_namespace, alt_namespace, alt_prefix) -> None:
         self.__dict__['_standard_namespace'] = standard_namespace
         self.__dict__['_alt_namespace'] = alt_namespace
         self.__dict__['_alt_prefix'] = alt_prefix
 
-    def _get(self):
+    def _get(self) -> Tuple[Any, Any]:
         return (self._standard_namespace, self._alt_namespace)
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
         if name.startswith(self._alt_prefix):
             setattr(self._alt_namespace, name[len(self._alt_prefix):], value)
         else:
             setattr(self._standard_namespace, name, value)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         if name.startswith(self._alt_prefix):
             return getattr(self._alt_namespace, name[len(self._alt_prefix):])
         else:
@@ -121,7 +121,7 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
     parser = argparse.ArgumentParser(prog='mypy', epilog=FOOTER,
                                      formatter_class=help_factory)
 
-    def parse_version(v):
+    def parse_version(v) -> Tuple[int, int]:
         m = re.match(r'\A(\d)\.(\d+)\Z', v)
         if m:
             return int(m.group(1)), int(m.group(2))

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -270,10 +270,10 @@ class TypeMeetVisitor(TypeVisitor[Type]):
         else:
             return self.default(self.s)
 
-    def meet(self, s, t):
+    def meet(self, s: Type, t: Type) -> Type:
         return meet_types(s, t)
 
-    def default(self, typ):
+    def default(self, typ: Type) -> Type:
         if isinstance(typ, UnboundType):
             return AnyType()
         elif isinstance(typ, Void) or isinstance(typ, ErrorType):

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -343,6 +343,12 @@ class OverloadedFuncDef(FuncBase, Statement):
 class Argument(Node):
     """A single argument in a FuncItem."""
 
+    variable = None  # type: Var
+    type_annotation = None  # type: Optional[mypy.types.Type]
+    initializater = None  # type: Optional[Expression]
+    kind = None  # type: int
+    initialization_statement = None  # type: Optional[AssignmentStmt]
+
     def __init__(self, variable: 'Var', type_annotation: 'Optional[mypy.types.Type]',
             initializer: Optional[Expression], kind: int,
             initialization_statement: Optional['AssignmentStmt'] = None) -> None:
@@ -438,7 +444,7 @@ class FuncItem(FuncBase):
             arg.set_line(self.line)
         return self
 
-    def is_dynamic(self):
+    def is_dynamic(self) -> bool:
         return self.type is None
 
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -1,5 +1,6 @@
 from mypy import defaults
 import pprint
+from typing import Any
 
 
 class BuildType:
@@ -55,11 +56,11 @@ class Options:
         self.fast_parser = False
         self.incremental = False
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         return self.__class__ == other.__class__ and self.__dict__ == other.__dict__
 
-    def __ne__(self, other):
+    def __ne__(self, other: Any) -> bool:
         return not self == other
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'Options({})'.format(pprint.pformat(self.__dict__))

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -56,10 +56,10 @@ class Options:
         self.fast_parser = False
         self.incremental = False
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         return self.__class__ == other.__class__ and self.__dict__ == other.__dict__
 
-    def __ne__(self, other: Any) -> bool:
+    def __ne__(self, other: object) -> bool:
         return not self == other
 
     def __repr__(self) -> str:

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -2000,7 +2000,7 @@ if __name__ == '__main__':
     # Parse a file and dump the AST (or display errors).
     import sys
 
-    def usage():
+    def usage() -> None:
         print('Usage: parse.py [--py2] [--quiet] FILE [...]', file=sys.stderr)
         sys.exit(2)
 

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -1528,7 +1528,7 @@ class Parser:
         expr = SetExpr(items)
         return expr
 
-    def parse_set_comprehension(self, expr: Node):
+    def parse_set_comprehension(self, expr: Node) -> SetComprehension:
         gen = self.parse_generator_expr(expr)
         self.expect('}')
         set_comp = SetComprehension(gen)

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -64,7 +64,7 @@ class FuncCounterVisitor(TraverserVisitor):
         super().__init__()
         self.counts = [0, 0]
 
-    def visit_func_def(self, defn: FuncDef):
+    def visit_func_def(self, defn: FuncDef) -> None:
         self.counts[defn.type is not None] += 1
 
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -605,7 +605,7 @@ class SemanticAnalyzer(NodeVisitor):
     def analyze_class_decorator(self, defn: ClassDef, decorator: Node) -> None:
         decorator.accept(self)
 
-    def setup_is_builtinclass(self, defn: ClassDef):
+    def setup_is_builtinclass(self, defn: ClassDef) -> None:
         for decorator in defn.decorators:
             if refers_to_fullname(decorator, 'typing.builtinclass'):
                 defn.is_builtinclass = True

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -12,7 +12,7 @@ from mypy import experiments
 
 
 def solve_constraints(vars: List[TypeVarId], constraints: List[Constraint],
-                      strict=True) -> List[Type]:
+                      strict: bool =True) -> List[Type]:
     """Solve type constraints.
 
     Return the best type(s) for type variables; each type can be None if the value of the variable

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -3,7 +3,7 @@
 import re
 import os
 
-import typing
+from typing import Any, List
 
 from mypy.util import dump_tagged, short_type
 import mypy.nodes
@@ -21,7 +21,7 @@ class StrConv(NodeVisitor[str]):
         ExpressionStmt:1(
           IntExpr(1)))
     """
-    def dump(self, nodes, obj):
+    def dump(self, nodes: List[Any], obj: 'mypy.nodes.Node') -> str:
         """Convert a list of items to a multiline pretty-printed string.
 
         The tag is produced from the type name of obj and its line
@@ -30,7 +30,7 @@ class StrConv(NodeVisitor[str]):
         """
         return dump_tagged(nodes, short_type(obj) + ':' + str(obj.line))
 
-    def func_helper(self, o):
+    def func_helper(self, o: 'mypy.nodes.FuncItem') -> List[Any]:
         """Return a list in a format suitable for dump() that represents the
         arguments and the body of a function. The caller can then decorate the
         array with information specific to methods, global functions or
@@ -50,7 +50,7 @@ class StrConv(NodeVisitor[str]):
                 extra.append(('VarArg', [o.arguments[i].variable]))
             elif kind == mypy.nodes.ARG_STAR2:
                 extra.append(('DictVarArg', [o.arguments[i].variable]))
-        a = []
+        a = []  # type: List[Any]
         if args:
             a.append(('Args', args))
         if o.type:
@@ -65,9 +65,9 @@ class StrConv(NodeVisitor[str]):
 
     # Top-level structures
 
-    def visit_mypy_file(self, o):
+    def visit_mypy_file(self, o: 'mypy.nodes.MypyFile') -> str:
         # Skip implicit definitions.
-        a = [o.defs]
+        a = [o.defs]  # type: List[Any]
         if o.is_bom:
             a.insert(0, 'BOM')
         # Omit path to special file with name "main". This is used to simplify
@@ -82,7 +82,7 @@ class StrConv(NodeVisitor[str]):
                                                     for line in sorted(o.ignored_lines)))
         return self.dump(a, o)
 
-    def visit_import(self, o):
+    def visit_import(self, o: 'mypy.nodes.Import') -> str:
         a = []
         for id, as_id in o.ids:
             if as_id is not None:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -58,7 +58,7 @@ def is_subtype_ignoring_tvars(left: Type, right: Type) -> bool:
 
 
 def is_equivalent(a: Type, b: Type,
-                  type_parameter_checker=check_type_parameter) -> bool:
+                  type_parameter_checker: TypeParameterChecker = check_type_parameter) -> bool:
     return is_subtype(a, b, type_parameter_checker) and is_subtype(b, a, type_parameter_checker)
 
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -236,7 +236,7 @@ class TypeList(Type):
 class AnyType(Type):
     """The type 'Any'."""
 
-    def __init__(self, implicit=False, line: int = -1) -> None:
+    def __init__(self, implicit: bool = False, line: int = -1) -> None:
         super().__init__(line)
         self.implicit = implicit
 
@@ -538,9 +538,9 @@ class CallableType(FunctionLike):
                  variables: List[TypeVarDef] = None,
                  line: int = -1,
                  is_ellipsis_args: bool = False,
-                 implicit=False,
-                 is_classmethod_class=False,
-                 special_sig=None,
+                 implicit: bool = False,
+                 is_classmethod_class: bool = False,
+                 special_sig: Optional[str] = None,
                  ) -> None:
         if variables is None:
             variables = []

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1131,41 +1131,41 @@ class TypeStrVisitor(TypeVisitor[str]):
      - Represent the NoneTyp type as None.
     """
 
-    def visit_unbound_type(self, t):
+    def visit_unbound_type(self, t: UnboundType)-> str:
         s = t.name + '?'
         if t.args != []:
             s += '[{}]'.format(self.list_str(t.args))
         return s
 
-    def visit_type_list(self, t):
+    def visit_type_list(self, t: TypeList) -> str:
         return '<TypeList {}>'.format(self.list_str(t.items))
 
-    def visit_error_type(self, t):
+    def visit_error_type(self, t: ErrorType) -> str:
         return '<ERROR>'
 
-    def visit_any(self, t):
+    def visit_any(self, t: AnyType) -> str:
         return 'Any'
 
-    def visit_void(self, t):
+    def visit_void(self, t: Void) -> str:
         return 'void'
 
-    def visit_none_type(self, t):
+    def visit_none_type(self, t: NoneTyp) -> str:
         # Fully qualify to make this distinct from the None value.
         return "builtins.None"
 
-    def visit_uninhabited_type(self, t):
+    def visit_uninhabited_type(self, t: UninhabitedType) -> str:
         return "<uninhabited>"
 
-    def visit_erased_type(self, t):
+    def visit_erased_type(self, t: ErasedType) -> str:
         return "<Erased>"
 
-    def visit_deleted_type(self, t):
+    def visit_deleted_type(self, t: DeletedType) -> str:
         if t.source is None:
             return "<Deleted>"
         else:
             return "<Deleted '{}'>".format(t.source)
 
-    def visit_instance(self, t):
+    def visit_instance(self, t: Instance) -> str:
         s = t.type.fullname() if t.type is not None else '<?>'
         if t.erased:
             s += '*'
@@ -1173,7 +1173,7 @@ class TypeStrVisitor(TypeVisitor[str]):
             s += '[{}]'.format(self.list_str(t.args))
         return s
 
-    def visit_type_var(self, t):
+    def visit_type_var(self, t: TypeVarType) -> str:
         if t.name is None:
             # Anonymous type variable type (only numeric id).
             return '`{}'.format(t.id)
@@ -1181,7 +1181,7 @@ class TypeStrVisitor(TypeVisitor[str]):
             # Named type variable type.
             return '{}`{}'.format(t.name, t.id)
 
-    def visit_callable_type(self, t):
+    def visit_callable_type(self, t: CallableType) -> str:
         s = ''
         bare_asterisk = False
         for i in range(len(t.arg_types)):
@@ -1210,13 +1210,13 @@ class TypeStrVisitor(TypeVisitor[str]):
 
         return 'def {}'.format(s)
 
-    def visit_overloaded(self, t):
+    def visit_overloaded(self, t: Overloaded) -> str:
         a = []
         for i in t.items():
             a.append(i.accept(self))
         return 'Overload({})'.format(', '.join(a))
 
-    def visit_tuple_type(self, t):
+    def visit_tuple_type(self, t: TupleType) -> str:
         s = self.list_str(t.items)
         if t.fallback and t.fallback.type:
             fallback_name = t.fallback.type.fullname()
@@ -1224,11 +1224,11 @@ class TypeStrVisitor(TypeVisitor[str]):
                 return 'Tuple[{}, fallback={}]'.format(s, t.fallback.accept(self))
         return 'Tuple[{}]'.format(s)
 
-    def visit_star_type(self, t):
+    def visit_star_type(self, t: StarType) -> str:
         s = t.type.accept(self)
         return '*{}'.format(s)
 
-    def visit_union_type(self, t):
+    def visit_union_type(self, t: UnionType) -> str:
         s = self.list_str(t.items)
         return 'Union[{}]'.format(s)
 
@@ -1239,13 +1239,13 @@ class TypeStrVisitor(TypeVisitor[str]):
             return '<partial {}[{}]>'.format(t.type.name(),
                                              ', '.join(['?'] * len(t.type.type_vars)))
 
-    def visit_ellipsis_type(self, t):
+    def visit_ellipsis_type(self, t: EllipsisType) -> str:
         return '...'
 
-    def visit_type_type(self, t):
+    def visit_type_type(self, t: TypeType) -> str:
         return 'Type[{}]'.format(t.item.accept(self))
 
-    def list_str(self, a):
+    def list_str(self, a: List[Type]) -> str:
         """Convert items of an array to strings (pretty-print types)
         and join the results with commas.
         """


### PR DESCRIPTION
I didn't get to everything:

- A whole bunch of untyped calls are left in strconv.py; this code
  uses a few nasty data types (a list of strings and variously-sized
  tuples) and a ton of node types from nodes, and I got tired of
  typing.

- A few untyped stdlib calls are left because the stubs for traceback
  and argparse are basically untyped.

- A few nested functions where I couldn't figure out the argument
  types; here I used some Any types so no errors are reported.