### PR TITLE
fix typeshed sync

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -215,7 +215,8 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
 
     options = Options()
     special_opts = argparse.Namespace()
-    parser.parse_args(args, SplitNamespace(options, special_opts, 'special-opts:'))
+    namespace = SplitNamespace(options, special_opts, 'special-opts:')
+    parser.parse_args(args, namespace)  # type: ignore
 
     # --use-python-path is no longer supported; explain why.
     if special_opts.use_python_path:

--- a/test-data/stdlib-samples/3.2/test/test_random.py
+++ b/test-data/stdlib-samples/3.2/test/test_random.py
@@ -46,7 +46,7 @@ class TestBasicOps(unittest.TestCase, Generic[RT]):
         for arg in [list(range(3)), {'one': 1}]:
             self.assertRaises(TypeError, self.gen.seed, arg)
         self.assertRaises(TypeError, self.gen.seed, 1, 2, 3, 4)
-        self.assertRaises(TypeError, type(self.gen), [])
+        self.assertRaises(TypeError, type(self.gen), [])  # type: ignore
 
     def test_choice(self) -> None:
         choice = self.gen.choice

--- a/test-data/stdlib-samples/3.2/test/test_shutil.py
+++ b/test-data/stdlib-samples/3.2/test/test_shutil.py
@@ -442,7 +442,7 @@ class TestShutil(unittest.TestCase):
             self.assertEqual(getattr(file1_stat, 'st_flags'),
                              getattr(file2_stat, 'st_flags'))
 
-    @unittest.skipUnless(zlib, "requires zlib")
+    @unittest.skipUnless(zlib is not None, "requires zlib")
     def test_make_tarball(self) -> None:
         # creating something to tar
         tmpdir = self.mkdtemp()
@@ -505,8 +505,8 @@ class TestShutil(unittest.TestCase):
         base_name = os.path.join(tmpdir2, 'archive')
         return tmpdir, tmpdir2, base_name
 
-    @unittest.skipUnless(zlib, "Requires zlib")
-    @unittest.skipUnless(find_executable('tar') and find_executable('gzip'),
+    @unittest.skipUnless(zlib is not None, "Requires zlib")
+    @unittest.skipUnless((find_executable('tar') and find_executable('gzip')) is not None,
                          'Need the tar command to run')
     def test_tarfile_vs_tar(self) -> None:
         tmpdir, tmpdir2, base_name =  self._create_files()
@@ -560,7 +560,7 @@ class TestShutil(unittest.TestCase):
         tarball = base_name + '.tar'
         self.assertTrue(os.path.exists(tarball))
 
-    @unittest.skipUnless(zlib, "Requires zlib")
+    @unittest.skipUnless(zlib is not None, "Requires zlib")
     @unittest.skipUnless(ZIP_SUPPORT, 'Need zip support to run')
     def test_make_zipfile(self) -> None:
         # creating something to tar
@@ -584,7 +584,7 @@ class TestShutil(unittest.TestCase):
         base_name = os.path.join(tmpdir, 'archive')
         self.assertRaises(ValueError, make_archive, base_name, 'xxx')
 
-    @unittest.skipUnless(zlib, "Requires zlib")
+    @unittest.skipUnless(zlib is not None, "Requires zlib")
     def test_make_archive_owner_group(self) -> None:
         # testing make_archive with owner and group, with various combinations
         # this works even if there's not gid/uid support
@@ -612,7 +612,7 @@ class TestShutil(unittest.TestCase):
         self.assertTrue(os.path.exists(res))
 
 
-    @unittest.skipUnless(zlib, "Requires zlib")
+    @unittest.skipUnless(zlib is not None, "Requires zlib")
     @unittest.skipUnless(UID_GID_SUPPORT, "Requires grp and pwd support")
     def test_tarfile_root_owner(self) -> None:
         tmpdir, tmpdir2, base_name =  self._create_files()
@@ -683,7 +683,7 @@ class TestShutil(unittest.TestCase):
                     diff.append(file_)
         return diff
 
-    @unittest.skipUnless(zlib, "Requires zlib")
+    @unittest.skipUnless(zlib is not None, "Requires zlib")
     def test_unpack_archive(self) -> None:
         formats = ['tar', 'gztar', 'zip']
         if BZ2_SUPPORTED:


### PR DESCRIPTION
Currently, syncing typeshed fail with mypy, mainly because of [typeshed#344](https://github.com/python/typeshed/pull/344). This PR works around it. This doesn't sync it, simply will avoid issue while doing it.

In itself, the stubs are correct, it's more related to how mypy handle some cases, here a short list
 * `type()` should be `Callable`, see #1831
 * `bool` can be anything which do not evaluated to `False` (which is not the case by default), which is quite an issue with method expecting a `bool` (more precisely, something that evaluate to `bool`), see #1730

I've also added a line for [typeshed#352](https://github.com/python/typeshed/pull/352).