### PR TITLE
Copy line number to func_type.

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -287,6 +287,7 @@ class ASTConverter(ast35.NodeTransformer):
                        func_type)
         if func_type is not None:
             func_type.definition = func_def
+            func_type.line = n.lineno
 
         if n.decorator_list:
             var = Var(func_def.name())


### PR DESCRIPTION
With `--fast-parser` I got a bunch of errors without line numbers (in particular `The return type of a generator function should be "Generator" or one of its supertypes`). I tracked it down to this place.