### PR TITLE
Add flag to set custom mypy cache directory

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -706,7 +706,7 @@ def find_cache_meta(id: str, path: str, manager: BuildManager) -> Optional[Cache
     """
     # TODO: May need to take more build options into account
     meta_json, data_json = get_cache_names(
-            id, path, manager.options.cache_dir, manager.options.python_version)
+        id, path, manager.options.cache_dir, manager.options.python_version)
     manager.trace('Looking for {} {}'.format(id, data_json))
     if not os.path.exists(meta_json):
         return None
@@ -796,7 +796,7 @@ def write_cache(id: str, path: str, tree: MypyFile,
     mtime = st.st_mtime
     size = st.st_size
     meta_json, data_json = get_cache_names(
-            id, path, manager.options.cache_dir, manager.options.python_version)
+        id, path, manager.options.cache_dir, manager.options.python_version)
     manager.log('Writing {} {} {}'.format(id, meta_json, data_json))
     data = tree.serialize()
     parent = os.path.dirname(data_json)

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -1,2 +1,3 @@
 PYTHON2_VERSION = (2, 7)
 PYTHON3_VERSION = (3, 5)
+MYPY_CACHE = '.mypy_cache'

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -166,6 +166,9 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
                         help="enable experimental fast parser")
     parser.add_argument('-i', '--incremental', action='store_true',
                         help="enable experimental module cache")
+    parser.add_argument('--cache-dir', action='store', metavar='DIR',
+                        help="store module cache info in the given folder in incremental mode "
+                        "(defaults to '{}')".format(defaults.MYPY_CACHE))
     parser.add_argument('--strict-optional', action='store_true',
                         dest='special-opts:strict_optional',
                         help="enable experimental strict Optional checks")

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -55,6 +55,7 @@ class Options:
         # -- experimental options --
         self.fast_parser = False
         self.incremental = False
+        self.cache_dir = defaults.MYPY_CACHE
 
     def __eq__(self, other: object) -> bool:
         return self.__class__ == other.__class__ and self.__dict__ == other.__dict__

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -8,7 +8,7 @@ import time
 
 from typing import Tuple, List, Dict, Set
 
-from mypy import build
+from mypy import build, defaults
 import mypy.myunit  # for mutable globals (ick!)
 from mypy.build import BuildSource, find_module_clear_caches
 from mypy.myunit import Suite, AssertionFailure
@@ -96,7 +96,7 @@ class TypeCheckSuite(Suite):
             self.run_test_once(testcase)
 
     def clear_cache(self) -> None:
-        dn = build.MYPY_CACHE
+        dn = defaults.MYPY_CACHE
 
         if os.path.exists(dn):
             shutil.rmtree(dn)


### PR DESCRIPTION
This pull request implements https://github.com/python/mypy/issues/1414 by adding the `--cache-dir` command line flag. Mypy will continue to default to using `.mypy_cache` when the flag is omitted.

The flag is a no-op if incremental mode is not enabled.

Usage:

    mypy --cache-dir ../custom-cache --incremental my_module