### PR TITLE
Fix importing new files in incremental mode

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -281,7 +281,7 @@ CacheMeta = NamedTuple('CacheMeta',
                         ('data_mtime', float),  # mtime of data_json
                         ('data_json', str),  # path of <id>.data.json
                         ('suppressed', List[str]),  # dependencies that weren't imported
-                        ('child_modules', Set[str]),  # all submodules of the given module
+                        ('child_modules', List[str]),  # all submodules of the given module
                         ('options', Optional[Dict[str, bool]]),  # build options
                         ('dep_prios', List[int]),
                         ])
@@ -727,7 +727,7 @@ def find_cache_meta(id: str, path: str, manager: BuildManager) -> Optional[Cache
         meta.get('data_mtime'),
         data_json,
         meta.get('suppressed', []),
-        set(meta.get('child_modules', set())),
+        meta.get('child_modules', []),
         meta.get('options'),
         meta.get('dep_prios', []),
     )
@@ -1157,12 +1157,11 @@ class State:
         # dependency is added back we find out later in the process.
         return (self.meta is not None
                 and self.dependencies == self.meta.dependencies
-                and self.child_modules == self.meta.child_modules)
+                and self.child_modules == set(self.meta.child_modules))
 
     def has_new_submodules(self) -> bool:
-        """Returns whether this module has any new submodules after it was
-        loaded from a warm cache in incremental mode."""
-        return self.meta is not None and self.child_modules != self.meta.child_modules
+        """Return if this module has new submodules after being loaded from a warm cache."""
+        return self.meta is not None and self.child_modules != set(self.meta.child_modules)
 
     def mark_stale(self) -> None:
         """Throw away the cache data for this file, marking it as stale."""

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -124,6 +124,7 @@ class DataDrivenTestCase(TestCase):
 
     def set_up(self) -> None:
         super().set_up()
+        encountered_files = set()
         self.clean_up = []
         for path, content in self.files:
             dir = os.path.dirname(path)
@@ -133,6 +134,13 @@ class DataDrivenTestCase(TestCase):
             f.write(content)
             f.close()
             self.clean_up.append((False, path))
+            encountered_files.add(path)
+            if path.endswith(".next"):
+                # Make sure new files introduced in the second run are accounted for
+                renamed_path = path[:-5]
+                if renamed_path not in encountered_files:
+                    encountered_files.add(renamed_path)
+                    self.clean_up.append((False, renamed_path))
 
     def add_dirs(self, dir: str) -> List[str]:
         """Add all subdirectories required to create dir.

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -155,3 +155,19 @@ import parent.a
 [builtins fixtures/args.py]
 [stale]
 [out]
+
+[case testIncrementalFoo]
+from parent import a
+
+[file parent/__init__.py]
+
+[file parent/a.py]
+
+[file parent/a.py.next]
+from parent import b
+
+[file parent/b.py.next]
+
+[stale parent.a, parent.b]
+[out]
+

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -156,7 +156,7 @@ import parent.a
 [stale]
 [out]
 
-[case testIncrementalFoo]
+[case testIncrementalReferenceNewFileWithImportFrom]
 from parent import a
 
 [file parent/__init__.py]
@@ -168,6 +168,20 @@ from parent import b
 
 [file parent/b.py.next]
 
-[stale parent.a, parent.b]
+[stale parent, parent.a, parent.b]
 [out]
 
+[case testIncrementalReferenceExistingFileWithImportFrom]
+from parent import a, b
+
+[file parent/__init__.py]
+
+[file parent/a.py]
+
+[file parent/b.py]
+
+[file parent/a.py.next]
+from parent import b
+
+[stale parent.a]
+[out]


### PR DESCRIPTION
This pull request makes mypy re-parse `__init__.py` files within modules when a new file is added to that module before incremental mode is run a second time.

Previously, when a file was modified to contain a new "from x import y" statement where "y" is the newly created submodule, mypy would assume that "y" was instead a new attribute added to the "x" module.

See #1848 for more details.