### PR TITLE
[1851] Tuple[int] considered with Container[T]

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -278,6 +278,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             return self.infer_against_any(template.args)
         if (isinstance(actual, TupleType) and
             (is_named_instance(template, 'typing.Iterable') or
+             is_named_instance(template, 'typing.Container') or
              is_named_instance(template, 'typing.Sequence') or
              is_named_instance(template, 'typing.Reversible'))
                 and self.direction == SUPERTYPE_OF):

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -856,4 +856,4 @@ g = f3
 from typing import TypeVar, Container
 T = TypeVar('T')
 def f(x: Container[T]) -> T: ...
-f((1, 2))
+reveal_type(f((1, 2))) # E: Revealed type is 'builtins.int*'

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -851,3 +851,9 @@ def f3(x: A, y: B) -> B: ...
 g = f1
 g = f2
 g = f3
+
+[case testTypeVariableWithContainerAndTuple]
+from typing import TypeVar, Container
+T = TypeVar('T')
+def f(x: Container[T]) -> T: ...
+f((1, 2))


### PR DESCRIPTION
Fixes #1851 

Previously, this didn't work - generic variables were not supported with `Container`:

```python
from typing import TypeVar, Container
T = TypeVar('T')
def f(x: Container[T]) -> T: ...
f((1, 2))
```

I'm receptive to suggestions regarding 1) the name of the test and 2) the location of the test. Because this concerned generic variables, I put it in `test-data/unit/check-generics.test`, but I'm not 100% sure this is the right place.