### PR TITLE
Fixes unhighlighted code in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ There is an experimental feature to generate coverage reports.  To use
 this feature, you need to `pip install lxml`.  This is an extension
 module and requires various library headers to install; on a
 Debian-derived system the command
-  apt-get install python3-dev libxml2-dev libxslt1-dev
+  `apt-get install python3-dev libxml2-dev libxslt1-dev`
 may provide the necessary dependencies.
 
 To use the feature, pass e.g. `--txt-report "$(mktemp -d)"`.


### PR DESCRIPTION
Small error, but I found it in the README file while reading it. For ease of discovery, apt-get install python3-dev libxml2-dev libxslt1-dev should be displayed as `apt-get install python3-dev libxml2-dev libxslt1-dev`.