### PR TITLE
Introduce import order linting

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1,7 +1,7 @@
 from functools import wraps
 import sys
-
 from typing import Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, cast, List
+
 from mypy.nodes import (
     MypyFile, Node, ImportBase, Import, ImportAll, ImportFrom, FuncDef, OverloadedFuncDef,
     ClassDef, Decorator, Block, Var, OperatorAssignmentStmt,

--- a/mypy/lex.py
+++ b/mypy/lex.py
@@ -7,10 +7,10 @@ This module can be run as a script (lex.py FILE).
 """
 
 import re
+from typing import List, Callable, Dict, Any, Match, Pattern, Set, Union, Tuple
 
 from mypy.util import short_type, find_python_encoding
 from mypy import defaults
-from typing import List, Callable, Dict, Any, Match, Pattern, Set, Union, Tuple
 
 
 class Token:

--- a/mypy/myunit/__main__.py
+++ b/mypy/myunit/__main__.py
@@ -4,14 +4,14 @@
 Usually used as a slave by runtests.py, but can be used directly.
 """
 
-from mypy.myunit import main
-
 # In Python 3.3, mypy.__path__ contains a relative path to the mypy module
 # (whereas in later Python versions it contains an absolute path).  Because the
 # test runner changes directories, this breaks non-toplevel mypy imports.  We
 # fix that problem by fixing up the path to be absolute here.
 import os.path
+
 import mypy
+from mypy.myunit import main
 # User-defined packages always have __path__ attributes, but mypy doesn't know that.
 mypy.__path__ = [os.path.abspath(p) for p in mypy.__path__]  # type: ignore
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -1,6 +1,7 @@
-from mypy import defaults
 import pprint
 from typing import Any
+
+from mypy import defaults
 
 
 class BuildType:

--- a/mypy/test/testargs.py
+++ b/mypy/test/testargs.py
@@ -6,6 +6,7 @@ object it creates.
 """
 
 import typing
+
 from mypy.myunit import Suite, assert_equal
 from mypy.options import Options, BuildType
 from mypy.main import process_options

--- a/runtests.py
+++ b/runtests.py
@@ -25,12 +25,11 @@ if True:
 
 
 from typing import Dict, List, Optional, Set, Iterable
+import itertools
+import os
 
 from mypy.waiter import Waiter, LazySubprocess
 from mypy import git, util
-
-import itertools
-import os
 
 
 # Ideally, all tests would be `discover`able so that they can be driven

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,5 @@ exclude = mypy/codec/*
 #   E704: multiple statements on one line (def)
 #   E402: module level import not at top of file
 ignore = E251,E128,F401,W601,E701,W503,E704,E402
+import-order-style = pep8
+application-import-names = mypy

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ if sys.version_info < (3, 2, 0):
     exit(1)
 
 from distutils.core import setup
+
 from mypy.version import __version__
 from mypy import git
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 flake8
+flake8-import-order
 typed-ast


### PR DESCRIPTION
This commit alters the code to conform to the PEP8 specification that
imports should be grouped and ordered[1] and adds flake8-import-order
to continue to lint the import ordering.

[1]: In summary from
https://www.python.org/dev/peps/pep-0008/#imports, the specified style
is:
```
Imports should be grouped in the following order:

standard library imports
related third party imports
local application/library specific imports

You should put a blank line between each group of imports.
```
Also see https://github.com/PyCQA/flake8-import-order