### PR TITLE
[1842] Abstract methods indicator message 

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -767,7 +767,7 @@ class MessageBuilder:
     def cannot_instantiate_abstract_class(self, class_name: str,
                                           abstract_attributes: List[str],
                                           context: Context) -> None:
-        attrs = format_string_list("'%s'" % a for a in abstract_attributes[:5])
+        attrs = format_string_list("'%s'" % a for a in abstract_attributes)
         self.fail("Cannot instantiate abstract class '%s' with abstract "
                   "attribute%s %s" % (class_name, plural_s(abstract_attributes),
                                    attrs),
@@ -881,8 +881,10 @@ def format_string_list(s: Iterable[str]) -> str:
     assert len(l) > 0
     if len(l) == 1:
         return l[0]
-    else:
+    elif len(l) <= 5:
         return '%s and %s' % (', '.join(l[:-1]), l[-1])
+    else:
+        return '%s, ... and %s (%i methods suppressed)' % (', '.join(l[:4]), l[-1], len(l) - 5)
 
 
 def callable_name(type: CallableType) -> str:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -884,7 +884,7 @@ def format_string_list(s: Iterable[str]) -> str:
     elif len(l) <= 5:
         return '%s and %s' % (', '.join(l[:-1]), l[-1])
     else:
-        return '%s, ... and %s (%i methods suppressed)' % (', '.join(l[:4]), l[-1], len(l) - 5)
+        return '%s, ... and %s (%i methods suppressed)' % (', '.join(l[:2]), l[-1], len(l) - 3)
 
 
 def callable_name(type: CallableType) -> str:

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -181,7 +181,7 @@ class A(metaclass=ABCMeta):
     def i(self): pass
     @abstractmethod
     def j(self): pass
-a = A() # E: Cannot instantiate abstract class 'A' with abstract attributes 'a', 'b', 'c', 'd', ... and 'j' (5 methods suppressed)
+a = A() # E: Cannot instantiate abstract class 'A' with abstract attributes 'a', 'b', ... and 'j' (7 methods suppressed)
 [out]
 
 

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -157,6 +157,33 @@ class B(A): pass
 B()# E: Cannot instantiate abstract class 'B' with abstract attributes 'f' and 'g'
 [out]
 
+[case testInstantiatingClassWithInheritedAbstractMethodAndSuppression]
+from abc import abstractmethod, ABCMeta
+import typing
+class A(metaclass=ABCMeta):
+    @abstractmethod
+    def a(self): pass
+    @abstractmethod
+    def b(self): pass
+    @abstractmethod
+    def c(self): pass
+    @abstractmethod
+    def d(self): pass
+    @abstractmethod
+    def e(self): pass
+    @abstractmethod
+    def f(self): pass
+    @abstractmethod
+    def g(self): pass
+    @abstractmethod
+    def h(self): pass
+    @abstractmethod
+    def i(self): pass
+    @abstractmethod
+    def j(self): pass
+a = A() # E: Cannot instantiate abstract class 'A' with abstract attributes 'a', 'b', 'c', 'd', ... and 'j' (5 methods suppressed)
+[out]
+
 
 -- Implementing abstract methods
 -- -----------------------------


### PR DESCRIPTION
Fixes #1842 

Suppresses a list of abstract classes whose abstract methods cannot be instantiated. The message looks like this for 5 or more abstract methods:

```
Cannot instantiate abstract class 'A' with abstract attributes 'a', 'b', 'c', 'd', 
... and 'j' (5 methods suppressed)
```