### PR TITLE
[review wanted] add support for locally installed typehints

### DIFF
--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -176,6 +176,25 @@ There is more information about creating stubs in the
 The following sections explain the kinds of type annotations you can use
 in your programs and stub files.
 
+Mypy will also look in some default install directory to try to find annotations.
+For example, for UNIX based, with python 3.4, it will try to find it in
+- ``${HOME}/.local/shared/typehints/python3.4/``
+- ``/usr/shared/typehints/python3.4/``
+- ``/usr/local/shared/typehints/python3.4/``
+
+If you want to package stubs for your library, write the ``.pyi`` alongside the
+``.py`` files, and add the next line to your ``setup.py``,
+
+.. code-block:: python
+
+    data_files=[
+        (
+            'shared/typehints/python{}.{}'.format(*sys.version_info[:2]),
+            pathlib.Path(SRC_PATH).glob('**/*.pyi'),
+        ),
+    ],
+
+
 .. note::
 
    You may be tempted to point ``MYPYPATH`` to the standard library or

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -275,9 +275,9 @@ def default_lib_path(data_dir: str, pyversion: Tuple[int, int]) -> List[str]:
         # The idea is to implement the example in PEP 484, where the annotations
         # are installed under shared/typehints/python.
         # TODO it would be nicer to find typehints directly via pkg_resources
+        pkgsubdir = os.path.join('shared', 'typehints', 'python' + v)
         for pkginstalldir in get_pkg_locations():
-            subdir = os.path.join('shared', 'typehints', 'python' + v)
-            pkgstubdir = os.path.join(pkginstalldir, subdir)
+            pkgstubdir = os.path.join(pkginstalldir, pkgsubdir)
             if os.path.isdir(pkgstubdir):
                 path.append(pkgstubdir)
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -245,6 +245,16 @@ def mypy_path() -> List[str]:
     return path_env.split(os.pathsep)
 
 
+def get_pkg_locations():
+    # The paths are based on https://docs.python.org/3/install
+    yield site.USER_BASE  # default user pkg dir
+    yield sys.prefix  # default system pkg dir
+
+    if sys.platform != 'win32':
+        yield '/usr'
+        yield '/usr/local'
+
+
 def default_lib_path(data_dir: str, pyversion: Tuple[int, int]) -> List[str]:
     """Return default standard library search paths."""
     # IDEA: Make this more portable.
@@ -263,11 +273,9 @@ def default_lib_path(data_dir: str, pyversion: Tuple[int, int]) -> List[str]:
     for v in versions + [str(pyversion[0]), '2and3']:
         # Add package installed annotations.
         # The idea is to implement the example in PEP 484, where the annotations
-        # are installed under shared/typehints/python. We here search for the
-        # user installation first, then system wide and add it if needed.
-        # The paths are based on https://docs.python.org/3/install
+        # are installed under shared/typehints/python.
         # TODO it would be nicer to find typehints directly via pkg_resources
-        for pkginstalldir in (site.USER_BASE, sys.prefix):
+        for pkginstalldir in get_pkg_locations():
             subdir = os.path.join('shared', 'typehints', 'python' + v)
             pkgstubdir = os.path.join(pkginstalldir, subdir)
             if os.path.isdir(pkgstubdir):

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -16,6 +16,7 @@ import contextlib
 import json
 import os
 import os.path
+import site
 import sys
 import time
 from os.path import dirname, basename
@@ -260,10 +261,13 @@ def default_lib_path(data_dir: str, pyversion: Tuple[int, int]) -> List[str]:
     # E.g. for Python 3.2, try 3.2/, 3.1/, 3.0/, 3/, 2and3/.
     # (Note that 3.1 and 3.0 aren't really supported, but we don't care.)
     for v in versions + [str(pyversion[0]), '2and3']:
-        # Add package installed annotations
-        # TODO better find typehints directly via pkg_resources
-        for pkginstalldir in (os.path.join(os.path.expanduser('~'), '.local'),
-                              os.path.join(os.path.sep, 'usr')):
+        # Add package installed annotations.
+        # The idea is to implement the example in PEP 484, where the annotations
+        # are installed under shared/typehints/python. We here search for the
+        # user installation first, then system wide and add it if needed.
+        # The paths are based on https://docs.python.org/3/install
+        # TODO it would be nicer to find typehints directly via pkg_resources
+        for pkginstalldir in (site.USER_BASE, sys.prefix):
             subdir = os.path.join('shared', 'typehints', 'python' + v)
             pkgstubdir = os.path.join(pkginstalldir, subdir)
             if os.path.isdir(pkgstubdir):

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -260,6 +260,15 @@ def default_lib_path(data_dir: str, pyversion: Tuple[int, int]) -> List[str]:
     # E.g. for Python 3.2, try 3.2/, 3.1/, 3.0/, 3/, 2and3/.
     # (Note that 3.1 and 3.0 aren't really supported, but we don't care.)
     for v in versions + [str(pyversion[0]), '2and3']:
+        # Add package installed annotations
+        # TODO better find typehints directly via pkg_resources
+        for pkginstalldir in (os.path.join(os.path.expanduser('~'), '.local'),
+                              os.path.join(os.path.sep, 'usr')):
+            subdir = os.path.join('shared', 'typehints', 'python' + v)
+            pkgstubdir = os.path.join(pkginstalldir, subdir)
+            if os.path.isdir(pkgstubdir):
+                path.append(pkgstubdir)
+
         for lib_type in ['stdlib', 'third_party']:
             stubdir = os.path.join(data_dir, 'typeshed', lib_type, v)
             if os.path.isdir(stubdir):


### PR DESCRIPTION
Implement example given in PEP 484, in chapter on how to [store and distribute stub files](https://www.python.org/dev/peps/pep-0484/#storing-and-distributing-stub-files), this is functional but not really nice, would be better to implement it via `pkg_resources` at module loading time.

Prefer locally installed stubs (`--user`) rather than system wide for easier user customization. Also, in general, one of the most important stubs location, more than typeshed, as it might be more up to date than it.
