### PR TITLE
Fix type hints of stubutil

### DIFF
--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -39,9 +39,10 @@ def parse_signature(sig: str) -> Optional[Tuple[str,
     return (name, fixed, optional)
 
 
-def build_signature(fixed: MutableSequence[str],
-                    optional: MutableSequence[str]) -> str:
-    args = fixed
+def build_signature(fixed: Sequence[str],
+                    optional: Sequence[str]) -> str:
+    args = []  # type: MutableSequence[str]
+    args.extend(fixed)
     for arg in optional:
         if arg.startswith('*'):
             args.append(arg)

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -50,8 +50,8 @@ def build_signature(fixed: MutableSequence[str], optional: MutableSequence[str])
     return sig
 
 
-def parse_all_signatures(lines: str) -> Tuple[List[Sig],
-                                              List[Sig]]:
+def parse_all_signatures(lines: Sequence[str]) -> Tuple[List[Sig],
+                                                        List[Sig]]:
     sigs = []
     class_sigs = []
     for line in lines:

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -1,7 +1,7 @@
 import re
 import sys
 
-from typing import Any, Optional, Tuple, Sequence, List
+from typing import Any, Optional, Tuple, Sequence, MutableSequence, List
 
 def parse_signature(sig: str) -> Optional[Tuple[str,
                                                 List[str],
@@ -34,8 +34,8 @@ def parse_signature(sig: str) -> Optional[Tuple[str,
     return (name, fixed, optional)
 
 
-def build_signature(fixed: Sequence[str], optional: Sequence[str]) -> str:
-    args = fixed[:]
+def build_signature(fixed: MutableSequence[str], optional: MutableSequence[str]) -> str:
+    args = fixed
     for arg in optional:
         if arg.startswith('*'):
             args.append(arg)

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -1,8 +1,11 @@
 import re
 import sys
 
+from typing import Any, Optional, Tuple, List
 
-def parse_signature(sig):
+def parse_signature(sig: str) -> Optional[Tuple[str,
+                                                List[str],
+                                                List[str]]]:
     m = re.match(r'([.a-zA-Z0-9_]+)\(([^)]*)\)', sig)
     if not m:
         return None

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -1,7 +1,7 @@
 import re
 import sys
 
-from typing import Any, Optional, Tuple, Sequence, MutableSequence, List
+from typing import Any, Optional, Tuple, Sequence, MutableSequence, List, MutableMapping
 
 # Type Alia for Signatures
 Sig = Tuple[str, str]
@@ -70,8 +70,8 @@ def parse_all_signatures(lines: str) -> Tuple[List[Sig],
     return sorted(sigs), sorted(class_sigs)
 
 
-def find_unique_signatures(sigs):
-    sig_map = {}
+def find_unique_signatures(sigs: Sequence[Sig]) -> List[Sig]:
+    sig_map = {} # type: MutableMapping[str, List[str]]
     for name, sig in sigs:
         sig_map.setdefault(name, []).append(sig)
     result = []

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -1,7 +1,7 @@
 import re
 import sys
 
-from typing import Any, Optional, Tuple, List
+from typing import Any, Optional, Tuple, Sequence, List
 
 def parse_signature(sig: str) -> Optional[Tuple[str,
                                                 List[str],
@@ -34,7 +34,7 @@ def parse_signature(sig: str) -> Optional[Tuple[str,
     return (name, fixed, optional)
 
 
-def build_signature(fixed, optional):
+def build_signature(fixed: Sequence[str], optional: Sequence[str]) -> str:
     args = fixed[:]
     for arg in optional:
         if arg.startswith('*'):

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -3,8 +3,10 @@ import sys
 
 from typing import Any, Optional, Tuple, Sequence, MutableSequence, List, MutableMapping
 
-# Type Alia for Signatures
+
+# Type Alias for Signatures
 Sig = Tuple[str, str]
+
 
 def parse_signature(sig: str) -> Optional[Tuple[str,
                                                 List[str],
@@ -37,7 +39,8 @@ def parse_signature(sig: str) -> Optional[Tuple[str,
     return (name, fixed, optional)
 
 
-def build_signature(fixed: MutableSequence[str], optional: MutableSequence[str]) -> str:
+def build_signature(fixed: MutableSequence[str],
+                    optional: MutableSequence[str]) -> str:
     args = fixed
     for arg in optional:
         if arg.startswith('*'):
@@ -71,7 +74,7 @@ def parse_all_signatures(lines: Sequence[str]) -> Tuple[List[Sig],
 
 
 def find_unique_signatures(sigs: Sequence[Sig]) -> List[Sig]:
-    sig_map = {} # type: MutableMapping[str, List[str]]
+    sig_map = {}  # type: MutableMapping[str, List[str]]
     for name, sig in sigs:
         sig_map.setdefault(name, []).append(sig)
     result = []

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -3,6 +3,9 @@ import sys
 
 from typing import Any, Optional, Tuple, Sequence, MutableSequence, List
 
+# Type Alia for Signatures
+Sig = Tuple[str, str]
+
 def parse_signature(sig: str) -> Optional[Tuple[str,
                                                 List[str],
                                                 List[str]]]:
@@ -47,7 +50,8 @@ def build_signature(fixed: MutableSequence[str], optional: MutableSequence[str])
     return sig
 
 
-def parse_all_signatures(lines):
+def parse_all_signatures(lines: str) -> Tuple[List[Sig],
+                                              List[Sig]]:
     sigs = []
     class_sigs = []
     for line in lines:


### PR DESCRIPTION
Fix all mypy errors involving stubutil and its functions.

"mypy mypy/ --disallow-untyped-calls --check-untyped-defs --html-report ../mypy-report/ > ../mypy-typing"

[mypy-typing-fix.txt](https://github.com/python/mypy/files/370142/mypy-typing-fix.txt)
[mypy-typing.txt](https://github.com/python/mypy/files/370143/mypy-typing.txt)

Also, reduced from 57.84% imprecise 102 LOC to 12.84% imprecise 109 LOC