### PR TITLE
Fixes #1717 by skiping the `%%` literal in parse_conversion_specifiers.

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -78,7 +78,11 @@ class StringFormatterChecker:
         regex = ('%' + key_regex + flags_regex + width_regex +
                  precision_regex + length_mod_regex + type_regex)
         specifiers = []  # type: List[ConversionSpecifier]
-        for parens_key, key, flags, width, precision, type in re.findall(regex, format):
+        for result in re.findall(regex, format):
+            # The following test gets rid of the `%%` literal.
+            if result == ('', '', '', '', '', '%'):
+                continue
+            parens_key, key, flags, width, precision, type = result
             if parens_key == '':
                 key = None
             specifiers.append(ConversionSpecifier(key, flags, width, precision, type))

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -971,6 +971,7 @@ a = None # type: Any
 '%3% %d' % 1
 '%*%' % 1
 '%*% %d' % 1  # E: Not enough arguments for format string
+'%(a)d %%' % {'a': 1}
 [builtins fixtures/primitives.py]
 
 [case testStringInterpolationC]


### PR DESCRIPTION
I think this should be clearer than doing regex changes; passes all tests and ignores `%%` correctly.

Fixes #1717 