### PR TITLE
Fix crash with # type: ignore in incremental mode

### DIFF
--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -186,7 +186,7 @@ from parent import b
 [stale parent.a]
 [out]
 
-[case testIncrementalWithTypeIgnore]
+[case testIncrementalWithTypeIgnoreOnDirectImport]
 import a, b
 
 [file a.py]
@@ -200,3 +200,50 @@ import c
 [stale]
 [out]
 
+[case testIncrementalWithTypeIgnoreOnImportFrom]
+import a, b
+
+[file a.py]
+from b import something # type: ignore
+
+[file b.py]
+import c
+something = 3
+
+[file c.py]
+
+[stale]
+[out]
+
+[case testIncrementalWithPartialTypeIgnore]
+import a  # type: ignore
+import a.b
+
+[file a/__init__.py]
+
+[file a/b.py]
+
+[stale]
+[out]
+
+[case testIncrementalAnyIsDifferentFromIgnore]
+import b
+
+[file b.py]
+from typing import Any
+import a.b
+
+[file b.py.next]
+from typing import Any
+
+a = 3  # type: Any
+import a.b
+
+[file a/__init__.py]
+
+[file a/b.py]
+
+[stale b]
+[out]
+main:1: note: In module imported here:
+tmp/b.py:4: error: Name 'a' already defined

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -185,3 +185,18 @@ from parent import b
 
 [stale parent.a]
 [out]
+
+[case testIncrementalWithTypeIgnore]
+import a, b
+
+[file a.py]
+import b  # type: ignore
+
+[file b.py]
+import c
+
+[file c.py]
+
+[stale]
+[out]
+


### PR DESCRIPTION
This commit fixes the bug described in https://github.com/python/mypy/issues/1904.

More precisely, the bug manifests when...

1. You import a module normally
2. From another file, you import the same module, but mark it with the `# type: ignore` comment
3. You run mypy twice in this setup in incremental mode, making sure mypy encounters the `#type: ignore` comment after the regular import.

The bug appears to stem from how the semantic analyzer seemed to always mark import symbols as being of kind `MODULE_REF` and did not preserve whether the module was previously marked with the `# type: ignore` comment or not.

This caused a contradiction since how mypy decides to order dependencies differs whether you're starting with a cold cache or a warm cache.

When you start with a cold cache, mypy determines what each module's dependencies are based roughly on the order mypy encounters each file while parsing and whether the import is marked as ignorable or not.

However, when you start with a warm cache, mypy will use the previously computed list of dependencies, but will also attempt to typecheck each symbol marked as being of kind `MODULE_REF`. This presents a problem, since if the module was marked as being ignorable, it wouldn't be in the list of dependencies, but since it was marked as `MODULE_REF`, mypy assumes it is...

This pull request fixes this problem by modifying the semantic analyzer so that it determines whether it needs to mark import symbols of being kind `MODULE_REF` or `UNBOUND_IMPORTED` to keep the behavior consistent during both runs.