### PR TITLE
Fix + test for string format with %% and keys

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -88,7 +88,9 @@ class StringFormatterChecker:
                                       context: Context) -> bool:
         has_star = any(specifier.has_star() for specifier in specifiers)
         has_key = any(specifier.has_key() for specifier in specifiers)
-        all_have_keys = all(specifier.has_key() for specifier in specifiers)
+        all_have_keys = all(
+            specifier.has_key() or specifier.type == '%' for specifier in specifiers
+        )
 
         if has_key and has_star:
             self.msg.string_interpolation_with_star_and_key(context)
@@ -145,6 +147,9 @@ class StringFormatterChecker:
                 mapping[key_str] = self.accept(v)
 
             for specifier in specifiers:
+                if specifier.type == '%':
+                    # %% is allowed in mappings, no checking is required
+                    continue
                 if specifier.key not in mapping:
                     self.msg.key_not_in_mapping(specifier.key, replacements)
                     return

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -989,6 +989,8 @@ a = None # type: Any
 '%()d' % {'': 2}
 '%(a)d' % {'a': 1, 'b': 2, 'c': 3}
 '%(q)d' % {'a': 1, 'b': 2, 'c': 3}  # E: Key 'q' not found in mapping
+'%(a)d %%' % {'a': 1}
+
 [builtins fixtures/dict.py]
 
 [case testStringInterpolationMappingDictTypes]


### PR DESCRIPTION
This fixes #1717 and adds the corresponding test. Alternate implementation to PR1900  (https://github.com/python/mypy/pull/1900 ) after discussing with @ddfisher 