### PR TITLE
Make mypy still check imports with `# type: ignore` comments if the import exists

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -40,7 +40,7 @@ The second line is now fine, since the ignore comment causes the name
 
     The ``# type: ignore`` comment will only assign the implicit ``Any``
     type if mypy cannot find information about that particular module. So,
-    if we did have a stub available for ``frobnicate`` then mypy will
+    if we did have a stub available for ``frobnicate`` then mypy would
     ignore the ``# type: ignore`` comment and typecheck the stub as usual.
 
 Types of empty collections

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -36,6 +36,13 @@ error:
 The second line is now fine, since the ignore comment causes the name
 ``frobnicate`` to get an implicit ``Any`` type.
 
+.. note::
+
+    The ``# type: ignore`` comment will only assign the implicit ``Any``
+    type if mypy cannot find information about that particular module. So,
+    if we did have a stub available for ``frobnicate`` then mypy will
+    ignore the ``# type: ignore`` comment and typecheck the stub as usual.
+
 Types of empty collections
 --------------------------
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -416,23 +416,12 @@ class BuildManager:
         tree = parse(source, path, self.errors, options=self.options)
         tree._fullname = id
 
-        # We don't want to warn about 'type: ignore' comments on
-        # imports, but we're about to modify tree.imports, so grab
-        # these first.
-        import_lines = set(node.line for node in tree.imports)
-
-        # Skip imports that have been ignored (so that we can ignore a C extension module without
-        # stub, for example), except for 'from x import *', because we wouldn't be able to
-        # determine which names should be defined unless we process the module. We can still
-        # ignore errors such as redefinitions when using the latter form.
-        imports = [node for node in tree.imports
-                   if node.line not in tree.ignored_lines or isinstance(node, ImportAll)]
-        tree.imports = imports
-
         if self.errors.num_messages() != num_errs:
             self.log("Bailing due to parse errors")
             self.errors.raise_error()
 
+        # We don't want to warn about 'type: ignore' comments on imports
+        import_lines = set(node.line for node in tree.imports)
         self.errors.set_file_ignored_lines(path, tree.ignored_lines)
         self.errors.mark_file_ignored_lines_used(path, import_lines)
         return tree

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -420,7 +420,12 @@ class BuildManager:
             self.log("Bailing due to parse errors")
             self.errors.raise_error()
 
-        # We don't want to warn about 'type: ignore' comments on imports
+        # We don't want to warn about unused 'type: ignore' comments on imports.
+        # That way, if we want to conditionally import a module that is valid
+        # only on one particular platform, we can silence the import so we don't
+        # get spurious error messages when mypy tries checking it. For example,
+        # we might want to conditionally import a Python 2 only module while
+        # checking the file as Python 3.
         import_lines = set(node.line for node in tree.imports)
         self.errors.set_file_ignored_lines(path, tree.ignored_lines)
         self.errors.mark_file_ignored_lines_used(path, import_lines)

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -47,11 +47,12 @@ import b # type: ignore
 reveal_type(a.foo) # E: Revealed type is 'Any'
 reveal_type(b.foo) # E: Revealed type is 'builtins.int'
 a.bar()
-b.bar() # E: Name 'bar' is not defined
+b.bar() # E: "module" has no attribute "bar"
 
 [file b.py]
 foo = 3
 
+[builtins fixtures/module_all.py]
 [out]
 
 [case testIgnoreImportStarFromBadModule]

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -36,7 +36,22 @@ x   # E: Name 'x' is not defined
 import m # type: ignore
 from m import a # type: ignore
 [file m.py]
-+ # A parse error, but we shouldn't even parse m.py
++
+[out]
+main:1: note: In module imported here:
+tmp/m.py:1: error: Parse error before end of line
+
+[case testIgnoreAppliesOnlyToMissing]
+import a # type: ignore
+import b # type: ignore
+reveal_type(a.foo) # E: Revealed type is 'Any'
+reveal_type(b.foo) # E: Revealed type is 'builtins.int'
+a.bar()
+b.bar() # E: Name 'bar' is not defined
+
+[file b.py]
+foo = 3
+
 [out]
 
 [case testIgnoreImportStarFromBadModule]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -185,3 +185,65 @@ from parent import b
 
 [stale parent.a]
 [out]
+
+[case testIncrementalWithTypeIgnoreOnDirectImport]
+import a, b
+
+[file a.py]
+import b  # type: ignore
+
+[file b.py]
+import c
+
+[file c.py]
+
+[stale]
+[out]
+
+[case testIncrementalWithTypeIgnoreOnImportFrom]
+import a, b
+
+[file a.py]
+from b import something # type: ignore
+
+[file b.py]
+import c
+something = 3
+
+[file c.py]
+
+[stale]
+[out]
+
+[case testIncrementalWithPartialTypeIgnore]
+import a  # type: ignore
+import a.b
+
+[file a/__init__.py]
+
+[file a/b.py]
+
+[stale]
+[out]
+
+[case testIncrementalAnyIsDifferentFromIgnore]
+import b
+
+[file b.py]
+from typing import Any
+import a.b
+
+[file b.py.next]
+from typing import Any
+
+a = 3  # type: Any
+import a.b
+
+[file a/__init__.py]
+
+[file a/b.py]
+
+[stale b]
+[out]
+main:1: note: In module imported here:
+tmp/b.py:4: error: Name 'a' already defined


### PR DESCRIPTION
This pull request fixes #1911. It also incidentally fixes #1904, which means that we can close #1906 since it's superseded by this pull request. However, this pull request does NOT fix issue #1910, which appears to be an unrelated bug.