### PR TITLE
Add current type to the binder when inferring a partial type

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -929,6 +929,7 @@ class TypeChecker(NodeVisitor[Type]):
                         # This doesn't actually provide any additional information -- multiple
                         # None initializers preserve the partial None type.
                         return
+
                     if is_valid_inferred_type(rvalue_type):
                         var = lvalue_type.var
                         partial_types = self.find_partial_types(var)
@@ -942,11 +943,12 @@ class TypeChecker(NodeVisitor[Type]):
                             else:
                                 var.type = None
                             del partial_types[var]
-                    # Try to infer a partial type. No need to check the return value, as
-                    # an error will be reported elsewhere.
-                    self.infer_partial_type(lvalue_type.var, lvalue, rvalue_type)
-                    return
-                if (is_literal_none(rvalue) and
+                            lvalue_type = var.type
+                    else:
+                        # Try to infer a partial type. No need to check the return value, as
+                        # an error will be reported elsewhere.
+                        self.infer_partial_type(lvalue_type.var, lvalue, rvalue_type)
+                elif (is_literal_none(rvalue) and
                         isinstance(lvalue, NameExpr) and
                         isinstance(lvalue.node, Var) and
                         lvalue.node.is_initialized_in_class):

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -105,9 +105,12 @@ f(None)
 [out]
 main: note: In function "f":
 
-[case testInferOptionalType]
+[case testInferOptionalTypeWithBinder]
 x = None
-x = 1
+if 0:
+  # scope limit binder
+  x = 1
+  reveal_type(x)  # E: Revealed type is 'builtins.int'
 reveal_type(x)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
 
 [case testInferOptionalTypeFromOptional]

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -105,13 +105,19 @@ f(None)
 [out]
 main: note: In function "f":
 
-[case testInferOptionalTypeWithBinder]
+[case testInferOptionalType]
 x = None
-if 0:
-  # scope limit binder
+if bool():
+  # scope limit assignment
   x = 1
-  reveal_type(x)  # E: Revealed type is 'builtins.int'
 reveal_type(x)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+[builtins fixtures/bool.py]
+
+[case testInferOptionalTypeLocallyBound]
+x = None
+x = 1
+reveal_type(x)  # E: Revealed type is 'builtins.int'
+
 
 [case testInferOptionalTypeFromOptional]
 from typing import Optional

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -110,6 +110,9 @@ x = None
 if bool():
   # scope limit assignment
   x = 1
+  # in scope of the assignment, x is an int
+  reveal_type(x)  # E: Revealed type is 'builtins.int'
+# out of scope of the assignment, it's an Optional[int]
 reveal_type(x)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
 [builtins fixtures/bool.py]
 


### PR DESCRIPTION
Fix #1819.