### PR TITLE
Remove the dict constraint in ForwardRef._eval_type

### DIFF
--- a/lib-typing/2.7/typing.py
+++ b/lib-typing/2.7/typing.py
@@ -155,12 +155,6 @@ class _ForwardRef(TypingMeta):
         return self
 
     def _eval_type(self, globalns, localns):
-        if not isinstance(localns, dict):
-            raise TypeError('ForwardRef localns must be a dict -- got %r' %
-                            (localns,))
-        if not isinstance(globalns, dict):
-            raise TypeError('ForwardRef globalns must be a dict -- got %r' %
-                            (globalns,))
         if not self.__forward_evaluated__:
             if globalns is None and localns is None:
                 globalns = localns = {}

--- a/lib-typing/3.2/typing.py
+++ b/lib-typing/3.2/typing.py
@@ -160,12 +160,6 @@ class _ForwardRef(TypingMeta):
         return self
 
     def _eval_type(self, globalns, localns):
-        if not isinstance(localns, dict):
-            raise TypeError('ForwardRef localns must be a dict -- got %r' %
-                            (localns,))
-        if not isinstance(globalns, dict):
-            raise TypeError('ForwardRef globalns must be a dict -- got %r' %
-                            (globalns,))
         if not self.__forward_evaluated__:
             if globalns is None and localns is None:
                 globalns = localns = {}


### PR DESCRIPTION
This came up when running mypy on Pyston -- we don't use 'dict' for globals, which causes _eval_type
to complain.  I'm not sure if there is a better solution here, but just removing the check seems ok:
eval() will still do type checking, and though the error messages won't be as nice I think it's
ok because this is all internal (the locals/globals seem to come from f_locals/f_globals).