### PR TITLE
Modify unknown symbol func to include class name

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -998,7 +998,10 @@ class SemanticAnalyzer(NodeVisitor):
 
     def add_unknown_symbol(self, name: str, context: Context) -> None:
         var = Var(name)
-        var._fullname = self.qualified_name(name)
+        if self.type:
+            var._fullname = self.type.fullname() + "." + name
+        else:
+            var._fullname = self.qualified_name(name)
         var.is_ready = True
         var.type = AnyType()
         self.add_symbol(name, SymbolTableNode(GDEF, var, self.cur_mod_id), context)

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -118,7 +118,6 @@ class TypeCheckSuite(Suite):
                 output = []
                 with open(program_name, 'w') as f:
                     f.write(program_text)
-                    program_text = None
             elif incremental == 2:
                 # In run 2, copy *.py.next files to *.py files.
                 for dn, dirs, files in os.walk(os.curdir):
@@ -127,6 +126,8 @@ class TypeCheckSuite(Suite):
                             full = os.path.join(dn, file)
                             target = full[:-5]
                             shutil.copy(full, target)
+            # Always set to none so we're forced to reread program_name
+            program_text = None
         source = BuildSource(program_name, module_name, program_text)
         try:
             res = build.build(sources=[source],

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -247,3 +247,10 @@ import a.b
 [out]
 main:1: note: In module imported here:
 tmp/b.py:4: error: Name 'a' already defined
+
+[case testIncrementalSilentImportsAndImportsInClass]
+# options: silent_imports
+class MyObject(object):
+    from bar import FooBar
+[stale]
+[out]


### PR DESCRIPTION
This pull request fixes https://github.com/python/mypy/issues/1931

Previously, the "unknown symbol" function defaulted to setting the qualified name of every symbol as a top-level symbol. While this works in most cases, it fails when working with imports contained within classes. For example, consider the following code:

**test.py**

```python
class MyObject:
    from foo import Foobar
```

Without the fix, and under silent imports, mypy would...

1. See that `foo` was not one of the specified files
2. Would not follow the import, and instead gives `MyObject` an attribute of type `Any` with a qualified name of `test.Foobar`
3. Attempt to serialize Foobar to create the incremental cache
4. See that `test.Foobar` is not the same as `test.MyObject.Foobar`
5. Save the attribute as a cross reference to `test.Foobar`
6. Crash when mypy is re-run since `test.Foobar` does not exist.

With the fix and under silent imports, mypy will...

1. See that `foo` was not one of the specified files
2. Would not follow the import, and instead gives `MyObject` an attribute of type `Any` with a qualified name of `test.MyObject.Foobar`
3. Attempt to serialize Foobar to create the incremental cache
4. See that the qualified name is the same as the actual name
5. Save the attribute as a regular attribute of type `Any`
6. Not crash when mypy is re-run.