### PR TITLE
fix yield nothing expression

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -272,7 +272,11 @@ class TypeChecker(NodeVisitor[Type]):
             # Same as above, but written as a separate branch so the typechecker can understand.
             return AnyType()
         elif return_type.args:
-            return return_type.args[0]
+            ret_type = return_type.args[0]
+            # TODO not best fix, better have dedicated yield token
+            if isinstance(ret_type, NoneTyp):
+                return Void()
+            return ret_type
         else:
             # If the function's declared supertype of Generator has no type
             # parameters (i.e. is `object`), then the yielded values can't

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -253,6 +253,12 @@ def f(b: T) -> T:
     return a or b
 [out]
 
+[case testYieldNothingInFunctionReturningGenerator]
+from typing import Generator
+def f() -> Generator[None, None, None]:
+    yield
+[out]
+
 [case testNoneAndStringIsNone]
 a = None
 b = "foo"

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -811,13 +811,6 @@ def f() -> Generator[int, None, None]:
 [builtins fixtures/for.py]
 [out]
 
-[case testYieldNothingInFunctionReturningGenerator]
-from typing import Generator
-def f() -> Generator[None, None, None]:
-    yield
-[builtins fixtures/for.py]
-[out]
-
 [case testYieldInFunctionReturningIterable]
 from typing import Iterable
 def f() -> Iterable[int]:

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -811,6 +811,13 @@ def f() -> Generator[int, None, None]:
 [builtins fixtures/for.py]
 [out]
 
+[case testYieldNothingInFunctionReturningGenerator]
+from typing import Generator
+def f() -> Generator[None, None, None]:
+    yield
+[builtins fixtures/for.py]
+[out]
+
 [case testYieldInFunctionReturningIterable]
 from typing import Iterable
 def f() -> Iterable[int]:


### PR DESCRIPTION
```python
from typing import Generator

def f() -> Generator[None, None, None]:
    yield
```
gives
```
/tmp/asd.py: note: In function "f":
/tmp/asd.py:4: error: Yield value expected
```

But IMO, it is correctly typed (`Generator[yield_type, send_type, return_type]`, no yield, no send, no return).

This PR allows a yield expression to yield nothing (it was alreadly handled in [checker.py:1902](https://github.com/python/mypy/blob/master/mypy/checker.py#L1902) but the wrong expr was generated.)