### PR TITLE
Add .DS_Store, *.swp, and .incremental_checker_cache.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,15 @@ docs/build/
 /out/
 .venv/
 .mypy_cache/
+.incremental_checker_cache.json
 
 # Packages
 *.egg
 *.egg-info
 
-#IDEs
+# IDEs
 .idea
+*.swp
+
+# Operating Systems
+.DS_store


### PR DESCRIPTION
`.DS_Store` appears on Macs, `*.swp` is a temporary file Vim creates when
editing a file, and `.incremental_checker_cache.json` should probably be
ignored for the same reason `.mypy_cache/` should be ignored.