### PR TITLE
Make tests more Emacs-friendly

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -405,7 +405,7 @@ class MypyDataCase(pytest.Item):
             self.parent._prunetraceback(excinfo)
             excrepr = excinfo.getrepr(style='short')
 
-        return "data: {}:{}\n{}".format(self.obj.file, self.obj.line, excrepr)
+        return "data: {}:{}:\n{}".format(self.obj.file, self.obj.line, excrepr)
 
 
 class DataSuite:


### PR DESCRIPTION
Add an extra colon to the "data: <file>:<line>" output from failing tests, so it looks like "data: <file>:<line>:".

@gnprice: With this small change my Emacs "compile" mode lets me jump to that line directly.