### PR TITLE
Fix "Too many arguments" error for f(*a, b) where f is varargs.

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1676,6 +1676,8 @@ def map_actuals_to_formals(caller_kinds: List[int],
                         break
                     else:
                         map[j].append(i)
+                    if callee_kinds[j] == nodes.ARG_STAR:
+                        break
                     j += 1
         elif kind == nodes.ARG_NAMED:
             name = caller_names[i]

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -672,6 +672,9 @@ class ExpressionChecker:
                     messages.invalid_keyword_var_arg(arg_type, context)
                 # Get the type of an individual actual argument (for *args
                 # and **args this is the item type, not the collection type).
+                if isinstance(arg_type, TupleType) and tuple_counter[0] >= len(arg_type.items):
+                    # The tuple is exhausted. Continue with further arguments.
+                    continue
                 actual_type = get_actual_type(arg_type, arg_kinds[actual],
                                               tuple_counter)
                 check_arg(actual_type, arg_type, arg_kinds[actual],
@@ -1667,7 +1670,8 @@ def map_actuals_to_formals(caller_kinds: List[int],
                             map[j].append(i)
                         else:
                             break
-                        j += 1
+                        if callee_kinds[j] != nodes.ARG_STAR:
+                            j += 1
             else:
                 # Assume that it is an iterable (if it isn't, there will be
                 # an error later).

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -672,7 +672,9 @@ class ExpressionChecker:
                     messages.invalid_keyword_var_arg(arg_type, context)
                 # Get the type of an individual actual argument (for *args
                 # and **args this is the item type, not the collection type).
-                if isinstance(arg_type, TupleType) and tuple_counter[0] >= len(arg_type.items):
+                if (isinstance(arg_type, TupleType)
+                        and tuple_counter[0] >= len(arg_type.items)
+                        and arg_kinds[actual] == nodes.ARG_STAR):
                     # The tuple is exhausted. Continue with further arguments.
                     continue
                 actual_type = get_actual_type(arg_type, arg_kinds[actual],

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -405,7 +405,7 @@ class MypyDataCase(pytest.Item):
             self.parent._prunetraceback(excinfo)
             excrepr = excinfo.getrepr(style='short')
 
-        return "data: {}:{}\n{}".format(self.obj.file, self.obj.line, excrepr)
+        return "data: {}:{}:\n{}".format(self.obj.file, self.obj.line, excrepr)
 
 
 class DataSuite:

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -122,6 +122,15 @@ f(*it1, 1, *it1, 2)
 f(*it1, '') # E: Argument 2 to "f" has incompatible type "str"; expected "int"
 [builtins fixtures/for.py]
 
+[case testCallVarargsFunctionWithTupleAndPositional]
+# options: fast_parser
+def f(*x: int) -> None: pass
+it1 = (1, 2)
+f(*it1, 1, 2)
+f(*it1, 1, *it1, 2)
+f(*it1, '') # E: Argument 2 to "f" has incompatible type "str"; expected "int"
+[builtins fixtures/for.py]
+
 
 -- Calling varargs function + type inference
 -- -----------------------------------------

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -112,6 +112,16 @@ f(*it1)
 f(*it2) # E: Argument 1 to "f" has incompatible type *Iterable[str]; expected "int"
 [builtins fixtures/for.py]
 
+[case testCallVarargsFunctionWithIterableAndPositional]
+# options: fast_parser
+from typing import Iterable
+it1 = None  # type: Iterable[int]
+def f(*x: int) -> None: pass
+f(*it1, 1, 2)
+f(*it1, 1, *it1, 2)
+f(*it1, '') # E: Argument 2 to "f" has incompatible type "str"; expected "int"
+[builtins fixtures/for.py]
+
 
 -- Calling varargs function + type inference
 -- -----------------------------------------


### PR DESCRIPTION
Fixes #1892 (all cases). Also fixes #1800.