### PR TITLE
Kill dirty stub checking

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -180,7 +180,8 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
     # deprecated options
     parser.add_argument('--silent', action='store_true', dest='special-opts:silent',
                         help=argparse.SUPPRESS)
-    parser.add_argument('-f', '--dirty-stubs', action='store_true', dest='special-opts:dirty_stubs',
+    parser.add_argument('-f', '--dirty-stubs', action='store_true',
+                        dest='special-opts:dirty_stubs',
                         help=argparse.SUPPRESS)
     parser.add_argument('--use-python-path', action='store_true',
                         dest='special-opts:use_python_path',

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -141,8 +141,6 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
                         const=defaults.PYTHON2_VERSION, help="use Python 2 mode")
     parser.add_argument('-s', '--silent-imports', action='store_true',
                         help="don't follow imports to .py files")
-    parser.add_argument('--silent', action='store_true', dest='special-opts:silent',
-                        help="deprecated name for --silent-imports")
     parser.add_argument('--almost-silent', action='store_true',
                         help="like --silent-imports but reports the imports as errors")
     parser.add_argument('--disallow-untyped-calls', action='store_true',
@@ -174,14 +172,19 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
                         dest='special-opts:strict_optional',
                         help="enable experimental strict Optional checks")
     parser.add_argument('--pdb', action='store_true', help="invoke pdb on fatal error")
-    parser.add_argument('--use-python-path', action='store_true',
-                        dest='special-opts:use_python_path',
-                        help="an anti-pattern")
     parser.add_argument('--stats', action='store_true', dest='dump_type_stats', help="dump stats")
     parser.add_argument('--inferstats', action='store_true', dest='dump_inference_stats',
                         help="dump type inference stats")
     parser.add_argument('--custom-typing', metavar='MODULE', dest='custom_typing_module',
                         help="use a custom typing module")
+    # deprecated options
+    parser.add_argument('--silent', action='store_true', dest='special-opts:silent',
+                        help=argparse.SUPPRESS)
+    parser.add_argument('-f', '--dirty-stubs', action='store_true', dest='special-opts:dirty_stubs',
+                        help=argparse.SUPPRESS)
+    parser.add_argument('--use-python-path', action='store_true',
+                        dest='special-opts:use_python_path',
+                        help=argparse.SUPPRESS)
 
     report_group = parser.add_argument_group(
         title='report generation',
@@ -227,11 +230,15 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
                      "See https://github.com/python/mypy/issues/1411 for more discussion."
                      )
 
-    # --silent is deprecated; warn about this.
+    # warn about deprecated options
     if special_opts.silent:
         print("Warning: --silent is deprecated; use --silent-imports",
               file=sys.stderr)
         options.silent_imports = True
+    if special_opts.dirty_stubs:
+        print("Warning: -f/--dirty-stubs is deprecated and no longer necessary. Mypy no longer "
+              "checks the git status of stubs.",
+              file=sys.stderr)
 
     # Check for invalid argument combinations.
     code_methods = sum(bool(c) for c in [special_opts.modules,

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -33,8 +33,6 @@ def main(script_path: str) -> None:
     sources, options = process_options(sys.argv[1:])
     if options.pdb:
         set_drop_into_pdb(True)
-    if not options.dirty_stubs:
-        git.verify_git_integrity_or_abort(build.default_data_dir(bin_dir))
     f = sys.stdout
     try:
         res = type_check_only(sources, bin_dir, options)
@@ -175,8 +173,6 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
     parser.add_argument('--strict-optional', action='store_true',
                         dest='special-opts:strict_optional',
                         help="enable experimental strict Optional checks")
-    parser.add_argument('-f', '--dirty-stubs', action='store_true',
-                        help="don't warn if typeshed is out of sync")
     parser.add_argument('--pdb', action='store_true', help="invoke pdb on fatal error")
     parser.add_argument('--use-python-path', action='store_true',
                         dest='special-opts:use_python_path',

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -43,7 +43,6 @@ class Options:
         self.pdb = False
         self.dump_type_stats = False
         self.dump_inference_stats = False
-        self.dirty_stubs = False
 
         # -- test options --
         # Stop after the semantic analysis phase

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -46,8 +46,7 @@ def test_python_evaluation(testcase: DataDrivenTestCase) -> None:
     args = parse_args(testcase.input[0])
     # Type check the program.
     fixed = [python3_path,
-             os.path.join(testcase.old_cwd, 'scripts', 'mypy'),
-             '-f']
+             os.path.join(testcase.old_cwd, 'scripts', 'mypy')]
     process = subprocess.Popen(fixed + args,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.STDOUT,

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -56,11 +56,11 @@ def test_python_evaluation(testcase):
             # Skip, can't find a Python 2 interpreter.
             raise SkipTestCaseException()
         interpreter = python2_interpreter
-        args = ['--py2', '-f']
+        args = ['--py2']
         py2 = True
     else:
         interpreter = python3_path
-        args = ['-f']
+        args = []
         py2 = False
     # Write the program to a file.
     program = '_program.py'

--- a/runtests.py
+++ b/runtests.py
@@ -27,7 +27,7 @@ if True:
 from typing import Dict, List, Optional, Set, Iterable
 
 from mypy.waiter import Waiter, LazySubprocess
-from mypy import git, util
+from mypy import util
 
 import itertools
 import os
@@ -325,7 +325,6 @@ def main() -> None:
     blacklist = []  # type: List[str]
     arglist = []  # type: List[str]
     list_only = False
-    dirty_stubs = False
 
     allow_opts = True
     curlist = whitelist
@@ -350,8 +349,6 @@ def main() -> None:
                 curlist = arglist
             elif a == '-l' or a == '--list':
                 list_only = True
-            elif a == '-f' or a == '--dirty-stubs':
-                dirty_stubs = True
             elif a == '-h' or a == '--help':
                 usage(0)
             else:
@@ -369,9 +366,6 @@ def main() -> None:
 
     driver = Driver(whitelist=whitelist, blacklist=blacklist, arglist=arglist,
             verbosity=verbosity, parallel_limit=parallel_limit, xfail=[])
-
-    if not dirty_stubs:
-        git.verify_git_integrity_or_abort(driver.cwd)
 
     driver.prepend_path('PATH', [join(driver.cwd, 'scripts')])
     driver.prepend_path('MYPYPATH', [driver.cwd])

--- a/runtests.py
+++ b/runtests.py
@@ -76,7 +76,7 @@ class Driver:
         full_name = 'check %s' % name
         if not self.allow(full_name):
             return
-        args = [sys.executable, self.mypy, '-f'] + mypy_args
+        args = [sys.executable, self.mypy] + mypy_args
         self.waiter.add(LazySubprocess(full_name, args, cwd=cwd, env=self.env))
 
     def add_mypy(self, name: str, *args: str, cwd: Optional[str] = None) -> None:


### PR DESCRIPTION
Fixes #1719.

This doesn't remove `git.py`, because we use the commit hash as our version for incremental checking, but it's now only used in `setup.py`.