### PR TITLE
Kill Void in strict optional mode

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -95,10 +95,7 @@ class TypeAnalyser(TypeVisitor[Type]):
                 return TypeVarType(sym.tvar_def, t.line)
             elif fullname == 'builtins.None':
                 if experiments.STRICT_OPTIONAL:
-                    if t.is_ret_type:
-                        return Void()
-                    else:
-                        return NoneTyp()
+                    return NoneTyp(is_ret_type=t.is_ret_type)
                 else:
                     return Void()
             elif fullname == 'typing.Any':

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -327,19 +327,22 @@ class NoneTyp(Type):
         of a function, where 'None' means Void.
     """
 
-    def __init__(self, line: int = -1) -> None:
+    def __init__(self, is_ret_type: bool = False, line: int = -1) -> None:
         super().__init__(line)
+        self.is_ret_type = is_ret_type
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_none_type(self)
 
     def serialize(self) -> JsonDict:
-        return {'.class': 'NoneTyp'}
+        return {'.class': 'NoneTyp',
+                'is_ret_type': self.is_ret_type,
+                }
 
     @classmethod
     def deserialize(self, data: JsonDict) -> 'NoneTyp':
         assert data['.class'] == 'NoneTyp'
-        return NoneTyp()
+        return NoneTyp(is_ret_type=data['is_ret_type'])
 
 
 class ErasedType(Type):

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -81,11 +81,6 @@ else:
 f = lambda: None
 x = f()
 
-[case testFunctionStillVoid]
-def f() -> None: pass
-f()
-x = f()  # E: "f" does not return a value
-
 [case testNoneArgumentType]
 def f(x: None) -> None: pass
 f(None)
@@ -274,3 +269,32 @@ from typing import overload
 def f() -> None: ...
 @overload
 def f(o: object) -> None: ...
+
+[case testGenericSubclassReturningNone]
+from typing import Generic, TypeVar
+
+T = TypeVar('T')
+
+class Base(Generic[T]):
+  def f(self) -> T:
+    pass
+
+class SubNone(Base[None]):
+  def f(self) -> None:
+    pass
+
+class SubInt(Base[int]):
+  def f(self) -> int:
+    return 1
+
+[case testUseOfNoneReturningFunction]
+from typing import Optional
+def f() -> None:
+    pass
+
+def g(x: Optional[int]) -> int:
+  pass
+
+x = f()  # E: Function does not return a value
+f() + 1  # E: Function does not return a value
+g(f())  # E: Function does not return a value


### PR DESCRIPTION
This preserves the vast majority of "Function does not return a value" warnings provided by `Void`.

Fixes #1975.
Fixes #1956.