### PR TITLE
Fix accidentally disallowing empty returns in strict-optional

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1453,10 +1453,7 @@ class TypeChecker(NodeVisitor[Type]):
                 if (self.function_stack[-1].is_generator and isinstance(return_type, AnyType)):
                     return None
 
-                if isinstance(return_type, Void):
-                    return None
-
-                if isinstance(return_type, AnyType):
+                if isinstance(return_type, (Void, NoneTyp, AnyType)):
                     return None
 
                 if self.typing_mode_full():

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -298,3 +298,11 @@ def g(x: Optional[int]) -> int:
 x = f()  # E: Function does not return a value
 f() + 1  # E: Function does not return a value
 g(f())  # E: Function does not return a value
+
+[case testEmptyReturn]
+def f() -> None:
+    return
+
+[case testReturnNone]
+def f() -> None:
+    return None


### PR DESCRIPTION
In #1980, I accidentally introduced a bug which disallowed empty returns in functions declared to return None.

#1980 actually fixed a little over 100 of the `mypy --strict-optional mypy` errors, but also introduced 88 "Return value expected" errors.  This fixes those 88 errors.