### PR TITLE
Optional Callable is no more valid

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -19,7 +19,13 @@ from mypy import nodes
 from mypy import experiments
 
 
-type_constructors = {'typing.Tuple', 'typing.Union', 'typing.Callable', 'typing.Type'}
+type_constructors = {
+    'typing.Callable',
+    'typing.Optional',
+    'typing.Tuple',
+    'typing.Type',
+    'typing.Union',
+}
 
 
 def analyze_type_alias(node: Node,

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -311,3 +311,7 @@ def f() -> None:
 from typing import Callable
 def f() -> None: pass
 x = f  # type: Callable[[], None]
+
+[case testOptionalCallable]
+from typing import Callable, Optional
+T = Optional[Callable[..., None]]


### PR DESCRIPTION
```python
from typing import Callable, Optional

T = Optional[Callable[..., None]]
```
gives
```
asd.py:3: error: Value of type "object" is not indexable
```

It is not related to the number of argument or return type, simply wrapping a Callable in an Optional. Union with None still works.

I'm kinda sure that it was working previously.

The PR is just adding the testcase.

(Actually, the CI gives `main:2: error: Value of type "int" is not indexable`)