### PR TITLE
Fix PartialType-related crash in --strict-optional

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2247,7 +2247,8 @@ class TypeChecker(NodeVisitor[Type]):
         partial_types = self.partial_types.pop()
         if not self.current_node_deferred:
             for var, context in partial_types.items():
-                if experiments.STRICT_OPTIONAL and cast(PartialType, var.type).type is None:
+                if (experiments.STRICT_OPTIONAL and
+                        isinstance(var.type, PartialType) and var.type.type is None):
                     # None partial type: assume variable is intended to have type None
                     var.type = NoneTyp()
                 else:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -157,8 +157,10 @@ class ExpressionChecker:
             var = cast(Var, e.callee.expr.node)
             partial_types = self.chk.find_partial_types(var)
             if partial_types is not None and not self.chk.current_node_deferred:
-                partial_type = cast(PartialType, var.type)
-                if partial_type is None or partial_type.type is None:
+                partial_type = var.type
+                if (partial_type is None or
+                        not isinstance(partial_type, PartialType) or
+                        partial_type.type is None):
                     # A partial None type -> can't infer anything.
                     return
                 typename = partial_type.type.fullname()

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -315,3 +315,18 @@ x = f  # type: Callable[[], None]
 [case testOptionalCallable]
 from typing import Callable, Optional
 T = Optional[Callable[..., None]]
+
+[case testAnyTypeInPartialTypeList]
+# options: check_untyped_defs
+def f(): ...
+
+def lookup_field(name, obj):
+    try:
+        pass
+    except:
+        attr = f()
+    else:
+        attr = None
+[out]
+main: note: In function "lookup_field":
+main:10: error: Need type annotation for variable


### PR DESCRIPTION
Some --strict-optional code previously assumed that the `partial_types` list could only contain `PartialType`s.  In some cases, it appears `AnyType` can also be part of that list.  It's not entirely clear to me what causes this, but it looks like the correct solution is to be robust to the presence of other types in that list.

Fixes #1948.