### PR TITLE
Fix None initializer not implying Optional with type comments

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -284,6 +284,9 @@ class ASTConverter(ast35.NodeTransformer):
             arg_types = [a.type_annotation for a in args]
             return_type = TypeConverter(line=n.lineno).visit(n.returns)
 
+        for arg, arg_type in zip(args, arg_types):
+            self.set_type_optional(arg_type, arg.initializer)
+
         if isinstance(return_type, UnboundType):
             return_type.is_ret_type = True
 
@@ -329,9 +332,7 @@ class ASTConverter(ast35.NodeTransformer):
     def transform_args(self, args: ast35.arguments, line: int) -> List[Argument]:
         def make_argument(arg: ast35.arg, default: Optional[ast35.expr], kind: int) -> Argument:
             arg_type = TypeConverter(line=line).visit(arg.annotation)
-            converted_default = self.visit(default)
-            self.set_type_optional(arg_type, converted_default)
-            return Argument(Var(arg.arg), arg_type, converted_default, kind)
+            return Argument(Var(arg.arg), arg_type, self.visit(default), kind)
 
         new_args = []
         num_no_defaults = len(args.args) - len(args.defaults)

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -479,6 +479,10 @@ class Parser:
             if is_error:
                 return None
 
+            if typ:
+                for arg, arg_type in zip(args, typ.arg_types):
+                    self.set_type_optional(arg_type, arg.initializer)
+
             if typ and isinstance(typ.ret_type, UnboundType):
                 typ.ret_type.is_ret_type = True
 
@@ -781,8 +785,6 @@ class Parser:
                 kind = nodes.ARG_NAMED
             else:
                 kind = nodes.ARG_POS
-
-        self.set_type_optional(type, initializer)
 
         return Argument(variable, type, initializer, kind), require_named
 

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -100,6 +100,23 @@ f(None)
 [out]
 main: note: In function "f":
 
+[case testInferOptionalFromDefaultNoneComment]
+def f(x=None):
+  # type: (int) -> None
+  x + 1  # E: Unsupported left operand type for + (some union)
+f(None)
+[out]
+main: note: In function "f":
+
+[case testInferOptionalFromDefaultNoneCommentWithFastParser]
+# options: fast_parser
+def f(x=None):
+  # type: (int) -> None
+  x + 1  # E: Unsupported left operand type for + (some union)
+f(None)
+[out]
+main: note: In function "f":
+
 [case testInferOptionalType]
 x = None
 if bool():


### PR DESCRIPTION
Currently, having a default argument of None does not properly imply an Optional type if the type is given as a type comment.  This PR fixes that issue.