### PR TITLE
Add --tb flag when running tests, so it'll print the traceback again.

### DIFF
--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -17,7 +17,7 @@ from mypy.test.helpers import (
     assert_string_arrays_equal, normalize_error_messages,
     testcase_pyversion, update_testcase_output,
 )
-from mypy.errors import CompileError
+from mypy.errors import CompileError, set_show_tb
 from mypy.options import Options
 
 from mypy import experiments
@@ -113,6 +113,7 @@ class TypeCheckSuite(DataSuite):
         options = self.parse_options(program_text)
         options.use_builtins_fixtures = True
         options.python_version = testcase_pyversion(testcase.file, testcase.name)
+        set_show_tb(True)  # Show traceback on crash.
 
         output = testcase.output
         if incremental:

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -44,6 +44,7 @@ def test_python_evaluation(testcase: DataDrivenTestCase) -> None:
         for s in testcase.input:
             file.write('{}\n'.format(s))
     args = parse_args(testcase.input[0])
+    args.append('--tb')  # Show traceback on crash.
     # Type check the program.
     fixed = [python3_path,
              os.path.join(testcase.old_cwd, 'scripts', 'mypy')]

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -62,6 +62,7 @@ def test_python_evaluation(testcase):
         interpreter = python3_path
         args = []
         py2 = False
+    args.append('--tb')  # Show traceback on crash.
     # Write the program to a file.
     program = '_program.py'
     program_path = os.path.join(test_temp_dir, program)

--- a/runtests.py
+++ b/runtests.py
@@ -77,6 +77,7 @@ class Driver:
         if not self.allow(full_name):
             return
         args = [sys.executable, self.mypy] + mypy_args
+        args.append('--tb')  # Show traceback on crash.
         self.waiter.add(LazySubprocess(full_name, args, cwd=cwd, env=self.env))
 
     def add_mypy(self, name: str, *args: str, cwd: Optional[str] = None) -> None:


### PR DESCRIPTION
@ddfisher please review