### PR TITLE
Unable to check method of same name of return type

### DIFF
--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -322,3 +322,10 @@ class C:
 [out]
 main: note: In member "__init__" of class "C":
 main:2: error: The return type of "__init__" must be None
+
+[case testMethodSameNameAsReturn]
+def str() -> str: ...
+def f() -> f: ...
+[out]
+main: note: In function "f":
+main:2: error: Invalid type "main.f"


### PR DESCRIPTION
```python
def str() -> str: ...
```
gives
```
/tmp/asd.py: note: In function "str":
/tmp/asd.py:1: error: Invalid type "asd2.str"
```

It was found when typing [`locale.str`](https://docs.python.org/3/library/locale.html#locale.str).

This PR only add the test case.