### PR TITLE
Make incremental not propagate staleness if the public interface of a module is unchanged (v2)

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -794,7 +794,10 @@ def random_string() -> str:
     return binascii.hexlify(os.urandom(8)).decode('ascii')
 
 
-def compute_md5_hash(text: str) -> str:
+def compute_hash(text: str) -> str:
+    # We use md5 instead of the builtin hash(...) function because the output of hash(...)
+    # can differ between runs due to hash randomization (enabled by default in Python 3.3).
+    # See the note in https://docs.python.org/3/reference/datamodel.html#object.__hash__.
     return hashlib.md5(text.encode('utf-8')).hexdigest()
 
 
@@ -837,7 +840,7 @@ def write_cache(id: str, path: str, tree: MypyFile,
     # Serialize data and analyze interface
     data = tree.serialize()
     data_str = json.dumps(data, indent=2, sort_keys=True)
-    interface_hash = compute_md5_hash(data_str)
+    interface_hash = compute_hash(data_str)
 
     # Write data cache file, if applicable
     if old_interface_hash == interface_hash:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -757,7 +757,7 @@ def find_cache_meta(id: str, path: str, manager: BuildManager) -> Optional[Cache
     return m
 
 
-def is_meta_fresh(meta: CacheMeta, path: str, manager: BuildManager) -> bool:
+def is_meta_fresh(meta: CacheMeta, id: str, path: str, manager: BuildManager) -> bool:
     if meta is None:
         return False
 
@@ -1135,7 +1135,7 @@ class State:
             if self.meta is not None:
                 self.interface_hash = self.meta.interface_hash
         self.add_ancestors()
-        if is_meta_fresh(self.meta, self.path, manager):
+        if is_meta_fresh(self.meta, self.id, self.path, manager):
             # Make copies, since we may modify these and want to
             # compare them to the originals later.
             self.dependencies = list(self.meta.dependencies)

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -731,7 +731,7 @@ def find_cache_meta(id: str, path: str, manager: BuildManager) -> Optional[Cache
         meta.get('child_modules', []),
         meta.get('options'),
         meta.get('dep_prios', []),
-        meta.get('interface_hash', 'missing'),
+        meta.get('interface_hash', ''),
         meta.get('version_id'),
     )
     if (m.id != id or m.path != path or
@@ -1051,7 +1051,7 @@ class State:
     externally_same = True
 
     # Contains a hash of the public interface in incremental mode
-    interface_hash = "never_set"  # type: str
+    interface_hash = ""  # type: str
 
     def __init__(self,
                  id: Optional[str],
@@ -1594,8 +1594,8 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
         # would not be considered changed.
         #
         # As a workaround, this check will force a module's interface to be
-        # considered stale if anything it imports also has a stale interface
-        # to make sure these changes are caught and propagated.
+        # considered stale if anything it imports has a stale interface,
+        # which ensures these changes are caught and propagated.
         if len(stale_deps) > 0:
             for id in scc:
                 graph[id].mark_interface_stale()

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -237,7 +237,7 @@ class TypeCheckSuite(DataSuite):
         missing = {}
         for id, path in modules.items():
             meta = build.find_cache_meta(id, path, manager)
-            if meta is None:
+            if not build.is_meta_fresh(meta, path, manager):
                 missing[id] = path
         return set(missing.values())
 

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -191,11 +191,17 @@ class TypeCheckSuite(DataSuite):
         # NOTE: When A imports B and there's an error in B, the cache
         # data for B is invalidated, but the cache data for A remains.
         # However build.process_graphs() will ignore A's cache data.
+        #
+        # Also note that when A imports B, and there's an error in A
+        # _due to a valid change in B_, the cache data for B will be
+        # invalidated and updated, but the old cache data for A will
+        # remain unchanged. As before, build.process_graphs() will
+        # ignore A's (old) cache data.
         error_paths = self.find_error_paths(a)
         modules = self.find_module_files()
         modules.update({module_name: path for module_name, path, text in module_data})
         missing_paths = self.find_missing_cache_files(modules, manager)
-        if missing_paths != error_paths:
+        if not missing_paths.issubset(error_paths):
             raise AssertionFailure("cache data discrepancy %s != %s" %
                                    (missing_paths, error_paths))
 

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -166,11 +166,22 @@ class TypeCheckSuite(DataSuite):
         if incremental and res:
             if not options.silent_imports:
                 self.verify_cache(module_data, a, res.manager)
-            if testcase.expected_stale_modules is not None and incremental == 2:
-                assert_string_arrays_equal(
-                    list(sorted(testcase.expected_stale_modules)),
-                    list(sorted(res.manager.stale_modules.difference({"__main__"}))),
-                    'Set of stale modules does not match expected set')
+            if incremental == 2:
+                self.check_module_equivalence(
+                    'rechecked',
+                    testcase.expected_rechecked_modules,
+                    res.manager.rechecked_modules)
+                self.check_module_equivalence(
+                    'stale',
+                    testcase.expected_stale_modules,
+                    res.manager.stale_modules)
+
+    def check_module_equivalence(self, name: str, expected: Set[str], actual: Set[str]) -> None:
+        if expected is not None:
+            assert_string_arrays_equal(
+                list(sorted(expected)),
+                list(sorted(actual.difference({"__main__"}))),
+                'Set of {} modules does not match expected set'.format(name))
 
     def verify_cache(self, module_data: List[Tuple[str, str, str]], a: List[str],
                      manager: build.BuildManager) -> None:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -237,7 +237,7 @@ class TypeCheckSuite(DataSuite):
         missing = {}
         for id, path in modules.items():
             meta = build.find_cache_meta(id, path, manager)
-            if not build.is_meta_fresh(meta, path, manager):
+            if not build.is_meta_fresh(meta, id, path, manager):
                 missing[id] = path
         return set(missing.values())
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -11,6 +11,8 @@
 -- if no files should be stale.
 
 [case testIncrementalEmpty]
+[rechecked]
+[stale]
 [out]
 
 [case testIncrementalBasics]
@@ -21,6 +23,7 @@ def foo():
 [file m.py.next]
 def foo() -> None:
     pass
+[rechecked m]
 [stale m]
 [out]
 
@@ -32,7 +35,8 @@ def foo() -> None:
 [file m.py.next]
 def foo() -> None:
     bar()
-[stale m]
+[rechecked m]
+[stale]
 [out]
 main:1: note: In module imported here:
 tmp/m.py: note: In function "foo":
@@ -53,6 +57,7 @@ def func2() -> None: mod3.func3()
 [file mod3.py]
 def func3() -> None: pass
 
+[rechecked]
 [stale]
 [out]
 
@@ -75,7 +80,8 @@ def func3() -> None: pass
 [file mod3.py.next]
 def func3() -> None: 3 + 2
 
-[stale mod3]
+[rechecked mod3]
+[stale]
 [out]
 
 
@@ -92,12 +98,12 @@ class A: pass
 [file mod1.py.next]
 def func1() -> A: pass
 
-[stale mod1]
+[rechecked mod1]
+[stale]
 [out]
 main:1: note: In module imported here:
 tmp/mod1.py: note: In function "func1":
 tmp/mod1.py:1: error: Name 'A' is not defined
-
 
 [case testIncrementalSameNameChange]
 import mod1
@@ -113,6 +119,7 @@ class A: pass
 class Parent: pass
 class A(Parent): pass
 
+[rechecked mod1, mod2]
 [stale mod1, mod2]
 [out]
 
@@ -135,9 +142,7 @@ def func3() -> None: pass
 [file mod3.py.next]
 def func3() -> int: return 2
 
-# TODO: ideally, only mod2 and mod3 would be stale, but we treat any
-# changes in our dependencies as an interface change, so mod1 is
-# rechecked as well.
+[rechecked mod1, mod2, mod3]
 [stale mod1, mod2, mod3]
 [out]
 
@@ -167,7 +172,8 @@ def bar() -> int:
 
 def baz() -> int:
     return 42
-[stale mod2]
+[rechecked mod2]
+[stale]
 [out]
 
 [case testIncrementalMethodInterfaceChange]
@@ -186,6 +192,7 @@ class Foo:
     def bar(self, a: float) -> str:
         return "a"
 
+[rechecked mod1, mod2]
 [stale mod1, mod2]
 [out]
 
@@ -208,6 +215,7 @@ class Good:
 class Bad: pass
 class Child(Bad): pass
 
+[rechecked mod1, mod2]
 [stale mod1, mod2]
 [out]
 main:1: note: In module imported here:
@@ -233,6 +241,7 @@ C = 3
 [file mod4.py.next]
 C = "A"
 
+[rechecked mod1, mod2, mod3, mod4]
 [stale mod1, mod2, mod3, mod4]
 [out]
 
@@ -278,6 +287,7 @@ def func2() -> int:
 def func2() -> str:
     return "foo"
 
+[rechecked mod1, mod2]
 [stale mod1, mod2]
 [out]
 main:1: note: In module imported here:
@@ -302,8 +312,9 @@ my_dict = {
     'b': [4, 5, 'a']
 }
 
+[rechecked mod1, mod1_private]
 [stale mod1, mod1_private]
-[builtins fixtures/dict.py]
+[builtins fixtures/dict.pyi]
 [out]
 
 [case testIncrementalWithComplexConstantExpressionNoAnnotation]
@@ -321,10 +332,10 @@ baz = 1 + foo()
 def foo() -> int: return 1
 def bar() -> int: return 2
 baz = 1 + bar()
-# Ideally, this wouldn't count as an interface change,
-# but the interface checker isn't easily able to deduce
-# the type of this constant.
-[stale mod1, mod1_private]
+# Foo
+
+[rechecked mod1_private]
+[stale]
 [out]
 
 [case testIncrementalWithComplexConstantExpressionWithAnnotation]
@@ -342,9 +353,10 @@ baz = 1 + foo()  # type: int
 def foo() -> int: return 1
 def bar() -> int: return 2
 baz = 1 + bar()  # type: int
-# However, if the constant expressions are annotated, we
-# _can_ currently deduce the type.
-[stale mod1_private]
+# Type annotations shouldn't make a difference, but just in case...
+
+[rechecked mod1_private]
+[stale]
 [out]
 
 [case testIncrementalWithDecorators]
@@ -378,9 +390,12 @@ def stringify(f: Callable[[int], int]) -> Callable[[int], str]:
 @stringify
 def some_func(a: int) -> int:
     return a + 2
+[rechecked mod1, mod1_private]
 [stale mod1, mod1_private]
-[builtins fixtures/ops.py]
+[builtins fixtures/ops.pyi]
 [out]
+main:1: note: In module imported here:
+tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalChangingClassAttributes]
 import mod1
@@ -397,6 +412,7 @@ class Foo:
 class Foo:
     A = "hello"
 
+[rechecked mod1, mod2]
 [stale mod1, mod2]
 [out]
 
@@ -418,6 +434,7 @@ class Foo:
     def __init__(self) -> None:
         self.A = "hello"
 
+[rechecked mod1, mod2]
 [stale mod1, mod2]
 [out]
 
@@ -439,6 +456,7 @@ class Foo:
     class Bar:
         attr = "foo"
 
+[rechecked mod1, mod2]
 [stale mod1, mod2]
 [out]
 
@@ -455,6 +473,7 @@ def func() -> None: pass
 [file mod1.py.next]
 def func() -> int: return 1
 
+[rechecked mod1]
 [stale mod1]
 [out]
 
@@ -482,6 +501,7 @@ class Bar:
     def test(self) -> int: return 3
 
 [builtins fixtures/module_all.pyi]
+[rechecked]
 [stale]
 [out]
 
@@ -607,7 +627,8 @@ import a.b
 
 [file a/b.py]
 
-[stale b]
+[rechecked b]
+[stale]
 [out]
 main:1: note: In module imported here:
 tmp/b.py:4: error: Name 'a' already defined

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -146,6 +146,34 @@ def func3() -> int: return 2
 [stale mod1, mod2, mod3]
 [out]
 
+[case testIncrementalInternalFunctionDefinitionChange]
+import mod1
+
+[file mod1.py]
+import mod2
+def accepts_int(a: int) -> int: return a
+accepts_int(mod2.foo())
+
+[file mod2.py]
+def foo() -> int:
+    def inner() -> int:
+        return 42
+    return inner()
+
+[file mod2.py.next]
+def foo() -> int:
+    def inner2() -> str:
+        return "foo"
+    return inner2()
+
+[rechecked mod2]
+[stale]
+[out]
+tmp/mod1.py:1: note: In module imported here,
+main:1: note: ... from here:
+tmp/mod2.py: note: In function "foo":
+tmp/mod2.py:4: error: Incompatible return value type (got "str", expected "int")
+
 [case testIncrementalInternalScramble]
 import mod1
 
@@ -226,6 +254,8 @@ import mod1
 
 [file mod1.py]
 from mod2 import A
+def accepts_int(a: int) -> None: pass
+accepts_int(A)
 
 [file mod2.py]
 from mod3 import B
@@ -244,6 +274,35 @@ C = "A"
 [rechecked mod1, mod2, mod3, mod4]
 [stale mod1, mod2, mod3, mod4]
 [out]
+main:1: note: In module imported here:
+tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
+
+[case testIncrementalBrokenCascade]
+import mod1
+
+[file mod1.py]
+import mod2
+def accept_int(a: int) -> int: return a
+accept_int(mod2.mod3.mod4.const)
+
+[file mod2.py]
+import mod3
+
+[file mod3.py]
+import mod4
+
+[file mod4.py]
+const = 3
+
+[file mod3.py.next]
+# Import to mod4 is gone!
+
+[rechecked mod1, mod2, mod3]
+[stale mod1, mod2, mod3]
+[builtins fixtures/module.py]
+[out]
+main:1: note: In module imported here:
+tmp/mod1.py:3: error: "module" has no attribute "mod4"
 
 [case testIncrementalRemoteChange]
 import mod1
@@ -324,15 +383,14 @@ import mod1
 import mod1_private
 
 [file mod1_private.py]
-def foo() -> int: return 1
-def bar() -> int: return 2
-baz = 1 + foo()
+def foobar() -> int: return 1
+def baz() -> int: return 2
+const = 1 + foobar()
 
 [file mod1_private.py.next]
-def foo() -> int: return 1
-def bar() -> int: return 2
-baz = 1 + bar()
-# Foo
+def foobar() -> int: return 1
+def baz() -> int: return 2
+const = 1 + baz()
 
 [rechecked mod1_private]
 [stale]
@@ -345,19 +403,41 @@ import mod1
 import mod1_private
 
 [file mod1_private.py]
-def foo() -> int: return 1
-def bar() -> int: return 2
-baz = 1 + foo()  # type: int
+def foobar() -> int: return 1
+def baz() -> int: return 2
+const = 1 + foobar()  # type: int
 
 [file mod1_private.py.next]
-def foo() -> int: return 1
-def bar() -> int: return 2
-baz = 1 + bar()  # type: int
-# Type annotations shouldn't make a difference, but just in case...
+def foobar() -> int: return 1
+def baz() -> int: return 2
+const = 1 + baz()  # type: int
 
 [rechecked mod1_private]
 [stale]
 [out]
+
+[case testIncrementalSmall]
+import mod1
+
+[file mod1.py]
+import mod1_private
+def accepts_int(a: int) -> None: pass
+accepts_int(mod1_private.some_func(12))
+
+[file mod1_private.py]
+def some_func(a: int) -> int:
+    return 1
+
+[file mod1_private.py.next]
+def some_func(a: int) -> str:
+    return "a"
+
+[rechecked mod1, mod1_private]
+[stale mod1, mod1_private]
+[builtins fixtures/ops.py]
+[out]
+main:1: note: In module imported here:
+tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalWithDecorators]
 import mod1
@@ -437,6 +517,31 @@ class Foo:
 [rechecked mod1, mod2]
 [stale mod1, mod2]
 [out]
+
+[case testIncrementalCheckingChangingFields]
+import mod1
+
+[file mod1.py]
+import mod2
+def accept_int(a: int) -> int: return a
+f = mod2.Foo()
+accept_int(f.A)
+
+[file mod2.py]
+class Foo:
+    def __init__(self) -> None:
+        self.A = 3
+
+[file mod2.py.next]
+class Foo:
+    def __init__(self) -> None:
+        self.A = "hello"
+
+[rechecked mod1, mod2]
+[stale mod1, mod2]
+[out]
+main:1: note: In module imported here:
+tmp/mod1.py:4: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalNestedClassDefinition]
 import mod1

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -761,7 +761,7 @@ def bar(a: str) -> None: pass
 bar(3)
 
 [rechecked m]
-[stale m]
+[stale]
 [out]
 main:1: note: In module imported here:
 tmp/m.py:4: error: Argument 1 to "bar" has incompatible type "int"; expected "str"

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -299,7 +299,7 @@ const = 3
 
 [rechecked mod1, mod2, mod3]
 [stale mod1, mod2, mod3]
-[builtins fixtures/module.py]
+[builtins fixtures/module.pyi]
 [out]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: "module" has no attribute "mod4"
@@ -434,7 +434,7 @@ def some_func(a: int) -> str:
 
 [rechecked mod1, mod1_private]
 [stale mod1, mod1_private]
-[builtins fixtures/ops.py]
+[builtins fixtures/ops.pyi]
 [out]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -852,3 +852,30 @@ class A:
 [rechecked m, n]
 [stale m, n]
 [out]
+
+[case testIncrementalReplacingImports]
+import good, bad, client
+
+[file good.py]
+def foo(a: int) -> None: pass
+
+[file bad.py]
+def foo(a: str) -> None: pass
+
+[file client.py]
+import good
+import bad 
+from good import foo
+foo(3)
+
+[file client.py.next]
+import good
+import bad
+from bad import foo
+foo(3)
+
+[rechecked client]
+[stale]
+[out]
+main:1: note: In module imported here:
+tmp/client.py:4: error: Argument 1 to "foo" has incompatible type "int"; expected "str"

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -760,6 +760,7 @@ def bar(a: str) -> None: pass
 
 bar(3)
 
+[rechecked m]
 [stale m]
 [out]
 main:1: note: In module imported here:
@@ -834,3 +835,20 @@ val = "foo"
 [out]
 tmp/c/submodule.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/main.py:7: error: "C" has no attribute "foo"
+
+[case testIncrementalRemoteError]
+import m
+m.C().foo().bar()  # E: "A" has no attribute "bar"
+[file m.py]
+import n
+class C:
+  def foo(self) -> n.A: pass
+[file n.py]
+class A:
+  def bar(self): pass
+[file n.py.next]
+class A:
+  pass
+[rechecked m, n]
+[stale m, n]
+[out]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -57,7 +57,67 @@ def func3() -> None: pass
 [out]
 
 
-[case testIncrementalSimpleImportCascade]
+[case testIncrementalInternalChangeOnly]
+import mod1
+mod1.func1()
+
+[file mod1.py]
+import mod2
+def func1() -> None: mod2.func2()
+
+[file mod2.py]
+import mod3
+def func2() -> None: mod3.func3()
+
+[file mod3.py]
+def func3() -> None: pass
+
+[file mod3.py.next]
+def func3() -> None: 3 + 2
+
+[stale mod3]
+[out]
+
+
+[case testIncrementalImportGone]
+import mod1
+
+[file mod1.py]
+from mod2 import A
+def func1() -> A: pass
+
+[file mod2.py]
+class A: pass
+
+[file mod1.py.next]
+def func1() -> A: pass
+
+[stale mod1]
+[out]
+main:1: note: In module imported here:
+tmp/mod1.py: note: In function "func1":
+tmp/mod1.py:1: error: Name 'A' is not defined
+
+
+[case testIncrementalSameNameChange]
+import mod1
+
+[file mod1.py]
+from mod2 import A
+def func1() -> A: pass
+
+[file mod2.py]
+class A: pass
+
+[file mod2.py.next]
+class Parent: pass
+class A(Parent): pass
+
+[stale mod1, mod2]
+[out]
+
+
+[case testIncrementalPartialInterfaceChange]
 import mod1
 mod1.func1()
 
@@ -75,7 +135,311 @@ def func3() -> None: pass
 [file mod3.py.next]
 def func3() -> int: return 2
 
+# TODO: ideally, only mod2 and mod3 would be stale, but we treat any
+# changes in our dependencies as an interface change, so mod1 is
+# rechecked as well.
 [stale mod1, mod2, mod3]
+[out]
+
+[case testIncrementalInternalScramble]
+import mod1
+
+[file mod1.py]
+import mod2
+mod2.foo()
+
+[file mod2.py]
+def baz() -> int:
+    return 3
+
+def bar() -> int:
+    return baz()
+
+def foo() -> int:
+    return bar()
+
+[file mod2.py.next]
+def foo() -> int:
+    return baz()
+
+def bar() -> int:
+    return bar()
+
+def baz() -> int:
+    return 42
+[stale mod2]
+[out]
+
+[case testIncrementalMethodInterfaceChange]
+import mod1
+
+[file mod1.py]
+import mod2
+
+[file mod2.py]
+class Foo:
+    def bar(self, a: str) -> str:
+        return "a"
+
+[file mod2.py.next]
+class Foo:
+    def bar(self, a: float) -> str:
+        return "a"
+
+[stale mod1, mod2]
+[out]
+
+[case testIncrementalBaseClassChange]
+import mod1
+
+[file mod1.py]
+from mod2 import Child
+Child().good_method()
+
+[file mod2.py]
+class Good:
+    def good_method(self) -> int: return 1
+class Bad: pass
+class Child(Good): pass
+
+[file mod2.py.next]
+class Good:
+    def good_method(self) -> int: return 1
+class Bad: pass
+class Child(Bad): pass
+
+[stale mod1, mod2]
+[out]
+main:1: note: In module imported here:
+tmp/mod1.py:2: error: "Child" has no attribute "good_method"
+
+[case testIncrementalCascadingChange]
+import mod1
+
+[file mod1.py]
+from mod2 import A
+
+[file mod2.py]
+from mod3 import B
+A = B
+
+[file mod3.py]
+from mod4 import C
+B = C
+
+[file mod4.py]
+C = 3
+
+[file mod4.py.next]
+C = "A"
+
+[stale mod1, mod2, mod3, mod4]
+[out]
+
+[case testIncrementalRemoteChange]
+import mod1
+
+[file mod1.py]
+import mod2
+def accepts_int(a: int) -> None: pass
+accepts_int(mod2.mod3.mod4.const)
+
+[file mod2.py]
+import mod3
+
+[file mod3.py]
+import mod4
+
+[file mod4.py]
+const = 3
+
+[file mod4.py.next]
+const = "foo"
+
+[stale mod1, mod2, mod3, mod4]
+[out]
+main:1: note: In module imported here:
+tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
+
+[case testIncrementalBadChange]
+import mod1
+
+[file mod1.py]
+from mod2 import func2
+
+def func1() -> int:
+    return func2()
+
+[file mod2.py]
+def func2() -> int:
+    return 1
+
+[file mod2.py.next]
+def func2() -> str:
+    return "foo"
+
+[stale mod1, mod2]
+[out]
+main:1: note: In module imported here:
+tmp/mod1.py: note: In function "func1":
+tmp/mod1.py:4: error: Incompatible return value type (got "str", expected "int")
+
+[case testIncrementalWithComplexDictExpression]
+import mod1 
+
+[file mod1.py]
+import mod1_private
+
+[file mod1_private.py]
+my_dict = {
+    'a': [1, 2, 3],
+    'b': [4, 5, 6]
+}
+
+[file mod1_private.py.next]
+my_dict = {
+    'a': [1, 2, 3],
+    'b': [4, 5, 'a']
+}
+
+[stale mod1, mod1_private]
+[builtins fixtures/dict.py]
+[out]
+
+[case testIncrementalWithComplexConstantExpressionNoAnnotation]
+import mod1 
+
+[file mod1.py]
+import mod1_private
+
+[file mod1_private.py]
+def foo() -> int: return 1
+def bar() -> int: return 2
+baz = 1 + foo()
+
+[file mod1_private.py.next]
+def foo() -> int: return 1
+def bar() -> int: return 2
+baz = 1 + bar()
+# Ideally, this wouldn't count as an interface change,
+# but the interface checker isn't easily able to deduce
+# the type of this constant.
+[stale mod1, mod1_private]
+[out]
+
+[case testIncrementalWithComplexConstantExpressionWithAnnotation]
+import mod1
+
+[file mod1.py]
+import mod1_private
+
+[file mod1_private.py]
+def foo() -> int: return 1
+def bar() -> int: return 2
+baz = 1 + foo()  # type: int
+
+[file mod1_private.py.next]
+def foo() -> int: return 1
+def bar() -> int: return 2
+baz = 1 + bar()  # type: int
+# However, if the constant expressions are annotated, we
+# _can_ currently deduce the type.
+[stale mod1_private]
+[out]
+
+[case testIncrementalWithDecorators]
+import mod1
+
+[file mod1.py]
+import mod1_private
+def accepts_int(a: int) -> None: pass
+accepts_int(mod1_private.some_func(12))
+
+[file mod1_private.py]
+from typing import Callable
+def multiply(f: Callable[[int], int]) -> Callable[[int], int]:
+    return lambda a: f(a) * 10
+
+def stringify(f: Callable[[int], int]) -> Callable[[int], str]:
+    return lambda a: str(f(a))
+
+@multiply
+def some_func(a: int) -> int:
+    return a + 2
+
+[file mod1_private.py.next]
+from typing import Callable
+def multiply(f: Callable[[int], int]) -> Callable[[int], int]:
+    return lambda a: f(a) * 10
+
+def stringify(f: Callable[[int], int]) -> Callable[[int], str]:
+    return lambda a: str(f(a))
+
+@stringify
+def some_func(a: int) -> int:
+    return a + 2
+[stale mod1, mod1_private]
+[builtins fixtures/ops.py]
+[out]
+
+[case testIncrementalChangingClassAttributes]
+import mod1
+
+[file mod1.py]
+import mod2
+mod2.Foo.A
+
+[file mod2.py]
+class Foo:
+    A = 3
+
+[file mod2.py.next]
+class Foo:
+    A = "hello"
+
+[stale mod1, mod2]
+[out]
+
+[case testIncrementalChangingFields]
+import mod1
+
+[file mod1.py]
+import mod2
+f = mod2.Foo()
+f.A
+
+[file mod2.py]
+class Foo:
+    def __init__(self) -> None:
+        self.A = 3
+
+[file mod2.py.next]
+class Foo:
+    def __init__(self) -> None:
+        self.A = "hello"
+
+[stale mod1, mod2]
+[out]
+
+[case testIncrementalNestedClassDefinition]
+import mod1
+
+[file mod1.py]
+import mod2
+b = mod2.Foo.Bar()
+b.attr
+
+[file mod2.py]
+class Foo:
+    class Bar:
+        attr = 3
+
+[file mod2.py.next]
+class Foo:
+    class Bar:
+        attr = "foo"
+
+[stale mod1, mod2]
 [out]
 
 [case testIncrementalSimpleBranchingModules]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -792,6 +792,7 @@ class Class: pass
 # empty
 
 [builtins fixtures/args.pyi]
+[rechecked collections, main, package.subpackage.mod1]
 [stale collections, main, package.subpackage.mod1]
 [out]
 tmp/main.py: note: In function "handle":
@@ -831,7 +832,8 @@ val = 3  # type: int
 val = "foo"
 
 [builtins fixtures/module_all.pyi]
-[stale main, c, c.submodule]
+[rechecked main, c, c.submodule]
+[stale]
 [out]
 tmp/c/submodule.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/main.py:7: error: "C" has no attribute "foo"

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -230,7 +230,8 @@ num = id + 1
 
 reveal_type(id)
 reveal_type(num)
-[stale m]
+[rechecked m]
+[stale]
 [out]
 main:1: note: In module imported here:
 tmp/m.py:13: error: Revealed type is 'm.UserId'

--- a/test-data/unit/fixtures/dict.pyi
+++ b/test-data/unit/fixtures/dict.pyi
@@ -20,7 +20,8 @@ class dict(Iterable[KT], Mapping[KT, VT], Generic[KT, VT]):
     def __iter__(self) -> Iterator[KT]: pass
     def update(self, a: Mapping[KT, VT]) -> None: pass
 
-class int: pass # for convenience
+class int: # for convenience
+    def __add__(self, x: int) -> int: pass
 
 class str: pass # for keyword argument key type
 


### PR DESCRIPTION
This pull request modifies incremental mode so that if a module is modified in a way such that the types for any of its publicly accessible symbols are unchanged, we recheck the file without queueing up the importers to be rechecked. Or, more precisely, if module A imports module B and module B's public interface is unchanged, then we consider module B to be internally stale but not externally stale and consider module A to still be fresh.

It does so by producing a hash of the serialized version of the output before writing the cache data to a file, and saving that hash to the meta file. The hashes are then compared against each other in subsequent runs.

This pull request is a strictly better version of https://github.com/python/mypy/pull/2002, although it also does not solve the "chained modules" problem.