### PR TITLE
Manually set mtime instead of sleeping

### DIFF
--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -88,7 +88,6 @@ class TypeCheckSuite(DataSuite):
             # We briefly sleep to make sure file timestamps are distinct.
             self.clear_cache()
             self.run_case_once(testcase, 1)
-            time.sleep(0.1)
             self.run_case_once(testcase, 2)
         elif optional:
             try:
@@ -131,6 +130,13 @@ class TypeCheckSuite(DataSuite):
                             full = os.path.join(dn, file)
                             target = full[:-5]
                             shutil.copy(full, target)
+
+                            # In some systems, mtime has a resolution of 1 second which can cause
+                            # annoying-to-debug issues when a file has the same size after a
+                            # change. We manually set the mtime to circumvent this.
+                            new_time = os.stat(target).st_mtime + 1
+                            os.utime(target, times=(new_time, new_time))
+
             # Always set to none so we're forced to reread program_name
             program_text = None
         source = BuildSource(program_name, module_name, program_text)

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -254,3 +254,23 @@ class MyObject(object):
     from bar import FooBar
 [stale]
 [out]
+
+[case testIncrementalSameFileSize]
+import m
+
+[file m.py]
+def foo(a: int) -> None: pass
+def bar(a: str) -> None: pass
+
+foo(3)
+
+[file m.py.next]
+def foo(a: int) -> None: pass
+def bar(a: str) -> None: pass
+
+bar(3)
+
+[stale m]
+[out]
+main:1: note: In module imported here:
+tmp/m.py:4: error: Argument 1 to "bar" has incompatible type "int"; expected "str"


### PR DESCRIPTION
Previously, the test suites for incremental added a delay of 0.1 seconds
between runs so that the mtime between runs would be different and a
file change would actually register with mypy.

Unfortunately, this doesn't necessarily work on some systems that have a
coarser mtime resolution.

To circumvent this, this commit gets rid of the sleep and just manually
adjusts the mtime upwards by a second so a file change is always
registered as a file change.