### PR TITLE
Fix silent imports/incremental mode/NoneType bug

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1385,7 +1385,6 @@ def load_graph(sources: List[BuildSource], manager: BuildManager) -> Graph:
                 if dep in st.suppressed:
                     st.suppressed.remove(dep)
                     st.dependencies.append(dep)
-                pass
     for id, g in graph.items():
         if g.has_new_submodules():
             g.parse_file()

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1359,7 +1359,7 @@ def load_graph(sources: List[BuildSource], manager: BuildManager) -> Graph:
     # Collect dependencies.  We go breadth-first.
     while new:
         st = new.popleft()
-        for dep in st.ancestors + st.dependencies:
+        for dep in st.ancestors + st.dependencies + st.suppressed:
             if dep not in graph:
                 try:
                     if dep in st.ancestors:
@@ -1380,6 +1380,12 @@ def load_graph(sources: List[BuildSource], manager: BuildManager) -> Graph:
                     new.append(newst)
             if dep in st.ancestors and dep in graph:
                 graph[dep].child_modules.add(st.id)
+            if dep in graph and dep in st.suppressed:
+                # Previously suppressed file is now visible
+                if dep in st.suppressed:
+                    st.suppressed.remove(dep)
+                    st.dependencies.append(dep)
+                pass
     for id, g in graph.items():
         if g.has_new_submodules():
             g.parse_file()

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -274,3 +274,34 @@ bar(3)
 [out]
 main:1: note: In module imported here:
 tmp/m.py:4: error: Argument 1 to "bar" has incompatible type "int"; expected "str"
+
+[case testIncrementalUnsilencingModule]
+# cmd: mypy -m main package.subpackage.mod2
+# cmd2: mypy -m main package.subpackage.mod1
+# options: silent_imports
+
+[file main.py]
+from package.subpackage.mod1 import Class
+
+def handle(c: Class) -> None:
+    c.some_attribute
+
+[file package/__init__.py]
+# empty
+
+[file package/subpackage/__init__.py]
+# empty
+
+[file package/subpackage/mod1.py]
+import math  # Any previously unloaded package works here
+
+class Class: pass
+
+[file package/subpackage/mod2.py]
+# empty
+
+[builtins fixtures/args.py]
+[stale]
+[out]
+main.py: note: In function "handle":
+main.py:4: error: "Class" has no attribute "some_attribute"

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -293,15 +293,15 @@ def handle(c: Class) -> None:
 # empty
 
 [file package/subpackage/mod1.py]
-import math  # Any previously unloaded package works here
+import collections # Any previously unloaded package works here
 
 class Class: pass
 
 [file package/subpackage/mod2.py]
 # empty
 
-[builtins fixtures/args.py]
-[stale]
+[builtins fixtures/args.pyi]
+[stale collections, main, package.subpackage.mod1]
 [out]
-main.py: note: In function "handle":
-main.py:4: error: "Class" has no attribute "some_attribute"
+tmp/main.py: note: In function "handle":
+tmp/main.py:4: error: "Class" has no attribute "some_attribute"

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -726,20 +726,20 @@ tmp/bar.py:1: error: Module has no attribute 'B'
 
 [case testImportSuppressedWhileAlmostSilent]
 # cmd: mypy -m main
-[file main.py]
 # options: silent_imports almost_silent
+[file main.py]
 import mod
 [file mod.py]
 [builtins fixtures/module.pyi]
 [out]
-tmp/main.py:2: note: Import of 'mod' silently ignored
-tmp/main.py:2: note: (Using --silent-imports, module not passed on command line)
-tmp/main.py:2: note: (This note courtesy of --almost-silent)
+tmp/main.py:1: note: Import of 'mod' silently ignored
+tmp/main.py:1: note: (Using --silent-imports, module not passed on command line)
+tmp/main.py:1: note: (This note courtesy of --almost-silent)
 
 [case testAncestorSuppressedWhileAlmostSilent]
 # cmd: mypy -m foo.bar
-[file foo/bar.py]
 # options: silent_imports almost_silent
+[file foo/bar.py]
 [file foo/__init__.py]
 [builtins fixtures/module.pyi]
 [out]
@@ -749,8 +749,8 @@ tmp/foo/bar.py: note: (This note brought to you by --almost-silent)
 
 [case testStubImportNonStubWhileSilent]
 # cmd: mypy -m main
-[file main.py]
 # options: silent_imports
+[file main.py]
 from stub import x # Permitted
 from other import y # Disallowed
 x + '' # Error here
@@ -763,7 +763,7 @@ x = 42
 y = 42
 [builtins fixtures/module.pyi]
 [out]
-tmp/main.py:4: error: Unsupported left operand type for + ("int")
+tmp/main.py:3: error: Unsupported left operand type for + ("int")
 
 [case testSuperclassInImportCycle]
 import a


### PR DESCRIPTION
This pull request fixes #2017.

Previously, if you tried running mypy with both silent imports and incremental enabled against a subset of modules, then re-ran mypy (still with silent imports and incremental enabled) against a _different_ subset of modules, you would run into the bug reported in #2017.

The issue appeared to be that modules added to the "suppressed" field in the cache metadata were assumed to also be suppressed in future runs of mypy, which is an incorrect assumption wince the user can change what files they want to recheck. This pull request modifies the loading process so modules previously marked as suppressed are rechecked again.