### PR TITLE
Fix regression with type: ignore + silent imports + incremental mode

### DIFF
--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -305,3 +305,9 @@ class Class: pass
 [out]
 tmp/main.py: note: In function "handle":
 tmp/main.py:4: error: "Class" has no attribute "some_attribute"
+
+[case testIncrementalWithIgnores]
+import foo # type: ignore
+
+[stale]
+[out]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -311,3 +311,36 @@ import foo # type: ignore
 
 [stale]
 [out]
+
+[case testIncrementalWithSilentImportsAndIgnore]
+# cmd: mypy -m main b
+# cmd2: mypy -m main c c.submodule
+# options: silent_imports
+
+[file main.py]
+import a  # type: ignore
+import b
+import c
+
+a.A().foo()
+b.B().foo()
+c.C().foo()
+
+[file b.py]
+class B:
+    def foo(self) -> None: pass
+
+[file b.py.next]
+
+[file c/__init__.py]
+class C: pass
+
+[file c/submodule.py]
+val = 3  # type: int
+val = "foo"
+
+[builtins fixtures/module_all.pyi]
+[stale main, c, c.submodule]
+[out]
+tmp/c/submodule.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+tmp/main.py:7: error: "C" has no attribute "foo"


### PR DESCRIPTION
This pull request fixes a regression introduced by pull request #2024.

The previous pull request made the incorrect assumption that all files listed within the `suppressed` field in the cache metadata were module that were silenced due to the silent imports flag. However, this assumption was incorrect -- the suppressed field may also contain imports that were suppressed by the `# type: ignore` annotation. The former type of file needs to be rechecked; the latter should not be.

This pull request distinguishes between the two by checking to see if the file to be rechecked was passed in via the command line. An alternate approach might perhaps be to split up the `suppressed` field into an `ignored` and `silenced` fields, but that seemed a bit complicated.