### PR TITLE
[waiting for typed_ast PR] allow to write both "type: ignore" and "mypy: ignore"

### DIFF
--- a/mypy/lex.py
+++ b/mypy/lex.py
@@ -829,7 +829,7 @@ class Lexer:
         self.pre_whitespace += s
         self.i += len(s)
 
-    type_ignore_exp = re.compile(r'[ \t]*#[ \t]*type:[ \t]*ignore\b')
+    type_ignore_exp = re.compile(r'[ \t]*#[ \t]*(mypy|type):[ \t]*ignore\b')
 
     def add_token(self, tok: Token) -> None:
         """Store a token.

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -3,6 +3,10 @@ x = 1
 x() # type: ignore
 x() # E: "int" not callable
 
+[case testMypyIgnore]
+x = 1
+x() # mypy: ignore
+
 [case testIgnoreUndefinedName]
 x = 1
 y # type: ignore


### PR DESCRIPTION
This is useful for adding mypy-specific ignores to typeshed.
