### PR TITLE
Detect and record implicit dependencies in incremental mode

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1442,6 +1442,8 @@ class State:
         extra = encountered - valid
 
         for dep in sorted(extra):
+            if dep not in self.manager.modules:
+                continue
             if dep not in self.suppressed and dep not in self.manager.missing_modules:
                 self.dependencies.append(dep)
                 self.priorities[dep] = PRI_INDIRECT

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1442,8 +1442,11 @@ class State:
         extra = encountered - valid
 
         for dep in sorted(extra):
-            self.dependencies.append(dep)
-            self.priorities[dep] = PRI_INDIRECT
+            if dep not in self.suppressed and dep not in self.manager.missing_modules:
+                self.dependencies.append(dep)
+                self.priorities[dep] = PRI_INDIRECT
+            elif dep not in self.suppressed and dep in self.manager.missing_modules:
+                self.suppressed.append(dep)
 
     def valid_references(self) -> Set[str]:
         valid_refs = set(self.dependencies + self.suppressed + self.ancestors)

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -29,6 +29,7 @@ from mypy.nodes import (MypyFile, Node, Import, ImportFrom, ImportAll,
                         SymbolTableNode, MODULE_REF)
 from mypy.semanal import FirstPass, SemanticAnalyzer, ThirdPass
 from mypy.checker import TypeChecker
+from mypy.indirection import TypeIndirectionVisitor
 from mypy.errors import Errors, CompileError, DecodeError, report_internal_error
 from mypy import fixup
 from mypy.report import Reports
@@ -306,6 +307,7 @@ CacheMeta = NamedTuple('CacheMeta',
 PRI_HIGH = 5  # top-level "from X import blah"
 PRI_MED = 10  # top-level "import X"
 PRI_LOW = 20  # either form inside a function
+PRI_INDIRECT = 30  # an indirect dependency
 PRI_ALL = 99  # include all priorities
 
 
@@ -352,6 +354,7 @@ class BuildManager:
         self.modules = self.semantic_analyzer.modules
         self.semantic_analyzer_pass3 = ThirdPass(self.modules, self.errors)
         self.type_checker = TypeChecker(self.errors, self.modules, options=options)
+        self.indirection_detector = TypeIndirectionVisitor()
         self.missing_modules = set()  # type: Set[str]
         self.stale_modules = set()  # type: Set[str]
         self.rechecked_modules = set()  # type: Set[str]
@@ -1422,10 +1425,34 @@ class State:
             return
         with self.wrap_context():
             manager.type_checker.visit_file(self.tree, self.xpath)
+
+            if manager.options.incremental:
+                self._patch_indirect_dependencies(manager.type_checker.module_refs)
+
             if manager.options.dump_inference_stats:
                 dump_type_stats(self.tree, self.xpath, inferred=True,
                                 typemap=manager.type_checker.type_map)
             manager.report_file(self.tree)
+
+    def _patch_indirect_dependencies(self, module_refs: Set[str]) -> None:
+        types = self.manager.type_checker.module_type_map.values()
+        valid = self.valid_references()
+
+        encountered = self.manager.indirection_detector.find_modules(types) | module_refs
+        extra = encountered - valid
+
+        for dep in sorted(extra):
+            self.dependencies.append(dep)
+            self.priorities[dep] = PRI_INDIRECT
+
+    def valid_references(self) -> Set[str]:
+        valid_refs = set(self.dependencies + self.suppressed + self.ancestors)
+        valid_refs .add(self.id)
+
+        if "os" in valid_refs:
+            valid_refs.add("os.path")
+
+        return valid_refs
 
     def write_cache(self) -> None:
         if self.path and self.manager.options.incremental and not self.manager.errors.is_errors():
@@ -1604,25 +1631,6 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
             process_fresh_scc(graph, scc)
         else:
             process_stale_scc(graph, scc)
-
-        # TODO: This is a workaround to get around the "chaining imports" problem
-        # with the interface checks.
-        #
-        # That is, if we have a file named `module_a.py` which does:
-        #
-        #     import module_b
-        #     module_b.module_c.foo(3)
-        #
-        # ...and if the type signature of `module_c.foo(...)` were to change,
-        # module_a_ would not be rechecked since the interface of `module_b`
-        # would not be considered changed.
-        #
-        # As a workaround, this check will force a module's interface to be
-        # considered stale if anything it imports has a stale interface,
-        # which ensures these changes are caught and propagated.
-        if len(stale_deps) > 0:
-            for id in scc:
-                graph[id].mark_interface_stale()
 
 
 def order_ascc(graph: Graph, ascc: AbstractSet[str], pri_max: int = PRI_ALL) -> List[str]:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -55,13 +55,17 @@ def extract_refexpr_names(expr: RefExpr) -> Set[str]:
     while expr.kind == MODULE_REF or expr.fullname is not None:
         if expr.kind == MODULE_REF:
             output.add(expr.fullname)
-        elif expr.fullname is not None and '.' in expr.fullname:
-            if not (isinstance(expr.node, Var) and expr.node.is_import):
-                output.add(expr.fullname.rsplit('.', 1)[0])
 
         if isinstance(expr, NameExpr):
+            is_silenced_import = isinstance(expr.node, Var) and expr.node.is_import
             if expr.info is not None:
+                # Reference to regular type
                 output.update(split_module_names(expr.info.module_name))
+            elif isinstance(expr.node, TypeInfo):
+                # Nested class
+                output.update(split_module_names(expr.node.module_name))
+            elif expr.fullname is not None and '.' in expr.fullname and not is_silenced_import:
+                output.add(expr.fullname.rsplit('.', 1)[0])
             break
         elif isinstance(expr, MemberExpr):
             if isinstance(expr.expr, RefExpr):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -100,10 +100,6 @@ class ExpressionChecker:
         self.msg = msg
         self.strfrm_checker = StringFormatterChecker(self, self.chk, self.msg)
 
-    def _visit_typeinfo(self, info: nodes.TypeInfo) -> None:
-        if info is not None:
-            self.chk.module_refs.update(split_module_names(info.module_name))
-
     def visit_name_expr(self, e: NameExpr) -> Type:
         """Type check a name expression.
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -36,6 +36,7 @@ from mypy.semanal import self_type
 from mypy.constraints import get_actual_type
 from mypy.checkstrformat import StringFormatterChecker
 from mypy.expandtype import expand_type
+from mypy.util import split_module_names
 
 from mypy import experiments
 
@@ -43,17 +44,6 @@ from mypy import experiments
 # check_args() below for details.
 ArgChecker = Callable[[Type, Type, int, Type, int, int, CallableType, Context, MessageBuilder],
                       None]
-
-
-def split_module_names(mod_name: str) -> Iterable[str]:
-    """Yields the module and all parent module names.
-
-    So, if `mod_name` is 'a.b.c', this function will yield
-    ['a.b.c', 'a.b', and 'a']."""
-    yield mod_name
-    while '.' in mod_name:
-        mod_name = mod_name.rsplit('.', 1)[0]
-        yield mod_name
 
 
 def extract_refexpr_names(expr: RefExpr) -> Set[str]:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -57,14 +57,12 @@ def extract_refexpr_names(expr: RefExpr) -> Set[str]:
             output.add(expr.fullname)
 
         if isinstance(expr, NameExpr):
-            is_silenced_import = isinstance(expr.node, Var) and expr.node.is_import
-            if expr.info is not None:
-                # Reference to regular type
-                output.update(split_module_names(expr.info.module_name))
-            elif isinstance(expr.node, TypeInfo):
-                # Nested class
+            is_suppressed_import = isinstance(expr.node, Var) and expr.node.is_suppressed_import
+            if isinstance(expr.node, TypeInfo):
+                # Reference to a class or a nested class
                 output.update(split_module_names(expr.node.module_name))
-            elif expr.fullname is not None and '.' in expr.fullname and not is_silenced_import:
+            elif expr.fullname is not None and '.' in expr.fullname and not is_suppressed_import:
+                # Everything else (that is not a silenced import within a class)
                 output.add(expr.fullname.rsplit('.', 1)[0])
             break
         elif isinstance(expr, MemberExpr):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -56,7 +56,8 @@ def extract_refexpr_names(expr: RefExpr) -> Set[str]:
         if expr.kind == MODULE_REF:
             output.add(expr.fullname)
         elif expr.fullname is not None and '.' in expr.fullname:
-            output.add(expr.fullname.rsplit('.', 1)[0])
+            if not (isinstance(expr.node, Var) and expr.node.is_import):
+                output.add(expr.fullname.rsplit('.', 1)[0])
 
         if isinstance(expr, NameExpr):
             if expr.info is not None:

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -9,12 +9,12 @@ import mypy.types as types
 from mypy.util import split_module_names
 
 
-def extract_module_names(symbol_name: str) -> Iterable[str]:
-    """Return the module and parent modules of a fully qualified symbol name."""
-    if symbol_name is not None:
-        while '.' in symbol_name:
-            symbol_name = symbol_name.rsplit('.', 1)[0]
-            yield symbol_name
+def extract_module_names(type_name: Optional[str]) -> Iterable[str]:
+    """Returns the module name of a fully qualified type name."""
+    if type_name is not None:
+        while '.' in type_name:
+            type_name = type_name.rsplit('.', 1)[0]
+            yield type_name
 
 
 class TypeIndirectionVisitor(TypeVisitor[Set[str]]):

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -1,0 +1,101 @@
+from typing import Optional, Set, Iterable
+from abc import abstractmethod
+
+from mypy.visitor import NodeVisitor
+from mypy.types import TypeVisitor
+from mypy.nodes import MODULE_REF
+import mypy.nodes as nodes
+import mypy.types as types
+from mypy.util import split_module_names
+
+
+def extract_module_names(symbol_name: str) -> Iterable[str]:
+    """Returns the module and parent modules of a fully qualified symbol name."""
+    if symbol_name is not None:
+        while '.' in symbol_name:
+            symbol_name = symbol_name.rsplit('.', 1)[0]
+            yield symbol_name
+
+
+class TypeIndirectionVisitor(TypeVisitor[Set[str]]):
+    """Returns all module references within a particular type."""
+
+    def __init__(self) -> None:
+        self.cache = {}  # type: Dict[types.Type, Set[str]]
+
+    def find_modules(self, typs: Iterable[types.Type]) -> Set[str]:
+        return self._visit(*typs)
+
+    def _visit(self, *typs: types.Type) -> Set[str]:
+        output = set()  # type: Set[str]
+        for typ in typs:
+            if typ in self.cache:
+                modules = self.cache[typ]
+            else:
+                modules = typ.accept(self)
+                self.cache[typ] = set(modules)
+            output.update(modules)
+        return output
+
+    def visit_unbound_type(self, t: types.UnboundType) -> Set[str]:
+        return self._visit(*t.args)
+
+    def visit_type_list(self, t: types.TypeList) -> Set[str]:
+        return self._visit(*t.items)
+
+    def visit_error_type(self, t: types.ErrorType) -> Set[str]:
+        return set()
+
+    def visit_any(self, t: types.AnyType) -> Set[str]:
+        return set()
+
+    def visit_void(self, t: types.Void) -> Set[str]:
+        return set()
+
+    def visit_none_type(self, t: types.NoneTyp) -> Set[str]:
+        return set()
+
+    def visit_uninhabited_type(self, t: types.UninhabitedType) -> Set[str]:
+        return set()
+
+    def visit_erased_type(self, t: types.ErasedType) -> Set[str]:
+        return set()
+
+    def visit_deleted_type(self, t: types.DeletedType) -> Set[str]:
+        return set()
+
+    def visit_type_var(self, t: types.TypeVarType) -> Set[str]:
+        return self._visit(*t.values) | self._visit(t.upper_bound)
+
+    def visit_instance(self, t: types.Instance) -> Set[str]:
+        out = self._visit(*t.args)
+        if t.type is not None:
+            out.update(split_module_names(t.type.module_name))
+        return out
+
+    def visit_callable_type(self, t: types.CallableType) -> Set[str]:
+        out = self._visit(*t.arg_types) | self._visit(t.ret_type)
+        if t.definition is not None:
+            out.update(extract_module_names(t.definition.fullname()))
+        return out
+
+    def visit_overloaded(self, t: types.Overloaded) -> Set[str]:
+        return self._visit(*t.items()) | self._visit(t.fallback)
+
+    def visit_tuple_type(self, t: types.TupleType) -> Set[str]:
+        return self._visit(*t.items) | self._visit(t.fallback)
+
+    def visit_star_type(self, t: types.StarType) -> Set[str]:
+        return set()
+
+    def visit_union_type(self, t: types.UnionType) -> Set[str]:
+        return self._visit(*t.items)
+
+    def visit_partial_type(self, t: types.PartialType) -> Set[str]:
+        return set()
+
+    def visit_ellipsis_type(self, t: types.EllipsisType) -> Set[str]:
+        return set()
+
+    def visit_type_type(self, t: types.TypeType) -> Set[str]:
+        return self._visit(t.item)

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -1,4 +1,4 @@
-from typing import Optional, Set, Iterable
+from typing import Dict, Iterable, List, Optional, Set
 from abc import abstractmethod
 
 from mypy.visitor import NodeVisitor
@@ -9,12 +9,14 @@ import mypy.types as types
 from mypy.util import split_module_names
 
 
-def extract_module_names(type_name: Optional[str]) -> Iterable[str]:
-    """Returns the module name of a fully qualified type name."""
+def extract_module_names(type_name: Optional[str]) -> List[str]:
+    """Returns the module names of a fully qualified type name."""
     if type_name is not None:
-        while '.' in type_name:
-            type_name = type_name.rsplit('.', 1)[0]
-            yield type_name
+        # Discard the first one, which is just the qualified name of the type
+        possible_module_names = split_module_names(type_name)
+        return possible_module_names[1:]
+    else:
+        return []
 
 
 class TypeIndirectionVisitor(TypeVisitor[Set[str]]):

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -10,7 +10,7 @@ from mypy.util import split_module_names
 
 
 def extract_module_names(symbol_name: str) -> Iterable[str]:
-    """Returns the module and parent modules of a fully qualified symbol name."""
+    """Return the module and parent modules of a fully qualified symbol name."""
     if symbol_name is not None:
         while '.' in symbol_name:
             symbol_name = symbol_name.rsplit('.', 1)[0]

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1109,8 +1109,6 @@ class NameExpr(RefExpr):
     """
 
     name = None  # type: str      # Name referred to (may be qualified)
-    # TypeInfo of class surrounding expression (may be None)
-    info = None  # type: TypeInfo
 
     literal = LITERAL_TYPE
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -583,6 +583,9 @@ class Var(SymbolNode, Statement):
     is_classmethod = False
     is_property = False
     is_settable_property = False
+    # Set to true when this variable refers to a module we were unable to
+    # parse for some reason (eg a silenced module)
+    is_import = False
 
     def __init__(self, name: str, type: 'mypy.types.Type' = None) -> None:
         self._name = name
@@ -613,6 +616,7 @@ class Var(SymbolNode, Statement):
                 'is_classmethod': self.is_classmethod,
                 'is_property': self.is_property,
                 'is_settable_property': self.is_settable_property,
+                'is_import': self.is_import,
                 }  # type: JsonDict
         return data
 
@@ -629,6 +633,7 @@ class Var(SymbolNode, Statement):
         v.is_classmethod = data['is_classmethod']
         v.is_property = data['is_property']
         v.is_settable_property = data['is_settable_property']
+        v.is_import = data['is_import']
         return v
 
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -585,7 +585,7 @@ class Var(SymbolNode, Statement):
     is_settable_property = False
     # Set to true when this variable refers to a module we were unable to
     # parse for some reason (eg a silenced module)
-    is_import = False
+    is_suppressed_import = False
 
     def __init__(self, name: str, type: 'mypy.types.Type' = None) -> None:
         self._name = name
@@ -616,7 +616,7 @@ class Var(SymbolNode, Statement):
                 'is_classmethod': self.is_classmethod,
                 'is_property': self.is_property,
                 'is_settable_property': self.is_settable_property,
-                'is_import': self.is_import,
+                'is_suppressed_import': self.is_suppressed_import,
                 }  # type: JsonDict
         return data
 
@@ -633,7 +633,7 @@ class Var(SymbolNode, Statement):
         v.is_classmethod = data['is_classmethod']
         v.is_property = data['is_property']
         v.is_settable_property = data['is_settable_property']
-        v.is_import = data['is_import']
+        v.is_suppressed_import = data['is_suppressed_import']
         return v
 
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -729,7 +729,7 @@ class SemanticAnalyzer(NodeVisitor):
     def setup_class_def_analysis(self, defn: ClassDef) -> None:
         """Prepare for the analysis of a class definition."""
         if not defn.info:
-            defn.info = TypeInfo(SymbolTable(), defn)
+            defn.info = TypeInfo(SymbolTable(), defn, self.cur_mod_id)
             defn.info._fullname = defn.info.name()
         if self.is_func_scope() or self.type:
             kind = MDEF
@@ -1416,7 +1416,7 @@ class SemanticAnalyzer(NodeVisitor):
         class_def.fullname = self.qualified_name(name)
 
         symbols = SymbolTable()
-        info = TypeInfo(symbols, class_def)
+        info = TypeInfo(symbols, class_def, self.cur_mod_id)
         info.mro = [info] + base_type.type.mro
         info.bases = [base_type]
         info.is_newtype = True
@@ -1704,7 +1704,8 @@ class SemanticAnalyzer(NodeVisitor):
         symbols = SymbolTable()
         class_def = ClassDef(name, Block([]))
         class_def.fullname = fullname
-        info = namedtuple_type_info(TupleType(types, fallback), symbols, class_def)
+        info = namedtuple_type_info(TupleType(types, fallback), symbols,
+                class_def, self.cur_mod_id)
 
         def add_field(var: Var, is_initialized_in_class: bool = False,
                       is_property: bool = False) -> None:
@@ -2641,7 +2642,7 @@ class FirstPass(NodeVisitor):
     def visit_class_def(self, cdef: ClassDef) -> None:
         self.sem.check_no_global(cdef.name, cdef)
         cdef.fullname = self.sem.qualified_name(cdef.name)
-        info = TypeInfo(SymbolTable(), cdef)
+        info = TypeInfo(SymbolTable(), cdef, self.sem.cur_mod_id)
         info.set_line(cdef.line)
         cdef.info = info
         self.sem.globals[cdef.name] = SymbolTableNode(GDEF, info,
@@ -2651,11 +2652,12 @@ class FirstPass(NodeVisitor):
     def process_nested_classes(self, outer_def: ClassDef) -> None:
         for node in outer_def.defs.body:
             if isinstance(node, ClassDef):
-                node.info = TypeInfo(SymbolTable(), node)
+                node.info = TypeInfo(SymbolTable(), node, self.sem.cur_mod_id)
                 if outer_def.fullname:
                     node.info._fullname = outer_def.fullname + '.' + node.info.name()
                 else:
                     node.info._fullname = node.info.name()
+                node.fullname = node.info._fullname
                 symbol = SymbolTableNode(MDEF, node.info)
                 outer_def.info.names[node.name] = symbol
                 self.process_nested_classes(node)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -923,7 +923,7 @@ class SemanticAnalyzer(NodeVisitor):
             self.add_symbol(as_id, SymbolTableNode(MODULE_REF, m, self.cur_mod_id,
                                                    module_public=module_public), context)
         else:
-            self.add_unknown_symbol(as_id, context)
+            self.add_unknown_symbol(as_id, context, is_import=True)
 
     def visit_import_from(self, imp: ImportFrom) -> None:
         import_id = self.correct_relative_import(imp)
@@ -969,7 +969,7 @@ class SemanticAnalyzer(NodeVisitor):
         else:
             # Missing module.
             for id, as_id in imp.names:
-                self.add_unknown_symbol(as_id or id, imp)
+                self.add_unknown_symbol(as_id or id, imp, is_import=True)
 
     def process_import_over_existing_name(self,
                                           imported_id: str, existing_symbol: SymbolTableNode,
@@ -1039,7 +1039,7 @@ class SemanticAnalyzer(NodeVisitor):
             # Don't add any dummy symbols for 'from x import *' if 'x' is unknown.
             pass
 
-    def add_unknown_symbol(self, name: str, context: Context) -> None:
+    def add_unknown_symbol(self, name: str, context: Context, is_import: bool = False) -> None:
         var = Var(name)
         if self.type:
             var._fullname = self.type.fullname() + "." + name
@@ -1047,6 +1047,7 @@ class SemanticAnalyzer(NodeVisitor):
             var._fullname = self.qualified_name(name)
         var.is_ready = True
         var.type = AnyType()
+        var.is_import = is_import
         self.add_symbol(name, SymbolTableNode(GDEF, var, self.cur_mod_id), context)
 
     #

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1047,7 +1047,7 @@ class SemanticAnalyzer(NodeVisitor):
             var._fullname = self.qualified_name(name)
         var.is_ready = True
         var.type = AnyType()
-        var.is_import = is_import
+        var.is_suppressed_import = is_import
         self.add_symbol(name, SymbolTableNode(GDEF, var, self.cur_mod_id), context)
 
     #

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -340,7 +340,6 @@ class TransformVisitor(NodeVisitor[Node]):
         # This method is used when the transform result must be a NameExpr.
         # visit_name_expr() is used when there is no such restriction.
         new = NameExpr(node.name)
-        new.info = node.info
         self.copy_ref(new, node)
         return new
 

--- a/mypy/typefixture.py
+++ b/mypy/typefixture.py
@@ -193,6 +193,7 @@ class TypeFixture:
                             a[-1], self.function)
 
     def make_type_info(self, name: str,
+                       module_name: str = None,
                        is_abstract: bool = False,
                        mro: List[TypeInfo] = None,
                        bases: List[Instance] = None,
@@ -202,6 +203,12 @@ class TypeFixture:
 
         class_def = ClassDef(name, Block([]), None, [])
         class_def.fullname = name
+
+        if module_name is None:
+            if '.' in name:
+                module_name = name.rsplit('.', 1)[0]
+            else:
+                module_name = '__main__'
 
         if typevars:
             v = []  # type: List[TypeVarDef]
@@ -213,7 +220,7 @@ class TypeFixture:
                 v.append(TypeVarDef(n, id, None, self.o, variance=variance))
             class_def.type_vars = v
 
-        info = TypeInfo(SymbolTable(), class_def)
+        info = TypeInfo(SymbolTable(), class_def, module_name)
         if mro is None:
             mro = []
             if name != 'builtins.object':

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -2,7 +2,7 @@
 
 import re
 import subprocess
-from typing import TypeVar, List, Any, Tuple, Optional
+from typing import TypeVar, List, Any, Tuple, Optional, Iterable
 
 
 T = TypeVar('T')
@@ -10,6 +10,17 @@ T = TypeVar('T')
 ENCODING_RE = re.compile(br'([ \t\v]*#.*(\r\n?|\n))??[ \t\v]*#.*coding[:=][ \t]*([-\w.]+)')
 
 default_python2_interpreter = ['python2', 'python', '/usr/bin/python']
+
+
+def split_module_names(mod_name: str) -> Iterable[str]:
+    """Yields the module and all parent module names.
+
+    So, if `mod_name` is 'a.b.c', this function will yield
+    ['a.b.c', 'a.b', and 'a']."""
+    yield mod_name
+    while '.' in mod_name:
+        mod_name = mod_name.rsplit('.', 1)[0]
+        yield mod_name
 
 
 def short_type(obj: object) -> str:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -2,7 +2,7 @@
 
 import re
 import subprocess
-from typing import TypeVar, List, Any, Tuple, Optional, Iterable
+from typing import TypeVar, List, Any, Tuple, Optional
 
 
 T = TypeVar('T')
@@ -12,15 +12,17 @@ ENCODING_RE = re.compile(br'([ \t\v]*#.*(\r\n?|\n))??[ \t\v]*#.*coding[:=][ \t]*
 default_python2_interpreter = ['python2', 'python', '/usr/bin/python']
 
 
-def split_module_names(mod_name: str) -> Iterable[str]:
-    """Yields the module and all parent module names.
+def split_module_names(mod_name: str) -> List[str]:
+    """Return the module and all parent module names.
 
-    So, if `mod_name` is 'a.b.c', this function will yield
-    ['a.b.c', 'a.b', and 'a']."""
-    yield mod_name
+    So, if `mod_name` is 'a.b.c', this function will return
+    ['a.b.c', 'a.b', and 'a'].
+    """
+    out = [mod_name]
     while '.' in mod_name:
         mod_name = mod_name.rsplit('.', 1)[0]
-        yield mod_name
+        out.append(mod_name)
+    return out
 
 
 def short_type(obj: object) -> str:

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1151,7 +1151,7 @@ tmp/m1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; exp
 
 [case testIncrementalSilentImportsWithInnerImports]
 # cmd: mypy -m main foo
-# options: silent_imports
+# flags: --silent-imports
 
 [file main.py]
 from foo import MyClass
@@ -1176,7 +1176,7 @@ tmp/main.py:3: error: Revealed type is 'Any'
 [case testIncrementalSilentImportsWithInnerImportsAndNewFile]
 # cmd: mypy -m main foo
 # cmd2: mypy -m main foo unrelated
-# options: silent_imports
+# flags: --silent-imports
 
 [file main.py]
 from foo import MyClass

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -351,11 +351,11 @@ import mod2.mod3 as mod3
 [file mod2/mod3/__init__.py]
 import mod2.mod3.mod4 as mod4
 
-[file mod2/mod3/mod4.py]
-const = 3
-
 [file mod2/mod3/__init__.py.next]
 # Import is gone!
+
+[file mod2/mod3/mod4.py]
+const = 3
 
 [rechecked mod1, mod2, mod2.mod3]
 [stale mod2.mod3]
@@ -363,6 +363,84 @@ const = 3
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: "module" has no attribute "mod4"
+
+[case testIncrementalNestedBrokenCascadeWithType1]
+import mod1, mod2.mod3.mod5
+
+[file mod1.py]
+import mod2
+def accept_int(x: int) -> None: pass
+def produce() -> mod2.CustomType:
+    return mod2.CustomType()
+a = produce()
+accept_int(a.foo())
+
+[file mod2/__init__.py]
+from mod2.mod3 import CustomType 
+
+[file mod2/mod3/__init__.py]
+from mod2.mod3.mod4 import CustomType
+
+[file mod2/mod3/__init__.py.next]
+# Import a different class that also happens to be called 'CustomType'
+from mod2.mod3.mod5 import CustomType
+def produce() -> CustomType:
+    return CustomType()
+
+[file mod2/mod3/mod4.py]
+class CustomType:
+    def foo(self) -> int: return 1
+
+[file mod2/mod3/mod5.py]
+class CustomType:
+    def foo(self) -> str: return "a"
+
+[rechecked mod1, mod2, mod2.mod3]
+[stale mod2, mod2.mod3]
+[builtins fixtures/module.pyi]
+[out1]
+[out2]
+main:1: note: In module imported here:
+tmp/mod1.py:6: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
+
+[case testIncrementalNestedBrokenCascadeWithType2]
+import mod1, mod2.mod3.mod5
+
+[file mod1.py]
+from mod2 import produce 
+def accept_int(x: int) -> None: pass
+a = produce()
+accept_int(a.foo())
+
+[file mod2/__init__.py]
+from mod2.mod3 import produce 
+
+[file mod2/mod3/__init__.py]
+from mod2.mod3.mod4 import CustomType
+def produce() -> CustomType:
+    return CustomType()
+
+[file mod2/mod3/__init__.py.next]
+# Import a different class that also happens to be called 'CustomType'
+from mod2.mod3.mod5 import CustomType
+def produce() -> CustomType:
+    return CustomType()
+
+[file mod2/mod3/mod4.py]
+class CustomType:
+    def foo(self) -> int: return 1
+
+[file mod2/mod3/mod5.py]
+class CustomType:
+    def foo(self) -> str: return "a"
+
+[rechecked mod1, mod2, mod2.mod3]
+[stale mod2.mod3]
+[builtins fixtures/module.pyi]
+[out1]
+[out2]
+main:1: note: In module imported here:
+tmp/mod1.py:4: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalRemoteChange]
 import mod1

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1200,3 +1200,17 @@ def test() -> str: return "foo"
 [stale foo, unrelated]
 [out]
 tmp/main.py:3: error: Revealed type is 'builtins.str'
+
+[case testIncrementalWorksWithNestedClasses]
+import foo
+
+[file foo.py]
+class MyClass:
+    class NestedClass:
+        pass
+
+    class_attr = NestedClass()
+
+[rechecked]
+[stale]
+[out]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1148,3 +1148,55 @@ def C() -> str:
 [out2]
 main:1: note: In module imported here:
 tmp/m1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
+
+[case testIncrementalSilentImportsWithInnerImports]
+# cmd: mypy -m main foo
+# options: silent_imports
+
+[file main.py]
+from foo import MyClass
+m = MyClass()
+
+[file main.py.next]
+from foo import MyClass
+m = MyClass()
+reveal_type(m.val)
+
+[file foo.py]
+class MyClass:
+    def __init__(self) -> None:
+        import unrelated
+        self.val = unrelated.test()
+
+[rechecked main]
+[stale]
+[out]
+tmp/main.py:3: error: Revealed type is 'Any'
+
+[case testIncrementalSilentImportsWithInnerImportsAndNewFile]
+# cmd: mypy -m main foo
+# cmd2: mypy -m main foo unrelated
+# options: silent_imports
+
+[file main.py]
+from foo import MyClass
+m = MyClass()
+
+[file main.py.next]
+from foo import MyClass
+m = MyClass()
+reveal_type(m.val)
+
+[file foo.py]
+class MyClass:
+    def __init__(self) -> None:
+        import unrelated
+        self.val = unrelated.test()
+
+[file unrelated.py]
+def test() -> str: return "foo"
+
+[rechecked main, foo, unrelated]
+[stale foo, unrelated]
+[out]
+tmp/main.py:3: error: Revealed type is 'builtins.str'

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -122,8 +122,7 @@ class Parent: pass
 class A(Parent): pass
 
 [rechecked mod1, mod2]
-[stale mod1, mod2]
-
+[stale mod2]
 
 [case testIncrementalPartialInterfaceChange]
 import mod1
@@ -143,8 +142,8 @@ def func3() -> None: pass
 [file mod3.py.next]
 def func3() -> int: return 2
 
-[rechecked mod1, mod2, mod3]
-[stale mod1, mod2, mod3]
+[rechecked mod2, mod3]
+[stale mod3]
 
 [case testIncrementalInternalFunctionDefinitionChange]
 import mod1
@@ -220,7 +219,7 @@ class Foo:
         return "a"
 
 [rechecked mod1, mod2]
-[stale mod1, mod2]
+[stale mod2]
 
 [case testIncrementalBaseClassChange]
 import mod1
@@ -242,7 +241,7 @@ class Bad: pass
 class Child(Bad): pass
 
 [rechecked mod1, mod2]
-[stale mod1, mod2]
+[stale mod2]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py:2: error: "Child" has no attribute "good_method"
@@ -270,7 +269,7 @@ C = 3
 C = "A"
 
 [rechecked mod1, mod2, mod3, mod4]
-[stale mod1, mod2, mod3, mod4]
+[stale mod2, mod3, mod4]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
@@ -296,7 +295,70 @@ const = 3
 # Import to mod4 is gone!
 
 [rechecked mod1, mod2, mod3]
-[stale mod1, mod2, mod3]
+[stale mod3]
+[builtins fixtures/module.pyi]
+[out2]
+main:1: note: In module imported here:
+tmp/mod1.py:3: error: "module" has no attribute "mod4"
+
+[case testIncrementalLongBrokenCascade]
+import mod1
+
+[file mod1.py]
+import mod2
+def accept_int(a: int) -> int: return a
+accept_int(mod2.mod3.mod4.mod5.mod6.mod7.const)
+
+[file mod2.py]
+import mod3
+
+[file mod3.py]
+import mod4
+
+[file mod4.py]
+import mod5
+
+[file mod5.py]
+import mod6
+
+[file mod6.py]
+import mod7
+
+[file mod7.py]
+const = 3
+
+[file mod6.py.next]
+# Import to mod7 is gone!
+
+[rechecked mod1, mod5, mod6]
+[stale mod6]
+[builtins fixtures/module.pyi]
+[out2]
+main:1: note: In module imported here:
+tmp/mod1.py:3: error: "module" has no attribute "mod7"
+
+[case testIncrementalNestedBrokenCascade]
+import mod1
+
+[file mod1.py]
+import mod2
+def accept_int(a: int) -> int: return a
+accept_int(mod2.mod3.mod4.const)
+
+[file mod2/__init__.py]
+import mod2.mod3 as mod3
+
+[file mod2/mod3/__init__.py]
+import mod2.mod3.mod4 as mod4
+
+[file mod2/mod3/mod4.py]
+const = 3
+
+[file mod2/mod3/__init__.py.next]
+# Import is gone!
+
+[rechecked mod1, mod2, mod2.mod3]
+[stale mod2.mod3]
 [builtins fixtures/module.pyi]
 [out2]
 main:1: note: In module imported here:
@@ -322,7 +384,8 @@ const = 3
 [file mod4.py.next]
 const = "foo"
 
-[stale mod1, mod2, mod3, mod4]
+[rechecked mod1, mod3, mod4]
+[stale mod4]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
@@ -345,11 +408,66 @@ def func2() -> str:
     return "foo"
 
 [rechecked mod1, mod2]
-[stale mod1, mod2]
+[stale mod2]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py: note: In function "func1":
 tmp/mod1.py:4: error: Incompatible return value type (got "str", expected "int")
+
+[case testIncrementalBadChangeWithSave]
+import mod0
+
+[file mod0.py]
+import mod1
+A = mod1.func2()
+
+[file mod1.py]
+from mod2 import func2
+
+def func1() -> int:
+    return func2()
+
+[file mod2.py]
+def func2() -> int:
+    return 1
+
+[file mod2.py.next]
+def func2() -> str:
+    return "foo"
+
+[rechecked mod0, mod1, mod2]
+[stale mod2]
+[out2]
+tmp/mod0.py:1: note: In module imported here,
+main:1: note: ... from here:
+tmp/mod1.py: note: In function "func1":
+tmp/mod1.py:4: error: Incompatible return value type (got "str", expected "int")
+
+[case testIncrementalOkChangeWithSave]
+import mod0
+
+[file mod0.py]
+import mod1
+A = mod1.func2()
+
+[file mod1.py]
+from mod2 import func2
+
+def func1() -> int:
+    func2()
+    return 1
+
+[file mod2.py]
+def func2() -> int:
+    return 1
+
+[file mod2.py.next]
+def func2() -> str:
+    return "foo"
+
+[rechecked mod0, mod1, mod2]
+[stale mod0, mod2]
+[out2]
 
 [case testIncrementalWithComplexDictExpression]
 import mod1 
@@ -370,7 +488,7 @@ my_dict = {
 }
 
 [rechecked mod1, mod1_private]
-[stale mod1, mod1_private]
+[stale mod1_private]
 [builtins fixtures/dict.pyi]
 
 [case testIncrementalWithComplexConstantExpressionNoAnnotation]
@@ -428,7 +546,7 @@ def some_func(a: int) -> str:
     return "a"
 
 [rechecked mod1, mod1_private]
-[stale mod1, mod1_private]
+[stale mod1_private]
 [builtins fixtures/ops.pyi]
 [out2]
 main:1: note: In module imported here:
@@ -466,7 +584,7 @@ def stringify(f: Callable[[int], int]) -> Callable[[int], str]:
 def some_func(a: int) -> int:
     return a + 2
 [rechecked mod1, mod1_private]
-[stale mod1, mod1_private]
+[stale mod1_private]
 [builtins fixtures/ops.pyi]
 [out2]
 main:1: note: In module imported here:
@@ -488,7 +606,7 @@ class Foo:
     A = "hello"
 
 [rechecked mod1, mod2]
-[stale mod1, mod2]
+[stale mod2]
 
 [case testIncrementalChangingFields]
 import mod1
@@ -497,6 +615,28 @@ import mod1
 import mod2
 f = mod2.Foo()
 f.A
+
+[file mod2.py]
+class Foo:
+    def __init__(self) -> None:
+        self.A = 3
+
+[file mod2.py.next]
+class Foo:
+    def __init__(self) -> None:
+        self.A = "hello"
+
+[rechecked mod1, mod2]
+[stale mod2]
+[out2]
+
+[case testIncrementalChangingFieldsWithAssignment]
+import mod1
+
+[file mod1.py]
+import mod2
+f = mod2.Foo()
+B = f.A
 
 [file mod2.py]
 class Foo:
@@ -531,7 +671,7 @@ class Foo:
         self.A = "hello"
 
 [rechecked mod1, mod2]
-[stale mod1, mod2]
+[stale mod2]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py:4: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
@@ -555,7 +695,7 @@ class Foo:
         attr = "foo"
 
 [rechecked mod1, mod2]
-[stale mod1, mod2]
+[stale mod2]
 
 [case testIncrementalSimpleBranchingModules]
 import mod1
@@ -598,6 +738,72 @@ class Bar:
 
 [builtins fixtures/module_all.pyi]
 [rechecked]
+[stale]
+
+[case testIncrementalSubmoduleWithAttr]
+import mod.child
+x = mod.child.Foo()
+x.bar()
+
+[file mod/__init__.py]
+
+[file mod/child.py]
+class Foo:
+    def bar(self) -> None: pass
+[builtins fixtures/module.pyi]
+[rechecked]
+[stale]
+
+[case testIncrementalNestedSubmoduleImportFromWithAttr]
+from mod1.mod2 import mod3
+def accept_int(a: int) -> None: pass
+
+accept_int(mod3.val3)
+
+[file mod1/__init__.py]
+val1 = 1
+
+[file mod1/mod2/__init__.py]
+val2 = 1
+
+[file mod1/mod2/mod3.py]
+val3 = 1
+
+[builtins fixtures/module.pyi]
+[rechecked]
+[stale]
+
+[case testIncrementalNestedSubmoduleWithAttr]
+import mod1.mod2.mod3
+def accept_int(a: int) -> None: pass
+
+accept_int(mod1.mod2.mod3.val3)
+accept_int(mod1.mod2.val2)
+accept_int(mod1.val1)
+
+[file mod1/__init__.py]
+val1 = 1
+
+[file mod1/mod2/__init__.py]
+val2 = 1
+
+[file mod1/mod2/mod3.py]
+val3 = 1
+
+[builtins fixtures/module.pyi]
+[rechecked]
+[stale]
+
+[case testIncrementalSubmoduleParentWithImportFrom]
+import parent
+
+[file parent/__init__.py]
+from parent import a
+
+[file parent/a.py]
+val = 3
+
+[builtins fixtures/args.pyi]
 [stale]
 
 [case testIncrementalSubmoduleParentBackreference]
@@ -775,7 +981,7 @@ class Class: pass
 
 [builtins fixtures/args.pyi]
 [rechecked collections, main, package.subpackage.mod1]
-[stale collections, main, package.subpackage.mod1]
+[stale collections, package.subpackage.mod1]
 [out2]
 tmp/main.py: note: In function "handle":
 tmp/main.py:4: error: "Class" has no attribute "some_attribute"
@@ -783,6 +989,7 @@ tmp/main.py:4: error: "Class" has no attribute "some_attribute"
 [case testIncrementalWithIgnores]
 import foo # type: ignore
 
+[builtins fixtures/module.pyi]
 [stale]
 
 [case testIncrementalWithSilentImportsAndIgnore]
@@ -833,7 +1040,7 @@ class A:
 class A:
   pass
 [rechecked m, n]
-[stale m, n]
+[stale n]
 [out2]
 main:2: error: "A" has no attribute "bar"
 
@@ -908,3 +1115,36 @@ foo(3)
 [out2]
 main:1: note: In module imported here:
 tmp/client.py:4: error: Argument 1 to "foo" has incompatible type "int"; expected "str"
+
+[case testIncrementalChangingAlias]
+import m1, m2, m3, m4, m5
+
+[file m1.py]
+from m2 import A
+def accepts_int(x: int) -> None: pass
+accepts_int(A())
+
+[file m2.py]
+from m3 import A
+
+[file m3.py]
+from m4 import B
+A = B
+
+[file m3.py.next]
+from m5 import C
+A = C
+
+[file m4.py]
+def B() -> int:
+    return 42
+
+[file m5.py]
+def C() -> str:
+    return "hello"
+
+[rechecked m1, m2, m3]
+[stale m3]
+[out2]
+main:1: note: In module imported here:
+tmp/m1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1058,7 +1058,7 @@ class A:
 class A:
   def bar(self): pass
 [rechecked m, n]
-[stale m, n]
+[stale n]
 [out1]
 main:2: error: "A" has no attribute "bar"
 
@@ -1149,6 +1149,214 @@ def C() -> str:
 main:1: note: In module imported here:
 tmp/m1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
 
+[case testIncrementalSilentImportsWithBlatantError]
+# cmd: mypy -m main
+# flags: --silent-imports
+
+[file main.py]
+from evil import Hello
+
+[file main.py.next]
+from evil import Hello
+reveal_type(Hello())
+
+[file evil.py]
+def accept_int(x: int) -> None: pass
+accept_int("not an int")
+
+[rechecked main]
+[stale]
+[out2]
+tmp/main.py:2: error: Revealed type is 'Any'
+
+[case testIncrementalImportIsNewlySilenced]
+# cmd: mypy -m main foo
+# cmd2: mypy -m main
+# flags: --silent-imports
+
+[file main.py]
+from foo import bar
+def accept_int(x: int) -> None: pass
+accept_int(bar)
+
+[file foo.py]
+bar = 3
+
+[file foo.py.next]
+# Empty!
+
+[rechecked main]
+[stale main]
+
+[case testIncrementalSilencedModuleNoLongerCausesError]
+# cmd: mypy -m main evil
+# cmd2: mypy -m main
+# flags: --silent-imports
+
+[file main.py]
+from evil import bar
+def accept_int(x: int) -> None: pass
+accept_int(bar)
+reveal_type(bar)
+
+[file evil.py]
+bar = "str"
+
+[rechecked main]
+[stale]
+[out1]
+tmp/main.py:3: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
+tmp/main.py:4: error: Revealed type is 'builtins.str'
+[out2]
+tmp/main.py:4: error: Revealed type is 'Any'
+
+[case testIncrementalFixedBugCausesPropagation]
+import mod1
+
+[file mod1.py]
+from mod2 import A
+val = A().makeB().makeC().foo()
+reveal_type(val)
+
+[file mod2.py]
+from mod3 import B
+class A:
+    def makeB(self) -> B: return B()
+
+[file mod3.py]
+from mod4 import C
+class B:
+    def makeC(self) -> C:
+        val = 3  # type: int
+        val = "str"   # deliberately triggering error
+        return C()
+
+[file mod3.py.next]
+from mod4 import C
+class B:
+    def makeC(self) -> C: return C()
+
+[file mod4.py]
+class C:
+    def foo(self) -> int: return 1
+
+[rechecked mod3, mod2, mod1]
+[stale mod3, mod2]
+[out1]
+tmp/mod2.py:1: note: In module imported here,
+tmp/mod1.py:1: note: ... from here,
+main:1: note: ... from here:
+tmp/mod3.py: note: In member "makeC" of class "B":
+tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:1: note: In module imported here:
+tmp/mod1.py: note: At top level:
+tmp/mod1.py:3: error: Revealed type is 'builtins.int'
+
+[out2]
+main:1: note: In module imported here:
+tmp/mod1.py:3: error: Revealed type is 'builtins.int'
+
+[case testIncrementalIncidentalChangeWithBugCausesPropagation]
+import mod1
+
+[file mod1.py]
+from mod2 import A
+val = A().makeB().makeC().foo()
+reveal_type(val)
+
+[file mod2.py]
+from mod3 import B
+class A:
+    def makeB(self) -> B: return B()
+
+[file mod3.py]
+from mod4 import C
+class B:
+    def makeC(self) -> C:
+        val = 3  # type: int
+        val = "str"   # deliberately triggering error
+        return C()
+
+[file mod4.py]
+class C:
+    def foo(self) -> int: return 1
+
+[file mod4.py.next]
+class C:
+    def foo(self) -> str: return 'a'
+
+[rechecked mod4, mod3, mod2, mod1]
+[stale mod4]
+[out1]
+tmp/mod2.py:1: note: In module imported here,
+tmp/mod1.py:1: note: ... from here,
+main:1: note: ... from here:
+tmp/mod3.py: note: In member "makeC" of class "B":
+tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:1: note: In module imported here:
+tmp/mod1.py: note: At top level:
+tmp/mod1.py:3: error: Revealed type is 'builtins.int'
+
+[out2]
+tmp/mod2.py:1: note: In module imported here,
+tmp/mod1.py:1: note: ... from here,
+main:1: note: ... from here:
+tmp/mod3.py: note: In member "makeC" of class "B":
+tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:1: note: In module imported here:
+tmp/mod1.py: note: At top level:
+tmp/mod1.py:3: error: Revealed type is 'builtins.str'
+
+[case testIncrementalIncidentalChangeWithBugFixCausesPropagation]
+import mod1
+
+[file mod1.py]
+from mod2 import A
+val = A().makeB().makeC().foo()
+reveal_type(val)
+
+[file mod2.py]
+from mod3 import B
+class A:
+    def makeB(self) -> B: return B()
+
+[file mod3.py]
+from mod4 import C
+class B:
+    def makeC(self) -> C:
+        val = 3  # type: int
+        val = "str"   # deliberately triggering error
+        return C()
+
+[file mod3.py.next]
+from mod4 import C
+class B:
+    def makeC(self) -> C: return C()
+
+[file mod4.py]
+class C:
+    def foo(self) -> int: return 1
+
+[file mod4.py.next]
+class C:
+    def foo(self) -> str: return 'a'
+
+[rechecked mod4, mod3, mod2, mod1]
+[stale mod4, mod3, mod2]
+[out1]
+tmp/mod2.py:1: note: In module imported here,
+tmp/mod1.py:1: note: ... from here,
+main:1: note: ... from here:
+tmp/mod3.py: note: In member "makeC" of class "B":
+tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:1: note: In module imported here:
+tmp/mod1.py: note: At top level:
+tmp/mod1.py:3: error: Revealed type is 'builtins.int'
+
+[out2]
+main:1: note: In module imported here:
+tmp/mod1.py:3: error: Revealed type is 'builtins.str'
+
 [case testIncrementalSilentImportsWithInnerImports]
 # cmd: mypy -m main foo
 # flags: --silent-imports
@@ -1170,7 +1378,7 @@ class MyClass:
 
 [rechecked main]
 [stale]
-[out]
+[out2]
 tmp/main.py:3: error: Revealed type is 'Any'
 
 [case testIncrementalSilentImportsWithInnerImportsAndNewFile]
@@ -1198,7 +1406,7 @@ def test() -> str: return "foo"
 
 [rechecked main, foo, unrelated]
 [stale foo, unrelated]
-[out]
+[out2]
 tmp/main.py:3: error: Revealed type is 'builtins.str'
 
 [case testIncrementalWorksWithNestedClasses]
@@ -1213,4 +1421,3 @@ class MyClass:
 
 [rechecked]
 [stale]
-[out]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1499,3 +1499,71 @@ class MyClass:
 
 [rechecked]
 [stale]
+
+[case testIncrementalWorksWithNamedTuple]
+import foo
+
+[file foo.py]
+from mid import MyTuple
+def accept_int(x: int) -> None: pass
+accept_int(MyTuple(1, "b", "c").a)
+
+[file mid.py]
+from bar import MyTuple
+
+[file bar.py]
+from typing import NamedTuple
+MyTuple = NamedTuple('MyTuple', [
+    ('a', int),
+    ('b', str),
+    ('c', str)
+])
+
+[file bar.py.next]
+from typing import NamedTuple
+MyTuple = NamedTuple('MyTuple', [
+    ('b', int),  # a and b are swapped
+    ('a', str),
+    ('c', str)
+])
+
+[rechecked bar, mid, foo]
+[stale bar]
+[out2]
+main:1: note: In module imported here:
+tmp/foo.py:3: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
+
+[case testIncrementalWorksWithNestedNamedTuple]
+import foo
+
+[file foo.py]
+from mid import Outer 
+def accept_int(x: int) -> None: pass
+accept_int(Outer.MyTuple(1, "b", "c").a)
+
+[file mid.py]
+from bar import Outer 
+
+[file bar.py]
+from typing import NamedTuple
+class Outer:
+    MyTuple = NamedTuple('MyTuple', [
+        ('a', int),
+        ('b', str),
+        ('c', str)
+    ])
+
+[file bar.py.next]
+from typing import NamedTuple
+class Outer:
+    MyTuple = NamedTuple('MyTuple', [
+        ('b', int),  # a and b are swapped
+        ('a', str),
+        ('c', str)
+    ])
+
+[rechecked bar, mid, foo]
+[stale bar]
+[out2]
+main:1: note: In module imported here:
+tmp/foo.py:3: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"

--- a/test-data/unit/fixtures/args.pyi
+++ b/test-data/unit/fixtures/args.pyi
@@ -26,3 +26,4 @@ class int:
 class str: pass
 class bool: pass
 class function: pass
+class module: pass

--- a/test-data/unit/fixtures/module.pyi
+++ b/test-data/unit/fixtures/module.pyi
@@ -1,8 +1,18 @@
+from typing import Any, Dict, Generic, TypeVar
+
+T = TypeVar('T')
+S = TypeVar('S')
+
 class object:
     def __init__(self) -> None: pass
-class module: pass
+class module:
+    __name__ = ...  # type: str
+    __file__ = ...  # type: str
+    __dict__ = ...  # type: Dict[str, Any]
 class type: pass
 class function: pass
 class int: pass
 class str: pass
 class bool: pass
+class tuple: pass
+class dict(Generic[T, S]): pass


### PR DESCRIPTION
This pull request modifies the typechecking phase and adds a new visitor to check types used within a particular module to find indirect module dependencies. These indirect module dependencies are then added to the set of a module's dependencies with a lowered priority so that they may be easily referenced when attempting to check if a module's dependencies have a stale interface or not. Now, instead of having to search through the import graph to see if a module's interface is stale or not, I only need to check the set of dependencies for that module, which is a potential optimization gain.

I've done some informal testing, and it seems like this optimization will decrease the time it takes for mypy to recheck a project after changing the interface of a single file by roughly 20% to 50%, depending on exactly which file is rechecked/the size of the repo. (If a project happens to have very few indirect dependencies, the percentage will naturally trend closer to 0%.)

However, this optimization does slow down how long it takes to run mypy with either a completely cold cache or a completely warm cache by approximately 5% to 10%. Figuring out how to speed up the changes in these cases is something I will most likely try solving in a separate pull request, unless I'm hit by a sudden burst of inspiration.

---

**More details:**

I define the term "indirect dependency" as a module that is not explicitly imported but still affects the types of the current module. For example, consider the following program:

```python
[file main.py]
from mod1 import A
localC = A().makeB()  # implicit dependency on mod3
val = localC.foo()  # implicit dependency on mod3

[file unrelated.py]
import mod2
def foo() -> None:
    mod2.unrelated_function_here()  # etc...

[file mod1.py]
from mod2 import B
class A:
    def makeB(self) -> B: return B()

[file mod2.py]
from mod3 import B
def unrelated_function_here() -> None:
    bar = B().foo() # etc...

[file mod3.py]
class B:
    def foo(self) -> int: return 0
```

In this test case, `mod1` is an **direct dependency** of `main`, since it is directly imported. Module `mod3.py` is an **indirect dependency** of `main`, since it was not directly imported, but does affect the type of the `val` global variable of `main` and therefore its public interface.

Note that `mod2` is neither a direct or indirect dependency of `main`, since `main` does not in any way use types or symbols that were defined within `mod2`.

However, `mod2` _is_ an **direct dependency** of `unrelated`. Note that `mod3` is neither a direct nor indirect dependency of `unrelated`.

This test case forms the following import graph (omitting the `builtins` module and all associated machinery):

```
  . . . . . . . . . . . . . . . . . . . .
  :                         :           :
  :                         V           V
mod3 ------> mod2 ------> mod1 ------> main
              |
              +-----> unrelated
```

The solid lines indicate direct dependencies, and the dotted lines indicate indirect dependencies. (The dependees point to the dependers).

The problem here is that if `mod3`'s interface is changed, we would also need to check `mod2` and all of its dependencies recursively since we have no idea what modules later in the import graph indirectly rely on us. So, in the current version of incremental mode, an interface change to `mod3` forces us to recheck the entire graph, including the `unrelated` module.

**Proposal:**

My proposal is to perform an operation similar to a transitive closure and explicitly record the indirect dependencies within the `dependencies` field of the `BuildState` class, and assign each indirect dependency a lowered priority compared to any import.

I then propose to remove the current requirement that an interface change in a module automatically forces an interface change in anything that imports it.

Instead, since we explicitly keep track of both direct and indirect dependencies, it should be sufficient to just check those enumerated files. So that means in this case, an interface change in `mod3` would trigger a recheck in `mod2`, `mod1`, and `main`, but NOT in `unrelated`. Since `mod2`'s interface would not be changed by an interface change in `mod2` (unless we delete or rename the `B` class, the `unrelated` module would not need to be rechecked in any way in most cases.

More visually, to determine if we need to recheck a module, we follow the arrows backwards exactly once.

This doesn't seem like a huge win here since we get to save rechecking only a single file, but if the `unrelated` module is subsequently imported by many different modules, this change allows us to avoid having to recheck a potentially large, unconnected SCC.

**Potential concerns:**

The main danger of this change is that it works by changing the import graph AFTER the files are fully typechecked. (The reason why we can only record these changes after the typechecking phase is because we need to know what the finalized types in the AST are before we can reliably determine what our indirect dependencies are).

This means in incremental mode, the import graph will look different on the second run of mypy compared to the first (though all subsequent runs should have the same import graph).

For example, if we take the above test case, the import graph would look like:

```
mod3 ------> mod2 ------> mod1 ------> main
              |
              +-----> unrelated
```

...at the start of the first run (when incremental mode is enabled), but would look like:

```
  . . . . . . . . . . . . . . . . . . . .
  :                         :           :
  :                         V           V
mod3 ------> mod2 ------> mod1 ------> main
              |
              +-----> unrelated
```

...at the start of all subsequent runs. This ends up breaking the invariant that incremental mode does not change the import graph and that the import graph looks the same between incremental mode and non-incremental mode. This may have subtle implications in complex graphs involving many cycles.

**Sketch of correctness:**

However, I believe this change is a safe one. If we have an indirect dependency between modules A and B, that means there must have been a *direct* chain of dependencies of the form `A -> mod1 -> mod2 -> ... -> modN -> B`. This means that module A would have been naturally loaded before B anyways, and adding a low-priority arrow connecting the two does not change the results. (That is, the existing SCC generation code produces a partial ordering of the modules by performing a modified topographical sort, and adding more arrows in the manner described above shouldn't seem like it should change that partial ordering).

Since the indirect dependencies are also given a lowered priority then any other module, they also shouldn't drastically affect how the SCC generation/sorting code works, since every other kind of import will take priority.

**Rejected idea:**

The original plan was to simply just outlaw indirect dependencies altogether, which worked beautifully well in the following case:

```python
[file main.py]
import mod1
mod1.mod2.value  #  Implicit dependency on mod2!

[file mod1.py]
import mod2

[file mod2.py]
value = 3
```

...but proved impossible in cases similar to the first test case listed above.

It also turned out that regular code contained far too many indirect dependencies of the first form in regular code, making outlawing them a non-starter.