### PR TITLE
Add --find-occurrences experimental option

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -18,6 +18,8 @@ from mypy.semanal import self_type
 from mypy import messages
 from mypy import subtypes
 
+from mypy import experiments
+
 
 def analyze_member_access(name: str,
                           typ: Type,
@@ -51,6 +53,11 @@ def analyze_member_access(name: str,
         info = typ.type
         if override_info:
             info = override_info
+
+        if (experiments.find_occurrences and
+                info.name() == experiments.find_occurrences[0] and
+                name == experiments.find_occurrences[1]):
+            msg.note("Occurrence of '{}.{}'".format(*experiments.find_occurrences), node)
 
         # Look up the member. First look up the method dictionary.
         method = info.get_method(name)

--- a/mypy/experiments.py
+++ b/mypy/experiments.py
@@ -1,1 +1,3 @@
+from typing import Optional, Tuple
 STRICT_OPTIONAL = False
+find_occurrences = None  # type: Optional[Tuple[str, str]]

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -181,6 +181,9 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
                         help="dump type inference stats")
     parser.add_argument('--custom-typing', metavar='MODULE', dest='custom_typing_module',
                         help="use a custom typing module")
+    parser.add_argument('--find-occurrences', metavar='CLASS.MEMBER',
+                        dest='special-opts:find_occurrences',
+                        help="print out all usages of a class member (experimental)")
     # deprecated options
     parser.add_argument('--silent', action='store_true', dest='special-opts:silent',
                         help=argparse.SUPPRESS)
@@ -258,6 +261,12 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
     # Set build flags.
     if special_opts.strict_optional:
         experiments.STRICT_OPTIONAL = True
+    if special_opts.find_occurrences:
+        experiments.find_occurrences = special_opts.find_occurrences.split('.')
+        if len(experiments.find_occurrences) < 2:
+            parser.error("Can only find occurrences of class members.")
+        if len(experiments.find_occurrences) != 2:
+            parser.error("Can only find occurrences of non-nested class members.")
 
     # Set reports.
     for flag, val in vars(special_opts).items():


### PR DESCRIPTION
I'm not sure if this is too hacky to merge, but I thought I'd put it up because it might be helpful to other people/to start a discussion.

Current problems:
- uses the `experiments` module to get a global variable inside `analyze_member_access`
- works only for non-nested class members

I've found it super-useful so already, though.