### PR TITLE
Add new --platform flag

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -8,7 +8,7 @@ summary of command line flags can always be printed using the ``-h``
 flag (or its long form ``--help``)::
 
   $ mypy -h
-  usage: mypy [-h] [-v] [-V] [--python-version x.y] [--os-platform PLATFORM]
+  usage: mypy [-h] [-v] [-V] [--python-version x.y] [--platform PLATFORM]
               [--py2] [-s] [--silent] [--almost-silent]
               [--disallow-untyped-calls] [--disallow-untyped-defs]
               [--check-untyped-defs]

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -8,9 +8,10 @@ summary of command line flags can always be printed using the ``-h``
 flag (or its long form ``--help``)::
 
   $ mypy -h
-  usage: mypy [-h] [-v] [-V] [--python-version x.y] [--py2] [-s] [--silent]
-              [--almost-silent] [--disallow-untyped-calls]
-              [--disallow-untyped-defs] [--check-untyped-defs]
+  usage: mypy [-h] [-v] [-V] [--python-version x.y] [--os-platform PLATFORM]
+              [--py2] [-s] [--silent] [--almost-silent]
+              [--disallow-untyped-calls] [--disallow-untyped-defs]
+              [--check-untyped-defs]
               [--warn-incomplete-stub] [--warn-redundant-casts]
               [--warn-unused-ignores] [--fast-parser] [-i] [--cache-dir DIR]
               [--strict-optional] [-f] [--pdb] [--use-python-path] [--stats]

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -107,6 +107,15 @@ class SplitNamespace(argparse.Namespace):
             return getattr(self._standard_namespace, name)
 
 
+def parse_version(v: str) -> Tuple[int, int]:
+    m = re.match(r'\A(\d)\.(\d+)\Z', v)
+    if m:
+        return int(m.group(1)), int(m.group(2))
+    else:
+        raise argparse.ArgumentTypeError(
+            "Invalid python version '{}' (expected format: 'x.y')".format(v))
+
+
 def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
     """Process command line arguments.
 
@@ -120,14 +129,6 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
                     argparse.RawDescriptionHelpFormatter(prog=prog, max_help_position=28))
     parser = argparse.ArgumentParser(prog='mypy', epilog=FOOTER,
                                      formatter_class=help_factory)
-
-    def parse_version(v: str) -> Tuple[int, int]:
-        m = re.match(r'\A(\d)\.(\d+)\Z', v)
-        if m:
-            return int(m.group(1)), int(m.group(2))
-        else:
-            raise argparse.ArgumentTypeError(
-                "Invalid python version '{}' (expected format: 'x.y')".format(v))
 
     # Unless otherwise specified, arguments will be parsed directly onto an
     # Options object.  Options that require further processing should have

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -139,6 +139,9 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
                         version='%(prog)s ' + __version__)
     parser.add_argument('--python-version', type=parse_version, metavar='x.y',
                         help='use Python x.y')
+    parser.add_argument('--os-platform', action='store', metavar='PLATFORM',
+                        help="typecheck special-cased code for the given OS platform "
+                        "(defaults to sys.platform).")
     parser.add_argument('-2', '--py2', dest='python_version', action='store_const',
                         const=defaults.PYTHON2_VERSION, help="use Python 2 mode")
     parser.add_argument('-s', '--silent-imports', action='store_true',

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -140,7 +140,7 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
                         version='%(prog)s ' + __version__)
     parser.add_argument('--python-version', type=parse_version, metavar='x.y',
                         help='use Python x.y')
-    parser.add_argument('--os-platform', action='store', metavar='PLATFORM',
+    parser.add_argument('--platform', action='store', metavar='PLATFORM',
                         help="typecheck special-cased code for the given OS platform "
                         "(defaults to sys.platform).")
     parser.add_argument('-2', '--py2', dest='python_version', action='store_const',

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -17,7 +17,7 @@ class Options:
         # -- build options --
         self.build_type = BuildType.STANDARD
         self.python_version = defaults.PYTHON3_VERSION
-        self.os_platform = sys.platform
+        self.platform = sys.platform
         self.custom_typing_module = None  # type: str
         self.report_dirs = {}  # type: Dict[str, str]
         self.silent_imports = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -1,5 +1,6 @@
 from mypy import defaults
 import pprint
+import sys
 from typing import Any
 
 
@@ -16,6 +17,7 @@ class Options:
         # -- build options --
         self.build_type = BuildType.STANDARD
         self.python_version = defaults.PYTHON3_VERSION
+        self.os_platform = sys.platform
         self.custom_typing_module = None  # type: str
         self.report_dirs = {}  # type: Dict[str, str]
         self.silent_imports = False

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1819,7 +1819,9 @@ class SemanticAnalyzer(NodeVisitor):
             self.fail("'continue' outside loop", s, True, blocker=True)
 
     def visit_if_stmt(self, s: IfStmt) -> None:
-        infer_reachability_of_if_statement(s, pyversion=self.options.python_version)
+        infer_reachability_of_if_statement(s,
+            pyversion=self.options.python_version,
+            osplatform=self.options.os_platform)
         for i in range(len(s.expr)):
             s.expr[i].accept(self)
             self.visit_block(s.body[i])
@@ -2473,6 +2475,7 @@ class FirstPass(NodeVisitor):
     def __init__(self, sem: SemanticAnalyzer) -> None:
         self.sem = sem
         self.pyversion = sem.options.python_version
+        self.osplatform = sem.options.os_platform
 
     def analyze(self, file: MypyFile, fnam: str, mod_id: str) -> None:
         """Perform the first analysis pass.
@@ -2641,7 +2644,7 @@ class FirstPass(NodeVisitor):
         self.sem.add_symbol(d.var.name(), SymbolTableNode(GDEF, d.var), d)
 
     def visit_if_stmt(self, s: IfStmt) -> None:
-        infer_reachability_of_if_statement(s, pyversion=self.pyversion)
+        infer_reachability_of_if_statement(s, pyversion=self.pyversion, osplatform=self.osplatform)
         for node in s.body:
             node.accept(self)
         if s.else_body:
@@ -2878,9 +2881,10 @@ def remove_imported_names_from_symtable(names: SymbolTable,
 
 
 def infer_reachability_of_if_statement(s: IfStmt,
-                                       pyversion: Tuple[int, int]) -> None:
+                                       pyversion: Tuple[int, int],
+                                       osplatform: str) -> None:
     for i in range(len(s.expr)):
-        result = infer_if_condition_value(s.expr[i], pyversion)
+        result = infer_if_condition_value(s.expr[i], pyversion, osplatform)
         if result == ALWAYS_FALSE:
             # The condition is always false, so we skip the if/elif body.
             mark_block_unreachable(s.body[i])
@@ -2894,7 +2898,7 @@ def infer_reachability_of_if_statement(s: IfStmt,
             break
 
 
-def infer_if_condition_value(expr: Node, pyversion: Tuple[int, int]) -> int:
+def infer_if_condition_value(expr: Node, pyversion: Tuple[int, int], osplatform: str) -> int:
     """Infer whether if condition is always true/false.
 
     Return ALWAYS_TRUE if always true, ALWAYS_FALSE if always false,
@@ -2915,7 +2919,7 @@ def infer_if_condition_value(expr: Node, pyversion: Tuple[int, int]) -> int:
     else:
         result = consider_sys_version_info(expr, pyversion)
         if result == TRUTH_VALUE_UNKNOWN:
-            result = consider_sys_platform(expr, sys.platform)
+            result = consider_sys_platform(expr, osplatform)
     if result == TRUTH_VALUE_UNKNOWN:
         if name == 'PY2':
             result = ALWAYS_TRUE if pyversion[0] == 2 else ALWAYS_FALSE

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -280,7 +280,7 @@ class TypeCheckSuite(DataSuite):
         options = Options()
         flags = re.search('# options: (.*)$', program_text, flags=re.MULTILINE)
         version_flag = re.search('# pyversion: (.*)$', program_text, flags=re.MULTILINE)
-        platform_flag = re.search('# osplatform: (.*)$', program_text, flags=re.MULTILINE)
+        platform_flag = re.search('# platform: (.*)$', program_text, flags=re.MULTILINE)
 
         if flags:
             options_to_enable = flags.group(1).split()
@@ -294,6 +294,6 @@ class TypeCheckSuite(DataSuite):
             options.python_version = testcase_pyversion(testcase.file, testcase.name)
 
         if platform_flag:
-            options.os_platform = platform_flag.group(1)
+            options.platform = platform_flag.group(1)
 
         return options

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -9,6 +9,7 @@ import time
 from typing import Tuple, List, Dict, Set
 
 from mypy import build, defaults
+from mypy.main import parse_version
 from mypy.build import BuildSource, find_module_clear_caches
 from mypy.myunit import AssertionFailure
 from mypy.test.config import test_temp_dir, test_data_prefix
@@ -109,9 +110,8 @@ class TypeCheckSuite(DataSuite):
         original_program_text = '\n'.join(testcase.input)
         module_data = self.parse_module(original_program_text, incremental)
 
-        options = self.parse_options(original_program_text)
+        options = self.parse_options(original_program_text, testcase)
         options.use_builtins_fixtures = True
-        options.python_version = testcase_pyversion(testcase.file, testcase.name)
         set_show_tb(True)  # Show traceback on crash.
 
         output = testcase.output
@@ -276,11 +276,24 @@ class TypeCheckSuite(DataSuite):
         else:
             return [('__main__', 'main', program_text)]
 
-    def parse_options(self, program_text: str) -> Options:
+    def parse_options(self, program_text: str, testcase: DataDrivenTestCase) -> Options:
         options = Options()
-        m = re.search('# options: (.*)$', program_text, flags=re.MULTILINE)
-        if m:
-            options_to_enable = m.group(1).split()
+        flags = re.search('# options: (.*)$', program_text, flags=re.MULTILINE)
+        version_flag = re.search('# pyversion: (.*)$', program_text, flags=re.MULTILINE)
+        platform_flag = re.search('# osplatform: (.*)$', program_text, flags=re.MULTILINE)
+
+        if flags:
+            options_to_enable = flags.group(1).split()
             for opt in options_to_enable:
                 setattr(options, opt, True)
+
+        # Allow custom pyversion comment to override testcase_pyversion
+        if version_flag:
+            options.python_version = parse_version(version_flag.group(1))
+        else:
+            options.python_version = testcase_pyversion(testcase.file, testcase.name)
+
+        if platform_flag:
+            options.os_platform = platform_flag.group(1)
+
         return options

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -365,7 +365,7 @@ reveal_type(x)  # E: Revealed type is 'builtins.int'
 [out]
 
 [case testCustomSysPlatform]
-# osplatform: linux
+# platform: linux
 import sys
 if sys.platform == 'linux':
     x = "foo"
@@ -376,7 +376,7 @@ reveal_type(x)  # E: Revealed type is 'builtins.str'
 [out]
 
 [case testCustomSysPlatform2]
-# osplatform: win32
+# platform: win32
 import sys
 if sys.platform == 'linux':
     x = "foo"
@@ -387,7 +387,7 @@ reveal_type(x)  # E: Revealed type is 'builtins.int'
 [out]
 
 [case testCustomSysPlatformStartsWith]
-# osplatform: win32
+# platform: win32
 import sys
 if sys.platform.startswith('win'):
     x = "foo"

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -341,3 +341,58 @@ class C:
 [builtins fixtures/ops.pyi]
 [out]
 main: note: In member "foo" of class "C":
+
+[case testCustomSysVersionInfo]
+# pyversion: 3.2
+import sys
+if sys.version_info == (3, 2):
+    x = "foo"
+else:
+    x = 3
+reveal_type(x)  # E: Revealed type is 'builtins.str'
+[builtins fixtures/ops.pyi]
+[out]
+
+[case testCustomSysVersionInfo2]
+# pyversion: 3.1
+import sys
+if sys.version_info == (3, 2):
+    x = "foo"
+else:
+    x = 3
+reveal_type(x)  # E: Revealed type is 'builtins.int'
+[builtins fixtures/ops.pyi]
+[out]
+
+[case testCustomSysPlatform]
+# osplatform: linux
+import sys
+if sys.platform == 'linux':
+    x = "foo"
+else:
+    x = 3
+reveal_type(x)  # E: Revealed type is 'builtins.str'
+[builtins fixtures/ops.pyi]
+[out]
+
+[case testCustomSysPlatform2]
+# osplatform: win32
+import sys
+if sys.platform == 'linux':
+    x = "foo"
+else:
+    x = 3
+reveal_type(x)  # E: Revealed type is 'builtins.int'
+[builtins fixtures/ops.pyi]
+[out]
+
+[case testCustomSysPlatformStartsWith]
+# osplatform: win32
+import sys
+if sys.platform.startswith('win'):
+    x = "foo"
+else:
+    x = 3
+reveal_type(x)  # E: Revealed type is 'builtins.str'
+[builtins fixtures/ops.pyi]
+[out]

--- a/test-data/unit/fixtures/ops.pyi
+++ b/test-data/unit/fixtures/ops.pyi
@@ -1,4 +1,4 @@
-from typing import builtinclass, overload, Any, Generic, Sequence, TypeVar
+from typing import builtinclass, overload, Any, Generic, Sequence, Tuple, TypeVar
 
 Tco = TypeVar('Tco', covariant=True)
 
@@ -30,6 +30,7 @@ class bool: pass
 class str:
     def __init__(self, x: 'int') -> None: pass
     def __add__(self, x: 'str') -> 'str': pass
+    def startswith(self, x: 'str') -> bool: pass
 
 class int:
     def __add__(self, x: 'int') -> 'int': pass
@@ -54,3 +55,5 @@ True = None # type: bool
 False = None # type: bool
 
 def __print(a1=None, a2=None, a3=None, a4=None): pass
+
+class module: pass


### PR DESCRIPTION
This pull request implements https://github.com/python/mypy/issues/1988 by adding a new `--platform` flag to allow the user to typecheck code specific to a particular operating system without having to actually run mypy on that OS.

It also modifies the test suite by adding `# pyversion: ...` and `# platform: ...` flags to let test suites pick and chose exactly which Python version/OS platform they should run under.

It also adds supports for checks of the form `if sys.platform.startswith(...)`. I added this check mainly because the Python docs seem to [explicitly recommend](https://docs.python.org/3/library/sys.html#sys.platform) using the `startswith` idiom over direct comparison.