### PR TITLE
Document --python-version and --platform

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -248,6 +248,17 @@ Here are some more useful flags:
   is faster than the default parser and supports multi-line comment
   function annotations (see :ref:`multi_line_annotation` for the details).
 
+- ``--python-version X.Y`` will make mypy typecheck your code as if it were
+  run under Python version X.Y. Without this option, mypy will default to using
+  whatever version of Python is running mypy. Note that the ``-2`` and
+  ``--py2`` flags are aliases for ``--python-version 2.7``. See
+  :ref:`version_and_platform_checks` for more about this feature.
+
+- ``--platform PLATFORM`` will make mypy typecheck your code as if it were
+  run under the the given operating system. Without this option, mypy will
+  default to using whatever operating system you are currently using. See
+  :ref:`version_and_platform_checks` for more about this feature.
+  
 For the remaining flags you can read the full ``mypy -h`` output.
 
 .. note::

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -189,7 +189,6 @@ More specifically, mypy will understand the use of ``sys.version_info`` and
 
 .. code-block:: python
 
-   from typing import Union, Text, Iterator
    import sys
 
    # Distinguishing between different versions of Python:

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -184,45 +184,30 @@ the targeted Python version or platform. This allows you to more effectively
 typecheck code that supports multiple versions of Python or multiple operating
 systems.
 
-More specifically, mypy understands ``if/elif`` statements of the following
-forms:
+More specifically, mypy will understand the use of ``sys.version_info`` and
+``sys.platform`` checks within ``if/elif/else`` statements. For example:
 
 .. code-block:: python
 
-   if sys.version_info[INT] COMPARE_OP INT:
-       ...
-
-   if sys.version_info[:INT] COMPARE_OP TUPLE_OF_N_INTS:
-       ...
-
-   if sys.version_info COMPARE_OP TUPLE_OF_1_OR_2_INTS:
-       # In this case, COMPARE_OP must be >, >=, <. <=, but not == or !=
-       ...
-
-   if sys.platform.startswith(STRING):
-       ...
-
-   if sys.platform COMPARE_OP STRING:
-       # In this case, COMPARE_OP must be == or !=
-       ...
-
-For example:
-
-.. code-block:: python
-
+   from typing import Union, Text, Iterator
    import sys
 
-   if sys.version_info[0] >= 3:
+   # Distinguishing between different versions of Python:
+   if sys.version_info >= (3, 5):
+       # Python 3.5+ specific definitions and imports
+   elif sys.version_info[0] >= 3:
        # Python 3 specific definitions and imports
    else:
        # Python 2 specific definitions and imports
 
-   if sys.platform.startswith("win32"):
-       # Windows specific code
-   elif sys.platform.startswith("cygwin"):
-       # Windows + Cygwin specific code
+   # Distinguishing between different operating systems:
+   if sys.platform.startswith("linux"):
+   elif sys.platform == "darwin":
+       # Mac-specific code
+   elif sys.platform == "win32":
+       # Windows-specific code
    else:
-       # Posix specific definitions.
+       # Other systems
 
 .. note::
 
@@ -238,10 +223,6 @@ To target a different Python version, use the ``--python-version X.Y`` flag.
 For example, to verify your code typechecks if were run using Python 2, pass
 in ``--python-version 2.7`` from the command line. Note that you do not need
 to have Python 2.7 installed to perform this check.
-
-Since typechecking your code against Python 2 is a common use case, mypy also
-provides the ``--py2`` and ``-2`` flags as aliases for
-``--python-version 2.7``.
 
 To target a different operating system, use the ``--platform PLATFORM`` flag.
 For example, to verify your code typechecks if it were run in Windows, pass

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -173,6 +173,82 @@ and difficult-to-predict failure modes and could result in very
 confusing error messages. The tradeoff is that you as a programmer
 sometimes have to give the type checker a little help.
 
+.. _version_and_platform_checks:
+
+Python version and system platform checks
+-----------------------------------------
+
+Mypy supports the ability to perform Python version checks and platform
+checks (e.g. Windows vs Posix), ignoring code paths that won't be run on
+the targeted Python version or platform. This allows you to more effectively
+typecheck code that supports multiple versions of Python or multiple operating
+systems.
+
+More specifically, mypy understands ``if/elif`` statements of the following
+forms:
+
+.. code-block:: python
+
+   if sys.version_info[INT] COMPARE_OP INT:
+       ...
+
+   if sys.version_info[:INT] COMPARE_OP TUPLE_OF_N_INTS:
+       ...
+
+   if sys.version_info COMPARE_OP TUPLE_OF_1_OR_2_INTS:
+       # In this case, COMPARE_OP must be >, >=, <. <=, but not == or !=
+       ...
+
+   if sys.platform.startswith(STRING):
+       ...
+
+   if sys.platform COMPARE_OP STRING:
+       # In this case, COMPARE_OP must be == or !=
+       ...
+
+For example:
+
+.. code-block:: python
+
+   import sys
+
+   if sys.version_info[0] >= 3:
+       # Python 3 specific definitions and imports
+   else:
+       # Python 2 specific definitions and imports
+
+   if sys.platform.startswith("win32"):
+       # Windows specific code
+   elif sys.platform.startswith("cygwin"):
+       # Windows + Cygwin specific code
+   else:
+       # Posix specific definitions.
+
+.. note::
+
+   Mypy currently does not support more complex checks, and does not assign
+   any special meaning when assigning a ``sys.version_info`` or ``sys.platform``
+   check to a variable. This may change in future versions of mypy.
+
+By default, mypy will use your current version of Python and your current
+operating system as default values for ``sys.version_info`` and
+``sys.platform``.
+
+To target a different Python version, use the ``--python-version X.Y`` flag.
+For example, to verify your code typechecks if were run using Python 2, pass
+in ``--python-version 2.7`` from the command line. Note that you do not need
+to have Python 2.7 installed to perform this check.
+
+Since typechecking your code against Python 2 is a common use case, mypy also
+provides the ``--py2`` and ``-2`` flags as aliases for
+``--python-version 2.7``.
+
+To target a different operating system, use the ``--platform PLATFORM`` flag.
+For example, to verify your code typechecks if it were run in Windows, pass
+in ``--platform win32``. See the documentation for
+`sys.platform <https://docs.python.org/3/library/sys.html#sys.platform>`_
+for examples of valid platform parameters.
+
 .. _reveal-type:
 
 Displaying the type of an expression

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -202,6 +202,7 @@ More specifically, mypy will understand the use of ``sys.version_info`` and
 
    # Distinguishing between different operating systems:
    if sys.platform.startswith("linux"):
+       # Linux-specific code
    elif sys.platform == "darwin":
        # Mac-specific code
    elif sys.platform == "win32":


### PR DESCRIPTION
This commit adds documentation for the `--python-version` and `--platform` command line arguments, as well as information on how to incorporate `sys.version_info` and `sys.platform` checks into a codebase.