### PR TITLE
Add option to limit strict Optional errors to whitelist of globs

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -227,6 +227,18 @@ Here are some more useful flags:
   use of ``None`` values -- they are valid everywhere. See :ref:`strict_optional` for
   more about this feature.
 
+- ``--strict-optional-whitelist`` attempts to suppress strict Optional-related
+  errors in non-whitelisted files.  Takes an arbitrary number of globs as the
+  whitelist.  This option is intended to be used to incrementally roll out
+  ``--strict-optional`` to a large codebase that already has mypy annotations.
+  However, this flag comes with some significant caveats.  It does not suppress
+  all errors caused by turning on ``--strict-optional``, only most of them, so
+  there may still be a bit of upfront work to be done before it can be used in
+  CI.  It will also suppress some errors that would be caught in a
+  non-strict-Optional run.  Therefore, when using this flag, you should also
+  re-check your code without ``--strict-optional`` to ensure new type errors
+  are not introduced.
+
 - ``--disallow-untyped-defs`` reports an error whenever it encounters
   a function definition without type annotations.
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2150,10 +2150,12 @@ class TypeChecker(NodeVisitor[Type]):
             return False
 
     def contains_none(self, t: Type):
-        return (isinstance(t, NoneTyp) or
-                (isinstance(t, UnionType) and any(self.contains_none(ut) for ut in t.items)) or
-                (isinstance(t, TupleType) and any(self.contains_none(tt) for tt in t.items)) or
-                (isinstance(t, Instance) and t.args and any(self.contains_none(it) for it in t.args)))
+        return (
+            isinstance(t, NoneTyp) or
+            (isinstance(t, UnionType) and any(self.contains_none(ut) for ut in t.items)) or
+            (isinstance(t, TupleType) and any(self.contains_none(tt) for tt in t.items)) or
+            (isinstance(t, Instance) and t.args and any(self.contains_none(it) for it in t.args))
+        )
 
     def should_suppress_optional_error(self, related_types: List[Type]) -> bool:
         return self.suppress_none_errors and any(self.contains_none(t) for t in related_types)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2135,7 +2135,7 @@ class TypeChecker(NodeVisitor[Type]):
             if self.is_unusable_type(subtype):
                 self.msg.does_not_return_value(subtype, context)
             else:
-                if self.should_suppress_optional_error([subtype, supertype]):
+                if self.should_suppress_optional_error([subtype]):
                     return False
                 extra_info = []  # type: List[str]
                 if subtype_label is not None or supertype_label is not None:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -874,7 +874,8 @@ class ExpressionChecker:
             # This is a reference to a non-module attribute.
             return analyze_member_access(e.name, self.accept(e.expr), e,
                                          is_lvalue, False, False,
-                                         self.named_type, self.not_ready_callback, self.msg, chk=self.chk)
+                                         self.named_type, self.not_ready_callback, self.msg,
+                                         chk=self.chk)
 
     def analyze_external_member_access(self, member: str, base_type: Type,
                                        context: Context) -> Type:
@@ -883,7 +884,8 @@ class ExpressionChecker:
         """
         # TODO remove; no private definitions in mypy
         return analyze_member_access(member, base_type, context, False, False, False,
-                                     self.named_type, self.not_ready_callback, self.msg, chk=self.chk)
+                                     self.named_type, self.not_ready_callback, self.msg,
+                                     chk=self.chk)
 
     def visit_int_expr(self, e: IntExpr) -> Type:
         """Type check an integer literal (trivial)."""
@@ -1035,7 +1037,8 @@ class ExpressionChecker:
         Return tuple (result type, inferred operator method type).
         """
         method_type = analyze_member_access(method, base_type, context, False, False, True,
-                                            self.named_type, self.not_ready_callback, local_errors, chk=self.chk)
+                                            self.named_type, self.not_ready_callback, local_errors,
+                                            chk=self.chk)
         return self.check_call(method_type, [arg], [nodes.ARG_POS],
                                context, arg_messages=local_errors)
 

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -17,7 +17,8 @@ from mypy.nodes import method_type, method_type_with_fallback
 from mypy.semanal import self_type
 from mypy import messages
 from mypy import subtypes
-import mypy.checker
+if False:  # import for forward declaration only
+    import mypy.checker
 
 
 def analyze_member_access(name: str,

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -91,7 +91,8 @@ def analyze_member_access(name: str,
         # The base object has dynamic type.
         msg.disable_type_names += 1
         results = [analyze_member_access(name, subtype, node, is_lvalue, is_super,
-                                         is_operator, builtin_type, not_ready_callback, msg, chk=chk)
+                                         is_operator, builtin_type, not_ready_callback, msg,
+                                         chk=chk)
                    for subtype in typ.items]
         msg.disable_type_names -= 1
         return UnionType.make_simplified_union(results)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -176,7 +176,7 @@ def process_options(args: List[str],
                         help="enable experimental strict Optional checks")
     parser.add_argument('--strict-optional-whitelist', metavar='GLOB', nargs='*',
                         help="suppress strict Optional errors in all but the provided files"
-                        " (experimental)")
+                        " (experimental).  Implies --strict-optional.")
     parser.add_argument('--pdb', action='store_true', help="invoke pdb on fatal error")
     parser.add_argument('--show-traceback', '--tb', action='store_true',
                         help="show traceback on fatal error")
@@ -271,7 +271,7 @@ def process_options(args: List[str],
             parser.error("May only specify one of: module, package, files, or command.")
 
     # Set build flags.
-    if special_opts.strict_optional:
+    if special_opts.strict_optional or options.strict_optional_whitelist is not None:
         experiments.STRICT_OPTIONAL = True
 
     # Set reports.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -175,8 +175,10 @@ def process_options(args: List[str],
                         dest='special-opts:strict_optional',
                         help="enable experimental strict Optional checks")
     parser.add_argument('--strict-optional-whitelist', metavar='GLOB', nargs='*',
-                        help="suppress strict Optional errors in all but the provided files"
-                        " (experimental).  Implies --strict-optional.")
+                        help="suppress strict Optional errors in all but the provided files "
+                        "(experimental -- read documentation before using!).  "
+                        "Implies --strict-optional.  Has the undesirable side-effect of "
+                        "suppressing other errors in non-whitelisted files.")
     parser.add_argument('--pdb', action='store_true', help="invoke pdb on fatal error")
     parser.add_argument('--show-traceback', '--tb', action='store_true',
                         help="show traceback on fatal error")

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -175,7 +175,8 @@ def process_options(args: List[str],
                         dest='special-opts:strict_optional',
                         help="enable experimental strict Optional checks")
     parser.add_argument('--strict-optional-whitelist', metavar='GLOB', nargs='*',
-                        help="suppress strict Optional errors in all but the provided files (experimental)")
+                        help="suppress strict Optional errors in all but the provided files"
+                        " (experimental)")
     parser.add_argument('--pdb', action='store_true', help="invoke pdb on fatal error")
     parser.add_argument('--show-traceback', '--tb', action='store_true',
                         help="show traceback on fatal error")

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -174,6 +174,8 @@ def process_options(args: List[str],
     parser.add_argument('--strict-optional', action='store_true',
                         dest='special-opts:strict_optional',
                         help="enable experimental strict Optional checks")
+    parser.add_argument('--strict-optional-whitelist', metavar='GLOB', nargs='*',
+                        help="suppress strict Optional errors in all but the provided files (experimental)")
     parser.add_argument('--pdb', action='store_true', help="invoke pdb on fatal error")
     parser.add_argument('--show-traceback', '--tb', action='store_true',
                         help="show traceback on fatal error")

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -1,7 +1,7 @@
 from mypy import defaults
 import pprint
 import sys
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, List
 
 
 class BuildType:
@@ -40,6 +40,10 @@ class Options:
 
         # Warn about unused '# type: ignore' comments
         self.warn_unused_ignores = False
+
+        # Files in which to allow strict-Optional related errors
+        self.strict_optional_whitelist = None   # type: Optional[List[str]]
+
         # -- development options --
         self.verbosity = 0  # More verbose messages (for troubleshooting)
         self.pdb = False

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -379,3 +379,52 @@ reveal_type(None if bool() else 0)  # E: Revealed type is 'Union[builtins.int, b
 [case testListWithNone]
 reveal_type([0, None, 0])    # E: Revealed type is 'builtins.list[Union[builtins.int, builtins.None]]'
 [builtins fixtures/list.pyi]
+
+[case testOptionalWhitelistSuppressesOptionalErrors]
+# flags: --strict-optional-whitelist
+import a
+import b
+[file a.py]
+from typing import Optional
+x = None  # type: Optional[str]
+x + "foo"
+
+[file b.py]
+from typing import Optional
+x = None  # type: Optional[int]
+x + 1
+
+[case testOptionalWhitelistPermitsOtherErrors]
+# flags: --strict-optional-whitelist
+import a
+import b
+[file a.py]
+from typing import Optional
+x = None  # type: Optional[str]
+x + "foo"
+
+[file b.py]
+from typing import Optional
+x = None  # type: Optional[int]
+x + 1
+1 + "foo"
+[out]
+main:3: note: In module imported here:
+tmp/b.py:4: error: Unsupported operand types for + ("int" and "str")
+
+[case testOptionalWhitelistPermitsWhitelistedFiles]
+# flags: --strict-optional-whitelist **/a.py
+import a
+import b
+[file a.py]
+from typing import Optional
+x = None  # type: Optional[str]
+x + "foo"
+
+[file b.py]
+from typing import Optional
+x = None  # type: Optional[int]
+x + 1
+[out]
+main:2: note: In module imported here:
+tmp/a.py:3: error: Unsupported left operand type for + (some union)


### PR DESCRIPTION
This allows you to suppress most, but not all, strict Optional related errors in all but a whitelist of files.  This is intended to help with rolling out strict Optional to large typed codebases.

Usage:
`mypy --strict-optional-whitelist [GLOB [GLOB [...]]] --strict-optional FILES`
If you omit all the globs, no paths will be whitelisted (i.e. all paths will be suppressed).  This can be useful to first fix strict Optional errors that the whitelisting fails to suppress.  Note that due to the way argparse parses args, you cannot use `--strict-optional-whitelist` as your last flag because it'll also gobble the list of files.