### PR TITLE
Remove Python 3.2 from trove classifier and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ type check them statically. Find bugs in your programs without even
 running them!
 
 The type annotation standard has also been backported to earlier
-Python 3.x versions.  Mypy supports Python 3.2 and later.
+Python 3.x versions.  Mypy supports Python 3.3 and later.
 
 For Python 2.7, you can add annotations as comments (this is also
 specified in [PEP 484](https://www.python.org/dev/peps/pep-0484/)).
@@ -56,7 +56,7 @@ See 'Development status' below.
 Requirements
 ------------
 
-You need Python 3.2 or later to run mypy.  You can have multiple Python
+You need Python 3.3 or later to run mypy.  You can have multiple Python
 versions (2.x and 3.x) installed on the same system without problems.
 
 In Ubuntu, Mint and Debian you can install Python 3 like this:

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ classifiers = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',
     'Operating System :: POSIX',
-    'Programming Language :: Python :: 3.2',
+    'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
[Mypy 0.4.3 dropped support for Python 3.2](https://mypy-lang.blogspot.com/2016/07/mypy-043-released.html).

This PR also adds the generic `'Programming Language :: Python :: 3'` trove classifier.

Question: Should

```python
if sys.version_info < (3, 2, 0):
    sys.stderr.write("ERROR: You need Python 3.2 or later to use mypy.\n")
    exit(1)
```

Be changed to?

```python
if sys.version_info < (3, 3, 0):
    sys.stderr.write("ERROR: You need Python 3.3 or later to use mypy.\n")
    exit(1)
```