### PR TITLE
Have test files specify flags instead of option names

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -116,13 +116,10 @@ def parse_version(v: str) -> Tuple[int, int]:
             "Invalid python version '{}' (expected format: 'x.y')".format(v))
 
 
-def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
-    """Process command line arguments.
-
-    Return (mypy program path (or None),
-            module to run as script (or None),
-            parsed flags)
-    """
+def process_options(args: List[str],
+                    require_targets: bool = True
+                    ) -> Tuple[List[BuildSource], Options]:
+    """Parse command line arguments."""
 
     # Make the help output a little less jarring.
     help_factory = (lambda prog:
@@ -259,14 +256,15 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
               file=sys.stderr)
 
     # Check for invalid argument combinations.
-    code_methods = sum(bool(c) for c in [special_opts.modules,
-                                         special_opts.command,
-                                         special_opts.package,
-                                         special_opts.files])
-    if code_methods == 0:
-        parser.error("Missing target module, package, files, or command.")
-    elif code_methods > 1:
-        parser.error("May only specify one of: module, package, files, or command.")
+    if require_targets:
+        code_methods = sum(bool(c) for c in [special_opts.modules,
+                                            special_opts.command,
+                                            special_opts.package,
+                                            special_opts.files])
+        if code_methods == 0:
+            parser.error("Missing target module, package, files, or command.")
+        elif code_methods > 1:
+            parser.error("May only specify one of: module, package, files, or command.")
 
     # Set build flags.
     if special_opts.strict_optional:

--- a/mypy/test/testargs.py
+++ b/mypy/test/testargs.py
@@ -13,9 +13,6 @@ from mypy.main import process_options
 
 class ArgSuite(Suite):
     def test_coherence(self):
-        # We have to special case Options.BuildType because we're required to
-        # set a target
         options = Options()
-        options.build_type = BuildType.PROGRAM_TEXT
-        _, parsed_options = process_options(['-c', 'cmd'])
+        _, parsed_options = process_options([], require_targets=False)
         assert_equal(options, parsed_options)

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -283,7 +283,10 @@ class TypeCheckSuite(DataSuite):
         flag_list = None
         if flags:
             flag_list = flags.group(1).split()
-            _, options = process_options(flag_list, require_targets=False)
+            targets, options = process_options(flag_list, require_targets=False)
+            if targets:
+                # TODO: support specifying targets via the flags pragma
+                raise RuntimeError('Specifying targets via the flags pragma is not supported.')
         else:
             options = Options()
 

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -288,7 +288,8 @@ class TypeCheckSuite(DataSuite):
             options = Options()
 
         # Allow custom python version to override testcase_pyversion
-        if not flag_list or '--python-version' not in flag_list:
+        if (not flag_list or
+                all(flag not in flag_list for flag in ['--python-version', '-2', '--py2'])):
             options.python_version = testcase_pyversion(testcase.file, testcase.name)
 
         return options

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -2,20 +2,20 @@
 -- ---------------------------------------
 
 [case testAsyncDefPass]
-# options: fast_parser
+# flags: --fast-parser
 async def f() -> int:
     pass
 [builtins fixtures/async_await.pyi]
 
 [case testAsyncDefReturn]
-# options: fast_parser
+# flags: --fast-parser
 async def f() -> int:
     return 0
 reveal_type(f())  # E: Revealed type is 'typing.Awaitable[builtins.int]'
 [builtins fixtures/async_await.pyi]
 
 [case testAwaitCoroutine]
-# options: fast_parser
+# flags: --fast-parser
 async def f() -> int:
     x = await f()
     reveal_type(x)  # E: Revealed type is 'builtins.int*'
@@ -25,7 +25,7 @@ async def f() -> int:
 main: note: In function "f":
 
 [case testAwaitDefaultContext]
-# options: fast_parser
+# flags: --fast-parser
 from typing import TypeVar
 T = TypeVar('T')
 async def f(x: T) -> T:
@@ -37,7 +37,7 @@ main: note: In function "f":
 main:6: error: Revealed type is 'T`-1'
 
 [case testAwaitAnyContext]
-# options: fast_parser
+# flags: --fast-parser
 from typing import Any, TypeVar
 T = TypeVar('T')
 async def f(x: T) -> T:
@@ -49,7 +49,7 @@ main: note: In function "f":
 main:6: error: Revealed type is 'Any'
 
 [case testAwaitExplicitContext]
-# options: fast_parser
+# flags: --fast-parser
 from typing import TypeVar
 T = TypeVar('T')
 async def f(x: T) -> T:
@@ -61,7 +61,7 @@ main:5: error: Argument 1 to "f" has incompatible type "T"; expected "int"
 main:6: error: Revealed type is 'builtins.int'
 
 [case testAwaitGeneratorError]
-# options: fast_parser
+# flags: --fast-parser
 from typing import Any, Generator
 def g() -> Generator[int, None, str]:
     yield 0
@@ -74,7 +74,7 @@ main: note: In function "f":
 main:7: error: Incompatible types in await (actual type Generator[int, None, str], expected type "Awaitable")
 
 [case testAwaitIteratorError]
-# options: fast_parser
+# flags: --fast-parser
 from typing import Any, Iterator
 def g() -> Iterator[Any]:
     yield
@@ -86,7 +86,7 @@ main: note: In function "f":
 main:6: error: Incompatible types in await (actual type Iterator[Any], expected type "Awaitable")
 
 [case testAwaitArgumentError]
-# options: fast_parser
+# flags: --fast-parser
 def g() -> int:
     return 0
 async def f() -> int:
@@ -98,7 +98,7 @@ main: note: In function "f":
 main:5: error: Incompatible types in await (actual type "int", expected type "Awaitable")
 
 [case testAwaitResultError]
-# options: fast_parser
+# flags: --fast-parser
 async def g() -> int:
     return 0
 async def f() -> str:
@@ -109,7 +109,7 @@ main: note: In function "f":
 main:5: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testAwaitReturnError]
-# options: fast_parser
+# flags: --fast-parser
 async def g() -> int:
     return 0
 async def f() -> str:
@@ -121,7 +121,7 @@ main: note: In function "f":
 main:6: error: Incompatible return value type (got "int", expected "str")
 
 [case testAsyncFor]
-# options: fast_parser
+# flags: --fast-parser
 from typing import AsyncIterator
 class C(AsyncIterator[int]):
     async def __anext__(self) -> int: return 0
@@ -133,7 +133,7 @@ async def f() -> None:
 main: note: In function "f":
 
 [case testAsyncForError]
-# options: fast_parser
+# flags: --fast-parser
 from typing import AsyncIterator
 async def f() -> None:
     async for x in [1]:
@@ -145,7 +145,7 @@ main:4: error: AsyncIterable expected
 main:4: error: List[int] has no attribute "__aiter__"
 
 [case testAsyncWith]
-# options: fast_parser
+# flags: --fast-parser
 class C:
     async def __aenter__(self) -> int: pass
     async def __aexit__(self, x, y, z) -> None: pass
@@ -157,7 +157,7 @@ async def f() -> None:
 main: note: In function "f":
 
 [case testAsyncWithError]
-# options: fast_parser
+# flags: --fast-parser
 class C:
     def __enter__(self) -> int: pass
     def __exit__(self, x, y, z) -> None: pass
@@ -171,7 +171,7 @@ main:6: error: "C" has no attribute "__aenter__"; maybe "__enter__"?
 main:6: error: "C" has no attribute "__aexit__"; maybe "__exit__"?
 
 [case testAsyncWithErrorBadAenter]
-# options: fast_parser
+# flags: --fast-parser
 class C:
     def __aenter__(self) -> int: pass
     async def __aexit__(self, x, y, z) -> None: pass
@@ -183,7 +183,7 @@ async def f() -> None:
 main: note: In function "f":
 
 [case testAsyncWithErrorBadAenter2]
-# options: fast_parser
+# flags: --fast-parser
 class C:
     def __aenter__(self) -> None: pass
     async def __aexit__(self, x, y, z) -> None: pass
@@ -195,7 +195,7 @@ async def f() -> None:
 main: note: In function "f":
 
 [case testAsyncWithErrorBadAexit]
-# options: fast_parser
+# flags: --fast-parser
 class C:
     async def __aenter__(self) -> int: pass
     def __aexit__(self, x, y, z) -> int: pass
@@ -207,7 +207,7 @@ async def f() -> None:
 main: note: In function "f":
 
 [case testAsyncWithErrorBadAexit2]
-# options: fast_parser
+# flags: --fast-parser
 class C:
     async def __aenter__(self) -> int: pass
     def __aexit__(self, x, y, z) -> None: pass
@@ -219,7 +219,7 @@ async def f() -> None:
 main: note: In function "f":
 
 [case testNoYieldInAsyncDef]
-# options: fast_parser
+# flags: --fast-parser
 async def f():
     yield None
 async def g():
@@ -236,7 +236,7 @@ main: note: In function "h":
 main:7: error: 'yield' in async function
 
 [case testNoYieldFromInAsyncDef]
-# options: fast_parser
+# flags: --fast-parser
 async def f():
     yield from []
 async def g():
@@ -249,12 +249,12 @@ main: note: In function "g":
 main:5: error: 'yield from' in async function
 
 [case testNoAsyncDefInPY2_python2]
-# options: fast_parser
+# flags: --fast-parser
 async def f():  # E: invalid syntax
     pass
 
 [case testYieldFromNoAwaitable]
-# options: fast_parser
+# flags: --fast-parser
 from typing import Any, Generator
 async def f() -> str:
     return ''
@@ -267,7 +267,7 @@ main: note: In function "g":
 main:6: error: "yield from" can't be applied to Awaitable[str]
 
 [case testAwaitableSubclass]
-# options: fast_parser
+# flags: --fast-parser
 from typing import Any, AsyncIterator, Awaitable, Generator
 class A(Awaitable[int]):
     def __await__(self) -> Generator[Any, None, int]:
@@ -295,7 +295,7 @@ async def main() -> None:
 main: note: In function "main":
 
 [case testYieldTypeCheckInDecoratedCoroutine]
-# options: fast_parser
+# flags: --fast-parser
 from typing import Generator
 from types import coroutine
 @coroutine
@@ -316,7 +316,7 @@ main: note: In function "f":
 -- ------------------------------------------
 
 [case testFullCoroutineMatrix]
-# options: fast_parser suppress_error_context
+# flags: --fast-parser --suppress-error-context
 from typing import Any, AsyncIterator, Awaitable, Generator, Iterator
 from types import coroutine
 

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1583,12 +1583,12 @@ None < None  # E: Unsupported left operand type for < (None)
 [builtins fixtures/ops.pyi]
 
 [case testDictWithStarExpr]
-# options: fast_parser
+# flags: --fast-parser
 b = {'z': 26, *a}  # E: invalid syntax
 [builtins fixtures/dict.pyi]
 
 [case testDictWithStarStarExpr]
-# options: fast_parser
+# flags: --fast-parser
 from typing import Dict
 a = {'a': 1}
 b = {'z': 26, **a}

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -1,31 +1,31 @@
 [case testFastParseSyntaxError]
-# options: fast_parser
+# flags: --fast-parser
 1 +  # E: invalid syntax
 
 [case testFastParseTypeCommentSyntaxError]
-# options: fast_parser
+# flags: --fast-parser
 x = None # type: a : b  # E: syntax error in type comment
 
 [case testFastParseInvalidTypeComment]
-# options: fast_parser
+# flags: --fast-parser
 x = None # type: a + b  # E: invalid type comment
 
 -- Function type comments are attributed to the function def line.
 -- This happens in both parsers.
 [case testFastParseFunctionAnnotationSyntaxError]
-# options: fast_parser
+# flags: --fast-parser
 def f():  # E: syntax error in type comment
   # type: None -> None
   pass
 
 [case testFastParseInvalidFunctionAnnotation]
-# options: fast_parser
+# flags: --fast-parser
 def f():  # E: invalid type comment
   # type: (a + b) -> None
   pass
 
 [case testFastParseProperty]
-# options: fast_parser
+# flags: --fast-parser
 class C:
   @property
   def x(self) -> str: pass
@@ -34,7 +34,7 @@ class C:
 [builtins fixtures/property.pyi]
 
 [case testFastParseConditionalProperty]
-# options: fast_parser
+# flags: --fast-parser
 class C:
   if 1:
     @property
@@ -44,7 +44,7 @@ class C:
 [builtins fixtures/property.pyi]
 
 [case testFastParsePerArgumentAnnotations]
-# options: fast_parser
+# flags: --fast-parser
 class A: pass
 class B: pass
 class C: pass
@@ -69,7 +69,7 @@ def f(a,        # type: A
 main: note: In function "f":
 
 [case testFastParsePerArgumentAnnotationsWithReturn]
-# options: fast_parser
+# flags: --fast-parser
 class A: pass
 class B: pass
 class C: pass
@@ -96,7 +96,7 @@ def f(a,        # type: A
 main: note: In function "f":
 
 [case testFastParsePerArgumentAnnotationsWithAnnotatedBareStar]
-# options: fast_parser
+# flags: --fast-parser
 def f(*, # type: int  # E: bare * has associated type comment
       x  # type: str
       ):
@@ -106,7 +106,7 @@ def f(*, # type: int  # E: bare * has associated type comment
 [out]
 
 [case testFastParsePerArgumentAnnotationsWithReturnAndBareStar]
-# options: fast_parser
+# flags: --fast-parser
 def f(*,
       x  # type: str
       ):
@@ -118,7 +118,7 @@ def f(*,
 main: note: In function "f":
 
 [case testFastParsePerArgumentAnnotations_python2]
-# options: fast_parser
+# flags: --fast-parser
 class A: pass
 class B: pass
 class C: pass
@@ -136,7 +136,7 @@ def f(a,        # type: A
 main: note: In function "f":
 
 [case testFastParsePerArgumentAnnotationsWithReturn_python2]
-# options: fast_parser
+# flags: --fast-parser
 class A: pass
 class B: pass
 class C: pass
@@ -156,7 +156,7 @@ def f(a,        # type: A
 main: note: In function "f":
 
 [case testFasterParseTooManyArgumentsAnnotation]
-# options: fast_parser
+# flags: --fast-parser
 def f():  # E: Type signature has too many arguments
     # type: (int) -> None
     pass
@@ -164,7 +164,7 @@ def f():  # E: Type signature has too many arguments
 main: note: In function "f":
 
 [case testFasterParseTooFewArgumentsAnnotation]
-# options: fast_parser
+# flags: --fast-parser
 def f(x):  # E: Type signature has too few arguments
     # type: () -> None
     pass

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1,36 +1,36 @@
 [case testUnannotatedFunction]
-# options: disallow_untyped_defs
+# flags: --disallow-untyped-defs
 def f(x): pass
 [out]
 main: note: In function "f":
 main:2: error: Function is missing a type annotation
 
 [case testUnannotatedArgument]
-# options: disallow_untyped_defs
+# flags: --disallow-untyped-defs
 def f(x) -> int: pass
 [out]
 main: note: In function "f":
 main:2: error: Function is missing a type annotation for one or more arguments
 
 [case testNoArgumentFunction]
-# options: disallow_untyped_defs
+# flags: --disallow-untyped-defs
 def f() -> int: pass
 [out]
 
 [case testUnannotatedReturn]
-# options: disallow_untyped_defs
+# flags: --disallow-untyped-defs
 def f(x: int): pass
 [out]
 main: note: In function "f":
 main:2: error: Function is missing a return type annotation
 
 [case testLambda]
-# options: disallow_untyped_defs
+# flags: --disallow-untyped-defs
 lambda x: x
 [out]
 
 [case testUntypedDef]
-# options: disallow_untyped_defs
+# flags: --disallow-untyped-defs
 def f():
     1 + "str"
 [out]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -739,7 +739,7 @@ main:1: note: In module imported here:
 tmp/b.py:4: error: Name 'a' already defined
 
 [case testIncrementalSilentImportsAndImportsInClass]
-# options: silent_imports
+# flags: --silent-imports
 class MyObject(object):
     from bar import FooBar
 [stale]
@@ -769,7 +769,7 @@ tmp/m.py:4: error: Argument 1 to "bar" has incompatible type "int"; expected "st
 [case testIncrementalUnsilencingModule]
 # cmd: mypy -m main package.subpackage.mod2
 # cmd2: mypy -m main package.subpackage.mod1
-# options: silent_imports
+# flags: --silent-imports
 
 [file main.py]
 from package.subpackage.mod1 import Class
@@ -807,7 +807,7 @@ import foo # type: ignore
 [case testIncrementalWithSilentImportsAndIgnore]
 # cmd: mypy -m main b
 # cmd2: mypy -m main c c.submodule
-# options: silent_imports
+# flags: --silent-imports
 
 [file main.py]
 import a  # type: ignore

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -810,7 +810,7 @@ s = s_s() # E: Incompatible types in assignment (expression has type Set[str], v
 [builtins fixtures/set.pyi]
 
 [case testSetWithStarExpr]
-# options: fast_parser
+# flags: --fast-parser
 s = {1, 2, *(3, 4)}
 t = {1, 2, *s}
 reveal_type(s)  # E: Revealed type is 'builtins.set[builtins.int*]'

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -889,7 +889,7 @@ tmp/bar.py:1: error: Module has no attribute 'B'
 
 [case testImportSuppressedWhileAlmostSilent]
 # cmd: mypy -m main
-# options: silent_imports almost_silent
+# flags: --silent-imports --almost-silent
 [file main.py]
 import mod
 [file mod.py]
@@ -901,7 +901,7 @@ tmp/main.py:1: note: (This note courtesy of --almost-silent)
 
 [case testAncestorSuppressedWhileAlmostSilent]
 # cmd: mypy -m foo.bar
-# options: silent_imports almost_silent
+# flags: --silent-imports --almost-silent
 [file foo/bar.py]
 [file foo/__init__.py]
 [builtins fixtures/module.pyi]
@@ -912,7 +912,7 @@ tmp/foo/bar.py: note: (This note brought to you by --almost-silent)
 
 [case testStubImportNonStubWhileSilent]
 # cmd: mypy -m main
-# options: silent_imports
+# flags: --silent-imports
 [file main.py]
 from stub import x # Permitted
 from other import y # Disallowed

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -117,7 +117,7 @@ f(None)
 main: note: In function "f":
 
 [case testInferOptionalFromDefaultNoneWithFastParser]
-# options: fast_parser
+# flags: --fast-parser
 def f(x: int = None) -> None:
   x + 1  # E: Unsupported left operand type for + (some union)
 f(None)
@@ -133,7 +133,7 @@ f(None)
 main: note: In function "f":
 
 [case testInferOptionalFromDefaultNoneCommentWithFastParser]
-# options: fast_parser
+# flags: --fast-parser
 def f(x=None):
   # type: (int) -> None
   x + 1  # E: Unsupported left operand type for + (some union)
@@ -358,7 +358,7 @@ from typing import Callable, Optional
 T = Optional[Callable[..., None]]
 
 [case testAnyTypeInPartialTypeList]
-# options: check_untyped_defs
+# flags: --check-untyped-defs
 def f(): ...
 
 def lookup_field(name, obj):

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -770,7 +770,7 @@ a = None  # type: Sized
 a = ()
 
 [case testTupleWithStarExpr1]
-# options: fast_parser
+# flags: --fast-parser
 a = (1, 2)
 b = (*a, '')
 reveal_type(b)  # E: Revealed type is 'Tuple[builtins.int, builtins.int, builtins.str]'

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -343,7 +343,7 @@ class C:
 main: note: In member "foo" of class "C":
 
 [case testCustomSysVersionInfo]
-# pyversion: 3.2
+# flags: --python-version 3.2
 import sys
 if sys.version_info == (3, 2):
     x = "foo"
@@ -354,7 +354,7 @@ reveal_type(x)  # E: Revealed type is 'builtins.str'
 [out]
 
 [case testCustomSysVersionInfo2]
-# pyversion: 3.1
+# flags: --python-version 3.1
 import sys
 if sys.version_info == (3, 2):
     x = "foo"
@@ -365,7 +365,7 @@ reveal_type(x)  # E: Revealed type is 'builtins.int'
 [out]
 
 [case testCustomSysPlatform]
-# platform: linux
+# flags: --platform linux
 import sys
 if sys.platform == 'linux':
     x = "foo"
@@ -376,7 +376,7 @@ reveal_type(x)  # E: Revealed type is 'builtins.str'
 [out]
 
 [case testCustomSysPlatform2]
-# platform: win32
+# flags: --platform win32
 import sys
 if sys.platform == 'linux':
     x = "foo"
@@ -387,7 +387,7 @@ reveal_type(x)  # E: Revealed type is 'builtins.int'
 [out]
 
 [case testCustomSysPlatformStartsWith]
-# platform: win32
+# flags: --platform win32
 import sys
 if sys.platform.startswith('win'):
     x = "foo"

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -113,7 +113,7 @@ f(*it2) # E: Argument 1 to "f" has incompatible type *Iterable[str]; expected "i
 [builtins fixtures/for.pyi]
 
 [case testCallVarargsFunctionWithIterableAndPositional]
-# options: fast_parser
+# flags: --fast-parser
 from typing import Iterable
 it1 = None  # type: Iterable[int]
 def f(*x: int) -> None: pass
@@ -123,7 +123,7 @@ f(*it1, '') # E: Argument 2 to "f" has incompatible type "str"; expected "int"
 [builtins fixtures/for.pyi]
 
 [case testCallVarargsFunctionWithTupleAndPositional]
-# options: fast_parser
+# flags: --fast-parser
 def f(*x: int) -> None: pass
 it1 = (1, 2)
 f(*it1, 1, 2)

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -4,7 +4,7 @@
 -- ---------------
 
 [case testRedundantCast]
-# options: warn_redundant_casts
+# flags: --warn-redundant-casts
 from typing import cast
 a = 1
 b = cast(str, a)
@@ -13,7 +13,7 @@ c = cast(int, a)
 main:5: note: Redundant cast to "int"
 
 [case testRedundantCastWithIsinstance]
-# options: warn_redundant_casts
+# flags: --warn-redundant-casts
 from typing import cast, Union
 x = 1  # type: Union[int, str]
 if isinstance(x, str):
@@ -23,7 +23,7 @@ if isinstance(x, str):
 main:5: note: Redundant cast to "str"
 
 [case testCastToSuperclassNotRedundant]
-# options: warn_redundant_casts
+# flags: --warn-redundant-casts
 from typing import cast, TypeVar, List
 T = TypeVar('T')
 def add(xs: List[T], ys: List[T]) -> List[T]: pass
@@ -40,14 +40,14 @@ c = add([cast(A, b)], [a])
 -- ------------------------------
 
 [case testUnusedTypeIgnore]
-# options: warn_unused_ignores
+# flags: --warn-unused-ignores
 a = 1
 a = 'a' # type: ignore
 a = 2 # type: ignore # N: unused 'type: ignore' comment
 a = 'b' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testUnusedTypeIgnoreImport]
-# options: warn_unused_ignores
+# flags: --warn-unused-ignores
 import banana # type: ignore
 import m # type: ignore
 from m import * # type: ignore


### PR DESCRIPTION
This is less hacky than the previous solution and allows for non-boolean options to be specified.