### PR TITLE
Change an incorrect word in the async/await docs

### DIFF
--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -837,9 +837,8 @@ will be a value of type ``Awaitable[T]``.
 
    However, mypy currently does not support converting functions into
    coroutines. Support for this feature will be added in a future version, but
-   for now, you can manually force the function to be a decorator by doing
+   for now, you can manually force the function to be a generator by doing
    something like this:
-
 
    .. code-block:: python
    


### PR DESCRIPTION
This commit fixes a small error with the docs for async/await -- the docs used the word "decorator" when it should have used the word "generator".