### PR TITLE
Modify incremental tests to allow initial error

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -82,12 +82,10 @@ def parse_test_cases(
                         tcout = [fix_win_path(line) for line in tcout]
                     ok = True
                 elif p[i].id == 'out2':
-                    if not ok:
-                        msg = '[out] section must precede [out2] section in {} at line {}'
-                        raise ValueError(msg.format(path, p[i].line))
                     tcout2 = p[i].data
                     if native_sep and os.path.sep == '\\':
                         tcout2 = [fix_win_path(line) for line in tcout2]
+                    ok = True
                 else:
                     raise ValueError(
                         'Invalid section header {} in {} at line {}'.format(

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -114,12 +114,10 @@ class TypeCheckSuite(DataSuite):
         options.use_builtins_fixtures = True
         set_show_tb(True)  # Show traceback on crash.
 
-        output = testcase.output
         if incremental:
             options.incremental = True
             if incremental == 1:
                 # In run 1, copy program text to program file.
-                output = []
                 for module_name, program_path, program_text in module_data:
                     if module_name == '__main__':
                         with open(program_path, 'w') as f:
@@ -155,16 +153,25 @@ class TypeCheckSuite(DataSuite):
             a = e.messages
         a = normalize_error_messages(a)
 
+        # Make sure error messages match
+        output = testcase.output
+        if incremental == 0:
+            msg = 'Invalid type checker output ({}, line {})'
+        elif incremental == 1:
+            msg = 'Invalid type checker output in incremental, run 1 ({}, line {})'
+        elif incremental == 2:
+            msg = 'Invalid type checker output in incremental, run 2 ({}, line {})'
+            if testcase.output2 is not None:
+                output = testcase.output2  # Only for incremental mode
+        else:
+            raise AssertionError()
+
         if output != a and self.update_data:
             update_testcase_output(testcase, a)
-
-        assert_string_arrays_equal(
-            output, a,
-            'Invalid type checker output ({}, line {})'.format(
-                testcase.file, testcase.line))
+        assert_string_arrays_equal(output, a, msg.format(testcase.file, testcase.line))
 
         if incremental and res:
-            if not options.silent_imports:
+            if not options.silent_imports and testcase.output is None:
                 self.verify_cache(module_data, a, res.manager)
             if incremental == 2:
                 self.check_module_equivalence(

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -154,15 +154,15 @@ class TypeCheckSuite(DataSuite):
         a = normalize_error_messages(a)
 
         # Make sure error messages match
-        output = testcase.output
         if incremental == 0:
             msg = 'Invalid type checker output ({}, line {})'
+            output = testcase.output
         elif incremental == 1:
             msg = 'Invalid type checker output in incremental, run 1 ({}, line {})'
+            output = testcase.output
         elif incremental == 2:
             msg = 'Invalid type checker output in incremental, run 2 ({}, line {})'
-            if testcase.output2 is not None:
-                output = testcase.output2  # Only for incremental mode
+            output = testcase.output2
         else:
             raise AssertionError()
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -13,7 +13,8 @@
 [case testIncrementalEmpty]
 [rechecked]
 [stale]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalBasics]
 import m
@@ -25,7 +26,8 @@ def foo() -> None:
     pass
 [rechecked m]
 [stale m]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalError]
 import m
@@ -37,7 +39,8 @@ def foo() -> None:
     bar()
 [rechecked m]
 [stale]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/m.py: note: In function "foo":
 tmp/m.py:2: error: Name 'bar' is not defined
@@ -59,7 +62,8 @@ def func3() -> None: pass
 
 [rechecked]
 [stale]
-[out]
+[out1]
+[out2]
 
 
 [case testIncrementalInternalChangeOnly]
@@ -82,7 +86,8 @@ def func3() -> None: 3 + 2
 
 [rechecked mod3]
 [stale]
-[out]
+[out1]
+[out2]
 
 
 [case testIncrementalImportGone]
@@ -100,7 +105,8 @@ def func1() -> A: pass
 
 [rechecked mod1]
 [stale]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/mod1.py: note: In function "func1":
 tmp/mod1.py:1: error: Name 'A' is not defined
@@ -121,7 +127,8 @@ class A(Parent): pass
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out]
+[out1]
+[out2]
 
 
 [case testIncrementalPartialInterfaceChange]
@@ -144,7 +151,8 @@ def func3() -> int: return 2
 
 [rechecked mod1, mod2, mod3]
 [stale mod1, mod2, mod3]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalInternalFunctionDefinitionChange]
 import mod1
@@ -168,7 +176,8 @@ def foo() -> int:
 
 [rechecked mod2]
 [stale]
-[out]
+[out1]
+[out2]
 tmp/mod1.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/mod2.py: note: In function "foo":
@@ -202,7 +211,8 @@ def baz() -> int:
     return 42
 [rechecked mod2]
 [stale]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalMethodInterfaceChange]
 import mod1
@@ -222,7 +232,8 @@ class Foo:
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalBaseClassChange]
 import mod1
@@ -245,7 +256,8 @@ class Child(Bad): pass
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/mod1.py:2: error: "Child" has no attribute "good_method"
 
@@ -273,7 +285,8 @@ C = "A"
 
 [rechecked mod1, mod2, mod3, mod4]
 [stale mod1, mod2, mod3, mod4]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
 
@@ -300,7 +313,8 @@ const = 3
 [rechecked mod1, mod2, mod3]
 [stale mod1, mod2, mod3]
 [builtins fixtures/module.pyi]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: "module" has no attribute "mod4"
 
@@ -325,7 +339,8 @@ const = 3
 const = "foo"
 
 [stale mod1, mod2, mod3, mod4]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
 
@@ -348,7 +363,8 @@ def func2() -> str:
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/mod1.py: note: In function "func1":
 tmp/mod1.py:4: error: Incompatible return value type (got "str", expected "int")
@@ -374,7 +390,8 @@ my_dict = {
 [rechecked mod1, mod1_private]
 [stale mod1, mod1_private]
 [builtins fixtures/dict.pyi]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalWithComplexConstantExpressionNoAnnotation]
 import mod1 
@@ -394,7 +411,8 @@ const = 1 + baz()
 
 [rechecked mod1_private]
 [stale]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalWithComplexConstantExpressionWithAnnotation]
 import mod1
@@ -414,7 +432,8 @@ const = 1 + baz()  # type: int
 
 [rechecked mod1_private]
 [stale]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalSmall]
 import mod1
@@ -435,7 +454,8 @@ def some_func(a: int) -> str:
 [rechecked mod1, mod1_private]
 [stale mod1, mod1_private]
 [builtins fixtures/ops.pyi]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
 
@@ -473,7 +493,8 @@ def some_func(a: int) -> int:
 [rechecked mod1, mod1_private]
 [stale mod1, mod1_private]
 [builtins fixtures/ops.pyi]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
 
@@ -494,7 +515,8 @@ class Foo:
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalChangingFields]
 import mod1
@@ -516,7 +538,8 @@ class Foo:
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalCheckingChangingFields]
 import mod1
@@ -539,7 +562,8 @@ class Foo:
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/mod1.py:4: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
 
@@ -563,7 +587,8 @@ class Foo:
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalSimpleBranchingModules]
 import mod1
@@ -580,7 +605,8 @@ def func() -> int: return 1
 
 [rechecked mod1]
 [stale mod1]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalSubmoduleImport]
 from parent.childA import Foo
@@ -608,7 +634,8 @@ class Bar:
 [builtins fixtures/module_all.pyi]
 [rechecked]
 [stale]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalSubmoduleParentBackreference]
 import parent
@@ -623,7 +650,8 @@ import parent.b
 
 [builtins fixtures/args.pyi]
 [stale]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalSubmoduleParentBackreferenceComplex]
 import parent
@@ -643,7 +671,8 @@ import parent.a
 
 [builtins fixtures/args.pyi]
 [stale]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalReferenceNewFileWithImportFrom]
 from parent import a
@@ -658,7 +687,8 @@ from parent import b
 [file parent/b.py.next]
 
 [stale parent, parent.a, parent.b]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalReferenceExistingFileWithImportFrom]
 from parent import a, b
@@ -673,7 +703,8 @@ from parent import a, b
 from parent import b
 
 [stale parent.a]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalWithTypeIgnoreOnDirectImport]
 import a, b
@@ -687,7 +718,8 @@ import c
 [file c.py]
 
 [stale]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalWithTypeIgnoreOnImportFrom]
 import a, b
@@ -702,7 +734,8 @@ something = 3
 [file c.py]
 
 [stale]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalWithPartialTypeIgnore]
 import a  # type: ignore
@@ -713,7 +746,8 @@ import a.b
 [file a/b.py]
 
 [stale]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalAnyIsDifferentFromIgnore]
 import b
@@ -734,7 +768,8 @@ import a.b
 
 [rechecked b]
 [stale]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/b.py:4: error: Name 'a' already defined
 
@@ -743,7 +778,8 @@ tmp/b.py:4: error: Name 'a' already defined
 class MyObject(object):
     from bar import FooBar
 [stale]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalSameFileSize]
 import m
@@ -762,7 +798,8 @@ bar(3)
 
 [rechecked m]
 [stale]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/m.py:4: error: Argument 1 to "bar" has incompatible type "int"; expected "str"
 
@@ -794,7 +831,8 @@ class Class: pass
 [builtins fixtures/args.pyi]
 [rechecked collections, main, package.subpackage.mod1]
 [stale collections, main, package.subpackage.mod1]
-[out]
+[out1]
+[out2]
 tmp/main.py: note: In function "handle":
 tmp/main.py:4: error: "Class" has no attribute "some_attribute"
 
@@ -802,7 +840,8 @@ tmp/main.py:4: error: "Class" has no attribute "some_attribute"
 import foo # type: ignore
 
 [stale]
-[out]
+[out1]
+[out2]
 
 [case testIncrementalWithSilentImportsAndIgnore]
 # cmd: mypy -m main b
@@ -834,13 +873,14 @@ val = "foo"
 [builtins fixtures/module_all.pyi]
 [rechecked main, c, c.submodule]
 [stale]
-[out]
+[out1]
+[out2]
 tmp/c/submodule.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/main.py:7: error: "C" has no attribute "foo"
 
 [case testIncrementalRemoteError]
 import m
-m.C().foo().bar()  # E: "A" has no attribute "bar"
+m.C().foo().bar()
 [file m.py]
 import n
 class C:
@@ -853,7 +893,9 @@ class A:
   pass
 [rechecked m, n]
 [stale m, n]
-[out]
+[out1]
+[out2]
+main:2: error: "A" has no attribute "bar"
 
 [case testIncrementalReplacingImports]
 import good, bad, client
@@ -878,6 +920,7 @@ foo(3)
 
 [rechecked client]
 [stale]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/client.py:4: error: Argument 1 to "foo" has incompatible type "int"; expected "str"

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1,8 +1,10 @@
 -- Checks for incremental mode (see testcheck.py).
 -- Each test is run twice, once with a cold cache, once with a warm cache.
--- Errors expected in the first run should be in the `[out1]` section, and
--- errors expected in the second run should be in the `[out2]` section.
 -- Before the tests are run the second time, any *.py.next files are copied to *.py.
+--
+-- Errors expected in the first run should be in the `[out1]` section, and
+-- errors expected in the second run should be in the `[out2]` section. If a
+-- section is omitted, it is expected there are no errors on that run.
 --
 -- Any files that we expect to be rechecked should be annotated in the [rechecked]
 -- annotation, and any files expect to be stale (aka have a modified interface)
@@ -17,8 +19,6 @@
 [case testIncrementalEmpty]
 [rechecked]
 [stale]
-[out1]
-[out2]
 
 [case testIncrementalBasics]
 import m
@@ -30,8 +30,6 @@ def foo() -> None:
     pass
 [rechecked m]
 [stale m]
-[out1]
-[out2]
 
 [case testIncrementalError]
 import m
@@ -43,7 +41,6 @@ def foo() -> None:
     bar()
 [rechecked m]
 [stale]
-[out1]
 [out2]
 main:1: note: In module imported here:
 tmp/m.py: note: In function "foo":
@@ -66,8 +63,6 @@ def func3() -> None: pass
 
 [rechecked]
 [stale]
-[out1]
-[out2]
 
 
 [case testIncrementalInternalChangeOnly]
@@ -90,8 +85,6 @@ def func3() -> None: 3 + 2
 
 [rechecked mod3]
 [stale]
-[out1]
-[out2]
 
 
 [case testIncrementalImportGone]
@@ -109,7 +102,6 @@ def func1() -> A: pass
 
 [rechecked mod1]
 [stale]
-[out1]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py: note: In function "func1":
@@ -131,8 +123,6 @@ class A(Parent): pass
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out1]
-[out2]
 
 
 [case testIncrementalPartialInterfaceChange]
@@ -155,8 +145,6 @@ def func3() -> int: return 2
 
 [rechecked mod1, mod2, mod3]
 [stale mod1, mod2, mod3]
-[out1]
-[out2]
 
 [case testIncrementalInternalFunctionDefinitionChange]
 import mod1
@@ -180,7 +168,6 @@ def foo() -> int:
 
 [rechecked mod2]
 [stale]
-[out1]
 [out2]
 tmp/mod1.py:1: note: In module imported here,
 main:1: note: ... from here:
@@ -215,8 +202,6 @@ def baz() -> int:
     return 42
 [rechecked mod2]
 [stale]
-[out1]
-[out2]
 
 [case testIncrementalMethodInterfaceChange]
 import mod1
@@ -236,8 +221,6 @@ class Foo:
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out1]
-[out2]
 
 [case testIncrementalBaseClassChange]
 import mod1
@@ -260,7 +243,6 @@ class Child(Bad): pass
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out1]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py:2: error: "Child" has no attribute "good_method"
@@ -289,7 +271,6 @@ C = "A"
 
 [rechecked mod1, mod2, mod3, mod4]
 [stale mod1, mod2, mod3, mod4]
-[out1]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
@@ -317,7 +298,6 @@ const = 3
 [rechecked mod1, mod2, mod3]
 [stale mod1, mod2, mod3]
 [builtins fixtures/module.pyi]
-[out1]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: "module" has no attribute "mod4"
@@ -343,7 +323,6 @@ const = 3
 const = "foo"
 
 [stale mod1, mod2, mod3, mod4]
-[out1]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
@@ -367,7 +346,6 @@ def func2() -> str:
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out1]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py: note: In function "func1":
@@ -394,8 +372,6 @@ my_dict = {
 [rechecked mod1, mod1_private]
 [stale mod1, mod1_private]
 [builtins fixtures/dict.pyi]
-[out1]
-[out2]
 
 [case testIncrementalWithComplexConstantExpressionNoAnnotation]
 import mod1 
@@ -415,8 +391,6 @@ const = 1 + baz()
 
 [rechecked mod1_private]
 [stale]
-[out1]
-[out2]
 
 [case testIncrementalWithComplexConstantExpressionWithAnnotation]
 import mod1
@@ -436,8 +410,6 @@ const = 1 + baz()  # type: int
 
 [rechecked mod1_private]
 [stale]
-[out1]
-[out2]
 
 [case testIncrementalSmall]
 import mod1
@@ -458,7 +430,6 @@ def some_func(a: int) -> str:
 [rechecked mod1, mod1_private]
 [stale mod1, mod1_private]
 [builtins fixtures/ops.pyi]
-[out1]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
@@ -497,7 +468,6 @@ def some_func(a: int) -> int:
 [rechecked mod1, mod1_private]
 [stale mod1, mod1_private]
 [builtins fixtures/ops.pyi]
-[out1]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
@@ -519,8 +489,6 @@ class Foo:
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out1]
-[out2]
 
 [case testIncrementalChangingFields]
 import mod1
@@ -542,8 +510,6 @@ class Foo:
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out1]
-[out2]
 
 [case testIncrementalCheckingChangingFields]
 import mod1
@@ -566,7 +532,6 @@ class Foo:
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out1]
 [out2]
 main:1: note: In module imported here:
 tmp/mod1.py:4: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
@@ -591,8 +556,6 @@ class Foo:
 
 [rechecked mod1, mod2]
 [stale mod1, mod2]
-[out1]
-[out2]
 
 [case testIncrementalSimpleBranchingModules]
 import mod1
@@ -609,8 +572,6 @@ def func() -> int: return 1
 
 [rechecked mod1]
 [stale mod1]
-[out1]
-[out2]
 
 [case testIncrementalSubmoduleImport]
 from parent.childA import Foo
@@ -638,8 +599,6 @@ class Bar:
 [builtins fixtures/module_all.pyi]
 [rechecked]
 [stale]
-[out1]
-[out2]
 
 [case testIncrementalSubmoduleParentBackreference]
 import parent
@@ -654,8 +613,6 @@ import parent.b
 
 [builtins fixtures/args.pyi]
 [stale]
-[out1]
-[out2]
 
 [case testIncrementalSubmoduleParentBackreferenceComplex]
 import parent
@@ -675,8 +632,6 @@ import parent.a
 
 [builtins fixtures/args.pyi]
 [stale]
-[out1]
-[out2]
 
 [case testIncrementalReferenceNewFileWithImportFrom]
 from parent import a
@@ -691,8 +646,6 @@ from parent import b
 [file parent/b.py.next]
 
 [stale parent, parent.a, parent.b]
-[out1]
-[out2]
 
 [case testIncrementalReferenceExistingFileWithImportFrom]
 from parent import a, b
@@ -707,8 +660,6 @@ from parent import a, b
 from parent import b
 
 [stale parent.a]
-[out1]
-[out2]
 
 [case testIncrementalWithTypeIgnoreOnDirectImport]
 import a, b
@@ -722,8 +673,6 @@ import c
 [file c.py]
 
 [stale]
-[out1]
-[out2]
 
 [case testIncrementalWithTypeIgnoreOnImportFrom]
 import a, b
@@ -738,8 +687,6 @@ something = 3
 [file c.py]
 
 [stale]
-[out1]
-[out2]
 
 [case testIncrementalWithPartialTypeIgnore]
 import a  # type: ignore
@@ -750,8 +697,6 @@ import a.b
 [file a/b.py]
 
 [stale]
-[out1]
-[out2]
 
 [case testIncrementalAnyIsDifferentFromIgnore]
 import b
@@ -772,7 +717,6 @@ import a.b
 
 [rechecked b]
 [stale]
-[out1]
 [out2]
 main:1: note: In module imported here:
 tmp/b.py:4: error: Name 'a' already defined
@@ -782,8 +726,6 @@ tmp/b.py:4: error: Name 'a' already defined
 class MyObject(object):
     from bar import FooBar
 [stale]
-[out1]
-[out2]
 
 [case testIncrementalSameFileSize]
 import m
@@ -802,7 +744,6 @@ bar(3)
 
 [rechecked m]
 [stale]
-[out1]
 [out2]
 main:1: note: In module imported here:
 tmp/m.py:4: error: Argument 1 to "bar" has incompatible type "int"; expected "str"
@@ -835,7 +776,6 @@ class Class: pass
 [builtins fixtures/args.pyi]
 [rechecked collections, main, package.subpackage.mod1]
 [stale collections, main, package.subpackage.mod1]
-[out1]
 [out2]
 tmp/main.py: note: In function "handle":
 tmp/main.py:4: error: "Class" has no attribute "some_attribute"
@@ -844,8 +784,6 @@ tmp/main.py:4: error: "Class" has no attribute "some_attribute"
 import foo # type: ignore
 
 [stale]
-[out1]
-[out2]
 
 [case testIncrementalWithSilentImportsAndIgnore]
 # cmd: mypy -m main b
@@ -877,7 +815,6 @@ val = "foo"
 [builtins fixtures/module_all.pyi]
 [rechecked main, c, c.submodule]
 [stale]
-[out1]
 [out2]
 tmp/c/submodule.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/main.py:7: error: "C" has no attribute "foo"
@@ -897,7 +834,6 @@ class A:
   pass
 [rechecked m, n]
 [stale m, n]
-[out1]
 [out2]
 main:2: error: "A" has no attribute "bar"
 
@@ -918,7 +854,6 @@ class A:
 [stale m, n]
 [out1]
 main:2: error: "A" has no attribute "bar"
-[out2]
 
 [case testIncrementalChangedError]
 import m
@@ -970,7 +905,6 @@ foo(3)
 
 [rechecked client]
 [stale]
-[out1]
 [out2]
 main:1: note: In module imported here:
 tmp/client.py:4: error: Argument 1 to "foo" has incompatible type "int"; expected "str"

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2,16 +2,16 @@
 -- Each test is run twice, once with a cold cache, once with a warm cache.
 -- Errors expected in the first run should be in the `[out1]` section, and
 -- errors expected in the second run should be in the `[out2]` section.
--- Before it is run the second time, any *.py.next files are copied to *.py.
+-- Before the tests are run the second time, any *.py.next files are copied to *.py.
 --
 -- Any files that we expect to be rechecked should be annotated in the [rechecked]
 -- annotation, and any files expect to be stale (aka have a modified interface)
 -- should be annotated in the [stale] annotation. Note that a file that ends up
 -- producing an error does not create a new cache file and so is not considered stale.
 --
--- The test suite will automatically assume that __main__ is automatically stale
--- and rechecked so we can avoid constantly having to annotate it.
--- The list of rechecked/stale files can be in any arbitrary order, or can be left empty
+-- The test suite will automatically assume that __main__ is stale and rechecked in
+-- all cases so we can avoid constantly having to annotate it. The list of
+-- rechecked/stale files can be in any arbitrary order, or can be left empty
 -- if no files should be rechecked/stale.
 
 [case testIncrementalEmpty]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -897,6 +897,52 @@ class A:
 [out2]
 main:2: error: "A" has no attribute "bar"
 
+[case testIncrementalRemoteErrorFixed]
+import m
+m.C().foo().bar()
+[file m.py]
+import n
+class C:
+  def foo(self) -> n.A: pass
+[file n.py]
+class A:
+  pass
+[file n.py.next]
+class A:
+  def bar(self): pass
+[rechecked m, n]
+[stale m, n]
+[out1]
+main:2: error: "A" has no attribute "bar"
+[out2]
+
+[case testIncrementalChangedError]
+import m
+[file m.py]
+import n
+def accept_int(x: int) -> None: pass
+accept_int(n.foo)
+[file n.py]
+foo = "hello"
+reveal_type(foo)
+[file n.py.next]
+foo = 3.14
+reveal_type(foo)
+[rechecked m, n]
+[stale]
+[out1]
+tmp/m.py:1: note: In module imported here,
+main:1: note: ... from here:
+tmp/n.py:2: error: Revealed type is 'builtins.str'
+main:1: note: In module imported here:
+tmp/m.py:3: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
+[out2]
+tmp/m.py:1: note: In module imported here,
+main:1: note: ... from here:
+tmp/n.py:2: error: Revealed type is 'builtins.float'
+main:1: note: In module imported here:
+tmp/m.py:3: error: Argument 1 to "accept_int" has incompatible type "float"; expected "int"
+
 [case testIncrementalReplacingImports]
 import good, bad, client
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1,14 +1,18 @@
 -- Checks for incremental mode (see testcheck.py).
 -- Each test is run twice, once with a cold cache, once with a warm cache.
--- The first time it must pass.
+-- Errors expected in the first run should be in the `[out1]` section, and
+-- errors expected in the second run should be in the `[out2]` section.
 -- Before it is run the second time, any *.py.next files are copied to *.py.
--- The second time it must produce the errors given in the [out] section, if any.
 --
--- Any files that we expect to be stale and rechecked should be annotated in
--- the [stale] annotation. The test suite will automatically assume that
--- __main__ is stale so we can avoid constantly having to annotate it.
--- The list of stale files can be in any arbitrary order, or can be left empty
--- if no files should be stale.
+-- Any files that we expect to be rechecked should be annotated in the [rechecked]
+-- annotation, and any files expect to be stale (aka have a modified interface)
+-- should be annotated in the [stale] annotation. Note that a file that ends up
+-- producing an error does not create a new cache file and so is not considered stale.
+--
+-- The test suite will automatically assume that __main__ is automatically stale
+-- and rechecked so we can avoid constantly having to annotate it.
+-- The list of rechecked/stale files can be in any arbitrary order, or can be left empty
+-- if no files should be rechecked/stale.
 
 [case testIncrementalEmpty]
 [rechecked]

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -232,7 +232,8 @@ reveal_type(id)
 reveal_type(num)
 [rechecked m]
 [stale]
-[out]
+[out1]
+[out2]
 main:1: note: In module imported here:
 tmp/m.py:13: error: Revealed type is 'm.UserId'
 tmp/m.py:14: error: Revealed type is 'builtins.int'


### PR DESCRIPTION
This pull request modifies the testing framework to allow us to specify the expected output during both the first and second runs of incremental mode, instead of mandating that the first run typechecks.

This is useful since it lets us write tests that check whether or not incremental recovers correctly in the presence of errors.