### PR TITLE
Accept ' ' as a valid format specifier name

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -70,7 +70,7 @@ class StringFormatterChecker:
         return self.named_type('builtins.str')
 
     def parse_conversion_specifiers(self, format: str) -> List[ConversionSpecifier]:
-        key_regex = r'(\((\w*)\))?'  # (optional) parenthesised sequence of characters
+        key_regex = r'(\(([\w ]*)\))?'  # (optional) parenthesised sequence of characters
         flags_regex = r'([#0\-+ ]*)'  # (optional) sequence of flags
         width_regex = r'(\*|[1-9][0-9]*)?'  # (optional) minimum field width (* or numbers)
         precision_regex = r'(?:\.(\*|[0-9]+)?)?'  # (optional) . followed by * of numbers

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1108,6 +1108,8 @@ di = None # type: Dict[int, int]
 main:3: error: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float]")
 main:4: error: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float]")
 
+[case testStringInterpolationSpaceKey]
+'%( )s' % {' ': 'foo'}
 
 -- Lambdas
 -- -------


### PR DESCRIPTION
Fix #2058.