### PR TITLE
Make cache files compressed by default

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -797,6 +797,7 @@ OPTIONS_AFFECTING_CACHE = [
     "disallow_untyped_calls",
     "disallow_untyped_defs",
     "check_untyped_defs",
+    "debug_cache",
 ]
 
 
@@ -849,7 +850,10 @@ def write_cache(id: str, path: str, tree: MypyFile,
 
     # Serialize data and analyze interface
     data = tree.serialize()
-    data_str = json.dumps(data, indent=2, sort_keys=True)
+    if manager.options.debug_cache:
+        data_str = json.dumps(data, indent=2, sort_keys=True)
+    else:
+        data_str = json.dumps(data, sort_keys=True)
     interface_hash = compute_hash(data_str)
 
     # Write data cache file, if applicable
@@ -886,8 +890,10 @@ def write_cache(id: str, path: str, tree: MypyFile,
 
     # Write meta cache file
     with open(meta_json_tmp, 'w') as f:
-        json.dump(meta, f, sort_keys=True)
-        f.write('\n')
+        if manager.options.debug_cache:
+            json.dump(meta, f, indent=2, sort_keys=True)
+        else:
+            json.dump(meta, f)
     os.replace(meta_json_tmp, meta_json)
 
     return interface_hash

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -194,6 +194,10 @@ def process_options(args: List[str],
     # (e.g. by adding a call to reveal_type).
     parser.add_argument('--shadow-file', metavar='PATH', nargs=2, dest='shadow_file',
                         help=argparse.SUPPRESS)
+    # --debug-cache will disable any cache-related compressions/optimizations,
+    # which will make the cache writing process output pretty-printed JSON (which
+    # is easier to debug).
+    parser.add_argument('--debug-cache', action='store_true', help=argparse.SUPPRESS)
     # deprecated options
     parser.add_argument('--silent', action='store_true', dest='special-opts:silent',
                         help=argparse.SUPPRESS)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -62,6 +62,7 @@ class Options:
         self.fast_parser = False
         self.incremental = False
         self.cache_dir = defaults.MYPY_CACHE
+        self.debug_cache = False
         self.suppress_error_context = False  # Suppress "note: In function "foo":" messages.
         self.shadow_file = None  # type: Optional[Tuple[str, str]]
 


### PR DESCRIPTION
This commit modifies the cache writing process so that the JSON generated for the cache files are not indented by default for performance improvements.

This commit also adds a hidden `--debug-cache` flag. When the flag is present, mypy will begin indenting the JSON cache data again to make it easier for developers to debug.