### PR TITLE
Remove "Stmt" suffix from node class names

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -15,7 +15,7 @@ from mypy.nodes import (
     SymbolTable, Node, MypyFile, Var, Expression,
     OverloadedFuncDef, FuncDef, FuncItem, FuncBase, TypeInfo,
     ClassDef, GDEF, Block, AssignmentStmt, NameExpr, MemberExpr, IndexExpr,
-    TupleExpr, ListExpr, ExpressionStmt, ReturnStmt, IfStmt,
+    TupleExpr, ListExpr, ExpressionStatement, ReturnStmt, IfStmt,
     WhileStmt, OperatorAssignmentStmt, WithStmt, AssertStmt,
     RaiseStmt, TryStmt, ForStmt, DelStmt, CallExpr, IntExpr, StrExpr,
     BytesExpr, UnicodeExpr, FloatExpr, OpExpr, UnaryExpr, CastExpr, RevealTypeExpr, SuperExpr,
@@ -1456,7 +1456,7 @@ class TypeChecker(NodeVisitor[Type]):
                                                                [full_key_type, full_value_type])
                         del partial_types[var]
 
-    def visit_expression_stmt(self, s: ExpressionStmt) -> Type:
+    def visit_expression_stmt(self, s: ExpressionStatement) -> Type:
         self.accept(s.expr)
 
     def visit_return_stmt(self, s: ReturnStmt) -> Type:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -4,10 +4,10 @@ import sys
 from typing import Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, cast, List
 from mypy.nodes import (
     MypyFile, Node, ImportBase, Import, ImportAll, ImportFrom, FuncDef, OverloadedFuncDef,
-    ClassDef, Decorator, Block, Var, OperatorAssignmentStmt,
-    ExpressionStatement, AssignmentStmt, ReturnStmt, RaiseStmt, AssertStmt,
-    DelStmt, BreakStmt, ContinueStmt, PassStmt, GlobalDecl,
-    WhileStmt, ForStmt, IfStmt, TryStmt, WithStmt,
+    ClassDef, Decorator, Block, Var, OperatorAssignment,
+    ExpressionStatement, Assignment, Return, Raise, Assert,
+    Del, Break, Continue, Pass, GlobalDecl,
+    While, For, If, Try, With,
     TupleExpr, GeneratorExpr, ListComprehension, ListExpr, ConditionalExpr,
     DictExpr, SetExpr, NameExpr, IntExpr, StrExpr, BytesExpr, UnicodeExpr,
     FloatExpr, CallExpr, SuperExpr, MemberExpr, IndexExpr, SliceExpr, OpExpr,
@@ -396,7 +396,7 @@ class ASTConverter(ast35.NodeTransformer):
     # Return(expr? value)
     @with_line
     def visit_Return(self, n: ast35.Return) -> Node:
-        return ReturnStmt(self.visit(n.value))
+        return Return(self.visit(n.value))
 
     # Delete(expr* targets)
     @with_line
@@ -404,9 +404,9 @@ class ASTConverter(ast35.NodeTransformer):
         if len(n.targets) > 1:
             tup = TupleExpr(self.visit_list(n.targets))
             tup.set_line(n.lineno)
-            return DelStmt(tup)
+            return Del(tup)
         else:
-            return DelStmt(self.visit(n.targets[0]))
+            return Del(self.visit(n.targets[0]))
 
     # Assign(expr* targets, expr value, string? type_comment)
     @with_line
@@ -415,69 +415,69 @@ class ASTConverter(ast35.NodeTransformer):
         if n.type_comment:
             typ = parse_type_comment(n.type_comment, n.lineno)
 
-        return AssignmentStmt(self.visit_list(n.targets),
-                              self.visit(n.value),
-                              type=typ)
+        return Assignment(self.visit_list(n.targets),
+                          self.visit(n.value),
+                          type=typ)
 
     # AugAssign(expr target, operator op, expr value)
     @with_line
     def visit_AugAssign(self, n: ast35.AugAssign) -> Node:
-        return OperatorAssignmentStmt(self.from_operator(n.op),
+        return OperatorAssignment(self.from_operator(n.op),
                               self.visit(n.target),
                               self.visit(n.value))
 
     # For(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
     @with_line
     def visit_For(self, n: ast35.For) -> Node:
-        return ForStmt(self.visit(n.target),
-                       self.visit(n.iter),
-                       self.as_block(n.body, n.lineno),
-                       self.as_block(n.orelse, n.lineno))
+        return For(self.visit(n.target),
+                   self.visit(n.iter),
+                   self.as_block(n.body, n.lineno),
+                   self.as_block(n.orelse, n.lineno))
 
     # AsyncFor(expr target, expr iter, stmt* body, stmt* orelse)
     @with_line
     def visit_AsyncFor(self, n: ast35.AsyncFor) -> Node:
-        r = ForStmt(self.visit(n.target),
-                    self.visit(n.iter),
-                    self.as_block(n.body, n.lineno),
-                    self.as_block(n.orelse, n.lineno))
+        r = For(self.visit(n.target),
+                self.visit(n.iter),
+                self.as_block(n.body, n.lineno),
+                self.as_block(n.orelse, n.lineno))
         r.is_async = True
         return r
 
     # While(expr test, stmt* body, stmt* orelse)
     @with_line
     def visit_While(self, n: ast35.While) -> Node:
-        return WhileStmt(self.visit(n.test),
-                         self.as_block(n.body, n.lineno),
-                         self.as_block(n.orelse, n.lineno))
+        return While(self.visit(n.test),
+                     self.as_block(n.body, n.lineno),
+                     self.as_block(n.orelse, n.lineno))
 
     # If(expr test, stmt* body, stmt* orelse)
     @with_line
     def visit_If(self, n: ast35.If) -> Node:
-        return IfStmt([self.visit(n.test)],
-                      [self.as_block(n.body, n.lineno)],
-                      self.as_block(n.orelse, n.lineno))
+        return If([self.visit(n.test)],
+                  [self.as_block(n.body, n.lineno)],
+                  self.as_block(n.orelse, n.lineno))
 
     # With(withitem* items, stmt* body, string? type_comment)
     @with_line
     def visit_With(self, n: ast35.With) -> Node:
-        return WithStmt([self.visit(i.context_expr) for i in n.items],
-                        [self.visit(i.optional_vars) for i in n.items],
-                        self.as_block(n.body, n.lineno))
+        return With([self.visit(i.context_expr) for i in n.items],
+                    [self.visit(i.optional_vars) for i in n.items],
+                    self.as_block(n.body, n.lineno))
 
     # AsyncWith(withitem* items, stmt* body)
     @with_line
     def visit_AsyncWith(self, n: ast35.AsyncWith) -> Node:
-        r = WithStmt([self.visit(i.context_expr) for i in n.items],
-                     [self.visit(i.optional_vars) for i in n.items],
-                     self.as_block(n.body, n.lineno))
+        r = With([self.visit(i.context_expr) for i in n.items],
+                 [self.visit(i.optional_vars) for i in n.items],
+                 self.as_block(n.body, n.lineno))
         r.is_async = True
         return r
 
     # Raise(expr? exc, expr? cause)
     @with_line
     def visit_Raise(self, n: ast35.Raise) -> Node:
-        return RaiseStmt(self.visit(n.exc), self.visit(n.cause))
+        return Raise(self.visit(n.exc), self.visit(n.cause))
 
     # Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
     @with_line
@@ -486,17 +486,17 @@ class ASTConverter(ast35.NodeTransformer):
         types = [self.visit(h.type) for h in n.handlers]
         handlers = [self.as_block(h.body, h.lineno) for h in n.handlers]
 
-        return TryStmt(self.as_block(n.body, n.lineno),
-                       vs,
-                       types,
-                       handlers,
-                       self.as_block(n.orelse, n.lineno),
-                       self.as_block(n.finalbody, n.lineno))
+        return Try(self.as_block(n.body, n.lineno),
+                   vs,
+                   types,
+                   handlers,
+                   self.as_block(n.orelse, n.lineno),
+                   self.as_block(n.finalbody, n.lineno))
 
     # Assert(expr test, expr? msg)
     @with_line
     def visit_Assert(self, n: ast35.Assert) -> Node:
-        return AssertStmt(self.visit(n.test))
+        return Assert(self.visit(n.test))
 
     # Import(alias* names)
     @with_line
@@ -537,17 +537,17 @@ class ASTConverter(ast35.NodeTransformer):
     # Pass
     @with_line
     def visit_Pass(self, n: ast35.Pass) -> Node:
-        return PassStmt()
+        return Pass()
 
-    # BreakToken
+    # Break
     @with_line
-    def visit_Break(self, n: ast35.BreakToken) -> Node:
-        return BreakStmt()
+    def visit_Break(self, n: ast35.Break) -> Node:
+        return Break()
 
     # Continue
     @with_line
     def visit_Continue(self, n: ast35.Continue) -> Node:
-        return ContinueStmt()
+        return Continue()
 
     # --- expr ---
     # BoolOp(boolop op, expr* values)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -5,7 +5,7 @@ from typing import Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, cas
 from mypy.nodes import (
     MypyFile, Node, ImportBase, Import, ImportAll, ImportFrom, FuncDef, OverloadedFuncDef,
     ClassDef, Decorator, Block, Var, OperatorAssignmentStmt,
-    ExpressionStmt, AssignmentStmt, ReturnStmt, RaiseStmt, AssertStmt,
+    ExpressionStatement, AssignmentStmt, ReturnStmt, RaiseStmt, AssertStmt,
     DelStmt, BreakStmt, ContinueStmt, PassStmt, GlobalDecl,
     WhileStmt, ForStmt, IfStmt, TryStmt, WithStmt,
     TupleExpr, GeneratorExpr, ListComprehension, ListExpr, ConditionalExpr,
@@ -532,16 +532,16 @@ class ASTConverter(ast35.NodeTransformer):
     @with_line
     def visit_Expr(self, n: ast35.Expr) -> Node:
         value = self.visit(n.value)
-        return ExpressionStmt(value)
+        return ExpressionStatement(value)
 
     # Pass
     @with_line
     def visit_Pass(self, n: ast35.Pass) -> Node:
         return PassStmt()
 
-    # Break
+    # BreakToken
     @with_line
-    def visit_Break(self, n: ast35.Break) -> Node:
+    def visit_Break(self, n: ast35.BreakToken) -> Node:
         return BreakStmt()
 
     # Continue

--- a/mypy/lex.py
+++ b/mypy/lex.py
@@ -47,7 +47,7 @@ class Token:
 # Token classes
 
 
-class Break(Token):
+class BreakToken(Token):
     """Statement break (line break or semicolon)"""
 
 
@@ -379,12 +379,12 @@ class Lexer:
 
         # Append a break if there is no statement/block terminator at the end
         # of input.
-        if len(self.tok) > 0 and (not isinstance(self.tok[-1], Break) and
+        if len(self.tok) > 0 and (not isinstance(self.tok[-1], BreakToken) and
                                   not isinstance(self.tok[-1], Dedent)):
-            self.add_token(Break(''))
+            self.add_token(BreakToken(''))
 
-        # Attach any dangling comments/whitespace to a final Break token.
-        if self.tok and isinstance(self.tok[-1], Break):
+        # Attach any dangling comments/whitespace to a final BreakToken token.
+        if self.tok and isinstance(self.tok[-1], BreakToken):
             self.tok[-1].string += self.pre_whitespace
             self.pre_whitespace = ''
 
@@ -408,7 +408,7 @@ class Lexer:
             LexError('', DECODE_ERROR,
                      "%r codec can't decode byte %d in column %d" % (
                          self.enc, line[exc.start], exc.start + 1)))
-        self.add_token(Break(''))
+        self.add_token(BreakToken(''))
         self.add_token(Eof(''))
 
     def report_unknown_encoding(self, encoding_line: int) -> None:
@@ -416,7 +416,7 @@ class Lexer:
         self.add_token(
             LexError('', DECODE_ERROR,
                      "Unknown encoding %r" % self.enc))
-        self.add_token(Break(''))
+        self.add_token(BreakToken(''))
         self.add_token(Eof(''))
 
     def lex_number_or_dot(self) -> None:
@@ -735,7 +735,7 @@ class Lexer:
         """Analyse a line break."""
         s = self.match(self.break_exp)
         last_tok = self.tok[-1] if self.tok else None
-        if isinstance(last_tok, Break):
+        if isinstance(last_tok, BreakToken):
             was_semicolon = last_tok.string == ';'
             last_tok.string += self.pre_whitespace + s
             self.i += len(s)
@@ -747,12 +747,12 @@ class Lexer:
             self.add_pre_whitespace(s)
             self.line += 1
         else:
-            self.add_token(Break(s))
+            self.add_token(BreakToken(s))
             self.line += 1
             self.lex_indent()
 
     def lex_semicolon(self) -> None:
-        self.add_token(Break(';'))
+        self.add_token(BreakToken(';'))
 
     def lex_colon(self) -> None:
         self.add_token(Colon(':'))
@@ -838,7 +838,7 @@ class Lexer:
         characters and comments.
         """
         if (tok.string == '' and not isinstance(tok, Eof)
-                and not isinstance(tok, Break)
+                and not isinstance(tok, BreakToken)
                 and not isinstance(tok, LexError)
                 and not isinstance(tok, Dedent)):
             raise ValueError('Empty token')
@@ -856,7 +856,7 @@ class Lexer:
     def add_special_token(self, tok: Token, line: int, skip: int) -> None:
         """Like add_token, but caller sets the number of chars to skip."""
         if (tok.string == '' and not isinstance(tok, Eof)
-                and not isinstance(tok, Break)
+                and not isinstance(tok, BreakToken)
                 and not isinstance(tok, LexError)
                 and not isinstance(tok, Dedent)):
             raise ValueError('Empty token')
@@ -874,7 +874,7 @@ class Lexer:
         else:
             # Ignore break after another break or dedent.
             t = self.tok[-1]
-            return isinstance(t, Break) or isinstance(t, Dedent)
+            return isinstance(t, BreakToken) or isinstance(t, Dedent)
 
 
 if __name__ == '__main__':

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -234,7 +234,7 @@ class ImportBase(Statement):
     #
     #     x = 1
     #     from m import x   <-- add assignment representing "x = m.x"
-    assignments = None  # type: List[AssignmentStmt]
+    assignments = None  # type: List[Assignment]
 
     def __init__(self) -> None:
         self.assignments = []
@@ -347,11 +347,11 @@ class Argument(Node):
     type_annotation = None  # type: Optional[mypy.types.Type]
     initializater = None  # type: Optional[Expression]
     kind = None  # type: int
-    initialization_statement = None  # type: Optional[AssignmentStmt]
+    initialization_statement = None  # type: Optional[Assignment]
 
     def __init__(self, variable: 'Var', type_annotation: 'Optional[mypy.types.Type]',
             initializer: Optional[Expression], kind: int,
-            initialization_statement: Optional['AssignmentStmt'] = None) -> None:
+            initialization_statement: Optional['Assignment'] = None) -> None:
         self.variable = variable
 
         self.type_annotation = type_annotation
@@ -363,7 +363,7 @@ class Argument(Node):
 
         self.kind = kind
 
-    def _initialization_statement(self) -> Optional['AssignmentStmt']:
+    def _initialization_statement(self) -> Optional['Assignment']:
         """Convert the initializer into an assignment statement.
         """
         if not self.initializer:
@@ -371,7 +371,7 @@ class Argument(Node):
 
         rvalue = self.initializer
         lvalue = NameExpr(self.variable.name())
-        assign = AssignmentStmt([lvalue], rvalue)
+        assign = Assignment([lvalue], rvalue)
         return assign
 
     def set_line(self, target: Union[Token, Node, int]) -> Node:
@@ -747,7 +747,7 @@ class ExpressionStatement(Statement):
         return visitor.visit_expression_stmt(self)
 
 
-class AssignmentStmt(Statement):
+class Assignment(Statement):
     """Assignment statement
     The same node class is used for single assignment, multiple assignment
     (e.g. x, y = z) and chained assignment (e.g. x = y = z), assignments
@@ -771,7 +771,7 @@ class AssignmentStmt(Statement):
         return visitor.visit_assignment_stmt(self)
 
 
-class OperatorAssignmentStmt(Statement):
+class OperatorAssignment(Statement):
     """Operator assignment statement such as x += 1"""
 
     op = ''
@@ -787,7 +787,7 @@ class OperatorAssignmentStmt(Statement):
         return visitor.visit_operator_assignment_stmt(self)
 
 
-class WhileStmt(Statement):
+class While(Statement):
     expr = None  # type: Expression
     body = None  # type: Block
     else_body = None  # type: Block
@@ -801,7 +801,7 @@ class WhileStmt(Statement):
         return visitor.visit_while_stmt(self)
 
 
-class ForStmt(Statement):
+class For(Statement):
     # Index variables
     index = None  # type: Expression
     # Expression to iterate
@@ -821,7 +821,7 @@ class ForStmt(Statement):
         return visitor.visit_for_stmt(self)
 
 
-class ReturnStmt(Statement):
+class Return(Statement):
     expr = None  # type: Optional[Expression]
 
     def __init__(self, expr: Optional[Expression]) -> None:
@@ -831,7 +831,7 @@ class ReturnStmt(Statement):
         return visitor.visit_return_stmt(self)
 
 
-class AssertStmt(Statement):
+class Assert(Statement):
     expr = None  # type: Expression
 
     def __init__(self, expr: Expression) -> None:
@@ -841,7 +841,7 @@ class AssertStmt(Statement):
         return visitor.visit_assert_stmt(self)
 
 
-class DelStmt(Statement):
+class Del(Statement):
     expr = None  # type: Expression
 
     def __init__(self, expr: Expression) -> None:
@@ -851,22 +851,22 @@ class DelStmt(Statement):
         return visitor.visit_del_stmt(self)
 
 
-class BreakStmt(Statement):
+class Break(Statement):
     def accept(self, visitor: NodeVisitor[T]) -> T:
         return visitor.visit_break_stmt(self)
 
 
-class ContinueStmt(Statement):
+class Continue(Statement):
     def accept(self, visitor: NodeVisitor[T]) -> T:
         return visitor.visit_continue_stmt(self)
 
 
-class PassStmt(Statement):
+class Pass(Statement):
     def accept(self, visitor: NodeVisitor[T]) -> T:
         return visitor.visit_pass_stmt(self)
 
 
-class IfStmt(Statement):
+class If(Statement):
     expr = None  # type: List[Expression]
     body = None  # type: List[Block]
     else_body = None  # type: Block
@@ -881,7 +881,7 @@ class IfStmt(Statement):
         return visitor.visit_if_stmt(self)
 
 
-class RaiseStmt(Statement):
+class Raise(Statement):
     expr = None  # type: Expression
     from_expr = None  # type: Expression
 
@@ -893,7 +893,7 @@ class RaiseStmt(Statement):
         return visitor.visit_raise_stmt(self)
 
 
-class TryStmt(Statement):
+class Try(Statement):
     body = None  # type: Block                # Try body
     types = None  # type: List[Expression]    # Except type expressions
     vars = None  # type: List[NameExpr]     # Except variable names
@@ -915,7 +915,7 @@ class TryStmt(Statement):
         return visitor.visit_try_stmt(self)
 
 
-class WithStmt(Statement):
+class With(Statement):
     expr = None  # type: List[Expression]
     target = None  # type: List[Expression]
     body = None  # type: Block
@@ -931,7 +931,7 @@ class WithStmt(Statement):
         return visitor.visit_with_stmt(self)
 
 
-class PrintStmt(Statement):
+class Print(Statement):
     """Python 2 print statement"""
 
     args = None  # type: List[Expression]
@@ -948,7 +948,7 @@ class PrintStmt(Statement):
         return visitor.visit_print_stmt(self)
 
 
-class ExecStmt(Statement):
+class Exec(Statement):
     """Python 2 exec statement"""
 
     expr = None  # type: Expression
@@ -1440,7 +1440,7 @@ class FuncExpr(FuncItem, Expression):
 
     def expr(self) -> Expression:
         """Return the expression (the body) of the lambda."""
-        ret = cast(ReturnStmt, self.body.body[-1])
+        ret = cast(Return, self.body.body[-1])
         return ret.expr
 
     def accept(self, visitor: NodeVisitor[T]) -> T:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -736,7 +736,7 @@ class Block(Statement):
 # Statements
 
 
-class ExpressionStmt(Statement):
+class ExpressionStatement(Statement):
     """An expression as a statement, such as print(s)."""
     expr = None  # type: Expression
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -51,7 +51,7 @@ from mypy.nodes import (
     MypyFile, TypeInfo, Node, AssignmentStmt, FuncDef, OverloadedFuncDef,
     ClassDef, Var, GDEF, MODULE_REF, FuncItem, Import,
     ImportFrom, ImportAll, Block, LDEF, NameExpr, MemberExpr,
-    IndexExpr, TupleExpr, ListExpr, ExpressionStmt, ReturnStmt,
+    IndexExpr, TupleExpr, ListExpr, ExpressionStatement, ReturnStmt,
     RaiseStmt, AssertStmt, OperatorAssignmentStmt, WhileStmt,
     ForStmt, BreakStmt, ContinueStmt, IfStmt, TryStmt, WithStmt, DelStmt,
     GlobalDecl, SuperExpr, DictExpr, CallExpr, RefExpr, OpExpr, UnaryExpr,
@@ -1826,7 +1826,7 @@ class SemanticAnalyzer(NodeVisitor):
         if not self.type or self.is_func_scope():
             self.fail("'%s' used with a non-method" % decorator, context)
 
-    def visit_expression_stmt(self, s: ExpressionStmt) -> None:
+    def visit_expression_stmt(self, s: ExpressionStatement) -> None:
         s.expr.accept(self)
 
     def visit_return_stmt(self, s: ReturnStmt) -> None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -48,21 +48,21 @@ from typing import (
 )
 
 from mypy.nodes import (
-    MypyFile, TypeInfo, Node, AssignmentStmt, FuncDef, OverloadedFuncDef,
+    MypyFile, TypeInfo, Node, Assignment, FuncDef, OverloadedFuncDef,
     ClassDef, Var, GDEF, MODULE_REF, FuncItem, Import,
     ImportFrom, ImportAll, Block, LDEF, NameExpr, MemberExpr,
-    IndexExpr, TupleExpr, ListExpr, ExpressionStatement, ReturnStmt,
-    RaiseStmt, AssertStmt, OperatorAssignmentStmt, WhileStmt,
-    ForStmt, BreakStmt, ContinueStmt, IfStmt, TryStmt, WithStmt, DelStmt,
+    IndexExpr, TupleExpr, ListExpr, ExpressionStatement, Return,
+    Raise, Assert, OperatorAssignment, While,
+    For, Break, Continue, If, Try, With, Del,
     GlobalDecl, SuperExpr, DictExpr, CallExpr, RefExpr, OpExpr, UnaryExpr,
     SliceExpr, CastExpr, RevealTypeExpr, TypeApplication, Context, SymbolTable,
     SymbolTableNode, BOUND_TVAR, UNBOUND_TVAR, ListComprehension, GeneratorExpr,
     FuncExpr, MDEF, FuncBase, Decorator, SetExpr, TypeVarExpr, NewTypeExpr,
-    StrExpr, BytesExpr, PrintStmt, ConditionalExpr, PromoteExpr,
+    StrExpr, BytesExpr, Print, ConditionalExpr, PromoteExpr,
     ComparisonExpr, StarExpr, ARG_POS, ARG_NAMED, MroError, type_aliases,
     YieldFromExpr, NamedTupleExpr, NonlocalDecl,
     SetComprehension, DictionaryComprehension, TYPE_ALIAS, TypeAliasExpr,
-    YieldExpr, ExecStmt, Argument, BackquoteExpr, ImportBase, AwaitExpr,
+    YieldExpr, Exec, Argument, BackquoteExpr, ImportBase, AwaitExpr,
     IntExpr, FloatExpr, UnicodeExpr,
     Expression, EllipsisExpr, namedtuple_type_info,
     COVARIANT, CONTRAVARIANT, INVARIANT, UNBOUND_IMPORTED, LITERAL_YES,
@@ -985,7 +985,7 @@ class SemanticAnalyzer(NodeVisitor):
             rvalue = NameExpr(imported_id)
             rvalue.kind = module_symbol.kind
             rvalue.node = module_symbol.node
-            assignment = AssignmentStmt([lvalue], rvalue)
+            assignment = Assignment([lvalue], rvalue)
             for node in assignment, lvalue, rvalue:
                 node.set_line(import_node)
             import_node.assignments.append(assignment)
@@ -1088,7 +1088,7 @@ class SemanticAnalyzer(NodeVisitor):
         else:
             return None
 
-    def visit_assignment_stmt(self, s: AssignmentStmt) -> None:
+    def visit_assignment_stmt(self, s: Assignment) -> None:
         for lval in s.lvalues:
             self.analyze_lvalue(lval, explicit_type=s.type is not None)
         s.rvalue.accept(self)
@@ -1151,7 +1151,7 @@ class SemanticAnalyzer(NodeVisitor):
             return self.named_type_or_none('builtins.unicode')
         return None
 
-    def check_and_set_up_type_alias(self, s: AssignmentStmt) -> None:
+    def check_and_set_up_type_alias(self, s: Assignment) -> None:
         """Check if assignment creates a type alias and set it up as needed."""
         # For now, type aliases only work at the top level of a module.
         if (len(s.lvalues) == 1 and not self.is_func_scope() and not self.type
@@ -1326,7 +1326,7 @@ class SemanticAnalyzer(NodeVisitor):
             # This has been flagged elsewhere as an error, so just ignore here.
             pass
 
-    def process_newtype_declaration(self, s: AssignmentStmt) -> None:
+    def process_newtype_declaration(self, s: Assignment) -> None:
         """Check if s declares a NewType; if yes, store it in symbol table."""
         # Extract and check all information from newtype declaration
         name, call = self.analyze_newtype_declaration(s)
@@ -1359,7 +1359,7 @@ class SemanticAnalyzer(NodeVisitor):
         call.analyzed = NewTypeExpr(newtype_class_info).set_line(call.line)
 
     def analyze_newtype_declaration(self,
-            s: AssignmentStmt) -> Tuple[Optional[str], Optional[CallExpr]]:
+            s: Assignment) -> Tuple[Optional[str], Optional[CallExpr]]:
         """Return the NewType call expression if `s` is a newtype declaration or None otherwise."""
         name, call = None, None
         if (len(s.lvalues) == 1
@@ -1438,7 +1438,7 @@ class SemanticAnalyzer(NodeVisitor):
 
         return info
 
-    def process_typevar_declaration(self, s: AssignmentStmt) -> None:
+    def process_typevar_declaration(self, s: Assignment) -> None:
         """Check if s declares a TypeVar; it yes, store it in symbol table."""
         call = self.get_typevar_declaration(s)
         if not call:
@@ -1490,7 +1490,7 @@ class SemanticAnalyzer(NodeVisitor):
             return False
         return True
 
-    def get_typevar_declaration(self, s: AssignmentStmt) -> Optional[CallExpr]:
+    def get_typevar_declaration(self, s: Assignment) -> Optional[CallExpr]:
         """Returns the TypeVar() call expression if `s` is a type var declaration
         or None otherwise.
         """
@@ -1568,7 +1568,7 @@ class SemanticAnalyzer(NodeVisitor):
             variance = INVARIANT
         return (variance, upper_bound)
 
-    def process_namedtuple_definition(self, s: AssignmentStmt) -> None:
+    def process_namedtuple_definition(self, s: Assignment) -> None:
         """Check if s defines a namedtuple; if yes, store the definition in symbol table."""
         if len(s.lvalues) != 1 or not isinstance(s.lvalues[0], NameExpr):
             return
@@ -1829,38 +1829,38 @@ class SemanticAnalyzer(NodeVisitor):
     def visit_expression_stmt(self, s: ExpressionStatement) -> None:
         s.expr.accept(self)
 
-    def visit_return_stmt(self, s: ReturnStmt) -> None:
+    def visit_return_stmt(self, s: Return) -> None:
         if not self.is_func_scope():
             self.fail("'return' outside function", s)
         if s.expr:
             s.expr.accept(self)
 
-    def visit_raise_stmt(self, s: RaiseStmt) -> None:
+    def visit_raise_stmt(self, s: Raise) -> None:
         if s.expr:
             s.expr.accept(self)
         if s.from_expr:
             s.from_expr.accept(self)
 
-    def visit_assert_stmt(self, s: AssertStmt) -> None:
+    def visit_assert_stmt(self, s: Assert) -> None:
         if s.expr:
             s.expr.accept(self)
 
     def visit_operator_assignment_stmt(self,
-                                       s: OperatorAssignmentStmt) -> None:
+                                       s: OperatorAssignment) -> None:
         s.lvalue.accept(self)
         s.rvalue.accept(self)
         if (isinstance(s.lvalue, NameExpr) and s.lvalue.name == '__all__' and
                 s.lvalue.kind == GDEF and isinstance(s.rvalue, (ListExpr, TupleExpr))):
             self.add_exports(*s.rvalue.items)
 
-    def visit_while_stmt(self, s: WhileStmt) -> None:
+    def visit_while_stmt(self, s: While) -> None:
         s.expr.accept(self)
         self.loop_depth += 1
         s.body.accept(self)
         self.loop_depth -= 1
         self.visit_block_maybe(s.else_body)
 
-    def visit_for_stmt(self, s: ForStmt) -> None:
+    def visit_for_stmt(self, s: For) -> None:
         s.expr.accept(self)
 
         # Bind index variables and check if they define new names.
@@ -1872,15 +1872,15 @@ class SemanticAnalyzer(NodeVisitor):
 
         self.visit_block_maybe(s.else_body)
 
-    def visit_break_stmt(self, s: BreakStmt) -> None:
+    def visit_break_stmt(self, s: Break) -> None:
         if self.loop_depth == 0:
             self.fail("'break' outside loop", s, True, blocker=True)
 
-    def visit_continue_stmt(self, s: ContinueStmt) -> None:
+    def visit_continue_stmt(self, s: Continue) -> None:
         if self.loop_depth == 0:
             self.fail("'continue' outside loop", s, True, blocker=True)
 
-    def visit_if_stmt(self, s: IfStmt) -> None:
+    def visit_if_stmt(self, s: If) -> None:
         infer_reachability_of_if_statement(s,
             pyversion=self.options.python_version,
             platform=self.options.platform)
@@ -1889,10 +1889,10 @@ class SemanticAnalyzer(NodeVisitor):
             self.visit_block(s.body[i])
         self.visit_block_maybe(s.else_body)
 
-    def visit_try_stmt(self, s: TryStmt) -> None:
+    def visit_try_stmt(self, s: Try) -> None:
         self.analyze_try_stmt(s, self)
 
-    def analyze_try_stmt(self, s: TryStmt, visitor: NodeVisitor,
+    def analyze_try_stmt(self, s: Try, visitor: NodeVisitor,
                          add_global: bool = False) -> None:
         s.body.accept(visitor)
         for type, var, handler in zip(s.types, s.vars, s.handlers):
@@ -1906,14 +1906,14 @@ class SemanticAnalyzer(NodeVisitor):
         if s.finally_body:
             s.finally_body.accept(visitor)
 
-    def visit_with_stmt(self, s: WithStmt) -> None:
+    def visit_with_stmt(self, s: With) -> None:
         for e, n in zip(s.expr, s.target):
             e.accept(self)
             if n:
                 self.analyze_lvalue(n)
         self.visit_block(s.body)
 
-    def visit_del_stmt(self, s: DelStmt) -> None:
+    def visit_del_stmt(self, s: Del) -> None:
         s.expr.accept(self)
         if not self.is_valid_del_target(s.expr):
             self.fail('Invalid delete target', s)
@@ -1949,13 +1949,13 @@ class SemanticAnalyzer(NodeVisitor):
                     self.fail("Name '{}' is nonlocal and global".format(name), d)
                 self.nonlocal_decls[-1].add(name)
 
-    def visit_print_stmt(self, s: PrintStmt) -> None:
+    def visit_print_stmt(self, s: Print) -> None:
         for arg in s.args:
             arg.accept(self)
         if s.target:
             s.target.accept(self)
 
-    def visit_exec_stmt(self, s: ExecStmt) -> None:
+    def visit_exec_stmt(self, s: Exec) -> None:
         s.expr.accept(self)
         if s.variables1:
             s.variables1.accept(self)
@@ -2627,7 +2627,7 @@ class FirstPass(NodeVisitor):
             node.accept(self)
         self.sem.block_depth[-1] -= 1
 
-    def visit_assignment_stmt(self, s: AssignmentStmt) -> None:
+    def visit_assignment_stmt(self, s: Assignment) -> None:
         for lval in s.lvalues:
             self.analyze_lvalue(lval, explicit_type=s.type is not None)
 
@@ -2705,18 +2705,18 @@ class FirstPass(NodeVisitor):
     def visit_import_all(self, node: ImportAll) -> None:
         node.is_top_level = True
 
-    def visit_while_stmt(self, s: WhileStmt) -> None:
+    def visit_while_stmt(self, s: While) -> None:
         s.body.accept(self)
         if s.else_body:
             s.else_body.accept(self)
 
-    def visit_for_stmt(self, s: ForStmt) -> None:
+    def visit_for_stmt(self, s: For) -> None:
         self.analyze_lvalue(s.index)
         s.body.accept(self)
         if s.else_body:
             s.else_body.accept(self)
 
-    def visit_with_stmt(self, s: WithStmt) -> None:
+    def visit_with_stmt(self, s: With) -> None:
         for n in s.target:
             if n:
                 self.analyze_lvalue(n)
@@ -2726,14 +2726,14 @@ class FirstPass(NodeVisitor):
         d.var._fullname = self.sem.qualified_name(d.var.name())
         self.sem.add_symbol(d.var.name(), SymbolTableNode(GDEF, d.var), d)
 
-    def visit_if_stmt(self, s: IfStmt) -> None:
+    def visit_if_stmt(self, s: If) -> None:
         infer_reachability_of_if_statement(s, pyversion=self.pyversion, platform=self.platform)
         for node in s.body:
             node.accept(self)
         if s.else_body:
             s.else_body.accept(self)
 
-    def visit_try_stmt(self, s: TryStmt) -> None:
+    def visit_try_stmt(self, s: Try) -> None:
         self.sem.analyze_try_stmt(s, self, add_global=True)
 
     def analyze_lvalue(self, lvalue: Node, explicit_type: bool = False) -> None:
@@ -2833,7 +2833,7 @@ class ThirdPass(TraverserVisitor):
                 sig.name = orig_sig.items()[0].name
                 dec.var.type = sig
 
-    def visit_assignment_stmt(self, s: AssignmentStmt) -> None:
+    def visit_assignment_stmt(self, s: Assignment) -> None:
         self.analyze(s.type)
         super().visit_assignment_stmt(s)
 
@@ -2962,7 +2962,7 @@ def remove_imported_names_from_symtable(names: SymbolTable,
         del names[name]
 
 
-def infer_reachability_of_if_statement(s: IfStmt,
+def infer_reachability_of_if_statement(s: If,
                                        pyversion: Tuple[int, int],
                                        platform: str) -> None:
     for i in range(len(s.expr)):

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -13,7 +13,7 @@ from mypy.types import (
 )
 from mypy import nodes
 from mypy.nodes import (
-    Node, FuncDef, TypeApplication, AssignmentStmt, NameExpr, CallExpr,
+    Node, FuncDef, TypeApplication, Assignment, NameExpr, CallExpr,
     MemberExpr, OpExpr, ComparisonExpr, IndexExpr, UnaryExpr, YieldFromExpr
 )
 
@@ -85,7 +85,7 @@ class StatisticsVisitor(TraverserVisitor):
             self.type(t)
         super().visit_type_application(o)
 
-    def visit_assignment_stmt(self, o: AssignmentStmt) -> None:
+    def visit_assignment_stmt(self, o: Assignment) -> None:
         self.line = o.line
         if (isinstance(o.rvalue, nodes.CallExpr) and
                 isinstance(o.rvalue.analyzed, nodes.TypeVarExpr)):

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -18,7 +18,7 @@ class StrConv(NodeVisitor[str]):
 
       MypyFile:1(
         fnam
-        ExpressionStmt:1(
+        ExpressionStatement:1(
           IntExpr(1)))
     """
     def dump(self, nodes: List[Any], obj: 'mypy.nodes.Node') -> str:

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -53,8 +53,8 @@ import mypy.traverser
 from mypy import defaults
 from mypy.nodes import (
     Node, IntExpr, UnaryExpr, StrExpr, BytesExpr, NameExpr, FloatExpr, MemberExpr, TupleExpr,
-    ListExpr, ComparisonExpr, CallExpr, ClassDef, MypyFile, Decorator, AssignmentStmt,
-    IfStmt, ImportAll, ImportFrom, Import, FuncDef, FuncBase, ARG_STAR, ARG_STAR2, ARG_NAMED
+    ListExpr, ComparisonExpr, CallExpr, ClassDef, MypyFile, Decorator, Assignment,
+    If, ImportAll, ImportFrom, Import, FuncDef, FuncBase, ARG_STAR, ARG_STAR2, ARG_NAMED
 )
 from mypy.stubgenc import parse_all_signatures, find_unique_signatures, generate_stub_for_c_module
 from mypy.stubutil import is_c_module, write_header
@@ -332,7 +332,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
                 self.add_import_line('import %s\n' % modname)
         return base_types
 
-    def visit_assignment_stmt(self, o: AssignmentStmt) -> None:
+    def visit_assignment_stmt(self, o: Assignment) -> None:
         foundl = []
 
         for lvalue in o.lvalues:
@@ -386,7 +386,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         self._classes.add(lvalue.name)
         self._state = CLASS
 
-    def visit_if_stmt(self, o: IfStmt) -> None:
+    def visit_if_stmt(self, o: If) -> None:
         # Ignore if __name__ == '__main__'.
         expr = o.expr[0]
         if (isinstance(expr, ComparisonExpr) and
@@ -528,7 +528,7 @@ def find_self_initializers(fdef: FuncBase) -> List[str]:
     results = []  # type: List[str]
 
     class SelfTraverser(mypy.traverser.TraverserVisitor):
-        def visit_assignment_stmt(self, o: AssignmentStmt) -> None:
+        def visit_assignment_stmt(self, o: Assignment) -> None:
             lvalue = o.lvalues[0]
             if (isinstance(lvalue, MemberExpr) and
                     isinstance(lvalue.expr, NameExpr) and

--- a/mypy/test/testlex.py
+++ b/mypy/test/testlex.py
@@ -14,7 +14,7 @@ class LexerSuite(Suite):
         self.assert_lex(
             'if else elif def return pass',
             'Keyword(if) Keyword( else) Keyword( elif) Keyword( def) '
-            'Keyword( return) Keyword( pass) Break() Eof()')
+            'Keyword( return) Keyword( pass) BreakToken() Eof()')
 
         self.assert_lex(
             'from import as class global',
@@ -25,17 +25,17 @@ class LexerSuite(Suite):
         self.assert_lex(
             'i x FooBar FOO_BAR __x var',
             'Name(i) Name( x) Name( FooBar) Name( FOO_BAR) Name( __x) '
-            'Name( var) Break() Eof()')
+            'Name( var) BreakToken() Eof()')
 
         self.assert_lex(
             'any interface void',
-            'Name(any) Name( interface) Name( void) Break() Eof()')
+            'Name(any) Name( interface) Name( void) BreakToken() Eof()')
 
     def test_int_literals(self):
         self.assert_lex(
             '0 00 1 0987654321 10002000300040005000600070008000',
             'IntLit(0) IntLit( 00) IntLit( 1) LexError( 0987654321) '
-            'IntLit( 10002000300040005000600070008000) Break() Eof()')
+            'IntLit( 10002000300040005000600070008000) BreakToken() Eof()')
 
     def test_hex_int_literals(self):
         self.assert_lex('0x0 0xabcedf0189 0xAFe 0X2',
@@ -62,16 +62,16 @@ class LexerSuite(Suite):
 
     def test_comments(self):
         self.assert_lex('# foo "" bar' + '\n' + 'x #x',
-                        'Name(# foo "" bar\\nx) Break( #x) Eof()')
+                        'Name(# foo "" bar\\nx) BreakToken( #x) Eof()')
 
     def test_empty_lines(self):
         self.assert_lex(r'\n1', r'IntLit(\n1) ...')
         self.assert_lex(r'\n\n1', r'IntLit(\n\n1) ...')
-        self.assert_lex(r'1\n\n2', r'IntLit(1) Break(\n\n) IntLit(2) ...')
+        self.assert_lex(r'1\n\n2', r'IntLit(1) BreakToken(\n\n) IntLit(2) ...')
 
     def test_line_breaks(self):
-        self.assert_lex('1\\r2', 'IntLit(1) Break(\\r) IntLit(2) ...')
-        self.assert_lex('1\\r\\n2', 'IntLit(1) Break(\\r\\n) IntLit(2) ...')
+        self.assert_lex('1\\r2', 'IntLit(1) BreakToken(\\r) IntLit(2) ...')
+        self.assert_lex('1\\r\\n2', 'IntLit(1) BreakToken(\\r\\n) IntLit(2) ...')
 
     def test_operators(self):
         self.assert_lex('- + < > == != <= >= .',
@@ -101,32 +101,32 @@ class LexerSuite(Suite):
     def test_basic_indentation(self):
         self.assert_lex(
             'y' + '\n' + '  x',
-            'Name(y) Break(\\n) Indent(  ) Name(x) Break() Dedent() Eof()')
+            'Name(y) BreakToken(\\n) Indent(  ) Name(x) BreakToken() Dedent() Eof()')
 
         self.assert_lex(
             'y' + '\n' + '  x' + '\n' + 'z',
-            'Name(y) Break(\\n) Indent(  ) Name(x) Break(\\n) Dedent() '
-            'Name(z) Break() Eof()')
+            'Name(y) BreakToken(\\n) Indent(  ) Name(x) BreakToken(\\n) Dedent() '
+            'Name(z) BreakToken() Eof()')
 
     def test_multiple_indent_levels(self):
         self.assert_lex('y' + '\n' +
                         '  x' + '\n' +
                         '  y' + '\n' +
                         '    z',
-                        'Name(y) Break(\\n) ' +
-                        'Indent(  ) Name(x) Break(\\n) ' +
-                        'Name(  y) Break(\\n) ' +
-                        'Indent(    ) Name(z) Break() ' +
+                        'Name(y) BreakToken(\\n) ' +
+                        'Indent(  ) Name(x) BreakToken(\\n) ' +
+                        'Name(  y) BreakToken(\\n) ' +
+                        'Indent(    ) Name(z) BreakToken() ' +
                         'Dedent() Dedent() Eof()')
 
         self.assert_lex('y' + '\n' +
                         '  x' + '\n' +
                         '    z' + '\n' +
                         '  y',
-                        'Name(y) Break(\\n) ' +
-                        'Indent(  ) Name(x) Break(\\n) ' +
-                        'Indent(    ) Name(z) Break(\\n) ' +
-                        'Dedent() Name(  y) Break() ' +
+                        'Name(y) BreakToken(\\n) ' +
+                        'Indent(  ) Name(x) BreakToken(\\n) ' +
+                        'Indent(    ) Name(z) BreakToken(\\n) ' +
+                        'Dedent() Name(  y) BreakToken() ' +
                         'Dedent() Eof()')
 
     def test_tab_indent(self):
@@ -134,10 +134,10 @@ class LexerSuite(Suite):
                         '\t' + 'x' + '\n' +
                         '        y' + '\n' +
                         ' ' + '\t' + 'z',
-                        'Name(y) Break(\\n) ' +
-                        'Indent(\\t) Name(x) Break(\\n) ' +
-                        'Name(        y) Break(\\n) ' +
-                        'Name( \\tz) Break() ' +
+                        'Name(y) BreakToken(\\n) ' +
+                        'Indent(\\t) Name(x) BreakToken(\\n) ' +
+                        'Name(        y) BreakToken(\\n) ' +
+                        'Name( \\tz) BreakToken() ' +
                         'Dedent() Eof()')
 
     def test_comment_after_dedent(self):
@@ -145,49 +145,49 @@ class LexerSuite(Suite):
                         '  x\n'
                         '# Foo\n'
                         'z',
-                        r'Name(y) Break(\n) Indent(  ) Name(x) '
-                        r'Break(\n# Foo\n) '
-                        r'Dedent() Name(z) Break() Eof()')
+                        r'Name(y) BreakToken(\n) Indent(  ) Name(x) '
+                        r'BreakToken(\n# Foo\n) '
+                        r'Dedent() Name(z) BreakToken() Eof()')
 
     def test_parens(self):
-        self.assert_lex('( x )', 'Punct(() Name( x) Punct( )) Break() Eof()')
+        self.assert_lex('( x )', 'Punct(() Name( x) Punct( )) BreakToken() Eof()')
         self.assert_lex(
             '( x' + '\n' + '  y )',
-            'Punct(() Name( x) Name(\\n  y) Punct( )) Break() Eof()')
+            'Punct(() Name( x) Name(\\n  y) Punct( )) BreakToken() Eof()')
 
         self.assert_lex('()' + '\n' + ' y',
-                        'Punct(() Punct()) Break(\\n) Indent( ) Name(y) '
-                        'Break() Dedent() Eof()')
+                        'Punct(() Punct()) BreakToken(\\n) Indent( ) Name(y) '
+                        'BreakToken() Dedent() Eof()')
 
         # [ ... ] and { ... }.
         self.assert_lex(
             '[ x' + '\n' + '  y ]',
-            'Punct([) Name( x) Name(\\n  y) Punct( ]) Break() Eof()')
+            'Punct([) Name( x) Name(\\n  y) Punct( ]) BreakToken() Eof()')
         self.assert_lex(
             '{ x' + '\n' + '  y }',
-            'Punct({) Name( x) Name(\\n  y) Punct( }) Break() Eof()')
+            'Punct({) Name( x) Name(\\n  y) Punct( }) BreakToken() Eof()')
 
         # Nested brackets.
         self.assert_lex(
             '({}' + '\n' + ' y)',
-            'Punct(() Punct({) Punct(}) Name(\\n y) Punct()) Break() Eof()')
+            'Punct(() Punct({) Punct(}) Name(\\n y) Punct()) BreakToken() Eof()')
 
     def test_brackets_and_line_breaks(self):
         # This used to fail.
         self.assert_lex('{}' + '\n' + '1',
-                        'Punct({) Punct(}) Break(\\n) IntLit(1) Break() Eof()')
+                        'Punct({) Punct(}) BreakToken(\\n) IntLit(1) BreakToken() Eof()')
 
     def test_str_literals(self):
         self.assert_lex("'' 'foo_bar'",
-                        "StrLit('') StrLit( 'foo_bar') Break() Eof()")
+                        "StrLit('') StrLit( 'foo_bar') BreakToken() Eof()")
         self.assert_lex('"" "foo_bar"',
-                        'StrLit("") StrLit( "foo_bar") Break() Eof()')
+                        'StrLit("") StrLit( "foo_bar") BreakToken() Eof()')
 
-        self.assert_lex('"\\"" 1', 'StrLit("\\"") IntLit( 1) Break() Eof()')
-        self.assert_lex("'\\'' 1", "StrLit('\\'') IntLit( 1) Break() Eof()")
+        self.assert_lex('"\\"" 1', 'StrLit("\\"") IntLit( 1) BreakToken() Eof()')
+        self.assert_lex("'\\'' 1", "StrLit('\\'') IntLit( 1) BreakToken() Eof()")
 
-        self.assert_lex('"\\\\" 1', 'StrLit("\\\\") IntLit( 1) Break() Eof()')
-        self.assert_lex("'\\\\' 1", "StrLit('\\\\') IntLit( 1) Break() Eof()")
+        self.assert_lex('"\\\\" 1', 'StrLit("\\\\") IntLit( 1) BreakToken() Eof()')
+        self.assert_lex("'\\\\' 1", "StrLit('\\\\') IntLit( 1) BreakToken() Eof()")
 
     def test_triple_quoted_string_literals(self):
         # Single-line
@@ -225,11 +225,11 @@ class LexerSuite(Suite):
         self.assert_lex("U'foo'", "UnicodeLit(U'foo') ...")
 
     def test_semicolons(self):
-        self.assert_lex('a;b', 'Name(a) Break(;) Name(b) ...')
-        self.assert_lex('a;', 'Name(a) Break(;) Eof()')
+        self.assert_lex('a;b', 'Name(a) BreakToken(;) Name(b) ...')
+        self.assert_lex('a;', 'Name(a) BreakToken(;) Eof()')
 
-        self.assert_lex(';a', 'Break(;) Name(a) ...')
-        self.assert_lex('a;;b', 'Name(a) Break(;) Break(;) Name(b) ...')
+        self.assert_lex(';a', 'BreakToken(;) Name(a) ...')
+        self.assert_lex('a;;b', 'Name(a) BreakToken(;) BreakToken(;) Name(b) ...')
 
     def test_raw_string(self):
         self.assert_lex("r'' r'foo bar'",
@@ -288,7 +288,7 @@ class LexerSuite(Suite):
         self.assert_lex('a\\' + '\n' + ' b', 'Name(a) Name(\\\\n b) ...')
         self.assert_lex(
             'a = \\' + '\n' + ' 1' + '\n' + '=',
-            'Name(a) Punct( =) IntLit( \\\\n 1) Break(\\n) Punct(=) ...')
+            'Name(a) Punct( =) IntLit( \\\\n 1) BreakToken(\\n) Punct(=) ...')
 
     def test_backslash_in_string(self):
         self.assert_lex("'foo\\" + '\n' + "bar'", "StrLit('foo\\\\nbar') ...")
@@ -310,29 +310,29 @@ class LexerSuite(Suite):
     def test_final_dedent(self):
         self.assert_lex(
             '1' + '\n' + ' 1' + '\n',
-            'IntLit(1) Break(\\n) Indent( ) IntLit(1) Break(\\n) Dedent() Eof()')
+            'IntLit(1) BreakToken(\\n) Indent( ) IntLit(1) BreakToken(\\n) Dedent() Eof()')
 
     def test_empty_line(self):
         self.assert_lex('1' + '\n' + ' 1' + '\n' + '\n',
-                        r'IntLit(1) Break(\n) Indent( ) IntLit(1) '
-                        r'Break(\n\n) Dedent() Eof()')
+                        r'IntLit(1) BreakToken(\n) Indent( ) IntLit(1) '
+                        r'BreakToken(\n\n) Dedent() Eof()')
 
     def test_comments_and_indents(self):
         self.assert_lex('1' + '\n' + ' #x' + '\n' + ' y',
-                        r'IntLit(1) Break(\n #x\n) Indent( ) Name(y) '
-                        r'Break() Dedent() Eof()')
+                        r'IntLit(1) BreakToken(\n #x\n) Indent( ) Name(y) '
+                        r'BreakToken() Dedent() Eof()')
         self.assert_lex('1' + '\n' + '#x' + '\n' + ' y',
-                        r'IntLit(1) Break(\n#x\n) Indent( ) Name(y) '
-                        r'Break() Dedent() Eof()')
+                        r'IntLit(1) BreakToken(\n#x\n) Indent( ) Name(y) '
+                        r'BreakToken() Dedent() Eof()')
 
     def test_form_feed(self):
         self.assert_lex('\x0c' + '\n' + 'x', 'Name(\x0c\\nx) ...')
 
     def test_comment_after_linebreak(self):
         self.assert_lex('1\n# foo\n2',
-                        'IntLit(1) Break(\\n# foo\\n) IntLit(2) ...')
+                        'IntLit(1) BreakToken(\\n# foo\\n) IntLit(2) ...')
         self.assert_lex('1\n# foo',
-                        'IntLit(1) Break(\\n# foo) Eof()')
+                        'IntLit(1) BreakToken(\\n# foo) Eof()')
 
     def test_line_numbers(self):
         self.assert_line('a\\nb', [1, 1, 2, 2, 2])
@@ -376,19 +376,19 @@ class LexerSuite(Suite):
 
     def test_invalid_indent(self):
         self.assert_lex('x\\n  y\\n z',
-                        'Name(x) Break(\\n) Indent(  ) Name(y) ' +
-                        'Break(\\n) Dedent() LexError( ) Name(z) ...')
+                        'Name(x) BreakToken(\\n) Indent(  ) Name(y) ' +
+                        'BreakToken(\\n) Dedent() LexError( ) Name(z) ...')
 
     def test_invalid_backslash(self):
-        self.assert_lex('\\ \\nx', 'LexError(\\) Break( \\n) Name(x) ...')
-        self.assert_lex('\\ \\nx', 'LexError(\\) Break( \\n) Name(x) ...')
+        self.assert_lex('\\ \\nx', 'LexError(\\) BreakToken( \\n) Name(x) ...')
+        self.assert_lex('\\ \\nx', 'LexError(\\) BreakToken( \\n) Name(x) ...')
 
     def test_non_terminated_string_literal(self):
         self.assert_lex("'", 'LexError(\') ...')
-        self.assert_lex("'\\na", 'LexError(\') Break(\\n) Name(a) ...')
+        self.assert_lex("'\\na", 'LexError(\') BreakToken(\\n) Name(a) ...')
 
         self.assert_lex('"', 'LexError(") ...')
-        self.assert_lex('"\\na', 'LexError(") Break(\\n) Name(a) ...')
+        self.assert_lex('"\\na', 'LexError(") BreakToken(\\n) Name(a) ...')
 
         self.assert_lex("r'", 'LexError(r\') ...')
         self.assert_lex('r"', 'LexError(r") ...')
@@ -410,21 +410,21 @@ class LexerSuite(Suite):
 
     def test_latin1_encoding(self):
         self.assert_lex(b'# coding: latin1\n"\xbb"',
-                        'StrLit(# coding: latin1\\n"\xbb") Break() Eof()')
+                        'StrLit(# coding: latin1\\n"\xbb") BreakToken() Eof()')
 
     def test_utf8_encoding(self):
         self.assert_lex('"\xbb"'.encode('utf8'),
-                        'StrLit("\xbb") Break() Eof()')
+                        'StrLit("\xbb") BreakToken() Eof()')
         self.assert_lex(b'"\xbb"',
                         "LexError('utf8' codec can't decode byte 187 in column 2) "
-                        'Break() Eof()')
+                        'BreakToken() Eof()')
         self.assert_lex(b'\n"abcde\xbc"',
                         "LexError('utf8' codec can't decode byte 188 in column 7) "
-                        'Break() Eof()')
+                        'BreakToken() Eof()')
 
     def test_byte_order_mark(self):
         self.assert_lex('\ufeff"\xbb"'.encode('utf8'),
-                        'Bom(\ufeff) StrLit("\xbb") Break() Eof()')
+                        'Bom(\ufeff) StrLit("\xbb") BreakToken() Eof()')
 
     def test_long_comment(self):
         prog = '# pass\n' * 1000
@@ -439,7 +439,7 @@ class LexerSuite(Suite):
             src = src.replace('\\r', '\r')
 
         if lexed.endswith(' ...'):
-            lexed = lexed[:-3] + 'Break() Eof()'
+            lexed = lexed[:-3] + 'BreakToken() Eof()'
 
         l = lex(src)[0]
         r = []

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -3,9 +3,9 @@
 from mypy.visitor import NodeVisitor
 from mypy.nodes import (
     Block, MypyFile, FuncItem, CallExpr, ClassDef, Decorator, FuncDef,
-    ExpressionStatement, AssignmentStmt, OperatorAssignmentStmt, WhileStmt,
-    ForStmt, ReturnStmt, AssertStmt, DelStmt, IfStmt, RaiseStmt,
-    TryStmt, WithStmt, MemberExpr, OpExpr, SliceExpr, CastExpr, RevealTypeExpr,
+    ExpressionStatement, Assignment, OperatorAssignment, While,
+    For, Return, Assert, Del, If, Raise,
+    Try, With, MemberExpr, OpExpr, SliceExpr, CastExpr, RevealTypeExpr,
     UnaryExpr, ListExpr, TupleExpr, DictExpr, SetExpr, IndexExpr,
     GeneratorExpr, ListComprehension, ConditionalExpr, TypeApplication,
     FuncExpr, ComparisonExpr, OverloadedFuncDef, YieldFromExpr,
@@ -62,41 +62,41 @@ class TraverserVisitor(NodeVisitor[None]):
     def visit_expression_stmt(self, o: ExpressionStatement) -> None:
         o.expr.accept(self)
 
-    def visit_assignment_stmt(self, o: AssignmentStmt) -> None:
+    def visit_assignment_stmt(self, o: Assignment) -> None:
         o.rvalue.accept(self)
         for l in o.lvalues:
             l.accept(self)
 
-    def visit_operator_assignment_stmt(self, o: OperatorAssignmentStmt) -> None:
+    def visit_operator_assignment_stmt(self, o: OperatorAssignment) -> None:
         o.rvalue.accept(self)
         o.lvalue.accept(self)
 
-    def visit_while_stmt(self, o: WhileStmt) -> None:
+    def visit_while_stmt(self, o: While) -> None:
         o.expr.accept(self)
         o.body.accept(self)
         if o.else_body:
             o.else_body.accept(self)
 
-    def visit_for_stmt(self, o: ForStmt) -> None:
+    def visit_for_stmt(self, o: For) -> None:
         o.index.accept(self)
         o.expr.accept(self)
         o.body.accept(self)
         if o.else_body:
             o.else_body.accept(self)
 
-    def visit_return_stmt(self, o: ReturnStmt) -> None:
+    def visit_return_stmt(self, o: Return) -> None:
         if o.expr is not None:
             o.expr.accept(self)
 
-    def visit_assert_stmt(self, o: AssertStmt) -> None:
+    def visit_assert_stmt(self, o: Assert) -> None:
         if o.expr is not None:
             o.expr.accept(self)
 
-    def visit_del_stmt(self, o: DelStmt) -> None:
+    def visit_del_stmt(self, o: Del) -> None:
         if o.expr is not None:
             o.expr.accept(self)
 
-    def visit_if_stmt(self, o: IfStmt) -> None:
+    def visit_if_stmt(self, o: If) -> None:
         for e in o.expr:
             e.accept(self)
         for b in o.body:
@@ -104,13 +104,13 @@ class TraverserVisitor(NodeVisitor[None]):
         if o.else_body:
             o.else_body.accept(self)
 
-    def visit_raise_stmt(self, o: RaiseStmt) -> None:
+    def visit_raise_stmt(self, o: Raise) -> None:
         if o.expr is not None:
             o.expr.accept(self)
         if o.from_expr is not None:
             o.from_expr.accept(self)
 
-    def visit_try_stmt(self, o: TryStmt) -> None:
+    def visit_try_stmt(self, o: Try) -> None:
         o.body.accept(self)
         for i in range(len(o.types)):
             if o.types[i]:
@@ -121,7 +121,7 @@ class TraverserVisitor(NodeVisitor[None]):
         if o.finally_body is not None:
             o.finally_body.accept(self)
 
-    def visit_with_stmt(self, o: WithStmt) -> None:
+    def visit_with_stmt(self, o: With) -> None:
         for i in range(len(o.expr)):
             o.expr[i].accept(self)
             if o.target[i] is not None:

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -3,7 +3,7 @@
 from mypy.visitor import NodeVisitor
 from mypy.nodes import (
     Block, MypyFile, FuncItem, CallExpr, ClassDef, Decorator, FuncDef,
-    ExpressionStmt, AssignmentStmt, OperatorAssignmentStmt, WhileStmt,
+    ExpressionStatement, AssignmentStmt, OperatorAssignmentStmt, WhileStmt,
     ForStmt, ReturnStmt, AssertStmt, DelStmt, IfStmt, RaiseStmt,
     TryStmt, WithStmt, MemberExpr, OpExpr, SliceExpr, CastExpr, RevealTypeExpr,
     UnaryExpr, ListExpr, TupleExpr, DictExpr, SetExpr, IndexExpr,
@@ -59,7 +59,7 @@ class TraverserVisitor(NodeVisitor[None]):
         for decorator in o.decorators:
             decorator.accept(self)
 
-    def visit_expression_stmt(self, o: ExpressionStmt) -> None:
+    def visit_expression_stmt(self, o: ExpressionStatement) -> None:
         o.expr.accept(self)
 
     def visit_assignment_stmt(self, o: AssignmentStmt) -> None:

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -8,7 +8,7 @@ from typing import List, Dict, cast
 from mypy.nodes import (
     MypyFile, Import, Node, ImportAll, ImportFrom, FuncItem, FuncDef,
     OverloadedFuncDef, ClassDef, Decorator, Block, Var,
-    OperatorAssignmentStmt, ExpressionStmt, AssignmentStmt, ReturnStmt,
+    OperatorAssignmentStmt, ExpressionStatement, AssignmentStmt, ReturnStmt,
     RaiseStmt, AssertStmt, DelStmt, BreakStmt, ContinueStmt,
     PassStmt, GlobalDecl, WhileStmt, ForStmt, IfStmt, TryStmt, WithStmt,
     CastExpr, RevealTypeExpr, TupleExpr, GeneratorExpr, ListComprehension, ListExpr,
@@ -229,8 +229,8 @@ class TransformVisitor(NodeVisitor[Node]):
         self.var_map[node] = new
         return new
 
-    def visit_expression_stmt(self, node: ExpressionStmt) -> Node:
-        return ExpressionStmt(self.node(node.expr))
+    def visit_expression_stmt(self, node: ExpressionStatement) -> Node:
+        return ExpressionStatement(self.node(node.expr))
 
     def visit_assignment_stmt(self, node: AssignmentStmt) -> Node:
         return self.duplicate_assignment(node)

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -8,18 +8,18 @@ from typing import List, Dict, cast
 from mypy.nodes import (
     MypyFile, Import, Node, ImportAll, ImportFrom, FuncItem, FuncDef,
     OverloadedFuncDef, ClassDef, Decorator, Block, Var,
-    OperatorAssignmentStmt, ExpressionStatement, AssignmentStmt, ReturnStmt,
-    RaiseStmt, AssertStmt, DelStmt, BreakStmt, ContinueStmt,
-    PassStmt, GlobalDecl, WhileStmt, ForStmt, IfStmt, TryStmt, WithStmt,
+    OperatorAssignment, ExpressionStatement, Assignment, Return,
+    Raise, Assert, Del, Break, Continue,
+    Pass, GlobalDecl, While, For, If, Try, With,
     CastExpr, RevealTypeExpr, TupleExpr, GeneratorExpr, ListComprehension, ListExpr,
     ConditionalExpr, DictExpr, SetExpr, NameExpr, IntExpr, StrExpr, BytesExpr,
     UnicodeExpr, FloatExpr, CallExpr, SuperExpr, MemberExpr, IndexExpr,
-    SliceExpr, OpExpr, UnaryExpr, FuncExpr, TypeApplication, PrintStmt,
+    SliceExpr, OpExpr, UnaryExpr, FuncExpr, TypeApplication, Print,
     SymbolTable, RefExpr, TypeVarExpr, NewTypeExpr, PromoteExpr,
     ComparisonExpr, TempNode, StarExpr,
     YieldFromExpr, NamedTupleExpr, NonlocalDecl, SetComprehension,
     DictionaryComprehension, ComplexExpr, TypeAliasExpr, EllipsisExpr,
-    YieldExpr, ExecStmt, Argument, BackquoteExpr, AwaitExpr,
+    YieldExpr, Exec, Argument, BackquoteExpr, AwaitExpr,
 )
 from mypy.types import Type, FunctionLike, Instance
 from mypy.traverser import TraverserVisitor
@@ -75,7 +75,7 @@ class TransformVisitor(NodeVisitor[Node]):
         return ImportAll(node.id, node.relative)
 
     def copy_argument(self, argument: Argument) -> Argument:
-        init_stmt = None  # type: AssignmentStmt
+        init_stmt = None  # type: Assignment
 
         if argument.initialization_statement:
             init_lvalue = cast(
@@ -83,7 +83,7 @@ class TransformVisitor(NodeVisitor[Node]):
                 self.node(argument.initialization_statement.lvalues[0]),
             )
             init_lvalue.set_line(argument.line)
-            init_stmt = AssignmentStmt(
+            init_stmt = Assignment(
                 [init_lvalue],
                 self.node(argument.initialization_statement.rvalue),
                 self.optional_type(argument.initialization_statement.type),
@@ -160,8 +160,8 @@ class TransformVisitor(NodeVisitor[Node]):
         new.line = original.line
 
     def duplicate_inits(self,
-                        inits: List[AssignmentStmt]) -> List[AssignmentStmt]:
-        result = []  # type: List[AssignmentStmt]
+                        inits: List[Assignment]) -> List[Assignment]:
+        result = []  # type: List[Assignment]
         for init in inits:
             if init:
                 result.append(self.duplicate_assignment(init))
@@ -232,82 +232,82 @@ class TransformVisitor(NodeVisitor[Node]):
     def visit_expression_stmt(self, node: ExpressionStatement) -> Node:
         return ExpressionStatement(self.node(node.expr))
 
-    def visit_assignment_stmt(self, node: AssignmentStmt) -> Node:
+    def visit_assignment_stmt(self, node: Assignment) -> Node:
         return self.duplicate_assignment(node)
 
-    def duplicate_assignment(self, node: AssignmentStmt) -> AssignmentStmt:
-        new = AssignmentStmt(self.nodes(node.lvalues),
-                             self.node(node.rvalue),
-                             self.optional_type(node.type))
+    def duplicate_assignment(self, node: Assignment) -> Assignment:
+        new = Assignment(self.nodes(node.lvalues),
+                         self.node(node.rvalue),
+                         self.optional_type(node.type))
         new.line = node.line
         return new
 
     def visit_operator_assignment_stmt(self,
-                                       node: OperatorAssignmentStmt) -> Node:
-        return OperatorAssignmentStmt(node.op,
-                                      self.node(node.lvalue),
-                                      self.node(node.rvalue))
+                                       node: OperatorAssignment) -> Node:
+        return OperatorAssignment(node.op,
+                                  self.node(node.lvalue),
+                                  self.node(node.rvalue))
 
-    def visit_while_stmt(self, node: WhileStmt) -> Node:
-        return WhileStmt(self.node(node.expr),
-                         self.block(node.body),
-                         self.optional_block(node.else_body))
+    def visit_while_stmt(self, node: While) -> Node:
+        return While(self.node(node.expr),
+                     self.block(node.body),
+                     self.optional_block(node.else_body))
 
-    def visit_for_stmt(self, node: ForStmt) -> Node:
-        return ForStmt(self.node(node.index),
-                       self.node(node.expr),
-                       self.block(node.body),
-                       self.optional_block(node.else_body))
+    def visit_for_stmt(self, node: For) -> Node:
+        return For(self.node(node.index),
+                   self.node(node.expr),
+                   self.block(node.body),
+                   self.optional_block(node.else_body))
 
-    def visit_return_stmt(self, node: ReturnStmt) -> Node:
-        return ReturnStmt(self.optional_node(node.expr))
+    def visit_return_stmt(self, node: Return) -> Node:
+        return Return(self.optional_node(node.expr))
 
-    def visit_assert_stmt(self, node: AssertStmt) -> Node:
-        return AssertStmt(self.node(node.expr))
+    def visit_assert_stmt(self, node: Assert) -> Node:
+        return Assert(self.node(node.expr))
 
-    def visit_del_stmt(self, node: DelStmt) -> Node:
-        return DelStmt(self.node(node.expr))
+    def visit_del_stmt(self, node: Del) -> Node:
+        return Del(self.node(node.expr))
 
-    def visit_if_stmt(self, node: IfStmt) -> Node:
-        return IfStmt(self.nodes(node.expr),
-                      self.blocks(node.body),
-                      self.optional_block(node.else_body))
+    def visit_if_stmt(self, node: If) -> Node:
+        return If(self.nodes(node.expr),
+                  self.blocks(node.body),
+                  self.optional_block(node.else_body))
 
-    def visit_break_stmt(self, node: BreakStmt) -> Node:
-        return BreakStmt()
+    def visit_break_stmt(self, node: Break) -> Node:
+        return Break()
 
-    def visit_continue_stmt(self, node: ContinueStmt) -> Node:
-        return ContinueStmt()
+    def visit_continue_stmt(self, node: Continue) -> Node:
+        return Continue()
 
-    def visit_pass_stmt(self, node: PassStmt) -> Node:
-        return PassStmt()
+    def visit_pass_stmt(self, node: Pass) -> Node:
+        return Pass()
 
-    def visit_raise_stmt(self, node: RaiseStmt) -> Node:
-        return RaiseStmt(self.optional_node(node.expr),
-                         self.optional_node(node.from_expr))
+    def visit_raise_stmt(self, node: Raise) -> Node:
+        return Raise(self.optional_node(node.expr),
+                     self.optional_node(node.from_expr))
 
-    def visit_try_stmt(self, node: TryStmt) -> Node:
-        return TryStmt(self.block(node.body),
-                       self.optional_names(node.vars),
-                       self.optional_nodes(node.types),
-                       self.blocks(node.handlers),
-                       self.optional_block(node.else_body),
-                       self.optional_block(node.finally_body))
+    def visit_try_stmt(self, node: Try) -> Node:
+        return Try(self.block(node.body),
+                   self.optional_names(node.vars),
+                   self.optional_nodes(node.types),
+                   self.blocks(node.handlers),
+                   self.optional_block(node.else_body),
+                   self.optional_block(node.finally_body))
 
-    def visit_with_stmt(self, node: WithStmt) -> Node:
-        return WithStmt(self.nodes(node.expr),
-                        self.optional_nodes(node.target),
-                        self.block(node.body))
+    def visit_with_stmt(self, node: With) -> Node:
+        return With(self.nodes(node.expr),
+                    self.optional_nodes(node.target),
+                    self.block(node.body))
 
-    def visit_print_stmt(self, node: PrintStmt) -> Node:
-        return PrintStmt(self.nodes(node.args),
-                         node.newline,
-                         self.optional_node(node.target))
+    def visit_print_stmt(self, node: Print) -> Node:
+        return Print(self.nodes(node.args),
+                     node.newline,
+                     self.optional_node(node.target))
 
-    def visit_exec_stmt(self, node: ExecStmt) -> Node:
-        return ExecStmt(self.node(node.expr),
-                        self.optional_node(node.variables1),
-                        self.optional_node(node.variables2))
+    def visit_exec_stmt(self, node: Exec) -> Node:
+        return Exec(self.node(node.expr),
+                    self.optional_node(node.variables1),
+                    self.optional_node(node.variables2))
 
     def visit_star_expr(self, node: StarExpr) -> Node:
         return StarExpr(node.expr)

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -63,56 +63,56 @@ class NodeVisitor(Generic[T]):
     def visit_block(self, o: 'mypy.nodes.Block') -> T:
         pass
 
-    def visit_expression_stmt(self, o: 'mypy.nodes.ExpressionStmt') -> T:
+    def visit_expression_stmt(self, o: 'mypy.nodes.ExpressionStatement') -> T:
         pass
 
-    def visit_assignment_stmt(self, o: 'mypy.nodes.AssignmentStmt') -> T:
+    def visit_assignment_stmt(self, o: 'mypy.nodes.Assignment') -> T:
         pass
 
     def visit_operator_assignment_stmt(self,
-                                       o: 'mypy.nodes.OperatorAssignmentStmt') -> T:
+                                       o: 'mypy.nodes.OperatorAssignment') -> T:
         pass
 
-    def visit_while_stmt(self, o: 'mypy.nodes.WhileStmt') -> T:
+    def visit_while_stmt(self, o: 'mypy.nodes.While') -> T:
         pass
 
-    def visit_for_stmt(self, o: 'mypy.nodes.ForStmt') -> T:
+    def visit_for_stmt(self, o: 'mypy.nodes.For') -> T:
         pass
 
-    def visit_return_stmt(self, o: 'mypy.nodes.ReturnStmt') -> T:
+    def visit_return_stmt(self, o: 'mypy.nodes.Return') -> T:
         pass
 
-    def visit_assert_stmt(self, o: 'mypy.nodes.AssertStmt') -> T:
+    def visit_assert_stmt(self, o: 'mypy.nodes.Assert') -> T:
         pass
 
-    def visit_del_stmt(self, o: 'mypy.nodes.DelStmt') -> T:
+    def visit_del_stmt(self, o: 'mypy.nodes.Del') -> T:
         pass
 
-    def visit_if_stmt(self, o: 'mypy.nodes.IfStmt') -> T:
+    def visit_if_stmt(self, o: 'mypy.nodes.If') -> T:
         pass
 
-    def visit_break_stmt(self, o: 'mypy.nodes.BreakStmt') -> T:
+    def visit_break_stmt(self, o: 'mypy.nodes.Break') -> T:
         pass
 
-    def visit_continue_stmt(self, o: 'mypy.nodes.ContinueStmt') -> T:
+    def visit_continue_stmt(self, o: 'mypy.nodes.Continue') -> T:
         pass
 
-    def visit_pass_stmt(self, o: 'mypy.nodes.PassStmt') -> T:
+    def visit_pass_stmt(self, o: 'mypy.nodes.Pass') -> T:
         pass
 
-    def visit_raise_stmt(self, o: 'mypy.nodes.RaiseStmt') -> T:
+    def visit_raise_stmt(self, o: 'mypy.nodes.Raise') -> T:
         pass
 
-    def visit_try_stmt(self, o: 'mypy.nodes.TryStmt') -> T:
+    def visit_try_stmt(self, o: 'mypy.nodes.Try') -> T:
         pass
 
-    def visit_with_stmt(self, o: 'mypy.nodes.WithStmt') -> T:
+    def visit_with_stmt(self, o: 'mypy.nodes.With') -> T:
         pass
 
-    def visit_print_stmt(self, o: 'mypy.nodes.PrintStmt') -> T:
+    def visit_print_stmt(self, o: 'mypy.nodes.Print') -> T:
         pass
 
-    def visit_exec_stmt(self, o: 'mypy.nodes.ExecStmt') -> T:
+    def visit_exec_stmt(self, o: 'mypy.nodes.Exec') -> T:
         pass
 
     # Expressions

--- a/test-data/unit/parse-python2.test
+++ b/test-data/unit/parse-python2.test
@@ -14,15 +14,15 @@ u'''bar'''
 b'foo'
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     StrExpr(bar))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     UnicodeExpr(foo))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     UnicodeExpr(foo))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     UnicodeExpr(bar))
-  ExpressionStmt:5(
+  ExpressionStatement:5(
     StrExpr(foo)))
 
 [case testSimplePrint]
@@ -31,14 +31,14 @@ print 2, 3
 print (4, 5)
 [out]
 MypyFile:1(
-  PrintStmt:1(
+  Print:1(
     IntExpr(1)
     Newline)
-  PrintStmt:2(
+  Print:2(
     IntExpr(2)
     IntExpr(3)
     Newline)
-  PrintStmt:3(
+  Print:3(
     TupleExpr:3(
       IntExpr(4)
       IntExpr(5))
@@ -48,14 +48,14 @@ MypyFile:1(
 print
 [out]
 MypyFile:1(
-  PrintStmt:1(
+  Print:1(
     Newline))
 
 [case testPrintWithTarget]
 print >>foo
 [out]
 MypyFile:1(
-  PrintStmt:1(
+  Print:1(
     Target(
       NameExpr(foo))
     Newline))
@@ -64,7 +64,7 @@ MypyFile:1(
 print >>foo, x
 [out]
 MypyFile:1(
-  PrintStmt:1(
+  Print:1(
     NameExpr(x)
     Target(
       NameExpr(foo))
@@ -74,7 +74,7 @@ MypyFile:1(
 print >>foo, x, y,
 [out]
 MypyFile:1(
-  PrintStmt:1(
+  Print:1(
     NameExpr(x)
     NameExpr(y)
     Target(
@@ -86,12 +86,12 @@ print 2, 3,
 print (4, 5),
 [out]
 MypyFile:1(
-  PrintStmt:1(
+  Print:1(
     IntExpr(1))
-  PrintStmt:2(
+  Print:2(
     IntExpr(2)
     IntExpr(3))
-  PrintStmt:3(
+  Print:3(
     TupleExpr:3(
       IntExpr(4)
       IntExpr(5))))
@@ -102,11 +102,11 @@ MypyFile:1(
 0377
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     IntExpr(0))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     IntExpr(1))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     IntExpr(255)))
 
 [case testLongLiteral]
@@ -116,13 +116,13 @@ MypyFile:1(
 0x123l
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     IntExpr(0))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     IntExpr(123))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     IntExpr(10))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     IntExpr(291)))
 
 [case testTryExceptWithComma]
@@ -132,14 +132,14 @@ except Exception, e:
     y
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         NameExpr(x)))
     NameExpr(Exception)
     NameExpr(e)
     Block:3(
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         NameExpr(y)))))
 
 [case testTryExceptWithNestedComma]
@@ -149,29 +149,29 @@ except (KeyError, IndexError):
     y
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         NameExpr(x)))
     TupleExpr:3(
       NameExpr(KeyError)
       NameExpr(IndexError))
     Block:3(
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         NameExpr(y)))))
 
 [case testExecStatement]
 exec a
 [out]
 MypyFile:1(
-  ExecStmt:1(
+  Exec:1(
     NameExpr(a)))
 
 [case testExecStatementWithIn]
 exec a in globals()
 [out]
 MypyFile:1(
-  ExecStmt:1(
+  Exec:1(
     NameExpr(a)
     CallExpr:1(
       NameExpr(globals)
@@ -181,7 +181,7 @@ MypyFile:1(
 exec a in x, y
 [out]
 MypyFile:1(
-  ExecStmt:1(
+  Exec:1(
     NameExpr(a)
     NameExpr(x)
     NameExpr(y)))
@@ -195,16 +195,16 @@ u'foo' 'bar'
 'bar' u'foo'
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     UnicodeExpr(foobar))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     UnicodeExpr(barfoo)))
 
 [case testLegacyInequality]
 1 <> 2
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     ComparisonExpr:1(
       !=
       IntExpr(1)
@@ -214,7 +214,7 @@ MypyFile:1(
 ([ 0 for x in 1, 2 if 3 ])
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     ListComprehension:1(
       GeneratorExpr:1(
         IntExpr(0)
@@ -234,12 +234,12 @@ MypyFile:1(
       Var(x)
       Var(__tuple_arg_2))
     Block:1(
-      AssignmentStmt:1(
+      Assignment:1(
         TupleExpr:1(
           NameExpr(y)
           NameExpr(z))
         NameExpr(__tuple_arg_2))
-      PassStmt:1())))
+      Pass:1())))
 
 [case testTupleArgListWithTwoTupleArgsInPython2]
 def f((x, y), (z, zz)): pass
@@ -251,17 +251,17 @@ MypyFile:1(
       Var(__tuple_arg_1)
       Var(__tuple_arg_2))
     Block:1(
-      AssignmentStmt:1(
+      Assignment:1(
         TupleExpr:1(
           NameExpr(x)
           NameExpr(y))
         NameExpr(__tuple_arg_1))
-      AssignmentStmt:1(
+      Assignment:1(
         TupleExpr:1(
           NameExpr(z)
           NameExpr(zz))
         NameExpr(__tuple_arg_2))
-      PassStmt:1())))
+      Pass:1())))
 
 [case testTupleArgListWithInitializerInPython2]
 def f((y, z) = (1, 2)): pass
@@ -272,62 +272,62 @@ MypyFile:1(
     Args(
       Var(__tuple_arg_1))
     Init(
-      AssignmentStmt:1(
+      Assignment:1(
         NameExpr(__tuple_arg_1)
         TupleExpr:1(
           IntExpr(1)
           IntExpr(2))))
     Block:1(
-      AssignmentStmt:1(
+      Assignment:1(
         TupleExpr:1(
           NameExpr(y)
           NameExpr(z))
         NameExpr(__tuple_arg_1))
-      PassStmt:1())))
+      Pass:1())))
 
 [case testLambdaTupleArgListInPython2]
 lambda (x, y): z
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     FuncExpr:1(
       Args(
         Var(__tuple_arg_1))
       Block:1(
-        AssignmentStmt:1(
+        Assignment:1(
           TupleExpr:1(
             NameExpr(x)
             NameExpr(y))
           NameExpr(__tuple_arg_1))
-        ReturnStmt:1(
+        Return:1(
           NameExpr(z))))))
 
 [case testLambdaSingletonTupleArgListInPython2]
 lambda (x,): z
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     FuncExpr:1(
       Args(
         Var(__tuple_arg_1))
       Block:1(
-        AssignmentStmt:1(
+        Assignment:1(
           TupleExpr:1(
             NameExpr(x))
           NameExpr(__tuple_arg_1))
-        ReturnStmt:1(
+        Return:1(
           NameExpr(z))))))
 
 [case testLambdaNoTupleArgListInPython2]
 lambda (x): z
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     FuncExpr:1(
       Args(
         Var(x))
       Block:1(
-        ReturnStmt:1(
+        Return:1(
           NameExpr(z))))))
 
 [case testInvalidExprInTupleArgListInPython2_1]
@@ -371,7 +371,7 @@ MypyFile:1(
       Var(x)
       Var(y))
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testDuplicateNameInTupleArgList_python2]
 def f(a, (a, b)):
@@ -388,7 +388,7 @@ main:3: error: Duplicate argument name "x"
 `1 + 2`
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     BackquoteExpr:1(
       OpExpr:1(
         +
@@ -399,7 +399,7 @@ MypyFile:1(
 `1, 2`
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     BackquoteExpr:1(
       TupleExpr:1(
         IntExpr(1)

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -14,14 +14,14 @@ MypyFile:1()
 1
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     IntExpr(1)))
 
 [case testAssignment]
 x = 1
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     IntExpr(1)))
 
@@ -32,14 +32,14 @@ x = f(1, None)
 -1.23
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     CallExpr:1(
       NameExpr(f)
       Args(
         IntExpr(1)
         NameExpr(None))))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     OpExpr:2(
       *
       IntExpr(123)
@@ -47,13 +47,13 @@ MypyFile:1(
         +
         IntExpr(2)
         NameExpr(x))))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     CallExpr:3(
       MemberExpr:3(
         StrExpr(hello)
         lower)
       Args()))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     UnaryExpr:4(
       -
       FloatExpr(1.23))))
@@ -65,11 +65,11 @@ MypyFile:1(
 bar'
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     StrExpr())
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     StrExpr(foo))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     StrExpr(foobar)))
 
 [case testDoubleQuotedStr]
@@ -79,11 +79,11 @@ MypyFile:1(
 bar"
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     StrExpr())
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     StrExpr(foo))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     StrExpr(foobar)))
 
 [case testTripleQuotedStr]
@@ -103,25 +103,25 @@ bar"""
 """fo""bar"""
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     StrExpr())
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     StrExpr(foo))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     StrExpr(foobar))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     StrExpr(\nfoo\u000abar))
-  ExpressionStmt:6(
+  ExpressionStatement:6(
     StrExpr(fo''bar))
-  ExpressionStmt:7(
+  ExpressionStatement:7(
     StrExpr())
-  ExpressionStmt:8(
+  ExpressionStatement:8(
     StrExpr(foo))
-  ExpressionStmt:9(
+  ExpressionStatement:9(
     StrExpr(foobar))
-  ExpressionStmt:10(
+  ExpressionStatement:10(
     StrExpr(\nfoo\u000abar))
-  ExpressionStmt:12(
+  ExpressionStatement:12(
     StrExpr(fo""bar)))
 
 [case testRawStr]
@@ -129,9 +129,9 @@ r'x\n\''
 r"x\n\""
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     StrExpr(x\n'))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     StrExpr(x\n")))
 --" fix syntax highlight
 
@@ -142,11 +142,11 @@ bar"
 br'x\n\''
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     BytesExpr(foo))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     BytesExpr(foobar))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     BytesExpr(x\n')))
 
 [case testEscapesInStrings]
@@ -154,9 +154,9 @@ MypyFile:1(
 b'\r\n\t\x2f\u123f'
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     StrExpr(\u000d\u000a\u0009/\u123f))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     BytesExpr(\u000d\u000a\u0009/\\u123f)))
 -- Note \\u in the b'...' case (\u sequence not translated)
 
@@ -164,7 +164,7 @@ MypyFile:1(
 '\''
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     StrExpr(')))
 --'
 
@@ -173,16 +173,16 @@ MypyFile:1(
 b'\1\476'
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     StrExpr(\u0000\u0001\u007fS4))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     BytesExpr(\u0001\u013e)))
 
 [case testUnicodeLiteralInPython3]
 u'foo'
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     StrExpr(foo)))
 
 [case testArrays]
@@ -191,15 +191,15 @@ a = [1, 2]
 a[[1]] = a[2]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a)
     ListExpr:1())
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(a)
     ListExpr:2(
       IntExpr(1)
       IntExpr(2)))
-  AssignmentStmt:3(
+  Assignment:3(
     IndexExpr:3(
       NameExpr(a)
       ListExpr:3(
@@ -215,16 +215,16 @@ MypyFile:1(
 a, b = 1, (2, 3)
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     TupleExpr:1())
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     TupleExpr:2(
       IntExpr(1)))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     TupleExpr:3(
       IntExpr(1)
       NameExpr(foo)))
-  AssignmentStmt:4(
+  Assignment:4(
     TupleExpr:4(
       NameExpr(a)
       NameExpr(b))
@@ -242,7 +242,7 @@ MypyFile:1(
   FuncDef:1(
     main
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         IntExpr(1)))))
 
 [case testPass]
@@ -253,18 +253,18 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testIf]
 if 1:
     2
 [out]
 MypyFile:1(
-  IfStmt:1(
+  If:1(
     If(
       IntExpr(1))
     Then(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         IntExpr(2)))))
 
 [case testIfElse]
@@ -274,14 +274,14 @@ else:
     3
 [out]
 MypyFile:1(
-  IfStmt:1(
+  If:1(
     If(
       IntExpr(1))
     Then(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         IntExpr(2)))
     Else(
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         IntExpr(3)))))
 
 [case testIfElif]
@@ -295,24 +295,24 @@ else:
     7
 [out]
 MypyFile:1(
-  IfStmt:1(
+  If:1(
     If(
       IntExpr(1))
     Then(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         IntExpr(2)))
     If(
       IntExpr(3))
     Then(
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         IntExpr(4)))
     If(
       IntExpr(5))
     Then(
-      ExpressionStmt:6(
+      ExpressionStatement:6(
         IntExpr(6)))
     Else(
-      ExpressionStmt:8(
+      ExpressionStatement:8(
         IntExpr(7)))))
 
 [case testWhile]
@@ -320,10 +320,10 @@ while 1:
     pass
 [out]
 MypyFile:1(
-  WhileStmt:1(
+  While:1(
     IntExpr(1)
     Block:1(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testReturn]
 def f():
@@ -333,7 +333,7 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      ReturnStmt:2(
+      Return:2(
         IntExpr(1)))))
 
 
@@ -345,17 +345,17 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      ReturnStmt:2())))
+      Return:2())))
 
 [case testBreak]
 while 1:
     break
 [out]
 MypyFile:1(
-  WhileStmt:1(
+  While:1(
     IntExpr(1)
     Block:1(
-      BreakStmt:2())))
+      Break:2())))
 
 [case testLargeBlock]
 if 1:
@@ -365,18 +365,18 @@ if 1:
     y = 2
 [out]
 MypyFile:1(
-  IfStmt:1(
+  If:1(
     If(
       IntExpr(1))
     Then(
-      AssignmentStmt:2(
+      Assignment:2(
         NameExpr(x)
         IntExpr(1))
-      WhileStmt:3(
+      While:3(
         IntExpr(2)
         Block:3(
-          PassStmt:4()))
-      AssignmentStmt:5(
+          Pass:4()))
+      Assignment:5(
         NameExpr(y)
         IntExpr(2)))))
 
@@ -393,18 +393,18 @@ MypyFile:1(
       Args(
         Var(self))
       Block:2(
-        PassStmt:3()))))
+        Pass:3()))))
 
 [case testGlobalVarWithType]
 x = 0 # type: int
 y = False # type: bool
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     IntExpr(0)
     int?)
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(y)
     NameExpr(False)
     bool?))
@@ -419,15 +419,15 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      AssignmentStmt:2(
+      Assignment:2(
         NameExpr(x)
         IntExpr(0)
         int?)
-      AssignmentStmt:3(
+      Assignment:3(
         NameExpr(y)
         NameExpr(False)
         bool?)
-      AssignmentStmt:4(
+      Assignment:4(
         NameExpr(a)
         NameExpr(None)
         Any?))))
@@ -437,7 +437,7 @@ x = 0
   # type: int
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     IntExpr(0)
     int?))
@@ -458,7 +458,7 @@ MypyFile:1(
       Var(y))
     def (y: str?) -> int?
     Block:1(
-      ReturnStmt:2()))
+      Return:2()))
   ClassDef:3(
     A
     FuncDef:4(
@@ -469,14 +469,14 @@ MypyFile:1(
         Var(b))
       def (self: Any, a: int?, b: Any?) -> x?
       Block:4(
-        PassStmt:5()))
+        Pass:5()))
     FuncDef:6(
       g
       Args(
         Var(self))
       def (self: Any) -> Any?
       Block:6(
-        PassStmt:7()))))
+        Pass:7()))))
 
 [case testFuncWithNoneReturn]
 def f() -> None:
@@ -487,18 +487,18 @@ MypyFile:1(
     f
     def () -> None?
     Block:1(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testVarDefWithGenericType]
 x = None # type: List[str]
 y = None # type: Dict[int, Any]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     NameExpr(None)
     List?[str?])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(y)
     NameExpr(None)
     Dict?[int?, Any?]))
@@ -514,7 +514,7 @@ MypyFile:1(
       Var(y))
     def (y: t?[Any?, x?]) -> a?[b?[c?], d?]
     Block:1(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testParsingExpressionsWithLessAndGreaterThan]
 # The operators < > can sometimes be confused with generic types.
@@ -525,7 +525,7 @@ x < b, y > 2
 (a < b > c)
 [out]
 MypyFile:1(
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x)
     ComparisonExpr:2(
       <
@@ -533,7 +533,7 @@ MypyFile:1(
       NameExpr(a)
       NameExpr(b)
       NameExpr(c)))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     CallExpr:3(
       NameExpr(f)
       Args(
@@ -545,14 +545,14 @@ MypyFile:1(
           >
           NameExpr(y)
           NameExpr(c)))))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     ComparisonExpr:4(
       <
       >
       NameExpr(a)
       NameExpr(b)
       IntExpr(1)))
-  ExpressionStmt:5(
+  ExpressionStatement:5(
     TupleExpr:5(
       ComparisonExpr:5(
         <
@@ -562,7 +562,7 @@ MypyFile:1(
         >
         NameExpr(y)
         IntExpr(2))))
-  ExpressionStmt:6(
+  ExpressionStatement:6(
     ComparisonExpr:6(
       <
       >
@@ -576,20 +576,20 @@ if (1 +
   pass
 [out]
 MypyFile:1(
-  IfStmt:1(
+  If:1(
     If(
       OpExpr:1(
         +
         IntExpr(1)
         IntExpr(2)))
     Then(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testMultipleVarDef]
 x, y = z # type: int, a[c]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     TupleExpr:1(
       NameExpr(x)
       NameExpr(y))
@@ -600,7 +600,7 @@ MypyFile:1(
 (xx, z, i) = 1 # type: (a[c], Any, int)
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     TupleExpr:1(
       NameExpr(xx)
       NameExpr(z)
@@ -612,7 +612,7 @@ MypyFile:1(
 (xx, (z, i)) = 1 # type: (a[c], (Any, int))
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     TupleExpr:1(
       NameExpr(xx)
       TupleExpr:1(
@@ -634,7 +634,7 @@ MypyFile:1(
       Args(
         Var(self))
       Block:2(
-        AssignmentStmt:3(
+        Assignment:3(
           MemberExpr:3(
             NameExpr(self)
             x)
@@ -645,7 +645,7 @@ MypyFile:1(
 x = 0 # type: int # bar!
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     IntExpr(0)
     int?))
@@ -656,7 +656,7 @@ MypyFile:1(
       2) # type: foo, bar
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     TupleExpr:1(
       NameExpr(x)
       NameExpr(y))
@@ -669,7 +669,7 @@ MypyFile:1(
 x = 1#type:int
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     IntExpr(1)
     int?))
@@ -678,7 +678,7 @@ MypyFile:1(
 x = 1#   type:   int
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     IntExpr(1)
     int?))
@@ -687,7 +687,7 @@ MypyFile:1(
 x = 1# type : int       # not recognized!
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     IntExpr(1)))
 
@@ -697,13 +697,13 @@ y=1 #.type: int
 z=1 # Type: int
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     IntExpr(1))
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(y)
     IntExpr(1))
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(z)
     IntExpr(1)))
 
@@ -714,14 +714,14 @@ class C:
 MypyFile:1(
   ClassDef:1(
     C
-    PassStmt:2()))
+    Pass:2()))
 
 [case testOperatorPrecedence]
 a | b ^ c
 a & b << c
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     OpExpr:1(
       |
       NameExpr(a)
@@ -729,7 +729,7 @@ MypyFile:1(
         ^
         NameExpr(b)
         NameExpr(c))))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     OpExpr:2(
       &
       NameExpr(a)
@@ -743,7 +743,7 @@ MypyFile:1(
 1 << 2 << 3
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     OpExpr:1(
       +
       OpExpr:1(
@@ -751,7 +751,7 @@ MypyFile:1(
         IntExpr(1)
         IntExpr(2))
       IntExpr(3)))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     OpExpr:2(
       <<
       OpExpr:2(
@@ -765,7 +765,7 @@ MypyFile:1(
 ~3**2
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     OpExpr:1(
       *
       OpExpr:1(
@@ -782,7 +782,7 @@ MypyFile:1(
           ~
           IntExpr(3)))
       IntExpr(2)))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     UnaryExpr:2(
       ~
       OpExpr:2(
@@ -797,24 +797,24 @@ def f(): pass
 def g() -> int: return 1
 [out]
 MypyFile:1(
-  IfStmt:1(
+  If:1(
     If(
       IntExpr(1))
     Then(
-      PassStmt:1()))
-  WhileStmt:2(
+      Pass:1()))
+  While:2(
     IntExpr(1)
     Block:2(
-      PassStmt:2()))
+      Pass:2()))
   FuncDef:3(
     f
     Block:3(
-      PassStmt:3()))
+      Pass:3()))
   FuncDef:4(
     g
     def () -> int?
     Block:4(
-      ReturnStmt:4(
+      Return:4(
         IntExpr(1)))))
 
 [case testForStatement]
@@ -826,12 +826,12 @@ for [x, (y, w)] in z:
   1
 [out]
 MypyFile:1(
-  ForStmt:1(
+  For:1(
     NameExpr(x)
     NameExpr(y)
     Block:1(
-      PassStmt:2()))
-  ForStmt:3(
+      Pass:2()))
+  For:3(
     TupleExpr:3(
       NameExpr(x)
       TupleExpr:3(
@@ -839,9 +839,9 @@ MypyFile:1(
         NameExpr(w)))
     NameExpr(z)
     Block:3(
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         IntExpr(1))))
-  ForStmt:5(
+  For:5(
     ListExpr:5(
       NameExpr(x)
       TupleExpr:5(
@@ -849,7 +849,7 @@ MypyFile:1(
         NameExpr(w)))
     NameExpr(z)
     Block:5(
-      ExpressionStmt:6(
+      ExpressionStatement:6(
         IntExpr(1)))))
 
 [case testGlobalDecl]
@@ -887,7 +887,7 @@ MypyFile:1(
 raise foo
 [out]
 MypyFile:1(
-  RaiseStmt:1(
+  Raise:1(
     NameExpr(foo)))
 
 [case testRaiseWithoutArg]
@@ -897,17 +897,17 @@ except:
   raise
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      PassStmt:2())
+      Pass:2())
     Block:3(
-      RaiseStmt:4())))
+      Raise:4())))
 
 [case testRaiseFrom]
 raise e from x
 [out]
 MypyFile:1(
-  RaiseStmt:1(
+  Raise:1(
     NameExpr(e)
     NameExpr(x)))
 
@@ -922,7 +922,7 @@ MypyFile:1(
     A
     BaseTypeExpr(
       NameExpr(B))
-    PassStmt:2())
+    Pass:2())
   ClassDef:3(
     A
     BaseTypeExpr(
@@ -936,13 +936,13 @@ MypyFile:1(
           IndexExpr:3(
             NameExpr(d)
             NameExpr(x)))))
-    PassStmt:4()))
+    Pass:4()))
 
 [case testIsNot]
 x is not y
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     ComparisonExpr:1(
       is not
       NameExpr(x)
@@ -952,7 +952,7 @@ MypyFile:1(
 x in not y
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     ComparisonExpr:1(
       in
       NameExpr(x)
@@ -966,19 +966,19 @@ not x not in y
 x not in y | z
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     ComparisonExpr:1(
       not in
       NameExpr(x)
       NameExpr(y)))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     UnaryExpr:2(
       not
       ComparisonExpr:2(
         not in
         NameExpr(x)
         NameExpr(y))))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     ComparisonExpr:3(
       not in
       NameExpr(x)
@@ -1002,13 +1002,13 @@ x not is y # E: Parse error before is
 {1:x, 2 or 1:2 and 3}
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     DictExpr:1())
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     DictExpr:2(
       IntExpr(1)
       NameExpr(x)))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     DictExpr:3(
       IntExpr(1)
       NameExpr(x)
@@ -1033,7 +1033,7 @@ MypyFile:1(
 x = None # type: x.y
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     NameExpr(None)
     x.y?))
@@ -1046,7 +1046,7 @@ MypyFile:1(
     f
     def () -> x.y?[a.b.c?]
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testImportFrom]
 from m import x
@@ -1078,7 +1078,7 @@ def f():
   from z import *
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     IntExpr(1))
   Import:2(x)
   FuncDef:3(
@@ -1105,11 +1105,11 @@ MypyFile:1(
     Args(
       Var(x))
     Init(
-      AssignmentStmt:1(
+      Assignment:1(
         NameExpr(x)
         IntExpr(1)))
     Block:1(
-      PassStmt:2()))
+      Pass:2()))
   FuncDef:3(
     g
     Args(
@@ -1117,19 +1117,19 @@ MypyFile:1(
       Var(y)
       Var(z))
     Init(
-      AssignmentStmt:3(
+      Assignment:3(
         NameExpr(y)
         OpExpr:3(
           +
           IntExpr(1)
           IntExpr(2)))
-      AssignmentStmt:3(
+      Assignment:3(
         NameExpr(z)
         TupleExpr:3(
           IntExpr(1)
           IntExpr(2))))
     Block:3(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testTryFinally]
 try:
@@ -1138,12 +1138,12 @@ finally:
   2
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         IntExpr(1)))
     Finally(
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         IntExpr(2)))))
 
 [case testTry]
@@ -1153,13 +1153,13 @@ except x:
   2
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         IntExpr(1)))
     NameExpr(x)
     Block:3(
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         IntExpr(2)))))
 
 [case testComplexTry]
@@ -1171,27 +1171,27 @@ except x.y:
   3
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         IntExpr(1)))
     NameExpr(x)
     NameExpr(y)
     Block:3(
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         IntExpr(2)))
     MemberExpr:5(
       NameExpr(x)
       y)
     Block:5(
-      ExpressionStmt:6(
+      ExpressionStatement:6(
         IntExpr(3)))))
 
 [case testGeneratorExpression]
 x for y in z
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     GeneratorExpr:1(
       NameExpr(x)
       NameExpr(y)
@@ -1201,7 +1201,7 @@ MypyFile:1(
 x for y, (p, q) in z
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     GeneratorExpr:1(
       NameExpr(x)
       TupleExpr:1(
@@ -1215,7 +1215,7 @@ MypyFile:1(
 x=[x for y in z]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     ListComprehension:1(
       GeneratorExpr:1(
@@ -1227,7 +1227,7 @@ MypyFile:1(
 x=[(x, y) for y, z in (1, 2)]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     ListComprehension:1(
       GeneratorExpr:1(
@@ -1245,7 +1245,7 @@ MypyFile:1(
 ([x + 1 for x in a])
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     ListComprehension:1(
       GeneratorExpr:1(
         OpExpr:1(
@@ -1262,25 +1262,25 @@ x[1:]
 x[:]
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     IndexExpr:1(
       NameExpr(x)
       SliceExpr:1(
         IntExpr(1)
         IntExpr(2))))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     IndexExpr:2(
       NameExpr(x)
       SliceExpr:2(
         <empty>
         IntExpr(1))))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     IndexExpr:3(
       NameExpr(x)
       SliceExpr:3(
         IntExpr(1)
         <empty>)))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     IndexExpr:4(
       NameExpr(x)
       SliceExpr:4(
@@ -1295,35 +1295,35 @@ x[::2]
 x[1:2:]
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     IndexExpr:1(
       NameExpr(x)
       SliceExpr:1(
         IntExpr(1)
         IntExpr(2)
         IntExpr(3))))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     IndexExpr:2(
       NameExpr(x)
       SliceExpr:2(
         IntExpr(1)
         <empty>
         IntExpr(2))))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     IndexExpr:3(
       NameExpr(x)
       SliceExpr:3(
         <empty>
         IntExpr(1)
         IntExpr(2))))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     IndexExpr:4(
       NameExpr(x)
       SliceExpr:4(
         <empty>
         <empty>
         IntExpr(2))))
-  ExpressionStmt:5(
+  ExpressionStatement:5(
     IndexExpr:5(
       NameExpr(x)
       SliceExpr:5(
@@ -1338,7 +1338,7 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         YieldExpr:2(
           OpExpr:2(
             +
@@ -1353,7 +1353,7 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         YieldFromExpr:2(
           CallExpr:2(
             NameExpr(h)
@@ -1367,7 +1367,7 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      AssignmentStmt:2(
+      Assignment:2(
         NameExpr(a)
         YieldFromExpr:2(
           CallExpr:2(
@@ -1379,9 +1379,9 @@ del x
 del x[0], y[1]
 [out]
 MypyFile:1(
-  DelStmt:1(
+  Del:1(
     NameExpr(x))
-  DelStmt:2(
+  Del:2(
     TupleExpr:2(
       IndexExpr:2(
         NameExpr(x)
@@ -1397,22 +1397,22 @@ f(1,)
 {1:2,}
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     TupleExpr:1(
       IntExpr(1)
       IntExpr(2)))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     UnaryExpr:2(
       +
       ListExpr:2(
         IntExpr(1)
         IntExpr(2))))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     CallExpr:3(
       NameExpr(f)
       Args(
         IntExpr(1))))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     DictExpr:4(
       IntExpr(1)
       IntExpr(2))))
@@ -1427,7 +1427,7 @@ MypyFile:1(
     Args(
       Var(x))
     Block:1(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testLambda]
 lambda: 1
@@ -1435,57 +1435,57 @@ lambda x: y + 1
 lambda x, y: 1
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     FuncExpr:1(
       Block:1(
-        ReturnStmt:1(
+        Return:1(
           IntExpr(1)))))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     FuncExpr:2(
       Args(
         Var(x))
       Block:2(
-        ReturnStmt:2(
+        Return:2(
           OpExpr:2(
             +
             NameExpr(y)
             IntExpr(1))))))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     FuncExpr:3(
       Args(
         Var(x)
         Var(y))
       Block:3(
-        ReturnStmt:3(
+        Return:3(
           IntExpr(1))))))
 
 [case testComplexLambda]
 lambda x=2: x
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     FuncExpr:1(
       Args(
         Var(x))
       Init(
-        AssignmentStmt:1(
+        Assignment:1(
           NameExpr(x)
           IntExpr(2)))
       Block:1(
-        ReturnStmt:1(
+        Return:1(
           NameExpr(x))))))
 
 [case testLambdaPrecedence]
 lambda x: 1, 2
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     TupleExpr:1(
       FuncExpr:1(
         Args(
           Var(x))
         Block:1(
-          ReturnStmt:1(
+          Return:1(
             IntExpr(1))))
       IntExpr(2))))
 
@@ -1494,31 +1494,31 @@ for (i, j) in x:
   pass
 [out]
 MypyFile:1(
-  ForStmt:1(
+  For:1(
     TupleExpr:1(
       NameExpr(i)
       NameExpr(j))
     NameExpr(x)
     Block:1(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testForAndTrailingCommaAfterIndexVar]
 for i, in x:
     pass
 [out]
 MypyFile:1(
-  ForStmt:1(
+  For:1(
     TupleExpr:1(
       NameExpr(i))
     NameExpr(x)
     Block:1(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testListComprehensionAndTrailingCommaAfterIndexVar]
 x = [a for b, in c]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     ListComprehension:1(
       GeneratorExpr:1(
@@ -1532,19 +1532,19 @@ for i, j, in x:
     pass
 [out]
 MypyFile:1(
-  ForStmt:1(
+  For:1(
     TupleExpr:1(
       NameExpr(i)
       NameExpr(j))
     NameExpr(x)
     Block:1(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testGeneratorWithCondition]
 x for y in z if 0
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     GeneratorExpr:1(
       NameExpr(x)
       NameExpr(y)
@@ -1555,7 +1555,7 @@ MypyFile:1(
 raise [x for y in z if 0]
 [out]
 MypyFile:1(
-  RaiseStmt:1(
+  Raise:1(
     ListComprehension:1(
       GeneratorExpr:1(
         NameExpr(x)
@@ -1567,7 +1567,7 @@ MypyFile:1(
 raise [x for y in z if 0 if 1]
 [out]
 MypyFile:1(
-  RaiseStmt:1(
+  Raise:1(
     ListComprehension:1(
       GeneratorExpr:1(
         NameExpr(x)
@@ -1580,7 +1580,7 @@ MypyFile:1(
 raise [x for y in z if (1 if 2 else 3) if 1]
 [out]
 MypyFile:1(
-  RaiseStmt:1(
+  Raise:1(
     ListComprehension:1(
       GeneratorExpr:1(
         NameExpr(x)
@@ -1597,7 +1597,7 @@ MypyFile:1(
 a = {x: y for x, y in xys}
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a)
     DictionaryComprehension:1(
       NameExpr(x)
@@ -1611,7 +1611,7 @@ MypyFile:1(
 a = {x: y for x, y in xys for p, q in pqs if c}
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a)
     DictionaryComprehension:1(
       NameExpr(x)
@@ -1630,7 +1630,7 @@ MypyFile:1(
 a = {i for i in l}
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a)
     SetComprehension:1(
       GeneratorExpr:1(
@@ -1642,7 +1642,7 @@ MypyFile:1(
 a = {x + p for x in xys for p in pqs if c}
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a)
     SetComprehension:1(
       GeneratorExpr:1(
@@ -1661,7 +1661,7 @@ with open('foo') as f:
   pass
 [out]
 MypyFile:1(
-  WithStmt:1(
+  With:1(
     Expr(
       CallExpr:1(
         NameExpr(open)
@@ -1670,24 +1670,24 @@ MypyFile:1(
     Target(
       NameExpr(f))
     Block:1(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testWithStatementWithoutTarget]
 with foo:
   pass
 [out]
 MypyFile:1(
-  WithStmt:1(
+  With:1(
     Expr(
       NameExpr(foo))
     Block:1(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testHexOctBinLiterals]
 0xa, 0Xaf, 0o7, 0O12, 0b1, 0B101
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     TupleExpr:1(
       IntExpr(10)
       IntExpr(175)
@@ -1705,15 +1705,15 @@ MypyFile:1(
   ImportFrom:1(x, [y])
   ImportFrom:2(x, [y, z]))
 
-[case testContinueStmt]
+[case testContinue]
 while 1:
   continue
 [out]
 MypyFile:1(
-  WhileStmt:1(
+  While:1(
     IntExpr(1)
     Block:1(
-      ContinueStmt:2())))
+      Continue:2())))
 
 [case testStrLiteralConcatenate]
 'f' 'bar'
@@ -1722,9 +1722,9 @@ MypyFile:1(
  'z')
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     StrExpr(fbar))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     StrExpr(xyz)))
 
 [case testCatchAllExcept]
@@ -1740,21 +1740,21 @@ except:
   2
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         IntExpr(1)))
     Block:3(
-      PassStmt:4()))
-  TryStmt:5(
+      Pass:4()))
+  Try:5(
     Block:5(
-      ExpressionStmt:6(
+      ExpressionStatement:6(
         IntExpr(1)))
     NameExpr(x)
     Block:7(
-      PassStmt:8())
+      Pass:8())
     Block:9(
-      ExpressionStmt:10(
+      ExpressionStatement:10(
         IntExpr(2)))))
 
 [case testTryElse]
@@ -1766,15 +1766,15 @@ else:
   2
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      PassStmt:2())
+      Pass:2())
     NameExpr(x)
     Block:3(
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         IntExpr(1)))
     Else(
-      ExpressionStmt:6(
+      ExpressionStatement:6(
         IntExpr(2)))))
 
 [case testExceptWithMultipleTypes]
@@ -1786,21 +1786,21 @@ except (a, b, c) as e:
   pass
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      PassStmt:2())
+      Pass:2())
     TupleExpr:3(
       NameExpr(x)
       NameExpr(y))
     Block:3(
-      PassStmt:4())
+      Pass:4())
     TupleExpr:5(
       NameExpr(a)
       NameExpr(b)
       NameExpr(c))
     NameExpr(e)
     Block:5(
-      PassStmt:6())))
+      Pass:6())))
 
 [case testNestedFunctions]
 def f():
@@ -1817,7 +1817,7 @@ MypyFile:1(
       FuncDef:2(
         g
         Block:2(
-          PassStmt:3()))))
+          Pass:3()))))
   FuncDef:4(
     h
     def () -> int?
@@ -1826,7 +1826,7 @@ MypyFile:1(
         g
         def () -> int?
         Block:5(
-          PassStmt:6())))))
+          Pass:6())))))
 
 [case testStatementsAndDocStringsInClassBody]
 class A:
@@ -1838,9 +1838,9 @@ class A:
 MypyFile:1(
   ClassDef:1(
     A
-    ExpressionStmt:2(
+    ExpressionStatement:2(
       StrExpr(doc string))
-    AssignmentStmt:3(
+    Assignment:3(
       NameExpr(x)
       NameExpr(y))
     FuncDef:4(
@@ -1848,7 +1848,7 @@ MypyFile:1(
       Args(
         Var(self))
       Block:4(
-        PassStmt:5()))))
+        Pass:5()))))
 
 [case testSingleLineClass]
 class a: pass
@@ -1856,7 +1856,7 @@ class a: pass
 MypyFile:1(
   ClassDef:1(
     a
-    PassStmt:1()))
+    Pass:1()))
 
 [case testDecorator]
 @property
@@ -1870,7 +1870,7 @@ MypyFile:1(
     FuncDef:2(
       f
       Block:2(
-        PassStmt:3()))))
+        Pass:3()))))
 
 [case testComplexDecorator]
 @foo(bar, 1)
@@ -1891,13 +1891,13 @@ MypyFile:1(
       f
       def () -> int?
       Block:3(
-        PassStmt:4()))))
+        Pass:4()))))
 
 [case testKeywordArgInCall]
 f(x=1)
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     CallExpr:1(
       NameExpr(f)
       Args()
@@ -1909,7 +1909,7 @@ MypyFile:1(
 f(x, y=1 or 2, z=y)
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     CallExpr:1(
       NameExpr(f)
       Args(
@@ -1928,7 +1928,7 @@ MypyFile:1(
 x = z = 1
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     Lvalues(
       NameExpr(x)
       NameExpr(z))
@@ -1946,8 +1946,8 @@ MypyFile:1(
     VarArg(
       Var(a))
     Block:1(
-      PassStmt:1()))
-  ExpressionStmt:2(
+      Pass:1()))
+  ExpressionStatement:2(
     CallExpr:2(
       NameExpr(f)
       Args(
@@ -1967,7 +1967,7 @@ MypyFile:1(
     VarArg(
       Var(a))
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testDictVarArgs]
 def f(x, **a): pass
@@ -1980,7 +1980,7 @@ MypyFile:1(
     DictVarArg(
       Var(a))
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testBothVarArgs]
 def f(x, *a, **b): pass
@@ -1996,7 +1996,7 @@ MypyFile:1(
     DictVarArg(
       Var(b))
     Block:1(
-      PassStmt:1()))
+      Pass:1()))
   FuncDef:2(
     g
     VarArg(
@@ -2004,7 +2004,7 @@ MypyFile:1(
     DictVarArg(
       Var(b))
     Block:2(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testDictVarArgsWithType]
 def f(x: X, **a: A) -> None: pass
@@ -2018,7 +2018,7 @@ MypyFile:1(
     DictVarArg(
       Var(a))
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testCallDictVarArgs]
 f(**x)
@@ -2027,20 +2027,20 @@ f(*x, **y)
 f(x, *y, **z)
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     CallExpr:1(
       NameExpr(f)
       Args()
       DictVarArg(
         NameExpr(x))))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     CallExpr:2(
       NameExpr(f)
       Args(
         NameExpr(x))
       DictVarArg(
         NameExpr(y))))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     CallExpr:3(
       NameExpr(f)
       Args(
@@ -2048,7 +2048,7 @@ MypyFile:1(
       VarArg
       DictVarArg(
         NameExpr(y))))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     CallExpr:4(
       NameExpr(f)
       Args(
@@ -2062,7 +2062,7 @@ MypyFile:1(
 assert x == y
 [out]
 MypyFile:1(
-  AssertStmt:1(
+  Assert:1(
     ComparisonExpr:1(
       ==
       NameExpr(x)
@@ -2076,14 +2076,14 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         YieldExpr:2()))))
 
 [case testConditionalExpression]
 x if y else z
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     ConditionalExpr:1(
       Condition(
         NameExpr(y))
@@ -2094,7 +2094,7 @@ MypyFile:1(
 a = [x if y else z for a in b]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a)
     ListComprehension:1(
       GeneratorExpr:1(
@@ -2110,7 +2110,7 @@ MypyFile:1(
 1 if 2 else 3, 4
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     TupleExpr:1(
       ConditionalExpr:1(
         Condition(
@@ -2124,13 +2124,13 @@ MypyFile:1(
 {1, 2}
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     SetExpr:1(
       OpExpr:1(
         or
         NameExpr(x)
         NameExpr(y))))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     SetExpr:2(
       IntExpr(1)
       IntExpr(2))))
@@ -2139,7 +2139,7 @@ MypyFile:1(
 {x,}
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     SetExpr:1(
       NameExpr(x))))
 
@@ -2158,13 +2158,13 @@ else:
   x
 [out]
 MypyFile:1(
-  ForStmt:1(
+  For:1(
     NameExpr(x)
     NameExpr(y)
     Block:1(
-      PassStmt:2())
+      Pass:2())
     Else(
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         NameExpr(x)))))
 
 [case testWhileAndElse]
@@ -2174,12 +2174,12 @@ else:
   y
 [out]
 MypyFile:1(
-  WhileStmt:1(
+  While:1(
     NameExpr(x)
     Block:1(
-      PassStmt:2())
+      Pass:2())
     Else(
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         NameExpr(y)))))
 
 [case testWithAndMultipleOperands]
@@ -2189,7 +2189,7 @@ with x(), y():
   pass
 [out]
 MypyFile:1(
-  WithStmt:1(
+  With:1(
     Expr(
       NameExpr(x))
     Target(
@@ -2199,8 +2199,8 @@ MypyFile:1(
     Target(
       NameExpr(b))
     Block:1(
-      PassStmt:2()))
-  WithStmt:3(
+      Pass:2()))
+  With:3(
     Expr(
       CallExpr:3(
         NameExpr(x)
@@ -2210,7 +2210,7 @@ MypyFile:1(
         NameExpr(y)
         Args()))
     Block:3(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testOperatorAssignment]
 x += 1
@@ -2227,51 +2227,51 @@ x >>= 1
 x <<= 1
 [out]
 MypyFile:1(
-  OperatorAssignmentStmt:1(
+  OperatorAssignment:1(
     +
     NameExpr(x)
     IntExpr(1))
-  OperatorAssignmentStmt:2(
+  OperatorAssignment:2(
     -
     NameExpr(x)
     IntExpr(1))
-  OperatorAssignmentStmt:3(
+  OperatorAssignment:3(
     *
     NameExpr(x)
     IntExpr(1))
-  OperatorAssignmentStmt:4(
+  OperatorAssignment:4(
     /
     NameExpr(x)
     IntExpr(1))
-  OperatorAssignmentStmt:5(
+  OperatorAssignment:5(
     //
     NameExpr(x)
     IntExpr(1))
-  OperatorAssignmentStmt:6(
+  OperatorAssignment:6(
     %
     NameExpr(x)
     IntExpr(1))
-  OperatorAssignmentStmt:7(
+  OperatorAssignment:7(
     **
     NameExpr(x)
     IntExpr(1))
-  OperatorAssignmentStmt:8(
+  OperatorAssignment:8(
     |
     NameExpr(x)
     IntExpr(1))
-  OperatorAssignmentStmt:9(
+  OperatorAssignment:9(
     &
     NameExpr(x)
     IntExpr(1))
-  OperatorAssignmentStmt:10(
+  OperatorAssignment:10(
     ^
     NameExpr(x)
     IntExpr(1))
-  OperatorAssignmentStmt:11(
+  OperatorAssignment:11(
     >>
     NameExpr(x)
     IntExpr(1))
-  OperatorAssignmentStmt:12(
+  OperatorAssignment:12(
     <<
     NameExpr(x)
     IntExpr(1)))
@@ -2288,10 +2288,10 @@ MypyFile:1(
     A
     ClassDef:2(
       B
-      PassStmt:3())
+      Pass:3())
     ClassDef:4(
       C
-      PassStmt:5())))
+      Pass:5())))
 
 [case testTryWithExceptAndFinally]
 try:
@@ -2302,15 +2302,15 @@ finally:
   y
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      PassStmt:2())
+      Pass:2())
     NameExpr(x)
     Block:3(
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         NameExpr(x)))
     Finally(
-      ExpressionStmt:6(
+      ExpressionStatement:6(
         NameExpr(y)))))
 
 [case testBareAsteriskInFuncDef]
@@ -2324,11 +2324,11 @@ MypyFile:1(
       Var(x)
       Var(y))
     Init(
-      AssignmentStmt:1(
+      Assignment:1(
         NameExpr(y)
         IntExpr(1)))
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testBareAsteriskInFuncDefWithSignature]
 def f(x: A, *, y: B = 1) -> None: pass
@@ -2342,11 +2342,11 @@ MypyFile:1(
       Var(y))
     def (x: A?, *, y: B?) -> None?
     Init(
-      AssignmentStmt:1(
+      Assignment:1(
         NameExpr(y)
         IntExpr(1)))
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testBareAsteriskNamedDefault]
 def f(*, y: B = 1) -> None: pass
@@ -2359,11 +2359,11 @@ MypyFile:1(
       Var(y))
     def (*, y: B?) -> None?
     Init(
-      AssignmentStmt:1(
+      Assignment:1(
         NameExpr(y)
         IntExpr(1)))
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testBareAsteriskNamedNoDefault]
 def f(*, y: B) -> None: pass
@@ -2377,13 +2377,13 @@ MypyFile:1(
     def (*, y: B?) -> None?
     Init()
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testSuperExpr]
 super().x
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     SuperExpr:1(
       x)))
 
@@ -2391,7 +2391,7 @@ MypyFile:1(
 f(x = y, **kwargs)
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     CallExpr:1(
       NameExpr(f)
       Args()
@@ -2405,7 +2405,7 @@ MypyFile:1(
 f = None # type: Callable[[], None]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(f)
     NameExpr(None)
     Callable?[<TypeList >, None?]))
@@ -2414,7 +2414,7 @@ MypyFile:1(
 f = None # type: Callable[[str], int]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(f)
     NameExpr(None)
     Callable?[<TypeList str?>, int?]))
@@ -2423,7 +2423,7 @@ MypyFile:1(
 f = None # type: Callable[[a[b], x.y], List[int]]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(f)
     NameExpr(None)
     Callable?[<TypeList a?[b?], x.y?>, List?[int?]]))
@@ -2438,7 +2438,7 @@ MypyFile:1(
       Var(x))
     def (x: Callable?[<TypeList str?>, int?]) -> Any
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testSimpleStringLiteralType]
 def f() -> 'A': pass
@@ -2448,7 +2448,7 @@ MypyFile:1(
     f
     def () -> A?
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testGenericStringLiteralType]
 def f() -> 'A[B, C]': pass
@@ -2458,7 +2458,7 @@ MypyFile:1(
     f
     def () -> A?[B?, C?]
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testPartialStringLiteralType]
 def f() -> A['B', C]: pass
@@ -2468,7 +2468,7 @@ MypyFile:1(
     f
     def () -> A?[B?, C?]
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testWhitespaceInStringLiteralType]
 def f() -> '  A  [  X  ]  ': pass
@@ -2478,7 +2478,7 @@ MypyFile:1(
     f
     def () -> A?[X?]
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testEscapeInStringLiteralType]
 def f() -> '\x41': pass
@@ -2488,7 +2488,7 @@ MypyFile:1(
     f
     def () -> A?
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testMetaclass]
 class Foo(metaclass=Bar): pass
@@ -2497,7 +2497,7 @@ MypyFile:1(
   ClassDef:1(
     Foo
     Metaclass(Bar)
-    PassStmt:1()))
+    Pass:1()))
 
 [case testQualifiedMetaclass]
 class Foo(metaclass=foo.Bar): pass
@@ -2506,7 +2506,7 @@ MypyFile:1(
   ClassDef:1(
     Foo
     Metaclass(foo.Bar)
-    PassStmt:1()))
+    Pass:1()))
 
 [case testBaseAndMetaclass]
 class Foo(foo.bar[x], metaclass=Bar): pass
@@ -2521,7 +2521,7 @@ MypyFile:1(
           NameExpr(foo)
           bar)
         NameExpr(x)))
-    PassStmt:1()))
+    Pass:1()))
 
 [case testClassKeywordArgs]
 class Foo(_root=None): pass
@@ -2529,7 +2529,7 @@ class Foo(_root=None): pass
 MypyFile:1(
   ClassDef:1(
     Foo
-    PassStmt:1()))
+    Pass:1()))
 
 [case testClassKeywordArgsBeforeMeta]
 class Foo(_root=None, metaclass=Bar): pass
@@ -2538,7 +2538,7 @@ MypyFile:1(
   ClassDef:1(
     Foo
     Metaclass(Bar)
-    PassStmt:1()))
+    Pass:1()))
 
 [case testClassKeywordArgsAfterMeta]
 class Foo(metaclass=Bar, _root=None): pass
@@ -2547,13 +2547,13 @@ MypyFile:1(
   ClassDef:1(
     Foo
     Metaclass(Bar)
-    PassStmt:1()))
+    Pass:1()))
 
 [case testNamesThatAreNoLongerKeywords]
 any = interface
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(any)
     NameExpr(interface)))
 
@@ -2572,7 +2572,7 @@ MypyFile:1(
         f
         def () -> x?
         Block:2(
-          PassStmt:2())))
+          Pass:2())))
     Decorator:3(
       Var(f)
       NameExpr(foo)
@@ -2580,7 +2580,7 @@ MypyFile:1(
         f
         def () -> y?
         Block:4(
-          PassStmt:4())))))
+          Pass:4())))))
 
 [case testFunctionOverloadAndOtherStatements]
 x
@@ -2591,7 +2591,7 @@ def f() -> y: pass
 x
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     NameExpr(x))
   OverloadedFuncDef:2(
     Decorator:2(
@@ -2601,7 +2601,7 @@ MypyFile:1(
         f
         def () -> x?
         Block:3(
-          PassStmt:3())))
+          Pass:3())))
     Decorator:4(
       Var(f)
       NameExpr(foo)
@@ -2609,8 +2609,8 @@ MypyFile:1(
         f
         def () -> y?
         Block:5(
-          PassStmt:5()))))
-  ExpressionStmt:6(
+          Pass:5()))))
+  ExpressionStatement:6(
     NameExpr(x)))
 
 [case testFunctionOverloadWithThreeVariants]
@@ -2630,7 +2630,7 @@ MypyFile:1(
         f
         def () -> x?
         Block:2(
-          PassStmt:2())))
+          Pass:2())))
     Decorator:3(
       Var(f)
       NameExpr(foo)
@@ -2638,7 +2638,7 @@ MypyFile:1(
         f
         def () -> y?
         Block:4(
-          PassStmt:4())))
+          Pass:4())))
     Decorator:5(
       Var(f)
       NameExpr(foo)
@@ -2647,7 +2647,7 @@ MypyFile:1(
         Args(
           Var(y))
         Block:6(
-          PassStmt:6())))))
+          Pass:6())))))
 
 [case testDecoratorsThatAreNotOverloads]
 @foo
@@ -2663,7 +2663,7 @@ MypyFile:1(
       f
       def () -> x?
       Block:2(
-        PassStmt:2())))
+        Pass:2())))
   Decorator:3(
     Var(g)
     NameExpr(foo)
@@ -2671,7 +2671,7 @@ MypyFile:1(
       g
       def () -> y?
       Block:4(
-        PassStmt:4()))))
+        Pass:4()))))
 
 [case testFunctionOverloadWithinFunction]
 def f():
@@ -2691,7 +2691,7 @@ MypyFile:1(
           FuncDef:3(
             g
             Block:3(
-              PassStmt:3())))
+              Pass:3())))
         Decorator:4(
           Var(g)
           NameExpr(foo)
@@ -2699,7 +2699,7 @@ MypyFile:1(
             g
             def () -> x?
             Block:5(
-              PassStmt:5())))))))
+              Pass:5())))))))
 
 [case testCommentFunctionAnnotation]
 def f(): # type: () -> A
@@ -2712,14 +2712,14 @@ MypyFile:1(
     f
     def () -> A?
     Block:1(
-      PassStmt:2()))
+      Pass:2()))
   FuncDef:3(
     g
     Args(
       Var(x))
     def (x: A?) -> B?
     Block:3(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testCommentMethodAnnotation]
 class A:
@@ -2737,7 +2737,7 @@ MypyFile:1(
         Var(self))
       def (self: Any) -> A?
       Block:2(
-        PassStmt:3()))
+        Pass:3()))
     FuncDef:4(
       g
       Args(
@@ -2745,7 +2745,7 @@ MypyFile:1(
         Var(x))
       def (xself: Any, x: A?) -> B?
       Block:4(
-        PassStmt:5()))))
+        Pass:5()))))
 
 [case testCommentMethodAnnotationAndNestedFunction]
 class A:
@@ -2768,7 +2768,7 @@ MypyFile:1(
             Var(x))
           def (x: A?) -> B?
           Block:3(
-            PassStmt:4()))))))
+            Pass:4()))))))
 
 [case testCommentFunctionAnnotationOnSeparateLine]
 def f(x):
@@ -2782,7 +2782,7 @@ MypyFile:1(
       Var(x))
     def (x: X?) -> Y?
     Block:1(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testCommentFunctionAnnotationOnSeparateLine2]
 def f(x):
@@ -2798,7 +2798,7 @@ MypyFile:1(
       Var(x))
     def (x: X?) -> Y?
     Block:1(
-      PassStmt:5())))
+      Pass:5())))
 
 [case testCommentFunctionAnnotationAndVarArg]
 def f(x, *y): # type: (X, *Y) -> Z
@@ -2813,7 +2813,7 @@ MypyFile:1(
     VarArg(
       Var(y))
     Block:1(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testCommentFunctionAnnotationAndAllVarArgs]
 def f(x, *y, **z): # type: (X, *Y, **Z) -> A
@@ -2830,7 +2830,7 @@ MypyFile:1(
     DictVarArg(
       Var(z))
     Block:1(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testClassDecorator]
 @foo
@@ -2844,7 +2844,7 @@ MypyFile:1(
     X
     Decorators(
       NameExpr(foo))
-    PassStmt:2())
+    Pass:2())
   ClassDef:3(
     Z
     Decorators(
@@ -2855,7 +2855,7 @@ MypyFile:1(
       MemberExpr:4(
         NameExpr(x)
         y))
-    PassStmt:5()))
+    Pass:5()))
 
 [case testTrailingSemicolon]
 def x():
@@ -2868,11 +2868,11 @@ MypyFile:1(
   FuncDef:1(
     x
     Block:1(
-      PassStmt:2()))
+      Pass:2()))
   FuncDef:4(
     y
     Block:4(
-      PassStmt:5())))
+      Pass:5())))
 
 [case testEmptySuperClass]
 class A():
@@ -2881,7 +2881,7 @@ class A():
 MypyFile:1(
   ClassDef:1(
     A
-    PassStmt:2()))
+    Pass:2()))
 
 [case testStarExpression]
 *a
@@ -2891,27 +2891,27 @@ a, (*x, y)
 a, (x, *y)
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     StarExpr:1(
       NameExpr(a)))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     TupleExpr:2(
       StarExpr:2(
         NameExpr(a))
       NameExpr(b)))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     TupleExpr:3(
       NameExpr(a)
       StarExpr:3(
         NameExpr(b))))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     TupleExpr:4(
       NameExpr(a)
       TupleExpr:4(
         StarExpr:4(
           NameExpr(x))
         NameExpr(y))))
-  ExpressionStmt:5(
+  ExpressionStatement:5(
     TupleExpr:5(
       NameExpr(a)
       TupleExpr:5(
@@ -2924,10 +2924,10 @@ MypyFile:1(
 *(a,b)
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     StarExpr:1(
       NameExpr(a)))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     StarExpr:2(
       TupleExpr:2(
         NameExpr(a)
@@ -2944,28 +2944,28 @@ for *a, b in c:
     pass
 [out]
 MypyFile:1(
-  ForStmt:1(
+  For:1(
     StarExpr:1(
       NameExpr(a))
     NameExpr(b)
     Block:1(
-      PassStmt:2()))
-  ForStmt:4(
+      Pass:2()))
+  For:4(
     TupleExpr:4(
       NameExpr(a)
       StarExpr:4(
         NameExpr(b)))
     NameExpr(c)
     Block:4(
-      PassStmt:5()))
-  ForStmt:7(
+      Pass:5()))
+  For:7(
     TupleExpr:7(
       StarExpr:7(
         NameExpr(a))
       NameExpr(b))
     NameExpr(c)
     Block:7(
-      PassStmt:8())))
+      Pass:8())))
 
 [case testStarExprInGeneratorExpr]
 x for y, *p in z
@@ -2973,7 +2973,7 @@ x for *p, y in z
 x for y, *p, q in z
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     GeneratorExpr:1(
       NameExpr(x)
       TupleExpr:1(
@@ -2981,7 +2981,7 @@ MypyFile:1(
         StarExpr:1(
           NameExpr(p)))
       NameExpr(z)))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     GeneratorExpr:2(
       NameExpr(x)
       TupleExpr:2(
@@ -2989,7 +2989,7 @@ MypyFile:1(
           NameExpr(p))
         NameExpr(y))
       NameExpr(z)))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     GeneratorExpr:3(
       NameExpr(x)
       TupleExpr:3(
@@ -3012,7 +3012,7 @@ MypyFile:1(
           StrExpr(x)
           ListExpr:1(
             StrExpr(y)))))
-    PassStmt:1()))
+    Pass:1()))
 
 [case testEllipsis]
 ...
@@ -3020,16 +3020,16 @@ a[1,...,2]
 ....__class__
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     Ellipsis)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     IndexExpr:2(
       NameExpr(a)
       TupleExpr:2(
         IntExpr(1)
         Ellipsis
         IntExpr(2))))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     MemberExpr:3(
       Ellipsis
       __class__)))
@@ -3045,7 +3045,7 @@ MypyFile:1(
       Var(x)
       Var(y))
     Init(
-      AssignmentStmt:1(
+      Assignment:1(
         NameExpr(y)
         NameExpr(None)))
     VarArg(
@@ -3053,19 +3053,19 @@ MypyFile:1(
     DictVarArg(
       Var(kw))
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testIfWithSemicolons]
 if 1: a; b
 [out]
 MypyFile:1(
-  IfStmt:1(
+  If:1(
     If(
       IntExpr(1))
     Then(
-      ExpressionStmt:1(
+      ExpressionStatement:1(
         NameExpr(a))
-      ExpressionStmt:1(
+      ExpressionStatement:1(
         NameExpr(b)))))
 
 [case testIfWithSemicolonsNested]
@@ -3073,16 +3073,16 @@ while 2:
     if 1: a; b
 [out]
 MypyFile:1(
-  WhileStmt:1(
+  While:1(
     IntExpr(2)
     Block:1(
-      IfStmt:2(
+      If:2(
         If(
           IntExpr(1))
         Then(
-          ExpressionStmt:2(
+          ExpressionStatement:2(
             NameExpr(a))
-          ExpressionStmt:2(
+          ExpressionStatement:2(
             NameExpr(b)))))))
 
 [case testIfElseWithSemicolons]
@@ -3091,22 +3091,22 @@ else: x = 1; return 3
 4
 [out]
 MypyFile:1(
-  IfStmt:1(
+  If:1(
     If(
       IntExpr(1))
     Then(
       GlobalDecl:1(
         x)
-      AssignmentStmt:1(
+      Assignment:1(
         NameExpr(y)
         IntExpr(1)))
     Else(
-      AssignmentStmt:2(
+      Assignment:2(
         NameExpr(x)
         IntExpr(1))
-      ReturnStmt:2(
+      Return:2(
         IntExpr(3))))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     IntExpr(4)))
 
 [case testIfElseWithSemicolonsNested]
@@ -3116,32 +3116,32 @@ while 2:
 4
 [out]
 MypyFile:1(
-  WhileStmt:1(
+  While:1(
     IntExpr(2)
     Block:1(
-      IfStmt:2(
+      If:2(
         If(
           IntExpr(1))
         Then(
           GlobalDecl:2(
             x)
-          AssignmentStmt:2(
+          Assignment:2(
             NameExpr(y)
             IntExpr(1)))
         Else(
-          AssignmentStmt:3(
+          Assignment:3(
             NameExpr(x)
             IntExpr(1))
-          ReturnStmt:3(
+          Return:3(
             IntExpr(3))))))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     IntExpr(4)))
 
 [case testKeywordArgumentAfterStarArgumentInCall]
 f(x=1, *y)
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     CallExpr:1(
       NameExpr(f)
       Args(
@@ -3155,7 +3155,7 @@ MypyFile:1(
 { 1 if x else 2 for x in y }
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     SetComprehension:1(
       GeneratorExpr:1(
         ConditionalExpr:1(
@@ -3170,7 +3170,7 @@ MypyFile:1(
 a = [ 1 if x else 2 for x in y ]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a)
     ListComprehension:1(
       GeneratorExpr:1(
@@ -3186,7 +3186,7 @@ MypyFile:1(
 with x as y.z: pass
 [out]
 MypyFile:1(
-  WithStmt:1(
+  With:1(
     Expr(
       NameExpr(x))
     Target(
@@ -3194,7 +3194,7 @@ MypyFile:1(
         NameExpr(y)
         z))
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testRelativeImportWithEllipsis]
 from ... import x
@@ -3212,7 +3212,7 @@ MypyFile:1(
 a[:, :]
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     IndexExpr:1(
       NameExpr(a)
       TupleExpr:1(
@@ -3227,7 +3227,7 @@ MypyFile:1(
 a[1:2:, :,]
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     IndexExpr:1(
       NameExpr(a)
       TupleExpr:1(
@@ -3242,7 +3242,7 @@ MypyFile:1(
 a[1:2:3, ..., 1]
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     IndexExpr:1(
       NameExpr(a)
       TupleExpr:1(
@@ -3257,7 +3257,7 @@ MypyFile:1(
 test =  { 'spam': 'eggs' if True else 'bacon' }
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(test)
     DictExpr:1(
       StrExpr(spam)
@@ -3280,11 +3280,11 @@ y # type: ignore
 z # type: ignore
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     NameExpr(x))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     NameExpr(y))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     NameExpr(z))
   IgnoredLines(2, 3))
 
@@ -3292,7 +3292,7 @@ MypyFile:1(
 y ## type: ignore
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     NameExpr(y)))
 
 [case testInvalidIgnoreAnnotations]
@@ -3301,11 +3301,11 @@ y # type: IGNORE
 y # type : ignore
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     NameExpr(y))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     NameExpr(y))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     NameExpr(y)))
 
 [case testSpaceInIgnoreAnnotations]
@@ -3313,9 +3313,9 @@ y #  type:  ignore    # foo
 y #type:ignore
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     NameExpr(y))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     NameExpr(y))
   IgnoredLines(1, 2))
 
@@ -3328,12 +3328,12 @@ y = {   # type: ignore
 }       # type: ignore
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x)
     DictExpr:1(
       IntExpr(1)
       IntExpr(2)))
-  AssignmentStmt:4(
+  Assignment:4(
     NameExpr(y)
     DictExpr:4(
       IntExpr(1)
@@ -3357,7 +3357,7 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      AssignmentStmt:2(
+      Assignment:2(
         NameExpr(x)
         YieldExpr:2(
           CallExpr:2(
@@ -3368,12 +3368,12 @@ MypyFile:1(
 for x in 1,: pass
 [out]
 MypyFile:1(
-  ForStmt:1(
+  For:1(
     NameExpr(x)
     TupleExpr:1(
       IntExpr(1))
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testIsoLatinUnixEncoding]
 # coding: iso-latin-1-unix
@@ -3398,5 +3398,5 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         YieldExpr:2()))))

--- a/test-data/unit/semanal-abstractclasses.test
+++ b/test-data/unit/semanal-abstractclasses.test
@@ -23,7 +23,7 @@ MypyFile:1(
         def (self: __main__.A) -> __main__.A
         Abstract
         Block:6(
-          PassStmt:6())))
+          Pass:6())))
     Decorator:7(
       Var(f)
       FuncDef:8(
@@ -33,7 +33,7 @@ MypyFile:1(
         def (self: __main__.A) -> __main__.A
         Abstract
         Block:8(
-          ReturnStmt:8(
+          Return:8(
             NameExpr(self [l])))))))
 
 [case testClassInheritingTwoAbstractClasses]
@@ -50,17 +50,17 @@ MypyFile:1(
   ClassDef:4(
     A
     Metaclass(ABCMeta)
-    PassStmt:4())
+    Pass:4())
   ClassDef:5(
     B
     Metaclass(ABCMeta)
-    PassStmt:5())
+    Pass:5())
   ClassDef:6(
     C
     BaseType(
       __main__.A
       __main__.B)
-    PassStmt:6()))
+    Pass:6()))
 
 [case testAbstractGenericClass]
 from abc import abstractmethod
@@ -73,7 +73,7 @@ class A(Generic[T]):
 MypyFile:1(
   ImportFrom:1(abc, [abstractmethod])
   ImportFrom:2(typing, [Generic, TypeVar])
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(T* [__main__.T])
     TypeVarExpr:3())
   ClassDef:4(
@@ -89,7 +89,7 @@ MypyFile:1(
         def (self: __main__.A[T`1]) -> __main__.A[T`1]
         Abstract
         Block:6(
-          PassStmt:6())))))
+          Pass:6())))))
 
 [case testFullyQualifiedAbstractMethodDecl]
 import abc
@@ -116,4 +116,4 @@ MypyFile:1(
         def (self: __main__.A) -> __main__.A
         Abstract
         Block:7(
-          PassStmt:7())))))
+          Pass:7())))))

--- a/test-data/unit/semanal-basic.test
+++ b/test-data/unit/semanal-basic.test
@@ -7,7 +7,7 @@ x = 1
 x
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
   ExpressionStatement:2(
@@ -19,12 +19,12 @@ z = 3
 (x, y, z)
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     Lvalues(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
     IntExpr(2))
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(z* [__main__.z])
     IntExpr(3))
   ExpressionStatement:3(
@@ -41,7 +41,7 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      PassStmt:1()))
+      Pass:1()))
   ExpressionStatement:2(
     CallExpr:2(
       NameExpr(f [__main__.f])
@@ -60,13 +60,13 @@ MypyFile:1(
     CallExpr:2(
       NameExpr(f [__main__.f])
       Args()))
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(x* [__main__.x])
     IntExpr(1))
   FuncDef:4(
     f
     Block:4(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testFunctionArgs]
 def f(x, y):
@@ -93,7 +93,7 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      AssignmentStmt:2(
+      Assignment:2(
         NameExpr(x* [l])
         IntExpr(1))
       ExpressionStatement:3(
@@ -116,13 +116,13 @@ MypyFile:1(
         CallExpr:3(
           NameExpr(g [__main__.g])
           Args()))))
-  AssignmentStmt:4(
+  Assignment:4(
     NameExpr(x* [__main__.x])
     IntExpr(1))
   FuncDef:5(
     g
     Block:5(
-      PassStmt:5())))
+      Pass:5())))
 
 [case testAssignmentAfterInit]
 x = 1
@@ -133,10 +133,10 @@ def f(y):
   z = 2
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x [__main__.x])
     IntExpr(2))
   FuncDef:3(
@@ -144,13 +144,13 @@ MypyFile:1(
     Args(
       Var(y))
     Block:3(
-      AssignmentStmt:4(
+      Assignment:4(
         NameExpr(y [l])
         IntExpr(1))
-      AssignmentStmt:5(
+      Assignment:5(
         NameExpr(z* [l])
         IntExpr(1))
-      AssignmentStmt:6(
+      Assignment:6(
         NameExpr(z [l])
         IntExpr(2)))))
 
@@ -162,13 +162,13 @@ def f():
 x
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
   FuncDef:2(
     f
     Block:2(
-      AssignmentStmt:3(
+      Assignment:3(
         NameExpr(x* [l])
         IntExpr(2))
       ExpressionStatement:4(
@@ -187,10 +187,10 @@ MypyFile:1(
       Var(x)
       Var(y))
     Init(
-      AssignmentStmt:1(
+      Assignment:1(
         NameExpr(x [l])
         NameExpr(f [__main__.f]))
-      AssignmentStmt:1(
+      Assignment:1(
         NameExpr(y [l])
         NameExpr(object [builtins.object])))
     Block:1(
@@ -225,7 +225,7 @@ def f():
 class A: pass
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     NameExpr(None [builtins.None]))
   FuncDef:2(
@@ -233,14 +233,14 @@ MypyFile:1(
     Block:2(
       GlobalDecl:3(
         x)
-      AssignmentStmt:4(
+      Assignment:4(
         NameExpr(x [__main__.x])
         NameExpr(None [builtins.None]))
       ExpressionStatement:5(
         NameExpr(x [__main__.x]))))
   ClassDef:6(
     A
-    PassStmt:6()))
+    Pass:6()))
 
 [case testMultipleNamesInGlobalDecl]
 x, y = None, None
@@ -249,7 +249,7 @@ def f():
     x = y
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     TupleExpr:1(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
@@ -262,7 +262,7 @@ MypyFile:1(
       GlobalDecl:3(
         x
         y)
-      AssignmentStmt:4(
+      Assignment:4(
         NameExpr(x [__main__.x])
         NameExpr(y [__main__.y])))))
 
@@ -274,7 +274,7 @@ def g():
     x = None
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     NameExpr(None [builtins.None]))
   FuncDef:2(
@@ -285,7 +285,7 @@ MypyFile:1(
   FuncDef:4(
     g
     Block:4(
-      AssignmentStmt:5(
+      Assignment:5(
         NameExpr(x* [l])
         NameExpr(None [builtins.None])))))
 
@@ -297,7 +297,7 @@ def g():
     x = None
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     NameExpr(None [builtins.None]))
   FuncDef:2(
@@ -308,7 +308,7 @@ MypyFile:1(
   FuncDef:4(
     g
     Block:4(
-      AssignmentStmt:5(
+      Assignment:5(
         NameExpr(x* [l])
         NameExpr(None [builtins.None])))))
 
@@ -320,7 +320,7 @@ class A:
     x = self
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     NameExpr(None [builtins.None]))
   ClassDef:2(
@@ -332,7 +332,7 @@ MypyFile:1(
       Block:3(
         GlobalDecl:4(
           x)
-        AssignmentStmt:5(
+        Assignment:5(
           NameExpr(x [__main__.x])
           NameExpr(self [l]))))))
 
@@ -343,16 +343,16 @@ if object:
 x
 [out]
 MypyFile:1(
-  IfStmt:1(
+  If:1(
     If(
       NameExpr(object [builtins.object]))
     Then(
-      AssignmentStmt:2(
+      Assignment:2(
         NameExpr(x* [__main__.x])
         CallExpr:2(
           NameExpr(object [builtins.object])
           Args()))
-      AssignmentStmt:3(
+      Assignment:3(
         NameExpr(x [__main__.x])
         NameExpr(x [__main__.x]))))
   ExpressionStatement:4(
@@ -370,7 +370,7 @@ MypyFile:1(
   FuncDef:1(
     g
     Block:1(
-      AssignmentStmt:2(
+      Assignment:2(
         NameExpr(x* [l])
         NameExpr(None [builtins.None]))
       FuncDef:3(
@@ -378,7 +378,7 @@ MypyFile:1(
         Block:3(
           NonlocalDecl:4(
             x)
-          AssignmentStmt:5(
+          Assignment:5(
             NameExpr(x [l])
             NameExpr(None [builtins.None]))
           ExpressionStatement:6(
@@ -395,7 +395,7 @@ MypyFile:1(
   FuncDef:1(
     g
     Block:1(
-      AssignmentStmt:2(
+      Assignment:2(
         TupleExpr:2(
           NameExpr(x* [l])
           NameExpr(y* [l]))
@@ -410,7 +410,7 @@ MypyFile:1(
           NonlocalDecl:4(
             x
             y)
-          AssignmentStmt:5(
+          Assignment:5(
             NameExpr(x [l])
             NameExpr(y [l])))))))
 
@@ -431,13 +431,13 @@ MypyFile:1(
         Args(
           Var(y))
         Block:2(
-          AssignmentStmt:3(
+          Assignment:3(
             NameExpr(z* [l])
             OpExpr:3(
               +
               NameExpr(y [l])
               NameExpr(x [l])))))
-      ReturnStmt:4(
+      Return:4(
         NameExpr(g [l])))))
 
 [case testNestedFunctionWithOverlappingName]
@@ -454,6 +454,6 @@ MypyFile:1(
       FuncDef:2(
         g
         Block:2(
-          AssignmentStmt:3(
+          Assignment:3(
             NameExpr(x* [l])
             IntExpr(1)))))))

--- a/test-data/unit/semanal-basic.test
+++ b/test-data/unit/semanal-basic.test
@@ -10,7 +10,7 @@ MypyFile:1(
   AssignmentStmt:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     NameExpr(x [__main__.x])))
 
 [case testMultipleGlobals]
@@ -27,7 +27,7 @@ MypyFile:1(
   AssignmentStmt:2(
     NameExpr(z* [__main__.z])
     IntExpr(3))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     TupleExpr:3(
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y])
@@ -42,7 +42,7 @@ MypyFile:1(
     f
     Block:1(
       PassStmt:1()))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     CallExpr:2(
       NameExpr(f [__main__.f])
       Args())))
@@ -54,9 +54,9 @@ x = 1
 def f(): pass
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     NameExpr(x [__main__.x]))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     CallExpr:2(
       NameExpr(f [__main__.f])
       Args()))
@@ -79,7 +79,7 @@ MypyFile:1(
       Var(x)
       Var(y))
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         TupleExpr:2(
           NameExpr(x [l])
           NameExpr(y [l]))))))
@@ -96,7 +96,7 @@ MypyFile:1(
       AssignmentStmt:2(
         NameExpr(x* [l])
         IntExpr(1))
-      ExpressionStmt:3(
+      ExpressionStatement:3(
         NameExpr(x [l])))))
 
 [case testAccessGlobalInFn]
@@ -110,9 +110,9 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         NameExpr(x [__main__.x]))
-      ExpressionStmt:3(
+      ExpressionStatement:3(
         CallExpr:3(
           NameExpr(g [__main__.g])
           Args()))))
@@ -171,9 +171,9 @@ MypyFile:1(
       AssignmentStmt:3(
         NameExpr(x* [l])
         IntExpr(2))
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         NameExpr(x [l]))))
-  ExpressionStmt:5(
+  ExpressionStatement:5(
     NameExpr(x [__main__.x])))
 
 [case testArgumentInitializers]
@@ -194,7 +194,7 @@ MypyFile:1(
         NameExpr(y [l])
         NameExpr(object [builtins.object])))
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         TupleExpr:2(
           NameExpr(x [l])
           NameExpr(y [l]))))))
@@ -211,7 +211,7 @@ MypyFile:1(
     VarArg(
       Var(y))
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         TupleExpr:2(
           NameExpr(x [l])
           NameExpr(y [l]))))))
@@ -236,7 +236,7 @@ MypyFile:1(
       AssignmentStmt:4(
         NameExpr(x [__main__.x])
         NameExpr(None [builtins.None]))
-      ExpressionStmt:5(
+      ExpressionStatement:5(
         NameExpr(x [__main__.x]))))
   ClassDef:6(
     A
@@ -355,7 +355,7 @@ MypyFile:1(
       AssignmentStmt:3(
         NameExpr(x [__main__.x])
         NameExpr(x [__main__.x]))))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     NameExpr(x [__main__.x])))
 
 [case testNonlocalDecl]
@@ -381,7 +381,7 @@ MypyFile:1(
           AssignmentStmt:5(
             NameExpr(x [l])
             NameExpr(None [builtins.None]))
-          ExpressionStmt:6(
+          ExpressionStatement:6(
             NameExpr(x [l])))))))
 
 [case testMultipleNamesInNonlocalDecl]

--- a/test-data/unit/semanal-classes.test
+++ b/test-data/unit/semanal-classes.test
@@ -7,8 +7,8 @@ x = A
 MypyFile:1(
   ClassDef:1(
     A
-    PassStmt:1())
-  AssignmentStmt:2(
+    Pass:1())
+  Assignment:2(
     NameExpr(x* [__main__.x])
     NameExpr(A [__main__.A])))
 
@@ -28,7 +28,7 @@ MypyFile:1(
         Var(self)
         Var(x))
       Block:2(
-        AssignmentStmt:3(
+        Assignment:3(
           NameExpr(y* [l])
           NameExpr(x [l]))))
     FuncDef:4(
@@ -36,7 +36,7 @@ MypyFile:1(
       Args(
         Var(self))
       Block:4(
-        AssignmentStmt:5(
+        Assignment:5(
           NameExpr(y* [l])
           NameExpr(self [l]))))))
 
@@ -54,12 +54,12 @@ MypyFile:1(
       Args(
         Var(self))
       Block:2(
-        AssignmentStmt:3(
+        Assignment:3(
           MemberExpr:3(
             NameExpr(self [l])
             x*)
           IntExpr(1))
-        AssignmentStmt:4(
+        Assignment:4(
           MemberExpr:4(
             NameExpr(self [l])
             y*)
@@ -80,7 +80,7 @@ MypyFile:1(
       Args(
         Var(self))
       Block:2(
-        AssignmentStmt:3(
+        Assignment:3(
           MemberExpr:3(
             NameExpr(self [l])
             x*)
@@ -90,7 +90,7 @@ MypyFile:1(
     Args(
       Var(self))
     Block:4(
-      AssignmentStmt:5(
+      Assignment:5(
         MemberExpr:5(
           NameExpr(self [l])
           y)
@@ -114,7 +114,7 @@ MypyFile:1(
         Var(x)
         Var(self))
       Block:2(
-        AssignmentStmt:3(
+        Assignment:3(
           MemberExpr:3(
             NameExpr(self [l])
             y)
@@ -126,10 +126,10 @@ MypyFile:1(
       Args(
         Var(x))
       Block:5(
-        AssignmentStmt:6(
+        Assignment:6(
           NameExpr(self* [l])
           NameExpr(x [l]))
-        AssignmentStmt:7(
+        Assignment:7(
           MemberExpr:7(
             NameExpr(self [l])
             z)
@@ -148,7 +148,7 @@ MypyFile:1(
       Args(
         Var(x))
       Block:2(
-        AssignmentStmt:3(
+        Assignment:3(
           MemberExpr:3(
             NameExpr(x [l])
             y*)
@@ -168,12 +168,12 @@ MypyFile:1(
       Args(
         Var(self))
       Block:2(
-        AssignmentStmt:3(
+        Assignment:3(
           MemberExpr:3(
             NameExpr(self [l])
             x*)
           IntExpr(1))
-        AssignmentStmt:4(
+        Assignment:4(
           MemberExpr:4(
             NameExpr(self [l])
             x)
@@ -225,7 +225,7 @@ class A:
 MypyFile:1(
   ClassDef:1(
     A
-    AssignmentStmt:2(
+    Assignment:2(
       NameExpr(a* [m])
       NameExpr(object [builtins.object]))))
 
@@ -237,10 +237,10 @@ class A:
 MypyFile:1(
   ClassDef:1(
     A
-    AssignmentStmt:2(
+    Assignment:2(
       NameExpr(x* [m])
       IntExpr(1))
-    AssignmentStmt:3(
+    Assignment:3(
       NameExpr(y* [m])
       NameExpr(x [m]))))
 
@@ -257,8 +257,8 @@ MypyFile:1(
       Args(
         Var(self))
       Block:2(
-        PassStmt:2()))
-    AssignmentStmt:3(
+        Pass:2()))
+    Assignment:3(
       NameExpr(g* [m])
       NameExpr(f [m]))))
 
@@ -272,15 +272,15 @@ class A:
 MypyFile:1(
   ClassDef:1(
     A
-    IfStmt:2(
+    If:2(
       If(
         NameExpr(A [__main__.A]))
       Then(
-        AssignmentStmt:3(
+        Assignment:3(
           NameExpr(x* [m])
           IntExpr(1)))
       Else(
-        AssignmentStmt:5(
+        Assignment:5(
           NameExpr(x [m])
           IntExpr(2))))))
 
@@ -292,13 +292,13 @@ class A:
 MypyFile:1(
   ClassDef:1(
     A
-    ForStmt:2(
+    For:2(
       NameExpr(x* [m])
       ListExpr:2(
         IntExpr(1)
         IntExpr(2))
       Block:2(
-        AssignmentStmt:3(
+        Assignment:3(
           NameExpr(y* [m])
           NameExpr(x [m]))))))
 
@@ -313,7 +313,7 @@ MypyFile:1(
     Block:1(
       ClassDef:2(
         A
-        PassStmt:2())
+        Pass:2())
       ExpressionStatement:3(
         NameExpr(A [l])))))
 
@@ -327,7 +327,7 @@ MypyFile:1(
     A
     ClassDef:2(
       B
-      PassStmt:2())
+      Pass:2())
     ExpressionStatement:3(
       NameExpr(B [__main__.A.B]))))
 
@@ -341,12 +341,12 @@ MypyFile:1(
     A
     ClassDef:2(
       B
-      PassStmt:2())
+      Pass:2())
     ClassDef:3(
       C
       BaseType(
         __main__.A.B)
-      PassStmt:3())))
+      Pass:3())))
 
 [case testDeclarationReferenceToNestedClass]
 def f() -> None:
@@ -360,8 +360,8 @@ MypyFile:1(
     Block:1(
       ClassDef:2(
         A
-        PassStmt:2())
-      AssignmentStmt:3(
+        Pass:2())
+      Assignment:3(
         NameExpr(x [l])
         NameExpr(None [builtins.None])
         A))))
@@ -381,7 +381,7 @@ MypyFile:1(
     Block:1(
       ClassDef:2(
         A
-        AssignmentStmt:3(
+        Assignment:3(
           NameExpr(y* [m])
           NameExpr(x [l]))
         FuncDef:4(
@@ -389,7 +389,7 @@ MypyFile:1(
           Args(
             Var(self))
           Block:4(
-            AssignmentStmt:5(
+            Assignment:5(
               NameExpr(z* [l])
               NameExpr(x [l]))))))))
 
@@ -402,7 +402,7 @@ MypyFile:1(
   ClassDef:2(
     A
     Metaclass(abc.ABCMeta)
-    PassStmt:2()))
+    Pass:2()))
 
 [case testStaticMethod]
 class A:
@@ -422,7 +422,7 @@ MypyFile:1(
         def (z: builtins.int) -> builtins.str
         Static
         Block:3(
-          PassStmt:3())))))
+          Pass:3())))))
 
 [case testStaticMethodWithNoArgs]
 class A:
@@ -440,7 +440,7 @@ MypyFile:1(
         def () -> builtins.str
         Static
         Block:3(
-          PassStmt:3())))))
+          Pass:3())))))
 
 [case testClassMethod]
 class A:
@@ -461,7 +461,7 @@ MypyFile:1(
         def (cls: def () -> __main__.A, z: builtins.int) -> builtins.str
         Class
         Block:3(
-          PassStmt:3())))))
+          Pass:3())))))
 
 [case testClassMethodWithNoArgs]
 class A:
@@ -481,7 +481,7 @@ MypyFile:1(
         def (cls: def () -> __main__.A) -> builtins.str
         Class
         Block:3(
-          PassStmt:3())))))
+          Pass:3())))))
 
 [case testProperty]
 import typing
@@ -503,7 +503,7 @@ MypyFile:1(
         def (self: __main__.A) -> builtins.str
         Property
         Block:4(
-          PassStmt:4())))))
+          Pass:4())))))
 
 [case testClassDecorator]
 import typing
@@ -516,7 +516,7 @@ MypyFile:1(
     A
     Decorators(
       NameExpr(object [builtins.object]))
-    PassStmt:3()))
+    Pass:3()))
 
 [case testBuiltinclassDecorator]
 from typing import builtinclass
@@ -530,7 +530,7 @@ MypyFile:1(
     Builtinclass
     Decorators(
       NameExpr(builtinclass [typing.builtinclass]))
-    PassStmt:3()))
+    Pass:3()))
 
 [case testClassAttributeAsMethodDefaultArgumentValue]
 import typing
@@ -542,7 +542,7 @@ MypyFile:1(
   Import:1(typing)
   ClassDef:2(
     A
-    AssignmentStmt:3(
+    Assignment:3(
       NameExpr(X* [m])
       IntExpr(1))
     FuncDef:4(
@@ -552,11 +552,11 @@ MypyFile:1(
         Var(x))
       def (self: __main__.A, x: builtins.int =)
       Init(
-        AssignmentStmt:4(
+        Assignment:4(
           NameExpr(x [l])
           NameExpr(X [m])))
       Block:4(
-        PassStmt:4()))))
+        Pass:4()))))
 
 [case testInvalidBaseClass]
 from typing import Any, Callable
@@ -585,7 +585,7 @@ MypyFile:1(
       Tuple[builtins.int, builtins.str])
     BaseType(
       builtins.tuple[Any])
-    PassStmt:2()))
+    Pass:2()))
 
 [case testBaseClassFromIgnoredModule]
 import m # type: ignore
@@ -599,7 +599,7 @@ MypyFile:1(
     FallbackToAny
     BaseType(
       builtins.object)
-    PassStmt:3())
+    Pass:3())
   IgnoredLines(1))
 
 [case testBaseClassFromIgnoredModuleUsingImportFrom]
@@ -614,7 +614,7 @@ MypyFile:1(
     FallbackToAny
     BaseType(
       builtins.int)
-    PassStmt:3())
+    Pass:3())
   IgnoredLines(1))
 
 [case testBaseClassWithExplicitAnyType]
@@ -625,7 +625,7 @@ class B(A):
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Any])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(A [__main__.A])
     IntExpr(1)
     Any)
@@ -634,4 +634,4 @@ MypyFile:1(
     FallbackToAny
     BaseType(
       builtins.object)
-    PassStmt:4()))
+    Pass:4()))

--- a/test-data/unit/semanal-classes.test
+++ b/test-data/unit/semanal-classes.test
@@ -203,7 +203,7 @@ MypyFile:1(
             Var(self))
           def (self: __main__.A)
           Block:4(
-            ExpressionStmt:4(
+            ExpressionStatement:4(
               NameExpr(self [l])))))
       Decorator:5(
         Var(f)
@@ -215,7 +215,7 @@ MypyFile:1(
             Var(x))
           def (self: __main__.A, x: __main__.A)
           Block:6(
-            ExpressionStmt:6(
+            ExpressionStatement:6(
               NameExpr(self [l]))))))))
 
 [case testAttributeWithoutType]
@@ -314,7 +314,7 @@ MypyFile:1(
       ClassDef:2(
         A
         PassStmt:2())
-      ExpressionStmt:3(
+      ExpressionStatement:3(
         NameExpr(A [l])))))
 
 [case testReferenceToClassWithinClass]
@@ -328,7 +328,7 @@ MypyFile:1(
     ClassDef:2(
       B
       PassStmt:2())
-    ExpressionStmt:3(
+    ExpressionStatement:3(
       NameExpr(B [__main__.A.B]))))
 
 [case testClassWithBaseClassWithinClass]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -457,7 +457,7 @@ main:1: error: Two starred expressions in assignment
 main:3: error: Two starred expressions in assignment
 main:4: error: Two starred expressions in assignment
 
-[case testTwoStarExpressionsInForStmt]
+[case testTwoStarExpressionsInFor]
 z = 1
 for a, *b, *c in z:
     pass

--- a/test-data/unit/semanal-expressions.test
+++ b/test-data/unit/semanal-expressions.test
@@ -2,7 +2,7 @@
 (1, 'x', 1.1, 1.1j)
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     TupleExpr:1(
       IntExpr(1)
       StrExpr(x)
@@ -17,7 +17,7 @@ MypyFile:1(
   AssignmentStmt:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     MemberExpr:2(
       NameExpr(x [__main__.x])
       y)))
@@ -32,7 +32,7 @@ MypyFile:1(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
     IntExpr(1))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     IndexExpr:2(
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y]))))
@@ -50,22 +50,22 @@ MypyFile:1(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
     IntExpr(1))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     OpExpr:2(
       +
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y])))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     OpExpr:3(
       |
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y])))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     ComparisonExpr:4(
       is not
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y])))
-  ExpressionStmt:5(
+  ExpressionStatement:5(
     ComparisonExpr:5(
       ==
       NameExpr(x [__main__.x])
@@ -82,19 +82,19 @@ MypyFile:1(
   AssignmentStmt:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     UnaryExpr:2(
       -
       NameExpr(x [__main__.x])))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     UnaryExpr:3(
       ~
       NameExpr(x [__main__.x])))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     UnaryExpr:4(
       +
       NameExpr(x [__main__.x])))
-  ExpressionStmt:5(
+  ExpressionStatement:5(
     UnaryExpr:5(
       not
       NameExpr(x [__main__.x]))))
@@ -112,20 +112,20 @@ MypyFile:1(
       NameExpr(y* [__main__.y])
       NameExpr(z* [__main__.z]))
     IntExpr(1))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     IndexExpr:2(
       NameExpr(x [__main__.x])
       SliceExpr:2(
         NameExpr(y [__main__.y])
         NameExpr(z [__main__.z])
         NameExpr(x [__main__.x]))))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     IndexExpr:3(
       NameExpr(x [__main__.x])
       SliceExpr:3(
         <empty>
         <empty>)))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     IndexExpr:4(
       NameExpr(x [__main__.x])
       SliceExpr:4(
@@ -142,7 +142,7 @@ MypyFile:1(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
     IntExpr(1))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     TupleExpr:2(
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y]))))
@@ -157,7 +157,7 @@ MypyFile:1(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
     IntExpr(1))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     TupleExpr:2(
       ListExpr:2()
       ListExpr:2(
@@ -174,7 +174,7 @@ MypyFile:1(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
     IntExpr(1))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     DictExpr:2(
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y])
@@ -189,7 +189,7 @@ MypyFile:1(
   AssignmentStmt:1(
     NameExpr(a* [__main__.a])
     IntExpr(0))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     ListComprehension:2(
       GeneratorExpr:2(
         OpExpr:2(
@@ -210,7 +210,7 @@ MypyFile:1(
       Var(a))
     def (a: Any)
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         ListComprehension:2(
           GeneratorExpr:2(
             NameExpr(x [l])
@@ -242,7 +242,7 @@ MypyFile:1(
   AssignmentStmt:1(
     NameExpr(a* [__main__.a])
     IntExpr(0))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     SetComprehension:2(
       GeneratorExpr:2(
         OpExpr:2(
@@ -277,7 +277,7 @@ MypyFile:1(
   AssignmentStmt:1(
     NameExpr(a* [__main__.a])
     IntExpr(0))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     DictionaryComprehension:2(
       NameExpr(x [l])
       OpExpr:2(
@@ -315,7 +315,7 @@ MypyFile:1(
   AssignmentStmt:1(
     NameExpr(a* [__main__.a])
     IntExpr(0))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     GeneratorExpr:2(
       NameExpr(x [l])
       NameExpr(x* [l])
@@ -329,7 +329,7 @@ MypyFile:1(
   AssignmentStmt:1(
     NameExpr(a* [__main__.a])
     IntExpr(0))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     GeneratorExpr:2(
       NameExpr(x [l])
       TupleExpr:2(
@@ -347,7 +347,7 @@ MypyFile:1(
   AssignmentStmt:1(
     NameExpr(x* [__main__.x])
     IntExpr(0))
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     FuncExpr:2(
       Block:2(
         ReturnStmt:2(
@@ -357,7 +357,7 @@ MypyFile:1(
 lambda x, y: x + y
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     FuncExpr:1(
       Args(
         Var(x)
@@ -373,7 +373,7 @@ MypyFile:1(
 int if None else str
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     ConditionalExpr:1(
       Condition(
         NameExpr(None [builtins.None]))
@@ -385,7 +385,7 @@ dict(a=1, b=str())
 [builtins fixtures/dict.pyi]
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     DictExpr:1(
       StrExpr(a)
       IntExpr(1)

--- a/test-data/unit/semanal-expressions.test
+++ b/test-data/unit/semanal-expressions.test
@@ -14,7 +14,7 @@ x = 1
 x.y
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
   ExpressionStatement:2(
@@ -27,7 +27,7 @@ x = y = 1
 x[y]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     Lvalues(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
@@ -45,7 +45,7 @@ x is not y
 x == y
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     Lvalues(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
@@ -79,7 +79,7 @@ x = 1
 not x
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
   ExpressionStatement:2(
@@ -106,7 +106,7 @@ x[:]
 x[:y]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     Lvalues(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y])
@@ -137,7 +137,7 @@ x = y = 1
 x, y
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     Lvalues(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
@@ -152,7 +152,7 @@ x = y = 1
 ([], [x, y])
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     Lvalues(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
@@ -169,7 +169,7 @@ x = y = 1
 { x : y, y : x }
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     Lvalues(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
@@ -186,7 +186,7 @@ a = 0
 ([x + 1 for x in a])
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a* [__main__.a])
     IntExpr(0))
   ExpressionStatement:2(
@@ -222,10 +222,10 @@ a = 0
 a = [x for x in a if x]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a* [__main__.a])
     IntExpr(0))
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(a [__main__.a])
     ListComprehension:2(
       GeneratorExpr:2(
@@ -239,7 +239,7 @@ a = 0
 ({x + 1 for x in a})
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a* [__main__.a])
     IntExpr(0))
   ExpressionStatement:2(
@@ -257,10 +257,10 @@ a = 0
 a = {x for x in a if x}
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a* [__main__.a])
     IntExpr(0))
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(a [__main__.a])
     SetComprehension:2(
       GeneratorExpr:2(
@@ -274,7 +274,7 @@ a = 0
 ({x: x + 1 for x in a})
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a* [__main__.a])
     IntExpr(0))
   ExpressionStatement:2(
@@ -292,10 +292,10 @@ a = 0
 a = {x: x + 1 for x in a if x}
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a* [__main__.a])
     IntExpr(0))
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(a [__main__.a])
     DictionaryComprehension:2(
       NameExpr(x [l])
@@ -312,7 +312,7 @@ a = 0
 x for x in a
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a* [__main__.a])
     IntExpr(0))
   ExpressionStatement:2(
@@ -326,7 +326,7 @@ a = 0
 x for x, (y, z) in a
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a* [__main__.a])
     IntExpr(0))
   ExpressionStatement:2(
@@ -344,13 +344,13 @@ x = 0
 lambda: x
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     IntExpr(0))
   ExpressionStatement:2(
     FuncExpr:2(
       Block:2(
-        ReturnStmt:2(
+        Return:2(
           NameExpr(x [__main__.x]))))))
 
 [case testLambdaWithArguments]
@@ -363,7 +363,7 @@ MypyFile:1(
         Var(x)
         Var(y))
       Block:1(
-        ReturnStmt:1(
+        Return:1(
           OpExpr:1(
             +
             NameExpr(x [l])

--- a/test-data/unit/semanal-modules.test
+++ b/test-data/unit/semanal-modules.test
@@ -15,7 +15,7 @@ MypyFile:1(
       y [x.y])))
 MypyFile:1(
   tmp/x.py
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(y* [x.y])
     IntExpr(1)))
 
@@ -27,7 +27,7 @@ class c: pass
 [out]
 MypyFile:1(
   Import:1(m)
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x [__main__.x])
     NameExpr(None [builtins.None])
     m.c))
@@ -35,7 +35,7 @@ MypyFile:1(
   tmp/m.py
   ClassDef:1(
     c
-    PassStmt:1()))
+    Pass:1()))
 
 [case testImportFrom]
 from m import y
@@ -45,12 +45,12 @@ y = 1
 [out]
 MypyFile:1(
   ImportFrom:1(m, [y])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x* [__main__.x])
     NameExpr(y [m.y])))
 MypyFile:1(
   tmp/m.py
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(y* [m.y])
     IntExpr(1)))
 
@@ -62,7 +62,7 @@ class c: pass
 [out]
 MypyFile:1(
   ImportFrom:1(m, [c])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x [__main__.x])
     NameExpr(None [builtins.None])
     m.c))
@@ -70,7 +70,7 @@ MypyFile:1(
   tmp/m.py
   ClassDef:1(
     c
-    PassStmt:1()))
+    Pass:1()))
 
 [case testImportMultiple]
 import _m, _n
@@ -138,7 +138,7 @@ x = 1
 [out]
 MypyFile:1(
   ImportFrom:1(m, [x])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(y* [__main__.y])
     NameExpr(x [_n.x])))
 MypyFile:1(
@@ -155,7 +155,7 @@ x = 1
 [out]
 MypyFile:1(
   Import:1(_m)
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(y* [__main__.y])
     MemberExpr:2(
       NameExpr(_m)
@@ -171,7 +171,7 @@ class c: pass
 [out]
 MypyFile:1(
   ImportFrom:1(_m, [c])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x [__main__.x])
     NameExpr(None [builtins.None])
     _n.c))
@@ -186,7 +186,7 @@ class c: pass
 [out]
 MypyFile:1(
   Import:1(_m)
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x [__main__.x])
     NameExpr(None [builtins.None])
     _n.c))
@@ -233,7 +233,7 @@ class c: pass
 [out]
 MypyFile:1(
   ImportFrom:1(_m, [c])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(a [__main__.a])
     NameExpr(None [builtins.None])
     _n.c))
@@ -248,7 +248,7 @@ class c: pass
 [out]
 MypyFile:1(
   Import:1(_m)
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(a [__main__.a])
     NameExpr(None [builtins.None])
     _n.c))
@@ -297,11 +297,11 @@ class d: pass
 [out]
 MypyFile:1(
   ImportAll:1(_m)
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x [__main__.x])
     NameExpr(None [builtins.None])
     n_.c)
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(y [__main__.y])
     NameExpr(None [builtins.None])
     n_.d))
@@ -341,7 +341,7 @@ MypyFile:1(
         y [m.y]))))
 MypyFile:1(
   tmp/m/n.py
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [m.n.x])
     IntExpr(1)))
 
@@ -380,7 +380,7 @@ class c: pass
 [out]
 MypyFile:1(
   Import:1(m._n)
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x [__main__.x])
     NameExpr(None [builtins.None])
     m._n.c))
@@ -394,7 +394,7 @@ class c: pass
 [out]
 MypyFile:1(
   ImportFrom:1(m._n, [c])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x [__main__.x])
     NameExpr(None [builtins.None])
     m._n.c))
@@ -447,7 +447,7 @@ MypyFile:1(
       a [m.a])))
 MypyFile:1(
   tmp/m/n/k.py
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [m.n.k.x])
     IntExpr(1)))
 
@@ -462,7 +462,7 @@ x = 1
 [out]
 MypyFile:1(
   Import:1(m._n)
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(y* [__main__.y])
     MemberExpr:2(
       MemberExpr:2(
@@ -474,7 +474,7 @@ MypyFile:1(
 o = None # type: __builtins__.object
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(o [__main__.o])
     NameExpr(None [builtins.None])
     builtins.object))
@@ -495,7 +495,7 @@ x = None
 [out]
 MypyFile:1(
   Import:1(_m)
-  AssignmentStmt:2(
+  Assignment:2(
     MemberExpr:2(
       NameExpr(_m)
       x [_m.x])
@@ -511,7 +511,7 @@ x = None
 [out]
 MypyFile:1(
   Import:1(_m)
-  AssignmentStmt:2(
+  Assignment:2(
     IndexExpr:2(
       MemberExpr:2(
         NameExpr(_m)
@@ -527,7 +527,7 @@ if 1:
 y = 1
 [out]
 MypyFile:1(
-  IfStmt:1(
+  If:1(
     If(
       IntExpr(1))
     Then(
@@ -566,7 +566,7 @@ MypyFile:1(
   ClassDef:1(
     A
     ImportFrom:2(_x, [y])
-    AssignmentStmt:3(
+    Assignment:3(
       NameExpr(z* [m])
       NameExpr(y [_x.y]))))
 
@@ -581,7 +581,7 @@ MypyFile:1(
   ClassDef:1(
     A
     Import:2(_x)
-    AssignmentStmt:3(
+    Assignment:3(
       NameExpr(z* [m])
       MemberExpr:3(
         NameExpr(_x)
@@ -608,7 +608,7 @@ MypyFile:1(
           y [x.y])))))
 MypyFile:1(
   tmp/x.py
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(y* [x.y])
     IntExpr(1)))
 
@@ -636,7 +636,7 @@ MypyFile:1(
   ImportFrom:1(., [z]))
 MypyFile:1(
   tmp/m/z.py
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(y* [m.z.y])
     IntExpr(1)))
 
@@ -672,12 +672,12 @@ MypyFile:1(
   ImportFrom:1(.., [x, z]))
 MypyFile:1(
   tmp/m/x.py
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(y* [m.x.y])
     IntExpr(1)))
 MypyFile:1(
   tmp/m/z.py
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(y* [m.z.y])
     IntExpr(3)))
 
@@ -711,12 +711,12 @@ MypyFile:1(
   ImportFrom:2(..z, [y : zy]))
 MypyFile:1(
   tmp/m/x.py
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(y* [m.x.y])
     IntExpr(1)))
 MypyFile:1(
   tmp/m/z.py
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(y* [m.z.y])
     IntExpr(3)))
 
@@ -761,7 +761,7 @@ MypyFile:1(
   ImportFrom:1(.z, [zy : xy]))
 MypyFile:1(
   tmp/m/z.py
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(zy* [m.z.zy])
     IntExpr(3)))
 
@@ -875,6 +875,6 @@ MypyFile:1(
   Import:7(x))
 MypyFile:1(
   tmp/x.py
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(a* [x.a])
     IntExpr(1)))

--- a/test-data/unit/semanal-modules.test
+++ b/test-data/unit/semanal-modules.test
@@ -9,7 +9,7 @@ y = 1
 [out]
 MypyFile:1(
   Import:1(x)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     MemberExpr:2(
       NameExpr(x)
       y [x.y])))
@@ -82,7 +82,7 @@ y = 2
 [out]
 MypyFile:1(
   Import:1(_m, _n)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     TupleExpr:2(
       MemberExpr:2(
         NameExpr(_m)
@@ -99,7 +99,7 @@ x = 1
 [out]
 MypyFile:1(
   Import:1(_m : n)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     MemberExpr:2(
       NameExpr(n [_m])
       x [_m.x])))
@@ -112,7 +112,7 @@ x = y = 1
 [out]
 MypyFile:1(
   ImportFrom:1(_m, [x, y])
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     TupleExpr:2(
       NameExpr(x [_m.x])
       NameExpr(y [_m.y]))))
@@ -125,7 +125,7 @@ y = 1
 [out]
 MypyFile:1(
   ImportFrom:1(_m, [y : z])
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     NameExpr(z [_m.y])))
 
 [case testAccessImportedName]
@@ -201,7 +201,7 @@ x = 1
 [out]
 MypyFile:1(
   ImportFrom:1(_m, [_n])
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     MemberExpr:2(
       NameExpr(_n)
       x [_n.x])))
@@ -216,7 +216,7 @@ x = 1
 [out]
 MypyFile:1(
   Import:1(_m)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     MemberExpr:2(
       MemberExpr:2(
         NameExpr(_m)
@@ -261,7 +261,7 @@ x = y = 1
 [out]
 MypyFile:1(
   ImportAll:1(_m)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     TupleExpr:2(
       NameExpr(x [_m.x])
       NameExpr(y [_m.y]))))
@@ -277,7 +277,7 @@ x = y = 1
 [out]
 MypyFile:1(
   ImportAll:1(_m)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     TupleExpr:2(
       MemberExpr:2(
         NameExpr(n_)
@@ -314,7 +314,7 @@ x = 1
 [out]
 MypyFile:1(
   Import:1(_m)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     MemberExpr:2(
       NameExpr(_m)
       x [_m.x])))
@@ -329,7 +329,7 @@ x = 1
 [out]
 MypyFile:1(
   Import:1(m.n)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     TupleExpr:2(
       MemberExpr:2(
         MemberExpr:2(
@@ -354,7 +354,7 @@ x = 1
 [out]
 MypyFile:1(
   ImportFrom:1(m._n, [x])
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     NameExpr(x [m._n.x])))
 
 [case testImportAllFromSubmodule]
@@ -366,7 +366,7 @@ x = y = 1
 [out]
 MypyFile:1(
   ImportAll:1(m._n)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     TupleExpr:2(
       NameExpr(x [m._n.x])
       NameExpr(y [m._n.y]))))
@@ -408,7 +408,7 @@ x = 1
 [out]
 MypyFile:1(
   ImportFrom:1(m, [_n])
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     MemberExpr:2(
       NameExpr(_n [m._n])
       x [m._n.x])))
@@ -427,7 +427,7 @@ x = 1
 [out]
 MypyFile:1(
   Import:1(m.n.k)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     MemberExpr:2(
       MemberExpr:2(
         MemberExpr:2(
@@ -435,13 +435,13 @@ MypyFile:1(
           n [m.n])
         k [m.n.k])
       x [m.n.k.x]))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     MemberExpr:3(
       MemberExpr:3(
         NameExpr(m)
         n [m.n])
       b [m.n.b]))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     MemberExpr:4(
       NameExpr(m)
       a [m.a])))
@@ -483,7 +483,7 @@ MypyFile:1(
 object
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     NameExpr(object [builtins.object])))
 
 [case testAssignmentToModuleAttribute]
@@ -532,7 +532,7 @@ MypyFile:1(
       IntExpr(1))
     Then(
       Import:2(_x)
-      ExpressionStmt:3(
+      ExpressionStatement:3(
         MemberExpr:3(
           NameExpr(_x)
           y [_x.y])))))
@@ -550,7 +550,7 @@ MypyFile:1(
     def ()
     Block:1(
       Import:2(_x)
-      ExpressionStmt:3(
+      ExpressionStatement:3(
         MemberExpr:3(
           NameExpr(_x)
           y [_x.y])))))
@@ -602,7 +602,7 @@ MypyFile:1(
     Block:1(
       Import:2(x)
       Import:3(x)
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         MemberExpr:4(
           NameExpr(x)
           y [x.y])))))
@@ -623,7 +623,7 @@ y = 1
 [out]
 MypyFile:1(
   Import:1(m.x)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     MemberExpr:2(
       MemberExpr:2(
         MemberExpr:2(
@@ -655,13 +655,13 @@ from .. import x, z
 [out]
 MypyFile:1(
   Import:1(m.t.b : b)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     MemberExpr:2(
       MemberExpr:2(
         NameExpr(b [m.t.b])
         x [m.x])
       y [m.x.y]))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     MemberExpr:3(
       MemberExpr:3(
         NameExpr(b [m.t.b])
@@ -697,11 +697,11 @@ from ..z import y as zy
 [out]
 MypyFile:1(
   Import:1(m.t.b : b)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     MemberExpr:2(
       NameExpr(b [m.t.b])
       xy [m.x.y]))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     MemberExpr:3(
       NameExpr(b [m.t.b])
       zy [m.z.y])))
@@ -739,15 +739,15 @@ from .. import xy as y
 [out]
 MypyFile:1(
   Import:1(m.t)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     MemberExpr:2(
       NameExpr(m)
       zy [m.z.zy]))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     MemberExpr:3(
       NameExpr(m)
       xy [m.z.zy]))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     MemberExpr:4(
       MemberExpr:4(
         NameExpr(m)
@@ -808,9 +808,9 @@ y = 2
 [out]
 MypyFile:1(
   ImportAll:1(m_)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     NameExpr(x [m2_.x]))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     NameExpr(y [m2_.y])))
 
 [case testImportAsInStub]
@@ -836,9 +836,9 @@ import m3_
 [out]
 MypyFile:1(
   ImportAll:1(m_)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     NameExpr(m2_))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     NameExpr(m3_)))
 
 [case testErrorsInMultipleModules]

--- a/test-data/unit/semanal-namedtuple.test
+++ b/test-data/unit/semanal-namedtuple.test
@@ -7,14 +7,14 @@ def f() -> N: pass
 [out]
 MypyFile:1(
   ImportFrom:1(collections, [namedtuple])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(N* [__main__.N])
     NamedTupleExpr:2(N, Tuple[Any]))
   FuncDef:3(
     f
     def () -> Tuple[Any, fallback=__main__.N]
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testTwoItemNamedtuple]
 from collections import namedtuple
@@ -23,14 +23,14 @@ def f() -> N: pass
 [out]
 MypyFile:1(
   ImportFrom:1(collections, [namedtuple])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(N* [__main__.N])
     NamedTupleExpr:2(N, Tuple[Any, Any]))
   FuncDef:3(
     f
     def () -> Tuple[Any, Any, fallback=__main__.N]
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testTwoItemNamedtupleWithShorthandSyntax]
 from collections import namedtuple
@@ -39,14 +39,14 @@ def f() -> N: pass
 [out]
 MypyFile:1(
   ImportFrom:1(collections, [namedtuple])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(N* [__main__.N])
     NamedTupleExpr:2(N, Tuple[Any, Any]))
   FuncDef:3(
     f
     def () -> Tuple[Any, Any, fallback=__main__.N]
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testNamedTupleWithItemTypes]
 from typing import NamedTuple
@@ -55,7 +55,7 @@ N = NamedTuple('N', [('a', int),
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [NamedTuple])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(N* [__main__.N])
     NamedTupleExpr:2(N, Tuple[builtins.int, builtins.str])))
 
@@ -66,7 +66,7 @@ class A(N): pass
 [out]
 MypyFile:1(
   ImportFrom:1(collections, [namedtuple])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(N* [__main__.N])
     NamedTupleExpr:2(N, Tuple[Any]))
   ClassDef:3(
@@ -75,7 +75,7 @@ MypyFile:1(
       Tuple[Any, fallback=__main__.N])
     BaseType(
       __main__.N)
-    PassStmt:3()))
+    Pass:3()))
 
 [case testNamedTupleBaseClass2]
 from collections import namedtuple
@@ -89,7 +89,7 @@ MypyFile:1(
       Tuple[Any, fallback=__main__.N@2])
     BaseType(
       __main__.N@2)
-    PassStmt:2()))
+    Pass:2()))
 
 [case testNamedTupleBaseClassWithItemTypes]
 from typing import NamedTuple
@@ -103,7 +103,7 @@ MypyFile:1(
       Tuple[builtins.int, fallback=__main__.N@2])
     BaseType(
       __main__.N@2)
-    PassStmt:2()))
+    Pass:2()))
 
 -- Errors
 

--- a/test-data/unit/semanal-python2.test
+++ b/test-data/unit/semanal-python2.test
@@ -4,7 +4,7 @@
 print int, None
 [out]
 MypyFile:1(
-  PrintStmt:1(
+  Print:1(
     NameExpr(int [builtins.int])
     NameExpr(None [builtins.None])
     Newline))
@@ -13,7 +13,7 @@ MypyFile:1(
 print >>int, None
 [out]
 MypyFile:1(
-  PrintStmt:1(
+  Print:1(
     NameExpr(None [builtins.None])
     Target(
       NameExpr(int [builtins.int]))
@@ -25,12 +25,12 @@ exec None in int
 exec None in int, str
 [out]
 MypyFile:1(
-  ExecStmt:1(
+  Exec:1(
     NameExpr(None [builtins.None]))
-  ExecStmt:2(
+  Exec:2(
     NameExpr(None [builtins.None])
     NameExpr(int [builtins.int]))
-  ExecStmt:3(
+  Exec:3(
     NameExpr(None [builtins.None])
     NameExpr(int [builtins.int])
     NameExpr(str [builtins.str])))
@@ -58,12 +58,12 @@ MypyFile:1(
       Var(x)
       Var(__tuple_arg_2))
     Block:1(
-      AssignmentStmt:1(
+      Assignment:1(
         TupleExpr:1(
           NameExpr(y* [l])
           NameExpr(z* [l]))
         NameExpr(__tuple_arg_2 [l]))
-      AssignmentStmt:2(
+      Assignment:2(
         NameExpr(x [l])
         NameExpr(y [l])))))
 

--- a/test-data/unit/semanal-python2.test
+++ b/test-data/unit/semanal-python2.test
@@ -42,7 +42,7 @@ cast(Tuple[int, ...], ())
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Tuple, cast])
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     CastExpr:2(
       TupleExpr:2()
       builtins.tuple[builtins.int])))
@@ -71,6 +71,6 @@ MypyFile:1(
 `object`
 [out]
 MypyFile:1(
-  ExpressionStmt:1(
+  ExpressionStatement:1(
     BackquoteExpr:1(
       NameExpr(object [builtins.object]))))

--- a/test-data/unit/semanal-statements.test
+++ b/test-data/unit/semanal-statements.test
@@ -8,18 +8,18 @@ MypyFile:1(
     Args(
       Var(x))
     Block:1(
-      ReturnStmt:1(
+      Return:1(
         NameExpr(x [l]))))
   FuncDef:2(
     g
     Block:2(
-      ReturnStmt:2())))
+      Return:2())))
 
 [case testRaise]
 raise object()
 [out]
 MypyFile:1(
-  RaiseStmt:1(
+  Raise:1(
     CallExpr:1(
       NameExpr(object [builtins.object])
       Args())))
@@ -40,7 +40,7 @@ MypyFile:1(
 assert object
 [out]
 MypyFile:1(
-  AssertStmt:1(
+  Assert:1(
     NameExpr(object [builtins.object])))
 
 [case testOperatorAssignment]
@@ -49,16 +49,16 @@ x += y
 y |= x
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     Lvalues(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
     IntExpr(1))
-  OperatorAssignmentStmt:2(
+  OperatorAssignment:2(
     +
     NameExpr(x [__main__.x])
     NameExpr(y [__main__.y]))
-  OperatorAssignmentStmt:3(
+  OperatorAssignment:3(
     |
     NameExpr(y [__main__.y])
     NameExpr(x [__main__.x])))
@@ -69,12 +69,12 @@ while x:
   y
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     Lvalues(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
     IntExpr(1))
-  WhileStmt:2(
+  While:2(
     NameExpr(x [__main__.x])
     Block:2(
       ExpressionStatement:3(
@@ -85,7 +85,7 @@ for x in object:
   x
 [out]
 MypyFile:1(
-  ForStmt:1(
+  For:1(
     NameExpr(x* [__main__.x])
     NameExpr(object [builtins.object])
     Block:1(
@@ -101,7 +101,7 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      ForStmt:2(
+      For:2(
         NameExpr(x* [l])
         NameExpr(f [__main__.f])
         Block:2(
@@ -113,7 +113,7 @@ for x, y in []:
   x, y
 [out]
 MypyFile:1(
-  ForStmt:1(
+  For:1(
     TupleExpr:1(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
@@ -130,11 +130,11 @@ for x in []:
 x
 [out]
 MypyFile:1(
-  ForStmt:1(
+  For:1(
     NameExpr(x* [__main__.x])
     ListExpr:1()
     Block:1(
-      PassStmt:2()))
+      Pass:2()))
   ExpressionStatement:3(
     NameExpr(x [__main__.x])))
 
@@ -148,11 +148,11 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      ForStmt:2(
+      For:2(
         NameExpr(x* [l])
         ListExpr:2()
         Block:2(
-          PassStmt:3()))
+          Pass:3()))
       ExpressionStatement:4(
         NameExpr(x [l])))))
 
@@ -163,16 +163,16 @@ for x in None:
     pass
 [out]
 MypyFile:1(
-  ForStmt:1(
+  For:1(
     NameExpr(x* [__main__.x])
     NameExpr(None [builtins.None])
     Block:1(
-      PassStmt:2()))
-  ForStmt:3(
+      Pass:2()))
+  For:3(
     NameExpr(x [__main__.x])
     NameExpr(None [builtins.None])
     Block:3(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testReusingForLoopIndexVariable2]
 def f():
@@ -185,16 +185,16 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      ForStmt:2(
+      For:2(
         NameExpr(x* [l])
         NameExpr(None [builtins.None])
         Block:2(
-          PassStmt:3()))
-      ForStmt:4(
+          Pass:3()))
+      For:4(
         NameExpr(x [l])
         NameExpr(None [builtins.None])
         Block:4(
-          PassStmt:5())))))
+          Pass:5())))))
 
 [case testLoopWithElse]
 for x in []:
@@ -207,18 +207,18 @@ else:
   x
 [out]
 MypyFile:1(
-  ForStmt:1(
+  For:1(
     NameExpr(x* [__main__.x])
     ListExpr:1()
     Block:1(
-      PassStmt:2())
+      Pass:2())
     Else(
       ExpressionStatement:4(
         NameExpr(x [__main__.x]))))
-  WhileStmt:5(
+  While:5(
     IntExpr(1)
     Block:5(
-      PassStmt:6())
+      Pass:6())
     Else(
       ExpressionStatement:8(
         NameExpr(x [__main__.x])))))
@@ -230,15 +230,15 @@ for x in []:
   break
 [out]
 MypyFile:1(
-  WhileStmt:1(
+  While:1(
     IntExpr(1)
     Block:1(
-      BreakStmt:2()))
-  ForStmt:3(
+      Break:2()))
+  For:3(
     NameExpr(x* [__main__.x])
     ListExpr:3()
     Block:3(
-      BreakStmt:4())))
+      Break:4())))
 
 [case testContinue]
 while 1:
@@ -247,15 +247,15 @@ for x in []:
   continue
 [out]
 MypyFile:1(
-  WhileStmt:1(
+  While:1(
     IntExpr(1)
     Block:1(
-      ContinueStmt:2()))
-  ForStmt:3(
+      Continue:2()))
+  For:3(
     NameExpr(x* [__main__.x])
     ListExpr:3()
     Block:3(
-      ContinueStmt:4())))
+      Continue:4())))
 
 [case testIf]
 x = 1
@@ -269,10 +269,10 @@ else:
   x
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
-  IfStmt:2(
+  If:2(
     If(
       NameExpr(x [__main__.x]))
     Then(
@@ -297,7 +297,7 @@ if object:
   object
 [out]
 MypyFile:1(
-  IfStmt:1(
+  If:1(
     If(
       NameExpr(object [builtins.object]))
     Then(
@@ -314,35 +314,35 @@ x, y = 1
 (x, y) = 1
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     Lvalues(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
     IntExpr(1))
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x [__main__.x])
     IntExpr(1))
-  AssignmentStmt:3(
+  Assignment:3(
     MemberExpr:3(
       NameExpr(x [__main__.x])
       m)
     IntExpr(1))
-  AssignmentStmt:4(
+  Assignment:4(
     IndexExpr:4(
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y]))
     IntExpr(1))
-  AssignmentStmt:5(
+  Assignment:5(
     TupleExpr:5(
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y]))
     IntExpr(1))
-  AssignmentStmt:6(
+  Assignment:6(
     ListExpr:6(
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y]))
     IntExpr(1))
-  AssignmentStmt:7(
+  Assignment:7(
     TupleExpr:7(
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y]))
@@ -354,13 +354,13 @@ MypyFile:1(
 *(x, q), r = 1
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     TupleExpr:1(
       StarExpr:1(
         NameExpr(x* [__main__.x]))
       NameExpr(y* [__main__.y]))
     IntExpr(1))
-  AssignmentStmt:2(
+  Assignment:2(
     TupleExpr:2(
       StarExpr:2(
         NameExpr(x [__main__.x]))
@@ -369,7 +369,7 @@ MypyFile:1(
         StarExpr:2(
           NameExpr(z* [__main__.z]))))
     IntExpr(1))
-  AssignmentStmt:3(
+  Assignment:3(
     TupleExpr:3(
       StarExpr:3(
         TupleExpr:3(
@@ -383,12 +383,12 @@ x, y = 1
 x, y = 2
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     TupleExpr:1(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
     IntExpr(1))
-  AssignmentStmt:2(
+  Assignment:2(
     TupleExpr:2(
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y]))
@@ -399,10 +399,10 @@ MypyFile:1(
 ([y]) = 2
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
-  AssignmentStmt:2(
+  Assignment:2(
     ListExpr:2(
       NameExpr(y* [__main__.y]))
     IntExpr(2)))
@@ -416,7 +416,7 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      AssignmentStmt:2(
+      Assignment:2(
         NameExpr(x* [l])
         IntExpr(1))
       ExpressionStatement:3(
@@ -427,10 +427,10 @@ x = 1
 y, x = 1
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
-  AssignmentStmt:2(
+  Assignment:2(
     TupleExpr:2(
       NameExpr(y* [__main__.y])
       NameExpr(x [__main__.x]))
@@ -441,10 +441,10 @@ x = 1
 y, (x, z) = 1
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
-  AssignmentStmt:2(
+  Assignment:2(
     TupleExpr:2(
       NameExpr(y* [__main__.y])
       TupleExpr:2(
@@ -458,17 +458,17 @@ y, [x, z] = 1
 [p, [x, r]] = 1
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
-  AssignmentStmt:2(
+  Assignment:2(
     TupleExpr:2(
       NameExpr(y* [__main__.y])
       ListExpr:2(
         NameExpr(x [__main__.x])
         NameExpr(z* [__main__.z])))
     IntExpr(1))
-  AssignmentStmt:3(
+  Assignment:3(
     ListExpr:3(
       NameExpr(p* [__main__.p])
       ListExpr:3(
@@ -481,12 +481,12 @@ x = y = 1
 del x[y]
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     Lvalues(
       NameExpr(x* [__main__.x])
       NameExpr(y* [__main__.y]))
     IntExpr(1))
-  DelStmt:2(
+  Del:2(
     IndexExpr:2(
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y]))))
@@ -496,10 +496,10 @@ x = 1
 del x
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
-  DelStmt:2(
+  Del:2(
     NameExpr(x [__main__.x])))
 
 [case testDelLocalName]
@@ -512,7 +512,7 @@ MypyFile:1(
     Args(
       Var(x))
     Block:1(
-      DelStmt:2(
+      Del:2(
         NameExpr(x [l])))))
 
 [case testDelMultipleThings]
@@ -526,7 +526,7 @@ MypyFile:1(
       Var(x)
       Var(y))
     Block:1(
-      DelStmt:2(
+      Del:2(
         TupleExpr:2(
           NameExpr(x [l])
           IndexExpr:2(
@@ -556,8 +556,8 @@ finally:
 MypyFile:1(
   ClassDef:1(
     c
-    PassStmt:1())
-  TryStmt:2(
+    Pass:1())
+  Try:2(
     Block:2(
       ExpressionStatement:3(
         NameExpr(c [__main__.c])))
@@ -586,11 +586,11 @@ else:
   object
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      PassStmt:2())
+      Pass:2())
     Block:3(
-      PassStmt:4())
+      Pass:4())
     Else(
       ExpressionStatement:6(
         NameExpr(object [builtins.object])))))
@@ -602,11 +602,11 @@ finally:
   pass
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      PassStmt:2())
+      Pass:2())
     Finally(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testExceptWithMultipleTypes]
 class c: pass
@@ -618,10 +618,10 @@ except (c, object) as e:
 MypyFile:1(
   ClassDef:1(
     c
-    PassStmt:1())
-  TryStmt:2(
+    Pass:1())
+  Try:2(
     Block:2(
-      PassStmt:3())
+      Pass:3())
     TupleExpr:4(
       NameExpr(c [__main__.c])
       NameExpr(object [builtins.object]))
@@ -634,14 +634,14 @@ MypyFile:1(
 raise
 [out]
 MypyFile:1(
-  RaiseStmt:1())
+  Raise:1())
 
 [case testWith]
 with object:
   object
 [out]
 MypyFile:1(
-  WithStmt:1(
+  With:1(
     Expr(
       NameExpr(object [builtins.object]))
     Block:1(
@@ -653,7 +653,7 @@ with object as x:
   x
 [out]
 MypyFile:1(
-  WithStmt:1(
+  With:1(
     Expr(
       NameExpr(object [builtins.object]))
     Target(
@@ -671,7 +671,7 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      WithStmt:2(
+      With:2(
         Expr(
           NameExpr(f [__main__.f]))
         Target(
@@ -687,14 +687,14 @@ with object as a, object as b:
   pass
 [out]
 MypyFile:1(
-  WithStmt:1(
+  With:1(
     Expr(
       NameExpr(object [builtins.object]))
     Expr(
       NameExpr(object [builtins.object]))
     Block:1(
-      PassStmt:2()))
-  WithStmt:3(
+      Pass:2()))
+  With:3(
     Expr(
       NameExpr(object [builtins.object]))
     Target(
@@ -704,7 +704,7 @@ MypyFile:1(
     Target(
       NameExpr(b* [__main__.b]))
     Block:3(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testVariableInBlock]
 while object:
@@ -712,13 +712,13 @@ while object:
   x = x
 [out]
 MypyFile:1(
-  WhileStmt:1(
+  While:1(
     NameExpr(object [builtins.object])
     Block:1(
-      AssignmentStmt:2(
+      Assignment:2(
         NameExpr(x* [__main__.x])
         NameExpr(None [builtins.None]))
-      AssignmentStmt:3(
+      Assignment:3(
         NameExpr(x [__main__.x])
         NameExpr(x [__main__.x])))))
 
@@ -730,16 +730,16 @@ except object as o:
   o = x
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      PassStmt:2())
+      Pass:2())
     NameExpr(object [builtins.object])
     NameExpr(o* [__main__.o])
     Block:3(
-      AssignmentStmt:4(
+      Assignment:4(
         NameExpr(x* [__main__.x])
         NameExpr(None [builtins.None]))
-      AssignmentStmt:5(
+      Assignment:5(
         NameExpr(o [__main__.o])
         NameExpr(x [__main__.x])))))
 
@@ -750,13 +750,13 @@ except object as o:
   o = object()
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      PassStmt:2())
+      Pass:2())
     NameExpr(object [builtins.object])
     NameExpr(o* [__main__.o])
     Block:3(
-      AssignmentStmt:4(
+      Assignment:4(
         NameExpr(o [__main__.o])
         CallExpr:4(
           NameExpr(object [builtins.object])
@@ -774,22 +774,22 @@ class Err(BaseException): pass
 [builtins fixtures/exception.pyi]
 [out]
 MypyFile:1(
-  TryStmt:1(
+  Try:1(
     Block:1(
-      PassStmt:2())
+      Pass:2())
     NameExpr(BaseException [builtins.BaseException])
     NameExpr(e* [__main__.e])
     Block:3(
-      PassStmt:4())
+      Pass:4())
     NameExpr(Err [__main__.Err])
     NameExpr(f* [__main__.f])
     Block:5(
-      AssignmentStmt:6(
+      Assignment:6(
         NameExpr(f [__main__.f])
         CallExpr:6(
           NameExpr(BaseException [builtins.BaseException])
           Args()))
-      AssignmentStmt:7(
+      Assignment:7(
         NameExpr(f [__main__.f])
         CallExpr:7(
           NameExpr(Err [__main__.Err])
@@ -798,17 +798,17 @@ MypyFile:1(
     Err
     BaseType(
       builtins.BaseException)
-    PassStmt:8()))
+    Pass:8()))
 
 [case testMultipleAssignmentWithPartialNewDef]
 o = None
 x, o = o, o
 [out]
 MypyFile:1(
-  AssignmentStmt:1(
+  Assignment:1(
     NameExpr(o* [__main__.o])
     NameExpr(None [builtins.None]))
-  AssignmentStmt:2(
+  Assignment:2(
     TupleExpr:2(
       NameExpr(x* [__main__.x])
       NameExpr(o [__main__.o]))
@@ -828,7 +828,7 @@ MypyFile:1(
     Args(
       Var(f))
     Block:1(
-      PassStmt:1()))
+      Pass:1()))
   Decorator:2(
     Var(g)
     NameExpr(decorate [__main__.decorate])
@@ -852,13 +852,13 @@ MypyFile:1(
     f
     def ()
     Block:1(
-      TryStmt:2(
+      Try:2(
         Block:2(
-          PassStmt:3())
+          Pass:3())
         NameExpr(object [builtins.object])
         NameExpr(o* [l])
         Block:4(
-          PassStmt:5())))))
+          Pass:5())))))
 
 [case testReuseExceptionVariable]
 def f() -> None:
@@ -874,17 +874,17 @@ MypyFile:1(
     f
     def ()
     Block:1(
-      TryStmt:2(
+      Try:2(
         Block:2(
-          PassStmt:3())
+          Pass:3())
         NameExpr(object [builtins.object])
         NameExpr(o* [l])
         Block:4(
-          PassStmt:5())
+          Pass:5())
         NameExpr(object [builtins.object])
         NameExpr(o [l])
         Block:6(
-          PassStmt:7())))))
+          Pass:7())))))
 
 [case testWithMultiple]
 def f(a):
@@ -899,11 +899,11 @@ MypyFile:1(
     Args(
       Var(a))
     Block:1(
-      PassStmt:2()))
+      Pass:2()))
   FuncDef:3(
     main
     Block:3(
-      WithStmt:4(
+      With:4(
         Expr(
           CallExpr:4(
             NameExpr(f [__main__.f])
@@ -919,7 +919,7 @@ MypyFile:1(
         Target(
           NameExpr(b* [l]))
         Block:4(
-          AssignmentStmt:5(
+          Assignment:5(
             NameExpr(x* [l])
             TupleExpr:5(
               NameExpr(a [l])

--- a/test-data/unit/semanal-statements.test
+++ b/test-data/unit/semanal-statements.test
@@ -32,7 +32,7 @@ MypyFile:1(
     f
     Generator
     Block:1(
-      ExpressionStmt:1(
+      ExpressionStatement:1(
         YieldExpr:1(
           NameExpr(f [__main__.f]))))))
 
@@ -77,7 +77,7 @@ MypyFile:1(
   WhileStmt:2(
     NameExpr(x [__main__.x])
     Block:2(
-      ExpressionStmt:3(
+      ExpressionStatement:3(
         NameExpr(y [__main__.y])))))
 
 [case testFor]
@@ -89,7 +89,7 @@ MypyFile:1(
     NameExpr(x* [__main__.x])
     NameExpr(object [builtins.object])
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         NameExpr(x [__main__.x])))))
 
 [case testForInFunction]
@@ -105,7 +105,7 @@ MypyFile:1(
         NameExpr(x* [l])
         NameExpr(f [__main__.f])
         Block:2(
-          ExpressionStmt:3(
+          ExpressionStatement:3(
             NameExpr(x [l])))))))
 
 [case testMultipleForIndexVars]
@@ -119,7 +119,7 @@ MypyFile:1(
       NameExpr(y* [__main__.y]))
     ListExpr:1()
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         TupleExpr:2(
           NameExpr(x [__main__.x])
           NameExpr(y [__main__.y]))))))
@@ -135,7 +135,7 @@ MypyFile:1(
     ListExpr:1()
     Block:1(
       PassStmt:2()))
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     NameExpr(x [__main__.x])))
 
 [case testForIndexVarScope2]
@@ -153,7 +153,7 @@ MypyFile:1(
         ListExpr:2()
         Block:2(
           PassStmt:3()))
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         NameExpr(x [l])))))
 
 [case testReusingForLoopIndexVariable]
@@ -213,14 +213,14 @@ MypyFile:1(
     Block:1(
       PassStmt:2())
     Else(
-      ExpressionStmt:4(
+      ExpressionStatement:4(
         NameExpr(x [__main__.x]))))
   WhileStmt:5(
     IntExpr(1)
     Block:5(
       PassStmt:6())
     Else(
-      ExpressionStmt:8(
+      ExpressionStatement:8(
         NameExpr(x [__main__.x])))))
 
 [case testBreak]
@@ -276,20 +276,20 @@ MypyFile:1(
     If(
       NameExpr(x [__main__.x]))
     Then(
-      ExpressionStmt:3(
+      ExpressionStatement:3(
         NameExpr(x [__main__.x])))
     If(
       NameExpr(x [__main__.x]))
     Then(
-      ExpressionStmt:5(
+      ExpressionStatement:5(
         NameExpr(x [__main__.x])))
     If(
       NameExpr(x [__main__.x]))
     Then(
-      ExpressionStmt:7(
+      ExpressionStatement:7(
         NameExpr(x [__main__.x])))
     Else(
-      ExpressionStmt:9(
+      ExpressionStatement:9(
         NameExpr(x [__main__.x])))))
 
 [case testSimpleIf]
@@ -301,7 +301,7 @@ MypyFile:1(
     If(
       NameExpr(object [builtins.object]))
     Then(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         NameExpr(object [builtins.object])))))
 
 [case testLvalues]
@@ -419,7 +419,7 @@ MypyFile:1(
       AssignmentStmt:2(
         NameExpr(x* [l])
         IntExpr(1))
-      ExpressionStmt:3(
+      ExpressionStatement:3(
         NameExpr(x [l])))))
 
 [case testMultipleDefOnlySomeNew]
@@ -559,22 +559,22 @@ MypyFile:1(
     PassStmt:1())
   TryStmt:2(
     Block:2(
-      ExpressionStmt:3(
+      ExpressionStatement:3(
         NameExpr(c [__main__.c])))
     NameExpr(object [builtins.object])
     Block:4(
-      ExpressionStmt:5(
+      ExpressionStatement:5(
         NameExpr(c [__main__.c])))
     NameExpr(c [__main__.c])
     NameExpr(e* [__main__.e])
     Block:6(
-      ExpressionStmt:7(
+      ExpressionStatement:7(
         NameExpr(e [__main__.e])))
     Block:8(
-      ExpressionStmt:9(
+      ExpressionStatement:9(
         NameExpr(c [__main__.c])))
     Finally(
-      ExpressionStmt:11(
+      ExpressionStatement:11(
         NameExpr(c [__main__.c])))))
 
 [case testTryElse]
@@ -592,7 +592,7 @@ MypyFile:1(
     Block:3(
       PassStmt:4())
     Else(
-      ExpressionStmt:6(
+      ExpressionStatement:6(
         NameExpr(object [builtins.object])))))
 
 [case testTryWithOnlyFinally]
@@ -627,7 +627,7 @@ MypyFile:1(
       NameExpr(object [builtins.object]))
     NameExpr(e* [__main__.e])
     Block:4(
-      ExpressionStmt:5(
+      ExpressionStatement:5(
         NameExpr(e [__main__.e])))))
 
 [case testRaiseWithoutExpr]
@@ -645,7 +645,7 @@ MypyFile:1(
     Expr(
       NameExpr(object [builtins.object]))
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         NameExpr(object [builtins.object])))))
 
 [case testWithAndVariable]
@@ -659,7 +659,7 @@ MypyFile:1(
     Target(
       NameExpr(x* [__main__.x]))
     Block:1(
-      ExpressionStmt:2(
+      ExpressionStatement:2(
         NameExpr(x [__main__.x])))))
 
 [case testWithInFunction]
@@ -677,7 +677,7 @@ MypyFile:1(
         Target(
           NameExpr(x* [l]))
         Block:2(
-          ExpressionStmt:3(
+          ExpressionStatement:3(
             NameExpr(x [l])))))))
 
 [case testComplexWith]
@@ -835,7 +835,7 @@ MypyFile:1(
     FuncDef:3(
       g
       Block:3(
-        ExpressionStmt:4(
+        ExpressionStatement:4(
           CallExpr:4(
             NameExpr(g [__main__.g])
             Args()))))))

--- a/test-data/unit/semanal-typealiases.test
+++ b/test-data/unit/semanal-typealiases.test
@@ -9,7 +9,7 @@ MypyFile:1(
     f
     def () -> builtins.list[builtins.int]
     Block:2(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testDictTypeAlias]
 from typing import Dict
@@ -22,7 +22,7 @@ MypyFile:1(
     f
     def () -> builtins.dict[builtins.int, builtins.str]
     Block:2(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testQualifiedTypeAlias]
 import typing
@@ -35,7 +35,7 @@ MypyFile:1(
     f
     def () -> builtins.list[builtins.int]
     Block:2(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testTypeApplicationWithTypeAlias]
 from typing import List
@@ -75,8 +75,8 @@ MypyFile:1(
   Import:1(typing)
   ClassDef:2(
     A
-    PassStmt:2())
-  AssignmentStmt:3(
+    Pass:2())
+  Assignment:3(
     NameExpr(A2* [__main__.A2])
     NameExpr(A [__main__.A]))
   FuncDef:4(
@@ -85,7 +85,7 @@ MypyFile:1(
       Var(x))
     def (x: __main__.A) -> __main__.A
     Block:4(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testQualifiedSimpleTypeAlias]
 import typing
@@ -99,12 +99,12 @@ class A: pass
 MypyFile:1(
   Import:1(typing)
   Import:2(_m)
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(A2* [__main__.A2])
     MemberExpr:3(
       NameExpr(_m)
       A [_m.A]))
-  AssignmentStmt:4(
+  Assignment:4(
     NameExpr(x [__main__.x])
     IntExpr(1)
     _m.A))
@@ -116,7 +116,7 @@ def f(x: U) -> None: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Union])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(U* [__main__.U])
     TypeAliasExpr(Union[builtins.int, builtins.str]))
   FuncDef:3(
@@ -125,7 +125,7 @@ MypyFile:1(
       Var(x))
     def (x: Union[builtins.int, builtins.str])
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testUnionTypeAlias2]
 from typing import Union
@@ -137,8 +137,8 @@ MypyFile:1(
   ImportFrom:1(typing, [Union])
   ClassDef:2(
     A
-    PassStmt:2())
-  AssignmentStmt:3(
+    Pass:2())
+  Assignment:3(
     NameExpr(U* [__main__.U])
     TypeAliasExpr(Union[builtins.int, __main__.A]))
   FuncDef:4(
@@ -147,7 +147,7 @@ MypyFile:1(
       Var(x))
     def (x: Union[builtins.int, __main__.A])
     Block:4(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testUnionTypeAliasWithQualifiedUnion]
 import typing
@@ -156,7 +156,7 @@ def f(x: U) -> None: pass
 [out]
 MypyFile:1(
   Import:1(typing)
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(U* [__main__.U])
     TypeAliasExpr(Union[builtins.int, builtins.str]))
   FuncDef:3(
@@ -165,7 +165,7 @@ MypyFile:1(
       Var(x))
     def (x: Union[builtins.int, builtins.str])
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testTupleTypeAlias]
 from typing import Tuple
@@ -174,7 +174,7 @@ def f(x: T) -> None: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Tuple])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(T* [__main__.T])
     TypeAliasExpr(Tuple[builtins.int, builtins.str]))
   FuncDef:3(
@@ -183,7 +183,7 @@ MypyFile:1(
       Var(x))
     def (x: Tuple[builtins.int, builtins.str])
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testCallableTypeAlias]
 from typing import Callable
@@ -192,7 +192,7 @@ def f(x: C) -> None: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Callable])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(C* [__main__.C])
     TypeAliasExpr(def (builtins.int)))
   FuncDef:3(
@@ -201,7 +201,7 @@ MypyFile:1(
       Var(x))
     def (x: def (builtins.int))
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testGenericTypeAlias]
 from typing import Generic, TypeVar
@@ -212,15 +212,15 @@ def f(x: A) -> None: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Generic, TypeVar])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(T* [__main__.T])
     TypeVarExpr:2())
   ClassDef:3(
     G
     TypeVars(
       T)
-    PassStmt:3())
-  AssignmentStmt:4(
+    Pass:3())
+  Assignment:4(
     NameExpr(A* [__main__.A])
     TypeAliasExpr(__main__.G[builtins.int]))
   FuncDef:5(
@@ -229,7 +229,7 @@ MypyFile:1(
       Var(x))
     def (x: __main__.G[builtins.int])
     Block:5(
-      PassStmt:5())))
+      Pass:5())))
 
 [case testGenericTypeAlias2]
 from typing import List
@@ -239,7 +239,7 @@ def f(x: A) -> None: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [List])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(A* [__main__.A])
     TypeAliasExpr(builtins.list[builtins.int]))
   FuncDef:3(
@@ -248,7 +248,7 @@ MypyFile:1(
       Var(x))
     def (x: builtins.list[builtins.int])
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testImportUnionTypeAlias]
 import typing
@@ -268,7 +268,7 @@ MypyFile:1(
       Var(x))
     def (x: Union[builtins.int, _m.A])
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testImportUnionTypeAlias2]
 import typing
@@ -288,7 +288,7 @@ MypyFile:1(
       Var(x))
     def (x: Union[builtins.int, _m.A])
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testImportSimpleTypeAlias]
 import typing
@@ -307,7 +307,7 @@ MypyFile:1(
       Var(x))
     def (x: builtins.int)
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testImportSimpleTypeAlias2]
 import typing
@@ -326,7 +326,7 @@ MypyFile:1(
       Var(x))
     def (x: builtins.int)
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testAnyTypeAlias]
 from typing import Any
@@ -335,10 +335,10 @@ a = 1 # type: A
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Any])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(A* [__main__.A])
     NameExpr(Any [typing.Any]))
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(a [__main__.a])
     IntExpr(1)
     Any))
@@ -350,12 +350,12 @@ a = 1 # type: A
 [out]
 MypyFile:1(
   Import:1(typing)
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(A* [__main__.A])
     MemberExpr:2(
       NameExpr(typing)
       Any [typing.Any]))
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(a [__main__.a])
     IntExpr(1)
     Any))
@@ -368,13 +368,13 @@ x = 1 # type: U2
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Union])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(U* [__main__.U])
     TypeAliasExpr(Union[builtins.int, builtins.str]))
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(U2* [__main__.U2])
     NameExpr(U [__main__.U]))
-  AssignmentStmt:4(
+  Assignment:4(
     NameExpr(x [__main__.x])
     IntExpr(1)
     Union[builtins.int, builtins.str]))
@@ -391,10 +391,10 @@ U = Union[int, str]
 MypyFile:1(
   ImportFrom:1(typing, [Union])
   ImportFrom:2(_m, [U])
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(U2* [__main__.U2])
     NameExpr(U [_m.U]))
-  AssignmentStmt:4(
+  Assignment:4(
     NameExpr(x [__main__.x])
     IntExpr(1)
     Union[builtins.int, builtins.str]))
@@ -416,10 +416,10 @@ a = 1 # type: A
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Union])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(A* [__main__.A])
     TypeAliasExpr(Union[builtins.int, builtins.str]))
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(a [__main__.a])
     IntExpr(1)
     Union[builtins.int, builtins.str]))
@@ -431,10 +431,10 @@ a = 1 # type: A
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Union, Tuple, Any])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(A* [__main__.A])
     TypeAliasExpr(Union[builtins.int, Tuple[builtins.int, Any]]))
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(a [__main__.a])
     IntExpr(1)
     Union[builtins.int, Tuple[builtins.int, Any]]))

--- a/test-data/unit/semanal-typealiases.test
+++ b/test-data/unit/semanal-typealiases.test
@@ -44,7 +44,7 @@ List[List[int]]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [List])
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     TypeApplication:2(
       NameExpr(List [builtins.list])
       Types(
@@ -57,7 +57,7 @@ typing.List[typing.List[int]]
 [out]
 MypyFile:1(
   Import:1(typing)
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     TypeApplication:2(
       MemberExpr:2(
         NameExpr(typing)

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -285,15 +285,15 @@ MypyFile:1(
     TypeVars(
       t)
     PassStmt:4())
-  ExpressionStmt:5(
+  ExpressionStatement:5(
     CastExpr:5(
       IntExpr(1)
       Any))
-  ExpressionStmt:6(
+  ExpressionStatement:6(
     CastExpr:6(
       IntExpr(1)
       __main__.c))
-  ExpressionStmt:7(
+  ExpressionStatement:7(
     CastExpr:7(
       NameExpr(c [__main__.c])
       __main__.d[__main__.c])))
@@ -308,7 +308,7 @@ class C: pass
 MypyFile:1(
   Import:1(typing)
   Import:2(_m)
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     CastExpr:3(
       NameExpr(object [builtins.object])
       _m.C)))
@@ -324,7 +324,7 @@ class C: pass
 MypyFile:1(
   Import:1(typing)
   Import:2(_m._n)
-  ExpressionStmt:3(
+  ExpressionStatement:3(
     CastExpr:3(
       NameExpr(object [builtins.object])
       _m._n.C)))
@@ -350,7 +350,7 @@ MypyFile:1(
       t
       s)
     PassStmt:4())
-  ExpressionStmt:5(
+  ExpressionStatement:5(
     CastExpr:5(
       NameExpr(C [__main__.C])
       __main__.C[builtins.str, builtins.int])))
@@ -361,7 +361,7 @@ Any(None)
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Any])
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     CastExpr:2(
       NameExpr(None [builtins.None])
       Any)))
@@ -372,7 +372,7 @@ cast(Tuple[int, str], None)
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Tuple, cast])
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     CastExpr:2(
       NameExpr(None [builtins.None])
       Tuple[builtins.int, builtins.str])))
@@ -383,7 +383,7 @@ cast(Callable[[int], str], None)
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Callable, cast])
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     CastExpr:2(
       NameExpr(None [builtins.None])
       def (builtins.int) -> builtins.str)))
@@ -394,7 +394,7 @@ cast('int', 1)
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [cast])
-  ExpressionStmt:2(
+  ExpressionStatement:2(
     CastExpr:2(
       IntExpr(1)
       builtins.int)))
@@ -751,7 +751,7 @@ MypyFile:1(
           Var(o))
         def (o: builtins.object) -> builtins.int
         Block:3(
-          ExpressionStmt:3(
+          ExpressionStatement:3(
             NameExpr(o [l])))))
     Decorator:4(
       Var(f)
@@ -762,7 +762,7 @@ MypyFile:1(
           Var(a))
         def (a: builtins.str) -> builtins.object
         Block:5(
-          ExpressionStmt:5(
+          ExpressionStatement:5(
             NameExpr(a [l])))))))
 
 [case testReferenceToOverloadedFunction]
@@ -963,7 +963,7 @@ MypyFile:1(
     def [t] (x: t`-1)
     Block:3(
       PassStmt:3()))
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     CallExpr:4(
       TypeApplication:4(
         NameExpr(f [__main__.f])
@@ -988,7 +988,7 @@ MypyFile:1(
     TypeVars(
       t)
     PassStmt:3())
-  ExpressionStmt:4(
+  ExpressionStatement:4(
     CallExpr:4(
       TypeApplication:4(
         NameExpr(A [__main__.A])

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -8,14 +8,14 @@ MypyFile:1(
   Import:1(typing)
   ClassDef:2(
     A
-    PassStmt:2())
-  AssignmentStmt:3(
+    Pass:2())
+  Assignment:3(
     NameExpr(x [__main__.x])
     CallExpr:3(
       NameExpr(A [__main__.A])
       Args())
     __main__.A)
-  AssignmentStmt:4(
+  Assignment:4(
     NameExpr(y* [__main__.y])
     NameExpr(x [__main__.x])))
 
@@ -28,15 +28,15 @@ def f():
 MypyFile:1(
   ClassDef:1(
     A
-    PassStmt:1())
+    Pass:1())
   FuncDef:2(
     f
     Block:2(
-      AssignmentStmt:3(
+      Assignment:3(
         NameExpr(x [l])
         NameExpr(None [builtins.None])
         __main__.A)
-      AssignmentStmt:4(
+      Assignment:4(
         NameExpr(y* [l])
         NameExpr(x [l])))))
 
@@ -47,11 +47,11 @@ y = x
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Any])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x [__main__.x])
     NameExpr(None [builtins.None])
     Any)
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(y* [__main__.y])
     NameExpr(x [__main__.x])))
 
@@ -70,7 +70,7 @@ MypyFile:1(
       Args(
         Var(self))
       Block:3(
-        AssignmentStmt:4(
+        Assignment:4(
           MemberExpr:4(
             NameExpr(self [l])
             x)
@@ -87,11 +87,11 @@ MypyFile:1(
   Import:1(typing)
   ClassDef:2(
     A
-    AssignmentStmt:3(
+    Assignment:3(
       NameExpr(x [m])
       NameExpr(None [builtins.None])
       builtins.int)
-    AssignmentStmt:4(
+    Assignment:4(
       NameExpr(x [m])
       IntExpr(1))))
 
@@ -106,14 +106,14 @@ MypyFile:1(
   ImportFrom:1(typing, [Any])
   ClassDef:2(
     A
-    PassStmt:2())
+    Pass:2())
   FuncDef:3(
     f
     Args(
       Var(x))
     def (x: __main__.A) -> __main__.A
     Block:3(
-      PassStmt:3()))
+      Pass:3()))
   FuncDef:4(
     g
     Args(
@@ -121,7 +121,7 @@ MypyFile:1(
       Var(y))
     def (x: Any, y: __main__.A)
     Block:4(
-      AssignmentStmt:5(
+      Assignment:5(
         NameExpr(z* [l])
         TupleExpr:5(
           NameExpr(x [l])
@@ -134,12 +134,12 @@ class B(A): pass
 MypyFile:1(
   ClassDef:1(
     A
-    PassStmt:1())
+    Pass:1())
   ClassDef:2(
     B
     BaseType(
       __main__.A)
-    PassStmt:2()))
+    Pass:2()))
 
 [case testMultipleVarDef]
 
@@ -151,11 +151,11 @@ x = a, b
 MypyFile:1(
   ClassDef:2(
     A
-    PassStmt:2())
+    Pass:2())
   ClassDef:3(
     B
-    PassStmt:3())
-  AssignmentStmt:4(
+    Pass:3())
+  Assignment:4(
     TupleExpr:4(
       NameExpr(a [__main__.a])
       NameExpr(b [__main__.b]))
@@ -163,7 +163,7 @@ MypyFile:1(
       NameExpr(None [builtins.None])
       NameExpr(None [builtins.None]))
     Tuple[__main__.A, __main__.B])
-  AssignmentStmt:5(
+  Assignment:5(
     NameExpr(x* [__main__.x])
     TupleExpr:5(
       NameExpr(a [__main__.a])
@@ -181,22 +181,22 @@ y = None # type: A[Any]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic, Any])
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(t* [__main__.t])
     TypeVarExpr:3())
   ClassDef:5(
     A
     TypeVars(
       t)
-    PassStmt:5())
+    Pass:5())
   ClassDef:6(
     B
-    PassStmt:6())
-  AssignmentStmt:7(
+    Pass:6())
+  Assignment:7(
     NameExpr(x [__main__.x])
     NameExpr(None [builtins.None])
     __main__.A[__main__.B])
-  AssignmentStmt:8(
+  Assignment:8(
     NameExpr(y [__main__.y])
     NameExpr(None [builtins.None])
     __main__.A[Any]))
@@ -211,10 +211,10 @@ x = None # type: A[B, Any]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic, Any])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(s* [__main__.s])
     TypeVarExpr:3())
   ClassDef:4(
@@ -222,11 +222,11 @@ MypyFile:1(
     TypeVars(
       t
       s)
-    PassStmt:4())
+    Pass:4())
   ClassDef:5(
     B
-    PassStmt:5())
-  AssignmentStmt:6(
+    Pass:5())
+  Assignment:6(
     NameExpr(x [__main__.x])
     NameExpr(None [builtins.None])
     __main__.A[__main__.B, Any]))
@@ -244,22 +244,22 @@ def f():
 MypyFile:1(
   ClassDef:3(
     A
-    PassStmt:3())
-  AssignmentStmt:4(
+    Pass:3())
+  Assignment:4(
     NameExpr(a [__main__.a])
     NameExpr(None [builtins.None])
     __main__.A)
-  AssignmentStmt:5(
+  Assignment:5(
     NameExpr(a [__main__.a])
     IntExpr(1))
   FuncDef:6(
     f
     Block:6(
-      AssignmentStmt:7(
+      Assignment:7(
         NameExpr(b [l])
         NameExpr(None [builtins.None])
         __main__.A)
-      AssignmentStmt:8(
+      Assignment:8(
         NameExpr(b [l])
         IntExpr(1)))))
 
@@ -274,17 +274,17 @@ cast(d[c], c)
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic, Any, cast])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
   ClassDef:3(
     c
-    PassStmt:3())
+    Pass:3())
   ClassDef:4(
     d
     TypeVars(
       t)
-    PassStmt:4())
+    Pass:4())
   ExpressionStatement:5(
     CastExpr:5(
       IntExpr(1)
@@ -338,10 +338,10 @@ cast(C[str, int], C)
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic, cast])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(s* [__main__.s])
     TypeVarExpr:3())
   ClassDef:4(
@@ -349,7 +349,7 @@ MypyFile:1(
     TypeVars(
       t
       s)
-    PassStmt:4())
+    Pass:4())
   ExpressionStatement:5(
     CastExpr:5(
       NameExpr(C [__main__.C])
@@ -407,7 +407,7 @@ def f(x: t) -> None:
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
   FuncDef:3(
@@ -416,7 +416,7 @@ MypyFile:1(
       Var(x))
     def [t] (x: t`-1)
     Block:3(
-      AssignmentStmt:4(
+      Assignment:4(
         NameExpr(y [l])
         NameExpr(None [builtins.None])
         t`-1))))
@@ -429,10 +429,10 @@ def f(x: t, y: u, z: t) -> None: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(u* [__main__.u])
     TypeVarExpr:3())
   FuncDef:4(
@@ -443,7 +443,7 @@ MypyFile:1(
       Var(z))
     def [t, u] (x: t`-1, y: u`-2, z: t`-1)
     Block:4(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testNestedGenericFunctionTypeVariable]
 from typing import TypeVar, Generic
@@ -453,14 +453,14 @@ def f(x: A[t], y) -> None: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
   ClassDef:3(
     A
     TypeVars(
       t)
-    PassStmt:3())
+    Pass:3())
   FuncDef:4(
     f
     Args(
@@ -468,7 +468,7 @@ MypyFile:1(
       Var(y))
     def [t] (x: __main__.A[t`-1], y: Any)
     Block:4(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testNestedGenericFunctionTypeVariable2]
 from typing import TypeVar, Tuple, Generic
@@ -478,21 +478,21 @@ def f(x: Tuple[int, t]) -> None: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Tuple, Generic])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
   ClassDef:3(
     A
     TypeVars(
       t)
-    PassStmt:3())
+    Pass:3())
   FuncDef:4(
     f
     Args(
       Var(x))
     def [t] (x: Tuple[builtins.int, t`-1])
     Block:4(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testNestedGenericFunctionTypeVariable3]
 from typing import TypeVar, Callable, Generic
@@ -502,21 +502,21 @@ def f(x: Callable[[int, t], int]) -> None: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Callable, Generic])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
   ClassDef:3(
     A
     TypeVars(
       t)
-    PassStmt:3())
+    Pass:3())
   FuncDef:4(
     f
     Args(
       Var(x))
     def [t] (x: def (builtins.int, t`-1) -> builtins.int)
     Block:4(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testNestedGenericFunctionTypeVariable4]
 from typing import TypeVar, Callable, Generic
@@ -526,21 +526,21 @@ def f(x: Callable[[], t]) -> None: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Callable, Generic])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
   ClassDef:3(
     A
     TypeVars(
       t)
-    PassStmt:3())
+    Pass:3())
   FuncDef:4(
     f
     Args(
       Var(x))
     def [t] (x: def () -> t`-1)
     Block:4(
-      PassStmt:4())))
+      Pass:4())))
 
 [case testGenericFunctionTypeVariableInReturnType]
 from typing import TypeVar
@@ -549,14 +549,14 @@ def f() -> t: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
   FuncDef:3(
     f
     def [t] () -> t`-1
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testSelfType]
 class A:
@@ -572,7 +572,7 @@ MypyFile:1(
         Var(o))
       def (self: __main__.A, o: builtins.object)
       Block:2(
-        PassStmt:2()))))
+        Pass:2()))))
 
 [case testNestedGenericFunction]
 from typing import TypeVar
@@ -582,7 +582,7 @@ def f() -> None:
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
   FuncDef:3(
@@ -593,7 +593,7 @@ MypyFile:1(
         g
         def [t] () -> t`-1
         Block:4(
-          PassStmt:4())))))
+          Pass:4())))))
 
 [case testClassTvar]
 from typing import TypeVar, Generic
@@ -605,7 +605,7 @@ class c(Generic[t]):
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic])
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(t* [__main__.t])
     TypeVarExpr:3())
   ClassDef:5(
@@ -618,7 +618,7 @@ MypyFile:1(
         Var(self))
       def (self: __main__.c[t`1]) -> t`1
       Block:6(
-        PassStmt:6()))))
+        Pass:6()))))
 
 [case testClassTvar2]
 from typing import TypeVar, Generic
@@ -631,10 +631,10 @@ class c(Generic[t, s]):
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic])
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(t* [__main__.t])
     TypeVarExpr:3())
-  AssignmentStmt:4(
+  Assignment:4(
     NameExpr(s* [__main__.s])
     TypeVarExpr:4())
   ClassDef:6(
@@ -649,7 +649,7 @@ MypyFile:1(
         Var(x))
       def (self: __main__.c[t`1, s`2], x: s`2) -> t`1
       Block:7(
-        PassStmt:7()))))
+        Pass:7()))))
 
 [case testGenericBaseClass]
 from typing import TypeVar, Generic
@@ -659,21 +659,21 @@ class c(d[t], Generic[t]): pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
   ClassDef:3(
     d
     TypeVars(
       t)
-    PassStmt:3())
+    Pass:3())
   ClassDef:4(
     c
     TypeVars(
       t)
     BaseType(
       __main__.d[t`1])
-    PassStmt:4()))
+    Pass:4()))
 
 [case testTupleType]
 from typing import Tuple
@@ -684,15 +684,15 @@ t2 = None # type: Tuple[int, object]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Tuple])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t [__main__.t])
     NameExpr(None [builtins.None])
     builtins.tuple[Any])
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(t1 [__main__.t1])
     NameExpr(None [builtins.None])
     Tuple[builtins.object])
-  AssignmentStmt:4(
+  Assignment:4(
     NameExpr(t2 [__main__.t2])
     NameExpr(None [builtins.None])
     Tuple[builtins.int, builtins.object]))
@@ -704,7 +704,7 @@ t = None # type: Tuple[int, ...]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Tuple])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t [__main__.t])
     NameExpr(None [builtins.None])
     builtins.tuple[builtins.int]))
@@ -721,11 +721,11 @@ g = None # type: Callable[[], None]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Callable])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(f [__main__.f])
     NameExpr(None [builtins.None])
     def (builtins.object, builtins.int) -> builtins.str)
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(g [__main__.g])
     NameExpr(None [builtins.None])
     def ()))
@@ -784,7 +784,7 @@ MypyFile:1(
         f
         def ()
         Block:3(
-          PassStmt:3())))
+          Pass:3())))
     Decorator:4(
       Var(f)
       NameExpr(overload [typing.overload])
@@ -794,8 +794,8 @@ MypyFile:1(
           Var(x))
         def (x: builtins.int)
         Block:5(
-          PassStmt:5()))))
-  AssignmentStmt:6(
+          Pass:5()))))
+  Assignment:6(
     NameExpr(x* [__main__.x])
     NameExpr(f [__main__.f])))
 
@@ -821,7 +821,7 @@ MypyFile:1(
           FuncDef:4(
             g
             Block:4(
-              PassStmt:4())))
+              Pass:4())))
         Decorator:5(
           Var(g)
           NameExpr(overload [typing.overload])
@@ -830,8 +830,8 @@ MypyFile:1(
             Args(
               Var(x))
             Block:6(
-              PassStmt:6()))))
-      AssignmentStmt:7(
+              Pass:6()))))
+      Assignment:7(
         NameExpr(y* [l])
         NameExpr(g [l])))))
 
@@ -844,10 +844,10 @@ x = None # type: A
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(s* [__main__.s])
     TypeVarExpr:3())
   ClassDef:4(
@@ -855,8 +855,8 @@ MypyFile:1(
     TypeVars(
       t
       s)
-    PassStmt:4())
-  AssignmentStmt:5(
+    Pass:4())
+  Assignment:5(
     NameExpr(x [__main__.x])
     NameExpr(None [builtins.None])
     __main__.A[Any, Any]))
@@ -870,24 +870,24 @@ class A(B, Generic[t]): pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(s* [__main__.s])
     TypeVarExpr:3())
   ClassDef:4(
     B
     TypeVars(
       s)
-    PassStmt:4())
+    Pass:4())
   ClassDef:5(
     A
     TypeVars(
       t)
     BaseType(
       __main__.B[Any])
-    PassStmt:5()))
+    Pass:5()))
 
 [case testTypeApplication]
 from typing import TypeVar, Generic
@@ -897,15 +897,15 @@ x = A[int]()
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
   ClassDef:3(
     A
     TypeVars(
       t)
-    PassStmt:3())
-  AssignmentStmt:4(
+    Pass:3())
+  Assignment:4(
     NameExpr(x* [__main__.x])
     CallExpr:4(
       TypeApplication:4(
@@ -923,10 +923,10 @@ x = A[int, Any]()
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic, Any])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(s* [__main__.s])
     TypeVarExpr:3())
   ClassDef:4(
@@ -934,8 +934,8 @@ MypyFile:1(
     TypeVars(
       t
       s)
-    PassStmt:4())
-  AssignmentStmt:5(
+    Pass:4())
+  Assignment:5(
     NameExpr(x* [__main__.x])
     CallExpr:5(
       TypeApplication:5(
@@ -953,7 +953,7 @@ f[int](1)
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
   FuncDef:3(
@@ -962,7 +962,7 @@ MypyFile:1(
       Var(x))
     def [t] (x: t`-1)
     Block:3(
-      PassStmt:3()))
+      Pass:3()))
   ExpressionStatement:4(
     CallExpr:4(
       TypeApplication:4(
@@ -980,14 +980,14 @@ A['int']()
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(t* [__main__.t])
     TypeVarExpr:2())
   ClassDef:3(
     A
     TypeVars(
       t)
-    PassStmt:3())
+    Pass:3())
   ExpressionStatement:4(
     CallExpr:4(
       TypeApplication:4(
@@ -1007,13 +1007,13 @@ MypyFile:1(
       Var(y))
     def (*x: builtins.int, *, y: builtins.str) -> Any
     Init(
-      AssignmentStmt:1(
+      Assignment:1(
         NameExpr(y [l])
         StrExpr()))
     VarArg(
       Var(x))
     Block:1(
-      PassStmt:1())))
+      Pass:1())))
 
 [case testQualifiedGeneric]
 from typing import TypeVar
@@ -1024,14 +1024,14 @@ class A(typing.Generic[T]): pass
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar])
   Import:2(typing)
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(T* [__main__.T])
     TypeVarExpr:3())
   ClassDef:4(
     A
     TypeVars(
       T)
-    PassStmt:4()))
+    Pass:4()))
 
 [case testQualifiedTypevar]
 import typing
@@ -1040,7 +1040,7 @@ def f(x: T) -> T: pass
 [out]
 MypyFile:1(
   Import:1(typing)
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(T* [__main__.T])
     TypeVarExpr:2())
   FuncDef:3(
@@ -1049,7 +1049,7 @@ MypyFile:1(
       Var(x))
     def [T] (x: T`-1) -> T`-1
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testAliasedTypevar]
 from typing import TypeVar as tv
@@ -1058,7 +1058,7 @@ def f(x: T) -> T: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar : tv])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(T* [__main__.T])
     TypeVarExpr:2())
   FuncDef:3(
@@ -1067,7 +1067,7 @@ MypyFile:1(
       Var(x))
     def [T] (x: T`-1) -> T`-1
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testLocalTypevar]
 from typing import TypeVar
@@ -1080,7 +1080,7 @@ MypyFile:1(
   FuncDef:2(
     f
     Block:2(
-      AssignmentStmt:3(
+      Assignment:3(
         NameExpr(T* [l])
         TypeVarExpr:3())
       FuncDef:4(
@@ -1089,7 +1089,7 @@ MypyFile:1(
           Var(x))
         def [T] (x: T`-1) -> T`-1
         Block:4(
-          PassStmt:4())))))
+          Pass:4())))))
 
 [case testClassLevelTypevar]
 from typing import TypeVar
@@ -1101,7 +1101,7 @@ MypyFile:1(
   ImportFrom:1(typing, [TypeVar])
   ClassDef:2(
     A
-    AssignmentStmt:3(
+    Assignment:3(
       NameExpr(T* [m])
       TypeVarExpr:3())
     FuncDef:4(
@@ -1111,7 +1111,7 @@ MypyFile:1(
         Var(x))
       def [T] (self: __main__.A, x: T`-1) -> T`-1
       Block:4(
-        PassStmt:4()))))
+        Pass:4()))))
 
 [case testImportTypevar]
 from typing import Generic
@@ -1129,7 +1129,7 @@ MypyFile:1(
     A
     TypeVars(
       T)
-    AssignmentStmt:4(
+    Assignment:4(
       NameExpr(y [m])
       NameExpr(None [builtins.None])
       T`1)))
@@ -1152,7 +1152,7 @@ MypyFile:1(
     A
     TypeVars(
       _m.T)
-    AssignmentStmt:4(
+    Assignment:4(
       NameExpr(a [m])
       NameExpr(None [builtins.None])
       _m.T`1)
@@ -1163,7 +1163,7 @@ MypyFile:1(
         Var(x))
       def (self: __main__.A[_m.T`1], x: _m.T`1) -> Any
       Block:5(
-        AssignmentStmt:6(
+        Assignment:6(
           NameExpr(b [l])
           NameExpr(None [builtins.None])
           _m.T`1)))))
@@ -1184,7 +1184,7 @@ MypyFile:1(
       Var(x))
     def [_m.T] (x: _m.T`-1)
     Block:2(
-      AssignmentStmt:3(
+      Assignment:3(
         NameExpr(a [l])
         NameExpr(None [builtins.None])
         _m.T`-1))))
@@ -1202,7 +1202,7 @@ MypyFile:1(
       Var(x))
     def (x: builtins.int) -> Any
     Block:2(
-      AssignmentStmt:3(
+      Assignment:3(
         NameExpr(x [l])
         IntExpr(1)))))
 
@@ -1223,7 +1223,7 @@ MypyFile:1(
         Var(x))
       def (self: __main__.A, x: builtins.int) -> builtins.str
       Block:3(
-        AssignmentStmt:4(
+        Assignment:4(
           NameExpr(x [l])
           IntExpr(1))))))
 
@@ -1234,13 +1234,13 @@ S = TypeVar('S', Any, int, str)
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Any])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(T* [__main__.T])
     TypeVarExpr:2(
       Values(
         builtins.int
         builtins.str)))
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(S* [__main__.S])
     TypeVarExpr:3(
       Values(
@@ -1255,7 +1255,7 @@ T = TypeVar('T', int, str, covariant=True)
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(T* [__main__.T])
     TypeVarExpr:2(
       Variance(COVARIANT)
@@ -1269,7 +1269,7 @@ T = TypeVar('T', bound=int)
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(T* [__main__.T])
     TypeVarExpr:2(
       UpperBound(builtins.int))))
@@ -1281,7 +1281,7 @@ def f(x: T) -> T: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(T* [__main__.T])
     TypeVarExpr:2(
       Values(
@@ -1293,7 +1293,7 @@ MypyFile:1(
       Var(x))
     def [T in (builtins.int, builtins.str)] (x: T`-1) -> T`-1
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testGenericClassWithValueSet]
 from typing import TypeVar, Generic
@@ -1302,7 +1302,7 @@ class C(Generic[T]): pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(T* [__main__.T])
     TypeVarExpr:2(
       Values(
@@ -1312,7 +1312,7 @@ MypyFile:1(
     C
     TypeVars(
       T in (builtins.int, builtins.str))
-    PassStmt:3()))
+    Pass:3()))
 
 [case testGenericFunctionWithBound]
 from typing import TypeVar
@@ -1321,7 +1321,7 @@ def f(x: T) -> T: pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(T* [__main__.T])
     TypeVarExpr:2(
       UpperBound(builtins.int)))
@@ -1331,7 +1331,7 @@ MypyFile:1(
       Var(x))
     def [T <: builtins.int] (x: T`-1) -> T`-1
     Block:3(
-      PassStmt:3())))
+      Pass:3())))
 
 [case testGenericClassWithBound]
 from typing import TypeVar, Generic
@@ -1340,7 +1340,7 @@ class C(Generic[T]): pass
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Generic])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(T* [__main__.T])
     TypeVarExpr:2(
       UpperBound(builtins.int)))
@@ -1348,7 +1348,7 @@ MypyFile:1(
     C
     TypeVars(
       T <: builtins.int)
-    PassStmt:3()))
+    Pass:3()))
 
 [case testSimpleDucktypeDecorator]
 from typing import _promote
@@ -1362,7 +1362,7 @@ MypyFile:1(
     Promote(builtins.str)
     Decorators(
       PromoteExpr:2(builtins.str))
-    PassStmt:3()))
+    Pass:3()))
 
 [case testUnionType]
 from typing import Union
@@ -1376,7 +1376,7 @@ MypyFile:1(
       Var(x))
     def (x: Union[builtins.int, builtins.str])
     Block:2(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testUnionTypeWithNoneItem]
 from typing import Union
@@ -1390,7 +1390,7 @@ MypyFile:1(
       Var(x))
     def (x: builtins.int)
     Block:2(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testUnionTypeWithNoneItemAndTwoItems]
 from typing import Union
@@ -1404,7 +1404,7 @@ MypyFile:1(
       Var(x))
     def (x: Union[builtins.int, builtins.str])
     Block:2(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testUnionTypeWithSingleItem]
 from typing import Union
@@ -1418,7 +1418,7 @@ MypyFile:1(
       Var(x))
     def (x: builtins.int)
     Block:2(
-      PassStmt:2())))
+      Pass:2())))
 
 [case testOptionalTypes]
 from typing import Optional
@@ -1426,7 +1426,7 @@ x = 1  # type: Optional[int]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Optional])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x [__main__.x])
     IntExpr(1)
     builtins.int))
@@ -1445,11 +1445,11 @@ S = TypeVar('S', contravariant=True)
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(T* [__main__.T])
     TypeVarExpr:2(
       Variance(COVARIANT)))
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(S* [__main__.S])
     TypeVarExpr:3(
       Variance(CONTRAVARIANT))))
@@ -1467,11 +1467,11 @@ z = 0 # type: x.y
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Any])
-  AssignmentStmt:2(
+  Assignment:2(
     NameExpr(x [__main__.x])
     IntExpr(0)
     Any)
-  AssignmentStmt:3(
+  Assignment:3(
     NameExpr(z [__main__.z])
     IntExpr(0)
     Any))


### PR DESCRIPTION
This is half of issue #249. Huge change, but better late than later.

This was done in several stages, that can be repeated case of (likely) merge conflicts:

1. Rename `ExpressionStmt` into `ExpressionStatement`, This is the only needed `Stmt` suffix
2. Rename the _token_ `lex.Break` into `lex.BreakToken` (a questionable decision, but [`parse.py`](../tree/master/mypy/parse.py) uses both `nodes.BreakStmt` and `lex.Break` unqualified)
3. Remove globally `"Stmt\b"` from all node names
4. Fix Linting errors, caused by the shorter names

Parts 1, 2 and 3 were done partially using renaming capability of PyDev. However, it does not completely understands type annotations yet, and of course can't understand test suites. I believe that the regex solution can be used on its own without *any* false positives.

The relative simplicity of this refactoring is lost in the resulting code. For example, `If` is somewhat ambiguous, more than `IfStmt`.

The `Expr` suffix is untouched. `IntLiteral` will be more readable, but longer and somewhat resembles names in `lex.py`.