### PR TITLE
Add `--disallow-subclassing-any` flag

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -11,7 +11,7 @@ flag (or its long form ``--help``)::
   usage: mypy [-h] [-v] [-V] [--python-version x.y] [--platform PLATFORM]
               [--py2] [-s] [--silent] [--almost-silent]
               [--disallow-untyped-calls] [--disallow-untyped-defs]
-              [--check-untyped-defs]
+              [--check-untyped-defs] [--disallow-subclassing-any]
               [--warn-incomplete-stub] [--warn-redundant-casts]
               [--warn-unused-ignores] [--fast-parser] [-i] [--cache-dir DIR]
               [--strict-optional] [-f] [--pdb] [--use-python-path] [--stats]
@@ -250,6 +250,14 @@ Here are some more useful flags:
 
 - ``--disallow-untyped-calls`` reports an error whenever a function
   with type annotations calls a function defined without annotations.
+
+- ``--disallow-subclassing-any`` reports an error whenever a class
+  inherits a value of type ``Any``. This often occurs when inheriting
+  a class that was imported from a module not typechecked by mypy while
+  using ``--silent-imports``. Since the module is silenced, the imported
+  class is given a type of ``Any``. By default, mypy will assume the
+  subclass correctly inherited the base class even though that may not
+  actually be the case. This flag makes mypy raise an error instead.
 
 - ``--incremental`` is an experimental option that enables incremental
   type checking. When enabled, mypy caches results from previous runs

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -154,6 +154,8 @@ def process_options(args: List[str],
                         " or with incomplete type annotations")
     parser.add_argument('--check-untyped-defs', action='store_true',
                         help="type check the interior of functions without type annotations")
+    parser.add_argument('--disallow-subclassing-any', action='store_true',
+                        help="disallow subclassing values of type 'Any' when defining classes")
     parser.add_argument('--warn-incomplete-stub', action='store_true',
                         help="warn if missing type annotation in typeshed, only relevant with"
                         " --check-untyped-defs enabled")

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -32,6 +32,9 @@ class Options:
         # Type check unannotated functions
         self.check_untyped_defs = False
 
+        # Disallow subclassing values of type 'Any'
+        self.disallow_subclassing_any = False
+
         # Also check typeshed for missing annotations
         self.warn_incomplete_stub = False
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -770,7 +770,7 @@ class SemanticAnalyzer(NodeVisitor):
                 base_types.append(base)
             elif isinstance(base, AnyType):
                 if self.options.disallow_subclassing_any:
-                    if isinstance(base_expr, RefExpr):
+                    if isinstance(base_expr, (NameExpr, MemberExpr)):
                         msg = "Class cannot subclass '{}' (has type 'Any')".format(base_expr.name)
                     else:
                         msg = "Class cannot subclass value of type 'Any'"

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -769,6 +769,8 @@ class SemanticAnalyzer(NodeVisitor):
                     self.fail("Cannot subclass NewType", defn)
                 base_types.append(base)
             elif isinstance(base, AnyType):
+                if self.options.disallow_subclassing_any:
+                    self.fail("Class cannot subclass value of type 'Any'", base_expr)
                 info.fallback_to_any = True
             else:
                 self.fail('Invalid base class', base_expr)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -770,7 +770,11 @@ class SemanticAnalyzer(NodeVisitor):
                 base_types.append(base)
             elif isinstance(base, AnyType):
                 if self.options.disallow_subclassing_any:
-                    self.fail("Class cannot subclass value of type 'Any'", base_expr)
+                    if isinstance(base_expr, RefExpr):
+                        msg = "Class cannot subclass '{}' (has type 'Any')".format(base_expr.name)
+                    else:
+                        msg = "Class cannot subclass value of type 'Any'"
+                    self.fail(msg, base_expr)
                 info.fallback_to_any = True
             else:
                 self.fail('Invalid base class', base_expr)

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -36,3 +36,32 @@ def f():
 [out]
 main: note: In function "f":
 main:2: error: Function is missing a type annotation
+
+[case testSubclassingAny]
+# flags: --disallow-subclassing-any
+from typing import Any
+FakeClass = None  # type: Any
+class Foo(FakeClass): pass  # E: Class cannot subclass value of type 'Any'
+[out]
+
+[case testSubclassingAnyMultipleBaseClasses]
+# flags: --disallow-subclassing-any
+from typing import Any
+FakeClass = None  # type: Any
+class ActualClass: pass
+class Foo(ActualClass, FakeClass): pass  # E: Class cannot subclass value of type 'Any'
+[out]
+
+[case testSubclassingAnySilentImports]
+# flags: --disallow-subclassing-any --silent-imports
+# cmd: mypy -m main
+
+[file main.py]
+from ignored_module import BaseClass
+class Foo(BaseClass): pass
+
+[file ignored_module.py]
+class BaseClass: pass
+
+[out]
+tmp/main.py:2: error: Class cannot subclass value of type 'Any'

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -41,7 +41,7 @@ main:2: error: Function is missing a type annotation
 # flags: --disallow-subclassing-any
 from typing import Any
 FakeClass = None  # type: Any
-class Foo(FakeClass): pass  # E: Class cannot subclass value of type 'Any'
+class Foo(FakeClass): pass  # E: Class cannot subclass 'FakeClass' (has type 'Any')
 [out]
 
 [case testSubclassingAnyMultipleBaseClasses]
@@ -49,7 +49,7 @@ class Foo(FakeClass): pass  # E: Class cannot subclass value of type 'Any'
 from typing import Any
 FakeClass = None  # type: Any
 class ActualClass: pass
-class Foo(ActualClass, FakeClass): pass  # E: Class cannot subclass value of type 'Any'
+class Foo(ActualClass, FakeClass): pass  # E: Class cannot subclass 'FakeClass' (has type 'Any')
 [out]
 
 [case testSubclassingAnySilentImports]
@@ -64,4 +64,18 @@ class Foo(BaseClass): pass
 class BaseClass: pass
 
 [out]
-tmp/main.py:2: error: Class cannot subclass value of type 'Any'
+tmp/main.py:2: error: Class cannot subclass 'BaseClass' (has type 'Any')
+
+[case testSubclassingAnySilentImports2]
+# flags: --disallow-subclassing-any --silent-imports
+# cmd: mypy -m main
+
+[file main.py]
+import ignored_module
+class Foo(ignored_module.BaseClass): pass
+
+[file ignored_module.py]
+class BaseClass: pass
+
+[out]
+tmp/main.py:2: error: Class cannot subclass 'BaseClass' (has type 'Any')


### PR DESCRIPTION
This commit adds a new flag that disallows classes from having a base class of type `Any`.

This tends to happen when using `--silent-imports` or when using a class from a module or library that is not typechecked by mypy. Normally, mypy will silently accept subclassing Any, which can sometimes lead to discrepancies which further leads to subtle bugs.

Passing in this optional flag will raise an error instead.