### PR TITLE
Delay processing fresh SCCs until needed

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1644,6 +1644,9 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
                 # Note that `process_graph` may end with us not having processed every
                 # single fresh SCC. This is intentional -- we don't need those modules
                 # loaded if there are no more stale SCCs to be rechecked.
+                #
+                # TODO: see if it's possible to determine if we need to process only a
+                # _subset_ of the past SCCs instead of having to process them all.
                 for prev_scc in fresh_scc_queue:
                     process_fresh_scc(graph, prev_scc)
                 fresh_scc_queue = []


### PR DESCRIPTION
Previously, the process_graph function would always process SCCs, fresh and stale, as they were encountered.

This commit modifies this process so instead, we batch and defer processing fresh SCCs until we encounter a stale SCCs. If we do not end up encountering any stale SCCs at all, we throw away the queued fresh SCCs without having to load any of the data files at all.

Since loading the data file of fresh SCCs does take a small amount of time, this change will make mypy slightly faster, particularly in the case where there are very few to no files to recheck, and the corresponding SCCs occur early in the sorted list of SCCs.

As an example, when running mypy against itself with a fully warm cache, the time it takes to finish typechecking is now approximately 0.3 to 0.4 seconds -- previously, it was 1.3 to 1.4.