### PR TITLE
Initial version of API module

### DIFF
--- a/mypy/api.py
+++ b/mypy/api.py
@@ -121,7 +121,7 @@ class CompilationError (ValidationError):
                         function_or_member = None,
                         line = line_nr,
                         severity = severity,
-                        description = description,
+                        message = description,
                         blocker = None,
                         only_once = None
                     )))

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -38,19 +38,19 @@ class CompilationError (ValidationError):
 # Validator options are those options in options.Options that are meant for production use
 class ValidatorOptions (options.Options):
 	def __init__ (self,
-        build_type = BuildType.STANDARD
-        python_version = defaults.PYTHON3_VERSION
-        platform = sys.platform
-        custom_typing_module = None # type: str
-        report_dirs = {} # type: Dict[str, str]
-        silent_imports = False
-        almost_silent = False
-        disallow_untyped_calls = False				# Disallow calling untyped functions from typed ones
-        disallow_untyped_defs = False				# Disallow defining untyped (or incompletely typed) functions
-        check_untyped_defs = False					# Type check unannotated functions
-        warn_incomplete_stub = False				# Also check typeshed for missing annotations
-        warn_redundant_casts = False				# Warn about casting an expression to its inferred type
-        warn_unused_ignores = False					# Warn about unused '# type: ignore' comments
+		build_type = BuildType.STANDARD
+		python_version = defaults.PYTHON3_VERSION
+		platform = sys.platform
+		custom_typing_module = None # type: str
+		report_dirs = {} # type: Dict[str, str]
+		silent_imports = False
+		almost_silent = False
+		disallow_untyped_calls = False				# Disallow calling untyped functions from typed ones
+		disallow_untyped_defs = False				# Disallow defining untyped (or incompletely typed) functions
+		check_untyped_defs = False					# Type check unannotated functions
+		warn_incomplete_stub = False				# Also check typeshed for missing annotations
+		warn_redundant_casts = False				# Warn about casting an expression to its inferred type
+		warn_unused_ignores = False					# Warn about unused '# type: ignore' comments
 	):
 		params = locals () .keys ()
 		self._options = options.Options ()

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -85,7 +85,7 @@ class ValidationError(ValidationMessage):
 # Any typing inconsistency in the code that is being validated
 class StaticTypingError(ValidationError):
     def __init__(self, error_info: errors.ErrorInfo) -> None:
-        ValidationError.__init__(self)      # Make attributes exist, init explicitly below
+        ValidationError.__init__(self)      # Make sure attributes exist, init explicitly below
         self._error_info = error_info       # Private
 
         self.description = self._error_info.message
@@ -101,7 +101,7 @@ class StaticTypingError(ValidationError):
 class CompilationError(ValidationError):
     def __init__(self, compile_error: errors.CompileError) -> None:
         ValidationError.__init__(self)      # Make sure attributes exist, init explicitly below
-                                            # but init them explicitly below
+        
         self._compile_error = compile_error                               # Private
         self._static_typing_errors = []  # type: List[StaticTypingError]    # Private
 

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -1,0 +1,87 @@
+# This module contains the API for using mypy as a module inside a tool written in Python,
+# rather than from the command line or as a separate process
+#
+# Being an interface, it attempts to be thin, stable and self-explanatory
+# Since the guts of mypy are bound to change, it doesn't depend too much upon them
+# Rather it uses its own 'outside view' concepts
+#
+# It exports a singleton type_validator along with two error types
+# All fields of these error types become evident by reading through their constructors
+
+from typing import Any, List, Dict
+from mypy import build, errors, options
+
+# Validate errors are all errors produced by the validator
+# Having a common base class allows easy specification of polymorphic lists
+class ValidationError:
+	pass
+
+# Type errors are static typing inconsistencies in the code that is being validated
+class StaticTypingError (ValidationError):
+	def __init__ (self, error_info: errors.ErrorInfo):
+		self._error_info = error_info
+		self.import_context = self._error_info.import_ctx
+		self.in_source_file_name = self._error_info.file
+		self.in_class = self._error_info.type
+		self.in_function = self._error_info.function_or_member
+		self.in_line_nr = self._error_info.line
+		self.error_severity_key = self._error_info.severity
+		self.error_description = self._error_info.message
+		self.report_once = self._error_info.only_once
+
+# Compile errors all other errors occuring during validation
+class CompilationError (ValidationError):
+	def	__init__ (self, compile_error: errors.CompileError) -> None:
+		self._compile_error = compile_error
+		self.error_messages = self.compile_error.messages
+		
+# Validator options are those options in options.Options that are meant for production use
+class ValidatorOptions (options.Options):
+	def __init__ (self,
+        build_type = BuildType.STANDARD
+        python_version = defaults.PYTHON3_VERSION
+        platform = sys.platform
+        custom_typing_module = None # type: str
+        report_dirs = {} # type: Dict[str, str]
+        silent_imports = False
+        almost_silent = False
+        disallow_untyped_calls = False				# Disallow calling untyped functions from typed ones
+        disallow_untyped_defs = False				# Disallow defining untyped (or incompletely typed) functions
+        check_untyped_defs = False					# Type check unannotated functions
+        warn_incomplete_stub = False				# Also check typeshed for missing annotations
+        warn_redundant_casts = False				# Warn about casting an expression to its inferred type
+        warn_unused_ignores = False					# Warn about unused '# type: ignore' comments
+	):
+		params = locals () .keys ()
+		self._options = options.Options ()
+		for param in params:
+			setattr (self._options, *param)
+			
+# Private class, to warant a singleton instance
+class _TypingValidator:
+	def __init__ (self) -> None:
+		self.options = options.Options ()
+		self.validation_resuls = []
+		
+	# Options are given as a dictionary	
+	def set_options_dict (self, options_dict: Dict [string, Any]) -> None :	
+		for option_item in option_dict.items ():
+			if option_item [0] in self.public_options:
+				setattr (self.options, option_item)	# While setattr currently doesn't do any typechecking, it's anticipated to do so in the future
+			else:
+				raise 
+		
+	def validate_types (self, source_paths: string) -> List [ValidationError]:			
+		try:
+			build_result = build.build (
+				[build.BuildSource (source_path, None, None) for source_path in source_paths],
+				None,
+				self.options
+			)
+			self.validation_results += [ValidationError (error_info) for error_info in build_result.manager.errors]
+		except CompileError as compile_eror:
+			self.validation_results.append (CompilationError (compile_error))
+
+# Singleton representing the mypy in any 3rd party tools that it's part of
+typing_validator = _TypingValidator ()
+

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -1,203 +1,243 @@
 # This module contains an API for using mypy as a module inside another (host) application,
-# rather than from the command line or as a separate process
-# Examples of such host applications are IDE's and command line build- or (pre)compilation-tools.
-# Once this API is stable and flexible enough, it deserves consideration to make the command line version of mypy just another host application
+# rather than from the command line or as a separate process. Examples of such host applications
+# are IDE's and command line build- or (pre)compilation-tools. Once this API is stable and
+# flexible enough, it deserves consideration to make the command line version of mypy just another
+# host application.
 #
-# Being an interface, this module attempts to be thin, stable and self-explanatory
-# Since the guts of mypy are bound to change, it doesn't depend too much upon them
-# Rather it presents an external view of mypy, using a very limited number of domain bound, hence presumably relativey stable concepts
+# Being an interface, this module attempts to be thin, stable and self-explanatory. Since the guts
+# of mypy are bound to change, it doesn't depend too much upon them. Rather it presents an
+# external view of mypy, using a very limited number of domain bound, hence presumably relativey
+# stable concepts.
 #
 # More specific, it exports:
 #
-#   -   A singleton object named type_validator, representing mypy to the host application
-#       This object features two methods:
+#	-	A singleton object named type_validator, representing mypy to the host application. This
+#		object features two methods:
 #
-#       -   Method set_options, which allows setting those options of mypy which are meant for production use
-#           Its argument list makes clear which they are and which defaults they have
+#		-	Method set_options, which allows setting those options of mypy which are meant for
+#			production use. Its argument list makes clear which they are and which defaults they
+#			have.
 #
-#       -   Method validate, which receives a list of strings, denoting source file paths of top level modules
-#           These top level modules and the modules they import are checked recursively
-#           Method validate returns a polymorphic list containing objects whose class derives from ValidationError
+#		-	Method validate, which receives a list of strings, denoting source file paths of top
+#			level modules. These top level modules and the modules they import are checked
+#			recursively. Method validate returns a polymorphic list containing objects whose class
+#			derives from ValidationError.
 #
-#   -   Class ValidationMessage
-#       It facilitates the use of its subclasses in a polymorphic, but still typed, list
-#       In most situations there's no need to use this baseclass directly
-#       Objects of its subclasses represent messages that the validator wants to deliver to the user via the host
-#       Such objects are in binary form, granting the host the freedom to convert them to any suitable format
+#	-	Class ValidationMessage. This class facilitates the use of its subclasses in a
+#		polymorphic, but still typed, list. In most situations there's no need to use this
+#		baseclass directly. Objects of its subclasses represent messages that the validator wants
+#		to deliver to the user via the host. Such objects are in binary form, granting the host
+#		the freedom to convert them to any suitable format.
 #
-#       -   Class ValidationRemark is a subclass of ValidationMessage
-#           It is the baseclass of all ValidationMessage's that do not represent an error
+#		-	Class ValidationRemark is a subclass of ValidationMessage. It is the baseclass of all
+#			ValidationMessage's that do not represent an error.
 #
-#       -   Class ValidationError is the baseclass of all errors encountered during a valiation run
-#           In most situations there's no need to use this baseclass directly
-#           There is no separate warning class, rather objects of some subclasses of ValidationError can have an error_severity attribute
+#		-	Class ValidationError is the baseclass of all errors encountered during a valiation
+#			run. In most situations there's no need to use this baseclass directly. There is no
+#			separate warning class, rather objects of some subclasses of ValidationError can have
+#			an error_severity attribute.
 #
-#           -   Class StaticTypingError is a subclass of ValidationError
-#               Its instances represent static typing inconsistencies found by mypy
-#               Finding objects of this class is what mypy is about
+#			-	Class StaticTypingError is a subclass of ValidationError. Its instances represent
+#				static typing inconsistencies found by mypy. Finding objects of this class is what
+#				mypy is about.
 #
-#           -   Class CompilationError is a subclass of ValidationError
-#               Its instances represent any other problem encountered by mypy
-#               Currently this category isn't subdivided any further
-#               It's derived classes, which are currently unused, suggest that in the future such a subdivision may be useful
+#			-	Class CompilationError is a subclass of ValidationError. Its instances represent
+#				any other problem encountered by mypy. Currently this category isn't subdivided
+#				any further. It's derived classes, which are currently unused, suggest that in the
+#				future such a subdivision may be useful.
 #
-#               -   Class SyntaxError is a subclass of CompilationError
-#                   Its instances represent syntax errors encountered by mypy in the code under scrutiny
-#                   It is there for future use
-#                   While in the end the Python interpreter will catch any syntax errors,
-#                   if mypy alreay knows about them, a second parse is redundant and can be avoided
-#       
-#               -   Class InternalError is a subclass of CompilationError
-#                   Its instances represent errors due to malfunction of mypy itself
-#                   It is there for future use 
+#				-	Class SyntaxError is a subclass of CompilationError. Its instances represent
+#					syntax errors encountered by mypy in the code under scrutiny. It is there for
+#					future use. While in the end the Python interpreter will catch any syntax
+#					errors, if mypy alreay knows about them, a second parse is redundant and can
+#					be avoided.
+#
+#				-	Class InternalError is a subclass of CompilationError. Its instances represent
+#					errors due to malfunction of mypy itself. It is there for future use.
 
 import sys
 from typing import List
 from mypy import build, defaults, errors, options
 
+
+# Any message produced by the validator. These messages are structured objects rather than
+# strings. In this way each tool that hosts mypy can represent them in its own suitable text
+# format.
 class ValidationMessage:
-# Any message produced by the validator.
-# These messages are structured objects rather than strings
-# In this way each tool that hosts mypy can represent them in its own suitable text format
-    def __init__ (self):
-    # Default values of inherited attributes are set here
-    # However overriding them happens explicitly in derived classes, rather than via this constructor
-        self.identifier = None
-        self.description = None
+	# Default values of inherited attributes are set here. However overriding them happens
+	# explicitly in derived classes, rather than via this constructor.
+	def __init__(self):
+		self.identifier = None
+		self.description = None
 
-class ValidationRemark (ValidationMessage):
+		
 # Any ValidationMessage that isn't a ValidationError
-    pass
-    
-class ValidationError (ValidationMessage):
-# Any error produced by the validator
-# Having a common (abstract) base class allows the use of polymorphic, yet typed, error lists
-    pass
-    
-class StaticTypingError (ValidationError):
+class ValidationRemark(ValidationMessage):
+	pass
+
+	
+# Any error produced by the validator. Having a common (abstract) base class allows the use of
+# polymorphic, yet typed, error lists.
+class ValidationError(ValidationMessage):
+	pass
+
+	
 # Any typing inconsistency in the code that is being validated
-    def __init__ (self, error_info: errors.ErrorInfo) -> None:
-        ValidationError.__init__ (self)     # Make sure all attributes are at least there, but init them explicitly below
-    
-        self._error_info = error_info       # Internal to mypy, not part of the API
-        
-        self.description = self._error_info.message
-        self.import_context = self._error_info.import_ctx
-        self.file_name = self._error_info.file.replace ('\\', '/')
-        self.class_name = self._error_info.type
-        self.function_name = self._error_info.function_or_member
-        self.line_nr = self._error_info.line
-        self.severity = self._error_info.severity
+class StaticTypingError(ValidationError):
+	def __init__(self, error_info: errors.ErrorInfo) -> None:
+		ValidationError.__init__(self)		# Make sure all attributes are at least there,
+											# but init them explicitly below
+		self._error_info = error_info		# Private
+
+		self.description = self._error_info.message
+		self.import_context = self._error_info.import_ctx
+		self.file_name = self._error_info.file.replace('\\', '/')
+		self.class_name = self._error_info.type
+		self.function_name = self._error_info.function_or_member
+		self.line_nr = self._error_info.line
+		self.severity = self._error_info.severity
 
 
-class CompilationError (ValidationError):
 # Any other error occuring during validation that isn't a StaticTypingError
-    def __init__ (self, compile_error: errors.CompileError) -> None:
-        ValidationError.__init__ (self)     # Make sure all attributes are at least there, but init them explicitly below
-        
-        self._compile_error = compile_error                                 # Internal to mypy, not part of the API
-        self._static_typing_errors = [] # type: List [StaticTypingError]    # Internal to mypy, not part of the API
-        
-        # BEGIN tempory hack
-        # Since a CompileError doesn't contain raw error info, we'll just reconstruct it from text for now
-        # The alternative, adding an attribute containing raw error info to CompileError, is avoided for the moment,
-        # since such a temporary solution might easily lead even more code becoming dependent on this vulnerable part of the design 
-        # The long term solution is probably a thorough revision of the raise_error / CompileError mechanism,
-        # but currently the focus is on getting the external view of this API right
-        # Behind such a stable facade all kinds of future reconstruction activities may be endeavoured, limiting their impact on hosts
-        
-        if self._compile_error.messages [0] .startswith ('mypy:'):
-            self.description = self._compile_error.messages [0]
-        else:
-            self.description = 'Unspecified compilation error'
-            
-            for formatted_message in self._compile_error.messages:
-                if ': error:' in formatted_message:
-                    file_name, line_nr, severity, description = formatted_message.split (':', 4)
-                    self._static_typing_errors.append (StaticTypingError (errors.ErrorInfo (
-                        import_ctx = None,
-                        file = file_name,
-                        typ = None,
-                        function_or_member = None,
-                        line = int (line_nr),
-                        severity = severity,
-                        message = description,
-                        blocker = None,
-                        only_once = None
-                    )))
-                    
-        # END temporary hack        
-        
-class SyntaxError (CompilationError):
-# For future use
-    pass
-    
-class InternalError (CompilationError):
-# For future use
-    pass
-                    
+class CompilationError(ValidationError):
+	def __init__(self, compile_error: errors.CompileError) -> None:
+		ValidationError.__init__(self)	   # Make sure all attributes are at least there,
+										   # but init them explicitly below
+		self._compile_error = compile_error								  # Private
+		self._static_typing_errors =[] # type: List[StaticTypingError]	  # Private
+
+		# BEGIN tempory hack.
+
+		# Since a CompileError doesn't contain raw error info, we'll just reconstruct it from text
+		# for now. The alternative, adding an attribute containing raw error info to CompileError,
+		# is avoided for the moment, since such a temporary solution might easily lead even more
+		# code becoming dependent on this vulnerable part of the design.
+		#
+		# The long term solution is probably a thorough revision of the raise_error / CompileError
+		# mechanism, but currently the focus is on getting the external view of this API right
+		# Behind such a stable facade all kinds of future reconstruction activities may be
+		# endeavoured, limiting their impact on hosts.
+
+		if self._compile_error.messages[0] .startswith('mypy:'):
+			self.description = self._compile_error.messages[0]
+		else:
+			self.description = 'Unspecified compilation error'
+
+			for formatted_message in self._compile_error.messages:
+				if ': error:' in formatted_message:
+					file_name, line_nr, severity, description = formatted_message.split(':', 4)
+					self._static_typing_errors.append(StaticTypingError(errors.ErrorInfo(
+						import_ctx = None,
+						file = file_name,
+						typ = None,
+						function_or_member = None,
+						line = int(line_nr),
+						severity = severity,
+						message = description,
+						blocker = None,
+						only_once = None
+					)))
+
+		# END temporary hack.
+
+		
+# For future use.
+class SyntaxError(CompilationError):
+	pass
+
+	
+# For future use.
+class InternalError(CompilationError):
+	pass
+
+	
+# Private class, only a singleton instance is exported.
 class _TypeValidator:
-# Private class, only a singleton instance is exported
-    def __init__ (self) -> None:
-        self.set_options ()
-    
-    def set_options (
-        self,
-        python_version = defaults.PYTHON3_VERSION,  # Target Python version 
-        platform = sys.platform,                    # Target platform
-        silent_imports = False,                     # Only import types from .pyi files, not from .py files             
-        disallow_untyped_calls = False,             # Disallow calling untyped functions from typed ones
-        disallow_untyped_defs = False,              # Disallow defining untyped (or incompletely typed) functions
-        check_untyped_defs = False,                 # Type check unannotated functions
-        warn_incomplete_stub = False,               # Also check typeshed for missing annotations
-        warn_redundant_casts = False,               # Warn about casting an expression to its inferred type
-        warn_unused_ignores = False                 # Warn about unused '# type: ignore' comments
-    ) -> None:
-        params = locals () .items ()
-        self._options = options.Options ()
-        for param in params:
-            setattr (self._options, *param)
-        
-    def validate (self, source_paths: str) -> List [ValidationMessage]:
-    # A call to validate denotes one validation run on a list of top level modules and the hierarchy of modules they import recursively
-    # This method returns one polymorphic list of ValidationMessage's, enabling easy future expansion and refinement of the message hierarchy
-        compilation_error = None
-        
-        try:
-            build_result = build.build (
-                [build.BuildSource (source_path, None, None) for source_path in source_paths],
-                self._options
-            )
-            static_typing_errors = [StaticTypingError (error_info) for error_info in build_result.manager.errors.error_info]
-        except errors.CompileError as compile_error:
-            compilation_error = CompilationError (compile_error)
-            static_typing_errors = compilation_error._static_typing_errors
-            
-        validation_messages = [] # type: List [ValidationMessage]
-            
-        # Sort StaticTypingError's on file_name, line_nr, error_message respectively, then remove duplicates
-        old_error = None # type: StaticTypingError
-        for index, error in enumerate (sorted (
-            static_typing_errors,
-            key = lambda error: (error.file_name, error.line_nr, error.description)
-        )):
-            if (index and (not (
-                error._error_info.only_once and 
-                error.file_name == old_error.file_name and
-                error.line_nr == old_error.line_nr and
-                error.description == old_error.description
-            ))):
-                validation_messages.append (error)
-                old_error = error
+	def __init__(self) -> None:
+		self.set_options()
 
-        # Append instance of CompilationError if it's there
-        if compilation_error:
-            validation_messages.append (compilation_error)
-            
-        return validation_messages
+	def set_options(
+		self,
+
+		# Target Python version.
+		python_version = defaults.PYTHON3_VERSION,
+
+		# Target platform.
+		platform = sys.platform,
+
+		# Only import types from .pyi files, not from .py files .
+		silent_imports = False,
+
+		# Disallow calling untyped functions from typed ones.
+		disallow_untyped_calls = False,
+
+		# Disallow defining untyped (or incompletely typed) functions.
+		disallow_untyped_defs = False,
+
+		# Type check unannotated functions.
+		check_untyped_defs = False,
+
+		# Also check typeshed for missing annotations.
+		warn_incomplete_stub = False,
+
+		# Warn about casting an expression to its inferred type.
+		warn_redundant_casts = False,
+
+		# Warn about unused '# type: ignore' comments.
+		warn_unused_ignores = False
+	) -> None:
+		params = locals() .items()
+		self._options = options.Options()
+		for param in params:
+			setattr(self._options, *param)
+
+	# A call to validate denotes one validation run on a list of top level modules and the
+	# hierarchy of modules they import recursively. This method returns one polymorphic list
+	# of ValidationMessage's, enabling easy future expansion and refinement of the message
+	# hierarchy.
+	def validate(self, source_paths: str) -> List[ValidationMessage]:
+		compilation_error = None
+
+		try:
+			build_result = build.build(
+				[build.BuildSource(source_path, None, None) for source_path in source_paths],
+				self._options
+			)
+			static_typing_errors = [
+				StaticTypingError(error_info)
+				for error_info in build_result.manager.errors.error_info
+			]
+		except errors.CompileError as compile_error:
+			compilation_error = CompilationError(compile_error)
+			static_typing_errors = compilation_error._static_typing_errors
+
+		validation_messages = []  # type: List[ValidationMessage]
+
+		# Sort StaticTypingError's on file_name, line_nr, error_message respectively, then remove
+		# duplicates.
+		old_error = None  # type: StaticTypingError
+		for index, error in enumerate(sorted(
+			static_typing_errors,
+			key = lambda error:(error.file_name, error.line_nr, error.description)
+		)):
+			if(index and(not(
+				error._error_info.only_once and
+				error.file_name == old_error.file_name and
+				error.line_nr == old_error.line_nr and
+				error.description == old_error.description
+			))):
+				validation_messages.append(error)
+				old_error = error
+
+		# Append instance of CompilationError if it's there.
+		if compilation_error:
+			validation_messages.append(compilation_error)
+
+		return validation_messages
 
 
-type_validator = _TypeValidator ()
-# Singleton instance, exported to represent the mypy static type validator in any 3rd party tools that it's part of
+# Singleton instance, exported to represent the mypy static type validator in any 3rd party tools
+# that it's part of.
+type_validator = _TypeValidator()
 
 # (Module revision timestamp: y16m09d09 h9m55s00 GMT)

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -85,8 +85,7 @@ class ValidationError(ValidationMessage):
 # Any typing inconsistency in the code that is being validated
 class StaticTypingError(ValidationError):
     def __init__(self, error_info: errors.ErrorInfo) -> None:
-        ValidationError.__init__(self)      # Make sure all attributes are at least there,
-                                            # but init them explicitly below
+        ValidationError.__init__(self)		# Make attributes exist, init explicitly below
         self._error_info = error_info       # Private
 
         self.description = self._error_info.message
@@ -101,10 +100,10 @@ class StaticTypingError(ValidationError):
 # Any other error occuring during validation that isn't a StaticTypingError
 class CompilationError(ValidationError):
     def __init__(self, compile_error: errors.CompileError) -> None:
-        ValidationError.__init__(self)     # Make sure all attributes are at least there,
-                                           # but init them explicitly below
+        ValidationError.__init__(self)		# Make sure attributes exist, init explicitly below
+											# but init them explicitly below
         self._compile_error = compile_error                               # Private
-        self._static_typing_errors =[] # type: List[StaticTypingError]    # Private
+        self._static_typing_errors = []  # type: List[StaticTypingError]    # Private
 
         # BEGIN tempory hack.
 
@@ -114,7 +113,7 @@ class CompilationError(ValidationError):
         # code becoming dependent on this vulnerable part of the design.
         #
         # The long term solution is probably a thorough revision of the raise_error / CompileError
-        # mechanism, but currently the focus is on getting the external view of this API right
+        # mechanism, but currently the focus is on getting the external view of this API right.
         # Behind such a stable facade all kinds of future reconstruction activities may be
         # endeavoured, limiting their impact on hosts.
 
@@ -218,7 +217,7 @@ class _TypeValidator:
         old_error = None  # type: StaticTypingError
         for index, error in enumerate(sorted(
             static_typing_errors,
-            key = lambda error:(error.file_name, error.line_nr, error.description)
+            key = lambda error: (error.file_name, error.line_nr, error.description)
         )):
             if(index and(not(
                 error._error_info.only_once and

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -119,7 +119,7 @@ class CompilationError (ValidationError):
                         file = file_name,
                         typ = None,
                         function_or_member = None,
-                        line = line_nr,
+                        line = int (line_nr),
                         severity = severity,
                         message = description,
                         blocker = None,

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -101,8 +101,8 @@ class StaticTypingError(ValidationError):
 class CompilationError(ValidationError):
     def __init__(self, compile_error: errors.CompileError) -> None:
         ValidationError.__init__(self)      # Make sure attributes exist, init explicitly below
-        
-        self._compile_error = compile_error                               # Private
+
+        self._compile_error = compile_error                                 # Private
         self._static_typing_errors = []  # type: List[StaticTypingError]    # Private
 
         # BEGIN tempory hack.

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -1,87 +1,203 @@
-# This module contains the API for using mypy as a module inside a tool written in Python,
+# This module contains an API for using mypy as a module inside another (host) application,
 # rather than from the command line or as a separate process
+# Examples of such host applications are IDE's and command line build- or (pre)compilation-tools.
+# Once this API is stable and flexible enough, it deserves consideration to make the command line version of mypy just another host application
 #
-# Being an interface, it attempts to be thin, stable and self-explanatory
+# Being an interface, this module attempts to be thin, stable and self-explanatory
 # Since the guts of mypy are bound to change, it doesn't depend too much upon them
-# Rather it uses its own 'outside view' concepts
+# Rather it presents an external view of mypy, using a very limited number of domain bound, hence presumably relativey stable concepts
 #
-# It exports a singleton type_validator along with two error types
-# All fields of these error types become evident by reading through their constructors
+# More specific, it exports:
+#
+#   -   A singleton object named type_validator, representing mypy to the host application
+#       This object features two methods:
+#
+#       -   Method set_options, which allows setting those options of mypy which are meant for production use
+#           Its argument list makes clear which they are and which defaults they have
+#
+#       -   Method validate, which receives a list of strings, denoting source file paths of top level modules
+#           These top level modules and the modules they import are checked recursively
+#           Method validate returns a polymorphic list containing objects whose class derives from ValidationError
+#
+#   -   Class ValidationMessage
+#       It facilitates the use of its subclasses in a polymorphic, but still typed, list
+#       In most situations there's no need to use this baseclass directly
+#       Objects of its subclasses represent messages that the validator wants to deliver to the user via the host
+#       Such objects are in binary form, granting the host the freedom to convert them to any suitable format
+#
+#       -   Class ValidationRemark is a subclass of ValidationMessage
+#           It is the baseclass of all ValidationMessage's that do not represent an error
+#
+#       -   Class ValidationError is the baseclass of all errors encountered during a valiation run
+#           In most situations there's no need to use this baseclass directly
+#           There is no separate warning class, rather objects of some subclasses of ValidationError can have an error_severity attribute
+#
+#           -   Class StaticTypingError is a subclass of ValidationError
+#               Its instances represent static typing inconsistencies found by mypy
+#               Finding objects of this class is what mypy is about
+#
+#           -   Class CompilationError is a subclass of ValidationError
+#               Its instances represent any other problem encountered by mypy
+#               Currently this category isn't subdivided any further
+#               It's derived classes, which are currently unused, suggest that in the future such a subdivision may be useful
+#
+#               -   Class SyntaxError is a subclass of CompilationError
+#                   Its instances represent syntax errors encountered by mypy in the code under scrutiny
+#                   It is there for future use
+#                   While in the end the Python interpreter will catch any syntax errors,
+#                   if mypy alreay knows about them, a second parse is redundant and can be avoided
+#       
+#               -   Class InternalError is a subclass of CompilationError
+#                   Its instances represent errors due to malfunction of mypy itself
+#                   It is there for future use 
 
-from typing import Any, List, Dict
-from mypy import build, errors, options
+import sys
+from typing import List
+from mypy import build, defaults, errors, options
 
-# Validate errors are all errors produced by the validator
-# Having a common base class allows easy specification of polymorphic lists
-class ValidationError:
-	pass
+class ValidationMessage:
+# Any message produced by the validator.
+# These messages are structured objects rather than strings
+# In this way each tool that hosts mypy can represent them in its own suitable text format
+    def __init__ (self):
+    # Default values of inherited attributes are set here
+    # However overriding them happens explicitly in derived classes, rather than via this constructor
+        self.identifier = None
+        self.description = None
 
-# Type errors are static typing inconsistencies in the code that is being validated
+class ValidationRemark (ValidationMessage):
+# Any ValidationMessage that isn't a ValidationError
+    pass
+    
+class ValidationError (ValidationMessage):
+# Any error produced by the validator
+# Having a common (abstract) base class allows the use of polymorphic, yet typed, error lists
+    pass
+    
 class StaticTypingError (ValidationError):
-	def __init__ (self, error_info: errors.ErrorInfo):
-		self._error_info = error_info
-		self.import_context = self._error_info.import_ctx
-		self.in_source_file_name = self._error_info.file
-		self.in_class = self._error_info.type
-		self.in_function = self._error_info.function_or_member
-		self.in_line_nr = self._error_info.line
-		self.error_severity_key = self._error_info.severity
-		self.error_description = self._error_info.message
-		self.report_once = self._error_info.only_once
+# Any typing inconsistency in the code that is being validated
+    def __init__ (self, error_info: errors.ErrorInfo) -> None:
+        ValidationError.__init__ (self)     # Make sure all attributes are at least there, but init them explicitly below
+    
+        self._error_info = error_info       # Internal to mypy, not part of the API
+        
+        self.description = self._error_info.message
+        self.import_context = self._error_info.import_ctx
+        self.file_name = self._error_info.file.replace ('\\', '/')
+        self.class_name = self._error_info.type
+        self.function_name = self._error_info.function_or_member
+        self.line_nr = self._error_info.line
+        self.severity = self._error_info.severity
 
-# Compile errors all other errors occuring during validation
+
 class CompilationError (ValidationError):
-	def	__init__ (self, compile_error: errors.CompileError) -> None:
-		self._compile_error = compile_error
-		self.error_messages = self.compile_error.messages
-		
-# Validator options are those options in options.Options that are meant for production use
-class ValidatorOptions (options.Options):
-	def __init__ (self,
-		build_type = BuildType.STANDARD
-		python_version = defaults.PYTHON3_VERSION
-		platform = sys.platform
-		custom_typing_module = None # type: str
-		report_dirs = {} # type: Dict[str, str]
-		silent_imports = False
-		almost_silent = False
-		disallow_untyped_calls = False				# Disallow calling untyped functions from typed ones
-		disallow_untyped_defs = False				# Disallow defining untyped (or incompletely typed) functions
-		check_untyped_defs = False					# Type check unannotated functions
-		warn_incomplete_stub = False				# Also check typeshed for missing annotations
-		warn_redundant_casts = False				# Warn about casting an expression to its inferred type
-		warn_unused_ignores = False					# Warn about unused '# type: ignore' comments
-	):
-		params = locals () .keys ()
-		self._options = options.Options ()
-		for param in params:
-			setattr (self._options, *param)
-			
-# Private class, to warant a singleton instance
-class _TypingValidator:
-	def __init__ (self) -> None:
-		self.options = options.Options ()
-		self.validation_resuls = []
-		
-	# Options are given as a dictionary	
-	def set_options_dict (self, options_dict: Dict [string, Any]) -> None :	
-		for option_item in option_dict.items ():
-			if option_item [0] in self.public_options:
-				setattr (self.options, option_item)	# While setattr currently doesn't do any typechecking, it's anticipated to do so in the future
-			else:
-				raise 
-		
-	def validate_types (self, source_paths: string) -> List [ValidationError]:			
-		try:
-			build_result = build.build (
-				[build.BuildSource (source_path, None, None) for source_path in source_paths],
-				None,
-				self.options
-			)
-			self.validation_results += [ValidationError (error_info) for error_info in build_result.manager.errors]
-		except CompileError as compile_eror:
-			self.validation_results.append (CompilationError (compile_error))
+# Any other error occuring during validation that isn't a StaticTypingError
+    def __init__ (self, compile_error: errors.CompileError) -> None:
+        ValidationError.__init__ (self)     # Make sure all attributes are at least there, but init them explicitly below
+        
+        self._compile_error = compile_error                                 # Internal to mypy, not part of the API
+        self._static_typing_errors = [] # type: List [StaticTypingError]    # Internal to mypy, not part of the API
+        
+        # BEGIN tempory hack
+        # Since a CompileError doesn't contain raw error info, we'll just reconstruct it from text for now
+        # The alternative, adding an attribute containing raw error info to CompileError, is avoided for the moment,
+        # since such a temporary solution might easily lead even more code becoming dependent on this vulnerable part of the design 
+        # The long term solution is probably a thorough revision of the raise_error / CompileError mechanism,
+        # but currently the focus is on getting the external view of this API right
+        # Behind such a stable facade all kinds of future reconstruction activities may be endeavoured, limiting their impact on hosts
+        
+        if self._compile_error.messages [0] .startswith ('mypy:'):
+            self.description = self._compile_error.messages [0]
+        else:
+            self.description = 'Unspecified compilation error'
+            
+            for formatted_message in self._compile_error.messages:
+                if ': error:' in formatted_message:
+                    file_name, line_nr, severity, description = formatted_message.split (':', 4)
+                    self._static_typing_errors.append (StaticTypingError (errors.ErrorInfo (
+                        import_ctx = None,
+                        file = file_name,
+                        typ = None,
+                        function_or_member = None,
+                        line = line_nr,
+                        severity = severity,
+                        description = description,
+                        blocker = None,
+                        only_once = None
+                    )))
+                    
+        # END temporary hack        
+        
+class SyntaxError (CompilationError):
+# For future use
+    pass
+    
+class InternalError (CompilationError):
+# For future use
+    pass
+                    
+class _TypeValidator:
+# Private class, only a singleton instance is exported
+    def __init__ (self) -> None:
+        self.set_options ()
+    
+    def set_options (
+        self,
+        python_version = defaults.PYTHON3_VERSION,  # Target Python version 
+        platform = sys.platform,                    # Target platform
+        silent_imports = False,                     # Only import types from .pyi files, not from .py files             
+        disallow_untyped_calls = False,             # Disallow calling untyped functions from typed ones
+        disallow_untyped_defs = False,              # Disallow defining untyped (or incompletely typed) functions
+        check_untyped_defs = False,                 # Type check unannotated functions
+        warn_incomplete_stub = False,               # Also check typeshed for missing annotations
+        warn_redundant_casts = False,               # Warn about casting an expression to its inferred type
+        warn_unused_ignores = False                 # Warn about unused '# type: ignore' comments
+    ) -> None:
+        params = locals () .items ()
+        self._options = options.Options ()
+        for param in params:
+            setattr (self._options, *param)
+        
+    def validate (self, source_paths: str) -> List [ValidationMessage]:
+    # A call to validate denotes one validation run on a list of top level modules and the hierarchy of modules they import recursively
+    # This method returns one polymorphic list of ValidationMessage's, enabling easy future expansion and refinement of the message hierarchy
+        compilation_error = None
+        
+        try:
+            build_result = build.build (
+                [build.BuildSource (source_path, None, None) for source_path in source_paths],
+                self._options
+            )
+            static_typing_errors = [StaticTypingError (error_info) for error_info in build_result.manager.errors.error_info]
+        except errors.CompileError as compile_error:
+            compilation_error = CompilationError (compile_error)
+            static_typing_errors = compilation_error._static_typing_errors
+            
+        validation_messages = [] # type: List [ValidationMessage]
+            
+        # Sort StaticTypingError's on file_name, line_nr, error_message respectively, then remove duplicates
+        old_error = None # type: StaticTypingError
+        for index, error in enumerate (sorted (
+            static_typing_errors,
+            key = lambda error: (error.file_name, error.line_nr, error.description)
+        )):
+            if (index and (not (
+                error._error_info.only_once and 
+                error.file_name == old_error.file_name and
+                error.line_nr == old_error.line_nr and
+                error.description == old_error.description
+            ))):
+                validation_messages.append (error)
+                old_error = error
 
-# Singleton representing the mypy in any 3rd party tools that it's part of
-typing_validator = _TypingValidator ()
+        # Append instance of CompilationError if it's there
+        if compilation_error:
+            validation_messages.append (compilation_error)
+            
+        return validation_messages
 
+
+type_validator = _TypeValidator ()
+# Singleton instance, exported to represent the mypy static type validator in any 3rd party tools that it's part of
+
+# (Module revision timestamp: y16m09d09 h9m55s00 GMT)

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -11,49 +11,49 @@
 #
 # More specific, it exports:
 #
-#	-	A singleton object named type_validator, representing mypy to the host application. This
-#		object features two methods:
+#   -   A singleton object named type_validator, representing mypy to the host application. This
+#       object features two methods:
 #
-#		-	Method set_options, which allows setting those options of mypy which are meant for
-#			production use. Its argument list makes clear which they are and which defaults they
-#			have.
+#       -   Method set_options, which allows setting those options of mypy which are meant for
+#           production use. Its argument list makes clear which they are and which defaults they
+#           have.
 #
-#		-	Method validate, which receives a list of strings, denoting source file paths of top
-#			level modules. These top level modules and the modules they import are checked
-#			recursively. Method validate returns a polymorphic list containing objects whose class
-#			derives from ValidationError.
+#       -   Method validate, which receives a list of strings, denoting source file paths of top
+#           level modules. These top level modules and the modules they import are checked
+#           recursively. Method validate returns a polymorphic list containing objects whose class
+#           derives from ValidationMessage.
 #
-#	-	Class ValidationMessage. This class facilitates the use of its subclasses in a
-#		polymorphic, but still typed, list. In most situations there's no need to use this
-#		baseclass directly. Objects of its subclasses represent messages that the validator wants
-#		to deliver to the user via the host. Such objects are in binary form, granting the host
-#		the freedom to convert them to any suitable format.
+#   -   Class ValidationMessage. This class facilitates the use of its subclasses in a
+#       polymorphic, but still typed, list. In most situations there's no need to use this
+#       baseclass directly. Objects of its subclasses represent messages that the validator wants
+#       to deliver to the user via the host. Such objects are in binary form, granting the host
+#       the freedom to convert them to any suitable format.
 #
-#		-	Class ValidationRemark is a subclass of ValidationMessage. It is the baseclass of all
-#			ValidationMessage's that do not represent an error.
+#       -   Class ValidationRemark is a subclass of ValidationMessage. It is the baseclass of all
+#           ValidationMessage's that do not represent an error.
 #
-#		-	Class ValidationError is the baseclass of all errors encountered during a valiation
-#			run. In most situations there's no need to use this baseclass directly. There is no
-#			separate warning class, rather objects of some subclasses of ValidationError can have
-#			an error_severity attribute.
+#       -   Class ValidationError is also a subclass of ValidationMessage. It is the baseclass
+#           of all errors encountered during a valiation run. In most situations there's no need
+#           to use this baseclass directly. There is no separate warning class, rather objects of
+#           some subclasses of ValidationError can have an severity attribute.
 #
-#			-	Class StaticTypingError is a subclass of ValidationError. Its instances represent
-#				static typing inconsistencies found by mypy. Finding objects of this class is what
-#				mypy is about.
+#           -   Class StaticTypingError is a subclass of ValidationError. Its instances represent
+#               static typing inconsistencies found by mypy. Finding objects of this class is what
+#               mypy is about.
 #
-#			-	Class CompilationError is a subclass of ValidationError. Its instances represent
-#				any other problem encountered by mypy. Currently this category isn't subdivided
-#				any further. It's derived classes, which are currently unused, suggest that in the
-#				future such a subdivision may be useful.
+#           -   Class CompilationError is a subclass of ValidationError. Its instances represent
+#               any other problem encountered by mypy. Currently this category isn't subdivided
+#               any further. Its derived classes, which are currently unused, suggest that in the
+#               future such a subdivision may be useful.
 #
-#				-	Class SyntaxError is a subclass of CompilationError. Its instances represent
-#					syntax errors encountered by mypy in the code under scrutiny. It is there for
-#					future use. While in the end the Python interpreter will catch any syntax
-#					errors, if mypy alreay knows about them, a second parse is redundant and can
-#					be avoided.
+#               -   Class SyntaxError is a subclass of CompilationError. Its instances represent
+#                   syntax errors encountered by mypy in the code under scrutiny. It is there for
+#                   future use. While in the end the Python interpreter will catch any syntax
+#                   errors, if mypy already knows about them, a second parse is redundant and can
+#                   be avoided.
 #
-#				-	Class InternalError is a subclass of CompilationError. Its instances represent
-#					errors due to malfunction of mypy itself. It is there for future use.
+#               -   Class InternalError is a subclass of CompilationError. Its instances represent
+#                   errors due to malfunction of mypy itself. It is there for future use.
 
 import sys
 from typing import List
@@ -64,176 +64,176 @@ from mypy import build, defaults, errors, options
 # strings. In this way each tool that hosts mypy can represent them in its own suitable text
 # format.
 class ValidationMessage:
-	# Default values of inherited attributes are set here. However overriding them happens
-	# explicitly in derived classes, rather than via this constructor.
-	def __init__(self):
-		self.identifier = None
-		self.description = None
+    # Default values of inherited attributes are set here. However overriding them happens
+    # explicitly in derived classes, rather than via this constructor.
+    def __init__(self):
+        self.identifier = None
+        self.description = None
 
-		
+        
 # Any ValidationMessage that isn't a ValidationError
 class ValidationRemark(ValidationMessage):
-	pass
+    pass
 
-	
+    
 # Any error produced by the validator. Having a common (abstract) base class allows the use of
 # polymorphic, yet typed, error lists.
 class ValidationError(ValidationMessage):
-	pass
+    pass
 
-	
+    
 # Any typing inconsistency in the code that is being validated
 class StaticTypingError(ValidationError):
-	def __init__(self, error_info: errors.ErrorInfo) -> None:
-		ValidationError.__init__(self)		# Make sure all attributes are at least there,
-											# but init them explicitly below
-		self._error_info = error_info		# Private
+    def __init__(self, error_info: errors.ErrorInfo) -> None:
+        ValidationError.__init__(self)      # Make sure all attributes are at least there,
+                                            # but init them explicitly below
+        self._error_info = error_info       # Private
 
-		self.description = self._error_info.message
-		self.import_context = self._error_info.import_ctx
-		self.file_name = self._error_info.file.replace('\\', '/')
-		self.class_name = self._error_info.type
-		self.function_name = self._error_info.function_or_member
-		self.line_nr = self._error_info.line
-		self.severity = self._error_info.severity
+        self.description = self._error_info.message
+        self.import_context = self._error_info.import_ctx
+        self.file_name = self._error_info.file.replace('\\', '/')
+        self.class_name = self._error_info.type
+        self.function_name = self._error_info.function_or_member
+        self.line_nr = self._error_info.line
+        self.severity = self._error_info.severity
 
 
 # Any other error occuring during validation that isn't a StaticTypingError
 class CompilationError(ValidationError):
-	def __init__(self, compile_error: errors.CompileError) -> None:
-		ValidationError.__init__(self)	   # Make sure all attributes are at least there,
-										   # but init them explicitly below
-		self._compile_error = compile_error								  # Private
-		self._static_typing_errors =[] # type: List[StaticTypingError]	  # Private
+    def __init__(self, compile_error: errors.CompileError) -> None:
+        ValidationError.__init__(self)     # Make sure all attributes are at least there,
+                                           # but init them explicitly below
+        self._compile_error = compile_error                               # Private
+        self._static_typing_errors =[] # type: List[StaticTypingError]    # Private
 
-		# BEGIN tempory hack.
+        # BEGIN tempory hack.
 
-		# Since a CompileError doesn't contain raw error info, we'll just reconstruct it from text
-		# for now. The alternative, adding an attribute containing raw error info to CompileError,
-		# is avoided for the moment, since such a temporary solution might easily lead even more
-		# code becoming dependent on this vulnerable part of the design.
-		#
-		# The long term solution is probably a thorough revision of the raise_error / CompileError
-		# mechanism, but currently the focus is on getting the external view of this API right
-		# Behind such a stable facade all kinds of future reconstruction activities may be
-		# endeavoured, limiting their impact on hosts.
+        # Since a CompileError doesn't contain raw error info, we'll just reconstruct it from text
+        # for now. The alternative, adding an attribute containing raw error info to CompileError,
+        # is avoided for the moment, since such a temporary solution might easily lead even more
+        # code becoming dependent on this vulnerable part of the design.
+        #
+        # The long term solution is probably a thorough revision of the raise_error / CompileError
+        # mechanism, but currently the focus is on getting the external view of this API right
+        # Behind such a stable facade all kinds of future reconstruction activities may be
+        # endeavoured, limiting their impact on hosts.
 
-		if self._compile_error.messages[0] .startswith('mypy:'):
-			self.description = self._compile_error.messages[0]
-		else:
-			self.description = 'Unspecified compilation error'
+        if self._compile_error.messages[0] .startswith('mypy:'):
+            self.description = self._compile_error.messages[0]
+        else:
+            self.description = 'Unspecified compilation error'
 
-			for formatted_message in self._compile_error.messages:
-				if ': error:' in formatted_message:
-					file_name, line_nr, severity, description = formatted_message.split(':', 4)
-					self._static_typing_errors.append(StaticTypingError(errors.ErrorInfo(
-						import_ctx = None,
-						file = file_name,
-						typ = None,
-						function_or_member = None,
-						line = int(line_nr),
-						severity = severity,
-						message = description,
-						blocker = None,
-						only_once = None
-					)))
+            for formatted_message in self._compile_error.messages:
+                if ': error:' in formatted_message:
+                    file_name, line_nr, severity, description = formatted_message.split(':', 4)
+                    self._static_typing_errors.append(StaticTypingError(errors.ErrorInfo(
+                        import_ctx = None,
+                        file = file_name,
+                        typ = None,
+                        function_or_member = None,
+                        line = int(line_nr),
+                        severity = severity,
+                        message = description,
+                        blocker = None,
+                        only_once = None
+                    )))
 
-		# END temporary hack.
+        # END temporary hack.
 
-		
+        
 # For future use.
 class SyntaxError(CompilationError):
-	pass
+    pass
 
-	
+    
 # For future use.
 class InternalError(CompilationError):
-	pass
+    pass
 
-	
+    
 # Private class, only a singleton instance is exported.
 class _TypeValidator:
-	def __init__(self) -> None:
-		self.set_options()
+    def __init__(self) -> None:
+        self.set_options()
 
-	def set_options(
-		self,
+    def set_options(
+        self,
 
-		# Target Python version.
-		python_version = defaults.PYTHON3_VERSION,
+        # Target Python version.
+        python_version = defaults.PYTHON3_VERSION,
 
-		# Target platform.
-		platform = sys.platform,
+        # Target platform.
+        platform = sys.platform,
 
-		# Only import types from .pyi files, not from .py files .
-		silent_imports = False,
+        # Only import types from .pyi files, not from .py files .
+        silent_imports = False,
 
-		# Disallow calling untyped functions from typed ones.
-		disallow_untyped_calls = False,
+        # Disallow calling untyped functions from typed ones.
+        disallow_untyped_calls = False,
 
-		# Disallow defining untyped (or incompletely typed) functions.
-		disallow_untyped_defs = False,
+        # Disallow defining untyped (or incompletely typed) functions.
+        disallow_untyped_defs = False,
 
-		# Type check unannotated functions.
-		check_untyped_defs = False,
+        # Type check unannotated functions.
+        check_untyped_defs = False,
 
-		# Also check typeshed for missing annotations.
-		warn_incomplete_stub = False,
+        # Also check typeshed for missing annotations.
+        warn_incomplete_stub = False,
 
-		# Warn about casting an expression to its inferred type.
-		warn_redundant_casts = False,
+        # Warn about casting an expression to its inferred type.
+        warn_redundant_casts = False,
 
-		# Warn about unused '# type: ignore' comments.
-		warn_unused_ignores = False
-	) -> None:
-		params = locals() .items()
-		self._options = options.Options()
-		for param in params:
-			setattr(self._options, *param)
+        # Warn about unused '# type: ignore' comments.
+        warn_unused_ignores = False
+    ) -> None:
+        params = locals() .items()
+        self._options = options.Options()
+        for param in params:
+            setattr(self._options, *param)
 
-	# A call to validate denotes one validation run on a list of top level modules and the
-	# hierarchy of modules they import recursively. This method returns one polymorphic list
-	# of ValidationMessage's, enabling easy future expansion and refinement of the message
-	# hierarchy.
-	def validate(self, source_paths: str) -> List[ValidationMessage]:
-		compilation_error = None
+    # A call to validate denotes one validation run on a list of top level modules and the
+    # hierarchy of modules they import recursively. This method returns one polymorphic list
+    # of ValidationMessage's, enabling easy future expansion and refinement of the message
+    # hierarchy.
+    def validate(self, source_paths: str) -> List[ValidationMessage]:
+        compilation_error = None
 
-		try:
-			build_result = build.build(
-				[build.BuildSource(source_path, None, None) for source_path in source_paths],
-				self._options
-			)
-			static_typing_errors = [
-				StaticTypingError(error_info)
-				for error_info in build_result.manager.errors.error_info
-			]
-		except errors.CompileError as compile_error:
-			compilation_error = CompilationError(compile_error)
-			static_typing_errors = compilation_error._static_typing_errors
+        try:
+            build_result = build.build(
+                [build.BuildSource(source_path, None, None) for source_path in source_paths],
+                self._options
+            )
+            static_typing_errors = [
+                StaticTypingError(error_info)
+                for error_info in build_result.manager.errors.error_info
+            ]
+        except errors.CompileError as compile_error:
+            compilation_error = CompilationError(compile_error)
+            static_typing_errors = compilation_error._static_typing_errors
 
-		validation_messages = []  # type: List[ValidationMessage]
+        validation_messages = []  # type: List[ValidationMessage]
 
-		# Sort StaticTypingError's on file_name, line_nr, error_message respectively, then remove
-		# duplicates.
-		old_error = None  # type: StaticTypingError
-		for index, error in enumerate(sorted(
-			static_typing_errors,
-			key = lambda error:(error.file_name, error.line_nr, error.description)
-		)):
-			if(index and(not(
-				error._error_info.only_once and
-				error.file_name == old_error.file_name and
-				error.line_nr == old_error.line_nr and
-				error.description == old_error.description
-			))):
-				validation_messages.append(error)
-				old_error = error
+        # Sort StaticTypingError's on file_name, line_nr, error_message respectively, then remove
+        # duplicates.
+        old_error = None  # type: StaticTypingError
+        for index, error in enumerate(sorted(
+            static_typing_errors,
+            key = lambda error:(error.file_name, error.line_nr, error.description)
+        )):
+            if(index and(not(
+                error._error_info.only_once and
+                error.file_name == old_error.file_name and
+                error.line_nr == old_error.line_nr and
+                error.description == old_error.description
+            ))):
+                validation_messages.append(error)
+                old_error = error
 
-		# Append instance of CompilationError if it's there.
-		if compilation_error:
-			validation_messages.append(compilation_error)
+        # Append instance of CompilationError if it's there.
+        if compilation_error:
+            validation_messages.append(compilation_error)
 
-		return validation_messages
+        return validation_messages
 
 
 # Singleton instance, exported to represent the mypy static type validator in any 3rd party tools

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -85,7 +85,7 @@ class ValidationError(ValidationMessage):
 # Any typing inconsistency in the code that is being validated
 class StaticTypingError(ValidationError):
     def __init__(self, error_info: errors.ErrorInfo) -> None:
-        ValidationError.__init__(self)		# Make attributes exist, init explicitly below
+        ValidationError.__init__(self)      # Make attributes exist, init explicitly below
         self._error_info = error_info       # Private
 
         self.description = self._error_info.message
@@ -100,8 +100,8 @@ class StaticTypingError(ValidationError):
 # Any other error occuring during validation that isn't a StaticTypingError
 class CompilationError(ValidationError):
     def __init__(self, compile_error: errors.CompileError) -> None:
-        ValidationError.__init__(self)		# Make sure attributes exist, init explicitly below
-											# but init them explicitly below
+        ValidationError.__init__(self)      # Make sure attributes exist, init explicitly below
+                                            # but init them explicitly below
         self._compile_error = compile_error                               # Private
         self._static_typing_errors = []  # type: List[StaticTypingError]    # Private
 

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -70,18 +70,18 @@ class ValidationMessage:
         self.identifier = None
         self.description = None
 
-        
+
 # Any ValidationMessage that isn't a ValidationError
 class ValidationRemark(ValidationMessage):
     pass
 
-    
+
 # Any error produced by the validator. Having a common (abstract) base class allows the use of
 # polymorphic, yet typed, error lists.
 class ValidationError(ValidationMessage):
     pass
 
-    
+
 # Any typing inconsistency in the code that is being validated
 class StaticTypingError(ValidationError):
     def __init__(self, error_info: errors.ErrorInfo) -> None:
@@ -140,17 +140,17 @@ class CompilationError(ValidationError):
 
         # END temporary hack.
 
-        
+
 # For future use.
 class SyntaxError(CompilationError):
     pass
 
-    
+
 # For future use.
 class InternalError(CompilationError):
     pass
 
-    
+
 # Private class, only a singleton instance is exported.
 class _TypeValidator:
     def __init__(self) -> None:


### PR DESCRIPTION
Hi,

On invitation of gvanrossum I've designed a simplified API for mypy, meant to enable easy use of mypy as module rather than as stand-alone program.

The main goals in designing this API were to keep everything simple and explicit. Not all functionality of mypy is currently accessible via the API. Still this initial version at least helped me to indeed use mypy as a module in a straightforward way.

The API is non-intrusive in this sense that for this initial version deliberately no modifications were made to the rest of mypy. For easy reference, below there is a brief description of the API, that's also part of the source code:

```
# This module contains an API for using mypy as a module inside another (host) application,
# rather than from the command line or as a separate process. Examples of such host applications
# are IDE's and command line build- or (pre)compilation-tools. Once this API is stable and
# flexible enough, it deserves consideration to make the command line version of mypy just another
# host application.
#
# Being an interface, this module attempts to be thin, stable and self-explanatory. Since the guts
# of mypy are bound to change, it doesn't depend too much upon them. Rather it presents an
# external view of mypy, using a very limited number of domain bound, hence presumably relativey
# stable concepts.
#
# More specific, it exports:
#
#	-	A singleton object named type_validator, representing mypy to the host application. This
#		object features two methods:
#
#		-	Method set_options, which allows setting those options of mypy which are meant for
#			production use. Its argument list makes clear which they are and which defaults they
#			have.
#
#		-	Method validate, which receives a list of strings, denoting source file paths of top
#			level modules. These top level modules and the modules they import are checked
#			recursively. Method validate returns a polymorphic list containing objects whose class
#			derives from ValidationMessage.
#
#	-	Class ValidationMessage. This class facilitates the use of its subclasses in a
#		polymorphic, but still typed, list. In most situations there's no need to use this
#		baseclass directly. Objects of its subclasses represent messages that the validator wants
#		to deliver to the user via the host. Such objects are in binary form, granting the host
#		the freedom to convert them to any suitable format.
#
#		-	Class ValidationRemark is a subclass of ValidationMessage. It is the baseclass of all
#			ValidationMessage's that do not represent an error.
#
#		-	Class ValidationError is also a subclass of ValidationMessage. It is the  baseclass
#			of all errors encountered during a valiation run. In most situations there's no need
#           to use this baseclass directly. There is no separate warning class, rather objects of
#           some subclasses of ValidationError can have an severity attribute.
#
#			-	Class StaticTypingError is a subclass of ValidationError. Its instances represent
#				static typing inconsistencies found by mypy. Finding objects of this class is what
#				mypy is about.
#
#			-	Class CompilationError is a subclass of ValidationError. Its instances represent
#				any other problem encountered by mypy. Currently this category isn't subdivided
#				any further. Its derived classes, which are currently unused, suggest that in the
#				future such a subdivision may be useful.
#
#				-	Class SyntaxError is a subclass of CompilationError. Its instances represent
#					syntax errors encountered by mypy in the code under scrutiny. It is there for
#					future use. While in the end the Python interpreter will catch any syntax
#					errors, if mypy already knows about them, a second parse is redundant and can
#					be avoided.
#
#				-	Class InternalError is a subclass of CompilationError. Its instances represent
#					errors due to malfunction of mypy itself. It is there for future use.
```

I've tested the correct functioning of the API in the [Transcrypt](http:/www.transcrypt.org) Python to JavaScript translator. While this test is by no means exhaustive, the API indeed provided very easy integration of mypy in Transcrypt. As an example here's the code of the Transcrypt module that uses the new mypy API and subsequently logs messages in a proprietary, hierarchical format, per file and, within that, per line.

Activating mypy is simply done in the following line (settings are just the defaults):

`validationMessages = api.type_validator.validate ([sourcePath])`

Everything mypy wants the world to know is in a polymorphic list returned by the validator, in a simple, non-textual format, documented explicitly in the API module, suitable for further processing. No exceptions to be caught, no special treatment or required dissection of CompileErrors, no need to read through other modules of mypy. The ValidationMessage class hierarchy can be expanded at will as mypy evolves, not changing anything to the API.

 The list of ValidationMessage's is used by the surrounding code of Transcrypt as follows:

(Note that while the code below is formatted according to non-PEP standards since it coexists with C++ and JS code, the API itself follows PEP)

```
import traceback
from mypy import api
from org.transcrypt import utils

def run (sourcePath):
	try:
		utils.log (True, 'Performing static type validation on application: {}\n', sourcePath)
		
		validationMessages = api.type_validator.validate ([sourcePath])
		
		if validationMessages:
			oldFileName = ''
			for validationMessage in validationMessages:
				if isinstance (validationMessage, api.StaticTypingError):
					if validationMessage.file_name != oldFileName:
						utils.log (True, '\tFile {}\n', validationMessage.file_name)
						oldFileName = validationMessage.file_name
					utils.log (True, '\t\tLine {}: {}\n', validationMessage.line_nr, validationMessage.description)
				elif isinstance (validationError, api.CompilationError):
					utils.log (True, '\t{}'.format (message))
				else:
					util.log (True, '\tUnknown error')
			utils.log (True, '\n')
	except Exception as exception:  # Just to be sure, not required by API
		utils.log (False, traceback.format_exc ())
		raise exception

```
Kind regards
Jacques de Hooge

