### PR TITLE
Make Statement a proper subclass of Node

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -4,7 +4,7 @@ import os
 from abc import abstractmethod
 
 from typing import (
-    Any, TypeVar, List, Tuple, cast, Set, Dict, Union, Optional, NewType
+    Any, TypeVar, List, Tuple, cast, Set, Dict, Union, Optional
 )
 
 from mypy.lex import Token

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1,11 +1,10 @@
 """Abstract syntax tree node classes (i.e. parse tree)."""
 
 import os
-import re
-from abc import abstractmethod, ABCMeta
+from abc import abstractmethod
 
 from typing import (
-    Any, TypeVar, List, Tuple, cast, Set, Dict, Union, Optional
+    Any, TypeVar, List, Tuple, cast, Set, Dict, Union, Optional, NewType
 )
 
 from mypy.lex import Token
@@ -117,11 +116,19 @@ class Node(Context):
         raise RuntimeError('Not implemented')
 
 
-# These are placeholders for a future refactoring; see #1783.
-# For now they serve as (unchecked) documentation of what various
+# This is a placeholder for a future refactoring; see #1783.
+# For now it serves as (unchecked) documentation of what various
 # fields of Node subtypes are expected to contain.
-Statement = Node
 Expression = Node
+
+
+class Statement(Node):
+    pass
+
+
+# For now, only Var is a declaration
+class Declaration(Node):
+    pass
 
 
 class SymbolNode(Node):
@@ -572,7 +579,7 @@ class Decorator(SymbolNode, Statement):
         return dec
 
 
-class Var(SymbolNode, Statement):
+class Var(SymbolNode, Declaration):
     """A variable.
 
     It can refer to global/local variable or a data attribute.

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -19,9 +19,9 @@ from mypy.nodes import (
     ComparisonExpr, TempNode, StarExpr,
     YieldFromExpr, NamedTupleExpr, NonlocalDecl, SetComprehension,
     DictionaryComprehension, ComplexExpr, TypeAliasExpr, EllipsisExpr,
-    YieldExpr, ExecStmt, Argument, BackquoteExpr, AwaitExpr,
+    YieldExpr, ExecStmt, Argument, BackquoteExpr, AwaitExpr, Statement
 )
-from mypy.types import Type, FunctionLike, Instance
+from mypy.types import Type, FunctionLike
 from mypy.traverser import TraverserVisitor
 from mypy.visitor import NodeVisitor
 
@@ -57,7 +57,7 @@ class TransformVisitor(NodeVisitor[Node]):
 
     def visit_mypy_file(self, node: MypyFile) -> Node:
         # NOTE: The 'names' and 'imports' instance variables will be empty!
-        new = MypyFile(self.nodes(node.defs), [], node.is_bom,
+        new = MypyFile(self.statements(node.defs), [], node.is_bom,
                        ignored_lines=set(node.ignored_lines))
         new._name = node._name
         new._fullname = node._fullname
@@ -200,7 +200,7 @@ class TransformVisitor(NodeVisitor[Node]):
         return NonlocalDecl(node.names[:])
 
     def visit_block(self, node: Block) -> Block:
-        return Block(self.nodes(node.body))
+        return Block(self.statements(node.body))
 
     def visit_decorator(self, node: Decorator) -> Decorator:
         # Note that a Decorator must be transformed to a Decorator.
@@ -523,6 +523,9 @@ class TransformVisitor(NodeVisitor[Node]):
 
     def nodes(self, nodes: List[Node]) -> List[Node]:
         return [self.node(node) for node in nodes]
+
+    def statements(self, nodes: List[Statement]) -> List[Statement]:
+        return [cast(Statement, self.node(node)) for node in nodes]
 
     def optional_nodes(self, nodes: List[Node]) -> List[Node]:
         return [self.optional_node(node) for node in nodes]


### PR DESCRIPTION
This is the easier half or #1783 (another step from #1785)

I've added a `Declaration` superclass to `Var`, since it's not a statement. It's not very useful yet, but at least it makes sure we don't get `Var` when we want a statement.