### PR TITLE
Make mismatched TypeVar name error clearer

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1485,7 +1485,7 @@ class SemanticAnalyzer(NodeVisitor):
             self.fail("TypeVar() expects a string literal as first argument", context)
             return False
         if cast(StrExpr, call.args[0]).value != name:
-            self.fail("Unexpected TypeVar() argument value", context)
+            self.fail("Argument 1 to TypeVar(...) does not match variable name", context)
             return False
         return True
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1400,7 +1400,8 @@ class SemanticAnalyzer(NodeVisitor):
             self.fail("Argument 1 to NewType(...) must be a string literal", context)
             has_failed = True
         elif cast(StrExpr, call.args[0]).value != name:
-            self.fail("Argument 1 to NewType(...) does not match variable name", context)
+            msg = "String argument 1 '{}' to NewType(...) does not match variable name '{}'"
+            self.fail(msg.format(cast(StrExpr, call.args[0]).value, name), context)
             has_failed = True
 
         # Check second argument
@@ -1485,7 +1486,8 @@ class SemanticAnalyzer(NodeVisitor):
             self.fail("TypeVar() expects a string literal as first argument", context)
             return False
         if cast(StrExpr, call.args[0]).value != name:
-            self.fail("Argument 1 to TypeVar(...) does not match variable name", context)
+            msg = "String argument 1 '{}' to TypeVar(...) does not match variable name '{}'"
+            self.fail(msg.format(cast(StrExpr, call.args[0]).value, name), context)
             return False
         return True
 

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -244,7 +244,7 @@ tmp/m.py:14: error: Revealed type is 'builtins.int'
 [case testNewTypeBadInitializationFails]
 from typing import NewType
 
-a = NewType('b', int)  # E: Argument 1 to NewType(...) does not match variable name
+a = NewType('b', int)  # E: String argument 1 'b' to NewType(...) does not match variable name 'a'
 b = NewType('b', 3)  # E: Argument 2 to NewType(...) must be a valid type
 c = NewType(2, int)  # E: Argument 1 to NewType(...) must be a string literal
 foo = "d"

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1001,7 +1001,7 @@ from typing import TypeVar
 a = TypeVar()       # E: Too few arguments for TypeVar()
 b = TypeVar(x='b')  # E: TypeVar() expects a string literal as first argument
 c = TypeVar(1)      # E: TypeVar() expects a string literal as first argument
-d = TypeVar('D')    # E: Unexpected TypeVar() argument value
+d = TypeVar('D')    # E: Argument 1 to TypeVar(...) does not match variable name
 e = TypeVar('e', int, str, x=1) # E: Unexpected argument to TypeVar(): x
 f = TypeVar('f', (int, str)) # E: Type expected
 g = TypeVar('g', x=(int, str)) # E: Unexpected argument to TypeVar(): x

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1001,7 +1001,7 @@ from typing import TypeVar
 a = TypeVar()       # E: Too few arguments for TypeVar()
 b = TypeVar(x='b')  # E: TypeVar() expects a string literal as first argument
 c = TypeVar(1)      # E: TypeVar() expects a string literal as first argument
-d = TypeVar('D')    # E: Argument 1 to TypeVar(...) does not match variable name
+d = TypeVar('D')    # E: String argument 1 'D' to TypeVar(...) does not match variable name 'd'
 e = TypeVar('e', int, str, x=1) # E: Unexpected argument to TypeVar(): x
 f = TypeVar('f', (int, str)) # E: Type expected
 g = TypeVar('g', x=(int, str)) # E: Unexpected argument to TypeVar(): x


### PR DESCRIPTION
Previously, if the string given to a TypeVar did not match the variable name, you would get the following error message:

    Unexpected TypeVar() argument value

...which I don't think is a particularly obvious error message. This commit makes the error message similar to the one used for NewType:

    Argument 1 to TypeVar(...) does not match variable name

...which should hopefully be more immediately understandable.