### PR TITLE
Add --scripts-are-modules flag. Fixes #1380.

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -189,6 +189,8 @@ def process_options(args: List[str],
                         help="dump type inference stats")
     parser.add_argument('--custom-typing', metavar='MODULE', dest='custom_typing_module',
                         help="use a custom typing module")
+    parser.add_argument('--scripts-are-modules', action='store_true',
+                        help="Script x becomes module x instead of __main__")
     # hidden options
     # --shadow-file a.py tmp.py will typecheck tmp.py in place of a.py.
     # Useful for tools to make transformations to a file to get more
@@ -319,7 +321,8 @@ def process_options(args: List[str],
                          .format(f))
                 targets.extend(sub_targets)
             else:
-                targets.append(BuildSource(f, None, None))
+                mod = os.path.basename(f) if options.scripts_are_modules else None
+                targets.append(BuildSource(f, mod, None))
         return targets, options
 
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -47,6 +47,9 @@ class Options:
         # Files in which to allow strict-Optional related errors
         self.strict_optional_whitelist = None   # type: Optional[List[str]]
 
+        # Use script name instead of __main__
+        self.scripts_are_modules = False
+
         # -- development options --
         self.verbosity = 0  # More verbose messages (for troubleshooting)
         self.pdb = False

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1131,3 +1131,20 @@ reveal_type(x)
 [out]
 main:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 main:2: error: Revealed type is 'builtins.str'
+
+-- Scripts and __main__
+
+[case testScriptsAreModules]
+# flags: --scripts-are-modules
+[file a]
+pass
+[file b]
+pass
+
+[case testScriptsAreNotModules]
+# cmd: mypy a b
+[file a]
+pass
+[file b]
+pass
+[out]


### PR DESCRIPTION
If set, each script file passed on the command line (i.e. without .py extension) is considered a module by that name (its basename, actually). Without this flag, the script is considered to be module `__main__` and there can be only one.