### PR TITLE
Allow identical classes to be imported twice

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -981,7 +981,7 @@ class SemanticAnalyzer(NodeVisitor):
                                           module_symbol: SymbolTableNode,
                                           import_node: ImportBase) -> bool:
         if (existing_symbol.kind in (LDEF, GDEF, MDEF) and
-                isinstance(existing_symbol.node, (Var, FuncDef))):
+                isinstance(existing_symbol.node, (Var, FuncDef, TypeInfo))):
             # This is a valid import over an existing definition in the file. Construct a dummy
             # assignment that we'll use to type check the import.
             lvalue = NameExpr(imported_id)

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -873,6 +873,49 @@ reveal_type(foo)
 main:1: note: In module imported here:
 tmp/parent/child.py:4: error: Revealed type is 'parent.common.SomeClass'
 
+-- Tests repeated imports
+
+[case testIdenticalImportFromTwice]
+from a import x, y, z
+from b import x, y, z
+[file a.py]
+from common import x, y, z
+[file b.py]
+from common import x, y, z
+[file common.py]
+x = 3
+def y() -> int: return 3
+class z: pass
+[out]
+
+[case testIdenticalImportStarTwice]
+from a import *
+from b import *
+[file a.py]
+from common import x, y, z
+[file b.py]
+from common import x, y, z
+[file common.py]
+x = 3
+def y() -> int: return 3
+class z: pass
+[out]
+
+[case testDifferentImportSameNameTwice]
+from a import x, y, z
+from b import x, y, z
+[file a.py]
+x = 3
+def y() -> int: return 1
+class z: pass
+[file b.py]
+x = "foo"
+def y() -> str: return "foo"
+class z: pass
+[out]
+main:2: error: Incompatible import of "x" (imported name has type "str", local name has type "int")
+main:2: error: Incompatible import of "y" (imported name has type Callable[[], str], local name has type Callable[[], int])
+main:2: error: Incompatible import of "z" (imported name has type "z" (type object), local name has type "z" (type object))
 
 -- Misc
 


### PR DESCRIPTION
This pull request fixes https://github.com/python/mypy/issues/2135.

Previously, if you attempted importing two symbols of the same name twice, mypy would check to see if that symbol was a variable definition or a function and would allow the import if that symbol was previously imported.

This commit extends this check slightly by also allowing identical classes to be imported twice.