### PR TITLE
Use a single exception class shared by fastparse.py and fastparse2.py.

### DIFF
--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -39,7 +39,7 @@ from mypy.types import (
 from mypy import defaults
 from mypy import experiments
 from mypy.errors import Errors
-from mypy.fastparse import TypeConverter
+from mypy.fastparse import TypeConverter, TypeCommentParseError
 
 try:
     from typed_ast import ast27
@@ -866,9 +866,3 @@ class ASTConverter(ast27.NodeTransformer):
     # Index(expr value)
     def visit_Index(self, n: ast27.Index) -> Node:
         return self.visit(n.value)
-
-
-class TypeCommentParseError(Exception):
-    def __init__(self, msg: str, lineno: int) -> None:
-        self.msg = msg
-        self.lineno = lineno

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -170,3 +170,12 @@ def f(x):  # E: Type signature has too few arguments
     pass
 [out]
 main: note: In function "f":
+
+[case testFasterParseTypeCommentError_python2]
+# flags: --fast-parser
+from typing import Tuple
+def f(a):
+    # type: (Tuple(int, int)) -> int
+    pass
+[out]
+main:3: error: invalid type comment


### PR DESCRIPTION
Fixes #2146.