### PR TITLE
Support reading options from a config file, default mypy.ini.

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -803,6 +803,7 @@ OPTIONS_AFFECTING_CACHE = [
     "debug_cache",
     "strict_optional",
     "strict_optional_whitelist",
+    "show_none_errors",
 ]
 
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -801,6 +801,8 @@ OPTIONS_AFFECTING_CACHE = [
     "disallow_untyped_defs",
     "check_untyped_defs",
     "debug_cache",
+    "strict_optional",
+    "strict_optional_whitelist",
 ]
 
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -762,7 +762,7 @@ def find_cache_meta(id: str, path: str, manager: BuildManager) -> Optional[Cache
 
     # Ignore cache if (relevant) options aren't the same.
     cached_options = m.options
-    current_options = select_options_affecting_cache(manager.options)
+    current_options = manager.options.select_options_affecting_cache()
     if cached_options != current_options:
         manager.trace('Metadata abandoned for {}: options differ'.format(id))
         return None
@@ -788,23 +788,6 @@ def is_meta_fresh(meta: CacheMeta, id: str, path: str, manager: BuildManager) ->
         return False
     manager.log('Found {} {} (metadata is fresh)'.format(id, meta.data_json))
     return True
-
-
-def select_options_affecting_cache(options: Options) -> Mapping[str, bool]:
-    return {opt: getattr(options, opt) for opt in OPTIONS_AFFECTING_CACHE}
-
-
-OPTIONS_AFFECTING_CACHE = [
-    "silent_imports",
-    "almost_silent",
-    "disallow_untyped_calls",
-    "disallow_untyped_defs",
-    "check_untyped_defs",
-    "debug_cache",
-    "strict_optional",
-    "strict_optional_whitelist",
-    "show_none_errors",
-]
 
 
 def random_string() -> str:
@@ -889,7 +872,7 @@ def write_cache(id: str, path: str, tree: MypyFile,
             'dependencies': dependencies,
             'suppressed': suppressed,
             'child_modules': child_modules,
-            'options': select_options_affecting_cache(options),
+            'options': options.select_options_affecting_cache(),
             'dep_prios': dep_prios,
             'interface_hash': interface_hash,
             'version_id': manager.version_id,

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -887,7 +887,7 @@ def write_cache(id: str, path: str, tree: MypyFile,
             'dependencies': dependencies,
             'suppressed': suppressed,
             'child_modules': child_modules,
-            'options': select_options_affecting_cache(manager.options),
+            'options': select_options_affecting_cache(manager.options),  # TODO: per-file options
             'dep_prios': dep_prios,
             'interface_hash': interface_hash,
             'version_id': manager.version_id,

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -879,6 +879,7 @@ def write_cache(id: str, path: str, tree: MypyFile,
     st = manager.get_stat(path)  # TODO: Handle errors
     mtime = st.st_mtime
     size = st.st_size
+    options = manager.options.clone_for_file(path)
     meta = {'id': id,
             'path': path,
             'mtime': mtime,
@@ -887,7 +888,7 @@ def write_cache(id: str, path: str, tree: MypyFile,
             'dependencies': dependencies,
             'suppressed': suppressed,
             'child_modules': child_modules,
-            'options': select_options_affecting_cache(manager.options),  # TODO: per-file options
+            'options': select_options_affecting_cache(options),
             'dep_prios': dep_prios,
             'interface_hash': interface_hash,
             'version_id': manager.version_id,

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -120,7 +120,7 @@ class TypeChecker(NodeVisitor[Type]):
     # Is this file a typeshed stub?
     is_typeshed_stub = False
     # Should strict Optional-related errors be suppressed in this file?
-    suppress_none_errors = False
+    suppress_none_errors = False  # TODO: Get it from options instead
     options = None  # type: Options
 
     # The set of all dependencies (suppressed or not) that this module accesses, either
@@ -165,7 +165,7 @@ class TypeChecker(NodeVisitor[Type]):
         self.module_type_map = {}
         self.module_refs = set()
         if self.options.strict_optional_whitelist is None:
-            self.suppress_none_errors = False
+            self.suppress_none_errors = not self.options.show_none_errors
         else:
             self.suppress_none_errors = not any(fnmatch.fnmatch(path, pattern)
                                                 for pattern

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -153,6 +153,8 @@ class TypeChecker(NodeVisitor[Type]):
 
     def visit_file(self, file_node: MypyFile, path: str) -> None:
         """Type check a mypy file with the given path."""
+        save_options = self.options
+        self.options = self.options.clone_for_file(path)
         self.pass_num = 0
         self.is_stub = file_node.is_stub
         self.errors.set_file(path)
@@ -187,6 +189,8 @@ class TypeChecker(NodeVisitor[Type]):
                 str_seq_s, all_s = self.msg.format_distinctly(seq_str, all_.type)
                 self.fail(messages.ALL_MUST_BE_SEQ_STR.format(str_seq_s, all_s),
                           all_.node)
+
+        self.options = save_options
 
     def check_second_pass(self) -> None:
         """Run second pass of type checking which goes through deferred nodes."""

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -1,3 +1,4 @@
 PYTHON2_VERSION = (2, 7)
 PYTHON3_VERSION = (3, 5)
-MYPY_CACHE = '.mypy_cache'
+CACHE_DIR = '.mypy_cache'
+CONFIG_FILE = 'mypy.ini'

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -242,9 +242,9 @@ def process_options(args: List[str],
     code_group.add_argument('-m', '--module', action='append', metavar='MODULE',
                             dest='special-opts:modules',
                             help="type-check module; can repeat for more modules")
-    # TODO: `mypy -c A -c B` and `mypy -p A -p B` currently silently
-    # ignore A (last option wins).  Perhaps -c, -m and -p could just
-    # be command-line flags that modify how we interpret self.files?
+    # TODO: `mypy -p A -p B` currently silently ignores ignores A
+    # (last option wins).  Perhaps -c, -m and -p could just be
+    # command-line flags that modify how we interpret self.files?
     code_group.add_argument('-c', '--command', action='append', metavar='PROGRAM_TEXT',
                             dest='special-opts:command',
                             help="type-check program passed in as string")

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -468,6 +468,11 @@ def parse_config_file(options: Options, filename: str) -> None:
         else:
             dv = getattr(options, key, None)
             if dv is None:
+                if key.endswith('_report'):
+                    report_type = key[:-7].replace('_', '-')
+                    report_dir = section.get(key)
+                    options.report_dirs[report_type] = report_dir
+                    continue
                 print("%s: Unrecognized option: %s = %s" % (filename, key, section[key]),
                       file=sys.stderr)
                 continue

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -117,6 +117,19 @@ def parse_version(v: str) -> Tuple[int, int]:
             "Invalid python version '{}' (expected format: 'x.y')".format(v))
 
 
+# Supported report types.
+valid_report_types = {
+    'html',
+    'old_html',
+    'xslt_html',
+    'xml',
+    'txt',
+    'xslt_txt',
+    'linecount',
+    'linecoverage',
+}
+
+
 def process_options(args: List[str],
                     require_targets: bool = True
                     ) -> Tuple[List[BuildSource], Options]:
@@ -220,23 +233,10 @@ def process_options(args: List[str],
     report_group = parser.add_argument_group(
         title='report generation',
         description='Generate a report in the specified format.')
-    # TODO: dynamicall generate these based on valid_report_types
-    report_group.add_argument('--html-report', metavar='DIR',
-                              dest='special-opts:html_report')
-    report_group.add_argument('--old-html-report', metavar='DIR',
-                              dest='special-opts:old_html_report')
-    report_group.add_argument('--xslt-html-report', metavar='DIR',
-                              dest='special-opts:xslt_html_report')
-    report_group.add_argument('--xml-report', metavar='DIR',
-                              dest='special-opts:xml_report')
-    report_group.add_argument('--txt-report', metavar='DIR',
-                              dest='special-opts:txt_report')
-    report_group.add_argument('--xslt-txt-report', metavar='DIR',
-                              dest='special-opts:xslt_txt_report')
-    report_group.add_argument('--linecount-report', metavar='DIR',
-                              dest='special-opts:linecount_report')
-    report_group.add_argument('--linecoverage-report', metavar='DIR',
-                              dest='special-opts:linecoverage_report')
+    for report_type in valid_report_types:
+        report_group.add_argument('--%s-report' % report_type.replace('_', '-'),
+                                  metavar='DIR',
+                                  dest='special-opts:%s_report' % report_type)
 
     code_group = parser.add_argument_group(title='How to specify the code to type check')
     code_group.add_argument('-m', '--module', action='append', metavar='MODULE',
@@ -444,18 +444,6 @@ config_types = {
     'python_version': lambda s: tuple(map(int, s.split('.'))),
     'strict_optional_whitelist': lambda s: s.split(),
     'custom_typing_module': str,
-}
-
-# Supported report types (must match --xxx-report flags above).
-valid_report_types = {
-    'html',
-    'old_html',
-    'xslt_html',
-    'xml',
-    'txt',
-    'xslt_txt',
-    'linecount',
-    'linecoverage',
 }
 
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -460,7 +460,6 @@ def parse_config_file(options: Options, filename: str) -> None:
 
     for name, section in parser.items():
         if name.startswith('mypy-'):
-            glob = name[5:]
             prefix = '%s: [%s]' % (filename, name)
             updates, report_dirs = parse_section(prefix, options, section)
             # TODO: Limit updates to flags that can be per-file.
@@ -472,7 +471,10 @@ def parse_config_file(options: Options, filename: str) -> None:
                 print("%s: Per-file sections should only specify per-file flags (%s)" %
                       (prefix, ', '.join(sorted(set(updates) - Options.PER_FILE_OPTIONS))),
                       file=sys.stderr)
-            options.per_file_options[glob] = updates
+                updates = {k: v for k, v in updates.items() if k in Options.PER_FILE_OPTIONS}
+            globs = name[5:]
+            for glob in globs.split(','):
+                options.per_file_options[glob] = updates
 
 
 def parse_section(prefix: str, template: Options,

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -495,7 +495,6 @@ def parse_section(prefix: str, template: Options,
                     if report_type in reporter_classes:
                         report_dirs[report_type] = section.get(key)
                     else:
-                        import pdb; pdb.set_trace()
                         print("%s: Unrecognized report type: %s" % (prefix, key),
                               file=sys.stderr)
                     continue

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -176,7 +176,7 @@ def process_options(args: List[str],
                         help="store module cache info in the given folder in incremental mode "
                         "(defaults to '{}')".format(defaults.CACHE_DIR))
     parser.add_argument('--strict-optional', action='store_true',
-                        dest='special-opts:strict_optional',
+                        dest='strict_optional',
                         help="enable experimental strict Optional checks")
     parser.add_argument('--strict-optional-whitelist', metavar='GLOB', nargs='*',
                         help="suppress strict Optional errors in all but the provided files "
@@ -297,7 +297,9 @@ def process_options(args: List[str],
             parser.error("May only specify one of: module, package, files, or command.")
 
     # Set build flags.
-    if special_opts.strict_optional or options.strict_optional_whitelist is not None:
+    if options.strict_optional_whitelist is not None:
+        options.strict_optional = True
+    if options.strict_optional:
         experiments.STRICT_OPTIONAL = True
 
     # Set reports.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -299,6 +299,7 @@ def process_options(args: List[str],
 
     # Set build flags.
     if options.strict_optional_whitelist is not None:
+        # TODO: Deprecate, then kill this flag
         options.strict_optional = True
     if options.strict_optional:
         experiments.STRICT_OPTIONAL = True
@@ -474,6 +475,7 @@ def parse_config_file(options: Options, filename: str) -> None:
             glob = name[5:]
             prefix = '%s: [%s]' % (filename, name)
             updates, report_dirs = parse_section(prefix, options, section)
+            # TODO: Limit updates to flags that can be per-file.
             if report_dirs:
                 print("%s: Per-file sections should not specify reports" % prefix,
                       file=sys.stderr)
@@ -487,7 +489,7 @@ def parse_section(prefix: str, template: Options,
     Returns a dict of option values encountered, and a dict of report directories.
     """
     results = {}
-    report_dirs = {}
+    report_dirs = {}  # type: Dict[str, str]
     for key in section:
         key = key.replace('-', '_')
         if key in config_types:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -417,7 +417,7 @@ class MessageBuilder:
 
     def untyped_function_call(self, callee: CallableType, context: Context) -> Type:
         name = callee.name if callee.name is not None else '(unknown)'
-        self.fail('call to untyped function {} in typed context'.format(name), context)
+        self.fail('Call to untyped function {} in typed context'.format(name), context)
         return AnyType()
 
     def incompatible_argument(self, n: int, m: int, callee: CallableType, arg_type: Type,

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -94,11 +94,13 @@ class Options:
         return 'Options({})'.format(pprint.pformat(self.__dict__))
 
     def clone_for_file(self, filename: str) -> 'Options':
-        new_options = Options()
-        new_options.__dict__.update(self.__dict__)
+        updates = {}
         for glob in self.per_file_options:
             if fnmatch.fnmatch(filename, glob):
-                updates = self.per_file_options[glob]
-                for k, v in updates.items():
-                    setattr(new_options, k, v)
+                updates.update(self.per_file_options[glob])
+        if not updates:
+            return self
+        new_options = Options()
+        new_options.__dict__.update(self.__dict__)
+        new_options.__dict__.update(updates)
         return new_options

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -67,7 +67,7 @@ class Options:
         # -- experimental options --
         self.fast_parser = False
         self.incremental = False
-        self.cache_dir = defaults.MYPY_CACHE
+        self.cache_dir = defaults.CACHE_DIR
         self.debug_cache = False
         self.suppress_error_context = False  # Suppress "note: In function "foo":" messages.
         self.shadow_file = None  # type: Optional[Tuple[str, str]]

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -51,7 +51,11 @@ class Options:
         self.strict_optional = False
 
         # Files in which to allow strict-Optional related errors
+        # TODO: Kill this in favor of show_none_errors
         self.strict_optional_whitelist = None   # type: Optional[List[str]]
+
+        # Alternate way to show/hide strict-None-checking related errors
+        self.show_none_errors = True
 
         # Use script name instead of __main__
         self.scripts_are_modules = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -2,7 +2,7 @@ import fnmatch
 import pprint
 import sys
 
-from typing import Any, Optional, Tuple, List
+from typing import Any, Mapping, Optional, Tuple, List
 
 from mypy import defaults
 
@@ -15,6 +15,20 @@ class BuildType:
 
 class Options:
     """Options collected from flags."""
+
+    PER_FILE_OPTIONS = {
+        "silent_imports",
+        "almost_silent",
+        "disallow_untyped_calls",
+        "disallow_untyped_defs",
+        "check_untyped_defs",
+        "debug_cache",
+        "strict_optional_whitelist",
+        "show_none_errors",
+    }
+
+    OPTIONS_AFFECTING_CACHE =  PER_FILE_OPTIONS | {"strict_optional"}
+
 
     def __init__(self) -> None:
         # -- build options --
@@ -108,3 +122,6 @@ class Options:
         new_options.__dict__.update(self.__dict__)
         new_options.__dict__.update(updates)
         return new_options
+
+    def select_options_affecting_cache(self) -> Mapping[str, bool]:
+        return {opt: getattr(self, opt) for opt in self.OPTIONS_AFFECTING_CACHE}

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -51,7 +51,7 @@ class Options:
         self.scripts_are_modules = False
 
         # Config file name
-        self.config_file = None
+        self.config_file = None  # type: Optional[str]
 
         # -- development options --
         self.verbosity = 0  # More verbose messages (for troubleshooting)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -1,7 +1,10 @@
-from mypy import defaults
+import fnmatch
 import pprint
 import sys
+
 from typing import Any, Optional, Tuple, List
+
+from mypy import defaults
 
 
 class BuildType:
@@ -56,6 +59,9 @@ class Options:
         # Config file name
         self.config_file = None  # type: Optional[str]
 
+        # Per-file options (raw)
+        self.per_file_options = {}  # type: Dict[str, Dict[str, object]]
+
         # -- development options --
         self.verbosity = 0  # More verbose messages (for troubleshooting)
         self.pdb = False
@@ -86,3 +92,13 @@ class Options:
 
     def __repr__(self) -> str:
         return 'Options({})'.format(pprint.pformat(self.__dict__))
+
+    def clone_for_file(self, filename: str) -> 'Options':
+        new_options = Options()
+        new_options.__dict__.update(self.__dict__)
+        for glob in self.per_file_options:
+            if fnmatch.fnmatch(filename, glob):
+                updates = self.per_file_options[glob]
+                for k, v in updates.items():
+                    setattr(new_options, k, v)
+        return new_options

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -44,6 +44,9 @@ class Options:
         # Warn about unused '# type: ignore' comments
         self.warn_unused_ignores = False
 
+        # Apply strict None checking
+        self.strict_optional = False
+
         # Files in which to allow strict-Optional related errors
         self.strict_optional_whitelist = None   # type: Optional[List[str]]
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -27,8 +27,7 @@ class Options:
         "show_none_errors",
     }
 
-    OPTIONS_AFFECTING_CACHE =  PER_FILE_OPTIONS | {"strict_optional"}
-
+    OPTIONS_AFFECTING_CACHE = PER_FILE_OPTIONS | {"strict_optional"}
 
     def __init__(self) -> None:
         # -- build options --

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -50,6 +50,9 @@ class Options:
         # Use script name instead of __main__
         self.scripts_are_modules = False
 
+        # Config file name
+        self.config_file = None
+
         # -- development options --
         self.verbosity = 0  # More verbose messages (for troubleshooting)
         self.pdb = False

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -217,6 +217,8 @@ class SemanticAnalyzer(NodeVisitor):
         self.all_exports = set()  # type: Set[str]
 
     def visit_file(self, file_node: MypyFile, fnam: str) -> None:
+        save_options = self.options
+        self.options = self.options.clone_for_file(fnam)
         self.errors.set_file(fnam)
         self.cur_mod_node = file_node
         self.cur_mod_id = file_node.fullname()
@@ -245,6 +247,8 @@ class SemanticAnalyzer(NodeVisitor):
             for name, g in self.globals.items():
                 if name not in self.all_exports:
                     g.module_public = False
+
+        self.options = save_options
 
     def visit_func_def(self, defn: FuncDef) -> None:
         phase_info = self.postpone_nested_functions_stack[-1]

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -100,7 +100,7 @@ class TypeCheckSuite(DataSuite):
             self.run_case_once(testcase)
 
     def clear_cache(self) -> None:
-        dn = defaults.MYPY_CACHE
+        dn = defaults.CACHE_DIR
 
         if os.path.exists(dn):
             shutil.rmtree(dn)

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -113,6 +113,8 @@ class TypeCheckSuite(DataSuite):
         options = self.parse_options(original_program_text, testcase)
         options.use_builtins_fixtures = True
         set_show_tb(True)  # Show traceback on crash.
+        if 'optional' in testcase.file:
+            options.strict_optional = True
 
         if incremental:
             options.incremental = True

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -90,3 +90,39 @@ mypy: can't decode file 'a.py': unknown encoding: uft-8
 # type: ignore
 [out]
 two/mod/__init__.py: error: Duplicate module named 'mod'
+
+[case testFlagsFile]
+# cmd: mypy @flagsfile
+[file flagsfile]
+-2
+main.py
+[file main.py]
+def f():
+    try:
+        1/0
+    except ZeroDivisionError, err:
+        print err
+
+[case testConfigFile]
+# cmd: mypy main.py
+[file mypy.ini]
+[[mypy]
+python_version = 2.7
+[file main.py]
+def f():
+    try:
+        1/0
+    except ZeroDivisionError, err:
+        print err
+
+[case testAltConfigFile]
+# cmd: mypy --config-file config.ini main.py
+[file config.ini]
+[[mypy]
+python_version = 2.7
+[file main.py]
+def f():
+    try:
+        1/0
+    except ZeroDivisionError, err:
+        print err

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -154,7 +154,7 @@ def g(a: int) -> int:
     return f(a)
 [out]
 z.py:1: error: Function is missing a type annotation
-z.py:4: error: call to untyped function "f" in typed context
+z.py:4: error: Call to untyped function "f" in typed context
 x.py:1: error: Function is missing a type annotation
 
 [case testConfigErrorNoSection]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -186,6 +186,22 @@ xy.py:1: error: Function is missing a type annotation
 xy.py:2: error: Call to untyped function "f" in typed context
 xx.py:1: error: Function is missing a type annotation
 
+[case testMultipleGlobConfigSection]
+# cmd: mypy x.py y.py z.py
+[file mypy.ini]
+[[mypy]
+suppress_error_context = True
+[[mypy-x*py,z*py]
+disallow_untyped_defs = True
+[file x.py]
+def f(a): pass
+[file y.py]
+def f(a): pass
+[file z.py]
+def f(a): pass
+[out]
+z.py:1: error: Function is missing a type annotation
+x.py:1: error: Function is missing a type annotation
 
 [case testConfigErrorNoSection]
 # cmd: mypy -c pass

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -156,3 +156,42 @@ def g(a: int) -> int:
 z.py:1: error: Function is missing a type annotation
 z.py:4: error: call to untyped function "f" in typed context
 x.py:1: error: Function is missing a type annotation
+
+[case testConfigErrorNoSection]
+# cmd: mypy -c pass
+[file mypy.ini]
+[out]
+mypy.ini: No [mypy] section in config file
+
+[case testConfigErrorUnknownFlag]
+# cmd: mypy -c pass
+[file mypy.ini]
+[[mypy]
+bad = 0
+[out]
+mypy.ini: [mypy]: Unrecognized option: bad = 0
+
+[case testConfigErrorUnknownReport]
+# cmd: mypy -c pass
+[file mypy.ini]
+[[mypy]
+bad_report = .
+[out]
+mypy.ini: [mypy]: Unrecognized report type: bad_report
+
+[case testConfigErrorBadBoolean]
+# cmd: mypy -c pass
+[file mypy.ini]
+[[mypy]
+silent_imports = nah
+[out]
+mypy.ini: [mypy]: silent_imports: Not a boolean: nah
+
+[case testConfigErrorNotPerFile]
+# cmd: mypy -c pass
+[file mypy.ini]
+[[mypy]
+[[mypy-*]
+strict_optional = True
+[out]
+mypy.ini: [mypy-*]: Per-file sections should only specify per-file flags (strict_optional)

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -157,6 +157,36 @@ z.py:1: error: Function is missing a type annotation
 z.py:4: error: Call to untyped function "f" in typed context
 x.py:1: error: Function is missing a type annotation
 
+[case testPerFileConfigSectionMultipleMatches]
+# cmd: mypy xx.py xy.py yx.py yy.py
+[file mypy.ini]
+[[mypy]
+suppress_error_context = True
+[[mypy-*x*.py]
+disallow_untyped_defs = True
+[[mypy-*y*.py]
+disallow_untyped_calls = True
+[file xx.py]
+def f(a): pass
+def g(a: int) -> int: return f(a)
+[file xy.py]
+def f(a): pass
+def g(a: int) -> int: return f(a)
+[file yx.py]
+def f(a): pass
+def g(a: int) -> int: return f(a)
+[file yy.py]
+def f(a): pass
+def g(a: int) -> int: return f(a)
+[out]
+yy.py:2: error: Call to untyped function "f" in typed context
+yx.py:1: error: Function is missing a type annotation
+yx.py:2: error: Call to untyped function "f" in typed context
+xy.py:1: error: Function is missing a type annotation
+xy.py:2: error: Call to untyped function "f" in typed context
+xx.py:1: error: Function is missing a type annotation
+
+
 [case testConfigErrorNoSection]
 # cmd: mypy -c pass
 [file mypy.ini]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -126,3 +126,33 @@ def f():
         1/0
     except ZeroDivisionError, err:
         print err
+
+[case testPerFileConfigSection]
+# cmd: mypy x.py y.py z.py
+[file mypy.ini]
+[[mypy]
+suppress_error_context = True
+disallow_untyped_defs = True
+[[mypy-y*]
+disallow_untyped_defs = False
+[[mypy-z*]
+disallow_untyped_calls = True
+[file x.py]
+def f(a):
+    pass
+def g(a: int) -> int:
+    return f(a)
+[file y.py]
+def f(a):
+    pass
+def g(a: int) -> int:
+    return f(a)
+[file z.py]
+def f(a):
+    pass
+def g(a: int) -> int:
+    return f(a)
+[out]
+z.py:1: error: Function is missing a type annotation
+z.py:4: error: call to untyped function "f" in typed context
+x.py:1: error: Function is missing a type annotation


### PR DESCRIPTION
Also support reading command line flags using `mypy @flagsfile`.

Addresses #1249 (but does not completely fix it).

The mypy.ini file has the format:
```
[mypy]
silent_imports = True
python_version = 2.7
```
Errors in this config file are non-fatal.  Comments and blank lines
are supported.

The `@flagsfile` option reads additional argparse-style flags,
including filenames, from `flagsfile`, one per line.  This is
typically used for passing in a list of files, but it can also be used
for passing flags:
```
--silent-imports
--py2
mypy
```
This format does not allow comments or blank lines.  Each option must
appear on a line by itself.  Errors are fatal.

The mypy.ini file serves as a set of defaults that can be overridden
(or in some cases extended) by command line flags.  An alternate
config file may be specified using a command line flag:
`--config-file anywhere.ini`.  (There's a trick involved in making
this work, read the source. :-)
