### PR TITLE
Add type hints to strconv.py, and propagate implications

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -256,6 +256,8 @@ class Import(ImportBase):
 class ImportFrom(ImportBase):
     """from m import x [as y], ..."""
 
+    id = None  # type: str
+    relative = None  # type: int
     names = None  # type: List[Tuple[str, Optional[str]]]  # Tuples (name, as name)
 
     def __init__(self, id: str, relative: int, names: List[Tuple[str, Optional[str]]]) -> None:
@@ -270,6 +272,8 @@ class ImportFrom(ImportBase):
 
 class ImportAll(ImportBase):
     """from m import *"""
+    id = None  # type: str
+    relative = None  # type: int
 
     def __init__(self, id: str, relative: int) -> None:
         super().__init__()
@@ -1727,11 +1731,14 @@ class PromoteExpr(Expression):
 
 class NewTypeExpr(Expression):
     """NewType expression NewType(...)."""
+    name = None  # type: str
+    old_type = None  # type: mypy.types.Type
 
     info = None  # type: Optional[TypeInfo]
 
-    def __init__(self, info: Optional['TypeInfo']) -> None:
-        self.info = info
+    def __init__(self, name: str, old_type: 'mypy.types.Type', line: int) -> None:
+        self.name = name
+        self.old_type = old_type
 
     def accept(self, visitor: NodeVisitor[T]) -> T:
         return visitor.visit_newtype_expr(self)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1339,6 +1339,7 @@ class SemanticAnalyzer(NodeVisitor):
             return
 
         old_type = self.check_newtype_args(name, call, s)
+        call.analyzed = NewTypeExpr(name, old_type, line=call.line)
         if old_type is None:
             return
 
@@ -1360,8 +1361,7 @@ class SemanticAnalyzer(NodeVisitor):
             return
         # TODO: why does NewType work in local scopes despite always being of kind GDEF?
         node.kind = GDEF
-        node.node = newtype_class_info
-        call.analyzed = NewTypeExpr(newtype_class_info).set_line(call.line)
+        call.analyzed.info = node.node = newtype_class_info
 
     def analyze_newtype_declaration(self,
             s: AssignmentStmt) -> Tuple[Optional[str], Optional[CallExpr]]:
@@ -1384,7 +1384,6 @@ class SemanticAnalyzer(NodeVisitor):
             # overwritten later with a fully complete NewTypeExpr if there are no other
             # errors with the NewType() call.
             call = s.rvalue
-            call.analyzed = NewTypeExpr(None).set_line(call.line)
 
         return name, call
 

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -3,7 +3,7 @@
 import re
 import os
 
-from typing import Any, List
+from typing import Any, List, Tuple, Optional, Union
 
 from mypy.util import dump_tagged, short_type
 import mypy.nodes
@@ -36,11 +36,11 @@ class StrConv(NodeVisitor[str]):
         array with information specific to methods, global functions or
         anonymous functions.
         """
-        args = []
-        init = []
-        extra = []
+        args = []  # type: List[mypy.nodes.Var]
+        init = []  # type: List[Optional[mypy.nodes.AssignmentStmt]]
+        extra = []  # type: List[Tuple[str, List[mypy.nodes.Var]]]
         for i, arg in enumerate(o.arguments):
-            kind = arg.kind
+            kind = arg.kind  # type: int
             if kind == mypy.nodes.ARG_POS:
                 args.append(o.arguments[i].variable)
             elif kind in (mypy.nodes.ARG_OPT, mypy.nodes.ARG_NAMED):
@@ -91,7 +91,7 @@ class StrConv(NodeVisitor[str]):
                 a.append(id)
         return 'Import:{}({})'.format(o.line, ', '.join(a))
 
-    def visit_import_from(self, o):
+    def visit_import_from(self, o: 'mypy.nodes.ImportFrom') -> str:
         a = []
         for name, as_name in o.names:
             if as_name is not None:
@@ -100,12 +100,12 @@ class StrConv(NodeVisitor[str]):
                 a.append(name)
         return 'ImportFrom:{}({}, [{}])'.format(o.line, "." * o.relative + o.id, ', '.join(a))
 
-    def visit_import_all(self, o):
+    def visit_import_all(self, o: 'mypy.nodes.ImportAll') -> str:
         return 'ImportAll:{}({})'.format(o.line, "." * o.relative + o.id)
 
     # Definitions
 
-    def visit_func_def(self, o):
+    def visit_func_def(self, o: 'mypy.nodes.FuncDef') -> str:
         a = self.func_helper(o)
         a.insert(0, o.name())
         if mypy.nodes.ARG_NAMED in [arg.kind for arg in o.arguments]:
@@ -120,13 +120,13 @@ class StrConv(NodeVisitor[str]):
             a.insert(-1, 'Property')
         return self.dump(a, o)
 
-    def visit_overloaded_func_def(self, o):
-        a = o.items[:]
+    def visit_overloaded_func_def(self, o: 'mypy.nodes.OverloadedFuncDef') -> str:
+        a = o.items[:]  # type: Any
         if o.type:
             a.insert(0, o.type)
         return self.dump(a, o)
 
-    def visit_class_def(self, o):
+    def visit_class_def(self, o: 'mypy.nodes.ClassDef') -> str:
         a = [o.name, o.defs.body]
         # Display base types unless they are implicitly just builtins.object
         # (in this case base_type_exprs is empty).
@@ -151,7 +151,7 @@ class StrConv(NodeVisitor[str]):
             a.insert(1, 'FallbackToAny')
         return self.dump(a, o)
 
-    def visit_var(self, o):
+    def visit_var(self, o: 'mypy.nodes.Var') -> str:
         l = ''
         # Add :nil line number tag if no line number is specified to remain
         # compatible with old test case descriptions that assume this.
@@ -159,27 +159,25 @@ class StrConv(NodeVisitor[str]):
             l = ':nil'
         return 'Var' + l + '(' + o.name() + ')'
 
-    def visit_global_decl(self, o):
+    def visit_global_decl(self, o: 'mypy.nodes.GlobalDecl') -> str:
         return self.dump([o.names], o)
 
-    def visit_nonlocal_decl(self, o):
+    def visit_nonlocal_decl(self, o: 'mypy.nodes.NonlocalDecl') -> str:
         return self.dump([o.names], o)
 
-    def visit_decorator(self, o):
+    def visit_decorator(self, o: 'mypy.nodes.Decorator') -> str:
         return self.dump([o.var, o.decorators, o.func], o)
-
-    def visit_annotation(self, o):
-        return 'Type:{}({})'.format(o.line, o.type)
 
     # Statements
 
-    def visit_block(self, o):
+    def visit_block(self, o: 'mypy.nodes.Block') -> str:
         return self.dump(o.body, o)
 
-    def visit_expression_stmt(self, o):
+    def visit_expression_stmt(self, o: 'mypy.nodes.ExpressionStmt') -> str:
         return self.dump([o.expr], o)
 
-    def visit_assignment_stmt(self, o):
+    def visit_assignment_stmt(self, o: 'mypy.nodes.AssignmentStmt') -> str:
+        a = []  # type: List[Any]
         if len(o.lvalues) > 1:
             a = [('Lvalues', o.lvalues)]
         else:
@@ -189,17 +187,17 @@ class StrConv(NodeVisitor[str]):
             a.append(o.type)
         return self.dump(a, o)
 
-    def visit_operator_assignment_stmt(self, o):
+    def visit_operator_assignment_stmt(self, o: 'mypy.nodes.OperatorAssignmentStmt') -> str:
         return self.dump([o.op, o.lvalue, o.rvalue], o)
 
-    def visit_while_stmt(self, o):
-        a = [o.expr, o.body]
+    def visit_while_stmt(self, o: 'mypy.nodes.WhileStmt') -> str:
+        a = [o.expr, o.body]  # type: List[Any]
         if o.else_body:
             a.append(('Else', o.else_body.body))
         return self.dump(a, o)
 
-    def visit_for_stmt(self, o):
-        a = []
+    def visit_for_stmt(self, o: 'mypy.nodes.ForStmt') -> str:
+        a = []  # type: List[Any]
         if o.is_async:
             a.append(('Async', ''))
         a.extend([o.index, o.expr, o.body])
@@ -207,11 +205,11 @@ class StrConv(NodeVisitor[str]):
             a.append(('Else', o.else_body.body))
         return self.dump(a, o)
 
-    def visit_return_stmt(self, o):
+    def visit_return_stmt(self, o: 'mypy.nodes.ReturnStmt') -> str:
         return self.dump([o.expr], o)
 
-    def visit_if_stmt(self, o):
-        a = []
+    def visit_if_stmt(self, o: 'mypy.nodes.IfStmt') -> str:
+        a = []  # type: List[Any]
         for i in range(len(o.expr)):
             a.append(('If', [o.expr[i]]))
             a.append(('Then', o.body[i].body))
@@ -221,38 +219,29 @@ class StrConv(NodeVisitor[str]):
         else:
             return self.dump([a, ('Else', o.else_body.body)], o)
 
-    def visit_break_stmt(self, o):
+    def visit_break_stmt(self, o: 'mypy.nodes.BreakStmt') -> str:
         return self.dump([], o)
 
-    def visit_continue_stmt(self, o):
+    def visit_continue_stmt(self, o: 'mypy.nodes.ContinueStmt') -> str:
         return self.dump([], o)
 
-    def visit_pass_stmt(self, o):
+    def visit_pass_stmt(self, o: 'mypy.nodes.PassStmt') -> str:
         return self.dump([], o)
 
-    def visit_raise_stmt(self, o):
+    def visit_raise_stmt(self, o: 'mypy.nodes.RaiseStmt') -> str:
         return self.dump([o.expr, o.from_expr], o)
 
-    def visit_assert_stmt(self, o):
+    def visit_assert_stmt(self, o: 'mypy.nodes.AssertStmt') -> str:
         return self.dump([o.expr], o)
 
-    def visit_yield_stmt(self, o):
+    def visit_await_expr(self, o: 'mypy.nodes.AwaitExpr') -> str:
         return self.dump([o.expr], o)
 
-    def visit_yield_from_stmt(self, o):
+    def visit_del_stmt(self, o: 'mypy.nodes.DelStmt') -> str:
         return self.dump([o.expr], o)
 
-    def visit_yield_expr(self, o):
-        return self.dump([o.expr], o)
-
-    def visit_await_expr(self, o):
-        return self.dump([o.expr], o)
-
-    def visit_del_stmt(self, o):
-        return self.dump([o.expr], o)
-
-    def visit_try_stmt(self, o):
-        a = [o.body]
+    def visit_try_stmt(self, o: 'mypy.nodes.TryStmt') -> str:
+        a = [o.body]  # type: List[Any]
 
         for i in range(len(o.vars)):
             a.append(o.types[i])
@@ -267,8 +256,8 @@ class StrConv(NodeVisitor[str]):
 
         return self.dump(a, o)
 
-    def visit_with_stmt(self, o):
-        a = []
+    def visit_with_stmt(self, o: 'mypy.nodes.WithStmt') -> str:
+        a = []  # type: List[Any]
         if o.is_async:
             a.append(('Async', ''))
         for i in range(len(o.expr)):
@@ -277,31 +266,31 @@ class StrConv(NodeVisitor[str]):
                 a.append(('Target', [o.target[i]]))
         return self.dump(a + [o.body], o)
 
-    def visit_print_stmt(self, o):
-        a = o.args[:]
+    def visit_print_stmt(self, o: 'mypy.nodes.PrintStmt') -> str:
+        a = o.args[:]  # type: List[Any]
         if o.target:
             a.append(('Target', [o.target]))
         if o.newline:
             a.append('Newline')
         return self.dump(a, o)
 
-    def visit_exec_stmt(self, o):
+    def visit_exec_stmt(self, o: 'mypy.nodes.ExecStmt') -> str:
         return self.dump([o.expr, o.variables1, o.variables2], o)
 
     # Expressions
 
     # Simple expressions
 
-    def visit_int_expr(self, o):
+    def visit_int_expr(self, o: 'mypy.nodes.IntExpr') -> str:
         return 'IntExpr({})'.format(o.value)
 
-    def visit_str_expr(self, o):
+    def visit_str_expr(self, o: 'mypy.nodes.StrExpr') -> str:
         return 'StrExpr({})'.format(self.str_repr(o.value))
 
-    def visit_bytes_expr(self, o):
+    def visit_bytes_expr(self, o: 'mypy.nodes.BytesExpr') -> str:
         return 'BytesExpr({})'.format(self.str_repr(o.value))
 
-    def visit_unicode_expr(self, o):
+    def visit_unicode_expr(self, o: 'mypy.nodes.UnicodeExpr') -> str:
         return 'UnicodeExpr({})'.format(self.str_repr(o.value))
 
     def str_repr(self, s):
@@ -309,24 +298,24 @@ class StrConv(NodeVisitor[str]):
         return re.sub('[^\\x20-\\x7e]',
                       lambda m: r'\u%.4x' % ord(m.group(0)), s)
 
-    def visit_float_expr(self, o):
+    def visit_float_expr(self, o: 'mypy.nodes.FloatExpr') -> str:
         return 'FloatExpr({})'.format(o.value)
 
-    def visit_complex_expr(self, o):
+    def visit_complex_expr(self, o: 'mypy.nodes.ComplexExpr') -> str:
         return 'ComplexExpr({})'.format(o.value)
 
-    def visit_ellipsis(self, o):
+    def visit_ellipsis(self, o: 'mypy.nodes.EllipsisExpr') -> str:
         return 'Ellipsis'
 
-    def visit_star_expr(self, o):
+    def visit_star_expr(self, o: 'mypy.nodes.StarExpr') -> str:
         return self.dump([o.expr], o)
 
-    def visit_name_expr(self, o):
+    def visit_name_expr(self, o: 'mypy.nodes.NameExpr') -> str:
         return (short_type(o) + '(' + self.pretty_name(o.name, o.kind,
                                                        o.fullname, o.is_def)
                 + ')')
 
-    def pretty_name(self, name, kind, fullname, is_def):
+    def pretty_name(self, name: str, kind: int, fullname: str, is_def: bool) -> str:
         n = name
         if is_def:
             n += '*'
@@ -342,21 +331,24 @@ class StrConv(NodeVisitor[str]):
             n += ' [m]'
         return n
 
-    def visit_member_expr(self, o):
+    def visit_member_expr(self, o: 'mypy.nodes.MemberExpr') -> str:
         return self.dump([o.expr, self.pretty_name(o.name, o.kind, o.fullname,
                                                    o.is_def)], o)
 
-    def visit_yield_from_expr(self, o):
+    def visit_yield_expr(self, o: 'mypy.nodes.YieldExpr') -> str:
+        return self.dump([o.expr], o)
+
+    def visit_yield_from_expr(self, o: 'mypy.nodes.YieldFromExpr') -> str:
         if o.expr:
             return self.dump([o.expr.accept(self)], o)
         else:
             return self.dump([], o)
 
-    def visit_call_expr(self, o):
+    def visit_call_expr(self, o: 'mypy.nodes.CallExpr') -> str:
         if o.analyzed:
             return o.analyzed.accept(self)
-        args = []
-        extra = []
+        args = []  # type: List[mypy.nodes.Node]
+        extra = []  # type: List[Union[str, Tuple[str, List[Any]]]]
         for i, kind in enumerate(o.arg_kinds):
             if kind in [mypy.nodes.ARG_POS, mypy.nodes.ARG_STAR]:
                 args.append(o.args[i])
@@ -368,50 +360,50 @@ class StrConv(NodeVisitor[str]):
                 extra.append(('DictVarArg', [o.args[i]]))
             else:
                 raise RuntimeError('unknown kind %d' % kind)
+        a = [o.callee, ('Args', args)]  # type: List[Any]
+        return self.dump(a + extra, o)
 
-        return self.dump([o.callee, ('Args', args)] + extra, o)
-
-    def visit_op_expr(self, o):
+    def visit_op_expr(self, o: 'mypy.nodes.OpExpr') -> str:
         return self.dump([o.op, o.left, o.right], o)
 
-    def visit_comparison_expr(self, o):
+    def visit_comparison_expr(self, o: 'mypy.nodes.ComparisonExpr') -> str:
         return self.dump([o.operators, o.operands], o)
 
-    def visit_cast_expr(self, o):
+    def visit_cast_expr(self, o: 'mypy.nodes.CastExpr') -> str:
         return self.dump([o.expr, o.type], o)
 
-    def visit_reveal_type_expr(self, o):
+    def visit_reveal_type_expr(self, o: 'mypy.nodes.RevealTypeExpr') -> str:
         return self.dump([o.expr], o)
 
-    def visit_unary_expr(self, o):
+    def visit_unary_expr(self, o: 'mypy.nodes.UnaryExpr') -> str:
         return self.dump([o.op, o.expr], o)
 
-    def visit_list_expr(self, o):
+    def visit_list_expr(self, o: 'mypy.nodes.ListExpr') -> str:
         return self.dump(o.items, o)
 
-    def visit_dict_expr(self, o):
+    def visit_dict_expr(self, o: 'mypy.nodes.DictExpr') -> str:
         return self.dump([[k, v] for k, v in o.items], o)
 
-    def visit_set_expr(self, o):
+    def visit_set_expr(self, o: 'mypy.nodes.SetExpr') -> str:
         return self.dump(o.items, o)
 
-    def visit_tuple_expr(self, o):
+    def visit_tuple_expr(self, o: 'mypy.nodes.TupleExpr') -> str:
         return self.dump(o.items, o)
 
-    def visit_index_expr(self, o):
+    def visit_index_expr(self, o: 'mypy.nodes.IndexExpr') -> str:
         if o.analyzed:
             return o.analyzed.accept(self)
         return self.dump([o.base, o.index], o)
 
-    def visit_super_expr(self, o):
+    def visit_super_expr(self, o: 'mypy.nodes.SuperExpr') -> str:
         return self.dump([o.name], o)
 
-    def visit_type_application(self, o):
+    def visit_type_application(self, o: 'mypy.nodes.TypeApplication') -> str:
         return self.dump([o.expr, ('Types', o.types)], o)
 
-    def visit_type_var_expr(self, o):
+    def visit_type_var_expr(self, o: 'mypy.nodes.TypeVarExpr') -> str:
         import mypy.types
-        a = []
+        a = []  # type: List[Any]
         if o.variance == mypy.nodes.COVARIANT:
             a += ['Variance(COVARIANT)']
         if o.variance == mypy.nodes.CONTRAVARIANT:
@@ -422,48 +414,49 @@ class StrConv(NodeVisitor[str]):
             a += ['UpperBound({})'.format(o.upper_bound)]
         return self.dump(a, o)
 
-    def visit_type_alias_expr(self, o):
+    def visit_type_alias_expr(self, o: 'mypy.nodes.TypeAliasExpr') -> str:
         return 'TypeAliasExpr({})'.format(o.type)
 
-    def visit_namedtuple_expr(self, o):
+    def visit_namedtuple_expr(self, o: 'mypy.nodes.NamedTupleExpr') -> str:
         return 'NamedTupleExpr:{}({}, {})'.format(o.line,
                                                   o.info.name(),
                                                   o.info.tuple_type)
 
-    def visit__promote_expr(self, o):
+    def visit__promote_expr(self, o: 'mypy.nodes.PromoteExpr') -> str:
         return 'PromoteExpr:{}({})'.format(o.line, o.type)
 
-    def visit_newtype_expr(self, o):
-        return 'NewTypeExpr:{}({}, {})'.format(o.line, o.fullname(), self.dump([o.value], o))
+    def visit_newtype_expr(self, o: 'mypy.nodes.NewTypeExpr') -> str:
+        return 'NewTypeExpr:{}({}, {})'.format(o.line, o.name,
+                                               self.dump([o.old_type], o))
 
-    def visit_func_expr(self, o):
+    def visit_func_expr(self, o: 'mypy.nodes.FuncExpr') -> str:
         a = self.func_helper(o)
         return self.dump(a, o)
 
-    def visit_generator_expr(self, o):
+    def visit_generator_expr(self, o: 'mypy.nodes.GeneratorExpr') -> str:
         condlists = o.condlists if any(o.condlists) else None
         return self.dump([o.left_expr, o.indices, o.sequences, condlists], o)
 
-    def visit_list_comprehension(self, o):
+    def visit_list_comprehension(self, o: 'mypy.nodes.ListComprehension') -> str:
         return self.dump([o.generator], o)
 
-    def visit_set_comprehension(self, o):
+    def visit_set_comprehension(self, o: 'mypy.nodes.SetComprehension') -> str:
         return self.dump([o.generator], o)
 
-    def visit_dictionary_comprehension(self, o):
+    def visit_dictionary_comprehension(self, o: 'mypy.nodes.DictionaryComprehension') -> str:
         condlists = o.condlists if any(o.condlists) else None
         return self.dump([o.key, o.value, o.indices, o.sequences, condlists], o)
 
-    def visit_conditional_expr(self, o):
+    def visit_conditional_expr(self, o: 'mypy.nodes.ConditionalExpr') -> str:
         return self.dump([('Condition', [o.cond]), o.if_expr, o.else_expr], o)
 
-    def visit_slice_expr(self, o):
-        a = [o.begin_index, o.end_index, o.stride]
+    def visit_slice_expr(self, o: 'mypy.nodes.SliceExpr') -> str:
+        a = [o.begin_index, o.end_index, o.stride]  # type: List[Any]
         if not a[0]:
             a[0] = '<empty>'
         if not a[1]:
             a[1] = '<empty>'
         return self.dump(a, o)
 
-    def visit_backquote_expr(self, o):
+    def visit_backquote_expr(self, o: 'mypy.nodes.BackquoteExpr') -> str:
         return self.dump([o.expr], o)

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -484,7 +484,9 @@ class TransformVisitor(NodeVisitor[Node]):
         return TypeAliasExpr(node.type)
 
     def visit_newtype_expr(self, node: NewTypeExpr) -> NewTypeExpr:
-        return NewTypeExpr(node.info)
+        res = NewTypeExpr(node.name, node.old_type, line=node.line)
+        res.info = node.info
+        return res
 
     def visit_namedtuple_expr(self, node: NamedTupleExpr) -> Node:
         return NamedTupleExpr(node.info)


### PR DESCRIPTION
I am not sure that's the best string representation for `NewType`.

I strongly feel that composing `TypeInfo` in subclasses of `nodes.Node` make them non-cohesive. This mapping should be external.