### PR TITLE
Fix #2070 - bytes formatting incorrect in python 3

### DIFF
--- a/docs/source/cheat_sheet.rst
+++ b/docs/source/cheat_sheet.rst
@@ -175,8 +175,9 @@ Other stuff
 
 .. code-block:: python
 
+   import sys
    # typing.Match describes regex matches from the re module.
-   from typing import Match, AnyStr
+   from typing import Match, AnyStr, IO
    x = re.match(r'[0-9]+', "15") # type: Match[str]
 
    # Use AnyStr for functions that should accept any kind of string
@@ -186,7 +187,16 @@ Other stuff
    concat(u"foo", u"bar")  # type: unicode
    concat(b"foo", b"bar")  # type: bytes
 
-   # TODO: add typing.IO: e.g., sys.stdout has type IO[str]
+   # Use IO[] for functions that should accept or return any
+   # object that comes from an open() call. The IO[] does not
+   # distinguish between reading, writing or other modes.
+   def get_sys_IO(mode='w') -> IO[str]:
+       if mode == 'w':
+           return sys.stdout
+       elif mode == 'r':
+           return sys.stdin
+       else:
+           return sys.stdout
 
    # TODO: add TypeVar and a simple generic function
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -966,7 +966,7 @@ class ExpressionChecker:
             # Expressions of form [...] * e get special type inference.
             return self.check_list_multiply(e)
         if e.op == '%':
-            if isinstance(e.left, (StrExpr, BytesExpr, UnicodeExpr,)):
+            if isinstance(e.left, (StrExpr, BytesExpr, UnicodeExpr)):
                 return self.strfrm_checker.check_str_interpolation(e.left, e.right)
         left_type = self.accept(e.left)
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -966,10 +966,7 @@ class ExpressionChecker:
             # Expressions of form [...] * e get special type inference.
             return self.check_list_multiply(e)
         if e.op == '%':
-            if isinstance(e.left, BytesExpr):
-                return self.strfrm_checker.check_byte_interpolation(e.left, e.right)
-            elif isinstance(e.left, StrExpr):
-                return self.strfrm_checker.check_str_interpolation(cast(StrExpr, e.left), e.right)
+            return self.strfrm_checker.check_str_interpolation(e.left, e.right)
         left_type = self.accept(e.left)
 
         if e.op in nodes.op_methods:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -966,7 +966,8 @@ class ExpressionChecker:
             # Expressions of form [...] * e get special type inference.
             return self.check_list_multiply(e)
         if e.op == '%':
-            return self.strfrm_checker.check_str_interpolation(e.left, e.right)
+            if isinstance(e.left, (StrExpr, BytesExpr, UnicodeExpr,)):
+                return self.strfrm_checker.check_str_interpolation(e.left, e.right)
         left_type = self.accept(e.left)
 
         if e.op in nodes.op_methods:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -965,8 +965,11 @@ class ExpressionChecker:
         if e.op == '*' and isinstance(e.left, ListExpr):
             # Expressions of form [...] * e get special type inference.
             return self.check_list_multiply(e)
-        if e.op == '%' and isinstance(e.left, (StrExpr, BytesExpr)):
-            return self.strfrm_checker.check_str_interpolation(cast(StrExpr, e.left), e.right)
+        if e.op == '%':
+            if isinstance(e.left, BytesExpr):
+                return self.strfrm_checker.check_byte_interpolation(e.left, e.right)
+            elif isinstance(e.left, StrExpr):
+                return self.strfrm_checker.check_str_interpolation(cast(StrExpr, e.left), e.right)
         left_type = self.accept(e.left)
 
         if e.op in nodes.op_methods:

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -77,8 +77,10 @@ class StringFormatterChecker:
             return self.named_type('builtins.bytes')
         elif isinstance(str, UnicodeExpr):
             return self.named_type('builtins.unicode')
-        else:
+        elif isinstance(str, StrExpr):
             return self.named_type('builtins.str')
+        else:
+            assert False
 
     def parse_conversion_specifiers(self, format: str) -> List[ConversionSpecifier]:
         key_regex = r'(\(([^()]*)\))?'  # (optional) parenthesised sequence of characters

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -55,6 +55,8 @@ class StringFormatterChecker:
         self.exprchk = exprchk
         self.msg = msg
 
+    # TODO: In Python 3, the bytes formatting has a more restricted set of options compared to string formatting
+    # TODO: Bytes formatting in Python 3 is only supported in 3.5 and up
     def check_str_interpolation(self, str: Union[StrExpr, BytesExpr, UnicodeExpr], replacements: Node) -> Type:
         """Check the types of the 'replacements' in a string interpolation
         expression: str % replacements

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -55,9 +55,12 @@ class StringFormatterChecker:
         self.exprchk = exprchk
         self.msg = msg
 
-    # TODO: In Python 3, the bytes formatting has a more restricted set of options compared to string formatting
+    # TODO: In Python 3, the bytes formatting has a more restricted set of options compared to
+    #  string formatting
     # TODO: Bytes formatting in Python 3 is only supported in 3.5 and up
-    def check_str_interpolation(self, str: Union[StrExpr, BytesExpr, UnicodeExpr], replacements: Node) -> Type:
+    def check_str_interpolation(self,
+                                str: Union[StrExpr, BytesExpr, UnicodeExpr],
+                                replacements: Node) -> Type:
         """Check the types of the 'replacements' in a string interpolation
         expression: str % replacements
         """

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -55,6 +55,20 @@ class StringFormatterChecker:
         self.exprchk = exprchk
         self.msg = msg
 
+    def check_byte_interpolation(self, str: StrExpr, replacements: Node) -> Type:
+        """Check the types of the 'replacements' in a string interpolation
+        expression: str % replacements
+        """
+        specifiers = self.parse_conversion_specifiers(str.value)
+        has_mapping_keys = self.analyze_conversion_specifiers(specifiers, str)
+        if has_mapping_keys is None:
+            pass  # Error was reported
+        elif has_mapping_keys:
+            self.check_mapping_str_interpolation(specifiers, replacements)
+        else:
+            self.check_simple_str_interpolation(specifiers, replacements)
+        return self.named_type('builtins.bytes')
+
     def check_str_interpolation(self, str: StrExpr, replacements: Node) -> Type:
         """Check the types of the 'replacements' in a string interpolation
         expression: str % replacements

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -55,7 +55,7 @@ class StringFormatterChecker:
         self.exprchk = exprchk
         self.msg = msg
 
-    def check_byte_interpolation(self, str: StrExpr, replacements: Node) -> Type:
+    def check_byte_interpolation(self, str: BytesExpr, replacements: Node) -> Type:
         """Check the types of the 'replacements' in a string interpolation
         expression: str % replacements
         """

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -55,9 +55,9 @@ class StringFormatterChecker:
         self.exprchk = exprchk
         self.msg = msg
 
-    # TODO: In Python 3, the bytes formatting has a more restricted set of options compared to
-    #  string formatting
-    # TODO: Bytes formatting in Python 3 is only supported in 3.5 and up
+    # TODO: In Python 3, the bytes formatting has a more restricted set of options
+    # compared to string formatting.
+    # TODO: Bytes formatting in Python 3 is only supported in 3.5 and up.
     def check_str_interpolation(self,
                                 str: Union[StrExpr, BytesExpr, UnicodeExpr],
                                 replacements: Node) -> Type:

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1121,6 +1121,9 @@ b'%s' % (b'xyz',)
 b'%(name)s' % {'name': 'jane'}
 b'%c' % (123)
 
+[case testUnicodeInterpolation_python2]
+u'%s' % (u'abc',)
+
 -- Lambdas
 -- -------
 

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1111,6 +1111,16 @@ main:4: error: Incompatible types in string interpolation (expression has type "
 [case testStringInterpolationSpaceKey]
 '%( )s' % {' ': 'foo'}
 
+[case testByteByteInterpolation]
+def foo(a: bytes, b: bytes):
+    b'%s:%s' % (a, b)
+foo(b'a', b'b') == b'a:b'
+
+[case testBytePercentInterpolationSupported]
+b'%s' % (b'xyz',)
+b'%(name)s' % {'name': 'jane'}
+b'%c' % (123)
+
 -- Lambdas
 -- -------
 


### PR DESCRIPTION
This pull request aims to fix the type checking of bytes strings. The code previously used a single path for both bytes and strings, which broke the example given in the bug (#2070) that expected a bytes output to a function for example. This pull request creates a separate method for handling bytes in the same pattern as strings, but with the correct type output.
At the time the pull request is created, there may be some errors in the types of inputs into the bytes % interpolation because it is using the type checking logic for string interpolation.