### PR TITLE
Add recursive and lenient modes to stub generation

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -69,7 +69,8 @@ Options = NamedTuple('Options', [('pyversion', Tuple[int, int]),
                                  ('interpreter', str),
                                  ('modules', List[str]),
                                  ('ignore_errors', bool),
-                                 ('recursive', bool)])
+                                 ('recursive', bool),
+                                ])
 
 
 def generate_stub_for_module(module: str, output_dir: str, quiet: bool = False,
@@ -618,7 +619,7 @@ def main() -> None:
             if not options.ignore_errors:
                 raise e
             else:
-                print("Stub generation failed for : ", module)
+                print("Stub generation failed for", module, file=sys.stderr)
 
 
 def parse_options() -> Options:


### PR DESCRIPTION
This is something I personally use for stub generation: whenever stubgen'ing a packages, you'll often want to generate modules inside of it. 

If you pass in `--recursive`, then you'll generate stubs for provided modules _and_ its included modules if its a package. 

Also included is `--lenient`. This will ignore exceptions (just printing a warning) when some module gens fail. This will let you stubgen for larger modules, even if they include some issues. I was having trouble using `--recursive` without this.