### PR TITLE
Bare `Tuple` should mean `Tuple[Any, ...]`.

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -833,12 +833,15 @@ class TypeConverter(ast35.NodeTransformer):
         assert isinstance(value, UnboundType)
         assert not value.args
 
+        empty_tuple_index = False
         if isinstance(n.slice.value, ast35.Tuple):
             params = self.visit_list(n.slice.value.elts)
+            if len(n.slice.value.elts) == 0:
+                empty_tuple_index = True
         else:
             params = [self.visit(n.slice.value)]
 
-        return UnboundType(value.name, params, line=self.line)
+        return UnboundType(value.name, params, line=self.line, empty_tuple_index=empty_tuple_index)
 
     def visit_Tuple(self, n: ast35.Tuple) -> Type:
         return TupleType(self.visit_list(n.elts), None, implicit=True, line=self.line)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -109,7 +109,7 @@ class TypeAnalyser(TypeVisitor[Type]):
             elif fullname == 'typing.Tuple':
                 if len(t.args) == 0 and not t.empty_tuple_index:
                     # Bare 'Tuple' is same as 'tuple'
-                    return self.builtin_type('builtins.tuple', [AnyType()])
+                    return self.builtin_type('builtins.tuple')
                 if len(t.args) == 2 and isinstance(t.args[1], EllipsisType):
                     # Tuple[T, ...] (uniform, variable-length tuple)
                     node = self.lookup_fqn_func('builtins.tuple')

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -107,7 +107,8 @@ class TypeAnalyser(TypeVisitor[Type]):
             elif fullname == 'typing.Any':
                 return AnyType()
             elif fullname == 'typing.Tuple':
-                if len(t.args) == 0:  # Bare 'Tuple' is same as 'tuple'
+                if len(t.args) == 0 and not t.empty_tuple_index:
+                    # Bare 'Tuple' is same as 'tuple'
                     return self.builtin_type('builtins.tuple', [AnyType()])
                 if len(t.args) == 2 and isinstance(t.args[1], EllipsisType):
                     # Tuple[T, ...] (uniform, variable-length tuple)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -107,6 +107,8 @@ class TypeAnalyser(TypeVisitor[Type]):
             elif fullname == 'typing.Any':
                 return AnyType()
             elif fullname == 'typing.Tuple':
+                if len(t.args) == 0:  # Bare 'Tuple' is same as 'tuple'
+                    return self.builtin_type('builtins.tuple', [AnyType()])
                 if len(t.args) == 2 and isinstance(t.args[1], EllipsisType):
                     # Tuple[T, ...] (uniform, variable-length tuple)
                     node = self.lookup_fqn_func('builtins.tuple')

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -181,6 +181,8 @@ class UnboundType(Type):
     optional = False
     # is this type a return type?
     is_ret_type = False
+    # special case for X[()]
+    empty_tuple_index = False
 
     def __init__(self,
                  name: str,
@@ -188,13 +190,15 @@ class UnboundType(Type):
                  line: int = -1,
                  column: int = -1,
                  optional: bool = False,
-                 is_ret_type: bool = False) -> None:
+                 is_ret_type: bool = False,
+                 empty_tuple_index: bool = False) -> None:
         if not args:
             args = []
         self.name = name
         self.args = args
         self.optional = optional
         self.is_ret_type = is_ret_type
+        self.empty_tuple_index = empty_tuple_index
         super().__init__(line, column)
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -820,3 +820,20 @@ from typing import List, Tuple
 def f() -> Tuple[List[str], ...]:
     return ([],)
 [builtins fixtures/tuple.pyi]
+
+[case testTupleWithoutArgs]
+from typing import Tuple
+def f(a: Tuple) -> None: pass
+f(())
+f((1,))
+f(('', ''))
+[builtins fixtures/tuple.pyi]
+
+[case testTupleSingleton]
+# flags: --fast-parser
+from typing import Tuple
+def f(a: Tuple[()]) -> None: pass
+f(())
+f((1,))  # E
+f(('', ''))  # #
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -827,6 +827,7 @@ def f(a: Tuple) -> None: pass
 f(())
 f((1,))
 f(('', ''))
+f(0)  # E: Argument 1 to "f" has incompatible type "int"; expected Tuple[Any, ...]
 [builtins fixtures/tuple.pyi]
 
 [case testTupleSingleton]
@@ -834,6 +835,7 @@ f(('', ''))
 from typing import Tuple
 def f(a: Tuple[()]) -> None: pass
 f(())
-f((1,))  # E
-f(('', ''))  # #
+f((1,))  # E: Argument 1 to "f" has incompatible type "Tuple[int]"; expected "Tuple[]"
+f(('', ''))  # E: Argument 1 to "f" has incompatible type "Tuple[str, str]"; expected "Tuple[]"
+f(0)  # E: Argument 1 to "f" has incompatible type "int"; expected "Tuple[]"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -25,5 +25,3 @@ T = TypeVar('T')
 class list(Sequence[T], Generic[T]): pass
 
 def sum(iterable: Iterable[T], start: T = None) -> T: pass
-
-True = bool()


### PR DESCRIPTION
Fix #2184. (See also python/typing#284.)