### PR TITLE
Change the representation of the empty Tuple type from Tuple[] to Tuple[()]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
   - python setup.py install
 
 script:
-  - python runtests.py -v
+  - python runtests.py

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -247,6 +247,8 @@ class MessageBuilder:
             # Prefer the name of the fallback class (if not tuple), as it's more informative.
             if typ.fallback.type.fullname() != 'builtins.tuple':
                 return self.format_simple(typ.fallback)
+            if not typ.items:
+                return '"Tuple[()]"'  # Avoid "Tuple[]"
             items = []
             for t in typ.items:
                 items.append(strip_quotes(self.format(t)))
@@ -492,6 +494,7 @@ class MessageBuilder:
             except IndexError:  # Varargs callees
                 expected_type = callee.arg_types[-1]
             arg_type_str, expected_type_str = self.format_distinctly(arg_type, expected_type)
+            if 'Tuple[]' in expected_type_str: import pdb; pdb.set_trace()
             if arg_kind == ARG_STAR:
                 arg_type_str = '*' + arg_type_str
             elif arg_kind == ARG_STAR2:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -494,7 +494,6 @@ class MessageBuilder:
             except IndexError:  # Varargs callees
                 expected_type = callee.arg_types[-1]
             arg_type_str, expected_type_str = self.format_distinctly(arg_type, expected_type)
-            if 'Tuple[]' in expected_type_str: import pdb; pdb.set_trace()
             if arg_kind == ARG_STAR:
                 arg_type_str = '*' + arg_type_str
             elif arg_kind == ARG_STAR2:

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -73,7 +73,7 @@ class TypesSuite(Suite):
         assert_equal(str(c3), 'def (X? =, *Y?) -> Any')
 
     def test_tuple_type(self):
-        assert_equal(str(TupleType([], None)), 'Tuple[]')
+        assert_equal(str(TupleType([], None)), 'Tuple[()]')
         assert_equal(str(TupleType([self.x], None)), 'Tuple[X?]')
         assert_equal(str(TupleType([self.x, AnyType()], None)), 'Tuple[X?, Any]')
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1277,7 +1277,10 @@ class TypeStrVisitor(TypeVisitor[str]):
         return 'Overload({})'.format(', '.join(a))
 
     def visit_tuple_type(self, t: TupleType) -> str:
-        s = self.list_str(t.items)
+        if not t.items:
+            s = '()'
+        else:
+            s = self.list_str(t.items)
         if t.fallback and t.fallback.type:
             fallback_name = t.fallback.type.fullname()
             if fallback_name != 'builtins.tuple':

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -489,7 +489,7 @@ def f(x: str) -> None: pass
 f(1.1)
 f('')
 f(1)
-f(()) # E: No overload variant of "f" matches argument types [Tuple[]]
+f(()) # E: No overload variant of "f" matches argument types [Tuple[()]]
 [builtins fixtures/primitives.pyi]
 [out]
 

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -117,7 +117,7 @@ t3 = None # type: Tuple[A, B]
 
 a, b, c = None, None, None # type: (A, B, C)
 
-t2 = ()        # E: Incompatible types in assignment (expression has type "Tuple[]", variable has type "Tuple[A]")
+t2 = ()        # E: Incompatible types in assignment (expression has type "Tuple[()]", variable has type "Tuple[A]")
 t2 = (a, a)    # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A]")
 t3 = (a, a)    # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A, B]")
 t3 = (b, b)    # E: Incompatible types in assignment (expression has type "Tuple[B, B]", variable has type "Tuple[A, B]")
@@ -835,7 +835,7 @@ f(0)  # E: Argument 1 to "f" has incompatible type "int"; expected Tuple[Any, ..
 from typing import Tuple
 def f(a: Tuple[()]) -> None: pass
 f(())
-f((1,))  # E: Argument 1 to "f" has incompatible type "Tuple[int]"; expected "Tuple[]"
-f(('', ''))  # E: Argument 1 to "f" has incompatible type "Tuple[str, str]"; expected "Tuple[]"
-f(0)  # E: Argument 1 to "f" has incompatible type "int"; expected "Tuple[]"
+f((1,))  # E: Argument 1 to "f" has incompatible type "Tuple[int]"; expected "Tuple[()]"
+f(('', ''))  # E: Argument 1 to "f" has incompatible type "Tuple[str, str]"; expected "Tuple[()]"
+f(0)  # E: Argument 1 to "f" has incompatible type "int"; expected "Tuple[()]"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -11,7 +11,7 @@ U = Union[int, str]
 def f(x: U) -> None: pass
 f(1)
 f('')
-f(()) # E: Argument 1 to "f" has incompatible type "Tuple[]"; expected "Union[int, str]"
+f(()) # E: Argument 1 to "f" has incompatible type "Tuple[()]"; expected "Union[int, str]"
 
 [case testTupleTypeAlias]
 from typing import Tuple
@@ -50,7 +50,7 @@ from _m import U
 def f(x: U) -> None: pass
 f(1)
 f('x')
-f(()) # E: Argument 1 to "f" has incompatible type "Tuple[]"; expected "Union[int, str]"
+f(()) # E: Argument 1 to "f" has incompatible type "Tuple[()]"; expected "Union[int, str]"
 [file _m.py]
 from typing import Union
 U = Union[int, str]

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -271,8 +271,8 @@ import typing
 x = ()
 [builtins fixtures/primitives.pyi]
 [out]
-NameExpr(2) : Tuple[]
-TupleExpr(2) : Tuple[]
+NameExpr(2) : Tuple[()]
+TupleExpr(2) : Tuple[()]
 
 [case testInferTwoTypes]
 ## NameExpr
@@ -290,8 +290,8 @@ def f() -> None:
     x = ()
 [builtins fixtures/primitives.pyi]
 [out]
-NameExpr(3) : Tuple[]
-TupleExpr(3) : Tuple[]
+NameExpr(3) : Tuple[()]
+TupleExpr(3) : Tuple[()]
 
 
 -- Basic generics


### PR DESCRIPTION
@JukkaL Thought I'd at least make a PR out of this so you can decide for yourself whether you like this or not. Personally I think it's less readable than Tuple[] even though that's not syntactically correct. If you agree, just close the PR and I'll delete my branch.