### PR TITLE
Small module name translation fix for fast parser

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -496,7 +496,17 @@ class ASTConverter(ast35.NodeTransformer):
     # Import(alias* names)
     @with_line
     def visit_Import(self, n: ast35.Import) -> Node:
-        i = Import([(self.translate_module_id(a.name), a.asname) for a in n.names])
+        names = []  # type: List[Tuple[str, str]]
+        for alias in n.names:
+            name = self.translate_module_id(alias.name)
+            asname = alias.asname
+            if asname is None and name != alias.name:
+                # if the module name has been translated (and it's not already
+                # an explicit import-as), make it an implicit import-as the
+                # original name
+                asname = alias.name
+            names.append((name, asname))
+        i = Import(names)
         self.imports.append(i)
         return i
 

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -572,7 +572,17 @@ class ASTConverter(ast27.NodeTransformer):
     # Import(alias* names)
     @with_line
     def visit_Import(self, n: ast27.Import) -> Node:
-        i = Import([(self.translate_module_id(a.name), a.asname) for a in n.names])
+        names = []  # type: List[Tuple[str, str]]
+        for alias in n.names:
+            name = self.translate_module_id(alias.name)
+            asname = alias.asname
+            if asname is None and name != alias.name:
+                # if the module name has been translated (and it's not already
+                # an explicit import-as), make it an implicit import-as the
+                # original name
+                asname = alias.name
+            names.append((name, asname))
+        i = Import(names)
         self.imports.append(i)
         return i
 

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -213,3 +213,8 @@ def bar(key: Callable[[Tuple[int, int]], int]) -> int:
 def foo() -> int:
     return bar(key=lambda (a, b): a)
 [out]
+
+[case testImportBuiltins]
+# flags: --fast-parser
+import __builtin__
+__builtin__.str


### PR DESCRIPTION
When a module name is translated as part of an import, it should be
treated as an implicit import-as if it's not already an explicit one.
This behavior was present in the old parser, but not the new one.  This
PR fixes that.

Fixes #2174.