### PR TITLE
Fix overzealous new submodule check

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1536,6 +1536,7 @@ def load_graph(sources: List[BuildSource], manager: BuildManager) -> Graph:
     for id, g in graph.items():
         if g.has_new_submodules():
             g.parse_file()
+            g.fix_suppressed_dependencies(graph)
             g.mark_interface_stale()
     return graph
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1567,3 +1567,26 @@ class Outer:
 [out2]
 main:1: note: In module imported here:
 tmp/foo.py:3: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
+
+[case testIncrementalPartialSubmoduleUpdate]
+# cmd: mypy -m a
+# cmd2: mypy -m a a.c
+# flags: --silent-imports
+
+[file a/__init__.py]
+from .b import B
+from .c import C
+
+[file a/b.py]
+class B: pass
+
+[file a/c.py]
+class C: pass
+
+[file a/c.py.next]
+class C: pass
+pass
+
+[rechecked a, a.c]
+[stale a, a.c]
+[out]


### PR DESCRIPTION
Fixes #2028?

Previously, when mypy detected a module acquired a new submodule after running mypy once in incremental, mypy would attempt to parse the module from scratch (if it hadn't already previously been parsed) which, as a side-effect, would find all of the child modules and load them as dependencies of the top-level module.

While this works in the usual case, this check made the flawed assumption that we would want to actually record/acknowledge every single new submodule that was created.

This assumption is not necessarily true when using --silent-imports -- it may be the case that we only want to record a _subset_ of the new submodules that were created, depending on what exactly the command line flags were.