### PR TITLE
Rename --suppress-error-context to --hide-error-context

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -13,7 +13,7 @@ flag (or its long form ``--help``)::
               [--disallow-untyped-defs] [--check-untyped-defs]
               [--disallow-subclassing-any] [--warn-incomplete-stub]
               [--warn-redundant-casts] [--warn-unused-ignores]
-              [--suppress-error-context] [--fast-parser] [-i]
+              [--hide-error-context] [--fast-parser] [-i]
               [--cache-dir DIR] [--strict-optional]
               [--strict-optional-whitelist [GLOB [GLOB ...]]] [--pdb]
               [--show-traceback] [--stats] [--inferstats]

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -87,7 +87,7 @@ The following global flags may only be set in the global section
 - ``cache_dir`` (string, default ``.mypy_cache``) stores module cache
   info in the given folder in incremental mode.
 
-- ``suppress_error_context`` (Boolean, default False) suppresses
+- ``hide_error_context`` (Boolean, default False) hides
   context notes before errors.
 
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -343,7 +343,7 @@ class BuildManager:
                  version_id: str) -> None:
         self.start_time = time.time()
         self.data_dir = data_dir
-        self.errors = Errors(options.suppress_error_context, options.show_column_numbers)
+        self.errors = Errors(options.hide_error_context, options.show_column_numbers)
         self.errors.set_ignore_prefix(ignore_prefix)
         self.lib_path = tuple(lib_path)
         self.source_set = source_set

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -94,12 +94,12 @@ class Errors:
     only_once_messages = None  # type: Set[str]
 
     # Set to True to suppress "In function "foo":" messages.
-    suppress_error_context = False  # type: bool
+    hide_error_context = False  # type: bool
 
     # Set to True to show column numbers in error messages
     show_column_numbers = False  # type: bool
 
-    def __init__(self, suppress_error_context: bool = False,
+    def __init__(self, hide_error_context: bool = False,
                  show_column_numbers: bool = False) -> None:
         self.error_info = []
         self.import_ctx = []
@@ -108,11 +108,11 @@ class Errors:
         self.ignored_lines = OrderedDict()
         self.used_ignored_lines = defaultdict(set)
         self.only_once_messages = set()
-        self.suppress_error_context = suppress_error_context
+        self.hide_error_context = hide_error_context
         self.show_column_numbers = show_column_numbers
 
     def copy(self) -> 'Errors':
-        new = Errors(self.suppress_error_context, self.show_column_numbers)
+        new = Errors(self.hide_error_context, self.show_column_numbers)
         new.file = self.file
         new.import_ctx = self.import_ctx[:]
         new.type_name = self.type_name[:]
@@ -309,7 +309,7 @@ class Errors:
             file = self.simplify_path(e.file)
 
             # Report context within a source file.
-            if self.suppress_error_context:
+            if self.hide_error_context:
                 pass
             elif (e.function_or_member != prev_function_or_member or
                     e.type != prev_type):

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -166,9 +166,9 @@ def process_options(args: List[str],
                         help="warn about casting an expression to its inferred type")
     parser.add_argument('--warn-unused-ignores', action='store_true',
                         help="warn about unneeded '# type: ignore' comments")
-    parser.add_argument('--suppress-error-context', action='store_true',
-                        dest='suppress_error_context',
-                        help="Suppress context notes before errors")
+    parser.add_argument('--hide-error-context', action='store_true',
+                        dest='hide_error_context',
+                        help="Hide context notes before errors")
     parser.add_argument('--fast-parser', action='store_true',
                         help="enable experimental fast parser")
     parser.add_argument('-i', '--incremental', action='store_true',

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -98,7 +98,7 @@ class Options:
         self.incremental = False
         self.cache_dir = defaults.CACHE_DIR
         self.debug_cache = False
-        self.suppress_error_context = False  # Suppress "note: In function "foo":" messages.
+        self.hide_error_context = False  # Hide "note: In function "foo":" messages.
         self.shadow_file = None  # type: Optional[Tuple[str, str]]
         self.show_column_numbers = False  # type: bool
 

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -316,7 +316,7 @@ main: note: In function "f":
 -- ------------------------------------------
 
 [case testFullCoroutineMatrix]
-# flags: --fast-parser --suppress-error-context
+# flags: --fast-parser --hide-error-context
 from typing import Any, AsyncIterator, Awaitable, Generator, Iterator
 from types import coroutine
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -131,7 +131,7 @@ def f():
 # cmd: mypy x.py y.py z.py
 [file mypy.ini]
 [[mypy]
-suppress_error_context = True
+hide_error_context = True
 disallow_untyped_defs = True
 [[mypy-y*]
 disallow_untyped_defs = False
@@ -161,7 +161,7 @@ x.py:1: error: Function is missing a type annotation
 # cmd: mypy xx.py xy.py yx.py yy.py
 [file mypy.ini]
 [[mypy]
-suppress_error_context = True
+hide_error_context = True
 [[mypy-*x*.py]
 disallow_untyped_defs = True
 [[mypy-*y*.py]
@@ -190,7 +190,7 @@ xx.py:1: error: Function is missing a type annotation
 # cmd: mypy x.py y.py z.py
 [file mypy.ini]
 [[mypy]
-suppress_error_context = True
+hide_error_context = True
 [[mypy-x*py,z*py]
 disallow_untyped_defs = True
 [file x.py]


### PR DESCRIPTION
@ddfisher, #JukkaL What do you think about this? (I found an old internal doc describing conventions for mypy flag naming, and realized that suppress is just a really long word meaning hide, in this context).