### PR TITLE
Fix strict none errors in the test subpackage.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+show_none_errors = False
+
+[mypy-mypy/test/*]
+show_none_errors = True

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -770,7 +770,7 @@ def find_cache_meta(id: str, path: str, manager: BuildManager) -> Optional[Cache
     return m
 
 
-def is_meta_fresh(meta: CacheMeta, id: str, path: str, manager: BuildManager) -> bool:
+def is_meta_fresh(meta: Optional[CacheMeta], id: str, path: str, manager: BuildManager) -> bool:
     if meta is None:
         return False
 

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -53,11 +53,15 @@ def parse_test_cases(
             while i < len(p) and p[i].id != 'case':
                 if p[i].id == 'file':
                     # Record an extra file needed for the test case.
-                    files.append((os.path.join(base_path, p[i].arg or ''),
+                    arg = p[i].arg
+                    assert arg is not None
+                    files.append((os.path.join(base_path, arg),
                                   '\n'.join(p[i].data)))
                 elif p[i].id in ('builtins', 'builtins_py2'):
                     # Use a custom source file for the std module.
-                    mpath = os.path.join(os.path.dirname(path), p[i].arg or '')
+                    arg = p[i].arg
+                    assert arg is not None
+                    mpath = os.path.join(os.path.dirname(path), p[i].arg)
                     if p[i].id == 'builtins':
                         fnam = 'builtins.pyi'
                     else:

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -61,7 +61,7 @@ def parse_test_cases(
                     # Use a custom source file for the std module.
                     arg = p[i].arg
                     assert arg is not None
-                    mpath = os.path.join(os.path.dirname(path), p[i].arg)
+                    mpath = os.path.join(os.path.dirname(path), arg)
                     if p[i].id == 'builtins':
                         fnam = 'builtins.pyi'
                     else:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -560,7 +560,7 @@ class CallableType(FunctionLike):
     def __init__(self,
                  arg_types: List[Type],
                  arg_kinds: List[int],
-                 arg_names: List[str],
+                 arg_names: List[Optional[str]],
                  ret_type: Type,
                  fallback: Instance,
                  name: str = None,

--- a/runtests.py
+++ b/runtests.py
@@ -88,8 +88,8 @@ class Driver:
         args = list(itertools.chain(*(['-m', mod] for mod in modules)))
         self.add_mypy_cmd(name, args, cwd=cwd)
 
-    def add_mypy_package(self, name: str, packagename: str) -> None:
-        self.add_mypy_cmd(name, ['-p', packagename])
+    def add_mypy_package(self, name: str, packagename: str, *flags: str) -> None:
+        self.add_mypy_cmd(name, ['-p', packagename] + list(flags))
 
     def add_mypy_string(self, name: str, *args: str, cwd: Optional[str] = None) -> None:
         self.add_mypy_cmd(name, ['-c'] + list(args), cwd=cwd)
@@ -168,6 +168,7 @@ def add_basic(driver: Driver) -> None:
 
 def add_selftypecheck(driver: Driver) -> None:
     driver.add_mypy_package('package mypy', 'mypy')
+    driver.add_mypy_package('package mypy', 'mypy', '--strict-optional')
 
 
 def find_files(base: str, prefix: str = '', suffix: str = '') -> List[str]:


### PR DESCRIPTION
This shows several different approaches to dealing with #2199 for `p[i].arg`.

@ddfisher Thoughts? Maybe we can also commit a mypy.ini containing
```
[mypy]
show_none_errors = False
[mypy-*mypy/test/*]
show_none_errors = True
```