### PR TITLE
Tighter types for fastparse and fastparse2

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -14,11 +14,11 @@ from mypy.nodes import (
     UnaryExpr, FuncExpr, ComparisonExpr,
     StarExpr, YieldFromExpr, NonlocalDecl, DictionaryComprehension,
     SetComprehension, ComplexExpr, EllipsisExpr, YieldExpr, Argument,
-    AwaitExpr, TempNode,
+    AwaitExpr, TempNode, Expression, Statement,
     ARG_POS, ARG_OPT, ARG_STAR, ARG_NAMED, ARG_STAR2
 )
 from mypy.types import (
-    Type, CallableType, FunctionLike, AnyType, UnboundType, TupleType, TypeList, EllipsisType,
+    Type, CallableType, AnyType, UnboundType, TupleType, TypeList, EllipsisType,
 )
 from mypy import defaults
 from mypy import experiments
@@ -125,7 +125,7 @@ class ASTConverter(ast35.NodeTransformer):
     def visit_NoneType(self, n: Any) -> Optional[Node]:
         return None
 
-    def visit_list(self, l: Sequence[ast35.AST]) -> List[Node]:
+    def visit_list(self, l: Sequence[ast35.AST]) -> List[Expression]:
         return [self.visit(e) for e in l]
 
     op_map = {
@@ -180,8 +180,8 @@ class ASTConverter(ast35.NodeTransformer):
             b.set_line(lineno)
         return b
 
-    def fix_function_overloads(self, stmts: List[Node]) -> List[Node]:
-        ret = []  # type: List[Node]
+    def fix_function_overloads(self, stmts: List[Statement]) -> List[Statement]:
+        ret = []  # type: List[Statement]
         current_overload = []
         current_overload_name = None
         # mypy doesn't actually check that the decorator is literally @overload
@@ -224,7 +224,7 @@ class ASTConverter(ast35.NodeTransformer):
             return 'builtins'
         return id
 
-    def visit_Module(self, mod: ast35.Module) -> Node:
+    def visit_Module(self, mod: ast35.Module) -> MypyFile:
         body = self.fix_function_overloads(self.visit_list(mod.body))
 
         return MypyFile(body,
@@ -239,17 +239,17 @@ class ASTConverter(ast35.NodeTransformer):
     # arguments = (arg* args, arg? vararg, arg* kwonlyargs, expr* kw_defaults,
     #              arg? kwarg, expr* defaults)
     @with_line
-    def visit_FunctionDef(self, n: ast35.FunctionDef) -> Node:
+    def visit_FunctionDef(self, n: ast35.FunctionDef) -> Union[FuncDef, Decorator]:
         return self.do_func_def(n)
 
     # AsyncFunctionDef(identifier name, arguments args,
     #                  stmt* body, expr* decorator_list, expr? returns, string? type_comment)
     @with_line
-    def visit_AsyncFunctionDef(self, n: ast35.AsyncFunctionDef) -> Node:
+    def visit_AsyncFunctionDef(self, n: ast35.AsyncFunctionDef) -> Union[FuncDef, Decorator]:
         return self.do_func_def(n, is_coroutine=True)
 
     def do_func_def(self, n: Union[ast35.FunctionDef, ast35.AsyncFunctionDef],
-                    is_coroutine: bool = False) -> Node:
+                    is_coroutine: bool = False) -> Union[FuncDef, Decorator]:
         """Helper shared between visit_FunctionDef and visit_AsyncFunctionDef."""
         args = self.transform_args(n.args, n.lineno)
 
@@ -316,7 +316,7 @@ class ASTConverter(ast35.NodeTransformer):
         else:
             return func_def
 
-    def set_type_optional(self, type: Type, initializer: Node) -> None:
+    def set_type_optional(self, type: Type, initializer: Expression) -> None:
         if not experiments.STRICT_OPTIONAL:
             return
         # Indicate that type should be wrapped in an Optional if arg is initialized to None.
@@ -372,7 +372,7 @@ class ASTConverter(ast35.NodeTransformer):
     #  stmt* body,
     #  expr* decorator_list)
     @with_line
-    def visit_ClassDef(self, n: ast35.ClassDef) -> Node:
+    def visit_ClassDef(self, n: ast35.ClassDef) -> ClassDef:
         self.class_nesting += 1
         metaclass_arg = find(lambda x: x.arg == 'metaclass', n.keywords)
         metaclass = None
@@ -390,12 +390,12 @@ class ASTConverter(ast35.NodeTransformer):
 
     # Return(expr? value)
     @with_line
-    def visit_Return(self, n: ast35.Return) -> Node:
+    def visit_Return(self, n: ast35.Return) -> ReturnStmt:
         return ReturnStmt(self.visit(n.value))
 
     # Delete(expr* targets)
     @with_line
-    def visit_Delete(self, n: ast35.Delete) -> Node:
+    def visit_Delete(self, n: ast35.Delete) -> DelStmt:
         if len(n.targets) > 1:
             tup = TupleExpr(self.visit_list(n.targets))
             tup.set_line(n.lineno)
@@ -405,7 +405,7 @@ class ASTConverter(ast35.NodeTransformer):
 
     # Assign(expr* targets, expr? value, string? type_comment, expr? annotation)
     @with_line
-    def visit_Assign(self, n: ast35.Assign) -> Node:
+    def visit_Assign(self, n: ast35.Assign) -> AssignmentStmt:
         typ = None
         if hasattr(n, 'annotation') and n.annotation is not None:  # type: ignore
             new_syntax = True
@@ -421,7 +421,7 @@ class ASTConverter(ast35.NodeTransformer):
         elif new_syntax:
             typ = TypeConverter(line=n.lineno).visit(n.annotation)  # type: ignore
         if n.value is None:  # always allow 'x: int'
-            rvalue = TempNode(AnyType())  # type: Node
+            rvalue = TempNode(AnyType())  # type: Expression
         else:
             rvalue = self.visit(n.value)
         lvalues = self.visit_list(n.targets)
@@ -431,14 +431,14 @@ class ASTConverter(ast35.NodeTransformer):
 
     # AugAssign(expr target, operator op, expr value)
     @with_line
-    def visit_AugAssign(self, n: ast35.AugAssign) -> Node:
+    def visit_AugAssign(self, n: ast35.AugAssign) -> OperatorAssignmentStmt:
         return OperatorAssignmentStmt(self.from_operator(n.op),
                               self.visit(n.target),
                               self.visit(n.value))
 
     # For(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
     @with_line
-    def visit_For(self, n: ast35.For) -> Node:
+    def visit_For(self, n: ast35.For) -> ForStmt:
         return ForStmt(self.visit(n.target),
                        self.visit(n.iter),
                        self.as_block(n.body, n.lineno),
@@ -446,7 +446,7 @@ class ASTConverter(ast35.NodeTransformer):
 
     # AsyncFor(expr target, expr iter, stmt* body, stmt* orelse)
     @with_line
-    def visit_AsyncFor(self, n: ast35.AsyncFor) -> Node:
+    def visit_AsyncFor(self, n: ast35.AsyncFor) -> ForStmt:
         r = ForStmt(self.visit(n.target),
                     self.visit(n.iter),
                     self.as_block(n.body, n.lineno),
@@ -456,28 +456,28 @@ class ASTConverter(ast35.NodeTransformer):
 
     # While(expr test, stmt* body, stmt* orelse)
     @with_line
-    def visit_While(self, n: ast35.While) -> Node:
+    def visit_While(self, n: ast35.While) -> WhileStmt:
         return WhileStmt(self.visit(n.test),
                          self.as_block(n.body, n.lineno),
                          self.as_block(n.orelse, n.lineno))
 
     # If(expr test, stmt* body, stmt* orelse)
     @with_line
-    def visit_If(self, n: ast35.If) -> Node:
+    def visit_If(self, n: ast35.If) -> IfStmt:
         return IfStmt([self.visit(n.test)],
                       [self.as_block(n.body, n.lineno)],
                       self.as_block(n.orelse, n.lineno))
 
     # With(withitem* items, stmt* body, string? type_comment)
     @with_line
-    def visit_With(self, n: ast35.With) -> Node:
+    def visit_With(self, n: ast35.With) -> WithStmt:
         return WithStmt([self.visit(i.context_expr) for i in n.items],
                         [self.visit(i.optional_vars) for i in n.items],
                         self.as_block(n.body, n.lineno))
 
     # AsyncWith(withitem* items, stmt* body)
     @with_line
-    def visit_AsyncWith(self, n: ast35.AsyncWith) -> Node:
+    def visit_AsyncWith(self, n: ast35.AsyncWith) -> WithStmt:
         r = WithStmt([self.visit(i.context_expr) for i in n.items],
                      [self.visit(i.optional_vars) for i in n.items],
                      self.as_block(n.body, n.lineno))
@@ -486,12 +486,12 @@ class ASTConverter(ast35.NodeTransformer):
 
     # Raise(expr? exc, expr? cause)
     @with_line
-    def visit_Raise(self, n: ast35.Raise) -> Node:
+    def visit_Raise(self, n: ast35.Raise) -> RaiseStmt:
         return RaiseStmt(self.visit(n.exc), self.visit(n.cause))
 
     # Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
     @with_line
-    def visit_Try(self, n: ast35.Try) -> Node:
+    def visit_Try(self, n: ast35.Try) -> TryStmt:
         vs = [NameExpr(h.name) if h.name is not None else None for h in n.handlers]
         types = [self.visit(h.type) for h in n.handlers]
         handlers = [self.as_block(h.body, h.lineno) for h in n.handlers]
@@ -505,12 +505,12 @@ class ASTConverter(ast35.NodeTransformer):
 
     # Assert(expr test, expr? msg)
     @with_line
-    def visit_Assert(self, n: ast35.Assert) -> Node:
+    def visit_Assert(self, n: ast35.Assert) -> AssertStmt:
         return AssertStmt(self.visit(n.test))
 
     # Import(alias* names)
     @with_line
-    def visit_Import(self, n: ast35.Import) -> Node:
+    def visit_Import(self, n: ast35.Import) -> Import:
         names = []  # type: List[Tuple[str, str]]
         for alias in n.names:
             name = self.translate_module_id(alias.name)
@@ -527,7 +527,7 @@ class ASTConverter(ast35.NodeTransformer):
 
     # ImportFrom(identifier? module, alias* names, int? level)
     @with_line
-    def visit_ImportFrom(self, n: ast35.ImportFrom) -> Node:
+    def visit_ImportFrom(self, n: ast35.ImportFrom) -> ImportBase:
         i = None  # type: ImportBase
         if len(n.names) == 1 and n.names[0].name == '*':
             i = ImportAll(n.module, n.level)
@@ -540,39 +540,39 @@ class ASTConverter(ast35.NodeTransformer):
 
     # Global(identifier* names)
     @with_line
-    def visit_Global(self, n: ast35.Global) -> Node:
+    def visit_Global(self, n: ast35.Global) -> GlobalDecl:
         return GlobalDecl(n.names)
 
     # Nonlocal(identifier* names)
     @with_line
-    def visit_Nonlocal(self, n: ast35.Nonlocal) -> Node:
+    def visit_Nonlocal(self, n: ast35.Nonlocal) -> NonlocalDecl:
         return NonlocalDecl(n.names)
 
     # Expr(expr value)
     @with_line
-    def visit_Expr(self, n: ast35.Expr) -> Node:
+    def visit_Expr(self, n: ast35.Expr) -> ExpressionStmt:
         value = self.visit(n.value)
         return ExpressionStmt(value)
 
     # Pass
     @with_line
-    def visit_Pass(self, n: ast35.Pass) -> Node:
+    def visit_Pass(self, n: ast35.Pass) -> PassStmt:
         return PassStmt()
 
     # Break
     @with_line
-    def visit_Break(self, n: ast35.Break) -> Node:
+    def visit_Break(self, n: ast35.Break) -> BreakStmt:
         return BreakStmt()
 
     # Continue
     @with_line
-    def visit_Continue(self, n: ast35.Continue) -> Node:
+    def visit_Continue(self, n: ast35.Continue) -> ContinueStmt:
         return ContinueStmt()
 
     # --- expr ---
     # BoolOp(boolop op, expr* values)
     @with_line
-    def visit_BoolOp(self, n: ast35.BoolOp) -> Node:
+    def visit_BoolOp(self, n: ast35.BoolOp) -> OpExpr:
         # mypy translates (1 and 2 and 3) as (1 and (2 and 3))
         assert len(n.values) >= 2
         op = None
@@ -584,7 +584,7 @@ class ASTConverter(ast35.NodeTransformer):
             raise RuntimeError('unknown BoolOp ' + str(type(n)))
 
         # potentially inefficient!
-        def group(vals: List[Node]) -> Node:
+        def group(vals: List[Expression]) -> OpExpr:
             if len(vals) == 2:
                 return OpExpr(op, vals[0], vals[1])
             else:
@@ -594,7 +594,7 @@ class ASTConverter(ast35.NodeTransformer):
 
     # BinOp(expr left, operator op, expr right)
     @with_line
-    def visit_BinOp(self, n: ast35.BinOp) -> Node:
+    def visit_BinOp(self, n: ast35.BinOp) -> OpExpr:
         op = self.from_operator(n.op)
 
         if op is None:
@@ -604,7 +604,7 @@ class ASTConverter(ast35.NodeTransformer):
 
     # UnaryOp(unaryop op, expr operand)
     @with_line
-    def visit_UnaryOp(self, n: ast35.UnaryOp) -> Node:
+    def visit_UnaryOp(self, n: ast35.UnaryOp) -> UnaryExpr:
         op = None
         if isinstance(n.op, ast35.Invert):
             op = '~'
@@ -622,7 +622,7 @@ class ASTConverter(ast35.NodeTransformer):
 
     # Lambda(arguments args, expr body)
     @with_line
-    def visit_Lambda(self, n: ast35.Lambda) -> Node:
+    def visit_Lambda(self, n: ast35.Lambda) -> FuncExpr:
         body = ast35.Return(n.body)
         body.lineno = n.lineno
         body.col_offset = n.col_offset
@@ -632,34 +632,34 @@ class ASTConverter(ast35.NodeTransformer):
 
     # IfExp(expr test, expr body, expr orelse)
     @with_line
-    def visit_IfExp(self, n: ast35.IfExp) -> Node:
+    def visit_IfExp(self, n: ast35.IfExp) -> ConditionalExpr:
         return ConditionalExpr(self.visit(n.test),
                                self.visit(n.body),
                                self.visit(n.orelse))
 
     # Dict(expr* keys, expr* values)
     @with_line
-    def visit_Dict(self, n: ast35.Dict) -> Node:
+    def visit_Dict(self, n: ast35.Dict) -> DictExpr:
         return DictExpr(list(zip(self.visit_list(n.keys), self.visit_list(n.values))))
 
     # Set(expr* elts)
     @with_line
-    def visit_Set(self, n: ast35.Set) -> Node:
+    def visit_Set(self, n: ast35.Set) -> SetExpr:
         return SetExpr(self.visit_list(n.elts))
 
     # ListComp(expr elt, comprehension* generators)
     @with_line
-    def visit_ListComp(self, n: ast35.ListComp) -> Node:
+    def visit_ListComp(self, n: ast35.ListComp) -> ListComprehension:
         return ListComprehension(self.visit_GeneratorExp(cast(ast35.GeneratorExp, n)))
 
     # SetComp(expr elt, comprehension* generators)
     @with_line
-    def visit_SetComp(self, n: ast35.SetComp) -> Node:
+    def visit_SetComp(self, n: ast35.SetComp) -> SetComprehension:
         return SetComprehension(self.visit_GeneratorExp(cast(ast35.GeneratorExp, n)))
 
     # DictComp(expr key, expr value, comprehension* generators)
     @with_line
-    def visit_DictComp(self, n: ast35.DictComp) -> Node:
+    def visit_DictComp(self, n: ast35.DictComp) -> DictionaryComprehension:
         targets = [self.visit(c.target) for c in n.generators]
         iters = [self.visit(c.iter) for c in n.generators]
         ifs_list = [self.visit_list(c.ifs) for c in n.generators]
@@ -682,23 +682,23 @@ class ASTConverter(ast35.NodeTransformer):
 
     # Await(expr value)
     @with_line
-    def visit_Await(self, n: ast35.Await) -> Node:
+    def visit_Await(self, n: ast35.Await) -> AwaitExpr:
         v = self.visit(n.value)
         return AwaitExpr(v)
 
     # Yield(expr? value)
     @with_line
-    def visit_Yield(self, n: ast35.Yield) -> Node:
+    def visit_Yield(self, n: ast35.Yield) -> YieldExpr:
         return YieldExpr(self.visit(n.value))
 
     # YieldFrom(expr value)
     @with_line
-    def visit_YieldFrom(self, n: ast35.YieldFrom) -> Node:
+    def visit_YieldFrom(self, n: ast35.YieldFrom) -> YieldFromExpr:
         return YieldFromExpr(self.visit(n.value))
 
     # Compare(expr left, cmpop* ops, expr* comparators)
     @with_line
-    def visit_Compare(self, n: ast35.Compare) -> Node:
+    def visit_Compare(self, n: ast35.Compare) -> ComparisonExpr:
         operators = [self.from_comp_operator(o) for o in n.ops]
         operands = self.visit_list([n.left] + n.comparators)
         return ComparisonExpr(operators, operands)
@@ -706,7 +706,7 @@ class ASTConverter(ast35.NodeTransformer):
     # Call(expr func, expr* args, keyword* keywords)
     # keyword = (identifier? arg, expr value)
     @with_line
-    def visit_Call(self, n: ast35.Call) -> Node:
+    def visit_Call(self, n: ast35.Call) -> CallExpr:
         def is_star2arg(k: ast35.keyword) -> bool:
             return k.arg is None
 
@@ -722,7 +722,7 @@ class ASTConverter(ast35.NodeTransformer):
 
     # Num(object n) -- a number as a PyObject.
     @with_line
-    def visit_Num(self, n: ast35.Num) -> Node:
+    def visit_Num(self, n: ast35.Num) -> Union[IntExpr, FloatExpr, ComplexExpr]:
         if isinstance(n.n, int):
             return IntExpr(n.n)
         elif isinstance(n.n, float):
@@ -734,7 +734,7 @@ class ASTConverter(ast35.NodeTransformer):
 
     # Str(string s)
     @with_line
-    def visit_Str(self, n: ast35.Str) -> Node:
+    def visit_Str(self, n: ast35.Str) -> Union[UnicodeExpr, StrExpr]:
         if self.pyversion[0] >= 3 or self.is_stub:
             # Hack: assume all string literals in Python 2 stubs are normal
             # strs (i.e. not unicode).  All stubs are parsed with the Python 3
@@ -748,7 +748,7 @@ class ASTConverter(ast35.NodeTransformer):
 
     # Bytes(bytes s)
     @with_line
-    def visit_Bytes(self, n: ast35.Bytes) -> Node:
+    def visit_Bytes(self, n: ast35.Bytes) -> Union[BytesExpr, StrExpr]:
         # The following line is a bit hacky, but is the best way to maintain
         # compatibility with how mypy currently parses the contents of bytes literals.
         contents = str(n.s)[2:-1]
@@ -759,17 +759,17 @@ class ASTConverter(ast35.NodeTransformer):
             return StrExpr(contents)
 
     # NameConstant(singleton value)
-    def visit_NameConstant(self, n: ast35.NameConstant) -> Node:
+    def visit_NameConstant(self, n: ast35.NameConstant) -> NameExpr:
         return NameExpr(str(n.value))
 
     # Ellipsis
     @with_line
-    def visit_Ellipsis(self, n: ast35.Ellipsis) -> Node:
+    def visit_Ellipsis(self, n: ast35.Ellipsis) -> EllipsisExpr:
         return EllipsisExpr()
 
     # Attribute(expr value, identifier attr, expr_context ctx)
     @with_line
-    def visit_Attribute(self, n: ast35.Attribute) -> Node:
+    def visit_Attribute(self, n: ast35.Attribute) -> Union[MemberExpr, SuperExpr]:
         if (isinstance(n.value, ast35.Call) and
                 isinstance(n.value.func, ast35.Name) and
                 n.value.func.id == 'super'):
@@ -779,39 +779,39 @@ class ASTConverter(ast35.NodeTransformer):
 
     # Subscript(expr value, slice slice, expr_context ctx)
     @with_line
-    def visit_Subscript(self, n: ast35.Subscript) -> Node:
+    def visit_Subscript(self, n: ast35.Subscript) -> IndexExpr:
         return IndexExpr(self.visit(n.value), self.visit(n.slice))
 
     # Starred(expr value, expr_context ctx)
     @with_line
-    def visit_Starred(self, n: ast35.Starred) -> Node:
+    def visit_Starred(self, n: ast35.Starred) -> StarExpr:
         return StarExpr(self.visit(n.value))
 
     # Name(identifier id, expr_context ctx)
     @with_line
-    def visit_Name(self, n: ast35.Name) -> Node:
+    def visit_Name(self, n: ast35.Name) -> NameExpr:
         return NameExpr(n.id)
 
     # List(expr* elts, expr_context ctx)
     @with_line
-    def visit_List(self, n: ast35.List) -> Node:
+    def visit_List(self, n: ast35.List) -> ListExpr:
         return ListExpr([self.visit(e) for e in n.elts])
 
     # Tuple(expr* elts, expr_context ctx)
     @with_line
-    def visit_Tuple(self, n: ast35.Tuple) -> Node:
+    def visit_Tuple(self, n: ast35.Tuple) -> TupleExpr:
         return TupleExpr([self.visit(e) for e in n.elts])
 
     # --- slice ---
 
     # Slice(expr? lower, expr? upper, expr? step)
-    def visit_Slice(self, n: ast35.Slice) -> Node:
+    def visit_Slice(self, n: ast35.Slice) -> SliceExpr:
         return SliceExpr(self.visit(n.lower),
                          self.visit(n.upper),
                          self.visit(n.step))
 
     # ExtSlice(slice* dims)
-    def visit_ExtSlice(self, n: ast35.ExtSlice) -> Node:
+    def visit_ExtSlice(self, n: ast35.ExtSlice) -> TupleExpr:
         return TupleExpr(self.visit_list(n.dims))
 
     # Index(expr value)

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -27,14 +27,13 @@ from mypy.nodes import (
     TupleExpr, GeneratorExpr, ListComprehension, ListExpr, ConditionalExpr,
     DictExpr, SetExpr, NameExpr, IntExpr, StrExpr, BytesExpr, UnicodeExpr,
     FloatExpr, CallExpr, SuperExpr, MemberExpr, IndexExpr, SliceExpr, OpExpr,
-    UnaryExpr, FuncExpr, ComparisonExpr,
-    StarExpr, YieldFromExpr, NonlocalDecl, DictionaryComprehension,
+    UnaryExpr, FuncExpr, ComparisonExpr, DictionaryComprehension,
     SetComprehension, ComplexExpr, EllipsisExpr, YieldExpr, Argument,
-    AwaitExpr, Expression,
+    Expression, Statement,
     ARG_POS, ARG_OPT, ARG_STAR, ARG_NAMED, ARG_STAR2
 )
 from mypy.types import (
-    Type, CallableType, FunctionLike, AnyType, UnboundType, TupleType, TypeList, EllipsisType,
+    Type, CallableType, AnyType, UnboundType,
 )
 from mypy import defaults
 from mypy import experiments
@@ -44,7 +43,6 @@ from mypy.fastparse import TypeConverter, TypeCommentParseError
 try:
     from typed_ast import ast27
     from typed_ast import ast35
-    from typed_ast import conversions
 except ImportError:
     if sys.version_info.minor > 2:
         print('You must install the typed_ast package before you can run mypy'
@@ -144,7 +142,7 @@ class ASTConverter(ast27.NodeTransformer):
     def visit_NoneType(self, n: Any) -> Optional[Node]:
         return None
 
-    def visit_list(self, l: Sequence[ast27.AST]) -> List[Node]:
+    def visit_list(self, l: Sequence[ast27.AST]) -> List[Expression]:
         return [self.visit(e) for e in l]
 
     op_map = {
@@ -198,8 +196,8 @@ class ASTConverter(ast27.NodeTransformer):
             b.set_line(lineno)
         return b
 
-    def fix_function_overloads(self, stmts: List[Node]) -> List[Node]:
-        ret = []  # type: List[Node]
+    def fix_function_overloads(self, stmts: List[Statement]) -> List[Statement]:
+        ret = []  # type: List[Statement]
         current_overload = []
         current_overload_name = None
         # mypy doesn't actually check that the decorator is literally @overload
@@ -242,7 +240,7 @@ class ASTConverter(ast27.NodeTransformer):
             return 'builtins'
         return id
 
-    def visit_Module(self, mod: ast27.Module) -> Node:
+    def visit_Module(self, mod: ast27.Module) -> MypyFile:
         body = self.fix_function_overloads(self.visit_list(mod.body))
 
         return MypyFile(body,
@@ -257,7 +255,7 @@ class ASTConverter(ast27.NodeTransformer):
     # arguments = (arg* args, arg? vararg, arg* kwonlyargs, expr* kw_defaults,
     #              arg? kwarg, expr* defaults)
     @with_line
-    def visit_FunctionDef(self, n: ast27.FunctionDef) -> Node:
+    def visit_FunctionDef(self, n: ast27.FunctionDef) -> Statement:
         converter = TypeConverter(line=n.lineno)
         args = self.transform_args(n.args, n.lineno)
 
@@ -321,7 +319,7 @@ class ASTConverter(ast27.NodeTransformer):
         else:
             return func_def
 
-    def set_type_optional(self, type: Type, initializer: Node) -> None:
+    def set_type_optional(self, type: Type, initializer: Expression) -> None:
         if not experiments.STRICT_OPTIONAL:
             return
         # Indicate that type should be wrapped in an Optional if arg is initialized to None.
@@ -393,7 +391,7 @@ class ASTConverter(ast27.NodeTransformer):
     #  stmt* body,
     #  expr* decorator_list)
     @with_line
-    def visit_ClassDef(self, n: ast27.ClassDef) -> Node:
+    def visit_ClassDef(self, n: ast27.ClassDef) -> ClassDef:
         self.class_nesting += 1
 
         cdef = ClassDef(n.name,
@@ -407,12 +405,12 @@ class ASTConverter(ast27.NodeTransformer):
 
     # Return(expr? value)
     @with_line
-    def visit_Return(self, n: ast27.Return) -> Node:
+    def visit_Return(self, n: ast27.Return) -> ReturnStmt:
         return ReturnStmt(self.visit(n.value))
 
     # Delete(expr* targets)
     @with_line
-    def visit_Delete(self, n: ast27.Delete) -> Node:
+    def visit_Delete(self, n: ast27.Delete) -> DelStmt:
         if len(n.targets) > 1:
             tup = TupleExpr(self.visit_list(n.targets))
             tup.set_line(n.lineno)
@@ -422,7 +420,7 @@ class ASTConverter(ast27.NodeTransformer):
 
     # Assign(expr* targets, expr value, string? type_comment)
     @with_line
-    def visit_Assign(self, n: ast27.Assign) -> Node:
+    def visit_Assign(self, n: ast27.Assign) -> AssignmentStmt:
         typ = None
         if n.type_comment:
             typ = parse_type_comment(n.type_comment, n.lineno)
@@ -433,14 +431,14 @@ class ASTConverter(ast27.NodeTransformer):
 
     # AugAssign(expr target, operator op, expr value)
     @with_line
-    def visit_AugAssign(self, n: ast27.AugAssign) -> Node:
+    def visit_AugAssign(self, n: ast27.AugAssign) -> OperatorAssignmentStmt:
         return OperatorAssignmentStmt(self.from_operator(n.op),
                               self.visit(n.target),
                               self.visit(n.value))
 
     # For(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
     @with_line
-    def visit_For(self, n: ast27.For) -> Node:
+    def visit_For(self, n: ast27.For) -> ForStmt:
         return ForStmt(self.visit(n.target),
                        self.visit(n.iter),
                        self.as_block(n.body, n.lineno),
@@ -448,27 +446,27 @@ class ASTConverter(ast27.NodeTransformer):
 
     # While(expr test, stmt* body, stmt* orelse)
     @with_line
-    def visit_While(self, n: ast27.While) -> Node:
+    def visit_While(self, n: ast27.While) -> WhileStmt:
         return WhileStmt(self.visit(n.test),
                          self.as_block(n.body, n.lineno),
                          self.as_block(n.orelse, n.lineno))
 
     # If(expr test, stmt* body, stmt* orelse)
     @with_line
-    def visit_If(self, n: ast27.If) -> Node:
+    def visit_If(self, n: ast27.If) -> IfStmt:
         return IfStmt([self.visit(n.test)],
                       [self.as_block(n.body, n.lineno)],
                       self.as_block(n.orelse, n.lineno))
 
     # With(withitem* items, stmt* body, string? type_comment)
     @with_line
-    def visit_With(self, n: ast27.With) -> Node:
+    def visit_With(self, n: ast27.With) -> WithStmt:
         return WithStmt([self.visit(n.context_expr)],
                         [self.visit(n.optional_vars)],
                         self.as_block(n.body, n.lineno))
 
     @with_line
-    def visit_Raise(self, n: ast27.Raise) -> Node:
+    def visit_Raise(self, n: ast27.Raise) -> RaiseStmt:
         e = None
         if n.type is not None:
             e = n.type
@@ -484,11 +482,11 @@ class ASTConverter(ast27.NodeTransformer):
 
     # TryExcept(stmt* body, excepthandler* handlers, stmt* orelse)
     @with_line
-    def visit_TryExcept(self, n: ast27.TryExcept) -> Node:
+    def visit_TryExcept(self, n: ast27.TryExcept) -> TryStmt:
         return self.try_handler(n.body, n.handlers, n.orelse, [], n.lineno)
 
     @with_line
-    def visit_TryFinally(self, n: ast27.TryFinally) -> Node:
+    def visit_TryFinally(self, n: ast27.TryFinally) -> TryStmt:
         if len(n.body) == 1 and isinstance(n.body[0], ast27.TryExcept):
             return self.try_handler([n.body[0]], [], [], n.finalbody, n.lineno)
         else:
@@ -499,7 +497,7 @@ class ASTConverter(ast27.NodeTransformer):
                     handlers: List[ast27.ExceptHandler],
                     orelse: List[ast27.stmt],
                     finalbody: List[ast27.stmt],
-                    lineno: int) -> Node:
+                    lineno: int) -> TryStmt:
         def produce_name(item: ast27.ExceptHandler) -> Optional[NameExpr]:
             if item.name is None:
                 return None
@@ -520,7 +518,7 @@ class ASTConverter(ast27.NodeTransformer):
                        self.as_block(finalbody, lineno))
 
     @with_line
-    def visit_Print(self, n: ast27.Print) -> Node:
+    def visit_Print(self, n: ast27.Print) -> ExpressionStmt:
         keywords = []
         if n.dest is not None:
             keywords.append(ast27.keyword("file", n.dest))
@@ -534,10 +532,10 @@ class ASTConverter(ast27.NodeTransformer):
             ast27.Name("print", ast27.Load(), lineno=n.lineno, col_offset=-1),
             n.values, keywords, None, None,
             lineno=n.lineno, col_offset=-1)
-        return self.visit(ast27.Expr(call, lineno=n.lineno, col_offset=-1))
+        return self.visit_Expr(ast27.Expr(call, lineno=n.lineno, col_offset=-1))
 
     @with_line
-    def visit_Exec(self, n: ast27.Exec) -> Node:
+    def visit_Exec(self, n: ast27.Exec) -> ExpressionStmt:
         new_globals = n.globals
         new_locals = n.locals
 
@@ -547,7 +545,7 @@ class ASTConverter(ast27.NodeTransformer):
             new_locals = ast27.Name("None", ast27.Load(), lineno=-1, col_offset=-1)
 
         # TODO: Comment in visit_Print also applies here
-        return self.visit(ast27.Expr(
+        return self.visit_Expr(ast27.Expr(
             ast27.Call(
                 ast27.Name("exec", ast27.Load(), lineno=n.lineno, col_offset=-1),
                 [n.body, new_globals, new_locals],
@@ -556,9 +554,9 @@ class ASTConverter(ast27.NodeTransformer):
             lineno=n.lineno, col_offset=-1))
 
     @with_line
-    def visit_Repr(self, n: ast27.Repr) -> Node:
+    def visit_Repr(self, n: ast27.Repr) -> CallExpr:
         # TODO: Comment in visit_Print also applies here
-        return self.visit(ast27.Call(
+        return self.visit_Call(ast27.Call(
             ast27.Name("repr", ast27.Load(), lineno=n.lineno, col_offset=-1),
             n.value,
             [], None, None,
@@ -566,12 +564,12 @@ class ASTConverter(ast27.NodeTransformer):
 
     # Assert(expr test, expr? msg)
     @with_line
-    def visit_Assert(self, n: ast27.Assert) -> Node:
+    def visit_Assert(self, n: ast27.Assert) -> AssertStmt:
         return AssertStmt(self.visit(n.test))
 
     # Import(alias* names)
     @with_line
-    def visit_Import(self, n: ast27.Import) -> Node:
+    def visit_Import(self, n: ast27.Import) -> Import:
         names = []  # type: List[Tuple[str, str]]
         for alias in n.names:
             name = self.translate_module_id(alias.name)
@@ -588,7 +586,7 @@ class ASTConverter(ast27.NodeTransformer):
 
     # ImportFrom(identifier? module, alias* names, int? level)
     @with_line
-    def visit_ImportFrom(self, n: ast27.ImportFrom) -> Node:
+    def visit_ImportFrom(self, n: ast27.ImportFrom) -> ImportBase:
         i = None  # type: ImportBase
         if len(n.names) == 1 and n.names[0].name == '*':
             i = ImportAll(n.module, n.level)
@@ -601,34 +599,34 @@ class ASTConverter(ast27.NodeTransformer):
 
     # Global(identifier* names)
     @with_line
-    def visit_Global(self, n: ast27.Global) -> Node:
+    def visit_Global(self, n: ast27.Global) -> GlobalDecl:
         return GlobalDecl(n.names)
 
     # Expr(expr value)
     @with_line
-    def visit_Expr(self, n: ast27.Expr) -> Node:
+    def visit_Expr(self, n: ast27.Expr) -> ExpressionStmt:
         value = self.visit(n.value)
         return ExpressionStmt(value)
 
     # Pass
     @with_line
-    def visit_Pass(self, n: ast27.Pass) -> Node:
+    def visit_Pass(self, n: ast27.Pass) -> PassStmt:
         return PassStmt()
 
     # Break
     @with_line
-    def visit_Break(self, n: ast27.Break) -> Node:
+    def visit_Break(self, n: ast27.Break) -> BreakStmt:
         return BreakStmt()
 
     # Continue
     @with_line
-    def visit_Continue(self, n: ast27.Continue) -> Node:
+    def visit_Continue(self, n: ast27.Continue) -> ContinueStmt:
         return ContinueStmt()
 
     # --- expr ---
     # BoolOp(boolop op, expr* values)
     @with_line
-    def visit_BoolOp(self, n: ast27.BoolOp) -> Node:
+    def visit_BoolOp(self, n: ast27.BoolOp) -> OpExpr:
         # mypy translates (1 and 2 and 3) as (1 and (2 and 3))
         assert len(n.values) >= 2
         op = None
@@ -640,7 +638,7 @@ class ASTConverter(ast27.NodeTransformer):
             raise RuntimeError('unknown BoolOp ' + str(type(n)))
 
         # potentially inefficient!
-        def group(vals: List[Node]) -> Node:
+        def group(vals: List[Expression]) -> OpExpr:
             if len(vals) == 2:
                 return OpExpr(op, vals[0], vals[1])
             else:
@@ -650,7 +648,7 @@ class ASTConverter(ast27.NodeTransformer):
 
     # BinOp(expr left, operator op, expr right)
     @with_line
-    def visit_BinOp(self, n: ast27.BinOp) -> Node:
+    def visit_BinOp(self, n: ast27.BinOp) -> OpExpr:
         op = self.from_operator(n.op)
 
         if op is None:
@@ -660,7 +658,7 @@ class ASTConverter(ast27.NodeTransformer):
 
     # UnaryOp(unaryop op, expr operand)
     @with_line
-    def visit_UnaryOp(self, n: ast27.UnaryOp) -> Node:
+    def visit_UnaryOp(self, n: ast27.UnaryOp) -> UnaryExpr:
         op = None
         if isinstance(n.op, ast27.Invert):
             op = '~'
@@ -678,7 +676,7 @@ class ASTConverter(ast27.NodeTransformer):
 
     # Lambda(arguments args, expr body)
     @with_line
-    def visit_Lambda(self, n: ast27.Lambda) -> Node:
+    def visit_Lambda(self, n: ast27.Lambda) -> FuncExpr:
         body = ast27.Return(n.body)
         body.lineno = n.lineno
         body.col_offset = n.col_offset
@@ -688,34 +686,34 @@ class ASTConverter(ast27.NodeTransformer):
 
     # IfExp(expr test, expr body, expr orelse)
     @with_line
-    def visit_IfExp(self, n: ast27.IfExp) -> Node:
+    def visit_IfExp(self, n: ast27.IfExp) -> ConditionalExpr:
         return ConditionalExpr(self.visit(n.test),
                                self.visit(n.body),
                                self.visit(n.orelse))
 
     # Dict(expr* keys, expr* values)
     @with_line
-    def visit_Dict(self, n: ast27.Dict) -> Node:
+    def visit_Dict(self, n: ast27.Dict) -> DictExpr:
         return DictExpr(list(zip(self.visit_list(n.keys), self.visit_list(n.values))))
 
     # Set(expr* elts)
     @with_line
-    def visit_Set(self, n: ast27.Set) -> Node:
+    def visit_Set(self, n: ast27.Set) -> SetExpr:
         return SetExpr(self.visit_list(n.elts))
 
     # ListComp(expr elt, comprehension* generators)
     @with_line
-    def visit_ListComp(self, n: ast27.ListComp) -> Node:
+    def visit_ListComp(self, n: ast27.ListComp) -> ListComprehension:
         return ListComprehension(self.visit_GeneratorExp(cast(ast27.GeneratorExp, n)))
 
     # SetComp(expr elt, comprehension* generators)
     @with_line
-    def visit_SetComp(self, n: ast27.SetComp) -> Node:
+    def visit_SetComp(self, n: ast27.SetComp) -> SetComprehension:
         return SetComprehension(self.visit_GeneratorExp(cast(ast27.GeneratorExp, n)))
 
     # DictComp(expr key, expr value, comprehension* generators)
     @with_line
-    def visit_DictComp(self, n: ast27.DictComp) -> Node:
+    def visit_DictComp(self, n: ast27.DictComp) -> DictionaryComprehension:
         targets = [self.visit(c.target) for c in n.generators]
         iters = [self.visit(c.iter) for c in n.generators]
         ifs_list = [self.visit_list(c.ifs) for c in n.generators]
@@ -738,12 +736,12 @@ class ASTConverter(ast27.NodeTransformer):
 
     # Yield(expr? value)
     @with_line
-    def visit_Yield(self, n: ast27.Yield) -> Node:
+    def visit_Yield(self, n: ast27.Yield) -> YieldExpr:
         return YieldExpr(self.visit(n.value))
 
     # Compare(expr left, cmpop* ops, expr* comparators)
     @with_line
-    def visit_Compare(self, n: ast27.Compare) -> Node:
+    def visit_Compare(self, n: ast27.Compare) -> ComparisonExpr:
         operators = [self.from_comp_operator(o) for o in n.ops]
         operands = self.visit_list([n.left] + n.comparators)
         return ComparisonExpr(operators, operands)
@@ -751,7 +749,7 @@ class ASTConverter(ast27.NodeTransformer):
     # Call(expr func, expr* args, keyword* keywords)
     # keyword = (identifier? arg, expr value)
     @with_line
-    def visit_Call(self, n: ast27.Call) -> Node:
+    def visit_Call(self, n: ast27.Call) -> CallExpr:
         arg_types = []  # type: List[ast27.expr]
         arg_kinds = []  # type: List[int]
         signature = []  # type: List[Optional[str]]
@@ -781,7 +779,7 @@ class ASTConverter(ast27.NodeTransformer):
 
     # Num(object n) -- a number as a PyObject.
     @with_line
-    def visit_Num(self, new: ast27.Num) -> Node:
+    def visit_Num(self, new: ast27.Num) -> Expression:
         value = new.n
         is_inverse = False
         if str(new.n).startswith('-'):  # Hackish because of complex.
@@ -805,7 +803,7 @@ class ASTConverter(ast27.NodeTransformer):
 
     # Str(string s)
     @with_line
-    def visit_Str(self, s: ast27.Str) -> Node:
+    def visit_Str(self, s: ast27.Str) -> Expression:
         # Hack: assume all string literals in Python 2 stubs are normal
         # strs (i.e. not unicode).  All stubs are parsed with the Python 3
         # parser, which causes unprefixed string literals to be interpreted
@@ -829,12 +827,12 @@ class ASTConverter(ast27.NodeTransformer):
                 return UnicodeExpr(s.s)
 
     # Ellipsis
-    def visit_Ellipsis(self, n: ast27.Ellipsis) -> Node:
+    def visit_Ellipsis(self, n: ast27.Ellipsis) -> EllipsisExpr:
         return EllipsisExpr()
 
     # Attribute(expr value, identifier attr, expr_context ctx)
     @with_line
-    def visit_Attribute(self, n: ast27.Attribute) -> Node:
+    def visit_Attribute(self, n: ast27.Attribute) -> Expression:
         if (isinstance(n.value, ast27.Call) and
                 isinstance(n.value.func, ast27.Name) and
                 n.value.func.id == 'super'):
@@ -844,36 +842,36 @@ class ASTConverter(ast27.NodeTransformer):
 
     # Subscript(expr value, slice slice, expr_context ctx)
     @with_line
-    def visit_Subscript(self, n: ast27.Subscript) -> Node:
+    def visit_Subscript(self, n: ast27.Subscript) -> IndexExpr:
         return IndexExpr(self.visit(n.value), self.visit(n.slice))
 
     # Name(identifier id, expr_context ctx)
     @with_line
-    def visit_Name(self, n: ast27.Name) -> Node:
+    def visit_Name(self, n: ast27.Name) -> NameExpr:
         return NameExpr(n.id)
 
     # List(expr* elts, expr_context ctx)
     @with_line
-    def visit_List(self, n: ast27.List) -> Node:
+    def visit_List(self, n: ast27.List) -> ListExpr:
         return ListExpr([self.visit(e) for e in n.elts])
 
     # Tuple(expr* elts, expr_context ctx)
     @with_line
-    def visit_Tuple(self, n: ast27.Tuple) -> Node:
+    def visit_Tuple(self, n: ast27.Tuple) -> TupleExpr:
         return TupleExpr([self.visit(e) for e in n.elts])
 
     # --- slice ---
 
     # Slice(expr? lower, expr? upper, expr? step)
-    def visit_Slice(self, n: ast27.Slice) -> Node:
+    def visit_Slice(self, n: ast27.Slice) -> SliceExpr:
         return SliceExpr(self.visit(n.lower),
                          self.visit(n.upper),
                          self.visit(n.step))
 
     # ExtSlice(slice* dims)
-    def visit_ExtSlice(self, n: ast27.ExtSlice) -> Node:
+    def visit_ExtSlice(self, n: ast27.ExtSlice) -> TupleExpr:
         return TupleExpr(self.visit_list(n.dims))
 
     # Index(expr value)
-    def visit_Index(self, n: ast27.Index) -> Node:
+    def visit_Index(self, n: ast27.Index) -> Expression:
         return self.visit(n.value)


### PR DESCRIPTION
Most of the types are immediate from the return statement.

To avoid casting (in the futre), I think `visit()` should be broken into `visit_expression()` and `visit_statement()`. But without the actual separation between Statement/Expression and Node it's harder to verify.