### PR TITLE
Remove weird implementation of --show_traceback and --pdb.

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1262,7 +1262,7 @@ class State:
         except CompileError:
             raise
         except Exception as err:
-            report_internal_error(err, self.path, 0, self.manager.errors)
+            report_internal_error(err, self.path, 0, self.manager.errors, self.options)
         self.manager.errors.set_import_context(save_import_context)
         self.check_blockers()
 
@@ -1405,7 +1405,7 @@ class State:
 
     def semantic_analysis_pass_three(self) -> None:
         with self.wrap_context():
-            self.manager.semantic_analyzer_pass3.visit_file(self.tree, self.xpath)
+            self.manager.semantic_analyzer_pass3.visit_file(self.tree, self.xpath, self.options)
             if self.options.dump_type_stats:
                 dump_type_stats(self.tree, self.xpath)
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -219,7 +219,7 @@ class TypeChecker(NodeVisitor[Type]):
         try:
             typ = node.accept(self)
         except Exception as err:
-            report_internal_error(err, self.errors.file, node.line, self.errors)
+            report_internal_error(err, self.errors.file, node.line, self.errors, self.options)
         self.type_context.pop()
         self.store_type(node, typ)
         if self.typing_mode_none():

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -6,6 +6,8 @@ from collections import OrderedDict, defaultdict
 
 from typing import Tuple, List, TypeVar, Set, Dict, Optional
 
+from mypy.options import Options
+
 
 T = TypeVar('T')
 
@@ -420,24 +422,8 @@ def remove_path_prefix(path: str, prefix: str) -> str:
         return path
 
 
-# Corresponds to command-line flag --pdb.
-drop_into_pdb = False
-
-# Corresponds to command-line flag --show-traceback.
-show_tb = False
-
-
-def set_drop_into_pdb(flag: bool) -> None:
-    global drop_into_pdb
-    drop_into_pdb = flag
-
-
-def set_show_tb(flag: bool) -> None:
-    global show_tb
-    show_tb = flag
-
-
-def report_internal_error(err: Exception, file: str, line: int, errors: Errors) -> None:
+def report_internal_error(err: Exception, file: str, line: int,
+                          errors: Errors, options: Options) -> None:
     """Report internal error and exit.
 
     This optionally starts pdb or shows a traceback.
@@ -462,14 +448,14 @@ def report_internal_error(err: Exception, file: str, line: int, errors: Errors) 
           file=sys.stderr)
 
     # If requested, drop into pdb. This overrides show_tb.
-    if drop_into_pdb:
+    if options.pdb:
         print('Dropping into pdb', file=sys.stderr)
         import pdb
         pdb.post_mortem(sys.exc_info()[2])
 
     # If requested, print traceback, else print note explaining how to get one.
-    if not show_tb:
-        if not drop_into_pdb:
+    if not options.show_traceback:
+        if not options.pdb:
             print('{}: note: please use --show-traceback to print a traceback '
                   'when reporting a bug'.format(prefix),
                   file=sys.stderr)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -13,7 +13,7 @@ from mypy import defaults
 from mypy import git
 from mypy import experiments
 from mypy.build import BuildSource, BuildResult, PYTHON_EXTENSIONS
-from mypy.errors import CompileError, set_drop_into_pdb, set_show_tb
+from mypy.errors import CompileError
 from mypy.options import Options, BuildType
 from mypy.report import reporter_classes
 
@@ -33,10 +33,6 @@ def main(script_path: str) -> None:
     else:
         bin_dir = None
     sources, options = process_options(sys.argv[1:])
-    if options.pdb:
-        set_drop_into_pdb(True)
-    if options.show_traceback:
-        set_show_tb(True)
     f = sys.stdout
     try:
         res = type_check_only(sources, bin_dir, options)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2559,7 +2559,7 @@ class SemanticAnalyzer(NodeVisitor):
         try:
             node.accept(self)
         except Exception as err:
-            report_internal_error(err, self.errors.file, node.line, self.errors)
+            report_internal_error(err, self.errors.file, node.line, self.errors, self.options)
 
 
 class FirstPass(NodeVisitor):
@@ -2768,15 +2768,16 @@ class ThirdPass(TraverserVisitor):
         self.modules = modules
         self.errors = errors
 
-    def visit_file(self, file_node: MypyFile, fnam: str) -> None:
+    def visit_file(self, file_node: MypyFile, fnam: str, options: Options) -> None:
         self.errors.set_file(fnam)
+        self.options = options
         self.accept(file_node)
 
     def accept(self, node: Node) -> None:
         try:
             node.accept(self)
         except Exception as err:
-            report_internal_error(err, self.errors.file, node.line, self.errors)
+            report_internal_error(err, self.errors.file, node.line, self.errors, self.options)
 
     def visit_block(self, b: Block) -> None:
         if b.is_unreachable:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -20,7 +20,7 @@ from mypy.test.helpers import (
     assert_string_arrays_equal, normalize_error_messages,
     testcase_pyversion, update_testcase_output,
 )
-from mypy.errors import CompileError, set_show_tb
+from mypy.errors import CompileError
 from mypy.options import Options
 
 from mypy import experiments
@@ -118,7 +118,7 @@ class TypeCheckSuite(DataSuite):
 
         options = self.parse_options(original_program_text, testcase)
         options.use_builtins_fixtures = True
-        set_show_tb(True)  # Show traceback on crash.
+        options.show_traceback = True
         if 'optional' in testcase.file:
             options.strict_optional = True
 

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -44,7 +44,7 @@ def test_python_evaluation(testcase: DataDrivenTestCase) -> None:
         for s in testcase.input:
             file.write('{}\n'.format(s))
     args = parse_args(testcase.input[0])
-    args.append('--tb')  # Show traceback on crash.
+    args.append('--show-traceback')
     # Type check the program.
     fixed = [python3_path,
              os.path.join(testcase.old_cwd, 'scripts', 'mypy')]

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -62,7 +62,7 @@ def test_python_evaluation(testcase):
         interpreter = python3_path
         args = []
         py2 = False
-    args.append('--tb')  # Show traceback on crash.
+    args.append('--show-traceback')
     # Write the program to a file.
     program = '_program.py'
     program_path = os.path.join(test_temp_dir, program)

--- a/mypy/test/testsemanal.py
+++ b/mypy/test/testsemanal.py
@@ -36,6 +36,7 @@ def get_semanal_options():
     options = Options()
     options.use_builtins_fixtures = True
     options.semantic_analysis_only = True
+    options.show_traceback = True
     return options
 
 

--- a/mypy/test/testtransform.py
+++ b/mypy/test/testtransform.py
@@ -45,6 +45,7 @@ def test_transform(testcase):
         options = Options()
         options.use_builtins_fixtures = True
         options.semantic_analysis_only = True
+        options.show_traceback = True
         options.python_version = testfile_pyversion(testcase.file)
         result = build.build(sources=[BuildSource('main', None, src)],
                              options=options,

--- a/mypy/test/testtypegen.py
+++ b/mypy/test/testtypegen.py
@@ -39,6 +39,7 @@ class TypeExportSuite(Suite):
             src = '\n'.join(testcase.input)
             options = Options()
             options.use_builtins_fixtures = True
+            options.show_traceback = True
             result = build.build(sources=[BuildSource('main', None, src)],
                                  options=options,
                                  alt_lib_path=config.test_temp_dir)

--- a/runtests.py
+++ b/runtests.py
@@ -77,7 +77,7 @@ class Driver:
         if not self.allow(full_name):
             return
         args = [sys.executable, self.mypy] + mypy_args
-        args.append('--tb')  # Show traceback on crash.
+        args.append('--show-traceback')
         self.waiter.add(LazySubprocess(full_name, args, cwd=cwd, env=self.env))
 
     def add_mypy(self, name: str, *args: str, cwd: Optional[str] = None) -> None:


### PR DESCRIPTION
Also set options.show_traceback in all test modules I could find.

These flags used to be implemented as globals in errors.py that had to
be set by calling set_show_tb() or set_drop_into_pdb() (and setting
the corresponding Options attributes had no effect).  Now they're just
regular options.  I had to adjust some plumbing to give
report_internal_error() access to the options but it was easier than I
thought.