### PR TITLE
Tighter types for strconv, report and check*

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2525,7 +2525,7 @@ def expand_func(defn: FuncItem, map: Dict[TypeVarId, Type]) -> FuncItem:
     visitor = TypeTransformVisitor(map)
     ret = defn.accept(visitor)
     assert isinstance(ret, FuncItem)
-    return cast(FuncItem, ret)
+    return ret
 
 
 class TypeTransformVisitor(TransformVisitor):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -9,7 +9,7 @@ from typing import (
 
 from mypy.errors import Errors, report_internal_error
 from mypy.nodes import (
-    SymbolTable, Node, MypyFile, Var, Expression, Lvalue,
+    SymbolTable, Statement, MypyFile, Var, Expression, Lvalue,
     OverloadedFuncDef, FuncDef, FuncItem, FuncBase, TypeInfo,
     ClassDef, GDEF, Block, AssignmentStmt, NameExpr, MemberExpr, IndexExpr,
     TupleExpr, ListExpr, ExpressionStmt, ReturnStmt, IfStmt,
@@ -64,7 +64,7 @@ T = TypeVar('T')
 DeferredNode = NamedTuple(
     'DeferredNode',
     [
-        ('node', Node),
+        ('node', Union[Expression, Statement, FuncItem]),
         ('context_type_name', Optional[str]),  # Name of the surrounding class (for error messages)
     ])
 
@@ -82,9 +82,9 @@ class TypeChecker(NodeVisitor[Type]):
     # Utility for generating messages
     msg = None  # type: MessageBuilder
     # Types of type checked nodes
-    type_map = None  # type: Dict[Node, Type]
+    type_map = None  # type: Dict[Expression, Type]
     # Types of type checked nodes within this specific module
-    module_type_map = None  # type: Dict[Node, Type]
+    module_type_map = None  # type: Dict[Expression, Type]
 
     # Helper for managing conditional types
     binder = None  # type: ConditionalTypeBinder
@@ -209,7 +209,8 @@ class TypeChecker(NodeVisitor[Type]):
         else:
             self.msg.cannot_determine_type(name, context)
 
-    def accept(self, node: Node, type_context: Type = None) -> Type:
+    def accept(self, node: Union[Expression, Statement, FuncItem],
+               type_context: Type = None) -> Type:
         """Type check a node in the given type context."""
         self.type_context.append(type_context)
         try:
@@ -217,7 +218,9 @@ class TypeChecker(NodeVisitor[Type]):
         except Exception as err:
             report_internal_error(err, self.errors.file, node.line, self.errors, self.options)
         self.type_context.pop()
-        self.store_type(node, typ)
+        if typ is not None:
+            assert isinstance(node, Expression)
+            self.store_type(node, typ)
         if not self.in_checked_function():
             return AnyType()
         else:
@@ -1788,7 +1791,8 @@ class TypeChecker(NodeVisitor[Type]):
             m.line = s.line
             c = CallExpr(m, [e.index], [nodes.ARG_POS], [None])
             c.line = s.line
-            return c.accept(self)
+            c.accept(self)
+            return None
         else:
             def flatten(t: Expression) -> List[Expression]:
                 """Flatten a nested sequence of tuples/lists into one list of nodes."""
@@ -1812,7 +1816,7 @@ class TypeChecker(NodeVisitor[Type]):
                 if d.fullname == 'typing.no_type_check':
                     e.var.type = AnyType()
                     e.var.is_ready = True
-                    return NoneTyp()
+                    return None
 
         e.func.accept(self)
         sig = self.function_type(e.func)  # type: Type
@@ -2203,7 +2207,7 @@ class TypeChecker(NodeVisitor[Type]):
         if not is_equivalent(t1, t2):
             self.fail(msg, node)
 
-    def store_type(self, node: Node, typ: Type) -> None:
+    def store_type(self, node: Expression, typ: Type) -> None:
         """Store the type of a node in the type map."""
         self.type_map[node] = typ
         if typ is not None:
@@ -2338,7 +2342,7 @@ class TypeChecker(NodeVisitor[Type]):
 # probably be better to have the dict keyed by the nodes' literal_hash
 # field instead.
 
-TypeMap = Optional[Dict[Node, Type]]
+TypeMap = Optional[Dict[Expression, Type]]
 
 
 def conditional_type_map(expr: Expression,
@@ -2417,7 +2421,7 @@ def or_conditional_maps(m1: TypeMap, m2: TypeMap) -> TypeMap:
 
 
 def find_isinstance_check(node: Expression,
-                          type_map: Dict[Node, Type],
+                          type_map: Dict[Expression, Type],
                           ) -> Tuple[TypeMap, TypeMap]:
     """Find any isinstance checks (within a chain of ands).  Includes
     implicit and explicit checks for None.
@@ -2442,8 +2446,8 @@ def find_isinstance_check(node: Expression,
         # Check for `x is None` and `x is not None`.
         is_not = node.operators == ['is not']
         if is_not or node.operators == ['is']:
-            if_vars = {}  # type: Dict[Node, Type]
-            else_vars = {}  # type: Dict[Node, Type]
+            if_vars = {}  # type: Dict[Expression, Type]
+            else_vars = {}  # type: Dict[Expression, Type]
             for expr in node.operands:
                 if expr.literal == LITERAL_TYPE and not is_literal_none(expr) and expr in type_map:
                     # This should only be true at most once: there should be
@@ -2462,7 +2466,7 @@ def find_isinstance_check(node: Expression,
         vartype = type_map[node]
         if_type = true_only(vartype)
         else_type = false_only(vartype)
-        ref = node  # type: Node
+        ref = node  # type: Expression
         if_map = {ref: if_type} if not isinstance(if_type, UninhabitedType) else None
         else_map = {ref: else_type} if not isinstance(else_type, UninhabitedType) else None
         return if_map, else_map
@@ -2490,7 +2494,7 @@ def find_isinstance_check(node: Expression,
     return {}, {}
 
 
-def get_isinstance_type(expr: Expression, type_map: Dict[Node, Type]) -> Type:
+def get_isinstance_type(expr: Expression, type_map: Dict[Expression, Type]) -> Type:
     type = type_map[expr]
 
     if isinstance(type, TupleType):
@@ -2517,13 +2521,11 @@ def get_isinstance_type(expr: Expression, type_map: Dict[Node, Type]) -> Type:
         return UnionType(types)
 
 
-def expand_node(defn: FuncItem, map: Dict[TypeVarId, Type]) -> Node:
-    visitor = TypeTransformVisitor(map)
-    return defn.accept(visitor)
-
-
 def expand_func(defn: FuncItem, map: Dict[TypeVarId, Type]) -> FuncItem:
-    return cast(FuncItem, expand_node(defn, map))
+    visitor = TypeTransformVisitor(map)
+    ret = defn.accept(visitor)
+    assert isinstance(ret, FuncItem)
+    return cast(FuncItem, ret)
 
 
 class TypeTransformVisitor(TransformVisitor):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -10,7 +10,7 @@ from mypy.types import (
 )
 from mypy.nodes import (
     NameExpr, RefExpr, Var, FuncDef, OverloadedFuncDef, TypeInfo, CallExpr,
-    Node, MemberExpr, IntExpr, StrExpr, BytesExpr, UnicodeExpr, FloatExpr,
+    MemberExpr, IntExpr, StrExpr, BytesExpr, UnicodeExpr, FloatExpr,
     OpExpr, UnaryExpr, IndexExpr, CastExpr, RevealTypeExpr, TypeApplication, ListExpr,
     TupleExpr, DictExpr, FuncExpr, SuperExpr, SliceExpr, Context, Expression,
     ListComprehension, GeneratorExpr, SetExpr, MypyFile, Decorator,
@@ -1734,8 +1734,8 @@ class ExpressionChecker:
 
         return res
 
-    def analyze_cond_branch(self, map: Optional[Dict[Node, Type]],
-                            node: Node, context: Optional[Type]) -> Type:
+    def analyze_cond_branch(self, map: Optional[Dict[Expression, Type]],
+                            node: Expression, context: Optional[Type]) -> Type:
         with self.chk.binder.frame_context():
             if map:
                 for var, type in map.items():
@@ -1750,7 +1750,7 @@ class ExpressionChecker:
     # Helpers
     #
 
-    def accept(self, node: Node, context: Type = None) -> Type:
+    def accept(self, node: Expression, context: Type = None) -> Type:
         """Type check a node. Alias for TypeChecker.accept."""
         return self.chk.accept(node, context)
 

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -8,7 +8,7 @@ from mypy.types import (
     Type, AnyType, TupleType, Instance, UnionType
 )
 from mypy.nodes import (
-    Node, StrExpr, BytesExpr, UnicodeExpr, TupleExpr, DictExpr, Context
+    StrExpr, BytesExpr, UnicodeExpr, TupleExpr, DictExpr, Context, Expression
 )
 if False:
     # break import cycle only needed for mypy
@@ -57,9 +57,10 @@ class StringFormatterChecker:
 
     # TODO: In Python 3, the bytes formatting has a more restricted set of options
     # compared to string formatting.
+    # TODO: Bytes formatting in Python 3 is only supported in 3.5 and up.
     def check_str_interpolation(self,
                                 str: Union[StrExpr, BytesExpr, UnicodeExpr],
-                                replacements: Node) -> Type:
+                                replacements: Expression) -> Type:
         """Check the types of the 'replacements' in a string interpolation
         expression: str % replacements
         """
@@ -114,7 +115,7 @@ class StringFormatterChecker:
         return has_key
 
     def check_simple_str_interpolation(self, specifiers: List[ConversionSpecifier],
-                                       replacements: Node) -> None:
+                                       replacements: Expression) -> None:
         checkers = self.build_replacement_checkers(specifiers, replacements)
         if checkers is None:
             return
@@ -149,7 +150,7 @@ class StringFormatterChecker:
                     check_type(rep_type)
 
     def check_mapping_str_interpolation(self, specifiers: List[ConversionSpecifier],
-                                       replacements: Node) -> None:
+                                       replacements: Expression) -> None:
         dict_with_only_str_literal_keys = (isinstance(replacements, DictExpr) and
                                           all(isinstance(k, (StrExpr, BytesExpr))
                                               for k, v in replacements.items))
@@ -183,9 +184,9 @@ class StringFormatterChecker:
                                    'expression has type', 'expected type for mapping is')
 
     def build_replacement_checkers(self, specifiers: List[ConversionSpecifier],
-                                   context: Context) -> List[Tuple[Callable[[Node], None],
+                                   context: Context) -> List[Tuple[Callable[[Expression], None],
                                                                    Callable[[Type], None]]]:
-        checkers = []  # type: List[Tuple[Callable[[Node], None], Callable[[Type], None]]]
+        checkers = []  # type: List[Tuple[Callable[[Expression], None], Callable[[Type], None]]]
         for specifier in specifiers:
             checker = self.replacement_checkers(specifier, context)
             if checker is None:
@@ -194,13 +195,14 @@ class StringFormatterChecker:
         return checkers
 
     def replacement_checkers(self, specifier: ConversionSpecifier,
-                             context: Context) -> List[Tuple[Callable[[Node], None],
+                             context: Context) -> List[Tuple[Callable[[Expression], None],
                                                              Callable[[Type], None]]]:
         """Returns a list of tuples of two functions that check whether a replacement is
         of the right type for the specifier. The first functions take a node and checks
         its type in the right type context. The second function just checks a type.
         """
-        checkers = []  # type: List[ Tuple[ Callable[[Node], None], Callable[[Type], None] ] ]
+        checkers = [
+        ]  # type: List[ Tuple[ Callable[[Expression], None], Callable[[Type], None] ] ]
 
         if specifier.width == '*':
             checkers.append(self.checkers_for_star(context))
@@ -218,7 +220,7 @@ class StringFormatterChecker:
             checkers.append(c)
         return checkers
 
-    def checkers_for_star(self, context: Context) -> Tuple[Callable[[Node], None],
+    def checkers_for_star(self, context: Context) -> Tuple[Callable[[Expression], None],
                                                            Callable[[Type], None]]:
         """Returns a tuple of check functions that check whether, respectively,
         a node or a type is compatible with a star in a conversion specifier
@@ -229,14 +231,14 @@ class StringFormatterChecker:
             expected = self.named_type('builtins.int')
             self.chk.check_subtype(type, expected, context, '* wants int')
 
-        def check_node(node: Node) -> None:
-            type = self.accept(node, expected)
+        def check_expr(expr: Expression) -> None:
+            type = self.accept(expr, expected)
             check_type(type)
 
-        return check_node, check_type
+        return check_expr, check_type
 
     def checkers_for_regular_type(self, type: str,
-                                  context: Context) -> Tuple[Callable[[Node], None],
+                                  context: Context) -> Tuple[Callable[[Expression], None],
                                                              Callable[[Type], None]]:
         """Returns a tuple of check functions that check whether, respectively,
         a node or a type is compatible with 'type'. Return None in case of an
@@ -250,14 +252,15 @@ class StringFormatterChecker:
                               messages.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
                               'expression has type', 'placeholder has type')
 
-        def check_node(node: Node) -> None:
-            type = self.accept(node, expected_type)
+        def check_expr(expr: Expression) -> None:
+            type = self.accept(expr, expected_type)
             check_type(type)
 
-        return check_node, check_type
+        return check_expr, check_type
 
-    def checkers_for_c_type(self, type: str, context: Context) -> Tuple[Callable[[Node], None],
-                                                                        Callable[[Type], None]]:
+    def checkers_for_c_type(self, type: str,
+                            context: Context) -> Tuple[Callable[[Expression], None],
+                                                       Callable[[Type], None]]:
         """Returns a tuple of check functions that check whether, respectively,
         a node or a type is compatible with 'type' that is a character type
         """
@@ -270,14 +273,14 @@ class StringFormatterChecker:
                               messages.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
                               'expression has type', 'placeholder has type')
 
-        def check_node(node: Node) -> None:
+        def check_expr(expr: Expression) -> None:
             """int, or str with length 1"""
-            type = self.accept(node, expected_type)
-            if isinstance(node, (StrExpr, BytesExpr)) and len(cast(StrExpr, node).value) != 1:
+            type = self.accept(expr, expected_type)
+            if isinstance(expr, (StrExpr, BytesExpr)) and len(cast(StrExpr, expr).value) != 1:
                 self.msg.requires_int_or_char(context)
             check_type(type)
 
-        return check_node, check_type
+        return check_expr, check_type
 
     def conversion_type(self, p: str, context: Context) -> Type:
         """Return the type that is accepted for a string interpolation
@@ -310,6 +313,6 @@ class StringFormatterChecker:
         """
         return self.chk.named_type(name)
 
-    def accept(self, node: Node, context: Type = None) -> Type:
+    def accept(self, expr: Expression, context: Type = None) -> Type:
         """Type check a node. Alias for TypeChecker.accept."""
-        return self.chk.accept(node, context)
+        return self.chk.accept(expr, context)

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -201,8 +201,7 @@ class StringFormatterChecker:
         of the right type for the specifier. The first functions take a node and checks
         its type in the right type context. The second function just checks a type.
         """
-        checkers = [
-        ]  # type: List[ Tuple[ Callable[[Expression], None], Callable[[Type], None] ] ]
+        checkers = []  # type: List[Tuple[Callable[[Expression], None], Callable[[Type], None]]]
 
         if specifier.width == '*':
             checkers.append(self.checkers_for_star(context))

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -12,8 +12,8 @@ from mypy.types import (
 )
 from mypy import nodes
 from mypy.nodes import (
-    Node, FuncDef, TypeApplication, AssignmentStmt, NameExpr, CallExpr, MypyFile,
-    MemberExpr, OpExpr, ComparisonExpr, IndexExpr, UnaryExpr, YieldFromExpr
+    Expression, FuncDef, TypeApplication, AssignmentStmt, NameExpr, CallExpr, MypyFile,
+    MemberExpr, OpExpr, ComparisonExpr, IndexExpr, UnaryExpr, YieldFromExpr, RefExpr
 )
 
 
@@ -31,7 +31,7 @@ precision_names = [
 
 
 class StatisticsVisitor(TraverserVisitor):
-    def __init__(self, inferred: bool, typemap: Dict[Node, Type] = None,
+    def __init__(self, inferred: bool, typemap: Dict[Expression, Type] = None,
                  all_nodes: bool = False) -> None:
         self.inferred = inferred
         self.typemap = typemap
@@ -101,7 +101,7 @@ class StatisticsVisitor(TraverserVisitor):
                 else:
                     items = [lvalue]
                 for item in items:
-                    if hasattr(item, 'is_def') and cast(Any, item).is_def:
+                    if isinstance(item, RefExpr) and item.is_def:
                         t = self.typemap.get(item)
                         if t:
                             self.type(t)
@@ -148,7 +148,7 @@ class StatisticsVisitor(TraverserVisitor):
         self.process_node(o)
         super().visit_unary_expr(o)
 
-    def process_node(self, node: Node) -> None:
+    def process_node(self, node: Expression) -> None:
         if self.all_nodes:
             typ = self.typemap.get(node)
             if typ:
@@ -198,7 +198,7 @@ class StatisticsVisitor(TraverserVisitor):
 
 
 def dump_type_stats(tree: MypyFile, path: str, inferred: bool = False,
-                    typemap: Dict[Node, Type] = None) -> None:
+                    typemap: Dict[Expression, Type] = None) -> None:
     if is_special_module(path):
         return
     print(path)
@@ -265,7 +265,7 @@ def is_complex(t: Type) -> bool:
 html_files = []  # type: List[Tuple[str, str, int, int]]
 
 
-def generate_html_report(tree: MypyFile, path: str, type_map: Dict[Node, Type],
+def generate_html_report(tree: MypyFile, path: str, type_map: Dict[Expression, Type],
                          output_dir: str) -> None:
     if is_special_module(path):
         return

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -11,7 +11,7 @@ from mypy.visitor import NodeVisitor
 
 
 class StrConv(NodeVisitor[str]):
-    """Visitor for converting nodes to a human-readable string.
+    """Visitor for converting a node to a human-readable string.
 
     For example, an MypyFile node from program '1' is converted into
     something like this:

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -3,7 +3,7 @@
 import re
 import os
 
-from typing import Any, List, Tuple, Optional, Union
+from typing import Any, List, Tuple, Optional, Union, Sequence
 
 from mypy.util import dump_tagged, short_type
 import mypy.nodes
@@ -11,7 +11,7 @@ from mypy.visitor import NodeVisitor
 
 
 class StrConv(NodeVisitor[str]):
-    """Visitor for converting a Node to a human-readable string.
+    """Visitor for converting nodes to a human-readable string.
 
     For example, an MypyFile node from program '1' is converted into
     something like this:
@@ -21,16 +21,16 @@ class StrConv(NodeVisitor[str]):
         ExpressionStmt:1(
           IntExpr(1)))
     """
-    def dump(self, nodes: List[Any], obj: 'mypy.nodes.Node') -> str:
+    def dump(self, nodes: Sequence[object], obj: 'mypy.nodes.Context') -> str:
         """Convert a list of items to a multiline pretty-printed string.
 
         The tag is produced from the type name of obj and its line
         number. See mypy.util.dump_tagged for a description of the nodes
         argument.
         """
-        return dump_tagged(nodes, short_type(obj) + ':' + str(obj.line))
+        return dump_tagged(nodes, short_type(obj) + ':' + str(obj.get_line()))
 
-    def func_helper(self, o: 'mypy.nodes.FuncItem') -> List[Any]:
+    def func_helper(self, o: 'mypy.nodes.FuncItem') -> List[object]:
         """Return a list in a format suitable for dump() that represents the
         arguments and the body of a function. The caller can then decorate the
         array with information specific to methods, global functions or
@@ -347,7 +347,7 @@ class StrConv(NodeVisitor[str]):
     def visit_call_expr(self, o: 'mypy.nodes.CallExpr') -> str:
         if o.analyzed:
             return o.analyzed.accept(self)
-        args = []  # type: List[mypy.nodes.Node]
+        args = []  # type: List[mypy.nodes.Expression]
         extra = []  # type: List[Union[str, Tuple[str, List[Any]]]]
         for i, kind in enumerate(o.arg_kinds):
             if kind in [mypy.nodes.ARG_POS, mypy.nodes.ARG_STAR]:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -2,7 +2,7 @@
 
 import re
 import subprocess
-from typing import TypeVar, List, Any, Tuple, Optional
+from typing import TypeVar, List, Tuple, Optional, Sequence
 
 
 T = TypeVar('T')
@@ -51,7 +51,7 @@ def array_repr(a: List[T]) -> List[str]:
     return aa
 
 
-def dump_tagged(nodes: List[Any], tag: str) -> str:
+def dump_tagged(nodes: Sequence[object], tag: str) -> str:
     """Convert an array into a pretty-printed multiline string representation.
 
     The format is


### PR DESCRIPTION
Branched out #2221: converting "Node" into "Expression" wherever possible.

This change is pretty minimal, since the types are somewhat entangled across the files.