### PR TITLE
[conflict] Allow assignment of types with `None`s without explicit annotation

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2698,7 +2698,12 @@ def infer_operator_assignment_method(type: Type, operator: str) -> Tuple[bool, s
 def is_valid_inferred_type(typ: Type) -> bool:
     """Is an inferred type valid?
 
-    Examples of invalid types include the None type or a type with a None component.
+    Examples of invalid types include the None type or List[None].
+
+    When not doing strict Optional checking, all types containing None are
+    invalid.  When doing strict Optional checking, only types that are
+    incompletely defined (i.e. contain UninhabitedType) or can be turned into
+    PartialTypes are invalid.
     """
     if is_same_type(typ, NoneTyp()):
         # With strict Optional checking, we *may* eventually infer NoneTyp, but
@@ -2706,14 +2711,33 @@ def is_valid_inferred_type(typ: Type) -> bool:
         # resolution happens in leave_partial_types when we pop a partial types
         # scope.
         return False
+    return is_valid_inferred_type_component(typ)
+
+
+def is_valid_inferred_type_component(typ: Type) -> bool:
+    """Is this part of a type a valid inferred type?
+
+    In strict Optional mode this excludes bare None types, as otherwise every
+    type containing None would be invalid.
+    """
+    if not experiments.STRICT_OPTIONAL:
+        if is_same_type(typ, NoneTyp()):
+            return False
     if is_same_type(typ, UninhabitedType()):
         return False
     elif isinstance(typ, Instance):
-        for arg in typ.args:
-            if not is_valid_inferred_type(arg):
-                return False
+        fullname = typ.type.fullname()
+        if ((fullname == 'builtins.list' or
+             fullname == 'builtins.set' or
+             fullname == 'builtins.dict') and
+                all(isinstance(t, (NoneTyp, UninhabitedType)) for t in typ.args)):
+            return False
+        else:
+            for arg in typ.args:
+                if not is_valid_inferred_type_component(arg):
+                    return False
     elif isinstance(typ, TupleType):
         for item in typ.items:
-            if not is_valid_inferred_type(item):
+            if not is_valid_inferred_type_component(item):
                 return False
     return True

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -428,3 +428,10 @@ x + 1
 [out]
 main:2: note: In module imported here:
 tmp/a.py:3: error: Unsupported left operand type for + (some union)
+
+[case testOptionalNonPartialTypeWithNone]
+from typing import Generator
+def f() -> Generator[str, None, None]: pass
+x = f()
+l = [f()]
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
Currently, mypy will not infer types containing None unless they are
valid PartialTypes (i.e. are bare None, list, set, or dict). This means
that all assignments of such types must be explicitly annotated.
It doesn't make sense to require this with strict Optional, as None is a
perfectly valid type.  This PR makes types containing None valid
inference targets.

Fixes #2195.