### PR TITLE
[needs test, failing test] Allow custom mapping in str interpolation

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -176,7 +176,7 @@ class StringFormatterChecker:
                                        'placeholder with key \'%s\' has type' % specifier.key)
         else:
             rep_type = self.accept(replacements)
-            dict_type = self.chk.named_generic_type('builtins.dict',
+            dict_type = self.chk.named_generic_type('typing.Mapping',
                                             [AnyType(), AnyType()])
             self.chk.check_subtype(rep_type, dict_type, replacements,
                                    messages.FORMAT_REQUIRES_MAPPING,


### PR DESCRIPTION
Although the error message reads "Format requires a mapping", the actual test is against Dict[Any,Any]. Relax this requirement to allow custom mapping types in string interpolations.
