### PR TITLE
Ensure reproducible --usage output.

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -220,7 +220,7 @@ def process_options(args: List[str],
     report_group = parser.add_argument_group(
         title='report generation',
         description='Generate a report in the specified format.')
-    for report_type in reporter_classes:
+    for report_type in sorted(reporter_classes):
         report_group.add_argument('--%s-report' % report_type.replace('_', '-'),
                                   metavar='DIR',
                                   dest='special-opts:%s_report' % report_type)


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed that mypy could not be built reproducibly due non-deterministic Python dict ordering.

 [0] https://reproducible-builds.org/
