### PR TITLE
Allow importing a submodule ahead of its parent module

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -774,7 +774,7 @@ def is_meta_fresh(meta: Optional[CacheMeta], id: str, path: str, manager: BuildM
     st = manager.get_stat(path)  # TODO: Errors
     if st.st_mtime != meta.mtime or st.st_size != meta.size:
         manager.log('Metadata abandoned for {}: file {} is modified'.format(id, path))
-        return None
+        return False
 
     # It's a match on (id, path, mtime, size).
     # Check data_json; assume if its mtime matches it's good.
@@ -1650,7 +1650,11 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
             process_stale_scc(graph, scc)
 
     sccs_left = len(fresh_scc_queue)
-    manager.log("{} fresh SCCs left in queue (and will remain unprocessed)".format(sccs_left))
+    if sccs_left:
+        manager.log("{} fresh SCCs left in queue (and will remain unprocessed)".format(sccs_left))
+        manager.trace(str(fresh_scc_queue))
+    else:
+        manager.log("No fresh SCCs left in queue")
 
 
 def order_ascc(graph: Graph, ascc: AbstractSet[str], pri_max: int = PRI_ALL) -> List[str]:

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1615,3 +1615,22 @@ from funcs import callee
 from classes import Outer
 def caller(a: Outer.Inner) -> int:
     callee(a)
+
+[case testIncrementalLoadsParentAfterChild]
+# cmd: mypy -m r.s
+
+[file r/__init__.py]
+from . import s
+
+[file r/m.py]
+class R: pass
+
+[file r/s.py]
+from . import m
+R = m.R
+a = None  # type: R
+
+[file r/s.py.next]
+from . import m
+R = m.R
+a = None  # type: R


### PR DESCRIPTION
Fixes #2133.
    
(This is the third fix for this issue.  I'm happiest with this version.)

The solution is not to bail out early when the parent module is
unavailable -- if all the imports are submodules of a package that's
acceptable (the bug was that in incremental mode it's possible that
the parent is fresh and has not been entered into the modules dict
yet, but the bail-out caused the import to be marked as missing).
