### PR TITLE
[conflict] Implicitly assign class type to the first parameter of its methods (#1514)

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -346,10 +346,10 @@ class BuildManager:
         self.reports = reports
         self.options = options
         self.version_id = version_id
-        self.semantic_analyzer = SemanticAnalyzer(lib_path, self.errors)
+        self.semantic_analyzer = SemanticAnalyzer(lib_path, self.errors, options)
         self.modules = self.semantic_analyzer.modules
-        self.semantic_analyzer_pass3 = ThirdPass(self.modules, self.errors)
-        self.type_checker = TypeChecker(self.errors, self.modules)
+        self.semantic_analyzer_pass3 = ThirdPass(self.modules, self.errors, options)
+        self.type_checker = TypeChecker(self.errors, self.modules, options)
         self.indirection_detector = TypeIndirectionVisitor()
         self.missing_modules = set()  # type: Set[str]
         self.stale_modules = set()  # type: Set[str]

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -121,7 +121,7 @@ class TypeChecker(NodeVisitor[Type]):
     # directly or indirectly.
     module_refs = None  # type: Set[str]
 
-    def __init__(self, errors: Errors, modules: Dict[str, MypyFile]) -> None:
+    def __init__(self, errors: Errors, modules: Dict[str, MypyFile], options: Options) -> None:
         """Construct a type checker.
 
         Use errors to report type check errors.
@@ -132,7 +132,7 @@ class TypeChecker(NodeVisitor[Type]):
         self.type_map = {}
         self.module_type_map = {}
         self.binder = ConditionalTypeBinder()
-        self.expr_checker = mypy.checkexpr.ExpressionChecker(self, self.msg)
+        self.expr_checker = mypy.checkexpr.ExpressionChecker(self, self.msg, options)
         self.return_types = []
         self.type_context = []
         self.dynamic_funcs = []
@@ -142,6 +142,7 @@ class TypeChecker(NodeVisitor[Type]):
         self.pass_num = 0
         self.current_node_deferred = False
         self.module_refs = set()
+        self.options = options
 
     def visit_file(self, file_node: MypyFile, path: str, options: Options) -> None:
         """Type check a mypy file with the given path."""
@@ -2322,10 +2323,10 @@ class TypeChecker(NodeVisitor[Type]):
         return iterable.args[0]
 
     def function_type(self, func: FuncBase) -> FunctionLike:
-        return function_type(func, self.named_type('builtins.function'))
+        return function_type(func, self.named_type('builtins.function'), self.options)
 
     def method_type(self, func: FuncBase) -> FunctionLike:
-        return method_type_with_fallback(func, self.named_type('builtins.function'))
+        return method_type_with_fallback(func, self.named_type('builtins.function'), self.options)
 
 
 # Data structure returned by find_isinstance_check representing


### PR DESCRIPTION
Follow up on PR #1586: assign the class type to first parameter of it's dynamic method if --check-untyped-defs is enabled and if the parameter variable is named "self".
