### PR TITLE
Implement new NamedTuple syntax

### DIFF
--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -66,6 +66,7 @@ files = [
     'check-warnings.test',
     'check-async-await.test',
     'check-newtype.test',
+    'check-class-namedtuple.test',
     'check-columns.test',
 ]
 

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -56,6 +56,14 @@ x.z      # E: "X" has no attribute "z"
 x = X(1) # E: Too few arguments for "X"
 x = X(1, '2', 3)  # E: Too many arguments for "X"
 
+[case testNewNamedTupleShouldBeSingleBase]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class A: ...
+class X(NamedTuple, A):  # E: NamedTuple should be a single base
+    pass
+
 [case testCreateNewNamedTupleWithKeywordArguments]
 # flags: --fast-parser --python-version 3.6
 from typing import NamedTuple
@@ -222,7 +230,19 @@ MyNamedTuple.x # E: "MyNamedTuple" has no attribute "x"
 from typing import NamedTuple
 
 class A(NamedTuple):
-    pass
+    ...
+
+[case testNewNamedTupleForwardRef]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class A(NamedTuple):
+    b: 'B'
+
+class B: ...
+
+a = A(B())
+a = A(1)  # E: Argument 1 to "A" has incompatible type "int"; expected "B"
 
 [case testNewNamedTupleProperty]
 # flags: --fast-parser --python-version 3.6
@@ -322,8 +342,8 @@ from typing import NamedTuple
 
 class X(NamedTuple):
     x: int
-    y: str
-    def f(self): pass  # E: Invalid definition in NamedTuple
+    y = z = 2  # E: Invalid statement in NamedTuple definition; expected "field_name: field_type"
+    def f(self): pass  # E: Invalid statement in NamedTuple definition; expected "field_name: field_type"
 
 [case testNewNamedTupleWithInvalidItems2]
 # flags: --fast-parser --python-version 3.6
@@ -331,10 +351,22 @@ from typing import NamedTuple
 
 class X(NamedTuple):
     x: int
-    y: str
-    x[0]: int  # E: NamedTuple supports only simple fields
+    y: str = 'y'  # E: NamedTuple does not support initial values
+    x[0]: int  # E: Invalid statement in NamedTuple definition; expected "field_name: field_type"
 
 [builtins fixtures/list.pyi]
+
+[case testNewNamedTupleWithoutTypesSpecified]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):
+    x: int
+    y = 2
+
+[out]
+main:6: error: NamedTuple does not support initial values
+main:6: error: NamedTuple field type must be specified
 
 [case testTypeUsingTypeCNamedTuple]
 # flags: --fast-parser --python-version 3.6

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -1,0 +1,358 @@
+[case testNewNamedTupleOldPythonVersion]
+# flags: --fast-parser --python-version 3.5
+from typing import NamedTuple
+
+class E(NamedTuple):  # E: NamedTuple class syntax is only supported in Python 3.6+
+    x: int
+    y: str
+
+[case testNewNamedTupleNoUnderscoreFields]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):  # E: NamedTuple field names cannot start with an underscore: _y, _z
+    x: int
+    _y: int
+    _z: int
+
+[case testNewNamedTupleAccessingAttributes]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):
+    x: int
+    y: str
+
+x: X
+x.x
+x.y
+x.z # E: "X" has no attribute "z"
+
+[case testNewNamedTupleAttributesAreReadOnly]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):
+    x: int
+    y: str
+
+x: X
+x.x = 5 # E: Property "x" defined in "X" is read-only
+x.y = 5 # E: Property "y" defined in "X" is read-only
+x.z = 5 # E: "X" has no attribute "z"
+
+class A(X): pass
+a: A
+a.x = 5 # E: Property "x" defined in "A" is read-only
+a.y = 5 # E: Property "y" defined in "A" is read-only
+-- a.z = 5 # not supported yet
+
+[case testNewNamedTupleCreateWithPositionalArguments]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):
+    x: int
+    y: str
+
+x = X(1, 'x')
+x.x
+x.z      # E: "X" has no attribute "z"
+x = X(1) # E: Too few arguments for "X"
+x = X(1, 2, 3)  # E: Too many arguments for "X"
+
+[case testCreateNewNamedTupleWithKeywordArguments]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):
+    x: int
+    y: str
+
+x = X(x=1, y='x')
+x = X(1, y='x')
+x = X(x=1, z=1) # E: Unexpected keyword argument "z" for "X"
+x = X(y=1) # E: Missing positional argument "x" in call to "X"
+
+[case testNewNamedTupleCreateAndUseAsTuple]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):
+    x: int
+    y: str
+
+x = X(1, 'x')
+a, b = x
+a, b, c = x  # E: Need more than 2 values to unpack (3 expected)
+
+[case testNewNamedTupleWithItemTypes]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class N(NamedTuple):
+    a: int
+    b: str
+
+n = N(1, 'x')
+s: str = n.a  # E: Incompatible types in assignment (expression has type "int", \
+                          variable has type "str")
+i: int = n.b  # E: Incompatible types in assignment (expression has type "str", \
+                          variable has type "int")
+x, y = n
+x = y  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testNewNamedTupleConstructorArgumentTypes]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class N(NamedTuple):
+    a: int
+    b: str
+
+n = N('x', 'x') # E: Argument 1 to "N" has incompatible type "str"; expected "int"
+n = N(1, b=2)   # E: Argument 2 to "N" has incompatible type "int"; expected "str"
+N(1, 'x')
+N(b='x', a=1)
+
+[case testNewNamedTupleAsBaseClass]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class N(NamedTuple):
+    a: int
+    b: str
+
+class X(N):
+    pass
+x = X(1, 2)  # E: Argument 2 to "X" has incompatible type "int"; expected "str"
+s = ''
+i = 0
+s = x.a  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+i, s = x
+s, s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+[case testNewNamedTupleSelfTypeWithNamedTupleAsBase]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class A(NamedTuple):
+    a: int
+    b: str
+
+class B(A):
+    def f(self, x: int) -> None:
+        self.f(self.a)
+        self.f(self.b)  # E: Argument 1 to "f" of "B" has incompatible type "str"; expected "int"
+        i = 0
+        s = ''
+        i, s = self
+        i, i = self  # E: Incompatible types in assignment (expression has type "str", \
+                          variable has type "int")
+[out]
+main: note: In member "f" of class "B":
+
+[case testNewNamedTupleTypeReferenceToClassDerivedFrom]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class A(NamedTuple):
+    a: int
+    b: str
+
+class B(A):
+    def f(self, x: 'B') -> None:
+        i = 0
+        s = ''
+        self = x
+        i, s = x
+        i, s = x.a, x.b
+        i, s = x.a, x.a  # E: Incompatible types in assignment (expression has type "int", \
+                              variable has type "str")
+        i, i = self  # E: Incompatible types in assignment (expression has type "str", \
+                          variable has type "int")
+
+[out]
+main: note: In member "f" of class "B":
+
+[case testNewNamedTupleSubtyping]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple, Tuple
+
+class A(NamedTuple):
+    a: int
+    b: str
+
+class B(A): pass
+a = A(1, '')
+b = B(1, '')
+t: Tuple[int, str]
+b = a  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+a = t  # E: Incompatible types in assignment (expression has type "Tuple[int, str]", variable has type "A")
+b = t  # E: Incompatible types in assignment (expression has type "Tuple[int, str]", variable has type "B")
+t = a
+t = (1, '')
+t = b
+a = b
+
+[case testNewNamedTupleSimpleTypeInference]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple, Tuple
+
+class A(NamedTuple):
+    a: int
+
+l = [A(1), A(2)]
+a = A(1)
+a = l[0]
+(i,) = l[0]
+i, i = l[0]  # E: Need more than 1 value to unpack (2 expected)
+l = [A(1)]
+a = (1,)  # E: Incompatible types in assignment (expression has type "Tuple[int]", \
+               variable has type "A")
+[builtins fixtures/list.pyi]
+
+[case testNewNamedTupleMissingClassAttribute]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class MyNamedTuple(NamedTuple):
+    a: int
+    b: str
+
+MyNamedTuple.x # E: "MyNamedTuple" has no attribute "x"
+
+[case testNewNamedTupleEmptyItems]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class A(NamedTuple):
+    ...
+
+[case testNewNamedTupleProperty]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class A(NamedTuple):
+    a: int
+    b: str
+
+class B(A):
+    @property
+    def b(self) -> int:
+        return self.a
+class C(B): pass
+B(1).b
+C(2).b
+
+[builtins fixtures/property.pyi]
+
+[case testNewNamedTupleAsDict]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple, Any
+
+class X(NamedTuple):
+    x: Any
+    y: Any
+
+x: X
+reveal_type(x._asdict())  # E: Revealed type is 'builtins.dict[builtins.str, Any]'
+
+[builtins fixtures/dict.pyi]
+
+[case testNewNamedTupleReplaceTyped]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):
+    x: int
+    y: str
+
+x: X
+reveal_type(x._replace())  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
+x._replace(x=5)
+x._replace(y=5)  # E: Argument 1 to X._replace has incompatible type "int"; expected "str"
+
+[case testNewNamedTupleFields]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):
+    x: int
+    y: str
+
+reveal_type(X._fields)  # E: Revealed type is 'Tuple[builtins.str, builtins.str]'
+
+[case testNewNamedTupleUnit]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):
+    ...
+
+x: X = X()
+x._replace()
+x._fields[0]  # E: Tuple index out of range
+
+[case testNewNamedTupleJoinNamedTuple]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):
+    x: int
+    y: str
+class Y(NamedTuple):
+    x: int
+    y: str
+
+reveal_type([X(3, 'b'), Y(1, 'a')])  # E: Revealed type is 'builtins.list[Tuple[builtins.int, builtins.str]]'
+
+[builtins fixtures/list.pyi]
+
+[case testNewNamedTupleJoinTuple]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):
+    x: int
+    y: str
+
+reveal_type([(3, 'b'), X(1, 'a')])  # E: Revealed type is 'builtins.list[Tuple[builtins.int, builtins.str]]'
+reveal_type([X(1, 'a'), (3, 'b')])  # E: Revealed type is 'builtins.list[Tuple[builtins.int, builtins.str]]'
+
+[builtins fixtures/list.pyi]
+
+[case testNewNamedTupleWithTooManyArguments]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):
+    x: int
+    y: str
+    def f(self): pass  # E: NamedTuple only allows names as fields
+
+[case testNewNamedTupleWithInvalidItems2]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class X(NamedTuple):
+    x: int
+    y: str
+    [0][0]: int  # E: NamedTuple only allows names as fields
+
+[builtins fixtures/list.pyi]
+
+[case testTypeUsingTypeCNamedTuple]
+# flags: --fast-parser --python-version 3.6
+from typing import NamedTuple
+
+class N(NamedTuple):
+    x: int
+    y: str
+
+def f(a: Type[N]):
+    a()
+[builtins fixtures/list.pyi]
+[out]
+main: note: In function "f":
+main:3: error: Unsupported type Type["N"]

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -2,18 +2,17 @@
 # flags: --fast-parser --python-version 3.5
 from typing import NamedTuple
 
-class E(NamedTuple):  # E: NamedTuple class syntax is only supported in Python 3.6+
-    x: int
-    y: str
+class E(NamedTuple):  # E: NamedTuple class syntax is only supported in Python 3.6
+    pass
 
 [case testNewNamedTupleNoUnderscoreFields]
 # flags: --fast-parser --python-version 3.6
 from typing import NamedTuple
 
-class X(NamedTuple):  # E: NamedTuple field names cannot start with an underscore: _y, _z
+class X(NamedTuple):
     x: int
-    _y: int
-    _z: int
+    _y: int  # E: NamedTuple field name cannot start with an underscore: _y
+    _z: int  # E: NamedTuple field name cannot start with an underscore: _z
 
 [case testNewNamedTupleAccessingAttributes]
 # flags: --fast-parser --python-version 3.6
@@ -34,18 +33,14 @@ from typing import NamedTuple
 
 class X(NamedTuple):
     x: int
-    y: str
 
 x: X
 x.x = 5 # E: Property "x" defined in "X" is read-only
-x.y = 5 # E: Property "y" defined in "X" is read-only
-x.z = 5 # E: "X" has no attribute "z"
+x.y = 5 # E: "X" has no attribute "y"
 
 class A(X): pass
 a: A
 a.x = 5 # E: Property "x" defined in "A" is read-only
-a.y = 5 # E: Property "y" defined in "A" is read-only
--- a.z = 5 # not supported yet
 
 [case testNewNamedTupleCreateWithPositionalArguments]
 # flags: --fast-parser --python-version 3.6
@@ -55,11 +50,11 @@ class X(NamedTuple):
     x: int
     y: str
 
-x = X(1, 'x')
+x = X(1, '2')
 x.x
 x.z      # E: "X" has no attribute "z"
 x = X(1) # E: Too few arguments for "X"
-x = X(1, 2, 3)  # E: Too many arguments for "X"
+x = X(1, '2', 3)  # E: Too many arguments for "X"
 
 [case testCreateNewNamedTupleWithKeywordArguments]
 # flags: --fast-parser --python-version 3.6
@@ -72,7 +67,7 @@ class X(NamedTuple):
 x = X(x=1, y='x')
 x = X(1, y='x')
 x = X(x=1, z=1) # E: Unexpected keyword argument "z" for "X"
-x = X(y=1) # E: Missing positional argument "x" in call to "X"
+x = X(y='x') # E: Missing positional argument "x" in call to "X"
 
 [case testNewNamedTupleCreateAndUseAsTuple]
 # flags: --fast-parser --python-version 3.6
@@ -227,7 +222,7 @@ MyNamedTuple.x # E: "MyNamedTuple" has no attribute "x"
 from typing import NamedTuple
 
 class A(NamedTuple):
-    ...
+    pass
 
 [case testNewNamedTupleProperty]
 # flags: --fast-parser --python-version 3.6
@@ -235,7 +230,6 @@ from typing import NamedTuple
 
 class A(NamedTuple):
     a: int
-    b: str
 
 class B(A):
     @property
@@ -288,7 +282,7 @@ reveal_type(X._fields)  # E: Revealed type is 'Tuple[builtins.str, builtins.str]
 from typing import NamedTuple
 
 class X(NamedTuple):
-    ...
+    pass
 
 x: X = X()
 x._replace()
@@ -329,7 +323,7 @@ from typing import NamedTuple
 class X(NamedTuple):
     x: int
     y: str
-    def f(self): pass  # E: NamedTuple only allows names as fields
+    def f(self): pass  # E: Invalid definition in NamedTuple
 
 [case testNewNamedTupleWithInvalidItems2]
 # flags: --fast-parser --python-version 3.6
@@ -338,13 +332,13 @@ from typing import NamedTuple
 class X(NamedTuple):
     x: int
     y: str
-    [0][0]: int  # E: NamedTuple only allows names as fields
+    x[0]: int  # E: NamedTuple supports only simple fields
 
 [builtins fixtures/list.pyi]
 
 [case testTypeUsingTypeCNamedTuple]
 # flags: --fast-parser --python-version 3.6
-from typing import NamedTuple
+from typing import NamedTuple, Type
 
 class N(NamedTuple):
     x: int
@@ -355,4 +349,4 @@ def f(a: Type[N]):
 [builtins fixtures/list.pyi]
 [out]
 main: note: In function "f":
-main:3: error: Unsupported type Type["N"]
+main:8: error: Unsupported type Type["N"]

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -351,7 +351,7 @@ import typing
 
 class X(typing.NamedTuple):
     x: int
-    y: str = 'y'
+    y: str = 'y'  # E: Right hand side values are not supported in NamedTuple
     z = None  # type: int # E: Invalid statement in NamedTuple definition; expected "field_name: field_type"
     x[0]: int  # E: Invalid statement in NamedTuple definition; expected "field_name: field_type"
 

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -347,11 +347,12 @@ class X(NamedTuple):
 
 [case testNewNamedTupleWithInvalidItems2]
 # flags: --fast-parser --python-version 3.6
-from typing import NamedTuple
+import typing
 
-class X(NamedTuple):
+class X(typing.NamedTuple):
     x: int
-    y: str = 'y'  # E: NamedTuple does not support initial values
+    y: str = 'y'
+    z = None  # type: int # E: Invalid statement in NamedTuple definition; expected "field_name: field_type"
     x[0]: int  # E: Invalid statement in NamedTuple definition; expected "field_name: field_type"
 
 [builtins fixtures/list.pyi]
@@ -362,11 +363,7 @@ from typing import NamedTuple
 
 class X(NamedTuple):
     x: int
-    y = 2
-
-[out]
-main:6: error: NamedTuple does not support initial values
-main:6: error: NamedTuple field type must be specified
+    y = 2  # E: Invalid statement in NamedTuple definition; expected "field_name: field_type"
 
 [case testTypeUsingTypeCNamedTuple]
 # flags: --fast-parser --python-version 3.6


### PR DESCRIPTION
Starting from Python 3.6b1, ``typing.NamedTuple`` supports the PEP 526 syntax:
```python
from typing import NamedTuple

class Employee(NamedTuple):
    name: str
    salary: int

manager = Employee('John Doe', 9000)
```
Here is the support of this feature for mypy. It works only with ``--fast-parser``, since it is required to parse PEP 526 syntax. Roughly half of the tests are simply adapted from tests for function ``NamedTuple`` syntax, plus another half are specific for the new syntax.

@gvanrossum Please take a look.