### PR TITLE
Allow a module to be imported with no __init__.py(i) file in its path

### DIFF
--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1,5 +1,16 @@
 -- Type checker test cases dealing with modules and imports.
 
+[case testAccessPackageWithoutInitFile]
+import typing
+import m.n
+from m.o.p import s
+m.n.x
+m.o.p.s("test")
+[file m/n.py]
+x = 1
+[file m/o/p.py]
+def s(a: str) -> None: pass
+
 [case testAccessImportedDefinitions]
 import m
 import typing

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -351,17 +351,6 @@ tmp/m/n.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/k.py:2: error: Name 'y' is not defined
 
-[case testPackageWithoutInitFile]
-import typing
-import m.n
-m.n.x
-[file m/n.py]
-x = 1
-[out]
-main:2: error: Cannot find module named 'm'
-main:2: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
-main:2: error: Cannot find module named 'm.n'
-
 [case testBreakOutsideLoop]
 break
 def f():


### PR DESCRIPTION
This change allows a user to import a module without the explicit need for an `__init__.py(i)` in the paths. For example, it a user wants to do the following:

```
# /project/main.py
from app.utils import foobar

# /project/app/utils.py
def foobar() -> None: pass
```

they now don't need to add an `__init__.py(i)` file into `/project/app`. 