### PR TITLE
Report error on dynamic metaclass

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -373,9 +373,10 @@ class ASTConverter(ast35.NodeTransformer):
         if isinstance(n, ast35.Name):
             return n.id
         elif isinstance(n, ast35.Attribute):
-            return "{}.{}".format(self.stringify_name(n.value), n.attr)
-        else:
-            assert False, "can't stringify " + str(type(n))
+            sv = self.stringify_name(n.value)
+            if sv is not None:
+                return "{}.{}".format(sv, n.attr)
+        return None  # Can't do it.
 
     # ClassDef(identifier name,
     #  expr* bases,
@@ -389,6 +390,8 @@ class ASTConverter(ast35.NodeTransformer):
         metaclass = None
         if metaclass_arg:
             metaclass = self.stringify_name(metaclass_arg.value)
+            if metaclass is None:
+                metaclass = '<error>'  # To be reported later
 
         cdef = ClassDef(n.name,
                         self.as_block(n.body, n.lineno),

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -846,6 +846,9 @@ class SemanticAnalyzer(NodeVisitor):
 
     def analyze_metaclass(self, defn: ClassDef) -> None:
         if defn.metaclass:
+            if defn.metaclass == '<error>':
+                self.fail("Dynamic metaclass not supported for '%s'" % defn.name, defn)
+                return
             sym = self.lookup_qualified(defn.metaclass, defn)
             if sym is not None and not isinstance(sym.node, TypeInfo):
                 self.fail("Invalid metaclass '%s'" % defn.metaclass, defn)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2070,3 +2070,8 @@ class A: pass
 class B(object, A): # E: Cannot determine consistent method resolution order (MRO) for "B"
     def readlines(self): pass
     __iter__ = readlines
+
+[case testDynamicMetaclass]
+# flags: --fast-parser
+class C(metaclass=int()):  # E: Dynamic metaclass not supported for 'C'
+    pass


### PR DESCRIPTION
Previously the fast parser would crash ("assert False" in stringify_name()). Now it forces an error.

I didn't see a decent way to report an error from fastparser.py, so I set the metaclass name to `"<error>"` and check for that in semanal.py which will report a decent error.

Note that the old parser still reports a syntax error on the '(', I think that's fine. Also there doesn't seem to be a corresponding issue with Python 2.

Fixes #2273.