### PR TITLE
Allow using --fast-parser in stubgen

### DIFF
--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -125,6 +125,8 @@ def test_stubgen(testcase):
         try:
             if testcase.name.endswith('_import'):
                 generate_stub_for_module(name, out_dir, quiet=True)
+            elif testcase.name.endswith('_fast_parser'):
+                generate_stub(path, out_dir, fast_parser=True)
             else:
                 generate_stub(path, out_dir)
             a = load_output(out_dir)

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -543,6 +543,12 @@ def syslog(a): pass
 [out]
 def syslog(a): ...
 
+[case testAsyncAwait_fast_parser]
+async def f(a):
+   x = await y
+[out]
+def f(a): ...
+
 [case testInferOptionalOnlyFunc]
 class A:
     x = None


### PR DESCRIPTION
Allow using fast parser in stubgen, as proposed on Gitter (mainly to generate stubs for modules that use ``async/await`` syntax).