### PR TITLE
Rename mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,0 @@
-[mypy]
-show_none_errors = False
-
-[mypy-mypy/test/*]
-show_none_errors = True

--- a/mypy_strict_optional.ini
+++ b/mypy_strict_optional.ini
@@ -1,0 +1,8 @@
+; Mypy is run both with and without this config file in CI.
+; This allows us to make mypy strict Optional compliant over time.
+[mypy]
+strict_optional = True
+show_none_errors = False
+
+[mypy-mypy/test/*]
+show_none_errors = True

--- a/runtests.py
+++ b/runtests.py
@@ -168,7 +168,7 @@ def add_basic(driver: Driver) -> None:
 
 def add_selftypecheck(driver: Driver) -> None:
     driver.add_mypy_package('package mypy', 'mypy')
-    driver.add_mypy_package('package mypy', 'mypy', '--strict-optional')
+    driver.add_mypy_package('package mypy', 'mypy', '--config-file', 'mypy_strict_optional.ini')
 
 
 def find_files(base: str, prefix: str = '', suffix: str = '') -> List[str]:


### PR DESCRIPTION
Otherwise, strict Optional errors are suppressed whenever you run mypy from the mypy directory, regardless of what you're running it on.