### PR TITLE
Don't learn anything from isinstance checks that always pass or fail

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2395,9 +2395,11 @@ def conditional_type_map(expr: Expression,
     if proposed_type:
         if current_type:
             if is_proper_subtype(current_type, proposed_type):
-                return {expr: proposed_type}, None
+                # Expression is always of type proposed_type
+                return {}, None
             elif not is_overlapping_types(current_type, proposed_type):
-                return None, {expr: current_type}
+                # Expression is never of type proposed_type
+                return None, {}
             else:
                 remaining_type = restrict_subtype_away(current_type, proposed_type)
                 return {expr: proposed_type}, {expr: remaining_type}

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1234,6 +1234,28 @@ def f(x: Union[A, B]) -> None:
         f(x)
 [builtins fixtures/isinstance.pyi]
 
+[case testIsinstanceOfSuperclass]
+class A: pass
+class B(A): pass
+x = B()
+if isinstance(x, A):
+    reveal_type(x)  # E: Revealed type is '__main__.B'
+if not isinstance(x, A):
+    reveal_type(x)  # unreachable
+    x = A()
+reveal_type(x)  # E: Revealed type is '__main__.B'
+[builtins fixtures/isinstance.pyi]
+
+[case testIsinstanceOfNonoverlapping]
+class A: pass
+class B: pass
+x = B()
+if isinstance(x, A):
+    reveal_type(x)  # unreachable
+else:
+    reveal_type(x)  # E: Revealed type is '__main__.B'
+[builtins fixtures/isinstance.pyi]
+
 [case testAssertIsinstance]
 def f(x: object):
     assert isinstance(x, int)


### PR DESCRIPTION
Previously in a case like

    class A: pass
    class B(A): pass
    x = B()
    if isinstance(x, A):
        ...

we would "learn" inside the `if` that x has type A (and forget that it has
type B), which is silly since B is a subtype of A anyway.

For symmetry we also learn nothing in the non-overlapping case, where an
isinstance check would always fail; this should make no difference since
the type we learned was the same as the current type.