### PR TITLE
Don't turn types containing None into partial types (in strict Optional mode)

### DIFF
--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -167,8 +167,7 @@ reveal_type(x)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
 
 [case testInferOptionalListType]
 x = [None]
-x.append(1)
-reveal_type(x)  # E: Revealed type is 'builtins.list[Union[builtins.int, builtins.None]]'
+x.append(1)  # E: Argument 1 to "append" of "list" has incompatible type "int"; expected None
 [builtins fixtures/list.pyi]
 
 [case testInferNonOptionalListType]
@@ -180,8 +179,10 @@ x()  # E: List[int] not callable
 [case testInferOptionalDictKeyValueTypes]
 x = {None: None}
 x["bar"] = 1
-reveal_type(x)  # E: Revealed type is 'builtins.dict[Union[builtins.str, builtins.None], Union[builtins.int, builtins.None]]'
 [builtins fixtures/dict.pyi]
+[out]
+main:2: error: Invalid index type "str" for "dict"
+main:2: error: Incompatible types in assignment (expression has type "int", target has type None)
 
 [case testInferNonOptionalDictType]
 x = {}
@@ -437,3 +438,16 @@ def g() -> Dict[None, None]:
 [case testRaiseFromNone]
 raise BaseException from None
 [builtins fixtures/exception.pyi]
+
+[case testOptionalNonPartialTypeWithNone]
+from typing import Generator
+def f() -> Generator[str, None, None]: pass
+x = f()
+reveal_type(x)  # E: Revealed type is 'typing.Generator[builtins.str, builtins.None, builtins.None]'
+l = [f()]
+reveal_type(l)  # E: Revealed type is 'builtins.list[typing.Generator*[builtins.str, builtins.None, builtins.None]]'
+[builtins fixtures/list.pyi]
+
+[case testNoneListTernary]
+x = [None] if "" else [1]  # E: List item 0 has incompatible type "int"
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
This means mypy will no longer give `Need type annotation for variable` errors for assignments with values of type `Generator[str, None, None]` or `List[None]` or similar.  However, lists, sets, and dicts that are initialized with None values that were previously inferred may now need type annotations.  I.e. constructs that look like:
```py
x = [None]
x.append(0)
```
will now be type errors unless they have explicit annotations.

Supplants #2225.  Fixes #2246.  Fixes #2195.  Fixes #2258.