### PR TITLE
Give a helpful error when attempting to call function of unknown type

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -351,7 +351,12 @@ class MessageBuilder:
             # Indexed set.
             self.fail('Unsupported target for indexed assignment', context)
         elif member == '__call__':
-            self.fail('{} not callable'.format(self.format(typ)), context)
+            if isinstance(typ, Instance) and (typ.type.fullname() == 'builtins.function'):
+                # "'function' not callable" is a confusing error message.
+                # Explain that the problem is that the type of the function is not known.
+                self.fail('Cannot call function of unknown type', context)
+            else:
+                self.fail('{} not callable'.format(self.format(typ)), context)
         else:
             # The non-special case: a missing ordinary attribute.
             if not self.disable_type_names:

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1524,3 +1524,13 @@ class A:
 def dec(f: Callable[[A, str], None]) -> Callable[[A, int], None]: pass
 [out]
 main: note: In member "f" of class "A":
+
+[case testUnknownFunctionNotCallable]
+def f() -> None:
+    pass
+def g(x: int) -> None:
+    pass
+h = f if bool() else g
+reveal_type(h) # E: Revealed type is 'builtins.function'
+h(7) # E: Cannot call function of unknown type
+[builtins fixtures/bool.pyi]


### PR DESCRIPTION
The old message was "'function' not callable", which was confusing.