### PR TITLE
Underscores in numeric literals

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -735,7 +735,7 @@ class ASTConverter(ast35.NodeTransformer):
     def visit_Num(self, n: ast35.Num) -> Union[IntExpr, FloatExpr, ComplexExpr]:
         if getattr(n, 'underscores', None) and self.pyversion < (3, 6):
             raise FastParserError('Underscores in numeric literals are only '
-                                  'suppoted in Python 3.6', n.lineno, n.col_offset)
+                                  'supported in Python 3.6', n.lineno, n.col_offset)
         if isinstance(n.n, int):
             return IntExpr(n.n)
         elif isinstance(n.n, float):

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -733,6 +733,9 @@ class ASTConverter(ast35.NodeTransformer):
     # Num(object n) -- a number as a PyObject.
     @with_line
     def visit_Num(self, n: ast35.Num) -> Union[IntExpr, FloatExpr, ComplexExpr]:
+        if getattr(n, 'underscores', None) and self.pyversion < (3, 6):
+            raise FastParserError('Underscores in numeric literals are only '
+                                  'suppoted in Python 3.6', n.lineno, n.col_offset)
         if isinstance(n.n, int):
             return IntExpr(n.n)
         elif isinstance(n.n, float):
@@ -904,3 +907,7 @@ class TypeCommentParseError(Exception):
         self.msg = msg
         self.lineno = lineno
         self.offset = offset
+
+
+class FastParserError(TypeCommentParseError):
+    pass

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -72,6 +72,9 @@ files = [
 if 'annotation' in typed_ast.ast35.Assign._fields:
     files.append('check-newsyntax.test')
 
+if 'underscores' in typed_ast.ast35.Num._fields:
+    files.append('check-underscores.test')
+
 
 class TypeCheckSuite(DataSuite):
     def __init__(self, *, update_data=False):

--- a/test-data/unit/check-underscores.test
+++ b/test-data/unit/check-underscores.test
@@ -1,6 +1,6 @@
 [case testUnderscoresRequire36]
 # flags: --fast-parser --python-version 3.5
-x = 1000_000  # E: Underscores in numeric literals are only suppoted in Python 3.6
+x = 1000_000  # E: Underscores in numeric literals are only supported in Python 3.6
 [out]
 
 [case testUnderscoresSyntaxError]

--- a/test-data/unit/check-underscores.test
+++ b/test-data/unit/check-underscores.test
@@ -1,0 +1,15 @@
+[case testUnderscoresRequire36]
+# flags: --fast-parser --python-version 3.5
+x = 1000_000  # E: Underscores in numeric literals are only suppoted in Python 3.6
+[out]
+
+[case testUnderscoresSyntaxError]
+# flags: --fast-parser --python-version 3.6
+x = 1000_000_  # E: invalid token
+[out]
+
+[case testUnderscoresBasics]
+# flags: --fast-parser --python-version 3.6
+x: int
+x = 1000_000
+y: str = 1000_000.000_001  # E: Incompatible types in assignment (expression has type "float", variable has type "str")


### PR DESCRIPTION
There is a PR for implementation of underscores in numeric literals https://github.com/dropbox/typed_ast/pull/21

Here is the mypy counterpart (essentially just an error if used with Python 3.5 or less).
Until the ``typed_ast`` PR is merged and published on PyPI, this PR will have no effect (but no problems as well).

@gvanrossum @ddfisher Please, take a look.