### PR TITLE
Understand that types are not Optional if they're equal to a non-Optional type

### DIFF
--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -451,3 +451,49 @@ reveal_type(l)  # E: Revealed type is 'builtins.list[typing.Generator*[builtins.
 [case testNoneListTernary]
 x = [None] if "" else [1]  # E: List item 0 has incompatible type "int"
 [builtins fixtures/list.pyi]
+
+[case testInferEqualsNotOptional]
+from typing import Optional
+x = ''  # type: Optional[str]
+if x == '<string>':
+    reveal_type(x)  # E: Revealed type is 'builtins.str'
+else:
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.None]'
+[builtins fixtures/ops.pyi]
+
+[case testInferEqualsNotOptionalWithUnion]
+from typing import Union
+x = ''  # type: Union[str, int, None]
+if x == '<string>':
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int]'
+else:
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int, builtins.None]'
+[builtins fixtures/ops.pyi]
+
+[case testInferEqualsNotOptionalWithOverlap]
+from typing import Union
+x = ''  # type: Union[str, int, None]
+if x == object():
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int]'
+else:
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int, builtins.None]'
+[builtins fixtures/ops.pyi]
+
+[case testInferEqualsStillOptionalWithNoOverlap]
+from typing import Optional
+x = ''  # type: Optional[str]
+if x == 0:
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.None]'
+else:
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.None]'
+[builtins fixtures/ops.pyi]
+
+[case testInferEqualsStillOptionalWithBothOptional]
+from typing import Union
+x = ''  # type: Union[str, int, None]
+y = ''  # type: Union[str, None]
+if x == y:
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int, builtins.None]'
+else:
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int, builtins.None]'
+[builtins fixtures/ops.pyi]

--- a/test-data/unit/fixtures/ops.pyi
+++ b/test-data/unit/fixtures/ops.pyi
@@ -51,8 +51,8 @@ class float: pass
 
 class BaseException: pass
 
-True = None # type: bool
-False = None # type: bool
+True = bool() # type: bool
+False = bool() # type: bool
 
 def __print(a1=None, a2=None, a3=None, a4=None): pass
 


### PR DESCRIPTION
If `x` is some Optional type and `y` is some non-Optional type, now infer that `x == y` implies `x` is not Optional, as long as types `x` and `y` overlap.

Fixes #1825.