### PR TITLE
Fix required python version (3.2 -> 3.3)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import os
 import os.path
 import sys
 
-if sys.version_info < (3, 2, 0):
-    sys.stderr.write("ERROR: You need Python 3.2 or later to use mypy.\n")
+if sys.version_info < (3, 3, 0):
+    sys.stderr.write("ERROR: You need Python 3.3 or later to use mypy.\n")
     exit(1)
 
 from distutils.core import setup


### PR DESCRIPTION
Required Python 3.3 or later to run mypy in [README.md](https://github.com/python/mypy#requirements)

But setup.py was 3.2