### PR TITLE
Add mypy_path config option (#2323)

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -51,6 +51,10 @@ The following global flags may only be set in the global section
   alternative directory which is used to look for stubs instead of the
   default ``typeshed`` directory.
 
+- ``mypy_path`` (string) specifies the paths to use, after trying the paths
+  from ``MYPYPATH`` environment variable.  Useful if you'd like to keep stubs
+  in your repo, along with the config file.
+
 - ``warn_incomplete_stub`` (Boolean, default False) warns for missing
   type annotation in typeshed.  This is only relevant in combination
   with ``check_untyped_defs``.

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -153,6 +153,9 @@ def build(sources: List[BuildSource],
         # to the lib_path
         lib_path.insert(0, os.getcwd())
 
+    # Prepend a config-defined mypy path.
+    lib_path[:0] = options.mypy_path
+
     # Add MYPYPATH environment variable to front of library path, if defined.
     lib_path[:0] = mypy_path()
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -454,7 +454,7 @@ config_types = {
     'strict_optional_whitelist': lambda s: s.split(),
     'custom_typing_module': str,
     'custom_typeshed_dir': str,
-    'mypy_path': lambda s: [p.strip() for p in s.split(',')],
+    'mypy_path': lambda s: [p.strip() for p in re.split('[,:]', s)],
     'junit_xml': str,
 }
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -454,6 +454,7 @@ config_types = {
     'strict_optional_whitelist': lambda s: s.split(),
     'custom_typing_module': str,
     'custom_typeshed_dir': str,
+    'mypy_path': lambda s: [p.strip() for p in s.split(',')],
     'junit_xml': str,
 }
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -454,7 +454,9 @@ config_types = {
     'strict_optional_whitelist': lambda s: s.split(),
     'custom_typing_module': str,
     'custom_typeshed_dir': str,
-    'mypy_path': lambda s: [p.strip() for p in re.split('[,:]', s)],
+    'mypy_path': lambda s: [
+        p.strip() for p in re.split('[,{}]'.format(os.pathsep), s)
+    ],
     'junit_xml': str,
 }
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -454,9 +454,7 @@ config_types = {
     'strict_optional_whitelist': lambda s: s.split(),
     'custom_typing_module': str,
     'custom_typeshed_dir': str,
-    'mypy_path': lambda s: [
-        p.strip() for p in re.split('[,{}]'.format(os.pathsep), s)
-    ],
+    'mypy_path': lambda s: [p.strip() for p in re.split('[,:]', s)],
     'junit_xml': str,
 }
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -36,6 +36,7 @@ class Options:
         self.platform = sys.platform
         self.custom_typing_module = None  # type: Optional[str]
         self.custom_typeshed_dir = None  # type: Optional[str]
+        self.mypy_path = []  # type: List[str]
         self.report_dirs = {}  # type: Dict[str, str]
         self.silent_imports = False
         self.almost_silent = False

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -296,3 +296,28 @@ def untyped_function():
     </package>
   </packages>
 </coverage>
+
+[case testConfigMypyPath]
+# cmd: mypy file.py
+[file mypy.ini]
+[[mypy]
+mypy_path =
+    foo:bar
+    , baz
+[file foo/foo.pyi]
+def foo(x: int) -> str: ...
+[file bar/bar.pyi]
+def bar(x: str) -> list: ...
+[file baz/baz.pyi]
+def baz(x: list) -> dict: ...
+[file file.py]
+import no_stubs
+from foo import foo
+from bar import bar
+from baz import baz
+baz(bar(foo(42)))
+baz(bar(foo('oof')))
+[out]
+file.py:1: error: Cannot find module named 'no_stubs'
+file.py:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
+file.py:6: error: Argument 1 to "foo" has incompatible type "str"; expected "int"


### PR DESCRIPTION
I tried to write a simple test for the new `build_lib_path` function, but pytest wouldn't pick it up. Help?