### PR TITLE
Make mypy --warn-no-return clean

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -69,7 +69,7 @@ DeferredNode = NamedTuple(
     ])
 
 
-class TypeChecker(NodeVisitor[Optional[Type]]):
+class TypeChecker(NodeVisitor[Type]):
     """Mypy type checker.
 
     Type check mypy source files that have been semantically analyzed.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -69,7 +69,7 @@ DeferredNode = NamedTuple(
     ])
 
 
-class TypeChecker(NodeVisitor[Type]):
+class TypeChecker(NodeVisitor[Optional[Type]]):
     """Mypy type checker.
 
     Type check mypy source files that have been semantically analyzed.
@@ -298,6 +298,7 @@ class TypeChecker(NodeVisitor[Type]):
             self.check_method_override(defn)
             self.check_inplace_operator_method(defn)
         self.check_overlapping_overloads(defn)
+        return None
 
     def check_overlapping_overloads(self, defn: OverloadedFuncDef) -> None:
         for i, item in enumerate(defn.items):
@@ -494,10 +495,11 @@ class TypeChecker(NodeVisitor[Type]):
                                        messages.INCOMPATIBLE_REDEFINITION,
                                        'redefinition with type',
                                        'original type')
+        return None
 
     def check_func_item(self, defn: FuncItem,
                         type_override: CallableType = None,
-                        name: str = None) -> Type:
+                        name: str = None) -> None:
         """Type check a function.
 
         If type_override is provided, use it as the function type.
@@ -994,6 +996,7 @@ class TypeChecker(NodeVisitor[Type]):
             self.check_multiple_inheritance(typ)
         self.leave_partial_types()
         self.errors.pop_type()
+        return None
 
     def check_multiple_inheritance(self, typ: TypeInfo) -> None:
         """Check for multiple inheritance related errors."""
@@ -1051,11 +1054,13 @@ class TypeChecker(NodeVisitor[Type]):
 
     def visit_import_from(self, node: ImportFrom) -> Type:
         self.check_import(node)
+        return None
 
     def visit_import_all(self, node: ImportAll) -> Type:
         self.check_import(node)
+        return None
 
-    def check_import(self, node: ImportBase) -> Type:
+    def check_import(self, node: ImportBase) -> None:
         for assign in node.assignments:
             lvalue = assign.lvalues[0]
             lvalue_type, _, __ = self.check_lvalue(lvalue)
@@ -1079,6 +1084,7 @@ class TypeChecker(NodeVisitor[Type]):
             if self.binder.is_unreachable():
                 break
             self.accept(s)
+        return None
 
     def visit_assignment_stmt(self, s: AssignmentStmt) -> Type:
         """Type check an assignment statement.
@@ -1095,6 +1101,7 @@ class TypeChecker(NodeVisitor[Type]):
             rvalue = self.temp_node(self.type_map[s.rvalue], s)
             for lv in s.lvalues[:-1]:
                 self.check_assignment(lv, rvalue, s.type is None)
+        return None
 
     def check_assignment(self, lvalue: Lvalue, rvalue: Expression, infer_lvalue_type: bool = True,
                          new_syntax: bool = False) -> None:
@@ -1512,11 +1519,13 @@ class TypeChecker(NodeVisitor[Type]):
 
     def visit_expression_stmt(self, s: ExpressionStmt) -> Type:
         self.accept(s.expr)
+        return None
 
     def visit_return_stmt(self, s: ReturnStmt) -> Type:
         """Type check a return statement."""
         self.check_return_stmt(s)
         self.binder.unreachable()
+        return None
 
     def check_return_stmt(self, s: ReturnStmt) -> None:
         if self.is_within_function():
@@ -1586,6 +1595,7 @@ class TypeChecker(NodeVisitor[Type]):
         """Type check a while statement."""
         self.accept_loop(IfStmt([s.expr], [s.body], None), s.else_body,
                          exit_condition=s.expr)
+        return None
 
     def visit_operator_assignment_stmt(self,
                                        s: OperatorAssignmentStmt) -> Type:
@@ -1600,6 +1610,7 @@ class TypeChecker(NodeVisitor[Type]):
         else:
             if not is_subtype(rvalue_type, lvalue_type):
                 self.msg.incompatible_operator_assignment(s.op, s)
+        return None
 
     def visit_assert_stmt(self, s: AssertStmt) -> Type:
         self.accept(s.expr)
@@ -1608,6 +1619,7 @@ class TypeChecker(NodeVisitor[Type]):
         true_map, _ = self.find_isinstance_check(s.expr)
 
         self.push_type_map(true_map)
+        return None
 
     def visit_raise_stmt(self, s: RaiseStmt) -> Type:
         """Type check a raise statement."""
@@ -1616,6 +1628,7 @@ class TypeChecker(NodeVisitor[Type]):
         if s.from_expr:
             self.type_check_raise(s.from_expr, s, True)
         self.binder.unreachable()
+        return None
 
     def type_check_raise(self, e: Expression, s: RaiseStmt,
                          optional: bool = False) -> None:
@@ -1765,6 +1778,7 @@ class TypeChecker(NodeVisitor[Type]):
             item_type = self.analyze_iterable_item_type(s.expr)
         self.analyze_index_variables(s.index, item_type, s)
         self.accept_loop(s.body, s.else_body)
+        return None
 
     def analyze_async_iterable_item_type(self, expr: Expression) -> Type:
         """Analyse async iterable expression and return iterator item type."""
@@ -1878,6 +1892,7 @@ class TypeChecker(NodeVisitor[Type]):
         e.var.is_ready = True
         if e.func.is_property:
             self.check_incompatible_property_override(e)
+        return None
 
     def check_incompatible_property_override(self, e: Decorator) -> None:
         if not e.var.is_settable_property and e.func.info is not None:
@@ -1898,6 +1913,7 @@ class TypeChecker(NodeVisitor[Type]):
             else:
                 self.check_with_item(expr, target)
         self.accept(s.body)
+        return None
 
     def check_async_with_item(self, expr: Expression, target: Expression) -> None:
         echk = self.expr_checker
@@ -1933,6 +1949,7 @@ class TypeChecker(NodeVisitor[Type]):
             if not isinstance(target_type, NoneTyp):
                 # TODO: Also verify the type of 'write'.
                 self.expr_checker.analyze_external_member_access('write', target_type, s.target)
+        return None
 
     #
     # Expressions

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -259,7 +259,7 @@ class TypeChecker(NodeVisitor[Type]):
             return typ
 
     def accept_loop(self, body: Statement, else_body: Statement = None, *,
-                    exit_condition: Expression = None) -> Type:
+                    exit_condition: Expression = None) -> None:
         """Repeatedly type check a loop body until the frame doesn't change.
         If exit_condition is set, assume it must be False on exit from the loop.
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1616,6 +1616,7 @@ class ExpressionChecker:
                                                  not_ready_callback=self.not_ready_callback,
                                                  msg=self.msg, override_info=base, chk=self.chk,
                                                  original_type=declared_self)
+            assert False, 'unreachable'
         else:
             # Invalid super. This has been reported by the semantic analyzer.
             return AnyType()

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -239,7 +239,7 @@ class Parser:
         node = None  # type: ImportBase
         if self.current_str() == '*':
             if name == '__future__':
-                self.parse_error()
+                raise self.parse_error()
             # An import all from a module node:
             self.skip()
             node = ImportAll(name, relative)
@@ -630,7 +630,7 @@ class Parser:
                 elif self.current_str() in ['*', '**']:
                     if bare_asterisk_before == len(args):
                         # named arguments must follow bare *
-                        self.parse_error()
+                        raise self.parse_error()
 
                     arg = self.parse_asterisk_arg(
                         allow_signature,
@@ -991,7 +991,7 @@ class Parser:
         expr = None
         current = self.current()
         if current.string == 'yield':
-            self.parse_error()
+            raise self.parse_error()
         if not isinstance(current, Break):
             expr = self.parse_expression()
         node = ReturnStmt(expr)
@@ -1247,10 +1247,10 @@ class Parser:
             if self.current_str() == ',':
                 self.skip()
                 if isinstance(self.current(), Break):
-                    self.parse_error()
+                    raise self.parse_error()
             else:
                 if not isinstance(self.current(), Break):
-                    self.parse_error()
+                    raise self.parse_error()
         comma = False
         while not isinstance(self.current(), Break):
             args.append(self.parse_expression(precedence[',']))
@@ -1325,7 +1325,7 @@ class Parser:
                 expr = self.parse_ellipsis()
             else:
                 # Invalid expression.
-                self.parse_error()
+                raise self.parse_error()
 
         # Set the line of the expression node, if not specified. This
         # simplifies recording the line number as not every node type needs to
@@ -1500,7 +1500,7 @@ class Parser:
             elif self.current_str() == 'for' and items == []:
                 return self.parse_set_comprehension(key)
             elif self.current_str() != ':':
-                self.parse_error()
+                raise self.parse_error()
             colon = self.expect(':')
             value = self.parse_expression(precedence['<for>'])
             if self.current_str() == 'for' and items == []:
@@ -1670,7 +1670,7 @@ class Parser:
                 kinds.append(nodes.ARG_POS)
                 names.append(None)
             else:
-                self.parse_error()
+                raise self.parse_error()
             args.append(self.parse_expression(precedence[',']))
             if self.current_str() != ',':
                 break
@@ -1738,7 +1738,7 @@ class Parser:
         op_str = op.string
         if op_str == '~':
             self.ind -= 1
-            self.parse_error()
+            raise self.parse_error()
         right = self.parse_expression(prec)
         node = OpExpr(op_str, left, right)
         return node
@@ -1755,7 +1755,7 @@ class Parser:
                     op_str = 'not in'
                     self.skip()
                 else:
-                    self.parse_error()
+                    raise self.parse_error()
             elif op_str == 'is' and self.current_str() == 'not':
                 op_str = 'is not'
                 self.skip()

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -39,6 +39,8 @@ from mypy.options import Options
 
 from mypy import experiments
 
+ThrowsException = Exception
+
 
 precedence = {
     '**': 16,
@@ -402,8 +404,7 @@ class Parser:
         elif isinstance(expr, MemberExpr):
             if isinstance(expr.expr, NameExpr):
                 return expr.expr.name == 'typing' and expr.name == 'no_type_check'
-        else:
-            return False
+        return False
 
     def parse_function(self, no_type_checks: bool = False) -> FuncDef:
         def_tok = self.expect('def')
@@ -790,6 +791,8 @@ class Parser:
         if self.current_str() == ':':
             self.skip()
             return self.parse_expression(precedence[','])
+        else:
+            return None
 
     def parse_arg_type(self, allow_signature: bool) -> Type:
         if self.current_str() == ':' and allow_signature:
@@ -1818,7 +1821,7 @@ class Parser:
             self.ind += 1
             return self.tok[self.ind - 1]
         else:
-            self.parse_error()
+            raise self.parse_error()
 
     def expect_indent(self) -> Token:
         if isinstance(self.current(), Indent):
@@ -1836,7 +1839,7 @@ class Parser:
             self.ind += 1
             return current
         else:
-            self.parse_error()
+            raise self.parse_error()
 
     def expect_break(self) -> Token:
         return self.expect_type(Break)
@@ -1850,7 +1853,7 @@ class Parser:
     def peek(self) -> Token:
         return self.tok[self.ind + 1]
 
-    def parse_error(self) -> None:
+    def parse_error(self) -> ThrowsException:
         self.parse_error_at(self.current())
         raise ParseError()
 

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -39,7 +39,8 @@ from mypy.options import Options
 
 from mypy import experiments
 
-ThrowsException = Exception
+
+class ParseError(Exception): pass
 
 
 precedence = {
@@ -1853,9 +1854,9 @@ class Parser:
     def peek(self) -> Token:
         return self.tok[self.ind + 1]
 
-    def parse_error(self) -> ThrowsException:
+    def parse_error(self) -> ParseError:
         self.parse_error_at(self.current())
-        raise ParseError()
+        return ParseError()
 
     def parse_error_at(self, tok: Token, skip: bool = True, reason: Optional[str] = None) -> None:
         msg = ''
@@ -1937,9 +1938,6 @@ class Parser:
             return type
         else:
             return None
-
-
-class ParseError(Exception): pass
 
 
 def token_repr(tok: Token) -> str:

--- a/mypy/parsetype.py
+++ b/mypy/parsetype.py
@@ -9,6 +9,8 @@ from mypy.types import (
 from mypy.lex import Token, Name, StrLit, lex
 from mypy import nodes
 
+ThrowsException = Exception
+
 
 none = Token('')  # Empty token
 
@@ -73,7 +75,7 @@ class TypeParser:
                 raise TypeParseError(e.token, self.ind)
             return result
         else:
-            self.parse_error()
+            raise self.parse_error()
 
     def parse_parens(self) -> Type:
         self.expect('(')
@@ -166,14 +168,14 @@ class TypeParser:
             self.ind += 1
             return self.tok[self.ind - 1]
         else:
-            self.parse_error()
+            raise self.parse_error()
 
     def expect_type(self, typ: type) -> Token:
         if isinstance(self.current_token(), typ):
             self.ind += 1
             return self.tok[self.ind - 1]
         else:
-            self.parse_error()
+            raise self.parse_error()
 
     def current_token(self) -> Token:
         return self.tok[self.ind]
@@ -181,7 +183,7 @@ class TypeParser:
     def current_token_str(self) -> str:
         return self.current_token().string
 
-    def parse_error(self) -> None:
+    def parse_error(self) -> ThrowsException:
         raise TypeParseError(self.tok[self.ind], self.ind)
 
 

--- a/mypy/parsetype.py
+++ b/mypy/parsetype.py
@@ -9,8 +9,6 @@ from mypy.types import (
 from mypy.lex import Token, Name, StrLit, lex
 from mypy import nodes
 
-ThrowsException = Exception
-
 
 none = Token('')  # Empty token
 
@@ -183,8 +181,8 @@ class TypeParser:
     def current_token_str(self) -> str:
         return self.current_token().string
 
-    def parse_error(self) -> ThrowsException:
-        raise TypeParseError(self.tok[self.ind], self.ind)
+    def parse_error(self) -> TypeParseError:
+        return TypeParseError(self.tok[self.ind], self.ind)
 
 
 def parse_str_as_type(typestr: str, line: int) -> Type:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2094,6 +2094,8 @@ class SemanticAnalyzer(NodeVisitor):
             return True
         elif isinstance(s, TupleExpr):
             return all(self.is_valid_del_target(item) for item in s.items)
+        else:
+            return False
 
     def visit_global_decl(self, g: GlobalDecl) -> None:
         for name in g.names:

--- a/runtests.py
+++ b/runtests.py
@@ -176,7 +176,7 @@ def add_basic(driver: Driver) -> None:
 
 
 def add_selftypecheck(driver: Driver) -> None:
-    driver.add_mypy_package('package mypy', 'mypy')
+    driver.add_mypy_package('package mypy', 'mypy', '--warn-no-return')
     driver.add_mypy_package('package mypy', 'mypy', '--config-file', 'mypy_strict_optional.ini')
 
 

--- a/runtests.py
+++ b/runtests.py
@@ -176,8 +176,9 @@ def add_basic(driver: Driver) -> None:
 
 
 def add_selftypecheck(driver: Driver) -> None:
-    driver.add_mypy_package('package mypy', 'mypy', '--warn-no-return')
-    driver.add_mypy_package('package mypy', 'mypy', '--config-file', 'mypy_strict_optional.ini')
+    driver.add_mypy_package('package mypy', 'mypy', '--fast-parser', '--warn-no-return')
+    driver.add_mypy_package('package mypy', 'mypy', '--fast-parser',
+                            '--config-file', 'mypy_strict_optional.ini')
 
 
 def find_files(base: str, prefix: str = '', suffix: str = '') -> List[str]:


### PR DESCRIPTION
I made up a way to handle calling a function that itself always raises.

The only errors that remain are in checker.py, and it's not entirely clear to me what to do about them.  A bunch of functions are declared as returning `Type` when they just don't, but they can't simply be changed because they're overriding functions from a superclass.  See e.g. https://github.com/python/mypy/blob/b024ac37531247fffefac56b33c2a4ed11387124/mypy/checker.py#L271
