### PR TITLE
Fix --warn-no-return for docstring only functions

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -651,7 +651,10 @@ class TypeChecker(NodeVisitor[Type]):
                 isinstance(body[0].expr, StrExpr)):
             body = block.body[1:]
 
-        if len(body) != 1:
+        if len(body) == 0:
+            # There's only a docstring.
+            return True
+        elif len(body) > 1:
             return False
         stmt = body[0]
         return (isinstance(stmt, PassStmt) or

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -79,3 +79,18 @@ class BaseClass: pass
 
 [out]
 tmp/main.py:2: error: Class cannot subclass 'BaseClass' (has type 'Any')
+
+[case testWarnNoReturnIgnoresTrivialFunctions]
+# flags: --warn-no-return
+def f() -> int:
+  pass
+def g() -> int:
+  ...
+def h() -> int:
+  """with docstring"""
+  pass
+def i() -> int:
+  """with docstring"""
+  ...
+def j() -> int:
+  """docstring only"""


### PR DESCRIPTION
Currently functions like
```py
def j() -> int:
  """docstring only"""
```
get a missing return statement note.  They shouldn't.