### PR TITLE
[WIP] Make typing and typed-ast external dependencies

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-recursive-include lib-typing *.py
 recursive-include scripts *
 recursive-exclude scripts myunit

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,0 +1,2 @@
+setuptools
+wheel

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ if sys.version_info < (3, 2, 0):
     sys.stderr.write("ERROR: You need Python 3.2 or later to use mypy.\n")
     exit(1)
 
-from distutils.core import setup
-from distutils.command.build_py import build_py
+from setuptools import setup
+from setuptools.command.build_py import build_py
 from mypy.version import __version__
 from mypy import git
 
@@ -94,16 +94,21 @@ classifiers = [
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Topic :: Software Development',
 ]
 
 package_dir = {'mypy': 'mypy'}
-if sys.version_info < (3, 5, 0):
-    package_dir[''] = 'lib-typing/3.2'
 
 scripts = ['scripts/mypy', 'scripts/stubgen']
 if os.name == 'nt':
     scripts.append('scripts/mypy.bat')
+
+install_requires = []
+if sys.platform != 'win32':
+    install_requires.append('typed-ast >= 0.6.1')
+if sys.version_info < (3, 5):
+    install_requires.append('typing >= 3.5.2')
 
 setup(name='mypy-lang',
       version=version,
@@ -115,10 +120,11 @@ setup(name='mypy-lang',
       license='MIT License',
       platforms=['POSIX'],
       package_dir=package_dir,
-      py_modules=['typing'] if sys.version_info < (3, 5, 0) else [],
+      py_modules=[],
       packages=['mypy'],
       scripts=scripts,
       data_files=data_files,
       classifiers=classifiers,
       cmdclass={'build_py': CustomPythonBuild},
+      install_requires=install_requires,
       )

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -11,7 +11,8 @@ print('hello, world')
 [out]
 hello, world
 
-[case testAbstractBaseClasses]
+-- Skipped because different typing package versions have different repr()s. 
+[case testAbstractBaseClasses-skip]
 import re
 from typing import Sized, Sequence, Iterator, Iterable, Mapping, AbstractSet
 


### PR DESCRIPTION
This will automatically install the typing and typed-ast packages when
appropriate.

The setup.py file now depends on setuptools.  We should build wheels
so that users installing from PyPI won't need setuptools.  In order to
build wheels the distribution builder/uploader needs to install the
wheel package.  To manage those dependencies, I've added
build-requirements.txt.

In summary:
- python3 -m pip install -r build-requirements.txt
- python3 setup.py bdist_wheel
- upload the .whl file that appears in the dist/ subdirectory to PyPI
