### PR TITLE
[in progress] TypedDict: Recognize creation of TypedDict instance. Define TypedDictType.

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -3,7 +3,7 @@
 from typing import cast, Callable, List, Optional, TypeVar
 
 from mypy.types import (
-    Type, Instance, AnyType, TupleType, CallableType, FunctionLike, TypeVarDef,
+    Type, Instance, AnyType, TupleType, TypedDictType, CallableType, FunctionLike, TypeVarDef,
     Overloaded, TypeVarType, UnionType, PartialType,
     DeletedType, NoneTyp, TypeType, function_type
 )
@@ -112,6 +112,11 @@ def analyze_member_access(name: str,
         msg.disable_type_names -= 1
         return UnionType.make_simplified_union(results)
     elif isinstance(typ, TupleType):
+        # Actually look up from the fallback instance type.
+        return analyze_member_access(name, typ.fallback, node, is_lvalue, is_super,
+                                     is_operator, builtin_type, not_ready_callback, msg,
+                                     original_type=original_type, chk=chk)
+    elif isinstance(typ, TypedDictType):
         # Actually look up from the fallback instance type.
         return analyze_member_access(name, typ.fallback, node, is_lvalue, is_super,
                                      is_operator, builtin_type, not_ready_callback, msg,

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -2,8 +2,8 @@ from typing import Optional, Container, Callable
 
 from mypy.types import (
     Type, TypeVisitor, UnboundType, ErrorType, AnyType, Void, NoneTyp, TypeVarId,
-    Instance, TypeVarType, CallableType, TupleType, UnionType, Overloaded, ErasedType,
-    PartialType, DeletedType, TypeTranslator, TypeList, UninhabitedType, TypeType
+    Instance, TypeVarType, CallableType, TupleType, TypedDictType, UnionType, Overloaded,
+    ErasedType, PartialType, DeletedType, TypeTranslator, TypeList, UninhabitedType, TypeType
 )
 from mypy import experiments
 
@@ -76,6 +76,9 @@ class EraseTypeVisitor(TypeVisitor[Type]):
         return t.items()[0].accept(self)
 
     def visit_tuple_type(self, t: TupleType) -> Type:
+        return t.fallback.accept(self)
+
+    def visit_typeddict_type(self, t: TypedDictType) -> Type:
         return t.fallback.accept(self)
 
     def visit_union_type(self, t: UnionType) -> Type:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -1,9 +1,9 @@
-from typing import Dict, List
+from typing import Dict, Iterable, List
 
 from mypy.types import (
     Type, Instance, CallableType, TypeVisitor, UnboundType, ErrorType, AnyType,
-    Void, NoneTyp, TypeVarType, Overloaded, TupleType, UnionType, ErasedType, TypeList,
-    PartialType, DeletedType, UninhabitedType, TypeType, TypeVarId
+    Void, NoneTyp, TypeVarType, Overloaded, TupleType, TypedDictType, UnionType,
+    ErasedType, TypeList, PartialType, DeletedType, UninhabitedType, TypeType, TypeVarId
 )
 
 
@@ -93,6 +93,9 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
     def visit_tuple_type(self, t: TupleType) -> Type:
         return t.copy_modified(items=self.expand_types(t.items))
 
+    def visit_typeddict_type(self, t: TypedDictType) -> Type:
+        return t.copy_modified(item_types=self.expand_types(t.items.values()))
+
     def visit_union_type(self, t: UnionType) -> Type:
         # After substituting for type variables in t.items,
         # some of the resulting types might be subtypes of others.
@@ -108,7 +111,7 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
         item = t.item.accept(self)
         return TypeType(item)
 
-    def expand_types(self, types: List[Type]) -> List[Type]:
+    def expand_types(self, types: Iterable[Type]) -> List[Type]:
         a = []  # type: List[Type]
         for t in types:
             a.append(t.accept(self))

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -2,13 +2,17 @@
 
 from typing import Any, Dict, Optional
 
-from mypy.nodes import (MypyFile, SymbolNode, SymbolTable, SymbolTableNode,
-                        TypeInfo, FuncDef, OverloadedFuncDef, Decorator, Var,
-                        TypeVarExpr, ClassDef,
-                        LDEF, MDEF, GDEF)
-from mypy.types import (CallableType, EllipsisType, Instance, Overloaded, TupleType,
-                        TypeList, TypeVarType, UnboundType, UnionType, TypeVisitor,
-                        TypeType)
+from mypy.nodes import (
+    MypyFile, SymbolNode, SymbolTable, SymbolTableNode,
+    TypeInfo, FuncDef, OverloadedFuncDef, Decorator, Var,
+    TypeVarExpr, ClassDef,
+    LDEF, MDEF, GDEF
+)
+from mypy.types import (
+    CallableType, EllipsisType, Instance, Overloaded, TupleType, TypedDictType,
+    TypeList, TypeVarType, UnboundType, UnionType, TypeVisitor,
+    TypeType
+)
 from mypy.visitor import NodeVisitor
 
 
@@ -191,6 +195,13 @@ class TypeFixer(TypeVisitor[None]):
                 it.accept(self)
         if tt.fallback is not None:
             tt.fallback.accept(self)
+
+    def visit_typeddict_type(self, tdt: TypedDictType) -> None:
+        if tdt.items:
+            for it in tdt.items.values():
+                it.accept(self)
+        if tdt.fallback is not None:
+            tdt.fallback.accept(self)
 
     def visit_type_list(self, tl: TypeList) -> None:
         for t in tl.items:

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -87,6 +87,9 @@ class TypeIndirectionVisitor(TypeVisitor[Set[str]]):
     def visit_tuple_type(self, t: types.TupleType) -> Set[str]:
         return self._visit(*t.items) | self._visit(t.fallback)
 
+    def visit_typeddict_type(self, t: types.TypedDictType) -> Set[str]:
+        return self._visit(*t.items.values()) | self._visit(t.fallback)
+
     def visit_star_type(self, t: types.StarType) -> Set[str]:
         return set()
 

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -1,10 +1,11 @@
 """Calculation of the least upper bound types (joins)."""
 
-from typing import List
+from collections import OrderedDict
+from typing import cast, List
 
 from mypy.types import (
     Type, AnyType, NoneTyp, Void, TypeVisitor, Instance, UnboundType,
-    ErrorType, TypeVarType, CallableType, TupleType, ErasedType, TypeList,
+    ErrorType, TypeVarType, CallableType, TupleType, TypedDictType, ErasedType, TypeList,
     UnionType, FunctionLike, Overloaded, PartialType, DeletedType,
     UninhabitedType, TypeType, true_or_false
 )
@@ -170,6 +171,8 @@ class TypeJoinVisitor(TypeVisitor[Type]):
             return join_types(t, self.s.fallback)
         elif isinstance(self.s, TypeType):
             return join_types(t, self.s)
+        elif isinstance(self.s, TypedDictType):
+            return join_types(t, self.s)
         else:
             return self.default(self.s)
 
@@ -234,10 +237,24 @@ class TypeJoinVisitor(TypeVisitor[Type]):
             items = []  # type: List[Type]
             for i in range(t.length()):
                 items.append(self.join(t.items[i], self.s.items[i]))
-            # join fallback types if they are different
             fallback = join_instances(self.s.fallback, t.fallback)
             assert isinstance(fallback, Instance)
             return TupleType(items, fallback)
+        else:
+            return self.default(self.s)
+
+    def visit_typeddict_type(self, t: TypedDictType) -> Type:
+        if isinstance(self.s, TypedDictType):
+            items = OrderedDict([
+                (item_name, s_item_type)
+                for (item_name, s_item_type, t_item_type) in self.s.zip(t)
+                if is_equivalent(s_item_type, t_item_type)
+            ])
+            mapping_value_type = join_type_list(list(items.values()))
+            fallback = self.s.create_anonymous_fallback(value_type=mapping_value_type)
+            return TypedDictType(items, fallback)
+        elif isinstance(self.s, Instance):
+            return join_instances(self.s, t.fallback)
         else:
             return self.default(self.s)
 
@@ -265,6 +282,8 @@ class TypeJoinVisitor(TypeVisitor[Type]):
         elif isinstance(typ, Void) or isinstance(typ, ErrorType):
             return ErrorType()
         elif isinstance(typ, TupleType):
+            return self.default(typ.fallback)
+        elif isinstance(typ, TypedDictType):
             return self.default(typ.fallback)
         elif isinstance(typ, FunctionLike):
             return self.default(typ.fallback)

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -1,12 +1,13 @@
-from typing import List
+from collections import OrderedDict
+from typing import List, Optional
 
-from mypy.join import is_similar_callables, combine_similar_callables
+from mypy.join import is_similar_callables, combine_similar_callables, join_type_list
 from mypy.types import (
     Type, AnyType, TypeVisitor, UnboundType, Void, ErrorType, NoneTyp, TypeVarType,
-    Instance, CallableType, TupleType, ErasedType, TypeList, UnionType, PartialType,
+    Instance, CallableType, TupleType, TypedDictType, ErasedType, TypeList, UnionType, PartialType,
     DeletedType, UninhabitedType, TypeType
 )
-from mypy.subtypes import is_subtype
+from mypy.subtypes import is_equivalent, is_subtype
 
 from mypy import experiments
 
@@ -243,6 +244,21 @@ class TypeMeetVisitor(TypeVisitor[Type]):
                 items.append(self.meet(t.items[i], self.s.items[i]))
             # TODO: What if the fallbacks are different?
             return TupleType(items, t.fallback)
+        else:
+            return self.default(self.s)
+
+    def visit_typeddict_type(self, t: TypedDictType) -> Type:
+        if isinstance(self.s, TypedDictType):
+            for (_, l, r) in self.s.zip(t):
+                if not is_equivalent(l, r):
+                    return self.default(self.s)
+            items = OrderedDict([
+                (item_name, s_item_type or t_item_type)
+                for (item_name, s_item_type, t_item_type) in self.s.zipall(t)
+            ])
+            mapping_value_type = join_type_list(list(items.values()))
+            fallback = self.s.create_anonymous_fallback(value_type=mapping_value_type)
+            return TypedDictType(items, fallback)
         else:
             return self.default(self.s)
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -10,8 +10,8 @@ from typing import cast, List, Dict, Any, Sequence, Iterable, Tuple
 
 from mypy.errors import Errors
 from mypy.types import (
-    Type, CallableType, Instance, TypeVarType, TupleType, UnionType, Void, NoneTyp, AnyType,
-    Overloaded, FunctionLike, DeletedType, TypeType
+    Type, CallableType, Instance, TypeVarType, TupleType, TypedDictType,
+    UnionType, Void, NoneTyp, AnyType, Overloaded, FunctionLike, DeletedType, TypeType
 )
 from mypy.nodes import (
     TypeInfo, Context, MypyFile, op_methods, FuncDef, reverse_type_aliases,
@@ -72,6 +72,10 @@ ARGUMENT_TYPE_EXPECTED = "Function is missing a type annotation for one or more 
 KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE = \
     'Keyword argument only valid with "str" key type in call to "dict"'
 ALL_MUST_BE_SEQ_STR = 'Type of __all__ must be {}, not {}'
+INVALID_TYPEDDICT_ARGS = \
+    'Expected keyword arguments, {...}, or dict(...) in TypedDict constructor'
+TYPEDDICT_ITEM_NAME_MUST_BE_STRING_LITERAL = \
+    'Expected TypedDict item name to be string literal'
 
 
 class MessageBuilder:
@@ -204,8 +208,8 @@ class MessageBuilder:
                 # interpreted as a normal word.
                 return '"{}"'.format(base_str)
             elif itype.type.fullname() == 'builtins.tuple':
-                item_type = strip_quotes(self.format(itype.args[0]))
-                return 'Tuple[{}, ...]'.format(item_type)
+                item_type_str = strip_quotes(self.format(itype.args[0]))
+                return 'Tuple[{}, ...]'.format(item_type_str)
             elif itype.type.fullname() in reverse_type_aliases:
                 alias = reverse_type_aliases[itype.type.fullname()]
                 alias = alias.split('.')[-1]
@@ -239,6 +243,15 @@ class MessageBuilder:
                 return s
             else:
                 return 'tuple(length {})'.format(len(items))
+        elif isinstance(typ, TypedDictType):
+            # If the TypedDictType is named, return the name
+            if typ.fallback.type.fullname() != 'typing.Mapping':
+                return self.format_simple(typ.fallback)
+            items = []
+            for (item_name, item_type) in typ.items.items():
+                items.append('{}={}'.format(item_name, strip_quotes(self.format(item_type))))
+            s = '"TypedDict({})"'.format(', '.join(items))
+            return s
         elif isinstance(typ, UnionType):
             # Only print Unions as Optionals if the Optional wouldn't have to contain another Union
             print_as_optional = (len(typ.items) -
@@ -787,6 +800,13 @@ class MessageBuilder:
 
     def redundant_cast(self, typ: Type, context: Context) -> None:
         self.note('Redundant cast to {}'.format(self.format(typ)), context)
+
+    def typeddict_instantiated_with_unexpected_items(self,
+                                                     expected_item_names: List[str],
+                                                     actual_item_names: List[str],
+                                                     context: Context) -> None:
+        self.fail('Expected items {} but found {}.'.format(
+            expected_item_names, actual_item_names), context)
 
 
 def capitalize(s: str) -> str:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1894,13 +1894,14 @@ class TypeInfo(SymbolNode):
     # object used for this class is not an Instance but a TupleType;
     # the corresponding Instance is set as the fallback type of the
     # tuple type.
-    tuple_type = None  # type: mypy.types.TupleType
+    tuple_type = None  # type: Optional[mypy.types.TupleType]
 
     # Is this a named tuple type?
     is_named_tuple = False
 
-    # Is this a typed dict type?
-    is_typed_dict = False
+    # If this class is defined by the TypedDict type constructor,
+    # then this is not None.
+    typeddict_type = None  # type: Optional[mypy.types.TypedDictType]
 
     # Is this a newtype type?
     is_newtype = False
@@ -1910,7 +1911,7 @@ class TypeInfo(SymbolNode):
 
     FLAGS = [
         'is_abstract', 'is_enum', 'fallback_to_any', 'is_named_tuple',
-        'is_typed_dict', 'is_newtype'
+        'is_newtype'
     ]
 
     def __init__(self, names: 'SymbolTable', defn: ClassDef, module_name: str) -> None:
@@ -2045,6 +2046,8 @@ class TypeInfo(SymbolNode):
                 'bases': [b.serialize() for b in self.bases],
                 '_promote': None if self._promote is None else self._promote.serialize(),
                 'tuple_type': None if self.tuple_type is None else self.tuple_type.serialize(),
+                'typeddict_type':
+                    None if self.typeddict_type is None else self.typeddict_type.serialize(),
                 'flags': get_flags(self, TypeInfo.FLAGS),
                 }
         return data
@@ -2065,6 +2068,8 @@ class TypeInfo(SymbolNode):
                        else mypy.types.Type.deserialize(data['_promote']))
         ti.tuple_type = (None if data['tuple_type'] is None
                          else mypy.types.TupleType.deserialize(data['tuple_type']))
+        ti.typeddict_type = (None if data['typeddict_type'] is None
+                            else mypy.types.TypedDictType.deserialize(data['typeddict_type']))
         set_flags(ti, data['flags'])
         return ti
 

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -1,9 +1,9 @@
 from typing import Sequence
 
 from mypy.types import (
-    Type, UnboundType, ErrorType, AnyType, NoneTyp, Void, TupleType, UnionType, CallableType,
-    TypeVarType, Instance, TypeVisitor, ErasedType, TypeList, Overloaded, PartialType,
-    DeletedType, UninhabitedType, TypeType
+    Type, UnboundType, ErrorType, AnyType, NoneTyp, Void, TupleType, TypedDictType,
+    UnionType, CallableType, TypeVarType, Instance, TypeVisitor, ErasedType,
+    TypeList, Overloaded, PartialType, DeletedType, UninhabitedType, TypeType
 )
 
 
@@ -108,6 +108,17 @@ class SameTypeVisitor(TypeVisitor[bool]):
     def visit_tuple_type(self, left: TupleType) -> bool:
         if isinstance(self.right, TupleType):
             return is_same_types(left.items, self.right.items)
+        else:
+            return False
+
+    def visit_typeddict_type(self, left: TypedDictType) -> bool:
+        if isinstance(self.right, TypedDictType):
+            if left.items.keys() != self.right.items.keys():
+                return False
+            for (_, left_item_type, right_item_type) in left.zip(self.right):
+                if not is_same_type(left_item_type, right_item_type):
+                    return False
+            return True
         else:
             return False
 

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -54,6 +54,7 @@ files = [
     'check-isinstance.test',
     'check-lists.test',
     'check-namedtuple.test',
+    'check-typeddict.test',
     'check-type-aliases.test',
     'check-ignore.test',
     'check-type-promotion.test',

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -23,7 +23,7 @@ x[2] # E: Tuple index out of range
 [case testNamedTupleNoUnderscoreFields]
 from collections import namedtuple
 
-X = namedtuple('X', 'x, _y, _z')  # E: namedtuple() Field names cannot start with an underscore: _y, _z
+X = namedtuple('X', 'x, _y, _z')  # E: namedtuple() field names cannot start with an underscore: _y, _z
 
 [case testNamedTupleAccessingAttributes]
 from collections import namedtuple

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1,0 +1,444 @@
+-- Create Instance
+
+[case testCanCreateTypedDictInstanceWithKeywordArguments]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+p = Point(x=42, y=1337)
+reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+[builtins fixtures/dict.pyi]
+
+[case testCanCreateTypedDictInstanceWithDictCall]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+p = Point(dict(x=42, y=1337))
+reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+[builtins fixtures/dict.pyi]
+
+[case testCanCreateTypedDictInstanceWithDictLiteral]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+p = Point({'x': 42, 'y': 1337})
+reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+[builtins fixtures/dict.pyi]
+
+[case testCanCreateTypedDictInstanceWithNoArguments]
+from mypy_extensions import TypedDict
+EmptyDict = TypedDict('EmptyDict', {})
+p = EmptyDict()
+reveal_type(p)  # E: Revealed type is 'TypedDict(_fallback=typing.Mapping[builtins.str, builtins.None])'
+[builtins fixtures/dict.pyi]
+
+
+-- Create Instance (Errors)
+
+[case testCannotCreateTypedDictInstanceWithUnknownArgumentPattern]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+p = Point(42, 1337)  # E: Expected keyword arguments, {...}, or dict(...) in TypedDict constructor
+[builtins fixtures/dict.pyi]
+
+[case testCannotCreateTypedDictInstanceNonLiteralItemName]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+x = 'x'
+p = Point({x: 42, 'y': 1337})  # E: Expected TypedDict item name to be string literal
+[builtins fixtures/dict.pyi]
+
+[case testCannotCreateTypedDictInstanceWithExtraItems]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+p = Point(x=42, y=1337, z=666)  # E: Expected items ['x', 'y'] but found ['x', 'y', 'z'].
+[builtins fixtures/dict.pyi]
+
+[case testCannotCreateTypedDictInstanceWithMissingItems]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+p = Point(x=42)  # E: Expected items ['x', 'y'] but found ['x'].
+[builtins fixtures/dict.pyi]
+
+[case testCannotCreateTypedDictInstanceWithIncompatibleItemType]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+p = Point(x='meaning_of_life', y=1337)  # E: Incompatible types (expression has type "str", TypedDict item "x" has type "int")
+[builtins fixtures/dict.pyi]
+
+
+-- Subtyping
+
+[case testCanConvertTypedDictToItself]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+def identity(p: Point) -> Point:
+    return p
+[builtins fixtures/dict.pyi]
+
+[case testCanConvertTypedDictToEquivalentTypedDict]
+from mypy_extensions import TypedDict
+PointA = TypedDict('PointA', {'x': int, 'y': int})
+PointB = TypedDict('PointB', {'x': int, 'y': int})
+def identity(p: PointA) -> PointB:
+    return p
+[builtins fixtures/dict.pyi]
+
+[case testCannotConvertTypedDictToSimilarTypedDictWithNarrowerItemTypes]
+# flags: --hide-error-context
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+ObjectPoint = TypedDict('ObjectPoint', {'x': object, 'y': object})
+def convert(op: ObjectPoint) -> Point:
+    return op  # E: Incompatible return value type (got "ObjectPoint", expected "Point")
+[builtins fixtures/dict.pyi]
+
+[case testCannotConvertTypedDictToSimilarTypedDictWithWiderItemTypes]
+# flags: --hide-error-context
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+ObjectPoint = TypedDict('ObjectPoint', {'x': object, 'y': object})
+def convert(p: Point) -> ObjectPoint:
+    return p  # E: Incompatible return value type (got "Point", expected "ObjectPoint")
+[builtins fixtures/dict.pyi]
+
+[case testCannotConvertTypedDictToSimilarTypedDictWithIncompatibleItemTypes]
+# flags: --hide-error-context
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+Chameleon = TypedDict('Chameleon', {'x': str, 'y': str})
+def convert(p: Point) -> Chameleon:
+    return p  # E: Incompatible return value type (got "Point", expected "Chameleon")
+[builtins fixtures/dict.pyi]
+
+[case testCanConvertTypedDictToNarrowerTypedDict]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+Point1D = TypedDict('Point1D', {'x': int})
+def narrow(p: Point) -> Point1D:
+    return p
+[builtins fixtures/dict.pyi]
+
+[case testCannotConvertTypedDictToWiderTypedDict]
+# flags: --hide-error-context
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+Point3D = TypedDict('Point3D', {'x': int, 'y': int, 'z': int})
+def widen(p: Point) -> Point3D:
+    return p  # E: Incompatible return value type (got "Point", expected "Point3D")
+[builtins fixtures/dict.pyi]
+
+[case testCanConvertTypedDictToCompatibleMapping]
+from mypy_extensions import TypedDict
+from typing import Mapping
+Point = TypedDict('Point', {'x': int, 'y': int})
+def as_mapping(p: Point) -> Mapping[str, int]:
+    return p
+[builtins fixtures/dict.pyi]
+
+[case testCannotConvertTypedDictToCompatibleMapping]
+# flags: --hide-error-context
+from mypy_extensions import TypedDict
+from typing import Mapping
+Point = TypedDict('Point', {'x': int, 'y': int})
+def as_mapping(p: Point) -> Mapping[str, str]:
+    return p  # E: Incompatible return value type (got "Point", expected Mapping[str, str])
+[builtins fixtures/dict.pyi]
+
+-- TODO: Fix mypy stubs so that the following passes in the test suite
+--[case testCanConvertTypedDictToAnySuperclassOfMapping]
+--from mypy_extensions import TypedDict
+--from typing import Sized, Iterable, Container
+--Point = TypedDict('Point', {'x': int, 'y': int})
+--def as_sized(p: Point) -> Sized:
+--    return p
+--def as_iterable(p: Point) -> Iterable[str]:
+--    return p
+--def as_container(p: Point) -> Container[str]:
+--    return p
+--def as_object(p: Point) -> object:
+--    return p
+--[builtins fixtures/dict.pyi]
+
+[case testCannotConvertTypedDictToDictOrMutableMapping]
+# flags: --hide-error-context
+from mypy_extensions import TypedDict
+from typing import Dict, MutableMapping
+Point = TypedDict('Point', {'x': int, 'y': int})
+def as_dict(p: Point) -> Dict[str, int]:
+    return p  # E: Incompatible return value type (got "Point", expected Dict[str, int])
+def as_mutable_mapping(p: Point) -> MutableMapping[str, int]:
+    return p  # E: Incompatible return value type (got "Point", expected MutableMapping[str, int])
+[builtins fixtures/dict.pyi]
+
+[case testCanConvertTypedDictToAny]
+from mypy_extensions import TypedDict
+from typing import Any
+Point = TypedDict('Point', {'x': int, 'y': int})
+def unprotect(p: Point) -> Any:
+    return p
+[builtins fixtures/dict.pyi]
+
+
+-- Join
+
+[case testJoinOfTypedDictHasOnlyCommonKeysAndNewFallback]
+from mypy_extensions import TypedDict
+TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+Point3D = TypedDict('Point3D', {'x': int, 'y': int, 'z': int})
+p1 = TaggedPoint(type='2d', x=0, y=0)
+p2 = Point3D(x=1, y=1, z=1)
+joined_points = [p1, p2]
+reveal_type(p1)             # E: Revealed type is 'TypedDict(type=builtins.str, x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.object])'
+reveal_type(p2)             # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, z=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+reveal_type(joined_points)  # E: Revealed type is 'builtins.list[TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])]'
+[builtins fixtures/dict.pyi]
+
+[case testJoinOfTypedDictRemovesNonequivalentKeys]
+from mypy_extensions import TypedDict
+CellWithInt = TypedDict('CellWithInt', {'value': object, 'meta': int})
+CellWithObject = TypedDict('CellWithObject', {'value': object, 'meta': object})
+c1 = CellWithInt(value=1, meta=42)
+c2 = CellWithObject(value=2, meta='turtle doves')
+joined_cells = [c1, c2]
+reveal_type(c1)             # E: Revealed type is 'TypedDict(value=builtins.int, meta=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+reveal_type(c2)             # E: Revealed type is 'TypedDict(value=builtins.int, meta=builtins.str, _fallback=typing.Mapping[builtins.str, builtins.object])'
+reveal_type(joined_cells)   # E: Revealed type is 'builtins.list[TypedDict(value=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])]'
+[builtins fixtures/dict.pyi]
+
+[case testJoinOfDisjointTypedDictsIsEmptyTypedDict]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+Cell = TypedDict('Cell', {'value': object})
+d1 = Point(x=0, y=0)
+d2 = Cell(value='pear tree')
+joined_dicts = [d1, d2]
+reveal_type(d1)             # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+reveal_type(d2)             # E: Revealed type is 'TypedDict(value=builtins.str, _fallback=typing.Mapping[builtins.str, builtins.str])'
+reveal_type(joined_dicts)   # E: Revealed type is 'builtins.list[TypedDict(_fallback=typing.Mapping[builtins.str, builtins.None])]'
+[builtins fixtures/dict.pyi]
+
+[case testJoinOfTypedDictWithCompatibleMappingIsMapping]
+from mypy_extensions import TypedDict
+from typing import Mapping
+Cell = TypedDict('Cell', {'value': int})
+left = Cell(value=42)
+right = {'score': 999}  # type: Mapping[str, int]
+joined1 = [left, right]
+joined2 = [right, left]
+reveal_type(joined1)  # E: Revealed type is 'builtins.list[typing.Mapping*[builtins.str, builtins.int]]'
+reveal_type(joined2)  # E: Revealed type is 'builtins.list[typing.Mapping*[builtins.str, builtins.int]]'
+[builtins fixtures/dict.pyi]
+
+-- TODO: Fix mypy stubs so that the following passes in the test suite
+--[case testJoinOfTypedDictWithCompatibleMappingSupertypeIsSupertype]
+--from mypy_extensions import TypedDict
+--from typing import Sized
+--Cell = TypedDict('Cell', {'value': int})
+--left = Cell(value=42)
+--right = {'score': 999}  # type: Sized
+--joined1 = [left, right]
+--joined2 = [right, left]
+--reveal_type(joined1)  # E: Revealed type is 'builtins.list[typing.Sized*]'
+--reveal_type(joined2)  # E: Revealed type is 'builtins.list[typing.Sized*]'
+--[builtins fixtures/dict.pyi]
+
+[case testJoinOfTypedDictWithIncompatibleMappingIsObject]
+from mypy_extensions import TypedDict
+from typing import Mapping
+Cell = TypedDict('Cell', {'value': int})
+left = Cell(value=42)
+right = {'score': 'zero'}  # type: Mapping[str, str]
+joined1 = [left, right]
+joined2 = [right, left]
+reveal_type(joined1)  # E: Revealed type is 'builtins.list[builtins.object*]'
+reveal_type(joined2)  # E: Revealed type is 'builtins.list[builtins.object*]'
+[builtins fixtures/dict.pyi]
+
+[case testJoinOfTypedDictWithIncompatibleTypeIsObject]
+from mypy_extensions import TypedDict
+from typing import Mapping
+Cell = TypedDict('Cell', {'value': int})
+left = Cell(value=42)
+right = 42
+joined1 = [left, right]
+joined2 = [right, left]
+reveal_type(joined1)  # E: Revealed type is 'builtins.list[builtins.object*]'
+reveal_type(joined2)  # E: Revealed type is 'builtins.list[builtins.object*]'
+[builtins fixtures/dict.pyi]
+
+
+-- Meet
+
+[case testMeetOfTypedDictsWithCompatibleCommonKeysHasAllKeysAndNewFallback]
+from mypy_extensions import TypedDict
+from typing import TypeVar, Callable
+XY = TypedDict('XY', {'x': int, 'y': int})
+YZ = TypedDict('YZ', {'y': int, 'z': int})
+T = TypeVar('T')
+def f(x: Callable[[T, T], None]) -> T: pass
+def g(x: XY, y: YZ) -> None: pass
+reveal_type(f(g))  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, z=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+[builtins fixtures/dict.pyi]
+
+[case testMeetOfTypedDictsWithIncompatibleCommonKeysIsUninhabited]
+# flags: --strict-optional
+from mypy_extensions import TypedDict
+from typing import TypeVar, Callable
+XYa = TypedDict('XYa', {'x': int, 'y': int})
+YbZ = TypedDict('YbZ', {'y': object, 'z': int})
+T = TypeVar('T')
+def f(x: Callable[[T, T], None]) -> T: pass
+def g(x: XYa, y: YbZ) -> None: pass
+reveal_type(f(g))  # E: Revealed type is '<uninhabited>'
+[builtins fixtures/dict.pyi]
+
+[case testMeetOfTypedDictsWithNoCommonKeysHasAllKeysAndNewFallback]
+from mypy_extensions import TypedDict
+from typing import TypeVar, Callable
+X = TypedDict('X', {'x': int})
+Z = TypedDict('Z', {'z': int})
+T = TypeVar('T')
+def f(x: Callable[[T, T], None]) -> T: pass
+def g(x: X, y: Z) -> None: pass
+reveal_type(f(g))  # E: Revealed type is 'TypedDict(x=builtins.int, z=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+[builtins fixtures/dict.pyi]
+
+# TODO: It would be more accurate for the meet to be TypedDict instead.
+[case testMeetOfTypedDictWithCompatibleMappingIsUninhabitedForNow]
+# flags: --strict-optional
+from mypy_extensions import TypedDict
+from typing import TypeVar, Callable, Mapping
+X = TypedDict('X', {'x': int})
+M = Mapping[str, int]
+T = TypeVar('T')
+def f(x: Callable[[T, T], None]) -> T: pass
+def g(x: X, y: M) -> None: pass
+reveal_type(f(g))  # E: Revealed type is '<uninhabited>'
+[builtins fixtures/dict.pyi]
+
+[case testMeetOfTypedDictWithIncompatibleMappingIsUninhabited]
+# flags: --strict-optional
+from mypy_extensions import TypedDict
+from typing import TypeVar, Callable, Mapping
+X = TypedDict('X', {'x': int})
+M = Mapping[str, str]
+T = TypeVar('T')
+def f(x: Callable[[T, T], None]) -> T: pass
+def g(x: X, y: M) -> None: pass
+reveal_type(f(g))  # E: Revealed type is '<uninhabited>'
+[builtins fixtures/dict.pyi]
+
+# TODO: It would be more accurate for the meet to be TypedDict instead.
+[case testMeetOfTypedDictWithCompatibleMappingSuperclassIsUninhabitedForNow]
+# flags: --strict-optional
+from mypy_extensions import TypedDict
+from typing import TypeVar, Callable, Iterable
+X = TypedDict('X', {'x': int})
+I = Iterable[str]
+T = TypeVar('T')
+def f(x: Callable[[T, T], None]) -> T: pass
+def g(x: X, y: I) -> None: pass
+reveal_type(f(g))  # E: Revealed type is '<uninhabited>'
+[builtins fixtures/dict.pyi]
+
+
+-- Constraint Solver
+
+-- TODO: Figure out some way to trigger the ConstraintBuilderVisitor.visit_typeddict_type() path.
+
+
+-- Methods
+
+-- TODO: iter() doesn't accept TypedDictType as an argument type. Figure out why.
+--[case testCanCallMappingMethodsOnTypedDict]
+--from mypy_extensions import TypedDict
+--Cell = TypedDict('Cell', {'value': int})
+--c = Cell(value=42)
+--c['value']
+--iter(c)
+--len(c)
+--'value' in c
+--c.keys()
+--c.items()
+--c.values()
+--c.get('value')
+--c == c
+--c != c
+--[builtins fixtures/dict.pyi]
+
+
+-- Special Method: __getitem__
+
+-- TODO: Implement support for this case.
+--[case testCanGetItemOfTypedDictWithValidStringLiteralKey]
+--from mypy_extensions import TypedDict
+--TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+--p = TaggedPoint(type='2d', x=42, y=1337)
+--def get_x(p: TaggedPoint) -> int:
+--    return p['x']
+--[builtins fixtures/dict.pyi]
+
+-- TODO: Implement support for this case.
+--[case testCannotGetItemOfTypedDictWithInvalidStringLiteralKey]
+--# flags: --hide-error-context
+--from mypy_extensions import TypedDict
+--TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+--p = TaggedPoint(type='2d', x=42, y=1337)
+--def get_z(p: TaggedPoint) -> int:
+--    return p['z']  # E: ... 'z' is not a valid key for Point. Expected one of {'x', 'y'}.
+--[builtins fixtures/dict.pyi]
+
+-- TODO: Implement support for this case.
+--[case testCannotGetItemOfTypedDictWithNonLiteralKey]
+--# flags: --hide-error-context
+--from mypy_extensions import TypedDict
+--from typing import Union
+--TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+--p = TaggedPoint(type='2d', x=42, y=1337)
+--def get_coordinate(p: TaggedPoint, key: str) -> Union[str, int]:
+--    return p[key]  # E: ... Cannot prove 'key' is a valid key for Point. Expected one of {'x', 'y'}
+--[builtins fixtures/dict.pyi]
+
+
+-- Special Method: __setitem__
+
+-- TODO: Implement support for this case.
+--[case testCanSetItemOfTypedDictWithValidStringLiteralKey]
+--from mypy_extensions import TypedDict
+--TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+--p = TaggedPoint(type='2d', x=42, y=1337)
+--def set_x(p: TaggedPoint, x: int) -> None:
+--    p['x'] = x
+--[builtins fixtures/dict.pyi]
+
+-- TODO: Implement support for this case.
+--[case testCannotSetItemOfTypedDictWithInvalidStringLiteralKey]
+--# flags: --hide-error-context
+--from mypy_extensions import TypedDict
+--TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+--p = TaggedPoint(type='2d', x=42, y=1337)
+--def set_z(p: TaggedPoint, z: int) -> None:
+--    p['z'] = z  # E: ... 'z' is not a valid key for Point. Expected one of {'x', 'y'}.
+--[builtins fixtures/dict.pyi]
+
+-- TODO: Implement support for this case.
+--[case testCannotSetItemOfTypedDictWithNonLiteralKey]
+--# flags: --hide-error-context
+--from mypy_extensions import TypedDict
+--from typing import Union
+--TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+--p = TaggedPoint(type='2d', x=42, y=1337)
+--def set_coordinate(p: TaggedPoint, key: str, value: Union[str, int]) -> None:
+--    p[key] = value  # E: ... Cannot prove 'key' is a valid key for Point. Expected one of {'x', 'y'}
+--[builtins fixtures/dict.pyi]
+
+
+-- Special Method: get
+
+-- TODO: Implement support for these cases:
+--[case testGetOfTypedDictWithValidStringLiteralKeyReturnsPreciseType]
+--[case testGetOfTypedDictWithInvalidStringLiteralKeyIsError]
+--[case testGetOfTypedDictWithNonLiteralKeyReturnsImpreciseType]
+
+
+-- isinstance
+
+-- TODO: Implement support for this case.
+--[case testCannotIsInstanceTypedDictType]

--- a/test-data/unit/lib-stub/mypy_extensions.pyi
+++ b/test-data/unit/lib-stub/mypy_extensions.pyi
@@ -3,4 +3,4 @@ from typing import Dict, Type, TypeVar
 T = TypeVar('T')
 
 
-def TypedDict(typename: str, fields: Dict[str, Type[T]]) -> Type[dict]: ...
+def TypedDict(typename: str, fields: Dict[str, Type[T]]) -> Type[dict]: pass

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -80,6 +80,8 @@ class Sequence(Iterable[T], Generic[T]):
 
 class Mapping(Generic[T, U]): pass
 
+class MutableMapping(Generic[T, U]): pass
+
 def NewType(name: str, tp: Type[T]) -> Callable[[T], T]:
     def new_type(x):
         return x

--- a/test-data/unit/semanal-namedtuple.test
+++ b/test-data/unit/semanal-namedtuple.test
@@ -154,6 +154,10 @@ N = namedtuple('N', 1) # E: List or tuple literal expected as the second argumen
 from collections import namedtuple
 N = namedtuple('N', ['x', 1]) # E: String literal expected as namedtuple() item
 
+[case testNamedTupleWithUnderscoreItemName]
+from collections import namedtuple
+N = namedtuple('N', ['_fallback']) # E: namedtuple() field names cannot start with an underscore: _fallback
+
 -- NOTE: The following code works at runtime but is not yet supported by mypy.
 --       Keyword arguments may potentially be supported in the future.
 [case testNamedTupleWithNonpositionalArgs]

--- a/test-data/unit/semanal-typeddict.test
+++ b/test-data/unit/semanal-typeddict.test
@@ -1,6 +1,30 @@
--- Semantic analysis of typed dicts
+-- Create Type
 
-[case testCanDefineTypedDictType]
+-- TODO: Implement support for this syntax.
+--[case testCanCreateTypedDictTypeWithKeywordArguments]
+--from mypy_extensions import TypedDict
+--Point = TypedDict('Point', x=int, y=int)
+--[builtins fixtures/dict.pyi]
+--[out]
+--MypyFile:1(
+--  ImportFrom:1(mypy_extensions, [TypedDict])
+--  AssignmentStmt:2(
+--    NameExpr(Point* [__main__.Point])
+--    TypedDictExpr:2(Point)))
+
+-- TODO: Implement support for this syntax.
+--[case testCanCreateTypedDictTypeWithDictCall]
+--from mypy_extensions import TypedDict
+--Point = TypedDict('Point', dict(x=int, y=int))
+--[builtins fixtures/dict.pyi]
+--[out]
+--MypyFile:1(
+--  ImportFrom:1(mypy_extensions, [TypedDict])
+--  AssignmentStmt:2(
+--    NameExpr(Point* [__main__.Point])
+--    TypedDictExpr:2(Point)))
+
+[case testCanCreateTypedDictTypeWithDictLiteral]
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 [builtins fixtures/dict.pyi]
@@ -11,41 +35,47 @@ MypyFile:1(
     NameExpr(Point* [__main__.Point])
     TypedDictExpr:2(Point)))
 
--- Errors
 
-[case testTypedDictWithTooFewArguments]
+-- Create Type (Errors)
+
+[case testCannotCreateTypedDictTypeWithTooFewArguments]
 from mypy_extensions import TypedDict
 Point = TypedDict('Point')  # E: Too few arguments for TypedDict()
 [builtins fixtures/dict.pyi]
 
-[case testTypedDictWithTooManyArguments]
+[case testCannotCreateTypedDictTypeWithTooManyArguments]
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int}, dict)  # E: Too many arguments for TypedDict()
 [builtins fixtures/dict.pyi]
 
-[case testTypedDictWithInvalidName]
+[case testCannotCreateTypedDictTypeWithInvalidName]
 from mypy_extensions import TypedDict
 Point = TypedDict(dict, {'x': int, 'y': int})  # E: TypedDict() expects a string literal as the first argument
 [builtins fixtures/dict.pyi]
 
-[case testTypedDictWithInvalidItems]
+[case testCannotCreateTypedDictTypeWithInvalidItems]
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x'})  # E: TypedDict() expects a dictionary literal as the second argument
 [builtins fixtures/dict.pyi]
 
+[case testCannotCreateTypedDictTypeWithUnderscoreItemName]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int, '_fallback': object})  # E: TypedDict() item names cannot start with an underscore: _fallback
+[builtins fixtures/dict.pyi]
+
 -- NOTE: The following code works at runtime but is not yet supported by mypy.
 --       Keyword arguments may potentially be supported in the future.
-[case testTypedDictWithNonpositionalArgs]
+[case testCannotCreateTypedDictTypeWithNonpositionalArgs]
 from mypy_extensions import TypedDict
 Point = TypedDict(typename='Point', fields={'x': int, 'y': int})  # E: Unexpected arguments to TypedDict()
 [builtins fixtures/dict.pyi]
 
-[case testTypedDictWithInvalidItemName]
+[case testCannotCreateTypedDictTypeWithInvalidItemName]
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {int: int, int: int})  # E: Invalid TypedDict() field name
 [builtins fixtures/dict.pyi]
 
-[case testTypedDictWithInvalidItemType]
+[case testCannotCreateTypedDictTypeWithInvalidItemType]
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': 1, 'y': 1})  # E: Invalid field type
 [builtins fixtures/dict.pyi]


### PR DESCRIPTION
This PR was created in the following steps:
- Recognize creation of TypedDict instance. Define TypedDictType.
- Implement all visitor methods for the new TypedDictType:
  - Easy visitors.
  - Interesting visitors: Subtype, Join, Meet, Constraint Solve
- Write a zillion tests.

Remaining work:

```
[x] Figure out some way to trigger the TypeJoinVisitor.visit_typeddict_type() path.
    [x] Do it.
[x] Figure out some way to trigger the TypeMeetVisitor.visit_typeddict_type() path.
    [x] Do it.
[x] Figure out some way to trigger the ConstraintBuilderVisitor.visit_typeddict_type() path.
    [ ] Do it.
[ ] Extend mypy stubs to recognize that superclasses of Mapping include {Sized, Iterable, Container}
```

**I am creating this PR now to solicit assistance on approach for the preceding items of remaining work.**

Since I haven't been able to trigger the code paths for the Join, Meet, and Constraint Solve visitors, I am not as confident in their correctness.

Out of Scope for this PR:
- Anything in the test suite sections: `__getitem__`, `__setitem__`, `get`, `isinstance`
- Creating TypedDict types with keyword-based syntax or a dict(...) call.
