### PR TITLE
apply_generic_arguments: replace runtime checks with assertions

### DIFF
--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -16,10 +16,9 @@ def apply_generic_arguments(callable: CallableType, types: List[Type],
     'def (int) -> int'.
 
     Note that each type can be None; in this case, it will not be applied.
-    Can only be None when len(tvars) != len(types)
     """
-    assert len(callable.variables) == len(types)
     tvars = callable.variables
+    assert len(tvars) == len(types)
     # Check that inferred type variable values are compatible with allowed
     # values and bounds.  Also, promote subtype values to allowed values.
     types = types[:]

--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -3,25 +3,23 @@ from typing import List, Dict
 import mypy.subtypes
 from mypy.sametypes import is_same_type
 from mypy.expandtype import expand_type
-from mypy.types import Type, TypeVarId, TypeVarType, CallableType, AnyType, Void
+from mypy.types import Type, TypeVarId, TypeVarType, CallableType, AnyType
 from mypy.messages import MessageBuilder
 from mypy.nodes import Context
 
 
 def apply_generic_arguments(callable: CallableType, types: List[Type],
-                            msg: MessageBuilder, context: Context) -> Type:
+                            msg: MessageBuilder, context: Context) -> CallableType:
     """Apply generic type arguments to a callable type.
 
     For example, applying [int] to 'def [T] (T) -> T' results in
     'def (int) -> int'.
 
     Note that each type can be None; in this case, it will not be applied.
+    Can only be None when len(tvars) != len(types)
     """
+    assert len(callable.variables) == len(types)
     tvars = callable.variables
-    if len(tvars) != len(types):
-        msg.incompatible_type_application(len(tvars), len(types), context)
-        return AnyType()
-
     # Check that inferred type variable values are compatible with allowed
     # values and bounds.  Also, promote subtype values to allowed values.
     types = types[:]

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -470,8 +470,7 @@ class ExpressionChecker:
                 new_args.append(None)
             else:
                 new_args.append(arg)
-        return cast(CallableType, self.apply_generic_arguments(callable, new_args,
-                                                           error_context))
+        return self.apply_generic_arguments(callable, new_args, error_context)
 
     def infer_function_type_arguments(self, callee_type: CallableType,
                                       args: List[Expression],
@@ -561,9 +560,8 @@ class ExpressionChecker:
         for i, arg in enumerate(inferred_args):
             if isinstance(arg, (NoneTyp, UninhabitedType)) or has_erased_component(arg):
                 inferred_args[i] = None
+        callee_type = self.apply_generic_arguments(callee_type, inferred_args, context)
 
-        callee_type = cast(CallableType, self.apply_generic_arguments(
-            callee_type, inferred_args, context))
         arg_types = self.infer_arg_types_in_context2(
             callee_type, args, arg_kinds, formal_to_actual)
 
@@ -609,8 +607,7 @@ class ExpressionChecker:
         # Apply the inferred types to the function type. In this case the
         # return type must be CallableType, since we give the right number of type
         # arguments.
-        return cast(CallableType, self.apply_generic_arguments(callee_type,
-                                                           inferred_args, context))
+        return self.apply_generic_arguments(callee_type, inferred_args, context)
 
     def check_argument_count(self, callee: CallableType, actual_types: List[Type],
                              actual_kinds: List[int], actual_names: List[str],
@@ -724,10 +721,10 @@ class ExpressionChecker:
 
                 # There may be some remaining tuple varargs items that haven't
                 # been checked yet. Handle them.
+                tuplet = arg_types[actual]
                 if (callee.arg_kinds[i] == nodes.ARG_STAR and
                         arg_kinds[actual] == nodes.ARG_STAR and
-                        isinstance(arg_types[actual], TupleType)):
-                    tuplet = cast(TupleType, arg_types[actual])
+                        isinstance(tuplet, TupleType)):
                     while tuple_counter[0] < len(tuplet.items):
                         actual_type = get_actual_type(arg_type,
                                                       arg_kinds[actual],
@@ -880,21 +877,9 @@ class ExpressionChecker:
         return ok
 
     def apply_generic_arguments(self, callable: CallableType, types: List[Type],
-                                context: Context) -> Type:
+                                context: Context) -> CallableType:
         """Simple wrapper around mypy.applytype.apply_generic_arguments."""
         return applytype.apply_generic_arguments(callable, types, self.msg, context)
-
-    def apply_generic_arguments2(self, overload: Overloaded, types: List[Type],
-                                 context: Context) -> Type:
-        items = []  # type: List[CallableType]
-        for item in overload.items():
-            applied = self.apply_generic_arguments(item, types, context)
-            if isinstance(applied, CallableType):
-                items.append(applied)
-            else:
-                # There was an error.
-                return AnyType()
-        return Overloaded(items)
 
     def visit_member_expr(self, e: MemberExpr) -> Type:
         """Visit member expression (of form e.id)."""
@@ -1375,9 +1360,19 @@ class ExpressionChecker:
         """Type check a type application (expr[type, ...])."""
         tp = self.accept(tapp.expr)
         if isinstance(tp, CallableType):
+            if len(tp.variables) != len(tapp.types):
+                self.msg.incompatible_type_application(len(tp.variables),
+                                                       len(tapp.types), tapp)
+                return AnyType()
             return self.apply_generic_arguments(tp, tapp.types, tapp)
-        if isinstance(tp, Overloaded):
-            return self.apply_generic_arguments2(tp, tapp.types, tapp)
+        elif isinstance(tp, Overloaded):
+            for item in tp.items():
+                if len(item.variables) != len(tapp.types):
+                    self.msg.incompatible_type_application(len(item.variables),
+                                                           len(tapp.types), tapp)
+                    return AnyType()
+            return Overloaded([self.apply_generic_arguments(item, tapp.types, tapp)
+                               for item in tp.items()])
         return AnyType()
 
     def visit_type_alias_expr(self, alias: TypeAliasExpr) -> Type:
@@ -1569,9 +1564,8 @@ class ExpressionChecker:
         # they must be considered as indeterminate. We use ErasedType since it
         # does not affect type inference results (it is for purposes like this
         # only).
-        ctx = replace_meta_vars(ctx, ErasedType())
-
-        callable_ctx = cast(CallableType, ctx)
+        callable_ctx = replace_meta_vars(ctx, ErasedType())
+        assert isinstance(callable_ctx, CallableType)
 
         arg_kinds = [arg.kind for arg in e.arguments]
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1,4 +1,4 @@
-from typing import cast, List, Dict, Callable
+from typing import List, Dict, Callable
 
 from mypy.types import (
     Type, AnyType, UnboundType, TypeVisitor, ErrorType, Void, NoneTyp,
@@ -333,7 +333,7 @@ def unify_generic_callable(type: CallableType, target: CallableType,
         return None
     msg = messages.temp_message_builder()
     applied = mypy.applytype.apply_generic_arguments(type, inferred_vars, msg, context=target)
-    if msg.is_errors() or not isinstance(applied, CallableType):
+    if msg.is_errors():
         return None
     return applied
 


### PR DESCRIPTION
Part of #2272.

The only place where the number of type arguments in type application might not match is when the user does that; this is explicitly checked in `visit_type_application`. Other places involve type inference, which must be correct "by construction" and if it isn't, that's a bug we want to catch, instead of returning AnyType.

It also allows us to remove casts.

cc @ddfisher