### PR TITLE
[WIP] Uniform handling of metaclasses

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1594,6 +1594,9 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
         # part of a small cycle involving at least {builtins, abc,
         # typing}.  Of these, builtins must be processed last or else
         # some builtin objects will be incompletely processed.)
+        if 'abc' in ascc:
+            scc.remove('abc')
+            scc.append('abc')
         if 'builtins' in ascc:
             scc.remove('builtins')
             scc.append('builtins')

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1791,10 +1791,12 @@ class TypeChecker(NodeVisitor[Type]):
             return joined
         else:
             # Non-tuple iterable.
-            self.check_subtype(iterable,
-                               self.named_generic_type('typing.Iterable',
-                                                       [AnyType()]),
-                               expr, messages.ITERABLE_EXPECTED)
+            if isinstance(iterable, CallableType) and iterable.is_type_obj():
+                print(iterable.fallback)
+            else:
+                self.check_subtype(iterable,
+                                   self.named_generic_type('typing.Iterable', [AnyType()]),
+                                   expr, messages.ITERABLE_EXPECTED)
 
             echk = self.expr_checker
             method = echk.analyze_external_member_access('__iter__', iterable,
@@ -2213,10 +2215,6 @@ class TypeChecker(NodeVisitor[Type]):
         # Assume that the name refers to a class.
         sym = self.lookup_qualified(fullname)
         return cast(TypeInfo, sym.node)
-
-    def type_type(self) -> Instance:
-        """Return instance type 'type'."""
-        return self.named_type('builtins.type')
 
     def object_type(self) -> Instance:
         """Return instance type 'object'."""

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1793,6 +1793,9 @@ class TypeChecker(NodeVisitor[Type]):
             # Non-tuple iterable.
             if isinstance(iterable, CallableType) and iterable.is_type_obj():
                 print(iterable.fallback)
+                self.check_subtype(iterable.fallback,
+                                   self.named_generic_type('typing.Iterable', [AnyType()]),
+                                   expr, messages.ITERABLE_EXPECTED)
             else:
                 self.check_subtype(iterable,
                                    self.named_generic_type('typing.Iterable', [AnyType()]),

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1607,7 +1607,7 @@ class ExpressionChecker:
                     args = self.chk.function_stack[-1].arguments
                     # An empty args with super() is an error; we need something in declared_self
                     if not args:
-                        self.chk.fail('super() requires at least on positional argument', e)
+                        self.chk.fail('super() requires at least one positional argument', e)
                         return AnyType()
                     declared_self = args[0].variable.type
                     return analyze_member_access(name=e.name, typ=fill_typevars(e.info), node=e,

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -175,7 +175,7 @@ def analyze_member_access(name: str,
                                                     original_type=original_type)
             if result:
                 return result
-        fallback = builtin_type('builtins.type')
+        fallback = item.type.metaclass_type
         return analyze_member_access(name, fallback, node, is_lvalue, is_super,
                                      is_operator, builtin_type, not_ready_callback, msg,
                                      original_type=original_type, chk=chk)
@@ -437,7 +437,7 @@ def type_object_type(info: TypeInfo, builtin_type: Callable[[str], Instance]) ->
         # Must be an invalid class definition.
         return AnyType()
     else:
-        fallback = builtin_type('builtins.type')
+        fallback = info.metaclass_type
         if init_method.info.fullname() == 'builtins.object':
             # No non-default __init__ -> look at __new__ instead.
             new_method = info.get_method('__new__')

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -175,7 +175,9 @@ def analyze_member_access(name: str,
                                                     original_type=original_type)
             if result:
                 return result
-        fallback = item.type.metaclass_type
+        fallback = builtin_type('builtins.type')
+        if item is not None:
+            fallback = item.type.metaclass_type or fallback
         return analyze_member_access(name, fallback, node, is_lvalue, is_super,
                                      is_operator, builtin_type, not_ready_callback, msg,
                                      original_type=original_type, chk=chk)
@@ -437,7 +439,7 @@ def type_object_type(info: TypeInfo, builtin_type: Callable[[str], Instance]) ->
         # Must be an invalid class definition.
         return AnyType()
     else:
-        fallback = info.metaclass_type
+        fallback = info.metaclass_type or builtin_type('builtins.type')
         if init_method.info.fullname() == 'builtins.object':
             # No non-default __init__ -> look at __new__ instead.
             new_method = info.get_method('__new__')

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1902,6 +1902,18 @@ class TypeInfo(SymbolNode):
         'is_abstract', 'is_enum', 'fallback_to_any', 'is_named_tuple',
         'is_typed_dict', 'is_newtype'
     ]
+    
+    _metaclass_type = None  # type: Optional[Instance]
+    
+    @property
+    def metaclass_type(self) -> 'mypy.types.Instance':
+        if self._metaclass_type:
+            return self._metaclass_type
+        return self.mro[1].metaclass_type
+
+    @metaclass_type.setter
+    def metaclass_type(self, value: 'mypy.types.Instance'):
+        self._metaclass_type = value
 
     def __init__(self, names: 'SymbolTable', defn: ClassDef, module_name: str) -> None:
         """Initialize a TypeInfo."""

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1902,15 +1902,18 @@ class TypeInfo(SymbolNode):
         'is_abstract', 'is_enum', 'fallback_to_any', 'is_named_tuple',
         'is_typed_dict', 'is_newtype'
     ]
-    
+
     _metaclass_type = None  # type: Optional[mypy.types.Instance]
-    
+
     @property
     def metaclass_type(self) -> 'Optional[mypy.types.Instance]':
         if self._metaclass_type:
             return self._metaclass_type
         if self._fullname == 'builtins.type':
             return mypy.types.Instance(self, [])
+        if self.mro is None:
+            # XXX why does this happen?
+            return None
         if len(self.mro) > 1:
             return self.mro[1].metaclass_type
         # FIX: assert False

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -902,8 +902,12 @@ class SemanticAnalyzer(NodeVisitor):
             if defn.metaclass == '<error>':
                 self.fail("Dynamic metaclass not supported for '%s'" % defn.name, defn)
                 return
-            sym = self.lookup_qualified(defn.metaclass, defn)
-            if sym is not None and not isinstance(sym.node, TypeInfo):
+            sym = self.lookup(defn.metaclass, defn)
+            if sym is not None:
+                assert isinstance(sym.node, TypeInfo)
+                defn.info.metaclass_type = fill_typevars(sym.node)
+                return
+            else:
                 self.fail("Invalid metaclass '%s'" % defn.metaclass, defn)
 
     def object_type(self) -> Instance:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -903,8 +903,7 @@ class SemanticAnalyzer(NodeVisitor):
                 self.fail("Dynamic metaclass not supported for '%s'" % defn.name, defn)
                 return
             sym = self.lookup(defn.metaclass, defn)
-            if sym is not None:
-                assert isinstance(sym.node, TypeInfo)
+            if sym is not None and isinstance(sym.node, TypeInfo):
                 inst = fill_typevars(sym.node)
                 assert isinstance(inst, Instance)
                 defn.info.metaclass_type = inst

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -905,7 +905,9 @@ class SemanticAnalyzer(NodeVisitor):
             sym = self.lookup(defn.metaclass, defn)
             if sym is not None:
                 assert isinstance(sym.node, TypeInfo)
-                defn.info.metaclass_type = fill_typevars(sym.node)
+                inst = fill_typevars(sym.node)
+                assert isinstance(inst, Instance)
+                defn.info.metaclass_type = inst
                 return
             else:
                 self.fail("Invalid metaclass '%s'" % defn.metaclass, defn)

--- a/mypy/typefixture.py
+++ b/mypy/typefixture.py
@@ -102,6 +102,7 @@ class TypeFixture:
         # Instance types
         self.std_tuple = Instance(self.std_tuplei, [])        # tuple
         self.type_type = Instance(self.type_typei, [])        # type
+        self.oi.metaclass_type = self.type_type
         self.function = Instance(self.functioni, [])  # function TODO
         self.a = Instance(self.ai, [])          # A
         self.b = Instance(self.bi, [])          # B

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -508,6 +508,9 @@ class FunctionLike(Type):
 
     can_be_false = False
 
+    # Corresponding instance type (e.g. builtins.type)
+    fallback = None  # type: Instance
+
     @abstractmethod
     def is_type_obj(self) -> bool: pass
 
@@ -522,9 +525,6 @@ class FunctionLike(Type):
 
     @abstractmethod
     def with_name(self, name: str) -> 'FunctionLike': pass
-
-    # Corresponding instance type (e.g. builtins.type)
-    fallback = None  # type: Instance
 
     @classmethod
     def deserialize(cls, data: JsonDict) -> 'FunctionLike':
@@ -624,7 +624,7 @@ class CallableType(FunctionLike):
         )
 
     def is_type_obj(self) -> bool:
-        return self.fallback.type is not None and self.fallback.type.fullname() == 'builtins.type'
+        return self.fallback.type is not None  # and self.fallback.type.fullname() == 'builtins.type'
 
     def is_concrete_type_obj(self) -> bool:
         return self.is_type_obj() and self.is_classmethod_class

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -624,7 +624,8 @@ class CallableType(FunctionLike):
         )
 
     def is_type_obj(self) -> bool:
-        return self.fallback.type is not None  # and self.fallback.type.fullname() == 'builtins.type'
+        t = self.fallback.type
+        return t is not None and t.is_metaclass()
 
     def is_concrete_type_obj(self) -> bool:
         return self.is_type_obj() and self.is_classmethod_class

--- a/test-data/unit/lib-stub/abc.pyi
+++ b/test-data/unit/lib-stub/abc.pyi
@@ -1,3 +1,3 @@
-class ABCMeta: pass
+class ABCMeta(type): pass
 abstractmethod = object()
 abstractproperty = object()

--- a/test-data/unit/pythoneval-enum.test
+++ b/test-data/unit/pythoneval-enum.test
@@ -118,3 +118,16 @@ takes_int(SomeExtIntEnum.x)
 def takes_some_ext_int_enum(s: SomeExtIntEnum):
     pass
 takes_some_ext_int_enum(SomeExtIntEnum.x)
+
+[case testEnumIter]
+from typing import List
+from enum import Enum
+class Medal(Enum):
+    gold = 1
+    silver = 2
+    bronze = 3
+
+for x in Medal:
+    reveal_type(x)
+
+x = list(Medal)  # type: List[Medal]

--- a/test-data/unit/pythoneval-enum.test
+++ b/test-data/unit/pythoneval-enum.test
@@ -118,17 +118,3 @@ takes_int(SomeExtIntEnum.x)
 def takes_some_ext_int_enum(s: SomeExtIntEnum):
     pass
 takes_some_ext_int_enum(SomeExtIntEnum.x)
-
-[case testEnumIter]
-from typing import List
-from enum import Enum
-class Medal(Enum):
-    gold = 1
-    silver = 2
-    bronze = 3
-
-for x in Medal:
-    reveal_type(x)  # E: Revealed type is '_program.Medal*'
-
--- TODO:
--- reveal_type(list(Medal))  # type: List[Medal]

--- a/test-data/unit/pythoneval-enum.test
+++ b/test-data/unit/pythoneval-enum.test
@@ -128,6 +128,7 @@ class Medal(Enum):
     bronze = 3
 
 for x in Medal:
-    reveal_type(x)
+    reveal_type(x)  # E: Revealed type is '_program.Medal*'
 
-x = list(Medal)  # type: List[Medal]
+-- TODO:
+-- reveal_type(list(Medal))  # type: List[Medal]

--- a/test-data/unit/semanal-classes.test
+++ b/test-data/unit/semanal-classes.test
@@ -394,11 +394,11 @@ MypyFile:1(
               NameExpr(x [l]))))))))
 
 [case testQualifiedMetaclass]
-import abc
-class A(metaclass=abc.ABCMeta): pass
+from abc import ABCMeta
+class A(metaclass=ABCMeta): pass
 [out]
 MypyFile:1(
-  Import:1(abc)
+  ImportFrom:1(abc, [ABCMeta])
   ClassDef:2(
     A
     Metaclass(abc.ABCMeta)

--- a/test-data/unit/semanal-classes.test
+++ b/test-data/unit/semanal-classes.test
@@ -401,7 +401,7 @@ MypyFile:1(
   ImportFrom:1(abc, [ABCMeta])
   ClassDef:2(
     A
-    Metaclass(abc.ABCMeta)
+    Metaclass(ABCMeta)
     PassStmt:2()))
 
 [case testStaticMethod]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -985,8 +985,8 @@ class A(Generic[T], Generic[S]): pass \
 [case testInvalidMetaclass]
 class A(metaclass=x): pass
 [out]
-main:2: error: Name 'x' is not defined
-main:2: error: Invalid metaclass 'x'
+main:1: error: Name 'x' is not defined
+main:1: error: Invalid metaclass 'x'
 
 [case testInvalidQualifiedMetaclass]
 import abc

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -983,13 +983,17 @@ class A(Generic[T], Generic[S]): pass \
 [out]
 
 [case testInvalidMetaclass]
-class A(metaclass=x): pass # E: Name 'x' is not defined
+class A(metaclass=x): pass
 [out]
+main:2: error: Name 'x' is not defined
+main:2: error: Invalid metaclass 'x'
 
 [case testInvalidQualifiedMetaclass]
 import abc
-class A(metaclass=abc.Foo): pass # E: Name 'abc.Foo' is not defined
+class A(metaclass=abc.Foo): pass
 [out]
+main:2: error: Name 'abc.Foo' is not defined
+main:2: error: Invalid metaclass 'abc.Foo'
 
 [case testNonClassMetaclass]
 def f(): pass


### PR DESCRIPTION
In order to fix #2305, I think we need a better handling of metaclasses: store the type of the metaclass in TypeInfo, and use it when possible, instead of `builtins.type`.

I assume metaclasses inherit from type; I don't yet follow [the documentation](https://docs.python.org/3/reference/datamodel.html#determining-the-appropriate-metaclass).

This PR requires changes to typeshed.