### PR TITLE
Generic type aliases

### DIFF
--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -426,9 +426,58 @@ assigning the type to a variable:
    def f() -> AliasType:
        ...
 
-A type alias does not create a new type. It's just a shorthand notation
-for another type -- it's equivalent to the target type. Type aliases
-can be imported from modules like any names.
+Type aliases can be generic, in this case they could be used in two variants:
+Subscribed aliases are equivalent to original types with substituted type variables,
+number of type arguments must match the number of free type variables
+in generic type alias. Unsubscribed aliases are treated as original types with free
+vaiables replacec with ``Any``. Examples (following `PEP 484
+<https://www.python.org/dev/peps/pep-0484/#type-aliases>`_):
+
+.. code-block:: python
+
+    from typing import TypeVar, Iterable, Tuple
+    T = TypeVar('T', int, float, complex)
+
+    Vec = Iterable[Tuple[T, T]]
+
+    def inproduct(v: Vec[T]) -> T:
+        return sum(x*y for x, y in v)
+
+    def dilate(v: Vec[T], scale: T) -> Vec[T]:
+        return ((x * scale, y * scale) for x, y in v)
+
+    v1: Vec[int] = []      # Same as Iterable[Tuple[int, int]]
+    v2: Vec = []           # Same as Iterable[Tuple[Any, Any]]
+    v3: Vec[int, int] = [] # Error: Invalid alias, too many type arguments!
+
+Type aliases can be imported from modules like any names. Following previous examples:
+
+.. code-block:: python
+
+    from typing import TypeVar, Generic
+    from first_example import AliasType
+    from secon_example import Vec
+
+    T = TypeVar('T')
+    class NewVec(Generic[T], Vec[T]):
+        ...
+
+    for i, j in NewVec[int]():
+        ...
+
+    def fun() -> AliasType:
+        ...
+
+.. note::
+
+    A type alias does not create a new type. It's just a shorthand notation for
+    another type -- it's equivalent to the target type. For generic type aliases
+    this means that variance of type variables used for alias definition does not
+    allpy to aliases. Parameterized generic alias is treated simply as an original
+    type with corresponding type variables substituted. Accordingly, type checking
+    happens when a type alias is used. Invalid aliases (like e.g.
+    ``Callable[..., List[T, T]]``) might not always be flagged by mypy if they are
+    left unused.
 
 .. _newtypes:
 

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -429,25 +429,26 @@ assigning the type to a variable:
 Type aliases can be generic, in this case they could be used in two variants:
 Subscripted aliases are equivalent to original types with substituted type variables,
 number of type arguments must match the number of free type variables
-in generic type alias. Unsubscribed aliases are treated as original types with free
+in generic type alias. Unsubscripted aliases are treated as original types with free
 variables replaced with ``Any``. Examples (following `PEP 484
 <https://www.python.org/dev/peps/pep-0484/#type-aliases>`_):
 
 .. code-block:: python
 
     from typing import TypeVar, Iterable, Tuple, Union, Callable
-    T = TypeVar('T', int, float, complex)
-
-    TInt = Tuple[int, T]
-    UInt = Union[T, int]
-    CBack = Callable[..., T]
-    Vec = Iterable[Tuple[T, T]]
+    S = TypeVar('S')
+    TInt = Tuple[int, S]
+    UInt = Union[S, int]
+    CBack = Callable[..., S]
 
     def response(query: str) -> UInt[str]:  # Same as Union[str, int]
         ...
     def activate(cb: CBack[T]) -> T:        # Same as Callable[..., T]
         ...
     table_entry: TInt  # Same as Tuple[int, Any]
+
+    T = TypeVar('T', int, float, complex)
+    Vec = Iterable[Tuple[T, T]]
 
     def inproduct(v: Vec[T]) -> T:
         return sum(x*y for x, y in v)

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -427,10 +427,10 @@ assigning the type to a variable:
        ...
 
 Type aliases can be generic, in this case they could be used in two variants:
-Subscribed aliases are equivalent to original types with substituted type variables,
+Subscripted aliases are equivalent to original types with substituted type variables,
 number of type arguments must match the number of free type variables
 in generic type alias. Unsubscribed aliases are treated as original types with free
-vaiables replacec with ``Any``. Examples (following `PEP 484
+variables replaced with ``Any``. Examples (following `PEP 484
 <https://www.python.org/dev/peps/pep-0484/#type-aliases>`_):
 
 .. code-block:: python
@@ -438,10 +438,16 @@ vaiables replacec with ``Any``. Examples (following `PEP 484
     from typing import TypeVar, Iterable, Tuple, Union, Callable
     T = TypeVar('T', int, float, complex)
 
-    TInt = Tuple[T, int]
+    TInt = Tuple[int, T]
     UInt = Union[T, int]
     CBack = Callable[..., T]
     Vec = Iterable[Tuple[T, T]]
+
+    def response(query: str) -> UInt[str]:  # Same as Union[str, int]
+        ...
+    def activate(cb: CBack[T]) -> T:        # Same as Callable[..., T]
+        ...
+    table_entry: TInt  # Same as Tuple[int, Any]
 
     def inproduct(v: Vec[T]) -> T:
         return sum(x*y for x, y in v)
@@ -479,12 +485,9 @@ Following previous examples:
 
     A type alias does not create a new type. It's just a shorthand notation for
     another type -- it's equivalent to the target type. For generic type aliases
-    this means that variance of type variables used for alias definition does not
-    allpy to aliases. Parameterized generic alias is treated simply as an original
-    type with corresponding type variables substituted. Accordingly, type checking
-    happens when a type alias is used. Invalid aliases (like e.g.
-    ``Callable[..., List[T, T]]``) might not always be flagged by mypy if they are
-    left unused.
+    this means that variance or constraints of type variables used for alias
+    definition don't apply to aliases. Parameterized generic alias is treated
+    simply as an original type with corresponding type variables substituted.
 
 .. _newtypes:
 

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -435,9 +435,12 @@ vaiables replacec with ``Any``. Examples (following `PEP 484
 
 .. code-block:: python
 
-    from typing import TypeVar, Iterable, Tuple
+    from typing import TypeVar, Iterable, Tuple, Union, Callable
     T = TypeVar('T', int, float, complex)
 
+    TInt = Tuple[T, int]
+    UInt = Union[T, int]
+    CBack = Callable[..., T]
     Vec = Iterable[Tuple[T, T]]
 
     def inproduct(v: Vec[T]) -> T:

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -450,23 +450,27 @@ vaiables replacec with ``Any``. Examples (following `PEP 484
     v2: Vec = []           # Same as Iterable[Tuple[Any, Any]]
     v3: Vec[int, int] = [] # Error: Invalid alias, too many type arguments!
 
-Type aliases can be imported from modules like any names. Following previous examples:
+Type aliases can be imported from modules like any names. Aliases can target another
+aliases (although building complex chains of aliases is not recommended, this
+impedes code readability, thus defeating the purpose of using aliases).
+Following previous examples:
 
 .. code-block:: python
 
-    from typing import TypeVar, Generic
+    from typing import TypeVar, Generic, Optional
     from first_example import AliasType
-    from secon_example import Vec
+    from second_example import Vec
+
+    def fun() -> AliasType:
+        ...
 
     T = TypeVar('T')
     class NewVec(Generic[T], Vec[T]):
         ...
-
     for i, j in NewVec[int]():
         ...
 
-    def fun() -> AliasType:
-        ...
+    OIntVec = Optional[Vec[int]]
 
 .. note::
 

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -487,8 +487,8 @@ Following previous examples:
     A type alias does not create a new type. It's just a shorthand notation for
     another type -- it's equivalent to the target type. For generic type aliases
     this means that variance of type variables used for alias definition does not
-    apply to aliases. Parameterized generic alias is treated simply as an original
-    type with corresponding type variables substituted.
+    apply to aliases. A parameterized generic alias is treated simply as an original
+    type with the corresponding type variables substituted.
 
 .. _newtypes:
 

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -443,7 +443,7 @@ variables replaced with ``Any``. Examples (following `PEP 484
 
     def response(query: str) -> UInt[str]:  # Same as Union[str, int]
         ...
-    def activate(cb: CBack[T]) -> T:        # Same as Callable[..., T]
+    def activate(cb: CBack[S]) -> S:        # Same as Callable[..., S]
         ...
     table_entry: TInt  # Same as Tuple[int, Any]
 

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -485,9 +485,9 @@ Following previous examples:
 
     A type alias does not create a new type. It's just a shorthand notation for
     another type -- it's equivalent to the target type. For generic type aliases
-    this means that variance or constraints of type variables used for alias
-    definition don't apply to aliases. Parameterized generic alias is treated
-    simply as an original type with corresponding type variables substituted.
+    this means that variance of type variables used for alias definition does not
+    apply to aliases. Parameterized generic alias is treated simply as an original
+    type with corresponding type variables substituted.
 
 .. _newtypes:
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1378,7 +1378,7 @@ class ExpressionChecker:
     def visit_type_alias_expr(self, alias: TypeAliasExpr) -> Type:
         item = alias.type
         if isinstance(item, Instance):
-            item = self.replace_tvars_any(item)
+            item = cast(Instance, self.replace_tvars_any(item))
             tp = type_object_type(item.type, self.named_type)
         else:
             return item

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1378,7 +1378,8 @@ class ExpressionChecker:
     def visit_type_alias_expr(self, alias: TypeAliasExpr) -> Type:
         """ Get type of a type alias (could be generic) in a runtime expression."""
         item = alias.type
-        if isinstance(item, (Instance, TupleType, UnionType, CallableType)):
+        if (isinstance(item, (Instance, TupleType, UnionType, CallableType))
+           and not alias.runtime):
             item = self.replace_tvars_any(item)
         if isinstance(item, Instance):
             tp = type_object_type(item.type, self.named_type)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -7,8 +7,7 @@ from mypy.types import (
     TupleType, Instance, TypeVarId, TypeVarType, ErasedType, UnionType,
     PartialType, DeletedType, UnboundType, UninhabitedType, TypeType,
     true_only, false_only, is_named_instance, function_type,
-    get_typ_args, set_typ_args
-
+    get_typ_args, set_typ_args,
 )
 from mypy.nodes import (
     NameExpr, RefExpr, Var, FuncDef, OverloadedFuncDef, TypeInfo, CallExpr,
@@ -1390,7 +1389,7 @@ class ExpressionChecker:
         else:
             # This type is invalid in most runtime contexts
             # and corresponding an error will be reported.
-            return alias.fback
+            return alias.fallback
         if isinstance(tp, CallableType):
             if len(tp.variables) != len(item.args):
                 self.msg.incompatible_type_application(len(tp.variables),
@@ -1425,7 +1424,7 @@ class ExpressionChecker:
                     new_args[i] = AnyType()
             else:
                 new_args[i] = self.replace_tvars_any(arg)
-        return set_typ_args(tp, new_args)
+        return set_typ_args(tp, new_args, tp.line, tp.column)
 
     def visit_list_expr(self, e: ListExpr) -> Type:
         """Type check a list expression [...]."""

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -20,11 +20,11 @@ def expr_to_unanalyzed_type(expr: Expression) -> Type:
     """
     if isinstance(expr, NameExpr):
         name = expr.name
-        return UnboundType(name, line=expr.line)
+        return UnboundType(name, line=expr.line, column=expr.column)
     elif isinstance(expr, MemberExpr):
         fullname = get_member_expr_fullname(expr)
         if fullname:
-            return UnboundType(fullname, line=expr.line)
+            return UnboundType(fullname, line=expr.line, column=expr.column)
         else:
             raise TypeTranslationError()
     elif isinstance(expr, IndexExpr):
@@ -42,7 +42,7 @@ def expr_to_unanalyzed_type(expr: Expression) -> Type:
             raise TypeTranslationError()
     elif isinstance(expr, ListExpr):
         return TypeList([expr_to_unanalyzed_type(t) for t in expr.items],
-                        line=expr.line)
+                        line=expr.line, column=expr.column)
     elif isinstance(expr, (StrExpr, BytesExpr)):
         # Parse string literal type.
         try:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -432,6 +432,7 @@ class ASTConverter(ast35.NodeTransformer):
             typ = parse_type_comment(n.type_comment, n.lineno)
         elif new_syntax:
             typ = TypeConverter(line=n.lineno).visit(n.annotation)  # type: ignore
+            typ.column = n.annotation.col_offset
         if n.value is None:  # always allow 'x: int'
             rvalue = TempNode(AnyType())  # type: Expression
         else:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1733,10 +1733,13 @@ class TypeAliasExpr(Expression):
 
     type = None  # type: mypy.types.Type
     line = None  # type: int
+    runtime = False  # type: bool
 
-    def __init__(self, type: 'mypy.types.Type', line: int = -1) -> None:
+    def __init__(self, type: 'mypy.types.Type', line: int = -1,
+                 runtime: bool = False) -> None:
         self.type = type
         self.line = line
+        self.runtime = runtime
 
     def accept(self, visitor: NodeVisitor[T]) -> T:
         return visitor.visit_type_alias_expr(self)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1732,9 +1732,11 @@ class TypeAliasExpr(Expression):
     """Type alias expression (rvalue)."""
 
     type = None  # type: mypy.types.Type
+    line = None  # type: int
 
-    def __init__(self, type: 'mypy.types.Type') -> None:
+    def __init__(self, type: 'mypy.types.Type', line: int = -1) -> None:
         self.type = type
+        self.line = line
 
     def accept(self, visitor: NodeVisitor[T]) -> T:
         return visitor.visit_type_alias_expr(self)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1732,15 +1732,17 @@ class TypeAliasExpr(Expression):
     """Type alias expression (rvalue)."""
 
     type = None  # type: mypy.types.Type
-    fback = None  # type: mypy.types.Type
+    # Simple fallback type for aliases that are invalid in runtime expressions
+    # (for example Union, Tuple, Callable).
+    fallback = None  # type: mypy.types.Type
     # This type alias is subscripted in a runtime expression like Alias[int](42)
     # (not in a type context like type annotation or base class).
     in_runtime = False  # type: bool
 
-    def __init__(self, type: 'mypy.types.Type', fback: 'mypy.types.Type' = None,
+    def __init__(self, type: 'mypy.types.Type', fallback: 'mypy.types.Type' = None,
                  in_runtime: bool = False) -> None:
         self.type = type
-        self.fback = fback
+        self.fallback = fallback
         self.in_runtime = in_runtime
 
     def accept(self, visitor: NodeVisitor[T]) -> T:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1732,13 +1732,13 @@ class TypeAliasExpr(Expression):
     """Type alias expression (rvalue)."""
 
     type = None  # type: mypy.types.Type
-    line = None  # type: int
+    fback = None  # type: mypy.types.Type
     runtime = False  # type: bool
 
-    def __init__(self, type: 'mypy.types.Type', line: int = -1,
+    def __init__(self, type: 'mypy.types.Type', fback: 'mypy.types.Type' = None,
                  runtime: bool = False) -> None:
         self.type = type
-        self.line = line
+        self.fback = fback
         self.runtime = runtime
 
     def accept(self, visitor: NodeVisitor[T]) -> T:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1733,13 +1733,15 @@ class TypeAliasExpr(Expression):
 
     type = None  # type: mypy.types.Type
     fback = None  # type: mypy.types.Type
-    runtime = False  # type: bool
+    # This type alias is subscripted in a runtime expression like Alias[int](42)
+    # (not in a type context like type annotation or base class).
+    in_runtime = False  # type: bool
 
     def __init__(self, type: 'mypy.types.Type', fback: 'mypy.types.Type' = None,
-                 runtime: bool = False) -> None:
+                 in_runtime: bool = False) -> None:
         self.type = type
         self.fback = fback
-        self.runtime = runtime
+        self.in_runtime = in_runtime
 
     def accept(self, visitor: NodeVisitor[T]) -> T:
         return visitor.visit_type_alias_expr(self)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1217,7 +1217,6 @@ class SemanticAnalyzer(NodeVisitor):
         """Make a dummy Instance with no methods. It is used as a fallback type
         to detect errors for non-Instance aliases (i.e. Unions, Tuples, Callables).
         """
-
         kind = (' to Callable' if isinstance(tp, CallableType) else
                 ' to Tuple' if isinstance(tp, TupleType) else
                 ' to Union' if isinstance(tp, UnionType) else '')
@@ -2378,13 +2377,13 @@ class SemanticAnalyzer(NodeVisitor):
     def visit_index_expr(self, expr: IndexExpr) -> None:
         expr.base.accept(self)
         if isinstance(expr.base, RefExpr) and expr.base.kind == TYPE_ALIAS:
-            # Special form -- subcribing a generic type alias.
+            # Special form -- subscripting a generic type alias.
             # Perform the type substitution and create a new alias.
             res = analyze_type_alias(expr,
                                      self.lookup_qualified,
                                      self.lookup_fully_qualified,
                                      self.fail)
-            expr.analyzed = TypeAliasExpr(res, fback=self.alias_fallback(res), runtime=True)
+            expr.analyzed = TypeAliasExpr(res, fback=self.alias_fallback(res), in_runtime=True)
         elif refers_to_class_or_function(expr.base):
             # Special form -- type application.
             # Translate index to an unanalyzed type.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2363,7 +2363,13 @@ class SemanticAnalyzer(NodeVisitor):
 
     def visit_index_expr(self, expr: IndexExpr) -> None:
         expr.base.accept(self)
-        if refers_to_class_or_function(expr.base):
+        if isinstance(expr.base, RefExpr) and expr.base.kind == TYPE_ALIAS:
+            res = analyze_type_alias(expr,
+                                     self.lookup_qualified,
+                                     self.lookup_fully_qualified,
+                                     self.fail)
+            expr.analyzed = TypeAliasExpr(res)
+        elif refers_to_class_or_function(expr.base):
             # Special form -- type application.
             # Translate index to an unanalyzed type.
             types = []  # type: List[Type]

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1126,7 +1126,8 @@ class SemanticAnalyzer(NodeVisitor):
         if b:
             self.visit_block(b)
 
-    def anal_type(self, t: Type, allow_tuple_literal: bool = False) -> Type:
+    def anal_type(self, t: Type, allow_tuple_literal: bool = False,
+                  aliasing: bool = False) -> Type:
         if t:
             if allow_tuple_literal:
                 # Types such as (t1, t2, ...) only allowed in assignment statements. They'll
@@ -1143,7 +1144,8 @@ class SemanticAnalyzer(NodeVisitor):
                     return TupleType(items, self.builtin_type('builtins.tuple'), t.line)
             a = TypeAnalyser(self.lookup_qualified,
                              self.lookup_fully_qualified,
-                             self.fail)
+                             self.fail,
+                             aliasing=aliasing)
             return t.accept(a)
         else:
             return None
@@ -2375,7 +2377,7 @@ class SemanticAnalyzer(NodeVisitor):
                 except TypeTranslationError:
                     self.fail('Type expected within [...]', expr)
                     return
-                typearg = self.anal_type(typearg)
+                typearg = self.anal_type(typearg, aliasing=True)
                 types.append(typearg)
             expr.analyzed = TypeApplication(expr.base, types)
             expr.analyzed.line = expr.line

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2364,6 +2364,8 @@ class SemanticAnalyzer(NodeVisitor):
     def visit_index_expr(self, expr: IndexExpr) -> None:
         expr.base.accept(self)
         if isinstance(expr.base, RefExpr) and expr.base.kind == TYPE_ALIAS:
+            # Special form -- subcribing a generic type alias.
+            # Perform the type substitution and create a new alias.
             res = analyze_type_alias(expr,
                                      self.lookup_qualified,
                                      self.lookup_fully_qualified,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2368,7 +2368,7 @@ class SemanticAnalyzer(NodeVisitor):
                                      self.lookup_qualified,
                                      self.lookup_fully_qualified,
                                      self.fail)
-            expr.analyzed = TypeAliasExpr(res)
+            expr.analyzed = TypeAliasExpr(res, line=expr.line)
         elif refers_to_class_or_function(expr.base):
             # Special form -- type application.
             # Translate index to an unanalyzed type.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1175,7 +1175,8 @@ class SemanticAnalyzer(NodeVisitor):
                     node.kind = TYPE_ALIAS
                     node.type_override = res
                     if isinstance(s.rvalue, IndexExpr):
-                        s.rvalue.analyzed = TypeAliasExpr(res, fback=self.alias_fallback(res))
+                        s.rvalue.analyzed = TypeAliasExpr(res,
+                                                          fallback=self.alias_fallback(res))
         if s.type:
             # Store type into nodes.
             for lvalue in s.lvalues:
@@ -1220,7 +1221,7 @@ class SemanticAnalyzer(NodeVisitor):
         kind = (' to Callable' if isinstance(tp, CallableType) else
                 ' to Tuple' if isinstance(tp, TupleType) else
                 ' to Union' if isinstance(tp, UnionType) else '')
-        cdef = ClassDef('Type alias{}'.format(kind), Block([]))
+        cdef = ClassDef('Type alias' + kind, Block([]))
         fb_info = TypeInfo(SymbolTable(), cdef, self.cur_mod_id)
         fb_info.bases = [self.object_type()]
         fb_info.mro = [fb_info, self.object_type().type]
@@ -2383,7 +2384,8 @@ class SemanticAnalyzer(NodeVisitor):
                                      self.lookup_qualified,
                                      self.lookup_fully_qualified,
                                      self.fail)
-            expr.analyzed = TypeAliasExpr(res, fback=self.alias_fallback(res), in_runtime=True)
+            expr.analyzed = TypeAliasExpr(res, fallback=self.alias_fallback(res),
+                                          in_runtime=True)
         elif refers_to_class_or_function(expr.base):
             # Special form -- type application.
             # Translate index to an unanalyzed type.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2370,7 +2370,7 @@ class SemanticAnalyzer(NodeVisitor):
                                      self.lookup_qualified,
                                      self.lookup_fully_qualified,
                                      self.fail)
-            expr.analyzed = TypeAliasExpr(res, line=expr.line)
+            expr.analyzed = TypeAliasExpr(res, line=expr.line, runtime=True)
         elif refers_to_class_or_function(expr.base):
             # Special form -- type application.
             # Translate index to an unanalyzed type.

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -159,7 +159,7 @@ class TypeAnalyser(TypeVisitor[Type]):
                     return override
                 if act_len != exp_len:
                     # TODO: Detect wrong type variable numer for unused aliases
-                    # (although it could be difficult at this stage, see comment below)
+                    # (it is difficult at this stage, see comment below, line 187 atm)
                     self.fail('Bad number of arguments for type alias, expected: %s, given: %s'
                               % (exp_len, act_len), t)
                     return t

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -5,7 +5,7 @@ from typing import Callable, cast, List, Optional
 from mypy.types import (
     Type, UnboundType, TypeVarType, TupleType, UnionType, Instance,
     AnyType, CallableType, Void, NoneTyp, DeletedType, TypeList, TypeVarDef, TypeVisitor,
-    StarType, PartialType, EllipsisType, UninhabitedType, TypeType, get_typ_args, set_typ_args
+    StarType, PartialType, EllipsisType, UninhabitedType, TypeType, get_typ_args, set_typ_args,
 )
 from mypy.nodes import (
     BOUND_TVAR, UNBOUND_TVAR, TYPE_ALIAS, UNBOUND_IMPORTED,
@@ -41,7 +41,8 @@ def analyze_type_alias(node: Expression,
     # (only string literals within index expressions).
     if isinstance(node, RefExpr):
         if node.kind == UNBOUND_TVAR or node.kind == BOUND_TVAR:
-            fail_func('Invalid type "{}" for aliasing'.format(node.fullname), node)
+            fail_func('Type variable "{}" is invalid as target for type alias'.format(
+                node.fullname), node)
             return None
         if not (isinstance(node.node, TypeInfo) or
                 node.fullname == 'typing.Any' or
@@ -429,7 +430,7 @@ class TypeAnalyserPass3(TypeVisitor[None]):
                     else:
                         arg_values = [arg]
                     self.check_type_var_values(info, arg_values,
-                                               TypeVar.values, i, t)
+                                               TypeVar.values, i + 1, t)
                 if not satisfies_upper_bound(arg, TypeVar.upper_bound):
                     self.fail('Type argument "{}" of "{}" must be '
                               'a subtype of "{}"'.format(
@@ -448,7 +449,7 @@ class TypeAnalyserPass3(TypeVisitor[None]):
                 else:
                     # print(context.column)
                     self.fail('Type argument {} of "{}" has incompatible value "{}"'.format(
-                        arg_number + 1, type.name(), actual.type.name()), context)
+                        arg_number, type.name(), actual.type.name()), context)
 
     def visit_callable_type(self, t: CallableType) -> None:
         t.ret_type.accept(self)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -447,7 +447,6 @@ class TypeAnalyserPass3(TypeVisitor[None]):
                     self.fail('Invalid type argument value for "{}"'.format(
                         type.name()), context)
                 else:
-                    # print(context.column)
                     self.fail('Type argument {} of "{}" has incompatible value "{}"'.format(
                         arg_number, type.name(), actual.type.name()), context)
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -79,7 +79,7 @@ class TypeAnalyser(TypeVisitor[Type]):
                  lookup_func: Callable[[str, Context], SymbolTableNode],
                  lookup_fqn_func: Callable[[str], SymbolTableNode],
                  fail_func: Callable[[str, Context], None], *,
-                 aliasing = False) -> None:
+                 aliasing: bool = False) -> None:
         self.lookup = lookup_func
         self.lookup_fqn_func = lookup_fqn_func
         self.fail = fail_func
@@ -158,8 +158,6 @@ class TypeAnalyser(TypeVisitor[Type]):
                 if exp_len == 0 and act_len == 0:
                     return override
                 if act_len != exp_len:
-                    # TODO: Detect wrong type variable numer for unused aliases
-                    # (it is difficult at this stage, see comment below, line 187 atm)
                     self.fail('Bad number of arguments for type alias, expected: %s, given: %s'
                               % (exp_len, act_len), t)
                     return t
@@ -174,7 +172,7 @@ class TypeAnalyser(TypeVisitor[Type]):
                     # as a base class -- however, this will fail soon at runtime so the problem
                     # is pretty minor.
                     return AnyType()
-                # Allow unbount type variables when defining an alias
+                # Allow unbound type variables when defining an alias
                 if not (self.aliasing and sym.kind == UNBOUND_TVAR):
                     self.fail('Invalid type "{}"'.format(name), t)
                 return t
@@ -205,7 +203,7 @@ class TypeAnalyser(TypeVisitor[Type]):
             return AnyType()
 
     def get_type_var_names(self, tp: Type) -> List[str]:
-        """ Get all type variable names that are present in a generic type alias
+        """Get all type variable names that are present in a generic type alias
         in order of textual appearance (recursively, if needed).
         """
         tvars = []  # type: List[str]
@@ -236,7 +234,7 @@ class TypeAnalyser(TypeVisitor[Type]):
         return None
 
     def replace_alias_tvars(self, tp: Type, vars: List[str], subs: List[Type]) -> Type:
-        """ Replace type variables in a generic type alias tp with substitutions subs.
+        """Replace type variables in a generic type alias tp with substitutions subs.
         Length of subs should be already checked.
         """
         typ_args = get_typ_args(tp)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1525,6 +1525,7 @@ def function_type(func: mypy.nodes.FuncBase, fallback: Instance) -> FunctionLike
             implicit=True,
         )
 
+
 def get_typ_args(tp: Type) -> List[Type]:
     if not isinstance(tp, (Instance, UnionType, TupleType, CallableType)):
         return []
@@ -1533,7 +1534,8 @@ def get_typ_args(tp: Type) -> List[Type]:
                 tp.arg_types + [tp.ret_type])
     return typ_args
 
-def set_typ_args(tp: Type, args: List[Type]) -> Type:
+
+def set_typ_args(tp: Type, new_args: List[Type]) -> Type:
     if isinstance(tp, Instance):
         return Instance(tp.type, new_args, tp.line)
     if isinstance(tp, TupleType):

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -880,7 +880,7 @@ class UnionType(Type):
                 items[i] = true_or_false(ti)
 
         simplified_set = [items[i] for i in range(len(items)) if i not in removed]
-        return UnionType.make_union(simplified_set)
+        return UnionType.make_union(simplified_set, line, column)
 
     def length(self) -> int:
         return len(self.items)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1536,14 +1536,17 @@ def get_typ_args(tp: Type) -> List[Type]:
     return typ_args
 
 
-def set_typ_args(tp: Type, new_args: List[Type]) -> Type:
+def set_typ_args(tp: Type, new_args: List[Type], line: int = -1, column: int = -1) -> Type:
     """Return a copy of a parameterizable Type with arguments set to new_args."""
+    line = line if line > 0 else tp.line
+    column = column if column > 0 else tp.column
     if isinstance(tp, Instance):
-        return Instance(tp.type, new_args, tp.line, tp.column)
+        return Instance(tp.type, new_args, line, column)
     if isinstance(tp, TupleType):
         return tp.copy_modified(items=new_args)
     if isinstance(tp, UnionType):
-        return UnionType.make_simplified_union(new_args, tp.line, tp.column)
+        return UnionType.make_simplified_union(new_args, line, column)
     if isinstance(tp, CallableType):
-        return tp.copy_modified(arg_types=new_args[:-1], ret_type=new_args[-1])
+        return tp.copy_modified(arg_types=new_args[:-1], ret_type=new_args[-1],
+                                line=line, column=column)
     return tp

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1527,6 +1527,7 @@ def function_type(func: mypy.nodes.FuncBase, fallback: Instance) -> FunctionLike
 
 
 def get_typ_args(tp: Type) -> List[Type]:
+    """Get all type arguments from a parameterizable Type."""
     if not isinstance(tp, (Instance, UnionType, TupleType, CallableType)):
         return []
     typ_args = (tp.args if isinstance(tp, Instance) else
@@ -1536,12 +1537,13 @@ def get_typ_args(tp: Type) -> List[Type]:
 
 
 def set_typ_args(tp: Type, new_args: List[Type]) -> Type:
+    """Return a copy of a parameterizable Type with arguments set to new_args."""
     if isinstance(tp, Instance):
-        return Instance(tp.type, new_args, tp.line)
+        return Instance(tp.type, new_args, tp.line, tp.column)
     if isinstance(tp, TupleType):
         return tp.copy_modified(items=new_args)
     if isinstance(tp, UnionType):
-        return UnionType.make_union(new_args, tp.line)
+        return UnionType.make_simplified_union(new_args, tp.line, tp.column)
     if isinstance(tp, CallableType):
         return tp.copy_modified(arg_types=new_args[:-1], ret_type=new_args[-1])
     return tp

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1538,8 +1538,6 @@ def get_typ_args(tp: Type) -> List[Type]:
 
 def set_typ_args(tp: Type, new_args: List[Type], line: int = -1, column: int = -1) -> Type:
     """Return a copy of a parameterizable Type with arguments set to new_args."""
-    line = line if line > 0 else tp.line
-    column = column if column > 0 else tp.column
     if isinstance(tp, Instance):
         return Instance(tp.type, new_args, line, column)
     if isinstance(tp, TupleType):

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1524,3 +1524,22 @@ def function_type(func: mypy.nodes.FuncBase, fallback: Instance) -> FunctionLike
             name,
             implicit=True,
         )
+
+def get_typ_args(tp: Type) -> List[Type]:
+    if not isinstance(tp, (Instance, UnionType, TupleType, CallableType)):
+        return []
+    typ_args = (tp.args if isinstance(tp, Instance) else
+                tp.items if not isinstance(tp, CallableType) else
+                tp.arg_types + [tp.ret_type])
+    return typ_args
+
+def set_typ_args(tp: Type, args: List[Type]) -> Type:
+    if isinstance(tp, Instance):
+        return Instance(tp.type, new_args, tp.line)
+    if isinstance(tp, TupleType):
+        return tp.copy_modified(items=new_args)
+    if isinstance(tp, UnionType):
+        return UnionType.make_union(new_args, tp.line)
+    if isinstance(tp, CallableType):
+        return tp.copy_modified(arg_types=new_args[:-1], ret_type=new_args[-1])
+    return tp

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -734,22 +734,42 @@ class E(Generic[T], UNode[T]): ... # E: Invalid base class
 [builtins fixtures/list.pyi]
 
 [case testGenericTypeAliasesUnion]
-from typing import TypeVar, Generic, Union
+from typing import TypeVar, Generic, Union, Any
 T = TypeVar('T')
 class Node(Generic[T]):
     def __init__(self, x: T) -> None:
-        ...
+        self.x = x
 
-[out]
+UNode = Union[int, Node[T]]
+x = 1 # type: UNode[int]
 
-[case testGenericTypeAliasesOptional]
-from typing import TypeVar, Generic, Optional
-T = TypeVar('T')
-class Node(Generic[T]):
-    def __init__(self, x: T) -> None:
-        ...
+x + 1 # E: Unsupported left operand type for + (some union)
+if not isinstance(x, Node):
+    x + 1
 
-[out]
+if not isinstance(x, int):
+   x.x = 1
+   x.x = 'a' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+def f(x: T) -> UNode[T]:
+    if 1:
+        return Node(x)
+    else:
+        return 1
+
+reveal_type(f(1)) # E: Revealed type is 'Union[builtins.int, __main__.Node[builtins.int*]]'
+
+TNode = Union[T, Node[int]]
+s = 1 # type: TNode[str] # E: Incompatible types in assignment (expression has type "int", variable has type "Union[str, Node[int]]")
+
+if not isinstance(s, str):
+    s.x = 1
+
+z = None # type: TNode # Same as TNode[Any]
+z.x
+z.foo() # E: Some element of union has no attribute "foo"
+
+[builtins fixtures/isinstance.pyi]
 
 [case testGenericTypeAliasesTuple]
 from typing import TypeVar, Generic, Tuple
@@ -801,7 +821,7 @@ T = TypeVar('T')
 n = None # type: TupledNode[int]
 n.x = 1
 n.y = (1, 1)
-n.y = 'x' # E: Bad type
+n.y = 'x' # E: Incompatible types in assignment (expression has type "str", variable has type "Tuple[int, int]")
 
 def f(x: Node[T, T]) -> TupledNode[T]:
     return Node(x.x, (x.x, x.x))

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -665,34 +665,76 @@ reveal_type(z) # E: Revealed type is '__main__.Node[Any, Any]'
 [out]
 
 [case testGenericTypeAliasesAcessingMethods]
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, List
 T = TypeVar('T')
 class Node(Generic[T]):
     def __init__(self, x: T) -> None:
-        ...
+        self.x = x
+    def meth(self) -> T:
+        return self.x
 
-[out]
+ListedNode = Node[List[T]]
+l = None # type: ListedNode[int]
+l.x.append(1)
+l.meth().append(1)
+reveal_type(l.meth()) # E: Revealed type is 'builtins.list*[builtins.int]'
+l.meth().append('x') # E: Argument 1 to "append" of "list" has incompatible type "str"; expected "int"
+
+ListedNode[str]([]).x = 1 # E: Incompatible types in assignment (expression has type "int", variable has type List[str])
+
+[builtins fixtures/list.pyi]
 
 [case testGenericTypeAliasesSubclassing]
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, Tuple, List
 T = TypeVar('T')
 class Node(Generic[T]):
     def __init__(self, x: T) -> None:
         ...
 
+TupledNode = Node[Tuple[T, T]]
+
+class D(Generic[T], TupledNode[T]):
+    ...
+class L(Generic[T], List[TupledNode[T]]):
+    ...
+
+def f_bad(x: T) -> D[T]:
+    return D(1)  # Error, see out
+
+L[int]().append(Node((1, 1)))
+L[int]().append(5) # E: Argument 1 to "append" of "list" has incompatible type "int"; expected Node[Tuple[int, int]]
+
+x = D((1, 1)) # type: D[int]
+y = D(5) # type: D[int] # E: Argument 1 to "D" has incompatible type "int"; expected "Tuple[int, int]"
+
+def f(x: T) -> D[T]:
+    return D((x, x))
+reveal_type(f('a'))  # E: Revealed type is '__main__.D[builtins.str*]'
+
+[builtins fixtures/list.pyi]
 [out]
+main: note: In function "f_bad":
+main:15: error: Argument 1 to "D" has incompatible type "int"; expected "Tuple[T, T]"
+main: note: At top level:
 
 [case testGenericTypeAliasesSubclassingBad]
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, Tuple, Union
 T = TypeVar('T')
 class Node(Generic[T]):
     def __init__(self, x: T) -> None:
         ...
 
-[out]
+TupledNode = Node[Tuple[T, T]]
+UNode = Union[int, Node[T]]
+
+class C(TupledNode): ... # Same as TupledNode[Any]
+class D(TupledNode[T]): ... # E: Invalid type "__main__.T"
+class E(Generic[T], UNode[T]): ... # E: Invalid base class
+
+[builtins fixtures/list.pyi]
 
 [case testGenericTypeAliasesUnion]
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, Union
 T = TypeVar('T')
 class Node(Generic[T]):
     def __init__(self, x: T) -> None:
@@ -710,7 +752,7 @@ class Node(Generic[T]):
 [out]
 
 [case testGenericTypeAliasesTuple]
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, Tuple
 T = TypeVar('T')
 class Node(Generic[T]):
     def __init__(self, x: T) -> None:
@@ -719,7 +761,7 @@ class Node(Generic[T]):
 [out]
 
 [case testGenericTypeAliasesCallable]
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, Callable
 T = TypeVar('T')
 class Node(Generic[T]):
     def __init__(self, x: T) -> None:
@@ -727,25 +769,31 @@ class Node(Generic[T]):
 
 [out]
 
-[case testGenericTypeAliasesCompex]
-from typing import TypeVar, Generic
-T = TypeVar('T')
-class Node(Generic[T]):
-    def __init__(self, x: T) -> None:
-        ...
+[case testGenericTypeAliasesPEPBasedExample]
+from typing import TypeVar, List, Tuple
+T = TypeVar('T', int, bool)
 
-[out]
+Vec = List[Tuple[T, T]]
+
+vec = []  # type: Vec[bool]
+vec.append('x') # E: Argument 1 to "append" of "list" has incompatible type "str"; expected "Tuple[bool, bool]"
+reveal_type(vec[0]) # E: Revealed type is 'Tuple[builtins.bool, builtins.bool]'
+
+def fun1(v: Vec[T]) -> T:
+    return v[0][0]
+def fun2(v: Vec[T], scale: T) -> Vec[T]:
+    return v
+
+reveal_type(fun1([(1, 1)])) # E: Revealed type is 'builtins.int*'
+fun1(1) # E: Argument 1 to "fun1" has incompatible type "int"; expected List[Tuple[int, int]]
+fun1([(1, 'x')]) # E: Cannot infer type argument 1 of "fun1"
+
+reveal_type(fun2([(1, 1)], 1)) # E: Revealed type is 'builtins.list[Tuple[builtins.int*, builtins.int*]]'
+fun2([('x', 'x')], 'x') # E: Type argument 1 of "fun2" has incompatible value "str"
+
+[builtins fixtures/list.pyi]
 
 [case testGenericTypeAliasesImporting]
-from typing import TypeVar, Generic
-T = TypeVar('T')
-class Node(Generic[T]):
-    def __init__(self, x: T) -> None:
-        ...
-
-[out]
-
-[case testGenericTypeAliasesImporting2]
 from typing import TypeVar, Generic
 T = TypeVar('T')
 class Node(Generic[T]):
@@ -762,9 +810,9 @@ class Node(Generic[T, S]):
     def __init__(self, x: T, y: S) -> None:
         ...
 
-IntIntNode = Node[int, int]
-IntIntNode(1, 1)
-IntIntNode(1, 'a')  # E: Argument 2 has incompatible type "str"; expected "int"
+IntNode = Node[int, T]
+IntNode[int](1, 1)
+IntNode[int](1, 'a')  # E: Argument 2 to "Node" has incompatible type "str"; expected "int"
 
 SameNode = Node[T, T]
 a = SameNode(1, 'x')
@@ -776,12 +824,21 @@ SameNode[int](1, 'x') # E: Argument 2 to "Node" has incompatible type "str"; exp
 [out]
 
 [case testGenericTypeAliasesRuntimeExpressionsOther]
-from typing import TypeVar, Generic
+from typing import TypeVar, Union, Tuple, Callable, Any
 T = TypeVar('T')
-S = TypeVar('S')
-class Node(Generic[T, S]):
-    def __init__(self, x: T, y: S) -> None:
-        ...
+
+CA = Callable[[T], int]
+TA = Tuple[T, int]
+UA = Union[T, int]
+
+cs = CA[str]() # E: Invalid type alias in runtime expression: def (builtins.str) -> builtins.int
+reveal_type(cs) # E: Revealed type is 'Any'
+
+ts = TA[str]() # E: Invalid type alias in runtime expression: Tuple[builtins.str, builtins.int]
+reveal_type(ts) # E: Revealed type is 'Any'
+
+us = UA[str]() # E: Invalid type alias in runtime expression: Union[builtins.str, builtins.int]
+reveal_type(us) # E: Revealed type is 'Any'
 
 [out]
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -794,13 +794,34 @@ fun2([('x', 'x')], 'x') # E: Type argument 1 of "fun2" has incompatible value "s
 [builtins fixtures/list.pyi]
 
 [case testGenericTypeAliasesImporting]
-from typing import TypeVar, Generic
+from typing import TypeVar
+from a import Node, TupledNode
 T = TypeVar('T')
-class Node(Generic[T]):
-    def __init__(self, x: T) -> None:
-        ...
 
-[out]
+n = None # type: TupledNode[int]
+n.x = 1
+n.y = (1, 1)
+n.y = 'x' # E: Bad type
+
+def f(x: Node[T, T]) -> TupledNode[T]:
+    return Node(x.x, (x.x, x.x))
+
+f(1) # E: Argument 1 to "f" has incompatible type "int"; expected Node[None, None]
+f(Node(1, 'x')) # E: Cannot infer type argument 1 of "f"
+reveal_type(Node('x', 'x')) # E: Revealed type is 'a.Node[builtins.str*, builtins.str*]'
+
+[file a.py]
+from typing import TypeVar, Generic, Tuple
+T = TypeVar('T')
+S = TypeVar('S')
+class Node(Generic[T, S]):
+    def __init__(self, x: T, y: S) -> None:
+        self.x = x
+        self.y = y
+
+TupledNode = Node[T, Tuple[T, T]]
+
+[builtins fixtures/list.pyi]
 
 [case testGenericTypeAliasesRuntimeExpressionsInstance]
 from typing import TypeVar, Generic

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -887,6 +887,7 @@ IntNode[int](1, 1)
 IntNode[int](1, 'a')  # E: Argument 2 to "Node" has incompatible type "str"; expected "int"
 
 SameNode = Node[T, T]
+ff = SameNode[T](1, 1)  # E: Need type annotation for variable
 a = SameNode(1, 'x')
 reveal_type(a) # E: Revealed type is '__main__.Node[Any, Any]'
 b = SameNode[int](1, 1)

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -505,6 +505,127 @@ type[int] # this was crashing, see #2302 (comment)  # E: Type application target
 [out]
 
 
+-- Generic type aliases
+-- --------------------
+
+[case testGenericTypeAliasesBasic1]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesBasic2]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesBadAliases]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesForAliases]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesAny]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesSubclassing]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesUnion]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesTuple]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesCallable]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesCompex1]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesCompex2]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesImporting]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesRuntimeExpressions]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+
 -- Multiple assignment with lists
 -- ------------------------------
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -508,43 +508,163 @@ type[int] # this was crashing, see #2302 (comment)  # E: Type application target
 -- Generic type aliases
 -- --------------------
 
-[case testGenericTypeAliasesBasic1]
+[case testGenericTypeAliasesBasic]
 from typing import TypeVar, Generic
 T = TypeVar('T')
-class Node(Generic[T]):
-    def __init__(self, x: T) -> None:
+S = TypeVar('S')
+class Node(Generic[T, S]):
+    def __init__(self, x: T, y: S) -> None:
         ...
+
+IntNode = Node[int, S]
+IntIntNode = Node[int, int]
+SameNode = Node[T, T]
+
+n = Node(1, 1) # type: IntIntNode
+n1 = Node(1, 'a') # type: IntIntNode # E: Argument 2 to "Node" has incompatible type "str"; expected "int"
+
+m = Node(1, 1) # type: IntNode
+m1 = Node('x', 1) # type: IntNode # E: Argument 1 to "Node" has incompatible type "str"; expected "int"
+m2 = Node(1, 1) # type: IntNode[str] # E: Argument 2 to "Node" has incompatible type "int"; expected "str"
+
+s = Node(1, 1) # type: SameNode[int]
+reveal_type(s) # E: Revealed type is '__main__.Node[builtins.int, builtins.int]'
+s1 = Node(1, 'x') # type: SameNode[int] # E: Argument 2 to "Node" has incompatible type "str"; expected "int"
 
 [out]
 
 [case testGenericTypeAliasesBasic2]
 from typing import TypeVar, Generic
 T = TypeVar('T')
-class Node(Generic[T]):
-    def __init__(self, x: T) -> None:
+S = TypeVar('S')
+class Node(Generic[T, S]):
+    def __init__(self, x: T, y: S) -> None:
         ...
 
-[out]
+IntNode = Node[int, S]
+IntIntNode = Node[int, int]
+SameNode = Node[T, T]
 
-[case testGenericTypeAliasesBadAliases]
-from typing import TypeVar, Generic
+def output_bad() -> IntNode[str]:
+    return Node(1, 1) # Eroor - bad return type, see out
+
+def input(x: IntNode[str]) -> None:
+    pass
+input(Node(1, 's'))
+input(Node(1, 1)) # E: Argument 2 to "Node" has incompatible type "int"; expected "str"
+
+def output() -> IntNode[str]:
+    return Node(1, 'x')
+reveal_type(output()) # E: Revealed type is '__main__.Node[builtins.int, builtins.str]'
+
+def func(x: IntNode[T]) -> IntNode[T]:
+    return x
+reveal_type(func) # E: Revealed type is 'def [T] (x: __main__.Node[builtins.int, T`-1]) -> __main__.Node[builtins.int, T`-1]'
+
+func(1) # E: Argument 1 to "func" has incompatible type "int"; expected Node[int, None]
+func(Node('x', 1)) # E: Argument 1 to "Node" has incompatible type "str"; expected "int"
+reveal_type(func(Node(1, 'x'))) # E: Revealed type is '__main__.Node[builtins.int, builtins.str*]'
+
+def func2(x: SameNode[T]) -> SameNode[T]:
+    return x
+reveal_type(func2) # E: Revealed type is 'def [T] (x: __main__.Node[T`-1, T`-1]) -> __main__.Node[T`-1, T`-1]'
+
+func2(Node(1, 'x')) # E: Cannot infer type argument 1 of "func2"
+y = func2(Node('x', 'x'))
+reveal_type(y) # E: Revealed type is '__main__.Node[builtins.str*, builtins.str*]'
+
+def wrap(x: T) -> IntNode[T]:
+    return Node(1, x)
+
+z = None # type: str
+reveal_type(wrap(z)) # E: Revealed type is '__main__.Node[builtins.int, builtins.str*]'
+
+[out]
+main: note: In function "output_bad":
+main:13: error: Argument 2 to "Node" has incompatible type "int"; expected "str"
+main: note: At top level:
+
+[case testGenericTypeAliasesWrongAliases]
+from typing import TypeVar, Generic, List, Callable, Tuple, Union
 T = TypeVar('T')
-class Node(Generic[T]):
-    def __init__(self, x: T) -> None:
+S = TypeVar('S')
+class Node(Generic[T, S]):
+    def __init__(self, x: T, y: S) -> None:
         ...
 
-[out]
+A = Node[T] # E: Type application has too few types (2 expected)
+B = Node[T, T]
+C = Node[T, T, T] # E: Type application has too many types (2 expected)
+D = Node[T, S]
+E = Node[Node[T, T], List[T]]
+
+# Errors for F, G, H are not reported if those aliases left used
+F = Node[List[T, T], S] # E: "list" expects 1 type argument, but 2 given
+f = None # type: F
+G = Callable[..., List[T, T]] # E: "list" expects 1 type argument, but 2 given
+g = None # type: G[int]
+H = Union[int, Tuple[T, Node[T]]] # E: "Node" expects 2 type arguments, but 1 given
+h = None # type: H
+h1 = None # type: H[int, str] # E: Bad number of arguments for type alias, expected: 1, given: 2
+
+x = None # type: D[int, str]
+reveal_type(x) # E: Revealed type is '__main__.Node[builtins.int, builtins.str]'
+y = None # type: E[int]
+reveal_type(y) # E: Revealed type is '__main__.Node[__main__.Node[builtins.int, builtins.int], builtins.list[builtins.int]]'
+
+[builtins fixtures/list.pyi]
 
 [case testGenericTypeAliasesForAliases]
+from typing import TypeVar, Generic, List, Union
+T = TypeVar('T')
+S = TypeVar('S')
+
+class Node(Generic[T, S]):
+    def __init__(self, x: T, y: S) -> None:
+        pass
+
+ListedNode = Node[List[T], List[S]]
+Second = ListedNode[int, T]
+Third = Union[int, Second[str]]
+
+def f2(x: T) -> Second[T]:
+    return Node([1], [x])
+reveal_type(f2('a')) # E: Revealed type is '__main__.Node[builtins.list[builtins.int], builtins.list[builtins.str*]]'
+
+def f3() -> Third:
+    return Node([1], ['x'])
+reveal_type(f3()) # E: Revealed type is 'Union[builtins.int, __main__.Node[builtins.list[builtins.int], builtins.list[builtins.str]]]'
+
+[builtins fixtures/list.pyi]
+
+[case testGenericTypeAliasesAny]
 from typing import TypeVar, Generic
 T = TypeVar('T')
-class Node(Generic[T]):
-    def __init__(self, x: T) -> None:
-        ...
+S = TypeVar('S')
+class Node(Generic[T, S]):
+    def __init__(self, x: T, y: S) -> None:
+        self.x = x
+        self.y = y
+
+IntNode = Node[int, S]
+AnyNode = Node[S, T]
+
+def output() -> IntNode[str]:
+    return Node(1, 'x')
+x = output() # type: IntNode # This is OK (implicit Any)
+
+y = None # type: IntNode
+y.x = 1
+y.x = 'x' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+y.y = 1 # Both are OK (implicit Any)
+y.y = 'x'
+
+z = Node(1, 'x') # type: AnyNode
+reveal_type(z) # E: Revealed type is '__main__.Node[Any, Any]'
 
 [out]
 
-[case testGenericTypeAliasesAny]
+[case testGenericTypeAliasesAcessingMethods]
 from typing import TypeVar, Generic
 T = TypeVar('T')
 class Node(Generic[T]):
@@ -562,8 +682,26 @@ class Node(Generic[T]):
 
 [out]
 
+[case testGenericTypeAliasesSubclassingBad]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
 [case testGenericTypeAliasesUnion]
 from typing import TypeVar, Generic
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesOptional]
+from typing import TypeVar, Generic, Optional
 T = TypeVar('T')
 class Node(Generic[T]):
     def __init__(self, x: T) -> None:
@@ -589,16 +727,7 @@ class Node(Generic[T]):
 
 [out]
 
-[case testGenericTypeAliasesCompex1]
-from typing import TypeVar, Generic
-T = TypeVar('T')
-class Node(Generic[T]):
-    def __init__(self, x: T) -> None:
-        ...
-
-[out]
-
-[case testGenericTypeAliasesCompex2]
+[case testGenericTypeAliasesCompex]
 from typing import TypeVar, Generic
 T = TypeVar('T')
 class Node(Generic[T]):
@@ -616,11 +745,42 @@ class Node(Generic[T]):
 
 [out]
 
-[case testGenericTypeAliasesRuntimeExpressions]
+[case testGenericTypeAliasesImporting2]
 from typing import TypeVar, Generic
 T = TypeVar('T')
 class Node(Generic[T]):
     def __init__(self, x: T) -> None:
+        ...
+
+[out]
+
+[case testGenericTypeAliasesRuntimeExpressionsInstance]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+S = TypeVar('S')
+class Node(Generic[T, S]):
+    def __init__(self, x: T, y: S) -> None:
+        ...
+
+IntIntNode = Node[int, int]
+IntIntNode(1, 1)
+IntIntNode(1, 'a')  # E: Argument 2 has incompatible type "str"; expected "int"
+
+SameNode = Node[T, T]
+a = SameNode(1, 'x')
+reveal_type(a) # E: Revealed type is '__main__.Node[Any, Any]'
+b = SameNode[int](1, 1)
+reveal_type(b) # E: Revealed type is '__main__.Node[builtins.int*, builtins.int*]'
+SameNode[int](1, 'x') # E: Argument 2 to "Node" has incompatible type "str"; expected "int"
+
+[out]
+
+[case testGenericTypeAliasesRuntimeExpressionsOther]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+S = TypeVar('S')
+class Node(Generic[T, S]):
+    def __init__(self, x: T, y: S) -> None:
         ...
 
 [out]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -766,7 +766,7 @@ if not isinstance(s, str):
 
 z = None # type: TNode # Same as TNode[Any]
 z.x
-z.foo() # E: Some element of union has no attribute "foo"
+z.foo() # Any simplyfies Union to Any
 
 [builtins fixtures/isinstance.pyi]
 
@@ -914,6 +914,44 @@ reveal_type(us) # E: Revealed type is 'Any'
 
 [out]
 
+[case testGenericTypeAliasesTypeVarBinding]
+from typing import TypeVar, Generic, List
+T = TypeVar('T')
+S = TypeVar('S')
+
+class A(Generic[T, S]):
+    def __init__(self, x: T, y: S) -> None: ...
+
+class B(Generic[T, S]):
+    def __init__(self, x: List[T], y: List[S]) -> None: ...
+
+SameA = A[T, T]
+SameB = B[T, T]
+
+class C(Generic[T]):
+    a = None # type: SameA[T]
+    b = SameB[T]([], [])
+
+reveal_type(C[int]().a) # E: Revealed type is '__main__.A[builtins.int*, builtins.int*]'
+reveal_type(C[str]().b) # E: Revealed type is '__main__.B[builtins.str*, builtins.str*]'
+
+[builtins fixtures/list.pyi]
+
+[case testGenericTypeAliasesTypeVarConstraints]
+from typing import TypeVar, Generic
+T = TypeVar('T', int, list)
+S = TypeVar('S', int, list)
+
+class A(Generic[T, S]):
+    def __init__(self, x: T, y: S) -> None: ...
+
+BadA = A[str, T] # E: Bad ...
+SameA = A[T, T]
+
+x = None # type: SameA[int]
+y = None # type: SameA[str] # E: Bad ...
+
+[builtins fixtures/list.pyi]
 
 -- Multiple assignment with lists
 -- ------------------------------

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -623,7 +623,7 @@ main:18:3: error: "Node" expects 2 type arguments, but 1 given
 main:19:4: error: Bad number of arguments for type alias, expected: 1, given: 2
 main:22: error: Revealed type is '__main__.Node[builtins.int, builtins.str]'
 main:24: error: Revealed type is '__main__.Node[__main__.Node[builtins.int, builtins.int], builtins.list[builtins.int]]'
-main:26:4: error: Invalid type "__main__.T" for aliasing
+main:26:4: error: Type variable "__main__.T" is invalid as target for type alias
 
 [case testGenericTypeAliasesForAliases]
 from typing import TypeVar, Generic, List, Union
@@ -778,7 +778,7 @@ if not isinstance(s, str):
 
 z = None # type: TNode # Same as TNode[Any]
 z.x
-z.foo() # Any simplyfies Union to Any
+z.foo() # Any simplifies Union to Any now. This test should be updated after #2197
 
 [builtins fixtures/isinstance.pyi]
 
@@ -967,8 +967,8 @@ y = None # type: SameA[str] # Two errors here, for both args of A
 [builtins fixtures/list.pyi]
 [out]
 main:9:7: error: Type argument 1 of "A" has incompatible value "str"
-main:13:8: error: Type argument 1 of "A" has incompatible value "str"
-main:13:8: error: Type argument 2 of "A" has incompatible value "str"
+main:13: error: Type argument 1 of "A" has incompatible value "str"
+main:13: error: Type argument 2 of "A" has incompatible value "str"
 
 
 -- Multiple assignment with lists

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -585,6 +585,7 @@ main:13: error: Argument 2 to "Node" has incompatible type "int"; expected "str"
 main: note: At top level:
 
 [case testGenericTypeAliasesWrongAliases]
+# flags: --show-column-numbers --fast-parser --python-version 3.6
 from typing import TypeVar, Generic, List, Callable, Tuple, Union
 T = TypeVar('T')
 S = TypeVar('S')
@@ -592,26 +593,37 @@ class Node(Generic[T, S]):
     def __init__(self, x: T, y: S) -> None:
         ...
 
-A = Node[T] # E: "Node" expects 2 type arguments, but 1 given
+A = Node[T] # Error
 B = Node[T, T]
-C = Node[T, T, T] # E: "Node" expects 2 type arguments, but 3 given
+C = Node[T, T, T] # Error
 D = Node[T, S]
 E = Node[Node[T, T], List[T]]
 
-F = Node[List[T, T], S] # E: "list" expects 1 type argument, but 2 given
-G = Callable[..., List[T, T]] # E: "list" expects 1 type argument, but 2 given
-H = Union[int, Tuple[T, Node[T]]] # E: "Node" expects 2 type arguments, but 1 given
-h = None # type: H # E: "Node" expects 2 type arguments, but 1 given
-h1 = None # type: H[int, str] # E: Bad number of arguments for type alias, expected: 1, given: 2
+F = Node[List[T, T], S] # Error
+G = Callable[..., List[T, T]] # Error
+H = Union[int, Tuple[T, Node[T]]] # Error
+h: H # Error
+h1: H[int, str] # Error
 
 x = None # type: D[int, str]
-reveal_type(x) # E: Revealed type is '__main__.Node[builtins.int, builtins.str]'
+reveal_type(x)
 y = None # type: E[int]
-reveal_type(y) # E: Revealed type is '__main__.Node[__main__.Node[builtins.int, builtins.int], builtins.list[builtins.int]]'
+reveal_type(y)
 
-X = T # E: Invalid type "__main__.T" for aliasing
+X = T # Error
 
 [builtins fixtures/list.pyi]
+[out]
+main:9:4: error: "Node" expects 2 type arguments, but 1 given
+main:11:4: error: "Node" expects 2 type arguments, but 3 given
+main:15:9: error: "list" expects 1 type argument, but 2 given
+main:16:18: error: "list" expects 1 type argument, but 2 given
+main:17:24: error: "Node" expects 2 type arguments, but 1 given
+main:18:3: error: "Node" expects 2 type arguments, but 1 given
+main:19:4: error: Bad number of arguments for type alias, expected: 1, given: 2
+main:22: error: Revealed type is '__main__.Node[builtins.int, builtins.str]'
+main:24: error: Revealed type is '__main__.Node[__main__.Node[builtins.int, builtins.int], builtins.list[builtins.int]]'
+main:26:4: error: Invalid type "__main__.T" for aliasing
 
 [case testGenericTypeAliasesForAliases]
 from typing import TypeVar, Generic, List, Union
@@ -938,6 +950,7 @@ reveal_type(C[str]().b) # E: Revealed type is '__main__.B[builtins.str*, builtin
 [builtins fixtures/list.pyi]
 
 [case testGenericTypeAliasesTypeVarConstraints]
+# flags: --show-column-numbers
 from typing import TypeVar, Generic
 T = TypeVar('T', int, list)
 S = TypeVar('S', int, list)
@@ -945,16 +958,17 @@ S = TypeVar('S', int, list)
 class A(Generic[T, S]):
     def __init__(self, x: T, y: S) -> None: ...
 
-BadA = A[str, T]  # This error is reported twice (but it actually looks useful)
+BadA = A[str, T]  # One error here
 SameA = A[T, T]
 
 x = None # type: SameA[int]
-y = None # type: SameA[str] # E: Invalid type argument value for "A"
+y = None # type: SameA[str] # Two errors here, for both args of A
 
 [builtins fixtures/list.pyi]
 [out]
-main:8: error: Invalid type argument value for "A"
-main:8: error: Type argument 1 of "A" has incompatible value "str"
+main:9:7: error: Type argument 1 of "A" has incompatible value "str"
+main:13:8: error: Type argument 1 of "A" has incompatible value "str"
+main:13:8: error: Type argument 2 of "A" has incompatible value "str"
 
 
 -- Multiple assignment with lists

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -592,17 +592,14 @@ class Node(Generic[T, S]):
     def __init__(self, x: T, y: S) -> None:
         ...
 
-A = Node[T] # E: Type application has too few types (2 expected)
+A = Node[T] # E: "Node" expects 2 type arguments, but 1 given
 B = Node[T, T]
-C = Node[T, T, T] # E: Type application has too many types (2 expected)
+C = Node[T, T, T] # E: "Node" expects 2 type arguments, but 3 given
 D = Node[T, S]
 E = Node[Node[T, T], List[T]]
 
-# Errors for F, G, H are not reported if those aliases left used
 F = Node[List[T, T], S] # E: "list" expects 1 type argument, but 2 given
-f = None # type: F
 G = Callable[..., List[T, T]] # E: "list" expects 1 type argument, but 2 given
-g = None # type: G[int]
 H = Union[int, Tuple[T, Node[T]]] # E: "Node" expects 2 type arguments, but 1 given
 h = None # type: H
 h1 = None # type: H[int, str] # E: Bad number of arguments for type alias, expected: 1, given: 2
@@ -611,6 +608,8 @@ x = None # type: D[int, str]
 reveal_type(x) # E: Revealed type is '__main__.Node[builtins.int, builtins.str]'
 y = None # type: E[int]
 reveal_type(y) # E: Revealed type is '__main__.Node[__main__.Node[builtins.int, builtins.int], builtins.list[builtins.int]]'
+
+X = T # E: Invalid type "__main__.T" for aliasing
 
 [builtins fixtures/list.pyi]
 
@@ -904,13 +903,13 @@ CA = Callable[[T], int]
 TA = Tuple[T, int]
 UA = Union[T, int]
 
-cs = CA[str]() # E: Invalid type alias in runtime expression: def (builtins.str) -> builtins.int
+cs = CA[str] + 1 # E: Unsupported left operand type for + ("Type alias to Callable")
 reveal_type(cs) # E: Revealed type is 'Any'
 
-ts = TA[str]() # E: Invalid type alias in runtime expression: Tuple[builtins.str, builtins.int]
+ts = TA[str]() # E: "Type alias to Tuple" not callable
 reveal_type(ts) # E: Revealed type is 'Any'
 
-us = UA[str]() # E: Invalid type alias in runtime expression: Union[builtins.str, builtins.int]
+us = UA[str].x # E: "Type alias to Union" has no attribute "x"
 reveal_type(us) # E: Revealed type is 'Any'
 
 [out]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -772,13 +772,26 @@ z.foo() # E: Some element of union has no attribute "foo"
 [builtins fixtures/isinstance.pyi]
 
 [case testGenericTypeAliasesTuple]
-from typing import TypeVar, Generic, Tuple
+from typing import TypeVar, Tuple
 T = TypeVar('T')
-class Node(Generic[T]):
-    def __init__(self, x: T) -> None:
-        ...
 
-[out]
+SameTP = Tuple[T, T]
+IntTP = Tuple[int, T]
+
+def f1(x: T) -> SameTP[T]:
+    return x, x
+
+a, b, c = f1(1) # E: Need more than 2 values to unpack (3 expected)
+x, y = f1(1)
+reveal_type(x) # E: Revealed type is 'builtins.int'
+
+def f2(x: IntTP[T]) -> IntTP[T]:
+    return x
+
+f2((1, 2, 3)) # E: Argument 1 to "f2" has incompatible type "Tuple[int, int, int]"; expected "Tuple[int, None]"
+reveal_type(f2((1, 'x'))) # E: Revealed type is 'Tuple[builtins.int, builtins.str*]'
+
+[builtins fixtures/for.pyi]
 
 [case testGenericTypeAliasesCallable]
 from typing import TypeVar, Generic, Callable
@@ -786,6 +799,24 @@ T = TypeVar('T')
 class Node(Generic[T]):
     def __init__(self, x: T) -> None:
         ...
+
+BadC = Callable[T] # E: Invalid function type
+
+C = Callable[..., T]
+C2 = Callable[[T, T], Node[T]]
+
+def make_cb(x: T) -> C[T]:
+    return lambda *args: x
+
+reveal_type(make_cb(1)) # E: Revealed type is 'def (*Any, **Any) -> builtins.int*'
+
+def use_cb(arg: T, cb: C2[T]) -> Node[T]:
+    return cb(arg, arg)
+
+use_cb(1, 1) # E: Argument 2 to "use_cb" has incompatible type "int"; expected Callable[[int, int], Node[int]]
+my_cb = None # type: C2[int]
+use_cb('x', my_cb) # E: Argument 2 to "use_cb" has incompatible type Callable[[int, int], Node[int]]; expected Callable[[str, str], Node[str]]
+reveal_type(use_cb(1, my_cb)) # E: Revealed type is '__main__.Node[builtins.int]'
 
 [out]
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -601,7 +601,7 @@ E = Node[Node[T, T], List[T]]
 F = Node[List[T, T], S] # E: "list" expects 1 type argument, but 2 given
 G = Callable[..., List[T, T]] # E: "list" expects 1 type argument, but 2 given
 H = Union[int, Tuple[T, Node[T]]] # E: "Node" expects 2 type arguments, but 1 given
-h = None # type: H
+h = None # type: H # E: "Node" expects 2 type arguments, but 1 given
 h1 = None # type: H[int, str] # E: Bad number of arguments for type alias, expected: 1, given: 2
 
 x = None # type: D[int, str]
@@ -945,13 +945,17 @@ S = TypeVar('S', int, list)
 class A(Generic[T, S]):
     def __init__(self, x: T, y: S) -> None: ...
 
-BadA = A[str, T] # E: Bad ...
+BadA = A[str, T]  # This error is reported twice (but it actually looks useful)
 SameA = A[T, T]
 
 x = None # type: SameA[int]
-y = None # type: SameA[str] # E: Bad ...
+y = None # type: SameA[str] # E: Invalid type argument value for "A"
 
 [builtins fixtures/list.pyi]
+[out]
+main:8: error: Invalid type argument value for "A"
+main:8: error: Type argument 1 of "A" has incompatible value "str"
+
 
 -- Multiple assignment with lists
 -- ------------------------------

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -277,8 +277,8 @@ A = NewType('A', T)
 B = NewType('B', List[T])
 [builtins fixtures/list.pyi]
 [out]
-main:3: error: Invalid type "__main__.T"
 main:3: error: Argument 2 to NewType(...) must be subclassable (got T?)
+main:3: error: Invalid type "__main__.T"
 main:4: error: Invalid type "__main__.T"
 
 [case testNewTypeWithNewTypeFails]

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -498,7 +498,6 @@ else:
     reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int, builtins.None]'
 [builtins fixtures/ops.pyi]
 
-
 [case testWarnNoReturnWorksWithStrictOptional]
 # flags: --warn-no-return
 def f() -> None:
@@ -509,3 +508,27 @@ def g() -> int:
 [out]
 main: note: In function "g":
 main:5: note: Missing return statement
+
+[case testGenericTypeAliasesOptional]
+from typing import TypeVar, Generic, Optional
+T = TypeVar('T')
+class Node(Generic[T]):
+    def __init__(self, x: T) -> None:
+        self.x = x
+
+ONode = Optional[Node[T]]
+def f(x: T) -> ONode[T]:
+    if 1 > 0:
+        return Node(x)
+    else:
+        return None
+
+x = None # type: ONode[int]
+x = f(1)
+x = f('x') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
+
+x.x = 1 # E: Some element of union has no attribute "x"
+if x is not None:
+    x.x = 1 # OK here
+
+[builtins fixtures/ops.pyi]

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -235,7 +235,7 @@ X = TypeVar('X', int, str)
 class A(Generic[X]): pass
 a = None  # type: A[int]
 b = None  # type: A[str]
-d = None  # type: A[object] # E: Invalid type argument value for "A"
+d = None  # type: A[object] # E: Type argument 1 of "A" has incompatible value "object"
 c = None  # type: A[Any]
 
 [case testConstructGenericTypeWithTypevarValuesAndTypeInference]
@@ -356,8 +356,8 @@ Y = TypeVar('Y', int, str)
 class C(Generic[X, Y]): pass
 a = None  # type: C[A, int]
 b = None  # type: C[B, str]
-c = None  # type: C[int, int] # E: Invalid type argument value for "C"
-d = None  # type: C[A, A]     # E: Invalid type argument value for "C"
+c = None  # type: C[int, int] # E: Type argument 1 of "C" has incompatible value "int"
+d = None  # type: C[A, A]     # E: Type argument 2 of "C" has incompatible value "A"
 
 [case testCallGenericFunctionUsingMultipleTypevarsWithValues]
 from typing import TypeVar

--- a/test-data/unit/fixtures/list.pyi
+++ b/test-data/unit/fixtures/list.pyi
@@ -9,6 +9,7 @@ class object:
     def __init__(self): pass
 
 class type: pass
+class ellipsis: pass
 
 class list(Iterable[T], Generic[T]):
     @overload


### PR DESCRIPTION
Fixes #606 as per PEP 484.

Now type aliases could be generic, so that the example in PEP now works. Generic type aliases are allowed for generic classes, unions, callables, and tuples, for example:

``` python
Vec = Iterable[Tuple[T, T]]
TInt = Tuple[T, int]
UInt = Union[T, int]
CBack = Callable[..., T]
```

The aliases could be used as specified in PEP 484, e.g. either one specifies all free type variables, or if unspecified they are all substituted by `Any`, for example:

``` python
def fun(v: Vec[T]) -> Vec[T]: # Same as Iterable[Tuple[T, T]]
    ...
v1: Vec[int] = []      # Same as Iterable[Tuple[int, int]]
v2: Vec = []           # Same as Iterable[Tuple[Any, Any]]
v3: Vec[int, int] = [] # Error: Invalid alias, too many type arguments!
```

Generic aliases could be used everywhere, where a normal generic type could be used (in annotations, generic base classes etc, and since recently in runtime expressions). Nested and chained aliases are allowed, but excessive use of those is discouraged in the docs. As ordinary (non-generic) aliases, generic ones could be imported from other modules.

I believe this is a useful feature (I found three issues on tracker requesting this). When someone wants precise types, they quickly become quite verbose, so that generic type aliases will improve readability. Please, don't be scared by the size of diff, the actual implementation is quite simple, 85% of changes are extensive tests.

**NOTE:** Many examples in the tests and in docs require a recent version of `typing.py` from `python/typing` to work at runtime (see https://github.com/python/mypy/pull/2382). This feature could be used with older versions of `typing.py` by using type comments or "forward references".
