### PR TITLE
For class variables, lookup type in base classes (#1338, #2022, #2211)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -36,14 +36,17 @@ from mypy.types import (
 from mypy.sametypes import is_same_type
 from mypy.messages import MessageBuilder
 import mypy.checkexpr
-from mypy.checkmember import map_type_from_supertype, bind_self, erase_to_bound
+from mypy.checkmember import (
+    map_type_from_supertype, bind_self, erase_to_bound, find_type_from_bases
+)
 from mypy import messages
 from mypy.subtypes import (
     is_subtype, is_equivalent, is_proper_subtype, is_more_precise, restrict_subtype_away,
     is_subtype_ignoring_tvars
 )
 from mypy.maptype import map_instance_to_supertype
-from mypy.semanal import fill_typevars, set_callable_name, refers_to_fullname
+from mypy.typevars import fill_typevars
+from mypy.semanal import set_callable_name, refers_to_fullname
 from mypy.erasetype import erase_typevars
 from mypy.expandtype import expand_type
 from mypy.visitor import NodeVisitor
@@ -1112,6 +1115,16 @@ class TypeChecker(NodeVisitor[Type]):
         else:
             lvalue_type, index_lvalue, inferred = self.check_lvalue(lvalue)
             if lvalue_type:
+                if isinstance(lvalue, NameExpr):
+                    base_type = find_type_from_bases(lvalue)
+
+                    # If a type is known, validate the type is a subtype of the base type
+                    if base_type:
+                        self.check_subtype(lvalue_type, base_type, lvalue,
+                                           messages.INCOMPATIBLE_TYPES_IN_ASSIGNMENT,
+                                           'expression has type',
+                                           'variable has type')
+
                 if isinstance(lvalue_type, PartialType) and lvalue_type.type is None:
                     # Try to infer a proper type for a variable with a partial None type.
                     rvalue_type = self.accept(rvalue)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -37,7 +37,7 @@ from mypy.constraints import get_actual_type
 from mypy.checkstrformat import StringFormatterChecker
 from mypy.expandtype import expand_type
 from mypy.util import split_module_names
-from mypy.semanal import fill_typevars
+from mypy.typevars import fill_typevars
 
 from mypy import experiments
 

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -7,14 +7,17 @@ from mypy.types import (
     Overloaded, TypeVarType, UnionType, PartialType,
     DeletedType, NoneTyp, TypeType, function_type
 )
-from mypy.nodes import TypeInfo, FuncBase, Var, FuncDef, SymbolNode, Context, MypyFile
+from mypy.nodes import (
+    TypeInfo, FuncBase, Var, FuncDef, SymbolNode, Context, MypyFile, MDEF,
+    NameExpr
+)
 from mypy.nodes import ARG_POS, ARG_STAR, ARG_STAR2
 from mypy.nodes import Decorator, OverloadedFuncDef
 from mypy.messages import MessageBuilder
 from mypy.maptype import map_instance_to_supertype
 from mypy.expandtype import expand_type_by_instance, expand_type
 from mypy.infer import infer_type_arguments
-from mypy.semanal import fill_typevars
+from mypy.typevars import fill_typevars, has_no_typevars
 from mypy import messages
 from mypy import subtypes
 MYPY = False
@@ -615,3 +618,27 @@ def erase_to_bound(t: Type):
         if isinstance(t.item, TypeVarType):
             return TypeType(t.item.upper_bound)
     return t
+
+
+def find_type_from_bases(e: NameExpr):
+    """For a NameExpr that is part of a class, walk all base classes and try
+    to find the first class that defines a Type for the same name."""
+
+    expr_node = e.node
+    if not (isinstance(expr_node, Var) and e.kind == MDEF and
+            len(expr_node.info.bases) > 0):
+        return None
+
+    expr_name = expr_node.name()
+    expr_base = expr_node.info.bases[0]
+
+    for base in expr_node.info.mro[1:]:
+        base_var = base.names.get(expr_name)
+        if base_var and base_var.type:
+            if has_no_typevars(base_var.type):
+                base_type = base_var.type
+            else:
+                itype = map_instance_to_supertype(expr_base, base)
+                base_type = expand_type_by_instance(base_var.type, itype)
+
+            return base_type

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -641,4 +641,11 @@ def find_type_from_bases(e: NameExpr):
                 itype = map_instance_to_supertype(expr_base, base)
                 base_type = expand_type_by_instance(base_var.type, itype)
 
+            if isinstance(base_type, CallableType):
+                # If we are a property, return the Type of the return value, not the Callable
+                if isinstance(base_var.node, Decorator) and base_var.node.func.is_property:
+                    base_type = base_type.ret_type
+                elif isinstance(base_var.node, FuncDef) and base_var.node.is_property:
+                    base_type = base_type.ret_type
+
             return base_type

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1169,8 +1169,10 @@ class SemanticAnalyzer(NodeVisitor):
                         for base in var_node.info.mro[1:]:
                             base_var = base.names.get(var_node.name())
                             if base_var and base_var.type:
-                                s.type = base_var.type
-                                break
+                                # TODO -- Can we resolve/support TypeVars at this stage?
+                                if not isinstance(base_var.type, TypeVarType):
+                                    s.type = base_var.type
+                                    break
 
                     if s.type is None:
                         s.type = self.analyze_simple_literal_type(s.rvalue)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1171,11 +1171,11 @@ class SemanticAnalyzer(NodeVisitor):
                         for base in var_node.info.mro[1:]:
                             base_var = base.names.get(var_node.name())
                             if base_var and base_var.type:
-                                if isinstance(base_var.type, TypeVarType):
+                                if has_no_typevars(base_var.type):
+                                    s.type = base_var.type
+                                else:
                                     itype = map_instance_to_supertype(var_node.info.bases[0], base)
                                     s.type = expand_type_by_instance(base_var.type, itype)
-                                else:
-                                    s.type = base_var.type
                                 break
 
                     if s.type is None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1161,7 +1161,20 @@ class SemanticAnalyzer(NodeVisitor):
             if (s.type is None and len(s.lvalues) == 1 and
                     isinstance(s.lvalues[0], NameExpr)):
                 if s.lvalues[0].is_def:
-                    s.type = self.analyze_simple_literal_type(s.rvalue)
+                    if (isinstance(s.lvalues[0].node, Var) and
+                            s.lvalues[0].kind == MDEF):
+                        # Try if any base class already defines a
+                        # type for this class variable.
+                        var_node = s.lvalues[0].node
+                        for base in var_node.info.mro[1:]:
+                            base_var = base.names.get(var_node.name())
+                            if base_var and base_var.type:
+                                s.type = base_var.type
+                                break
+
+                    if s.type is None:
+                        s.type = self.analyze_simple_literal_type(s.rvalue)
+
                 res = analyze_type_alias(s.rvalue,
                                          self.lookup_qualified,
                                          self.lookup_fully_qualified,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -79,6 +79,8 @@ from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.sametypes import is_same_type
 from mypy.erasetype import erase_typevars
 from mypy.options import Options
+from mypy.expandtype import expand_type_by_instance
+from mypy.maptype import map_instance_to_supertype
 
 
 T = TypeVar('T')
@@ -1169,8 +1171,10 @@ class SemanticAnalyzer(NodeVisitor):
                         for base in var_node.info.mro[1:]:
                             base_var = base.names.get(var_node.name())
                             if base_var and base_var.type:
-                                # TODO -- Can we resolve/support TypeVars at this stage?
-                                if not isinstance(base_var.type, TypeVarType):
+                                if isinstance(base_var.type, TypeVarType):
+                                    itype = map_instance_to_supertype(var_node.info.bases[0], base)
+                                    s.type = expand_type_by_instance(base_var.type, itype)
+                                else:
                                     s.type = base_var.type
                                 break
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1172,7 +1172,7 @@ class SemanticAnalyzer(NodeVisitor):
                                 # TODO -- Can we resolve/support TypeVars at this stage?
                                 if not isinstance(base_var.type, TypeVarType):
                                     s.type = base_var.type
-                                    break
+                                break
 
                     if s.type is None:
                         s.type = self.analyze_simple_literal_type(s.rvalue)

--- a/mypy/typevars.py
+++ b/mypy/typevars.py
@@ -1,0 +1,24 @@
+from typing import Union
+
+from mypy.nodes import TypeInfo
+
+from mypy.erasetype import erase_typevars
+from mypy.sametypes import is_same_type
+from mypy.types import Instance, TypeVarType, TupleType, Type
+
+
+def fill_typevars(typ: TypeInfo) -> Union[Instance, TupleType]:
+    """For a non-generic type, return instance type representing the type.
+    For a generic G type with parameters T1, .., Tn, return G[T1, ..., Tn].
+    """
+    tv = []  # type: List[Type]
+    for i in range(len(typ.type_vars)):
+        tv.append(TypeVarType(typ.defn.type_vars[i]))
+    inst = Instance(typ, tv)
+    if typ.tuple_type is None:
+        return inst
+    return typ.tuple_type.copy_modified(fallback=inst)
+
+
+def has_no_typevars(typ: Type) -> bool:
+    return is_same_type(typ, erase_typevars(typ))

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2132,3 +2132,16 @@ class B(A[int]):
 [out]
 main: note: In class "B":
 main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testVariableTypeVarIndirectly]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class A(Generic[T]):
+    a = None  # type: T
+class B(A[int]):
+    pass
+class C(B):
+    a = "a"
+[out]
+main: note: In class "C":
+main:8: error: Incompatible types in assignment (expression has type "str", variable has type "int")

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2058,9 +2058,9 @@ class C(metaclass=int()):  # E: Dynamic metaclass not supported for 'C'
 
 [case testVariableSubclass]
 class A:
-    a = 1 # type: int
+    a = 1  # type: int
 class B(A):
-    a = None
+    a = 1
 [out]
 
 [case testVariableSubclassAssignMismatch]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2182,3 +2182,18 @@ class B(A):
 main: note: In class "B":
 main:5: error: Incompatible types in assignment (expression has type "int", variable has type Callable[[A], None])
 main:6: error: Signature of "b" incompatible with supertype "A"
+
+[case testVariableProperty]
+class A:
+    @property
+    def a(self) -> bool: pass
+class B(A):
+    a = None  # type: bool
+class C(A):
+    a = True
+class D(A):
+    a = 1
+[builtins fixtures/property.pyi]
+[out]
+main: note: In class "D":
+main:9: error: Incompatible types in assignment (expression has type "int", variable has type "bool")

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2113,3 +2113,22 @@ main: note: In class "A":
 main:2: error: Need type annotation for variable
 main: note: In class "C":
 main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testVariableTypeVar]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class A(Generic[T]):
+    a = None  # type: T
+class B(A[int]):
+    a = 1
+
+[case testVariableTypeVarInvalid]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class A(Generic[T]):
+    a = None  # type: T
+class B(A[int]):
+    a = "abc"
+[out]
+main: note: In class "B":
+main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2145,3 +2145,17 @@ class C(B):
 [out]
 main: note: In class "C":
 main:8: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testVariableTypeVarList]
+from typing import List, TypeVar, Generic
+T = TypeVar('T')
+class A(Generic[T]):
+    a = None  # type: List[T]
+    b = None  # type: List[T]
+class B(A[int]):
+    a = [1]
+    b = ['']
+[builtins fixtures/list.pyi]
+[out]
+main: note: In class "B":
+main:8: error: List item 0 has incompatible type "str"

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2055,3 +2055,61 @@ class B(object, A): # E: Cannot determine consistent method resolution order (MR
 # flags: --fast-parser
 class C(metaclass=int()):  # E: Dynamic metaclass not supported for 'C'
     pass
+
+[case testVariableSubclass]
+class A:
+    a = 1 # type: int
+class B(A):
+    a = None
+[out]
+
+[case testVariableSubclassAssignMismatch]
+class A:
+    a = 1  # type: int
+class B(A):
+    a = "a"
+[out]
+main: note: In class "B":
+main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testVariableSubclassAssignment]
+class A:
+    a = None  # type: int
+class B(A):
+    def __init__(self) -> None:
+        self.a = "a"
+[out]
+main: note: In member "__init__" of class "B":
+main:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testVariableSubclassTypeOverwrite]
+class A:
+    a = None  # type: int
+class B(A):
+    a = None  # type: str
+class C(B):
+    a = "a"
+[out]
+
+[case testVariableSuperUsage]
+class A:
+    a = []  # type: list
+class B(A):
+    a = [1, 2]
+class C(B):
+    a = B.a + [3]
+[builtins fixtures/list.pyi]
+[out]
+
+[case testVariableRvalue]
+class A:
+    a = None
+class B(A):
+    a = 1
+class C(B):
+    a = "a"
+[out]
+main: note: In class "A":
+main:2: error: Need type annotation for variable
+main: note: In class "C":
+main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2090,6 +2090,17 @@ class B(A):
 class C(B):
     a = "a"
 [out]
+main: note: In class "B":
+main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testVariableSubclassTypeOverwriteImplicit]
+class A:
+    a = 1
+class B(A):
+    a = None  # type: str
+[out]
+main: note: In class "B":
+main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testVariableSuperUsage]
 class A:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2170,3 +2170,15 @@ class B(A[int]):
 [out]
 main: note: In class "B":
 main:8: error: List item 0 has incompatible type "str"
+
+[case testVariableMethod]
+class A:
+    def a(self) -> None: pass
+    b = 1
+class B(A):
+    a = 1
+    def b(self) -> None: pass
+[out]
+main: note: In class "B":
+main:5: error: Incompatible types in assignment (expression has type "int", variable has type Callable[[A], None])
+main:6: error: Signature of "b" incompatible with supertype "A"

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2265,3 +2265,11 @@ class D(A):
 [out]
 main: note: In class "D":
 main:9: error: Incompatible types in assignment (expression has type "int", variable has type "bool")
+
+[case testVariableOverwriteAny]
+from typing import Any
+class A:
+    a = 1
+class B(A):
+    a = 'x'  # type: Any
+[out]


### PR DESCRIPTION
With this patch, class variables are validated for their type if only the base class defines the type.

Typeshed shows 1 issue in the pyi files. __doc__ is set by MyPy to be 'str'. In stdlib/2/types.pyi, in FunctionType, it is set to func_doc, which is 'Optional[str]'. Because with this patch assignments are checked against their definition, assigning 'Optional[str]' to 'str' is incompatible.

The solution appears simple, by doing types.pyi similar as stdlib/3: not using a level of indirection when assigning these types.

So instead of:

```
func_doc = ...  # type: Optional[str]
 __doc__ = func_doc
```

Doing:

```
__doc__ = ... # type: Optional[str]
```

If you like, I can make a PR for that change too; but I was first more curious if this PR is correct.
