### PR TITLE
Do not construct malformed CallableType

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -296,6 +296,10 @@ class ASTConverter(ast35.NodeTransformer):
 
         func_type = None
         if any(arg_types) or return_type:
+            if len(arg_types) > len(arg_kinds):
+                raise FastParserError('Type signature has too many arguments', n.lineno, offset=0)
+            if len(arg_types) < len(arg_kinds):
+                raise FastParserError('Type signature has too few arguments', n.lineno, offset=0)
             func_type = CallableType([a if a is not None else AnyType() for a in arg_types],
                                      arg_kinds,
                                      arg_names,

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -53,6 +53,7 @@ except ImportError:
         print('The typed_ast package required by --fast-parser is only compatible with'
               ' Python 3.3 and greater.')
     sys.exit(1)
+from mypy.fastparse import FastParserError
 
 T = TypeVar('T', bound=Union[ast27.expr, ast27.stmt])
 U = TypeVar('U', bound=Node)
@@ -302,6 +303,10 @@ class ASTConverter(ast27.NodeTransformer):
 
         func_type = None
         if any(arg_types) or return_type:
+            if len(arg_types) > len(arg_kinds):
+                raise FastParserError('Type signature has too many arguments', n.lineno, offset=0)
+            if len(arg_types) < len(arg_kinds):
+                raise FastParserError('Type signature has too few arguments', n.lineno, offset=0)
             func_type = CallableType([a if a is not None else AnyType() for a in arg_types],
                                      arg_kinds,
                                      arg_names,

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -456,6 +456,10 @@ class Parser:
                 else:
                     self.check_argument_kinds(arg_kinds, sig.arg_kinds,
                                               def_tok.line, def_tok.column)
+                    if len(sig.arg_types) > len(arg_kinds):
+                        raise ParseError('Type signature has too many arguments')
+                    if len(sig.arg_types) < len(arg_kinds):
+                        raise ParseError('Type signature has too few arguments')
                     typ = CallableType(
                         sig.arg_types,
                         arg_kinds,

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -576,6 +576,7 @@ class CallableType(FunctionLike):
                  ) -> None:
         if variables is None:
             variables = []
+        assert len(arg_types) == len(arg_kinds)
         self.arg_types = arg_types
         self.arg_kinds = arg_kinds
         self.arg_names = arg_names

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -160,16 +160,12 @@ main: note: In function "f":
 def f():  # E: Type signature has too many arguments
     # type: (int) -> None
     pass
-[out]
-main: note: In function "f":
 
 [case testFasterParseTooFewArgumentsAnnotation]
 # flags: --fast-parser
 def f(x):  # E: Type signature has too few arguments
     # type: () -> None
     pass
-[out]
-main: note: In function "f":
 
 [case testFasterParseTypeCommentError_python2]
 # flags: --fast-parser


### PR DESCRIPTION
Handle too many/few types in signature on the parser level, instead of breaking the invariant of CallableType.