### PR TITLE
[WIP] Support metaclasses

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -176,6 +176,8 @@ def analyze_member_access(name: str,
             if result:
                 return result
         fallback = builtin_type('builtins.type')
+        if item is not None:
+            fallback = item.type.metaclass_type or fallback
         return analyze_member_access(name, fallback, node, is_lvalue, is_super,
                                      is_operator, builtin_type, not_ready_callback, msg,
                                      original_type=original_type, chk=chk)
@@ -438,7 +440,7 @@ def type_object_type(info: TypeInfo, builtin_type: Callable[[str], Instance]) ->
         # Must be an invalid class definition.
         return AnyType()
     else:
-        fallback = builtin_type('builtins.type')
+        fallback = info.metaclass_type or builtin_type('builtins.type')
         if init_method.info.fullname() == 'builtins.object':
             # No non-default __init__ -> look at __new__ instead.
             new_method = info.get_method('__new__')

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -296,6 +296,10 @@ class ASTConverter(ast35.NodeTransformer):
 
         func_type = None
         if any(arg_types) or return_type:
+            if len(arg_types) > len(arg_kinds):
+                raise FastParserError('Type signature has too many arguments', n.lineno, offset=0)
+            if len(arg_types) < len(arg_kinds):
+                raise FastParserError('Type signature has too few arguments', n.lineno, offset=0)
             func_type = CallableType([a if a is not None else AnyType() for a in arg_types],
                                      arg_kinds,
                                      arg_names,

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -53,6 +53,7 @@ except ImportError:
         print('The typed_ast package required by --fast-parser is only compatible with'
               ' Python 3.3 and greater.')
     sys.exit(1)
+from mypy.fastparse import FastParserError
 
 T = TypeVar('T', bound=Union[ast27.expr, ast27.stmt])
 U = TypeVar('U', bound=Node)
@@ -302,6 +303,10 @@ class ASTConverter(ast27.NodeTransformer):
 
         func_type = None
         if any(arg_types) or return_type:
+            if len(arg_types) > len(arg_kinds):
+                raise FastParserError('Type signature has too many arguments', n.lineno, offset=0)
+            if len(arg_types) < len(arg_kinds):
+                raise FastParserError('Type signature has too few arguments', n.lineno, offset=0)
             func_type = CallableType([a if a is not None else AnyType() for a in arg_types],
                                      arg_kinds,
                                      arg_names,

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1920,6 +1920,29 @@ class TypeInfo(SymbolNode):
             for vd in defn.type_vars:
                 self.type_vars.append(vd.name)
 
+    _metaclass_type = None  # type: Optional[mypy.types.Instance]
+
+    @property
+    def metaclass_type(self) -> 'Optional[mypy.types.Instance]':
+        if self._metaclass_type:
+            return self._metaclass_type
+        if self._fullname == 'builtins.type':
+            return mypy.types.Instance(self, [])
+        if self.mro is None:
+            # XXX why does this happen?
+            return None
+        if len(self.mro) > 1:
+            return self.mro[1].metaclass_type
+        # FIX: assert False
+        return None
+
+    @metaclass_type.setter
+    def metaclass_type(self, value: 'mypy.types.Instance'):
+        self._metaclass_type = value
+
+    def is_metaclass(self) -> bool:
+        return self.has_base('builtins.type')
+
     def name(self) -> str:
         """Short name."""
         return self.defn.name

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -456,6 +456,10 @@ class Parser:
                 else:
                     self.check_argument_kinds(arg_kinds, sig.arg_kinds,
                                               def_tok.line, def_tok.column)
+                    if len(sig.arg_types) > len(arg_kinds):
+                        raise ParseError('Type signature has too many arguments')
+                    if len(sig.arg_types) < len(arg_kinds):
+                        raise ParseError('Type signature has too few arguments')
                     typ = CallableType(
                         sig.arg_types,
                         arg_kinds,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -902,7 +902,7 @@ class SemanticAnalyzer(NodeVisitor):
             if defn.metaclass == '<error>':
                 self.fail("Dynamic metaclass not supported for '%s'" % defn.name, defn)
                 return
-            sym = self.lookup(defn.metaclass, defn)
+            sym = self.lookup_qualified(defn.metaclass, defn)
             if sym is not None and isinstance(sym.node, TypeInfo):
                 inst = fill_typevars(sym.node)
                 assert isinstance(inst, Instance)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -902,8 +902,13 @@ class SemanticAnalyzer(NodeVisitor):
             if defn.metaclass == '<error>':
                 self.fail("Dynamic metaclass not supported for '%s'" % defn.name, defn)
                 return
-            sym = self.lookup_qualified(defn.metaclass, defn)
-            if sym is not None and not isinstance(sym.node, TypeInfo):
+            sym = self.lookup(defn.metaclass, defn)
+            if sym is not None and isinstance(sym.node, TypeInfo):
+                inst = fill_typevars(sym.node)
+                assert isinstance(inst, Instance)
+                defn.info.metaclass_type = inst
+                return
+            else:
                 self.fail("Invalid metaclass '%s'" % defn.metaclass, defn)
 
     def object_type(self) -> Instance:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -624,7 +624,8 @@ class CallableType(FunctionLike):
         )
 
     def is_type_obj(self) -> bool:
-        return self.fallback.type is not None and self.fallback.type.fullname() == 'builtins.type'
+        t = self.fallback.type
+        return t is not None and t.is_metaclass()
 
     def is_concrete_type_obj(self) -> bool:
         return self.is_type_obj() and self.is_classmethod_class

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -576,6 +576,7 @@ class CallableType(FunctionLike):
                  ) -> None:
         if variables is None:
             variables = []
+        assert len(arg_types) == len(arg_kinds)
         self.arg_types = arg_types
         self.arg_kinds = arg_kinds
         self.arg_names = arg_names

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -160,16 +160,12 @@ main: note: In function "f":
 def f():  # E: Type signature has too many arguments
     # type: (int) -> None
     pass
-[out]
-main: note: In function "f":
 
 [case testFasterParseTooFewArgumentsAnnotation]
 # flags: --fast-parser
 def f(x):  # E: Type signature has too few arguments
     # type: () -> None
     pass
-[out]
-main: note: In function "f":
 
 [case testFasterParseTypeCommentError_python2]
 # flags: --fast-parser

--- a/test-data/unit/lib-stub/abc.pyi
+++ b/test-data/unit/lib-stub/abc.pyi
@@ -1,3 +1,3 @@
-class ABCMeta: pass
+class ABCMeta(type): pass
 abstractmethod = object()
 abstractproperty = object()

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -985,15 +985,15 @@ class A(Generic[T], Generic[S]): pass \
 [case testInvalidMetaclass]
 class A(metaclass=x): pass
 [out]
-main:3: error: Name 'x' is not defined
-main:3: error: Invalid metaclass 'x'
+main:1: error: Name 'x' is not defined
+main:1: error: Invalid metaclass 'x'
 
 [case testInvalidQualifiedMetaclass]
 import abc
 class A(metaclass=abc.Foo): pass
 [out]
-main:3: error: Name 'abc.Foo' is not defined
-main:3: error: Invalid metaclass 'abc.Foo'
+main:2: error: Name 'abc.Foo' is not defined
+main:2: error: Invalid metaclass 'abc.Foo'
 
 [case testNonClassMetaclass]
 def f(): pass

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -983,13 +983,17 @@ class A(Generic[T], Generic[S]): pass \
 [out]
 
 [case testInvalidMetaclass]
-class A(metaclass=x): pass # E: Name 'x' is not defined
+class A(metaclass=x): pass
 [out]
+main:3: error: Name 'x' is not defined
+main:3: error: Invalid metaclass 'x'
 
 [case testInvalidQualifiedMetaclass]
 import abc
-class A(metaclass=abc.Foo): pass # E: Name 'abc.Foo' is not defined
+class A(metaclass=abc.Foo): pass
 [out]
+main:3: error: Name 'abc.Foo' is not defined
+main:3: error: Invalid metaclass 'abc.Foo'
 
 [case testNonClassMetaclass]
 def f(): pass


### PR DESCRIPTION
(#2365 take two)
Store the type of the metaclass in TypeInfo, and use it when possible, instead of builtins.type.

I assume metaclasses always inherit from type.

This PR will help fixing #2305, but the fix is not part of this PR.

For now it also includes #2391 which is needed for some reason (but is reasonable regardless).