### PR TITLE
Make mypy -V show git commit hash more often

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -139,12 +139,8 @@ def process_options(args: List[str],
     # parsed into the separate special_opts namespace object.
     parser.add_argument('-v', '--verbose', action='count', dest='verbosity',
                         help="more verbose messages")
-    full_version = __version__
-    mypy_dir = os.path.dirname(os.path.dirname(__file__))
-    if git.is_git_repo(mypy_dir) and git.have_git():
-        full_version += '-' + git.git_revision(mypy_dir).decode('utf-8')
     parser.add_argument('-V', '--version', action='version',
-                        version='%(prog)s ' + full_version)
+                        version='%(prog)s ' + __version__)
     parser.add_argument('--python-version', type=parse_version, metavar='x.y',
                         help='use Python x.y')
     parser.add_argument('--platform', action='store', metavar='PLATFORM',

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -140,9 +140,9 @@ def process_options(args: List[str],
     parser.add_argument('-v', '--verbose', action='count', dest='verbosity',
                         help="more verbose messages")
     full_version = __version__
-    if git.is_git_repo('.') and git.have_git():
-        full_version += '-' + git.git_revision('.').decode('utf-8')
-
+    mypy_dir = os.path.dirname(os.path.dirname(__file__))
+    if git.is_git_repo(mypy_dir) and git.have_git():
+        full_version += '-' + git.git_revision(mypy_dir).decode('utf-8')
     parser.add_argument('-V', '--version', action='version',
                         version='%(prog)s ' + full_version)
     parser.add_argument('--python-version', type=parse_version, metavar='x.y',

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -139,8 +139,12 @@ def process_options(args: List[str],
     # parsed into the separate special_opts namespace object.
     parser.add_argument('-v', '--verbose', action='count', dest='verbosity',
                         help="more verbose messages")
+    full_version = __version__
+    if git.is_git_repo('.') and git.have_git():
+        full_version += '-' + git.git_revision('.').decode('utf-8')
+
     parser.add_argument('-V', '--version', action='version',
-                        version='%(prog)s ' + __version__)
+                        version='%(prog)s ' + full_version)
     parser.add_argument('--python-version', type=parse_version, metavar='x.y',
                         help='use Python x.y')
     parser.add_argument('--platform', action='store', metavar='PLATFORM',

--- a/mypy/version.py
+++ b/mypy/version.py
@@ -1,1 +1,11 @@
+import os
+from mypy import git
+
 __version__ = '0.4.6-dev'
+
+mypy_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+if git.is_git_repo(mypy_dir) and git.have_git():
+    __version__ += '-' + git.git_revision(mypy_dir).decode('utf-8')
+    if git.is_dirty(mypy_dir):
+        __version__ += '-dirty'
+del mypy_dir

--- a/setup.py
+++ b/setup.py
@@ -31,19 +31,6 @@ types.
 '''.lstrip()
 
 
-def cache_version_id():
-    """Returns the version id to use for the incremental hash.
-
-    If setup.py is run from a git repo, the git commit hash will be
-    included if possible. If not, then this function will fall back to
-    using the default version id from mypy/version.py."""
-    if git.is_git_repo('.') and git.have_git():
-        return __version__ + '-' + git.git_revision('.').decode('utf-8')
-    else:
-        # Default fallback
-        return __version__
-
-
 def find_data_files(base, globs):
     """Find all interesting data files, for setup(data_files=)
 
@@ -71,7 +58,7 @@ class CustomPythonBuild(build_py):
         path = os.path.join(self.build_lib, 'mypy')
         self.mkpath(path)
         with open(os.path.join(path, 'version.py'), 'w') as stream:
-            stream.write('__version__ = "{}"\n'.format(cache_version_id()))
+            stream.write('__version__ = "{}"\n'.format(version))
 
     def run(self):
         self.execute(self.pin_version, ())


### PR DESCRIPTION
Previously the git commit hash was only appended to `__version__` by setup.py. Now we do this dynamically in mypy/version.py. This means the commit hash is also reported when run directly from the repo (e.g. `python3 -m mypy -V` from the repo root). It is also used by the cache in this case.

I didn't notice any slowdown. Notice the contents of version.py in distributions is still overwritten by setup.py so a properly installed version should not be executing any git commands at startup.
