### PR TITLE
Show column number for reveal_type() expressions

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2241,6 +2241,7 @@ class SemanticAnalyzer(NodeVisitor):
                 return
             expr.analyzed = RevealTypeExpr(expr.args[0])
             expr.analyzed.line = expr.line
+            expr.analyzed.column = expr.column
             expr.analyzed.accept(self)
         elif refers_to_fullname(expr.callee, 'typing.Any'):
             # Special form Any(...).

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -621,8 +621,8 @@ main:16:18: error: "list" expects 1 type argument, but 2 given
 main:17:24: error: "Node" expects 2 type arguments, but 1 given
 main:18:3: error: "Node" expects 2 type arguments, but 1 given
 main:19:4: error: Bad number of arguments for type alias, expected: 1, given: 2
-main:22: error: Revealed type is '__main__.Node[builtins.int, builtins.str]'
-main:24: error: Revealed type is '__main__.Node[__main__.Node[builtins.int, builtins.int], builtins.list[builtins.int]]'
+main:22:0: error: Revealed type is '__main__.Node[builtins.int, builtins.str]'
+main:24:0: error: Revealed type is '__main__.Node[__main__.Node[builtins.int, builtins.int], builtins.list[builtins.int]]'
 main:26:4: error: Type variable "__main__.T" is invalid as target for type alias
 
 [case testGenericTypeAliasesForAliases]


### PR DESCRIPTION
(But only if `--show-column-numbers` is selected, of course.)