### PR TITLE
Allow instance access to class attributes that are class objects

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -255,7 +255,7 @@ def analyze_var(name: str, var: Var, itype: Instance, info: TypeInfo, node: Cont
         if is_lvalue and var.is_property and not var.is_settable_property:
             # TODO allow setting attributes in subclass (although it is probably an error)
             msg.read_only_property(name, info, node)
-        if var.is_initialized_in_class and isinstance(t, FunctionLike):
+        if var.is_initialized_in_class and isinstance(t, FunctionLike) and not t.is_type_obj():
             if is_lvalue:
                 if var.is_property:
                     if not var.is_settable_property:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1405,6 +1405,74 @@ class X(Nope): pass  # E: Name 'Nope' is not defined
 a, b = X()  # Used to crash here (#2244)
 
 
+-- Class-valued attributes
+-- -----------------------
+
+[case testClassValuedAttributesBasics]
+class A: ...
+class B:
+    a = A
+    bad = lambda: 42
+
+B().bad() # E: Invalid method type
+reveal_type(B.a) # E: Revealed type is 'def () -> __main__.A'
+reveal_type(B().a) # E: Revealed type is 'def () -> __main__.A'
+reveal_type(B().a()) # E: Revealed type is '__main__.A'
+
+class C:
+    a = A
+    def __init__(self) -> None:
+        self.aa = self.a()
+
+reveal_type(C().aa) # E: Revealed type is '__main__.A'
+[out]
+
+[case testClassValuedAttributesGeneric]
+from typing import Generic, TypeVar
+T = TypeVar('T')
+
+class A(Generic[T]):
+    def __init__(self, x: T) -> None:
+        self.x = x
+class B(Generic[T]):
+    a = A[T]
+
+reveal_type(B[int]().a) # E: Revealed type is 'def (x: builtins.int*) -> __main__.A[builtins.int*]'
+B[int]().a('hi') # E: Argument 1 has incompatible type "str"; expected "int"
+
+class C(Generic[T]):
+    a = A
+    def __init__(self) -> None:
+        self.aa = self.a(42)
+
+reveal_type(C().aa) # E: Revealed type is '__main__.A[builtins.int]'
+[out]
+
+[case testClassValuedAttributesAlias]
+from typing import Generic, TypeVar
+T = TypeVar('T')
+S = TypeVar('S')
+
+class A(Generic[T, S]): ...
+
+SameA = A[T, T]
+
+class B:
+    a_any = SameA
+    a_int = SameA[int]
+
+reveal_type(B().a_any) # E: Revealed type is 'def () -> __main__.A[Any, Any]'
+reveal_type(B().a_int()) # E: Revealed type is '__main__.A[builtins.int*, builtins.int*]'
+
+class C:
+    a_int = SameA[int]
+    def __init__(self) -> None:
+        self.aa = self.a_int()
+
+reveal_type(C().aa) # E: Revealed type is '__main__.A[builtins.int*, builtins.int*]'
+[out]
+
+
 -- Type[C]
 -- -------
 


### PR DESCRIPTION
Currently, mypy flags as error access via instances to class attributes that are class objects. For example:
```python
class C:
    ...
class D:
    c = C
    def __init__(self) -> None:
        self.c  # Flagged as error, but perfectly valid at runtime
        self.c()  # Flagged as error, but perfectly valid at runtime

D().c  # Flagged as error, but perfectly valid at runtime
D().c()  # Flagged as error, but perfectly valid at runtime
```

In this PR I propose to allow this since it is valid at runtime, valid logically, and is sometimes a useful pattern (in django for example).

The fix is very simple -- don't consider ``FunctionLike`` members with ``.is_type_obj()`` returning ``True`` as instance methods.