### PR TITLE
Type application of generic function shouldn't be allowed

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1361,12 +1361,16 @@ class ExpressionChecker:
         """Type check a type application (expr[type, ...])."""
         tp = self.accept(tapp.expr)
         if isinstance(tp, CallableType):
+            if not tp.is_type_obj():
+                self.chk.fail(messages.ONLY_CLASS_APPLICATION, tapp)
             if len(tp.variables) != len(tapp.types):
                 self.msg.incompatible_type_application(len(tp.variables),
                                                        len(tapp.types), tapp)
                 return AnyType()
             return self.apply_generic_arguments(tp, tapp.types, tapp)
         elif isinstance(tp, Overloaded):
+            if not tp.is_type_obj():
+                self.chk.fail(messages.ONLY_CLASS_APPLICATION, tapp)
             for item in tp.items():
                 if len(item.variables) != len(tapp.types):
                     self.msg.incompatible_type_application(len(item.variables),

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -66,6 +66,7 @@ RETURN_TYPE_CANNOT_BE_CONTRAVARIANT = "Cannot use a contravariant type variable 
 FUNCTION_PARAMETER_CANNOT_BE_COVARIANT = "Cannot use a covariant type variable as a parameter"
 INCOMPATIBLE_IMPORT_OF = "Incompatible import of"
 FUNCTION_TYPE_EXPECTED = "Function is missing a type annotation"
+ONLY_CLASS_APPLICATION = "Type application is only supported for generic classes"
 RETURN_TYPE_EXPECTED = "Function is missing a return type annotation"
 ARGUMENT_TYPE_EXPECTED = "Function is missing a type annotation for one or more arguments"
 KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE = \

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -417,6 +417,14 @@ class A(Generic[T]):
 [out]
 main: note: In member "f" of class "A":
 
+[case testProhibitTypeApplicationToGenericFunctions]
+from typing import TypeVar
+T = TypeVar('T')
+def f(x: T) -> T: pass
+
+y = f[int]  # E: Type application is only supported for generic classes
+[out]
+
 
 -- Generic types in expressions
 -- ----------------------------


### PR DESCRIPTION
Fixes #2348 

Currently, mypy accepts this program, which will fail at runtime:
```python
from typing import TypeVar
T = TypeVar('T')
def f(x: T) -> T: pass
y = f[int]
```

This PR prohibits type application to functions.