### PR TITLE
Flexible callable

### DIFF
--- a/extensions/mypy_extensions.py
+++ b/extensions/mypy_extensions.py
@@ -28,3 +28,9 @@ class Arg(object):
         self.name = name
         self.typ = typ
         self.named_only = named_only
+
+class DefaultArg(object):
+    def __init__(name=None, typ=Any, keyword_only=False):
+        self.name = name
+        self.typ = typ
+        self.named_only = named_only

--- a/extensions/mypy_extensions.py
+++ b/extensions/mypy_extensions.py
@@ -5,6 +5,8 @@ Example usage:
     from mypy_extensions import TypedDict
 """
 
+from typing import Any
+
 # NOTE: This module must support Python 2.7 in addition to Python 3.x
 
 
@@ -20,3 +22,9 @@ def TypedDict(typename, fields):
     new_dict.__name__ = typename
     new_dict.__supertype__ = dict
     return new_dict
+
+class Arg(object):
+    def __init__(name=None, typ=Any, keyword_only=False):
+        self.name = name
+        self.typ = typ
+        self.named_only = named_only

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -816,7 +816,7 @@ class TypeChecker(NodeVisitor[Type]):
     def check_getattr_method(self, typ: CallableType, context: Context) -> None:
         method_type = CallableType([AnyType(), self.named_type('builtins.str')],
                                    [nodes.ARG_POS, nodes.ARG_POS],
-                                   [None],
+                                   [None, None],
                                    AnyType(),
                                    self.named_type('builtins.function'))
         if not is_subtype(typ, method_type):

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -3,7 +3,7 @@ from typing import Optional, Container, Callable
 from mypy.types import (
     Type, TypeVisitor, UnboundType, ErrorType, AnyType, Void, NoneTyp, TypeVarId,
     Instance, TypeVarType, CallableType, TupleType, UnionType, Overloaded, ErasedType,
-    PartialType, DeletedType, TypeTranslator, TypeList, UninhabitedType, TypeType
+    PartialType, DeletedType, TypeTranslator, ArgumentList, UninhabitedType, TypeType
 )
 from mypy import experiments
 
@@ -32,7 +32,7 @@ class EraseTypeVisitor(TypeVisitor[Type]):
     def visit_error_type(self, t: ErrorType) -> Type:
         return t
 
-    def visit_type_list(self, t: TypeList) -> Type:
+    def visit_type_list(self, t: ArgumentList) -> Type:
         assert False, 'Not supported'
 
     def visit_any(self, t: AnyType) -> Type:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 
 from mypy.types import (
     Type, Instance, CallableType, TypeVisitor, UnboundType, ErrorType, AnyType,
-    Void, NoneTyp, TypeVarType, Overloaded, TupleType, UnionType, ErasedType, TypeList,
+    Void, NoneTyp, TypeVarType, Overloaded, TupleType, UnionType, ErasedType, ArgumentList,
     PartialType, DeletedType, UninhabitedType, TypeType, TypeVarId
 )
 
@@ -42,7 +42,7 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
     def visit_error_type(self, t: ErrorType) -> Type:
         return t
 
-    def visit_type_list(self, t: TypeList) -> Type:
+    def visit_type_list(self, t: ArgumentList) -> Type:
         assert False, 'Not supported'
 
     def visit_any(self, t: AnyType) -> Type:

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -2,10 +2,11 @@
 
 from mypy.nodes import (
     Expression, NameExpr, MemberExpr, IndexExpr, TupleExpr,
-    ListExpr, StrExpr, BytesExpr, EllipsisExpr
+    ListExpr, StrExpr, BytesExpr, EllipsisExpr, CallExpr,
+    ARG_POS, ARG_NAMED,
 )
 from mypy.parsetype import parse_str_as_type, TypeParseError
-from mypy.types import Type, UnboundType, TypeList, EllipsisType
+from mypy.types import Type, UnboundType, ArgumentList, EllipsisType, AnyType
 
 
 class TypeTranslationError(Exception):
@@ -15,7 +16,7 @@ class TypeTranslationError(Exception):
 def expr_to_unanalyzed_type(expr: Expression) -> Type:
     """Translate an expression to the corresponding type.
 
-    The result is not semantically analyzed. It can be UnboundType or TypeList.
+    The result is not semantically analyzed. It can be UnboundType or ArgumentList.
     Raise TypeTranslationError if the expression cannot represent a type.
     """
     if isinstance(expr, NameExpr):
@@ -41,7 +42,39 @@ def expr_to_unanalyzed_type(expr: Expression) -> Type:
         else:
             raise TypeTranslationError()
     elif isinstance(expr, ListExpr):
-        return TypeList([expr_to_unanalyzed_type(t) for t in expr.items],
+        types = [] # type: List[Type]
+        names = [] # type: List[Optional[str]]
+        kinds = [] # type: List[int]
+        for it in expr.items:
+            if isinstance(expr_to_unanalyzed_type(it), CallExpr):
+                if not isinstance(it.callee, NameExpr):
+                    raise TypeTranslationError()
+                arg_const = it.callee.name
+                if arg_const == 'Arg':
+                    if len(it.args) > 0:
+                        name = it.args[0]
+                        if not isinstance(name, StrLit):
+                            raise TypeTranslationError()
+                        names.append(name.parsed())
+                    else:
+                        names.append(None)
+
+                    if len(it.args) > 1:
+                        typ = it.args[1]
+                        types.append(expr_to_unanalyzed_type(typ))
+                    else:
+                        types.append(AnyType)
+
+                    if len(it.args) > 2:
+                        kinds.append(ARG_NAMED)
+                    else:
+                        kinds.append(ARG_POS)
+
+            else:
+                types.append(expr_to_unanalyzed_type(it))
+                names.append(None)
+                kinds.append(ARG_POS)
+        return ArgumentList(types, names, kinds,
                         line=expr.line)
     elif isinstance(expr, (StrExpr, BytesExpr)):
         # Parse string literal type.

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -18,7 +18,7 @@ from mypy.nodes import (
     ARG_POS, ARG_OPT, ARG_STAR, ARG_NAMED, ARG_STAR2
 )
 from mypy.types import (
-    Type, CallableType, AnyType, UnboundType, TupleType, TypeList, EllipsisType,
+    Type, CallableType, AnyType, UnboundType, TupleType, ArgumentList, EllipsisType,
 )
 from mypy import defaults
 from mypy import experiments
@@ -904,7 +904,7 @@ class TypeConverter(ast35.NodeTransformer):
 
     # List(expr* elts, expr_context ctx)
     def visit_List(self, n: ast35.List) -> Type:
-        return TypeList(self.translate_expr_list(n.elts), line=self.line)
+        return ArgumentList(self.translate_expr_list(n.elts), line=self.line)
 
 
 class TypeCommentParseError(Exception):

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -904,7 +904,11 @@ class TypeConverter(ast35.NodeTransformer):
 
     # List(expr* elts, expr_context ctx)
     def visit_List(self, n: ast35.List) -> Type:
-        return ArgumentList(self.translate_expr_list(n.elts), line=self.line)
+        return ArgumentList(
+            self.translate_expr_list(n.elts),
+            [None]*len(n.elts),
+            [0]*len(n.elts),
+            line=self.line)
 
 
 class TypeCommentParseError(Exception):

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -7,7 +7,7 @@ from mypy.nodes import (MypyFile, SymbolNode, SymbolTable, SymbolTableNode,
                         TypeVarExpr, ClassDef,
                         LDEF, MDEF, GDEF)
 from mypy.types import (CallableType, EllipsisType, Instance, Overloaded, TupleType,
-                        TypeList, TypeVarType, UnboundType, UnionType, TypeVisitor,
+                        ArgumentList, TypeVarType, UnboundType, UnionType, TypeVisitor,
                         TypeType)
 from mypy.visitor import NodeVisitor
 
@@ -192,7 +192,7 @@ class TypeFixer(TypeVisitor[None]):
         if tt.fallback is not None:
             tt.fallback.accept(self)
 
-    def visit_type_list(self, tl: TypeList) -> None:
+    def visit_type_list(self, tl: ArgumentList) -> None:
         for t in tl.items:
             t.accept(self)
 

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -42,7 +42,7 @@ class TypeIndirectionVisitor(TypeVisitor[Set[str]]):
     def visit_unbound_type(self, t: types.UnboundType) -> Set[str]:
         return self._visit(*t.args)
 
-    def visit_type_list(self, t: types.TypeList) -> Set[str]:
+    def visit_type_list(self, t: types.ArgumentList) -> Set[str]:
         return self._visit(*t.items)
 
     def visit_error_type(self, t: types.ErrorType) -> Set[str]:

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -4,7 +4,7 @@ from typing import List
 
 from mypy.types import (
     Type, AnyType, NoneTyp, Void, TypeVisitor, Instance, UnboundType,
-    ErrorType, TypeVarType, CallableType, TupleType, ErasedType, TypeList,
+    ErrorType, TypeVarType, CallableType, TupleType, ErasedType, ArgumentList,
     UnionType, FunctionLike, Overloaded, PartialType, DeletedType,
     UninhabitedType, TypeType, true_or_false
 )
@@ -114,7 +114,7 @@ class TypeJoinVisitor(TypeVisitor[Type]):
     def visit_error_type(self, t: ErrorType) -> Type:
         return t
 
-    def visit_type_list(self, t: TypeList) -> Type:
+    def visit_type_list(self, t: ArgumentList) -> Type:
         assert False, 'Not supported'
 
     def visit_any(self, t: AnyType) -> Type:

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -3,7 +3,7 @@ from typing import List
 from mypy.join import is_similar_callables, combine_similar_callables
 from mypy.types import (
     Type, AnyType, TypeVisitor, UnboundType, Void, ErrorType, NoneTyp, TypeVarType,
-    Instance, CallableType, TupleType, ErasedType, TypeList, UnionType, PartialType,
+    Instance, CallableType, TupleType, ErasedType, ArgumentList, UnionType, PartialType,
     DeletedType, UninhabitedType, TypeType
 )
 from mypy.subtypes import is_subtype
@@ -133,7 +133,7 @@ class TypeMeetVisitor(TypeVisitor[Type]):
     def visit_error_type(self, t: ErrorType) -> Type:
         return t
 
-    def visit_type_list(self, t: TypeList) -> Type:
+    def visit_type_list(self, t: ArgumentList) -> Type:
         assert False, 'Not supported'
 
     def visit_any(self, t: AnyType) -> Type:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -15,7 +15,7 @@ from mypy.types import (
 )
 from mypy.nodes import (
     TypeInfo, Context, MypyFile, op_methods, FuncDef, reverse_type_aliases,
-    ARG_STAR, ARG_STAR2
+    ARG_POS, ARG_OPT, ARG_NAMED, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2
 )
 
 
@@ -167,8 +167,40 @@ class MessageBuilder:
                 return_type = strip_quotes(self.format(func.ret_type))
                 if func.is_ellipsis_args:
                     return 'Callable[..., {}]'.format(return_type)
-                arg_types = [strip_quotes(self.format(t)) for t in func.arg_types]
-                return 'Callable[[{}], {}]'.format(", ".join(arg_types), return_type)
+                arg_strings = []
+                for arg_name, arg_type, arg_kind in zip(
+                        func.arg_names, func.arg_types, func.arg_kinds):
+                    if arg_kind == ARG_POS and arg_name is None or verbosity == 0:
+                        arg_strings.append(
+                            strip_quotes(
+                                self.format(
+                                    arg_type,
+                                    verbosity = max(verbosity-1, 0))))
+                    else:
+                        constructor = {
+                            ARG_POS: "Arg",
+                            ARG_OPT: "DefaultArg",
+                            ARG_NAMED: "Arg",
+                            ARG_NAMED_OPT: "DefaultArg",
+                            ARG_STAR: "StarArg",
+                            ARG_STAR2: "KwArg",
+                        }[arg_kind]
+                        if arg_kind in (
+                                ARG_POS,
+                                ARG_OPT,
+                                ARG_NAMED,
+                                ARG_NAMED_OPT
+                        ):
+                            arg_strings.append("{}('{}', {}, {})".format(
+                                constructor,
+                                arg_name,
+                                strip_quotes(self.format(arg_type)),
+                                arg_kind in (ARG_NAMED, ARG_NAMED_OPT)))
+                        else:
+                            arg_strings.append("{}({})".format(
+                                constructor,
+                                arg_name))
+                return 'Callable[[{}], {}]'.format(", ".join(arg_strings), return_type)
             else:
                 # Use a simple representation for function types; proper
                 # function types may result in long and difficult-to-read

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1213,6 +1213,8 @@ ARG_STAR = 2  # type: int
 ARG_NAMED = 3  # type: int
 # **arg argument
 ARG_STAR2 = 4  # type: int
+# In an argument list, keyword-only and also optional
+ARG_NAMED_OPT = 5
 
 
 class CallExpr(Expression):

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -70,7 +70,6 @@ op_comp = set([
 
 none = Token('')  # Empty token
 
-
 def parse(source: Union[str, bytes],
           fnam: str,
           errors: Errors,
@@ -415,6 +414,11 @@ class Parser:
 
             arg_kinds = [arg.kind for arg in args]
             arg_names = [arg.variable.name() for arg in args]
+            # for overloads of special methods, let people name their arguments
+            # whatever they want, and don't let them call those functions with
+            # arguments by name.
+            if _special_function_elide_names(name):
+                arg_names = [None]*len(arg_names)
 
             body, comment_type = self.parse_block(allow_type=True)
             # Potentially insert extra assignment statements to the beginning of the
@@ -531,10 +535,11 @@ class Parser:
         try:
             name_tok = self.expect_type(Name)
             name = name_tok.string
+            include_names = not _special_function_elide_names(name)
 
             self.errors.push_function(name)
 
-            args, typ, extra_stmts = self.parse_args(no_type_checks)
+            args, typ, extra_stmts = self.parse_args(no_type_checks, include_names)
         except ParseError:
             if not isinstance(self.current(), Break):
                 self.ind -= 1  # Kludge: go back to the Break token
@@ -545,9 +550,11 @@ class Parser:
 
         return (name, args, typ, False, extra_stmts)
 
-    def parse_args(self, no_type_checks: bool=False) -> Tuple[List[Argument],
-                                                              CallableType,
-                                                              List[AssignmentStmt]]:
+    def parse_args(self,
+                   no_type_checks: bool=False,
+                   include_names: bool=True) -> Tuple[List[Argument],
+                                                  CallableType,
+                                                  List[AssignmentStmt]]:
         """Parse a function signature (...) [-> t].
 
         See parse_arg_list for an explanation of the final tuple item.
@@ -573,18 +580,24 @@ class Parser:
         self.verify_argument_kinds(arg_kinds, lparen.line, lparen.column)
 
         annotation = self.build_func_annotation(
-            ret_type, args, lparen.line, lparen.column)
+            ret_type, args, lparen.line, lparen.column, include_names=include_names)
 
         return args, annotation, extra_stmts
 
-    def build_func_annotation(self, ret_type: Type, args: List[Argument],
-            line: int, column: int, is_default_ret: bool = False) -> CallableType:
+    def build_func_annotation(self,
+                              ret_type: Type,
+                              args: List[Argument],
+                              line: int,
+                              column: int,
+                              is_default_ret: bool = False,
+                              *,
+                              include_names: bool = True) -> CallableType:
         arg_types = [arg.type_annotation for arg in args]
         # Are there any type annotations?
         if ((ret_type and not is_default_ret)
                 or arg_types != [None] * len(arg_types)):
             # Yes. Construct a type for the function signature.
-            return self.construct_function_type(args, ret_type, line, column)
+            return self.construct_function_type(args, ret_type, line, column, include_names)
         else:
             return None
 
@@ -812,8 +825,12 @@ class Parser:
                 self.fail('Invalid argument list', line, column)
             found.add(kind)
 
-    def construct_function_type(self, args: List[Argument], ret_type: Type,
-                                line: int, column: int) -> CallableType:
+    def construct_function_type(self,
+                                args: List[Argument],
+                                ret_type: Type,
+                                line: int,
+                                column: int,
+                                include_names: bool=True) -> CallableType:
         # Complete the type annotation by replacing omitted types with 'Any'.
         arg_types = [arg.type_annotation for arg in args]
         for i in range(len(arg_types)):
@@ -822,7 +839,10 @@ class Parser:
         if ret_type is None:
             ret_type = AnyType(implicit=True)
         arg_kinds = [arg.kind for arg in args]
-        arg_names = [arg.variable.name() for arg in args]
+        if include_names:
+            arg_names = [arg.variable.name() for arg in args]
+        else:
+            arg_names = [None]*len(args)
         return CallableType(arg_types, arg_kinds, arg_names, ret_type, None, name=None,
                         variables=None, line=line, column=column)
 
@@ -1937,6 +1957,10 @@ class Parser:
         else:
             return None
 
+def _special_function_elide_names(name: str) -> bool:
+    if name == "__init__" or name == "__new__":
+        return False
+    return name.startswith("__") and name.endswith("__")
 
 class ParseError(Exception): pass
 

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -3,6 +3,7 @@
 Constructs a parse tree (abstract syntax tree) based on a string
 representing a source file. Performs only minimal semantic checks.
 """
+import traceback
 
 import re
 
@@ -1896,6 +1897,7 @@ class Parser:
         try:
             typ, self.ind = parse_type(self.tok, self.ind)
         except TypeParseError as e:
+            traceback.print_stack()
             self.parse_error_at(e.token, reason=e.message)
             raise ParseError()
         return typ

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -840,7 +840,9 @@ class Parser:
             ret_type = AnyType(implicit=True)
         arg_kinds = [arg.kind for arg in args]
         if include_names:
-            arg_names = [arg.variable.name() for arg in args]
+            arg_names = [arg.variable.name()
+                         if not arg.variable.name().startswith('__') else None
+                         for arg in args]
         else:
             arg_names = [None]*len(args)
         return CallableType(arg_types, arg_kinds, arg_names, ret_type, None, name=None,

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -2,7 +2,7 @@ from typing import Sequence
 
 from mypy.types import (
     Type, UnboundType, ErrorType, AnyType, NoneTyp, Void, TupleType, UnionType, CallableType,
-    TypeVarType, Instance, TypeVisitor, ErasedType, TypeList, Overloaded, PartialType,
+    TypeVarType, Instance, TypeVisitor, ErasedType, ArgumentList, Overloaded, PartialType,
     DeletedType, UninhabitedType, TypeType
 )
 
@@ -58,7 +58,7 @@ class SameTypeVisitor(TypeVisitor[bool]):
     def visit_error_type(self, left: ErrorType) -> bool:
         return False
 
-    def visit_type_list(self, t: TypeList) -> bool:
+    def visit_type_list(self, t: ArgumentList) -> bool:
         assert False, 'Not supported'
 
     def visit_any(self, left: AnyType) -> bool:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -71,7 +71,7 @@ from mypy.traverser import TraverserVisitor
 from mypy.errors import Errors, report_internal_error
 from mypy.types import (
     NoneTyp, CallableType, Overloaded, Instance, Type, TypeVarType, AnyType,
-    FunctionLike, UnboundType, TypeList, TypeVarDef,
+    FunctionLike, UnboundType, ArgumentList, TypeVarDef,
     TupleType, UnionType, StarType, EllipsisType, function_type)
 from mypy.nodes import implicit_module_attrs
 from mypy.typeanal import TypeAnalyser, TypeAnalyserPass3, analyze_type_alias
@@ -396,8 +396,8 @@ class SemanticAnalyzer(NodeVisitor):
                 result.append((name, node.node))
             for arg in type.args:
                 result.extend(self.find_type_variables_in_type(arg))
-        elif isinstance(type, TypeList):
-            for item in type.items:
+        elif isinstance(type, ArgumentList):
+            for item in type.types:
                 result.extend(self.find_type_variables_in_type(item))
         elif isinstance(type, UnionType):
             for item in type.items:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -240,7 +240,6 @@ class SubtypeVisitor(TypeVisitor[bool]):
 def is_callable_subtype(left: CallableType, right: CallableType,
                         ignore_return: bool = False) -> bool:
     """Is left a subtype of right?"""
-    # TODO: Support named arguments, **args, etc.
     # Non-type cannot be a subtype of type.
     if right.is_type_obj() and not left.is_type_obj():
         return False

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Callable
 from mypy.types import (
     Type, AnyType, UnboundType, TypeVisitor, ErrorType, Void, NoneTyp,
     Instance, TypeVarType, CallableType, TupleType, UnionType, Overloaded,
-    ErasedType, TypeList, PartialType, DeletedType, UninhabitedType, TypeType, is_named_instance
+    ErasedType, ArgumentList, PartialType, DeletedType, UninhabitedType, TypeType, is_named_instance
 )
 import mypy.applytype
 import mypy.constraints
@@ -91,7 +91,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
     def visit_error_type(self, left: ErrorType) -> bool:
         return False
 
-    def visit_type_list(self, t: TypeList) -> bool:
+    def visit_type_list(self, t: ArgumentList) -> bool:
         assert False, 'Not supported'
 
     def visit_any(self, left: AnyType) -> bool:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -255,8 +255,8 @@ class TypeAnalyser(TypeVisitor[Type]):
                 # Callable[[ARG, ...], RET] (ordinary callable type)
                 args = t.args[0].types
                 return CallableType(self.anal_array(args),
-                                    [nodes.ARG_POS] * len(args),
-                                    [None] * len(args),
+                                    t.args[0].kinds,
+                                    t.args[0].names,
                                     ret_type=ret_type,
                                     fallback=fallback)
             elif isinstance(t.args[0], EllipsisType):

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -4,7 +4,7 @@ from typing import Callable, cast, List
 
 from mypy.types import (
     Type, UnboundType, TypeVarType, TupleType, UnionType, Instance,
-    AnyType, CallableType, Void, NoneTyp, DeletedType, TypeList, TypeVarDef, TypeVisitor,
+    AnyType, CallableType, Void, NoneTyp, DeletedType, ArgumentList, TypeVarDef, TypeVisitor,
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType
 )
 from mypy.nodes import (
@@ -196,7 +196,7 @@ class TypeAnalyser(TypeVisitor[Type]):
     def visit_deleted_type(self, t: DeletedType) -> Type:
         return t
 
-    def visit_type_list(self, t: TypeList) -> Type:
+    def visit_type_list(self, t: ArgumentList) -> Type:
         self.fail('Invalid type', t)
         return AnyType()
 
@@ -251,9 +251,9 @@ class TypeAnalyser(TypeVisitor[Type]):
                                 is_ellipsis_args=True)
         elif len(t.args) == 2:
             ret_type = t.args[1].accept(self)
-            if isinstance(t.args[0], TypeList):
+            if isinstance(t.args[0], ArgumentList):
                 # Callable[[ARG, ...], RET] (ordinary callable type)
-                args = t.args[0].items
+                args = t.args[0].types
                 return CallableType(self.anal_array(args),
                                     [nodes.ARG_POS] * len(args),
                                     [None] * len(args),
@@ -411,7 +411,7 @@ class TypeAnalyserPass3(TypeVisitor[None]):
     def visit_deleted_type(self, t: DeletedType) -> None:
         pass
 
-    def visit_type_list(self, t: TypeList) -> None:
+    def visit_type_list(self, t: ArgumentList) -> None:
         self.fail('Invalid type', t)
 
     def visit_type_var(self, t: TypeVarType) -> None:

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -22,220 +22,220 @@ class NodeVisitor(Generic[T]):
 
     # Module structure
 
-    def visit_mypy_file(self, o: 'mypy.nodes.MypyFile') -> T:
+    def visit_mypy_file(self, __o: 'mypy.nodes.MypyFile') -> T:
         pass
 
-    def visit_import(self, o: 'mypy.nodes.Import') -> T:
+    def visit_import(self, __o: 'mypy.nodes.Import') -> T:
         pass
 
-    def visit_import_from(self, o: 'mypy.nodes.ImportFrom') -> T:
+    def visit_import_from(self, __o: 'mypy.nodes.ImportFrom') -> T:
         pass
 
-    def visit_import_all(self, o: 'mypy.nodes.ImportAll') -> T:
+    def visit_import_all(self, __o: 'mypy.nodes.ImportAll') -> T:
         pass
 
     # Definitions
 
-    def visit_func_def(self, o: 'mypy.nodes.FuncDef') -> T:
+    def visit_func_def(self, __o: 'mypy.nodes.FuncDef') -> T:
         pass
 
     def visit_overloaded_func_def(self,
-                                  o: 'mypy.nodes.OverloadedFuncDef') -> T:
+                                  __o: 'mypy.nodes.OverloadedFuncDef') -> T:
         pass
 
-    def visit_class_def(self, o: 'mypy.nodes.ClassDef') -> T:
+    def visit_class_def(self, __o: 'mypy.nodes.ClassDef') -> T:
         pass
 
-    def visit_global_decl(self, o: 'mypy.nodes.GlobalDecl') -> T:
+    def visit_global_decl(self, __o: 'mypy.nodes.GlobalDecl') -> T:
         pass
 
-    def visit_nonlocal_decl(self, o: 'mypy.nodes.NonlocalDecl') -> T:
+    def visit_nonlocal_decl(self, __o: 'mypy.nodes.NonlocalDecl') -> T:
         pass
 
-    def visit_decorator(self, o: 'mypy.nodes.Decorator') -> T:
+    def visit_decorator(self, __o: 'mypy.nodes.Decorator') -> T:
         pass
 
-    def visit_var(self, o: 'mypy.nodes.Var') -> T:
+    def visit_var(self, __o: 'mypy.nodes.Var') -> T:
         pass
 
     # Statements
 
-    def visit_block(self, o: 'mypy.nodes.Block') -> T:
+    def visit_block(self, __o: 'mypy.nodes.Block') -> T:
         pass
 
-    def visit_expression_stmt(self, o: 'mypy.nodes.ExpressionStmt') -> T:
+    def visit_expression_stmt(self, __o: 'mypy.nodes.ExpressionStmt') -> T:
         pass
 
-    def visit_assignment_stmt(self, o: 'mypy.nodes.AssignmentStmt') -> T:
+    def visit_assignment_stmt(self, __o: 'mypy.nodes.AssignmentStmt') -> T:
         pass
 
     def visit_operator_assignment_stmt(self,
-                                       o: 'mypy.nodes.OperatorAssignmentStmt') -> T:
+                                       __o: 'mypy.nodes.OperatorAssignmentStmt') -> T:
         pass
 
-    def visit_while_stmt(self, o: 'mypy.nodes.WhileStmt') -> T:
+    def visit_while_stmt(self, __o: 'mypy.nodes.WhileStmt') -> T:
         pass
 
-    def visit_for_stmt(self, o: 'mypy.nodes.ForStmt') -> T:
+    def visit_for_stmt(self, __o: 'mypy.nodes.ForStmt') -> T:
         pass
 
-    def visit_return_stmt(self, o: 'mypy.nodes.ReturnStmt') -> T:
+    def visit_return_stmt(self, __o: 'mypy.nodes.ReturnStmt') -> T:
         pass
 
-    def visit_assert_stmt(self, o: 'mypy.nodes.AssertStmt') -> T:
+    def visit_assert_stmt(self, __o: 'mypy.nodes.AssertStmt') -> T:
         pass
 
-    def visit_del_stmt(self, o: 'mypy.nodes.DelStmt') -> T:
+    def visit_del_stmt(self, __o: 'mypy.nodes.DelStmt') -> T:
         pass
 
-    def visit_if_stmt(self, o: 'mypy.nodes.IfStmt') -> T:
+    def visit_if_stmt(self, __o: 'mypy.nodes.IfStmt') -> T:
         pass
 
-    def visit_break_stmt(self, o: 'mypy.nodes.BreakStmt') -> T:
+    def visit_break_stmt(self, __o: 'mypy.nodes.BreakStmt') -> T:
         pass
 
-    def visit_continue_stmt(self, o: 'mypy.nodes.ContinueStmt') -> T:
+    def visit_continue_stmt(self, __o: 'mypy.nodes.ContinueStmt') -> T:
         pass
 
-    def visit_pass_stmt(self, o: 'mypy.nodes.PassStmt') -> T:
+    def visit_pass_stmt(self, __o: 'mypy.nodes.PassStmt') -> T:
         pass
 
-    def visit_raise_stmt(self, o: 'mypy.nodes.RaiseStmt') -> T:
+    def visit_raise_stmt(self, __o: 'mypy.nodes.RaiseStmt') -> T:
         pass
 
-    def visit_try_stmt(self, o: 'mypy.nodes.TryStmt') -> T:
+    def visit_try_stmt(self, __o: 'mypy.nodes.TryStmt') -> T:
         pass
 
-    def visit_with_stmt(self, o: 'mypy.nodes.WithStmt') -> T:
+    def visit_with_stmt(self, __o: 'mypy.nodes.WithStmt') -> T:
         pass
 
-    def visit_print_stmt(self, o: 'mypy.nodes.PrintStmt') -> T:
+    def visit_print_stmt(self, __o: 'mypy.nodes.PrintStmt') -> T:
         pass
 
-    def visit_exec_stmt(self, o: 'mypy.nodes.ExecStmt') -> T:
+    def visit_exec_stmt(self, __o: 'mypy.nodes.ExecStmt') -> T:
         pass
 
     # Expressions
 
-    def visit_int_expr(self, o: 'mypy.nodes.IntExpr') -> T:
+    def visit_int_expr(self, __o: 'mypy.nodes.IntExpr') -> T:
         pass
 
-    def visit_str_expr(self, o: 'mypy.nodes.StrExpr') -> T:
+    def visit_str_expr(self, __o: 'mypy.nodes.StrExpr') -> T:
         pass
 
-    def visit_bytes_expr(self, o: 'mypy.nodes.BytesExpr') -> T:
+    def visit_bytes_expr(self, __o: 'mypy.nodes.BytesExpr') -> T:
         pass
 
-    def visit_unicode_expr(self, o: 'mypy.nodes.UnicodeExpr') -> T:
+    def visit_unicode_expr(self, __o: 'mypy.nodes.UnicodeExpr') -> T:
         pass
 
-    def visit_float_expr(self, o: 'mypy.nodes.FloatExpr') -> T:
+    def visit_float_expr(self, __o: 'mypy.nodes.FloatExpr') -> T:
         pass
 
-    def visit_complex_expr(self, o: 'mypy.nodes.ComplexExpr') -> T:
+    def visit_complex_expr(self, __o: 'mypy.nodes.ComplexExpr') -> T:
         pass
 
-    def visit_ellipsis(self, o: 'mypy.nodes.EllipsisExpr') -> T:
+    def visit_ellipsis(self, __o: 'mypy.nodes.EllipsisExpr') -> T:
         pass
 
-    def visit_star_expr(self, o: 'mypy.nodes.StarExpr') -> T:
+    def visit_star_expr(self, __o: 'mypy.nodes.StarExpr') -> T:
         pass
 
-    def visit_name_expr(self, o: 'mypy.nodes.NameExpr') -> T:
+    def visit_name_expr(self, __o: 'mypy.nodes.NameExpr') -> T:
         pass
 
-    def visit_member_expr(self, o: 'mypy.nodes.MemberExpr') -> T:
+    def visit_member_expr(self, __o: 'mypy.nodes.MemberExpr') -> T:
         pass
 
-    def visit_yield_from_expr(self, o: 'mypy.nodes.YieldFromExpr') -> T:
+    def visit_yield_from_expr(self, __o: 'mypy.nodes.YieldFromExpr') -> T:
         pass
 
-    def visit_yield_expr(self, o: 'mypy.nodes.YieldExpr') -> T:
+    def visit_yield_expr(self, __o: 'mypy.nodes.YieldExpr') -> T:
         pass
 
-    def visit_call_expr(self, o: 'mypy.nodes.CallExpr') -> T:
+    def visit_call_expr(self, __o: 'mypy.nodes.CallExpr') -> T:
         pass
 
-    def visit_op_expr(self, o: 'mypy.nodes.OpExpr') -> T:
+    def visit_op_expr(self, __o: 'mypy.nodes.OpExpr') -> T:
         pass
 
-    def visit_comparison_expr(self, o: 'mypy.nodes.ComparisonExpr') -> T:
+    def visit_comparison_expr(self, __o: 'mypy.nodes.ComparisonExpr') -> T:
         pass
 
-    def visit_cast_expr(self, o: 'mypy.nodes.CastExpr') -> T:
+    def visit_cast_expr(self, __o: 'mypy.nodes.CastExpr') -> T:
         pass
 
-    def visit_reveal_type_expr(self, o: 'mypy.nodes.RevealTypeExpr') -> T:
+    def visit_reveal_type_expr(self, __o: 'mypy.nodes.RevealTypeExpr') -> T:
         pass
 
-    def visit_super_expr(self, o: 'mypy.nodes.SuperExpr') -> T:
+    def visit_super_expr(self, __o: 'mypy.nodes.SuperExpr') -> T:
         pass
 
-    def visit_unary_expr(self, o: 'mypy.nodes.UnaryExpr') -> T:
+    def visit_unary_expr(self, __o: 'mypy.nodes.UnaryExpr') -> T:
         pass
 
-    def visit_list_expr(self, o: 'mypy.nodes.ListExpr') -> T:
+    def visit_list_expr(self, __o: 'mypy.nodes.ListExpr') -> T:
         pass
 
-    def visit_dict_expr(self, o: 'mypy.nodes.DictExpr') -> T:
+    def visit_dict_expr(self, __o: 'mypy.nodes.DictExpr') -> T:
         pass
 
-    def visit_tuple_expr(self, o: 'mypy.nodes.TupleExpr') -> T:
+    def visit_tuple_expr(self, __o: 'mypy.nodes.TupleExpr') -> T:
         pass
 
-    def visit_set_expr(self, o: 'mypy.nodes.SetExpr') -> T:
+    def visit_set_expr(self, __o: 'mypy.nodes.SetExpr') -> T:
         pass
 
-    def visit_index_expr(self, o: 'mypy.nodes.IndexExpr') -> T:
+    def visit_index_expr(self, __o: 'mypy.nodes.IndexExpr') -> T:
         pass
 
-    def visit_type_application(self, o: 'mypy.nodes.TypeApplication') -> T:
+    def visit_type_application(self, __o: 'mypy.nodes.TypeApplication') -> T:
         pass
 
-    def visit_func_expr(self, o: 'mypy.nodes.FuncExpr') -> T:
+    def visit_func_expr(self, __o: 'mypy.nodes.FuncExpr') -> T:
         pass
 
-    def visit_list_comprehension(self, o: 'mypy.nodes.ListComprehension') -> T:
+    def visit_list_comprehension(self, __o: 'mypy.nodes.ListComprehension') -> T:
         pass
 
-    def visit_set_comprehension(self, o: 'mypy.nodes.SetComprehension') -> T:
+    def visit_set_comprehension(self, __o: 'mypy.nodes.SetComprehension') -> T:
         pass
 
-    def visit_dictionary_comprehension(self, o: 'mypy.nodes.DictionaryComprehension') -> T:
+    def visit_dictionary_comprehension(self, __o: 'mypy.nodes.DictionaryComprehension') -> T:
         pass
 
-    def visit_generator_expr(self, o: 'mypy.nodes.GeneratorExpr') -> T:
+    def visit_generator_expr(self, __o: 'mypy.nodes.GeneratorExpr') -> T:
         pass
 
-    def visit_slice_expr(self, o: 'mypy.nodes.SliceExpr') -> T:
+    def visit_slice_expr(self, __o: 'mypy.nodes.SliceExpr') -> T:
         pass
 
-    def visit_conditional_expr(self, o: 'mypy.nodes.ConditionalExpr') -> T:
+    def visit_conditional_expr(self, __o: 'mypy.nodes.ConditionalExpr') -> T:
         pass
 
-    def visit_backquote_expr(self, o: 'mypy.nodes.BackquoteExpr') -> T:
+    def visit_backquote_expr(self, __o: 'mypy.nodes.BackquoteExpr') -> T:
         pass
 
-    def visit_type_var_expr(self, o: 'mypy.nodes.TypeVarExpr') -> T:
+    def visit_type_var_expr(self, __o: 'mypy.nodes.TypeVarExpr') -> T:
         pass
 
-    def visit_type_alias_expr(self, o: 'mypy.nodes.TypeAliasExpr') -> T:
+    def visit_type_alias_expr(self, __o: 'mypy.nodes.TypeAliasExpr') -> T:
         pass
 
-    def visit_namedtuple_expr(self, o: 'mypy.nodes.NamedTupleExpr') -> T:
+    def visit_namedtuple_expr(self, __o: 'mypy.nodes.NamedTupleExpr') -> T:
         pass
 
-    def visit_typeddict_expr(self, o: 'mypy.nodes.TypedDictExpr') -> T:
+    def visit_typeddict_expr(self, __o: 'mypy.nodes.TypedDictExpr') -> T:
         pass
 
-    def visit_newtype_expr(self, o: 'mypy.nodes.NewTypeExpr') -> T:
+    def visit_newtype_expr(self, __o: 'mypy.nodes.NewTypeExpr') -> T:
         pass
 
-    def visit__promote_expr(self, o: 'mypy.nodes.PromoteExpr') -> T:
+    def visit__promote_expr(self, __o: 'mypy.nodes.PromoteExpr') -> T:
         pass
 
-    def visit_await_expr(self, o: 'mypy.nodes.AwaitExpr') -> T:
+    def visit_await_expr(self, __o: 'mypy.nodes.AwaitExpr') -> T:
         pass
 
-    def visit_temp_node(self, o: 'mypy.nodes.TempNode') -> T:
+    def visit_temp_node(self, __o: 'mypy.nodes.TempNode') -> T:
         pass

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1230,9 +1230,9 @@ class D:
     def __getattr__(self, x: str) -> None: pass
 [out]
 main: note: In member "__getattr__" of class "B":
-main:4: error: Invalid signature "def (self: __main__.B, x: __main__.A) -> __main__.B"
+main:4: error: Invalid signature "def (__main__.B, __main__.A) -> __main__.B"
 main: note: In member "__getattr__" of class "C":
-main:6: error: Invalid signature "def (self: __main__.C, x: builtins.str, y: builtins.str) -> __main__.C"
+main:6: error: Invalid signature "def (__main__.C, builtins.str, builtins.str) -> __main__.C"
 
 
 -- CallableType objects

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1285,6 +1285,50 @@ from mypy_extensions import Arg
 def a(f: Callable[[Arg('x', int)], int]):
     f(x=4)
     f(5)
+    f(y=3) # E: Unexpected keyword argument "y"
+
+[builtins fixtures/dict.pyi]
+
+[out]
+main: note: In function "a":
+
+[case testCallableWithOptionalArg]
+from typing import Callable
+from mypy_extensions import DefaultArg
+
+def a(f: Callable[[DefaultArg('x', int)], int]):
+    f(x=4)
+    f(2)
+    f()
+    f(y=3) # E: Unexpected keyword argument "y"
+    f("foo") # E: Argument 1 has incompatible type "str"; expected "int"
+
+[builtins fixtures/dict.pyi]
+
+[out]
+main: note: In function "a":
+
+[case testCallableArgKindSubtyping]
+from typing import Callable
+from mypy_extensions import Arg, DefaultArg
+
+int_str_fun = None # type: Callable[[int, str], str]
+int_opt_str_fun = None # type: Callable[[int, DefaultArg(None, str)], str]
+int_named_str_fun = None # type: Callable[[int, Arg('s', str)], str]
+
+def isf(ii: int, ss: str) -> str:
+    return ss
+
+def iosf(i: int, s: str = "bar") -> str:
+    return s
+
+int_str_fun = isf
+int_opt_str_fun = iosf
+int_str_fun = iosf
+int_opt_str_fun = isf # E: Incompatible types in assignment (expression has type Callable[[Arg('ii', int, False), Arg('ss', str, False)], str], variable has type Callable[[int, DefaultArg('None', str, False)], str])
+
+int_named_str_fun = isf # E: Incompatible types in assignment (expression has type Callable[[Arg('ii', int, False), Arg('ss', str, False)], str], variable has type Callable[[int, Arg('s', str, False)], str])
+int_named_str_fun = iosf
 
 [builtins fixtures/dict.pyi]
 
@@ -1470,8 +1514,10 @@ class A(Generic[t]):
 [case testRedefineFunction]
 def f(x): pass
 def g(x, y): pass
-def h(y): pass
+def h(x): pass
+def j(y): pass
 f = h
+f = j # E: Incompatible types in assignment (expression has type Callable[[Arg('y', Any, False)], Any], variable has type Callable[[Arg('x', Any, False)], Any])
 f = g # E: Incompatible types in assignment (expression has type Callable[[Any, Any], Any], variable has type Callable[[Any], Any])
 
 [case testRedefineFunction2]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1275,6 +1275,18 @@ f('x') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 g('x')
 g(1) # E: Argument 1 to "g" has incompatible type "int"; expected "str"
 
+-- Callable with specific arg list
+-- -------------------------------
+
+[case testCallableWithNamedArg]
+from typing import Callable
+from mypy_extensions import Arg
+
+def a(f: Callable[[Arg('x', int)], int]):
+    f(x=4)
+    f(5)
+
+[builtins fixtures/dict.pyi]
 
 -- Callable[..., T]
 -- ----------------

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1322,7 +1322,12 @@ def isf(ii: int, ss: str) -> str:
 def iosf(i: int, s: str = "bar") -> str:
     return s
 
+def isf_unnamed(__i: int, __s: str) -> str:
+    return __s
+
 int_str_fun = isf
+int_str_fun = isf_unnamed
+int_named_str_fun = isf_unnamed # E: Incompatible types in assignment (expression has type Callable[[int, str], str], variable has type Callable[[int, Arg('s', str, False)], str])
 int_opt_str_fun = iosf
 int_str_fun = iosf
 int_opt_str_fun = isf # E: Incompatible types in assignment (expression has type Callable[[Arg('ii', int, False), Arg('ss', str, False)], str], variable has type Callable[[int, DefaultArg('None', str, False)], str])

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -590,7 +590,7 @@ try:
 except:
     f = g
 [file m.py]
-def f(y): pass
+def f(x): pass
 
 [case testImportFunctionAndAssignIncompatible]
 try:

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -358,7 +358,7 @@ x = f  # type: Callable[[], None]
 from typing import Callable, Optional
 T = Optional[Callable[..., None]]
 
-[case testAnyTypeInPartialTypeList]
+[case testAnyTypeInPartialArgumentList]
 # flags: --check-untyped-defs
 def f(): ...
 

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -23,7 +23,7 @@ from typing import Any
 class B:
   def f(self, y: 'A') -> None: pass
 class A(B):
-  def f(self, x: Any) -> None:
+  def f(self, y: Any) -> None:
     a, b = None, None # type: (A, B)
     super().f(b) # E: Argument 1 to "f" of "B" has incompatible type "B"; expected "A"
     super().f(a)

--- a/test-data/unit/fixtures/dict.pyi
+++ b/test-data/unit/fixtures/dict.pyi
@@ -32,3 +32,6 @@ class list(Iterable[T], Generic[T]): # needed by some test cases
 class tuple: pass
 class function: pass
 class float: pass
+class bool: pass
+
+class ellipsis: pass

--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -12,7 +12,7 @@ class type:
     def __call__(self, *a) -> object: pass
 class tuple(Sequence[Tco], Generic[Tco]):
     def __iter__(self) -> Iterator[Tco]: pass
-    def __getitem__(self, x: int) -> Tco: pass
+    def __getitem__(self, n: int) -> Tco: pass
 class function: pass
 
 # We need int for indexing tuples.

--- a/test-data/unit/lib-stub/mypy_extensions.pyi
+++ b/test-data/unit/lib-stub/mypy_extensions.pyi
@@ -1,6 +1,1 @@
-from typing import Dict, Type, TypeVar
-
-T = TypeVar('T')
-
-
-def TypedDict(typename: str, fields: Dict[str, Type[T]]) -> Type[dict]: ...
+typeshed/third_party/2and3/mypy_extensions.pyi

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -82,7 +82,7 @@ class Sequence(Iterable[T], Generic[T]):
 class Mapping(Generic[T, U]): pass
 
 def NewType(name: str, tp: Type[T]) -> Callable[[T], T]:
-    def new_type(x):
+    def new_type(x: T) -> T:
         return x
     return new_type
 

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -75,8 +75,9 @@ class AsyncIterator(AsyncIterable[T], Generic[T]):
     def __anext__(self) -> Awaitable[T]: pass
 
 class Sequence(Iterable[T], Generic[T]):
+    # Use int because slice isn't defined in the default test builtins
     @abstractmethod
-    def __getitem__(self, n: Any) -> T: pass
+    def __getitem__(self, n: int) -> T: pass
 
 class Mapping(Generic[T, U]): pass
 

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -2408,7 +2408,7 @@ MypyFile:1(
   AssignmentStmt:1(
     NameExpr(f)
     NameExpr(None)
-    Callable?[<TypeList >, None?]))
+    Callable?[<ArgumentList >, None?]))
 
 [case testFunctionTypeWithArgument]
 f = None # type: Callable[[str], int]
@@ -2417,7 +2417,7 @@ MypyFile:1(
   AssignmentStmt:1(
     NameExpr(f)
     NameExpr(None)
-    Callable?[<TypeList str?>, int?]))
+    Callable?[<ArgumentList str?>, int?]))
 
 [case testFunctionTypeWithTwoArguments]
 f = None # type: Callable[[a[b], x.y], List[int]]
@@ -2426,7 +2426,7 @@ MypyFile:1(
   AssignmentStmt:1(
     NameExpr(f)
     NameExpr(None)
-    Callable?[<TypeList a?[b?], x.y?>, List?[int?]]))
+    Callable?[<ArgumentList a?[b?], x.y?>, List?[int?]]))
 
 [case testFunctionTypeWithExtraComma]
 def f(x: Callable[[str,], int]): pass
@@ -2436,7 +2436,7 @@ MypyFile:1(
     f
     Args(
       Var(x))
-    def (x: Callable?[<TypeList str?>, int?]) -> Any
+    def (x: Callable?[<ArgumentList str?>, int?]) -> Any
     Block:1(
       PassStmt:1())))
 

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -834,7 +834,7 @@ Any(str, None) # E: 'Any' expects 1 argument
 Any(arg=str)   # E: 'Any' must be called with 1 positional argument
 [out]
 
-[case testTypeListAsType]
+[case testArgumentListAsType]
 def f(x:[int, str]) -> None: # E: Invalid type
     pass
 [out]


### PR DESCRIPTION
This is a draft implementation of the work discussed in https://github.com/python/typing/issues/264

Most of the subtlety was in getting the function subtyping rules (what I believe to be) right.

Unfortunately basically all the typeshed stub files violate these rules all over the place -- specifically, arguments in a function overriding a superclass function must be named the same thing, otherwise calling that function by keyword is going to fail.  So I still need to resolve that stuff.

Also I need to write a pile more tests.

Also also apparently I haven't implemented StarArg and KwArg yet.  

Actually there's a decent amount left to do.