### PR TITLE
Allow subclassing Tuple[...] outside stubs

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -810,10 +810,6 @@ class SemanticAnalyzer(NodeVisitor):
                 if info.tuple_type:
                     self.fail("Class has two incompatible bases derived from tuple", defn)
                     defn.has_incompatible_baseclass = True
-                if (not self.is_stub_file
-                        and not info.is_named_tuple
-                        and base.fallback.type.fullname() == 'builtins.tuple'):
-                    self.fail("Tuple[...] not supported as a base class outside a stub file", defn)
                 info.tuple_type = base
                 base_types.append(base.fallback)
             elif isinstance(base, Instance):

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -681,9 +681,23 @@ tmp/m.pyi:6: error: Incompatible types in assignment (expression has type "int",
 tmp/m.pyi:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/m.pyi:7: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
 
-[case testInvalidTupleBaseClass]
+[case testValidTupleBaseClass2]
 from typing import Tuple
-class A(Tuple[int, str]): pass # E: Tuple[...] not supported as a base class outside a stub file
+class A(Tuple[int, str]): pass
+
+x, y = A()
+reveal_type(x) # E: Revealed type is 'builtins.int'
+reveal_type(y) # E: Revealed type is 'builtins.str'
+
+x1 = A()[0] # type: int
+x2 = A()[1] # type: int # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+A()[2] # E: Tuple index out of range
+
+class B(Tuple[int, ...]): pass
+
+z1 = B()[0] # type: int
+z2 = B()[1] # type: str # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+B()[100]
 [builtins fixtures/tuple.pyi]
 [out]
 
@@ -712,7 +726,6 @@ class Test(Generic[T], Tuple[T]): pass
 x = Test() # type: Test[int]
 [builtins fixtures/tuple.pyi]
 [out]
-main:3: error: Tuple[...] not supported as a base class outside a stub file
 main:4: error: Generic tuple types not supported
 
 


### PR DESCRIPTION
Currently, mypy allows declaring tuple types only in stubs:
```python
# stub.pyi
class C(Tuple[int, str]):
    ...
# main.py
from stub import C
x: str = C()[1]  # OK
y: int = C()[1]  # Error, incompatible types
C()[2]  # Error, index out of range
```
It looks like the only reason for existing limitation was that ``typing.py`` didn't support this at runtime.
Now this is supported by ``typing.py``, and in this PR I propose to allow such declarations also outside stubs.

@JukkaL what do you think?