### PR TITLE
Selftype with TupleType

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -323,8 +323,9 @@ class ExpressionChecker:
                     callee)
         elif isinstance(callee, Instance):
             call_function = analyze_member_access('__call__', callee, context,
-                                         False, False, False, self.named_type,
-                                         self.not_ready_callback, self.msg, chk=self.chk)
+                                                  False, False, False, self.named_type,
+                                                  self.not_ready_callback, self.msg,
+                                                  original_type=callee, chk=self.chk)
             return self.check_call(call_function, args, arg_kinds, context, arg_names,
                                    callable_node, arg_messages)
         elif isinstance(callee, TypeVarType):
@@ -896,10 +897,11 @@ class ExpressionChecker:
             return self.analyze_ref_expr(e)
         else:
             # This is a reference to a non-module attribute.
-            return analyze_member_access(e.name, self.accept(e.expr), e,
+            original_type = self.accept(e.expr)
+            return analyze_member_access(e.name, original_type, e,
                                          is_lvalue, False, False,
                                          self.named_type, self.not_ready_callback, self.msg,
-                                         chk=self.chk)
+                                         original_type=original_type, chk=self.chk)
 
     def analyze_external_member_access(self, member: str, base_type: Type,
                                        context: Context) -> Type:
@@ -909,7 +911,7 @@ class ExpressionChecker:
         # TODO remove; no private definitions in mypy
         return analyze_member_access(member, base_type, context, False, False, False,
                                      self.named_type, self.not_ready_callback, self.msg,
-                                     chk=self.chk)
+                                     original_type=base_type, chk=self.chk)
 
     def visit_int_expr(self, e: IntExpr) -> Type:
         """Type check an integer literal (trivial)."""
@@ -1070,7 +1072,7 @@ class ExpressionChecker:
         """
         method_type = analyze_member_access(method, base_type, context, False, False, True,
                                             self.named_type, self.not_ready_callback, local_errors,
-                                            chk=self.chk)
+                                            original_type=base_type, chk=self.chk)
         return self.check_call(method_type, [arg], [nodes.ARG_POS],
                                context, arg_messages=local_errors)
 
@@ -1670,8 +1672,8 @@ class ExpressionChecker:
                                                  is_lvalue=False, is_super=True, is_operator=False,
                                                  builtin_type=self.named_type,
                                                  not_ready_callback=self.not_ready_callback,
-                                                 msg=self.msg, override_info=base, chk=self.chk,
-                                                 original_type=declared_self)
+                                                 msg=self.msg, override_info=base,
+                                                 original_type=declared_self, chk=self.chk)
             assert False, 'unreachable'
         else:
             # Invalid super. This has been reported by the semantic analyzer.

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -108,14 +108,15 @@ def analyze_member_access(name: str,
         msg.disable_type_names += 1
         results = [analyze_member_access(name, subtype, node, is_lvalue, is_super,
                                          is_operator, builtin_type, not_ready_callback, msg,
-                                         chk=chk)
+                                         original_type=typ, chk=chk)
                    for subtype in typ.items]
         msg.disable_type_names -= 1
         return UnionType.make_simplified_union(results)
     elif isinstance(typ, TupleType):
         # Actually look up from the fallback instance type.
         return analyze_member_access(name, typ.fallback, node, is_lvalue, is_super,
-                                     is_operator, builtin_type, not_ready_callback, msg, chk=chk)
+                                     is_operator, builtin_type, not_ready_callback, msg,
+                                     original_type=typ, chk=chk)
     elif isinstance(typ, FunctionLike) and typ.is_type_obj():
         # Class attribute.
         # TODO super?
@@ -573,7 +574,7 @@ def bind_self(method: F, original_type: Type = None) -> F:
         return cast(F, func)
     if func.arg_kinds[0] == ARG_STAR:
         # The signature is of the form 'def foo(*args, ...)'.
-        # In this case we shouldn'func drop the first arg,
+        # In this case we shouldn't drop the first arg,
         # since func will be absorbed by the *args.
 
         # TODO: infer bounds on the type of *args?

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1815,15 +1815,15 @@ class SemanticAnalyzer(NodeVisitor):
             arg_kinds = [arg.kind for arg in args]
             signature = CallableType(types, arg_kinds, items, ret, function_type,
                                      name=name or info.name() + '.' + funcname)
+            signature.variables = [tvd]
             func = FuncDef(funcname, args, Block([]), typ=signature)
             func.info = info
-            func.type.variables = [tvd]
             func.is_class = is_classmethod
             if is_classmethod:
                 v = Var(funcname, signature)
                 v.is_classmethod = True
                 v.info = info
-                dec = Decorator(func, NameExpr('classmethod'), v)
+                dec = Decorator(func, [NameExpr('classmethod')], v)
                 info.names[funcname] = SymbolTableNode(MDEF, dec)
             else:
                 info.names[funcname] = SymbolTableNode(MDEF, func)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1799,7 +1799,7 @@ class SemanticAnalyzer(NodeVisitor):
         add_field(Var('_field_types', dictype), is_initialized_in_class=True)
         add_field(Var('_source', strtype), is_initialized_in_class=True)
 
-        tvd = TypeVarDef('NT', 1, [], TupleType(types, fill_typevars(info)))
+        tvd = TypeVarDef('NT', 1, [], info.tuple_type)
         selftype = TypeVarType(tvd)
 
         def add_method(funcname: str, ret: Type, args: List[Argument], name=None,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1799,7 +1799,7 @@ class SemanticAnalyzer(NodeVisitor):
         add_field(Var('_field_types', dictype), is_initialized_in_class=True)
         add_field(Var('_source', strtype), is_initialized_in_class=True)
 
-        tvd = TypeVarDef('NT', 1, [], fill_typevars(info))
+        tvd = TypeVarDef('NT', 1, [], TupleType(types, fill_typevars(info)))
         selftype = TypeVarType(tvd)
 
         def add_method(funcname: str, ret: Type, args: List[Argument], name=None,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -71,7 +71,7 @@ from mypy.traverser import TraverserVisitor
 from mypy.errors import Errors, report_internal_error
 from mypy.types import (
     NoneTyp, CallableType, Overloaded, Instance, Type, TypeVarType, AnyType,
-    FunctionLike, UnboundType, TypeList, TypeVarDef,
+    FunctionLike, UnboundType, TypeList, TypeVarDef, TypeType,
     TupleType, UnionType, StarType, EllipsisType, function_type)
 from mypy.nodes import implicit_module_attrs
 from mypy.typeanal import TypeAnalyser, TypeAnalyserPass3, analyze_type_alias
@@ -1799,31 +1799,41 @@ class SemanticAnalyzer(NodeVisitor):
         add_field(Var('_field_types', dictype), is_initialized_in_class=True)
         add_field(Var('_source', strtype), is_initialized_in_class=True)
 
-        # TODO: SelfType should be bind to actual 'self'
-        this_type = fill_typevars(info)
+        tvd = TypeVarDef('NT', 1, [], fill_typevars(info))
+        selftype = TypeVarType(tvd)
 
         def add_method(funcname: str, ret: Type, args: List[Argument], name=None,
                        is_classmethod=False) -> None:
-            if not is_classmethod:
-                args = [Argument(Var('self'), this_type, None, ARG_POS)] + args
+            if is_classmethod:
+                first = [Argument(Var('cls'), TypeType(selftype), None, ARG_POS)]
+            else:
+                first = [Argument(Var('self'), selftype, None, ARG_POS)]
+            args = first + args
+
             types = [arg.type_annotation for arg in args]
             items = [arg.variable.name() for arg in args]
             arg_kinds = [arg.kind for arg in args]
             signature = CallableType(types, arg_kinds, items, ret, function_type,
                                      name=name or info.name() + '.' + funcname)
-            signature.is_classmethod_class = is_classmethod
             func = FuncDef(funcname, args, Block([]), typ=signature)
             func.info = info
+            func.type.variables = [tvd]
             func.is_class = is_classmethod
-            info.names[funcname] = SymbolTableNode(MDEF, func)
+            if is_classmethod:
+                v = Var(funcname, signature)
+                v.is_classmethod = True
+                v.info = info
+                dec = Decorator(func, NameExpr('classmethod'), v)
+                info.names[funcname] = SymbolTableNode(MDEF, dec)
+            else:
+                info.names[funcname] = SymbolTableNode(MDEF, func)
 
-        add_method('_replace', ret=this_type,
+        add_method('_replace', ret=selftype,
                    args=[Argument(var, var.type, EllipsisExpr(), ARG_NAMED) for var in vars])
         add_method('__init__', ret=NoneTyp(), name=info.name(),
                    args=[Argument(var, var.type, None, ARG_POS) for var in vars])
         add_method('_asdict', args=[], ret=ordereddictype)
-        # FIX: make it actual class method
-        add_method('_make', ret=this_type, is_classmethod=True,
+        add_method('_make', ret=selftype, is_classmethod=True,
                    args=[Argument(Var('iterable', iterable_type), iterable_type, None, ARG_POS),
                          Argument(Var('new'), AnyType(), EllipsisExpr(), ARG_NAMED),
                          Argument(Var('len'), AnyType(), EllipsisExpr(), ARG_NAMED)])

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -283,7 +283,7 @@ class X(NamedTuple):
     y: str
 
 x: X
-reveal_type(x._replace())  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
+reveal_type(x._replace())  # E: Revealed type is '__main__.X*'
 x._replace(x=5)
 x._replace(y=5)  # E: Argument 1 to X._replace has incompatible type "int"; expected "str"
 

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -283,7 +283,7 @@ class X(NamedTuple):
     y: str
 
 x: X
-reveal_type(x._replace())  # E: Revealed type is '__main__.X*'
+reveal_type(x._replace())  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
 x._replace(x=5)
 x._replace(y=5)  # E: Argument 1 to X._replace has incompatible type "int"; expected "str"
 

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -391,7 +391,7 @@ def f(x: Union[List[int], List[str], int]) -> None:
     else:
         x[0] # E: Value of type "int" is not indexable
         x + 1
-    x[0] # E: Value of type "int" is not indexable
+    x[0] # E: Value of type "Union[List[int], List[str], int]" is not indexable
     x + 1 # E: Unsupported operand types for + (likely involving Union)
 [builtins fixtures/isinstancelist.pyi]
 [out]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -258,7 +258,7 @@ from collections import namedtuple
 
 X = namedtuple('X', ['x', 'y'])
 x = None  # type: X
-reveal_type(x._replace())  # E: Revealed type is '__main__.X*'
+reveal_type(x._replace())  # E: Revealed type is 'Tuple[Any, Any, fallback=__main__.X]'
 x._replace(y=5)
 x._replace(x=3)
 x._replace(x=3, y=5)
@@ -279,7 +279,7 @@ from typing import NamedTuple
 
 X = NamedTuple('X', [('x', int), ('y', str)])
 x = None  # type: X
-reveal_type(x._replace())  # E: Revealed type is '__main__.X*'
+reveal_type(x._replace())  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
 x._replace(x=5)
 x._replace(y=5)  # E: Argument 1 to X._replace has incompatible type "int"; expected "str"
 
@@ -367,23 +367,37 @@ g(D())  # E: Argument 1 to "g" has incompatible type "D"; expected "C"
 y = None  # type: C
 y = D()  # E: Incompatible types in assignment (expression has type "D", variable has type "C")
 
-[case testNamedTupleSelfType]
+[case testNamedTupleSelfTypeMethod]
+from typing import TypeVar, NamedTuple
+
+T = TypeVar('T', bound='A')
+
+class A(NamedTuple('A', [('x', str)])):
+    def member(self: T) -> T:
+        return self
+
+class B(A):
+    pass
+
+a = None  # type: A
+a = A('').member()
+b = None  # type: B
+b = B('').member()
+a = B('')
+a = B('').member()
+
+
+[case testNamedTupleSelfTypeReplace]
 from typing import NamedTuple, TypeVar
 A = NamedTuple('A', [('x', str)])
-reveal_type(A('hello')._replace(x=''))  # E: Revealed type is '__main__.A*'
+reveal_type(A('hello')._replace(x=''))  # E: Revealed type is 'Tuple[builtins.str, fallback=__main__.A]'
 a = None  # type: A
 a = A('hello')._replace(x='')
 
 class B(A):
     pass
 
-reveal_type(B('hello')._replace(x=''))  # E: Revealed type is '__main__.B*'
+reveal_type(B('hello')._replace(x=''))  # E: Revealed type is 'Tuple[builtins.str, fallback=__main__.B]'
 b = None  # type: B
 b = B('hello')._replace(x='')
 
-T = TypeVar('T', bound='C')
-class C(B):
-    def foo(self: T) -> T: return self
-
-c = None  # type: C
-c = C('hello').foo()

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -366,3 +366,17 @@ class D(NamedTuple('D', []), A): pass
 g(D())  # E: Argument 1 to "g" has incompatible type "D"; expected "C"
 y = None  # type: C
 y = D()  # E: Incompatible types in assignment (expression has type "D", variable has type "C")
+
+[case testNamedTupleSelfType]
+from typing import NamedTuple
+A = NamedTuple('A', [('x', str)])
+reveal_type(A('hello')._replace(x=''))  # E: Revealed type is '__main__.A*'
+a = None  # type: A
+a = A('hello')._replace(x='')
+
+class B(A):
+    pass
+
+reveal_type(B('hello')._replace(x=''))  # E: Revealed type is '__main__.B*'
+b = None  # type: B
+b = B('hello')._replace(x='')

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -258,7 +258,7 @@ from collections import namedtuple
 
 X = namedtuple('X', ['x', 'y'])
 x = None  # type: X
-reveal_type(x._replace())  # E: Revealed type is 'Tuple[Any, Any, fallback=__main__.X]'
+reveal_type(x._replace())  # E: Revealed type is '__main__.X*'
 x._replace(y=5)
 x._replace(x=3)
 x._replace(x=3, y=5)
@@ -279,19 +279,18 @@ from typing import NamedTuple
 
 X = NamedTuple('X', [('x', int), ('y', str)])
 x = None  # type: X
-reveal_type(x._replace())  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
+reveal_type(x._replace())  # E: Revealed type is '__main__.X*'
 x._replace(x=5)
 x._replace(y=5)  # E: Argument 1 to X._replace has incompatible type "int"; expected "str"
-
 
 [case testNamedTupleMake]
 from typing import NamedTuple
 
 X = NamedTuple('X', [('x', int), ('y', str)])
-reveal_type(X._make([5, 'a']))  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
+reveal_type(X._make([5, 'a']))  # E: Revealed type is '__main__.X*'
 X._make('a b')  # E: Argument 1 to X._make has incompatible type "str"; expected Iterable[Any]
 
--- # FIX: not a proper class method 
+-- # FIX: not a proper class method
 -- x = None  # type: X
 -- reveal_type(x._make([5, 'a']))  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
 -- x._make('a b')  # E: Argument 1 to X._make has incompatible type "str"; expected Iterable[Any]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -287,7 +287,7 @@ x._replace(y=5)  # E: Argument 1 to X._replace has incompatible type "int"; expe
 from typing import NamedTuple
 
 X = NamedTuple('X', [('x', int), ('y', str)])
-reveal_type(X._make([5, 'a']))  # E: Revealed type is '__main__.X*'
+reveal_type(X._make([5, 'a']))  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
 X._make('a b')  # E: Argument 1 to X._make has incompatible type "str"; expected Iterable[Any]
 
 -- # FIX: not a proper class method
@@ -386,7 +386,6 @@ b = B('').member()
 a = B('')
 a = B('').member()
 
-
 [case testNamedTupleSelfTypeReplace]
 from typing import NamedTuple, TypeVar
 A = NamedTuple('A', [('x', str)])
@@ -401,3 +400,16 @@ reveal_type(B('hello')._replace(x=''))  # E: Revealed type is 'Tuple[builtins.st
 b = None  # type: B
 b = B('hello')._replace(x='')
 
+[case testNamedTupleSelfTypeMake]
+from typing import NamedTuple, TypeVar
+A = NamedTuple('A', [('x', str)])
+reveal_type(A._make(['']))  # E: Revealed type is 'Tuple[builtins.str, fallback=__main__.A]'
+a = A._make([''])  # type: A
+
+class B(A):
+    pass
+
+reveal_type(B._make(['']))  # E: Revealed type is 'Tuple[builtins.str, fallback=__main__.B]'
+b = B._make([''])  # type: B
+
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -368,7 +368,7 @@ y = None  # type: C
 y = D()  # E: Incompatible types in assignment (expression has type "D", variable has type "C")
 
 [case testNamedTupleSelfType]
-from typing import NamedTuple
+from typing import NamedTuple, TypeVar
 A = NamedTuple('A', [('x', str)])
 reveal_type(A('hello')._replace(x=''))  # E: Revealed type is '__main__.A*'
 a = None  # type: A
@@ -380,3 +380,10 @@ class B(A):
 reveal_type(B('hello')._replace(x=''))  # E: Revealed type is '__main__.B*'
 b = None  # type: B
 b = B('hello')._replace(x='')
+
+T = TypeVar('T', bound='C')
+class C(B):
+    def foo(self: T) -> T: return self
+
+c = None  # type: C
+c = C('hello').foo()

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -559,10 +559,10 @@ main:15: error: Incompatible types in assignment (expression has type "Tuple[A, 
 
 a = None # type: A
 
-(a, a) + a  # E: Unsupported left operand type for + (Tuple[A, ...])
+(a, a) + a  # E: Unsupported left operand type for + ("Tuple[A, A]")
 a + (a, a)  # E: Unsupported operand types for + ("A" and "Tuple[A, A]")
 f((a, a))   # E: Argument 1 to "f" has incompatible type "Tuple[A, A]"; expected "A"
-(a, a).foo  # E: Tuple[A, ...] has no attribute "foo"
+(a, a).foo  # E: "Tuple[A, A]" has no attribute "foo"
 
 def f(x: 'A') -> None: pass
 
@@ -596,7 +596,7 @@ b = bool()
 s = t.__len__()  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 i = t.__str__()  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 i = s in t       # E: Incompatible types in assignment (expression has type "bool", variable has type "int")
-t.foo            # E: Tuple[Any, ...] has no attribute "foo"
+t.foo            # E: "Tuple[int, str]" has no attribute "foo"
 
 i = t.__len__()
 s = t.__str__()


### PR DESCRIPTION
(Reopening #2408 after the revert #2414. This fixes parts of #2090)
This PR does three things:
1. Fix the handling of TupleType (pass `original_type` recursively)
2. Fix the handling of TypeType (avoid ad-hoc buggy special casing)
3. Make NamedTuple's `_replace()`  and `_make()` return selftype, serving as test case for (1) and (2)

As a consequence of (1), some error messages are changed, as exemplified in `check-isinstance.test`. I think it's better now, but if it isn't, perhaps we should separate `original_type` and `report_type` as discussed in #2193.