### PR TITLE
Fix --warn-no-return with unicode docstrings

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -668,7 +668,7 @@ class TypeChecker(NodeVisitor[Type]):
 
         # Skip a docstring
         if (isinstance(body[0], ExpressionStmt) and
-                isinstance(body[0].expr, StrExpr)):
+                isinstance(body[0].expr, (StrExpr, UnicodeExpr))):
             body = block.body[1:]
 
         if len(body) == 0:

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -93,6 +93,9 @@ def i() -> int:
   """with docstring"""
   ...
 def j() -> int:
+  u"""with unicode docstring"""
+  pass
+def k() -> int:
   """docstring only"""
 
 [case testWarnNoReturnWorksWithAlwaysTrue]


### PR DESCRIPTION
This is mainly important for files with `unicode_literals`.