### PR TITLE
Type tooltips in HTML output

### DIFF
--- a/xml/mypy-html-tooltips.xslt
+++ b/xml/mypy-html-tooltips.xslt
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- vim: set sts=2 sw=2: -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:param name="ext" select="'xml'"/>
+  <xsl:output method="html"/>
+  <xsl:variable name="xml_stylesheet_pi" select="string(//processing-instruction('xml-stylesheet'))"/>
+  <xsl:variable name="stylesheet_name" select="substring($xml_stylesheet_pi, 23, string-length($xml_stylesheet_pi) - 28)"/>
+  <xsl:template match="/mypy-report-index">
+    <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;&#10;</xsl:text>
+    <html>
+      <head>
+        <link rel="stylesheet" type="text/css" href="{$stylesheet_name}.css"/>
+      </head>
+      <body>
+        <h1>Mypy Type Check Coverage Summary</h1>
+        <table class="summary">
+          <caption>Summary from <xsl:value-of select="@name"/></caption>
+          <thead>
+            <tr class="summary">
+              <th class="summary">File</th>
+              <th class="summary">Imprecision</th>
+              <th class="summary">Lines</th>
+            </tr>
+          </thead>
+          <tfoot>
+            <xsl:variable name="bad_lines" select="sum(file/@imprecise|file/@any)"/>
+            <xsl:variable name="total_lines" select="sum(file/@total)"/>
+            <xsl:variable name="global_score" select="$bad_lines div ($total_lines + not(number($total_lines)))"/>
+            <xsl:variable name="global_quality" select="string(number(number($global_score) &gt; 0.00) + number(number($global_score) &gt;= 0.20))"/>
+            <tr class="summary summary-quality-{$global_quality}">
+              <th class="summary summary-filename">Total</th>
+              <th class="summary summary-precision"><xsl:value-of select="format-number($global_score, '0.00%')"/> imprecise</th>
+              <th class="summary summary-lines"><xsl:value-of select="$total_lines"/> LOC</th>
+            </tr>
+          </tfoot>
+          <tbody>
+            <xsl:for-each select="file">
+              <xsl:variable name="local_score" select="(@imprecise + @any) div (@total + not(number(@total)))"/>
+              <xsl:variable name="local_quality" select="string(number(number($local_score) &gt; 0.00) + number(number($local_score) &gt;= 0.20))"/>
+              <tr class="summary summary-quality-{$local_quality}">
+                <td class="summary summary-filename"><a href="{$ext}/{@name}.{$ext}"><xsl:value-of select="@module"/></a></td>
+                <td class="summary summary-precision"><xsl:value-of select="format-number($local_score, '0.00%')"/> imprecise</td>
+                <td class="summary summary-lines"><xsl:value-of select="@total"/> LOC</td>
+              </tr>
+            </xsl:for-each>
+          </tbody>
+        </table>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template match="/mypy-report-file">
+    <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;&#10;</xsl:text>
+    <html>
+      <head>
+        <link rel="stylesheet" type="text/css" href="{$stylesheet_name}.css"/>
+      </head>
+      <body>
+        <h2><xsl:value-of select="@module"/></h2>
+        <table>
+          <caption><xsl:value-of select="@name"/></caption>
+          <tbody>
+            <tr>
+              <td class="table-lines">
+                <pre>
+                  <xsl:for-each select="line">
+                    <span id="L{@number}" class="lineno"><a class="lineno" href="#L{@number}"><xsl:value-of select="@number"/></a></span><xsl:text>&#10;</xsl:text>
+                  </xsl:for-each>
+                </pre>
+              </td>
+              <td class="table-code">
+                <pre>
+                  <xsl:for-each select="line">
+                    <span class="line-{@precision}">
+		      <xsl:for-each select="char">
+			<xsl:if test="@typestr!=''">
+			  <span class="type-char">
+			    <xsl:value-of select="@content"/>
+			    <span class="type-tooltip">
+			      <xsl:value-of select="@typestr"/>
+			    </span>
+			  </span>
+			</xsl:if>
+			<xsl:if test="@typestr=''">
+			  <xsl:value-of select="@content"/>
+			</xsl:if>
+		    </xsl:for-each>
+		    </span>
+		    <xsl:text>&#10;</xsl:text>
+                  </xsl:for-each>
+                </pre>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>

--- a/xml/mypy-html.css
+++ b/xml/mypy-html.css
@@ -102,3 +102,26 @@ a:hover.lineno, a:active.lineno {
 .line-any {
     background-color: #faa;
 }
+
+.type-char {
+    position : relative;
+    border-bottom : 1px dotted black;
+}
+
+.type-char:hover .type-tooltip {
+    visibility: visible;
+}
+
+.type-char .type-tooltip {
+    visibility: hidden;
+    background-color : #f80;
+    position : absolute;
+    z-index : 1;
+    padding : 5px 0;
+    text-align : center;
+    border-radius : 6px;
+}
+
+.type-char .type-tooltip {
+    top : 200%;
+}

--- a/xml/mypy-html.xslt
+++ b/xml/mypy-html.xslt
@@ -6,6 +6,7 @@
   <xsl:variable name="xml_stylesheet_pi" select="string(//processing-instruction('xml-stylesheet'))"/>
   <xsl:variable name="stylesheet_name" select="substring($xml_stylesheet_pi, 23, string-length($xml_stylesheet_pi) - 28)"/>
   <xsl:template match="/mypy-report-index">
+    <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;&#10;</xsl:text>
     <html>
       <head>
         <link rel="stylesheet" type="text/css" href="{$stylesheet_name}.css"/>
@@ -48,6 +49,7 @@
     </html>
   </xsl:template>
   <xsl:template match="/mypy-report-file">
+    <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;&#10;</xsl:text>
     <html>
       <head>
         <link rel="stylesheet" type="text/css" href="{$stylesheet_name}.css"/>

--- a/xml/mypy.xsd
+++ b/xml/mypy.xsd
@@ -34,6 +34,15 @@
       <xs:sequence>
         <xs:element name="line" minOccurs="0" maxOccurs="unbounded">
           <xs:complexType>
+	    <xs:sequence>
+	      <xs:element name="char" minOccurs="0" maxOccurs="unbounded">
+		<xs:complexType>
+		  <xs:attribute name="column" type="xs:integer" use="required"/>
+		  <xs:attribute name="typestr" type="xs:string" use="required"/>
+		  <xs:attribute name="content" type="xs:string" use="required"/>
+		</xs:complexType>
+	      </xs:element>
+	    </xs:sequence>
             <xs:attribute name="number" type="xs:integer" use="required"/>
             <xs:attribute name="precision" type="precision" use="required"/>
             <xs:attribute name="content" type="xs:string" use="required"/>


### PR DESCRIPTION
Hi,

this is likely related to #1123. This PR is meant as a basis for feedback and discussion and is not meant as ready to merge.

I was annoyed by always having to put in reveal_type(...) whenever I was confused what was going on with the typing system. This PR is a proposal to display the type for expressions in the HTML report, via a 'tooltip like' popup. This is how the HTML output looks like with this PR:

![typing-tooltips](https://cloud.githubusercontent.com/assets/91150/20237836/c69abda4-a8dd-11e6-8339-caa956071653.png)

Questions I have: 
- Is such a feature welcome?
- Is the general approach o.k.?
- should there be a command line flag to disable/enable HTML tooltips? (I guess so, if only because there is a performance impact: I measured 38s without tooltips and 68s with tooltips, generating a HTML report for a ~15k line project).
