### PR TITLE
Keep Any when restricting Union in isinstance

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -345,7 +345,8 @@ def restrict_subtype_away(t: Type, s: Type) -> Type:
     Currently just remove elements of a union type.
     """
     if isinstance(t, UnionType):
-        new_items = [item for item in t.items if not is_subtype(item, s)]
+        new_items = [item for item in t.items if (not is_subtype(item, s)
+                                                  or isinstance(item, AnyType))]
         return UnionType.make_union(new_items)
     else:
         return t

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -40,7 +40,7 @@ from typing import Any, Union
 
 def func(v:Union[int, Any]) -> None:
     if isinstance(v, int):
-        reveal_type(v) # E: Revealed type is 'builins.int'
+        reveal_type(v) # E: Revealed type is 'builtins.int'
     else:
         reveal_type(v) # E: Revealed type is 'Any'
 [builtins fixtures/isinstance.pyi]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -35,6 +35,17 @@ def f(x: Union[int, str]) -> None:
 [out]
 main: note: In function "f":
 
+[case testUnionAnyIsInstance]
+from typing import Any, Union
+
+def func(v:Union[int, Any]) -> None:
+    if isinstance(v, int):
+        reveal_type(v) # E: Revealed type is 'builins.int'
+    else:
+        reveal_type(v) # E: Revealed type is 'Any'
+[builtins fixtures/isinstance.pyi]
+[out]
+main: note: In function "func":
 
 [case testUnionAttributeAccess]
 from typing import Union


### PR DESCRIPTION
Fixes #1720 

Currently, mypy incorrectly determines restrictions of unions containing ``Any`` after ``isinstance()``, for example:
```python
def func(v: Union[int, Any]) -> None:
    if isinstance(v, int):
        reveal_type(s) # This is correctly int
    else:
        reveal_type(s) # But this is incorrectly Union[<ERROR>, void], should be Any
```
This PR fixes this by not considering ``Any`` a subtype-of-every-type when restricting the union.

(Note that this PR is not a replacement for #2197 but a complement to it.)