### PR TITLE
Reset changes to STRICT_OPTIONAL so that any test can use --strict-optional

### DIFF
--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -107,7 +107,11 @@ class TypeCheckSuite(DataSuite):
             finally:
                 experiments.STRICT_OPTIONAL = False
         else:
-            self.run_case_once(testcase)
+            try:
+                old_strict_optional = experiments.STRICT_OPTIONAL
+                self.run_case_once(testcase)
+            finally:
+                experiments.STRICT_OPTIONAL = old_strict_optional
 
     def clear_cache(self) -> None:
         dn = defaults.CACHE_DIR


### PR DESCRIPTION
This was extracted from https://github.com/python/mypy/pull/2266.

