### PR TITLE
Make typing and typed-ast external dependencies

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-recursive-include lib-typing *.py
 recursive-include scripts *
 recursive-exclude scripts myunit

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,0 +1,2 @@
+setuptools
+wheel

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -15,7 +15,7 @@ from mypy.myunit import Suite, SkipTestCaseException, AssertionFailure
 from mypy.test.config import test_data_prefix, test_temp_dir
 from mypy.test.data import parse_test_cases, DataDrivenTestCase
 from mypy.test.helpers import assert_string_arrays_equal
-from mypy.version import __version__
+from mypy.version import __version__, base_version
 
 # Path to Python 3 interpreter
 python3_path = sys.executable
@@ -99,5 +99,6 @@ def normalize_file_output(content: List[str], current_abs_path: str) -> List[str
     timestamp_regex = re.compile('\d{10}')
     result = [x.replace(current_abs_path, '$PWD') for x in content]
     result = [x.replace(__version__, '$VERSION') for x in result]
+    result = [x.replace(base_version, '$VERSION') for x in result]
     result = [timestamp_regex.sub('$TIMESTAMP', x) for x in result]
     return result

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,12 +21,6 @@ parallel = true
 [coverage:report]
 show_missing = true
 
-[wheel]
-universal = true
-
-[bdist_wheel]
-universal = true
-
 [metadata]
 requires-dist =
     typed-ast >= 0.6.1; sys_platform != 'win32'

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,14 @@ parallel = true
 
 [coverage:report]
 show_missing = true
+
+[wheel]
+universal = true
+
+[bdist_wheel]
+universal = true
+
+[metadata]
+requires-dist =
+    typed-ast >= 0.6.1; sys_platform != 'win32'
+    typing >= 3.5.2; python_version < "3.5"

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,5 +27,5 @@ show_missing = true
 # Then run "python3 setup.py bdist_wheel" to build a wheel file
 # (and then upload that to PyPI).
 requires-dist =
-    typed-ast >= 0.6.1; sys_platform != 'win32'
-    typing >= 3.5.2; python_version < "3.5"
+    typed-ast >= 0.6.2
+    typing >= 3.5.3; python_version < "3.5"

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,5 +27,5 @@ show_missing = true
 # Then run "python3 setup.py bdist_wheel" to build a wheel file
 # (and then upload that to PyPI).
 requires-dist =
-    typed-ast >= 0.6.2
+    typed-ast >= 0.6.3
     typing >= 3.5.3; python_version < "3.5"

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,10 @@ parallel = true
 show_missing = true
 
 [metadata]
+# This seems to be used only by bdist_wheel.
+# You need "pip3 install wheel".
+# Then run "python3 setup.py bdist_wheel" to build a wheel file
+# (and then upload that to PyPI).
 requires-dist =
     typed-ast >= 0.6.1; sys_platform != 'win32'
     typing >= 3.5.2; python_version < "3.5"

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ if sys.version_info < (3, 2, 0):
     sys.stderr.write("ERROR: You need Python 3.2 or later to use mypy.\n")
     exit(1)
 
+# This requires setuptools when building; setuptools is not needed
+# when installing from a wheel file (though it is still neeeded for
+# alternative forms of installing, as suggested by README.md).
 from setuptools import setup
 from setuptools.command.build_py import build_py
 from mypy.version import base_version
@@ -92,6 +95,10 @@ scripts = ['scripts/mypy', 'scripts/stubgen']
 if os.name == 'nt':
     scripts.append('scripts/mypy.bat')
 
+# These requirements are used when installing by other means than bdist_wheel.
+# E.g. "pip3 install ." or
+# "pip3 install git+git://github.com/python/mypy.git"
+# (as suggested by README.md).
 install_requires = []
 if sys.platform != 'win32':
     install_requires.append('typed-ast >= 0.6.1')

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ if sys.version_info < (3, 2, 0):
     sys.stderr.write("ERROR: You need Python 3.2 or later to use mypy.\n")
     exit(1)
 
-from distutils.core import setup
-from distutils.command.build_py import build_py
+from setuptools import setup
+from setuptools.command.build_py import build_py
 from mypy.version import base_version
 from mypy import git
 
@@ -81,17 +81,22 @@ classifiers = [
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Topic :: Software Development',
 ]
 
 
 package_dir = {'mypy': 'mypy'}
-if sys.version_info < (3, 5, 0):
-    package_dir[''] = 'lib-typing/3.2'
 
 scripts = ['scripts/mypy', 'scripts/stubgen']
 if os.name == 'nt':
     scripts.append('scripts/mypy.bat')
+
+install_requires = []
+if sys.platform != 'win32':
+    install_requires.append('typed-ast >= 0.6.1')
+if sys.version_info < (3, 5):
+    install_requires.append('typing >= 3.5.2')
 
 setup(name='mypy-lang',
       version=version,
@@ -103,10 +108,11 @@ setup(name='mypy-lang',
       license='MIT License',
       platforms=['POSIX'],
       package_dir=package_dir,
-      py_modules=['typing'] if sys.version_info < (3, 5, 0) else [],
+      py_modules=[],
       packages=['mypy'],
       scripts=scripts,
       data_files=data_files,
       classifiers=classifiers,
       cmdclass={'build_py': CustomPythonBuild},
+      install_requires=install_requires,
       )

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ if os.name == 'nt':
 # "pip3 install git+git://github.com/python/mypy.git"
 # (as suggested by README.md).
 install_requires = []
-install_requires.append('typed-ast >= 0.6.2')
+install_requires.append('typed-ast >= 0.6.3')
 if sys.version_info < (3, 5):
     install_requires.append('typing >= 3.5.3')
 

--- a/setup.py
+++ b/setup.py
@@ -100,10 +100,9 @@ if os.name == 'nt':
 # "pip3 install git+git://github.com/python/mypy.git"
 # (as suggested by README.md).
 install_requires = []
-if sys.platform != 'win32':
-    install_requires.append('typed-ast >= 0.6.1')
+install_requires.append('typed-ast >= 0.6.2')
 if sys.version_info < (3, 5):
-    install_requires.append('typing >= 3.5.2')
+    install_requires.append('typing >= 3.5.3')
 
 setup(name='mypy-lang',
       version=version,

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -11,7 +11,8 @@ print('hello, world')
 [out]
 hello, world
 
-[case testAbstractBaseClasses]
+-- Skipped because different typing package versions have different repr()s. 
+[case testAbstractBaseClasses-skip]
 import re
 from typing import Sized, Sequence, Iterator, Iterable, Mapping, AbstractSet
 


### PR DESCRIPTION
Reviving #2340.

This will automatically install the typing and typed-ast packages when
appropriate.

The setup.py file now depends on setuptools. We should build wheels
so that users installing from PyPI won't need setuptools. In order to
build wheels the distribution builder/uploader needs to install the
wheel package. To manage those dependencies, I've added
build-requirements.txt.

In summary:

- python3 -m pip install -r build-requirements.txt
- python3 setup.py bdist_wheel
- upload the .whl file that appears in the dist/ subdirectory to PyPI

Remaining issues:

- The installed scripts (mypy, stubgen) have the Python version used to create the wheel file hard-coded, so I'll have to do some more digging.
- I'm getting [warnings about the version being invalid](https://github.com/python/mypy/pull/2394#issuecomment-260475615).