### PR TITLE
Turn --warn-no-return on by default

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -27,7 +27,7 @@ from mypy.types import (
     Type, AnyType, CallableType, Void, FunctionLike, Overloaded, TupleType, TypedDictType,
     Instance, NoneTyp, ErrorType, strip_type, TypeType,
     UnionType, TypeVarId, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarDef,
-    true_only, false_only, function_type
+    true_only, false_only, function_type, is_named_instance
 )
 from mypy.sametypes import is_same_type, is_same_types
 from mypy.messages import MessageBuilder
@@ -606,16 +606,20 @@ class TypeChecker(StatementVisitor[None]):
                     self.accept(item.body)
                 unreachable = self.binder.is_unreachable()
 
-            if (self.options.warn_no_return and not unreachable
-                    and not isinstance(self.return_types[-1], (Void, NoneTyp, AnyType))
-                    and (defn.is_coroutine or not defn.is_generator)):
-                # Control flow fell off the end of a function that was
-                # declared to return a non-None type.
-                # Allow functions that are entirely pass/Ellipsis.
-                if self.is_trivial_body(defn.body):
-                    pass
+            if (self.options.warn_no_return and not unreachable):
+                if (defn.is_generator or
+                        is_named_instance(self.return_types[-1], 'typing.AwaitableGenerator')):
+                    return_type = self.get_generator_return_type(self.return_types[-1],
+                                                                 defn.is_coroutine)
                 else:
-                    if isinstance(self.return_types[-1], UninhabitedType):
+                    return_type = self.return_types[-1]
+
+                if (not isinstance(return_type, (Void, NoneTyp, AnyType))
+                        and not self.is_trivial_body(defn.body)):
+                    # Control flow fell off the end of a function that was
+                    # declared to return a non-None type and is not
+                    # entirely pass/Ellipsis.
+                    if isinstance(return_type, UninhabitedType):
                         # This is a NoReturn function
                         self.msg.note(messages.INVALID_IMPLICIT_RETURN, defn)
                     else:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -623,7 +623,7 @@ class TypeChecker(StatementVisitor[None]):
                         # This is a NoReturn function
                         self.msg.note(messages.INVALID_IMPLICIT_RETURN, defn)
                     else:
-                        self.msg.note(messages.MISSING_RETURN_STATEMENT, defn)
+                        self.msg.fail(messages.MISSING_RETURN_STATEMENT, defn)
 
             self.return_types.pop()
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -219,8 +219,8 @@ def process_options(args: List[str],
                         " --check-untyped-defs enabled")
     add_invertible_flag('--warn-redundant-casts', default=False, strict_flag=True,
                         help="warn about casting an expression to its inferred type")
-    add_invertible_flag('--warn-no-return', default=False,
-                        help="warn about functions that end without returning")
+    add_invertible_flag('--no-warn-no-return', dest='warn_no_return', default=True,
+                        help="do not warn about functions that end without returning")
     add_invertible_flag('--warn-unused-ignores', default=False, strict_flag=True,
                         help="warn about unneeded '# type: ignore' comments")
     add_invertible_flag('--show-error-context', default=True,

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -63,7 +63,7 @@ class Options:
         self.warn_redundant_casts = False
 
         # Warn about falling off the end of a function returning non-None
-        self.warn_no_return = False
+        self.warn_no_return = True
 
         # Warn about unused '# type: ignore' comments
         self.warn_unused_ignores = False

--- a/test-data/samples/crawl.py
+++ b/test-data/samples/crawl.py
@@ -319,7 +319,7 @@ class Request:
             self.conn = None
 
     @asyncio.coroutine
-    def putline(self, line: str) -> Generator[Any, None, None]:
+    def putline(self, line: str) -> None:
         """Write a line to the connection.
 
         Used for the request line and headers.

--- a/test-data/stdlib-samples/3.2/subprocess.py
+++ b/test-data/stdlib-samples/3.2/subprocess.py
@@ -784,6 +784,7 @@ class Popen(object):
             self.stdin.close()
         # Wait for the process to terminate, to avoid zombies.
         self.wait()
+        return False
 
     def __del__(self, _maxsize: int = sys.maxsize,
                 _active: List['Popen'] = _active) -> None:

--- a/test-data/stdlib-samples/3.2/tempfile.py
+++ b/test-data/stdlib-samples/3.2/tempfile.py
@@ -101,6 +101,7 @@ else:
         except IOError:
             raise _os.error()
         f.close()
+        return None
     _stat = __stat
 
 def _exists(fn: str) -> bool:
@@ -421,6 +422,7 @@ class _TemporaryFileWrapper:
         def __exit__(self, exc: _Type[BaseException], value: BaseException,
                      tb: _Optional[_TracebackType]) -> bool:
             self.file.__exit__(exc, value, tb)
+            return False
 
 
 def NamedTemporaryFile(mode: str = 'w+b', buffering: int = -1,
@@ -554,6 +556,7 @@ class SpooledTemporaryFile:
     def __exit__(self, exc: type, value: BaseException,
                  tb: _TracebackType) -> bool:
         self._file.close()
+        return False
 
     # file protocol
     def __iter__(self) -> _Iterable[_Any]:
@@ -690,6 +693,7 @@ class TemporaryDirectory(object):
     def __exit__(self, exc: type, value: BaseException,
                  tb: _TracebackType) -> bool:
         self.cleanup()
+        return False
 
     def __del__(self) -> None:
         # Issue a ResourceWarning if implicit cleanup needed

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -20,7 +20,7 @@ async def f() -> int:
     make_this_not_trivial = 1
 [builtins fixtures/async_await.pyi]
 [out]
-main:2: note: Missing return statement
+main:2: error: Missing return statement
 
 [case testAsyncDefReturnWithoutValue]
 # flags: --fast-parser

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -69,6 +69,7 @@ T = TypeVar('T')
 async def f(x: T) -> T:
     y = await f(x)  # type: int
     reveal_type(y)
+    return x
 [out]
 main:5: error: Argument 1 to "f" has incompatible type "T"; expected "int"
 main:6: error: Revealed type is 'builtins.int'
@@ -113,6 +114,7 @@ async def g() -> int:
     return 0
 async def f() -> str:
     x = await g()  # type: str
+    return x
 [builtins fixtures/async_await.pyi]
 [out]
 main:5: error: Incompatible types in assignment (expression has type "int", variable has type "str")

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -838,6 +838,7 @@ class A:
     def f(self) -> str:
         self.x = 1
         self.x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+        return ''
 [builtins fixtures/property.pyi]
 [out]
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -250,6 +250,7 @@ class A(Generic[T]):
         a = object()    # Fail
         b = self.f() # type: object
         b = self.f()
+        return None
 [out]
 main:5: error: Incompatible types in assignment (expression has type "object", variable has type "T")
 main:6: error: Incompatible types in assignment (expression has type "object", variable has type "T")

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1553,6 +1553,7 @@ from funcs import callee
 from classes import Outer
 def caller(a: Outer.Inner) -> int:
     callee(a)
+    return 0
 
 [case testIncrementalLoadsParentAfterChild]
 # cmd: mypy -m r.s

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -493,7 +493,7 @@ def f() -> None:
 def g() -> int:
   1 + 1  #
 [out]
-main:5: note: Missing return statement
+main:5: error: Missing return statement
 
 [case testGenericTypeAliasesOptional]
 from typing import TypeVar, Generic, Optional

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -61,6 +61,12 @@ def f() -> Generator[int, None, str]:
     return  # E: Return value expected
 [out]
 
+[case testNoReturnInGenerator]
+from typing import Generator
+def f() -> Generator[int, None, str]:  # N: Missing return statement
+    yield 1
+[out]
+
 [case testEmptyReturnInNoneTypedGenerator]
 from typing import Generator
 def f() -> Generator[int, None, None]:
@@ -722,6 +728,7 @@ def f(*a: BaseException) -> int:
     except BaseException as err: pass
     try: pass
     except BaseException as err: f(err)
+    return 0
 x = f()
 [builtins fixtures/exception.pyi]
 
@@ -732,6 +739,7 @@ def f(*a: BaseException) -> int:
     x
     try: pass
     except BaseException as err: f(err)
+    return 0
 x = f()
 [builtins fixtures/exception.pyi]
 
@@ -742,6 +750,7 @@ def f(*a: BaseException) -> int:
     try: pass
     except BaseException as err: f(err)
     x
+    return 0
 x = f()
 [builtins fixtures/exception.pyi]
 
@@ -762,6 +771,7 @@ def f(*arg: BaseException) -> int:
         f(err)
         b = err.b
         reveal_type(b)
+    return 0
 x = f()
 [builtins fixtures/exception.pyi]
 [out]
@@ -785,6 +795,7 @@ def f(*arg: BaseException) -> int:
         f(err)
         b = err.b
         reveal_type(b)
+    return 0
 x = f()
 [builtins fixtures/exception.pyi]
 [out]
@@ -808,6 +819,7 @@ def f(*arg: BaseException) -> int:
         b = err.b
         reveal_type(b)
     x
+    return 0
 x = f()
 [builtins fixtures/exception.pyi]
 [out]

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -63,7 +63,7 @@ def f() -> Generator[int, None, str]:
 
 [case testNoReturnInGenerator]
 from typing import Generator
-def f() -> Generator[int, None, str]:  # N: Missing return statement
+def f() -> Generator[int, None, str]:  # E: Missing return statement
     yield 1
 [out]
 

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -15,6 +15,7 @@ class A(B):
     a = super().f() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
     a = super().g() # E: "g" undefined in superclass
     b = super().f()
+    return a
 [out]
 
 [case testAccessingSuperTypeMethodWithArgs]
@@ -85,7 +86,7 @@ class A:
 class B(A):
     def __new__(cls, x: int, y: str = '') -> 'A':
         super().__new__(cls, 1)
-        super().__new__(cls, 1, '')  # E: Too many arguments for "__new__" of "A"
+        return super().__new__(cls, 1, '')  # E: Too many arguments for "__new__" of "A"
 B('')  # E: Argument 1 to "B" has incompatible type "str"; expected "int"
 B(1)
 B(1, 'x')

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -99,6 +99,7 @@ def f(x: T) -> T:
     b = x
     a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
     b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+    return x
 [out]
 
 [case testIsinstanceAndTypeVarValues]
@@ -107,9 +108,11 @@ T = TypeVar('T', int, str)
 def f(x: T) -> T:
     if isinstance(x, int):
         return 2
+    return x
 def g(x: T) -> T:
     if isinstance(x, str):
         return ''
+    return x
 def h(x: T) -> T:
     if isinstance(x, int):
         return '' # E: Incompatible return value type (got "str", expected "int")

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -71,7 +71,7 @@ def g() -> int:
         return 1
 [builtins fixtures/list.pyi]
 [out]
-main:5: note: Missing return statement
+main:5: error: Missing return statement
 
 [case testNoReturnWhile]
 # flags: --warn-no-return
@@ -95,7 +95,7 @@ def j() -> int:
             continue
 [builtins fixtures/list.pyi]
 [out]
-main:7: note: Missing return statement
+main:7: error: Missing return statement
 
 [case testNoReturnExcept]
 # flags: --warn-no-return
@@ -122,7 +122,7 @@ def h() -> int:
         return 1
 [builtins fixtures/exception.pyi]
 [out]
-main:2: note: Missing return statement
+main:2: error: Missing return statement
 
 [case testNoReturnEmptyBodyWithDocstring]
 def f() -> int:

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -314,7 +314,7 @@ from typing import TypeVar, Generic
 T = TypeVar('T')
 class A(Generic[T]):
   def f(self) -> T:
-    self.f()
+    return self.f()
 [out]
 CallExpr(5) : T`1
 MemberExpr(5) : def () -> T`1


### PR DESCRIPTION
`--warn-no-return` has shown itself to be generally useful, and so far has had only minor bugs (which have been fixed) over hundreds of thousands of lines of code.  This sort of check is pretty integral to correctness -- let's turn it on by default.