### PR TITLE
meet.py should consider all Tuple[t1, t2, ...] as subtypes of plain tuple

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -227,6 +227,8 @@ class TypeMeetVisitor(TypeVisitor[Type]):
                         return NoneTyp()
         elif isinstance(self.s, TypeType):
             return meet_types(t, self.s)
+        elif isinstance(self.s, TupleType):
+            return meet_types(t, self.s)
         else:
             return self.default(self.s)
 
@@ -243,6 +245,10 @@ class TypeMeetVisitor(TypeVisitor[Type]):
                 items.append(self.meet(t.items[i], self.s.items[i]))
             # TODO: What if the fallbacks are different?
             return TupleType(items, t.fallback)
+        # Special case: all Tuple[t1, t2, ...] are subtypes of plain tuple.
+        elif (isinstance(self.s, Instance) and self.s.type.fullname() == 'builtins.tuple'
+              and len(self.s.args) == 1 and isinstance(self.s.args[0], AnyType)):
+            return t
         else:
             return self.default(self.s)
 

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -245,10 +245,10 @@ class TypeMeetVisitor(TypeVisitor[Type]):
                 items.append(self.meet(t.items[i], self.s.items[i]))
             # TODO: What if the fallbacks are different?
             return TupleType(items, t.fallback)
-        # Special case: all Tuple[t1, t2, ...] are subtypes of plain tuple.
-        elif (isinstance(self.s, Instance) and self.s.type.fullname() == 'builtins.tuple'
-              and len(self.s.args) == 1 and isinstance(self.s.args[0], AnyType)):
-            return t
+        # meet(Tuple[t1, t2, <...>], Tuple[s, ...]) == Tuple[meet(t1, s), meet(t2, s), <...>].
+        elif (isinstance(self.s, Instance) and
+              self.s.type.fullname() == 'builtins.tuple' and self.s.args):
+            return t.copy_modified(items=[meet_types(it, self.s.args[0]) for it in t.items])
         else:
             return self.default(self.s)
 

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -809,15 +809,16 @@ a = (0, *b, '')
 [builtins fixtures/tuple.pyi]
 
 [case testTupleMeetTupleAny]
+# flags: --hide-error-context
 from typing import Union, Tuple
 class A: pass
 class B: pass
 
 def f(x: Union[B, Tuple[A, A]]) -> None:
     if isinstance(x, tuple):
-        reveal_type(x)
+        reveal_type(x) # E: Revealed type is 'Tuple[__main__.A, __main__.A]'
     else:
-        reveal_type(x)
+        reveal_type(x) # E: Revealed type is '__main__.B'
 
 def g(x: Union[str, Tuple[str, str]]) -> None:
     if isinstance(x, tuple):
@@ -827,24 +828,21 @@ def g(x: Union[str, Tuple[str, str]]) -> None:
 
 [builtins fixtures/tuple.pyi]
 [out]
-main: note: In function "f":
-main:7: error: Revealed type is 'Tuple[__main__.A, __main__.A]'
-main:9: error: Revealed type is '__main__.B'
-main: note: In function "g":
 
 [case testTupleMeetTUpleAnyComplex]
+# flags: --hide-error-context
 from typing import Tuple, Union
 
 Pair = Tuple[int, int]
 Variant = Union[int, Pair]
 def tuplify(v: Variant) -> None:
-    reveal_type(v)
+    reveal_type(v) # E: Revealed type is 'Union[builtins.int, Tuple[builtins.int, builtins.int]]'
     if not isinstance(v, tuple):
-        reveal_type(v)
+        reveal_type(v) # E: Revealed type is 'builtins.int'
         v = (v, v)
-        reveal_type(v)
-    reveal_type(v)
-    reveal_type(v[0])
+        reveal_type(v) # E: Revealed type is 'Tuple[builtins.int, builtins.int]'
+    reveal_type(v) # E: Revealed type is 'Tuple[builtins.int, builtins.int]'
+    reveal_type(v[0]) # E: Revealed type is 'builtins.int'
 
 Pair2 = Tuple[int, str]
 Variant2 = Union[int, Pair2]
@@ -855,15 +853,9 @@ def tuplify2(v: Variant2) -> None:
         reveal_type(v) # E: Revealed type is 'builtins.int'
 [builtins fixtures/tuple.pyi]
 [out]
-main: note: In function "tuplify":
-main:6: error: Revealed type is 'Union[builtins.int, Tuple[builtins.int, builtins.int]]'
-main:8: error: Revealed type is 'builtins.int'
-main:10: error: Revealed type is 'Tuple[builtins.int, builtins.int]'
-main:11: error: Revealed type is 'Tuple[builtins.int, builtins.int]'
-main:12: error: Revealed type is 'builtins.int'
-main: note: In function "tuplify2":
 
 [case testTupleMeetTupleAnyAfter]
+# flags: --hide-error-context
 from typing import Tuple, Union
 
 def good(blah: Union[Tuple[int, int], int]) -> None:
@@ -873,7 +865,6 @@ def good(blah: Union[Tuple[int, int], int]) -> None:
     reveal_type(blah) # E: Revealed type is 'Union[Tuple[builtins.int, builtins.int], builtins.int]'
 [builtins fixtures/tuple.pyi]
 [out]
-main: note: In function "good":
 
 [case testTupleWithUndersizedContext]
 a = ([1], 'x')

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -866,6 +866,26 @@ def good(blah: Union[Tuple[int, int], int]) -> None:
 [builtins fixtures/tuple.pyi]
 [out]
 
+[case testTupleMeetTupleVariable]
+from typing import Tuple, TypeVar, Generic, Union
+T = TypeVar('T')
+
+class A: pass
+class B1(A): pass
+class B2(A): pass
+class C: pass
+
+x = None # type: Tuple[A, ...]
+y = None # type: Tuple[Union[B1, C], Union[B2, C]]
+
+def g(x: T) -> Tuple[T, T]:
+    return (x, x)
+
+z = 1
+x, y = g(z) # E: Argument 1 to "g" has incompatible type "int"; expected "Tuple[B1, B2]"
+[builtins fixtures/tuple.pyi]
+[out]
+
 [case testTupleWithUndersizedContext]
 a = ([1], 'x')
 a = ([], 'x', 1)  # E: Incompatible types in assignment (expression has type "Tuple[List[int], str, int]", variable has type "Tuple[List[int], str]")

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -808,6 +808,73 @@ b = (1, 'x')
 a = (0, *b, '')
 [builtins fixtures/tuple.pyi]
 
+[case testTupleMeetTupleAny]
+from typing import Union, Tuple
+class A: pass
+class B: pass
+
+def f(x: Union[B, Tuple[A, A]]) -> None:
+    if isinstance(x, tuple):
+        reveal_type(x)
+    else:
+        reveal_type(x)
+
+def g(x: Union[str, Tuple[str, str]]) -> None:
+    if isinstance(x, tuple):
+        reveal_type(x) # E: Revealed type is 'Tuple[builtins.str, builtins.str]'
+    else:
+        reveal_type(x) # E: Revealed type is 'builtins.str'
+
+[builtins fixtures/tuple.pyi]
+[out]
+main: note: In function "f":
+main:7: error: Revealed type is 'Tuple[__main__.A, __main__.A]'
+main:9: error: Revealed type is '__main__.B'
+main: note: In function "g":
+
+[case testTupleMeetTUpleAnyComplex]
+from typing import Tuple, Union
+
+Pair = Tuple[int, int]
+Variant = Union[int, Pair]
+def tuplify(v: Variant) -> None:
+    reveal_type(v)
+    if not isinstance(v, tuple):
+        reveal_type(v)
+        v = (v, v)
+        reveal_type(v)
+    reveal_type(v)
+    reveal_type(v[0])
+
+Pair2 = Tuple[int, str]
+Variant2 = Union[int, Pair2]
+def tuplify2(v: Variant2) -> None:
+    if isinstance(v, tuple):
+        reveal_type(v) # E: Revealed type is 'Tuple[builtins.int, builtins.str]'
+    else:
+        reveal_type(v) # E: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
+[out]
+main: note: In function "tuplify":
+main:6: error: Revealed type is 'Union[builtins.int, Tuple[builtins.int, builtins.int]]'
+main:8: error: Revealed type is 'builtins.int'
+main:10: error: Revealed type is 'Tuple[builtins.int, builtins.int]'
+main:11: error: Revealed type is 'Tuple[builtins.int, builtins.int]'
+main:12: error: Revealed type is 'builtins.int'
+main: note: In function "tuplify2":
+
+[case testTupleMeetTupleAnyAfter]
+from typing import Tuple, Union
+
+def good(blah: Union[Tuple[int, int], int]) -> None:
+    reveal_type(blah) # E: Revealed type is 'Union[Tuple[builtins.int, builtins.int], builtins.int]'
+    if isinstance(blah, tuple):
+        reveal_type(blah) # E: Revealed type is 'Tuple[builtins.int, builtins.int]'
+    reveal_type(blah) # E: Revealed type is 'Union[Tuple[builtins.int, builtins.int], builtins.int]'
+[builtins fixtures/tuple.pyi]
+[out]
+main: note: In function "good":
+
 [case testTupleWithUndersizedContext]
 a = ([1], 'x')
 a = ([], 'x', 1)  # E: Incompatible types in assignment (expression has type "Tuple[List[int], str, int]", variable has type "Tuple[List[int], str]")

--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -23,5 +23,6 @@ class str: pass # For convenience
 T = TypeVar('T')
 
 class list(Sequence[T], Generic[T]): pass
+def isinstance(x: object, t: type) -> bool: pass
 
 def sum(iterable: Iterable[T], start: T = None) -> T: pass


### PR DESCRIPTION
Fixes #1691 
Fixes #2456 

This is a simple-minded fix. In the future we could add more rules for tuples in ``meet.py`` (for example for homogeneous tuples, a tuple and an iterable etc).

Tests are based on (extended) examples discussed in issues.