### PR TITLE
Support metaclasses

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2029,14 +2029,9 @@ class TypeChecker(NodeVisitor[Type]):
             return joined
         else:
             # Non-tuple iterable.
-            if isinstance(iterable, CallableType) and iterable.is_type_obj():
-                self.check_subtype(iterable.fallback,
-                                   self.named_generic_type('typing.Iterable', [AnyType()]),
-                                   expr, messages.ITERABLE_EXPECTED)
-            else:
-                self.check_subtype(iterable,
-                                   self.named_generic_type('typing.Iterable', [AnyType()]),
-                                   expr, messages.ITERABLE_EXPECTED)
+            self.check_subtype(iterable,
+                               self.named_generic_type('typing.Iterable', [AnyType()]),
+                               expr, messages.ITERABLE_EXPECTED)
             echk = self.expr_checker
             method = echk.analyze_external_member_access('__iter__', iterable,
                                                          expr)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1433,6 +1433,8 @@ class TypeChecker(NodeVisitor[Type]):
         return (left, star, right)
 
     def type_is_iterable(self, type: Type) -> bool:
+        if isinstance(type, CallableType) and type.is_type_obj():
+            type = type.fallback
         return (is_subtype(type, self.named_generic_type('typing.Iterable',
                                                         [AnyType()])) and
                 isinstance(type, Instance))
@@ -2027,11 +2029,14 @@ class TypeChecker(NodeVisitor[Type]):
             return joined
         else:
             # Non-tuple iterable.
-            self.check_subtype(iterable,
-                               self.named_generic_type('typing.Iterable',
-                                                       [AnyType()]),
-                               expr, messages.ITERABLE_EXPECTED)
-
+            if isinstance(iterable, CallableType) and iterable.is_type_obj():
+                self.check_subtype(iterable.fallback,
+                                   self.named_generic_type('typing.Iterable', [AnyType()]),
+                                   expr, messages.ITERABLE_EXPECTED)
+            else:
+                self.check_subtype(iterable,
+                                   self.named_generic_type('typing.Iterable', [AnyType()]),
+                                   expr, messages.ITERABLE_EXPECTED)
             echk = self.expr_checker
             method = echk.analyze_external_member_access('__iter__', iterable,
                                                          expr)
@@ -2183,6 +2188,10 @@ class TypeChecker(NodeVisitor[Type]):
 
     def visit_yield_from_expr(self, e: YieldFromExpr) -> Type:
         return self.expr_checker.visit_yield_from_expr(e)
+
+    def has_coroutine_decorator(self, t: Type) -> bool:
+        """Whether t came from a function decorated with `@coroutine`."""
+        return isinstance(t, Instance) and t.type.fullname() == 'typing.AwaitableGenerator'
 
     def visit_member_expr(self, e: MemberExpr) -> Type:
         return self.expr_checker.visit_member_expr(e)
@@ -2361,10 +2370,6 @@ class TypeChecker(NodeVisitor[Type]):
         # Assume that the name refers to a class.
         sym = self.lookup_qualified(fullname)
         return cast(TypeInfo, sym.node)
-
-    def type_type(self) -> Instance:
-        """Return instance type 'type'."""
-        return self.named_type('builtins.type')
 
     def object_type(self) -> Instance:
         """Return instance type 'object'."""

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2030,8 +2030,10 @@ class TypeChecker(NodeVisitor[Type]):
         else:
             # Non-tuple iterable.
             self.check_subtype(iterable,
-                               self.named_generic_type('typing.Iterable', [AnyType()]),
+                               self.named_generic_type('typing.Iterable',
+                                                       [AnyType()]),
                                expr, messages.ITERABLE_EXPECTED)
+
             echk = self.expr_checker
             method = echk.analyze_external_member_access('__iter__', iterable,
                                                          expr)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2099,8 +2099,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         # by __iter__.
         if isinstance(subexpr_type, AnyType):
             iter_type = AnyType()
-        elif (isinstance(subexpr_type, Instance) and
-                is_subtype(subexpr_type, self.chk.named_type('typing.Iterable'))):
+        elif self.chk.type_is_iterable(subexpr_type):
             if is_async_def(subexpr_type) and not has_coroutine_decorator(return_type):
                 self.chk.msg.yield_from_invalid_operand_type(subexpr_type, e)
             iter_method_type = self.analyze_external_member_access(

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -184,6 +184,8 @@ def analyze_member_access(name: str,
             if result:
                 return result
         fallback = builtin_type('builtins.type')
+        if item is not None:
+            fallback = item.type.metaclass_type or fallback
         return analyze_member_access(name, fallback, node, is_lvalue, is_super,
                                      is_operator, builtin_type, not_ready_callback, msg,
                                      original_type=original_type, chk=chk)
@@ -450,7 +452,7 @@ def type_object_type(info: TypeInfo, builtin_type: Callable[[str], Instance]) ->
         # Must be an invalid class definition.
         return AnyType()
     else:
-        fallback = builtin_type('builtins.type')
+        fallback = info.metaclass_type or builtin_type('builtins.type')
         if init_method.info.fullname() == 'builtins.object':
             # No non-default __init__ -> look at __new__ instead.
             new_method = info.get_method('__new__')

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -294,6 +294,8 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
     def visit_instance(self, template: Instance) -> List[Constraint]:
         actual = self.actual
         res = []  # type: List[Constraint]
+        if isinstance(actual, CallableType) and actual.fallback is not None:
+            actual = actual.fallback
         if isinstance(actual, Instance):
             instance = actual
             if (self.direction == SUBTYPE_OF and

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1946,6 +1946,29 @@ class TypeInfo(SymbolNode):
             for vd in defn.type_vars:
                 self.type_vars.append(vd.name)
 
+    _metaclass_type = None  # type: Optional[mypy.types.Instance]
+
+    @property
+    def metaclass_type(self) -> 'Optional[mypy.types.Instance]':
+        if self._metaclass_type:
+            return self._metaclass_type
+        if self._fullname == 'builtins.type':
+            return mypy.types.Instance(self, [])
+        if self.mro is None:
+            # XXX why does this happen?
+            return None
+        if len(self.mro) > 1:
+            return self.mro[1].metaclass_type
+        # FIX: assert False
+        return None
+
+    @metaclass_type.setter
+    def metaclass_type(self, value: 'mypy.types.Instance'):
+        self._metaclass_type = value
+
+    def is_metaclass(self) -> bool:
+        return self.has_base('builtins.type')
+
     def name(self) -> str:
         """Short name."""
         return self.defn.name

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2015,7 +2015,7 @@ class TypeInfo(SymbolNode):
             return declared
         if self._fullname == 'builtins.type':
             return mypy.types.Instance(self, [])
-        candidates = {s.declared_metaclass for s in self.mro} - {None}
+        candidates = [s.declared_metaclass for s in self.mro if s.declared_metaclass is not None]
         for c in candidates:
             if all(other.type in c.type.mro for other in candidates):
                 return c

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -908,13 +908,11 @@ class SemanticAnalyzer(NodeVisitor):
             if sym is None:
                 # Probably a name error - it is already handled elsewhere
                 return
-            if not isinstance(sym.node, TypeInfo):
+            if not isinstance(sym.node, TypeInfo) or sym.node.tuple_type is not None:
                 self.fail("Invalid metaclass '%s'" % defn.metaclass, defn)
                 return
             inst = fill_typevars(sym.node)
-            if not isinstance(inst, Instance):
-                self.fail("Invalid metaclass '%s'" % defn.metaclass, defn)
-                return
+            assert isinstance(inst, Instance)
             defn.info.declared_metaclass = inst
             defn.info.metaclass_type = defn.info.calculate_metaclass_type()
             if defn.info.metaclass_type is None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -904,7 +904,7 @@ class SemanticAnalyzer(NodeVisitor):
             if defn.metaclass == '<error>':
                 self.fail("Dynamic metaclass not supported for '%s'" % defn.name, defn)
                 return
-            sym = self.lookup(defn.metaclass, defn)
+            sym = self.lookup_qualified(defn.metaclass, defn)
             if sym is not None and isinstance(sym.node, TypeInfo):
                 inst = fill_typevars(sym.node)
                 assert isinstance(inst, Instance)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -904,8 +904,13 @@ class SemanticAnalyzer(NodeVisitor):
             if defn.metaclass == '<error>':
                 self.fail("Dynamic metaclass not supported for '%s'" % defn.name, defn)
                 return
-            sym = self.lookup_qualified(defn.metaclass, defn)
-            if sym is not None and not isinstance(sym.node, TypeInfo):
+            sym = self.lookup(defn.metaclass, defn)
+            if sym is not None and isinstance(sym.node, TypeInfo):
+                inst = fill_typevars(sym.node)
+                assert isinstance(inst, Instance)
+                defn.info.metaclass_type = inst
+                return
+            else:
                 self.fail("Invalid metaclass '%s'" % defn.metaclass, defn)
 
     def object_type(self) -> Instance:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -913,7 +913,7 @@ class SemanticAnalyzer(NodeVisitor):
                 return
             inst = fill_typevars(sym.node)
             assert isinstance(inst, Instance)
-            defn.info.declared_metaclass_type = inst
+            defn.info.declared_metaclass = inst
             defn.info.metaclass_type = defn.info.calculate_metaclass_type()
             if defn.info.metaclass_type is None:
                 # Inconsistency may happen due to multiple baseclasses even in classes that

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -905,13 +905,20 @@ class SemanticAnalyzer(NodeVisitor):
                 self.fail("Dynamic metaclass not supported for '%s'" % defn.name, defn)
                 return
             sym = self.lookup_qualified(defn.metaclass, defn)
-            if sym is not None and isinstance(sym.node, TypeInfo):
-                inst = fill_typevars(sym.node)
-                assert isinstance(inst, Instance)
-                defn.info.metaclass_type = inst
+            if sym is None:
+                # Probably a name error - it is already handled elsewhere
                 return
-            else:
+            if not isinstance(sym.node, TypeInfo):
                 self.fail("Invalid metaclass '%s'" % defn.metaclass, defn)
+                return
+            inst = fill_typevars(sym.node)
+            assert isinstance(inst, Instance)
+            defn.info.declared_metaclass_type = inst
+            defn.info.metaclass_type = defn.info.calculate_metaclass_type()
+            if defn.info.metaclass_type is None:
+                # Inconsistency may happen due to multiple baseclasses even in classes that
+                # do not declare explicit metaclass, but it's harder to catch at this stage
+                self.fail("Inconsistent metaclass structure for '%s'" % defn.name, defn)
 
     def object_type(self) -> Instance:
         return self.named_type('__builtins__.object')

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -912,7 +912,9 @@ class SemanticAnalyzer(NodeVisitor):
                 self.fail("Invalid metaclass '%s'" % defn.metaclass, defn)
                 return
             inst = fill_typevars(sym.node)
-            assert isinstance(inst, Instance)
+            if not isinstance(inst, Instance):
+                self.fail("Invalid metaclass '%s'" % defn.metaclass, defn)
+                return
             defn.info.declared_metaclass = inst
             defn.info.metaclass_type = defn.info.calculate_metaclass_type()
             if defn.info.metaclass_type is None:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -643,7 +643,8 @@ class CallableType(FunctionLike):
         )
 
     def is_type_obj(self) -> bool:
-        return self.fallback.type is not None and self.fallback.type.fullname() == 'builtins.type'
+        t = self.fallback.type
+        return t is not None and t.is_metaclass()
 
     def is_concrete_type_obj(self) -> bool:
         return self.is_type_obj() and self.is_classmethod_class

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2806,3 +2806,10 @@ reveal_type(list(Good))  # E: Revealed type is 'builtins.list[builtins.int*]'
 
 [builtins fixtures/list.pyi]
 
+[case testMetaclassTuple]
+from typing import Tuple
+
+class M(Tuple[int]): pass
+class C(metaclass=M): pass  # E: Invalid metaclass 'M'
+
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2802,3 +2802,7 @@ class GoodMeta(type, Iterable[int]):
 
 class Good(metaclass=GoodMeta): pass
 for _ in Good: pass
+reveal_type(list(Good))  # E: Revealed type is 'builtins.list[builtins.int*]'
+
+[builtins fixtures/list.pyi]
+

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2759,3 +2759,46 @@ class B(A):
 class C(B):
     x = ''
 [out]
+
+[case testInvalidMetaclassStructure]
+class X(type): pass
+class Y(type): pass
+class A(metaclass=X): pass
+class B(A, metaclass=Y): pass  # E: Inconsistent metaclass structure for 'B'
+
+[case testMetaclassNoTypeReveal]
+class M:
+    x = 0  # type: int
+
+class A(metaclass=M): pass
+
+reveal_type(A.x)  # E: Revealed type is 'builtins.int'
+
+[case testMetaclassTypeReveal]
+from typing import Type
+class M(type):
+    x = 0  # type: int
+
+class A(metaclass=M): pass
+
+reveal_type(A.x)  # E: Revealed type is 'builtins.int'
+
+def f(TA: Type[A]):
+    reveal_type(TA)  # E: Revealed type is 'Type[__main__.A]'
+    reveal_type(TA.x)  # E: Revealed type is 'builtins.int'
+
+[case testMetaclassIterable]
+from typing import Iterable, Iterator
+
+class BadMeta(type):
+    def __iter__(self) -> Iterator[int]: yield 1
+
+class Bad(metaclass=BadMeta): pass
+
+for _ in Bad: pass  # E: Iterable expected
+
+class GoodMeta(type, Iterable[int]):
+    def __iter__(self) -> Iterator[int]: yield 1
+
+class Good(metaclass=GoodMeta): pass
+for _ in Good: pass

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2781,8 +2781,6 @@ class M(type):
 
 class A(metaclass=M): pass
 
-reveal_type(A.x)  # E: Revealed type is 'builtins.int'
-
 def f(TA: Type[A]):
     reveal_type(TA)  # E: Revealed type is 'Type[__main__.A]'
     reveal_type(TA.x)  # E: Revealed type is 'builtins.int'

--- a/test-data/unit/lib-stub/abc.pyi
+++ b/test-data/unit/lib-stub/abc.pyi
@@ -1,3 +1,3 @@
-class ABCMeta: pass
+class ABCMeta(type): pass
 abstractmethod = object()
 abstractproperty = object()

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -964,15 +964,15 @@ class A(Generic[T], Generic[S]): pass \
 [case testInvalidMetaclass]
 class A(metaclass=x): pass
 [out]
-main:3: error: Name 'x' is not defined
-main:3: error: Invalid metaclass 'x'
+main:1: error: Name 'x' is not defined
+main:1: error: Invalid metaclass 'x'
 
 [case testInvalidQualifiedMetaclass]
 import abc
 class A(metaclass=abc.Foo): pass
 [out]
-main:3: error: Name 'abc.Foo' is not defined
-main:3: error: Invalid metaclass 'abc.Foo'
+main:2: error: Name 'abc.Foo' is not defined
+main:2: error: Invalid metaclass 'abc.Foo'
 
 [case testNonClassMetaclass]
 def f(): pass

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -962,13 +962,17 @@ class A(Generic[T], Generic[S]): pass \
 [out]
 
 [case testInvalidMetaclass]
-class A(metaclass=x): pass # E: Name 'x' is not defined
+class A(metaclass=x): pass
 [out]
+main:3: error: Name 'x' is not defined
+main:3: error: Invalid metaclass 'x'
 
 [case testInvalidQualifiedMetaclass]
 import abc
-class A(metaclass=abc.Foo): pass # E: Name 'abc.Foo' is not defined
+class A(metaclass=abc.Foo): pass
 [out]
+main:3: error: Name 'abc.Foo' is not defined
+main:3: error: Invalid metaclass 'abc.Foo'
 
 [case testNonClassMetaclass]
 def f(): pass

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -962,22 +962,15 @@ class A(Generic[T], Generic[S]): pass \
 [out]
 
 [case testInvalidMetaclass]
-class A(metaclass=x): pass
-[out]
-main:1: error: Name 'x' is not defined
-main:1: error: Invalid metaclass 'x'
+class A(metaclass=x): pass  # E: Name 'x' is not defined
 
 [case testInvalidQualifiedMetaclass]
 import abc
-class A(metaclass=abc.Foo): pass
-[out]
-main:2: error: Name 'abc.Foo' is not defined
-main:2: error: Invalid metaclass 'abc.Foo'
+class A(metaclass=abc.Foo): pass  # E: Name 'abc.Foo' is not defined
 
 [case testNonClassMetaclass]
 def f(): pass
-class A(metaclass=f): pass # E: Invalid metaclass 'f'
-[out]
+class A(metaclass=f): pass  # E: Invalid metaclass 'f'
 
 [case testInvalidTypevarArguments]
 from typing import TypeVar

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -962,15 +962,18 @@ class A(Generic[T], Generic[S]): pass \
 [out]
 
 [case testInvalidMetaclass]
-class A(metaclass=x): pass  # E: Name 'x' is not defined
+class A(metaclass=x): pass # E: Name 'x' is not defined
+[out]
 
 [case testInvalidQualifiedMetaclass]
 import abc
-class A(metaclass=abc.Foo): pass  # E: Name 'abc.Foo' is not defined
+class A(metaclass=abc.Foo): pass # E: Name 'abc.Foo' is not defined
+[out]
 
 [case testNonClassMetaclass]
 def f(): pass
-class A(metaclass=f): pass  # E: Invalid metaclass 'f'
+class A(metaclass=f): pass # E: Invalid metaclass 'f'
+[out]
 
 [case testInvalidTypevarArguments]
 from typing import TypeVar


### PR DESCRIPTION
Reopening #2392 (itself a reopen of #2365).

Store the type of the metaclass in TypeInfo, and use it when possible, instead of builtins.type.

I assume metaclasses always inherit from type.

This PR will help fixing #2305 and #741, but the fix is not part of this PR.