### PR TITLE
Document kwarg annotation syntax with example

### DIFF
--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -39,6 +39,13 @@ context results in a type check error:
 
    a = p()   # Type check error: p has None return value
 
+Arguments with default values can be annotated as follows:
+
+.. code-block:: python
+
+   def greeting(name: str, prefix: str = 'Mr.') -> str:
+      return 'Hello, {} {}'.format(name, prefix)
+
 Mixing dynamic and static typing
 ********************************
 


### PR DESCRIPTION
I added a little example showing how to annotate keyword arguments in function signatures, as it seems to be missing at the moment.