### PR TITLE
Fix type aliases with unicode in Python 2

### DIFF
--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -2,7 +2,7 @@
 
 from mypy.nodes import (
     Expression, NameExpr, MemberExpr, IndexExpr, TupleExpr,
-    ListExpr, StrExpr, BytesExpr, EllipsisExpr
+    ListExpr, StrExpr, BytesExpr, UnicodeExpr, EllipsisExpr
 )
 from mypy.parsetype import parse_str_as_type, TypeParseError
 from mypy.types import Type, UnboundType, TypeList, EllipsisType
@@ -43,7 +43,7 @@ def expr_to_unanalyzed_type(expr: Expression) -> Type:
     elif isinstance(expr, ListExpr):
         return TypeList([expr_to_unanalyzed_type(t) for t in expr.items],
                         line=expr.line, column=expr.column)
-    elif isinstance(expr, (StrExpr, BytesExpr)):
+    elif isinstance(expr, (StrExpr, BytesExpr, UnicodeExpr)):
         # Parse string literal type.
         try:
             result = parse_str_as_type(expr.value, expr.line)

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -218,3 +218,9 @@ def foo() -> int:
 # flags: --fast-parser
 import __builtin__
 __builtin__.str
+
+[case testUnicodeAlias]
+from typing import List
+Alias = List[u'Foo']
+class Foo: pass
+[builtins_py2 fixtures/python2.pyi]

--- a/test-data/unit/fixtures/python2.pyi
+++ b/test-data/unit/fixtures/python2.pyi
@@ -1,3 +1,5 @@
+from typing import Generic, Iterable, TypeVar
+
 class object:
     def __init__(self) -> None: pass
 
@@ -9,5 +11,8 @@ class function: pass
 class int: pass
 class str: pass
 class unicode: pass
+
+T = TypeVar('T')
+class list(Iterable[T], Generic[T]): pass
 
 # Definition of None is implicit


### PR DESCRIPTION
This is especially important for `unicode_literals` files.