### PR TITLE
Allow `__all__` to be a Sequence[unicode] in Python 2

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -179,25 +179,14 @@ class TypeChecker(NodeVisitor[Type]):
 
         all_ = self.globals.get('__all__')
         if all_ is not None and all_.type is not None:
-            valid_all_types = [self.named_generic_type('typing.Sequence',
-                                                       [self.named_type('builtins.str')])]
+            seq_str = self.named_generic_type('typing.Sequence',
+                                              [self.named_type('builtins.str')])
             if self.options.python_version[0] < 3:
-                valid_all_types.append(
-                    self.named_generic_type('typing.Sequence',
-                                            [self.named_type('builtins.unicode')]))
-            if not any(is_subtype(all_.type, x) for x in valid_all_types):
-                valid_types = []  # type: List[str]
-                all_s = self.msg.format(all_.type)
-                for valid_all_type in valid_all_types:
-                    str_seq_s, all_s = self.msg.format_distinctly(valid_all_type, all_.type)
-                    valid_types.append(str_seq_s)
-
-                if len(valid_types) > 1:
-                    valid_type_str = 'Union[{}]'.format(', '.join(valid_types))
-                else:
-                    valid_type_str = valid_types[0]
-
-                self.fail(messages.ALL_MUST_BE_SEQ_STR.format(valid_type_str, all_s),
+                seq_str = self.named_generic_type('typing.Sequence',
+                                                  [self.named_type('builtins.unicode')])
+            if not is_subtype(all_.type, seq_str):
+                str_seq_s, all_s = self.msg.format_distinctly(seq_str, all_.type)
+                self.fail(messages.ALL_MUST_BE_SEQ_STR.format(str_seq_s, all_s),
                           all_.node)
 
     def check_second_pass(self) -> bool:

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -423,7 +423,7 @@ import typing
 __all__ = [1, 2, 3]
 [builtins_py2 fixtures/module_all_python2.pyi]
 [out]
-main: error: Type of __all__ must be Union[Sequence[str], Sequence[unicode]], not List[int]
+main: error: Type of __all__ must be Sequence[unicode], not List[int]
 
 [case testAllUnicodeSequenceOK_python2]
 import typing

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -418,6 +418,20 @@ __all__ = [1, 2, 3]
 [out]
 main: error: Type of __all__ must be Sequence[str], not List[int]
 
+[case testAllMustBeSequenceStr_python2]
+import typing
+__all__ = [1, 2, 3]
+[builtins_py2 fixtures/module_all_python2.pyi]
+[out]
+main: error: Type of __all__ must be Union[Sequence[str], Sequence[unicode]], not List[int]
+
+[case testAllUnicodeSequenceOK_python2]
+import typing
+__all__ = [u'a', u'b', u'c']
+[builtins_py2 fixtures/module_all_python2.pyi]
+
+[out]
+
 [case testEllipsisInitializerInStubFileWithType]
 import m
 m.x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")

--- a/test-data/unit/fixtures/module_all_python2.pyi
+++ b/test-data/unit/fixtures/module_all_python2.pyi
@@ -1,0 +1,16 @@
+from typing import Generic, Sequence, TypeVar
+_T = TypeVar('_T')
+
+class object:
+    def __init__(self) -> None: pass
+class module: pass
+class type: pass
+class function: pass
+class int: pass
+class str: pass
+class unicode: pass
+class list(Generic[_T], Sequence[_T]):
+    def append(self, x: _T): pass
+    def extend(self, x: Sequence[_T]): pass
+    def __add__(self, rhs: Sequence[_T]) -> list[_T]: pass
+class tuple: pass


### PR DESCRIPTION
This change fixes the following issue:

```python
from __future__ import unicode_literals

__all__ = ['a', 'b', 'c']  # Fails in Python 2
```