### PR TITLE
Function compatibility rewrite

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -40,8 +40,8 @@ import mypy.checkexpr
 from mypy.checkmember import map_type_from_supertype, bind_self, erase_to_bound
 from mypy import messages
 from mypy.subtypes import (
-    is_subtype, is_equivalent, is_proper_subtype, is_more_precise, restrict_subtype_away,
-    is_subtype_ignoring_tvars
+    is_subtype, is_equivalent, is_proper_subtype, is_more_precise,
+    restrict_subtype_away, is_subtype_ignoring_tvars
 )
 from mypy.maptype import map_instance_to_supertype
 from mypy.semanal import fill_typevars, set_callable_name, refers_to_fullname
@@ -835,7 +835,7 @@ class TypeChecker(NodeVisitor[Type]):
     def check_getattr_method(self, typ: CallableType, context: Context) -> None:
         method_type = CallableType([AnyType(), self.named_type('builtins.str')],
                                    [nodes.ARG_POS, nodes.ARG_POS],
-                                   [None],
+                                   [None, None],
                                    AnyType(),
                                    self.named_type('builtins.function'))
         if not is_subtype(typ, method_type):
@@ -936,7 +936,7 @@ class TypeChecker(NodeVisitor[Type]):
         """
         # Use boolean variable to clarify code.
         fail = False
-        if not is_subtype(override, original):
+        if not is_subtype(override, original, ignore_positional_arg_names=True):
             fail = True
         elif (not isinstance(original, Overloaded) and
               isinstance(override, Overloaded) and

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -936,7 +936,7 @@ class TypeChecker(NodeVisitor[Type]):
         """
         # Use boolean variable to clarify code.
         fail = False
-        if not is_subtype(override, original, ignore_positional_arg_names=True):
+        if not is_subtype(override, original, ignore_pos_arg_names=True):
             fail = True
         elif (not isinstance(original, Overloaded) and
               isinstance(override, Overloaded) and

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1043,7 +1043,7 @@ class TypeChecker(NodeVisitor[Type]):
             # Method override
             first_sig = bind_self(first_type)
             second_sig = bind_self(second_type)
-            ok = is_subtype(first_sig, second_sig)
+            ok = is_subtype(first_sig, second_sig, ignore_pos_arg_names=True)
         elif first_type and second_type:
             ok = is_equivalent(first_type, second_type)
         else:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -15,7 +15,7 @@ from mypy.types import (
 )
 from mypy.nodes import (
     TypeInfo, Context, MypyFile, op_methods, FuncDef, reverse_type_aliases,
-    ARG_STAR, ARG_STAR2
+    ARG_POS, ARG_OPT, ARG_NAMED, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2
 )
 
 
@@ -76,6 +76,15 @@ INVALID_TYPEDDICT_ARGS = \
     'Expected keyword arguments, {...}, or dict(...) in TypedDict constructor'
 TYPEDDICT_ITEM_NAME_MUST_BE_STRING_LITERAL = \
     'Expected TypedDict item name to be string literal'
+
+ARG_CONSTRUCTOR_NAMES = {
+    ARG_POS: "Arg",
+    ARG_OPT: "DefaultArg",
+    ARG_NAMED: "Arg",
+    ARG_NAMED_OPT: "DefaultArg",
+    ARG_STAR: "StarArg",
+    ARG_STAR2: "KwArg",
+}
 
 
 class MessageBuilder:
@@ -176,8 +185,29 @@ class MessageBuilder:
                 return_type = strip_quotes(self.format(func.ret_type))
                 if func.is_ellipsis_args:
                     return 'Callable[..., {}]'.format(return_type)
-                arg_types = [strip_quotes(self.format(t)) for t in func.arg_types]
-                return 'Callable[[{}], {}]'.format(", ".join(arg_types), return_type)
+                arg_strings = []
+                for arg_name, arg_type, arg_kind in zip(
+                        func.arg_names, func.arg_types, func.arg_kinds):
+                    if arg_kind == ARG_POS and arg_name is None or verbosity == 0:
+                        arg_strings.append(
+                            strip_quotes(
+                                self.format(
+                                    arg_type,
+                                    verbosity = max(verbosity - 1, 0))))
+                    else:
+                        constructor = ARG_CONSTRUCTOR_NAMES[arg_kind]
+                        if arg_kind in (ARG_STAR, ARG_STAR2):
+                            arg_strings.append("{}({})".format(
+                                constructor,
+                                arg_name))
+                        else:
+                            arg_strings.append("{}('{}', {}, {})".format(
+                                constructor,
+                                arg_name,
+                                strip_quotes(self.format(arg_type)),
+                                arg_kind in (ARG_NAMED, ARG_NAMED_OPT)))
+
+                return 'Callable[[{}], {}]'.format(", ".join(arg_strings), return_type)
             else:
                 # Use a simple representation for function types; proper
                 # function types may result in long and difficult-to-read

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -188,8 +188,8 @@ class MessageBuilder:
                 arg_strings = []
                 for arg_name, arg_type, arg_kind in zip(
                         func.arg_names, func.arg_types, func.arg_kinds):
-                    if ( arg_kind == ARG_POS and arg_name is None or
-                         verbosity == 0 and arg_kind in (ARG_POS, ARG_OPT) ):
+                    if (arg_kind == ARG_POS and arg_name is None
+                            or verbosity == 0 and arg_kind in (ARG_POS, ARG_OPT)):
 
                         arg_strings.append(
                             strip_quotes(

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -80,8 +80,8 @@ TYPEDDICT_ITEM_NAME_MUST_BE_STRING_LITERAL = \
 ARG_CONSTRUCTOR_NAMES = {
     ARG_POS: "Arg",
     ARG_OPT: "DefaultArg",
-    ARG_NAMED: "Arg",
-    ARG_NAMED_OPT: "DefaultArg",
+    ARG_NAMED: "NamedArg",
+    ARG_NAMED_OPT: "DefaultNamedArg",
     ARG_STAR: "StarArg",
     ARG_STAR2: "KwArg",
 }
@@ -188,7 +188,9 @@ class MessageBuilder:
                 arg_strings = []
                 for arg_name, arg_type, arg_kind in zip(
                         func.arg_names, func.arg_types, func.arg_kinds):
-                    if arg_kind == ARG_POS and arg_name is None or verbosity == 0:
+                    if ( arg_kind == ARG_POS and arg_name is None or
+                         verbosity == 0 and arg_kind in (ARG_POS, ARG_OPT) ):
+
                         arg_strings.append(
                             strip_quotes(
                                 self.format(
@@ -199,13 +201,12 @@ class MessageBuilder:
                         if arg_kind in (ARG_STAR, ARG_STAR2):
                             arg_strings.append("{}({})".format(
                                 constructor,
-                                arg_name))
+                                strip_quotes(self.format(arg_type))))
                         else:
-                            arg_strings.append("{}('{}', {}, {})".format(
+                            arg_strings.append("{}('{}', {})".format(
                                 constructor,
                                 arg_name,
-                                strip_quotes(self.format(arg_type)),
-                                arg_kind in (ARG_NAMED, ARG_NAMED_OPT)))
+                                strip_quotes(self.format(arg_type))))
 
                 return 'Callable[[{}], {}]'.format(", ".join(arg_strings), return_type)
             else:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -354,7 +354,7 @@ def is_callable_subtype(left: CallableType, right: CallableType,
                 right_by_position = right.argument_by_position(j)
                 assert right_by_position is not None
                 if not are_args_compatible(left_by_position, right_by_position,
-                                            ignore_pos_arg_names):
+                                           ignore_pos_arg_names):
                     return False
                 j += 1
             continue
@@ -367,8 +367,8 @@ def is_callable_subtype(left: CallableType, right: CallableType,
             # sure left has its own infinite set of optional named arguments.
             if not left.is_kw_arg:
                 return False
-            left_names = { name for name in left.arg_names if name is not None }
-            right_names = { name for name in right.arg_names if name is not None }
+            left_names = {name for name in left.arg_names if name is not None}
+            right_names = {name for name in right.arg_names if name is not None}
             left_only_names = left_names - right_names
             for name in left_only_names:
                 left_by_name = left.argument_by_name(name)
@@ -377,7 +377,7 @@ def is_callable_subtype(left: CallableType, right: CallableType,
                 right_by_name = right.argument_by_name(name)
                 assert right_by_name is not None
                 if not are_args_compatible(left_by_name, right_by_name,
-                                            ignore_pos_arg_names):
+                                           ignore_pos_arg_names):
                     return False
             continue
 
@@ -445,13 +445,13 @@ def is_callable_subtype(left: CallableType, right: CallableType,
                 return False
             continue
 
-        right_by_name = ( right.argument_by_name(left_arg.name)
-                          if left_arg.name is not None
-                          else None )
+        right_by_name = (right.argument_by_name(left_arg.name)
+                         if left_arg.name is not None
+                         else None)
 
-        right_by_pos = ( right.argument_by_position(left_arg.pos)
-                         if left_arg.pos is not None
-                         else None )
+        right_by_pos = (right.argument_by_position(left_arg.pos)
+                        if left_arg.pos is not None
+                        else None)
 
         # If the left hand argument corresponds to two right-hand arguments,
         # neither of them can be required.

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -322,7 +322,7 @@ def is_callable_subtype(left: CallableType, right: CallableType,
     # used for in practice.
 
     # Every argument in R must have a corresponding argument in L, and every
-    # required argument in L must have a corresponding arugment in R.
+    # required argument in L must have a corresponding argument in R.
     done_with_positional = False
     for i in range(len(right.arg_types)):
         right_kind = right.arg_kinds[i]

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -353,7 +353,7 @@ def is_callable_subtype(left: CallableType, right: CallableType,
                 # This fetches the synthetic argument that's from the *args
                 right_by_position = right.argument_by_position(j)
                 assert right_by_position is not None
-                if not is_left_more_general(left_by_position, right_by_position,
+                if not are_args_compatible(left_by_position, right_by_position,
                                             ignore_pos_arg_names):
                     return False
                 j += 1
@@ -376,7 +376,7 @@ def is_callable_subtype(left: CallableType, right: CallableType,
                 # This fetches the synthetic argument that's from the **kwargs
                 right_by_name = right.argument_by_name(name)
                 assert right_by_name is not None
-                if not is_left_more_general(left_by_name, right_by_name,
+                if not are_args_compatible(left_by_name, right_by_name,
                                             ignore_pos_arg_names):
                     return False
             continue
@@ -421,7 +421,7 @@ def is_callable_subtype(left: CallableType, right: CallableType,
 
         assert left_arg is not None
 
-        if not is_left_more_general(left_arg, right_arg, ignore_pos_arg_names):
+        if not are_args_compatible(left_arg, right_arg, ignore_pos_arg_names):
             return False
 
     done_with_positional = False
@@ -462,14 +462,14 @@ def is_callable_subtype(left: CallableType, right: CallableType,
             return False
 
         # All *required* left-hand arguments must have a corresponding
-        # right-hand argument.
+        # right-hand argument.  Optional args it does not matter.
         if left_arg.required and right_by_pos is None and right_by_name is None:
             return False
 
     return True
 
 
-def is_left_more_general(
+def are_args_compatible(
         left: FormalArgument,
         right: FormalArgument,
         ignore_pos_arg_names: bool) -> bool:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -275,6 +275,11 @@ def is_callable_subtype(left: CallableType, right: CallableType,
                         ignore_return: bool = False,
                         ignore_pos_arg_names: bool = False) -> bool:
     """Is left a subtype of right?"""
+
+    # If either function is implicitly typed, ignore positional arg names too
+    if left.implicit or right.implicit:
+        ignore_pos_arg_names = True
+
     # Non-type cannot be a subtype of type.
     if right.is_type_obj() and not left.is_type_obj():
         return False

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -367,8 +367,8 @@ def is_callable_subtype(left: CallableType, right: CallableType,
             # sure left has its own infinite set of optional named arguments.
             if not left.is_kw_arg:
                 return False
-            left_names = set([name for name in left.arg_names if name is not None])
-            right_names = set([name for name in right.arg_names if name is not None])
+            left_names = { name for name in left.arg_names if name is not None }
+            right_names = { name for name in right.arg_names if name is not None }
             left_only_names = left_names - right_names
             for name in left_only_names:
                 left_by_name = left.argument_by_name(name)
@@ -401,7 +401,11 @@ def is_callable_subtype(left: CallableType, right: CallableType,
                 and left_by_position is not None
                 and left_by_name != left_by_position):
             # If we're dealing with an optional pos-only and an optional
-            # name-only arg, merge them.
+            # name-only arg, merge them.  This is the case for all functions
+            # taking both *args and **args, or a pair of functions like so:
+
+            # def right(a: int = ...) -> None: ...
+            # def left(__a: int = ..., *, a: int = ...) -> None: ...
             if (left_by_position.required is False and left_by_name.required is False
                     and left_by_position.name is None and left_by_name.pos is None
                     and is_equivalent(left_by_position.typ, left_by_name.typ)):

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -64,8 +64,11 @@ def is_subtype_ignoring_tvars(left: Type, right: Type) -> bool:
 
 
 def is_equivalent(a: Type, b: Type,
-                  type_parameter_checker: TypeParameterChecker = check_type_parameter) -> bool:
-    return is_subtype(a, b, type_parameter_checker) and is_subtype(b, a, type_parameter_checker)
+                  type_parameter_checker: TypeParameterChecker = check_type_parameter,
+                  *, ignore_pos_arg_names=False) -> bool:
+    return (
+        is_subtype(a, b, type_parameter_checker, ignore_pos_arg_names=ignore_pos_arg_names)
+        and is_subtype(b, a, type_parameter_checker, ignore_pos_arg_names=ignore_pos_arg_names))
 
 
 def satisfies_upper_bound(a: Type, upper_bound: Type) -> bool:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -15,6 +15,7 @@ from mypy.nodes import (
 )
 
 from mypy import experiments
+from mypy.sharedparse import argument_elide_name
 
 
 T = TypeVar('T')
@@ -1699,7 +1700,7 @@ def function_type(func: mypy.nodes.FuncBase, fallback: Instance) -> FunctionLike
         return CallableType(
             [AnyType()] * len(fdef.arg_names),
             fdef.arg_kinds,
-            fdef.arg_names,
+            [None if argument_elide_name(n) else n for n in fdef.arg_names],
             AnyType(),
             fallback,
             name,

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -545,8 +545,8 @@ _dummy = object()  # type: Any
 
 
 FormalArgument = NamedTuple('FormalArgument', [
-    ('name', str),
-    ('pos', int),
+    ('name', Optional[str]),
+    ('pos', Optional[int]),
     ('typ', Type),
     ('required', bool)])
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -671,7 +671,33 @@ class CallableType(FunctionLike):
             n -= 1
         return n
 
+    def corresponding_argument(self, model: FormalArgument) -> Optional[FormalArgument]:
+        """Return the argument in this function that corresponds to `model`"""
+
+        by_name = self.argument_by_name(model.name)
+        by_pos = self.argument_by_position(model.pos)
+        if by_name is None and by_pos is None:
+            return None
+        if by_name is not None and by_pos is not None:
+            if by_name == by_pos:
+                return by_name
+            # If we're dealing with an optional pos-only and an optional
+            # name-only arg, merge them.  This is the case for all functions
+            # taking both *args and **args, or a pair of functions like so:
+
+            # def right(a: int = ...) -> None: ...
+            # def left(__a: int = ..., *, a: int = ...) -> None: ...
+            from mypy.subtypes import is_equivalent
+            if (not (by_name.required or by_pos.required)
+                    and by_pos.name is None
+                    and by_name.pos is None
+                    and is_equivalent(by_name.typ, by_pos.typ)):
+                return FormalArgument(by_name.name, by_pos.pos, by_name.typ, False)
+        return by_name if by_name is not None else by_pos
+
     def argument_by_name(self, name: str) -> Optional[FormalArgument]:
+        if name is None:
+            return None
         seen_star = False
         star2_type = None  # type: Optional[Type]
         for i, (arg_name, kind, typ) in enumerate(
@@ -692,6 +718,8 @@ class CallableType(FunctionLike):
         return None
 
     def argument_by_position(self, position: int) -> Optional[FormalArgument]:
+        if position is None:
+            return None
         if self.is_var_arg:
             for kind, typ in zip(self.arg_kinds, self.arg_types):
                 if kind == ARG_STAR:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -662,6 +662,58 @@ class CallableType(FunctionLike):
             n -= 1
         return n
 
+    def argument_by_name(self, name: str) -> Optional[Tuple[
+            Optional[str],
+            Optional[int],
+            Type,
+            bool]]:
+        seen_star = False
+        star2_type = None  # type: Optional[Type]
+        for i, (arg_name, kind, typ) in enumerate(
+                zip(self.arg_names, self.arg_kinds, self.arg_types)):
+            # No more positional arguments after these.
+            if kind in (ARG_STAR, ARG_STAR2, ARG_NAMED, ARG_NAMED_OPT):
+                seen_star = True
+            if kind == ARG_STAR:
+                continue
+            if kind == ARG_STAR2:
+                star2_type = typ
+                continue
+            if arg_name == name:
+                position = None if seen_star else i
+                return name, position, typ, kind in (ARG_POS, ARG_NAMED)
+        if star2_type is not None:
+            return name, None, star2_type, False
+        return None
+
+    def argument_by_position(self, position: int) -> Optional[Tuple[
+            Optional[str],
+            Optional[int],
+            Type,
+            bool]]:
+        if self.is_var_arg:
+            for kind, typ in zip(self.arg_kinds, self.arg_types):
+                if kind == ARG_STAR:
+                    star_type = typ
+                    break
+        if position >= len(self.arg_names):
+            if self.is_var_arg:
+                return None, position, star_type, False
+            else:
+                return None
+        name, kind, typ = (
+            self.arg_names[position],
+            self.arg_kinds[position],
+            self.arg_types[position],
+        )
+        if kind in (ARG_POS, ARG_OPT):
+            return name, position, typ, kind == ARG_POS
+        else:
+            if self.is_var_arg:
+                return None, position, star_type, False
+            else:
+                return None
+
     def items(self) -> List['CallableType']:
         return [self]
 

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -33,9 +33,6 @@ class B(A):
 class C(A):
     def f(self, *, b: int, a: str) -> None: pass # E: Signature of "f" incompatible with supertype "A"
 
-[out]
-main: note: In class "C":
-
 [case testPositionalOverridingArgumentNameInsensitivity]
 import typing
 
@@ -48,8 +45,6 @@ class B(A):
 class C(A):
     def f(self, foo: int, bar: str) -> None: pass
 
-[out]
-main: note: In class "B":
 
 [case testPositionalOverridingArgumentNamesCheckedWhenMismatchingPos]
 import typing
@@ -60,8 +55,6 @@ class A(object):
 class B(A):
     def f(self, b: int, a: str) -> None: pass # E: Signature of "f" incompatible with supertype "A"
 
-[out]
-main: note: In class "B":
 
 [case testSubtypingFunctionTypes]
 from typing import Callable

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -149,8 +149,8 @@ ee_def = specific_1 # E: Incompatible types in assignment (expression has type C
 
 [case testLackOfNamesImplicitAny]
 
-def f(__a): pass
-def g(a): pass
+def f(__a) -> Any: pass
+def g(a) -> Any: pass
 
 ff = f
 gg = g
@@ -161,8 +161,8 @@ gg = f # E: Incompatible types in assignment (expression has type Callable[[Any]
 [case testLackOfNamesImplicitAnyFastparse]
 # flags: --fast-parser
 
-def f(__a): pass
-def g(a): pass
+def f(__a) -> Any: pass
+def g(a) -> Any: pass
 
 ff = f
 gg = g

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -99,10 +99,10 @@ hh = h
 ff = gg
 ff_nonames = ff
 ff_nonames = f_nonames # reset
-ff = ff_nonames # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[Arg('a', int, False), Arg('b', str, False)], None])
+ff = ff_nonames # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[Arg('a', int), Arg('b', str)], None])
 ff = f # reset
-gg = ff # E: Incompatible types in assignment (expression has type Callable[[Arg('a', int, False), Arg('b', str, False)], None], variable has type Callable[[Arg('a', int, False), DefaultArg('b', str, False)], None])
-gg = hh # E: Incompatible types in assignment (expression has type Callable[[Arg('aa', int, False), DefaultArg('b', str, False)], None], variable has type Callable[[Arg('a', int, False), DefaultArg('b', str, False)], None])
+gg = ff # E: Incompatible types in assignment (expression has type Callable[[Arg('a', int), Arg('b', str)], None], variable has type Callable[[Arg('a', int), DefaultArg('b', str)], None])
+gg = hh # E: Incompatible types in assignment (expression has type Callable[[Arg('aa', int), DefaultArg('b', str)], None], variable has type Callable[[Arg('a', int), DefaultArg('b', str)], None])
 
 [case testSubtypingFunctionsArgsKwargs]
 from typing import Any, Callable
@@ -127,8 +127,8 @@ ee_def = everything
 ee_var = everything
 ee_var = everywhere
 
-ee_var = specific_1 # The difference between Callable[[...], blah] and one with a *args: Any, **kwargs: Any is that the ... goes loosely both ways.
-ee_def = specific_1 # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[Any, Any], None])
+ee_var = specific_1 # The difference between Callable[..., blah] and one with a *args: Any, **kwargs: Any is that the ... goes loosely both ways.
+ee_def = specific_1 # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[StarArg(Any), KwArg(Any)], None])
 
 [builtins fixtures/dict.pyi]
 
@@ -140,7 +140,7 @@ def g(a): pass
 ff = f
 gg = g
 ff = g
-gg = f # E: Incompatible types in assignment (expression has type Callable[[Any], Any], variable has type Callable[[Arg('a', Any, False)], Any])
+gg = f # E: Incompatible types in assignment (expression has type Callable[[Any], Any], variable has type Callable[[Arg('a', Any)], Any])
 
 
 [case testLackOfNamesImplicitAnyFastparse]
@@ -152,7 +152,7 @@ def g(a): pass
 ff = f
 gg = g
 ff = g
-gg = f # E: Incompatible types in assignment (expression has type Callable[[Any], Any], variable has type Callable[[Arg('a', Any, False)], Any])
+gg = f # E: Incompatible types in assignment (expression has type Callable[[Any], Any], variable has type Callable[[Arg('a', Any)], Any])
 
 [case testLackOfNames]
 def f(__a: int, __b: str) -> None: pass
@@ -162,7 +162,7 @@ ff = f
 gg = g
 
 ff = g
-gg = f # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[Arg('a', int, False), Arg('b', str, False)], None])
+gg = f # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[Arg('a', int), Arg('b', str)], None])
 
 [case testLackOfNamesFastparse]
 # flags: --fast-parser
@@ -174,7 +174,7 @@ ff = f
 gg = g
 
 ff = g
-gg = f # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[Arg('a', int, False), Arg('b', str, False)], None])
+gg = f # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[Arg('a', int), Arg('b', str)], None])
 
 [case testFunctionTypeCompatibilityWithOtherTypes]
 from typing import Callable
@@ -1412,7 +1412,7 @@ def g4(*, y: int) -> str: pass
 f(g1)
 f(g2)
 f(g3)
-f(g4) # E: Argument 1 to "f" has incompatible type Callable[[int], str]; expected Callable[..., int]
+f(g4) # E: Argument 1 to "f" has incompatible type Callable[[NamedArg('y', int)], str]; expected Callable[..., int]
 
 [case testCallableWithArbitraryArgsSubtypingWithGenericFunc]
 from typing import Callable, TypeVar
@@ -1540,7 +1540,7 @@ def g(x, y): pass
 def h(x): pass
 def j(y): pass
 f = h
-f = j # E: Incompatible types in assignment (expression has type Callable[[Arg('y', Any, False)], Any], variable has type Callable[[Arg('x', Any, False)], Any])
+f = j # E: Incompatible types in assignment (expression has type Callable[[Arg('y', Any)], Any], variable has type Callable[[Arg('x', Any)], Any])
 f = g # E: Incompatible types in assignment (expression has type Callable[[Any, Any], Any], variable has type Callable[[Any], Any])
 
 [case testRedefineFunction2]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -132,6 +132,28 @@ ee_def = specific_1 # E: Incompatible types in assignment (expression has type C
 
 [builtins fixtures/dict.pyi]
 
+[case testLackOfNamesImplicitAny]
+
+def f(__a): pass
+def g(a): pass
+
+ff = f
+gg = g
+ff = g
+gg = f # E: Incompatible types in assignment (expression has type Callable[[Any], Any], variable has type Callable[[Arg('a', Any, False)], Any])
+
+
+[case testLackOfNamesImplicitAnyFastparse]
+# flags: --fast-parser
+
+def f(__a): pass
+def g(a): pass
+
+ff = f
+gg = g
+ff = g
+gg = f # E: Incompatible types in assignment (expression has type Callable[[Any], Any], variable has type Callable[[Arg('a', Any, False)], Any])
+
 [case testLackOfNames]
 def f(__a: int, __b: str) -> None: pass
 def g(a: int, b: str) -> None: pass

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -147,28 +147,6 @@ ee_def = specific_1 # E: Incompatible types in assignment (expression has type C
 
 [builtins fixtures/dict.pyi]
 
-[case testLackOfNamesImplicitAny]
-
-def f(__a) -> Any: pass
-def g(a) -> Any: pass
-
-ff = f
-gg = g
-ff = g
-gg = f # E: Incompatible types in assignment (expression has type Callable[[Any], Any], variable has type Callable[[Arg('a', Any)], Any])
-
-
-[case testLackOfNamesImplicitAnyFastparse]
-# flags: --fast-parser
-
-def f(__a) -> Any: pass
-def g(a) -> Any: pass
-
-ff = f
-gg = g
-ff = g
-gg = f # E: Incompatible types in assignment (expression has type Callable[[Any], Any], variable has type Callable[[Arg('a', Any)], Any])
-
 [case testLackOfNames]
 def f(__a: int, __b: str) -> None: pass
 def g(a: int, b: str) -> None: pass

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -87,6 +87,17 @@ def l(x, y) -> None: ...
 def r(x) -> None: ...
 r = l # E: Incompatible types in assignment (expression has type Callable[[Any, Any], None], variable has type Callable[[Any], None])
 
+[case testSubtypingFunctionsImplicitNames]
+
+def f(a, b): pass
+def g(c: Any, d: Any) -> Any: pass
+
+ff = f
+gg = g
+
+gg = f
+ff = g
+
 [case testSubtypingFunctionsDefaultsNames]
 from typing import Callable
 
@@ -1539,10 +1550,10 @@ class A(Generic[t]):
 
 
 [case testRedefineFunction]
-def f(x): pass
+def f(x) -> Any: pass
 def g(x, y): pass
 def h(x): pass
-def j(y): pass
+def j(y) -> Any: pass
 f = h
 f = j # E: Incompatible types in assignment (expression has type Callable[[Arg('y', Any)], Any], variable has type Callable[[Arg('x', Any)], Any])
 f = g # E: Incompatible types in assignment (expression has type Callable[[Any, Any], Any], variable has type Callable[[Any], Any])

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -21,6 +21,48 @@ b = f(a)
 class A: pass
 class B: pass
 
+[case testKeywordOnlyArgumentOrderInsensitivity]
+import typing
+
+class A(object):
+    def f(self, *, a: int, b: str) -> None: pass
+
+class B(A):
+    def f(self, *, b: str, a: int) -> None: pass
+
+class C(A):
+    def f(self, *, b: int, a: str) -> None: pass # E: Signature of "f" incompatible with supertype "A"
+
+[out]
+main: note: In class "C":
+
+[case testPositionalOverridingArgumentNameInsensitivity]
+import typing
+
+class A(object):
+    def f(self, a: int, b: str) -> None: pass
+
+class B(A):
+    def f(self, b: str, a: int) -> None: pass # E: Argument 1 of "f" incompatible with supertype "A" # E: Argument 2 of "f" incompatible with supertype "A"
+
+class C(A):
+    def f(self, foo: int, bar: str) -> None: pass
+
+[out]
+main: note: In class "B":
+
+[case testPositionalOverridingArgumentNamesCheckedWhenMismatchingPos]
+import typing
+
+class A(object):
+    def f(self, a: int, b: str) -> None: pass
+
+class B(A):
+    def f(self, b: int, a: str) -> None: pass # E: Signature of "f" incompatible with supertype "A"
+
+[out]
+main: note: In class "B":
+
 [case testSubtypingFunctionTypes]
 from typing import Callable
 
@@ -39,6 +81,78 @@ f = h
 f = f
 g = g
 h = h
+
+
+[case testSubtypingFunctionsDefaultsNames]
+from typing import Callable
+
+def f(a: int, b: str) -> None: pass
+f_nonames = None # type: Callable[[int, str], None]
+def g(a: int, b: str = "") -> None: pass
+def h(aa: int, b: str = "") -> None: pass
+
+ff_nonames = f_nonames
+ff = f
+gg = g
+hh = h
+
+ff = gg
+ff_nonames = ff
+ff_nonames = f_nonames # reset
+ff = ff_nonames # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[Arg('a', int, False), Arg('b', str, False)], None])
+ff = f # reset
+gg = ff # E: Incompatible types in assignment (expression has type Callable[[Arg('a', int, False), Arg('b', str, False)], None], variable has type Callable[[Arg('a', int, False), DefaultArg('b', str, False)], None])
+gg = hh # E: Incompatible types in assignment (expression has type Callable[[Arg('aa', int, False), DefaultArg('b', str, False)], None], variable has type Callable[[Arg('a', int, False), DefaultArg('b', str, False)], None])
+
+[case testSubtypingFunctionsArgsKwargs]
+from typing import Any, Callable
+
+def everything(*args: Any, **kwargs: Any) -> None: pass
+everywhere = None # type: Callable[..., None]
+
+def specific_1(a: int, b: str) -> None: pass
+def specific_2(a: int, *, b: str) -> None: pass
+
+ss_1 = specific_1
+ss_2 = specific_2
+ee_def = everything
+ee_var = everywhere
+
+ss_1 = ee_def
+ss_1 = specific_1
+ss_2 = ee_def
+ss_2 = specific_2
+ee_def = everywhere
+ee_def = everything
+ee_var = everything
+ee_var = everywhere
+
+ee_var = specific_1 # The difference between Callable[[...], blah] and one with a *args: Any, **kwargs: Any is that the ... goes loosely both ways.
+ee_def = specific_1 # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[Any, Any], None])
+
+[case testLackOfNames]
+def f(__a: int, __b: str) -> None: pass
+def g(a: int, b: str) -> None: pass
+
+ff = f
+gg = g
+
+ff = g
+gg = f # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[Arg('a', int, False), Arg('b', str, False)], None])
+
+[case testLackOfNamesFastparse]
+# flags: --fast-parser
+
+def f(__a: int, __b: str) -> None: pass
+def g(a: int, b: str) -> None: pass
+
+ff = f
+gg = g
+
+ff = g
+gg = f # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[Arg('a', int, False), Arg('b', str, False)], None])
+
+[builtins fixtures/dict.pyi]
 
 [case testFunctionTypeCompatibilityWithOtherTypes]
 from typing import Callable
@@ -1401,8 +1515,10 @@ class A(Generic[t]):
 [case testRedefineFunction]
 def f(x): pass
 def g(x, y): pass
-def h(y): pass
+def h(x): pass
+def j(y): pass
 f = h
+f = j # E: Incompatible types in assignment (expression has type Callable[[Arg('y', Any, False)], Any], variable has type Callable[[Arg('x', Any, False)], Any])
 f = g # E: Incompatible types in assignment (expression has type Callable[[Any, Any], Any], variable has type Callable[[Any], Any])
 
 [case testRedefineFunction2]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -82,6 +82,17 @@ f = f
 g = g
 h = h
 
+[case testSubtypingFunctionsDoubleCorrespondence]
+
+def l(x) -> None: ...
+def r(__, *, x) -> None: ...
+r = l # E: Incompatible types in assignment (expression has type Callable[[Any], None], variable has type Callable[[Any, NamedArg('x', Any)], None])
+
+[case testSubtypingFunctionsRequiredLeftArgNotPresent]
+
+def l(x, y) -> None: ...
+def r(x) -> None: ...
+r = l # E: Incompatible types in assignment (expression has type Callable[[Any, Any], None], variable has type Callable[[Any], None])
 
 [case testSubtypingFunctionsDefaultsNames]
 from typing import Callable

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -130,6 +130,8 @@ ee_var = everywhere
 ee_var = specific_1 # The difference between Callable[[...], blah] and one with a *args: Any, **kwargs: Any is that the ... goes loosely both ways.
 ee_def = specific_1 # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[Any, Any], None])
 
+[builtins fixtures/dict.pyi]
+
 [case testLackOfNames]
 def f(__a: int, __b: str) -> None: pass
 def g(a: int, b: str) -> None: pass
@@ -151,8 +153,6 @@ gg = g
 
 ff = g
 gg = f # E: Incompatible types in assignment (expression has type Callable[[int, str], None], variable has type Callable[[Arg('a', int, False), Arg('b', str, False)], None])
-
-[builtins fixtures/dict.pyi]
 
 [case testFunctionTypeCompatibilityWithOtherTypes]
 from typing import Callable

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -594,7 +594,7 @@ try:
 except:
     f = g
 [file m.py]
-def f(y): pass
+def f(x): pass
 
 [case testImportFunctionAndAssignIncompatible]
 try:

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -22,7 +22,7 @@ from typing import Any
 class B:
   def f(self, y: 'A') -> None: pass
 class A(B):
-  def f(self, x: Any) -> None:
+  def f(self, y: Any) -> None:
     a, b = None, None # type: (A, B)
     super().f(b) # E: Argument 1 to "f" of "B" has incompatible type "B"; expected "A"
     super().f(a)

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -572,7 +572,7 @@ x = None # type: Callable[[int], None]
 def f(*x: int) -> None: pass
 def g(*x: str) -> None: pass
 x = f
-x = g # E: Incompatible types in assignment (expression has type Callable[[str], None], variable has type Callable[[int], None])
+x = g # E: Incompatible types in assignment (expression has type Callable[[StarArg(str)], None], variable has type Callable[[int], None])
 [builtins fixtures/list.pyi]
 [out]
 

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -755,7 +755,7 @@ def f(*args: str) -> str: return args[0]
 map(f, ['x'])
 map(f, [1])
 [out]
-_program.py:4: error: Argument 1 to "map" has incompatible type Callable[[str], str]; expected Callable[[int], str]
+_program.py:4: error: Argument 1 to "map" has incompatible type Callable[[StarArg(str)], str]; expected Callable[[int], str]
 
 [case testMapStr]
 import typing


### PR DESCRIPTION
Before, the logic for determining whether a function was an `Any`-permissive subtype of another function compared their argument types in order, with some special provision for `*args`.  It did not handle keyword-only arguments, or `**kwargs`, or argument names being different, or any other such situation.

This PR introduces an algorithm for `is_callable_subtype` that pairs up corresponding arguments by both name and position, and makes sure the argument in the ostensible subtype is "more general".  It also deals with what happens when an arg in one function corresponds to different args in the other function when you try to pair it up by name vs. when you try to pair it up by argument position.

Note that specifically for the case of determining whether a function is a valid override, we ignore the names of positional arguments; too many people regularly pay no attention to the names of positional arguments of functions in subtypes in code they write, even if it's not a technically perfect python subtype.  We do error in the case the names of positional arguments are transposed (ex. argument `foo` is the first argument in one function, but the second argument in the other), as this is likely to be an actual mistake.  

We pay attention to the names of positional arguments for assignment statements and argument accepting.