### PR TITLE
Turn --hide-error-context on by default

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -13,7 +13,7 @@ flag (or its long form ``--help``)::
               [--disallow-untyped-defs] [--check-untyped-defs]
               [--disallow-subclassing-any] [--warn-incomplete-stub]
               [--warn-redundant-casts] [--warn-no-return]
-              [--warn-unused-ignores] [--hide-error-context] [--fast-parser]
+              [--warn-unused-ignores] [--show-error-context] [--fast-parser]
               [-i] [--cache-dir DIR] [--strict-optional]
               [--strict-optional-whitelist [GLOB [GLOB ...]]]
               [--junit-xml JUNIT_XML] [--pdb] [--show-traceback] [--stats]

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -95,7 +95,7 @@ The following global flags may only be set in the global section
 - ``cache_dir`` (string, default ``.mypy_cache``) stores module cache
   info in the given folder in incremental mode.
 
-- ``hide_error_context`` (Boolean, default False) hides
+- ``show_error_context`` (Boolean, default False) shows
   context notes before errors.
 
 - ``show_column_numbers`` (Boolean, default False) shows column numbers in

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -99,13 +99,13 @@ class Errors:
     # Collection of reported only_once messages.
     only_once_messages = None  # type: Set[str]
 
-    # Set to True to suppress "In function "foo":" messages.
-    hide_error_context = False  # type: bool
+    # Set to False to show "In function "foo":" messages.
+    hide_error_context = True  # type: bool
 
     # Set to True to show column numbers in error messages
     show_column_numbers = False  # type: bool
 
-    def __init__(self, hide_error_context: bool = False,
+    def __init__(self, hide_error_context: bool = True,
                  show_column_numbers: bool = False) -> None:
         self.error_info = []
         self.import_ctx = []

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -171,7 +171,7 @@ def process_options(args: List[str],
                         help="warn about functions that end without returning")
     parser.add_argument('--warn-unused-ignores', action='store_true',
                         help="warn about unneeded '# type: ignore' comments")
-    parser.add_argument('--hide-error-context', action='store_true',
+    parser.add_argument('--show-error-context', action='store_false',
                         dest='hide_error_context',
                         help="Hide context notes before errors")
     parser.add_argument('--fast-parser', action='store_true',

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -111,7 +111,7 @@ class Options:
         self.incremental = False
         self.cache_dir = defaults.CACHE_DIR
         self.debug_cache = False
-        self.hide_error_context = False  # Hide "note: In function "foo":" messages.
+        self.hide_error_context = True  # Hide "note: In function "foo":" messages.
         self.shadow_file = None  # type: Optional[Tuple[str, str]]
         self.show_column_numbers = False  # type: bool
 

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -636,7 +636,6 @@ b.x() # E
 [builtins fixtures/property.pyi]
 [out]
 main:7: error: Return type of "x" incompatible with supertype "A"
-main: note: At top level:
 main:9: error: "str" not callable
 
 [case testCantImplementAbstractPropertyViaInstanceVariable]
@@ -653,7 +652,6 @@ b.x.y # E
 [out]
 main: note: In member "__init__" of class "B":
 main:7: error: Property "x" defined in "B" is read-only
-main: note: At top level:
 main:8: error: Cannot instantiate abstract class 'B' with abstract attribute 'x'
 main:9: error: "int" has no attribute "y"
 
@@ -705,7 +703,6 @@ b.x.y # E
 [builtins fixtures/property.pyi]
 [out]
 main:8: error: Read-only property cannot override read-write property
-main: note: At top level:
 main:11: error: "int" has no attribute "y"
 
 [case testDynamicallyTypedReadOnlyAbstractProperty]

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -563,7 +563,6 @@ def f(a: A) -> None:
     a.x() # E: "int" not callable
     a.x = 1  # E: Property "x" defined in "A" is read-only
 [out]
-main: note: In function "f":
 
 [case testReadOnlyAbstractPropertyForwardRef]
 from abc import abstractproperty, ABCMeta
@@ -574,7 +573,6 @@ class A(metaclass=ABCMeta):
     @abstractproperty
     def x(self) -> int: pass
 [out]
-main: note: In function "f":
 
 [case testReadWriteAbstractProperty]
 from abc import abstractproperty, ABCMeta
@@ -587,7 +585,6 @@ class A(metaclass=ABCMeta):
     @x.setter
     def x(self, x: int) -> None: pass
 [out]
-main: note: In function "f":
 
 [case testInstantiateClassWithReadOnlyAbstractProperty]
 from abc import abstractproperty, ABCMeta
@@ -701,7 +698,6 @@ class B(A):
 [out]
 main: note: In member "x" of class "B":
 main:10: error: "int" has no attribute "y"
-main: note: In function "x":
 main:13: error: Invalid assignment target
 
 [case testOnlyImplementGetterOfReadWriteAbstractProperty]
@@ -732,7 +728,6 @@ def f(a: A) -> None:
     a.x.y
     a.x = 1  # E: Property "x" defined in "A" is read-only
 [out]
-main: note: In function "f":
 
 [case testDynamicallyTypedReadOnlyAbstractPropertyForwardRef]
 from abc import abstractproperty, ABCMeta
@@ -743,7 +738,6 @@ class A(metaclass=ABCMeta):
     @abstractproperty
     def x(self): pass
 [out]
-main: note: In function "f":
 
 [case testDynamicallyTypedReadWriteAbstractProperty]
 from abc import abstractproperty, ABCMeta

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -516,7 +516,6 @@ class A(metaclass=ABCMeta):
     @abstractmethod
     def g(self, x: str) -> None: pass
 [out]
-main: note: In member "f" of class "A":
 
 [case testAbstractOperatorMethods1]
 import typing
@@ -650,7 +649,6 @@ b = B() # E
 b.x.y # E
 [builtins fixtures/property.pyi]
 [out]
-main: note: In member "__init__" of class "B":
 main:7: error: Property "x" defined in "B" is read-only
 main:8: error: Cannot instantiate abstract class 'B' with abstract attribute 'x'
 main:9: error: "int" has no attribute "y"
@@ -666,7 +664,6 @@ class B(A):
         return super().x.y # E: "int" has no attribute "y"
 [builtins fixtures/property.pyi]
 [out]
-main: note: In member "x" of class "B":
 
 [case testSuperWithReadWriteAbstractProperty]
 from abc import abstractproperty, ABCMeta
@@ -684,7 +681,6 @@ class B(A):
         super().x = '' # E
 [builtins fixtures/property.pyi]
 [out]
-main: note: In member "x" of class "B":
 main:10: error: "int" has no attribute "y"
 main:13: error: Invalid assignment target
 

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -203,7 +203,6 @@ class B(A):
         pass
     def g(self, x: int) -> int: pass
 [out]
-main: note: In class "B":
 
 [case testImplementingAbstractMethodWithMultipleBaseClasses]
 from abc import abstractmethod, ABCMeta
@@ -221,7 +220,6 @@ class A(I, J):
         # E: Return type of "g" incompatible with supertype "J"
     def h(self) -> int: pass # Not related to any base class
 [out]
-main: note: In class "A":
 
 [case testImplementingAbstractMethodWithExtension]
 from abc import abstractmethod, ABCMeta
@@ -234,7 +232,6 @@ class A(I):
     def f(self, x: str) -> int: pass \
         # E: Argument 1 of "f" incompatible with supertype "J"
 [out]
-main: note: In class "A":
 
 [case testInvalidOverridingAbstractMethod]
 from abc import abstractmethod, ABCMeta
@@ -246,7 +243,6 @@ class I(J):
     @abstractmethod
     def f(self, x: 'I') -> None: pass # E: Argument 1 of "f" incompatible with supertype "J"
 [out]
-main: note: In class "I":
 
 [case testAbstractClassCoAndContraVariance]
 from abc import abstractmethod, ABCMeta
@@ -266,7 +262,6 @@ class A(I):
     def g(self, a: 'A') -> 'A':
         pass
 [out]
-main: note: In class "A":
 main:11: error: Argument 1 of "h" incompatible with supertype "I"
 main:11: error: Return type of "h" incompatible with supertype "I"
 
@@ -323,7 +318,6 @@ class A(I):
     def g(self, x, y) -> None: pass \
         # E: Signature of "g" incompatible with supertype "I"
 [out]
-main: note: In class "A":
 
 [case testAbstractClassWithAllDynamicTypes2]
 from abc import abstractmethod, ABCMeta
@@ -477,7 +471,6 @@ class A(metaclass=ABCMeta):
   @overload
   def f(self, x: str) -> str: pass
 [out]
-main: note: In class "A":
 
 [case testOverloadedAbstractMethodVariantMissingDecorator1]
 from abc import abstractmethod, ABCMeta
@@ -491,7 +484,6 @@ class A(metaclass=ABCMeta):
   @overload
   def f(self, x: str) -> str: pass
 [out]
-main: note: In class "A":
 
 [case testMultipleInheritanceAndAbstractMethod]
 import typing
@@ -513,7 +505,6 @@ class B(metaclass=ABCMeta):
   def f(self, x: int) -> None: pass
 class C(A, B): pass
 [out]
-main: note: In class "C":
 main:8: error: Definition of "f" in base class "A" is incompatible with definition in base class "B"
 
 [case testCallAbstractMethodBeforeDefinition]
@@ -644,7 +635,6 @@ b = B()
 b.x() # E
 [builtins fixtures/property.pyi]
 [out]
-main: note: In class "B":
 main:7: error: Return type of "x" incompatible with supertype "A"
 main: note: At top level:
 main:9: error: "str" not callable
@@ -714,7 +704,6 @@ b = B()
 b.x.y # E
 [builtins fixtures/property.pyi]
 [out]
-main: note: In class "B":
 main:8: error: Read-only property cannot override read-write property
 main: note: At top level:
 main:11: error: "int" has no attribute "y"

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -316,7 +316,7 @@ main: note: In function "f":
 -- ------------------------------------------
 
 [case testFullCoroutineMatrix]
-# flags: --fast-parser --hide-error-context
+# flags: --fast-parser
 from typing import Any, AsyncIterator, Awaitable, Generator, Iterator
 from types import coroutine
 

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -22,7 +22,6 @@ async def f() -> int:
     return x
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 
 [case testAwaitDefaultContext]
 # flags: --fast-parser
@@ -33,7 +32,6 @@ async def f(x: T) -> T:
     reveal_type(y)
     return y
 [out]
-main: note: In function "f":
 main:6: error: Revealed type is 'T`-1'
 
 [case testAwaitAnyContext]
@@ -45,7 +43,6 @@ async def f(x: T) -> T:
     reveal_type(y)
     return y
 [out]
-main: note: In function "f":
 main:6: error: Revealed type is 'Any'
 
 [case testAwaitExplicitContext]
@@ -56,7 +53,6 @@ async def f(x: T) -> T:
     y = await f(x)  # type: int
     reveal_type(y)
 [out]
-main: note: In function "f":
 main:5: error: Argument 1 to "f" has incompatible type "T"; expected "int"
 main:6: error: Revealed type is 'builtins.int'
 
@@ -70,7 +66,6 @@ async def f() -> int:
     x = await g()
     return x
 [out]
-main: note: In function "f":
 main:7: error: Incompatible types in await (actual type Generator[int, None, str], expected type "Awaitable")
 
 [case testAwaitIteratorError]
@@ -82,7 +77,6 @@ async def f() -> int:
     x = await g()
     return x
 [out]
-main: note: In function "f":
 main:6: error: Incompatible types in await (actual type Iterator[Any], expected type "Awaitable")
 
 [case testAwaitArgumentError]
@@ -94,7 +88,6 @@ async def f() -> int:
     return x
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 main:5: error: Incompatible types in await (actual type "int", expected type "Awaitable")
 
 [case testAwaitResultError]
@@ -105,7 +98,6 @@ async def f() -> str:
     x = await g()  # type: str
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 main:5: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testAwaitReturnError]
@@ -117,7 +109,6 @@ async def f() -> str:
     return x
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 main:6: error: Incompatible return value type (got "int", expected "str")
 
 [case testAsyncFor]
@@ -130,7 +121,6 @@ async def f() -> None:
         reveal_type(x)  # E: Revealed type is 'builtins.int*'
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 
 [case testAsyncForError]
 # flags: --fast-parser
@@ -140,7 +130,6 @@ async def f() -> None:
         pass
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 main:4: error: AsyncIterable expected
 main:4: error: List[int] has no attribute "__aiter__"
 
@@ -154,7 +143,6 @@ async def f() -> None:
         reveal_type(x)  # E: Revealed type is 'builtins.int*'
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 
 [case testAsyncWithError]
 # flags: --fast-parser
@@ -166,7 +154,6 @@ async def f() -> None:
         pass
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 main:6: error: "C" has no attribute "__aenter__"; maybe "__enter__"?
 main:6: error: "C" has no attribute "__aexit__"; maybe "__exit__"?
 
@@ -180,7 +167,6 @@ async def f() -> None:
         pass
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 
 [case testAsyncWithErrorBadAenter2]
 # flags: --fast-parser
@@ -192,7 +178,6 @@ async def f() -> None:
         pass
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 
 [case testAsyncWithErrorBadAexit]
 # flags: --fast-parser
@@ -204,7 +189,6 @@ async def f() -> None:
         pass
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 
 [case testAsyncWithErrorBadAexit2]
 # flags: --fast-parser
@@ -216,7 +200,6 @@ async def f() -> None:
         pass
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 
 [case testNoYieldInAsyncDef]
 # flags: --fast-parser
@@ -228,11 +211,8 @@ async def h():
     x = yield
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 main:3: error: 'yield' in async function
-main: note: In function "g":
 main:5: error: 'yield' in async function
-main: note: In function "h":
 main:7: error: 'yield' in async function
 
 [case testNoYieldFromInAsyncDef]
@@ -243,9 +223,7 @@ async def g():
     x = yield from []
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 main:3: error: 'yield from' in async function
-main: note: In function "g":
 main:5: error: 'yield from' in async function
 
 [case testNoAsyncDefInPY2_python2]
@@ -263,7 +241,6 @@ def g() -> Generator[Any, None, str]:
     return x
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "g":
 main:6: error: "yield from" can't be applied to Awaitable[str]
 
 [case testAwaitableSubclass]
@@ -292,7 +269,6 @@ async def main() -> None:
         reveal_type(z)  # E: Revealed type is 'builtins.int'
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "main":
 
 [case testYieldTypeCheckInDecoratedCoroutine]
 # flags: --fast-parser
@@ -309,7 +285,6 @@ def f() -> Generator[int, str, int]:
         return ''  # E: Incompatible return value type (got "str", expected "int")
 [builtins fixtures/async_await.pyi]
 [out]
-main: note: In function "f":
 
 
 -- The full matrix of coroutine compatibility

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -131,7 +131,6 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 main:6: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testLocalVariableScope]
@@ -145,7 +144,6 @@ def g() -> None:
 class A: pass
 class B: pass
 [out]
-main: note: In function "g":
 main:7: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 [case testFunctionArguments]
@@ -157,7 +155,6 @@ def f(x: 'A', y: 'B') -> None:
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testLocalVariableInitialization]
@@ -168,7 +165,6 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testVariableInitializationWithSubtype]
@@ -192,7 +188,6 @@ def f() -> 'A':
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 main:3: error: Incompatible return value type (got "B", expected "A")
 
 [case testTopLevelContextAndInvalidReturn]
@@ -203,7 +198,6 @@ a = B() # type: A
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 main:3: error: Incompatible return value type (got "B", expected "A")
 main: note: At top level:
 main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
@@ -265,7 +259,6 @@ class A: pass
 class B: pass
 [out]
 main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
-main: note: In function "f":
 main:7: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 main: note: At top level:
 main:9: error: Incompatible types in assignment (expression has type "B", variable has type "A")
@@ -288,7 +281,6 @@ def f(x): # type: (int) -> str
     return 1
 f('')
 [out]
-main: note: In function "f":
 main:2: error: Incompatible return value type (got "int", expected "str")
 main: note: At top level:
 main:3: error: Argument 1 to "f" has incompatible type "str"; expected "int"

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -199,7 +199,6 @@ class A: pass
 class B: pass
 [out]
 main:3: error: Incompatible return value type (got "B", expected "A")
-main: note: At top level:
 main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testEmptyReturnInAnyTypedFunction]
@@ -260,7 +259,6 @@ class B: pass
 [out]
 main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 main:7: error: Incompatible types in assignment (expression has type "A", variable has type "B")
-main: note: At top level:
 main:9: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testGlobalDefinedInBlockWithType]
@@ -282,7 +280,6 @@ def f(x): # type: (int) -> str
 f('')
 [out]
 main:2: error: Incompatible return value type (got "int", expected "str")
-main: note: At top level:
 main:3: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 
 [case testMethodSignatureAsComment]
@@ -296,7 +293,6 @@ A().f('') # Fail
 main: note: In member "f" of class "A":
 main:4: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
 main:5: error: Incompatible return value type (got "int", expected "str")
-main: note: At top level:
 main:6: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
 
 [case testTrailingCommaParsing-skip]

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -290,7 +290,6 @@ class A:
         return 1
 A().f('') # Fail
 [out]
-main: note: In member "f" of class "A":
 main:4: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
 main:5: error: Incompatible return value type (got "int", expected "str")
 main:6: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
@@ -308,5 +307,4 @@ class C:
         # type: () -> int
         pass
 [out]
-main: note: In member "__init__" of class "C":
 main:2: error: The return type of "__init__" must be None

--- a/test-data/unit/check-bound.test
+++ b/test-data/unit/check-bound.test
@@ -25,7 +25,6 @@ b = f(b)
 b = f(C()) # Fail
 [out]
 main:12: error: Type argument 1 of "f" has incompatible value "U"
-main: note: At top level:
 main:16: error: Type argument 1 of "f" has incompatible value "D"
 main:20: error: Incompatible types in assignment (expression has type "C", variable has type "B")
 

--- a/test-data/unit/check-bound.test
+++ b/test-data/unit/check-bound.test
@@ -24,7 +24,6 @@ b = B()
 b = f(b)
 b = f(C()) # Fail
 [out]
-main: note: In function "g":
 main:12: error: Type argument 1 of "f" has incompatible value "U"
 main: note: At top level:
 main:16: error: Type argument 1 of "f" has incompatible value "D"
@@ -127,9 +126,7 @@ def j(x: TA) -> A:
 def k(x: TA) -> B:
     return x # Fail
 [out]
-main: note: In function "g2":
 main:16: error: Type argument 1 of "h" has incompatible value "TA"
-main: note: In function "k":
 main:21: error: Incompatible return value type (got "TA", expected "B")
 
 
@@ -159,7 +156,6 @@ def f(x: T) -> T:
 b = f(B())
 [builtins fixtures/property.pyi]
 [out]
-main: note: In function "f":
 
 [case testBoundClassMethod]
 from typing import TypeVar

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -377,5 +377,4 @@ def f(a: Type[N]):
     a()
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 main:8: error: Unsupported type Type["N"]

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -153,7 +153,6 @@ class B(A):
         i, i = self  # E: Incompatible types in assignment (expression has type "str", \
                           variable has type "int")
 [out]
-main: note: In member "f" of class "B":
 
 [case testNewNamedTupleTypeReferenceToClassDerivedFrom]
 # flags: --fast-parser --python-version 3.6
@@ -176,7 +175,6 @@ class B(A):
                           variable has type "int")
 
 [out]
-main: note: In member "f" of class "B":
 
 [case testNewNamedTupleSubtyping]
 # flags: --fast-parser --python-version 3.6

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -603,7 +603,6 @@ def f() -> None:
     a.g()
     a.g(a) # E: Too many arguments for "g" of "A"
 [out]
-main: note: In function "f":
 
 [case testConstructNestedClass]
 import typing
@@ -635,7 +634,6 @@ def f() -> None:
     a = A()
     a = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
 [out]
-main: note: In function "f":
 
 [case testExternalReferenceToClassWithinClass]
 
@@ -699,7 +697,6 @@ class A:
             a = None
         b = None
 [out]
-main: note: In function "g":
 main:5: error: Need type annotation for variable
 main: note: In member "f" of class "A":
 main:6: error: Need type annotation for variable
@@ -1356,7 +1353,6 @@ class B:
     class C:
         def f(self, x: int) -> None: pass
 [out]
-main: note: In function "f":
 
 [case testForwardReferenceToNestedClassDeep]
 def f(o: 'B.C.D') -> None:
@@ -1367,7 +1363,6 @@ class B:
         class D:
             def f(self, x: int) -> None: pass
 [out]
-main: note: In function "f":
 
 [case testForwardReferenceToNestedClassWithinClass]
 class B:
@@ -1495,7 +1490,6 @@ def f(A: Type[B]) -> None:
     A(0)  # E: Too many arguments for "B"
     A()
 [out]
-main: note: In function "f":
 
 [case testTypeUsingTypeCInitWithArg]
 from typing import Type
@@ -1505,7 +1499,6 @@ def f(A: Type[B]) -> None:
     A(0)
     A()  # E: Too few arguments for "B"
 [out]
-main: note: In function "f":
 
 [case testTypeUsingTypeCTypeVar]
 from typing import Type, TypeVar
@@ -1519,7 +1512,6 @@ def new_user(user_class: Type[U]) -> U:
 pro_user = new_user(ProUser)
 reveal_type(pro_user)
 [out]
-main: note: In function "new_user":
 main:7: error: Revealed type is 'U`-1'
 main: note: At top level:
 main:10: error: Revealed type is '__main__.ProUser*'
@@ -1533,7 +1525,6 @@ def f(A: Type[T]) -> None:
     A()
     A(0)  # E: Too many arguments for "B"
 [out]
-main: note: In function "f":
 
 [case testTypeUsingTypeCTypeVarWithInit]
 from typing import Type, TypeVar
@@ -1544,7 +1535,6 @@ def f(A: Type[T]) -> None:
     A()  # E: Too few arguments for "B"
     A(0)
 [out]
-main: note: In function "f":
 
 [case testTypeUsingTypeCTwoTypeVars]
 from typing import Type, TypeVar
@@ -1562,7 +1552,6 @@ def error(u_c: Type[U]) -> P:
     return new_pro(u_c)  # Error here, see below
 [out]
 main:11: error: Revealed type is '__main__.WizUser*'
-main: note: In function "error":
 main:13: error: Incompatible return value type (got "U", expected "P")
 main:13: error: Type argument 1 of "new_pro" has incompatible value "U"
 
@@ -1584,7 +1573,6 @@ def new_user(user_class: Type[User]):
 def foo(arg: Type[int]):
     new_user(arg)  # E: Argument 1 to "new_user" has incompatible type Type[int]; expected Type[User]
 [out]
-main: note: In function "foo":
 
 [case testTypeUsingTypeCUnionOverload]
 from typing import Type, Union, overload
@@ -1611,7 +1599,6 @@ def foo(arg: Type[Any]):
 class X: pass
 foo(X)
 [out]
-main: note: In function "foo":
 
 [case testTypeUsingTypeCTypeNoArg]
 from typing import Type
@@ -1621,7 +1608,6 @@ def foo(arg: Type):
 class X: pass
 foo(X)
 [out]
-main: note: In function "foo":
 
 [case testTypeUsingTypeCBuiltinType]
 from typing import Type
@@ -1647,7 +1633,6 @@ def process(cls: Type[User]):
     cls.error  # E: Type[User] has no attribute "error"
 [builtins fixtures/classmethod.pyi]
 [out]
-main: note: In function "process":
 
 [case testTypeUsingTypeCClassMethodUnion]
 # Ideally this would work, but not worth the effort; just don't crash
@@ -1666,7 +1651,6 @@ def process(cls: Type[Union[BasicUser, ProUser]]):
     cls.error  # E: Type[Union[BasicUser, ProUser]] has no attribute "error"
 [builtins fixtures/classmethod.pyi]
 [out]
-main: note: In function "process":
 
 [case testTypeUsingTypeCClassMethodFromTypeVar]
 from typing import Type, TypeVar
@@ -1683,7 +1667,6 @@ def process(cls: Type[U]):
     cls.error  # E: Type[U] has no attribute "error"
 [builtins fixtures/classmethod.pyi]
 [out]
-main: note: In function "process":
 
 [case testTypeUsingTypeCClassMethodFromTypeVarUnionBound]
 # Ideally this would work, but not worth the effort; just don't crash
@@ -1703,7 +1686,6 @@ def process(cls: Type[U]):
     cls.error  # E: Type[U] has no attribute "error"
 [builtins fixtures/classmethod.pyi]
 [out]
-main: note: In function "process":
 
 [case testTypeUsingTypeCErrorUnsupportedType]
 from typing import Type, Tuple
@@ -1711,7 +1693,6 @@ def foo(arg: Type[Tuple[int]]):  # E: Unsupported type Type["Tuple[int]"]
     arg()
 [builtins fixtures/tuple.pyi]
 [out]
-main: note: In function "foo":
 
 [case testTypeUsingTypeCOverloadedClass]
 from typing import Type, TypeVar, overload
@@ -1735,7 +1716,6 @@ def new(uc: Type[U]) -> U:
 u = new(User)
 [builtins fixtures/classmethod.pyi]
 [out]
-main: note: In function "new":
 main:16: error: No overload variant of "User" matches argument types [builtins.str]
 main:17: error: Too many arguments for "foo" of "User"
 
@@ -1751,7 +1731,6 @@ from typing import Type, Tuple
 def f(a: Type[Tuple[int, int]]):
     a()
 [out]
-main: note: In function "f":
 main:2: error: Unsupported type Type["Tuple[int, int]"]
 
 [case testTypeUsingTypeCNamedTuple]
@@ -1761,7 +1740,6 @@ def f(a: Type[N]):
     a()
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 main:3: error: Unsupported type Type["N"]
 
 [case testTypeUsingTypeCJoin]
@@ -1775,7 +1753,6 @@ def foo(c: Type[C], d: Type[D]) -> None:
 
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "foo":
 main:7: error: Revealed type is 'builtins.list[Type[__main__.B]]'
 
 [case testTypeMatchesOverloadedFunctions]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1496,7 +1496,6 @@ pro_user = new_user(ProUser)
 reveal_type(pro_user)
 [out]
 main:7: error: Revealed type is 'U`-1'
-main: note: At top level:
 main:10: error: Revealed type is '__main__.ProUser*'
 
 [case testTypeUsingTypeCTypeVarDefaultInit]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -243,7 +243,6 @@ class B(A):
   def g(self, x: A, y: A) -> A: pass
   def h(self, x: A, y: 'B') -> object: pass  # Fail
 [out]
-main: note: In class "B":
 main:7: error: Argument 1 of "f" incompatible with supertype "A"
 main:9: error: Return type of "h" incompatible with supertype "A"
 
@@ -256,7 +255,6 @@ class B(A):
     def f(self, x: A, y: A) -> None: pass # Fail
     def g(self, x: A) -> A: pass # Fail
 [out]
-main: note: In class "B":
 main:6: error: Signature of "f" incompatible with supertype "A"
 main:7: error: Signature of "g" incompatible with supertype "A"
 
@@ -269,7 +267,6 @@ class C(B): # with gap in implementations
     def f(self, x: 'C') -> None:  # Fail
         pass
 [out]
-main: note: In class "C":
 main:6: error: Argument 1 of "f" incompatible with supertype "A"
 
 [case testMethodOverridingAcrossDeepInheritanceHierarchy2]
@@ -282,7 +279,6 @@ class C(B): # with multiple implementations
     def f(self) -> B:  # Fail
         pass
 [out]
-main: note: In class "C":
 main:7: error: Return type of "f" incompatible with supertype "B"
 
 [case testMethodOverridingWithVoidReturnValue]
@@ -294,7 +290,6 @@ class B(A):
     def f(self) -> A: pass  # Fail
     def g(self) -> None: pass  # Fail
 [out]
-main: note: In class "B":
 main:6: error: Return type of "f" incompatible with supertype "A"
 main:7: error: Return type of "g" incompatible with supertype "A"
 
@@ -452,7 +447,6 @@ class A:
     c = x # type: A # E: Incompatible types in assignment (expression has type "B", variable has type "A")
     c = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 [out]
-main: note: In class "A":
 
 [case testMethodRefInClassBody]
 from typing import Callable
@@ -466,7 +460,6 @@ class A:
     ff = f # type: Callable[[B], None]  # E: Incompatible types in assignment (expression has type Callable[[A], None], variable has type Callable[[B], None])
     g = ff                # E: Incompatible types in assignment (expression has type Callable[[B], None], variable has type Callable[[A], None])
 [out]
-main: note: In class "A":
 
 
 -- Arbitrary statements in class body
@@ -485,7 +478,6 @@ class A:
     x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 [builtins fixtures/for.pyi]
 [out]
-main: note: In class "A":
 
 
 -- Class attributes
@@ -586,7 +578,6 @@ class C:
 x = C.x
 [builtins fixtures/list.pyi]
 [out]
-main: note: In class "C":
 main:2: error: Need type annotation for variable
 
 
@@ -612,7 +603,6 @@ class A:
     b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
     b = B(b) # E: Too many arguments for "B"
 [out]
-main: note: In class "A":
 
 [case testConstructNestedClassWithCustomInit]
 import typing
@@ -945,7 +935,6 @@ class B(A):
     @overload
     def __add__(self, x: str) -> str: pass
 [out]
-main: note: In class "B":
 
 [case testOperatorMethodOverrideWideningArgumentType]
 import typing
@@ -1009,7 +998,6 @@ class B(A):
     @overload
     def __add__(self, x: type) -> A: pass
 [out]
-main: note: In class "B":
 main:8: error: Signature of "__add__" incompatible with supertype "A"
 
 [case testOverloadedOperatorMethodOverrideWithSwitchedItemOrder]
@@ -1025,7 +1013,6 @@ class B(A):
     @overload
     def __add__(self, x: 'B') -> 'B': pass
 [out]
-main: note: In class "B":
 main:8: error: Signature of "__add__" incompatible with supertype "A"
 
 [case testReverseOperatorMethodArgumentType]
@@ -1156,7 +1143,6 @@ class B:
     def __iadd__(self, x: A) -> int: pass
 class C(A): pass
 [out]
-main: note: In class "A":
 main:5: error: Signatures of "__iadd__" and "__add__" are incompatible
 
 [case testOverloadedNormalAndInplaceOperatorMethod]
@@ -1180,7 +1166,6 @@ class B:
     @overload
     def __iadd__(self, x: str) -> str: pass
 [out]
-main: note: In class "A":
 main:7: error: Signatures of "__iadd__" and "__add__" are incompatible
 
 [case testIntroducingInplaceOperatorInSubclass]
@@ -1195,9 +1180,7 @@ class C(A):
 class D(A):
     def __iadd__(self, x: 'A') -> 'B': pass
 [out]
-main: note: In class "B":
 main:6: error: Return type of "__iadd__" incompatible with "__add__" of supertype "A"
-main: note: In class "C":
 main:8: error: Argument 1 of "__iadd__" incompatible with "__add__" of supertype "A"
 main:8: error: Signatures of "__iadd__" and "__add__" are incompatible
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -67,7 +67,6 @@ class A:
     def f(self) -> None:
         a = object() # type: A    # Fail
 [out]
-main: note: In member "f" of class "A":
 main:4: error: Incompatible types in assignment (expression has type "object", variable has type "A")
 
 [case testMethodArguments]
@@ -82,7 +81,6 @@ class A:
         a = b # Fail
 class B: pass
 [out]
-main: note: In member "f" of class "A":
 main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 main:5: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 main:9: error: Incompatible types in assignment (expression has type "B", variable has type "A")
@@ -95,7 +93,6 @@ class A:
         return A()
 class B: pass
 [out]
-main: note: In member "f" of class "A":
 main:4: error: Incompatible return value type (got "B", expected "A")
 
 [case testSelfArgument]
@@ -108,7 +105,6 @@ class A:
         self.f()
 class B: pass
 [out]
-main: note: In member "f" of class "A":
 main:4: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 main:5: error: "A" has no attribute "g"
 
@@ -188,7 +184,6 @@ class B(A):
     def f(self) -> None:
         self.x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
-main: note: In member "f" of class "B":
 
 [case testAssignmentToAttributeInMultipleMethods]
 import typing
@@ -200,9 +195,7 @@ class A:
     def __init__(self) -> None:
         self.x = '' # Fail
 [out]
-main: note: In member "g" of class "A":
 main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main: note: In member "__init__" of class "A":
 main:8: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 
@@ -380,7 +373,6 @@ import typing
 class A:
     def __init__(self) -> 'A': pass
 [out]
-main: note: In member "__init__" of class "A":
 main:3: error: The return type of "__init__" must be None
 
 [case testConstructorWithImplicitReturnValueType]
@@ -388,7 +380,6 @@ import typing
 class A:
     def __init__(self, x: int): pass
 [out]
-main: note: In member "__init__" of class "A":
 main:3: error: The return type of "__init__" must be None
 
 [case testGlobalFunctionInitWithReturnType]
@@ -614,7 +605,6 @@ class A:
         b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
         b = B() # E: Too few arguments for "B"
 [out]
-main: note: In member "f" of class "A":
 
 [case testDeclareVariableWithNestedClassType]
 
@@ -688,7 +678,6 @@ class A:
         b = None
 [out]
 main:5: error: Need type annotation for variable
-main: note: In member "f" of class "A":
 main:6: error: Need type annotation for variable
 
 
@@ -773,7 +762,6 @@ class C:
     cls.bozo()  # E: "C" has no attribute "bozo"
 [builtins fixtures/classmethod.pyi]
 [out]
-main: note: In member "bar" of class "C":
 
 [case testClassMethodCalledOnClass]
 import typing
@@ -840,7 +828,6 @@ class A:
         self.x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [builtins fixtures/property.pyi]
 [out]
-main: note: In member "f" of class "A":
 
 [case testDynamicallyTypedProperty]
 import typing
@@ -1060,7 +1047,6 @@ class C:
     __add__ = 42
     def __radd__(self, other: C) -> C: return C()
 [out]
-main: note: In member "__radd__" of class "C":
 main:5: error: Forward operator "__add__" is not callable
 
 [case testOverloadedReverseOperatorMethodArgumentType]
@@ -1117,7 +1103,6 @@ class B:
 class X:
     def __add__(self, x): pass
 [out]
-main: note: In member "__radd__" of class "B":
 main:6: error: Signatures of "__radd__" of "B" and "__add__" of "X" are unsafely overlapping
 
 [case testUnsafeOverlappingWithLineNo]
@@ -1128,7 +1113,6 @@ class Real:
 class Fraction(Real):
     def __radd__(self, other: T) -> T: ...
 [out]
-main: note: In member "__radd__" of class "Fraction":
 main:6: error: Signatures of "__radd__" of "Fraction" and "__add__" of "Real" are unsafely overlapping
 
 [case testOverlappingNormalAndInplaceOperatorMethod]
@@ -1209,9 +1193,7 @@ class C:
 class D:
     def __getattr__(self, x: str) -> None: pass
 [out]
-main: note: In member "__getattr__" of class "B":
 main:4: error: Invalid signature "def (__main__.B, __main__.A) -> __main__.B"
-main: note: In member "__getattr__" of class "C":
 main:6: error: Invalid signature "def (__main__.C, builtins.str, builtins.str) -> __main__.C"
 
 
@@ -1356,7 +1338,6 @@ class B:
         class D:
             def f(self, x: int) -> None: pass
 [out]
-main: note: In member "f" of class "B":
 
 [case testClassVsInstanceDisambiguation]
 class A: pass

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -15,9 +15,7 @@ def f() -> 'A':
 class A: pass
 class B: pass
 [out]
-main: note: In function "g":
 main:5:8: error: Incompatible return value type (got "A", expected "B")
-main: note: In function "f":
 main:6:4: error: Incompatible return value type (got "B", expected "A")
 
 [case testColumnsNestedFunctionsWithFastParse]
@@ -30,9 +28,7 @@ def f() -> 'A':
 class A: pass
 class B: pass
 [out]
-main: note: In function "g":
 main:5:8: error: Incompatible return value type (got "A", expected "B")
-main: note: In function "f":
 main:6:4: error: Incompatible return value type (got "B", expected "A")
 
 
@@ -68,6 +64,5 @@ def f(x: object, n: int, s: str) -> None:
     n = x # E:4: Incompatible types in assignment (expression has type "object", variable has type "int")
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 

--- a/test-data/unit/check-dynamic-typing.test
+++ b/test-data/unit/check-dynamic-typing.test
@@ -625,7 +625,6 @@ class A(B):
         pass
 class D: pass
 [out]
-main: note: In class "A":
 
 [case testInvalidOverrideArgumentCountWithImplicitSignature1]
 import typing
@@ -644,7 +643,6 @@ class A(B):
     def f(self, x: 'A') -> None: # E: Signature of "f" incompatible with supertype "B"
         pass
 [out]
-main: note: In class "A":
 
 [case testInvalidOverrideArgumentCountWithImplicitSignature3]
 import typing
@@ -654,7 +652,6 @@ class A(B):
     def f(self, x, y) -> None: # E: Signature of "f" incompatible with supertype "B"
         x()
 [out]
-main: note: In class "A":
 
 
 -- Don't complain about too few/many arguments in dynamic functions

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -678,7 +678,6 @@ class B:
 A()[1] # Error
 [out]
 main:5: error: Invalid index type "int" for "A"; expected type "str"
-main: note: In class "B":
 main:7: error: Invalid index type "int" for "A"; expected type "str"
 main: note: At top level:
 main:8: error: Invalid index type "int" for "A"; expected type "str"
@@ -697,7 +696,6 @@ A()[1] # Error
 [out]
 main:1: note: In module imported here:
 tmp/m.py:5: error: Invalid index type "int" for "A"; expected type "str"
-tmp/m.py: note: In class "B":
 tmp/m.py:7: error: Invalid index type "int" for "A"; expected type "str"
 tmp/m.py: note: At top level:
 tmp/m.py:8: error: Invalid index type "int" for "A"; expected type "str"
@@ -1249,7 +1247,6 @@ class A:
 class B: pass
 [builtins fixtures/for.pyi]
 [out]
-main: note: In class "A":
 
 
 -- Set comprehension

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -679,7 +679,6 @@ A()[1] # Error
 [out]
 main:5: error: Invalid index type "int" for "A"; expected type "str"
 main:7: error: Invalid index type "int" for "A"; expected type "str"
-main: note: At top level:
 main:8: error: Invalid index type "int" for "A"; expected type "str"
 
 [case testErrorContextAndBinaryOperators2]
@@ -697,7 +696,6 @@ A()[1] # Error
 main:1: note: In module imported here:
 tmp/m.py:5: error: Invalid index type "int" for "A"; expected type "str"
 tmp/m.py:7: error: Invalid index type "int" for "A"; expected type "str"
-tmp/m.py: note: At top level:
 tmp/m.py:8: error: Invalid index type "int" for "A"; expected type "str"
 
 

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -693,7 +693,6 @@ class B:
     A()[1] # Error
 A()[1] # Error
 [out]
-main:1: note: In module imported here:
 tmp/m.py:5: error: Invalid index type "int" for "A"; expected type "str"
 tmp/m.py:7: error: Invalid index type "int" for "A"; expected type "str"
 tmp/m.py:8: error: Invalid index type "int" for "A"; expected type "str"

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -677,7 +677,6 @@ class B:
     A()[1] # Error
 A()[1] # Error
 [out]
-main: note: In function "f":
 main:5: error: Invalid index type "int" for "A"; expected type "str"
 main: note: In class "B":
 main:7: error: Invalid index type "int" for "A"; expected type "str"
@@ -697,7 +696,6 @@ class B:
 A()[1] # Error
 [out]
 main:1: note: In module imported here:
-tmp/m.py: note: In function "f":
 tmp/m.py:5: error: Invalid index type "int" for "A"; expected type "str"
 tmp/m.py: note: In class "B":
 tmp/m.py:7: error: Invalid index type "int" for "A"; expected type "str"
@@ -919,7 +917,6 @@ main:2: error: "f" does not return a value
 main:3: error: "f" does not return a value
 main:5: error: "f" does not return a value
 main:7: error: "f" does not return a value
-main: note: In function "g":
 main:10: error: "f" does not return a value
 
 [case testNoneReturnTypeWithExpressions]
@@ -1461,7 +1458,6 @@ def f(x: int) -> None:
     x = 1
 [builtins fixtures/for.pyi]
 [out]
-main: note: In function "f":
 main:1: error: The return type of a generator function should be "Generator" or one of its supertypes
 main:2: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 
@@ -1484,7 +1480,6 @@ def f() -> Iterator[int]:
 def g() -> Iterator[int]:
     a = yield from f()
 [out]
-main: note: In function "g":
 main:5: error: Function does not return a value
 
 [case testYieldFromGeneratorHasValue]
@@ -1636,7 +1631,6 @@ def f() -> None:
     reveal_type(x)
 x = 1 + 1
 [out]
-main: note: In function "f":
 main:2: error: Revealed type is 'builtins.int'
 
 [case testEqNone]

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -66,7 +66,6 @@ def f(a,        # type: A
     reveal_type(kwargs) # E: Revealed type is 'builtins.dict[builtins.str, __main__.F]'
 [builtins fixtures/dict.pyi]
 [out]
-main: note: In function "f":
 
 [case testFastParsePerArgumentAnnotationsWithReturn]
 # flags: --fast-parser
@@ -93,7 +92,6 @@ def f(a,        # type: A
     return "not an int"  # E: Incompatible return value type (got "str", expected "int")
 [builtins fixtures/dict.pyi]
 [out]
-main: note: In function "f":
 
 [case testFastParsePerArgumentAnnotationsWithAnnotatedBareStar]
 # flags: --fast-parser
@@ -115,7 +113,6 @@ def f(*,
     return "not an int"  # E: Incompatible return value type (got "str", expected "int")
 [builtins fixtures/dict.pyi]
 [out]
-main: note: In function "f":
 
 [case testFastParsePerArgumentAnnotations_python2]
 # flags: --fast-parser
@@ -133,7 +130,6 @@ def f(a,        # type: A
     reveal_type(args)   # E: Revealed type is 'builtins.tuple[__main__.C]'
 [builtins fixtures/dict.pyi]
 [out]
-main: note: In function "f":
 
 [case testFastParsePerArgumentAnnotationsWithReturn_python2]
 # flags: --fast-parser
@@ -153,7 +149,6 @@ def f(a,        # type: A
     return "not an int"  # E: Incompatible return value type (got "str", expected "int")
 [builtins fixtures/dict.pyi]
 [out]
-main: note: In function "f":
 
 [case testFasterParseTooManyArgumentsAnnotation]
 # flags: --fast-parser

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -123,3 +123,60 @@ def f() -> int:
     else:
         return 0
 [builtins fixtures/bool.pyi]
+
+[case testShowErrorContextFunction]
+# flags: --show-error-context
+def f() -> None:
+  0 + ""
+[out]
+main: note: In function "f":
+main:3: error: Unsupported operand types for + ("int" and "str")
+
+[case testShowErrorContextClass]
+# flags: --show-error-context
+class A:
+  0 + ""
+[out]
+main: note: In class "A":
+main:3: error: Unsupported operand types for + ("int" and "str")
+
+[case testShowErrorContextMember]
+# flags: --show-error-context
+class A:
+  def f(self, x: int) -> None:
+    self.f("")
+[out]
+main: note: In member "f" of class "A":
+main:4: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+
+[case testShowErrorContextModule]
+# flags: --show-error-context
+import m
+[file m.py]
+0 + ""
+[out]
+main:2: note: In module imported here:
+tmp/m.py:1: error: Unsupported operand types for + ("int" and "str")
+
+[case testShowErrorContextTopLevel]
+# flags: --show-error-context
+def f() -> None:
+  0 + ""
+0 + ""
+[out]
+main: note: In function "f":
+main:3: error: Unsupported operand types for + ("int" and "str")
+main: note: At top level:
+main:4: error: Unsupported operand types for + ("int" and "str")
+
+[case testShowErrorContextFromHere]
+# flags: --show-error-context
+import a
+[file a.py]
+import b
+[file b.py]
+0 + ""
+[out]
+tmp/a.py:1: note: In module imported here,
+main:2: note: ... from here:
+tmp/b.py:1: error: Unsupported operand types for + ("int" and "str")

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -2,14 +2,12 @@
 # flags: --disallow-untyped-defs
 def f(x): pass
 [out]
-main: note: In function "f":
 main:2: error: Function is missing a type annotation
 
 [case testUnannotatedArgument]
 # flags: --disallow-untyped-defs
 def f(x) -> int: pass
 [out]
-main: note: In function "f":
 main:2: error: Function is missing a type annotation for one or more arguments
 
 [case testNoArgumentFunction]
@@ -21,7 +19,6 @@ def f() -> int: pass
 # flags: --disallow-untyped-defs
 def f(x: int): pass
 [out]
-main: note: In function "f":
 main:2: error: Function is missing a return type annotation
 
 [case testLambda]
@@ -34,7 +31,6 @@ lambda x: x
 def f():
     1 + "str"
 [out]
-main: note: In function "f":
 main:2: error: Function is missing a type annotation
 
 [case testSubclassingAny]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1183,7 +1183,6 @@ class A:
     f(x, 1)
     f(x, 'x') # E: Argument 2 to "f" of "A" has incompatible type "str"; expected "int"
 [out]
-main: note: In class "A":
 
 [case testCallConditionalMethodViaInstance]
 from typing import Any
@@ -1232,7 +1231,6 @@ class A:
     else:
         def f(self, x): pass # E: All conditional function variants must have identical signatures
 [out]
-main: note: In class "A":
 
 [case testConditionalFunctionDefinitionInTry]
 import typing

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -218,7 +218,6 @@ def f(x: 'A' = A()) -> None:
 class B: pass
 class A: pass
 [out]
-main: note: In function "f":
 
 [case testDefaultArgumentExpressions2]
 import typing
@@ -229,7 +228,6 @@ def f(x: 'A' = B()) -> None: # E: Incompatible types in assignment (expression h
 class B: pass
 class A: pass
 [out]
-main: note: In function "f":
 
 [case testDefaultArgumentsWithSubtypes]
 import typing
@@ -241,7 +239,6 @@ def g(x: 'A' = B()) -> None:
 class A: pass
 class B(A): pass
 [out]
-main: note: In function "f":
 
 [case testMultipleDefaultArgumentExpressions]
 import typing
@@ -253,7 +250,6 @@ def h(x: 'A' = A(), y: 'B' = B()) -> None:
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 
 [case testMultipleDefaultArgumentExpressions2]
 import typing
@@ -263,7 +259,6 @@ def g(x: 'A' = A(), y: 'B' = A()) -> None: # E: Incompatible types in assignment
 class A: pass
 class B: pass
 [out]
-main: note: In function "g":
 
 [case testDefaultArgumentsAndSignatureAsComment]
 import typing
@@ -411,9 +406,7 @@ def f(a: 'A') -> None:
 class A: pass
 class B: pass
 [out]
-main: note: In function "g":
 main:4: error: Incompatible types in assignment (expression has type "A", variable has type "B")
-main: note: In function "f":
 main:7: error: Argument 1 to "g" has incompatible type "A"; expected "B"
 
 [case testReturnAndNestedFunction]
@@ -427,9 +420,7 @@ def f() -> 'A':
 class A: pass
 class B: pass
 [out]
-main: note: In function "g":
 main:4: error: Incompatible return value type (got "A", expected "B")
-main: note: In function "f":
 main:6: error: Incompatible return value type (got "B", expected "A")
 
 [case testDynamicallyTypedNestedFunction]
@@ -440,7 +431,6 @@ def f(x: object) -> None:
     g() # E: Too few arguments for "g"
     g(x)
 [out]
-main: note: In function "f":
 
 [case testNestedFunctionInMethod]
 import typing
@@ -452,7 +442,6 @@ class A:
         g(2)
         g(A()) # fail
 [out]
-main: note: In function "g":
 main:6: error: Incompatible types in assignment (expression has type "int", variable has type "A")
 main: note: In member "f" of class "A":
 main:8: error: Argument 1 to "g" has incompatible type "A"; expected "int"
@@ -466,9 +455,7 @@ def f() -> None:
         g()
         g(1) # E
 [out]
-main: note: In function "g":
 main:4: error: Argument 1 to "h" has incompatible type "str"; expected "int"
-main: note: In function "h":
 main:7: error: Too many arguments for "g"
 
 [case testMutuallyRecursiveDecoratedFunctions]
@@ -484,9 +471,7 @@ def f() -> None:
         g(1)
         g.x # E
 [out]
-main: note: In function "g":
 main:7: error: Callable[..., Any] has no attribute "x"
-main: note: In function "h":
 main:11: error: Callable[..., Any] has no attribute "x"
 
 [case testNestedGenericFunctions]
@@ -552,7 +537,6 @@ def g() -> None:
     f(1)
     f('') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 [out]
-main: note: In function "g":
 
 [case testCheckingDecoratedFunction]
 import typing
@@ -563,7 +547,6 @@ def f(x: 'A') -> None:
     x = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
 class A: pass
 [out]
-main: note: In function "f":
 
 [case testDecoratorThatSwitchesType]
 from typing import Callable
@@ -703,7 +686,6 @@ def g(): pass
 @dec
 def h(x: int) -> str: pass
 [out]
-main: note: In function "f":
 
 [case testForwardReferenceToDynamicallyTypedDecoratedMethod]
 def f(self) -> None:
@@ -732,7 +714,6 @@ T = TypeVar('T')
 def dec(f: T) -> T: return f
 [builtins fixtures/staticmethod.pyi]
 [out]
-main: note: In function "f":
 
 [case testForwardReferenceToDynamicallyTypedProperty]
 def f(self) -> None:
@@ -752,7 +733,6 @@ class A:
     def x(self) -> int: return 1
 [builtins fixtures/property.pyi]
 [out]
-main: note: In function "f":
 
 [case testForwardReferenceToDynamicallyTypedStaticMethod]
 def f(self) -> None:
@@ -764,7 +744,6 @@ class A:
     def x(x): pass
 [builtins fixtures/staticmethod.pyi]
 [out]
-main: note: In function "f":
 
 [case testForwardReferenceToStaticallyTypedStaticMethod]
 def f(self) -> None:
@@ -776,7 +755,6 @@ class A:
     def x(a: int) -> str: return ''
 [builtins fixtures/staticmethod.pyi]
 [out]
-main: note: In function "f":
 
 [case testForwardReferenceToDynamicallyTypedClassMethod]
 def f(self) -> None:
@@ -788,7 +766,6 @@ class A:
     def x(cls, a): pass
 [builtins fixtures/classmethod.pyi]
 [out]
-main: note: In function "f":
 
 [case testForwardReferenceToStaticallyTypedClassMethod]
 def f(self) -> None:
@@ -800,7 +777,6 @@ class A:
     def x(cls, x: int) -> str: return ''
 [builtins fixtures/classmethod.pyi]
 [out]
-main: note: In function "f":
 
 [case testForwardReferenceToDecoratedFunctionUsingMemberExpr]
 import m
@@ -816,7 +792,6 @@ T = TypeVar('T')
 def dec(f: T) -> T:
     return f
 [out]
-main: note: In function "f":
 
 [case testForwardReferenceToFunctionWithMultipleDecorators]
 def f(self) -> None:
@@ -1029,7 +1004,6 @@ if x:
         x = 1
         x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
-main: note: In function "f":
 
 [case testCallConditionalFunction]
 from typing import Any
@@ -1055,7 +1029,6 @@ else:
 f(1)
 f('x') # fail
 [out]
-main: note: In function "f":
 main:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:9: error: Unsupported operand types for + ("int" and "str")
 main: note: At top level:
@@ -1076,10 +1049,8 @@ def top() -> None:
     f(1)
     f('x') # fail
 [out]
-main: note: In function "f":
 main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:10: error: Unsupported operand types for + ("int" and "str")
-main: note: In function "top":
 main:13: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 
 [case testUnconditionalRedefinitionOfConditionalFunction]
@@ -1154,7 +1125,6 @@ def g() -> None:
     f(1)
     f('') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 [out]
-main: note: In function "g":
 
 [case testRedefineFunctionDefinedAsVariableWithInvalidSignature]
 def g(): pass
@@ -1288,7 +1258,6 @@ def f(x: Callable[..., int]) -> None:
     x(z=1)
     x() + '' # E: Unsupported operand types for + ("int" and "str")
 [out]
-main: note: In function "f":
 
 [case testCallableWithArbitraryArgs2]
 from typing import Callable
@@ -1306,7 +1275,6 @@ from typing import Callable
 def f(x: Callable[..., int]) -> None:
     x = 1  # E: Incompatible types in assignment (expression has type "int", variable has type Callable[..., int])
 [out]
-main: note: In function "f":
 
 [case testCallableWithArbitraryArgsInGenericFunction]
 from typing import Callable, TypeVar
@@ -1364,7 +1332,6 @@ def f(x, **kwargs): # type: (...) -> None
 f(1, thing_in_kwargs=["hey"])
 [builtins fixtures/dict.pyi]
 [out]
-main: note: In function "f":
 
 [case testEllipsisWithArbitraryArgsOnBareFunctionWithVarargs]
 from typing import Tuple, Any
@@ -1374,7 +1341,6 @@ def f(x, *args): # type: (...) -> None
 f(1, "hello")
 [builtins fixtures/tuple.pyi]
 [out]
-main: note: In function "f":
 
 [case testEllipsisWithArbitraryArgsOnInstanceMethod]
 class A:
@@ -1399,14 +1365,12 @@ class A:
 def f(x, y, z): # type: (..., int) -> None
     pass
 [out]
-main: note: In function "f":
 main:1: error: Parse error before ): Ellipses cannot accompany other argument types in function type signature.
 
 [case testEllipsisWithSomethingBeforeItFails]
 def f(x, y, z): # type: (int, ...) -> None
     pass
 [out]
-main: note: In function "f":
 main:1: error: Parse error before ): Ellipses cannot accompany other argument types in function type signature.
 
 [case testRejectCovariantArgument]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -443,7 +443,6 @@ class A:
         g(A()) # fail
 [out]
 main:6: error: Incompatible types in assignment (expression has type "int", variable has type "A")
-main: note: In member "f" of class "A":
 main:8: error: Argument 1 to "g" has incompatible type "A"; expected "int"
 
 [case testMutuallyRecursiveNestedFunctions]
@@ -1169,7 +1168,6 @@ class A:
             x = 1
             x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
-main: note: In member "f" of class "A":
 
 [case testCallConditionalMethodInClassBody]
 from typing import Any
@@ -1207,7 +1205,6 @@ class A:
 A().f(1)
 A().f('x') # fail
 [out]
-main: note: In member "f" of class "A":
 main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:10: error: Unsupported operand types for + ("int" and "str")
 main:13: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
@@ -1378,7 +1375,6 @@ class A(Generic[t]):
         return None
 [builtins fixtures/bool.pyi]
 [out]
-main: note: In member "foo" of class "A":
 main:5: error: Cannot use a covariant type variable as a parameter
 
 [case testRejectContravariantReturnType]
@@ -1390,7 +1386,6 @@ class A(Generic[t]):
         return None
 [builtins fixtures/bool.pyi]
 [out]
-main: note: In member "foo" of class "A":
 main:5: error: Cannot use a contravariant type variable as return type
 
 [case testAcceptCovariantReturnType]
@@ -1483,7 +1478,6 @@ class A:
 
 def dec(f: Callable[[A, str], None]) -> Callable[[A, int], None]: pass
 [out]
-main: note: In member "f" of class "A":
 
 [case testUnknownFunctionNotCallable]
 def f() -> None:

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1031,7 +1031,6 @@ f('x') # fail
 [out]
 main:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:9: error: Unsupported operand types for + ("int" and "str")
-main: note: At top level:
 main:12: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 
 [case testNestedConditionalFunctionDefinitionWithIfElse]
@@ -1211,7 +1210,6 @@ A().f('x') # fail
 main: note: In member "f" of class "A":
 main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:10: error: Unsupported operand types for + ("int" and "str")
-main: note: At top level:
 main:13: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
 
 [case testUnconditionalRedefinitionOfConditionalMethod]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -864,10 +864,8 @@ T = TypeVar('T')
 def dec(f: T) -> T: return f
 
 [out]
-tmp/a.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/b.py:5: error: Argument 1 to "f" has incompatible type "str"; expected "int"
-main:1: note: In module imported here:
 tmp/a.py:5: error: Argument 1 to "g" has incompatible type "int"; expected "str"
 
 [case testDecoratorWithNoAnnotationInImportCycle]
@@ -912,10 +910,8 @@ from typing import Callable
 def dec(f: Callable[[int], str]) -> Callable[[int], str]: return f
 
 [out]
-tmp/a.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/b.py:5: error: "str" not callable
-main:1: note: In module imported here:
 tmp/a.py:5: error: "str" not callable
 
 [case testDecoratorWithCallAndFixedReturnTypeInImportCycle]
@@ -940,10 +936,8 @@ from typing import Callable
 def dec() -> Callable[[Callable[[int], str]], Callable[[int], str]]: pass
 
 [out]
-tmp/a.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/b.py:5: error: "str" not callable
-main:1: note: In module imported here:
 tmp/a.py:5: error: "str" not callable
 
 [case testDecoratorWithCallAndFixedReturnTypeInImportCycleAndDecoratorArgs]
@@ -968,11 +962,9 @@ from typing import Callable
 def dec(x: str) -> Callable[[Callable[[int], str]], Callable[[int], str]]: pass
 
 [out]
-tmp/a.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/b.py:3: error: Argument 1 to "dec" has incompatible type "int"; expected "str"
 tmp/b.py:5: error: "str" not callable
-main:1: note: In module imported here:
 tmp/a.py:3: error: Argument 1 to "dec" has incompatible type "int"; expected "str"
 tmp/a.py:5: error: "str" not callable
 

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -864,7 +864,6 @@ T = TypeVar('T')
 def dec(f: T) -> T: return f
 
 [out]
-main:1: note: ... from here:
 tmp/b.py:5: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 tmp/a.py:5: error: Argument 1 to "g" has incompatible type "int"; expected "str"
 
@@ -910,7 +909,6 @@ from typing import Callable
 def dec(f: Callable[[int], str]) -> Callable[[int], str]: return f
 
 [out]
-main:1: note: ... from here:
 tmp/b.py:5: error: "str" not callable
 tmp/a.py:5: error: "str" not callable
 
@@ -936,7 +934,6 @@ from typing import Callable
 def dec() -> Callable[[Callable[[int], str]], Callable[[int], str]]: pass
 
 [out]
-main:1: note: ... from here:
 tmp/b.py:5: error: "str" not callable
 tmp/a.py:5: error: "str" not callable
 
@@ -962,7 +959,6 @@ from typing import Callable
 def dec(x: str) -> Callable[[Callable[[int], str]], Callable[[int], str]]: pass
 
 [out]
-main:1: note: ... from here:
 tmp/b.py:3: error: Argument 1 to "dec" has incompatible type "int"; expected "str"
 tmp/b.py:5: error: "str" not callable
 tmp/a.py:3: error: Argument 1 to "dec" has incompatible type "int"; expected "str"

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -175,7 +175,6 @@ class A(B[C]):
         # E: Argument 1 of "f" incompatible with supertype "B"
     def g(self, a: C) -> None: pass
 [out]
-main: note: In class "A":
 
 [case testOverridingMethodInGenericTypeInheritingSimpleType]
 from typing import TypeVar, Generic
@@ -189,7 +188,6 @@ class A(B, Generic[T]):
         # E: Argument 1 of "f" incompatible with supertype "B"
     def g(self, a: 'C') -> None: pass
 [out]
-main: note: In class "A":
 
 [case testOverridingMethodInGenericTypeInheritingGenericType]
 from typing import TypeVar, Generic
@@ -203,7 +201,6 @@ class A(B[S], Generic[T, S]):
         # E: Argument 1 of "f" incompatible with supertype "B"
     def g(self, a: S) -> None: pass
 [out]
-main: note: In class "A":
 
 [case testOverridingMethodInMultilevelHierarchyOfGenericTypes]
 from typing import TypeVar, Generic
@@ -222,7 +219,6 @@ class A(B[S], Generic[T, S]):
         # E: Argument 1 of "f" incompatible with supertype "C"
     def g(self, a: S) -> None: pass
 [out]
-main: note: In class "A":
 
 [case testOverrideGenericMethodInNonGenericClass]
 from typing import TypeVar
@@ -252,7 +248,6 @@ class C(A):
     def f(self, x: List[T], y: List[T]) -> None: pass # E: Signature of "f" incompatible with supertype "A"
 [builtins fixtures/list.pyi]
 [out]
-main: note: In class "C":
 
 [case testOverrideGenericMethodInNonGenericClassGeneralize]
 from typing import TypeVar
@@ -270,9 +265,7 @@ class C(A):
 class D(A):
     def f(self, x: T1, y: S) -> None: pass # TODO: This error could be more specific.
 [out]
-main: note: In class "C":
 main:12: error: Argument 2 of "f" incompatible with supertype "A"
-main: note: In class "D":
 main:14: error: Signature of "f" incompatible with supertype "A"
 
 
@@ -485,7 +478,6 @@ class B(A, I[D]): pass # Fail
 class C: pass
 class D: pass
 [out]
-main: note: In class "B":
 main:5: error: Class "B" has base "I" duplicated inconsistently
 
 [case testSubtypingAndABCExtension]
@@ -526,7 +518,6 @@ class A(I[C]):
 class C: pass
 class D: pass
 [out]
-main: note: In class "A":
 
 
 -- Extending a generic ABC with deep type hierarchy
@@ -559,7 +550,6 @@ class C: pass
 class D: pass
 [out]
 main:7: error: Incompatible types in assignment (expression has type "A", variable has type I[D])
-main: note: In class "A":
 
 [case testSubclassingGenericABCWithDeepHierarchy2]
 from typing import Any, TypeVar, Generic
@@ -576,7 +566,6 @@ class A(B):
 class C: pass
 class D: pass
 [out]
-main: note: In class "A":
 
 
 -- Implicit Any types and subclassing generic ABC

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -332,7 +332,6 @@ class A(B):
 
 class C: pass
 [out]
-main: note: In member "g" of class "A":
 
 [case testInheritanceFromGenericWithImplicitDynamicAndOverriding]
 from typing import TypeVar, Generic, Tuple
@@ -361,7 +360,6 @@ class A(B[S], Generic[T, S]):
         super().f(t)   # E: Argument 1 to "f" of "B" has incompatible type "T"; expected "S"
         super().f(s)
 [out]
-main: note: In member "g" of class "A":
 
 [case testSuperExpressionsWhenInheritingFromGenericTypeAndDeepHierarchy]
 from typing import TypeVar, Generic
@@ -378,7 +376,6 @@ class A(B[S], Generic[T, S]):
         super().f(t)   # E: Argument 1 to "f" of "C" has incompatible type "T"; expected "S"
         super().f(s)
 [out]
-main: note: In member "g" of class "A":
 
 
 -- Type of inherited constructor

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -393,7 +393,6 @@ def f(s: S, t: T) -> p[T, A]:
     p_t_a = None  # type: p[T, A]
     return p_t_a
 [out]
-main: note: In function "f":
 
 [case testTypeCheckingGenericMethodBody]
 from typing import TypeVar, Generic
@@ -588,7 +587,6 @@ z = None # type: str
 reveal_type(wrap(z)) # E: Revealed type is '__main__.Node[builtins.int, builtins.str*]'
 
 [out]
-main: note: In function "output_bad":
 main:13: error: Argument 2 to "Node" has incompatible type "int"; expected "str"
 main: note: At top level:
 
@@ -732,7 +730,6 @@ reveal_type(f('a'))  # E: Revealed type is '__main__.D[builtins.str*]'
 
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f_bad":
 main:15: error: Argument 1 to "D" has incompatible type "int"; expected "Tuple[T, T]"
 main: note: At top level:
 
@@ -1179,7 +1176,6 @@ def f() -> None:
     a = 1
     a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
-main: note: In function "f":
 
 [case testClassLevelTypeVariable]
 from typing import TypeVar
@@ -1282,7 +1278,6 @@ def outer(t: T) -> None:
     y5 = f3
     y5 = f4
 [out]
-main: note: In function "outer":
 
 [case testSubtypingWithGenericFunctionUsingTypevarWithValues]
 from typing import TypeVar, Callable
@@ -1339,7 +1334,6 @@ def f(a: T, b: T) -> T:
         return b
 [builtins fixtures/ops.pyi]
 [out]
-main: note: In function "f":
 main:4: error: Unsupported left operand type for < ("T")
 
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -588,7 +588,6 @@ reveal_type(wrap(z)) # E: Revealed type is '__main__.Node[builtins.int, builtins
 
 [out]
 main:13: error: Argument 2 to "Node" has incompatible type "int"; expected "str"
-main: note: At top level:
 
 [case testGenericTypeAliasesWrongAliases]
 # flags: --show-column-numbers --fast-parser --python-version 3.6
@@ -731,7 +730,6 @@ reveal_type(f('a'))  # E: Revealed type is '__main__.D[builtins.str*]'
 [builtins fixtures/list.pyi]
 [out]
 main:15: error: Argument 1 to "D" has incompatible type "int"; expected "Tuple[T, T]"
-main: note: At top level:
 
 [case testGenericTypeAliasesSubclassingBad]
 from typing import TypeVar, Generic, Tuple, Union

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -207,7 +207,6 @@ class A(Generic[T]):
 x = None # type: B
 class B: pass
 [out]
-main: note: In member "f" of class "A":
 main:7: error: Argument 1 to "f" of "A" has incompatible type "B"; expected "T"
 main:8: error: Incompatible types in assignment (expression has type A[T], variable has type A[B])
 
@@ -228,7 +227,6 @@ class A(Generic[S, T]):
 
 class B: pass
 [out]
-main: note: In member "f" of class "A":
 main:8: error: Incompatible types in assignment (expression has type "T", variable has type "S")
 main:9: error: Incompatible types in assignment (expression has type "S", variable has type "T")
 main:10: error: Incompatible types in assignment (expression has type A[S, T], variable has type A[S, B])
@@ -253,7 +251,6 @@ class A(Generic[T]):
         b = self.f() # type: object
         b = self.f()
 [out]
-main: note: In member "f" of class "A":
 main:5: error: Incompatible types in assignment (expression has type "object", variable has type "T")
 main:6: error: Incompatible types in assignment (expression has type "object", variable has type "T")
 
@@ -414,7 +411,6 @@ class A(Generic[T]):
         p_s_t = None  # type: p[S, T]
         return p_s_t
 [out]
-main: note: In member "f" of class "A":
 
 [case testProhibitTypeApplicationToGenericFunctions]
 from typing import TypeVar
@@ -1196,7 +1192,6 @@ class A(Generic[T]):
         g(self.a)
         g(n) # E: Argument 1 to "g" has incompatible type "int"; expected "T"
 [out]
-main: note: In member "f" of class "A":
 
 
 -- Callable subtyping with generic functions

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -38,7 +38,6 @@ from m import a # type: ignore
 [file m.py]
 +
 [out]
-main:1: note: In module imported here:
 tmp/m.py:1: error: Parse error before end of line
 
 [case testIgnoreAppliesOnlyToMissing]
@@ -60,7 +59,6 @@ from m import * # type: ignore
 [file m.py]
 +
 [out]
-main:1: note: In module imported here:
 tmp/m.py:1: error: Parse error before end of line
 
 [case testIgnoreAssignmentTypeError]

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -123,7 +123,6 @@ class C(B):
         self.f(1) # E: Too many arguments for "f" of "C"
         self.g(1)
 [out]
-main: note: In member "f" of class "C":
 
 [case testIgnoredModuleDefinesBaseClass2]
 import m # type: ignore
@@ -159,7 +158,6 @@ class D(C, B):
         self.f(1) # E: Too many arguments for "f" of "D"
         self.g(1)
 [out]
-main: note: In member "f" of class "D":
 
 [case testIgnoredModuleDefinesBaseClassWithInheritance2]
 from m import B # type: ignore
@@ -170,7 +168,6 @@ class D(C):
         self.f(1) # E: Too many arguments for "f" of "D"
         self.g(1)
 [out]
-main: note: In member "f" of class "D":
 
 [case testIgnoreWithFollowingIndentedComment]
 if 1:  # type: ignore

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1640,8 +1640,6 @@ class Y:
 class Z(X, Y): pass
 [stale]
 [out]
-main: note: In class "Z":
 main:8: error: Definition of "attr" in base class "X" is incompatible with definition in base class "Y"
 [out2]
-main: note: In class "Z":
 main:8: error: Definition of "attr" in base class "X" is incompatible with definition in base class "Y"

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1321,7 +1321,6 @@ main:1: note: ... from here:
 tmp/mod3.py: note: In member "makeC" of class "B":
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:1: note: In module imported here:
-tmp/mod1.py: note: At top level:
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 
 [out2]
@@ -1366,7 +1365,6 @@ main:1: note: ... from here:
 tmp/mod3.py: note: In member "makeC" of class "B":
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:1: note: In module imported here:
-tmp/mod1.py: note: At top level:
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 
 [out2]
@@ -1376,7 +1374,6 @@ main:1: note: ... from here:
 tmp/mod3.py: note: In member "makeC" of class "B":
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:1: note: In module imported here:
-tmp/mod1.py: note: At top level:
 tmp/mod1.py:3: error: Revealed type is 'builtins.str'
 
 [case testIncrementalIncidentalChangeWithBugFixCausesPropagation]
@@ -1422,7 +1419,6 @@ main:1: note: ... from here:
 tmp/mod3.py: note: In member "makeC" of class "B":
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:1: note: In module imported here:
-tmp/mod1.py: note: At top level:
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 
 [out2]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -164,7 +164,6 @@ def foo() -> int:
 [rechecked mod2]
 [stale]
 [out2]
-main:1: note: ... from here:
 tmp/mod2.py:4: error: Incompatible return value type (got "str", expected "int")
 
 [case testIncrementalInternalScramble]
@@ -500,7 +499,6 @@ def func2() -> str:
 [rechecked mod0, mod1, mod2]
 [stale mod2]
 [out2]
-main:1: note: ... from here:
 tmp/mod1.py:4: error: Incompatible return value type (got "str", expected "int")
 
 [case testIncrementalOkChangeWithSave]
@@ -1131,11 +1129,9 @@ reveal_type(foo)
 [rechecked m, n]
 [stale]
 [out1]
-main:1: note: ... from here:
 tmp/n.py:2: error: Revealed type is 'builtins.str'
 tmp/m.py:3: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
 [out2]
-main:1: note: ... from here:
 tmp/n.py:2: error: Revealed type is 'builtins.float'
 tmp/m.py:3: error: Argument 1 to "accept_int" has incompatible type "float"; expected "int"
 
@@ -1291,8 +1287,6 @@ class C:
 [rechecked mod3, mod2, mod1]
 [stale mod3, mod2]
 [out1]
-tmp/mod1.py:1: note: ... from here,
-main:1: note: ... from here:
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 
@@ -1331,14 +1325,10 @@ class C:
 [rechecked mod4, mod3, mod2, mod1]
 [stale mod4]
 [out1]
-tmp/mod1.py:1: note: ... from here,
-main:1: note: ... from here:
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 
 [out2]
-tmp/mod1.py:1: note: ... from here,
-main:1: note: ... from here:
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/mod1.py:3: error: Revealed type is 'builtins.str'
 
@@ -1379,8 +1369,6 @@ class C:
 [rechecked mod4, mod3, mod2, mod1]
 [stale mod4, mod3, mod2]
 [out1]
-tmp/mod1.py:1: note: ... from here,
-main:1: note: ... from here:
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -42,7 +42,6 @@ def foo() -> None:
 [rechecked m]
 [stale]
 [out2]
-main:1: note: In module imported here:
 tmp/m.py:2: error: Name 'bar' is not defined
 
 [case testIncrementalSimpleImportSequence]
@@ -102,7 +101,6 @@ def func1() -> A: pass
 [rechecked mod1]
 [stale]
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:1: error: Name 'A' is not defined
 
 [case testIncrementalSameNameChange]
@@ -166,7 +164,6 @@ def foo() -> int:
 [rechecked mod2]
 [stale]
 [out2]
-tmp/mod1.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/mod2.py:4: error: Incompatible return value type (got "str", expected "int")
 
@@ -240,7 +237,6 @@ class Child(Bad): pass
 [rechecked mod1, mod2]
 [stale mod2]
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:2: error: "Child" has no attribute "good_method"
 
 [case testIncrementalCascadingChange]
@@ -268,7 +264,6 @@ C = "A"
 [rechecked mod1, mod2, mod3, mod4]
 [stale mod2, mod3, mod4]
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalBrokenCascade]
@@ -295,7 +290,6 @@ const = 3
 [stale mod3]
 [builtins fixtures/module.pyi]
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:3: error: "module" has no attribute "mod4"
 
 [case testIncrementalLongBrokenCascade]
@@ -331,7 +325,6 @@ const = 3
 [stale mod6]
 [builtins fixtures/module.pyi]
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:3: error: "module" has no attribute "mod7"
 
 [case testIncrementalNestedBrokenCascade]
@@ -358,7 +351,6 @@ const = 3
 [stale mod2.mod3]
 [builtins fixtures/module.pyi]
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:3: error: "module" has no attribute "mod4"
 
 [case testIncrementalNestedBrokenCascadeWithType1]
@@ -397,7 +389,6 @@ class CustomType:
 [builtins fixtures/module.pyi]
 [out1]
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:6: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalNestedBrokenCascadeWithType2]
@@ -436,7 +427,6 @@ class CustomType:
 [builtins fixtures/module.pyi]
 [out1]
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:4: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalRemoteChange]
@@ -462,7 +452,6 @@ const = "foo"
 [rechecked mod1, mod3, mod4]
 [stale mod4]
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalBadChange]
@@ -485,7 +474,6 @@ def func2() -> str:
 [rechecked mod1, mod2]
 [stale mod2]
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:4: error: Incompatible return value type (got "str", expected "int")
 
 [case testIncrementalBadChangeWithSave]
@@ -512,7 +500,6 @@ def func2() -> str:
 [rechecked mod0, mod1, mod2]
 [stale mod2]
 [out2]
-tmp/mod0.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/mod1.py:4: error: Incompatible return value type (got "str", expected "int")
 
@@ -622,7 +609,6 @@ def some_func(a: int) -> str:
 [stale mod1_private]
 [builtins fixtures/ops.pyi]
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalWithDecorators]
@@ -660,7 +646,6 @@ def some_func(a: int) -> int:
 [stale mod1_private]
 [builtins fixtures/ops.pyi]
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalChangingClassAttributes]
@@ -746,7 +731,6 @@ class Foo:
 [rechecked mod1, mod2]
 [stale mod2]
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:4: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalNestedClassDefinition]
@@ -997,7 +981,6 @@ import a.b
 [rechecked b]
 [stale]
 [out2]
-main:1: note: In module imported here:
 tmp/b.py:4: error: Name 'a' already defined
 
 [case testIncrementalSilentImportsAndImportsInClass]
@@ -1024,7 +1007,6 @@ bar(3)
 [rechecked m]
 [stale]
 [out2]
-main:1: note: In module imported here:
 tmp/m.py:4: error: Argument 1 to "bar" has incompatible type "int"; expected "str"
 
 [case testIncrementalUnsilencingModule]
@@ -1149,16 +1131,12 @@ reveal_type(foo)
 [rechecked m, n]
 [stale]
 [out1]
-tmp/m.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/n.py:2: error: Revealed type is 'builtins.str'
-main:1: note: In module imported here:
 tmp/m.py:3: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
 [out2]
-tmp/m.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/n.py:2: error: Revealed type is 'builtins.float'
-main:1: note: In module imported here:
 tmp/m.py:3: error: Argument 1 to "accept_int" has incompatible type "float"; expected "int"
 
 [case testIncrementalReplacingImports]
@@ -1185,7 +1163,6 @@ foo(3)
 [rechecked client]
 [stale]
 [out2]
-main:1: note: In module imported here:
 tmp/client.py:4: error: Argument 1 to "foo" has incompatible type "int"; expected "str"
 
 [case testIncrementalChangingAlias]
@@ -1218,7 +1195,6 @@ def C() -> str:
 [rechecked m1, m2, m3]
 [stale m3]
 [out2]
-main:1: note: In module imported here:
 tmp/m1.py:3: error: Argument 1 to "accepts_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalSilentImportsWithBlatantError]
@@ -1315,15 +1291,12 @@ class C:
 [rechecked mod3, mod2, mod1]
 [stale mod3, mod2]
 [out1]
-tmp/mod2.py:1: note: In module imported here,
 tmp/mod1.py:1: note: ... from here,
 main:1: note: ... from here:
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:1: note: In module imported here:
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 
 [case testIncrementalIncidentalChangeWithBugCausesPropagation]
@@ -1358,19 +1331,15 @@ class C:
 [rechecked mod4, mod3, mod2, mod1]
 [stale mod4]
 [out1]
-tmp/mod2.py:1: note: In module imported here,
 tmp/mod1.py:1: note: ... from here,
 main:1: note: ... from here:
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:1: note: In module imported here:
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 
 [out2]
-tmp/mod2.py:1: note: In module imported here,
 tmp/mod1.py:1: note: ... from here,
 main:1: note: ... from here:
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:1: note: In module imported here:
 tmp/mod1.py:3: error: Revealed type is 'builtins.str'
 
 [case testIncrementalIncidentalChangeWithBugFixCausesPropagation]
@@ -1410,15 +1379,12 @@ class C:
 [rechecked mod4, mod3, mod2, mod1]
 [stale mod4, mod3, mod2]
 [out1]
-tmp/mod2.py:1: note: In module imported here,
 tmp/mod1.py:1: note: ... from here,
 main:1: note: ... from here:
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:1: note: In module imported here:
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 
 [out2]
-main:1: note: In module imported here:
 tmp/mod1.py:3: error: Revealed type is 'builtins.str'
 
 [case testIncrementalSilentImportsWithInnerImports]
@@ -1516,7 +1482,6 @@ MyTuple = NamedTuple('MyTuple', [
 [rechecked bar, mid, foo]
 [stale bar]
 [out2]
-main:1: note: In module imported here:
 tmp/foo.py:3: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalWorksWithNestedNamedTuple]
@@ -1551,7 +1516,6 @@ class Outer:
 [rechecked bar, mid, foo]
 [stale bar]
 [out2]
-main:1: note: In module imported here:
 tmp/foo.py:3: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
 
 [case testIncrementalPartialSubmoduleUpdate]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -43,7 +43,6 @@ def foo() -> None:
 [stale]
 [out2]
 main:1: note: In module imported here:
-tmp/m.py: note: In function "foo":
 tmp/m.py:2: error: Name 'bar' is not defined
 
 [case testIncrementalSimpleImportSequence]
@@ -104,7 +103,6 @@ def func1() -> A: pass
 [stale]
 [out2]
 main:1: note: In module imported here:
-tmp/mod1.py: note: In function "func1":
 tmp/mod1.py:1: error: Name 'A' is not defined
 
 [case testIncrementalSameNameChange]
@@ -170,7 +168,6 @@ def foo() -> int:
 [out2]
 tmp/mod1.py:1: note: In module imported here,
 main:1: note: ... from here:
-tmp/mod2.py: note: In function "foo":
 tmp/mod2.py:4: error: Incompatible return value type (got "str", expected "int")
 
 [case testIncrementalInternalScramble]
@@ -489,7 +486,6 @@ def func2() -> str:
 [stale mod2]
 [out2]
 main:1: note: In module imported here:
-tmp/mod1.py: note: In function "func1":
 tmp/mod1.py:4: error: Incompatible return value type (got "str", expected "int")
 
 [case testIncrementalBadChangeWithSave]
@@ -518,7 +514,6 @@ def func2() -> str:
 [out2]
 tmp/mod0.py:1: note: In module imported here,
 main:1: note: ... from here:
-tmp/mod1.py: note: In function "func1":
 tmp/mod1.py:4: error: Incompatible return value type (got "str", expected "int")
 
 [case testIncrementalOkChangeWithSave]
@@ -1061,7 +1056,6 @@ class Class: pass
 [rechecked collections, main, package.subpackage.mod1]
 [stale collections, package.subpackage.mod1]
 [out2]
-tmp/main.py: note: In function "handle":
 tmp/main.py:4: error: "Class" has no attribute "some_attribute"
 
 [case testIncrementalWithIgnores]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1318,7 +1318,6 @@ class C:
 tmp/mod2.py:1: note: In module imported here,
 tmp/mod1.py:1: note: ... from here,
 main:1: note: ... from here:
-tmp/mod3.py: note: In member "makeC" of class "B":
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
@@ -1362,7 +1361,6 @@ class C:
 tmp/mod2.py:1: note: In module imported here,
 tmp/mod1.py:1: note: ... from here,
 main:1: note: ... from here:
-tmp/mod3.py: note: In member "makeC" of class "B":
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
@@ -1371,7 +1369,6 @@ tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 tmp/mod2.py:1: note: In module imported here,
 tmp/mod1.py:1: note: ... from here,
 main:1: note: ... from here:
-tmp/mod3.py: note: In member "makeC" of class "B":
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Revealed type is 'builtins.str'
@@ -1416,7 +1413,6 @@ class C:
 tmp/mod2.py:1: note: In module imported here,
 tmp/mod1.py:1: note: ... from here,
 main:1: note: ... from here:
-tmp/mod3.py: note: In member "makeC" of class "B":
 tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:1: note: In module imported here:
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -787,7 +787,6 @@ class A(Generic[S]):
         l.append(b) # E: Argument 1 to "append" of "list" has incompatible type "S"; expected "T"
 [builtins fixtures/list.pyi]
 [out]
-main: note: In member "f" of class "A":
 
 [case testLambdaInGenericFunction]
 from typing import TypeVar, Callable
@@ -807,6 +806,5 @@ class A(Generic[T]):
     def f(self, b: S) -> None:
         c = lambda x: x  # type: Callable[[T], S]
 [out]
-main: note: In member "f" of class "A":
 main:6: error: Incompatible types in assignment (expression has type Callable[[T], T], variable has type Callable[[T], S])
 main:6: error: Incompatible return value type (got "T", expected "S")

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -85,7 +85,6 @@ def f(a: T) -> 'A[T]': pass
 class A(Generic[T]): pass
 class B: pass
 [out]
-main: note: In function "g":
 
 [case testInferLocalVariableTypeWithUnderspecifiedGenericType]
 from typing import TypeVar, Generic
@@ -96,7 +95,6 @@ def g() -> None:
 def f() -> 'A[T]': pass
 class A(Generic[T]): pass
 [out]
-main: note: In function "g":
 
 [case testInferMultipleLocalVariableTypesWithTupleRvalue]
 from typing import TypeVar, Generic
@@ -115,7 +113,6 @@ def f(a: T) -> 'A[T]': pass
 class A(Generic[T]): pass
 class B: pass
 [out]
-main: note: In function "g":
 
 [case testInferMultipleLocalVariableTypesWithArrayRvalueAndNesting]
 from typing import TypeVar, List, Generic
@@ -137,7 +134,6 @@ class A(Generic[T]): pass
 class B: pass
 [builtins fixtures/for.pyi]
 [out]
-main: note: In function "h":
 
 
 -- Return types with multiple tvar instances
@@ -396,7 +392,6 @@ def f() -> None:
 class B: pass
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 
 [case testNestedListExpressions]
 from typing import List
@@ -487,7 +482,6 @@ class B: pass
 class C(B): pass
 class D: pass
 [out]
-main: note: In function "t":
 
 [case testIntersectionWithInferredGenericArgument]
 from typing import overload, TypeVar, Generic
@@ -781,7 +775,6 @@ def f(a: T) -> None:
     l.append(1) # E: Argument 1 to "append" of "list" has incompatible type "int"; expected "T"
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 
 [case testInferenceInGenericClass]
 from typing import TypeVar, Generic, List
@@ -803,7 +796,6 @@ S = TypeVar('S')
 def f(a: T, b: S) -> None:
     c = lambda x: x  # type: Callable[[T], S]
 [out]
-main: note: In function "f":
 main:5: error: Incompatible types in assignment (expression has type Callable[[T], T], variable has type Callable[[T], S])
 main:5: error: Incompatible return value type (got "T", expected "S")
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -958,7 +958,6 @@ class A:
         self.a = B()
 class B: pass
 [out]
-main: note: In member "__init__" of class "A":
 
 [case testInferAttributeInInit]
 import typing
@@ -1206,7 +1205,6 @@ class A:
         a.append('')  # E: Argument 1 to "append" of "list" has incompatible type "str"; expected "int"
 [builtins fixtures/list.pyi]
 [out]
-main: note: In member "f" of class "A":
 
 [case testInferListInitializedToEmptyAndNotAnnotatedInMethod]
 class A:
@@ -1214,7 +1212,6 @@ class A:
         a = []  # E: Need type annotation for variable
 [builtins fixtures/list.pyi]
 [out]
-main: note: In member "f" of class "A":
 
 [case testInferListInitializedToEmptyInMethodViaAttribute]
 class A:
@@ -1225,7 +1222,6 @@ class A:
         self.a.append('') # E: Cannot determine type of 'a'
 [builtins fixtures/list.pyi]
 [out]
-main: note: In member "f" of class "A":
 
 [case testInferSetInitializedToEmpty]
 a = set()
@@ -1391,7 +1387,6 @@ class A:
         self.x = 1
         self.x() # E: "int" not callable
 [out]
-main: note: In member "f" of class "A":
 
 [case testAttributePartiallyInitializedToNoneWithMissingAnnotation]
 class A:
@@ -1402,9 +1397,7 @@ class A:
         self.x = 1
         self.x()
 [out]
-main: note: In member "f" of class "A":
 main:3: error: Need type annotation for variable
-main: note: In member "g" of class "A":
 main:7: error: "int" not callable
 
 [case testGlobalInitializedToNoneSetFromFunction]
@@ -1435,7 +1428,6 @@ class A:
 [builtins fixtures/for.pyi]
 [out]
 main:3: error: Need type annotation for variable
-main: note: In member "f" of class "A":
 main:5: error: None has no attribute "__iter__"
 
 [case testPartialTypeErrorSpecialCase2]
@@ -1447,7 +1439,6 @@ class A:
             pass
 [builtins fixtures/for.pyi]
 [out]
-main: note: In member "f" of class "A":
 main:3: error: Need type annotation for variable
 main:3: error: Need type annotation for variable
 
@@ -1460,7 +1451,6 @@ class A:
 [builtins fixtures/for.pyi]
 [out]
 main:2: error: Need type annotation for variable
-main: note: In member "f" of class "A":
 main:4: error: None has no attribute "__iter__"
 
 
@@ -1484,7 +1474,6 @@ class A:
     def g(self) -> None:
         self.x = 1
 [out]
-main: note: In member "f" of class "A":
 
 [case testMultipassAndTopLevelVariable]
 y = x # E: Cannot determine type of 'x'
@@ -1506,7 +1495,6 @@ class A:
 
 def dec(f: Callable[[A, str], T]) -> Callable[[A, int], T]: pass
 [out]
-main: note: In member "f" of class "A":
 
 [case testMultipassAndDefineAttributeBasedOnNotReadyAttribute]
 class A:
@@ -1519,7 +1507,6 @@ class A:
     def h(self) -> None:
         self.y() # E: "int" not callable
 [out]
-main: note: In member "h" of class "A":
 
 [case testMultipassAndDefineAttributeBasedOnNotReadyAttribute2]
 class A:
@@ -1535,10 +1522,8 @@ class A:
     def h(self) -> None:
         self.y() # E
 [out]
-main: note: In member "f" of class "A":
 main:5: error: "int" not callable
 main:6: error: "int" not callable
-main: note: In member "h" of class "A":
 main:12: error: "int" not callable
 
 [case testMultipassAndPartialTypes]
@@ -1599,7 +1584,6 @@ class A:
     def g(self) -> None:
         self.y = self.x
 [out]
-main: note: In member "f" of class "A":
 
 [case testMultipassAndPartialTypesSpecialCase1]
 def f() -> None:

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1440,7 +1440,6 @@ class A:
 [builtins fixtures/for.pyi]
 [out]
 main:3: error: Need type annotation for variable
-main:3: error: Need type annotation for variable
 
 [case testPartialTypeErrorSpecialCase3]
 class A:

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1650,7 +1650,6 @@ def g() -> None:
     y()
 y = 0
 [out]
-main:1: note: In module imported here:
 tmp/m.py:2: error: "int" not callable
 main:3: error: "int" not callable
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -28,7 +28,6 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 main:5: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 main:7: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
@@ -40,7 +39,6 @@ def f() -> None:
 
 def g() -> None: pass
 [out]
-main: note: In function "f":
 
 [case testInferringLvarTypeFromArgument]
 import typing
@@ -53,7 +51,6 @@ def f(a: 'A') -> None:
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 
 [case testInferringLvarTypeFromGvar]
 
@@ -67,7 +64,6 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 
 [case testInferringImplicitDynamicTypeForLvar]
 import typing
@@ -78,7 +74,6 @@ def f() -> None:
 
 def g(): pass
 [out]
-main: note: In function "f":
 
 [case testInferringExplicitDynamicTypeForLvar]
 from typing import Any
@@ -89,7 +84,6 @@ def f(a: Any) -> None:
     None(b) # E: None not callable
     a.x()
 [out]
-main: note: In function "f":
 
 
 -- Inferring types of local variables with complex types
@@ -111,7 +105,6 @@ class A: pass
 class B: pass
 [builtins fixtures/tuple.pyi]
 [out]
-main: note: In function "f":
 
 [case testInferringTupleTypeForLvarWithNones]
 import typing
@@ -122,7 +115,6 @@ def f() -> None:
 class A: pass
 [builtins fixtures/tuple.pyi]
 [out]
-main: note: In function "f":
 
 [case testInferringGenericTypeForLvar]
 from typing import TypeVar, Generic
@@ -138,7 +130,6 @@ def f() -> None:
     a = a_i
 [builtins fixtures/tuple.pyi]
 [out]
-main: note: In function "f":
 
 [case testInferringFunctionTypeForLvar]
 import typing
@@ -152,7 +143,6 @@ def g(a: 'A') -> None: pass
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 
 [case testInferringFunctionTypeForLvarFromTypeObject]
 import typing
@@ -164,7 +154,6 @@ def f() -> None:
 
 class A: pass
 [out]
-main: note: In function "f":
 
 
 -- Inferring variable types in multiple definition
@@ -185,7 +174,6 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 
 [case testInferringLvarTypesInTupleAssignment]
 from typing import Tuple
@@ -202,7 +190,6 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 
 [case testInferringLvarTypesInNestedTupleAssignment1]
 from typing import Tuple
@@ -219,7 +206,6 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 
 [case testInferringLvarTypesInNestedTupleAssignment2]
 import typing
@@ -238,7 +224,6 @@ class A: pass
 class B: pass
 class C: pass
 [out]
-main: note: In function "f":
 
 [case testInferringLvarTypesInNestedListAssignment]
 import typing
@@ -257,7 +242,6 @@ class A: pass
 class B: pass
 class C: pass
 [out]
-main: note: In function "f":
 
 [case testInferringLvarTypesInMultiDefWithNoneTypes]
 import typing
@@ -267,7 +251,6 @@ def f() -> None:
 
 class A: pass
 [out]
-main: note: In function "f":
 
 [case testInferringLvarTypesInNestedTupleAssignmentWithNoneTypes]
 import typing
@@ -276,7 +259,6 @@ def f() -> None:
 
 class A: pass
 [out]
-main: note: In function "f":
 
 [case testInferringLvarTypesInMultiDefWithInvalidTuple]
 from typing import Tuple
@@ -288,7 +270,6 @@ def f() -> None:
     g, h, i = t
 [builtins fixtures/tuple.pyi]
 [out]
-main: note: In function "f":
 main:5: error: Too many values to unpack (2 expected, 3 provided)
 main:6: error: Need more than 3 values to unpack (4 expected)
 
@@ -300,7 +281,6 @@ def f() -> None:
 class A: pass
 [builtins fixtures/for.pyi]
 [out]
-main: note: In function "f":
 
 [case testInvalidRvalueTypeInInferredNestedTupleAssignment]
 import typing
@@ -310,7 +290,6 @@ def f() -> None:
 class A: pass
 [builtins fixtures/for.pyi]
 [out]
-main: note: In function "f":
 
 [case testInferringMultipleLvarDefinitionWithListRvalue]
 from typing import List
@@ -339,7 +318,6 @@ def f() -> None:
     d = e
 [builtins fixtures/for.pyi]
 [out]
-main: note: In function "f":
 
 [case testInferringNestedTupleAssignmentWithListRvalue]
 from typing import List
@@ -368,7 +346,6 @@ def f() -> None:
     d = e
 [builtins fixtures/for.pyi]
 [out]
-main: note: In function "f":
 
 [case testInferringMultipleLvarDefinitionWithImplicitDynamicRvalue]
 import typing
@@ -435,7 +412,6 @@ def f() -> None:
 def id(x: T) -> T:
     return x
 [out]
-main: note: In function "f":
 
 [case testUnderspecifiedInferenceResult]
 from typing import TypeVar
@@ -453,7 +429,6 @@ g(a)
 def f() -> T: pass
 def g(a: T) -> None: pass
 [out]
-main: note: In function "ff":
 
 [case testUnsolvableInferenceResult]
 from typing import TypeVar
@@ -914,7 +889,6 @@ class A: pass
 class B: pass
 [builtins fixtures/for.pyi]
 [out]
-main: note: In function "f":
 
 
 -- Regression tests
@@ -1185,7 +1159,6 @@ def f() -> None:
    a.append('')  # E: Argument 1 to "append" of "list" has incompatible type "str"; expected "int"
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 
 [case testInferListInitializedToEmptyAndNotAnnotatedInFunction]
 def f() -> None:
@@ -1197,7 +1170,6 @@ a = []
 a.append(1)
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 
 [case testInferListInitializedToEmptyAndReadBeforeAppendInFunction]
 def f() -> None:
@@ -1207,7 +1179,6 @@ def f() -> None:
     a.append('')
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 
 [case testInferListInitializedToEmptyInClassBody]
 class A:
@@ -1321,7 +1292,6 @@ def f(blocks: Any): # E: Name 'Any' is not defined
     to_process = list(blocks)
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 
 [case testSpecialCaseEmptyListInitialization2]
 def f(blocks: object):
@@ -1329,7 +1299,6 @@ def f(blocks: object):
     to_process = list(blocks) # E: No overload variant of "list" matches argument types [builtins.object]
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 
 
 -- Inferring types of variables first initialized to None (partial types)
@@ -1344,7 +1313,6 @@ def f() -> None:
         x = 1
     x() # E: "int" not callable
 [out]
-main: note: In function "f":
 
 [case testLocalVariablePartiallyTwiceInitializedToNone]
 def f() -> None:
@@ -1356,7 +1324,6 @@ def f() -> None:
         x = 1
     x() # E: "int" not callable
 [out]
-main: note: In function "f":
 
 [case testLvarInitializedToNoneWithoutType]
 import typing
@@ -1364,7 +1331,6 @@ def f() -> None:
     a = None # E: Need type annotation for variable
     a.x() # E: None has no attribute "x"
 [out]
-main: note: In function "f":
 
 [case testGvarPartiallyInitializedToNone]
 x = None
@@ -1397,7 +1363,6 @@ def f() -> None:
         x = []  # E: Need type annotation for variable
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 
 [case testPartiallyInitializedToNoneAndThenToIncompleteType]
 from typing import TypeVar,  Dict
@@ -1413,7 +1378,6 @@ def f() -> None:
     x = None  # E: Need type annotation for variable
 x = 1
 [out]
-main: note: In function "f":
 
 [case testPartiallyInitializedVariableDoesNotEscapeScope2]
 x = None  # E: Need type annotation for variable
@@ -1515,7 +1479,6 @@ def f() -> None:
     y() # E: "int" not callable
 x = 1
 [out]
-main: note: In function "f":
 
 [case testMultipassAndAccessInstanceVariableBeforeDefinition]
 class A:
@@ -1593,7 +1556,6 @@ def f() -> None:
 y = ''
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 
 [case testMultipassAndPartialTypes2]
 s = ''
@@ -1608,7 +1570,6 @@ def f() -> None:
 y = ''
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 
 [case testMultipassAndPartialTypes3]
 from typing import Dict
@@ -1622,7 +1583,6 @@ def f() -> None:
 y = ''
 [builtins fixtures/dict.pyi]
 [out]
-main: note: In function "f":
 
 [case testMultipassAndPartialTypes4]
 from typing import Dict
@@ -1635,7 +1595,6 @@ def f() -> None:
 y = ''
 [builtins fixtures/dict.pyi]
 [out]
-main: note: In function "f":
 
 [case testMultipassAndCircularDependency]
 class A:
@@ -1656,7 +1615,6 @@ def f() -> None:
 o = 1
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 
 [case testMultipassAndPartialTypesSpecialCase2]
 def f() -> None:
@@ -1667,7 +1625,6 @@ def f() -> None:
 o = 1
 [builtins fixtures/dict.pyi]
 [out]
-main: note: In function "f":
 
 [case testMultipassAndPartialTypesSpecialCase3]
 def f() -> None:
@@ -1677,7 +1634,6 @@ def f() -> None:
 o = 1
 [builtins fixtures/dict.pyi]
 [out]
-main: note: In function "f":
 
 [case testMultipassAndPartialTypesSpecialCase4]
 def f() -> None:
@@ -1687,7 +1643,6 @@ def f() -> None:
     x() # E: "int" not callable
 o = 1
 [out]
-main: note: In function "f":
 
 [case testMultipassAndPartialTypesSpecialCase5]
 def f() -> None:
@@ -1697,7 +1652,6 @@ def f() -> None:
     x() # E: "int" not callable
 o = 1
 [out]
-main: note: In function "f":
 
 [case testMultipassAndClassAttribute]
 class S:
@@ -1718,9 +1672,7 @@ def g() -> None:
 y = 0
 [out]
 main:1: note: In module imported here:
-tmp/m.py: note: In function "g":
 tmp/m.py:2: error: "int" not callable
-main: note: In function "f":
 main:3: error: "int" not callable
 
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1187,7 +1187,6 @@ class A:
    a.append('')  # E: Argument 1 to "append" of "list" has incompatible type "str"; expected "int"
 [builtins fixtures/list.pyi]
 [out]
-main: note: In class "A":
 
 [case testInferListInitializedToEmptyAndNotAnnotatedInClassBody]
 class A:
@@ -1198,7 +1197,6 @@ class B:
     a.append(1)
 [builtins fixtures/list.pyi]
 [out]
-main: note: In class "A":
 
 [case testInferListInitializedToEmptyInMethod]
 class A:
@@ -1436,7 +1434,6 @@ class A:
             pass
 [builtins fixtures/for.pyi]
 [out]
-main: note: In class "A":
 main:3: error: Need type annotation for variable
 main: note: In member "f" of class "A":
 main:5: error: None has no attribute "__iter__"
@@ -1452,7 +1449,6 @@ class A:
 [out]
 main: note: In member "f" of class "A":
 main:3: error: Need type annotation for variable
-main: note: In class "A":
 main:3: error: Need type annotation for variable
 
 [case testPartialTypeErrorSpecialCase3]
@@ -1463,7 +1459,6 @@ class A:
             pass
 [builtins fixtures/for.pyi]
 [out]
-main: note: In class "A":
 main:2: error: Need type annotation for variable
 main: note: In member "f" of class "A":
 main:4: error: None has no attribute "__iter__"

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -55,7 +55,6 @@ x = None # type: int
 y = [x]
 [builtins fixtures/isinstancelist.pyi]
 [out]
-main: note: In function "foo":
 
 [case testFunctionDefaultArgs]
 
@@ -68,7 +67,6 @@ def foo(x: A = B()):
     x.y   # E: "A" has no attribute "y"
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "foo":
 
 [case testIsinstanceFancyConditionals]
 
@@ -187,7 +185,6 @@ def bar() -> None:
     x + 'a'
 [builtins fixtures/isinstancelist.pyi]
 [out]
-main: note: In function "bar":
 
 [case testUnionTryExcept]
 
@@ -367,7 +364,6 @@ def f() -> int:
     finally:
         return x.b # E: "A" has no attribute "b"
 [out]
-main: note: In function "f":
 [case testUnionListIsinstance]
 
 from typing import Union, List
@@ -395,7 +391,6 @@ def f(x: Union[List[int], List[str], int]) -> None:
     x + 1 # E: Unsupported operand types for + (likely involving Union)
 [builtins fixtures/isinstancelist.pyi]
 [out]
-main: note: In function "f":
 
 [case testUnionListIsinstance2]
 
@@ -622,7 +617,6 @@ def foo() -> None:
 foo()
 [builtins fixtures/isinstancelist.pyi]
 [out]
-main: note: In function "foo":
 [case testIsInstanceThreeUnion]
 from typing import Union, List
 
@@ -922,7 +916,6 @@ def bar() -> None:
 
 [builtins fixtures/isinstancelist.pyi]
 [out]
-main: note: In function "bar":
 
 [case testWhileExitCondition1]
 from typing import Union
@@ -1180,7 +1173,6 @@ def f(x: Union[int, str]) -> None:
 def foo(): pass
 [builtins fixtures/isinstancelist.pyi]
 [out]
-main: note: In function "f":
 
 [case testIsinstanceOr1]
 from typing import Optional
@@ -1191,7 +1183,6 @@ def f(a: bool, x: object) -> Optional[int]:
     return x
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 [case testIsinstanceOr2]
 from typing import Optional
@@ -1202,7 +1193,6 @@ def g(a: bool, x: object) -> Optional[int]:
     return x
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "g":
 
 [case testIsinstanceOr3]
 from typing import Optional
@@ -1212,7 +1202,6 @@ def h(a: bool, x: object) -> Optional[int]:
     return x # E: Incompatible return value type (got "object", expected "int")
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "h":
 
 [case testIsinstanceWithOverlappingUnionType]
 from typing import Union
@@ -1278,7 +1267,6 @@ def f(x: Any):
     x + "foo"  # E: Unsupported operand types for + ("int" and "str")
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 [case testIsinstanceOfGenericClassRetainsParameters]
 from typing import List, Union
@@ -1287,7 +1275,6 @@ def f(x: Union[List[int], str]) -> None:
         x[0]()
 [builtins fixtures/isinstancelist.pyi]
 [out]
-main: note: In function "f":
 main:4: error: "int" not callable
 
 [case testIsinstanceOrIsinstance]
@@ -1331,7 +1318,6 @@ def f(x: object) -> None:
         pass
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 [case testIsinstanceAndOr]
 class A:
@@ -1342,4 +1328,3 @@ def f(x: object) -> None:
     reveal_type(b)  # E: Revealed type is '__main__.A'
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -228,7 +228,6 @@ def f( **kwargs: 'A') -> None:
 class A: pass
 [builtins fixtures/dict.pyi]
 [out]
-main: note: In function "f":
 
 [case testKwargsArgumentInFunctionBodyWithImplicitAny]
 from typing import Dict, Any
@@ -239,7 +238,6 @@ def f(**kwargs) -> None:
 class A: pass
 [builtins fixtures/dict.pyi]
 [out]
-main: note: In function "f":
 
 [case testCallingFunctionThatAcceptsVarKwargs]
 import typing

--- a/test-data/unit/check-lists.test
+++ b/test-data/unit/check-lists.test
@@ -60,7 +60,6 @@ class B: pass
 class C: pass
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 
 [case testListWithStarExpr]
 (x, *a) = [1, 2, 3]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -123,7 +123,6 @@ class C:
 [file m.py]
 def f() -> None: pass
 [out]
-main: note: In class "C":
 
 [case testImportWithinClassBody2]
 import typing
@@ -134,7 +133,6 @@ class C:
 [file m.py]
 def f() -> None: pass
 [out]
-main: note: In class "C":
 
 [case testImportWithStub]
 import _m

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1092,7 +1092,6 @@ import x
 class Sub(x.Base):
     attr = 0
 [out]
-main:1: note: ... from here:
 tmp/x.py:5: error: Revealed type is 'builtins.int'
 
 -- This case has a symmetrical cycle, so it doesn't matter in what
@@ -1197,7 +1196,6 @@ def g() -> int:
     return a.y
 x = 1 + 1
 [out]
-main:1: note: ... from here:
 tmp/b.py:3: error: Revealed type is 'builtins.int'
 
 [case testSymmetricImportCycle2]
@@ -1214,7 +1212,6 @@ def g() -> int:
     return a.y
 x = 1 + 1
 [out]
-main:1: note: ... from here:
 tmp/a.py:3: error: Revealed type is 'builtins.int'
 
 [case testThreePassesRequired]
@@ -1230,7 +1227,6 @@ class C:
 import a
 b = 1 + 1
 [out]
-main:1: note: ... from here:
 tmp/a.py:4: error: Cannot determine type of 'x2'
 
 [case testErrorInPassTwo1]
@@ -1244,7 +1240,6 @@ def f() -> None:
 import a
 x = 1 + 1
 [out]
-main:1: note: ... from here:
 tmp/a.py:4: error: Unsupported operand types for + ("int" and "str")
 
 [case testErrorInPassTwo2]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -112,7 +112,6 @@ a = A()
 b = B()
 def f() -> None: pass
 [out]
-main: note: In member "f" of class "C":
 
 [case testImportWithinClassBody]
 import typing
@@ -1244,7 +1243,6 @@ b = 1 + 1
 [out]
 tmp/b.py:1: note: In module imported here,
 main:1: note: ... from here:
-tmp/a.py: note: In member "f1" of class "C":
 tmp/a.py:4: error: Cannot determine type of 'x2'
 
 [case testErrorInPassTwo1]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -93,7 +93,6 @@ a = A()
 b = B()
 def f() -> None: pass
 [out]
-main: note: In function "f":
 
 [case testImportWithinMethod]
 import typing
@@ -462,15 +461,12 @@ def f(x: int = ...) -> None: pass
 def g(x: int = '') -> None: pass
 [out]
 main:1: note: In module imported here:
-tmp/m.pyi: note: In function "g":
 tmp/m.pyi:1: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main: note: In function "f":
 main:2: error: Incompatible types in assignment (expression has type "ellipsis", variable has type "int")
 
 [case testEllipsisDefaultArgValueInNonStub]
 def f(x: int = ...) -> None: pass # E: Incompatible types in assignment (expression has type "ellipsis", variable has type "int")
 [out]
-main: note: In function "f":
 
 [case testStarImportOverlapping]
 from m1 import *
@@ -624,7 +620,6 @@ def g() -> None:
 [file m.py]
 def f(): pass
 [out]
-main: note: In function "g":
 
 [case testAssignToFuncDefViaNestedModules]
 import m.n
@@ -1109,7 +1104,6 @@ class Sub(x.Base):
 [out]
 tmp/y.py:1: note: In module imported here,
 main:1: note: ... from here:
-tmp/x.py: note: In function "foo":
 tmp/x.py:5: error: Revealed type is 'builtins.int'
 
 -- This case has a symmetrical cycle, so it doesn't matter in what
@@ -1187,7 +1181,6 @@ import x
 value = 12
 [out]
 main:1: note: In module imported here:
-tmp/x.py: note: In function "foo":
 tmp/x.py:3: error: Revealed type is 'builtins.int'
 
 -- This is not really cycle-related but still about the lightweight
@@ -1218,7 +1211,6 @@ x = 1 + 1
 [out]
 tmp/a.py:1: note: In module imported here,
 main:1: note: ... from here:
-tmp/b.py: note: In function "g":
 tmp/b.py:3: error: Revealed type is 'builtins.int'
 
 [case testSymmetricImportCycle2]
@@ -1237,7 +1229,6 @@ x = 1 + 1
 [out]
 tmp/b.py:1: note: In module imported here,
 main:1: note: ... from here:
-tmp/a.py: note: In function "f":
 tmp/a.py:3: error: Revealed type is 'builtins.int'
 
 [case testThreePassesRequired]
@@ -1271,7 +1262,6 @@ x = 1 + 1
 [out]
 tmp/b.py:1: note: In module imported here,
 main:1: note: ... from here:
-tmp/a.py: note: In function "f":
 tmp/a.py:4: error: Unsupported operand types for + ("int" and "str")
 
 [case testErrorInPassTwo2]
@@ -1286,7 +1276,6 @@ import a
 x = 1 + 1
 [out]
 main:1: note: In module imported here:
-tmp/a.py: note: In function "f":
 tmp/a.py:4: error: Unsupported operand types for + ("int" and "str")
 
 [case testDeferredDecorator]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -327,7 +327,6 @@ x.z
 import nonexistent
 [builtins fixtures/module.pyi]
 [out]
-main:1: note: In module imported here:
 tmp/x.py:1: error: Cannot find module named 'nonexistent'
 tmp/x.py:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 main:3: error: "module" has no attribute "z"
@@ -369,7 +368,6 @@ class B: pass
 x = A()
 y = B()
 [out]
-main:2: note: In module imported here:
 tmp/m/a.py:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
@@ -457,7 +455,6 @@ def f(x: int = ...) -> None: pass
 [file m.pyi]
 def g(x: int = '') -> None: pass
 [out]
-main:1: note: In module imported here:
 tmp/m.pyi:1: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:2: error: Incompatible types in assignment (expression has type "ellipsis", variable has type "int")
 
@@ -798,7 +795,6 @@ a.b.c.value
 [file a/b/c.py]
 value = 3.2
 [out]
-main:1: note: In module imported here:
 tmp/a/b/__init__.py:2: error: Name 'c' is not defined
 tmp/a/b/__init__.py:3: error: Name 'a' is not defined
 tmp/a/__init__.py:2: error: Name 'b' is not defined
@@ -829,7 +825,6 @@ foo = parent.common.SomeClass()
 
 [builtins fixtures/module.pyi]
 [out]
-main:1: note: In module imported here:
 tmp/parent/child.py:3: error: Name 'parent' is not defined
 
 [case testSubmoduleMixingImportFromAndImport]
@@ -856,7 +851,6 @@ bar = parent.unrelated.ShouldNotLoad()
 
 [builtins fixtures/module.pyi]
 [out]
-main:1: note: In module imported here:
 tmp/parent/child.py:8: error: Revealed type is 'parent.common.SomeClass'
 tmp/parent/child.py:9: error: "module" has no attribute "unrelated"
 
@@ -876,7 +870,6 @@ reveal_type(foo)
 
 [builtins fixtures/module.pyi]
 [out]
-main:1: note: In module imported here:
 tmp/parent/child.py:4: error: Revealed type is 'parent.common.SomeClass'
 
 -- Tests repeated imports
@@ -1099,7 +1092,6 @@ import x
 class Sub(x.Base):
     attr = 0
 [out]
-tmp/y.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/x.py:5: error: Revealed type is 'builtins.int'
 
@@ -1177,7 +1169,6 @@ def foo() -> int:
 import x
 value = 12
 [out]
-main:1: note: In module imported here:
 tmp/x.py:3: error: Revealed type is 'builtins.int'
 
 -- This is not really cycle-related but still about the lightweight
@@ -1206,7 +1197,6 @@ def g() -> int:
     return a.y
 x = 1 + 1
 [out]
-tmp/a.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/b.py:3: error: Revealed type is 'builtins.int'
 
@@ -1224,7 +1214,6 @@ def g() -> int:
     return a.y
 x = 1 + 1
 [out]
-tmp/b.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/a.py:3: error: Revealed type is 'builtins.int'
 
@@ -1241,7 +1230,6 @@ class C:
 import a
 b = 1 + 1
 [out]
-tmp/b.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/a.py:4: error: Cannot determine type of 'x2'
 
@@ -1256,7 +1244,6 @@ def f() -> None:
 import a
 x = 1 + 1
 [out]
-tmp/b.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/a.py:4: error: Unsupported operand types for + ("int" and "str")
 
@@ -1271,7 +1258,6 @@ def f() -> None:
 import a
 x = 1 + 1
 [out]
-main:1: note: In module imported here:
 tmp/a.py:4: error: Unsupported operand types for + ("int" and "str")
 
 [case testDeferredDecorator]
@@ -1292,7 +1278,6 @@ def deco(f: Callable[[T], int]) -> Callable[[T], int]:
     a.x
     return f
 [out]
-main:1: note: In module imported here:
 tmp/a.py:6: error: Revealed type is 'def (builtins.str*) -> builtins.int'
 
 [case testDeferredClassContext]
@@ -1361,7 +1346,6 @@ AnyAlias = Any
 ListAlias = List
 [builtins fixtures/list.pyi]
 [out]
-main:1: note: In module imported here:
 tmp/bar.py:5: error: Revealed type is 'builtins.list[builtins.int]'
 
 [case testImportStarAliasSimpleGeneric]

--- a/test-data/unit/check-multiple-inheritance.test
+++ b/test-data/unit/check-multiple-inheritance.test
@@ -123,7 +123,6 @@ class B:
     def f(self, x: str) -> None: pass
 class C(A, B): pass
 [out]
-main: note: In class "C":
 main:6: error: Definition of "f" in base class "A" is incompatible with definition in base class "B"
 
 [case testMethodNameCollisionInMultipleInheritanceWithIncompatibleSigs2]
@@ -135,9 +134,7 @@ class B:
 class C(A, B): pass
 class D(B, A): pass
 [out]
-main: note: In class "C":
 main:6: error: Definition of "f" in base class "A" is incompatible with definition in base class "B"
-main: note: In class "D":
 main:7: error: Definition of "f" in base class "B" is incompatible with definition in base class "A"
 
 
@@ -160,7 +157,6 @@ class B:
         self.x = ''
 class C(A, B): pass
 [out]
-main: note: In class "C":
 main:8: error: Definition of "x" in base class "A" is incompatible with definition in base class "B"
 
 [case testClassVarNameOverlapInMultipleInheritanceWithInvalidTypes]
@@ -171,7 +167,6 @@ class B:
     x = ''
 class C(A, B): pass
 [out]
-main: note: In class "C":
 main:6: error: Definition of "x" in base class "A" is incompatible with definition in base class "B"
 
 [case testMethodOverlapsWithClassVariableInMultipleInheritance]
@@ -182,7 +177,6 @@ class B:
     f = ''
 class C(A, B): pass
 [out]
-main: note: In class "C":
 main:6: error: Definition of "f" in base class "A" is incompatible with definition in base class "B"
 
 [case testMethodOverlapsWithInstanceVariableInMultipleInheritance]
@@ -194,7 +188,6 @@ class B:
         self.f = ''
 class C(A, B): pass
 [out]
-main: note: In class "C":
 main:7: error: Definition of "f" in base class "A" is incompatible with definition in base class "B"
 
 [case testMultipleInheritanceAndInit]
@@ -215,7 +208,6 @@ class B:
 class C(B, A): pass
 class D(A, B): pass
 [out]
-main: note: In class "D":
 main:8: error: Definition of "clear" in base class "A" is incompatible with definition in base class "B"
 
 
@@ -246,6 +238,5 @@ class C:
 def dec(f: Callable[..., T]) -> Callable[..., T]:
     return f
 [out]
-main: note: In class "A":
 main:3: error: Cannot determine type of 'f' in base class 'B'
 main:3: error: Cannot determine type of 'f' in base class 'C'

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -171,7 +171,6 @@ class B(A):
 
 
 [out]
-main: note: In member "f" of class "B":
 
 [case testNamedTupleTypeReferenceToClassDerivedFrom]
 from typing import NamedTuple
@@ -189,7 +188,6 @@ class B(A):
                           variable has type "int")
 
 [out]
-main: note: In member "f" of class "B":
 
 [case testNamedTupleSubtyping]
 from typing import NamedTuple, Tuple

--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -78,7 +78,6 @@ def f() -> None:
     x: int
     x = None  # E: Incompatible types in assignment (expression has type None, variable has type "int")
 [out]
-main: note: In function "f":
 
 [case testNewSyntaxWithStrictOptionalClasses]
 # flags: --fast-parser --strict-optional --python-version 3.6

--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -85,4 +85,3 @@ class C:
         x: int = None  # E: Incompatible types in assignment (expression has type None, variable has type "int")
         self.x: int = None  # E: Incompatible types in assignment (expression has type None, variable has type "int")
 [out]
-main: note: In member "meth" of class "C":

--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -63,7 +63,6 @@ TstInstance().a = 'ab'
 class CCC:
     a: str = None  # E: Incompatible types in assignment (expression has type None, variable has type "str")
 [out]
-main: note: In class "CCC":
 
 [case testNewSyntaxWithStrictOptional]
 # flags: --fast-parser --strict-optional --python-version 3.6

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -180,7 +180,6 @@ class MyClass:
 b = A(3)
 c = MyClass.C(3.5)
 [out]
-main: note: In function "func":
 
 [case testNewTypeInMultipleFiles]
 import a

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -233,7 +233,6 @@ reveal_type(num)
 [stale]
 [out1]
 [out2]
-main:1: note: In module imported here:
 tmp/m.py:13: error: Revealed type is 'm.UserId'
 tmp/m.py:14: error: Revealed type is 'builtins.int'
 

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -200,7 +200,6 @@ class C:
     def __init__(self) -> None:
         self.x = None  # E: Incompatible types in assignment (expression has type None, variable has type "int")
 [out]
-main: note: In member "__init__" of class "C":
 
 [case testMultipleAssignmentNoneClassVariableInInit]
 from typing import Optional
@@ -210,7 +209,6 @@ class C:
         self.x = None  # E: Incompatible types in assignment (expression has type None, variable has type "int")
         self.y = None  # E: Incompatible types in assignment (expression has type None, variable has type "str")
 [out]
-main: note: In member "__init__" of class "C":
 
 [case testOverloadWithNone]
 from typing import overload

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -114,7 +114,6 @@ def f(x: int = None) -> None:
   x + 1  # E: Unsupported left operand type for + (some union)
 f(None)
 [out]
-main: note: In function "f":
 
 [case testInferOptionalFromDefaultNoneWithFastParser]
 # flags: --fast-parser
@@ -122,7 +121,6 @@ def f(x: int = None) -> None:
   x + 1  # E: Unsupported left operand type for + (some union)
 f(None)
 [out]
-main: note: In function "f":
 
 [case testInferOptionalFromDefaultNoneComment]
 def f(x=None):
@@ -130,7 +128,6 @@ def f(x=None):
   x + 1  # E: Unsupported left operand type for + (some union)
 f(None)
 [out]
-main: note: In function "f":
 
 [case testInferOptionalFromDefaultNoneCommentWithFastParser]
 # flags: --fast-parser
@@ -139,7 +136,6 @@ def f(x=None):
   x + 1  # E: Unsupported left operand type for + (some union)
 f(None)
 [out]
-main: note: In function "f":
 
 [case testInferOptionalType]
 x = None
@@ -245,9 +241,7 @@ def f(a: Optional[int], b: Optional[int]) -> None:
 def g(a: int, b: Optional[int]) -> None:
     reveal_type(a or b)
 [out]
-main: note: In function "f":
 main:3: error: Revealed type is 'Union[builtins.int, builtins.None]'
-main: note: In function "g":
 main:5: error: Revealed type is 'Union[builtins.int, builtins.None]'
 
 [case testOptionalTypeOrTypeComplexUnion]
@@ -255,7 +249,6 @@ from typing import Union
 def f(a: Union[int, str, None]) -> None:
     reveal_type(a or 'default')
 [out]
-main: note: In function "f":
 main:3: error: Revealed type is 'Union[builtins.int, builtins.str]'
 
 [case testOptionalTypeOrTypeNoTriggerPlain]
@@ -263,7 +256,6 @@ from typing import Optional
 def f(a: Optional[int], b: int) -> int:
     return b or a
 [out]
-main: note: In function "f":
 main:3: error: Incompatible return value type (got "Optional[int]", expected "int")
 
 [case testOptionalTypeOrTypeNoTriggerTypeVar]
@@ -272,7 +264,6 @@ T = TypeVar('T')
 def f(a: Optional[T], b: T) -> T:
     return b or a
 [out]
-main: note: In function "f":
 main:4: error: Incompatible return value type (got "Optional[T]", expected "T")
 
 [case testNoneOrStringIsString]
@@ -506,7 +497,6 @@ def f() -> None:
 def g() -> int:
   1 + 1  #
 [out]
-main: note: In function "g":
 main:5: note: Missing return statement
 
 [case testGenericTypeAliasesOptional]

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -396,7 +396,6 @@ x = None  # type: Optional[int]
 x + 1
 1 + "foo"
 [out]
-main:3: note: In module imported here:
 tmp/b.py:4: error: Unsupported operand types for + ("int" and "str")
 
 [case testOptionalWhitelistPermitsWhitelistedFiles]
@@ -413,7 +412,6 @@ from typing import Optional
 x = None  # type: Optional[int]
 x + 1
 [out]
-main:2: note: In module imported here:
 tmp/a.py:3: error: Unsupported left operand type for + (some union)
 
 [case testNoneContextInference]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -454,9 +454,7 @@ class D(A):
     @overload
     def f(self, x: str) -> str: return ''
 [out]
-main: note: In class "B":
 main:12: error: Signature of "f" incompatible with supertype "A"
-main: note: In class "C":
 main:17: error: Signature of "f" incompatible with supertype "A"
 
 [case testOverloadingAndDucktypeCompatibility]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -14,7 +14,6 @@ def f(x: 'B'):
 class A: pass
 class B: pass
 [out]
-main: note: In function "f":
 
 [case testTypeCheckOverloadedMethodBody]
 from typing import overload
@@ -610,7 +609,6 @@ def g(x: U, y: V) -> None:
     f([x, y]) # E: Type argument 1 of "f" has incompatible value "object"
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "g":
 
 [case testOverlapWithTypeVars]
 from typing import overload, TypeVar, Sequence

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -28,7 +28,6 @@ class A:
         x = B()
 class B: pass
 [out]
-main: note: In member "f" of class "A":
 
 [case testCallToOverloadedFunction]
 from typing import overload

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -114,7 +114,6 @@ f(object(), (1, ''))
 f(1, 1) # E
 [builtins_py2 fixtures/tuple.pyi]
 [out]
-main: note: In function "f":
 main:3: error: "object" not callable
 main:4: error: "int" not callable
 main:5: error: "str" not callable
@@ -132,7 +131,6 @@ f(object(), (1, ('', 2)))
 f(1, 1) # E
 [builtins fixtures/tuple.pyi]
 [out]
-main: note: In function "f":
 main:3: error: "object" not callable
 main:4: error: "int" not callable
 main:5: error: "str" not callable
@@ -182,7 +180,6 @@ def f(x, y, z): # type: (...) -> None
 def f(x, y, z): # type: (..., int) -> None
     pass
 [out]
-main: note: In function "f":
 main:1: error: Parse error before ): Ellipses cannot accompany other argument types in function type signature.
 
 [case testLambdaTupleArgInPython2]

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -117,7 +117,6 @@ f(1, 1) # E
 main:3: error: "object" not callable
 main:4: error: "int" not callable
 main:5: error: "str" not callable
-main: note: At top level:
 main:7: error: Argument 2 to "f" has incompatible type "int"; expected "Tuple[int, str]"
 
 [case testNestedTupleArgListAnnotated]
@@ -135,7 +134,6 @@ main:3: error: "object" not callable
 main:4: error: "int" not callable
 main:5: error: "str" not callable
 main:6: error: "int" not callable
-main: note: At top level:
 main:8: error: Argument 2 to "f" has incompatible type "int"; expected "Tuple[int, Tuple[str, int]]"
 
 [case testBackquoteExpr]

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -43,7 +43,6 @@ g(B.copy(B()))
 [builtins fixtures/bool.pyi]
 
 [case testSelfTypeReturn]
-# flags: --hide-error-context
 from typing import TypeVar, Type
 
 R = TypeVar('R')
@@ -76,7 +75,6 @@ class C:
 [builtins fixtures/bool.pyi]
 
 [case testSelfTypeClass]
-# flags: --hide-error-context
 from typing import TypeVar, Type
 
 T = TypeVar('T', bound='A')
@@ -131,7 +129,6 @@ reveal_type(cast(A, C()).copy())  # E: Revealed type is '__main__.A*'
 [builtins fixtures/bool.pyi]
 
 [case testSelfTypeSuper]
-# flags: --hide-error-context
 from typing import TypeVar, cast
  
 T = TypeVar('T', bound='A', covariant=True)
@@ -149,7 +146,6 @@ class B(A):
 [builtins fixtures/bool.pyi]
 
 [case testSelfTypeRecursiveBinding]
-# flags: --hide-error-context
 from typing import TypeVar, Callable, Type
  
 T = TypeVar('T', bound='A', covariant=True)
@@ -176,7 +172,6 @@ reveal_type(B.new)  # E: Revealed type is 'def (factory: def (__main__.B*) -> __
 [builtins fixtures/classmethod.pyi]
 
 [case testSelfTypeBound]
-# flags: --hide-error-context
 from typing import TypeVar, Callable, cast
  
 TA = TypeVar('TA', bound='A', covariant=True)
@@ -204,7 +199,6 @@ class B(A):
 
 -- # TODO: fail for this
 -- [case testSelfTypeBare]
--- # flags: --hide-error-context
 -- from typing import TypeVar, Type
 -- 
 -- T = TypeVar('T', bound='E')
@@ -213,7 +207,6 @@ class B(A):
 --     def copy(self: T, other: T) -> T: pass
 
 [case testSelfTypeClone]
-# flags: --hide-error-context
 from typing import TypeVar, Type
 
 T = TypeVar('T', bound='C')
@@ -250,7 +243,6 @@ class B(A):
         super(B, self).__init__()
 
 [case testSelfTypeNonsensical]
-# flags: --hide-error-context
 from typing import TypeVar, Type
 
 T = TypeVar('T', bound=str)
@@ -293,7 +285,6 @@ class D:
 [builtins fixtures/classmethod.pyi]
 
 [case testSelfTypeLambdaDefault]
-# flags: --hide-error-context
 from typing import Callable
 class C:
     @classmethod
@@ -309,7 +300,6 @@ class C:
 [builtins fixtures/classmethod.pyi]
 
 [case testSelfTypeNew]
-# flags: --hide-error-context
 from typing import TypeVar, Type
 
 T = TypeVar('T', bound=A)    

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -13,7 +13,6 @@ class A:
 class B:
     pass
 [out]
-main: note: In function "g":
 main:5: error: Incompatible return value type (got "A", expected "B")
 
 [case testReturnSubtype]
@@ -27,7 +26,6 @@ class A:
 class B(A):
     pass
 [out]
-main: note: In function "f":
 main:3: error: Incompatible return value type (got "A", expected "B")
 
 [case testReturnWithoutAValue]
@@ -39,7 +37,6 @@ def g() -> None:
 class A:
     pass
 [out]
-main: note: In function "f":
 main:3: error: Return value expected
 
 [case testReturnNoneInFunctionReturningNone]
@@ -49,7 +46,6 @@ def f() -> None:
 def g() -> None:
     return f()  # E: No return value expected
 [out]
-main: note: In function "g":
 
 [case testReturnInGenerator]
 from typing import Generator
@@ -64,7 +60,6 @@ def f() -> Generator[int, None, str]:
     yield 1
     return  # E: Return value expected
 [out]
-main: note: In function "f":
 
 [case testEmptyReturnInNoneTypedGenerator]
 from typing import Generator
@@ -79,7 +74,6 @@ def f() -> Generator[int, None, None]:
     yield 1
     return 42  # E: No return value expected
 [out]
-main: note: In function "f":
 
 [case testReturnInIterator]
 from typing import Iterator
@@ -520,7 +514,6 @@ def f() -> None:
 class Err(BaseException): pass
 [builtins fixtures/exception.pyi]
 [out]
-main: note: In function "f":
 main:5: error: Incompatible types in assignment (expression has type "object", variable has type "BaseException")
 main:8: error: Incompatible types in assignment (expression has type "BaseException", variable has type "Err")
 
@@ -534,7 +527,6 @@ def f() -> None:
   x + 'a' # E: Unsupported left operand type for + ("int")
 [builtins fixtures/exception.pyi]
 [out]
-main: note: In function "f":
 
 [case testTryWithElse]
 import typing
@@ -737,7 +729,6 @@ def f(*arg: BaseException) -> int:
 x = f()
 [builtins fixtures/exception.pyi]
 [out]
-main: note: In function "f":
 main:11: error: Revealed type is 'builtins.int'
 main:16: error: Revealed type is 'builtins.str'
 
@@ -761,7 +752,6 @@ def f(*arg: BaseException) -> int:
 x = f()
 [builtins fixtures/exception.pyi]
 [out]
-main: note: In function "f":
 main:10: error: Revealed type is 'builtins.int'
 main:16: error: Revealed type is 'builtins.str'
 
@@ -785,7 +775,6 @@ def f(*arg: BaseException) -> int:
 x = f()
 [builtins fixtures/exception.pyi]
 [out]
-main: note: In function "f":
 main:10: error: Revealed type is 'builtins.int'
 main:15: error: Revealed type is 'builtins.str'
 
@@ -880,9 +869,7 @@ def h(e: Type[int]):
     except e: pass
 [builtins fixtures/exception.pyi]
 [out]
-main: note: In function "g":
 main:9: error: Revealed type is 'builtins.BaseException'
-main: note: In function "h":
 main:12: error: Exception type must be derived from BaseException
 
 
@@ -952,7 +939,6 @@ def f() -> Iterator[int]:
     yield '' # E: Incompatible types in yield (actual type "str", expected type "int")
 [builtins fixtures/for.pyi]
 [out]
-main: note: In function "f":
 
 [case testYieldInFunctionReturningGenerator]
 from typing import Generator
@@ -985,7 +971,6 @@ from typing import Callable
 def f() -> Callable[[], None]: # E: The return type of a generator function should be "Generator" or one of its supertypes
     yield object()
 [out]
-main: note: In function "f":
 
 [case testYieldInDynamicallyTypedFunction]
 import typing
@@ -998,7 +983,6 @@ def f() -> int: # E: The return type of a generator function should be "Generato
     yield 1
 [builtins fixtures/for.pyi]
 [out]
-main: note: In function "f":
 
 [case testTypeInferenceContextAndYield]
 from typing import List, Iterator
@@ -1007,7 +991,6 @@ def f() -> 'Iterator[List[int]]':
     yield [object()] # E: List item 0 has incompatible type "object"
 [builtins fixtures/for.pyi]
 [out]
-main: note: In function "f":
 
 [case testYieldAndReturnWithoutValue]
 from typing import Iterator
@@ -1028,7 +1011,6 @@ def f() -> Iterator[int]:
     yield  # E: Yield value expected
 [builtins fixtures/for.pyi]
 [out]
-main: note: In function "f":
 
 [case testYieldWithExplicitNone]
 from typing import Iterator
@@ -1036,7 +1018,6 @@ def f() -> Iterator[None]:
     yield None  # E: Incompatible types in yield (actual type None, expected type None)
 [builtins fixtures/for.pyi]
 [out]
-main: note: In function "f":
 
 
 -- Yield from statement
@@ -1055,7 +1036,6 @@ def f() -> Iterator[str]:
     yield from g()
     yield from h()  # E: Incompatible types in "yield from" (actual type "int", expected type "str")
 [out]
-main: note: In function "f":
 
 [case testYieldFromAppliedToAny]
 from typing import Any
@@ -1072,7 +1052,6 @@ def g() -> Iterator[int]:
 def f() -> Callable[[], None]:  # E: The return type of a generator function should be "Generator" or one of its supertypes
     yield from g()
 [out]
-main: note: In function "f":
 
 [case testYieldFromNotIterableReturnType]
 from typing import Iterator
@@ -1081,7 +1060,6 @@ def g() -> Iterator[int]:
 def f() -> int:  # E: The return type of a generator function should be "Generator" or one of its supertypes
     yield from g()
 [out]
-main: note: In function "f":
 
 [case testYieldFromNotAppliedIterator]
 from typing import Iterator
@@ -1090,7 +1068,6 @@ def g() -> int:
 def f() -> Iterator[int]:
     yield from g()  # E: "yield from" can't be applied to "int"
 [out]
-main: note: In function "f":
 
 [case testYieldFromCheckIncompatibleTypesTwoIterables]
 from typing import List, Iterator
@@ -1101,13 +1078,11 @@ def f() -> Iterator[List[int]]:
     yield from [1, 2, 3]  # E: Incompatible types in "yield from" (actual type "int", expected type List[int])
 [builtins fixtures/for.pyi]
 [out]
-main: note: In function "f":
 
 [case testYieldFromNotAppliedToNothing]
 def h():
     yield from  # E: Parse error before end of line
 [out]
-main: note: In function "h":
 
 [case testYieldFromAndYieldTogether]
 from typing import Iterator
@@ -1242,7 +1217,6 @@ def f() -> None:
     x = y = 1   # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 [builtins fixtures/primitives.pyi]
 [out]
-main: note: In function "f":
 
 [case testChainedAssignmentWithType]
 
@@ -1316,7 +1290,6 @@ def f() -> None:
 class A(): pass
 class B(): pass
 [out]
-main: note: In function "f":
 main:5: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testTypeOfNonlocalUsed]
@@ -1330,7 +1303,6 @@ def f() -> None:
 class A(): pass
 class B(): pass
 [out]
-main: note: In function "g":
 main:6: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testTypeOfOuterMostNonlocalUsed]
@@ -1347,5 +1319,4 @@ def f() -> None:
 class A(): pass
 class B(): pass
 [out]
-main: note: In function "h":
 main:8: error: Incompatible types in assignment (expression has type "A", variable has type "B")

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -16,7 +16,6 @@ class A(B):
     a = super().g() # E: "g" undefined in superclass
     b = super().f()
 [out]
-main: note: In member "f" of class "A":
 
 [case testAccessingSuperTypeMethodWithArgs]
 from typing import Any
@@ -30,7 +29,6 @@ class A(B):
     self.f(b)
     self.f(a)
 [out]
-main: note: In member "f" of class "A":
 
 [case testAccessingSuperInit]
 import typing
@@ -42,7 +40,6 @@ class A(B):
     super().__init__()       # E: Too few arguments for "__init__" of "B"
     super().__init__(A())
 [out]
-main: note: In member "__init__" of class "A":
 
 [case testAccessingSuperMemberWithDeepHierarchy]
 import typing
@@ -54,7 +51,6 @@ class A(B):
     super().g() # E: "g" undefined in superclass
     super().f()
 [out]
-main: note: In member "f" of class "A":
 
 [case testAssignToBaseClassMethod]
 import typing
@@ -80,7 +76,6 @@ class C(A, B):
         super().g() # E: Too few arguments for "g" of "B"
         super().not_there() # E: "not_there" undefined in superclass
 [out]
-main: note: In member "f" of class "C":
 
 [case testSuperWithNew]
 class A:

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -64,7 +64,6 @@ class B(A):
     def g(self) -> None:
         super().f = None
 [out]
-main: note: In function "g":
 main:6: error: Invalid assignment target
 
 [case testSuperWithMultipleInheritance]

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -84,7 +84,6 @@ class C(A, B):
 main: note: In member "f" of class "C":
 
 [case testSuperWithNew]
-# flags: --hide-error-context
 class A:
     def __new__(cls, x: int) -> 'A':
         return object.__new__(cls)

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -676,7 +676,6 @@ class A(Tuple[int, str]):
 [builtins fixtures/tuple.pyi]
 [out]
 main:1: note: In module imported here:
-tmp/m.pyi: note: In member "f" of class "A":
 tmp/m.pyi:6: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 tmp/m.pyi:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/m.pyi:7: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -675,7 +675,6 @@ class A(Tuple[int, str]):
         self.f('')   # Error
 [builtins fixtures/tuple.pyi]
 [out]
-main:1: note: In module imported here:
 tmp/m.pyi:6: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 tmp/m.pyi:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/m.pyi:7: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -809,7 +809,6 @@ a = (0, *b, '')
 [builtins fixtures/tuple.pyi]
 
 [case testTupleMeetTupleAny]
-# flags: --hide-error-context
 from typing import Union, Tuple
 class A: pass
 class B: pass
@@ -830,7 +829,6 @@ def g(x: Union[str, Tuple[str, str]]) -> None:
 [out]
 
 [case testTupleMeetTUpleAnyComplex]
-# flags: --hide-error-context
 from typing import Tuple, Union
 
 Pair = Tuple[int, int]
@@ -855,7 +853,6 @@ def tuplify2(v: Variant2) -> None:
 [out]
 
 [case testTupleMeetTupleAnyAfter]
-# flags: --hide-error-context
 from typing import Tuple, Union
 
 def good(blah: Union[Tuple[int, int], int]) -> None:

--- a/test-data/unit/check-type-checks.test
+++ b/test-data/unit/check-type-checks.test
@@ -23,7 +23,6 @@ def f(x: object, n: int, s: str) -> None:
     n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 [case testSimpleIsinstance3]
 
@@ -54,7 +53,6 @@ def f(x: object, a: A, b: B, c: int) -> None:
         c = x # E: Incompatible types in assignment (expression has type "A", variable has type "int")
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 [case testMultipleIsinstanceTests2]
 import typing
@@ -72,7 +70,6 @@ def f(x: object, y: object, n: int, s: str) -> None:
         n = x
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 [case testIsinstanceAndElif]
 import typing
@@ -90,7 +87,6 @@ def f(x: object, n: int, s: str) -> None:
     n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 [case testIsinstanceAndAnyType]
 from typing import Any
@@ -102,7 +98,6 @@ def f(x: Any, n: int, s: str) -> None:
     s = x
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 [case testIsinstanceAndGenericType]
 from typing import TypeVar, Generic
@@ -117,4 +112,3 @@ def f(x: object) -> None:
     x.g() # E: "object" has no attribute "g"
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":

--- a/test-data/unit/check-type-checks.test
+++ b/test-data/unit/check-type-checks.test
@@ -38,7 +38,6 @@ class A:
         n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In class "A":
 
 [case testMultipleIsinstanceTests]
 import typing

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -81,7 +81,6 @@ def identity(p: PointA) -> PointB:
 [builtins fixtures/dict.pyi]
 
 [case testCannotConvertTypedDictToSimilarTypedDictWithNarrowerItemTypes]
-# flags: --hide-error-context
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 ObjectPoint = TypedDict('ObjectPoint', {'x': object, 'y': object})
@@ -90,7 +89,6 @@ def convert(op: ObjectPoint) -> Point:
 [builtins fixtures/dict.pyi]
 
 [case testCannotConvertTypedDictToSimilarTypedDictWithWiderItemTypes]
-# flags: --hide-error-context
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 ObjectPoint = TypedDict('ObjectPoint', {'x': object, 'y': object})
@@ -99,7 +97,6 @@ def convert(p: Point) -> ObjectPoint:
 [builtins fixtures/dict.pyi]
 
 [case testCannotConvertTypedDictToSimilarTypedDictWithIncompatibleItemTypes]
-# flags: --hide-error-context
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 Chameleon = TypedDict('Chameleon', {'x': str, 'y': str})
@@ -116,7 +113,6 @@ def narrow(p: Point) -> Point1D:
 [builtins fixtures/dict.pyi]
 
 [case testCannotConvertTypedDictToWiderTypedDict]
-# flags: --hide-error-context
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 Point3D = TypedDict('Point3D', {'x': int, 'y': int, 'z': int})
@@ -133,7 +129,6 @@ def as_mapping(p: Point) -> Mapping[str, int]:
 [builtins fixtures/dict.pyi]
 
 [case testCannotConvertTypedDictToCompatibleMapping]
-# flags: --hide-error-context
 from mypy_extensions import TypedDict
 from typing import Mapping
 Point = TypedDict('Point', {'x': int, 'y': int})
@@ -157,7 +152,6 @@ def as_mapping(p: Point) -> Mapping[str, str]:
 --[builtins fixtures/dict.pyi]
 
 [case testCannotConvertTypedDictToDictOrMutableMapping]
-# flags: --hide-error-context
 from mypy_extensions import TypedDict
 from typing import Dict, MutableMapping
 Point = TypedDict('Point', {'x': int, 'y': int})
@@ -377,7 +371,6 @@ reveal_type(f(g))  # E: Revealed type is '<uninhabited>'
 
 -- TODO: Implement support for this case.
 --[case testCannotGetItemOfTypedDictWithInvalidStringLiteralKey]
---# flags: --hide-error-context
 --from mypy_extensions import TypedDict
 --TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 --p = TaggedPoint(type='2d', x=42, y=1337)
@@ -387,7 +380,6 @@ reveal_type(f(g))  # E: Revealed type is '<uninhabited>'
 
 -- TODO: Implement support for this case.
 --[case testCannotGetItemOfTypedDictWithNonLiteralKey]
---# flags: --hide-error-context
 --from mypy_extensions import TypedDict
 --from typing import Union
 --TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
@@ -410,7 +402,6 @@ reveal_type(f(g))  # E: Revealed type is '<uninhabited>'
 
 -- TODO: Implement support for this case.
 --[case testCannotSetItemOfTypedDictWithInvalidStringLiteralKey]
---# flags: --hide-error-context
 --from mypy_extensions import TypedDict
 --TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 --p = TaggedPoint(type='2d', x=42, y=1337)
@@ -420,7 +411,6 @@ reveal_type(f(g))  # E: Revealed type is '<uninhabited>'
 
 -- TODO: Implement support for this case.
 --[case testCannotSetItemOfTypedDictWithNonLiteralKey]
---# flags: --hide-error-context
 --from mypy_extensions import TypedDict
 --from typing import Union
 --TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -286,7 +286,6 @@ class C(Generic[X]):
         x.g(1) # E: Argument 1 to "g" of "B" has incompatible type "int"; expected "str"
         x.h(1) # E: Argument 1 to "h" of "A" has incompatible type "int"; expected "str"
 [out]
-main: note: In member "f" of class "C":
 
 [case testAttributeInGenericTypeWithTypevarValues1]
 from typing import TypeVar, Generic
@@ -297,7 +296,6 @@ class C(Generic[X]):
         self.x = x
         self.x = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 [out]
-main: note: In member "f" of class "C":
 
 [case testAttributeInGenericTypeWithTypevarValues2]
 from typing import TypeVar, Generic
@@ -331,7 +329,6 @@ class C(Generic[X, Y]):
     def f(self, x: X, y: Y) -> None:
         x.f(y)
 [out]
-main: note: In member "f" of class "C":
 main:10: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
 main:10: error: Argument 1 to "f" of "B" has incompatible type "int"; expected "str"
 

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -423,7 +423,6 @@ class C(A[str]):
     def f(self) -> int: # E: Return type of "f" incompatible with supertype "A"
         pass
 [out]
-main: note: In class "C":
 
 [case testDefaultArgumentValueInGenericClassWithTypevarValues]
 from typing import TypeVar, Generic

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -69,9 +69,7 @@ def f(x: AB) -> AB:
 def g(x: AB) -> AB:
     return x.g() # Error
 [out]
-main: note: In function "f":
 main:10: error: Incompatible return value type (got "A", expected "B")
-main: note: In function "g":
 main:12: error: Incompatible return value type (got "B", expected "A")
 
 [case testTypeInferenceAndTypeVarValues]
@@ -90,7 +88,6 @@ def f(x: AB) -> AB:
     else:
         return y.g() # E: Incompatible return value type (got "B", expected "A")
 [out]
-main: note: In function "f":
 
 [case testTypeDeclaredBasedOnTypeVarWithValues]
 from typing import TypeVar
@@ -103,7 +100,6 @@ def f(x: T) -> T:
     a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
     b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 [out]
-main: note: In function "f":
 
 [case testIsinstanceAndTypeVarValues]
 from typing import TypeVar
@@ -120,7 +116,6 @@ def h(x: T) -> T:
     return x
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "h":
 
 [case testIsinstanceAndTypeVarValues2]
 from typing import TypeVar
@@ -138,7 +133,6 @@ def g(x: T) -> T:
     return x
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "g":
 
 [case testIsinstanceAndTypeVarValues3]
 from typing import TypeVar
@@ -162,7 +156,6 @@ def f(x: T) -> T:
     return y # E: Incompatible return value type (got "object", expected "str")
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 [case testIsinstanceAndTypeVarValues5]
 from typing import TypeVar
@@ -175,7 +168,6 @@ def f(x: T) -> T:
     return y # E: Incompatible return value type (got "object", expected "int")
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 [case testIsinstanceWithUserDefinedTypeAndTypeVarValues]
 from typing import TypeVar
@@ -199,7 +191,6 @@ def g(x: S) -> None:
         x = y
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 [case testIsinstanceWithUserDefinedTypeAndTypeVarValues2]
 from typing import TypeVar
@@ -218,7 +209,6 @@ def f(x: T) -> None:
         x = S() # E: Incompatible types in assignment (expression has type "S", variable has type "int")
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 [case testTypeVarValuesAndNestedCalls]
 from typing import TypeVar
@@ -263,9 +253,7 @@ def g(x: Y) -> None:
 def h(x: Z) -> None:
     a = None  # type: D[Z]
 [out]
-main: note: In function "g":
 main:11: error: Invalid type argument value for "D"
-main: note: In function "h":
 main:13: error: Type variable "Z" not valid as type argument value for "D"
 
 [case testGenericTypeWithTypevarValuesAndSubtypePromotion]
@@ -384,7 +372,6 @@ def f(x: X, y: Y, z: int) -> None:
     z = y # Error
     y.foo # Error
 [out]
-main: note: In function "f":
 main:8: error: Type argument 1 of "C" has incompatible value "X"
 main:9: error: Incompatible types in assignment (expression has type "X", variable has type "int")
 main:10: error: Incompatible types in assignment (expression has type "str", variable has type "int")
@@ -462,7 +449,6 @@ def g(x: int) -> int: return x
 @overload
 def g(x: str) -> str: return x
 [out]
-main: note: In function "f":
 main:7: error: Incompatible types in assignment (expression has type "object", variable has type "int")
 main:7: error: Incompatible types in assignment (expression has type "object", variable has type "str")
 
@@ -496,7 +482,6 @@ def outer(x: T) -> T:
     outer(3)
     return x
 [out]
-main: note: In function "outer":
 
 [case testInnerFunctionMutualRecursionWithTypevarValues]
 from typing import TypeVar
@@ -508,4 +493,3 @@ def outer(x: T) -> T:
         return inner1('a') # E: Argument 1 to "inner1" has incompatible type "str"; expected "int"
     return inner1(x)
 [out]
-main: note: In function "inner2":

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -33,7 +33,6 @@ def f(x: Union[int, str]) -> None:
         z = x # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "f":
 
 [case testUnionAnyIsInstance]
 from typing import Any, Union
@@ -45,7 +44,6 @@ def func(v:Union[int, Any]) -> None:
         reveal_type(v) # E: Revealed type is 'Any'
 [builtins fixtures/isinstance.pyi]
 [out]
-main: note: In function "func":
 
 [case testUnionAttributeAccess]
 from typing import Union

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -370,7 +370,6 @@ def foo() -> None:
     reveal_type(x)  # E: Revealed type is 'builtins.str'
 [builtins fixtures/ops.pyi]
 [out]
-main: note: In function "foo":
 
 [case testSysPlatformInMethod]
 import sys

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -382,7 +382,6 @@ class C:
         reveal_type(x)  # E: Revealed type is 'builtins.str'
 [builtins fixtures/ops.pyi]
 [out]
-main: note: In member "foo" of class "C":
 
 [case testSysPlatformInFunctionImport]
 import sys

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -66,7 +66,6 @@ import typing
 x = 1
 x = 'a'
 [out]
-main:9: note: In module imported here:
 tmp/m.py:3: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testNegatedMypyConditional]

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -19,7 +19,6 @@ class B: pass
 class C: pass
 [builtins fixtures/tuple.pyi]
 [out]
-main: note: In function "f":
 
 
 [case testVarArgsAreTuple]

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -71,7 +71,6 @@ def g() -> int:
         return 1
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "g":
 main:5: note: Missing return statement
 
 [case testNoReturnWhile]
@@ -96,7 +95,6 @@ def j() -> int:
             continue
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "i":
 main:7: note: Missing return statement
 
 [case testNoReturnExcept]
@@ -124,7 +122,6 @@ def h() -> int:
         return 1
 [builtins fixtures/exception.pyi]
 [out]
-main: note: In function "f":
 main:2: note: Missing return statement
 
 [case testNoReturnEmptyBodyWithDocstring]

--- a/test-data/unit/parse-errors.test
+++ b/test-data/unit/parse-errors.test
@@ -13,7 +13,6 @@ def f()
   pass
 [out]
 file:1: error: Parse error before end of line
-file: note: At top level:
 file:2: error: Inconsistent indentation
 
 [case testMissingIndent]

--- a/test-data/unit/parse-errors.test
+++ b/test-data/unit/parse-errors.test
@@ -12,7 +12,6 @@
 def f()
   pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before end of line
 file: note: At top level:
 file:2: error: Inconsistent indentation
@@ -101,56 +100,48 @@ file:1: error: Parse error before "y"
 [case testInvalidBareAsteriskAndVarArgs2]
 def f(*x: A, *) -> None: pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before )
 file:1: error: Parse error before end of line
 
 [case testInvalidBareAsteriskAndVarArgs3]
 def f(*, *x: A) -> None: pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before *
 file:1: error: Parse error before end of line
 
 [case testInvalidBareAsteriskAndVarArgs4]
 def f(*, **x: A) -> None: pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before **
 file:1: error: Parse error before end of line
 
 [case testInvalidBareAsterisk1]
 def f(*) -> None: pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before )
 file:1: error: Parse error before end of line
 
 [case testInvalidBareAsterisk2]
 def f(x, *) -> None: pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before )
 file:1: error: Parse error before end of line
 
 [case testInvalidFuncDefArgs1]
 def f(x = y, x): pass
 [out]
-file: note: In function "f":
 file:1: error: Invalid argument list
 
 [case testInvalidFuncDefArgs3]
 def f(**x, y):
    pass
 [out]
-file: note: In function "f":
 file:1: error: Invalid argument list
 
 [case testInvalidFuncDefArgs4]
 def f(**x, y=x):
     pass
 [out]
-file: note: In function "f":
 file:1: error: Invalid argument list
 
 [case testInvalidStringLiteralType]
@@ -158,7 +149,6 @@ def f(x:
      'A['
      ) -> None: pass
 [out]
-file: note: In function "f":
 file:2: error: Parse error before end of line
 file:3: error: Parse error before end of line
 
@@ -167,7 +157,6 @@ def f(x:
       'A B'
       ) -> None: pass
 [out]
-file: note: In function "f":
 file:2: error: Parse error before "B"
 file:3: error: Parse error before end of line
 
@@ -198,7 +187,6 @@ file:2: error: Parse error before end of line
 [case testInvalidMultilineLiteralType]
 def f() -> "A\nB": pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before end of line
 
 [case testInvalidMetaclass]
@@ -212,70 +200,60 @@ file:1: error: Parse error before end of file
 def f(): # type: x
   pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before "x"
 
 [case testInvalidSignatureInComment2]
 def f(): # type:
   pass
 [out]
-file: note: In function "f":
 file:1: error: Empty type annotation
 
 [case testInvalidSignatureInComment3]
 def f(): # type: (
   pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before end of line
 
 [case testInvalidSignatureInComment4]
 def f(): # type: (.
   pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before .
 
 [case testInvalidSignatureInComment5]
 def f(): # type: (x
   pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before end of line
 
 [case testInvalidSignatureInComment6]
 def f(): # type: (x)
   pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before end of line
 
 [case testInvalidSignatureInComment7]
 def f(): # type: (x) -
   pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before -
 
 [case testInvalidSignatureInComment8]
 def f(): # type: (x) ->
   pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before end of line
 
 [case testInvalidSignatureInComment9]
 def f(): # type: (x) -> .
   pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before .
 
 [case testInvalidSignatureInComment10]
 def f(): # type: (x) -> x x
   pass
 [out]
-file: note: In function "f":
 file:1: error: Parse error before "x"
 
 [case testDuplicateSignatures1]
@@ -284,28 +262,24 @@ def f() -> None: # type: () -> None
 def f(): # type: () -> None
     pass
 [out]
-file: note: In function "f":
 file:1: error: Function has duplicate type signatures
 
 [case testDuplicateSignatures2]
 def f(x, y: Z): # type: (x, y) -> z
   pass
 [out]
-file: note: In function "f":
 file:1: error: Function has duplicate type signatures
 
 [case testTooManyTypes]
 def f(x, y): # type: (X, Y, Z) -> z
   pass
 [out]
-file: note: In function "f":
 file:1: error: Type signature has too many arguments
 
 [case testTooFewTypes]
 def f(x, y): # type: (X) -> z
   pass
 [out]
-file: note: In function "f":
 file:1: error: Type signature has too few arguments
 
 [case testCommentFunctionAnnotationVarArgMispatch]
@@ -314,9 +288,7 @@ def f(x): # type: (*X) -> Y
 def g(*x): # type: (X) -> Y
     pass
 [out]
-file: note: In function "f":
 file:1: error: Inconsistent use of '*' in function signature
-file: note: In function "g":
 file:3: error: Inconsistent use of '*' in function signature
 
 [case testCommentFunctionAnnotationVarArgMispatch2]
@@ -325,10 +297,8 @@ def f(*x, **y): # type: (**X, *Y) -> Z
 def g(*x, **y): # type: (*X, *Y) -> Z
     pass
 [out]
-file: note: In function "f":
 file:1: error: Inconsistent use of '*' in function signature
 file:1: error: Inconsistent use of '**' in function signature
-file: note: In function "g":
 file:3: error: Inconsistent use of '*' in function signature
 file:3: error: Inconsistent use of '**' in function signature
 
@@ -356,14 +326,12 @@ file:1: error: Parse error before "for"
 def f():
     yield from
 [out]
-file: note: In function "f":
 file:2: error: Parse error before end of line
 
 [case testYieldFromAfterReturn]
 def f():
     return yield from h()
 [out]
-file: note: In function "f":
 file:2: error: Parse error before "yield"
 
 [case testImportDotModule]
@@ -509,7 +477,6 @@ file:1: error: Parse error before ,
 [case testTupleArgListInPython3]
 def f(x, (y, z)): pass
 [out]
-file: note: In function "f":
 file:1: error: Tuples in argument lists only supported in Python 2 mode
 
 [case testBackquoteInPython3]

--- a/test-data/unit/parse-errors.test
+++ b/test-data/unit/parse-errors.test
@@ -60,7 +60,6 @@ file:1: error: Parse error before **
 class A(C[):
   pass
 [out]
-file: note: In class "A":
 file:1: error: Parse error before )
 file:2: error: Parse error before end of file
 
@@ -68,7 +67,6 @@ file:2: error: Parse error before end of file
 class A(:
   pass
 [out]
-file: note: In class "A":
 file:1: error: Parse error before :
 file:2: error: Parse error before end of file
 
@@ -192,7 +190,6 @@ file:1: error: Parse error before end of line
 [case testInvalidMetaclass]
 class A(metaclass=1): pass
 [out]
-file: note: In class "A":
 file:1: error: Parse error before numeric literal
 file:1: error: Parse error before end of file
 

--- a/test-data/unit/parse-python2.test
+++ b/test-data/unit/parse-python2.test
@@ -333,32 +333,27 @@ MypyFile:1(
 [case testInvalidExprInTupleArgListInPython2_1]
 def f(x, ()): pass
 [out]
-main: note: In function "f":
 main: error: Empty tuple not valid as an argument
 
 [case testInvalidExprInTupleArgListInPython2_2]
 def f(x, (y, x[1])): pass
 [out]
-main: note: In function "f":
 main:1: error: Invalid item in tuple argument
 
 [case testListLiteralAsTupleArgInPython2]
 def f(x, [x]): pass
 [out]
-main: note: In function "f":
 main:1: error: Parse error before [
 main:1: error: Parse error before end of line
 
 [case testTupleArgAfterStarArgInPython2]
 def f(*a, (b, c)): pass
 [out]
-main: note: In function "f":
 main:1: error: Invalid argument list
 
 [case testTupleArgAfterStarStarArgInPython2]
 def f(*a, (b, c)): pass
 [out]
-main: note: In function "f":
 main:1: error: Invalid argument list
 
 [case testParenthesizedArgumentInPython2]
@@ -379,9 +374,7 @@ def f(a, (a, b)):
 def g((x, (x, y))):
     pass
 [out]
-main: note: In function "f":
 main:1: error: Duplicate argument name "a"
-main: note: In function "g":
 main:3: error: Duplicate argument name "x"
 
 [case testBackquotesInPython2]

--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -468,5 +468,4 @@ re.subn(upat, lambda m: u'', u'')[0] + u''
 def g() -> int:
     yield
 [out]
-_program.py: note: In function "g":
 _program.py:2: error: The return type of a generator function should be "Generator" or one of its supertypes

--- a/test-data/unit/pythoneval-asyncio.test
+++ b/test-data/unit/pythoneval-asyncio.test
@@ -277,7 +277,6 @@ try:
 finally:
     loop.close()
 [out]
-_program.py: note: In function "test":
 _program.py:13: error: Function does not return a value
 
 [case testErrorReturnIsNotTheSameType]
@@ -301,7 +300,6 @@ loop.run_until_complete(print_sum(1, 2))
 loop.close()
 
 [out]
-_program.py: note: In function "compute":
 _program.py:9: error: Incompatible return value type (got "str", expected "int")
 
 [case testErrorSetFutureDifferentInternalType]
@@ -321,7 +319,6 @@ loop.run_until_complete(future)
 print(future.result())
 loop.close()
 [out]
-_program.py: note: In function "slow_operation":
 _program.py:8: error: Argument 1 to "set_result" of "Future" has incompatible type "int"; expected "str"
 
 
@@ -361,7 +358,6 @@ loop.run_until_complete(future)
 print(future.result())
 loop.close()
 [out]
-_program.py: note: In function "slow_operation":
 _program.py:8: error: Argument 1 to "set_result" of "Future" has incompatible type "str"; expected "int"
 _program.py: note: At top level:
 _program.py:12: error: Argument 1 to "slow_operation" has incompatible type Future[str]; expected Future[int]
@@ -427,7 +423,6 @@ loop = asyncio.get_event_loop()
 loop.run_until_complete(h())
 loop.close()
 [out]
-_program.py: note: In function "h3":
 _program.py:18: error: Incompatible return value type (got Future[Future[int]], expected Future[Future[Future[int]]])
 
 [case testErrorOneLessFutureInReturnType]
@@ -462,7 +457,6 @@ loop = asyncio.get_event_loop()
 loop.run_until_complete(h())
 loop.close()
 [out]
-_program.py: note: In function "h3":
 _program.py:18: error: Incompatible return value type (got Future[Future[int]], expected Future[int])
 
 [case testErrorAssignmentDifferentType]
@@ -490,5 +484,4 @@ future.set_result(A(42))
 loop.run_until_complete(h())
 loop.close()
 [out]
-_program.py: note: In function "h":
 _program.py:16: error: Incompatible types in assignment (expression has type "A", variable has type "B")

--- a/test-data/unit/pythoneval-asyncio.test
+++ b/test-data/unit/pythoneval-asyncio.test
@@ -359,7 +359,6 @@ print(future.result())
 loop.close()
 [out]
 _program.py:8: error: Argument 1 to "set_result" of "Future" has incompatible type "str"; expected "int"
-_program.py: note: At top level:
 _program.py:12: error: Argument 1 to "slow_operation" has incompatible type Future[str]; expected Future[int]
 
 [case testErrorSettingCallbackWithDifferentFutureType]

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -533,7 +533,6 @@ b = None  # type: B
 b = C()
 print(A() + b)
 [out]
-_program.py: note: In member "__radd__" of class "B":
 _program.py:9: error: Signatures of "__radd__" of "B" and "__add__" of "A" are unsafely overlapping
 
 [case testBytesAndBytearrayComparisons]
@@ -1111,7 +1110,6 @@ class A:
         super().__setattr__('a', 1)
         super().__setattr__(1, 'a')
 [out]
-_program.py: note: In member "__init__" of class "A":
 _program.py:4: error: Argument 1 to "__setattr__" of "object" has incompatible type "int"; expected "str"
 
 [case testMetaclassAndSuper]

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -389,7 +389,6 @@ def bin(f: IO[bytes]) -> None:
 txt(sys.stdout)
 bin(sys.stdout)
 [out]
-_program.py: note: In function "txt":
 _program.py:5: error: Argument 1 to "write" of "IO" has incompatible type "bytes"; expected "str"
 _program.py: note: At top level:
 _program.py:10: error: Argument 1 to "bin" has incompatible type "TextIO"; expected IO[bytes]
@@ -431,7 +430,6 @@ S = TypeVar('S', int, str)
 def f(t: T, s: S) -> None:
     t + s
 [out]
-_program.py: note: In function "f":
 _program.py:7: error: Unsupported operand types for + ("int" and "str")
 _program.py:7: error: Unsupported operand types for + ("str" and "int")
 
@@ -751,7 +749,6 @@ print('>', list(b))
 import typing
 def f(x: _T) -> None: pass
 [out]
-_program.py: note: In function "f":
 _program.py:2: error: Name '_T' is not defined
 
 [case testVarArgsFunctionSubtyping]
@@ -915,7 +912,6 @@ def f(x: A) -> None:
     x(1)
     x('')
 [out]
-_program.py: note: In function "f":
 _program.py:5: error: Argument 1 has incompatible type "str"; expected "int"
 
 [case testSuperNew]
@@ -971,7 +967,6 @@ def f(*x: int) -> None:
     x.append(1)
 f(1)
 [out]
-_program.py: note: In function "f":
 _program.py:3: error: Tuple[int, ...] has no attribute "append"
 
 [case testExit]
@@ -1045,7 +1040,6 @@ def p(t: Tuple[str, ...]) -> None:
 ''.startswith(('x', 'y'))
 ''.startswith(('x', b'y'))
 [out]
-_program.py: note: In function "p":
 _program.py:6: error: "str" not callable
 _program.py: note: At top level:
 _program.py:8: error: Argument 1 to "startswith" of "str" has incompatible type "Tuple[str, bytes]"; expected "Union[str, Tuple[str, ...]]"

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -390,7 +390,6 @@ txt(sys.stdout)
 bin(sys.stdout)
 [out]
 _program.py:5: error: Argument 1 to "write" of "IO" has incompatible type "bytes"; expected "str"
-_program.py: note: At top level:
 _program.py:10: error: Argument 1 to "bin" has incompatible type "TextIO"; expected IO[bytes]
 
 [case testBuiltinOpen]
@@ -1041,7 +1040,6 @@ def p(t: Tuple[str, ...]) -> None:
 ''.startswith(('x', b'y'))
 [out]
 _program.py:6: error: "str" not callable
-_program.py: note: At top level:
 _program.py:8: error: Argument 1 to "startswith" of "str" has incompatible type "Tuple[str, bytes]"; expected "Union[str, Tuple[str, ...]]"
 
 [case testMultiplyTupleByInteger]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -333,7 +333,6 @@ import k
 import typing
 x = y
 [out]
-main:1: note: ... from here:
 tmp/k.py:2: error: Name 'y' is not defined
 
 [case testPackageWithoutInitFile]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -21,7 +21,6 @@ def f() -> None:
 y
 [out]
 main:3: error: Name 'x' is not defined
-main: note: At top level:
 main:4: error: Name 'y' is not defined
 
 [case testMethodScope]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -244,7 +244,6 @@ import m
 [file m/__init__.py]
 from .x import y
 [out]
-main:2: note: In module imported here:
 tmp/m/__init__.py:1: error: Cannot find module named 'm.x'
 tmp/m/__init__.py:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 
@@ -255,7 +254,6 @@ import m.a
 [file m/a.py]
 from .x import y
 [out]
-main:2: note: In module imported here:
 tmp/m/a.py:1: error: Cannot find module named 'm.x'
 tmp/m/a.py:1: note: (Perhaps setting MYPYPATH or using the "--silent-imports" flag would help)
 
@@ -324,7 +322,6 @@ import m
 import typing
 x = y
 [out]
-main:1: note: In module imported here:
 tmp/m.py:2: error: Name 'y' is not defined
 
 [case testErrorInImportedModule2]
@@ -336,7 +333,6 @@ import k
 import typing
 x = y
 [out]
-tmp/m/n.py:1: note: In module imported here,
 main:1: note: ... from here:
 tmp/k.py:2: error: Name 'y' is not defined
 

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -4,7 +4,6 @@ def f():
   1 1
 [out]
 main:1: error: Parse error before in
-main: note: In function "f":
 main:3: error: Parse error before numeric literal
 
 [case testUndefinedVariableInGlobalStatement]
@@ -21,7 +20,6 @@ def f() -> None:
   x
 y
 [out]
-main: note: In function "f":
 main:3: error: Name 'x' is not defined
 main: note: At top level:
 main:4: error: Name 'y' is not defined
@@ -43,7 +41,6 @@ class B:
     f # error
     g # error
 [out]
-main: note: In function "g":
 main:6: error: Name 'f' is not defined
 main:7: error: Name 'g' is not defined
 
@@ -87,14 +84,12 @@ class B:
             x = None  # type: A[int] \
                 # E: "A" expects no type arguments, but 1 given
 [out]
-main: note: In function "f":
 
 [case testInvalidNumberOfGenericArgsInSignature]
 import typing
 class A: pass
 def f() -> A[int]: pass # E: "A" expects no type arguments, but 1 given
 [out]
-main: note: In function "f":
 
 [case testInvalidNumberOfGenericArgsInOverloadedSignature]
 from typing import overload
@@ -104,7 +99,6 @@ def f(): pass
 @overload
 def f(x: A[int]) -> None: pass # E: "A" expects no type arguments, but 1 given
 [out]
-main: note: In function "f":
 
 [case testInvalidNumberOfGenericArgsInBaseType]
 import typing
@@ -132,7 +126,6 @@ class A(Generic[T]): pass
 class B: pass
 def f() -> A[B[int]]: pass # E: "B" expects no type arguments, but 1 given
 [out]
-main: note: In function "f":
 
 [case testInvalidNumberOfGenericArgsInTupleType]
 from typing import Tuple
@@ -182,7 +175,6 @@ def f() -> None:
   x = 0 # type: A
   x = 0 # type: A
 [out]
-main: note: In function "f":
 main:5: error: Name 'x' already defined
 
 [case testClassVarRedefinition]
@@ -307,9 +299,7 @@ def f() -> m.c: pass
 def g() -> n.c: pass
 [file m.py]
 [out]
-main: note: In function "f":
 main:3: error: Name 'm.c' is not defined
-main: note: In function "g":
 main:4: error: Name 'n' is not defined
 
 [case testMissingPackage]
@@ -368,7 +358,6 @@ def f():
   break
 [out]
 main:1: error: 'break' outside loop
-main: note: In function "f":
 main:3: error: 'break' outside loop
 
 [case testContinueOutsideLoop]
@@ -377,7 +366,6 @@ def f():
   continue
 [out]
 main:1: error: 'continue' outside loop
-main: note: In function "f":
 main:3: error: 'continue' outside loop
 
 [case testReturnOutsideFunction]
@@ -526,7 +514,6 @@ class c(Generic[t]):
     def f(self) -> None: x = t
 def f(y: t): x = t
 [out]
-main: note: In function "f":
 main:4: error: 't' is a type variable and only valid in type context
 main:5: error: 't' is a type variable and only valid in type context
 
@@ -549,7 +536,6 @@ super().x
 def f() -> None: super().y
 [out]
 main:2: error: "super" used outside class
-main: note: In function "f":
 main:3: error: "super" used outside class
 
 [case testMissingSelfInMethod]
@@ -576,7 +562,6 @@ def f() -> None:
     global x
     x = None
 [out]
-main: note: In function "f":
 main:4: error: Name 'x' is not defined
 
 [case testInvalidNonlocalDecl]
@@ -586,7 +571,6 @@ def f():
        nonlocal x
        x = None
 [out]
-main: note: In function "g":
 main:4: error: No binding for nonlocal 'x' found
 main:5: error: Name 'x' is not defined
 
@@ -597,7 +581,6 @@ def f() -> None:
     nonlocal x
     x = None
 [out]
-main: note: In function "f":
 main:4: error: No binding for nonlocal 'x' found
 main:5: error: Name 'x' is not defined
 
@@ -609,7 +592,6 @@ def g():
         nonlocal x
         x = None
 [out]
-main: note: In function "f":
 main:5: error: Name 'x' is already defined in local scope before nonlocal declaration
 
 [case testNonlocalDeclOutsideFunction]
@@ -628,7 +610,6 @@ def f():
        nonlocal x
        x = None
 [out]
-main: note: In function "g":
 main:7: error: Name 'x' is nonlocal and global
 
 [case testNonlocalAndGlobalDecl]
@@ -641,7 +622,6 @@ def f():
        global x
        x = None
 [out]
-main: note: In function "g":
 main:7: error: Name 'x' is nonlocal and global
 
 [case testNestedFunctionAndScoping]
@@ -653,7 +633,6 @@ def f(x) -> None:
     y
     x
 [out]
-main: note: In function "f":
 main:5: error: Name 'z' is not defined
 main:6: error: Name 'y' is not defined
 
@@ -664,7 +643,6 @@ def f(x) -> None:
     x = 1
     def g(): pass
 [out]
-main: note: In function "f":
 main:5: error: Name 'g' already defined
 
 [case testRedefinedOverloadedFunction]
@@ -677,7 +655,6 @@ def f() -> None:
     x = 1
     def p(): pass # fail
 [out]
-main: note: In function "f":
 main:8: error: Name 'p' already defined
 
 [case testNestedFunctionInMethod]
@@ -688,9 +665,7 @@ class A:
            x
        y
 [out]
-main: note: In function "g":
 main:5: error: Name 'x' is not defined
-main: note: In function "f":
 main:6: error: Name 'y' is not defined
 
 [case testImportScope]
@@ -838,7 +813,6 @@ Any(arg=str)   # E: 'Any' must be called with 1 positional argument
 def f(x:[int, str]) -> None: # E: Invalid type
     pass
 [out]
-main: note: In function "f":
 
 [case testInvalidFunctionType]
 from typing import Callable
@@ -865,7 +839,6 @@ def g() -> None:
   @abstractmethod
   def foo(): pass
 [out]
-main: note: In function "g":
 main:4: error: 'abstractmethod' used with a non-method
 
 [case testInvalidTypeDeclaration]
@@ -893,7 +866,6 @@ class A:
   def f(self, x) -> None:
     x.y = 1 # type: int
 [out]
-main: note: In function "f":
 main:4: error: Type cannot be declared in assignment to non-self attribute
 
 [case testInvalidTypeInTypeApplication]
@@ -1034,7 +1006,6 @@ def f() -> None:
     T = TypeVar('T')
 def g(x: T) -> None: pass # E: Name 'T' is not defined
 [out]
-main: note: In function "g":
 
 [case testClassTypevarScope]
 from typing import TypeVar
@@ -1042,7 +1013,6 @@ class A:
     T = TypeVar('T')
 def g(x: T) -> None: pass # E: Name 'T' is not defined
 [out]
-main: note: In function "g":
 
 [case testRedefineVariableAsTypevar]
 from typing import TypeVar
@@ -1082,12 +1052,10 @@ from typing import Generic as t # E: Name 't' already defined
 [case testInvalidStrLiteralType]
 def f(x: 'foo'): pass # E: Name 'foo' is not defined
 [out]
-main: note: In function "f":
 
 [case testInvalidStrLiteralType2]
 def f(x: 'int['): pass # E: Parse error before end of line
 [out]
-main: note: In function "f":
 
 [case testInconsistentOverload]
 from typing import overload
@@ -1123,9 +1091,7 @@ def f(): # type: (int) -> int
 def g(x): # type: () -> int
   pass
 [out]
-main: note: In function "f":
 main:2: error: Type signature has too many arguments
-main: note: In function "g":
 main:4: error: Type signature has too few arguments
 
 [case testStaticmethodAndNonMethod]
@@ -1139,7 +1105,6 @@ class A:
 [builtins fixtures/staticmethod.pyi]
 [out]
 main:2: error: 'staticmethod' used with a non-method
-main: note: In function "g":
 main:6: error: 'staticmethod' used with a non-method
 
 [case testClassmethodAndNonMethod]
@@ -1153,7 +1118,6 @@ class A:
 [builtins fixtures/classmethod.pyi]
 [out]
 main:2: error: 'classmethod' used with a non-method
-main: note: In function "g":
 main:6: error: 'classmethod' used with a non-method
 
 [case testNonMethodProperty]
@@ -1219,7 +1183,6 @@ def f() -> None:
 y = 1
 [file y.py]
 [out]
-main: note: In function "f":
 
 [case testImportTwoModulesWithSameNameInGlobalContext]
 import typing
@@ -1236,7 +1199,6 @@ import typing
 def f() -> List[int]: pass
 [builtins fixtures/list.pyi]
 [out]
-main: note: In function "f":
 main:2: error: Name 'List' is not defined
 
 [case testImportObsoleteTypingFunction]
@@ -1252,10 +1214,8 @@ def f(x: typing.Function[[], None]) -> None: pass
 def g(x: _m.Function[[], None]) -> None: pass
 [file _m.py]
 [out]
-main: note: In function "f":
 main:3: error: Name 'typing.Function' is not defined (it's now called 'typing.Callable')
 --'
-main: note: In function "g":
 main:4: error: Name '_m.Function' is not defined
 
 [case testUnqualifiedNameRefersToObsoleteTypingFunction]
@@ -1294,7 +1254,6 @@ import typing
 def f() -> None:
     1[2] = 1  # type: int
 [out]
-main: note: In function "f":
 main:3: error: Unexpected type declaration
 
 [case testInvalidTypeAnnotation2]
@@ -1302,7 +1261,6 @@ import typing
 def f() -> None:
     f() = 1  # type: int
 [out]
-main: note: In function "f":
 main:3: error: Invalid assignment target
 
 [case testInvalidReferenceToAttributeOfOuterClass]

--- a/test-data/unit/semanal-modules.test
+++ b/test-data/unit/semanal-modules.test
@@ -771,7 +771,6 @@ import m.x
 [file m/x.py]
 from .x import nonexistent
 [out]
-main:1: note: In module imported here:
 tmp/m/x.py:1: error: Module 'm.x' has no attribute 'nonexistent'
 
 [case testImportFromSameModule]
@@ -780,7 +779,6 @@ import m.x
 [file m/x.py]
 from m.x import nonexistent
 [out]
-main:1: note: In module imported here:
 tmp/m/x.py:1: error: Module 'm.x' has no attribute 'nonexistent'
 
 [case testFromImportAsInStub]
@@ -847,7 +845,6 @@ x
 [file m.py]
 y
 [out]
-main:1: note: In module imported here:
 tmp/m.py:1: error: Name 'y' is not defined
 main:2: error: Name 'x' is not defined
 

--- a/test-data/unit/semanal-statements.test
+++ b/test-data/unit/semanal-statements.test
@@ -537,7 +537,6 @@ MypyFile:1(
 def f(x, y) -> None:
     del x, y + 1
 [out]
-main: note: In function "f":
 main:2: error: Invalid delete target
 
 [case testTry]

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -1457,7 +1457,6 @@ MypyFile:1(
 [case testTupleExpressionAsType]
 def f(x: (int, int)) -> None: pass
 [out]
-main: note: In function "f":
 main:1: error: Invalid tuple literal type
 
 [case tesQualifiedTypeNameBasedOnAny]


### PR DESCRIPTION
This diff provides a flag called `--show-error-context` in place of `--hide-error-context` and flips the default.

This also removes all context lines from tests so they do not need to be special cased. Here's why:
- It's much easier to write tests when not having to worry about error context, so this is nicer going forward.
- It avoids adding any more special casing to tests.
- This won't results in any `git blame` problems because the transformation is purely subtractive.
- This shouldn't be particularly difficult to review, because the transformations are split into separate commits.