### PR TITLE
Track whether or not a Var's type is inferred

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1433,6 +1433,7 @@ class TypeChecker(NodeVisitor[Type]):
         """
         if var and not self.current_node_deferred:
             var.type = type
+            var.is_inferred = True
             self.store_type(lvalue, type)
 
     def set_inference_error_fallback_type(self, var: Var, lvalue: Lvalue, type: Type,

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -627,6 +627,7 @@ class Var(SymbolNode):
     is_self = False
     is_ready = False  # If inferred, is the inferred type available?
     # Is this initialized explicitly to a non-None value in class body?
+    is_inferred = False
     is_initialized_in_class = False
     is_staticmethod = False
     is_classmethod = False
@@ -644,6 +645,8 @@ class Var(SymbolNode):
     def __init__(self, name: str, type: 'mypy.types.Type' = None) -> None:
         self._name = name
         self.type = type
+        if self.type is None:
+            self.is_inferred = True
         self.is_self = False
         self.is_ready = True
         self.is_initialized_in_class = False


### PR DESCRIPTION
Simple PR that does as it says, and opens the way for a few, more sophisticated error messages (inspired by #2529)