### PR TITLE
Set Var node line/column to the line/col where they were initially defined

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1267,6 +1267,7 @@ class SemanticAnalyzer(NodeVisitor):
             if (add_global or nested_global) and lval.name not in self.globals:
                 # Define new global name.
                 v = Var(lval.name)
+                v.set_line(lval)
                 v._fullname = self.qualified_name(lval.name)
                 v.is_ready = False  # Type not inferred yet
                 lval.node = v
@@ -1284,6 +1285,7 @@ class SemanticAnalyzer(NodeVisitor):
                   lval.name not in self.nonlocal_decls[-1]):
                 # Define new local name.
                 v = Var(lval.name)
+                v.set_line(lval)
                 lval.node = v
                 lval.is_def = True
                 lval.kind = LDEF
@@ -1355,6 +1357,7 @@ class SemanticAnalyzer(NodeVisitor):
             # Implicit attribute definition in __init__.
             lval.is_def = True
             v = Var(lval.name)
+            v.set_line(lval)
             v.info = self.type
             v.is_ready = False
             lval.def_var = v

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -416,14 +416,14 @@ import typing
 __all__ = [1, 2, 3]
 [builtins fixtures/module_all.pyi]
 [out]
-main: error: Type of __all__ must be Sequence[str], not List[int]
+main:2: error: Type of __all__ must be Sequence[str], not List[int]
 
 [case testAllMustBeSequenceStr_python2]
 import typing
 __all__ = [1, 2, 3]
 [builtins_py2 fixtures/module_all_python2.pyi]
 [out]
-main: error: Type of __all__ must be Sequence[unicode], not List[int]
+main:2: error: Type of __all__ must be Sequence[unicode], not List[int]
 
 [case testAllUnicodeSequenceOK_python2]
 import typing


### PR DESCRIPTION
Var nodes carry around a line and column value that is usually left initalised. Actually setting them allows giving more context to error messages (ala #2529, the motivation for this PR).