### PR TITLE
Bring back --hide-error-context flag

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -222,6 +222,9 @@ def process_options(args: List[str],
     # which will make the cache writing process output pretty-printed JSON (which
     # is easier to debug).
     parser.add_argument('--debug-cache', action='store_true', help=argparse.SUPPRESS)
+    parser.add_argument('--hide-error-context', action='store_true',
+                        dest='hide_error_context',
+                        help=argparse.SUPPRESS)
     # deprecated options
     parser.add_argument('-f', '--dirty-stubs', action='store_true',
                         dest='special-opts:dirty_stubs',

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -73,6 +73,9 @@ class Options:
         # Apply strict None checking
         self.strict_optional = False
 
+        # Hide "note: In function "foo":" messages.
+        self.hide_error_context = True
+
         # Files in which to allow strict-Optional related errors
         # TODO: Kill this in favor of show_none_errors
         self.strict_optional_whitelist = None   # type: Optional[List[str]]
@@ -111,7 +114,6 @@ class Options:
         self.incremental = False
         self.cache_dir = defaults.CACHE_DIR
         self.debug_cache = False
-        self.hide_error_context = True  # Hide "note: In function "foo":" messages.
         self.shadow_file = None  # type: Optional[Tuple[str, str]]
         self.show_column_numbers = False  # type: bool
 


### PR DESCRIPTION
Also moves `hide_error_context` out of the experimental section in `options.py`.

Fixes #2545.