### PR TITLE
Runtime implementation of TypedDict extension

### DIFF
--- a/extensions/__init__.py
+++ b/extensions/__init__.py
@@ -1,1 +1,0 @@
-# This page intentionally left blank.

--- a/extensions/__init__.py
+++ b/extensions/__init__.py
@@ -1,1 +1,1 @@
-# This page intentioanlly left blank.
+# This page intentionally left blank.

--- a/extensions/__init__.py
+++ b/extensions/__init__.py
@@ -1,0 +1,1 @@
+# This page intentioanlly left blank.

--- a/extensions/mypy_extensions.py
+++ b/extensions/mypy_extensions.py
@@ -8,15 +8,65 @@ Example usage:
 # NOTE: This module must support Python 2.7 in addition to Python 3.x
 
 
-def TypedDict(typename, fields):
-    """TypedDict creates a dictionary type that expects all of its
+import sys
+from typing import _type_check  # type: ignore
+
+
+def _check_fails(cls, other):
+    if sys._getframe(1).f_globals['__name__'] not in ['abc', 'functools']:
+        raise TypeError('TypedDict does not support instance and class checks')
+
+class _TypedDictMeta(type):
+    def __new__(cls, name, bases, ns):
+        tp_dict = super(_TypedDictMeta, cls).__new__(cls, name, (dict,), ns)
+        try:
+            tp_dict.__module__ = sys._getframe(2).f_globals.get('__name__', '__main__')
+        except (AttributeError, ValueError):
+            pass
+        anns = ns.get('__annotations__', {})
+        msg = "TypedDict('Name', {f0: t0, f1: t1, ...}); each t must be a type"
+        anns = {n: _type_check(tp, msg) for n, tp in anns.items()}
+        for base in bases:
+            anns.update(base.__dict__.get('__annotations__', {}))
+        tp_dict.__annotations__ = anns
+        return tp_dict
+
+    __instancecheck__ = __subclasscheck__ = _check_fails
+
+
+class _TypedDict(object):
+    """A simple typed name space. At runtime it is equivalent to a plain dict.
+
+    TypedDict creates a dictionary type that expects all of its
     instances to have a certain set of keys, with each key
     associated with a value of a consistent type. This expectation
     is not checked at runtime but is only enforced by typecheckers.
-    """
-    def new_dict(*args, **kwargs):
-        return dict(*args, **kwargs)
+    Usage::
 
-    new_dict.__name__ = typename
-    new_dict.__supertype__ = dict
-    return new_dict
+        Point2D = TypedDict('Point2D', {'x': int, 'y': int, 'label': str})
+        a: Point2D = {'x': 1, 'y': 2, 'label': 'good'}  # OK
+        b: Point2D = {'z': 3, 'label': 'bad'}           # Fails type check
+        assert Point2D(x=1, y=2, label='first') == dict(x=1, y=2, label='first')
+
+    The type info could be accessed via Point2D.__annotations__. TypedDict
+    supports two additional equivalent forms::
+
+        Point2D = TypedDict('Point2D', x=int, y=int, label=str)
+
+        class Point2D(TypedDict):
+            x: int
+            y: int
+            label: str
+
+    The latter syntax is only supported in Python 3.6+
+    """
+    def __new__(cls, _typename, fields=None, **kwargs):
+        if fields is None:
+            fields = kwargs
+        elif kwargs:
+            raise TypeError("Either list of fields or keywords"
+                            " can be provided to TypedDict, not both")
+        return cls.__class__(_typename, (), {'__annotations__': dict(fields)})
+
+
+TypedDict = _TypedDictMeta('TypedDict', _TypedDict.__bases__, dict(_TypedDict.__dict__))

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1870,8 +1870,9 @@ class SemanticAnalyzer(NodeVisitor):
             return
         # Yes, it's a valid TypedDict definition. Add it to the symbol table.
         node = self.lookup(name, s)
-        node.kind = GDEF   # TODO locally defined TypedDict
-        node.node = typed_dict
+        if node:
+            node.kind = GDEF   # TODO locally defined TypedDict
+            node.node = typed_dict
 
     def check_typeddict(self, node: Expression, var_name: str = None) -> Optional[TypeInfo]:
         """Check if a call defines a TypedDict.

--- a/mypy/test/testextensions.py
+++ b/mypy/test/testextensions.py
@@ -110,6 +110,9 @@ class TypedDictTests(BaseTestCase):
             jane2 = pickle.loads(z)
             self.assertEqual(jane2, jane)
             self.assertEqual(jane2, {'name': 'jane', 'id': 37})
+            ZZ = pickle.dumps(EmpD, proto)
+            EmpDnew = pickle.loads(ZZ)
+            self.assertEqual(EmpDnew({'name': 'jane', 'id': 37}), jane)
 
 
 if __name__ == '__main__':

--- a/mypy/test/testextensions.py
+++ b/mypy/test/testextensions.py
@@ -98,5 +98,6 @@ class TypedDictTests(BaseTestCase):
             self.assertEqual(jane2, jane)
             self.assertEqual(jane2, {'name': 'jane', 'id': 37})
 
+
 if __name__ == '__main__':
     main()

--- a/mypy/test/testextensions.py
+++ b/mypy/test/testextensions.py
@@ -1,6 +1,11 @@
 import sys
 import pickle
-from unittest import TestCase, main, skipUnless, SkipTest
+import typing
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc  # type: ignore # PY32 and earlier
+from unittest import TestCase, main, skipUnless
 from extensions.mypy_extensions import TypedDict
 
 
@@ -42,8 +47,10 @@ class TypedDictTests(BaseTestCase):
     def test_basics_iterable_syntax(self):
         Emp = TypedDict('Emp', {'name': str, 'id': int})
         self.assertIsSubclass(Emp, dict)
+        self.assertIsSubclass(Emp, typing.MutableMapping)
+        self.assertNotIsSubclass(Emp, collections_abc.Sequence)
         jim = Emp(name='Jim', id=1)
-        self.assertIsInstance(jim, dict)
+        self.assertIs(type(jim), dict)
         self.assertEqual(jim['name'], 'Jim')
         self.assertEqual(jim['id'], 1)
         self.assertEqual(Emp.__name__, 'Emp')
@@ -54,8 +61,10 @@ class TypedDictTests(BaseTestCase):
     def test_basics_keywords_syntax(self):
         Emp = TypedDict('Emp', name=str, id=int)
         self.assertIsSubclass(Emp, dict)
+        self.assertIsSubclass(Emp, typing.MutableMapping)
+        self.assertNotIsSubclass(Emp, collections_abc.Sequence)
         jim = Emp(name='Jim', id=1)
-        self.assertIsInstance(jim, dict)
+        self.assertIs(type(jim), dict)
         self.assertEqual(jim['name'], 'Jim')
         self.assertEqual(jim['id'], 1)
         self.assertEqual(Emp.__name__, 'Emp')
@@ -84,6 +93,7 @@ class TypedDictTests(BaseTestCase):
     def test_class_syntax_usage(self):
         self.assertEqual(LabelPoint2D.__annotations__, {'x': int, 'y': int, 'label': str})  # noqa
         self.assertEqual(LabelPoint2D.__bases__, (dict,))  # noqa
+        self.assertNotIsSubclass(LabelPoint2D, typing.Sequence)  # noqa
         not_origin = Point2D(x=0, y=1)  # noqa
         self.assertEqual(not_origin['x'], 0)
         self.assertEqual(not_origin['y'], 1)

--- a/mypy/test/testextensions.py
+++ b/mypy/test/testextensions.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     import collections as collections_abc  # type: ignore # PY32 and earlier
 from unittest import TestCase, main, skipUnless
+sys.path[0:0] = ['extensions']
 from mypy_extensions import TypedDict
 
 
@@ -63,7 +64,7 @@ class TypedDictTests(BaseTestCase):
         self.assertIsSubclass(Emp, dict)
         self.assertIsSubclass(Emp, typing.MutableMapping)
         self.assertNotIsSubclass(Emp, collections_abc.Sequence)
-        jim = Emp(name='Jim', id=1)
+        jim = Emp(name='Jim', id=1)  # type: ignore # mypy doesn't support keyword syntax yet
         self.assertIs(type(jim), dict)
         self.assertEqual(jim['name'], 'Jim')
         self.assertEqual(jim['id'], 1)
@@ -74,7 +75,7 @@ class TypedDictTests(BaseTestCase):
 
     def test_typeddict_errors(self):
         Emp = TypedDict('Emp', {'name': str, 'id': int})
-        self.assertEqual(TypedDict.__module__, 'extensions.mypy_extensions')
+        self.assertEqual(TypedDict.__module__, 'mypy_extensions')
         jim = Emp(name='Jim', id=1)
         with self.assertRaises(TypeError):
             isinstance({}, Emp)

--- a/mypy/test/testextensions.py
+++ b/mypy/test/testextensions.py
@@ -40,16 +40,14 @@ if PY36:
 class TypedDictTests(BaseTestCase):
 
     def test_basics_iterable_syntax(self):
-        # Check that two iterables allowed
-        Emp = TypedDict('Emp', [('name', str), ('id', int)])
         Emp = TypedDict('Emp', {'name': str, 'id': int})
         self.assertIsSubclass(Emp, dict)
         jim = Emp(name='Jim', id=1)
-        self.assertIsInstance(jim, Emp)
         self.assertIsInstance(jim, dict)
         self.assertEqual(jim['name'], 'Jim')
         self.assertEqual(jim['id'], 1)
         self.assertEqual(Emp.__name__, 'Emp')
+        self.assertEqual(Emp.__module__, 'mypy.test.testextensions')
         self.assertEqual(Emp.__bases__, (dict,))
         self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
 
@@ -57,18 +55,22 @@ class TypedDictTests(BaseTestCase):
         Emp = TypedDict('Emp', name=str, id=int)
         self.assertIsSubclass(Emp, dict)
         jim = Emp(name='Jim', id=1)
-        self.assertIsInstance(jim, Emp)
         self.assertIsInstance(jim, dict)
         self.assertEqual(jim['name'], 'Jim')
         self.assertEqual(jim['id'], 1)
         self.assertEqual(Emp.__name__, 'Emp')
+        self.assertEqual(Emp.__module__, 'mypy.test.testextensions')
         self.assertEqual(Emp.__bases__, (dict,))
         self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
 
     def test_typeddict_errors(self):
         Emp = TypedDict('Emp', {'name': str, 'id': int})
+        self.assertEqual(TypedDict.__module__, 'extensions.mypy_extensions')
+        jim = Emp(name='Jim', id=1)
         with self.assertRaises(TypeError):
             isinstance({}, Emp)
+        with self.assertRaises(TypeError):
+            isinstance(jim, Emp)
         with self.assertRaises(TypeError):
             issubclass(dict, Emp)
         with self.assertRaises(TypeError):

--- a/mypy/test/testextensions.py
+++ b/mypy/test/testextensions.py
@@ -1,0 +1,102 @@
+import sys
+import pickle
+from unittest import TestCase, main, skipUnless, SkipTest
+from extensions.mypy_extensions import TypedDict
+
+
+class BaseTestCase(TestCase):
+
+    def assertIsSubclass(self, cls, class_or_tuple, msg=None):
+        if not issubclass(cls, class_or_tuple):
+            message = '%r is not a subclass of %r' % (cls, class_or_tuple)
+            if msg is not None:
+                message += ' : %s' % msg
+            raise self.failureException(message)
+
+    def assertNotIsSubclass(self, cls, class_or_tuple, msg=None):
+        if issubclass(cls, class_or_tuple):
+            message = '%r is a subclass of %r' % (cls, class_or_tuple)
+            if msg is not None:
+                message += ' : %s' % msg
+            raise self.failureException(message)
+
+
+PY36 = sys.version_info[:2] >= (3, 6)
+
+PY36_TESTS = """
+Label = TypedDict('Label', [('label', str)])
+
+class Point2D(TypedDict):
+    x: int
+    y: int
+
+class LabelPoint2D(Point2D, Label): ...
+"""
+
+if PY36:
+    exec(PY36_TESTS)
+
+
+class TypedDictTests(BaseTestCase):
+
+    def test_basics_iterable_syntax(self):
+        # Check that two iterables allowed
+        Emp = TypedDict('Emp', [('name', str), ('id', int)])
+        Emp = TypedDict('Emp', {'name': str, 'id': int})
+        self.assertIsSubclass(Emp, dict)
+        jim = Emp(name='Jim', id=1)
+        self.assertIsInstance(jim, Emp)
+        self.assertIsInstance(jim, dict)
+        self.assertEqual(jim['name'], 'Jim')
+        self.assertEqual(jim['id'], 1)
+        self.assertEqual(Emp.__name__, 'Emp')
+        self.assertEqual(Emp.__bases__, (dict,))
+        self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
+
+    def test_basics_keywords_syntax(self):
+        Emp = TypedDict('Emp', name=str, id=int)
+        self.assertIsSubclass(Emp, dict)
+        jim = Emp(name='Jim', id=1)
+        self.assertIsInstance(jim, Emp)
+        self.assertIsInstance(jim, dict)
+        self.assertEqual(jim['name'], 'Jim')
+        self.assertEqual(jim['id'], 1)
+        self.assertEqual(Emp.__name__, 'Emp')
+        self.assertEqual(Emp.__bases__, (dict,))
+        self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
+
+    def test_typeddict_errors(self):
+        Emp = TypedDict('Emp', {'name': str, 'id': int})
+        with self.assertRaises(TypeError):
+            isinstance({}, Emp)
+        with self.assertRaises(TypeError):
+            issubclass(dict, Emp)
+        with self.assertRaises(TypeError):
+            TypedDict('Hi', x=1)
+        with self.assertRaises(TypeError):
+            TypedDict('Hi', [('x', int), ('y', 1)])
+        with self.assertRaises(TypeError):
+            TypedDict('Hi', [('x', int)], y=int)
+
+    @skipUnless(PY36, 'Python 3.6 required')
+    def test_class_syntax_usage(self):
+        self.assertEqual(LabelPoint2D.__annotations__, {'x': int, 'y': int, 'label': str})  # noqa
+        self.assertEqual(LabelPoint2D.__bases__, (dict,))  # noqa
+        not_origin = Point2D(x=0, y=1)  # noqa
+        self.assertEqual(not_origin['x'], 0)
+        self.assertEqual(not_origin['y'], 1)
+        other = LabelPoint2D(x=0, y=1, label='hi')  # noqa
+        self.assertEqual(other['label'], 'hi')
+
+    def test_pickle(self):
+        global EmpD  # pickle wants to reference the class by name
+        EmpD = TypedDict('EmpD', name=str, id=int)
+        jane = EmpD({'name': 'jane', 'id': 37})
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            z = pickle.dumps(jane, proto)
+            jane2 = pickle.loads(z)
+            self.assertEqual(jane2, jane)
+            self.assertEqual(jane2, {'name': 'jane', 'id': 37})
+
+if __name__ == '__main__':
+    main()

--- a/mypy/test/testextensions.py
+++ b/mypy/test/testextensions.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     import collections as collections_abc  # type: ignore # PY32 and earlier
 from unittest import TestCase, main, skipUnless
-from extensions.mypy_extensions import TypedDict
+from mypy_extensions import TypedDict
 
 
 class BaseTestCase(TestCase):
@@ -90,7 +90,7 @@ class TypedDictTests(BaseTestCase):
             TypedDict('Hi', [('x', int)], y=int)
 
     @skipUnless(PY36, 'Python 3.6 required')
-    def test_class_syntax_usage(self):
+    def test_py36_class_syntax_usage(self):
         self.assertEqual(LabelPoint2D.__annotations__, {'x': int, 'y': int, 'label': str})  # noqa
         self.assertEqual(LabelPoint2D.__bases__, (dict,))  # noqa
         self.assertNotIsSubclass(LabelPoint2D, typing.Sequence)  # noqa

--- a/runtests.py
+++ b/runtests.py
@@ -207,7 +207,7 @@ def add_imports(driver: Driver) -> None:
 
 
 PYTEST_FILES = ['mypy/test/{}.py'.format(name) for name in [
-    'testcheck',
+    'testcheck', 'testextensions',
 ]]
 
 


### PR DESCRIPTION
Here is the runtime implementation of ``TypedDict`` initially proposed in https://github.com/python/typing/pull/322, @davidfstr please take a look. You told you are interested only in keyword syntax, but here I add all three forms. I think it will be easy to add support for other forms in mypy (as it happened for ``NamedTuple``), I could do this later in a separate PR. The implementation is tested on both Python 2 and 3 but I didn't find how to add Python2 runtime tests in mypy.

I copy the description from original ``typing`` PR:

-------------------------------------------------------
Here is a simple (but quite flexible) implementation that supports three forms (iterable, keywords, class for 3.6+). In all forms type info for runtime introspection is accessible via ``__annotations__``, multiple inheritance is supported. Some examples:
```python
class Point1D(TypedDict):
    x: float
class Point2D(Point1D):
    y: float

Grid2D = TypedDict('Grid2D', [('x', int), ('y', int)])
Grid3D = TypedDict('Grid3D', {'x': int, 'y': int, 'z': int})
Info = TypedDict('Info', color=str, size=int)

class CoolPoint2D(Point2D, Info):
    pass

assert Point2D(x=1, y=2) == dict(x=1, y=2)
assert CoolPoint2D.__bases__ == (dict,)
assert CoolPoint2D.__annotations__ == {'x': float, 'y': float, 'size': int, 'color': str}
```
Everything is implemented to be pickleable and fast. I have measured and ``Point2D(x=1, y=2)`` is slower that ``dict(x=1, y=2)`` by only 3% to 11% depending on Python version.