### PR TITLE
Get rid of MDEF and LDEF [WIP]

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2284,9 +2284,8 @@ class TypeChecker(NodeVisitor[Type]):
                 or not self.dynamic_funcs
                 or not self.dynamic_funcs[-1])
 
-    def lookup(self, name: str, kind: int) -> SymbolTableNode:
+    def lookup(self, name: str) -> SymbolTableNode:
         """Look up a definition from the symbol table with the given name.
-        TODO remove kind argument
         """
         if name in self.globals:
             return self.globals[name]
@@ -2300,7 +2299,7 @@ class TypeChecker(NodeVisitor[Type]):
 
     def lookup_qualified(self, name: str) -> SymbolTableNode:
         if '.' not in name:
-            return self.lookup(name, GDEF)  # FIX kind
+            return self.lookup(name)
         else:
             parts = name.split('.')
             n = self.modules[parts[0]]

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -5,8 +5,7 @@ from typing import Any, Dict, Optional
 from mypy.nodes import (
     MypyFile, SymbolNode, SymbolTable, SymbolTableNode,
     TypeInfo, FuncDef, OverloadedFuncDef, Decorator, Var,
-    TypeVarExpr, ClassDef,
-    LDEF, MDEF, GDEF
+    TypeVarExpr, ClassDef, GDEF,
 )
 from mypy.types import (
     CallableType, EllipsisType, Instance, Overloaded, TupleType, TypedDictType,
@@ -27,7 +26,7 @@ def fixup_module_pass_two(tree: MypyFile, modules: Dict[str, MypyFile]) -> None:
 
 def compute_all_mros(symtab: SymbolTable, modules: Dict[str, MypyFile]) -> None:
     for key, value in symtab.items():
-        if value.kind in (LDEF, MDEF, GDEF) and isinstance(value.node, TypeInfo):
+        if value.kind == GDEF and isinstance(value.node, TypeInfo):
             info = value.node
             info.calculate_mro()
             assert info.mro, "No MRO calculated for %s" % (info.fullname(),)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -62,9 +62,7 @@ LITERAL_NO = 0
 ENUM_BASECLASS = "enum.Enum"
 
 node_kinds = {
-    LDEF: 'Ldef',
     GDEF: 'Gdef',
-    MDEF: 'Mdef',
     MODULE_REF: 'ModuleRef',
     UNBOUND_TVAR: 'UnboundTvar',
     BOUND_TVAR: 'Tvar',
@@ -1132,7 +1130,7 @@ class StarExpr(Expression):
 class RefExpr(Expression):
     """Abstract base class for name-like constructs"""
 
-    kind = None  # type: int      # LDEF/GDEF/MDEF/... (None if not available)
+    kind = None  # type: int      # GDEF, MODULE_REF etc. (None if not available)
     node = None  # type: SymbolNode  # Var, FuncDef or TypeInfo that describes this
     fullname = None  # type: str  # Fully qualified name (or name if not global)
 
@@ -2078,9 +2076,7 @@ class TypeInfo(SymbolNode):
 
 class SymbolTableNode:
     # Kind of node. Possible values:
-    #  - LDEF: local definition (of any kind)
     #  - GDEF: global (module-level) definition
-    #  - MDEF: class member definition
     #  - UNBOUND_TVAR: TypeVar(...) definition, not bound
     #  - TVAR: type variable in a bound scope (generic function / generic clas)
     #  - MODULE_REF: reference to a module

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -36,9 +36,7 @@ JsonDict = Dict[str, Any]
 #
 # TODO rename to use more descriptive names
 
-LDEF = 0  # type: int
 GDEF = 1  # type: int
-MDEF = 2  # type: int
 MODULE_REF = 3  # type: int
 # Type variable declared using TypeVar(...) has kind UNBOUND_TVAR. It's not
 # valid as a type. A type variable is valid as a type (kind BOUND_TVAR) within

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2886,7 +2886,7 @@ class FirstPass(NodeVisitor):
             self.sem.check_no_global(func.name(), func, True)
         func._fullname = self.sem.qualified_name(func.name())
         if kind == GDEF:
-            self.sem.globals[func.name()] = SymbolTableNode(kind, func, self.sem.cur_mod_id)
+            self.sem.globals[func.name()] = SymbolTableNode(GDEF, func, self.sem.cur_mod_id)
 
     def visit_class_def(self, cdef: ClassDef) -> None:
         kind = self.kind_by_scope()
@@ -2899,7 +2899,7 @@ class FirstPass(NodeVisitor):
         info.set_line(cdef.line, cdef.column)
         cdef.info = info
         if kind == GDEF:
-            self.sem.globals[cdef.name] = SymbolTableNode(kind, info, self.sem.cur_mod_id)
+            self.sem.globals[cdef.name] = SymbolTableNode(GDEF, info, self.sem.cur_mod_id)
         self.process_nested_classes(cdef)
 
     def process_nested_classes(self, outer_def: ClassDef) -> None:
@@ -2970,7 +2970,7 @@ class FirstPass(NodeVisitor):
 
     def visit_decorator(self, d: Decorator) -> None:
         d.var._fullname = self.sem.qualified_name(d.var.name())
-        self.sem.add_symbol(d.var.name(), SymbolTableNode(self.kind_by_scope(), d.var), d)
+        self.sem.add_symbol(d.var.name(), SymbolTableNode(GDEF, d.var), d)
 
     def visit_if_stmt(self, s: IfStmt) -> None:
         infer_reachability_of_if_statement(s, pyversion=self.pyversion, platform=self.platform)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -738,7 +738,7 @@ class SemanticAnalyzer(NodeVisitor):
                 if base_expr.fullname == 'typing.NamedTuple':
                     node = self.lookup(defn.name, defn)
                     if node is not None:
-                        node.kind = GDEF  # TODO in process_namedtuple_definition also applies here
+                        node.kind = GDEF
                         items, types = self.check_namedtuple_classdef(defn)
                         node.node = self.build_namedtuple_typeinfo(defn.name, items, types)
                         return True
@@ -786,10 +786,7 @@ class SemanticAnalyzer(NodeVisitor):
             defn.info = TypeInfo(SymbolTable(), defn, self.cur_mod_id)
             defn.info._fullname = defn.info.name()
         if self.is_func_scope() or self.type:
-            kind = GDEF
-            if self.is_func_scope():
-                kind = GDEF
-            self.add_symbol(defn.name, SymbolTableNode(kind, defn.info), defn)
+            self.add_symbol(defn.name, SymbolTableNode(GDEF, defn.info), defn)
 
     def analyze_base_classes(self, defn: ClassDef) -> None:
         """Analyze and set up base classes.
@@ -1037,7 +1034,7 @@ class SemanticAnalyzer(NodeVisitor):
                                           imported_id: str, existing_symbol: SymbolTableNode,
                                           module_symbol: SymbolTableNode,
                                           import_node: ImportBase) -> bool:
-        if (existing_symbol.kind in (GDEF, GDEF, GDEF) and
+        if (existing_symbol.kind == GDEF and
                 isinstance(existing_symbol.node, (Var, FuncDef, TypeInfo))):
             # This is a valid import over an existing definition in the file. Construct a dummy
             # assignment that we'll use to type check the import.
@@ -1430,7 +1427,6 @@ class SemanticAnalyzer(NodeVisitor):
         if node is None:
             self.fail("Could not find {} in current namespace".format(name), s)
             return
-        # TODO: why does NewType work in local scopes despite always being of kind GDEF?
         node.kind = GDEF
         call.analyzed.info = node.node = newtype_class_info
 
@@ -1651,7 +1647,7 @@ class SemanticAnalyzer(NodeVisitor):
             return
         # Yes, it's a valid namedtuple definition. Add it to the symbol table.
         node = self.lookup(name, s)
-        node.kind = GDEF   # TODO locally defined namedtuple
+        node.kind = GDEF
         node.node = named_tuple
 
     def check_namedtuple(self, node: Expression, var_name: str = None) -> Optional[TypeInfo]:
@@ -1870,7 +1866,7 @@ class SemanticAnalyzer(NodeVisitor):
             return
         # Yes, it's a valid TypedDict definition. Add it to the symbol table.
         node = self.lookup(name, s)
-        node.kind = GDEF   # TODO locally defined TypedDict
+        node.kind = GDEF
         node.node = typed_dict
 
     def check_typeddict(self, node: Expression, var_name: str = None) -> Optional[TypeInfo]:

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -322,12 +322,6 @@ class StrConv(NodeVisitor[str]):
                                        fullname is not None):
             # Append fully qualified name for global references.
             n += ' [{}]'.format(fullname)
-        elif kind == mypy.nodes.LDEF:
-            # Add tag to signify a local reference.
-            n += ' [l]'
-        elif kind == mypy.nodes.MDEF:
-            # Add tag to signify a member reference.
-            n += ' [m]'
         return n
 
     def visit_member_expr(self, o: 'mypy.nodes.MemberExpr') -> str:

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -318,9 +318,8 @@ class StrConv(NodeVisitor[str]):
         n = name
         if is_def:
             n += '*'
-        if kind == mypy.nodes.GDEF or (fullname != name and
-                                       fullname is not None):
-            # Append fully qualified name for global references.
+        if fullname is not None and fullname != name:
+            # Append fully qualified name if non-trivially different.
             n += ' [{}]'.format(fullname)
         return n
 

--- a/test-data/unit/semanal-abstractclasses.test
+++ b/test-data/unit/semanal-abstractclasses.test
@@ -34,7 +34,7 @@ MypyFile:1(
         Abstract
         Block:8(
           ReturnStmt:8(
-            NameExpr(self [l])))))))
+            NameExpr(self)))))))
 
 [case testClassInheritingTwoAbstractClasses]
 from abc import abstractmethod, ABCMeta

--- a/test-data/unit/semanal-basic.test
+++ b/test-data/unit/semanal-basic.test
@@ -81,8 +81,8 @@ MypyFile:1(
     Block:1(
       ExpressionStmt:2(
         TupleExpr:2(
-          NameExpr(x [l])
-          NameExpr(y [l]))))))
+          NameExpr(x)
+          NameExpr(y))))))
 
 [case testLocalVar]
 def f():
@@ -94,10 +94,10 @@ MypyFile:1(
     f
     Block:1(
       AssignmentStmt:2(
-        NameExpr(x* [l])
+        NameExpr(x*)
         IntExpr(1))
       ExpressionStmt:3(
-        NameExpr(x [l])))))
+        NameExpr(x)))))
 
 [case testAccessGlobalInFn]
 def f():
@@ -145,13 +145,13 @@ MypyFile:1(
       Var(y))
     Block:3(
       AssignmentStmt:4(
-        NameExpr(y [l])
+        NameExpr(y)
         IntExpr(1))
       AssignmentStmt:5(
-        NameExpr(z* [l])
+        NameExpr(z*)
         IntExpr(1))
       AssignmentStmt:6(
-        NameExpr(z [l])
+        NameExpr(z)
         IntExpr(2)))))
 
 [case testLocalAndGlobalAliasing]
@@ -169,10 +169,10 @@ MypyFile:1(
     f
     Block:2(
       AssignmentStmt:3(
-        NameExpr(x* [l])
+        NameExpr(x*)
         IntExpr(2))
       ExpressionStmt:4(
-        NameExpr(x [l]))))
+        NameExpr(x))))
   ExpressionStmt:5(
     NameExpr(x [__main__.x])))
 
@@ -188,16 +188,16 @@ MypyFile:1(
       Var(y))
     Init(
       AssignmentStmt:1(
-        NameExpr(x [l])
+        NameExpr(x)
         NameExpr(f [__main__.f]))
       AssignmentStmt:1(
-        NameExpr(y [l])
+        NameExpr(y)
         NameExpr(object [builtins.object])))
     Block:1(
       ExpressionStmt:2(
         TupleExpr:2(
-          NameExpr(x [l])
-          NameExpr(y [l]))))))
+          NameExpr(x)
+          NameExpr(y))))))
 
 [case testVarArgs]
 def f(x, *y):
@@ -213,8 +213,8 @@ MypyFile:1(
     Block:1(
       ExpressionStmt:2(
         TupleExpr:2(
-          NameExpr(x [l])
-          NameExpr(y [l]))))))
+          NameExpr(x)
+          NameExpr(y))))))
 
 [case testGlobalDecl]
 x = None
@@ -286,7 +286,7 @@ MypyFile:1(
     g
     Block:4(
       AssignmentStmt:5(
-        NameExpr(x* [l])
+        NameExpr(x*)
         NameExpr(None [builtins.None])))))
 
 [case testGlobalDeclScope]
@@ -309,7 +309,7 @@ MypyFile:1(
     g
     Block:4(
       AssignmentStmt:5(
-        NameExpr(x* [l])
+        NameExpr(x*)
         NameExpr(None [builtins.None])))))
 
 [case testGlobaWithinMethod]
@@ -334,7 +334,7 @@ MypyFile:1(
           x)
         AssignmentStmt:5(
           NameExpr(x [__main__.x])
-          NameExpr(self [l]))))))
+          NameExpr(self))))))
 
 [case testGlobalDefinedInBlock]
 if object:
@@ -371,7 +371,7 @@ MypyFile:1(
     g
     Block:1(
       AssignmentStmt:2(
-        NameExpr(x* [l])
+        NameExpr(x*)
         NameExpr(None [builtins.None]))
       FuncDef:3(
         f
@@ -379,10 +379,10 @@ MypyFile:1(
           NonlocalDecl:4(
             x)
           AssignmentStmt:5(
-            NameExpr(x [l])
+            NameExpr(x)
             NameExpr(None [builtins.None]))
           ExpressionStmt:6(
-            NameExpr(x [l])))))))
+            NameExpr(x)))))))
 
 [case testMultipleNamesInNonlocalDecl]
 def g():
@@ -397,8 +397,8 @@ MypyFile:1(
     Block:1(
       AssignmentStmt:2(
         TupleExpr:2(
-          NameExpr(x* [l])
-          NameExpr(y* [l]))
+          NameExpr(x*)
+          NameExpr(y*))
         TupleExpr:2(
           NameExpr(None [builtins.None])
           NameExpr(None [builtins.None])))
@@ -411,8 +411,8 @@ MypyFile:1(
             x
             y)
           AssignmentStmt:5(
-            NameExpr(x [l])
-            NameExpr(y [l])))))))
+            NameExpr(x)
+            NameExpr(y)))))))
 
 [case testNestedFunctions]
 def f(x):
@@ -432,13 +432,13 @@ MypyFile:1(
           Var(y))
         Block:2(
           AssignmentStmt:3(
-            NameExpr(z* [l])
+            NameExpr(z*)
             OpExpr:3(
               +
-              NameExpr(y [l])
-              NameExpr(x [l])))))
+              NameExpr(y)
+              NameExpr(x)))))
       ReturnStmt:4(
-        NameExpr(g [l])))))
+        NameExpr(g)))))
 
 [case testNestedFunctionWithOverlappingName]
 def f(x):
@@ -455,5 +455,5 @@ MypyFile:1(
         g
         Block:2(
           AssignmentStmt:3(
-            NameExpr(x* [l])
+            NameExpr(x*)
             IntExpr(1)))))))

--- a/test-data/unit/semanal-classes.test
+++ b/test-data/unit/semanal-classes.test
@@ -29,16 +29,16 @@ MypyFile:1(
         Var(x))
       Block:2(
         AssignmentStmt:3(
-          NameExpr(y* [l])
-          NameExpr(x [l]))))
+          NameExpr(y*)
+          NameExpr(x))))
     FuncDef:4(
       f
       Args(
         Var(self))
       Block:4(
         AssignmentStmt:5(
-          NameExpr(y* [l])
-          NameExpr(self [l]))))))
+          NameExpr(y*)
+          NameExpr(self))))))
 
 [case testMemberDefinitionInInit]
 class A:
@@ -56,12 +56,12 @@ MypyFile:1(
       Block:2(
         AssignmentStmt:3(
           MemberExpr:3(
-            NameExpr(self [l])
+            NameExpr(self)
             x*)
           IntExpr(1))
         AssignmentStmt:4(
           MemberExpr:4(
-            NameExpr(self [l])
+            NameExpr(self)
             y*)
           IntExpr(2))))))
 
@@ -82,7 +82,7 @@ MypyFile:1(
       Block:2(
         AssignmentStmt:3(
           MemberExpr:3(
-            NameExpr(self [l])
+            NameExpr(self)
             x*)
           IntExpr(1)))))
   FuncDef:4(
@@ -92,7 +92,7 @@ MypyFile:1(
     Block:4(
       AssignmentStmt:5(
         MemberExpr:5(
-          NameExpr(self [l])
+          NameExpr(self)
           y)
         IntExpr(1)))))
 
@@ -116,7 +116,7 @@ MypyFile:1(
       Block:2(
         AssignmentStmt:3(
           MemberExpr:3(
-            NameExpr(self [l])
+            NameExpr(self)
             y)
           IntExpr(1)))))
   ClassDef:4(
@@ -127,11 +127,11 @@ MypyFile:1(
         Var(x))
       Block:5(
         AssignmentStmt:6(
-          NameExpr(self* [l])
-          NameExpr(x [l]))
+          NameExpr(self*)
+          NameExpr(x))
         AssignmentStmt:7(
           MemberExpr:7(
-            NameExpr(self [l])
+            NameExpr(self)
             z)
           IntExpr(1))))))
 
@@ -150,7 +150,7 @@ MypyFile:1(
       Block:2(
         AssignmentStmt:3(
           MemberExpr:3(
-            NameExpr(x [l])
+            NameExpr(x)
             y*)
           IntExpr(1))))))
 
@@ -170,12 +170,12 @@ MypyFile:1(
       Block:2(
         AssignmentStmt:3(
           MemberExpr:3(
-            NameExpr(self [l])
+            NameExpr(self)
             x*)
           IntExpr(1))
         AssignmentStmt:4(
           MemberExpr:4(
-            NameExpr(self [l])
+            NameExpr(self)
             x)
           IntExpr(2))))))
 
@@ -204,7 +204,7 @@ MypyFile:1(
           def (self: __main__.A)
           Block:4(
             ExpressionStmt:4(
-              NameExpr(self [l])))))
+              NameExpr(self)))))
       Decorator:5(
         Var(f)
         NameExpr(overload [typing.overload])
@@ -216,7 +216,7 @@ MypyFile:1(
           def (self: __main__.A, x: __main__.A)
           Block:6(
             ExpressionStmt:6(
-              NameExpr(self [l]))))))))
+              NameExpr(self))))))))
 
 [case testAttributeWithoutType]
 class A:
@@ -226,7 +226,7 @@ MypyFile:1(
   ClassDef:1(
     A
     AssignmentStmt:2(
-      NameExpr(a* [m])
+      NameExpr(a*)
       NameExpr(object [builtins.object]))))
 
 [case testDataAttributeRefInClassBody]
@@ -238,11 +238,11 @@ MypyFile:1(
   ClassDef:1(
     A
     AssignmentStmt:2(
-      NameExpr(x* [m])
+      NameExpr(x*)
       IntExpr(1))
     AssignmentStmt:3(
-      NameExpr(y* [m])
-      NameExpr(x [m]))))
+      NameExpr(y*)
+      NameExpr(x))))
 
 [case testMethodRefInClassBody]
 class A:
@@ -259,8 +259,8 @@ MypyFile:1(
       Block:2(
         PassStmt:2()))
     AssignmentStmt:3(
-      NameExpr(g* [m])
-      NameExpr(f [m]))))
+      NameExpr(g*)
+      NameExpr(f))))
 
 [case testIfStatementInClassBody]
 class A:
@@ -277,11 +277,11 @@ MypyFile:1(
         NameExpr(A [__main__.A]))
       Then(
         AssignmentStmt:3(
-          NameExpr(x* [m])
+          NameExpr(x*)
           IntExpr(1)))
       Else(
         AssignmentStmt:5(
-          NameExpr(x [m])
+          NameExpr(x)
           IntExpr(2))))))
 
 [case testForStatementInClassBody]
@@ -293,14 +293,14 @@ MypyFile:1(
   ClassDef:1(
     A
     ForStmt:2(
-      NameExpr(x* [m])
+      NameExpr(x*)
       ListExpr:2(
         IntExpr(1)
         IntExpr(2))
       Block:2(
         AssignmentStmt:3(
-          NameExpr(y* [m])
-          NameExpr(x [m]))))))
+          NameExpr(y*)
+          NameExpr(x))))))
 
 [case testReferenceToClassWithinFunction]
 def f():
@@ -315,7 +315,7 @@ MypyFile:1(
         A
         PassStmt:2())
       ExpressionStmt:3(
-        NameExpr(A [l])))))
+        NameExpr(A)))))
 
 [case testReferenceToClassWithinClass]
 class A:
@@ -362,7 +362,7 @@ MypyFile:1(
         A
         PassStmt:2())
       AssignmentStmt:3(
-        NameExpr(x [l])
+        NameExpr(x)
         NameExpr(None [builtins.None])
         A))))
 
@@ -382,16 +382,16 @@ MypyFile:1(
       ClassDef:2(
         A
         AssignmentStmt:3(
-          NameExpr(y* [m])
-          NameExpr(x [l]))
+          NameExpr(y*)
+          NameExpr(x))
         FuncDef:4(
           g
           Args(
             Var(self))
           Block:4(
             AssignmentStmt:5(
-              NameExpr(z* [l])
-              NameExpr(x [l]))))))))
+              NameExpr(z*)
+              NameExpr(x))))))))
 
 [case testQualifiedMetaclass]
 import abc
@@ -529,7 +529,7 @@ MypyFile:1(
   ClassDef:2(
     A
     AssignmentStmt:3(
-      NameExpr(X* [m])
+      NameExpr(X*)
       IntExpr(1))
     FuncDef:4(
       f
@@ -539,8 +539,8 @@ MypyFile:1(
       def (self: __main__.A, x: builtins.int =)
       Init(
         AssignmentStmt:4(
-          NameExpr(x [l])
-          NameExpr(X [m])))
+          NameExpr(x)
+          NameExpr(X)))
       Block:4(
         PassStmt:4()))))
 

--- a/test-data/unit/semanal-expressions.test
+++ b/test-data/unit/semanal-expressions.test
@@ -194,9 +194,9 @@ MypyFile:1(
       GeneratorExpr:2(
         OpExpr:2(
           +
-          NameExpr(x [l])
+          NameExpr(x)
           IntExpr(1))
-        NameExpr(x* [l])
+        NameExpr(x*)
         NameExpr(a [__main__.a])))))
 
 [case testListComprehensionInFunction]
@@ -213,9 +213,9 @@ MypyFile:1(
       ExpressionStmt:2(
         ListComprehension:2(
           GeneratorExpr:2(
-            NameExpr(x [l])
-            NameExpr(x* [l])
-            NameExpr(a [l])))))))
+            NameExpr(x)
+            NameExpr(x*)
+            NameExpr(a)))))))
 
 [case testListComprehensionWithCondition]
 a = 0
@@ -229,10 +229,10 @@ MypyFile:1(
     NameExpr(a [__main__.a])
     ListComprehension:2(
       GeneratorExpr:2(
-        NameExpr(x [l])
-        NameExpr(x* [l])
+        NameExpr(x)
+        NameExpr(x*)
         NameExpr(a [__main__.a])
-        NameExpr(x [l])))))
+        NameExpr(x)))))
 
 [case testSetComprehension]
 a = 0
@@ -247,9 +247,9 @@ MypyFile:1(
       GeneratorExpr:2(
         OpExpr:2(
           +
-          NameExpr(x [l])
+          NameExpr(x)
           IntExpr(1))
-        NameExpr(x* [l])
+        NameExpr(x*)
         NameExpr(a [__main__.a])))))
 
 [case testSetComprehensionWithCondition]
@@ -264,10 +264,10 @@ MypyFile:1(
     NameExpr(a [__main__.a])
     SetComprehension:2(
       GeneratorExpr:2(
-        NameExpr(x [l])
-        NameExpr(x* [l])
+        NameExpr(x)
+        NameExpr(x*)
         NameExpr(a [__main__.a])
-        NameExpr(x [l])))))
+        NameExpr(x)))))
 
 [case testDictionaryComprehension]
 a = 0
@@ -279,12 +279,12 @@ MypyFile:1(
     IntExpr(0))
   ExpressionStmt:2(
     DictionaryComprehension:2(
-      NameExpr(x [l])
+      NameExpr(x)
       OpExpr:2(
         +
-        NameExpr(x [l])
+        NameExpr(x)
         IntExpr(1))
-      NameExpr(x* [l])
+      NameExpr(x*)
       NameExpr(a [__main__.a]))))
 
 [case testDictionaryComprehensionWithCondition]
@@ -298,14 +298,14 @@ MypyFile:1(
   AssignmentStmt:2(
     NameExpr(a [__main__.a])
     DictionaryComprehension:2(
-      NameExpr(x [l])
+      NameExpr(x)
       OpExpr:2(
         +
-        NameExpr(x [l])
+        NameExpr(x)
         IntExpr(1))
-      NameExpr(x* [l])
+      NameExpr(x*)
       NameExpr(a [__main__.a])
-      NameExpr(x [l]))))
+      NameExpr(x))))
 
 [case testGeneratorExpression]
 a = 0
@@ -317,8 +317,8 @@ MypyFile:1(
     IntExpr(0))
   ExpressionStmt:2(
     GeneratorExpr:2(
-      NameExpr(x [l])
-      NameExpr(x* [l])
+      NameExpr(x)
+      NameExpr(x*)
       NameExpr(a [__main__.a]))))
 
 [case testGeneratorExpressionNestedIndex]
@@ -331,12 +331,12 @@ MypyFile:1(
     IntExpr(0))
   ExpressionStmt:2(
     GeneratorExpr:2(
-      NameExpr(x [l])
+      NameExpr(x)
       TupleExpr:2(
-        NameExpr(x* [l])
+        NameExpr(x*)
         TupleExpr:2(
-          NameExpr(y* [l])
-          NameExpr(z* [l])))
+          NameExpr(y*)
+          NameExpr(z*)))
       NameExpr(a [__main__.a]))))
 
 [case testLambda]
@@ -366,8 +366,8 @@ MypyFile:1(
         ReturnStmt:1(
           OpExpr:1(
             +
-            NameExpr(x [l])
-            NameExpr(y [l])))))))
+            NameExpr(x)
+            NameExpr(y)))))))
 
 [case testConditionalExpression]
 int if None else str

--- a/test-data/unit/semanal-modules.test
+++ b/test-data/unit/semanal-modules.test
@@ -567,7 +567,7 @@ MypyFile:1(
     A
     ImportFrom:2(_x, [y])
     AssignmentStmt:3(
-      NameExpr(z* [m])
+      NameExpr(z*)
       NameExpr(y [_x.y]))))
 
 [case testImportInClassBody2]
@@ -582,7 +582,7 @@ MypyFile:1(
     A
     Import:2(_x)
     AssignmentStmt:3(
-      NameExpr(z* [m])
+      NameExpr(z*)
       MemberExpr:3(
         NameExpr(_x)
         y [_x.y]))))

--- a/test-data/unit/semanal-python2.test
+++ b/test-data/unit/semanal-python2.test
@@ -60,12 +60,12 @@ MypyFile:1(
     Block:1(
       AssignmentStmt:1(
         TupleExpr:1(
-          NameExpr(y* [l])
-          NameExpr(z* [l]))
-        NameExpr(__tuple_arg_2 [l]))
+          NameExpr(y*)
+          NameExpr(z*))
+        NameExpr(__tuple_arg_2))
       AssignmentStmt:2(
-        NameExpr(x [l])
-        NameExpr(y [l])))))
+        NameExpr(x)
+        NameExpr(y)))))
 
 [case testBackquoteExpr_python2]
 `object`

--- a/test-data/unit/semanal-statements.test
+++ b/test-data/unit/semanal-statements.test
@@ -9,7 +9,7 @@ MypyFile:1(
       Var(x))
     Block:1(
       ReturnStmt:1(
-        NameExpr(x [l]))))
+        NameExpr(x))))
   FuncDef:2(
     g
     Block:2(
@@ -102,11 +102,11 @@ MypyFile:1(
     f
     Block:1(
       ForStmt:2(
-        NameExpr(x* [l])
+        NameExpr(x*)
         NameExpr(f [__main__.f])
         Block:2(
           ExpressionStmt:3(
-            NameExpr(x [l])))))))
+            NameExpr(x)))))))
 
 [case testMultipleForIndexVars]
 for x, y in []:
@@ -149,12 +149,12 @@ MypyFile:1(
     f
     Block:1(
       ForStmt:2(
-        NameExpr(x* [l])
+        NameExpr(x*)
         ListExpr:2()
         Block:2(
           PassStmt:3()))
       ExpressionStmt:4(
-        NameExpr(x [l])))))
+        NameExpr(x)))))
 
 [case testReusingForLoopIndexVariable]
 for x in None:
@@ -186,12 +186,12 @@ MypyFile:1(
     f
     Block:1(
       ForStmt:2(
-        NameExpr(x* [l])
+        NameExpr(x*)
         NameExpr(None [builtins.None])
         Block:2(
           PassStmt:3()))
       ForStmt:4(
-        NameExpr(x [l])
+        NameExpr(x)
         NameExpr(None [builtins.None])
         Block:4(
           PassStmt:5())))))
@@ -417,10 +417,10 @@ MypyFile:1(
     f
     Block:1(
       AssignmentStmt:2(
-        NameExpr(x* [l])
+        NameExpr(x*)
         IntExpr(1))
       ExpressionStmt:3(
-        NameExpr(x [l])))))
+        NameExpr(x)))))
 
 [case testMultipleDefOnlySomeNew]
 x = 1
@@ -513,7 +513,7 @@ MypyFile:1(
       Var(x))
     Block:1(
       DelStmt:2(
-        NameExpr(x [l])))))
+        NameExpr(x)))))
 
 [case testDelMultipleThings]
 def f(x, y):
@@ -528,9 +528,9 @@ MypyFile:1(
     Block:1(
       DelStmt:2(
         TupleExpr:2(
-          NameExpr(x [l])
+          NameExpr(x)
           IndexExpr:2(
-            NameExpr(y [l])
+            NameExpr(y)
             IntExpr(0)))))))
 
 [case testDelMultipleThingsInvalid]
@@ -674,10 +674,10 @@ MypyFile:1(
         Expr(
           NameExpr(f [__main__.f]))
         Target(
-          NameExpr(x* [l]))
+          NameExpr(x*))
         Block:2(
           ExpressionStmt:3(
-            NameExpr(x [l])))))))
+            NameExpr(x)))))))
 
 [case testComplexWith]
 with object, object:
@@ -855,7 +855,7 @@ MypyFile:1(
         Block:2(
           PassStmt:3())
         NameExpr(object [builtins.object])
-        NameExpr(o* [l])
+        NameExpr(o*)
         Block:4(
           PassStmt:5())))))
 
@@ -877,11 +877,11 @@ MypyFile:1(
         Block:2(
           PassStmt:3())
         NameExpr(object [builtins.object])
-        NameExpr(o* [l])
+        NameExpr(o*)
         Block:4(
           PassStmt:5())
         NameExpr(object [builtins.object])
-        NameExpr(o [l])
+        NameExpr(o)
         Block:6(
           PassStmt:7())))))
 
@@ -909,17 +909,17 @@ MypyFile:1(
             Args(
               IntExpr(0))))
         Target(
-          NameExpr(a* [l]))
+          NameExpr(a*))
         Expr(
           CallExpr:4(
             NameExpr(f [__main__.f])
             Args(
-              NameExpr(a [l]))))
+              NameExpr(a))))
         Target(
-          NameExpr(b* [l]))
+          NameExpr(b*))
         Block:4(
           AssignmentStmt:5(
-            NameExpr(x* [l])
+            NameExpr(x*)
             TupleExpr:5(
-              NameExpr(a [l])
-              NameExpr(b [l]))))))))
+              NameExpr(a)
+              NameExpr(b))))))))

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -33,12 +33,12 @@ MypyFile:1(
     f
     Block:2(
       AssignmentStmt:3(
-        NameExpr(x [l])
+        NameExpr(x)
         NameExpr(None [builtins.None])
         __main__.A)
       AssignmentStmt:4(
-        NameExpr(y* [l])
-        NameExpr(x [l])))))
+        NameExpr(y*)
+        NameExpr(x)))))
 
 [case testAnyType]
 from typing import Any
@@ -72,7 +72,7 @@ MypyFile:1(
       Block:3(
         AssignmentStmt:4(
           MemberExpr:4(
-            NameExpr(self [l])
+            NameExpr(self)
             x)
           NameExpr(None [builtins.None])
           builtins.int)))))
@@ -88,11 +88,11 @@ MypyFile:1(
   ClassDef:2(
     A
     AssignmentStmt:3(
-      NameExpr(x [m])
+      NameExpr(x)
       NameExpr(None [builtins.None])
       builtins.int)
     AssignmentStmt:4(
-      NameExpr(x [m])
+      NameExpr(x)
       IntExpr(1))))
 
 [case testFunctionSig]
@@ -122,10 +122,10 @@ MypyFile:1(
     def (x: Any, y: __main__.A)
     Block:4(
       AssignmentStmt:5(
-        NameExpr(z* [l])
+        NameExpr(z*)
         TupleExpr:5(
-          NameExpr(x [l])
-          NameExpr(y [l]))))))
+          NameExpr(x)
+          NameExpr(y))))))
 
 [case testBaseclass]
 class A: pass
@@ -256,11 +256,11 @@ MypyFile:1(
     f
     Block:6(
       AssignmentStmt:7(
-        NameExpr(b [l])
+        NameExpr(b)
         NameExpr(None [builtins.None])
         __main__.A)
       AssignmentStmt:8(
-        NameExpr(b [l])
+        NameExpr(b)
         IntExpr(1)))))
 
 [case testCast]
@@ -417,7 +417,7 @@ MypyFile:1(
     def [t] (x: t`-1)
     Block:3(
       AssignmentStmt:4(
-        NameExpr(y [l])
+        NameExpr(y)
         NameExpr(None [builtins.None])
         t`-1))))
 
@@ -752,7 +752,7 @@ MypyFile:1(
         def (o: builtins.object) -> builtins.int
         Block:3(
           ExpressionStmt:3(
-            NameExpr(o [l])))))
+            NameExpr(o)))))
     Decorator:4(
       Var(f)
       NameExpr(overload [typing.overload])
@@ -763,7 +763,7 @@ MypyFile:1(
         def (a: builtins.str) -> builtins.object
         Block:5(
           ExpressionStmt:5(
-            NameExpr(a [l])))))))
+            NameExpr(a)))))))
 
 [case testReferenceToOverloadedFunction]
 from typing import overload
@@ -832,8 +832,8 @@ MypyFile:1(
             Block:6(
               PassStmt:6()))))
       AssignmentStmt:7(
-        NameExpr(y* [l])
-        NameExpr(g [l])))))
+        NameExpr(y*)
+        NameExpr(g)))))
 
 [case testImplicitGenericTypeArgs]
 from typing import TypeVar, Generic
@@ -1008,7 +1008,7 @@ MypyFile:1(
     def (*x: builtins.int, *, y: builtins.str =) -> Any
     Init(
       AssignmentStmt:1(
-        NameExpr(y [l])
+        NameExpr(y)
         StrExpr()))
     VarArg(
       Var(x))
@@ -1081,7 +1081,7 @@ MypyFile:1(
     f
     Block:2(
       AssignmentStmt:3(
-        NameExpr(T* [l])
+        NameExpr(T*)
         TypeVarExpr:3())
       FuncDef:4(
         g
@@ -1102,7 +1102,7 @@ MypyFile:1(
   ClassDef:2(
     A
     AssignmentStmt:3(
-      NameExpr(T* [m])
+      NameExpr(T*)
       TypeVarExpr:3())
     FuncDef:4(
       g
@@ -1130,7 +1130,7 @@ MypyFile:1(
     TypeVars(
       T)
     AssignmentStmt:4(
-      NameExpr(y [m])
+      NameExpr(y)
       NameExpr(None [builtins.None])
       T`1)))
 
@@ -1153,7 +1153,7 @@ MypyFile:1(
     TypeVars(
       _m.T)
     AssignmentStmt:4(
-      NameExpr(a [m])
+      NameExpr(a)
       NameExpr(None [builtins.None])
       _m.T`1)
     FuncDef:5(
@@ -1164,7 +1164,7 @@ MypyFile:1(
       def (self: __main__.A[_m.T`1], x: _m.T`1) -> Any
       Block:5(
         AssignmentStmt:6(
-          NameExpr(b [l])
+          NameExpr(b)
           NameExpr(None [builtins.None])
           _m.T`1)))))
 
@@ -1185,7 +1185,7 @@ MypyFile:1(
     def [_m.T] (x: _m.T`-1)
     Block:2(
       AssignmentStmt:3(
-        NameExpr(a [l])
+        NameExpr(a)
         NameExpr(None [builtins.None])
         _m.T`-1))))
 
@@ -1203,7 +1203,7 @@ MypyFile:1(
     def (x: builtins.int) -> Any
     Block:2(
       AssignmentStmt:3(
-        NameExpr(x [l])
+        NameExpr(x)
         IntExpr(1)))))
 
 [case testMethodCommentAnnotation]
@@ -1224,7 +1224,7 @@ MypyFile:1(
       def (self: __main__.A, x: builtins.int) -> builtins.str
       Block:3(
         AssignmentStmt:4(
-          NameExpr(x [l])
+          NameExpr(x)
           IntExpr(1))))))
 
 [case testTypevarWithValues]


### PR DESCRIPTION
@JukkaL what do you think? Note that the 'kind' of a node can have a number of values, it's just that all plain variables are now GDEF. This came up in https://github.com/python/mypy/pull/2553#issuecomment-266307655.

@elazarg what do *you* think? GDEF isn't the greatest name, but I couldn't really come up with a better one, and DEF feels too short/ambiguous.