### PR TITLE
add cheat sheet for python3 into index page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,7 @@ Mypy is a static type checker for Python.
    python36
    faq
    cheat_sheet
+   cheat_sheet_py3
    revision_history
 
 Indices and tables


### PR DESCRIPTION
At first, I didn't know that there is cheat sheet for python3 since I couldn't find its link. That's a misleading.