### PR TITLE
Add typing to test-requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 flake8
 lxml
-typed-ast>=0.6.1
+typed-ast>=0.6.1; sys_platform != 'win32'
 pytest>=2.8
 pytest-xdist>=1.13
 pytest-cov>=2.4.0
+typing>=3.5.2; python_version < '3.5'


### PR DESCRIPTION
Also make typed_ast and typing conditional on platform/version.

I found that typing was missing when attempting to run pytest in a mostly vanilla 3.3 install.

The platform/version conditionals are borrowed from PR #2452.