### PR TITLE
Update docs to describe --follow-imports and --ignore-missing-imports

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -1,7 +1,7 @@
 .. _common_issues:
 
-Dealing with common issues
-==========================
+Common issues
+=============
 
 This section has examples of cases when you need to update your code
 to use static typing, and ideas for working around issues if mypy
@@ -27,7 +27,7 @@ No errors reported for obviously wrong code
 There are several common reasons why obviously wrong code is not
 flagged as an error.
 
-- **No annotations on function containing the errors.** Functions that
+- **The function containing the error is not annotated.** Functions that
   do not have any annotations (neither for any argument nor for the
   return type) are not type-checked, and even the most blatant type
   errors (e.g. ``2 + 'a'``) pass silently.  The solution is to add
@@ -72,14 +72,19 @@ flagged as an error.
   e.g. the ``pow()`` builtin returns ``Any`` (see `typeshed issue 285
   <https://github.com/python/typeshed/issues/285>`_ for the reason).
 
-  Another source of unexpected ``Any`` values is the
-  :ref:`"silent-imports" <silent-imports>` flag, which causes
-  everything imported from a module that cannot be located to have the
-  type ``Any`` (including classes inheriting from such).  Sometimes
-  the :ref:`"disallow-subclassing-any" <disallow-subclassing-any>`
-  flag is helpful in diagnosing this.  (Read up about these and other
-  useful flags like :ref:`"almost-silent" <almost-silent>` in
-  :ref:`command-line`.)
+- **Some imports may be silently ignored**.  Another source of
+  unexpected ``Any`` values are the :ref:`"--ignore-missing-imports"
+  <ignore-missing-imports>` and :ref:`"--follow-imports=skip"
+  <follow-imports>` flags.  When you use ``--ignore-missing-imports``,
+  any imported module that cannot be found is silently replaced with
+  ``Any``.  When using ``--follow-imports=skip`` the same is true for
+  modules for which a ``.py`` file is found but that are not specified
+  on the command line.  (If a ``.pyi`` stub is found it is always
+  processed normally, regardless of the value of
+  ``--follow-imports``.)  To help debug the former situation (no
+  module found at all) leave out ``--ignore-missing-imports``; to get
+  clarity about the latter use ``--follow-imports=error``.  You can
+  read up about these and other useful flags in :ref:`command-line`.
 
 .. _silencing_checker:
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -114,11 +114,26 @@ overridden by the pattern sections matching the module name.
    If multiple pattern sections match a module they are processed in
    unspecified order.
 
-- ``silent_imports`` (Boolean, default False) silences complaints
-  about :ref:`imports not found <silent-imports>`.
+- ``follow_imports`` (string, default ``normal``) directs what to do
+  with imports when the imported module is found as a ``.py`` file and
+  not part of the files, modules and packages on the command line.
+  The four possible values are ``normal``, ``silent``, ``skip`` and
+  ``error``.  For explanations see the discussion for the
+  :ref:`--follow-imports <follow-imports>` command line flag.  Note
+  that if pattern matching is used, the pattern should match the name
+  of the _imported_ module, not the module containing the import
+  statement.
 
-- ``almost_silent`` (Boolean, default False) is similar but
-  :ref:`slightly less silent <almost-silent>`.
+- ``ignore_missing_imports`` (Boolean, default False) suppress error
+  messages about imports that cannot be resolved.  Note that if
+  pattern matching is used, the pattern should match the name of the
+  _imported_ module, not the module containing the import statement.
+
+- ``silent_imports`` (Boolean, deprecated) equivalent to
+  ``follow_imports=skip`` plus ``ignore_missing_imports=True``.
+
+- ``almost_silent`` (Boolean, deprecated) equivalent to
+  ``follow_imports=skip``.
 
 - ``disallow_untyped_calls`` (Boolean, default False) disallows
   calling functions without type annotations from functions with type


### PR DESCRIPTION
These replace --silent-imports and --almost-silent.
I ended up largely rewriting the section on following imports.

Fixes #2546.