### PR TITLE
Allow arbitrary overriding of  comparision methods

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -874,8 +874,10 @@ class TypeChecker(NodeVisitor[Type]):
         """Check if method definition is compatible with a base class."""
         if base:
             name = defn.name()
-            if name not in ('__init__', '__new__'):
-                # Check method override (__init__ and __new__ are special).
+            if name not in ('__init__', '__new__',
+                            '__eq__', '__ne__', '__lt__', '__le__', '__gt__', '__ge__'):
+                # Check method override (__init__, __new__ and the comparison
+                # operators are special).
                 self.check_method_override_for_base_with_name(defn, name, base)
                 if name in nodes.inplace_operator_methods:
                     # Figure out the name of the corresponding operator method.


### PR DESCRIPTION
subclasses should be allowed to override these with differing argument types.

The documentation explicitly allows returning non-`bool` values for instance.

This also allows typeshed to define comparison methods for `object` and still error on comparisons of unrelated types (like `str() < int()`).