### PR TITLE
Fixes #2589: type redeclarations cause spurious warnings

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1309,10 +1309,11 @@ class SemanticAnalyzer(NodeVisitor):
                 lval.kind = MDEF
                 lval.fullname = lval.name
                 self.type.names[lval.name] = SymbolTableNode(MDEF, v)
+            elif explicit_type:
+                # Don't re-bind types
+                self.name_already_defined(lval.name, lval)
             else:
                 # Bind to an existing name.
-                if explicit_type:
-                    self.name_already_defined(lval.name, lval)
                 lval.accept(self)
                 self.check_lvalue_validity(lval.node, lval)
         elif isinstance(lval, MemberExpr):

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1311,3 +1311,13 @@ class A:
 [out]
 main:5: error: Name 'x' is not defined
 main:5: error: Name 'y' is not defined
+
+[case testTypeRedeclarationNoSpuriousWarnings]
+from typing import Tuple
+a = 1  # type: int
+a = 's'  # type: str
+a = ('spam', 'spam', 'eggs', 'spam')  # type: Tuple[str]
+
+[out]
+main:3: error: Name 'a' already defined
+main:4: error: Name 'a' already defined


### PR DESCRIPTION
This addresses the problem by refusing to re-bind the explicit type for a name once one type was already present.  This means it changes the logic from "last type declaration wins" to "first type declaration wins".  The error about redeclaring the type is still being reported but the type does not change, which changes the errors given, producing less surprising results.

**Test plan**: added a new test case to `unit/semanal`.  Without the change, there's spurious errors about names not conforming to the type defined last.  With the change, only the "Name already defined" errors remain.