### PR TITLE
Fix handling of empty tuple type aliases

### DIFF
--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -37,6 +37,8 @@ def expr_to_unanalyzed_type(expr: Expression) -> Type:
             else:
                 args = [expr.index]
             base.args = [expr_to_unanalyzed_type(arg) for arg in args]
+            if not base.args:
+                base.empty_tuple_index = True
             return base
         else:
             raise TypeTranslationError()

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -61,3 +61,14 @@ def f(x: bytes): pass
 bytes
 f(1) # E: Argument 1 to "f" has incompatible type "int"; expected "str"
 [builtins fixtures/alias.pyi]
+
+[case testEmptyTupleTypeAlias]
+from typing import Tuple, Callable
+EmptyTuple = Tuple[()]
+x = None # type: EmptyTuple
+reveal_type(x)  # E: Revealed type is 'Tuple[]'
+
+EmptyTupleCallable = Callable[[Tuple[()]], None]
+f = None # type: EmptyTupleCallable
+reveal_type(f)  # E: Revealed type is 'def (Tuple[])'
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
Previously, `Tuple[()]` in type aliases would be treated as `Tuple`, which is incorrect.  This adds the appropriate check for this situation to `expr_to_unanalyzed_type`.

Fixes #2594.