### PR TITLE
Allow isinstance checks of TypedDict from the typing module

### DIFF
--- a/extensions/mypy_extensions.py
+++ b/extensions/mypy_extensions.py
@@ -15,7 +15,7 @@ from typing import _type_check  # type: ignore
 
 def _check_fails(cls, other):
     try:
-        if sys._getframe(1).f_globals['__name__'] not in ['abc', 'functools']:
+        if sys._getframe(1).f_globals['__name__'] not in ['abc', 'functools', 'typing']:
             # Typed dicts are only for static structural subtyping.
             raise TypeError('TypedDict does not support instance and class checks')
     except (AttributeError, ValueError):

--- a/mypy/test/testextensions.py
+++ b/mypy/test/testextensions.py
@@ -117,10 +117,8 @@ class TypedDictTests(BaseTestCase):
     def test_optional(self):
         EmpD = TypedDict('EmpD', name=str, id=int)
 
-        def internal_function() -> typing.Optional[EmpD]:
-            return None
-
-        internal_function()
+        self.assertEqual(typing.Optional[EmpD], typing.Union[None, EmpD])
+        self.assertNotEqual(typing.List[EmpD], typing.Tuple[EmpD])
 
 
 if __name__ == '__main__':

--- a/mypy/test/testextensions.py
+++ b/mypy/test/testextensions.py
@@ -114,6 +114,14 @@ class TypedDictTests(BaseTestCase):
             EmpDnew = pickle.loads(ZZ)
             self.assertEqual(EmpDnew({'name': 'jane', 'id': 37}), jane)
 
+    def test_optional(self):
+        EmpD = TypedDict('EmpD', name=str, id=int)
+
+        def internal_function() -> typing.Optional[EmpD]:
+            return None
+
+        internal_function()
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This fixes https://github.com/python/mypy/issues/2614