### PR TITLE
Fix performance degradation with many entries in mypy.ini (#2617)

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -2,6 +2,7 @@
 
 import argparse
 import configparser
+import fnmatch
 import os
 import re
 import sys
@@ -522,7 +523,8 @@ def parse_config_file(options: Options, filename: str) -> None:
                 glob = glob.replace(os.sep, '.')
                 if os.altsep:
                     glob = glob.replace(os.altsep, '.')
-                options.per_module_options[glob] = updates
+                pattern = re.compile(fnmatch.translate(glob))
+                options.per_module_options[pattern] = updates
 
 
 def parse_section(prefix: str, template: Options,

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -2,7 +2,7 @@ import fnmatch
 import pprint
 import sys
 
-from typing import Any, Mapping, Optional, Tuple, List
+from typing import Any, Mapping, Optional, Tuple, List, Pattern
 
 from mypy import defaults
 
@@ -93,7 +93,7 @@ class Options:
         self.junit_xml = None  # type: Optional[str]
 
         # Per-module options (raw)
-        self.per_module_options = {}  # type: Dict[str, Dict[str, object]]
+        self.per_module_options = {}  # type: Dict[Pattern[str], Dict[str, object]]
 
         # -- development options --
         self.verbosity = 0  # More verbose messages (for troubleshooting)
@@ -139,11 +139,11 @@ class Options:
         new_options.__dict__.update(updates)
         return new_options
 
-    def module_matches_pattern(self, module: str, pattern: str) -> bool:
+    def module_matches_pattern(self, module: str, pattern: Pattern[str]) -> bool:
         # If the pattern is 'mod.*', we want 'mod' to match that too.
         # (That's so that a pattern specifying a package also matches
         # that package's __init__.)
-        return fnmatch.fnmatch(module, pattern) or fnmatch.fnmatch(module + '.', pattern)
+        return pattern.match(module) is not None or pattern.match(module + '.') is not None
 
     def select_options_affecting_cache(self) -> Mapping[str, bool]:
         return {opt: getattr(self, opt) for opt in self.OPTIONS_AFFECTING_CACHE}


### PR DESCRIPTION
Since we were calling `fnmatch.fnmatch` for every entry in `mypy.ini` for every file that gets checked, performance would degrade sharply when the number of entries was more than 256.
That's because `fnmatch.fnmatch` lrucaches 256 patterns internally. And because the access pattern is linear this would cause a perfect storm of (fnmatch.translate + re.compile) * entries * modules if you went over 256 items.

So to solve it we store the Pattern in the dict and use that to match.

Bonus: The old code was using fnmatch.fnmatch which was not case sensitive.  Since modules are meant to be case sensitive I think it's ok to not call `os.path.normcase`.