### PR TITLE
Implement type-aware `get` for TypedDict

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -344,6 +344,9 @@ class ExpressionChecker:
             if isinstance(callee, TypedDictGetFunction):
                 if 1 <= len(args) <= 2 and isinstance(args[0], (StrExpr, UnicodeExpr)):
                     return_type = self.get_typeddict_index_type(callee.typed_dict, args[0])
+                    if len(args) == 1:
+                        return_type = UnionType.make_union([
+                            return_type, NoneTyp()])
                     return return_type, callee
             if callee.is_concrete_type_obj() and callee.type_object().is_abstract:
                 type = callee.type_object()

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -980,6 +980,26 @@ class TypedDictType(Type):
             yield (item_name, None, right_item_type)
 
 
+class TypedDictGetFunction(CallableType):
+    """A special callable type containing a reference to the TypedDict `get` callable instance.
+    This is needed to delay determining the signature of a TypedDict's `get` method until the
+    method is actually called.  This allows `get` to behave just as indexing into the TypedDict
+    would.
+
+    This is not a real type, but is needed to allow TypedDict.get to behave as expected.
+    """
+    def __init__(self, typed_dict: TypedDictType, fallback_callable: CallableType) -> None:
+        super().__init__(fallback_callable.arg_types, fallback_callable.arg_kinds,
+                         fallback_callable.arg_names, fallback_callable.ret_type,
+                         fallback_callable.fallback, fallback_callable.name,
+                         fallback_callable.definition, fallback_callable.variables,
+                         fallback_callable.line, fallback_callable.column,
+                         fallback_callable.is_ellipsis_args, fallback_callable.implicit,
+                         fallback_callable.is_classmethod_class, fallback_callable.special_sig)
+        self.typed_dict = typed_dict
+        self.fallback_callable = fallback_callable
+
+
 class StarType(Type):
     """The star type *type_parameter.
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -438,6 +438,15 @@ p = TaggedPoint(type='2d', x=42, y=1337)
 reveal_type(p.get('type'))  # E: Revealed type is 'Union[builtins.str, builtins.None]'
 reveal_type(p.get('x'))     # E: Revealed type is 'Union[builtins.int, builtins.None]'
 reveal_type(p.get('y', 0))     # E: Revealed type is 'builtins.int'
+reveal_type(p.get('y', 'hello'))     # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(p.get('y', {}))     # E: Revealed type is 'Union[builtins.int, builtins.dict[builtins.None, builtins.None]]'
+[builtins fixtures/dict.pyi]
+
+[case testDefaultParameterStillTypeChecked]
+from mypy_extensions import TypedDict
+TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+p = TaggedPoint(type='2d', x=42, y=1337)
+p.get('x', 1 + 'y')     # E: Unsupported operand types for + ("int" and "str")
 [builtins fixtures/dict.pyi]
 
 [case testCannotGetMethodWithInvalidStringLiteralKey]
@@ -455,12 +464,20 @@ key = 'type'
 reveal_type(p.get(key))  # E: Revealed type is 'builtins.object*'
 [builtins fixtures/dict.pyi]
 
-[case testChainedGetMethodWithFallback]
+[case testChainedGetMethodWithDictFallback]
 from mypy_extensions import TypedDict
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 PointSet = TypedDict('PointSet', {'first_point': TaggedPoint})
 p = PointSet(first_point=TaggedPoint(type='2d', x=42, y=1337))
 reveal_type(p.get('first_point', {}).get('x', 0))  # E: Revealed type is 'builtins.int'
+[builtins fixtures/dict.pyi]
+
+[case testChainedGetMethodWithNonDictFallback]
+from mypy_extensions import TypedDict
+TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+PointSet = TypedDict('PointSet', {'first_point': TaggedPoint})
+p = PointSet(first_point=TaggedPoint(type='2d', x=42, y=1337))
+p.get('first_point', 32).get('x', 0)  # E: Some element of union has no attribute "get"
 [builtins fixtures/dict.pyi]
 
 [case testDictGetMethodStillCallable]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -463,6 +463,26 @@ p = PointSet(first_point=TaggedPoint(type='2d', x=42, y=1337))
 reveal_type(p.get('first_point', {}).get('x'))  # E: Revealed type is 'builtins.int'
 [builtins fixtures/dict.pyi]
 
+[case testDictGetMethodStillCallable]
+from typing import Callable
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+p = Point(x=42, y=13)
+def invoke_method(method: Callable[[str, int], int]) -> None:
+    pass
+invoke_method(p.get)
+[builtins fixtures/dict.pyi]
+
+[case testDictGetMethodStillCallableWithObject]
+from typing import Callable
+from mypy_extensions import TypedDict
+TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+p = TaggedPoint(type='2d', x=42, y=1337)
+def invoke_method(method: Callable[..., object]) -> None:
+    pass
+invoke_method(p.get)
+[builtins fixtures/dict.pyi]
+
 -- TODO: Implement support for these cases:
 --[case testGetOfTypedDictWithValidStringLiteralKeyReturnsPreciseType]
 --[case testGetOfTypedDictWithInvalidStringLiteralKeyIsError]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -438,8 +438,6 @@ p = TaggedPoint(type='2d', x=42, y=1337)
 reveal_type(p.get('type'))  # E: Revealed type is 'Union[builtins.str, builtins.None]'
 reveal_type(p.get('x'))     # E: Revealed type is 'Union[builtins.int, builtins.None]'
 reveal_type(p.get('y', 0))     # E: Revealed type is 'builtins.int'
-reveal_type(p.get('y', 'hello'))     # E: Revealed type is 'Union[builtins.int, builtins.str]'
-reveal_type(p.get('y', {}))     # E: Revealed type is 'Union[builtins.int, builtins.dict[builtins.None, builtins.None]]'
 [builtins fixtures/dict.pyi]
 
 [case testDefaultParameterStillTypeChecked]
@@ -472,12 +470,12 @@ p = PointSet(first_point=TaggedPoint(type='2d', x=42, y=1337))
 reveal_type(p.get('first_point', {}).get('x', 0))  # E: Revealed type is 'builtins.int'
 [builtins fixtures/dict.pyi]
 
-[case testChainedGetMethodWithNonDictFallback]
+[case testGetMethodInvalidDefaultType]
 from mypy_extensions import TypedDict
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 PointSet = TypedDict('PointSet', {'first_point': TaggedPoint})
 p = PointSet(first_point=TaggedPoint(type='2d', x=42, y=1337))
-p.get('first_point', 32).get('x', 0)  # E: Some element of union has no attribute "get"
+p.get('first_point', 32)  # E: Argument 2 to "get" of "Mapping" has incompatible type "int"; expected "Union[TypedDict(type=str, x=int, y=int), Mapping]"
 [builtins fixtures/dict.pyi]
 
 [case testGetMethodOnList]
@@ -487,6 +485,14 @@ TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 PointSet = TypedDict('PointSet', {'points': List[TaggedPoint]})
 p = PointSet(points=[TaggedPoint(type='2d', x=42, y=1337)])
 reveal_type(p.get('points', []))  # E: Revealed type is 'builtins.list[TypedDict(type=builtins.str, x=builtins.int, y=builtins.int, _fallback=__main__.TaggedPoint)]'
+[builtins fixtures/dict.pyi]
+
+[case testGetMethodWithListOfStrUnifies]
+from typing import List
+from mypy_extensions import TypedDict
+Items = TypedDict('Items', {'name': str, 'values': List[str]})
+def foo(i: Items) -> None:
+  reveal_type(i.get('values', []))  # E: Revealed type is 'builtins.list[builtins.str]'
 [builtins fixtures/dict.pyi]
 
 [case testDictGetMethodStillCallable]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -431,6 +431,38 @@ def set_coordinate(p: TaggedPoint, key: str, value: int) -> None:
 
 -- Special Method: get
 
+[case testCanUseGetMethodWithStringLiteralKey]
+from mypy_extensions import TypedDict
+TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+p = TaggedPoint(type='2d', x=42, y=1337)
+reveal_type(p.get('type'))  # E: Revealed type is 'builtins.str'
+reveal_type(p.get('x'))     # E: Revealed type is 'builtins.int'
+reveal_type(p.get('y'))     # E: Revealed type is 'builtins.int'
+[builtins fixtures/dict.pyi]
+
+[case testCannotGetMethodWithInvalidStringLiteralKey]
+from mypy_extensions import TypedDict
+TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+p = TaggedPoint(type='2d', x=42, y=1337)
+p.get('z')  # E: 'z' is not a valid item name; expected one of ['type', 'x', 'y']
+[builtins fixtures/dict.pyi]
+
+[case testGetMethodWithVariableKeyFallsBack]
+from mypy_extensions import TypedDict
+TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+p = TaggedPoint(type='2d', x=42, y=1337)
+key = 'type'
+reveal_type(p.get(key))  # E: Revealed type is 'builtins.object*'
+[builtins fixtures/dict.pyi]
+
+[case testChainedGetMethodWithFallback]
+from mypy_extensions import TypedDict
+TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+PointSet = TypedDict('PointSet', {'first_point': TaggedPoint})
+p = PointSet(first_point=TaggedPoint(type='2d', x=42, y=1337))
+reveal_type(p.get('first_point', {}).get('x'))  # E: Revealed type is 'builtins.int'
+[builtins fixtures/dict.pyi]
+
 -- TODO: Implement support for these cases:
 --[case testGetOfTypedDictWithValidStringLiteralKeyReturnsPreciseType]
 --[case testGetOfTypedDictWithInvalidStringLiteralKeyIsError]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -435,9 +435,9 @@ def set_coordinate(p: TaggedPoint, key: str, value: int) -> None:
 from mypy_extensions import TypedDict
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 p = TaggedPoint(type='2d', x=42, y=1337)
-reveal_type(p.get('type'))  # E: Revealed type is 'builtins.str'
-reveal_type(p.get('x'))     # E: Revealed type is 'builtins.int'
-reveal_type(p.get('y'))     # E: Revealed type is 'builtins.int'
+reveal_type(p.get('type'))  # E: Revealed type is 'Union[builtins.str, builtins.None]'
+reveal_type(p.get('x'))     # E: Revealed type is 'Union[builtins.int, builtins.None]'
+reveal_type(p.get('y', 0))     # E: Revealed type is 'builtins.int'
 [builtins fixtures/dict.pyi]
 
 [case testCannotGetMethodWithInvalidStringLiteralKey]
@@ -460,7 +460,7 @@ from mypy_extensions import TypedDict
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 PointSet = TypedDict('PointSet', {'first_point': TaggedPoint})
 p = PointSet(first_point=TaggedPoint(type='2d', x=42, y=1337))
-reveal_type(p.get('first_point', {}).get('x'))  # E: Revealed type is 'builtins.int'
+reveal_type(p.get('first_point', {}).get('x', 0))  # E: Revealed type is 'builtins.int'
 [builtins fixtures/dict.pyi]
 
 [case testDictGetMethodStillCallable]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -480,6 +480,15 @@ p = PointSet(first_point=TaggedPoint(type='2d', x=42, y=1337))
 p.get('first_point', 32).get('x', 0)  # E: Some element of union has no attribute "get"
 [builtins fixtures/dict.pyi]
 
+[case testGetMethodOnList]
+from typing import List
+from mypy_extensions import TypedDict
+TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
+PointSet = TypedDict('PointSet', {'points': List[TaggedPoint]})
+p = PointSet(points=[TaggedPoint(type='2d', x=42, y=1337)])
+reveal_type(p.get('points', []))  # E: Revealed type is 'builtins.list[TypedDict(type=builtins.str, x=builtins.int, y=builtins.int, _fallback=__main__.TaggedPoint)]'
+[builtins fixtures/dict.pyi]
+
 [case testDictGetMethodStillCallable]
 from typing import Callable
 from mypy_extensions import TypedDict

--- a/test-data/unit/fixtures/dict.pyi
+++ b/test-data/unit/fixtures/dict.pyi
@@ -18,6 +18,7 @@ class dict(Iterable[KT], Mapping[KT, VT], Generic[KT, VT]):
     def __init__(self, arg: Iterable[Tuple[KT, VT]], **kwargs: VT) -> None: pass
     def __setitem__(self, k: KT, v: VT) -> None: pass
     def __iter__(self) -> Iterator[KT]: pass
+    def get(self, k: KT, default: VT=None) -> VT: pass
     def update(self, a: Mapping[KT, VT]) -> None: pass
 
 class int: # for convenience

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -78,7 +78,9 @@ class Sequence(Iterable[T], Generic[T]):
     @abstractmethod
     def __getitem__(self, n: Any) -> T: pass
 
-class Mapping(Generic[T, U]): pass
+class Mapping(Generic[T, U]):
+    @abstractmethod
+    def get(self, k: T, default: U=None) -> U: pass
 
 class MutableMapping(Generic[T, U]): pass
 


### PR DESCRIPTION
Previously, `get` would simply fallback to the type of the underlying dictionary which made
TypedDicts hard to use with code that's parsing objects where fields may or may not be
present (for example, parsing a response).

This implementation _explicitly_ ignores the default parameter's type as it's quite useful to
chain together get calls (Until something like PEP 505 hits :smile:)

```python
foo.get('a', {}).get('b', {}).get('c')
```

This fixes https://github.com/python/mypy/issues/2612