### PR TITLE
Fix detecting missing parameter/return type annotations with fast parser

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -304,10 +304,12 @@ class ASTConverter(ast35.NodeTransformer):
                 raise FastParserError('Type signature has too many arguments', n.lineno, offset=0)
             if len(arg_types) < len(arg_kinds):
                 raise FastParserError('Type signature has too few arguments', n.lineno, offset=0)
-            func_type = CallableType([a if a is not None else AnyType() for a in arg_types],
+            func_type = CallableType([a if a is not None else
+                                      AnyType(implicit=True) for a in arg_types],
                                      arg_kinds,
                                      arg_names,
-                                     return_type if return_type is not None else AnyType(),
+                                     return_type if return_type is not None else
+                                     AnyType(implicit=True),
                                      None)
 
         func_def = FuncDef(n.name,

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -10,6 +10,12 @@ def f(x) -> int: pass
 [out]
 main:2: error: Function is missing a type annotation for one or more arguments
 
+[case testUnannotatedArgumentWithFastParser]
+# flags: --fast-parser --disallow-untyped-defs
+def f(x) -> int: pass
+[out]
+main:2: error: Function is missing a type annotation for one or more arguments
+
 [case testNoArgumentFunction]
 # flags: --disallow-untyped-defs
 def f() -> int: pass
@@ -17,6 +23,12 @@ def f() -> int: pass
 
 [case testUnannotatedReturn]
 # flags: --disallow-untyped-defs
+def f(x: int): pass
+[out]
+main:2: error: Function is missing a return type annotation
+
+[case testUnannotatedReturnWithFastParser]
+# flags: --fast-parser --disallow-untyped-defs
 def f(x: int): pass
 [out]
 main:2: error: Function is missing a return type annotation


### PR DESCRIPTION
Some test code:

```python
    # test.py
    def f1(i) -> None:
        pass

    def f2(i: int):
        pass

    def f3():
        pass
```

Without fast parser the detection was working just fine:

```
    % mypy --disallow-untyped-defs test.py
    test.py: note: In function "f1":
    test.py:1: error: Function is missing a type annotation for one or more arguments
    test.py: note: In function "f2":
    test.py:5: error: Function is missing a return type annotation
    test.py: note: In function "f3":
    test.py:9: error: Function is missing a type annotation
```

With fast parser, however, functions missing only parameter or only
return type annotation would remain undetected:

```
    % mypy --disallow-untyped-defs --fast-parser test.py
    test.py: note: In function "f3":
    test.py:9: error: Function is missing a type annotation
```