### PR TITLE
Make TypeVars with only one constraint illegal

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1544,7 +1544,7 @@ class SemanticAnalyzer(NodeVisitor):
         res = self.process_typevar_parameters(call.args[1 + n_values:],
                                               call.arg_names[1 + n_values:],
                                               call.arg_kinds[1 + n_values:],
-                                              bool(values),
+                                              n_values,
                                               s)
         if res is None:
             return
@@ -1591,8 +1591,9 @@ class SemanticAnalyzer(NodeVisitor):
     def process_typevar_parameters(self, args: List[Expression],
                                    names: List[Optional[str]],
                                    kinds: List[int],
-                                   has_values: bool,
+                                   num_values: int,
                                    context: Context) -> Optional[Tuple[int, Type]]:
+        has_values = (num_values > 0)
         covariant = False
         contravariant = False
         upper_bound = self.object_type()   # type: Type
@@ -1641,6 +1642,9 @@ class SemanticAnalyzer(NodeVisitor):
 
         if covariant and contravariant:
             self.fail("TypeVar cannot be both covariant and contravariant", context)
+            return None
+        elif num_values == 1:
+            self.fail("TypeVar cannot have only a single constraint", context)
             return None
         elif covariant:
             variance = COVARIANT

--- a/test-data/unit/check-bound.test
+++ b/test-data/unit/check-bound.test
@@ -142,7 +142,7 @@ class A(A0):
 class B(A):
     def baz(self) -> None: pass
 
-T = TypeVar('T', A)
+T = TypeVar('T', bound=A)
 
 def f(x: T) -> T:
     x.foo()

--- a/test-data/unit/check-bound.test
+++ b/test-data/unit/check-bound.test
@@ -147,7 +147,7 @@ T = TypeVar('T', bound=A)
 def f(x: T) -> T:
     x.foo()
     x.bar()
-    x.baz()  # E: "A" has no attribute "baz"
+    x.baz()  # E: "T" has no attribute "baz"
     x.a
     x.b
     return x

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1458,13 +1458,12 @@ main:6: error: Signatures of "__radd__" of "B" and "__add__" of "X" are unsafely
 
 [case testUnsafeOverlappingWithLineNo]
 from typing import TypeVar
-T = TypeVar('T', bound=Real)
 class Real:
     def __add__(self, other): ...
 class Fraction(Real):
-    def __radd__(self, other: T) -> T: ...
+    def __radd__(self, other: Real) -> Real: ...
 [out]
-main:6: error: Signatures of "__radd__" of "Fraction" and "__add__" of "Real" are unsafely overlapping
+main:5: error: Signatures of "__radd__" of "Fraction" and "__add__" of "Real" are unsafely overlapping
 
 [case testOverlappingNormalAndInplaceOperatorMethod]
 import typing

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1458,7 +1458,7 @@ main:6: error: Signatures of "__radd__" of "B" and "__add__" of "X" are unsafely
 
 [case testUnsafeOverlappingWithLineNo]
 from typing import TypeVar
-T = TypeVar('T', Real)
+T = TypeVar('T', bound=Real)
 class Real:
     def __add__(self, other): ...
 class Fraction(Real):

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -493,7 +493,7 @@ def outer(x: T) -> T:
 [case testClassMemberTypeVarInFunctionBody]
 from typing import TypeVar
 class C:
-    T = TypeVar('T', int)
+    T = TypeVar('T', bound=int)
     def f(self, x: T) -> T:
         A = C.T
         return x

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -964,10 +964,10 @@ class A(metaclass=f): pass # E: Invalid metaclass 'f'
 
 [case testInvalidTypevarArguments]
 from typing import TypeVar
-a = TypeVar()       # E: Too few arguments for TypeVar()
-b = TypeVar(x='b')  # E: TypeVar() expects a string literal as first argument
-c = TypeVar(1)      # E: TypeVar() expects a string literal as first argument
-d = TypeVar('D')    # E: String argument 1 'D' to TypeVar(...) does not match variable name 'd'
+a = TypeVar() # E: Too few arguments for TypeVar()
+b = TypeVar(x='b') # E: TypeVar() expects a string literal as first argument
+c = TypeVar(1) # E: TypeVar() expects a string literal as first argument
+d = TypeVar('D') # E: String argument 1 'D' to TypeVar(...) does not match variable name 'd'
 e = TypeVar('e', int, str, x=1) # E: Unexpected argument to TypeVar(): x
 f = TypeVar('f', (int, str), int) # E: Type expected
 g = TypeVar('g', int) # E: TypeVar cannot have only a single constraint

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -964,15 +964,15 @@ class A(metaclass=f): pass # E: Invalid metaclass 'f'
 
 [case testInvalidTypevarArguments]
 from typing import TypeVar
-a = TypeVar() # E: Too few arguments for TypeVar()
-b = TypeVar(x='b') # E: TypeVar() expects a string literal as first argument
-c = TypeVar(1) # E: TypeVar() expects a string literal as first argument
-d = TypeVar('D') # E: String argument 1 'D' to TypeVar(...) does not match variable name 'd'
-e = TypeVar('e', int, str, x=1) # E: Unexpected argument to TypeVar(): x
+a = TypeVar()       # E: Too few arguments for TypeVar()
+b = TypeVar(x='b')  # E: TypeVar() expects a string literal as first argument
+c = TypeVar(1)      # E: TypeVar() expects a string literal as first argument
+d = TypeVar('D')    # E: String argument 1 'D' to TypeVar(...) does not match variable name 'd'
+e = TypeVar('e', int, str, x=1)   # E: Unexpected argument to TypeVar(): x
 f = TypeVar('f', (int, str), int) # E: Type expected
-g = TypeVar('g', int) # E: TypeVar cannot have only a single constraint
-h = TypeVar('h', x=(int, str)) # E: Unexpected argument to TypeVar(): x
-i = TypeVar('i', bound=1) # E: TypeVar 'bound' must be a type
+g = TypeVar('g', int)             # E: TypeVar cannot have only a single constraint
+h = TypeVar('h', x=(int, str))    # E: Unexpected argument to TypeVar(): x
+i = TypeVar('i', bound=1)         # E: TypeVar 'bound' must be a type
 [out]
 
 [case testMoreInvalidTypevarArguments]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -969,9 +969,10 @@ b = TypeVar(x='b')  # E: TypeVar() expects a string literal as first argument
 c = TypeVar(1)      # E: TypeVar() expects a string literal as first argument
 d = TypeVar('D')    # E: String argument 1 'D' to TypeVar(...) does not match variable name 'd'
 e = TypeVar('e', int, str, x=1) # E: Unexpected argument to TypeVar(): x
-f = TypeVar('f', (int, str)) # E: Type expected
-g = TypeVar('g', x=(int, str)) # E: Unexpected argument to TypeVar(): x
-h = TypeVar('h', bound=1) # E: TypeVar 'bound' must be a type
+f = TypeVar('f', (int, str), int) # E: Type expected
+g = TypeVar('g', int) # E: TypeVar cannot have only a single constraint
+h = TypeVar('h', x=(int, str)) # E: Unexpected argument to TypeVar(): x
+i = TypeVar('i', bound=1) # E: TypeVar 'bound' must be a type
 [out]
 
 [case testMoreInvalidTypevarArguments]


### PR DESCRIPTION
At runtime, doing something like `T = TypeVar('T', str)` results in the following exception:

    TypeError: A single constraint is not allowed

However, mypy itself seems to ignore this particular error, which feels incongruous.

This pull request slightly tweaks the semanal phase to emit an error message in this case to mirror the existing runtime behavior implemented in the typing module.