### PR TITLE
Disable flake8-bugbear errors (if installed)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,8 @@ exclude = mypy/codec/*
 #   W503: line break before binary operator
 #   E704: multiple statements on one line (def)
 #   E402: module level import not at top of file
-ignore = E251,E128,F401,W601,E701,W503,E704,E402
+#   B???: flake8-bugbear errors
+ignore = E251,E128,F401,W601,E701,W503,E704,E402,B
 
 [coverage:run]
 branch = true


### PR DESCRIPTION
These bit me since the typeshed tests now install flake8-bugbear. We're not interested in these.