### PR TITLE
Only catch SystemExit in api.run()

### DIFF
--- a/mypy/api.py
+++ b/mypy/api.py
@@ -47,7 +47,7 @@ def run(params: str) -> Tuple[str, str]:
 
     try:
         main(None)
-    except:
+    except SystemExit:
         pass
 
     sys.stdout = old_stdout


### PR DESCRIPTION
`mypy.main.main()` calls `sys.exit(1)` in case of errors. We don't want this to
bubble up during API usage.

Other exceptions raised from `mypy.main.main()` shouldn't be swallowed as they
point out at internal errors or environment errors (no memory, interrupts,
etc.).