### PR TITLE
Appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,4 +28,4 @@ build: off
 test_script:
   # we ignore test-cmdline, due to path differences and other tests that need lxml. extensions and check don't have tests that are discovered
   - "%PYTHON%\\python.exe runtests.py -x lint -x check -x extensions -x reports -x cmdline"
-  - ps: if ($env:PYTHON_VERSION -Match "3.6.x") { flake8}
+  - ps: if ($env:PYTHON_VERSION -Match "3.6.x") { iex "$env:PYTHON\\python.exe -m flake8"}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
 install:
    - "%PYTHON%\\python.exe -m pip install -r test-requirements.txt"
    - "git submodule update --init typeshed"
-   - "%PYTHON%\\python.exe setup.py install"
+   - "%PYTHON%\\python.exe setup.py -q install"
    
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,3 +28,4 @@ build: off
 test_script:
   # we ignore test-cmdline, due to path differences and other tests that need lxml. extensions and check don't have tests that are discovered
   - "%PYTHON%\\python.exe runtests.py -x lint -x check -x extensions -x reports -x cmdline"
+  - ps: if ($env:PYTHON_VERSION -Match "3.6.x") { flake8}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+environment:
+  matrix:
+
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.1"
+      PYTHON_ARCH: "32"
+      
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.1"
+      PYTHON_ARCH: "64"
+    
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "32"
+      
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
+     
+     
+install:
+   - "%PYTHON%\\python.exe -m pip install -r test-requirements.txt"
+   - "git submodule update --init typeshed"
+   - "%PYTHON%\\python.exe setup.py install"
+   
+build: off
+
+test_script:
+  # we ignore test-cmdline, due to path differences and other tests that need lxml. extensions and check don't have tests that are discovered
+  - "%PYTHON%\\python.exe runtests.py -x lint -x check -x extensions -x reports -x cmdline"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,4 +28,4 @@ build: off
 test_script:
   # we ignore test-cmdline, due to path differences and other tests that need lxml. extensions and check don't have tests that are discovered
   - "%PYTHON%\\python.exe runtests.py -x lint -x check -x extensions -x reports -x cmdline"
-  - ps: if ($env:PYTHON_VERSION -Match "3.6.x") { iex "$env:PYTHON\\python.exe -m flake8"}
+  - ps: if ($env:PYTHON_VERSION -Match "3.6.x" -And $env:PYTHON_ARCH -Match "64") { iex "$env:PYTHON\\python.exe -m flake8"}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,8 @@
 flake8
 flake8-bugbear; python_version >= '3.5'
 flake8-pyi; python_version >= '3.5'
-lxml
-typed-ast>=0.6.1; sys_platform != 'win32'
+lxml; sys_platform != 'win32'
+typed-ast>=0.6.3; sys_platform != 'win32' or python_version >= '3.5'
 pytest>=2.8
 pytest-xdist>=1.13
 pytest-cov>=2.4.0


### PR DESCRIPTION
I made a couple of small adjustments in test-requirements to reflect the new typed_ast dependency, and add an appveyor script. Due to several issues, I disabled a few tests beyond the lint disabled in the travis script. As, mentioned in the appveyor file, we ignore test-cmdline, due to path differences (unix and windows directory seperator differences) and report that needs lxml. extensions and check don't have tests that are discovered on Windows.

You can see the results here: https://ci.appveyor.com/project/ethanhs/mypy

TODO:

- [x] run flake8 on one version of Python (assumed version 3.6 like travis)
- [x] ~Python 3.3 and 3.4 testing? If so this is dependent on https://github.com/dropbox/typed_ast/issues/24~ (Guido said 3.5+ is fine on Gitter)
