### PR TITLE
Clean up appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,13 +19,14 @@ environment:
      
      
 install:
-   - "%PYTHON%\\python.exe -m pip install -r test-requirements.txt"
-   - "git submodule update --init typeshed"
-   - "%PYTHON%\\python.exe setup.py -q install"
+    - "%PYTHON%\\python.exe -m pip install -r test-requirements.txt"
+    - "git submodule update --init typeshed"
+    - "%PYTHON%\\python.exe setup.py -q install"
    
 build: off
 
 test_script:
-  # we ignore test-cmdline, due to path differences and other tests that need lxml. extensions and check don't have tests that are discovered
-  - "%PYTHON%\\python.exe runtests.py -x lint -x check -x extensions -x reports -x cmdline"
-  - ps: if ($env:PYTHON_VERSION -Match "3.6.x" -And $env:PYTHON_ARCH -Match "64") { iex "$env:PYTHON\\python.exe -m flake8"}
+    # Ignore lint (it's run separately below), reports (since we don't have lxml),
+    # and cmdline (since one of its tests depend on lxml)
+    - "%PYTHON%\\python.exe runtests.py -x lint -x reports -x cmdline"
+    - ps: if ($env:PYTHON_VERSION -Match "3.6.x" -And $env:PYTHON_ARCH -Match "64") { iex "$env:PYTHON\\python.exe -m flake8" }


### PR DESCRIPTION
Given https://github.com/python/mypy/pull/2658 we can remove the `-x check -x extensions` from the command line. Also cleaned up some indentation and improved the comment.