### PR TITLE
Fix crash when a typevar's value restriction is generic without parameters

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -186,7 +186,10 @@ class SubtypeVisitor(TypeVisitor[bool]):
                   is_named_instance(right, 'typing.Container') or
                   is_named_instance(right, 'typing.Sequence') or
                   is_named_instance(right, 'typing.Reversible')):
-                iter_type = right.args[0]
+                if right.args:
+                    iter_type = right.args[0]
+                else:
+                    iter_type = AnyType()
                 return all(is_subtype(li, iter_type) for li in left.items)
             elif is_subtype(left.fallback, right, self.check_type_parameter):
                 return True

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -497,3 +497,9 @@ class C:
     def f(self, x: T) -> T:
         A = C.T
         return x
+
+[case testParameterLessGenericAsRestriction]
+from typing import Sequence, Iterable, TypeVar
+S = TypeVar('S', Sequence, Iterable)
+def my_len(s: S) -> None: pass
+def crash() -> None: my_len((0,))


### PR DESCRIPTION
Fixes #2662