### PR TITLE
Make import of Type check-time only.

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -9,9 +9,6 @@ import sys
 import time
 
 from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, cast
-MYPY = False
-if MYPY:
-    from typing import Type
 
 from mypy import build
 from mypy import defaults
@@ -131,8 +128,8 @@ def process_options(args: List[str],
     """Parse command line arguments."""
 
     # Make the help output a little less jarring.
-    help_factory = cast(Type[argparse.HelpFormatter], (lambda prog:
-                        argparse.RawDescriptionHelpFormatter(prog=prog, max_help_position=28)))
+    help_factory = (lambda prog:
+                    argparse.RawDescriptionHelpFormatter(prog=prog, max_help_position=28))  # type: Any
     parser = argparse.ArgumentParser(prog='mypy', epilog=FOOTER,
                                      fromfile_prefix_chars='@',
                                      formatter_class=help_factory)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -129,7 +129,8 @@ def process_options(args: List[str],
 
     # Make the help output a little less jarring.
     help_factory = (lambda prog:
-                    argparse.RawDescriptionHelpFormatter(prog=prog, max_help_position=28))  # type: Any
+                    argparse.RawDescriptionHelpFormatter(prog=prog,
+                                                         max_help_position=28))  # type: Any
     parser = argparse.ArgumentParser(prog='mypy', epilog=FOOTER,
                                      fromfile_prefix_chars='@',
                                      formatter_class=help_factory)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -8,7 +8,10 @@ import re
 import sys
 import time
 
-from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Type, cast
+from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, cast
+MYPY = False
+if MYPY:
+    from typing import Type
 
 from mypy import build
 from mypy import defaults


### PR DESCRIPTION
This is needed to support Python 3.5.1.
(I'm surprised this didn't come up in the tests?
There's supposed to be a test run on Python 3.5.1.)