### PR TITLE
empty elements in PYTHONPATH allowed in runtest

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -328,7 +328,7 @@ def sanity() -> None:
         return
     failed = False
     for p in paths.split(os.pathsep):
-        if not os.path.isabs(p):
+        if not os.path.isabs(p) and p != '':
             print('Relative PYTHONPATH entry %r' % p)
             failed = True
     if failed:


### PR DESCRIPTION
For now, empty elements in PYTHONPATH are not allowed while running tests, so something looking like `PYTHONPATH="static-dir:${dynamic-dir}"` (with `dynamic-dir` not definied in this case) whould not work as it would get considered a relative and not absolute filename (but it should get treated as an invalid filename).

There exists a [legacy feature](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html) in POSIX where an empty element (`a::b` or `a:b:`) is treated as the local directory, but a strict reading of the specification show that "a strictly conforming application shall use an actual pathname (such as .) to represent the current working directory in PATH."

It is common to use variable expension in defining `PYTHONPATH`, which will be empty under sh if not defined, so IMO, mypy should allow tests to get run even if it is weirdly definied.