### PR TITLE
Fixes order mismatch when comparing unions

### DIFF
--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -123,9 +123,18 @@ class SameTypeVisitor(TypeVisitor[bool]):
             return False
 
     def visit_union_type(self, left: UnionType) -> bool:
-        # XXX This is a test for syntactic equality, not equivalence
         if isinstance(self.right, UnionType):
-            return is_same_types(left.items, self.right.items)
+            # Check that everything in left is in right
+            for left_item in left.items:
+                if not any(is_same_type(left_item, right_item) for right_item in self.right.items):
+                    return False
+
+            # Check that everything in right is in left
+            for right_item in self.right.items:
+                if not any(is_same_type(right_item, left_item) for left_item in left.items):
+                    return False
+
+            return True
         else:
             return False
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -138,3 +138,33 @@ class C(Generic[T, U]):
 a = C() # type: C[int, int]
 b = a.f('a')
 a.f(b) # E: Argument 1 to "f" of "C" has incompatible type "int"; expected "str"
+
+[case testUnionOrderEquivalence]
+from typing import Union
+
+def foo(): pass
+
+S = str
+T = int
+
+if foo():
+    def f(x: Union[int, str]) -> None: pass
+elif foo():
+    def f(x: Union[str, int]) -> None: pass
+elif foo():
+    def f(x: Union[int, str, int, int, str]) -> None: pass
+elif foo():
+    def f(x: Union[int, str, float]) -> None: pass  # E: All conditional function variants must have identical signatures
+elif foo():
+    def f(x: Union[S, T]) -> None: pass
+elif foo():
+    def f(x: Union[str]) -> None: pass  # E: All conditional function variants must have identical signatures
+else:
+    def f(x: Union[Union[int, T], Union[S, T], str]) -> None: pass
+
+# Checks bidirectionality of testing. The first definition of g is consistent with
+# the second, but not vice-versa.
+if foo():
+    def g(x: Union[int, str, bytes]) -> None: pass
+else:
+    def g(x: Union[int, str]) -> None: pass  # E: All conditional function variants must have identical signatures


### PR DESCRIPTION
Addresses https://github.com/python/mypy/issues/2214

I realize using the stringified form as a key is in general a terrible idea, but I _believe_ that it works here (someone else feel free to confirm). I couldn't find any counter-examples in testing, and it makes sense since the signatures have to be __identical__ and all aliasing/sub-unions are already gone, so any differing stringified order implies differing value.

Of course the right™ thing to do is implement \_\_lt__ for every type in types.py, but that feels like extreme overkill to me. Input is appreciated.

Some other thoughts:
• `serialize` seems like a good way to sort, but neither dicts nor arbitrary values are sortable
• `messages.format` is another option, but that might cause collisions of non-similar types (ie two disjoint unions of more than 400 characters)
• It might make more sense to directly call `repr` rather than calling `str` and relying on that defaulting to `__repr__` for all Types.