### PR TITLE
Raise warning for possibly malformed asserts

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1678,7 +1678,7 @@ class TypeChecker(NodeVisitor[Type]):
 
         if self.options.fast_parser:
             if isinstance(s.expr, TupleExpr) and len(s.expr.items) > 0:
-                self.fail(messages.MALFORMED_ASSERT, s)
+                self.warn(messages.MALFORMED_ASSERT, s)
 
         # If this is asserting some isinstance check, bind that type in the following code
         true_map, _ = self.find_isinstance_check(s.expr)
@@ -2334,6 +2334,10 @@ class TypeChecker(NodeVisitor[Type]):
     def fail(self, msg: str, context: Context) -> None:
         """Produce an error message."""
         self.msg.fail(msg, context)
+
+    def warn(self, msg: str, context: Context) -> None:
+        """Produce a warning message."""
+        self.msg.warn(msg, context)
 
     def iterable_item_type(self, instance: Instance) -> Type:
         iterable = map_instance_to_supertype(

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1676,6 +1676,10 @@ class TypeChecker(NodeVisitor[Type]):
     def visit_assert_stmt(self, s: AssertStmt) -> Type:
         self.accept(s.expr)
 
+        if self.options.fast_parser:
+            if isinstance(s.expr, TupleExpr) and len(s.expr.items) > 0:
+                self.fail(messages.MALFORMED_ASSERT, s)
+
         # If this is asserting some isinstance check, bind that type in the following code
         true_map, _ = self.find_isinstance_check(s.expr)
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -158,7 +158,7 @@ class MessageBuilder:
 
     def note(self, msg: str, context: Context, file: str = None,
              origin: Context = None) -> None:
-        """Report an error message (unless disabled)."""
+        """Report a note (unless disabled)."""
         self.report(msg, context, 'note', file=file, origin=origin)
 
     def warn(self, msg: str, context: Context, file: str = None,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -76,6 +76,7 @@ INVALID_TYPEDDICT_ARGS = \
     'Expected keyword arguments, {...}, or dict(...) in TypedDict constructor'
 TYPEDDICT_ITEM_NAME_MUST_BE_STRING_LITERAL = \
     'Expected TypedDict item name to be string literal'
+MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'
 
 ARG_CONSTRUCTOR_NAMES = {
     ARG_POS: "Arg",

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -161,6 +161,11 @@ class MessageBuilder:
         """Report an error message (unless disabled)."""
         self.report(msg, context, 'note', file=file, origin=origin)
 
+    def warn(self, msg: str, context: Context, file: str = None,
+             origin: Context = None) -> None:
+        """Report a warning message (unless disabled)."""
+        self.report(msg, context, 'warning', file=file, origin=origin)
+
     def format(self, typ: Type, verbosity: int = 0) -> str:
         """Convert a type to a relatively short string that is suitable for error messages.
 

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -377,10 +377,15 @@ def expand_errors(input: List[str], output: List[str], fnam: str) -> None:
         # The first in the split things isn't a comment
         for possible_err_comment in input[i].split('#')[1:]:
             m = re.search(
-                '^([EN]):((?P<col>\d+):)? (?P<message>.*)$',
+                '^([ENW]):((?P<col>\d+):)? (?P<message>.*)$',
                 possible_err_comment.strip())
             if m:
-                severity = 'error' if m.group(1) == 'E' else 'note'
+                if m.group(1) == 'E':
+                    severity = 'error'
+                elif m.group(1) == 'N':
+                    severity = 'note'
+                elif m.group(1) == 'W':
+                    severity = 'warning'
                 col = m.group('col')
                 if col is None:
                     output.append(

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -203,6 +203,5 @@ def g():  # E: Type signature has too many arguments
 assert 1, 2
 assert (1, 2)  # W: Assertion is always true, perhaps remove parentheses?
 assert (1, 2), 3  # W: Assertion is always true, perhaps remove parentheses?
-# This seems correct, but Python raises a syntax warning for this case so we will too
 assert ()
 assert (1,)  # W: Assertion is always true, perhaps remove parentheses?

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -201,8 +201,8 @@ def g():  # E: Type signature has too many arguments
 [case testFastParseMalformedAssert]
 # flags: --fast-parser
 assert 1, 2
-assert (1, 2)  # E: Assertion is always true, perhaps remove parentheses?
-assert (1, 2), 3  # E: Assertion is always true, perhaps remove parentheses?
+assert (1, 2)  # W: Assertion is always true, perhaps remove parentheses?
+assert (1, 2), 3  # W: Assertion is always true, perhaps remove parentheses?
 # This seems correct, but Python raises a syntax warning for this case so we will too
 assert ()
-assert (1,)  # E: Assertion is always true, perhaps remove parentheses?
+assert (1,)  # W: Assertion is always true, perhaps remove parentheses?

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -197,3 +197,12 @@ def f(x):  # E: Type signature has too few arguments
 def g():  # E: Type signature has too many arguments
     # type: (int) -> None
     pass
+
+[case testFastParseMalformedAssert]
+# flags: --fast-parser
+assert 1, 2
+assert (1, 2)  # E: Assertion is always true, perhaps remove parentheses?
+assert (1, 2), 3  # E: Assertion is always true, perhaps remove parentheses?
+# This seems correct, but Python raises a syntax warning for this case so we will too
+assert ()
+assert (1,)  # E: Assertion is always true, perhaps remove parentheses?


### PR DESCRIPTION
Addresses https://github.com/python/mypy/issues/29
Low priority, but also a simple addition. Only works with fast parser, since the logic for the non-fast parser is more complicated, while it's trivial for the fast parser.