### PR TITLE
Change PyPI project name to simply `mypy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Mypy: Optional Static Typing for Python
 =======================================
 
 [![Build Status](https://travis-ci.org/python/mypy.svg)](https://travis-ci.org/python/mypy)
-[![Chat at https://gitter.im/python/mypy](https://badges.gitter.im/python/mypy.svg)](https://gitter.im/python/mypy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) 
+[![Chat at https://gitter.im/python/mypy](https://badges.gitter.im/python/mypy.svg)](https://gitter.im/python/mypy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
 Got a question? File an issue!
@@ -75,9 +75,7 @@ Quick start
 
 Mypy can be installed using pip:
 
-    $ python3 -m pip install -U mypy-lang
-
-*Note that the package name is `mypy-lang`, not `mypy`.*
+    $ python3 -m pip install -U mypy
 
 If you want to run the latest version of the code, you can install from git:
 
@@ -113,9 +111,7 @@ Troubleshooting
 Depending on your configuration, you may have to run `pip3` like
 this:
 
-    $ python3 -m pip install -U mypy-lang
-
-Double-check that you installed `mypy-lang`, not `mypy`.
+    $ python3 -m pip install -U mypy
 
 Except on Windows, it's best to always use the `--fast-parser`
 option to mypy; this requires installing `typed-ast`:

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -14,10 +14,9 @@ Can't install mypy using pip
 
 If installation fails, you've probably hit one of these issues:
 
-* The package name is **mypy-lang** -- *not* just mypy.
 * Mypy needs Python 3.3 or later to run.
 * You may have to run pip like this:
-  ``python3 -m pip install mypy-lang``.
+  ``python3 -m pip install mypy``.
 
 .. _annotations_needed:
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -10,9 +10,7 @@ Mypy requires Python 3.3 or later.  Once you've `installed Python 3 <https://www
 
 .. code-block:: text
 
-    $ python3 -m pip install mypy-lang
-
-Note that the package name is ``mypy-lang`` and not just ``mypy``, as unfortunately the ``mypy`` PyPI name is not available.
+    $ python3 -m pip install mypy
 
 Installing from source
 **********************

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ install_requires.append('typed-ast >= 0.6.3')
 if sys.version_info < (3, 5):
     install_requires.append('typing >= 3.5.3')
 
-setup(name='mypy-lang',
+setup(name='mypy',
       version=version,
       description=description,
       long_description=long_description,


### PR DESCRIPTION
Why: for people to be able to `pip install mypy`. The current name (`mypy-lang`) is not an obvious name on the package index, it was not discoverable and an endless support burden for new users installing the wrong package by mistake.

Following an extended investigation into what can be done, @dstufft and I decided to free the "mypy" name of PyPI. The arguments are clear. The project is not maintained, there's no website, there's no bug tracker, there's no public source repo for it, all means of contact with the author failed even though we independently tried for a year now. In all likelihood all continued downloads of that project are confused users of the type checker.

An official policy on how to deal with cases like these in the future will be established by a PEP that I'm writing.

I added @JukkaL, @lrem, and @gvanrossum as owners of the "mypy" package. I have archived the old files in case the author re-appears and needs them. I will need to delete them before we release 0.4.7 since they used 0.256 as the last version number... or we can publish the next release as mypy 1.0 to keep the existing packages there. Or we can use calver. Your call.