### PR TITLE
fix example of class hints in cheatsheet

### DIFF
--- a/docs/source/cheat_sheet.rst
+++ b/docs/source/cheat_sheet.rst
@@ -195,7 +195,7 @@ Classes
    class MyClass(object):
 
        # For instance methods, omit `self`.
-       def my_class_method(self, num, str1):
+       def my_method(self, num, str1):
            # type: (int, str) -> str
            return num * str1
 

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -181,7 +181,7 @@ Classes
        def __init__(self) -> None:
            ...
        # For instance methods, omit `self`.
-       def my_class_method(self, num: int, str1: str) -> str:
+       def my_method(self, num: int, str1: str) -> str:
            return num * str1
 
 


### PR DESCRIPTION
The example shows instance method, but method itself was named `my_class_method`, seems misleading (classmethod?).