### PR TITLE
Add ExpressionVisitor (refactoring)

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -9,7 +9,7 @@ from mypy.types import (
     PartialType, DeletedType, UnboundType, UninhabitedType, TypeType,
     true_only, false_only, is_named_instance, function_type, callable_type, FunctionLike,
     get_typ_args, set_typ_args,
-)
+    StarType)
 from mypy.nodes import (
     NameExpr, RefExpr, Var, FuncDef, OverloadedFuncDef, TypeInfo, CallExpr,
     MemberExpr, IntExpr, StrExpr, BytesExpr, UnicodeExpr, FloatExpr,
@@ -17,7 +17,8 @@ from mypy.nodes import (
     TupleExpr, DictExpr, FuncExpr, SuperExpr, SliceExpr, Context, Expression,
     ListComprehension, GeneratorExpr, SetExpr, MypyFile, Decorator,
     ConditionalExpr, ComparisonExpr, TempNode, SetComprehension,
-    DictionaryComprehension, ComplexExpr, EllipsisExpr, StarExpr,
+    DictionaryComprehension, ComplexExpr, EllipsisExpr, StarExpr, AwaitExpr, YieldExpr,
+    YieldFromExpr, TypedDictExpr, PromoteExpr, NewTypeExpr, NamedTupleExpr, TypeVarExpr,
     TypeAliasExpr, BackquoteExpr, ARG_POS, ARG_NAMED, ARG_STAR, ARG_STAR2, MODULE_REF,
     UNBOUND_TVAR, BOUND_TVAR,
 )
@@ -2041,35 +2042,150 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """
         self.chk.handle_cannot_determine_type(name, context)
 
-    def visit_star_expr(self, o: 'mypy.nodes.StarExpr') -> Type:
-        assert False
+    def visit_yield_expr(self, e: YieldExpr) -> Type:
+        return_type = self.chk.return_types[-1]
+        expected_item_type = self.chk.get_generator_yield_type(return_type, False)
+        if e.expr is None:
+            if (not isinstance(expected_item_type, (Void, NoneTyp, AnyType))
+                    and self.chk.in_checked_function()):
+                self.chk.fail(messages.YIELD_VALUE_EXPECTED, e)
+        else:
+            actual_item_type = self.accept(e.expr, expected_item_type)
+            self.chk.check_subtype(actual_item_type, expected_item_type, e,
+                                   messages.INCOMPATIBLE_TYPES_IN_YIELD,
+                                   'actual type', 'expected type')
+        return self.chk.get_generator_receive_type(return_type, False)
 
-    def visit_yield_from_expr(self, o: 'mypy.nodes.YieldFromExpr') -> Type:
-        assert False
+    def visit_await_expr(self, e: AwaitExpr) -> Type:
+        expected_type = self.chk.type_context[-1]
+        if expected_type is not None:
+            expected_type = self.chk.named_generic_type('typing.Awaitable', [expected_type])
+        actual_type = self.accept(e.expr, expected_type)
+        if isinstance(actual_type, AnyType):
+            return AnyType()
+        return self.check_awaitable_expr(actual_type, e, messages.INCOMPATIBLE_TYPES_IN_AWAIT)
 
-    def visit_typeddict_expr(self, o: 'mypy.nodes.TypedDictExpr') -> Type:
-        assert False
+    def check_awaitable_expr(self, t: Type, ctx: Context, msg: str) -> Type:
+        """Check the argument to `await` and extract the type of value.
 
-    def visit_temp_node(self, o: 'mypy.nodes.TempNode') -> Type:
-        assert False
+        Also used by `async for` and `async with`.
+        """
+        if not self.chk.check_subtype(t, self.named_type('typing.Awaitable'), ctx,
+                                      msg, 'actual type', 'expected type'):
+            return AnyType()
+        else:
+            method = self.analyze_external_member_access('__await__', t, ctx)
+            generator = self.check_call(method, [], [], ctx)[0]
+            return self.chk.get_generator_return_type(generator, False)
 
-    def visit_await_expr(self, o: 'mypy.nodes.AwaitExpr') -> Type:
-        assert False
+    def visit_yield_from_expr(self, e: YieldFromExpr) -> Type:
+        # NOTE: Whether `yield from` accepts an `async def` decorated
+        # with `@types.coroutine` (or `@asyncio.coroutine`) depends on
+        # whether the generator containing the `yield from` is itself
+        # thus decorated.  But it accepts a generator regardless of
+        # how it's decorated.
+        return_type = self.chk.return_types[-1]
+        subexpr_type = self.accept(e.expr, return_type)
+        iter_type = None  # type: Type
 
-    def visit__promote_expr(self, o: 'mypy.nodes.PromoteExpr') -> Type:
-        assert False
+        # Check that the expr is an instance of Iterable and get the type of the iterator produced
+        # by __iter__.
+        if isinstance(subexpr_type, AnyType):
+            iter_type = AnyType()
+        elif (isinstance(subexpr_type, Instance) and
+                is_subtype(subexpr_type, self.chk.named_type('typing.Iterable'))):
+            if is_async_def(subexpr_type) and not has_coroutine_decorator(return_type):
+                self.chk.msg.yield_from_invalid_operand_type(subexpr_type, e)
+            iter_method_type = self.analyze_external_member_access(
+                '__iter__',
+                subexpr_type,
+                AnyType())
 
-    def visit_newtype_expr(self, o: 'mypy.nodes.NewTypeExpr') -> Type:
-        assert False
+            generic_generator_type = self.chk.named_generic_type('typing.Generator',
+                                                                 [AnyType(), AnyType(), AnyType()])
+            iter_type, _ = self.check_call(iter_method_type, [], [],
+                                           context=generic_generator_type)
+        else:
+            if not (is_async_def(subexpr_type) and has_coroutine_decorator(return_type)):
+                self.chk.msg.yield_from_invalid_operand_type(subexpr_type, e)
+                iter_type = AnyType()
+            else:
+                iter_type = self.check_awaitable_expr(subexpr_type, e,
+                                                      messages.INCOMPATIBLE_TYPES_IN_YIELD_FROM)
 
-    def visit_namedtuple_expr(self, o: 'mypy.nodes.NamedTupleExpr') -> Type:
-        assert False
+        # Check that the iterator's item type matches the type yielded by the Generator function
+        # containing this `yield from` expression.
+        expected_item_type = self.chk.get_generator_yield_type(return_type, False)
+        actual_item_type = self.chk.get_generator_yield_type(iter_type, False)
 
-    def visit_type_var_expr(self, o: 'mypy.nodes.TypeVarExpr') -> Type:
-        assert False
+        self.chk.check_subtype(actual_item_type, expected_item_type, e,
+                           messages.INCOMPATIBLE_TYPES_IN_YIELD_FROM,
+                           'actual type', 'expected type')
 
-    def visit_yield_expr(self, o: 'mypy.nodes.YieldExpr') -> Type:
-        assert False
+        # Determine the type of the entire yield from expression.
+        if (isinstance(iter_type, Instance) and
+                iter_type.type.fullname() == 'typing.Generator'):
+            return self.chk.get_generator_return_type(iter_type, False)
+        else:
+            # Non-Generators don't return anything from `yield from` expressions.
+            # However special-case Any (which might be produced by an error).
+            if isinstance(actual_item_type, AnyType):
+                return AnyType()
+            else:
+                if experiments.STRICT_OPTIONAL:
+                    return NoneTyp(is_ret_type=True)
+                else:
+                    return Void()
+
+    def visit_temp_node(self, e: TempNode) -> Type:
+        return e.type
+
+    def visit_type_var_expr(self, e: TypeVarExpr) -> Type:
+        # TODO: Perhaps return a special type used for type variables only?
+        return AnyType()
+
+    def visit_newtype_expr(self, e: NewTypeExpr) -> Type:
+        return AnyType()
+
+    def visit_namedtuple_expr(self, e: NamedTupleExpr) -> Type:
+        # TODO: Perhaps return a type object type?
+        return AnyType()
+
+    def visit_typeddict_expr(self, e: TypedDictExpr) -> Type:
+        # TODO: Perhaps return a type object type?
+        return AnyType()
+
+    def visit__promote_expr(self, e: PromoteExpr) -> Type:
+        return e.type
+
+    def visit_star_expr(self, e: StarExpr) -> StarType:
+        return StarType(self.accept(e.expr))
+
+
+def has_coroutine_decorator(t: Type) -> bool:
+    """Whether t came from a function decorated with `@coroutine`."""
+    return isinstance(t, Instance) and t.type.fullname() == 'typing.AwaitableGenerator'
+
+
+def is_async_def(t: Type) -> bool:
+    """Whether t came from a function defined using `async def`."""
+    # In check_func_def(), when we see a function decorated with
+    # `@typing.coroutine` or `@async.coroutine`, we change the
+    # return type to typing.AwaitableGenerator[...], so that its
+    # type is compatible with either Generator or Awaitable.
+    # But for the check here we need to know whether the original
+    # function (before decoration) was an `async def`.  The
+    # AwaitableGenerator type conveniently preserves the original
+    # type as its 4th parameter (3rd when using 0-origin indexing
+    # :-), so that we can recover that information here.
+    # (We really need to see whether the original, undecorated
+    # function was an `async def`, which is orthogonal to its
+    # decorations.)
+    if (isinstance(t, Instance)
+            and t.type.fullname() == 'typing.AwaitableGenerator'
+            and len(t.args) >= 4):
+        t = t.args[3]
+    return isinstance(t, Instance) and t.type.fullname() == 'typing.Awaitable'
 
 
 def map_actuals_to_formals(caller_kinds: List[int],

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -40,6 +40,7 @@ from mypy.checkstrformat import StringFormatterChecker
 from mypy.expandtype import expand_type, expand_type_by_instance
 from mypy.util import split_module_names
 from mypy.semanal import fill_typevars
+from mypy.visitor import ExpressionVisitor
 
 from mypy import experiments
 
@@ -85,7 +86,7 @@ class Finished(Exception):
     """Raised if we can terminate overload argument check early (no match)."""
 
 
-class ExpressionChecker:
+class ExpressionChecker(ExpressionVisitor[Type]):
     """Expression type checker.
 
     This class works closely together with checker.TypeChecker.
@@ -2039,6 +2040,36 @@ class ExpressionChecker:
         pass or report an error.
         """
         self.chk.handle_cannot_determine_type(name, context)
+
+    def visit_star_expr(self, o: 'mypy.nodes.StarExpr') -> Type:
+        assert False
+
+    def visit_yield_from_expr(self, o: 'mypy.nodes.YieldFromExpr') -> Type:
+        assert False
+
+    def visit_typeddict_expr(self, o: 'mypy.nodes.TypedDictExpr') -> Type:
+        assert False
+
+    def visit_temp_node(self, o: 'mypy.nodes.TempNode') -> Type:
+        assert False
+
+    def visit_await_expr(self, o: 'mypy.nodes.AwaitExpr') -> Type:
+        assert False
+
+    def visit__promote_expr(self, o: 'mypy.nodes.PromoteExpr') -> Type:
+        assert False
+
+    def visit_newtype_expr(self, o: 'mypy.nodes.NewTypeExpr') -> Type:
+        assert False
+
+    def visit_namedtuple_expr(self, o: 'mypy.nodes.NamedTupleExpr') -> Type:
+        assert False
+
+    def visit_type_var_expr(self, o: 'mypy.nodes.TypeVarExpr') -> Type:
+        assert False
+
+    def visit_yield_expr(self, o: 'mypy.nodes.YieldExpr') -> Type:
+        assert False
 
 
 def map_actuals_to_formals(caller_kinds: List[int],

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -282,7 +282,7 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T]):
     def visit_exec_stmt(self, o: 'mypy.nodes.ExecStmt') -> T:
         pass
 
-    # expressions (default no-op implementation)
+    # Expressions (default no-op implementation)
 
     def visit_int_expr(self, o: 'mypy.nodes.IntExpr') -> T:
         pass

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -10,112 +10,7 @@ if False:
 T = TypeVar('T')
 
 
-class NodeVisitor(Generic[T]):
-    """Empty base class for parse tree node visitors.
-
-    The T type argument specifies the return type of the visit
-    methods. As all methods defined here return None by default,
-    subclasses do not always need to override all the methods.
-
-    TODO make the default return value explicit
-    """
-
-    # Module structure
-
-    def visit_mypy_file(self, o: 'mypy.nodes.MypyFile') -> T:
-        pass
-
-    def visit_import(self, o: 'mypy.nodes.Import') -> T:
-        pass
-
-    def visit_import_from(self, o: 'mypy.nodes.ImportFrom') -> T:
-        pass
-
-    def visit_import_all(self, o: 'mypy.nodes.ImportAll') -> T:
-        pass
-
-    # Definitions
-
-    def visit_func_def(self, o: 'mypy.nodes.FuncDef') -> T:
-        pass
-
-    def visit_overloaded_func_def(self,
-                                  o: 'mypy.nodes.OverloadedFuncDef') -> T:
-        pass
-
-    def visit_class_def(self, o: 'mypy.nodes.ClassDef') -> T:
-        pass
-
-    def visit_global_decl(self, o: 'mypy.nodes.GlobalDecl') -> T:
-        pass
-
-    def visit_nonlocal_decl(self, o: 'mypy.nodes.NonlocalDecl') -> T:
-        pass
-
-    def visit_decorator(self, o: 'mypy.nodes.Decorator') -> T:
-        pass
-
-    def visit_var(self, o: 'mypy.nodes.Var') -> T:
-        pass
-
-    # Statements
-
-    def visit_block(self, o: 'mypy.nodes.Block') -> T:
-        pass
-
-    def visit_expression_stmt(self, o: 'mypy.nodes.ExpressionStmt') -> T:
-        pass
-
-    def visit_assignment_stmt(self, o: 'mypy.nodes.AssignmentStmt') -> T:
-        pass
-
-    def visit_operator_assignment_stmt(self,
-                                       o: 'mypy.nodes.OperatorAssignmentStmt') -> T:
-        pass
-
-    def visit_while_stmt(self, o: 'mypy.nodes.WhileStmt') -> T:
-        pass
-
-    def visit_for_stmt(self, o: 'mypy.nodes.ForStmt') -> T:
-        pass
-
-    def visit_return_stmt(self, o: 'mypy.nodes.ReturnStmt') -> T:
-        pass
-
-    def visit_assert_stmt(self, o: 'mypy.nodes.AssertStmt') -> T:
-        pass
-
-    def visit_del_stmt(self, o: 'mypy.nodes.DelStmt') -> T:
-        pass
-
-    def visit_if_stmt(self, o: 'mypy.nodes.IfStmt') -> T:
-        pass
-
-    def visit_break_stmt(self, o: 'mypy.nodes.BreakStmt') -> T:
-        pass
-
-    def visit_continue_stmt(self, o: 'mypy.nodes.ContinueStmt') -> T:
-        pass
-
-    def visit_pass_stmt(self, o: 'mypy.nodes.PassStmt') -> T:
-        pass
-
-    def visit_raise_stmt(self, o: 'mypy.nodes.RaiseStmt') -> T:
-        pass
-
-    def visit_try_stmt(self, o: 'mypy.nodes.TryStmt') -> T:
-        pass
-
-    def visit_with_stmt(self, o: 'mypy.nodes.WithStmt') -> T:
-        pass
-
-    def visit_print_stmt(self, o: 'mypy.nodes.PrintStmt') -> T:
-        pass
-
-    def visit_exec_stmt(self, o: 'mypy.nodes.ExecStmt') -> T:
-        pass
-
-    # Expressions
+class ExpressionVisitor(Generic[T]):
 
     def visit_int_expr(self, o: 'mypy.nodes.IntExpr') -> T:
         pass
@@ -238,4 +133,110 @@ class NodeVisitor(Generic[T]):
         pass
 
     def visit_temp_node(self, o: 'mypy.nodes.TempNode') -> T:
+        pass
+
+
+class NodeVisitor(Generic[T], ExpressionVisitor[T]):
+    """Empty base class for parse tree node visitors.
+
+    The T type argument specifies the return type of the visit
+    methods. As all methods defined here return None by default,
+    subclasses do not always need to override all the methods.
+
+    TODO make the default return value explicit
+    """
+
+    # Module structure
+
+    def visit_mypy_file(self, o: 'mypy.nodes.MypyFile') -> T:
+        pass
+
+    def visit_import(self, o: 'mypy.nodes.Import') -> T:
+        pass
+
+    def visit_import_from(self, o: 'mypy.nodes.ImportFrom') -> T:
+        pass
+
+    def visit_import_all(self, o: 'mypy.nodes.ImportAll') -> T:
+        pass
+
+    # Definitions
+
+    def visit_func_def(self, o: 'mypy.nodes.FuncDef') -> T:
+        pass
+
+    def visit_overloaded_func_def(self,
+                                  o: 'mypy.nodes.OverloadedFuncDef') -> T:
+        pass
+
+    def visit_class_def(self, o: 'mypy.nodes.ClassDef') -> T:
+        pass
+
+    def visit_global_decl(self, o: 'mypy.nodes.GlobalDecl') -> T:
+        pass
+
+    def visit_nonlocal_decl(self, o: 'mypy.nodes.NonlocalDecl') -> T:
+        pass
+
+    def visit_decorator(self, o: 'mypy.nodes.Decorator') -> T:
+        pass
+
+    def visit_var(self, o: 'mypy.nodes.Var') -> T:
+        pass
+
+    # Statements
+
+    def visit_block(self, o: 'mypy.nodes.Block') -> T:
+        pass
+
+    def visit_expression_stmt(self, o: 'mypy.nodes.ExpressionStmt') -> T:
+        pass
+
+    def visit_assignment_stmt(self, o: 'mypy.nodes.AssignmentStmt') -> T:
+        pass
+
+    def visit_operator_assignment_stmt(self,
+                                       o: 'mypy.nodes.OperatorAssignmentStmt') -> T:
+        pass
+
+    def visit_while_stmt(self, o: 'mypy.nodes.WhileStmt') -> T:
+        pass
+
+    def visit_for_stmt(self, o: 'mypy.nodes.ForStmt') -> T:
+        pass
+
+    def visit_return_stmt(self, o: 'mypy.nodes.ReturnStmt') -> T:
+        pass
+
+    def visit_assert_stmt(self, o: 'mypy.nodes.AssertStmt') -> T:
+        pass
+
+    def visit_del_stmt(self, o: 'mypy.nodes.DelStmt') -> T:
+        pass
+
+    def visit_if_stmt(self, o: 'mypy.nodes.IfStmt') -> T:
+        pass
+
+    def visit_break_stmt(self, o: 'mypy.nodes.BreakStmt') -> T:
+        pass
+
+    def visit_continue_stmt(self, o: 'mypy.nodes.ContinueStmt') -> T:
+        pass
+
+    def visit_pass_stmt(self, o: 'mypy.nodes.PassStmt') -> T:
+        pass
+
+    def visit_raise_stmt(self, o: 'mypy.nodes.RaiseStmt') -> T:
+        pass
+
+    def visit_try_stmt(self, o: 'mypy.nodes.TryStmt') -> T:
+        pass
+
+    def visit_with_stmt(self, o: 'mypy.nodes.WithStmt') -> T:
+        pass
+
+    def visit_print_stmt(self, o: 'mypy.nodes.PrintStmt') -> T:
+        pass
+
+    def visit_exec_stmt(self, o: 'mypy.nodes.ExecStmt') -> T:
         pass

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -1,5 +1,6 @@
 """Generic abstract syntax tree node visitor"""
 
+from abc import abstractmethod
 from typing import TypeVar, Generic
 
 if False:
@@ -11,6 +12,277 @@ T = TypeVar('T')
 
 
 class ExpressionVisitor(Generic[T]):
+    @abstractmethod
+    def visit_int_expr(self, o: 'mypy.nodes.IntExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_str_expr(self, o: 'mypy.nodes.StrExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_bytes_expr(self, o: 'mypy.nodes.BytesExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_unicode_expr(self, o: 'mypy.nodes.UnicodeExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_float_expr(self, o: 'mypy.nodes.FloatExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_complex_expr(self, o: 'mypy.nodes.ComplexExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_ellipsis(self, o: 'mypy.nodes.EllipsisExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_star_expr(self, o: 'mypy.nodes.StarExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_name_expr(self, o: 'mypy.nodes.NameExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_member_expr(self, o: 'mypy.nodes.MemberExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_yield_from_expr(self, o: 'mypy.nodes.YieldFromExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_yield_expr(self, o: 'mypy.nodes.YieldExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_call_expr(self, o: 'mypy.nodes.CallExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_op_expr(self, o: 'mypy.nodes.OpExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_comparison_expr(self, o: 'mypy.nodes.ComparisonExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_cast_expr(self, o: 'mypy.nodes.CastExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_reveal_type_expr(self, o: 'mypy.nodes.RevealTypeExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_super_expr(self, o: 'mypy.nodes.SuperExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_unary_expr(self, o: 'mypy.nodes.UnaryExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_list_expr(self, o: 'mypy.nodes.ListExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_dict_expr(self, o: 'mypy.nodes.DictExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_tuple_expr(self, o: 'mypy.nodes.TupleExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_set_expr(self, o: 'mypy.nodes.SetExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_index_expr(self, o: 'mypy.nodes.IndexExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_type_application(self, o: 'mypy.nodes.TypeApplication') -> T:
+        pass
+
+    @abstractmethod
+    def visit_func_expr(self, o: 'mypy.nodes.FuncExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_list_comprehension(self, o: 'mypy.nodes.ListComprehension') -> T:
+        pass
+
+    @abstractmethod
+    def visit_set_comprehension(self, o: 'mypy.nodes.SetComprehension') -> T:
+        pass
+
+    @abstractmethod
+    def visit_dictionary_comprehension(self, o: 'mypy.nodes.DictionaryComprehension') -> T:
+        pass
+
+    @abstractmethod
+    def visit_generator_expr(self, o: 'mypy.nodes.GeneratorExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_slice_expr(self, o: 'mypy.nodes.SliceExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_conditional_expr(self, o: 'mypy.nodes.ConditionalExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_backquote_expr(self, o: 'mypy.nodes.BackquoteExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_type_var_expr(self, o: 'mypy.nodes.TypeVarExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_type_alias_expr(self, o: 'mypy.nodes.TypeAliasExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_namedtuple_expr(self, o: 'mypy.nodes.NamedTupleExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_typeddict_expr(self, o: 'mypy.nodes.TypedDictExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_newtype_expr(self, o: 'mypy.nodes.NewTypeExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit__promote_expr(self, o: 'mypy.nodes.PromoteExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_await_expr(self, o: 'mypy.nodes.AwaitExpr') -> T:
+        pass
+
+    @abstractmethod
+    def visit_temp_node(self, o: 'mypy.nodes.TempNode') -> T:
+        pass
+
+
+class NodeVisitor(Generic[T], ExpressionVisitor[T]):
+    """Empty base class for parse tree node visitors.
+
+    The T type argument specifies the return type of the visit
+    methods. As all methods defined here return None by default,
+    subclasses do not always need to override all the methods.
+
+    TODO make the default return value explicit
+    """
+
+    # Module structure
+
+    def visit_mypy_file(self, o: 'mypy.nodes.MypyFile') -> T:
+        pass
+
+    def visit_import(self, o: 'mypy.nodes.Import') -> T:
+        pass
+
+    def visit_import_from(self, o: 'mypy.nodes.ImportFrom') -> T:
+        pass
+
+    def visit_import_all(self, o: 'mypy.nodes.ImportAll') -> T:
+        pass
+
+    # Definitions
+
+    def visit_func_def(self, o: 'mypy.nodes.FuncDef') -> T:
+        pass
+
+    def visit_overloaded_func_def(self,
+                                  o: 'mypy.nodes.OverloadedFuncDef') -> T:
+        pass
+
+    def visit_class_def(self, o: 'mypy.nodes.ClassDef') -> T:
+        pass
+
+    def visit_global_decl(self, o: 'mypy.nodes.GlobalDecl') -> T:
+        pass
+
+    def visit_nonlocal_decl(self, o: 'mypy.nodes.NonlocalDecl') -> T:
+        pass
+
+    def visit_decorator(self, o: 'mypy.nodes.Decorator') -> T:
+        pass
+
+    def visit_var(self, o: 'mypy.nodes.Var') -> T:
+        pass
+
+    # Statements
+
+    def visit_block(self, o: 'mypy.nodes.Block') -> T:
+        pass
+
+    def visit_expression_stmt(self, o: 'mypy.nodes.ExpressionStmt') -> T:
+        pass
+
+    def visit_assignment_stmt(self, o: 'mypy.nodes.AssignmentStmt') -> T:
+        pass
+
+    def visit_operator_assignment_stmt(self,
+                                       o: 'mypy.nodes.OperatorAssignmentStmt') -> T:
+        pass
+
+    def visit_while_stmt(self, o: 'mypy.nodes.WhileStmt') -> T:
+        pass
+
+    def visit_for_stmt(self, o: 'mypy.nodes.ForStmt') -> T:
+        pass
+
+    def visit_return_stmt(self, o: 'mypy.nodes.ReturnStmt') -> T:
+        pass
+
+    def visit_assert_stmt(self, o: 'mypy.nodes.AssertStmt') -> T:
+        pass
+
+    def visit_del_stmt(self, o: 'mypy.nodes.DelStmt') -> T:
+        pass
+
+    def visit_if_stmt(self, o: 'mypy.nodes.IfStmt') -> T:
+        pass
+
+    def visit_break_stmt(self, o: 'mypy.nodes.BreakStmt') -> T:
+        pass
+
+    def visit_continue_stmt(self, o: 'mypy.nodes.ContinueStmt') -> T:
+        pass
+
+    def visit_pass_stmt(self, o: 'mypy.nodes.PassStmt') -> T:
+        pass
+
+    def visit_raise_stmt(self, o: 'mypy.nodes.RaiseStmt') -> T:
+        pass
+
+    def visit_try_stmt(self, o: 'mypy.nodes.TryStmt') -> T:
+        pass
+
+    def visit_with_stmt(self, o: 'mypy.nodes.WithStmt') -> T:
+        pass
+
+    def visit_print_stmt(self, o: 'mypy.nodes.PrintStmt') -> T:
+        pass
+
+    def visit_exec_stmt(self, o: 'mypy.nodes.ExecStmt') -> T:
+        pass
+
+    # expressions (default no-op implementation)
 
     def visit_int_expr(self, o: 'mypy.nodes.IntExpr') -> T:
         pass
@@ -133,110 +405,4 @@ class ExpressionVisitor(Generic[T]):
         pass
 
     def visit_temp_node(self, o: 'mypy.nodes.TempNode') -> T:
-        pass
-
-
-class NodeVisitor(Generic[T], ExpressionVisitor[T]):
-    """Empty base class for parse tree node visitors.
-
-    The T type argument specifies the return type of the visit
-    methods. As all methods defined here return None by default,
-    subclasses do not always need to override all the methods.
-
-    TODO make the default return value explicit
-    """
-
-    # Module structure
-
-    def visit_mypy_file(self, o: 'mypy.nodes.MypyFile') -> T:
-        pass
-
-    def visit_import(self, o: 'mypy.nodes.Import') -> T:
-        pass
-
-    def visit_import_from(self, o: 'mypy.nodes.ImportFrom') -> T:
-        pass
-
-    def visit_import_all(self, o: 'mypy.nodes.ImportAll') -> T:
-        pass
-
-    # Definitions
-
-    def visit_func_def(self, o: 'mypy.nodes.FuncDef') -> T:
-        pass
-
-    def visit_overloaded_func_def(self,
-                                  o: 'mypy.nodes.OverloadedFuncDef') -> T:
-        pass
-
-    def visit_class_def(self, o: 'mypy.nodes.ClassDef') -> T:
-        pass
-
-    def visit_global_decl(self, o: 'mypy.nodes.GlobalDecl') -> T:
-        pass
-
-    def visit_nonlocal_decl(self, o: 'mypy.nodes.NonlocalDecl') -> T:
-        pass
-
-    def visit_decorator(self, o: 'mypy.nodes.Decorator') -> T:
-        pass
-
-    def visit_var(self, o: 'mypy.nodes.Var') -> T:
-        pass
-
-    # Statements
-
-    def visit_block(self, o: 'mypy.nodes.Block') -> T:
-        pass
-
-    def visit_expression_stmt(self, o: 'mypy.nodes.ExpressionStmt') -> T:
-        pass
-
-    def visit_assignment_stmt(self, o: 'mypy.nodes.AssignmentStmt') -> T:
-        pass
-
-    def visit_operator_assignment_stmt(self,
-                                       o: 'mypy.nodes.OperatorAssignmentStmt') -> T:
-        pass
-
-    def visit_while_stmt(self, o: 'mypy.nodes.WhileStmt') -> T:
-        pass
-
-    def visit_for_stmt(self, o: 'mypy.nodes.ForStmt') -> T:
-        pass
-
-    def visit_return_stmt(self, o: 'mypy.nodes.ReturnStmt') -> T:
-        pass
-
-    def visit_assert_stmt(self, o: 'mypy.nodes.AssertStmt') -> T:
-        pass
-
-    def visit_del_stmt(self, o: 'mypy.nodes.DelStmt') -> T:
-        pass
-
-    def visit_if_stmt(self, o: 'mypy.nodes.IfStmt') -> T:
-        pass
-
-    def visit_break_stmt(self, o: 'mypy.nodes.BreakStmt') -> T:
-        pass
-
-    def visit_continue_stmt(self, o: 'mypy.nodes.ContinueStmt') -> T:
-        pass
-
-    def visit_pass_stmt(self, o: 'mypy.nodes.PassStmt') -> T:
-        pass
-
-    def visit_raise_stmt(self, o: 'mypy.nodes.RaiseStmt') -> T:
-        pass
-
-    def visit_try_stmt(self, o: 'mypy.nodes.TryStmt') -> T:
-        pass
-
-    def visit_with_stmt(self, o: 'mypy.nodes.WithStmt') -> T:
-        pass
-
-    def visit_print_stmt(self, o: 'mypy.nodes.PrintStmt') -> T:
-        pass
-
-    def visit_exec_stmt(self, o: 'mypy.nodes.ExecStmt') -> T:
         pass


### PR DESCRIPTION
Added a class ExpressionVisitor with abstract methods (NodeVisitor implements it with defaults). ExpressionChecker implements it; some relevant methods moved from TypedChecker.

I did not yet removed the delegating methods from TypeChecker, but I don't think it should be hard.