### PR TITLE
Allow unicode docstrings in Python 2

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -75,7 +75,7 @@ inverse_node_kinds = {_kind: _name for _name, _kind in node_kinds.items()}
 
 
 implicit_module_attrs = {'__name__': '__builtins__.str',
-                         '__doc__': '__builtins__.str',
+                         '__doc__': None,  # depends on Python version, see semanal.py
                          '__file__': '__builtins__.str',
                          '__package__': '__builtins__.str'}
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2828,7 +2828,16 @@ class FirstPass(NodeVisitor):
 
         # Add implicit definitions of module '__name__' etc.
         for name, t in implicit_module_attrs.items():
-            v = Var(name, UnboundType(t))
+            # Issue #2471: unicode docstrings should be accepted in Python 2
+            if name == '__doc__':
+                if self.pyversion < (3, 0):
+                    typ = UnionType([UnboundType('__builtins__.str'),
+                                     UnboundType('__builtins__.unicode')])
+                else:
+                    typ = UnboundType('__builtins__.str')
+            else:
+                typ = UnboundType(t)
+            v = Var(name, typ)
             v._fullname = self.sem.qualified_name(name)
             self.sem.globals[name] = SymbolTableNode(GDEF, v, self.sem.cur_mod_id)
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2830,11 +2830,11 @@ class FirstPass(NodeVisitor):
         for name, t in implicit_module_attrs.items():
             # Issue #2471: unicode docstrings should be accepted in Python 2
             if name == '__doc__':
-                if self.pyversion < (3, 0):
+                if self.pyversion >= (3, 0):
+                    typ = UnboundType('__builtins__.str')  # type: Type
+                else:
                     typ = UnionType([UnboundType('__builtins__.str'),
                                      UnboundType('__builtins__.unicode')])
-                else:
-                    typ = UnboundType('__builtins__.str')
             else:
                 typ = UnboundType(t)
             v = Var(name, typ)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2828,7 +2828,7 @@ class FirstPass(NodeVisitor):
 
         # Add implicit definitions of module '__name__' etc.
         for name, t in implicit_module_attrs.items():
-            # Issue #2471: unicode docstrings should be accepted in Python 2
+            # unicode docstrings should be accepted in Python 2
             if name == '__doc__':
                 if self.pyversion >= (3, 0):
                     typ = UnboundType('__builtins__.str')  # type: Type
@@ -2836,6 +2836,7 @@ class FirstPass(NodeVisitor):
                     typ = UnionType([UnboundType('__builtins__.str'),
                                      UnboundType('__builtins__.unicode')])
             else:
+                assert t is not None, 'type should be specified for {}'.format(name)
                 typ = UnboundType(t)
             v = Var(name, typ)
             v._fullname = self.sem.qualified_name(name)

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -229,3 +229,14 @@ class Foo: pass
 
 [case testExec]
 exec('print 1 + 1')
+
+[case testUnicodeDocStrings]
+# flags: --python-version=2.7
+__doc__ = u"unicode"
+
+class A:
+    u"unicode"
+
+def f():
+    # type: () -> None
+    u"unicode"

--- a/test-data/unit/fixtures/bool.pyi
+++ b/test-data/unit/fixtures/bool.pyi
@@ -12,3 +12,4 @@ class function: pass
 class bool: pass
 class int: pass
 class str: pass
+class unicode: pass

--- a/test-data/unit/fixtures/dict.pyi
+++ b/test-data/unit/fixtures/dict.pyi
@@ -24,6 +24,7 @@ class int: # for convenience
     def __add__(self, x: int) -> int: pass
 
 class str: pass # for keyword argument key type
+class unicode: pass # needed for py2 docstrings
 
 class list(Iterable[T], Generic[T]): # needed by some test cases
     def __iter__(self) -> Iterator[T]: pass

--- a/test-data/unit/fixtures/exception.pyi
+++ b/test-data/unit/fixtures/exception.pyi
@@ -7,6 +7,7 @@ class tuple: pass
 class function: pass
 class int: pass
 class str: pass
+class unicode: pass
 class bool: pass
 
 class BaseException: pass

--- a/test-data/unit/fixtures/ops.pyi
+++ b/test-data/unit/fixtures/ops.pyi
@@ -32,6 +32,8 @@ class str:
     def __add__(self, x: 'str') -> 'str': pass
     def startswith(self, x: 'str') -> bool: pass
 
+class unicode: pass
+
 class int:
     def __add__(self, x: 'int') -> 'int': pass
     def __sub__(self, x: 'int') -> 'int': pass

--- a/test-data/unit/fixtures/staticmethod.pyi
+++ b/test-data/unit/fixtures/staticmethod.pyi
@@ -15,4 +15,5 @@ class int:
     def from_bytes(bytes: bytes, byteorder: str) -> int: pass
 
 class str: pass
+class unicode: pass
 class bytes: pass

--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -19,6 +19,7 @@ class function: pass
 class int: pass
 class bool: pass
 class str: pass # For convenience
+class unicode: pass
 
 T = TypeVar('T')
 


### PR DESCRIPTION
This adds runtime logic to figure out the type of `__doc__` depending on the version. To make this clear, I removed `__doc__`'s type from `implicit_module_attrs`. As a consequence, all test cases that use Python 2 now have to define `unicode` in their fixture.

Closes #2471 