### PR TITLE
Add support for `__getattribute__`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -572,7 +572,7 @@ class TypeChecker(NodeVisitor[Type]):
 
                 if name in nodes.reverse_op_method_set:
                     self.check_reverse_op_method(item, typ, name)
-                elif name == '__getattr__':
+                elif name in ('__getattr__', '__getattribute__'):
                     self.check_getattr_method(typ, defn)
 
                 # Refuse contravariant return type variable

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -222,6 +222,9 @@ def analyze_member_var_access(name: str, itype: Instance, info: TypeInfo,
         if not is_lvalue:
             for method_name in ('__getattribute__', '__getattr__'):
                 method = info.get_method(method_name)
+                # __getattribute__ is defined on builtins.object and returns Any, so without
+                # the guard this search will always find object.__getattribute__ and conclude
+                # that the attribute exists
                 if method and method.info.fullname() != 'builtins.object':
                     function = function_type(method, builtin_type('builtins.function'))
                     bound_method = bind_self(function, original_type)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -222,7 +222,7 @@ def analyze_member_var_access(name: str, itype: Instance, info: TypeInfo,
         if not is_lvalue:
             for method_name in ('__getattribute__', '__getattr__'):
                 method = info.get_method(method_name)
-                if method:
+                if method and method.info.fullname() != 'builtins.object':
                     function = function_type(method, builtin_type('builtins.function'))
                     bound_method = bind_self(function, original_type)
                     typ = map_instance_to_supertype(itype, method.info)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -218,16 +218,17 @@ def analyze_member_var_access(name: str, itype: Instance, info: TypeInfo,
                            original_type, not_ready_callback)
     elif isinstance(v, FuncDef):
         assert False, "Did not expect a function"
-    elif not v and name not in ['__getattr__', '__setattr__']:
+    elif not v and name not in ['__getattr__', '__setattr__', '__getattribute__']:
         if not is_lvalue:
-            method = info.get_method('__getattr__')
-            if method:
-                function = function_type(method, builtin_type('builtins.function'))
-                bound_method = bind_self(function, original_type)
-                typ = map_instance_to_supertype(itype, method.info)
-                getattr_type = expand_type_by_instance(bound_method, typ)
-                if isinstance(getattr_type, CallableType):
-                    return getattr_type.ret_type
+            for method_name in ('__getattribute__', '__getattr__'):
+                method = info.get_method(method_name)
+                if method:
+                    function = function_type(method, builtin_type('builtins.function'))
+                    bound_method = bind_self(function, original_type)
+                    typ = map_instance_to_supertype(itype, method.info)
+                    getattr_type = expand_type_by_instance(bound_method, typ)
+                    if isinstance(getattr_type, CallableType):
+                        return getattr_type.ret_type
 
     if itype.type.fallback_to_any:
         return AnyType()

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1533,6 +1533,31 @@ main:6: error: Return type of "__iadd__" incompatible with "__add__" of supertyp
 main:8: error: Argument 1 of "__iadd__" incompatible with "__add__" of supertype "A"
 main:8: error: Signatures of "__iadd__" and "__add__" are incompatible
 
+[case testGetAttribute]
+
+a, b = None, None # type: A, B
+class A:
+    def __getattribute__(self, x: str) -> A:
+        return A()
+class B: pass
+
+a = a.foo
+b = a.bar
+[out]
+main:9: error: Incompatible types in assignment (expression has type "A", variable has type "B")
+
+[case testGetAttributeSignature]
+class A:
+    def __getattribute__(self, x: str) -> A: pass
+class B:
+    def __getattribute__(self, x: A) -> B: pass
+class C:
+    def __getattribute__(self, x: str, y: str) -> C: pass
+class D:
+    def __getattribute__(self, x: str) -> None: pass
+[out]
+main:4: error: Invalid signature "def (__main__.B, __main__.A) -> __main__.B"
+main:6: error: Invalid signature "def (__main__.C, builtins.str, builtins.str) -> __main__.C"
 
 [case testGetAttr]
 


### PR DESCRIPTION
Similar to `__getattr__`, this special-cases classes with `__getattribute__`.

There doesn't seem to be an open issue about this but #2581 mentions that `__getattribute__` needs to be special-cased.