### PR TITLE
Fix `--warn-no-return` for async def functions

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -654,7 +654,7 @@ class TypeChecker(NodeVisitor[Type]):
 
             if (self.options.warn_no_return and not unreachable
                     and not isinstance(self.return_types[-1], (Void, NoneTyp, AnyType))
-                    and not defn.is_generator):
+                    and (defn.is_coroutine or not defn.is_generator)):
                 # Control flow fell off the end of a function that was
                 # declared to return a non-None type.
                 # Allow functions that are entirely pass/Ellipsis.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1633,8 +1633,9 @@ class TypeChecker(NodeVisitor[Type]):
                         context=s,
                         msg=messages.INCOMPATIBLE_RETURN_VALUE_TYPE)
             else:
-                # Empty returns are valid in Generators with Any typed returns.
-                if (defn.is_generator and isinstance(return_type, AnyType)):
+                # Empty returns are valid in Generators with Any typed returns, but not in
+                # coroutines.
+                if (defn.is_generator and not defn.is_coroutine and isinstance(return_type, AnyType)):
                     return
 
                 if isinstance(return_type, (Void, NoneTyp, AnyType)):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1635,7 +1635,8 @@ class TypeChecker(NodeVisitor[Type]):
             else:
                 # Empty returns are valid in Generators with Any typed returns, but not in
                 # coroutines.
-                if (defn.is_generator and not defn.is_coroutine and isinstance(return_type, AnyType)):
+                if (defn.is_generator and not defn.is_coroutine and
+                        isinstance(return_type, AnyType)):
                     return
 
                 if isinstance(return_type, (Void, NoneTyp, AnyType)):

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -22,6 +22,15 @@ async def f() -> int:
 [out]
 main:2: note: Missing return statement
 
+[case testAsyncDefReturnWithoutValue]
+# flags: --fast-parser
+async def f() -> int:
+    make_this_not_trivial = 1
+    return
+[builtins fixtures/async_await.pyi]
+[out]
+main:4: error: Return value expected
+
 [case testAwaitCoroutine]
 # flags: --fast-parser
 async def f() -> int:

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -14,6 +14,14 @@ async def f() -> int:
 reveal_type(f())  # E: Revealed type is 'typing.Awaitable[builtins.int]'
 [builtins fixtures/async_await.pyi]
 
+[case testAsyncDefMissingReturn]
+# flags: --fast-parser --warn-no-return
+async def f() -> int:
+    make_this_not_trivial = 1
+[builtins fixtures/async_await.pyi]
+[out]
+main:2: note: Missing return statement
+
 [case testAwaitCoroutine]
 # flags: --fast-parser
 async def f() -> int:


### PR DESCRIPTION
Because mypy still considers async def functions to be generators internally, the `--warn-no-return` flag inadvertently skips missing returns in async def functions.

This bug actually caused mypy to miss a number of my issues in my own code.