### PR TITLE
Propagate type context through reveal_type

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1513,7 +1513,7 @@ class ExpressionChecker:
 
     def visit_reveal_type_expr(self, expr: RevealTypeExpr) -> Type:
         """Type check a reveal_type expression."""
-        revealed_type = self.accept(expr.expr)
+        revealed_type = self.accept(expr.expr, context=self.chk.type_context[-1])
         if not self.chk.current_node_deferred:
             self.msg.reveal_type(revealed_type, expr)
         return revealed_type

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -818,3 +818,11 @@ class A(Generic[T]):
 [out]
 main:6: error: Incompatible types in assignment (expression has type Callable[[T], T], variable has type Callable[[T], S])
 main:6: error: Incompatible return value type (got "T", expected "S")
+
+[case testRevealTypeContext]
+from typing import TypeVar, Callable, Generic
+T = TypeVar('T')
+class A(Generic[T]):
+    pass
+reveal_type(A()) # E: Revealed type is '__main__.A[builtins.None]'
+b = reveal_type(A())  # type: A[int] # E: Revealed type is '__main__.A[builtins.int]'


### PR DESCRIPTION
Previously using `reveal_type` could change inferred types and cause type errors.