### PR TITLE
Fix pytest warning about cov

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,3 @@
 pytest_plugins = [
     'mypy.test.data',
-    'pytest_cov',
 ]


### PR DESCRIPTION
Without this I get a pytest warning about cov every time I run it.
The cov plugin still gets loaded and I can still generate coverage
reports, so I assume that the coverage plugin is loaded
automatically. Not sure if we should require a more recent pytest
version.

This is what the warning looked like:

```
======================= pytest-warning summary ========================
WP1 None Module already imported so can not be re-written: pytest_cov
```