### PR TITLE
Fix make_simplified_union interaction with Any

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -25,9 +25,19 @@ def meet_types(s: Type, t: Type) -> Type:
     return t.accept(TypeMeetVisitor(s))
 
 
-def meet_simple(s: Type, t: Type, default_right: bool = True) -> Type:
+def meet_simple(s: Type, t: Type) -> Type:
+    """Return the type s "narrowed down" to t.
+
+    Note that this is not symmetric with respect to s and t.
+
+    TODO: Explain what this does in more detail and how this is
+          different from meet_types.
+    """
     if s == t:
         return s
+    if isinstance(t, AnyType):
+        # Anything can be narrowed down to Any.
+        return t
     if isinstance(s, UnionType):
         return UnionType.make_simplified_union([meet_types(x, t) for x in s.items])
     elif not is_overlapping_types(s, t, use_promotions=True):
@@ -36,10 +46,7 @@ def meet_simple(s: Type, t: Type, default_right: bool = True) -> Type:
         else:
             return NoneTyp()
     else:
-        if default_right:
-            return t
-        else:
-            return s
+        return t
 
 
 def is_overlapping_types(t: Type, s: Type, use_promotions: bool = False) -> bool:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -141,6 +141,9 @@ class MessageBuilder:
     def is_errors(self) -> bool:
         return self.errors.is_errors()
 
+    def num_messages(self) -> int:
+        return self.errors.num_messages()
+
     def report(self, msg: str, context: Context, severity: str,
                file: str = None, origin: Context = None) -> None:
         """Report an error or note (unless disabled)."""

--- a/test-data/unit/check-dynamic-typing.test
+++ b/test-data/unit/check-dynamic-typing.test
@@ -79,8 +79,8 @@ n = 0
 d in a  # E: Unsupported right operand type for in ("A")
 d and a
 d or a
-c = d and b # Unintuitive type inference?
-c = d or b  # Unintuitive type inference?
+c = d and b # E: Incompatible types in assignment (expression has type "Union[Any, bool]", variable has type "C")
+c = d or b  # E: Incompatible types in assignment (expression has type "Union[Any, bool]", variable has type "C")
 
 c = d + a
 c = d - a
@@ -123,8 +123,8 @@ n = 0
 a and d
 a or d
 c = a in d
-c = b and d # Unintuitive type inference?
-c = b or d  # Unintuitive type inference?
+c = b and d # E: Incompatible types in assignment (expression has type "Union[bool, Any]", variable has type "C")
+c = b or d  # E: Incompatible types in assignment (expression has type "Union[bool, Any]", variable has type "C")
 b = a + d
 b = a / d
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -777,7 +777,7 @@ if not isinstance(s, str):
 
 z = None # type: TNode # Same as TNode[Any]
 z.x
-z.foo() # Any simplifies Union to Any now. This test should be updated after #2197
+z.foo() # E: Some element of union has no attribute "foo"
 
 [builtins fixtures/isinstance.pyi]
 

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -525,3 +525,26 @@ f = None # type: Optional[Callable[[int], None]]
 f = lambda x: None
 f(0)
 [builtins fixtures/function.pyi]
+
+[case testOptionalAndAnyBaseClass]
+from typing import Any, Optional
+class C(Any):
+    pass
+x = None  # type: Optional[C]
+x.foo()  # E: Some element of union has no attribute "foo"
+
+[case testUnionSimplificationWithStrictOptional]
+from typing import Any, TypeVar, Union
+class C(Any): pass
+T = TypeVar('T')
+S = TypeVar('S')
+def u(x: T, y: S) -> Union[S, T]: pass
+a = None # type: Any
+
+# Test both orders
+reveal_type(u(C(), None))  # E: Revealed type is 'Union[builtins.None, __main__.C*]'
+reveal_type(u(None, C()))  # E: Revealed type is 'Union[__main__.C*, builtins.None]'
+reveal_type(u(a, None))  # E: Revealed type is 'Union[builtins.None, Any]'
+reveal_type(u(None, a))  # E: Revealed type is 'Union[Any, builtins.None]'
+reveal_type(u(1, None))  # E: Revealed type is 'Union[builtins.None, builtins.int*]'
+reveal_type(u(None, 1))  # E: Revealed type is 'Union[builtins.int*, builtins.None]'

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -630,11 +630,11 @@ try:
 except BaseException as e1:
     reveal_type(e1)  # E: Revealed type is 'builtins.BaseException'
 except (E1, BaseException) as e2:
-    reveal_type(e2)  # E: Revealed type is 'Any'
+    reveal_type(e2)  # E: Revealed type is 'Union[Any, builtins.BaseException]'
 except (E1, E2) as e3:
-    reveal_type(e3)  # E: Revealed type is 'Any'
+    reveal_type(e3)  # E: Revealed type is 'Union[Any, __main__.E2]'
 except (E1, E2, BaseException) as e4:
-    reveal_type(e4)  # E: Revealed type is 'Any'
+    reveal_type(e4)  # E: Revealed type is 'Union[Any, builtins.BaseException]'
 
 try: pass
 except E1 as e1:

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -37,7 +37,7 @@ def f(x: Union[int, str]) -> None:
 [case testUnionAnyIsInstance]
 from typing import Any, Union
 
-def func(v:Union[int, Any]) -> None:
+def func(v: Union[int, Any]) -> None:
     if isinstance(v, int):
         reveal_type(v) # E: Revealed type is 'builtins.int'
     else:
@@ -61,7 +61,8 @@ y = w.y
 z = w.y       # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 w.y = 'a'     # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 y = x.y       # E: Some element of union has no attribute "y"
-z = x.y       # E: Some element of union has no attribute "y"
+v = x.y       # E: Some element of union has no attribute "y"
+reveal_type(v) # E: Revealed type is 'Any'
 
 [builtins fixtures/isinstance.pyi]
 
@@ -168,3 +169,66 @@ if foo():
     def g(x: Union[int, str, bytes]) -> None: pass
 else:
     def g(x: Union[int, str]) -> None: pass  # E: All conditional function variants must have identical signatures
+
+[case testUnionSimplificationSpecialCases]
+from typing import Any, TypeVar, Union
+
+class C(Any): pass
+
+T = TypeVar('T')
+S = TypeVar('S')
+def u(x: T, y: S) -> Union[S, T]: pass
+
+a = None # type: Any
+
+# Base-class-Any and None, simplify
+reveal_type(u(C(), None))  # E: Revealed type is '__main__.C*'
+reveal_type(u(None, C()))  # E: Revealed type is '__main__.C*'
+
+# Normal instance type and None, simplify
+reveal_type(u(1, None))  # E: Revealed type is 'builtins.int*'
+reveal_type(u(None, 1))  # E: Revealed type is 'builtins.int*'
+
+# Normal instance type and base-class-Any, no simplification
+reveal_type(u(C(), 1))  # E: Revealed type is 'Union[builtins.int*, __main__.C*]'
+reveal_type(u(1, C()))  # E: Revealed type is 'Union[__main__.C*, builtins.int*]'
+
+# Normal instance type and Any, no simplification
+reveal_type(u(1, a))  # E: Revealed type is 'Union[Any, builtins.int*]'
+reveal_type(u(a, 1))  # E: Revealed type is 'Union[builtins.int*, Any]'
+
+# Any and base-class-Any, no simplificaiton
+reveal_type(u(C(), a))  # E: Revealed type is 'Union[Any, __main__.C*]'
+reveal_type(u(a, C()))  # E: Revealed type is 'Union[__main__.C*, Any]'
+
+# Two normal instance types, simplify
+reveal_type(u(1, object()))  # E: Revealed type is 'builtins.object*'
+reveal_type(u(object(), 1))  # E: Revealed type is 'builtins.object*'
+
+# Two normal instance types, no simplification
+reveal_type(u(1, ''))  # E: Revealed type is 'Union[builtins.str*, builtins.int*]'
+reveal_type(u('', 1))  # E: Revealed type is 'Union[builtins.int*, builtins.str*]'
+
+[case testUnionSimplificationWithDuplicateItems]
+from typing import Any, TypeVar, Union
+
+class C(Any): pass
+
+T = TypeVar('T')
+S = TypeVar('S')
+R = TypeVar('R')
+def u(x: T, y: S, z: R) -> Union[R, S, T]: pass
+
+a = None # type: Any
+
+reveal_type(u(1, 1, 1))  # E: Revealed type is 'builtins.int*'
+reveal_type(u(C(), C(), None))  # E: Revealed type is '__main__.C*'
+reveal_type(u(a, a, 1))  # E: Revealed type is 'Union[builtins.int*, Any]'
+reveal_type(u(a, C(), a))  # E: Revealed type is 'Union[Any, __main__.C*]'
+reveal_type(u('', 1, 1))  # E: Revealed type is 'Union[builtins.int*, builtins.str*]'
+
+[case testUnionAndBinaryOperation]
+from typing import Union
+class A: pass
+def f(x: Union[int, str, A]):
+    x + object() # E: Unsupported left operand type for + (some union)


### PR DESCRIPTION
DO NOT MERGE YET -- this causes errors in internal Dropbox
repos.

(This is an updated version of #2197 by ddfisher.)

Fixes #2712.

make_simplified_union had two incorrect interactions with Any that this
fixes:
1) Any unions containing Any were simplified to Any, which is incorrect.
2) Any classes that inherited from Any would be removed from the union
by the subclass simplification (because subclasses of Any are
considered subclasses of all other classes due to subtype/compatible
with confusion).

Note that `Union`s call make_union and not make_simplified_union, so
this doesn't change their behavior directly (unless they interact with
something else which causes them to be simplified, like being part of
an `Optional`).