### PR TITLE
Fast parser: support @no_type_check, give better ellipses error

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -289,7 +289,7 @@ class ASTConverter(ast35.NodeTransformer):
             arg_names = [None] * len(arg_names)
         arg_types = None  # type: List[Type]
         if no_type_check:
-            arg_types = [None for _ in args]
+            arg_types = [None] * len(args)
             return_type = None
         elif n.type_comment is not None:
             try:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -313,7 +313,7 @@ class ASTConverter(ast35.NodeTransformer):
                     arg_types.insert(0, AnyType())
             except SyntaxError:
                 self.fail(TYPE_COMMENT_SYNTAX_ERROR, n.lineno, n.col_offset)
-                arg_types = [AnyType() for _ in args]
+                arg_types = [AnyType()] * len(args)
                 return_type = AnyType()
         else:
             arg_types = [a.type_annotation for a in args]
@@ -777,7 +777,7 @@ class ASTConverter(ast35.NodeTransformer):
         return CallExpr(self.visit(n.func),
                         arg_types,
                         arg_kinds,
-                        cast("List[str]", [None for _ in n.args]) + [k.arg for k in n.keywords])
+                        cast("List[str]", [None] * len(n.args)) + [k.arg for k in n.keywords])
 
     # Num(object n) -- a number as a PyObject.
     @with_line

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -284,7 +284,7 @@ class ASTConverter(ast27.NodeTransformer):
 
         arg_types = None  # type: List[Type]
         if (n.decorator_list and any(is_no_type_check_decorator(d) for d in n.decorator_list)):
-            arg_types = [None for _ in args]
+            arg_types = [None] * len(args)
             return_type = None
         elif n.type_comment is not None and len(n.type_comment) > 0:
             try:
@@ -305,7 +305,7 @@ class ASTConverter(ast27.NodeTransformer):
                     arg_types.insert(0, AnyType())
             except SyntaxError:
                 self.fail(TYPE_COMMENT_SYNTAX_ERROR, n.lineno, n.col_offset)
-                arg_types = [AnyType() for _ in args]
+                arg_types = [AnyType()] * len(args)
                 return_type = AnyType()
         else:
             arg_types = [a.type_annotation for a in args]

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -34,7 +34,7 @@ from mypy.nodes import (
     ARG_POS, ARG_OPT, ARG_STAR, ARG_NAMED, ARG_STAR2
 )
 from mypy.types import (
-    Type, CallableType, AnyType, UnboundType,
+    Type, CallableType, AnyType, UnboundType, EllipsisType
 )
 from mypy import defaults
 from mypy import experiments
@@ -112,6 +112,15 @@ def find(f: Callable[[V], bool], seq: Sequence[V]) -> V:
         if f(item):
             return item
     return None
+
+
+def is_no_type_check_decorator(expr: ast27.expr) -> bool:
+    if isinstance(expr, ast27.Name):
+        return expr.id == 'no_type_check'
+    elif isinstance(expr, ast27.Attribute):
+        if isinstance(expr.value, ast27.Name):
+            return expr.value.id == 'typing' and expr.attr == 'no_type_check'
+    return False
 
 
 class ASTConverter(ast27.NodeTransformer):
@@ -274,7 +283,10 @@ class ASTConverter(ast27.NodeTransformer):
             arg_names = [None] * len(arg_names)
 
         arg_types = None  # type: List[Type]
-        if n.type_comment is not None and len(n.type_comment) > 0:
+        if (n.decorator_list and any(is_no_type_check_decorator(d) for d in n.decorator_list)):
+            arg_types = [None for _ in args]
+            return_type = None
+        elif n.type_comment is not None and len(n.type_comment) > 0:
             try:
                 func_type_ast = ast35.parse(n.type_comment, '<func_type>', 'func_type')
                 assert isinstance(func_type_ast, ast35.FunctionType)
@@ -307,7 +319,10 @@ class ASTConverter(ast27.NodeTransformer):
 
         func_type = None
         if any(arg_types) or return_type:
-            if len(arg_types) > len(arg_kinds):
+            if len(arg_types) != 1 and any(isinstance(t, EllipsisType) for t in arg_types):
+                self.fail("Ellipses cannot accompany other argument types "
+                          "in function type signature.", n.lineno, 0)
+            elif len(arg_types) > len(arg_kinds):
                 self.fail('Type signature has too many arguments', n.lineno, 0)
             elif len(arg_types) < len(arg_kinds):
                 self.fail('Type signature has too few arguments', n.lineno, 0)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1404,10 +1404,11 @@ class SemanticAnalyzer(NodeVisitor):
                 self.fail('Tuple type expected for multiple variables',
                           lvalue)
         elif isinstance(lvalue, StarExpr):
+            # Historical behavior for the old parser
             if isinstance(typ, StarType):
                 self.store_declared_types(lvalue.expr, typ.type)
             else:
-                self.fail('Star type expected for starred expression', lvalue)
+                self.store_declared_types(lvalue.expr, typ)
         else:
             # This has been flagged elsewhere as an error, so just ignore here.
             pass

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -27,11 +27,8 @@ from mypy import experiments
 
 # List of files that contain test case descriptions.
 files = [
-    'check-columns.test',
     'check-expressions.test',
-    'check-functions.test',
     'check-generic-subtyping.test',
-    'check-tuples.test',
     'check-varargs.test',
 ]
 fast_parser_files = [
@@ -73,6 +70,9 @@ fast_parser_files = [
     'check-class-namedtuple.test',
     'check-selftype.test',
     'check-python2.test',
+    'check-columns.test',
+    'check-functions.test',
+    'check-tuples.test',
 ]
 
 files.extend(fast_parser_files)

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -2,7 +2,7 @@
 # flags: --show-column-numbers
 1 +
 [out]
-main:2:3: error: Parse error before end of line
+main:2:4: error: invalid syntax
 
 
 [case testColumnsNestedFunctions]
@@ -40,9 +40,9 @@ class A:
         pass
 A().f()
 A().f(1)
-A().f('') # E:5: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
-A().f(1, 1) # E:5: Argument 2 to "f" of "A" has incompatible type "int"; expected "str"
-A().f(1, 'hello', 'hi') # E:5: Too many arguments for "f" of "A"
+A().f('') # E:0: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+A().f(1, 1) # E:0: Argument 2 to "f" of "A" has incompatible type "int"; expected "str"
+A().f(1, 'hello', 'hi') # E:0: Too many arguments for "f" of "A"
 
 [case testColumnsMultipleStatementsPerLine]
 # flags: --show-column-numbers

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1475,13 +1475,13 @@ class A:
 def f(x, y, z): # type: (..., int) -> None
     pass
 [out]
-main:1: error: Parse error before ): Ellipses cannot accompany other argument types in function type signature.
+main:1: error: Ellipses cannot accompany other argument types in function type signature.
 
 [case testEllipsisWithSomethingBeforeItFails]
 def f(x, y, z): # type: (int, ...) -> None
     pass
 [out]
-main:1: error: Parse error before ): Ellipses cannot accompany other argument types in function type signature.
+main:1: error: Ellipses cannot accompany other argument types in function type signature.
 
 [case testRejectCovariantArgument]
 from typing import TypeVar, Generic

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -183,7 +183,7 @@ def f(x, y, z): # type: (...) -> None
 def f(x, y, z): # type: (..., int) -> None
     pass
 [out]
-main:1: error: Type signature has too few arguments
+main:1: error: Ellipses cannot accompany other argument types in function type signature.
 
 [case testLambdaTupleArgInPython2]
 f = lambda (x, y): x + y

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -387,7 +387,7 @@ aa, bb, *cc = t  # E: Need type annotation for variable
 [case testAssignmentToStarAnnotation]
 from typing import List
 li, lo = None, None # type: List[int], List[object]
-a, b, *c = 1, 2  # type: int, int, *List[int]
+a, b, *c = 1, 2  # type: int, int, List[int]
 c = lo  # E: Incompatible types in assignment (expression has type List[object], variable has type List[int])
 c = li
 [builtins fixtures/list.pyi]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -149,16 +149,6 @@ z = 0 # type: x
 main:4: error: Invalid type "__main__.f"
 main:5: error: Invalid type "__main__.x"
 
-[case testTwoStarsInType]
-import typing
-x, x2 = 1 # type: *object, *object
-y, y2 = 1 # type: object, (*object, *object)
-z, z2 = 1 # type: *object, (object, *object)
-[out]
-main:2: error: At most one star type allowed in a tuple
-main:3: error: At most one star type allowed in a tuple
-main:4: error: Star type only allowed for starred expressions
-
 [case testGlobalVarRedefinition]
 import typing
 class A: pass
@@ -418,16 +408,6 @@ main:3: error: Invalid assignment target
 main:4: error: Invalid assignment target
 main:5: error: Invalid assignment target
 main:6: error: Invalid assignment target
-
-[case testInvalidStarType]
-a = 1  # type: *int
-[out]
-main:1: error: Star type only allowed for starred expressions
-
-[case testInvalidStarType]
-*a, b = 1  # type: int, int
-[out]
-main:1: error: Star type expected for starred expression
 
 [case testTwoStarExpressions]
 a, *b, *c = 1


### PR DESCRIPTION
This PR converts 3 more test files to the fast parser.  To do so, we add support for the `@no_type_check` decorator and fixup the error message about mixed ellipses arguments (i.e. fixes #2704).