### PR TITLE
fix error context for `x[0]: int` (with no rvalue)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1150,7 +1150,7 @@ class TypeChecker(NodeVisitor[Type]):
                                             lvalue_type,
                                             False)
             elif index_lvalue:
-                self.check_indexed_assignment(index_lvalue, rvalue, rvalue)
+                self.check_indexed_assignment(index_lvalue, rvalue, lvalue)
 
             if inferred:
                 self.infer_variable_type(inferred, lvalue, self.accept(rvalue),

--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -85,3 +85,16 @@ class C:
         x: int = None  # E: Incompatible types in assignment (expression has type None, variable has type "int")
         self.x: int = None  # E: Incompatible types in assignment (expression has type None, variable has type "int")
 [out]
+
+[case testNewSyntaxSpecialAssign]
+# flags: --fast-parser --python-version 3.6
+class X:
+    x: str
+    x[0]: int
+    x.x: int
+
+[out]
+main:4: error: Unexpected type declaration
+main:4: error: Unsupported target for indexed assignment
+main:5: error: Type cannot be declared in assignment to non-self attribute
+main:5: error: "str" has no attribute "x"


### PR DESCRIPTION
Without the change in checker.py, the indexed assignment error for code like `x[0]: int`
wouldn't give a line number.

Ran into this implementing namedtuple defaults.

Also added a test for the equivalent code with attribute assignment,
although that error message already had the right line number.