### PR TITLE
Make fast parser handles type annotations + type comments better

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -23,6 +23,7 @@ from mypy.types import (
 )
 from mypy import defaults
 from mypy import experiments
+from mypy import messages
 from mypy.errors import Errors
 
 try:
@@ -283,9 +284,15 @@ class ASTConverter(ast35.NodeTransformer):
                 # for ellipsis arg
                 if (len(func_type_ast.argtypes) == 1 and
                         isinstance(func_type_ast.argtypes[0], ast35.Ellipsis)):
+                    if n.returns:
+                        # PEP 484 disallows both type annotations and type comments
+                        self.fail(messages.DUPLICATE_TYPE_SIGNATURES, n.lineno, n.col_offset)
                     arg_types = [a.type_annotation if a.type_annotation is not None else AnyType()
                                  for a in args]
                 else:
+                    # PEP 484 disallows both type annotations and type comments
+                    if n.returns or any(a.type_annotation is not None for a in args):
+                        self.fail(messages.DUPLICATE_TYPE_SIGNATURES, n.lineno, n.col_offset)
                     translated_args = (TypeConverter(self.errors, line=n.lineno)
                                        .translate_expr_list(func_type_ast.argtypes))
                     arg_types = [a if a is not None else AnyType()

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -38,6 +38,7 @@ from mypy.types import (
 )
 from mypy import defaults
 from mypy import experiments
+from mypy import messages
 from mypy.errors import Errors
 from mypy.fastparse import TypeConverter, parse_type_comment
 
@@ -284,6 +285,9 @@ class ASTConverter(ast27.NodeTransformer):
                     arg_types = [a.type_annotation if a.type_annotation is not None else AnyType()
                                 for a in args]
                 else:
+                    # PEP 484 disallows both type annotations and type comments
+                    if any(a.type_annotation is not None for a in args):
+                        self.fail(messages.DUPLICATE_TYPE_SIGNATURES, n.lineno, n.col_offset)
                     arg_types = [a if a is not None else AnyType() for
                                 a in converter.translate_expr_list(func_type_ast.argtypes)]
                 return_type = converter.visit(func_type_ast.returns)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -78,6 +78,7 @@ TYPEDDICT_ITEM_NAME_MUST_BE_STRING_LITERAL = \
     'Expected TypedDict item name to be string literal'
 MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'
 NON_BOOLEAN_IN_CONDITIONAL = 'Condition must be a boolean'
+DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'
 
 ARG_CONSTRUCTOR_NAMES = {
     ARG_POS: "Arg",

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -213,3 +213,39 @@ assert 1, 2
 assert 1, 1+2
 assert 1, 1+'test'  # E: Unsupported operand types for + ("int" and "str")
 assert 1, f()  # E: Name 'f' is not defined
+
+[case testFastParserConsistentFunctionTypes]
+# flags: --fast-parser
+def f(x, y, z):
+  # type: (int, int, int) -> int
+  pass
+
+def f(x,  # type: int  # E: Function has duplicate type signatures
+      y,  # type: int
+      z   # type: int
+    ):
+    # type: (int, int, int) -> int
+    pass
+
+def f(x,  # type: int
+      y,  # type: int
+      z   # type: int
+    ):
+    # type: (...) -> int
+    pass
+
+def f(x, y, z):
+  # type: (int, int, int) -> int
+  pass
+
+def f(x) -> int:  # E: Function has duplicate type signatures
+  # type: (int) -> int
+  pass
+
+def f(x: int, y: int, z: int):
+  # type: (...) -> int
+  pass
+
+def f(x: int):  # E: Function has duplicate type signatures
+  # type: (int) -> int
+  pass


### PR DESCRIPTION
This PR has two parts:

1. Disallows two return annotations (ie addresses #2733)
2. Enforces that type annotations and the type comment are consistent.

I assume 1 is not controversial, but 2 might be.

The point of it is to prevent:
```python
def f(x: str):
  # type: (int) -> int
  return x
```

which is currently perfectly allowed. 

Thus, this code checks, for every argument with a type annotation, that the type in the type comment is identical.
The way the code works, `# type: (...) -> int` will _always_ pass. 
The reason this might controversial is that it does string comparison, so it's not always right. In fact, it's very simple to get a false positive:

```python
def f(x: Union[int, str]):
  # type: (Union[str, int]) -> int
  return 5
```

will now complain about an inconsistent type signature. 

Now, I feel this is fine, since if you're going to go through the trouble of using both a type annotation and a non `...` type comment, then you might as well make them the same. The only reason this might be an actual problem is for something like:

```python
T = Union[int, str]
def f(x: Union[int, str]):
  # type: (T) -> int
  return 5
```

Which fails. Because we only keep a single source of truth for what the arg types are, we cannot postpone this check until we have actual types without a large and unnecessary (imo) refactor. 

So in summary, I think it's perfectly fine to insist that if users are going to use both type annotations and type comments in a function that they match identically.
But if the Powers That Be disagree, I'll happily remove the second part from this PR.