### PR TITLE
Make fast parser checks for duplicate names in function definitions

### DIFF
--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -249,3 +249,47 @@ def f(x: int, y: int, z: int):
 def f(x: int):  # E: Function has duplicate type signatures
   # type: (int) -> int
   pass
+
+[case testFastParserDuplicateNames]
+# flags: --fast-parser
+def f(x, y, z):
+  pass
+
+def g(x, y, x):  # E: duplicate argument 'x' in function definition
+  pass
+
+def h(x, y, *x):  # E: duplicate argument 'x' in function definition
+  pass
+
+def i(x, y, *z, **z):  # E: duplicate argument 'z' in function definition
+  pass
+
+def j(x: int, y: int, *, x: int = 3):  # E: duplicate argument 'x' in function definition
+  pass
+
+def k(*, y, z, y):  # E: duplicate argument 'y' in function definition
+  pass
+
+lambda x, y, x: ...  # E: duplicate argument 'x' in function definition
+
+[case testFastParserDuplicateNames_python2]
+# flags: --fast-parser
+def f(x, y, z):
+  pass
+
+def g(x, y, x):  # E: duplicate argument 'x' in function definition
+  pass
+
+def h(x, y, *x):  # E: duplicate argument 'x' in function definition
+  pass
+
+def i(x, y, *z, **z):  # E: duplicate argument 'z' in function definition
+  pass
+
+def j(x, (y, y), z):  # E: duplicate argument 'y' in function definition
+  pass
+
+def k(x, (y, x)):  # E: duplicate argument 'x' in function definition
+  pass
+
+lambda x, (y, x): None  # E: duplicate argument 'x' in function definition

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -292,4 +292,10 @@ def j(x, (y, y), z):  # E: duplicate argument 'y' in function definition
 def k(x, (y, x)):  # E: duplicate argument 'x' in function definition
   pass
 
+def l((x, y), (z, x)):  # E: duplicate argument 'x' in function definition
+  pass
+
+def m(x, ((x, y), z)):  # E: duplicate argument 'x' in function definition
+  pass
+
 lambda x, (y, x): None  # E: duplicate argument 'x' in function definition


### PR DESCRIPTION
Fixes #2732 
Waiting on #2735 (new commits start at 874153fd1aa5411c19bf51390168138c915d45ea)

This also checks for the general case (as I described in my comment on #2732).