### PR TITLE
Shortcut delegations from TypeChecker to ExpressionChecker (refactoring)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -278,7 +278,6 @@ class TypeChecker(StatementVisitor[None]):
             self.check_method_override(defn)
             self.check_inplace_operator_method(defn)
         self.check_overlapping_overloads(defn)
-        return None
 
     def check_overlapping_overloads(self, defn: OverloadedFuncDef) -> None:
         for i, item in enumerate(defn.items):
@@ -461,7 +460,6 @@ class TypeChecker(StatementVisitor[None]):
                                        messages.INCOMPATIBLE_REDEFINITION,
                                        'redefinition with type',
                                        'original type')
-        return
 
     def check_func_item(self, defn: FuncItem,
                         type_override: CallableType = None,
@@ -961,7 +959,6 @@ class TypeChecker(StatementVisitor[None]):
             if not defn.has_incompatible_baseclass:
                 # Otherwise we've already found errors; more errors are not useful
                 self.check_multiple_inheritance(typ)
-        return None
 
     def check_multiple_inheritance(self, typ: TypeInfo) -> None:
         """Check for multiple inheritance related errors."""
@@ -1019,11 +1016,9 @@ class TypeChecker(StatementVisitor[None]):
 
     def visit_import_from(self, node: ImportFrom) -> None:
         self.check_import(node)
-        return None
 
     def visit_import_all(self, node: ImportAll) -> None:
         self.check_import(node)
-        return None
 
     def check_import(self, node: ImportBase) -> None:
         for assign in node.assignments:
@@ -1045,12 +1040,11 @@ class TypeChecker(StatementVisitor[None]):
     def visit_block(self, b: Block) -> None:
         if b.is_unreachable:
             self.binder.unreachable()
-            return None
+            return
         for s in b.body:
             if self.binder.is_unreachable():
                 break
             self.accept(s)
-        return None
 
     def visit_assignment_stmt(self, s: AssignmentStmt) -> None:
         """Type check an assignment statement.
@@ -1067,7 +1061,6 @@ class TypeChecker(StatementVisitor[None]):
             rvalue = self.temp_node(self.type_map[s.rvalue], s)
             for lv in s.lvalues[:-1]:
                 self.check_assignment(lv, rvalue, s.type is None)
-        return None
 
     def check_assignment(self, lvalue: Lvalue, rvalue: Expression, infer_lvalue_type: bool = True,
                          new_syntax: bool = False) -> None:
@@ -1680,13 +1673,11 @@ class TypeChecker(StatementVisitor[None]):
 
     def visit_expression_stmt(self, s: ExpressionStmt) -> None:
         self.expr_checker.accept(s.expr)
-        return None
 
     def visit_return_stmt(self, s: ReturnStmt) -> None:
         """Type check a return statement."""
         self.check_return_stmt(s)
         self.binder.unreachable()
-        return None
 
     def check_return_stmt(self, s: ReturnStmt) -> None:
         defn = self.scope.top_function()
@@ -1765,7 +1756,6 @@ class TypeChecker(StatementVisitor[None]):
             with self.binder.frame_context(can_skip=False, fall_through=2):
                 if s.else_body:
                     self.accept(s.else_body)
-        return None
 
     def visit_while_stmt(self, s: WhileStmt) -> None:
         """Type check a while statement."""
@@ -1773,7 +1763,6 @@ class TypeChecker(StatementVisitor[None]):
         if_stmt.set_line(s.get_line(), s.get_column())
         self.accept_loop(if_stmt, s.else_body,
                          exit_condition=s.expr)
-        return None
 
     def visit_operator_assignment_stmt(self,
                                        s: OperatorAssignmentStmt) -> None:
@@ -1788,7 +1777,6 @@ class TypeChecker(StatementVisitor[None]):
         else:
             if not is_subtype(rvalue_type, lvalue_type):
                 self.msg.incompatible_operator_assignment(s.op, s)
-        return None
 
     def visit_assert_stmt(self, s: AssertStmt) -> None:
         self.expr_checker.accept(s.expr)
@@ -1804,7 +1792,6 @@ class TypeChecker(StatementVisitor[None]):
         true_map, _ = self.find_isinstance_check(s.expr)
 
         self.push_type_map(true_map)
-        return None
 
     def visit_raise_stmt(self, s: RaiseStmt) -> None:
         """Type check a raise statement."""
@@ -1813,7 +1800,6 @@ class TypeChecker(StatementVisitor[None]):
         if s.from_expr:
             self.type_check_raise(s.from_expr, s, True)
         self.binder.unreachable()
-        return None
 
     def type_check_raise(self, e: Expression, s: RaiseStmt,
                          optional: bool = False) -> None:
@@ -1872,8 +1858,6 @@ class TypeChecker(StatementVisitor[None]):
             # from the latter context affect the type state in the code
             # that follows the try statement.)
             self.accept(s.finally_body)
-
-        return None
 
     def visit_try_without_finally(self, s: TryStmt, try_frame: bool) -> None:
         """Type check a try statement, ignoring the finally block.
@@ -2036,15 +2020,7 @@ class TypeChecker(StatementVisitor[None]):
             c = CallExpr(m, [e.index], [nodes.ARG_POS], [None])
             c.line = s.line
             c.accept(self.expr_checker)
-            return
         else:
-            def flatten(t: Expression) -> List[Expression]:
-                """Flatten a nested sequence of tuples/lists into one list of nodes."""
-                if isinstance(t, TupleExpr) or isinstance(t, ListExpr):
-                    return [b for a in t.items for b in flatten(a)]
-                else:
-                    return [t]
-
             s.expr.accept(self.expr_checker)
             for elt in flatten(s.expr):
                 if isinstance(elt, NameExpr):
@@ -2052,7 +2028,6 @@ class TypeChecker(StatementVisitor[None]):
                                             DeletedType(source=elt.name),
                                             self.binder.get_declaration(elt),
                                             False)
-            return
 
     def visit_decorator(self, e: Decorator) -> None:
         for d in e.decorators:
@@ -2081,7 +2056,6 @@ class TypeChecker(StatementVisitor[None]):
         e.var.is_ready = True
         if e.func.is_property:
             self.check_incompatible_property_override(e)
-        return None
 
     def check_incompatible_property_override(self, e: Decorator) -> None:
         if not e.var.is_settable_property and e.func.info is not None:
@@ -2102,7 +2076,6 @@ class TypeChecker(StatementVisitor[None]):
             else:
                 self.check_with_item(expr, target, s.target_type is None)
         self.accept(s.body)
-        return None
 
     def check_async_with_item(self, expr: Expression, target: Expression,
                               infer_lvalue_type: bool) -> None:
@@ -2140,15 +2113,12 @@ class TypeChecker(StatementVisitor[None]):
             if not isinstance(target_type, NoneTyp):
                 # TODO: Also verify the type of 'write'.
                 self.expr_checker.analyze_external_member_access('write', target_type, s.target)
-        return None
 
     def visit_break_stmt(self, s: BreakStmt) -> None:
         self.binder.handle_break()
-        return None
 
     def visit_continue_stmt(self, s: ContinueStmt) -> None:
         self.binder.handle_continue()
-        return None
 
     def visit_exec_stmt(self, s: ExecStmt) -> None:
         pass
@@ -2651,6 +2621,14 @@ def find_isinstance_check(node: Expression,
 
     # Not a supported isinstance check
     return {}, {}
+
+
+def flatten(t: Expression) -> List[Expression]:
+    """Flatten a nested sequence of tuples/lists into one list of nodes."""
+    if isinstance(t, TupleExpr) or isinstance(t, ListExpr):
+        return [b for a in t.items for b in flatten(a)]
+    else:
+        return [t]
 
 
 def get_isinstance_type(expr: Expression, type_map: Dict[Expression, Type]) -> Type:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1020,6 +1020,9 @@ class TypeChecker(StatementVisitor[None]):
     def visit_import_all(self, node: ImportAll) -> None:
         self.check_import(node)
 
+    def visit_import(self, s: Import) -> None:
+        pass
+
     def check_import(self, node: ImportBase) -> None:
         for assign in node.assignments:
             lvalue = assign.lvalues[0]
@@ -2133,9 +2136,6 @@ class TypeChecker(StatementVisitor[None]):
         pass
 
     def visit_pass_stmt(self, s: PassStmt) -> None:
-        pass
-
-    def visit_import(self, s: Import) -> None:
         pass
 
     #

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -93,8 +93,6 @@ class TypeChecker(StatementVisitor[None]):
     scope = None  # type: Scope
     # Stack of function return types
     return_types = None  # type: List[Type]
-    # Type context for type inference
-    type_context = None  # type: List[Type]
     # Flags; true for dynamically typed functions
     dynamic_funcs = None  # type: List[bool]
     # Stack of collections of variables with partial types
@@ -136,7 +134,6 @@ class TypeChecker(StatementVisitor[None]):
         self.binder = ConditionalTypeBinder()
         self.globals = tree.names
         self.return_types = []
-        self.type_context = []
         self.dynamic_funcs = []
         self.partial_types = []
         self.deferred_nodes = []
@@ -230,14 +227,12 @@ class TypeChecker(StatementVisitor[None]):
         else:
             self.msg.cannot_determine_type(name, context)
 
-    def accept(self, stmt: Statement, type_context: Type = None) -> None:
+    def accept(self, stmt: Statement) -> None:
         """Type check a node in the given type context."""
-        self.type_context.append(type_context)
         try:
             stmt.accept(self)
         except Exception as err:
             report_internal_error(err, self.errors.file, stmt.line, self.errors, self.options)
-        self.type_context.pop()
 
     def accept_loop(self, body: Statement, else_body: Statement = None, *,
                     exit_condition: Expression = None) -> None:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -46,7 +46,7 @@ from mypy.expandtype import expand_type, expand_type_by_instance
 from mypy.visitor import StatementVisitor
 from mypy.join import join_types
 from mypy.treetransform import TransformVisitor
-from mypy.meet import meet_simple, is_overlapping_types
+from mypy.meet import is_overlapping_types
 from mypy.binder import ConditionalTypeBinder
 from mypy.options import Options
 
@@ -1535,14 +1535,6 @@ class TypeChecker(StatementVisitor[None]):
         if context.get_line() in self.errors.ignored_lines[self.errors.file]:
             self.set_inferred_type(var, lvalue, AnyType())
 
-    def narrow_type_from_binder(self, expr: Expression, known_type: Type) -> Type:
-        if expr.literal >= LITERAL_TYPE:
-            restriction = self.binder.get(expr)
-            if restriction:
-                ans = meet_simple(known_type, restriction)
-                return ans
-        return known_type
-
     def check_simple_assignment(self, lvalue_type: Type, rvalue: Expression,
                                 context: Context,
                                 msg: str = messages.INCOMPATIBLE_TYPES_IN_ASSIGNMENT,
@@ -2198,13 +2190,9 @@ class TypeChecker(StatementVisitor[None]):
         sym = self.lookup_qualified(fullname)
         return cast(TypeInfo, sym.node)
 
-    def object_type(self) -> Instance:
-        """Return instance type 'object'."""
-        return self.named_type('builtins.object')
-
-    def bool_type(self) -> Instance:
-        """Return instance type 'bool'."""
-        return self.named_type('builtins.bool')
+    def type_type(self) -> Instance:
+        """Return instance type 'type'."""
+        return self.named_type('builtins.type')
 
     def str_type(self) -> Instance:
         """Return instance type 'str'."""

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -19,7 +19,8 @@ from mypy.nodes import (
     UnicodeExpr, OpExpr, UnaryExpr, FuncExpr, TempNode, SymbolTableNode,
     Context, Decorator, PrintStmt, LITERAL_TYPE, BreakStmt, PassStmt, ContinueStmt,
     ComparisonExpr, StarExpr, EllipsisExpr, RefExpr, ImportFrom, ImportAll, ImportBase,
-    ARG_POS, CONTRAVARIANT, COVARIANT, ExecStmt, GlobalDecl, Import, NonlocalDecl
+    ARG_POS, CONTRAVARIANT, COVARIANT, ExecStmt, GlobalDecl, Import, NonlocalDecl,
+    MDEF, Node
 )
 from mypy import nodes
 from mypy.types import (
@@ -1181,7 +1182,7 @@ class TypeChecker(StatementVisitor[None]):
             compare_type = lvalue_type
             compare_node = lvalue.node
         else:
-            compare_type = self.accept(rvalue, base_type)
+            compare_type = self.expr_checker.accept(rvalue, base_type)
             if isinstance(rvalue, NameExpr):
                 compare_node = rvalue.node
                 if isinstance(compare_node, Decorator):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2135,9 +2135,6 @@ class TypeChecker(StatementVisitor[None]):
     def visit_pass_stmt(self, s: PassStmt) -> None:
         pass
 
-    def visit_mypy_file(self, s: MypyFile) -> None:
-        assert False
-
     def visit_import(self, s: Import) -> None:
         pass
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -110,7 +110,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Construct an expression type checker."""
         self.chk = chk
         self.msg = msg
-        self.type_context = [AnyType()]
+        self.type_context = [UninhabitedType()]
         self.strfrm_checker = StringFormatterChecker(self, self.chk, self.msg)
 
     def visit_name_expr(self, e: NameExpr) -> Type:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -110,7 +110,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Construct an expression type checker."""
         self.chk = chk
         self.msg = msg
-        self.type_context = []
+        self.type_context = [AnyType()]
         self.strfrm_checker = StringFormatterChecker(self, self.chk, self.msg)
 
     def visit_name_expr(self, e: NameExpr) -> Type:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -100,7 +100,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     # This is shared with TypeChecker, but stored also here for convenience.
     msg = None  # type: MessageBuilder
     # Type context for type inference
-    type_context = None  # type: List[Type]
+    type_context = None  # type: List[Optional[Type]]
 
     strfrm_checker = None  # type: StringFormatterChecker
 
@@ -110,7 +110,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Construct an expression type checker."""
         self.chk = chk
         self.msg = msg
-        self.type_context = [UninhabitedType()]
+        self.type_context = [None]
         self.strfrm_checker = StringFormatterChecker(self, self.chk, self.msg)
 
     def visit_name_expr(self, e: NameExpr) -> Type:

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -313,4 +313,4 @@ class StringFormatterChecker:
 
     def accept(self, expr: Expression, context: Type = None) -> Type:
         """Type check a node. Alias for TypeChecker.accept."""
-        return self.chk.accept(expr, context)
+        return self.chk.expr_checker.accept(expr, context)

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -2,8 +2,9 @@ import os.path
 import sys
 import traceback
 from collections import OrderedDict, defaultdict
+from contextlib import contextmanager
 
-from typing import Tuple, List, TypeVar, Set, Dict
+from typing import Tuple, List, TypeVar, Set, Dict, Iterator
 
 from mypy.options import Options
 
@@ -162,12 +163,25 @@ class Errors:
     def pop_function(self) -> None:
         self.function_or_member.pop()
 
+    @contextmanager
+    def enter_function(self, name: str) -> Iterator[None]:
+        self.push_function(name)
+        yield
+        self.pop_function()
+
     def push_type(self, name: str) -> None:
         """Set the short name of the current type (it can be None)."""
         self.type_name.append(name)
 
     def pop_type(self) -> None:
         self.type_name.pop()
+
+    @contextmanager
+    def enter_type(self, name: str) -> Iterator[None]:
+        """Set the short name of the current type (it can be None)."""
+        self.push_type(name)
+        yield
+        self.pop_type()
 
     def import_context(self) -> List[Tuple[str, int]]:
         """Return a copy of the import context."""

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -177,7 +177,131 @@ class ExpressionVisitor(Generic[T]):
         pass
 
 
-class NodeVisitor(Generic[T], ExpressionVisitor[T]):
+class StatementVisitor(Generic[T]):
+    # Definitions
+
+    @abstractmethod
+    def visit_assignment_stmt(self, o: 'mypy.nodes.AssignmentStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_for_stmt(self, o: 'mypy.nodes.ForStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_with_stmt(self, o: 'mypy.nodes.WithStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_del_stmt(self, o: 'mypy.nodes.DelStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_func_def(self, o: 'mypy.nodes.FuncDef') -> T:
+        pass
+
+    @abstractmethod
+    def visit_overloaded_func_def(self, o: 'mypy.nodes.OverloadedFuncDef') -> T:
+        pass
+
+    @abstractmethod
+    def visit_class_def(self, o: 'mypy.nodes.ClassDef') -> T:
+        pass
+
+    @abstractmethod
+    def visit_global_decl(self, o: 'mypy.nodes.GlobalDecl') -> T:
+        pass
+
+    @abstractmethod
+    def visit_nonlocal_decl(self, o: 'mypy.nodes.NonlocalDecl') -> T:
+        pass
+
+    @abstractmethod
+    def visit_decorator(self, o: 'mypy.nodes.Decorator') -> T:
+        pass
+
+    @abstractmethod
+    def visit_var(self, o: 'mypy.nodes.Var') -> T:
+        pass
+
+    # Module structure
+
+    @abstractmethod
+    def visit_mypy_file(self, o: 'mypy.nodes.MypyFile') -> T:
+        pass
+
+    @abstractmethod
+    def visit_import(self, o: 'mypy.nodes.Import') -> T:
+        pass
+
+    @abstractmethod
+    def visit_import_from(self, o: 'mypy.nodes.ImportFrom') -> T:
+        pass
+
+    @abstractmethod
+    def visit_import_all(self, o: 'mypy.nodes.ImportAll') -> T:
+        pass
+
+    # Statements
+
+    @abstractmethod
+    def visit_block(self, o: 'mypy.nodes.Block') -> T:
+        pass
+
+    @abstractmethod
+    def visit_expression_stmt(self, o: 'mypy.nodes.ExpressionStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_operator_assignment_stmt(self, o: 'mypy.nodes.OperatorAssignmentStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_while_stmt(self, o: 'mypy.nodes.WhileStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_return_stmt(self, o: 'mypy.nodes.ReturnStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_assert_stmt(self, o: 'mypy.nodes.AssertStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_if_stmt(self, o: 'mypy.nodes.IfStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_break_stmt(self, o: 'mypy.nodes.BreakStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_continue_stmt(self, o: 'mypy.nodes.ContinueStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_pass_stmt(self, o: 'mypy.nodes.PassStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_raise_stmt(self, o: 'mypy.nodes.RaiseStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_try_stmt(self, o: 'mypy.nodes.TryStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_print_stmt(self, o: 'mypy.nodes.PrintStmt') -> T:
+        pass
+
+    @abstractmethod
+    def visit_exec_stmt(self, o: 'mypy.nodes.ExecStmt') -> T:
+        pass
+
+
+class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T]):
     """Empty base class for parse tree node visitors.
 
     The T type argument specifies the return type of the visit

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -227,10 +227,6 @@ class StatementVisitor(Generic[T]):
     # Module structure
 
     @abstractmethod
-    def visit_mypy_file(self, o: 'mypy.nodes.MypyFile') -> T:
-        pass
-
-    @abstractmethod
     def visit_import(self, o: 'mypy.nodes.Import') -> T:
         pass
 
@@ -311,10 +307,12 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T]):
     TODO make the default return value explicit
     """
 
-    # Module structure
+    # Not in superclasses:
 
     def visit_mypy_file(self, o: 'mypy.nodes.MypyFile') -> T:
         pass
+
+    # Module structure
 
     def visit_import(self, o: 'mypy.nodes.Import') -> T:
         pass


### PR DESCRIPTION
A follow-up for #2699.

There are some cases that were not explicitly handled in TypeChecker. I have added a no-op function for them, to keep the current behavior, but I am not sure this is intended (especially `visit_exec_stmt`).