### PR TITLE
Link to how-to opt-in to type checking in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ If you want to run the latest version of the code, you can install from git:
 
 
 Now, if Python on your system is configured properly (else see
-"Troubleshooting" below), you can type-check a program like this:
+"Troubleshooting" below), you can type-check the [statically typed parts] of a
+program like this:
 
     $ mypy PROGRAM
 
@@ -91,6 +92,8 @@ You can always use a Python interpreter to run your statically typed
 programs, even if they have type errors:
 
     $ python3 PROGRAM
+
+[statically typed parts]: http://mypy.readthedocs.io/en/latest/basics.html#function-signatures
 
 
 Web site and documentation


### PR DESCRIPTION
mypy doesn't typecheck functions that don't have a type signature. It's
literally the first thing in the docs, but I only read the README.

This behavior confused me enough to think that there was a bug and open #2741