### PR TITLE
Issues #2727 #2728: api.run now accepts a list of command args and returns a 3-tuple including exit status + docs adapted

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -386,7 +386,7 @@ It is possible to integrate mypy into another Python 3 application by
 importing ``mypy.api`` and calling the ``run`` function with a list containing
 what normally would have been the command line arguments to mypy.
 
-Function ``run`` returns a ``Tuple [str, str, int]`` containing
+Function ``run`` returns a ``Tuple [str, str, int]``, namely
 ``(<normal_report>, <error_report>, <exit_status>)``, in which ``<normal_report>``
 is what mypy normally writes to ``sys.stdout``, ``<error_report>`` is what mypy
 normally writes to ``sys.stderr`` and ``exit_status`` is the exit status mypy normally

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -407,4 +407,4 @@ A trivial example of using the api the  is the following::
         print('\nError report:\n')
         print(result[1])  # stderr
 
-    print ('\nExit status:', result [2])
+    print ('\nExit status:', result[2])

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -389,8 +389,8 @@ what normally would have been the command line arguments to mypy.
 Function ``run`` returns a ``Tuple [str, str, int]`` containing
 ``(<normal_report>, <error_report>, <exit_status>)``, in which ``<normal_report>``
 is what mypy normally writes to ``sys.stdout``, ``<error_report>`` is what mypy
-normally writes to ``sys.stderr`` and ``exit_status`` is the exit status mypy would
-have normally returned to the operating system.
+normally writes to ``sys.stderr`` and ``exit_status`` is the exit status mypy normally
+returns to the operating system.
 
 A trivial example of this is the following::
 

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -383,20 +383,21 @@ Integrating mypy into another Python application
 ************************************************
 
 It is possible to integrate mypy into another Python 3 application by
-importing ``mypy.api`` and calling the ``run`` function with exactly the string
-you would have passed to mypy from the command line.
+importing ``mypy.api`` and calling the ``run`` function with a list containing
+what normally would have been the command line arguments to mypy.
 
-Function ``run`` returns a tuple of strings:
-``(<normal_report>, <error_report>)``, in which ``<normal_report>`` is what mypy
-normally writes to ``sys.stdout`` and ``<error_report>`` is what mypy normally
-writes to ``sys.stderr``.
+Function ``run`` returns a ``Tuple [str, str, int]`` containing
+``(<normal_report>, <error_report>, <exit status>)``, in which ``<normal_report>``
+is what mypy normally writes to ``sys.stdout``, ``<error_report>`` is what mypy
+normally writes to ``sys.stderr`` and ``exit_status`` is the exit status mypy would
+have normally returned to the operating system.
 
 A trivial example of this is the following::
 
     import sys
     from mypy import api
 
-    result = api.run(' '.join(sys.argv[1:]))
+    result = api.run(sys.argv[1:])
 
     if result[0]:
         print('\nType checking report:\n')
@@ -405,3 +406,5 @@ A trivial example of this is the following::
     if result[1]:
         print('\nError report:\n')
         print(result[1])  # stderr
+
+    print ('\nExit status:', result [2])

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -387,7 +387,7 @@ importing ``mypy.api`` and calling the ``run`` function with a list containing
 what normally would have been the command line arguments to mypy.
 
 Function ``run`` returns a ``Tuple [str, str, int]`` containing
-``(<normal_report>, <error_report>, <exit status>)``, in which ``<normal_report>``
+``(<normal_report>, <error_report>, <exit_status>)``, in which ``<normal_report>``
 is what mypy normally writes to ``sys.stdout``, ``<error_report>`` is what mypy
 normally writes to ``sys.stderr`` and ``exit_status`` is the exit status mypy would
 have normally returned to the operating system.

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -383,16 +383,16 @@ Integrating mypy into another Python application
 ************************************************
 
 It is possible to integrate mypy into another Python 3 application by
-importing ``mypy.api`` and calling the ``run`` function with a list containing
+importing ``mypy.api`` and calling the ``run`` function with a ``List[str]`` containing
 what normally would have been the command line arguments to mypy.
 
-Function ``run`` returns a ``Tuple [str, str, int]``, namely
+Function ``run`` returns a ``Tuple[str, str, int]``, namely
 ``(<normal_report>, <error_report>, <exit_status>)``, in which ``<normal_report>``
 is what mypy normally writes to ``sys.stdout``, ``<error_report>`` is what mypy
 normally writes to ``sys.stderr`` and ``exit_status`` is the exit status mypy normally
 returns to the operating system.
 
-A trivial example of this is the following::
+A trivial example of using the api the  is the following::
 
     import sys
     from mypy import api

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -383,7 +383,7 @@ Integrating mypy into another Python application
 ************************************************
 
 It is possible to integrate mypy into another Python 3 application by
-importing ``mypy.api`` and calling the ``run`` function with a ``List[str]`` containing
+importing ``mypy.api`` and calling the ``run`` function with a parameter of type ``List[str]`` containing
 what normally would have been the command line arguments to mypy.
 
 Function ``run`` returns a ``Tuple[str, str, int]``, namely

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -383,7 +383,7 @@ Integrating mypy into another Python application
 ************************************************
 
 It is possible to integrate mypy into another Python 3 application by
-importing ``mypy.api`` and calling the ``run`` function with a parameter of type ``List[str]`` containing
+importing ``mypy.api`` and calling the ``run`` function with a parameter of type ``List[str]``, containing
 what normally would have been the command line arguments to mypy.
 
 Function ``run`` returns a ``Tuple[str, str, int]``, namely

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -5,11 +5,16 @@ It just mimics command line activation without starting a new interpreter.
 So the normal docs about the mypy command line apply.
 Changes in the command line version of mypy will be immediately useable.
 
-Just import this module and then call the 'run' function with exactly the
-string you would have passed to mypy from the command line.
-Function 'run' returns a tuple of strings: (<normal_report>, <error_report>),
-in which <normal_report> is what mypy normally writes to sys.stdout and
-<error_report> is what mypy normally writes to sys.stderr.
+Just import this module and then call the 'run' function with a parameter of
+type List[str], containing what normally would have been the command line
+arguments to mypy.
+
+Function 'run' returns a Tuple[str, str, int], namely
+(<normal_report>, <error_report>, <exit_status>),
+in which <normal_report> is what mypy normally writes to sys.stdout,
+<error_report> is what mypy normally writes to sys.stderr and exit_status is
+the exit status mypy normally returns to the operating system.
+
 Any pretty formatting is left to the caller.
 
 Trivial example of code using this module:

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -27,7 +27,7 @@ if result[1]:
     print('\nError report:\n')
     print(result[1])  # stderr
 
-print ('\nExit status:', result [2])
+print ('\nExit status:', result[2])
 """
 
 import sys

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -17,7 +17,7 @@ Trivial example of code using this module:
 import sys
 from mypy import api
 
-result = api.run(' '.join(sys.argv[1:]))
+result = api.run(sys.argv[1:])
 
 if result[0]:
     print('\nType checking report:\n')
@@ -26,16 +26,18 @@ if result[0]:
 if result[1]:
     print('\nError report:\n')
     print(result[1])  # stderr
+
+print ('\nExit status:', result [2])
 """
 
 import sys
 from io import StringIO
-from typing import Tuple
+from typing import List, Tuple
 from mypy.main import main
 
 
-def run(params: str) -> Tuple[str, str]:
-    sys.argv = [''] + params.split()
+def run(params: List [str]) -> Tuple[str, str, int]:
+    sys.argv = [''] + params
 
     old_stdout = sys.stdout
     new_stdout = StringIO()
@@ -47,10 +49,11 @@ def run(params: str) -> Tuple[str, str]:
 
     try:
         main(None)
-    except SystemExit:
-        pass
+        exit_status = 0
+    except SystemExit as system_exit:
+        exit_status = system_exit.code
 
     sys.stdout = old_stdout
     sys.stderr = old_stderr
 
-    return new_stdout.getvalue(), new_stderr.getvalue()
+    return new_stdout.getvalue(), new_stderr.getvalue(), exit_status

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -36,7 +36,7 @@ from typing import List, Tuple
 from mypy.main import main
 
 
-def run(params: List [str]) -> Tuple[str, str, int]:
+def run(params: List[str]) -> Tuple[str, str, int]:
     sys.argv = [''] + params
 
     old_stdout = sys.stdout


### PR DESCRIPTION
#2727 #2728
