### PR TITLE
Freshen type variables of generic methods

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -14,7 +14,7 @@ from mypy.nodes import (
 )
 from mypy.messages import MessageBuilder
 from mypy.maptype import map_instance_to_supertype
-from mypy.expandtype import expand_type_by_instance, expand_type
+from mypy.expandtype import expand_type_by_instance, expand_type, freshen_function_type_vars
 from mypy.infer import infer_type_arguments
 from mypy.semanal import fill_typevars
 from mypy import messages
@@ -80,6 +80,7 @@ def analyze_member_access(name: str,
             if is_lvalue:
                 msg.cant_assign_to_method(node)
             signature = function_type(method, builtin_type('builtins.function'))
+            signature = freshen_function_type_vars(signature)
             if name == '__new__':
                 # __new__ is special and behaves like a static method -- don't strip
                 # the first argument.

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -1,13 +1,14 @@
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, TypeVar, Mapping, cast
 
 from mypy.types import (
     Type, Instance, CallableType, TypeVisitor, UnboundType, ErrorType, AnyType,
     Void, NoneTyp, TypeVarType, Overloaded, TupleType, TypedDictType, UnionType,
-    ErasedType, TypeList, PartialType, DeletedType, UninhabitedType, TypeType, TypeVarId
+    ErasedType, TypeList, PartialType, DeletedType, UninhabitedType, TypeType, TypeVarId,
+    FunctionLike, TypeVarDef
 )
 
 
-def expand_type(typ: Type, env: Dict[TypeVarId, Type]) -> Type:
+def expand_type(typ: Type, env: Mapping[TypeVarId, Type]) -> Type:
     """Substitute any type variable references in a type given by a type
     environment.
     """
@@ -28,12 +29,34 @@ def expand_type_by_instance(typ: Type, instance: Instance) -> Type:
         return expand_type(typ, variables)
 
 
+F = TypeVar('F', bound=FunctionLike)
+
+def freshen_function_type_vars(callee: F) -> F:
+    """Substitute fresh type variables for generic function type variables."""
+    if isinstance(callee, CallableType):
+        if not callee.is_generic():
+            return cast(F, callee)
+        tvdefs = []
+        tvmap = {}  # type: Dict[TypeVarId, Type]
+        for v in callee.variables:
+            tvdef = TypeVarDef.new_unification_variable(v)
+            tvdefs.append(tvdef)
+            tvmap[v.id] = TypeVarType(tvdef)
+        fresh = cast(CallableType, expand_type(callee, tvmap)).copy_modified(variables=tvdefs)
+        return cast(F, fresh)
+    else:
+        assert isinstance(callee, Overloaded)
+        fresh_overload = Overloaded([freshen_function_type_vars(item)
+                                     for item in callee.items()])
+        return cast(F, fresh_overload)
+
+
 class ExpandTypeVisitor(TypeVisitor[Type]):
     """Visitor that substitutes type variables with values."""
 
-    variables = None  # type: Dict[TypeVarId, Type]  # TypeVar id -> TypeVar value
+    variables = None  # type: Mapping[TypeVarId, Type]  # TypeVar id -> TypeVar value
 
-    def __init__(self, variables: Dict[TypeVarId, Type]) -> None:
+    def __init__(self, variables: Mapping[TypeVarId, Type]) -> None:
         self.variables = variables
 
     def visit_unbound_type(self, t: UnboundType) -> Type:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -31,6 +31,7 @@ def expand_type_by_instance(typ: Type, instance: Instance) -> Type:
 
 F = TypeVar('F', bound=FunctionLike)
 
+
 def freshen_function_type_vars(callee: F) -> F:
     """Substitute fresh type variables for generic function type variables."""
     if isinstance(callee, CallableType):

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1417,3 +1417,46 @@ class A:
     @classmethod
     def f(cls) -> None: pass
 [builtins fixtures/classmethod.pyi]
+
+[case testGenericOperatorMethodOverlapping]
+from typing import TypeVar, Generic, Tuple
+T = TypeVar('T')
+T2 = TypeVar('T2')
+S = TypeVar('S', bound=str)
+S2 = TypeVar('S2', bound=str)
+class G(Generic[T]):
+    pass
+class A:
+    def __or__(self, x: G[T]) -> G[T]: pass
+    def __ior__(self, x: G[T2]) -> G[T2]: pass
+class B:
+    def __or__(self, x: G[T]) -> G[T]: pass
+    def __ior__(self, x: G[S]) -> G[S]: pass \
+        # E: Signatures of "__ior__" and "__or__" are incompatible
+class C:
+    def __or__(self, x: G[S]) -> G[S]: pass
+    def __ior__(self, x: G[S2]) -> G[S2]: pass
+
+[case testGenericOperatorMethodOverlapping2]
+from typing import TypeVar, Generic, Tuple
+X = TypeVar('X')
+T = TypeVar('T', int, str)
+T2 = TypeVar('T2', int, str)
+S = TypeVar('S', float, str)
+S2 = TypeVar('S2', float, str)
+class G(Generic[X]):
+    pass
+class A:
+    def __or__(self, x: G[T]) -> G[T]: pass
+    def __ior__(self, x: G[T2]) -> G[T2]: pass
+class B:
+    def __or__(self, x: G[T]) -> G[T]: pass
+    def __ior__(self, x: G[S]) -> G[S]: pass \
+        # E: Signatures of "__ior__" and "__or__" are incompatible
+class C:
+    def __or__(self, x: G[S]) -> G[S]: pass
+    def __ior__(self, x: G[S2]) -> G[S2]: pass
+class D:
+    def __or__(self, x: G[X]) -> G[X]: pass
+    def __ior__(self, x: G[S2]) -> G[S2]: pass \
+        # E: Signatures of "__ior__" and "__or__" are incompatible

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -865,3 +865,16 @@ reveal_type(c.f([1])) # E: Revealed type is 'builtins.list[builtins.int]'
 reveal_type(c.f([])) # E: Revealed type is 'builtins.list[builtins.int]'
 reveal_type(c.f(None)) # E: Revealed type is 'builtins.list[builtins.int]'
 [builtins fixtures/list.pyi]
+
+[case testGenericMethodCalledInGenericContext]
+from typing import TypeVar, Generic
+
+_KT = TypeVar('_KT')
+_VT = TypeVar('_VT')
+_T = TypeVar('_T')
+
+class M(Generic[_KT, _VT]):
+    def get(self, k: _KT, default: _T) -> _T: ...
+
+def f(d: M[_KT, _VT], k: _KT) -> _VT:
+    return d.get(k, None)


### PR DESCRIPTION
This fixes conflicts where unrelated type variables were treated as
the same, because type variables defined in different scopes happened
to have the same ids. The fix is to substitute type variables with fresh
ones when looking up the types of methods. Fixes #2726.

Also fix method overlapping checks to unify type variables, as
otherwise the freshened generic methods may cause errors
elsewhere. Type variables don't need to be the same for signatures to
be compatible -- they just need to be equivalent.