### PR TITLE
Add support for additional predefined config file paths

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -345,9 +345,9 @@ Here are some more useful flags:
 
 - ``--config-file CONFIG_FILE`` causes configuration settings to be
   read from the given file.  By default settings are read from ``mypy.ini``
-  in the current directory.  Settings override mypy's built-in defaults
-  and command line flags can override settings.  See :ref:`config-file`
-  for the syntax of configuration files.
+  or ``setup.cfg`` in the current directory.  Settings override mypy's
+  built-in defaults and command line flags can override settings.
+  See :ref:`config-file` for the syntax of configuration files.
 
 - ``--junit-xml JUNIT_XML`` will make mypy generate a JUnit XML test
   result document with type checking results. This can make it easier

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -4,9 +4,16 @@ The mypy configuration file
 ===========================
 
 Mypy supports reading configuration settings from a file.  By default
-it uses the file ``mypy.ini`` in the current directory; the
-``--config-file`` command-line flag can be used to read a different
-file instead (see :ref:`--config-file <config-file-flag>`).
+it uses the file ``mypy.ini`` (with fallback to ``setup.cfg``) in the
+current directory; the ``--config-file`` command-line flag can be used to
+read a different file instead (see :ref:`--config-file <config-file-flag>`).
+
+It is important to understand that there is no merging of configuration
+files, as it would lead to ambiguity.  The ``--config-file`` flag
+has the highest precedence and must be correct; otherwise mypy will report
+an error and exit.  Without command line option, mypy will look for defaults,
+but will use only one of them.  The first one to read is ``mypy.ini``,
+and then ``setup.cfg``.
 
 Most flags correspond closely to :ref:`command-line flags
 <command-line>` but there are some differences in flag names and some
@@ -19,7 +26,7 @@ settings of the form `NAME = VALUE`.  Comments start with ``#``
 characters.
 
 - A section named ``[mypy]`` must be present.  This specifies
-  the global flags.
+  the global flags. The ``setup.cfg`` file is an exception to this.
 
 - Additional sections named ``[mypy-PATTERN1,PATTERN2,...]`` may be
   present, where ``PATTERN1``, ``PATTERN2`` etc. are `fnmatch patterns


### PR DESCRIPTION
When `--config-file` option isn't passed to mypy and mypy can't load mypy.ini (default config filename), it will try to load settings from common shared config files -- currently `setup.cfg` and `tox.ini`. However, with these files, mypy will become less verbose; specifically it won't require `mypy` section.

My main incentive is that I don't wan't to "bloat" my project structure with loads of config files; OTOH I expect them to work just by typing well-known command (with options loaded from configuration files). Two common development tools I use are pytest and flake8 and both support loading `setup.cfg` files. Another popular one is tox, which unfortunately doesn't load that file, but the former two load `tox.ini` in addition to `setup.cfg`. Moreover, tox is often used to run all these tools with mypy included and I believe some people consider keeping all configuration in one place as a nice thing to have.

I do understand that this is kind of an anti-pattern, but with small codebases it is quite annoying to have as many config files as source code. This is why it is implemented as a completely optional feature, with `--config-file` option and `mypy.ini` taking precedence over shared configs. Anyway, this PR is rather small - I hope the code won't need any maintenance - and some people will benefit from it, while others will never use it.