### PR TITLE
Make fast_parse able to parse real-world machine-generated code

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -35,6 +35,7 @@ def main(script_path: str) -> None:
         bin_dir = find_bin_directory(script_path)
     else:
         bin_dir = None
+    sys.setrecursionlimit(2 ** 14)
     sources, options = process_options(sys.argv[1:])
     serious = False
     try:


### PR DESCRIPTION
This is not changing the recursive nature of the visitor so it's effectively
a workaround.  However, this lets the parser deal with actual code in the wild,
such as `idnadata.py` by simply raising the recursion limit 16X.

Repro of the failure without this change:
```
$ python3 -m venv /tmp/recurse
$ . /tmp/recurse/bin/activate
(recurse)$ pip install -e .
(recurse)$ pip install idna==2.0
(recurse)$ mypy --show-traceback /tmp/recurse/lib/python3.6/site-packages/idna/idnadata.py
/tmp/recurse/lib/python3.6/site-packages/idna/idnadata.py: error: INTERNAL ERROR -- please report a bug at https://github.com/python/mypy/issues
Traceback (most recent call last):
...
RecursionError: maximum recursion depth exceeded
/tmp/recurse/lib/python3.6/site-packages/idna/idnadata.py: note: use --pdb to drop into pdb
```