### PR TITLE
Fix an assert that passed type checks but could fail at runtime.

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2404,7 +2404,7 @@ class SemanticAnalyzer(NodeVisitor):
             # In this case base.node is the module's MypyFile and we look up
             # bar in its namespace.  This must be done for all types of bar.
             file = base.node
-            assert isinstance(file, MypyFile)
+            assert isinstance(file, (MypyFile, type(None)))
             n = file.names.get(expr.name, None) if file is not None else None
             if n:
                 n = self.normalize_type_alias(n, expr)


### PR DESCRIPTION
Fixes #2751.

(That assert was added in #2341 to force the type checker to believe
that 'file' is a MypyFile instance, but the rest of the code makes it
clear that it may also be None, in which case the assert fails.)