### PR TITLE
Revert "Treat varargs as legal context in default lambda argument"

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1799,7 +1799,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         if ARG_STAR in arg_kinds or ARG_STAR2 in arg_kinds:
             # TODO treat this case appropriately
-            return callable_ctx
+            return None
         if callable_ctx.arg_kinds != arg_kinds:
             # Incompatible context; cannot use it to infer types.
             self.chk.fail(messages.CANNOT_INFER_LAMBDA_TYPE, e)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1033,18 +1033,7 @@ b = lambda: None  # type: Callable[[], None]
 f(b)
 g(b) # E: Argument 1 to "g" has incompatible type Callable[[], None]; expected Callable[[], int]
 
-[case testLambdaDefaultContext]
-# flags: --strict-optional
-from typing import Callable
-def f(a: Callable[..., None] = lambda *a, **k: None):
-    pass
 
-def g(a: Callable[..., None] = lambda *a, **k: 1):  # E: Incompatible return value type (got "int", expected None)
-    pass
-[out]
-main:6: error: Incompatible types in assignment (expression has type Callable[[StarArg(Any), KwArg(Any)], int], variable has type Callable[..., None])
-
-[builtins fixtures/dict.pyi]
 -- Boolean operators
 -- -----------------
 


### PR DESCRIPTION
Reverts python/mypy#2770

Here's a snippet that now crashes:
```python
import warnings
warnings.warn = lambda *args, **kwargs: None
```
(This is literally from our codebase, except there we have a `# type: ignore` too.)