### PR TITLE
Treat varargs as legal context in default lambda argument (Take 2)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -614,7 +614,7 @@ class TypeChecker(NodeVisitor[Type]):
                                       .format(erased, ref_type), defn)
                     elif isinstance(arg_type, TypeVarType):
                         # Refuse covariant parameter type variables
-                        # TODO: check recuresively for inner type variables
+                        # TODO: check recursively for inner type variables
                         if arg_type.variance == COVARIANT:
                             self.fail(messages.FUNCTION_PARAMETER_CANNOT_BE_COVARIANT, arg_type)
                     if typ.arg_kinds[i] == nodes.ARG_STAR:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1798,6 +1798,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         if ARG_STAR in arg_kinds or ARG_STAR2 in arg_kinds:
             # TODO treat this case appropriately
+            self.chk.check_func_item(e)
             return callable_ctx
         if callable_ctx.arg_kinds != arg_kinds:
             # Incompatible context; cannot use it to infer types.

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1799,7 +1799,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         if ARG_STAR in arg_kinds or ARG_STAR2 in arg_kinds:
             # TODO treat this case appropriately
-            return None
+            return callable_ctx
         if callable_ctx.arg_kinds != arg_kinds:
             # Incompatible context; cannot use it to infer types.
             self.chk.fail(messages.CANNOT_INFER_LAMBDA_TYPE, e)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1752,7 +1752,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             return callable_type(e, fallback, ret_type)
         else:
             # Type context available.
-            self.chk.check_func_item(e, type_override=inferred_type)
             if e.expr() not in self.chk.type_map:
                 self.accept(e.expr())
             ret_type = self.chk.type_map[e.expr()]
@@ -1805,6 +1804,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             self.chk.fail(messages.CANNOT_INFER_LAMBDA_TYPE, e)
             return None
 
+        self.chk.check_func_item(e, type_override=callable_ctx)
         return callable_ctx
 
     def visit_super_expr(self, e: SuperExpr) -> Type:

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1039,10 +1039,14 @@ from typing import Callable
 def f(a: Callable[..., None] = lambda *a, **k: None):
     pass
 
-def g(a: Callable[..., None] = lambda *a, **k: 1):  # E: Incompatible return value type (got "int", expected None)
+def g(a: Callable[..., None] = lambda *a, **k: 1):  # E: Incompatible types in assignment (expression has type Callable[[StarArg(Any), KwArg(Any)], int], variable has type Callable[..., None])
     pass
-[out]
-main:6: error: Incompatible types in assignment (expression has type Callable[[StarArg(Any), KwArg(Any)], int], variable has type Callable[..., None])
+
+[case testLambdaVarargContext]
+# Should not crash
+from typing import Callable
+def f(a: Callable[[int, int, int], int] = lambda *a, **k: 1):
+    pass
 
 [builtins fixtures/dict.pyi]
 -- Boolean operators

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1033,7 +1033,18 @@ b = lambda: None  # type: Callable[[], None]
 f(b)
 g(b) # E: Argument 1 to "g" has incompatible type Callable[[], None]; expected Callable[[], int]
 
+[case testLambdaDefaultContext]
+# flags: --strict-optional
+from typing import Callable
+def f(a: Callable[..., None] = lambda *a, **k: None):
+    pass
 
+def g(a: Callable[..., None] = lambda *a, **k: 1):  # E: Incompatible return value type (got "int", expected None)
+    pass
+[out]
+main:6: error: Incompatible types in assignment (expression has type Callable[[StarArg(Any), KwArg(Any)], int], variable has type Callable[..., None])
+
+[builtins fixtures/dict.pyi]
 -- Boolean operators
 -- -----------------
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1041,14 +1041,15 @@ def f(a: Callable[..., None] = lambda *a, **k: None):
 
 def g(a: Callable[..., None] = lambda *a, **k: 1):  # E: Incompatible types in assignment (expression has type Callable[[StarArg(Any), KwArg(Any)], int], variable has type Callable[..., None])
     pass
+[builtins fixtures/dict.pyi]
 
 [case testLambdaVarargContext]
 # Should not crash
 from typing import Callable
 def f(a: Callable[[int, int, int], int] = lambda *a, **k: 1):
     pass
-
 [builtins fixtures/dict.pyi]
+
 -- Boolean operators
 -- -----------------
 


### PR DESCRIPTION
Fix #2764.

Reopen #2770, fixing the issue in #2790 triggered by a context with more parameters than a varargs lambda.