### PR TITLE
Implement class syntax for TypedDict

### DIFF
--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -85,9 +85,10 @@ class Point1D(TypedDict):
     x: int
 class Point2D(Point1D):
     y: int
-
+r: Point1D
 p: Point2D
-reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+reveal_type(r)  # E: Revealed type is 'TypedDict(x=builtins.int, _fallback=__main__.Point1D)'
+reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=__main__.Point2D)'
 [builtins fixtures/dict.pyi]
 
 [case testCanCreateTypedDictWithSubclass2]
@@ -100,7 +101,7 @@ class Point2D(TypedDict, Point1D): # We also allow to include TypedDict in bases
     y: int
 
 p: Point2D
-reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=__main__.Point2D)'
 [builtins fixtures/dict.pyi]
 
 [case testCanCreateTypedDictClassEmpty]
@@ -122,8 +123,7 @@ reveal_type(p)  # E: Revealed type is 'TypedDict(_fallback=typing.Mapping[builti
 from mypy_extensions import TypedDict
 
 class Point(TypedDict): # E: TypedDict class syntax is only supported in Python 3.6
-    x: int
-    y: int
+    pass
 [builtins fixtures/dict.pyi]
 
 [case testCannotCreateTypedDictWithClassOtherBases]
@@ -138,7 +138,7 @@ class Point2D(Point1D, A): # E: All bases of a new TypedDict must be TypedDict's
     y: int
 
 p: Point2D
-reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=__main__.Point2D)'
 [builtins fixtures/dict.pyi]
 
 [case testCannotCreateTypedDictWithClassWithOtherStuff]
@@ -164,7 +164,7 @@ class Point(TypedDict):
     _y: int  # E: TypedDict field name cannot start with an underscore: _y
 
 p: Point
-reveal_type(p) # E: Revealed type is 'TypedDict(x=builtins.int, _y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+reveal_type(p) # E: Revealed type is 'TypedDict(x=builtins.int, _y=builtins.int, _fallback=__main__.Point)'
 [builtins fixtures/dict.pyi]
 
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -132,9 +132,9 @@ from mypy_extensions import TypedDict
 
 class A: pass
 
-class Point1D(TypedDict, A): # E: All bases of a new TypedDict must be TypedDict's
+class Point1D(TypedDict, A): # E: All bases of a new TypedDict must be TypedDict types
     x: int
-class Point2D(Point1D, A): # E: All bases of a new TypedDict must be TypedDict's
+class Point2D(Point1D, A): # E: All bases of a new TypedDict must be TypedDict types
     y: int
 
 p: Point2D
@@ -149,10 +149,10 @@ class Point(TypedDict):
     x: int
     y: int = 1 # E: Right hand side values are not supported in TypedDict
     def f(): pass # E: Invalid statement in TypedDict definition; expected "field_name: field_type"
-    x = 5 # E: Invalid statement in TypedDict definition; expected "field_name: field_type"
+    z = int # E: Invalid statement in TypedDict definition; expected "field_name: field_type"
 
-p = Point(x=42, y=1337)
-reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+p = Point(x=42, y=1337, z='whatever')
+reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, z=builtins.str, _fallback=typing.Mapping[builtins.str, builtins.object])'
 [builtins fixtures/dict.pyi]
 
 [case testCannotCreateTypedDictWithClassUnderscores]
@@ -171,11 +171,23 @@ reveal_type(p) # E: Revealed type is 'TypedDict(x=builtins.int, _y=builtins.int,
 # flags: --python-version 3.6
 from mypy_extensions import TypedDict
 
+class Bad(TypedDict):
+    x: int
+    x: str # E: Duplicate TypedDict field "x"
+
+b: Bad
+reveal_type(b) # E: Revealed type is 'TypedDict(x=builtins.int, _fallback=__main__.Bad)'
+[builtins fixtures/dict.pyi]
+
+[case testCannotCreateTypedDictWithClassOverwriting2]
+# flags: --python-version 3.6
+from mypy_extensions import TypedDict
+
 class Point1(TypedDict):
     x: int
 class Point2(TypedDict):
     x: float
-class Bad(Point1, Point2): # E: Cannot overwrite TypedDict field x while merging
+class Bad(Point1, Point2): # E: Cannot overwrite TypedDict field "x" while merging
     pass
 
 b: Bad
@@ -189,7 +201,7 @@ from mypy_extensions import TypedDict
 class Point1(TypedDict):
     x: int
 class Point2(Point1):
-    x: float # E: Cannot overwrite TypedDict field x while extending
+    x: float # E: Cannot overwrite TypedDict field "x" while extending
 
 p2: Point2
 reveal_type(p2) # E: Revealed type is 'TypedDict(x=builtins.int, _fallback=__main__.Point2)'

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -63,6 +63,111 @@ p = Point(x='meaning_of_life', y=1337)  # E: Incompatible types (expression has 
 [builtins fixtures/dict.pyi]
 
 
+-- Define TypedDict (Class syntax)
+
+[case testCanCreateTypedDictWithClass]
+# flags: --python-version 3.6
+from mypy_extensions import TypedDict
+
+class Point(TypedDict):
+    x: int
+    y: int
+
+p = Point(x=42, y=1337)
+reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+[builtins fixtures/dict.pyi]
+
+[case testCanCreateTypedDictWithSubclass]
+# flags: --python-version 3.6
+from mypy_extensions import TypedDict
+
+class Point1D(TypedDict):
+    x: int
+class Point2D(Point1D):
+    y: int
+
+p: Point2D
+reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+[builtins fixtures/dict.pyi]
+
+[case testCanCreateTypedDictWithSubclass2]
+# flags: --python-version 3.6
+from mypy_extensions import TypedDict
+
+class Point1D(TypedDict):
+    x: int
+class Point2D(TypedDict, Point1D): # We also allow to include TypedDict in bases, it is simply ignored at runtime
+    y: int
+
+p: Point2D
+reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+[builtins fixtures/dict.pyi]
+
+[case testCanCreateTypedDictClassEmpty]
+# flags: --python-version 3.6
+from mypy_extensions import TypedDict
+
+class EmptyDict(TypedDict):
+    pass
+
+p = EmptyDict()
+reveal_type(p)  # E: Revealed type is 'TypedDict(_fallback=typing.Mapping[builtins.str, builtins.None])'
+[builtins fixtures/dict.pyi]
+
+
+-- Define TypedDict (Class syntax errors)
+
+[case testCanCreateTypedDictWithClassOldVersion]
+# flags: --python-version 3.5
+from mypy_extensions import TypedDict
+
+class Point(TypedDict): # E: TypedDict class syntax is only supported in Python 3.6
+    x: int
+    y: int
+[builtins fixtures/dict.pyi]
+
+[case testCannotCreateTypedDictWithClassOtherBases]
+# flags: --python-version 3.6
+from mypy_extensions import TypedDict
+
+class A: pass
+
+class Point1D(TypedDict, A): # E: All bases of a new TypedDict must be TypedDict's
+    x: int
+class Point2D(Point1D, A): # E: All bases of a new TypedDict must be TypedDict's
+    y: int
+
+p: Point2D
+reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+[builtins fixtures/dict.pyi]
+
+[case testCannotCreateTypedDictWithClassWithOtherStuff]
+# flags: --python-version 3.6
+from mypy_extensions import TypedDict
+
+class Point(TypedDict):
+    x: int
+    y: int = 1 # E: Right hand side values are not supported in TypedDict
+    def f(): pass # E: Invalid statement in TypedDict definition; expected "field_name: field_type"
+    x = 5 # E: Invalid statement in TypedDict definition; expected "field_name: field_type"
+
+p = Point(x=42, y=1337)
+reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+[builtins fixtures/dict.pyi]
+
+[case testCannotCreateTypedDictWithClassUnderscores]
+# flags: --python-version 3.6
+from mypy_extensions import TypedDict
+
+class Point(TypedDict):
+    x: int
+    _y: int  # E: TypedDict field name cannot start with an underscore: _y
+
+p: Point
+reveal_type(p) # E: Revealed type is 'TypedDict(x=builtins.int, _y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
+[builtins fixtures/dict.pyi]
+
+
 -- Subtyping
 
 [case testCanConvertTypedDictToItself]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -167,6 +167,34 @@ p: Point
 reveal_type(p) # E: Revealed type is 'TypedDict(x=builtins.int, _y=builtins.int, _fallback=__main__.Point)'
 [builtins fixtures/dict.pyi]
 
+[case testCannotCreateTypedDictWithClassOverwriting]
+# flags: --python-version 3.6
+from mypy_extensions import TypedDict
+
+class Point1(TypedDict):
+    x: int
+class Point2(TypedDict):
+    x: float
+class Bad(Point1, Point2): # E: Cannot overwrite TypedDict field x while merging
+    pass
+
+b: Bad
+reveal_type(b) # E: Revealed type is 'TypedDict(x=builtins.int, _fallback=__main__.Bad)'
+[builtins fixtures/dict.pyi]
+
+[case testCannotCreateTypedDictWithClassOverwriting2]
+# flags: --python-version 3.6
+from mypy_extensions import TypedDict
+
+class Point1(TypedDict):
+    x: int
+class Point2(Point1):
+    x: float # E: Cannot overwrite TypedDict field x while extending
+
+p2: Point2
+reveal_type(p2) # E: Revealed type is 'TypedDict(x=builtins.int, _fallback=__main__.Point2)'
+[builtins fixtures/dict.pyi]
+
 
 -- Subtyping
 


### PR DESCRIPTION
Fixes #2740 

This allows the following:
```python
class Point(TypedDict):
    x: int
    y: int
class Label(TypedDict):
    label: str

class LabeledPoint3D(Point, Label):
    z: int

p: Point
p3D = LabeledPoint3D(x=1, y=2, z=42, label='Good point!')
```

(Side note: I spent an hour figuring out what are anonymous and named TypedDict's, maybe better call them explicit/implicit, or explicit/ihferred, if I understood them correctly?)