### PR TITLE
Fix meta level on member access

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -990,6 +990,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 e.name, original_type, e, is_lvalue, False, False,
                 self.named_type, self.not_ready_callback, self.msg,
                 original_type=original_type, chk=self.chk)
+            if isinstance(member_type, CallableType):
+                for v in member_type.variables:
+                    v.id.meta_level = 0
+            if isinstance(member_type, Overloaded):
+                for it in member_type.items():
+                    for v in it.variables:
+                        v.id.meta_level = 0
             if is_lvalue:
                 return member_type
             else:

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1767,6 +1767,25 @@ main:2: error: Revealed type is 'TypedDict(x=builtins.int, _fallback=typing.Mapp
 main:3: error: Revealed type is 'TypedDict(x=builtins.int, _fallback=ntcrash.C.A@4)'
 main:4: error: Revealed type is 'def () -> ntcrash.C.A@4'
 
+[case testGenericMethodRestoreMetaLevel]
+from typing import Dict
+
+d = {}  # type: Dict[str, int]
+g = d.get  # This should not crash: see https://github.com/python/mypy/issues/2804
+[builtins fixtures/dict.pyi]
+
+[case testGenericMethodRestoreMetaLevel2]
+from typing import TypeVar
+
+T = TypeVar('T')
+
+class D:
+    def m(self, x: T) -> T:
+        return x
+
+g = D().m  # This should not crash: see https://github.com/python/mypy/issues/2804
+[builtins fixtures/dict.pyi]
+
 [case testIncrementalPerFileFlags]
 # flags: --config-file tmp/mypy.ini
 import a

--- a/test-data/unit/fixtures/dict.pyi
+++ b/test-data/unit/fixtures/dict.pyi
@@ -1,6 +1,6 @@
 # Builtins stub used in dictionary-related test cases.
 
-from typing import TypeVar, Generic, Iterable, Iterator, Mapping, Tuple, overload
+from typing import TypeVar, Generic, Iterable, Iterator, Mapping, Tuple, overload, Optional, Union
 
 T = TypeVar('T')
 KT = TypeVar('KT')
@@ -19,6 +19,10 @@ class dict(Iterable[KT], Mapping[KT, VT], Generic[KT, VT]):
     def __setitem__(self, k: KT, v: VT) -> None: pass
     def __iter__(self) -> Iterator[KT]: pass
     def update(self, a: Mapping[KT, VT]) -> None: pass
+    @overload
+    def get(self, k: KT) -> Optional[VT]: pass
+    @overload
+    def get(self, k: KT, default: Union[KT, T]) -> Union[VT, T]: pass
 
 class int: # for convenience
     def __add__(self, x: int) -> int: pass

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -78,11 +78,7 @@ class Sequence(Iterable[T], Generic[T]):
     @abstractmethod
     def __getitem__(self, n: Any) -> T: pass
 
-class Mapping(Generic[T, U]):
-    @overload
-    def get(self, k: T) -> Optional[U]: pass
-    @overload
-    def get(self, k: T, default: Union[U, S]) -> Union[U, S]: pass
+class Mapping(Generic[T, U]): pass
 
 class MutableMapping(Generic[T, U]): pass
 

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -78,7 +78,11 @@ class Sequence(Iterable[T], Generic[T]):
     @abstractmethod
     def __getitem__(self, n: Any) -> T: pass
 
-class Mapping(Generic[T, U]): pass
+class Mapping(Generic[T, U]):
+    @overload
+    def get(self, k: T) -> Optional[U]: pass
+    @overload
+    def get(self, k: T, default: Union[U, S]) -> Union[U, S]: pass
 
 class MutableMapping(Generic[T, U]): pass
 


### PR DESCRIPTION
Fixes #2804 

The problem is that ``analize_member_access`` calls ``freshen_function_type_vars`` if the member is a function (i.e. method). This is necessary to not mix the type variables during type inference of generic methods inside generic functions. However, if the method does not participate in type inference, type variables are left in ``meta_level = 1`` state. This causes the error, since the types could not be serialized in the middle of type inference.

In this PR I propose to restore ``meta_level = 0`` on member access, this is safe, since anyway, ``check_call`` always calls ``freshen_function_type_vars`` on callee (for generic functions, generic methods, etc).