### PR TITLE
Allow omitting redundant Generic[T] in base classes

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -763,14 +763,17 @@ class SemanticAnalyzer(NodeVisitor):
     def get_tvars(self, tp: Type) -> List[Tuple[str, TypeVarExpr]]:
         tvars = []  # type: List[Tuple[str, TypeVarExpr]]
         if isinstance(tp, UnboundType):
-            for arg in tp.args:
-                tvar = self.analyze_unbound_tvar(arg)
-                if tvar:
-                    tvars.append(tvar)
-                else:
-                    subvars = self.get_tvars(arg)
-                    if subvars:
-                        tvars.extend(subvars)
+            tp_args = tp.args
+        elif isinstance(tp, TypeList):
+            tp_args = tp.items
+        else:
+            return tvars
+        for arg in tp_args:
+            tvar = self.analyze_unbound_tvar(arg)
+            if tvar:
+                tvars.append(tvar)
+            else:
+                tvars.extend(self.get_tvars(arg))
         return self.remove_dups(tvars)
 
     def remove_dups(self, tvars: List[T]) -> List[T]:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -692,7 +692,7 @@ class SemanticAnalyzer(NodeVisitor):
                 continue
             tvars = self.analyze_typevar_declaration(base)
             if tvars is not None:
-                if type_vars:
+                if declared_tvars:
                     self.fail('Duplicate Generic in bases', defn)
                 removed.append(i)
                 declared_tvars.extend(tvars)

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -738,9 +738,10 @@ TupledNode = Node[Tuple[T, T]]
 UNode = Union[int, Node[T]]
 
 class C(TupledNode): ... # Same as TupledNode[Any]
-class D(TupledNode[T]): ... # E: Invalid type "__main__.T"
+class D(TupledNode[T]): ...
 class E(Generic[T], UNode[T]): ... # E: Invalid base class
 
+reveal_type(D((1, 1))) # E: Revealed type is '__main__.D[builtins.int*]'
 [builtins fixtures/list.pyi]
 
 [case testGenericTypeAliasesUnion]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -998,6 +998,19 @@ reveal_type(D[str, int]().c()) # E: Revealed type is 'builtins.int*'
 [builtins fixtures/list.pyi]
 [out]
 
+[case testSimplifiedGenericCallable]
+from typing import TypeVar, Generic, Callable
+T = TypeVar('T')
+S = TypeVar('S')
+class B(Generic[T]):
+    def b(self) -> T: ...
+
+class D(B[Callable[[T], S]]): ...
+
+reveal_type(D[str, int]().b()) # E: Revealed type is 'def (builtins.str*) -> builtins.int*'
+[builtins fixtures/list.pyi]
+[out]
+
 [case testSimplifiedGenericComplex]
 from typing import TypeVar, Generic, Tuple
 T = TypeVar('T')

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -481,7 +481,7 @@ class C(Generic[T, S]):
     def __init__(self, x: T, y: S) -> None:
         ...
 
-class D(C[int, T], Generic[T]): ...
+class D(C[int, T]): ...
 
 D[str](1, 'a')
 D[str](1, 1)  # E: Argument 2 to "D" has incompatible type "int"; expected "str"
@@ -705,9 +705,9 @@ class Node(Generic[T]):
 
 TupledNode = Node[Tuple[T, T]]
 
-class D(Generic[T], TupledNode[T]):
+class D(TupledNode[T]):
     ...
-class L(Generic[T], List[TupledNode[T]]):
+class L(List[TupledNode[T]]):
     ...
 
 def f_bad(x: T) -> D[T]:
@@ -978,6 +978,107 @@ reveal_type(Bad) # E: Revealed type is 'Any'
 [out]
 
 
+-- Simplified declaration of generics
+-- ----------------------------------
+
+[case testSimplifiedGenericSimple]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+S = TypeVar('S')
+class B(Generic[T]):
+    def b(self) -> T: ...
+
+class C(Generic[T]):
+    def c(self) -> T: ...
+
+class D(B[T], C[S]): ...
+
+reveal_type(D[str, int]().b()) # E: Revealed type is 'builtins.str*'
+reveal_type(D[str, int]().c()) # E: Revealed type is 'builtins.int*'
+[builtins fixtures/list.pyi]
+[out]
+
+[case testSimplifiedGenericComplex]
+from typing import TypeVar, Generic, Tuple
+T = TypeVar('T')
+S = TypeVar('S')
+U = TypeVar('U')
+
+class A(Generic[T, S]):
+    pass
+
+class B(Generic[T, S]):
+    def m(self) -> Tuple[T, S]:
+        pass
+
+class C(A[S, B[T, int]], B[U, A[int, T]]):
+    pass
+
+c = C[object, int, str]()
+reveal_type(c.m()) # E: Revealed type is 'Tuple[builtins.str*, __main__.A*[builtins.int, builtins.int*]]'
+[builtins fixtures/tuple.pyi]
+[out]
+
+
+[case testSimplifiedGenericOrder]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+S = TypeVar('S')
+
+class B(Generic[T]):
+    def b(self) -> T: ...
+
+class C(Generic[T]):
+    def c(self) -> T: ...
+
+class D(B[T], C[S], Generic[S, T]): ...
+
+reveal_type(D[str, int]().b()) # E: Revealed type is 'builtins.int*'
+reveal_type(D[str, int]().c()) # E: Revealed type is 'builtins.str*'
+[builtins fixtures/list.pyi]
+[out]
+
+[case testSimplifiedGenericDuplicate]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+
+class A(Generic[T, T]): # E: Duplicate type variables in Generic[...]
+    pass
+
+a = A[int]()
+[builtins fixtures/list.pyi]
+[out]
+
+[case testSimplifiedGenericNotAll]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+S = TypeVar('S')
+
+class A(Generic[T]):
+    pass
+class B(Generic[T]):
+    pass
+
+class C(A[T], B[S], Generic[T]): # E: If Generic[...] is present it should list all type variables
+    pass
+
+c = C[int, str]()
+[builtins fixtures/list.pyi]
+[out]
+
+[case testSimplifiedGenericInvalid]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+
+class A(Generic[T]):
+    pass
+
+class B(A[S]): # E: Name 'S' is not defined
+    pass
+[builtins fixtures/list.pyi]
+[out]
+
+
 -- Multiple assignment with lists
 -- ------------------------------
 
@@ -1026,7 +1127,7 @@ class A: pass
 from typing import TypeVar, Generic, Iterable
 T = TypeVar('T')
 class object: pass
-class list(Iterable[T], Generic[T]):
+class list(Iterable[T]):
   def __setitem__(self, x: int, v: T) -> None: pass
 class int: pass
 class type: pass


### PR DESCRIPTION
Fixes #302 

This PR allows omitting ``Generic[T, ...]`` if there are other generics in bases:
```python
class Stream(Iterable[T]):
    ...
```
The rules are as per PEP 484:
* If ``Generic[...]`` is present, then it should list all type variables (or more). In this case the order of variables is determined by their order in ``Generic[...]``
* If there are no ``Generic[...]`` in bases, then all type variables are collected in lexicographic order (i.e. by first appearance)

@gvanrossum You might be interested in this.