### PR TITLE
Do not support metaclasses not inheriting from type

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2022,7 +2022,7 @@ class TypeInfo(SymbolNode):
         return None
 
     def is_metaclass(self) -> bool:
-        return self.has_base('builtins.type')
+        return self.has_base('builtins.type') or self.fullname() == 'abc.ABCMeta'
 
     def _calculate_is_enum(self) -> bool:
         """

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -911,6 +911,9 @@ class SemanticAnalyzer(NodeVisitor):
             if not isinstance(sym.node, TypeInfo) or sym.node.tuple_type is not None:
                 self.fail("Invalid metaclass '%s'" % defn.metaclass, defn)
                 return
+            if not sym.node.is_metaclass():
+                self.fail("Metaclasses not inheriting from 'type' are not supported", defn)
+                return
             inst = fill_typevars(sym.node)
             assert isinstance(inst, Instance)
             defn.info.declared_metaclass = inst

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2785,6 +2785,14 @@ def f(TA: Type[A]):
     reveal_type(TA)  # E: Revealed type is 'Type[__main__.A]'
     reveal_type(TA.x)  # E: Revealed type is 'builtins.int'
 
+[case testSubclassMetaclass]
+class M1(type):
+    x = 0
+class M2(M1): pass
+class C(metaclass=M2):
+    pass
+reveal_type(C.x) # E: Revealed type is 'builtins.int'
+
 [case testMetaclassIterable]
 from typing import Iterable, Iterator
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2770,9 +2770,9 @@ class B(A, metaclass=Y): pass  # E: Inconsistent metaclass structure for 'B'
 class M:
     x = 0  # type: int
 
-class A(metaclass=M): pass
+class A(metaclass=M): pass  # E: Metaclasses not inheriting from 'type' are not supported
 
-reveal_type(A.x)  # E: Revealed type is 'builtins.int'
+A.x  # E: "A" has no attribute "x"
 
 [case testMetaclassTypeReveal]
 from typing import Type


### PR DESCRIPTION
Fix #2818.

ABCMeta requires special treatment.

Related: #2475