### PR TITLE
Treat type equivalent to Type[Any]

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -136,6 +136,8 @@ class SubtypeVisitor(TypeVisitor[bool]):
         right = self.right
         if isinstance(right, TupleType) and right.fallback.type.is_enum:
             return is_subtype(left, right.fallback)
+        if isinstance(right, TypeType):
+            return left.type.fullname() == 'builtins.type' and isinstance(right.item, AnyType)
         if isinstance(right, Instance):
             if left.type._promote and is_subtype(
                     left.type._promote, self.right, self.check_type_parameter,

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -277,7 +277,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
             return is_subtype(left.item, right.item)
         if isinstance(right, CallableType):
             # This is unsound, we don't check the __init__ signature.
-            return right.is_type_obj() and is_subtype(left.item, right.ret_type
+            return right.is_type_obj() and is_subtype(left.item, right.ret_type)
         if isinstance(right, Instance):
             if right.type.fullname() == 'builtins.object':
                 # treat builtins.object the same as Any.

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -52,6 +52,11 @@ def is_subtype(left: Type, right: Type,
         return any(is_subtype(left, item, type_parameter_checker,
                               ignore_pos_arg_names=ignore_pos_arg_names)
                    for item in right.items)
+    # Treat builtins.type the same as Type[Any]
+    elif is_named_instance(left, 'builtins.type'):
+            return is_subtype(TypeType(AnyType()), right)
+    elif is_named_instance(right, 'builtins.type'):
+            return is_subtype(left, TypeType(AnyType()))
     else:
         return left.accept(SubtypeVisitor(right, type_parameter_checker,
                                           ignore_pos_arg_names=ignore_pos_arg_names))
@@ -136,8 +141,6 @@ class SubtypeVisitor(TypeVisitor[bool]):
         right = self.right
         if isinstance(right, TupleType) and right.fallback.type.is_enum:
             return is_subtype(left, right.fallback)
-        if isinstance(right, TypeType):
-            return left.type.fullname() == 'builtins.type' and isinstance(right.item, AnyType)
         if isinstance(right, Instance):
             if left.type._promote and is_subtype(
                     left.type._promote, self.right, self.check_type_parameter,
@@ -230,8 +233,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
         right = self.right
         if isinstance(right, Instance):
             return is_subtype(left.fallback, right)
-        elif isinstance(right, CallableType) or is_named_instance(
-                right, 'builtins.type'):
+        elif isinstance(right, CallableType):
             for item in left.items():
                 if is_subtype(item, right, self.check_type_parameter,
                               ignore_pos_arg_names=self.ignore_pos_arg_names):
@@ -271,9 +273,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
         if isinstance(right, CallableType):
             # This is unsound, we don't check the __init__ signature.
             return right.is_type_obj() and is_subtype(left.item, right.ret_type)
-        if (isinstance(right, Instance) and
-                right.type.fullname() in ('builtins.type', 'builtins.object')):
-            # Treat builtins.type the same as Type[Any];
+        if is_named_instance(right, 'builtins.object'):
             # treat builtins.object the same as Any.
             return True
         return False

--- a/mypy/test/testsubtypes.py
+++ b/mypy/test/testsubtypes.py
@@ -168,7 +168,7 @@ class SubtypingSuite(Suite):
             self.fx.callable_var_arg(0, self.fx.b, self.fx.d))
 
     def test_type_callable_subtyping(self) -> None:
-        self.assert_strict_subtype(
+        self.assert_subtype(
             self.fx.callable_type(self.fx.d, self.fx.a), self.fx.type_type)
 
         self.assert_strict_subtype(

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2134,7 +2134,7 @@ x = None # type: type
 y = None # type: Type[Any]
 z = None # type: Type[C]
 
-lst = [x, y]
+lst = [x, y, z]
 reveal_type(lst) # E: Revealed type is 'builtins.list[builtins.type*]'
 
 T1 = TypeVar('T1', bound=type)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2126,7 +2126,7 @@ q = p # type: Type[C]
 [builtins fixtures/list.pyi]
 [out]
 
-[case testTypeEquivalentTypeAny]
+[case testTypeEquivalentTypeAny2]
 from typing import Type, Any, TypeVar, Generic
 
 class C: ...

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2126,6 +2126,26 @@ q = p # type: Type[C]
 [builtins fixtures/list.pyi]
 [out]
 
+[case testTypeEquivalentTypeAny]
+from typing import Type, Any, TypeVar, Generic
+
+class C: ...
+x = None # type: type
+y = None # type: Type[Any]
+z = None # type: Type[C]
+
+lst = [x, y]
+reveal_type(lst) # E: Revealed type is 'builtins.list[builtins.type*]'
+
+T1 = TypeVar('T1', bound=type)
+T2 = TypeVar('T2', bound=Type[Any])
+class C1(Generic[T1]): ...
+class C2(Generic[T2]): ...
+
+C1[Type[Any]], C2[type] # both these sould not fail
+[builtins fixtures/list.pyi]
+[out]
+
 [case testTypeMatchesOverloadedFunctions]
 from typing import Type, overload, Union
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2121,7 +2121,7 @@ y = x # type: Type[Any]
 class C: ...
 
 p = None # type: type
-q = p # type: Type[C] # E: Incompatible types in assignment (expression has type "type", variable has type Type[C])
+q = p # type: Type[C]
 
 [builtins fixtures/list.pyi]
 [out]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2109,6 +2109,23 @@ def foo(c: Type[C], d: Type[D]) -> None:
 [out]
 main:7: error: Revealed type is 'builtins.list[Type[__main__.B]]'
 
+[case testTypeEquivalentTypeAny]
+from typing import Type, Any
+
+a = None # type: Type[Any]
+b = a # type: type
+
+x = None # type: type
+y = x # type: Type[Any]
+
+class C: ...
+
+p = None # type: type
+q = p # type: Type[C] # E: Incompatible types in assignment (expression has type "type", variable has type Type[C])
+
+[builtins fixtures/list.pyi]
+[out]
+
 [case testTypeMatchesOverloadedFunctions]
 from typing import Type, overload, Union
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2159,7 +2159,7 @@ T2 = TypeVar('T2', bound=Type[Any])
 class C1(Generic[T1]): ...
 class C2(Generic[T2]): ...
 
-C1[Type[Any]], C2[type] # both these sould not fail
+C1[Type[Any]], C2[type] # both these should not fail
 [builtins fixtures/list.pyi]
 [out]
 


### PR DESCRIPTION
Fixes #2655 

As discussed in typing docs, ``Type[Any]`` is equivalent to plain ``type``. ``is_subtype`` was checking this only one side, here I add the opposite side.