### PR TITLE
Allow using __getitem__ defined in metaclasses of non-generic classes

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -392,8 +392,13 @@ class MessageBuilder:
                 self.format(typ)), context)
         elif member == '__getitem__':
             # Indexed get.
-            self.fail('Value of type {} is not indexable'.format(
-                self.format(typ)), context)
+            # TODO: Fix this consistently in self.format
+            if isinstance(typ, CallableType) and typ.is_type_obj():
+                self.fail('The type {} is not generic and not indexable'.format(
+                    self.format(typ)), context)
+            else:
+                self.fail('Value of type {} is not indexable'.format(
+                    self.format(typ)), context)
         elif member == '__setitem__':
             # Indexed set.
             self.fail('Unsupported target for indexed assignment', context)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2623,7 +2623,7 @@ class SemanticAnalyzer(NodeVisitor):
         expr.base.accept(self)
         if (isinstance(expr.base, RefExpr)
                 and isinstance(expr.base.node, TypeInfo)
-                and expr.base.node.is_enum):
+                and not expr.base.node.is_generic()):
             expr.index.accept(self)
         elif isinstance(expr.base, RefExpr) and expr.base.kind == TYPE_ALIAS:
             # Special form -- subscripting a generic type alias.

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2845,3 +2845,11 @@ class Concrete(metaclass=Meta):
 
 reveal_type(Concrete + X())  # E: Revealed type is 'builtins.str'
 Concrete + "hello"  # E: Unsupported operand types for + ("Meta" and "str")
+
+[case testMetaclassGetitem]
+class M(type):
+    def __getitem__(self, key) -> int: return 1
+
+class A(metaclass=M): pass
+
+reveal_type(A[M])  # E: Revealed type is 'builtins.int'

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -449,7 +449,7 @@ A[int, str, int]() # E: Type application has too many types (2 expected)
 a = None # type: A
 class A: pass
 a[A]()  # E: Value of type "A" is not indexable
-A[A]()  # E: Value of type "A" is not indexable
+A[A]()  # E: The type "A" is not generic and not indexable
 [out]
 
 [case testTypeApplicationArgTypes]
@@ -505,7 +505,7 @@ Alias[int]("a")  # E: Argument 1 to "Node" has incompatible type "str"; expected
 [out]
 
 [case testTypeApplicationCrash]
-type[int] # this was crashing, see #2302 (comment)  # E: Value of type "type" is not indexable
+type[int] # this was crashing, see #2302 (comment)  # E: The type "type" is not generic and not indexable
 [out]
 
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -449,7 +449,7 @@ A[int, str, int]() # E: Type application has too many types (2 expected)
 a = None # type: A
 class A: pass
 a[A]()  # E: Value of type "A" is not indexable
-A[A]()  # E: Type application targets a non-generic function or class
+A[A]()  # E: Value of type "A" is not indexable
 [out]
 
 [case testTypeApplicationArgTypes]
@@ -505,7 +505,7 @@ Alias[int]("a")  # E: Argument 1 to "Node" has incompatible type "str"; expected
 [out]
 
 [case testTypeApplicationCrash]
-type[int] # this was crashing, see #2302 (comment)  # E: Type application targets a non-generic function or class
+type[int] # this was crashing, see #2302 (comment)  # E: Value of type "type" is not indexable
 [out]
 
 

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -103,13 +103,6 @@ class A: pass
 x = cast(A[int], 1) # E: "A" expects no type arguments, but 1 given
 [out]
 
-[case testInvalidNumberOfGenericArgsInTypeApplication]
-import typing
-class A: pass
-class B: pass
-x = A[B[int]]() # E: "B" expects no type arguments, but 1 given
-[out]
-
 [case testInvalidNumberOfGenericArgsInNestedGenericType]
 from typing import TypeVar, Generic
 T = TypeVar('T')


### PR DESCRIPTION
Fix #1771. (Seems to be much simpler than I thought)

In particular, this will allow removing some special-casing for enum (#2812).

Related to #1381.