### PR TITLE
Partial support for metaclasses in Python 2

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -966,7 +966,10 @@ class SemanticAnalyzer(NodeVisitor):
                         if isinstance(body_node.rvalue, NameExpr):
                             defn.metaclass = body_node.rvalue.name
                         else:
-                            self.fail("Dynamic metaclass not supported for '%s'" % defn.name, body_node)
+                            self.fail(
+                                "Dynamic metaclass not supported for '%s'" % defn.name,
+                                body_node
+                            )
                             return None
         if defn.metaclass:
             if defn.metaclass == '<error>':

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -959,12 +959,15 @@ class SemanticAnalyzer(NodeVisitor):
             for body_node in defn.defs.body:
                 if isinstance(body_node, ClassDef) and body_node.name == "__metaclass__":
                     self.fail("Metaclasses defined as inner classes are not supported", body_node)
-                    return
+                    return None
                 elif isinstance(body_node, AssignmentStmt) and len(body_node.lvalues) == 1:
                     lvalue = body_node.lvalues[0]
                     if isinstance(lvalue, NameExpr) and lvalue.name == "__metaclass__":
                         if isinstance(body_node.rvalue, NameExpr):
                             defn.metaclass = body_node.rvalue.name
+                        else:
+                            self.fail("Dynamic metaclass not supported for '%s'" % defn.name, body_node)
+                            return None
         if defn.metaclass:
             if defn.metaclass == '<error>':
                 self.fail("Dynamic metaclass not supported for '%s'" % defn.name, defn)

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -253,3 +253,7 @@ class A(object):
 
 reveal_type(A.x) # E: Revealed type is 'builtins.int'
 reveal_type(A.test()) # E: Revealed type is 'builtins.str'
+
+[case testDynamicMetaclass]
+class C(object):
+    __metaclass__ = int()  # E: Dynamic metaclass not supported for 'C'

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -240,3 +240,16 @@ class A:
 def f():
     # type: () -> None
     u"unicode"
+
+[case testMetaclassBasics]
+class M(type):
+    x = 0  # type: int
+    def test(cls):
+        # type: () -> str
+        return "test"
+
+class A(object):
+    __metaclass__ = M
+
+reveal_type(A.x) # E: Revealed type is 'builtins.int'
+reveal_type(A.test()) # E: Revealed type is 'builtins.str'


### PR DESCRIPTION
Works with `__metaclass__ = M`, does not work with inner class (`class __metaclass__(type):`) declarations.

This feels a bit hacky, but seems to consistently work.