### PR TITLE
Strip type objects when constructing TypeType

### DIFF
--- a/mypy/test/testtypegen.py
+++ b/mypy/test/testtypegen.py
@@ -88,7 +88,7 @@ class SkippedNodeSearcher(TraverserVisitor):
         self.is_typing = False
 
     def visit_mypy_file(self, f: MypyFile) -> None:
-        self.is_typing = f.fullname() == 'typing'
+        self.is_typing = f.fullname() == 'typing' or f.fullname() == 'builtins'
         super().visit_mypy_file(f)
 
     def visit_assignment_stmt(self, s: AssignmentStmt) -> None:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -129,7 +129,7 @@ class TypeAnalyser(TypeVisitor[Type]):
                 return TypeVarType(sym.tvar_def, t.line)
             elif fullname == 'builtins.None':
                 return NoneTyp()
-            elif fullname == 'typing.Any':
+            elif fullname == 'typing.Any' or fullname == 'builtins.Any':
                 return AnyType()
             elif fullname == 'typing.Tuple':
                 if len(t.args) == 0 and not t.empty_tuple_index:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1146,7 +1146,10 @@ class TypeType(Type):
 
     def __init__(self, item: Type, *, line: int = -1, column: int = -1) -> None:
         super().__init__(line, column)
-        self.item = item
+        if isinstance(item, CallableType) and item.is_type_obj():
+            self.item = item.fallback
+        else:
+            self.item = item
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_type_type(self)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -384,6 +384,7 @@ class Instance(Type):
 
     def __init__(self, typ: Optional[mypy.nodes.TypeInfo], args: List[Type],
                  line: int = -1, column: int = -1, erased: bool = False) -> None:
+        assert(typ is None or typ.fullname() not in ["builtins.Any", "typing.Any"])
         self.type = typ
         self.args = args
         self.erased = erased

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3111,3 +3111,11 @@ reveal_type(A.x) # E: Revealed type is 'Any'
 A.f(1) # E: Too many arguments for "f" of "A"
 A().g(1) # E: Too many arguments for "g" of "A"
 [builtins fixtures/classmethod.pyi]
+
+[case testMetaclassTypeCallable]
+class M(type):
+    x = 5
+
+class A(metaclass=M): pass
+reveal_type(type(A).x)  # E: Revealed type is 'builtins.int'
+

--- a/test-data/unit/lib-stub/__builtin__.pyi
+++ b/test-data/unit/lib-stub/__builtin__.pyi
@@ -1,4 +1,4 @@
-class Any: pass
+Any = 0
 
 class object:
     def __init__(self):

--- a/test-data/unit/lib-stub/builtins.pyi
+++ b/test-data/unit/lib-stub/builtins.pyi
@@ -1,4 +1,4 @@
-class Any: pass
+Any = 0
 
 class object:
     def __init__(self) -> None: pass

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -736,7 +736,7 @@ MypyFile:1(
       f
       Args(
         Var(a))
-      def (a: builtins.Any) -> builtins.Any
+      def (a: Any) -> Any
       Block:7(
         ReturnStmt:7(
           NameExpr(a [l]))))


### PR DESCRIPTION
Fix #2826,

I am not entirely sure this is the right fix, but removing a level of indirection seems reasonable. (I think the right thing, in the long run, is to remove TypeType completely from the system)

There are changes in testtypegen, which I do not completely understand but without which it kept adding `IntExpr(1)` in the output - presumably from Any.