### PR TITLE
Improve join and meet of callables and overloads

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -925,7 +925,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                          formal_to_actual, None, None):
             # Too few or many arguments -> no match.
             return 0
-
         similarity = 2
 
         def check_arg(caller_type: Type, original_caller_type: Type, caller_kind: int,
@@ -2400,9 +2399,12 @@ def overload_arg_similarity(actual: Type, formal: Type) -> int:
             (isinstance(actual, Instance) and actual.type.fallback_to_any)):
         # These could match anything at runtime.
         return 2
-    if isinstance(formal, CallableType) and isinstance(actual, (CallableType, Overloaded)):
-        # TODO: do more sophisticated callable matching
-        return 2
+    if isinstance(formal, CallableType):
+        if isinstance(actual, (CallableType, Overloaded)):
+            # TODO: do more sophisticated callable matching
+            return 2
+        if isinstance(actual, TypeType):
+            return 2 if is_subtype(actual, formal) else 0
     if isinstance(actual, NoneTyp):
         if not experiments.STRICT_OPTIONAL:
             # NoneTyp matches anything if we're not doing strict Optional checking

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -925,6 +925,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                          formal_to_actual, None, None):
             # Too few or many arguments -> no match.
             return 0
+
         similarity = 2
 
         def check_arg(caller_type: Type, original_caller_type: Type, caller_kind: int,

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -369,7 +369,7 @@ def join_similar_callables(t: CallableType, s: CallableType) -> CallableType:
     arg_types = []  # type: List[Type]
     for i in range(len(t.arg_types)):
         arg_types.append(meet_types(t.arg_types[i], s.arg_types[i]))
-    # TODO kinds and argument names
+    # TODO in combine_similar_callables also applies here (names and kinds)
     # The fallback type can be either 'function' or 'type'. The result should have 'type' as
     # fallback only if both operands have it as 'type'.
     if t.fallback.type.fullname() != 'builtins.type':

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -180,7 +180,11 @@ class TypeJoinVisitor(TypeVisitor[Type]):
         if isinstance(self.s, CallableType) and is_similar_callables(t, self.s):
             if is_equivalent(t, self.s):
                 return combine_similar_callables(t, self.s)
-            return join_similar_callables(t, self.s)
+            result = join_similar_callables(t, self.s)
+            if any(isinstance(tp, (NoneTyp, UninhabitedType)) for tp in result.arg_types):
+                # We don't want to return unusable Callable, attempt fallback instead.
+                return join_types(t.fallback, self.s)
+            return result
         elif isinstance(self.s, Overloaded):
             # Switch the order of arguments to that we'll get to visit_overloaded.
             return join_types(t, self.s)

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -177,14 +177,15 @@ class TypeJoinVisitor(TypeVisitor[Type]):
             return self.default(self.s)
 
     def visit_callable_type(self, t: CallableType) -> Type:
-        # TODO: Consider subtyping instead of just similarity.
         if isinstance(self.s, CallableType) and is_similar_callables(t, self.s):
+            if is_equivalent(t, self.s):
+                return combine_similar_callables(t, self.s)
             return join_similar_callables(t, self.s)
         elif isinstance(self.s, Overloaded):
             # Switch the order of arguments to that we'll get to visit_overloaded.
             return join_types(t, self.s)
         else:
-            return join_types(self.s, t.fallback)
+            return join_types(t.fallback, self.s)
 
     def visit_overloaded(self, t: Overloaded) -> Type:
         # This is more complex than most other cases. Here are some
@@ -214,7 +215,7 @@ class TypeJoinVisitor(TypeVisitor[Type]):
         #   join(Ov([int, Any] -> Any, [str, Any] -> Any), [Any, int] -> Any) ==
         #       Ov([Any, int] -> Any, [Any, int] -> Any)
         #
-        # TODO: Use callable subtyping instead of just similarity.
+        # TODO: Consider more cases of callable subtyping.
         result = []  # type: List[CallableType]
         s = self.s
         if isinstance(s, FunctionLike):
@@ -222,7 +223,10 @@ class TypeJoinVisitor(TypeVisitor[Type]):
             for t_item in t.items():
                 for s_item in s.items():
                     if is_similar_callables(t_item, s_item):
-                        result.append(join_similar_callables(t_item, s_item))
+                        if is_equivalent(t_item, s_item):
+                            result.append(combine_similar_callables(t_item, s_item))
+                        elif is_subtype(t_item, s_item):
+                            result.append(s_item)
             if result:
                 # TODO: Simplify redundancies from the result.
                 if len(result) == 1:
@@ -352,21 +356,36 @@ def is_better(t: Type, s: Type) -> bool:
 
 
 def is_similar_callables(t: CallableType, s: CallableType) -> bool:
-    """Return True if t and s are equivalent and have identical numbers of
+    """Return True if t and s have identical numbers of
     arguments, default arguments and varargs.
     """
 
     return (len(t.arg_types) == len(s.arg_types) and t.min_args == s.min_args and
-            t.is_var_arg == s.is_var_arg and
-            t.fallback.type.fullname() == s.fallback.type.fullname())
+            t.is_var_arg == s.is_var_arg)
 
 
 def join_similar_callables(t: CallableType, s: CallableType) -> CallableType:
     from mypy.meet import meet_types
-
     arg_types = []  # type: List[Type]
     for i in range(len(t.arg_types)):
         arg_types.append(meet_types(t.arg_types[i], s.arg_types[i]))
+    # TODO kinds and argument names
+    # The fallback type can be either 'function' or 'type'. The result should have 'type' as
+    # fallback only if both operands have it as 'type'.
+    if t.fallback.type.fullname() != 'builtins.type':
+        fallback = t.fallback
+    else:
+        fallback = s.fallback
+    return t.copy_modified(arg_types=arg_types,
+                           ret_type=join_types(t.ret_type, s.ret_type),
+                           fallback=fallback,
+                           name=None)
+
+
+def combine_similar_callables(t: CallableType, s: CallableType) -> CallableType:
+    arg_types = []  # type: List[Type]
+    for i in range(len(t.arg_types)):
+        arg_types.append(join_types(t.arg_types[i], s.arg_types[i]))
     # TODO kinds and argument names
     # The fallback type can be either 'function' or 'type'. The result should have 'type' as
     # fallback only if both operands have it as 'type'.

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from typing import List, Optional
 
-from mypy.join import is_similar_callables, join_type_list
+from mypy.join import is_similar_callables, combine_similar_callables, join_type_list
 from mypy.types import (
     Type, AnyType, TypeVisitor, UnboundType, Void, ErrorType, NoneTyp, TypeVarType,
     Instance, CallableType, TupleType, TypedDictType, ErasedType, TypeList, UnionType, PartialType,
@@ -235,6 +235,8 @@ class TypeMeetVisitor(TypeVisitor[Type]):
 
     def visit_callable_type(self, t: CallableType) -> Type:
         if isinstance(self.s, CallableType) and is_similar_callables(t, self.s):
+            if is_equivalent(t, self.s):
+                return combine_similar_callables(t, self.s)
             return meet_similar_callables(t, self.s)
         else:
             return self.default(self.s)

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -305,7 +305,7 @@ def meet_similar_callables(t: CallableType, s: CallableType) -> CallableType:
     arg_types = []  # type: List[Type]
     for i in range(len(t.arg_types)):
         arg_types.append(join_types(t.arg_types[i], s.arg_types[i]))
-    # TODO kinds and argument names
+    # TODO in combine_similar_callables also applies here (names and kinds)
     # The fallback type can be either 'function' or 'type'. The result should have 'function' as
     # fallback only if both operands have it as 'function'.
     if t.fallback.type.fullname() != 'builtins.function':

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -237,7 +237,11 @@ class TypeMeetVisitor(TypeVisitor[Type]):
         if isinstance(self.s, CallableType) and is_similar_callables(t, self.s):
             if is_equivalent(t, self.s):
                 return combine_similar_callables(t, self.s)
-            return meet_similar_callables(t, self.s)
+            result = meet_similar_callables(t, self.s)
+            if isinstance(result.ret_type, UninhabitedType):
+                # Return a plain None or <uninhabited> instead of a weird function.
+                return self.default(self.s)
+            return result
         else:
             return self.default(self.s)
 

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -390,10 +390,10 @@ class JoinSuite(Suite):
 
         self.assert_join(self.callable(self.fx.a, self.fx.b),
                          self.callable(self.fx.b, self.fx.b),
-                         self.fx.function)
+                         self.callable(self.fx.b, self.fx.b))
         self.assert_join(self.callable(self.fx.a, self.fx.b),
                          self.callable(self.fx.a, self.fx.a),
-                         self.fx.function)
+                         self.callable(self.fx.a, self.fx.a))
         self.assert_join(self.callable(self.fx.a, self.fx.b),
                          self.fx.function,
                          self.fx.function)
@@ -509,7 +509,7 @@ class JoinSuite(Suite):
                                        self.fx.a),
                          self.callable(self.fx.a, self.fx.anyt, self.fx.a,
                                        self.fx.anyt),
-                         self.callable(self.fx.a, self.fx.anyt, self.fx.anyt,
+                         self.callable(self.fx.a, self.fx.a, self.fx.a,
                                        self.fx.anyt))
 
     def test_overloaded(self) -> None:
@@ -523,8 +523,8 @@ class JoinSuite(Suite):
         c1 = c(fx.a, fx.a)
         c2 = c(fx.b, fx.b)
         c3 = c(fx.c, fx.c)
-        self.assert_join(ov(c1, c2), c1, c1)
-        self.assert_join(ov(c1, c2), c2, c2)
+        self.assert_join(ov(c1, c2), c1, ov(c(fx.a, fx.a), c(fx.b, fx.a)))
+        self.assert_join(ov(c1, c2), c2, ov(c(fx.b, fx.a), c(fx.b, fx.b)))
         self.assert_join(ov(c1, c2), ov(c1, c2), ov(c1, c2))
         self.assert_join(ov(c1, c2), ov(c1, c3), c1)
         self.assert_join(ov(c2, c1), ov(c3, c1), c1)
@@ -538,8 +538,8 @@ class JoinSuite(Suite):
 
         fx = self.fx
         any = fx.anyt
-        self.assert_join(ov(c(fx.a, fx.a), c(fx.b, fx.b)), c(any, fx.b), c(any, fx.b))
-        self.assert_join(ov(c(fx.a, fx.a), c(any, fx.b)), c(fx.b, fx.b), c(any, fx.b))
+        self.assert_join(ov(c(fx.a, fx.a), c(fx.b, fx.b)), c(any, fx.b), ov(c(fx.a, fx.a), c(fx.b, fx.b)))
+        self.assert_join(ov(c(fx.a, fx.a), c(any, fx.b)), c(fx.b, fx.b), ov(c(fx.b, fx.a), c(fx.b, fx.b)))
 
     def test_join_interface_types(self) -> None:
         self.skip()  # FIX
@@ -578,13 +578,14 @@ class JoinSuite(Suite):
     def test_simple_type_objects(self) -> None:
         t1 = self.type_callable(self.fx.a, self.fx.a)
         t2 = self.type_callable(self.fx.b, self.fx.b)
+        tr = self.type_callable(self.fx.b, self.fx.a)
 
         self.assert_join(t1, t1, t1)
         j = join_types(t1, t1)
         assert isinstance(j, CallableType)
         assert_true(j.is_type_obj())
 
-        self.assert_join(t1, t2, self.fx.type_type)
+        self.assert_join(t1, t2, tr)
         self.assert_join(t1, self.fx.type_type, self.fx.type_type)
         self.assert_join(self.fx.type_type, self.fx.type_type,
                          self.fx.type_type)
@@ -678,10 +679,10 @@ class MeetSuite(Suite):
 
         self.assert_meet(self.callable(self.fx.a, self.fx.b),
                          self.callable(self.fx.b, self.fx.b),
-                         NoneTyp())
+                         self.callable(self.fx.a, self.fx.b))
         self.assert_meet(self.callable(self.fx.a, self.fx.b),
                          self.callable(self.fx.a, self.fx.a),
-                         NoneTyp())
+                         self.callable(self.fx.a, self.fx.b))
 
     def test_type_vars(self) -> None:
         self.assert_meet(self.fx.t, self.fx.t, self.fx.t)
@@ -778,7 +779,7 @@ class MeetSuite(Suite):
                          self.callable(self.fx.a, self.fx.anyt, self.fx.a,
                                        self.fx.anyt),
                          self.callable(self.fx.a, self.fx.anyt, self.fx.anyt,
-                                       self.fx.anyt))
+                                       self.fx.a))
 
     def test_meet_interface_types(self) -> None:
         self.assert_meet(self.fx.f, self.fx.f, self.fx.f)

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -509,7 +509,7 @@ class JoinSuite(Suite):
                                        self.fx.a),
                          self.callable(self.fx.a, self.fx.anyt, self.fx.a,
                                        self.fx.anyt),
-                         self.callable(self.fx.a, self.fx.a, self.fx.a,
+                         self.callable(self.fx.a, self.fx.anyt, self.fx.anyt,
                                        self.fx.anyt))
 
     def test_overloaded(self) -> None:
@@ -523,8 +523,8 @@ class JoinSuite(Suite):
         c1 = c(fx.a, fx.a)
         c2 = c(fx.b, fx.b)
         c3 = c(fx.c, fx.c)
-        self.assert_join(ov(c1, c2), c1, ov(c(fx.a, fx.a), c(fx.b, fx.a)))
-        self.assert_join(ov(c1, c2), c2, ov(c(fx.b, fx.a), c(fx.b, fx.b)))
+        self.assert_join(ov(c1, c2), c1, c1)
+        self.assert_join(ov(c1, c2), c2, c2)
         self.assert_join(ov(c1, c2), ov(c1, c2), ov(c1, c2))
         self.assert_join(ov(c1, c2), ov(c1, c3), c1)
         self.assert_join(ov(c2, c1), ov(c3, c1), c1)
@@ -538,8 +538,8 @@ class JoinSuite(Suite):
 
         fx = self.fx
         any = fx.anyt
-        self.assert_join(ov(c(fx.a, fx.a), c(fx.b, fx.b)), c(any, fx.b), ov(c(fx.a, fx.a), c(fx.b, fx.b)))
-        self.assert_join(ov(c(fx.a, fx.a), c(any, fx.b)), c(fx.b, fx.b), ov(c(fx.b, fx.a), c(fx.b, fx.b)))
+        self.assert_join(ov(c(fx.a, fx.a), c(fx.b, fx.b)), c(any, fx.b), c(any, fx.b))
+        self.assert_join(ov(c(fx.a, fx.a), c(any, fx.b)), c(fx.b, fx.b), c(any, fx.b))
 
     def test_join_interface_types(self) -> None:
         self.skip()  # FIX
@@ -779,7 +779,7 @@ class MeetSuite(Suite):
                          self.callable(self.fx.a, self.fx.anyt, self.fx.a,
                                        self.fx.anyt),
                          self.callable(self.fx.a, self.fx.anyt, self.fx.anyt,
-                                       self.fx.a))
+                                       self.fx.anyt))
 
     def test_meet_interface_types(self) -> None:
         self.assert_meet(self.fx.f, self.fx.f, self.fx.f)

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -397,6 +397,9 @@ class JoinSuite(Suite):
         self.assert_join(self.callable(self.fx.a, self.fx.b),
                          self.fx.function,
                          self.fx.function)
+        self.assert_join(self.callable(self.fx.a, self.fx.b),
+                         self.callable(self.fx.d, self.fx.b),
+                         self.fx.function)
 
     def test_type_vars(self) -> None:
         self.assert_join(self.fx.t, self.fx.t, self.fx.t)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -723,6 +723,7 @@ def call(c: Callable[[int], Any], i: int) -> None:
 [out]
 
 [case testCallableMeetAndJoin]
+# flags: --python-version 3.6
 from typing import Callable, Any, TypeVar
 
 class A: ...

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -722,6 +722,32 @@ def call(c: Callable[[int], Any], i: int) -> None:
 [builtins fixtures/list.pyi]
 [out]
 
+[case testCallableMeetAndJoin]
+from typing import Callable, Any, TypeVar
+
+class A: ...
+class B(A): ...
+
+def f(c: Callable[[B], int]) -> None: ...
+
+c: Callable[[A], int]
+d: Callable[[B], int]
+
+lst = [c, d]
+reveal_type(lst) # E: Revealed type is 'builtins.list[def (tstmorecall.B) -> builtins.int]'
+
+T = TypeVar('T')
+def meet_test(x: Callable[[T], int], y: Callable[[T], int]) -> T: ...
+
+CA = Callable[[A], A]
+CB = Callable[[B], B]
+
+ca: Callable[[CA], int]
+cb: Callable[[CB], int]
+reveal_type(meet_test(ca, cb)) # E: Revealed type is Revealed type is 'def (tstmorecall.A) -> tstmorecall.B'
+[builtins fixtures/list.pyi]
+[out]
+
 [case testUnionInferenceWithTypeVarValues]
 from typing import TypeVar, Union
 AnyStr = TypeVar('AnyStr', bytes, str)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -701,6 +701,26 @@ i(b, a, b)
 i(a, b, b) # E: Argument 1 to "i" has incompatible type List[int]; expected List[str]
 [builtins fixtures/list.pyi]
 
+[case testListJoinInference]
+from typing import Any, Callable
+
+def fun() -> None:
+    callbacks = [
+        callback1,
+        callback2,
+    ]
+
+    for c in callbacks:
+        call(c, 1234) # this must not fail
+
+def callback1(i: int) -> int:
+    return i
+def callback2(i: int) -> str:
+    return 'hello'
+def call(c: Callable[[int], Any], i: int) -> None:
+    c(i)
+[builtins fixtures/list.pyi]
+[out]
 
 [case testUnionInferenceWithTypeVarValues]
 from typing import TypeVar, Union

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -745,7 +745,7 @@ CB = Callable[[B], B]
 
 ca: Callable[[CA], int]
 cb: Callable[[CB], int]
-reveal_type(meet_test(ca, cb)) # E: Revealed type is Revealed type is 'def (__main__.A) -> __main__.B'
+reveal_type(meet_test(ca, cb)) # E: Revealed type is 'def (__main__.A) -> __main__.B'
 [builtins fixtures/list.pyi]
 [out]
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -735,7 +735,7 @@ c: Callable[[A], int]
 d: Callable[[B], int]
 
 lst = [c, d]
-reveal_type(lst) # E: Revealed type is 'builtins.list[def (tstmorecall.B) -> builtins.int]'
+reveal_type(lst) # E: Revealed type is 'builtins.list[def (__main__.B) -> builtins.int]'
 
 T = TypeVar('T')
 def meet_test(x: Callable[[T], int], y: Callable[[T], int]) -> T: ...
@@ -745,7 +745,7 @@ CB = Callable[[B], B]
 
 ca: Callable[[CA], int]
 cb: Callable[[CB], int]
-reveal_type(meet_test(ca, cb)) # E: Revealed type is Revealed type is 'def (tstmorecall.A) -> tstmorecall.B'
+reveal_type(meet_test(ca, cb)) # E: Revealed type is Revealed type is 'def (__main__.A) -> __main__.B'
 [builtins fixtures/list.pyi]
 [out]
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -701,7 +701,7 @@ i(b, a, b)
 i(a, b, b) # E: Argument 1 to "i" has incompatible type List[int]; expected List[str]
 [builtins fixtures/list.pyi]
 
-[case testListJoinInference]
+[case testCallableListJoinInference]
 from typing import Any, Callable
 
 def fun() -> None:


### PR DESCRIPTION
Fixes #1983 

Here I implement:
* ``join(Callable[[A1], R1]), Callable[[A2], R2]) == Callable[[meet(A1, A2)], join(R1, R2)]``
* ``meet(Callable[[A1], R1]), Callable[[A2], R2]) == Callable[[join(A1, A2)], meet(R1, R2)]``
plus special cases for ``Any``, overloads, and callable type objects.
The meet and join are still not perfect, but I think this PR improves the situation.

@ddfisher I just noticed that you assigned issue to yourself, I hope you are not too angry at me.