### PR TITLE
Allow TypedDict field names starting with underscore

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1100,9 +1100,6 @@ class SemanticAnalyzer(NodeVisitor):
                 fields.append(name)
                 types.append(AnyType() if stmt.type is None else self.anal_type(stmt.type))
                 # ...despite possible minor failures that allow further analyzis.
-                if name.startswith('_'):
-                    self.fail('TypedDict field name cannot start with an underscore: {}'
-                              .format(name), stmt)
                 if stmt.type is None or hasattr(stmt, 'new_syntax') and not stmt.new_syntax:
                     self.fail(TPDICT_CLASS_ERROR, stmt)
                 elif not isinstance(stmt.rvalue, TempNode):
@@ -2118,10 +2115,6 @@ class SemanticAnalyzer(NodeVisitor):
                 "TypedDict() expects a dictionary literal as the second argument", call)
         dictexpr = args[1]
         items, types, ok = self.parse_typeddict_fields_with_types(dictexpr.items, call)
-        underscore = [item for item in items if item.startswith('_')]
-        if underscore:
-            self.fail("TypedDict() item names cannot start with an underscore: "
-                      + ', '.join(underscore), call)
         return items, types, ok
 
     def parse_typeddict_fields_with_types(self, dict_items: List[Tuple[Expression, Expression]],

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -155,13 +155,18 @@ p = Point(x=42, y=1337, z='whatever')
 reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, z=builtins.str, _fallback=typing.Mapping[builtins.str, builtins.object])'
 [builtins fixtures/dict.pyi]
 
-[case testCannotCreateTypedDictWithClassUnderscores]
+[case testCanCreateTypedDictTypeWithUnderscoreItemName]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int, '_fallback': object})
+[builtins fixtures/dict.pyi]
+
+[case testCanCreateTypedDictWithClassUnderscores]
 # flags: --python-version 3.6
 from mypy_extensions import TypedDict
 
 class Point(TypedDict):
     x: int
-    _y: int  # E: TypedDict field name cannot start with an underscore: _y
+    _y: int
 
 p: Point
 reveal_type(p) # E: Revealed type is 'TypedDict(x=builtins.int, _y=builtins.int, _fallback=__main__.Point)'

--- a/test-data/unit/semanal-typeddict.test
+++ b/test-data/unit/semanal-typeddict.test
@@ -58,11 +58,6 @@ from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x'})  # E: TypedDict() expects a dictionary literal as the second argument
 [builtins fixtures/dict.pyi]
 
-[case testCannotCreateTypedDictTypeWithUnderscoreItemName]
-from mypy_extensions import TypedDict
-Point = TypedDict('Point', {'x': int, 'y': int, '_fallback': object})  # E: TypedDict() item names cannot start with an underscore: _fallback
-[builtins fixtures/dict.pyi]
-
 -- NOTE: The following code works at runtime but is not yet supported by mypy.
 --       Keyword arguments may potentially be supported in the future.
 [case testCannotCreateTypedDictTypeWithNonpositionalArgs]


### PR DESCRIPTION
As proposed by @JukkaL in discussion of #2808 
Unlike ``NamedTuple``, where the limitation on field names is imposed by underlying ``collections.namedtuple``, here we are free. In case if we decide to include special keyword arguments later, we could just check for those particular names.