### PR TITLE
Handle unions in is_proper_subtype

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -514,6 +514,12 @@ def is_proper_subtype(t: Type, s: Type) -> bool:
     Any types. Any instance type t is also a proper subtype of t.
     """
     # FIX tuple types
+    if isinstance(s, UnionType):
+        if isinstance(t, UnionType):
+            return all([is_proper_subtype(item, s) for item in t.items])
+        else:
+            return any([is_proper_subtype(t, item) for item in s.items])
+
     if isinstance(t, Instance):
         if isinstance(s, Instance):
             if not t.type.has_base(s.type.fullname()):

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -210,6 +210,12 @@ class TypeOpsSuite(Suite):
         assert_true(is_proper_subtype(fx.t, fx.t))
         assert_false(is_proper_subtype(fx.t, fx.s))
 
+        assert_true(is_proper_subtype(fx.a, UnionType([fx.a, fx.b])))
+        assert_true(is_proper_subtype(UnionType([fx.a, fx.b]),
+                                      UnionType([fx.a, fx.b, fx.c])))
+        assert_false(is_proper_subtype(UnionType([fx.a, fx.b]),
+                                       UnionType([fx.b, fx.c])))
+
     def test_is_proper_subtype_covariance(self) -> None:
         fx_co = self.fx_co
 

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -534,6 +534,22 @@ if isinstance(v, (B, C)):
     v.method3('xyz') # E: Some element of union has no attribute "method3"
 [builtins fixtures/isinstance.pyi]
 
+[case testIsinstanceNeverWidens]
+from typing import Union
+
+class A: pass
+class B: pass
+class C: pass
+
+a = A()  # type: A
+assert isinstance(a, (A, B))
+reveal_type(a)  # E: Revealed type is '__main__.A'
+
+b = A()  # type: Union[A, B]
+assert isinstance(b, (A, B, C))
+reveal_type(b)  # E: Revealed type is 'Union[__main__.A, __main__.B]'
+[builtins fixtures/isinstance.pyi]
+
 [case testMemberAssignmentChanges-skip]
 from typing import Union
 


### PR DESCRIPTION
Fixes #2840.

If you guys don't want to change `is_proper_subtype`, I have another fix, too.