### PR TITLE
Fix crash on invalid type comments/annotations

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -44,9 +44,7 @@ U = TypeVar('U', bound=Node)
 V = TypeVar('V')
 
 TYPE_COMMENT_SYNTAX_ERROR = 'syntax error in type comment'
-TYPE_COMMENT_AST_ERROR = 'invalid type comment'
-if sys.version_info.minor > 2:
-    TYPE_COMMENT_AST_ERROR += '/annotation'
+TYPE_COMMENT_AST_ERROR = 'invalid type comment/annotation'
 
 
 def parse(source: Union[str, bytes], fnam: str = None, errors: Errors = None,

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -964,7 +964,8 @@ class TypeConverter(ast35.NodeTransformer):
 
         value = self.visit(n.value)
         if isinstance(value, UnboundType) and not value.args:
-            return UnboundType(value.name, params, line=self.line, empty_tuple_index=empty_tuple_index)
+            return UnboundType(value.name, params, line=self.line,
+                               empty_tuple_index=empty_tuple_index)
         else:
             self.fail(TYPE_COMMENT_AST_ERROR, self.line, getattr(n, 'col_offset', -1))
             return AnyType()

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -8,7 +8,7 @@ x = None # type: a : b  # E: syntax error in type comment
 
 [case testFastParseInvalidTypeComment]
 # flags: --fast-parser
-x = None # type: a + b  # E: invalid type comment/annotation
+x = None # type: a + b  # E: invalid type comment or annotation
 
 -- Function type comments are attributed to the function def line.
 -- This happens in both parsers.
@@ -20,7 +20,7 @@ def f():  # E: syntax error in type comment
 
 [case testFastParseInvalidFunctionAnnotation]
 # flags: --fast-parser
-def f(x):  # E: invalid type comment/annotation
+def f(x):  # E: invalid type comment or annotation
   # type: (a + b) -> None
   pass
 
@@ -29,33 +29,33 @@ def f(x):  # E: invalid type comment/annotation
 # All of these should not crash
 from typing import Callable, Tuple, Iterable
 
-x = None # type: Tuple[int, str].x # E: invalid type comment/annotation
-x = None # type: Iterable[x].x # E: invalid type comment/annotation
-x = None # type: Tuple[x][x] # E: invalid type comment/annotation
-x = None # type: Iterable[x][x] # E: invalid type comment/annotation
-x = None # type: Callable[..., int][x] # E: invalid type comment/annotation
-x = None # type: Callable[..., int].x # E: invalid type comment/annotation
-x = None # type: Tuple[1] # E: invalid type comment/annotation
+x = None # type: Tuple[int, str].x # E: invalid type comment or annotation
+x = None # type: Iterable[x].x # E: invalid type comment or annotation
+x = None # type: Tuple[x][x] # E: invalid type comment or annotation
+x = None # type: Iterable[x][x] # E: invalid type comment or annotation
+x = None # type: Callable[..., int][x] # E: invalid type comment or annotation
+x = None # type: Callable[..., int].x # E: invalid type comment or annotation
+x = None # type: Tuple[1] # E: invalid type comment or annotation
 
-def f1(x): # E: invalid type comment/annotation
+def f1(x): # E: invalid type comment or annotation
     # type: (Tuple[int, str].x) -> None
     pass
-def f2(x): # E: invalid type comment/annotation
+def f2(x): # E: invalid type comment or annotation
     # type: (Iterable[x].x) -> None
     pass
-def f3(x): # E: invalid type comment/annotation
+def f3(x): # E: invalid type comment or annotation
     # type: (Tuple[x][x]) -> None
     pass
-def f4(x): # E: invalid type comment/annotation
+def f4(x): # E: invalid type comment or annotation
     # type: (Iterable[x][x]) -> None
     pass
-def f5(x): # E: invalid type comment/annotation
+def f5(x): # E: invalid type comment or annotation
     # type: (Callable[..., int][x]) -> None
     pass
-def f6(x): # E: invalid type comment/annotation
+def f6(x): # E: invalid type comment or annotation
     # type: (Callable[..., int].x) -> None
     pass
-def f7(x): # E: invalid type comment/annotation
+def f7(x): # E: invalid type comment or annotation
     # type: (Tuple[1]) -> None
     pass
 
@@ -65,29 +65,29 @@ def f7(x): # E: invalid type comment/annotation
 # All of these should not crash
 from typing import Callable, Tuple, Iterable
 
-x: Tuple[int, str].x # E: invalid type comment/annotation
-x: Iterable[x].x # E: invalid type comment/annotation
-x: Tuple[x][x] # E: invalid type comment/annotation
-x: Iterable[x][x] # E: invalid type comment/annotation
-x: Callable[..., int][x] # E: invalid type comment/annotation
-x: Callable[..., int].x # E: invalid type comment/annotation
-x: Tuple[1] # E: invalid type comment/annotation
+x: Tuple[int, str].x # E: invalid type comment or annotation
+x: Iterable[x].x # E: invalid type comment or annotation
+x: Tuple[x][x] # E: invalid type comment or annotation
+x: Iterable[x][x] # E: invalid type comment or annotation
+x: Callable[..., int][x] # E: invalid type comment or annotation
+x: Callable[..., int].x # E: invalid type comment or annotation
+x: Tuple[1] # E: invalid type comment or annotation
 
-x = None # type: Tuple[int, str].x # E: invalid type comment/annotation
-x = None # type: Iterable[x].x # E: invalid type comment/annotation
-x = None # type: Tuple[x][x] # E: invalid type comment/annotation
-x = None # type: Iterable[x][x] # E: invalid type comment/annotation
-x = None # type: Callable[..., int][x] # E: invalid type comment/annotation
-x = None # type: Callable[..., int].x # E: invalid type comment/annotation
-x = None # type: Tuple[1] # E: invalid type comment/annotation
+x = None # type: Tuple[int, str].x # E: invalid type comment or annotation
+x = None # type: Iterable[x].x # E: invalid type comment or annotation
+x = None # type: Tuple[x][x] # E: invalid type comment or annotation
+x = None # type: Iterable[x][x] # E: invalid type comment or annotation
+x = None # type: Callable[..., int][x] # E: invalid type comment or annotation
+x = None # type: Callable[..., int].x # E: invalid type comment or annotation
+x = None # type: Tuple[1] # E: invalid type comment or annotation
 
-def f1(x: Tuple[int, str].x) -> None: pass # E: invalid type comment/annotation
-def f2(x: Iterable[x].x) -> None: pass # E: invalid type comment/annotation
-def f3(x: Tuple[x][x]) -> None: pass # E: invalid type comment/annotation
-def f4(x: Iterable[x][x]) -> None: pass # E: invalid type comment/annotation
-def f5(x: Callable[..., int][x]) -> None: pass # E: invalid type comment/annotation
-def f6(x: Callable[..., int].x) -> None: pass # E: invalid type comment/annotation
-def f7(x: Tuple[1]) -> None: pass # E: invalid type comment/annotation
+def f1(x: Tuple[int, str].x) -> None: pass # E: invalid type comment or annotation
+def f2(x: Iterable[x].x) -> None: pass # E: invalid type comment or annotation
+def f3(x: Tuple[x][x]) -> None: pass # E: invalid type comment or annotation
+def f4(x: Iterable[x][x]) -> None: pass # E: invalid type comment or annotation
+def f5(x: Callable[..., int][x]) -> None: pass # E: invalid type comment or annotation
+def f6(x: Callable[..., int].x) -> None: pass # E: invalid type comment or annotation
+def f7(x: Tuple[1]) -> None: pass # E: invalid type comment or annotation
 
 [case testFastParseProperty]
 # flags: --fast-parser
@@ -234,7 +234,7 @@ def f(a):
     # type: (Tuple(int, int)) -> int
     pass
 [out]
-main:3: error: invalid type comment/annotation
+main:3: error: invalid type comment or annotation
 
 [case testFastParseMatMul]
 # flags: --fast-parser

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -8,7 +8,7 @@ x = None # type: a : b  # E: syntax error in type comment
 
 [case testFastParseInvalidTypeComment]
 # flags: --fast-parser
-x = None # type: a + b  # E: invalid type comment
+x = None # type: a + b  # E: invalid type comment/annotation
 
 -- Function type comments are attributed to the function def line.
 -- This happens in both parsers.
@@ -20,9 +20,59 @@ def f():  # E: syntax error in type comment
 
 [case testFastParseInvalidFunctionAnnotation]
 # flags: --fast-parser
-def f(x):  # E: invalid type comment
+def f(x):  # E: invalid type comment/annotation
   # type: (a + b) -> None
   pass
+
+[case testFastParseInvalidTypes2]
+# flags: --fast-parser --py2
+# All of these should not crash
+from typing import Callable, Tuple, Iterable
+
+x = None # type: Tuple[int, str].x # E: Invalid type comment
+x = None # type: Iterable[x].x # E: Invalid type comment
+x = None # type: Tuple[x][x] # E: Invalid type comment
+x = None # type: Iterable[x][x] # E: Invalid type comment
+x = None # type: Callable[..., int][x] # E: Invalid type comment
+x = None # type: Callable[..., int].x # E: Invalid type comment
+x = None # type: Tuple[1] # E: Invalid type comment
+
+def f1(x: Tuple[int, str].x) -> None: pass # E: Invalid type comment
+def f2(x: Iterable[x].x) -> None: pass # E: Invalid type comment
+def f3(x: Tuple[x][x]) -> None: pass # E: Invalid type comment
+def f4(x: Iterable[x][x]) -> None: pass # E: Invalid type comment
+def f5(x: Callable[..., int][x]) -> None: pass # E: Invalid type comment
+def f6(x: Callable[..., int].x) -> None: pass # E: Invalid type comment
+def f7(x: Tuple[1]) -> None: pass # E: Invalid type comment
+
+[case testFastParseInvalidTypes3]
+# flags: --fast-parser --python-version=3.6
+# All of these should not crash
+from typing import Callable, Tuple, Iterable
+
+x: Tuple[int, str].x # E: Invalid type comment/annotation
+x: Iterable[x].x # E: Invalid type comment/annotation
+x: Tuple[x][x] # E: Invalid type comment/annotation
+x: Iterable[x][x] # E: Invalid type comment/annotation
+x: Callable[..., int][x] # E: Invalid type comment/annotation
+x: Callable[..., int].x # E: Invalid type comment/annotation
+x: Tuple[1] # E: Invalid type comment/annotation
+
+x = None # type: Tuple[int, str].x # E: Invalid type comment/annotation
+x = None # type: Iterable[x].x # E: Invalid type comment/annotation
+x = None # type: Tuple[x][x] # E: Invalid type comment/annotation
+x = None # type: Iterable[x][x] # E: Invalid type comment/annotation
+x = None # type: Callable[..., int][x] # E: Invalid type comment/annotation
+x = None # type: Callable[..., int].x # E: Invalid type comment/annotation
+x = None # type: Tuple[1] # E: Invalid type comment/annotation
+
+def f1(x: Tuple[int, str].x) -> None: pass # E: Invalid type comment/annotation
+def f2(x: Iterable[x].x) -> None: pass # E: Invalid type comment/annotation
+def f3(x: Tuple[x][x]) -> None: pass # E: Invalid type comment/annotation
+def f4(x: Iterable[x][x]) -> None: pass # E: Invalid type comment/annotation
+def f5(x: Callable[..., int][x]) -> None: pass # E: Invalid type comment/annotation
+def f6(x: Callable[..., int].x) -> None: pass # E: Invalid type comment/annotation
+def f7(x: Tuple[1]) -> None: pass # E: Invalid type comment/annotation
 
 [case testFastParseProperty]
 # flags: --fast-parser

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -37,16 +37,31 @@ x = None # type: Callable[..., int][x] # E: Invalid type comment
 x = None # type: Callable[..., int].x # E: Invalid type comment
 x = None # type: Tuple[1] # E: Invalid type comment
 
-def f1(x: Tuple[int, str].x) -> None: pass # E: Invalid type comment
-def f2(x: Iterable[x].x) -> None: pass # E: Invalid type comment
-def f3(x: Tuple[x][x]) -> None: pass # E: Invalid type comment
-def f4(x: Iterable[x][x]) -> None: pass # E: Invalid type comment
-def f5(x: Callable[..., int][x]) -> None: pass # E: Invalid type comment
-def f6(x: Callable[..., int].x) -> None: pass # E: Invalid type comment
-def f7(x: Tuple[1]) -> None: pass # E: Invalid type comment
+def f1(x): # E: Invalid type comment
+    # type: Tuple[int, str].x
+    pass
+def f2(x): # E: Invalid type comment
+    # type: Iterable[x].x
+    pass
+def f3(x): # E: Invalid type comment
+    # type: Tuple[x][x]
+    pass
+def f4(x): # E: Invalid type comment
+    # type: Iterable[x][x]
+    pass
+def f5(x): # E: Invalid type comment
+    # type: Callable[..., int][x]
+    pass
+def f6(x): # E: Invalid type comment
+    # type: Callable[..., int].x
+    pass
+def f7(x): # E: Invalid type comment
+    # type: Tuple[1]
+    pass
+
 
 [case testFastParseInvalidTypes3]
-# flags: --fast-parser --python-version=3.6
+# flags: --fast-parser --python-version 3.6
 # All of these should not crash
 from typing import Callable, Tuple, Iterable
 
@@ -219,7 +234,7 @@ def f(a):
     # type: (Tuple(int, int)) -> int
     pass
 [out]
-main:3: error: invalid type comment
+main:3: error: invalid type comment/annotation
 
 [case testFastParseMatMul]
 # flags: --fast-parser

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -29,33 +29,33 @@ def f(x):  # E: invalid type comment/annotation
 # All of these should not crash
 from typing import Callable, Tuple, Iterable
 
-x = None # type: Tuple[int, str].x # E: invalid type comment
-x = None # type: Iterable[x].x # E: invalid type comment
-x = None # type: Tuple[x][x] # E: invalid type comment
-x = None # type: Iterable[x][x] # E: invalid type comment
-x = None # type: Callable[..., int][x] # E: invalid type comment
-x = None # type: Callable[..., int].x # E: invalid type comment
-x = None # type: Tuple[1] # E: invalid type comment
+x = None # type: Tuple[int, str].x # E: invalid type comment/annotation
+x = None # type: Iterable[x].x # E: invalid type comment/annotation
+x = None # type: Tuple[x][x] # E: invalid type comment/annotation
+x = None # type: Iterable[x][x] # E: invalid type comment/annotation
+x = None # type: Callable[..., int][x] # E: invalid type comment/annotation
+x = None # type: Callable[..., int].x # E: invalid type comment/annotation
+x = None # type: Tuple[1] # E: invalid type comment/annotation
 
-def f1(x): # E: invalid type comment
+def f1(x): # E: invalid type comment/annotation
     # type: (Tuple[int, str].x) -> None
     pass
-def f2(x): # E: invalid type comment
+def f2(x): # E: invalid type comment/annotation
     # type: (Iterable[x].x) -> None
     pass
-def f3(x): # E: invalid type comment
+def f3(x): # E: invalid type comment/annotation
     # type: (Tuple[x][x]) -> None
     pass
-def f4(x): # E: invalid type comment
+def f4(x): # E: invalid type comment/annotation
     # type: (Iterable[x][x]) -> None
     pass
-def f5(x): # E: invalid type comment
+def f5(x): # E: invalid type comment/annotation
     # type: (Callable[..., int][x]) -> None
     pass
-def f6(x): # E: invalid type comment
+def f6(x): # E: invalid type comment/annotation
     # type: (Callable[..., int].x) -> None
     pass
-def f7(x): # E: invalid type comment
+def f7(x): # E: invalid type comment/annotation
     # type: (Tuple[1]) -> None
     pass
 

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -29,34 +29,34 @@ def f(x):  # E: invalid type comment/annotation
 # All of these should not crash
 from typing import Callable, Tuple, Iterable
 
-x = None # type: Tuple[int, str].x # E: Invalid type comment
-x = None # type: Iterable[x].x # E: Invalid type comment
-x = None # type: Tuple[x][x] # E: Invalid type comment
-x = None # type: Iterable[x][x] # E: Invalid type comment
-x = None # type: Callable[..., int][x] # E: Invalid type comment
-x = None # type: Callable[..., int].x # E: Invalid type comment
-x = None # type: Tuple[1] # E: Invalid type comment
+x = None # type: Tuple[int, str].x # E: invalid type comment
+x = None # type: Iterable[x].x # E: invalid type comment
+x = None # type: Tuple[x][x] # E: invalid type comment
+x = None # type: Iterable[x][x] # E: invalid type comment
+x = None # type: Callable[..., int][x] # E: invalid type comment
+x = None # type: Callable[..., int].x # E: invalid type comment
+x = None # type: Tuple[1] # E: invalid type comment
 
-def f1(x): # E: Invalid type comment
-    # type: Tuple[int, str].x
+def f1(x): # E: invalid type comment
+    # type: (Tuple[int, str].x) -> None
     pass
-def f2(x): # E: Invalid type comment
-    # type: Iterable[x].x
+def f2(x): # E: invalid type comment
+    # type: (Iterable[x].x) -> None
     pass
-def f3(x): # E: Invalid type comment
-    # type: Tuple[x][x]
+def f3(x): # E: invalid type comment
+    # type: (Tuple[x][x]) -> None
     pass
-def f4(x): # E: Invalid type comment
-    # type: Iterable[x][x]
+def f4(x): # E: invalid type comment
+    # type: (Iterable[x][x]) -> None
     pass
-def f5(x): # E: Invalid type comment
-    # type: Callable[..., int][x]
+def f5(x): # E: invalid type comment
+    # type: (Callable[..., int][x]) -> None
     pass
-def f6(x): # E: Invalid type comment
-    # type: Callable[..., int].x
+def f6(x): # E: invalid type comment
+    # type: (Callable[..., int].x) -> None
     pass
-def f7(x): # E: Invalid type comment
-    # type: Tuple[1]
+def f7(x): # E: invalid type comment
+    # type: (Tuple[1]) -> None
     pass
 
 
@@ -65,29 +65,29 @@ def f7(x): # E: Invalid type comment
 # All of these should not crash
 from typing import Callable, Tuple, Iterable
 
-x: Tuple[int, str].x # E: Invalid type comment/annotation
-x: Iterable[x].x # E: Invalid type comment/annotation
-x: Tuple[x][x] # E: Invalid type comment/annotation
-x: Iterable[x][x] # E: Invalid type comment/annotation
-x: Callable[..., int][x] # E: Invalid type comment/annotation
-x: Callable[..., int].x # E: Invalid type comment/annotation
-x: Tuple[1] # E: Invalid type comment/annotation
+x: Tuple[int, str].x # E: invalid type comment/annotation
+x: Iterable[x].x # E: invalid type comment/annotation
+x: Tuple[x][x] # E: invalid type comment/annotation
+x: Iterable[x][x] # E: invalid type comment/annotation
+x: Callable[..., int][x] # E: invalid type comment/annotation
+x: Callable[..., int].x # E: invalid type comment/annotation
+x: Tuple[1] # E: invalid type comment/annotation
 
-x = None # type: Tuple[int, str].x # E: Invalid type comment/annotation
-x = None # type: Iterable[x].x # E: Invalid type comment/annotation
-x = None # type: Tuple[x][x] # E: Invalid type comment/annotation
-x = None # type: Iterable[x][x] # E: Invalid type comment/annotation
-x = None # type: Callable[..., int][x] # E: Invalid type comment/annotation
-x = None # type: Callable[..., int].x # E: Invalid type comment/annotation
-x = None # type: Tuple[1] # E: Invalid type comment/annotation
+x = None # type: Tuple[int, str].x # E: invalid type comment/annotation
+x = None # type: Iterable[x].x # E: invalid type comment/annotation
+x = None # type: Tuple[x][x] # E: invalid type comment/annotation
+x = None # type: Iterable[x][x] # E: invalid type comment/annotation
+x = None # type: Callable[..., int][x] # E: invalid type comment/annotation
+x = None # type: Callable[..., int].x # E: invalid type comment/annotation
+x = None # type: Tuple[1] # E: invalid type comment/annotation
 
-def f1(x: Tuple[int, str].x) -> None: pass # E: Invalid type comment/annotation
-def f2(x: Iterable[x].x) -> None: pass # E: Invalid type comment/annotation
-def f3(x: Tuple[x][x]) -> None: pass # E: Invalid type comment/annotation
-def f4(x: Iterable[x][x]) -> None: pass # E: Invalid type comment/annotation
-def f5(x: Callable[..., int][x]) -> None: pass # E: Invalid type comment/annotation
-def f6(x: Callable[..., int].x) -> None: pass # E: Invalid type comment/annotation
-def f7(x: Tuple[1]) -> None: pass # E: Invalid type comment/annotation
+def f1(x: Tuple[int, str].x) -> None: pass # E: invalid type comment/annotation
+def f2(x: Iterable[x].x) -> None: pass # E: invalid type comment/annotation
+def f3(x: Tuple[x][x]) -> None: pass # E: invalid type comment/annotation
+def f4(x: Iterable[x][x]) -> None: pass # E: invalid type comment/annotation
+def f5(x: Callable[..., int][x]) -> None: pass # E: invalid type comment/annotation
+def f6(x: Callable[..., int].x) -> None: pass # E: invalid type comment/annotation
+def f7(x: Tuple[1]) -> None: pass # E: invalid type comment/annotation
 
 [case testFastParseProperty]
 # flags: --fast-parser


### PR DESCRIPTION
Fixes #2834 

This PR replaces an (incorrect) assert with error message for invalid types that are syntactically valid expressions (+ a bunch of test samples).