### PR TITLE
Avoid crash in analyze_member_access

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -998,13 +998,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 e.name, original_type, e, is_lvalue, False, False,
                 self.named_type, self.not_ready_callback, self.msg,
                 original_type=original_type, chk=self.chk)
-            if isinstance(member_type, CallableType):
-                for v in member_type.variables:
-                    v.id.meta_level = 0
-            if isinstance(member_type, Overloaded):
-                for it in member_type.items():
-                    for v in it.variables:
-                        v.id.meta_level = 0
             if is_lvalue:
                 return member_type
             else:

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -88,7 +88,9 @@ def analyze_member_access(name: str,
             else:
                 signature = bind_self(signature, original_type)
             typ = map_instance_to_supertype(typ, method.info)
-            return expand_type_by_instance(signature, typ)
+            member_type = expand_type_by_instance(signature, typ)
+            freeze_type_vars(member_type)
+            return member_type
         else:
             # Not a method.
             return analyze_member_var_access(name, typ, info, node,
@@ -296,6 +298,16 @@ def analyze_var(name: str, var: Var, itype: Instance, info: TypeInfo, node: Cont
             not_ready_callback(var.name(), node)
         # Implicit 'Any' type.
         return AnyType()
+
+
+def freeze_type_vars(member_type: Type) -> None:
+    if isinstance(member_type, CallableType):
+        for v in member_type.variables:
+            v.id.meta_level = 0
+    if isinstance(member_type, Overloaded):
+        for it in member_type.items():
+            for v in it.variables:
+                v.id.meta_level = 0
 
 
 def handle_partial_attribute_type(typ: PartialType, is_lvalue: bool, msg: MessageBuilder,

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1787,6 +1787,19 @@ class D:
 g = D().m  # This should not crash: see https://github.com/python/mypy/issues/2804
 [builtins fixtures/dict.pyi]
 
+[case testGenericMethodRestoreMetaLevel3]
+from typing import TypeVar
+T = TypeVar('T')
+
+class C:
+    def m(self, x: T) -> T:
+        return x
+
+class D(C):
+    def __init__(self) -> None:
+        self.d = super().m # This should not crash: see https://github.com/python/mypy/issues/2804
+[builtins fixtures/dict.pyi]
+
 [case testIncrementalPerFileFlags]
 # flags: --config-file tmp/mypy.ini
 import a


### PR DESCRIPTION
This is a follow-up of PR #2809. This PR makes a more robust fix by moving the relevant piece of code from ``visit_member_expr`` to ``analyze_member_access``. The latter, as noted by @JukkaL also used few times outside the former (for example in ``analyze_super``).