### PR TITLE
Fix crash on access to local classes

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -847,7 +847,15 @@ class SemanticAnalyzer(NodeVisitor):
             kind = MDEF
             if self.is_func_scope():
                 kind = LDEF
-            self.add_symbol(defn.name, SymbolTableNode(kind, defn.info), defn)
+            node = SymbolTableNode(kind, defn.info)
+            self.add_symbol(defn.name, node, defn)
+            if kind == LDEF:
+                # We need to preserve local classes, let's store them
+                # in globals under mangled unique names
+                local_name = defn.info._fullname + '@' + str(defn.line)
+                defn.info._fullname = self.cur_mod_id + '.' + local_name
+                defn.fullname = defn.info._fullname
+                self.globals[local_name] = node
 
     def analyze_base_classes(self, defn: ClassDef) -> None:
         """Analyze and set up base classes.

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1768,6 +1768,51 @@ main:2: error: Revealed type is 'TypedDict(x=builtins.int, _fallback=typing.Mapp
 main:3: error: Revealed type is 'TypedDict(x=builtins.int, _fallback=ntcrash.C.A@4)'
 main:4: error: Revealed type is 'def () -> ntcrash.C.A@4'
 
+[case testIncrementalInnerClassAttrInMethod]
+import crash
+nonexisting
+[file crash.py]
+class C:
+    def f(self) -> None:
+        class A:
+            pass
+        self.a = A()
+[out1]
+main:2: error: Name 'nonexisting' is not defined
+[out2]
+main:2: error: Name 'nonexisting' is not defined
+
+[case testIncrementalInnerClassAttrInMethodReveal]
+import crash
+reveal_type(crash.C().a)
+reveal_type(crash.D().a)
+[file crash.py]
+class C:
+    def f(self) -> None:
+        class A:
+            pass
+        self.a = A()
+reveal_type(C().a)
+class D:
+    def f(self) -> None:
+        class A:
+            def g(self) -> None:
+                class B:
+                    pass
+                self.b = B()
+        self.a = A().b
+reveal_type(D().a)
+[out1]
+tmp/crash.py:6: error: Revealed type is 'crash.A@3'
+tmp/crash.py:15: error: Revealed type is 'crash.B@11'
+main:2: error: Revealed type is 'crash.A@3'
+main:3: error: Revealed type is 'crash.B@11'
+[out2]
+tmp/crash.py:6: error: Revealed type is 'crash.A@3'
+tmp/crash.py:15: error: Revealed type is 'crash.B@11'
+main:2: error: Revealed type is 'crash.A@3'
+main:3: error: Revealed type is 'crash.B@11'
+
 [case testGenericMethodRestoreMetaLevel]
 from typing import Dict
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1787,6 +1787,8 @@ import crash
 reveal_type(crash.C().a)
 reveal_type(crash.D().a)
 [file crash.py]
+from typing import TypeVar, Generic
+T = TypeVar('T')
 class C:
     def f(self) -> None:
         class A:
@@ -1797,21 +1799,21 @@ class D:
     def f(self) -> None:
         class A:
             def g(self) -> None:
-                class B:
+                class B(Generic[T]):
                     pass
-                self.b = B()
+                self.b = B[int]()
         self.a = A().b
 reveal_type(D().a)
 [out1]
-tmp/crash.py:6: error: Revealed type is 'crash.A@3'
-tmp/crash.py:15: error: Revealed type is 'crash.B@11'
-main:2: error: Revealed type is 'crash.A@3'
-main:3: error: Revealed type is 'crash.B@11'
+tmp/crash.py:8: error: Revealed type is 'crash.A@5'
+tmp/crash.py:17: error: Revealed type is 'crash.B@13[builtins.int*]'
+main:2: error: Revealed type is 'crash.A@5'
+main:3: error: Revealed type is 'crash.B@13[builtins.int*]'
 [out2]
-tmp/crash.py:6: error: Revealed type is 'crash.A@3'
-tmp/crash.py:15: error: Revealed type is 'crash.B@11'
-main:2: error: Revealed type is 'crash.A@3'
-main:3: error: Revealed type is 'crash.B@11'
+tmp/crash.py:8: error: Revealed type is 'crash.A@5'
+tmp/crash.py:17: error: Revealed type is 'crash.B@13[builtins.int*]'
+main:2: error: Revealed type is 'crash.A@5'
+main:3: error: Revealed type is 'crash.B@13[builtins.int*]'
 
 [case testGenericMethodRestoreMetaLevel]
 from typing import Dict

--- a/test-data/unit/semanal-classes.test
+++ b/test-data/unit/semanal-classes.test
@@ -315,7 +315,7 @@ MypyFile:1(
         A
         PassStmt:2())
       ExpressionStmt:3(
-        NameExpr(A [l])))))
+        NameExpr(A [__main__.A@2])))))
 
 [case testReferenceToClassWithinClass]
 class A:
@@ -364,7 +364,7 @@ MypyFile:1(
       AssignmentStmt:3(
         NameExpr(x [l])
         NameExpr(None [builtins.None])
-        A))))
+        __main__.A@2))))
 
 [case testAccessToLocalInOuterScopeWithinNestedClass]
 def f(x):


### PR DESCRIPTION
Fixes #2559 

The idea is the same as in PR #2553. The only difference is that mangled names are always stored in ``globals``, otherwise there would be a problem for a method in a nested class that is itself inside a method.