### PR TITLE
Do not import List, Dict, and Set by default

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -398,7 +398,7 @@ class ASTConverter(ast3.NodeTransformer):  # type: ignore  # typeshed PR #931
                 if arg.annotation is not None:
                     arg_type = TypeConverter(self.errors, line=line).visit(arg.annotation)
                 elif arg.type_comment is not None:
-                    arg_type = parse_type_comment(arg.type_comment, arg.lineno, arg.col_offset)
+                    arg_type = parse_type_comment(arg.type_comment, arg.lineno, self.errors)
             return Argument(Var(arg.arg), arg_type, self.visit(default), kind)
 
         new_args = []

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -2,7 +2,7 @@ import fnmatch
 import pprint
 import sys
 
-from typing import Any, Mapping, Optional, Tuple, List, Pattern
+from typing import Any, Mapping, Optional, Tuple, List, Pattern, Dict
 
 from mypy import defaults
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -253,6 +253,8 @@ class SemanticAnalyzer(NodeVisitor):
 
         if self.cur_mod_id == 'builtins':
             remove_imported_names_from_symtable(self.globals, 'builtins')
+            for alias_name in ['List', 'Dict', 'Set']:
+                self.globals.pop(alias_name, None)
 
         if '__all__' in self.globals:
             for name, g in self.globals.items():
@@ -3453,9 +3455,6 @@ def remove_imported_names_from_symtable(names: SymbolTable,
             removed.append(name)
     for name in removed:
         del names[name]
-    if module == 'builtins':
-        for alias_name in ['List', 'Dict', 'Set']:
-            names.pop(alias_name, None)
 
 
 def infer_reachability_of_if_statement(s: IfStmt,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3453,6 +3453,9 @@ def remove_imported_names_from_symtable(names: SymbolTable,
             removed.append(name)
     for name in removed:
         del names[name]
+    if module == 'builtins':
+        for alias_name in ['List', 'Dict', 'Set']:
+            names.pop(alias_name, None)
 
 
 def infer_reachability_of_if_statement(s: IfStmt,

--- a/mypy/test/testgraph.py
+++ b/mypy/test/testgraph.py
@@ -1,6 +1,6 @@
 """Test cases for graph processing code in build.py."""
 
-from typing import AbstractSet, Dict, Set
+from typing import AbstractSet, Dict, Set, List
 
 from mypy.myunit import Suite, assert_equal
 from mypy.build import BuildManager, State, BuildSourceSet

--- a/mypy/typevars.py
+++ b/mypy/typevars.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, List
 
 from mypy.nodes import TypeInfo
 

--- a/test-data/samples/crawl.py
+++ b/test-data/samples/crawl.py
@@ -16,7 +16,7 @@ import re
 import sys
 import time
 import urllib.parse
-from typing import Any, Generator, IO, Optional, Sequence, Set, Tuple
+from typing import Any, Generator, IO, Optional, Sequence, Set, Tuple, List, Dict
 
 
 ARGS = argparse.ArgumentParser(description="Web crawler")

--- a/test-data/samples/crawl2.py
+++ b/test-data/samples/crawl2.py
@@ -17,7 +17,7 @@ import re
 import sys
 import time
 import urllib.parse
-from typing import Any, Awaitable, IO, Optional, Sequence, Set, Tuple
+from typing import Any, Awaitable, IO, Optional, Sequence, Set, Tuple, List, Dict
 
 
 ARGS = argparse.ArgumentParser(description="Web crawler")

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1147,7 +1147,7 @@ print(b.x + 1)
 4
 
 [case testInferenceWithLambda]
-from typing import TypeVar, Iterable, Iterator
+from typing import TypeVar, Iterable, Iterator, List
 import itertools
 
 _T = TypeVar('_T')


### PR DESCRIPTION
Fix #999 

This is a straightforward fix: ``List``, ``Set``, and ``Dict`` are treated as aliases to their ``builtins`` counterparts, therefore they are ignored by ``remove_imported_names_from_symtable``, I fix this by also removing the alias names.

This depends on https://github.com/python/typeshed/pull/933 + sync typeshed

The fix also revealed few places in mypy where imports were missing.