### PR TITLE
Fix crash in calculate_metaclass_type() when c.type is None

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2017,7 +2017,10 @@ class TypeInfo(SymbolNode):
             return declared
         if self._fullname == 'builtins.type':
             return mypy.types.Instance(self, [])
-        candidates = [s.declared_metaclass for s in self.mro if s.declared_metaclass is not None]
+        candidates = [s.declared_metaclass
+                      for s in self.mro
+                      if s.declared_metaclass is not None
+                      and s.declared_metaclass.type is not None]
         for c in candidates:
             if c.type.mro is None:
                 continue

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -422,12 +422,12 @@ class Instance(Type):
     The list of type variables may be empty.
     """
 
-    type = None  # type: mypy.nodes.TypeInfo
+    type = None  # type: Optional[mypy.nodes.TypeInfo]
     args = None  # type: List[Type]
     erased = False  # True if result of type variable substitution
     invalid = False  # True if recovered after incorrect number of type arguments error
 
-    def __init__(self, typ: mypy.nodes.TypeInfo, args: List[Type],
+    def __init__(self, typ: Optional[mypy.nodes.TypeInfo], args: List[Type],
                  line: int = -1, column: int = -1, erased: bool = False) -> None:
         self.type = typ
         self.args = args


### PR DESCRIPTION
This can happen in incremental mode. I'm also updating the type of `Instance.type` to `Optional` to make it clear this is legit (the constructor call in `deserialize()` is the source).