### PR TITLE
Fix generic type expansion for attribute acces on class

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -383,7 +383,8 @@ def analyze_class_attribute_access(itype: Instance,
         if isinstance(t, PartialType):
             return handle_partial_attribute_type(t, is_lvalue, msg, node.node)
         is_classmethod = is_decorated and cast(Decorator, node.node).func.is_class
-        return add_class_tvars(t, itype, is_classmethod, builtin_type, original_type)
+        res = add_class_tvars(t, itype, is_classmethod, builtin_type, original_type)
+        return expand_type_by_instance(res, itype)
     elif isinstance(node.node, Var):
         not_ready_callback(name, context)
         return AnyType()

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1564,7 +1564,7 @@ class B(Generic[T, S]):
     y = None # type: Union[T, A[S]]
 
 reveal_type(B[int, str].x) # E: Revealed type is 'Tuple[builtins.int*, builtins.str*]'
-reveal_type(B[int, str].y) # E: Revealed type is 'Union[builtins.int*, __maun__.A[builtins.str*]]'
+reveal_type(B[int, str].y) # E: Revealed type is 'Union[builtins.int*, __main__.A[builtins.str*]]'
 [builtins fixtures/list.pyi]
 
 [case testGenericOperatorMethodOverlapping]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1534,6 +1534,39 @@ class A:
     def f(cls) -> None: pass
 [builtins fixtures/classmethod.pyi]
 
+[case testGenericTypeExpansionOnClassAccess]
+from typing import TypeVar, Generic
+from typing import Generic, TypeVar
+
+T = TypeVar('T')
+class A(Generic[T]):
+    def f(self, x: T) -> None:
+        pass
+class B(Generic[T]):
+    x = None  # type: A[T]
+
+B[int].x.f(0)
+B[int].x.f('hi') # E: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+[builtins fixtures/classmethod.pyi]
+
+[case testGenericClassVariableTypeExpansion]
+from typing import TypeVar, Generic, List, Tuple, Union
+T = TypeVar('T')
+S = TypeVar('S')
+class A(Generic[T]):
+    x = None # type: List[T]
+
+A[int].x.append(42)
+A[int].x.append('hi') # E: Argument 1 to "append" of "list" has incompatible type "str"; expected "int"
+
+class B(Generic[T, S]):
+    x = None # type: Tuple[T, S]
+    y = None # type: Union[T, A[S]]
+
+reveal_type(B[int, str].x) # E: Revealed type is 'Tuple[builtins.int*, builtins.str*]'
+reveal_type(B[int, str].y) # E: Revealed type is 'Union[builtins.int*, __maun__.A[builtins.str*]]'
+[builtins fixtures/list.pyi]
+
 [case testGenericOperatorMethodOverlapping]
 from typing import TypeVar, Generic, Tuple
 T = TypeVar('T')


### PR DESCRIPTION
Fixes #2878 

The fix is very simple, ``expand_type_by_instance`` was applied only on access via instance (like ``C[int]().attr``), now it will be also applied on access via class (like ``C[int].attr``).