### PR TITLE
Don't check method subtyping when supertype method's type is `Any`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -880,6 +880,8 @@ class TypeChecker(StatementVisitor[None]):
                                     name,
                                     base.name(),
                                     defn)
+            elif isinstance(original_type, AnyType):
+                pass
             else:
                 self.msg.signature_incompatible_with_supertype(
                     defn.name(), name, base.name(), defn)

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -147,6 +147,25 @@ ee_def = specific_1 # E: Incompatible types in assignment (expression has type C
 
 [builtins fixtures/dict.pyi]
 
+[case testSubtypingFunctionsDecorated]
+from typing import Any
+
+# untyped decorator
+def deco(f): pass
+
+class A:
+    @deco
+    def f(self) -> Any:
+        pass
+
+class B(A):
+    @deco
+    def f(self) -> Any:
+        pass
+
+[builtins fixtures/list.pyi]
+
+
 [case testLackOfNames]
 def f(__a: int, __b: str) -> None: pass
 def g(a: int, b: str) -> None: pass


### PR DESCRIPTION
Previously, we were bailing out with an error because we thought that overriding
a non-method type with a method type was bad.

This comes up when you have an untyped decorator on a supertype method.

https://github.com/python/mypy/issues/2782