### PR TITLE
Allow covariant args in constructor

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -582,7 +582,10 @@ class TypeChecker(StatementVisitor[None]):
                     elif isinstance(arg_type, TypeVarType):
                         # Refuse covariant parameter type variables
                         # TODO: check recursively for inner type variables
-                        if arg_type.variance == COVARIANT:
+                        if (
+                            arg_type.variance == COVARIANT and
+                            defn.name() not in ('__init__', '__new__')
+                        ):
                             self.fail(messages.FUNCTION_PARAMETER_CANNOT_BE_COVARIANT, arg_type)
                     if typ.arg_kinds[i] == nodes.ARG_STAR:
                         # builtins.tuple[T] is typing.Tuple[T, ...]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1950,6 +1950,7 @@ T_co = TypeVar('T_co', covariant=True)
 class C(Generic[T_co]):
     def __init__(self, x: T_co) -> None: # This should be allowed
        pass
+[builtins fixtures/property.pyi]
 [out]
 
 [case testTypeUsingTypeCErrorCovariance]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1949,7 +1949,11 @@ T_co = TypeVar('T_co', covariant=True)
 
 class C(Generic[T_co]):
     def __init__(self, x: T_co) -> None: # This should be allowed
-       pass
+        self.x = x
+    def meth(self) -> None:
+        reveal_type(self.x) # E: Revealed type is 'T_co`1'
+
+reveal_type(C(1).x) # E: Revealed type is 'builtins.int*'
 [builtins fixtures/property.pyi]
 [out]
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1942,6 +1942,16 @@ def new_pro_user(user_class: Type[ProUser]):
     new_user(user_class)
 [out]
 
+[case testAllowCovariantArgsInConstructor]
+from typing import Generic, TypeVar
+
+T_co = TypeVar('T_co', covariant=True)
+
+class C(Generic[T_co]):
+    def __init__(self, x: T_co) -> None: # This should be allowed
+       pass
+[out]
+
 [case testTypeUsingTypeCErrorCovariance]
 from typing import Type, TypeVar
 class User: pass


### PR DESCRIPTION
Fixes #2850 

It looks like we could make a simple exclusion for ``__init__`` and ``__new__``.