### PR TITLE
Fix __metaclass__ = m.C

### DIFF
--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -2,7 +2,8 @@
 
 from mypy.nodes import (
     Expression, NameExpr, MemberExpr, IndexExpr, TupleExpr,
-    ListExpr, StrExpr, BytesExpr, UnicodeExpr, EllipsisExpr
+    ListExpr, StrExpr, BytesExpr, UnicodeExpr, EllipsisExpr,
+    get_member_expr_fullname
 )
 from mypy.parsetype import parse_str_as_type, TypeParseError
 from mypy.types import Type, UnboundType, TypeList, EllipsisType
@@ -56,18 +57,3 @@ def expr_to_unanalyzed_type(expr: Expression) -> Type:
         return EllipsisType(expr.line)
     else:
         raise TypeTranslationError()
-
-
-def get_member_expr_fullname(expr: MemberExpr) -> str:
-    """Return the qualified name representation of a member expression.
-
-    Return a string of form foo.bar, foo.bar.baz, or similar, or None if the
-    argument cannot be represented in this form.
-    """
-    if isinstance(expr.expr, NameExpr):
-        initial = expr.expr.name
-    elif isinstance(expr.expr, MemberExpr):
-        initial = get_member_expr_fullname(expr.expr)
-    else:
-        return None
-    return '{}.{}'.format(initial, expr.name)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2327,3 +2327,18 @@ def get_flags(node: Node, names: List[str]) -> List[str]:
 def set_flags(node: Node, flags: List[str]) -> None:
     for name in flags:
         setattr(node, name, True)
+
+
+def get_member_expr_fullname(expr: MemberExpr) -> str:
+    """Return the qualified name representation of a member expression.
+
+    Return a string of form foo.bar, foo.bar.baz, or similar, or None if the
+    argument cannot be represented in this form.
+    """
+    if isinstance(expr.expr, NameExpr):
+        initial = expr.expr.name
+    elif isinstance(expr.expr, MemberExpr):
+        initial = get_member_expr_fullname(expr.expr)
+    else:
+        return None
+    return '{}.{}'.format(initial, expr.name)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -958,7 +958,7 @@ class SemanticAnalyzer(NodeVisitor):
         return False
 
     def analyze_metaclass(self, defn: ClassDef) -> None:
-        error_context = defn
+        error_context = defn  # type: Context
         if defn.metaclass is None and self.options.python_version[0] == 2:
             for body_node in defn.defs.body:
                 if isinstance(body_node, ClassDef) and body_node.name == "__metaclass__":

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -82,6 +82,7 @@ from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.sametypes import is_same_type
 from mypy.options import Options
 from mypy import join
+from mypy.exprtotype import get_member_expr_fullname
 
 
 T = TypeVar('T')
@@ -957,27 +958,35 @@ class SemanticAnalyzer(NodeVisitor):
         return False
 
     def analyze_metaclass(self, defn: ClassDef) -> None:
+        error_context = defn
         if defn.metaclass is None and self.options.python_version[0] == 2:
             for body_node in defn.defs.body:
                 if isinstance(body_node, ClassDef) and body_node.name == "__metaclass__":
                     self.fail("Metaclasses defined as inner classes are not supported", body_node)
-                    return None
+                    return
                 elif isinstance(body_node, AssignmentStmt) and len(body_node.lvalues) == 1:
                     lvalue = body_node.lvalues[0]
                     if isinstance(lvalue, NameExpr) and lvalue.name == "__metaclass__":
+                        error_context = body_node.rvalue
                         if isinstance(body_node.rvalue, NameExpr):
-                            defn.metaclass = body_node.rvalue.name
+                            name = body_node.rvalue.name
+                        elif isinstance(body_node.rvalue, MemberExpr):
+                            name = get_member_expr_fullname(body_node.rvalue)
+                        else:
+                            name = None
+                        if name:
+                            defn.metaclass = name
                         else:
                             self.fail(
                                 "Dynamic metaclass not supported for '%s'" % defn.name,
                                 body_node
                             )
-                            return None
+                            return
         if defn.metaclass:
             if defn.metaclass == '<error>':
-                self.fail("Dynamic metaclass not supported for '%s'" % defn.name, defn)
+                self.fail("Dynamic metaclass not supported for '%s'" % defn.name, error_context)
                 return
-            sym = self.lookup_qualified(defn.metaclass, defn)
+            sym = self.lookup_qualified(defn.metaclass, error_context)
             if sym is None:
                 # Probably a name error - it is already handled elsewhere
                 return

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -66,6 +66,7 @@ from mypy.nodes import (
     YieldExpr, ExecStmt, Argument, BackquoteExpr, ImportBase, AwaitExpr,
     IntExpr, FloatExpr, UnicodeExpr, EllipsisExpr, TempNode,
     COVARIANT, CONTRAVARIANT, INVARIANT, UNBOUND_IMPORTED, LITERAL_YES,
+    get_member_expr_fullname,
 )
 from mypy.typevars import has_no_typevars, fill_typevars
 from mypy.visitor import NodeVisitor
@@ -82,7 +83,6 @@ from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.sametypes import is_same_type
 from mypy.options import Options
 from mypy import join
-from mypy.exprtotype import get_member_expr_fullname
 
 
 T = TypeVar('T')

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -254,6 +254,32 @@ class A(object):
 reveal_type(A.x) # E: Revealed type is 'builtins.int'
 reveal_type(A.test()) # E: Revealed type is 'builtins.str'
 
+[case testImportedMetaclass]
+import m
+
+class A(object):
+    __metaclass__ = m.M
+
+reveal_type(A.x) # E: Revealed type is 'builtins.int'
+reveal_type(A.test()) # E: Revealed type is 'builtins.str'
+[file m.py]
+class M(type):
+    x = 0
+    def test(cls):
+        # type: () -> str
+        return "test"
+
 [case testDynamicMetaclass]
 class C(object):
     __metaclass__ = int()  # E: Dynamic metaclass not supported for 'C'
+
+[case testMetaclassDefinedAsClass]
+class C(object):
+    class __metaclass__: pass # E: Metaclasses defined as inner classes are not supported
+
+[case testErrorInMetaclass]
+x = 0
+class A(object):
+    __metaclass__ = m.M  # E: Name 'm' is not defined
+class B(object):
+    __metaclass__ = M  # E: Name 'M' is not defined


### PR DESCRIPTION
Also fix some duplicate error messages.

Tweaks Python 2 metaclass implementation introduced in #2830.