### PR TITLE
Make Type[T] subtype of Callable[..., T]

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -273,7 +273,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
             return is_subtype(left.item, right.item)
         if isinstance(right, CallableType):
             # This is unsound, we don't check the __init__ signature.
-            return right.is_type_obj() and is_subtype(left.item, right.ret_type)
+            return is_subtype(left.item, right.ret_type)
         if isinstance(right, Instance):
             if right.type.fullname() in ('builtins.type', 'builtins.object'):
                 # Treat builtins.type the same as Type[Any];

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -317,6 +317,20 @@ class D:
 f([D])  # E: List item 0 has incompatible type
 [builtins fixtures/list.pyi]
 
+[case testSubtypingTypeTypeAsCallable]
+from typing import Callable, Type
+class A: pass
+x = None  # type: Callable[..., A]
+y = None  # type: Type[A]
+x = y
+
+[case testSubtypingCallableAsTypeType]
+from typing import Callable, Type
+class A: pass
+x = None  # type: Callable[..., A]
+y = None  # type: Type[A]
+y = x  # E: Incompatible types in assignment (expression has type Callable[..., A], variable has type Type[A])
+
 -- Default argument values
 -- -----------------------
 


### PR DESCRIPTION
Fixes case like

```python
from typing import Callable, Type
class A: pass
x: Callable[..., A]
y: Type[A]
x = y
```

Note that it shouldn't typecheck in the opposite direction. There is still problem with parameter types, as the comment says, but this isn't the problem I'm trying to fix.

This is needed for #2892, but isn't enough (I'll hopefully open another PR).