### PR TITLE
Fix constraint inference of CallableType and TypeType

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -362,6 +362,8 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             return res
         elif isinstance(self.actual, Overloaded):
             return self.infer_against_overloaded(self.actual, template)
+        elif isinstance(self.actual, TypeType):
+            return infer_constraints(template.ret_type, self.actual.item, self.direction)
         else:
             return []
 
@@ -423,9 +425,9 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
         return res
 
     def visit_type_type(self, template: TypeType) -> List[Constraint]:
-        if isinstance(self.actual, CallableType) and self.actual.is_type_obj():
+        if isinstance(self.actual, CallableType):
             return infer_constraints(template.item, self.actual.ret_type, self.direction)
-        elif isinstance(self.actual, Overloaded) and self.actual.is_type_obj():
+        elif isinstance(self.actual, Overloaded):
             return infer_constraints(template.item, self.actual.items()[0].ret_type,
                                      self.direction)
         elif isinstance(self.actual, TypeType):

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -670,7 +670,8 @@ T = TypeVar('T')
 def f(x: Callable[..., T]) -> T: return x()
 class A: pass
 x = None  # type: Type[A]
-f(x)
+y = f(x)
+reveal_type(y)  # E: Revealed type is '__main__.A*'
 
 -- Generic function inference with unions
 -- --------------------------------------

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -664,6 +664,13 @@ lb = [b]
 l = lb # E: Incompatible types in assignment (expression has type List[bool], variable has type List[A])
 [builtins fixtures/for.pyi]
 
+[case testGenericFunctionWithTypeTypeAsCallable]
+from typing import Callable, Type, TypeVar
+T = TypeVar('T')
+def f(x: Callable[..., T]) -> T: return x()
+class A: pass
+x = None  # type: Type[A]
+f(x)
 
 -- Generic function inference with unions
 -- --------------------------------------


### PR DESCRIPTION
Fixes #2892 together with #2894.

Currently tests are failing because of unfixed subtype relations. Once #2894 is merged, tests will pass.