### PR TITLE
Remove API's reliance on overwriting sys.argv

### DIFF
--- a/mypy/api.py
+++ b/mypy/api.py
@@ -42,8 +42,6 @@ from mypy.main import main
 
 
 def run(params: List[str]) -> Tuple[str, str, int]:
-    sys.argv = [''] + params
-
     old_stdout = sys.stdout
     new_stdout = StringIO()
     sys.stdout = new_stdout
@@ -53,12 +51,12 @@ def run(params: List[str]) -> Tuple[str, str, int]:
     sys.stderr = new_stderr
 
     try:
-        main(None)
+        main(None, argv=params)
         exit_status = 0
     except SystemExit as system_exit:
         exit_status = system_exit.code
-
-    sys.stdout = old_stdout
-    sys.stderr = old_stderr
+    finally:
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
 
     return new_stdout.getvalue(), new_stderr.getvalue(), exit_status

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -41,7 +41,7 @@ from typing import List, Tuple
 from mypy.main import main
 
 
-def run(params: List[str]) -> Tuple[str, str, int]:
+def run(args: List[str]) -> Tuple[str, str, int]:
     old_stdout = sys.stdout
     new_stdout = StringIO()
     sys.stdout = new_stdout
@@ -51,7 +51,7 @@ def run(params: List[str]) -> Tuple[str, str, int]:
     sys.stderr = new_stderr
 
     try:
-        main(None, argv=params)
+        main(None, args=args)
         exit_status = 0
     except SystemExit as system_exit:
         exit_status = system_exit.code

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -24,12 +24,13 @@ from mypy.version import __version__
 PY_EXTENSIONS = tuple(PYTHON_EXTENSIONS)
 
 
-def main(script_path: str, argv: List[str] = None) -> None:
+def main(script_path: str, args: List[str] = None) -> None:
     """Main entry point to the type checker.
 
     Args:
         script_path: Path to the 'mypy' script (used for finding data files).
-        argv: Used instead of sys.argv if given.
+        args: Custom command-line arguments.  If not given, sys.argv[1:] will
+        be used.
     """
     t0 = time.time()
     if script_path:
@@ -37,9 +38,9 @@ def main(script_path: str, argv: List[str] = None) -> None:
     else:
         bin_dir = None
     sys.setrecursionlimit(2 ** 14)
-    if argv is None:
-        argv = sys.argv[1:]
-    sources, options = process_options(argv)
+    if args is None:
+        args = sys.argv[1:]
+    sources, options = process_options(args)
     serious = False
     try:
         res = type_check_only(sources, bin_dir, options)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -24,11 +24,12 @@ from mypy.version import __version__
 PY_EXTENSIONS = tuple(PYTHON_EXTENSIONS)
 
 
-def main(script_path: str) -> None:
+def main(script_path: str, argv: List[str] = None) -> None:
     """Main entry point to the type checker.
 
     Args:
         script_path: Path to the 'mypy' script (used for finding data files).
+        argv: Used instead of sys.argv if given.
     """
     t0 = time.time()
     if script_path:
@@ -36,7 +37,9 @@ def main(script_path: str) -> None:
     else:
         bin_dir = None
     sys.setrecursionlimit(2 ** 14)
-    sources, options = process_options(sys.argv[1:])
+    if argv is None:
+        argv = sys.argv[1:]
+    sources, options = process_options(argv)
     serious = False
     try:
         res = type_check_only(sources, bin_dir, options)


### PR DESCRIPTION
Also, original `sys.stdout` and `sys.stderr` are now recovered also in case of
internal exceptions.

Test plan:

- mypy command-line still works

- all tests still pass