### PR TITLE
fix stubgen crash on an extension module containing an alias of object

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -165,10 +165,12 @@ def generate_c_type_stub(module: ModuleType,
             continue
         if attr not in done:
             variables.append('%s = ... # type: Any' % attr)
-    all_bases = obj.mro()[1:]
+    all_bases = obj.mro()
     if all_bases[-1] is object:
         # TODO: Is this always object?
         del all_bases[-1]
+    # remove the class itself
+    all_bases = all_bases[1:]
     # Remove base classes of other bases as redundant.
     bases = []  # type: List[type]
     for base in all_bases:

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -16,7 +16,7 @@ from mypy.test import config
 from mypy.parse import parse
 from mypy.errors import CompileError
 from mypy.stubgen import generate_stub, generate_stub_for_module
-from mypy.stubgenc import infer_method_sig
+from mypy.stubgenc import generate_c_type_stub, infer_method_sig
 from mypy.stubutil import (
     parse_signature, parse_all_signatures, build_signature, find_unique_signatures,
     infer_sig_from_docstring
@@ -184,3 +184,8 @@ class StubgencSuite(Suite):
     def test_infer_unary_op_sig(self) -> None:
         for op in ('neg', 'pos'):
             assert_equal(infer_method_sig('__%s__' % op), '()')
+
+    def test_generate_c_type_stub_no_crash_for_object(self) -> None:
+        output = []
+        generate_c_type_stub(os, 'alias', object, output)
+        assert_equal(output[0], 'class alias:')

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 import tempfile
 import time
+from types import ModuleType
 
 from typing import List, Tuple
 
@@ -186,6 +187,7 @@ class StubgencSuite(Suite):
             assert_equal(infer_method_sig('__%s__' % op), '()')
 
     def test_generate_c_type_stub_no_crash_for_object(self) -> None:
-        output = []
-        generate_c_type_stub(os, 'alias', object, output)
+        output = []  # type: List[str]
+        mod = ModuleType('module', '')  # any module is fine
+        generate_c_type_stub(mod, 'alias', object, output)
         assert_equal(output[0], 'class alias:')


### PR DESCRIPTION
Closes https://github.com/python/typeshed/issues/766.

I verified that the new test case fails without the changes made in
stubgenc.py. Obviously a lot more tests for stubgenc could be added,
but that's for another day.

The original crash can be reproduced by creating file called alias.py
containing the line `alias = object`, compiling it to a .so with
Cython, and running stubgen on the .so. I got the following stack
trace:

```
$ python3 -m mypy.stubgen alias
Traceback (most recent call last):
  File ".../lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File ".../lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File ".../lib/python3.6/site-packages/mypy/stubgen.py", line 734, in <module>
    main()
  File ".../lib/python3.6/site-packages/mypy/stubgen.py", line 632, in main
    raise e
  File ".../lib/python3.6/site-packages/mypy/stubgen.py", line 629, in main
    interpreter=options.interpreter)
  File ".../lib/python3.6/site-packages/mypy/stubgen.py", line 101, in generate_stub_for_module
    class_sigs=class_sigs)
  File ".../lib/python3.6/site-packages/mypy/stubgenc.py", line 41, in generate_stub_for_c_module
    generate_c_type_stub(module, name, obj, types, sigs=sigs, class_sigs=class_sigs)
  File ".../lib/python3.6/site-packages/mypy/stubgenc.py", line 169, in generate_c_type_stub
    if all_bases[-1] is object:
IndexError: list index out of range
```