### PR TITLE
Support `Any` metaclasses

### DIFF
--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2923,3 +2923,30 @@ class M1(M):
 
 class A(metaclass=M1): pass
 reveal_type(A.foo())  # E: Revealed type is '__main__.A*'
+
+[case testMetaclassAndSkippedImport]
+# flags: --ignore-missing-imports
+from missing import M
+class A(metaclass=M):
+    y = 0
+reveal_type(A().y) # E: Revealed type is 'builtins.int'
+A().x # E: "A" has no attribute "x"
+
+[case testAnyMetaclass]
+from typing import Any
+M = None  # type: Any
+class A(metaclass=M):
+    y = 0
+reveal_type(A().y) # E: Revealed type is 'builtins.int'
+A().x # E: "A" has no attribute "x"
+
+[case testInvalidVariableAsMetaclass]
+from typing import Any
+M = 0  # type: int
+MM = 0
+class A(metaclass=M): # E: Invalid metaclass 'M'
+    y = 0
+class B(metaclass=MM): # E: Invalid metaclass 'MM'
+    y = 0
+reveal_type(A().y) # E: Revealed type is 'builtins.int'
+A().x # E: "A" has no attribute "x"

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2929,16 +2929,16 @@ reveal_type(A.foo())  # E: Revealed type is '__main__.A*'
 from missing import M
 class A(metaclass=M):
     y = 0
-reveal_type(A().y) # E: Revealed type is 'builtins.int'
-A().x # E: "A" has no attribute "x"
+reveal_type(A.y) # E: Revealed type is 'builtins.int'
+A.x # E: "A" has no attribute "x"
 
 [case testAnyMetaclass]
 from typing import Any
 M = None  # type: Any
 class A(metaclass=M):
     y = 0
-reveal_type(A().y) # E: Revealed type is 'builtins.int'
-A().x # E: "A" has no attribute "x"
+reveal_type(A.y) # E: Revealed type is 'builtins.int'
+A.x # E: "A" has no attribute "x"
 
 [case testInvalidVariableAsMetaclass]
 from typing import Any
@@ -2948,5 +2948,5 @@ class A(metaclass=M): # E: Invalid metaclass 'M'
     y = 0
 class B(metaclass=MM): # E: Invalid metaclass 'MM'
     y = 0
-reveal_type(A().y) # E: Revealed type is 'builtins.int'
-A().x # E: "A" has no attribute "x"
+reveal_type(A.y) # E: Revealed type is 'builtins.int'
+A.x # E: "A" has no attribute "x"

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -283,3 +283,12 @@ class A(object):
     __metaclass__ = m.M  # E: Name 'm' is not defined
 class B(object):
     __metaclass__ = M  # E: Name 'M' is not defined
+
+[case testMetaclassAndSkippedImportInPython2]
+# flags: --ignore-missing-imports
+from missing import M
+class A(object):
+    __metaclass__ = M
+    y = 0
+reveal_type(A().y) # E: Revealed type is 'builtins.int'
+A().x # E: "A" has no attribute "x"

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -290,5 +290,5 @@ from missing import M
 class A(object):
     __metaclass__ = M
     y = 0
-reveal_type(A().y) # E: Revealed type is 'builtins.int'
-A().x # E: "A" has no attribute "x"
+reveal_type(A.y) # E: Revealed type is 'builtins.int'
+A.x # E: "A" has no attribute "x"


### PR DESCRIPTION
A metaclasses that is known to be `Any` is just ignored. A better
approach would be to treat this similarly to an `Any` base class,
and assume that arbitrary class attributes may exist.

Fixes #2911.