### PR TITLE
Allow a class with an `Any` base to be used as a metaclass

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2026,7 +2026,8 @@ class TypeInfo(SymbolNode):
         return None
 
     def is_metaclass(self) -> bool:
-        return self.has_base('builtins.type') or self.fullname() == 'abc.ABCMeta'
+        return (self.has_base('builtins.type') or self.fullname() == 'abc.ABCMeta' or
+                self.fallback_to_any)
 
     def _calculate_is_enum(self) -> bool:
         """

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2950,3 +2950,27 @@ class B(metaclass=MM): # E: Invalid metaclass 'MM'
     y = 0
 reveal_type(A.y) # E: Revealed type is 'builtins.int'
 A.x # E: "A" has no attribute "x"
+
+[case testAnyAsBaseOfMetaclass]
+from typing import Any, Type
+M = None  # type: Any
+class MM(M): pass
+
+class A(metaclass=MM):
+    y = 0
+    @classmethod
+    def f(cls) -> None: pass
+    def g(self) -> None: pass
+
+def h(a: Type[A], b: Type[object]) -> None:
+    h(a, a)
+    h(b, a) # E: Argument 1 to "h" has incompatible type Type[object]; expected Type[A]
+    a.f(1) # E: Too many arguments for "f" of "A"
+    reveal_type(a.y) # E: Revealed type is 'builtins.int'
+
+x = A # type: MM
+reveal_type(A.y) # E: Revealed type is 'builtins.int'
+reveal_type(A.x) # E: Revealed type is 'Any'
+A.f(1) # E: Too many arguments for "f" of "A"
+A().g(1) # E: Too many arguments for "g" of "A"
+[builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -292,3 +292,10 @@ class A(object):
     y = 0
 reveal_type(A.y) # E: Revealed type is 'builtins.int'
 A.x # E: "A" has no attribute "x"
+
+[case testAnyAsBaseOfMetaclass]
+from typing import Any, Type
+M = None  # type: Any
+class MM(M): pass
+class A(object):
+    __metaclass__ = MM


### PR DESCRIPTION
This is a little risky since we biw support a new kind of type object
type, so the test case is more elaborate than may seem necessary at
first sight.

Fixes #2913.