### PR TITLE
Default to type checking in Python 3.6 mode

### DIFF
--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -1,4 +1,4 @@
 PYTHON2_VERSION = (2, 7)
-PYTHON3_VERSION = (3, 5)
+PYTHON3_VERSION = (3, 6)
 CACHE_DIR = '.mypy_cache'
 CONFIG_FILE = 'mypy.ini'


### PR DESCRIPTION
Now that 3.6 is out, there's really no need to default to 3.5
any more.

Fixes #2836.