### PR TITLE
Improve messages when suitable typed-ast isn't installed

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -27,16 +27,23 @@ from mypy import messages
 from mypy.errors import Errors
 
 try:
-    from typed_ast import ast3  # type: ignore  # typeshed PR #931
+    from typed_ast import ast3
 except ImportError:
     if sys.version_info.minor > 2:
-        print('You must install the typed_ast package before you can run mypy'
-              ' with `--fast-parser`.\n'
-              'You can do this with `python3 -m pip install typed-ast`.',
-              file=sys.stderr)
+        try:
+            from typed_ast import ast35  # type: ignore
+        except ImportError:
+            print('The typed_ast package is not installed.\n'
+                  'You can install it with `python3 -m pip install typed-ast`.',
+                  file=sys.stderr)
+        else:
+            print('You need a more recent version of the typed_ast package.\n'
+                  'You can update to the latest version with '
+                  '`python3 -m pip install -U typed-ast`.',
+                  file=sys.stderr)
     else:
-        print('The typed_ast package required by --fast-parser is only compatible with'
-              ' Python 3.3 and greater.')
+        print('Mypy requires the typed_ast package, which is only compatible with\n'
+              'Python 3.3 and greater.', file=sys.stderr)
     sys.exit(1)
 
 T = TypeVar('T', bound=Union[ast3.expr, ast3.stmt])

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -44,16 +44,23 @@ from mypy.fastparse import TypeConverter, parse_type_comment
 
 try:
     from typed_ast import ast27
-    from typed_ast import ast3  # type: ignore  # typeshed PR #931
+    from typed_ast import ast3
 except ImportError:
     if sys.version_info.minor > 2:
-        print('You must install the typed_ast package before you can run mypy'
-              ' with `--fast-parser`.\n'
-              'You can do this with `python3 -m pip install typed-ast`.',
-              file=sys.stderr)
+        try:
+            from typed_ast import ast35  # type: ignore
+        except ImportError:
+            print('The typed_ast package is not installed.\n'
+                  'You can install it with `python3 -m pip install typed-ast`.',
+                  file=sys.stderr)
+        else:
+            print('You need a more recent version of the typed_ast package.\n'
+                  'You can update to the latest version with '
+                  '`python3 -m pip install -U typed-ast`.',
+                  file=sys.stderr)
     else:
-        print('The typed_ast package required by --fast-parser is only compatible with'
-              ' Python 3.3 and greater.')
+        print('Mypy requires the typed_ast package, which is only compatible with\n'
+              'Python 3.3 and greater.', file=sys.stderr)
     sys.exit(1)
 
 T = TypeVar('T', bound=Union[ast27.expr, ast27.stmt])


### PR DESCRIPTION
In particular, fix message if installed typed-ast is not recent
enough.

Fixes #2902.