### PR TITLE
Fix crash in super() outside methods

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1851,6 +1851,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                         return AnyType()
                     if not self.chk.in_checked_function():
                         return AnyType()
+                    if self.chk.scope.active_class() is not None:
+                        self.chk.fail('super() outside of a method is not supported', e)
+                        return AnyType()
                     args = self.chk.scope.top_function().arguments
                     # An empty args with super() is an error; we need something in declared_self
                     if not args:

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -92,6 +92,13 @@ B(1)
 B(1, 'x')
 [builtins fixtures/__new__.pyi]
 
+[case testSuperOutsideMethodNoCrash]
+class C:
+    a = super().whatever  # E: super() outside of a method is not supported
+
+reveal_type(C.a)  # E: Revealed type is 'Any'
+[out]
+
 [case testSuperWithUnknownBase]
 from typing import Any
 B = None  # type: Any


### PR DESCRIPTION
Fixes #2848 

Although ``super()`` outside methods works at runtime, such use case is rare, so that I just fix the crash here. Support for such use case may be added later in a separate PR (there is already an issue #526 to track such feature).