### PR TITLE
Build windows artifacts on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,3 +29,10 @@ test_script:
     # Ignore lint (it's run separately below)
     - "%PYTHON%\\python.exe runtests.py -x lint"
     - ps: if ($env:PYTHON_VERSION -Match "3.6.x" -And $env:PYTHON_ARCH -Match "64") { iex "$env:PYTHON\\python.exe -m flake8" }
+
+after_test:
+  - "%PYTHON%\\python.exe setup.py bdist_wheel -p win32"
+  - "%PYTHON%\\python.exe setup.py bdist_wheel -p win_amd64"
+
+artifacts:
+  - path: dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ test_script:
     - ps: if ($env:PYTHON_VERSION -Match "3.6.x" -And $env:PYTHON_ARCH -Match "64") { iex "$env:PYTHON\\python.exe -m flake8" }
 
 after_test:
+  - "%PYTHON%\\python.exe -m pip install wheel"
   - "%PYTHON%\\python.exe setup.py bdist_wheel -p win32"
   - "%PYTHON%\\python.exe setup.py bdist_wheel -p win_amd64"
 


### PR DESCRIPTION
There wasn't a simple way (as far as I could tell) to build artifacts on tagged builds only but test on all builds, so currently this builds artifacts for every build.