### PR TITLE
Fix test failure caused by version being 0.500

### DIFF
--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -101,7 +101,7 @@ def normalize_file_output(content: List[str], current_abs_path: str) -> List[str
     """Normalize file output for comparison."""
     timestamp_regex = re.compile('\d{10}')
     result = [x.replace(current_abs_path, '$PWD') for x in content]
-    result = [re.sub(re.escape(__version__) + r'\b', '$VERSION', x) for x in result]
-    result = [re.sub(re.escape(base_version) + r'\b', '$VERSION', x) for x in result]
+    result = [re.sub(r'\b' + re.escape(__version__) + r'\b', '$VERSION', x) for x in result]
+    result = [re.sub(r'\b' + re.escape(base_version) + r'\b', '$VERSION', x) for x in result]
     result = [timestamp_regex.sub('$TIMESTAMP', x) for x in result]
     return result

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -101,7 +101,7 @@ def normalize_file_output(content: List[str], current_abs_path: str) -> List[str
     """Normalize file output for comparison."""
     timestamp_regex = re.compile('\d{10}')
     result = [x.replace(current_abs_path, '$PWD') for x in content]
-    result = [x.replace(__version__, '$VERSION') for x in result]
-    result = [x.replace(base_version, '$VERSION') for x in result]
+    result = [re.sub(re.escape(__version__) + r'\b', '$VERSION', x) for x in result]
+    result = [re.sub(re.escape(base_version) + r'\b', '$VERSION', x) for x in result]
     result = [timestamp_regex.sub('$TIMESTAMP', x) for x in result]
     return result


### PR DESCRIPTION
Fix replace() that used the mypy version as the thing to replace,
which happened to match the string '0.5000' in the output of a test
case.