### PR TITLE
Translate f-string expression to str.format expression.

### DIFF
--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -115,6 +115,7 @@ f'foobar'
 f'{"foobar"}'
 f'foo{"bar"}'
 f'.{1}.'
+f'{type(1)}'
 a: str
 a = f'foobar'
 a = f'{"foobar"}'

--- a/test-data/unit/fixtures/primitives.pyi
+++ b/test-data/unit/fixtures/primitives.pyi
@@ -14,6 +14,7 @@ class complex: pass
 class bool: pass
 class str:
     def __add__(self, s: str) -> str: pass
+    def format(self, *args) -> str: pass
 class bytes: pass
 class bytearray: pass
 class tuple: pass


### PR DESCRIPTION
This changes the way f-string expressions are translated. f-string expressions are now translated into a str.format call.

This allows using expressions inside an f-string that do not have a callable \_\_str\_\_ method (such as types).

This PR also adds a test-case where a type is used in an f-string expression and adds a format method the str primitive fixture.

This fixes python/mypy#2947.