### PR TITLE
Infer constraints for union when there are multiple identical options

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -12,6 +12,7 @@ from mypy.types import (
 from mypy.maptype import map_instance_to_supertype
 from mypy import nodes
 import mypy.subtypes
+from mypy.sametypes import is_same_type
 from mypy.erasetype import erase_typevars
 
 
@@ -203,15 +204,33 @@ def any_constraints(options: List[Optional[List[Constraint]]], eager: bool) -> L
         valid_options = [option for option in options if option is not None]
     if len(valid_options) == 1:
         return valid_options[0]
-    # Otherwise, there are either no valid options or multiple valid options.
-    # Give up and deduce nothing.
+    elif (len(valid_options) > 1 and
+          all(is_same_constraints(valid_options[0], c)
+              for c in valid_options[1:])):
+        # Multiple sets of constraints that are all the same. Just pick any one of them.
+        # TODO: More generally, if a given (variable, direction) pair appears in
+        #       every option, combine the bounds with meet/join.
+        return valid_options[0]
+
+    # Otherwise, there are either no valid options or multiple, inconsistent valid
+    # options. Give up and deduce nothing.
     return []
 
-    # TODO: In the latter case, it could happen that every valid
-    # option requires the same constraint on the same variable. Then
-    # we could include that that constraint in the result. Or more
-    # generally, if a given (variable, direction) pair appears in
-    # every option, combine the bounds with meet/join.
+
+def is_same_constraints(x: List[Constraint], y: List[Constraint]) -> bool:
+    for c1 in x:
+        if not any(is_same_constraint(c1, c2) for c2 in y):
+            return False
+    for c1 in y:
+        if not any(is_same_constraint(c1, c2) for c2 in x):
+            return False
+    return True
+
+
+def is_same_constraint(c1: Constraint, c2: Constraint) -> bool:
+    return (c1.type_var == c2.type_var
+            and c1.op == c2.op
+            and is_same_type(c1.target, c2.target))
 
 
 def simplify_away_incomplete_types(types: List[Type]) -> List[Type]:

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -756,6 +756,34 @@ b = k1
 b = k2
 [builtins fixtures/list.pyi]
 
+[case testAmbiguousUnionContextAndMultipleInheritance]
+from typing import TypeVar, Union, Generic
+
+_T = TypeVar('_T')
+
+class T(Generic[_T]): pass
+class U(Generic[_T]): pass
+class V(T[_T], U[_T]): pass
+
+def wait_for(fut: Union[T[_T], U[_T]]) -> _T: ...
+
+reveal_type(wait_for(V[str]()))  # E: Revealed type is 'builtins.str*'
+
+[case testAmbiguousUnionContextAndMultipleInheritance2]
+from typing import TypeVar, Union, Generic
+
+_T = TypeVar('_T')
+_S = TypeVar('_S')
+
+class T(Generic[_T, _S]): pass
+class U(Generic[_T, _S]): pass
+class V(T[_T, _S], U[_T, _S]): pass
+
+def wait_for(fut: Union[T[_T, _S], U[_T, _S]]) -> T[_T, _S]: ...
+
+reveal_type(wait_for(V[int, str]()))  \
+    # E: Revealed type is '__main__.T[builtins.int*, builtins.str*]'
+
 
 -- Literal expressions
 -- -------------------


### PR DESCRIPTION
Fixes #1873.

This doesn't fix the entire underlying issue but this quick fix hopefully is enough to unblock some real use cases.