### PR TITLE
Quick and dirty variant of incremental mode

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1321,10 +1321,12 @@ class State:
         self.manager.modules[self.id] = self.tree
 
     def fix_cross_refs(self) -> None:
-        fixup_module_pass_one(self.tree, self.manager.modules, self.manager.options.quick_and_dirty)
+        fixup_module_pass_one(self.tree, self.manager.modules,
+                              self.manager.options.quick_and_dirty)
 
     def calculate_mros(self) -> None:
-        fixup_module_pass_two(self.tree, self.manager.modules, self.manager.options.quick_and_dirty)
+        fixup_module_pass_two(self.tree, self.manager.modules,
+                              self.manager.options.quick_and_dirty)
 
     def fix_suppressed_dependencies(self, graph: Graph) -> None:
         """Corrects whether dependencies are considered stale in silent mode.

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1878,10 +1878,10 @@ def process_stale_scc(graph: Graph, scc: List[str], manager: BuildManager) -> No
         # If the former, parse_file() is a no-op.
         graph[id].parse_file()
         graph[id].fix_suppressed_dependencies(graph)
-    for id in stale:
-        graph[id].semantic_analysis()
     for id in fresh:
         graph[id].fix_cross_refs()
+    for id in stale:
+        graph[id].semantic_analysis()
     for id in stale:
         graph[id].semantic_analysis_pass_three()
     for id in fresh:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1516,7 +1516,14 @@ class State:
         return valid_refs
 
     def write_cache(self) -> None:
-        if self.path and self.options.incremental and not self.manager.errors.is_errors():
+        ok = self.path and self.options.incremental
+        if ok:
+            if self.manager.options.quick_and_dirty:
+                is_errors = self.manager.errors.is_errors_for_file(self.path)
+            else:
+                is_errors = self.manager.errors.is_errors()
+            ok = not is_errors
+        if ok:
             dep_prios = [self.priorities.get(dep, PRI_HIGH) for dep in self.dependencies]
             new_interface_hash = write_cache(
                 self.id, self.path, self.tree,

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1321,10 +1321,10 @@ class State:
         self.manager.modules[self.id] = self.tree
 
     def fix_cross_refs(self) -> None:
-        fixup_module_pass_one(self.tree, self.manager.modules)
+        fixup_module_pass_one(self.tree, self.manager.modules, self.manager.options.quick_and_dirty)
 
     def calculate_mros(self) -> None:
-        fixup_module_pass_two(self.tree, self.manager.modules)
+        fixup_module_pass_two(self.tree, self.manager.modules, self.manager.options.quick_and_dirty)
 
     def fix_suppressed_dependencies(self, graph: Graph) -> None:
         """Corrects whether dependencies are considered stale in silent mode.

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -76,6 +76,9 @@ class Errors:
     # Current error context: nested import context/stack, as a list of (path, line) pairs.
     import_ctx = None  # type: List[Tuple[str, int]]
 
+    # Set of files with errors.
+    error_files = None  # type: Set[str]
+
     # Path name prefix that is removed from all paths, if set.
     ignore_prefix = None  # type: str
 
@@ -110,6 +113,7 @@ class Errors:
                  show_column_numbers: bool = False) -> None:
         self.error_info = []
         self.import_ctx = []
+        self.error_files = set()
         self.type_name = [None]
         self.function_or_member = [None]
         self.ignored_lines = OrderedDict()
@@ -230,6 +234,7 @@ class Errors:
                 return
             self.only_once_messages.add(info.message)
         self.error_info.append(info)
+        self.error_files.add(file)
 
     def generate_unused_ignore_notes(self) -> None:
         for file, ignored_lines in self.ignored_lines.items():
@@ -256,6 +261,10 @@ class Errors:
     def is_blockers(self) -> bool:
         """Are the any errors that are blockers?"""
         return any(err for err in self.error_info if err.blocker)
+
+    def is_errors_for_file(self, file: str) -> bool:
+        """Are there any errors for the given file?"""
+        return file in self.error_files
 
     def raise_error(self) -> None:
         """Raise a CompileError with the generated messages.

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -16,12 +16,14 @@ from mypy.types import (
 from mypy.visitor import NodeVisitor
 
 
-def fixup_module_pass_one(tree: MypyFile, modules: Dict[str, MypyFile]) -> None:
-    node_fixer = NodeFixer(modules)
+def fixup_module_pass_one(tree: MypyFile, modules: Dict[str, MypyFile],
+                          quick_and_dirty: bool) -> None:
+    node_fixer = NodeFixer(modules, quick_and_dirty)
     node_fixer.visit_symbol_table(tree.names)
 
 
-def fixup_module_pass_two(tree: MypyFile, modules: Dict[str, MypyFile]) -> None:
+def fixup_module_pass_two(tree: MypyFile, modules: Dict[str, MypyFile],
+                          quick_and_dirty: bool) -> None:
     compute_all_mros(tree.names, modules)
 
 
@@ -38,11 +40,10 @@ def compute_all_mros(symtab: SymbolTable, modules: Dict[str, MypyFile]) -> None:
 class NodeFixer(NodeVisitor[None]):
     current_info = None  # type: Optional[TypeInfo]
 
-    def __init__(self, modules: Dict[str, MypyFile], type_fixer: 'TypeFixer' = None) -> None:
+    def __init__(self, modules: Dict[str, MypyFile], quick_and_dirty: bool) -> None:
         self.modules = modules
-        if type_fixer is None:
-            type_fixer = TypeFixer(self.modules)
-        self.type_fixer = type_fixer
+        self.quick_and_dirty = quick_and_dirty
+        self.type_fixer = TypeFixer(self.modules, quick_and_dirty)
 
     # NOTE: This method isn't (yet) part of the NodeVisitor API.
     def visit_type_info(self, info: TypeInfo) -> None:
@@ -76,10 +77,13 @@ class NodeFixer(NodeVisitor[None]):
                 if cross_ref in self.modules:
                     value.node = self.modules[cross_ref]
                 else:
-                    stnode = lookup_qualified_stnode(self.modules, cross_ref)
+                    stnode = lookup_qualified_stnode(self.modules, cross_ref,
+                                                     self.quick_and_dirty)
                     if stnode is not None:
                         value.node = stnode.node
                         value.type_override = stnode.type_override
+                    elif not self.quick_and_dirty:
+                        assert stnode is not None, "Could not find cross-ref %s" % (cross_ref,)
             else:
                 if isinstance(value.node, TypeInfo):
                     # TypeInfo has no accept().  TODO: Add it?
@@ -132,8 +136,9 @@ class NodeFixer(NodeVisitor[None]):
 
 
 class TypeFixer(TypeVisitor[None]):
-    def __init__(self, modules: Dict[str, MypyFile]) -> None:
+    def __init__(self, modules: Dict[str, MypyFile], quick_and_dirty: bool) -> None:
         self.modules = modules
+        self.quick_and_dirty = quick_and_dirty
 
     def visit_instance(self, inst: Instance) -> None:
         # TODO: Combine Instances that are exactly the same?
@@ -141,7 +146,7 @@ class TypeFixer(TypeVisitor[None]):
         if type_ref is None:
             return  # We've already been here.
         del inst.type_ref
-        node = lookup_qualified(self.modules, type_ref)
+        node = lookup_qualified(self.modules, type_ref, self.quick_and_dirty)
         if isinstance(node, TypeInfo):
             inst.type = node
             # TODO: Is this needed or redundant?
@@ -230,19 +235,23 @@ class TypeFixer(TypeVisitor[None]):
         t.item.accept(self)
 
 
-def lookup_qualified(modules: Dict[str, MypyFile], name: str) -> SymbolNode:
-    stnode = lookup_qualified_stnode(modules, name)
+def lookup_qualified(modules: Dict[str, MypyFile], name: str,
+                     quick_and_dirty: bool) -> SymbolNode:
+    stnode = lookup_qualified_stnode(modules, name, quick_and_dirty)
     if stnode is None:
         return None
     else:
         return stnode.node
 
 
-def lookup_qualified_stnode(modules: Dict[str, MypyFile], name: str) -> Optional[SymbolTableNode]:
+def lookup_qualified_stnode(modules: Dict[str, MypyFile], name: str,
+                            quick_and_dirty: bool) -> Optional[SymbolTableNode]:
     head = name
     rest = []
     while True:
         if '.' not in head:
+            if not quick_and_dirty:
+                assert '.' in head, "Cannot find %s" % (name,)
             return None
         head, tail = head.rsplit('.', 1)
         rest.append(tail)
@@ -252,10 +261,14 @@ def lookup_qualified_stnode(modules: Dict[str, MypyFile], name: str) -> Optional
     names = mod.names
     while True:
         if not rest:
+            if not quick_and_dirty:
+                assert rest, "Cannot find %s" % (name,)
             return None
         key = rest.pop()
         if key not in names:
             return None
+        elif not quick_and_dirty:
+            assert key in names, "Cannot find %s for %s" % (key, name)
         stnode = names[key]
         if not rest:
             return stnode

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -239,7 +239,10 @@ def process_options(args: List[str],
     add_invertible_flag('--no-fast-parser', default=True, dest='fast_parser',
                         help="disable the fast parser (not recommended)")
     parser.add_argument('-i', '--incremental', action='store_true',
-                        help="enable experimental module cache")
+                        help="enable module cache")
+    parser.add_argument('--quick-and-dirty', action='store_true',
+                        help="use cache even if dependencies out of date "
+                        "(implies --incremental)")
     parser.add_argument('--cache-dir', action='store', metavar='DIR',
                         help="store module cache info in the given folder in incremental mode "
                         "(defaults to '{}')".format(defaults.CACHE_DIR))
@@ -404,6 +407,10 @@ def process_options(args: List[str],
             report_type = flag[:-7].replace('_', '-')
             report_dir = val
             options.report_dirs[report_type] = report_dir
+
+    # Let quick_and_dirty imply incremental.
+    if options.quick_and_dirty:
+        options.incremental = True
 
     # Set target.
     if special_opts.modules:

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -31,7 +31,7 @@ class Options:
         "strict_boolean",
     }
 
-    OPTIONS_AFFECTING_CACHE = PER_MODULE_OPTIONS | {"strict_optional"}
+    OPTIONS_AFFECTING_CACHE = PER_MODULE_OPTIONS | {"strict_optional", "quick_and_dirty"}
 
     def __init__(self) -> None:
         # -- build options --
@@ -101,6 +101,12 @@ class Options:
         # Write junit.xml to given file
         self.junit_xml = None  # type: Optional[str]
 
+        # Caching options
+        self.incremental = False
+        self.cache_dir = defaults.CACHE_DIR
+        self.debug_cache = False
+        self.quick_and_dirty = False
+
         # Per-module options (raw)
         self.per_module_options = {}  # type: Dict[Pattern[str], Dict[str, object]]
 
@@ -120,9 +126,6 @@ class Options:
 
         # -- experimental options --
         self.fast_parser = True
-        self.incremental = False
-        self.cache_dir = defaults.CACHE_DIR
-        self.debug_cache = False
         self.shadow_file = None  # type: Optional[Tuple[str, str]]
         self.show_column_numbers = False  # type: bool
         self.dump_graph = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -101,6 +101,9 @@ class Options:
         # Write junit.xml to given file
         self.junit_xml = None  # type: Optional[str]
 
+        # Fast parser is on by default
+        self.fast_parser = True
+
         # Caching options
         self.incremental = False
         self.cache_dir = defaults.CACHE_DIR
@@ -125,7 +128,6 @@ class Options:
         self.use_builtins_fixtures = False
 
         # -- experimental options --
-        self.fast_parser = True
         self.shadow_file = None  # type: Optional[Tuple[str, str]]
         self.show_column_numbers = False  # type: bool
         self.dump_graph = False

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -149,7 +149,7 @@ class TypeCheckSuite(DataSuite):
                             os.utime(target, times=(new_time, new_time))
 
         # Parse options after moving files (in case mypy.ini is being moved).
-        options = self.parse_options(original_program_text, testcase)
+        options = self.parse_options(original_program_text, testcase, incremental)
         options.use_builtins_fixtures = True
         options.show_traceback = True
         if 'optional' in testcase.file:
@@ -305,9 +305,14 @@ class TypeCheckSuite(DataSuite):
         else:
             return [('__main__', 'main', program_text)]
 
-    def parse_options(self, program_text: str, testcase: DataDrivenTestCase) -> Options:
+    def parse_options(self, program_text: str, testcase: DataDrivenTestCase,
+                      incremental: int) -> Options:
         options = Options()
-        flags = re.search('# flags: (.*)$', program_text, flags=re.MULTILINE)
+        flags = re.search('# flags1?: (.*)$', program_text, flags=re.MULTILINE)
+        if incremental == 2:
+            flags2 = re.search('# flags2: (.*)$', program_text, flags=re.MULTILINE)
+            if flags2:
+                flags = flags2
 
         flag_list = None
         if flags:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -308,7 +308,7 @@ class TypeCheckSuite(DataSuite):
     def parse_options(self, program_text: str, testcase: DataDrivenTestCase,
                       incremental: int) -> Options:
         options = Options()
-        flags = re.search('# flags1?: (.*)$', program_text, flags=re.MULTILINE)
+        flags = re.search('# flags: (.*)$', program_text, flags=re.MULTILINE)
         if incremental == 2:
             flags2 = re.search('# flags2: (.*)$', program_text, flags=re.MULTILINE)
             if flags2:

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5,8 +5,14 @@
 -- Errors expected in the first run should be in the `[out1]` section, and
 -- errors expected in the second run should be in the `[out2]` section. If a
 -- section is omitted, it is expected there are no errors on that run.
+-- (Note that [out] is equivalent to [out1].)
 --
--- As always, extra flags may be specified using
+-- The list of modules to be checked can be specified using
+-- # cmd: mypy -m mod1 mod2 mod3
+-- To check a different list on the second run, use
+-- # cmd2: mypy -m mod1 mod3
+--
+-- Extra command line flags may be specified using
 -- # flags: --some-flag
 -- If the second run requires different flags, those can be specified using
 -- # flags2: --another-flag
@@ -1924,3 +1930,116 @@ tmp/a.py:2: error: Incompatible return value type (got "str", expected "int")
 [out2]
 [rechecked a]
 [stale a]
+
+[case testQuickAndDirty5]
+# flags: --quick-and-dirty
+import a, b
+[file a.py]
+import b
+[file b.py]
+import a
+[file a.py.next]
+import b
+def foo() -> int: return ''
+[out1]
+[out2]
+tmp/a.py:2: error: Incompatible return value type (got "str", expected "int")
+[rechecked a]
+[stale]
+
+[case testQuickAndDirty6]
+# flags: --quick-and-dirty
+import a, b
+[file a.py]
+import b
+def foo() -> int: return ''
+[file b.py]
+import a
+[file a.py.next]
+import b
+def foo() -> int: return 0.5
+[out1]
+tmp/a.py:2: error: Incompatible return value type (got "str", expected "int")
+[out2]
+tmp/a.py:2: error: Incompatible return value type (got "float", expected "int")
+[rechecked a]
+[stale]
+
+[case testQuickAndDirty7]
+# flags: --quick-and-dirty
+import a, b
+[file a.py]
+import b
+[file b.py]
+import a
+class C: pass
+def f() -> int: pass
+[file a.py.next]
+import b
+reveal_type(b.C)
+reveal_type(b.f)
+[out1]
+[out2]
+tmp/a.py:2: error: Revealed type is 'def () -> b.C'
+tmp/a.py:3: error: Revealed type is 'def () -> builtins.int'
+[rechecked a]
+[stale]
+
+[case testQuickAndDirty8]
+# flags: --quick-and-dirty
+import a, b
+[file a.py]
+import b
+class C: pass
+def f() -> int: pass
+[file b.py]
+import a
+[file b.py.next]
+import a
+reveal_type(a.C)
+reveal_type(a.f)
+[out1]
+[out2]
+tmp/b.py:2: error: Revealed type is 'def () -> a.C'
+tmp/b.py:3: error: Revealed type is 'def () -> builtins.int'
+[rechecked b]
+[stale]
+
+-- (The behavior for blockers is actually no different than in regular incremental mode)
+[case testQuickAndDirty9]
+# noflags: --quick-and-dirty
+import a, b
+[file a.py]
+import b
+class B: pass
+class C(B, B): pass  # blocker
+[file b.py]
+import a
+[file a.py.next]
+import b
+class B: pass
+class C(B): pass
+[out1]
+tmp/a.py:3: error: Duplicate base class "B"
+[out2]
+[rechecked a, b]
+[stale a, b]
+
+[case testQuickAndDirty10]
+# noflags: --quick-and-dirty
+import a, b
+[file a.py]
+import b
+class B: pass
+class C(B): pass
+[file b.py]
+import a
+[file a.py.next]
+import b
+class B: pass
+class C(B, B): pass  # blocker
+[out1]
+[out2]
+tmp/a.py:3: error: Duplicate base class "B"
+[rechecked a, b]
+[stale a, b]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2112,46 +2112,38 @@ class C:
 import a, b
 [file a.py]
 import b
-class C: pass
+def f(x: b.S) -> b.S: return x
 [file b.py]
 import a
-C = a.C
+S = str
 [file a.py.next]
 import b
-class C:
-    def f(self): pass
-[rechecked a]
-[stale a]
+def f(x: b.S) -> int: return 0
 
 [case testQuickAndDirty15]
 # flags: --quick-and-dirty
 import a, b
 [file a.py]
-from typing import NamedTuple
 import b
-C = NamedTuple('C', (('a', int),))
+def f(x: b.P) -> b.P: return x
 [file b.py]
-from a import C
-[file a.py.next]
 from typing import NamedTuple
+import a
+P = NamedTuple('P', (('x', int),))
+[file a.py.next]
 import b
-C = NamedTuple('C', (('a', int), ('b', int)))
-[rechecked a]
-[stale a]
+def f(x: b.P) -> int: return 0
 
 [case testQuickAndDirty16]
 # flags: --quick-and-dirty
 import a, b
 [file a.py]
-from typing import TypeVar
 import b
-T = TypeVar('T')
+def f(x: b.T) -> b.T: return x
 [file b.py]
-from a import T
-def f(x: T) -> T: return x
-[file a.py.next]
 from typing import TypeVar
+import a
+T = TypeVar('T')
+[file a.py.next]
 import b
-T = TypeVar('T', bound=int)
-[rechecked a]
-[stale a]
+def f(x: b.T) -> int: return 0

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6,6 +6,11 @@
 -- errors expected in the second run should be in the `[out2]` section. If a
 -- section is omitted, it is expected there are no errors on that run.
 --
+-- As always, extra flags may be specified using
+-- # flags: --some-flag
+-- If the second run requires different flags, those can be specified using
+-- # flags2: --another-flag
+--
 -- Any files that we expect to be rechecked should be annotated in the [rechecked]
 -- annotation, and any files expect to be stale (aka have a modified interface)
 -- should be annotated in the [stale] annotation. Note that a file that ends up
@@ -1903,3 +1908,19 @@ import b
 import a
 [rechecked a, b, builtins]
 [stale a, b, builtins]
+
+[case testQuickAndDirty4]
+# flags: --quick-and-dirty
+import a, b
+[file a.py]
+import b
+def foo() -> int: return ''
+[file b.py]
+import a
+[file a.py.next]
+def foo() -> int: return 0
+[out1]
+tmp/a.py:2: error: Incompatible return value type (got "str", expected "int")
+[out2]
+[rechecked a]
+[stale a]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1892,3 +1892,14 @@ import c
 x = 0
 [rechecked b]
 [stale b]
+
+[case testQuickAndDirty3]
+# flags: --quick-and-dirty
+# flags2: --incremental
+import a, b
+[file a.py]
+import b
+[file b.py]
+import a
+[rechecked a, b, builtins]
+[stale a, b, builtins]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1858,3 +1858,37 @@ warn_no_return = False
 [[mypy-a]
 warn_no_return = True
 [rechecked]
+
+[case testQuickAndDirty1]
+# flags: --quick-and-dirty
+import b, c
+[file a.py]
+def a(): pass
+[file b.py]
+import a
+import c
+[file c.py]
+import a
+import b
+[file a.py.next]
+def a(x): pass
+[rechecked a]
+[stale a]
+
+[case testQuickAndDirty2]
+# flags: --quick-and-dirty
+import b, c
+[file a.py]
+def a(): pass
+[file b.py]
+import a
+import c
+[file c.py]
+import a
+import b
+[file b.py.next]
+import a
+import c
+x = 0
+[rechecked b]
+[stale b]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2007,7 +2007,7 @@ tmp/b.py:3: error: Revealed type is 'def () -> builtins.int'
 
 -- (The behavior for blockers is actually no different than in regular incremental mode)
 [case testQuickAndDirty9]
-# noflags: --quick-and-dirty
+# flags: --quick-and-dirty
 import a, b
 [file a.py]
 import b
@@ -2026,7 +2026,7 @@ tmp/a.py:3: error: Duplicate base class "B"
 [stale a, b]
 
 [case testQuickAndDirty10]
-# noflags: --quick-and-dirty
+# flags: --quick-and-dirty
 import a, b
 [file a.py]
 import b
@@ -2043,3 +2043,115 @@ class C(B, B): pass  # blocker
 tmp/a.py:3: error: Duplicate base class "B"
 [rechecked a, b]
 [stale a, b]
+
+[case testQuickAndDirty11]
+# flags: --quick-and-dirty
+import a, b, c, d
+[file a.py]
+import d
+def f(): pass
+[file b.py]
+from a import f
+[file c.py]
+from b import f
+[file d.py]
+from c import f
+[file a.py.next]
+import d
+def g(): pass  # renamed f to g
+[file c.py.next]
+from a import g
+
+[case testQuickAndDirty12]
+# flags: --quick-and-dirty
+import a, b, c, d
+[file a.py]
+import d
+class C:
+    def f(self): pass
+[file b.py]
+from a import C
+[file c.py]
+from b import C
+[file d.py]
+from c import C
+C().f()
+[file a.py.next]
+import d
+class C:
+    def g(self): pass  # renamed f to g
+[file c.py.next]
+from a import C
+[out1]
+[out2]
+
+[case testQuickAndDirty13]
+# flags: --quick-and-dirty
+import a, b, c
+[file a.py]
+import c
+class C:
+    x = 0
+[file b.py]
+import a
+x = a.C.x  # type: int
+[file c.py]
+import b
+x = b.x
+[file a.py.next]
+import c
+class C:
+    pass  # Removed x
+[out1]
+[out2]
+[rechecked a]
+[stale a]
+
+[case testQuickAndDirty14]
+# flags: --quick-and-dirty
+import a, b
+[file a.py]
+import b
+class C: pass
+[file b.py]
+import a
+C = a.C
+[file a.py.next]
+import b
+class C:
+    def f(self): pass
+[rechecked a]
+[stale a]
+
+[case testQuickAndDirty15]
+# flags: --quick-and-dirty
+import a, b
+[file a.py]
+from typing import NamedTuple
+import b
+C = NamedTuple('C', (('a', int),))
+[file b.py]
+from a import C
+[file a.py.next]
+from typing import NamedTuple
+import b
+C = NamedTuple('C', (('a', int), ('b', int)))
+[rechecked a]
+[stale a]
+
+[case testQuickAndDirty16]
+# flags: --quick-and-dirty
+import a, b
+[file a.py]
+from typing import TypeVar
+import b
+T = TypeVar('T')
+[file b.py]
+from a import T
+def f(x: T) -> T: return x
+[file a.py.next]
+from typing import TypeVar
+import b
+T = TypeVar('T', bound=int)
+[rechecked a]
+[stale a]


### PR DESCRIPTION
This uses the cache whenever the cache file exists and is newer than the source.

The difference with regular incremental mode is that regular
incremental mode forces a re-check whenever any dependency is stale,
and it forces re-checks for all modules in an SCC.  In quick-and-dirty
mode, by contrast, if some modules in an SCC have a new-enough cache
file, they are loaded from the cache even if some other module in the
same SCC or one of its dependencies was stale.

This is much quicker but obviously not always correct.  The hope is
that it speeds up checking single files when there are large SCCs (or
large dependency graphs) around.

A typical workflow would be:

1. mypy -i (slow, but warms the cache)
2. edit some file (or a few)
3. mypy --quick-and-dirty (re-checks only the file(s) you edited)
4. repeat steps 2-4 any number of times (maybe for different files)
5. mypy -i (re-check everything -- this could be part of CI)
6. if any errors left, go to step 2
