### PR TITLE
Fix is_overlapping_types(NoneTyp, AnyType) for strict Optional checking

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -69,16 +69,9 @@ def is_overlapping_types(t: Type, s: Type, use_promotions: bool = False) -> bool
     TODO: Don't consider callables always overlapping.
     TODO: Don't consider type variables with values always overlapping.
     """
-    # TODO(benkuhn): another option for the fix would be to add the following lines here:
-
-    # # Any overlaps with everything
-    # if isinstance(t, AnyType) or isinstance(s, AnyType):
-    #     return True
-
-    # This passes all the tests locally, and if I understand the mechanics of type overlap
-    # correctly, this would prevent similar classes of bugs from occurring in the future. But I'm
-    # guessing that there's a good reason these lines aren't already there, so I'm defaulting to a
-    # smaller-scoped fix.
+    # Any overlaps with everything
+    if isinstance(t, AnyType) or isinstance(s, AnyType):
+        return True
 
     # Since we are effectively working with the erased types, we only
     # need to handle occurrences of TypeVarType at the top level.
@@ -117,8 +110,6 @@ def is_overlapping_types(t: Type, s: Type, use_promotions: bool = False) -> bool
         else:
             return False
     if experiments.STRICT_OPTIONAL:
-        if isinstance(t, AnyType) or isinstance(s, AnyType):
-            return True
         if isinstance(t, NoneTyp) != isinstance(s, NoneTyp):
             # NoneTyp does not overlap with other non-Union types under strict Optional checking
             return False

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -69,17 +69,16 @@ def is_overlapping_types(t: Type, s: Type, use_promotions: bool = False) -> bool
     TODO: Don't consider callables always overlapping.
     TODO: Don't consider type variables with values always overlapping.
     """
-    # TODO(benkuhn): another option for the fix would be to add the following
-    # lines here:
+    # TODO(benkuhn): another option for the fix would be to add the following lines here:
 
     # # Any overlaps with everything
     # if isinstance(t, AnyType) or isinstance(s, AnyType):
     #     return True
 
-    # This passes all the tests, and if I understand the mechanics of type
-    # overlap correctly, this would prevent similar classes of bugs from
-    # occurring in the future. But I'm guessing that there's a good reason these
-    # lines aren't already there, so I'm defaulting to a smaller-scoped fix.
+    # This passes all the tests locally, and if I understand the mechanics of type overlap
+    # correctly, this would prevent similar classes of bugs from occurring in the future. But I'm
+    # guessing that there's a good reason these lines aren't already there, so I'm defaulting to a
+    # smaller-scoped fix.
 
     # Since we are effectively working with the erased types, we only
     # need to handle occurrences of TypeVarType at the top level.

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -69,6 +69,9 @@ def is_overlapping_types(t: Type, s: Type, use_promotions: bool = False) -> bool
     TODO: Don't consider callables always overlapping.
     TODO: Don't consider type variables with values always overlapping.
     """
+    # If either side is Any, there is definitely overlap.
+    if isinstance(t, AnyType) or isinstance(s, AnyType):
+        return True
     # Since we are effectively working with the erased types, we only
     # need to handle occurrences of TypeVarType at the top level.
     if isinstance(t, TypeVarType):

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -69,9 +69,18 @@ def is_overlapping_types(t: Type, s: Type, use_promotions: bool = False) -> bool
     TODO: Don't consider callables always overlapping.
     TODO: Don't consider type variables with values always overlapping.
     """
-    # If either side is Any, there is definitely overlap.
-    if isinstance(t, AnyType) or isinstance(s, AnyType):
-        return True
+    # TODO(benkuhn): another option for the fix would be to add the following
+    # lines here:
+
+    # # Any overlaps with everything
+    # if isinstance(t, AnyType) or isinstance(s, AnyType):
+    #     return True
+
+    # This passes all the tests, and if I understand the mechanics of type
+    # overlap correctly, this would prevent similar classes of bugs from
+    # occurring in the future. But I'm guessing that there's a good reason these
+    # lines aren't already there, so I'm defaulting to a smaller-scoped fix.
+
     # Since we are effectively working with the erased types, we only
     # need to handle occurrences of TypeVarType at the top level.
     if isinstance(t, TypeVarType):
@@ -109,6 +118,8 @@ def is_overlapping_types(t: Type, s: Type, use_promotions: bool = False) -> bool
         else:
             return False
     if experiments.STRICT_OPTIONAL:
+        if isinstance(t, AnyType) or isinstance(s, AnyType):
+            return True
         if isinstance(t, NoneTyp) != isinstance(s, NoneTyp):
             # NoneTyp does not overlap with other non-Union types under strict Optional checking
             return False

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -77,6 +77,15 @@ else:
   reveal_type(x)  # E: Revealed type is 'builtins.int'
 [builtins fixtures/bool.pyi]
 
+[case testAnyCanBeNone]
+from typing import Optional, Any
+x = None  # type:  Any
+if x is None:
+  reveal_type(x)  # E: Revealed type is 'builtins.None'
+else:
+  reveal_type(x)  # E: Revealed type is 'Any'
+[builtins fixtures/bool.pyi]
+
 [case testOrCases]
 from typing import Optional
 x = None  # type: Optional[str]


### PR DESCRIPTION
This fixes #2970. However, this is my first contribution to mypy, so I don't really know if this is the right place to fix it. (I'm mostly going off of following the control flow back from `visit_assert_stmt` and noticing that the comment near here seemed wrong.)

Note: I defaulted to a conservative change (only to the `if experiments.STRICT_OPTIONAL` branch of the function). However, I noticed that the function doesn't explicitly check whether either side is `Any`, instead leaving this path to be caught by the catch-all at the end. This seems like it could lead to other similar bugs in the future if people forgot about `Any`, and so an alternative fix might be to check if either argument is `Any` before doing anything else. I've left that change commented out so you can see what I'm talking about.

Let me know which is preferable! And sorry if I've missed something basic.