### PR TITLE
Optimize FuncDef serialization

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -541,15 +541,17 @@ class FuncDef(FuncItem, SymbolNode, Statement):
         return visitor.visit_func_def(self)
 
     def serialize(self) -> JsonDict:
-        if self.type is None:
+        if self.type is not None:
+            type_field = self.type
+        else:
             fallback = mypy.types.Instance(None, [])
             fallback.type_ref = 'builtins.function'
-            self.type = mypy.types.callable_type(self, fallback)
+            type_field = mypy.types.callable_type(self, fallback)
 
         return {'.class': 'FuncDef',
                 'name': self._name,
                 'fullname': self._fullname,
-                'type': self.type.serialize(),
+                'type': type_field.serialize(),
                 'flags': get_flags(self, FuncDef.FLAGS),
                 # TODO: Do we need expanded, original_def?
                 }

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -444,6 +444,8 @@ class Instance(Type):
     type_ref = None  # type: str
 
     def serialize(self) -> Union[JsonDict, str]:
+        if self.type_ref:
+            return self.type_ref
         assert self.type is not None
         type_ref = self.type.alt_fullname or self.type.fullname()
         if not self.args:


### PR DESCRIPTION
This is a bit of a hack, so I'm not sure if it's (a) perfectly safe and (b) worth doing.

But I tried to remove `arg_names` and `arg_kinds` from `FuncDef` serialization. Since they were needed in case there's no type, I added the type if it's absent (the hack is that the `fallback` is not a proper object, it's just something good enough for serialization).