### PR TITLE
Don't use TYPE_CEHCKING, use MYPY instead

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -21,8 +21,10 @@ import time
 from os.path import dirname, basename
 
 from typing import (AbstractSet, Dict, Iterable, Iterator, List,
-                    NamedTuple, Optional, Set, Tuple, Union, TYPE_CHECKING)
-if TYPE_CHECKING:
+                    NamedTuple, Optional, Set, Tuple, Union)
+# Can't use TYPE_CHECKING because it's not in the Python 3.5.1 stdlib
+MYPY = False
+if MYPY:
     from typing import Deque
 
 from mypy.nodes import (MypyFile, Node, ImportBase, Import, ImportFrom, ImportAll)


### PR DESCRIPTION
The reason we can't use TYPE_CHECKING is that it's not in the Python 3.5.1 stdlib, and we must support that Python version.