### PR TITLE
Fix a regression in Type[Any]

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -160,7 +160,14 @@ class SubtypeVisitor(TypeVisitor[bool]):
             item = right.item
             if isinstance(item, TupleType):
                 item = item.fallback
-            return isinstance(item, Instance) and is_subtype(left, item.type.metaclass_type)
+            if isinstance(item, Instance):
+                return is_subtype(left, item.type.metaclass_type)
+            elif isinstance(item, AnyType):
+                # Special case: all metaclasses are subtypes of Type[Any]
+                mro = left.type.mro or []
+                return any(base.fullname() == 'builtins.type' for base in mro)
+            else:
+                return False
         else:
             return False
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2217,6 +2217,20 @@ C1[Type[Any]], C2[type] # both these should not fail
 [builtins fixtures/list.pyi]
 [out]
 
+[case testTypeEquivalentTypeAnyEdgeCase]
+class C:
+    pass
+
+class M(type):
+    def __init__(cls, x) -> None:
+        type.__init__(cls, x)
+
+class Mbad(type):
+    def __init__(cls, x) -> None:
+        type.__init__(C(), x) # E: Argument 1 to "__init__" of "type" has incompatible type "C"; expected "type"
+[builtins fixtures/primitives.pyi]
+[out]
+
 [case testTypeMatchesOverloadedFunctions]
 from typing import Type, overload, Union
 


### PR DESCRIPTION
Fixes #3010

This just takes care of a corner case: every metaclass is a subtype of ``Type[Any]``.