### PR TITLE
fix installess tests on windows

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -61,9 +61,9 @@ class Driver:
         if not paths:
             return
         if old_val is not None:
-            new_val = ':'.join(itertools.chain(paths, [old_val]))
+            new_val = os.pathsep.join(itertools.chain(paths, [old_val]))
         else:
-            new_val = ':'.join(paths)
+            new_val = os.pathsep.join(paths)
         self.env[name] = new_val
 
     def allow(self, name: str) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -95,8 +95,7 @@ classifiers = [
 package_dir = {'mypy': 'mypy'}
 
 scripts = ['scripts/mypy', 'scripts/stubgen']
-if os.name == 'nt':
-    scripts.append('scripts/mypy.bat')
+
 
 # These requirements are used when installing by other means than bdist_wheel.
 # E.g. "pip3 install ." or
@@ -119,6 +118,9 @@ setup(name='mypy',
       package_dir=package_dir,
       py_modules=[],
       packages=['mypy'],
+      entry_points={
+            'console_scripts': [
+                'mypy = mypy:main',]},
       scripts=scripts,
       data_files=data_files,
       classifiers=classifiers,


### PR DESCRIPTION
The tests were failing to import mypy because the paths were not being joined correctly. This corrects this by using the OS path seperator.