### PR TITLE
Make strict Optional type system changes standard

### DIFF
--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -42,7 +42,7 @@ def apply_generic_arguments(callable: CallableType, types: List[Type],
 
         upper_bound = callable.variables[i].upper_bound
         if (type and not isinstance(type, PartialType) and
-                not mypy.subtypes.satisfies_upper_bound(type, upper_bound)):
+                not mypy.subtypes.is_subtype(type, upper_bound)):
             msg.incompatible_typevar_value(callable, i + 1, type, context)
 
     # Create a map from type variable id to target type.

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -557,9 +557,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         for arg in args:
             if isinstance(arg, UninhabitedType) or has_erased_component(arg):
                 new_args.append(None)
-            elif not experiments.STRICT_OPTIONAL and isinstance(arg, NoneTyp):
-                # Don't substitute None types in non-strict-Optional mode.
-                new_args.append(None)
             else:
                 new_args.append(arg)
         return self.apply_generic_arguments(callable, new_args, error_context)
@@ -2184,10 +2181,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             if isinstance(actual_item_type, AnyType):
                 return AnyType()
             else:
-                if experiments.STRICT_OPTIONAL:
-                    return NoneTyp(is_ret_type=True)
-                else:
-                    return Void()
+                return NoneTyp(is_ret_type=True)
 
     def visit_temp_node(self, e: TempNode) -> Type:
         return e.type

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -4,7 +4,7 @@ from typing import Iterable, List, Optional
 
 from mypy import experiments
 from mypy.types import (
-    CallableType, Type, TypeVisitor, UnboundType, AnyType, Void, NoneTyp, TypeVarType,
+    CallableType, Type, TypeVisitor, UnboundType, AnyType, NoneTyp, TypeVarType,
     Instance, TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType,
     DeletedType, UninhabitedType, TypeType, TypeVarId, TypeQuery, ALL_TYPES_STRATEGY,
     is_named_instance
@@ -279,9 +279,6 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
         return []
 
     def visit_any(self, template: AnyType) -> List[Constraint]:
-        return []
-
-    def visit_void(self, template: Void) -> List[Constraint]:
         return []
 
     def visit_none_type(self, template: NoneTyp) -> List[Constraint]:

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -63,7 +63,7 @@ class EraseTypeVisitor(TypeVisitor[Type]):
 
     def visit_callable_type(self, t: CallableType) -> Type:
         # We must preserve the fallback type for overload resolution to work.
-        ret_type = NoneTyp(is_ret_type=True)  # type: Type
+        ret_type = NoneTyp()  # type: Type
         return CallableType([], [], [], ret_type, t.fallback)
 
     def visit_overloaded(self, t: Overloaded) -> Type:

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -66,10 +66,7 @@ class EraseTypeVisitor(TypeVisitor[Type]):
 
     def visit_callable_type(self, t: CallableType) -> Type:
         # We must preserve the fallback type for overload resolution to work.
-        if experiments.STRICT_OPTIONAL:
-            ret_type = NoneTyp(is_ret_type=True)  # type: Type
-        else:
-            ret_type = Void()
+        ret_type = NoneTyp(is_ret_type=True)  # type: Type
         return CallableType([], [], [], ret_type, t.fallback)
 
     def visit_overloaded(self, t: Overloaded) -> Type:

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -1,7 +1,7 @@
 from typing import Optional, Container, Callable
 
 from mypy.types import (
-    Type, TypeVisitor, UnboundType, ErrorType, AnyType, Void, NoneTyp, TypeVarId,
+    Type, TypeVisitor, UnboundType, ErrorType, AnyType, NoneTyp, TypeVarId,
     Instance, TypeVarType, CallableType, TupleType, TypedDictType, UnionType, Overloaded,
     ErasedType, PartialType, DeletedType, TypeTranslator, TypeList, UninhabitedType, TypeType
 )
@@ -36,9 +36,6 @@ class EraseTypeVisitor(TypeVisitor[Type]):
         assert False, 'Not supported'
 
     def visit_any(self, t: AnyType) -> Type:
-        return t
-
-    def visit_void(self, t: Void) -> Type:
         return t
 
     def visit_none_type(self, t: NoneTyp) -> Type:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -2,7 +2,7 @@ from typing import Dict, Iterable, List, TypeVar, Mapping, cast
 
 from mypy.types import (
     Type, Instance, CallableType, TypeVisitor, UnboundType, ErrorType, AnyType,
-    Void, NoneTyp, TypeVarType, Overloaded, TupleType, TypedDictType, UnionType,
+    NoneTyp, TypeVarType, Overloaded, TupleType, TypedDictType, UnionType,
     ErasedType, TypeList, PartialType, DeletedType, UninhabitedType, TypeType, TypeVarId,
     FunctionLike, TypeVarDef
 )
@@ -70,9 +70,6 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
         assert False, 'Not supported'
 
     def visit_any(self, t: AnyType) -> Type:
-        return t
-
-    def visit_void(self, t: Void) -> Type:
         return t
 
     def visit_none_type(self, t: NoneTyp) -> Type:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -342,9 +342,6 @@ class ASTConverter(ast3.NodeTransformer):  # type: ignore  # typeshed PR #931
         for arg, arg_type in zip(args, arg_types):
             self.set_type_optional(arg_type, arg.initializer)
 
-        if isinstance(return_type, UnboundType):
-            return_type.is_ret_type = True
-
         func_type = None
         if any(arg_types) or return_type:
             if len(arg_types) != 1 and any(isinstance(t, EllipsisType) for t in arg_types):

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -327,9 +327,6 @@ class ASTConverter(ast27.NodeTransformer):
         for arg, arg_type in zip(args, arg_types):
             self.set_type_optional(arg_type, arg.initializer)
 
-        if isinstance(return_type, UnboundType):
-            return_type.is_ret_type = True
-
         func_type = None
         if any(arg_types) or return_type:
             if len(arg_types) != 1 and any(isinstance(t, EllipsisType) for t in arg_types):

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -51,9 +51,6 @@ class TypeIndirectionVisitor(TypeVisitor[Set[str]]):
     def visit_any(self, t: types.AnyType) -> Set[str]:
         return set()
 
-    def visit_void(self, t: types.Void) -> Set[str]:
-        return set()
-
     def visit_none_type(self, t: types.NoneTyp) -> Set[str]:
         return set()
 

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from typing import cast, List
 
 from mypy.types import (
-    Type, AnyType, NoneTyp, Void, TypeVisitor, Instance, UnboundType,
+    Type, AnyType, NoneTyp, TypeVisitor, Instance, UnboundType,
     ErrorType, TypeVarType, CallableType, TupleType, TypedDictType, ErasedType, TypeList,
     UnionType, FunctionLike, Overloaded, PartialType, DeletedType,
     UninhabitedType, TypeType, true_or_false
@@ -101,7 +101,7 @@ class TypeJoinVisitor(TypeVisitor[Type]):
         self.s = s
 
     def visit_unbound_type(self, t: UnboundType) -> Type:
-        if isinstance(self.s, Void) or isinstance(self.s, ErrorType):
+        if isinstance(self.s, ErrorType):
             return ErrorType()
         else:
             return AnyType()
@@ -121,39 +121,24 @@ class TypeJoinVisitor(TypeVisitor[Type]):
     def visit_any(self, t: AnyType) -> Type:
         return t
 
-    def visit_void(self, t: Void) -> Type:
-        if isinstance(self.s, Void):
-            return t
-        else:
-            return ErrorType()
-
     def visit_none_type(self, t: NoneTyp) -> Type:
         if experiments.STRICT_OPTIONAL:
             if isinstance(self.s, (NoneTyp, UninhabitedType)):
                 return t
             elif isinstance(self.s, UnboundType):
                 return AnyType()
-            elif isinstance(self.s, Void) or isinstance(self.s, ErrorType):
+            elif isinstance(self.s, ErrorType):
                 return ErrorType()
             else:
                 return UnionType.make_simplified_union([self.s, t])
         else:
-            if not isinstance(self.s, Void):
-                return self.s
-            else:
-                return self.default(self.s)
+            return self.s
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> Type:
-        if not isinstance(self.s, Void):
-            return self.s
-        else:
-            return self.default(self.s)
+        return self.s
 
     def visit_deleted_type(self, t: DeletedType) -> Type:
-        if not isinstance(self.s, Void):
-            return self.s
-        else:
-            return self.default(self.s)
+        return self.s
 
     def visit_erased_type(self, t: ErasedType) -> Type:
         return self.s
@@ -279,7 +264,7 @@ class TypeJoinVisitor(TypeVisitor[Type]):
             return object_from_instance(typ)
         elif isinstance(typ, UnboundType):
             return AnyType()
-        elif isinstance(typ, Void) or isinstance(typ, ErrorType):
+        elif isinstance(typ, ErrorType):
             return ErrorType()
         elif isinstance(typ, TupleType):
             return self.default(typ.fallback)

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -387,13 +387,8 @@ def object_from_instance(instance: Instance) -> Instance:
 def join_type_list(types: List[Type]) -> Type:
     if not types:
         # This is a little arbitrary but reasonable. Any empty tuple should be compatible
-        # with all variable length tuples, and this makes it possible. A better approach
-        # would be to use a special bottom type, which we do when strict Optional
-        # checking is enabled.
-        if experiments.STRICT_OPTIONAL:
-            return UninhabitedType()
-        else:
-            return NoneTyp()
+        # with all variable length tuples, and this makes it possible.
+        return UninhabitedType()
     joined = types[0]
     for t in types[1:]:
         joined = join_types(joined, t)

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from mypy.join import is_similar_callables, combine_similar_callables, join_type_list
 from mypy.types import (
-    Type, AnyType, TypeVisitor, UnboundType, Void, ErrorType, NoneTyp, TypeVarType,
+    Type, AnyType, TypeVisitor, UnboundType, ErrorType, NoneTyp, TypeVarType,
     Instance, CallableType, TupleType, TypedDictType, ErasedType, TypeList, UnionType, PartialType,
     DeletedType, UninhabitedType, TypeType
 )
@@ -123,7 +123,7 @@ class TypeMeetVisitor(TypeVisitor[Type]):
         self.s = s
 
     def visit_unbound_type(self, t: UnboundType) -> Type:
-        if isinstance(self.s, Void) or isinstance(self.s, ErrorType):
+        if isinstance(self.s, ErrorType):
             return ErrorType()
         elif isinstance(self.s, NoneTyp):
             if experiments.STRICT_OPTIONAL:
@@ -155,12 +155,6 @@ class TypeMeetVisitor(TypeVisitor[Type]):
                      for x in t.items]
         return UnionType.make_simplified_union(meets)
 
-    def visit_void(self, t: Void) -> Type:
-        if isinstance(self.s, Void):
-            return t
-        else:
-            return ErrorType()
-
     def visit_none_type(self, t: NoneTyp) -> Type:
         if experiments.STRICT_OPTIONAL:
             if isinstance(self.s, NoneTyp) or (isinstance(self.s, Instance) and
@@ -169,19 +163,19 @@ class TypeMeetVisitor(TypeVisitor[Type]):
             else:
                 return UninhabitedType()
         else:
-            if not isinstance(self.s, Void) and not isinstance(self.s, ErrorType):
+            if not isinstance(self.s, ErrorType):
                 return t
             else:
                 return ErrorType()
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> Type:
-        if not isinstance(self.s, Void) and not isinstance(self.s, ErrorType):
+        if not isinstance(self.s, ErrorType):
             return t
         else:
             return ErrorType()
 
     def visit_deleted_type(self, t: DeletedType) -> Type:
-        if not isinstance(self.s, Void) and not isinstance(self.s, ErrorType):
+        if not isinstance(self.s, ErrorType):
             if isinstance(self.s, NoneTyp):
                 if experiments.STRICT_OPTIONAL:
                     return t
@@ -293,7 +287,7 @@ class TypeMeetVisitor(TypeVisitor[Type]):
     def default(self, typ: Type) -> Type:
         if isinstance(typ, UnboundType):
             return AnyType()
-        elif isinstance(typ, Void) or isinstance(typ, ErrorType):
+        elif isinstance(typ, ErrorType):
             return ErrorType()
         else:
             if experiments.STRICT_OPTIONAL:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -619,9 +619,13 @@ class MessageBuilder:
                   format(capitalize(callable_name(callee)),
                          callee.arg_names[index]), context)
 
-    def does_not_return_value(self, unusable_type: Type, context: Context) -> None:
+    def does_not_return_value(self, callee_type: Type, context: Context) -> None:
         """Report an error about use of an unusable type."""
-        self.fail('Function does not return a value', context)
+        if isinstance(callee_type, FunctionLike) and callee_type.get_name() is not None:
+            self.fail('{} does not return a value'.format(
+                capitalize(callee_type.get_name())), context)
+        else:
+            self.fail('Function does not return a value', context)
 
     def deleted_as_rvalue(self, typ: DeletedType, context: Context) -> None:
         """Report an error about using an deleted type as an rvalue."""

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -1,7 +1,7 @@
 from typing import Sequence
 
 from mypy.types import (
-    Type, UnboundType, ErrorType, AnyType, NoneTyp, Void, TupleType, TypedDictType,
+    Type, UnboundType, ErrorType, AnyType, NoneTyp, TupleType, TypedDictType,
     UnionType, CallableType, TypeVarType, Instance, TypeVisitor, ErasedType,
     TypeList, Overloaded, PartialType, DeletedType, UninhabitedType, TypeType
 )
@@ -63,9 +63,6 @@ class SameTypeVisitor(TypeVisitor[bool]):
 
     def visit_any(self, left: AnyType) -> bool:
         return isinstance(self.right, AnyType)
-
-    def visit_void(self, left: Void) -> bool:
-        return isinstance(self.right, Void)
 
     def visit_none_type(self, left: NoneTyp) -> bool:
         return isinstance(self.right, NoneTyp)

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -3,7 +3,7 @@
 from typing import List, Dict
 from collections import defaultdict
 
-from mypy.types import Type, Void, NoneTyp, AnyType, ErrorType, UninhabitedType, TypeVarId
+from mypy.types import Type, NoneTyp, AnyType, ErrorType, UninhabitedType, TypeVarId
 from mypy.constraints import Constraint, SUPERTYPE_OF
 from mypy.join import join_types
 from mypy.meet import meet_types

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -57,12 +57,9 @@ def solve_constraints(vars: List[TypeVarId], constraints: List[Constraint],
             if top:
                 candidate = top
             else:
-                # No constraints for type variable -- type 'None' is the most specific type.
+                # No constraints for type variable -- 'UninhabitedType' is the most specific type.
                 if strict:
-                    if experiments.STRICT_OPTIONAL:
-                        candidate = UninhabitedType()
-                    else:
-                        candidate = NoneTyp()
+                    candidate = UninhabitedType()
                 else:
                     candidate = AnyType()
         elif top is None:

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, cast, Tuple
 
 from mypy.traverser import TraverserVisitor
 from mypy.types import (
-    Type, AnyType, Instance, FunctionLike, TupleType, Void, TypeVarType,
+    Type, AnyType, Instance, FunctionLike, TupleType, TypeVarType,
     TypeQuery, ANY_TYPE_STRATEGY, CallableType
 )
 from mypy import nodes
@@ -177,8 +177,6 @@ class StatisticsVisitor(TraverserVisitor):
                     self.num_generic += 1
             else:
                 self.num_simple += 1
-        elif isinstance(t, Void):
-            self.num_simple += 1
         elif isinstance(t, FunctionLike):
             self.num_function += 1
         elif isinstance(t, TupleType):

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Dict, Callable
 
 from mypy.types import (
-    Type, AnyType, UnboundType, TypeVisitor, ErrorType, FormalArgument, Void, NoneTyp,
+    Type, AnyType, UnboundType, TypeVisitor, ErrorType, FormalArgument, NoneTyp,
     Instance, TypeVarType, CallableType, TupleType, TypedDictType, UnionType, Overloaded,
     ErasedType, TypeList, PartialType, DeletedType, UninhabitedType, TypeType, is_named_instance
 )
@@ -79,19 +79,6 @@ def is_equivalent(a: Type,
         and is_subtype(b, a, type_parameter_checker, ignore_pos_arg_names=ignore_pos_arg_names))
 
 
-def satisfies_upper_bound(a: Type, upper_bound: Type) -> bool:
-    """Is 'a' valid value for a type variable with the given 'upper_bound'?
-
-    Same as is_subtype except that Void is considered to be a subtype of
-    any upper_bound. This is needed in a case like
-
-        def f(g: Callable[[], T]) -> T: ...
-        def h() -> None: ...
-        f(h)
-    """
-    return isinstance(a, Void) or is_subtype(a, upper_bound)
-
-
 class SubtypeVisitor(TypeVisitor[bool]):
 
     def __init__(self, right: Type,
@@ -116,18 +103,15 @@ class SubtypeVisitor(TypeVisitor[bool]):
     def visit_any(self, left: AnyType) -> bool:
         return True
 
-    def visit_void(self, left: Void) -> bool:
-        return isinstance(self.right, Void)
-
     def visit_none_type(self, left: NoneTyp) -> bool:
         if experiments.STRICT_OPTIONAL:
             return (isinstance(self.right, NoneTyp) or
                     is_named_instance(self.right, 'builtins.object'))
         else:
-            return not isinstance(self.right, Void)
+            return True
 
     def visit_uninhabited_type(self, left: UninhabitedType) -> bool:
-        return not isinstance(self.right, Void)
+        return True
 
     def visit_erased_type(self, left: ErasedType) -> bool:
         return True

--- a/mypy/test/testsolve.py
+++ b/mypy/test/testsolve.py
@@ -64,13 +64,13 @@ class SolveSuite(Suite):
     def test_no_constraints_for_var(self) -> None:
         self.assert_solve([self.fx.t.id],
                           [],
-                          [self.fx.nonet])
+                          [self.fx.uninhabited])
         self.assert_solve([self.fx.t.id, self.fx.s.id],
                           [],
-                          [self.fx.nonet, self.fx.nonet])
+                          [self.fx.uninhabited, self.fx.uninhabited])
         self.assert_solve([self.fx.t.id, self.fx.s.id],
                           [self.supc(self.fx.s, self.fx.a)],
-                          [self.fx.nonet, (self.fx.a, self.fx.o)])
+                          [self.fx.uninhabited, (self.fx.a, self.fx.o)])
 
     def test_simple_constraints_with_dynamic_type(self) -> None:
         self.assert_solve([self.fx.t.id],

--- a/mypy/test/testsolve.py
+++ b/mypy/test/testsolve.py
@@ -72,30 +72,6 @@ class SolveSuite(Suite):
                           [self.supc(self.fx.s, self.fx.a)],
                           [self.fx.nonet, (self.fx.a, self.fx.o)])
 
-    def test_void_constraints(self) -> None:
-        self.assert_solve([self.fx.t.id],
-                          [self.supc(self.fx.t, self.fx.void)],
-                          [(self.fx.void, self.fx.void)])
-        self.assert_solve([self.fx.t.id],
-                          [self.subc(self.fx.t, self.fx.void)],
-                          [(self.fx.void, self.fx.void)])
-
-        # Both bounds void.
-        self.assert_solve([self.fx.t.id],
-                          [self.supc(self.fx.t, self.fx.void),
-                           self.subc(self.fx.t, self.fx.void)],
-                          [(self.fx.void, self.fx.void)])
-
-        # Cannot infer any type.
-        self.assert_solve([self.fx.t.id],
-                          [self.supc(self.fx.t, self.fx.a),
-                           self.supc(self.fx.t, self.fx.void)],
-                          [None])
-        self.assert_solve([self.fx.t.id],
-                          [self.subc(self.fx.t, self.fx.a),
-                           self.subc(self.fx.t, self.fx.void)],
-                          [None])
-
     def test_simple_constraints_with_dynamic_type(self) -> None:
         self.assert_solve([self.fx.t.id],
                           [self.supc(self.fx.t, self.fx.anyt)],

--- a/mypy/test/testsubtypes.py
+++ b/mypy/test/testsubtypes.py
@@ -84,8 +84,8 @@ class SubtypingSuite(Suite):
         self.assert_strict_subtype(self.fx.callable(self.fx.d, self.fx.b),
                                    self.fx.callable(self.fx.d, self.fx.a))
 
-        self.assert_unrelated(self.fx.callable(self.fx.a, self.fx.a),
-                              self.fx.callable(self.fx.a, self.fx.nonet))
+        self.assert_strict_subtype(self.fx.callable(self.fx.a, self.fx.nonet),
+                                   self.fx.callable(self.fx.a, self.fx.a))
 
         self.assert_unrelated(
             self.fx.callable(self.fx.a, self.fx.a, self.fx.a),

--- a/mypy/test/testsubtypes.py
+++ b/mypy/test/testsubtypes.py
@@ -12,7 +12,7 @@ class SubtypingSuite(Suite):
         self.fx_co = TypeFixture(COVARIANT)
 
     def test_trivial_cases(self) -> None:
-        for simple in self.fx_co.void, self.fx_co.a, self.fx_co.o, self.fx_co.b:
+        for simple in self.fx_co.a, self.fx_co.o, self.fx_co.b:
             self.assert_subtype(simple, simple)
 
     def test_instance_subtyping(self) -> None:
@@ -85,7 +85,7 @@ class SubtypingSuite(Suite):
                                    self.fx.callable(self.fx.d, self.fx.a))
 
         self.assert_unrelated(self.fx.callable(self.fx.a, self.fx.a),
-                              self.fx.callable(self.fx.a, self.fx.void))
+                              self.fx.callable(self.fx.a, self.fx.nonet))
 
         self.assert_unrelated(
             self.fx.callable(self.fx.a, self.fx.a, self.fx.a),
@@ -184,7 +184,6 @@ class SubtypingSuite(Suite):
     #  * more generic interface subtyping test cases
     #  * type variables
     #  * tuple types
-    #  * void type
     #  * None type
     #  * any type
     #  * generic function types

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -45,7 +45,7 @@ class TypesSuite(Suite):
                          AnyType(), self.function)
         assert_equal(str(c), 'def (X?, Y?) -> Any')
 
-        c2 = CallableType([], [], [], NoneTyp(is_ret_type=True), None)
+        c2 = CallableType([], [], [], NoneTyp(), None)
         assert_equal(str(c2), 'def ()')
 
     def test_callable_type_with_default_args(self) -> None:
@@ -87,7 +87,7 @@ class TypesSuite(Suite):
 
         v = [TypeVarDef('Y', -1, None, self.fx.o),
              TypeVarDef('X', -2, None, self.fx.o)]
-        c2 = CallableType([], [], [], NoneTyp(is_ret_type=True), self.function, name=None, variables=v)
+        c2 = CallableType([], [], [], NoneTyp(), self.function, name=None, variables=v)
         assert_equal(str(c2), 'def [Y, X] ()')
 
 

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -10,7 +10,7 @@ from mypy.expandtype import expand_type
 from mypy.join import join_types, join_simple
 from mypy.meet import meet_types
 from mypy.types import (
-    UnboundType, AnyType, Void, CallableType, TupleType, TypeVarDef, Type,
+    UnboundType, AnyType, CallableType, TupleType, TypeVarDef, Type,
     Instance, NoneTyp, ErrorType, Overloaded, TypeType, UnionType, UninhabitedType,
     true_only, false_only, TypeVarId
 )
@@ -38,9 +38,6 @@ class TypesSuite(Suite):
         u = UnboundType('Foo', [UnboundType('T'), AnyType()])
         assert_equal(str(u), 'Foo?[T?, Any]')
 
-    def test_void_type(self) -> None:
-        assert_equal(str(Void(None)), 'void')
-
     def test_callable_type(self) -> None:
         c = CallableType([self.x, self.y],
                          [ARG_POS, ARG_POS],
@@ -48,7 +45,7 @@ class TypesSuite(Suite):
                          AnyType(), self.function)
         assert_equal(str(c), 'def (X?, Y?) -> Any')
 
-        c2 = CallableType([], [], [], Void(None), None)
+        c2 = CallableType([], [], [], NoneTyp(is_ret_type=True), None)
         assert_equal(str(c2), 'def ()')
 
     def test_callable_type_with_default_args(self) -> None:
@@ -90,7 +87,7 @@ class TypesSuite(Suite):
 
         v = [TypeVarDef('Y', -1, None, self.fx.o),
              TypeVarDef('X', -2, None, self.fx.o)]
-        c2 = CallableType([], [], [], Void(None), self.function, name=None, variables=v)
+        c2 = CallableType([], [], [], NoneTyp(is_ret_type=True), self.function, name=None, variables=v)
         assert_equal(str(c2), 'def [Y, X] ()')
 
 
@@ -103,7 +100,7 @@ class TypeOpsSuite(Suite):
     # expand_type
 
     def test_trivial_expand(self) -> None:
-        for t in (self.fx.a, self.fx.o, self.fx.t, self.fx.void, self.fx.nonet,
+        for t in (self.fx.a, self.fx.o, self.fx.t, self.fx.nonet,
                   self.tuple(self.fx.a),
                   self.callable([], self.fx.a, self.fx.a), self.fx.anyt):
             self.assert_expand(t, [], t)
@@ -139,7 +136,7 @@ class TypeOpsSuite(Suite):
     # erase_type
 
     def test_trivial_erase(self) -> None:
-        for t in (self.fx.a, self.fx.o, self.fx.void, self.fx.nonet,
+        for t in (self.fx.a, self.fx.o, self.fx.nonet,
                   self.fx.anyt, self.fx.err):
             self.assert_erase(t, t)
 
@@ -156,11 +153,11 @@ class TypeOpsSuite(Suite):
 
     def test_erase_with_function_type(self) -> None:
         self.assert_erase(self.fx.callable(self.fx.a, self.fx.b),
-                          self.fx.callable_type(self.fx.void))
+                          self.fx.callable_type(self.fx.nonet))
 
     def test_erase_with_type_object(self) -> None:
         self.assert_erase(self.fx.callable_type(self.fx.a, self.fx.b),
-                          self.fx.callable_type(self.fx.void))
+                          self.fx.callable_type(self.fx.nonet))
 
     def test_erase_with_type_type(self) -> None:
         self.assert_erase(self.fx.type_a, self.fx.type_a)
@@ -363,7 +360,7 @@ class JoinSuite(Suite):
         self.fx = TypeFixture()
 
     def test_trivial_cases(self) -> None:
-        for simple in self.fx.void, self.fx.a, self.fx.o, self.fx.b:
+        for simple in self.fx.a, self.fx.o, self.fx.b:
             self.assert_join(simple, simple, simple)
 
     def test_class_subtyping(self) -> None:
@@ -409,17 +406,6 @@ class JoinSuite(Suite):
         self.assert_join(self.fx.s, self.fx.s, self.fx.s)
         self.assert_join(self.fx.t, self.fx.s, self.fx.o)
 
-    def test_void(self) -> None:
-        self.assert_join(self.fx.void, self.fx.void, self.fx.void)
-        self.assert_join(self.fx.void, self.fx.anyt, self.fx.anyt)
-
-        # Join of any other type against void results in ErrorType, since there
-        # is no other meaningful result.
-        for t in [self.fx.a, self.fx.o, NoneTyp(), UnboundType('x'),
-                  self.fx.t, self.tuple(),
-                  self.callable(self.fx.a, self.fx.b)]:
-            self.assert_join(t, self.fx.void, self.fx.err)
-
     def test_none(self) -> None:
         # Any type t joined with None results in t.
         for t in [NoneTyp(), self.fx.a, self.fx.o, UnboundType('x'),
@@ -441,7 +427,7 @@ class JoinSuite(Suite):
     def test_any_type(self) -> None:
         # Join against 'Any' type always results in 'Any'.
         for t in [self.fx.anyt, self.fx.a, self.fx.o, NoneTyp(),
-                  UnboundType('x'), self.fx.void, self.fx.t, self.tuple(),
+                  UnboundType('x'), self.fx.t, self.tuple(),
                   self.callable(self.fx.a, self.fx.b)]:
             self.assert_join(t, self.fx.anyt, self.fx.anyt)
 
@@ -475,7 +461,7 @@ class JoinSuite(Suite):
 
         # Meet against any type except dynamic results in ErrorType.
         for t in [self.fx.a, self.fx.o, NoneTyp(), UnboundType('x'),
-                  self.fx.void, self.fx.t, self.tuple(),
+                  self.fx.t, self.tuple(),
                   self.callable(self.fx.a, self.fx.b)]:
             self.assert_join(t, self.fx.err, self.fx.err)
 
@@ -651,7 +637,7 @@ class MeetSuite(Suite):
         self.fx = TypeFixture()
 
     def test_trivial_cases(self) -> None:
-        for simple in self.fx.void, self.fx.a, self.fx.o, self.fx.b:
+        for simple in self.fx.a, self.fx.o, self.fx.b:
             self.assert_meet(simple, simple, simple)
 
     def test_class_subtyping(self) -> None:
@@ -694,25 +680,12 @@ class MeetSuite(Suite):
         self.assert_meet(self.fx.s, self.fx.s, self.fx.s)
         self.assert_meet(self.fx.t, self.fx.s, NoneTyp())
 
-    def test_void(self) -> None:
-        self.assert_meet(self.fx.void, self.fx.void, self.fx.void)
-        self.assert_meet(self.fx.void, self.fx.anyt, self.fx.void)
-
-        # Meet of any other type against void results in ErrorType, since there
-        # is no meaningful valid result.
-        for t in [self.fx.a, self.fx.o, UnboundType('x'), NoneTyp(),
-                  self.fx.t, self.tuple(),
-                  self.callable(self.fx.a, self.fx.b)]:
-            self.assert_meet(t, self.fx.void, self.fx.err)
-
     def test_none(self) -> None:
         self.assert_meet(NoneTyp(), NoneTyp(), NoneTyp())
 
         self.assert_meet(NoneTyp(), self.fx.anyt, NoneTyp())
-        self.assert_meet(NoneTyp(), self.fx.void, self.fx.err)
 
-        # Any type t joined with None results in None, unless t is any or
-        # void.
+        # Any type t joined with None results in None, unless t is Any.
         for t in [self.fx.a, self.fx.o, UnboundType('x'), self.fx.t,
                   self.tuple(), self.callable(self.fx.a, self.fx.b)]:
             self.assert_meet(t, NoneTyp(), NoneTyp())
@@ -721,12 +694,11 @@ class MeetSuite(Suite):
         self.assert_meet(UnboundType('x'), UnboundType('x'), self.fx.anyt)
         self.assert_meet(UnboundType('x'), UnboundType('y'), self.fx.anyt)
 
-        self.assert_meet(UnboundType('x'), self.fx.void, self.fx.err)
         self.assert_meet(UnboundType('x'), self.fx.anyt, UnboundType('x'))
 
-        # The meet of any type t with an unbound type results in dynamic
-        # (except for void). Unbound type means that there is an error
-        # somewhere in the program, so this does not affect type safety.
+        # The meet of any type t with an unbound type results in dynamic.
+        # Unbound type means that there is an error somewhere in the program,
+        # so this does not affect type safety.
         for t in [self.fx.a, self.fx.o, self.fx.t, self.tuple(),
                   self.callable(self.fx.a, self.fx.b)]:
             self.assert_meet(t, UnboundType('X'), self.fx.anyt)
@@ -734,7 +706,7 @@ class MeetSuite(Suite):
     def test_dynamic_type(self) -> None:
         # Meet against dynamic type always results in dynamic.
         for t in [self.fx.anyt, self.fx.a, self.fx.o, NoneTyp(),
-                  UnboundType('x'), self.fx.void, self.fx.t, self.tuple(),
+                  UnboundType('x'), self.fx.t, self.tuple(),
                   self.callable(self.fx.a, self.fx.b)]:
             self.assert_meet(t, self.fx.anyt, t)
 
@@ -743,7 +715,7 @@ class MeetSuite(Suite):
 
         # Meet against any type except dynamic results in ErrorType.
         for t in [self.fx.a, self.fx.o, NoneTyp(), UnboundType('x'),
-                  self.fx.void, self.fx.t, self.tuple(),
+                  self.fx.t, self.tuple(),
                   self.callable(self.fx.a, self.fx.b)]:
             self.assert_meet(t, self.fx.err, self.fx.err)
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -4,8 +4,8 @@ from collections import OrderedDict
 from typing import Callable, List, Optional, Set
 
 from mypy.types import (
-    Type, UnboundType, TypeVarType, TupleType, TypedDictType, UnionType, Instance, TypeVarId,
-    AnyType, CallableType, Void, NoneTyp, DeletedType, TypeList, TypeVarDef, TypeVisitor,
+    Type, UnboundType, TypeVarType, TupleType, TypedDictType, UnionType, Instance,
+    AnyType, CallableType, NoneTyp, DeletedType, TypeList, TypeVarDef, TypeVisitor,
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType, get_typ_args, set_typ_args,
     get_type_vars,
 )
@@ -16,7 +16,7 @@ from mypy.nodes import (
 )
 from mypy.sametypes import is_same_type
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
-from mypy.subtypes import satisfies_upper_bound
+from mypy.subtypes import is_subtype
 from mypy import nodes
 from mypy import experiments
 
@@ -293,9 +293,6 @@ class TypeAnalyser(TypeVisitor[Type]):
     def visit_any(self, t: AnyType) -> Type:
         return t
 
-    def visit_void(self, t: Void) -> Type:
-        return t
-
     def visit_none_type(self, t: NoneTyp) -> Type:
         return t
 
@@ -493,7 +490,7 @@ class TypeAnalyserPass3(TypeVisitor[None]):
                         arg_values = [arg]
                     self.check_type_var_values(info, arg_values,
                                                TypeVar.values, i + 1, t)
-                if not satisfies_upper_bound(arg, TypeVar.upper_bound):
+                if not is_subtype(arg, TypeVar.upper_bound):
                     self.fail('Type argument "{}" of "{}" must be '
                               'a subtype of "{}"'.format(
                                   arg, info.name(), TypeVar.upper_bound), t)
@@ -538,9 +535,6 @@ class TypeAnalyserPass3(TypeVisitor[None]):
         pass
 
     def visit_any(self, t: AnyType) -> None:
-        pass
-
-    def visit_void(self, t: Void) -> None:
         pass
 
     def visit_none_type(self, t: NoneTyp) -> None:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -128,10 +128,7 @@ class TypeAnalyser(TypeVisitor[Type]):
                 assert sym.tvar_def is not None
                 return TypeVarType(sym.tvar_def, t.line)
             elif fullname == 'builtins.None':
-                if experiments.STRICT_OPTIONAL:
-                    return NoneTyp(is_ret_type=t.is_ret_type)
-                else:
-                    return Void()
+                return NoneTyp(is_ret_type=t.is_ret_type)
             elif fullname == 'typing.Any':
                 return AnyType()
             elif fullname == 'typing.Tuple':
@@ -153,11 +150,7 @@ class TypeAnalyser(TypeVisitor[Type]):
                     self.fail('Optional[...] must have exactly one type argument', t)
                     return AnyType()
                 item = self.anal_type(t.args[0])
-                if experiments.STRICT_OPTIONAL:
-                    return UnionType.make_simplified_union([item, NoneTyp()])
-                else:
-                    # Without strict Optional checking Optional[t] is just an alias for t.
-                    return item
+                return UnionType.make_simplified_union([item, NoneTyp()])
             elif fullname == 'typing.Callable':
                 return self.analyze_callable_type(t)
             elif fullname == 'typing.Type':

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -143,7 +143,8 @@ class TypeAnalyser(TypeVisitor[Type]):
                 return self.tuple_type(self.anal_array(t.args))
             elif fullname == 'typing.Union':
                 items = self.anal_array(t.args)
-                items = [item for item in items if not isinstance(item, Void)]
+                if not experiments.STRICT_OPTIONAL:
+                    items = [item for item in items if not isinstance(item, NoneTyp)]
                 return UnionType.make_union(items)
             elif fullname == 'typing.Optional':
                 if len(t.args) != 1:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -128,7 +128,7 @@ class TypeAnalyser(TypeVisitor[Type]):
                 assert sym.tvar_def is not None
                 return TypeVarType(sym.tvar_def, t.line)
             elif fullname == 'builtins.None':
-                return NoneTyp(is_ret_type=t.is_ret_type)
+                return NoneTyp()
             elif fullname == 'typing.Any':
                 return AnyType()
             elif fullname == 'typing.Tuple':

--- a/mypy/typefixture.py
+++ b/mypy/typefixture.py
@@ -7,7 +7,7 @@ from typing import List
 
 from mypy.types import (
     Type, TypeVarType, AnyType, ErrorType, NoneTyp,
-    Instance, CallableType, TypeVarDef, TypeType,
+    Instance, CallableType, TypeVarDef, TypeType, UninhabitedType
 )
 from mypy.nodes import (
     TypeInfo, ClassDef, Block, ARG_POS, ARG_OPT, ARG_STAR, SymbolTable,
@@ -43,6 +43,7 @@ class TypeFixture:
         self.anyt = AnyType()
         self.err = ErrorType()
         self.nonet = NoneTyp()
+        self.uninhabited = UninhabitedType()
 
         # Abstract class TypeInfos
 

--- a/mypy/typefixture.py
+++ b/mypy/typefixture.py
@@ -6,7 +6,7 @@ It contains class TypeInfos and Type objects.
 from typing import List
 
 from mypy.types import (
-    Type, TypeVarType, AnyType, Void, ErrorType, NoneTyp,
+    Type, TypeVarType, AnyType, ErrorType, NoneTyp,
     Instance, CallableType, TypeVarDef, TypeType,
 )
 from mypy.nodes import (
@@ -41,7 +41,6 @@ class TypeFixture:
 
         # Simple types
         self.anyt = AnyType()
-        self.void = Void()
         self.err = ErrorType()
         self.nonet = NoneTyp()
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -188,8 +188,6 @@ class UnboundType(Type):
     args = None  # type: List[Type]
     # should this type be wrapped in an Optional?
     optional = False
-    # is this type a return type?
-    is_ret_type = False
 
     # special case for X[()]
     empty_tuple_index = False
@@ -200,14 +198,12 @@ class UnboundType(Type):
                  line: int = -1,
                  column: int = -1,
                  optional: bool = False,
-                 is_ret_type: bool = False,
                  empty_tuple_index: bool = False) -> None:
         if not args:
             args = []
         self.name = name
         self.args = args
         self.optional = optional
-        self.is_ret_type = is_ret_type
         self.empty_tuple_index = empty_tuple_index
         super().__init__(line, column)
 
@@ -319,29 +315,24 @@ class UninhabitedType(Type):
 class NoneTyp(Type):
     """The type of 'None'.
 
-    This type can be written by users as 'None'. When used as a return type,
-    `is_ret_type` is set to true, which signifies the result should not be
-    used.
+    This type can be written by users as 'None'.
     """
 
     can_be_true = False
 
-    def __init__(self, is_ret_type: bool = False, line: int = -1, column: int = -1) -> None:
+    def __init__(self, line: int = -1, column: int = -1) -> None:
         super().__init__(line, column)
-        self.is_ret_type = is_ret_type
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_none_type(self)
 
     def serialize(self) -> JsonDict:
-        return {'.class': 'NoneTyp',
-                'is_ret_type': self.is_ret_type,
-                }
+        return {'.class': 'NoneTyp'}
 
     @classmethod
     def deserialize(cls, data: JsonDict) -> 'NoneTyp':
         assert data['.class'] == 'NoneTyp'
-        return NoneTyp(is_ret_type=data['is_ret_type'])
+        return NoneTyp()
 
 
 class ErasedType(Type):

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1412,7 +1412,8 @@ class TypeStrVisitor(TypeVisitor[str]):
 
         s = '({})'.format(s)
 
-        s += ' -> {}'.format(t.ret_type)
+        if not isinstance(t.ret_type, NoneTyp):
+            s += ' -> {}'.format(t.ret_type)
 
         if t.variables:
             s = '{} {}'.format(t.variables, s)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -14,7 +14,6 @@ from mypy.nodes import (
     ARG_POS, ARG_OPT, ARG_STAR, ARG_STAR2, ARG_NAMED, ARG_NAMED_OPT,
 )
 
-from mypy import experiments
 from mypy.sharedparse import argument_elide_name
 
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1025,10 +1025,7 @@ class UnionType(Type):
         elif len(items) == 1:
             return items[0]
         else:
-            if experiments.STRICT_OPTIONAL:
-                return UninhabitedType()
-            else:
-                return Void()
+            return UninhabitedType()
 
     @staticmethod
     def make_simplified_union(items: List[Type], line: int = -1, column: int = -1) -> Type:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -506,6 +506,9 @@ class FunctionLike(Type):
     @abstractmethod
     def with_name(self, name: str) -> 'FunctionLike': pass
 
+    @abstractmethod
+    def get_name(self) -> str: pass
+
     # Corresponding instance type (e.g. builtins.type)
     fallback = None  # type: Instance
 
@@ -631,6 +634,9 @@ class CallableType(FunctionLike):
     def with_name(self, name: str) -> 'CallableType':
         """Return a copy of this type with the specified name."""
         return self.copy_modified(ret_type=self.ret_type, name=name)
+
+    def get_name(self) -> str:
+        return self.name
 
     def max_fixed_args(self) -> int:
         n = len(self.arg_types)
@@ -778,7 +784,7 @@ class Overloaded(FunctionLike):
         return self._items
 
     def name(self) -> str:
-        return self._items[0].name
+        return self.get_name()
 
     def is_type_obj(self) -> bool:
         # All the items must have the same type object status, so it's
@@ -795,6 +801,9 @@ class Overloaded(FunctionLike):
         for it in self._items:
             ni.append(it.with_name(name))
         return Overloaded(ni)
+
+    def get_name(self) -> str:
+        return self._items[0].name
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_overloaded(self)

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -282,7 +282,7 @@ class C:
     def __aenter__(self) -> None: pass
     async def __aexit__(self, x, y, z) -> None: pass
 async def f() -> None:
-    async with C() as x:  # E: "__aenter__" of "C" does not return a value
+    async with C() as x:  # E: None has no attribute "__await__"
         pass
 [builtins fixtures/async_await.pyi]
 [out]
@@ -304,7 +304,7 @@ class C:
     async def __aenter__(self) -> int: pass
     def __aexit__(self, x, y, z) -> None: pass
 async def f() -> None:
-    async with C() as x: # E: "__aexit__" of "C" does not return a value
+    async with C() as x: # E: None has no attribute "__await__"
         pass
 [builtins fixtures/async_await.pyi]
 [out]
@@ -425,8 +425,8 @@ async def g() -> AsyncGenerator[int, None]:
     yield 'not an int'  # E: Incompatible types in yield (actual type "str", expected type "int")
     # return without a value is fine
     return
-reveal_type(g)  # E: Revealed type is 'def () -> typing.AsyncGenerator[builtins.int, void]'
-reveal_type(g())  # E: Revealed type is 'typing.AsyncGenerator[builtins.int, void]'
+reveal_type(g)  # E: Revealed type is 'def () -> typing.AsyncGenerator[builtins.int, builtins.None]'
+reveal_type(g())  # E: Revealed type is 'typing.AsyncGenerator[builtins.int, builtins.None]'
 
 async def h() -> None:
     async for item in g():
@@ -463,7 +463,7 @@ async def genfunc() -> AsyncGenerator[int, None]:
 async def user() -> None:
     gen = genfunc()
 
-    reveal_type(gen.__aiter__())  # E: Revealed type is 'typing.AsyncGenerator[builtins.int*, void]'
+    reveal_type(gen.__aiter__())  # E: Revealed type is 'typing.AsyncGenerator[builtins.int*, builtins.None]'
 
     reveal_type(await gen.__anext__())  # E: Revealed type is 'builtins.int*'
 
@@ -548,13 +548,20 @@ async def return_int() -> AsyncGenerator[int, None]:
 async def return_none() -> AsyncGenerator[int, None]:
     yield 1
     return None  # E: 'return' with value in async generator is not allowed
+[builtins fixtures/dict.pyi]
 
+[case testAsyncGeneratorNoReturnWithValue2]
+# flags: --python-version 3.6
+from typing import AsyncGenerator
 def f() -> None:
     return
 
 async def return_f() -> AsyncGenerator[int, None]:
     yield 1
-    return f()  # E: 'return' with value in async generator is not allowed
+    return f()
+[out]
+main:8: error: 'return' with value in async generator is not allowed
+main:8: error: "f" does not return a value
 
 [builtins fixtures/dict.pyi]
 

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -548,20 +548,13 @@ async def return_int() -> AsyncGenerator[int, None]:
 async def return_none() -> AsyncGenerator[int, None]:
     yield 1
     return None  # E: 'return' with value in async generator is not allowed
-[builtins fixtures/dict.pyi]
 
-[case testAsyncGeneratorNoReturnWithValue2]
-# flags: --python-version 3.6
-from typing import AsyncGenerator
 def f() -> None:
     return
 
 async def return_f() -> AsyncGenerator[int, None]:
     yield 1
-    return f()
-[out]
-main:8: error: 'return' with value in async generator is not allowed
-main:8: error: "f" does not return a value
+    return f()  # E: 'return' with value in async generator is not allowed
 
 [builtins fixtures/dict.pyi]
 

--- a/test-data/unit/check-bound.test
+++ b/test-data/unit/check-bound.test
@@ -56,7 +56,7 @@ class C(Generic[T]):
         return self.t
 c1 = None # type: C[None]
 c1.get()
-d = c1.get() # E: Function does not return a value
+d = c1.get() # E: "get" of "C" does not return a value
 
 
 [case testBoundAny]
@@ -82,7 +82,7 @@ def f(g: Callable[[], T]) -> T:
     return g()
 def h() -> None: pass
 f(h)
-a = f(h) # E: "h" does not return a value
+a = f(h) # E: "f" does not return a value
 
 
 [case testBoundInheritance]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -281,10 +281,9 @@ class A:
     def g(self) -> 'A': pass
 class B(A):
     def f(self) -> A: pass  # Fail
-    def g(self) -> None: pass  # Fail
+    def g(self) -> None: pass
 [out]
 main:6: error: Return type of "f" incompatible with supertype "A"
-main:7: error: Return type of "g" incompatible with supertype "A"
 
 [case testOverride__new__WithDifferentSignature]
 class A:
@@ -727,12 +726,9 @@ import typing
 class A:
     def f(self) -> None:
         def g() -> None:
-            a = None
-        b = None
+            "" + 1  # E: Unsupported operand types for + ("str" and "int")
+        "" + 1  # E: Unsupported operand types for + ("str" and "int")
 [out]
-main:5: error: Need type annotation for variable
-main:6: error: Need type annotation for variable
-
 
 -- Static methods
 -- --------------

--- a/test-data/unit/check-dynamic-typing.test
+++ b/test-data/unit/check-dynamic-typing.test
@@ -537,7 +537,7 @@ f11 = None # type: Callable[[], Any]
 f2 = None # type: Callable[[], A]
 f3 = None # type: Callable[[], None]
 
-f2 = f3 # E: Incompatible types in assignment (expression has type Callable[[], None], variable has type Callable[[], A])
+f2 = f3
 
 f1 = f2
 f1 = f3

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -921,8 +921,8 @@ a = None # type: A
 f() + a     # E: "f" does not return a value
 a + f()     # E: "f" does not return a value
 f() == a    # E: "f" does not return a value
-a != f()    # E: Unsupported left operand type for != ("A")
-cast(A, f()) # E: "f" does not return a value
+a != f()    # E: "f" does not return a value
+cast(A, f())
 f().foo     # E: "f" does not return a value
 
 def f() -> None: pass
@@ -933,9 +933,9 @@ class A:
 [case testNoneReturnTypeWithExpressions2]
 
 a, b = None, None # type: (A, bool)
-a < f()    # E: Unsupported left operand type for < ("A")
+f() in a
+a < f()    # E: "f" does not return a value
 f() <= a   # E: "f" does not return a value
-f() in a   # E: Unsupported right operand type for in ("A")
 a in f()   # E: "f" does not return a value
 -f()       # E: "f" does not return a value
 not f()    # E: "f" does not return a value
@@ -947,6 +947,9 @@ class A:
     def __add__(self, x: 'A') -> 'A':
         pass
 [builtins fixtures/bool.pyi]
+[out]
+main:3: error: "f" does not return a value
+main:3: error: Unsupported right operand type for in ("A")
 
 
 -- Slicing
@@ -1474,6 +1477,7 @@ def f(x: int) -> None:
 [out]
 main:1: error: The return type of a generator function should be "Generator" or one of its supertypes
 main:2: error: Argument 1 to "f" has incompatible type "str"; expected "int"
+main:2: error: "f" does not return a value
 
 [case testYieldExpressionWithNone]
 from typing import Iterator
@@ -1487,14 +1491,14 @@ def f(x: int) -> Iterator[None]:
 -- ----------------
 
 
-[case testYieldFromIteratorHasNoValue]
+[case testYieldFromIteratorIsNone]
 from typing import Iterator
 def f() -> Iterator[int]:
     yield 5
 def g() -> Iterator[int]:
     a = yield from f()
+    reveal_type(a)  # E: Revealed type is 'builtins.None'
 [out]
-main:5: error: Function does not return a value
 
 [case testYieldFromGeneratorHasValue]
 from typing import Iterator, Generator

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -933,7 +933,7 @@ class A:
 [case testNoneReturnTypeWithExpressions2]
 
 a, b = None, None # type: (A, bool)
-f() in a
+f() in a   # Fail (see output)
 a < f()    # E: "f" does not return a value
 f() <= a   # E: "f" does not return a value
 a in f()   # E: "f" does not return a value
@@ -1491,14 +1491,14 @@ def f(x: int) -> Iterator[None]:
 -- ----------------
 
 
-[case testYieldFromIteratorIsNone]
+[case testYieldFromIteratorHasNoValue]
 from typing import Iterator
 def f() -> Iterator[int]:
     yield 5
 def g() -> Iterator[int]:
     a = yield from f()
-    reveal_type(a)  # E: Revealed type is 'builtins.None'
 [out]
+main:5: error: Function does not return a value
 
 [case testYieldFromGeneratorHasValue]
 from typing import Iterator, Generator

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -208,7 +208,7 @@ from typing import Callable
 f = None # type: Callable[[], None]
 g = None # type: Callable[[], object]
 f = g  # E: Incompatible types in assignment (expression has type Callable[[], object], variable has type Callable[[], None])
-g = f  # E: Incompatible types in assignment (expression has type Callable[[], None], variable has type Callable[[], object])
+g = f  # OK
 
 f = f
 g = g

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -394,7 +394,7 @@ B(1)
 C(1)
 C('a')  # E: Argument 1 to "C" has incompatible type "str"; expected "int"
 D(A(1))
-D(1)  # E: Argument 1 to "D" has incompatible type "int"; expected A[None]
+D(1)  # E: Argument 1 to "D" has incompatible type "int"; expected A[<uninhabited>]
 
 
 [case testInheritedConstructor2]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -565,7 +565,7 @@ def func(x: IntNode[T]) -> IntNode[T]:
     return x
 reveal_type(func) # E: Revealed type is 'def [T] (x: __main__.Node[builtins.int, T`-1]) -> __main__.Node[builtins.int, T`-1]'
 
-func(1) # E: Argument 1 to "func" has incompatible type "int"; expected Node[int, None]
+func(1) # E: Argument 1 to "func" has incompatible type "int"; expected Node[int, <uninhabited>]
 func(Node('x', 1)) # E: Argument 1 to "Node" has incompatible type "str"; expected "int"
 reveal_type(func(Node(1, 'x'))) # E: Revealed type is '__main__.Node[builtins.int, builtins.str*]'
 
@@ -800,7 +800,7 @@ reveal_type(x) # E: Revealed type is 'builtins.int'
 def f2(x: IntTP[T]) -> IntTP[T]:
     return x
 
-f2((1, 2, 3)) # E: Argument 1 to "f2" has incompatible type "Tuple[int, int, int]"; expected "Tuple[int, None]"
+f2((1, 2, 3)) # E: Argument 1 to "f2" has incompatible type "Tuple[int, int, int]"; expected "Tuple[int, <uninhabited>]"
 reveal_type(f2((1, 'x'))) # E: Revealed type is 'Tuple[builtins.int, builtins.str*]'
 
 [builtins fixtures/for.pyi]
@@ -869,7 +869,7 @@ n.y = 'x' # E: Incompatible types in assignment (expression has type "str", vari
 def f(x: Node[T, T]) -> TupledNode[T]:
     return Node(x.x, (x.x, x.x))
 
-f(1) # E: Argument 1 to "f" has incompatible type "int"; expected Node[None, None]
+f(1) # E: Argument 1 to "f" has incompatible type "int"; expected Node[<uninhabited>, <uninhabited>]
 f(Node(1, 'x')) # E: Cannot infer type argument 1 of "f"
 reveal_type(Node('x', 'x')) # E: Revealed type is 'a.Node[builtins.str*, builtins.str*]'
 

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -13,7 +13,7 @@ b = None # type: B
 
 ao = f()
 ab = f()
-b = f() # E: Incompatible types in assignment (expression has type A[None], variable has type "B")
+b = f() # E: Incompatible types in assignment (expression has type A[<uninhabited>], variable has type "B")
 
 def f() -> 'A[T]': pass
 
@@ -29,7 +29,7 @@ b = None # type: B
 
 ao = A()
 ab = A()
-b = A() # E: Incompatible types in assignment (expression has type A[None], variable has type "B")
+b = A() # E: Incompatible types in assignment (expression has type A[<uninhabited>], variable has type "B")
 
 class A(Generic[T]): pass
 class B: pass
@@ -334,7 +334,7 @@ aa = None # type: List[A]
 ao = None # type: List[object]
 a = None # type: A
 
-a = [] # E: Incompatible types in assignment (expression has type List[None], variable has type "A")
+a = [] # E: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type "A")
 
 aa = []
 ao = []
@@ -385,7 +385,7 @@ class B(A): pass
 import typing
 def f() -> None:
     a = []     # E: Need type annotation for variable
-    b = [None]  # E: Need type annotation for variable
+    b = [None]
     c = [B()]
     c = [object()] # E: List item 0 has incompatible type "object"
     c = [B()]
@@ -755,7 +755,7 @@ T = TypeVar('T')
 def f(x: Union[List[T], str]) -> None: pass
 f([1])
 f('')
-f(1) # E: Argument 1 to "f" has incompatible type "int"; expected "Union[List[None], str]"
+f(1) # E: Argument 1 to "f" has incompatible type "int"; expected "Union[List[<uninhabited>], str]"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testIgnoringInferenceContext]
@@ -824,7 +824,7 @@ from typing import TypeVar, Callable, Generic
 T = TypeVar('T')
 class A(Generic[T]):
     pass
-reveal_type(A()) # E: Revealed type is '__main__.A[builtins.None]'
+reveal_type(A()) # E: Revealed type is '__main__.A[<uninhabited>]'
 b = reveal_type(A())  # type: A[int] # E: Revealed type is '__main__.A[builtins.int]'
 
 [case testUnionWithGenericTypeItemContext]
@@ -877,4 +877,17 @@ class M(Generic[_KT, _VT]):
     def get(self, k: _KT, default: _T) -> _T: ...
 
 def f(d: M[_KT, _VT], k: _KT) -> _VT:
+    return d.get(k, None)  # E: "get" of "M" does not return a value
+
+[case testGenericMethodCalledInGenericContext2]
+from typing import TypeVar, Generic, Union
+
+_KT = TypeVar('_KT')
+_VT = TypeVar('_VT')
+_T = TypeVar('_T')
+
+class M(Generic[_KT, _VT]):
+    def get(self, k: _KT, default: _T) -> Union[_VT, _T]: ...
+
+def f(d: M[_KT, _VT], k: _KT) -> Union[_VT, None]:
     return d.get(k, None)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -109,8 +109,8 @@ class B: pass
 [case testInferringTupleTypeForLvarWithNones]
 import typing
 def f() -> None:
-    a = A(), None # E: Need type annotation for variable
-    b = None, A() # E: Need type annotation for variable
+    a = A(), None
+    b = None, A()
 
 class A: pass
 [builtins fixtures/tuple.pyi]
@@ -246,8 +246,8 @@ class C: pass
 [case testInferringLvarTypesInMultiDefWithNoneTypes]
 import typing
 def f() -> None:
-    a, b = A(), None # E: Need type annotation for variable
-    c, d = None, A() # E: Need type annotation for variable
+    a, b = A(), None
+    c, d = None, A()
 
 class A: pass
 [out]
@@ -255,7 +255,7 @@ class A: pass
 [case testInferringLvarTypesInNestedTupleAssignmentWithNoneTypes]
 import typing
 def f() -> None:
-    a1, (a2, b) = A(), (A(), None) # E: Need type annotation for variable
+    a1, (a2, b) = A(), (A(), None)
 
 class A: pass
 [out]
@@ -420,7 +420,8 @@ class A: pass
 a = None # type: A
 
 def ff() -> None:
-    x = f() # E: Need type annotation for variable
+    x = f()
+    reveal_type(x)
 
 g(None) # Ok
 f()     # Ok because not used to infer local variable type
@@ -429,19 +430,6 @@ g(a)
 def f() -> T: pass
 def g(a: T) -> None: pass
 [out]
-
-[case testUnsolvableInferenceResult]
-from typing import TypeVar
-T = TypeVar('T')
-f(A(), g()) # Fail
-f(A(), A())
-
-def f(a: T, b: T) -> None: pass
-def g() -> None: pass
-class A: pass
-[out]
-main:3: error: Cannot infer type argument 1 of "f"
-main:3: error: "g" does not return a value
 
 [case testInferenceWithMultipleConstraints]
 from typing import TypeVar
@@ -694,10 +682,10 @@ g('a')() # E: List[str] not callable
 # The next line is a case where there are multiple ways to satisfy a constraint
 # involving a Union. Either T = List[str] or T = str would turn out to be valid,
 # but mypy doesn't know how to branch on these two options (and potentially have
-# to backtrack later) and defaults to T = None. The result is an awkward error
-# message. Either a better error message, or simply accepting the call, would be
-# preferable here.
-g(['a']) # E: Argument 1 to "g" has incompatible type List[str]; expected List[None]
+# to backtrack later) and defaults to T = <uninhabited>. The result is an
+# awkward error message. Either a better error message, or simply accepting the
+# call, would be preferable here.
+g(['a']) # E: Argument 1 to "g" has incompatible type List[str]; expected List[<uninhabited>]
 
 h(g(['a']))
 
@@ -744,7 +732,7 @@ from typing import TypeVar, Union, List
 T = TypeVar('T')
 def f() -> List[T]: pass
 d1 = f() # type: Union[List[int], str]
-d2 = f() # type: Union[int, str] # E: Incompatible types in assignment (expression has type List[None], variable has type "Union[int, str]")
+d2 = f() # type: Union[int, str] # E: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type "Union[int, str]")
 def g(x: T) -> List[T]: pass
 d3 = g(1) # type: Union[List[int], List[str]]
 [builtins fixtures/list.pyi]
@@ -840,7 +828,7 @@ for x in [A()]:
     b = x # E: Incompatible types in assignment (expression has type "A", variable has type "B")
     a = x
 
-for y in []: # E: Need type annotation for variable
+for y in []:
     a = y
 
 class A: pass
@@ -861,7 +849,7 @@ for xx, yy, zz in [(A(), B())]: # Fail
     pass
 for xx, (yy, zz) in [(A(), B())]: # Fail
     pass
-for xxx, yyy in [(None, None)]: # Fail
+for xxx, yyy in [(None, None)]:
     pass
 
 class A: pass
@@ -874,7 +862,6 @@ main:5: error: Incompatible types in assignment (expression has type "B", variab
 main:6: error: Incompatible types in assignment (expression has type "C", variable has type "A")
 main:10: error: Need more than 2 values to unpack (3 expected)
 main:12: error: '__main__.B' object is not iterable
-main:14: error: Need type annotation for variable
 
 [case testInferenceOfFor3]
 
@@ -886,7 +873,7 @@ for x, y in [[A()]]:
     a = x
     a = y
 
-for e, f in [[]]: # E: Need type annotation for variable
+for e, f in [[]]:
     pass
 
 class A: pass
@@ -1073,10 +1060,10 @@ def f(x: Callable[[], None]) -> None: pass
 def g(x: Callable[[], int]) -> None: pass
 a = lambda: None
 f(a)
-g(a) # E: Argument 1 to "g" has incompatible type Callable[[], None]; expected Callable[[], int]
+g(a)
 b = lambda: None  # type: Callable[[], None]
 f(b)
-g(b) # E: Argument 1 to "g" has incompatible type Callable[[], None]; expected Callable[[], int]
+g(b)
 
 [case testLambdaDefaultContext]
 # flags: --strict-optional
@@ -1383,7 +1370,7 @@ def f() -> None:
 [case testLvarInitializedToNoneWithoutType]
 import typing
 def f() -> None:
-    a = None # E: Need type annotation for variable
+    a = None
     a.x() # E: None has no attribute "x"
 [out]
 
@@ -1419,7 +1406,8 @@ def f() -> None:
 [builtins fixtures/list.pyi]
 [out]
 
-[case testPartiallyInitializedToNoneAndThenToIncompleteType]
+[case testPartiallyInitializedToNoneAndThenToIncompleteType-skip]
+# TODO(ddfisher): fix partial type bug and re-enable
 from typing import TypeVar,  Dict
 T = TypeVar('T')
 def f(*x: T) -> Dict[int, T]: pass
@@ -1430,12 +1418,13 @@ if object():
 
 [case testPartiallyInitializedVariableDoesNotEscapeScope1]
 def f() -> None:
-    x = None  # E: Need type annotation for variable
+    x = None
+    reveal_type(x)  # E: Revealed type is 'builtins.None'
 x = 1
 [out]
 
 [case testPartiallyInitializedVariableDoesNotEscapeScope2]
-x = None  # E: Need type annotation for variable
+x = None
 def f() -> None:
     x = None
     x = 1
@@ -1458,8 +1447,8 @@ class A:
         self.x = 1
         self.x()
 [out]
-main:3: error: Need type annotation for variable
-main:7: error: "int" not callable
+main:6: error: Incompatible types in assignment (expression has type "int", variable has type None)
+main:7: error: None not callable
 
 [case testGlobalInitializedToNoneSetFromFunction]
 a = None
@@ -1488,7 +1477,6 @@ class A:
             pass
 [builtins fixtures/for.pyi]
 [out]
-main:3: error: Need type annotation for variable
 main:5: error: None has no attribute "__iter__"
 
 [case testPartialTypeErrorSpecialCase2]
@@ -1510,7 +1498,6 @@ class A:
             pass
 [builtins fixtures/for.pyi]
 [out]
-main:2: error: Need type annotation for variable
 main:4: error: None has no attribute "__iter__"
 
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -413,15 +413,14 @@ def id(x: T) -> T:
     return x
 [out]
 
-[case testUnderspecifiedInferenceResult]
+[case testUnderspecifiedInferenceResult-skip]
 from typing import TypeVar
 T = TypeVar('T')
 class A: pass
 a = None # type: A
 
 def ff() -> None:
-    x = f()
-    reveal_type(x)
+    x = f() # E: Need type annotation for variable
 
 g(None) # Ok
 f()     # Ok because not used to infer local variable type
@@ -830,6 +829,7 @@ for x in [A()]:
 
 for y in []:
     a = y
+    reveal_type(y)  # E: Revealed type is 'builtins.None'
 
 class A: pass
 class B: pass
@@ -874,7 +874,8 @@ for x, y in [[A()]]:
     a = y
 
 for e, f in [[]]:
-    pass
+    reveal_type(e)  # E: Revealed type is 'builtins.None'
+    reveal_type(f)  # E: Revealed type is 'builtins.None'
 
 class A: pass
 class B: pass

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -491,7 +491,7 @@ x = 1
 
 [case testAssignToFuncDefViaImport]
 from m import *  # E: Incompatible import of "x" (imported name has type "int", local name has type "str")
-f = None # E: Need type annotation for variable
+f = None
 x = ''
 [file m.py]
 def f(): pass

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -335,9 +335,9 @@ def f() -> None:
 def g(x: Optional[int]) -> int:
   pass
 
-x = f()  # E: Function does not return a value
-f() + 1  # E: Function does not return a value
-g(f())  # E: Function does not return a value
+x = f()  # E: "f" does not return a value
+f() + 1  # E: "f" does not return a value
+g(f())  # E: "f" does not return a value
 
 [case testEmptyReturn]
 def f() -> None:

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -44,7 +44,7 @@ import typing
 def f() -> None:
     return None
 def g() -> None:
-    return f()  # E: No return value expected
+    return f()
 [out]
 
 [case testReturnInGenerator]
@@ -1127,7 +1127,7 @@ def f() -> Iterator[int]:
 [case testYieldWithExplicitNone]
 from typing import Iterator
 def f() -> Iterator[None]:
-    yield None  # E: Incompatible types in yield (actual type None, expected type None)
+    yield None
 [builtins fixtures/for.pyi]
 [out]
 

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -633,13 +633,13 @@ for x in t:
 [case testForLoopOverEmptyTuple]
 import typing
 t = ()
-for x in t: pass # E: Need type annotation for variable
+for x in t: pass
 [builtins fixtures/for.pyi]
 
 [case testForLoopOverNoneValuedTuple]
 import typing
 t = ()
-for x in None, None: pass # E: Need type annotation for variable
+for x in None, None: pass
 [builtins fixtures/for.pyi]
 
 [case testForLoopOverTupleAndSubtyping]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -25,7 +25,7 @@ reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int,
 from mypy_extensions import TypedDict
 EmptyDict = TypedDict('EmptyDict', {})
 p = EmptyDict()
-reveal_type(p)  # E: Revealed type is 'TypedDict(_fallback=typing.Mapping[builtins.str, builtins.None])'
+reveal_type(p)  # E: Revealed type is 'TypedDict(_fallback=typing.Mapping[builtins.str, <uninhabited>])'
 [builtins fixtures/dict.pyi]
 
 
@@ -112,7 +112,7 @@ class EmptyDict(TypedDict):
     pass
 
 p = EmptyDict()
-reveal_type(p)  # E: Revealed type is 'TypedDict(_fallback=typing.Mapping[builtins.str, builtins.None])'
+reveal_type(p)  # E: Revealed type is 'TypedDict(_fallback=typing.Mapping[builtins.str, <uninhabited>])'
 [builtins fixtures/dict.pyi]
 
 
@@ -355,7 +355,7 @@ d2 = Cell(value='pear tree')
 joined_dicts = [d1, d2]
 reveal_type(d1)             # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
 reveal_type(d2)             # E: Revealed type is 'TypedDict(value=builtins.str, _fallback=typing.Mapping[builtins.str, builtins.str])'
-reveal_type(joined_dicts)   # E: Revealed type is 'builtins.list[TypedDict(_fallback=typing.Mapping[builtins.str, builtins.None])]'
+reveal_type(joined_dicts)   # E: Revealed type is 'builtins.list[TypedDict(_fallback=typing.Mapping[builtins.str, <uninhabited>])]'
 [builtins fixtures/dict.pyi]
 
 [case testJoinOfTypedDictWithCompatibleMappingIsMapping]

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -531,8 +531,8 @@ a, aa = G().f(*[a])  # Fail
 aa, a = G().f(*[a])  # Fail
 ab, aa = G().f(*[a]) # Fail
 
-ao, ao = G().f(*[a]) # E: Incompatible types in assignment (expression has type List[None], variable has type List[object])
-aa, aa = G().f(*[a]) # E: Incompatible types in assignment (expression has type List[None], variable has type List[A])
+ao, ao = G().f(*[a]) # E: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type List[object])
+aa, aa = G().f(*[a]) # E: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type List[A])
 
 class G(Generic[T]):
     def f(self, *a: S) -> Tuple[List[S], List[T]]:
@@ -543,9 +543,9 @@ class B: pass
 [builtins fixtures/list.pyi]
 [out]
 main:9: error: Incompatible types in assignment (expression has type List[A], variable has type "A")
-main:9: error: Incompatible types in assignment (expression has type List[None], variable has type List[A])
-main:10: error: Incompatible types in assignment (expression has type List[None], variable has type "A")
-main:11: error: Incompatible types in assignment (expression has type List[None], variable has type List[A])
+main:9: error: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type List[A])
+main:10: error: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type "A")
+main:11: error: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type List[A])
 main:11: error: Argument 1 to "f" of "G" has incompatible type *List[A]; expected "B"
 
 

--- a/test-data/unit/pythoneval-asyncio.test
+++ b/test-data/unit/pythoneval-asyncio.test
@@ -269,8 +269,7 @@ def greet() -> 'Generator[Any, None, None]':
 @asyncio.coroutine
 def test() -> 'Generator[Any, None, None]':
     yield from greet()
-    x = yield from greet()
-    reveal_type(x)
+    x = yield from greet()  # Error
 
 loop = asyncio.get_event_loop()
 try:
@@ -278,7 +277,7 @@ try:
 finally:
     loop.close()
 [out]
-_program.py:14: error: Revealed type is 'builtins.None'
+_program.py:13: error: Function does not return a value
 
 [case testErrorReturnIsNotTheSameType]
 from typing import Generator, Any

--- a/test-data/unit/pythoneval-asyncio.test
+++ b/test-data/unit/pythoneval-asyncio.test
@@ -269,7 +269,8 @@ def greet() -> 'Generator[Any, None, None]':
 @asyncio.coroutine
 def test() -> 'Generator[Any, None, None]':
     yield from greet()
-    x = yield from greet()  # Error
+    x = yield from greet()
+    reveal_type(x)
 
 loop = asyncio.get_event_loop()
 try:
@@ -277,7 +278,7 @@ try:
 finally:
     loop.close()
 [out]
-_program.py:13: error: Function does not return a value
+_program.py:14: error: Revealed type is 'builtins.None'
 
 [case testErrorReturnIsNotTheSameType]
 from typing import Generator, Any

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1097,7 +1097,7 @@ MyDDict(dict)[0]
 _program.py:6: error: Argument 1 to "defaultdict" has incompatible type List[_T]; expected Callable[[], str]
 _program.py:9: error: Invalid index type "str" for "dict"; expected type "int"
 _program.py:9: error: Incompatible types in assignment (expression has type "int", target has type "str")
-_program.py:19: error: List item 0 has incompatible type "Tuple[str, List[None]]"
+_program.py:19: error: List item 0 has incompatible type "Tuple[str, List[<uninhabited>]]"
 _program.py:23: error: Invalid index type "str" for "dict"; expected type "int"
 
 [case testNoSubcriptionOfStdlibCollections]

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -414,7 +414,7 @@ class B(A[C]):
   def g(self, c: C) -> None:
     self.f(c)
 [out]
-CallExpr(8) : void
+CallExpr(8) : builtins.None
 MemberExpr(8) : def (a: C)
 NameExpr(8) : C
 NameExpr(8) : B
@@ -430,7 +430,7 @@ class B(A[C, T], Generic[T]):
   def g(self, c: C) -> None:
     self.f(c)
 [out]
-CallExpr(9) : void
+CallExpr(9) : builtins.None
 MemberExpr(9) : def (a: C)
 NameExpr(9) : C
 NameExpr(9) : B[T`1]
@@ -446,7 +446,7 @@ b = None # type: B
 c = None # type: C
 b.f(c)
 [out]
-CallExpr(9) : void
+CallExpr(9) : builtins.None
 MemberExpr(9) : def (a: C)
 NameExpr(9) : B
 NameExpr(9) : C
@@ -597,11 +597,11 @@ class A(Generic[T]): pass
 class B: pass
 class C(B): pass
 [out]
-CallExpr(4) : void
+CallExpr(4) : builtins.None
 CallExpr(4) : A[B]
-CallExpr(5) : void
+CallExpr(5) : builtins.None
 CallExpr(5) : A[B]
-CallExpr(6) : void
+CallExpr(6) : builtins.None
 CallExpr(6) : A[B]
 
 [case testInferGenericTypeForLocalVariable]
@@ -1104,7 +1104,7 @@ m(fun,
 [out]
 IntExpr(13) : builtins.int
 ListExpr(13) : builtins.list[builtins.int]
-CallExpr(14) : void
+CallExpr(14) : builtins.None
 NameExpr(14) : def (s: builtins.int) -> builtins.int
 NameExpr(14) : def (fun: def (builtins.int) -> builtins.int, iter: builtins.list[builtins.int])
 NameExpr(15) : builtins.list[builtins.int]


### PR DESCRIPTION
After this lands, per-file strict Optional *should* be straightforward.  This should fix a lot of bugs around None.  Introduces a small bug with partial types (where mypy is overly permissive) which will be fixed in a follow up PR.