### PR TITLE
Fix subtyping for type variables whose upper bound is a union

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -49,17 +49,30 @@ def is_subtype(left: Type, right: Type,
             or isinstance(right, ErasedType)):
         return True
     elif isinstance(right, UnionType) and not isinstance(left, UnionType):
-        return any(is_subtype(left, item, type_parameter_checker,
-                              ignore_pos_arg_names=ignore_pos_arg_names)
-                   for item in right.items)
+        # Normally, when 'left' is not itself a union, the only way
+        # 'left' can be a subtype of the union 'right' is if it is a
+        # subtype of one of the items making up the union.
+        is_subtype_of_item = any(is_subtype(left, item, type_parameter_checker,
+                                            ignore_pos_arg_names=ignore_pos_arg_names)
+                                 for item in right.items)
+        # However, if 'left' is a type variable T, T might also have
+        # an upper bound which is itself a union. This case will be
+        # handled below by the SubtypeVisitor. We have to check both
+        # possibilities, to handle both cases like T <: Union[T, U]
+        # and cases like T <: B where B is the upper bound of T and is
+        # a union. (See #2314.)
+        if not isinstance(left, TypeVarType):
+            return is_subtype_of_item
+        elif is_subtype_of_item:
+            return True
+        # otherwise, fall through
     # Treat builtins.type the same as Type[Any]
     elif is_named_instance(left, 'builtins.type'):
             return is_subtype(TypeType(AnyType()), right)
     elif is_named_instance(right, 'builtins.type'):
             return is_subtype(left, TypeType(AnyType()))
-    else:
-        return left.accept(SubtypeVisitor(right, type_parameter_checker,
-                                          ignore_pos_arg_names=ignore_pos_arg_names))
+    return left.accept(SubtypeVisitor(right, type_parameter_checker,
+                                      ignore_pos_arg_names=ignore_pos_arg_names))
 
 
 def is_subtype_ignoring_tvars(left: Type, right: Type) -> bool:

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -744,3 +744,20 @@ b = a  # E: Incompatible types in assignment (expression has type G[A], variable
 b = c  # E: Incompatible types in assignment (expression has type G[C], variable has type G[B])
 [builtins fixtures/bool.pyi]
 [out]
+
+
+[case testTypeVarSubtypeUnion]
+from typing import Union, TypeVar, Generic
+
+class U: pass
+class W: pass
+
+T = TypeVar('T', bound=Union[U, W])
+
+class Y(Generic[T]):
+    def __init__(self) -> None:
+        pass
+    def f(self) -> T:
+        return U()  # E: Incompatible return value type (got "U", expected "T")
+
+[out]


### PR DESCRIPTION
Continuing #2327: just added a test and merged with current master. 