### PR TITLE
Allow importing NoReturn from typing

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -174,7 +174,7 @@ class TypeAnalyser(TypeVisitor[Type]):
                     self.fail('Invalid type: ClassVar cannot be generic', t)
                     return AnyType()
                 return item
-            elif fullname == 'mypy_extensions.NoReturn':
+            elif fullname in ('mypy_extensions.NoReturn', 'typing.NoReturn'):
                 return UninhabitedType(is_noreturn=True)
             elif sym.kind == TYPE_ALIAS:
                 override = sym.type_override

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -194,7 +194,6 @@ x = 0  # type: NoReturn  # E: Incompatible types in assignment (expression has t
 [builtins fixtures/dict.pyi]
 
 [case testNoReturnImportFromTyping]
-# flags: --warn-no-return
 from typing import NoReturn
 
 def h() -> NoReturn:
@@ -207,7 +206,7 @@ def no_return() -> NoReturn: pass
 def f() -> NoReturn:
   no_return()
 
-x = 0  # type: NoReturn  # E: Incompatible types in assignment (expression has type "int", variable has type NoReturn)
+x: NoReturn = 0 # E: Incompatible types in assignment (expression has type "int", variable has type NoReturn)
 [builtins fixtures/dict.pyi]
 
 [case testShowErrorContextFunction]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -193,6 +193,23 @@ from mypy_extensions import NoReturn
 x = 0  # type: NoReturn  # E: Incompatible types in assignment (expression has type "int", variable has type NoReturn)
 [builtins fixtures/dict.pyi]
 
+[case testNoReturnImportFromTyping]
+# flags: --warn-no-return
+from typing import NoReturn
+
+def h() -> NoReturn:
+  if bool():
+    return 5  # E: Return statement in function which does not return
+  else:
+    return  # E: Return statement in function which does not return
+
+def no_return() -> NoReturn: pass
+def f() -> NoReturn:
+  no_return()
+
+x = 0  # type: NoReturn  # E: Incompatible types in assignment (expression has type "int", variable has type NoReturn)
+[builtins fixtures/dict.pyi]
+
 [case testShowErrorContextFunction]
 # flags: --show-error-context
 def f() -> None:

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -18,6 +18,7 @@ NamedTuple = 0
 Type = 0
 no_type_check = 0
 ClassVar = 0
+NoReturn = 0
 
 # Type aliases.
 List = 0


### PR DESCRIPTION
``NoReturn`` was added to PEP 484 recently, and will be added to ``typing`` right after Python 3.6.1 release.

This PR allows to import ``NoReturn`` from ``typing`` in addition to ``mypy_extensions``.