### PR TITLE
use different stubs in test

### DIFF
--- a/mypy/moduleinfo.py
+++ b/mypy/moduleinfo.py
@@ -225,6 +225,9 @@ third_party_modules = {
     'PyQt4',
     'PyQt5',
     'pylons',
+
+    # for use in tests
+    '__dummy_third_party1',
 }
 
 # Modules and packages common to Python 2.7 and 3.x.
@@ -422,6 +425,9 @@ common_std_lib_modules = {
     'xml.sax.xmlreader',
     'zipfile',
     'zlib',
+    # fake names to use in tests
+    '__dummy_stdlib1',
+    '__dummy_stdlib2',
 }
 
 # Python 2 standard library modules.

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1295,18 +1295,18 @@ main:1: error: No library stub file for module 'nosexcover'
 main:1: note: (Stub files are from https://github.com/python/typeshed)
 
 [case testMissingStubForStdLibModule]
-import tabnanny
+import antigravity
 [out]
-main:1: error: No library stub file for standard library module 'tabnanny'
+main:1: error: No library stub file for standard library module 'antigravity'
 main:1: note: (Stub files are from https://github.com/python/typeshed)
 
 [case testMissingStubForTwoModules]
-import tabnanny
-import xdrlib
+import antigravity
+import this
 [out]
-main:1: error: No library stub file for standard library module 'tabnanny'
+main:1: error: No library stub file for standard library module 'antigravity'
 main:1: note: (Stub files are from https://github.com/python/typeshed)
-main:2: error: No library stub file for standard library module 'xdrlib'
+main:2: error: No library stub file for standard library module 'this'
 
 [case testListComprehensionSpecialScoping]
 class A:

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1289,24 +1289,24 @@ y = 1
 [out]
 
 [case testMissingStubForThirdPartyModule]
-import nosexcover
+import __dummy_third_party1
 [out]
-main:1: error: No library stub file for module 'nosexcover'
+main:1: error: No library stub file for module '__dummy_third_party1'
 main:1: note: (Stub files are from https://github.com/python/typeshed)
 
 [case testMissingStubForStdLibModule]
-import antigravity
+import __dummy_stdlib1
 [out]
-main:1: error: No library stub file for standard library module 'antigravity'
+main:1: error: No library stub file for standard library module '__dummy_stdlib1'
 main:1: note: (Stub files are from https://github.com/python/typeshed)
 
 [case testMissingStubForTwoModules]
-import antigravity
-import this
+import __dummy_stdlib1
+import __dummy_stdlib2
 [out]
-main:1: error: No library stub file for standard library module 'antigravity'
+main:1: error: No library stub file for standard library module '__dummy_stdlib1'
 main:1: note: (Stub files are from https://github.com/python/typeshed)
-main:2: error: No library stub file for standard library module 'this'
+main:2: error: No library stub file for standard library module '__dummy_stdlib2'
 
 [case testListComprehensionSpecialScoping]
 class A:


### PR DESCRIPTION
I added stubs for xdrlib in python/typeshed#1049 and have a pending PR to add stubs for tabnanny too. `this` and `antigravity` are unlikely to ever get stubs.