### PR TITLE
Avoid errors in select() calls in stdlib-samples.

### DIFF
--- a/test-data/stdlib-samples/3.2/subprocess.py
+++ b/test-data/stdlib-samples/3.2/subprocess.py
@@ -1583,7 +1583,7 @@ class Popen(object):
             input_offset = 0
             while read_set or write_set:
                 try:
-                    rlist, wlist, xlist = select.select(read_set, write_set, [])
+                    rlist, wlist, xlist = select.select(read_set, write_set, cast(List[object], []))
                 except select.error as e:
                     if e.args[0] == errno.EINTR:
                         continue

--- a/test-data/stdlib-samples/3.2/test/test_subprocess.py
+++ b/test-data/stdlib-samples/3.2/test/test_subprocess.py
@@ -1291,7 +1291,7 @@ class POSIXProcessTestCase(BaseTestCase):
         p1.stdin.write(data)
         p1.stdin.close()
 
-        readfiles, ignored1, ignored2 = select.select([p2.stdout], [], [], 10)
+        readfiles, ignored1, ignored2 = select.select([p2.stdout], cast(List[object], []), cast(List[object], []), 10)
 
         self.assertTrue(readfiles, "The child hung")
         self.assertEqual(p2.stdout.read(), data)


### PR DESCRIPTION
See https://github.com/python/typeshed/pull/1080#issuecomment-289157170