### PR TITLE
Fix #2308: Keep suppressed imports in the suppressed list

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1665,6 +1665,9 @@ def load_graph(sources: List[BuildSource], manager: BuildManager) -> Graph:
                     assert newst.id not in graph, newst.id
                     graph[newst.id] = newst
                     new.append(newst)
+            elif ignored:
+                manager.missing_modules.add(dep)
+
             if dep in st.ancestors and dep in graph:
                 graph[dep].child_modules.add(st.id)
             if dep in graph and dep in st.suppressed:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1647,7 +1647,9 @@ def load_graph(sources: List[BuildSource], manager: BuildManager) -> Graph:
             # so we ignore any suppressed module not explicitly re-included
             # from the command line.
             ignored = dep in st.suppressed and dep not in entry_points
-            if dep not in graph and not ignored:
+            if ignored:
+                manager.missing_modules.add(dep)
+            elif dep not in graph:
                 try:
                     if dep in st.ancestors:
                         # TODO: Why not 'if dep not in st.dependencies' ?
@@ -1665,9 +1667,6 @@ def load_graph(sources: List[BuildSource], manager: BuildManager) -> Graph:
                     assert newst.id not in graph, newst.id
                     graph[newst.id] = newst
                     new.append(newst)
-            elif ignored:
-                manager.missing_modules.add(dep)
-
             if dep in st.ancestors and dep in graph:
                 graph[dep].child_modules.add(st.id)
             if dep in graph and dep in st.suppressed:


### PR DESCRIPTION
The problem here was a logic discrepancy.

In one side of the code, suppressed modules need to be inside `manager.modules_missing` in order to stay suppressed. In the other side of the code, suppressed modules are never checked, meaning they are never added to that run's `modules_missing`.

There's a 99% chance this fix is mostly wrong, because the incremental code is really freaking complicated, but at least I get an A for effort, right? ;)