### PR TITLE
Allow variables inside isinstance

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -110,8 +110,7 @@ class ConditionalTypeBinder:
         return None
 
     def put(self, expr: Expression, typ: Type) -> None:
-        # TODO: replace with isinstance(expr, BindableTypes)
-        if not isinstance(expr, (IndexExpr, MemberExpr, NameExpr)):
+        if not isinstance(expr, BindableTypes):
             return
         if not expr.literal:
             return
@@ -203,8 +202,7 @@ class ConditionalTypeBinder:
                     type: Type,
                     declared_type: Type,
                     restrict_any: bool = False) -> None:
-        # TODO: replace with isinstance(expr, BindableTypes)
-        if not isinstance(expr, (IndexExpr, MemberExpr, NameExpr)):
+        if not isinstance(expr, BindableTypes):
             return None
         if not expr.literal:
             return

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2774,8 +2774,16 @@ def flatten(t: Expression) -> List[Expression]:
         return [t]
 
 
+def flatten_types(t: Type) -> List[Type]:
+    """Flatten a nested sequence of tuples into one list of nodes."""
+    if isinstance(t, TupleType):
+        return [b for a in t.items for b in flatten_types(a)]
+    else:
+        return [t]
+
+
 def get_isinstance_type(expr: Expression, type_map: Dict[Expression, Type]) -> List[TypeRange]:
-    all_types = [type_map[e] for e in flatten(expr)]
+    all_types = flatten_types(type_map[expr])
     types = []  # type: List[TypeRange]
     for type in all_types:
         if isinstance(type, FunctionLike) and type.is_type_obj():

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1412,3 +1412,19 @@ def f(x: Union[int, A], a: Type[A]) -> None:
 
 [builtins fixtures/isinstancelist.pyi]
 
+
+[case testIsinstanceVariableSubstitution]
+T = (int, str)
+U = (list, T)
+x: object = None
+
+if isinstance(x, T):
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.int, builtins.str]'
+
+if isinstance(x, U):
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.list[Any], builtins.int, builtins.str]'
+
+if isinstance(x, (set, (list, T))):
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.set[Any], builtins.list[Any], builtins.int, builtins.str]'
+
+[builtins fixtures/isinstancelist.pyi]


### PR DESCRIPTION
Fixes #3068 

This would allow the use of variables inside the second argument to `isinstance`/`issubclass`, as long as those variables are assigned a tuple of types in a "visible range".