### PR TITLE
Make it an error to use a class-attribute type var outside a type

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -406,8 +406,8 @@ def analyze_class_attribute_access(itype: Instance,
         return AnyType()
 
     if isinstance(node.node, TypeVarExpr):
-        msg.fail('Type variable "{}" is invalid except as a parameter to another type'.format(
-                 node.node.fullname() or node.node.name()), context)
+        msg.fail('Type variable "{}.{}" is invalid in a runtime context'.format(
+                 itype.type.name(), name), context)
         return AnyType()
 
     if isinstance(node.node, TypeInfo):

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -406,7 +406,7 @@ def analyze_class_attribute_access(itype: Instance,
         return AnyType()
 
     if isinstance(node.node, TypeVarExpr):
-        msg.fail('Type variable "{}.{}" is invalid in a runtime context'.format(
+        msg.fail('Type variable "{}.{}" cannot be used as an expression'.format(
                  itype.type.name(), name), context)
         return AnyType()
 

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -406,7 +406,9 @@ def analyze_class_attribute_access(itype: Instance,
         return AnyType()
 
     if isinstance(node.node, TypeVarExpr):
-        return TypeVarType(node.tvar_def, node.tvar_def.line, node.tvar_def.column)
+        msg.fail('Type variable "{}" is invalid as target for type alias'.format(
+                node.node.fullname() or node.node.name()), context)
+        return AnyType()
 
     if isinstance(node.node, TypeInfo):
         return type_object_type(node.node, builtin_type)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -406,8 +406,8 @@ def analyze_class_attribute_access(itype: Instance,
         return AnyType()
 
     if isinstance(node.node, TypeVarExpr):
-        msg.fail('Type variable "{}" is invalid as target for type alias'.format(
-                node.node.fullname() or node.node.name()), context)
+        msg.fail('Type variable "{}" is invalid except as a parameter to another type'.format(
+                 node.node.fullname() or node.node.name()), context)
         return AnyType()
 
     if isinstance(node.node, TypeInfo):

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -43,6 +43,9 @@ def analyze_type_alias(node: Expression,
     # that we don't support straight string literals as type aliases
     # (only string literals within index expressions).
     if isinstance(node, RefExpr):
+        # Note that this misses the case where someone tried to use a
+        # class-referenced type variable as a type alias.  It's easier to catch
+        # that one in checkmemeber.py
         if node.kind == UNBOUND_TVAR or node.kind == BOUND_TVAR:
             fail_func('Type variable "{}" is invalid as target for type alias'.format(
                 node.fullname), node)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -45,7 +45,7 @@ def analyze_type_alias(node: Expression,
     if isinstance(node, RefExpr):
         # Note that this misses the case where someone tried to use a
         # class-referenced type variable as a type alias.  It's easier to catch
-        # that one in checkmemeber.py
+        # that one in checkmember.py
         if node.kind == UNBOUND_TVAR or node.kind == BOUND_TVAR:
             fail_func('Type variable "{}" is invalid as target for type alias'.format(
                 node.fullname), node)

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -14,6 +14,7 @@ class A(Generic[T]):
 
 class B: pass
 class C: pass
+
 [out]
 main:4: error: Incompatible types in assignment (expression has type "B", variable has type "C")
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -14,7 +14,6 @@ class A(Generic[T]):
 
 class B: pass
 class C: pass
-
 [out]
 main:4: error: Incompatible types in assignment (expression has type "B", variable has type "C")
 

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -503,7 +503,8 @@ class C:
         L = List[C.T] # a valid type alias
         l: L = []
         l.append(x)
-        A = C.T  # E: Type variable "T" is invalid as target for type alias
+        C.T  # E: Type variable "T" is invalid except as a parameter to another type
+        A = C.T  # E: Type variable "T" is invalid except as a parameter to another type
         return l[0]
 
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -505,8 +505,8 @@ class C:
         reveal_type(l)  # E: Revealed type is 'builtins.list[T`-1]'
         y: C.T = x
         l.append(x)
-        C.T  # E: Type variable "C.T" is invalid in a runtime context
-        A = C.T  # E: Type variable "C.T" is invalid in a runtime context
+        C.T  # E: Type variable "C.T" cannot be used as an expression
+        A = C.T  # E: Type variable "C.T" cannot be used as an expression
         return l[0]
 
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -505,8 +505,8 @@ class C:
         reveal_type(l)  # E: Revealed type is 'builtins.list[T`-1]'
         y: C.T = x
         l.append(x)
-        C.T  # E: Type variable "T" is invalid except as a parameter to another type
-        A = C.T  # E: Type variable "T" is invalid except as a parameter to another type
+        C.T  # E: Type variable "C.T" is invalid in a runtime context
+        A = C.T  # E: Type variable "C.T" is invalid in a runtime context
         return l[0]
 
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -502,6 +502,8 @@ class C:
     def f(self, x: T) -> T:
         L = List[C.T] # a valid type alias
         l: L = []
+        reveal_type(l)  # E: Revealed type is 'builtins.list[T`-1]'
+        y: C.T = x
         l.append(x)
         C.T  # E: Type variable "T" is invalid except as a parameter to another type
         A = C.T  # E: Type variable "T" is invalid except as a parameter to another type

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -496,12 +496,17 @@ def outer(x: T) -> T:
 [out]
 
 [case testClassMemberTypeVarInFunctionBody]
-from typing import TypeVar
+from typing import TypeVar, List
 class C:
     T = TypeVar('T', bound=int)
     def f(self, x: T) -> T:
-        A = C.T
-        return x
+        L = List[C.T] # a valid type alias
+        l: L = []
+        l.append(x)
+        A = C.T  # E: Type variable "T" is invalid as target for type alias
+        return l[0]
+
+[builtins fixtures/list.pyi]
 
 [case testParameterLessGenericAsRestriction]
 from typing import Sequence, Iterable, TypeVar


### PR DESCRIPTION
Previously, e9d28a0 fixed a crash when you tried to access a class-attribute
type variable. The test in that commit involved assigning a variable the value
of the typevar. It resulted in no crash, but rather treating the variable as
being an instance of the type the typevar bound to, later, which is incorrect.

For example (and this is the test defined in e9d28a0, modified)

```python
 from typing import TypeVar
 class C:
     T = TypeVar('T', int)
     def f(self, x: T) -> T:
         A = C.T
         reveal_type(A)  # E: revealed type is "T`-1"
         return x
```

Instead, this PR treats such an assignment as an error -- any reference to such a classvar tvar outside trying to construct a type out of it is an error.

Also test a *correct* alias with the typevar access method in question -- it
works.