### PR TITLE
disallow generic Enums and fix assigning Enum indexes

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1016,6 +1016,8 @@ class SemanticAnalyzer(NodeVisitor):
         # the MRO. Fix MRO if needed.
         if info.mro and info.mro[-1].fullname() != 'builtins.object':
             info.mro.append(self.object_type().type)
+        if defn.info.is_enum and defn.type_vars:
+            self.fail("Enum class cannot be generic", defn)
 
     def expr_to_analyzed_type(self, expr: Expression) -> Type:
         if isinstance(expr, CallExpr):

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -61,6 +61,10 @@ def analyze_type_alias(node: Expression,
                     base.fullname in type_constructors or
                     base.kind == TYPE_ALIAS):
                 return None
+            # Enums can't be generic, and without this check we may incorrectly interpret indexing
+            # an Enum class as creating a type alias.
+            if isinstance(base.node, TypeInfo) and base.node.is_enum:
+                return None
         else:
             return None
     else:

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -150,10 +150,8 @@ main:5: error: Revealed type is '__main__.E'
 from enum import IntEnum
 class E(IntEnum):
     a = 1
-E[1]
-[out]
-main:4: error: Enum index should be a string (actual index type "int")
-
+E[1]  # E: Enum index should be a string (actual index type "int")
+x = E[1]  # E: Enum index should be a string (actual index type "int")
 
 [case testEnumIndexIsNotAnAlias]
 from enum import Enum

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -154,6 +154,36 @@ E[1]
 [out]
 main:4: error: Enum index should be a string (actual index type "int")
 
+
+[case testEnumIndexIsNotAnAlias]
+from enum import Enum
+
+class E(Enum):
+    a = 1
+    b = 2
+reveal_type(E['a'])  # E: Revealed type is '__main__.E'
+E['a']
+x = E['a']
+reveal_type(x)  # E: Revealed type is '__main__.E'
+
+def get_member(name: str) -> E:
+    val = E[name]
+    return val
+
+reveal_type(get_member('a'))  # E: Revealed type is '__main__.E'
+
+[case testGenericEnum]
+from enum import Enum
+from typing import Generic, TypeVar
+
+T = TypeVar('T')
+
+class F(Generic[T], Enum):  # E: Enum class cannot be generic
+    x: T
+    y: T
+
+reveal_type(F[int].x)  # E: Revealed type is '__main__.F[builtins.int*]'
+
 [case testEnumFlag]
 from enum import Flag
 class C(Flag):


### PR DESCRIPTION
Fixes #3137 

Under some circumstances, Enum indexing was interpreted as creating a type alias. I fixed that bug by making it so that indexing an Enum typeinfo never creates an alias. Not the most elegant solution but I'm not sure there's a better one.

In the process, I discovered that mypy allows generic enums. I don't think a generic enum makes practical sense, and inheriting from both `Enum` and `Generic[T]` fails at runtime with a metaclass conflict. Therefore, this PR also disallows generic enums.