### PR TITLE
Bump required typed_ast version to 1.0.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,5 +58,5 @@ show_missing = true
 # Then run "python3 setup.py bdist_wheel" to build a wheel file
 # (and then upload that to PyPI).
 requires-dist =
-    typed-ast >= 1.0.0, < 1.1.0
+    typed-ast >= 1.0.3, < 1.1.0
     typing >= 3.5.3; python_version < "3.5"

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ if os.name == 'nt':
 # "pip3 install git+git://github.com/python/mypy.git"
 # (as suggested by README.md).
 install_requires = []
-install_requires.append('typed-ast >= 1.0.0, < 1.1.0')
+install_requires.append('typed-ast >= 1.0.3, < 1.1.0')
 if sys.version_info < (3, 5):
     install_requires.append('typing >= 3.5.3')
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ flake8
 flake8-bugbear; python_version >= '3.5'
 flake8-pyi; python_version >= '3.5'
 lxml; sys_platform != 'win32' or python_version == '3.5' or python_version == '3.6'
-typed-ast>=1.0.0,<1.1.0; sys_platform != 'win32' or python_version >= '3.5'
+typed-ast>=1.0.3,<1.1.0; sys_platform != 'win32' or python_version >= '3.5'
 pytest>=2.8
 pytest-xdist>=1.13
 pytest-cov>=2.4.0


### PR DESCRIPTION
This includes the important uninitialized read fix (https://github.com/python/typed_ast/pull/38).