### PR TITLE
Better handling of compile-time relational operators

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1497,6 +1497,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             restricted_left_type = true_only(left_type)
             result_is_left = not left_type.can_be_false
 
+        if e.right_unreachable:
+            right_map = None
+        elif e.right_always:
+            left_map = None
+
         right_type = self.analyze_cond_branch(right_map, e.right, left_type)
 
         if right_map is None:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1440,6 +1440,10 @@ class OpExpr(Expression):
     right = None  # type: Expression
     # Inferred type for the operator method type (when relevant).
     method_type = None  # type: Optional[mypy.types.Type]
+    # Is the right side going to be evaluated every time?
+    right_always = False
+    # Is the right side unreachable?
+    right_unreachable = False
 
     def __init__(self, op: str, left: Expression, right: Expression) -> None:
         self.op = op

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -457,3 +457,63 @@ else:
 reveal_type(x)  # E: Revealed type is 'builtins.str'
 [builtins fixtures/ops.pyi]
 [out]
+
+[case testShortCircuitInExpression]
+import typing
+def make() -> bool: pass
+PY2 = PY3 = make()
+
+a = PY2 and 's'
+b = PY3 and 's'
+c = PY2 or 's'
+d = PY3 or 's'
+e = (PY2 or PY3) and 's'
+f = (PY3 or PY2) and 's'
+g = (PY2 or PY3) or 's'
+h = (PY3 or PY2) or 's'
+reveal_type(a)  # E: Revealed type is 'builtins.bool'
+reveal_type(b)  # E: Revealed type is 'builtins.str'
+reveal_type(c)  # E: Revealed type is 'builtins.str'
+reveal_type(d)  # E: Revealed type is 'builtins.bool'
+reveal_type(e)  # E: Revealed type is 'builtins.str'
+reveal_type(f)  # E: Revealed type is 'builtins.str'
+reveal_type(g)  # E: Revealed type is 'builtins.bool'
+reveal_type(h)  # E: Revealed type is 'builtins.bool'
+[builtins fixtures/ops.pyi]
+[out]
+
+[case testShortCircuitAndWithConditionalAssignment]
+# flags: --platform linux
+import sys
+
+def f(): pass
+PY2 = f()
+if PY2 and sys.platform == 'linux':
+    x = 'foo'
+else:
+    x = 3
+reveal_type(x)  # E: Revealed type is 'builtins.int'
+if sys.platform == 'linux' and PY2:
+    y = 'foo'
+else:
+    y = 3
+reveal_type(y)  # E: Revealed type is 'builtins.int'
+[builtins fixtures/ops.pyi]
+
+[case testShortCircuitOrWithConditionalAssignment]
+# flags: --platform linux
+import sys
+
+def f(): pass
+PY2 = f()
+if PY2 or sys.platform == 'linux':
+    x = 'foo'
+else:
+    x = 3
+reveal_type(x)  # E: Revealed type is 'builtins.str'
+if sys.platform == 'linux' or PY2:
+    y = 'foo'
+else:
+    y = 3
+reveal_type(y)  # E: Revealed type is 'builtins.str'
+[builtins fixtures/ops.pyi]

--- a/test-data/unit/fixtures/ops.pyi
+++ b/test-data/unit/fixtures/ops.pyi
@@ -29,6 +29,7 @@ class bool: pass
 class str:
     def __init__(self, x: 'int') -> None: pass
     def __add__(self, x: 'str') -> 'str': pass
+    def __eq__(self, x: object) -> bool: pass
     def startswith(self, x: 'str') -> bool: pass
 
 class unicode: pass


### PR DESCRIPTION
Inspired by (but doesn't fix [yet!]) #3156. (A "fix" would to be to add an early `return` to `check_boolean_op` if `e.right_unreachable` is `True`, but I'm not sure if that change would have other repercussions that I'm not aware of.)

Now stuff like this works better:

```python
if PY2 and sys.platform == 'linux':
    # ...
else:
    # ...

a = PY2 and 's'  # Type is str under Python 2, bool under Python 3.
```