### PR TITLE
[Refactoring] add AbstractNodeVisitor

### DIFF
--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -1,10 +1,6 @@
 from typing import Dict, Iterable, List, Optional, Set
-from abc import abstractmethod
 
-from mypy.visitor import NodeVisitor
 from mypy.types import TypeVisitor
-from mypy.nodes import MODULE_REF
-import mypy.nodes as nodes
 import mypy.types as types
 from mypy.util import split_module_names
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -8,8 +8,8 @@ from typing import (
 )
 
 import mypy.strconv
-from mypy.visitor import NodeVisitor, StatementVisitor, ExpressionVisitor
-from mypy.util import short_type, IdMapper
+from mypy.visitor import AbstractNodeVisitor, StatementVisitor, ExpressionVisitor
+from mypy.util import short_type
 
 
 class Context:
@@ -144,7 +144,7 @@ class Node(Context):
         # TODO this should be just 'column'
         return self.column
 
-    def accept(self, visitor: NodeVisitor[T]) -> T:
+    def accept(self, visitor: AbstractNodeVisitor[T]) -> T:
         raise RuntimeError('Not implemented')
 
 
@@ -271,7 +271,7 @@ class MypyFile(SymbolNode):
     def fullname(self) -> str:
         return self._fullname
 
-    def accept(self, visitor: NodeVisitor[T]) -> T:
+    def accept(self, visitor: AbstractNodeVisitor[T]) -> T:
         return visitor.visit_mypy_file(self)
 
     def is_package_init_file(self) -> bool:

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -7,10 +7,10 @@ from typing import Any, List, Tuple, Optional, Union, Sequence, Dict
 
 from mypy.util import short_type, IdMapper
 import mypy.nodes
-from mypy.visitor import NodeVisitor
+from mypy.visitor import AbstractNodeVisitor
 
 
-class StrConv(NodeVisitor[str]):
+class StrConv(AbstractNodeVisitor[str]):
     """Visitor for converting a node to a human-readable string.
 
     For example, an MypyFile node from program '1' is converted into
@@ -502,6 +502,9 @@ class StrConv(NodeVisitor[str]):
 
     def visit_backquote_expr(self, o: 'mypy.nodes.BackquoteExpr') -> str:
         return self.dump([o.expr], o)
+
+    def visit_temp_node(self, o: 'mypy.nodes.TempNode') -> str:
+        return self.dump([o.type], o)
 
 
 def dump_tagged(nodes: Sequence[object], tag: str, str_conv: 'StrConv') -> str:

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -1,6 +1,6 @@
 """Generic node traverser visitor"""
 
-from mypy.visitor import NodeVisitor
+from mypy.visitor import AbstractNodeVisitor
 from mypy.nodes import (
     Block, MypyFile, FuncItem, CallExpr, ClassDef, Decorator, FuncDef,
     ExpressionStmt, AssignmentStmt, OperatorAssignmentStmt, WhileStmt,
@@ -9,11 +9,16 @@ from mypy.nodes import (
     UnaryExpr, ListExpr, TupleExpr, DictExpr, SetExpr, IndexExpr,
     GeneratorExpr, ListComprehension, ConditionalExpr, TypeApplication,
     LambdaExpr, ComparisonExpr, OverloadedFuncDef, YieldFromExpr,
-    YieldExpr, StarExpr, BackquoteExpr, AwaitExpr
+    YieldExpr, StarExpr, BackquoteExpr, AwaitExpr,
+    TempNode, PromoteExpr, NewTypeExpr, TypedDictExpr, EnumCallExpr, NamedTupleExpr,
+    TypeAliasExpr, TypeVarExpr, DictionaryComprehension, SetComprehension, SuperExpr,
+    NameExpr, EllipsisExpr, ComplexExpr, FloatExpr, UnicodeExpr, BytesExpr, StrExpr,
+    IntExpr, ExecStmt, PrintStmt, PassStmt, ContinueStmt, BreakStmt, NonlocalDecl,
+    GlobalDecl, ImportAll, Var, ImportFrom, Import,
 )
 
 
-class TraverserVisitor(NodeVisitor[None]):
+class TraverserVisitor(AbstractNodeVisitor[None]):
     """A parse tree visitor that traverses the parse tree during visiting.
 
     It does not peform any actions outside the traversal. Subclasses
@@ -211,7 +216,20 @@ class TraverserVisitor(NodeVisitor[None]):
                 cond.accept(self)
         o.left_expr.accept(self)
 
+    def visit_dictionary_comprehension(self, o: DictionaryComprehension) -> None:
+        for index, sequence, conditions in zip(o.indices, o.sequences,
+                                               o.condlists):
+            sequence.accept(self)
+            index.accept(self)
+            for cond in conditions:
+                cond.accept(self)
+        o.key.accept(self)
+        o.value.accept(self)
+
     def visit_list_comprehension(self, o: ListComprehension) -> None:
+        o.generator.accept(self)
+
+    def visit_set_comprehension(self, o: SetComprehension) -> None:
         o.generator.accept(self)
 
     def visit_conditional_expr(self, o: ConditionalExpr) -> None:
@@ -233,3 +251,90 @@ class TraverserVisitor(NodeVisitor[None]):
 
     def visit_await_expr(self, o: AwaitExpr) -> None:
         o.expr.accept(self)
+
+    def visit_import(self, o: Import) -> None:
+        for a in o.assignments:
+            a.accept(self)
+
+    def visit_import_from(self, o: ImportFrom) -> None:
+        for a in o.assignments:
+            a.accept(self)
+
+    def visit_print_stmt(self, o: PrintStmt) -> None:
+        for arg in o.args:
+            arg.accept(self)
+
+    def visit_exec_stmt(self, o: ExecStmt) -> None:
+        o.expr.accept(self)
+
+    def visit_import_all(self, o: ImportAll) -> None:
+        pass
+
+    def visit_global_decl(self, o: GlobalDecl) -> None:
+        pass
+
+    def visit_nonlocal_decl(self, o: NonlocalDecl) -> None:
+        pass
+
+    def visit_var(self, o: Var) -> None:
+        pass
+
+    def visit_break_stmt(self, o: BreakStmt) -> None:
+        pass
+
+    def visit_continue_stmt(self, o: ContinueStmt) -> None:
+        pass
+
+    def visit_pass_stmt(self, o: PassStmt) -> None:
+        pass
+
+    def visit_int_expr(self, o: IntExpr) -> None:
+        pass
+
+    def visit_str_expr(self, o: StrExpr) -> None:
+        pass
+
+    def visit_bytes_expr(self, o: BytesExpr) -> None:
+        pass
+
+    def visit_unicode_expr(self, o: UnicodeExpr) -> None:
+        pass
+
+    def visit_float_expr(self, o: FloatExpr) -> None:
+        pass
+
+    def visit_complex_expr(self, o: ComplexExpr) -> None:
+        pass
+
+    def visit_ellipsis(self, o: EllipsisExpr) -> None:
+        pass
+
+    def visit_name_expr(self, o: NameExpr) -> None:
+        pass
+
+    def visit_super_expr(self, o: SuperExpr) -> None:
+        pass
+
+    def visit_type_var_expr(self, o: TypeVarExpr) -> None:
+        pass
+
+    def visit_type_alias_expr(self, o: TypeAliasExpr) -> None:
+        pass
+
+    def visit_namedtuple_expr(self, o: NamedTupleExpr) -> None:
+        pass
+
+    def visit_enum_call_expr(self, o: EnumCallExpr) -> None:
+        pass
+
+    def visit_typeddict_expr(self, o: TypedDictExpr) -> None:
+        pass
+
+    def visit_newtype_expr(self, o: NewTypeExpr) -> None:
+        pass
+
+    def visit__promote_expr(self, o: PromoteExpr) -> None:
+        pass
+
+    def visit_temp_node(self, o: TempNode) -> None:
+        pass

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -24,10 +24,10 @@ from mypy.nodes import (
 )
 from mypy.types import Type, FunctionLike
 from mypy.traverser import TraverserVisitor
-from mypy.visitor import NodeVisitor
+from mypy.visitor import AbstractNodeVisitor
 
 
-class TransformVisitor(NodeVisitor[Node]):
+class TransformVisitor(AbstractNodeVisitor[Node]):
     """Transform a semantically analyzed AST (or subtree) to an identical copy.
 
     Use the node() method to transform an AST node.

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -301,7 +301,13 @@ class StatementVisitor(Generic[T]):
         pass
 
 
-class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T]):
+class AbstractNodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T]):
+    # Not in superclasses:
+    def visit_mypy_file(self, o: 'mypy.nodes.MypyFile') -> T:
+        pass
+
+
+class NodeVisitor(Generic[T], AbstractNodeVisitor[T]):
     """Empty base class for parse tree node visitors.
 
     The T type argument specifies the return type of the visit
@@ -310,11 +316,6 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T]):
 
     TODO make the default return value explicit
     """
-
-    # Not in superclasses:
-
-    def visit_mypy_file(self, o: 'mypy.nodes.MypyFile') -> T:
-        pass
 
     # Module structure
 


### PR DESCRIPTION
I think it an abstract visitor can help keeping the visitors in pace; for some reason, TraverserVisitor does not implement `visit_set_comprehension` and `visit_dict_comprehension`.