### PR TITLE
[Refactoring] Remove Decorator.type

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -612,7 +612,6 @@ class Decorator(SymbolNode, Statement):
     func = None  # type: FuncDef                # Decorated function
     decorators = None  # type: List[Expression] # Decorators, at least one  # XXX Not true
     var = None  # type: Var                     # Represents the decorated function obj
-    type = None  # type: mypy.types.Type
     is_overload = False
 
     def __init__(self, func: FuncDef, decorators: List[Expression],

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2563,7 +2563,6 @@ class SemanticAnalyzer(NodeVisitor):
                     self.fail('Too many arguments', dec.func)
             elif refers_to_fullname(d, 'typing.no_type_check'):
                 dec.var.type = AnyType()
-                dec.type = dec.var.type
                 no_type_check = True
         for i in reversed(removed):
             del dec.decorators[i]


### PR DESCRIPTION
This field was added in #2603 ([here](https://github.com/python/mypy/commit/e674e2587710c1e11da207107eaf94d34ad4d863#diff-abd352ca9f518956b2d76e1cfc9ad35bR614)) but is not used now.