### PR TITLE
[Refactoring] Unify context

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -15,8 +15,8 @@ from mypy.util import short_type
 class Context:
     """Base type for objects that are valid as error message locations."""
 
-    line = 0
-    column = 0
+    line = -1
+    column = -1
 
     def __init__(self, line: int = -1, column: int = -1) -> None:
         self.line = line
@@ -37,10 +37,13 @@ class Context:
             self.column = column
 
     def get_line(self) -> int:
+        """Don't use. Use x.line."""
         return self.line
 
     def get_column(self) -> int:
+        """Don't use. Use x.column."""
         return self.column
+
 
 if False:
     # break import cycle only needed for mypy
@@ -134,36 +137,11 @@ Key = tuple
 class Node(Context):
     """Common base class for all non-type parse tree nodes."""
 
-    line = -1
-    column = -1
-
     def __str__(self) -> str:
         ans = self.accept(mypy.strconv.StrConv())
         if ans is None:
             return repr(self)
         return ans
-
-    def set_line(self, target: Union['Context', int], column: int = None) -> None:
-        """If target is a node, pull line (and column) information
-        into this node. If column is specified, this will override any column
-        information coming from a node.
-        """
-        if isinstance(target, int):
-            self.line = target
-        else:
-            self.line = target.line
-            self.column = target.column
-
-        if column is not None:
-            self.column = column
-
-    def get_line(self) -> int:
-        # TODO this should be just 'line'
-        return self.line
-
-    def get_column(self) -> int:
-        # TODO this should be just 'column'
-        return self.column
 
     def accept(self, visitor: NodeVisitor[T]) -> T:
         raise RuntimeError('Not implemented')

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -111,12 +111,11 @@ class TypeVarDef(mypy.nodes.Context):
     values = None  # type: List[Type]  # Value restriction, empty list if no restriction
     upper_bound = None  # type: Type
     variance = INVARIANT  # type: int
-    line = 0
-    column = 0
 
     def __init__(self, name: str, id: Union[TypeVarId, int], values: Optional[List[Type]],
                  upper_bound: Type, variance: int = INVARIANT, line: int = -1,
                  column: int = -1) -> None:
+        super().__init__(line, column)
         self.name = name
         if isinstance(id, int):
             id = TypeVarId(id)
@@ -124,20 +123,12 @@ class TypeVarDef(mypy.nodes.Context):
         self.values = values
         self.upper_bound = upper_bound
         self.variance = variance
-        self.line = line
-        self.column = column
 
     @staticmethod
     def new_unification_variable(old: 'TypeVarDef') -> 'TypeVarDef':
         new_id = TypeVarId.new(meta_level=1)
         return TypeVarDef(old.name, new_id, old.values,
                           old.upper_bound, old.variance, old.line, old.column)
-
-    def get_line(self) -> int:
-        return self.line
-
-    def get_column(self) -> int:
-        return self.column
 
     def __repr__(self) -> str:
         if self.values:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -35,20 +35,8 @@ def deserialize_type(data: Union[JsonDict, str]) -> 'Type':
 class Type(mypy.nodes.Context):
     """Abstract base class for all types."""
 
-    line = 0
-    column = 0
     can_be_true = True
     can_be_false = True
-
-    def __init__(self, line: int = -1, column: int = -1) -> None:
-        self.line = line
-        self.column = column
-
-    def get_line(self) -> int:
-        return self.line
-
-    def get_column(self) -> int:
-        return self.column
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         raise RuntimeError('Not implemented')


### PR DESCRIPTION
Unify the handling of context from `Node`, `Type` and `TypeVarDef` to Context, now as a non-abstract base class.