### PR TITLE
Document variance change in subclasses

### DIFF
--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -370,6 +370,36 @@ type variables defined with special keyword arguments ``covariant`` or
    my_box = Box(Cat())
    look_into(my_box)  # OK, but mypy would complain here for an invariant type
 
+Note that the only change permitted in the variance of the generic class type
+variable as you move down the inheritance hierarchy is from covariant or
+contravariant to invariant. For example, this is valid:
+
+.. code-block:: python
+
+    from typing import Generic, TypeVar, Tuple, Iterable
+
+    K = TypeVar('K')
+    class CovariantSet(Generic[K_co]):
+        def items(self) -> Iterable[K_co]: ...
+
+    K_co = TypeVar('K_co', covariant=True)
+    class InvariantSet(Generic[K], CovariantSet[K]):
+        def __contains__(self, key: K) -> bool: ...
+
+but this is not:
+
+.. code-block:: python
+
+    from typing import Generic, TypeVar, Tuple, Iterable
+
+    K = TypeVar('K')
+    class CovariantSet(Generic[K_co]):
+        def items(self) -> Iterable[K_co]: ...
+
+    K_contra = TypeVar('K_contra', contravariant=True)
+    class ContravariantSet(Generic[K_contra], CovariantSet[K_contra]):
+        def __contains__(self, key: K_contra) -> bool: ...
+
 .. _type-variable-value-restriction:
 
 Type variables with value restriction

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -376,29 +376,30 @@ contravariant to invariant. For example, this is valid:
 
 .. code-block:: python
 
-    from typing import Generic, TypeVar, Tuple, Iterable
-
-    K = TypeVar('K')
-    class CovariantSet(Generic[K_co]):
-        def items(self) -> Iterable[K_co]: ...
+    from typing import Generic, TypeVar
 
     K_co = TypeVar('K_co', covariant=True)
-    class InvariantSet(Generic[K], CovariantSet[K]):
-        def __contains__(self, key: K) -> bool: ...
+    class MultisetCo(Generic[K_co]):
+        def choose_random_item(self) -> K_co: ...
 
-but this is not:
+    K = TypeVar('K')
+    class Multiset(Generic[K], MultisetCo[K]):
+        def count(self, key: K) -> int: ...
+
+The following is not valid simply because ``choose_random_item`` does not
+allow contravariance:
 
 .. code-block:: python
 
-    from typing import Generic, TypeVar, Tuple, Iterable
+    from typing import Generic, TypeVar
 
-    K = TypeVar('K')
-    class CovariantSet(Generic[K_co]):
-        def items(self) -> Iterable[K_co]: ...
+    K_co = TypeVar('K_co', covariant=True)
+    class MultisetCo(Generic[K_co]):
+        def choose_random_item(self) -> K_co: ...
 
     K_contra = TypeVar('K_contra', contravariant=True)
-    class ContravariantSet(Generic[K_contra], CovariantSet[K_contra]):
-        def __contains__(self, key: K_contra) -> bool: ...
+    class MultisetContra(Generic[K_contra], MultisetCo[K_contra]):
+        def count(self, key: K) -> int: ...
 
 .. _type-variable-value-restriction:
 


### PR DESCRIPTION
The intent is to clarify that it's ok to change variance of type variables in subclasses; this is useful if someone wants to separate the interface into the parts that are covariant and contravariant in a type variable (rather than living with the overly-pessimistic invariance and/or overruling the type checker).