### PR TITLE
Update CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+cache: pip
 python:
   - "3.3"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+# cache package wheels (1 cache per python version)
 cache: pip
 python:
   - "3.3"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,31 +4,30 @@ environment:
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "32"
-      
+
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "64"
-    
+
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "32"
-      
+
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
-     
-     
+
+
 install:
     - "%PYTHON%\\python.exe -m pip install -r test-requirements.txt"
     - "git submodule update --init typeshed"
     - "%PYTHON%\\python.exe setup.py -q install"
-   
+
 build: off
 
 test_script:
-    # Ignore lint (it's run separately below)
+    # Ignore lint (it's run in Travis)
     - "%PYTHON%\\python.exe runtests.py -x lint"
-    - ps: if ($env:PYTHON_VERSION -Match "3.6.x" -And $env:PYTHON_ARCH -Match "64") { iex "$env:PYTHON\\python.exe -m flake8" }
 
 after_test:
   - "%PYTHON%\\python.exe -m pip install wheel"
@@ -37,3 +36,14 @@ after_test:
 
 artifacts:
   - path: dist\*
+
+skip_commits:
+  files:
+    - docs/**/*
+    - '**/*.rst'
+    - '**/*.md'
+    - .gitignore
+    - .runtest_log.json
+    - .travis.yml
+    - CREDITS
+    - LICENSE


### PR DESCRIPTION
- Add caching of pip packages to Travis (makes tests faster by ~15 sec x 5 builds = 75 sec)
- Skip builds in AppVeyor when only .rst/.md/docs/etc. are changed
- Remove lint from AppVeyor (it's already run in Travis)

I tried adding caching to AppVeyor but it didn't help according to my benchmarks.

Auto-skipping build is not availalbe as a feature in Travis (apart from manually adding `[skip ci]` to the commit message that no one will ever remember); if there's interest, I can add a small `before_install` script (which I found in [Facebook React](https://github.com/facebook/react/blob/8782ab759e5564785fa1d2412ad5f4b86e24c758/.travis.yml#L19L24) repo).

Note that currently the bottleneck by a long margin is AppVeyor: 1 concurrent VM, 3.5 min/build, 4 builds/commit; total ~14 min/commit. By compariosn, Travis: 5 concurrent VMs, 2.5 min/build, 5 builds/commit; total ~2.5 min/commit. So whatever we do to improve test times should mostly focus on AppVeyor for now.