### PR TITLE
Update PY3 cheat sheet with varargs example.

### DIFF
--- a/docs/source/cheat_sheet.rst
+++ b/docs/source/cheat_sheet.rst
@@ -134,7 +134,6 @@ When you're puzzled or when things are complicated
             # type: (*str, **str) -> str
             request = make_request(*args, **kwargs)
             return self.do_api_query(request)
-
    
    # Use `ignore` to suppress type-checking on a given line, when your
    # code confuses mypy or runs into an outright bug in mypy.

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -124,8 +124,7 @@ When you're puzzled or when things are complicated
 
    # This is how to deal with varargs.
    # This makes each positional arg and each keyword arg a 'str'.
-   def call(self, *args, **kwargs):
-            # type: (*str, **str) -> str
+   def call(self, *args: str, **kwargs: str) -> str:
             request = make_request(*args, **kwargs)
             return self.do_api_query(request)
 

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -122,6 +122,13 @@ When you're puzzled or when things are complicated
    # dynamic to write a type for.
    x = mystery_function()  # type: Any
 
+   # This is how to deal with varargs.
+   # This makes each positional arg and each keyword arg a 'str'.
+   def call(self, *args, **kwargs):
+            # type: (*str, **str) -> str
+            request = make_request(*args, **kwargs)
+            return self.do_api_query(request)
+
    # Use `ignore` to suppress type-checking on a given line, when your
    # code confuses mypy or runs into an outright bug in mypy.
    # Good practice is to comment every `ignore` with a bug link


### PR DESCRIPTION
Also remove an extraneous blank line from the PY2 sheet.

(This was added for PY2 in #2524 but forgotten for PY3.)