### PR TITLE
Fix incremental type check crash

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -15,6 +15,8 @@ from mypy.types import (
 )
 from mypy.visitor import NodeVisitor
 
+from mypy.semanal import rev_module_rename_map
+
 
 def fixup_module_pass_one(tree: MypyFile, modules: Dict[str, MypyFile],
                           quick_and_dirty: bool) -> None:
@@ -248,6 +250,7 @@ def lookup_qualified(modules: Dict[str, MypyFile], name: str,
 
 def lookup_qualified_stnode(modules: Dict[str, MypyFile], name: str,
                             quick_and_dirty: bool) -> Optional[SymbolTableNode]:
+    name = rev_module_rename_map.get(name, name)
     head = name
     rest = []
     while True:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -120,6 +120,8 @@ module_rename_map = {
     '_importlib_modulespec.Loader': 'importlib.abc.Loader'
 }
 
+rev_module_rename_map = {v: k for (k, v) in module_rename_map.items()}
+
 # Hard coded type promotions (shared between all Python versions).
 # These add extra ad-hoc edges to the subtyping relation. For example,
 # int is considered a subtype of float, even though there is no


### PR DESCRIPTION
Fix #3202

I can't add a test for this because this only crashes on the production version, not when run with test fixtures. But I verified on my machine and it fixed the crash.