### PR TITLE
Use inheritance to allow most TypeVisitors not to deal with "synthetic" types

### DIFF
--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -26,10 +26,8 @@ def erase_type(typ: Type) -> Type:
 
 
 class EraseTypeVisitor(TypeVisitor[Type]):
-    def visit_unbound_type(self, t: UnboundType) -> Type:
-        assert False, 'Not supported'
 
-    def visit_type_list(self, t: TypeList) -> Type:
+    def visit_unbound_type(self, t: UnboundType) -> Type:
         assert False, 'Not supported'
 
     def visit_any(self, t: AnyType) -> Type:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -63,9 +63,6 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
     def visit_unbound_type(self, t: UnboundType) -> Type:
         return t
 
-    def visit_type_list(self, t: TypeList) -> Type:
-        assert False, 'Not supported'
-
     def visit_any(self, t: AnyType) -> Type:
         return t
 

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -177,9 +177,6 @@ class TypeFixer(TypeVisitor[None]):
                     val.accept(self)
             v.upper_bound.accept(self)
 
-    def visit_ellipsis_type(self, e: EllipsisType) -> None:
-        pass  # Nothing to descend into.
-
     def visit_overloaded(self, t: Overloaded) -> None:
         for ct in t.items():
             ct.accept(self)
@@ -209,10 +206,6 @@ class TypeFixer(TypeVisitor[None]):
                 it.accept(self)
         if tdt.fallback is not None:
             tdt.fallback.accept(self)
-
-    def visit_type_list(self, tl: TypeList) -> None:
-        for t in tl.items:
-            t.accept(self)
 
     def visit_type_var(self, tvt: TypeVarType) -> None:
         if tvt.values:

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -2,7 +2,7 @@ from typing import Dict, Iterable, List, Optional, Set
 from abc import abstractmethod
 
 from mypy.visitor import NodeVisitor
-from mypy.types import TypeVisitor
+from mypy.types import SyntheticTypeVisitor
 from mypy.nodes import MODULE_REF
 import mypy.nodes as nodes
 import mypy.types as types
@@ -19,7 +19,7 @@ def extract_module_names(type_name: Optional[str]) -> List[str]:
         return []
 
 
-class TypeIndirectionVisitor(TypeVisitor[Set[str]]):
+class TypeIndirectionVisitor(SyntheticTypeVisitor[Set[str]]):
     """Returns all module references within a particular type."""
 
     def __init__(self) -> None:

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -107,9 +107,6 @@ class TypeJoinVisitor(TypeVisitor[Type]):
         else:
             return UnionType.make_simplified_union([self.s, t])
 
-    def visit_type_list(self, t: TypeList) -> Type:
-        assert False, 'Not supported'
-
     def visit_any(self, t: AnyType) -> Type:
         return t
 

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -139,9 +139,6 @@ class TypeMeetVisitor(TypeVisitor[Type]):
         else:
             return AnyType()
 
-    def visit_type_list(self, t: TypeList) -> Type:
-        assert False, 'Not supported'
-
     def visit_any(self, t: AnyType) -> Type:
         return self.s
 

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -55,9 +55,6 @@ class SameTypeVisitor(TypeVisitor[bool]):
     def visit_unbound_type(self, left: UnboundType) -> bool:
         return True
 
-    def visit_type_list(self, t: TypeList) -> bool:
-        assert False, 'Not supported'
-
     def visit_any(self, left: AnyType) -> bool:
         return isinstance(self.right, AnyType)
 

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -136,9 +136,6 @@ class IdenticalTypeVisitor(TypeVisitor[bool]):
     def visit_unbound_type(self, left: UnboundType) -> bool:
         return False
 
-    def visit_type_list(self, t: TypeList) -> bool:
-        assert False, 'Not supported'
-
     def visit_any(self, left: AnyType) -> bool:
         return isinstance(self.right, AnyType)
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -109,9 +109,6 @@ class SubtypeVisitor(TypeVisitor[bool]):
     def visit_unbound_type(self, left: UnboundType) -> bool:
         return True
 
-    def visit_type_list(self, t: TypeList) -> bool:
-        assert False, 'Not supported'
-
     def visit_any(self, left: AnyType) -> bool:
         return True
 
@@ -562,9 +559,6 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
         # doesn't matter much but by returning True we simplify these bad types away
         # from unions, which could filter out some bogus messages.
         return True
-
-    def visit_type_list(self, left: TypeList) -> bool:
-        assert False, 'Should not happen'
 
     def visit_any(self, left: AnyType) -> bool:
         return isinstance(self.right, AnyType)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -314,14 +314,6 @@ class TypeAnalyser(SyntheticTypeVisitor[Type]):
         self.fail('Invalid type', t)
         return AnyType()
 
-    def visit_star_type(self, t: StarType) -> Type:
-        self.fail('Invalid type', t)
-        return AnyType()
-
-    def visit_ellipsis_type(self, t: EllipsisType) -> Type:
-        self.fail('Invalid type', t)
-        return AnyType()
-
     def visit_instance(self, t: Instance) -> Type:
         return t
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -6,6 +6,7 @@ from typing import Callable, List, Optional, Set
 from mypy.types import (
     Type, UnboundType, TypeVarType, TupleType, TypedDictType, UnionType, Instance,
     AnyType, CallableType, NoneTyp, DeletedType, TypeList, TypeVarDef, TypeVisitor,
+    SyntheticTypeVisitor,
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType, get_typ_args, set_typ_args,
     get_type_vars, union_items
 )
@@ -89,7 +90,7 @@ def no_subscript_builtin_alias(name: str, propose_alt: bool = True) -> str:
     return msg
 
 
-class TypeAnalyser(TypeVisitor[Type]):
+class TypeAnalyser(SyntheticTypeVisitor[Type]):
     """Semantic analyzer for types (semantic analysis pass 2).
 
     Converts unbound types into bound types.
@@ -310,6 +311,14 @@ class TypeAnalyser(TypeVisitor[Type]):
         return t
 
     def visit_type_list(self, t: TypeList) -> Type:
+        self.fail('Invalid type', t)
+        return AnyType()
+
+    def visit_star_type(self, t: StarType) -> Type:
+        self.fail('Invalid type', t)
+        return AnyType()
+
+    def visit_ellipsis_type(self, t: EllipsisType) -> Type:
         self.fail('Invalid type', t)
         return AnyType()
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -238,6 +238,7 @@ class TypeList(Type):
         self.items = items
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
+        assert isinstance(visitor, SyntheticTypeVisitor)
         return visitor.visit_type_list(self)
 
     def serialize(self) -> JsonDict:
@@ -1267,10 +1268,6 @@ class SyntheticTypeVisitor(TypeVisitor[T]):
 
     @abstractmethod
     def visit_type_list(self, t: TypeList) -> T:
-        pass
-
-    @abstractmethod
-    def visit_callable_argument(self, t: CallableArgument) -> T:
         pass
 
     @abstractmethod


### PR DESCRIPTION
This is a nearly-complete fix to https://github.com/python/mypy/issues/730 -- the trick is that some types aren't real, they're synthetic AST constructs, and so we shouldn't have to deal with those in every type visitor. Only the type visitors that deal with types before the synthetic constructs are analyzed away.

I added another synthetic type in a version of https://github.com/python/mypy/pull/2607 I am about to toss up, and this refactor made me only have to add a new handler to the relevant visitors, not every visitor ever. #2607 will now depend on this PR.