### PR TITLE
Synthetic types never serialize. Kill dead code.

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -242,14 +242,7 @@ class TypeList(Type):
         return visitor.visit_type_list(self)
 
     def serialize(self) -> JsonDict:
-        return {'.class': 'TypeList',
-                'items': [t.serialize() for t in self.items],
-                }
-
-    @classmethod
-    def deserialize(cls, data: JsonDict) -> 'TypeList':
-        assert data['.class'] == 'TypeList'
-        return TypeList([deserialize_type(t) for t in data['items']])
+        assert False, "Sythetic types don't serialize"
 
 
 class AnyType(Type):
@@ -979,6 +972,9 @@ class StarType(Type):
         assert isinstance(visitor, SyntheticTypeVisitor)
         return visitor.visit_star_type(self)
 
+    def serialize(self) -> JsonDict:
+        assert False, "Sythetic types don't serialize"
+
 
 class UnionType(Type):
     """The union type Union[T1, ..., Tn] (at least one type argument)."""
@@ -1122,12 +1118,7 @@ class EllipsisType(Type):
         return visitor.visit_ellipsis_type(self)
 
     def serialize(self) -> JsonDict:
-        return {'.class': 'EllipsisType'}
-
-    @classmethod
-    def deserialize(cls, data: JsonDict) -> 'EllipsisType':
-        assert data['.class'] == 'EllipsisType'
-        return EllipsisType()
+        assert False, "Synthetic types don't serialize"
 
 
 class TypeType(Type):


### PR DESCRIPTION
And also add an `assert False` implementation to `StarType` just in case.