### PR TITLE
Don't use os.replace

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -863,11 +863,6 @@ def write_cache(id: str, path: str, tree: MypyFile,
     os.makedirs(parent, exist_ok=True)
     assert os.path.dirname(meta_json) == parent
 
-    # Construct temp file names
-    nonce = '.' + random_string()
-    data_json_tmp = data_json + nonce
-    meta_json_tmp = meta_json + nonce
-
     # Serialize data and analyze interface
     data = tree.serialize()
     if manager.options.debug_cache:
@@ -897,11 +892,10 @@ def write_cache(id: str, path: str, tree: MypyFile,
         data_mtime = os.path.getmtime(data_json)
         manager.trace("Interface for {} is unchanged".format(id))
     else:
-        with open(data_json_tmp, 'w') as f:
+        with open(data_json, 'w') as f:
             f.write(data_str)
             f.write('\n')
-        data_mtime = os.path.getmtime(data_json_tmp)
-        os.replace(data_json_tmp, data_json)
+        data_mtime = os.path.getmtime(data_json)
         manager.trace("Interface for {} has changed".format(id))
 
     mtime = st.st_mtime
@@ -922,12 +916,11 @@ def write_cache(id: str, path: str, tree: MypyFile,
             }
 
     # Write meta cache file
-    with open(meta_json_tmp, 'w') as f:
+    with open(meta_json, 'w') as f:
         if manager.options.debug_cache:
             json.dump(meta, f, indent=2, sort_keys=True)
         else:
             json.dump(meta, f)
-    os.replace(meta_json_tmp, meta_json)
 
     return interface_hash
 


### PR DESCRIPTION
Fix #3215 

For now, `os.remove` is still left in the code. Let's see if the problem is solved by just writing directly to the file instead of writing to a temp file and deleting the original. I don't recall problems with Windows-specific race conditions around `open ('filename', 'w')`; only rename and delete are affected.