### PR TITLE
Pluggable system for generating types from docstrings (revisited)

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -638,7 +638,7 @@ class BuildManager:
         Raise CompileError if there is a parse error.
         """
         num_errs = self.errors.num_messages()
-        tree = parse(source, path, id, self.errors, options=self.options)
+        tree = parse(source, path, id, self.errors, options=self.options, plugin=self.plugin)
         tree._fullname = id
         self.add_stats(files_parsed=1,
                        modules_parsed=int(not tree.is_stub),

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -2,6 +2,7 @@ from typing import List, Tuple, Set, cast, Union, Optional
 
 from mypy.errors import Errors
 from mypy.options import Options
+from mypy.plugin import Plugin
 from mypy.nodes import MypyFile
 
 
@@ -9,7 +10,8 @@ def parse(source: Union[str, bytes],
           fnam: str,
           module: Optional[str],
           errors: Optional[Errors],
-          options: Options) -> MypyFile:
+          options: Options,
+          plugin: Optional[Plugin]) -> MypyFile:
     """Parse a source file, without doing any semantic analysis.
 
     Return the parse tree. If errors is not provided, raise ParseError
@@ -24,11 +26,13 @@ def parse(source: Union[str, bytes],
                                     fnam=fnam,
                                     module=module,
                                     errors=errors,
-                                    options=options)
+                                    options=options,
+                                    plugin=plugin)
     else:
         import mypy.fastparse2
         return mypy.fastparse2.parse(source,
                                      fnam=fnam,
                                      module=module,
                                      errors=errors,
-                                     options=options)
+                                     options=options,
+                                     plugin=plugin)

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -67,6 +67,7 @@ from mypy.stubutil import is_c_module, write_header
 from mypy.options import Options as MypyOptions
 from mypy.types import Type, TypeStrVisitor, AnyType, CallableType, UnboundType, NoneTyp, TupleType
 from mypy.visitor import NodeVisitor
+from mypy.plugin import Plugin
 
 Options = NamedTuple('Options', [('pyversion', Tuple[int, int]),
                                  ('no_import', bool),
@@ -204,8 +205,9 @@ def generate_stub(path: str,
         source = f.read()
     options = MypyOptions()
     options.python_version = pyversion
+    plugin = Plugin(options)
     try:
-        ast = mypy.parse.parse(source, fnam=path, module=module, errors=None, options=options)
+        ast = mypy.parse.parse(source, fnam=path, module=module, errors=None, options=options, plugin=plugin)
     except mypy.errors.CompileError as e:
         # Syntax error!
         for m in e.messages:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -76,6 +76,7 @@ typecheck_files = [
     'check-incomplete-fixture.test',
     'check-custom-plugin.test',
     'check-default-plugin.test',
+    'check-docstring-hook.test',
 ]
 
 

--- a/mypy/test/testparse.py
+++ b/mypy/test/testparse.py
@@ -8,6 +8,7 @@ from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.parse import parse
 from mypy.errors import CompileError
 from mypy.options import Options
+from mypy.plugin import Plugin
 
 
 class ParserSuite(DataSuite):
@@ -35,7 +36,8 @@ def test_parser(testcase: DataDrivenTestCase) -> None:
                   fnam='main',
                   module='__main__',
                   errors=None,
-                  options=options)
+                  options=options,
+                  plugin=Plugin(options))
         a = str(n).split('\n')
     except CompileError as e:
         a = e.messages
@@ -59,8 +61,9 @@ class ParseErrorSuite(DataSuite):
 def test_parse_error(testcase: DataDrivenTestCase) -> None:
     try:
         # Compile temporary file. The test file contains non-ASCII characters.
+        options = Options()
         parse(bytes('\n'.join(testcase.input), 'utf-8'), INPUT_FILE_NAME, '__main__', None,
-              Options())
+              options, Plugin(options))
         raise AssertionFailure('No errors reported')
     except CompileError as e:
         assert e.module_with_blocker == '__main__'

--- a/test-data/unit/check-docstring-hook.test
+++ b/test-data/unit/check-docstring-hook.test
@@ -1,0 +1,169 @@
+[case testFunctionDocstringHook]
+# flags: --config-file tmp/mypy.ini
+def f(x):
+    """
+    x: int
+    return: str
+    """
+    return 1  # E: Incompatible return value type (got "int", expected "str")
+f('')  # E: Argument 1 to "f" has incompatible type "str"; expected "int"
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/docstring.py
+
+[case testMethodDocstringHook]
+# flags: --config-file tmp/mypy.ini
+class A:
+    def f(self, x):
+        """
+        x: int
+        return: str
+        """
+        self.f('')  # E: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+        return 1  # E: Incompatible return value type (got "int", expected "str")
+A().f('')  # E: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/docstring.py
+
+[case testSparseDocstringAnnotations]
+# flags: --config-file tmp/mypy.ini
+def f(x, y):
+    """
+    x: int
+    """
+    return 1
+f('', 1)  # E: Argument 1 to "f" has incompatible type "str"; expected "int"
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/docstring.py
+
+[case testInvalidDocstringAnnotation]
+# flags: --config-file tmp/mypy.ini
+def f(x):
+    """
+    x: B/A/D
+    return: None
+    """
+    return None
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/docstring.py
+[out]
+main:3: error: invalid type comment or annotation
+
+[case testDuplicateTypeSignaturesAnnotations]
+# flags: --config-file tmp/mypy.ini
+def f(x: int):
+    """
+    x: int
+    """
+    return None
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/docstring.py
+[out]
+main:2: error: Function has duplicate type signatures
+
+[case testDuplicateTypeSignaturesComments]
+# flags: --config-file tmp/mypy.ini
+def f(x):
+    # type: (int) -> None
+    """
+    x: int
+    """
+    return None
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/docstring.py
+[out]
+main:2: error: Function has duplicate type signatures
+
+[case testDuplicateTypeSignaturesMultiComments]
+# flags: --config-file tmp/mypy.ini
+def f(x  # type: int
+      ):
+    # type: (...) -> None
+    """
+    x: int
+    """
+    return None
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/docstring.py
+[out]
+main:2: error: Function has duplicate type signatures
+
+-- Python 2.7
+-- -------------------------
+
+[case testFunctionDocstringHook27]
+# flags: --config-file tmp/mypy.ini --python-version 2.7
+def f(x):
+    """
+    x: int
+    return: str
+    """
+    return 1  # E: Incompatible return value type (got "int", expected "str")
+f('')  # E: Argument 1 to "f" has incompatible type "str"; expected "int"
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/docstring.py
+
+[case testMethodDocstringHook27]
+# flags: --config-file tmp/mypy.ini --python-version 2.7
+class A:
+    def f(self, x):
+        """
+        x: int
+        return: str
+        """
+        self.f('')  # E: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+        return 1  # E: Incompatible return value type (got "int", expected "str")
+A().f('')  # E: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/docstring.py
+
+[case testInvalidDocstringAnnotation27]
+# flags: --config-file tmp/mypy.ini --python-version 2.7
+def f(x):
+    """
+    x: B/A/D
+    return: None
+    """
+    return None
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/docstring.py
+[out]
+main:3: error: invalid type comment or annotation
+
+[case testDuplicateTypeSignaturesComments27]
+# flags: --config-file tmp/mypy.ini --python-version 2.7
+def f(x):
+    # type: (int) -> None
+    """
+    x: int
+    """
+    return None
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/docstring.py
+[out]
+main:2: error: Function has duplicate type signatures
+
+[case testDuplicateTypeSignaturesMultiComments27]
+# flags: --config-file tmp/mypy.ini --python-version 2.7
+def f(x  # type: int
+      ):
+    # type: (...) -> None
+    """
+    x: int
+    """
+    return None
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/docstring.py
+[out]
+main:2: error: Function has duplicate type signatures

--- a/test-data/unit/plugins/docstring.py
+++ b/test-data/unit/plugins/docstring.py
@@ -1,0 +1,14 @@
+from mypy.plugin import Plugin
+from mypy.fastparse import parse_type_comment
+
+class MyPlugin(Plugin):
+    def get_docstring_parser_hook(self):
+        return my_hook
+
+def my_hook(ctx):
+    params = [l.split(':', 1) for l in ctx.docstring.strip().split('\n')]
+    return {k.strip(): parse_type_comment(v.strip(), ctx.line + i + 1, ctx.errors)
+            for i, (k, v) in enumerate(params)}
+
+def plugin(version):
+    return MyPlugin


### PR DESCRIPTION
Hi,
I'm picking up where I left off on #2240.  

Here's a bit of a review:

This PR would allow third-party tools to extend mypy with callbacks to parse PEP484 type annotations within function docstrings.  To do so, this PR introduces a basic "hook" system, as a pre-cursor to a complete plugin system (issue #1240).  

A hook can be registered, along with options specific to that hook, using the mypy configuration file:

```ini
[mypy]
fast_parser = true
hooks.docstring_parser = mypydoc.parse_docstring

[docstring_parser]
default_return_type = 'None'
```

Hook options specified in the config file are passed to the hook as a dictionary.

One big new change from where I left off with #2240 is that the `docstring_parser` hook is now passed the active `mypy.errors.Errors` instance so that it can use the full range of error reporting, especially specification of blocker and severity level.  

I have concerns about exposing the `mypy.errors.Errors` class as part of a public API so I was considering writing a simple wrapper that exposes only the bare minimum interface, perhaps something like this:

```python
class Errors:
    _errors = None  # type: errors.Errors

    def __init__(self, errors: errors.Errors):
        self._errors = errors

    def report(self, line: int, column: int, message: str, blocker: bool = False,
               severity: str = 'error', file: str = None, only_once: bool = False,
               origin_line: int = None) -> None:
        return self._errors.report(line, column, message, blocker, severity, file, only_once, origin_line)
```

What do you think?

Sorry about getting stalled out before (I blamed it on the birth of my second daughter!).  Looking forward to getting this wrapped up.

