### PR TITLE
Redirect to _importlib_modulespec in python 3 only

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -243,7 +243,9 @@ def lookup_qualified(modules: Dict[str, MypyFile], name: str,
 
 def lookup_qualified_stnode(modules: Dict[str, MypyFile], name: str,
                             quick_and_dirty: bool) -> Optional[SymbolTableNode]:
-    name = rev_module_rename_map.get(name, name)
+    if '_importlib_modulespec' in modules:
+        # we are using python 3, so renaming is necessary
+        name = rev_module_rename_map.get(name, name)
     head = name
     rest = []
     while True:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -117,13 +117,18 @@ obsolete_name_mapping = {
     'typing.typevar': 'typing.TypeVar',
 }
 
+# Used for python 3 only
 # Rename objects placed in _importlib_modulespec due to circular imports
+# Safe in python 2 because no one will ask for these keys
 module_rename_map = {
     '_importlib_modulespec.ModuleType': 'types.ModuleType',
     '_importlib_modulespec.ModuleSpec': 'importlib.machinery.ModuleSpec',
     '_importlib_modulespec.Loader': 'importlib.abc.Loader'
 }
 
+# Must not be used in python 2 (it will replace correct names with incorrect)
+# The check for version is currently made at the point of use
+# TODO: consider moving these maps from global scope to somewhere where python version is known
 rev_module_rename_map = {v: k for (k, v) in module_rename_map.items()}
 
 # Hard coded type promotions (shared between all Python versions).


### PR DESCRIPTION
Fix #3232 