### PR TITLE
Reliable version of os.replace for Windows (wait/retry loop)

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -901,7 +901,7 @@ def write_cache(id: str, path: str, tree: MypyFile,
             f.write(data_str)
             f.write('\n')
         data_mtime = os.path.getmtime(data_json_tmp)
-        os.replace(data_json_tmp, data_json)
+        util.replace(data_json_tmp, data_json)
         manager.trace("Interface for {} has changed".format(id))
 
     mtime = st.st_mtime
@@ -927,7 +927,7 @@ def write_cache(id: str, path: str, tree: MypyFile,
             json.dump(meta, f, indent=2, sort_keys=True)
         else:
             json.dump(meta, f)
-    os.replace(meta_json_tmp, meta_json)
+    util.replace(meta_json_tmp, meta_json)
 
     return interface_hash
 

--- a/mypy/test/testutil.py
+++ b/mypy/test/testutil.py
@@ -1,41 +1,78 @@
-import sys
-from typing import Type, Callable, List
+from typing import Iterator
 import time
-try:
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc  # type: ignore # PY32 and earlier
+import os
+import sys
+import tempfile
+from contextlib import contextmanager
+from threading import Thread
 from unittest import TestCase, main, skipUnless
 from mypy import util
 
 
-def create_bad_function(lag: float, exc: BaseException) -> Callable[[], None]:
-    start_time = time.perf_counter()
-
-    def f() -> None:
-        if time.perf_counter() - start_time < lag:
-            raise exc
-        else:
-            return
-    return f
+WIN32 = sys.platform.startswith("win")
 
 
-def create_funcs() -> List[Callable[[], None]]:
+@contextmanager
+def lock_file(filename: str, duration: float) -> Iterator[Thread]:
+    '''
+    Opens filename (which must exist) for reading
+    After duration sec, releases the handle
+    '''
+    def _lock_file() -> None:
+        with open(filename):
+            time.sleep(duration)
+    t = Thread(target=_lock_file, daemon=True)
+    t.start()
+    yield t
+    t.join()
 
-    def linux_function() -> None: pass
-    windows_function1 = create_bad_function(0.1, PermissionError())
-    windows_function2 = create_bad_function(0.2, FileExistsError())
-    return [windows_function1, windows_function2, linux_function]
 
+@skipUnless(WIN32, "only relevant for Windows")
+class ReliableReplace(TestCase):
+    tmpdir = tempfile.TemporaryDirectory(prefix='mypy-test-',
+                                         dir=os.path.abspath('tmp-test-dirs'))
+    src = os.path.join(tmpdir.name, 'tmp1')
+    dest = os.path.join(tmpdir.name, 'tmp2')
 
-class WaitRetryTests(TestCase):
-    def test_waitfor(self) -> None:
-        with self.assertRaises(OSError):
-            util.wait_for(create_funcs(), (PermissionError, FileExistsError), 0.1)
-        util.wait_for(create_funcs(), (PermissionError, FileExistsError), 1)
-        util.wait_for(create_funcs(), (OSError,), 1)
-        with self.assertRaises(FileExistsError):
-            util.wait_for(create_funcs(), (PermissionError,), 0.4)
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.tmpdir.cleanup()
+
+    def setUp(self) -> None:
+        # create two temporary files
+        for fname in (self.src, self.dest):
+            with open(fname, 'w') as f:
+                f.write(fname)
+
+    def replace_ok(self) -> None:
+        util._replace(self.src, self.dest, timeout=0.25)
+        self.assertEqual(open(self.dest).read(), self.src, 'replace failed')
+
+    def test_normal(self) -> None:
+        self.replace_ok()
+
+    def test_problem_exists(self) -> None:
+        with lock_file(self.src, 0.1):
+            with self.assertRaises(PermissionError):
+                os.replace(self.src, self.dest)
+
+    def test_short_lock_src(self) -> None:
+        with lock_file(self.src, 0.1):
+            self.replace_ok()
+
+    def test_short_lock_dest(self) -> None:
+        with lock_file(self.dest, 0.1):
+            self.replace_ok()
+
+    def test_long_lock_src(self) -> None:
+        with lock_file(self.src, 0.4):
+            with self.assertRaises(PermissionError):
+                self.replace_ok()
+
+    def test_long_lock_dest(self) -> None:
+        with lock_file(self.dest, 0.4):
+            with self.assertRaises(PermissionError):
+                self.replace_ok()
 
 
 if __name__ == '__main__':

--- a/mypy/test/testutil.py
+++ b/mypy/test/testutil.py
@@ -72,16 +72,22 @@ class WindowsReplace(TestCase):
         util._replace(src, dest, timeout=timeout)
         self.assertEqual(open(dest).read(), src, 'replace failed')
 
-    def test_everything(self) -> None:
+    def test_no_locks(self) -> None:
         # No files locked.
         self.replace_ok(0, 0, self.timeout)
+
+    def test_original_problem(self) -> None:
         # Make sure we can reproduce the issue with our setup.
         src, dest = self.prepare_src_dest(self.short_lock, 0)
         with self.assertRaises(PermissionError):
             os.replace(src, dest)
+
+    def test_short_locks(self) -> None:
         # Lock files for a time short enough that util.replace won't timeout.
         self.replace_ok(self.short_lock, 0, self.timeout)
         self.replace_ok(0, self.short_lock, self.timeout)
+
+    def test_long_locks(self) -> None:
         # Lock files for a time long enough that util.replace times out.
         with self.assertRaises(PermissionError):
             self.replace_ok(self.long_lock, 0, self.timeout)

--- a/mypy/test/testutil.py
+++ b/mypy/test/testutil.py
@@ -1,0 +1,42 @@
+import sys
+from typing import Type, Callable, List
+import time
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc  # type: ignore # PY32 and earlier
+from unittest import TestCase, main, skipUnless
+from mypy import util
+
+
+def create_bad_function(lag: float, exc: BaseException) -> Callable[[], None]:
+    start_time = time.perf_counter()
+
+    def f() -> None:
+        if time.perf_counter() - start_time < lag:
+            raise exc
+        else:
+            return
+    return f
+
+
+def create_funcs() -> List[Callable[[], None]]:
+
+    def linux_function() -> None: pass
+    windows_function1 = create_bad_function(0.1, PermissionError())
+    windows_function2 = create_bad_function(0.2, FileExistsError())
+    return [windows_function1, windows_function2, linux_function]
+
+
+class WaitRetryTests(TestCase):
+    def test_waitfor(self) -> None:
+        with self.assertRaises(OSError):
+            util.wait_for(create_funcs(), (PermissionError, FileExistsError), 0.1)
+        util.wait_for(create_funcs(), (PermissionError, FileExistsError), 1)
+        util.wait_for(create_funcs(), (OSError,), 1)
+        with self.assertRaises(FileExistsError):
+            util.wait_for(create_funcs(), (PermissionError,), 0.4)
+
+
+if __name__ == '__main__':
+    main()

--- a/mypy/test/testutil.py
+++ b/mypy/test/testutil.py
@@ -74,14 +74,16 @@ class WindowsReplace(TestCase):
         """
         src, dest = self.prepare_src_dest(src_lock_duration, dest_lock_duration)
         util._replace(src, dest, timeout=timeout)
-        self.assertEqual(open(dest).read(), src, 'replace failed')
+        # Note that dest handle may still be open but reading from it is ok.
+        with open(dest) as f:
+            self.assertEqual(f.read(), src, 'replace failed')
 
     def test_no_locks(self) -> None:
         # No files locked.
         self.replace_ok(0, 0, self.timeout)
 
     def test_original_problem(self) -> None:
-        # Make sure we can reproduce the issue with our setup.
+        # Make sure we can reproduce https://github.com/python/mypy/issues/3215 with our setup.
         src, dest = self.prepare_src_dest(self.short_lock, 0)
         with self.assertRaises(PermissionError):
             os.replace(src, dest)

--- a/mypy/test/testutil.py
+++ b/mypy/test/testutil.py
@@ -38,7 +38,7 @@ class ReliableReplace(TestCase):
     threads = []  # type: List[Thread]
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         for t in cls.threads:
             t.join()
 
@@ -62,19 +62,17 @@ class ReliableReplace(TestCase):
         util._replace(src, dest, timeout=timeout)
         self.assertEqual(open(dest).read(), src, 'replace failed')
 
-    def test_normal(self) -> None:
+    def test_everything(self) -> None:
+        # normal use, no locks
         self.replace_ok(0, 0, self.timeout)
-
-    def test_problem_exists(self) -> None:
+        # make sure the problem is real
         src, dest = self.prepare_src_dest(self.short_lock, 0)
         with self.assertRaises(PermissionError):
             os.replace(src, dest)
-
-    def test_short_lock(self) -> None:
+        # short lock
         self.replace_ok(self.short_lock, 0, self.timeout)
         self.replace_ok(0, self.short_lock, self.timeout)
-
-    def test_long_lock(self) -> None:
+        # long lock
         with self.assertRaises(PermissionError):
             self.replace_ok(self.long_lock, 0, self.timeout)
         with self.assertRaises(PermissionError):

--- a/mypy/test/testutil.py
+++ b/mypy/test/testutil.py
@@ -44,7 +44,11 @@ class WindowsReplace(TestCase):
 
     def prepare_src_dest(self, src_lock_duration: float, dest_lock_duration: float
                          ) -> Tuple[str, str]:
-        # Create two temporary files with random names.
+        '''Create two files in self.tmpdir random names (src, dest) and unique contents;
+        then spawn two threads that lock each of them for a specified duration.
+
+        Return a tuple (src, dest).
+        '''
         src = os.path.join(self.tmpdir.name, random_string())
         dest = os.path.join(self.tmpdir.name, random_string())
 
@@ -58,6 +62,12 @@ class WindowsReplace(TestCase):
 
     def replace_ok(self, src_lock_duration: float, dest_lock_duration: float,
                    timeout: float) -> None:
+        '''Check whether util._replace, called with a specified timeout,
+        worked successfully on two newly created files locked for specified
+        durations.
+
+        Return True if the replacement succeeded.
+        '''
         src, dest = self.prepare_src_dest(src_lock_duration, dest_lock_duration)
         util._replace(src, dest, timeout=timeout)
         self.assertEqual(open(dest).read(), src, 'replace failed')

--- a/mypy/test/testutil.py
+++ b/mypy/test/testutil.py
@@ -24,12 +24,13 @@ def lock_file(filename: str, duration: float) -> Thread:
 
 
 @skipUnless(WIN32, "only relevant for Windows")
-class ReliableReplace(TestCase):
+class WindowsReplace(TestCase):
     tmpdir = tempfile.TemporaryDirectory(prefix='mypy-test-',
                                          dir=os.path.abspath('tmp-test-dirs'))
-    timeout = 1
-    short_lock = 0.25
-    long_lock = 2
+    # Choose timeout value that would ensure actual wait inside util.replace is close to timeout
+    timeout = 0.0009 * 2 ** 10
+    short_lock = timeout / 4
+    long_lock = timeout * 2
 
     threads = []  # type: List[Thread]
 

--- a/mypy/test/testutil.py
+++ b/mypy/test/testutil.py
@@ -44,11 +44,11 @@ class WindowsReplace(TestCase):
 
     def prepare_src_dest(self, src_lock_duration: float, dest_lock_duration: float
                          ) -> Tuple[str, str]:
-        '''Create two files in self.tmpdir random names (src, dest) and unique contents;
+        """Create two files in self.tmpdir random names (src, dest) and unique contents;
         then spawn two threads that lock each of them for a specified duration.
 
         Return a tuple (src, dest).
-        '''
+        """
         src = os.path.join(self.tmpdir.name, random_string())
         dest = os.path.join(self.tmpdir.name, random_string())
 
@@ -62,12 +62,12 @@ class WindowsReplace(TestCase):
 
     def replace_ok(self, src_lock_duration: float, dest_lock_duration: float,
                    timeout: float) -> None:
-        '''Check whether util._replace, called with a specified timeout,
+        """Check whether util._replace, called with a specified timeout,
         worked successfully on two newly created files locked for specified
         durations.
 
         Return True if the replacement succeeded.
-        '''
+        """
         src, dest = self.prepare_src_dest(src_lock_duration, dest_lock_duration)
         util._replace(src, dest, timeout=timeout)
         self.assertEqual(open(dest).read(), src, 'replace failed')

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -4,9 +4,7 @@ import re
 import subprocess
 import os
 import sys
-import math
 import time
-from itertools import count
 from xml.sax.saxutils import escape
 from typing import (
     TypeVar, List, Tuple, Optional, Sequence, Dict, Callable, Iterable, Type, Union,
@@ -164,12 +162,11 @@ def _replace(src: PathType[AnyStr], dest: PathType[AnyStr], timeout: float = 1) 
     while True:
         try:
             os.replace(src, dest)
+            return
         except PermissionError:
             # The actual total wait might be up to 2x larger than timeout parameter
             if wait > timeout:
                 raise
-        else:
-            return
         time.sleep(wait)
         wait *= 2
 

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -160,26 +160,17 @@ def _replace(src: PathType[AnyStr], dest: PathType[AnyStr], timeout: float = 1) 
     Increase wait time exponentially until total wait of timeout sec;
     on timeout, give up and reraise the last exception seen.
     """
-    # Find starting value for wait.
-    wait = timeout
-    total_wait = 0  # type: float
-    while True:
-        if wait < 0.001:
-            break
-        wait /= 2
+    wait = 0.001
     while True:
         try:
             os.replace(src, dest)
         except PermissionError:
-            # Can't compare for equality because float arithmetic;
-            # if we hit 0.9999 * timeout, it's time to stop.
-            # For timeout more than a few ms, we'll be very close to the desired timeout.
-            if total_wait > 0.99 * timeout:
+            # The actual total wait might be up to 2x larger than timeout parameter
+            if wait > timeout:
                 raise
         else:
             return
         time.sleep(wait)
-        total_wait += wait
         wait *= 2
 
 

--- a/runtests.py
+++ b/runtests.py
@@ -215,6 +215,7 @@ PYTEST_FILES = [os.path.join('mypy', 'test', '{}.py'.format(name)) for name in [
     'testdiff',
     'testfinegrained',
     'testmerge',
+    'testutil',
 ]]
 
 


### PR DESCRIPTION
Fix #3215 

Copying my comment from there:

> Do we need to block until the atomic write completes? At present, the answer is that we don't need to block right away since we don't need to read from those files for a while (we can wait at least until the end of `process_stale_scc`). So we can postpone all the failed writes until some checkpoint in the future, greatly reducing the worst-case delay since we can wait for all the "stuck" files at once. However, this means that the wait/retry will be run from a faraway location in the code. This makes this approach dangerous: who knows where else `write_cache()` might be used in the future? In fact, there's already a *#*TODO item to add it to `update.build_incremental_step()`. (Note that `write_cache` saves a single module, not the entire cache.)
> 
> The cleanest solution would be (1) to refactor the `write_cache` to require a list of files to be written and wait for completion at the end of that function. This would have the best of both worlds: not wait for each file, and prevent future contributors from accidentally writing subtly buggy code that relies on writes that haven't happened yet.
> 
> An alternative is (2) to wait for each file, but if total wait time exceeds a threshold, exit and warn user that something is really wrong with access rights.
> 
> Finally, I can simply (3) wait for each file, and not worry about the case when multiple files are permanently stuck.
> 

For now I used (3), but made the `wait_for` API to support refactoring into (1) if it's desired.