### PR TITLE
Only do one run on AppVeyor instead of four.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,10 @@ environment:
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "32"
 
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
+
 
 install:
     - "git config core.symlinks true"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,21 +1,9 @@
 environment:
   matrix:
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.1"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.1"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_ARCH: "64"
 
 
 install:


### PR DESCRIPTION
I picked Python 3.6 Windows 32-bit:
- 3.6 because it's the most recent and supported
- 32-bit because the 64-bit Python installers are advertised
  for esoteric platforms (e.g. AMD-64).

Fixes #3238.