### PR TITLE
Drop Python 3.2 support.

### DIFF
--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -10,7 +10,7 @@ import typed_ast
 from typing import Dict, List, Optional, Set, Tuple
 
 from mypy import build, defaults
-from mypy.main import parse_version, process_options
+from mypy.main import process_options
 from mypy.build import BuildSource, find_module_clear_caches
 from mypy.myunit import AssertionFailure
 from mypy.test.config import test_temp_dir, test_data_prefix

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -404,9 +404,9 @@ x = 1
 [out]
 
 [case testCustomSysVersionInfo]
-# flags: --python-version 3.2
+# flags: --python-version 3.5
 import sys
-if sys.version_info == (3, 2):
+if sys.version_info == (3, 5):
     x = "foo"
 else:
     x = 3
@@ -415,9 +415,9 @@ reveal_type(x)  # E: Revealed type is 'builtins.str'
 [out]
 
 [case testCustomSysVersionInfo2]
-# flags: --python-version 3.1
+# flags: --python-version 3.5
 import sys
-if sys.version_info == (3, 2):
+if sys.version_info == (3, 6):
     x = "foo"
 else:
     x = 3

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -554,3 +554,24 @@ mypy.ini: [mypy]: python_version: Python 2.8 is not supported (must be 2.7)
 python_version = 4.0
 [out]
 mypy.ini: [mypy]: python_version: Python major version '4' out of range (must be 2 or 3)
+
+[case testPythonVersionAccepted27]
+# cmd: mypy -c pass
+[file mypy.ini]
+[[mypy]
+python_version = 2.7
+[out]
+
+[case testPythonVersionAccepted33]
+# cmd: mypy -c pass
+[file mypy.ini]
+[[mypy]
+python_version = 3.3
+[out]
+
+[case testPythonVersionAccepted36]
+# cmd: mypy -c pass
+[file mypy.ini]
+[[mypy]
+python_version = 3.6
+[out]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -514,3 +514,43 @@ whatever
 main.py:1: error: Cannot find module named 'a'
 main.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 main.py:1: error: Cannot find module named 'a.b'
+
+[case testPythonVersionTooOld10]
+# cmd: mypy -c pass
+[file mypy.ini]
+[[mypy]
+python_version = 1.0
+[out]
+mypy.ini: [mypy]: python_version: Python major version '1' out of range (must be 2 or 3)
+
+[case testPythonVersionTooOld26]
+# cmd: mypy -c pass
+[file mypy.ini]
+[[mypy]
+python_version = 2.6
+[out]
+mypy.ini: [mypy]: python_version: Python 2.6 is not supported (must be 2.7)
+
+[case testPythonVersionTooOld32]
+# cmd: mypy -c pass
+[file mypy.ini]
+[[mypy]
+python_version = 3.2
+[out]
+mypy.ini: [mypy]: python_version: Python 3.2 is not supported (must be 3.3 or higher)
+
+[case testPythonVersionTooNew28]
+# cmd: mypy -c pass
+[file mypy.ini]
+[[mypy]
+python_version = 2.8
+[out]
+mypy.ini: [mypy]: python_version: Python 2.8 is not supported (must be 2.7)
+
+[case testPythonVersionTooNew40]
+# cmd: mypy -c pass
+[file mypy.ini]
+[[mypy]
+python_version = 4.0
+[out]
+mypy.ini: [mypy]: python_version: Python major version '4' out of range (must be 2 or 3)


### PR DESCRIPTION
Tighten parsing of Python version on command line and in config file.
The only versions now supported are:
- 2.7
- 3.3 and higher 3.x versions

Closes #3231.

TBH I'm not sure this is worth it. It may be enough to declare in the docs "The only supported Python versions are 2.7, 3.3 and higher."