### PR TITLE
Allow keyword arguments in __call__

### DIFF
--- a/mypy/sharedparse.py
+++ b/mypy/sharedparse.py
@@ -87,6 +87,7 @@ MAGIC_METHODS_ALLOWING_KWARGS = {
     "__init__",
     "__init_subclass__",
     "__new__",
+    "__call__",
 }
 
 MAGIC_METHODS_POS_ARGS_ONLY = MAGIC_METHODS - MAGIC_METHODS_ALLOWING_KWARGS

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -260,35 +260,24 @@ class B: pass
 
 [case testKwargsAllowedInDunderCall]
 class Formatter:
-    def __call__(
-        self,
-        message: str,
-        bold: bool = False,
-    ) -> str:
-        if bold:
-            message = f"** {message} **"
-        return message
+    def __call__(self, message: str, bold: bool = False) -> str:
+        pass
 
 formatter = Formatter()
-print(formatter("test", bold=True))
+formatter("test", bold=True)
 reveal_type(formatter.__call__)  # E: Revealed type is 'def (message: builtins.str, bold: builtins.bool =) -> builtins.str'
+[builtins fixtures/bool.pyi]
 [out]
 
 [case testKwargsAllowedInDunderCallKwOnly]
 class Formatter:
-    def __call__(
-        self,
-        message: str,
-        *,
-        bold: bool = False,
-    ) -> str:
-        if bold:
-            message = f"** {message} **"
-        return message
+    def __call__(self, message: str, *, bold: bool = False) -> str:
+        pass
 
 formatter = Formatter()
-print(formatter("test", bold=True))
+formatter("test", bold=True)
 reveal_type(formatter.__call__)  # E: Revealed type is 'def (message: builtins.str, *, bold: builtins.bool =) -> builtins.str'
+[builtins fixtures/bool.pyi]
 [out]
 
 [case testInvalidTypeForKeywordVarArg]

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -258,6 +258,39 @@ class A: pass
 class B: pass
 [builtins fixtures/dict.pyi]
 
+[case testKwargsAllowedInDunderCall]
+class Formatter:
+    def __call__(
+        self,
+        message: str,
+        bold: bool = False,
+    ) -> str:
+        if bold:
+            message = f"** {message} **"
+        return message
+
+formatter = Formatter()
+print(formatter("test", bold=True))
+reveal_type(formatter.__call__)  # E: Revealed type is 'def (message: builtins.str, bold: builtins.bool =) -> builtins.str'
+[out]
+
+[case testKwargsAllowedInDunderCallKwOnly]
+class Formatter:
+    def __call__(
+        self,
+        message: str,
+        *,
+        bold: bool = False,
+    ) -> str:
+        if bold:
+            message = f"** {message} **"
+        return message
+
+formatter = Formatter()
+print(formatter("test", bold=True))
+reveal_type(formatter.__call__)  # E: Revealed type is 'def (message: builtins.str, *, bold: builtins.bool =) -> builtins.str'
+[out]
+
 [case testInvalidTypeForKeywordVarArg]
 from typing import Dict
 def f( **kwargs: 'A') -> None: pass


### PR DESCRIPTION
Fixes #3241 

Straightforward fix.
Tests are based on the original example.