### PR TITLE
Allow subtypes to define more overloads than their supertype

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -249,17 +249,17 @@ class SubtypeVisitor(TypeVisitor[bool]):
                     return True
             return False
         elif isinstance(right, Overloaded):
-            # Ensure each overload in the left side is accounted for.
-            sub_overloads = left.items()[:]
-            while sub_overloads:
-                left_item = sub_overloads[-1]
-                for right_item in right.items():
+            # Ensure each overload in the right side is accounted for.
+            super_overloads = right.items()[:]
+            while super_overloads:
+                right_item = super_overloads[-1]
+                for left_item in left.items():
                     if is_subtype(left_item, right_item, self.check_type_parameter,
                                   ignore_pos_arg_names=self.ignore_pos_arg_names):
-                        sub_overloads.pop()
+                        super_overloads.pop()
                         break
                 else:
-                    # One of the overloads was not present in the right side.
+                    # One of the overloads was not present in the left side.
                     return False
 
             return True

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -249,13 +249,19 @@ class SubtypeVisitor(TypeVisitor[bool]):
                     return True
             return False
         elif isinstance(right, Overloaded):
-            # TODO: this may be too restrictive
-            if len(left.items()) != len(right.items()):
-                return False
-            for i in range(len(left.items())):
-                if not is_subtype(left.items()[i], right.items()[i], self.check_type_parameter,
+            # Ensure each overload in the left side is accounted for.
+            sub_overloads = left.items()[:]
+            while sub_overloads:
+                left_item = sub_overloads[-1]
+                for right_item in right.items():
+                    if is_subtype(left_item, right_item, self.check_type_parameter,
                                   ignore_pos_arg_names=self.ignore_pos_arg_names):
+                        sub_overloads.pop()
+                        break
+                else:
+                    # One of the overloads was not present in the right side.
                     return False
+
             return True
         elif isinstance(right, UnboundType):
             return True

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1416,8 +1416,6 @@ class B(A):
     def __add__(self, x: str) -> A: pass
     @overload
     def __add__(self, x: type) -> A: pass
-[out]
-tmp/foo.pyi:8: error: Signature of "__add__" incompatible with supertype "A"
 
 [case testReverseOperatorMethodArgumentType]
 from typing import Any

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1417,6 +1417,23 @@ class B(A):
     @overload
     def __add__(self, x: type) -> A: pass
 
+[case testOverloadedOperatorMethodOverrideWithSwitchedItemOrder]
+from foo import *
+[file foo.pyi]
+from typing import overload, Any
+class A:
+    @overload
+    def __add__(self, x: 'B') -> 'B': pass
+    @overload
+    def __add__(self, x: 'A') -> 'A': pass
+class B(A):
+    @overload
+    def __add__(self, x: 'A') -> 'A': pass
+    @overload
+    def __add__(self, x: 'B') -> 'B': pass
+[out]
+tmp/foo.pyi:8: error: Signature of "__add__" incompatible with supertype "A"
+
 [case testReverseOperatorMethodArgumentType]
 from typing import Any
 class A: pass
@@ -2499,6 +2516,61 @@ class B(A):
     def f(self, y: Y) -> Y: pass
     @overload
     def f(self, z: Z) -> Z: pass
+[builtins fixtures/classmethod.pyi]
+[out]
+
+[case testSubtypeOverloadCoveringMultipleSupertypeOverloadsSucceeds]
+from foo import *
+[file foo.pyi]
+from typing import overload
+
+
+class A: pass
+class B(A): pass
+class C(A): pass
+class D: pass
+
+
+class Super:
+    @overload
+    def foo(self, a: B) -> C: pass
+    @overload
+    def foo(self, a: C) -> A: pass
+    @overload
+    def foo(self, a: D) -> D: pass
+
+class Sub(Super):
+    @overload
+    def foo(self, a: A) -> C: pass
+    @overload
+    def foo(self, a: D) -> D: pass
+[builtins fixtures/classmethod.pyi]
+[out]
+
+[case testSubtypeOverloadWithOverlappingArgumentsButWrongReturnType]
+from foo import *
+[file foo.pyi]
+from typing import overload
+
+
+class A: pass
+class B(A): pass
+class C: pass
+
+
+class Super:
+    @overload
+    def foo(self, a: A) -> A: pass
+    @overload
+    def foo(self, a: C) -> C: pass
+
+class Sub(Super):
+    @overload  # E: Signature of "foo" incompatible with supertype "Super"
+    def foo(self, a: A) -> A: pass
+    @overload
+    def foo(self, a: B) -> C: pass
+    @overload
+    def foo(self, a: C) -> C: pass
 [builtins fixtures/classmethod.pyi]
 [out]
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1419,23 +1419,6 @@ class B(A):
 [out]
 tmp/foo.pyi:8: error: Signature of "__add__" incompatible with supertype "A"
 
-[case testOverloadedOperatorMethodOverrideWithSwitchedItemOrder]
-from foo import *
-[file foo.pyi]
-from typing import overload, Any
-class A:
-    @overload
-    def __add__(self, x: 'B') -> 'B': pass
-    @overload
-    def __add__(self, x: 'A') -> 'A': pass
-class B(A):
-    @overload
-    def __add__(self, x: 'A') -> 'A': pass
-    @overload
-    def __add__(self, x: 'B') -> 'B': pass
-[out]
-tmp/foo.pyi:8: error: Signature of "__add__" incompatible with supertype "A"
-
 [case testReverseOperatorMethodArgumentType]
 from typing import Any
 class A: pass
@@ -2491,6 +2474,33 @@ reveal_type(f(A()))  # E: Revealed type is 'foo.A'
 reveal_type(f(AChild()))  # E: Revealed type is 'foo.A'
 reveal_type(f(B()))  # E: Revealed type is 'foo.B'
 reveal_type(f(BChild()))  # E: Revealed type is 'foo.B'
+[builtins fixtures/classmethod.pyi]
+[out]
+
+[case testSubtypeWithMoreOverloadsThanSupertypeSucceeds]
+from foo import *
+[file foo.pyi]
+from typing import overload
+
+
+class X: pass
+class Y: pass
+class Z: pass
+
+
+class A:
+    @overload
+    def f(self, x: X) -> X: pass
+    @overload
+    def f(self, y: Y) -> Y: pass
+
+class B(A):
+    @overload
+    def f(self, x: X) -> X: pass
+    @overload
+    def f(self, y: Y) -> Y: pass
+    @overload
+    def f(self, z: Z) -> Z: pass
 [builtins fixtures/classmethod.pyi]
 [out]
 


### PR DESCRIPTION
Fixes #3262.

I removed `testOverloadedOperatorMethodOverrideWithSwitchedItemOrder`, because the test case had been added back in 2013, long before `@overload` was banned from non-stubs. Now that it's stub-only, switching the order shouldn't really change anything anymore, since it's unaffected by the runtime.