### PR TITLE
Revert reveal_type message fix

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -15,8 +15,6 @@ from mypy.types import (
 )
 from mypy.visitor import NodeVisitor
 
-from mypy.semanal import rev_module_rename_map
-
 
 def fixup_module_pass_one(tree: MypyFile, modules: Dict[str, MypyFile],
                           quick_and_dirty: bool) -> None:
@@ -243,9 +241,6 @@ def lookup_qualified(modules: Dict[str, MypyFile], name: str,
 
 def lookup_qualified_stnode(modules: Dict[str, MypyFile], name: str,
                             quick_and_dirty: bool) -> Optional[SymbolTableNode]:
-    if '_importlib_modulespec' in modules:
-        # we are using python 3, so renaming is necessary
-        name = rev_module_rename_map.get(name, name)
     head = name
     rest = []
     while True:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -117,19 +117,12 @@ obsolete_name_mapping = {
     'typing.typevar': 'typing.TypeVar',
 }
 
-# Used for python 3 only
 # Rename objects placed in _importlib_modulespec due to circular imports
-# Safe in python 2 because no one will ask for these keys
 module_rename_map = {
     '_importlib_modulespec.ModuleType': 'types.ModuleType',
     '_importlib_modulespec.ModuleSpec': 'importlib.machinery.ModuleSpec',
     '_importlib_modulespec.Loader': 'importlib.abc.Loader'
 }
-
-# Must not be used in python 2 (it will replace correct names with incorrect)
-# The check for version is currently made at the point of use
-# TODO: consider moving these maps from global scope to somewhere where python version is known
-rev_module_rename_map = {v: k for (k, v) in module_rename_map.items()}
 
 # Hard coded type promotions (shared between all Python versions).
 # These add extra ad-hoc edges to the subtyping relation. For example,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -117,13 +117,6 @@ obsolete_name_mapping = {
     'typing.typevar': 'typing.TypeVar',
 }
 
-# Rename objects placed in _importlib_modulespec due to circular imports
-module_rename_map = {
-    '_importlib_modulespec.ModuleType': 'types.ModuleType',
-    '_importlib_modulespec.ModuleSpec': 'importlib.machinery.ModuleSpec',
-    '_importlib_modulespec.Loader': 'importlib.abc.Loader'
-}
-
 # Hard coded type promotions (shared between all Python versions).
 # These add extra ad-hoc edges to the subtyping relation. For example,
 # int is considered a subtype of float, even though there is no
@@ -3332,8 +3325,6 @@ class FirstPass(NodeVisitor):
 
         for d in defs:
             d.accept(self)
-            if isinstance(d, ClassDef):
-                d.info._fullname = module_rename_map.get(d.info._fullname, d.info._fullname)
 
         # Add implicit definition of literals/keywords to builtins, as we
         # cannot define a variable with them explicitly.


### PR DESCRIPTION
Fix #3259.

#3202, #3232, #3259 were all caused by a feature introduced in #3107 that changed `reveal_type` message from `_importlib_modulespec.ModuleType` to `types.ModuleType` etc. My attempts to fix those issues with #3205 and #3235 were no good. I revert #3205 and #3235, and the feature itself.