### PR TITLE
Add option to run tests without builtins stub fixtures

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -42,6 +42,7 @@ from mypy.parse import parse
 from mypy.stats import dump_type_stats
 from mypy.types import Type
 from mypy.version import __version__
+from mypy.defaults import allow_fixtures
 
 
 # We need to know the location of this file to load data, but
@@ -143,8 +144,9 @@ def build(sources: List[BuildSource],
         # debug).  This is a test-only feature, so assume our files are laid out
         # as in the source tree.
         root_dir = dirname(dirname(__file__))
-        lib_path.insert(0, os.path.join(root_dir, 'test-data', 'unit', 'lib-stub'))
-    else:
+        if allow_fixtures():
+            lib_path.insert(0, os.path.join(root_dir, 'test-data', 'unit', 'lib-stub'))
+    if not options.use_builtins_fixtures or not allow_fixtures():
         for source in sources:
             if source.path:
                 # Include directory of the program file in the module search path.

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -1,4 +1,9 @@
+import os
 PYTHON2_VERSION = (2, 7)
 PYTHON3_VERSION = (3, 6)
 CACHE_DIR = '.mypy_cache'
 CONFIG_FILE = 'mypy.ini'
+
+
+def allow_fixtures() -> bool:
+    return not os.environ.get('NO_BUILTINS_FIXTURES', False)

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -12,6 +12,8 @@ from typing import Callable, List, Tuple, Set, Optional, Iterator, Any
 
 from mypy.myunit import TestCase, SkipTestCaseException
 
+from mypy.defaults import allow_fixtures
+
 
 def parse_test_cases(
         path: str,
@@ -63,7 +65,8 @@ def parse_test_cases(
                     assert arg is not None
                     file_entry = (join(base_path, arg), '\n'.join(p[i].data))
                     if p[i].id == 'file':
-                        files.append(file_entry)
+                        if arg != 'builtins.py' or allow_fixtures():
+                            files.append(file_entry)
                     elif p[i].id == 'outfile':
                         output_files.append(file_entry)
                 elif p[i].id in ('builtins', 'builtins_py2'):
@@ -77,7 +80,8 @@ def parse_test_cases(
                         # Python 2
                         fnam = '__builtin__.pyi'
                     with open(mpath) as f:
-                        files.append((join(base_path, fnam), f.read()))
+                        if allow_fixtures():
+                            files.append((join(base_path, fnam), f.read()))
                 elif p[i].id == 'stale':
                     arg = p[i].arg
                     if arg is None:

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -2,16 +2,49 @@ import sys
 import re
 import os
 
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Iterable
+from itertools import groupby
 
 from mypy import defaults
 from mypy.myunit import AssertionFailure
 from mypy.test.data import DataDrivenTestCase
+from mypy.defaults import allow_fixtures
 
 
 # AssertStringArraysEqual displays special line alignment helper messages if
 # the first different line has at least this many characters,
 MIN_LINE_LENGTH_FOR_ALIGNMENT = 5
+
+
+# should match 'tmp/foo.pyi', 'main.py', etc.
+MODULE_NAME_PATTERN = r'[\w/.]'
+# we really want to be precise because accidentally matching the pattern
+# may cause failed tests to look like they pass
+# should match 'tmp/foo.pyi:15:30', 'tmp/foo.pyi:15', 'main.py:1:2', etc.
+ERROR_PATTERN = re.compile(r'^{}+:(\d+):(\d+:)? error: '.format(MODULE_NAME_PATTERN))
+
+
+class ErrorStr(str):
+    '''
+    Same as str, but compares equal iff it starts with the same file and line no prefix
+    '''
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, str):
+            return False
+        m_self = re.search(ERROR_PATTERN, self)
+        m_other = re.search(ERROR_PATTERN, other)
+        if not m_self or not m_other:  # we can't parse it, just use normal str comparison
+            return super().__eq__(other)
+        else:  # parsed successfully, compare line no (ignore filename and column no)
+            return m_self.group(1) == m_other.group(1)
+
+
+def skip_same_line_errors(iterable: Iterable) -> List:
+    '''
+    Converts all strings into ErrorStr objects, skips consecutive
+    duplicates, and returns the list (preserving original order)
+    '''
+    return [k for k, g in groupby(map(ErrorStr, iterable))]
 
 
 def assert_string_arrays_equal(expected: List[str], actual: List[str],
@@ -22,6 +55,10 @@ def assert_string_arrays_equal(expected: List[str], actual: List[str],
     """
 
     actual = clean_up(actual)
+
+    if not allow_fixtures():
+        actual = skip_same_line_errors(actual)
+        expected = skip_same_line_errors(expected)
 
     if actual != expected:
         num_skip_start = num_skipped_prefix_lines(expected, actual)

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -14,6 +14,8 @@ from mypy.defaults import allow_fixtures
 # AssertStringArraysEqual displays special line alignment helper messages if
 # the first different line has at least this many characters,
 MIN_LINE_LENGTH_FOR_ALIGNMENT = 5
+# Maximum lines of actual error output to print (to prevent hitting log size limit)
+MAX_ACTUAL_LINES = float('inf') if allow_fixtures() else 25
 
 
 # should match 'tmp/foo.pyi', 'main.py', etc.
@@ -97,6 +99,9 @@ def assert_string_arrays_equal(expected: List[str], actual: List[str],
             sys.stderr.write('  ...\n')
 
         for j in range(num_skip_start, len(actual) - num_skip_end):
+            if j - num_skip_start > MAX_ACTUAL_LINES:
+                sys.stderr.write('... (additional lines suppressed)')
+                break
             if j >= len(expected) or expected[j] != actual[j]:
                 sys.stderr.write('  {:<45} (diff)'.format(actual[j]))
             else:

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -88,6 +88,7 @@ def r(x) -> None: ...
 r = l # E: Incompatible types in assignment (expression has type Callable[[Any, Any], None], variable has type Callable[[Any], None])
 
 [case testSubtypingFunctionsImplicitNames]
+from typing import Any
 
 def f(a, b): pass
 def g(c: Any, d: Any) -> Any: pass
@@ -1567,6 +1568,7 @@ class A(Generic[t]):
 
 
 [case testRedefineFunction]
+from typing import Any
 def f(x) -> Any: pass
 def g(x, y): pass
 def h(x): pass

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -434,13 +434,13 @@ def foo() -> Union[int, str]: pass
 
 x = foo()
 x = 1
-x = x + 1
+x + 1
 x = foo()
-x = x + 1                # E: Unsupported operand types for + (likely involving Union)
+x + 1                # E: Unsupported operand types for + (likely involving Union)
 if isinstance(x, str):
-   x = x + 1             # E: Unsupported operand types for + ("str" and "int")
+   x + 1             # E: Unsupported operand types for + ("str" and "int")
    x = 1
-   x = x + 1
+   x + 1
 
 [builtins fixtures/isinstancelist.pyi]
 
@@ -463,11 +463,11 @@ from typing import Union
 x = None # type: Union[int, str]
 
 if isinstance(x, str):
-    x = x + 1   # E: Unsupported operand types for + ("str" and "int")
-    x = x + 'a'
+    x + 1   # E: Unsupported operand types for + ("str" and "int")
+    x + 'a'
 else:
-    x = x + 'a' # E: Unsupported operand types for + ("int" and "str")
-    x = x + 1
+    x + 'a' # E: Unsupported operand types for + ("int" and "str")
+    x + 1
 [builtins fixtures/isinstancelist.pyi]
 
 [case testIsInstanceIndexing]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -670,45 +670,45 @@ def f(x: str) -> None: pass
 [case testTypeCheckNamedModule]
 # cmd: mypy -m m.a
 [file m/__init__.py]
-None + 1
+object() + 1
 [file m/a.py]
 [out]
-tmp/m/__init__.py:1: error: Unsupported left operand type for + (None)
+tmp/m/__init__.py:1: error: Unsupported left operand type for + ("object")
 
 [case testTypeCheckNamedModule2]
 # cmd: mypy -m m.a
 [file m/__init__.py]
 [file m/a.py]
-None + 1
+object() + 1
 [out]
-tmp/m/a.py:1: error: Unsupported left operand type for + (None)
+tmp/m/a.py:1: error: Unsupported left operand type for + ("object")
 
 [case testTypeCheckNamedModule3]
 # cmd: mypy -m m
 [file m/__init__.py]
-None + 1
+object() + 1
 [file m/a.py]
 [out]
-tmp/m/__init__.py:1: error: Unsupported left operand type for + (None)
+tmp/m/__init__.py:1: error: Unsupported left operand type for + ("object")
 
 [case testTypeCheckNamedModule4]
 # cmd: mypy -m m
 [file m/__init__.py]
 [file m/a.py]
-None + 1  # Not analyzed.
+object() + 1  # Not analyzed.
 [out]
 
 [case testTypeCheckNamedModule5]
 # cmd: mypy -m m
-None + ''  # Not analyzed.
+object() + 1  # Not analyzed.
 [file m.py]
-None + 1
+object() + 1
 [out]
-tmp/m.py:1: error: Unsupported left operand type for + (None)
+tmp/m.py:1: error: Unsupported left operand type for + ("object")
 
 [case testTypeCheckNamedModuleWithImportCycle]
 # cmd: mypy -m m.a
-None + 1  # Does not generate error, as this file won't be analyzed.
+object() + 1  # Does not generate error, as this file won't be analyzed.
 [file m/__init__.py]
 import m.a
 [file m/a.py]

--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -35,7 +35,9 @@ d['ab'] = 'ab'  # E: Invalid index type "str" for Dict[int, str]; expected type 
 
 [case testNewSyntaxWithRevealType]
 # flags: --python-version 3.6
-from typing import Dict
+from typing import Dict, TypeVar
+
+T = TypeVar('T')
 
 def tst_local(dct: Dict[int, T]) -> Dict[T, int]:
     ret: Dict[T, int] = {}

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -84,9 +84,9 @@ main:6: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" 
 import typing
 MYPY = 0
 if MYPY:
-    None + 1 # E: Unsupported left operand type for + (None)
+    object() + 1 # E: Unsupported left operand type for + ("object")
 else:
-    None + ''
+    object() + 1
 [builtins fixtures/bool.pyi]
 
 [case testTypeCheckingConditional]


### PR DESCRIPTION
This PR is a cleaned up and rebased version of #3189. 

**If the environment does not contain env. var. `NO_BUILTINS_FIXTURES`, this PR does nothing at all.**

If env. var. `NO_BUILTINS_FIXTURES` is defined, this PR affects the tests as follows:

- Builtins stub fixtures are disabled; that is, all tests are run using the normal builtins stub.
- When comparing error output, only line numbers matter, not the contents; if the expected and actual output have identical line numbers, the test passes (note: multiple errors in the same line are treated as one). This is to help reduce the effort of analyzing failing tests, since minor changes in message wording is not the highest priority.
- When a test fails, the actual output printed to stderr is limited to 25 lines per test. This is to avoid killing the terminal window when a few dozen tests fail with hundreds of lines actual output each.
- `mergetest.py` skips not only `builtins` module but all modules other than `__main__` and `target`. This is to make existing expected output work in the no-builtins-fixtures environment.

I chose the environment variable instead of a command-line option for `runttests` because this feature impacts code in locations where it's somewhat troublesome to obtain the command line options.

Right now, a few tests have no hope of working without builtins fixtures. To exclude them, use this command line:
```
NO_BUILTINS_FIXTURES=1 python runtests.py -x lint -x "unit-test mypy.test.testtypegen" -x "unit-test mypy.test.testtransform" -x "unit-test mypy.test.testsemanal" -p -k -p "not mypy/test/testfinegrained.py"
```

This run would take 5-6 min, and would produce 10 errors (all from pytest) on the current master. Over time, we can gradually fix the failing tests or mark them with "xfail", but this can be done separately from this PR.