### PR TITLE
Fix crash due to deserialization of TypedDict type objects

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -64,6 +64,8 @@ class NodeFixer(NodeVisitor[None]):
                 info._promote.accept(self.type_fixer)
             if info.tuple_type:
                 info.tuple_type.accept(self.type_fixer)
+            if info.typeddict_type:
+                info.typeddict_type.accept(self.type_fixer)
         finally:
             self.current_info = save_info
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1907,6 +1907,23 @@ a.A().x = 0
 [out2]
 tmp/b.py:2: error: Cannot assign to class variable "x" via instance
 
+[case testSerializeTypedDict]
+import b
+reveal_type(b.x)
+y: b.A
+reveal_type(y)
+[file b.py]
+from mypy_extensions import TypedDict
+A = TypedDict('A', {'x': int, 'y': str})
+x: A
+[builtins fixtures/dict.pyi]
+[out1]
+main:2: error: Revealed type is 'TypedDict(x=builtins.int, y=builtins.str, _fallback=b.A)'
+main:4: error: Revealed type is 'TypedDict(x=builtins.int, y=builtins.str, _fallback=b.A)'
+[out2]
+main:2: error: Revealed type is 'TypedDict(x=builtins.int, y=builtins.str, _fallback=b.A)'
+main:4: error: Revealed type is 'TypedDict(x=builtins.int, y=builtins.str, _fallback=b.A)'
+
 [case testQuickAndDirty1]
 # flags: --quick-and-dirty
 import b, c


### PR DESCRIPTION
A TypeInfo attribute was not handled during fixup, causing a crash when
using a TypedDict type imported from a deserialized module in an
annotation (when using `-i`).

Fixes #3272.