### PR TITLE
Make .flake8 not a symlink.

### DIFF
--- a/test-data/.flake8
+++ b/test-data/.flake8
@@ -1,1 +1,22 @@
-../typeshed/.flake8
+# Some PEP8 deviations are considered irrelevant to stub files:
+# (error counts as of 2016-12-19)
+# 17381 E704 multiple statements on one line (def)
+# 11840 E301 expected 1 blank line
+#  7467 E302 expected 2 blank lines
+#  1772 E501 line too long
+#  1487 F401 imported but unused
+#  1248 E701 multiple statements on one line (colon)
+#   427 F811 redefinition
+#   356 E305 expected 2 blank lines
+
+# Nice-to-haves ignored for now
+#   152 E128 continuation line under-indented for visual indent
+#    43 E127 continuation line over-indented for visual indent
+
+[flake8]
+ignore = F401, F811, E127, E128, E301, E302, E305, E501, E701, E704, B303
+# We are checking with Python 3 but many of the stubs are Python 2 stubs.
+# A nice future improvement would be to provide separate .flake8
+# configurations for Python 2 and Python 3 files.
+builtins = StandardError,apply,basestring,buffer,cmp,coerce,execfile,file,intern,long,raw_input,reduce,reload,unichr,unicode,xrange
+exclude = .venv*,@*


### PR DESCRIPTION
This is so there are no symlinks in the mypy repo itself.
However there are some in the typeshed repo.

See https://github.com/python/mypy/issues/3222