### PR TITLE
Add missing methods to TraveserVisitor and SubexpressionFinder

### DIFF
--- a/mypy/server/subexpr.py
+++ b/mypy/server/subexpr.py
@@ -5,8 +5,8 @@ from typing import List
 from mypy.nodes import (
     Expression, Node, MemberExpr, YieldFromExpr, YieldExpr, CallExpr, OpExpr, ComparisonExpr,
     SliceExpr, CastExpr, RevealTypeExpr, UnaryExpr, ListExpr, TupleExpr, DictExpr, SetExpr,
-    IndexExpr, GeneratorExpr, ListComprehension, ConditionalExpr, TypeApplication, LambdaExpr,
-    StarExpr, BackquoteExpr, AwaitExpr
+    IndexExpr, GeneratorExpr, ListComprehension, SetComprehension, DictionaryComprehension,
+    ConditionalExpr, TypeApplication, LambdaExpr, StarExpr, BackquoteExpr, AwaitExpr,
 )
 from mypy.traverser import TraverserVisitor
 
@@ -104,9 +104,17 @@ class SubexpressionFinder(TraverserVisitor):
         self.add(e)
         super().visit_generator_expr(e)
 
+    def visit_dictionary_comprehension(self, e: DictionaryComprehension) -> None:
+        self.add(e)
+        super().visit_dictionary_comprehension(e)
+
     def visit_list_comprehension(self, e: ListComprehension) -> None:
         self.add(e)
         super().visit_list_comprehension(e)
+
+    def visit_set_comprehension(self, e: SetComprehension) -> None:
+        self.add(e)
+        super().visit_set_comprehension(e)
 
     def visit_conditional_expr(self, e: ConditionalExpr) -> None:
         self.add(e)

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -505,6 +505,9 @@ class StrConv(NodeVisitor[str]):
     def visit_backquote_expr(self, o: 'mypy.nodes.BackquoteExpr') -> str:
         return self.dump([o.expr], o)
 
+    def visit_temp_node(self, o: 'mypy.nodes.TempNode') -> str:
+        return self.dump([o.type], o)
+
 
 def dump_tagged(nodes: Sequence[object], tag: Optional[str], str_conv: 'StrConv') -> str:
     """Convert an array into a pretty-printed multiline string representation.

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -7,9 +7,10 @@ from mypy.nodes import (
     ForStmt, ReturnStmt, AssertStmt, DelStmt, IfStmt, RaiseStmt,
     TryStmt, WithStmt, MemberExpr, OpExpr, SliceExpr, CastExpr, RevealTypeExpr,
     UnaryExpr, ListExpr, TupleExpr, DictExpr, SetExpr, IndexExpr,
-    GeneratorExpr, ListComprehension, ConditionalExpr, TypeApplication,
+    GeneratorExpr, ListComprehension, SetComprehension, DictionaryComprehension,
+    ConditionalExpr, TypeApplication, ExecStmt, Import, ImportFrom,
     LambdaExpr, ComparisonExpr, OverloadedFuncDef, YieldFromExpr,
-    YieldExpr, StarExpr, BackquoteExpr, AwaitExpr
+    YieldExpr, StarExpr, BackquoteExpr, AwaitExpr, PrintStmt,
 )
 
 
@@ -211,7 +212,20 @@ class TraverserVisitor(NodeVisitor[None]):
                 cond.accept(self)
         o.left_expr.accept(self)
 
+    def visit_dictionary_comprehension(self, o: DictionaryComprehension) -> None:
+        for index, sequence, conditions in zip(o.indices, o.sequences,
+                                               o.condlists):
+            sequence.accept(self)
+            index.accept(self)
+            for cond in conditions:
+                cond.accept(self)
+        o.key.accept(self)
+        o.value.accept(self)
+
     def visit_list_comprehension(self, o: ListComprehension) -> None:
+        o.generator.accept(self)
+
+    def visit_set_comprehension(self, o: SetComprehension) -> None:
         o.generator.accept(self)
 
     def visit_conditional_expr(self, o: ConditionalExpr) -> None:
@@ -232,4 +246,19 @@ class TraverserVisitor(NodeVisitor[None]):
         o.expr.accept(self)
 
     def visit_await_expr(self, o: AwaitExpr) -> None:
+        o.expr.accept(self)
+
+    def visit_import(self, o: Import) -> None:
+        for a in o.assignments:
+            a.accept(self)
+
+    def visit_import_from(self, o: ImportFrom) -> None:
+        for a in o.assignments:
+            a.accept(self)
+
+    def visit_print_stmt(self, o: PrintStmt) -> None:
+        for arg in o.args:
+            arg.accept(self)
+
+    def visit_exec_stmt(self, o: ExecStmt) -> None:
         o.expr.accept(self)


### PR DESCRIPTION
Branched out of #3164 