### PR TITLE
[clean strict optional] Fix more strict optional errors

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -180,6 +180,8 @@ class TypeChecker(NodeVisitor[None]):
 
         all_ = self.globals.get('__all__')
         if all_ is not None and all_.type is not None:
+            all_node = all_.node
+            assert all_node is not None
             seq_str = self.named_generic_type('typing.Sequence',
                                               [self.named_type('builtins.str')])
             if self.options.python_version[0] < 3:
@@ -188,7 +190,7 @@ class TypeChecker(NodeVisitor[None]):
             if not is_subtype(all_.type, seq_str):
                 str_seq_s, all_s = self.msg.format_distinctly(seq_str, all_.type)
                 self.fail(messages.ALL_MUST_BE_SEQ_STR.format(str_seq_s, all_s),
-                          all_.node)
+                          all_node)
 
     def check_second_pass(self, todo: List[DeferredNode] = None) -> bool:
         """Run second or following pass of type checking.
@@ -346,12 +348,13 @@ class TypeChecker(NodeVisitor[None]):
                     self.msg.overloaded_signatures_arg_specific(i + 1, defn.impl)
                 impl_type_subst = impl_type
                 if impl_type.variables:
-                    impl_type_subst = unify_generic_callable(impl_type, sig1, ignore_return=False)
-                    if impl_type_subst is None:
+                    unified = unify_generic_callable(impl_type, sig1, ignore_return=False)
+                    if unified is None:
                         self.fail("Type variable mismatch between " +
                                   "overload signature {} and implementation".format(i + 1),
                                   defn.impl)
                         return
+                    impl_type_subst = unified
                 if not is_subtype(sig1.ret_type, impl_type_subst.ret_type):
                     self.msg.overloaded_signatures_ret_specific(i + 1, defn.impl)
 
@@ -593,7 +596,7 @@ class TypeChecker(NodeVisitor[None]):
                             not isinstance(typ.ret_type, NoneTyp) and
                             not self.dynamic_funcs[-1]):
                         self.fail(messages.MUST_HAVE_NONE_RETURN_TYPE.format(fdef.name()),
-                                  item.type)
+                                  item)
 
                     show_untyped = not self.is_typeshed_stub or self.options.warn_incomplete_stub
                     if self.options.disallow_untyped_defs and show_untyped:
@@ -1257,7 +1260,7 @@ class TypeChecker(NodeVisitor[None]):
                 self.infer_variable_type(inferred, lvalue, self.expr_checker.accept(rvalue),
                                          rvalue)
 
-    def check_compatibility_all_supers(self, lvalue: NameExpr, lvalue_type: Type,
+    def check_compatibility_all_supers(self, lvalue: NameExpr, lvalue_type: Optional[Type],
                                        rvalue: Expression) -> bool:
         lvalue_node = lvalue.node
 
@@ -1300,8 +1303,9 @@ class TypeChecker(NodeVisitor[None]):
                     break
         return False
 
-    def check_compatibility_super(self, lvalue: NameExpr, lvalue_type: Type, rvalue: Expression,
-                                  base: TypeInfo, base_type: Type, base_node: Node) -> bool:
+    def check_compatibility_super(self, lvalue: NameExpr, lvalue_type: Optional[Type],
+                                  rvalue: Expression, base: TypeInfo, base_type: Type,
+                                  base_node: Node) -> bool:
         lvalue_node = lvalue.node
         assert isinstance(lvalue_node, Var)
 
@@ -1574,10 +1578,12 @@ class TypeChecker(NodeVisitor[None]):
         else:
             self.msg.type_not_iterable(rvalue_type, context)
 
-    def check_lvalue(self, lvalue: Lvalue) -> Tuple[Type, IndexExpr, Var]:
-        lvalue_type = None  # type: Type
-        index_lvalue = None  # type: IndexExpr
-        inferred = None  # type: Var
+    def check_lvalue(self, lvalue: Lvalue) -> Tuple[Optional[Type],
+                                                    Optional[IndexExpr],
+                                                    Optional[Var]]:
+        lvalue_type = None  # type: Optional[Type]
+        index_lvalue = None  # type: Optional[IndexExpr]
+        inferred = None  # type: Optional[Var]
 
         if self.is_definition(lvalue):
             if isinstance(lvalue, NameExpr):
@@ -2750,8 +2756,8 @@ def find_isinstance_check(node: Expression,
         # Check for `x is None` and `x is not None`.
         is_not = node.operators == ['is not']
         if any(is_literal_none(n) for n in node.operands) and (is_not or node.operators == ['is']):
-            if_vars = {}  # type: Dict[Expression, Type]
-            else_vars = {}  # type: Dict[Expression, Type]
+            if_vars = {}  # type: TypeMap
+            else_vars = {}  # type: TypeMap
             for expr in node.operands:
                 if expr.literal == LITERAL_TYPE and not is_literal_none(expr) and expr in type_map:
                     # This should only be true at most once: there should be
@@ -2829,7 +2835,8 @@ def flatten_types(t: Type) -> List[Type]:
         return [t]
 
 
-def get_isinstance_type(expr: Expression, type_map: Dict[Expression, Type]) -> List[TypeRange]:
+def get_isinstance_type(expr: Expression,
+                        type_map: Dict[Expression, Type]) -> Optional[List[TypeRange]]:
     all_types = flatten_types(type_map[expr])
     types = []  # type: List[TypeRange]
     for typ in all_types:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -123,7 +123,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return self.narrow_type_from_binder(e, result)
 
     def analyze_ref_expr(self, e: RefExpr, lvalue: bool = False) -> Type:
-        result = None  # type: Type
+        result = None  # type: Optional[Type]
         node = e.node
         if isinstance(node, Var):
             # Variable reference.
@@ -157,6 +157,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             # Unknown reference; use any type implicitly to avoid
             # generating extra type errors.
             result = AnyType()
+        assert result is not None
         return result
 
     def analyze_var_ref(self, var: Var, context: Context) -> Type:
@@ -468,7 +469,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             # i.e. its constructor (a poor approximation for reality,
             # but better than AnyType...), but replace the return type
             # with typevar.
-            callee = self.analyze_type_type_callee(item.upper_bound, context)
+            callee = self.analyze_type_type_callee(item.upper_bound,
+                                                   context)  # type: Optional[Type]
             if isinstance(callee, CallableType):
                 if callee.is_generic():
                     callee = None

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -517,12 +517,10 @@ def type_object_type_from_function(init_or_new: FuncBase, info: TypeInfo,
     # We need to first map B's __init__ to the type (List[T]) -> None.
     signature = cast(FunctionLike,
                      map_type_from_supertype(signature, info, init_or_new.info))
-
+    special_sig = None  # type: Optional[str]
     if init_or_new.info.fullname() == 'builtins.dict':
         # Special signature!
         special_sig = 'dict'  # type: Optional[str]
-    else:
-        special_sig = None
 
     if isinstance(signature, CallableType):
         return class_callable(signature, info, fallback, special_sig)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -520,7 +520,7 @@ def type_object_type_from_function(init_or_new: FuncBase, info: TypeInfo,
     special_sig = None  # type: Optional[str]
     if init_or_new.info.fullname() == 'builtins.dict':
         # Special signature!
-        special_sig = 'dict'  # type: Optional[str]
+        special_sig = 'dict'
 
     if isinstance(signature, CallableType):
         return class_callable(signature, info, fallback, special_sig)

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -25,7 +25,7 @@ class Constraint:
     It can be either T <: type or T :> type (T is a type variable).
     """
 
-    type_var = None  # Type variable id
+    type_var = None  # type: TypeVarId # Type variable id
     op = 0           # SUBTYPE_OF or SUPERTYPE_OF
     target = None    # type: Type
 
@@ -53,10 +53,11 @@ def infer_constraints_for_callable(
 
     for i, actuals in enumerate(formal_to_actual):
         for actual in actuals:
-            if arg_types[actual] is None:
+            actual_arg_type = arg_types[actual]
+            if actual_arg_type is None:
                 continue
 
-            actual_type = get_actual_type(arg_types[actual], arg_kinds[actual],
+            actual_type = get_actual_type(actual_arg_type, arg_kinds[actual],
                                           tuple_counter)
             c = infer_constraints(callee.arg_types[i], actual_type,
                                   SUPERTYPE_OF)

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -25,7 +25,7 @@ class Constraint:
     It can be either T <: type or T :> type (T is a type variable).
     """
 
-    type_var = None  # type: TypeVarId # Type variable id
+    type_var = None  # type: TypeVarId
     op = 0           # SUBTYPE_OF or SUPERTYPE_OF
     target = None    # type: Type
 

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -50,9 +50,9 @@ def expr_to_unanalyzed_type(expr: Expression) -> Type:
         # Parse string literal type.
         try:
             result = parse_type_comment(expr.value, expr.line, None)
+            assert result is not None
         except SyntaxError:
             raise TypeTranslationError()
-        assert result is not None
         return result
     elif isinstance(expr, EllipsisExpr):
         return EllipsisType(expr.line)

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -52,6 +52,7 @@ def expr_to_unanalyzed_type(expr: Expression) -> Type:
             result = parse_type_comment(expr.value, expr.line, None)
         except SyntaxError:
             raise TypeTranslationError()
+        assert result is not None
         return result
     elif isinstance(expr, EllipsisExpr):
         return EllipsisType(expr.line)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -95,7 +95,7 @@ def parse(source: Union[str, bytes], fnam: str = None, errors: Errors = None,
     return tree
 
 
-def parse_type_comment(type_comment: str, line: int, errors: Errors) -> Optional[Type]:
+def parse_type_comment(type_comment: str, line: int, errors: Optional[Errors]) -> Optional[Type]:
     try:
         typ = ast3.parse(type_comment, '<type_comment>', 'eval')
     except SyntaxError as e:

--- a/mypy/infer.py
+++ b/mypy/infer.py
@@ -12,7 +12,7 @@ def infer_function_type_arguments(callee_type: CallableType,
                                   arg_types: List[Optional[Type]],
                                   arg_kinds: List[int],
                                   formal_to_actual: List[List[int]],
-                                  strict: bool = True) -> List[Type]:
+                                  strict: bool = True) -> List[Optional[Type]]:
     """Infer the type arguments of a generic function.
 
     Return an array of lower bound types for the type variables -1 (at
@@ -36,7 +36,7 @@ def infer_function_type_arguments(callee_type: CallableType,
 
 
 def infer_type_arguments(type_var_ids: List[TypeVarId],
-                         template: Type, actual: Type) -> List[Type]:
+                         template: Type, actual: Type) -> List[Optional[Type]]:
     # Like infer_function_type_arguments, but only match a single type
     # against a generic type.
     constraints = infer_constraints(template, actual, SUBTYPE_OF)

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -1,7 +1,7 @@
 """Calculation of the least upper bound types (joins)."""
 
 from collections import OrderedDict
-from typing import cast, List
+from typing import cast, List, Optional
 
 from mypy.types import (
     Type, AnyType, NoneTyp, TypeVisitor, Instance, UnboundType,
@@ -305,7 +305,7 @@ def join_instances_via_supertype(t: Instance, s: Instance) -> Type:
     # Compute the "best" supertype of t when joined with s.
     # The definition of "best" may evolve; for now it is the one with
     # the longest MRO.  Ties are broken by using the earlier base.
-    best = None  # type: Type
+    best = None  # type: Optional[Type]
     for base in t.type.bases:
         mapped = map_instance_to_supertype(t, base.type)
         res = join_instances(mapped, s)

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -255,10 +255,14 @@ class TypeMeetVisitor(TypeVisitor[Type]):
             for (_, l, r) in self.s.zip(t):
                 if not is_equivalent(l, r):
                     return self.default(self.s)
-            item_list = cast(List[Tuple[str, Type]],
-                # at least one of s_item_type and t_item_type is not None
-                [(item_name, s_item_type if s_item_type is not None else t_item_type)
-                for (item_name, s_item_type, t_item_type) in self.s.zipall(t)])
+            item_list = []  # type: List[Tuple[str, Type]]
+            for (item_name, s_item_type, t_item_type) in self.s.zipall(t):
+                if s_item_type is not None:
+                    item_list.append((item_name, s_item_type))
+                else:
+                    # at least one of s_item_type and t_item_type is not None
+                    assert t_item_type is not None
+                    item_list.append((item_name, t_item_type))
             items = OrderedDict(item_list)
             mapping_value_type = join_type_list(list(items.values()))
             fallback = self.s.create_anonymous_fallback(value_type=mapping_value_type)

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import List, Optional
+from typing import List, Optional, cast, Tuple
 
 from mypy.join import is_similar_callables, combine_similar_callables, join_type_list
 from mypy.types import (
@@ -255,10 +255,11 @@ class TypeMeetVisitor(TypeVisitor[Type]):
             for (_, l, r) in self.s.zip(t):
                 if not is_equivalent(l, r):
                     return self.default(self.s)
-            items = OrderedDict([
-                (item_name, s_item_type if s_item_type is not None else t_item_type)
-                for (item_name, s_item_type, t_item_type) in self.s.zipall(t)
-            ])
+            item_list = cast(List[Tuple[str, Type]],
+                # at least one of s_item_type and t_item_type is not None
+                [(item_name, s_item_type if s_item_type is not None else t_item_type)
+                for (item_name, s_item_type, t_item_type) in self.s.zipall(t)])
+            items = OrderedDict(item_list)
             mapping_value_type = join_type_list(list(items.values()))
             fallback = self.s.create_anonymous_fallback(value_type=mapping_value_type)
             return TypedDictType(items, fallback)

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -256,7 +256,7 @@ class TypeMeetVisitor(TypeVisitor[Type]):
                 if not is_equivalent(l, r):
                     return self.default(self.s)
             items = OrderedDict([
-                (item_name, s_item_type or t_item_type)
+                (item_name, s_item_type if s_item_type is not None else t_item_type)
                 for (item_name, s_item_type, t_item_type) in self.s.zipall(t)
             ])
             mapping_value_type = join_type_list(list(items.values()))

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1536,10 +1536,12 @@ class LambdaExpr(FuncItem, Expression):
     def name(self) -> str:
         return '<lambda>'
 
-    def expr(self) -> Optional[Expression]:
+    def expr(self) -> Expression:
         """Return the expression (the body) of the lambda."""
         ret = cast(ReturnStmt, self.body.body[-1])
-        return ret.expr
+        expr = ret.expr
+        assert expr is not None  # lambda can't have empty body
+        return expr
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_lambda_expr(self)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2033,7 +2033,7 @@ class TypeInfo(SymbolNode):
                 return n
         return None
 
-    def __getitem__(self, name: str) -> Optional['SymbolTableNode']:
+    def __getitem__(self, name: str) -> 'SymbolTableNode':
         n = self.get(name)
         if n:
             return n

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -1,6 +1,6 @@
 """Type inference constraint solving"""
 
-from typing import List, Dict
+from typing import List, Dict, Optional
 from collections import defaultdict
 
 from mypy.types import Type, NoneTyp, AnyType, UninhabitedType, TypeVarId
@@ -13,7 +13,7 @@ from mypy import experiments
 
 
 def solve_constraints(vars: List[TypeVarId], constraints: List[Constraint],
-                      strict: bool =True) -> List[Type]:
+                      strict: bool =True) -> List[Optional[Type]]:
     """Solve type constraints.
 
     Return the best type(s) for type variables; each type can be None if the value of the variable
@@ -28,12 +28,13 @@ def solve_constraints(vars: List[TypeVarId], constraints: List[Constraint],
     for con in constraints:
         cmap[con.type_var].append(con)
 
-    res = []  # type: List[Type]
+    res = []  # type: List[Optional[Type]]
 
     # Solve each type variable separately.
     for tvar in vars:
-        bottom = None  # type: Type
-        top = None  # type: Type
+        bottom = None  # type: Optional[Type]
+        top = None  # type: Optional[Type]
+        candidate = None  # type: Optional[Type]
 
         # Process each constraint separately, and calculate the lower and upper
         # bounds based on constraints. Note that we assume that the constraint

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict, Callable
+from typing import List, Optional, Dict, Callable, cast
 
 from mypy.types import (
     Type, AnyType, UnboundType, TypeVisitor, FormalArgument, NoneTyp,
@@ -514,8 +514,10 @@ def unify_generic_callable(type: CallableType, target: CallableType,
     inferred_vars = mypy.solve.solve_constraints(type_var_ids, constraints)
     if None in inferred_vars:
         return None
+    non_none_inferred_vars = cast(List[Type], inferred_vars)
     msg = messages.temp_message_builder()
-    applied = mypy.applytype.apply_generic_arguments(type, inferred_vars, msg, context=target)
+    applied = mypy.applytype.apply_generic_arguments(type, non_none_inferred_vars, msg,
+                                                     context=target)
     if msg.is_errors():
         return None
     return applied

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -166,7 +166,7 @@ class TransformVisitor(NodeVisitor[Node]):
             newitem.line = olditem.line
         new = OverloadedFuncDef(items)
         new._fullname = node._fullname
-        new.type = self.type(node.type)
+        new.type = self.optional_type(node.type)
         new.info = node.info
         if node.impl:
             new.impl = cast(OverloadPart, node.impl.accept(self))

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -950,7 +950,7 @@ class TypedDictType(Type):
                 yield (item_name, left_item_type, right_item_type)
 
     def zipall(self, right: 'TypedDictType') \
-            -> Iterable[Tuple[str, Optional[Type], Optional[Type]]]:
+            -> Iterable[Tuple[str, Optional[Type], Type]]:
         left = self
         for (item_name, left_item_type) in left.items.items():
             right_item_type = right.items.get(item_name)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -950,7 +950,7 @@ class TypedDictType(Type):
                 yield (item_name, left_item_type, right_item_type)
 
     def zipall(self, right: 'TypedDictType') \
-            -> Iterable[Tuple[str, Optional[Type], Type]]:
+            -> Iterable[Tuple[str, Optional[Type], Optional[Type]]]:
         left = self
         for (item_name, left_item_type) in left.items.items():
             right_item_type = right.items.get(item_name)


### PR DESCRIPTION
This PR makes ``--strict-optional`` clean for:
* join.py
* meet.py
* solve.py
* infer.py
* constraints.py
* exprtotype.py
* checkmember.py
* nodes.py

Fixing annotations in nodes.py lead to few dozens new errors (reducing the net progress), mostly in fastparse.py, fastparse2.py, semanal.py, checker.py, checkexpr.py. Actually those files seem to be most "dirty" (in general, the type layer is much "cleaner" than the expression layer).

There are few observations about what features would be useful with ``-strict-optional``:
* _Always_ represent ``Union[X, None]`` as ``Optioal[X]`` in errors, not something like ``some element of union doesn't have attribute x`` or ``unsupported left type for + (some union)``
* Allow ``x = None  # type: X`` in functions (not only in classes). This could be fixed by PEP 526 syntax, but only in Python 3.6+
* It will be useful to recognize more complex checks like ``x[i] is not None``, ``x.attr is not None``, and ``None not in x`` (for collections).