### PR TITLE
Use refers_to_fullname instead of poorly mimicking it

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2208,7 +2208,7 @@ class TypeChecker(NodeVisitor[None]):
         sig = self.function_type(e.func)  # type: Type
         # Process decorators from the inside out.
         for d in reversed(e.decorators):
-            if isinstance(d, NameExpr) and d.fullname == 'typing.overload':
+            if refers_to_fullname(d, 'typing.overload'):
                 self.fail('Single overload definition, multiple required', e)
                 continue
             dec = self.expr_checker.accept(d)


### PR DESCRIPTION
This should have the effect of producing the correct error message when the user writes `@typing.overload`.  It's so small I'm not even sure it's worth a test.