### PR TITLE
Add an option to choose tests based on the data file name

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,9 @@
+import pytest
+
 pytest_plugins = [
     'mypy.test.data',
 ]
+
+
+def pytest_addoption(parser):
+    parser.addoption("--casefile", action="store")

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -24,70 +24,62 @@ from mypy.options import Options
 
 from mypy import experiments
 
-# List of files that contain test case descriptions.
-files = [
-    'check-basic.test',
-    'check-callable.test',
-    'check-classes.test',
-    'check-statements.test',
-    'check-generics.test',
-    'check-dynamic-typing.test',
-    'check-inference.test',
-    'check-inference-context.test',
-    'check-kwargs.test',
-    'check-overloading.test',
-    'check-type-checks.test',
-    'check-abstract.test',
-    'check-multiple-inheritance.test',
-    'check-super.test',
-    'check-modules.test',
-    'check-typevar-values.test',
-    'check-unsupported.test',
-    'check-unreachable-code.test',
-    'check-unions.test',
-    'check-isinstance.test',
-    'check-lists.test',
-    'check-namedtuple.test',
-    'check-typeddict.test',
-    'check-type-aliases.test',
-    'check-ignore.test',
-    'check-type-promotion.test',
-    'check-semanal-error.test',
-    'check-flags.test',
-    'check-incremental.test',
-    'check-bound.test',
-    'check-optional.test',
-    'check-fastparse.test',
-    'check-warnings.test',
-    'check-async-await.test',
-    'check-newtype.test',
-    'check-class-namedtuple.test',
-    'check-selftype.test',
-    'check-python2.test',
-    'check-columns.test',
-    'check-functions.test',
-    'check-tuples.test',
-    'check-expressions.test',
-    'check-generic-subtyping.test',
-    'check-varargs.test',
-    'check-newsyntax.test',
-    'check-underscores.test',
-    'check-classvar.test',
-    'check-enum.test',
-]
-
 
 class TypeCheckSuite(DataSuite):
+    # List of files that contain test case descriptions.
+    files = [
+        'check-basic.test',
+        'check-callable.test',
+        'check-classes.test',
+        'check-statements.test',
+        'check-generics.test',
+        'check-dynamic-typing.test',
+        'check-inference.test',
+        'check-inference-context.test',
+        'check-kwargs.test',
+        'check-overloading.test',
+        'check-type-checks.test',
+        'check-abstract.test',
+        'check-multiple-inheritance.test',
+        'check-super.test',
+        'check-modules.test',
+        'check-typevar-values.test',
+        'check-unsupported.test',
+        'check-unreachable-code.test',
+        'check-unions.test',
+        'check-isinstance.test',
+        'check-lists.test',
+        'check-namedtuple.test',
+        'check-typeddict.test',
+        'check-type-aliases.test',
+        'check-ignore.test',
+        'check-type-promotion.test',
+        'check-semanal-error.test',
+        'check-flags.test',
+        'check-incremental.test',
+        'check-bound.test',
+        'check-optional.test',
+        'check-fastparse.test',
+        'check-warnings.test',
+        'check-async-await.test',
+        'check-newtype.test',
+        'check-class-namedtuple.test',
+        'check-selftype.test',
+        'check-python2.test',
+        'check-columns.test',
+        'check-functions.test',
+        'check-tuples.test',
+        'check-expressions.test',
+        'check-generic-subtyping.test',
+        'check-varargs.test',
+        'check-newsyntax.test',
+        'check-underscores.test',
+        'check-classvar.test',
+        'check-enum.test',
+    ]
+
     def __init__(self, *, update_data: bool = False) -> None:
         self.update_data = update_data
-
-    @classmethod
-    def cases(cls) -> List[DataDrivenTestCase]:
-        c = []  # type: List[DataDrivenTestCase]
-        for f in files:
-            c += parse_test_cases(os.path.join(test_data_prefix, f),
-                                  None, test_temp_dir, True)
-        return c
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         incremental = 'incremental' in testcase.name.lower() or 'incremental' in testcase.file

--- a/mypy/test/testdeps.py
+++ b/mypy/test/testdeps.py
@@ -14,22 +14,14 @@ from mypy.test.data import parse_test_cases, DataDrivenTestCase, DataSuite
 from mypy.test.helpers import assert_string_arrays_equal
 from mypy.types import Type
 
-files = [
-    'deps.test'
-]
-
 
 class GetDependenciesSuite(DataSuite):
+    files = [
+        'deps.test'
+    ]
+
     def __init__(self, *, update_data: bool) -> None:
         pass
-
-    @classmethod
-    def cases(cls) -> List[DataDrivenTestCase]:
-        c = []  # type: List[DataDrivenTestCase]
-        for f in files:
-            c += parse_test_cases(os.path.join(test_data_prefix, f),
-                                  None, test_temp_dir, True)
-        return c
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         src = '\n'.join(testcase.input)

--- a/mypy/test/testdiff.py
+++ b/mypy/test/testdiff.py
@@ -14,22 +14,13 @@ from mypy.test.data import parse_test_cases, DataDrivenTestCase, DataSuite
 from mypy.test.helpers import assert_string_arrays_equal
 
 
-files = [
-    'diff.test'
-]
-
-
 class ASTDiffSuite(DataSuite):
+    files = [
+        'diff.test'
+    ]
+
     def __init__(self, *, update_data: bool) -> None:
         pass
-
-    @classmethod
-    def cases(cls) -> List[DataDrivenTestCase]:
-        c = []  # type: List[DataDrivenTestCase]
-        for f in files:
-            c += parse_test_cases(os.path.join(test_data_prefix, f),
-                                  None, test_temp_dir, True)
-        return c
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         first_src = '\n'.join(testcase.input)

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -29,22 +29,13 @@ from mypy.types import TypeStrVisitor, Type
 from mypy.util import short_type
 
 
-files = [
-    'fine-grained.test'
-]
-
-
 class FineGrainedSuite(DataSuite):
+    files = [
+        'fine-grained.test'
+    ]
+
     def __init__(self, *, update_data: bool) -> None:
         pass
-
-    @classmethod
-    def cases(cls) -> List[DataDrivenTestCase]:
-        c = []  # type: List[DataDrivenTestCase]
-        for f in files:
-            c += parse_test_cases(os.path.join(test_data_prefix, f),
-                                  None, test_temp_dir, True)
-        return c
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         main_src = '\n'.join(testcase.input)

--- a/mypy/test/testmerge.py
+++ b/mypy/test/testmerge.py
@@ -23,11 +23,6 @@ from mypy.types import TypeStrVisitor, Type
 from mypy.util import short_type
 
 
-files = [
-    'merge.test'
-]
-
-
 # Which data structures to dump in a test case?
 SYMTABLE = 'SYMTABLE'
 TYPEINFO = ' TYPEINFO'
@@ -36,18 +31,14 @@ AST = 'AST'
 
 
 class ASTMergeSuite(DataSuite):
+    files = [
+        'merge.test'
+    ]
+
     def __init__(self, *, update_data: bool) -> None:
         self.str_conv = StrConv(show_ids=True)
         self.id_mapper = self.str_conv.id_mapper
         self.type_str_conv = TypeStrVisitor(self.id_mapper)
-
-    @classmethod
-    def cases(cls) -> List[DataDrivenTestCase]:
-        c = []  # type: List[DataDrivenTestCase]
-        for f in files:
-            c += parse_test_cases(os.path.join(test_data_prefix, f),
-                                  None, test_temp_dir, True)
-        return c
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         name = testcase.name

--- a/mypy/waiter.py
+++ b/mypy/waiter.py
@@ -339,7 +339,7 @@ class Waiter:
 
         if self.new_log:  # don't append empty log, it will corrupt the cache file
             # log only LOGSIZE most recent tests
-            test_log = (self.load_log_file() + [self.new_log])[:self.LOGSIZE]
+            test_log = (self.load_log_file() + [self.new_log])[-self.LOGSIZE:]
             try:
                 with open(self.FULL_LOG_FILENAME, 'w') as fp:
                     json.dump(test_log, fp, sort_keys=True, indent=4)

--- a/test-data/unit/README.md
+++ b/test-data/unit/README.md
@@ -101,14 +101,17 @@ finer control over which unit tests are run and how, you can run `py.test` or
 `scripts/myunit` directly, or pass inferior arguments via `-a`:
 
     $ py.test mypy/test/testcheck.py -v -k MethodCall
-    $ ./runtests.py -v 'pytest mypy/test/testcheck' -a -v -a -k -a MethodCall
+    $ ./runtests.py -v pytest -a -v -a -k -a testcheck -a -k -a MethodCall
 
     $ PYTHONPATH=$PWD scripts/myunit -m mypy.test.testlex -v '*backslash*'
     $ ./runtests.py mypy.test.testlex -a -v -a '*backslash*'
 
+Option `-a` is passed to all inferior tests (pytest or myunit); to pass an
+option just to pytest, use `-p`.
+
 To limit the run of data file-based tests to specific data files, use `--casefile`:
 
-    # ./runtests.py pytest -v -a -v -a --casefile -a check-uni.* -a -k -a testcheck
+    # ./runtests.py pytest -v -p -v -p --casefile -p check-uni.* -p -k -p testcheck
 
 You can also run the type checker for manual testing without
 installing anything by setting up the Python module search path

--- a/test-data/unit/README.md
+++ b/test-data/unit/README.md
@@ -106,6 +106,10 @@ finer control over which unit tests are run and how, you can run `py.test` or
     $ PYTHONPATH=$PWD scripts/myunit -m mypy.test.testlex -v '*backslash*'
     $ ./runtests.py mypy.test.testlex -a -v -a '*backslash*'
 
+To limit the run of data file-based tests to specific data files, use `--casefile`:
+
+    # ./runtests.py pytest -v -a -v -a --casefile -a check-uni.* -a -k -a testcheck
+
 You can also run the type checker for manual testing without
 installing anything by setting up the Python module search path
 suitably (the lib-typing/3.2 path entry is not needed for Python 3.5


### PR DESCRIPTION
Also fix an unrelated minor bug in the test runtime cache (I was deleting the newest instead of the oldest logs).