### PR TITLE
Fix crash on older version of typing

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2272,7 +2272,7 @@ class SymbolTableNode:
             return None
 
     @property
-    def type(self) -> Optional['mypy.types.Type']:
+    def type(self) -> 'Optional[mypy.types.Type]':
         # IDEA: Get rid of the Any type.
         node = self.node  # type: Any
         if self.type_override is not None:


### PR DESCRIPTION
Fixes #3301 

It looks like there is only one dangerous line. This PR makes it safe.

Attn: @JelleZijlstra @gvanrossum 