### PR TITLE
Display uninhabited types as <nothing> instead of <uninhabited>

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -329,7 +329,7 @@ class MessageBuilder:
             if typ.is_noreturn:
                 return 'NoReturn'
             else:
-                return '<uninhabited>'
+                return '<nothing>'
         elif isinstance(typ, TypeType):
             return 'Type[{}]'.format(
                 strip_quotes(self.format_simple(typ.item, verbosity)))

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1418,7 +1418,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         return "builtins.None"
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> str:
-        return "<uninhabited>"
+        return "<nothing>"
 
     def visit_erased_type(self, t: ErasedType) -> str:
         return "<Erased>"

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -394,7 +394,7 @@ B(1)
 C(1)
 C('a')  # E: Argument 1 to "C" has incompatible type "str"; expected "int"
 D(A(1))
-D(1)  # E: Argument 1 to "D" has incompatible type "int"; expected A[<uninhabited>]
+D(1)  # E: Argument 1 to "D" has incompatible type "int"; expected A[<nothing>]
 
 
 [case testInheritedConstructor2]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -565,7 +565,7 @@ def func(x: IntNode[T]) -> IntNode[T]:
     return x
 reveal_type(func) # E: Revealed type is 'def [T] (x: __main__.Node[builtins.int, T`-1]) -> __main__.Node[builtins.int, T`-1]'
 
-func(1) # E: Argument 1 to "func" has incompatible type "int"; expected Node[int, <uninhabited>]
+func(1) # E: Argument 1 to "func" has incompatible type "int"; expected Node[int, <nothing>]
 func(Node('x', 1)) # E: Argument 1 to "Node" has incompatible type "str"; expected "int"
 reveal_type(func(Node(1, 'x'))) # E: Revealed type is '__main__.Node[builtins.int, builtins.str*]'
 
@@ -800,7 +800,7 @@ reveal_type(x) # E: Revealed type is 'builtins.int'
 def f2(x: IntTP[T]) -> IntTP[T]:
     return x
 
-f2((1, 2, 3)) # E: Argument 1 to "f2" has incompatible type "Tuple[int, int, int]"; expected "Tuple[int, <uninhabited>]"
+f2((1, 2, 3)) # E: Argument 1 to "f2" has incompatible type "Tuple[int, int, int]"; expected "Tuple[int, <nothing>]"
 reveal_type(f2((1, 'x'))) # E: Revealed type is 'Tuple[builtins.int, builtins.str*]'
 
 [builtins fixtures/for.pyi]
@@ -869,7 +869,7 @@ n.y = 'x' # E: Incompatible types in assignment (expression has type "str", vari
 def f(x: Node[T, T]) -> TupledNode[T]:
     return Node(x.x, (x.x, x.x))
 
-f(1) # E: Argument 1 to "f" has incompatible type "int"; expected Node[<uninhabited>, <uninhabited>]
+f(1) # E: Argument 1 to "f" has incompatible type "int"; expected Node[<nothing>, <nothing>]
 f(Node(1, 'x')) # E: Cannot infer type argument 1 of "f"
 reveal_type(Node('x', 'x')) # E: Revealed type is 'a.Node[builtins.str*, builtins.str*]'
 

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -13,7 +13,7 @@ b = None # type: B
 
 ao = f()
 ab = f()
-b = f() # E: Incompatible types in assignment (expression has type A[<uninhabited>], variable has type "B")
+b = f() # E: Incompatible types in assignment (expression has type A[<nothing>], variable has type "B")
 
 def f() -> 'A[T]': pass
 
@@ -29,7 +29,7 @@ b = None # type: B
 
 ao = A()
 ab = A()
-b = A() # E: Incompatible types in assignment (expression has type A[<uninhabited>], variable has type "B")
+b = A() # E: Incompatible types in assignment (expression has type A[<nothing>], variable has type "B")
 
 class A(Generic[T]): pass
 class B: pass
@@ -334,7 +334,7 @@ aa = None # type: List[A]
 ao = None # type: List[object]
 a = None # type: A
 
-a = [] # E: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type "A")
+a = [] # E: Incompatible types in assignment (expression has type List[<nothing>], variable has type "A")
 
 aa = []
 ao = []
@@ -759,7 +759,7 @@ T = TypeVar('T')
 def f(x: Union[List[T], str]) -> None: pass
 f([1])
 f('')
-f(1) # E: Argument 1 to "f" has incompatible type "int"; expected "Union[List[<uninhabited>], str]"
+f(1) # E: Argument 1 to "f" has incompatible type "int"; expected "Union[List[<nothing>], str]"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testIgnoringInferenceContext]
@@ -828,7 +828,7 @@ from typing import TypeVar, Callable, Generic
 T = TypeVar('T')
 class A(Generic[T]):
     pass
-reveal_type(A()) # E: Revealed type is '__main__.A[<uninhabited>]'
+reveal_type(A()) # E: Revealed type is '__main__.A[<nothing>]'
 b = reveal_type(A())  # type: A[int] # E: Revealed type is '__main__.A[builtins.int]'
 
 [case testUnionWithGenericTypeItemContext]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -681,10 +681,10 @@ g('a')() # E: List[str] not callable
 # The next line is a case where there are multiple ways to satisfy a constraint
 # involving a Union. Either T = List[str] or T = str would turn out to be valid,
 # but mypy doesn't know how to branch on these two options (and potentially have
-# to backtrack later) and defaults to T = <uninhabited>. The result is an
+# to backtrack later) and defaults to T = <nothing>. The result is an
 # awkward error message. Either a better error message, or simply accepting the
 # call, would be preferable here.
-g(['a']) # E: Argument 1 to "g" has incompatible type List[str]; expected List[<uninhabited>]
+g(['a']) # E: Argument 1 to "g" has incompatible type List[str]; expected List[<nothing>]
 
 h(g(['a']))
 
@@ -778,7 +778,7 @@ from typing import TypeVar, Union, List
 T = TypeVar('T')
 def f() -> List[T]: pass
 d1 = f() # type: Union[List[int], str]
-d2 = f() # type: Union[int, str] # E: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type "Union[int, str]")
+d2 = f() # type: Union[int, str] # E: Incompatible types in assignment (expression has type List[<nothing>], variable has type "Union[int, str]")
 def g(x: T) -> List[T]: pass
 d3 = g(1) # type: Union[List[int], List[str]]
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1452,16 +1452,16 @@ def f(x: Union[Type[int], Type[str], Type[List]]) -> None:
         x()[1]  # E: Value of type "Union[int, str]" is not indexable
     else:
         reveal_type(x)  # E: Revealed type is 'Type[builtins.list]'
-        reveal_type(x())  # E: Revealed type is 'builtins.list[<uninhabited>]'
+        reveal_type(x())  # E: Revealed type is 'builtins.list[<nothing>]'
         x()[1]
     reveal_type(x)  # E: Revealed type is 'Union[Type[builtins.int], Type[builtins.str], Type[builtins.list]]'
-    reveal_type(x())  # E: Revealed type is 'Union[builtins.int, builtins.str, builtins.list[<uninhabited>]]'
+    reveal_type(x())  # E: Revealed type is 'Union[builtins.int, builtins.str, builtins.list[<nothing>]]'
     if issubclass(x, (str, (list,))):
         reveal_type(x)  # E: Revealed type is 'Union[Type[builtins.str], Type[builtins.list[Any]]]'
-        reveal_type(x())  # E: Revealed type is 'Union[builtins.str, builtins.list[<uninhabited>]]'
+        reveal_type(x())  # E: Revealed type is 'Union[builtins.str, builtins.list[<nothing>]]'
         x()[1]
     reveal_type(x)  # E: Revealed type is 'Union[Type[builtins.int], Type[builtins.str], Type[builtins.list[Any]]]'
-    reveal_type(x())  # E: Revealed type is 'Union[builtins.int, builtins.str, builtins.list[<uninhabited>]]'
+    reveal_type(x())  # E: Revealed type is 'Union[builtins.int, builtins.str, builtins.list[<nothing>]]'
 [builtins fixtures/isinstancelist.pyi]
 
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -25,7 +25,7 @@ reveal_type(p)  # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int,
 from mypy_extensions import TypedDict
 EmptyDict = TypedDict('EmptyDict', {})
 p = EmptyDict()
-reveal_type(p)  # E: Revealed type is 'TypedDict(_fallback=typing.Mapping[builtins.str, <uninhabited>])'
+reveal_type(p)  # E: Revealed type is 'TypedDict(_fallback=typing.Mapping[builtins.str, <nothing>])'
 [builtins fixtures/dict.pyi]
 
 
@@ -112,7 +112,7 @@ class EmptyDict(TypedDict):
     pass
 
 p = EmptyDict()
-reveal_type(p)  # E: Revealed type is 'TypedDict(_fallback=typing.Mapping[builtins.str, <uninhabited>])'
+reveal_type(p)  # E: Revealed type is 'TypedDict(_fallback=typing.Mapping[builtins.str, <nothing>])'
 [builtins fixtures/dict.pyi]
 
 
@@ -393,7 +393,7 @@ d2 = Cell(value='pear tree')
 joined_dicts = [d1, d2]
 reveal_type(d1)             # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, _fallback=typing.Mapping[builtins.str, builtins.int])'
 reveal_type(d2)             # E: Revealed type is 'TypedDict(value=builtins.object, _fallback=typing.Mapping[builtins.str, builtins.object])'
-reveal_type(joined_dicts)   # E: Revealed type is 'builtins.list[TypedDict(_fallback=typing.Mapping[builtins.str, <uninhabited>])]'
+reveal_type(joined_dicts)   # E: Revealed type is 'builtins.list[TypedDict(_fallback=typing.Mapping[builtins.str, <nothing>])]'
 [builtins fixtures/dict.pyi]
 
 [case testJoinOfTypedDictWithCompatibleMappingIsMapping]
@@ -468,7 +468,7 @@ YbZ = TypedDict('YbZ', {'y': object, 'z': int})
 T = TypeVar('T')
 def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: XYa, y: YbZ) -> None: pass
-reveal_type(f(g))  # E: Revealed type is '<uninhabited>'
+reveal_type(f(g))  # E: Revealed type is '<nothing>'
 [builtins fixtures/dict.pyi]
 
 [case testMeetOfTypedDictsWithNoCommonKeysHasAllKeysAndNewFallback]
@@ -492,7 +492,7 @@ M = Mapping[str, int]
 T = TypeVar('T')
 def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: X, y: M) -> None: pass
-reveal_type(f(g))  # E: Revealed type is '<uninhabited>'
+reveal_type(f(g))  # E: Revealed type is '<nothing>'
 [builtins fixtures/dict.pyi]
 
 [case testMeetOfTypedDictWithIncompatibleMappingIsUninhabited]
@@ -504,7 +504,7 @@ M = Mapping[str, str]
 T = TypeVar('T')
 def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: X, y: M) -> None: pass
-reveal_type(f(g))  # E: Revealed type is '<uninhabited>'
+reveal_type(f(g))  # E: Revealed type is '<nothing>'
 [builtins fixtures/dict.pyi]
 
 # TODO: It would be more accurate for the meet to be TypedDict instead.
@@ -517,7 +517,7 @@ I = Iterable[str]
 T = TypeVar('T')
 def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: X, y: I) -> None: pass
-reveal_type(f(g))  # E: Revealed type is '<uninhabited>'
+reveal_type(f(g))  # E: Revealed type is '<nothing>'
 [builtins fixtures/dict.pyi]
 
 

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -533,8 +533,8 @@ a, aa = G().f(*[a])  # Fail
 aa, a = G().f(*[a])  # Fail
 ab, aa = G().f(*[a]) # Fail
 
-ao, ao = G().f(*[a]) # E: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type List[object])
-aa, aa = G().f(*[a]) # E: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type List[A])
+ao, ao = G().f(*[a]) # E: Incompatible types in assignment (expression has type List[<nothing>], variable has type List[object])
+aa, aa = G().f(*[a]) # E: Incompatible types in assignment (expression has type List[<nothing>], variable has type List[A])
 
 class G(Generic[T]):
     def f(self, *a: S) -> Tuple[List[S], List[T]]:
@@ -545,9 +545,9 @@ class B: pass
 [builtins fixtures/list.pyi]
 [out]
 main:9: error: Incompatible types in assignment (expression has type List[A], variable has type "A")
-main:9: error: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type List[A])
-main:10: error: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type "A")
-main:11: error: Incompatible types in assignment (expression has type List[<uninhabited>], variable has type List[A])
+main:9: error: Incompatible types in assignment (expression has type List[<nothing>], variable has type List[A])
+main:10: error: Incompatible types in assignment (expression has type List[<nothing>], variable has type "A")
+main:11: error: Incompatible types in assignment (expression has type List[<nothing>], variable has type List[A])
 main:11: error: Argument 1 to "f" of "G" has incompatible type *List[A]; expected "B"
 
 

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1099,7 +1099,7 @@ MyDDict(dict)[0]
 _program.py:6: error: Argument 1 to "defaultdict" has incompatible type List[_T]; expected Callable[[], str]
 _program.py:9: error: Invalid index type "str" for defaultdict[int, str]; expected type "int"
 _program.py:9: error: Incompatible types in assignment (expression has type "int", target has type "str")
-_program.py:19: error: Dict entry 0 has incompatible type "str": List[<uninhabited>]
+_program.py:19: error: Dict entry 0 has incompatible type "str": List[<nothing>]
 _program.py:23: error: Invalid index type "str" for MyDDict[Dict[_KT, _VT]]; expected type "int"
 
 [case testNoSubcriptionOfStdlibCollections]


### PR DESCRIPTION
Rationale: 

1) This looks less cryptic than `<uninhabited>` and communicates the 
  meaning better, arguably. 

2) This is closer to 'None' that was usually produced in earlier mypy versions 
  in similar contexts.

I feel like this is better than the current situation, though an even better 
option would be to not infer uninhabited types as often.

@gvanrossum @ddfisher What do you think?