### PR TITLE
Fix crash with NamedTuple classmethod

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -817,6 +817,12 @@ class SemanticAnalyzer(NodeVisitor):
                         items, types, default_items = self.check_namedtuple_classdef(defn)
                         node.node = self.build_namedtuple_typeinfo(
                             defn.name, items, types, default_items)
+                        # We only really need the assignments in the body to be type checked later;
+                        # attempting to type check methods may lead to crashes because NamedTuples
+                        # do not have a fully functional TypeInfo.
+                        # TODO remove this hack and add full support for NamedTuple methods
+                        defn.defs.body = [stmt for stmt in defn.defs.body
+                                          if isinstance(stmt, AssignmentStmt)]
                         return True
         return False
 

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -482,3 +482,15 @@ Y(y=1, x='1').method()
 class CallsBaseInit(X):
     def __init__(self, x: str) -> None:
         super().__init__(x)
+
+[case testNewNamedTupleClassMethod]
+from typing import NamedTuple
+
+class HasClassMethod(NamedTuple):
+    x: str
+
+    @classmethod  # E: Invalid statement in NamedTuple definition; expected "field_name: field_type"
+    def new(cls, f: str) -> 'HasClassMethod':
+        pass
+
+[builtins fixtures/classmethod.pyi]

--- a/test-data/unit/fixtures/classmethod.pyi
+++ b/test-data/unit/fixtures/classmethod.pyi
@@ -1,5 +1,7 @@
 import typing
 
+_T = typing.TypeVar('_T')
+
 class object:
     def __init__(self) -> None: pass
 
@@ -20,3 +22,5 @@ class int:
 class str: pass
 class bytes: pass
 class bool: pass
+
+class tuple(typing.Generic[_T]): pass


### PR DESCRIPTION
Really hacky but this should work for now. I think the bug
was introduced when we added support for NamedTuple
classmethods.

Fixes #3317