### PR TITLE
Refer to modules using 'Module' in errors, not "ModuleType"

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -249,7 +249,9 @@ class MessageBuilder:
         if isinstance(typ, Instance):
             itype = typ
             # Get the short name of the type.
-            if itype.type.fullname() == 'types.ModuleType':
+            if itype.type.fullname() in ('types.ModuleType',
+                                         '_importlib_modulespec.ModuleType'):
+                # Make some common error messages simpler and tidier.
                 return 'Module'
             if verbosity >= 2:
                 base_str = itype.type.fullname()

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -249,6 +249,8 @@ class MessageBuilder:
         if isinstance(typ, Instance):
             itype = typ
             # Get the short name of the type.
+            if itype.type.fullname() == 'types.ModuleType':
+                return 'Module'
             if verbosity >= 2:
                 base_str = itype.type.fullname()
             else:

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -46,7 +46,7 @@ import b # type: ignore
 reveal_type(a.foo) # E: Revealed type is 'Any'
 reveal_type(b.foo) # E: Revealed type is 'builtins.int'
 a.bar()
-b.bar() # E: "ModuleType" has no attribute "bar"
+b.bar() # E: Module has no attribute "bar"
 
 [file b.py]
 foo = 3
@@ -76,7 +76,7 @@ class B(A):
 import m
 m.x = object # type: ignore
 m.f() # type: ignore
-m.y # E: "ModuleType" has no attribute "y"
+m.y # E: Module has no attribute "y"
 [file m.py]
 [builtins fixtures/module.pyi]
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -319,7 +319,7 @@ const = 3
 [stale mod3]
 [builtins fixtures/module.pyi]
 [out2]
-tmp/mod1.py:3: error: "ModuleType" has no attribute "mod4"
+tmp/mod1.py:3: error: Module has no attribute "mod4"
 
 [case testIncrementalLongBrokenCascade]
 import mod1
@@ -354,7 +354,7 @@ const = 3
 [stale mod6]
 [builtins fixtures/module.pyi]
 [out2]
-tmp/mod1.py:3: error: "ModuleType" has no attribute "mod7"
+tmp/mod1.py:3: error: Module has no attribute "mod7"
 
 [case testIncrementalNestedBrokenCascade]
 import mod1
@@ -380,7 +380,7 @@ const = 3
 [stale mod2.mod3]
 [builtins fixtures/module.pyi]
 [out2]
-tmp/mod1.py:3: error: "ModuleType" has no attribute "mod4"
+tmp/mod1.py:3: error: Module has no attribute "mod4"
 
 [case testIncrementalNestedBrokenCascadeWithType1]
 import mod1, mod2.mod3.mod5

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -155,16 +155,16 @@ import m
 import typing
 
 class A: pass
-m()      # E: "ModuleType" not callable
-a = m # type: A  # E: Incompatible types in assignment (expression has type "ModuleType", variable has type "A")
-m + None # E: Unsupported left operand type for + ("ModuleType")
+m()      # E: Module not callable
+a = m # type: A  # E: Incompatible types in assignment (expression has type Module, variable has type "A")
+m + None # E: Unsupported left operand type for + (Module)
 [file m.py]
 [builtins fixtures/module.pyi]
 
 [case testNameDefinedInDifferentModule]
 import m, n
 import typing
-m.x # E: "ModuleType" has no attribute "x"
+m.x # E: Module has no attribute "x"
 [file m.py]
 y = object()
 [file n.py]
@@ -330,7 +330,7 @@ import nonexistent
 [out]
 tmp/x.py:1: error: Cannot find module named 'nonexistent'
 tmp/x.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
-main:3: error: "ModuleType" has no attribute "z"
+main:3: error: Module has no attribute "z"
 
 [case testUnknownModuleImportedWithinFunction]
 def f():
@@ -648,7 +648,7 @@ def f(x: str) -> None: pass
 if object():
     import m
 else:
-    m = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "ModuleType")
+    m = 1 # E: Incompatible types in assignment (expression has type "int", variable has type Module)
 [file m.py]
 [builtins fixtures/module.pyi]
 [out]
@@ -752,7 +752,7 @@ value = 3.2
 [case testSubmoduleImportFromDoesNotAddParents]
 from a import b
 reveal_type(b.value)  # E: Revealed type is 'builtins.str'
-b.c.value  # E: "ModuleType" has no attribute "c"
+b.c.value  # E: Module has no attribute "c"
 a.value  # E: Name 'a' is not defined
 
 [file a/__init__.py]
@@ -853,7 +853,7 @@ bar = parent.unrelated.ShouldNotLoad()
 [builtins fixtures/module.pyi]
 [out]
 tmp/parent/child.py:8: error: Revealed type is 'parent.common.SomeClass'
-tmp/parent/child.py:9: error: "ModuleType" has no attribute "unrelated"
+tmp/parent/child.py:9: error: Module has no attribute "unrelated"
 
 [case testSubmoduleMixingImportFromAndImport2]
 import parent.child

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -365,8 +365,8 @@ x += ''  # Error reported here
 a.py:2: error: Unsupported operand types for + ("int" and "str")
 main.py:3: error: Unsupported operand types for + ("int" and "str")
 main.py:6: error: Unsupported operand types for + ("int" and "str")
-main.py:7: error: "ModuleType" has no attribute "y"
-main.py:8: error: Unsupported operand types for + ("ModuleType" and "int")
+main.py:7: error: Module has no attribute "y"
+main.py:8: error: Unsupported operand types for + (Module and "int")
 
 [case testConfigFollowImportsSilent]
 # cmd: mypy main.py
@@ -386,8 +386,8 @@ x += ''  # No error reported
 [out]
 main.py:2: error: Unsupported operand types for + ("int" and "str")
 main.py:4: error: Unsupported operand types for + ("int" and "str")
-main.py:5: error: "ModuleType" has no attribute "y"
-main.py:6: error: Unsupported operand types for + ("ModuleType" and "int")
+main.py:5: error: Module has no attribute "y"
+main.py:6: error: Unsupported operand types for + (Module and "int")
 
 [case testConfigFollowImportsSkip]
 # cmd: mypy main.py

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -68,7 +68,7 @@ def g(x: str) -> None: pass
 [builtins fixtures/fine_grained.pyi]
 [out]
 ==
-main:3: error: "ModuleType" has no attribute "f"
+main:3: error: Module has no attribute "f"
 
 [case testTopLevelMissingModuleAttribute]
 import m
@@ -81,7 +81,7 @@ def g(x: int) -> None: pass
 [builtins fixtures/fine_grained.pyi]
 [out]
 ==
-main:2: error: "ModuleType" has no attribute "f"
+main:2: error: Module has no attribute "f"
 
 [case testClassChangedIntoFunction]
 import m
@@ -241,7 +241,7 @@ class A: pass
 [builtins fixtures/fine_grained.pyi]
 [out]
 ==
-main:3: error: "ModuleType" has no attribute "A"
+main:3: error: Module has no attribute "A"
 ==
 
 [case testContinueToReportTypeCheckError]
@@ -281,10 +281,10 @@ class A: pass
 [builtins fixtures/fine_grained.pyi]
 [out]
 ==
-main:3: error: "ModuleType" has no attribute "A"
-main:5: error: "ModuleType" has no attribute "B"
+main:3: error: Module has no attribute "A"
+main:5: error: Module has no attribute "B"
 ==
-main:5: error: "ModuleType" has no attribute "B"
+main:5: error: Module has no attribute "B"
 
 [case testContinueToReportErrorAtTopLevel]
 import n
@@ -348,9 +348,9 @@ def g() -> None: pass
 [builtins fixtures/fine_grained.pyi]
 [out]
 main:3: error: Too few arguments for "f"
-main:5: error: "ModuleType" has no attribute "g"
+main:5: error: Module has no attribute "g"
 ==
-main:5: error: "ModuleType" has no attribute "g"
+main:5: error: Module has no attribute "g"
 ==
 
 [case testKeepReportingErrorIfNoChanges]
@@ -361,9 +361,9 @@ def h() -> None:
 [file m.py.2]
 [builtins fixtures/fine_grained.pyi]
 [out]
-main:3: error: "ModuleType" has no attribute "g"
+main:3: error: Module has no attribute "g"
 ==
-main:3: error: "ModuleType" has no attribute "g"
+main:3: error: Module has no attribute "g"
 
 [case testFixErrorAndReintroduce]
 import m
@@ -375,10 +375,10 @@ def g() -> None: pass
 [file m.py.3]
 [builtins fixtures/fine_grained.pyi]
 [out]
-main:3: error: "ModuleType" has no attribute "g"
+main:3: error: Module has no attribute "g"
 ==
 ==
-main:3: error: "ModuleType" has no attribute "g"
+main:3: error: Module has no attribute "g"
 
 [case testAddBaseClassMethodCausingInvalidOverride]
 import m

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1171,8 +1171,8 @@ collections.Deque()
 typing.deque()
 
 [out]
-_testDequeWrongCase.py:4: error: "ModuleType" has no attribute "Deque"
-_testDequeWrongCase.py:5: error: "ModuleType" has no attribute "deque"
+_testDequeWrongCase.py:4: error: Module has no attribute "Deque"
+_testDequeWrongCase.py:5: error: Module has no attribute "deque"
 
 [case testDictUpdateInference]
 from typing import Dict, Optional


### PR DESCRIPTION
The Python runtime talks about modules, so this should be less
surprising, and some common errors now look tidier. Motivation:

```
>>> import os
>>> type(os)
<class 'module'>
>>> str(os)
"<module 'os' from '.../lib/python3.6/os.py'>"
```

Mypy 0.501 used "module" in error messages and using
"ModuleType" is arguably a small regression.