### PR TITLE
Fix missing node in --quick mode also for type aliases

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -6,7 +6,7 @@ from mypy.nodes import (
     MypyFile, SymbolNode, SymbolTable, SymbolTableNode,
     TypeInfo, FuncDef, OverloadedFuncDef, Decorator, Var,
     TypeVarExpr, ClassDef, Block,
-    LDEF, MDEF, GDEF
+    LDEF, MDEF, GDEF, TYPE_ALIAS
 )
 from mypy.types import (
     CallableType, EllipsisType, Instance, Overloaded, TupleType, TypedDictType,
@@ -93,8 +93,8 @@ class NodeFixer(NodeVisitor[None]):
                     else:
                         # We have a missing crossref in quick mode, need to put something
                         value.node = stale_info()
-                        if value.type_override is not None:
-                            value.type_override.accept(self.type_fixer)
+                        if value.kind == TYPE_ALIAS:
+                            value.type_override = Instance(stale_info(), [])
             else:
                 if isinstance(value.node, TypeInfo):
                     # TypeInfo has no accept().  TODO: Add it?


### PR DESCRIPTION
This should fix #3355 

For deserialized node with ``cross_ref``, if we can't find the ``cross_ref`` in quick mode, then we need to put something in there, see #3304. This PR does exactly the same for the case of a type alias node.

@gvanrossum Could yo please check that this works?