### PR TITLE
Re-broaden type to Any if it started as Any but was narrowed in an enclosing frame

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -221,7 +221,8 @@ class ConditionalTypeBinder:
             # times?
             return
 
-        if (isinstance(self.most_recent_enclosing_type(expr, type), AnyType)
+        enclosing_type = self.most_recent_enclosing_type(expr, type)
+        if (isinstance(enclosing_type, AnyType)
                 and not restrict_any):
             # If x is Any and y is int, after x = y we do not infer that x is int.
             # This could be changed.
@@ -229,7 +230,7 @@ class ConditionalTypeBinder:
                 # We narrowed type from Any in a recent frame (probably an
                 # isinstance check), but now it is reassigned, so broaden back
                 # to Any (which is the most recent enclosing type)
-                self.put(expr, self.most_recent_enclosing_type(expr, type))
+                self.put(expr, enclosing_type)
         elif (isinstance(type, AnyType)
               and not (isinstance(declared_type, UnionType)
                        and any(isinstance(item, AnyType) for item in declared_type.items))):

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -221,12 +221,15 @@ class ConditionalTypeBinder:
             # times?
             return
 
-        # If x is Any and y is int, after x = y we do not infer that x is int.
-        # This could be changed.
 
         if (isinstance(self.most_recent_enclosing_type(expr, type), AnyType)
                 and not restrict_any):
-            pass
+            # If x is Any and y is int, after x = y we do not infer that x is int.
+            # This could be changed.
+            # However, we may have narrowed it down from Any in a recent frame,
+            # so un-narrow it back to Any at this point.
+            if not isinstance(type, AnyType):
+                self.put(expr, self.most_recent_enclosing_type(expr, type))
         elif (isinstance(type, AnyType)
               and not (isinstance(declared_type, UnionType)
                        and any(isinstance(item, AnyType) for item in declared_type.items))):

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -221,14 +221,14 @@ class ConditionalTypeBinder:
             # times?
             return
 
-
         if (isinstance(self.most_recent_enclosing_type(expr, type), AnyType)
                 and not restrict_any):
             # If x is Any and y is int, after x = y we do not infer that x is int.
             # This could be changed.
-            # However, we may have narrowed it down from Any in a recent frame,
-            # so un-narrow it back to Any at this point.
             if not isinstance(type, AnyType):
+                # We narrowed type from Any in a recent frame (probably an
+                # isinstance check), but now it is reassigned, so broaden back
+                # to Any (which is the most recent enclosing type)
                 self.put(expr, self.most_recent_enclosing_type(expr, type))
         elif (isinstance(type, AnyType)
               and not (isinstance(declared_type, UnionType)

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1721,7 +1721,8 @@ def narrow_any_to_str_then_reassign_to_int() -> None:
     v = 1 # type: Any
 
     if isinstance(v, str):
+        reveal_type(v)  # E: Revealed type is 'builtins.str'
         v = 2
-        v + 3
+        reveal_type(v)  # E: Revealed type is 'Any'
 
 [builtins fixtures/isinstance.pyi]

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1712,3 +1712,16 @@ if isinstance(x, (set, (list, T))):
     reveal_type(x)  # E: Revealed type is 'Union[builtins.set[Any], builtins.list[Any], builtins.int, builtins.str]'
 
 [builtins fixtures/isinstancelist.pyi]
+
+
+[case testIsinstanceNarrowAny]
+from typing import Any
+
+def narrow_any_to_str_then_reassign_to_int() -> None:
+    v = 1 # type: Any
+
+    if isinstance(v, str):
+        v = 2
+        v + 3
+
+[builtins fixtures/isinstance.pyi]


### PR DESCRIPTION
Fixes #3338.

* Note 1: I don't understand mypy very well yet so be warned that this may break things I don't understand.
* Note 2: it looks like I was confused in the original bug report, and attributing the problem to strict-optional was actually a red herring. So I created a new test case for which strict-optional isn't needed.

## My investigation notes:

The explanation is that the bug is caused by an interaction between `most_recent_enclosing_type` and its caller, `assign_type`. `assign_type` has a special case for when the most recent enclosing type is Any, commented with the following note: "If x is Any and y is int, after x = y we do not infer that x is int. This could be changed." The special case does nothing (the normal case assigns the inferred type to the variable).

In my test case, `most_recent_enclosing_type` misses the frame which reassigns `v` because `int` is not a subtype of `str`, and so returns Any and so the special case applies (this explains why declaring with type Union doesn't reproduce the problem). So it doesn't assign any new type for this assignment, causing the bug.

I took the approach of fixing that special case so if `type` is not bound to Any at the moment of assignment, it re-binds it to Any (or, really, whatever is the result of `most_recent_enclosing_type`).

Another approach might be to remove the subtype check from most_recent_enclosing_type. https://github.com/python/mypy/compare/master...lincolnq:lincoln/remove-subtype-check-from-binder?expand=1 is where I tried that. I thought that change was more aggressive / likely to break things, and I didn't understand why the subtype check was put there in the first place. But it has the desirable (to me) property of inferring `int` on the reassignment rather than `Any`.

Both approaches pass the automated tests.