### PR TITLE
Add --include-private option to stubgen to include private members.

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -617,7 +617,7 @@ def walk_packages(packages: List[str]) -> Iterator[str]:
 
 
 def main() -> None:
-    options = parse_options()
+    options = parse_options(sys.argv[1:])
     if not os.path.isdir('out'):
         raise SystemExit('Directory "out" does not exist')
     if options.recursive and options.no_import:
@@ -652,9 +652,7 @@ def main() -> None:
                 print("Stub generation failed for", module, file=sys.stderr)
 
 
-def parse_options(args: Optional[List[str]] = None) -> Options:
-    if args is None:
-        args = sys.argv[1:]
+def parse_options(args: List[str]) -> Options:
     pyversion = defaults.PYTHON3_VERSION
     no_import = False
     recursive = False

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -73,6 +73,7 @@ Options = NamedTuple('Options', [('pyversion', Tuple[int, int]),
                                  ('modules', List[str]),
                                  ('ignore_errors', bool),
                                  ('recursive', bool),
+                                 ('include_private', bool),
                                  ])
 
 
@@ -86,7 +87,8 @@ def generate_stub_for_module(module: str, output_dir: str, quiet: bool = False,
                              pyversion: Tuple[int, int] = defaults.PYTHON3_VERSION,
                              no_import: bool = False,
                              search_path: List[str] = [],
-                             interpreter: str = sys.executable) -> None:
+                             interpreter: str = sys.executable,
+                             include_private: bool = False) -> None:
     target = module.replace('.', '/')
     try:
         result = find_module_path_and_all(module=module,
@@ -118,7 +120,7 @@ def generate_stub_for_module(module: str, output_dir: str, quiet: bool = False,
         target = os.path.join(output_dir, target)
         generate_stub(module_path, output_dir, module_all,
                       target=target, add_header=add_header, module=module,
-                      pyversion=pyversion)
+                      pyversion=pyversion, include_private=include_private)
     if not quiet:
         print('Created %s' % target)
 
@@ -185,7 +187,8 @@ def load_python_module_info(module: str, interpreter: str) -> Tuple[str, Optiona
 
 def generate_stub(path: str, output_dir: str, _all_: Optional[List[str]] = None,
                   target: str = None, add_header: bool = False, module: str = None,
-                  pyversion: Tuple[int, int] = defaults.PYTHON3_VERSION
+                  pyversion: Tuple[int, int] = defaults.PYTHON3_VERSION,
+                  include_private: bool = False
                   ) -> None:
     with open(path, 'rb') as f:
         source = f.read()
@@ -199,7 +202,7 @@ def generate_stub(path: str, output_dir: str, _all_: Optional[List[str]] = None,
             sys.stderr.write('%s\n' % m)
         sys.exit(1)
 
-    gen = StubGenerator(_all_, pyversion=pyversion)
+    gen = StubGenerator(_all_, pyversion=pyversion, include_private=include_private)
     ast.accept(gen)
     if not target:
         target = os.path.join(output_dir, os.path.basename(path))
@@ -223,7 +226,8 @@ NOT_IN_ALL = 'NOT_IN_ALL'
 
 
 class StubGenerator(mypy.traverser.TraverserVisitor):
-    def __init__(self, _all_: Optional[List[str]], pyversion: Tuple[int, int]) -> None:
+    def __init__(self, _all_: Optional[List[str]], pyversion: Tuple[int, int],
+                 include_private: bool = False) -> None:
         self._all_ = _all_
         self._output = []  # type: List[str]
         self._import_lines = []  # type: List[str]
@@ -235,6 +239,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         self._classes = set()  # type: Set[str]
         self._base_classes = []  # type: List[str]
         self._pyversion = pyversion
+        self._include_private = include_private
 
     def visit_mypy_file(self, o: MypyFile) -> None:
         self._classes = find_classes(o)
@@ -515,6 +520,8 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         return False
 
     def is_private_name(self, name: str) -> bool:
+        if self._include_private:
+            return False
         return name.startswith('_') and (not name.endswith('__')
                                          or name in ('__all__',
                                                      '__author__',
@@ -636,7 +643,8 @@ def main() -> None:
                                      pyversion=options.pyversion,
                                      no_import=options.no_import,
                                      search_path=options.search_path,
-                                     interpreter=options.interpreter)
+                                     interpreter=options.interpreter,
+                                     include_private=options.include_private)
         except Exception as e:
             if not options.ignore_errors:
                 raise e
@@ -644,8 +652,9 @@ def main() -> None:
                 print("Stub generation failed for", module, file=sys.stderr)
 
 
-def parse_options() -> Options:
-    args = sys.argv[1:]
+def parse_options(args: Optional[List[str]] = None) -> Options:
+    if args is None:
+        args = sys.argv[1:]
     pyversion = defaults.PYTHON3_VERSION
     no_import = False
     recursive = False
@@ -653,6 +662,7 @@ def parse_options() -> Options:
     doc_dir = ''
     search_path = []  # type: List[str]
     interpreter = ''
+    include_private = False
     while args and args[0].startswith('-'):
         if args[0] == '--doc-dir':
             doc_dir = args[1]
@@ -673,6 +683,8 @@ def parse_options() -> Options:
             pyversion = defaults.PYTHON2_VERSION
         elif args[0] == '--no-import':
             no_import = True
+        elif args[0] == '--include-private':
+            include_private = True
         elif args[0] in ('-h', '--help'):
             usage()
         else:
@@ -689,7 +701,8 @@ def parse_options() -> Options:
                    interpreter=interpreter,
                    modules=args,
                    ignore_errors=ignore_errors,
-                   recursive=recursive)
+                   recursive=recursive,
+                   include_private=include_private)
 
 
 def default_python2_interpreter() -> str:
@@ -721,6 +734,9 @@ def usage() -> None:
           --no-import     don't import the modules, just parse and analyze them
                           (doesn't work with C extension modules and doesn't
                           respect __all__)
+          --include-private
+                          generate stubs for objects and members considered private
+                          (single leading undescore and no trailing underscores)
           --doc-dir PATH  use .rst documentation in PATH (this may result in
                           better stubs in some cases; consider setting this to
                           DIR/Python-X.Y.Z/Doc/library)

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 import tempfile
 import time
+import re
 from types import ModuleType
 
 from typing import List, Tuple
@@ -104,12 +105,13 @@ class StubgenPythonSuite(Suite):
         return c
 
 
-def parse_args(line: str) -> Options:
-    if line.startswith('# opts:'):
-        opts = line[7:].strip().split()
+def parse_flags(program_text: str) -> Options:
+    flags = re.search('# flags: (.*)$', program_text, flags=re.MULTILINE)
+    if flags:
+        flag_list = flags.group(1).split()
     else:
-        opts = []
-    return parse_options(opts + ['dummy.py'])
+        flag_list = []
+    return parse_options(flag_list + ['dummy.py'])
 
 
 def test_stubgen(testcase: DataDrivenTestCase) -> None:
@@ -117,7 +119,7 @@ def test_stubgen(testcase: DataDrivenTestCase) -> None:
         sys.path.insert(0, 'stubgen-test-path')
     os.mkdir('stubgen-test-path')
     source = '\n'.join(testcase.input)
-    options = parse_args(testcase.input[0] if testcase.input else '')
+    options = parse_flags(source)
     handle = tempfile.NamedTemporaryFile(prefix='prog_', suffix='.py', dir='stubgen-test-path',
                                          delete=False)
     assert os.path.isabs(handle.name)

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -125,24 +125,51 @@ class A: ...
 [out]
 class A: ...
 
-[case testPrivateFunction]
+[case testSkipPrivateFunction]
 def _f(): ...
 def g(): ...
 [out]
 def g(): ...
 
-[case testPrivateMethod]
+[case testIncludePrivateFunction]
+# opts: --include-private
+def _f(): ...
+def g(): ...
+[out]
+def _f(): ...
+def g(): ...
+
+[case testSkipPrivateMethod]
 class A:
     def _f(self): ...
 [out]
 class A: ...
 
-[case testPrivateVar]
+[case testIncludePrivateMethod]
+# opts: --include-private
+class A:
+    def _f(self): ...
+[out]
+class A:
+    def _f(self): ...
+
+[case testSkipPrivateVar]
 _x = 1
 class A:
     _y = 1
 [out]
 class A: ...
+
+[case testIncludePrivateVar]
+# opts: --include-private
+_x = 1
+class A:
+    _y = 1
+[out]
+_x = ...  # type: int
+
+class A:
+    _y = ...  # type: int
 
 [case testSpecialInternalVar]
 __all__ = []
@@ -309,7 +336,7 @@ class A:
     x = ...  # type: int
     def f(self): ...
 
-[case testMultiplePrivateDefs]
+[case testSkipMultiplePrivateDefs]
 class A: ...
 _x = 1
 _y = 1
@@ -317,6 +344,22 @@ _z = 1
 class C: ...
 [out]
 class A: ...
+class C: ...
+
+[case testIncludeMultiplePrivateDefs]
+# opts: --include-private
+class A: ...
+_x = 1
+_y = 1
+_z = 1
+class C: ...
+[out]
+class A: ...
+
+_x = ...  # type: int
+_y = ...  # type: int
+_z = ...  # type: int
+
 class C: ...
 
 [case testIncludeFromImportIfInAll_import]
@@ -396,6 +439,16 @@ class A:
 [out]
 class A: ...
 
+[case testIncludePrivateProperty]
+# opts: --include-private
+class A:
+    @property
+    def _foo(self): ...
+[out]
+class A:
+    @property
+    def _foo(self): ...
+
 [case testSkipPrivateStaticAndClassMethod]
 class A:
     @staticmethod
@@ -404,6 +457,20 @@ class A:
     def _bar(cls): ...
 [out]
 class A: ...
+
+[case testIncludePrivateStaticAndClassMethod]
+# opts: --include-private
+class A:
+    @staticmethod
+    def _foo(): ...
+    @classmethod
+    def _bar(cls): ...
+[out]
+class A:
+    @staticmethod
+    def _foo(): ...
+    @classmethod
+    def _bar(cls): ...
 
 [case testNamedtuple]
 import collections, x

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -132,7 +132,7 @@ def g(): ...
 def g(): ...
 
 [case testIncludePrivateFunction]
-# opts: --include-private
+# flags:  --include-private
 def _f(): ...
 def g(): ...
 [out]
@@ -146,7 +146,7 @@ class A:
 class A: ...
 
 [case testIncludePrivateMethod]
-# opts: --include-private
+# flags:  --include-private
 class A:
     def _f(self): ...
 [out]
@@ -161,7 +161,7 @@ class A:
 class A: ...
 
 [case testIncludePrivateVar]
-# opts: --include-private
+# flags:  --include-private
 _x = 1
 class A:
     _y = 1
@@ -347,7 +347,7 @@ class A: ...
 class C: ...
 
 [case testIncludeMultiplePrivateDefs]
-# opts: --include-private
+# flags:  --include-private
 class A: ...
 _x = 1
 _y = 1
@@ -440,7 +440,7 @@ class A:
 class A: ...
 
 [case testIncludePrivateProperty]
-# opts: --include-private
+# flags:  --include-private
 class A:
     @property
     def _foo(self): ...
@@ -459,7 +459,7 @@ class A:
 class A: ...
 
 [case testIncludePrivateStaticAndClassMethod]
-# opts: --include-private
+# flags:  --include-private
 class A:
     @staticmethod
     def _foo(): ...


### PR DESCRIPTION
I've found this option to be useful when generating stubs for some third party modules.  It can also be useful when using stubs for internal use in place of comments annotations in python2.  In this scenario, where stubs are used to type check their corresponding files, you can't omit members.  
