### PR TITLE
Parse each format-string component separately

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -858,8 +858,8 @@ class ASTConverter(ast3.NodeTransformer):  # type: ignore  # typeshed PR #931
         # JoinedStr(expr* values)
         @with_line
         def visit_JoinedStr(self, n: ast3.JoinedStr) -> Expression:
-            """Each of n.values is a str or FormattedValue; we just concatenate
-            them all using ''.join."""
+            # Each of n.values is a str or FormattedValue; we just concatenate
+            # them all using ''.join.
             empty_string = StrExpr('')
             empty_string.set_line(n.lineno, n.col_offset)
             strs_to_join = ListExpr(self.translate_expr_list(n.values))
@@ -874,9 +874,9 @@ class ASTConverter(ast3.NodeTransformer):  # type: ignore  # typeshed PR #931
         # FormattedValue(expr value)
         @with_line
         def visit_FormattedValue(self, n: ast3.FormattedValue) -> Expression:
-            """A FormattedValue is a component of a JoinedStr, or it can exist
-            on its own. We translate them to individual '{}'.format(value)
-            calls -- we don't bother with the conversion/format_spec fields."""
+            # A FormattedValue is a component of a JoinedStr, or it can exist
+            # on its own. We translate them to individual '{}'.format(value)
+            # calls -- we don't bother with the conversion/format_spec fields.
             exp = self.visit(n.value)
             exp.set_line(n.lineno, n.col_offset)
             format_string = StrExpr('{}')

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -858,22 +858,35 @@ class ASTConverter(ast3.NodeTransformer):  # type: ignore  # typeshed PR #931
         # JoinedStr(expr* values)
         @with_line
         def visit_JoinedStr(self, n: ast3.JoinedStr) -> Expression:
-            arg_count = len(n.values)
-            format_string = StrExpr('{}' * arg_count)
-            format_string.set_line(n.lineno, n.col_offset)
-            format_method = MemberExpr(format_string, 'format')
-            format_method.set_line(format_string)
-            format_args = self.translate_expr_list(n.values)
-            format_arg_kinds = [ARG_POS] * arg_count
-            result_expression = CallExpr(format_method,
-                                         format_args,
-                                         format_arg_kinds)
+            """Each of n.values is a str or FormattedValue; we just concatenate
+            them all using ''.join."""
+            empty_string = StrExpr('')
+            empty_string.set_line(n.lineno, n.col_offset)
+            strs_to_join = ListExpr(self.translate_expr_list(n.values))
+            strs_to_join.set_line(empty_string)
+            join_method = MemberExpr(empty_string, 'join')
+            join_method.set_line(empty_string)
+            result_expression = CallExpr(join_method,
+                                         [strs_to_join],
+                                         [ARG_POS])
             return result_expression
 
         # FormattedValue(expr value)
         @with_line
         def visit_FormattedValue(self, n: ast3.FormattedValue) -> Expression:
-            return self.visit(n.value)
+            """A FormattedValue is a component of a JoinedStr, or it can exist
+            on its own. We translate them to individual '{}'.format(value)
+            calls -- we don't bother with the conversion/format_spec fields."""
+            exp = self.visit(n.value)
+            exp.set_line(n.lineno, n.col_offset)
+            format_string = StrExpr('{}')
+            format_string.set_line(n.lineno, n.col_offset)
+            format_method = MemberExpr(format_string, 'format')
+            format_method.set_line(format_string)
+            result_expression = CallExpr(format_method,
+                                         [exp],
+                                         [ARG_POS])
+            return result_expression
 
     # Bytes(bytes s)
     @with_line

--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -147,8 +147,7 @@ f'result: {value:{width}.{precision}}'
 [case testNewSyntaxFStringSingleField]
 # flags: --python-version 3.6
 v = 1
-f'{v}' + ''
-f'{1}' + ''
-f' {v}' + ''
+reveal_type(f'{v}') # E: Revealed type is 'builtins.str'
+reveal_type(f'{1}') # E: Revealed type is 'builtins.str'
 [builtins fixtures/f_string.pyi]
 

--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -119,19 +119,19 @@ f'{type(1)}'
 a: str
 a = f'foobar'
 a = f'{"foobar"}'
-[builtins fixtures/primitives.pyi]
+[builtins fixtures/f_string.pyi]
 
 [case testNewSyntaxFStringExpressionsOk]
 # flags: --python-version 3.6
 f'.{1 + 1}.'
 f'.{1 + 1}.{"foo" + "bar"}'
-[builtins fixtures/primitives.pyi]
+[builtins fixtures/f_string.pyi]
 
 [case testNewSyntaxFStringExpressionsErrors]
 # flags: --python-version 3.6
 f'{1 + ""}'
 f'.{1 + ""}'
-[builtins fixtures/primitives.pyi]
+[builtins fixtures/f_string.pyi]
 [out]
 main:2: error: Unsupported operand types for + ("int" and "str")
 main:3: error: Unsupported operand types for + ("int" and "str")
@@ -142,4 +142,13 @@ value = 10.5142
 width = 10
 precision = 4
 f'result: {value:{width}.{precision}}'
-[builtins fixtures/primitives.pyi]
+[builtins fixtures/f_string.pyi]
+
+[case testNewSyntaxFStringSingleField]
+# flags: --python-version 3.6
+v = 1
+f'{v}' + ''
+f'{1}' + ''
+f' {v}' + ''
+[builtins fixtures/f_string.pyi]
+

--- a/test-data/unit/fixtures/f_string.pyi
+++ b/test-data/unit/fixtures/f_string.pyi
@@ -1,0 +1,41 @@
+# Builtins stub used for format-string-related test cases.
+# We need str and list, and str needs join and format methods.
+
+from typing import TypeVar, Generic, builtinclass, Iterable, Iterator, List, overload
+
+T = TypeVar('T')
+
+@builtinclass
+class object:
+    def __init__(self): pass
+
+class type:
+    def __init__(self, x) -> None: pass
+
+class ellipsis: pass
+
+class list(Iterable[T], Generic[T]):
+    @overload
+    def __init__(self) -> None: pass
+    @overload
+    def __init__(self, x: Iterable[T]) -> None: pass
+    def __iter__(self) -> Iterator[T]: pass
+    def __add__(self, x: list[T]) -> list[T]: pass
+    def __mul__(self, x: int) -> list[T]: pass
+    def __getitem__(self, x: int) -> T: pass
+    def append(self, x: T) -> None: pass
+    def extend(self, x: Iterable[T]) -> None: pass
+
+class tuple(Generic[T]): pass
+
+class function: pass
+class int:
+    def __add__(self, i: int) -> int: pass
+class float: pass
+class bool(int): pass
+
+class str:
+    def __add__(self, s: str) -> str: pass
+    def format(self, *args) -> str: pass
+    def join(self, l: List[str]) -> str: pass
+

--- a/test-data/unit/fixtures/f_string.pyi
+++ b/test-data/unit/fixtures/f_string.pyi
@@ -18,12 +18,7 @@ class list(Iterable[T], Generic[T]):
     def __init__(self) -> None: pass
     @overload
     def __init__(self, x: Iterable[T]) -> None: pass
-    def __iter__(self) -> Iterator[T]: pass
-    def __add__(self, x: list[T]) -> list[T]: pass
-    def __mul__(self, x: int) -> list[T]: pass
-    def __getitem__(self, x: int) -> T: pass
     def append(self, x: T) -> None: pass
-    def extend(self, x: Iterable[T]) -> None: pass
 
 class tuple(Generic[T]): pass
 

--- a/test-data/unit/fixtures/f_string.pyi
+++ b/test-data/unit/fixtures/f_string.pyi
@@ -1,11 +1,10 @@
 # Builtins stub used for format-string-related test cases.
 # We need str and list, and str needs join and format methods.
 
-from typing import TypeVar, Generic, builtinclass, Iterable, Iterator, List, overload
+from typing import TypeVar, Generic, Iterable, Iterator, List, overload
 
 T = TypeVar('T')
 
-@builtinclass
 class object:
     def __init__(self): pass
 
@@ -31,6 +30,7 @@ class tuple(Generic[T]): pass
 class function: pass
 class int:
     def __add__(self, i: int) -> int: pass
+
 class float: pass
 class bool(int): pass
 


### PR DESCRIPTION
Fixes #3385.

The old code evaluated each FormattedValue as an expression potentially returning the type of the value, rather than a string. But that's wrong, because a FormattedValue can exist on its own when it's not being joined to any other format strings + those FormattedValues need type str. The new code evaluates each FormattedValue by synthesizing '{}'.format(expr) and then, if necessary, joins them in JoinedStr using ''.join(items).

I had to create a new unittest fixture for this with list, str, and int.