### PR TITLE
remove @builtinclass from stubs

### DIFF
--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -932,9 +932,10 @@ class A:
 [builtins fixtures/list.pyi]
 
 [case testNoneReturnTypeWithExpressions2]
+import typing
 
 a, b = None, None # type: (A, bool)
-f() in a   # Fail (see output)
+f() in a   # E: "f" does not return a value  # E: Unsupported right operand type for in ("A")
 a < f()    # E: "f" does not return a value
 f() <= a   # E: "f" does not return a value
 a in f()   # E: "f" does not return a value
@@ -948,10 +949,6 @@ class A:
     def __add__(self, x: 'A') -> 'A':
         pass
 [builtins fixtures/bool.pyi]
-[out]
-main:3: error: "f" does not return a value
-main:3: error: Unsupported right operand type for in ("A")
-
 
 -- Slicing
 -- -------

--- a/test-data/unit/fixtures/bool.pyi
+++ b/test-data/unit/fixtures/bool.pyi
@@ -1,8 +1,5 @@
 # builtins stub used in boolean-related test cases.
 
-from typing import builtinclass
-
-@builtinclass
 class object:
     def __init__(self) -> None: pass
 

--- a/test-data/unit/fixtures/function.pyi
+++ b/test-data/unit/fixtures/function.pyi
@@ -1,6 +1,3 @@
-from typing import builtinclass
-
-@builtinclass
 class object:
     def __init__(self): pass
 

--- a/test-data/unit/fixtures/isinstance.pyi
+++ b/test-data/unit/fixtures/isinstance.pyi
@@ -1,4 +1,4 @@
-from typing import builtinclass, Tuple, TypeVar, Generic, Union
+from typing import Tuple, TypeVar, Generic, Union
 
 T = TypeVar('T')
 

--- a/test-data/unit/fixtures/isinstancelist.pyi
+++ b/test-data/unit/fixtures/isinstancelist.pyi
@@ -1,10 +1,8 @@
-from typing import builtinclass, Iterable, Iterator, TypeVar, List, Mapping, overload, Tuple, Set, Union
+from typing import Iterable, Iterator, TypeVar, List, Mapping, overload, Tuple, Set, Union
 
-@builtinclass
 class object:
     def __init__(self) -> None: pass
 
-@builtinclass
 class type:
     def __init__(self, x) -> None: pass
 
@@ -14,12 +12,9 @@ class function: pass
 def isinstance(x: object, t: Union[type, Tuple]) -> bool: pass
 def issubclass(x: object, t: Union[type, Tuple]) -> bool: pass
 
-@builtinclass
 class int:
     def __add__(self, x: int) -> int: pass
-@builtinclass
 class bool(int): pass
-@builtinclass
 class str:
     def __add__(self, x: str) -> str: pass
     def __getitem__(self, x: int) -> str: pass

--- a/test-data/unit/fixtures/list.pyi
+++ b/test-data/unit/fixtures/list.pyi
@@ -1,10 +1,9 @@
 # Builtins stub used in list-related test cases.
 
-from typing import TypeVar, Generic, builtinclass, Iterable, Iterator, overload
+from typing import TypeVar, Generic, Iterable, Iterator, overload
 
 T = TypeVar('T')
 
-@builtinclass
 class object:
     def __init__(self): pass
 

--- a/test-data/unit/fixtures/ops.pyi
+++ b/test-data/unit/fixtures/ops.pyi
@@ -1,10 +1,9 @@
-from typing import builtinclass, overload, Any, Generic, Sequence, Tuple, TypeVar
+from typing import overload, Any, Generic, Sequence, Tuple, TypeVar
 
 Tco = TypeVar('Tco', covariant=True)
 
 # This is an extension of transform builtins with additional operations.
 
-@builtinclass
 class object:
     def __init__(self) -> None: pass
     def __eq__(self, o: 'object') -> 'bool': pass

--- a/test-data/unit/fixtures/type.pyi
+++ b/test-data/unit/fixtures/type.pyi
@@ -1,10 +1,9 @@
 # builtins stub used in type-related test cases.
 
-from typing import builtinclass, Generic, TypeVar, List
+from typing import Generic, TypeVar, List
 
 T = TypeVar('T')
 
-@builtinclass
 class object:
     def __init__(self) -> None: pass
     def __str__(self) -> 'str': pass

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -14,7 +14,6 @@ TypeVar = 0
 Generic = 0
 Tuple = 0
 Callable = 0
-builtinclass = 0
 _promote = 0
 NamedTuple = 0
 Type = 0


### PR DESCRIPTION
This appears to do nothing. My guess is that this is a feature
from an old version of typing that managed to stick around in
mypy.