### PR TITLE
Add line # of previous definition

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3315,7 +3315,7 @@ class SemanticAnalyzer(NodeVisitor):
             elif prev_is_overloaded:
                 self.fail("Definition of '{}' missing 'overload'".format(n), ctx)
             else:
-                self.name_already_defined(n, ctx)
+                self.name_already_defined(n, ctx, self.globals[n])
 
     def name_not_defined(self, name: str, ctx: Context) -> None:
         message = "Name '{}' is not defined".format(name)
@@ -3324,8 +3324,13 @@ class SemanticAnalyzer(NodeVisitor):
             message += ' {}'.format(extra)
         self.fail(message, ctx)
 
-    def name_already_defined(self, name: str, ctx: Context) -> None:
-        self.fail("Name '{}' already defined".format(name), ctx)
+    def name_already_defined(self, name: str, ctx: Context,
+                             original_ctx: Optional[SymbolTableNode] = None) -> None:
+        if original_ctx:
+            extra_msg = ' in line {}'.format(original_ctx.node.get_line())
+        else:
+            extra_msg = ''
+        self.fail("Name '{}' already defined{}".format(name, extra_msg), ctx)
 
     def fail(self, msg: str, ctx: Context, serious: bool = False, *,
              blocker: bool = False) -> None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3327,7 +3327,7 @@ class SemanticAnalyzer(NodeVisitor):
     def name_already_defined(self, name: str, ctx: Context,
                              original_ctx: Optional[SymbolTableNode] = None) -> None:
         if original_ctx:
-            extra_msg = ' in line {}'.format(original_ctx.node.get_line())
+            extra_msg = ' on line {}'.format(original_ctx.node.get_line())
         else:
             extra_msg = ''
         self.fail("Name '{}' already defined{}".format(name, extra_msg), ctx)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -714,7 +714,7 @@ A()
 class A: pass
 class A: pass
 [out]
-main:4: error: Name 'A' already defined in line 3
+main:4: error: Name 'A' already defined on line 3
 
 [case testDocstringInClass]
 import typing

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -714,7 +714,7 @@ A()
 class A: pass
 class A: pass
 [out]
-main:4: error: Name 'A' already defined
+main:4: error: Name 'A' already defined in line 3
 
 [case testDocstringInClass]
 import typing

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1212,7 +1212,7 @@ from typing import Any
 x = None # type: Any
 if x:
     def f(): pass
-def f(): pass # E: Name 'f' already defined
+def f(): pass # E: Name 'f' already defined in line 4
 
 [case testIncompatibleConditionalFunctionDefinition]
 from typing import Any
@@ -1835,7 +1835,7 @@ f = g # E: Incompatible types in assignment (expression has type Callable[[Any, 
 
 [case testRedefineFunction2]
 def f() -> None: pass
-def f() -> None: pass # E: Name 'f' already defined
+def f() -> None: pass # E: Name 'f' already defined in line 1
 
 
 -- Special cases

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1212,7 +1212,7 @@ from typing import Any
 x = None # type: Any
 if x:
     def f(): pass
-def f(): pass # E: Name 'f' already defined in line 4
+def f(): pass # E: Name 'f' already defined on line 4
 
 [case testIncompatibleConditionalFunctionDefinition]
 from typing import Any
@@ -1835,7 +1835,7 @@ f = g # E: Incompatible types in assignment (expression has type Callable[[Any, 
 
 [case testRedefineFunction2]
 def f() -> None: pass
-def f() -> None: pass # E: Name 'f' already defined in line 1
+def f() -> None: pass # E: Name 'f' already defined on line 1
 
 
 -- Special cases

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1106,7 +1106,7 @@ def f(a: int) -> None: pass
 def f(a: str) -> None: pass
 [out]
 tmp/foo.pyi:2: error: Single overload definition, multiple required
-tmp/foo.pyi:5: error: Name 'f' already defined
+tmp/foo.pyi:5: error: Name 'f' already defined in line 2
 
 [case testOverloadTuple]
 from foo import *

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1106,7 +1106,7 @@ def f(a: int) -> None: pass
 def f(a: str) -> None: pass
 [out]
 tmp/foo.pyi:2: error: Single overload definition, multiple required
-tmp/foo.pyi:5: error: Name 'f' already defined in line 2
+tmp/foo.pyi:5: error: Name 'f' already defined on line 2
 
 [case testOverloadTuple]
 from foo import *

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -165,7 +165,7 @@ import typing
 class A: pass
 class A: pass
 [out]
-main:3: error: Name 'A' already defined
+main:3: error: Name 'A' already defined in line 2
 
 [case testMultipleMixedDefinitions]
 import typing
@@ -173,8 +173,8 @@ x = 1
 def x(): pass
 class x: pass
 [out]
-main:3: error: Name 'x' already defined
-main:4: error: Name 'x' already defined
+main:3: error: Name 'x' already defined in line 2
+main:4: error: Name 'x' already defined in line 2
 
 [case testNameNotImported]
 import typing
@@ -1037,13 +1037,13 @@ t = 1 # E: Invalid assignment target
 [case testRedefineTypevar2]
 from typing import TypeVar
 t = TypeVar('t')
-def t(): pass # E: Name 't' already defined
+def t(): pass # E: Name 't' already defined in line 2
 [out]
 
 [case testRedefineTypevar3]
 from typing import TypeVar
 t = TypeVar('t')
-class t: pass # E: Name 't' already defined
+class t: pass # E: Name 't' already defined in line 2
 [out]
 
 [case testRedefineTypevar4]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -165,7 +165,7 @@ import typing
 class A: pass
 class A: pass
 [out]
-main:3: error: Name 'A' already defined in line 2
+main:3: error: Name 'A' already defined on line 2
 
 [case testMultipleMixedDefinitions]
 import typing
@@ -173,8 +173,8 @@ x = 1
 def x(): pass
 class x: pass
 [out]
-main:3: error: Name 'x' already defined in line 2
-main:4: error: Name 'x' already defined in line 2
+main:3: error: Name 'x' already defined on line 2
+main:4: error: Name 'x' already defined on line 2
 
 [case testNameNotImported]
 import typing
@@ -1037,13 +1037,13 @@ t = 1 # E: Invalid assignment target
 [case testRedefineTypevar2]
 from typing import TypeVar
 t = TypeVar('t')
-def t(): pass # E: Name 't' already defined in line 2
+def t(): pass # E: Name 't' already defined on line 2
 [out]
 
 [case testRedefineTypevar3]
 from typing import TypeVar
 t = TypeVar('t')
-class t: pass # E: Name 't' already defined in line 2
+class t: pass # E: Name 't' already defined on line 2
 [out]
 
 [case testRedefineTypevar4]


### PR DESCRIPTION
*Partial* fix for #1874 - just improve the error message. The duplicate definitions in different if/else branches are still not allowed.