### PR TITLE
tear_down tests when KeyboardInterrupt

### DIFF
--- a/mypy/myunit/__init__.py
+++ b/mypy/myunit/__init__.py
@@ -293,6 +293,7 @@ def run_single_test(name: str, test: Any) -> Tuple[bool, bool]:
         test.run()
     except BaseException as e:
         if isinstance(e, KeyboardInterrupt):
+            test.tear_down()
             raise
         exc_type, exc_value, exc_traceback = sys.exc_info()
     test.tear_down()  # FIX: check exceptions

--- a/mypy/myunit/__init__.py
+++ b/mypy/myunit/__init__.py
@@ -293,10 +293,10 @@ def run_single_test(name: str, test: Any) -> Tuple[bool, bool]:
         test.run()
     except BaseException as e:
         if isinstance(e, KeyboardInterrupt):
-            test.tear_down()
             raise
         exc_type, exc_value, exc_traceback = sys.exc_info()
-    test.tear_down()  # FIX: check exceptions
+    finally:
+        test.tear_down()
     times.append((time.time() - time0, name))
 
     if exc_traceback:


### PR DESCRIPTION
This is a small fix that I encountered. If you start running tests, and KeyboardInterrupt, the tmp-test-dir has leftover data, as the test is not cleaned up. Jukka suggested assuring that the test was cleaned up as a solution.