### PR TITLE
fix flake8-pyi python_version conditional in test-requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 flake8
 flake8-bugbear; python_version >= '3.5'
-flake8-pyi; python_version >= '3.5'
+flake8-pyi; python_version >= '3.6'
 lxml; sys_platform != 'win32' or python_version == '3.5' or python_version == '3.6'
 typed-ast>=1.0.3,<1.1.0; sys_platform != 'win32' or python_version >= '3.5'
 pytest>=2.8


### PR DESCRIPTION
flake8-pyi only works with 3.6 right now, so installing it alongside
python3.5 results in a test failure when it is imported.