### PR TITLE
run tests on one version of Python on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,9 @@
 environment:
   matrix:
 
-    - PYTHON: "C:\\Python36"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
-
 
 install:
     - "git config core.symlinks true"


### PR DESCRIPTION
After discussing with @ddfisher, we concurred that we only need to build on one bitness of Python. The appveyor script is already building for both bitnesses, we are just doing it twice :^)