### PR TITLE
Disallow implicit Any types from Silent Imports

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1387,9 +1387,7 @@ class State:
         """
         # TODO: See if it's possible to move this check directly into parse_file in some way.
         # TODO: Find a way to write a test case for this fix.
-        silent_mode = (self.options.ignore_missing_imports or
-                       self.options.follow_imports == 'skip')
-        if not silent_mode:
+        if not self.options.silent_mode():
             return
 
         new_suppressed = []

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1387,7 +1387,9 @@ class State:
         """
         # TODO: See if it's possible to move this check directly into parse_file in some way.
         # TODO: Find a way to write a test case for this fix.
-        if not self.options.silent_mode():
+        silent_mode = (self.options.disallow_implicit_any_types or
+                       self.options.follow_imports == 'skip')
+        if not silent_mode:
             return
 
         new_suppressed = []

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1387,7 +1387,7 @@ class State:
         """
         # TODO: See if it's possible to move this check directly into parse_file in some way.
         # TODO: Find a way to write a test case for this fix.
-        silent_mode = (self.options.disallow_implicit_any_types or
+        silent_mode = (self.options.ignore_missing_imports or
                        self.options.follow_imports == 'skip')
         if not silent_mode:
             return

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -614,15 +614,18 @@ class TypeChecker(NodeVisitor[None]):
                                 self.fail(messages.ARGUMENT_TYPE_EXPECTED, fdef)
                     if self.options.disallow_implicit_any_types:
                         if fdef.type and isinstance(fdef.type, CallableType):
-                            if has_any_from_silent_import(fdef.type.ret_type):
+                            ret_type = fdef.type.ret_type
+                            if has_any_from_silent_import(ret_type):
+                                type_name = self.msg.format(ret_type)
                                 self.fail("Return type is implicitly converted to "
-                                          "'{}' due to import from "
-                                          "unanalyzed module".format(fdef.type.ret_type), fdef)
+                                          "{} due to import from "
+                                          "unanalyzed module".format(type_name), fdef)
                             for idx, arg_type in enumerate(fdef.type.arg_types):
                                 if has_any_from_silent_import(arg_type):
-                                    self.fail("Argument {} to '{}' is implicitly converted to "
-                                              "'{}' due to import from unanalyzed "
-                                              "module".format(idx + 1, fdef.name(), arg_type),
+                                    arg_type_name = self.msg.format(arg_type)
+                                    self.fail("Argument {} to \"{}\" is implicitly converted to "
+                                              "{} due to import from unanalyzed "
+                                              "module".format(idx + 1, fdef.name(), arg_type_name),
                                               fdef)
 
                 if name in nodes.reverse_op_method_set:
@@ -1721,8 +1724,9 @@ class TypeChecker(NodeVisitor[None]):
                 self.msg.deleted_as_lvalue(lvalue_type, context)
             elif (self.options.disallow_implicit_any_types
                   and has_any_from_silent_import(lvalue_type)):
-                self.msg.fail("Type of {} is implicitly converted to '{}' due to import from "
-                              "unanalyzed module".format(lvalue_name, lvalue_type), context)
+                type_name = self.msg.format(lvalue_type)
+                self.msg.fail("Type of {} is implicitly converted to {} due to import from "
+                              "unanalyzed module".format(lvalue_name, type_name), context)
             else:
                 self.check_subtype(rvalue_type, lvalue_type, context, msg,
                                    '{} has type'.format(rvalue_name),

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1193,7 +1193,9 @@ class TypeChecker(NodeVisitor[None]):
         if (s.type is not None and
                 self.options.disallow_implicit_any_types and
                 has_any_from_silent_import(s.type)):
-            if isinstance(s.lvalues[-1], TupleExpr):  # is multiple
+            if isinstance(s.lvalues[-1], TupleExpr):
+                # This is a multiple assignment. Instead of figuring out which type is problematic,
+                # give a generic error message.
                 self.msg.fail(messages.IMPLICIT_CONVERT_TO_ANY_SILENT_IMPORT, s)
             else:
                 self.msg.implicit_any_from_silent_import("Type of variable", s.type, s)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -29,6 +29,7 @@ from mypy.nodes import (
     ARG_POS, MDEF,
     CONTRAVARIANT, COVARIANT)
 from mypy import nodes
+from mypy.typeanal import has_any_from_silent_import
 from mypy.types import (
     Type, AnyType, CallableType, FunctionLike, Overloaded, TupleType, TypedDictType,
     Instance, NoneTyp, strip_type, TypeType,
@@ -611,6 +612,18 @@ class TypeChecker(NodeVisitor[None]):
                                 self.fail(messages.RETURN_TYPE_EXPECTED, fdef)
                             if any(is_implicit_any(t) for t in fdef.type.arg_types):
                                 self.fail(messages.ARGUMENT_TYPE_EXPECTED, fdef)
+                    if self.options.disallow_implicit_any_types:
+                        if fdef.type and isinstance(fdef.type, CallableType):
+                            if has_any_from_silent_import(fdef.type.ret_type):
+                                self.fail("Return type is implicitly converted to "
+                                          "'{}' due to import from "
+                                          "unanalyzed module".format(fdef.type.ret_type), fdef)
+                            for idx, arg_type in enumerate(fdef.type.arg_types):
+                                if has_any_from_silent_import(arg_type):
+                                    self.fail("Argument {} to '{}' is implicitly converted to "
+                                              "'{}' due to import from unanalyzed "
+                                              "module".format(idx + 1, fdef.name(), arg_type),
+                                              fdef)
 
                 if name in nodes.reverse_op_method_set:
                     self.check_reverse_op_method(item, typ, name)
@@ -1706,6 +1719,10 @@ class TypeChecker(NodeVisitor[None]):
                 self.msg.deleted_as_rvalue(rvalue_type, context)
             if isinstance(lvalue_type, DeletedType):
                 self.msg.deleted_as_lvalue(lvalue_type, context)
+            elif (self.options.disallow_implicit_any_types
+                  and has_any_from_silent_import(lvalue_type)):
+                self.msg.fail("Type of {} is implicitly converted to '{}' due to import from "
+                              "unanalyzed module".format(lvalue_name, lvalue_type), context)
             else:
                 self.check_subtype(rvalue_type, lvalue_type, context, msg,
                                    '{} has type'.format(rvalue_name),

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -616,18 +616,13 @@ class TypeChecker(NodeVisitor[None]):
                         if fdef.type and isinstance(fdef.type, CallableType):
                             ret_type = fdef.type.ret_type
                             if has_any_from_silent_import(ret_type):
-                                type_name = self.msg.format(ret_type)
-                                self.fail("Return type is implicitly converted to "
-                                          "{} due to import from "
-                                          "unanalyzed module".format(type_name), fdef)
+                                self.msg.implicit_any_from_silent_import("Return type", ret_type,
+                                                                         fdef)
                             for idx, arg_type in enumerate(fdef.type.arg_types):
                                 if has_any_from_silent_import(arg_type):
-                                    arg_type_name = self.msg.format(arg_type)
-                                    self.fail("Argument {} to \"{}\" is implicitly converted to "
-                                              "{} due to import from unanalyzed "
-                                              "module".format(idx + 1, fdef.name(), arg_type_name),
-                                              fdef)
-
+                                    prefix = "Argument {} to \"{}\"".format(idx + 1, fdef.name())
+                                    self.msg.implicit_any_from_silent_import(prefix, arg_type,
+                                                                             fdef)
                 if name in nodes.reverse_op_method_set:
                     self.check_reverse_op_method(item, typ, name)
                 elif name in ('__getattr__', '__getattribute__'):
@@ -1724,9 +1719,8 @@ class TypeChecker(NodeVisitor[None]):
                 self.msg.deleted_as_lvalue(lvalue_type, context)
             elif (self.options.disallow_implicit_any_types
                   and has_any_from_silent_import(lvalue_type)):
-                type_name = self.msg.format(lvalue_type)
-                self.msg.fail("Type of {} is implicitly converted to {} due to import from "
-                              "unanalyzed module".format(lvalue_name, type_name), context)
+                prefix = "Type of {}".format(lvalue_name)
+                self.msg.implicit_any_from_silent_import(prefix, lvalue_type, context)
             else:
                 self.check_subtype(rvalue_type, lvalue_type, context, msg,
                                    '{} has type'.format(rvalue_name),

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from typing import cast, Dict, Set, List, Tuple, Callable, Union, Optional
 
 from mypy.errors import report_internal_error
-from mypy.typeanal import has_any_from_silent_import
+from mypy.typeanal import has_any_from_unimported_type
 from mypy.types import (
     Type, AnyType, CallableType, Overloaded, NoneTyp, TypeVarDef,
     TupleType, TypedDictType, Instance, TypeVarType, ErasedType, UnionType,
@@ -1547,8 +1547,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         options = self.chk.options
         if options.warn_redundant_casts and is_same_type(source_type, target_type):
             self.msg.redundant_cast(target_type, expr)
-        if options.disallow_implicit_any_types and has_any_from_silent_import(target_type):
-            self.msg.implicit_any_from_silent_import("Target type of cast", target_type, expr)
+        if 'unimported' in options.disallow_any and has_any_from_unimported_type(target_type):
+            self.msg.unimported_type_becomes_any("Target type of cast", target_type, expr)
         return target_type
 
     def visit_reveal_type_expr(self, expr: RevealTypeExpr) -> Type:
@@ -2235,9 +2235,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def visit_namedtuple_expr(self, e: NamedTupleExpr) -> Type:
         tuple_type = e.info.tuple_type
         if tuple_type:
-            if (self.chk.options.disallow_implicit_any_types and
-                    has_any_from_silent_import(tuple_type)):
-                self.msg.implicit_any_from_silent_import("NamedTuple type", tuple_type, e)
+            if ('unimported' in self.chk.options.disallow_any and
+                    has_any_from_unimported_type(tuple_type)):
+                self.msg.unimported_type_becomes_any("NamedTuple type", tuple_type, e)
         # TODO: Perhaps return a type object type?
         return AnyType()
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from typing import cast, Dict, Set, List, Tuple, Callable, Union, Optional
 
 from mypy.errors import report_internal_error
+from mypy.typeanal import has_any_from_silent_import
 from mypy.types import (
     Type, AnyType, CallableType, Overloaded, NoneTyp, TypeVarDef,
     TupleType, TypedDictType, Instance, TypeVarType, ErasedType, UnionType,
@@ -1543,8 +1544,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Type check a cast expression."""
         source_type = self.accept(expr.expr, type_context=AnyType(), allow_none_return=True)
         target_type = expr.type
-        if self.chk.options.warn_redundant_casts and is_same_type(source_type, target_type):
+        options = self.chk.options
+        if options.warn_redundant_casts and is_same_type(source_type, target_type):
             self.msg.redundant_cast(target_type, expr)
+        if options.disallow_implicit_any_types and has_any_from_silent_import(target_type):
+            self.msg.implicit_any_from_silent_import("Target type of cast", target_type, expr)
         return target_type
 
     def visit_reveal_type_expr(self, expr: RevealTypeExpr) -> Type:
@@ -2229,6 +2233,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return AnyType()
 
     def visit_namedtuple_expr(self, e: NamedTupleExpr) -> Type:
+        tuple_type = e.info.tuple_type
+        if tuple_type:
+            if (self.chk.options.disallow_implicit_any_types and
+                    has_any_from_silent_import(tuple_type)):
+                self.msg.implicit_any_from_silent_import("NamedTuple type", tuple_type, e)
         # TODO: Perhaps return a type object type?
         return AnyType()
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -205,15 +205,15 @@ def process_options(args: List[str],
             strict_flag_assignments.append((dest, not default))
 
     def disallow_any_argument_type(raw_options: str) -> List[str]:
-        options = raw_options.split(',')
-        for option in options:
+        flag_options = raw_options.split(',')
+        for option in flag_options:
             if option not in disallow_any_options:
                 formatted_valid_options = ', '.join(
-                    "'{}'".format(option) for option in disallow_any_options)
+                    "'{}'".format(o) for o in disallow_any_options)
                 message = "Invalid '--disallow-any' option '{}' (valid options are: {}).".format(
                     option, formatted_valid_options)
                 raise argparse.ArgumentError(None, message)
-        return options
+        return flag_options
 
     # Unless otherwise specified, arguments will be parsed directly onto an
     # Options object.  Options that require further processing should have

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -179,7 +179,7 @@ def process_options(args: List[str],
 
     strict_flag_names = []  # type: List[str]
     strict_flag_assignments = []  # type: List[Tuple[str, bool]]
-    valid_disallow_any_options = {'unimported'}
+    disallow_any_options = ['unimported']
 
     def add_invertible_flag(flag: str,
                             *,
@@ -205,14 +205,15 @@ def process_options(args: List[str],
             strict_flag_assignments.append((dest, not default))
 
     def disallow_any_argument_type(raw_options: str) -> List[str]:
-        current_options = raw_options.split(',')
-        for option in current_options:
-            if option not in valid_disallow_any_options:
-                formatted_opts = ', '.join(map("'{}'".format, valid_disallow_any_options))
-                message = "Unrecognized option '{}' (valid options are: {}).".format(
-                    option, formatted_opts)
+        options = raw_options.split(',')
+        for option in options:
+            if option not in disallow_any_options:
+                formatted_valid_options = ', '.join(
+                    "'{}'".format(option) for option in disallow_any_options)
+                message = "Invalid '--disallow-any' option '{}' (valid options are: {}).".format(
+                    option, formatted_valid_options)
                 raise argparse.ArgumentError(None, message)
-        return current_options
+        return options
 
     # Unless otherwise specified, arguments will be parsed directly onto an
     # Options object.  Options that require further processing should have
@@ -234,7 +235,7 @@ def process_options(args: List[str],
     parser.add_argument('--follow-imports', choices=['normal', 'silent', 'skip', 'error'],
                         default='normal', help="how to treat imports (default normal)")
     parser.add_argument('--disallow-any', type=disallow_any_argument_type, default=[],
-                        metavar='{{{}}}'.format(', '.join(valid_disallow_any_options)),
+                        metavar='{{{}}}'.format(', '.join(disallow_any_options)),
                         help="disallow various types of Any in a module. Takes a comma-separated "
                              "list of options (defaults to all options disabled)")
     add_invertible_flag('--disallow-untyped-calls', default=False, strict_flag=True,

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -222,6 +222,9 @@ def process_options(args: List[str],
                         help="silently ignore imports of missing modules")
     parser.add_argument('--follow-imports', choices=['normal', 'silent', 'skip', 'error'],
                         default='normal', help="how to treat imports (default normal)")
+    parser.add_argument('--disallow-implicit-any-types', action='store_true',
+                        help="disallow implicit conversion of types from unanalyzed modules"
+                             " into Any")
     add_invertible_flag('--disallow-untyped-calls', default=False, strict_flag=True,
                         help="disallow calling functions without type annotations"
                         " from functions with type annotations")

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -88,8 +88,6 @@ MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'
 NON_BOOLEAN_IN_CONDITIONAL = 'Condition must be a boolean'
 DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'
 GENERIC_INSTANCE_VAR_CLASS_ACCESS = 'Access to generic instance variables via class is ambiguous'
-IMPLICIT_CONVERT_TO_ANY_SILENT_IMPORT = 'A type on this line is implicitly converted to "Any" ' \
-                                        'due to import from unanalyzed module'
 
 ARG_CONSTRUCTOR_NAMES = {
     ARG_POS: "Arg",
@@ -857,9 +855,10 @@ class MessageBuilder:
     def redundant_cast(self, typ: Type, context: Context) -> None:
         self.note('Redundant cast to {}'.format(self.format(typ)), context)
 
-    def implicit_any_from_silent_import(self, prefix: str, typ: Type, ctx: Context) -> None:
-        self.fail("{} is implicitly converted to {} due to import from unanalyzed module".format(
-            prefix, self.format(typ)), ctx)
+    def unimported_type_becomes_any(self, prefix: str, typ: Type, ctx: Context) -> None:
+        self.fail("{} becomes {} due to an unfollowed import (such imports occur either "
+                  "when the imported module does not exist or when --follow-imports=skip "
+                  "is set)".format(prefix, self.format(typ)), ctx)
 
     def typeddict_instantiated_with_unexpected_items(self,
                                                      expected_item_names: List[str],

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -856,9 +856,8 @@ class MessageBuilder:
         self.note('Redundant cast to {}'.format(self.format(typ)), context)
 
     def unimported_type_becomes_any(self, prefix: str, typ: Type, ctx: Context) -> None:
-        self.fail("{} becomes {} due to an unfollowed import (such imports occur either "
-                  "when the imported module does not exist or when --follow-imports=skip "
-                  "is set)".format(prefix, self.format(typ)), ctx)
+        self.fail("{} becomes {} due to an unfollowed import".format(prefix, self.format(typ)),
+                  ctx)
 
     def typeddict_instantiated_with_unexpected_items(self,
                                                      expected_item_names: List[str],

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -88,6 +88,8 @@ MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'
 NON_BOOLEAN_IN_CONDITIONAL = 'Condition must be a boolean'
 DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'
 GENERIC_INSTANCE_VAR_CLASS_ACCESS = 'Access to generic instance variables via class is ambiguous'
+IMPLICIT_CONVERT_TO_ANY_SILENT_IMPORT = 'A type on this line is implicitly converted to "Any" ' \
+                                        'due to import from unanalyzed module'
 
 ARG_CONSTRUCTOR_NAMES = {
     ARG_POS: "Arg",

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -855,6 +855,10 @@ class MessageBuilder:
     def redundant_cast(self, typ: Type, context: Context) -> None:
         self.note('Redundant cast to {}'.format(self.format(typ)), context)
 
+    def implicit_any_from_silent_import(self, prefix: str, typ: Type, ctx: Context) -> None:
+        self.fail("{} is implicitly converted to {} due to import from unanalyzed module".format(
+            prefix, self.format(typ)), ctx)
+
     def typeddict_instantiated_with_unexpected_items(self,
                                                      expected_item_names: List[str],
                                                      actual_item_names: List[str],

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -2,7 +2,7 @@ import fnmatch
 import pprint
 import sys
 
-from typing import Any, Mapping, Optional, Tuple, List, Pattern, Dict
+from typing import Mapping, Optional, Tuple, List, Pattern, Dict
 
 from mypy import defaults
 
@@ -19,7 +19,7 @@ class Options:
     PER_MODULE_OPTIONS = {
         "ignore_missing_imports",
         "follow_imports",
-        "disallow_implicit_any_types",
+        "disallow_any",
         "disallow_untyped_calls",
         "disallow_untyped_defs",
         "check_untyped_defs",
@@ -45,7 +45,7 @@ class Options:
         self.report_dirs = {}  # type: Dict[str, str]
         self.ignore_missing_imports = False
         self.follow_imports = 'normal'  # normal|silent|skip|error
-        self.disallow_implicit_any_types = False
+        self.disallow_any = []  # type: List[str]
 
         # Disallow calling untyped functions from typed ones
         self.disallow_untyped_calls = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -19,6 +19,7 @@ class Options:
     PER_MODULE_OPTIONS = {
         "ignore_missing_imports",
         "follow_imports",
+        "disallow_implicit_any_types",
         "disallow_untyped_calls",
         "disallow_untyped_defs",
         "check_untyped_defs",
@@ -44,6 +45,7 @@ class Options:
         self.report_dirs = {}  # type: Dict[str, str]
         self.ignore_missing_imports = False
         self.follow_imports = 'normal'  # normal|silent|skip|error
+        self.disallow_implicit_any_types = False
 
         # Disallow calling untyped functions from typed ones
         self.disallow_untyped_calls = False
@@ -158,3 +160,6 @@ class Options:
 
     def select_options_affecting_cache(self) -> Mapping[str, bool]:
         return {opt: getattr(self, opt) for opt in self.OPTIONS_AFFECTING_CACHE}
+
+    def silent_mode(self) -> bool:
+        return self.ignore_missing_imports or self.follow_imports == 'skip'

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -160,6 +160,3 @@ class Options:
 
     def select_options_affecting_cache(self) -> Mapping[str, bool]:
         return {opt: getattr(self, opt) for opt in self.OPTIONS_AFFECTING_CACHE}
-
-    def silent_mode(self) -> bool:
-        return self.ignore_missing_imports or self.follow_imports == 'skip'

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -75,7 +75,7 @@ from mypy.typevars import has_no_typevars, fill_typevars
 from mypy.visitor import NodeVisitor
 from mypy.traverser import TraverserVisitor
 from mypy.errors import Errors, report_internal_error
-from mypy.messages import CANNOT_ASSIGN_TO_TYPE
+from mypy.messages import CANNOT_ASSIGN_TO_TYPE, MessageBuilder
 from mypy.types import (
     NoneTyp, CallableType, Overloaded, Instance, Type, TypeVarType, AnyType,
     FunctionLike, UnboundType, TypeList, TypeVarDef, TypeType,
@@ -236,6 +236,7 @@ class SemanticAnalyzer(NodeVisitor):
         self.lib_path = lib_path
         self.errors = errors
         self.modules = modules
+        self.msg = MessageBuilder(errors, modules)
         self.missing_modules = missing_modules
         self.postpone_nested_functions_stack = [FUNCTION_BOTH_PHASES]
         self.postponed_functions_stack = []
@@ -978,12 +979,13 @@ class SemanticAnalyzer(NodeVisitor):
                 info.fallback_to_any = True
             if (self.options.disallow_implicit_any_types and
                     has_any_from_silent_import(base)):
+                base_name = self.msg.format(base)
                 if isinstance(base_expr, (NameExpr, MemberExpr)):
-                    msg = ("Subclassing type '{}' that is implicitly converted to '{}' due to "
-                           "import from unanalyzed module".format(base_expr.name, base))
+                    msg = ("Subclassing type {} that is implicitly converted to {} due to "
+                           "import from unanalyzed module".format(base_expr.name, base_name))
                 else:
-                    msg = ("Subclassing a type that is implicitly converted to '{}' "
-                           "due to import from unanalyzed module".format(base))
+                    msg = ("Subclassing a type that is implicitly converted to {} "
+                           "due to import from unanalyzed module".format(base_name))
                 self.fail(msg, base_expr)
 
         # Add 'object' as implicit base if there is no other base class.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -965,9 +965,7 @@ class SemanticAnalyzer(NodeVisitor):
                     self.fail("Cannot subclass NewType", defn)
                 base_types.append(base)
             elif isinstance(base, AnyType):
-                # if --disallow-implicit-any-types is set, the issue is reported later
-                implicit = self.options.disallow_implicit_any_types and base.is_from_silent_import
-                if self.options.disallow_subclassing_any and not implicit:
+                if self.options.disallow_subclassing_any:
                     if isinstance(base_expr, (NameExpr, MemberExpr)):
                         msg = "Class cannot subclass '{}' (has type 'Any')".format(base_expr.name)
                     else:
@@ -1438,12 +1436,7 @@ class SemanticAnalyzer(NodeVisitor):
         else:
             var._fullname = self.qualified_name(name)
         var.is_ready = True
-        any_type = AnyType()
-        if self.options.silent_mode():
-            # if silent mode is not enabled, no need to report implicit conversion to Any,
-            # let mypy report an import error.
-            any_type.is_from_silent_import = is_import
-        var.type = any_type
+        var.type = AnyType(from_silent_import=is_import)
         var.is_suppressed_import = is_import
         self.add_symbol(name, SymbolTableNode(GDEF, var, self.cur_mod_id), context)
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -966,8 +966,8 @@ class SemanticAnalyzer(NodeVisitor):
                 base_types.append(base)
             elif isinstance(base, AnyType):
                 # if --disallow-implicit-any-types is set, the issue is reported later
-                if (self.options.disallow_subclassing_any and
-                        not self.options.disallow_implicit_any_types):
+                implicit = self.options.disallow_implicit_any_types and base.is_from_silent_import
+                if self.options.disallow_subclassing_any and not implicit:
                     if isinstance(base_expr, (NameExpr, MemberExpr)):
                         msg = "Class cannot subclass '{}' (has type 'Any')".format(base_expr.name)
                     else:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -232,7 +232,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type]):
                     # context. This is slightly problematic as it allows using the type 'Any'
                     # as a base class -- however, this will fail soon at runtime so the problem
                     # is pretty minor.
-                    return AnyType(from_silent_import=True)
+                    return AnyType(from_unimported_type=True)
                 # Allow unbound type variables when defining an alias
                 if not (self.aliasing and sym.kind == TVAR and
                         self.tvar_scope.get_binding(sym) is None):
@@ -731,21 +731,21 @@ class TypeVariableQuery(TypeQuery[TypeVarList]):
             return []
 
 
-def has_any_from_silent_import(t: Type) -> bool:
-    """Return true if this type was converted to Any because of a silenced import.
+def has_any_from_unimported_type(t: Type) -> bool:
+    """Return true if this type is Any because an import was not followed.
 
     If type t is such Any type or has type arguments that contain such Any type
     this function will return true.
     """
-    return t.accept(HasAnyFromSilentImportQuery())
+    return t.accept(HasAnyFromUnimportedType())
 
 
-class HasAnyFromSilentImportQuery(TypeQuery[bool]):
+class HasAnyFromUnimportedType(TypeQuery[bool]):
     def __init__(self) -> None:
         super().__init__(any)
 
     def visit_any(self, t: AnyType) -> bool:
-        return t.from_silent_import
+        return t.from_unimported_type
 
 
 def make_optional_type(t: Type) -> Type:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -232,7 +232,9 @@ class TypeAnalyser(SyntheticTypeVisitor[Type]):
                     # context. This is slightly problematic as it allows using the type 'Any'
                     # as a base class -- however, this will fail soon at runtime so the problem
                     # is pretty minor.
-                    return AnyType()
+                    any_type = AnyType()
+                    any_type.is_from_silent_import = sym.node.type.is_from_silent_import
+                    return any_type
                 # Allow unbound type variables when defining an alias
                 if not (self.aliasing and sym.kind == TVAR and
                         self.tvar_scope.get_binding(sym) is None):
@@ -729,6 +731,23 @@ class TypeVariableQuery(TypeQuery[TypeVarList]):
             return super().visit_callable_type(t)
         else:
             return []
+
+
+def has_any_from_silent_import(t: Type) -> bool:
+    """Return true if this type was converted to Any because of a silenced import.
+
+    If type t is was co or is has type arguments that contain such Any type
+    this function will return true.
+    """
+    return t.accept(HasAnyFromSilentImportQuery())
+
+
+class HasAnyFromSilentImportQuery(TypeQuery[bool]):
+    def __init__(self) -> None:
+        super().__init__(any)
+
+    def visit_any(self, t: AnyType) -> bool:
+        return t.is_from_silent_import
 
 
 def make_optional_type(t: Type) -> Type:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -736,7 +736,7 @@ class TypeVariableQuery(TypeQuery[TypeVarList]):
 def has_any_from_silent_import(t: Type) -> bool:
     """Return true if this type was converted to Any because of a silenced import.
 
-    If type t is was co or is has type arguments that contain such Any type
+    If type t is such Any type or has type arguments that contain such Any type
     this function will return true.
     """
     return t.accept(HasAnyFromSilentImportQuery())

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -232,9 +232,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type]):
                     # context. This is slightly problematic as it allows using the type 'Any'
                     # as a base class -- however, this will fail soon at runtime so the problem
                     # is pretty minor.
-                    any_type = AnyType()
-                    any_type.is_from_silent_import = sym.node.type.is_from_silent_import
-                    return any_type
+                    return AnyType(from_silent_import=True)
                 # Allow unbound type variables when defining an alias
                 if not (self.aliasing and sym.kind == TVAR and
                         self.tvar_scope.get_binding(sym) is None):
@@ -747,7 +745,7 @@ class HasAnyFromSilentImportQuery(TypeQuery[bool]):
         super().__init__(any)
 
     def visit_any(self, t: AnyType) -> bool:
-        return t.is_from_silent_import
+        return t.from_silent_import
 
 
 def make_optional_type(t: Type) -> Type:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -274,14 +274,14 @@ class AnyType(Type):
 
     def __init__(self,
                  implicit: bool = False,
-                 from_silent_import: bool = False,
+                 from_unimported_type: bool = False,
                  line: int = -1,
                  column: int = -1) -> None:
         super().__init__(line, column)
         # Was this Any type was inferred without a type annotation?
         self.implicit = implicit
-        # Does this come from an unresolved import? See --disallow-implicit-any-types flag
-        self.from_silent_import = from_silent_import
+        # Does this come from an unfollowed import? See --disallow-any=unimported option
+        self.from_unimported_type = from_unimported_type
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_any(self)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -272,6 +272,9 @@ class TypeList(Type):
 class AnyType(Type):
     """The type 'Any'."""
 
+    # Does this come from a silent import? Used for --disallow-implicit-any-types flag
+    is_from_silent_import = False
+
     def __init__(self, implicit: bool = False, line: int = -1, column: int = -1) -> None:
         super().__init__(line, column)
         self.implicit = implicit

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -272,12 +272,12 @@ class TypeList(Type):
 class AnyType(Type):
     """The type 'Any'."""
 
-    # Does this come from a silent import? Used for --disallow-implicit-any-types flag
-    is_from_silent_import = False
-
-    def __init__(self, implicit: bool = False, line: int = -1, column: int = -1) -> None:
+    def __init__(self, implicit: bool = False, from_silent_import: bool = False,
+                 line: int = -1, column: int = -1) -> None:
         super().__init__(line, column)
-        self.implicit = implicit
+        self.implicit = implicit  # Was this Any type was inferred without a type annotation?
+        # Does this come from an unresolved import? See--disallow-implicit-any-types flag
+        self.from_silent_import = from_silent_import
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_any(self)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -272,11 +272,15 @@ class TypeList(Type):
 class AnyType(Type):
     """The type 'Any'."""
 
-    def __init__(self, implicit: bool = False, from_silent_import: bool = False,
-                 line: int = -1, column: int = -1) -> None:
+    def __init__(self,
+                 implicit: bool = False,
+                 from_silent_import: bool = False,
+                 line: int = -1,
+                 column: int = -1) -> None:
         super().__init__(line, column)
-        self.implicit = implicit  # Was this Any type was inferred without a type annotation?
-        # Does this come from an unresolved import? See--disallow-implicit-any-types flag
+        # Was this Any type was inferred without a type annotation?
+        self.implicit = implicit
+        # Does this come from an unresolved import? See --disallow-implicit-any-types flag
         self.from_silent_import = from_silent_import
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -381,7 +381,7 @@ if z:  # E: Condition must be a boolean
 # flags: --ignore-missing-imports --disallow-any=unimported
 from missing import MyType
 
-def f(x: MyType) -> None:  # E: Argument 1 to "f" becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+def f(x: MyType) -> None:  # E: Argument 1 to "f" becomes "Any" due to an unfollowed import
     pass
 
 [case testDisallowImplicitTypes]
@@ -393,13 +393,13 @@ def f(x: MyType) -> None:
 [out]
 main:2: error: Cannot find module named 'missing'
 main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
-main:4: error: Argument 1 to "f" becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+main:4: error: Argument 1 to "f" becomes "Any" due to an unfollowed import
 
 [case testDisallowImplicitAnyVariableDefinition]
 # flags: --ignore-missing-imports --disallow-any=unimported
 from missing import Unchecked
 
-t: Unchecked = 12  # E: Type of variable becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+t: Unchecked = 12  # E: Type of variable becomes "Any" due to an unfollowed import
 
 [case testDisallowImplicitAnyGeneric]
 # flags: --ignore-missing-imports --disallow-any=unimported
@@ -411,19 +411,19 @@ def foo(l: List[Unchecked]) -> List[Unchecked]:
     return l
 [builtins fixtures/list.pyi]
 [out]
-main:5: error: Return type becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
-main:5: error: Argument 1 to "foo" becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
-main:6: error: Type of variable becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+main:5: error: Return type becomes List[Any] due to an unfollowed import
+main:5: error: Argument 1 to "foo" becomes List[Any] due to an unfollowed import
+main:6: error: Type of variable becomes List[Any] due to an unfollowed import
 
 [case testDisallowImplicitAnyInherit]
 # flags: --ignore-missing-imports --disallow-any=unimported
 from missing import Unchecked
 from typing import List
 
-class C(Unchecked): # E: Base type Unchecked becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+class C(Unchecked): # E: Base type Unchecked becomes "Any" due to an unfollowed import
     pass
 
-class A(List[Unchecked]): # E: Base type becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+class A(List[Unchecked]): # E: Base type becomes List[Any] due to an unfollowed import
     pass
 [builtins fixtures/list.pyi]
 
@@ -434,7 +434,7 @@ from typing import List
 
 X = List[Unchecked]
 
-def f(x: X) -> None:  # E: Argument 1 to "f" becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+def f(x: X) -> None:  # E: Argument 1 to "f" becomes List[Any] due to an unfollowed import
     pass
 [builtins fixtures/list.pyi]
 
@@ -445,8 +445,8 @@ from typing import List, cast
 
 
 foo = [1, 2, 3]
-cast(List[Unchecked], foo)  # E: Target type of cast becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
-cast(Unchecked, foo)  # E: Target type of cast becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+cast(List[Unchecked], foo)  # E: Target type of cast becomes List[Any] due to an unfollowed import
+cast(Unchecked, foo)  # E: Target type of cast becomes "Any" due to an unfollowed import
 [builtins fixtures/list.pyi]
 
 [case testDisallowImplicitAnyNamedTuple]
@@ -458,7 +458,7 @@ Point = NamedTuple('Point', [('x', List[Unchecked]),
                              ('y', Unchecked)])
 [builtins fixtures/list.pyi]
 [out]
-main:5: error: NamedTuple type becomes "Tuple[List[Any], Any]" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+main:5: error: NamedTuple type becomes "Tuple[List[Any], Any]" due to an unfollowed import
 
 [case testDisallowImplicitAnyTypeVarConstraints]
 # flags: --ignore-missing-imports --disallow-any=unimported
@@ -468,8 +468,8 @@ from missing import Unchecked
 T = TypeVar('T', Unchecked, List[Unchecked], str)
 [builtins fixtures/list.pyi]
 [out]
-main:5: error: Constraint 1 becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
-main:5: error: Constraint 2 becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+main:5: error: Constraint 1 becomes "Any" due to an unfollowed import
+main:5: error: Constraint 2 becomes List[Any] due to an unfollowed import
 
 [case testDisallowImplicitAnyNewType]
 # flags: --ignore-missing-imports --disallow-any=unimported
@@ -489,8 +489,8 @@ def foo(f: Callable[[], Unchecked]) -> Tuple[Unchecked]:
     return f()
 [builtins fixtures/list.pyi]
 [out]
-main:5: error: Return type becomes "Tuple[Any]" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
-main:5: error: Argument 1 to "foo" becomes Callable[[], Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+main:5: error: Return type becomes "Tuple[Any]" due to an unfollowed import
+main:5: error: Argument 1 to "foo" becomes Callable[[], Any] due to an unfollowed import
 
 [case testDisallowImplicitAnySubclassingExplicitAny]
 # flags: --ignore-missing-imports --disallow-any=unimported --disallow-subclassing-any
@@ -507,5 +507,5 @@ foo: Unchecked = ""
 foo = ""
 x, y = 1, 2  # type: Unchecked, Unchecked
 [out]
-main:4: error: Type of variable becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
-main:6: error: A type on this line becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+main:4: error: Type of variable becomes "Any" due to an unfollowed import
+main:6: error: A type on this line becomes "Any" due to an unfollowed import

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -378,14 +378,14 @@ if z:  # E: Condition must be a boolean
 [builtins fixtures/bool.pyi]
 
 [case testDisallowImplicitTypesIgnoreMissingTypes]
-# flags: --ignore-missing-imports --disallow-implicit-any-types
+# flags: --ignore-missing-imports --disallow-any=unimported
 from missing import MyType
 
-def f(x: MyType) -> None:  # E: Argument 1 to "f" is implicitly converted to "Any" due to import from unanalyzed module
+def f(x: MyType) -> None:  # E: Argument 1 to "f" becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
     pass
 
 [case testDisallowImplicitTypes]
-# flags: --disallow-implicit-any-types
+# flags: --disallow-any=unimported
 from missing import MyType
 
 def f(x: MyType) -> None:
@@ -393,16 +393,16 @@ def f(x: MyType) -> None:
 [out]
 main:2: error: Cannot find module named 'missing'
 main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
-main:4: error: Argument 1 to "f" is implicitly converted to "Any" due to import from unanalyzed module
+main:4: error: Argument 1 to "f" becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
 
 [case testDisallowImplicitAnyVariableDefinition]
-# flags: --ignore-missing-imports --disallow-implicit-any-types
+# flags: --ignore-missing-imports --disallow-any=unimported
 from missing import Unchecked
 
-t: Unchecked = 12  # E: Type of variable is implicitly converted to "Any" due to import from unanalyzed module
+t: Unchecked = 12  # E: Type of variable becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
 
 [case testDisallowImplicitAnyGeneric]
-# flags: --ignore-missing-imports --disallow-implicit-any-types
+# flags: --ignore-missing-imports --disallow-any=unimported
 from missing import Unchecked
 from typing import List
 
@@ -411,46 +411,46 @@ def foo(l: List[Unchecked]) -> List[Unchecked]:
     return l
 [builtins fixtures/list.pyi]
 [out]
-main:5: error: Return type is implicitly converted to List[Any] due to import from unanalyzed module
-main:5: error: Argument 1 to "foo" is implicitly converted to List[Any] due to import from unanalyzed module
-main:6: error: Type of variable is implicitly converted to List[Any] due to import from unanalyzed module
+main:5: error: Return type becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+main:5: error: Argument 1 to "foo" becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+main:6: error: Type of variable becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
 
 [case testDisallowImplicitAnyInherit]
-# flags: --ignore-missing-imports --disallow-implicit-any-types
+# flags: --ignore-missing-imports --disallow-any=unimported
 from missing import Unchecked
 from typing import List
 
-class C(Unchecked): # E: Base type Unchecked is implicitly converted to "Any" due to import from unanalyzed module
+class C(Unchecked): # E: Base type Unchecked becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
     pass
 
-class A(List[Unchecked]): # E: Base type is implicitly converted to List[Any] due to import from unanalyzed module
+class A(List[Unchecked]): # E: Base type becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
     pass
 [builtins fixtures/list.pyi]
 
 [case testDisallowImplicitAnyAlias]
-# flags: --ignore-missing-imports --disallow-implicit-any-types
+# flags: --ignore-missing-imports --disallow-any=unimported
 from missing import Unchecked
 from typing import List
 
 X = List[Unchecked]
 
-def f(x: X) -> None:  # E: Argument 1 to "f" is implicitly converted to List[Any] due to import from unanalyzed module
+def f(x: X) -> None:  # E: Argument 1 to "f" becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
     pass
 [builtins fixtures/list.pyi]
 
 [case testDisallowImplicitAnyCast]
-# flags: --ignore-missing-imports --disallow-implicit-any-types
+# flags: --ignore-missing-imports --disallow-any=unimported
 from missing import Unchecked
 from typing import List, cast
 
 
 foo = [1, 2, 3]
-cast(List[Unchecked], foo)  # E: Target type of cast is implicitly converted to List[Any] due to import from unanalyzed module
-cast(Unchecked, foo)  # E: Target type of cast is implicitly converted to "Any" due to import from unanalyzed module
+cast(List[Unchecked], foo)  # E: Target type of cast becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+cast(Unchecked, foo)  # E: Target type of cast becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
 [builtins fixtures/list.pyi]
 
 [case testDisallowImplicitAnyNamedTuple]
-# flags: --ignore-missing-imports --disallow-implicit-any-types
+# flags: --ignore-missing-imports --disallow-any=unimported
 from typing import List, NamedTuple
 from missing import Unchecked
 
@@ -458,21 +458,21 @@ Point = NamedTuple('Point', [('x', List[Unchecked]),
                              ('y', Unchecked)])
 [builtins fixtures/list.pyi]
 [out]
-main:5: error: NamedTuple type is implicitly converted to "Tuple[List[Any], Any]" due to import from unanalyzed module
+main:5: error: NamedTuple type becomes "Tuple[List[Any], Any]" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
 
 [case testDisallowImplicitAnyTypeVarConstraints]
-# flags: --ignore-missing-imports --disallow-implicit-any-types
+# flags: --ignore-missing-imports --disallow-any=unimported
 from typing import List, NamedTuple, TypeVar, Any
 from missing import Unchecked
 
 T = TypeVar('T', Unchecked, List[Unchecked], str)
 [builtins fixtures/list.pyi]
 [out]
-main:5: error: Constraint 1 is implicitly converted to "Any" due to import from unanalyzed module
-main:5: error: Constraint 2 is implicitly converted to List[Any] due to import from unanalyzed module
+main:5: error: Constraint 1 becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+main:5: error: Constraint 2 becomes List[Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
 
 [case testDisallowImplicitAnyNewType]
-# flags: --ignore-missing-imports --disallow-implicit-any-types
+# flags: --ignore-missing-imports --disallow-any=unimported
 from typing import NewType
 from missing import Unchecked
 
@@ -481,7 +481,7 @@ Baz = NewType('Baz', Unchecked)
 main:5: error: Argument 2 to NewType(...) must be subclassable (got Any)
 
 [case testDisallowImplicitAnyCallableAndTuple]
-# flags: --ignore-missing-imports --disallow-implicit-any-types
+# flags: --ignore-missing-imports --disallow-any=unimported
 from typing import Callable, Tuple
 from missing import Unchecked
 
@@ -489,23 +489,23 @@ def foo(f: Callable[[], Unchecked]) -> Tuple[Unchecked]:
     return f()
 [builtins fixtures/list.pyi]
 [out]
-main:5: error: Return type is implicitly converted to "Tuple[Any]" due to import from unanalyzed module
-main:5: error: Argument 1 to "foo" is implicitly converted to Callable[[], Any] due to import from unanalyzed module
+main:5: error: Return type becomes "Tuple[Any]" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+main:5: error: Argument 1 to "foo" becomes Callable[[], Any] due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
 
 [case testDisallowImplicitAnySubclassingExplicitAny]
-# flags: --ignore-missing-imports --disallow-implicit-any-types --disallow-subclassing-any
+# flags: --ignore-missing-imports --disallow-any=unimported --disallow-subclassing-any
 from typing import Any
 
 class C(Any): # E: Class cannot subclass 'Any' (has type 'Any')
     pass
 
 [case testDisallowImplicitAnyVarDeclaration]
-# flags: --ignore-missing-imports --disallow-implicit-any-types
+# flags: --ignore-missing-imports --disallow-any=unimported
 from missing import Unchecked
 
 foo: Unchecked = ""
 foo = ""
 x, y = 1, 2  # type: Unchecked, Unchecked
 [out]
-main:4: error: Type of variable is implicitly converted to "Any" due to import from unanalyzed module
-main:6: error: A type on this line is implicitly converted to "Any" due to import from unanalyzed module
+main:4: error: Type of variable becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)
+main:6: error: A type on this line becomes "Any" due to an unfollowed import (such imports occur either when the imported module does not exist or when --follow-imports=skip is set)

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -437,6 +437,7 @@ X = List[Unchecked]
 def f(x: X) -> None:  # E: Argument 1 to "f" is implicitly converted to List[Any] due to import from unanalyzed module
     pass
 [builtins fixtures/list.pyi]
+
 [case testDisallowImplicitAnyCast]
 # flags: --ignore-missing-imports --disallow-implicit-any-types
 from missing import Unchecked
@@ -478,6 +479,7 @@ from missing import Unchecked
 Baz = NewType('Baz', Unchecked)
 [out]
 main:5: error: Argument 2 to NewType(...) must be subclassable (got Any)
+
 [case testDisallowImplicitAnyCallableAndTuple]
 # flags: --ignore-missing-imports --disallow-implicit-any-types
 from typing import Callable, Tuple
@@ -489,6 +491,7 @@ def foo(f: Callable[[], Unchecked]) -> Tuple[Unchecked]:
 [out]
 main:5: error: Return type is implicitly converted to "Tuple[Any]" due to import from unanalyzed module
 main:5: error: Argument 1 to "foo" is implicitly converted to Callable[[], Any] due to import from unanalyzed module
+
 [case testDisallowImplicitAnySubclassingExplicitAny]
 # flags: --ignore-missing-imports --disallow-implicit-any-types --disallow-subclassing-any
 from typing import Any

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -376,3 +376,52 @@ if y:  # E: Condition must be a boolean
 if z:  # E: Condition must be a boolean
   pass
 [builtins fixtures/bool.pyi]
+
+[case testDisallowImplicitTypesIgnoreMissingTypes]
+# flags: --ignore-missing-imports --disallow-implicit-any-types
+from missing import MyType
+
+def f(x: MyType) -> None:  # E: Argument 1 to 'f' is implicitly converted to 'Any' due to import from unanalyzed module
+  pass
+
+[case testDisallowImplicitTypes]
+# flags: --disallow-implicit-any-types
+from missing import MyType
+
+def f(x: MyType) -> None:
+  pass
+[out]
+main:2: error: Cannot find module named 'missing'
+main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+
+[case testDisallowImplicitAnyVariableDefinition]
+# flags: --ignore-missing-imports --disallow-implicit-any-types
+from missing import Unchecked
+
+t: Unchecked = 12  # E: Type of variable is implicitly converted to 'Any' due to import from unanalyzed module
+
+[case testDisallowImplicitAnyGeneric]
+# flags: --ignore-missing-imports --disallow-implicit-any-types
+from missing import Unchecked
+from typing import List
+
+def foo(l: List[Unchecked]) -> List[Unchecked]:
+  t = []  # type: List[Unchecked]
+  return l
+[builtins fixtures/list.pyi]
+[out]
+main:5: error: Return type is implicitly converted to 'builtins.list[Any]' due to import from unanalyzed module
+main:5: error: Argument 1 to 'foo' is implicitly converted to 'builtins.list[Any]' due to import from unanalyzed module
+main:6: error: Type of variable is implicitly converted to 'builtins.list[Any]' due to import from unanalyzed module
+
+[case testDisallowImplicitAnyInherit]
+# flags: --ignore-missing-imports --disallow-implicit-any-types
+from missing import Unchecked
+from typing import List
+
+class C(Unchecked): # E: Subclassing type 'Unchecked' that is implicitly converted to 'Any' due to import from unanalyzed module
+  pass
+
+class A(List[Unchecked]): # E: Subclassing a type that is implicitly converted to 'builtins.list[Any]' due to import from unanalyzed module
+  pass
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -419,10 +419,10 @@ main:6: error: Type of variable is implicitly converted to List[Any] due to impo
 from missing import Unchecked
 from typing import List
 
-class C(Unchecked): # E: Subclassing type Unchecked that is implicitly converted to "Any" due to import from unanalyzed module
+class C(Unchecked): # E: Base type Unchecked is implicitly converted to "Any" due to import from unanalyzed module
     pass
 
-class A(List[Unchecked]): # E: Subclassing a type that is implicitly converted to List[Any] due to import from unanalyzed module
+class A(List[Unchecked]): # E: Base type is implicitly converted to List[Any] due to import from unanalyzed module
     pass
 [builtins fixtures/list.pyi]
 
@@ -436,3 +436,55 @@ X = List[Unchecked]
 def f(x: X) -> None:  # E: Argument 1 to "f" is implicitly converted to List[Any] due to import from unanalyzed module
     pass
 [builtins fixtures/list.pyi]
+[case testDisallowImplicitAnyCast]
+# flags: --ignore-missing-imports --disallow-implicit-any-types
+from missing import Unchecked
+from typing import List, cast
+
+
+foo = [1, 2, 3]
+cast(List[Unchecked], foo)  # E: Target type of cast is implicitly converted to List[Any] due to import from unanalyzed module
+cast(Unchecked, foo)  # E: Target type of cast is implicitly converted to "Any" due to import from unanalyzed module
+[builtins fixtures/list.pyi]
+
+[case testDisallowImplicitAnyNamedTuple]
+# flags: --ignore-missing-imports --disallow-implicit-any-types
+from typing import List, NamedTuple
+from missing import Unchecked
+
+Point = NamedTuple('Point', [('x', List[Unchecked]),
+                             ('y', Unchecked)])
+[builtins fixtures/list.pyi]
+[out]
+main:5: error: NamedTuple type is implicitly converted to "Tuple[List[Any], Any]" due to import from unanalyzed module
+
+[case testDisallowImplicitAnyTypeVarConstraints]
+# flags: --ignore-missing-imports --disallow-implicit-any-types
+from typing import List, NamedTuple, TypeVar, Any
+from missing import Unchecked
+
+T = TypeVar('T', Unchecked, List[Unchecked], str)
+[builtins fixtures/list.pyi]
+[out]
+main:5: error: Constraint 1 is implicitly converted to "Any" due to import from unanalyzed module
+main:5: error: Constraint 2 is implicitly converted to List[Any] due to import from unanalyzed module
+
+[case testDisallowImplicitAnyNewType]
+# flags: --ignore-missing-imports --disallow-implicit-any-types
+from typing import NewType
+from missing import Unchecked
+
+Baz = NewType('Baz', Unchecked)
+[out]
+main:5: error: Argument 2 to NewType(...) must be subclassable (got Any)
+[case testDisallowImplicitAnyCallableAndTuple]
+# flags: --ignore-missing-imports --disallow-implicit-any-types
+from typing import Callable, Tuple
+from missing import Unchecked
+
+def foo(f: Callable[[], Unchecked]) -> Tuple[Unchecked]:
+    return f()
+[builtins fixtures/list.pyi]
+[out]
+main:5: error: Return type is implicitly converted to "Tuple[Any]" due to import from unanalyzed module
+main:5: error: Argument 1 to "foo" is implicitly converted to Callable[[], Any] due to import from unanalyzed module

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -393,6 +393,7 @@ def f(x: MyType) -> None:
 [out]
 main:2: error: Cannot find module named 'missing'
 main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:4: error: Argument 1 to "f" is implicitly converted to "Any" due to import from unanalyzed module
 
 [case testDisallowImplicitAnyVariableDefinition]
 # flags: --ignore-missing-imports --disallow-implicit-any-types

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -495,3 +495,14 @@ from typing import Any
 
 class C(Any): # E: Class cannot subclass 'Any' (has type 'Any')
     pass
+
+[case testDisallowImplicitAnyVarDeclaration]
+# flags: --ignore-missing-imports --disallow-implicit-any-types
+from missing import Unchecked
+
+foo: Unchecked = ""
+foo = ""
+x, y = 1, 2  # type: Unchecked, Unchecked
+[out]
+main:4: error: Type of variable is implicitly converted to "Any" due to import from unanalyzed module
+main:6: error: A type on this line is implicitly converted to "Any" due to import from unanalyzed module

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -488,3 +488,9 @@ def foo(f: Callable[[], Unchecked]) -> Tuple[Unchecked]:
 [out]
 main:5: error: Return type is implicitly converted to "Tuple[Any]" due to import from unanalyzed module
 main:5: error: Argument 1 to "foo" is implicitly converted to Callable[[], Any] due to import from unanalyzed module
+[case testDisallowImplicitAnySubclassingExplicitAny]
+# flags: --ignore-missing-imports --disallow-implicit-any-types --disallow-subclassing-any
+from typing import Any
+
+class C(Any): # E: Class cannot subclass 'Any' (has type 'Any')
+    pass

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -381,15 +381,15 @@ if z:  # E: Condition must be a boolean
 # flags: --ignore-missing-imports --disallow-implicit-any-types
 from missing import MyType
 
-def f(x: MyType) -> None:  # E: Argument 1 to 'f' is implicitly converted to 'Any' due to import from unanalyzed module
-  pass
+def f(x: MyType) -> None:  # E: Argument 1 to "f" is implicitly converted to "Any" due to import from unanalyzed module
+    pass
 
 [case testDisallowImplicitTypes]
 # flags: --disallow-implicit-any-types
 from missing import MyType
 
 def f(x: MyType) -> None:
-  pass
+    pass
 [out]
 main:2: error: Cannot find module named 'missing'
 main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
@@ -398,7 +398,7 @@ main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" 
 # flags: --ignore-missing-imports --disallow-implicit-any-types
 from missing import Unchecked
 
-t: Unchecked = 12  # E: Type of variable is implicitly converted to 'Any' due to import from unanalyzed module
+t: Unchecked = 12  # E: Type of variable is implicitly converted to "Any" due to import from unanalyzed module
 
 [case testDisallowImplicitAnyGeneric]
 # flags: --ignore-missing-imports --disallow-implicit-any-types
@@ -406,22 +406,33 @@ from missing import Unchecked
 from typing import List
 
 def foo(l: List[Unchecked]) -> List[Unchecked]:
-  t = []  # type: List[Unchecked]
-  return l
+    t = []  # type: List[Unchecked]
+    return l
 [builtins fixtures/list.pyi]
 [out]
-main:5: error: Return type is implicitly converted to 'builtins.list[Any]' due to import from unanalyzed module
-main:5: error: Argument 1 to 'foo' is implicitly converted to 'builtins.list[Any]' due to import from unanalyzed module
-main:6: error: Type of variable is implicitly converted to 'builtins.list[Any]' due to import from unanalyzed module
+main:5: error: Return type is implicitly converted to List[Any] due to import from unanalyzed module
+main:5: error: Argument 1 to "foo" is implicitly converted to List[Any] due to import from unanalyzed module
+main:6: error: Type of variable is implicitly converted to List[Any] due to import from unanalyzed module
 
 [case testDisallowImplicitAnyInherit]
 # flags: --ignore-missing-imports --disallow-implicit-any-types
 from missing import Unchecked
 from typing import List
 
-class C(Unchecked): # E: Subclassing type 'Unchecked' that is implicitly converted to 'Any' due to import from unanalyzed module
-  pass
+class C(Unchecked): # E: Subclassing type Unchecked that is implicitly converted to "Any" due to import from unanalyzed module
+    pass
 
-class A(List[Unchecked]): # E: Subclassing a type that is implicitly converted to 'builtins.list[Any]' due to import from unanalyzed module
-  pass
+class A(List[Unchecked]): # E: Subclassing a type that is implicitly converted to List[Any] due to import from unanalyzed module
+    pass
+[builtins fixtures/list.pyi]
+
+[case testDisallowImplicitAnyAlias]
+# flags: --ignore-missing-imports --disallow-implicit-any-types
+from missing import Unchecked
+from typing import List
+
+X = List[Unchecked]
+
+def f(x: X) -> None:  # E: Argument 1 to "f" is implicitly converted to List[Any] due to import from unanalyzed module
+    pass
 [builtins fixtures/list.pyi]


### PR DESCRIPTION
These types can appear from an unanalyzed module.
If mypy encounters a type annotation that uses such a type,
it will report an error.

Note that this PR is different from #3141 although the flags have similar names. Perhaps, we should figure out the proper names for all flags. 