### PR TITLE
Ignore errors when cleaning up test temporary directories

### DIFF
--- a/mypy/myunit/__init__.py
+++ b/mypy/myunit/__init__.py
@@ -131,7 +131,10 @@ class TestCase:
         if self.suite:
             self.suite.tear_down()
         os.chdir(self.old_cwd)
-        self.tmpdir.cleanup()
+        try:
+            self.tmpdir.cleanup()
+        except OSError:
+            pass
         self.old_cwd = None
         self.tmpdir = None
 


### PR DESCRIPTION
Running the `pytest` tests on Windows sometimes cause `OSError` when cleaning up a test's temporary directory in teardown. A fuller fix was discussed in #3239, but this PR implements a workaround to make tests pass regardless of the error (as opposed to actually waiting for the files to get unlocked and delete them).