### PR TITLE
Improve message when assigning to an un-indexable by index. (#2900)

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -406,7 +406,8 @@ class MessageBuilder:
                     self.format(original_type)), context)
         elif member == '__setitem__':
             # Indexed set.
-            self.fail('Unsupported target for indexed assignment', context)
+            self.fail('Unsupported target of type {} for indexed assignment'.format(
+                self.format(typ)), context)
         elif member == '__call__':
             if isinstance(original_type, Instance) and \
                     (original_type.type.fullname() == 'builtins.function'):

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -537,7 +537,7 @@ class Base(NamedTuple):
     def good_override(self) -> int:
         reveal_type(self)  # E: Revealed type is 'Tuple[builtins.int, fallback=__main__.Base]'
         reveal_type(self[0])  # E: Revealed type is 'builtins.int'
-        self[0] = 3  # E: Unsupported target for indexed assignment
+        self[0] = 3  # E: Unsupported target of type "Base" for indexed assignment
         reveal_type(self.x)  # E: Revealed type is 'builtins.int'
         self.x = 3  # E: Property "x" defined in "Base" is read-only
         self[1]  # E: Tuple index out of range
@@ -550,7 +550,7 @@ class Child(Base):
     def new_method(self) -> int:
         reveal_type(self)  # E: Revealed type is 'Tuple[builtins.int, fallback=__main__.Child]'
         reveal_type(self[0])  # E: Revealed type is 'builtins.int'
-        self[0] = 3  # E: Unsupported target for indexed assignment
+        self[0] = 3  # E: Unsupported target of type "Child" for indexed assignment
         reveal_type(self.x)  # E: Revealed type is 'builtins.int'
         self.x = 3  # E: Property "x" defined in "Child" is read-only
         self[1]  # E: Tuple index out of range

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -803,7 +803,7 @@ class C:
 [out]
 main:3: error: Invalid index type "C" for "A"; expected type "B"
 main:4: error: Incompatible types in assignment (expression has type "A", target has type "C")
-main:5: error: Unsupported target for indexed assignment
+main:5: error: Unsupported target of type "B" for indexed assignment
 
 [case testOverloadedIndexing]
 from foo import *

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1886,4 +1886,4 @@ class C(Sequence[T], Generic[T]): pass
 C[0] = 0
 [out]
 main:4: error: Type expected within [...]
-main:4: error: Unsupported target for indexed assignment
+main:4: error: Unsupported target of type "type" for indexed assignment

--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -95,7 +95,7 @@ class X:
 
 [out]
 main:4: error: Unexpected type declaration
-main:4: error: Unsupported target for indexed assignment
+main:4: error: Unsupported target of type "str" for indexed assignment
 main:5: error: Type cannot be declared in assignment to non-self attribute
 main:5: error: "str" has no attribute "x"
 

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -207,9 +207,9 @@ from typing import Tuple
 t = None # type: Tuple[A, B]
 n = 0
 
-t[0] = A() # E: Unsupported target for indexed assignment
-t[2] = A() # E: Unsupported target for indexed assignment
-t[n] = A() # E: Unsupported target for indexed assignment
+t[0] = A() # E: Unsupported target of type Tuple[Any, ...] for indexed assignment
+t[2] = A() # E: Unsupported target of type Tuple[Any, ...] for indexed assignment
+t[n] = A() # E: Unsupported target of type Tuple[Any, ...] for indexed assignment
 
 class A: pass
 class B: pass


### PR DESCRIPTION
Now produces:
`z.py:2: error: Unsupported target of type "object" for indexed assignment`

Instead of:
```
$ cat z.py
foo = dict(junk=1, bar=dict(yo=3))
foo['bar']['yo'] = 5
$ python -m mypy z.py
z.py:2: error: Unsupported target for indexed assignment
```