### PR TITLE
Add line # of previous definition (resubmit #3396)

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3330,7 +3330,7 @@ class SemanticAnalyzer(NodeVisitor):
             if original_ctx.node and original_ctx.node.get_line() != -1:
                 extra_msg = ' on line {}'.format(original_ctx.node.get_line())
             else:
-                extra_msg = ' (line unavailable; possibly an import)'
+                extra_msg = ' (possibly by an import)'
         else:
             extra_msg = ''
         self.fail("Name '{}' already defined{}".format(name, extra_msg), ctx)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3315,7 +3315,7 @@ class SemanticAnalyzer(NodeVisitor):
             elif prev_is_overloaded:
                 self.fail("Definition of '{}' missing 'overload'".format(n), ctx)
             else:
-                self.name_already_defined(n, ctx)
+                self.name_already_defined(n, ctx, self.globals[n])
 
     def name_not_defined(self, name: str, ctx: Context) -> None:
         message = "Name '{}' is not defined".format(name)
@@ -3324,8 +3324,13 @@ class SemanticAnalyzer(NodeVisitor):
             message += ' {}'.format(extra)
         self.fail(message, ctx)
 
-    def name_already_defined(self, name: str, ctx: Context) -> None:
-        self.fail("Name '{}' already defined".format(name), ctx)
+    def name_already_defined(self, name: str, ctx: Context,
+                             original_ctx: Optional[SymbolTableNode] = None) -> None:
+        if original_ctx:
+            extra_msg = ' in line {}'.format(original_ctx.node.get_line())
+        else:
+            extra_msg = ''
+        self.fail("Name '{}' already defined{}".format(name, extra_msg), ctx)
 
     def fail(self, msg: str, ctx: Context, serious: bool = False, *,
              blocker: bool = False) -> None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3327,7 +3327,10 @@ class SemanticAnalyzer(NodeVisitor):
     def name_already_defined(self, name: str, ctx: Context,
                              original_ctx: Optional[SymbolTableNode] = None) -> None:
         if original_ctx:
-            extra_msg = ' on line {}'.format(original_ctx.node.get_line())
+            if original_ctx.node and original_ctx.node.get_line() != -1:
+                extra_msg = ' on line {}'.format(original_ctx.node.get_line())
+            else:
+                extra_msg = ' (line unavailable; possibly an import)'
         else:
             extra_msg = ''
         self.fail("Name '{}' already defined{}".format(name, extra_msg), ctx)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3327,7 +3327,7 @@ class SemanticAnalyzer(NodeVisitor):
     def name_already_defined(self, name: str, ctx: Context,
                              original_ctx: Optional[SymbolTableNode] = None) -> None:
         if original_ctx:
-            extra_msg = ' in line {}'.format(original_ctx.node.get_line())
+            extra_msg = ' on line {}'.format(original_ctx.node.get_line())
         else:
             extra_msg = ''
         self.fail("Name '{}' already defined{}".format(name, extra_msg), ctx)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -714,7 +714,7 @@ A()
 class A: pass
 class A: pass
 [out]
-main:4: error: Name 'A' already defined in line 3
+main:4: error: Name 'A' already defined on line 3
 
 [case testDocstringInClass]
 import typing

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -714,7 +714,7 @@ A()
 class A: pass
 class A: pass
 [out]
-main:4: error: Name 'A' already defined
+main:4: error: Name 'A' already defined in line 3
 
 [case testDocstringInClass]
 import typing

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1212,7 +1212,7 @@ from typing import Any
 x = None # type: Any
 if x:
     def f(): pass
-def f(): pass # E: Name 'f' already defined
+def f(): pass # E: Name 'f' already defined in line 4
 
 [case testIncompatibleConditionalFunctionDefinition]
 from typing import Any
@@ -1835,7 +1835,7 @@ f = g # E: Incompatible types in assignment (expression has type Callable[[Any, 
 
 [case testRedefineFunction2]
 def f() -> None: pass
-def f() -> None: pass # E: Name 'f' already defined
+def f() -> None: pass # E: Name 'f' already defined in line 1
 
 
 -- Special cases

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1212,7 +1212,7 @@ from typing import Any
 x = None # type: Any
 if x:
     def f(): pass
-def f(): pass # E: Name 'f' already defined in line 4
+def f(): pass # E: Name 'f' already defined on line 4
 
 [case testIncompatibleConditionalFunctionDefinition]
 from typing import Any
@@ -1835,7 +1835,7 @@ f = g # E: Incompatible types in assignment (expression has type Callable[[Any, 
 
 [case testRedefineFunction2]
 def f() -> None: pass
-def f() -> None: pass # E: Name 'f' already defined in line 1
+def f() -> None: pass # E: Name 'f' already defined on line 1
 
 
 -- Special cases

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1106,7 +1106,7 @@ def f(a: int) -> None: pass
 def f(a: str) -> None: pass
 [out]
 tmp/foo.pyi:2: error: Single overload definition, multiple required
-tmp/foo.pyi:5: error: Name 'f' already defined
+tmp/foo.pyi:5: error: Name 'f' already defined in line 2
 
 [case testOverloadTuple]
 from foo import *

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1106,7 +1106,7 @@ def f(a: int) -> None: pass
 def f(a: str) -> None: pass
 [out]
 tmp/foo.pyi:2: error: Single overload definition, multiple required
-tmp/foo.pyi:5: error: Name 'f' already defined in line 2
+tmp/foo.pyi:5: error: Name 'f' already defined on line 2
 
 [case testOverloadTuple]
 from foo import *

--- a/test-data/unit/check-semanal-error.test
+++ b/test-data/unit/check-semanal-error.test
@@ -79,3 +79,19 @@ yield # E: 'yield' outside function
 [case testYieldFromOutsideFunction]
 x = 1
 yield from x # E: 'yield from' outside function
+
+[case testImportFuncDup]
+import m
+def m() -> None: ...  # ok
+
+[file m.py]
+[out]
+
+[case testIgnoredImportDup]
+import m # type: ignore
+from m import f # type: ignore
+def m() -> None: ...  # ok
+def f() -> None: ...  # ok
+
+[out]
+

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1333,13 +1333,12 @@ main:4: error: Name 'a' already defined
 
 [case testDuplicateDefFromImport]
 from m import A
-class A:
+class A:  # E: Name 'A' already defined (possibly by an import)
     pass
 [file m.py]
 class A:
     pass
 [out]
-main:2: error: Name 'A' already defined (possibly by an import)
 
 [case testDuplicateDefDec]
 from typing import Any
@@ -1348,11 +1347,10 @@ def dec(x: Any) -> Any:
 @dec
 def f() -> None:
     pass
-@dec
+@dec  # E: Name 'f' already defined
 def f() -> None:
     pass
 [out]
-main:7: error: Name 'f' already defined
 
 [case testDuplicateDefOverload]
 from typing import overload
@@ -1366,32 +1364,40 @@ if 1:
     def f(x: Any) -> None:
         pass
 else:
-    def f(x: str) -> None:
+    def f(x: str) -> None:  # E: Name 'f' already defined on line 3
         pass
 [out]
-main:12: error: Name 'f' already defined on line 3
-
 
 [case testDuplicateDefNT]
 from typing import NamedTuple
 N = NamedTuple('N', [('a', int),
                      ('b', str)])
 
-class N:
+class N:  # E: Name 'N' already defined on line 2
     pass
 [out]
-main:5: error: Name 'N' already defined on line 2
-
 
 [case testDuplicateDefTypedDict]
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 
-class Point:
+class Point:  # E: Name 'Point' already defined on line 2
     pass
 [builtins fixtures/dict.pyi]
 
 [out]
-main:4: error: Name 'Point' already defined on line 2
 
+[case testTypeVarClassDup]
+from typing import TypeVar
+T = TypeVar('T')
+class T: ...  # E: Name 'T' already defined on line 2
 
+[out]
+
+[case testAliasDup]
+from typing import List
+A = List[int]
+class A: ... # E: Name 'A' already defined on line 2
+
+[builtins fixtures/list.pyi]
+[out]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1330,3 +1330,15 @@ a = ('spam', 'spam', 'eggs', 'spam')  # type: Tuple[str]
 [out]
 main:3: error: Name 'a' already defined
 main:4: error: Name 'a' already defined
+
+[case testUnknownContextDuplicateDef]
+try:
+    from m import A
+except ImportError:
+    class A:
+        pass
+[file m.py]
+class A:
+    pass
+[out]
+main:4: error: Name 'A' already defined (line unavailable; possibly an import)

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -165,7 +165,7 @@ import typing
 class A: pass
 class A: pass
 [out]
-main:3: error: Name 'A' already defined
+main:3: error: Name 'A' already defined in line 2
 
 [case testMultipleMixedDefinitions]
 import typing
@@ -173,8 +173,8 @@ x = 1
 def x(): pass
 class x: pass
 [out]
-main:3: error: Name 'x' already defined
-main:4: error: Name 'x' already defined
+main:3: error: Name 'x' already defined in line 2
+main:4: error: Name 'x' already defined in line 2
 
 [case testNameNotImported]
 import typing
@@ -1037,13 +1037,13 @@ t = 1 # E: Invalid assignment target
 [case testRedefineTypevar2]
 from typing import TypeVar
 t = TypeVar('t')
-def t(): pass # E: Name 't' already defined
+def t(): pass # E: Name 't' already defined in line 2
 [out]
 
 [case testRedefineTypevar3]
 from typing import TypeVar
 t = TypeVar('t')
-class t: pass # E: Name 't' already defined
+class t: pass # E: Name 't' already defined in line 2
 [out]
 
 [case testRedefineTypevar4]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1331,7 +1331,7 @@ a = ('spam', 'spam', 'eggs', 'spam')  # type: Tuple[str]
 main:3: error: Name 'a' already defined
 main:4: error: Name 'a' already defined
 
-[case testUnknownContextDuplicateDef]
+[case testDuplicateDefFromImport]
 from m import A
 class A:
     pass
@@ -1339,4 +1339,59 @@ class A:
 class A:
     pass
 [out]
-main:2: error: Name 'A' already defined (line unavailable; possibly an import)
+main:2: error: Name 'A' already defined (possibly by an import)
+
+[case testDuplicateDefDec]
+from typing import Any
+def dec(x: Any) -> Any:
+    return x
+@dec
+def f() -> None:
+    pass
+@dec
+def f() -> None:
+    pass
+[out]
+main:7: error: Name 'f' already defined
+
+[case testDuplicateDefOverload]
+from typing import overload
+if 1:
+    @overload
+    def f(x: int) -> None:
+        pass
+    @overload
+    def f(x: str) -> None:
+        pass
+    def f(x: Any) -> None:
+        pass
+else:
+    def f(x: str) -> None:
+        pass
+[out]
+main:12: error: Name 'f' already defined on line 3
+
+
+[case testDuplicateDefNT]
+from typing import NamedTuple
+N = NamedTuple('N', [('a', int),
+                     ('b', str)])
+
+class N:
+    pass
+[out]
+main:5: error: Name 'N' already defined on line 2
+
+
+[case testDuplicateDefTypedDict]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+
+class Point:
+    pass
+[builtins fixtures/dict.pyi]
+
+[out]
+main:4: error: Name 'Point' already defined on line 2
+
+

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1332,13 +1332,11 @@ main:3: error: Name 'a' already defined
 main:4: error: Name 'a' already defined
 
 [case testUnknownContextDuplicateDef]
-try:
-    from m import A
-except ImportError:
-    class A:
-        pass
+from m import A
+class A:
+    pass
 [file m.py]
 class A:
     pass
 [out]
-main:4: error: Name 'A' already defined (line unavailable; possibly an import)
+main:2: error: Name 'A' already defined (line unavailable; possibly an import)

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -165,7 +165,7 @@ import typing
 class A: pass
 class A: pass
 [out]
-main:3: error: Name 'A' already defined in line 2
+main:3: error: Name 'A' already defined on line 2
 
 [case testMultipleMixedDefinitions]
 import typing
@@ -173,8 +173,8 @@ x = 1
 def x(): pass
 class x: pass
 [out]
-main:3: error: Name 'x' already defined in line 2
-main:4: error: Name 'x' already defined in line 2
+main:3: error: Name 'x' already defined on line 2
+main:4: error: Name 'x' already defined on line 2
 
 [case testNameNotImported]
 import typing
@@ -1037,13 +1037,13 @@ t = 1 # E: Invalid assignment target
 [case testRedefineTypevar2]
 from typing import TypeVar
 t = TypeVar('t')
-def t(): pass # E: Name 't' already defined in line 2
+def t(): pass # E: Name 't' already defined on line 2
 [out]
 
 [case testRedefineTypevar3]
 from typing import TypeVar
 t = TypeVar('t')
-class t: pass # E: Name 't' already defined in line 2
+class t: pass # E: Name 't' already defined on line 2
 [out]
 
 [case testRedefineTypevar4]


### PR DESCRIPTION
Partial fix for #1874: improve the error message. The duplicate definitions in different if/else branches are still not allowed (this is much harder to fix).

This is a resubmission of #3396 which caused the crash in #3415 and was reverted. The old PR is in commit 39c3058; after that, I added 2 more commits: the failing test that repros the crash, and the fix to it.