### PR TITLE
Implement a reveal_locals expression. (#3387)

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -437,8 +437,10 @@ to see the types of all local varaibles at once. Example:
 
    a = 1
    b = 'one'
-   reveal_locals()  # Revealed local types are '{'a': builtins.int, 'b': builtins.str}'
-
+   reveal_locals()
+   # Revealed local types are:
+   # a: builtins.int
+   # b: builtins.str
 .. note::
 
    ``reveal_type`` and ``reveal_locals`` are only understood by mypy and

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -430,12 +430,23 @@ understand how mypy handles a particular piece of code. Example:
 
    reveal_type((1, 'hello'))  # Revealed type is 'Tuple[builtins.int, builtins.str]'
 
+You can also use ``reveal_locals()`` at any line in a file
+to see the types of all local varaibles at once. Example:
+
+.. code-block:: python
+
+   a = 1
+   b = 'one'
+   reveal_locals()  # Revealed local types are '{'a': builtins.int, 'b': builtins.str}'
+
 .. note::
 
-   ``reveal_type`` is only understood by mypy and doesn't exist
-   in Python, if you try to run your program. You'll have to remove
-   any ``reveal_type`` calls before you can run your code.
-   ``reveal_type`` is always available and you don't need to import it.
+   ``reveal_type`` and ``reveal_locals`` are only understood by mypy and
+   don't exist in Python. If you try to run your program, you'll have to
+   remove any ``reveal_type`` and ``reveal_locals`` calls before you can
+   run your code. Both are always available and you don't need to import
+   them.
+
 
 .. _import-cycles:
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1799,8 +1799,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def visit_reveal_expr(self, expr: RevealExpr) -> Type:
         """Type check a reveal_type expression."""
         if expr.kind == REVEAL_TYPE:
-            if expr.expr is not None:
-                revealed_type = self.accept(expr.expr, type_context=self.type_context[-1])
+            assert expr.expr is not None
+            revealed_type = self.accept(expr.expr, type_context=self.type_context[-1])
             if not self.chk.current_node_deferred:
                 self.msg.reveal_type(revealed_type, expr)
                 if not self.chk.in_checked_function():

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -15,14 +15,14 @@ from mypy.types import (
 from mypy.nodes import (
     NameExpr, RefExpr, Var, FuncDef, OverloadedFuncDef, TypeInfo, CallExpr,
     MemberExpr, IntExpr, StrExpr, BytesExpr, UnicodeExpr, FloatExpr,
-    OpExpr, UnaryExpr, IndexExpr, CastExpr, RevealTypeExpr, TypeApplication, ListExpr,
+    OpExpr, UnaryExpr, IndexExpr, CastExpr, RevealExpr, TypeApplication, ListExpr,
     TupleExpr, DictExpr, LambdaExpr, SuperExpr, SliceExpr, Context, Expression,
     ListComprehension, GeneratorExpr, SetExpr, MypyFile, Decorator,
     ConditionalExpr, ComparisonExpr, TempNode, SetComprehension,
     DictionaryComprehension, ComplexExpr, EllipsisExpr, StarExpr, AwaitExpr, YieldExpr,
     YieldFromExpr, TypedDictExpr, PromoteExpr, NewTypeExpr, NamedTupleExpr, TypeVarExpr,
     TypeAliasExpr, BackquoteExpr, EnumCallExpr,
-    ARG_POS, ARG_NAMED, ARG_STAR, ARG_STAR2, MODULE_REF, TVAR, LITERAL_TYPE,
+    ARG_POS, ARG_NAMED, ARG_STAR, ARG_STAR2, MODULE_REF, TVAR, LITERAL_TYPE, REVEAL_TYPE
 )
 from mypy.literals import literal
 from mypy import nodes
@@ -1796,14 +1796,29 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                context=expr)
         return target_type
 
-    def visit_reveal_type_expr(self, expr: RevealTypeExpr) -> Type:
+    def visit_reveal_expr(self, expr: RevealExpr) -> Type:
         """Type check a reveal_type expression."""
-        revealed_type = self.accept(expr.expr, type_context=self.type_context[-1])
-        if not self.chk.current_node_deferred:
-            self.msg.reveal_type(revealed_type, expr)
-            if not self.chk.in_checked_function():
-                self.msg.note("'reveal_type' always outputs 'Any' in unchecked functions", expr)
-        return revealed_type
+        if expr.kind == REVEAL_TYPE:
+            if expr.expr is not None:
+                revealed_type = self.accept(expr.expr, type_context=self.type_context[-1])
+            if not self.chk.current_node_deferred:
+                self.msg.reveal_type(revealed_type, expr)
+                if not self.chk.in_checked_function():
+                    self.msg.note("'reveal_type' always outputs 'Any' in unchecked functions",
+                                  expr)
+            return revealed_type
+        else:
+            # REVEAL_LOCALS
+            if not self.chk.current_node_deferred:
+                # the RevealExpr contains a local_nodes attribute,
+                # calculated at semantic analysis time. Use it to pull out the
+                # corresponding subset of variables in self.chk.type_map
+                names_to_types = {
+                    var_node.name(): var_node.type for var_node in expr.local_nodes
+                } if expr.local_nodes is not None else {}
+
+                self.msg.reveal_locals(names_to_types, expr)
+            return NoneTyp()
 
     def visit_type_application(self, tapp: TypeApplication) -> Type:
         """Type check a type application (expr[type, ...])."""

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -4,7 +4,7 @@ from mypy.nodes import (
     Expression, ComparisonExpr, OpExpr, MemberExpr, UnaryExpr, StarExpr, IndexExpr, LITERAL_YES,
     LITERAL_NO, NameExpr, LITERAL_TYPE, IntExpr, FloatExpr, ComplexExpr, StrExpr, BytesExpr,
     UnicodeExpr, ListExpr, TupleExpr, SetExpr, DictExpr, CallExpr, SliceExpr, CastExpr,
-    ConditionalExpr, EllipsisExpr, YieldFromExpr, YieldExpr, RevealTypeExpr, SuperExpr,
+    ConditionalExpr, EllipsisExpr, YieldFromExpr, YieldExpr, RevealExpr, SuperExpr,
     TypeApplication, LambdaExpr, ListComprehension, SetComprehension, DictionaryComprehension,
     GeneratorExpr, BackquoteExpr, TypeVarExpr, TypeAliasExpr, NamedTupleExpr, EnumCallExpr,
     TypedDictExpr, NewTypeExpr, PromoteExpr, AwaitExpr, TempNode,
@@ -175,7 +175,7 @@ class _Hasher(ExpressionVisitor[Optional[Key]]):
     def visit_yield_expr(self, e: YieldExpr) -> None:
         return None
 
-    def visit_reveal_type_expr(self, e: RevealTypeExpr) -> None:
+    def visit_reveal_expr(self, e: RevealExpr) -> None:
         return None
 
     def visit_super_expr(self, e: SuperExpr) -> None:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -974,11 +974,11 @@ class MessageBuilder:
         # To ensure that the output is predictable on Python < 3.6,
         # use an ordered dictionary sorted by variable name
         sorted_locals = OrderedDict(sorted(type_map.items(), key=lambda t: t[0]))
-        # Format the OrderedDict to look like a regular dict
-        s = "{{{}}}".format(
-            ', '.join("'{}': {}".format(k, v) for k, v in sorted_locals.items())
-        )
-        self.fail('Revealed local types are \'{}\''.format(s), context)
+        self.fail("Revealed local types are:", context)
+        # Note that self.fail does a strip() on the message, so we cannot prepend with spaces
+        # for indentation
+        for line in ['{}: {}'.format(k, v) for k, v in sorted_locals.items()]:
+            self.fail(line, context)
 
     def unsupported_type_type(self, item: Type, context: Context) -> None:
         self.fail('Unsupported type Type[{}]'.format(self.format(item)), context)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -78,6 +78,9 @@ TYPE_ALIAS = 6  # type: int
 # XXX what?
 UNBOUND_IMPORTED = 7  # type: int
 
+# RevealExpr node kinds
+REVEAL_TYPE = 0  # type: int
+REVEAL_LOCALS = 1  # type: int
 
 LITERAL_YES = 2
 LITERAL_TYPE = 1
@@ -1595,17 +1598,24 @@ class CastExpr(Expression):
         return visitor.visit_cast_expr(self)
 
 
-class RevealTypeExpr(Expression):
-    """Reveal type expression reveal_type(expr)."""
+class RevealExpr(Expression):
+    """Reveal type expression reveal_type(expr) or reveal_locals() expression."""
 
-    expr = None  # type: Expression
+    expr = None  # type: Optional[Expression]
+    kind = 0  # type: int
+    local_nodes = None  # type: Optional[List[Var]]
 
-    def __init__(self, expr: Expression) -> None:
+    def __init__(
+            self, kind: int,
+            expr: Optional[Expression] = None,
+            local_nodes: 'Optional[List[Var]]' = None) -> None:
         super().__init__()
         self.expr = expr
+        self.kind = kind
+        self.local_nodes = local_nodes
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
-        return visitor.visit_reveal_type_expr(self)
+        return visitor.visit_reveal_expr(self)
 
 
 class SuperExpr(Expression):

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -103,6 +103,9 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
                     # reveal_type is a mypy-only function that gives an error with
                     # the type of its arg.
                     ('reveal_type', AnyType(TypeOfAny.special_form)),
+                    # reveal_locals is a mypy-only function that gives an error with the types of
+                    # locals
+                    ('reveal_locals', AnyType(TypeOfAny.special_form)),
                 ]  # type: List[Tuple[str, Type]]
 
                 # TODO(ddfisher): This guard is only needed because mypy defines

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -18,7 +18,7 @@ from mypy.nodes import (
     Node, Expression, MypyFile, FuncDef, FuncItem, Decorator, RefExpr, Context, TypeInfo, ClassDef,
     Block, TypedDictExpr, NamedTupleExpr, AssignmentStmt, IndexExpr, TypeAliasExpr, NameExpr,
     CallExpr, NewTypeExpr, ForStmt, WithStmt, CastExpr, TypeVarExpr, TypeApplication, Lvalue,
-    TupleExpr, RevealTypeExpr, SymbolTableNode, SymbolTable, Var, ARG_POS, OverloadedFuncDef,
+    TupleExpr, RevealExpr, SymbolTableNode, SymbolTable, Var, ARG_POS, OverloadedFuncDef,
     MDEF,
 )
 from mypy.types import (
@@ -278,8 +278,8 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
         self.analyze(e.type, e)
         super().visit_cast_expr(e)
 
-    def visit_reveal_type_expr(self, e: RevealTypeExpr) -> None:
-        super().visit_reveal_type_expr(e)
+    def visit_reveal_expr(self, e: RevealExpr) -> None:
+        super().visit_reveal_expr(e)
 
     def visit_type_application(self, e: TypeApplication) -> None:
         for type in e.types:

--- a/mypy/server/subexpr.py
+++ b/mypy/server/subexpr.py
@@ -4,7 +4,7 @@ from typing import List
 
 from mypy.nodes import (
     Expression, Node, MemberExpr, YieldFromExpr, YieldExpr, CallExpr, OpExpr, ComparisonExpr,
-    SliceExpr, CastExpr, RevealTypeExpr, UnaryExpr, ListExpr, TupleExpr, DictExpr, SetExpr,
+    SliceExpr, CastExpr, RevealExpr, UnaryExpr, ListExpr, TupleExpr, DictExpr, SetExpr,
     IndexExpr, GeneratorExpr, ListComprehension, SetComprehension, DictionaryComprehension,
     ConditionalExpr, TypeApplication, LambdaExpr, StarExpr, BackquoteExpr, AwaitExpr,
 )
@@ -72,9 +72,9 @@ class SubexpressionFinder(TraverserVisitor):
         self.add(e)
         super().visit_cast_expr(e)
 
-    def visit_reveal_type_expr(self, e: RevealTypeExpr) -> None:
+    def visit_reveal_expr(self, e: RevealExpr) -> None:
         self.add(e)
-        super().visit_reveal_type_expr(e)
+        super().visit_reveal_expr(e)
 
     def visit_unary_expr(self, e: UnaryExpr) -> None:
         self.add(e)

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -406,8 +406,12 @@ class StrConv(NodeVisitor[str]):
     def visit_cast_expr(self, o: 'mypy.nodes.CastExpr') -> str:
         return self.dump([o.expr, o.type], o)
 
-    def visit_reveal_type_expr(self, o: 'mypy.nodes.RevealTypeExpr') -> str:
-        return self.dump([o.expr], o)
+    def visit_reveal_expr(self, o: 'mypy.nodes.RevealExpr') -> str:
+        if o.kind == mypy.nodes.REVEAL_TYPE:
+            return self.dump([o.expr], o)
+        else:
+            # REVEAL_LOCALS
+            return self.dump([o.local_nodes], o)
 
     def visit_unary_expr(self, o: 'mypy.nodes.UnaryExpr') -> str:
         return self.dump([o.op, o.expr], o)

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -5,12 +5,12 @@ from mypy.nodes import (
     Block, MypyFile, FuncItem, CallExpr, ClassDef, Decorator, FuncDef,
     ExpressionStmt, AssignmentStmt, OperatorAssignmentStmt, WhileStmt,
     ForStmt, ReturnStmt, AssertStmt, DelStmt, IfStmt, RaiseStmt,
-    TryStmt, WithStmt, MemberExpr, OpExpr, SliceExpr, CastExpr, RevealTypeExpr,
+    TryStmt, WithStmt, MemberExpr, OpExpr, SliceExpr, CastExpr, RevealExpr,
     UnaryExpr, ListExpr, TupleExpr, DictExpr, SetExpr, IndexExpr,
     GeneratorExpr, ListComprehension, SetComprehension, DictionaryComprehension,
     ConditionalExpr, TypeApplication, ExecStmt, Import, ImportFrom,
     LambdaExpr, ComparisonExpr, OverloadedFuncDef, YieldFromExpr,
-    YieldExpr, StarExpr, BackquoteExpr, AwaitExpr, PrintStmt, SuperExpr,
+    YieldExpr, StarExpr, BackquoteExpr, AwaitExpr, PrintStmt, SuperExpr, REVEAL_TYPE
 )
 
 
@@ -181,8 +181,15 @@ class TraverserVisitor(NodeVisitor[None]):
     def visit_cast_expr(self, o: CastExpr) -> None:
         o.expr.accept(self)
 
-    def visit_reveal_type_expr(self, o: RevealTypeExpr) -> None:
-        o.expr.accept(self)
+    def visit_reveal_expr(self, o: RevealExpr) -> None:
+        if o.kind == REVEAL_TYPE:
+            from mypy.nodes import Expression
+            from typing import cast
+            expr = cast(Expression, o.expr)
+            expr.accept(self)
+        else:
+            # RevealLocalsExpr doesn't have an inner expression
+            pass
 
     def visit_unary_expr(self, o: UnaryExpr) -> None:
         o.expr.accept(self)

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -183,10 +183,8 @@ class TraverserVisitor(NodeVisitor[None]):
 
     def visit_reveal_expr(self, o: RevealExpr) -> None:
         if o.kind == REVEAL_TYPE:
-            from mypy.nodes import Expression
-            from typing import cast
-            expr = cast(Expression, o.expr)
-            expr.accept(self)
+            assert o.expr is not None
+            o.expr.accept(self)
         else:
             # RevealLocalsExpr doesn't have an inner expression
             pass

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -11,7 +11,7 @@ from mypy.nodes import (
     OperatorAssignmentStmt, ExpressionStmt, AssignmentStmt, ReturnStmt,
     RaiseStmt, AssertStmt, DelStmt, BreakStmt, ContinueStmt,
     PassStmt, GlobalDecl, WhileStmt, ForStmt, IfStmt, TryStmt, WithStmt,
-    CastExpr, RevealTypeExpr, TupleExpr, GeneratorExpr, ListComprehension, ListExpr,
+    CastExpr, RevealExpr, TupleExpr, GeneratorExpr, ListComprehension, ListExpr,
     ConditionalExpr, DictExpr, SetExpr, NameExpr, IntExpr, StrExpr, BytesExpr,
     UnicodeExpr, FloatExpr, CallExpr, SuperExpr, MemberExpr, IndexExpr,
     SliceExpr, OpExpr, UnaryExpr, LambdaExpr, TypeApplication, PrintStmt,
@@ -20,7 +20,7 @@ from mypy.nodes import (
     YieldFromExpr, NamedTupleExpr, TypedDictExpr, NonlocalDecl, SetComprehension,
     DictionaryComprehension, ComplexExpr, TypeAliasExpr, EllipsisExpr,
     YieldExpr, ExecStmt, Argument, BackquoteExpr, AwaitExpr,
-    OverloadPart, EnumCallExpr,
+    OverloadPart, EnumCallExpr, REVEAL_TYPE
 )
 from mypy.types import Type, FunctionLike
 from mypy.traverser import TraverserVisitor
@@ -377,8 +377,12 @@ class TransformVisitor(NodeVisitor[Node]):
         return CastExpr(self.expr(node.expr),
                         self.type(node.type))
 
-    def visit_reveal_type_expr(self, node: RevealTypeExpr) -> RevealTypeExpr:
-        return RevealTypeExpr(self.expr(node.expr))
+    def visit_reveal_expr(self, node: RevealExpr) -> RevealExpr:
+        if node.kind == REVEAL_TYPE:
+            return RevealExpr(kind=REVEAL_TYPE, expr=self.expr(cast(Expression, node.expr)))
+        else:
+            # Reveal locals expressions don't have any sub expressions
+            return node
 
     def visit_super_expr(self, node: SuperExpr) -> SuperExpr:
         call = self.expr(node.call)

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -379,7 +379,8 @@ class TransformVisitor(NodeVisitor[Node]):
 
     def visit_reveal_expr(self, node: RevealExpr) -> RevealExpr:
         if node.kind == REVEAL_TYPE:
-            return RevealExpr(kind=REVEAL_TYPE, expr=self.expr(cast(Expression, node.expr)))
+            assert node.expr is not None
+            return RevealExpr(kind=REVEAL_TYPE, expr=self.expr(node.expr))
         else:
             # Reveal locals expressions don't have any sub expressions
             return node

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -1,7 +1,7 @@
 """Generic abstract syntax tree node visitor"""
 
 from abc import abstractmethod
-from typing import TypeVar, Generic
+from typing import Dict, TypeVar, Generic
 
 if False:
     # break import cycle only needed for mypy
@@ -77,7 +77,7 @@ class ExpressionVisitor(Generic[T]):
         pass
 
     @abstractmethod
-    def visit_reveal_type_expr(self, o: 'mypy.nodes.RevealTypeExpr') -> T:
+    def visit_reveal_expr(self, o: 'mypy.nodes.RevealExpr') -> T:
         pass
 
     @abstractmethod
@@ -458,7 +458,7 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T]):
     def visit_cast_expr(self, o: 'mypy.nodes.CastExpr') -> T:
         pass
 
-    def visit_reveal_type_expr(self, o: 'mypy.nodes.RevealTypeExpr') -> T:
+    def visit_reveal_expr(self, o: 'mypy.nodes.RevealExpr') -> T:
         pass
 
     def visit_super_expr(self, o: 'mypy.nodes.SuperExpr') -> T:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4314,4 +4314,9 @@ class D(B, C):
 class C1(object):
     t = 'a'
     y = 3.0
-    reveal_locals()  # E: Revealed local types are '{'t': builtins.str, 'y': builtins.float}'
+    reveal_locals()
+
+[out]
+main:4: error: Revealed local types are:
+main:4: error: t: builtins.str
+main:4: error: y: builtins.float

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4309,3 +4309,9 @@ class C:
     __slots__ = ('x',)
 class D(B, C):
     __slots__ = ('aa', 'bb', 'cc')
+
+[case testRevealLocalsOnClassVars]
+class C1(object):
+    t = 'a'
+    y = 3.0
+    reveal_locals()  # E: Revealed local types are '{'t': builtins.str, 'y': builtins.float}'

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1712,7 +1712,12 @@ reveal_type(1) # E: Revealed type is 'builtins.int'
 x = 1
 y = 2
 z = x + y
-reveal_locals() # E: Revealed local types are '{'x': builtins.int, 'y': builtins.int, 'z': builtins.int}'
+reveal_locals()
+[out]
+main:4: error: Revealed local types are:
+main:4: error: x: builtins.int
+main:4: error: y: builtins.int
+main:4: error: z: builtins.int
 
 [case testUndefinedRevealType]
 reveal_type(x)

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1708,6 +1708,12 @@ d() # E: "D[str, int]" not callable
 [case testRevealType]
 reveal_type(1) # E: Revealed type is 'builtins.int'
 
+[case testRevealLocals]
+x = 1
+y = 2
+z = x + y
+reveal_locals() # E: Revealed local types are '{'x': builtins.int, 'y': builtins.int, 'z': builtins.int}'
+
 [case testUndefinedRevealType]
 reveal_type(x)
 [out]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2307,9 +2307,19 @@ main:2: error: Revealed type is 'def () -> builtins.int'
 a = 1.0
 
 def f(a: int, b: int) -> int:
-    reveal_locals() # E: Revealed local types are '{'a': builtins.int, 'b': builtins.int}'
+    reveal_locals()
     c = a + b
-    reveal_locals() # E: Revealed local types are '{'a': builtins.int, 'b': builtins.int, 'c': builtins.int}'
+    reveal_locals()
     return c
 
-reveal_locals() # E: Revealed local types are '{'a': builtins.float}'
+reveal_locals()
+[out]
+main:4: error: Revealed local types are:
+main:4: error: a: builtins.int
+main:4: error: b: builtins.int
+main:6: error: Revealed local types are:
+main:6: error: a: builtins.int
+main:6: error: b: builtins.int
+main:6: error: c: builtins.int
+main:9: error: Revealed local types are:
+main:9: error: a: builtins.float

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2302,3 +2302,14 @@ f = lambda: 5
 reveal_type(f)
 [out]
 main:2: error: Revealed type is 'def () -> builtins.int'
+
+[case testRevealLocalsFunction]
+a = 1.0
+
+def f(a: int, b: int) -> int:
+    reveal_locals() # E: Revealed local types are '{'a': builtins.int, 'b': builtins.int}'
+    c = a + b
+    reveal_locals() # E: Revealed local types are '{'a': builtins.int, 'b': builtins.int, 'c': builtins.int}'
+    return c
+
+reveal_locals() # E: Revealed local types are '{'a': builtins.float}'


### PR DESCRIPTION
This PR is a "rough draft" implementation of a `reveal_locals` expression, which as it stands can produce from this input:

```
def f(a: int, b: int) -> int:
    c = a + b
    reveal_locals()
    return c
```

this output:
```
sample.py:3: error: Revealed local types are '{'a': builtins.int, 'b': builtins.int, 'c': builtins.int}'
```

I am new to the codebase so likely this PR will need a fair bit more work and would like some feedback. I certainly need to add new tests and documentation but wanted to do that after a first round of feedback if possible. 

Some notes:
* Essentially, the implementation is just using the `type_map` attribute of the `TypeChecker` instance to produce the output. I don't know if this is the correct approach but it seemed the simplest to my admittedly cursory knowledge of the codebase.
* I also am storing the `locals` attribute of the `SemanticAnalyzer` into each `RevealLocalsExpr`, but at the moment I am not using it. This could lead to other ways of implementing this but I wasn't sure of the best use of it. 
* Currently the output is on one line, dictionary style. I am open to other possibilities, e.g:
```
sample.py:3: error: Revealed type of 'a': builtins.int
sample.py:3: error: Revealed type of 'b': builtins.int
sample.py:3: error: Revealed type of 'c': builtins.int
```
However, it's worth considering who the "audience" of this output is. The dictionary output is more machine parseable, which could be useful for editor plugins that use this functionality. Admittedly, when I first thought of this feature, this was the use case I was thinking of.
* There is at least one bug in the current implementation:
```
def f(a: int, b: int) -> int:
    reveal_locals()
    c = a + b
    reveal_locals()
    return c
```
gives:
```
sample.py:2: error: Revealed local types are '{}'
sample.py:4: error: Revealed local types are '{'a': builtins.int, 'b': builtins.int, 'c': builtins.int}'
```
The output should be the same for both lines. I do not know of an easy fix yet.

Feedback is welcomed. I realize there will be likely many changes to this before it is merge ready.