### PR TITLE
myunit: Find temp directory relative to source tree, not cwd

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,12 @@
+import os.path
+
+import pytest
+
 pytest_plugins = [
     'mypy.test.data',
 ]
+
+def pytest_configure(config):
+    mypy_source_root = os.path.dirname(os.path.abspath(__file__))
+    if os.getcwd() != mypy_source_root:
+        os.chdir(mypy_source_root)

--- a/mypy/myunit/__init__.py
+++ b/mypy/myunit/__init__.py
@@ -120,9 +120,7 @@ class TestCase:
 
     def set_up(self) -> None:
         self.old_cwd = os.getcwd()
-        root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        self.tmpdir = tempfile.TemporaryDirectory(prefix='mypy-test-',
-                dir=os.path.abspath(os.path.join(root_dir, 'tmp-test-dirs')))
+        self.tmpdir = tempfile.TemporaryDirectory(prefix='mypy-test-')
         os.chdir(self.tmpdir.name)
         os.mkdir('tmp')
         if self.suite:

--- a/mypy/myunit/__init__.py
+++ b/mypy/myunit/__init__.py
@@ -120,8 +120,9 @@ class TestCase:
 
     def set_up(self) -> None:
         self.old_cwd = os.getcwd()
+        root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         self.tmpdir = tempfile.TemporaryDirectory(prefix='mypy-test-',
-                dir=os.path.abspath('tmp-test-dirs'))
+                dir=os.path.abspath(os.path.join(root_dir, 'tmp-test-dirs')))
         os.chdir(self.tmpdir.name)
         os.mkdir('tmp')
         if self.suite:


### PR DESCRIPTION
We use a directory tmp-test-dirs/ under the top level of the mypy
source tree for our temporary directories when running tests.
We've been finding it relative to the current working directory, on
the assumption that that is the root of the source tree; which is a
fine constraint to require, but the way we fail if that constraint is
broken is an error in each test case's setup, which pytest presents as
one of those massive stack traces it specializes in. See #3412.

Instead, find the root of the source tree directly, using `__file__`.

After this change, `pytest -n0` runs fine from `mypy/` or
`mypy/test/`, and plain `pytest` (with parallelization) runs fine from
`mypy/test/` and gives a different, now mercifully short, obscure
error from `mypy/`.  We'll leave that for another PR or another day.