### PR TITLE
Mismatch of inferred type and return type note

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -17,7 +17,8 @@ from mypy.types import (
 )
 from mypy.nodes import (
     TypeInfo, Context, MypyFile, op_methods, FuncDef, reverse_type_aliases,
-    ARG_POS, ARG_OPT, ARG_NAMED, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2
+    ARG_POS, ARG_OPT, ARG_NAMED, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2,
+    ReturnStmt, NameExpr, Var
 )
 
 
@@ -977,3 +978,31 @@ def pretty_or(args: List[str]) -> str:
     if len(quoted) == 2:
         return "{} or {}".format(quoted[0], quoted[1])
     return ", ".join(quoted[:-1]) + ", or " + quoted[-1]
+
+
+def make_inferred_type_note(context: Context, subtype: Type,
+                            supertype: Type, supertype_str: str) -> str:
+    """Explain that the user may have forgotten to type a variable.
+
+    The user does not expect an error if the inferred container type is the same as the return
+    type of a function and the argument type(s) are a subtype of the argument type(s) of the
+    return type. This note suggests that they add a type annotation with the return type instead
+    of relying on the inferred type.
+    """
+    from mypy.subtypes import is_subtype
+    if (isinstance(subtype, Instance) and
+            isinstance(supertype, Instance) and
+            subtype.type.fullname() == supertype.type.fullname() and
+            subtype.args and
+            supertype.args and
+            isinstance(context, ReturnStmt) and
+            isinstance(context.expr, NameExpr) and
+            isinstance(context.expr.node, Var) and
+            context.expr.node.is_inferred):
+        for subtype_arg, supertype_arg in zip(subtype.args, supertype.args):
+            if not is_subtype(subtype_arg, supertype_arg):
+                return ''
+        var_name = context.expr.name
+        return 'Perhaps you need a type annotation for "{}"? Suggestion: {}'.format(
+            var_name, supertype_str)
+    return ''

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2094,24 +2094,28 @@ def j() -> List[Union[int, float]]:
     x = ['a']
     return x # E: Incompatible return value type (got List[str], expected List[Union[int, float]])
 
-def k() -> Dict[str, Union[str, int]]:
+def k() -> List[Union[str, int]]:
+    x = ('a', 2)
+    return x # E: Incompatible return value type (got "Tuple[str, int]", expected List[Union[str, int]])
+
+[builtins fixtures/dict.pyi]
+
+[case testInferredTypeIsObjectNotMatchUnion]
+from typing import Union, Dict, List
+def f() -> Dict[str, Union[str, int]]:
     x = {'a': 'a', 'b': 2}
     return x # E: Incompatible return value type (got Dict[str, object], expected Dict[str, Union[str, int]])
 
-def l() -> Dict[str, Union[str, int]]:
+def g() -> Dict[str, Union[str, int]]:
     x: Dict[str, Union[str, int]] = {'a': 'a', 'b': 2}
     return x
 
-def m() -> List[Union[str, int]]:
+def h() -> List[Union[str, int]]:
     x = ['a', 2]
     return x # E: Incompatible return value type (got List[object], expected List[Union[str, int]])
 
-def n() -> List[Union[str, int]]:
+def i() -> List[Union[str, int]]:
     x: List[Union[str, int]] = ['a', 2]
-    return x
-
-def o() -> Union[str, int]:
-    x = 'a'
     return x
 
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2068,7 +2068,7 @@ def fn(
         a: badtype) -> None: # E: Name 'badtype' is not defined
     pass
 
-[case testInferredTypeMismatchReturnType]
+[case testInferredTypeSubTypeOfReturnType]
 from typing import Union, Dict, List
 def f() -> List[Union[str, int]]:
     x = ['a']
@@ -2090,17 +2090,21 @@ def i() -> List[Union[int, float]]:
     return x # E: Incompatible return value type (got List[int], expected List[Union[int, float]]) \
 # N: Perhaps you need a type annotation for "x"? Suggestion: List[Union[int, float]]
 
-def j() -> List[Union[int, float]]:
+[builtins fixtures/dict.pyi]
+
+[case testInferredTypeNotSubTypeOfReturnType]
+from typing import Union, List
+def f() -> List[Union[int, float]]:
     x = ['a']
     return x # E: Incompatible return value type (got List[str], expected List[Union[int, float]])
 
-def k() -> List[Union[str, int]]:
+def g() -> List[Union[str, int]]:
     x = ('a', 2)
     return x # E: Incompatible return value type (got "Tuple[str, int]", expected List[Union[str, int]])
 
-[builtins fixtures/dict.pyi]
+[builtins fixtures/list.pyi]
 
-[case testInferredTypeIsObjectNotMatchUnion]
+[case testInferredTypeIsObjectMismatch]
 from typing import Union, Dict, List
 def f() -> Dict[str, Union[str, int]]:
     x = {'a': 'a', 'b': 2}

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2070,23 +2070,48 @@ def fn(
 
 [case testInferredTypeMismatchReturnType]
 from typing import Union, Dict, List
-def f() -> List[Union[int, str]]:
+def f() -> List[Union[str, int]]:
     x = ['a']
-    return x # E: Incompatible return value type (got List[str], expected List[Union[int, str]]) \
-# N: Perhaps you need a type annotation for "x"? Suggestion: List[Union[int, str]]
+    return x # E: Incompatible return value type (got List[str], expected List[Union[str, int]]) \
+# N: Perhaps you need a type annotation for "x"? Suggestion: List[Union[str, int]]
 
-def g() -> Dict[str, Union[int, str]]:
+def g() -> Dict[str, Union[str, int]]:
     x = {'a': 'a'}
-    return x # E: Incompatible return value type (got Dict[str, str], expected Dict[str, Union[int, str]]) \
-# N: Perhaps you need a type annotation for "x"? Suggestion: Dict[str, Union[int, str]]
+    return x # E: Incompatible return value type (got Dict[str, str], expected Dict[str, Union[str, int]]) \
+# N: Perhaps you need a type annotation for "x"? Suggestion: Dict[str, Union[str, int]]
 
-def h() -> List[Union[int, float]]:
+def h() -> Dict[Union[str, int], str]:
+    x = {'a': 'a'}
+    return x # E: Incompatible return value type (got Dict[str, str], expected Dict[Union[str, int], str]) \
+# N: Perhaps you need a type annotation for "x"? Suggestion: Dict[Union[str, int], str]
+
+def i() -> List[Union[int, float]]:
+    x: List[int] = [1]
+    return x # E: Incompatible return value type (got List[int], expected List[Union[int, float]]) \
+# N: Perhaps you need a type annotation for "x"? Suggestion: List[Union[int, float]]
+
+def j() -> List[Union[int, float]]:
     x = ['a']
     return x # E: Incompatible return value type (got List[str], expected List[Union[int, float]])
 
-def i() -> List[Union[int, float]]:
-    x = [1] # Type: List[int]
-    return x # E: Incompatible return value type (got List[int], expected List[Union[int, float]]) \
-# N: Perhaps you need a type annotation for "x"? Suggestion: List[Union[int, float]]
+def k() -> Dict[str, Union[str, int]]:
+    x = {'a': 'a', 'b': 2}
+    return x # E: Incompatible return value type (got Dict[str, object], expected Dict[str, Union[str, int]])
+
+def l() -> Dict[str, Union[str, int]]:
+    x: Dict[str, Union[str, int]] = {'a': 'a', 'b': 2}
+    return x
+
+def m() -> List[Union[str, int]]:
+    x = ['a', 2]
+    return x # E: Incompatible return value type (got List[object], expected List[Union[str, int]])
+
+def n() -> List[Union[str, int]]:
+    x: List[Union[str, int]] = ['a', 2]
+    return x
+
+def o() -> Union[str, int]:
+    x = 'a'
+    return x
 
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2072,11 +2072,13 @@ def fn(
 from typing import Union, Dict, List
 def f() -> List[Union[int, str]]:
     x = ['a']
-    return x # E: Incompatible return value type (got List[str], expected List[Union[int, str]]) # N: Perhaps a type annotation is missing here? Suggestion: List[Union[int, str]]
+    return x # E: Incompatible return value type (got List[str], expected List[Union[int, str]]) \
+# N: Perhaps a type annotation is missing here? Suggestion: List[Union[int, str]]
 
 def g() -> Dict[str, Union[int, str]]:
     x = {'a': 'a'}
-    return x # E: Incompatible return value type (got Dict[str, str], expected Dict[str, Union[int, str]]) # N: Perhaps a type annotation is missing here? Suggestion: Dict[str, Union[int, str]]
+    return x # E: Incompatible return value type (got Dict[str, str], expected Dict[str, Union[int, str]]) \
+# N: Perhaps a type annotation is missing here? Suggestion: Dict[str, Union[int, str]]
 
 def h() -> List[Union[int, float]]:
     x = ['a']
@@ -2084,6 +2086,7 @@ def h() -> List[Union[int, float]]:
 
 def i() -> List[Union[int, float]]:
     x = [1] # Type: List[int]
-    return x # E: Incompatible return value type (got List[int], expected List[Union[int, float]]) # N: Perhaps a type annotation is missing here? Suggestion: List[Union[int, float]]
+    return x # E: Incompatible return value type (got List[int], expected List[Union[int, float]]) \
+# N: Perhaps a type annotation is missing here? Suggestion: List[Union[int, float]]
 
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2073,12 +2073,12 @@ from typing import Union, Dict, List
 def f() -> List[Union[int, str]]:
     x = ['a']
     return x # E: Incompatible return value type (got List[str], expected List[Union[int, str]]) \
-# N: Perhaps a type annotation is missing here? Suggestion: List[Union[int, str]]
+# N: Perhaps you need a type annotation for "x"? Suggestion: List[Union[int, str]]
 
 def g() -> Dict[str, Union[int, str]]:
     x = {'a': 'a'}
     return x # E: Incompatible return value type (got Dict[str, str], expected Dict[str, Union[int, str]]) \
-# N: Perhaps a type annotation is missing here? Suggestion: Dict[str, Union[int, str]]
+# N: Perhaps you need a type annotation for "x"? Suggestion: Dict[str, Union[int, str]]
 
 def h() -> List[Union[int, float]]:
     x = ['a']
@@ -2087,6 +2087,6 @@ def h() -> List[Union[int, float]]:
 def i() -> List[Union[int, float]]:
     x = [1] # Type: List[int]
     return x # E: Incompatible return value type (got List[int], expected List[Union[int, float]]) \
-# N: Perhaps a type annotation is missing here? Suggestion: List[Union[int, float]]
+# N: Perhaps you need a type annotation for "x"? Suggestion: List[Union[int, float]]
 
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2067,3 +2067,23 @@ def some_method(self: badtype): pass # E: Name 'badtype' is not defined
 def fn(
         a: badtype) -> None: # E: Name 'badtype' is not defined
     pass
+
+[case testInferredTypeMismatchReturnType]
+from typing import Union, Dict, List
+def f() -> List[Union[int, str]]:
+    x = ['a']
+    return x # E: Incompatible return value type (got List[str], expected List[Union[int, str]]) # N: Perhaps a type annotation is missing here? Suggestion: List[Union[int, str]]
+
+def g() -> Dict[str, Union[int, str]]:
+    x = {'a': 'a'}
+    return x # E: Incompatible return value type (got Dict[str, str], expected Dict[str, Union[int, str]]) # N: Perhaps a type annotation is missing here? Suggestion: Dict[str, Union[int, str]]
+
+def h() -> List[Union[int, float]]:
+    x = ['a']
+    return x # E: Incompatible return value type (got List[str], expected List[Union[int, float]])
+
+def i() -> List[Union[int, float]]:
+    x = [1] # Type: List[int]
+    return x # E: Incompatible return value type (got List[int], expected List[Union[int, float]]) # N: Perhaps a type annotation is missing here? Suggestion: List[Union[int, float]]
+
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes #2529 

Not sure about this function sitting in `checker.py`, might need to move it to `messages.py` but didn't look into that yet.

I use the `context.expr.node.is_inferred` to determine if the type of the variable is inferred to determine if the message is printed. Apparently `is_inferred` is still `True` even when the adding a type comment in the code. See below:

```
def i() -> List[Union[int, float]]:
    x = [1] # Type: List[int]
    return x
```

Specifically, the `context.expr.node.is_inferred=True` for `x` when I would expect it to be `False`.