### PR TITLE
Rework cache to key on hash of file contents instead of mtime

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -698,6 +698,7 @@ def read_with_python_encoding(path: str, pyversion: Tuple[int, int]) -> Tuple[st
         # read first two lines and check if PEP-263 coding is present
         source_bytearray.extend(f.readline())
         source_bytearray.extend(f.readline())
+        m = hashlib.md5(source_bytearray)
 
         # check for BOM UTF-8 encoding and strip it out if present
         if source_bytearray.startswith(b'\xef\xbb\xbf'):
@@ -710,12 +711,14 @@ def read_with_python_encoding(path: str, pyversion: Tuple[int, int]) -> Tuple[st
             if _encoding != 'mypy':
                 encoding = _encoding
 
-        source_bytearray.extend(f.read())
+        remainder = f.read()
+        m.update(remainder)
+        source_bytearray.extend(remainder)
         try:
-            source_bytearray.decode(encoding)
+            source_text = source_bytearray.decode(encoding)
         except LookupError as lookuperr:
             raise DecodeError(str(lookuperr))
-        return source_bytearray.decode(encoding), hashlib.md5(source_bytearray).hexdigest()
+        return source_text, m.hexdigest()
 
 
 def get_cache_names(id: str, path: str, cache_dir: str,

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -282,7 +282,7 @@ class TypeCheckSuite(DataSuite):
         missing = {}
         for id, path in modules.items():
             meta = build.find_cache_meta(id, path, manager)
-            if not build.is_meta_fresh(meta, id, path, manager):
+            if not build.validate_meta(meta, id, path, manager):
                 missing[id] = path
         return set(missing.values())
 

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -78,18 +78,6 @@ files = [
 ]
 
 
-# Used temporarily to demonstrate behavior of the new algorithm; removed in the later commit, and
-# will be eventually replaced by a proper test.
-def recursive_touch(root: str) -> None:
-    try:
-        import pathlib
-    except ImportError:
-        return
-    p = pathlib.Path(root)
-    for test_module in p.glob('**/*.py'):
-        test_module.touch()
-
-
 class TypeCheckSuite(DataSuite):
     def __init__(self, *, update_data: bool = False) -> None:
         self.update_data = update_data
@@ -183,8 +171,6 @@ class TypeCheckSuite(DataSuite):
             # Always set to none so we're forced to reread the module in incremental mode
             sources.append(BuildSource(program_path, module_name,
                                        None if incremental_step else program_text))
-        # Update mtime for all module files to test our behavior when relying on module hashes.
-        recursive_touch('.')
         res = None
         try:
             res = build.build(sources=sources,

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -78,6 +78,18 @@ files = [
 ]
 
 
+# Used temporarily to demonstrate behavior of the new algorithm; removed in the later commit, and
+# will be eventually replaced by a proper test.
+def recursive_touch(root: str) -> None:
+    try:
+        import pathlib
+    except ImportError:
+        return
+    p = pathlib.Path(root)
+    for test_module in p.glob('**/*.py'):
+        test_module.touch()
+
+
 class TypeCheckSuite(DataSuite):
     def __init__(self, *, update_data: bool = False) -> None:
         self.update_data = update_data
@@ -171,6 +183,8 @@ class TypeCheckSuite(DataSuite):
             # Always set to none so we're forced to reread the module in incremental mode
             sources.append(BuildSource(program_path, module_name,
                                        None if incremental_step else program_text))
+        # Update mtime for all module files to test our behavior when relying on module hashes.
+        recursive_touch('.')
         res = None
         try:
             res = build.build(sources=sources,


### PR DESCRIPTION
Attempt to fix #3403 

At present, I'm only adding the ability to validate the cache using a hash even though the module file mtime doesn't match the meta mtime.

However, I'm NOT getting rid of the use of `data_mtime` (modified time of the cache file) for the purpose of finding dependencies that tell us that a given module needs to be reparsed. This is much more complex than I thought, and it may also be possible to work around that by using @JukkaL  suggestion of putting the enitre cache into a tarball to preserve cache mtimes.

To verify that the approach works, I first create a failing test by changing the tests runner to touch all the source files before running mypy for incremental tests. Then in the second commit, I fix the broken tests.

How this whole thing should be tested is something that I'd like feedback on (running the tests twice is too time consuming I think?). As it stands, this PR only tests the new approach, and loses the tests for the old approach (with mtime/size). Maybe some kind of combination of the two would be good?