### PR TITLE
Fix bug in cache log

### DIFF
--- a/mypy/waiter.py
+++ b/mypy/waiter.py
@@ -339,7 +339,7 @@ class Waiter:
 
         if self.new_log:  # don't append empty log, it will corrupt the cache file
             # log only LOGSIZE most recent tests
-            test_log = (self.load_log_file() + [self.new_log])[:self.LOGSIZE]
+            test_log = (self.load_log_file() + [self.new_log])[-self.LOGSIZE:]
             try:
                 with open(self.FULL_LOG_FILENAME, 'w') as fp:
                     json.dump(test_log, fp, sort_keys=True, indent=4)


### PR DESCRIPTION
A bug in the test runner was deleting the newest instead of the oldest log entries. This had nearly no visible impact on the users, except that ordering tests by descendinig runtime was done using old data, and `python runtests.py --lf` does not work correctly.