### PR TITLE
Fix last character cut in html-report if file does not end with newline

### DIFF
--- a/mypy/report.py
+++ b/mypy/report.py
@@ -331,10 +331,12 @@ class MemoryXmlReporter(AbstractReporter):
             for lineno, line_text in enumerate(input_file, 1):
                 status = visitor.line_map.get(lineno, stats.TYPE_EMPTY)
                 file_info.counts[status] += 1
+                if line_text.endswith('\n'):
+                    line_text = line_text[:-1]
                 etree.SubElement(root, 'line',
                                  number=str(lineno),
                                  precision=stats.precision_names[status],
-                                 content=line_text[:-1])
+                                 content=line_text)
         # Assumes a layout similar to what XmlReporter uses.
         xslt_path = os.path.relpath('mypy-html.xslt', path)
         transform_pi = etree.ProcessingInstruction('xml-stylesheet',

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -334,7 +334,7 @@ class MemoryXmlReporter(AbstractReporter):
                 etree.SubElement(root, 'line',
                                  number=str(lineno),
                                  precision=stats.precision_names[status],
-                                 content=line_text.strip('\n'))
+                                 content=line_text.rstrip('\n'))
         # Assumes a layout similar to what XmlReporter uses.
         xslt_path = os.path.relpath('mypy-html.xslt', path)
         transform_pi = etree.ProcessingInstruction('xml-stylesheet',

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -331,12 +331,10 @@ class MemoryXmlReporter(AbstractReporter):
             for lineno, line_text in enumerate(input_file, 1):
                 status = visitor.line_map.get(lineno, stats.TYPE_EMPTY)
                 file_info.counts[status] += 1
-                if line_text.endswith('\n'):
-                    line_text = line_text[:-1]
                 etree.SubElement(root, 'line',
                                  number=str(lineno),
                                  precision=stats.precision_names[status],
-                                 content=line_text)
+                                 content=line_text.strip('\n'))
         # Assumes a layout similar to what XmlReporter uses.
         xslt_path = os.path.relpath('mypy-html.xslt', path)
         transform_pi = etree.ProcessingInstruction('xml-stylesheet',


### PR DESCRIPTION
If a file did not end with a newline, html-report would not output it.

I couldn't find any tests for html report. Maybe it's worth having some. 