### PR TITLE
Add exception to descriptor protocol for MethodType().__func__.

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1086,6 +1086,16 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if not descriptor_type.type.has_readable_member('__get__'):
             return descriptor_type
 
+        # accessing MethodType().__func__ gives FunctionType, despite the fact
+        # that FunctionType is usually a descriptor returning MethodType
+        if (
+            isinstance(instance_type, Instance) and
+            instance_type.type.fullname() == 'types.MethodType' and
+            isinstance(context, MemberExpr) and
+            context.name == '__func__'
+        ):
+            return descriptor_type
+
         dunder_get = descriptor_type.type.get_method('__get__')
 
         if dunder_get is None:

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2123,3 +2123,24 @@ def i() -> List[Union[str, int]]:
     return x
 
 [builtins fixtures/dict.pyi]
+
+[case testMethodTypeFuncAttribute]
+from types import MethodType
+
+class C:
+    def foo(self): ...
+
+method = C().foo
+if isinstance(method, MethodType):
+    reveal_type(method)  # E: Revealed type is 'types.MethodType'
+    mfunc = method.__func__
+    reveal_type(mfunc)  # E: Revealed type is 'types.FunctionType'
+
+[file types.pyi]
+class FunctionType:
+    def __get__(self, obj, type) -> 'MethodType': ...
+
+class MethodType:
+    __func__ = ...  # type: FunctionType
+
+[builtins fixtures/isinstance.pyi]


### PR DESCRIPTION
`types.FunctionType` is [annotated as a descriptor](https://github.com/python/typeshed/blob/master/stdlib/3/types.pyi#L35) returning `types.MethodType`. In general, this is correct: if you access a `FunctionType` as an attribute of some instance, you get back a `MethodType`.

But `MethodType` has an attribute `__func__`, [which is a](https://github.com/python/typeshed/blob/master/stdlib/3/types.pyi#L125) `FunctionType`. And this attribute does not obey the descriptor protocol; it really does give you a `FunctionType`, not a `MethodType`.

(I think in general `MethodType`, as a type implemented in C, doesn't obey the descriptor protocol: e.g. this is true of its `__self__` attribute too, even if the self-object of a method is a descriptor, if you access `mymethod.__self__` you get the object, not the return value of its `__get__` method. But `__self__` does not currently require special-casing here, because mypy just considers it to be of type `object`, which isn't a descriptor; mypy doesn't track the type of the actual `__self__` of a given method.)

This pull request fixes mypy's type inference so it knows that `mymethod.__func__` is a `FunctionType`, not a `MethodType`.