### PR TITLE
Improve test output when a test doesn't specify the correct fixture

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -154,7 +154,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             result = type_object_type(node, self.named_type)
         elif isinstance(node, MypyFile):
             # Reference to a module object.
-            result = self.named_type('types.ModuleType')
+            try:
+                result = self.named_type('types.ModuleType')
+            except KeyError:
+                # In test cases might 'types' may not be available.
+                # Fall back to a dummy 'object' type instead to
+                # avoid a crash.
+                result = self.named_type('builtins.object')
         elif isinstance(node, Decorator):
             result = self.analyze_var_ref(node.var, e)
         else:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -75,6 +75,7 @@ files = [
     'check-underscores.test',
     'check-classvar.test',
     'check-enum.test',
+    'check-incomplete-fixture.test',
 ]
 
 

--- a/test-data/unit/check-incomplete-fixture.test
+++ b/test-data/unit/check-incomplete-fixture.test
@@ -1,0 +1,98 @@
+-- Test cases for reporting errors when a test case uses a fixture with
+-- missing definitions.  At least in the most common cases this should not
+-- result in an uncaught exception.  These tests make sure that this behavior
+-- does not regress.
+--
+-- NOTE: These tests do NOT test behavior of mypy outside tests.
+
+[case testVariableUndefinedUsingDefaultFixture]
+import m
+# This used to cause a crash since types.ModuleType is not available
+# by default. We fall back to 'object' now.
+m.x # E: "object" has no attribute "x"
+[file m.py]
+
+[case testListMissingFromStubs]
+from typing import List
+def f(x: List[int]) -> None: pass
+[out]
+main:1: error: Name '__builtins__.list' is not defined
+main:1: note: Maybe your test fixture does not define "typing.List"?
+main:1: note: Consider adding [builtins fixtures/list.pyi] to your test description
+
+[case testDictMissingFromStubs]
+from typing import Dict
+def f(x: Dict[int]) -> None: pass
+[out]
+main:1: error: Name '__builtins__.dict' is not defined
+main:1: note: Maybe your test fixture does not define "typing.Dict"?
+main:1: note: Consider adding [builtins fixtures/dict.pyi] to your test description
+
+[case testSetMissingFromStubs]
+from typing import Set
+def f(x: Set[int]) -> None: pass
+[out]
+main:1: error: Name '__builtins__.set' is not defined
+main:1: note: Maybe your test fixture does not define "typing.Set"?
+main:1: note: Consider adding [builtins fixtures/set.pyi] to your test description
+
+[case testBoolMissingFromStubs]
+x: bool
+[out]
+main:1: error: Name 'bool' is not defined
+main:1: note: Maybe your test fixture does not define "builtins.bool"?
+main:1: note: Consider adding [builtins fixtures/bool.pyi] to your test description
+
+[case testBaseExceptionMissingFromStubs]
+e: BaseException
+[out]
+main:1: error: Name 'BaseException' is not defined
+main:1: note: Maybe your test fixture does not define "builtins.BaseException"?
+main:1: note: Consider adding [builtins fixtures/exception.pyi] to your test description
+
+[case testExceptionMissingFromStubs]
+e: Exception
+[out]
+main:1: error: Name 'Exception' is not defined
+main:1: note: Maybe your test fixture does not define "builtins.Exception"?
+main:1: note: Consider adding [builtins fixtures/exception.pyi] to your test description
+
+[case testIsinstanceMissingFromStubs]
+if isinstance(1, int):
+    pass
+[out]
+main:1: error: Name 'isinstance' is not defined
+main:1: note: Maybe your test fixture does not define "builtins.isinstance"?
+main:1: note: Consider adding [builtins fixtures/isinstancelist.pyi] to your test description
+
+[case testInvalidTupleDefinitionFromStubs]
+from typing import Tuple
+x: Tuple[int, ...]
+x[0]
+for y in x:
+    pass
+[out]
+-- These errors are pretty bad, but keeping this test anyway to
+-- avoid things getting worse.
+main:2: error: "tuple" expects no type arguments, but 1 given
+main:3: error: Value of type "tuple" is not indexable
+main:4: error: Iterable expected
+main:4: error: "tuple" has no attribute "__iter__"
+
+[case testClassmethodMissingFromStubs]
+class A:
+    @classmethod
+    def f(cls): pass
+[out]
+main:2: error: Name 'classmethod' is not defined
+main:2: note: Maybe your test fixture does not define "builtins.classmethod"?
+main:2: note: Consider adding [builtins fixtures/classmethod.pyi] to your test description
+
+[case testPropertyMissingFromStubs]
+class A:
+    @property
+    def f(self): pass
+[out]
+main:2: error: Name 'property' is not defined
+main:2: note: Maybe your test fixture does not define "builtins.property"?
+main:2: note: Consider adding [builtins fixtures/property.pyi] to your test description


### PR DESCRIPTION
Improve things in two ways:

1) Don't crash in tests due to missing types.ModuleType

   The fixtures used in many test cases don't import the `types` module
   to speed up tests, and this would often cause uncaught exceptions while
   writing tests.  Now we generate a useful message instead.

2) Suggest fixtures

   If a developer is doing certain common things in a mypy test that
   require a non-default builtins fixture (such as using `typing.List`), add a
   hint that points to a fixture that is likely to help.