### PR TITLE
fix crash when serializing a type-ignored property setter

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -564,9 +564,10 @@ class SemanticAnalyzer(NodeVisitor):
                         first_item.var.is_settable_property = True
                         # Get abstractness from the original definition.
                         item.func.is_abstract = first_item.func.is_abstract
-                item.func.accept(self)
             else:
                 self.fail("Decorated property not supported", item)
+            if isinstance(item, Decorator):
+                item.func.accept(self)
 
     def analyze_function(self, defn: FuncItem) -> None:
         is_method = self.is_class_scope()

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2684,3 +2684,32 @@ b.x.y
 [out3]
 tmp/c.py:2: error: Revealed type is '<stale cache: consider running mypy without --quick>'
 tmp/c.py:5: error: "<stale cache: consider running mypy without --quick>" has no attribute "y"
+
+[case testSerializeAbstractPropertyIncremental]
+from abc import abstractmethod
+import typing
+class A:
+    @property
+    def f(self) -> int:
+        return 1
+    @f.setter  # type: ignore
+    @abstractmethod
+    def f(self, x: int) -> None:
+        pass
+a = A()
+[builtins fixtures/property.pyi]
+
+[case testSerializeAbstractPropertyDisallowUntypedIncremental]
+# flags: --disallow-untyped-defs
+from abc import abstractmethod
+import typing
+class A:
+    @property
+    def f(self) -> int:
+        return 1
+    @f.setter  # type: ignore
+    @abstractmethod
+    def f(self, x: int) -> None:
+        pass
+a = A()
+[builtins fixtures/property.pyi]

--- a/test-data/unit/fixtures/property.pyi
+++ b/test-data/unit/fixtures/property.pyi
@@ -6,7 +6,7 @@ class object:
     def __init__(self) -> None: pass
 
 class type:
-    def __init__(self, x) -> None: pass
+    def __init__(self, x: typing.Any) -> None: pass
 
 class function: pass
 

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -54,7 +54,7 @@ class Generator(Iterator[T], Generic[T, U, V]):
     def send(self, value: U) -> T: pass
 
     @abstractmethod
-    def throw(self, typ: Any, val: Any=None, tb=None) -> None: pass
+    def throw(self, typ: Any, val: Any=None, tb: Any=None) -> None: pass
 
     @abstractmethod
     def close(self) -> None: pass

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -54,7 +54,7 @@ class Generator(Iterator[T], Generic[T, U, V]):
     def send(self, value: U) -> T: pass
 
     @abstractmethod
-    def throw(self, typ: Any, val: Any=None, tb: Any=None) -> None: pass
+    def throw(self, typ: Any, val: Any = None, tb: Any = None) -> None: pass
 
     @abstractmethod
     def close(self) -> None: pass


### PR DESCRIPTION
This fixes two issues from #3491: a crash in serialization and an incorrect error "Function is missing a type annotation for one or more arguments". Both had the same root cause; we were skipping semantic analysis for the function body if mypy was unhappy with the property.setter decorator.