### PR TITLE
Fix spurious "cycle in function expansion" errors.

### DIFF
--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -57,7 +57,7 @@ class StatisticsVisitor(TraverserVisitor):
 
     def visit_func_def(self, o: FuncDef) -> None:
         self.line = o.line
-        if len(o.expanded) > 1:
+        if len(o.expanded) > 1 and o.expanded != [o] * len(o.expanded):
             if o in o.expanded:
                 print('ERROR: cycle in function expansion; skipping')
                 return


### PR DESCRIPTION
Most of these (at least) seem to be due to a function being analyzed
multiple times, and the 'expanded' list filling up with 2 or more
references to the same FuncDef.

If there are other reasons they will still trigger the same error, but
at least for mypy itself, the error no longer appears with this simple
fix.

Fixes #3503.