### PR TITLE
User-plugin system

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -21,7 +21,7 @@ import time
 from os.path import dirname, basename
 
 from typing import (AbstractSet, Dict, Iterable, Iterator, List,
-                    NamedTuple, Optional, Set, Tuple, Type as Class, Union)
+                    NamedTuple, Optional, Set, Tuple, Union)
 # Can't use TYPE_CHECKING because it's not in the Python 3.5.1 stdlib
 MYPY = False
 if MYPY:
@@ -113,7 +113,7 @@ def build(sources: List[BuildSource],
           options: Options,
           alt_lib_path: str = None,
           bin_dir: str = None,
-          plugins: Optional[List[Class[Plugin]]] = None,
+          plugin: Optional[Plugin] = None,
           ) -> BuildResult:
     """Analyze a program.
 
@@ -176,9 +176,9 @@ def build(sources: List[BuildSource],
 
     source_set = BuildSourceSet(sources)
 
-    if plugins is None:
-        plugins = [DefaultPlugin]
-    plugin_manager = PluginManager(options.python_version, plugins)
+    if plugin is None:
+        plugin = DefaultPlugin(options.python_version)
+
     # Construct a build manager object to hold state during the build.
     #
     # Ignore current directory prefix in error messages.
@@ -188,7 +188,7 @@ def build(sources: List[BuildSource],
                            reports=reports,
                            options=options,
                            version_id=__version__,
-                           plugin=plugin_manager,
+                           plugin=plugin,
                            )
 
     try:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -21,7 +21,7 @@ import time
 from os.path import dirname, basename
 
 from typing import (AbstractSet, Dict, Iterable, Iterator, List,
-                    NamedTuple, Optional, Set, Tuple, Union)
+                    NamedTuple, Optional, Set, Tuple, Type as Class, Union)
 # Can't use TYPE_CHECKING because it's not in the Python 3.5.1 stdlib
 MYPY = False
 if MYPY:
@@ -42,7 +42,7 @@ from mypy.parse import parse
 from mypy.stats import dump_type_stats
 from mypy.types import Type
 from mypy.version import __version__
-from mypy.plugin import DefaultPlugin
+from mypy.plugin import PluginManager, Plugin, DefaultPlugin
 
 
 # We need to know the location of this file to load data, but
@@ -112,7 +112,9 @@ class BuildSourceSet:
 def build(sources: List[BuildSource],
           options: Options,
           alt_lib_path: str = None,
-          bin_dir: str = None) -> BuildResult:
+          bin_dir: str = None,
+          plugins: Optional[List[Class[Plugin]]] = None,
+          ) -> BuildResult:
     """Analyze a program.
 
     A single call to build performs parsing, semantic analysis and optionally
@@ -174,6 +176,9 @@ def build(sources: List[BuildSource],
 
     source_set = BuildSourceSet(sources)
 
+    if plugins is None:
+        plugins = [DefaultPlugin]
+    plugin_manager = PluginManager(options.python_version, plugins)
     # Construct a build manager object to hold state during the build.
     #
     # Ignore current directory prefix in error messages.
@@ -183,6 +188,7 @@ def build(sources: List[BuildSource],
                            reports=reports,
                            options=options,
                            version_id=__version__,
+                           plugin=plugin_manager,
                            )
 
     try:
@@ -364,7 +370,8 @@ class BuildManager:
                  source_set: BuildSourceSet,
                  reports: Reports,
                  options: Options,
-                 version_id: str) -> None:
+                 version_id: str,
+                 plugin: Plugin) -> None:
         self.start_time = time.time()
         self.data_dir = data_dir
         self.errors = Errors(options.show_error_context, options.show_column_numbers)
@@ -374,6 +381,7 @@ class BuildManager:
         self.reports = reports
         self.options = options
         self.version_id = version_id
+        self.plugin_manager = plugin
         self.modules = {}  # type: Dict[str, MypyFile]
         self.missing_modules = set()  # type: Set[str]
         self.semantic_analyzer = SemanticAnalyzer(self.modules, self.missing_modules,
@@ -1506,9 +1514,8 @@ class State:
         if self.options.semantic_analysis_only:
             return
         with self.wrap_context():
-            plugin = DefaultPlugin(self.options.python_version)
             self.type_checker = TypeChecker(manager.errors, manager.modules, self.options,
-                                            self.tree, self.xpath, plugin)
+                                            self.tree, self.xpath, manager.plugin_manager)
             self.type_checker.check_first_pass()
 
     def type_check_second_pass(self) -> bool:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -381,7 +381,7 @@ class BuildManager:
         self.reports = reports
         self.options = options
         self.version_id = version_id
-        self.plugin_manager = plugin
+        self.plugin = plugin
         self.modules = {}  # type: Dict[str, MypyFile]
         self.missing_modules = set()  # type: Set[str]
         self.semantic_analyzer = SemanticAnalyzer(self.modules, self.missing_modules,
@@ -1515,7 +1515,7 @@ class State:
             return
         with self.wrap_context():
             self.type_checker = TypeChecker(manager.errors, manager.modules, self.options,
-                                            self.tree, self.xpath, manager.plugin_manager)
+                                            self.tree, self.xpath, manager.plugin)
             self.type_checker.check_first_pass()
 
     def type_check_second_pass(self) -> bool:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -727,7 +727,7 @@ def parse_section(prefix: str, template: Options,
         key = key.replace('-', '_')
         if key.startswith('plugins.'):
             dv = section.get(key)
-            key = key[6:]
+            key = key[8:]
             plugins.append((key, dv))
             continue
         elif key in config_types:

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -3,6 +3,10 @@ import pprint
 import sys
 
 from typing import Mapping, Optional, Tuple, List, Pattern, Dict
+# Can't use TYPE_CHECKING because it's not in the Python 3.5.1 stdlib
+MYPY = False
+if MYPY:
+    from mypy.plugin import PluginRegistry
 
 from mypy import defaults
 
@@ -112,6 +116,9 @@ class Options:
         self.cache_dir = defaults.CACHE_DIR
         self.debug_cache = False
         self.quick_and_dirty = False
+
+        # plugins
+        self.plugins = []  # type: List[PluginRegistry]
 
         # Per-module options (raw)
         self.per_module_options = {}  # type: Dict[Pattern[str], Dict[str, object]]

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -3,10 +3,7 @@ import pprint
 import sys
 
 from typing import Mapping, Optional, Tuple, List, Pattern, Dict
-# Can't use TYPE_CHECKING because it's not in the Python 3.5.1 stdlib
-MYPY = False
-if MYPY:
-    from mypy.plugin import PluginRegistry
+from mypy.plugin import PluginRegistry
 
 from mypy import defaults
 

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Tuple, Type as Class, Optional, NamedTuple
+from typing import Callable, Dict, List, Tuple, Optional, NamedTuple
 
 from types import ModuleType
 from mypy.nodes import Expression, StrExpr, IntExpr, UnaryExpr, Context
@@ -178,10 +178,9 @@ class DefaultPlugin(Plugin):
 
 class PluginManager(Plugin):
     def __init__(self, python_version: Tuple[int, int],
-                 plugins: List[Class[Plugin]]) -> None:
+                 plugins: List[Plugin]) -> None:
         super().__init__(python_version)
-        # TODO: handle exceptions to provide more feedback
-        self.plugins = [p(python_version) for p in plugins]
+        self.plugins = plugins
         self._function_hooks = {}  # type: Dict[str, Optional[FunctionHook]]
         self._method_signature_hooks = {}  # type: Dict[str, Optional[MethodSignatureHook]]
         self._method_hooks = {}  # type: Dict[str, Optional[MethodHook]]

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -6,7 +6,9 @@ from mypy.types import (
     Type, Instance, CallableType, TypedDictType, UnionType, NoneTyp, FunctionLike, TypeVarType,
     AnyType
 )
-from mypy.messages import MessageBuilder
+MYPY = False
+if MYPY:
+    from mypy.messages import MessageBuilder
 
 
 def _safeimport(path: str) -> Optional[ModuleType]:
@@ -79,7 +81,7 @@ PluginRegistry = NamedTuple('PluginRegistry', [('name', str),
 # Some objects and callbacks that plugins can use to get information from the
 # type checker or to report errors.
 PluginContext = NamedTuple('PluginContext', [('named_instance', NamedInstanceCallback),
-                                             ('msg', MessageBuilder),
+                                             ('msg', 'MessageBuilder'),
                                              ('context', Context)])
 
 

--- a/mypy/test/testargs.py
+++ b/mypy/test/testargs.py
@@ -14,5 +14,5 @@ from mypy.main import process_options
 class ArgSuite(Suite):
     def test_coherence(self) -> None:
         options = Options()
-        _, parsed_options = process_options([], require_targets=False)
+        parsed_options = process_options([], require_targets=False)[1]
         assert_equal(options, parsed_options)

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -346,7 +346,7 @@ class TypeCheckSuite(DataSuite):
         flag_list = None
         if flags:
             flag_list = flags.group(1).split()
-            targets, options = process_options(flag_list, require_targets=False)
+            targets, options, _ = process_options(flag_list, require_targets=False)
             if targets:
                 # TODO: support specifying targets via the flags pragma
                 raise RuntimeError('Specifying targets via the flags pragma is not supported.')

--- a/mypy/test/testgraph.py
+++ b/mypy/test/testgraph.py
@@ -6,8 +6,10 @@ from mypy.myunit import Suite, assert_equal
 from mypy.build import BuildManager, State, BuildSourceSet
 from mypy.build import topsort, strongly_connected_components, sorted_components, order_ascc
 from mypy.version import __version__
+from mypy.plugin import DefaultPlugin
 from mypy.options import Options
 from mypy.report import Reports
+from mypy import defaults
 
 
 class GraphSuite(Suite):
@@ -42,6 +44,7 @@ class GraphSuite(Suite):
             reports=Reports('', {}),
             options=Options(),
             version_id=__version__,
+            plugin=DefaultPlugin(defaults.PYTHON3_VERSION)
         )
         return manager
 


### PR DESCRIPTION
Here's a design sketch for #1240.

Some thoughts, copied from there:

### Plugin discovery options
- A. by file path.  e.g.  `/path/to/myplugin.py`.  could also extend this with a `MYPY_PLUGIN_PATH`
  - pro: easier to write test cases (I discovered that placing a file on the PYTHONPATH within the tests was difficult, likely by design)
  - con: can't use `pip` to install plugins
- B. by dotted path:  e.g. `package.module`
  - pro: easy for users to create pip-installable plugins
  - con: adding plugin modules and their requirements to the PYTHONPATH could interfere with type checking? 
- C: setuptools entry points. e.g.:
    ```python
    setup(
        entry_points={
            'mypy.userplugin': ['my_plugin = my_module.plugin:register_plugin']
        }
    )
    ```

#### Sub-Options
- shall we always look for an object within the module with a designated named, e.g. `Plugin`, or make this configurable as well?  e.g. `package.module.MyPlugin` or `/path/to/myplugin.py:MyPlugin`  (Note: I've already written some functionality for the latter in my hooks branch)
- do user plugins need to inherit from `mypy.plugin.Plugin`?

### Plugin chainability options
- A. aggregate all user plugins into a single uber-plugin instance.  
  - each method on this aggregate plugin would cycle through its children in order until one returns a non-`None` result.  we could then cache the mapping from feature (e.g. `'typing.Mapping.get'`) to user-plugin instance to speed up future lookups.
  - this is compatible with the current design which passes a single `Plugin` instance around.
- B. register a plugin per feature.  this allows you to replace the search with a fast dictionary lookup, as well as detect up-front when two plugins contend for the same feature.


Right now I'm using discovery option B and chainability option A, but this is just a starting point for debate.

