### PR TITLE
Option to disallow all expressions of type Any(--disallow-any=expr)

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -278,7 +278,7 @@ Here are some more useful flags:
 
 - ``--disallow-any`` disallows various types of ``Any`` in a module.
   The option takes a comma-separated list of the following values:
-  ``unimported``, ``unannotated``.
+  ``unimported``, ``unannotated``, ``expr``.
 
   ``unimported`` disallows usage of types that come from unfollowed imports
   (such types become aliases for ``Any``). Unfollowed imports occur either
@@ -289,6 +289,13 @@ Here are some more useful flags:
   typed (i.e. that are missing an explicit type annotation for any
   of the parameters or the return type). ``unannotated`` option is
   interchangeable with ``--disallow-untyped-defs``.
+
+  ``expr`` disallows all expressions in the module that have type ``Any``.
+  If an expression of type ``Any`` appears anywhere in the module
+  mypy will output an error unless the expression is immediately
+  used as an argument to ``cast`` or assigned to a variable with an
+  explicit type annotation. Note that declaring a variable of type ``Any``
+  or casting to type ``Any`` is not allowed.
 
 - ``--disallow-untyped-defs`` reports an error whenever it encounters
   a function definition without type annotations.

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -294,8 +294,10 @@ Here are some more useful flags:
   If an expression of type ``Any`` appears anywhere in the module
   mypy will output an error unless the expression is immediately
   used as an argument to ``cast`` or assigned to a variable with an
-  explicit type annotation. Note that declaring a variable of type ``Any``
-  or casting to type ``Any`` is not allowed.
+  explicit type annotation. In addition, declaring a variable of type ``Any``
+  or casting to type ``Any`` is not allowed. Note that calling functions
+  that take parameters of type ``Any`` is still allowed.
+
 
 - ``--disallow-untyped-defs`` reports an error whenever it encounters
   a function definition without type annotations.

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -150,7 +150,7 @@ overridden by the pattern sections matching the module name.
 - ``disallow_any`` (Comma-separated list, default empty) is an option to
   disallow various types of ``Any`` in a module. The flag takes a
   comma-separated list of the following arguments: ``unimported``,
-  ``unannotated``. For explanations see the discussion for the
+  ``unannotated``, ``expr``. For explanations see the discussion for the
   :ref:`--disallow-any <disallow-any>` option.
 
 - ``disallow_untyped_calls`` (Boolean, default False) disallows

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1736,7 +1736,7 @@ class TypeChecker(NodeVisitor[None]):
             # '...' is always a valid initializer in a stub.
             return AnyType()
         else:
-            always_allow_any = lvalue_type and not isinstance(lvalue_type, AnyType)
+            always_allow_any = lvalue_type is not None and not isinstance(lvalue_type, AnyType)
             rvalue_type = self.expr_checker.accept(rvalue, lvalue_type,
                                                    always_allow_any=always_allow_any)
             if isinstance(rvalue_type, DeletedType):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1292,9 +1292,8 @@ class TypeChecker(NodeVisitor[None]):
                 self.check_indexed_assignment(index_lvalue, rvalue, lvalue)
 
             if inferred:
-                is_cast = isinstance(rvalue, CallExpr) and rvalue.is_cast()
-                init_type = self.expr_checker.accept(rvalue, always_allow_any=is_cast)
-                self.infer_variable_type(inferred, lvalue, init_type, rvalue)
+                self.infer_variable_type(inferred, lvalue, self.expr_checker.accept(rvalue),
+                                         rvalue)
 
     def check_compatibility_all_supers(self, lvalue: NameExpr, lvalue_type: Optional[Type],
                                        rvalue: Expression) -> bool:
@@ -1737,8 +1736,9 @@ class TypeChecker(NodeVisitor[None]):
             # '...' is always a valid initializer in a stub.
             return AnyType()
         else:
+            always_allow_any = lvalue_type and not isinstance(lvalue_type, AnyType)
             rvalue_type = self.expr_checker.accept(rvalue, lvalue_type,
-                                                   always_allow_any=lvalue_type is not None)
+                                                   always_allow_any=always_allow_any)
             if isinstance(rvalue_type, DeletedType):
                 self.msg.deleted_as_rvalue(rvalue_type, context)
             if isinstance(lvalue_type, DeletedType):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1736,7 +1736,7 @@ class TypeChecker(NodeVisitor[None]):
             # '...' is always a valid initializer in a stub.
             return AnyType()
         else:
-            rvalue_type = self.expr_checker.accept(rvalue, lvalue_type)
+            rvalue_type = self.expr_checker.accept(rvalue, lvalue_type, disallow_any=False)
             if isinstance(rvalue_type, DeletedType):
                 self.msg.deleted_as_rvalue(rvalue_type, context)
             if isinstance(lvalue_type, DeletedType):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -993,10 +993,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 return
             messages.incompatible_argument(n, m, callee, original_caller_type,
                                            caller_kind, context)
-        elif ('expr' in self.chk.options.disallow_any and
-                has_any_type(callee_type) and
-                not self.chk.is_stub):
-            messages.call_any_parameter(n, callee.name, callee_type, context)
 
     def overload_call_target(self, arg_types: List[Type], arg_kinds: List[int],
                              arg_names: List[str],

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -993,6 +993,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 return
             messages.incompatible_argument(n, m, callee, original_caller_type,
                                            caller_kind, context)
+        elif ('expr' in self.chk.options.disallow_any and
+                has_any_type(callee_type) and
+                not self.chk.is_stub):
+            messages.call_any_parameter(n, callee.name, callee_type, context)
 
     def overload_call_target(self, arg_types: List[Type], arg_kinds: List[int],
                              arg_names: List[str],

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -185,7 +185,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Type check a call expression."""
         if e.analyzed:
             # It's really a special form that only looks like a call.
-            return self.accept(e.analyzed, self.type_context[-1], always_allow_any=True)
+            return self.accept(e.analyzed, self.type_context[-1])
         if isinstance(e.callee, NameExpr) and isinstance(e.callee.node, TypeInfo) and \
                 e.callee.node.typeddict_type is not None:
             return self.check_typeddict_call(e.callee.node.typeddict_type,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2444,7 +2444,7 @@ def has_any_type(t: Type) -> bool:
 
 
 class HasAnyType(TypeQuery[bool]):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(any)
 
     def visit_any(self, t: AnyType) -> bool:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2217,6 +2217,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if ('expr' in self.chk.options.disallow_any and
                 not always_allow_any and
                 not self.chk.is_stub and
+                self.chk.in_checked_function() and
                 has_any_type(typ)):
             self.msg.disallowed_any_type(typ, node)
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -97,7 +97,7 @@ def type_check_only(sources: List[BuildSource], bin_dir: str, options: Options) 
                        options=options)
 
 
-disallow_any_options = ['unimported']
+disallow_any_options = ['unimported', 'expr']
 
 
 def disallow_any_argument_type(raw_options: str) -> List[str]:
@@ -201,7 +201,6 @@ def process_options(args: List[str],
 
     strict_flag_names = []  # type: List[str]
     strict_flag_assignments = []  # type: List[Tuple[str, bool]]
-    disallow_any_options = ['unimported']
 
     def add_invertible_flag(flag: str,
                             *,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -906,11 +906,10 @@ class MessageBuilder:
 
     def disallowed_any_type(self, typ: Type, context: Context) -> None:
         if isinstance(typ, AnyType):
-            infix = 'type'
+            message = 'Expression has type "Any"'
         else:
-            infix = 'type that contains type'
-        self.fail('Expressions of {} "Any" are disallowed '
-                  '(has type {})'.format(infix, self.format(typ)), context)
+            message = 'Expression type contains "Any" (has type {})'.format(self.format(typ))
+        self.fail(message, context)
 
     def call_any_parameter(self,
                            param_index: int,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -897,7 +897,7 @@ class MessageBuilder:
     def type_arguments_not_allowed(self, context: Context) -> None:
         self.fail('Parameterized generics cannot be used with class or instance checks', context)
 
-    def disallowed_any_type(self, typ: Type, context: Context):
+    def disallowed_any_type(self, typ: Type, context: Context) -> None:
         self.fail('Expressions of type "Any" are disallowed '
                   '(has type {})'.format(self.format(typ)), context)
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -905,6 +905,18 @@ class MessageBuilder:
         self.fail('Expressions of {} "Any" are disallowed '
                   '(has type {})'.format(infix, self.format(typ)), context)
 
+    def call_any_parameter(self,
+                           param_index: int,
+                           func_name: str,
+                           typ: Type,
+                           context: Context) -> None:
+        if isinstance(typ, AnyType):
+            msg = 'Parameter {} to {} has disallowed type "Any"'.format(param_index, func_name)
+        else:
+            msg = 'Parameter {} to {} contains disallowed type "Any" ({})'.format(
+                param_index, func_name, self.format(typ))
+        self.fail(msg, context)
+
 
 def capitalize(s: str) -> str:
     """Capitalize the first character of a string."""

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -6,7 +6,7 @@ improve code clarity and to simplify localization (in the future)."""
 import re
 import difflib
 
-from typing import cast, List, Dict, Any, Sequence, Iterable, Tuple, Optional
+from typing import cast, List, Dict, Any, Sequence, Iterable, Tuple
 
 from mypy.erasetype import erase_type
 from mypy.errors import Errors

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -898,8 +898,12 @@ class MessageBuilder:
         self.fail('Parameterized generics cannot be used with class or instance checks', context)
 
     def disallowed_any_type(self, typ: Type, context: Context) -> None:
-        self.fail('Expressions of type "Any" are disallowed '
-                  '(has type {})'.format(self.format(typ)), context)
+        if isinstance(typ, AnyType):
+            infix = 'type'
+        else:
+            infix = 'type that contains type'
+        self.fail('Expressions of {} "Any" are disallowed '
+                  '(has type {})'.format(infix, self.format(typ)), context)
 
 
 def capitalize(s: str) -> str:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -911,18 +911,6 @@ class MessageBuilder:
             message = 'Expression type contains "Any" (has type {})'.format(self.format(typ))
         self.fail(message, context)
 
-    def call_any_parameter(self,
-                           param_index: int,
-                           func_name: str,
-                           typ: Type,
-                           context: Context) -> None:
-        if isinstance(typ, AnyType):
-            msg = 'Parameter {} to {} has disallowed type "Any"'.format(param_index, func_name)
-        else:
-            msg = 'Parameter {} to {} contains disallowed type "Any" ({})'.format(
-                param_index, func_name, self.format(typ))
-        self.fail(msg, context)
-
 
 def capitalize(s: str) -> str:
     """Capitalize the first character of a string."""

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -6,7 +6,7 @@ improve code clarity and to simplify localization (in the future)."""
 import re
 import difflib
 
-from typing import cast, List, Dict, Any, Sequence, Iterable, Tuple
+from typing import cast, List, Dict, Any, Sequence, Iterable, Tuple, Optional
 
 from mypy.erasetype import erase_type
 from mypy.errors import Errors
@@ -896,6 +896,10 @@ class MessageBuilder:
 
     def type_arguments_not_allowed(self, context: Context) -> None:
         self.fail('Parameterized generics cannot be used with class or instance checks', context)
+
+    def disallowed_any_type(self, typ: Type, context: Context):
+        self.fail('Expressions of type "Any" are disallowed '
+                  '(has type {})'.format(self.format(typ)), context)
 
 
 def capitalize(s: str) -> str:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1300,9 +1300,6 @@ class CallExpr(Expression):
         self.arg_names = arg_names
         self.analyzed = analyzed
 
-    def is_cast(self) -> bool:
-        return self.analyzed is not None and isinstance(self.analyzed, CastExpr)
-
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_call_expr(self)
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1300,6 +1300,9 @@ class CallExpr(Expression):
         self.arg_names = arg_names
         self.analyzed = analyzed
 
+    def is_cast(self) -> bool:
+        return self.analyzed is not None and isinstance(self.analyzed, CastExpr)
+
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_call_expr(self)
 

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -516,6 +516,25 @@ x, y = 1, 2  # type: Unchecked, Unchecked
 main:4: error: Type of variable becomes "Any" due to an unfollowed import
 main:6: error: A type on this line becomes "Any" due to an unfollowed import
 
+[case testDisallowAnyExprSimple]
+# flags: --disallow-any=expr
+from typing import Any
+def f(s):
+    yield s
+
+x = f(0)  # E: Expression has type "Any"
+for x in f(0):  # E: Expression has type "Any"
+    g(x)  # E: Expression has type "Any"
+
+def g(x) -> Any:
+    yield x  # E: Expression has type "Any"
+
+l = [1, 2, 3]
+l[f(0)]  # E: Expression has type "Any"
+f(l)
+f(f(0))  # E: Expression has type "Any"
+[builtins fixtures/list.pyi]
+
 [case testDisallowAnyExprUnannotatedFunction]
 # flags: --disallow-any=expr
 def g(s):

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -515,17 +515,28 @@ main:6: error: A type on this line becomes "Any" due to an unfollowed import
 def g(s):
     return s  # E: Expressions of type "Any" are disallowed (has type "Any")
 
-g(0)
-
-v = g(1)  # E: Expressions of type "Any" are disallowed (has type "Any")
-w: int = g(1)
+g(0)  # E: Parameter 1 to "g" has disallowed type "Any"
+w: int = g(1)  # E: Parameter 1 to "g" has disallowed type "Any"
 
 [case testDisallowAnyExprExplicitAnyParam]
-from typing import Any
+# flags: --disallow-any=expr
+from typing import Any, List
 def f(s: Any) -> None:
     pass
 
+def g(s: List[Any]) -> None:
+    pass
+
 f(0)
+
+# because expected type is List[Any] the inferred type of [''] is List[Any], which causes
+# more than one error on the line below
+g([''])
+[out]
+main:9: error: Parameter 1 to "f" has disallowed type "Any"
+main:13: error: Parameter 1 to "g" contains disallowed type "Any" (List[Any])
+main:13: error: Parameter 1 to <list> has disallowed type "Any"
+main:13: error: Expressions of type that contains type "Any" are disallowed (has type List[Any])
 [builtins fixtures/list.pyi]
 
 [case testDisallowAnyExprAllowsAnyInCast]
@@ -559,5 +570,6 @@ k = l[0]
 [builtins fixtures/list.pyi]
 [out]
 main:5: error: Expressions of type that contains type "Any" are disallowed (has type List[Any])
+main:5: error: Parameter 1 to "append" of "list" has disallowed type "Any"
 main:6: error: Expressions of type that contains type "Any" are disallowed (has type List[Any])
 main:6: error: Expressions of type "Any" are disallowed (has type "Any")

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -510,47 +510,69 @@ x, y = 1, 2  # type: Unchecked, Unchecked
 main:4: error: Type of variable becomes "Any" due to an unfollowed import
 main:6: error: A type on this line becomes "Any" due to an unfollowed import
 
-[case testDisallowAnyBasic]
+[case testDisallowAnyExprUnannotatedFunction]
 # flags: --disallow-any=expr
-from typing import List, Any, cast
+def g(s):
+    return s  # E: Expressions of type "Any" are disallowed (has type "Any")
 
-def foo(z: int):
-    return z
+g(0)
+g('hello')
 
-def print(s: Any) -> None:
-    s = s + 1
+v = g(1)  # E: Expressions of type "Any" are disallowed (has type "Any")
+w: int = g(1)
+
+[case testDisallowAnyExprExplicitAnyParam]
+from typing import Any
+def f(s: Any) -> None:
     pass
 
+f(0)
+f('hello')
+[builtins fixtures/list.pyi]
+
+[case testDisallowAnyExprAllowsAnyInCast]
+# flags: --disallow-any=expr
+from typing import Any, cast
 class Foo:
     g: Any = 2
 
-x: List[str] = ['hello']
-
-f: int = Foo.doo()
-k = Foo.doo()
-
 z = cast(int, Foo().g)
 m = cast(Any, Foo().g)
-y = Foo().g
-print(x[0])
-print(x[foo(0)])
+k = Foo.g  # E: Expressions of type "Any" are disallowed (has type "Any")
+[builtins fixtures/list.pyi]
+
+[case testDisallowAnyExprAllowsAnyInVariableAssignmentWithExplicitTypeAnnotation]
+# flags: --disallow-any=expr
+from typing import Any
+class Foo:
+    g: Any = 2
+
+z: int = Foo().g
+m: Any = Foo().g
+[builtins fixtures/list.pyi]
+
+[case testDisallowAnyExprAllowsNonExistentMembers]
+# flags: --disallow-any=expr
+from typing import cast
+class Foo: pass
+
+i: int = Foo.doo()
+j = cast(int, Foo.doo())
+k = Foo.doo()
 [builtins fixtures/list.pyi]
 [out]
-main:8: error: Expressions of type "Any" are disallowed (has type "Any")
-main:16: error: Type[Foo] has no attribute "doo"
-main:17: error: Type[Foo] has no attribute "doo"
-main:17: error: Expressions of type "Any" are disallowed (has type "Any")
-main:20: error: Expressions of type "Any" are disallowed (has type "Any")
-main:21: error: Expressions of type "Any" are disallowed (has type "Any")
-main:23: error: Expressions of type "Any" are disallowed (has type "Any")
+main:5: error: Type[Foo] has no attribute "doo"
+main:6: error: Type[Foo] has no attribute "doo"
+main:7: error: Type[Foo] has no attribute "doo"
+main:7: error: Expressions of type "Any" are disallowed (has type "Any")
 
 [case testDisallowAnyExprGeneric]
 # flags: --disallow-any=expr
 from typing import List
 
-blargle: List = []
-blargle.append(1)
-k = blargle[0]
+l: List = []
+l.append(1)
+k = l[0]
 [builtins fixtures/list.pyi]
 [out]
 main:5: error: Expressions of type "Any" are disallowed (has type List[Any])

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -521,8 +521,8 @@ main:6: error: A type on this line becomes "Any" due to an unfollowed import
 def g(s):
     return s  # E: Expression has type "Any"
 
-g(0)  # E: Parameter 1 to "g" has disallowed type "Any"
-w: int = g(1)  # E: Parameter 1 to "g" has disallowed type "Any"
+g(0)
+w: int = g(1)
 
 [case testDisallowAnyExprExplicitAnyParam]
 # flags: --disallow-any=expr
@@ -535,14 +535,9 @@ def g(s: List[Any]) -> None:
 
 f(0)
 
-# because expected type is List[Any] the inferred type of [''] is List[Any], which causes
-# more than one error on the line below
-g([''])
-[out]
-main:9: error: Parameter 1 to "f" has disallowed type "Any"
-main:13: error: Parameter 1 to "g" contains disallowed type "Any" (List[Any])
-main:13: error: Parameter 1 to <list> has disallowed type "Any"
-main:13: error: Expression type contains "Any" (has type List[Any])
+# type of list below is inferred with expected type of List[Any], so that becomes it's type
+# instead of List[str]
+g([''])  # E: Expression type contains "Any" (has type List[Any])
 [builtins fixtures/list.pyi]
 
 [case testDisallowAnyExprAllowsAnyInCast]
@@ -573,11 +568,6 @@ n = Foo().g  # type: Any  # E: Expression has type "Any"
 from typing import List
 
 l: List = []
-l.append(1)
-k = l[0]
+l.append(1)  # E: Expression type contains "Any" (has type List[Any])
+k = l[0]  # E: Expression type contains "Any" (has type List[Any])  # E: Expression has type "Any"
 [builtins fixtures/list.pyi]
-[out]
-main:5: error: Expression type contains "Any" (has type List[Any])
-main:5: error: Parameter 1 to "append" of "list" has disallowed type "Any"
-main:6: error: Expression type contains "Any" (has type List[Any])
-main:6: error: Expression has type "Any"

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -575,6 +575,6 @@ l.append(1)
 k = l[0]
 [builtins fixtures/list.pyi]
 [out]
-main:5: error: Expressions of type "Any" are disallowed (has type List[Any])
-main:6: error: Expressions of type "Any" are disallowed (has type List[Any])
+main:5: error: Expressions of type that contains type "Any" are disallowed (has type List[Any])
+main:6: error: Expressions of type that contains type "Any" are disallowed (has type List[Any])
 main:6: error: Expressions of type "Any" are disallowed (has type "Any")

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -519,7 +519,7 @@ main:6: error: A type on this line becomes "Any" due to an unfollowed import
 [case testDisallowAnyExprUnannotatedFunction]
 # flags: --disallow-any=expr
 def g(s):
-    return s  # E: Expressions of type "Any" are disallowed (has type "Any")
+    return s  # E: Expression has type "Any"
 
 g(0)  # E: Parameter 1 to "g" has disallowed type "Any"
 w: int = g(1)  # E: Parameter 1 to "g" has disallowed type "Any"
@@ -542,7 +542,7 @@ g([''])
 main:9: error: Parameter 1 to "f" has disallowed type "Any"
 main:13: error: Parameter 1 to "g" contains disallowed type "Any" (List[Any])
 main:13: error: Parameter 1 to <list> has disallowed type "Any"
-main:13: error: Expressions of type that contains type "Any" are disallowed (has type List[Any])
+main:13: error: Expression type contains "Any" (has type List[Any])
 [builtins fixtures/list.pyi]
 
 [case testDisallowAnyExprAllowsAnyInCast]
@@ -552,8 +552,8 @@ class Foo:
     g: Any = 2
 
 z = cast(int, Foo().g)
-m = cast(Any, Foo().g)  # E: Expressions of type "Any" are disallowed (has type "Any")
-k = Foo.g  # E: Expressions of type "Any" are disallowed (has type "Any")
+m = cast(Any, Foo().g)  # E: Expression has type "Any"
+k = Foo.g  # E: Expression has type "Any"
 [builtins fixtures/list.pyi]
 
 [case testDisallowAnyExprAllowsAnyInVariableAssignmentWithExplicitTypeAnnotation]
@@ -564,8 +564,8 @@ class Foo:
 
 z: int = Foo().g
 x = Foo().g  # type: int
-m: Any = Foo().g  # E: Expressions of type "Any" are disallowed (has type "Any")
-n = Foo().g  # type: Any  # E: Expressions of type "Any" are disallowed (has type "Any")
+m: Any = Foo().g  # E: Expression has type "Any"
+n = Foo().g  # type: Any  # E: Expression has type "Any"
 [builtins fixtures/list.pyi]
 
 [case testDisallowAnyExprGeneric]
@@ -577,7 +577,7 @@ l.append(1)
 k = l[0]
 [builtins fixtures/list.pyi]
 [out]
-main:5: error: Expressions of type that contains type "Any" are disallowed (has type List[Any])
+main:5: error: Expression type contains "Any" (has type List[Any])
 main:5: error: Parameter 1 to "append" of "list" has disallowed type "Any"
-main:6: error: Expressions of type that contains type "Any" are disallowed (has type List[Any])
-main:6: error: Expressions of type "Any" are disallowed (has type "Any")
+main:6: error: Expression type contains "Any" (has type List[Any])
+main:6: error: Expression has type "Any"

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -535,7 +535,7 @@ class Foo:
     g: Any = 2
 
 z = cast(int, Foo().g)
-m = cast(Any, Foo().g)
+m = cast(Any, Foo().g)  # E: Expressions of type "Any" are disallowed (has type "Any")
 k = Foo.g  # E: Expressions of type "Any" are disallowed (has type "Any")
 [builtins fixtures/list.pyi]
 
@@ -546,7 +546,7 @@ class Foo:
     g: Any = 2
 
 z: int = Foo().g
-m: Any = Foo().g
+m: Any = Foo().g  # E: Expressions of type "Any" are disallowed (has type "Any")
 [builtins fixtures/list.pyi]
 
 [case testDisallowAnyExprGeneric]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -519,7 +519,7 @@ main:6: error: A type on this line becomes "Any" due to an unfollowed import
 [case testDisallowAnyExprUnannotatedFunction]
 # flags: --disallow-any=expr
 def g(s):
-    return s  # E: Expression has type "Any"
+    return s
 
 g(0)
 w: int = g(1)

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -509,3 +509,50 @@ x, y = 1, 2  # type: Unchecked, Unchecked
 [out]
 main:4: error: Type of variable becomes "Any" due to an unfollowed import
 main:6: error: A type on this line becomes "Any" due to an unfollowed import
+
+[case testDisallowAnyBasic]
+# flags: --disallow-any=expr
+from typing import List, Any, cast
+
+def foo(z: int):
+    return z
+
+def print(s: Any) -> None:
+    s = s + 1
+    pass
+
+class Foo:
+    g: Any = 2
+
+x: List[str] = ['hello']
+
+f: int = Foo.doo()
+k = Foo.doo()
+
+z = cast(int, Foo().g)
+m = cast(Any, Foo().g)
+y = Foo().g
+print(x[0])
+print(x[foo(0)])
+[builtins fixtures/list.pyi]
+[out]
+main:8: error: Expressions of type "Any" are disallowed (has type "Any")
+main:16: error: Type[Foo] has no attribute "doo"
+main:17: error: Type[Foo] has no attribute "doo"
+main:17: error: Expressions of type "Any" are disallowed (has type "Any")
+main:20: error: Expressions of type "Any" are disallowed (has type "Any")
+main:21: error: Expressions of type "Any" are disallowed (has type "Any")
+main:23: error: Expressions of type "Any" are disallowed (has type "Any")
+
+[case testDisallowAnyExprGeneric]
+# flags: --disallow-any=expr
+from typing import List
+
+blargle: List = []
+blargle.append(1)
+k = blargle[0]
+[builtins fixtures/list.pyi]
+[out]
+main:5: error: Expressions of type "Any" are disallowed (has type List[Any])
+main:6: error: Expressions of type "Any" are disallowed (has type List[Any])
+main:6: error: Expressions of type "Any" are disallowed (has type "Any")

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -557,7 +557,9 @@ class Foo:
     g: Any = 2
 
 z: int = Foo().g
+x = Foo().g  # type: int
 m: Any = Foo().g  # E: Expressions of type "Any" are disallowed (has type "Any")
+n = Foo().g  # type: Any  # E: Expressions of type "Any" are disallowed (has type "Any")
 [builtins fixtures/list.pyi]
 
 [case testDisallowAnyExprGeneric]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -516,7 +516,6 @@ def g(s):
     return s  # E: Expressions of type "Any" are disallowed (has type "Any")
 
 g(0)
-g('hello')
 
 v = g(1)  # E: Expressions of type "Any" are disallowed (has type "Any")
 w: int = g(1)
@@ -527,7 +526,6 @@ def f(s: Any) -> None:
     pass
 
 f(0)
-f('hello')
 [builtins fixtures/list.pyi]
 
 [case testDisallowAnyExprAllowsAnyInCast]
@@ -550,21 +548,6 @@ class Foo:
 z: int = Foo().g
 m: Any = Foo().g
 [builtins fixtures/list.pyi]
-
-[case testDisallowAnyExprAllowsNonExistentMembers]
-# flags: --disallow-any=expr
-from typing import cast
-class Foo: pass
-
-i: int = Foo.doo()
-j = cast(int, Foo.doo())
-k = Foo.doo()
-[builtins fixtures/list.pyi]
-[out]
-main:5: error: Type[Foo] has no attribute "doo"
-main:6: error: Type[Foo] has no attribute "doo"
-main:7: error: Type[Foo] has no attribute "doo"
-main:7: error: Expressions of type "Any" are disallowed (has type "Any")
 
 [case testDisallowAnyExprGeneric]
 # flags: --disallow-any=expr


### PR DESCRIPTION
The option disallows all expressions of type Any except:
* if a value of type Any used as a second parameter to `cast`
* if a value of type Any is assigned to a variable with an explicit type annotation