### PR TITLE
Push return type for lambda expressions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1936,12 +1936,15 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Type check lambda expression."""
         inferred_type, type_override = self.infer_lambda_type_using_context(e)
         if not inferred_type:
+            self.chk.return_types.append(AnyType())
             # No useful type context.
             ret_type = self.accept(e.expr(), allow_none_return=True)
             fallback = self.named_type('builtins.function')
+            self.chk.return_types.pop()
             return callable_type(e, fallback, ret_type)
         else:
             # Type context available.
+            self.chk.return_types.append(inferred_type.ret_type)
             self.chk.check_func_item(e, type_override=type_override)
             if e.expr() not in self.chk.type_map:
                 self.accept(e.expr(), allow_none_return=True)
@@ -1950,7 +1953,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 # For "lambda ...: None", just use type from the context.
                 # Important when the context is Callable[..., None] which
                 # really means Void. See #1425.
+                self.chk.return_types.pop()
                 return inferred_type
+            self.chk.return_types.pop()
             return replace_callable_return_type(inferred_type, ret_type)
 
     def infer_lambda_type_using_context(self, e: LambdaExpr) -> Tuple[Optional[CallableType],

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1208,6 +1208,20 @@ def void() -> None:
     pass
 x = lambda: void() # type: typing.Callable[[], None]
 
+[case testNoCrashOnLambdaGenerator]
+from typing import Iterator, Callable
+
+# These should not crash
+lambda: (yield)
+
+gen: Callable[[], Iterator[str]]
+gen = (lambda: (yield 1))  # E: Incompatible types in yield (actual type "int", expected type "str")
+
+def fun(cb: Callable[[], Iterator[str]]) -> None:
+    pass
+fun(lambda: (yield from [1]))  # E: Incompatible types in "yield from" (actual type "int", expected type "str")
+[builtins fixtures/list.pyi]
+[out]
 
 -- List comprehensions
 -- -------------------


### PR DESCRIPTION
This fixes #3243 and similar crashes on lambda generators.

Solution is straightforward: push return type (if known, or ``Any`` otherwise) same as we do for normal functions.