### PR TITLE
Cheat sheet for Python 2 still used some annotation syntax

### DIFF
--- a/docs/source/cheat_sheet.rst
+++ b/docs/source/cheat_sheet.rst
@@ -232,7 +232,8 @@ Other stuff
 
    # Use AnyStr for functions that should accept any kind of string
    # without allowing different kinds of strings to mix.
-   def concat(a: AnyStr, b: AnyStr) -> AnyStr:
+   def concat(a, b):
+       # type: (AnyStr, AnyStr) -> AnyStr
        return a + b
    concat(u"foo", u"bar")  # type: unicode
    concat(b"foo", b"bar")  # type: bytes
@@ -240,7 +241,8 @@ Other stuff
    # Use IO[] for functions that should accept or return any
    # object that comes from an open() call. The IO[] does not
    # distinguish between reading, writing or other modes.
-   def get_sys_IO(mode='w') -> IO[str]:
+   def get_sys_IO(mode='w'):
+       # type: (str) -> IO[str]
        if mode == 'w':
            return sys.stdout
        elif mode == 'r':


### PR DESCRIPTION
I am not sure about this, but considering that the annotation format is not supported in Python 2, probably we missed changing it from the Python 3 cheat sheet. So, used the comment format for those few examples.