### PR TITLE
add support for __path__ attribute on modules

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -75,7 +75,8 @@ inverse_node_kinds = {_kind: _name for _name, _kind in node_kinds.items()}
 implicit_module_attrs = {'__name__': '__builtins__.str',
                          '__doc__': None,  # depends on Python version, see semanal.py
                          '__file__': '__builtins__.str',
-                         '__package__': '__builtins__.str'}
+                         '__package__': '__builtins__.str',
+                         '__path__': '__builtins__.str', }  # only present in __init__.py files
 
 
 type_aliases = {

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1640,3 +1640,39 @@ m = n  # E: Cannot assign multiple modules to name 'm' without explicit 'types.M
 [file n.py]
 
 [builtins fixtures/module.pyi]
+
+[case testPathAttributePresence]
+import m
+import m.m
+
+x = m.__path__
+x.append('xyzzy')
+
+y = m.m.__path__  # E: Module has no attribute "__path__"
+
+[file m/__init__.py]
+import typing
+
+[file m/m.py]
+
+[builtins fixtures/module_all.pyi]
+
+[typing fixtures/typing-full.pyi]
+
+
+[case testPathAttributePresence_python2]
+import m
+import m.m
+
+x = m.__path__
+x.append('xyzzy')
+
+y = m.m.__path__  # E: Module has no attribute "__path__"
+
+[file m/__init__.py]
+
+[file m/m.py]
+
+[builtins fixtures/module_all.pyi]
+
+[typing fixtures/typing-full.pyi]


### PR DESCRIPTION
Attempts to fix https://github.com/python/mypy/issues/1422

I am not familiar enough with the mypy code to know how to encode `List[str]` as the type of the `__path__` attribute. Feedback is definitely needed for that. (Then I can uncomment the line in the test that attempts to call `.append` on a `__path__` attribute.)
