### PR TITLE
Add flag to disallow decorating typed functions with untyped decorators

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -278,7 +278,7 @@ Here are some more useful flags:
 
 - ``--disallow-any`` disallows various types of ``Any`` in a module.
   The option takes a comma-separated list of the following values:
-  ``unimported``, ``unannotated``.
+  ``unimported``, ``unannotated``, ``decorated``.
 
   ``unimported`` disallows usage of types that come from unfollowed imports
   (such types become aliases for ``Any``). Unfollowed imports occur either
@@ -289,6 +289,9 @@ Here are some more useful flags:
   typed (i.e. that are missing an explicit type annotation for any
   of the parameters or the return type). ``unannotated`` option is
   interchangeable with ``--disallow-untyped-defs``.
+
+  ``decorated`` disallows functions that have ``Any`` in their signature
+  after decorator transformation.
 
 - ``--disallow-untyped-defs`` reports an error whenever it encounters
   a function definition without type annotations.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2315,7 +2315,7 @@ class TypeChecker(NodeVisitor[None]):
 
         num_missing_types = len(func_type.arg_types) - len(new_param_types)
         if num_missing_types > 0:
-            new_param_types.extend([AnyType()] * num_missing_types)
+            new_param_types = new_param_types + [AnyType()] * num_missing_types
 
         dec_name = None  # type: Optional[str]
         if isinstance(dec_expr, NameExpr):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2297,9 +2297,6 @@ class TypeChecker(NodeVisitor[None]):
     def check_untyped_after_decorator(self, typ: Type, func: FuncDef) -> None:
         if 'decorated' not in self.options.disallow_any or self.is_stub:
             return
-        if not isinstance(typ, CallableType):
-            self.msg.untyped_decorated_function(typ, func)
-            return
 
         if mypy.checkexpr.has_any_type(typ):
             self.msg.untyped_decorated_function(typ, func)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2295,7 +2295,7 @@ class TypeChecker(NodeVisitor[None]):
         self.accept(s.body)
 
     def check_untyped_after_decorator(self, typ: Type, func: FuncDef) -> None:
-        if 'decorator' not in self.options.disallow_any or self.is_stub:
+        if 'decorated' not in self.options.disallow_any or self.is_stub:
             return
         if not isinstance(typ, CallableType):
             self.msg.untyped_decorated_function(typ, func)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -28,7 +28,7 @@ from mypy.nodes import (
     AwaitExpr, PromoteExpr, Node, EnumCallExpr,
     ARG_POS, MDEF,
     CONTRAVARIANT, COVARIANT)
-from mypy import nodes, checkexpr
+from mypy import nodes
 from mypy.typeanal import has_any_from_unimported_type
 from mypy.types import (
     Type, AnyType, CallableType, FunctionLike, Overloaded, TupleType, TypedDictType,
@@ -2301,7 +2301,7 @@ class TypeChecker(NodeVisitor[None]):
             self.msg.untyped_decorated_function(typ, func)
             return
 
-        if checkexpr.has_any_type(typ):
+        if mypy.checkexpr.has_any_type(typ):
             self.msg.untyped_decorated_function(typ, func)
 
     def check_async_with_item(self, expr: Expression, target: Expression,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2429,6 +2429,19 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return known_type
 
 
+def has_any_type(t: Type) -> bool:
+    """Whether t contains Any type"""
+    return t.accept(HasAnyType())
+
+
+class HasAnyType(types.TypeQuery[bool]):
+    def __init__(self) -> None:
+        super().__init__(any)
+
+    def visit_any(self, t: AnyType) -> bool:
+        return True
+
+
 def has_coroutine_decorator(t: Type) -> bool:
     """Whether t came from a function decorated with `@coroutine`."""
     return isinstance(t, Instance) and t.type.fullname() == 'typing.AwaitableGenerator'

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -97,7 +97,7 @@ def type_check_only(sources: List[BuildSource], bin_dir: str, options: Options) 
                        options=options)
 
 
-disallow_any_options = ['unimported', 'unannotated']
+disallow_any_options = ['unimported', 'unannotated', 'decorator']
 
 
 def disallow_any_argument_type(raw_options: str) -> List[str]:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -97,7 +97,7 @@ def type_check_only(sources: List[BuildSource], bin_dir: str, options: Options) 
                        options=options)
 
 
-disallow_any_options = ['unimported', 'unannotated', 'decorator']
+disallow_any_options = ['unimported', 'unannotated', 'decorated']
 
 
 def disallow_any_argument_type(raw_options: str) -> List[str]:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -905,15 +905,16 @@ class MessageBuilder:
         self.fail('Parameterized generics cannot be used with class or instance checks', context)
 
     def untyped_decorator(self,
-                          decorator_name: Optional[str],
+                          prefix: str,
                           func_name: str,
+                          decorator_name: Optional[str],
                           context: Context,
                           ) -> None:
-        prefix = 'Untyped decorator'
+        postfix = ''
         if decorator_name:
-            prefix += " '{}'".format(decorator_name)
-        self.fail("{} makes typed function '{}' untyped".format(prefix, func_name), context)
-
+            postfix = ' "{}"'.format(decorator_name)
+        self.fail('{} of {} becomes "Any" due to untyped decorator{}'.format(
+            prefix, func_name, postfix), context)
 
 def capitalize(s: str) -> str:
     """Capitalize the first character of a string."""

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -6,7 +6,7 @@ improve code clarity and to simplify localization (in the future)."""
 import re
 import difflib
 
-from typing import cast, List, Dict, Any, Sequence, Iterable, Tuple
+from typing import cast, List, Dict, Any, Sequence, Iterable, Tuple, Optional
 
 from mypy.erasetype import erase_type
 from mypy.errors import Errors
@@ -903,6 +903,16 @@ class MessageBuilder:
 
     def type_arguments_not_allowed(self, context: Context) -> None:
         self.fail('Parameterized generics cannot be used with class or instance checks', context)
+
+    def untyped_decorator(self,
+                          decorator_name: Optional[str],
+                          func_name: str,
+                          context: Context,
+                          ) -> None:
+        prefix = 'Untyped decorator'
+        if decorator_name:
+            prefix += " '{}'".format(decorator_name)
+        self.fail("{} makes typed function '{}' untyped".format(prefix, func_name), context)
 
 
 def capitalize(s: str) -> str:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -904,18 +904,12 @@ class MessageBuilder:
     def type_arguments_not_allowed(self, context: Context) -> None:
         self.fail('Parameterized generics cannot be used with class or instance checks', context)
 
-    def untyped_decorator(self,
-                          prefix: str,
-                          func_name: str,
-                          decorator_name: Optional[str],
-                          context: Context,
-                          ) -> None:
-        postfix = ''
-        if decorator_name:
-            postfix = ' "{}"'.format(decorator_name)
-        self.fail('{} of {} becomes "Any" due to untyped decorator{}'.format(
-            prefix, func_name, postfix), context)
-
+    def untyped_decorated_function(self, typ: Type, context: Context):
+        if isinstance(typ, AnyType):
+            self.fail("Function is untyped after decorator transformation", context)
+        else:
+            self.fail('Type of decorated function contains type "Any" ({})'.format(
+                self.format(typ)), context)
 
 def capitalize(s: str) -> str:
     """Capitalize the first character of a string."""

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -6,7 +6,7 @@ improve code clarity and to simplify localization (in the future)."""
 import re
 import difflib
 
-from typing import cast, List, Dict, Any, Sequence, Iterable, Tuple, Optional
+from typing import cast, List, Dict, Any, Sequence, Iterable, Tuple
 
 from mypy.erasetype import erase_type
 from mypy.errors import Errors

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -916,6 +916,7 @@ class MessageBuilder:
         self.fail('{} of {} becomes "Any" due to untyped decorator{}'.format(
             prefix, func_name, postfix), context)
 
+
 def capitalize(s: str) -> str:
     """Capitalize the first character of a string."""
     if s == '':

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -904,12 +904,13 @@ class MessageBuilder:
     def type_arguments_not_allowed(self, context: Context) -> None:
         self.fail('Parameterized generics cannot be used with class or instance checks', context)
 
-    def untyped_decorated_function(self, typ: Type, context: Context):
+    def untyped_decorated_function(self, typ: Type, context: Context) -> None:
         if isinstance(typ, AnyType):
             self.fail("Function is untyped after decorator transformation", context)
         else:
             self.fail('Type of decorated function contains type "Any" ({})'.format(
                 self.format(typ)), context)
+
 
 def capitalize(s: str) -> str:
     """Capitalize the first character of a string."""

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -516,7 +516,7 @@ x, y = 1, 2  # type: Unchecked, Unchecked
 main:4: error: Type of variable becomes "Any" due to an unfollowed import
 main:6: error: A type on this line becomes "Any" due to an unfollowed import
 
-[case testDisallowAnyDecoratorUnannotatedDecorator]
+[case testDisallowAnyDecoratedUnannotatedDecorator]
 # flags: --disallow-any=decorated
 from typing import Any
 
@@ -530,7 +530,7 @@ def f(x: Any) -> Any:  # E: Function is untyped after decorator transformation
 def h(x):  # E: Function is untyped after decorator transformation
     pass
 [builtins fixtures/list.pyi]
-[case testDisallowAnyDecoratorErrorIsReportedOnlyOnce]
+[case testDisallowAnyDecoratedErrorIsReportedOnlyOnce]
 # flags: --disallow-any=decorated
 
 def d(f):
@@ -543,7 +543,7 @@ def d2(f):
 @d2
 @d
 def f(x: int) -> None: pass  # E: Function is untyped after decorator transformation
-[case testDisallowAnyDecoratorReturnAny]
+[case testDisallowAnyDecoratedReturnAny]
 # flags: --disallow-any=decorated
 from typing import Any
 
@@ -553,7 +553,7 @@ def d(f) -> Any:
 @d
 def f() -> None: pass  # E: Function is untyped after decorator transformation
 [builtins fixtures/list.pyi]
-[case testDisallowAnyDecoratorReturnCallable]
+[case testDisallowAnyDecoratedReturnCallable]
 # flags: --disallow-any=decorated
 from typing import Any, Callable
 
@@ -564,7 +564,7 @@ def d(f) -> Callable[..., None]:
 def g(i: int, s: str) -> None: pass  # E: Type of decorated function contains type "Any" (Callable[..., None])
 
 [builtins fixtures/list.pyi]
-[case testDisallowAnyDecoratorNonexistentDecorator]
+[case testDisallowAnyDecoratedNonexistentDecorator]
 # flags: --disallow-any=decorated --ignore-missing-imports
 from nonexistent import d
 
@@ -572,7 +572,7 @@ from nonexistent import d
 def f() -> None: pass  # E: Function is untyped after decorator transformation
 [builtins fixtures/list.pyi]
 
-[case testDisallowAnyPartlyTypedCallable]
+[case testDisallowAnyDecoratedPartlyTypedCallable]
 # flags: --disallow-any=decorated --ignore-missing-imports
 from typing import Callable, Any, List
 
@@ -587,7 +587,7 @@ def g(i: int) -> None: # E: Type of decorated function contains type "Any" (Call
     pass
 [builtins fixtures/list.pyi]
 
-[case testDisallowAnyDecoratorReturnsCallableNoParams]
+[case testDisallowAnyDecoratedReturnsCallableNoParams]
 # flags: --disallow-any=decorated
 from typing import Callable
 

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -516,30 +516,21 @@ x, y = 1, 2  # type: Unchecked, Unchecked
 main:4: error: Type of variable becomes "Any" due to an unfollowed import
 main:6: error: A type on this line becomes "Any" due to an unfollowed import
 
-[case testDisallowAnyDecoratorSimple]
+[case testDisallowAnyDecoratorUnannotatedDecorator]
 # flags: --disallow-any=decorator
 from typing import Any
 
 def d(f):
     return f
 
-@d  # no error
-def f(x: Any) -> Any: pass
-@d  # error
-def g(x: Any) -> None: pass
-@d  # no error
-def h(x): pass
-@d  # errors
-def i(x: int) -> None: pass
-@d  # errors
-def j() -> None: pass
+@d
+def f(x: Any) -> Any:  # E: Function is untyped after decorator transformation
+    pass
+@d
+def h(x):  # E: Function is untyped after decorator transformation
+    pass
 [builtins fixtures/list.pyi]
-[out]
-main:9: error: Return type of "g" becomes "Any" due to untyped decorator "d"
-main:13: error: Parameter 1 of "i" becomes "Any" due to untyped decorator "d"
-main:13: error: Return type of "i" becomes "Any" due to untyped decorator "d"
-main:15: error: Return type of "j" becomes "Any" due to untyped decorator "d"
-[case testDisallowAnyDecoratorMultiple]
+[case testDisallowAnyDecoratorErrorIsReportedOnlyOnce]
 # flags: --disallow-any=decorator
 
 def d(f):
@@ -548,65 +539,52 @@ def d(f):
 def d2(f):
     return f
 
-@d  # errors
-@d2  # errors
-@d  # errors
-def f(x: int) -> None: pass
-[out]
-main:9: error: Parameter 1 of "f" becomes "Any" due to untyped decorator "d"
-main:9: error: Return type of "f" becomes "Any" due to untyped decorator "d"
-main:10: error: Parameter 1 of "f" becomes "Any" due to untyped decorator "d2"
-main:10: error: Return type of "f" becomes "Any" due to untyped decorator "d2"
-main:11: error: Parameter 1 of "f" becomes "Any" due to untyped decorator "d"
-main:11: error: Return type of "f" becomes "Any" due to untyped decorator "d"
-
+@d
+@d2
+@d
+def f(x: int) -> None: pass  # E: Function is untyped after decorator transformation
 [case testDisallowAnyDecoratorReturnAny]
 # flags: --disallow-any=decorator
 from typing import Any
 
 def d(f) -> Any:
     return f
-def d2(f: int) -> Any:
-    return f
 
-@d2  # E: Return type of "f" becomes "Any" due to untyped decorator "d2"
-@d  # E: Return type of "f" becomes "Any" due to untyped decorator "d"
-def f() -> None: pass
+@d
+def f() -> None: pass  # E: Function is untyped after decorator transformation
 [builtins fixtures/list.pyi]
 [case testDisallowAnyDecoratorReturnCallable]
 # flags: --disallow-any=decorator
 from typing import Any, Callable
 
-def d(f) -> Callable[..., Any]:
+def d(f) -> Callable[..., None]:
     return f
 
-@d  # errors
-def g(i: int, s: str) -> None: pass
+@d
+def g(i: int, s: str) -> None: pass  # E: Type of decorated function contains type "Any" (Callable[..., None])
 
-@d  # E: Return type of "f" becomes "Any" due to untyped decorator "d"
-def f() -> None: pass
 [builtins fixtures/list.pyi]
-[out]
-main:7: error: Parameter 1 of "g" becomes "Any" due to untyped decorator "d"
-main:7: error: Parameter 2 of "g" becomes "Any" due to untyped decorator "d"
-main:7: error: Return type of "g" becomes "Any" due to untyped decorator "d"
-
 [case testDisallowAnyDecoratorNonexistentDecorator]
 # flags: --disallow-any=decorator --ignore-missing-imports
 from nonexistent import d
 
-@d  # E: Return type of "f" becomes "Any" due to untyped decorator "d"
-def f() -> None: pass
+@d
+def f() -> None: pass  # E: Function is untyped after decorator transformation
 [builtins fixtures/list.pyi]
 
 [case testDisallowAnyPartlyTypedCallable]
 # flags: --disallow-any=decorator --ignore-missing-imports
-from typing import Callable, Any
+from typing import Callable, Any, List
 
 def d(f) -> Callable[[int, Any], Any]: pass
+def d2(f) -> Callable[[int], List[Any]]: pass
 
-@d  # E: Parameter 2 of "f" becomes "Any" due to untyped decorator "d"
-def f(i: int, s: str): pass
+@d
+def f(i: int, s: str) -> None:  # E: Type of decorated function contains type "Any" (Callable[[int, Any], Any])
+    pass
+@d2
+def g(i: int) -> None: # E: Type of decorated function contains type "Any" (Callable[[int], List[Any]])
+    pass
 [builtins fixtures/list.pyi]
 
 [case testDisallowAnyDecoratorReturnsCallableNoParams]
@@ -616,7 +594,7 @@ from typing import Callable
 def d(p) -> Callable[[], int]:
     return p
 
-@d  # E: Parameter 1 of "f" becomes "Any" due to untyped decorator "d"
-def f(i: int) -> int:
+@d
+def f(i):
     return i
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -525,16 +525,20 @@ def d(f):
 
 @d  # no error
 def f(x: Any) -> Any: pass
-@d  # no error
+@d  # error
 def g(x: Any) -> None: pass
 @d  # no error
 def h(x): pass
-@d  # E: Untyped decorator 'd' makes typed function 'i' untyped
+@d  # errors
 def i(x: int) -> None: pass
-@d  # E: Untyped decorator 'd' makes typed function 'j' untyped
+@d  # errors
 def j() -> None: pass
-
 [builtins fixtures/list.pyi]
+[out]
+main:9: error: Return type of "g" becomes "Any" due to untyped decorator "d"
+main:13: error: Parameter 1 of "i" becomes "Any" due to untyped decorator "d"
+main:13: error: Return type of "i" becomes "Any" due to untyped decorator "d"
+main:15: error: Return type of "j" becomes "Any" due to untyped decorator "d"
 [case testDisallowAnyDecoratorMultiple]
 # flags: --disallow-any=decorator
 
@@ -544,10 +548,17 @@ def d(f):
 def d2(f):
     return f
 
-@d  # E: Untyped decorator 'd' makes typed function 'f' untyped
-@d2  # E: Untyped decorator 'd2' makes typed function 'f' untyped
-@d  # E: Untyped decorator 'd' makes typed function 'f' untyped
+@d  # errors
+@d2  # errors
+@d  # errors
 def f(x: int) -> None: pass
+[out]
+main:9: error: Parameter 1 of "f" becomes "Any" due to untyped decorator "d"
+main:9: error: Return type of "f" becomes "Any" due to untyped decorator "d"
+main:10: error: Parameter 1 of "f" becomes "Any" due to untyped decorator "d2"
+main:10: error: Return type of "f" becomes "Any" due to untyped decorator "d2"
+main:11: error: Parameter 1 of "f" becomes "Any" due to untyped decorator "d"
+main:11: error: Return type of "f" becomes "Any" due to untyped decorator "d"
 
 [case testDisallowAnyDecoratorReturnAny]
 # flags: --disallow-any=decorator
@@ -558,8 +569,8 @@ def d(f) -> Any:
 def d2(f: int) -> Any:
     return f
 
-@d2  # E: Untyped decorator 'd2' makes typed function 'f' untyped
-@d  # E: Untyped decorator 'd' makes typed function 'f' untyped
+@d2  # E: Return type of "f" becomes "Any" due to untyped decorator "d2"
+@d  # E: Return type of "f" becomes "Any" due to untyped decorator "d"
 def f() -> None: pass
 [builtins fixtures/list.pyi]
 [case testDisallowAnyDecoratorReturnCallable]
@@ -569,14 +580,31 @@ from typing import Any, Callable
 def d(f) -> Callable[..., Any]:
     return f
 
-@d  # no error
+@d  # errors
+def g(i: int, s: str) -> None: pass
+
+@d  # E: Return type of "f" becomes "Any" due to untyped decorator "d"
 def f() -> None: pass
 [builtins fixtures/list.pyi]
+[out]
+main:7: error: Parameter 1 of "g" becomes "Any" due to untyped decorator "d"
+main:7: error: Parameter 2 of "g" becomes "Any" due to untyped decorator "d"
+main:7: error: Return type of "g" becomes "Any" due to untyped decorator "d"
+
 [case testDisallowAnyDecoratorNonexistentDecorator]
 # flags: --disallow-any=decorator --ignore-missing-imports
-from typing import Any, Callable
 from nonexistent import d
 
-@d  # E: Untyped decorator 'd' makes typed function 'f' untyped
+@d  # E: Return type of "f" becomes "Any" due to untyped decorator "d"
 def f() -> None: pass
+[builtins fixtures/list.pyi]
+
+[case testDisallowAnyPartlyTypedCallable]
+# flags: --disallow-any=decorator --ignore-missing-imports
+from typing import Callable, Any
+
+def d(f) -> Callable[[int, Any], Any]: pass
+
+@d  # E: Parameter 2 of "f" becomes "Any" due to untyped decorator "d"
+def f(i: int, s: str): pass
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -608,3 +608,15 @@ def d(f) -> Callable[[int, Any], Any]: pass
 @d  # E: Parameter 2 of "f" becomes "Any" due to untyped decorator "d"
 def f(i: int, s: str): pass
 [builtins fixtures/list.pyi]
+
+[case testDisallowAnyDecoratorReturnsCallableNoParams]
+# flags: --disallow-any=decorator
+from typing import Callable
+
+def d(p) -> Callable[[], int]:
+    return p
+
+@d  # E: Parameter 1 of "f" becomes "Any" due to untyped decorator "d"
+def f(i: int) -> int:
+    return i
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -578,7 +578,7 @@ from typing import Callable, Any, List
 
 def d(f) -> Callable[[int, Any], Any]: pass
 def d2(f) -> Callable[[int], List[Any]]: pass
-def d3(f) -> Callable[[int], List[str]]: pass
+def d3(f) -> Callable[[Any], List[str]]: pass
 
 @d
 def f(i: int, s: str) -> None:  # E: Type of decorated function contains type "Any" (Callable[[int, Any], Any])
@@ -587,7 +587,7 @@ def f(i: int, s: str) -> None:  # E: Type of decorated function contains type "A
 def g(i: int) -> None:  # E: Type of decorated function contains type "Any" (Callable[[int], List[Any]])
     pass
 @d3
-def h(i: int) -> None:  # no error
+def h(i: int) -> None:  # E: Type of decorated function contains type "Any" (Callable[[Any], List[str]])
     pass
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -598,3 +598,12 @@ def d(p) -> Callable[[], int]:
 def f(i):
     return i
 [builtins fixtures/list.pyi]
+
+[case testDisallowAnyDecoratedDecoratorReturnsNonCallable]
+# flags: --disallow-any=decorated
+def d(p) -> int:
+    return p(0)
+
+@d
+def f(i):
+    return i

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -517,7 +517,7 @@ main:4: error: Type of variable becomes "Any" due to an unfollowed import
 main:6: error: A type on this line becomes "Any" due to an unfollowed import
 
 [case testDisallowAnyDecoratorUnannotatedDecorator]
-# flags: --disallow-any=decorator
+# flags: --disallow-any=decorated
 from typing import Any
 
 def d(f):
@@ -531,7 +531,7 @@ def h(x):  # E: Function is untyped after decorator transformation
     pass
 [builtins fixtures/list.pyi]
 [case testDisallowAnyDecoratorErrorIsReportedOnlyOnce]
-# flags: --disallow-any=decorator
+# flags: --disallow-any=decorated
 
 def d(f):
     return f
@@ -544,7 +544,7 @@ def d2(f):
 @d
 def f(x: int) -> None: pass  # E: Function is untyped after decorator transformation
 [case testDisallowAnyDecoratorReturnAny]
-# flags: --disallow-any=decorator
+# flags: --disallow-any=decorated
 from typing import Any
 
 def d(f) -> Any:
@@ -554,7 +554,7 @@ def d(f) -> Any:
 def f() -> None: pass  # E: Function is untyped after decorator transformation
 [builtins fixtures/list.pyi]
 [case testDisallowAnyDecoratorReturnCallable]
-# flags: --disallow-any=decorator
+# flags: --disallow-any=decorated
 from typing import Any, Callable
 
 def d(f) -> Callable[..., None]:
@@ -565,7 +565,7 @@ def g(i: int, s: str) -> None: pass  # E: Type of decorated function contains ty
 
 [builtins fixtures/list.pyi]
 [case testDisallowAnyDecoratorNonexistentDecorator]
-# flags: --disallow-any=decorator --ignore-missing-imports
+# flags: --disallow-any=decorated --ignore-missing-imports
 from nonexistent import d
 
 @d
@@ -573,7 +573,7 @@ def f() -> None: pass  # E: Function is untyped after decorator transformation
 [builtins fixtures/list.pyi]
 
 [case testDisallowAnyPartlyTypedCallable]
-# flags: --disallow-any=decorator --ignore-missing-imports
+# flags: --disallow-any=decorated --ignore-missing-imports
 from typing import Callable, Any, List
 
 def d(f) -> Callable[[int, Any], Any]: pass
@@ -588,7 +588,7 @@ def g(i: int) -> None: # E: Type of decorated function contains type "Any" (Call
 [builtins fixtures/list.pyi]
 
 [case testDisallowAnyDecoratorReturnsCallableNoParams]
-# flags: --disallow-any=decorator
+# flags: --disallow-any=decorated
 from typing import Callable
 
 def d(p) -> Callable[[], int]:

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -515,3 +515,68 @@ x, y = 1, 2  # type: Unchecked, Unchecked
 [out]
 main:4: error: Type of variable becomes "Any" due to an unfollowed import
 main:6: error: A type on this line becomes "Any" due to an unfollowed import
+
+[case testDisallowAnyDecoratorSimple]
+# flags: --disallow-any=decorator
+from typing import Any
+
+def d(f):
+    return f
+
+@d  # no error
+def f(x: Any) -> Any: pass
+@d  # no error
+def g(x: Any) -> None: pass
+@d  # no error
+def h(x): pass
+@d  # E: Untyped decorator 'd' makes typed function 'i' untyped
+def i(x: int) -> None: pass
+@d  # E: Untyped decorator 'd' makes typed function 'j' untyped
+def j() -> None: pass
+
+[builtins fixtures/list.pyi]
+[case testDisallowAnyDecoratorMultiple]
+# flags: --disallow-any=decorator
+
+def d(f):
+    return f
+
+def d2(f):
+    return f
+
+@d  # E: Untyped decorator 'd' makes typed function 'f' untyped
+@d2  # E: Untyped decorator 'd2' makes typed function 'f' untyped
+@d  # E: Untyped decorator 'd' makes typed function 'f' untyped
+def f(x: int) -> None: pass
+
+[case testDisallowAnyDecoratorReturnAny]
+# flags: --disallow-any=decorator
+from typing import Any
+
+def d(f) -> Any:
+    return f
+def d2(f: int) -> Any:
+    return f
+
+@d2  # E: Untyped decorator 'd2' makes typed function 'f' untyped
+@d  # E: Untyped decorator 'd' makes typed function 'f' untyped
+def f() -> None: pass
+[builtins fixtures/list.pyi]
+[case testDisallowAnyDecoratorReturnCallable]
+# flags: --disallow-any=decorator
+from typing import Any, Callable
+
+def d(f) -> Callable[..., Any]:
+    return f
+
+@d  # no error
+def f() -> None: pass
+[builtins fixtures/list.pyi]
+[case testDisallowAnyDecoratorNonexistentDecorator]
+# flags: --disallow-any=decorator --ignore-missing-imports
+from typing import Any, Callable
+from nonexistent import d
+
+@d  # E: Untyped decorator 'd' makes typed function 'f' untyped
+def f() -> None: pass
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -578,12 +578,16 @@ from typing import Callable, Any, List
 
 def d(f) -> Callable[[int, Any], Any]: pass
 def d2(f) -> Callable[[int], List[Any]]: pass
+def d3(f) -> Callable[[int], List[str]]: pass
 
 @d
 def f(i: int, s: str) -> None:  # E: Type of decorated function contains type "Any" (Callable[[int, Any], Any])
     pass
 @d2
-def g(i: int) -> None: # E: Type of decorated function contains type "Any" (Callable[[int], List[Any]])
+def g(i: int) -> None:  # E: Type of decorated function contains type "Any" (Callable[[int], List[Any]])
+    pass
+@d3
+def h(i: int) -> None:  # no error
     pass
 [builtins fixtures/list.pyi]
 
@@ -606,6 +610,30 @@ def d(p) -> int:
 
 @d
 def f(i):
+    return i
+
+[case testDisallowAnyDecoratedUntypedUndecoratedFunction]
+# flags: --disallow-any=decorated
+from typing import Callable
+
+def f(i):  # no error
+    return i
+
+[case testDisallowAnyDecoratedTwoDecorators]
+# flags: --disallow-any=decorated
+from typing import Callable
+
+def typed_dec(f) -> Callable[[], int]: pass
+def untyped_dec(f): pass
+
+@typed_dec
+@untyped_dec
+def f():  # no error
+    return i
+
+@untyped_dec
+@typed_dec
+def g():  # E: Function is untyped after decorator transformation
     return i
 
 [case testDisallowAnyExprSimple]


### PR DESCRIPTION
If none of the argument types + return type of the decorated function are Any and the decorator has return type `Any`, `--disallow-any=decorator` reports an error.