### PR TITLE
Fix crash with forward reference in TypedDict

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -21,7 +21,7 @@ import time
 from os.path import dirname, basename
 
 from typing import (AbstractSet, Dict, Iterable, Iterator, List,
-                    NamedTuple, Optional, Set, Tuple, Union)
+                    NamedTuple, Optional, Set, Tuple, Union, Callable)
 # Can't use TYPE_CHECKING because it's not in the Python 3.5.1 stdlib
 MYPY = False
 if MYPY:
@@ -1601,14 +1601,20 @@ class State:
         self.check_blockers()
 
     def semantic_analysis(self) -> None:
+        fixups = []  # type: List[Callable[[], None]]
         with self.wrap_context():
-            self.manager.semantic_analyzer.visit_file(self.tree, self.xpath, self.options)
+            self.manager.semantic_analyzer.visit_file(self.tree, self.xpath, self.options, fixups)
+        self.fixups = fixups
 
     def semantic_analysis_pass_three(self) -> None:
         with self.wrap_context():
             self.manager.semantic_analyzer_pass3.visit_file(self.tree, self.xpath, self.options)
             if self.options.dump_type_stats:
                 dump_type_stats(self.tree, self.xpath)
+
+    def semantic_analysis_fixups(self) -> None:
+        for fixup in self.fixups:
+            fixup()
 
     def type_check_first_pass(self) -> None:
         manager = self.manager
@@ -2043,6 +2049,8 @@ def process_stale_scc(graph: Graph, scc: List[str], manager: BuildManager) -> No
         graph[id].semantic_analysis_pass_three()
     for id in fresh:
         graph[id].calculate_mros()
+    for id in stale:
+        graph[id].semantic_analysis_fixups()
     for id in stale:
         graph[id].type_check_first_pass()
     more = True

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1601,10 +1601,10 @@ class State:
         self.check_blockers()
 
     def semantic_analysis(self) -> None:
-        fixups = []  # type: List[Callable[[], None]]
+        patches = []  # type: List[Callable[[], None]]
         with self.wrap_context():
-            self.manager.semantic_analyzer.visit_file(self.tree, self.xpath, self.options, fixups)
-        self.fixups = fixups
+            self.manager.semantic_analyzer.visit_file(self.tree, self.xpath, self.options, patches)
+        self.patches = patches
 
     def semantic_analysis_pass_three(self) -> None:
         with self.wrap_context():
@@ -1612,9 +1612,9 @@ class State:
             if self.options.dump_type_stats:
                 dump_type_stats(self.tree, self.xpath)
 
-    def semantic_analysis_fixups(self) -> None:
-        for fixup in self.fixups:
-            fixup()
+    def semantic_analysis_apply_patches(self) -> None:
+        for patch_func in self.patches:
+            patch_func()
 
     def type_check_first_pass(self) -> None:
         manager = self.manager
@@ -2050,7 +2050,7 @@ def process_stale_scc(graph: Graph, scc: List[str], manager: BuildManager) -> No
     for id in fresh:
         graph[id].calculate_mros()
     for id in stale:
-        graph[id].semantic_analysis_fixups()
+        graph[id].semantic_analysis_apply_patches()
     for id in stale:
         graph[id].type_check_first_pass()
     more = True

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -147,6 +147,7 @@ def build_incremental_step(manager: BuildManager,
     # TODO: state.fix_suppressed_dependencies()?
     state.semantic_analysis()
     state.semantic_analysis_pass_three()
+    # TODO: state.semantic_analysis_fixups()
     state.type_check_first_pass()
     # TODO: state.type_check_second_pass()?
     state.finish_passes()

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -147,7 +147,7 @@ def build_incremental_step(manager: BuildManager,
     # TODO: state.fix_suppressed_dependencies()?
     state.semantic_analysis()
     state.semantic_analysis_pass_three()
-    # TODO: state.semantic_analysis_fixups()
+    # TODO: state.semantic_analysis_apply_patches()
     state.type_check_first_pass()
     # TODO: state.type_check_second_pass()?
     state.finish_passes()

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -829,6 +829,20 @@ m1: Mapping[str, B] = x
 m2: Mapping[str, C] = x # E: Incompatible types in assignment (expression has type "X", variable has type Mapping[str, C])
 [builtins fixtures/dict.pyi]
 
+[case testForwardReferenceInClassTypedDict]
+from typing import Mapping
+from mypy_extensions import TypedDict
+class X(TypedDict):
+    b: 'B'
+    c: 'C'
+class B: pass
+class C(B): pass
+x: X
+reveal_type(x) # E: Revealed type is 'TypedDict(b=__main__.B, c=__main__.C, _fallback=__main__.X)'
+m1: Mapping[str, B] = x
+m2: Mapping[str, C] = x # E: Incompatible types in assignment (expression has type "X", variable has type Mapping[str, C])
+[builtins fixtures/dict.pyi]
+
 [case testForwardReferenceToTypedDictInTypedDict]
 from typing import Mapping
 from mypy_extensions import TypedDict

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -813,3 +813,29 @@ p = TaggedPoint(type='2d', x=42, y=1337)
 p.get('x', 1 + 'y')     # E: Unsupported operand types for + ("int" and "str")
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
+
+
+-- Special cases
+
+[case testForwardReferenceInTypedDict]
+from typing import Mapping
+from mypy_extensions import TypedDict
+X = TypedDict('X', {'b': 'B', 'c': 'C'})
+class B: pass
+class C(B): pass
+x: X
+reveal_type(x) # E: Revealed type is 'TypedDict(b=__main__.B, c=__main__.C, _fallback=__main__.X)'
+m1: Mapping[str, B] = x
+m2: Mapping[str, C] = x # E: Incompatible types in assignment (expression has type "X", variable has type Mapping[str, C])
+[builtins fixtures/dict.pyi]
+
+[case testForwardReferenceToTypedDictInTypedDict]
+from typing import Mapping
+from mypy_extensions import TypedDict
+# Forward references don't quite work yet
+X = TypedDict('X', {'a': 'A'}) # E: Invalid type "__main__.A"
+A = TypedDict('A', {'b': int})
+x: X
+reveal_type(x) # E: Revealed type is 'TypedDict(a=TypedDict(b=builtins.int, _fallback=__main__.A), _fallback=__main__.X)'
+reveal_type(x['a']['b']) # E: Revealed type is 'builtins.int'
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Move join to happen after semantic analysis to avoid crash due to
incomplete MRO in TypeInfo. The implementation uses a new semantic
analysis 'fixup' phase.

Fixes #3319. Fixes #2489. Fixes #3316.