### PR TITLE
Fix regression in semanal tests

### DIFF
--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1353,7 +1353,7 @@ def f() -> None:
 [out]
 
 [case testDuplicateDefOverload]
-from typing import overload
+from typing import overload, Any
 if 1:
     @overload
     def f(x: int) -> None:


### PR DESCRIPTION
The testDuplicateDefOverload tests in semanal-errors.test forgot to import `Any`, so the tests on the master branch are currently failing.

(Maybe this issue will be already fixed by the time somebody reviews this pull request?)