### PR TITLE
Make binder handle unconditional ifs with no else

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4020,8 +4020,14 @@ def infer_reachability_of_if_statement(s: IfStmt,
                 mark_block_mypy_only(s.body[i])
             for body in s.body[i + 1:]:
                 mark_block_unreachable(body)
-            if s.else_body:
-                mark_block_unreachable(s.else_body)
+
+            # Make sure else body always exists and is marked as
+            # unreachable so the type checker always knows that
+            # all control flow paths will flow through the if
+            # statement body.
+            if not s.else_body:
+                s.else_body = Block([])
+            mark_block_unreachable(s.else_body)
             break
 
 

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -517,3 +517,20 @@ else:
     y = 3
 reveal_type(y)  # E: Revealed type is 'builtins.str'
 [builtins fixtures/ops.pyi]
+
+[case testConditionalAssertWithoutElse]
+import typing
+
+class A: pass
+class B(A): pass
+
+x = A()
+reveal_type(x)  # E: Revealed type is '__main__.A'
+
+if typing.TYPE_CHECKING:
+    assert isinstance(x, B)
+    reveal_type(x)  # E: Revealed type is '__main__.B'
+
+reveal_type(x)  # E: Revealed type is '__main__.B'
+
+[builtins fixtures/isinstancelist.pyi]


### PR DESCRIPTION
This pull request fixes https://github.com/python/mypy/issues/2673.

The problem was that in the semantic analysis phase, we can only ever mark blocks as *unreachable*. So, if we have code of the form:

```python
if typing.TYPE_CHECKING:
    assert isinstance(...)
```

...nothing happens since there's no "else" block to mark as unreachable, which means the binder sees nothing special about this if statement and consequently ignores the special conditional.

I decided to just add a dummy empty "else" block if one doesn't already exist and mark it as unreachable. Two other solutions I considered were to add another field somewhere to record reachability or to repeat the special conditional checks in the typechecking phase, but these solutions seemed a bit redundant/wasteful.