### PR TITLE
Report error for NewType used with an unimported type

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1801,6 +1801,9 @@ class SemanticAnalyzer(NodeVisitor):
             self.fail(message.format(old_type), s)
             return
 
+        if 'unimported' in self.options.disallow_any and has_any_from_unimported_type(old_type):
+            self.msg.unimported_type_becomes_any("Argument 2 to NewType(...)", old_type, s)
+
         # If so, add it to the symbol table.
         node = self.lookup(name, s)
         if node is None:

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -482,8 +482,8 @@ main:5: error: Constraint 2 becomes List[Any] due to an unfollowed import
 from typing import NewType, List
 from missing import Unchecked
 
-# this case is handled elsewhere: Baz = NewType('Baz', Unchecked)
-Baz = NewType('Baz', List[Unchecked])  # E: Argument 2 to NewType(...) becomes List[Any] due to an unfollowed import
+Baz = NewType('Baz', Unchecked)  # E: Argument 2 to NewType(...) must be subclassable (got Any)
+Bar = NewType('Bar', List[Unchecked])  # E: Argument 2 to NewType(...) becomes List[Any] due to an unfollowed import
 
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -479,12 +479,13 @@ main:5: error: Constraint 2 becomes List[Any] due to an unfollowed import
 
 [case testDisallowImplicitAnyNewType]
 # flags: --ignore-missing-imports --disallow-any=unimported
-from typing import NewType
+from typing import NewType, List
 from missing import Unchecked
 
-Baz = NewType('Baz', Unchecked)
-[out]
-main:5: error: Argument 2 to NewType(...) must be subclassable (got Any)
+# this case is handled elsewhere: Baz = NewType('Baz', Unchecked)
+Baz = NewType('Baz', List[Unchecked])  # E: Argument 2 to NewType(...) becomes List[Any] due to an unfollowed import
+
+[builtins fixtures/list.pyi]
 
 [case testDisallowImplicitAnyCallableAndTuple]
 # flags: --ignore-missing-imports --disallow-any=unimported


### PR DESCRIPTION
Report error for NewType used with an unimported type if `--disallow-any=unimported` is enabled.

If second argument to `NewType(...)` is a simple unimported type, this is already an error. Here is an example:
```py
from x import Unimported

Baz = NewType('Baz', Unchecked)  # E: Argument 2 to NewType(...) must be subclassable (got Any)
```

This PR adds functionality to report error in the following case:
```py
from x import Unimported
from typing import List

Baz = NewType('Baz', List[Unchecked])
```