### PR TITLE
Fix contextmanager with generic functions

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -247,7 +247,9 @@ def contextmanager_callback(ctx: FunctionContext) -> Type:
             return ctx.default_return_type.copy_modified(
                 arg_types=arg_type.arg_types,
                 arg_kinds=arg_type.arg_kinds,
-                arg_names=arg_type.arg_names)
+                arg_names=arg_type.arg_names,
+                variables=arg_type.variables,
+                is_ellipsis_args=arg_type.is_ellipsis_args)
     return ctx.default_return_type
 
 

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -77,6 +77,7 @@ files = [
     'check-enum.test',
     'check-incomplete-fixture.test',
     'check-custom-plugin.test',
+    'check-default-plugin.test',
 ]
 
 

--- a/test-data/unit/check-default-plugin.test
+++ b/test-data/unit/check-default-plugin.test
@@ -1,0 +1,33 @@
+-- Test cases for the default plugin
+--
+-- Note that we have additional test cases in pythoneval.test (that use real typeshed stubs).
+
+
+[case testContextManagerWithGenericFunction]
+from contextlib import contextmanager
+from typing import TypeVar, Iterator
+
+T = TypeVar('T')
+
+@contextmanager
+def yield_id(item: T) -> Iterator[T]:
+    yield item
+
+reveal_type(yield_id) # E: Revealed type is 'def [T] (item: T`-1) -> contextlib.GeneratorContextManager[T`-1]'
+
+with yield_id(1) as x:
+    reveal_type(x) # E: Revealed type is 'builtins.int*'
+
+f = yield_id
+def g(x, y): pass
+f = g # E: Incompatible types in assignment (expression has type Callable[[Any, Any], Any], variable has type Callable[[T], GeneratorContextManager[T]])
+[typing fixtures/typing-full.pyi]
+
+[case testContextManagerWithUnspecifiedArguments]
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+c: Callable[..., Iterator[int]]
+reveal_type(c) # E: Revealed type is 'def (*Any, **Any) -> typing.Iterator[builtins.int]'
+reveal_type(contextmanager(c)) # E: Revealed type is 'def (*Any, **Any) -> contextlib.GeneratorContextManager[builtins.int*]'
+[typing fixtures/typing-full.pyi]

--- a/test-data/unit/fixtures/typing-full.pyi
+++ b/test-data/unit/fixtures/typing-full.pyi
@@ -111,4 +111,8 @@ class Mapping(Generic[T, U]):
 
 class MutableMapping(Generic[T, U]): pass
 
+class ContextManager(Generic[T]):
+    def __enter__(self) -> T: ...
+    def __exit__(self, exc_type, exc_value, traceback): ...
+
 TYPE_CHECKING = 1

--- a/test-data/unit/lib-stub/contextlib.pyi
+++ b/test-data/unit/lib-stub/contextlib.pyi
@@ -1,0 +1,10 @@
+from typing import Generic, TypeVar, Callable, Iterator
+from typing import ContextManager as ContextManager
+
+_T = TypeVar('_T')
+
+class GeneratorContextManager(ContextManager[_T], Generic[_T]):
+    def __call__(self, func: Callable[..., _T]) -> Callable[..., _T]: ...
+
+def contextmanager(func: Callable[..., Iterator[_T]]) -> Callable[..., GeneratorContextManager[_T]]:
+    ...


### PR DESCRIPTION
Fixes #3549. Also fixes subtyping of function types generated
through `contextmanager`.

Add a fixture for contextlib so that the new tests run quickly.