### PR TITLE
Improve pretty-printed TypedDicts in error messages

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -300,8 +300,11 @@ class MessageBuilder:
                 return self.format_simple(typ.fallback)
             items = []
             for (item_name, item_type) in typ.items.items():
-                items.append('{}={}'.format(item_name, strip_quotes(self.format(item_type))))
-            s = '"TypedDict({})"'.format(', '.join(items))
+                modifier = '' if item_name in typ.required_keys else '?'
+                items.append('{!r}{}: {}'.format(item_name,
+                                                 modifier,
+                                                 strip_quotes(self.format(item_type))))
+            s = '"TypedDict({{{}}})"'.format(', '.join(items))
             return s
         elif isinstance(typ, UnionType):
             # Only print Unions as Optionals if the Optional wouldn't have to contain another Union

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -357,6 +357,24 @@ def unprotect(p: Point) -> Any:
     return p
 [builtins fixtures/dict.pyi]
 
+[case testAnonymousTypedDictInErrorMessages]
+from mypy_extensions import TypedDict
+
+A = TypedDict('A', {'x': int, 'y': str})
+B = TypedDict('B', {'x': int, 'z': str, 'a': int})
+C = TypedDict('C', {'x': int, 'z': str, 'a': str})
+a: A
+b: B
+c: C
+
+def f(a: A) -> None: pass
+
+l = [a, b]  # Join generates an anonymous TypedDict
+f(l) # E: Argument 1 to "f" has incompatible type List[TypedDict({'x': int})]; expected "A"
+ll = [b, c]
+f(ll) # E: Argument 1 to "f" has incompatible type List[TypedDict({'x': int, 'z': str})]; expected "A"
+[builtins fixtures/dict.pyi]
+
 
 -- Join
 
@@ -989,6 +1007,24 @@ class C(TypedDict, B, total=True):
     z: str
 c: C
 reveal_type(c) # E: Revealed type is 'TypedDict(x=builtins.int, y=builtins.int, z=builtins.str, _fallback=__main__.C, _required_keys=[x, z])'
+[builtins fixtures/dict.pyi]
+
+[case testNonTotalTypedDictInErrorMessages]
+from mypy_extensions import TypedDict
+
+A = TypedDict('A', {'x': int, 'y': str}, total=False)
+B = TypedDict('B', {'x': int, 'z': str, 'a': int}, total=False)
+C = TypedDict('C', {'x': int, 'z': str, 'a': str}, total=False)
+a: A
+b: B
+c: C
+
+def f(a: A) -> None: pass
+
+l = [a, b]  # Join generates an anonymous TypedDict
+f(l) # E: Argument 1 to "f" has incompatible type List[TypedDict({'x'?: int})]; expected "A"
+ll = [b, c]
+f(ll) # E: Argument 1 to "f" has incompatible type List[TypedDict({'x'?: int, 'z'?: str})]; expected "A"
 [builtins fixtures/dict.pyi]
 
 


### PR DESCRIPTION
Distinguish between required and non-required keys and use
syntax that is closer to TypedDict definition syntax.

This is follow-up to #3598.