### PR TITLE
Make TypedDict messages clearer

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -82,7 +82,7 @@ KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE = \
 ALL_MUST_BE_SEQ_STR = 'Type of __all__ must be {}, not {}'
 INVALID_TYPEDDICT_ARGS = \
     'Expected keyword arguments, {...}, or dict(...) in TypedDict constructor'
-TYPEDDICT_ITEM_NAME_MUST_BE_STRING_LITERAL = \
+TYPEDDICT_KEY_MUST_BE_STRING_LITERAL = \
     'Expected TypedDict key to be string literal'
 MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'
 NON_BOOLEAN_IN_CONDITIONAL = 'Condition must be a boolean'
@@ -296,7 +296,7 @@ class MessageBuilder:
                 return 'tuple(length {})'.format(len(items))
         elif isinstance(typ, TypedDictType):
             # If the TypedDictType is named, return the name
-            if typ.fallback.type.fullname() != 'typing.Mapping':
+            if not typ.is_anonymous():
                 return self.format_simple(typ.fallback)
             items = []
             for (item_name, item_type) in typ.items.items():
@@ -872,34 +872,59 @@ class MessageBuilder:
         self.fail("{} becomes {} due to an unfollowed import".format(prefix, self.format(typ)),
                   ctx)
 
-    def typeddict_instantiated_with_unexpected_items(self,
-                                                     expected_item_names: List[str],
-                                                     actual_item_names: List[str],
-                                                     context: Context) -> None:
-        if not expected_item_names:
+    def unexpected_typeddict_keys(
+            self,
+            typ: TypedDictType,
+            expected_keys: List[str],
+            actual_keys: List[str],
+            context: Context) -> None:
+        actual_set = set(actual_keys)
+        expected_set = set(expected_keys)
+        if not typ.is_anonymous():
+            # Generate simpler messages for some common special cases.
+            if actual_set < expected_set:
+                # Use list comprehension instead of set operations to preserve order.
+                missing = [key for key in expected_keys if key not in actual_set]
+                self.fail('{} missing for TypedDict {}'.format(
+                    format_key_list(missing, short=True).capitalize(), self.format(typ)),
+                    context)
+                return
+            else:
+                extra = [key for key in actual_keys if key not in expected_set]
+                if extra:
+                    # If there are both extra and missing keys, only report extra ones for
+                    # simplicity.
+                    self.fail('Extra {} for TypedDict {}'.format(
+                        format_key_list(extra, short=True), self.format(typ)),
+                        context)
+                    return
+        if not expected_keys:
             expected = '(no keys)'
         else:
-            expected = format_key_list(expected_item_names)
-        found = format_key_list(actual_item_names, short=True)
-        if actual_item_names and set(actual_item_names) < set(expected_item_names):
+            expected = format_key_list(expected_keys)
+        found = format_key_list(actual_keys, short=True)
+        if actual_keys and actual_set < expected_set:
             found = 'only {}'.format(found)
         self.fail('Expected {} but found {}'.format(expected, found), context)
 
-    def typeddict_item_name_must_be_string_literal(self,
-                                                   typ: TypedDictType,
-                                                   context: Context,
-                                                   ) -> None:
+    def typeddict_key_must_be_string_literal(
+            self,
+            typ: TypedDictType,
+            context: Context) -> None:
         self.fail(
             'TypedDict key must be a string literal; expected one of {}'.format(
                 format_item_name_list(typ.items.keys())), context)
 
-    def typeddict_item_name_not_found(self,
-                                      typ: TypedDictType,
-                                      item_name: str,
-                                      context: Context,
-                                      ) -> None:
-        self.fail('\'{}\' is not a valid TypedDict key; expected one of {}'.format(
-            item_name, format_item_name_list(typ.items.keys())), context)
+    def typeddict_key_not_found(
+            self,
+            typ: TypedDictType,
+            item_name: str,
+            context: Context) -> None:
+        if typ.is_anonymous():
+            self.fail('\'{}\' is not a valid TypedDict key; expected one of {}'.format(
+                item_name, format_item_name_list(typ.items.keys())), context)
+        else:
+            self.fail("TypedDict {} has no key '{}'".format(self.format(typ), item_name), context)
 
     def type_arguments_not_allowed(self, context: Context) -> None:
         self.fail('Parameterized generics cannot be used with class or instance checks', context)

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -308,7 +308,7 @@ def typed_dict_get_callback(ctx: MethodContext) -> Type:
                     else:
                         return UnionType.make_simplified_union([value_type, ctx.arg_types[1][0]])
             else:
-                ctx.api.msg.typeddict_item_name_not_found(ctx.type, key, ctx.context)
+                ctx.api.msg.typeddict_key_not_found(ctx.type, key, ctx.context)
                 return AnyType()
     return ctx.default_return_type
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -931,8 +931,11 @@ class TypedDictType(Type):
                              set(data['required_keys']),
                              Instance.deserialize(data['fallback']))
 
+    def is_anonymous(self) -> bool:
+        return self.fallback.type.fullname() == 'typing.Mapping'
+
     def as_anonymous(self) -> 'TypedDictType':
-        if self.fallback.type.fullname() == 'typing.Mapping':
+        if self.is_anonymous():
             return self
         assert self.fallback.type.typeddict_type is not None
         return self.fallback.type.typeddict_type.as_anonymous()

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -603,8 +603,22 @@ reveal_type(c[u'value'])  # E: Revealed type is 'builtins.int'
 [case testCannotGetItemOfTypedDictWithInvalidStringLiteralKey]
 from mypy_extensions import TypedDict
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
-p = TaggedPoint(type='2d', x=42, y=1337)
-p['z']  # E: 'z' is not a valid TypedDict key; expected one of ('type', 'x', 'y')
+p: TaggedPoint
+p['z']  # E: TypedDict "TaggedPoint" has no key 'z'
+[builtins fixtures/dict.pyi]
+
+[case testCannotGetItemOfAnonymousTypedDictWithInvalidStringLiteralKey]
+from typing import TypeVar
+from mypy_extensions import TypedDict
+A = TypedDict('A', {'x': str, 'y': int, 'z': str})
+B = TypedDict('B', {'x': str, 'z': int})
+C = TypedDict('C', {'x': str, 'y': int, 'z': int})
+T = TypeVar('T')
+def join(x: T, y: T) -> T: return x
+ab = join(A(x='', y=1, z=''), B(x='', z=1))
+ac = join(A(x='', y=1, z=''), C(x='', y=0, z=1))
+ab['y']  # E: 'y' is not a valid TypedDict key; expected one of ('x')
+ac['a']  # E: 'a' is not a valid TypedDict key; expected one of ('x', 'y')
 [builtins fixtures/dict.pyi]
 
 [case testCannotGetItemOfTypedDictWithNonLiteralKey]
@@ -750,14 +764,15 @@ Point = TypedDict('Point', {'x': int, 'y': int})
 
 def f(p: Point) -> None:
     p = {'x': 2, 'y': 3}
-    p = {'x': 2}  # E: Expected TypedDict keys ('x', 'y') but found only key 'x'
+    p = {'x': 2}  # E: Key 'y' missing for TypedDict "Point"
     p = dict(x=2, y=3)
 
 f({'x': 1, 'y': 3})
 f({'x': 1, 'y': 'z'})  # E: Incompatible types (expression has type "str", TypedDict item "y" has type "int")
 
 f(dict(x=1, y=3))
-f(dict(x=1, y=3, z=4))  # E: Expected TypedDict keys ('x', 'y') but found keys ('x', 'y', 'z')
+f(dict(x=1, y=3, z=4))  # E: Extra key 'z' for TypedDict "Point"
+f(dict(x=1, y=3, z=4, a=5))  # E: Extra keys ('z', 'a') for TypedDict "Point"
 
 [builtins fixtures/dict.pyi]
 
@@ -766,16 +781,39 @@ from mypy_extensions import TypedDict
 
 Point = TypedDict('Point', {'x': int, 'y': int})
 
-p1: Point = {'x': 'hi'}  # E: Expected TypedDict keys ('x', 'y') but found only key 'x'
+p1a: Point = {'x': 'hi'}  # E: Key 'y' missing for TypedDict "Point"
+p1b: Point = {}           # E: Keys ('x', 'y') missing for TypedDict "Point"
 
 p2: Point
-p2 = dict(x='bye')  # E: Expected TypedDict keys ('x', 'y') but found only key 'x'
+p2 = dict(x='bye')  # E: Key 'y' missing for TypedDict "Point"
 
 p3 = Point(x=1, y=2)
 p3 = {'x': 'hi'}  # E: Expected TypedDict keys ('x', 'y') but found only key 'x'
 
 p4: Point = {'x': 1, 'y': 2}
 
+[builtins fixtures/dict.pyi]
+
+[case testCannotCreateAnonymousTypedDictInstanceUsingDictLiteralWithExtraItems]
+from mypy_extensions import TypedDict
+from typing import TypeVar
+A = TypedDict('A', {'x': int, 'y': int})
+B = TypedDict('B', {'x': int, 'y': str})
+T = TypeVar('T')
+def join(x: T, y: T) -> T: return x
+ab = join(A(x=1, y=1), B(x=1, y=''))
+ab = {'x': 1, 'z': 1} # E: Expected TypedDict key 'x' but found keys ('x', 'z')
+[builtins fixtures/dict.pyi]
+
+[case testCannotCreateAnonymousTypedDictInstanceUsingDictLiteralWithMissingItems]
+from mypy_extensions import TypedDict
+from typing import TypeVar
+A = TypedDict('A', {'x': int, 'y': int, 'z': int})
+B = TypedDict('B', {'x': int, 'y': int, 'z': str})
+T = TypeVar('T')
+def join(x: T, y: T) -> T: return x
+ab = join(A(x=1, y=1, z=1), B(x=1, y=1, z=''))
+ab = {} # E: Expected TypedDict keys ('x', 'y') but found no keys
 [builtins fixtures/dict.pyi]
 
 
@@ -815,7 +853,7 @@ D = TypedDict('D', {'x': int, 'y': str})
 d: D
 d.get() # E: No overload variant of "get" of "Mapping" matches argument types []
 d.get('x', 1, 2) # E: No overload variant of "get" of "Mapping" matches argument types [builtins.str, builtins.int, builtins.int]
-x = d.get('z') # E: 'z' is not a valid TypedDict key; expected one of ('x', 'y')
+x = d.get('z') # E: TypedDict "D" has no key 'z'
 reveal_type(x) # E: Revealed type is 'Any'
 s = ''
 y = d.get(s)
@@ -890,7 +928,7 @@ f({})
 f({'x': 1})
 f({'y': ''})
 f({'x': 1, 'y': ''})
-f({'x': 1, 'z': ''}) # E: Expected TypedDict key 'x' but found keys ('x', 'z')
+f({'x': 1, 'z': ''}) # E: Extra key 'z' for TypedDict "D"
 f({'x': ''}) # E: Incompatible types (expression has type "str", TypedDict item "x" has type "int")
 [builtins fixtures/dict.pyi]
 

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1353,6 +1353,6 @@ reveal_type(d.get(s))
 [out]
 _testTypedDictGet.py:7: error: Revealed type is 'builtins.int'
 _testTypedDictGet.py:8: error: Revealed type is 'builtins.str'
-_testTypedDictGet.py:9: error: 'z' is not a valid TypedDict key; expected one of ('x', 'y')
+_testTypedDictGet.py:9: error: TypedDict "D" has no key 'z'
 _testTypedDictGet.py:10: error: No overload variant of "get" of "Mapping" matches argument types []
 _testTypedDictGet.py:12: error: Revealed type is 'builtins.object*'


### PR DESCRIPTION
Include TypedDict name when it's available, and avoid displaying
all the available keys in that case, since it can result in very
long messages.

Also minor refactoring.
