### PR TITLE
add version number of typed-ast to --version

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -4,6 +4,7 @@ import argparse
 import configparser
 import fnmatch
 import os
+import pkg_resources
 import re
 import sys
 import time
@@ -236,7 +237,8 @@ def process_options(args: List[str],
     parser.add_argument('-v', '--verbose', action='count', dest='verbosity',
                         help="more verbose messages")
     parser.add_argument('-V', '--version', action='version',
-                        version='%(prog)s ' + __version__)
+                        version='%(prog)s {} [typed-ast {}]'.format(
+                            __version__, pkg_resources.require('typed-ast')[0].version))
     parser.add_argument('--python-version', type=parse_version, metavar='x.y',
                         help='use Python x.y')
     parser.add_argument('--platform', action='store', metavar='PLATFORM',


### PR DESCRIPTION
Since `setup.py` only sets a lower bound for `typed-ast` the same version of `mypy` can have different `typed-ast` version installed, depending on the time of `mypy`'s installation/upgrade. The actual installed version of typed-ast can have a profound effect on the warnings/errors generated by mypy. 

This change shows the version of both packages (`test 0.511 [typed-ast 1.0.4]`) when doing `mypy --version`.

I could not find the actual version number of typed-ast in its sources ( `__version__` or `version_info`)