### PR TITLE
Turn on strict optional in CI

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -15,7 +15,7 @@ BindableTypes = (IndexExpr, MemberExpr, NameExpr)
 BindableExpression = Union[IndexExpr, MemberExpr, NameExpr]
 
 
-class Frame(Dict[Key, Optional[Type]]):
+class Frame(Dict[Key, Type]):
     """A Frame represents a specific point in the execution of a program.
     It carries information about the current types of expressions at
     that point, arising either from assignments to those expressions
@@ -26,6 +26,13 @@ class Frame(Dict[Key, Optional[Type]]):
     onto the stack, so a given Frame only has information about types
     that were assigned in that frame.
     """
+
+    def __init__(self) -> None:
+        self.unreachable = False
+
+
+class DeclarationsFrame(Dict[Key, Optional[Type]]):
+    """Same as above, but allowed to have None values."""
 
     def __init__(self) -> None:
         self.unreachable = False
@@ -70,7 +77,7 @@ class ConditionalTypeBinder:
 
         # Maps expr.literal_hash to get_declaration(expr)
         # for every expr stored in the binder
-        self.declarations = Frame()
+        self.declarations = DeclarationsFrame()
         # Set of other keys to invalidate if a key is changed, e.g. x -> {x.a, x[0]}
         # Whenever a new key (e.g. x.a.b) is added, we update this
         self.dependencies = {}  # type: Dict[Key, Set[Key]]

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -212,7 +212,7 @@ def analyze_member_var_access(name: str, itype: Instance, info: TypeInfo,
                               not_ready_callback: Callable[[str, Context], None],
                               msg: MessageBuilder,
                               original_type: Type,
-                              chk: 'mypy.checker.TypeChecker' = None) -> Type:
+                              chk: 'mypy.checker.TypeChecker') -> Type:
     """Analyse attribute access that does not target a method.
 
     This is logically part of analyze_member_access and the arguments are similar.

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -4,7 +4,7 @@ import traceback
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
 
-from typing import Tuple, List, TypeVar, Set, Dict, Iterator, Optional
+from typing import Tuple, List, TypeVar, Set, Dict, Iterator, Optional, cast
 
 from mypy.options import Options
 from mypy.version import __version__ as mypy_version

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -278,7 +278,7 @@ class Errors:
         self.add_error_info(info)
 
     def add_error_info(self, info: ErrorInfo) -> None:
-        (file, line) = info.origin
+        (file, line) = cast(Tuple[str, int], info.origin)  # see issue 1855
         if not info.blocker:  # Blockers cannot be ignored
             if file in self.ignored_lines and line in self.ignored_lines[file]:
                 # Annotation requests us to ignore all errors on this line.

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -34,6 +34,7 @@ def expr_to_unanalyzed_type(expr: Expression, _parent: Optional[Expression] = No
     """
     # The `parent` paremeter is used in recursive calls to provide context for
     # understanding whether an CallableArgument is ok.
+    name = None  # type: Optional[str]
     if isinstance(expr, NameExpr):
         name = expr.name
         return UnboundType(name, line=expr.line, column=expr.column)

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -15,7 +15,7 @@ from mypy.subtypes import is_subtype, is_equivalent, is_subtype_ignoring_tvars, 
 from mypy import experiments
 
 
-def join_simple(declaration: Type, s: Type, t: Type) -> Type:
+def join_simple(declaration: Optional[Type], s: Type, t: Type) -> Type:
     """Return a simple least upper bound given the declared type."""
 
     if (s.can_be_true, s.can_be_false) != (t.can_be_true, t.can_be_false):

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -28,7 +28,7 @@ class InvalidPackageName(Exception):
     """Exception indicating that a package name was invalid."""
 
 
-def main(script_path: str, args: List[str] = None) -> None:
+def main(script_path: Optional[str], args: List[str] = None) -> None:
     """Main entry point to the type checker.
 
     Args:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1954,7 +1954,7 @@ class TypeInfo(SymbolNode):
     mro = None  # type: List[TypeInfo]
 
     declared_metaclass = None  # type: Optional[mypy.types.Instance]
-    metaclass_type = None  # type: mypy.types.Instance
+    metaclass_type = None  # type: Optional[mypy.types.Instance]
 
     subtypes = None  # type: Set[TypeInfo] # Direct subclasses encountered so far
     names = None  # type: SymbolTable      # Names defined directly in this type
@@ -2506,9 +2506,9 @@ def check_arg_kinds(arg_kinds: List[int], nodes: List[T], fail: Callable[[str, T
             is_kw_arg = True
 
 
-def check_arg_names(names: List[str], nodes: List[T], fail: Callable[[str, T], None],
+def check_arg_names(names: List[Optional[str]], nodes: List[T], fail: Callable[[str, T], None],
                     description: str = 'function definition') -> None:
-    seen_names = set()  # type: Set[str]
+    seen_names = set()  # type: Set[Optional[str]]
     for name, node in zip(names, nodes):
         if name is not None and name in seen_names:
             fail("Duplicate argument '{}' in {}".format(name, description), node)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1713,6 +1713,7 @@ class SemanticAnalyzer(NodeVisitor):
                 v.info = self.type
                 v.is_initialized_in_class = True
                 v.set_line(lval)
+                v._fullname = self.qualified_name(lval.name)
                 lval.node = v
                 lval.is_def = True
                 lval.kind = MDEF

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -103,7 +103,10 @@ class StatisticsVisitor(TraverserVisitor):
                     items = [lvalue]
                 for item in items:
                     if isinstance(item, RefExpr) and item.is_def:
-                        t = self.typemap.get(item)
+                        if self.typemap is not None:
+                            t = self.typemap.get(item)
+                        else:
+                            t = None
                         if t:
                             self.type(t)
                         else:
@@ -151,10 +154,11 @@ class StatisticsVisitor(TraverserVisitor):
 
     def process_node(self, node: Expression) -> None:
         if self.all_nodes:
-            typ = self.typemap.get(node)
-            if typ:
-                self.line = node.line
-                self.type(typ)
+            if self.typemap is not None:
+                typ = self.typemap.get(node)
+                if typ:
+                    self.line = node.line
+                    self.type(typ)
 
     def type(self, t: Type) -> None:
         if isinstance(t, AnyType):

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -164,7 +164,9 @@ def parse_test_cases(
                 for file_path, contents in files:
                     expand_errors(contents.split('\n'), tcout, file_path)
                 lastline = p[i].line if i < len(p) else p[i - 1].line + 9999
-                tc = DataDrivenTestCase(p[i0].arg, input, tcout, tcout2, path,
+                arg0 = p[i0].arg
+                assert arg0 is not None
+                tc = DataDrivenTestCase(arg0, input, tcout, tcout2, path,
                                         p[i0].line, lastline, perform,
                                         files, output_files, stale_modules,
                                         rechecked_modules, deleted_paths, native_sep)
@@ -200,7 +202,7 @@ class DataDrivenTestCase(TestCase):
                  file: str,
                  line: int,
                  lastline: int,
-                 perform: Callable[['DataDrivenTestCase'], None],
+                 perform: Optional[Callable[['DataDrivenTestCase'], None]],
                  files: List[Tuple[str, str]],
                  output_files: List[Tuple[str, str]],
                  expected_stale_modules: Dict[int, Set[str]],
@@ -270,6 +272,7 @@ class DataDrivenTestCase(TestCase):
         if self.name.endswith('-skip'):
             raise SkipTestCaseException()
         else:
+            assert self.perform is not None, 'Tests without `perform` should not be `run`'
             self.perform(self)
 
     def tear_down(self) -> None:

--- a/mypy/test/testdeps.py
+++ b/mypy/test/testdeps.py
@@ -1,7 +1,7 @@
 """Test cases for generating node-level dependencies (for fine-grained incremental checking)"""
 
 import os
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Optional
 
 from mypy import build
 from mypy.build import BuildSource
@@ -35,6 +35,8 @@ class GetDependenciesSuite(DataSuite):
         src = '\n'.join(testcase.input)
         messages, files, type_map = self.build(src)
         a = messages
+        assert files is not None and type_map is not None, ('cases where CompileError'
+                                                            ' occurred should not be run')
         deps = get_dependencies('__main__', files['__main__'], type_map)
 
         for source, targets in sorted(deps.items()):
@@ -49,8 +51,8 @@ class GetDependenciesSuite(DataSuite):
                                                   testcase.line))
 
     def build(self, source: str) -> Tuple[List[str],
-                                          Dict[str, MypyFile],
-                                          Dict[Expression, Type]]:
+                                          Optional[Dict[str, MypyFile]],
+                                          Optional[Dict[Expression, Type]]]:
         options = Options()
         options.use_builtins_fixtures = True
         options.show_traceback = True

--- a/mypy/test/testdiff.py
+++ b/mypy/test/testdiff.py
@@ -1,7 +1,7 @@
 """Test cases for AST diff (used for fine-grained incremental checking)"""
 
 import os
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Optional
 
 from mypy import build
 from mypy.build import BuildSource
@@ -46,6 +46,8 @@ class ASTDiffSuite(DataSuite):
             a.append('== next ==')
             a.extend(messages2)
 
+        assert files1 is not None and files2 is not None, ('cases where CompileError'
+                                                           ' occurred should not be run')
         diff = compare_symbol_tables(
             '__main__',
             files1['__main__'].names,
@@ -58,7 +60,7 @@ class ASTDiffSuite(DataSuite):
             'Invalid output ({}, line {})'.format(testcase.file,
                                                   testcase.line))
 
-    def build(self, source: str) -> Tuple[List[str], Dict[str, MypyFile]]:
+    def build(self, source: str) -> Tuple[List[str], Optional[Dict[str, MypyFile]]]:
         options = Options()
         options.use_builtins_fixtures = True
         options.show_traceback = True

--- a/mypy/test/testsemanal.py
+++ b/mypy/test/testsemanal.py
@@ -201,6 +201,7 @@ class SemAnalTypeInfoSuite(Suite):
             for f in result.files.values():
                 for n in f.names.values():
                     if isinstance(n.node, TypeInfo):
+                        assert n.fullname is not None
                         typeinfos[n.fullname] = n.node
 
             # The output is the symbol table converted into a string.

--- a/mypy/test/testsolve.py
+++ b/mypy/test/testsolve.py
@@ -1,6 +1,6 @@
 """Test cases for the constraint solver used in type inference."""
 
-from typing import List, Union, Tuple
+from typing import List, Union, Tuple, Optional
 
 from mypy.myunit import Suite, assert_equal
 from mypy.constraints import SUPERTYPE_OF, SUBTYPE_OF, Constraint
@@ -114,9 +114,9 @@ class SolveSuite(Suite):
     def assert_solve(self,
                      vars: List[TypeVarId],
                      constraints: List[Constraint],
-                     results: List[Union[Type, Tuple[Type, Type]]],
+                     results: List[Union[None, Type, Tuple[Type, Type]]],
                      ) -> None:
-        res = []
+        res = []  # type: List[Optional[Type]]
         for r in results:
             if isinstance(r, tuple):
                 res.append(r[0])

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -122,8 +122,9 @@ class TraverserVisitor(NodeVisitor[None]):
     def visit_try_stmt(self, o: TryStmt) -> None:
         o.body.accept(self)
         for i in range(len(o.types)):
-            if o.types[i]:
-                o.types[i].accept(self)
+            tp = o.types[i]
+            if tp is not None:
+                tp.accept(self)
             o.handlers[i].accept(self)
         if o.else_body is not None:
             o.else_body.accept(self)
@@ -133,8 +134,9 @@ class TraverserVisitor(NodeVisitor[None]):
     def visit_with_stmt(self, o: WithStmt) -> None:
         for i in range(len(o.expr)):
             o.expr[i].accept(self)
-            if o.target[i] is not None:
-                o.target[i].accept(self)
+            targ = o.target[i]
+            if targ is not None:
+                targ.accept(self)
         o.body.accept(self)
 
     def visit_member_expr(self, o: MemberExpr) -> None:

--- a/mypy/tvar_scope.py
+++ b/mypy/tvar_scope.py
@@ -68,6 +68,7 @@ class TypeVarScope:
 
     def get_binding(self, item: Union[str, SymbolTableNode]) -> Optional[TypeVarDef]:
         fullname = item.fullname if isinstance(item, SymbolTableNode) else item
+        assert fullname is not None
         if fullname in self.scope:
             return self.scope[fullname]
         elif self.parent is not None:

--- a/mypy/tvar_scope.py
+++ b/mypy/tvar_scope.py
@@ -30,7 +30,7 @@ class TypeVarScope:
 
     def get_function_scope(self) -> Optional['TypeVarScope']:
         """Get the nearest parent that's a function scope, not a class scope"""
-        it = self
+        it = self  # type: Optional[TypeVarScope]
         while it is not None and it.is_class_scope:
             it = it.parent
         return it

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -523,8 +523,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], AnalyzerPluginInterface):
                 self.fail("Type variable '{}' is bound by an outer class".format(name), defn)
             self.tvar_scope.bind(name, tvar)
             binding = self.tvar_scope.get_binding(tvar.fullname())
-            if binding is not None:
-                defs.append(binding)
+            assert binding is not None
+            defs.append(binding)
 
         return defs
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -438,7 +438,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], AnalyzerPluginInterface):
                                                                          List[Optional[str]]]]:
         args = []   # type: List[Type]
         kinds = []  # type: List[int]
-        names = []  # type: List[str]
+        names = []  # type: List[Optional[str]]
         for arg in arglist.items:
             if isinstance(arg, CallableArgument):
                 args.append(arg.typ)
@@ -454,6 +454,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], AnalyzerPluginInterface):
                         found.fullname), arg)
                     return None
                 else:
+                    assert found.fullname is not None
                     kind = ARG_KINDS_BY_CONSTRUCTOR[found.fullname]
                     kinds.append(kind)
                     if arg.name is not None and kind in {ARG_STAR, ARG_STAR2}:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -523,8 +523,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], AnalyzerPluginInterface):
                 self.fail("Type variable '{}' is bound by an outer class".format(name), defn)
             self.tvar_scope.bind(name, tvar)
             binding = self.tvar_scope.get_binding(tvar.fullname())
-            assert binding is not None
-            defs.append(binding)
+            if binding is not None:
+                defs.append(binding)
 
         return defs
 

--- a/mypy_strict_optional.ini
+++ b/mypy_strict_optional.ini
@@ -4,8 +4,20 @@
 strict_optional = True
 
 ; temporary exceptions
+[mypy-mypy.build]
+strict_optional = False
+
 [mypy-mypy.fastparse]
 strict_optional = False
 
 [mypy-mypy.fastparse2]
+strict_optional = False
+
+[mypy-mypy.checker]
+strict_optional = False
+
+[mypy-mypy.checkexpr]
+strict_optional = False
+
+[mypy-mypy.semanal]
 strict_optional = False

--- a/mypy_strict_optional.ini
+++ b/mypy_strict_optional.ini
@@ -21,6 +21,3 @@ strict_optional = False
 
 [mypy-mypy.semanal]
 strict_optional = False
-
-[mypy-mypy.test]
-strict_optional = False

--- a/mypy_strict_optional.ini
+++ b/mypy_strict_optional.ini
@@ -2,4 +2,10 @@
 ; This allows us to make mypy strict Optional compliant over time.
 [mypy]
 strict_optional = True
-ignore_errors = True
+
+; temporary exceptions
+[mypy-mypy.fastparse]
+strict_optional = False
+
+[mypy-mypy.fastparse2]
+strict_optional = False

--- a/mypy_strict_optional.ini
+++ b/mypy_strict_optional.ini
@@ -21,3 +21,6 @@ strict_optional = False
 
 [mypy-mypy.semanal]
 strict_optional = False
+
+[mypy-mypy.test]
+strict_optional = False

--- a/mypy_strict_optional.ini
+++ b/mypy_strict_optional.ini
@@ -7,17 +7,47 @@ strict_optional = True
 [mypy-mypy.build]
 strict_optional = False
 
-[mypy-mypy.fastparse]
-strict_optional = False
-
-[mypy-mypy.fastparse2]
-strict_optional = False
-
 [mypy-mypy.checker]
 strict_optional = False
 
 [mypy-mypy.checkexpr]
 strict_optional = False
 
+[mypy-mypy.fastparse]
+strict_optional = False
+
+[mypy-mypy.fastparse2]
+strict_optional = False
+
+[mypy-mypy.main]
+strict_optional = False
+
+[mypy-mypy.myunit]
+strict_optional = False
+
 [mypy-mypy.semanal]
+strict_optional = False
+
+[mypy-mypy.server.astdiff]
+strict_optional = False
+
+[mypy-mypy.server.astmerge]
+strict_optional = False
+
+[mypy-mypy.server.aststrip]
+strict_optional = False
+
+[mypy-mypy.server.update]
+strict_optional = False
+
+[mypy-mypy.test.testinfer]
+strict_optional = False
+
+[mypy-mypy.test.testmerge]
+strict_optional = False
+
+[mypy-mypy.test.testtypes]
+strict_optional = False
+
+[mypy-mypy.waiter]
 strict_optional = False

--- a/test-data/unit/semanal-classes.test
+++ b/test-data/unit/semanal-classes.test
@@ -252,7 +252,7 @@ MypyFile:1(
       IntExpr(1))
     AssignmentStmt:3(
       NameExpr(y* [m])
-      NameExpr(x [m]))))
+      NameExpr(x [__main__.A.x]))))
 
 [case testMethodRefInClassBody]
 class A:
@@ -291,7 +291,7 @@ MypyFile:1(
           IntExpr(1)))
       Else(
         AssignmentStmt:5(
-          NameExpr(x [m])
+          NameExpr(x [__main__.A.x])
           IntExpr(2))))))
 
 [case testForStatementInClassBody]
@@ -310,7 +310,7 @@ MypyFile:1(
       Block:2(
         AssignmentStmt:3(
           NameExpr(y* [m])
-          NameExpr(x [m]))))))
+          NameExpr(x [__main__.A.x]))))))
 
 [case testReferenceToClassWithinFunction]
 def f():
@@ -550,7 +550,7 @@ MypyFile:1(
       Init(
         AssignmentStmt:4(
           NameExpr(x [l])
-          NameExpr(X [m])))
+          NameExpr(X [__main__.A.X])))
       Block:4(
         PassStmt:4()))))
 

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -92,7 +92,7 @@ MypyFile:1(
       NameExpr(None [builtins.None])
       builtins.int)
     AssignmentStmt:4(
-      NameExpr(x [m])
+      NameExpr(x [__main__.A.x])
       IntExpr(1))))
 
 [case testFunctionSig]


### PR DESCRIPTION
Now ``--strict-optional`` can be turned on/off per file.
This PR turns on strict optional self-test for most files (there are still 16 files that are skipped, I will clean-up them in subsequent PRs).

There is an observation:
```python
class C:
    fullname = None  # type: str
```
is allowed even with ``--strict-optional``. I understand this is because of limitations of the type comment syntax, but this leads to some hard to find bugs. It would be great to be able to catch this somehow.