### PR TITLE
Treat ASCII-only literals as str when using unicode_literals

### DIFF
--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -638,8 +638,7 @@ class ASTConverter(ast27.NodeTransformer):
                            n.level,
                            [(a.name, a.asname) for a in n.names])
         self.imports.append(i)
-        if (n.module == '__future__' and len(n.names) == 1 and
-                n.names[0].name == 'unicode_literals' and n.names[0].asname is None):
+        if n.module == '__future__' and any(nm.name == 'unicode_literals' for nm in n.names):
             self.unicode_literals = True
         return i
 

--- a/runtests.py
+++ b/runtests.py
@@ -233,7 +233,7 @@ def add_pythoneval(driver: Driver) -> None:
     cases = set()
     case_re = re.compile(r'^\[case ([^\]]+)\]$')
     for file in python_eval_files + python_34_eval_files:
-        with open(os.path.join(test_data_prefix, file), 'r') as f:
+        with open(os.path.join(test_data_prefix, file), 'r', encoding='utf-8') as f:
             for line in f:
                 m = case_re.match(line)
                 if m:

--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -173,6 +173,18 @@ reveal_type('another ascii')
 _program.py:4: error: Incompatible types in assignment (expression has type "unicode", variable has type "str")
 _program.py:6: error: Revealed type is 'builtins.str'
 
+[case testUnicodeLiteralsFutureImportAllASCIIvariant1_python2]
+from __future__ import absolute_import, unicode_literals
+x = None  # type: str
+x = 'only ascii'
+[out]
+
+[case testUnicodeLiteralsFutureImportAllASCIIvariant2_python2]
+from __future__ import unicode_literals as something_else
+x = None  # type: str
+x = 'only ascii'
+[out]
+
 [case testStrUnicodeCompatibility_python2]
 import typing
 def f(s): # type: (unicode) -> None

--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -151,15 +151,27 @@ f(**params)
 [out]
 
 [case testFromFutureImportUnicodeLiterals2_python2]
+# coding=utf-8
 from __future__ import unicode_literals
 def f(x): # type: (str) -> None
   pass
 f(b'')
-f(u'')
-f('')
+f(u'щось')
+f('щось інше')
 [out]
-_program.py:5: error: Argument 1 to "f" has incompatible type "unicode"; expected "str"
 _program.py:6: error: Argument 1 to "f" has incompatible type "unicode"; expected "str"
+_program.py:7: error: Argument 1 to "f" has incompatible type "unicode"; expected "str"
+
+[case testUnicodeLiteralsFutureImportAllASCII_python2]
+# coding=utf-8
+from __future__ import unicode_literals
+x = None  # type: str
+x = 'не латиниця'  # Error
+x = 'only ascii'  # This is however OK
+reveal_type('another ascii')
+[out]
+_program.py:4: error: Incompatible types in assignment (expression has type "unicode", variable has type "str")
+_program.py:6: error: Revealed type is 'builtins.str'
 
 [case testStrUnicodeCompatibility_python2]
 import typing


### PR DESCRIPTION
Fixes #3619 

This PR only affects code that uses ``from __future__ import unicode_literals``.

It looks like there is a solution that will not require modifying ``typed_ast``. Note that this will treat ASCII-only literals with an explicit prefix ``u'foo'`` as ``str``, not ``unicode``. This can be changed, but only by updating ``typed_ast`` (the point is that ``Str`` has an attribute ``has_b`` indicating the presence of ``b`` prefix, we will need also ``has_u``).

I know ``unicode_literals`` are bad, but I have seen several people complaining about this recently.
@JukkaL @JelleZijlstra what do you think?