### PR TITLE
Give useful message if can't infer TypeVar-based type for attribute

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1704,8 +1704,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 self.fail(messages.NEED_ANNOTATION_FOR_VAR, context)
                 self.set_inference_error_fallback_type(name, lvalue, init_type, context)
         elif (isinstance(lvalue, MemberExpr) and self.inferred_attribute_types is not None
-                  and lvalue.def_var in self.inferred_attribute_types
-                  and not is_same_type(self.inferred_attribute_types[lvalue.def_var], init_type)):
+              and lvalue.def_var in self.inferred_attribute_types
+              and not is_same_type(self.inferred_attribute_types[lvalue.def_var], init_type)):
             # Multiple, inconsistent types inferred for an attribute.
             self.fail(messages.NEED_ANNOTATION_FOR_VAR, context)
             name.type = AnyType()

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1247,7 +1247,8 @@ class MemberExpr(RefExpr):
 
     expr = None  # type: Expression
     name = None  # type: str
-    # The variable node related to a definition.
+    # The variable node related to a definition through 'self.x = <initializer>'.
+    # The nodes of other kinds of member expressions are resolved during type checking.
     def_var = None  # type: Var
 
     def __init__(self, expr: Expression, name: str) -> None:

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -340,7 +340,9 @@ class TransformVisitor(NodeVisitor[Node]):
         member = MemberExpr(self.expr(node.expr),
                             node.name)
         if node.def_var:
-            member.def_var = self.visit_var(node.def_var)
+            # This refers to an attribute and we don't transform attributes by default,
+            # just normal variables.
+            member.def_var = node.def_var
         self.copy_ref(member, node)
         return member
 

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -312,6 +312,52 @@ cs = C() # type: C[str]
 cs.x = ''
 cs.x = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
+[case testAttributeInGenericTypeWithTypevarValues3]
+from typing import TypeVar, Generic
+X = TypeVar('X', int, str)
+class C(Generic[X]):
+    def f(self, x: X) -> None:
+        self.x = x  # type: X
+ci: C[int]
+cs: C[str]
+reveal_type(ci.x) # E: Revealed type is 'builtins.int*'
+reveal_type(cs.x) # E: Revealed type is 'builtins.str*'
+
+[case testAttributeInGenericTypeWithTypevarValuesUsingInference1]
+from typing import TypeVar, Generic
+X = TypeVar('X', int, str)
+class C(Generic[X]):
+    def f(self, x: X) -> None:
+        self.x = x # E: Need type annotation for variable
+ci: C[int]
+cs: C[str]
+reveal_type(ci.x) # E: Revealed type is 'Any'
+reveal_type(cs.x) # E: Revealed type is 'Any'
+
+[case testAttributeInGenericTypeWithTypevarValuesUsingInference2]
+from typing import TypeVar, Generic
+X = TypeVar('X', int, str)
+class C(Generic[X]):
+    def f(self, x: X) -> None:
+        self.x = 1
+        reveal_type(self.x) # E: Revealed type is 'builtins.int'
+ci: C[int]
+cs: C[str]
+reveal_type(ci.x) # E: Revealed type is 'builtins.int'
+reveal_type(cs.x) # E: Revealed type is 'builtins.int'
+
+[case testAttributeInGenericTypeWithTypevarValuesUsingInference3]
+from typing import TypeVar, Generic
+X = TypeVar('X', int, str)
+class C(Generic[X]):
+    x: X
+    def f(self) -> None:
+        self.y = self.x # E: Need type annotation for variable
+ci: C[int]
+cs: C[str]
+reveal_type(ci.y) # E: Revealed type is 'Any'
+reveal_type(cs.y) # E: Revealed type is 'Any'
+
 [case testInferredAttributeInGenericClassBodyWithTypevarValues]
 from typing import TypeVar, Generic
 X = TypeVar('X', int, str)
@@ -402,6 +448,19 @@ c(g(1))
 [out]
 main:6: error: Argument 1 to "c" has incompatible type "str"; expected "ss"
 main:7: error: Argument 1 to "c" has incompatible type "int"; expected "ss"
+
+[case testDefineAttributeInGenericMethodUsingTypeVarWithValues]
+from typing import TypeVar
+T = TypeVar('T', int, str)
+class A:
+    def f(self, x: T) -> None:
+        self.x = x # E: Need type annotation for variable
+        self.y = [x] # E: Need type annotation for variable
+        self.z = 1
+reveal_type(A().x)  # E: Revealed type is 'Any'
+reveal_type(A().y)  # E: Revealed type is 'Any'
+reveal_type(A().z)  # E: Revealed type is 'builtins.int'
+[builtins fixtures/list.pyi]
 
 
 -- Special cases


### PR DESCRIPTION
Require a type annotation if the inferred attribute type includes a
type variable with values.

Fix #2697 by giving a better error message. Fixing type inference
would be much more complicated. This partial fix should be fine as the
issue seems to arise pretty rarely.

Mypy processes methods of a generic class that has a type variable
with values by type checking the methods multiple times, once for each
type variable value. This implementation detects if different type
checking passes infer a different type for an attribute.

The extra data structure for storing inferred attibute types helps
with with fine-grained incremental checking.
