### PR TITLE
Don't crash if isinstance() called with too few arguments

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -192,7 +192,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             typeddict_type = e.callee.node.typeddict_type.copy_modified(
                 fallback=Instance(e.callee.node, []))
             return self.check_typeddict_call(typeddict_type, e.arg_kinds, e.arg_names, e.args, e)
-        if isinstance(e.callee, NameExpr) and e.callee.name in ('isinstance', 'issubclass'):
+        if (isinstance(e.callee, NameExpr) and e.callee.name in ('isinstance', 'issubclass')
+                and len(e.args) == 2):
             for typ in mypy.checker.flatten(e.args[1]):
                 if isinstance(typ, NameExpr):
                     try:

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1757,3 +1757,24 @@ if isinstance(x, (set, (list, T))):
     reveal_type(x)  # E: Revealed type is 'Union[builtins.set[Any], builtins.list[Any], builtins.int, builtins.str]'
 
 [builtins fixtures/isinstancelist.pyi]
+
+[case testIsInstanceTooFewArgs]
+isinstance() # E: Too few arguments for "isinstance"
+x: object
+if isinstance(): # E: Too few arguments for "isinstance"
+    x = 1
+    reveal_type(x) # E: Revealed type is 'builtins.int'
+if isinstance(x): # E: Too few arguments for "isinstance"
+    x = 1
+    reveal_type(x) # E: Revealed type is 'builtins.int'
+[builtins fixtures/isinstancelist.pyi]
+
+[case testIsInstanceTooManyArgs]
+isinstance(1, 1, 1) # E: Too many arguments for "isinstance" \
+         # E: Argument 2 to "isinstance" has incompatible type "int"; expected "Union[type, tuple]"
+x: object
+if isinstance(x, str, 1): # E: Too many arguments for "isinstance"
+    reveal_type(x) # E: Revealed type is 'builtins.object'
+    x = 1
+    reveal_type(x) # E: Revealed type is 'builtins.int'
+[builtins fixtures/isinstancelist.pyi]


### PR DESCRIPTION
Fix #3650.