### PR TITLE
Reject isinstance() with TypedDict and NewType

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -88,6 +88,8 @@ MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'
 NON_BOOLEAN_IN_CONDITIONAL = 'Condition must be a boolean'
 DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'
 GENERIC_INSTANCE_VAR_CLASS_ACCESS = 'Access to generic instance variables via class is ambiguous'
+CANNOT_ISINSTANCE_TYPEDDICT = 'Cannot use isinstance() with a TypedDict type'
+CANNOT_ISINSTANCE_NEWTYPE = 'Cannot use isinstance() with a NewType type'
 
 ARG_CONSTRUCTOR_NAMES = {
     ARG_POS: "Arg",

--- a/mypy/test/testextensions.py
+++ b/mypy/test/testextensions.py
@@ -84,11 +84,11 @@ class TypedDictTests(BaseTestCase):
         self.assertEqual(TypedDict.__module__, 'mypy_extensions')
         jim = Emp(name='Jim', id=1)
         with self.assertRaises(TypeError):
-            isinstance({}, Emp)
+            isinstance({}, Emp)  # type: ignore
         with self.assertRaises(TypeError):
-            isinstance(jim, Emp)
+            isinstance(jim, Emp)  # type: ignore
         with self.assertRaises(TypeError):
-            issubclass(dict, Emp)
+            issubclass(dict, Emp)  # type: ignore
         with self.assertRaises(TypeError):
             TypedDict('Hi', x=1)
         with self.assertRaises(TypeError):

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -336,3 +336,11 @@ class C(B): pass  # E: Cannot subclass NewType
 from typing import NewType
 Any = NewType('Any', int)
 Any(5)
+
+[case testNewTypeAndIsInstance]
+from typing import NewType
+T = NewType('T', int)
+d: object
+if isinstance(d, T):  # E: Cannot use isinstance() with a NewType type
+    reveal_type(d) # E: Revealed type is '__main__.T'
+[builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -717,8 +717,14 @@ def set_coordinate(p: TaggedPoint, key: str, value: int) -> None:
 
 -- isinstance
 
--- TODO: Implement support for this case.
---[case testCannotIsInstanceTypedDictType]
+[case testTypedDictAndInstance]
+from mypy_extensions import TypedDict
+D = TypedDict('D', {'x': int})
+d: object
+if isinstance(d, D):  # E: Cannot use isinstance() with a TypedDict type
+    reveal_type(d) # E: Revealed type is '__main__.D'
+[builtins fixtures/isinstancelist.pyi]
+
 
 -- scoping
 [case testTypedDictInClassNamespace]

--- a/test-data/unit/fixtures/isinstancelist.pyi
+++ b/test-data/unit/fixtures/isinstancelist.pyi
@@ -8,6 +8,7 @@ class type:
 
 class tuple: pass
 class function: pass
+class ellipsis: pass
 
 def isinstance(x: object, t: Union[type, Tuple]) -> bool: pass
 def issubclass(x: object, t: Union[type, Tuple]) -> bool: pass


### PR DESCRIPTION
These can't be used with `isinstance()` at runtime.