### PR TITLE
Declare literal_hash as Optional[Key]

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -122,7 +122,7 @@ class ConditionalTypeBinder:
         if not expr.literal:
             return
         key = expr.literal_hash
-        assert key is not None
+        assert key is not None, 'Internal error: binder tried to put non-literal'
         if key not in self.declarations:
             assert isinstance(expr, BindableTypes)
             self.declarations[key] = get_declaration(expr)
@@ -133,7 +133,7 @@ class ConditionalTypeBinder:
         self.frames[-1].unreachable = True
 
     def get(self, expr: Expression) -> Optional[Type]:
-        assert expr.literal_hash is not None
+        assert expr.literal_hash is not None, 'Internal error: binder tried to get non-literal'
         return self._get(expr.literal_hash)
 
     def is_unreachable(self) -> bool:
@@ -143,7 +143,7 @@ class ConditionalTypeBinder:
 
     def cleanse(self, expr: Expression) -> None:
         """Remove all references to a Node from the binder."""
-        assert expr.literal_hash is not None
+        assert expr.literal_hash is not None, 'Internal error: binder tried cleanse non-literal'
         self._cleanse_key(expr.literal_hash)
 
     def _cleanse_key(self, key: Key) -> None:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -156,7 +156,7 @@ class Statement(Node):
 class Expression(Node):
     """An expression node."""
     literal = LITERAL_NO
-    literal_hash = None  # type: Key
+    literal_hash = None  # type: Optional[Key]
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         raise RuntimeError('Not implemented')


### PR DESCRIPTION
`literal_hash = None  # type: Key` is an actual initialization and the None value is accessed, so it should be declared that way. Strict-optional mode does not catch it since it looks like a declaration.

(Surfaced in #3071 [here](https://github.com/python/mypy/pull/3071#pullrequestreview-47924551))