### PR TITLE
Fix crash during deserialization of callable types

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -191,6 +191,9 @@ class TypeFixer(TypeVisitor[None]):
                 for val in v.values:
                     val.accept(self)
             v.upper_bound.accept(self)
+        for arg in ct.bound_args:
+            if arg:
+                arg.accept(self)
 
     def visit_overloaded(self, t: Overloaded) -> None:
         for ct in t.items():

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -124,6 +124,26 @@ def f(x: int,
 [builtins fixtures/dict.pyi]
 [out2]
 
+[case testSerializeCallableWithBoundTypeArguments]
+import a
+[file a.py]
+import b
+[file a.py.2]
+import b
+x = b.f
+[file b.py]
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+
+class C(Generic[T]):
+    def f(self, x: T) -> None: pass
+
+c: C[int]
+f = c.f
+[out]
+[out2]
+
 [case testSerializePositionalOnlyArgument]
 import a
 [file a.py]


### PR DESCRIPTION
The bound type arguments of callables were not fixed up properly.