### PR TITLE
Prohibit referring to class within its definition

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -357,7 +357,7 @@ class ASTConverter(ast3.NodeTransformer):  # type: ignore  # typeshed PR #931
                     arg_types = [a if a is not None else AnyType()
                                 for a in translated_args]
                 return_type = TypeConverter(
-                        self.errors, set(), line=n.lineno).visit(func_type_ast.returns)
+                    self.errors, set(), line=n.lineno).visit(func_type_ast.returns)
 
                 # add implicit self type
                 if self.in_class() and len(arg_types) < len(args):

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -280,7 +280,7 @@ class ASTConverter(ast27.NodeTransformer):
     #              arg? kwarg, expr* defaults)
     @with_line
     def visit_FunctionDef(self, n: ast27.FunctionDef) -> Statement:
-        converter = TypeConverter(self.errors, line=n.lineno)
+        converter = TypeConverter(self.errors, set(), line=n.lineno)
         args, decompose_stmts = self.transform_args(n.args, n.lineno)
 
         arg_kinds = [arg.kind for arg in args]
@@ -378,7 +378,7 @@ class ASTConverter(ast27.NodeTransformer):
         # TODO: remove the cast once https://github.com/python/typeshed/pull/522
         # is accepted and synced
         type_comments = cast(List[str], n.type_comments)  # type: ignore
-        converter = TypeConverter(self.errors, line=line)
+        converter = TypeConverter(self.errors, set(), line=line)
         decompose_stmts = []  # type: List[Statement]
 
         def extract_names(arg: ast27.expr) -> List[str]:

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -499,7 +499,7 @@ class XRepr(NamedTuple):
     y: int = 1
     def __str__(self) -> str:
         return 'string'
-    def __add__(self, other: XRepr) -> int:
+    def __add__(self, other: 'XRepr') -> int:
         return 0
 
 reveal_type(XMeth(1).double()) # E: Revealed type is 'builtins.int'

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1477,8 +1477,8 @@ from typing import Any
 def deco(f: Any) -> Any: return f
 class C:
     @deco
-    def __add__(self, other: C) -> C: return C()
-    def __radd__(self, other: C) -> C: return C()
+    def __add__(self, other: 'C') -> 'C': return C()
+    def __radd__(self, other: 'C') -> 'C': return C()
 [out]
 
 [case testReverseOperatorMethodForwardIsAny2]
@@ -1486,7 +1486,7 @@ from typing import Any
 def deco(f: Any) -> Any: return f
 class C:
     __add__ = None  # type: Any
-    def __radd__(self, other: C) -> C: return C()
+    def __radd__(self, other: 'C') -> 'C': return C()
 [out]
 
 [case testReverseOperatorMethodForwardIsAny3]
@@ -1494,7 +1494,7 @@ from typing import Any
 def deco(f: Any) -> Any: return f
 class C:
     __add__ = 42
-    def __radd__(self, other: C) -> C: return C()
+    def __radd__(self, other: 'C') -> 'C': return C()
 [out]
 main:5: error: Forward operator "__add__" is not callable
 
@@ -1631,7 +1631,7 @@ main:8: error: Signatures of "__iadd__" and "__add__" are incompatible
 
 a, b = None, None # type: A, B
 class A:
-    def __getattribute__(self, x: str) -> A:
+    def __getattribute__(self, x: str) -> 'A':
         return A()
 class B: pass
 
@@ -1642,11 +1642,11 @@ main:9: error: Incompatible types in assignment (expression has type "A", variab
 
 [case testGetAttributeSignature]
 class A:
-    def __getattribute__(self, x: str) -> A: pass
+    def __getattribute__(self, x: str) -> 'A': pass
 class B:
-    def __getattribute__(self, x: A) -> B: pass
+    def __getattribute__(self, x: A) -> 'B': pass
 class C:
-    def __getattribute__(self, x: str, y: str) -> C: pass
+    def __getattribute__(self, x: str, y: str) -> 'C': pass
 class D:
     def __getattribute__(self, x: str) -> None: pass
 [out]
@@ -1657,7 +1657,7 @@ main:6: error: Invalid signature "def (__main__.C, builtins.str, builtins.str) -
 
 a, b = None, None # type: A, B
 class A:
-    def __getattr__(self, x: str) -> A:
+    def __getattr__(self, x: str) -> 'A':
         return A()
 class B: pass
 
@@ -1668,11 +1668,11 @@ main:9: error: Incompatible types in assignment (expression has type "A", variab
 
 [case testGetAttrSignature]
 class A:
-    def __getattr__(self, x: str) -> A: pass
+    def __getattr__(self, x: str) -> 'A': pass
 class B:
-    def __getattr__(self, x: A) -> B: pass
+    def __getattr__(self, x: A) -> 'B': pass
 class C:
-    def __getattr__(self, x: str, y: str) -> C: pass
+    def __getattr__(self, x: str, y: str) -> 'C': pass
 class D:
     def __getattr__(self, x: str) -> None: pass
 [out]
@@ -1776,7 +1776,7 @@ a = a(b)  # E: Argument 1 to "__call__" of "A" has incompatible type "B"; expect
 b = a(a)  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 class A:
-    def __call__(self, x: A) -> A:
+    def __call__(self, x: 'A') -> 'A':
         pass
 class B: pass
 
@@ -3280,7 +3280,7 @@ def r(ta: Type[TA], tta: TTA) -> None:
 
 class Class(metaclass=M):
     @classmethod
-    def f1(cls: Type[Class]) -> None: pass
+    def f1(cls: Type['Class']) -> None: pass
     @classmethod
     def f2(cls: M) -> None: pass
 cl: Type[Class] = m  # E: Incompatible types in assignment (expression has type "M", variable has type Type[Class])

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -181,7 +181,7 @@ class A:
         pass
 
 class C(A):
-    def copy(self: C) -> C:
+    def copy(self: 'C') -> 'C':
         pass
 
 class D(A):
@@ -276,10 +276,10 @@ class B:
         return cls()
 
 class C:
-    def foo(self: C) -> C: return self
+    def foo(self: 'C') -> 'C': return self
 
     @classmethod
-    def cfoo(cls: Type[C]) -> C:
+    def cfoo(cls: Type['C']) -> 'C':
         return cls()
 
 class D:
@@ -330,21 +330,21 @@ class B:
         pass
 
 class C:
-    def __new__(cls: Type[C]) -> C:
+    def __new__(cls: Type['C']) -> 'C':
         return cls()
 
-    def __init_subclass__(cls: Type[C]) -> None:
+    def __init_subclass__(cls: Type['C']) -> None:
         pass
 
 class D:
-    def __new__(cls: D) -> D:  # E: The erased type of self '__main__.D' is not a supertype of its class 'Type[__main__.D]'
+    def __new__(cls: 'D') -> 'D':  # E: The erased type of self '__main__.D' is not a supertype of its class 'Type[__main__.D]'
         return cls
 
-    def __init_subclass__(cls: D) -> None:  # E: The erased type of self '__main__.D' is not a supertype of its class 'Type[__main__.D]'
+    def __init_subclass__(cls: 'D') -> None:  # E: The erased type of self '__main__.D' is not a supertype of its class 'Type[__main__.D]'
         pass
 
 class E:
-    def __new__(cls) -> E:
+    def __new__(cls) -> 'E':
         reveal_type(cls)  # E: Revealed type is 'def () -> __main__.E'
         return cls()
 

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -357,7 +357,7 @@ class A(object):
         self.a = 0
 
     def __iadd__(self, a):
-        # type: (int) -> A
+        # type: (int) -> 'A'
         self.a += 1
         return self
 

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -47,9 +47,9 @@ f(S())
 [case testCheckGenericFunctionBodyWithTypeVarValues]
 from typing import TypeVar
 class A:
-    def f(self, x: int) -> A: return self
+    def f(self, x: int) -> 'A': return self
 class B:
-    def f(self, x: int) -> B: return self
+    def f(self, x: int) -> 'B': return self
 AB = TypeVar('AB', A, B)
 def f(x: AB) -> AB:
     x = x.f(1)
@@ -58,11 +58,11 @@ def f(x: AB) -> AB:
 [case testCheckGenericFunctionBodyWithTypeVarValues2]
 from typing import TypeVar
 class A:
-    def f(self) -> A: return A()
-    def g(self) -> B: return B()
+    def f(self) -> 'A': return A()
+    def g(self) -> 'B': return B()
 class B:
     def f(self) -> A: return A()
-    def g(self) -> B: return B()
+    def g(self) -> 'B': return B()
 AB = TypeVar('AB', A, B)
 def f(x: AB) -> AB:
     return x.f() # Error
@@ -75,11 +75,11 @@ main:12: error: Incompatible return value type (got "B", expected "A")
 [case testTypeInferenceAndTypeVarValues]
 from typing import TypeVar
 class A:
-    def f(self) -> A: return self
-    def g(self) -> B: return B()
+    def f(self) -> 'A': return self
+    def g(self) -> 'B': return B()
 class B:
-    def f(self) -> B: return self
-    def g(self) -> B: return B()
+    def f(self) -> 'B': return self
+    def g(self) -> 'B': return B()
 AB = TypeVar('AB', A, B)
 def f(x: AB) -> AB:
     y = x

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -52,7 +52,7 @@ class A:
     def g(self) -> None: pass
 [file m.py.2]
 class A:
-    def g(self, a: A) -> None: pass
+    def g(self, a: 'A') -> None: pass
 [out]
 ==
 main:4: error: Too few arguments for "g" of "A"

--- a/test-data/unit/merge.test
+++ b/test-data/unit/merge.test
@@ -442,12 +442,12 @@ NameExpr:6: target.A<0>
 import target
 [file target.py]
 class A:
-    def f(self) -> A:
+    def f(self) -> 'A':
         return self.f()
 [file target.py.next]
 class A:
     # Extra line to change line numbers
-    def f(self) -> A:
+    def f(self) -> 'A':
         return self.f()
 [out]
 ## target

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1401,3 +1401,40 @@ class A: ... # E: Name 'A' already defined on line 2
 
 [builtins fixtures/list.pyi]
 [out]
+
+[case testReferringToClassInDefinition]
+class A:
+    def foo(self) -> A:  # E: class 'A' is not fully defined; use a forward reference
+        pass
+
+[out]
+
+[case testReferringToClassInClassVar]
+class A:
+    x: A  # E: class 'A' is not fully defined; use a forward reference
+
+[out]
+
+[case testReferringToClassInNestedStructures]
+class A:
+    class B:
+        def foo(self, arg: A) -> int:  # E: class 'A' is not fully defined; use a forward reference
+            return 3
+
+        def bar(self, arg: B) -> int:   # E: class 'B' is not fully defined; use a forward reference
+            return 4
+
+    def baz(self) -> int:
+        x: A
+
+        class C:
+            def qux(self, arg: A) -> int:
+                return 3
+
+            def qix(self, arg: C) -> int:  # E: class 'C' is not fully defined; use a forward reference
+                return 3
+
+        return 3
+
+[out]
+

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -108,7 +108,7 @@ a = 1 + 2
 1.2 * 3
 2.2 - 3
 1 / 2
-[file builtins.py]
+[file builtins.pyi]
 class object:
     def __init__(self) -> None: pass
 class function: pass
@@ -135,7 +135,7 @@ import typing
 1 < 2 < 3
 8 > 3
 4 < 6 > 2
-[file builtins.py]
+[file builtins.pyi]
 class object:
     def __init__(self) -> None: pass
 class int:


### PR DESCRIPTION
This partially, but not completely, addresses https://github.com/python/mypy/issues/3088

Previously, code of the following form was accepted without an error by mypy:

    class A:
        def foo(self) -> A:
            ...

However, this results in an error at runtime because 'A' is not yet defined. This pull request modifies the parsing process to report an error when a type is being incorrectly used within its class definition.

However, this commit does *not* attempt to handle other cases where the user is using a type that is undefined at runtime. For example, mypy will continue to accept the following code without an error:

    def f() -> A:
        ...

    class A:
        ...

I decided it would probably be best to address this in a future pull request.