### PR TITLE
Do not report higher-kinded types as Anys with --disallow-any=expr

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2405,11 +2405,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return e.type
 
     def visit_type_var_expr(self, e: TypeVarExpr) -> Type:
-        # TODO: Perhaps return a special type used for type variables only?
-        return AnyType()
+        return AnyType(is_higher_kinded_type=True)
 
     def visit_newtype_expr(self, e: NewTypeExpr) -> Type:
-        return AnyType()
+        return AnyType(is_higher_kinded_type=True)
 
     def visit_namedtuple_expr(self, e: NamedTupleExpr) -> Type:
         tuple_type = e.info.tuple_type
@@ -2419,8 +2418,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 self.msg.unimported_type_becomes_any("NamedTuple type", tuple_type, e)
             check_for_explicit_any(tuple_type, self.chk.options, self.chk.is_typeshed_stub,
                                    self.msg, context=e)
-        # TODO: Perhaps return a type object type?
-        return AnyType()
+        return AnyType(is_higher_kinded_type=True)
 
     def visit_enum_call_expr(self, e: EnumCallExpr) -> Type:
         for name, value in zip(e.items, e.values):
@@ -2435,12 +2433,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                         # to have type Any in the typeshed stub.)
                         var.type = typ
                         var.is_inferred = True
-        # TODO: Perhaps return a type object type?
-        return AnyType()
+        return AnyType(is_higher_kinded_type=True)
 
     def visit_typeddict_expr(self, e: TypedDictExpr) -> Type:
-        # TODO: Perhaps return a type object type?
-        return AnyType()
+        return AnyType(is_higher_kinded_type=True)
 
     def visit__promote_expr(self, e: PromoteExpr) -> Type:
         return e.type
@@ -2475,7 +2471,7 @@ class HasAnyType(types.TypeQuery[bool]):
         super().__init__(any)
 
     def visit_any(self, t: AnyType) -> bool:
-        return True
+        return not t.is_higher_kinded_type  # higher kinded types are not real any types
 
 
 def has_coroutine_decorator(t: Type) -> bool:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2405,10 +2405,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return e.type
 
     def visit_type_var_expr(self, e: TypeVarExpr) -> Type:
-        return AnyType(is_higher_kinded_type=True)
+        return AnyType(special_form=True)
 
     def visit_newtype_expr(self, e: NewTypeExpr) -> Type:
-        return AnyType(is_higher_kinded_type=True)
+        return AnyType(special_form=True)
 
     def visit_namedtuple_expr(self, e: NamedTupleExpr) -> Type:
         tuple_type = e.info.tuple_type
@@ -2418,7 +2418,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 self.msg.unimported_type_becomes_any("NamedTuple type", tuple_type, e)
             check_for_explicit_any(tuple_type, self.chk.options, self.chk.is_typeshed_stub,
                                    self.msg, context=e)
-        return AnyType(is_higher_kinded_type=True)
+        return AnyType(special_form=True)
 
     def visit_enum_call_expr(self, e: EnumCallExpr) -> Type:
         for name, value in zip(e.items, e.values):
@@ -2433,10 +2433,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                         # to have type Any in the typeshed stub.)
                         var.type = typ
                         var.is_inferred = True
-        return AnyType(is_higher_kinded_type=True)
+        return AnyType(special_form=True)
 
     def visit_typeddict_expr(self, e: TypedDictExpr) -> Type:
-        return AnyType(is_higher_kinded_type=True)
+        return AnyType(special_form=True)
 
     def visit__promote_expr(self, e: PromoteExpr) -> Type:
         return e.type
@@ -2471,7 +2471,7 @@ class HasAnyType(types.TypeQuery[bool]):
         super().__init__(any)
 
     def visit_any(self, t: AnyType) -> bool:
-        return not t.is_higher_kinded_type  # higher kinded types are not real any types
+        return not t.special_form  # special forms are not real Any types
 
 
 def has_coroutine_decorator(t: Type) -> bool:

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -178,7 +178,7 @@ class StatisticsVisitor(TraverserVisitor):
             return
 
         if isinstance(t, AnyType) and t.is_higher_kinded_type:
-            # Don't collect stats higher-kinded types.
+            # Don't collect stats for higher-kinded types.
             return
 
         if isinstance(t, AnyType):

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -177,8 +177,8 @@ class StatisticsVisitor(TraverserVisitor):
             self.record_line(self.line, TYPE_UNANALYZED)
             return
 
-        if isinstance(t, AnyType) and t.is_higher_kinded_type:
-            # Don't collect stats for higher-kinded types.
+        if isinstance(t, AnyType) and t.special_form:
+            # This is not a real Any type, so don't collect stats for it.
             return
 
         if isinstance(t, AnyType):

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -177,6 +177,10 @@ class StatisticsVisitor(TraverserVisitor):
             self.record_line(self.line, TYPE_UNANALYZED)
             return
 
+        if isinstance(t, AnyType) and t.is_higher_kinded_type:
+            # Don't collect stats higher-kinded types.
+            return
+
         if isinstance(t, AnyType):
             self.log('  !! Any type around line %d' % self.line)
             self.num_any += 1

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -258,7 +258,7 @@ class AnyType(Type):
                  from_unimported_type: bool = False,
                  explicit: bool = False,
                  from_omitted_generics: bool = False,
-                 is_higher_kinded_type: bool = False,
+                 special_form: bool = False,
                  line: int = -1,
                  column: int = -1) -> None:
         super().__init__(line, column)
@@ -273,10 +273,9 @@ class AnyType(Type):
         self.explicit = explicit
         # Does this type come from omitted generics?
         self.from_omitted_generics = from_omitted_generics
-        # Is this type a higher-kinded type (e.g. type of call expr to NewType or NamedTuple)?
-        # We can't fully represent higher-kinded types in mypy's type system, so we treat them
-        # as 'Any' and give specific errors for each higher-kinded type (e.g. NewType).
-        self.is_higher_kinded_type = is_higher_kinded_type
+        # Is this a type that can't be represented in mypy's type system? For instance, type of
+        # call to NewType(...)). Even though these types aren't real Anys, we treat them as such.
+        self.special_form = special_form
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_any(self)
@@ -286,7 +285,7 @@ class AnyType(Type):
                       from_unimported_type: bool = _dummy,
                       explicit: bool = _dummy,
                       from_omitted_generics: bool = _dummy,
-                      is_higher_kinded_type: bool = _dummy,
+                      special_form: bool = _dummy,
                       ) -> 'AnyType':
         if implicit is _dummy:
             implicit = self.implicit
@@ -296,11 +295,11 @@ class AnyType(Type):
             explicit = self.explicit
         if from_omitted_generics is _dummy:
             from_omitted_generics = self.from_omitted_generics
-        if is_higher_kinded_type is _dummy:
-            is_higher_kinded_type = self.is_higher_kinded_type
+        if special_form is _dummy:
+            special_form = self.special_form
         return AnyType(implicit=implicit, from_unimported_type=from_unimported_type,
                        explicit=explicit, from_omitted_generics=from_omitted_generics,
-                       is_higher_kinded_type=is_higher_kinded_type,
+                       special_form=special_form,
                        line=self.line, column=self.column)
 
     def serialize(self) -> JsonDict:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -258,6 +258,7 @@ class AnyType(Type):
                  from_unimported_type: bool = False,
                  explicit: bool = False,
                  from_omitted_generics: bool = False,
+                 is_higher_kinded_type: bool = False,
                  line: int = -1,
                  column: int = -1) -> None:
         super().__init__(line, column)
@@ -272,6 +273,10 @@ class AnyType(Type):
         self.explicit = explicit
         # Does this type come from omitted generics?
         self.from_omitted_generics = from_omitted_generics
+        # Is this type a higher-kinded type (e.g. type of call expr to NewType or NamedTuple)?
+        # We can't fully represent higher-kinded types in mypy's type system, so we treat them
+        # as 'Any' and give specific errors for each higher-kinded type (e.g. NewType).
+        self.is_higher_kinded_type = is_higher_kinded_type
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_any(self)
@@ -281,6 +286,7 @@ class AnyType(Type):
                       from_unimported_type: bool = _dummy,
                       explicit: bool = _dummy,
                       from_omitted_generics: bool = _dummy,
+                      is_higher_kinded_type: bool = _dummy,
                       ) -> 'AnyType':
         if implicit is _dummy:
             implicit = self.implicit
@@ -290,8 +296,11 @@ class AnyType(Type):
             explicit = self.explicit
         if from_omitted_generics is _dummy:
             from_omitted_generics = self.from_omitted_generics
+        if is_higher_kinded_type is _dummy:
+            is_higher_kinded_type = self.is_higher_kinded_type
         return AnyType(implicit=implicit, from_unimported_type=from_unimported_type,
                        explicit=explicit, from_omitted_generics=from_omitted_generics,
+                       is_higher_kinded_type=is_higher_kinded_type,
                        line=self.line, column=self.column)
 
     def serialize(self) -> JsonDict:

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -832,3 +832,51 @@ l: List = []
 l.append(1)  # E: Expression type contains "Any" (has type List[Any])
 k = l[0]  # E: Expression type contains "Any" (has type List[Any])  # E: Expression has type "Any"
 [builtins fixtures/list.pyi]
+
+[case testDisallowAnyExprTypeVar]
+# flags: --disallow-any=expr
+from typing import TypeVar
+
+T = TypeVar('T')  # no error
+
+def f(t: T) -> T:
+    return t
+[builtins fixtures/list.pyi]
+
+[case testDisallowAnyExprNamedTuple]
+# flags: --disallow-any=expr
+from typing import NamedTuple
+
+Point = NamedTuple('Point', [('x', int), ('y', int)])  # no error
+
+def origin() -> Point:
+    return Point(x=0, y=0)
+[builtins fixtures/list.pyi]
+
+[case testDisallowAnyExprNewType]
+# flags: --disallow-any=expr
+from typing import NewType
+
+NT = NewType('NT', int)  # no error
+
+def nt() -> NT:
+    return NT(1)
+[builtins fixtures/list.pyi]
+
+[case testDisallowAnyExprEnum]
+# flags: --disallow-any=expr
+from enum import Enum
+E = Enum('E', '1, 2, 3')  # no error
+
+def k(s: E) -> None: pass
+[builtins fixtures/list.pyi]
+
+[case testDisallowAnyExprTypedDict]
+# flags: --disallow-any=expr
+from mypy_extensions import TypedDict
+
+Movie = TypedDict('Movie', {'name': str, 'year': int})
+
+def g(m: Movie) -> Movie:
+    return m
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -233,3 +233,44 @@ i        1     7      85.71%
 j        0     6     100.00%
 ------------------------------
 Total    1    13      92.31%
+
+[case testAnyExprReportHigherKindedTypesAreNotAny]
+# cmd: mypy --any-exprs-report report i.py
+
+[file i.py]
+from enum import Enum
+from mypy_extensions import TypedDict
+from typing import NewType, NamedTuple, TypeVar
+
+from typing import TypeVar
+
+T = TypeVar('T')  # no error
+
+def f(t: T) -> T:
+    return t
+
+Point = NamedTuple('Point', [('x', int), ('y', int)])  # no error
+
+def origin() -> Point:
+    return Point(x=0, y=0)
+
+NT = NewType('NT', int)  # no error
+
+def nt() -> NT:
+    return NT(1)
+
+E = Enum('E', '1, 2, 3')  # no error
+
+def k(s: E) -> None: pass
+
+Movie = TypedDict('Movie', {'name': str, 'year': int})
+
+def g(m: Movie) -> Movie:
+    return m
+
+[outfile report/any-exprs.txt]
+Name  Anys Exprs    Coverage
+------------------------------
+i        0    16     100.00%
+------------------------------
+Total    0    16     100.00%


### PR DESCRIPTION
Do not report higher-kinded types as Anys with --disallow-any=expr as well as in `--any-exprs-report` and `--html-report`

We can't fully represent higher-kinded types (e.g. calls to NewType) in mypy's type system,
so we treat them as 'Any' and give specific errors for each higher-kinded type (e.g. NewType).

Another design I considered is either returning object type or having a new HigherKindedType type.
The problem with that approach is that because now a call to NewType() does not have type 'Any'
if something is wrong with the call, it reports redundant errors.
Consider the following situation:
```
C = NewType('C', int)
C = NewType('C', str)
```

If `NewType(...)` has type object, in addition to all the expected errors,
it will also report `Incompatible types in assignment` error.