### PR TITLE
Use OrderedDict for raw per-module options to preserve section order

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -124,7 +124,7 @@ overridden by the pattern sections matching the module name.
 .. note::
 
    If multiple pattern sections match a module they are processed in
-   unspecified order.
+   order of their occurrence in the config file.
 
 - ``follow_imports`` (string, default ``normal``) directs what to do
   with imports when the imported module is found as a ``.py`` file and

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -120,7 +120,8 @@ class Options:
         self.plugins = []  # type: List[str]
 
         # Per-module options (raw)
-        self.per_module_options = OrderedDict()  # type: OrderedDict[Pattern[str], Dict[str, object]]
+        pm_opts = OrderedDict()  # type: OrderedDict[Pattern[str], Dict[str, object]]
+        self.per_module_options = pm_opts
 
         # -- development options --
         self.verbosity = 0  # More verbose messages (for troubleshooting)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -1,4 +1,4 @@
-import collections
+from collections import OrderedDict
 import fnmatch
 import pprint
 import sys
@@ -120,7 +120,7 @@ class Options:
         self.plugins = []  # type: List[str]
 
         # Per-module options (raw)
-        self.per_module_options = collections.OrderedDict()  # type: MutableMapping[Pattern[str], Dict[str, object]]
+        self.per_module_options = OrderedDict()  # type: OrderedDict[Pattern[str], Dict[str, object]]
 
         # -- development options --
         self.verbosity = 0  # More verbose messages (for troubleshooting)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -1,8 +1,9 @@
+import collections
 import fnmatch
 import pprint
 import sys
 
-from typing import Mapping, Optional, Tuple, List, Pattern, Dict
+from typing import Mapping, MutableMapping, Optional, Tuple, List, Pattern, Dict
 
 from mypy import defaults
 
@@ -119,7 +120,7 @@ class Options:
         self.plugins = []  # type: List[str]
 
         # Per-module options (raw)
-        self.per_module_options = {}  # type: Dict[Pattern[str], Dict[str, object]]
+        self.per_module_options = collections.OrderedDict()  # type: MutableMapping[Pattern[str], Dict[str, object]]
 
         # -- development options --
         self.verbosity = 0  # More verbose messages (for troubleshooting)

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1031,3 +1031,26 @@ m.py:4: error: Missing type parameters for generic type
 m.py:5: error: Missing type parameters for generic type
 m.py:6: error: Missing type parameters for generic type
 m.py:7: error: Missing type parameters for generic type
+
+[case testDeterministicSectionOrdering]
+# cmd: mypy a
+[file a/__init__.py]
+[file a/b/__init__.py]
+[file a/b/c/__init__.py]
+[file a/b/c/d/__init__.py]
+[file a/b/c/d/e/__init__.py]
+0()
+[file mypy.ini]
+[[mypy]
+[[mypy-a.*]
+ignore_errors = True
+[[mypy-a.b.*]
+ignore_errors = True
+[[mypy-a.b.c.*]
+ignore_errors = True
+[[mypy-a.b.c.d.*]
+ignore_errors = True
+[[mypy-a.b.c.d.e]
+ignore_errors = False
+[out]
+a/b/c/d/e/__init__.py:1: error: "int" not callable


### PR DESCRIPTION
Fixes #3675.

Note that the problem only occurs on Python 3.5 and earlier, since in Python 3.6 the standard `dict` type preserves order. Also note that this relies on `ConfigParser` preserving order -- which it does (it uses `OrderedDict` for everything by default).