### PR TITLE
Fix per-file strict Optional interaction with default-None args

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -392,7 +392,7 @@ class ASTConverter(ast3.NodeTransformer):  # type: ignore  # typeshed PR #931
             return func_def
 
     def set_type_optional(self, type: Type, initializer: Expression) -> None:
-        if self.options.no_implicit_optional or not experiments.STRICT_OPTIONAL:
+        if self.options.no_implicit_optional:
             return
         # Indicate that type should be wrapped in an Optional if arg is initialized to None.
         optional = isinstance(initializer, NameExpr) and initializer.name == 'None'

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -366,7 +366,7 @@ class ASTConverter(ast27.NodeTransformer):
             return func_def
 
     def set_type_optional(self, type: Type, initializer: Expression) -> None:
-        if self.options.no_implicit_optional or not experiments.STRICT_OPTIONAL:
+        if self.options.no_implicit_optional:
             return
         # Indicate that type should be wrapped in an Optional if arg is initialized to None.
         optional = isinstance(initializer, NameExpr) and initializer.name == 'None'

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -124,9 +124,9 @@ def f(a,        # type: A
       **kwargs  # type: F
       ):
     reveal_type(a)      # E: Revealed type is '__main__.A'
-    reveal_type(b)      # E: Revealed type is '__main__.B'
+    reveal_type(b)      # E: Revealed type is 'Union[__main__.B, builtins.None]'
     reveal_type(args)   # E: Revealed type is 'builtins.tuple[__main__.C]'
-    reveal_type(d)      # E: Revealed type is '__main__.D'
+    reveal_type(d)      # E: Revealed type is 'Union[__main__.D, builtins.None]'
     reveal_type(e)      # E: Revealed type is '__main__.E'
     reveal_type(kwargs) # E: Revealed type is 'builtins.dict[builtins.str, __main__.F]'
 [builtins fixtures/dict.pyi]
@@ -149,9 +149,9 @@ def f(a,        # type: A
       ):
       # type: (...) -> int
     reveal_type(a)      # E: Revealed type is '__main__.A'
-    reveal_type(b)      # E: Revealed type is '__main__.B'
+    reveal_type(b)      # E: Revealed type is 'Union[__main__.B, builtins.None]'
     reveal_type(args)   # E: Revealed type is 'builtins.tuple[__main__.C]'
-    reveal_type(d)      # E: Revealed type is '__main__.D'
+    reveal_type(d)      # E: Revealed type is 'Union[__main__.D, builtins.None]'
     reveal_type(e)      # E: Revealed type is '__main__.E'
     reveal_type(kwargs) # E: Revealed type is 'builtins.dict[builtins.str, __main__.F]'
     return "not an int"  # E: Incompatible return value type (got "str", expected "int")
@@ -191,7 +191,7 @@ def f(a,        # type: A
       # kwargs not tested due to lack of 2.7 dict fixtures
       ):
     reveal_type(a)      # E: Revealed type is '__main__.A'
-    reveal_type(b)      # E: Revealed type is '__main__.B'
+    reveal_type(b)      # E: Revealed type is 'Union[__main__.B, builtins.None]'
     reveal_type(args)   # E: Revealed type is 'builtins.tuple[__main__.C]'
 [builtins fixtures/dict.pyi]
 [out]
@@ -209,7 +209,7 @@ def f(a,        # type: A
       ):
       # type: (...) -> int
     reveal_type(a)      # E: Revealed type is '__main__.A'
-    reveal_type(b)      # E: Revealed type is '__main__.B'
+    reveal_type(b)      # E: Revealed type is 'Union[__main__.B, builtins.None]'
     reveal_type(args)   # E: Revealed type is 'builtins.tuple[__main__.C]'
     return "not an int"  # E: Incompatible return value type (got "str", expected "int")
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -488,6 +488,7 @@ import standard, optional
 
 [file standard.py]
 def f(x: int = None) -> None: pass
+
 [file optional.py]
 import standard
 def f(x: int = None) -> None: pass
@@ -498,8 +499,6 @@ standard.f(None)
 strict_optional = False
 [[mypy-optional]
 strict_optional = True
-
-
 
 [case testDisallowImplicitTypesIgnoreMissingTypes]
 # flags: --ignore-missing-imports --disallow-any=unimported

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -489,7 +489,9 @@ import standard, optional
 [file standard.py]
 def f(x: int = None) -> None: pass
 [file optional.py]
+import standard
 def f(x: int = None) -> None: pass
+standard.f(None)
 
 [file mypy.ini]
 [[mypy]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -482,6 +482,23 @@ def f() -> None:
     x = [] # type: Union[List[Optional[str]], str]
 [builtins fixtures/list.pyi]
 
+[case testPerFileStrictOptionalNoneArguments]
+# flags: --config-file tmp/mypy.ini
+import standard, optional
+
+[file standard.py]
+def f(x: int = None) -> None: pass
+[file optional.py]
+def f(x: int = None) -> None: pass
+
+[file mypy.ini]
+[[mypy]
+strict_optional = False
+[[mypy-optional]
+strict_optional = True
+
+
+
 [case testDisallowImplicitTypesIgnoreMissingTypes]
 # flags: --ignore-missing-imports --disallow-any=unimported
 from missing import MyType

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -363,7 +363,7 @@ y = x  # E: Incompatible types in assignment (expression has type Callable[..., 
 
 a, b = None, None # type: (A, B)
 a = f()     # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-b = f(b)    # E: Argument 1 to "f" has incompatible type "B"; expected "A"
+b = f(b)    # E: Argument 1 to "f" has incompatible type "B"; expected "Optional[A]"
 b = f(a, a) # E: Too many arguments for "f"
 
 b = f()

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -30,10 +30,10 @@ f(a=A())
 f(b=B())
 f(c=C())
 f(b=B(), c=C())
-f(a=B()) # E: Argument 1 to "f" has incompatible type "B"; expected "A"
-f(b=A()) # E: Argument 1 to "f" has incompatible type "A"; expected "B"
-f(c=B()) # E: Argument 1 to "f" has incompatible type "B"; expected "C"
-f(b=B(), c=A()) # E: Argument 2 to "f" has incompatible type "A"; expected "C"
+f(a=B()) # E: Argument 1 to "f" has incompatible type "B"; expected "Optional[A]"
+f(b=A()) # E: Argument 1 to "f" has incompatible type "A"; expected "Optional[B]"
+f(c=B()) # E: Argument 1 to "f" has incompatible type "B"; expected "Optional[C]"
+f(b=B(), c=A()) # E: Argument 2 to "f" has incompatible type "A"; expected "Optional[C]"
 class A: pass
 class B: pass
 class C: pass
@@ -182,7 +182,7 @@ f(A(), b=B())
 f(A(), A(), b=B())
 f(B())      # E: Argument 1 to "f" has incompatible type "B"; expected "A"
 f(A(), B()) # E: Argument 2 to "f" has incompatible type "B"; expected "A"
-f(b=A())    # E: Argument 1 to "f" has incompatible type "A"; expected "B"
+f(b=A())    # E: Argument 1 to "f" has incompatible type "A"; expected "Optional[B]"
 class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
@@ -197,8 +197,8 @@ f(b=B())
 f(*a, b=B())
 f(A(), *a, b=B())
 f(A(), B())   # E: Argument 2 to "f" has incompatible type "B"; expected "A"
-f(A(), b=A()) # E: Argument 2 to "f" has incompatible type "A"; expected "B"
-f(*a, b=A())  # E: Argument 2 to "f" has incompatible type "A"; expected "B"
+f(A(), b=A()) # E: Argument 2 to "f" has incompatible type "A"; expected "Optional[B]"
+f(*a, b=A())  # E: Argument 2 to "f" has incompatible type "A"; expected "Optional[B]"
 class A: pass
 class B: pass
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -86,7 +86,7 @@ a = None # type: A
 b = None # type: B
 c = None # type: C
 
-f(a)           # E: Argument 1 to "f" has incompatible type "A"; expected "C"
+f(a)           # E: Argument 1 to "f" has incompatible type "A"; expected "Optional[C]"
 f(c, c)        # E: Argument 2 to "f" has incompatible type "C"; expected "A"
 f(c, a, b, c)  # E: Argument 4 to "f" has incompatible type "C"; expected "A"
 f()
@@ -377,9 +377,10 @@ class B: pass
 [builtins fixtures/list.pyi]
 [out]
 main:3: error: Too few arguments for "f"
+main:4: error: Argument 2 to "f" has incompatible type *List[A]; expected "Optional[B]"
 main:4: error: Argument 2 to "f" has incompatible type *List[A]; expected "B"
 main:5: error: Argument 3 to "f" has incompatible type *List[A]; expected "B"
-main:6: error: Argument 1 to "f" has incompatible type *"Tuple[A, A, B]"; expected "B"
+main:6: error: Argument 1 to "f" has incompatible type *"Tuple[A, A, B]"; expected "Optional[B]"
 
 [case testVarArgsAfterKeywordArgInCall1-skip]
 # see: mypy issue #2729


### PR DESCRIPTION
With per-file strict Optional, default-None args should always be interpreted as Optional (except with `--no-implicit-optional`), instead of only in strict Optional files.