### PR TITLE
Make Travis badge show build status on master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Mypy: Optional Static Typing for Python
 =======================================
 
-[![Build Status](https://travis-ci.org/python/mypy.svg)](https://travis-ci.org/python/mypy)
+[![Build Status](https://api.travis-ci.org/python/mypy.svg?branch=master)](https://travis-ci.org/python/mypy)
 [![Chat at https://gitter.im/python/typing](https://badges.gitter.im/python/typing.svg)](https://gitter.im/python/typing?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 


### PR DESCRIPTION
Currently, the Travis badge shows the status of the latest build, regardless of the branch.

For instance, if someone is working on a feature and has broken some tests, the badge in the README on master branch will be `red`.