### PR TITLE
move typeshed to external package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "typeshed"]
-	path = typeshed
-	url = http://github.com/python/typeshed

--- a/README.md
+++ b/README.md
@@ -172,16 +172,7 @@ Quick start for contributing to mypy
 
 If you want to contribute, first clone the mypy git repository:
 
-    $ git clone --recurse-submodules https://github.com/python/mypy.git
-
-If you've already cloned the repo without `--recurse-submodules`,
-you need to pull in the typeshed repo as follows:
-
-    $ git submodule init
-    $ git submodule update
-
-Either way you should now have a subdirectory `typeshed` containing a
-clone of the typeshed repo (`https://github.com/python/typeshed`).
+    $ git clone https://github.com/python/mypy.git
 
 From the mypy directory, use pip to install mypy:
 
@@ -195,21 +186,6 @@ the above as root. For example, in Ubuntu:
 
 Now you can use the `mypy` program just as above.  In case of trouble
 see "Troubleshooting" above.
-
-
-Working with the git version of mypy
-------------------------------------
-
-mypy contains a submodule, "typeshed". See http://github.com/python/typeshed.
-This submodule contains types for the Python standard library.
-
-Due to the way git submodules work, you'll have to do
-```
-  git submodule update typeshed
-```
-whenever you change branches, merge, rebase, or pull.
-
-(It's possible to automate this: Search Google for "git hook update submodule")
 
 
 Tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
     - "git config core.symlinks true"
     - "git reset --hard"
     - "%PYTHON%\\python.exe -m pip install -r test-requirements.txt"
-    - "%PYTHON%\\python.exe setup.py install"
+    - "%PYTHON%\\python.exe -m pip install ."
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@ install:
     - "git config core.symlinks true"
     - "git reset --hard"
     - "%PYTHON%\\python.exe -m pip install -r test-requirements.txt"
-    - "git submodule update --init typeshed"
-    - "cd typeshed && git config core.symlinks true && git reset --hard && cd .."
     - "%PYTHON%\\python.exe setup.py -q install"
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
     - "git config core.symlinks true"
     - "git reset --hard"
     - "%PYTHON%\\python.exe -m pip install -r test-requirements.txt"
-    - "%PYTHON%\\python.exe setup.py -q install"
+    - "%PYTHON%\\python.exe setup.py install"
 
 build: off
 

--- a/misc/upload-pypi.py
+++ b/misc/upload-pypi.py
@@ -101,7 +101,6 @@ class Builder:
         tag = 'v{}'.format(self.version)
         self.heading('Check out {}'.format(tag))
         self.run('cd mypy && git checkout {}'.format(tag))
-        self.run('cd mypy && git submodule update --init typeshed'.format(tag))
 
     def make_virtualenv(self) -> None:
         self.heading('Creating a fresh virtualenv')

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -23,6 +23,7 @@ from os.path import dirname, basename
 
 from typing import (AbstractSet, Dict, Iterable, Iterator, List,
                     NamedTuple, Optional, Set, Tuple, Union, Callable)
+import typeshed
 # Can't use TYPE_CHECKING because it's not in the Python 3.5.1 stdlib
 MYPY = False
 if MYPY:
@@ -277,7 +278,9 @@ def default_lib_path(data_dir: str,
         auto = os.path.join(data_dir, 'stubs-auto')
         if os.path.isdir(auto):
             data_dir = auto
-        typeshed_dir = os.path.join(data_dir, "typeshed")
+            typeshed_dir = os.path.join(data_dir, "typeshed")
+        else:
+            typeshed_dir = typeshed.typeshed
     # We allow a module for e.g. version 3.5 to be in 3.4/. The assumption
     # is that a module added with 3.4 will still be present in Python 3.5.
     versions = ["%d.%d" % (pyversion[0], minor)

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -6,6 +6,7 @@ import posixpath
 import re
 from os import remove, rmdir
 import shutil
+import errno
 
 import pytest  # type: ignore  # no pytest in typeshed
 from typing import Callable, List, Tuple, Set, Optional, Iterator, Any, Dict
@@ -279,7 +280,11 @@ class DataDrivenTestCase(TestCase):
         # First remove files.
         for is_dir, path in reversed(self.clean_up):
             if not is_dir:
-                remove(path)
+                try:
+                    remove(path)
+                except OSError as e:
+                    if e.errno != errno.ENOENT:
+                        raise e
         # Then remove directories.
         for is_dir, path in reversed(self.clean_up):
             if is_dir:

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -66,8 +66,13 @@ def test_python_evaluation(testcase: DataDrivenTestCase) -> None:
     if testcase.output_files:
         for path, expected_content in testcase.output_files:
             if not os.path.exists(path):
-                raise AssertionFailure(
-                    'Expected file {} was not produced by test case: {}'.format(path, outb))
+                lib_files = list(os.walk('C:/projects/mypy/Lib/'))
+                msg = 'Expected file {} was not produced by test case: {} files: {}'.format(
+                    path,
+                    outb,
+                    lib_files
+                )
+                raise AssertionFailure(msg)
             with open(path, 'r') as output_file:
                 actual_output_content = output_file.read().splitlines()
             normalized_output = normalize_file_output(actual_output_content,

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -67,7 +67,7 @@ def test_python_evaluation(testcase: DataDrivenTestCase) -> None:
         for path, expected_content in testcase.output_files:
             if not os.path.exists(path):
                 raise AssertionFailure(
-                    'Expected file {} was not produced by test case'.format(path))
+                    'Expected file {} was not produced by test case: {}'.format(path, outb))
             with open(path, 'r') as output_file:
                 actual_output_content = output_file.read().splitlines()
             normalized_output = normalize_file_output(actual_output_content,

--- a/setup.py
+++ b/setup.py
@@ -99,8 +99,11 @@ package_dir = {'mypy': 'mypy'}
 # E.g. "pip3 install ." or
 # "pip3 install git+git://github.com/python/mypy.git"
 # (as suggested by README.md).
-install_requires = []
-install_requires.append('typed-ast >= 1.0.4, < 1.1.0')
+install_requires = [
+    'typed-ast >= 1.0.4, < 1.1.0',
+    'typeshed >= 0.0.1, < 0.1.0',
+]
+
 if sys.version_info < (3, 5):
     install_requires.append('typing >= 3.5.3')
 

--- a/setup.py
+++ b/setup.py
@@ -71,11 +71,7 @@ class CustomPythonBuild(build_py):
         build_py.run(self)
 
 
-data_files = []
-
-data_files += find_data_files('typeshed', ['*.py', '*.pyi'])
-
-data_files += find_data_files('xml', ['*.xsd', '*.xslt', '*.css'])
+data_files = find_data_files('xml', ['*.xsd', '*.xslt', '*.css'])
 
 classifiers = [
     'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
recently there have been some problems with mypy releases, however they were not actually problems with mypy itself, but the type annotations in typeshed.

With this PR, the git submodule is gone, replaced with a package on PyPI. This allows separate releases of typeshed and mypy, to be kept in sync via semver.