### PR TITLE
Stubgen: Added basic support for importing modules that base classes are a member of

### DIFF
--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -530,6 +530,14 @@ import x.y
 
 class D(x.y.C): ...
 
+[case testArbitraryBaseClassWithAlias]
+import x as y
+class D(y.C): ...
+[out]
+import x as y
+
+class D(y.C): ...
+
 [case testUnqualifiedArbitraryBaseClassWithNoDef]
 class A(int): ...
 [out]
@@ -627,6 +635,24 @@ from typing import Any, Optional
 class A:
     x = ...  # type: Any
     def __init__(self, a: Optional[Any] = ...) -> None: ...
+
+[case testImportAddedForQualifiedBaseClass]
+from foo import bar
+
+class A(bar.fuzz.Baz): ...
+[out]
+from foo import bar
+
+class A(bar.fuzz.Baz): ...
+
+[case testImportAddedForQualifiedBaseClassWithAlias]
+from foo import bar as baz
+
+class A(baz.Baz): ...
+[out]
+from foo import bar as baz
+
+class A(baz.Baz): ...
 
 -- More features/fixes:
 --   do not export deleted names


### PR DESCRIPTION
Resolves #1782 

I've taken the liberty of adding a very basic check to match imports with qualified base classes and adding those to the list of imports to be added to the stub.

Disclaimer: I wouldn't consider myself a Python expert. I'm not sure I've seen any other way to declare or reassign imports that would break this check so I wouldn't know if there was any extra processing required here. :)