### PR TITLE
[disallow-any=expr] Do not typecheck type_object_type

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2459,6 +2459,13 @@ class HasAnyType(types.TypeQuery[bool]):
     def __init__(self) -> None:
         super().__init__(any)
 
+    def visit_callable_type(self, t: CallableType) -> bool:
+        if t.is_type_obj():
+            # Do not complain about Any's in Type objects because signature of their __init__s
+            # can contain Any and should be allowed.
+            return False
+        return super().visit_callable_type(t)
+
     def visit_any(self, t: AnyType) -> bool:
         return not t.special_form  # special forms are not real Any types
 

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -880,3 +880,27 @@ Movie = TypedDict('Movie', {'name': str, 'year': int})
 def g(m: Movie) -> Movie:
     return m
 [builtins fixtures/dict.pyi]
+
+[case testDisallowAnyExprAlias]
+# flags: --disallow-any=expr
+from typing import Any
+
+class Foo(BaseException):
+    def __init__(self, f: Any) -> None:
+          pass
+
+F = Foo  # no error
+[builtins fixtures/exception.pyi]
+
+[case testDisallowAnyExprRaise]
+# flags: --disallow-any=expr
+from typing import Any
+
+
+class Foo(BaseException):
+    def __init__(self, f: Any) -> None:
+          pass
+
+def foo() -> int:
+    raise Foo  # no error
+[builtins fixtures/exception.pyi]


### PR DESCRIPTION
TypeObjectTypes are callables that can have `Any` in parameters if
the constructor of the original type has `Any` in it. This is not a real
`Any` and we should not report it.