### PR TITLE
Fix spurious error on acessing class names defined on self

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3406,6 +3406,7 @@ class SemanticAnalyzer(NodeVisitor[None]):
             if not node.implicit:
                 return node
             implicit_name = True
+            implicit_node = node
         # 3. Local (function) scopes
         for table in reversed(self.locals):
             if table is not None and name in table:
@@ -3428,6 +3429,8 @@ class SemanticAnalyzer(NodeVisitor[None]):
         if not implicit_name:
             self.name_not_defined(name, ctx)
             self.check_for_obsolete_short_name(name, ctx)
+        else:
+            return implicit_node
         return None
 
     def check_for_obsolete_short_name(self, name: str, ctx: Context) -> None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3384,6 +3384,7 @@ class SemanticAnalyzer(NodeVisitor[None]):
 
     def lookup(self, name: str, ctx: Context) -> SymbolTableNode:
         """Look up an unqualified name in all active namespaces."""
+        implicit_name = False
         # 1a. Name declared using 'global x' takes precedence
         if name in self.global_decls[-1]:
             if name in self.globals:
@@ -3404,6 +3405,7 @@ class SemanticAnalyzer(NodeVisitor[None]):
             node = self.type.names[name]
             if not node.implicit:
                 return node
+            implicit_name = True
         # 3. Local (function) scopes
         for table in reversed(self.locals):
             if table is not None and name in table:
@@ -3423,8 +3425,9 @@ class SemanticAnalyzer(NodeVisitor[None]):
                 node = table[name]
                 return node
         # Give up.
-        self.name_not_defined(name, ctx)
-        self.check_for_obsolete_short_name(name, ctx)
+        if not implicit_name:
+            self.name_not_defined(name, ctx)
+            self.check_for_obsolete_short_name(name, ctx)
         return None
 
     def check_for_obsolete_short_name(self, name: str, ctx: Context) -> None:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -233,16 +233,6 @@ class B(object):
     attr = 0
     def f(self) -> None:
         reveal_type(self.attr)  # E: Revealed type is 'builtins.int'
-
-class C(object):
-    reveal_type(attr)  # E: Revealed type is 'builtins.int'
-    def f(self) -> None:
-        self.attr = 1
-
-class D(object):
-    def f(self) -> None:
-        reveal_type(self.attr)  # E: Revealed type is 'builtins.int'
-    attr = 0
 [out]
 
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -223,6 +223,28 @@ class D(object):
         self.attr = 1
 [out]
 
+[case testClassNamesDefinedOnSelUsedInClassBodyReveal]
+class A(object):
+    def f(self) -> None:
+        self.attr = 1
+    reveal_type(attr)  # E: Revealed type is 'builtins.int'
+
+class B(object):
+    attr = 0
+    def f(self) -> None:
+        reveal_type(self.attr)  # E: Revealed type is 'builtins.int'
+
+class C(object):
+    reveal_type(attr)  # E: Revealed type is 'builtins.int'
+    def f(self) -> None:
+        self.attr = 1
+
+class D(object):
+    def f(self) -> None:
+        reveal_type(self.attr)  # E: Revealed type is 'builtins.int'
+    attr = 0
+[out]
+
 
 -- Method overriding
 -- -----------------

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -198,6 +198,31 @@ class A:
 main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:8: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
+[case testClassNamesDefinedOnSelUsedInClassBody]
+class A(object):
+    def f(self):
+        self.attr = 1
+    attr = 0
+
+class B(object):
+    attr = 0
+    def f(self):
+        self.attr = 1
+
+class C(object):
+    attr = 0
+    def f(self):
+        self.attr = 1
+    attr = 0
+
+class D(object):
+    def g(self):
+        self.attr = 1
+    attr = 0
+    def f(self):
+        self.attr = 1
+[out]
+
 
 -- Method overriding
 -- -----------------
@@ -3386,9 +3411,7 @@ NT([])
 [builtins fixtures/dict.pyi]
 [out]
 
--- The two tests below will not crash after
--- https://github.com/python/mypy/issues/3319 is fixed
-[case testCrashForwardSyntheticClassSyntax-skip]
+[case testCrashForwardSyntheticClassSyntax]
 from typing import NamedTuple
 from mypy_extensions import TypedDict
 class A1(NamedTuple):
@@ -3406,7 +3429,7 @@ reveal_type(y['b']) # E: Revealed type is '__main__.B'
 [builtins fixtures/dict.pyi]
 [out]
 
-[case testCrashForwardSyntheticFunctionSyntax-skip]
+[case testCrashForwardSyntheticFunctionSyntax]
 from typing import NamedTuple
 from mypy_extensions import TypedDict
 A1 = NamedTuple('A1', [('b', 'B'), ('x', int)])


### PR DESCRIPTION
Fixes #3713

The idea is just to not show an error when accessing in the class body an attribute defined on ``self`` (mypy does not distinguishes them anyway). As well, the correct node is returned on lookup, previously this resulted in some spurious ``Any`` types.

(In addition I enable two previously skipped test, just noticed them when added tests for this PR.)