### PR TITLE
Python 3.4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ type check them statically. Find bugs in your programs without even
 running them!
 
 The type annotation standard has also been backported to earlier
-Python 3.x versions.  Mypy supports Python 3.3 and later.
+Python 3.x versions.  Mypy supports Python 3.3 and later. 
+XML based reports do not work on Python 3.3 and 3.4 on Windows.
 
 For Python 2.7, you can add annotations as comments (this is also
 specified in [PEP 484](https://www.python.org/dev/peps/pep-0484/)).
@@ -156,6 +157,9 @@ In Windows, the script is generally installed in
 
     C:\>\Python34\python \Python34\Scripts\mypy PROGRAM
 
+If you are on Windows using Python 3.3 or 3.4, and would like to use XML reports
+download LXML from [PyPi](https://pypi.python.org/pypi/lxml).
+
 ### Working with `virtualenv`
 
 If you are using [`virtualenv`](https://virtualenv.pypa.io/en/stable/),
@@ -254,9 +258,8 @@ Help wanted
 Any help in testing, development, documentation and other tasks is
 highly appreciated and useful to the project. There are tasks for
 contributors of all experience levels. If you're just getting started,
-check out the
-[difficulty/easy](https://github.com/python/mypy/labels/difficulty%2Feasy)
-label.
+ask on the [gitter chat](https://gitter.im/python/typing) for ideas of good
+beginner issues.
 
 For more details, see the file [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(name='mypy',
       data_files=data_files,
       classifiers=classifiers,
       cmdclass={'build_py': CustomPythonBuild},
-      install_requires = ['typed-ast >= 1.0.4, < 1.1.0'],
+      install_requires = ['typed-ast >= 1.1.0, < 1.2.0'],
       extras_require = {
           ':python_version < "3.5"': 'typing >= 3.5.3',
       },

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ flake8
 flake8-bugbear; python_version >= '3.5'
 flake8-pyi; python_version >= '3.6'
 lxml; sys_platform != 'win32' or python_version == '3.5' or python_version == '3.6'
-typed-ast>=1.0.4,<1.1.0; sys_platform != 'win32' or python_version >= '3.5'
+typed-ast>=1.1.0,<1.2.0
 pytest>=2.8
 pytest-xdist>=1.13
 pytest-cov>=2.4.0


### PR DESCRIPTION
The new typed_ast 1.1.0 includes a patch adding support for Python 3.4
and 3.3. The README is updated to discuss this. A comment on LXML on
Python 3.3/3.4 was added in case there was someone who really wanted to use reports. Also I removed the comment about the difficulty/easy tag on issues as that isn't used anymore.

3.3 ends up being supported incidentally as it uses the same compiler as 3.4 (thus typed_ast supports it, so we do).

lxml in test-requirements is not updated due to lxml not supplying wheels for Python 3.4 64 bit.