### PR TITLE
Do not follow imports from stubs with `--follow-imports=skip`

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1377,12 +1377,9 @@ class State:
                 # - skip -> don't analyze, make the type Any
                 follow_imports = self.options.follow_imports
                 if (follow_imports != 'normal'
-                    and not root_source  # Honor top-level modules
-                    and path.endswith('.py')  # Stubs are always normal
-                    and id != 'builtins'  # Builtins is always normal
-                    and not (caller_state and
-                             caller_state.tree and
-                             caller_state.tree.is_stub)):
+                        and not root_source  # Honor top-level modules
+                        and path.endswith('.py')  # Stubs are always normal
+                        and id != 'builtins'):  # Builtins is always normal
                     if follow_imports == 'silent':
                         # Still import it, but silence non-blocker errors.
                         manager.log("Silencing %s (%s)" % (path, id))

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -955,19 +955,24 @@ tmp/foo/bar.py: note: (Using --follow-imports=error, submodule passed on command
 # cmd: mypy -m main
 # flags: --follow-imports=skip
 [file main.py]
-from stub import x # Permitted
-from other import y # Disallowed
-x + '' # Error here
-y + '' # But not here
+from stub import x, z  # Followed
+from other import y  # Not followed
+x + ''  # No error here
+y + ''  # No error here
+z + ''  # Error here
 [file stub.pyi]
-from non_stub import x
+from non_stub import x  # this import is not followed
+
+z = 42
 [file non_stub.py]
 x = 42
+
+x + ''  # no error because file is not analyzed
 [file other.py]
 y = 42
 [builtins fixtures/module.pyi]
 [out]
-tmp/main.py:3: error: Unsupported left operand type for + ("int")
+tmp/main.py:5: error: Unsupported left operand type for + ("int")
 
 [case testSilentSubmoduleImport]
 # cmd: mypy -m foo


### PR DESCRIPTION
If such imports are followed, previously unanalyzed modules can become analyzed.

Fixes #3727