### PR TITLE
Fix crash in --quick mode when aliases are re-exported

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -88,6 +88,9 @@ class NodeFixer(NodeVisitor[None]):
                     if stnode is not None:
                         value.node = stnode.node
                         value.type_override = stnode.type_override
+                        if (self.quick_and_dirty and value.kind == TYPE_ALIAS and
+                                stnode.type_override is None):
+                            value.type_override = Instance(stale_info(), [])
                         value.alias_tvars = stnode.alias_tvars or []
                     elif not self.quick_and_dirty:
                         assert stnode is not None, "Could not find cross-ref %s" % (cross_ref,)

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2707,6 +2707,29 @@ b.x.y
 tmp/c.py:2: error: Revealed type is '<stale cache: consider running mypy without --quick>'
 tmp/c.py:5: error: "<stale cache: consider running mypy without --quick>" has no attribute "y"
 
+[case testNoCrashOnDoubleImportAliasQuick]
+# cmd: mypy -m e
+# cmd2: mypy -m c
+# cmd3: mypy -m e
+# flags: --quick
+[file c.py]
+from typing import List
+Alias = List[int]
+[file c.py.2]
+from typing import List
+Alias = int
+
+[file d.py]
+from c import Alias
+
+[file e.py]
+from d import Alias
+[file e.py.3]
+from d import Alias
+x: Alias
+[out3]
+[builtins fixtures/list.pyi]
+
 [case testSerializeAbstractPropertyIncremental]
 from abc import abstractmethod
 import typing


### PR DESCRIPTION
Fixes #3355 

This happens since dependencies in ``--quick`` mode are not rechecked, therefore we need to put something in place of the outdated values.

In general, I could imagine there are similar problems with outdated values in ``--quick`` mode, so that it is better to move towards fine grained incremental, that actually rechecks dependencies.