### PR TITLE
Generate note if reveal_type is used in an unchecked function

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1713,6 +1713,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         revealed_type = self.accept(expr.expr, type_context=self.type_context[-1])
         if not self.chk.current_node_deferred:
             self.msg.reveal_type(revealed_type, expr)
+            if not self.chk.in_checked_function():
+                self.msg.note("'reveal_type' always outputs 'Any' in unchecked functions", expr)
         return revealed_type
 
     def visit_type_application(self, tapp: TypeApplication) -> Type:

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1680,6 +1680,29 @@ x = 1 + 1
 [out]
 main:2: error: Revealed type is 'builtins.int'
 
+[case testRevealUncheckedFunction]
+def f():
+    x = 42
+    reveal_type(x)
+[out]
+main:3: error: Revealed type is 'Any'
+main:3: note: 'reveal_type' always outputs 'Any' in unchecked functions
+
+[case testRevealCheckUntypedDefs]
+# flags: --check-untyped-defs
+def f():
+    x = 42
+    reveal_type(x)
+[out]
+main:4: error: Revealed type is 'builtins.int'
+
+[case testRevealTypedDef]
+def f() -> None:
+    x = 42
+    reveal_type(x)
+[out]
+main:3: error: Revealed type is 'builtins.int'
+
 [case testEqNone]
 None == None
 [builtins fixtures/ops.pyi]


### PR DESCRIPTION
Generate note saying `reveal_type` always outputs `Any` if used in an unchecked function.
Fixes #3629