### PR TITLE
Add flag to disallow partially annotated defs

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -322,7 +322,7 @@ Here are some more useful flags:
   annotations are not type checked.)  It will assume all arguments
   have type ``Any`` and always infer ``Any`` as the return type.
 
-- ``--disallow-incompletely-annotated-defs`` reports an error whenever it
+- ``--disallow-incomplete-defs`` reports an error whenever it
   encounters a partly annotated function definition.
 
 - ``--disallow-untyped-calls`` reports an error whenever a function

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -322,6 +322,9 @@ Here are some more useful flags:
   annotations are not type checked.)  It will assume all arguments
   have type ``Any`` and always infer ``Any`` as the return type.
 
+- ``--disallow-incompletely-annotated-defs`` reports an error whenever it
+  encounters a partly annotated function definition.
+
 - ``--disallow-untyped-calls`` reports an error whenever a function
   with type annotations calls a function defined without annotations.
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -766,14 +766,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         def is_implicit_any(t: Type) -> bool:
             return isinstance(t, AnyType) and t.implicit
 
-        if isinstance(fdef.type, CallableType):
-            has_an_explicit_annotation = any(not is_implicit_any(t)
-                                             for t in fdef.type.arg_types + [fdef.type.ret_type])
-        else:
-            has_an_explicit_annotation = False
+        has_explicit_annotation = (isinstance(fdef.type, CallableType)
+                                   and any(not is_implicit_any(t)
+                                           for t in fdef.type.arg_types + [fdef.type.ret_type]))
+
         show_untyped = not self.is_typeshed_stub or self.options.warn_incomplete_stub
-        check_incomplete_defs = (self.options.disallow_incomplete_defs
-                                        and has_an_explicit_annotation)
+        check_incomplete_defs = self.options.disallow_incomplete_defs and has_explicit_annotation
         if show_untyped and (self.options.disallow_untyped_defs or check_incomplete_defs):
             if fdef.type is None and self.options.disallow_untyped_defs:
                 self.fail(messages.FUNCTION_TYPE_EXPECTED, fdef)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -619,19 +619,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         self.fail(messages.MUST_HAVE_NONE_RETURN_TYPE.format(fdef.name()),
                                   item)
 
-                    show_untyped = not self.is_typeshed_stub or self.options.warn_incomplete_stub
-                    if self.options.disallow_untyped_defs and show_untyped:
-                        # Check for functions with unspecified/not fully specified types.
-                        def is_implicit_any(t: Type) -> bool:
-                            return isinstance(t, AnyType) and t.implicit
-
-                        if fdef.type is None:
-                            self.fail(messages.FUNCTION_TYPE_EXPECTED, fdef)
-                        elif isinstance(fdef.type, CallableType):
-                            if is_implicit_any(fdef.type.ret_type):
-                                self.fail(messages.RETURN_TYPE_EXPECTED, fdef)
-                            if any(is_implicit_any(t) for t in fdef.type.arg_types):
-                                self.fail(messages.ARGUMENT_TYPE_EXPECTED, fdef)
+                    self.check_for_missing_annotations(fdef)
                     if 'unimported' in self.options.disallow_any:
                         if fdef.type and isinstance(fdef.type, CallableType):
                             ret_type = fdef.type.ret_type
@@ -772,6 +760,28 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             self.return_types.pop()
 
             self.binder = old_binder
+
+    def check_for_missing_annotations(self, fdef: FuncItem) -> None:
+        # Check for functions with unspecified/not fully specified types.
+        def is_implicit_any(t: Type) -> bool:
+            return isinstance(t, AnyType) and t.implicit
+
+        if isinstance(fdef.type, CallableType):
+            has_an_explicit_annotation = any(not is_implicit_any(t)
+                                             for t in fdef.type.arg_types + [fdef.type.ret_type])
+        else:
+            has_an_explicit_annotation = False
+        show_untyped = not self.is_typeshed_stub or self.options.warn_incomplete_stub
+        check_incompletely_annotated = (self.options.disallow_incompletely_annotated_defs
+                                        and has_an_explicit_annotation)
+        if show_untyped and (self.options.disallow_untyped_defs or check_incompletely_annotated):
+            if fdef.type is None and self.options.disallow_untyped_defs:
+                self.fail(messages.FUNCTION_TYPE_EXPECTED, fdef)
+            elif isinstance(fdef.type, CallableType):
+                if is_implicit_any(fdef.type.ret_type):
+                    self.fail(messages.RETURN_TYPE_EXPECTED, fdef)
+                if any(is_implicit_any(t) for t in fdef.type.arg_types):
+                    self.fail(messages.ARGUMENT_TYPE_EXPECTED, fdef)
 
     def is_trivial_body(self, block: Block) -> bool:
         body = block.body

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -772,9 +772,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         else:
             has_an_explicit_annotation = False
         show_untyped = not self.is_typeshed_stub or self.options.warn_incomplete_stub
-        check_incompletely_annotated = (self.options.disallow_incompletely_annotated_defs
+        check_incomplete_defs = (self.options.disallow_incomplete_defs
                                         and has_an_explicit_annotation)
-        if show_untyped and (self.options.disallow_untyped_defs or check_incompletely_annotated):
+        if show_untyped and (self.options.disallow_untyped_defs or check_incomplete_defs):
             if fdef.type is None and self.options.disallow_untyped_defs:
                 self.fail(messages.FUNCTION_TYPE_EXPECTED, fdef)
             elif isinstance(fdef.type, CallableType):

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -258,7 +258,7 @@ def process_options(args: List[str],
     add_invertible_flag('--disallow-untyped-defs', default=False, strict_flag=True,
                         help="disallow defining functions without type annotations"
                         " or with incomplete type annotations")
-    add_invertible_flag('--disallow-incompletely-annotated-defs', default=False, strict_flag=True,
+    add_invertible_flag('--disallow-incomplete-defs', default=False, strict_flag=True,
                         help="disallow defining functions with incomplete type annotations")
     add_invertible_flag('--check-untyped-defs', default=False, strict_flag=True,
                         help="type check the interior of functions without type annotations")

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -258,6 +258,8 @@ def process_options(args: List[str],
     add_invertible_flag('--disallow-untyped-defs', default=False, strict_flag=True,
                         help="disallow defining functions without type annotations"
                         " or with incomplete type annotations")
+    add_invertible_flag('--disallow-incompletely-annotated-defs', default=False, strict_flag=True,
+                        help="disallow defining functions with incomplete type annotations")
     add_invertible_flag('--check-untyped-defs', default=False, strict_flag=True,
                         help="type check the interior of functions without type annotations")
     add_invertible_flag('--disallow-subclassing-any', default=False, strict_flag=True,

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -58,7 +58,7 @@ class Options:
         self.disallow_untyped_defs = False
 
         # Disallow defining incompletely typed functions
-        self.disallow_incompletely_annotated_defs = False
+        self.disallow_incomplete_defs = False
 
         # Type check unannotated functions
         self.check_untyped_defs = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -57,6 +57,9 @@ class Options:
         # Disallow defining untyped (or incompletely typed) functions
         self.disallow_untyped_defs = False
 
+        # Disallow defining incompletely typed functions
+        self.disallow_incompletely_annotated_defs = False
+
         # Type check unannotated functions
         self.check_untyped_defs = False
 

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -911,7 +911,7 @@ def h(i: int) -> int:  # no error
 def i() -> None:  # no error
     pass
 
-[case testDisallowIncompleteDefsUntypedDefs]
+[case testDisallowIncompleteDefsNoReturn]
 # flags: --disallow-incomplete-defs --disallow-untyped-defs
 
 def f(i: int):  # E: Function is missing a return type annotation
@@ -923,13 +923,7 @@ class C:
     def foo(self) -> None:  # no error
         pass
 
-[case testDisallowIncompleteDefsUntypedDefs]
-# flags: --disallow-incomplete-defs --disallow-untyped-defs
-
-def f(i: int):  # E: Function is missing a return type annotation
-    pass
-
-[case testDisallowPartiallyAnnotatedDefsSelf]
+[case testDisallowIncompleteDefsPartiallyAnnotatedParams]
 # flags: --disallow-incomplete-defs
 
 def f(i: int, s):

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -900,7 +900,7 @@ def g(m: Movie) -> Movie:
 [builtins fixtures/dict.pyi]
 
 [case testDisallowPartiallyAnnotatedDefs]
-# flags: --disallow-incompletely-annotated-defs
+# flags: --disallow-incomplete-defs
 
 def f(i: int):  # E: Function is missing a return type annotation
     pass
@@ -912,13 +912,13 @@ def i() -> None:  # no error
     pass
 
 [case testDisallowPartiallyAnnotatedDefsUntypedDefs]
-# flags: --disallow-incompletely-annotated-defs --disallow-untyped-defs
+# flags: --disallow-incomplete-defs --disallow-untyped-defs
 
 def f(i: int):  # E: Function is missing a return type annotation
     pass
 
 [case testDisallowPartiallyAnnotatedDefsSelf]
-# flags: --disallow-incompletely-annotated-defs
+# flags: --disallow-incomplete-defs
 class C:
     def foo(self) -> None:  # no error
         pass

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -899,7 +899,7 @@ def g(m: Movie) -> Movie:
     return m
 [builtins fixtures/dict.pyi]
 
-[case testDisallowPartiallyAnnotatedDefs]
+[case testDisallowIncompleteDefs]
 # flags: --disallow-incomplete-defs
 
 def f(i: int):  # E: Function is missing a return type annotation
@@ -911,7 +911,19 @@ def h(i: int) -> int:  # no error
 def i() -> None:  # no error
     pass
 
-[case testDisallowPartiallyAnnotatedDefsUntypedDefs]
+[case testDisallowIncompleteDefsUntypedDefs]
+# flags: --disallow-incomplete-defs --disallow-untyped-defs
+
+def f(i: int):  # E: Function is missing a return type annotation
+    pass
+
+[case testDisallowIncompleteDefsSelf]
+# flags: --disallow-incomplete-defs
+class C:
+    def foo(self) -> None:  # no error
+        pass
+
+[case testDisallowIncompleteDefsUntypedDefs]
 # flags: --disallow-incomplete-defs --disallow-untyped-defs
 
 def f(i: int):  # E: Function is missing a return type annotation
@@ -919,6 +931,10 @@ def f(i: int):  # E: Function is missing a return type annotation
 
 [case testDisallowPartiallyAnnotatedDefsSelf]
 # flags: --disallow-incomplete-defs
-class C:
-    def foo(self) -> None:  # no error
-        pass
+
+def f(i: int, s):
+    pass
+
+[out]
+main:3: error: Function is missing a return type annotation
+main:3: error: Function is missing a type annotation for one or more arguments

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -898,3 +898,27 @@ Movie = TypedDict('Movie', {'name': str, 'year': int})
 def g(m: Movie) -> Movie:
     return m
 [builtins fixtures/dict.pyi]
+
+[case testDisallowPartiallyAnnotatedDefs]
+# flags: --disallow-incompletely-annotated-defs
+
+def f(i: int):  # E: Function is missing a return type annotation
+    pass
+def g(i) -> None:  # E: Function is missing a type annotation for one or more arguments
+    pass
+def h(i: int) -> int:  # no error
+    return i
+def i() -> None:  # no error
+    pass
+
+[case testDisallowPartiallyAnnotatedDefsUntypedDefs]
+# flags: --disallow-incompletely-annotated-defs --disallow-untyped-defs
+
+def f(i: int):  # E: Function is missing a return type annotation
+    pass
+
+[case testDisallowPartiallyAnnotatedDefsSelf]
+# flags: --disallow-incompletely-annotated-defs
+class C:
+    def foo(self) -> None:  # no error
+        pass


### PR DESCRIPTION
This flag helps user remember to annotate the entire function instead of just
parts of it.
Fixes #3742