### PR TITLE
Search lib directory suffixed by ABI (32 or 64) used in Gentoo Linux #3211

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -219,13 +219,14 @@ def default_data_dir(bin_dir: Optional[str]) -> str:
             # Installed in site-packages or dist-packages, but invoked with python3 -m mypy;
             # __file__ is .../blah/lib/python3.N/site-packages/mypy/build.py
             # or .../blah/lib/python3.N/dist-packages/mypy/build.py (Debian)
+            # or .../blah/lib64/python3.N/dist-packages/mypy/build.py (Gentoo)
             # or .../blah/lib/site-packages/mypy/build.py (Windows)
             # blah may be a virtualenv or /usr/local.  We want .../blah/lib/mypy.
             lib = parent
             for i in range(2):
                 lib = os.path.dirname(lib)
-                if os.path.basename(lib) == 'lib':
-                    return os.path.join(lib, 'mypy')
+                if os.path.basename(lib) in ('lib', 'lib32', 'lib64'):
+                    return os.path.join(os.path.dirname(lib), 'lib/mypy')
         subdir = os.path.join(parent, 'lib', 'mypy')
         if os.path.isdir(subdir):
             # If installed via buildout, the __file__ is


### PR DESCRIPTION
Explanation is found on (#3211).
Though this patch doesn't completely solve #3211 as there are many different platforms ans installs, it works on my platform and probably some other platforms.