### PR TITLE
Make `None` promotable to `object`, not a subclass, when resolving overloads

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2650,9 +2650,10 @@ def overload_arg_similarity(actual: Type, formal: Type) -> int:
             # NoneTyp matches anything if we're not doing strict Optional checking
             return 2
         else:
-            # NoneType is a subtype of object
+            # NoneType can be promoted to object, but isn't actually a subtype (otherwise you
+            # wouldn't be able to define overloads between object and None).
             if isinstance(formal, Instance) and formal.type.fullname() == "builtins.object":
-                return 2
+                return 1
     if isinstance(actual, UnionType):
         return max(overload_arg_similarity(item, formal)
                    for item in actual.relevant_items())

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -238,6 +238,17 @@ def f(x: int) -> int: pass
 reveal_type(f(None))  # E: Revealed type is 'builtins.str'
 reveal_type(f(0))  # E: Revealed type is 'builtins.int'
 
+[case testOverloadWithObject]
+from foo import *
+[file foo.pyi]
+from typing import overload
+@overload
+def f(x: None) -> str: pass
+@overload
+def f(x: object) -> int: pass
+reveal_type(f(None))  # E: Revealed type is 'builtins.str'
+reveal_type(f(0))  # E: Revealed type is 'builtins.int'
+
 [case testOptionalTypeOrTypePlain]
 from typing import Optional
 def f(a: Optional[int]) -> int:


### PR DESCRIPTION
Fixes #3757. However, I'm not at all sure that this is the right approach--please let me know if this seems reasonable, or if it's an abuse of the meaning of "overload arg similarity" and I should do something else!