### PR TITLE
Add 0.521 to release notes

### DIFF
--- a/docs/source/revision_history.rst
+++ b/docs/source/revision_history.rst
@@ -4,6 +4,8 @@ Revision history
 List of major changes:
 
 - July 2017
+    * Publish ``mypy`` version 0.521 on PyPI.
+
     * Publish ``mypy`` version 0.520 on PyPI.
 
     * Add :ref:`fine-grained control of Any types <disallow-any>`.


### PR DESCRIPTION
The one commit from the release-0.521 branch that wasn't cherry-picked from master.