### PR TITLE
Make tuple generic in most stubs

### DIFF
--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1749,7 +1749,7 @@ if isinstance(x): # E: Too few arguments for "isinstance"
 
 [case testIsInstanceTooManyArgs]
 isinstance(1, 1, 1) # E: Too many arguments for "isinstance" \
-         # E: Argument 2 to "isinstance" has incompatible type "int"; expected "Union[type, tuple]"
+         # E: Argument 2 to "isinstance" has incompatible type "int"; expected "Union[type, Tuple[Any, ...]]"
 x: object
 if isinstance(x, str, 1): # E: Too many arguments for "isinstance"
     reveal_type(x) # E: Revealed type is 'builtins.object'

--- a/test-data/unit/fixtures/async_await.pyi
+++ b/test-data/unit/fixtures/async_await.pyi
@@ -1,6 +1,7 @@
 import typing
 
 T = typing.TypeVar('T')
+U = typing.TypeVar('U')
 class list(typing.Sequence[T]): pass
 
 class object:
@@ -9,8 +10,8 @@ class type: pass
 class function: pass
 class int: pass
 class str: pass
-class dict: pass
-class set: pass
+class dict(typing.Generic[T, U]): pass
+class set(typing.Generic[T]): pass
 class tuple(typing.Generic[T]): pass
 class BaseException: pass
 class StopIteration(BaseException): pass

--- a/test-data/unit/fixtures/async_await.pyi
+++ b/test-data/unit/fixtures/async_await.pyi
@@ -1,7 +1,7 @@
 import typing
 
 T = typing.TypeVar('T')
-class list(typing.Generic[T], typing.Sequence[T]): pass
+class list(typing.Sequence[T]): pass
 
 class object:
     def __init__(self): pass
@@ -11,7 +11,7 @@ class int: pass
 class str: pass
 class dict: pass
 class set: pass
-class tuple: pass
+class tuple(typing.Generic[T]): pass
 class BaseException: pass
 class StopIteration(BaseException): pass
 class StopAsyncIteration(BaseException): pass

--- a/test-data/unit/fixtures/bool.pyi
+++ b/test-data/unit/fixtures/bool.pyi
@@ -1,10 +1,12 @@
 # builtins stub used in boolean-related test cases.
+from typing import Generic, TypeVar
+T = TypeVar('T')
 
 class object:
     def __init__(self) -> None: pass
 
 class type: pass
-class tuple: pass
+class tuple(Generic[T]): pass
 class function: pass
 class bool: pass
 class int: pass

--- a/test-data/unit/fixtures/dict.pyi
+++ b/test-data/unit/fixtures/dict.pyi
@@ -35,7 +35,7 @@ class list(Iterable[T], Generic[T]): # needed by some test cases
     def __iter__(self) -> Iterator[T]: pass
     def __mul__(self, x: int) -> list[T]: pass
 
-class tuple: pass
+class tuple(Generic[T]): pass
 class function: pass
 class float: pass
 class bool: pass

--- a/test-data/unit/fixtures/exception.pyi
+++ b/test-data/unit/fixtures/exception.pyi
@@ -1,9 +1,11 @@
+from typing import Generic, TypeVar
+T = TypeVar('T')
 
 class object:
     def __init__(self): pass
 
 class type: pass
-class tuple: pass
+class tuple(Generic[T]): pass
 class function: pass
 class int: pass
 class str: pass

--- a/test-data/unit/fixtures/fine_grained.pyi
+++ b/test-data/unit/fixtures/fine_grained.pyi
@@ -4,6 +4,9 @@
 #       enough to handle them.
 
 import types
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
 
 class Any: pass
 
@@ -20,7 +23,7 @@ class str:
 
 class float: pass
 class bytes: pass
-class tuple: pass
+class tuple(Generic[T]): pass
 class function: pass
 class ellipsis: pass
-class list: pass
+class list(Generic[T]): pass

--- a/test-data/unit/fixtures/float.pyi
+++ b/test-data/unit/fixtures/float.pyi
@@ -1,3 +1,6 @@
+from typing import Generic, TypeVar
+T = TypeVar('T')
+
 Any = 0
 
 class object:
@@ -12,7 +15,7 @@ class str:
 
 class bytes: pass
 
-class tuple: pass
+class tuple(Generic[T]): pass
 class function: pass
 
 class ellipsis: pass

--- a/test-data/unit/fixtures/floatdict.pyi
+++ b/test-data/unit/fixtures/floatdict.pyi
@@ -18,7 +18,7 @@ class str:
 
 class bytes: pass
 
-class tuple: pass
+class tuple(Generic[T]): pass
 class function: pass
 
 class ellipsis: pass

--- a/test-data/unit/fixtures/for.pyi
+++ b/test-data/unit/fixtures/for.pyi
@@ -9,7 +9,7 @@ class object:
     def __init__(self) -> None: pass
 
 class type: pass
-class tuple: pass
+class tuple(Generic[t]): pass
 class function: pass
 class bool: pass
 class int: pass # for convenience

--- a/test-data/unit/fixtures/isinstancelist.pyi
+++ b/test-data/unit/fixtures/isinstancelist.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable, Iterator, TypeVar, List, Mapping, overload, Tuple, Set, Union
+from typing import Iterable, Iterator, TypeVar, List, Mapping, overload, Tuple, Set, Union, Generic
 
 class object:
     def __init__(self) -> None: pass
@@ -6,7 +6,6 @@ class object:
 class type:
     def __init__(self, x) -> None: pass
 
-class tuple: pass
 class function: pass
 class ellipsis: pass
 
@@ -23,6 +22,8 @@ class str:
 T = TypeVar('T')
 KT = TypeVar('KT')
 VT = TypeVar('VT')
+
+class tuple(Generic[T]): pass
 
 class list(Iterable[T]):
     def __iter__(self) -> Iterator[T]: pass

--- a/test-data/unit/fixtures/module.pyi
+++ b/test-data/unit/fixtures/module.pyi
@@ -13,7 +13,7 @@ class function: pass
 class int: pass
 class str: pass
 class bool: pass
-class tuple: pass
+class tuple(Generic[T]): pass
 class dict(Generic[T, S]): pass
 class ellipsis: pass
 

--- a/test-data/unit/fixtures/module_all.pyi
+++ b/test-data/unit/fixtures/module_all.pyi
@@ -14,5 +14,5 @@ class list(Generic[_T], Sequence[_T]):
     def append(self, x: _T): pass
     def extend(self, x: Sequence[_T]): pass
     def __add__(self, rhs: Sequence[_T]) -> list[_T]: pass
-class tuple: pass
+class tuple(Generic[_T]): pass
 class ellipsis: pass

--- a/test-data/unit/fixtures/module_all_python2.pyi
+++ b/test-data/unit/fixtures/module_all_python2.pyi
@@ -12,4 +12,4 @@ class list(Generic[_T], Sequence[_T]):
     def append(self, x: _T): pass
     def extend(self, x: Sequence[_T]): pass
     def __add__(self, rhs: Sequence[_T]) -> list[_T]: pass
-class tuple: pass
+class tuple(Generic[_T]): pass

--- a/test-data/unit/fixtures/primitives.pyi
+++ b/test-data/unit/fixtures/primitives.pyi
@@ -1,4 +1,6 @@
 # builtins stub with non-generic primitive types
+from typing import Generic, TypeVar
+T = TypeVar('T')
 
 class object:
     def __init__(self) -> None: pass
@@ -17,5 +19,5 @@ class str:
     def format(self, *args) -> str: pass
 class bytes: pass
 class bytearray: pass
-class tuple: pass
+class tuple(Generic[T]): pass
 class function: pass

--- a/test-data/unit/fixtures/set.pyi
+++ b/test-data/unit/fixtures/set.pyi
@@ -8,7 +8,7 @@ class object:
     def __init__(self) -> None: pass
 
 class type: pass
-class tuple: pass
+class tuple(Generic[T]): pass
 class function: pass
 
 class int: pass

--- a/test-data/unit/fixtures/slice.pyi
+++ b/test-data/unit/fixtures/slice.pyi
@@ -1,10 +1,12 @@
 # Builtins stub used in slicing test cases.
+from typing import Generic, TypeVar
+T = TypeVar('T')
 
 class object:
     def __init__(self): pass
 
 class type: pass
-class tuple: pass
+class tuple(Generic[T]): pass
 class function: pass
 
 class int: pass

--- a/test-data/unit/fixtures/type.pyi
+++ b/test-data/unit/fixtures/type.pyi
@@ -13,7 +13,7 @@ class list(Generic[T]): pass
 class type:
     def mro(self) -> List['type']: pass
 
-class tuple: pass
+class tuple(Generic[T]): pass
 class function: pass
 class bool: pass
 class int: pass

--- a/test-data/unit/fixtures/union.pyi
+++ b/test-data/unit/fixtures/union.pyi
@@ -1,7 +1,8 @@
 # Builtins stub used in tuple-related test cases.
 
 from isinstance import isinstance
-from typing import Iterable, TypeVar
+from typing import Iterable, TypeVar, Generic
+T = TypeVar('T')
 
 class object:
     def __init__(self): pass
@@ -9,9 +10,7 @@ class object:
 class type: pass
 class function: pass
 
-# Current tuple types get special treatment in the type checker, thus there
-# is no need for type arguments here.
-class tuple: pass
+class tuple(Generic[T]): pass
 
 # We need int for indexing tuples.
 class int: pass


### PR DESCRIPTION
Per @ilevkivskyi suggestion, making tuples generic in stubs to reduce incompatibility between stubs and production.

This is a carve-out from #3129.