### PR TITLE
Bump Pytest version requirement to 3.0

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ flake8-bugbear; python_version >= '3.5'
 flake8-pyi; python_version >= '3.6'
 lxml; sys_platform != 'win32' or python_version == '3.5' or python_version == '3.6'
 typed-ast>=1.1.0,<1.2.0
-pytest>=2.8
-pytest-xdist>=1.13
+pytest>=3.0
+pytest-xdist>=1.18
 pytest-cov>=2.4.0
 typing>=3.5.2; python_version < '3.5'


### PR DESCRIPTION
pytest-xdist requires pytest 3.0, so I bumped the requirements to meet that. Hopefully this fixes the issues on Travis we've been having.