### PR TITLE
Support from ... import ... with module level __getattr__

### DIFF
--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1795,9 +1795,9 @@ from typing import Any
 def __getattr__(name: str) -> Any: ...
 
 [out]
-tmp/non_stub.py:3: error: __getattr__ is not valid at the module level outside a stub file
-main:2: error: Module 'non_stub' has no attribute 'name'
-main:4: error: Revealed type is 'Any'
+tmp/non_stub.py:2: error: __getattr__ is not valid at the module level outside a stub file
+main:1: error: Module 'non_stub' has no attribute 'name'
+main:2: error: Revealed type is 'Any'
 
 [builtins fixtures/module.pyi]
 
@@ -1811,8 +1811,8 @@ from typing import Any
 def __getattr__(name: str) -> Any: ...
 
 [out]
-main:4: error: Revealed type is 'Any'
-main:4: error: Name 'name' is not defined
-main:5: error: Revealed type is 'Any'
+main:2: error: Revealed type is 'Any'
+main:2: error: Name 'name' is not defined
+main:3: error: Revealed type is 'Any'
 
 [builtins fixtures/module.pyi]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1766,3 +1766,64 @@ main:3: error: Module has no attribute "any_attribute"
 [case testModuleLevelGetattribute]
 
 def __getattribute__(): ...  # E: __getattribute__ is not valid at the module level
+
+[case testModuleLevelGetattrImportFrom]
+
+from has_attr import name
+reveal_type(name)  # E: Revealed type is 'Any'
+
+[file has_attr.pyi]
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...
+
+[builtins fixtures/module.pyi]
+
+[case testModuleLevelGetattrImportFromRetType]
+
+from has_attr import int_attr
+
+reveal_type(int_attr)  # E: Revealed type is 'builtins.int'
+
+[file has_attr.pyi]
+
+def __getattr__(name: str) -> int: ...
+
+[builtins fixtures/module.pyi]
+
+[case testModuleLevelGetattrImportFromNotStub]
+
+from non_stub import name
+
+reveal_type(name)
+
+[file non_stub.py]
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...
+
+[out]
+tmp/non_stub.py:3: error: __getattr__ is not valid at the module level outside a stub file
+main:2: error: Module 'non_stub' has no attribute 'name'
+main:4: error: Revealed type is 'Any'
+
+[builtins fixtures/module.pyi]
+
+[case testModuleLevelGetattrImportFromAs]
+
+from has_attr import name as n
+
+reveal_type(name)
+reveal_type(n)
+
+[file has_attr.pyi]
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...
+
+[out]
+main:4: error: Revealed type is 'Any'
+main:4: error: Name 'name' is not defined
+main:5: error: Revealed type is 'Any'
+
+[builtins fixtures/module.pyi]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1768,38 +1768,30 @@ main:3: error: Module has no attribute "any_attribute"
 def __getattribute__(): ...  # E: __getattribute__ is not valid at the module level
 
 [case testModuleLevelGetattrImportFrom]
-
 from has_attr import name
 reveal_type(name)  # E: Revealed type is 'Any'
 
 [file has_attr.pyi]
 from typing import Any
-
 def __getattr__(name: str) -> Any: ...
 
 [builtins fixtures/module.pyi]
 
 [case testModuleLevelGetattrImportFromRetType]
-
 from has_attr import int_attr
-
 reveal_type(int_attr)  # E: Revealed type is 'builtins.int'
 
 [file has_attr.pyi]
-
 def __getattr__(name: str) -> int: ...
 
 [builtins fixtures/module.pyi]
 
 [case testModuleLevelGetattrImportFromNotStub]
-
 from non_stub import name
-
 reveal_type(name)
 
 [file non_stub.py]
 from typing import Any
-
 def __getattr__(name: str) -> Any: ...
 
 [out]
@@ -1810,15 +1802,12 @@ main:4: error: Revealed type is 'Any'
 [builtins fixtures/module.pyi]
 
 [case testModuleLevelGetattrImportFromAs]
-
 from has_attr import name as n
-
 reveal_type(name)
 reveal_type(n)
 
 [file has_attr.pyi]
 from typing import Any
-
 def __getattr__(name: str) -> Any: ...
 
 [out]


### PR DESCRIPTION
PEP 484 specifies one can `def __getattr__(name): ...` to specify that
unresolved names should be Any (or the return type of the `__getattr__`
method). This change adds support for access to these attributes via the
`from module import name` pattern. The `module.name` pattern is already
supported.