### PR TITLE
Fix crash with unanalyzed branches and old-html report

### DIFF
--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -332,7 +332,8 @@ def generate_html_report(tree: MypyFile, path: str, type_map: Dict[Expression, T
             status = visitor.line_map.get(lineno, TYPE_PRECISE)
             style_map = {TYPE_PRECISE: 'white',
                          TYPE_IMPRECISE: 'yellow',
-                         TYPE_ANY: 'red'}
+                         TYPE_ANY: 'red',
+                         TYPE_UNANALYZED: 'red'}
             style = style_map[status]
             append('<span class="lineno">%4d</span>   ' % lineno +
                    '<span class="%s">%s</span>' % (style,


### PR DESCRIPTION
I think the right solution would be to remove `--old-html-report` altogether. What do you think?