### PR TITLE
add config option to skip package checking

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -187,6 +187,8 @@ overridden by the pattern sections matching the module name.
 - ``no_implicit_optional`` (Boolean, default false) changes the treatment of
   arguments with a default value of None by not implicitly making their type Optional
 
+- ``skip`` (Boolean, default False) skip typechecking in given package.
+
 Example
 *******
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1358,6 +1358,10 @@ class State:
             self.import_context = []
         self.id = id or '__main__'
         self.options = manager.options.clone_for_module(self.id)
+
+        if self.options.skip:
+            raise ModuleNotFound
+
         if not path and source is None:
             file_id = id
             if id == 'builtins' and self.options.python_version[0] == 2:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -625,6 +625,7 @@ config_types = {
     'silent_imports': bool,
     'almost_silent': bool,
     'plugins': lambda s: [p.strip() for p in s.split(',')],
+    'skip': bool,
 }
 
 SHARED_CONFIG_FILES = ('setup.cfg',)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -34,6 +34,7 @@ class Options:
         "no_implicit_optional",
         "strict_optional",
         "disallow_untyped_decorators",
+        "skip",
     }
 
     OPTIONS_AFFECTING_CACHE = ((PER_MODULE_OPTIONS | {"quick_and_dirty", "platform"})
@@ -149,6 +150,7 @@ class Options:
         self.shadow_file = None  # type: Optional[Tuple[str, str]]
         self.show_column_numbers = False  # type: bool
         self.dump_graph = False
+        self.skip = False
 
     def __eq__(self, other: object) -> bool:
         return self.__class__ == other.__class__ and self.__dict__ == other.__dict__


### PR DESCRIPTION
Hi,
this could be partially related to #626.

This PR adds a new option into the per-module section in config file, which would allow to skip typechecks in a given package. 

Example for skipping any packages in `kiwi.schemas`:

```
[mypy-kiwi.schemas.*]
skip = true
```

Thanks for any feedback.