### PR TITLE
Add ability to report on linecounts of specific flags

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -175,7 +175,7 @@ def build(sources: List[BuildSource],
     if alt_lib_path:
         lib_path.insert(0, alt_lib_path)
 
-    reports = Reports(data_dir, options.report_dirs)
+    reports = Reports(data_dir, options.report_dirs, options)
     source_set = BuildSourceSet(sources)
     errors = Errors(options.show_error_context, options.show_column_numbers)
     plugin = load_plugins(options, errors)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -364,6 +364,11 @@ def process_options(args: List[str],
                                   metavar='DIR',
                                   dest='special-opts:%s_report' % report_type)
 
+    parser.add_argument('--linecount-breakdown', action='append', metavar='OPTION',
+                        dest='linecount_report_breakdowns',
+                        help='Generate an additional linecount report which '
+                        'tracks only files with OPTION enabled.')
+
     code_group = parser.add_argument_group(title='How to specify the code to type check')
     code_group.add_argument('-m', '--module', action='append', metavar='MODULE',
                             dest='special-opts:modules',

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -141,6 +141,9 @@ class Options:
         # Use stub builtins fixtures to speed up tests
         self.use_builtins_fixtures = False
 
+        # -- report options --
+        self.linecount_report_breakdowns = []  # type: List[str]
+
         # -- experimental options --
         self.shadow_file = None  # type: Optional[Tuple[str, str]]
         self.show_column_numbers = False  # type: bool

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -149,11 +149,11 @@ class LineCountReporter(AbstractReporter):
         imputed_annotated_lines = (physical_lines * annotated_funcs // total_funcs
                                    if total_funcs else physical_lines)
 
-        self.counts[tree._fullname] = (imputed_annotated_lines, physical_lines,
-                                       annotated_funcs, total_funcs)
+        self.counts[tree.fullname()] = (imputed_annotated_lines, physical_lines,
+                                        annotated_funcs, total_funcs)
         for option in self.breakdowns:
             if getattr(options, option):
-                self.breakdown_counts[option][tree._fullname] = (
+                self.breakdown_counts[option][tree.fullname()] = (
                     imputed_annotated_lines, physical_lines, annotated_funcs, total_funcs
                 )
 

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -26,8 +26,8 @@ try:
 except ImportError:
     LXML_INSTALLED = False
 
-
-reporter_classes = {}  # type: Dict[str, Tuple[Callable[[Reports, str, Options], AbstractReporter], bool]]
+ReportConstructor = Callable[["Reports", str, Options], "AbstractReporter"]
+reporter_classes = {}  # type: Dict[str, Tuple[ReportConstructor, bool]]
 
 
 class Reports:
@@ -108,10 +108,10 @@ class LineCountReporter(AbstractReporter):
         super().__init__(reports, output_dir, options)
         self.counts = {}  # type: Dict[str, Tuple[int, int, int, int]]
 
-        linecount_breakdowns = options.linecount_report_breakdowns
-        self.linecount_breakdowns = linecount_breakdowns if linecount_breakdowns is not None else []
+        breakdowns = options.linecount_report_breakdowns
+        self.breakdowns = breakdowns if breakdowns is not None else []
         self.breakdown_counts = {
-            option: {} for option in self.linecount_breakdowns
+            option: {} for option in self.breakdowns
         }  # type: Dict[str, Dict[str, Tuple[int, int, int, int]]]
 
         stats.ensure_dir_exists(output_dir)
@@ -139,10 +139,11 @@ class LineCountReporter(AbstractReporter):
 
         self.counts[tree._fullname] = (imputed_annotated_lines, physical_lines,
                                        annotated_funcs, total_funcs)
-        for option in self.linecount_breakdowns:
+        for option in self.breakdowns:
             if getattr(options, option):
-                self.breakdown_counts[option][tree._fullname] = (imputed_annotated_lines, physical_lines,
-                                                          annotated_funcs, total_funcs)
+                self.breakdown_counts[option][tree._fullname] = (
+                    imputed_annotated_lines, physical_lines, annotated_funcs, total_funcs
+                )
 
     def on_finish(self) -> None:
         self._print_counts(self.counts, 'linecount.txt')

--- a/mypy/test/testgraph.py
+++ b/mypy/test/testgraph.py
@@ -44,7 +44,7 @@ class GraphSuite(Suite):
             lib_path=[],
             ignore_prefix='',
             source_set=BuildSourceSet([]),
-            reports=Reports('', {}),
+            reports=Reports('', {}, Options()),
             options=options,
             version_id=__version__,
             plugin=Plugin(options),


### PR DESCRIPTION
For example: `mypy --config-file mypy_self_check.ini --linecount-report linecounts --linecount-breakdown strict_optional mypy` tells me that mypy has 24,054 lines of checked strict Optional code.