### PR TITLE
Add --ignore-imports option to ignore imports of specific modules (#3476)

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1401,7 +1401,8 @@ class State:
                 # misspelled module name, missing stub, module not in
                 # search path or the module has not been installed.
                 if caller_state:
-                    if not self.options.ignore_missing_imports:
+                    if (not self.options.ignore_missing_imports
+                            and id not in self.options.ignore_imports):
                         save_import_context = manager.errors.import_context()
                         manager.errors.set_import_context(caller_state.import_context)
                         manager.module_not_found(caller_state.xpath, caller_line, id)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -246,6 +246,9 @@ def process_options(args: List[str],
                         const=defaults.PYTHON2_VERSION, help="use Python 2 mode")
     parser.add_argument('--ignore-missing-imports', action='store_true',
                         help="silently ignore imports of missing modules")
+    parser.add_argument('--ignore-imports', action='append',
+                        help="silently ignore imports of the given module (may"
+                             " be specified more than once)")
     parser.add_argument('--follow-imports', choices=['normal', 'silent', 'skip', 'error'],
                         default='normal', help="how to treat imports (default normal)")
     parser.add_argument('--disallow-any', type=disallow_any_argument_type, default=[],
@@ -617,6 +620,7 @@ config_types = {
     'custom_typing_module': str,
     'custom_typeshed_dir': str,
     'mypy_path': lambda s: [p.strip() for p in re.split('[,:]', s)],
+    'ignore_imports': lambda s: [p.strip() for p in s.split('.')],
     'junit_xml': str,
     'disallow_any': disallow_any_argument_type,
     # These two are for backwards compatibility

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -48,6 +48,7 @@ class Options:
         self.mypy_path = []  # type: List[str]
         self.report_dirs = {}  # type: Dict[str, str]
         self.ignore_missing_imports = False
+        self.ignore_imports = []  # type: List[str]
         self.follow_imports = 'normal'  # normal|silent|skip|error
         self.disallow_any = []  # type: List[str]
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -502,6 +502,21 @@ ignore_missing_imports = True
 [out]
 main.py:2: error: Revealed type is 'Any'
 
+[case testConfigIgnoreImports]
+# cmd: mypy main.py
+[file main.py]
+import ignored  # No error here
+import missing  # But error here
+reveal_type(missing.x)  # Expect Any
+[file mypy.ini]
+[[mypy]
+ignore_imports =
+    ignored
+[out]
+main.py:2: error: Cannot find module named 'missing'
+main.py:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main.py:3: error: Revealed type is 'Any'
+
 [case testDotInFilenameOKScript]
 # cmd: mypy a.b.py c.d.pyi
 [file a.b.py]


### PR DESCRIPTION
This is essentially a per-module version of --ignore-missing-imports.
It only supports matching the full name that is used to import the
module (so `--ignore-import foo` will not cause `import foo.bar` to be
ignored).

This addresses #3476.