### PR TITLE
Don't supply a context to the expression in `yield from`

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2340,7 +2340,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         # thus decorated.  But it accepts a generator regardless of
         # how it's decorated.
         return_type = self.chk.return_types[-1]
-        subexpr_type = self.accept(e.expr, return_type)
+        # TODO: What should the context for the sub-expression be?
+        # If the containing function has type Generator[X, Y, ...],
+        # the context should be Generator[X, Y, T], where T is the
+        # context of the 'yield from' itself (but it isn't known).
+        subexpr_type = self.accept(e.expr)
         iter_type = None  # type: Type
 
         # Check that the expr is an instance of Iterable and get the type of the iterator produced

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1136,9 +1136,8 @@ def f() -> Iterator[None]:
 
 -- Yield from statement
 -- --------------------
-
--- Iterables
--- ----------
+--
+-- (It's not really a statement, but don't want to move the tests.)
 
 [case testSimpleYieldFromWithIterator]
 from typing import Iterator
@@ -1215,6 +1214,15 @@ def f(a):
     b = yield from a
     return b
 [out]
+
+[case testYieldFromGenericCall]
+from typing import Generator, TypeVar
+T = TypeVar('T')
+def f(a: T) -> Generator[int, str, T]: pass
+def g() -> Generator[int, str, float]:
+    r = yield from f('')
+    reveal_type(r)  # E: Revealed type is 'builtins.str*'
+    return 3.14
 
 -- With statement
 -- --------------


### PR DESCRIPTION
The actual expected type is complicated; it should be either a
Generator[X, Y, Z] sharing X and Y with the containing generator
function, or an Iterable[X].

Fixes #3808.
