### PR TITLE
Fix ambiguous identifiers.

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1031,22 +1031,23 @@ def plural_s(s: Sequence[Any]) -> str:
 
 
 def format_string_list(s: Iterable[str]) -> str:
-    l = list(s)
-    assert len(l) > 0
-    if len(l) == 1:
-        return l[0]
-    elif len(l) <= 5:
-        return '%s and %s' % (', '.join(l[:-1]), l[-1])
+    lst = list(s)
+    assert len(lst) > 0
+    if len(lst) == 1:
+        return lst[0]
+    elif len(lst) <= 5:
+        return '%s and %s' % (', '.join(lst[:-1]), lst[-1])
     else:
-        return '%s, ... and %s (%i methods suppressed)' % (', '.join(l[:2]), l[-1], len(l) - 3)
+        return '%s, ... and %s (%i methods suppressed)' % (
+            ', '.join(lst[:2]), lst[-1], len(lst) - 3)
 
 
 def format_item_name_list(s: Iterable[str]) -> str:
-    l = list(s)
-    if len(l) <= 5:
-        return '(' + ', '.join(["'%s'" % name for name in l]) + ')'
+    lst = list(s)
+    if len(lst) <= 5:
+        return '(' + ', '.join(["'%s'" % name for name in lst]) + ')'
     else:
-        return '(' + ', '.join(["'%s'" % name for name in l[:5]]) + ', ...)'
+        return '(' + ', '.join(["'%s'" % name for name in lst[:5]]) + ', ...)'
 
 
 def callable_name(type: CallableType) -> str:

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -175,12 +175,12 @@ class StrConv(NodeVisitor[str]):
         return self.dump(a, o)
 
     def visit_var(self, o: 'mypy.nodes.Var') -> str:
-        l = ''
+        lst = ''
         # Add :nil line number tag if no line number is specified to remain
         # compatible with old test case descriptions that assume this.
         if o.line < 0:
-            l = ':nil'
-        return 'Var' + l + '(' + o.name() + ')'
+            lst = ':nil'
+        return 'Var' + lst + '(' + o.name() + ')'
 
     def visit_global_decl(self, o: 'mypy.nodes.GlobalDecl') -> str:
         return self.dump([o.names], o)

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -38,10 +38,10 @@ def parse_test_cases(
     if not include_path:
         include_path = os.path.dirname(path)
     with open(path, encoding='utf-8') as f:
-        l = f.readlines()
-    for i in range(len(l)):
-        l[i] = l[i].rstrip('\n')
-    p = parse_test_data(l, path)
+        lst = f.readlines()
+    for i in range(len(lst)):
+        lst[i] = lst[i].rstrip('\n')
+    p = parse_test_data(lst, path)
     out = []  # type: List[DataDrivenTestCase]
 
     # Process the parsed items. Each item has a header of form [id args],


### PR DESCRIPTION
This makes mypy flake8-clean on flake8 trunk, which enabled a new pycodestyle check for ambiguous identifiers (E741).