### PR TITLE
Erase typevars of generic types when used in Type[C]

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -154,6 +154,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         elif isinstance(node, TypeInfo):
             # Reference to a type object.
             result = type_object_type(node, self.named_type)
+            if isinstance(self.type_context[-1], TypeType):
+                # This is the type in a Type[] expression, so substitute type
+                # variables with Any.
+                result = erasetype.erase_typevars(result)
         elif isinstance(node, MypyFile):
             # Reference to a module object.
             try:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3373,6 +3373,17 @@ reveal_type(f(e1t))  # E: Revealed type is '__main__.A'
 
 reveal_type(f(''))  # E: Revealed type is 'builtins.str'
 
+[case testTypeCErasesGenericsFromC]
+from typing import Generic, Type, TypeVar
+
+K = TypeVar('K')
+V = TypeVar('V')
+class ExampleDict(Generic[K, V]): ...
+
+D = TypeVar('D')
+def mkdict(dict_type: Type[D]) -> D: ...
+reveal_type(mkdict(ExampleDict))  # E: Revealed type is '__main__.ExampleDict*[Any, Any]'
+
 -- Synthetic types crashes
 -- -----------------------
 


### PR DESCRIPTION
Prior to this commit, when generic types are used as the C in a Type[C]
expression, they don't have their typevars substituted; this leads to
the internal type variables of their implementations leaking out in a
way that makes them difficult to use.

Instead, we now erase those typevars to Any.  This fixes #3824.