### PR TITLE
Attempt to expand Type[C] calls using C's upper bound

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -156,7 +156,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             result = type_object_type(node, self.named_type)
             if isinstance(self.type_context[-1], TypeType):
                 # This is the type in a Type[] expression, so substitute type
-                # variables with Any.
+                # variables. Use the upper bound if applicable, or Any if we
+                # don't have a useful upper bound.
+                target_type = self.type_context[-1].item
+                if (isinstance(target_type, TypeVarType)
+                        and isinstance(target_type.upper_bound, Instance)):
+                    result = expand_type_by_instance(
+                        result, target_type.upper_bound)
                 result = erasetype.erase_typevars(result)
         elif isinstance(node, MypyFile):
             # Reference to a module object.

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3384,6 +3384,19 @@ D = TypeVar('D')
 def mkdict(dict_type: Type[D]) -> D: ...
 reveal_type(mkdict(ExampleDict))  # E: Revealed type is '__main__.ExampleDict*[Any, Any]'
 
+[case testTypeCRetainsBoundsFromC]
+from typing import Generic, Type, TypeVar
+
+K = TypeVar('K')
+V = TypeVar('V')
+class ExampleDict(Generic[K, V]): ...
+
+class SubclassDict(ExampleDict[K, V]): ...
+
+D = TypeVar('D', bound=ExampleDict[str, str])
+def mkdict(dict_type: Type[D]) -> D: ...
+reveal_type(mkdict(SubclassDict))  # E: Revealed type is '__main__.SubclassDict*[builtins.str, builtins.str]'
+
 -- Synthetic types crashes
 -- -----------------------
 


### PR DESCRIPTION
When C in Type[C] is a type variable with an upper bound, use that upper
bound to realise type variables in Type[C] instead of just erasing them.

This allows, for example, `instance` in the following to typecheck as
dict[str, str] instead of dict[Any, Any].

```
C = TypeVar('C', upper_bound=Mapping[str, str])
def func(param: Type[C]) -> C: ...
instance = func(dict)
```