### PR TITLE
Switch typeshed submodule URL to `https`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "typeshed"]
 	path = typeshed
-	url = http://github.com/python/typeshed
+	url = https://github.com/python/typeshed


### PR DESCRIPTION
Not only is this more hip to the future of the Web -- but right now
GitHub is failing to respond most of the time on port 80 for me, while
things work fine for the `https` URL.
