### PR TITLE
Even more strict optional

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1545,8 +1545,7 @@ class State:
         self.manager.modules[self.id] = self.tree
 
     def fix_cross_refs(self) -> None:
-        assert self.tree is not None, "Internal error: this method must be called only" \
-                                      " for cached modules"
+        assert self.tree is not None, "Internal error: method must be called on parsed file only"
         fixup_module_pass_one(self.tree, self.manager.modules,
                               self.manager.options.quick_and_dirty)
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -116,8 +116,8 @@ class BuildSourceSet:
 
 def build(sources: List[BuildSource],
           options: Options,
-          alt_lib_path: str = None,
-          bin_dir: str = None) -> BuildResult:
+          alt_lib_path: Optional[str] = None,
+          bin_dir: Optional[str] = None) -> BuildResult:
     """Analyze a program.
 
     A single call to build performs parsing, semantic analysis and optionally

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -21,7 +21,7 @@ import sys
 import time
 from os.path import dirname, basename
 
-from typing import (AbstractSet, Dict, Iterable, Iterator, List,
+from typing import (AbstractSet, Dict, Iterable, Iterator, List, cast, Any,
                     NamedTuple, Optional, Set, Tuple, Union, Callable)
 # Can't use TYPE_CHECKING because it's not in the Python 3.5.1 stdlib
 MYPY = False
@@ -643,7 +643,7 @@ def remove_cwd_prefix_from_path(p: str) -> str:
 
 
 # Cache find_module: (id, lib_path) -> result.
-find_module_cache = {}  # type: Dict[Tuple[str, Tuple[str, ...]], str]
+find_module_cache = {}  # type: Dict[Tuple[str, Tuple[str, ...]], Optional[str]]
 
 # Cache some repeated work within distinct find_module calls: finding which
 # elements of lib_path have even the subdirectory they'd need for the module
@@ -673,7 +673,7 @@ def list_dir(path: str) -> Optional[List[str]]:
     if path in find_module_listdir_cache:
         return find_module_listdir_cache[path]
     try:
-        res = os.listdir(path)
+        res = os.listdir(path)  # type: Optional[List[str]]
     except OSError:
         res = None
     find_module_listdir_cache[path] = res
@@ -698,7 +698,7 @@ def is_file(path: str) -> bool:
     return os.path.isfile(path)
 
 
-def find_module(id: str, lib_path_arg: Iterable[str]) -> str:
+def find_module(id: str, lib_path_arg: Iterable[str]) -> Optional[str]:
     """Return the path of the module source file, or None if not found."""
     lib_path = tuple(lib_path_arg)
 
@@ -873,21 +873,22 @@ def find_cache_meta(id: str, path: str, manager: BuildManager) -> Optional[Cache
         manager.log('Could not load cache for {}: meta cache is not a dict: {}'
                     .format(id, repr(meta)))
         return None
+    sentinel = None  # type: Any  # the values will be post-validated below
     m = CacheMeta(
-        meta.get('id'),
-        meta.get('path'),
-        int(meta['mtime']) if 'mtime' in meta else None,
-        meta.get('size'),
-        meta.get('hash'),
+        meta.get('id', sentinel),
+        meta.get('path', sentinel),
+        int(meta['mtime']) if 'mtime' in meta else sentinel,
+        meta.get('size', sentinel),
+        meta.get('hash', sentinel),
         meta.get('dependencies', []),
-        int(meta['data_mtime']) if 'data_mtime' in meta else None,
+        int(meta['data_mtime']) if 'data_mtime' in meta else sentinel,
         data_json,
         meta.get('suppressed', []),
         meta.get('child_modules', []),
         meta.get('options'),
         meta.get('dep_prios', []),
         meta.get('interface_hash', ''),
-        meta.get('version_id'),
+        meta.get('version_id', sentinel),
     )
     # Don't check for path match, that is dealt with in validate_meta().
     if (m.id != id or
@@ -944,7 +945,7 @@ def atomic_write(filename: str, *lines: str) -> bool:
     return True
 
 
-def validate_meta(meta: Optional[CacheMeta], id: str, path: str,
+def validate_meta(meta: Optional[CacheMeta], id: str, path: Optional[str],
                   manager: BuildManager) -> Optional[CacheMeta]:
     '''Checks whether the cached AST of this module can be used.
 
@@ -961,7 +962,7 @@ def validate_meta(meta: Optional[CacheMeta], id: str, path: str,
     if meta is None:
         manager.log('Metadata not found for {}'.format(id))
         return None
-
+    assert path is not None, "Internal error: meta was provided without a path"
     # Check data_json; assume if its mtime matches it's good.
     # TODO: stat() errors
     data_mtime = getmtime(meta.data_json)
@@ -1312,7 +1313,7 @@ class State:
     ancestors = None  # type: Optional[List[str]]
 
     # A list of all direct submodules of a given module
-    child_modules = None  # type: Optional[Set[str]]
+    child_modules = None  # type: Set[str]
 
     # List of (path, line number) tuples giving context for import
     import_context = None  # type: List[Tuple[str, int]]
@@ -1340,9 +1341,9 @@ class State:
                  path: Optional[str],
                  source: Optional[str],
                  manager: BuildManager,
-                 caller_state: 'State' = None,
+                 caller_state: 'Optional[State]' = None,
                  caller_line: int = 0,
-                 ancestor_for: 'State' = None,
+                 ancestor_for: 'Optional[State]' = None,
                  root_source: bool = False,
                  ) -> None:
         assert id or path or source is not None, "Neither id, path nor source given"
@@ -1359,6 +1360,7 @@ class State:
         self.id = id or '__main__'
         self.options = manager.options.clone_for_module(self.id)
         if not path and source is None:
+            assert id is not None
             file_id = id
             if id == 'builtins' and self.options.python_version[0] == 2:
                 # The __builtin__ module is called internally by mypy
@@ -1417,7 +1419,7 @@ class State:
         self.xpath = path or '<string>'
         self.source = source
         if path and source is None and self.options.incremental:
-            self.meta = find_cache_meta(self.id, self.path, manager)
+            self.meta = find_cache_meta(self.id, path, manager)
             # TODO: Get mtime if not cached.
             if self.meta is not None:
                 self.interface_hash = self.meta.interface_hash
@@ -1534,6 +1536,8 @@ class State:
     # Methods for processing cached modules.
 
     def load_tree(self) -> None:
+        assert self.meta is not None, "Internal error: this method must be called only" \
+                                      " for cached modules"
         with open(self.meta.data_json) as f:
             data = json.load(f)
         # TODO: Assert data file wasn't changed.
@@ -1541,10 +1545,13 @@ class State:
         self.manager.modules[self.id] = self.tree
 
     def fix_cross_refs(self) -> None:
+        assert self.tree is not None, "Internal error: this method must be called only" \
+                                      " for cached modules"
         fixup_module_pass_one(self.tree, self.manager.modules,
                               self.manager.options.quick_and_dirty)
 
     def calculate_mros(self) -> None:
+        assert self.tree is not None, "Internal error: method must be called on parsed file only"
         fixup_module_pass_two(self.tree, self.manager.modules,
                               self.manager.options.quick_and_dirty)
 
@@ -1626,6 +1633,7 @@ class State:
                 except (UnicodeDecodeError, DecodeError) as decodeerr:
                     raise CompileError([
                         "mypy: can't decode file '{}': {}".format(self.path, str(decodeerr))])
+            assert source is not None
             self.tree = manager.parse_file(self.id, self.xpath, source,
                                            self.ignore_all or self.options.ignore_errors)
 
@@ -1689,12 +1697,14 @@ class State:
         self.check_blockers()
 
     def semantic_analysis(self) -> None:
+        assert self.tree is not None, "Internal error: method must be called on parsed file only"
         patches = []  # type: List[Callable[[], None]]
         with self.wrap_context():
             self.manager.semantic_analyzer.visit_file(self.tree, self.xpath, self.options, patches)
         self.patches = patches
 
     def semantic_analysis_pass_three(self) -> None:
+        assert self.tree is not None, "Internal error: method must be called on parsed file only"
         with self.wrap_context():
             self.manager.semantic_analyzer_pass3.visit_file(self.tree, self.xpath, self.options)
             if self.options.dump_type_stats:
@@ -1705,6 +1715,7 @@ class State:
             patch_func()
 
     def type_check_first_pass(self) -> None:
+        assert self.tree is not None, "Internal error: method must be called on parsed file only"
         manager = self.manager
         if self.options.semantic_analysis_only:
             return
@@ -1720,6 +1731,7 @@ class State:
             return self.type_checker.check_second_pass()
 
     def finish_passes(self) -> None:
+        assert self.tree is not None, "Internal error: method must be called on parsed file only"
         manager = self.manager
         if self.options.semantic_analysis_only:
             return
@@ -1739,7 +1751,7 @@ class State:
                                      module_refs: Set[str],
                                      type_map: Dict[Expression, Type]) -> None:
         types = set(type_map.values())
-        types.discard(None)
+        assert None not in types
         valid = self.valid_references()
 
         encountered = self.manager.indirection_detector.find_modules(types) | module_refs
@@ -1755,8 +1767,9 @@ class State:
                 self.suppressed.append(dep)
 
     def valid_references(self) -> Set[str]:
+        assert self.ancestors is not None
         valid_refs = set(self.dependencies + self.suppressed + self.ancestors)
-        valid_refs .add(self.id)
+        valid_refs.add(self.id)
 
         if "os" in valid_refs:
             valid_refs.add("os.path")
@@ -1764,6 +1777,7 @@ class State:
         return valid_refs
 
     def write_cache(self) -> None:
+        assert self.tree is not None, "Internal error: method must be called on parsed file only"
         if not self.path or self.options.cache_dir == os.devnull:
             return
         if self.manager.options.quick_and_dirty:
@@ -1884,6 +1898,7 @@ def load_graph(sources: List[BuildSource], manager: BuildManager) -> Graph:
     # Collect dependencies.  We go breadth-first.
     while new:
         st = new.popleft()
+        assert st.ancestors is not None
         for dep in st.ancestors + st.dependencies + st.suppressed:
             # We don't want to recheck imports marked with '# type: ignore'
             # so we ignore any suppressed module not explicitly re-included
@@ -1922,6 +1937,10 @@ def load_graph(sources: List[BuildSource], manager: BuildManager) -> Graph:
             g.fix_suppressed_dependencies(graph)
             g.mark_interface_stale()
     return graph
+
+
+class FreshState(State):
+    meta = None  # type: CacheMeta
 
 
 def process_graph(graph: Graph, manager: BuildManager) -> None:
@@ -1978,23 +1997,25 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
         if fresh:
             # All cache files are fresh.  Check that no dependency's
             # cache file is newer than any scc node's cache file.
-            oldest_in_scc = min(graph[id].meta.data_mtime for id in scc)
+            fresh_graph = cast(Dict[str, FreshState], graph)
+            oldest_in_scc = min(fresh_graph[id].meta.data_mtime for id in scc)
             viable = {id for id in stale_deps if graph[id].meta is not None}
-            newest_in_deps = 0 if not viable else max(graph[dep].meta.data_mtime for dep in viable)
+            newest_in_deps = 0 if not viable else max(fresh_graph[dep].meta.data_mtime
+                                                      for dep in viable)
             if manager.options.verbosity >= 3:  # Dump all mtimes for extreme debugging.
-                all_ids = sorted(ascc | viable, key=lambda id: graph[id].meta.data_mtime)
+                all_ids = sorted(ascc | viable, key=lambda id: fresh_graph[id].meta.data_mtime)
                 for id in all_ids:
                     if id in scc:
-                        if graph[id].meta.data_mtime < newest_in_deps:
+                        if fresh_graph[id].meta.data_mtime < newest_in_deps:
                             key = "*id:"
                         else:
                             key = "id:"
                     else:
-                        if graph[id].meta.data_mtime > oldest_in_scc:
+                        if fresh_graph[id].meta.data_mtime > oldest_in_scc:
                             key = "+dep:"
                         else:
                             key = "dep:"
-                    manager.trace(" %5s %.0f %s" % (key, graph[id].meta.data_mtime, id))
+                    manager.trace(" %5s %.0f %s" % (key, fresh_graph[id].meta.data_mtime, id))
             # If equal, give the benefit of the doubt, due to 1-sec time granularity
             # (on some platforms).
             if manager.options.quick_and_dirty and stale_deps:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3110,6 +3110,11 @@ def is_unsafe_overlapping_signatures(signature: Type, other: Type) -> bool:
             # latter will never be called
             if is_more_general_arg_prefix(signature, other):
                 return False
+            # Special case: all args are subtypes, and returns are subtypes
+            if (all(is_proper_subtype(s, o)
+                    for (s, o) in zip(signature.arg_types, other.arg_types)) and
+                    is_proper_subtype(signature.ret_type, other.ret_type)):
+                return False
             return not is_more_precise_signature(signature, other)
     return True
 

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -530,7 +530,7 @@ def remove_path_prefix(path: str, prefix: str) -> str:
         return path
 
 
-def report_internal_error(err: Exception, file: str, line: int,
+def report_internal_error(err: Exception, file: Optional[str], line: int,
                           errors: Errors, options: Options) -> None:
     """Report internal error and exit.
 
@@ -545,13 +545,16 @@ def report_internal_error(err: Exception, file: str, line: int,
         print("Failed to dump errors:", repr(e), file=sys.stderr)
 
     # Compute file:line prefix for official-looking error messages.
-    if line:
-        prefix = '{}:{}'.format(file, line)
+    if file:
+        if line:
+            prefix = '{}:{}: '.format(file, line)
+        else:
+            prefix = '{}: '.format(file)
     else:
-        prefix = file
+        prefix = ''
 
     # Print "INTERNAL ERROR" message.
-    print('{}: error: INTERNAL ERROR --'.format(prefix),
+    print('{}error: INTERNAL ERROR --'.format(prefix),
           'please report a bug at https://github.com/python/mypy/issues',
           'version: {}'.format(mypy_version),
           file=sys.stderr)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -986,13 +986,7 @@ class TypeConverter(ast3.NodeTransformer):
         self.line = line
         self.node_stack = []  # type: List[ast3.AST]
 
-    @overload
-    def visit(self, node: ast3.expr) -> Type: ...
-
-    @overload  # noqa
-    def visit(self, node: Optional[ast3.AST]) -> Optional[Type]: ...
-
-    def visit(self, node: Optional[ast3.AST]) -> Optional[Type]:  # noqa
+    def _visit_implementation(self, node: Optional[ast3.AST]) -> Optional[Type]:
         """Modified visit -- keep track of the stack of nodes"""
         if node is None:
             return None
@@ -1001,6 +995,19 @@ class TypeConverter(ast3.NodeTransformer):
             return super().visit(node)
         finally:
             self.node_stack.pop()
+
+    if sys.version_info >= (3, 6):
+        @overload
+        def visit(self, node: ast3.expr) -> Type: ...
+
+        @overload  # noqa
+        def visit(self, node: Optional[ast3.AST]) -> Optional[Type]: ...
+
+        def visit(self, node: Optional[ast3.AST]) -> Optional[Type]:  # noqa
+            return self._visit_implementation(node)
+    else:
+        def visit(self, node: Optional[ast3.AST]) -> Any:
+            return self._visit_implementation(node)
 
     def parent(self) -> Optional[ast3.AST]:
         """Return the AST node above the one we are processing"""

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1,7 +1,9 @@
 from functools import wraps
 import sys
 
-from typing import Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, cast, List, Set
+from typing import (
+    Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, cast, List, Set, overload
+)
 from mypy.sharedparse import (
     special_function_elide_names, argument_elide_name,
 )
@@ -56,12 +58,16 @@ T = TypeVar('T', bound=Union[ast3.expr, ast3.stmt])
 U = TypeVar('U', bound=Node)
 V = TypeVar('V')
 
+# There is no way to create reasonable fallbacks at this stage,
+# they must be patched later.
+_dummy_fallback = None  # type: Any
+
 TYPE_COMMENT_SYNTAX_ERROR = 'syntax error in type comment'
 TYPE_COMMENT_AST_ERROR = 'invalid type comment or annotation'
 
 
 def parse(source: Union[str, bytes],
-          fnam: Optional[str] = None,
+          fnam: str,
           errors: Optional[Errors] = None,
           options: Options = Options()) -> MypyFile:
 
@@ -74,8 +80,8 @@ def parse(source: Union[str, bytes],
     if errors is None:
         errors = Errors()
         raise_on_error = True
-    errors.set_file('<input>' if fnam is None else fnam, None)
-    is_stub_file = bool(fnam) and fnam.endswith('.pyi')
+    errors.set_file(fnam, None)
+    is_stub_file = fnam.endswith('.pyi')
     try:
         if is_stub_file:
             feature_version = defaults.PYTHON3_VERSION[1]
@@ -123,7 +129,7 @@ def with_line(f: Callable[['ASTConverter', T], U]) -> Callable[['ASTConverter', 
     return wrapper
 
 
-def find(f: Callable[[V], bool], seq: Sequence[V]) -> V:
+def find(f: Callable[[V], bool], seq: Sequence[V]) -> Optional[V]:
     for item in seq:
         if f(item):
             return item
@@ -157,14 +163,16 @@ class ASTConverter(ast3.NodeTransformer):
     def generic_visit(self, node: ast3.AST) -> None:
         raise RuntimeError('AST node not implemented: ' + str(type(node)))
 
-    def visit_NoneType(self, n: Any) -> Optional[Node]:
-        return None
+    def visit(self, node: Optional[ast3.AST]) -> Any:  # same as in typed_ast stub
+        if node is None:
+            return None
+        return super().visit(node)
 
     def translate_expr_list(self, l: Sequence[ast3.AST]) -> List[Expression]:
         res = []  # type: List[Expression]
         for e in l:
             exp = self.visit(e)
-            assert exp is None or isinstance(exp, Expression)
+            isinstance(exp, Expression)
             res.append(exp)
         return res
 
@@ -172,7 +180,7 @@ class ASTConverter(ast3.NodeTransformer):
         res = []  # type: List[Statement]
         for e in l:
             stmt = self.visit(e)
-            assert stmt is None or isinstance(stmt, Statement)
+            isinstance(stmt, Statement)
             res.append(stmt)
         return res
 
@@ -219,11 +227,17 @@ class ASTConverter(ast3.NodeTransformer):
         else:
             return op_name
 
-    def as_block(self, stmts: List[ast3.stmt], lineno: int) -> Block:
+    def as_block(self, stmts: List[ast3.stmt], lineno: int) -> Optional[Block]:
         b = None
         if stmts:
             b = Block(self.fix_function_overloads(self.translate_stmt_list(stmts)))
             b.set_line(lineno)
+        return b
+
+    def as_required_block(self, stmts: List[ast3.stmt], lineno: int) -> Block:
+        assert stmts  # must be non-empty
+        b = Block(self.fix_function_overloads(self.translate_stmt_list(stmts)))
+        b.set_line(lineno)
         return b
 
     def fix_function_overloads(self, stmts: List[Statement]) -> List[Statement]:
@@ -308,7 +322,7 @@ class ASTConverter(ast3.NodeTransformer):
         arg_names = [None if argument_elide_name(name) else name for name in arg_names]
         if special_function_elide_names(n.name):
             arg_names = [None] * len(arg_names)
-        arg_types = None  # type: List[Type]
+        arg_types = []  # type: List[Optional[Type]]
         if no_type_check:
             arg_types = [None] * len(args)
             return_type = None
@@ -368,11 +382,11 @@ class ASTConverter(ast3.NodeTransformer):
                                          arg_names,
                                          return_type if return_type is not None else
                                          AnyType(TypeOfAny.implicit),
-                                         None)
+                                         _dummy_fallback)
 
         func_def = FuncDef(n.name,
                        args,
-                       self.as_block(n.body, n.lineno),
+                       self.as_required_block(n.body, n.lineno),
                        func_type)
         if is_coroutine:
             # A coroutine is also a generator, mostly for internal reasons.
@@ -393,7 +407,7 @@ class ASTConverter(ast3.NodeTransformer):
         else:
             return func_def
 
-    def set_type_optional(self, type: Type, initializer: Expression) -> None:
+    def set_type_optional(self, type: Optional[Type], initializer: Optional[Expression]) -> None:
         if self.options.no_implicit_optional:
             return
         # Indicate that type should be wrapped in an Optional if arg is initialized to None.
@@ -472,10 +486,10 @@ class ASTConverter(ast3.NodeTransformer):
             if metaclass is None:
                 metaclass = '<error>'  # To be reported later
         keywords = [(kw.arg, self.visit(kw.value))
-                    for kw in n.keywords]
+                    for kw in n.keywords if kw.arg]
 
         cdef = ClassDef(n.name,
-                        self.as_block(n.body, n.lineno),
+                        self.as_required_block(n.body, n.lineno),
                         None,
                         self.translate_expr_list(n.bases),
                         metaclass=metaclass,
@@ -518,6 +532,7 @@ class ASTConverter(ast3.NodeTransformer):
         else:
             rvalue = self.visit(n.value)
         typ = TypeConverter(self.errors, line=n.lineno).visit(n.annotation)
+        assert typ is not None
         typ.column = n.annotation.col_offset
         return AssignmentStmt([self.visit(n.target)], rvalue, type=typ, new_syntax=True)
 
@@ -537,7 +552,7 @@ class ASTConverter(ast3.NodeTransformer):
             target_type = None
         return ForStmt(self.visit(n.target),
                        self.visit(n.iter),
-                       self.as_block(n.body, n.lineno),
+                       self.as_required_block(n.body, n.lineno),
                        self.as_block(n.orelse, n.lineno),
                        target_type)
 
@@ -550,7 +565,7 @@ class ASTConverter(ast3.NodeTransformer):
             target_type = None
         r = ForStmt(self.visit(n.target),
                     self.visit(n.iter),
-                    self.as_block(n.body, n.lineno),
+                    self.as_required_block(n.body, n.lineno),
                     self.as_block(n.orelse, n.lineno),
                     target_type)
         r.is_async = True
@@ -560,14 +575,14 @@ class ASTConverter(ast3.NodeTransformer):
     @with_line
     def visit_While(self, n: ast3.While) -> WhileStmt:
         return WhileStmt(self.visit(n.test),
-                         self.as_block(n.body, n.lineno),
+                         self.as_required_block(n.body, n.lineno),
                          self.as_block(n.orelse, n.lineno))
 
     # If(expr test, stmt* body, stmt* orelse)
     @with_line
     def visit_If(self, n: ast3.If) -> IfStmt:
         return IfStmt([self.visit(n.test)],
-                      [self.as_block(n.body, n.lineno)],
+                      [self.as_required_block(n.body, n.lineno)],
                       self.as_block(n.orelse, n.lineno))
 
     # With(withitem* items, stmt* body, string? type_comment)
@@ -579,7 +594,7 @@ class ASTConverter(ast3.NodeTransformer):
             target_type = None
         return WithStmt([self.visit(i.context_expr) for i in n.items],
                         [self.visit(i.optional_vars) for i in n.items],
-                        self.as_block(n.body, n.lineno),
+                        self.as_required_block(n.body, n.lineno),
                         target_type)
 
     # AsyncWith(withitem* items, stmt* body, string? type_comment)
@@ -591,7 +606,7 @@ class ASTConverter(ast3.NodeTransformer):
             target_type = None
         r = WithStmt([self.visit(i.context_expr) for i in n.items],
                      [self.visit(i.optional_vars) for i in n.items],
-                     self.as_block(n.body, n.lineno),
+                     self.as_required_block(n.body, n.lineno),
                      target_type)
         r.is_async = True
         return r
@@ -606,9 +621,9 @@ class ASTConverter(ast3.NodeTransformer):
     def visit_Try(self, n: ast3.Try) -> TryStmt:
         vs = [NameExpr(h.name) if h.name is not None else None for h in n.handlers]
         types = [self.visit(h.type) for h in n.handlers]
-        handlers = [self.as_block(h.body, h.lineno) for h in n.handlers]
+        handlers = [self.as_required_block(h.body, h.lineno) for h in n.handlers]
 
-        return TryStmt(self.as_block(n.body, n.lineno),
+        return TryStmt(self.as_required_block(n.body, n.lineno),
                        vs,
                        types,
                        handlers,
@@ -623,7 +638,7 @@ class ASTConverter(ast3.NodeTransformer):
     # Import(alias* names)
     @with_line
     def visit_Import(self, n: ast3.Import) -> Import:
-        names = []  # type: List[Tuple[str, str]]
+        names = []  # type: List[Tuple[str, Optional[str]]]
         for alias in n.names:
             name = self.translate_module_id(alias.name)
             asname = alias.asname
@@ -640,9 +655,10 @@ class ASTConverter(ast3.NodeTransformer):
     # ImportFrom(identifier? module, alias* names, int? level)
     @with_line
     def visit_ImportFrom(self, n: ast3.ImportFrom) -> ImportBase:
-        i = None  # type: ImportBase
+        assert n.level is not None
         if len(n.names) == 1 and n.names[0].name == '*':
-            i = ImportAll(n.module, n.level)
+            assert n.module is not None
+            i = ImportAll(n.module, n.level)  # type: ImportBase
         else:
             i = ImportFrom(self.translate_module_id(n.module) if n.module is not None else '',
                            n.level,
@@ -687,7 +703,6 @@ class ASTConverter(ast3.NodeTransformer):
     def visit_BoolOp(self, n: ast3.BoolOp) -> OpExpr:
         # mypy translates (1 and 2 and 3) as (1 and (2 and 3))
         assert len(n.values) >= 2
-        op = None
         if isinstance(n.op, ast3.And):
             op = 'and'
         elif isinstance(n.op, ast3.Or):
@@ -740,7 +755,7 @@ class ASTConverter(ast3.NodeTransformer):
         body.col_offset = n.col_offset
 
         return LambdaExpr(self.transform_args(n.args, n.lineno),
-                        self.as_block([body], n.lineno))
+                        self.as_required_block([body], n.lineno))
 
     # IfExp(expr test, expr body, expr orelse)
     @with_line
@@ -835,7 +850,8 @@ class ASTConverter(ast3.NodeTransformer):
         return CallExpr(self.visit(n.func),
                         arg_types,
                         arg_kinds,
-                        cast("List[str]", [None] * len(n.args)) + [k.arg for k in n.keywords])
+                        cast(List[Optional[str]], [None] * len(n.args)) +
+                        [k.arg for k in n.keywords])
 
     # Num(object n) -- a number as a PyObject.
     @with_line
@@ -965,27 +981,36 @@ class ASTConverter(ast3.NodeTransformer):
 
 
 class TypeConverter(ast3.NodeTransformer):
-    def __init__(self, errors: Errors, line: int = -1) -> None:
+    def __init__(self, errors: Optional[Errors], line: int = -1) -> None:
         self.errors = errors
         self.line = line
         self.node_stack = []  # type: List[ast3.AST]
 
-    def visit(self, node: ast3.AST) -> Type:
+    @overload
+    def visit(self, node: ast3.expr) -> Type: ...
+
+    @overload  # noqa
+    def visit(self, node: Optional[ast3.AST]) -> Optional[Type]: ...
+
+    def visit(self, node: Optional[ast3.AST]) -> Optional[Type]:  # noqa
         """Modified visit -- keep track of the stack of nodes"""
+        if node is None:
+            return None
         self.node_stack.append(node)
         try:
             return super().visit(node)
         finally:
             self.node_stack.pop()
 
-    def parent(self) -> ast3.AST:
+    def parent(self) -> Optional[ast3.AST]:
         """Return the AST node above the one we are processing"""
         if len(self.node_stack) < 2:
             return None
         return self.node_stack[-2]
 
     def fail(self, msg: str, line: int, column: int) -> None:
-        self.errors.report(line, column, msg)
+        if self.errors:
+            self.errors.report(line, column, msg)
 
     def visit_raw_str(self, s: str) -> Type:
         # An escape hatch that allows the AST walker in fastparse2 to
@@ -998,10 +1023,7 @@ class TypeConverter(ast3.NodeTransformer):
         self.fail(TYPE_COMMENT_AST_ERROR, self.line, getattr(node, 'col_offset', -1))
         return AnyType(TypeOfAny.from_error)
 
-    def visit_NoneType(self, n: Any) -> Type:
-        return None
-
-    def translate_expr_list(self, l: Sequence[ast3.AST]) -> List[Type]:
+    def translate_expr_list(self, l: Sequence[ast3.expr]) -> List[Type]:
         return [self.visit(e) for e in l]
 
     def visit_Call(self, e: ast3.Call) -> Type:
@@ -1017,7 +1039,9 @@ class TypeConverter(ast3.NodeTransformer):
         typ = default_type  # type: Type
         for i, arg in enumerate(e.args):
             if i == 0:
-                typ = self.visit(arg)
+                converted = self.visit(arg)
+                assert converted is not None
+                typ = converted
             elif i == 1:
                 name = self._extract_argument_name(arg)
             else:
@@ -1034,17 +1058,19 @@ class TypeConverter(ast3.NodeTransformer):
                 if typ is not default_type:
                     self.fail('"{}" gets multiple values for keyword argument "type"'.format(
                         constructor), f.lineno, f.col_offset)
-                typ = self.visit(value)
+                converted = self.visit(value)
+                assert converted is not None
+                typ = converted
             else:
                 self.fail(
                     'Unexpected argument "{}" for argument constructor'.format(k.arg),
                     value.lineno, value.col_offset)
         return CallableArgument(typ, name, constructor, e.lineno, e.col_offset)
 
-    def translate_argument_list(self, l: Sequence[ast3.AST]) -> TypeList:
+    def translate_argument_list(self, l: Sequence[ast3.expr]) -> TypeList:
         return TypeList([self.visit(e) for e in l], line=self.line)
 
-    def _extract_argument_name(self, n: ast3.expr) -> str:
+    def _extract_argument_name(self, n: ast3.expr) -> Optional[str]:
         if isinstance(n, ast3.Str):
             return n.s.strip()
         elif isinstance(n, ast3.NameConstant) and str(n.value) == 'None':
@@ -1087,7 +1113,8 @@ class TypeConverter(ast3.NodeTransformer):
             return AnyType(TypeOfAny.from_error)
 
     def visit_Tuple(self, n: ast3.Tuple) -> Type:
-        return TupleType(self.translate_expr_list(n.elts), None, implicit=True, line=self.line)
+        return TupleType(self.translate_expr_list(n.elts), _dummy_fallback,
+                         implicit=True, line=self.line)
 
     # Attribute(expr value, identifier attr, expr_context ctx)
     def visit_Attribute(self, n: ast3.Attribute) -> Type:

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -69,12 +69,16 @@ T = TypeVar('T', bound=Union[ast27.expr, ast27.stmt])
 U = TypeVar('U', bound=Node)
 V = TypeVar('V')
 
+# There is no way to create reasonable fallbacks at this stage,
+# they must be patched later.
+_dummy_fallback = None  # type: Any
+
 TYPE_COMMENT_SYNTAX_ERROR = 'syntax error in type comment'
 TYPE_COMMENT_AST_ERROR = 'invalid type comment'
 
 
 def parse(source: Union[str, bytes],
-          fnam: Optional[str] = None,
+          fnam: str,
           errors: Optional[Errors] = None,
           options: Options = Options()) -> MypyFile:
     """Parse a source file, without doing any semantic analysis.
@@ -86,8 +90,8 @@ def parse(source: Union[str, bytes],
     if errors is None:
         errors = Errors()
         raise_on_error = True
-    errors.set_file('<input>' if fnam is None else fnam, None)
-    is_stub_file = bool(fnam) and fnam.endswith('.pyi')
+    errors.set_file(fnam, None)
+    is_stub_file = fnam.endswith('.pyi')
     try:
         assert options.python_version[0] < 3 and not is_stub_file
         ast = ast27.parse(source, fnam, 'exec')
@@ -117,7 +121,7 @@ def with_line(f: Callable[['ASTConverter', T], U]) -> Callable[['ASTConverter', 
     return wrapper
 
 
-def find(f: Callable[[V], bool], seq: Sequence[V]) -> V:
+def find(f: Callable[[V], bool], seq: Sequence[V]) -> Optional[V]:
     for item in seq:
         if f(item):
             return item
@@ -151,8 +155,10 @@ class ASTConverter(ast27.NodeTransformer):
     def generic_visit(self, node: ast27.AST) -> None:
         raise RuntimeError('AST node not implemented: ' + str(type(node)))
 
-    def visit_NoneType(self, n: Any) -> Optional[Node]:
-        return None
+    def visit(self, node: Optional[ast27.AST]) -> Any:  # same as in typed_ast stub
+        if node is None:
+            return None
+        return super().visit(node)
 
     def translate_expr_list(self, l: Sequence[ast27.AST]) -> List[Expression]:
         res = []  # type: List[Expression]
@@ -214,11 +220,17 @@ class ASTConverter(ast27.NodeTransformer):
         else:
             return op_name
 
-    def as_block(self, stmts: List[ast27.stmt], lineno: int) -> Block:
+    def as_block(self, stmts: List[ast27.stmt], lineno: int) -> Optional[Block]:
         b = None
         if stmts:
             b = Block(self.fix_function_overloads(self.translate_stmt_list(stmts)))
             b.set_line(lineno)
+        return b
+
+    def as_required_block(self, stmts: List[ast27.stmt], lineno: int) -> Block:
+        assert stmts  # must be non-empty
+        b = Block(self.fix_function_overloads(self.translate_stmt_list(stmts)))
+        b.set_line(lineno)
         return b
 
     def fix_function_overloads(self, stmts: List[Statement]) -> List[Statement]:
@@ -291,7 +303,7 @@ class ASTConverter(ast27.NodeTransformer):
         if special_function_elide_names(n.name):
             arg_names = [None] * len(arg_names)
 
-        arg_types = None  # type: List[Type]
+        arg_types = []  # type: List[Optional[Type]]
         if (n.decorator_list and any(is_no_type_check_decorator(d) for d in n.decorator_list)):
             arg_types = [None] * len(args)
             return_type = None
@@ -343,9 +355,9 @@ class ASTConverter(ast27.NodeTransformer):
                                         arg_kinds,
                                         arg_names,
                                         return_type if return_type is not None else any_type,
-                                        None)
+                                        _dummy_fallback)
 
-        body = self.as_block(n.body, n.lineno)
+        body = self.as_required_block(n.body, n.lineno)
         if decompose_stmts:
             body.body = decompose_stmts + body.body
         func_def = FuncDef(n.name,
@@ -368,7 +380,7 @@ class ASTConverter(ast27.NodeTransformer):
         else:
             return func_def
 
-    def set_type_optional(self, type: Type, initializer: Expression) -> None:
+    def set_type_optional(self, type: Optional[Type], initializer: Optional[Expression]) -> None:
         if self.options.no_implicit_optional:
             return
         # Indicate that type should be wrapped in an Optional if arg is initialized to None.
@@ -461,7 +473,7 @@ class ASTConverter(ast27.NodeTransformer):
         self.class_nesting += 1
 
         cdef = ClassDef(n.name,
-                        self.as_block(n.body, n.lineno),
+                        self.as_required_block(n.body, n.lineno),
                         None,
                         self.translate_expr_list(n.bases),
                         metaclass=None)
@@ -511,7 +523,7 @@ class ASTConverter(ast27.NodeTransformer):
             target_type = None
         return ForStmt(self.visit(n.target),
                        self.visit(n.iter),
-                       self.as_block(n.body, n.lineno),
+                       self.as_required_block(n.body, n.lineno),
                        self.as_block(n.orelse, n.lineno),
                        target_type)
 
@@ -519,14 +531,14 @@ class ASTConverter(ast27.NodeTransformer):
     @with_line
     def visit_While(self, n: ast27.While) -> WhileStmt:
         return WhileStmt(self.visit(n.test),
-                         self.as_block(n.body, n.lineno),
+                         self.as_required_block(n.body, n.lineno),
                          self.as_block(n.orelse, n.lineno))
 
     # If(expr test, stmt* body, stmt* orelse)
     @with_line
     def visit_If(self, n: ast27.If) -> IfStmt:
         return IfStmt([self.visit(n.test)],
-                      [self.as_block(n.body, n.lineno)],
+                      [self.as_required_block(n.body, n.lineno)],
                       self.as_block(n.orelse, n.lineno))
 
     # With(withitem* items, stmt* body, string? type_comment)
@@ -538,7 +550,7 @@ class ASTConverter(ast27.NodeTransformer):
             target_type = None
         return WithStmt([self.visit(n.context_expr)],
                         [self.visit(n.optional_vars)],
-                        self.as_block(n.body, n.lineno),
+                        self.as_required_block(n.body, n.lineno),
                         target_type)
 
     @with_line
@@ -584,9 +596,9 @@ class ASTConverter(ast27.NodeTransformer):
 
         vs = [produce_name(h) for h in handlers]
         types = [self.visit(h.type) for h in handlers]
-        handlers_ = [self.as_block(h.body, h.lineno) for h in handlers]
+        handlers_ = [self.as_required_block(h.body, h.lineno) for h in handlers]
 
-        return TryStmt(self.as_block(body, lineno),
+        return TryStmt(self.as_required_block(body, lineno),
                        vs,
                        types,
                        handlers_,
@@ -615,7 +627,7 @@ class ASTConverter(ast27.NodeTransformer):
     # Import(alias* names)
     @with_line
     def visit_Import(self, n: ast27.Import) -> Import:
-        names = []  # type: List[Tuple[str, str]]
+        names = []  # type: List[Tuple[str, Optional[str]]]
         for alias in n.names:
             name = self.translate_module_id(alias.name)
             asname = alias.asname
@@ -632,9 +644,10 @@ class ASTConverter(ast27.NodeTransformer):
     # ImportFrom(identifier? module, alias* names, int? level)
     @with_line
     def visit_ImportFrom(self, n: ast27.ImportFrom) -> ImportBase:
-        i = None  # type: ImportBase
+        assert n.level is not None
         if len(n.names) == 1 and n.names[0].name == '*':
-            i = ImportAll(n.module, n.level)
+            assert n.module is not None
+            i = ImportAll(n.module, n.level)  # type: ImportBase
         else:
             i = ImportFrom(self.translate_module_id(n.module) if n.module is not None else '',
                            n.level,
@@ -674,7 +687,6 @@ class ASTConverter(ast27.NodeTransformer):
     def visit_BoolOp(self, n: ast27.BoolOp) -> OpExpr:
         # mypy translates (1 and 2 and 3) as (1 and (2 and 3))
         assert len(n.values) >= 2
-        op = None
         if isinstance(n.op, ast27.And):
             op = 'and'
         elif isinstance(n.op, ast27.Or):
@@ -727,7 +739,7 @@ class ASTConverter(ast27.NodeTransformer):
         n_body = ast27.Return(n.body)
         n_body.lineno = n.lineno
         n_body.col_offset = n.col_offset
-        body = self.as_block([n_body], n.lineno)
+        body = self.as_required_block([n_body], n.lineno)
         if decompose_stmts:
             body.body = decompose_stmts + body.body
 
@@ -838,9 +850,8 @@ class ASTConverter(ast27.NodeTransformer):
             value = -new.n
             is_inverse = True
 
-        expr = None  # type: Expression
         if isinstance(value, int):
-            expr = IntExpr(value)
+            expr = IntExpr(value)  # type: Expression
         elif isinstance(value, float):
             expr = FloatExpr(value)
         elif isinstance(value, complex):

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -16,7 +16,7 @@ def parse(source: Union[str, bytes],
 
     The python_version (major, minor) option determines the Python syntax variant.
     """
-    is_stub_file = bool(fnam) and fnam.endswith('.pyi')
+    is_stub_file = fnam.endswith('.pyi')
     if options.python_version[0] >= 3 or is_stub_file:
         import mypy.fastparse
         return mypy.fastparse.parse(source,

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -135,6 +135,7 @@ def find_module_path_and_all(module: str, pyversion: Tuple[int, int],
     Return None if the module is a C module. Return (module_path, __all__) if
     Python module. Raise an exception or exit if failed.
     """
+    module_path = None  # type: Optional[str]
     if not no_import:
         if pyversion[0] == 2:
             module_path, module_all = load_python_module_info(module, interpreter)

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -328,6 +328,7 @@ class TypeCheckSuite(DataSuite):
             out = []
             for module_name in module_names.split(' '):
                 path = build.find_module(module_name, [test_temp_dir])
+                assert path is not None, "Can't find ad hoc case file"
                 with open(path) as f:
                     program_text = f.read()
                 out.append((module_name, path, program_text))

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -18,12 +18,6 @@ strict_optional = False
 [mypy-mypy.checkexpr]
 strict_optional = False
 
-[mypy-mypy.fastparse]
-strict_optional = False
-
-[mypy-mypy.fastparse2]
-strict_optional = False
-
 [mypy-mypy.semanal]
 strict_optional = False
 

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -12,9 +12,6 @@ warn_unused_ignores = True
 [mypy-mypy.binder]
 disallow_any = unimported
 
-[mypy-mypy.build]
-strict_optional = False
-
 [mypy-mypy.checker]
 strict_optional = False
 

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -27,9 +27,6 @@ strict_optional = False
 [mypy-mypy.fastparse2]
 strict_optional = False
 
-[mypy-mypy.main]
-strict_optional = False
-
 [mypy-mypy.semanal]
 strict_optional = False
 


### PR DESCRIPTION
This PR cleans another hundred of ``--strict-optional`` errors and makes four more  files completely clean:
* main.py
* build.py
* fastparse.py
* fastparse2.py

------------------------------
The next PR will be probably the last one, also it will be pretty "hardcore", since there are only three files left - checker/checkexpr/semanal - but these files are touched by almost every PR, so there will be lots of conflicts.