### PR TITLE
[Refactoring]Rename TypeOfAny.implicit to TypeOfAny.unannotated

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -771,11 +771,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
     def check_for_missing_annotations(self, fdef: FuncItem) -> None:
         # Check for functions with unspecified/not fully specified types.
-        def is_implicit_any(t: Type) -> bool:
-            return isinstance(t, AnyType) and t.type_of_any == TypeOfAny.implicit
+        def is_unannotated_any(t: Type) -> bool:
+            return isinstance(t, AnyType) and t.type_of_any == TypeOfAny.unannotated
 
         has_explicit_annotation = (isinstance(fdef.type, CallableType)
-                                   and any(not is_implicit_any(t)
+                                   and any(not is_unannotated_any(t)
                                            for t in fdef.type.arg_types + [fdef.type.ret_type]))
 
         show_untyped = not self.is_typeshed_stub or self.options.warn_incomplete_stub
@@ -784,9 +784,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if fdef.type is None and self.options.disallow_untyped_defs:
                 self.fail(messages.FUNCTION_TYPE_EXPECTED, fdef)
             elif isinstance(fdef.type, CallableType):
-                if is_implicit_any(fdef.type.ret_type):
+                if is_unannotated_any(fdef.type.ret_type):
                     self.fail(messages.RETURN_TYPE_EXPECTED, fdef)
-                if any(is_implicit_any(t) for t in fdef.type.arg_types):
+                if any(is_unannotated_any(t) for t in fdef.type.arg_types):
                     self.fail(messages.ARGUMENT_TYPE_EXPECTED, fdef)
 
     def is_trivial_body(self, block: Block) -> bool:
@@ -3301,7 +3301,7 @@ def nothing() -> Iterator[None]:
 def is_typed_callable(c: Optional[Type]) -> bool:
     if not c or not isinstance(c, CallableType):
         return False
-    return not all(isinstance(t, AnyType) and t.type_of_any == TypeOfAny.implicit
+    return not all(isinstance(t, AnyType) and t.type_of_any == TypeOfAny.unannotated
                    for t in c.arg_types + [c.ret_type])
 
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -817,7 +817,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         else:
             # In dynamically typed functions use implicit 'Any' types for
             # type variables.
-            inferred_args = [AnyType(TypeOfAny.implicit)] * len(callee_type.variables)
+            inferred_args = [AnyType(TypeOfAny.unannotated)] * len(callee_type.variables)
         return self.apply_inferred_arguments(callee_type, inferred_args,
                                              context)
 
@@ -2083,7 +2083,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                         # at the end of the chain.  That's not an error.
                         return AnyType(TypeOfAny.special_form)
                     if not self.chk.in_checked_function():
-                        return AnyType(TypeOfAny.implicit)
+                        return AnyType(TypeOfAny.unannotated)
                     if self.chk.scope.active_class() is not None:
                         self.chk.fail('super() outside of a method is not supported', e)
                         return AnyType(TypeOfAny.from_error)
@@ -2285,7 +2285,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             self.msg.disallowed_any_type(typ, node)
 
         if not self.chk.in_checked_function():
-            return AnyType(TypeOfAny.implicit)
+            return AnyType(TypeOfAny.unannotated)
         else:
             return typ
 

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -77,7 +77,7 @@ def expr_to_unanalyzed_type(expr: Expression, _parent: Optional[Expression] = No
 
         # Go through the constructor args to get its name and type.
         name = None
-        default_type = AnyType(TypeOfAny.implicit)
+        default_type = AnyType(TypeOfAny.unannotated)
         typ = default_type  # type: Type
         for i, arg in enumerate(expr.args):
             if expr.arg_names[i] is not None:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -324,7 +324,7 @@ class ASTConverter(ast3.NodeTransformer):
                         self.fail(messages.DUPLICATE_TYPE_SIGNATURES, n.lineno, n.col_offset)
                     arg_types = [a.type_annotation
                                  if a.type_annotation is not None
-                                 else AnyType(TypeOfAny.implicit)
+                                 else AnyType(TypeOfAny.unannotated)
                                  for a in args]
                 else:
                     # PEP 484 disallows both type annotations and type comments
@@ -332,7 +332,7 @@ class ASTConverter(ast3.NodeTransformer):
                         self.fail(messages.DUPLICATE_TYPE_SIGNATURES, n.lineno, n.col_offset)
                     translated_args = (TypeConverter(self.errors, line=n.lineno)
                                        .translate_expr_list(func_type_ast.argtypes))
-                    arg_types = [a if a is not None else AnyType(TypeOfAny.implicit)
+                    arg_types = [a if a is not None else AnyType(TypeOfAny.unannotated)
                                 for a in translated_args]
                 return_type = TypeConverter(self.errors,
                                             line=n.lineno).visit(func_type_ast.returns)
@@ -363,11 +363,11 @@ class ASTConverter(ast3.NodeTransformer):
                 self.fail('Type signature has too few arguments', n.lineno, 0)
             else:
                 func_type = CallableType([a if a is not None else
-                                          AnyType(TypeOfAny.implicit) for a in arg_types],
+                                          AnyType(TypeOfAny.unannotated) for a in arg_types],
                                          arg_kinds,
                                          arg_names,
                                          return_type if return_type is not None else
-                                         AnyType(TypeOfAny.implicit),
+                                         AnyType(TypeOfAny.unannotated),
                                          None)
 
         func_def = FuncDef(n.name,

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -304,14 +304,14 @@ class ASTConverter(ast27.NodeTransformer):
                         isinstance(func_type_ast.argtypes[0], ast3.Ellipsis)):
                     arg_types = [a.type_annotation
                                  if a.type_annotation is not None
-                                 else AnyType(TypeOfAny.implicit)
+                                 else AnyType(TypeOfAny.unannotated)
                                  for a in args]
                 else:
                     # PEP 484 disallows both type annotations and type comments
                     if any(a.type_annotation is not None for a in args):
                         self.fail(messages.DUPLICATE_TYPE_SIGNATURES, n.lineno, n.col_offset)
-                    arg_types = [a if a is not None else AnyType(TypeOfAny.implicit) for
-                                a in converter.translate_expr_list(func_type_ast.argtypes)]
+                    arg_types = [a if a is not None else AnyType(TypeOfAny.unannotated) for
+                                 a in converter.translate_expr_list(func_type_ast.argtypes)]
                 return_type = converter.visit(func_type_ast.returns)
 
                 # add implicit self type
@@ -338,7 +338,7 @@ class ASTConverter(ast27.NodeTransformer):
             elif len(arg_types) < len(arg_kinds):
                 self.fail('Type signature has too few arguments', n.lineno, 0)
             else:
-                any_type = AnyType(TypeOfAny.implicit)
+                any_type = AnyType(TypeOfAny.unannotated)
                 func_type = CallableType([a if a is not None else any_type for a in arg_types],
                                         arg_kinds,
                                         arg_names,

--- a/mypy/maptype.py
+++ b/mypy/maptype.py
@@ -87,7 +87,7 @@ def map_instance_to_direct_supertypes(instance: Instance,
     else:
         # Relationship with the supertype not specified explicitly. Use dynamic
         # type arguments implicitly.
-        any_type = AnyType(TypeOfAny.implicit)
+        any_type = AnyType(TypeOfAny.unannotated)
         return [Instance(supertype, [any_type] * len(supertype.type_vars))]
 
 

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -31,7 +31,7 @@ except ImportError:
     LXML_INSTALLED = False
 
 type_of_any_name_map = collections.OrderedDict([
-    (TypeOfAny.implicit, "Unannotated"),
+    (TypeOfAny.unannotated, "Unannotated"),
     (TypeOfAny.explicit, "Explicit"),
     (TypeOfAny.from_unimported_type, "Unimported"),
     (TypeOfAny.from_omitted_generics, "Omitted Generics"),

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -982,7 +982,7 @@ class SemanticAnalyzer(NodeVisitor[None]):
                 # Append name and type in this case...
                 name = stmt.lvalues[0].name
                 items.append(name)
-                types.append(AnyType(TypeOfAny.implicit)
+                types.append(AnyType(TypeOfAny.unannotated)
                              if stmt.type is None
                              else self.anal_type(stmt.type))
                 # ...despite possible minor failures that allow further analyzis.
@@ -1247,7 +1247,7 @@ class SemanticAnalyzer(NodeVisitor[None]):
         if args:
             # TODO: assert len(args) == len(node.defn.type_vars)
             return Instance(node, args)
-        return Instance(node, [AnyType(TypeOfAny.implicit)] * len(node.defn.type_vars))
+        return Instance(node, [AnyType(TypeOfAny.unannotated)] * len(node.defn.type_vars))
 
     def is_typeddict(self, expr: Expression) -> bool:
         return (isinstance(expr, RefExpr) and isinstance(expr.node, TypeInfo) and
@@ -1341,7 +1341,7 @@ class SemanticAnalyzer(NodeVisitor[None]):
                     continue
                 # Append name and type in this case...
                 fields.append(name)
-                types.append(AnyType(TypeOfAny.implicit)
+                types.append(AnyType(TypeOfAny.unannotated)
                              if stmt.type is None
                              else self.anal_type(stmt.type))
                 # ...despite possible minor failures that allow further analyzis.
@@ -2291,7 +2291,7 @@ class SemanticAnalyzer(NodeVisitor[None]):
                 # The fields argument contains (name, type) tuples.
                 items, types, ok = self.parse_namedtuple_fields_with_types(listexpr.items, call)
         if not types:
-            types = [AnyType(TypeOfAny.implicit) for _ in items]
+            types = [AnyType(TypeOfAny.unannotated) for _ in items]
         underscore = [item for item in items if item.startswith('_')]
         if underscore:
             self.fail("namedtuple() field names cannot start with an underscore: "
@@ -4566,7 +4566,7 @@ def calculate_return_type(expr: Expression) -> Optional[Type]:
             typ = expr.node.type
             if typ is None:
                 # No signature -> default to Any.
-                return AnyType(TypeOfAny.implicit)
+                return AnyType(TypeOfAny.unannotated)
             # Explicit Any return?
             if isinstance(typ, CallableType):
                 return typ.ret_type

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -274,7 +274,7 @@ class TypeOfAny:
             return x
 
     # Was this Any type was inferred without a type annotation?
-    implicit = TypeOfAny('implicit')
+    unannotated = TypeOfAny('unannotated')
     # Does this Any come from an explicit type annotation?
     explicit = TypeOfAny('explicit')
     # Does this come from an unfollowed import? See --disallow-any=unimported option
@@ -1893,10 +1893,10 @@ def callable_type(fdef: mypy.nodes.FuncItem, fallback: Instance,
         name = '"{}"'.format(name)
 
     return CallableType(
-        [AnyType(TypeOfAny.implicit)] * len(fdef.arg_names),
+        [AnyType(TypeOfAny.unannotated)] * len(fdef.arg_names),
         fdef.arg_kinds,
         [None if argument_elide_name(n) else n for n in fdef.arg_names],
-        ret_type or AnyType(TypeOfAny.implicit),
+        ret_type or AnyType(TypeOfAny.unannotated),
         fallback,
         name,
         implicit=True,


### PR DESCRIPTION
TypeOfAny.implicit designates Anys that come from omitted type annotations.

```
def f(x) -> None:
    pass
```
In the example above, type of `x` is `Any` and type of that `Any` is "implicit".

However, usage of the word "implicit" is ambiguous since you could consider omitted generics, for instance, implicit as well but it is a different category of Anys.

`unannotated` is a term that is already used in `--disallow-any=unannotated` option.