### PR TITLE
Move testtypegen to pytest

### DIFF
--- a/mypy/test/testtypegen.py
+++ b/mypy/test/testtypegen.py
@@ -7,9 +7,8 @@ from typing import Set, List
 
 from mypy import build
 from mypy.build import BuildSource
-from mypy.myunit import Suite
 from mypy.test import config
-from mypy.test.data import parse_test_cases, DataDrivenTestCase
+from mypy.test.data import parse_test_cases, DataDrivenTestCase, DataSuite
 from mypy.test.helpers import assert_string_arrays_equal
 from mypy.util import short_type
 from mypy.nodes import (
@@ -20,18 +19,19 @@ from mypy.errors import CompileError
 from mypy.options import Options
 
 
-class TypeExportSuite(Suite):
+class TypeExportSuite(DataSuite):
     # List of files that contain test case descriptions.
     files = ['typexport-basic.test']
 
-    def cases(self) -> List[DataDrivenTestCase]:
+    @classmethod
+    def cases(cls) -> List[DataDrivenTestCase]:
         c = []  # type: List[DataDrivenTestCase]
-        for f in self.files:
+        for f in cls.files:
             c += parse_test_cases(os.path.join(config.test_data_prefix, f),
-                                  self.run_test, config.test_temp_dir)
+                                  None, config.test_temp_dir)
         return c
 
-    def run_test(self, testcase: DataDrivenTestCase) -> None:
+    def run_case(self, testcase: DataDrivenTestCase) -> None:
         try:
             line = testcase.input[0]
             mask = ''

--- a/runtests.py
+++ b/runtests.py
@@ -205,6 +205,7 @@ PYTEST_FILES = [os.path.join('mypy', 'test', '{}.py'.format(name)) for name in [
     'testfinegrained',
     'testmerge',
     'testtransform',
+    'testtypegen',
     'testparse',
 ]]
 


### PR DESCRIPTION
Another item from #1673, following #3780 and #3788

As in previous PRs, I have checked that a test may fail by changing `testConstructorCall` and running

    ./runtests.py pytest -a -n0 -a -k -a testGlobalVariable
