### PR TITLE
Better error on empty typeshed directory

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -44,6 +44,7 @@ from mypy.stats import dump_type_stats
 from mypy.types import Type
 from mypy.version import __version__
 from mypy.plugin import Plugin, DefaultPlugin, ChainedPlugin
+from mypy.defaults import PYTHON3_VERSION_MIN
 
 
 # We need to know the location of this file to load data, but
@@ -283,11 +284,11 @@ def default_lib_path(data_dir: str,
         # We allow a module for e.g. version 3.5 to be in 3.4/. The assumption
         # is that a module added with 3.4 will still be present in Python 3.5.
         versions = ["%d.%d" % (pyversion[0], minor)
-                    for minor in reversed(range(3, pyversion[1] + 1))]
+                    for minor in reversed(range(PYTHON3_VERSION_MIN[1], pyversion[1] + 1))]
     else:
         # For Python 2, we only have stubs for 2.7
         versions = ["2.7"]
-    # E.g. for Python 3.2, try 3.2/, 3.1/, 3.0/, 3/, 2and3/.
+    # E.g. for Python 3.5, try 3.5/, 3.4/, 3.3/, 3/, 2and3/.
     # (Note that 3.1 and 3.0 aren't really supported, but we don't care.)
     for v in versions + [str(pyversion[0]), '2and3']:
         for lib_type in ['stdlib', 'third_party']:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -279,10 +279,14 @@ def default_lib_path(data_dir: str,
         if os.path.isdir(auto):
             data_dir = auto
         typeshed_dir = os.path.join(data_dir, "typeshed")
-    # We allow a module for e.g. version 3.5 to be in 3.4/. The assumption
-    # is that a module added with 3.4 will still be present in Python 3.5.
-    versions = ["%d.%d" % (pyversion[0], minor)
-                for minor in reversed(range(pyversion[1] + 1))]
+    if pyversion[0] == 3:
+        # We allow a module for e.g. version 3.5 to be in 3.4/. The assumption
+        # is that a module added with 3.4 will still be present in Python 3.5.
+        versions = ["%d.%d" % (pyversion[0], minor)
+                    for minor in reversed(range(pyversion[1] + 1))]
+    else:
+        # For Python 2, we only have stubs for 2.7
+        versions = ["2.7"]
     # E.g. for Python 3.2, try 3.2/, 3.1/, 3.0/, 3/, 2and3/.
     # (Note that 3.1 and 3.0 aren't really supported, but we don't care.)
     for v in versions + [str(pyversion[0]), '2and3']:
@@ -294,7 +298,9 @@ def default_lib_path(data_dir: str,
     # Add fallback path that can be used if we have a broken installation.
     if sys.platform != 'win32':
         path.append('/usr/local/lib/mypy')
-
+    assert path, "Could not resolve typeshed subdirectories. If you are using MyPy " \
+                 "from source, you need to run \"git submodule --init update\"." \
+                 "Otherwise your MyPy install is broken."
     return path
 
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -289,7 +289,6 @@ def default_lib_path(data_dir: str,
         # For Python 2, we only have stubs for 2.7
         versions = ["2.7"]
     # E.g. for Python 3.5, try 3.5/, 3.4/, 3.3/, 3/, 2and3/.
-    # (Note that 3.1 and 3.0 aren't really supported, but we don't care.)
     for v in versions + [str(pyversion[0]), '2and3']:
         for lib_type in ['stdlib', 'third_party']:
             stubdir = os.path.join(typeshed_dir, lib_type, v)

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -283,7 +283,7 @@ def default_lib_path(data_dir: str,
         # We allow a module for e.g. version 3.5 to be in 3.4/. The assumption
         # is that a module added with 3.4 will still be present in Python 3.5.
         versions = ["%d.%d" % (pyversion[0], minor)
-                    for minor in reversed(range(pyversion[1] + 1))]
+                    for minor in reversed(range(3, pyversion[1] + 1))]
     else:
         # For Python 2, we only have stubs for 2.7
         versions = ["2.7"]
@@ -298,9 +298,11 @@ def default_lib_path(data_dir: str,
     # Add fallback path that can be used if we have a broken installation.
     if sys.platform != 'win32':
         path.append('/usr/local/lib/mypy')
-    assert path, "Could not resolve typeshed subdirectories. If you are using MyPy " \
-                 "from source, you need to run \"git submodule --init update\"." \
-                 "Otherwise your MyPy install is broken."
+    if not path:
+        print("Could not resolve typeshed subdirectories. If you are using MyPy"
+              "from source, you need to run \"git submodule --init update\"."
+              "Otherwise your MyPy install is broken.", file=sys.stderr)
+        sys.exit(1)
     return path
 
 

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -1,4 +1,5 @@
 PYTHON2_VERSION = (2, 7)
 PYTHON3_VERSION = (3, 6)
+PYTHON3_VERSION_MIN = (3, 3)
 CACHE_DIR = '.mypy_cache'
 CONFIG_FILE = 'mypy.ini'


### PR DESCRIPTION
If typeshed is empty (someone forgot to pull the submodule, or the install is broken) the path to typeshed will resolve correctly, but of course stubs will not be found. I added an assert to catch this case. In addition, I realized that before when analyzing 2.7 code, it would look for subdirectories of the typeshed directory for 2.0-2.6, which is pointless, so I modified it to only look in the 2.7 subdirectory.