### PR TITLE
Add --warn-unused-configs flag

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -34,6 +34,11 @@ characters.
   separated by commas.  These sections specify additional flags that
   only apply to *modules* whose name matches at least one of the patterns.
 
+.. note::
+
+   The ``warn_unused_configs`` flag may be useful to debug misspelled
+   section names.
+
 Global flags
 ************
 
@@ -71,6 +76,10 @@ The following global flags may only be set in the global section
 
 - ``warn_unused_ignores`` (Boolean, default False) warns about
   unneeded ``# type: ignore`` comments.
+
+- ``warn_unused_configs`` (Boolean, default False) warns about
+  per-module sections in the config file that didn't match any
+  files processed in the current run.
 
 - ``strict_optional`` (Boolean, default False) enables experimental
   strict Optional checks.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -53,6 +53,11 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
         a = e.messages
         if not e.use_stdout:
             serious = True
+    if options.warn_unused_configs and options.unused_configs:
+        print("warning: unused section(s) in %s: %s" %
+              (options.config_file,
+               ", ".join("[mypy-%s]" % glob for glob in options.unused_configs.values())),
+              file=sys.stderr)
     if options.junit_xml:
         t1 = time.time()
         util.write_junit_xml(t1 - t0, serious, a, options.junit_xml)
@@ -280,6 +285,8 @@ def process_options(args: List[str],
                              " from non-Any typed functions")
     add_invertible_flag('--warn-unused-ignores', default=False, strict_flag=True,
                         help="warn about unneeded '# type: ignore' comments")
+    add_invertible_flag('--warn-unused-configs', default=False, strict_flag=True,
+                        help="warn about unnused '[mypy-<pattern>]' config sections")
     add_invertible_flag('--show-error-context', default=False,
                         dest='show_error_context',
                         help='Precede errors with "note:" messages explaining context')
@@ -694,6 +701,7 @@ def parse_config_file(options: Options, filename: Optional[str]) -> None:
                     glob = glob.replace(os.altsep, '.')
                 pattern = re.compile(fnmatch.translate(glob))
                 options.per_module_options[pattern] = updates
+                options.unused_configs[pattern] = glob
 
 
 def parse_section(prefix: str, template: Options,

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -54,7 +54,7 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
         if not e.use_stdout:
             serious = True
     if options.warn_unused_configs and options.unused_configs:
-        print("warning: unused section(s) in %s: %s" %
+        print("Warning: unused section(s) in %s: %s" %
               (options.config_file,
                ", ".join("[mypy-%s]" % glob for glob in options.unused_configs.values())),
               file=sys.stderr)


### PR DESCRIPTION
This is handy for debugging misspellings in mypy.ini, and other mishaps due to e.g. file moves.