### PR TITLE
Move testsemanal to pytest

### DIFF
--- a/mypy/test/testsemanal.py
+++ b/mypy/test/testsemanal.py
@@ -6,11 +6,10 @@ from typing import Dict, List
 
 from mypy import build
 from mypy.build import BuildSource
-from mypy.myunit import Suite
 from mypy.test.helpers import (
     assert_string_arrays_equal, normalize_error_messages, testfile_pyversion,
 )
-from mypy.test.data import parse_test_cases, DataDrivenTestCase
+from mypy.test.data import parse_test_cases, DataDrivenTestCase, DataSuite
 from mypy.test.config import test_data_prefix, test_temp_dir
 from mypy.errors import CompileError
 from mypy.nodes import TypeInfo
@@ -42,8 +41,9 @@ def get_semanal_options() -> Options:
     return options
 
 
-class SemAnalSuite(Suite):
-    def cases(self) -> List[DataDrivenTestCase]:
+class SemAnalSuite(DataSuite):
+    @classmethod
+    def cases(cls) -> List[DataDrivenTestCase]:
         c = []  # type: List[DataDrivenTestCase]
         for f in semanal_files:
             c += parse_test_cases(os.path.join(test_data_prefix, f),
@@ -52,6 +52,9 @@ class SemAnalSuite(Suite):
                                   optional_out=True,
                                   native_sep=True)
         return c
+
+    def run_case(self, testcase: DataDrivenTestCase) -> None:
+        test_semanal(testcase)
 
 
 def test_semanal(testcase: DataDrivenTestCase) -> None:
@@ -102,14 +105,18 @@ def test_semanal(testcase: DataDrivenTestCase) -> None:
 semanal_error_files = ['semanal-errors.test']
 
 
-class SemAnalErrorSuite(Suite):
-    def cases(self) -> List[DataDrivenTestCase]:
+class SemAnalErrorSuite(DataSuite):
+    @classmethod
+    def cases(cls) -> List[DataDrivenTestCase]:
         # Read test cases from test case description files.
         c = []  # type: List[DataDrivenTestCase]
         for f in semanal_error_files:
             c += parse_test_cases(os.path.join(test_data_prefix, f),
                                   test_semanal_error, test_temp_dir, optional_out=True)
         return c
+
+    def run_case(self, testcase: DataDrivenTestCase) -> None:
+        test_semanal_error(testcase)
 
 
 def test_semanal_error(testcase: DataDrivenTestCase) -> None:
@@ -137,15 +144,16 @@ def test_semanal_error(testcase: DataDrivenTestCase) -> None:
 semanal_symtable_files = ['semanal-symtable.test']
 
 
-class SemAnalSymtableSuite(Suite):
-    def cases(self) -> List[DataDrivenTestCase]:
+class SemAnalSymtableSuite(DataSuite):
+    @classmethod
+    def cases(cls) -> List[DataDrivenTestCase]:
         c = []  # type: List[DataDrivenTestCase]
         for f in semanal_symtable_files:
             c += parse_test_cases(os.path.join(test_data_prefix, f),
-                                  self.run_test, test_temp_dir)
+                                  None, test_temp_dir)
         return c
 
-    def run_test(self, testcase: DataDrivenTestCase) -> None:
+    def run_case(self, testcase: DataDrivenTestCase) -> None:
         """Perform a test case."""
         try:
             # Build test case input.
@@ -175,16 +183,17 @@ class SemAnalSymtableSuite(Suite):
 semanal_typeinfo_files = ['semanal-typeinfo.test']
 
 
-class SemAnalTypeInfoSuite(Suite):
-    def cases(self) -> List[DataDrivenTestCase]:
+class SemAnalTypeInfoSuite(DataSuite):
+    @classmethod
+    def cases(cls) -> List[DataDrivenTestCase]:
         """Test case descriptions"""
         c = []  # type: List[DataDrivenTestCase]
         for f in semanal_typeinfo_files:
             c += parse_test_cases(os.path.join(test_data_prefix, f),
-                                  self.run_test, test_temp_dir)
+                                  None, test_temp_dir)
         return c
 
-    def run_test(self, testcase: DataDrivenTestCase) -> None:
+    def run_case(self, testcase: DataDrivenTestCase) -> None:
         """Perform a test case."""
         try:
             # Build test case input.

--- a/runtests.py
+++ b/runtests.py
@@ -207,6 +207,7 @@ PYTEST_FILES = [os.path.join('mypy', 'test', '{}.py'.format(name)) for name in [
     'testtransform',
     'testtypegen',
     'testparse',
+    'testsemanal',
 ]]
 
 


### PR DESCRIPTION
Another item from #1673, following #3780, #3788 and #3861.

As in previous PRs, I have checked that a test may fail by changing `testMissingModuleImport1` and running

    ./runtests.py pytest -a -n0 -a -k -a testMissingModuleImport1

If I am not mistaken this is the last "simple" file. After this there's the pyeval/cmd tests, refactoring/cleanup, and the non-datadriven tests which require special treatment.