### PR TITLE
Use global minimum Python version for version check

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -155,7 +155,8 @@ def parse_version(v: str) -> Tuple[int, int]:
     elif major == 3:
         if minor <= 2:
             raise argparse.ArgumentTypeError(
-                "Python 3.{} is not supported (must be 3.3 or higher)".format(minor))
+                "Python 3.{0} is not supported (must be {1}.{2} or higher)".format(minor,
+                                                                    *defaults.PYTHON3_VERSION_MIN))
     else:
         raise argparse.ArgumentTypeError(
             "Python major version '{}' out of range (must be 2 or 3)".format(major))

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -153,7 +153,7 @@ def parse_version(v: str) -> Tuple[int, int]:
             raise argparse.ArgumentTypeError(
                 "Python 2.{} is not supported (must be 2.7)".format(minor))
     elif major == 3:
-        if minor <= 2:
+        if minor <= defaults.PYTHON3_VERSION_MIN[1]:
             raise argparse.ArgumentTypeError(
                 "Python 3.{0} is not supported (must be {1}.{2} or higher)".format(minor,
                                                                     *defaults.PYTHON3_VERSION_MIN))

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -153,7 +153,7 @@ def parse_version(v: str) -> Tuple[int, int]:
             raise argparse.ArgumentTypeError(
                 "Python 2.{} is not supported (must be 2.7)".format(minor))
     elif major == 3:
-        if minor <= defaults.PYTHON3_VERSION_MIN[1]:
+        if minor < defaults.PYTHON3_VERSION_MIN[1]:
             raise argparse.ArgumentTypeError(
                 "Python 3.{0} is not supported (must be {1}.{2} or higher)".format(minor,
                                                                     *defaults.PYTHON3_VERSION_MIN))


### PR DESCRIPTION
As a follow up to [this comment](https://github.com/python/mypy/pull/3862#discussion_r134635535) I thought it would be good to use this constant everywhere. Now to update the minimum supported Python version we just need to update the default in `defaults.py` and the trove classifiers in `setup.py`.

EDIT: It seems I accidentally based this off of my previous branch. If you want I can rebase to be based off of master.