### PR TITLE
Move pythoneval and cmdline to pytest

### DIFF
--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -14,7 +14,7 @@ from typing import Tuple, List, Dict, Set
 from mypy.myunit import Suite, SkipTestCaseException, AssertionFailure
 from mypy.test.config import test_data_prefix, test_temp_dir
 from mypy.test.data import fix_cobertura_filename
-from mypy.test.data import parse_test_cases, DataDrivenTestCase
+from mypy.test.data import parse_test_cases, DataDrivenTestCase, DataSuite
 from mypy.test.helpers import assert_string_arrays_equal, normalize_error_messages
 from mypy.version import __version__, base_version
 
@@ -28,9 +28,10 @@ cmdline_files = [
 ]
 
 
-class PythonEvaluationSuite(Suite):
+class PythonEvaluationSuite(DataSuite):
 
-    def cases(self) -> List[DataDrivenTestCase]:
+    @classmethod
+    def cases(cls) -> List[DataDrivenTestCase]:
         c = []  # type: List[DataDrivenTestCase]
         for f in cmdline_files:
             c += parse_test_cases(os.path.join(test_data_prefix, f),
@@ -39,6 +40,9 @@ class PythonEvaluationSuite(Suite):
                                   optional_out=True,
                                   native_sep=True)
         return c
+
+    def run_case(self, testcase: DataDrivenTestCase):
+        test_python_evaluation(testcase)
 
 
 def test_python_evaluation(testcase: DataDrivenTestCase) -> None:

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -18,15 +18,13 @@ import re
 import subprocess
 import sys
 
-import typing
+import pytest  # type: ignore  # no pytest in typeshed
 from typing import Dict, List, Tuple, Optional
 
-from mypy.myunit import Suite, SkipTestCaseException
 from mypy.test.config import test_data_prefix, test_temp_dir
-from mypy.test.data import DataDrivenTestCase, parse_test_cases
+from mypy.test.data import DataDrivenTestCase, parse_test_cases, DataSuite
 from mypy.test.helpers import assert_string_arrays_equal
 from mypy.util import try_find_python2_interpreter
-
 
 # Files which contain test case descriptions.
 python_eval_files = ['pythoneval.test',
@@ -39,8 +37,9 @@ python3_path = sys.executable
 program_re = re.compile(r'\b_program.py\b')
 
 
-class PythonEvaluationSuite(Suite):
-    def cases(self) -> List[DataDrivenTestCase]:
+class PythonEvaluationSuite(DataSuite):
+    @classmethod
+    def cases(cls) -> List[DataDrivenTestCase]:
         c = []  # type: List[DataDrivenTestCase]
         for f in python_eval_files:
             c += parse_test_cases(os.path.join(test_data_prefix, f),
@@ -50,6 +49,9 @@ class PythonEvaluationSuite(Suite):
                 c += parse_test_cases(os.path.join(test_data_prefix, f),
                     test_python_evaluation, test_temp_dir, True)
         return c
+
+    def run_case(self, testcase: DataDrivenTestCase):
+        test_python_evaluation(testcase)
 
 
 def test_python_evaluation(testcase: DataDrivenTestCase) -> None:
@@ -68,9 +70,11 @@ def test_python_evaluation(testcase: DataDrivenTestCase) -> None:
     if py2:
         mypy_cmdline.append('--py2')
         interpreter = try_find_python2_interpreter()
-        if not interpreter:
+        if interpreter is None:
             # Skip, can't find a Python 2 interpreter.
-            raise SkipTestCaseException()
+            pytest.skip()
+            # placate the type checker
+            return
     else:
         interpreter = python3_path
 

--- a/runtests.py
+++ b/runtests.py
@@ -5,13 +5,10 @@ from typing import Dict, List, Optional, Set, Iterable
 
 from mypy.waiter import Waiter, LazySubprocess
 from mypy import util
-from mypy.test.config import test_data_prefix
-from mypy.test.testpythoneval import python_eval_files, python_34_eval_files
 
 import itertools
 import os
 from os.path import join, isdir
-import re
 import sys
 
 
@@ -92,7 +89,8 @@ class Driver:
     def add_mypy_string(self, name: str, *args: str, cwd: Optional[str] = None) -> None:
         self.add_mypy_cmd(name, ['-c'] + list(args), cwd=cwd)
 
-    def add_pytest(self, name: str, pytest_args: List[str], coverage: bool = False) -> None:
+    def add_pytest(self, name: str, pytest_files: List[str], coverage: bool = True) -> None:
+        pytest_args = pytest_files + self.arglist + self.pyt_arglist
         full_name = 'pytest %s' % name
         if not self.allow(full_name):
             return
@@ -197,7 +195,12 @@ def add_imports(driver: Driver) -> None:
             driver.add_python_string('import %s' % mod, 'import %s' % mod)
 
 
-PYTEST_FILES = [os.path.join('mypy', 'test', '{}.py'.format(name)) for name in [
+def test_path(*names: str):
+    return [os.path.join('mypy', 'test', '{}.py'.format(name))
+            for name in names]
+
+
+PYTEST_FILES = test_path(
     'testcheck',
     'testextensions',
     'testdeps',
@@ -208,57 +211,36 @@ PYTEST_FILES = [os.path.join('mypy', 'test', '{}.py'.format(name)) for name in [
     'testtypegen',
     'testparse',
     'testsemanal',
-]]
+    'testpythoneval',
+    'testcmdline'
+)
+
+MYUNIT_FILES = test_path(
+    'teststubgen',  # contains data-driven suite
+
+    'testargs',
+    'testgraph',
+    'testinfer',
+    'testmoduleinfo',
+    'testreports',
+    'testsolve',
+    'testsubtypes',
+    'testtypes'
+)
+
+for f in find_files('mypy', prefix='test', suffix='.py'):
+    assert f in PYTEST_FILES + MYUNIT_FILES, f
 
 
 def add_pytest(driver: Driver) -> None:
-    driver.add_pytest('pytest', PYTEST_FILES + driver.arglist + driver.pyt_arglist, True)
+    driver.add_pytest('pytest', PYTEST_FILES)
 
 
 def add_myunit(driver: Driver) -> None:
-    for f in find_files('mypy', prefix='test', suffix='.py'):
+    for f in MYUNIT_FILES:
         mod = file_to_module(f)
-        if mod in ('mypy.test.testpythoneval', 'mypy.test.testcmdline'):
-            # Run Python evaluation integration tests and command-line
-            # parsing tests separately since they are much slower than
-            # proper unit tests.
-            pass
-        elif f in PYTEST_FILES:
-            # This module has been converted to pytest; don't try to use myunit.
-            pass
-        else:
-            driver.add_python_mod('unit-test %s' % mod, 'mypy.myunit', '-m', mod,
-                                  *driver.arglist, coverage=True)
-
-
-def add_pythoneval(driver: Driver) -> None:
-    cases = set()
-    case_re = re.compile(r'^\[case ([^\]]+)\]$')
-    for file in python_eval_files + python_34_eval_files:
-        with open(os.path.join(test_data_prefix, file), 'r') as f:
-            for line in f:
-                m = case_re.match(line)
-                if m:
-                    case_name = m.group(1)
-                    assert case_name[:4] == 'test'
-                    cases.add(case_name[4:5])
-
-    for prefix in sorted(cases):
-        driver.add_python_mod(
-            'eval-test-' + prefix,
-            'mypy.myunit',
-            '-m',
-            'mypy.test.testpythoneval',
-            'test_testpythoneval_PythonEvaluationSuite.test' + prefix + '*',
-            *driver.arglist,
-            coverage=True
-        )
-
-
-def add_cmdline(driver: Driver) -> None:
-    driver.add_python_mod('cmdline-test', 'mypy.myunit',
-                          '-m', 'mypy.test.testcmdline', *driver.arglist,
-                         coverage=True)
+        driver.add_python_mod('unit-test %s' % mod, 'mypy.myunit', '-m', mod,
+                              *driver.arglist, coverage=True)
 
 
 def add_stubs(driver: Driver) -> None:
@@ -432,8 +414,6 @@ def main() -> None:
 
     driver.add_flake8()
     add_pytest(driver)
-    add_pythoneval(driver)
-    add_cmdline(driver)
     add_basic(driver)
     add_selftypecheck(driver)
     add_myunit(driver)


### PR DESCRIPTION
(EDITED)
Another item from #1673, following #3780, #3788, #3861 and #3866.

After this, `StubgenPythonSuite` is the only data-driven test left in myunit.

As in previous PRs, I have checked that a test may fail by changing tests and running

    ./runtests.py eval -a -n0 -a -k -a testHello
    ./runtests.py eval -a -n0 -a -k -a testSimpleCoroutineSleep
    ./runtests.py cmd -a -n0 -a -k -a testCmdlinePackageContainingSubdir

I am somewhat less confident about this PR, since I am not entirely sure what special considerations are in play here (which aren't there for the proper unit tests).

@ambv @gvanrossum: The splitting of eval tests, introduced in PR #2635, is removed. IIUC this was the intention - please correct me if I'm wrong. (I did not time the difference).

Executing multiple pytest instances does not work well with appveyor.
