### PR TITLE
Move data driven part of stubgen to pytest

### DIFF
--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -13,7 +13,7 @@ from typing import List, Tuple
 
 from mypy.myunit import Suite, AssertionFailure, assert_equal
 from mypy.test.helpers import assert_string_arrays_equal
-from mypy.test.data import parse_test_cases, DataDrivenTestCase
+from mypy.test.data import DataSuite, parse_test_cases, DataDrivenTestCase
 from mypy.test import config
 from mypy.parse import parse
 from mypy.errors import CompileError
@@ -95,14 +95,18 @@ class StubgenUtilSuite(Suite):
         assert_equal(infer_sig_from_docstring('\nfunc x', 'func'), None)
 
 
-class StubgenPythonSuite(Suite):
+class StubgenPythonSuite(DataSuite):
     test_data_files = ['stubgen.test']
 
-    def cases(self) -> List[DataDrivenTestCase]:
+    @classmethod
+    def cases(cls) -> List[DataDrivenTestCase]:
         c = []  # type: List[DataDrivenTestCase]
-        for path in self.test_data_files:
+        for path in cls.test_data_files:
             c += parse_test_cases(os.path.join(config.test_data_prefix, path), test_stubgen)
         return c
+
+    def run_case(self, testcase: DataDrivenTestCase) -> None:
+        test_stubgen(testcase)
 
 
 def parse_flags(program_text: str) -> Options:

--- a/runtests.py
+++ b/runtests.py
@@ -212,12 +212,12 @@ PYTEST_FILES = test_path(
     'testparse',
     'testsemanal',
     'testpythoneval',
-    'testcmdline'
+    'testcmdline',
+    'teststubgen'
 )
 
 MYUNIT_FILES = test_path(
-    'teststubgen',  # contains data-driven suite
-
+    'teststubgen',
     'testargs',
     'testgraph',
     'testinfer',

--- a/runtests.py
+++ b/runtests.py
@@ -213,7 +213,7 @@ PYTEST_FILES = test_path(
     'testsemanal',
     'testpythoneval',
     'testcmdline',
-    'teststubgen'
+    'teststubgen',
 )
 
 MYUNIT_FILES = test_path(
@@ -225,7 +225,7 @@ MYUNIT_FILES = test_path(
     'testreports',
     'testsolve',
     'testsubtypes',
-    'testtypes'
+    'testtypes',
 )
 
 for f in find_files('mypy', prefix='test', suffix='.py'):


### PR DESCRIPTION
Another item from #1673, following #3780, #3788, #3861, #3866 and #3870.

As in previous PRs, I have checked that a test may fail by changing tests in `stubgen.test` and `teststubgen.py` and running:

    ./runtests.py stubgen