### PR TITLE
Format many-itemed tuples and unions consistently and more clearly

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -185,7 +185,7 @@ class MessageBuilder:
 
     def quote_type_string(self, type_string: str) -> str:
         """Quotes a type representation for use in messages."""
-        no_quote_regex = r'^tuple\(length \d+\)$'
+        no_quote_regex = r'^<(tuple|union): \d+ items>$'
         if (type_string in ['Module', 'overloaded function', '<nothing>', '<deleted>']
                 or re.match(no_quote_regex, type_string) is not None):
             # Messages are easier to read if these aren't quoted.  We use a
@@ -260,7 +260,7 @@ class MessageBuilder:
             if len(s) < 400:
                 return s
             else:
-                return 'tuple(length {})'.format(len(items))
+                return '<tuple: {} items>'.format(len(items))
         elif isinstance(typ, TypedDictType):
             # If the TypedDictType is named, return the name
             if not typ.is_anonymous():
@@ -288,7 +288,7 @@ class MessageBuilder:
                 if len(s) < 400:
                     return s
                 else:
-                    return 'union type ({} items)'.format(len(items))
+                    return '<union: {} items>'.format(len(items))
         elif isinstance(typ, NoneTyp):
             return 'None'
         elif isinstance(typ, AnyType):

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -183,6 +183,16 @@ class MessageBuilder:
         """Report a warning message (unless disabled)."""
         self.report(msg, context, 'warning', file=file, origin=origin)
 
+    def quote_type_string(self, type_string: str) -> str:
+        """Quotes a type representation for use in messages."""
+        no_quote_regex = r'^tuple\(length \d+\)$'
+        if (type_string in ['Module', 'overloaded function', '<nothing>', '<deleted>']
+                or re.match(no_quote_regex, type_string) is not None):
+            # Messages are easier to read if these aren't quoted.  We use a
+            # regex to match strings with variable contents.
+            return type_string
+        return '"{}"'.format(type_string)
+
     def format(self, typ: Type, verbosity: int = 0) -> str:
         """
         Convert a type to a relatively short string suitable for error messages.
@@ -192,14 +202,7 @@ class MessageBuilder:
         modification of the formatted string is required, callers should use
         .format_bare.
         """
-        ret = self.format_bare(typ, verbosity)
-        no_quote_regex = r'^tuple\(length \d+\)$'
-        if (ret in ['Module', 'overloaded function', '<nothing>', '<deleted>']
-                or re.match(no_quote_regex, ret) is not None):
-            # Messages are easier to read if these aren't quoted.  We use a
-            # regex to match strings with variable contents.
-            return ret
-        return '"{}"'.format(ret)
+        return self.quote_type_string(self.format_bare(typ, verbosity))
 
     def format_bare(self, typ: Type, verbosity: int = 0) -> str:
         """
@@ -207,7 +210,8 @@ class MessageBuilder:
 
         This method will return an unquoted string.  If a caller doesn't need to
         perform post-processing on the string output, .format should be used
-        instead.
+        instead.  (The caller may want to use .quote_type_string after
+        processing has happened, to maintain consistent quoting in messages.)
         """
         if isinstance(typ, Instance):
             itype = typ
@@ -614,8 +618,9 @@ class MessageBuilder:
                 arg_type_str = '*' + arg_type_str
             elif arg_kind == ARG_STAR2:
                 arg_type_str = '**' + arg_type_str
-            msg = 'Argument {} {}has incompatible type "{}"; expected "{}"'.format(
-                n, target, arg_type_str, expected_type_str)
+            msg = 'Argument {} {}has incompatible type {}; expected {}'.format(
+                n, target, self.quote_type_string(arg_type_str),
+                self.quote_type_string(expected_type_str))
             if isinstance(arg_type, Instance) and isinstance(expected_type, Instance):
                 notes = append_invariance_notes(notes, arg_type, expected_type)
         self.fail(msg, context)

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -579,7 +579,7 @@ class LongTypeName:
     def __add__(self, x: 'LongTypeName') -> 'LongTypeName': pass
 [builtins fixtures/tuple.pyi]
 [out]
-main:3: error: Unsupported operand types for + ("LongTypeName" and tuple(length 50))
+main:3: error: Unsupported operand types for + ("LongTypeName" and <tuple: 50 items>)
 
 
 -- Tuple methods

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -496,3 +496,22 @@ if bool():
     reveal_type(x)  # E: Revealed type is 'Any'
 reveal_type(x)  # E: Revealed type is 'Union[builtins.int, Any]'
 [builtins fixtures/bool.pyi]
+
+[case testLongUnionFormatting]
+from typing import Any, Generic, TypeVar, Union
+
+T = TypeVar('T')
+
+class ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes(Generic[T]):
+    pass
+
+x: Union[ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes[int],
+         ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes[object],
+         ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes[float],
+         ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes[str],
+         ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes[Any],
+         ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes[bytes]]
+
+def takes_int(arg: int) -> None: pass
+
+takes_int(x)  # E: Argument 1 to "takes_int" has incompatible type <union: 6 items>; expected "int"


### PR DESCRIPTION
When the string representation of a tuple or union is too long to display, a shorter representation is used.  This moves from two different representations to `<tuple: N items>` and `<union: N items>`, and consistently does not quote them.

This also includes a refactoring of the quoting logic in to a separate method, which enables the quoting of star arguments consistently with other types.