### PR TITLE
Fix unit-test and pytest lookup

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Mypy test runner."""
 
-from typing import Dict, List, Optional, Set, Iterable
+from typing import Dict, List, Optional, Set, Iterable, Tuple
 
 from mypy.waiter import Waiter, LazySubprocess
 from mypy import util
@@ -89,8 +89,9 @@ class Driver:
     def add_mypy_string(self, name: str, *args: str, cwd: Optional[str] = None) -> None:
         self.add_mypy_cmd(name, ['-c'] + list(args), cwd=cwd)
 
-    def add_pytest(self, pytest_files: List[str], coverage: bool = True) -> None:
-        pytest_files = [name for name in pytest_files if self.allow(name[4:])]
+    def add_pytest(self, files: List[Tuple[str, str]], coverage: bool = True) -> None:
+        pytest_files = [name for kind, name in files
+                        if self.allow('pytest {} {}'.format(kind, name))]
         if not pytest_files:
             return
         pytest_args = pytest_files + self.arglist + self.pyt_arglist
@@ -99,7 +100,8 @@ class Driver:
         else:
             args = [sys.executable, '-m', 'pytest'] + pytest_args
 
-        self.waiter.add(LazySubprocess('pytest', args, env=self.env, passthrough=self.verbosity),
+        self.waiter.add(LazySubprocess('pytest', args, env=self.env,
+                                       passthrough=self.verbosity),
                         sequential=True)
 
     def add_python(self, name: str, *args: str, cwd: Optional[str] = None) -> None:
@@ -210,14 +212,16 @@ PYTEST_FILES = test_path(
     'testtransform',
     'testtypegen',
     'testparse',
-    'testsemanal',
+    'testsemanal'
+)
+
+SLOW_FILES = test_path(
     'testpythoneval',
     'testcmdline'
 )
 
 MYUNIT_FILES = test_path(
-    'teststubgen',  # contains data-driven suite
-
+    'teststubgen',
     'testargs',
     'testgraph',
     'testinfer',
@@ -229,17 +233,18 @@ MYUNIT_FILES = test_path(
 )
 
 for f in find_files('mypy', prefix='test', suffix='.py'):
-    assert f in PYTEST_FILES + MYUNIT_FILES, f
+    assert f in PYTEST_FILES + SLOW_FILES + MYUNIT_FILES, f
 
 
 def add_pytest(driver: Driver) -> None:
-    driver.add_pytest(PYTEST_FILES)
+    driver.add_pytest([('unit-test', name) for name in PYTEST_FILES] +
+                      [('integration', name) for name in SLOW_FILES])
 
 
 def add_myunit(driver: Driver) -> None:
     for f in MYUNIT_FILES:
         mod = file_to_module(f)
-        driver.add_python_mod('unit-test %s' % mod, 'mypy.myunit', '-m', mod,
+        driver.add_python_mod('myunit unit-test %s' % mod, 'mypy.myunit', '-m', mod,
                               *driver.arglist, coverage=True)
 
 

--- a/test-data/unit/README.md
+++ b/test-data/unit/README.md
@@ -102,7 +102,7 @@ filters:
 
 For example, to run unit tests only, which run pretty quickly:
 
-    $ ./runtests.py unit-test pytest
+    $ ./runtests.py unit-test
 
 The unit test suites are driven by a mixture of test frameworks: mypy's own
 `myunit` framework, and `pytest`, which we're in the process of migrating to.


### PR DESCRIPTION
Quick fix for <s>both #3890 and</s> #3891. I'm not sure it does the right thing, but it's will be easier to discuss it here. I'm also not sure about terminology.

`./runtests.py unit-test` runs all unit tests (both myunit and pytest) except pythoneval and cmdline
`./runtests.py integration` runs pythoneval and cmdline

Also possible `./runtests.py myunit` and `./runtests.py pytest`

