### PR TITLE
Infer better type for call to overload with Any actual arguments

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2790,20 +2790,21 @@ def any_arg_causes_overload_ambiguity(items: List[CallableType],
         for item in items
     ]
 
-    for i, arg_type in enumerate(arg_types):
+    for arg_idx, arg_type in enumerate(arg_types):
         if isinstance(arg_type, AnyType):
-            matching_formals_unfiltered = [(j, lookup[i])
-                                           for j, lookup in enumerate(actual_to_formal)
-                                           if lookup[i]]
+            matching_formals_unfiltered = [(item_idx, lookup[arg_idx])
+                                           for item_idx, lookup in enumerate(actual_to_formal)
+                                           if lookup[arg_idx]]
             matching_formals = []
-            for j, formals in matching_formals_unfiltered:
+            for item_idx, formals in matching_formals_unfiltered:
                 if len(formals) > 1:
                     # An actual maps to multiple formals -- give up as too
                     # complex, just assume it overlaps.
                     return True
-                matching_formals.append((j, items[j].arg_types[formals[0]]))
+                matching_formals.append((item_idx, items[item_idx].arg_types[formals[0]]))
             if (not all_same_types(t for _, t in matching_formals) and
-                    not all_same_types(items[j].ret_type for j, _ in matching_formals)):
+                    not all_same_types(items[idx].ret_type
+                                       for idx, _ in matching_formals)):
                 # Any maps to multiple different types, and the return types of these items differ.
                 return True
     return False

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1157,3 +1157,116 @@ class Test(object):
 
 t = Test()
 reveal_type(t.do_chain)  # E: Revealed type is '__main__.Chain'
+
+[case testOverloadWithOverlappingItemsAndAnyArgument1]
+from typing import overload, Any
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: object) -> object: ...
+def f(x): pass
+
+a: Any
+reveal_type(f(a))  # E: Revealed type is 'Any'
+
+[case testOverloadWithOverlappingItemsAndAnyArgument2]
+from typing import overload, Any
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: float) -> float: ...
+def f(x): pass
+
+a: Any
+reveal_type(f(a))  # E: Revealed type is 'Any'
+
+[case testOverloadWithOverlappingItemsAndAnyArgument3]
+from typing import overload, Any
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: str) -> str: ...
+def f(x): pass
+
+a: Any
+reveal_type(f(a))  # E: Revealed type is 'Any'
+
+[case testOverloadWithOverlappingItemsAndAnyArgument4]
+from typing import overload, Any
+
+@overload
+def f(x: int, y: int, z: str) -> int: ...
+@overload
+def f(x: object, y: int, z: str) -> object: ...
+def f(x): pass
+
+a: Any
+# Any causes ambiguity
+reveal_type(f(a, 1, ''))  # E: Revealed type is 'Any'
+# Any causes no ambiguity
+reveal_type(f(1, a, a))  # E: Revealed type is 'builtins.int'
+reveal_type(f('', a, a))  # E: Revealed type is 'builtins.object'
+# Like above, but use keyword arguments.
+reveal_type(f(y=1, z='', x=a))  # E: Revealed type is 'Any'
+reveal_type(f(y=a, z='', x=1))  # E: Revealed type is 'builtins.int'
+
+[case testOverloadWithOverlappingItemsAndAnyArgument5]
+from typing import overload, Any, Union
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: Union[int, float]) -> float: ...
+def f(x): pass
+
+a: Any
+reveal_type(f(a))  # E: Revealed type is 'Any'
+
+[case testOverloadWithOverlappingItemsAndAnyArgument6]
+from typing import overload, Any
+
+@overload
+def f(x: int, y: int) -> int: ...
+@overload
+def f(x: float, y: int, z: str) -> float: ...
+@overload
+def f(x: object, y: int, z: str, a: None) -> object: ...
+def f(x): pass
+
+a: Any
+# Any causes ambiguity
+reveal_type(f(*a))  # E: Revealed type is 'Any'
+reveal_type(f(a, *a))  # E: Revealed type is 'Any'
+reveal_type(f(1, *a))  # E: Revealed type is 'Any'
+reveal_type(f(1.1, *a))  # E: Revealed type is 'Any'
+reveal_type(f('', *a))  # E: Revealed type is 'builtins.object'
+
+[case testOverloadWithOverlappingItemsAndAnyArgument7]
+from typing import overload, Any
+
+@overload
+def f(x: int, y: int, z: int) -> int: ...
+@overload
+def f(x: object, y: int, z: int) -> object: ...
+def f(x): pass
+
+a: Any
+# TODO: We could infer 'int' here
+reveal_type(f(1, *a))  # E: Revealed type is 'Any'
+
+[case testOverloadWithOverlappingItemsAndAnyArgument8]
+from typing import overload, Any
+
+@overload
+def f(x: int, y: int, z: int) -> str: ...
+@overload
+def f(x: object, y: int, z: int) -> str: ...
+def f(x): pass
+
+a: Any
+# The return type is not ambiguous so Any arguments cause no ambiguity.
+reveal_type(f(a, 1, 1)) # E: Revealed type is 'builtins.str'
+reveal_type(f(1, *a))  # E: Revealed type is 'builtins.str'

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1212,6 +1212,8 @@ reveal_type(f('', a, a))  # E: Revealed type is 'builtins.object'
 # Like above, but use keyword arguments.
 reveal_type(f(y=1, z='', x=a))  # E: Revealed type is 'Any'
 reveal_type(f(y=a, z='', x=1))  # E: Revealed type is 'builtins.int'
+reveal_type(f(z='', x=1, y=a))  # E: Revealed type is 'builtins.int'
+reveal_type(f(z='', x=a, y=1))  # E: Revealed type is 'Any'
 
 [case testOverloadWithOverlappingItemsAndAnyArgument5]
 from typing import overload, Any, Union


### PR DESCRIPTION
If the overload return type is ambiguous and there is an `Any` actual
argument that seems to cause the ambiguity, infer `Any` as the type of
the call expression instead of some precise type. Previously we
sometimes inferred a precise type even though the type was ambiguous,
resulting in false positives.

This is not quite the most correct implementation since we sometimes
incorrectly assume ambiguity caused by `Any` even though none actually
exists. This is acceptable since this only affects calls with `Any`
arguments that are imprecise anyway. Also, the correct logic would be
quite complex, hard to test and probably not worth it, at least right
now.

Fixes #3662.