### PR TITLE
Type check arguments for "super"

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2105,7 +2105,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             elif isinstance(type_obj_type, AnyType):
                 return
             else:
-                self.chk.fail('First argument for "super" must be a type object', e)
+                self.msg.first_argument_for_super_must_be_type(type_obj_type, e)
                 return
 
             if isinstance(instance_type, (Instance, TupleType, TypeVarType)):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2099,7 +2099,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 if not isinstance(item, Instance):
                     # A complicated type object type. Too tricky, give up.
                     # TODO: Do something more clever here.
-                    self.chk.fail(messages.UNSUPPORTED_ARGUMENT_2_FOR_SUPER, e)
+                    self.chk.fail('Unsupported argument 1 for "super"', e)
                     return
                 type_info = item.type
             elif isinstance(type_obj_type, AnyType):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2145,9 +2145,12 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                         self.chk.fail('super() outside of a method is not supported', e)
                         return AnyType(TypeOfAny.from_error)
                     args = self.chk.scope.top_function().arguments
-                    # An empty args with super() is an error; we need something in declared_self
+                    # super() in a function with empty args is an error; we
+                    # need something in declared_self.
                     if not args:
-                        self.chk.fail('super() requires at least one positional argument', e)
+                        self.chk.fail(
+                            'super() requires one or more positional arguments in '
+                            'enclosing function', e)
                         return AnyType(TypeOfAny.from_error)
                     declared_self = args[0].variable.type
                     return analyze_member_access(name=e.name, typ=fill_typevars(e.info), node=e,

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -928,7 +928,7 @@ class ASTConverter(ast3.NodeTransformer):
         if (isinstance(n.value, ast3.Call) and
                 isinstance(n.value.func, ast3.Name) and
                 n.value.func.id == 'super'):
-            return SuperExpr(n.attr)
+            return SuperExpr(n.attr, self.visit(n.value))
 
         return MemberExpr(self.visit(n.value), n.attr)
 

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -892,7 +892,7 @@ class ASTConverter(ast27.NodeTransformer):
         if (isinstance(n.value, ast27.Call) and
                 isinstance(n.value.func, ast27.Name) and
                 n.value.func.id == 'super'):
-            return SuperExpr(n.attr)
+            return SuperExpr(n.attr, self.visit(n.value))
 
         return MemberExpr(self.visit(n.value), n.attr)
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -820,6 +820,15 @@ class MessageBuilder:
     def undefined_in_superclass(self, member: str, context: Context) -> None:
         self.fail('"{}" undefined in superclass'.format(member), context)
 
+    def first_argument_for_super_must_be_type(self, actual: Type, context: Context) -> None:
+        if isinstance(actual, Instance):
+            # Don't include type of instance, because it can look confusingly like a type
+            # object.
+            type_str = 'a non-type instance'
+        else:
+            type_str = self.format(actual)
+        self.fail('Argument 1 for "super" must be a type object; got {}'.format(type_str), context)
+
     def too_few_string_formatting_arguments(self, context: Context) -> None:
         self.fail('Not enough arguments for format string', context)
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -99,6 +99,7 @@ CANNOT_ISINSTANCE_NEWTYPE = 'Cannot use isinstance() with a NewType type'
 BARE_GENERIC = 'Missing type parameters for generic type'
 IMPLICIT_GENERIC_ANY_BUILTIN = 'Implicit generic "Any". Use \'{}\' and specify generic parameters'
 INCOMPATIBLE_TYPEVAR_VALUE = 'Value of type variable "{}" of {} cannot be {}'
+UNSUPPORTED_ARGUMENT_2_FOR_SUPER = 'Unsupported argument 2 for "super"'
 
 ARG_CONSTRUCTOR_NAMES = {
     ARG_POS: "Arg",

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1465,9 +1465,11 @@ class SuperExpr(Expression):
 
     name = ''
     info = None  # type: TypeInfo  # Type that contains this super expression
+    call = None  # type: CallExpr  # The expression super(...)
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, call: CallExpr) -> None:
         self.name = name
+        self.call = call
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_super_expr(self)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3086,6 +3086,8 @@ class SemanticAnalyzer(NodeVisitor[None]):
             self.fail('"super" used outside class', expr)
             return
         expr.info = self.type
+        for arg in expr.call.args:
+            arg.accept(self)
 
     def visit_tuple_expr(self, expr: TupleExpr) -> None:
         for item in expr.items:

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -392,7 +392,9 @@ class TransformVisitor(NodeVisitor[Node]):
         return RevealTypeExpr(self.expr(node.expr))
 
     def visit_super_expr(self, node: SuperExpr) -> SuperExpr:
-        new = SuperExpr(node.name, cast(CallExpr, self.expr(node.call)))
+        call = self.expr(node.call)
+        assert isinstance(call, CallExpr)
+        new = SuperExpr(node.name, call)
         new.info = node.info
         return new
 

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -392,7 +392,7 @@ class TransformVisitor(NodeVisitor[Node]):
         return RevealTypeExpr(self.expr(node.expr))
 
     def visit_super_expr(self, node: SuperExpr) -> SuperExpr:
-        new = SuperExpr(node.name)
+        new = SuperExpr(node.name, cast(CallExpr, self.expr(node.call)))
         new.info = node.info
         return new
 

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -308,3 +308,12 @@ class A:
 [out]
 main:2: error: Invalid type for self, or extra argument type in function annotation
 main:2: note: (Hint: typically annotations omit the type for self)
+
+[case testSuper]
+class A:
+    def f(self): # type: () -> None
+        pass
+class B(A):
+    def g(self): # type: () -> None
+        super(B, self).f()
+        super().f() # E: Too few arguments for "super"

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -260,7 +260,14 @@ class B:
     def f(self) -> None: pass
 class C(B):
     def h(self) -> None:
-        super(self, C).f # E: First argument for "super" must be a type object
+        super(self, C).f # E: Argument 1 for "super" must be a type object; got a non-type instance
+
+[case testInvalidFirstSuperArg]
+class B:
+    def f(self) -> None: pass
+class C(B):
+    def h(self) -> None:
+        super(None, C).f # E: Argument 1 for "super" must be a type object; got "None"
 
 [case testInvalidSecondArgumentToSuper]
 class B:

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -125,16 +125,21 @@ class C:
     def h(self):
         super(C, self).xyz
 
-[case testSuperWithTypeType]
+[case testSuperWithTypeObjects]
 from typing import Type
 
 class A:
-    def f(self) -> None: pass
+    def f(self) -> object: pass
 
 class B(A):
+    def f(self) -> int: pass
+
     @classmethod
     def g(cls, x) -> None:
-        reveal_type(super(cls, x).f) # E: Revealed type is 'def ()'
+        reveal_type(super(cls, x).f) # E: Revealed type is 'def () -> builtins.object'
+
+    def h(self, t: Type[B]) -> None:
+        reveal_type(super(t, self).f) # E: Revealed type is 'def () -> builtins.object'
 [builtins fixtures/classmethod.pyi]
 
 [case testSuperWithTypeTypeAsSecondArgument]
@@ -152,17 +157,17 @@ from typing import TypeVar
 T = TypeVar('T', bound='C')
 
 class B:
-    def f(self) -> None: pass
+    def f(self) -> float: pass
 
 class C(B):
-    def f(self) -> None: pass
+    def f(self) -> int: pass
 
     def g(self: T) -> T:
-        reveal_type(super(C, self).f) # E: Revealed type is 'def ()'
+        reveal_type(super(C, self).f) # E: Revealed type is 'def () -> builtins.float'
         return self
 
-[case testSuperWithTypeVarValues]
-from typing import TypeVar, Generic
+[case testSuperWithTypeVarValues1]
+from typing import TypeVar
 
 T = TypeVar('T', 'C', 'D')
 S = TypeVar('S', 'B', 'C')
@@ -171,6 +176,24 @@ class B:
     def f(self) -> None: pass
 
 class C(B):
+    def f(self) -> None: pass
+
+    def g(self, x: T, y: S) -> None:
+        super(C, x).f
+        super(C, y).f # E: Argument 2 for "super" not an instance of argument 1
+
+class D(C): pass
+
+[case testSuperWithTypeVarValues2]
+from typing import TypeVar, Generic
+
+T = TypeVar('T', 'C', 'D')
+S = TypeVar('S', 'B', 'C')
+
+class B:
+    def f(self) -> None: pass
+
+class C(B, Generic[T, S]):
     def f(self) -> None: pass
 
     def g(self, x: T, y: S) -> None:

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -287,3 +287,13 @@ class B(A):
     def h(self) -> None:
         def a() -> None:
             super().f() # E: super() requires one or more positional arguments in enclosing function
+
+[case testSuperWithUnsupportedTypeObject]
+from typing import Type
+
+class A:
+    def f(self) -> int: pass
+
+class B(A):
+    def h(self, t: Type[None]) -> None:
+        super(t, self).f # E: Unsupported argument 1 for "super"

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -269,3 +269,14 @@ class C(B):
     def h(self) -> None:
         super(C, 1).f # E: Argument 2 for "super" not an instance of argument 1
         super(C, None).f # E: Unsupported argument 2 for "super"
+
+[case testSuperInMethodWithNoArguments]
+class A:
+    def f(self) -> None: pass
+
+class B(A):
+    def g() -> None: # E: Method must have at least one argument
+        super().f() # E: super() requires one or more positional arguments in enclosing function
+    def h(self) -> None:
+        def a() -> None:
+            super().f() # E: super() requires one or more positional arguments in enclosing function

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -92,10 +92,6 @@ B(1)
 B(1, 'x')
 [builtins fixtures/__new__.pyi]
 
-[case testSuperOutsideMethodNoCrash]
-class C:
-    a = super().whatever  # E: super() outside of a method is not supported
-
 reveal_type(C.a)  # E: Revealed type is 'Any'
 [out]
 
@@ -115,3 +111,138 @@ class B(A):
     def foo(self):
         super(B, self).foo() # Not an error
 [out]
+
+[case testSuperWithAny]
+class B:
+    def f(self) -> None: pass
+class C(B):
+    def h(self, x) -> None:
+        reveal_type(super(x, x).f) # E: Revealed type is 'def ()'
+        reveal_type(super(C, x).f) # E: Revealed type is 'def ()'
+
+[case testSuperInUnannotatedMethod]
+class C:
+    def h(self):
+        super(C, self).xyz
+
+[case testSuperWithTypeType]
+from typing import Type
+
+class A:
+    def f(self) -> None: pass
+
+class B(A):
+    @classmethod
+    def g(cls, x) -> None:
+        reveal_type(super(cls, x).f) # E: Revealed type is 'def ()'
+[builtins fixtures/classmethod.pyi]
+
+[case testSuperWithTypeTypeAsSecondArgument]
+class B:
+    def f(self) -> None: pass
+
+class C(B):
+    def __new__(cls) -> 'C':
+        super(C, cls).f
+        return C()
+
+[case testSuperWithGenericSelf]
+from typing import TypeVar
+
+T = TypeVar('T', bound='C')
+
+class B:
+    def f(self) -> None: pass
+
+class C(B):
+    def f(self) -> None: pass
+
+    def g(self: T) -> T:
+        reveal_type(super(C, self).f) # E: Revealed type is 'def ()'
+        return self
+
+[case testSuperWithTypeVarValues]
+from typing import TypeVar, Generic
+
+T = TypeVar('T', 'C', 'D')
+S = TypeVar('S', 'B', 'C')
+
+class B:
+    def f(self) -> None: pass
+
+class C(B):
+    def f(self) -> None: pass
+
+    def g(self, x: T, y: S) -> None:
+        super(C, x).f
+        super(C, y).f # E: Argument 2 for "super" not an instance of argument 1
+
+class D(C): pass
+
+
+-- Invalid uses of super()
+-- -----------------------
+
+
+[case testSuperOutsideMethodNoCrash]
+class C:
+    a = super().whatever  # E: super() outside of a method is not supported
+
+[case testSuperWithSingleArgument]
+class B:
+    def f(self) -> None: pass
+class C(B):
+    def __init__(self) -> None:
+        super(C).f() # E: "super" with a single argument not supported
+
+[case testSuperWithThreeArguments]
+class B:
+    def f(self) -> None: pass
+class C(B):
+    def h(self) -> None:
+        super(C, self, 1).f() # E: Too many arguments for "super"
+
+[case testSuperWithNonPositionalArguments]
+class B:
+    def f(self) -> None: pass
+class C(B):
+    def h(self) -> None:
+        super(C, x=self).f() # E: "super" only accepts positional arguments
+        super(**{}).f() # E: "super" only accepts positional arguments
+
+[case testSuperWithVarArgs]
+class B:
+    def f(self) -> None: pass
+class C(B):
+    def h(self) -> None:
+        super(*(C, self)).f() # E: Varargs not supported with "super"
+
+[case testInvalidSuperArg]
+class B:
+    def f(self) -> None: pass
+class C(B):
+    def h(self) -> None:
+        super(x, y).f # E: Name 'x' is not defined # E: Name 'y' is not defined
+
+[case testTypeErrorInSuperArg]
+class B:
+    def f(self) -> None: pass
+class C(B):
+    def h(self) -> None:
+        super(1(), self).f # E: "int" not callable
+        super(C, ''()).f  # E: "str" not callable
+
+[case testFlippedSuperArgs]
+class B:
+    def f(self) -> None: pass
+class C(B):
+    def h(self) -> None:
+        super(self, C).f # E: First argument for "super" must be a type object
+
+[case testInvalidSecondArgumentToSuper]
+class B:
+    def f(self) -> None: pass
+class C(B):
+    def h(self) -> None:
+        super(C, 1).f # E: Argument 2 for "super" not an instance of argument 1
+        super(C, None).f # E: Unsupported argument 2 for "super"


### PR DESCRIPTION
This is not quite as strict as we could be, but this is still better
than what we had before. A full implementation will be somewhat
complicated.

Remaining issues:

* Assume that the first argument refers to the enclosing class, even
  though that's not generally the case.

* Assume that a type object as the second argument is always fine.

* Don't validate some kinds of type object types as the first argument.

* Single-argument variant is not supported.

Fixes #526 (modulo the open issues).

Also, I no longer think that defining messages as constants in
`mypy.messages` is generally a good idea so I'm not following
that pattern here. I'll officially update the convention in a
separate PR.