### PR TITLE
Update convention about implenting messages in the type checker

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1,7 +1,14 @@
 """Facilities and constants for generating error messages during type checking.
 
-The type checker itself does not deal with message string literals to
-improve code clarity and to simplify localization (in the future)."""
+Don't add any non-trivial message construction logic to the type
+checker, as it can compromise clarity and make messages less
+consistent. Add such logic to this module instead. Literal messages used
+in multiple places should also be defined as constants in this module so
+they won't get out of sync.
+
+Historically we tried to avoid all message string literals in the type
+checker but we are moving away from this convention.
+"""
 
 import re
 import difflib


### PR DESCRIPTION
Using constants for all type checker messages doesn't seem very
valuable and it introduces some unnecessary friction when defining
simple messages.

I don't think that it's useful to refactor away the existing
constants, though. The cost of the old convention is primarily in
writing new code, not in reading existing code.