### PR TITLE
Fix misindented `del` statement

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1989,7 +1989,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         if not self.current_node_deferred:
                             var.type = self.named_generic_type('builtins.dict',
                                                                [full_key_type, full_value_type])
-                        del partial_types[var]
+                            del partial_types[var]
 
     def visit_expression_stmt(self, s: ExpressionStmt) -> None:
         self.expr_checker.accept(s.expr, allow_none_return=True, always_allow_any=True)

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2951,3 +2951,21 @@ def foo(a: int, b: int) -> str:
 [out1]
 [out2]
 tmp/b.py:2: error: Incompatible return value type (got "int", expected "str")
+
+[case testCrashWithPartialGlobalAndCycle]
+import bar
+
+[file foo.py]
+import bar
+my_global_dict = {}  # type: ignore
+def external_func_0() -> None:
+    global my_global_dict
+    bar.external_list
+    my_global_dict[12] = 0
+
+[file bar.py]
+import foo
+
+external_list = [0]
+
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes #3892.

Everywhere we infer the correct type for a partially-typed variable,
we do two things: set var.type and delete var from partial_tyes.
However in one place (try_infer_partial_type_from_indexed_assignment())
the var.type assignment was skipped if the current node was deferred
but the deletion was done unconditionally.  This caused the partial
type to remain in a place where serialization could not handle it.