### PR TITLE
[clean-strict-optional] Clean-up the type checking files

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -212,7 +212,7 @@ class ConditionalTypeBinder:
 
     def assign_type(self, expr: Expression,
                     type: Type,
-                    declared_type: Type,
+                    declared_type: Optional[Type],
                     restrict_any: bool = False) -> None:
         if not isinstance(expr, BindableTypes):
             return None

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -205,7 +205,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     self.fail(messages.ALL_MUST_BE_SEQ_STR.format(str_seq_s, all_s),
                             all_node)
 
-    def check_second_pass(self, todo: List[DeferredNode] = None) -> bool:
+    def check_second_pass(self, todo: Optional[List[DeferredNode]] = None) -> bool:
         """Run second or following pass of type checking.
 
         This goes through deferred nodes, returning True if there were any.
@@ -279,8 +279,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         except Exception as err:
             report_internal_error(err, self.errors.file, stmt.line, self.errors, self.options)
 
-    def accept_loop(self, body: Statement, else_body: Statement = None, *,
-                    exit_condition: Expression = None) -> None:
+    def accept_loop(self, body: Statement, else_body: Optional[Statement] = None, *,
+                    exit_condition: Optional[Expression] = None) -> None:
         """Repeatedly type check a loop body until the frame doesn't change.
         If exit_condition is set, assume it must be False on exit from the loop.
 
@@ -562,15 +562,15 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                        'original type')
 
     def check_func_item(self, defn: FuncItem,
-                        type_override: CallableType = None,
-                        name: str = None) -> None:
+                        type_override: Optional[CallableType] = None,
+                        name: Optional[str] = None) -> None:
         """Type check a function.
 
         If type_override is provided, use it as the function type.
         """
         # We may be checking a function definition or an anonymous function. In
         # the first case, set up another reference with the precise type.
-        fdef = None  # type: FuncDef
+        fdef = None  # type: Optional[FuncDef]
         if isinstance(defn, FuncDef):
             fdef = defn
 
@@ -597,7 +597,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         yield None
         self.inferred_attribute_types = old_types
 
-    def check_func_def(self, defn: FuncItem, typ: CallableType, name: str) -> None:
+    def check_func_def(self, defn: FuncItem, typ: CallableType, name: Optional[str]) -> None:
         """Type check a function definition."""
         # Expand type variables with value restrictions to ordinary types.
         for item, typ in self.expand_typevars(defn, typ):
@@ -610,7 +610,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 # function. In the first case, set up another reference with the
                 # precise type.
                 if isinstance(item, FuncDef):
-                    fdef = item
+                    fdef = item  # type: Optional[FuncDef]
                 else:
                     fdef = None
 
@@ -634,12 +634,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                     self.msg.unimported_type_becomes_any(prefix, arg_type, fdef)
                     check_for_explicit_any(fdef.type, self.options, self.is_typeshed_stub,
                                            self.msg, context=fdef)
-                if name in nodes.reverse_op_method_set:
-                    self.check_reverse_op_method(item, typ, name)
-                elif name in ('__getattr__', '__getattribute__'):
-                    self.check_getattr_method(typ, defn, name)
-                elif name == '__setattr__':
-                    self.check_setattr_method(typ, defn)
+                if name:  # Special method names
+                    if name in nodes.reverse_op_method_set:
+                        self.check_reverse_op_method(item, typ, name)
+                    elif name in ('__getattr__', '__getattribute__'):
+                        self.check_getattr_method(typ, defn, name)
+                    elif name == '__setattr__':
+                        self.check_setattr_method(typ, defn)
                 # Refuse contravariant return type variable
                 if isinstance(typ.ret_type, TypeVarType):
                     if typ.ret_type.variance == CONTRAVARIANT:
@@ -1454,7 +1455,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # lvalue had a type defined; this is handled by other
         # parts, and all we have to worry about in that case is
         # that lvalue is compatible with the base class.
-        compare_node = None  # type: Node
+        compare_node = None  # type: Optional[Node]
         if lvalue_type:
             compare_type = lvalue_type
             compare_node = lvalue.node
@@ -1533,7 +1534,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         return None, None
 
     def check_compatibility_classvar_super(self, node: Var,
-                                           base: TypeInfo, base_node: Node) -> bool:
+                                           base: TypeInfo, base_node: Optional[Node]) -> bool:
         if not isinstance(base_node, Var):
             return True
         if node.is_classvar and not base_node.is_classvar:
@@ -1600,7 +1601,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                rvalue: Expression,
                                context: Context,
                                infer_lvalue_type: bool = True,
-                               msg: str = None) -> None:
+                               msg: Optional[str] = None) -> None:
         """Check the assignment of one rvalue to a number of lvalues."""
 
         # Infer the type of an ordinary rvalue expression.
@@ -1801,7 +1802,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 self.fail(messages.NEED_ANNOTATION_FOR_VAR, context)
                 self.set_inference_error_fallback_type(name, lvalue, init_type, context)
         elif (isinstance(lvalue, MemberExpr) and self.inferred_attribute_types is not None
-              and lvalue.def_var in self.inferred_attribute_types
+              and lvalue.def_var and lvalue.def_var in self.inferred_attribute_types
               and not is_same_type(self.inferred_attribute_types[lvalue.def_var], init_type)):
             # Multiple, inconsistent types inferred for an attribute.
             self.fail(messages.NEED_ANNOTATION_FOR_VAR, context)
@@ -1844,6 +1845,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             var.is_inferred = True
             if isinstance(lvalue, MemberExpr) and self.inferred_attribute_types is not None:
                 # Store inferred attribute type so that we can check consistency afterwards.
+                assert lvalue.def_var is not None
                 self.inferred_attribute_types[lvalue.def_var] = type
             self.store_type(lvalue, type)
 
@@ -2223,22 +2225,25 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     self.accept(s.body)
                 for i in range(len(s.handlers)):
                     with self.binder.frame_context(can_skip=True, fall_through=4):
-                        if s.types[i]:
-                            t = self.check_except_handler_test(s.types[i])
-                            if s.vars[i]:
+                        typ = s.types[i]
+                        if typ:
+                            t = self.check_except_handler_test(typ)
+                            var = s.vars[i]
+                            if var:
                                 # To support local variables, we make this a definition line,
                                 # causing assignment to set the variable's type.
-                                s.vars[i].is_def = True
+                                var.is_def = True
                                 # We also temporarily set current_node_deferred to False to
                                 # make sure the inference happens.
                                 # TODO: Use a better solution, e.g. a
                                 # separate Var for each except block.
                                 am_deferring = self.current_node_deferred
                                 self.current_node_deferred = False
-                                self.check_assignment(s.vars[i], self.temp_node(t, s.vars[i]))
+                                self.check_assignment(var, self.temp_node(t, var))
                                 self.current_node_deferred = am_deferring
                         self.accept(s.handlers[i])
-                        if s.vars[i]:
+                        var = s.vars[i]
+                        if var:
                             # Exception variables are deleted in python 3 but not python 2.
                             # But, since it's bad form in python 2 and the type checking
                             # wouldn't work very well, we delete it anyway.
@@ -2246,14 +2251,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             # Unfortunately, this doesn't let us detect usage before the
                             # try/except block.
                             if self.options.python_version[0] >= 3:
-                                source = s.vars[i].name
+                                source = var.name
                             else:
                                 source = ('(exception variable "{}", which we do not '
                                           'accept outside except: blocks even in '
-                                          'python 2)'.format(s.vars[i].name))
-                            var = cast(Var, s.vars[i].node)
-                            var.type = DeletedType(source=source)
-                            self.binder.cleanse(s.vars[i])
+                                          'python 2)'.format(var.name))
+                            cast(Var, var.node).type = DeletedType(source=source)
+                            self.binder.cleanse(var)
             if s.else_body:
                 self.accept(s.else_body)
 
@@ -2452,7 +2456,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if mypy.checkexpr.has_any_type(typ):
             self.msg.untyped_decorated_function(typ, func)
 
-    def check_async_with_item(self, expr: Expression, target: Expression,
+    def check_async_with_item(self, expr: Expression, target: Optional[Expression],
                               infer_lvalue_type: bool) -> None:
         echk = self.expr_checker
         ctx = echk.accept(expr)
@@ -2468,7 +2472,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         echk.check_awaitable_expr(
             res, expr, messages.INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AEXIT)
 
-    def check_with_item(self, expr: Expression, target: Expression,
+    def check_with_item(self, expr: Expression, target: Optional[Expression],
                         infer_lvalue_type: bool) -> None:
         echk = self.expr_checker
         ctx = echk.accept(expr)
@@ -2502,8 +2506,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
     def check_subtype(self, subtype: Type, supertype: Type, context: Context,
                       msg: str = messages.INCOMPATIBLE_TYPES,
-                      subtype_label: str = None,
-                      supertype_label: str = None) -> bool:
+                      subtype_label: Optional[str] = None,
+                      supertype_label: Optional[str] = None) -> bool:
         """Generate an error if the subtype is not compatible with
         supertype."""
         if is_subtype(subtype, supertype):
@@ -2621,7 +2625,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             parts = name.split('.')
             n = self.modules[parts[0]]
             for i in range(1, len(parts) - 1):
-                n = cast(MypyFile, n.names.get(parts[i], None).node)
+                sym = n.names.get(parts[i])
+                assert sym is not None, "Internal error: attempted lookup of unknown name"
+                n = cast(MypyFile, sym.node)
             last = parts[-1]
             if last in n.names:
                 return n.names[last]
@@ -2659,7 +2665,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 return partial_types
         return None
 
-    def temp_node(self, t: Type, context: Context = None) -> TempNode:
+    def temp_node(self, t: Type, context: Optional[Context] = None) -> TempNode:
         """Create a temporary node with the given, fixed type."""
         temp = TempNode(t)
         if context:
@@ -2904,7 +2910,7 @@ def or_conditional_maps(m1: TypeMap, m2: TypeMap) -> TypeMap:
 
 
 def convert_to_typetype(type_map: TypeMap) -> TypeMap:
-    converted_type_map = {}  # type: TypeMap
+    converted_type_map = {}  # type: Dict[Expression, Type]
     if type_map is None:
         return None
     for expr, typ in type_map.items():
@@ -3278,7 +3284,7 @@ def is_valid_inferred_type_component(typ: Type) -> bool:
     return True
 
 
-def is_node_static(node: Node) -> Optional[bool]:
+def is_node_static(node: Optional[Node]) -> Optional[bool]:
     """Find out if a node describes a static function method."""
 
     if isinstance(node, FuncDef):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -610,11 +610,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 # function. In the first case, set up another reference with the
                 # precise type.
                 if isinstance(item, FuncDef):
-                    fdef = item  # type: Optional[FuncDef]
-                else:
-                    fdef = None
-
-                if fdef:
+                    fdef = item
                     # Check if __init__ has an invalid, non-None return type.
                     if (fdef.info and fdef.name() in ('__init__', '__init_subclass__') and
                             not isinstance(typ.ret_type, NoneTyp) and
@@ -634,6 +630,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                     self.msg.unimported_type_becomes_any(prefix, arg_type, fdef)
                     check_for_explicit_any(fdef.type, self.options, self.is_typeshed_stub,
                                            self.msg, context=fdef)
+
                 if name:  # Special method names
                     if name in nodes.reverse_op_method_set:
                         self.check_reverse_op_method(item, typ, name)
@@ -641,6 +638,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         self.check_getattr_method(typ, defn, name)
                     elif name == '__setattr__':
                         self.check_setattr_method(typ, defn)
+
                 # Refuse contravariant return type variable
                 if isinstance(typ.ret_type, TypeVarType):
                     if typ.ret_type.variance == CONTRAVARIANT:
@@ -1456,7 +1454,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # lvalue had a type defined; this is handled by other
         # parts, and all we have to worry about in that case is
         # that lvalue is compatible with the base class.
-        compare_node = None  # type: Optional[Node]
+        compare_node = None
         if lvalue_type:
             compare_type = lvalue_type
             compare_node = lvalue.node

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1,7 +1,7 @@
 """Expression type checker. This file is conceptually part of TypeChecker."""
 
 from collections import OrderedDict
-from typing import cast, Dict, Set, List, Tuple, Callable, Union, Optional, Iterable
+from typing import cast, Dict, Set, List, Tuple, Callable, Union, Optional, Iterable, Sequence, Any
 
 from mypy.errors import report_internal_error
 from mypy.typeanal import has_any_from_unimported_type, check_for_explicit_any, set_any_tvars
@@ -281,12 +281,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def check_typeddict_call(self, callee: TypedDictType,
                              arg_kinds: List[int],
-                             arg_names: List[str],
+                             arg_names: Sequence[Optional[str]],
                              args: List[Expression],
                              context: Context) -> Type:
         if len(args) >= 1 and all([ak == ARG_NAMED for ak in arg_kinds]):
             # ex: Point(x=42, y=1337)
-            item_names = arg_names
+            assert all(arg_name is not None for arg_name in arg_names)
+            item_names = cast(List[str], arg_names)
             item_args = args
             return self.check_typeddict_call_with_kwargs(
                 callee, OrderedDict(zip(item_names, item_args)), context)
@@ -487,7 +488,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def check_call(self, callee: Type, args: List[Expression],
                    arg_kinds: List[int], context: Context,
-                   arg_names: Optional[List[str]] = None,
+                   arg_names: Optional[Sequence[Optional[str]]] = None,
                    callable_node: Optional[Expression] = None,
                    arg_messages: Optional[MessageBuilder] = None,
                    callable_name: Optional[str] = None,
@@ -675,8 +676,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if callee:
             fixed = min(fixed, callee.max_fixed_args())
 
-        arg_type = None  # type: Type
-        ctx = None  # type: Type
+        ctx = None  # type: Optional[Type]
         for i, arg in enumerate(args):
             if i < fixed:
                 if callee and i < len(callee.arg_types):
@@ -703,7 +703,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         Returns the inferred types of *actual arguments*.
         """
-        res = [None] * len(args)  # type: List[Type]
+        dummy = None  # type: Any
+        res = [dummy] * len(args)  # type: List[Type]
 
         for i, actuals in enumerate(formal_to_actual):
             for ai in actuals:
@@ -750,7 +751,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 ret_type = NoneTyp()
         args = infer_type_arguments(callable.type_var_ids(), ret_type, erased_ctx)
         # Only substitute non-Uninhabited and non-erased types.
-        new_args = []  # type: List[Type]
+        new_args = []  # type: List[Optional[Type]]
         for arg in args:
             if isinstance(arg, UninhabitedType) or has_erased_component(arg):
                 new_args.append(None)
@@ -793,7 +794,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
             inferred_args = infer_function_type_arguments(
                 callee_type, pass1_args, arg_kinds, formal_to_actual,
-                strict=self.chk.in_checked_function())  # type: List[Type]
+                strict=self.chk.in_checked_function())
 
             if 2 in arg_pass_nums:
                 # Second pass of type inference.
@@ -810,9 +811,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 #       if they shuffle type variables around, as we assume that there is a 1-1
                 #       correspondence with dict type variables. This is a marginal issue and
                 #       a little tricky to fix so it's left unfixed for now.
-                if isinstance(inferred_args[0], (NoneTyp, UninhabitedType)):
+                first_arg = inferred_args[0]
+                if isinstance(first_arg, (NoneTyp, UninhabitedType)):
                     inferred_args[0] = self.named_type('builtins.str')
-                elif not is_subtype(self.named_type('builtins.str'), inferred_args[0]):
+                elif not first_arg or not is_subtype(self.named_type('builtins.str'), first_arg):
                     self.msg.fail(messages.KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE,
                                   context)
         else:
@@ -827,8 +829,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             args: List[Expression],
             arg_kinds: List[int],
             formal_to_actual: List[List[int]],
-            inferred_args: List[Type],
-            context: Context) -> Tuple[CallableType, List[Type]]:
+            old_inferred_args: Sequence[Optional[Type]],
+            context: Context) -> Tuple[CallableType, List[Optional[Type]]]:
         """Perform second pass of generic function type argument inference.
 
         The second pass is needed for arguments with types such as Callable[[T], S],
@@ -843,6 +845,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         # None or erased types in inferred types mean that there was not enough
         # information to infer the argument. Replace them with None values so
         # that they are not applied yet below.
+        inferred_args = list(old_inferred_args)
         for i, arg in enumerate(inferred_args):
             if isinstance(arg, (NoneTyp, UninhabitedType)) or has_erased_component(arg):
                 inferred_args[i] = None
@@ -875,7 +878,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return res
 
     def apply_inferred_arguments(self, callee_type: CallableType,
-                                 inferred_args: List[Type],
+                                 inferred_args: Sequence[Optional[Type]],
                                  context: Context) -> CallableType:
         """Apply inferred values of type arguments to a generic function.
 
@@ -896,9 +899,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return self.apply_generic_arguments(callee_type, inferred_args, context)
 
     def check_argument_count(self, callee: CallableType, actual_types: List[Type],
-                             actual_kinds: List[int], actual_names: List[str],
+                             actual_kinds: List[int],
+                             actual_names: Optional[Sequence[Optional[str]]],
                              formal_to_actual: List[List[int]],
-                             context: Context,
+                             context: Optional[Context],
                              messages: Optional[MessageBuilder]) -> bool:
         """Check that there is a value for all required arguments to a function.
 
@@ -925,11 +929,16 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 ok = False
                 if kind != nodes.ARG_NAMED:
                     if messages:
+                        assert context, "Internal error: messages given without context"
                         messages.too_many_arguments(callee, context)
                 else:
                     if messages:
+                        assert context, "Internal error: messages given without context"
+                        assert actual_names, "Internal error: named kinds without names given"
+                        act_name = actual_names[i]
+                        assert act_name is not None
                         messages.unexpected_keyword_argument(
-                            callee, actual_names[i], context)
+                            callee, act_name, context)
                     is_unexpected_arg_error = True
             elif kind == nodes.ARG_STAR and (
                     nodes.ARG_STAR not in formal_kinds):
@@ -938,6 +947,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     if all_actuals.count(i) < len(actual_type.items):
                         # Too many tuple items as some did not match.
                         if messages:
+                            assert context, "Internal error: messages given without context"
                             messages.too_many_arguments(callee, context)
                         ok = False
                 # *args can be applied even if the function takes a fixed
@@ -948,13 +958,17 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                           not is_unexpected_arg_error):
                 # No actual for a mandatory positional formal.
                 if messages:
+                    assert context, "Internal error: messages given without context"
                     messages.too_few_arguments(callee, context, actual_names)
                 ok = False
             elif kind == nodes.ARG_NAMED and (not formal_to_actual[i] and
                                               not is_unexpected_arg_error):
                 # No actual for a mandatory named formal
                 if messages:
-                    messages.missing_named_argument(callee, context, callee.arg_names[i])
+                    argname = callee.arg_names[i]
+                    assert argname is not None
+                    assert context, "Internal error: messages given without context"
+                    messages.missing_named_argument(callee, context, argname)
                 ok = False
             elif kind in [nodes.ARG_POS, nodes.ARG_OPT,
                           nodes.ARG_NAMED, nodes.ARG_NAMED_OPT] and is_duplicate_mapping(
@@ -962,12 +976,14 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 if (self.chk.in_checked_function() or
                         isinstance(actual_types[formal_to_actual[i][0]], TupleType)):
                     if messages:
+                        assert context, "Internal error: messages given without context"
                         messages.duplicate_argument_value(callee, i, context)
                     ok = False
             elif (kind in (nodes.ARG_NAMED, nodes.ARG_NAMED_OPT) and formal_to_actual[i] and
                   actual_kinds[formal_to_actual[i][0]] not in [nodes.ARG_NAMED, nodes.ARG_STAR2]):
                 # Positional argument when expecting a keyword argument.
                 if messages:
+                    assert context, "Internal error: messages given without context"
                     messages.too_many_positional_arguments(callee, context)
                 ok = False
         return ok
@@ -1057,7 +1073,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     self.msg.note_call(original_caller_type, call, context)
 
     def overload_call_target(self, arg_types: List[Type], arg_kinds: List[int],
-                             arg_names: List[str],
+                             arg_names: Optional[Sequence[Optional[str]]],
                              overload: Overloaded, context: Context,
                              messages: Optional[MessageBuilder] = None) -> Type:
         """Infer the correct overload item to call with given argument types.
@@ -1120,7 +1136,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 return match[0]
 
     def erased_signature_similarity(self, arg_types: List[Type], arg_kinds: List[int],
-                                    arg_names: List[str], callee: CallableType,
+                                    arg_names: Optional[Sequence[Optional[str]]],
+                                    callee: CallableType,
                                     context: Context) -> int:
         """Determine whether arguments could match the signature at runtime.
 
@@ -1160,7 +1177,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return similarity
 
     def match_signature_types(self, arg_types: List[Type], arg_kinds: List[int],
-                              arg_names: List[str], callee: CallableType,
+                              arg_names: Optional[Sequence[Optional[str]]], callee: CallableType,
                               context: Context) -> bool:
         """Determine whether arguments types match the signature.
 
@@ -1186,7 +1203,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                   context=context, check_arg=check_arg)
         return ok
 
-    def apply_generic_arguments(self, callable: CallableType, types: List[Type],
+    def apply_generic_arguments(self, callable: CallableType, types: Sequence[Optional[Type]],
                                 context: Context) -> CallableType:
         """Simple wrapper around mypy.applytype.apply_generic_arguments."""
         return applytype.apply_generic_arguments(callable, types, self.msg, context)
@@ -1245,7 +1262,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         bound_method = bind_self(function, descriptor_type)
         typ = map_instance_to_supertype(descriptor_type, dunder_get.info)
         dunder_get_type = expand_type_by_instance(bound_method, typ)
-        owner_type = None  # type: Type
 
         if isinstance(instance_type, FunctionLike) and instance_type.is_type_obj():
             owner_type = instance_type.items()[0].ret_type
@@ -1351,13 +1367,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         Comparison expressions are type checked consecutive-pair-wise
         That is, 'a < b > c == d' is check as 'a < b and b > c and c == d'
         """
-        result = None  # type: mypy.types.Type
+        result = None  # type: Optional[mypy.types.Type]
 
         # Check each consecutive operand pair and their operator
         for left, right, operator in zip(e.operands, e.operands[1:], e.operators):
             left_type = self.accept(left)
 
-            method_type = None  # type: mypy.types.Type
+            method_type = None  # type: Optional[mypy.types.Type]
 
             if operator == 'in' or operator == 'not in':
                 right_type = self.accept(right)  # TODO only evaluate if needed
@@ -1407,6 +1423,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             else:
                 result = join.join_types(result, sub_result)
 
+        assert result is not None
         return result
 
     def get_operator_method(self, op: str) -> str:
@@ -1679,9 +1696,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             return result
 
     def visit_tuple_slice_helper(self, left_type: TupleType, slic: SliceExpr) -> Type:
-        begin = None  # type: int
-        end = None  # type: int
-        stride = None  # type:int
+        begin = None  # type: Optional[int]
+        end = None  # type: Optional[int]
+        stride = None  # type: Optional[int]
 
         if slic.begin_index:
             begin = self._get_value(slic.begin_index)
@@ -1698,6 +1715,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             if stride is None:
                 return self.nonliteral_tuple_index_helper(left_type, slic)
 
+        assert begin and stride and end
         return left_type.slice(begin, stride, end)
 
     def nonliteral_tuple_index_helper(self, left_type: TupleType, index: Expression) -> Type:
@@ -1872,7 +1890,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         if isinstance(type_context, TupleType):
             type_context_items = type_context.items
-        elif is_named_instance(type_context, 'builtins.tuple'):
+        elif type_context and is_named_instance(type_context, 'builtins.tuple'):
             assert isinstance(type_context, Instance)
             if type_context.args:
                 type_context_items = [type_context.args[0]] * len(e.items)
@@ -1887,7 +1905,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         j = 0  # Index into type_context_items; irrelevant if type_context_items is none
         for i in range(len(e.items)):
             item = e.items[i]
-            tt = None  # type: Type
             if isinstance(item, StarExpr):
                 # Special handling for star expressions.
                 # TODO: If there's a context, and item.expr is a
@@ -1977,9 +1994,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 else:
                     method = self.analyze_external_member_access('update', rv, arg)
                     self.check_call(method, [arg], [nodes.ARG_POS], arg)
+        assert rv is not None
         return rv
 
-    def find_typeddict_context(self, context: Type) -> Optional[TypedDictType]:
+    def find_typeddict_context(self, context: Optional[Type]) -> Optional[TypedDictType]:
         if isinstance(context, TypedDictType):
             return context
         elif isinstance(context, UnionType):
@@ -2148,7 +2166,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     if self.chk.scope.active_class() is not None:
                         self.chk.fail('super() outside of a method is not supported', e)
                         return AnyType(TypeOfAny.from_error)
-                    args = self.chk.scope.top_function().arguments
+                    method = self.chk.scope.top_function()
+                    assert method is not None
+                    args = method.arguments
                     # super() in a function with empty args is an error; we
                     # need something in declared_self.
                     if not args:
@@ -2157,6 +2177,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                             'enclosing function', e)
                         return AnyType(TypeOfAny.from_error)
                     declared_self = args[0].variable.type
+                    assert declared_self is not None, "Internal error: type of self is None"
                     return analyze_member_access(name=e.name, typ=fill_typevars(e.info), node=e,
                                                  is_lvalue=False, is_super=True, is_operator=False,
                                                  builtin_type=self.named_type,
@@ -2457,12 +2478,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         # the context should be Generator[X, Y, T], where T is the
         # context of the 'yield from' itself (but it isn't known).
         subexpr_type = self.accept(e.expr)
-        iter_type = None  # type: Type
 
         # Check that the expr is an instance of Iterable and get the type of the iterator produced
         # by __iter__.
         if isinstance(subexpr_type, AnyType):
-            iter_type = AnyType(TypeOfAny.from_another_any, source_any=subexpr_type)
+            iter_type = AnyType(TypeOfAny.from_another_any, source_any=subexpr_type)  # type: Type
         elif self.chk.type_is_iterable(subexpr_type):
             if is_async_def(subexpr_type) and not has_coroutine_decorator(return_type):
                 self.chk.msg.yield_from_invalid_operand_type(subexpr_type, e)
@@ -2609,7 +2629,7 @@ def is_async_def(t: Type) -> bool:
 
 
 def map_actuals_to_formals(caller_kinds: List[int],
-                           caller_names: List[Optional[str]],
+                           caller_names: Optional[Sequence[Optional[str]]],
                            callee_kinds: List[int],
                            callee_names: List[Optional[str]],
                            caller_arg_type: Callable[[int],
@@ -2659,6 +2679,7 @@ def map_actuals_to_formals(caller_kinds: List[int],
                         break
                     j += 1
         elif kind in (nodes.ARG_NAMED, nodes.ARG_NAMED_OPT):
+            assert caller_names is not None, "Internal error: named kinds without names given"
             name = caller_names[i]
             if name in callee_names:
                 map[callee_names.index(name)].append(i)
@@ -2719,7 +2740,7 @@ class HasTypeVarQuery(types.TypeQuery[bool]):
         return True
 
 
-def has_erased_component(t: Type) -> bool:
+def has_erased_component(t: Optional[Type]) -> bool:
     return t is not None and t.accept(HasErasedComponentsQuery())
 
 
@@ -2832,7 +2853,7 @@ def overload_arg_similarity(actual: Type, formal: Type) -> int:
 def any_arg_causes_overload_ambiguity(items: List[CallableType],
                                       arg_types: List[Type],
                                       arg_kinds: List[int],
-                                      arg_names: List[Optional[str]]) -> bool:
+                                      arg_names: Optional[Sequence[Optional[str]]]) -> bool:
     """May an Any actual argument cause ambiguous result type on call to overloaded function?
 
     Note that this sometimes returns True even if there is no ambiguity, since a correct

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -21,7 +21,7 @@ from mypy.nodes import (
     ConditionalExpr, ComparisonExpr, TempNode, SetComprehension,
     DictionaryComprehension, ComplexExpr, EllipsisExpr, StarExpr, AwaitExpr, YieldExpr,
     YieldFromExpr, TypedDictExpr, PromoteExpr, NewTypeExpr, NamedTupleExpr, TypeVarExpr,
-    TypeAliasExpr, BackquoteExpr, EnumCallExpr, SymbolTableNode,
+    TypeAliasExpr, BackquoteExpr, EnumCallExpr,
     ARG_POS, ARG_NAMED, ARG_STAR, ARG_STAR2, MODULE_REF, TVAR, LITERAL_TYPE,
 )
 from mypy.literals import literal
@@ -201,7 +201,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 and len(e.args) == 2):
             for typ in mypy.checker.flatten(e.args[1]):
                 if isinstance(typ, NameExpr):
-                    node = None  # type: Optional[SymbolTableNode]
+                    node = None
                     try:
                         node = self.chk.lookup_qualified(typ.name)
                     except KeyError:
@@ -218,7 +218,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     elif typ.node.is_newtype:
                         self.msg.fail(messages.CANNOT_ISINSTANCE_NEWTYPE, e)
         self.try_infer_partial_type(e)
-        type_context = None  # type: Optional[CallableType]
+        type_context = None
         if isinstance(e.callee, LambdaExpr):
             formal_to_actual = map_actuals_to_formals(
                 e.arg_kinds, e.arg_names,
@@ -677,7 +677,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if callee:
             fixed = min(fixed, callee.max_fixed_args())
 
-        ctx = None  # type: Optional[Type]
+        ctx = None
         for i, arg in enumerate(args):
             if i < fixed:
                 if callee and i < len(callee.arg_types):
@@ -908,7 +908,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Check that there is a value for all required arguments to a function.
 
         Also check that there are no duplicate values for arguments. Report found errors
-        using 'messages' if it's not None.
+        using 'messages' if it's not None. If 'messages' is given, 'context' must also be given.
 
         Return False if there were any errors. Otherwise return True
         """
@@ -1368,7 +1368,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         Comparison expressions are type checked consecutive-pair-wise
         That is, 'a < b > c == d' is check as 'a < b and b > c and c == d'
         """
-        result = None  # type: Optional[mypy.types.Type]
+        result = None
 
         # Check each consecutive operand pair and their operator
         for left, right, operator in zip(e.operands, e.operands[1:], e.operators):
@@ -1697,9 +1697,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             return result
 
     def visit_tuple_slice_helper(self, left_type: TupleType, slic: SliceExpr) -> Type:
-        begin = None  # type: Optional[int]
-        end = None  # type: Optional[int]
-        stride = None  # type: Optional[int]
+        begin = None
+        end = None
+        stride = None
 
         if slic.begin_index:
             begin = self._get_value(slic.begin_index)
@@ -1960,7 +1960,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         vtdef = TypeVarDef('VT', -2, [], self.object_type())
         kt = TypeVarType(ktdef)
         vt = TypeVarType(vtdef)
-        rv = None  # type: Optional[Type]
+        rv = None
         # Call dict(*args), unless it's empty and stargs is not.
         if args or not stargs:
             # The callable type represents a function like this:

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -630,7 +630,7 @@ def bind_self(method: F, original_type: Optional[Type] = None, is_classmethod: b
 
     """
     if isinstance(method, Overloaded):
-        return cast(F, Overloaded([bind_self(c, method) for c in method.items()]))
+        return cast(F, Overloaded([bind_self(c, original_type) for c in method.items()]))
     assert isinstance(method, CallableType)
     func = method
     if not func.arg_types:

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -1,6 +1,6 @@
 """Type inference constraints."""
 
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Sequence
 
 from mypy import experiments
 from mypy.types import (
@@ -42,7 +42,7 @@ class Constraint:
 
 
 def infer_constraints_for_callable(
-        callee: CallableType, arg_types: List[Optional[Type]], arg_kinds: List[int],
+        callee: CallableType, arg_types: Sequence[Optional[Type]], arg_kinds: List[int],
         formal_to_actual: List[List[int]]) -> List[Constraint]:
     """Infer type variable constraints for a callable and actual arguments.
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -885,7 +885,8 @@ class ASTConverter(ast3.NodeTransformer):
             join_method.set_line(empty_string)
             result_expression = CallExpr(join_method,
                                          [strs_to_join],
-                                         [ARG_POS])
+                                         [ARG_POS],
+                                         [None])
             return result_expression
 
         # FormattedValue(expr value)
@@ -902,7 +903,8 @@ class ASTConverter(ast3.NodeTransformer):
             format_method.set_line(format_string)
             result_expression = CallExpr(format_method,
                                          [exp],
-                                         [ARG_POS])
+                                         [ARG_POS],
+                                         [None])
             return result_expression
 
     # Bytes(bytes s)

--- a/mypy/infer.py
+++ b/mypy/infer.py
@@ -1,6 +1,6 @@
 """Utilities for type argument inference."""
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 from mypy.constraints import infer_constraints, infer_constraints_for_callable
 from mypy.types import Type, TypeVarId, CallableType
@@ -9,7 +9,7 @@ from mypy.constraints import SUBTYPE_OF
 
 
 def infer_function_type_arguments(callee_type: CallableType,
-                                  arg_types: List[Optional[Type]],
+                                  arg_types: Sequence[Optional[Type]],
                                   arg_kinds: List[int],
                                   formal_to_actual: List[List[int]],
                                   strict: bool = True) -> List[Optional[Type]]:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -165,7 +165,7 @@ class MessageBuilder:
     def is_errors(self) -> bool:
         return self.errors.is_errors()
 
-    def report(self, msg: str, context: Context, severity: str,
+    def report(self, msg: str, context: Optional[Context], severity: str,
                file: Optional[str] = None, origin: Optional[Context] = None,
                offset: int = 0) -> None:
         """Report an error or note (unless disabled)."""
@@ -175,7 +175,7 @@ class MessageBuilder:
                                msg.strip(), severity=severity, file=file, offset=offset,
                                origin_line=origin.get_line() if origin else None)
 
-    def fail(self, msg: str, context: Context, file: Optional[str] = None,
+    def fail(self, msg: str, context: Optional[Context], file: Optional[str] = None,
              origin: Optional[Context] = None) -> None:
         """Report an error message (unless disabled)."""
         self.report(msg, context, 'error', file=file, origin=origin)
@@ -641,7 +641,7 @@ class MessageBuilder:
             self.format(index_type), base_str, self.format(expected_type)), context)
 
     def too_few_arguments(self, callee: CallableType, context: Context,
-                          argument_names: List[str]) -> None:
+                          argument_names: Optional[Sequence[Optional[str]]]) -> None:
         if (argument_names is not None and not all(k is None for k in argument_names)
                 and len(argument_names) >= 1):
             diff = [k for k in callee.arg_names if k not in argument_names]
@@ -695,7 +695,7 @@ class MessageBuilder:
                   format(capitalize(callable_name(callee)),
                          callee.arg_names[index]), context)
 
-    def does_not_return_value(self, callee_type: Type, context: Context) -> None:
+    def does_not_return_value(self, callee_type: Optional[Type], context: Context) -> None:
         """Report an error about use of an unusable type."""
         name = None  # type: Optional[str]
         if isinstance(callee_type, FunctionLike):

--- a/mypy/myunit/__init__.py
+++ b/mypy/myunit/__init__.py
@@ -112,7 +112,7 @@ class TestCase:
         self.name = name
         self.suite = suite
         self.old_cwd = None  # type: Optional[str]
-        self.tmpdir = None  # type: Optional[tempfile.TemporaryDirectory]
+        self.tmpdir = None  # type: Optional[tempfile.TemporaryDirectory[str]]
 
     def run(self) -> None:
         if self.func:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1241,7 +1241,7 @@ class CallExpr(Expression):
                  callee: Expression,
                  args: List[Expression],
                  arg_kinds: List[int],
-                 arg_names: Optional[List[Optional[str]]] = None,
+                 arg_names: List[Optional[str]],
                  analyzed: Optional[Expression] = None) -> None:
         if not arg_names:
             arg_names = [None] * len(args)
@@ -1731,13 +1731,13 @@ class TypeAliasExpr(Expression):
     type = None  # type: mypy.types.Type
     # Simple fallback type for aliases that are invalid in runtime expressions
     # (for example Union, Tuple, Callable).
-    fallback = None  # type: Optional[mypy.types.Type]
+    fallback = None  # type: mypy.types.Type
     # This type alias is subscripted in a runtime expression like Alias[int](42)
     # (not in a type context like type annotation or base class).
     in_runtime = False  # type: bool
 
     def __init__(self, type: 'mypy.types.Type', tvars: List[str],
-                 fallback: 'Optional[mypy.types.Type]' = None, in_runtime: bool = False) -> None:
+                 fallback: 'mypy.types.Type', in_runtime: bool = False) -> None:
         self.type = type
         self.fallback = fallback
         self.in_runtime = in_runtime

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1011,7 +1011,8 @@ class TupleType(Type):
             items = self.items
         return TupleType(items, fallback, self.line, self.column)
 
-    def slice(self, begin: int, stride: int, end: int) -> 'TupleType':
+    def slice(self, begin: Optional[int], stride: Optional[int],
+              end: Optional[int]) -> 'TupleType':
         return TupleType(self.items[begin:end:stride], self.fallback,
                          self.line, self.column, self.implicit)
 

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -8,6 +8,6 @@ disallow_any = generics, unimported
 warn_redundant_casts = True
 warn_unused_ignores = True
 
-; historical exception
+# historical exception
 [mypy-mypy.semanal]
 strict_optional = False

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -8,15 +8,6 @@ disallow_any = generics, unimported
 warn_redundant_casts = True
 warn_unused_ignores = True
 
-; historical exceptions
-[mypy-mypy.binder]
-disallow_any = unimported
-
+; historical exception
 [mypy-mypy.semanal]
 strict_optional = False
-
-[mypy-mypy.myunit]
-disallow_any = unimported
-
-[mypy-mypy.nodes]
-disallow_any = unimported

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -12,12 +12,6 @@ warn_unused_ignores = True
 [mypy-mypy.binder]
 disallow_any = unimported
 
-[mypy-mypy.checker]
-strict_optional = False
-
-[mypy-mypy.checkexpr]
-strict_optional = False
-
 [mypy-mypy.semanal]
 strict_optional = False
 


### PR DESCRIPTION
This makes another major piece of mypy ``--strict-optional`` clean: the type checking files.
After this PR there will be only single exception left ``semanal.py``.