### PR TITLE
README.md: rearrange first paragraph to be more friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,7 @@ In Windows, the script is generally installed in
     C:\>\Python34\python \Python34\Scripts\mypy PROGRAM
 
 If you are on Windows using Python 3.3 or 3.4, and would like to use XML reports
-download LXML from [PyPi](https://pypi.python.org/pypi/lxml). 
-XML based reports do not work on Python 3.3 and 3.4 on Windows.
+download LXML from [PyPi](https://pypi.python.org/pypi/lxml).
 
 ### Working with `virtualenv`
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ See [the documentation](http://mypy.readthedocs.io/en/stable/introduction.html) 
 
 For Python 2.7, the standard annotations are written as comments:
 ```python
-def reverse(s):
-    # type: str -> str
-    return s[::-1]
+def is_palindrome(s):
+    # type: (str) -> str
+    return s == s[::-1]
 ```
 
 See [the documentation for Python 2 support](http://mypy.readthedocs.io/en/latest/python2.html).

--- a/README.md
+++ b/README.md
@@ -25,17 +25,8 @@ What is mypy?
 -------------
 
 Mypy is an optional static type checker for Python.  You can add type
-hints to your Python programs using the standard for type
-annotations introduced in Python 3.5 ([PEP 484](https://www.python.org/dev/peps/pep-0484/)), and use mypy to
-type check them statically. Find bugs in your programs without even
-running them!
-
-The type annotation standard has also been backported to earlier
-Python 3.x versions.  Mypy supports Python 3.3 and later.
-XML based reports do not work on Python 3.3 and 3.4 on Windows.
-
-For Python 2.7, you can add annotations as comments (this is also
-specified in [PEP 484](https://www.python.org/dev/peps/pep-0484/)).
+hints to your Python programs, and use mypy to type check them statically.
+Find bugs in your programs without even running them!
 
 You can mix dynamic and static typing in your programs. You can always
 fall back to dynamic typing when static typing is not convenient, such
@@ -55,6 +46,17 @@ def fib(n: int) -> Iterator[int]:
 
 Mypy is in development; some features are missing and there are bugs.
 See 'Development status' below.
+
+Annotations
+-----------
+You can add type hints to your Python programs using the standard for type
+annotations introduced in Python 3.5 ([PEP 484](https://www.python.org/dev/peps/pep-0484/)).
+The type annotation standard has also been backported to earlier
+Python 3.x versions.  Mypy supports Python 3.3 and later.
+XML based reports do not work on Python 3.3 and 3.4 on Windows.
+
+For Python 2.7, you can add annotations as comments (this is also
+specified in [PEP 484](https://www.python.org/dev/peps/pep-0484/)).
 
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Here is a small example to whet your appetite:
 from typing import Iterator
 
 def fib(n: int) -> Iterator[int]:
-    a, b = 0, 1
+    a: int = 0
+    b: int = 1
     while a < n:
         yield a
         a, b = b, a + b
@@ -49,14 +50,21 @@ See 'Development status' below.
 
 Annotations
 -----------
-You can add type hints to your Python programs using the standard for type
-annotations introduced in Python 3.5 ([PEP 484](https://www.python.org/dev/peps/pep-0484/)).
-The type annotation standard has also been backported to earlier
-Python 3.x versions.  Mypy supports Python 3.3 and later.
-XML based reports do not work on Python 3.3 and 3.4 on Windows.
+For Python 3, you can add type hints to your Python programs using the standard for type
+annotations ([PEP 484](https://www.python.org/dev/peps/pep-0484/)).
 
 For Python 2.7, you can add annotations as comments (this is also
-specified in [PEP 484](https://www.python.org/dev/peps/pep-0484/)).
+specified in [PEP 484](https://www.python.org/dev/peps/pep-0484/)):
+```python
+from typing import Iterator
+
+def fib(n):  # type: int -> Iterator[int]
+    a = 0  # type: int
+    b = 1  # type: int
+    while a < n:
+        yield a
+        a, b = b, a + b
+```
 
 
 Requirements
@@ -160,7 +168,8 @@ In Windows, the script is generally installed in
     C:\>\Python34\python \Python34\Scripts\mypy PROGRAM
 
 If you are on Windows using Python 3.3 or 3.4, and would like to use XML reports
-download LXML from [PyPi](https://pypi.python.org/pypi/lxml).
+download LXML from [PyPi](https://pypi.python.org/pypi/lxml). 
+XML based reports do not work on Python 3.3 and 3.4 on Windows.
 
 ### Working with `virtualenv`
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See [the documentation](http://mypy.readthedocs.io/en/stable/introduction.html) 
 For Python 2.7, the standard annotations are written as comments:
 ```python
 def is_palindrome(s):
-    # type: (str) -> str
+    # type: (str) -> bool
     return s == s[::-1]
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ What is mypy?
 -------------
 
 Mypy is an optional static type checker for Python.  You can add type
-hints ([PEP 484](https://www.python.org/dev/peps/pep-0484/)) to your Python programs, and use mypy to type check them statically.
+hints ([PEP 484](https://www.python.org/dev/peps/pep-0484/)) to your
+Python programs, and use mypy to type check them statically.
 Find bugs in your programs without even running them!
 
 You can mix dynamic and static typing in your programs. You can always

--- a/README.md
+++ b/README.md
@@ -157,9 +157,6 @@ In Windows, the script is generally installed in
 
     C:\>\Python34\python \Python34\Scripts\mypy PROGRAM
 
-If you are on Windows using Python 3.3 or 3.4, and would like to use XML reports
-download LXML from [PyPi](https://pypi.python.org/pypi/lxml).
-
 ### Working with `virtualenv`
 
 If you are using [`virtualenv`](https://virtualenv.pypa.io/en/stable/),

--- a/README.md
+++ b/README.md
@@ -38,34 +38,23 @@ Here is a small example to whet your appetite:
 from typing import Iterator
 
 def fib(n: int) -> Iterator[int]:
-    a: int = 0
-    b: int = 1
+    a, b = 0, 1
     while a < n:
         yield a
         a, b = b, a + b
 ```
+This example uses Python 3 style of the standard type annotations, defined in [PEP 484](https://www.python.org/dev/peps/pep-0484/). 
+
+For Python 2.7, the standard annotations are written as comments:
+```python
+def reverse(s):  # type: str -> str
+    return s[::-1]
+```
+
+See [the documentation](http://mypy.readthedocs.io/en/stable/introduction.html) for more examples.
 
 Mypy is in development; some features are missing and there are bugs.
 See 'Development status' below.
-
-Annotations
------------
-For Python 3, you can add type hints to your Python programs using the standard for type
-annotations ([PEP 484](https://www.python.org/dev/peps/pep-0484/)).
-
-For Python 2.7, you can add annotations as comments (this is also
-specified in [PEP 484](https://www.python.org/dev/peps/pep-0484/)):
-```python
-from typing import Iterator
-
-def fib(n):  # type: int -> Iterator[int]
-    a = 0  # type: int
-    b = 1  # type: int
-    while a < n:
-        yield a
-        a, b = b, a + b
-```
-
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ What is mypy?
 -------------
 
 Mypy is an optional static type checker for Python.  You can add type
-hints to your Python programs, and use mypy to type check them statically.
+hints ([PEP 484](https://www.python.org/dev/peps/pep-0484/)) to your Python programs, and use mypy to type check them statically.
 Find bugs in your programs without even running them!
 
 You can mix dynamic and static typing in your programs. You can always
 fall back to dynamic typing when static typing is not convenient, such
 as for legacy code.
 
-Here is a small example to whet your appetite:
+Here is a small example to whet your appetite (Python 3):
 
 ```python
 from typing import Iterator
@@ -43,15 +43,16 @@ def fib(n: int) -> Iterator[int]:
         yield a
         a, b = b, a + b
 ```
-This example uses Python 3 style of the standard type annotations, defined in [PEP 484](https://www.python.org/dev/peps/pep-0484/). 
+See [the documentation](http://mypy.readthedocs.io/en/stable/introduction.html) for more examples.
 
 For Python 2.7, the standard annotations are written as comments:
 ```python
-def reverse(s):  # type: str -> str
+def reverse(s):
+    # type: str -> str
     return s[::-1]
 ```
 
-See [the documentation](http://mypy.readthedocs.io/en/stable/introduction.html) for more examples.
+See [the documentation for Python 2 support](http://mypy.readthedocs.io/en/latest/python2.html).
 
 Mypy is in development; some features are missing and there are bugs.
 See 'Development status' below.


### PR DESCRIPTION
The discussion of different annotations need not be the first thing the reader see.