### PR TITLE
Run mypy self-check only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ python:
   - "3.5.1"
   - "3.6"
   - "3.7-dev"
-  # Pypy build is disabled because it doubles the travis build time, and it rarely fails
-  # unless one one of the other builds fails.
-  # - "pypy3"
 
 install:
   - pip install -U pip setuptools wheel
@@ -20,5 +17,6 @@ install:
   - pip install .
 
 script:
-  - python runtests.py -j12 -x lint
+  - python runtests.py -j12 -x lint package
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then flake8; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.5.1' ]]; then python runtests.py package; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ install:
   - pip install .
 
 script:
-  - python runtests.py -j12 -x lint package
+  - python runtests.py -j12 -x lint -x package
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then flake8; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.5.1' ]]; then python runtests.py package; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
 build: off
 
 test_script:
-    # Ignore lint (it's run in Travis)
+    # Ignore lint and mypy self check (both run in Travis)
     - "%PYTHON%\\python.exe runtests.py -x lint -x package"
 
 skip_commits:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ build: off
 
 test_script:
     # Ignore lint (it's run in Travis)
-    - "%PYTHON%\\python.exe runtests.py -x lint package"
+    - "%PYTHON%\\python.exe runtests.py -x lint -x package"
 
 skip_commits:
   files:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ build: off
 
 test_script:
     # Ignore lint (it's run in Travis)
-    - "%PYTHON%\\python.exe runtests.py -x lint"
+    - "%PYTHON%\\python.exe runtests.py -x lint package"
 
 skip_commits:
   files:


### PR DESCRIPTION
Since we only need to test that mypy is type safe once, we skip the
mypy package check except on one test run. This is arbitrarily chosen as
3.5.1. 3.6 is not chosen as it already is running flake8.

Additionally, the old comment about pypy is removed as typed_ast doesn't run on pypy, so the comment is confusing and misleading.