### PR TITLE
Fix checking of self when accessing a non-method callable attribute (take 2)

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -393,8 +393,7 @@ def check_self_arg(functype: FunctionLike, dispatched_arg_type: Type, is_classme
     for item in functype.items():
         if not item.arg_types or item.arg_kinds[0] not in (ARG_POS, ARG_STAR):
             # No positional first (self) argument (*args is okay).
-            msg.fail('Attribute function with type %s does not accept self argument'
-                     % msg.format(item), context)
+            msg.no_formal_self(name, item, context)
         else:
             selfarg = item.arg_types[0]
             if is_classmethod:

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -384,10 +384,10 @@ def check_self_arg(functype: FunctionLike, dispatched_arg_type: Type, is_classme
     """For x.f where A.f: A1 -> T, check that meet(type(x), A) <: A1 for each overload.
 
     dispatched_arg_type is meet(B, A) in the following example
-        class A:
-            f: Callable[[A1], None]
 
         def g(x: B): x.f
+        class A:
+            f: Callable[[A1], None]
     """
     # TODO: this is too strict. We can return filtered overloads for matching definitions
     for item in functype.items():
@@ -399,7 +399,8 @@ def check_self_arg(functype: FunctionLike, dispatched_arg_type: Type, is_classme
             if is_classmethod:
                 dispatched_arg_type = TypeType.make_normalized(dispatched_arg_type)
             if not subtypes.is_subtype(dispatched_arg_type, erase_to_bound(selfarg)):
-                msg.incompatible_self_argument(name, dispatched_arg_type, item, is_classmethod, context)
+                msg.incompatible_self_argument(name, dispatched_arg_type, item,
+                                               is_classmethod, context)
 
 
 def analyze_class_attribute_access(itype: Instance,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -863,6 +863,10 @@ class MessageBuilder:
     def cannot_determine_type_in_base(self, name: str, base: str, context: Context) -> None:
         self.fail("Cannot determine type of '%s' in base class '%s'" % (name, base), context)
 
+    def no_formal_self(self, name: str, item: CallableType, context: Context) -> None:
+        self.fail('Attribute function "%s" with type %s does not accept self argument'
+                  % (name, self.format(item)), context)
+
     def incompatible_self_argument(self, name: str, arg: Type, sig: CallableType,
                                    is_classmethod: bool, context: Context) -> None:
         kind = 'class attribute function' if is_classmethod else 'attribute function'

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -856,11 +856,11 @@ class MessageBuilder:
     def cannot_determine_type_in_base(self, name: str, base: str, context: Context) -> None:
         self.fail("Cannot determine type of '%s' in base class '%s'" % (name, base), context)
 
-    def invalid_method_type(self, sig: CallableType, context: Context) -> None:
-        self.fail('Invalid method type', context)
-
-    def invalid_class_method_type(self, sig: CallableType, context: Context) -> None:
-        self.fail('Invalid class method type', context)
+    def invalid_method_type(self, name: str, arg: Type, sig: CallableType, is_classmethod: bool,
+                            context: Context) -> None:
+        kind = 'class attribute function' if is_classmethod else 'attribute function'
+        self.fail('Invalid self argument %s to %s "%s" with type %s'
+                  % (self.format(arg), kind, name, self.format(sig)), context)
 
     def incompatible_conditional_function_def(self, defn: FuncDef) -> None:
         self.fail('All conditional function variants must have identical '

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -863,8 +863,8 @@ class MessageBuilder:
     def cannot_determine_type_in_base(self, name: str, base: str, context: Context) -> None:
         self.fail("Cannot determine type of '%s' in base class '%s'" % (name, base), context)
 
-    def invalid_method_type(self, name: str, arg: Type, sig: CallableType, is_classmethod: bool,
-                            context: Context) -> None:
+    def incompatible_self_argument(self, name: str, arg: Type, sig: CallableType,
+                                   is_classmethod: bool, context: Context) -> None:
         kind = 'class attribute function' if is_classmethod else 'attribute function'
         self.fail('Invalid self argument %s to %s "%s" with type %s'
                   % (self.format(arg), kind, name, self.format(sig)), context)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2105,7 +2105,7 @@ class B:
     a = A
     bad = lambda: 42
 
-B().bad() # E: Invalid method type
+B().bad() # E: Attribute function with type "Callable[[], int]" does not accept self argument
 reveal_type(B.a) # E: Revealed type is 'def () -> __main__.A'
 reveal_type(B().a) # E: Revealed type is 'def () -> __main__.A'
 reveal_type(B().a()) # E: Revealed type is '__main__.A'

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2105,7 +2105,7 @@ class B:
     a = A
     bad = lambda: 42
 
-B().bad() # E: Attribute function with type "Callable[[], int]" does not accept self argument
+B().bad() # E: Attribute function "bad" with type "Callable[[], int]" does not accept self argument
 reveal_type(B.a) # E: Revealed type is 'def () -> __main__.A'
 reveal_type(B().a) # E: Revealed type is 'def () -> __main__.A'
 reveal_type(B().a()) # E: Revealed type is '__main__.A'

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -507,7 +507,7 @@ class A:
     f = x # type: Callable[[], None]
     g = x # type: Callable[[B], None]
 a = None # type: A
-a.f() # E: Attribute function with type "Callable[[], None]" does not accept self argument
+a.f() # E: Attribute function "f" with type "Callable[[], None]" does not accept self argument
 a.g() # E: Invalid self argument "A" to attribute function "g" with type "Callable[[B], None]"
 
 [case testMethodWithDynamicallyTypedMethodAsDataAttribute]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -507,8 +507,8 @@ class A:
     f = x # type: Callable[[], None]
     g = x # type: Callable[[B], None]
 a = None # type: A
-a.f() # E: Invalid method type
-a.g() # E: Invalid method type
+a.f() # E: Attribute function with type "Callable[[], None]" does not accept self argument
+a.g() # E: Invalid self argument "A" to attribute function "g" with type "Callable[[B], None]"
 
 [case testMethodWithDynamicallyTypedMethodAsDataAttribute]
 from typing import Any, Callable
@@ -568,7 +568,7 @@ class A(Generic[t]):
 ab = None # type: A[B]
 ac = None # type: A[C]
 ab.f()
-ac.f()   # E: Invalid method type
+ac.f()   # E: Invalid self argument "A[C]" to attribute function "f" with type "Callable[[A[B]], None]"
 
 [case testPartiallyTypedSelfInMethodDataAttribute]
 from typing import Any, TypeVar, Generic, Callable

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -470,11 +470,11 @@ b: B[str]
 reveal_type(a.g)  # E: Revealed type is 'builtins.int'
 --reveal_type(a.gt)  # E: Revealed type is 'builtins.int'
 reveal_type(a.f())  # E: Revealed type is 'builtins.int'
---reveal_type(a.ft())  # E: Revealed type is '__main__.A*[builtins.int]'
+reveal_type(a.ft())  # E: Revealed type is '__main__.A*[builtins.int]'
 reveal_type(b.g)  # E: Revealed type is 'builtins.int'
 --reveal_type(b.gt)  # E: Revealed type is '__main__.B*[builtins.str]'
 reveal_type(b.f())  # E: Revealed type is 'builtins.int'
---reveal_type(b.ft())  # E: Revealed type is '__main__.B*[builtins.str]'
+reveal_type(b.ft())  # E: Revealed type is '__main__.B*[builtins.str]'
 
 [builtins fixtures/property.pyi]
 

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -354,16 +354,21 @@ class E:
 [case testSelfTypeProperty]
 from typing import TypeVar
 
-T = TypeVar('T', bound='A')
+Q = TypeVar('Q')
+T = TypeVar('T', bound='X')
 
-class A:
+class X:
     @property
-    def member(self: T) -> T:
-        pass
+    def __members__(self: Q) -> Q: return self
+
+class A(X):
+    @property
+    def member(self: T) -> T: return self
 
 class B(A):
     pass
 
+reveal_type(X().__members__)  # E: Revealed type is '__main__.X*'
 reveal_type(A().member)  # E: Revealed type is '__main__.A*'
 reveal_type(B().member)  # E: Revealed type is '__main__.B*'
 
@@ -376,3 +381,21 @@ class A:
     # def g(self: None) -> None: ... see in check-python2.test
 [out]
 main:3: error: Self argument missing for a non-static method (or an invalid type for self)
+
+[case testUnionPropertyField]
+from typing import Union
+
+class A:
+    x: int
+
+class B:
+    @property
+    def x(self) -> int: return 1
+
+class C:
+    @property
+    def x(self) -> int: return 1
+
+ab: Union[A, B, C]
+reveal_type(ab.x)  # E: Revealed type is 'builtins.int'
+[builtins fixtures/property.pyi]

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -449,6 +449,35 @@ reveal_type(X1.ft())  # E: Revealed type is 'Type[__main__.X]'
 
 [builtins fixtures/property.pyi]
 
+[case testSelfTypeProperSupertypeAttributeGeneric]
+from typing import Callable, TypeVar, Generic
+Q = TypeVar('Q', covariant=True)
+class K(Generic[Q]):
+    q: Q
+T = TypeVar('T')
+class A(K[Q]):
+    @property
+    def g(self: K[object]) -> int: return 0
+    @property
+    def gt(self: K[T]) -> T: return self.q
+    f: Callable[[object], int]
+    ft: Callable[[T], T]
+
+class B(A[Q]):
+    pass
+a: A[int]
+b: B[str]
+reveal_type(a.g)  # E: Revealed type is 'builtins.int'
+--reveal_type(a.gt)  # E: Revealed type is 'builtins.int'
+reveal_type(a.f())  # E: Revealed type is 'builtins.int'
+--reveal_type(a.ft())  # E: Revealed type is '__main__.A*[builtins.int]'
+reveal_type(b.g)  # E: Revealed type is 'builtins.int'
+--reveal_type(b.gt)  # E: Revealed type is '__main__.B*[builtins.str]'
+reveal_type(b.f())  # E: Revealed type is 'builtins.int'
+--reveal_type(b.ft())  # E: Revealed type is '__main__.B*[builtins.str]'
+
+[builtins fixtures/property.pyi]
+
 [case testSelfTypeNotSelfType]
 # Friendlier error messages for common mistakes. See #2950
 class A:

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -367,10 +367,11 @@ reveal_type(x.f)  # E: Revealed type is 'builtins.int'
 
 [case testSelfTypeProperSupertypeAttribute]
 from typing import Callable, TypeVar
-T = TypeVar('T', bound=object)
-class A:
+class K: pass
+T = TypeVar('T', bound=K)
+class A(K):
     @property
-    def g(self: object) -> int: return 0
+    def g(self: K) -> int: return 0
     @property
     def gt(self: T) -> T: return self
     f: Callable[[object], int]
@@ -392,7 +393,7 @@ reveal_type(B().ft())  # E: Revealed type is '__main__.B*'
 
 [case testSelfTypeProperSupertypeAttributeTuple]
 from typing import Callable, TypeVar, Tuple
-T = TypeVar('T', bound=object)
+T = TypeVar('T')
 class A(Tuple[int, int]):
     @property
     def g(self: object) -> int: return 0
@@ -417,7 +418,7 @@ reveal_type(B().ft())  # E: Revealed type is 'Tuple[builtins.int, builtins.int, 
 
 [case testSelfTypeProperSupertypeAttributeMeta]
 from typing import Callable, TypeVar, Type
-T = TypeVar('T', bound=object)
+T = TypeVar('T')
 class A(type):
     @property
     def g(cls: object) -> int: return 0
@@ -429,17 +430,18 @@ class A(type):
 class B(A):
     pass
 
-class X(metaclass=B): pass
+class X(metaclass=B):
+    def __init__(self, x: int) -> None: pass
 class Y(X): pass
 X1: Type[X]
 reveal_type(X.g)  # E: Revealed type is 'builtins.int'
-reveal_type(X.gt)  # E: Revealed type is 'def () -> __main__.X'
+reveal_type(X.gt)  # E: Revealed type is 'def (x: builtins.int) -> __main__.X'
 reveal_type(X.f())  # E: Revealed type is 'builtins.int'
-reveal_type(X.ft())  # E: Revealed type is 'def () -> __main__.X'
+reveal_type(X.ft())  # E: Revealed type is 'def (x: builtins.int) -> __main__.X'
 reveal_type(Y.g)  # E: Revealed type is 'builtins.int'
-reveal_type(Y.gt)  # E: Revealed type is 'def () -> __main__.Y'
+reveal_type(Y.gt)  # E: Revealed type is 'def (x: builtins.int) -> __main__.Y'
 reveal_type(Y.f())  # E: Revealed type is 'builtins.int'
-reveal_type(Y.ft())  # E: Revealed type is 'def () -> __main__.Y'
+reveal_type(Y.ft())  # E: Revealed type is 'def (x: builtins.int) -> __main__.Y'
 reveal_type(X1.g)  # E: Revealed type is 'builtins.int'
 reveal_type(X1.gt)  # E: Revealed type is 'Type[__main__.X]'
 reveal_type(X1.f())  # E: Revealed type is 'builtins.int'

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -351,26 +351,85 @@ class E:
     def __init_subclass__(cls) -> None:
         reveal_type(cls)  # E: Revealed type is 'def () -> __main__.E'
 
-[case testSelfTypeProperty]
-from typing import TypeVar
-
-Q = TypeVar('Q')
-T = TypeVar('T', bound='X')
-
-class X:
+[case testSelfTypeProperSupertypeAttribute]
+from typing import Callable, TypeVar
+T = TypeVar('T', bound=object)
+class A:
     @property
-    def __members__(self: Q) -> Q: return self
-
-class A(X):
+    def g(self: object) -> int: return 0
     @property
-    def member(self: T) -> T: return self
+    def gt(self: T) -> T: return self
+    f: Callable[[object], int]
+    ft: Callable[[T], T]
 
 class B(A):
     pass
 
-reveal_type(X().__members__)  # E: Revealed type is '__main__.X*'
-reveal_type(A().member)  # E: Revealed type is '__main__.A*'
-reveal_type(B().member)  # E: Revealed type is '__main__.B*'
+reveal_type(A().g)  # E: Revealed type is 'builtins.int'
+reveal_type(A().gt)  # E: Revealed type is '__main__.A*'
+reveal_type(A().f())  # E: Revealed type is 'builtins.int'
+reveal_type(A().ft())  # E: Revealed type is '__main__.A*'
+reveal_type(B().g)  # E: Revealed type is 'builtins.int'
+reveal_type(B().gt)  # E: Revealed type is '__main__.B*'
+reveal_type(B().f())  # E: Revealed type is 'builtins.int'
+reveal_type(B().ft())  # E: Revealed type is '__main__.B*'
+
+[builtins fixtures/property.pyi]
+
+[case testSelfTypeProperSupertypeAttributeTuple]
+from typing import Callable, TypeVar, Tuple
+T = TypeVar('T', bound=object)
+class A(Tuple[int, int]):
+    @property
+    def g(self: object) -> int: return 0
+    @property
+    def gt(self: T) -> T: return self
+    f: Callable[[object], int]
+    ft: Callable[[T], T]
+
+class B(A):
+    pass
+
+reveal_type(A().g)  # E: Revealed type is 'builtins.int'
+reveal_type(A().gt)  # E: Revealed type is 'Tuple[builtins.int, builtins.int, fallback=__main__.A]'
+reveal_type(A().f())  # E: Revealed type is 'builtins.int'
+reveal_type(A().ft())  # E: Revealed type is 'Tuple[builtins.int, builtins.int, fallback=__main__.A]'
+reveal_type(B().g)  # E: Revealed type is 'builtins.int'
+reveal_type(B().gt)  # E: Revealed type is 'Tuple[builtins.int, builtins.int, fallback=__main__.B]'
+reveal_type(B().f())  # E: Revealed type is 'builtins.int'
+reveal_type(B().ft())  # E: Revealed type is 'Tuple[builtins.int, builtins.int, fallback=__main__.B]'
+
+[builtins fixtures/property.pyi]
+
+[case testSelfTypeProperSupertypeAttributeMeta]
+from typing import Callable, TypeVar, Type
+T = TypeVar('T', bound=object)
+class A(type):
+    @property
+    def g(cls: object) -> int: return 0
+    @property
+    def gt(cls: T) -> T: return cls
+    f: Callable[[object], int]
+    ft: Callable[[T], T]
+
+class B(A):
+    pass
+
+class X(metaclass=B): pass
+class Y(X): pass
+X1: Type[X]
+reveal_type(X.g)  # E: Revealed type is 'builtins.int'
+reveal_type(X.gt)  # E: Revealed type is 'def () -> __main__.X'
+reveal_type(X.f())  # E: Revealed type is 'builtins.int'
+reveal_type(X.ft())  # E: Revealed type is 'def () -> __main__.X'
+reveal_type(Y.g)  # E: Revealed type is 'builtins.int'
+reveal_type(Y.gt)  # E: Revealed type is 'def () -> __main__.Y'
+reveal_type(Y.f())  # E: Revealed type is 'builtins.int'
+reveal_type(Y.ft())  # E: Revealed type is 'def () -> __main__.Y'
+reveal_type(X1.g)  # E: Revealed type is 'builtins.int'
+reveal_type(X1.gt)  # E: Revealed type is 'Type[__main__.X]'
+reveal_type(X1.f())  # E: Revealed type is 'builtins.int'
+reveal_type(X1.ft())  # E: Revealed type is 'Type[__main__.X]'
 
 [builtins fixtures/property.pyi]
 

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -351,6 +351,20 @@ class E:
     def __init_subclass__(cls) -> None:
         reveal_type(cls)  # E: Revealed type is 'def () -> __main__.E'
 
+[case testSelfTypePropertyUnion]
+from typing import Union
+class A:
+    @property
+    def f(self: A) -> int: pass
+
+class B:
+    @property
+    def f(self: B) -> int: pass
+x: Union[A, B]
+reveal_type(x.f)  # E: Revealed type is 'builtins.int'
+
+[builtins fixtures/property.pyi]
+
 [case testSelfTypeProperSupertypeAttribute]
 from typing import Callable, TypeVar
 T = TypeVar('T', bound=object)


### PR DESCRIPTION
Fix #3223. Minimal examples:
```python
from typing import Callable
class X:
    f: Callable[[object], None]
X().f  # E: Invalid method type
```
```python
class X:
    @property
    def g(self: object): pass
X().g  # E: Invalid method type
```
The problem is that for non-methods the check performed on access to `self` is whether `object <: X` instead of the other way around.

1. Reverse subtyping check. This change alone fixes the issue described above.
2. For classmethod, fallback on the argument instead of on the parameter
3. Mimic dispatch better: meet `original_type` with static class. This handles the case were instead of `X()` above there was something of type `Union[X, Y]`.
4. Better error message

Take 2 of #3227, but without the reverse-operator part