### PR TITLE
Fix --incremental crash on Type[...]

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -717,8 +717,7 @@ class CallableType(FunctionLike):
         )
 
     def is_type_obj(self) -> bool:
-        t = self.fallback.type
-        return t is not None and t.is_metaclass()
+        return self.fallback.type.is_metaclass()
 
     def is_concrete_type_obj(self) -> bool:
         return self.is_type_obj() and self.is_classmethod_class
@@ -1341,10 +1340,7 @@ class TypeType(Type):
         type UnionType must be handled through make_normalized static method.
         """
         super().__init__(line, column)
-        if isinstance(item, CallableType) and item.is_type_obj():
-            self.item = item.fallback
-        else:
-            self.item = item
+        self.item = item
 
     @staticmethod
     def make_normalized(item: Type, *, line: int = -1, column: int = -1) -> Type:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4025,3 +4025,14 @@ x: Type[C]
 reveal_type(x.m) # E: Revealed type is 'def (x: builtins.int) -> builtins.int'
 reveal_type(x.whatever) # E: Revealed type is 'Any'
 [out]
+
+[case testMetaclassMemberAccessViaType3]
+from typing import Any, Type, TypeVar
+T = TypeVar('T')
+class C(Any):
+    def bar(self: T) -> Type[T]: pass
+    def foo(self) -> None:
+        reveal_type(self.bar()) # E: Revealed type is 'Type[__main__.C*]'
+        reveal_type(self.bar().__name__) # E: Revealed type is 'builtins.str'
+[builtins fixtures/type.pyi]
+[out]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3995,3 +3995,33 @@ class E(metaclass=t.M): pass
 class F(six.with_metaclass(t.M)): pass
 @six.add_metaclass(t.M)
 class G: pass
+
+[case testMetaclassMemberAccessViaType]
+from typing import Type
+class M(type):
+    def m(cls, x: int) -> int:
+        pass
+
+class C(metaclass=M):
+    pass
+x = C
+y: Type[C] = C
+
+reveal_type(type(C).m) # E: Revealed type is 'def (cls: __main__.M, x: builtins.int) -> builtins.int'
+reveal_type(type(x).m) # E: Revealed type is 'def (cls: __main__.M, x: builtins.int) -> builtins.int'
+reveal_type(type(y).m) # E: Revealed type is 'def (cls: __main__.M, x: builtins.int) -> builtins.int'
+[out]
+
+[case testMetaclassMemberAccessViaType2]
+from typing import Any, Type
+class M(type):
+    def m(cls, x: int) -> int:
+        pass
+B: Any
+class C(B, metaclass=M):
+    pass
+
+x: Type[C]
+reveal_type(x.m) # E: Revealed type is 'def (x: builtins.int) -> builtins.int'
+reveal_type(x.whatever) # E: Revealed type is 'Any'
+[out]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3164,3 +3164,23 @@ import foo
 external_list = [0]
 
 [builtins fixtures/dict.pyi]
+
+[case testIncrementalCrashOnTypeWithFunction]
+import a
+[file a.py]
+import b
+[file a.py.2]
+from b import x
+
+[file b.py]
+from typing import TypeVar, Type
+T = TypeVar('T')
+
+def tp(arg: T) -> Type[T]:
+    pass
+def func(x: int) -> int:
+    pass
+
+x = tp(func)
+[out]
+[out2]

--- a/test-data/unit/fixtures/type.pyi
+++ b/test-data/unit/fixtures/type.pyi
@@ -11,6 +11,7 @@ class object:
 class list(Generic[T]): pass
 
 class type:
+    __name__: str
     def mro(self) -> List['type']: pass
 
 class tuple(Generic[T]): pass


### PR DESCRIPTION
This fixes the second traceback reported in #3852. This also improves member lookup on ``Type[...]`` by moving it to a later stage (``checkmember.py`` instead of some manipulations in ``TypeType`` constructor that are dangerous during de-serialization).

By the way it looks like the first traceback reported in #3852 is just another manifestation of #3052, but instead of just deleting a class it is replaced by a ``Var`` or by a ``FunctionDef``.

Also fixes #4058.