### PR TITLE
Require typing module before using a Py2 interpreter for tests.

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -69,10 +69,11 @@ def try_find_python2_interpreter() -> Optional[str]:
         return _python2_interpreter
     for interpreter in default_python2_interpreter:
         try:
-            process = subprocess.Popen([interpreter, '-V'], stdout=subprocess.PIPE,
-                                       stderr=subprocess.STDOUT)
-            stdout, stderr = process.communicate()
-            if b'Python 2.7' in stdout:
+            retcode = subprocess.Popen([
+                interpreter, '-c',
+                'import sys, typing; assert sys.version_info[:2] == (2, 7)'
+            ]).wait()
+            if not retcode:
                 _python2_interpreter = interpreter
                 return interpreter
         except OSError:


### PR DESCRIPTION
Fixes #4039.

Tested with:

a) Python 2.7 interpreter on PATH without typing installed: Py2 subprocess
tests skipped.

b) Python 2.7 interpreter on PATH with typing installed: Py2 subprocess tests
pass.

c) Temporarily change assertion to require `(2, 6)` instead of `(2, 7)`, with
no Python2.6 interpreter available, and `typing` installed in Python2.7 interpreter
on PATH (to verify that version assert works correctly): Py2 subprocess tests skipped.