### PR TITLE
Move pythoneval to mypy.api and increase timeout

### DIFF
--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -84,8 +84,11 @@ def test_python_evaluation(testcase: DataDrivenTestCase) -> None:
     # Type check the program.
     out, err, returncode = api.run(mypy_cmdline)
     # split lines, remove newlines, and remove directory of test case
-    output.extend([s.rstrip('\r\n')[len(test_temp_dir + os.sep):]
-                   for s in (out + err).splitlines()])
+    for line in (out + err).splitlines():
+        if line.startswith(test_temp_dir + os.sep):
+            output.append(line[len(test_temp_dir + os.sep):].rstrip("\r\n"))
+        else:
+            output.append(line.rstrip("\r\n"))
     if returncode == 0:
         # Execute the program.
         returncode, interp_out = run([interpreter, program])

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -83,7 +83,8 @@ def test_python_evaluation(testcase: DataDrivenTestCase) -> None:
     output = []
     # Type check the program.
     out, err, returncode = api.run(mypy_cmdline)
-    output.extend([s.rstrip('\r\n').lstrip(test_temp_dir + os.sep)
+    # split lines, remove newlines, and remove directory of test case
+    output.extend([s.rstrip('\r\n')[len(test_temp_dir + os.sep):]
                    for s in (out + err).splitlines()])
     if returncode == 0:
         # Execute the program.

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -113,7 +113,7 @@ def adapt_output(testcase: DataDrivenTestCase) -> List[str]:
 
 def run(
     cmdline: List[str], *, env: Optional[Dict[str, str]] = None, timeout: int = 300
-    ) -> Tuple[int, List[str]]:
+) -> Tuple[int, List[str]]:
     """A poor man's subprocess.run() for 3.3 and 3.4 compatibility."""
     process = subprocess.Popen(
         cmdline,


### PR DESCRIPTION
This is a re-do of #4025.
This change moves the mypy checking of the eval files away from subprocesses, instead using `mypy.api`.
 It also increases the timeout of the `run` function in an attempt to fix #3543.
