### PR TITLE
Add default Python 2 install on Windows to search

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ install:
     - "git config core.symlinks true"
     - "git reset --hard"
     - "%PYTHON%\\python.exe -m pip install -r test-requirements.txt"
+    - "C:\\Python27\\python.exe -m pip install typing"
     - "git submodule update --init typeshed"
     - "cd typeshed && git config core.symlinks true && git reset --hard && cd .."
     - "%PYTHON%\\python.exe -m pip install ."

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -10,7 +10,7 @@ T = TypeVar('T')
 
 ENCODING_RE = re.compile(br'([ \t\v]*#.*(\r\n?|\n))??[ \t\v]*#.*coding[:=][ \t]*([-\w.]+)')
 
-default_python2_interpreter = ['python2', 'python', '/usr/bin/python']
+default_python2_interpreter = ['python2', 'python', '/usr/bin/python', 'C:\\Python27\\python.exe']
 
 
 def split_module_names(mod_name: str) -> List[str]:


### PR DESCRIPTION
Working on #3895, I realized that the tests were not resolving the installed Python 2 on my machine. This is a simple fix. A run of pytest went from `4549 passed, 72 skipped` to `4596 passed, 25 skipped`.