### PR TITLE
Fix crash when using decorated function with multiple definitions 

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -150,7 +150,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         elif isinstance(node, FuncDef):
             # Reference to a global function.
             result = function_type(node, self.named_type('builtins.function'))
-        elif isinstance(node, OverloadedFuncDef):
+        elif isinstance(node, OverloadedFuncDef) and node.type is not None:
+            # node.type is None when there are multiple definitions of a function
+            # and it's decorated by somthing that is not typing.overload
             result = node.type
         elif isinstance(node, TypeInfo):
             # Reference to a type object.

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1,4 +1,26 @@
 -- Test cases for function overloading
+[case testOverloadNotImportedNoCrash]
+@overload
+def f(a): pass
+@overload
+def f(a): pass
+def f(a): pass
+f(0)
+
+@overload  # E: Name 'overload' is not defined
+def g(a:int): pass
+def g(a): pass  # E: Name 'g' already defined
+g(0)
+
+@something  # E: Name 'something' is not defined
+def r(a:int): pass
+def r(a): pass  # E: Name 'r' already defined
+r(0)
+[out]
+main:1: error: Name 'overload' is not defined
+main:3: error: Name 'f' already defined
+main:3: error: Name 'overload' is not defined
+main:5: error: Name 'f' already defined
 
 [case testTypeCheckOverloadWithImplementation]
 from typing import overload, Any


### PR DESCRIPTION
Quick fix for #3574  - fall back to Any when there are multiple definitions of a decorated function, if the decorator is not `typing.overload`. This might not be the best solution, but it's better than crashing.

(This also does not address the deeper problem - the fact that OverloadedFuncDefs are not necessarily overloaded functions)