### PR TITLE
Allow assignments to multiple targets from union types

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -1,6 +1,10 @@
-from typing import Dict, List, Set, Iterator, Union, Optional, Tuple, DefaultDict, cast
+from typing import Dict, List, Set, Iterator, Union, Optional, Tuple, cast
 from contextlib import contextmanager
 from collections import defaultdict
+
+MYPY = False
+if MYPY:
+    from typing import DefaultDict
 
 from mypy.types import Type, AnyType, PartialType, UnionType, TypeOfAny
 from mypy.subtypes import is_subtype
@@ -38,7 +42,8 @@ class DeclarationsFrame(Dict[Key, Optional[Type]]):
         self.unreachable = False
 
 
-Assigns = DefaultDict[Expression, List[Tuple[Type, Optional[Type]]]]
+if MYPY:
+    Assigns = DefaultDict[Expression, List[Tuple[Type, Optional[Type]]]]
 
 
 class ConditionalTypeBinder:
@@ -216,7 +221,7 @@ class ConditionalTypeBinder:
         return result
 
     @contextmanager
-    def accumulate_type_assignments(self) -> Iterator[Assigns]:
+    def accumulate_type_assignments(self) -> 'Iterator[Assigns]':
         self.type_assignments = defaultdict(list)
         yield self.type_assignments
         self.type_assignments = None

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -232,9 +232,12 @@ class ConditionalTypeBinder:
         the union are processed (a union of collected items is later bound
         manually by the caller).
         """
+        old_assignments = None
+        if self.type_assignments is not None:
+            old_assignments = self.type_assignments
         self.type_assignments = defaultdict(list)
         yield self.type_assignments
-        self.type_assignments = None
+        self.type_assignments = old_assignments
 
     def assign_type(self, expr: Expression,
                     type: Type,

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -38,6 +38,9 @@ class DeclarationsFrame(Dict[Key, Optional[Type]]):
         self.unreachable = False
 
 
+Assigns = DefaultDict[Expression, List[Tuple[Type, Optional[Type]]]]
+
+
 class ConditionalTypeBinder:
     """Keep track of conditional types of variables.
 
@@ -58,7 +61,7 @@ class ConditionalTypeBinder:
     reveal_type(lst[0].a) # str
     ```
     """
-    type_assignments = None  # type: Optional[DefaultDict[Expression, List[Tuple[Type, Type]]]]
+    type_assignments = None  # type: Optional[Assigns]
 
     def __init__(self) -> None:
         # The stack of frames currently used.  These map
@@ -213,8 +216,7 @@ class ConditionalTypeBinder:
         return result
 
     @contextmanager
-    def accumulate_type_assignments(self) -> Iterator[DefaultDict[Expression,
-                                                                  List[Tuple[Type, Type]]]]:
+    def accumulate_type_assignments(self) -> Iterator[Assigns]:
         self.type_assignments = defaultdict(list)
         yield self.type_assignments
         self.type_assignments = None

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1683,7 +1683,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     relevant_items = reinferred_rvalue_type.relevant_items()
                     if len(relevant_items) == 1:
                         reinferred_rvalue_type = relevant_items[0]
-
+                if isinstance(reinferred_rvalue_type, UnionType):
+                    self.check_multi_assignment_from_union(lvalues, rvalue,
+                                                           reinferred_rvalue_type, context,
+                                                           infer_lvalue_type)
+                    return
                 assert isinstance(reinferred_rvalue_type, TupleType)
                 rvalue_type = reinferred_rvalue_type
 
@@ -1745,7 +1749,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         returns in: ([1,2], [3,4,5], [6,7])
         """
         nr_right_of_star = length - star_index - 1
-        right_index = nr_right_of_star if -nr_right_of_star != 0 else len(items)
+        right_index = -nr_right_of_star if nr_right_of_star != 0 else len(items)
         left = items[:star_index]
         star = items[star_index:right_index]
         right = items[right_index:]

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1852,6 +1852,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
             # Make the type more general (strip away function names etc.).
             init_type = strip_type(init_type)
+
             self.set_inferred_type(name, lvalue, init_type)
 
     def infer_partial_type(self, name: Var, lvalue: Lvalue, init_type: Type) -> bool:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1646,15 +1646,21 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                             infer_lvalue_type=infer_lvalue_type,
                                             rv_type=item, undefined_rvalue=True)
                 for t, lv in zip(transposed, lvalues):
+                    if isinstance(lv, StarExpr):
+                        lv = lv.expr
                     t.append(self.type_map.pop(lv, AnyType(TypeOfAny.special_form)))
         union_types = tuple(UnionType.make_simplified_union(col) for col in transposed)
         for expr, items in assignments.items():
+            if isinstance(expr, StarExpr):
+                expr = expr.expr
             types, declared_types = zip(*items)
             self.binder.assign_type(expr,
                                     UnionType.make_simplified_union(types),
                                     UnionType.make_simplified_union(declared_types),
                                     False)
         for union, lv in zip(union_types, lvalues):
+            if isinstance(lv, StarExpr):
+                lv = lv.expr
             _1, _2, inferred = self.check_lvalue(lv)
             if inferred:
                 self.set_inferred_type(inferred, lv, union)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1525,8 +1525,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     def check_multi_assignment(self, lvalues: List[Lvalue],
                                rvalue: Expression,
                                context: Context,
-                               infer_lvalue_type: bool = True,
-                               msg: str = None) -> None:
+                               infer_lvalue_type: bool = True) -> None:
         """Check the assignment of one rvalue to a number of lvalues."""
 
         # Infer the type of an ordinary rvalue expression.
@@ -1547,6 +1546,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         elif isinstance(rvalue_type, TupleType):
             self.check_multi_assignment_from_tuple(lvalues, rvalue, rvalue_type,
                                                    context, undefined_rvalue, infer_lvalue_type)
+        elif isinstance(rvalue_type, UnionType):
+            self.check_multi_assignment_from_union(lvalues, rvalue, context, infer_lvalue_type)
         else:
             self.check_multi_assignment_from_iterable(lvalues, rvalue_type,
                                                       context, infer_lvalue_type)

--- a/mypy/maptype.py
+++ b/mypy/maptype.py
@@ -10,7 +10,8 @@ def map_instance_to_supertype(instance: Instance,
     """Produce a supertype of `instance` that is an Instance
     of `superclass`, mapping type arguments up the chain of bases.
 
-    `superclass` is required to be a superclass of `instance.type`.
+    If `superclass` is not a nominal superclass of `instance.type`,
+    then all type arguments are mapped to 'Any'.
     """
     if instance.type == superclass:
         # Fast path: `instance` already belongs to `superclass`.

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -500,28 +500,31 @@ reveal_type(x)  # E: Revealed type is 'Union[builtins.int, Any]'
 [case testUnionMultiassign1]
 from typing import Union, Tuple, Any
 
-b = None  # type: Union[Tuple[int], Tuple[float]]
+a: Union[Tuple[int], Tuple[float]]
+(a1,) = a
+reveal_type(a1)  # E: Revealed type is 'builtins.float'
+
+b: Union[Tuple[int], Tuple[str]]
 (b1,) = b
-reveal_type(b1)  # E: Revealed type is 'builtins.float'
+reveal_type(b1)  # E: Revealed type is 'Union[builtins.int, builtins.str]'
 
 [case testUnionMultiassign2]
 from typing import Union, Tuple
 
-c = None  # type: Union[Tuple[int, int], Tuple[int, str]]
-q = None  # type: Tuple[int, float]
+c: Union[Tuple[int, int], Tuple[int, float]]
 (c1, c2) = c
 reveal_type(c1)  # E: Revealed type is 'builtins.int'
-reveal_type(c2)  # E: Revealed type is 'builtins.object'
+reveal_type(c2)  # E: Revealed type is 'builtins.float'
 
 [case testUnionMultiassignAny]
 from typing import Union, Tuple, Any
 
-d = None  # type: Union[Any, Tuple[float, float]]
+d: Union[Any, Tuple[float, float]]
 (d1, d2) = d
-reveal_type(d1)  # E: Revealed type is 'Any'
-reveal_type(d2)  # E: Revealed type is 'Any'
+reveal_type(d1)  # E: Revealed type is 'Union[Any, builtins.float]'
+reveal_type(d2)  # E: Revealed type is 'Union[Any, builtins.float]'
 
-e = None  # type: Union[Any, Tuple[float, float], int]
+e: Union[Any, Tuple[float, float], int]
 (e1, e2) = e  # E: 'builtins.int' object is not iterable
 
 [case testUnionMultiassignJoin]
@@ -530,9 +533,9 @@ from typing import Union, List
 class A: pass
 class B(A): pass
 class C(A): pass
-a = None  # type: Union[List[B], List[C]]
+a: Union[List[B], List[C]]
 x, y = a
-reveal_type(x)  # E: Revealed type is '__main__.A'
+reveal_type(x)  # E: Revealed type is 'Union[__main__.B*, __main__.C*]'
 
 [builtins fixtures/list.pyi]
 [case testUnionMultiassignRebind]
@@ -541,12 +544,11 @@ from typing import Union, List
 class A: pass
 class B(A): pass
 class C(A): pass
-obj = None  # type: object
-c = None  # type: object
-a = None  # type: Union[List[B], List[C]]
+obj: object
+a: Union[List[B], List[C]]
 obj, new = a
-reveal_type(obj)  # E: Revealed type is '__main__.A'
-reveal_type(new)  # E: Revealed type is '__main__.A'
+reveal_type(obj)  # E: Revealed type is 'Union[__main__.B*, __main__.C*]'
+reveal_type(new)  # E: Revealed type is 'Union[__main__.B*, __main__.C*]'
 
 obj = 1
 reveal_type(obj)  # E: Revealed type is 'builtins.int'
@@ -556,29 +558,28 @@ reveal_type(obj)  # E: Revealed type is 'builtins.int'
 [case testUnionMultiassignAlreadyDeclared]
 from typing import Union, Tuple
 
-a = None  # type: Union[Tuple[int, int], Tuple[int, float]]
-a1 = None  # type: object
-a2 = None  # type: int
+a: Union[Tuple[int, int], Tuple[int, float]]
+a1: object
+a2: int
 
 (a1, a2) = a  # E: Incompatible types in assignment (expression has type "float", variable has type "int")
 
-b = None  # type: Union[Tuple[float, int], Tuple[int, int]]
-b1 = None  # type: object
-b2 = None  # type: int
+b: Union[Tuple[float, int], Tuple[int, int]]
+b1: object
+b2: int
 
-# Binder should act last
-(b1, b2) = a  # QUESTIONABLE: Incompatible types in assignment (expression has type "float", variable has type "int")
+(b1, b2) = b
 
-c = None  # type: Union[Tuple[int, int], Tuple[int, int]]
-c1 = None  # type: object
-c2 = None  # type: int
+c: Union[Tuple[int, int], Tuple[int, int]]
+c1: object
+c2: int
 
 (c1, c2) = c
 reveal_type(c1)  # E: Revealed type is 'builtins.int'
 reveal_type(c2)  # E: Revealed type is 'builtins.int'
 
-d = None  # type: Union[Tuple[int, int], Tuple[int, float]]
-d1 = None  # type: object
+d: Union[Tuple[int, int], Tuple[int, float]]
+d1: object
 
 (d1, d2) = d
 reveal_type(d1)  # E: Revealed type is 'builtins.int'
@@ -588,12 +589,12 @@ reveal_type(d2)  # E: Revealed type is 'builtins.float'
 from typing import Union, Tuple, List
 
 class B:
-    x = None  # type: object
+    x: object
 
-x = None  # type: List[int]
-b = None  # type: B
+x: List[int]
+b: B
 
-a = None  # type: Union[Tuple[int, int], Tuple[int, object]]
+a: Union[Tuple[int, int], Tuple[int, object]]
 (x[0], b.x) = a
 
 reveal_type(x[0])  # E: Revealed type is 'builtins.int*'
@@ -604,11 +605,11 @@ reveal_type(b.x)  # E: Revealed type is 'builtins.object'
 [case testUnionMultiassignPacked]
 from typing import Union, Tuple, List
 
-a = None  # type: Union[Tuple[int, int, int], Tuple[int, int, str]]
-a1 = None  # type: int
-a2 = None  # type: object
+a: Union[Tuple[int, int, int], Tuple[int, int, str]]
+a1: int
+a2: object
 --FIX: allow proper rebinding of packed
-xs = None  # type: List[int]
+xs: List[int]
 (a1, *xs, a2) = a
 
 reveal_type(a1)  # E: Revealed type is 'builtins.int'

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -818,6 +818,49 @@ reveal_type(y) # E: Revealed type is 'builtins.object'
 [builtins fixtures/tuple.pyi]
 [out]
 
+[case testUnionUnpackingFromNestedTuples]
+from typing import Union, Tuple
+
+t: Union[Tuple[int, Tuple[int, int]], Tuple[str, Tuple[str, str]]]
+x, (y, z) = t
+reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(z) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+[builtins fixtures/tuple.pyi]
+[out]
+
+[case testNestedUnionUnpackingFromNestedTuples]
+from typing import Union, Tuple
+
+class A: pass
+class B: pass
+
+t: Union[Tuple[int, Union[Tuple[int, int], Tuple[A, A]]], Tuple[str, Union[Tuple[str, str], Tuple[B, B]]]]
+x, (y, z) = t
+reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(y) # E: Revealed type is 'Union[builtins.int, __main__.A, builtins.str, __main__.B]'
+reveal_type(z) # E: Revealed type is 'Union[builtins.int, __main__.A, builtins.str, __main__.B]'
+[builtins fixtures/tuple.pyi]
+[out]
+
+[case testNestedUnionUnpackingFromNestedTuplesBinder]
+from typing import Union, Tuple
+
+class A: pass
+class B: pass
+
+x: object
+y: object
+z: object
+
+t: Union[Tuple[int, Union[Tuple[int, int], Tuple[A, A]]], Tuple[str, Union[Tuple[str, str], Tuple[B, B]]]]
+x, (y, z) = t
+reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(y) # E: Revealed type is 'Union[builtins.int, __main__.A, builtins.str, __main__.B]'
+reveal_type(z) # E: Revealed type is 'Union[builtins.int, __main__.A, builtins.str, __main__.B]'
+[builtins fixtures/tuple.pyi]
+[out]
+
 [case testLongUnionFormatting]
 from typing import Any, Generic, TypeVar, Union
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -608,15 +608,43 @@ from typing import Union, Tuple, List
 a: Union[Tuple[int, int, int], Tuple[int, int, str]]
 a1: int
 a2: object
---FIX: allow proper rebinding of packed
-xs: List[int]
 (a1, *xs, a2) = a
 
 reveal_type(a1)  # E: Revealed type is 'builtins.int'
-reveal_type(xs)  # E: Revealed type is 'builtins.list[builtins.int]'
-reveal_type(a2)  # E: Revealed type is 'builtins.int'
+reveal_type(xs)  # E: Revealed type is 'builtins.list[builtins.int*]'
+reveal_type(a2)  # E: Revealed type is 'Union[builtins.int, builtins.str]'
 
 [builtins fixtures/list.pyi]
+
+[case testUnpackingUnionOfListsInFunction]
+from typing import Union, List
+
+def f(x: bool) -> Union[List[int], List[str]]:
+    if x:
+        return [1, 1]
+    else:
+        return ['a', 'a']
+
+def g(x: bool) -> None:
+    a, b = f(x)
+    reveal_type(a) # E: Revealed type is 'Union[builtins.int*, builtins.str*]'
+    reveal_type(b) # E: Revealed type is 'Union[builtins.int*, builtins.str*]'
+[builtins fixtures/list.pyi]
+
+[case testUnionOfVariableLengthTupleUnpacking]
+from typing import Tuple, Union
+VarTuple = Union[Tuple[int, int], Tuple[int, int, int]]
+
+def make_tuple() -> VarTuple:
+    pass
+x = make_tuple()
+
+a, b = x # E: Too many values to unpack (2 expected, 3 provided)
+a, b, c = x # E: Need more than 2 values to unpack (3 expected)
+c, *d = x
+reveal_type(c) # E: Revealed type is 'builtins.int'
+reveal_type(d) # E: Revealed type is 'builtins.list[builtins.int*]'
+[builtins fixtures/tuple.pyi]
 
 [case testLongUnionFormatting]
 from typing import Any, Generic, TypeVar, Union

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -861,6 +861,67 @@ reveal_type(z) # E: Revealed type is 'Union[builtins.int, __main__.A, builtins.s
 [builtins fixtures/tuple.pyi]
 [out]
 
+[case testUnpackUnionNoCrashOnPartialNone]
+# flags: --strict-optional
+from typing import Dict, Tuple, List, Any
+
+a: Any
+d: Dict[str, Tuple[List[Tuple[str, str]], str]]
+x, _ = d.get(a, (None, None))
+
+for y in x: pass # E: Iterable expected \
+                 # E: Item "None" of "Optional[List[Tuple[str, str]]]" has no attribute "__iter__"
+if x:
+    for s, t in x:
+        reveal_type(s) # E: Revealed type is 'builtins.str'
+[builtins fixtures/dict.pyi]
+[out]
+
+[case testUnpackUnionNoCrashOnPartialNone2]
+# flags: --strict-optional
+from typing import Dict, Tuple, List, Any
+
+a: Any
+x = None
+d: Dict[str, Tuple[List[Tuple[str, str]], str]]
+x, _ = d.get(a, (None, None))
+
+for y in x: pass # E: Iterable expected \
+                 # E: Item "None" of "Optional[List[Tuple[str, str]]]" has no attribute "__iter__"
+if x:
+    for s, t in x:
+        reveal_type(s) # E: Revealed type is 'builtins.str'
+[builtins fixtures/dict.pyi]
+[out]
+
+[case testUnpackUnionNoCrashOnPartialNoneBinder]
+# flags: --strict-optional
+from typing import Dict, Tuple, List, Any
+
+x: object
+a: Any
+d: Dict[str, Tuple[List[Tuple[str, str]], str]]
+x, _ = d.get(a, (None, None))
+# FIXME: fix narrow_declared_type for narrowed Optional types.
+reveal_type(x) # E: Revealed type is 'builtins.list[Tuple[builtins.str, builtins.str]]'
+
+for y in x: pass
+[builtins fixtures/dict.pyi]
+[out]
+
+[case testUnpackUnionNoCrashOnPartialNoneList]
+# flags: --strict-optional
+from typing import Dict, Tuple, List, Any
+
+a: Any
+d: Dict[str, Tuple[List[Tuple[str, str]], str]]
+x, _ = d.get(a, ([], []))
+reveal_type(x) # E: Revealed type is 'Union[builtins.list[Tuple[builtins.str, builtins.str]], builtins.list[<nothing>]]'
+
+for y in x: pass
+[builtins fixtures/dict.pyi]
+[out]
+
 [case testLongUnionFormatting]
 from typing import Any, Generic, TypeVar, Union
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -497,7 +497,7 @@ if bool():
 reveal_type(x)  # E: Revealed type is 'Union[builtins.int, Any]'
 [builtins fixtures/bool.pyi]
 
-[case testUnionMultiassign1]
+[case testUnionMultiassignSingle]
 from typing import Union, Tuple, Any
 
 a: Union[Tuple[int], Tuple[float]]
@@ -508,13 +508,25 @@ b: Union[Tuple[int], Tuple[str]]
 (b1,) = b
 reveal_type(b1)  # E: Revealed type is 'Union[builtins.int, builtins.str]'
 
-[case testUnionMultiassign2]
+[case testUnionMultiassignDouble]
 from typing import Union, Tuple
 
 c: Union[Tuple[int, int], Tuple[int, float]]
 (c1, c2) = c
 reveal_type(c1)  # E: Revealed type is 'builtins.int'
 reveal_type(c2)  # E: Revealed type is 'builtins.float'
+
+[case testUnionMultiassignGeneric]
+from typing import Union, Tuple, TypeVar
+T = TypeVar('T')
+S = TypeVar('S')
+
+def pack_two(x: T, y: S) -> Union[Tuple[T, T], Tuple[S, S]]:
+    pass
+
+(x, y) = pack_two(1, 'a')
+reveal_type(x)  # E: Revealed type is 'Union[builtins.int*, builtins.str*]'
+reveal_type(y)  # E: Revealed type is 'Union[builtins.int*, builtins.str*]'
 
 [case testUnionMultiassignAny]
 from typing import Union, Tuple, Any
@@ -527,7 +539,7 @@ reveal_type(d2)  # E: Revealed type is 'Union[Any, builtins.float]'
 e: Union[Any, Tuple[float, float], int]
 (e1, e2) = e  # E: 'builtins.int' object is not iterable
 
-[case testUnionMultiassignJoin]
+[case testUnionMultiassignNotJoin]
 from typing import Union, List
 
 class A: pass
@@ -536,8 +548,8 @@ class C(A): pass
 a: Union[List[B], List[C]]
 x, y = a
 reveal_type(x)  # E: Revealed type is 'Union[__main__.B*, __main__.C*]'
-
 [builtins fixtures/list.pyi]
+
 [case testUnionMultiassignRebind]
 from typing import Union, List
 
@@ -552,7 +564,6 @@ reveal_type(new)  # E: Revealed type is 'Union[__main__.B*, __main__.C*]'
 
 obj = 1
 reveal_type(obj)  # E: Revealed type is 'builtins.int'
-
 [builtins fixtures/list.pyi]
 
 [case testUnionMultiassignAlreadyDeclared]
@@ -561,26 +572,24 @@ from typing import Union, Tuple
 a: Union[Tuple[int, int], Tuple[int, float]]
 a1: object
 a2: int
-
 (a1, a2) = a  # E: Incompatible types in assignment (expression has type "float", variable has type "int")
 
 b: Union[Tuple[float, int], Tuple[int, int]]
 b1: object
 b2: int
-
 (b1, b2) = b
+reveal_type(b1) # E: Revealed type is 'builtins.float'
+reveal_type(b2) # E: Revealed type is 'builtins.int'
 
 c: Union[Tuple[int, int], Tuple[int, int]]
 c1: object
 c2: int
-
 (c1, c2) = c
 reveal_type(c1)  # E: Revealed type is 'builtins.int'
 reveal_type(c2)  # E: Revealed type is 'builtins.int'
 
 d: Union[Tuple[int, int], Tuple[int, float]]
 d1: object
-
 (d1, d2) = d
 reveal_type(d1)  # E: Revealed type is 'builtins.int'
 reveal_type(d2)  # E: Revealed type is 'builtins.float'
@@ -596,10 +605,8 @@ b: B
 
 a: Union[Tuple[int, int], Tuple[int, object]]
 (x[0], b.x) = a
-
 reveal_type(x[0])  # E: Revealed type is 'builtins.int*'
 reveal_type(b.x)  # E: Revealed type is 'builtins.object'
-
 [builtins fixtures/list.pyi]
 
 [case testUnionMultiassignPacked]
@@ -613,7 +620,6 @@ a2: object
 reveal_type(a1)  # E: Revealed type is 'builtins.int'
 reveal_type(xs)  # E: Revealed type is 'builtins.list[builtins.int*]'
 reveal_type(a2)  # E: Revealed type is 'Union[builtins.int, builtins.str]'
-
 [builtins fixtures/list.pyi]
 
 [case testUnpackingUnionOfListsInFunction]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -609,6 +609,23 @@ reveal_type(x[0])  # E: Revealed type is 'builtins.int*'
 reveal_type(b.x)  # E: Revealed type is 'builtins.object'
 [builtins fixtures/list.pyi]
 
+[case testUnionMultiassignIndexedWithError]
+from typing import Union, Tuple, List
+
+class A: pass
+class B:
+    x: int
+
+x: List[A]
+b: B
+
+a: Union[Tuple[int, int], Tuple[int, object]]
+(x[0], b.x) = a  # E: Incompatible types in assignment (expression has type "int", target has type "A") \
+                 # E: Incompatible types in assignment (expression has type "object", variable has type "int")
+reveal_type(x[0])  # E: Revealed type is '__main__.A*'
+reveal_type(b.x)  # E: Revealed type is 'builtins.int'
+[builtins fixtures/list.pyi]
+
 [case testUnionMultiassignPacked]
 from typing import Union, Tuple, List
 
@@ -651,6 +668,155 @@ c, *d = x
 reveal_type(c) # E: Revealed type is 'builtins.int'
 reveal_type(d) # E: Revealed type is 'builtins.list[builtins.int*]'
 [builtins fixtures/tuple.pyi]
+
+[case testUnionOfNonIterableUnpacking]
+from typing import Union
+bad: Union[int, str]
+
+x, y = bad # E: 'builtins.int' object is not iterable \
+           # E: 'builtins.str' object is not iterable
+reveal_type(x) # E: Revealed type is 'Any'
+reveal_type(y) # E: Revealed type is 'Any'
+[out]
+
+[case testUnionAlwaysTooMany]
+from typing import Union, Tuple
+bad: Union[Tuple[int, int, int], Tuple[str, str, str]]
+
+x, y = bad # E: Too many values to unpack (2 expected, 3 provided)
+reveal_type(x) # E: Revealed type is 'Any'
+reveal_type(y) # E: Revealed type is 'Any'
+[builtins fixtures/tuple.pyi]
+[out]
+
+[case testUnionAlwaysTooFew]
+from typing import Union, Tuple
+bad: Union[Tuple[int, int, int], Tuple[str, str, str]]
+
+x, y, z, w = bad # E: Need more than 3 values to unpack (4 expected)
+reveal_type(x) # E: Revealed type is 'Any'
+reveal_type(y) # E: Revealed type is 'Any'
+reveal_type(z) # E: Revealed type is 'Any'
+reveal_type(w) # E: Revealed type is 'Any'
+[builtins fixtures/tuple.pyi]
+[out]
+
+[case testUnionUnpackingChainedTuple]
+from typing import Union, Tuple
+good: Union[Tuple[int, int], Tuple[str, str]]
+
+x, y = t = good
+reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(t) # E: Revealed type is 'Union[Tuple[builtins.int, builtins.int], Tuple[builtins.str, builtins.str]]'
+[builtins fixtures/tuple.pyi]
+[out]
+
+[case testUnionUnpackingChainedTuple2]
+from typing import Union, Tuple
+good: Union[Tuple[int, int], Tuple[str, str]]
+
+t = x, y = good
+reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(t) # E: Revealed type is 'Union[Tuple[builtins.int, builtins.int], Tuple[builtins.str, builtins.str]]'
+[builtins fixtures/tuple.pyi]
+[out]
+
+[case testUnionUnpackingChainedTuple3]
+from typing import Union, Tuple
+good: Union[Tuple[int, int], Tuple[str, str]]
+
+x, y = a, b = good
+reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(a) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(b) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+[builtins fixtures/tuple.pyi]
+[out]
+
+[case testUnionUnpackingChainedList]
+from typing import Union, List
+good: Union[List[int], List[str]]
+
+lst = x, y = good
+reveal_type(x) # E: Revealed type is 'Union[builtins.int*, builtins.str*]'
+reveal_type(y) # E: Revealed type is 'Union[builtins.int*, builtins.str*]'
+reveal_type(lst) # E: Revealed type is 'Union[builtins.list[builtins.int], builtins.list[builtins.str]]'
+[builtins fixtures/list.pyi]
+[out]
+
+[case testUnionUnpackingChainedList2]
+from typing import Union, List
+good: Union[List[int], List[str]]
+
+x, *y, z = lst = good
+reveal_type(x) # E: Revealed type is 'Union[builtins.int*, builtins.str*]'
+reveal_type(y) # E: Revealed type is 'Union[builtins.list[builtins.int], builtins.list[builtins.str]]'
+reveal_type(z) # E: Revealed type is 'Union[builtins.int*, builtins.str*]'
+reveal_type(lst) # E: Revealed type is 'Union[builtins.list[builtins.int], builtins.list[builtins.str]]'
+[builtins fixtures/list.pyi]
+[out]
+
+[case testUnionUnpackingInForTuple]
+from typing import Union, Tuple, NamedTuple
+class NTInt(NamedTuple):
+    x: int
+    y: int
+class NTStr(NamedTuple):
+    x: str
+    y: str
+
+nt: Union[NTInt, NTStr]
+for nx in nt:
+    reveal_type(nx) # E: Revealed type is 'Union[builtins.int*, builtins.str*]'
+
+t: Union[Tuple[int, int], Tuple[str, str]]
+for x in t:
+    # TODO(Ivan): This will be OK when tuple fallback patches are added (like above)
+    reveal_type(x) # E: Revealed type is 'Any'
+[builtins fixtures/for.pyi]
+[out]
+
+[case testUnionUnpackingInForList]
+from typing import Union, List, Tuple
+
+t: Union[List[Tuple[int, int]], List[Tuple[str, str]]]
+for x, y in t:
+    reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+
+t2: List[Union[Tuple[int, int], Tuple[str, str]]]
+for x2, y2 in t2:
+    reveal_type(x2) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+    reveal_type(y2) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+[builtins fixtures/for.pyi]
+[out]
+
+[case testUnionUnpackingDoubleBinder]
+from typing import Union, Tuple
+
+x: object
+y: object
+class A: pass
+class B: pass
+
+t1: Union[Tuple[A, A], Tuple[B, B]]
+t2: Union[Tuple[int, int], Tuple[str, str]]
+
+x, y = t1
+reveal_type(x) # E: Revealed type is 'Union[__main__.A, __main__.B]'
+reveal_type(y) # E: Revealed type is 'Union[__main__.A, __main__.B]'
+
+x, y = t2
+reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.str]'
+
+x, y = object(), object()
+reveal_type(x) # E: Revealed type is 'builtins.object'
+reveal_type(y) # E: Revealed type is 'builtins.object'
+[builtins fixtures/tuple.pyi]
+[out]
 
 [case testLongUnionFormatting]
 from typing import Any, Generic, TypeVar, Union

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -496,3 +496,123 @@ if bool():
     reveal_type(x)  # E: Revealed type is 'Any'
 reveal_type(x)  # E: Revealed type is 'Union[builtins.int, Any]'
 [builtins fixtures/bool.pyi]
+
+[case testUnionMultiassign1]
+from typing import Union, Tuple, Any
+
+b = None  # type: Union[Tuple[int], Tuple[float]]
+(b1,) = b
+reveal_type(b1)  # E: Revealed type is 'builtins.float'
+
+[case testUnionMultiassign2]
+from typing import Union, Tuple
+
+c = None  # type: Union[Tuple[int, int], Tuple[int, str]]
+q = None  # type: Tuple[int, float]
+(c1, c2) = c
+reveal_type(c1)  # E: Revealed type is 'builtins.int'
+reveal_type(c2)  # E: Revealed type is 'builtins.object'
+
+[case testUnionMultiassignAny]
+from typing import Union, Tuple, Any
+
+d = None  # type: Union[Any, Tuple[float, float]]
+(d1, d2) = d
+reveal_type(d1)  # E: Revealed type is 'Any'
+reveal_type(d2)  # E: Revealed type is 'Any'
+
+e = None  # type: Union[Any, Tuple[float, float], int]
+(e1, e2) = e  # E: 'builtins.int' object is not iterable
+
+[case testUnionMultiassignJoin]
+from typing import Union, List
+
+class A: pass
+class B(A): pass
+class C(A): pass
+a = None  # type: Union[List[B], List[C]]
+x, y = a
+reveal_type(x)  # E: Revealed type is '__main__.A'
+
+[builtins fixtures/list.pyi]
+[case testUnionMultiassignRebind]
+from typing import Union, List
+
+class A: pass
+class B(A): pass
+class C(A): pass
+obj = None  # type: object
+c = None  # type: object
+a = None  # type: Union[List[B], List[C]]
+obj, new = a
+reveal_type(obj)  # E: Revealed type is '__main__.A'
+reveal_type(new)  # E: Revealed type is '__main__.A'
+
+obj = 1
+reveal_type(obj)  # E: Revealed type is 'builtins.int'
+
+[builtins fixtures/list.pyi]
+
+[case testUnionMultiassignAlreadyDeclared]
+from typing import Union, Tuple
+
+a = None  # type: Union[Tuple[int, int], Tuple[int, float]]
+a1 = None  # type: object
+a2 = None  # type: int
+
+(a1, a2) = a  # E: Incompatible types in assignment (expression has type "float", variable has type "int")
+
+b = None  # type: Union[Tuple[float, int], Tuple[int, int]]
+b1 = None  # type: object
+b2 = None  # type: int
+
+# Binder should act last
+(b1, b2) = a  # QUESTIONABLE: Incompatible types in assignment (expression has type "float", variable has type "int")
+
+c = None  # type: Union[Tuple[int, int], Tuple[int, int]]
+c1 = None  # type: object
+c2 = None  # type: int
+
+(c1, c2) = c
+reveal_type(c1)  # E: Revealed type is 'builtins.int'
+reveal_type(c2)  # E: Revealed type is 'builtins.int'
+
+d = None  # type: Union[Tuple[int, int], Tuple[int, float]]
+d1 = None  # type: object
+
+(d1, d2) = d
+reveal_type(d1)  # E: Revealed type is 'builtins.int'
+reveal_type(d2)  # E: Revealed type is 'builtins.float'
+
+[case testUnionMultiassignIndexed]
+from typing import Union, Tuple, List
+
+class B:
+    x = None  # type: object
+
+x = None  # type: List[int]
+b = None  # type: B
+
+a = None  # type: Union[Tuple[int, int], Tuple[int, object]]
+(x[0], b.x) = a
+
+reveal_type(x[0])  # E: Revealed type is 'builtins.int*'
+reveal_type(b.x)  # E: Revealed type is 'builtins.object'
+
+[builtins fixtures/list.pyi]
+
+[case testUnionMultiassignPacked]
+from typing import Union, Tuple, List
+
+a = None  # type: Union[Tuple[int, int, int], Tuple[int, int, str]]
+a1 = None  # type: int
+a2 = None  # type: object
+--FIX: allow proper rebinding of packed
+xs = None  # type: List[int]
+(a1, *xs, a2) = a
+
+reveal_type(a1)  # E: Revealed type is 'builtins.int'
+reveal_type(xs)  # E: Revealed type is 'builtins.list[builtins.int]'
+reveal_type(a2)  # E: Revealed type is 'builtins.int'
+
+[builtins fixtures/list.pyi]

--- a/test-data/unit/fixtures/for.pyi
+++ b/test-data/unit/fixtures/for.pyi
@@ -9,7 +9,8 @@ class object:
     def __init__(self) -> None: pass
 
 class type: pass
-class tuple(Generic[t]): pass
+class tuple(Generic[t]):
+    def __iter__(self) -> Iterator[t]: pass
 class function: pass
 class bool: pass
 class int: pass # for convenience

--- a/test-data/unit/fixtures/list.pyi
+++ b/test-data/unit/fixtures/list.pyi
@@ -19,6 +19,7 @@ class list(Generic[T]):
     def __add__(self, x: list[T]) -> list[T]: pass
     def __mul__(self, x: int) -> list[T]: pass
     def __getitem__(self, x: int) -> T: pass
+    def __setitem__(self, x: int, v: T) -> None: pass
     def append(self, x: T) -> None: pass
     def extend(self, x: Iterable[T]) -> None: pass
 

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1419,31 +1419,26 @@ _testAsyncioGatherPreciseType.py:9: error: Revealed type is 'builtins.str'
 _testAsyncioGatherPreciseType.py:10: error: Revealed type is 'builtins.str'
 
 [case testNoCrashOnGenericUnionUnpacking]
+from typing import Union, Dict
+
 TEST = {'key': ('a', 'b')}
 def test() -> None:
     a, b = TEST.get('foo', ('x', 'y'))
     reveal_type(a)
     reveal_type(b)
-[out]
-_testNoCrashOnGenericUnionUnpacking.py:4: error: Revealed type is 'builtins.str'
-_testNoCrashOnGenericUnionUnpacking.py:5: error: Revealed type is 'builtins.str'
-
-[case testNoCrashOnGenericUnionUnpacking2]
-TEST = {'key': ('a', 'b')}
-def test() -> None:
+def test2() -> None:
     a, b = TEST.get('foo', (1, 2))
     reveal_type(a)
     reveal_type(b)
-[out]
-_testNoCrashOnGenericUnionUnpacking2.py:4: error: Revealed type is 'Union[builtins.str, builtins.int]'
-_testNoCrashOnGenericUnionUnpacking2.py:5: error: Revealed type is 'Union[builtins.str, builtins.int]'
 
-[case testCorrectItemIteratorUnionDict]
-from typing import Union, Dict
 x: Union[Dict[int, int], Dict[str, str]] = dict(a='b')
 for a, b in x.items():
     reveal_type(a)
     reveal_type(b)
 [out]
-_testCorrectItemIteratorUnionDict.py:4: error: Revealed type is 'Union[builtins.int*, builtins.str*]'
-_testCorrectItemIteratorUnionDict.py:5: error: Revealed type is 'Union[builtins.int*, builtins.str*]'
+_testNoCrashOnGenericUnionUnpacking.py:6: error: Revealed type is 'builtins.str'
+_testNoCrashOnGenericUnionUnpacking.py:7: error: Revealed type is 'builtins.str'
+_testNoCrashOnGenericUnionUnpacking.py:10: error: Revealed type is 'Union[builtins.str, builtins.int]'
+_testNoCrashOnGenericUnionUnpacking.py:11: error: Revealed type is 'Union[builtins.str, builtins.int]'
+_testNoCrashOnGenericUnionUnpacking.py:15: error: Revealed type is 'Union[builtins.int*, builtins.str*]'
+_testNoCrashOnGenericUnionUnpacking.py:16: error: Revealed type is 'Union[builtins.int*, builtins.str*]'

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1417,3 +1417,33 @@ async def main() -> None:
 [out]
 _testAsyncioGatherPreciseType.py:9: error: Revealed type is 'builtins.str'
 _testAsyncioGatherPreciseType.py:10: error: Revealed type is 'builtins.str'
+
+[case testNoCrashOnGenericUnionUnpacking]
+TEST = {'key': ('a', 'b')}
+def test() -> None:
+    a, b = TEST.get('foo', ('x', 'y'))
+    reveal_type(a)
+    reveal_type(b)
+[out]
+_testNoCrashOnGenericUnionUnpacking.py:4: error: Revealed type is 'builtins.str'
+_testNoCrashOnGenericUnionUnpacking.py:5: error: Revealed type is 'builtins.str'
+
+[case testNoCrashOnGenericUnionUnpacking2]
+TEST = {'key': ('a', 'b')}
+def test() -> None:
+    a, b = TEST.get('foo', (1, 2))
+    reveal_type(a)
+    reveal_type(b)
+[out]
+_testNoCrashOnGenericUnionUnpacking2.py:4: error: Revealed type is 'Union[builtins.str, builtins.int]'
+_testNoCrashOnGenericUnionUnpacking2.py:5: error: Revealed type is 'Union[builtins.str, builtins.int]'
+
+[case testCorrectItemIteratorUnionDict]
+from typing import Union, Dict
+x : Union[Dict[int, int], Dict[str, str]] = dict(a='b')
+for a, b in x.items():
+    reveal_type(a)
+    reveal_type(b)
+[out]
+_testCorrectItemIteratorUnionDict.py:4: error: Revealed type is 'Union[builtins.int*, builtins.str*]'
+_testCorrectItemIteratorUnionDict.py:5: error: Revealed type is 'Union[builtins.int*, builtins.str*]'

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1440,7 +1440,7 @@ _testNoCrashOnGenericUnionUnpacking2.py:5: error: Revealed type is 'Union[builti
 
 [case testCorrectItemIteratorUnionDict]
 from typing import Union, Dict
-x : Union[Dict[int, int], Dict[str, str]] = dict(a='b')
+x: Union[Dict[int, int], Dict[str, str]] = dict(a='b')
 for a, b in x.items():
     reveal_type(a)
     reveal_type(b)


### PR DESCRIPTION
Fixes #3859 
Fixes #3240 
Fixes #1855 
Fixes #1575 

This is a simple fix of various bugs and a crash based on the idea originally proposed in #2219. The idea is to check assignment for every item in a union. However, in contrast to #2219, I think it will be more expected/consistent to construct a union of the resulting types instead of a join, for example:
```python
x: Union[int, str]
x1 = x
reveal_type(x1) # Revealed type is 'Union[int, str]'

y: Union[Tuple[int], Tuple[str]]
(y1,) = y
reveal_type(y1) # Revealed type is 'Union[int, str]'
```

Thanks to @elazarg for initial work on this!