### PR TITLE
Push correct enclosing class while deferring a method

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3326,7 +3326,7 @@ class Scope:
         top = self.top_function()
         assert top, "This method must be called from inside a function"
         index = self.stack.index(top)
-        assert index
+        assert index, "Scope stack must always start with a module"
         enclosing = self.stack[index - 1]
         if isinstance(enclosing, TypeInfo):
             return enclosing

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3326,9 +3326,10 @@ class Scope:
         top = self.top_function()
         assert top, "This method must be called from inside a function"
         index = self.stack.index(top)
-        for e in reversed(self.stack[:index]):
-            if isinstance(e, TypeInfo):
-                return e
+        assert index
+        enclosing = self.stack[index - 1]
+        if isinstance(enclosing, TypeInfo):
+            return enclosing
         return None
 
     def active_self_type(self) -> Optional[Union[Instance, TupleType]]:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -266,8 +266,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             else:
                 type_name = None
             # Shouldn't we freeze the entire scope?
-            active_class = self.scope.enclosing_class()
-            self.deferred_nodes.append(DeferredNode(node, type_name, active_class))
+            enclosing_class = self.scope.enclosing_class()
+            self.deferred_nodes.append(DeferredNode(node, type_name, enclosing_class))
             # Set a marker so that we won't infer additional types in this
             # function. Any inferred types could be bogus, because there's at
             # least one type that we don't know.

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3995,3 +3995,29 @@ class E(metaclass=t.M): pass
 class F(six.with_metaclass(t.M)): pass
 @six.add_metaclass(t.M)
 class G: pass
+
+[case testCorrectEnclosingClassPushedInDeferred]
+class C:
+    def __getattr__(self, attr: str) -> int:
+        x: F
+        return x.f
+
+class F:
+    def __init__(self, f: int) -> None:
+        self.f = f
+[out]
+
+[case testCorrectEnclosingClassPushedInDeferred2]
+from typing import TypeVar
+T = TypeVar('T', bound=C)
+class C:
+    def m(self: T) -> T:
+        class Inner:
+            x: F
+            f = x.f
+        return self
+
+class F:
+    def __init__(self, f: int) -> None:
+        self.f = f
+[out]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4022,6 +4022,15 @@ class F:
         self.f = f
 [out]
 
+[case testCorrectEnclosingClassPushedInDeferred3]
+class A:
+    def f(self) -> None:
+        def g(x: int) -> int:
+            return y
+
+y = int()
+[out]
+
 [case testMetaclassMemberAccessViaType]
 from typing import Type
 class M(type):


### PR DESCRIPTION
Fixes #4069 

This pushes the correct enclosing class while deferring a method instead of just the top class.

A related comment: the name ``active_class`` is a bit misleading, it returns ``None`` from within methods, I think it would be more consistent if ``active_class`` behave the same way as ``self.type`` in semantic analysis, but it is too late to change this, it is already used in several other places with this semantics.