### PR TITLE
Remove Argument.initialization_statement

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -395,32 +395,13 @@ class Argument(Node):
     type_annotation = None  # type: Optional[mypy.types.Type]
     initializer = None  # type: Optional[Expression]
     kind = None  # type: int  # must be an ARG_* constant
-    initialization_statement = None  # type: Optional[AssignmentStmt]
 
     def __init__(self, variable: 'Var', type_annotation: 'Optional[mypy.types.Type]',
-            initializer: Optional[Expression], kind: int,
-            initialization_statement: 'Optional[AssignmentStmt]' = None) -> None:
+                 initializer: Optional[Expression], kind: int) -> None:
         self.variable = variable
-
         self.type_annotation = type_annotation
         self.initializer = initializer
-
-        self.initialization_statement = initialization_statement
-        if not self.initialization_statement:
-            self.initialization_statement = self._initialization_statement()
-
         self.kind = kind
-
-    def _initialization_statement(self) -> 'Optional[AssignmentStmt]':
-        """Convert the initializer into an assignment statement.
-        """
-        if not self.initializer:
-            return None
-
-        rvalue = self.initializer
-        lvalue = NameExpr(self.variable.name())
-        assign = AssignmentStmt([lvalue], rvalue)
-        return assign
 
     def set_line(self, target: Union[Context, int], column: Optional[int] = None) -> None:
         super().set_line(target, column)
@@ -429,10 +410,6 @@ class Argument(Node):
             self.initializer.set_line(self.line, self.column)
 
         self.variable.set_line(self.line, self.column)
-
-        if self.initialization_statement:
-            self.initialization_statement.set_line(self.line, self.column)
-            self.initialization_statement.lvalues[0].set_line(self.line, self.column)
 
 
 class FuncItem(FuncBase):

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -618,10 +618,6 @@ class SemanticAnalyzer(NodeVisitor[None]):
             self.enter()
             for arg in defn.arguments:
                 self.add_local(arg.variable, defn)
-            for arg in defn.arguments:
-                if arg.initialization_statement:
-                    lvalue = arg.initialization_statement.lvalues[0]
-                    lvalue.accept(self)
 
             # The first argument of a non-static, non-class method is like 'self'
             # (though the name could be different), having the enclosing class's

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -58,27 +58,24 @@ class StrConv(NodeVisitor[str]):
         array with information specific to methods, global functions or
         anonymous functions.
         """
-        args = []  # type: List[mypy.nodes.Var]
-        init = []  # type: List[Optional[mypy.nodes.AssignmentStmt]]
+        args = []  # type: List[Union[mypy.nodes.Var, Tuple[str, List[mypy.nodes.Node]]]]
         extra = []  # type: List[Tuple[str, List[mypy.nodes.Var]]]
-        for i, arg in enumerate(o.arguments):
+        for arg in o.arguments:
             kind = arg.kind  # type: int
             if kind in (mypy.nodes.ARG_POS, mypy.nodes.ARG_NAMED):
-                args.append(o.arguments[i].variable)
+                args.append(arg.variable)
             elif kind in (mypy.nodes.ARG_OPT, mypy.nodes.ARG_NAMED_OPT):
-                args.append(o.arguments[i].variable)
-                init.append(o.arguments[i].initialization_statement)
+                assert arg.initializer is not None
+                args.append(('default', [arg.variable, arg.initializer]))
             elif kind == mypy.nodes.ARG_STAR:
-                extra.append(('VarArg', [o.arguments[i].variable]))
+                extra.append(('VarArg', [arg.variable]))
             elif kind == mypy.nodes.ARG_STAR2:
-                extra.append(('DictVarArg', [o.arguments[i].variable]))
+                extra.append(('DictVarArg', [arg.variable]))
         a = []  # type: List[Any]
         if args:
             a.append(('Args', args))
         if o.type:
             a.append(o.type)
-        if init:
-            a.append(('Init', init))
         if o.is_generator:
             a.append('Generator')
         a.extend(extra)

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -455,13 +455,12 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
                 annotation = ": {}".format(self.print_annotation(annotated_type))
             else:
                 annotation = ""
-            init_stmt = arg_.initialization_statement
-            if init_stmt:
+            if arg_.initializer:
                 initializer = '...'
                 if kind in (ARG_NAMED, ARG_NAMED_OPT) and '*' not in args:
                     args.append('*')
                 if not annotation:
-                    typename = self.get_str_type_of_node(init_stmt.rvalue, True)
+                    typename = self.get_str_type_of_node(arg_.initializer, True)
                     annotation = ': {} = ...'.format(typename)
                 else:
                     annotation += '={}'.format(initializer)

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -35,7 +35,7 @@ class TraverserVisitor(NodeVisitor[None]):
 
     def visit_func(self, o: FuncItem) -> None:
         for arg in o.arguments:
-            init = arg.initialization_statement
+            init = arg.initializer
             if init is not None:
                 init.accept(self)
 

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -76,26 +76,11 @@ class TransformVisitor(NodeVisitor[Node]):
         return ImportAll(node.id, node.relative)
 
     def copy_argument(self, argument: Argument) -> Argument:
-        init_stmt = None  # type: Optional[AssignmentStmt]
-
-        if argument.initialization_statement:
-            init_lvalue = cast(
-                NameExpr,
-                self.expr(argument.initialization_statement.lvalues[0]),
-            )
-            init_lvalue.set_line(argument.line)
-            init_stmt = AssignmentStmt(
-                [init_lvalue],
-                self.expr(argument.initialization_statement.rvalue),
-                self.optional_type(argument.initialization_statement.type),
-            )
-
         arg = Argument(
             self.visit_var(argument.variable),
             argument.type_annotation,
             argument.initializer,
             argument.kind,
-            init_stmt,
         )
 
         # Refresh lines of the inner things

--- a/test-data/unit/parse-python2.test
+++ b/test-data/unit/parse-python2.test
@@ -271,10 +271,8 @@ MypyFile:1(
   FuncDef:1(
     f
     Args(
-      Var(__tuple_arg_1))
-    Init(
-      AssignmentStmt:1(
-        NameExpr(__tuple_arg_1)
+      default(
+        Var(__tuple_arg_1)
         TupleExpr:1(
           IntExpr(1)
           IntExpr(2))))

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -1088,10 +1088,8 @@ MypyFile:1(
   FuncDef:1(
     f
     Args(
-      Var(x))
-    Init(
-      AssignmentStmt:1(
-        NameExpr(x)
+      default(
+        Var(x)
         IntExpr(1)))
     Block:1(
       PassStmt:2()))
@@ -1099,17 +1097,14 @@ MypyFile:1(
     g
     Args(
       Var(x)
-      Var(y)
-      Var(z))
-    Init(
-      AssignmentStmt:3(
-        NameExpr(y)
+      default(
+        Var(y)
         OpExpr:3(
           +
           IntExpr(1)
           IntExpr(2)))
-      AssignmentStmt:3(
-        NameExpr(z)
+      default(
+        Var(z)
         TupleExpr:3(
           IntExpr(1)
           IntExpr(2))))
@@ -1451,10 +1446,8 @@ MypyFile:1(
   ExpressionStmt:1(
     LambdaExpr:1(
       Args(
-        Var(x))
-      Init(
-        AssignmentStmt:1(
-          NameExpr(x)
+        default(
+          Var(x)
           IntExpr(2)))
       Block:1(
         ReturnStmt:1(
@@ -2307,10 +2300,8 @@ MypyFile:1(
     MaxPos(1)
     Args(
       Var(x)
-      Var(y))
-    Init(
-      AssignmentStmt:1(
-        NameExpr(y)
+      default(
+        Var(y)
         IntExpr(1)))
     Block:1(
       PassStmt:1())))
@@ -2324,12 +2315,10 @@ MypyFile:1(
     MaxPos(1)
     Args(
       Var(x)
-      Var(y))
-    def (x: A?, *, y: B? =) -> None?
-    Init(
-      AssignmentStmt:1(
-        NameExpr(y)
+      default(
+        Var(y)
         IntExpr(1)))
+    def (x: A?, *, y: B? =) -> None?
     Block:1(
       PassStmt:1())))
 
@@ -2341,12 +2330,10 @@ MypyFile:1(
     f
     MaxPos(0)
     Args(
-      Var(y))
-    def (*, y: B? =) -> None?
-    Init(
-      AssignmentStmt:1(
-        NameExpr(y)
+      default(
+        Var(y)
         IntExpr(1)))
+    def (*, y: B? =) -> None?
     Block:1(
       PassStmt:1())))
 
@@ -3029,10 +3016,8 @@ MypyFile:1(
     MaxPos(1)
     Args(
       Var(x)
-      Var(y))
-    Init(
-      AssignmentStmt:1(
-        NameExpr(y)
+      default(
+        Var(y)
         NameExpr(None)))
     VarArg(
       Var(args))

--- a/test-data/unit/semanal-basic.test
+++ b/test-data/unit/semanal-basic.test
@@ -184,14 +184,11 @@ MypyFile:1(
   FuncDef:1(
     f
     Args(
-      Var(x)
-      Var(y))
-    Init(
-      AssignmentStmt:1(
-        NameExpr(x [l])
+      default(
+        Var(x)
         NameExpr(f [__main__.f]))
-      AssignmentStmt:1(
-        NameExpr(y [l])
+      default(
+        Var(y)
         NameExpr(object [builtins.object])))
     Block:1(
       ExpressionStmt:2(

--- a/test-data/unit/semanal-classes.test
+++ b/test-data/unit/semanal-classes.test
@@ -547,12 +547,10 @@ MypyFile:1(
       f
       Args(
         Var(self)
-        Var(x))
-      def (self: __main__.A, x: builtins.int =)
-      Init(
-        AssignmentStmt:4(
-          NameExpr(x [l])
+        default(
+          Var(x)
           NameExpr(X [__main__.A.X])))
+      def (self: __main__.A, x: builtins.int =)
       Block:4(
         PassStmt:4()))))
 

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -1023,12 +1023,10 @@ MypyFile:1(
     g
     MaxPos(0)
     Args(
-      Var(y))
-    def (*x: builtins.int, *, y: builtins.str =) -> Any
-    Init(
-      AssignmentStmt:1(
-        NameExpr(y [l])
+      default(
+        Var(y)
         StrExpr()))
+    def (*x: builtins.int, *, y: builtins.str =) -> Any
     VarArg(
       Var(x))
     Block:1(


### PR DESCRIPTION
As mentioned in #3785, since #3783 the initialization statement for Argument is not used anywhere, except when printing, copying etc. What's left is almost pure data.

Most of the changes in the PR is the expected output in semanal and parse tests.