### PR TITLE
Fix config file parsing of disallow_any/disallow_untyped_defs combination

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -750,7 +750,13 @@ def parse_section(prefix: str, template: Options,
             print("%s: %s: %s" % (prefix, key, err), file=sys.stderr)
             continue
         if key == 'disallow_any':
-            results['disallow_untyped_defs'] = v and 'unannotated' in v
+            # "disallow_any = " should disable all disallow_any options, including untyped defs,
+            # given in a more general config.
+            if not v:
+                results['disallow_untyped_defs'] = False
+            # If "unannotated" is explicitly given, turn on disallow_untyped_defs.
+            elif 'unannotated' in v:
+                results['disallow_untyped_defs'] = True
         if key == 'silent_imports':
             print("%s: silent_imports has been replaced by "
                   "ignore_missing_imports=True; follow_imports=skip" % prefix, file=sys.stderr)

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -41,7 +41,7 @@ class PythonEvaluationSuite(DataSuite):
                                   native_sep=True)
         return c
 
-    def run_case(self, testcase: DataDrivenTestCase):
+    def run_case(self, testcase: DataDrivenTestCase) -> None:
         test_python_evaluation(testcase)
 
 

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -49,7 +49,7 @@ class PythonEvaluationSuite(DataSuite):
                     test_python_evaluation, test_temp_dir, True)
         return c
 
-    def run_case(self, testcase: DataDrivenTestCase):
+    def run_case(self, testcase: DataDrivenTestCase) -> None:
         test_python_evaluation(testcase)
 
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1398,7 +1398,7 @@ class ForwardRef(Type):
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_forwardref_type(self)
 
-    def serialize(self):
+    def serialize(self) -> str:
         if isinstance(self.link, UnboundType):
             name = self.link.name
         if isinstance(self.link, Instance):

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -7,7 +7,12 @@ no_implicit_optional = True
 disallow_any = generics, unimported
 warn_redundant_casts = True
 warn_unused_ignores = True
+warn_unused_configs = True
 
 # historical exception
 [mypy-mypy.semanal]
 strict_optional = False
+
+# needs py2 compatibility
+[mypy-mypy.test.testextensions]
+disallow_untyped_defs = False

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1086,5 +1086,7 @@ a/b/c/d/e/__init__.py:1: error: "int" not callable
 disallow_untyped_defs = True
 disallow_any = generics
 [file a.py]
-def get_tasks(self):  # E: Function is missing a type annotation
+def get_tasks(self):
     return 'whatever'
+[out]
+a.py:1: error: Function is missing a type annotation

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1078,3 +1078,13 @@ ignore_errors = True
 ignore_errors = False
 [out]
 a/b/c/d/e/__init__.py:1: error: "int" not callable
+
+[case testDisallowUntypedDefsAndGenerics]
+# cmd: mypy a.py
+[file mypy.ini]
+[[mypy]
+disallow_untyped_defs = True
+disallow_any = generics
+[file a.py]
+def get_tasks(self):  # E: Function is missing a type annotation
+    return 'whatever'


### PR DESCRIPTION
Fixes #4075.

Due to the way `disallow_any` is parsed in config files, any `disallow_any` directive basically overrode `disallow_untyped_defs`. This confused me in #4075, and it also meant that `disallow_untyped_defs` was implicitly disabled for mypy itself, because of the way `mypy_self_check.ini` was written.

This PR solves the problem by making `disallow_any` override `disallow_untyped_defs` only if the config file either has `disallow_any = ` (disabling all `disallow_any` checks) or explicitly lists `unannotated` (enabling `disallow_untyped_defs`). This passes all tests (including a new one), but it's awkward because it makes `unannotated` behave differently from other `disallow_any` flags: if a more general config has `disallow_any =  A B` and a more specific one has `disallow_any = A`, then `B` should be disabled, but this is no longer true for `unannotated`.

Here are two other options for solving the problem:
* We could parse `disallow_untyped_defs` and `disallow_any` completely independently, and just AND them at runtime when we check whether to give an error for an untyped def. This leads to an awkward situation because now if you have both `disallow_any = unannotated` in a general config and `disallow_untyped_defs = False` in the specific one, untyped defs still produce errors.
* The root cause of the problem is that we have two options that do the same thing, so we should get rid of one of them so we don't have to worry about how they interact. I think that's what @ilinum originally did, but I argued against it because `disallow_untyped_defs` is more intuitively named. What if we just get rid of `disallow_any = unannotated` instead?

In this PR I also fix the untyped defs that crept into mypy itself due to the bug.