### PR TITLE
Refactoring: Make the state of type forward references explicit

### DIFF
--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -103,4 +103,7 @@ class TypeIndirectionVisitor(SyntheticTypeVisitor[Set[str]]):
         return self._visit(t.item)
 
     def visit_forwardref_type(self, t: types.ForwardRef) -> Set[str]:
-        return self._visit(t.link)
+        if t.resolved:
+            return self._visit(t.resolved)
+        else:
+            return set()

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -310,7 +310,10 @@ class MessageBuilder:
         elif isinstance(typ, TypeType):
             return 'Type[{}]'.format(self.format_bare(typ.item, verbosity))
         elif isinstance(typ, ForwardRef):  # may appear in semanal.py
-            return self.format_bare(typ.link, verbosity)
+            if typ.resolved:
+                return self.format_bare(typ.resolved, verbosity)
+            else:
+                return self.format_bare(typ.unbound, verbosity)
         elif isinstance(typ, FunctionLike):
             func = typ
             if func.is_type_obj():

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4836,7 +4836,9 @@ class ForwardReferenceResolver(TypeTranslator):
                   # its content is updated in ThirdPass, now we need to unwrap this type.
             A = NewType('A', int)
         """
-        return t.link.accept(self)
+        assert t.resolved, 'Internal error: Unresolved forward reference: {}'.format(
+            t.unbound.name)
+        return t.resolved.accept(self)
 
     def visit_instance(self, t: Instance, from_fallback: bool = False) -> Type:
         """This visitor method tracks situations like this:

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -213,7 +213,7 @@ class TypeDependenciesVisitor(TypeVisitor[List[str]]):
         return []
 
     def visit_forwardref_type(self, typ: ForwardRef) -> List[str]:
-        return get_type_dependencies(typ.link)
+        assert False, 'Internal error: Leaked forward reference object {}'.format(typ)
 
     def visit_type_var(self, typ: TypeVarType) -> List[str]:
         # TODO: replace with actual implementation

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -704,8 +704,8 @@ class TypeAnalyserPass3(TypeVisitor[None]):
                         arg_values = [arg]
                     self.check_type_var_values(info, arg_values, tvar.name, tvar.values, i + 1, t)
                 # TODO: These hacks will be not necessary when this will be moved to later stage.
-                arg = self.update_type(arg)
-                bound = self.update_type(tvar.upper_bound)
+                arg = self.resolve_type(arg)
+                bound = self.resolve_type(tvar.upper_bound)
                 if not is_subtype(arg, bound):
                     self.fail('Type argument "{}" of "{}" must be '
                               'a subtype of "{}"'.format(
@@ -719,9 +719,10 @@ class TypeAnalyserPass3(TypeVisitor[None]):
     def check_type_var_values(self, type: TypeInfo, actuals: List[Type], arg_name: str,
                               valids: List[Type], arg_number: int, context: Context) -> None:
         for actual in actuals:
-            actual = self.update_type(actual)
+            actual = self.resolve_type(actual)
             if (not isinstance(actual, AnyType) and
-                    not any(is_same_type(actual, self.update_type(value)) for value in valids)):
+                    not any(is_same_type(actual, self.resolve_type(value))
+                            for value in valids)):
                 if len(actuals) > 1 or not isinstance(actual, Instance):
                     self.fail('Invalid type argument value for "{}"'.format(
                         type.name()), context)
@@ -731,11 +732,13 @@ class TypeAnalyserPass3(TypeVisitor[None]):
                     self.fail(messages.INCOMPATIBLE_TYPEVAR_VALUE.format(
                         arg_name, class_name, actual_type_name), context)
 
-    def update_type(self, tp: Type) -> Type:
+    def resolve_type(self, tp: Type) -> Type:
         # This helper is only needed while is_subtype and is_same_type are
         # called in third pass. This can be removed when TODO in visit_instance is fixed.
         if isinstance(tp, ForwardRef):
-            tp = tp.link
+            if tp.resolved is None:
+                return tp.unbound
+            tp = tp.resolved
         if isinstance(tp, Instance) and tp.type.replaced:
             replaced = tp.type.replaced
             if replaced.tuple_type:
@@ -799,8 +802,9 @@ class TypeAnalyserPass3(TypeVisitor[None]):
 
     def visit_forwardref_type(self, t: ForwardRef) -> None:
         self.indicator['forward'] = True
-        if isinstance(t.link, UnboundType):
-            t.link = self.anal_type(t.link)
+        if t.resolved is None:
+            resolved = self.anal_type(t.unbound)
+            t.resolve(resolved)
 
     def anal_type(self, tp: UnboundType) -> Type:
         tpan = TypeAnalyser(self.lookup_func,


### PR DESCRIPTION
Forward references can be either unbound or resolved. Also ensure
that each forward reference is only resolved at most once.

As a semi-related change, be more careful about forward references
leaking after semantic analysis.