### PR TITLE
Fix type constaint inference for Any vs Type[T]

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -506,6 +506,8 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                                      self.direction)
         elif isinstance(self.actual, TypeType):
             return infer_constraints(template.item, self.actual.item, self.direction)
+        elif isinstance(self.actual, AnyType):
+            return infer_constraints(template.item, self.actual, self.direction)
         else:
             return []
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1747,3 +1747,13 @@ class D:
     def __or__(self, x: G[X]) -> G[X]: pass
     def __ior__(self, x: G[S2]) -> G[S2]: pass \
         # E: Signatures of "__ior__" and "__or__" are incompatible
+
+[case testConstraintInferenceForAnyAgainstTypeT]
+from typing import Type, Any, TypeVar
+
+T = TypeVar('T')
+
+def f(c: Type[T]) -> T: ...
+
+x: Any
+reveal_type(f(x))  # E: Revealed type is 'Any'


### PR DESCRIPTION
Previously this case was just not handled at all, falling back to
inferring no constraints. Instead, infer `T` = `Any`.

Fixes #4105.