### PR TITLE
Fix narrowing from object to Optional

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -80,6 +80,10 @@ def is_overlapping_types(t: Type, s: Type, use_promotions: bool = False) -> bool
     # Any overlaps with everything
     if isinstance(t, AnyType) or isinstance(s, AnyType):
         return True
+    # object overlaps with everything
+    if (isinstance(t, Instance) and t.type.fullname() == 'builtins.object' or
+            isinstance(s, Instance) and s.type.fullname() == 'builtins.object'):
+        return True
 
     # Since we are effectively working with the erased types, we only
     # need to handle occurrences of TypeVarType at the top level.

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -642,3 +642,11 @@ def test_or_shortcut(value: Optional[Any]) -> None:
     if not value or value.get('foo') == 'hello':
         pass
 [builtins fixtures/bool.pyi]
+
+[case testNarrowingFromObjectToOptional]
+from typing import Optional
+x: object
+y: Optional[int]
+x = y
+reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+[out]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -902,7 +902,7 @@ x: object
 a: Any
 d: Dict[str, Tuple[List[Tuple[str, str]], str]]
 x, _ = d.get(a, (None, None))
-reveal_type(x) # E: Revealed type is 'builtins.list[Tuple[builtins.str, builtins.str]]'
+reveal_type(x) # E: Revealed type is 'Union[builtins.list[Tuple[builtins.str, builtins.str]], builtins.None]'
 
 if x:
     for y in x: pass

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -902,10 +902,10 @@ x: object
 a: Any
 d: Dict[str, Tuple[List[Tuple[str, str]], str]]
 x, _ = d.get(a, (None, None))
-# FIXME: fix narrow_declared_type for narrowed Optional types.
 reveal_type(x) # E: Revealed type is 'builtins.list[Tuple[builtins.str, builtins.str]]'
 
-for y in x: pass
+if x:
+    for y in x: pass
 [builtins fixtures/dict.pyi]
 [out]
 


### PR DESCRIPTION
Currently:
```python
x: object
y: Optional[int]
x = y
reveal_type(x) # builtins.int
```
this is unexpected and may be unsafe. This PR fixes this by considering ``object`` as overlapping with everything (including ``None``).