### PR TITLE
add psutil to test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,8 +2,9 @@ flake8
 flake8-bugbear; python_version >= '3.5'
 flake8-pyi; python_version >= '3.6'
 lxml==4.0.0
-typed-ast>=1.1.0,<1.2.0
+psutil==5.4.0
 pytest>=3.0
 pytest-xdist>=1.18
 pytest-cov>=2.4.0
+typed-ast>=1.1.0,<1.2.0
 typing>=3.5.2; python_version < '3.5'


### PR DESCRIPTION
This is causing typeshed's build to fail (e.g. python/typeshed#1680). Followup from #4130.

Also sorted the requirements alphabetically.