### PR TITLE
Clarify documentation about TypedDicts.

### DIFF
--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -1166,8 +1166,8 @@ TypedDict
 
 .. note::
 
-   TypedDict is not yet an officially supported feature.  It may not work reliably,
-   and details of TypedDict may change in future mypy releases.
+   TypedDict is an officially supported feature, but it is still experimental.
+
 
 Python programs often use dictionaries with string keys to represent objects.
 Here is a typical example:
@@ -1307,7 +1307,9 @@ Class-based syntax
 ------------------
 
 Python 3.6 supports an alternative, class-based syntax to define a
-TypedDict:
+TypedDict. This means that your code must be checked as if it were
+Python 3.6 (using the ``--python-version`` flag on the command line,
+for example). Simply running mypy on Python 3.6 is insufficient.
 
 .. code-block:: python
 


### PR DESCRIPTION
This notes that `TypedDict`s are now officially supported and clarifies what is required to use the inheritance syntax for `TypedDict`s.