### PR TITLE
Make stubgen return status 0 on --help

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -977,12 +977,12 @@ def usage(exit_nonzero: bool=True) -> None:
     """.rstrip())
 
     if exit_nonzero:
-      # The user made a mistake, so we should return with an error code
-      raise SystemExit(usage)
+        # The user made a mistake, so we should return with an error code
+        raise SystemExit(usage)
     else:
-      # The user asked for help specifically, so we should exit with success
-      print(usage, file=sys.stderr)
-      sys.exit()
+        # The user asked for help specifically, so we should exit with success
+        print(usage, file=sys.stderr)
+        sys.exit()
 
 
 if __name__ == '__main__':

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -943,7 +943,7 @@ def default_python2_interpreter() -> str:
     raise SystemExit("Can't find a Python 2 interpreter -- please use the -p option")
 
 
-def usage(bool: exit_nonzero=True) -> None:
+def usage(exit_nonzero: bool=True) -> None:
     usage = textwrap.dedent("""\
         usage: stubgen [--py2] [--no-import] [--doc-dir PATH]
                        [--search-path PATH] [-p PATH] [-o PATH]

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -908,7 +908,7 @@ def parse_options(args: List[str]) -> Options:
         elif args[0] == '--include-private':
             include_private = True
         elif args[0] in ('-h', '--help'):
-            usage()
+            usage(exit_nonzero=False)
         else:
             raise SystemExit('Unrecognized option %s' % args[0])
         args = args[1:]
@@ -943,7 +943,7 @@ def default_python2_interpreter() -> str:
     raise SystemExit("Can't find a Python 2 interpreter -- please use the -p option")
 
 
-def usage() -> None:
+def usage(bool: exit_nonzero=True) -> None:
     usage = textwrap.dedent("""\
         usage: stubgen [--py2] [--no-import] [--doc-dir PATH]
                        [--search-path PATH] [-p PATH] [-o PATH]
@@ -976,7 +976,13 @@ def usage() -> None:
           -h, --help      print this help message and exit
     """.rstrip())
 
-    raise SystemExit(usage)
+    if exit_nonzero:
+      # The user made a mistake, so we should return with an error code
+      raise SystemExit(usage)
+    else:
+      # The user asked for help specifically, so we should exit with success
+      print(usage, file=sys.stderr)
+      sys.exit()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This lets package managers like [conda](https://conda.io/docs/) use `stubgen --help` as a quick-and-dirty test.

Also it makes more sense if you squint at it a little. The user _requested_ help, so they shouldn't be put in some an error state.