### PR TITLE
Add --semantic-analysis-only flag

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -353,6 +353,8 @@ def process_options(args: List[str],
     parser.add_argument('--debug-cache', action='store_true', help=argparse.SUPPRESS)
     # --dump-graph will dump the contents of the graph of SCCs and exit.
     parser.add_argument('--dump-graph', action='store_true', help=argparse.SUPPRESS)
+    # --semantic-analysis-only does exactly that.
+    parser.add_argument('--semantic-analysis-only', action='store_true', help=argparse.SUPPRESS)
     # deprecated options
     parser.add_argument('--disallow-any', dest='special-opts:disallow_any',
                         help=argparse.SUPPRESS)


### PR DESCRIPTION
This gives shallow errors quicker (though not as quick as I had hoped -- the run time on e.g. mypy goes down from 16s to 7s, or a little over twice as fast).