### PR TITLE
README: link to flycheck-mypy's home instead of issues page

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ IDE & Linter Integrations
 Mypy can be integrated into popular IDEs:
 
 * Vim: [vim-mypy](https://github.com/Integralist/vim-mypy)
-* Emacs: using [Flycheck](https://github.com/flycheck/) and [Flycheck-mypy](https://github.com/lbolla/emacs-flycheck-mypy/issues)
+* Emacs: using [Flycheck](https://github.com/flycheck/) and [Flycheck-mypy](https://github.com/lbolla/emacs-flycheck-mypy)
 * Sublime Text: [SublimeLinter-contrib-mypy](https://github.com/fredcallaway/SublimeLinter-contrib-mypy)
 * Atom: [linter-mypy](https://atom.io/packages/linter-mypy)
 * PyCharm: PyCharm integrates [its own implementation of PEP 484](https://www.jetbrains.com/help/pycharm/2017.1/type-hinting-in-pycharm.html).


### PR DESCRIPTION
It's weird to link to the issues page, while the links for the other plugins point to the "home" / code tab.