### PR TITLE
Move quoting of function names to messages.py

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -584,7 +584,7 @@ def class_callable(init_type: CallableType, info: TypeInfo, type_type: Instance,
     callable_type = init_type.copy_modified(
         ret_type=fill_typevars(info), fallback=type_type, name=None, variables=variables,
         special_sig=special_sig)
-    c = callable_type.with_name('"{}"'.format(info.name()))
+    c = callable_type.with_name(info.name())
     return c
 
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -536,6 +536,7 @@ class MessageBuilder:
 
             for op, method in op_methods.items():
                 for variant in method, '__r' + method[2:]:
+                    # FIX: do not rely on textual formatting
                     if name.startswith('"{}" of'.format(variant)):
                         if op == 'in' or variant != method:
                             # Reversed order of base/argument.
@@ -726,9 +727,10 @@ class MessageBuilder:
 
     def no_variant_matches_arguments(self, overload: Overloaded, arg_types: List[Type],
                                      context: Context) -> None:
-        if overload.name():
+        name = callable_name(overload)
+        if name:
             self.fail('No overload variant of {} matches argument types {}'
-                      .format(overload.name(), arg_types), context)
+                      .format(name, arg_types), context)
         else:
             self.fail('No overload variant matches argument types {}'.format(arg_types), context)
 
@@ -1349,7 +1351,10 @@ def format_item_name_list(s: Iterable[str]) -> str:
 
 
 def callable_name(type: FunctionLike) -> Optional[str]:
-    return type.get_name()
+    name = type.get_name()
+    if name is not None and name[0] != '<':
+        return '"{}"'.format(name).replace(' of ', '" of "')
+    return name
 
 
 def for_function(callee: CallableType) -> str:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2448,14 +2448,14 @@ class SemanticAnalyzerPass2(NodeVisitor[None]):
             arg_kinds = [arg.kind for arg in args]
             assert None not in types
             signature = CallableType(cast(List[Type], types), arg_kinds, items, ret,
-                                     function_type,
-                                     name=name or info.name() + '.' + funcname)
+                                     function_type)
             signature.variables = [tvd]
-            func = FuncDef(funcname, args, Block([]), typ=signature)
+            func = FuncDef(funcname, args, Block([]))
             func.info = info
             func.is_class = is_classmethod
+            func.type = set_callable_name(signature, func)
             if is_classmethod:
-                v = Var(funcname, signature)
+                v = Var(funcname, func.type)
                 v.is_classmethod = True
                 v.info = info
                 dec = Decorator(func, [NameExpr('classmethod')], v)
@@ -3830,9 +3830,9 @@ def set_callable_name(sig: Type, fdef: FuncDef) -> Type:
     if isinstance(sig, FunctionLike):
         if fdef.info:
             return sig.with_name(
-                '"{}" of "{}"'.format(fdef.name(), fdef.info.name()))
+                '{} of {}'.format(fdef.name(), fdef.info.name()))
         else:
-            return sig.with_name('"{}"'.format(fdef.name()))
+            return sig.with_name(fdef.name())
     else:
         return sig
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1962,17 +1962,13 @@ def function_type(func: mypy.nodes.FuncBase, fallback: Instance) -> FunctionLike
 
 def callable_type(fdef: mypy.nodes.FuncItem, fallback: Instance,
                   ret_type: Optional[Type] = None) -> CallableType:
-    name = fdef.name()
-    if name:
-        name = '"{}"'.format(name)
-
     return CallableType(
         [AnyType(TypeOfAny.unannotated)] * len(fdef.arg_names),
         fdef.arg_kinds,
         [None if argument_elide_name(n) else n for n in fdef.arg_names],
         ret_type or AnyType(TypeOfAny.unannotated),
         fallback,
-        name,
+        name=fdef.name(),
         implicit=True,
     )
 

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -283,7 +283,7 @@ class X(NamedTuple):
 x: X
 reveal_type(x._replace())  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
 x._replace(x=5)
-x._replace(y=5)  # E: Argument 1 to X._replace has incompatible type "int"; expected "str"
+x._replace(y=5)  # E: Argument 1 to "_replace" of "X" has incompatible type "int"; expected "str"
 
 [case testNewNamedTupleFields]
 # flags: --python-version 3.6

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -260,8 +260,8 @@ reveal_type(x._replace())  # E: Revealed type is 'Tuple[Any, Any, fallback=__mai
 x._replace(y=5)
 x._replace(x=3)
 x._replace(x=3, y=5)
-x._replace(z=5)  # E: Unexpected keyword argument "z" for X._replace
-x._replace(5)  # E: Too many positional arguments for X._replace
+x._replace(z=5)  # E: Unexpected keyword argument "z" for "_replace" of "X"
+x._replace(5)  # E: Too many positional arguments for "_replace" of "X"
 
 [case testNamedTupleReplaceAsClass]
 from collections import namedtuple
@@ -269,7 +269,7 @@ from collections import namedtuple
 X = namedtuple('X', ['x', 'y'])
 x = None  # type: X
 X._replace(x, x=1, y=2)
-X._replace(x=1, y=2)  # E: Missing positional argument "self" in call to X._replace
+X._replace(x=1, y=2)  # E: Missing positional argument "self" in call to "_replace" of "X"
 
 
 [case testNamedTupleReplaceTyped]
@@ -279,19 +279,19 @@ X = NamedTuple('X', [('x', int), ('y', str)])
 x = None  # type: X
 reveal_type(x._replace())  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
 x._replace(x=5)
-x._replace(y=5)  # E: Argument 1 to X._replace has incompatible type "int"; expected "str"
+x._replace(y=5)  # E: Argument 1 to "_replace" of "X" has incompatible type "int"; expected "str"
 
 [case testNamedTupleMake]
 from typing import NamedTuple
 
 X = NamedTuple('X', [('x', int), ('y', str)])
 reveal_type(X._make([5, 'a']))  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
-X._make('a b')  # E: Argument 1 to X._make has incompatible type "str"; expected "Iterable[Any]"
+X._make('a b')  # E: Argument 1 to "_make" of "X" has incompatible type "str"; expected "Iterable[Any]"
 
 -- # FIX: not a proper class method
 -- x = None  # type: X
 -- reveal_type(x._make([5, 'a']))  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
--- x._make('a b')  # E: Argument 1 to X._make has incompatible type "str"; expected Iterable[Any]
+-- x._make('a b')  # E: Argument 1 to "_make" of "X" has incompatible type "str"; expected Iterable[Any]
 
 [builtins fixtures/list.pyi]
 


### PR DESCRIPTION
Fix #4133 (continuing #4136).

Also fix naming of namedtuple methods (to which I believe I am responsible :| ).

(I don't like the use of "method of T" as part of the name, but this PR doesn't change that).

I wonder if `callable_type()` shouldn't be using `set_callable_name()` to keep naming consistent.