### PR TITLE
Improve error message for an invalid callable type

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -467,7 +467,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], AnalyzerPluginInterface):
                 self.fail('The first argument to Callable must be a list of types or "..."', t)
                 return AnyType(TypeOfAny.from_error)
         else:
-            self.fail('Invalid function type', t)
+            self.fail('Please use "Callable[[<parameters>], <return type>]" or "Callable"', t)
             return AnyType(TypeOfAny.from_error)
         assert isinstance(ret, CallableType)
         return ret.accept(self)

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -812,7 +812,7 @@ class Node(Generic[T]):
     def __init__(self, x: T) -> None:
         ...
 
-BadC = Callable[T] # E: Invalid function type
+BadC = Callable[T] # E: Please use "Callable[[<parameters>], <return type>]" or "Callable"
 
 C = Callable[..., T]
 C2 = Callable[[T, T], Node[T]]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -819,8 +819,8 @@ y = None # type: Callable[int]
 z = None # type: Callable[int, int, int]
 [out]
 main:2: error: The first argument to Callable must be a list of types or "..."
-main:3: error: Invalid function type
-main:4: error: Invalid function type
+main:3: error: Please use "Callable[[<parameters>], <return type>]" or "Callable"
+main:4: error: Please use "Callable[[<parameters>], <return type>]" or "Callable"
 
 [case testAbstractGlobalFunction]
 import typing


### PR DESCRIPTION
If the user gives the wrong number of arguments to Callable[], tell them
how many arguments are expected.