### PR TITLE
add "type: ignore" to lxml imports

### DIFF
--- a/mypy/report.py
+++ b/mypy/report.py
@@ -25,7 +25,7 @@ from mypy.types import Type, TypeOfAny
 from mypy.version import __version__
 
 try:
-    import lxml.etree as etree
+    import lxml.etree as etree  # type: ignore
     LXML_INSTALLED = True
 except ImportError:
     LXML_INSTALLED = False

--- a/mypy/test/testreports.py
+++ b/mypy/test/testreports.py
@@ -4,7 +4,7 @@ import textwrap
 from mypy.myunit import Suite, assert_equal
 from mypy.report import CoberturaPackage, get_line_rate
 
-import lxml.etree as etree
+import lxml.etree as etree  # type: ignore
 
 
 class CoberturaReportSuite(Suite):

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -5,9 +5,10 @@ warn_no_return = True
 strict_optional = True
 no_implicit_optional = True
 disallow_any_generics = True
-disallow_any_unimported = True
+# TODO(Jelle): turn these back on after https://github.com/python/typeshed/pull/1664 is resolved
+# disallow_any_unimported = True
 warn_redundant_casts = True
-warn_unused_ignores = True
+# warn_unused_ignores = True
 warn_unused_configs = True
 
 # needs py2 compatibility


### PR DESCRIPTION
See python/typeshed#525 and python/typeshed#1664.

We decided to remove the lxml stubs because they cause problems so
frequently. However, this requires small tweaks to mypy's own usage
of lxml.

My plan is to proceed as follows:
- Merge this PR, adding type ignores and removing warn_unused_ignores
  from mypy's self-check config.
- Merge python/typeshed#1664, which should pass Travis after his PR
  is merged.
- Add "warn_unused_ignores" back to mypy's self-check config.

I confirmed that this PR passes tests both with and without the
lxml stubs being present.