### PR TITLE
With disallow_untyped_defs, warn for missing return types on async def

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -789,7 +789,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if fdef.type is None and self.options.disallow_untyped_defs:
                 self.fail(messages.FUNCTION_TYPE_EXPECTED, fdef)
             elif isinstance(fdef.type, CallableType):
-                if is_unannotated_any(fdef.type.ret_type):
+                ret_type = fdef.type.ret_type
+                if is_unannotated_any(ret_type):
+                    self.fail(messages.RETURN_TYPE_EXPECTED, fdef)
+                elif (fdef.is_coroutine and isinstance(ret_type, Instance) and
+                      is_unannotated_any(ret_type.args[0])):
                     self.fail(messages.RETURN_TYPE_EXPECTED, fdef)
                 if any(is_unannotated_any(t) for t in fdef.type.arg_types):
                     self.fail(messages.ARGUMENT_TYPE_EXPECTED, fdef)

--- a/test-data/unit/check-default-plugin.test
+++ b/test-data/unit/check-default-plugin.test
@@ -30,5 +30,4 @@ from typing import Callable, Iterator
 c: Callable[..., Iterator[int]]
 reveal_type(c) # E: Revealed type is 'def (*Any, **Any) -> typing.Iterator[builtins.int]'
 reveal_type(contextmanager(c)) # E: Revealed type is 'def (*Any, **Any) -> contextlib.GeneratorContextManager[builtins.int*]'
-[builtins fixtures/async_await.pyi]
 [typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-default-plugin.test
+++ b/test-data/unit/check-default-plugin.test
@@ -30,4 +30,5 @@ from typing import Callable, Iterator
 c: Callable[..., Iterator[int]]
 reveal_type(c) # E: Revealed type is 'def (*Any, **Any) -> typing.Iterator[builtins.int]'
 reveal_type(contextmanager(c)) # E: Revealed type is 'def (*Any, **Any) -> contextlib.GeneratorContextManager[builtins.int*]'
+[builtins fixtures/async_await.pyi]
 [typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -10,12 +10,6 @@ def f(x) -> int: pass
 [out]
 main:2: error: Function is missing a type annotation for one or more arguments
 
-[case testUnannotatedArgumentWithFastParser]
-# flags: --disallow-untyped-defs
-def f(x) -> int: pass
-[out]
-main:2: error: Function is missing a type annotation for one or more arguments
-
 [case testNoArgumentFunction]
 # flags: --disallow-untyped-defs
 def f() -> int: pass
@@ -44,6 +38,31 @@ def f():
     1 + "str"
 [out]
 main:2: error: Function is missing a type annotation
+
+[case testUntypedAsyncDef]
+# flags: --disallow-untyped-defs
+async def f():  # E: Function is missing a type annotation
+    pass
+[builtins fixtures/async_await.pyi]
+[typing fixtures/typing-full.pyi]
+
+[case testAsyncUnannotatedArgument]
+# flags: --disallow-untyped-defs
+async def f(x) -> None:  # E: Function is missing a type annotation for one or more arguments
+    pass
+[builtins fixtures/async_await.pyi]
+[typing fixtures/typing-full.pyi]
+
+[case testAsyncUnannotatedReturn]
+# flags: --disallow-untyped-defs
+from typing import Any
+async def f(x: int):  # E: Function is missing a return type annotation
+    pass
+# Make sure explicit Any is allowed.
+async def g(x: int) -> Any:
+    pass
+[builtins fixtures/async_await.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testDisallowUntypedDefsUntypedDecorator]
 # flags: --disallow-untyped-decorators

--- a/test-data/unit/fixtures/async_await.pyi
+++ b/test-data/unit/fixtures/async_await.pyi
@@ -5,11 +5,12 @@ U = typing.TypeVar('U')
 class list(typing.Sequence[T]): pass
 
 class object:
-    def __init__(self): pass
+    def __init__(self) -> None: pass
 class type: pass
 class function: pass
 class int: pass
 class str: pass
+class bool: pass
 class dict(typing.Generic[T, U]): pass
 class set(typing.Generic[T]): pass
 class tuple(typing.Generic[T]): pass

--- a/test-data/unit/fixtures/typing-full.pyi
+++ b/test-data/unit/fixtures/typing-full.pyi
@@ -140,6 +140,6 @@ def runtime(cls: T) -> T:
 
 class ContextManager(Generic[T]):
     def __enter__(self) -> T: pass
-    def __exit__(self, exc_type, exc_value, traceback): pass
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Optional[bool]: pass
 
 TYPE_CHECKING = 1

--- a/test-data/unit/fixtures/typing-full.pyi
+++ b/test-data/unit/fixtures/typing-full.pyi
@@ -140,6 +140,7 @@ def runtime(cls: T) -> T:
 
 class ContextManager(Generic[T]):
     def __enter__(self) -> T: pass
-    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Optional[bool]: pass
+    # Use Any because not all the precise types are in the fixtures.
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any: pass
 
 TYPE_CHECKING = 1


### PR DESCRIPTION
Fixes #4209.

Under disallow_untyped_defs, we were missing errors for missing return
types on async def functions, because the return type of such functions
is Awaitable[Any] instead of Any.

This PR also removes a duplicate test case (apparently from the fast
parser cleanup) and adds some missing annotations to stubs.