### PR TITLE
Fix abstract attribute errors with Any base class

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -543,7 +543,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
             if (callee.is_type_obj() and callee.type_object().is_abstract
                     # Exceptions for Type[...] and classmethod first argument
-                    and not callee.from_type_type and not callee.is_classmethod_class):
+                    and not callee.from_type_type and not callee.is_classmethod_class
+                    and not callee.type_object().fallback_to_any):
                 type = callee.type_object()
                 self.msg.cannot_instantiate_abstract_class(
                     callee.type_object().name(), type.abstract_attributes,

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -638,6 +638,21 @@ class C:
     def __add__(self, other: int) -> B: pass
 [out]
 
+[case testAbstractClassWithAnyBase]
+from typing import Any
+from abc import abstractmethod, ABCMeta
+
+A: Any
+
+class D(metaclass=ABCMeta):
+    @abstractmethod
+    def f(self) -> None: pass
+
+class C(A, D):
+    pass
+
+C()  # A might implement 'f'
+
 
 -- Abstract properties
 -- -------------------


### PR DESCRIPTION
Don't complain about abstract attributes in case there is an `Any`
base class, since an unknown base class could implement them.

Fixes #4229.