### PR TITLE
Fix crash caused by deferred lambdas by not deferring lambdas

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -48,7 +48,6 @@ from mypy.typevars import fill_typevars
 from mypy.visitor import ExpressionVisitor
 from mypy.plugin import Plugin, MethodContext, MethodSigContext, FunctionContext
 from mypy.typeanal import make_optional_type
-from mypy.binder import ConditionalTypeBinder
 
 from mypy import experiments
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -48,6 +48,7 @@ from mypy.typevars import fill_typevars
 from mypy.visitor import ExpressionVisitor
 from mypy.plugin import Plugin, MethodContext, MethodSigContext, FunctionContext
 from mypy.typeanal import make_optional_type
+from mypy.binder import ConditionalTypeBinder
 
 from mypy import experiments
 

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -911,3 +911,11 @@ class M(Generic[_KT, _VT]):
 
 def f(d: M[_KT, _VT], k: _KT) -> Union[_VT, None]:
     return d.get(k, None)
+
+[case testLambdaDeferredCrash]
+from typing import Callable
+
+class C:
+    def f(self) -> None:
+        g: Callable[[], int] = lambda: 1 or self.x
+        self.x = int()

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -650,3 +650,26 @@ y: Optional[int]
 x = y
 reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.None]'
 [out]
+
+[case testNarrowOptionalOutsideLambda]
+from typing import Optional
+
+class A:
+    a: int
+
+def f(x: Optional[A]) -> None:
+    assert x
+    lambda: x.a
+[builtins fixtures/isinstancelist.pyi]
+
+[case testNarrowOptionalOutsideLambdaWithDeferred]
+from typing import Optional
+
+class A:
+    a: int
+
+    def f(self, x: Optional['A']) -> None:
+        assert x
+        lambda: (self.y, x.a) # E: Cannot determine type of 'y'
+        self.y = int()
+[builtins fixtures/isinstancelist.pyi]


### PR DESCRIPTION
The inferred type of lambda may affect the surrounding scope, and
lambdas inherit the binder from the surrounding scope. These things
make it a bad idea to defer lambdas.

Fixes #3672.