### PR TITLE
[WIP] enable deprecation warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -17,5 +17,12 @@ python_files = test*.py
 python_classes =
 python_functions =
 
-# always run in parallel (requires pytest-xdist, see test-requirements.txt)
+# Always run in parallel (requires pytest-xdist, see test-requirements.txt)
 addopts = -nauto --cov-append --cov-report=
+
+# Always show deprecation warnings.  From:
+# https://docs.pytest.org/en/latest/warnings.html#pytest-mark-filterwarnings
+# Via: https://mail.python.org/pipermail/python-dev/2017-November/150436.html
+filterwarnings =
+    once::DeprecationWarning
+    once::PendingDeprecationWarning


### PR DESCRIPTION
See the links in the code for the motivation. We should really enable deprecation warnings when running the tests. But the simplest way to do this (in pytest.ini) triggers warnings in code that is intended to test deprecated features (`\u` escapes in byte string literals and `<>` in Python 2). So I need to find a way to disable those specific warnings and I'm too lazy to figure out how.