### PR TITLE
Force a py version < 1.5.0 on Windows, to fix AppVeyor flakes

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,3 +8,4 @@ pytest-xdist>=1.18
 pytest-cov>=2.4.0
 typed-ast>=1.1.0,<1.2.0
 typing>=3.5.2; python_version < '3.5'
+py<1.5.0; sys_platform == 'win32'


### PR DESCRIPTION
Fixes #4252.