### PR TITLE
Switch py dependency to >= 1.5.2

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,4 +8,4 @@ pytest-xdist>=1.18
 pytest-cov>=2.4.0
 typed-ast>=1.1.0,<1.2.0
 typing>=3.5.2; python_version < '3.5'
-py<1.5.0; sys_platform == 'win32'
+py>=1.5.2


### PR DESCRIPTION
Fixes #4252 differently.

According to https://github.com/pytest-dev/py/issues/169#issuecomment-344767761, py 1.5.2 has been pushed out that fixes this issue.