### PR TITLE
Do semantic analysis on lambda's bodies

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1480,6 +1480,9 @@ class LambdaExpr(FuncItem, Expression):
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_lambda_expr(self)
 
+    def is_dynamic(self) -> bool:
+        return False
+
 
 class ListExpr(Expression):
     """List literal expression [...]."""

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2212,3 +2212,19 @@ def i() -> List[Union[str, int]]:
     return x
 
 [builtins fixtures/dict.pyi]
+
+[case testLambdaSemanal]
+f = lambda: xyz
+[out]
+main:1: error: Name 'xyz' is not defined
+
+[case testLambdaTypeCheck]
+f = lambda: 1 + '1'
+[out]
+main:1: error: Unsupported operand types for + ("int" and "str")
+
+[case testLambdaTypeInference]
+f = lambda: 5
+reveal_type(f)
+[out]
+main:2: error: Revealed type is 'def () -> builtins.int'


### PR DESCRIPTION
Lambdas were seen as dynamic functions when going to report errors. This
changes them to not be dynamic functions and report semantic analysis
errors in their bodies.
Fixes #4098

The relevant check for `is_dynamic()` is here:
https://github.com/python/mypy/blob/b240125f96949b35dc2ad54c3707fd3dca5d170b/mypy/semanal.py#L3790
