### PR TITLE
Update to take advantage of 3.4 features

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -53,10 +53,6 @@ from mypy.plugin import Plugin, DefaultPlugin, ChainedPlugin
 from mypy.defaults import PYTHON3_VERSION_MIN
 
 
-# We need to know the location of this file to load data, but
-# until Python 3.4, __file__ is relative.
-__file__ = os.path.realpath(__file__)
-
 PYTHON_EXTENSIONS = ['.pyi', '.py']
 
 

--- a/mypy/myunit/__main__.py
+++ b/mypy/myunit/__main__.py
@@ -6,13 +6,4 @@ Usually used as a slave by runtests.py, but can be used directly.
 
 from mypy.myunit import main
 
-# In Python 3.3, mypy.__path__ contains a relative path to the mypy module
-# (whereas in later Python versions it contains an absolute path).  Because the
-# test runner changes directories, this breaks non-toplevel mypy imports.  We
-# fix that problem by fixing up the path to be absolute here.
-import os.path
-import mypy
-# User-defined packages always have __path__ attributes, but mypy doesn't know that.
-mypy.__path__ = [os.path.abspath(p) for p in mypy.__path__]  # type: ignore
-
 main()

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -37,7 +37,7 @@ type_of_any_name_map = collections.OrderedDict([
     (TypeOfAny.from_omitted_generics, "Omitted Generics"),
     (TypeOfAny.from_error, "Error"),
     (TypeOfAny.special_form, "Special Form"),
-])  # type: collections.OrderedDict[TypeOfAny.TypeOfAny, str]
+])  # type: collections.OrderedDict[TypeOfAny, str]
 
 reporter_classes = {}  # type: Dict[str, Tuple[Callable[[Reports, str], AbstractReporter], bool]]
 
@@ -159,7 +159,7 @@ class AnyExpressionsReporter(AbstractReporter):
     def __init__(self, reports: Reports, output_dir: str) -> None:
         super().__init__(reports, output_dir)
         self.counts = {}  # type: Dict[str, Tuple[int, int]]
-        self.any_types_counter = {}  # type: Dict[str, typing.Counter[TypeOfAny.TypeOfAny]]
+        self.any_types_counter = {}  # type: Dict[str, typing.Counter[TypeOfAny]]
         stats.ensure_dir_exists(output_dir)
 
     def on_file(self,
@@ -229,7 +229,7 @@ class AnyExpressionsReporter(AbstractReporter):
         self._write_out_report('any-exprs.txt', column_names, rows, total_row)
 
     def _report_types_of_anys(self) -> None:
-        total_counter = collections.Counter()  # type: typing.Counter[TypeOfAny.TypeOfAny]
+        total_counter = collections.Counter()  # type: typing.Counter[TypeOfAny]
         for counter in self.any_types_counter.values():
             for any_type, value in counter.items():
                 total_counter[any_type] += value
@@ -435,7 +435,7 @@ class MemoryXmlReporter(AbstractReporter):
     def _get_any_info_for_line(visitor: stats.StatisticsVisitor, lineno: int) -> str:
         if lineno in visitor.any_line_map:
             result = "Any Types on this line: "
-            counter = collections.Counter()  # type: typing.Counter[TypeOfAny.TypeOfAny]
+            counter = collections.Counter()  # type: typing.Counter[TypeOfAny]
             for typ in visitor.any_line_map[lineno]:
                 counter[typ.type_of_any] += 1
             for any_type, occurrences in counter.items():

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -64,7 +64,7 @@ class StatisticsVisitor(TraverserVisitor):
 
         self.line_map = {}  # type: Dict[int, int]
 
-        self.type_of_any_counter = Counter()  # type: typing.Counter[TypeOfAny.TypeOfAny]
+        self.type_of_any_counter = Counter()  # type: typing.Counter[TypeOfAny]
         self.any_line_map = {}  # type: Dict[int, List[AnyType]]
 
         self.output = []  # type: List[str]

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3,6 +3,7 @@
 import copy
 from abc import abstractmethod
 from collections import OrderedDict
+from enum import Enum
 from typing import (
     Any, TypeVar, Dict, List, Tuple, cast, Generic, Set, Optional, Union, Iterable, NamedTuple,
     Callable, Sequence
@@ -263,42 +264,32 @@ class TypeList(Type):
 _dummy = object()  # type: Any
 
 
-class TypeOfAny:
+class TypeOfAny(Enum):
     """
     This class describes different types of Any. Each 'Any' can be of only one type at a time.
-
-    TODO: this class should be made an Enum once we drop support for python 3.3.
     """
-    MYPY = False
-    if MYPY:
-        from typing import NewType
-        TypeOfAny = NewType('TypeOfAny', str)
-    else:
-        def TypeOfAny(x: str) -> str:
-            return x
-
     # Was this Any type was inferred without a type annotation?
-    unannotated = TypeOfAny('unannotated')
+    unannotated = 'unannotated'
     # Does this Any come from an explicit type annotation?
-    explicit = TypeOfAny('explicit')
+    explicit = 'explicit'
     # Does this come from an unfollowed import? See --disallow-any-unimported option
-    from_unimported_type = TypeOfAny('from_unimported_type')
+    from_unimported_type = 'from_unimported_type'
     # Does this Any type come from omitted generics?
-    from_omitted_generics = TypeOfAny('from_omitted_generics')
+    from_omitted_generics = 'from_omitted_generics'
     # Does this Any come from an error?
-    from_error = TypeOfAny('from_error')
+    from_error = 'from_error'
     # Is this a type that can't be represented in mypy's type system? For instance, type of
-    # call to NewType(...)). Even though these types aren't real Anys, we treat them as such.
-    special_form = TypeOfAny('special_form')
+    # call to NewType...). Even though these types aren't real Anys, we treat them as such.
+    special_form = 'special_form'
     # Does this Any come from interaction with another Any?
-    from_another_any = TypeOfAny('from_another_any')
+    from_another_any = 'from_another_any'
 
 
 class AnyType(Type):
     """The type 'Any'."""
 
     def __init__(self,
-                 type_of_any: TypeOfAny.TypeOfAny,
+                 type_of_any: TypeOfAny,
                  source_any: Optional['AnyType'] = None,
                  line: int = -1,
                  column: int = -1) -> None:
@@ -319,7 +310,7 @@ class AnyType(Type):
         return visitor.visit_any(self)
 
     def copy_modified(self,
-                      type_of_any: TypeOfAny.TypeOfAny = _dummy,
+                      type_of_any: TypeOfAny = _dummy,
                       original_any: Optional['AnyType'] = _dummy,
                       ) -> 'AnyType':
         if type_of_any is _dummy:


### PR DESCRIPTION
With mypy 0.550, Python 3.3 support was dropped. This commit removes
some hacks done to accommodate for 3.3, which are no longer needed.
- Move TypeOfAny to use an Enum
- Remove `__file__` and `__path__` hacks