### PR TITLE
[WIP] Begin implementing PEP 561 checking

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -792,6 +792,21 @@ def find_module(id: str, lib_path_arg: Iterable[str]) -> Optional[str]:
                 dir = os.path.normpath(os.path.join(pathitem, dir_chain))
                 if os.path.isdir(dir):
                     dirs.append(dir)
+            try:
+                user_dir = site.getusersitepackages()
+                package_dirs = site.getsitepackages() + [user_dir]
+            except AttributeError:
+                package_dirs = [get_python_lib()]
+
+            for pkg_dir in package_dirs:
+                # Third-party stub packages
+                stub_pkg = os.path.join(pkg_dir, components[0] + '_stubs')
+                if os.path.isfile(os.path.join(stub_pkg, 'py.typed')):
+                    components[0] = components[0] + '_stubs'
+                    dirs.append(os.path.join(pkg_dir, os.sep.join(components[:-1])))
+                elif os.path.isfile(os.path.join(pkg_dir, components[0], 'py.typed')):
+                    dirs.append(os.path.join(pkg_dir, dir_chain))
+
             find_module_dir_cache[dir_chain, lib_path] = dirs
         candidate_base_dirs = find_module_dir_cache[dir_chain, lib_path]
 


### PR DESCRIPTION
This is the initial work to add checking using packages that opt into type checking via
PEP 561.

TODO:

~~- [ ] Namespace package support (awaiting #4277)~~ I'm going ahead without this.
- [ ] Tests (installing packages etc is going to be interesting...)
- [x] Check PEP 561 conformance to [resolution order](https://www.python.org/dev/peps/pep-0561/#type-checker-module-resolution-order)
- [x] ignore errors in these files.
- [ ] support running with alternate Python version.
- [ ] document how to make a package compatible.

As of right now, you can install regular packages with types and third party stub packages and they should be picked up. `$MYPYPATH` supersedes both types of packages, and third-party stubs supersede bundled type packages per PEP 561. Errors in installed packages should be ignored.

Questions:
~~- Should this be behind a flag?~~
~~- Should errors that are ignored in typeshed be ignored for these packages too? I'm not too keen on this, but open to recommendations.~~