### PR TITLE
Fix symbol table representation of certain failing imports

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1486,6 +1486,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None]):
                 if extra:
                     message += " {}".format(extra)
                 self.fail(message, imp)
+                self.add_unknown_symbol(as_id or id, imp, is_import=True)
             else:
                 # Missing module.
                 self.add_unknown_symbol(as_id or id, imp, is_import=True)

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2817,10 +2817,8 @@ from b import x
 [out]
 [out2]
 tmp/b.py:1: error: Module 'c' has no attribute 'x'
-tmp/a.py:1: error: Module 'b' has no attribute 'x'
 [out3]
 tmp/b.py:1: error: Module 'c' has no attribute 'x'
-tmp/a.py:1: error: Module 'b' has no attribute 'x'
 
 [case testCacheDeletedAfterErrorsFound2]
 import a
@@ -2875,12 +2873,8 @@ from b import x
 [out]
 [out2]
 tmp/c.py:1: error: Module 'd' has no attribute 'x'
-tmp/b.py:1: error: Module 'c' has no attribute 'x'
-tmp/a.py:1: error: Module 'b' has no attribute 'x'
 [out3]
 tmp/c.py:1: error: Module 'd' has no attribute 'x'
-tmp/b.py:1: error: Module 'c' has no attribute 'x'
-tmp/a.py:1: error: Module 'b' has no attribute 'x'
 
 [case testNoCrashOnDoubleImportAliasQuick]
 # cmd: mypy -m e

--- a/test-data/unit/merge.test
+++ b/test-data/unit/merge.test
@@ -964,7 +964,7 @@ target:
 ==>
 __main__:
     TypeVar: Var<0>
-    f: UNBOUND_IMPORTED
+    f: Var<4>
     x: Var<2>
     y: Var<3>
 target:
@@ -987,7 +987,7 @@ target:
 __main__:
     T: TypeVarExpr<0>
     TypeVar: Var<1>
-    f: UNBOUND_IMPORTED
+    f: Var<3>
 target:
 
 [case testRefreshNamedTuple_symtable]
@@ -1008,7 +1008,7 @@ target:
 __main__:
     N: TypeInfo<0>
     NamedTuple: Var<1>
-    f: UNBOUND_IMPORTED
+    f: Var<3>
 target:
 
 [case testRefreshAttributeDefinedInClassBody_typeinfo]

--- a/test-data/unit/semanal-symtable.test
+++ b/test-data/unit/semanal-symtable.test
@@ -64,3 +64,21 @@ m:
   SymbolTable(
     x : Gdef/TypeInfo (m.x)
     y : Gdef/Var (m.y))
+
+[case testFailingImports]
+from sys import non_existing1  # type: ignore
+from xyz import non_existing2  # type: ignore
+if int():
+    from sys import non_existing3  # type: ignore
+import non_existing4  # type: ignore
+[out]
+__main__:
+  SymbolTable(
+    non_existing1 : Gdef/Var (__main__.non_existing1) : Any
+    non_existing2 : Gdef/Var (__main__.non_existing2) : Any
+    non_existing3 : Gdef/Var (__main__.non_existing3) : Any
+    non_existing4 : Gdef/Var (__main__.non_existing4) : Any)
+sys:
+  SymbolTable(
+    platform : Gdef/Var (sys.platform)
+    version_info : Gdef/Var (sys.version_info))


### PR DESCRIPTION
Some of them were left in the UNBOUND_IMPORTED state which is incorrect
and caused problems in fine-grained incremental mode.
