### PR TITLE
Two optimizations for load_graph()

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -180,6 +180,11 @@ class Options:
         return 'Options({})'.format(pprint.pformat(self.__dict__))
 
     def clone_for_module(self, module: str) -> 'Options':
+        """Create an Options object that incorporates per-module options.
+
+        NOTE: Once this method is called all Options objects should be
+        considered read-only, else the caching might be incorrect.
+        """
         res = self.clone_cache.get(module)
         if res is not None:
             return res

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -46,7 +46,7 @@ class Options:
 
     def __init__(self) -> None:
         # Cache for clone_for_module()
-        self.clone_cache = {}
+        self.clone_cache = {}  # type: Dict[str, Options]
 
         # -- build options --
         self.build_type = BuildType.STANDARD

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -45,6 +45,9 @@ class Options:
                                - {"debug_cache"})
 
     def __init__(self) -> None:
+        # Cache for clone_for_module()
+        self.clone_cache = {}
+
         # -- build options --
         self.build_type = BuildType.STANDARD
         self.python_version = defaults.PYTHON3_VERSION
@@ -177,6 +180,9 @@ class Options:
         return 'Options({})'.format(pprint.pformat(self.__dict__))
 
     def clone_for_module(self, module: str) -> 'Options':
+        res = self.clone_cache.get(module)
+        if res is not None:
+            return res
         updates = {}
         for pattern in self.per_module_options:
             if self.module_matches_pattern(module, pattern):
@@ -184,10 +190,12 @@ class Options:
                     del self.unused_configs[pattern]
                 updates.update(self.per_module_options[pattern])
         if not updates:
+            self.clone_cache[module] = self
             return self
         new_options = Options()
         new_options.__dict__.update(self.__dict__)
         new_options.__dict__.update(updates)
+        self.clone_cache[module] = new_options
         return new_options
 
     def module_matches_pattern(self, module: str, pattern: Pattern[str]) -> bool:


### PR DESCRIPTION
Profiling load_graph() found that there were some unnecessary stat() calls going on, and, more importantly, that Options.clone_for_module() is very inefficient if you have many sections in your mypy.ini file. I solved the latter by introducing a cache. An alternative design would move the cache into BuildManager -- that would avoid a reference cycle, but it turns out that having the cache in the root Options object means that it survives between dmypy check runs, and that's a nice win there. (This explains at least partly why load_graph() was slow even with everything loaded in memory.)

@JukkaL