### PR TITLE
Do not warn on returning any from deferred node

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2133,7 +2133,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if isinstance(typ, AnyType):
                     # (Unless you asked to be warned in that case, and the
                     # function is not declared to return Any)
-                    if (self.options.warn_return_any and
+                    if (self.options.warn_return_any and not self.current_node_deferred and
                             not is_proper_subtype(AnyType(TypeOfAny.special_form), return_type)):
                         self.msg.incorrectly_returning_any(return_type, s)
                     return

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -209,5 +209,3 @@ def foo(a1: A) -> int:
 class A:
     def __init__(self, x: int) -> None:
         self._x = x
-
-

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -197,3 +197,17 @@ class Test(object):
             return None
 [builtins fixtures/list.pyi]
 [out]
+
+[case testReturnAnyDeferred]
+# flags: --warn-return-any
+def foo(a1: A) -> int:
+    if a1._x:
+        return 1
+    n = 1
+    return n
+
+class A:
+    def __init__(self, x: int) -> None:
+        self._x = x
+
+


### PR DESCRIPTION
Fix #4296

The access to member defined in `__init__` causes the current node to be deferred, so mypy assumes expressions are `Any` but should not warn about it.

This is not the only conceivable fix - for example, I'm not sure why mypy should continue checking the function in the first place.