### PR TITLE
Clean up decorator implementation

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -475,7 +475,8 @@ class FuncDef(FuncItem, SymbolNode, Statement):
     is_conditional = False             # Defined conditionally (within block)?
     is_abstract = False
     is_property = False
-    original_def = None  # type: Union[None, FuncDef, Var]  # Original conditional definition
+    # Original conditional definition
+    original_def = None  # type: Union[None, FuncDef, Var, Decorator]
 
     FLAGS = FuncItem.FLAGS + [
         'is_decorated', 'is_conditional', 'is_abstract', 'is_property'
@@ -543,6 +544,7 @@ class Decorator(SymbolNode, Statement):
 
     func = None  # type: FuncDef                # Decorated function
     decorators = None  # type: List[Expression] # Decorators (may be empty)
+    # TODO: This is mostly used for the type; consider replacing with a 'type' attribute
     var = None  # type: Var                     # Represents the decorated function obj
     is_overload = False
 
@@ -562,6 +564,10 @@ class Decorator(SymbolNode, Statement):
     @property
     def info(self) -> 'TypeInfo':
         return self.func.info
+
+    @property
+    def type(self) -> Optional['mypy.types.Type']:
+        return self.var.type
 
     def accept(self, visitor: StatementVisitor[T]) -> T:
         return visitor.visit_decorator(self)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -566,7 +566,7 @@ class Decorator(SymbolNode, Statement):
         return self.func.info
 
     @property
-    def type(self) -> Optional['mypy.types.Type']:
+    def type(self) -> 'Optional[mypy.types.Type]':
         return self.var.type
 
     def accept(self, visitor: StatementVisitor[T]) -> T:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -449,7 +449,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None]):
         . def f(): ...
         . def f(): ...  # Error: 'f' redefined
         """
-        if isinstance(previous, (FuncDef, Var)) and new.is_conditional:
+        if isinstance(previous, (FuncDef, Var, Decorator)) and new.is_conditional:
             new.original_def = previous
             return True
         else:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1496,7 +1496,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None]):
                                           module_symbol: SymbolTableNode,
                                           import_node: ImportBase) -> bool:
         if (existing_symbol.kind in (LDEF, GDEF, MDEF) and
-                isinstance(existing_symbol.node, (Var, FuncDef, TypeInfo))):
+                isinstance(existing_symbol.node, (Var, FuncDef, TypeInfo, Decorator))):
             # This is a valid import over an existing definition in the file. Construct a dummy
             # assignment that we'll use to type check the import.
             lvalue = NameExpr(imported_id)

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -267,7 +267,7 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
 
     def visit_decorator(self, d: Decorator) -> None:
         d.var._fullname = self.sem.qualified_name(d.var.name())
-        self.sem.add_symbol(d.var.name(), SymbolTableNode(self.kind_by_scope(), d.var), d)
+        self.sem.add_symbol(d.var.name(), SymbolTableNode(self.kind_by_scope(), d), d)
 
     def visit_if_stmt(self, s: IfStmt) -> None:
         infer_reachability_of_if_statement(s, pyversion=self.pyversion, platform=self.platform)

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -19,11 +19,13 @@ from mypy import experiments
 from mypy.nodes import (
     MypyFile, SymbolTable, SymbolTableNode, Var, Block, AssignmentStmt, FuncDef, Decorator,
     ClassDef, TypeInfo, ImportFrom, Import, ImportAll, IfStmt, WhileStmt, ForStmt, WithStmt,
-    TryStmt, OverloadedFuncDef, Lvalue, LDEF, GDEF, MDEF, UNBOUND_IMPORTED, implicit_module_attrs
+    TryStmt, OverloadedFuncDef, Lvalue, Context, LDEF, GDEF, MDEF, UNBOUND_IMPORTED, MODULE_REF,
+    implicit_module_attrs
 )
 from mypy.types import Type, UnboundType, UnionType, AnyType, TypeOfAny, NoneTyp
 from mypy.semanal import SemanticAnalyzerPass2, infer_reachability_of_if_statement
 from mypy.options import Options
+from mypy.sametypes import is_same_type
 from mypy.visitor import NodeVisitor
 
 
@@ -133,6 +135,9 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
 
     def visit_func_def(self, func: FuncDef) -> None:
         sem = self.sem
+        if sem.type is not None:
+            # Don't process methods during pass 1.
+            return
         func.is_conditional = sem.block_depth[-1] > 0
         func._fullname = sem.qualified_name(func.name())
         at_module = sem.is_module_scope()
@@ -159,6 +164,9 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
             sem.function_stack.pop()
 
     def visit_overloaded_func_def(self, func: OverloadedFuncDef) -> None:
+        if self.sem.type is not None:
+            # Don't process methods during pass 1.
+            return
         kind = self.kind_by_scope()
         if kind == GDEF:
             self.sem.check_no_global(func.name(), func, True)
@@ -228,7 +236,7 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
         for name, as_name in node.names:
             imported_name = as_name or name
             if imported_name not in self.sem.globals:
-                self.sem.add_symbol(imported_name, SymbolTableNode(UNBOUND_IMPORTED, None), node)
+                self.add_symbol(imported_name, SymbolTableNode(UNBOUND_IMPORTED, None), node)
 
     def visit_import(self, node: Import) -> None:
         node.is_top_level = self.sem.is_module_scope()
@@ -240,7 +248,7 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
             # For 'import a.b.c' we create symbol 'a'.
             imported_id = imported_id.split('.')[0]
             if imported_id not in self.sem.globals:
-                self.sem.add_symbol(imported_id, SymbolTableNode(UNBOUND_IMPORTED, None), node)
+                self.add_symbol(imported_id, SymbolTableNode(UNBOUND_IMPORTED, None), node)
 
     def visit_import_all(self, node: ImportAll) -> None:
         node.is_top_level = self.sem.is_module_scope()
@@ -266,8 +274,11 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
             s.body.accept(self)
 
     def visit_decorator(self, d: Decorator) -> None:
+        if self.sem.type is not None:
+            # Don't process methods during pass 1.
+            return
         d.var._fullname = self.sem.qualified_name(d.var.name())
-        self.sem.add_symbol(d.var.name(), SymbolTableNode(self.kind_by_scope(), d), d)
+        self.add_symbol(d.var.name(), SymbolTableNode(self.kind_by_scope(), d), d)
 
     def visit_if_stmt(self, s: IfStmt) -> None:
         infer_reachability_of_if_statement(s, pyversion=self.pyversion, platform=self.platform)
@@ -293,3 +304,31 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
             return LDEF
         else:
             assert False, "Couldn't determine scope"
+
+    def add_symbol(self, name: str, node: SymbolTableNode,
+                   context: Context) -> None:
+        # This is related to SemanticAnalyzerPass2.add_symbol. Since both methods will
+        # be called on top-level definitions, they need to co-operate.
+        if self.sem.is_func_scope():
+            assert self.sem.locals[-1] is not None
+            if name in self.sem.locals[-1]:
+                # Flag redefinition unless this is a reimport of a module.
+                if not (node.kind == MODULE_REF and
+                        self.sem.locals[-1][name].node == node.node):
+                    self.sem.name_already_defined(name, context)
+            self.sem.locals[-1][name] = node
+        else:
+            assert self.sem.type is None  # Pass 1 doesn't look inside classes
+            existing = self.sem.globals.get(name)
+            if existing and (not isinstance(node.node, MypyFile) or
+                             existing.node != node.node) and existing.kind != UNBOUND_IMPORTED:
+                # Modules can be imported multiple times to support import
+                # of multiple submodules of a package (e.g. a.x and a.y).
+                ok = False
+                # Only report an error if the symbol collision provides a different type.
+                if existing.type and node.type and is_same_type(existing.type, node.type):
+                    ok = True
+                if not ok:
+                    self.sem.name_already_defined(name, context)
+            elif not existing:
+                self.sem.globals[name] = node

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -38,8 +38,8 @@ class TransformVisitor(NodeVisitor[Node]):
 
      * Do not duplicate TypeInfo nodes. This would generally not be desirable.
      * Only update some name binding cross-references, but only those that
-       refer to Var or FuncDef nodes, not those targeting ClassDef or TypeInfo
-       nodes.
+       refer to Var, Decorator or FuncDef nodes, not those targeting ClassDef or
+       TypeInfo nodes.
      * Types are not transformed, but you can override type() to also perform
        type transformation.
 
@@ -337,6 +337,8 @@ class TransformVisitor(NodeVisitor[Node]):
         target = original.node
         if isinstance(target, Var):
             target = self.visit_var(target)
+        elif isinstance(target, Decorator):
+            target = self.visit_var(target.var)
         elif isinstance(target, FuncDef):
             # Use a placeholder node for the function if it exists.
             target = self.func_placeholder_map.get(target, target)

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1411,6 +1411,20 @@ f()
 f(1)
 [builtins fixtures/list.pyi]
 
+[case testDefineConditionallyAsImportedAndDecorated]
+from typing import Callable
+
+def dec(f: Callable[[], None]) -> Callable[[], None]: ...
+
+if int():
+    from m import f
+else:
+    @dec
+    def f():
+        yield
+[file m.py]
+def f(): pass
+
 
 -- Conditional method definition
 -- -----------------------------

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1326,19 +1326,6 @@ else:
     @dec # E: Name 'f' already defined
     def f(): pass
 
-[case testConditionalMethodDefinitionUsingDecorator]
-from typing import Callable
-
-def dec(f) -> Callable[['A', int], None]: pass
-
-class A:
-    x = int()
-    if x:
-        @dec
-        def f(self): pass
-    else:
-        def f(self, x: int) -> None: pass
-
 [case testConditionalRedefinitionOfAnUnconditionalFunctionDefinition1]
 from typing import Any
 def f(x: str) -> None: pass
@@ -1425,6 +1412,23 @@ else:
 [file m.py]
 def f(): pass
 
+[case testDefineConditionallyAsImportedAndDecoratedWithInference]
+if int():
+    from m import f
+else:
+    from contextlib import contextmanager
+
+    @contextmanager
+    def f():
+        yield
+[file m.py]
+from contextlib import contextmanager
+
+@contextmanager
+def f():
+    yield
+[typing fixtures/typing-full.pyi]
+
 
 -- Conditional method definition
 -- -----------------------------
@@ -1509,8 +1513,23 @@ f('x') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 g('x')
 g(1) # E: Argument 1 to "g" has incompatible type "int"; expected "str"
 
+[case testConditionalMethodDefinitionUsingDecorator]
+from typing import Callable
+
+def dec(f) -> Callable[['A', int], None]: pass
+
+class A:
+    x = int()
+    if x:
+        @dec
+        def f(self): pass
+    else:
+        def f(self, x: int) -> None: pass
+
+
 -- Callable with specific arg list
 -- -------------------------------
+
 
 [case testCallableWithNamedArg]
 from typing import Callable

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1326,6 +1326,19 @@ else:
     @dec # E: Name 'f' already defined
     def f(): pass
 
+[case testConditionalMethodDefinitionUsingDecorator]
+from typing import Callable
+
+def dec(f) -> Callable[['A', int], None]: pass
+
+class A:
+    x = int()
+    if x:
+        @dec
+        def f(self): pass
+    else:
+        def f(self, x: int) -> None: pass
+
 [case testConditionalRedefinitionOfAnUnconditionalFunctionDefinition1]
 from typing import Any
 def f(x: str) -> None: pass

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -573,3 +573,18 @@ from typing import Sequence, Iterable, TypeVar
 S = TypeVar('S', Sequence, Iterable)
 def my_len(s: S) -> None: pass
 def crash() -> None: my_len((0,))
+
+[case testReferenceToDecoratedFunctionAndTypeVarValues]
+from typing import TypeVar, Callable
+
+T = TypeVar('T')
+S = TypeVar('S', int, str)
+
+def dec(f: Callable[..., T]) -> Callable[..., T]: ...
+
+@dec
+def g(s: S) -> Callable[[S], None]: ...
+
+def f(x: S) -> None:
+    h = g(x)
+    h(x)

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -390,7 +390,7 @@ class C:
 [builtins fixtures/ops.pyi]
 [out]
 
-[case testSysPlatformInFunctionImport]
+[case testSysPlatformInFunctionImport1]
 import sys
 def foo() -> None:
     if sys.platform != 'fictional':
@@ -398,6 +398,36 @@ def foo() -> None:
     else:
         import b as a
     a.x
+[file a.py]
+x = 1
+[builtins fixtures/ops.pyi]
+[out]
+
+[case testSysPlatformInFunctionImport2]
+import sys
+def foo() -> None:
+    if sys.platform == 'fictional':
+        import b as a
+    else:
+        import a
+    a.x
+[file a.py]
+x = 1
+[builtins fixtures/ops.pyi]
+[out]
+
+[case testSysPlatformInMethodImport2]
+import sys
+class A:
+    def foo(self) -> None:
+        if sys.platform == 'fictional':
+            # TODO: This is inconsistent with how top-level functions work
+            #     (https://github.com/python/mypy/issues/4324)
+            import b as a # E: Cannot find module named 'b' \
+            # N: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+        else:
+            import a
+        a.x
 [file a.py]
 x = 1
 [builtins fixtures/ops.pyi]

--- a/test-data/unit/semanal-symtable.test
+++ b/test-data/unit/semanal-symtable.test
@@ -82,3 +82,19 @@ sys:
   SymbolTable(
     platform : Gdef/Var (sys.platform)
     version_info : Gdef/Var (sys.version_info))
+
+[case testDecorator]
+from typing import Callable
+
+def dec(f: Callable[[], None]) -> Callable[[], None]:
+    return f
+
+@dec
+def g() -> None:
+    pass
+[out]
+__main__:
+  SymbolTable(
+    Callable : Gdef/Var (typing.Callable)
+    dec : Gdef/FuncDef (__main__.dec) : def (f: def ()) -> def ()
+    g : Gdef/Decorator (__main__.g) : def ())


### PR DESCRIPTION
Store decorated function as Decorator in symbol table, not as Var.
Previously module-level function were stored as Var nodes in symbol
tables.  That was inconsistent, as decorated methods were stored as
Decorators in symbol tables.

As a side effect, this also fixes some cases of conditional method
definition that were incorrectly rejected previously.

This helps with fine-grained incremental checking, as it gives us
access to a decorated function through the module symbol table.
