### PR TITLE
Issue a blocking error early if builtins can't be found

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -651,12 +651,16 @@ class BuildManager:
         self.errors.set_file_ignored_lines(path, tree.ignored_lines, ignore_errors)
         return tree
 
-    def module_not_found(self, path: str, id: str, line: int, target: str) -> None:
-        self.errors.set_file(path, id)
+    def module_not_found(self, path: str, source: str, line: int, target: str) -> None:
+        self.errors.set_file(path, source)
         stub_msg = "(Stub files are from https://github.com/python/typeshed)"
-        if ((self.options.python_version[0] == 2 and moduleinfo.is_py2_std_lib_module(target)) or
-                (self.options.python_version[0] >= 3 and
-                 moduleinfo.is_py3_std_lib_module(target))):
+        if target == 'builtins':
+            self.errors.report(line, 0, "Cannot find 'builtins' module. Typeshed appears broken!",
+                               blocker=True)
+            self.errors.raise_error()
+        elif ((self.options.python_version[0] == 2 and moduleinfo.is_py2_std_lib_module(target))
+              or (self.options.python_version[0] >= 3
+                  and moduleinfo.is_py3_std_lib_module(target))):
             self.errors.report(
                 line, 0, "No library stub file for standard library module '{}'".format(target))
             self.errors.report(line, 0, stub_msg, severity='note', only_once=True)


### PR DESCRIPTION
Fixes #4301. Perhaps also fixes other similar errors?