### PR TITLE
Give better error message for ommited parens in function type

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -157,6 +157,9 @@ class ASTConverter(ast3.NodeTransformer):
         self.is_stub = is_stub
         self.errors = errors
 
+    def note(self, msg: str, line: int, column: int) -> None:
+        self.errors.report(line, column, msg, severity='note')
+
     def fail(self, msg: str, line: int, column: int) -> None:
         self.errors.report(line, column, msg)
 
@@ -356,6 +359,8 @@ class ASTConverter(ast3.NodeTransformer):
                     arg_types.insert(0, AnyType(TypeOfAny.special_form))
             except SyntaxError:
                 self.fail(TYPE_COMMENT_SYNTAX_ERROR, n.lineno, n.col_offset)
+                if n.type_comment and n.type_comment[0] != "(":
+                    self.note('Suggestion: wrap input types in parens', n.lineno, n.col_offset)
                 arg_types = [AnyType(TypeOfAny.from_error)] * len(args)
                 return_type = AnyType(TypeOfAny.from_error)
         else:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -360,7 +360,8 @@ class ASTConverter(ast3.NodeTransformer):
             except SyntaxError:
                 self.fail(TYPE_COMMENT_SYNTAX_ERROR, n.lineno, n.col_offset)
                 if n.type_comment and n.type_comment[0] != "(":
-                    self.note('Suggestion: wrap input types in parens', n.lineno, n.col_offset)
+                    self.note('Suggestion: wrap argument types in parentheses',
+                              n.lineno, n.col_offset)
                 arg_types = [AnyType(TypeOfAny.from_error)] * len(args)
                 return_type = AnyType(TypeOfAny.from_error)
         else:

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -14,8 +14,14 @@ x = None # type: a + b  # E: invalid type comment or annotation
 -- This happens in both parsers.
 [case testFastParseFunctionAnnotationSyntaxError]
 
-def f():  # E: syntax error in type comment # N: Suggestion: wrap input types in parens
+def f():  # E: syntax error in type comment # N: Suggestion: wrap argument types in parentheses
   # type: None -> None
+  pass
+
+[case testFastParseFunctionAnnotationSyntaxErrorSpaces]
+
+def f():  # E: syntax error in type comment # N: Suggestion: wrap argument types in parentheses
+  # type:             None -> None
   pass
 
 [case testFastParseInvalidFunctionAnnotation]

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -14,7 +14,7 @@ x = None # type: a + b  # E: invalid type comment or annotation
 -- This happens in both parsers.
 [case testFastParseFunctionAnnotationSyntaxError]
 
-def f():  # E: syntax error in type comment
+def f():  # E: syntax error in type comment # N: Suggestion: wrap input types in parens
   # type: None -> None
   pass
 

--- a/test-data/unit/parse-errors.test
+++ b/test-data/unit/parse-errors.test
@@ -169,7 +169,7 @@ def f(): # type: x
   pass
 [out]
 file:1: error: syntax error in type comment
-file:1: note: Suggestion: wrap input types in parens
+file:1: note: Suggestion: wrap argument types in parentheses
 
 [case testInvalidSignatureInComment2]
 def f(): # type:

--- a/test-data/unit/parse-errors.test
+++ b/test-data/unit/parse-errors.test
@@ -169,6 +169,7 @@ def f(): # type: x
   pass
 [out]
 file:1: error: syntax error in type comment
+file:1: note: Suggestion: wrap input types in parens
 
 [case testInvalidSignatureInComment2]
 def f(): # type:


### PR DESCRIPTION
Partially fixes #4323 

The direct check for a paren feels janky, but I'm not sure if there is a nicer way.