### PR TITLE
Suggest spurious trailing commas as a cause for invalid tuple types

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -389,6 +389,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], AnalyzerPluginInterface):
         # generate errors elsewhere, and Tuple[t1, t2, ...] must be used instead.
         if t.implicit and not self.allow_tuple_literal:
             self.fail('Invalid tuple literal type', t)
+            if len(t.items) == 1:
+                self.note_func('Suggestion: Is there a spurious trailing comma?', t)
             return AnyType(TypeOfAny.from_error)
         star_count = sum(1 for item in t.items if isinstance(item, StarType))
         if star_count > 1:

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -423,3 +423,15 @@ def call() -> str: pass
 [case testNoCrashOnImportFromStarPython2]
 # flags: --py2
 from . import * # E: No parent module -- cannot perform relative import
+
+[case testSpuriousTrailingComma_python2]
+from typing import Optional
+
+def update_state(tid,                # type: int
+                 vid,                # type: int
+                 update_ts=None,     # type: Optional[float],
+                 ):         # type: (...) -> str
+    pass
+[out]
+main:3: error: Invalid tuple literal type
+main:3: note: Suggestion: Is there a spurious trailing comma?

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2212,7 +2212,7 @@ foo(y=2)  # E: Missing positional arguments
 def dec(f): pass
 
 @dec
-def test(a: str) -> (str,): # E: Invalid tuple literal type
+def test(a: str) -> (str,): # E: Invalid tuple literal type # N: Suggestion: Is there a spurious trailing comma?
     return None
 
 [case testReturnTypeLineNumberNewLine]


### PR DESCRIPTION
Fixes #4172 

This will generate the suggestion in some situations where it is probably not the right thing, unfortunately. (Like when the tuple type is wrapped in parens). That isn't *wrong*, since this is only a suggestion, but I don't have a good intuition for how likely those cases are.