### PR TITLE
Fix a few cases of invalid emphasis syntax in documentation

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -176,7 +176,7 @@ same directory on the search path, only the stub file is used.
 in the earlier directory is used.)
 
 NOTE: These rules are relevant to the following section too:
-the ``--follow-imports`` flag described below is applied _after_ the
+the ``--follow-imports`` flag described below is applied *after* the
 above algorithm has determined which package, stub or module to use.
 
 .. _follow-imports:

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -142,13 +142,13 @@ overridden by the pattern sections matching the module name.
   ``error``.  For explanations see the discussion for the
   :ref:`--follow-imports <follow-imports>` command line flag.  Note
   that if pattern matching is used, the pattern should match the name
-  of the _imported_ module, not the module containing the import
+  of the *imported* module, not the module containing the import
   statement.
 
 - ``ignore_missing_imports`` (Boolean, default False) suppress error
   messages about imports that cannot be resolved.  Note that if
   pattern matching is used, the pattern should match the name of the
-  _imported_ module, not the module containing the import statement.
+  *imported* module, not the module containing the import statement.
 
 - ``silent_imports`` (Boolean, deprecated) equivalent to
   ``follow_imports=skip`` plus ``ignore_missing_imports=True``.


### PR DESCRIPTION
`_foo_` isn't used for emphasis in rst.