### PR TITLE
Some daemon code cleanup

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2271,7 +2271,9 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
 
         scc_str = " ".join(scc)
         if fresh:
-            if not maybe_reuse_in_memory_tree(graph, scc, manager):
+            if maybe_reuse_in_memory_tree(graph, scc, manager):
+                manager.add_stats(sccs_kept=1, nodes_kept=len(scc))
+            else:
                 manager.trace("Queuing %s SCC (%s)" % (fresh_msg, scc_str))
                 fresh_scc_queue.append(scc)
         else:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1156,8 +1156,11 @@ def write_cache(id: str, path: str, tree: MypyFile,
       tree: the fully checked module data
       dependencies: module IDs on which this module depends
       suppressed: module IDs which were suppressed as dependencies
+      child_modules: module IDs which are this package's direct submodules
       dep_prios: priorities (parallel array to dependencies)
       old_interface_hash: the hash from the previous version of the data cache file
+      source_hash: the hash of the source code
+      ignore_all: the ignore_all flag for this module
       manager: the build manager (for pyversion, log/trace)
 
     Returns:

--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -28,9 +28,9 @@ subparsers = parser.add_subparsers()
 
 start_parser = p = subparsers.add_parser('start', help="Start daemon")
 p.add_argument('--log-file', metavar='FILE', type=str,
-                          help="Direct daemon stdout/stderr to FILE")
+               help="Direct daemon stdout/stderr to FILE")
 p.add_argument('flags', metavar='FLAG', nargs='*', type=str,
-                          help="Regular mypy flags (precede with --)")
+               help="Regular mypy flags (precede with --)")
 
 restart_parser = p = subparsers.add_parser('restart',
     help="Restart daemon (stop or kill followed by start)")
@@ -46,7 +46,8 @@ stop_parser = p = subparsers.add_parser('stop', help="Stop daemon (asks it polit
 
 kill_parser = p = subparsers.add_parser('kill', help="Kill daemon (kills the process)")
 
-check_parser = p = subparsers.add_parser('check', help="Check some files (requires running daemon)")
+check_parser = p = subparsers.add_parser('check',
+                                         help="Check some files (requires running daemon)")
 p.add_argument('-v', '--verbose', action='store_true', help="Print detailed status")
 p.add_argument('-q', '--quiet', action='store_true', help=argparse.SUPPRESS)  # Deprecated
 p.add_argument('files', metavar='FILE', nargs='+', help="File (or directory) to check")
@@ -252,7 +253,7 @@ def check_output(response: Dict[str, Any], verbose: bool) -> None:
     sys.stderr.write(err)
     if verbose:
         show_stats(response)
-    if status:
+    if status_code:
         sys.exit(status_code)
 
 

--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -300,10 +300,12 @@ def request(command: str, *, timeout: Optional[float] = None,
 
     Return the JSON dict with the response.
 
-    Raise BadStatus if there is something wrong with the status file.
+    Raise BadStatus if there is something wrong with the status file
+    or if the process whose pid is in the status file has died.
 
-    Return {'error': <message>} if there was something wrong with the
-    response (including OSError raised by a socket operation).
+    Return {'error': <message>} if a socket operation or receive()
+    raised OSError.  This covers cases such as connection refused or
+    closed prematurely as well as invalid JSON received.
     """
     args = dict(kwds)
     args.update(command=command)

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -16,11 +16,11 @@ import time
 
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 
-# TODO: Import all mypy modules lazily to speed up client startup time.
 import mypy.build
 import mypy.errors
 import mypy.main
 from mypy.dmypy_util import STATUS_FILE, receive
+from mypy.gclogger import GcLogger
 
 
 def daemonize(func: Callable[[], None], log_file: Optional[str] = None) -> int:
@@ -219,48 +219,6 @@ class Server:
 
 
 # Misc utilities.
-
-
-class GcLogger:
-    """Context manager to log GC stats and overall time."""
-
-    def __enter__(self) -> 'GcLogger':
-        self.gc_start_time = None  # type: Optional[float]
-        self.gc_time = 0.0
-        self.gc_calls = 0
-        self.gc_collected = 0
-        self.gc_uncollectable = 0
-        gc.callbacks.append(self.gc_callback)
-        self.start_time = time.time()
-        return self
-
-    def gc_callback(self, phase: str, info: Mapping[str, int]) -> None:
-        if phase == 'start':
-            assert self.gc_start_time is None, "Start phase out of sequence"
-            self.gc_start_time = time.time()
-        elif phase == 'stop':
-            assert self.gc_start_time is not None, "Stop phase out of sequence"
-            self.gc_calls += 1
-            self.gc_time += time.time() - self.gc_start_time
-            self.gc_start_time = None
-            self.gc_collected += info['collected']
-            self.gc_uncollectable += info['uncollectable']
-        else:
-            assert False, "Unrecognized gc phase (%r)" % (phase,)
-
-    def __exit__(self, *args: object) -> None:
-        while self.gc_callback in gc.callbacks:
-            gc.callbacks.remove(self.gc_callback)
-
-    def get_stats(self) -> Dict[str, float]:
-        end_time = time.time()
-        result = {}
-        result['gc_time'] = self.gc_time
-        result['gc_calls'] = self.gc_calls
-        result['gc_collected'] = self.gc_collected
-        result['gc_uncollectable'] = self.gc_uncollectable
-        result['build_time'] = end_time - self.start_time
-        return result
 
 
 MiB = 2**20

--- a/mypy/dmypy_util.py
+++ b/mypy/dmypy_util.py
@@ -12,7 +12,13 @@ STATUS_FILE = 'dmypy.json'
 
 
 def receive(sock: socket.socket) -> Any:
-    """Receive JSON data from a socket until EOF."""
+    """Receive JSON data from a socket until EOF.
+
+    Raise a subclass of OSError if there's a socket exception.
+
+    Raise OSError if the data received is not valid JSON or if it is
+    not a dict.
+    """
     bdata = bytearray()
     while True:
         more = sock.recv(100000)
@@ -21,7 +27,10 @@ def receive(sock: socket.socket) -> Any:
         bdata.extend(more)
     if not bdata:
         raise OSError("No data received")
-    data = json.loads(bdata.decode('utf8'))
+    try:
+        data = json.loads(bdata.decode('utf8'))
+    except Exception:
+        raise OSError("Data received is not valid JSON")
     if not isinstance(data, dict):
         raise OSError("Data received is not a dict (%s)" % str(type(data)))
     return data

--- a/mypy/gclogger.py
+++ b/mypy/gclogger.py
@@ -1,0 +1,46 @@
+import gc
+import time
+
+from typing import Mapping, Optional
+
+
+class GcLogger:
+    """Context manager to log GC stats and overall time."""
+
+    def __enter__(self) -> 'GcLogger':
+        self.gc_start_time = None  # type: Optional[float]
+        self.gc_time = 0.0
+        self.gc_calls = 0
+        self.gc_collected = 0
+        self.gc_uncollectable = 0
+        gc.callbacks.append(self.gc_callback)
+        self.start_time = time.time()
+        return self
+
+    def gc_callback(self, phase: str, info: Mapping[str, int]) -> None:
+        if phase == 'start':
+            assert self.gc_start_time is None, "Start phase out of sequence"
+            self.gc_start_time = time.time()
+        elif phase == 'stop':
+            assert self.gc_start_time is not None, "Stop phase out of sequence"
+            self.gc_calls += 1
+            self.gc_time += time.time() - self.gc_start_time
+            self.gc_start_time = None
+            self.gc_collected += info['collected']
+            self.gc_uncollectable += info['uncollectable']
+        else:
+            assert False, "Unrecognized gc phase (%r)" % (phase,)
+
+    def __exit__(self, *args: object) -> None:
+        while self.gc_callback in gc.callbacks:
+            gc.callbacks.remove(self.gc_callback)
+
+    def get_stats(self) -> Mapping[str, float]:
+        end_time = time.time()
+        result = {}
+        result['gc_time'] = self.gc_time
+        result['gc_calls'] = self.gc_calls
+        result['gc_collected'] = self.gc_collected
+        result['gc_uncollectable'] = self.gc_uncollectable
+        result['build_time'] = end_time - self.start_time
+        return result


### PR DESCRIPTION
- Move do_restart() and wait_for_server() right after do_start()
- Introduce BadStatus exception, use instead of SystemExit
- Add a timeout option to request(), use for stop/status
- Include all socket ops in the try/except clause
- Rationalize and document exceptions raised by receive().
- Move GcLogger to its own file; fixes #4194
- Make status quiet by default; add -v to print full status
- Replace -q flags with -v flags
- If 'error' in response, sys.exit with that message
- Streamline the way command subparsers are updated
- Misc other cleanup