### PR TITLE
ListExpr is not an lvalue anymore

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -960,8 +960,11 @@ class ASTConverter(ast3.NodeTransformer):
 
     # List(expr* elts, expr_context ctx)
     @with_line
-    def visit_List(self, n: ast3.List) -> ListExpr:
-        return ListExpr([self.visit(e) for e in n.elts])
+    def visit_List(self, n: ast3.List) -> Union[ListExpr, TupleExpr]:
+        expr_list = [self.visit(e) for e in n.elts]  # type: List[Expression]
+        if isinstance(n.ctx, ast3.Store):
+            return TupleExpr(expr_list)
+        return ListExpr(expr_list)
 
     # Tuple(expr* elts, expr_context ctx)
     @with_line
@@ -1155,6 +1158,7 @@ class TypeConverter(ast3.NodeTransformer):
 
     # List(expr* elts, expr_context ctx)
     def visit_List(self, n: ast3.List) -> Type:
+        assert isinstance(n.ctx, ast3.Load)
         return self.translate_argument_list(n.elts)
 
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -963,6 +963,7 @@ class ASTConverter(ast3.NodeTransformer):
     def visit_List(self, n: ast3.List) -> Union[ListExpr, TupleExpr]:
         expr_list = [self.visit(e) for e in n.elts]  # type: List[Expression]
         if isinstance(n.ctx, ast3.Store):
+            # [x, y] = z and (x, y) = z means exactly the same thing
             return TupleExpr(expr_list)
         return ListExpr(expr_list)
 

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -915,6 +915,7 @@ class ASTConverter(ast27.NodeTransformer):
     def visit_List(self, n: ast27.List) -> Union[ListExpr, TupleExpr]:
         expr_list = [self.visit(e) for e in n.elts]  # type: List[Expression]
         if isinstance(n.ctx, ast27.Store):
+            # [x, y] = z and (x, y) = z means exactly the same thing
             return TupleExpr(expr_list)
         return ListExpr(expr_list)
 

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -912,8 +912,11 @@ class ASTConverter(ast27.NodeTransformer):
 
     # List(expr* elts, expr_context ctx)
     @with_line
-    def visit_List(self, n: ast27.List) -> ListExpr:
-        return ListExpr([self.visit(e) for e in n.elts])
+    def visit_List(self, n: ast27.List) -> Union[ListExpr, TupleExpr]:
+        expr_list = [self.visit(e) for e in n.elts]  # type: List[Expression]
+        if isinstance(n.ctx, ast27.Store):
+            return TupleExpr(expr_list)
+        return ListExpr(expr_list)
 
     # Tuple(expr* elts, expr_context ctx)
     @with_line

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -156,7 +156,7 @@ class Expression(Node):
 
 # TODO:
 # Lvalue = Union['NameExpr', 'MemberExpr', 'IndexExpr', 'SuperExpr', 'StarExpr'
-#                'TupleExpr', 'ListExpr']; see #1783.
+#                'TupleExpr']; see #1783.
 Lvalue = Expression
 
 
@@ -1524,7 +1524,9 @@ class DictExpr(Expression):
 
 
 class TupleExpr(Expression):
-    """Tuple literal expression (..., ...)"""
+    """Tuple literal expression (..., ...)
+
+    Also lvalue sequences (..., ...) and [..., ...]"""
 
     items = None  # type: List[Expression]
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1684,7 +1684,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
         self.check_classvar(s)
         s.rvalue.accept(self)
         if s.type:
-            allow_tuple_literal = isinstance(s.lvalues[-1], (TupleExpr, ListExpr))
+            allow_tuple_literal = isinstance(s.lvalues[-1], TupleExpr)
             s.type = self.anal_type(s.type, allow_tuple_literal=allow_tuple_literal)
             if (self.type and self.type.is_protocol and isinstance(lval, NameExpr) and
                     isinstance(s.rvalue, TempNode) and s.rvalue.no_rhs):
@@ -1921,8 +1921,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
                 self.fail('Unexpected type declaration', lval)
             if not add_global:
                 lval.accept(self)
-        elif (isinstance(lval, TupleExpr) or
-              isinstance(lval, ListExpr)):
+        elif isinstance(lval, TupleExpr):
             items = lval.items
             if len(items) == 0 and isinstance(lval, TupleExpr):
                 self.fail("can't assign to ()", lval)
@@ -1935,7 +1934,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
         else:
             self.fail('Invalid assignment target', lval)
 
-    def analyze_tuple_or_list_lvalue(self, lval: Union[ListExpr, TupleExpr],
+    def analyze_tuple_or_list_lvalue(self, lval: TupleExpr,
                                      add_global: bool = False,
                                      explicit_type: bool = False) -> None:
         """Analyze an lvalue or assignment target that is a list or tuple."""
@@ -2717,7 +2716,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
     def fail_invalid_classvar(self, context: Context) -> None:
         self.fail('ClassVar can only be used for assignments in class body', context)
 
-    def process_module_assignment(self, lvals: List[Expression], rval: Expression,
+    def process_module_assignment(self, lvals: List[Lvalue], rval: Expression,
                                   ctx: AssignmentStmt) -> None:
         """Propagate module references across assignments.
 
@@ -2728,14 +2727,13 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
         y].
 
         """
-        if all(isinstance(v, (TupleExpr, ListExpr)) for v in lvals + [rval]):
+        if (isinstance(rval, (TupleExpr, ListExpr))
+                and all(isinstance(v, TupleExpr) for v in lvals)):
             # rval and all lvals are either list or tuple, so we are dealing
             # with unpacking assignment like `x, y = a, b`. Mypy didn't
-            # understand our all(isinstance(...)), so cast them as
-            # Union[TupleExpr, ListExpr] so mypy knows it is safe to access
-            # their .items attribute.
-            seq_lvals = cast(List[Union[TupleExpr, ListExpr]], lvals)
-            seq_rval = cast(Union[TupleExpr, ListExpr], rval)
+            # understand our all(isinstance(...)), so cast them as TupleExpr
+            # so mypy knows it is safe to access their .items attribute.
+            seq_lvals = cast(List[TupleExpr], lvals)
             # given an assignment like:
             #     (x, y) = (m, n) = (a, b)
             # we now have:
@@ -2753,7 +2751,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
             # If the rval and all lvals are not all of the same length, zip will just ignore
             # extra elements, so no error will be raised here; mypy will later complain
             # about the length mismatch in type-checking.
-            elementwise_assignments = zip(seq_rval.items, *[v.items for v in seq_lvals])
+            elementwise_assignments = zip(rval.items, *[v.items for v in seq_lvals])
             for rv, *lvs in elementwise_assignments:
                 self.process_module_assignment(lvs, rv, ctx)
         elif isinstance(rval, RefExpr):
@@ -3014,7 +3012,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
         if s.index_type:
             if self.is_classvar(s.index_type):
                 self.fail_invalid_classvar(s.index)
-            allow_tuple_literal = isinstance(s.index, (TupleExpr, ListExpr))
+            allow_tuple_literal = isinstance(s.index, TupleExpr)
             s.index_type = self.anal_type(s.index_type, allow_tuple_literal=allow_tuple_literal)
             self.store_declared_types(s.index, s.index_type)
 
@@ -3091,7 +3089,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
                     t = types.pop(0)
                     if self.is_classvar(t):
                         self.fail_invalid_classvar(n)
-                    allow_tuple_literal = isinstance(n, (TupleExpr, ListExpr))
+                    allow_tuple_literal = isinstance(n, TupleExpr)
                     t = self.anal_type(t, allow_tuple_literal=allow_tuple_literal)
                     new_types.append(t)
                     self.store_declared_types(n, t)

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -198,7 +198,7 @@ class DependencyVisitor(TraverserVisitor):
             for i in range(len(items) - 1):
                 lvalue = items[i]
                 rvalue = items[i + 1]
-                if isinstance(lvalue, (TupleExpr, ListExpr)):
+                if isinstance(lvalue, TupleExpr):
                     self.add_attribute_dependency_for_expr(rvalue, '__iter__')
             if o.type:
                 for trigger in get_type_triggers(o.type):
@@ -229,7 +229,7 @@ class DependencyVisitor(TraverserVisitor):
                 for attr_trigger in self.attribute_triggers(object_type, lvalue.name):
                     for type_trigger in type_triggers:
                         self.add_dependency(type_trigger, attr_trigger)
-        elif isinstance(lvalue, (ListExpr, TupleExpr)):
+        elif isinstance(lvalue, TupleExpr):
             for item in lvalue.items:
                 self.process_lvalue(item)
         # TODO: star lvalue
@@ -268,7 +268,7 @@ class DependencyVisitor(TraverserVisitor):
         self.add_attribute_dependency_for_expr(o.expr, '__iter__')
         self.add_attribute_dependency_for_expr(o.expr, '__getitem__')
         self.process_lvalue(o.index)
-        if isinstance(o.index, (TupleExpr, ListExpr)):
+        if isinstance(o.index, TupleExpr):
             # Process multiple assignment to index variables.
             item_type = o.inferred_item_type
             if item_type:

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -123,8 +123,6 @@ class StatisticsVisitor(TraverserVisitor):
             for lvalue in o.lvalues:
                 if isinstance(lvalue, nodes.TupleExpr):
                     items = lvalue.items
-                elif isinstance(lvalue, nodes.ListExpr):
-                    items = lvalue.items
                 else:
                     items = [lvalue]
                 for item in items:

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -225,13 +225,75 @@ from typing import Tuple
 t1 = None # type: Tuple[A, B]
 t2 = None # type: Tuple[A, B, A]
 a, b = None, None # type: (A, B)
+(a1, b1) = None, None # type: Tuple[A, B]
+
+reveal_type(a1)  # E: Revealed type is '__main__.A'
+reveal_type(b1)  # E: Revealed type is '__main__.B'
 
 a, a = t1 # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 b, b = t1 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 a, b, b = t2 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 a, b = t1
-a, b, a = t2
+a, b, a1 = t2
+
+class A: pass
+class B: pass
+[builtins fixtures/tuple.pyi]
+
+[case testMultipleAssignmentWithSquareBracketTuples]
+from typing import Tuple
+
+def avoid_confusing_test_parser() -> None:
+    t1 = None # type: Tuple[A, B]
+    t2 = None # type: Tuple[A, B, A]
+    [a, b] = None, None # type: (A, B)
+    [a1, b1] = None, None # type: Tuple[A, B]
+
+    reveal_type(a)  # E: Revealed type is '__main__.A'
+    reveal_type(b)  # E: Revealed type is '__main__.B'
+    reveal_type(a1)  # E: Revealed type is '__main__.A'
+    reveal_type(b1)  # E: Revealed type is '__main__.B'
+
+    [a, a] = t1 # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    [b, b] = t1 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+    [a, b, b] = t2 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+
+    [a, b] = t1
+    [a, b, a1] = t2
+
+    [a2, b2] = t1
+    reveal_type(a2)  # E: Revealed type is '__main__.A'
+    reveal_type(b2)  # E: Revealed type is '__main__.B'
+
+class A: pass
+class B: pass
+[builtins fixtures/tuple.pyi]
+
+[case testMultipleAssignmentWithSquareBracketTuplesPython2]
+# flags: --python-version 2.7
+from typing import Tuple
+
+def avoid_confusing_test_parser():
+    # type: () -> None
+    t1 = None # type: Tuple[A, B]
+    t2 = None # type: Tuple[A, B, A]
+    [a, b] = None, None # type: Tuple[A, B]
+    [a1, b1] = None, None # type: Tuple[A, B]
+
+    reveal_type(a1)  # E: Revealed type is '__main__.A'
+    reveal_type(b1)  # E: Revealed type is '__main__.B'
+
+    [a, a] = t1 # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    [b, b] = t1 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+    [a, b, b] = t2 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+
+    [a, b] = t1
+    [a, b, a1] = t2
+
+    [a2, b2] = t1
+    reveal_type(a2)  # E: Revealed type is '__main__.A'
+    reveal_type(b2)  # E: Revealed type is '__main__.B'
 
 class A: pass
 class B: pass

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -836,7 +836,7 @@ MypyFile:1(
       ExpressionStmt:4(
         IntExpr(1))))
   ForStmt:5(
-    ListExpr:5(
+    TupleExpr:5(
       NameExpr(x)
       TupleExpr:5(
         NameExpr(y)

--- a/test-data/unit/semanal-classvar.test
+++ b/test-data/unit/semanal-classvar.test
@@ -133,10 +133,10 @@ x = None  # type: Tuple[ClassVar, int]
 main:2: error: Invalid type: ClassVar nested inside other type
 
 [case testMultipleLvaluesWithList]
-from typing import ClassVar, List
+from typing import ClassVar, Tuple
 class A:
-    [x, y] = None, None  # type: List[ClassVar]
-[builtins fixtures/list.pyi]
+    [x, y] = None, None  # type: Tuple[ClassVar, ClassVar]
+[builtins fixtures/tuple.pyi]
 [out]
 main:3: error: Invalid type: ClassVar nested inside other type
 

--- a/test-data/unit/semanal-statements.test
+++ b/test-data/unit/semanal-statements.test
@@ -342,7 +342,7 @@ MypyFile:1(
       NameExpr(y [__main__.y]))
     IntExpr(1))
   AssignmentStmt:6(
-    ListExpr:6(
+    TupleExpr:6(
       NameExpr(x [__main__.x])
       NameExpr(y [__main__.y]))
     IntExpr(1))
@@ -407,7 +407,7 @@ MypyFile:1(
     NameExpr(x* [__main__.x])
     IntExpr(1))
   AssignmentStmt:2(
-    ListExpr:2(
+    TupleExpr:2(
       NameExpr(y* [__main__.y]))
     IntExpr(2)))
 
@@ -468,14 +468,14 @@ MypyFile:1(
   AssignmentStmt:2(
     TupleExpr:2(
       NameExpr(y* [__main__.y])
-      ListExpr:2(
+      TupleExpr:2(
         NameExpr(x [__main__.x])
         NameExpr(z* [__main__.z])))
     IntExpr(1))
   AssignmentStmt:3(
-    ListExpr:3(
+    TupleExpr:3(
       NameExpr(p* [__main__.p])
-      ListExpr:3(
+      TupleExpr:3(
         NameExpr(x [__main__.x])
         NameExpr(r* [__main__.r])))
     IntExpr(1)))


### PR DESCRIPTION
Fix #4340 by considering TupleExpr as the only lvalue sequence.

(And maybe one day it will be LvalueSeq)