### PR TITLE
Rework how we refine information from callable()

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2659,7 +2659,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # Build the fake ClassDef and TypeInfo together.
         # The ClassDef is full of lies and doesn't actually contain a body.
         # Use format_bare to generate a nice name for error messages.
-        # We skip filling fully filling out a handful of TypeInfo fields because they
+        # We skip fully filling out a handful of TypeInfo fields because they
         # should be irrelevant for a generated type like this:
         # is_protocol, protocol_members, is_abstract
         short_name = self.msg.format_bare(typ)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2924,7 +2924,9 @@ def intersect_instance_callable(type: Instance, callable_type: CallableType,
 
     # Build the fake ClassDef and TypeInfo together.
     # The ClassDef is full of lies and doesn't actually contain a body.
-    cdef = ClassDef(type.type.name(), Block([]))
+    # Use format_bare to generate a nice name for error messages.
+    short_name = typechecker.msg.format_bare(type)
+    cdef = ClassDef(short_name, Block([]))
     cdef.fullname = cur_module.fullname() + '.' + gen_name
     info = TypeInfo(SymbolTable(), cdef, cur_module.fullname())
     cdef.info = info

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -81,6 +81,32 @@ DeferredNode = NamedTuple(
     ])
 
 
+# Data structure returned by find_isinstance_check representing
+# information learned from the truth or falsehood of a condition.  The
+# dict maps nodes representing expressions like 'a[0].x' to their
+# refined types under the assumption that the condition has a
+# particular truth value. A value of None means that the condition can
+# never have that truth value.
+
+# NB: The keys of this dict are nodes in the original source program,
+# which are compared by reference equality--effectively, being *the
+# same* expression of the program, not just two identical expressions
+# (such as two references to the same variable). TODO: it would
+# probably be better to have the dict keyed by the nodes' literal_hash
+# field instead.
+
+TypeMap = Optional[Dict[Expression, Type]]
+
+# An object that represents either a precise type or a type with an upper bound;
+# it is important for correct type inference with isinstance.
+TypeRange = NamedTuple(
+    'TypeRange',
+    [
+        ('item', Type),
+        ('is_upper_bound', bool),  # False => precise type
+    ])
+
+
 class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     """Mypy type checker.
 
@@ -2615,6 +2641,306 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         self.binder.handle_continue()
         return None
 
+    def intersect_instance_callable(self, typ: Instance, callable_type: CallableType) -> Instance:
+        """Creates a fake type that represents the intersection of an
+        Instance and a CallableType.
+
+        It operates by creating a bare-minimum dummy TypeInfo that
+        subclasses type and adds a __call__ method matching callable_type.
+        """
+
+        # In order for this to work in incremental mode, the type we generate needs to
+        # have a valid fullname and a corresponding entry in a symbol table. We generate
+        # a unique name inside the symbol table of the current module.
+        cur_module = cast(MypyFile, self.scope.stack[0])
+        gen_name = gen_unique_name("<callable subtype of {}>".format(typ.type.name()),
+                                   cur_module.names)
+
+        # Build the fake ClassDef and TypeInfo together.
+        # The ClassDef is full of lies and doesn't actually contain a body.
+        # Use format_bare to generate a nice name for error messages.
+        # We skip filling fully filling out a handful of TypeInfo fields because they
+        # should be irrelevant for a generated type like this:
+        # is_protocol, protocol_members, is_abstract
+        short_name = self.msg.format_bare(typ)
+        cdef = ClassDef(short_name, Block([]))
+        cdef.fullname = cur_module.fullname() + '.' + gen_name
+        info = TypeInfo(SymbolTable(), cdef, cur_module.fullname())
+        cdef.info = info
+        info.bases = [typ]
+        info.calculate_mro()
+        info.calculate_metaclass_type()
+
+        # Build up a fake FuncDef so we can populate the symbol table.
+        func_def = FuncDef('__call__', [], Block([]), callable_type)
+        func_def.info = info
+        info.names['__call__'] = SymbolTableNode(MDEF, func_def, callable_type)
+
+        cur_module.names[gen_name] = SymbolTableNode(GDEF, info)
+
+        return Instance(info, [])
+
+    def make_fake_callable(self, typ: Instance) -> Instance:
+        """Produce a new type that makes type Callable with a generic callable type."""
+
+        fallback = self.named_type('builtins.function')
+        callable_type = CallableType([AnyType(TypeOfAny.explicit),
+                                      AnyType(TypeOfAny.explicit)],
+                                     [nodes.ARG_STAR, nodes.ARG_STAR2],
+                                     [None, None],
+                                     ret_type=AnyType(TypeOfAny.explicit),
+                                     fallback=fallback,
+                                     is_ellipsis_args=True)
+
+        return self.intersect_instance_callable(typ, callable_type)
+
+    def partition_by_callable(self, typ: Type,
+                              unsound_partition: bool) -> Tuple[List[Type], List[Type]]:
+        """Takes in a type and partitions that type into callable subtypes and
+        uncallable subtypes.
+
+        Thus, given:
+        `callables, uncallables = partition_by_callable(type)`
+
+        If we assert `callable(type)` then `type` has type Union[*callables], and
+        If we assert `not callable(type)` then `type` has type Union[*uncallables]
+
+        If unsound_partition is set, assume that anything that is not
+        clearly callable is in fact not callable. Otherwise we generate a
+        new subtype that *is* callable.
+
+        Guaranteed to not return [], []
+
+        """
+        if isinstance(typ, FunctionLike) or isinstance(typ, TypeType):
+            return [typ], []
+
+        if isinstance(typ, AnyType):
+            return [typ], [typ]
+
+        if isinstance(typ, UnionType):
+            callables = []
+            uncallables = []
+            for subtype in typ.relevant_items():
+                # Use unsound_partition when handling unions in order to
+                # allow the expected type discrimination.
+                subcallables, subuncallables = self.partition_by_callable(subtype,
+                                                                          unsound_partition=True)
+                callables.extend(subcallables)
+                uncallables.extend(subuncallables)
+            return callables, uncallables
+
+        if isinstance(typ, TypeVarType):
+            # We could do better probably?
+            # Refine the the type variable's bound as our type in the case that
+            # callable() is true. This unfortuantely loses the information that
+            # the type is a type variable in that branch.
+            # This matches what is done for isinstance, but it may be possible to
+            # do better.
+            # If it is possible for the false branch to execute, return the original
+            # type to avoid losing type information.
+            callables, uncallables = self.partition_by_callable(typ.erase_to_union_or_bound(),
+                                                                unsound_partition)
+            uncallables = [typ] if len(uncallables) else []
+            return callables, uncallables
+
+        # A TupleType is callable if its fallback is, but needs special handling
+        # when we dummy up a new type.
+        ityp = typ
+        if isinstance(typ, TupleType):
+            ityp = typ.fallback
+
+        if isinstance(ityp, Instance):
+            method = ityp.type.get_method('__call__')
+            if method and method.type:
+                callables, uncallables = self.partition_by_callable(method.type,
+                                                                    unsound_partition=False)
+                if len(callables) and not len(uncallables):
+                    # Only consider the type callable if its __call__ method is
+                    # definitely callable.
+                    return [typ], []
+
+            if not unsound_partition:
+                fake = self.make_fake_callable(ityp)
+                if isinstance(typ, TupleType):
+                    fake.type.tuple_type = TupleType(typ.items, fake)
+                    return [fake.type.tuple_type], [typ]
+                return [fake], [typ]
+
+        if unsound_partition:
+            return [], [typ]
+        else:
+            # We don't know how properly make the type callable.
+            return [typ], [typ]
+
+    def conditional_callable_type_map(self, expr: Expression,
+                                      current_type: Optional[Type],
+                                      ) -> Tuple[TypeMap, TypeMap]:
+        """Takes in an expression and the current type of the expression.
+
+        Returns a 2-tuple: The first element is a map from the expression to
+        the restricted type if it were callable. The second element is a
+        map from the expression to the type it would hold if it weren't
+        callable.
+        """
+        if not current_type:
+            return {}, {}
+
+        if isinstance(current_type, AnyType):
+            return {}, {}
+
+        callables, uncallables = self.partition_by_callable(current_type,
+                                                            unsound_partition=False)
+
+        if len(callables) and len(uncallables):
+            callable_map = {expr: UnionType.make_union(callables)} if len(callables) else None
+            uncallable_map = {
+                expr: UnionType.make_union(uncallables)} if len(uncallables) else None
+            return callable_map, uncallable_map
+
+        elif len(callables):
+            return {}, None
+
+        return None, {}
+
+    def find_isinstance_check(self, node: Expression
+                              ) -> Tuple[TypeMap, TypeMap]:
+        """Find any isinstance checks (within a chain of ands).  Includes
+        implicit and explicit checks for None and calls to callable.
+
+        Return value is a map of variables to their types if the condition
+        is true and a map of variables to their types if the condition is false.
+
+        If either of the values in the tuple is None, then that particular
+        branch can never occur.
+
+        Guaranteed to not return None, None. (But may return {}, {})
+        """
+        type_map = self.type_map
+        if is_true_literal(node):
+            return {}, None
+        elif is_false_literal(node):
+            return None, {}
+        elif isinstance(node, CallExpr):
+            if refers_to_fullname(node.callee, 'builtins.isinstance'):
+                if len(node.args) != 2:  # the error will be reported later
+                    return {}, {}
+                expr = node.args[0]
+                if literal(expr) == LITERAL_TYPE:
+                    vartype = type_map[expr]
+                    type = get_isinstance_type(node.args[1], type_map)
+                    return conditional_type_map(expr, vartype, type)
+            elif refers_to_fullname(node.callee, 'builtins.issubclass'):
+                expr = node.args[0]
+                if literal(expr) == LITERAL_TYPE:
+                    vartype = type_map[expr]
+                    type = get_isinstance_type(node.args[1], type_map)
+                    if isinstance(vartype, UnionType):
+                        union_list = []
+                        for t in vartype.items:
+                            if isinstance(t, TypeType):
+                                union_list.append(t.item)
+                            else:
+                                #  this is an error that should be reported earlier
+                                #  if we reach here, we refuse to do any type inference
+                                return {}, {}
+                        vartype = UnionType(union_list)
+                    elif isinstance(vartype, TypeType):
+                        vartype = vartype.item
+                    else:
+                        # any other object whose type we don't know precisely
+                        # for example, Any or Instance of type type
+                        return {}, {}  # unknown type
+                    yes_map, no_map = conditional_type_map(expr, vartype, type)
+                    yes_map, no_map = map(convert_to_typetype, (yes_map, no_map))
+                    return yes_map, no_map
+            elif refers_to_fullname(node.callee, 'builtins.callable'):
+                expr = node.args[0]
+                if literal(expr) == LITERAL_TYPE:
+                    vartype = type_map[expr]
+                    return self.conditional_callable_type_map(expr, vartype)
+        elif isinstance(node, ComparisonExpr) and experiments.STRICT_OPTIONAL:
+            # Check for `x is None` and `x is not None`.
+            is_not = node.operators == ['is not']
+            if any(is_literal_none(n) for n in node.operands) and (
+                    is_not or node.operators == ['is']):
+                if_vars = {}  # type: TypeMap
+                else_vars = {}  # type: TypeMap
+                for expr in node.operands:
+                    if (literal(expr) == LITERAL_TYPE and not is_literal_none(expr)
+                            and expr in type_map):
+                        # This should only be true at most once: there should be
+                        # two elements in node.operands, and at least one of them
+                        # should represent a None.
+                        vartype = type_map[expr]
+                        none_typ = [TypeRange(NoneTyp(), is_upper_bound=False)]
+                        if_vars, else_vars = conditional_type_map(expr, vartype, none_typ)
+                        break
+
+                if is_not:
+                    if_vars, else_vars = else_vars, if_vars
+                return if_vars, else_vars
+            # Check for `x == y` where x is of type Optional[T] and y is of type T
+            # or a type that overlaps with T (or vice versa).
+            elif node.operators == ['==']:
+                first_type = type_map[node.operands[0]]
+                second_type = type_map[node.operands[1]]
+                if is_optional(first_type) != is_optional(second_type):
+                    if is_optional(first_type):
+                        optional_type, comp_type = first_type, second_type
+                        optional_expr = node.operands[0]
+                    else:
+                        optional_type, comp_type = second_type, first_type
+                        optional_expr = node.operands[1]
+                    if is_overlapping_types(optional_type, comp_type):
+                        return {optional_expr: remove_optional(optional_type)}, {}
+            elif node.operators in [['in'], ['not in']]:
+                expr = node.operands[0]
+                left_type = type_map[expr]
+                right_type = builtin_item_type(type_map[node.operands[1]])
+                right_ok = right_type and (not is_optional(right_type) and
+                                           (not isinstance(right_type, Instance) or
+                                            right_type.type.fullname() != 'builtins.object'))
+                if (right_type and right_ok and is_optional(left_type) and
+                        literal(expr) == LITERAL_TYPE and not is_literal_none(expr) and
+                        is_overlapping_types(left_type, right_type)):
+                    if node.operators == ['in']:
+                        return {expr: remove_optional(left_type)}, {}
+                    if node.operators == ['not in']:
+                        return {}, {expr: remove_optional(left_type)}
+        elif isinstance(node, RefExpr):
+            # Restrict the type of the variable to True-ish/False-ish in the if and else branches
+            # respectively
+            vartype = type_map[node]
+            if_type = true_only(vartype)
+            else_type = false_only(vartype)
+            ref = node  # type: Expression
+            if_map = {ref: if_type} if not isinstance(if_type, UninhabitedType) else None
+            else_map = {ref: else_type} if not isinstance(else_type, UninhabitedType) else None
+            return if_map, else_map
+        elif isinstance(node, OpExpr) and node.op == 'and':
+            left_if_vars, left_else_vars = self.find_isinstance_check(node.left)
+            right_if_vars, right_else_vars = self.find_isinstance_check(node.right)
+
+            # (e1 and e2) is true if both e1 and e2 are true,
+            # and false if at least one of e1 and e2 is false.
+            return (and_conditional_maps(left_if_vars, right_if_vars),
+                    or_conditional_maps(left_else_vars, right_else_vars))
+        elif isinstance(node, OpExpr) and node.op == 'or':
+            left_if_vars, left_else_vars = self.find_isinstance_check(node.left)
+            right_if_vars, right_else_vars = self.find_isinstance_check(node.right)
+
+            # (e1 or e2) is true if at least one of e1 or e2 is true,
+            # and false if both e1 and e2 are false.
+            return (or_conditional_maps(left_if_vars, right_if_vars),
+                    and_conditional_maps(left_else_vars, right_else_vars))
+        elif isinstance(node, UnaryExpr) and node.op == 'not':
+            left, right = self.find_isinstance_check(node.expr)
+            return right, left
+
+        # Not a supported isinstance check
+        return {}, {}
+
     #
     # Helpers
     #
@@ -2822,41 +3148,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     def function_type(self, func: FuncBase) -> FunctionLike:
         return function_type(func, self.named_type('builtins.function'))
 
-    def find_isinstance_check(self, n: Expression) -> 'Tuple[TypeMap, TypeMap]':
-        return find_isinstance_check(n, self.type_map, self)
-
     def push_type_map(self, type_map: 'TypeMap') -> None:
         if type_map is None:
             self.binder.unreachable()
         else:
             for expr, type in type_map.items():
                 self.binder.put(expr, type)
-
-# Data structure returned by find_isinstance_check representing
-# information learned from the truth or falsehood of a condition.  The
-# dict maps nodes representing expressions like 'a[0].x' to their
-# refined types under the assumption that the condition has a
-# particular truth value. A value of None means that the condition can
-# never have that truth value.
-
-# NB: The keys of this dict are nodes in the original source program,
-# which are compared by reference equality--effectively, being *the
-# same* expression of the program, not just two identical expressions
-# (such as two references to the same variable). TODO: it would
-# probably be better to have the dict keyed by the nodes' literal_hash
-# field instead.
-
-
-TypeMap = Optional[Dict[Expression, Type]]
-
-# An object that represents either a precise type or a type with an upper bound;
-# it is important for correct type inference with isinstance.
-TypeRange = NamedTuple(
-    'TypeRange',
-    [
-        ('item', Type),
-        ('is_upper_bound', bool),  # False => precise type
-    ])
 
 
 def conditional_type_map(expr: Expression,
@@ -2905,173 +3202,6 @@ def gen_unique_name(base: str, table: SymbolTable) -> str:
     while base + str(i) in table:
         i += 1
     return base + str(i)
-
-
-def intersect_instance_callable(typ: Instance, callable_type: CallableType,
-                                typechecker: TypeChecker) -> Instance:
-    """Creates a fake type that represents the intersection of an
-    Instance and a CallableType.
-
-    It operates by creating a bare-minimum dummy TypeInfo that
-    subclasses type and adds a __call__ method matching callable_type.
-    """
-
-    # In order for this to work in incremental mode, the type we generate needs to
-    # have a valid fullname and a corresponding entry in a symbol table. We generate
-    # a unique name inside the symbol table of the current module.
-    cur_module = cast(MypyFile, typechecker.scope.stack[0])
-    gen_name = gen_unique_name("<callable subtype of {}>".format(typ.type.name()),
-                               cur_module.names)
-
-    # Build the fake ClassDef and TypeInfo together.
-    # The ClassDef is full of lies and doesn't actually contain a body.
-    # Use format_bare to generate a nice name for error messages.
-    # We skip filling fully filling out a handful of TypeInfo fields because they
-    # should be irrelevant for a generated type like this:
-    # is_protocol, protocol_members, is_abstract
-    short_name = typechecker.msg.format_bare(typ)
-    cdef = ClassDef(short_name, Block([]))
-    cdef.fullname = cur_module.fullname() + '.' + gen_name
-    info = TypeInfo(SymbolTable(), cdef, cur_module.fullname())
-    cdef.info = info
-    info.bases = [typ]
-    info.calculate_mro()
-    info.calculate_metaclass_type()
-
-    # Build up a fake FuncDef so we can populate the symbol table.
-    func_def = FuncDef('__call__', [], Block([]), callable_type)
-    func_def.info = info
-    info.names['__call__'] = SymbolTableNode(MDEF, func_def, callable_type)
-
-    cur_module.names[gen_name] = SymbolTableNode(GDEF, info)
-
-    return Instance(info, [])
-
-
-def make_fake_callable(typ: Instance, typechecker: TypeChecker) -> Instance:
-    """Produce a new type that makes type Callable with a generic callable type."""
-
-    fallback = typechecker.named_type('builtins.function')
-    callable_type = CallableType([AnyType(TypeOfAny.explicit),
-                                  AnyType(TypeOfAny.explicit)],
-                                 [nodes.ARG_STAR, nodes.ARG_STAR2],
-                                 [None, None],
-                                 ret_type=AnyType(TypeOfAny.explicit),
-                                 fallback=fallback,
-                                 is_ellipsis_args=True)
-
-    return intersect_instance_callable(typ, callable_type, typechecker)
-
-
-def partition_by_callable(typ: Type, typechecker: TypeChecker,
-                          unsound_partition: bool) -> Tuple[List[Type], List[Type]]:
-    """Takes in a type and partitions that type into callable subtypes and
-    uncallable subtypes.
-
-    Thus, given:
-    `callables, uncallables = partition_by_callable(type)`
-
-    If we assert `callable(type)` then `type` has type Union[*callables], and
-    If we assert `not callable(type)` then `type` has type Union[*uncallables]
-
-    If unsound_partition is set, assume that anything that is not
-    clearly callable is in fact not callable. Otherwise we generate a
-    new subtype that *is* callable.
-
-    Guaranteed to not return [], []
-
-    """
-    if isinstance(typ, FunctionLike) or isinstance(typ, TypeType):
-        return [typ], []
-
-    if isinstance(typ, AnyType):
-        return [typ], [typ]
-
-    if isinstance(typ, UnionType):
-        callables = []
-        uncallables = []
-        for subtype in typ.relevant_items():
-            # Use unsound_partition when handling unions in order to
-            # allow the expected type discrimination.
-            subcallables, subuncallables = partition_by_callable(subtype, typechecker,
-                                                                 unsound_partition=True)
-            callables.extend(subcallables)
-            uncallables.extend(subuncallables)
-        return callables, uncallables
-
-    if isinstance(typ, TypeVarType):
-        # We could do better probably?
-        # Refine the the type variable's bound as our type in the case that
-        # callable() is true. This unfortuantely loses the information that
-        # the type is a type variable in that branch.
-        # This matches what is done for isinstance, but it may be possible to
-        # do better.
-        # If it is possible for the false branch to execute, return the original
-        # type to avoid losing type information.
-        callables, uncallables = partition_by_callable(typ.erase_to_union_or_bound(), typechecker,
-                                                       unsound_partition)
-        uncallables = [typ] if len(uncallables) else []
-        return callables, uncallables
-
-    # A TupleType is callable if its fallback is, but needs special handling
-    # when we dummy up a new type.
-    ityp = typ
-    if isinstance(typ, TupleType):
-        ityp = typ.fallback
-
-    if isinstance(ityp, Instance):
-        method = ityp.type.get_method('__call__')
-        if method and method.type:
-            callables, uncallables = partition_by_callable(method.type, typechecker,
-                                                           unsound_partition=False)
-            if len(callables) and not len(uncallables):
-                # Only consider the type callable if its __call__ method is
-                # definitely callable.
-                return [typ], []
-
-        if not unsound_partition:
-            fake = make_fake_callable(ityp, typechecker)
-            if isinstance(typ, TupleType):
-                fake.type.tuple_type = TupleType(typ.items, fake)
-                return [fake.type.tuple_type], [typ]
-            return [fake], [typ]
-
-    if unsound_partition:
-        return [], [typ]
-    else:
-        # We don't know how properly make the type callable.
-        return [typ], [typ]
-
-
-def conditional_callable_type_map(expr: Expression,
-                                  current_type: Optional[Type],
-                                  typechecker: TypeChecker,
-                                  ) -> Tuple[TypeMap, TypeMap]:
-    """Takes in an expression and the current type of the expression.
-
-    Returns a 2-tuple: The first element is a map from the expression to
-    the restricted type if it were callable. The second element is a
-    map from the expression to the type it would hold if it weren't
-    callable.
-    """
-    if not current_type:
-        return {}, {}
-
-    if isinstance(current_type, AnyType):
-        return {}, {}
-
-    callables, uncallables = partition_by_callable(current_type, typechecker,
-                                                   unsound_partition=False)
-
-    if len(callables) and len(uncallables):
-        callable_map = {expr: UnionType.make_union(callables)} if len(callables) else None
-        uncallable_map = {expr: UnionType.make_union(uncallables)} if len(uncallables) else None
-        return callable_map, uncallable_map
-
-    elif len(callables):
-        return {}, None
-
-    return None, {}
 
 
 def is_true_literal(n: Expression) -> bool:
@@ -3186,145 +3316,6 @@ def convert_to_typetype(type_map: TypeMap) -> TypeMap:
             return {}
         converted_type_map[expr] = TypeType.make_normalized(typ)
     return converted_type_map
-
-
-def find_isinstance_check(node: Expression,
-                          type_map: Dict[Expression, Type],
-                          typechecker: TypeChecker,
-                          ) -> Tuple[TypeMap, TypeMap]:
-    """Find any isinstance checks (within a chain of ands).  Includes
-    implicit and explicit checks for None and calls to callable.
-
-    Return value is a map of variables to their types if the condition
-    is true and a map of variables to their types if the condition is false.
-
-    If either of the values in the tuple is None, then that particular
-    branch can never occur.
-
-    Guaranteed to not return None, None. (But may return {}, {})
-    """
-    if is_true_literal(node):
-        return {}, None
-    elif is_false_literal(node):
-        return None, {}
-    elif isinstance(node, CallExpr):
-        if refers_to_fullname(node.callee, 'builtins.isinstance'):
-            if len(node.args) != 2:  # the error will be reported later
-                return {}, {}
-            expr = node.args[0]
-            if literal(expr) == LITERAL_TYPE:
-                vartype = type_map[expr]
-                type = get_isinstance_type(node.args[1], type_map)
-                return conditional_type_map(expr, vartype, type)
-        elif refers_to_fullname(node.callee, 'builtins.issubclass'):
-            expr = node.args[0]
-            if literal(expr) == LITERAL_TYPE:
-                vartype = type_map[expr]
-                type = get_isinstance_type(node.args[1], type_map)
-                if isinstance(vartype, UnionType):
-                    union_list = []
-                    for t in vartype.items:
-                        if isinstance(t, TypeType):
-                            union_list.append(t.item)
-                        else:
-                            #  this is an error that should be reported earlier
-                            #  if we reach here, we refuse to do any type inference
-                            return {}, {}
-                    vartype = UnionType(union_list)
-                elif isinstance(vartype, TypeType):
-                    vartype = vartype.item
-                else:
-                    # any other object whose type we don't know precisely
-                    # for example, Any or Instance of type type
-                    return {}, {}  # unknown type
-                yes_map, no_map = conditional_type_map(expr, vartype, type)
-                yes_map, no_map = map(convert_to_typetype, (yes_map, no_map))
-                return yes_map, no_map
-        elif refers_to_fullname(node.callee, 'builtins.callable'):
-            expr = node.args[0]
-            if literal(expr) == LITERAL_TYPE:
-                vartype = type_map[expr]
-                return conditional_callable_type_map(expr, vartype, typechecker)
-    elif isinstance(node, ComparisonExpr) and experiments.STRICT_OPTIONAL:
-        # Check for `x is None` and `x is not None`.
-        is_not = node.operators == ['is not']
-        if any(is_literal_none(n) for n in node.operands) and (is_not or node.operators == ['is']):
-            if_vars = {}  # type: TypeMap
-            else_vars = {}  # type: TypeMap
-            for expr in node.operands:
-                if (literal(expr) == LITERAL_TYPE and not is_literal_none(expr)
-                        and expr in type_map):
-                    # This should only be true at most once: there should be
-                    # two elements in node.operands, and at least one of them
-                    # should represent a None.
-                    vartype = type_map[expr]
-                    none_typ = [TypeRange(NoneTyp(), is_upper_bound=False)]
-                    if_vars, else_vars = conditional_type_map(expr, vartype, none_typ)
-                    break
-
-            if is_not:
-                if_vars, else_vars = else_vars, if_vars
-            return if_vars, else_vars
-        # Check for `x == y` where x is of type Optional[T] and y is of type T
-        # or a type that overlaps with T (or vice versa).
-        elif node.operators == ['==']:
-            first_type = type_map[node.operands[0]]
-            second_type = type_map[node.operands[1]]
-            if is_optional(first_type) != is_optional(second_type):
-                if is_optional(first_type):
-                    optional_type, comp_type = first_type, second_type
-                    optional_expr = node.operands[0]
-                else:
-                    optional_type, comp_type = second_type, first_type
-                    optional_expr = node.operands[1]
-                if is_overlapping_types(optional_type, comp_type):
-                    return {optional_expr: remove_optional(optional_type)}, {}
-        elif node.operators in [['in'], ['not in']]:
-            expr = node.operands[0]
-            left_type = type_map[expr]
-            right_type = builtin_item_type(type_map[node.operands[1]])
-            right_ok = right_type and (not is_optional(right_type) and
-                                       (not isinstance(right_type, Instance) or
-                                        right_type.type.fullname() != 'builtins.object'))
-            if (right_type and right_ok and is_optional(left_type) and
-                    literal(expr) == LITERAL_TYPE and not is_literal_none(expr) and
-                    is_overlapping_types(left_type, right_type)):
-                if node.operators == ['in']:
-                    return {expr: remove_optional(left_type)}, {}
-                if node.operators == ['not in']:
-                    return {}, {expr: remove_optional(left_type)}
-    elif isinstance(node, RefExpr):
-        # Restrict the type of the variable to True-ish/False-ish in the if and else branches
-        # respectively
-        vartype = type_map[node]
-        if_type = true_only(vartype)
-        else_type = false_only(vartype)
-        ref = node  # type: Expression
-        if_map = {ref: if_type} if not isinstance(if_type, UninhabitedType) else None
-        else_map = {ref: else_type} if not isinstance(else_type, UninhabitedType) else None
-        return if_map, else_map
-    elif isinstance(node, OpExpr) and node.op == 'and':
-        left_if_vars, left_else_vars = find_isinstance_check(node.left, type_map, typechecker)
-        right_if_vars, right_else_vars = find_isinstance_check(node.right, type_map, typechecker)
-
-        # (e1 and e2) is true if both e1 and e2 are true,
-        # and false if at least one of e1 and e2 is false.
-        return (and_conditional_maps(left_if_vars, right_if_vars),
-                or_conditional_maps(left_else_vars, right_else_vars))
-    elif isinstance(node, OpExpr) and node.op == 'or':
-        left_if_vars, left_else_vars = find_isinstance_check(node.left, type_map, typechecker)
-        right_if_vars, right_else_vars = find_isinstance_check(node.right, type_map, typechecker)
-
-        # (e1 or e2) is true if at least one of e1 or e2 is true,
-        # and false if both e1 and e2 are false.
-        return (or_conditional_maps(left_if_vars, right_if_vars),
-                and_conditional_maps(left_else_vars, right_else_vars))
-    elif isinstance(node, UnaryExpr) and node.op == 'not':
-        left, right = find_isinstance_check(node.expr, type_map, typechecker)
-        return right, left
-
-    # Not a supported isinstance check
-    return {}, {}
 
 
 def flatten(t: Expression) -> List[Expression]:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2288,7 +2288,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 self.accept(condition)
 
                 # values are only part of the comprehension when all conditions are true
-                true_map, _ = mypy.checker.find_isinstance_check(condition, self.chk.type_map)
+                true_map, _ = mypy.checker.find_isinstance_check(condition, self.chk.type_map,
+                                                                 self.chk)
 
                 if true_map:
                     for var, type in true_map.items():

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2288,8 +2288,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 self.accept(condition)
 
                 # values are only part of the comprehension when all conditions are true
-                true_map, _ = mypy.checker.find_isinstance_check(condition, self.chk.type_map,
-                                                                 self.chk)
+                true_map, _ = self.chk.find_isinstance_check(condition)
 
                 if true_map:
                     for var, type in true_map.items():

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2095,6 +2095,8 @@ class TypeInfo(SymbolNode):
         assert mro, "Could not produce a MRO at all for %s" % (self,)
         self.mro = mro
         self.is_enum = self._calculate_is_enum()
+        # The property of falling back to Any is inherited.
+        self.fallback_to_any = any(baseinfo.fallback_to_any for baseinfo in self.mro)
 
     def calculate_metaclass_type(self) -> 'Optional[mypy.types.Instance]':
         declared = self.declared_metaclass

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3938,8 +3938,6 @@ def calculate_class_mro(defn: ClassDef, fail: Callable[[str, Context], None]) ->
         fail("Cannot determine consistent method resolution order "
              '(MRO) for "%s"' % defn.name, defn)
         defn.info.mro = []
-    # The property of falling back to Any is inherited.
-    defn.info.fallback_to_any = any(baseinfo.fallback_to_any for baseinfo in defn.info.mro)
 
 
 def find_duplicate(list: List[T]) -> Optional[T]:

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -214,7 +214,7 @@ if not callable(b):
     5 + 'test'
 
 if callable(c):
-    reveal_type(c)  # E: Revealed type is 'Union[__main__.<callable subtype of A>1, __main__.B]'
+    reveal_type(c)  # E: Revealed type is '__main__.B'
 else:
     reveal_type(c)  # E: Revealed type is '__main__.A'
 
@@ -227,7 +227,7 @@ T = Union[Union[int, Callable[[], int]], Union[str, Callable[[], str]]]
 
 def f(t: T) -> None:
     if callable(t):
-        reveal_type(t())  # E: Revealed type is 'Union[Any, builtins.int, builtins.str]'
+        reveal_type(t())  # E: Revealed type is 'Union[builtins.int, builtins.str]'
     else:
         reveal_type(t)  # E: Revealed type is 'Union[builtins.int, builtins.str]'
 
@@ -255,7 +255,7 @@ def f(t: T) -> None:
     if callable(t):
         reveal_type(t())  # E: Revealed type is 'Any'  \
             # E: Revealed type is 'builtins.int'  \
-            # E: Revealed type is 'Union[Any, builtins.str]'
+            # E: Revealed type is 'builtins.str'
     else:
         reveal_type(t)  # E: Revealed type is 'builtins.int*'  # E: Revealed type is 'builtins.str'
 

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -214,7 +214,7 @@ if not callable(b):
     5 + 'test'
 
 if callable(c):
-    reveal_type(c)  # E: Revealed type is 'Union[<callable subtype of A>, __main__.B]'
+    reveal_type(c)  # E: Revealed type is 'Union[__main__.<callable subtype of A>1, __main__.B]'
 else:
     reveal_type(c)  # E: Revealed type is '__main__.A'
 

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -373,3 +373,41 @@ def g(o: Foo) -> None:
         o.bar()
 
 [builtins fixtures/callable.pyi]
+[case testCallableObjectAny]
+
+from typing import Any
+
+class Foo(Any):
+    def bar(self) -> None:
+        pass
+
+def g(o: Foo) -> None:
+    o.bar()
+    o.baz()
+    if callable(o):
+        o('test')
+        o.lurr(1,2,3)
+
+[builtins fixtures/callable.pyi]
+
+[case testCallableObjectGeneric]
+
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+class Test(Generic[T]):
+    def __self__(self, x: T) -> None:
+        self.x = x
+
+def g(o: Test[T], x: T) -> T:
+    if callable(o):
+        o.foo()  # E: "Test[T]" has no attribute "foo"
+        o(1,2,3)
+        o.x = x
+        o.x = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "T")
+        1 + o.x  # E: Unsupported operand types for + ("int" and "T")
+        return o.x
+
+    return x
+
+[builtins fixtures/callable.pyi]

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -208,7 +208,7 @@ b = B()  # type: B
 c = A()  # type: Union[A, B]
 
 if callable(a):
-    5 + 'test' # E: Unsupported operand types for + ("int" and "str")
+    5 + 'test'  # E: Unsupported operand types for + ("int" and "str")
 
 if not callable(b):
     5 + 'test'
@@ -240,7 +240,7 @@ T = TypeVar('T')
 
 def f(t: T) -> T:
     if callable(t):
-        return 5 # E: Incompatible return value type (got "int", expected "T")
+        return 5  # E: Incompatible return value type (got "int", expected "T")
     else:
         return t
 
@@ -253,7 +253,9 @@ T = TypeVar('T', int, Callable[[], int], Union[str, Callable[[], str]])
 
 def f(t: T) -> None:
     if callable(t):
-        reveal_type(t())  # E: Revealed type is 'Any'  # E: Revealed type is 'builtins.int'  # E: Revealed type is 'Union[Any, builtins.str]'
+        reveal_type(t())  # E: Revealed type is 'Any'  \
+            # E: Revealed type is 'builtins.int'  \
+            # E: Revealed type is 'Union[Any, builtins.str]'
     else:
         reveal_type(t)  # E: Revealed type is 'builtins.int*'  # E: Revealed type is 'builtins.str'
 
@@ -348,9 +350,10 @@ else:
 
 def f(o: object) -> None:
     if callable(o):
-        o()
+        o(1,2,3)
         1 + 'boom'  # E: Unsupported operand types for + ("int" and "str")
-        o()
+        o('hi') + 12
+        reveal_type(o)  # E: Revealed type is '__main__.<callable subtype of object>'
 
 [builtins fixtures/callable.pyi]
 
@@ -363,8 +366,9 @@ class Foo(object):
 def g(o: Foo) -> None:
     o.bar()
     if callable(o):
+        o.foo()  # E: "Foo" has no attribute "foo"
         o.bar()
-        o()
+        o(1,2,3)
     else:
         o.bar()
 

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -373,6 +373,7 @@ def g(o: Foo) -> None:
         o.bar()
 
 [builtins fixtures/callable.pyi]
+
 [case testCallableObjectAny]
 
 from typing import Any
@@ -409,5 +410,33 @@ def g(o: Test[T], x: T) -> T:
         return o.x
 
     return x
+
+[builtins fixtures/callable.pyi]
+
+[case testCallablePromote]
+
+def take_float(f: float) -> None:
+    pass
+
+def g(o: int) -> None:
+    if callable(o):
+        take_float(o)
+        o(1,2,3)
+
+[builtins fixtures/callable.pyi]
+
+[case testCallableTuple]
+
+from typing import NamedTuple
+
+Thing = NamedTuple('Thing', [('s', str), ('n', int)])
+
+def g(o: Thing) -> None:
+    if callable(o):
+        o.s + o.n  # E: Unsupported operand types for + ("str" and "int")
+        i, s = o
+        i + s  # E: Unsupported operand types for + ("str" and "int")
+        # Tuples can't be called yet but this should work at least
+        o.__call__(1,2,3)
 
 [builtins fixtures/callable.pyi]

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -208,13 +208,13 @@ b = B()  # type: B
 c = A()  # type: Union[A, B]
 
 if callable(a):
-    5 + 'test'
+    5 + 'test' # E: Unsupported operand types for + ("int" and "str")
 
 if not callable(b):
     5 + 'test'
 
 if callable(c):
-    reveal_type(c)  # E: Revealed type is '__main__.B'
+    reveal_type(c)  # E: Revealed type is 'Union[<callable subtype of A>, __main__.B]'
 else:
     reveal_type(c)  # E: Revealed type is '__main__.A'
 
@@ -227,7 +227,7 @@ T = Union[Union[int, Callable[[], int]], Union[str, Callable[[], str]]]
 
 def f(t: T) -> None:
     if callable(t):
-        reveal_type(t())  # E: Revealed type is 'Union[builtins.int, builtins.str]'
+        reveal_type(t())  # E: Revealed type is 'Union[Any, builtins.int, builtins.str]'
     else:
         reveal_type(t)  # E: Revealed type is 'Union[builtins.int, builtins.str]'
 
@@ -240,7 +240,7 @@ T = TypeVar('T')
 
 def f(t: T) -> T:
     if callable(t):
-        return 5
+        return 5 # E: Incompatible return value type (got "int", expected "T")
     else:
         return t
 
@@ -253,7 +253,7 @@ T = TypeVar('T', int, Callable[[], int], Union[str, Callable[[], str]])
 
 def f(t: T) -> None:
     if callable(t):
-        reveal_type(t())  # E: Revealed type is 'builtins.int'  # E: Revealed type is 'builtins.str'
+        reveal_type(t())  # E: Revealed type is 'Any'  # E: Revealed type is 'builtins.int'  # E: Revealed type is 'Union[Any, builtins.str]'
     else:
         reveal_type(t)  # E: Revealed type is 'builtins.int*'  # E: Revealed type is 'builtins.str'
 
@@ -341,5 +341,31 @@ if callable(x):
     pass
 else:
     'test' + 5
+
+[builtins fixtures/callable.pyi]
+
+[case testCallableObject]
+
+def f(o: object) -> None:
+    if callable(o):
+        o()
+        1 + 'boom'  # E: Unsupported operand types for + ("int" and "str")
+        o()
+
+[builtins fixtures/callable.pyi]
+
+[case testCallableObject2]
+
+class Foo(object):
+    def bar(self) -> None:
+        pass
+
+def g(o: Foo) -> None:
+    o.bar()
+    if callable(o):
+        o.bar()
+        o()
+    else:
+        o.bar()
 
 [builtins fixtures/callable.pyi]

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -436,7 +436,6 @@ def g(o: Thing) -> None:
         o.s + o.n  # E: Unsupported operand types for + ("str" and "int")
         i, s = o
         i + s  # E: Unsupported operand types for + ("str" and "int")
-        # Tuples can't be called yet but this should work at least
-        o.__call__(1,2,3)
+        o(1,2,3)
 
 [builtins fixtures/callable.pyi]

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -1247,3 +1247,24 @@ def f() -> None: pass
 main:2: error: Too many arguments for "f"
 [out2]
 main:2: error: Too many arguments for "f"
+
+[case testSerializeDummyType]
+import a
+[file a.py]
+import b
+reveal_type(b.Test(None).foo)
+[file a.py.2]
+import b
+reveal_type(b.Test(b.Foo()).foo)
+[file b.py]
+class Foo(object): pass
+class Test:
+    def __init__(self, o: Foo) -> None:
+        self.foo = None
+        if callable(o):
+            self.foo = o
+[builtins fixtures/callable.pyi]
+[out1]
+tmp/a.py:2: error: Revealed type is 'b.<callable subtype of Foo>'
+[out2]
+tmp/a.py:2: error: Revealed type is 'b.<callable subtype of Foo>'


### PR DESCRIPTION
Don't ever assume that something is *not* callable; basically anything
could be, and getting it wrong leaves code to not be typechecked.

When operating on an Instance that is not clearly callable, construct
a callable version of it by generating a fake subclass with a ``__call__``
method to be used.

Fixes #3605 

This is being posted to solicit feedback, I expect it might need some large changes.
The hack perpetrated here is somewhat grevious, and I suspect I missed something, so I am interested to find out what :).
Also, to reduce the change size during development I threaded a `TypeChecker` through a bunch of functions; the right thing might be to move all of those functions to be `TypeChecker` methods.