### PR TITLE
[WIP] When a module has errors but the interface hash is the same, keep the cache

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1967,8 +1967,8 @@ class State:
             is_errors = self.transitive_error
         if is_errors:
             new_interface_hash = compute_interface_hash(self.tree, self.manager)
+            delete_cache(self.id, self.path, self.manager)
             if new_interface_hash != self.interface_hash:
-                delete_cache(self.id, self.path, self.manager)
                 self.meta = None
                 self.mark_interface_stale(on_errors=True)
                 self.interface_hash = new_interface_hash

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -201,7 +201,7 @@ def foo() -> int:
         return "foo"
     return inner2()
 
-[rechecked mod1, mod2]
+[rechecked mod2]
 [stale]
 [out2]
 tmp/mod2.py:4: error: Incompatible return value type (got "str", expected "int")


### PR DESCRIPTION
Closes #4212.

However, there are still many scenarios where a trivial error affects
the interface hash and hence causes a recheck of everything
downstream.

Also, this affects regular incremental mode too (making it faster, but
if there's a bug in my logic, it will also be hit by that bug.)