### PR TITLE
Fix crash in decorated functions containing forward references

### DIFF
--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -162,6 +162,7 @@ class SemanticAnalyzerPass3(TraverserVisitor):
                     name=dec.var.name())
             elif isinstance(dec.func.type, CallableType):
                 dec.var.type = dec.func.type
+                self.analyze(dec.var.type, dec.var)
             return
         decorator_preserves_type = True
         for expr in dec.decorators:
@@ -189,6 +190,7 @@ class SemanticAnalyzerPass3(TraverserVisitor):
                 orig_sig = function_type(dec.func, self.builtin_type('function'))
                 sig.name = orig_sig.items()[0].name
                 dec.var.type = sig
+        self.analyze(dec.var.type, dec.var)
 
     def visit_assignment_stmt(self, s: AssignmentStmt) -> None:
         """Traverse the assignment statement.

--- a/test-data/unit/pythoneval-asyncio.test
+++ b/test-data/unit/pythoneval-asyncio.test
@@ -484,3 +484,21 @@ loop.run_until_complete(h())
 loop.close()
 [out]
 _program.py:16: error: Incompatible types in assignment (expression has type "A", variable has type "B")
+
+[case testForwardRefToBadAsyncShouldNotCrash]
+from typing import TypeVar
+import asyncio
+
+T = TypeVar('T')
+P = whatever  # type: ignore
+
+def test() -> None:
+    reveal_type(bad)
+    bad(0)
+
+@asyncio.coroutine
+def bad(arg: P) -> T:
+    pass
+[out]
+_program.py:8: error: Revealed type is 'def [T] (arg: P?) -> T`-1'
+_program.py:12: error: Invalid type "_testForwardRefToBadAsyncShouldNotCrash.P"


### PR DESCRIPTION
Fixes original crash in #4370 