### PR TITLE
Flush error messages incrementally after processing a file

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -74,9 +74,6 @@ The following global flags may only be set in the global section
 - ``warn_redundant_casts`` (Boolean, default False) warns about
   casting an expression to its inferred type.
 
-- ``warn_unused_ignores`` (Boolean, default False) warns about
-  unneeded ``# type: ignore`` comments.
-
 - ``warn_unused_configs`` (Boolean, default False) warns about
   per-module sections in the config file that didn't match any
   files processed in the current run.
@@ -202,6 +199,9 @@ overridden by the pattern sections matching the module name.
 - ``warn_return_any`` (Boolean, default False) shows a warning when
   returning a value with type ``Any`` from a function declared with a
   non- ``Any`` return type.
+
+- ``warn_unused_ignores`` (Boolean, default False) warns about
+  unneeded ``# type: ignore`` comments.
 
 - ``strict_boolean`` (Boolean, default False) makes using non-boolean
   expressions in conditions an error.

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -135,7 +135,6 @@ def build(sources: List[BuildSource],
           bin_dir: Optional[str] = None,
           saved_cache: Optional[SavedCache] = None,
           flush_errors: Optional[Callable[[List[str], bool], None]] = None,
-          plugin: Optional[Plugin] = None,
           ) -> BuildResult:
     """Analyze a program.
 
@@ -154,10 +153,9 @@ def build(sources: List[BuildSource],
         directories; if omitted, use '.' as the data directory
       saved_cache: optional dict with saved cache state for dmypy (read-write!)
       flush_errors: optional function to flush errors after a file is processed
-      plugin: optional plugin that overrides the configured one
     """
     try:
-        return _build(sources, options, alt_lib_path, bin_dir, saved_cache, flush_errors, plugin)
+        return _build(sources, options, alt_lib_path, bin_dir, saved_cache, flush_errors)
     except CompileError as e:
         serious = not e.use_stdout
         if flush_errors:
@@ -171,7 +169,6 @@ def _build(sources: List[BuildSource],
            bin_dir: Optional[str] = None,
            saved_cache: Optional[SavedCache] = None,
            flush_errors: Optional[Callable[[List[str], bool], None]] = None,
-           plugin: Optional[Plugin] = None,
            ) -> BuildResult:
     # This seems the most reasonable place to tune garbage collection.
     gc.set_threshold(50000)
@@ -221,7 +218,7 @@ def _build(sources: List[BuildSource],
     reports = Reports(data_dir, options.report_dirs)
     source_set = BuildSourceSet(sources)
     errors = Errors(options.show_error_context, options.show_column_numbers)
-    plugin = plugin or load_plugins(options, errors)
+    plugin = load_plugins(options, errors)
 
     # Construct a build manager object to hold state during the build.
     #

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -253,7 +253,6 @@ def _build(sources: List[BuildSource],
 
     try:
         graph = dispatch(sources, manager)
-        manager.error_flush(manager.errors.new_messages())
         return BuildResult(manager, graph)
     finally:
         manager.log("Build finished in %.3f seconds with %d modules, and %d errors" %

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -161,7 +161,7 @@ def build(sources: List[BuildSource],
     except CompileError as e:
         serious = not e.use_stdout
         if flush_errors:
-            flush_errors(e.messages[e.num_already_seen:], serious)
+            flush_errors(e.fresh_messages, serious)
         raise
 
 

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -295,6 +295,7 @@ class Errors:
         self.add_error_info(info)
 
     def _add_error_info(self, file: str, info: ErrorInfo) -> None:
+        assert file not in self.flushed_files
         if file not in self.error_info_map:
             self.error_info_map[file] = []
         self.error_info_map[file].append(info)
@@ -358,7 +359,7 @@ class Errors:
         Render the messages suitable for displaying.
         """
         # self.new_messages() will format all messages that haven't already
-        # been returned from a new_module_messages() call.
+        # been returned from a file_messages() call.
         raise CompileError(self.new_messages(),
                            use_stdout=True,
                            module_with_blocker=self.blocker_module())
@@ -596,7 +597,6 @@ def report_internal_error(err: Exception, file: Optional[str], line: int,
     # Dump out errors so far, they often provide a clue.
     # But catch unexpected errors rendering them.
     try:
-        errors.flushed_files = set()  # Print out already flushed messages too
         for msg in errors.new_messages():
             print(msg)
     except Exception as e:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -104,9 +104,6 @@ class Errors:
     # Current error context: nested import context/stack, as a list of (path, line) pairs.
     import_ctx = None  # type: List[Tuple[str, int]]
 
-    # Set of files with errors.
-    error_files = None  # type: Set[str]
-
     # Path name prefix that is removed from all paths, if set.
     ignore_prefix = None  # type: str
 
@@ -153,7 +150,6 @@ class Errors:
         self.fresh_error_info_map = OrderedDict()
         self.import_ctx = []
         self.formatted_messages = []
-        self.error_files = set()
         self.type_name = [None]
         self.function_or_member = [None]
         self.ignored_lines = OrderedDict()
@@ -320,7 +316,6 @@ class Errors:
                 return
             self.only_once_messages.add(info.message)
         self._add_error_info(info)
-        self.error_files.add(file)
 
     def generate_unused_ignore_notes(self, file: str) -> None:
         ignored_lines = self.ignored_lines[file]
@@ -358,7 +353,7 @@ class Errors:
 
     def is_errors_for_file(self, file: str) -> bool:
         """Are there any errors for the given file?"""
-        return file in self.error_files
+        return file in self.error_info_map
 
     def raise_error(self) -> None:
         """Raise a CompileError with the generated messages.

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -428,7 +428,7 @@ class Errors:
 
         Use a form suitable for displaying to the user.
         """
-        self.new_messages()
+        self.new_messages()  # Updates formatted_messages as a side effect
         return self.formatted_messages
 
     def targets(self) -> Set[str]:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -407,16 +407,6 @@ class Errors:
                 msgs.extend(self.file_messages(path))
         return msgs
 
-    def messages(self) -> List[str]:
-        """Return a string list that represents the error messages.
-
-        Use a form suitable for displaying to the user.
-        """
-        msgs = []
-        for path in self.error_info_map.keys():
-            msgs.extend(self.file_messages(path))
-        return msgs
-
     def targets(self) -> Set[str]:
         """Return a set of all targets that contain errors."""
         # TODO: Make sure that either target is always defined or that not being defined
@@ -603,7 +593,8 @@ def report_internal_error(err: Exception, file: Optional[str], line: int,
     # Dump out errors so far, they often provide a clue.
     # But catch unexpected errors rendering them.
     try:
-        for msg in errors.messages():
+        errors.flushed_files = set()  # Print out already flushed messages too
+        for msg in errors.new_messages():
             print(msg)
     except Exception as e:
         print("Failed to dump errors:", repr(e), file=sys.stderr)

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -417,8 +417,8 @@ class Errors:
         they first generated an error.
         """
         msgs = []
-        for key in self.error_info_map.keys():
-            msgs.extend(self.new_file_messages(key))
+        for path in self.error_info_map.keys():
+            msgs.extend(self.new_file_messages(path))
         return msgs
 
     def messages(self) -> List[str]:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -62,21 +62,22 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
         args = sys.argv[1:]
     sources, options = process_options(args)
 
+    messages = []
+
     def flush_errors(a: List[str], serious: bool) -> None:
+        messages.extend(a)
         f = sys.stderr if serious else sys.stdout
         try:
             for m in a:
                 f.write(m + '\n')
             f.flush()
         except BrokenPipeError:
-            pass
+            sys.exit(1)
 
     serious = False
     try:
-        res = type_check_only(sources, bin_dir, options, flush_errors)
-        a = res.errors
+        type_check_only(sources, bin_dir, options, flush_errors)
     except CompileError as e:
-        a = e.messages
         if not e.use_stdout:
             serious = True
     if options.warn_unused_configs and options.unused_configs:
@@ -86,8 +87,8 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
               file=sys.stderr)
     if options.junit_xml:
         t1 = time.time()
-        util.write_junit_xml(t1 - t0, serious, a, options.junit_xml)
-    if a:
+        util.write_junit_xml(t1 - t0, serious, messages, options.junit_xml)
+    if messages:
         sys.exit(1)
 
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -67,6 +67,7 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
         try:
             for m in a:
                 f.write(m + '\n')
+            f.flush()
         except BrokenPipeError:
             pass
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -64,12 +64,12 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
 
     messages = []
 
-    def flush_errors(a: List[str], serious: bool) -> None:
-        messages.extend(a)
+    def flush_errors(new_messages: List[str], serious: bool) -> None:
+        messages.extend(new_messages)
         f = sys.stderr if serious else sys.stdout
         try:
-            for m in a:
-                f.write(m + '\n')
+            for msg in new_messages:
+                f.write(msg + '\n')
             f.flush()
         except BrokenPipeError:
             sys.exit(1)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -153,8 +153,9 @@ class MessageBuilder:
     def add_errors(self, messages: 'MessageBuilder') -> None:
         """Add errors in messages to this builder."""
         if self.disable_count <= 0:
-            for info in messages.errors.error_info:
-                self.errors.add_error_info(info)
+            for errs in messages.errors.error_info_map.values():
+                for info in errs:
+                    self.errors.add_error_info(info)
 
     def disable_errors(self) -> None:
         self.disable_count += 1

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -34,6 +34,7 @@ class Options:
         "show_none_errors",
         "warn_no_return",
         "warn_return_any",
+        "warn_unused_ignores",
         "ignore_errors",
         "strict_boolean",
         "no_implicit_optional",

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -195,9 +195,9 @@ class FineGrainedBuildManager:
         result = update_single_isolated(module, path, manager, previous_modules)
         if isinstance(result, BlockedUpdate):
             # Blocking error -- just give up
-            module, path, remaining = result
+            module, path, remaining, errors = result
             self.previous_modules = get_module_to_path_map(manager)
-            return manager.errors.messages(), remaining, (module, path), True
+            return errors, remaining, (module, path), True
         assert isinstance(result, NormalUpdate)  # Work around #4124
         module, path, remaining, tree, graph = result
 
@@ -230,7 +230,7 @@ class FineGrainedBuildManager:
         self.previous_modules = get_module_to_path_map(manager)
         self.type_maps = extract_type_maps(graph)
 
-        return manager.errors.messages(), remaining, (module, path), False
+        return manager.errors.new_messages(), remaining, (module, path), False
 
 
 def mark_all_meta_as_memory_only(graph: Dict[str, State],
@@ -271,7 +271,8 @@ NormalUpdate = NamedTuple('NormalUpdate', [('module', str),
 # are similar to NormalUpdate (but there are fewer).
 BlockedUpdate = NamedTuple('BlockedUpdate', [('module', str),
                                              ('path', str),
-                                             ('remaining', List[Tuple[str, str]])])
+                                             ('remaining', List[Tuple[str, str]]),
+                                             ('messages', List[str])])
 
 UpdateResult = Union[NormalUpdate, BlockedUpdate]
 
@@ -318,7 +319,7 @@ def update_single_isolated(module: str,
             remaining_modules = [(module, path)]
         else:
             remaining_modules = []
-        return BlockedUpdate(err.module_with_blocker, path, remaining_modules)
+        return BlockedUpdate(err.module_with_blocker, path, remaining_modules, err.messages)
 
     if not os.path.isfile(path):
         graph = delete_module(module, graph, manager)
@@ -353,7 +354,7 @@ def update_single_isolated(module: str,
         manager.modules.clear()
         manager.modules.update(old_modules)
         del graph[module]
-        return BlockedUpdate(module, path, remaining_modules)
+        return BlockedUpdate(module, path, remaining_modules, err.messages)
     state.semantic_analysis_pass_three()
     state.semantic_analysis_apply_patches()
 

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -169,22 +169,16 @@ class TypeCheckSuite(DataSuite):
             # Always set to none so we're forced to reread the module in incremental mode
             sources.append(BuildSource(program_path, module_name,
                                        None if incremental_step else program_text))
-        streamed_messages = []
-
-        def flush_errors(msgs: List[str], serious: bool) -> None:
-            streamed_messages.extend(msgs)
 
         res = None
         try:
             res = build.build(sources=sources,
                               options=options,
-                              alt_lib_path=test_temp_dir,
-                              flush_errors=flush_errors)
+                              alt_lib_path=test_temp_dir)
             a = res.errors
         except CompileError as e:
             a = e.messages
         a = normalize_error_messages(a)
-        streamed_messages = normalize_error_messages(streamed_messages)
 
         # Make sure error messages match
         if incremental_step == 0:
@@ -204,9 +198,6 @@ class TypeCheckSuite(DataSuite):
         if output != a and self.update_data:
             update_testcase_output(testcase, a)
         assert_string_arrays_equal(output, a, msg.format(testcase.file, testcase.line))
-        assert_string_arrays_equal(a, streamed_messages,
-                                   "Streamed/reported error mismatch: " +
-                                   msg.format(testcase.file, testcase.line))
 
         if incremental_step and res:
             if options.follow_imports == 'normal' and testcase.output is None:

--- a/mypy/test/testerrorstream.py
+++ b/mypy/test/testerrorstream.py
@@ -44,7 +44,7 @@ def test_error_stream(testcase: DataDrivenTestCase) -> None:
                     alt_lib_path=test_temp_dir,
                     flush_errors=flush_errors)
     except CompileError as e:
-        pass
+        assert e.messages == []
 
     assert_string_arrays_equal(testcase.output, logged_messages,
                                'Invalid output ({}, line {})'.format(

--- a/mypy/test/testerrorstream.py
+++ b/mypy/test/testerrorstream.py
@@ -31,27 +31,21 @@ def test_error_stream(testcase: DataDrivenTestCase) -> None:
     options.show_traceback = True
 
     logged_messages = []  # type: List[str]
-    real_messages = []  # type: List[str]
 
     def flush_errors(msgs: List[str], serious: bool) -> None:
         if msgs:
             logged_messages.append('==== Errors flushed ====')
             logged_messages.extend(msgs)
-        real_messages.extend(msgs)
 
     sources = [BuildSource('main', '__main__', '\n'.join(testcase.input))]
     try:
-        res = build.build(sources=sources,
-                          options=options,
-                          alt_lib_path=test_temp_dir,
-                          flush_errors=flush_errors)
-        reported_messages = res.errors
+        build.build(sources=sources,
+                    options=options,
+                    alt_lib_path=test_temp_dir,
+                    flush_errors=flush_errors)
     except CompileError as e:
-        reported_messages = e.messages
+        pass
 
     assert_string_arrays_equal(testcase.output, logged_messages,
                                'Invalid output ({}, line {})'.format(
-                                   testcase.file, testcase.line))
-    assert_string_arrays_equal(reported_messages, real_messages,
-                               'Streamed/reported mismatch ({}, line {})'.format(
                                    testcase.file, testcase.line))

--- a/mypy/test/testerrorstream.py
+++ b/mypy/test/testerrorstream.py
@@ -34,7 +34,7 @@ def test_error_stream(testcase: DataDrivenTestCase) -> None:
     logged_messages = []  # type: List[str]
     real_messages = []  # type: List[str]
 
-    def flush_errors(msgs: List[str], serious: bool, is_real: bool=True) -> None:
+    def flush_errors(msgs: List[str], serious: bool, is_real: bool = True) -> None:
         if msgs:
             logged_messages.append('==== Errors flushed ====')
             logged_messages.extend(msgs)

--- a/mypy/test/testerrorstream.py
+++ b/mypy/test/testerrorstream.py
@@ -31,8 +31,8 @@ def test_error_stream(testcase: DataDrivenTestCase) -> None:
     options = Options()
     options.show_traceback = True
 
-    logged_messages: List[str] = []
-    real_messages: List[str] = []
+    logged_messages = []  # type: List[str]
+    real_messages = []  # type: List[str]
 
     def flush_errors(msgs: List[str], serious: bool, is_real: bool=True) -> None:
         if msgs:

--- a/mypy/test/testerrorstream.py
+++ b/mypy/test/testerrorstream.py
@@ -1,0 +1,76 @@
+"""Tests for mypy incremental error output."""
+from typing import List, Callable, Optional
+
+import os
+
+from mypy import defaults, build
+from mypy.test.config import test_temp_dir
+from mypy.myunit import AssertionFailure
+from mypy.test.helpers import assert_string_arrays_equal
+from mypy.test.data import DataDrivenTestCase, DataSuite
+from mypy.build import BuildSource
+from mypy.errors import CompileError
+from mypy.options import Options
+from mypy.plugin import Plugin, ChainedPlugin, DefaultPlugin, FunctionContext
+from mypy.nodes import CallExpr, StrExpr
+from mypy.types import Type
+
+
+class ErrorStreamSuite(DataSuite):
+    files = ['errorstream.test']
+
+    def run_case(self, testcase: DataDrivenTestCase) -> None:
+        test_error_stream(testcase)
+
+
+def test_error_stream(testcase: DataDrivenTestCase) -> None:
+    """Perform a single error streaming test case.
+
+    The argument contains the description of the test case.
+    """
+    options = Options()
+    options.show_traceback = True
+
+    a = []
+
+    def flush_errors(msgs: List[str]) -> None:
+        nonlocal a
+        if msgs:
+            a.append('==== Errors flushed ====')
+            a += msgs
+    plugin = ChainedPlugin(options, [LoggingPlugin(options, flush_errors), DefaultPlugin(options)])
+
+    sources = [BuildSource('main', '__main__', '\n'.join(testcase.input))]
+    try:
+        build.build(sources=sources,
+                    options=options,
+                    alt_lib_path=test_temp_dir,
+                    flush_errors=flush_errors,
+                    plugin=plugin)
+    except CompileError as e:
+        a.append('==== Blocking error ====')
+        a += e.messages[e.num_already_seen:]
+
+    assert_string_arrays_equal(testcase.output, a,
+                               'Invalid output ({}, line {})'.format(
+                                   testcase.file, testcase.line))
+
+
+# Use a typechecking plugin to allow test cases to emit messages
+# during typechecking. This allows us to verify that error messages
+# from one SCC are printed before later ones are typechecked.
+class LoggingPlugin(Plugin):
+    def __init__(self, options: Options, log: Callable[[List[str]], None]) -> None:
+        super().__init__(options)
+        self.log = log
+
+    def get_function_hook(self, fullname: str) -> Optional[Callable[[FunctionContext], Type]]:
+        if fullname == 'log.log_checking':
+            return self.hook
+        return None
+
+    def hook(self, ctx: FunctionContext) -> Type:
+        assert(isinstance(ctx.context, CallExpr) and len(ctx.context.args) > 0 and
+               isinstance(ctx.context.args[0], StrExpr))
+        self.log([ctx.context.args[0].value])
+        return ctx.default_return_type

--- a/mypy/test/testerrorstream.py
+++ b/mypy/test/testerrorstream.py
@@ -11,7 +11,6 @@ from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.build import BuildSource
 from mypy.errors import CompileError
 from mypy.options import Options
-from mypy.plugin import Plugin, ChainedPlugin, DefaultPlugin, FunctionContext
 from mypy.nodes import CallExpr, StrExpr
 from mypy.types import Type
 
@@ -34,22 +33,18 @@ def test_error_stream(testcase: DataDrivenTestCase) -> None:
     logged_messages = []  # type: List[str]
     real_messages = []  # type: List[str]
 
-    def flush_errors(msgs: List[str], serious: bool, is_real: bool = True) -> None:
+    def flush_errors(msgs: List[str], serious: bool) -> None:
         if msgs:
             logged_messages.append('==== Errors flushed ====')
             logged_messages.extend(msgs)
-        if is_real:
-            real_messages.extend(msgs)
-
-    plugin = ChainedPlugin(options, [LoggingPlugin(options, flush_errors), DefaultPlugin(options)])
+        real_messages.extend(msgs)
 
     sources = [BuildSource('main', '__main__', '\n'.join(testcase.input))]
     try:
         res = build.build(sources=sources,
                           options=options,
                           alt_lib_path=test_temp_dir,
-                          flush_errors=flush_errors,
-                          plugin=plugin)
+                          flush_errors=flush_errors)
         reported_messages = res.errors
     except CompileError as e:
         reported_messages = e.messages
@@ -60,23 +55,3 @@ def test_error_stream(testcase: DataDrivenTestCase) -> None:
     assert_string_arrays_equal(reported_messages, real_messages,
                                'Streamed/reported mismatch ({}, line {})'.format(
                                    testcase.file, testcase.line))
-
-
-# Use a typechecking plugin to allow test cases to emit messages
-# during typechecking. This allows us to verify that error messages
-# from one SCC are printed before later ones are typechecked.
-class LoggingPlugin(Plugin):
-    def __init__(self, options: Options, log: Callable[[List[str], bool, bool], None]) -> None:
-        super().__init__(options)
-        self.log = log
-
-    def get_function_hook(self, fullname: str) -> Optional[Callable[[FunctionContext], Type]]:
-        if fullname == 'log.log_checking':
-            return self.hook
-        return None
-
-    def hook(self, ctx: FunctionContext) -> Type:
-        assert(isinstance(ctx.context, CallExpr) and len(ctx.context.args) > 0 and
-               isinstance(ctx.context.args[0], StrExpr))
-        self.log([ctx.context.args[0].value], False, False)
-        return ctx.default_return_type

--- a/mypy/test/testgraph.py
+++ b/mypy/test/testgraph.py
@@ -49,6 +49,7 @@ class GraphSuite(Suite):
             version_id=__version__,
             plugin=Plugin(options),
             errors=errors,
+            flush_errors=lambda msgs, serious: None,
         )
         return manager
 

--- a/runtests.py
+++ b/runtests.py
@@ -213,7 +213,8 @@ PYTEST_FILES = test_path(
     'testtransform',
     'testtypegen',
     'testparse',
-    'testsemanal'
+    'testsemanal',
+    'testerrorstream',
 )
 
 SLOW_FILES = test_path(

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -390,8 +390,14 @@ A.B(x=1)  # E: Unexpected keyword argument "x" for "B"
 
 [case testUnexpectedMethodKwargFromOtherModule]
 import m
-m.A(x=1)  # E: Unexpected keyword argument "x" for "A"
+m.A(x=1)
 [file m.py]
+1+'asdf'
 class A:
-    def __init__(self) -> None:  # N: "A" defined here
+    def __init__(self) -> None:
         pass
+
+[out]
+tmp/m.py:1: error: Unsupported operand types for + ("int" and "str")
+main:2: error: Unexpected keyword argument "x" for "A"
+tmp/m.py:3: note: "A" defined here

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -396,8 +396,10 @@ m.A(x=1)
 class A:
     def __init__(self) -> None:
         pass
-
 [out]
+-- Note that the messages appear "out of order" because the m.py:3
+-- message is really an attachment to the main:2 error and should be
+-- reported with it.
 tmp/m.py:1: error: Unsupported operand types for + ("int" and "str")
 main:2: error: Unexpected keyword argument "x" for "A"
 tmp/m.py:3: note: "A" defined here

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -400,9 +400,9 @@ bla bla
 [file error.py]
 bla bla
 [out]
+normal.py:2: error: Unsupported operand types for + ("int" and "str")
 main.py:4: note: Import of 'error' ignored
 main.py:4: note: (Using --follow-imports=error, module not passed on command line)
-normal.py:2: error: Unsupported operand types for + ("int" and "str")
 main.py:5: error: Revealed type is 'builtins.int'
 main.py:6: error: Revealed type is 'builtins.int'
 main.py:7: error: Revealed type is 'Any'

--- a/test-data/unit/errorstream.test
+++ b/test-data/unit/errorstream.test
@@ -1,0 +1,46 @@
+-- Test cases for incremental error streaming. Each test case consists of two
+-- sections.
+-- The first section contains [case NAME] followed by the input code, while
+-- the second section contains [out] followed by the output from the checker.
+-- Each time errors are reported, '==== Errors flushed ====' is printed.
+-- The log.log_checking() function will immediately emit a message from
+-- a plugin when a call to it is checked, which can be used to verify that
+-- error messages are printed before doing later typechecking work.
+--
+-- The input file name in errors is "file".
+--
+-- Comments starting with "--" in this file will be ignored, except for lines
+-- starting with "----" that are not ignored. The first two dashes of these
+-- lines are interpreted as escapes and removed.
+
+[case testErrorStream]
+import b
+[file log.py]
+def log_checking(msg: str) -> None: ...
+[file a.py]
+1 + ''
+[file b.py]
+import a
+import log
+log.log_checking('Checking b')  # Make sure that a has been flushed before this is checked
+'' / 2
+[out]
+==== Errors flushed ====
+a.py:1: error: Unsupported operand types for + ("int" and "str")
+==== Errors flushed ====
+Checking b
+==== Errors flushed ====
+b.py:4: error: Unsupported operand types for / ("str" and "int")
+
+[case testBlockers]
+import b
+[file a.py]
+1 + ''
+[file b.py]
+import a
+break
+[out]
+==== Errors flushed ====
+a.py:1: error: Unsupported operand types for + ("int" and "str")
+==== Blocking error ====
+b.py:2: error: 'break' outside loop

--- a/test-data/unit/errorstream.test
+++ b/test-data/unit/errorstream.test
@@ -39,8 +39,34 @@ import b
 [file b.py]
 import a
 break
+1 / ''  # won't get reported, after a blocker
 [out]
 ==== Errors flushed ====
 a.py:1: error: Unsupported operand types for + ("int" and "str")
-==== Blocking error ====
+==== Errors flushed ====
 b.py:2: error: 'break' outside loop
+
+[case testCycles]
+import a
+[file a.py]
+import b
+1 + ''
+def f() -> int:
+    reveal_type(b.x)
+    return b.x
+y = 0 + 0
+[file b.py]
+import a
+def g() -> int:
+    reveal_type(a.y)
+    return a.y
+1 / ''
+x = 1 + 1
+
+[out]
+==== Errors flushed ====
+b.py:3: error: Revealed type is 'builtins.int'
+b.py:5: error: Unsupported operand types for / ("int" and "str")
+==== Errors flushed ====
+a.py:2: error: Unsupported operand types for + ("int" and "str")
+a.py:4: error: Revealed type is 'builtins.int'

--- a/test-data/unit/errorstream.test
+++ b/test-data/unit/errorstream.test
@@ -1,36 +1,18 @@
--- Test cases for incremental error streaming. Each test case consists of two
--- sections.
--- The first section contains [case NAME] followed by the input code, while
--- the second section contains [out] followed by the output from the checker.
+-- Test cases for incremental error streaming.
 -- Each time errors are reported, '==== Errors flushed ====' is printed.
--- The log.log_checking() function will immediately emit a message from
--- a plugin when a call to it is checked, which can be used to verify that
--- error messages are printed before doing later typechecking work.
---
--- The input file name in errors is "file".
---
--- Comments starting with "--" in this file will be ignored, except for lines
--- starting with "----" that are not ignored. The first two dashes of these
--- lines are interpreted as escapes and removed.
 
 [case testErrorStream]
 import b
-[file log.py]
-def log_checking(msg: str) -> None: ...
 [file a.py]
 1 + ''
 [file b.py]
 import a
-import log
-log.log_checking('Checking b')  # Make sure that a has been flushed before this is checked
 '' / 2
 [out]
 ==== Errors flushed ====
 a.py:1: error: Unsupported operand types for + ("int" and "str")
 ==== Errors flushed ====
-Checking b
-==== Errors flushed ====
-b.py:4: error: Unsupported operand types for / ("str" and "int")
+b.py:2: error: Unsupported operand types for / ("str" and "int")
 
 [case testBlockers]
 import b

--- a/test-data/unit/fine-grained-blockers.test
+++ b/test-data/unit/fine-grained-blockers.test
@@ -255,9 +255,6 @@ a.py:1: error: invalid syntax
 main:1: error: Cannot find module named 'a'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 b.py:1: error: Cannot find module named 'a'
--- TODO: Remove redundant errors
-main:1: error: Cannot find module named 'a'
-b.py:1: error: Cannot find module named 'a'
 
 [case testModifyFileWhileBlockingErrorElsewhere]
 import a

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1032,8 +1032,8 @@ main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.Non
 ==
 a.py:1: error: Cannot find module named 'b'
 a.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
-main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 a.py:3: error: Cannot find module named 'b'
+main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 ==
 main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 


### PR DESCRIPTION
In order to avoid duplicate error messages for errors produced in both
load_graph() and process_graph() and to prevent misordered error
messages in a number of places, lists of error messages are now
tracked per-file.

These lists are collected and printed out when a file is complete.  To
maintain consistency with clients that use .messages() (namely,
tests), messages are generated file-at-a-time even when not printing
them out incrementally.

Fixes #1294