### PR TITLE
Handling of field names tuple (#4406)

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -593,7 +593,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         name = repr(getattr(rvalue.args[0], 'value', '<ERROR>'))
         if isinstance(rvalue.args[1], StrExpr):
             items = repr(rvalue.args[1].value)
-        elif isinstance(rvalue.args[1], ListExpr):
+        elif isinstance(rvalue.args[1], (ListExpr, TupleExpr)):
             list_items = cast(List[StrExpr], rvalue.args[1].items)
             items = '[%s]' % ', '.join(repr(item.value) for item in list_items)
         else:

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -569,6 +569,20 @@ _X = namedtuple('_X', ['a', 'b'])
 
 class Y(_X): ...
 
+[case testNamedtupleAltSyntaxFieldsTuples]
+from collections import namedtuple, x
+X = namedtuple('X', ())
+Y = namedtuple('Y', ('a',))
+Z = namedtuple('Z', ('a', 'b', 'c', 'd', 'e'))
+[out]
+from collections import namedtuple
+
+X = namedtuple('X', [])
+
+Y = namedtuple('Y', ['a'])
+
+Z = namedtuple('Z', ['a', 'b', 'c', 'd', 'e'])
+
 [case testArbitraryBaseClass]
 import x
 class D(x.C): ...


### PR DESCRIPTION
Is this fix for #4406 acceptable? My concern is that in this solution, the tuple case is merely a duplication of the list case, with only the output formatting being different.