### PR TITLE
[WIP] Treat obvious return types as annotated

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -620,6 +620,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         If type_override is provided, use it as the function type.
         """
+        if not defn.is_checkable:
+            return
         # We may be checking a function definition or an anonymous function. In
         # the first case, set up another reference with the precise type.
         fdef = None  # type: Optional[FuncDef]

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -376,7 +376,7 @@ class ASTConverter(ast3.NodeTransformer):
             self.set_type_optional(arg_type, arg.initializer)
 
         func_type = None
-        if any(arg_types) or return_type:
+        if any(arg_types) or return_type or self.options.obvious_return:
             if len(arg_types) != 1 and any(isinstance(t, EllipsisType) for t in arg_types):
                 self.fail("Ellipses cannot accompany other argument types "
                           "in function type signature.", n.lineno, 0)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -318,6 +318,9 @@ def process_options(args: List[str],
                         "(experimental -- read documentation before using!).  "
                         "Implies --strict-optional.  Has the undesirable side-effect of "
                         "suppressing other errors in non-whitelisted files.")
+    add_invertible_flag('--obvious-return', default=False, strict_flag=True,
+                        help="Treat obvious return values as function annotations")
+
     parser.add_argument('--junit-xml', help="write junit.xml to the given file")
     parser.add_argument('--pdb', action='store_true', help="invoke pdb on fatal error")
     parser.add_argument('--show-traceback', '--tb', action='store_true',

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -429,12 +429,13 @@ class FuncItem(FuncBase):
     is_awaitable_coroutine = False  # Decorated with '@{typing,asyncio}.coroutine'?
     is_static = False      # Uses @staticmethod?
     is_class = False       # Uses @classmethod?
+    is_checkable = False
     # Variants of function with type variables with values expanded
     expanded = None  # type: List[FuncItem]
 
     FLAGS = [
         'is_overload', 'is_generator', 'is_coroutine', 'is_async_generator',
-        'is_awaitable_coroutine', 'is_static', 'is_class',
+        'is_awaitable_coroutine', 'is_static', 'is_class', 'is_checkable',
     ]
 
     def __init__(self, arguments: List[Argument], body: 'Block',

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -39,6 +39,7 @@ class Options:
         "no_implicit_optional",
         "strict_optional",
         "disallow_untyped_decorators",
+        "obvious_return",
     }
 
     OPTIONS_AFFECTING_CACHE = ((PER_MODULE_OPTIONS | {"quick_and_dirty", "platform"})
@@ -111,6 +112,8 @@ class Options:
 
         # Apply strict None checking
         self.strict_optional = False
+
+        self.obvious_return = False
 
         # Show "note: In function "foo":" messages.
         self.show_error_context = False

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -588,18 +588,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
     def analyze_function(self, defn: FuncItem) -> None:
         is_method = self.is_class_scope()
         with self.tvar_scope_frame(self.tvar_scope.method_frame()):
-            if self.options.obvious_return:
-                # FIX: if we need names, it can't be done here since it's out of scope
-                if isinstance(defn.type, CallableType):
-                    if isinstance(defn.type.ret_type, AnyType):
-                        if defn.type.ret_type.type_of_any == TypeOfAny.unannotated:
-                            finder = RetFinder()
-                            defn.accept(finder)
-                            ret_types = [self.analyze_simple_literal_type(ret) for ret in finder.rets]
-                            if None not in ret_types:
-                                defn.type.ret_type = UnionType.make_simplified_union(ret_types)
 
-            if defn.type:
+            if defn.type is not None and defn.is_checkable:
                 self.check_classvar_in_signature(defn.type)
                 assert isinstance(defn.type, CallableType)
                 # Signature must be analyzed in the surrounding scope so that
@@ -612,9 +602,10 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
                 if arg.initializer:
                     arg.initializer.accept(self)
             # Bind the type variables again to visit the body.
-            if defn.type:
+            if defn.type is not None and defn.is_checkable:
                 a = self.type_analyzer()
-                a.bind_function_type_variables(cast(CallableType, defn.type), defn)
+                assert isinstance(defn.type, CallableType)
+                a.bind_function_type_variables(defn.type, defn)
             self.function_stack.append(defn)
             self.enter()
             for arg in defn.arguments:
@@ -637,6 +628,17 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
                 postponed.accept(self)
             self.postpone_nested_functions_stack.pop()
             self.postponed_functions_stack.pop()
+
+            if self.options.obvious_return:
+                if isinstance(defn.type, CallableType):
+                    if isinstance(defn.type.ret_type, AnyType):
+                        if defn.type.ret_type.type_of_any == TypeOfAny.unannotated:
+                            finder = RetFinder()
+                            defn.accept(finder)
+                            # Ad-hoc join: trivial identity
+                            ret_types = {self.analyze_simple_literal_type(ret) for ret in finder.rets}
+                            if None not in ret_types and len(ret_types) == 1:
+                                defn.type.ret_type = ret_types.pop()
 
             self.leave()
             self.function_stack.pop()
@@ -1714,7 +1716,16 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
             # Set the type if the rvalue is a simple literal (even if the above error occurred).
             if len(s.lvalues) == 1 and isinstance(s.lvalues[0], NameExpr):
                 if s.lvalues[0].is_inferred_def:
-                    s.type = self.analyze_simple_literal_type(s.rvalue)
+                    if self.options.semantic_analysis_only or self.function_stack:
+                        # Skip this if we're only doing the semantic analysis pass.
+                        # This is mostly to avoid breaking unit tests.
+                        # Also skip inside a function; this is to avoid confusing
+                        # the code that handles dead code due to isinstance()
+                        # inside type variables with value restrictions (like
+                        # AnyStr).
+                        s.type = None
+                    else:
+                        s.type = self.analyze_simple_literal_type(s.rvalue)
         if s.type:
             # Store type into nodes.
             for lvalue in s.lvalues:
@@ -1735,14 +1746,6 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
 
     def analyze_simple_literal_type(self, rvalue: Expression) -> Optional[Type]:
         """Return builtins.int if rvalue is an int literal, etc."""
-        if self.options.semantic_analysis_only or self.function_stack:
-            # Skip this if we're only doing the semantic analysis pass.
-            # This is mostly to avoid breaking unit tests.
-            # Also skip inside a function; this is to avoid confusing
-            # the code that handles dead code due to isinstance()
-            # inside type variables with value restrictions (like
-            # AnyStr).
-            return None
         if isinstance(rvalue, IntExpr):
             return self.named_type_or_none('builtins.int')
         if isinstance(rvalue, FloatExpr):

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -55,6 +55,7 @@ typecheck_files = [
     'check-serialize.test',
     'check-bound.test',
     'check-optional.test',
+    'check-obvious.test',
     'check-fastparse.test',
     'check-warnings.test',
     'check-async-await.test',

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -647,7 +647,7 @@ class CallableType(FunctionLike):
                  arg_kinds: List[int],
                  arg_names: Sequence[Optional[str]],
                  ret_type: Type,
-                 fallback: Instance,
+                 fallback: Instance,  # or none at parsing time
                  name: Optional[str] = None,
                  definition: Optional[SymbolNode] = None,
                  variables: Optional[List[TypeVarDef]] = None,
@@ -720,7 +720,8 @@ class CallableType(FunctionLike):
         )
 
     def is_type_obj(self) -> bool:
-        return self.fallback.type.is_metaclass()
+        # self.fallback is None at initialization
+        return self.fallback is not None and self.fallback.type.is_metaclass()
 
     def is_concrete_type_obj(self) -> bool:
         return self.is_type_obj() and self.is_classmethod_class

--- a/test-data/unit/check-obvious.test
+++ b/test-data/unit/check-obvious.test
@@ -3,10 +3,22 @@
 [case testObviousLiteralString]
 # flags: --obvious-return
 def foo():
+    "" + 1
     return ""
 
 def bar():
+    1 + ""
     return 1
 
 reveal_type(foo() + "")  # E: Revealed type is 'builtins.str'
 bar() + foo()  # E: Unsupported operand types for + ("int" and "str")
+
+[case testObviousOverride]
+# flags: --obvious-return
+class A:
+    def foo(self):
+        return ""
+
+class B(A):
+    def foo(self):  # E: Return type of "foo" incompatible with supertype "A"
+        return 1

--- a/test-data/unit/check-obvious.test
+++ b/test-data/unit/check-obvious.test
@@ -1,0 +1,12 @@
+-- Tests for obvious return types
+
+[case testObviousLiteralString]
+# flags: --obvious-return
+def foo():
+    return ""
+
+def bar():
+    return 1
+
+reveal_type(foo() + "")  # E: Revealed type is 'builtins.str'
+bar() + foo()  # E: Unsupported operand types for + ("int" and "str")


### PR DESCRIPTION
Implementing #4409.

* Only literal types for now
* The join is very naive (of course, it _must_ be very simple)

`defn.type` is used on master to signify unannotated functions and bad signatures; I think distinguishing between the purposes is important regardless of the proposal.

Also:

- [ ] Find a good name for the feature.

(I open it early to accompany the discussion at #4409)