### PR TITLE
Allow subclassing NamedTuple as a nested class

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -956,8 +956,9 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
                 tvars.extend(base_tvars)
         return remove_dups(tvars)
 
-    def is_namedtuple_classdef(self, defn: ClassDef):
-        return 'typing.NamedTuple' in [ getattr(base_expr, 'fullname', None) for base_expr in defn.base_type_exprs ]
+    def is_namedtuple_classdef(self, defn: ClassDef) -> bool:
+        base_exprs = defn.base_type_exprs
+        return any(getattr(b, 'fullname', None) == 'typing.NamedTuple' for b in base_exprs)
 
     def analyze_namedtuple_classdef(self, defn: ClassDef) -> Optional[TypeInfo]:
         # special case for NamedTuple
@@ -1054,12 +1055,10 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
                 defn.info._fullname = self.cur_mod_id + '.' + local_name
                 defn.fullname = defn.info._fullname
                 if self.type and self.is_namedtuple_classdef(defn):
-                    # Special Case for NamedTuple: store in class because that is what NamedTuples expect.
+                    # Special case for NamedTuple.
                     self.type.names[local_name] = node
                 else:
                     self.globals[local_name] = node
-
-
 
     def analyze_base_classes(self, defn: ClassDef) -> None:
         """Analyze and set up base classes.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -671,6 +671,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
             if self.analyze_typeddict_classdef(defn):
                 yield False
                 return
+            self.setup_class_def_analysis(defn)
             named_tuple_info = self.analyze_namedtuple_classdef(defn)
             if named_tuple_info is not None:
                 # Temporarily clear the names dict so we don't get errors about duplicate names
@@ -704,7 +705,6 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
                     if key not in named_tuple_info.names or key != '__doc__'
                 })
             else:
-                self.setup_class_def_analysis(defn)
                 self.analyze_base_classes(defn)
                 self.analyze_metaclass(defn)
                 defn.info.is_protocol = is_protocol

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -667,3 +667,11 @@ class HasStaticMethod(NamedTuple):
         return 4
 
 [builtins fixtures/property.pyi]
+
+[case testNamedTupleLocalScope]
+from typing import NamedTuple, Any, Tuple
+
+def function() -> Tuple:
+    class InnerNamedTuple(NamedTuple):
+        x: int
+    return InnerNamedTuple(x=0)

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1925,6 +1925,21 @@ tmp/crash.py:17: error: Revealed type is 'crash.B@13[builtins.int*]'
 main:2: error: Revealed type is 'crash.A@5'
 main:3: error: Revealed type is 'crash.B@13[builtins.int*]'
 
+[case testIncrementalSubclassNamedTuple]
+from a import C
+reveal_type(C().a)
+[file a.py]
+from typing import NamedTuple
+class C:
+    def __init__(self) -> None:
+        class A(NamedTuple):
+            x: int
+        self.a = A(1)
+[out1]
+main:2: error: Revealed type is 'Tuple[builtins.int, fallback=a.C.A@4]'
+[out2]
+main:2: error: Revealed type is 'Tuple[builtins.int, fallback=a.C.A@4]'
+
 [case testGenericMethodRestoreMetaLevel]
 from typing import Dict
 

--- a/test-data/unit/semanal-namedtuple.test
+++ b/test-data/unit/semanal-namedtuple.test
@@ -132,6 +132,48 @@ MypyFile:1(
       __main__.N@2)
     PassStmt:2()))
 
+[case testNamedTupleDirectSubclass]
+from typing import NamedTuple
+class A(NamedTuple):
+	x: int
+
+[out]
+MypyFile:1(
+  ImportFrom:1(typing, [NamedTuple])
+  ClassDef:2(
+    A
+    TupleType(
+      Tuple[builtins.int])
+    BaseType(
+      builtins.tuple[builtins.int])
+    AssignmentStmt:3(
+      NameExpr(x [m])
+      TempNode:-1(
+        Any)
+      builtins.int)))
+
+[case testLocalNamedTupleDirectSubclass]
+from typing import NamedTuple
+def foo():
+    class A(NamedTuple):
+            x: int
+[out]
+MypyFile:1(
+  ImportFrom:1(typing, [NamedTuple])
+  FuncDef:2(
+    foo
+    Block:2(
+      ClassDef:3(
+        A
+        TupleType(
+          Tuple[builtins.int])
+        BaseType(
+          builtins.tuple[builtins.int])
+        AssignmentStmt:4(
+          NameExpr(x [m])
+          TempNode:-1(
+            Any)
+          builtins.int)))))
 -- Errors
 
 [case testNamedTupleWithTooFewArguments]


### PR DESCRIPTION
Fixes #4349.

This 1-line change allows subclassing NamedTuple inside a function.

The current problem is that inner NamedTuples aren't added to the symbol table.
Inner classes get added in `self.setup_class_def_analysis(defn)` , so we just call that method before calling `analyze_namedtuple_classdef`, which looks up the node in the symbol table.

As far as I can tell, `setup_class_def_analysis` does the work that would be done in pass 1's `visit_class_defn`, which, for inner classes, adds the defn to the local symbol table and the global symbol table, under a mangled name. That should also happen for NamedTuples.

I added some semaneval unit tests for this change to verify the change in behavior, but that may not be the right place. I might want to add a test to prove that local NamedTuples need to be go in the global symbol table as well.

