### PR TITLE
Mention distinction between Generator and Iterator

### DIFF
--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -988,7 +988,9 @@ annotated the first example as the following:
            yield i * i
            
 This is slightly different from using ``Iterable[int]`` or ``Iterator[int]``,
-since generators have a ``close()`` method that generic iterables don't.
+since generators have ``close()``, ``send()``, and ``throw()`` methods that
+generic iterables don't. If you will call these methods on the returned
+generator, use the ``Generator`` type instead of ``Iterable`` or ``Iterator``.
 
 .. _async-and-await:
 

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -986,6 +986,9 @@ annotated the first example as the following:
    def squares(n: int) -> Generator[int, None, None]:
        for i in range(n):
            yield i * i
+           
+This is slightly different from using ``Iterable[int]`` or ``Iterator[int]``,
+since generators have a ``close()`` method that generic iterables don't.
 
 .. _async-and-await:
 


### PR DESCRIPTION
As seen in https://github.com/python/typeshed/issues/1806, `Generator[..., None, None]` is not quite equivalent to `Iterator[...]`, due to the `close()` method on generators. In most cases this probably doesn't matter, since the `close()` method is infrequently used, so I've left the basic structure of the docs the same (recommending `Iterator[...]` first for simple generators). But it's at least worth a mention.