### PR TITLE
Annotate functions in tests

### DIFF
--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -125,13 +125,18 @@ class A:
     def __init__(self) -> None:
         self.x = object()
 a = None # type: A
-a.y
-a.y = object()
+a.y  # E: "A" has no attribute "y"
+a.y = object()  # E: "A" has no attribute "y"
 a.x
 a.x = object()
-[out]
-main:6: error: "A" has no attribute "y"
-main:7: error: "A" has no attribute "y"
+
+[case testInferAttributeUnannotatedInit]
+class A:
+    def __init__(self):
+        self.x = object()
+
+a.x
+a.x = object()
 
 [case testArgumentTypeInference]
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -124,17 +124,20 @@ A().f = None # E: Cannot assign to a method
 class A:
     def __init__(self) -> None:
         self.x = object()
-a = None # type: A
+a: A
 a.y  # E: "A" has no attribute "y"
 a.y = object()  # E: "A" has no attribute "y"
 a.x
 a.x = object()
 
-[case testInferAttributeUnannotatedInit]
+[case testReferToInvalidAttributeUnannotatedInit]
 class A:
     def __init__(self):
         self.x = object()
 
+a: A
+a.y  # E: "A" has no attribute "y"
+a.y = object()  # E: "A" has no attribute "y"
 a.x
 a.x = object()
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -122,7 +122,7 @@ A().f = None # E: Cannot assign to a method
 [case testReferToInvalidAttribute]
 
 class A:
-    def __init__(self):
+    def __init__(self) -> None:
         self.x = object()
 a = None # type: A
 a.y

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1403,7 +1403,7 @@ b[{}] = 1
 
 [case testInferDictInitializedToEmptyAndUpdatedFromMethod]
 map = {}
-def add():
+def add() -> None:
     map[1] = 2
 [builtins fixtures/dict.pyi]
 [out]
@@ -1959,7 +1959,7 @@ class C:
 
 if bool():
     f()
-    1 + '' # E: Unsupported left operand type for + ("int")
+    1 + '' # E: Unsupported operand types for + ("int" and "str")
 [builtins fixtures/list.pyi]
 [out]
 
@@ -1976,7 +1976,7 @@ class C:
 
 if bool():
     f()
-    1 + '' # E: Unsupported left operand type for + ("int")
+    1 + '' # E: Unsupported operand types for + ("int" and "str")
 [builtins fixtures/list.pyi]
 [out]
 
@@ -1992,6 +1992,6 @@ class C:
 
 if bool():
     f([])
-    1 + '' # E: Unsupported left operand type for + ("int")
+    1 + '' # E: Unsupported operand types for + ("int" and "str")
 [builtins fixtures/list.pyi]
 [out]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1406,7 +1406,12 @@ map = {}
 def add() -> None:
     map[1] = 2
 [builtins fixtures/dict.pyi]
-[out]
+
+[case testInferDictInitializedToEmptyAndUpdatedFromMethodUnannotated]
+map = {}
+def add():
+    map[1] = 2
+[builtins fixtures/dict.pyi]
 
 [case testSpecialCaseEmptyListInitialization]
 def f(blocks: Any): # E: Name 'Any' is not defined
@@ -1959,7 +1964,7 @@ class C:
 
 if bool():
     f()
-    1 + '' # E: Unsupported operand types for + ("int" and "str")
+    1() # E: "int" not callable
 [builtins fixtures/list.pyi]
 [out]
 
@@ -1976,7 +1981,7 @@ class C:
 
 if bool():
     f()
-    1 + '' # E: Unsupported operand types for + ("int" and "str")
+    1() # E: "int" not callable
 [builtins fixtures/list.pyi]
 [out]
 
@@ -1992,6 +1997,6 @@ class C:
 
 if bool():
     f([])
-    1 + '' # E: Unsupported operand types for + ("int" and "str")
+    1() # E: "int" not callable
 [builtins fixtures/list.pyi]
 [out]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1313,8 +1313,13 @@ class A:
 class B(A):
     def f(self) -> str: return self.x
     def initialize(self) -> None: self.x = 'bar'
-[out]
 
+[case testDeferredClassContextUnannotated]
+class A:
+    def f(self) -> str: return 'foo'
+class B(A):
+    def f(self) -> str: return self.x
+    def initialize(self): self.x = 'bar'
 
 -- Scripts and __main__
 

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1312,7 +1312,7 @@ class A:
     def f(self) -> str: return 'foo'
 class B(A):
     def f(self) -> str: return self.x
-    def initialize(self): self.x = 'bar'
+    def initialize(self) -> None: self.x = 'bar'
 [out]
 
 

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -353,7 +353,7 @@ a @= 1  # E: Argument 1 to "__imatmul__" of "A" has incompatible type "int"; exp
 
 [case testInplaceSetitem]
 class A(object):
-    def __init__(self):
+    def __init__(self) -> None:
         self.a = 0
 
     def __iadd__(self, a):

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -354,11 +354,11 @@ a @= 1  # E: Argument 1 to "__imatmul__" of "A" has incompatible type "int"; exp
 [case testInplaceSetitem]
 class A(object):
     def __init__(self) -> None:
-        self.a = 0
+        self.a = [1]
 
     def __iadd__(self, a):
         # type: (int) -> A
-        self.a += 1
+        self.a += [2]
         return self
 
 a = A()

--- a/test-data/unit/fixtures/list.pyi
+++ b/test-data/unit/fixtures/list.pyi
@@ -26,8 +26,7 @@ class list(Generic[T]):
 
 class tuple(Generic[T]): pass
 class function: pass
-class int:
-    def __add__(self, other: 'int') -> 'int': pass
+class int: pass
 class float: pass
 class str: pass
 class bool(int): pass

--- a/test-data/unit/fixtures/list.pyi
+++ b/test-data/unit/fixtures/list.pyi
@@ -26,7 +26,8 @@ class list(Generic[T]):
 
 class tuple(Generic[T]): pass
 class function: pass
-class int: pass
+class int:
+    def __add__(self, other: 'int') -> 'int': pass
 class float: pass
 class str: pass
 class bool(int): pass


### PR DESCRIPTION
Seems like some functions are accidentally unannotated. For example, `testInplaceSetitem` should have actually failed since the list fixture does not declare addition for `int`; but it doesn't, since mypy seems to silently infer `Any` for the attribute.