### PR TITLE
Fix interaction between finegrained incremental and callable()

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2675,7 +2675,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         # Build up a fake FuncDef so we can populate the symbol table.
         func_def = FuncDef('__call__', [], Block([]), callable_type)
-        func_def._fullname = gen_name + '.__call__'
+        func_def._fullname = '__call__'
         func_def.info = info
         info.names['__call__'] = SymbolTableNode(MDEF, func_def, callable_type)
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2675,6 +2675,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         # Build up a fake FuncDef so we can populate the symbol table.
         func_def = FuncDef('__call__', [], Block([]), callable_type)
+        func_def._fullname = gen_name + '.__call__'
         func_def.info = info
         info.names['__call__'] = SymbolTableNode(MDEF, func_def, callable_type)
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2675,7 +2675,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         # Build up a fake FuncDef so we can populate the symbol table.
         func_def = FuncDef('__call__', [], Block([]), callable_type)
-        func_def._fullname = '__call__'
+        func_def._fullname = cdef.fullname + '.__call__'
         func_def.info = info
         info.names['__call__'] = SymbolTableNode(MDEF, func_def, callable_type)
 

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1346,3 +1346,17 @@ def g() -> str: pass
 [builtins fixtures/exception.pyi]
 [out]
 ==
+
+[case testFineGrainedCallable]
+import a
+[file a.py]
+def f(o: object) -> None:
+    if callable(o):
+        o()
+[file a.py.2]
+def f(o: object) -> None:
+    if callable(o):
+        o()
+[builtins fixtures/callable.pyi]
+[out]
+==


### PR DESCRIPTION
The fake classes created for callable() was missing the fullname
field, which breaks fine-grained incremental.