### PR TITLE
 Fixes to AST merge of named tuples and callables 

### DIFF
--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -301,7 +301,9 @@ class TypeReplaceVisitor(TypeVisitor[None]):
         if typ.definition:
             # No need to fixup since this is just a cross-reference.
             typ.definition = self.replacements.get(typ.definition, typ.definition)
-        typ.fallback.accept(self)
+        # Fallback can be None for non semantically analyzed callable types.
+        if typ.fallback is not None:
+            typ.fallback.accept(self)
         for tv in typ.variables:
             tv.upper_bound.accept(self)
             for value in tv.values:

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -301,7 +301,7 @@ class TypeReplaceVisitor(TypeVisitor[None]):
         if typ.definition:
             # No need to fixup since this is just a cross-reference.
             typ.definition = self.replacements.get(typ.definition, typ.definition)
-        # Fallback can be None for non semantically analyzed callable types.
+        # Fallback can be None for callable types that haven't been semantically analyzed.
         if typ.fallback is not None:
             typ.fallback.accept(self)
         for tv in typ.variables:

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -203,6 +203,7 @@ class NodeReplaceVisitor(TraverserVisitor):
 
     def visit_namedtuple_expr(self, node: NamedTupleExpr) -> None:
         super().visit_namedtuple_expr(node)
+        node.info = self.fixup(node.info)
         self.process_type_info(node.info)
 
     def visit_super_expr(self, node: SuperExpr) -> None:
@@ -300,7 +301,7 @@ class TypeReplaceVisitor(TypeVisitor[None]):
         if typ.definition:
             # No need to fixup since this is just a cross-reference.
             typ.definition = self.replacements.get(typ.definition, typ.definition)
-        # TODO: typ.fallback
+        typ.fallback.accept(self)
         for tv in typ.variables:
             tv.upper_bound.accept(self)
             for value in tv.values:
@@ -309,6 +310,7 @@ class TypeReplaceVisitor(TypeVisitor[None]):
     def visit_overloaded(self, t: Overloaded) -> None:
         for item in t.items():
             item.accept(self)
+        t.fallback.accept(self)
 
     def visit_deleted_type(self, typ: DeletedType) -> None:
         pass
@@ -319,6 +321,7 @@ class TypeReplaceVisitor(TypeVisitor[None]):
     def visit_tuple_type(self, typ: TupleType) -> None:
         for item in typ.items:
             item.accept(self)
+        typ.fallback.accept(self)
 
     def visit_type_type(self, typ: TypeType) -> None:
         typ.item.accept(self)

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1495,3 +1495,42 @@ def f(o: object) -> None:
 [builtins fixtures/callable.pyi]
 [out]
 ==
+
+[case testRefreshFunctionalNamedTuple]
+import a
+
+[file a.py]
+from typing import NamedTuple
+from b import L
+
+A = NamedTuple('A', [])
+a: A
+
+def g() -> None:
+    x = L(A())
+    x.f(a)
+
+[file b.pyi]
+from typing import TypeVar, Generic, overload
+
+T = TypeVar('T')
+
+class L(Generic[T]):
+    def __init__(self, x: T) -> None: pass
+    @overload
+    def f(self) -> None: pass
+    @overload
+    def f(self, a: T) -> None: pass
+
+[file a.py.2]
+from typing import NamedTuple
+from b import L
+
+A = NamedTuple('A', [])
+a: A
+
+def g() -> None:
+    x = L(A())
+    x.f(a)
+[out]
+==


### PR DESCRIPTION
Some parts of the AST were not handled in AST merge, resulting
in old AST nodes leaking and causing trouble. Added a test case
that depends on the fix to the named tuple fallback. Not sure
if the other changes fix user-visible bugs.