### PR TITLE
Fine-grained: Fix crash on module deletion if parent module is ignored

### DIFF
--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -493,9 +493,13 @@ def delete_module(module_id: str,
         del manager.saved_cache[module_id]
     components = module_id.split('.')
     if len(components) > 1:
-        parent = manager.modules['.'.join(components[:-1])]
-        if components[-1] in parent.names:
-            del parent.names[components[-1]]
+        # Delete reference to module in parent module.
+        parent_id = '.'.join(components[:-1])
+        # If parent module is ignored, it won't be included in the modules dictionary.
+        if parent_id in manager.modules:
+            parent = manager.modules[parent_id]
+            if components[-1] in parent.names:
+                del parent.names[components[-1]]
     return new_graph
 
 

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -137,7 +137,7 @@ class FineGrainedSuite(DataSuite):
         description.
         """
         # TODO: Support defining separately for each incremental step.
-        m = re.search('# cmd: mypy ([a-zA-Z0-9_. ]+)$', program_text, flags=re.MULTILINE)
+        m = re.search('# cmd: mypy ([a-zA-Z0-9_./ ]+)$', program_text, flags=re.MULTILINE)
         if m:
             # The test case wants to use a non-default set of files.
             paths = m.group(1).strip().split()

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -619,3 +619,15 @@ import x
 a/b.py:3: error: Revealed type is 'Any'
 ==
 a/b.py:3: error: Unsupported operand types for + ("int" and "str")
+
+[case testDeleteModuleWithinPackageInitIgnored]
+# cmd: mypy x.py a/b.py
+# flags: --follow-imports=skip --ignore-missing-imports
+[file x.py]
+import a.b
+[file a/__init__.py]
+[file a/b.py]
+x = 1
+[delete a/b.py.2]
+[out]
+==


### PR DESCRIPTION
We used to assume that the parent module of a package submodule always
exists, which is not the case if the parent module is not included in
the build.

Also fix test runner to allow '/' in command lines, needed for files
inside packages.