### PR TITLE
Add note about not squashing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ which consist mainly of a reference to
 put in the pull request.
 
 Also, do not squash your commits after you have submitted a pull request, as this
-erases context during review. We can squash commits when the pull request is merged.
+erases context during review. We will squash commits when the pull request is merged.
 
 You may also find other pages in the
 [Mypy developer guide](https://github.com/python/mypy/wiki/Developer-Guides)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,9 @@ which consist mainly of a reference to
 [PEP 8](https://www.python.org/dev/peps/pep-0008/) -- for the code you
 put in the pull request.
 
+Also, do not squash your commits after you have submitted a pull request, as this
+erases context during review. We can squash commits when the pull request is merged.
+
 You may also find other pages in the
 [Mypy developer guide](https://github.com/python/mypy/wiki/Developer-Guides)
 helpful in developing your change.


### PR DESCRIPTION
Fixes #4161.
Nickatak asked about this in https://github.com/python/typing/pull/527, and we might as well fix it.
I can open a PR in typing after this is merged.