### PR TITLE
Fine-grained: Don't crash if passed a non-existent file to dmypy

### DIFF
--- a/test-data/unit/check-dmypy-fine-grained.test
+++ b/test-data/unit/check-dmypy-fine-grained.test
@@ -110,3 +110,57 @@ tmp/a.py:1: error: "int" not callable
 [out2]
 tmp/a.py:1: error: "int" not callable
 [out3]
+
+[case testNonExistentFileOnCommandLineFineGrainedIncremental1]
+# cmd: mypy -m a nonexistent
+# NOTE: 'nonexistent' is a magic module name understood by mypy.test.testdmypy
+[file a.py]
+[file a.py.2]
+1()
+[out1]
+mypy: can't read file 'tmp/nonexistent.py': No such file or directory
+[out2]
+mypy: can't read file 'tmp/nonexistent.py': No such file or directory
+
+[case testNonExistentFileOnCommandLineFineGrainedIncremental2]
+# cmd: mypy -m a
+# cmd2: mypy -m a nonexistent
+# NOTE: 'nonexistent' is a magic module name understood by mypy.test.testdmypy
+# TODO: Should generate an error for missing file
+[file a.py]
+[file a.py.2]
+1()
+[out1]
+[out2]
+tmp/a.py:1: error: "int" not callable
+
+[case testNonExistentFileOnCommandLineFineGrainedIncremental3]
+# cmd: mypy -m a
+# cmd2: mypy -m a nonexistent
+# NOTE: 'nonexistent' is a magic module name understood by mypy.test.testdmypy
+# TODO: Should generate an error for missing file
+[file a.py]
+[file nonexistent.py]
+[delete nonexistent.py.2]
+[out1]
+[out2]
+
+[case testNonExistentFileOnCommandLineFineGrainedIncremental4]
+# cmd: mypy -m a nonexistent
+# NOTE: 'nonexistent' is a magic module name understood by mypy.test.testdmypy
+# TODO: Should generate an error for missing file
+[file a.py]
+[file nonexistent.py]
+[delete nonexistent.py.2]
+[out1]
+[out2]
+
+[case testNonExistentFileOnCommandLineFineGrainedIncremental5]
+# cmd: mypy -m a nonexistent_stub
+# NOTE: 'nonexistent_stub' is a magic module name understood by mypy.test.testdmypy
+# TODO: Should generate an error for missing file
+[file a.py]
+[file nonexistent_stub.pyi]
+[delete nonexistent_stub.pyi.2]
+[out1]
+[out2]


### PR DESCRIPTION
This fixes crashes, but the current behavior is still not correct, as
non-existent files are not reported as errors in fine-grained
incremental updates. Always detecting these is somewhat non-trivial,
since currently mypy.server.update doesn't get information about which
files were explicitly passed as arguments -- it's okay to files to be
deleted, as long they weren't explictly passed on the command
line. I'm not fixing this issue here since it's relatively benign,
whereas the crashes are blocking progress.

Also update the test runner to support passing non-existent paths as
arguments. These need to be tagged using magic module name
prefixes/suffixes, as we normally check that there are no misspelled
module names in test case descriptions by checking that the modules
passed on the command line exist.