### PR TITLE
Fine-grained: Fix refresh of class nested inside function

### DIFF
--- a/test-data/unit/deps-classes.test
+++ b/test-data/unit/deps-classes.test
@@ -49,3 +49,20 @@ class C:
 [out]
 <m.C.x> -> m.C.__init__
 <m.C> -> m.C
+
+[case testClassNestedWithinFunction]
+class C: pass
+
+def f() -> None:
+    class S1(C): pass
+
+class D:
+    def g(self) -> None:
+        class S2(C): pass
+[out]
+-- TODO: Is it okay to have targets like m.S1@4.__init__?
+<m.C.__init__> -> <m.S1@4.__init__>, <m.S2@8.__init__>
+<m.C> -> m.C, m.D.g, m.f
+<m.D.g> -> m.D.g
+<m.D> -> m.D
+<m.f> -> m.f

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1534,3 +1534,32 @@ def g() -> None:
     x.f(a)
 [out]
 ==
+
+[case testRefreshSubclassNestedInFunction1]
+from a import C
+def f() -> None:
+    class D(C): pass
+[file a.py]
+class C: pass
+[file a.py.2]
+[out]
+==
+main:1: error: Module 'a' has no attribute 'C'
+
+[case testRefreshSubclassNestedInFunction2]
+from a import C
+def f() -> None:
+    class D(C):
+        def g(self) -> None:
+            super().__init__()
+    d = D()
+[file a.py]
+class C:
+    def __init__(self) -> None: pass
+[file a.py.2]
+class C:
+    def __init__(self, x: int) -> None: pass
+[out]
+==
+main:5: error: Too few arguments for "__init__" of "C"
+main:6: error: Too few arguments for "D"


### PR DESCRIPTION
Fix crash on refreshing class nested inside function. Typically this
seemed to happen when the base class got triggered. Classes nested
within functions aren't supposed to be targets separate from the
surrounding function, and this PR effectively adds them to the 
surrounding target. Previously they were treated as separate targets,
which broke some assumptions when looking up targets.

Also refactor current target tracking in dependency generation since 
the logic would otherwise have been pretty messy. The main change 
is to not include classes defined within functions in target names.

Some weird dependencies are still generated for nested classes, but
they may be harmless -- extra dependencies should not be a problem.

Fixes #4462.