### PR TITLE
Fix narrowing down types in deferred nodes

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2595,7 +2595,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def narrow_type_from_binder(self, expr: Expression, known_type: Type) -> Type:
         if literal(expr) >= LITERAL_TYPE:
             restriction = self.chk.binder.get(expr)
-            if restriction:
+            # If the current node is deferred, some variables may get Any types that they
+            # otherwise wouldn't have. We don't want to narrow down these since it may
+            # produce invalid inferred Optional[Any] types, at least.
+            if restriction and not (isinstance(known_type, AnyType)
+                                    and self.chk.current_node_deferred):
                 ans = narrow_declared_type(known_type, restriction)
                 return ans
         return known_type

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -673,3 +673,19 @@ class A:
         lambda: (self.y, x.a) # E: Cannot determine type of 'y'
         self.y = int()
 [builtins fixtures/isinstancelist.pyi]
+
+[case testDeferredAndOptionalInferenceSpecialCase]
+def f() -> str:
+    y
+    x = None
+    if int():
+        x = ''
+    if x is None:
+        x = ''
+        g(x)
+    return x
+
+def g(x: str) -> None: pass
+
+y = int()
+[builtins fixtures/bool.pyi]


### PR DESCRIPTION
Previously a partial type could be narrowed down to a bogus
`Optional[Any]` type. Selectively switch narrowing down off
in deferred nodes to work around the issue.

Fixes #4488.