### PR TITLE
Adds the --ignore-missing-stubs command line option

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -10,7 +10,7 @@ flag (or its long form ``--help``)::
   $ mypy -h
   usage: mypy [-h] [-v] [-V] [--python-version x.y] [--platform PLATFORM] [-2]
               [--ignore-missing-imports]
-              [--ignore-missing-stubs MODULE [MODULE ...]]
+              [--ignore-missing-stubs MODULE-1[,MODULE-2...]]
               [--follow-imports {normal,silent,skip,error}]
               [--disallow-any-{unimported,expr,decorated,explicit,generics}]
               [--disallow-untyped-calls] [--disallow-untyped-defs]
@@ -292,7 +292,7 @@ Here are some more useful flags:
   that cannot be resolved (see :ref:`follow-imports` for some examples).
 
 .. _ignore-missing-stubs:
-- ``--ignore-missing-stubs MODULE`` suppresses error messages about imports
+- ``--ignore-missing-stubs MODULE-1[,MODULE-2...]`` suppresses error messages about imports
   for ``MODULE`` when it can be resolved but it lacks library stub files.
 
 - ``--strict-optional`` enables experimental strict checking of ``Optional[...]``

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -10,6 +10,7 @@ flag (or its long form ``--help``)::
   $ mypy -h
   usage: mypy [-h] [-v] [-V] [--python-version x.y] [--platform PLATFORM] [-2]
               [--ignore-missing-imports]
+              [--ignore-missing-stubs MODULE [MODULE ...]]
               [--follow-imports {normal,silent,skip,error}]
               [--disallow-any-{unimported,expr,decorated,explicit,generics}]
               [--disallow-untyped-calls] [--disallow-untyped-defs]
@@ -205,10 +206,8 @@ may want to silence during your initial conquest:
     main.py:2: error: No library stub file for module 'flask'
     main.py:3: error: Cannot find module named 'sir_not_appearing_in_this_film'
 
-  If you see only a few of these you may be able to silence them by
-  putting ``# type: ignore`` on the respective ``import`` statements,
-  but it's usually easier to silence all such errors by using
-  :ref:`--ignore-missing-imports <ignore-missing-imports>`.
+  You can silence these by specifying the module names on the command
+  line by using :ref:`--ignore-missing-stubs <ignore-missing-stubs>`.
 
 - Your project's directory structure may hinder mypy in finding
   certain modules that are part of your project, e.g. modules hidden
@@ -291,6 +290,10 @@ Here are some more useful flags:
 
 - ``--ignore-missing-imports`` suppresses error messages about imports
   that cannot be resolved (see :ref:`follow-imports` for some examples).
+
+.. _ignore-missing-stubs:
+- ``--ignore-missing-stubs MODULE`` suppresses error messages about imports
+  for ``MODULE`` when it can be resolved but it lacks library stub files.
 
 - ``--strict-optional`` enables experimental strict checking of ``Optional[...]``
   types and ``None`` values. Without this option, mypy doesn't generally check the

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -147,6 +147,10 @@ overridden by the pattern sections matching the module name.
   pattern matching is used, the pattern should match the name of the
   *imported* module, not the module containing the import statement.
 
+- ``ignore_missing_stubs`` (List[str], default []) suppress error
+  messages about imports that are resolved but are missing library
+  stubs.
+
 - ``silent_imports`` (Boolean, deprecated) equivalent to
   ``follow_imports=skip`` plus ``ignore_missing_imports=True``.
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -710,7 +710,8 @@ class BuildManager:
         elif moduleinfo.is_third_party_module(target):
             if target not in self.options.ignore_missing_stubs:
                 self.errors.report(line, 0, "No library stub file for module '{}'".format(target))
-                self.errors.report(line, 0, "(To suppress this error add this module to --ignore-missing-stubs)",
+                self.errors.report(
+                    line, 0, "(To suppress this error add this module to --ignore-missing-stubs)",
                     severity='note', only_once=True)
                 self.errors.report(line, 0, stub_msg, severity='note', only_once=True)
         else:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -708,8 +708,11 @@ class BuildManager:
                 line, 0, "No library stub file for standard library module '{}'".format(target))
             self.errors.report(line, 0, stub_msg, severity='note', only_once=True)
         elif moduleinfo.is_third_party_module(target):
-            self.errors.report(line, 0, "No library stub file for module '{}'".format(target))
-            self.errors.report(line, 0, stub_msg, severity='note', only_once=True)
+            if target not in self.options.ignore_missing_stubs:
+                self.errors.report(line, 0, "No library stub file for module '{}'".format(target))
+                self.errors.report(line, 0, "(To suppress this error add this module to --ignore-missing-stubs)",
+                    severity='note', only_once=True)
+                self.errors.report(line, 0, stub_msg, severity='note', only_once=True)
         else:
             self.errors.report(line, 0, "Cannot find module named '{}'".format(target))
             self.errors.report(line, 0, '(Perhaps setting MYPYPATH '

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -765,6 +765,14 @@ def parse_section(prefix: str, template: Options,
         try:
             if ct is bool:
                 v = section.getboolean(key)  # type: ignore  # Until better stub
+            elif ct is list:
+                value = section.get(key)
+                if value is None:
+                    print("%s: %s: value is None" % (prefix, key), file=sys.stderr)
+                    continue
+                else:
+                    # based on suggestion here: https://stackoverflow.com/a/335754/755934
+                    v = [item.strip() for item in value.split(",")]
             elif callable(ct):
                 try:
                     v = ct(section.get(key))

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -262,6 +262,8 @@ def process_options(args: List[str],
                         const=defaults.PYTHON2_VERSION, help="use Python 2 mode")
     parser.add_argument('--ignore-missing-imports', action='store_true',
                         help="silently ignore imports of missing modules")
+    parser.add_argument('--ignore-missing-stubs', nargs='+', metavar='MODULE', default=[],
+                        help="silently ignore missing library stubs for the specified modules")
     parser.add_argument('--follow-imports', choices=['normal', 'silent', 'skip', 'error'],
                         default='normal', help="how to treat imports (default normal)")
     parser.add_argument('--disallow-any-unimported', default=False, action='store_true',

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -8,7 +8,7 @@ import re
 import sys
 import time
 
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple, Callable
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple, Callable, Union
 
 from mypy import build
 from mypy import defaults
@@ -205,6 +205,18 @@ def invert_flag_name(flag: str) -> str:
     return '--no-{}'.format(flag[2:])
 
 
+class IgnoreMissingStubsParseAction(argparse.Action):
+    def __call__(self, parser: argparse.ArgumentParser,
+                namespace: argparse.Namespace, values: Union[str, Sequence[Any], None],
+                option_string: str = "") -> None:
+        if not isinstance(values, str):
+            # this should never happen
+            parser.error("%s: %s" % (option_string, "Argument must be of type string"))
+            return  # this should never be reached because parser.error should exit the program
+        modules = [m.strip() for m in values.split(",")]
+        namespace.ignore_missing_stubs = modules
+
+
 def process_options(args: List[str],
                     require_targets: bool = True
                     ) -> Tuple[List[BuildSource], Options]:
@@ -262,7 +274,8 @@ def process_options(args: List[str],
                         const=defaults.PYTHON2_VERSION, help="use Python 2 mode")
     parser.add_argument('--ignore-missing-imports', action='store_true',
                         help="silently ignore imports of missing modules")
-    parser.add_argument('--ignore-missing-stubs', nargs='+', metavar='MODULE', default=[],
+    parser.add_argument('--ignore-missing-stubs', action=IgnoreMissingStubsParseAction,
+                        metavar="MODULE-1[,MODULE-2...]",
                         help="silently ignore missing library stubs for the specified modules")
     parser.add_argument('--follow-imports', choices=['normal', 'silent', 'skip', 'error'],
                         default='normal', help="how to treat imports (default normal)")

--- a/mypy/moduleinfo.py
+++ b/mypy/moduleinfo.py
@@ -228,6 +228,7 @@ third_party_modules = {
 
     # for use in tests
     '__dummy_third_party1',
+    '__dummy_third_party2'
 }
 
 # Modules and packages common to Python 2.7 and 3.x.

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -59,7 +59,7 @@ class Options:
         self.mypy_path = []  # type: List[str]
         self.report_dirs = {}  # type: Dict[str, str]
         self.ignore_missing_imports = False
-        self.ignore_missing_stubs = [] # type: List[str]
+        self.ignore_missing_stubs = []  # type: List[str]
         self.follow_imports = 'normal'  # normal|silent|skip|error
 
         # disallow_any options

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -19,6 +19,7 @@ class Options:
 
     PER_MODULE_OPTIONS = {
         "ignore_missing_imports",
+        "ignore_missing_stubs",
         "follow_imports",
         "disallow_any_generics",
         "disallow_any_unimported",
@@ -58,6 +59,7 @@ class Options:
         self.mypy_path = []  # type: List[str]
         self.report_dirs = {}  # type: Dict[str, str]
         self.ignore_missing_imports = False
+        self.ignore_missing_stubs = [] # type: List[str]
         self.follow_imports = 'normal'  # normal|silent|skip|error
 
         # disallow_any options

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -28,6 +28,7 @@ typecheck_files = [
     'check-statements.test',
     'check-generics.test',
     'check-dynamic-typing.test',
+    'check-ignore-missing-stubs.test',
     'check-inference.test',
     'check-inference-context.test',
     'check-kwargs.test',

--- a/test-data/unit/check-ignore-missing-stubs.test
+++ b/test-data/unit/check-ignore-missing-stubs.test
@@ -1,46 +1,60 @@
--- Test cases for the --ignore-missing-stubs command line flag
+-- Test cases for the --ignore-missing-stubs command line option
+-- Also test ignore_missing_stubs config file option
 
-[case testIgnoreMissingStubsErrorOnMissingImport]
+-- these testcases are for the command line option
+
+[case testIgnoreMissingStubs_Cli_IgnoreNothingFail]
 import missing # Expect error here
 [out]
 main:1: error: Cannot find module named 'missing'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 
-[case testIgnoreMissingStubs_OneModuleCommandLineFail]
+[case testIgnoreMissingStubs_Cli_IgnoreOneModuleFail]
 import __dummy_third_party1 # third-party module without type defs
 [out]
 main:1: error: No library stub file for module '__dummy_third_party1'
 main:1: note: (To suppress this error add this module to --ignore-missing-stubs)
 main:1: note: (Stub files are from https://github.com/python/typeshed)
 
-[case testIgnoreMissingStubs_OneModuleCommandLinePass]
+[case testIgnoreMissingStubs_Cli_IgnoreOneModulePass]
 # flags: --ignore-missing-stubs __dummy_third_party1
 import __dummy_third_party1 # third-party module without type defs
 
-[case testIgnoreMissingStubs_TwoModulesCommandLineFail]
+[case testIgnoreMissingStubs_Cli_IgnoreTwoModulesFail]
 # flags: --ignore-missing-stubs __dummy_third_party1
 import __dummy_third_party1 # third-party module without type defs
-import __dummy_third_party2
+import __dummy_third_party2 # third-party module without type defs
 [out]
 main:3: error: No library stub file for module '__dummy_third_party2'
 main:3: note: (To suppress this error add this module to --ignore-missing-stubs)
 main:3: note: (Stub files are from https://github.com/python/typeshed)
 
-[case testIgnoreMissingStubs_TwoModulesCommandLineBothFail]
+[case testIgnoreMissingStubs_Cli_IgnoreTwoModulesFail]
 import __dummy_third_party1 # third-party module without type defs
-import __dummy_third_party2
+import __dummy_third_party2 # third-party module without type defs
 [out]
 main:1: error: No library stub file for module '__dummy_third_party1'
 main:1: note: (To suppress this error add this module to --ignore-missing-stubs)
 main:1: note: (Stub files are from https://github.com/python/typeshed)
 main:2: error: No library stub file for module '__dummy_third_party2'
 
-[case testIgnoreMissingStubs_TwoModulesCommandLinePass]
-# flags: --ignore-missing-stubs __dummy_third_party1 __dummy_third_party2
+[case testIgnoreMissingStubs_Cli_IgnoreTwoModulesWrongModules]
+# flags: --ignore-missing-stubs __dummy_third_party2,bar
+import __dummy_third_party1 # third-party module without type defs
+import __dummy_third_party2 # third-party module without type defs
+[out]
+main:2: error: No library stub file for module '__dummy_third_party1'
+main:2: note: (To suppress this error add this module to --ignore-missing-stubs)
+main:2: note: (Stub files are from https://github.com/python/typeshed)
+
+[case testIgnoreMissingStubs_Cli_IgnoreTwoModulesPass]
+# flags: --ignore-missing-stubs __dummy_third_party1,__dummy_third_party2
 import __dummy_third_party1 # third-party module without type defs
 import __dummy_third_party2 # third-party module without type defs
 
-[case testIgnoreMissingStubs_IgnoreOneModule]
+-- these testcases are for the config option
+
+[case testIgnoreMissingStubs_Config_IgnoreOneModule]
 # flags: --config-file tmp/mypy.ini
 import __dummy_third_party1 # third-party module without type defs
 import __dummy_third_party2 # third-party module without type defs
@@ -52,7 +66,7 @@ main:3: error: No library stub file for module '__dummy_third_party2'
 main:3: note: (To suppress this error add this module to --ignore-missing-stubs)
 main:3: note: (Stub files are from https://github.com/python/typeshed)
 
-[case testIgnoreMissingStubs_IgnoreWrongModule]
+[case testIgnoreMissingStubs_Config_IgnoreWrongModule]
 # flags: --config-file tmp/mypy.ini
 import __dummy_third_party1 # third-party module without type defs
 import __dummy_third_party2 # third-party module without type defs
@@ -65,10 +79,18 @@ main:2: note: (To suppress this error add this module to --ignore-missing-stubs)
 main:2: note: (Stub files are from https://github.com/python/typeshed)
 main:3: error: No library stub file for module '__dummy_third_party2'
 
-[case testIgnoreMissingStubs_IgnoreBothModules]
+[case testIgnoreMissingStubs_Config_IgnoreBothModules]
 # flags: --config-file tmp/mypy.ini
 import __dummy_third_party1 # third-party module without type defs
 import __dummy_third_party2 # third-party module without type defs
 [file mypy.ini]
 [[mypy]
 ignore_missing_stubs = __dummy_third_party1, __dummy_third_party2
+
+[case testIgnoreMissingStubs_Config_IgnoreBothModulesNoSpaces]
+# flags: --config-file tmp/mypy.ini
+import __dummy_third_party1 # third-party module without type defs
+import __dummy_third_party2 # third-party module without type defs
+[file mypy.ini]
+[[mypy]
+ignore_missing_stubs = __dummy_third_party1,__dummy_third_party2

--- a/test-data/unit/check-ignore-missing-stubs.test
+++ b/test-data/unit/check-ignore-missing-stubs.test
@@ -1,0 +1,74 @@
+-- Test cases for the --ignore-missing-stubs command line flag
+
+[case testIgnoreMissingStubsErrorOnMissingImport]
+import missing # Expect error here
+[out]
+main:1: error: Cannot find module named 'missing'
+main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+
+[case testIgnoreMissingStubs_OneModuleCommandLineFail]
+import __dummy_third_party1 # third-party module without type defs
+[out]
+main:1: error: No library stub file for module '__dummy_third_party1'
+main:1: note: (To suppress this error add this module to --ignore-missing-stubs)
+main:1: note: (Stub files are from https://github.com/python/typeshed)
+
+[case testIgnoreMissingStubs_OneModuleCommandLinePass]
+# flags: --ignore-missing-stubs __dummy_third_party1
+import __dummy_third_party1 # third-party module without type defs
+
+[case testIgnoreMissingStubs_TwoModulesCommandLineFail]
+# flags: --ignore-missing-stubs __dummy_third_party1
+import __dummy_third_party1 # third-party module without type defs
+import __dummy_third_party2
+[out]
+main:3: error: No library stub file for module '__dummy_third_party2'
+main:3: note: (To suppress this error add this module to --ignore-missing-stubs)
+main:3: note: (Stub files are from https://github.com/python/typeshed)
+
+[case testIgnoreMissingStubs_TwoModulesCommandLineBothFail]
+import __dummy_third_party1 # third-party module without type defs
+import __dummy_third_party2
+[out]
+main:1: error: No library stub file for module '__dummy_third_party1'
+main:1: note: (To suppress this error add this module to --ignore-missing-stubs)
+main:1: note: (Stub files are from https://github.com/python/typeshed)
+main:2: error: No library stub file for module '__dummy_third_party2'
+
+[case testIgnoreMissingStubs_TwoModulesCommandLinePass]
+# flags: --ignore-missing-stubs __dummy_third_party1 __dummy_third_party2
+import __dummy_third_party1 # third-party module without type defs
+import __dummy_third_party2 # third-party module without type defs
+
+[case testIgnoreMissingStubs_IgnoreOneModule]
+# flags: --config-file tmp/mypy.ini
+import __dummy_third_party1 # third-party module without type defs
+import __dummy_third_party2 # third-party module without type defs
+[file mypy.ini]
+[[mypy]
+ignore_missing_stubs = __dummy_third_party1
+[out]
+main:3: error: No library stub file for module '__dummy_third_party2'
+main:3: note: (To suppress this error add this module to --ignore-missing-stubs)
+main:3: note: (Stub files are from https://github.com/python/typeshed)
+
+[case testIgnoreMissingStubs_IgnoreWrongModule]
+# flags: --config-file tmp/mypy.ini
+import __dummy_third_party1 # third-party module without type defs
+import __dummy_third_party2 # third-party module without type defs
+[file mypy.ini]
+[[mypy]
+ignore_missing_stubs = foo
+[out]
+main:2: error: No library stub file for module '__dummy_third_party1'
+main:2: note: (To suppress this error add this module to --ignore-missing-stubs)
+main:2: note: (Stub files are from https://github.com/python/typeshed)
+main:3: error: No library stub file for module '__dummy_third_party2'
+
+[case testIgnoreMissingStubs_IgnoreBothModules]
+# flags: --config-file tmp/mypy.ini
+import __dummy_third_party1 # third-party module without type defs
+import __dummy_third_party2 # third-party module without type defs
+[file mypy.ini]
+[[mypy]
+ignore_missing_stubs = __dummy_third_party1, __dummy_third_party2

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1295,6 +1295,7 @@ y = 1
 import __dummy_third_party1
 [out]
 main:1: error: No library stub file for module '__dummy_third_party1'
+main:1: note: (To suppress this error add this module to --ignore-missing-stubs)
 main:1: note: (Stub files are from https://github.com/python/typeshed)
 
 [case testMissingStubForStdLibModule]


### PR DESCRIPTION
--ignore-missing-stubs MODULE-1 [MODULE-2 ...] will suppress missing typeshed information for the specified modules

Includes tests for both command-line and config file invocations

Fixes issue #3905