### PR TITLE
Fix order of processing of deferred nodes in fine-grained mode

### DIFF
--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -810,12 +810,11 @@ def reprocess_nodes(manager: BuildManager,
     old_symbols = {name: names.copy() for name, names in old_symbols.items()}
 
     def key(node: DeferredNode) -> int:
-        # Unlike for modules which are soreted by name within SCC,
-        # nodes within the same module are sprted by line number, because
+        # Unlike modules which are sorted by name within SCC,
+        # nodes within the same module are sorted by line number, because
         # this is how they are processed in normal mode.
         return node.node.line
 
-    # Sort nodes by full name so that the order of processing is deterministic.
     nodes = sorted(nodeset, key=key)
 
     # TODO: ignore_all argument to set_file_ignored_lines

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -809,18 +809,11 @@ def reprocess_nodes(manager: BuildManager,
     old_symbols = find_symbol_tables_recursive(file_node.fullname(), file_node.names)
     old_symbols = {name: names.copy() for name, names in old_symbols.items()}
 
-    def key(node: DeferredNode) -> str:
-        fullname = node.node.fullname()
-        if fullname is None:
-            if isinstance(node.node, FuncDef):
-                info = node.node.info
-            elif isinstance(node.node, OverloadedFuncDef):
-                info = node.node.items[0].info
-            else:
-                assert False, "'None' fullname for %s instance" % type(node.node)
-            assert info is not None
-            fullname = '%s.%s' % (info.fullname(), node.node.name())
-        return fullname
+    def key(node: DeferredNode) -> int:
+        # Unlike for modules which are soreted by name within SCC,
+        # nodes within the same module are sprted by line number, because
+        # this is how they are processed in normal mode.
+        return node.node.line
 
     # Sort nodes by full name so that the order of processing is deterministic.
     nodes = sorted(nodeset, key=key)

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1564,6 +1564,26 @@ class C:
 main:5: error: Too few arguments for "__init__" of "C"
 main:6: error: Too few arguments for "D"
 
+[case testInferAttributeTypeAndMultipleStaleTargets]
+import a
+
+class A:
+    def g(self) -> None:
+        a.x
+        self.x = 1
+
+    def f(self) -> None:
+        a.x
+        b = self.x
+        self.x = 1
+
+[file a.py]
+x = 0
+[file a.py.2]
+x = ''
+[out]
+==
+
 [case testNamedTupleUpdate]
 import b
 [file a.py]


### PR DESCRIPTION
This fixes the order of processing of deferred nodes in fine-grained incremental mode. (This reflects how they are processed in normal, i.e. full, mode.)

Fixes #4465 