### PR TITLE
Display arg name, not number, for functions called with kwargs

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -26,7 +26,8 @@ from mypy.nodes import (
     TypeInfo, Context, MypyFile, op_methods, FuncDef, reverse_type_aliases,
     ARG_POS, ARG_OPT, ARG_NAMED, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2,
     ReturnStmt, NameExpr, Var, CONTRAVARIANT, COVARIANT, SymbolNode,
-    CallExpr)
+    CallExpr
+)
 
 
 # Constants that represent simple type checker error message, i.e. messages
@@ -635,17 +636,16 @@ class MessageBuilder:
             elif arg_kind == ARG_STAR2:
                 arg_type_str = '**' + arg_type_str
 
-            # For function calls with keyword arguments, use the argument name instead of the
+            # For function calls with keyword arguments, display the argument name rather than the
             # number.
-            arg_name = context.arg_names[n - 1] if isinstance(context, CallExpr) else None
-            if arg_name:
-                message_format = 'Argument "{}" {}has incompatible type {}; expected {}'
-            else:
-                message_format = 'Argument {} {}has incompatible type {}; expected {}'
-                arg_name = str(n)
+            arg_label = str(n)
+            if isinstance(context, CallExpr):
+                arg_name = context.arg_names[n - 1]
+                if arg_name is not None:
+                    arg_label = '"{}"'.format(arg_name)
 
-            msg = message_format.format(
-                arg_name, target, self.quote_type_string(arg_type_str),
+            msg = 'Argument {} {}has incompatible type {}; expected {}'.format(
+                arg_label, target, self.quote_type_string(arg_type_str),
                 self.quote_type_string(expected_type_str))
             if isinstance(arg_type, Instance) and isinstance(expected_type, Instance):
                 notes = append_invariance_notes(notes, arg_type, expected_type)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -635,13 +635,15 @@ class MessageBuilder:
             elif arg_kind == ARG_STAR2:
                 arg_type_str = '**' + arg_type_str
 
-            # For call expressions with keyword arguments, use the keyword argument.
+            # For function calls with keyword arguments, use the argument name instead of the
+            # number.
             arg_name = context.arg_names[n - 1] if isinstance(context, CallExpr) else None
             if arg_name:
                 message_format = 'Argument "{}" {}has incompatible type {}; expected {}'
             else:
                 message_format = 'Argument {} {}has incompatible type {}; expected {}'
                 arg_name = n
+
             msg = message_format.format(
                 arg_name, target, self.quote_type_string(arg_type_str),
                 self.quote_type_string(expected_type_str))

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -642,7 +642,7 @@ class MessageBuilder:
                 message_format = 'Argument "{}" {}has incompatible type {}; expected {}'
             else:
                 message_format = 'Argument {} {}has incompatible type {}; expected {}'
-                arg_name = n
+                arg_name = str(n)
 
             msg = message_format.format(
                 arg_name, target, self.quote_type_string(arg_type_str),

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -114,7 +114,7 @@ class N(NamedTuple):
     b: str
 
 n = N('x', 'x') # E: Argument 1 to "N" has incompatible type "str"; expected "int"
-n = N(1, b=2)   # E: Argument 2 to "N" has incompatible type "int"; expected "str"
+n = N(1, b=2)   # E: Argument "b" to "N" has incompatible type "int"; expected "str"
 N(1, 'x')
 N(b='x', a=1)
 
@@ -283,7 +283,7 @@ class X(NamedTuple):
 x: X
 reveal_type(x._replace())  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
 x._replace(x=5)
-x._replace(y=5)  # E: Argument 1 to "_replace" of "X" has incompatible type "int"; expected "str"
+x._replace(y=5)  # E: Argument "y" to "_replace" of "X" has incompatible type "int"; expected "str"
 
 [case testNewNamedTupleFields]
 # flags: --python-version 3.6

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1978,7 +1978,7 @@ class C:
 
 x = C(foo=12)
 x.a # E: "C" has no attribute "a"
-C(foo='') # E: Argument 1 to "C" has incompatible type "str"; expected "int"
+C(foo='') # E: Argument "foo" to "C" has incompatible type "str"; expected "int"
 [builtins fixtures/__new__.pyi]
 
 [case testConstructInstanceWithDynamicallyTyped__new__]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1584,7 +1584,7 @@ d() # E: "Dict[str, int]" not callable
 d2 = dict(it, x='') # E: Cannot infer type argument 2 of "dict"
 d2() # E: "Dict[Any, Any]" not callable
 
-d3 = dict(it, x='') # type: Dict[str, int] # E: Argument 2 to "dict" has incompatible type "str"; expected "int"
+d3 = dict(it, x='') # type: Dict[str, int] # E: Argument "x" to "dict" has incompatible type "str"; expected "int"
 [builtins fixtures/dict.pyi]
 
 [case testDictFromIterableAndKeywordArg2]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1717,7 +1717,7 @@ def a(f: Callable[[NamedArg(int, 'x')], int]):
     f(2) # E: Too many positional arguments
     f() # E: Missing named argument "x"
     f(y=3) # E: Unexpected keyword argument "y"
-    f(x="foo") # E: Argument 1 has incompatible type "str"; expected "int"
+    f(x="foo") # E: Argument "x" has incompatible type "str"; expected "int"
 [builtins fixtures/dict.pyi]
 
 [case testCallableWithKeywordOnlyOptionalArg]
@@ -1729,7 +1729,7 @@ def a(f: Callable[[DefaultNamedArg(int, 'x')], int]):
     f(2) # E: Too many positional arguments
     f()
     f(y=3) # E: Unexpected keyword argument "y"
-    f(x="foo") # E: Argument 1 has incompatible type "str"; expected "int"
+    f(x="foo") # E: Argument "x" has incompatible type "str"; expected "int"
 [builtins fixtures/dict.pyi]
 
 [case testCallableWithKwargs]
@@ -1742,7 +1742,7 @@ def a(f: Callable[[KwArg(int)], int]):
     f()
     f(y=3)
     f(x=4, y=3, z=10)
-    f(x="foo") # E: Argument 1 has incompatible type "str"; expected "int"
+    f(x="foo") # E: Argument "x" has incompatible type "str"; expected "int"
 [builtins fixtures/dict.pyi]
 
 

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -10,14 +10,14 @@ f(o=None()) # E: "None" not callable
 import typing
 def f(a: 'A') -> None: pass
 f(a=A())
-f(a=object()) # E: Argument 1 to "f" has incompatible type "object"; expected "A"
+f(a=object()) # E: Argument "a" to "f" has incompatible type "object"; expected "A"
 class A: pass
 
 [case testTwoKeywordArgumentsNotInOrder]
 import typing
 def f(a: 'A', b: 'B') -> None: pass
-f(b=A(), a=A()) # E: Argument 1 to "f" has incompatible type "A"; expected "B"
-f(b=B(), a=B()) # E: Argument 2 to "f" has incompatible type "B"; expected "A"
+f(b=A(), a=A()) # E: Argument "b" to "f" has incompatible type "A"; expected "B"
+f(b=B(), a=B()) # E: Argument "a" to "f" has incompatible type "B"; expected "A"
 f(a=A(), b=B())
 f(b=B(), a=A())
 class A: pass
@@ -30,10 +30,10 @@ f(a=A())
 f(b=B())
 f(c=C())
 f(b=B(), c=C())
-f(a=B()) # E: Argument 1 to "f" has incompatible type "B"; expected "Optional[A]"
-f(b=A()) # E: Argument 1 to "f" has incompatible type "A"; expected "Optional[B]"
-f(c=B()) # E: Argument 1 to "f" has incompatible type "B"; expected "Optional[C]"
-f(b=B(), c=A()) # E: Argument 2 to "f" has incompatible type "A"; expected "Optional[C]"
+f(a=B()) # E: Argument "a" to "f" has incompatible type "B"; expected "Optional[A]"
+f(b=A()) # E: Argument "b" to "f" has incompatible type "A"; expected "Optional[B]"
+f(c=B()) # E: Argument "c" to "f" has incompatible type "B"; expected "Optional[C]"
+f(b=B(), c=A()) # E: Argument "c" to "f" has incompatible type "A"; expected "Optional[C]"
 class A: pass
 class B: pass
 class C: pass
@@ -41,7 +41,7 @@ class C: pass
 [case testBothPositionalAndKeywordArguments]
 import typing
 def f(a: 'A', b: 'B') -> None: pass
-f(A(), b=A()) # E: Argument 2 to "f" has incompatible type "A"; expected "B"
+f(A(), b=A()) # E: Argument "b" to "f" has incompatible type "A"; expected "B"
 f(A(), b=B())
 class A: pass
 class B: pass
@@ -182,7 +182,7 @@ f(A(), b=B())
 f(A(), A(), b=B())
 f(B())      # E: Argument 1 to "f" has incompatible type "B"; expected "A"
 f(A(), B()) # E: Argument 2 to "f" has incompatible type "B"; expected "A"
-f(b=A())    # E: Argument 1 to "f" has incompatible type "A"; expected "Optional[B]"
+f(b=A())    # E: Argument "b" to "f" has incompatible type "A"; expected "Optional[B]"
 class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
@@ -197,8 +197,8 @@ f(b=B())
 f(*a, b=B())
 f(A(), *a, b=B())
 f(A(), B())   # E: Argument 2 to "f" has incompatible type "B"; expected "A"
-f(A(), b=A()) # E: Argument 2 to "f" has incompatible type "A"; expected "Optional[B]"
-f(*a, b=A())  # E: Argument 2 to "f" has incompatible type "A"; expected "Optional[B]"
+f(A(), b=A()) # E: Argument "b" to "f" has incompatible type "A"; expected "Optional[B]"
+f(*a, b=A())  # E: Argument "b" to "f" has incompatible type "A"; expected "Optional[B]"
 class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
@@ -238,7 +238,7 @@ def f( **kwargs: 'A') -> None: pass
 f()
 f(x=A())
 f(y=A(), z=A())
-f(x=B()) # E: Argument 1 to "f" has incompatible type "B"; expected "A"
+f(x=B()) # E: Argument "x" to "f" has incompatible type "B"; expected "A"
 f(A())   # E: Too many arguments for "f"
 # Perhaps a better message would be "Too many *positional* arguments..."
 class A: pass
@@ -334,7 +334,7 @@ class A: pass
 import typing
 def f(x): # type: (int) -> str # N: "f" defined here
     pass
-f(x='') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
+f(x='') # E: Argument "x" to "f" has incompatible type "str"; expected "int"
 f(x=0)
 f(y=0) # E: Unexpected keyword argument "y" for "f"
 
@@ -343,7 +343,7 @@ import typing
 class A:
     def f(self, x): # type: (int) -> str  # N: "f" of "A" defined here
         pass
-A().f(x='') # E: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+A().f(x='') # E: Argument "x" to "f" of "A" has incompatible type "str"; expected "int"
 A().f(x=0)
 A().f(y=0) # E: Unexpected keyword argument "y" for "f" of "A"
 
@@ -353,8 +353,8 @@ def f(**kwargs): # type: (**int) -> None
     pass
 f(z=1)
 f(x=1, y=1)
-f(x='', y=1) # E: Argument 1 to "f" has incompatible type "str"; expected "int"
-f(x=1, y='') # E: Argument 2 to "f" has incompatible type "str"; expected "int"
+f(x='', y=1) # E: Argument "x" to "f" has incompatible type "str"; expected "int"
+f(x=1, y='') # E: Argument "y" to "f" has incompatible type "str"; expected "int"
 [builtins fixtures/dict.pyi]
 
 [case testCallsWithStars]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -111,7 +111,7 @@ from typing import NamedTuple
 N = NamedTuple('N', [('a', int),
                      ('b', str)])
 n = N('x', 'x') # E: Argument 1 to "N" has incompatible type "str"; expected "int"
-n = N(1, b=2)   # E: Argument 2 to "N" has incompatible type "int"; expected "str"
+n = N(1, b=2)   # E: Argument "b" to "N" has incompatible type "int"; expected "str"
 N(1, 'x')
 N(b='x', a=1)
 
@@ -279,7 +279,7 @@ X = NamedTuple('X', [('x', int), ('y', str)])
 x = None  # type: X
 reveal_type(x._replace())  # E: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
 x._replace(x=5)
-x._replace(y=5)  # E: Argument 1 to "_replace" of "X" has incompatible type "int"; expected "str"
+x._replace(y=5)  # E: Argument "y" to "_replace" of "X" has incompatible type "int"; expected "str"
 
 [case testNamedTupleMake]
 from typing import NamedTuple

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -168,7 +168,7 @@ from b import f
 f('', z=1)           # Line 2
 f(1, 2, z=1)         # 3
 f(1, y=1, z=1)       # 4
-f(1, '', 2, '', z=1) # 5testKeywordVarArgsAndCommentSignaturetestKeywordVarArgsAndCommentSignature
+f(1, '', 2, '', z=1) # 5
 f(1, '', z='')       # 6
 f(1, '', zz='', z=1) # 7
 f(1, '', z=1, foo=1) # 8

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -168,7 +168,7 @@ from b import f
 f('', z=1)           # Line 2
 f(1, 2, z=1)         # 3
 f(1, y=1, z=1)       # 4
-f(1, '', 2, '', z=1) # 5
+f(1, '', 2, '', z=1) # 5testKeywordVarArgsAndCommentSignaturetestKeywordVarArgsAndCommentSignature
 f(1, '', z='')       # 6
 f(1, '', zz='', z=1) # 7
 f(1, '', z=1, foo=1) # 8
@@ -183,11 +183,11 @@ def f(x: int,
 [out2]
 tmp/a.py:2: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 tmp/a.py:3: error: Argument 2 to "f" has incompatible type "int"; expected "str"
-tmp/a.py:4: error: Argument 2 to "f" has incompatible type "int"; expected "str"
+tmp/a.py:4: error: Argument "y" to "f" has incompatible type "int"; expected "str"
 tmp/a.py:5: error: Argument 4 to "f" has incompatible type "str"; expected "int"
-tmp/a.py:6: error: Argument 3 to "f" has incompatible type "str"; expected "int"
-tmp/a.py:7: error: Argument 3 to "f" has incompatible type "str"; expected "int"
-tmp/a.py:8: error: Argument 4 to "f" has incompatible type "int"; expected "str"
+tmp/a.py:6: error: Argument "z" to "f" has incompatible type "str"; expected "int"
+tmp/a.py:7: error: Argument "zz" to "f" has incompatible type "str"; expected "int"
+tmp/a.py:8: error: Argument "foo" to "f" has incompatible type "int"; expected "str"
 
 [case testSerializeOverloadedFunction]
 import a
@@ -920,7 +920,7 @@ tmp/a.py:5: error: Incompatible types in assignment (expression has type "Tuple[
 tmp/a.py:6: error: Incompatible types in assignment (expression has type "Tuple[int]", variable has type "N")
 tmp/a.py:9: error: Revealed type is 'Tuple[builtins.int, fallback=b.N]'
 tmp/a.py:10: error: Revealed type is 'builtins.int'
-tmp/a.py:11: error: Argument 1 to "N" has incompatible type "str"; expected "int"
+tmp/a.py:11: error: Argument "x" to "N" has incompatible type "str"; expected "int"
 
 --
 -- Types and type aliases


### PR DESCRIPTION
Fixes #4487.
The new error message is in this format:
```python
 C(foo='')  # E: Argument "foo" to "C" has incompatible type "str"; expected "int"
```