### PR TITLE
Tweak NamedTuple dep handling and remove it from TODO

### DIFF
--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -197,6 +197,8 @@ class DependencyVisitor(TraverserVisitor):
         # Add dependencies to base types.
         for base in o.info.bases:
             self.add_type_dependencies(base, target=target)
+        if o.info.tuple_type:
+            self.add_type_dependencies(base, target=make_trigger(target))
         # TODO: Add dependencies based on remaining TypeInfo attributes.
         super().visit_class_def(o)
         self.is_class = old_is_class

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -198,7 +198,7 @@ class DependencyVisitor(TraverserVisitor):
         for base in o.info.bases:
             self.add_type_dependencies(base, target=target)
         if o.info.tuple_type:
-            self.add_type_dependencies(base, target=make_trigger(target))
+            self.add_type_dependencies(o.info.tuple_type, target=make_trigger(target))
         # TODO: Add dependencies based on remaining TypeInfo attributes.
         super().visit_class_def(o)
         self.is_class = old_is_class

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -150,7 +150,6 @@ class DependencyVisitor(TraverserVisitor):
     # TODO (incomplete):
     #   from m import *
     #   await
-    #   named tuples
     #   TypedDict
     #   protocols
     #   metaclasses
@@ -237,7 +236,6 @@ class DependencyVisitor(TraverserVisitor):
     def visit_assignment_stmt(self, o: AssignmentStmt) -> None:
         # TODO: Implement all assignment special forms, including these:
         #   TypedDict
-        #   NamedTuple
         #   Enum
         #   type aliases
         rvalue = o.rvalue
@@ -255,6 +253,7 @@ class DependencyVisitor(TraverserVisitor):
                     typ = symnode.node.type
                     if typ:
                         self.add_type_dependencies(typ)
+                        self.add_type_dependencies(typ, target=make_trigger(prefix))
                         attr_target = make_trigger('%s.%s' % (prefix, name))
                         self.add_type_dependencies(typ, target=attr_target)
         else:

--- a/test-data/unit/deps-classes.test
+++ b/test-data/unit/deps-classes.test
@@ -20,7 +20,39 @@ class A: pass
 <m.N.__init__> -> m.f
 <m.N.a> -> m.f
 <m.N> -> m.f
-<a.A> -> <m.N.a>, m
+<a.A> -> <m.N.a>, <m.N>, m
+
+[case testNamedTuple2]
+from typing import NamedTuple, Any, Tuple
+from a import A, B
+N = NamedTuple('N', [('a', 'Tuple[A, B]')])
+
+def f(a: Any) -> None:
+    n = N(a)
+    n.a
+[file a.py]
+class A: pass
+class B: pass
+[out]
+<m.N.__init__> -> m.f
+<m.N.a> -> m.f
+<m.N> -> m.f
+<a.A> -> <m.N.a>, <m.N>, m
+<a.B> -> <m.N.a>, <m.N>, m
+
+[case namedTuple3]
+from typing import NamedTuple
+N = NamedTuple('N', [('x', int)])
+x = N(1)
+M = NamedTuple('M', [('z', 'N')])
+y = M(x)
+[out]
+<m.M.__init__> -> m
+<m.M> -> <m.y>, m
+<m.N.__init__> -> m
+<m.N> -> <m.M.z>, <m.M>, <m.x>, <m.y>, m
+<m.x> -> m
+<m.y> -> m
 
 [case testIfFalseInClassBody]
 class A:

--- a/test-data/unit/deps-classes.test
+++ b/test-data/unit/deps-classes.test
@@ -40,7 +40,7 @@ class B: pass
 <a.A> -> <m.N.a>, <m.N>, m
 <a.B> -> <m.N.a>, <m.N>, m
 
-[case namedTuple3]
+[case testNamedTuple3]
 from typing import NamedTuple
 N = NamedTuple('N', [('x', int)])
 x = N(1)
@@ -53,6 +53,23 @@ y = M(x)
 <m.N> -> <m.M.z>, <m.M>, <m.x>, <m.y>, m
 <m.x> -> m
 <m.y> -> m
+
+[case testNamedTuple4]
+from typing import NamedTuple, Any
+from a import A
+class N(NamedTuple):
+    a: A
+
+def f(a: Any) -> None:
+    n = N(a)
+    n.a
+[file a.py]
+class A: pass
+[out]
+<m.N.__init__> -> m.f
+<m.N.a> -> m.f
+<m.N> -> m.N, m.f
+<a.A> -> <m.N.a>, <m.N>, m, m.N
 
 [case testIfFalseInClassBody]
 class A:

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1649,3 +1649,23 @@ lol(b.x)
 ==
 c.py:7: error: Argument 1 to "lol" has incompatible type "M"; expected "Tuple[Tuple[int]]"
 c.py:9: error: Argument 1 to "lol" has incompatible type "M"; expected "Tuple[Tuple[int]]"
+
+[case testNamedTupleUpdate4]
+import b
+[file a.py]
+from typing import NamedTuple
+class N(NamedTuple):
+    x: int
+x = N(1)
+[file a.py.2]
+from typing import NamedTuple
+class N(NamedTuple):
+    x: str
+x = N('hi')
+[file b.py]
+import a
+def f(x: a.N) -> None:
+    pass
+f(a.x)
+[out]
+==

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1619,3 +1619,33 @@ def f(x: a.N) -> None:
 f(a.x)
 [out]
 ==
+
+[case testNamedTupleUpdate3]
+import c
+[file a.py]
+from typing import NamedTuple
+N = NamedTuple('N', [('x', int)])
+x = N(1)
+[file a.py.2]
+from typing import NamedTuple
+N = NamedTuple('N', [('x', str)])
+x = N('hi')
+[file b.py]
+import a
+from typing import NamedTuple
+M = NamedTuple('M', [('z', 'a.N')])
+x = M(a.x)
+[file c.py]
+import a
+import b
+from typing import Tuple
+def lol(n: Tuple[Tuple[int]]) -> None:
+    pass
+def f(x: b.M) -> None:
+    lol(x)
+f(b.x)
+lol(b.x)
+[out]
+==
+c.py:7: error: Argument 1 to "lol" has incompatible type "M"; expected "Tuple[Tuple[int]]"
+c.py:9: error: Argument 1 to "lol" has incompatible type "M"; expected "Tuple[Tuple[int]]"


### PR DESCRIPTION
For completeness, add dependency from member types to the trigger for
major namedtuple changes, since a change to a member type changes the
underlying tuple_type. In practice it seems that generating any
dependencies from NamedTuples might be redundant, since exposing the
underlying types as part of its TupleType means that any clients will
already have those dependencies.

Adds a bunch of tests because I was convinced there had to be a bug related to that.