### PR TITLE
Don't warn about unrecognized options starting with 'x_'

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -755,6 +755,8 @@ def parse_section(prefix: str, template: Options,
                         print("%s: Unrecognized report type: %s" % (prefix, orig_key),
                               file=sys.stderr)
                     continue
+                if key.startswith('x_'):
+                    continue  # Don't complain about `x_blah` flags
                 print("%s: Unrecognized option: %s = %s" % (prefix, key, section[orig_key]),
                       file=sys.stderr)
                 continue

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -441,6 +441,14 @@ ignore_missing_imports = True
 [out]
 main.py:2: error: Revealed type is 'Any'
 
+[case testConfigNoErrorForUnknownXFlagInSubsection]
+# cmd: mypy -c pass
+[file mypy.ini]
+[[mypy]
+[[mypy-foo]
+x_bad = 0
+[out]
+
 [case testDotInFilenameOKScript]
 # cmd: mypy a.b.py c.d.pyi
 [file a.b.py]


### PR DESCRIPTION
Fixes #4521