### PR TITLE
Rename variable, OSError.filename will have union type (typeshed #1852)

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -315,11 +315,11 @@ class DataDrivenTestCase(BaseTestCase):
                     # a bug in a test case -- we shouldn't leave
                     # garbage lying around. By nuking the directory,
                     # the next test run hopefully passes.
-                    path = error.filename
+                    error_path = error.filename
                     # Be defensive -- only call rmtree if we're sure we aren't removing anything
                     # valuable.
-                    if path.startswith(test_temp_dir + '/') and os.path.isdir(path):
-                        shutil.rmtree(path)
+                    if error_path.startswith(test_temp_dir + '/') and os.path.isdir(error_path):
+                        shutil.rmtree(error_path)
                     raise
         super().teardown()
 


### PR DESCRIPTION
See https://github.com/python/typeshed/pull/1852, I want to change the type of `OSError.filename` to `Union[str, bytes, None]`, but since the `path` variable is inferred to have `str` type, this causes a Mypy error.

On the other hand, the `path = error.filename` assignment seems of questionable value anyway, since `path` already contained the path. But I may be missing something so I erred on the side of caution of not (potentially) changing the behavior.