### PR TITLE
During fine-grained cache loading, use the real path, not the cached

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -281,7 +281,7 @@ class Server:
             for meta, mypyfile, type_map in manager.saved_cache.values():
                 if meta.mtime is None: continue
                 self.fswatcher.set_file_data(
-                    meta.path,
+                    mypyfile.path,
                     FileData(st_mtime=float(meta.mtime), st_size=meta.size, md5=meta.hash))
 
             # Run an update


### PR DESCRIPTION
The path in the cache file will be a full path possibly from some
build machine, and so might not match what is actually on disk
locally. This can cause changes to be missed in the initial run.