### PR TITLE
Clean up handling of STRICT_OPTIONAL flag

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -494,8 +494,6 @@ def process_options(args: List[str],
     if options.strict_optional_whitelist is not None:
         # TODO: Deprecate, then kill this flag
         options.strict_optional = True
-    if options.strict_optional:
-        experiments.STRICT_OPTIONAL = True
     if special_opts.find_occurrences:
         experiments.find_occurrences = special_opts.find_occurrences.split('.')
         assert experiments.find_occurrences is not None

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -86,32 +86,24 @@ class TypeCheckSuite(DataSuite):
         incremental = ('incremental' in testcase.name.lower()
                        or 'incremental' in testcase.file
                        or 'serialize' in testcase.file)
-        optional = 'optional' in testcase.file
-        old_strict_optional = experiments.STRICT_OPTIONAL
-        try:
-            if incremental:
-                # Incremental tests are run once with a cold cache, once with a warm cache.
-                # Expect success on first run, errors from testcase.output (if any) on second run.
-                # We briefly sleep to make sure file timestamps are distinct.
-                self.clear_cache()
-                num_steps = max([2] + list(testcase.output2.keys()))
-                # Check that there are no file changes beyond the last run (they would be ignored).
-                for dn, dirs, files in os.walk(os.curdir):
-                    for file in files:
-                        m = re.search(r'\.([2-9])$', file)
-                        if m and int(m.group(1)) > num_steps:
-                            raise ValueError(
-                                'Output file {} exists though test case only has {} runs'.format(
-                                    file, num_steps))
-                for step in range(1, num_steps + 1):
-                    self.run_case_once(testcase, step)
-            elif optional:
-                experiments.STRICT_OPTIONAL = True
-                self.run_case_once(testcase)
-            else:
-                self.run_case_once(testcase)
-        finally:
-            experiments.STRICT_OPTIONAL = old_strict_optional
+        if incremental:
+            # Incremental tests are run once with a cold cache, once with a warm cache.
+            # Expect success on first run, errors from testcase.output (if any) on second run.
+            # We briefly sleep to make sure file timestamps are distinct.
+            self.clear_cache()
+            num_steps = max([2] + list(testcase.output2.keys()))
+            # Check that there are no file changes beyond the last run (they would be ignored).
+            for dn, dirs, files in os.walk(os.curdir):
+                for file in files:
+                    m = re.search(r'\.([2-9])$', file)
+                    if m and int(m.group(1)) > num_steps:
+                        raise ValueError(
+                            'Output file {} exists though test case only has {} runs'.format(
+                                file, num_steps))
+            for step in range(1, num_steps + 1):
+                self.run_case_once(testcase, step)
+        else:
+            self.run_case_once(testcase)
 
     def clear_cache(self) -> None:
         dn = defaults.CACHE_DIR

--- a/mypy/test/testdmypy.py
+++ b/mypy/test/testdmypy.py
@@ -47,6 +47,7 @@ class DmypySuite(DataSuite):
     files = dmypy_files
     base_path = test_temp_dir
     optional_out = True
+    test_name_suffix = '_dmypy'
 
     @classmethod
     def filter(cls, testcase: DataDrivenTestCase) -> bool:

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3467,6 +3467,19 @@ tmp/main.py:2: error: Expression has type "Any"
 [out2]
 tmp/main.py:2: error: Expression has type "Any"
 
+[case testIncrementalStrictOptional]
+# flags: --strict-optional
+import a
+1 + a.foo()
+[file a.py]
+def foo() -> int: return 0
+[file a.py.2]
+from typing import Optional
+def foo() -> Optional[int]: return 0
+[out1]
+[out2]
+main:3: error: Unsupported operand types for + ("int" and "Optional[int]")
+
 [case testDeletedDepLineNumber]
 # The import is not on line 1 and that data should be preserved
 import a


### PR DESCRIPTION
STRICT_OPTIONAL is managed with strict_optional_set based on
options.strict_optional. It doesn't need to be set directly anymore,
so get rid of the code that does it.

In addition to the code cleanup, this fixes a bug where using strict
optional in a test case run by testdmypy would cause the strict
optional state to leak, causing nondeterministic test failures in unit
tests.