### PR TITLE
[Doc] mypy skips check function return None as a common issue

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -51,6 +51,11 @@ flagged as an error.
 
   If you don't know what types to add, you can use ``Any``, but beware:
 
+- **The function returns ``None`` value but it was annotated as having a return
+  type of other types.** By default, ``None`` value is considered compatible
+  with everything. See :ref:`optional` for details and an experimental mode
+  which allows mypy to check ``None`` values precisely.
+
 - **One of the values involved has type ``Any``.** Extending the above
   example, if we were to leave out the annotation for ``a``, we'd get
   no error:

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -51,12 +51,6 @@ flagged as an error.
 
   If you don't know what types to add, you can use ``Any``, but beware:
 
-- **A function annotated as non-optional returns ``None`` and mypy doesn't
-  complain** By default, ``None`` value is considered compatible
-  with everything. See :ref:`optional` for details on strict optional checking,
-  which allows mypy to check ``None`` values precisely, and will soon become
-  default.
-
 - **One of the values involved has type ``Any``.** Extending the above
   example, if we were to leave out the annotation for ``a``, we'd get
   no error:
@@ -90,6 +84,12 @@ flagged as an error.
   module found at all) leave out ``--ignore-missing-imports``; to get
   clarity about the latter use ``--follow-imports=error``.  You can
   read up about these and other useful flags in :ref:`command-line`.
+
+- **A function annotated as returning non-optional type but returns ``None``
+  and mypy doesn't complain** By default, the ``None`` value is considered
+  compatible with everything. See :ref:`optional` for details on strict
+  optional checking, which allows mypy to check ``None`` values precisely, and
+  will soon become default.
 
 .. _silencing_checker:
 

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -86,10 +86,16 @@ flagged as an error.
   read up about these and other useful flags in :ref:`command-line`.
 
 - **A function annotated as returning non-optional type but returns ``None``
-  and mypy doesn't complain** By default, the ``None`` value is considered
-  compatible with everything. See :ref:`optional` for details on strict
-  optional checking, which allows mypy to check ``None`` values precisely, and
-  will soon become default.
+  and mypy doesn't complain**.
+
+  .. code-block:: python
+
+      def foo() -> str:
+          return None  # No error!
+
+  By default, the ``None`` value is considered compatible with everything. See
+  :ref:`optional` for details on strict optional checking, which allows mypy to
+  check ``None`` values precisely, and will soon become default.
 
 .. _silencing_checker:
 

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -51,10 +51,11 @@ flagged as an error.
 
   If you don't know what types to add, you can use ``Any``, but beware:
 
-- **The function returns ``None`` value but it was annotated as having a return
-  type of other types.** By default, ``None`` value is considered compatible
-  with everything. See :ref:`optional` for details and an experimental mode
-  which allows mypy to check ``None`` values precisely.
+- **A function annotated as non-optional returns ``None`` and mypy doesn't
+  complain** By default, ``None`` value is considered compatible
+  with everything. See :ref:`optional` for details on strict optional checking,
+  which allows mypy to check ``None`` values precisely, and will soon become
+  default.
 
 - **One of the values involved has type ``Any``.** Extending the above
   example, if we were to leave out the annotation for ``a``, we'd get

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -85,7 +85,7 @@ flagged as an error.
   clarity about the latter use ``--follow-imports=error``.  You can
   read up about these and other useful flags in :ref:`command-line`.
 
-- **A function annotated as returning non-optional type but returns ``None``
+- **A function annotated as returning a non-optional type returns ``None``
   and mypy doesn't complain**.
 
   .. code-block:: python


### PR DESCRIPTION
When I got problem (https://github.com/python/mypy/issues/4587) , I looked into the doc and noticed "common issues" and FAQ but non of these helped me. Add this as I think it is a common issue when new user evaluating using mypy, they might write simple functions to see how the tool work.