### PR TITLE
Fine-grained: Compare symbol table snapshots when following dependencies

### DIFF
--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -244,7 +244,7 @@ def snapshot_symbol_table(name_prefix: str, table: SymbolTable) -> Dict[str, Sna
 
     Only "shallow" state is included in the snapshot -- references to
     things defined in other modules are represented just by the names of
-    the targers.
+    the targets.
     """
     result = {}  # type: Dict[str, SnapshotItem]
     for name, symbol in table.items():

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1,7 +1,7 @@
 -- Test cases for fine-grained incremental mode related to modules
 --
--- Covers adding and deleting modules, changes to multiple modules, and
--- changes to import graph.
+-- Covers adding and deleting modules, changes to multiple modules,
+-- changes to import graph, and changes to module references.
 --
 -- The comments in fine-grained.test explain how these tests work.
 
@@ -808,3 +808,41 @@ def main() -> None:
 [file config.py]
 [out]
 ==
+
+
+-- Misc
+-- ----
+
+
+[case testChangeModuleToVariable]
+from a import m
+m.x
+[file a.py]
+from b import m
+[file b.py]
+import m
+[file b.py.2]
+m = ''
+[file m.py]
+x = 1
+[file m2.py]
+[out]
+==
+main:2: error: "str" has no attribute "x"
+
+[case testChangeVariableToModule]
+from a import m
+y: str = m
+[file a.py]
+from b import m
+[file b.py]
+m = ''
+[file b.py.2]
+import m
+[file m.py]
+x = 1
+[file m2.py]
+[builtins fixtures/module.pyi]
+[out]
+==
+main:2: error: Incompatible types in assignment (expression has type Module, variable has type "str")


### PR DESCRIPTION
Previously we just compared symbol table node types, which would fail to
propagate certain changes. For example, we could fail to detect a change
from a module reference to a normal variable.

This only affects detecting changes when we are propagating changes using
fine-grained dependencies. Snapshot comparison was already being used
when processing an entire module.

Fixes #4595.