### PR TITLE
Fix callable types with inconsistent argument counts

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -10,8 +10,8 @@ from mypy.types import (
     TupleType, TypedDictType, Instance, TypeVarType, ErasedType, UnionType,
     PartialType, DeletedType, UnboundType, UninhabitedType, TypeType, TypeOfAny,
     true_only, false_only, is_named_instance, function_type, callable_type, FunctionLike,
-    get_typ_args, set_typ_args,
-    StarType)
+    get_typ_args, StarType
+)
 from mypy.nodes import (
     NameExpr, RefExpr, Var, FuncDef, OverloadedFuncDef, TypeInfo, CallExpr,
     MemberExpr, IntExpr, StrExpr, BytesExpr, UnicodeExpr, FloatExpr,
@@ -2088,7 +2088,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             callable_ctx = callable_ctx.copy_modified(
                 is_ellipsis_args=False,
                 arg_types=[AnyType(TypeOfAny.special_form)] * len(arg_kinds),
-                arg_kinds=arg_kinds
+                arg_kinds=arg_kinds,
+                arg_names=[None] * len(arg_kinds)
             )
 
         if ARG_STAR in arg_kinds or ARG_STAR2 in arg_kinds:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3904,6 +3904,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
 
 def replace_implicit_first_type(sig: FunctionLike, new: Type) -> FunctionLike:
     if isinstance(sig, CallableType):
+        if len(sig.arg_types) == 0:
+            return sig
         return sig.copy_modified(arg_types=[new] + sig.arg_types[1:])
     elif isinstance(sig, Overloaded):
         return Overloaded([cast(CallableType, replace_implicit_first_type(i, new))

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -663,6 +663,7 @@ class CallableType(FunctionLike):
                  from_type_type: bool = False,
                  bound_args: Optional[List[Optional[Type]]] = None,
                  ) -> None:
+        assert len(arg_types) == len(arg_kinds) == len(arg_names)
         if variables is None:
             variables = []
         assert len(arg_types) == len(arg_kinds)


### PR DESCRIPTION
This fixes potential issues with callable types where there are a
different number of argument names compared to argument types. These
malformed callable types might have caused crashes.

This may address #4599. Even if the issue remains unfixed, future
tracebacks could be more useful due to an assert that I added.