### PR TITLE
Clarify generic function documentation

### DIFF
--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -224,19 +224,7 @@ example we use the same type variable in two generic functions:
        return seq[-1]
 
 A variable cannot have a type variable in its type unless the type
-variable is bound in a containing generic class or function:
-
-.. code-block:: python
-
-    from typing import TypeVar
-
-    T = TypeVar('T')      # Declare type variable
-
-    def bad_function() -> T:
-        return 1
-
-    x = bad_function()  # Error! There is no containing class or function binding T.
-                        # x has type T, which cannot be replaced with a non-generic type.
+variable is bound in a containing generic class or function.
 
 .. _generic-methods-and-generic-self:
 

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -223,6 +223,26 @@ example we use the same type variable in two generic functions:
    def last(seq: Sequence[T]) -> T:
        return seq[-1]
 
+Note that a variable cannot have a type variable in its type unless the type variable is bound in a containing generic class or function:
+
+.. code-block:: python
+
+    from typing import Sequence, TypeVar
+
+    T = TypeVar('T')      # Declare type variable
+
+    def first(seq: Sequence[T]) -> T:
+        return seq[0]
+
+    s = first(['foo', 'bar'])  # s has type str.
+    n = first([1, 2, 3])       # n has type int
+
+    def bad_function() -> T:
+        return 1
+
+    x = bad_function()  # Error! There is no containing class or function binding T.
+                        # x has type T, which cannot be replaced with a non-generic type.
+
 .. _generic-methods-and-generic-self:
 
 Generic methods and generic self

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -223,19 +223,14 @@ example we use the same type variable in two generic functions:
    def last(seq: Sequence[T]) -> T:
        return seq[-1]
 
-Note that a variable cannot have a type variable in its type unless the type variable is bound in a containing generic class or function:
+A variable cannot have a type variable in its type unless the type
+variable is bound in a containing generic class or function:
 
 .. code-block:: python
 
-    from typing import Sequence, TypeVar
+    from typing import TypeVar
 
     T = TypeVar('T')      # Declare type variable
-
-    def first(seq: Sequence[T]) -> T:
-        return seq[0]
-
-    s = first(['foo', 'bar'])  # s has type str.
-    n = first([1, 2, 3])       # n has type int
 
     def bad_function() -> T:
         return 1


### PR DESCRIPTION
This explains that a variable of a generic type must be able to be resolved to a non-generic type, hopefully preventing the confusion that made me (and possibly others) think #4590 is a bug.

@gvanrossum, I used some of the wording in your explanation almost verbatim. I'm guessing you don't mind.