### PR TITLE
Optimize fine-grained update by using Graph as the cache

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -389,7 +389,6 @@ def default_lib_path(data_dir: str,
 CacheMeta = NamedTuple('CacheMeta',
                        [('id', str),
                         ('path', str),
-                        ('memory_only', bool),  # no corresponding json files (fine-grained only)
                         ('mtime', int),
                         ('size', int),
                         ('hash', str),
@@ -415,7 +414,6 @@ def cache_meta_from_dict(meta: Dict[str, Any], data_json: str) -> CacheMeta:
     return CacheMeta(
         meta.get('id', sentinel),
         meta.get('path', sentinel),
-        meta.get('memory_only', False),
         int(meta['mtime']) if 'mtime' in meta else sentinel,
         meta.get('size', sentinel),
         meta.get('hash', sentinel),
@@ -1120,12 +1118,6 @@ def validate_meta(meta: Optional[CacheMeta], id: str, path: Optional[str],
     if meta.ignore_all and not ignore_all:
         manager.log('Metadata abandoned for {}: errors were previously ignored'.format(id))
         return None
-
-    if meta.memory_only:
-        # Special case for fine-grained incremental mode when the JSON file is missing but
-        # we want to cache the module anyway.
-        manager.log('Memory-only metadata for {}'.format(id))
-        return meta
 
     assert path is not None, "Internal error: meta was provided without a path"
     # Check data_json; assume if its mtime matches it's good.

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2199,6 +2199,9 @@ def load_graph(sources: List[BuildSource], manager: BuildManager,
                old_graph: Optional[Graph] = None) -> Graph:
     """Given some source files, load the full dependency graph.
 
+    If an old_graph is passed in, it is used as the starting point and
+    modified during graph loading.
+
     As this may need to parse files, this can raise CompileError in case
     there are syntax errors.
     """

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -658,23 +658,15 @@ class BuildManager:
                 elif isinstance(imp, ImportFrom):
                     cur_id = correct_rel_imp(imp)
                     pos = len(res)
-                    all_are_submodules = True
                     # Also add any imported names that are submodules.
                     pri = import_priority(imp, PRI_MED)
                     for name, __ in imp.names:
                         sub_id = cur_id + '.' + name
                         if self.is_module(sub_id):
                             res.append((pri, sub_id, imp.line))
-                        else:
-                            all_are_submodules = False
-                    # If all imported names are submodules, don't add
-                    # cur_id as a dependency.  Otherwise (i.e., if at
-                    # least one imported name isn't a submodule)
-                    # cur_id is also a dependency, and we should
-                    # insert it *before* any submodules.
-                    if not all_are_submodules:
-                        pri = import_priority(imp, PRI_HIGH)
-                        res.insert(pos, ((pri, cur_id, imp.line)))
+
+                    pri = import_priority(imp, PRI_HIGH)
+                    res.insert(pos, ((pri, cur_id, imp.line)))
                 elif isinstance(imp, ImportAll):
                     pri = import_priority(imp, PRI_HIGH)
                     res.append((pri, correct_rel_imp(imp), imp.line))

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2186,13 +2186,16 @@ def dump_graph(graph: Graph) -> None:
     print("[" + ",\n ".join(node.dumps() for node in nodes) + "\n]")
 
 
-def load_graph(sources: List[BuildSource], manager: BuildManager) -> Graph:
+def load_graph(sources: List[BuildSource], manager: BuildManager,
+               old_graph: Optional[Graph] = None) -> Graph:
     """Given some source files, load the full dependency graph.
 
     As this may need to parse files, this can raise CompileError in case
     there are syntax errors.
     """
-    graph = {}  # type: Graph
+
+    graph = old_graph or {}  # type: Graph
+
     # The deque is used to implement breadth-first traversal.
     # TODO: Consider whether to go depth-first instead.  This may
     # affect the order in which we process files within import cycles.

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1623,7 +1623,8 @@ class State:
                         self.ignore_all = True
                     else:
                         # In 'error' mode, produce special error messages.
-                        manager.log("Skipping %s (%s)" % (path, id))
+                        if id not in manager.missing_modules:
+                            manager.log("Skipping %s (%s)" % (path, id))
                         if follow_imports == 'error':
                             if ancestor_for:
                                 self.skipping_ancestor(id, path, ancestor_for)

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1893,7 +1893,7 @@ class State:
 
         self.check_blockers()
 
-    def compute_dependencies(self):
+    def compute_dependencies(self) -> None:
         """Compute a module's dependencies after parsing it.
 
         This is used when we parse a file that we didn't have
@@ -1901,6 +1901,7 @@ class State:
         cache, we just use the cached info.
         """
         manager = self.manager
+        assert self.tree is not None
 
         # Compute (direct) dependencies.
         # Add all direct imports (this is why we needed the first pass).

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -656,15 +656,23 @@ class BuildManager:
                 elif isinstance(imp, ImportFrom):
                     cur_id = correct_rel_imp(imp)
                     pos = len(res)
+                    all_are_submodules = True
                     # Also add any imported names that are submodules.
                     pri = import_priority(imp, PRI_MED)
                     for name, __ in imp.names:
                         sub_id = cur_id + '.' + name
                         if self.is_module(sub_id):
                             res.append((pri, sub_id, imp.line))
-
-                    pri = import_priority(imp, PRI_HIGH)
-                    res.insert(pos, ((pri, cur_id, imp.line)))
+                        else:
+                            all_are_submodules = False
+                    # If all imported names are submodules, don't add
+                    # cur_id as a dependency.  Otherwise (i.e., if at
+                    # least one imported name isn't a submodule)
+                    # cur_id is also a dependency, and we should
+                    # insert it *before* any submodules.
+                    if not all_are_submodules:
+                        pri = import_priority(imp, PRI_HIGH)
+                        res.insert(pos, ((pri, cur_id, imp.line)))
                 elif isinstance(imp, ImportAll):
                     pri = import_priority(imp, PRI_HIGH)
                     res.append((pri, correct_rel_imp(imp), imp.line))

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -216,6 +216,16 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # for processing module top levels in fine-grained incremental mode.
         self.recurse_into_functions = True
 
+    def reset(self) -> None:
+        """Cleanup stale state that might be left over from a typechecking run.
+
+        This allows us to reuse TypeChecker objects in fine-grained
+        incremental mode.
+        """
+        self.partial_reported.clear()
+        assert self.partial_types == []
+        assert self.deferred_nodes == []
+
     def check_first_pass(self) -> None:
         """Type check the entire file, but defer functions with unresolved references.
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -222,9 +222,17 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         This allows us to reuse TypeChecker objects in fine-grained
         incremental mode.
         """
+        # TODO: verify this is still actually worth it over creating new checkers
         self.partial_reported.clear()
+        self.module_refs.clear()
+        self.binder = ConditionalTypeBinder()
+        self.type_map.clear()
+
+        assert self.inferred_attribute_types is None
         assert self.partial_types == []
         assert self.deferred_nodes == []
+        assert len(self.scope.stack) == 1
+        assert self.partial_types == []
 
     def check_first_pass(self) -> None:
         """Type check the entire file, but defer functions with unresolved references.

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -282,10 +282,11 @@ class Server:
         if self.options.use_fine_grained_cache:
             # Pull times and hashes out of the saved_cache and stick them into
             # the fswatcher, so we pick up the changes.
-            for meta, mypyfile, type_map in manager.saved_cache.values():
-                if meta.mtime is None: continue
+            for state in self.fine_grained_manager.graph.values():
+                meta = state.meta
+                if meta is None: continue
                 self.fswatcher.set_file_data(
-                    mypyfile.path,
+                    state.xpath,
                     FileData(st_mtime=float(meta.mtime), st_size=meta.size, md5=meta.hash))
 
             # Run an update

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -285,8 +285,9 @@ class Server:
             for state in self.fine_grained_manager.graph.values():
                 meta = state.meta
                 if meta is None: continue
+                assert state.path is not None
                 self.fswatcher.set_file_data(
-                    state.xpath,
+                    state.path,
                     FileData(st_mtime=float(meta.mtime), st_size=meta.size, md5=meta.hash))
 
             # Run an update

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -149,6 +149,7 @@ class TypeCheckSuite(DataSuite):
         options = parse_options(original_program_text, testcase, incremental_step)
         options.use_builtins_fixtures = True
         options.show_traceback = True
+        options.verbosity = 1
         if 'optional' in testcase.file:
             options.strict_optional = True
         if incremental_step:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -149,7 +149,6 @@ class TypeCheckSuite(DataSuite):
         options = parse_options(original_program_text, testcase, incremental_step)
         options.use_builtins_fixtures = True
         options.show_traceback = True
-        options.verbosity = 1
         if 'optional' in testcase.file:
             options.strict_optional = True
         if incremental_step:

--- a/test-data/unit/check-dmypy-fine-grained.test
+++ b/test-data/unit/check-dmypy-fine-grained.test
@@ -32,7 +32,7 @@ def f() -> str:
 [out2]
 tmp/b.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
-[case testAddFileFineGrainedIncremental]
+[case testAddFileFineGrainedIncremental1]
 # cmd: mypy -m a
 # cmd2: mypy -m a b
 [file a.py]
@@ -43,6 +43,19 @@ def f(x: str) -> None: pass
 [out1]
 tmp/a.py:1: error: Cannot find module named 'b'
 tmp/a.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+[out2]
+tmp/a.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
+
+[case testAddFileFineGrainedIncremental2]
+# flags: --follow-imports=skip --ignore-missing-imports
+# cmd: mypy -m a
+# cmd2: mypy -m a b
+[file a.py]
+import b
+b.f(1)
+[file b.py.2]
+def f(x: str) -> None: pass
+[out1]
 [out2]
 tmp/a.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4059,3 +4059,71 @@ class Baz:
 [out]
 [out2]
 tmp/a.py:3: error: Unsupported operand types for + ("int" and "str")
+
+[case testIncrementalWithIgnoresTwice]
+import a
+[file a.py]
+import b
+import foo # type: ignore
+[file b.py]
+x = 1
+[file b.py.2]
+x = 'hi'
+[file b.py.3]
+x = 1
+[builtins fixtures/module.pyi]
+[out]
+[out2]
+[out3]
+
+[case testIgnoredImport2]
+import x
+[file y.py]
+import xyz  # type: ignore
+B = 0
+from x import A
+[file x.py]
+A = 0
+from y import B
+[file x.py.2]
+A = 1
+from y import B
+[file x.py.3]
+A = 2
+from y import B
+[out]
+[out2]
+[out3]
+
+[case testDeletionOfSubmoduleTriggersImportFrom2]
+from p.q import f
+f()
+[file p/__init__.py]
+[file p/q.py]
+def f() -> None: pass
+[delete p/q.py.2]
+[file p/q.py.3]
+def f(x: int) -> None: pass
+[out]
+[out2]
+main:1: error: Cannot find module named 'p.q'
+main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+[out3]
+main:2: error: Too few arguments for "f"
+
+[case testDeleteIndirectDependency]
+import b
+b.x.foo()
+[file b.py]
+import c
+x = c.Foo()
+[file c.py]
+class Foo:
+    def foo(self) -> None: pass
+[delete c.py.2]
+[file b.py.2]
+class Foo:
+    def foo(self) -> None: pass
+x = Foo()
+[out]
+[out2]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1943,3 +1943,15 @@ main:2: error: Name 'name' is not defined
 main:3: error: Revealed type is 'Any'
 
 [builtins fixtures/module.pyi]
+
+[case testFailedImportFromTwoModules]
+import c
+import b
+[file b.py]
+import c
+
+[out]
+-- TODO: it would be better for this to be in the other order
+tmp/b.py:1: error: Cannot find module named 'c'
+main:1: error: Cannot find module named 'c'
+main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)

--- a/test-data/unit/fine-grained-cycles.test
+++ b/test-data/unit/fine-grained-cycles.test
@@ -174,44 +174,7 @@ def h() -> None:
 ==
 a.py:1: error: Module 'b' has no attribute 'C'
 
-[case testReferenceToTypeThroughCycleAndReplaceWithFunction-skip-cache]
--- Different cache/no-cache tests because:
--- Cache mode has a "need type annotation" message (like coarse incremental does)
-
-import a
-
-[file a.py]
-from b import C
-
-def f() -> C: pass
-
-[file b.py]
-import a
-
-class C:
-    def g(self) -> None: pass
-
-def h() -> None:
-    c = a.f()
-    c.g()
-
-[file b.py.2]
-import a
-
-def C() -> int: pass
-
-def h() -> None:
-    c = a.f()
-    c.g()
-
-[out]
-==
-a.py:3: error: Invalid type "b.C"
-
-[case testReferenceToTypeThroughCycleAndReplaceWithFunction-skip-nocache]
--- Different cache/no-cache tests because:
--- Cache mode has a "need type annotation" message (like coarse incremental does)
-
+[case testReferenceToTypeThroughCycleAndReplaceWithFunction]
 import a
 
 [file a.py]

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -963,5 +963,11 @@ class Foo:
 class Foo:
     def foo(self) -> None: pass
 x = Foo()
+[file b.py.3]
+class Foo:
+    def foo(self, x: int) -> None: pass
+x = Foo()
 [out]
 ==
+==
+main:2: error: Too few arguments for "foo" of "Foo"

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -56,7 +56,7 @@ b.py:1: error: Cannot find module named 'a'
 b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 ==
 
-[case testAddFileFixesAndGeneratesError]
+[case testAddFileFixesAndGeneratesError1]
 import b
 [file b.py]
 [file b.py.2]
@@ -75,6 +75,38 @@ b.py:1: error: Cannot find module named 'a'
 b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 ==
 b.py:2: error: Too many arguments for "f"
+
+[case testAddFileFixesAndGeneratesError2]
+import b
+[file b.py]
+[file b.py.2]
+from a import f
+f(1)
+[file c.py.3]
+x = 'whatever'
+[file a.py.4]
+def f() -> None: pass
+[out]
+==
+b.py:1: error: Cannot find module named 'a'
+b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+==
+b.py:1: error: Cannot find module named 'a'
+b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+==
+b.py:2: error: Too many arguments for "f"
+
+[case testAddFileGeneratesError1]
+# flags: --ignore-missing-imports
+import a
+[file a.py]
+from b import f
+f(1)
+[file b.py.2]
+def f() -> None: pass
+[out]
+==
+a.py:2: error: Too many arguments for "f"
 
 [case testAddFilePreservesError1]
 import b
@@ -234,9 +266,7 @@ main:1: error: Cannot find module named 'a'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 ==
 
-[case testDeletionOfSubmoduleTriggersImportFrom1-skip-cache]
--- Different cache/no-cache tests because:
--- missing module error message mismatch
+[case testDeletionOfSubmoduleTriggersImportFrom1]
 from p import q
 [file p/__init__.py]
 [file p/q.py]
@@ -249,20 +279,6 @@ main:1: error: Module 'p' has no attribute 'q'
 main:1: error: Cannot find module named 'p.q'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 ==
-
-[case testDeletionOfSubmoduleTriggersImportFrom1-skip-nocache]
--- Different cache/no-cache tests because:
--- missing module error message mismatch
-from p import q
-[file p/__init__.py]
-[file p/q.py]
-[delete p/q.py.2]
-[file p/q.py.3]
-[out]
-==
-main:1: error: Module 'p' has no attribute 'q'
-==
-
 
 [case testDeletionOfSubmoduleTriggersImportFrom2]
 from p.q import f
@@ -637,7 +653,6 @@ main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
 main:1: error: Cannot find module named 'p'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
-main:1: error: Cannot find module named 'p.a'
 
 [case testDeletePackage3]
 import p.a
@@ -845,3 +860,92 @@ x = 1
 [out]
 ==
 main:2: error: Incompatible types in assignment (expression has type Module, variable has type "str")
+
+[case testRefreshImportOfIgnoredModule1]
+# flags: --follow-imports=skip --ignore-missing-imports
+# cmd: mypy c.py a/__init__.py b.py
+[file c.py]
+from a import a2
+import b
+b.x
+[file a/__init__.py]
+[file b.py]
+x = 0
+[file b.py.2]
+x = ''
+[file b.py.3]
+x = 0
+[file a/a2.py]
+[out]
+==
+==
+
+[case testRefreshImportOfIgnoredModule2]
+# flags: --follow-imports=skip --ignore-missing-imports
+# cmd: mypy c.py a/__init__.py b.py
+[file c.py]
+from a import a2
+import b
+b.x
+[file a/__init__.py]
+[file b.py]
+x = 0
+[file b.py.2]
+x = ''
+[file b.py.3]
+x = 0
+[file a/a2/__init__.py]
+[out]
+==
+==
+
+[case testIncrementalWithIgnoresTwice]
+import a
+[file a.py]
+import b
+import foo # type: ignore
+[file b.py]
+x = 1
+[file b.py.2]
+x = 'hi'
+[file b.py.3]
+x = 1
+[out]
+==
+==
+
+[case testIgnoredImport2]
+import x
+[file y.py]
+import xyz  # type: ignore
+B = 0
+from x import A
+[file x.py]
+A = 0
+from y import B
+[file x.py.2]
+A = 1
+from y import B
+[file x.py.3]
+A = 2
+from y import B
+[out]
+==
+==
+
+[case testDeleteIndirectDependency]
+import b
+b.x.foo()
+[file b.py]
+import c
+x = c.Foo()
+[file c.py]
+class Foo:
+    def foo(self) -> None: pass
+[delete c.py.2]
+[file b.py.2]
+class Foo:
+    def foo(self) -> None: pass
+x = Foo()
+[out]
+==

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -266,7 +266,9 @@ main:1: error: Cannot find module named 'a'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 ==
 
-[case testDeletionOfSubmoduleTriggersImportFrom1]
+[case testDeletionOfSubmoduleTriggersImportFrom1-skip-cache]
+-- Different cache/no-cache tests because:
+-- missing module error message mismatch
 from p import q
 [file p/__init__.py]
 [file p/q.py]
@@ -276,6 +278,20 @@ from p import q
 ==
 main:1: error: Module 'p' has no attribute 'q'
 -- TODO: The following messages are different compared to non-incremental mode
+main:1: error: Cannot find module named 'p.q'
+main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+==
+
+[case testDeletionOfSubmoduleTriggersImportFrom1-skip-nocache]
+-- Different cache/no-cache tests because:
+-- missing module error message mismatch
+from p import q
+[file p/__init__.py]
+[file p/q.py]
+[delete p/q.py.2]
+[file p/q.py.3]
+[out]
+==
 main:1: error: Cannot find module named 'p.q'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 ==

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -236,8 +236,7 @@ main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" 
 
 [case testDeletionOfSubmoduleTriggersImportFrom1-skip-cache]
 -- Different cache/no-cache tests because:
--- Cache mode matches the message from regular mode and no-cache mode
--- matches the message from coarse incremental mode...
+-- missing module error message mismatch
 from p import q
 [file p/__init__.py]
 [file p/q.py]
@@ -245,15 +244,15 @@ from p import q
 [file p/q.py.3]
 [out]
 ==
-main:1: error: Cannot find module named 'p.q'
+main:1: error: Module 'p' has no attribute 'q'
 -- TODO: The following messages are different compared to non-incremental mode
+main:1: error: Cannot find module named 'p.q'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 ==
 
 [case testDeletionOfSubmoduleTriggersImportFrom1-skip-nocache]
 -- Different cache/no-cache tests because:
--- Cache mode matches the message from regular mode and no-cache mode
--- matches the message from coarse incremental mode...
+-- missing module error message mismatch
 from p import q
 [file p/__init__.py]
 [file p/q.py]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1108,9 +1108,9 @@ def f() -> Iterator[None]:
 [out]
 main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 ==
+main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 a.py:3: error: Cannot find module named 'b'
 a.py:3: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
-main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 ==
 main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 
@@ -2355,7 +2355,7 @@ def f() -> None:
 d.py:3: error: Argument 1 to "A" has incompatible type "str"; expected "int"
 ==
 
-[case testNonePartialType]
+[case testNonePartialType1]
 import a
 a.y
 


### PR DESCRIPTION
Make fine-grained update use a `Graph` as the source of truth instead of a `SavedCache`. We modify `load_graph` to optionally use an existing graph as a starting point.

This allows us to skip the expensive full `load_graph` (~500ms on S) and `preserve_full_cache` (~200ms on S) operations that essentially only convert between `Graph` and `SavedCache`.