### PR TITLE
Clean up credits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,11 +80,7 @@ For every pull request, we aim to promptly either merge it or say why
 it's not yet ready; if you go a few days without a reply, please feel
 free to ping the thread by adding a new comment.
 
-At present the core developers are (alphabetically):
-* David Fisher (@ddfisher)
-* Jukka Lehtosalo (@JukkaL)
-* Greg Price (@gnprice)
-* Guido van Rossum (@gvanrossum)
+For a list of mypy core developers, see the file [CREDITS](CREDITS).
 
 
 Preparing Changes

--- a/CREDITS
+++ b/CREDITS
@@ -7,12 +7,17 @@ https://github.com/python/mypy/commits/master
 For lists of contributors per mypy release (including typeshed) see
 the release blog posts at https://mypy-lang.blogspot.com/.
 
-Mypy team:
+Dropbox core team:
 
   Jukka Lehtosalo <jukka.lehtosalo@iki.fi>
   Guido van Rossum <guido@python.org>
   Ivan Levkivskyi
   Michael J. Sullivan
+
+Non-Dropbox core team members:
+
+  Ethan Smith
+  Jelle Zijlstra
 
 Past Dropbox core team members:
 
@@ -22,11 +27,6 @@ Past Dropbox core team members:
   Naomi Seyfer
   Michael Lee
   Reid Barton
-
-Non-Dropbox core team members:
-
-  Ethan Smith
-  Jelle Zijlstra
 
 Additional thanks to:
 


### PR DESCRIPTION
In CONTRIBUTING.md, link to CREDITS instead of maintaining a separate
list (which was out of date).