### PR TITLE
Make attributes in attr classes be instance variables.

### DIFF
--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -705,3 +705,24 @@ import attr
 class A(object):
     x = attr.ib()
 [builtins_py2 fixtures/bool.pyi]
+
+[case testAttrsCallableAttributes]
+from typing import Callable
+import attr
+def blah(a: int, b: int) -> bool:
+    return True
+
+@attr.s(auto_attribs=True)
+class F:
+    _cb: Callable[[int, int], bool] = blah
+
+    def foo(self) -> bool:
+        return self._cb(5, 6)
+
+@attr.s
+class G:
+    _cb: Callable[[int, int], bool] = attr.ib(blah)
+
+    def foo(self) -> bool:
+        return self._cb(5, 6)
+[builtins fixtures/callable.pyi]

--- a/test-data/unit/fixtures/callable.pyi
+++ b/test-data/unit/fixtures/callable.pyi
@@ -24,3 +24,4 @@ class bool(int): pass
 class str:
     def __add__(self, other: 'str') -> 'str': pass
     def __eq__(self, other: 'str') -> bool: pass
+class ellipsis: pass


### PR DESCRIPTION
This is only a problem when trying to assign callables into attrs.
This avoids hitting #708