### PR TITLE
Make psutil an optional dependency

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -13,12 +13,6 @@ you can install mypy with:
 
     $ python3 -m pip install mypy
 
-Optionally you can install extra dependencies for daemon server with:
-
-.. code-block:: text
-
-    $ python3 -m pip install mypy[dmypy]
-
 Installing from source
 **********************
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -13,6 +13,12 @@ you can install mypy with:
 
     $ python3 -m pip install mypy
 
+Optionally you can install extra dependencies for daemon server with:
+
+.. code-block:: text
+
+    $ python3 -m pip install mypy[dmypy]
+
 Installing from source
 **********************
 

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -363,7 +363,8 @@ def get_meminfo() -> Mapping[str, float]:
     try:
         import psutil  # type: ignore  # It's not in typeshed yet
     except ImportError:
-        pass
+        if sys.platform != 'win32':
+            print('psutil not found, run pip install mypy[dmypy] to install the needed components for dmypy')
     else:
         process = psutil.Process(os.getpid())
         meminfo = process.memory_info()

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -364,7 +364,8 @@ def get_meminfo() -> Mapping[str, float]:
         import psutil  # type: ignore  # It's not in typeshed yet
     except ImportError:
         if sys.platform != 'win32':
-            print('psutil not found, run pip install mypy[dmypy] to install the needed components for dmypy')
+            print('psutil not found, run pip install mypy[dmypy]'
+                  'to install the needed components for dmypy')
     else:
         process = psutil.Process(os.getpid())
         meminfo = process.memory_info()

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -364,8 +364,10 @@ def get_meminfo() -> Mapping[str, float]:
         import psutil  # type: ignore  # It's not in typeshed yet
     except ImportError:
         if sys.platform != 'win32':
-            print('psutil not found, run pip install mypy[dmypy]'
-                  'to install the needed components for dmypy')
+            res['memory_psutil_missing'] = (
+                'psutil not found, run pip install mypy[dmypy] '
+                'to install the needed components for dmypy'
+            )
     else:
         process = psutil.Process(os.getpid())
         meminfo = process.memory_info()

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -349,10 +349,10 @@ class Server:
 MiB = 2**20
 
 
-def get_meminfo() -> Mapping[str, float]:
+def get_meminfo() -> Dict[str, Any]:
     # See https://stackoverflow.com/questions/938733/total-memory-used-by-python-process
     import resource  # Since it doesn't exist on Windows.
-    res = {}
+    res = {}  # type: Dict[str, Any]
     rusage = resource.getrusage(resource.RUSAGE_SELF)
     if sys.platform == 'darwin':
         factor = 1

--- a/setup.py
+++ b/setup.py
@@ -109,9 +109,9 @@ setup(name='mypy',
       classifiers=classifiers,
       cmdclass={'build_py': CustomPythonBuild},
       install_requires = ['typed-ast >= 1.1.0, < 1.2.0',
-                          'psutil >= 5.4.0, < 5.5.0',
                           ],
       extras_require = {
           ':python_version < "3.5"': 'typing >= 3.5.3',
+          'dmypy': 'psutil >= 5.4.0, < 5.5.0',
       },
       )

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,6 @@ setup(name='mypy',
                           ],
       extras_require = {
           ':python_version < "3.5"': 'typing >= 3.5.3',
-          'dmypy': 'psutil >= 5.4.0, < 5.5.0',
+          'dmypy': 'psutil >= 5.4.0, < 5.5.0; sys_platform!="win32"',
       },
       )


### PR DESCRIPTION
* in case of `psutil` not installed, daemon reports it and suggests installing it
* on Windows it isn't declared as dependency nor reported as missing

Fixes #4593.