### PR TITLE
Don't call --strict-optional and --incremental experimental

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -296,6 +296,7 @@ Here are some more useful flags:
   types and ``None`` values. Without this option, mypy doesn't
   generally check the use of ``None`` values -- they are valid
   everywhere. See :ref:`strict_optional` for more about this feature.
+  This flag will become the default in the near future.
 
 - ``--disallow-untyped-defs`` reports an error whenever it encounters
   a function definition without type annotations.

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -333,8 +333,10 @@ Here are some more useful flags:
 - ``--incremental`` enables a module cache, using results from
   previous runs to speed up type checking. Incremental mode can help
   when most parts of your program haven't changed since the previous
-  mypy run.  A companion flag is ``--cache-dir DIR``, which specifies
-  where the cache files are written.  By default this is
+  mypy run.
+
+- ``--cache-dir DIR`` is a companion flag to ``-incremental``, which
+  specifies where the cache files are written.  By default this is
   ``.mypy_cache`` in the current directory.  While the cache is only
   read in incremental mode, it is written even in non-incremental
   mode, in order to "warm" the cache.  To disable writing the cache,

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -292,22 +292,10 @@ Here are some more useful flags:
 - ``--ignore-missing-imports`` suppresses error messages about imports
   that cannot be resolved (see :ref:`follow-imports` for some examples).
 
-- ``--strict-optional`` enables experimental strict checking of ``Optional[...]``
-  types and ``None`` values. Without this option, mypy doesn't generally check the
-  use of ``None`` values -- they are valid everywhere. See :ref:`strict_optional` for
-  more about this feature.
-
-- ``--strict-optional-whitelist`` attempts to suppress strict Optional-related
-  errors in non-whitelisted files.  Takes an arbitrary number of globs as the
-  whitelist.  This option is intended to be used to incrementally roll out
-  ``--strict-optional`` to a large codebase that already has mypy annotations.
-  However, this flag comes with some significant caveats.  It does not suppress
-  all errors caused by turning on ``--strict-optional``, only most of them, so
-  there may still be a bit of upfront work to be done before it can be used in
-  CI.  It will also suppress some errors that would be caught in a
-  non-strict-Optional run.  Therefore, when using this flag, you should also
-  re-check your code without ``--strict-optional`` to ensure new type errors
-  are not introduced.
+- ``--strict-optional`` enables strict checking of ``Optional[...]``
+  types and ``None`` values. Without this option, mypy doesn't
+  generally check the use of ``None`` values -- they are valid
+  everywhere. See :ref:`strict_optional` for more about this feature.
 
 - ``--disallow-untyped-defs`` reports an error whenever it encounters
   a function definition without type annotations.
@@ -342,17 +330,17 @@ Here are some more useful flags:
 
 .. _incremental:
 
-- ``--incremental`` is an experimental option that enables a module
-  cache. When enabled, mypy caches results from previous runs
-  to speed up type checking. Incremental mode can help when most parts
-  of your program haven't changed since the previous mypy run.  A
-  companion flag is ``--cache-dir DIR``, which specifies where the
-  cache files are written.  By default this is ``.mypy_cache`` in the
-  current directory.  While the cache is only read in incremental
-  mode, it is written even in non-incremental mode, in order to "warm"
-  the cache.  To disable writing the cache, use
-  ``--cache-dir=/dev/null`` (UNIX) or ``--cache-dir=nul`` (Windows).
-  Cache files belonging to a different mypy version are ignored.
+- ``--incremental`` enables a module cache, using results from
+  previous runs to speed up type checking. Incremental mode can help
+  when most parts of your program haven't changed since the previous
+  mypy run.  A companion flag is ``--cache-dir DIR``, which specifies
+  where the cache files are written.  By default this is
+  ``.mypy_cache`` in the current directory.  While the cache is only
+  read in incremental mode, it is written even in non-incremental
+  mode, in order to "warm" the cache.  To disable writing the cache,
+  use ``--cache-dir=/dev/null`` (UNIX) or ``--cache-dir=nul``
+  (Windows).  Cache files belonging to a different mypy version are
+  ignored.
 
 .. _quick-mode:
 

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -437,8 +437,9 @@ Strict optional type and None checking
 
 Currently, ``None`` is a valid value for each type, similar to
 ``null`` or ``NULL`` in many languages. However, you can use the
-``--strict-optional`` command line option to tell mypy
-that types should not include ``None``
+``--strict-optional`` command line option
+(which will become the default in the near future)
+to tell mypy that types should not include ``None``
 by default. The ``Optional`` type modifier is then used to define
 a type variant that includes ``None``, such as ``Optional[int]``:
 

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -432,12 +432,12 @@ idiomatic.
 
 .. _strict_optional:
 
-Experimental strict optional type and None checking
+Strict optional type and None checking
 ***************************************************
 
 Currently, ``None`` is a valid value for each type, similar to
 ``null`` or ``NULL`` in many languages. However, you can use the
-experimental ``--strict-optional`` command line option to tell mypy
+``--strict-optional`` command line option to tell mypy
 that types should not include ``None``
 by default. The ``Optional`` type modifier is then used to define
 a type variant that includes ``None``, such as ``Optional[int]``:
@@ -477,10 +477,6 @@ recognizes ``is None`` checks:
 
 Mypy will infer the type of ``x`` to be ``int`` in the else block due to the
 check against ``None`` in the if condition.
-
-.. note::
-
-    ``--strict-optional`` is experimental and still has known issues.
 
 .. _noreturn:
 
@@ -986,7 +982,7 @@ annotated the first example as the following:
    def squares(n: int) -> Generator[int, None, None]:
        for i in range(n):
            yield i * i
-           
+
 This is slightly different from using ``Iterable[int]`` or ``Iterator[int]``,
 since generators have ``close()``, ``send()``, and ``throw()`` methods that
 generic iterables don't. If you will call these methods on the returned


### PR DESCRIPTION
Also stop documenting strict_optional_whitelist, since it has been
long since obsoleted, with the idea of removing it soon.