### PR TITLE
Add instructions for encountering AssertionErrors

### DIFF
--- a/mypy/__main__.py
+++ b/mypy/__main__.py
@@ -1,10 +1,20 @@
 """Mypy type checker command line tool."""
 
+import sys
+
 from mypy.main import main
 
 
 def console_entry() -> None:
-    main(None)
+    try:
+        main(None)
+    except AssertionError:
+        print("Uncaught AssertionError thrown by mypy. "
+              "This may be caused by a bug in mypy, and can sometimes be "
+              "worked around by clearing the '.mypy_cache' directory. "
+              "Please report an issue at: https://github.com/python/mypy/issues",
+              file=sys.stderr)
+        raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The thought is that new users do not necessarily know that AssertionErrors are not how mypy is supposed to communicate with the end user. The two times I have encountered AssertionErrors the last year have been caused by cold caches, and it took my a while before realizing it (after debugging my own code for some time).

This pull request adds instructions for the user to clear their cache and report an issue if an AssertionError goes all the way up the stack to the CLI entrypoint.

I can amend the pull request if you have different answers for the following questions:
- Should only AssertionErrors be caught (as it is now), or should we catch BaseException instead, since any uncaught exception this far up the stack is probably caused by a bug.
- Is the ``console_entry`` function the correct place to put this. Should we guard ``mypy.__main__::__main__`` too?

Thanks in advance!
Jakob