### PR TITLE
Fine-grained: Support NewType and reset subtype caches

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -861,12 +861,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         body = block.body
 
         # Skip a docstring
-        if (isinstance(body[0], ExpressionStmt) and
+        if (body and isinstance(body[0], ExpressionStmt) and
                 isinstance(body[0].expr, (StrExpr, UnicodeExpr))):
             body = block.body[1:]
 
         if len(body) == 0:
-            # There's only a docstring.
+            # There's only a docstring (or no body at all).
             return True
         elif len(body) > 1:
             return False

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2080,6 +2080,11 @@ class TypeInfo(SymbolNode):
             return (left, right) in self._cache
         return (left, right) in self._cache_proper
 
+    def reset_subtype_cache(self) -> None:
+        for item in self.mro:
+            item._cache = set()
+            item._cache_proper = set()
+
     def __getitem__(self, name: str) -> 'SymbolTableNode':
         n = self.get(name)
         if n:
@@ -2122,6 +2127,7 @@ class TypeInfo(SymbolNode):
         self.is_enum = self._calculate_is_enum()
         # The property of falling back to Any is inherited.
         self.fallback_to_any = any(baseinfo.fallback_to_any for baseinfo in self.mro)
+        self.reset_subtype_cache()
 
     def calculate_metaclass_type(self) -> 'Optional[mypy.types.Instance]':
         declared = self.declared_metaclass

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2182,7 +2182,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
             arg_types=[Instance(info, []), old_type],
             arg_kinds=[arg.kind for arg in args],
             arg_names=['self', 'item'],
-            ret_type=old_type,
+            ret_type=NoneTyp(),
             fallback=self.named_type('__builtins__.function'),
             name=name)
         init_func = FuncDef('__init__', args, Block([]), typ=signature)

--- a/test-data/unit/deps-statements.test
+++ b/test-data/unit/deps-statements.test
@@ -655,3 +655,20 @@ class C:
 <m.C> -> m.C
 <sys.platform> -> m
 <sys> -> m
+
+[case testNewType]
+from typing import NewType
+from m import C
+
+N = NewType('N', C)
+
+def f(n: N) -> None:
+    pass
+[file m.py]
+class C:
+    x: int
+[out]
+<m.N> -> <m.f>, m, m.f
+<m.C.__init__> -> <m.N.__init__>
+<m.C.x> -> <m.N.x>
+<m.C> -> m, m.N

--- a/test-data/unit/diff.test
+++ b/test-data/unit/diff.test
@@ -680,3 +680,27 @@ B = Dict[str, S]
 [out]
 __main__.A
 __main__.T
+
+[case testNewType]
+from typing import NewType
+class C: pass
+class D: pass
+N1 = NewType('N1', C)
+N2 = NewType('N2', D)
+N3 = NewType('N3', C)
+class N4(C): pass
+[file next.py]
+from typing import NewType
+class C: pass
+class D(C): pass
+N1 = NewType('N1', C)
+N2 = NewType('N2', D)
+class N3(C): pass
+N4 = NewType('N4', C)
+[out]
+__main__.D
+__main__.N2
+__main__.N3
+__main__.N3.__init__
+__main__.N4
+__main__.N4.__init__

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1506,7 +1506,8 @@ import a
 [file a.py]
 from typing import Dict, NewType
 
-N = NewType('N', int)
+class A: pass
+N = NewType('N', A)
 
 a: Dict[N, int]
 
@@ -1516,7 +1517,8 @@ def f(self, x: N) -> None:
 [file a.py.2]
 from typing import Dict, NewType  # dummy change
 
-N = NewType('N', int)
+class A: pass
+N = NewType('N', A)
 
 a: Dict[N, int]
 
@@ -2475,3 +2477,68 @@ else:
 [builtins fixtures/ops.pyi]
 [out]
 ==
+
+[case testNewTypeDependencies1]
+from a import N
+
+def f(x: N) -> None:
+    x.y = 1
+[file a.py]
+from typing import NewType
+from b import C
+
+N = NewType('N', C)
+[file b.py]
+class C:
+    y: int
+[file b.py.2]
+class C:
+    y: str
+[out]
+==
+main:4: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+[case testNewTypeDependencies2]
+from a import N
+from b import C, D
+
+def f(x: C) -> None: pass
+
+def g(x: N) -> None:
+    f(x)
+[file a.py]
+from typing import NewType
+from b import D
+
+N = NewType('N', D)
+[file b.py]
+class C: pass
+class D(C): pass
+[file b.py.2]
+class C: pass
+class D: pass
+[out]
+==
+main:7: error: Argument 1 to "f" has incompatible type "N"; expected "C"
+
+[case testNewTypeDependencies3]
+from a import N
+
+def f(x: N) -> None:
+    x.y
+[file a.py]
+from typing import NewType
+from b import C
+N = NewType('N', C)
+[file a.py.2]
+from typing import NewType
+from b import D
+N = NewType('N', D)
+[file b.py]
+class C:
+    y: int
+class D:
+    pass
+[out]
+==
+main:4: error: "N" has no attribute "y"


### PR DESCRIPTION
NewType work highlighted an issue with subtype caches with stale
information leaking, and this fixes that issue as well. We reset the
subtype cache in two places:

* When calculating the MRO; we reset caches of all base classes as
  well.

* When merging a new version of a TypeInfo, which may have a
  different MRO; we reset all caches of base classes in the old
  MRO, as they might no longer be supertypes.