### PR TITLE
Fine-grained: Detect changes in additional TypeInfo attributes

### DIFF
--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -304,10 +304,6 @@ def snapshot_definition(node: Optional[SymbolNode],
                 snapshot_optional_type(node.var.type),
                 snapshot_definition(node.func, common))
     elif isinstance(node, TypeInfo):
-        # TODO:
-        #   type_vars
-        #   bases
-        #   _promote
         attrs = (node.is_abstract,
                  node.is_enum,
                  node.fallback_to_any,
@@ -315,12 +311,15 @@ def snapshot_definition(node: Optional[SymbolNode],
                  node.is_newtype,
                  snapshot_optional_type(node.tuple_type),
                  snapshot_optional_type(node.typeddict_type),
-                 [base.fullname() for base in node.mro])
+                 [base.fullname() for base in node.mro],
+                 node.type_vars,
+                 [snapshot_type(base) for base in node.bases],
+                 snapshot_optional_type(node._promote))
         prefix = node.fullname()
         symbol_table = snapshot_symbol_table(prefix, node.names)
         return ('TypeInfo', common, attrs, symbol_table)
     else:
-        # TODO: Handle additional types: TypeVarExpr, MypyFile, ...
+        # Other node types are handled elsewhere.
         assert False, type(node)
 
 

--- a/test-data/unit/diff.test
+++ b/test-data/unit/diff.test
@@ -680,3 +680,13 @@ B = Dict[str, S]
 [out]
 __main__.A
 __main__.T
+
+[case testChangeGenericBaseClassOnly]
+from typing import List
+class C(List[int]): pass
+[file next.py]
+from typing import List
+class C(List[str]): pass
+[builtins fixtures/list.pyi]
+[out]
+__main__.C

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1297,6 +1297,28 @@ class A: pass
 main:2: error: Module 'a' has no attribute 'A'
 ==
 
+[case testRefreshGenericAndFailInPass3]
+# Failure in semantic analysis pass 3
+from a import C
+a: C[int]
+[file a.py]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class C(Generic[T]): pass
+[file a.py.2]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+S = TypeVar('S')
+class C(Generic[T, S]): pass
+[file a.py.3]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class C(Generic[T]): pass
+[out]
+==
+main:3: error: "C" expects 2 type arguments, but 1 given
+==
+
 [case testPrintStatement_python2]
 # flags: --py2
 import a


### PR DESCRIPTION
Detect changes in type variables, generic base classes and the
`_promote` attribute. Also one of the new test cases specifically
tests semantic analyzer pass 3 when propagating fine-grained
dependencies.