### PR TITLE
Fine-grained: Fix crashes when refreshing synthetic types

### DIFF
--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -55,9 +55,9 @@ from mypy.nodes import (
 )
 from mypy.traverser import TraverserVisitor
 from mypy.types import (
-    Type, TypeVisitor, Instance, AnyType, NoneTyp, CallableType, DeletedType, PartialType,
+    Type, SyntheticTypeVisitor, Instance, AnyType, NoneTyp, CallableType, DeletedType, PartialType,
     TupleType, TypeType, TypeVarType, TypedDictType, UnboundType, UninhabitedType, UnionType,
-    Overloaded, TypeVarDef, TypeList
+    Overloaded, TypeVarDef, TypeList, CallableArgument, EllipsisType, StarType
 )
 from mypy.util import get_prefix
 
@@ -307,7 +307,7 @@ class NodeReplaceVisitor(TraverserVisitor):
         return result
 
 
-class TypeReplaceVisitor(TypeVisitor[None]):
+class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
     """Similar to NodeReplaceVisitor, but for type objects."""
 
     def __init__(self, replacements: Dict[SymbolNode, SymbolNode]) -> None:
@@ -375,6 +375,15 @@ class TypeReplaceVisitor(TypeVisitor[None]):
     def visit_type_list(self, typ: TypeList) -> None:
         for item in typ.items:
             item.accept(self)
+
+    def visit_callable_argument(self, typ: CallableArgument) -> None:
+        typ.typ.accept(self)
+
+    def visit_ellipsis_type(self, typ: EllipsisType) -> None:
+        pass
+
+    def visit_star_type(self, typ: StarType) -> None:
+        typ.type.accept(self)
 
     def visit_uninhabited_type(self, typ: UninhabitedType) -> None:
         pass

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -255,6 +255,7 @@ class TypeList(Type):
         self.items = items
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
+        assert isinstance(visitor, SyntheticTypeVisitor)
         return visitor.visit_type_list(self)
 
     def serialize(self) -> JsonDict:
@@ -1505,11 +1506,6 @@ class TypeVisitor(Generic[T]):
 
     def visit_forwardref_type(self, t: ForwardRef) -> T:
         raise RuntimeError('Internal error: unresolved forward reference')
-
-    def visit_type_list(self, t: TypeList) -> T:
-        # TODO: Do we need to implement this in more visitors? TypeList objects can
-        #   exist as components of UnboundTypes.
-        raise self._notimplemented_helper('type_list')
 
 
 class SyntheticTypeVisitor(TypeVisitor[T]):

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -2531,3 +2531,40 @@ x = ''
 b.py:5: error: Incompatible types in assignment (expression has type "int", base class "tuple" defined the type as "Callable[[Tuple[int, ...], Any], int]")
 ==
 b.py:5: error: Incompatible types in assignment (expression has type "int", base class "tuple" defined the type as "Callable[[Tuple[int, ...], Any], int]")
+
+[case testReprocessEllipses1]
+import a
+[file a.py]
+from typing import Tuple
+def foo(x: Tuple[int, ...]) -> None: pass
+[file a.py.2]
+from typing import Tuple
+def foo(x: Tuple[int, ...]) -> None: pass
+[builtins fixtures/tuple.pyi]
+[out]
+==
+
+[case testReprocessEllipses2]
+import a
+[file a.py]
+from typing import Callable
+def foo(x: Callable[..., int]) -> None: pass
+[file a.py.2]
+from typing import Callable
+def foo(x: Callable[..., int]) -> None: pass
+[out]
+==
+
+[case testReprocessCallableArg]
+import a
+[file a.py]
+from typing import Callable
+from mypy_extensions import Arg
+def a(f: Callable[[Arg(int, 'x')], int]) -> None: pass
+[file a.py.2]
+from typing import Callable
+from mypy_extensions import Arg
+def a(f: Callable[[Arg(int, 'x')], int]) -> None: pass
+[builtins fixtures/dict.pyi]
+[out]
+==

--- a/test-data/unit/lib-stub/mypy_extensions.pyi
+++ b/test-data/unit/lib-stub/mypy_extensions.pyi
@@ -1,3 +1,5 @@
+# NOTE: Requires fixtures/dict.pyi
+
 from typing import Dict, Type, TypeVar, Optional, Any
 
 _T = TypeVar('_T')


### PR DESCRIPTION
Previously we only handled one kind of synthetic type, and others would
cause a crash.

Fixes #4665.