### PR TITLE
Add coroutines to the cheatsheet

### DIFF
--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -125,8 +125,9 @@ See :ref:`async-and-await` for the full detail on typing coroutines and asynchro
            count -= 1
        return "Blastoff!"
 
-   # mypy currently does not support converting functions into async generators
-   # in Python 3.4, so you need to add a 'yield' to make it typecheck.
+   # mypy currently does not support converting functions into generator-based
+   # coroutines in Python 3.4, so you need to add a 'yield' to make it
+   # typecheck.
    @asyncio.coroutine
    def async1(obj: object) -> Generator[None, None, str]:
        if False:

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -105,8 +105,10 @@ Python 3 introduces an annotation syntax for function declarations in `PEP 3107 
        
        ...
 
-Coroutines
-**********
+Coroutines and asyncio
+**********************
+
+See :ref:`async-and-await` for the full detail on typing coroutines and asynchronous code.
 
 .. code-block:: python
 

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -115,8 +115,8 @@ See :ref:`async-and-await` for the full detail on typing coroutines and asynchro
    import asyncio
    from typing import Generator, Any
 
-   # A Python 3.4 coroutine should have a return type of
-   # Generator[Any, None, T], where T is the type it returns.
+   # A generator-based coroutine created with @asyncio.coroutine should have a
+   # return type of Generator[Any, None, T], where T is the type it returns.
    @asyncio.coroutine
    def countdown34(tag: str, count: int) -> Generator[Any, None, str]:
        while count > 0:
@@ -125,16 +125,15 @@ See :ref:`async-and-await` for the full detail on typing coroutines and asynchro
            count -= 1
        return "Blastoff!"
 
-   # mypy currently does not support converting functions into coroutines in
-   # Python 3.4, so you need to add a 'yield' to make it typecheck.
+   # mypy currently does not support converting functions into async generators
+   # in Python 3.4, so you need to add a 'yield' to make it typecheck.
    @asyncio.coroutine
    def async1(obj: object) -> Generator[None, None, str]:
        if False:
            yield
        return "placeholder"
 
-   # A Python 3.5+ coroutine is typed like a normal function, and doesn't need
-   # a 'yield' to make it typecheck.
+   # A Python 3.5+ coroutine is typed like a normal function.
    async def countdown35(tag: str, count: int) -> str:
        while count > 0:
            print('T-minus {} ({})'.format(count, tag))

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -94,6 +94,36 @@ Python 3 introduces an annotation syntax for function declarations in `PEP 3107 
            yield i
            i += 1
 
+   # A Python 3.4 coroutine should have a return type of
+   # Generator[Any, None, T], where T is the type it returns.
+   @asyncio.coroutine
+   def countdown(tag: str, count: int) -> Generator[Any, None, str]:
+       while count > 0:
+           print('T-minus {} ({})'.format(count, tag))
+           yield from asyncio.sleep(0.1)
+           count -= 1
+       return "Blastoff!"
+
+   # mypy currently does not support converting functions into coroutines in
+   # Python 3.4, so you need to add a 'yield' to make it typecheck.
+   @asyncio.coroutine
+   def quux(obj: object) -> Generator[None, None, str]:
+       if False:
+           yield
+       return "placeholder"
+
+   # A Python 3.5+ coroutine is typed like a normal function, and doesn't need
+   # a 'yield' to make it typecheck.
+   async def countdown(tag: str, count: int) -> str:
+       while count > 0:
+           print('T-minus {} ({})'.format(count, tag))
+           await asyncio.sleep(0.1)
+           count -= 1
+       return "Blastoff!"
+
+   async def quux(obj: object) -> str:
+       return "placeholder"
+
    # For a function with many arguments, you can of course split it over multiple lines
    def send_email(address: Union[str, List[str]],
                   sender: str,

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -62,8 +62,7 @@ Python 3 introduces an annotation syntax for function declarations in `PEP 3107 
 
 .. code-block:: python
 
-   from typing import Callable, Iterable, Union, Optional, List, Generator, Any
-   import asyncio
+   from typing import Callable, Iterable, Union, Optional, List
 
    # This is how you annotate a function definition.
    def stringify(num: int) -> str:
@@ -89,11 +88,30 @@ Python 3 introduces an annotation syntax for function declarations in `PEP 3107 
 
    # A generator function that yields ints is secretly just a function that
    # returns an iterable (see below) of ints, so that's how we annotate it.
-   def f2(n: int) -> Iterable[int]:
+   def f(n: int) -> Iterable[int]:
        i = 0
        while i < n:
            yield i
            i += 1
+
+   # For a function with many arguments, you can of course split it over multiple lines
+   def send_email(address: Union[str, List[str]],
+                  sender: str,
+                  cc: Optional[List[str]],
+                  bcc: Optional[List[str]],
+                  subject='',
+                  body: List[str] = None
+                  ) -> bool:
+       
+       ...
+
+Coroutines
+**********
+
+.. code-block:: python
+
+   import asyncio
+   from typing import Generator, Any
 
    # A Python 3.4 coroutine should have a return type of
    # Generator[Any, None, T], where T is the type it returns.
@@ -124,18 +142,6 @@ Python 3 introduces an annotation syntax for function declarations in `PEP 3107 
 
    async def async2(obj: object) -> str:
        return "placeholder"
-
-   # For a function with many arguments, you can of course split it over multiple lines
-   def send_email(address: Union[str, List[str]],
-                  sender: str,
-                  cc: Optional[List[str]],
-                  bcc: Optional[List[str]],
-                  subject='',
-                  body: List[str] = None
-                  ) -> bool:
-       
-       ...
-
 
 When you're puzzled or when things are complicated
 **************************************************

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -62,7 +62,8 @@ Python 3 introduces an annotation syntax for function declarations in `PEP 3107 
 
 .. code-block:: python
 
-   from typing import Callable, Iterable, Union, Optional, List
+   from typing import Callable, Iterable, Union, Optional, List, Generator, Any
+   import asyncio
 
    # This is how you annotate a function definition.
    def stringify(num: int) -> str:
@@ -88,7 +89,7 @@ Python 3 introduces an annotation syntax for function declarations in `PEP 3107 
 
    # A generator function that yields ints is secretly just a function that
    # returns an iterable (see below) of ints, so that's how we annotate it.
-   def f(n: int) -> Iterable[int]:
+   def f2(n: int) -> Iterable[int]:
        i = 0
        while i < n:
            yield i
@@ -97,7 +98,7 @@ Python 3 introduces an annotation syntax for function declarations in `PEP 3107 
    # A Python 3.4 coroutine should have a return type of
    # Generator[Any, None, T], where T is the type it returns.
    @asyncio.coroutine
-   def countdown(tag: str, count: int) -> Generator[Any, None, str]:
+   def countdown34(tag: str, count: int) -> Generator[Any, None, str]:
        while count > 0:
            print('T-minus {} ({})'.format(count, tag))
            yield from asyncio.sleep(0.1)
@@ -107,21 +108,21 @@ Python 3 introduces an annotation syntax for function declarations in `PEP 3107 
    # mypy currently does not support converting functions into coroutines in
    # Python 3.4, so you need to add a 'yield' to make it typecheck.
    @asyncio.coroutine
-   def quux(obj: object) -> Generator[None, None, str]:
+   def async1(obj: object) -> Generator[None, None, str]:
        if False:
            yield
        return "placeholder"
 
    # A Python 3.5+ coroutine is typed like a normal function, and doesn't need
    # a 'yield' to make it typecheck.
-   async def countdown(tag: str, count: int) -> str:
+   async def countdown35(tag: str, count: int) -> str:
        while count > 0:
            print('T-minus {} ({})'.format(count, tag))
            await asyncio.sleep(0.1)
            count -= 1
        return "Blastoff!"
 
-   async def quux(obj: object) -> str:
+   async def async2(obj: object) -> str:
        return "placeholder"
 
    # For a function with many arguments, you can of course split it over multiple lines


### PR DESCRIPTION
It took me a while to find http://mypy.readthedocs.io/en/stable/kinds_of_types.html#typing-async-await in the documentation, and it would have been easier to find if it was mentioned in the cheatsheet - this adds both `@asyncio.coroutine` and `async def` examples to the Python 3 cheatsheet.

I *think* it's right that the YieldType of a Python 3.4 generator-coroutine should always be Any, and the SendType always None, but if there are exceptions let me know and I can tweak the text. 