### PR TITLE
Add support for --junit-xml=FILE to dmypy [re]check

### DIFF
--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -17,6 +17,7 @@ import time
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, TypeVar
 
 from mypy.dmypy_util import STATUS_FILE, receive
+from mypy.util import write_junit_xml
 
 # Argument parser.  Subparsers are tied to action functions by the
 # @action(subparse) decorator.
@@ -50,12 +51,14 @@ check_parser = p = subparsers.add_parser('check',
                                          help="Check some files (requires running daemon)")
 p.add_argument('-v', '--verbose', action='store_true', help="Print detailed status")
 p.add_argument('-q', '--quiet', action='store_true', help=argparse.SUPPRESS)  # Deprecated
+p.add_argument('--junit-xml', help="write junit.xml to the given file")
 p.add_argument('files', metavar='FILE', nargs='+', help="File (or directory) to check")
 
 recheck_parser = p = subparsers.add_parser('recheck',
     help="Check the same files as the most previous  check run (requires running daemon)")
 p.add_argument('-v', '--verbose', action='store_true', help="Print detailed status")
 p.add_argument('-q', '--quiet', action='store_true', help=argparse.SUPPRESS)  # Deprecated
+p.add_argument('--junit-xml', help="write junit.xml to the given file")
 
 hang_parser = p = subparsers.add_parser('hang', help="Hang for 100 seconds")
 
@@ -221,7 +224,7 @@ def do_check(args: argparse.Namespace) -> None:
     response = request('check', files=args.files)
     t1 = time.time()
     response['roundtrip_time'] = t1 - t0
-    check_output(response, args.verbose)
+    check_output(response, args.verbose, args.junit_xml)
 
 
 @action(recheck_parser)
@@ -234,10 +237,10 @@ def do_recheck(args: argparse.Namespace) -> None:
     response = request('recheck')
     t1 = time.time()
     response['roundtrip_time'] = t1 - t0
-    check_output(response, args.verbose)
+    check_output(response, args.verbose, args.junit_xml)
 
 
-def check_output(response: Dict[str, Any], verbose: bool) -> None:
+def check_output(response: Dict[str, Any], verbose: bool, junit_xml: Optional[str]) -> None:
     """Print the output from a check or recheck command.
 
     Call sys.exit() unless the status code is zero.
@@ -252,6 +255,9 @@ def check_output(response: Dict[str, Any], verbose: bool) -> None:
     sys.stderr.write(err)
     if verbose:
         show_stats(response)
+    if junit_xml:
+        messages = (out + err).splitlines()
+        write_junit_xml(response['roundtrip_time'], bool(err), messages, junit_xml)
     if status_code:
         sys.exit(status_code)
 


### PR DESCRIPTION
Refuse a non-empty value for dmypy [re]start.

Also implement blocker logic in dmypy (CompileError === blocker).

Fixes #4663.