### PR TITLE
Fix issues related to indirect imports in import cycles

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -333,7 +333,7 @@ class ImportedName(SymbolNode):
     analysis pass 2, these references should be replaced with direct
     reference to a real AST node.
 
-    Note that this is neither a Statement nor an Expressions so this
+    Note that this is neither a Statement nor an Expression so this
     can't be visited.
     """
 
@@ -352,6 +352,9 @@ class ImportedName(SymbolNode):
     @classmethod
     def deserialize(cls, data: JsonDict) -> 'ImportedName':
         assert False, "ImportedName should never be serialized"
+
+    def __str__(self) -> str:
+        return 'ImportedName(%s)' % self.target_fullname
 
 
 class FuncBase(Node):

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -325,6 +325,35 @@ class ImportAll(ImportBase):
         return visitor.visit_import_all(self)
 
 
+class ImportedName(SymbolNode):
+    """Indirect reference to a fullname stored in symbol table.
+
+    This node is not present in the original program as such. This is
+    just a temporary artifact in binding imported names. After semantic
+    analysis pass 2, these references should be replaced with direct
+    reference to a real AST node.
+
+    Note that this is neither a Statement nor an Expressions so this
+    can't be visited.
+    """
+
+    def __init__(self, target_fullname: str) -> None:
+        self.target_fullname = target_fullname
+
+    def name(self) -> str:
+        return self.target_fullname.split('.')[-1]
+
+    def fullname(self) -> str:
+        return self.target_fullname
+
+    def serialize(self) -> JsonDict:
+        assert False, "ImportedName leaked from semantic analysis"
+
+    @classmethod
+    def deserialize(cls, data: JsonDict) -> 'ImportedName':
+        assert False, "ImportedName should never be serialized"
+
+
 class FuncBase(Node):
     """Abstract base class for function-like nodes"""
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1647,8 +1647,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         if i_id in self.modules:
             m = self.modules[i_id]
             self.add_submodules_to_parent_modules(i_id, True)
-            for name, node in m.names.items():
-                node = self.dereference_module_cross_ref(node)
+            for name, orig_node in m.names.items():
+                node = self.dereference_module_cross_ref(orig_node)
                 if node is None:
                     continue
                 new_node = self.normalize_type_alias(node, i)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1648,6 +1648,9 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             m = self.modules[i_id]
             self.add_submodules_to_parent_modules(i_id, True)
             for name, node in m.names.items():
+                node = self.dereference_module_cross_ref(node)
+                if node is None:
+                    continue
                 new_node = self.normalize_type_alias(node, i)
                 # if '__all__' exists, all nodes not included have had module_public set to
                 # False, and we can skip checking '_' because it's been explicitly included.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1568,6 +1568,9 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         # nothing).
         while node and isinstance(node.node, ImportedName):
             fullname = node.node.fullname()
+            if fullname in self.modules:
+                # This is a module reference.
+                return SymbolTableNode(MODULE_REF, self.modules[fullname])
             if fullname in seen:
                 # Looks like a reference cycle. Just break it.
                 # TODO: Generate a more specific error message.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3440,6 +3440,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             # else:
             #     names = file.names
             n = file.names.get(expr.name, None) if file is not None else None
+            n = self.dereference_module_cross_ref(n)
             if n and not n.module_hidden:
                 n = self.normalize_type_alias(n, expr)
                 if not n:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -84,7 +84,7 @@ from mypy import experiments
 from mypy.plugin import Plugin, ClassDefContext, SemanticAnalyzerPluginInterface
 from mypy import join
 from mypy.util import get_prefix, correct_relative_import
-from mypy.semanal_shared import PRIORITY_FALLBACKS
+from mypy.semanal_shared import SemanticAnalyzerInterface, PRIORITY_FALLBACKS
 from mypy.scope import Scope
 
 
@@ -174,7 +174,9 @@ SUGGESTED_TEST_FIXTURES = {
 }
 
 
-class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
+class SemanticAnalyzerPass2(NodeVisitor[None],
+                            SemanticAnalyzerInterface,
+                            SemanticAnalyzerPluginInterface):
     """Semantically analyze parsed mypy files.
 
     The analyzer binds names and does various consistency checks for a
@@ -1703,11 +1705,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
                       third_pass: bool = False) -> TypeAnalyser:
         if tvar_scope is None:
             tvar_scope = self.tvar_scope
-        tpan = TypeAnalyser(self.lookup_qualified,
-                            self.lookup_fully_qualified,
+        tpan = TypeAnalyser(self,
                             tvar_scope,
-                            self.fail,
-                            self.note,
                             self.plugin,
                             self.options,
                             self.is_typeshed_stub_file,
@@ -1836,11 +1835,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None], SemanticAnalyzerPluginInterface):
         dynamic = bool(self.function_stack and self.function_stack[-1].is_dynamic())
         global_scope = not self.type and not self.function_stack
         res = analyze_type_alias(rvalue,
-                                 self.lookup_qualified,
-                                 self.lookup_fully_qualified,
+                                 self,
                                  self.tvar_scope,
-                                 self.fail,
-                                 self.note,
                                  self.plugin,
                                  self.options,
                                  self.is_typeshed_stub_file,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1603,7 +1603,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
 
     def normalize_type_alias(self, node: SymbolTableNode,
                              ctx: Context) -> Optional[SymbolTableNode]:
-        """If node refers to a built-intype alias, normalize it.
+        """If node refers to a built-in type alias, normalize it.
 
         An example normalization is 'typing.List' -> '__builtins__.list'.
 

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -23,14 +23,15 @@ from mypy import experiments
 from mypy.nodes import (
     MypyFile, SymbolTable, SymbolTableNode, Var, Block, AssignmentStmt, FuncDef, Decorator,
     ClassDef, TypeInfo, ImportFrom, Import, ImportAll, IfStmt, WhileStmt, ForStmt, WithStmt,
-    TryStmt, OverloadedFuncDef, Lvalue, Context, LDEF, GDEF, MDEF, UNBOUND_IMPORTED, MODULE_REF,
-    implicit_module_attrs
+    TryStmt, OverloadedFuncDef, Lvalue, Context, ImportedName, LDEF, GDEF, MDEF, UNBOUND_IMPORTED,
+    MODULE_REF, implicit_module_attrs
 )
 from mypy.types import Type, UnboundType, UnionType, AnyType, TypeOfAny, NoneTyp
 from mypy.semanal import SemanticAnalyzerPass2, infer_reachability_of_if_statement
 from mypy.options import Options
 from mypy.sametypes import is_same_type
 from mypy.visitor import NodeVisitor
+from mypy.util import correct_relative_import
 
 
 class SemanticAnalyzerPass1(NodeVisitor[None]):
@@ -62,6 +63,7 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
         self.pyversion = options.python_version
         self.platform = options.platform
         sem.cur_mod_id = mod_id
+        sem.cur_mod_node = file
         sem.errors.set_file(fnam, mod_id)
         sem.globals = SymbolTable()
         sem.global_decls = [set()]
@@ -148,7 +150,8 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
         if at_module and func.name() in sem.globals:
             # Already defined in this module.
             original_sym = sem.globals[func.name()]
-            if original_sym.kind == UNBOUND_IMPORTED:
+            if (original_sym.kind == UNBOUND_IMPORTED or
+                    isinstance(original_sym.node, ImportedName)):
                 # Ah this is an imported name. We can't resolve them now, so we'll postpone
                 # this until the main phase of semantic analysis.
                 return
@@ -241,7 +244,16 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
         for name, as_name in node.names:
             imported_name = as_name or name
             if imported_name not in self.sem.globals:
-                self.add_symbol(imported_name, SymbolTableNode(UNBOUND_IMPORTED, None), node)
+                target_module, ok = correct_relative_import(
+                    self.sem.cur_mod_id,
+                    node.relative,
+                    node.id,
+                    self.sem.cur_mod_node.is_package_init_file())
+                if ok:
+                    target_name = '%s.%s' % (target_module, imported_name)
+                    link_node = ImportedName(target_name)
+                    sym = SymbolTableNode(GDEF, link_node)
+                    self.add_symbol(imported_name, sym, context=node)
 
     def visit_import(self, node: Import) -> None:
         node.is_top_level = self.sem.is_module_scope()
@@ -312,8 +324,9 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
 
     def add_symbol(self, name: str, node: SymbolTableNode,
                    context: Context) -> None:
-        # This is related to SemanticAnalyzerPass2.add_symbol. Since both methods will
-        # be called on top-level definitions, they need to co-operate.
+        # NOTE: This is closely related to SemanticAnalyzerPass2.add_symbol. Since both methods
+        #     will be called on top-level definitions, they need to co-operate. If you change
+        #     this, you may have to change the other method as well.
         if self.sem.is_func_scope():
             assert self.sem.locals[-1] is not None
             if name in self.sem.locals[-1]:
@@ -325,8 +338,10 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
         else:
             assert self.sem.type is None  # Pass 1 doesn't look inside classes
             existing = self.sem.globals.get(name)
-            if existing and (not isinstance(node.node, MypyFile) or
-                             existing.node != node.node) and existing.kind != UNBOUND_IMPORTED:
+            if (existing
+                    and (not isinstance(node.node, MypyFile) or existing.node != node.node)
+                    and existing.kind != UNBOUND_IMPORTED
+                    and not isinstance(existing.node, ImportedName)):
                 # Modules can be imported multiple times to support import
                 # of multiple submodules of a package (e.g. a.x and a.y).
                 ok = False

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -451,8 +451,7 @@ class SemanticAnalyzerPass3(TraverserVisitor,
 
     def fail(self, msg: str, ctx: Context, serious: bool = False, *,
              blocker: bool = False) -> None:
-        # TODO: Process all arguments
-        self.errors.report(ctx.get_line(), ctx.get_column(), msg)
+        self.sem.fail(msg, ctx, serious, blocker=blocker)
 
     def fail_blocker(self, msg: str, ctx: Context) -> None:
         self.fail(msg, ctx, blocker=True)

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -445,6 +445,10 @@ class SemanticAnalyzerPass3(TraverserVisitor,
     def lookup_fully_qualified(self, fullname: str) -> Optional[SymbolTableNode]:
         return self.sem.lookup_fully_qualified(fullname)
 
+    def dereference_module_cross_ref(
+            self, node: Optional[SymbolTableNode]) -> Optional[SymbolTableNode]:
+        return self.sem.dereference_module_cross_ref(node)
+
     def fail(self, msg: str, ctx: Context, serious: bool = False, *,
              blocker: bool = False) -> None:
         # TODO: Process all arguments

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -442,7 +442,7 @@ class SemanticAnalyzerPass3(TraverserVisitor,
                          suppress_errors: bool = False) -> Optional[SymbolTableNode]:
         return self.sem.lookup_qualified(name, ctx, suppress_errors=suppress_errors)
 
-    def lookup_fully_qualified(self, fullname: str) -> Optional[SymbolTableNode]:
+    def lookup_fully_qualified(self, fullname: str) -> SymbolTableNode:
         return self.sem.lookup_fully_qualified(fullname)
 
     def dereference_module_cross_ref(

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -1,5 +1,11 @@
 """Shared definitions used by different parts of semantic analysis."""
 
+from abc import abstractmethod
+from typing import Optional
+
+from mypy.nodes import Context, SymbolTableNode
+
+
 # Priorities for ordering of patches within the final "patch" phase of semantic analysis
 # (after pass 3):
 
@@ -9,3 +15,32 @@ PRIORITY_FORWARD_REF = 0
 PRIORITY_FALLBACKS = 1
 # Checks type var values (does subtype checks)
 PRIORITY_TYPEVAR_VALUES = 2
+
+
+class SemanticAnalyzerInterface:
+    """A limited abstract interface to some generic semantic analyzer functionality.
+
+    We use this interface for various reasons:
+
+    * Looser coupling
+    * Cleaner import graph
+    * Less need to pass around callback functions
+    """
+
+    @abstractmethod
+    def lookup_qualified(self, name: str, ctx: Context,
+                         suppress_errors: bool = False) -> Optional[SymbolTableNode]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def lookup_fully_qualified(self, name: str) -> SymbolTableNode:
+        raise NotImplementedError
+
+    @abstractmethod
+    def fail(self, msg: str, ctx: Context, serious: bool = False, *,
+             blocker: bool = False) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def note(self, msg: str, ctx: Context) -> None:
+        raise NotImplementedError

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -37,6 +37,11 @@ class SemanticAnalyzerInterface:
         raise NotImplementedError
 
     @abstractmethod
+    def dereference_module_cross_ref(
+            self, node: Optional[SymbolTableNode]) -> Optional[SymbolTableNode]:
+        raise NotImplementedError
+
+    @abstractmethod
     def fail(self, msg: str, ctx: Context, serious: bool = False, *,
              blocker: bool = False) -> None:
         raise NotImplementedError

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -180,7 +180,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             # We don't need to worry about double-wrapping Optionals or
             # wrapping Anys: Union simplification will take care of that.
             return make_optional_type(self.visit_unbound_type(t))
-        sym = self.lookup(t.name, t, suppress_errors=self.third_pass)  # type: ignore
+        sym = self.lookup(t.name, t, suppress_errors=self.third_pass)
         if '.' in t.name:
             # Handle indirect references to imported names.
             #

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -284,6 +284,8 @@ class TypeOfAny(Enum):
     special_form = 'special_form'
     # Does this Any come from interaction with another Any?
     from_another_any = 'from_another_any'
+    # Does this Any come from an implementation limitation/bug?
+    implementation_artifact = 'implementation_artifact'
 
 
 class AnyType(Type):

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4127,3 +4127,26 @@ class Foo:
 x = Foo()
 [out]
 [out2]
+
+[case testImportReExportInCycle]
+from m import One
+[file m/__init__.py]
+from .one import One
+from .two import Two
+[file m/one.py]
+class One:
+    pass
+[file m/two.py]
+import m
+class Two:
+    pass
+[file m/one.py.2]
+class One:
+    name: str
+[file m/two.py.2]
+import m
+reveal_type(m.One.name)
+class Two:
+    pass
+[out2]
+tmp/m/two.py:2: error: Revealed type is 'builtins.str'

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4127,22 +4127,3 @@ class Foo:
 x = Foo()
 [out]
 [out2]
-
-[case testForwardReferenceToImportedAliasInProperty]
-import a
-
-class A:
-    @property
-    def p(self) -> C: pass
-    @p.setter
-    def p(self, c: C) -> None: pass
-    @p.deleter
-    def p(self) -> None: pass
-
-from m import C
-[file m.py]
-C = str
-[file a.py]
-[file a.py.2]
-# dummy
-[builtins fixtures/property.pyi]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4127,3 +4127,22 @@ class Foo:
 x = Foo()
 [out]
 [out2]
+
+[case testForwardReferenceToImportedAliasInProperty]
+import a
+
+class A:
+    @property
+    def p(self) -> C: pass
+    @p.setter
+    def p(self, c: C) -> None: pass
+    @p.deleter
+    def p(self) -> None: pass
+
+from m import C
+[file m.py]
+C = str
+[file a.py]
+[file a.py.2]
+# dummy
+[builtins fixtures/property.pyi]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2152,3 +2152,22 @@ class Two:
     pass
 [out]
 tmp/m/two.py:3: error: Revealed type is 'Union[builtins.int, builtins.str]'
+
+[case testImportCycleSpecialCase]
+import p
+[file p/__init__.py]
+from . import a
+from . import b
+reveal_type(a.foo())
+[file p/a.py]
+import p
+def foo() -> int: pass
+[file p/b.py]
+import p
+
+def run() -> None:
+    reveal_type(p.a.foo())
+[builtins fixtures/module.pyi]
+[out]
+tmp/p/b.py:4: error: Revealed type is 'builtins.int'
+tmp/p/__init__.py:3: error: Revealed type is 'builtins.int'

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2049,3 +2049,106 @@ class B:
     x: int
 x = str()
 y = int()
+
+[case testImportFromReExportInCycleUsingRelativeImport1]
+from m import One
+reveal_type(One)
+[file m/__init__.py]
+from .one import One
+from .two import Two
+reveal_type(One)
+[file m/one.py]
+class One:
+    pass
+[file m/two.py]
+from m import One
+reveal_type(One)
+x: One
+reveal_type(x)
+
+class Two(One):
+    pass
+y: Two
+y = x
+x = y
+[out]
+tmp/m/two.py:2: error: Revealed type is 'def () -> m.one.One'
+tmp/m/two.py:4: error: Revealed type is 'm.one.One'
+tmp/m/two.py:9: error: Incompatible types in assignment (expression has type "One", variable has type "Two")
+tmp/m/__init__.py:3: error: Revealed type is 'def () -> m.one.One'
+main:2: error: Revealed type is 'def () -> m.one.One'
+
+[case testImportReExportInCycleUsingRelativeImport2]
+from m import One
+reveal_type(One)
+[file m/__init__.py]
+from .one import One
+from .two import Two
+reveal_type(One)
+[file m/one.py]
+class One:
+    pass
+[file m/two.py]
+import m
+reveal_type(m.One)
+x: m.One
+reveal_type(x)
+class Two:
+    pass
+[out]
+tmp/m/two.py:2: error: Revealed type is 'def () -> m.one.One'
+tmp/m/two.py:4: error: Revealed type is 'm.one.One'
+tmp/m/__init__.py:3: error: Revealed type is 'def () -> m.one.One'
+main:2: error: Revealed type is 'def () -> m.one.One'
+
+[case testImportReExportedNamedTupleInCycle1]
+from m import One
+[file m/__init__.py]
+from .one import One
+from .two import Two
+[file m/one.py]
+from typing import NamedTuple
+class One(NamedTuple):
+    name: str
+[file m/two.py]
+import m
+x = m.One(name="Foo")
+reveal_type(x.name)
+class Two:
+    pass
+[out]
+tmp/m/two.py:3: error: Revealed type is 'builtins.str'
+
+[case testImportReExportedNamedTupleInCycle2]
+from m import One
+[file m/__init__.py]
+from .one import One
+from .two import Two
+[file m/one.py]
+from typing import NamedTuple
+One = NamedTuple('One', [('name', str)])
+[file m/two.py]
+import m
+x = m.One(name="Foo")
+reveal_type(x.name)
+class Two:
+    pass
+[out]
+tmp/m/two.py:3: error: Revealed type is 'builtins.str'
+
+[case testImportReExportedTypeAliasInCycle]
+from m import One
+[file m/__init__.py]
+from .one import One
+from .two import Two
+[file m/one.py]
+from typing import Union
+One = Union[int, str]
+[file m/two.py]
+import m
+x: m.One
+reveal_type(x)
+class Two:
+    pass
+[out]
+tmp/m/two.py:3: error: Revealed type is 'Union[builtins.int, builtins.str]'

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2003,18 +2003,15 @@ reveal_type(x) # E: Revealed type is 'builtins.str'
 x = str()
 y = int()
 
-[case testForwardReferenceToImportedAlias]
+[case testForwardReferenceToListAlias]
+x: List[int]
+reveal_type(x) # E: Revealed type is 'builtins.list[builtins.int]'
+def f() -> 'List[int]': pass
+reveal_type(f) # E: Revealed type is 'def () -> builtins.list[builtins.int]'
 class A:
-    @property
-    def p(self) -> C: pass
-    @p.setter
-    def p(self, c: C) -> None: pass
-    @p.deleter
-    def p(self) -> None: pass
-
-#reveal_type(A().x)
-
-from m import C
-[file m.py]
-C = str
-[builtins fixtures/property.pyi]
+    y: 'List[str]'
+    def g(self, x: 'List[int]') -> None: pass
+reveal_type(A().y) # E: Revealed type is 'builtins.list[builtins.str]'
+reveal_type(A().g) # E: Revealed type is 'def (x: builtins.list[builtins.int])'
+from typing import List
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2015,3 +2015,17 @@ reveal_type(A().y) # E: Revealed type is 'builtins.list[builtins.str]'
 reveal_type(A().g) # E: Revealed type is 'def (x: builtins.list[builtins.int])'
 from typing import List
 [builtins fixtures/list.pyi]
+
+[case testIndirectStarImportWithinCycle]
+import a
+[file a.py]
+from b import f
+from c import x
+[file b.py]
+from c import y
+from a import *
+def f() -> None: pass
+reveal_type(x) # E: Revealed type is 'builtins.str'
+[file c.py]
+x = str()
+y = int()

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2003,7 +2003,9 @@ reveal_type(x) # E: Revealed type is 'builtins.str'
 x = str()
 y = int()
 
-[case testForwardReferenceToListAlias]
+[case testForwardReferenceToListAlias-skip]
+# TODO: This fails because of missing ImportedName handling in
+#     mypy.typeanal.TypeAnalyser.visit_unbound_type.
 x: List[int]
 reveal_type(x) # E: Revealed type is 'builtins.list[builtins.int]'
 def f() -> 'List[int]': pass
@@ -2027,5 +2029,23 @@ from a import *
 def f() -> None: pass
 reveal_type(x) # E: Revealed type is 'builtins.str'
 [file c.py]
+x = str()
+y = int()
+
+[case testIndirectFromImportWithinCycleUsedAsBaseClass-skip]
+-- TODO: Fails because of missing ImportedName handling in mypy.typeanal
+import a
+[file a.py]
+from b import f
+from c import B
+[file b.py]
+from c import y
+class A(B): pass
+reveal_type(A().x) # E: Revealed type is 'builtins.str'
+from a import B
+def f() -> None: pass
+[file c.py]
+class B:
+    x: int
 x = str()
 y = int()

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1330,6 +1330,8 @@ pass
 [file b]
 pass
 
+-- Misc
+
 [case testScriptsAreNotModules]
 # cmd: mypy a b
 [file a]
@@ -1955,3 +1957,17 @@ import c
 tmp/b.py:1: error: Cannot find module named 'c'
 main:1: error: Cannot find module named 'c'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+
+[case testIndirectImportWithinCycle1]
+import a
+[file a.py]
+from b import f
+from c import x
+[file b.py]
+from c import y
+from a import x
+def f() -> None: pass
+reveal_type(x) # E: Revealed type is 'builtins.str'
+[file c.py]
+x = str()
+y = int()

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1958,7 +1958,7 @@ tmp/b.py:1: error: Cannot find module named 'c'
 main:1: error: Cannot find module named 'c'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 
-[case testIndirectImportWithinCycle1]
+[case testIndirectFromImportWithinCycle]
 import a
 [file a.py]
 from b import f
@@ -1969,5 +1969,36 @@ from a import x
 def f() -> None: pass
 reveal_type(x) # E: Revealed type is 'builtins.str'
 [file c.py]
+x = str()
+y = int()
+
+[case testIndirectFromImportWithinCycleInPackage]
+import p.a
+[file p/__init__.py]
+[file p/a.py]
+from p.b import f
+from p.c import x
+[file p/b.py]
+from p.c import y
+from p.a import x
+def f() -> None: pass
+reveal_type(x) # E: Revealed type is 'builtins.str'
+[file p/c.py]
+x = str()
+y = int()
+
+[case testIndirectFromImportWithinCycleInPackageIgnoredInit]
+# cmd: mypy -m p.a p.b p.c
+# flags: --follow-imports=skip --ignore-missing-imports
+[file p/__init__.py]
+[file p/a.py]
+from p.b import f
+from p.c import x
+[file p/b.py]
+from p.c import y
+from p.a import x
+def f() -> None: pass
+reveal_type(x) # E: Revealed type is 'builtins.str'
+[file p/c.py]
 x = str()
 y = int()

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2002,3 +2002,19 @@ reveal_type(x) # E: Revealed type is 'builtins.str'
 [file p/c.py]
 x = str()
 y = int()
+
+[case testForwardReferenceToImportedAlias]
+class A:
+    @property
+    def p(self) -> C: pass
+    @p.setter
+    def p(self, c: C) -> None: pass
+    @p.deleter
+    def p(self) -> None: pass
+
+#reveal_type(A().x)
+
+from m import C
+[file m.py]
+C = str
+[builtins fixtures/property.pyi]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1958,7 +1958,7 @@ tmp/b.py:1: error: Cannot find module named 'c'
 main:1: error: Cannot find module named 'c'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 
-[case testIndirectFromImportWithinCycle]
+[case testIndirectFromImportWithinCycle1]
 import a
 [file a.py]
 from b import f
@@ -1968,6 +1968,20 @@ from c import y
 from a import x
 def f() -> None: pass
 reveal_type(x) # E: Revealed type is 'builtins.str'
+[file c.py]
+x = str()
+y = int()
+
+[case testIndirectFromImportWithinCycle2]
+import a
+[file a.py]
+from c import y
+from b import x
+def f() -> None: pass
+reveal_type(x) # E: Revealed type is 'builtins.str'
+[file b.py]
+from a import f
+from c import x
 [file c.py]
 x = str()
 y = int()
@@ -2018,7 +2032,7 @@ reveal_type(A().g) # E: Revealed type is 'def (x: builtins.list[builtins.int])'
 from typing import List
 [builtins fixtures/list.pyi]
 
-[case testIndirectStarImportWithinCycle]
+[case testIndirectStarImportWithinCycle1]
 import a
 [file a.py]
 from b import f
@@ -2028,6 +2042,20 @@ from c import y
 from a import *
 def f() -> None: pass
 reveal_type(x) # E: Revealed type is 'builtins.str'
+[file c.py]
+x = str()
+y = int()
+
+[case testIndirectStarImportWithinCycle2]
+import a
+[file a.py]
+from c import y
+from b import *
+def f() -> None: pass
+reveal_type(x) # E: Revealed type is 'builtins.str'
+[file b.py]
+from a import f
+from c import x
 [file c.py]
 x = str()
 y = int()

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -1312,4 +1312,5 @@ from m import C
 C = str
 [builtins fixtures/property.pyi]
 [out2]
-tmp/a.py:2: error: Revealed type is 'builtins.str'
+-- TODO: Should be 'builtins.str'
+tmp/a.py:2: error: Revealed type is 'Any'

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -1268,3 +1268,48 @@ class Test:
 tmp/a.py:2: error: Revealed type is 'b.<callable subtype of Foo>'
 [out2]
 tmp/a.py:2: error: Revealed type is 'b.<callable subtype of Foo>'
+
+[case testSerializeForwardReferenceToAliasInProperty]
+import a
+[file a.py]
+import b
+[file a.py.2]
+import b
+reveal_type(b.A().p)
+[file b.py]
+
+class A:
+    @property
+    def p(self) -> C: pass
+    @p.setter
+    def p(self, c: C) -> None: pass
+    @p.deleter
+    def p(self) -> None: pass
+
+C = str
+[builtins fixtures/property.pyi]
+[out2]
+tmp/a.py:2: error: Revealed type is 'builtins.str'
+
+[case testSerializeForwardReferenceToImportedAliasInProperty]
+import a
+[file a.py]
+import b
+[file a.py.2]
+import b
+reveal_type(b.A().p)
+[file b.py]
+class A:
+    @property
+    def p(self) -> C: pass
+    @p.setter
+    def p(self, c: C) -> None: pass
+    @p.deleter
+    def p(self) -> None: pass
+
+from m import C
+[file m.py]
+C = str
+[builtins fixtures/property.pyi]
+[out2]
+tmp/a.py:2: error: Revealed type is 'builtins.str'


### PR DESCRIPTION
This adds supports for some cases of importing an imported name
within an import cycle. Originally they could result in false positives 
or false negatives.

The idea is to use a new node type `ImportedName` in semantic
analysis pass 1 to represent an indirect reference to a name in another
module. It will get resolved in semantic analysis pass 2.

`ImportedName` is not yet used everywhere where it could make 
sense and this doesn't fix all related issues with import cycles.

Also did a bit of refactoring of type semantic analysis to avoid passing
multiple callback functions.

Fixes #4049.
Fixes #4429.
Fixes #4682.

Borrowed test cases from #4495 by @carljm. This PR is an alternative 
for #4495.

Supersedes #4495 