### PR TITLE
Make testfinegrained use dmypy_server

### DIFF
--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -147,8 +147,8 @@ def do_restart(args: argparse.Namespace) -> None:
 def start_server(args: argparse.Namespace) -> None:
     """Start the server from command arguments and wait for it."""
     # Lazy import so this import doesn't slow down other commands.
-    from mypy.dmypy_server import daemonize, Server
-    if daemonize(Server(args.flags).serve, args.log_file) != 0:
+    from mypy.dmypy_server import daemonize, Server, process_start_options
+    if daemonize(Server(process_start_options(args.flags)).serve, args.log_file) != 0:
         sys.exit(1)
     wait_for_server()
 
@@ -283,8 +283,8 @@ def do_hang(args: argparse.Namespace) -> None:
 def do_daemon(args: argparse.Namespace) -> None:
     """Serve requests in the foreground."""
     # Lazy import so this import doesn't slow down other commands.
-    from mypy.dmypy_server import Server
-    Server(args.flags).serve()
+    from mypy.dmypy_server import Server, process_start_options
+    Server(process_start_options(args.flags)).serve()
 
 
 @action(help_parser)

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 import mypy.build
 import mypy.errors
 import mypy.main
-import mypy.server.update
+from mypy.server.update import FineGrainedBuildManager
 from mypy.dmypy_util import STATUS_FILE, receive
 from mypy.gclogger import GcLogger
 from mypy.fscache import FileSystemCache
@@ -109,12 +109,14 @@ class Server:
     # NOTE: the instance is constructed in the parent process but
     # serve() is called in the grandchild (by daemonize()).
 
-    def __init__(self, options: Options) -> None:
+    def __init__(self, options: Options, alt_lib_path: Optional[str] = None) -> None:
         """Initialize the server with the desired mypy flags."""
         self.saved_cache = {}  # type: mypy.build.SavedCache
-        self.fine_grained_initialized = False
         self.fine_grained = options.fine_grained_incremental
         self.options = options
+        self.alt_lib_path = alt_lib_path
+        self.fine_grained_manager = None  # type: Optional[FineGrainedBuildManager]
+
         if os.path.isfile(STATUS_FILE):
             os.unlink(STATUS_FILE)
         if self.fine_grained:
@@ -224,15 +226,13 @@ class Server:
     # Needed by tests.
     last_manager = None  # type: Optional[mypy.build.BuildManager]
 
-    def check(self, sources: List[mypy.build.BuildSource],
-              alt_lib_path: Optional[str] = None) -> Dict[str, Any]:
+    def check(self, sources: List[mypy.build.BuildSource]) -> Dict[str, Any]:
         if self.fine_grained:
             return self.check_fine_grained(sources)
         else:
-            return self.check_default(sources, alt_lib_path)
+            return self.check_default(sources)
 
-    def check_default(self, sources: List[mypy.build.BuildSource],
-                      alt_lib_path: Optional[str] = None) -> Dict[str, Any]:
+    def check_default(self, sources: List[mypy.build.BuildSource]) -> Dict[str, Any]:
         """Check using the default (per-file) incremental mode."""
         self.last_manager = None
         blockers = False
@@ -241,7 +241,7 @@ class Server:
                 # saved_cache is mutated in place.
                 res = mypy.build.build(sources, self.options,
                                        saved_cache=self.saved_cache,
-                                       alt_lib_path=alt_lib_path)
+                                       alt_lib_path=self.alt_lib_path)
                 msgs = res.errors
                 self.last_manager = res.manager  # type: Optional[mypy.build.BuildManager]
             except mypy.errors.CompileError as err:
@@ -264,7 +264,7 @@ class Server:
 
     def check_fine_grained(self, sources: List[mypy.build.BuildSource]) -> Dict[str, Any]:
         """Check using fine-grained incremental mode."""
-        if not self.fine_grained_initialized:
+        if not self.fine_grained_manager:
             return self.initialize_fine_grained(sources)
         else:
             return self.fine_grained_increment(sources)
@@ -277,9 +277,9 @@ class Server:
             # Stores the initial state of sources as a side effect.
             self.fswatcher.find_changed()
         try:
-            # TODO: alt_lib_path
             result = mypy.build.build(sources=sources,
-                                      options=self.options)
+                                      options=self.options,
+                                      alt_lib_path=self.alt_lib_path)
         except mypy.errors.CompileError as e:
             output = ''.join(s + '\n' for s in e.messages)
             if e.use_stdout:
@@ -290,8 +290,7 @@ class Server:
         messages = result.errors
         manager = result.manager
         graph = result.graph
-        self.fine_grained_manager = mypy.server.update.FineGrainedBuildManager(manager, graph)
-        self.fine_grained_initialized = True
+        self.fine_grained_manager = FineGrainedBuildManager(manager, graph)
         self.previous_sources = sources
         self.fscache.flush()
 
@@ -320,6 +319,8 @@ class Server:
         return {'out': ''.join(s + '\n' for s in messages), 'err': '', 'status': status}
 
     def fine_grained_increment(self, sources: List[mypy.build.BuildSource]) -> Dict[str, Any]:
+        assert self.fine_grained_manager is not None
+
         t0 = time.time()
         self.update_sources(sources)
         changed = self.find_changed(sources)

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -97,6 +97,10 @@ def process_start_options(flags: List[str]) -> Options:
         sys.exit("dmypy: start/restart should not specify quick_and_dirty mode")
     if options.use_fine_grained_cache and not options.fine_grained_incremental:
         sys.exit("dmypy: fine-grained cache can only be used in experimental mode")
+    # Our file change tracking can't yet handle changes to files that aren't
+    # specified in the sources list.
+    if options.follow_imports not in ('skip', 'error'):
+        sys.exit("dmypy: follow-imports must be 'skip' or 'error'")
     return options
 
 

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 import sys
 import time
+import shutil
 
 from typing import List, Dict, Tuple, Callable, Any, Optional
 
@@ -356,3 +357,22 @@ def run_command(cmdline: List[str], *, env: Optional[Dict[str, str]] = None,
         out = err = b''
         process.kill()
     return process.returncode, split_lines(out, err)
+
+
+def copy_and_fudge_mtime(source_path: str, target_path: str) -> None:
+    # In some systems, mtime has a resolution of 1 second which can
+    # cause annoying-to-debug issues when a file has the same size
+    # after a change. We manually set the mtime to circumvent this.
+    # Note that we increment the old file's mtime, which guarentees a
+    # different value, rather than incrementing the mtime after the
+    # copy, which could leave the mtime unchanged if the old file had
+    # a similarly fudged mtime.
+    new_time = None
+    if os.path.isfile(target_path):
+        new_time = os.stat(target_path).st_mtime + 1
+
+    # Use retries to work around potential flakiness on Windows (AppVeyor).
+    retry_on_error(lambda: shutil.copy(source_path, target_path))
+
+    if new_time:
+        os.utime(target_path, times=(new_time, new_time))

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -12,7 +12,8 @@ from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.test.helpers import (
     assert_string_arrays_equal, normalize_error_messages,
-    retry_on_error, update_testcase_output, parse_options
+    retry_on_error, update_testcase_output, parse_options,
+    copy_and_fudge_mtime
 )
 from mypy.errors import CompileError
 from mypy.options import Options
@@ -132,14 +133,7 @@ class TypeCheckSuite(DataSuite):
                         if file.endswith('.' + str(incremental_step)):
                             full = os.path.join(dn, file)
                             target = full[:-2]
-                            # Use retries to work around potential flakiness on Windows (AppVeyor).
-                            retry_on_error(lambda: shutil.copy(full, target))
-
-                            # In some systems, mtime has a resolution of 1 second which can cause
-                            # annoying-to-debug issues when a file has the same size after a
-                            # change. We manually set the mtime to circumvent this.
-                            new_time = os.stat(target).st_mtime + 1
-                            os.utime(target, times=(new_time, new_time))
+                            copy_and_fudge_mtime(full, target)
                 # Delete files scheduled to be deleted in [delete <path>.num] sections.
                 for path in testcase.deleted_paths.get(incremental_step, set()):
                     # Use retries to work around potential flakiness on Windows (AppVeyor).

--- a/mypy/test/testdmypy.py
+++ b/mypy/test/testdmypy.py
@@ -119,14 +119,14 @@ class DmypySuite(DataSuite):
         if incremental_step == 1:
             if 'fine-grained' in testcase.file:
                 options.fine_grained_incremental = True
-            self.server = dmypy_server.Server(options)
+            self.server = dmypy_server.Server(options, alt_lib_path=test_temp_dir)
 
         assert self.server is not None  # Set in step 1 and survives into next steps
         sources = []
         for module_name, program_path, program_text in module_data:
             # Always set to none so we're forced to reread the module in incremental mode
             sources.append(build.BuildSource(program_path, module_name, None))
-        response = self.server.check(sources, alt_lib_path=test_temp_dir)
+        response = self.server.check(sources)
         a = (response['out'] or response['err']).splitlines()
         a = normalize_error_messages(a)
 

--- a/mypy/test/testdmypy.py
+++ b/mypy/test/testdmypy.py
@@ -117,13 +117,9 @@ class DmypySuite(DataSuite):
         # Parse options after moving files (in case mypy.ini is being moved).
         options = self.parse_options(original_program_text, testcase, incremental_step)
         if incremental_step == 1:
-            server_options = []  # type: List[str]
             if 'fine-grained' in testcase.file:
-                server_options.append('--experimental')
                 options.fine_grained_incremental = True
-                options.local_partial_types = True
-            self.server = dmypy_server.Server(server_options)  # TODO: Fix ugly API
-            self.server.options = options
+            self.server = dmypy_server.Server(options)
 
         assert self.server is not None  # Set in step 1 and survives into next steps
         sources = []

--- a/mypy/test/testdmypy.py
+++ b/mypy/test/testdmypy.py
@@ -15,6 +15,7 @@ from mypy.test.data import DataDrivenTestCase, DataSuite, has_stable_flags, is_i
 from mypy.test.helpers import (
     assert_string_arrays_equal, normalize_error_messages,
     retry_on_error, testcase_pyversion, update_testcase_output,
+    copy_and_fudge_mtime,
 )
 from mypy.options import Options
 
@@ -91,14 +92,7 @@ class DmypySuite(DataSuite):
                     if file.endswith('.' + str(incremental_step)):
                         full = os.path.join(dn, file)
                         target = full[:-2]
-                        # Use retries to work around potential flakiness on Windows (AppVeyor).
-                        retry_on_error(lambda: shutil.copy(full, target))
-
-                        # In some systems, mtime has a resolution of 1 second which can cause
-                        # annoying-to-debug issues when a file has the same size after a
-                        # change. We manually set the mtime to circumvent this.
-                        new_time = os.stat(target).st_mtime + 1
-                        os.utime(target, times=(new_time, new_time))
+                        copy_and_fudge_mtime(full, target)
             # Delete files scheduled to be deleted in [delete <path>.num] sections.
             for path in testcase.deleted_paths.get(incremental_step, set()):
                 # Use retries to work around potential flakiness on Windows (AppVeyor).

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -11,29 +11,27 @@ import os
 import re
 import shutil
 
-from typing import List, Tuple, Dict, Optional, Set
+from typing import List, Tuple, Optional, cast
 
 from mypy import build
 from mypy.build import BuildManager, BuildSource, Graph
-from mypy.errors import Errors, CompileError
-from mypy.nodes import Node, MypyFile, SymbolTable, SymbolTableNode, TypeInfo, Expression
+from mypy.errors import CompileError
 from mypy.options import Options
-from mypy.server.astmerge import merge_asts
-from mypy.server.subexpr import get_subexpressions
 from mypy.server.update import FineGrainedBuildManager
-from mypy.strconv import StrConv, indent
-from mypy.test.config import test_temp_dir, test_data_prefix
+from mypy.test.config import test_temp_dir
 from mypy.test.data import (
-    parse_test_cases, DataDrivenTestCase, DataSuite, UpdateFile, module_from_path
+    DataDrivenTestCase, DataSuite, UpdateFile, module_from_path
 )
 from mypy.test.helpers import assert_string_arrays_equal, parse_options
-from mypy.test.testtypegen import ignore_node
-from mypy.types import TypeStrVisitor, Type
-from mypy.util import short_type
 from mypy.server.mergecheck import check_consistency
+from mypy.dmypy_server import Server
+from mypy.main import expand_dir
 
 import pytest  # type: ignore  # no pytest in typeshed
 
+# TODO: This entire thing is a weird semi-duplication of testdmypy.
+# One of them should be eliminated and its remaining useful features
+# merged into the other.
 
 # Set to True to perform (somewhat expensive) checks for duplicate AST nodes after merge
 CHECK_CONSISTENCY = False
@@ -75,52 +73,56 @@ class FineGrainedSuite(DataSuite):
             return
 
         main_src = '\n'.join(testcase.input)
+        main_path = os.path.join(test_temp_dir, 'main')
+        with open(main_path, 'w') as f:
+            f.write(main_src)
+
+        server = Server(self.get_options(main_src, testcase, build_cache=False),
+                        alt_lib_path=test_temp_dir)
+
         step = 1
-        sources_override = self.parse_sources(main_src, step)
-        messages, manager, graph = self.build(main_src, testcase, sources_override,
-                                              build_cache=self.use_cache,
-                                              enable_cache=self.use_cache)
+        sources = self.parse_sources(main_src, step)
+        if self.use_cache:
+            messages = self.build(self.get_options(main_src, testcase, build_cache=True), sources)
+        else:
+            messages = self.run_check(server, sources)
+
         a = []
         if messages:
             a.extend(normalize_messages(messages))
 
-        fine_grained_manager = None
-        if not self.use_cache:
-            fine_grained_manager = FineGrainedBuildManager(manager, graph)
+        if server.fine_grained_manager:
             if CHECK_CONSISTENCY:
-                check_consistency(fine_grained_manager)
+                check_consistency(server.fine_grained_manager)
 
         steps = testcase.find_steps()
         all_triggered = []
         for operations in steps:
             step += 1
-            modules = []
             for op in operations:
                 if isinstance(op, UpdateFile):
                     # Modify/create file
+
+                    # In some systems, mtime has a resolution of 1 second which can cause
+                    # annoying-to-debug issues when a file has the same size after a
+                    # change. We manually set the mtime to circumvent this.
+                    new_time = None
+                    if os.path.isfile(op.target_path):
+                        new_time = os.stat(op.target_path).st_mtime + 1
+
                     shutil.copy(op.source_path, op.target_path)
-                    modules.append((op.module, op.target_path))
+                    if new_time:
+                        os.utime(op.target_path, times=(new_time, new_time))
                 else:
                     # Delete file
                     os.remove(op.path)
-                    modules.append((op.module, op.path))
-            sources_override = self.parse_sources(main_src, step)
-            if sources_override is not None:
-                modules = [(module, path)
-                           for module, path in sources_override
-                           if any(m == module for m, _ in modules)]
+            sources = self.parse_sources(main_src, step)
+            new_messages = self.run_check(server, sources)
 
-            # If this is the second iteration and we are using a
-            # cache, now we need to set it up
-            if fine_grained_manager is None:
-                messages, manager, graph = self.build(main_src, testcase, sources_override,
-                                                      build_cache=False, enable_cache=True)
-                fine_grained_manager = FineGrainedBuildManager(manager, graph)
-
-            new_messages = fine_grained_manager.update(modules)
-            if CHECK_CONSISTENCY:
-                check_consistency(fine_grained_manager)
-            all_triggered.append(fine_grained_manager.triggered)
+            if server.fine_grained_manager:
+                if CHECK_CONSISTENCY:
+                    check_consistency(server.fine_grained_manager)
+                all_triggered.append(server.fine_grained_manager.triggered)
             new_messages = normalize_messages(new_messages)
 
             a.append('==')
@@ -141,39 +143,39 @@ class FineGrainedSuite(DataSuite):
                 'Invalid active triggers ({}, line {})'.format(testcase.file,
                                                                testcase.line))
 
-    def build(self,
-              source: str,
-              testcase: DataDrivenTestCase,
-              sources_override: Optional[List[Tuple[str, str]]],
-              build_cache: bool,
-              enable_cache: bool) -> Tuple[List[str], BuildManager, Graph]:
+    def get_options(self,
+                    source: str,
+                    testcase: DataDrivenTestCase,
+                    build_cache: bool) -> Options:
         # This handles things like '# flags: --foo'.
         options = parse_options(source, testcase, incremental_step=1)
         options.incremental = True
         options.use_builtins_fixtures = True
         options.show_traceback = True
         options.fine_grained_incremental = not build_cache
-        options.use_fine_grained_cache = enable_cache and not build_cache
-        options.cache_fine_grained = enable_cache
+        options.use_fine_grained_cache = self.use_cache and not build_cache
+        options.cache_fine_grained = self.use_cache
         options.local_partial_types = True
+        if options.follow_imports == 'normal':
+            options.follow_imports = 'error'
 
-        main_path = os.path.join(test_temp_dir, 'main')
-        with open(main_path, 'w') as f:
-            f.write(source)
-        if sources_override is not None:
-            sources = [BuildSource(path, module, None)
-                       for module, path in sources_override]
-        else:
-            sources = [BuildSource(main_path, None, None)]
+        return options
+
+    def run_check(self, server: Server, sources: List[BuildSource]) -> List[str]:
+        response = server.check(sources)
+        out = cast(str, response['out'] or response['err'])
+        return out.splitlines()
+
+    def build(self,
+              options: Options,
+              sources: List[BuildSource]) -> List[str]:
         try:
             result = build.build(sources=sources,
                                  options=options,
                                  alt_lib_path=test_temp_dir)
         except CompileError as e:
-            # TODO: We need a manager and a graph in this case as well
-            assert False, str('\n'.join(e.messages))
-            return e.messages, None, None
-        return result.errors, result.manager, result.graph
+            return e.messages
+        return result.errors
 
     def format_triggered(self, triggered: List[List[str]]) -> List[str]:
         result = []
@@ -185,11 +187,22 @@ class FineGrainedSuite(DataSuite):
         return result
 
     def parse_sources(self, program_text: str,
-                      incremental_step: int) -> Optional[List[Tuple[str, str]]]:
-        """Return target (module, path) tuples for a test case, if not using the defaults.
+                      incremental_step: int) -> List[BuildSource]:
+        """Return target BuildSources for a test case.
 
-        These are defined through a comment like '# cmd: main a.py' in the test case
-        description.
+        Normally, the unit tests will check all files included in the test
+        case. This differs from how testcheck works by default, as dmypy
+        doesn't currently support following imports.
+
+        You can override this behavior and instruct the tests to check
+        multiple modules by using a comment like this in the test case
+        input:
+
+          # cmd: main a.py
+
+        You can also use `# cmdN:` to have a different cmd for incremental
+        step N (2, 3, ...).
+
         """
         m = re.search('# cmd: mypy ([a-zA-Z0-9_./ ]+)$', program_text, flags=re.MULTILINE)
         regex = '# cmd{}: mypy ([a-zA-Z0-9_./ ]+)$'.format(incremental_step)
@@ -209,9 +222,11 @@ class FineGrainedSuite(DataSuite):
                 module = module_from_path(path)
                 if module == 'main':
                     module = '__main__'
-                result.append((module, path))
+                result.append(BuildSource(path, module, None))
             return result
-        return None
+        else:
+            base = BuildSource(os.path.join(test_temp_dir, 'main'), '__main__', None)
+            return [base] + expand_dir(test_temp_dir)
 
 
 def normalize_messages(messages: List[str]) -> List[str]:

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -282,7 +282,9 @@ main:1: error: Cannot find module named 'p.q'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 ==
 
-[case testDeletionOfSubmoduleTriggersImportFrom1-skip-nocache]
+-- TODO: Fix this bug. It is a real bug that was been papered over
+-- by the test harness.
+[case testDeletionOfSubmoduleTriggersImportFrom1-skip-nocache-skip]
 -- Different cache/no-cache tests because:
 -- missing module error message mismatch
 from p import q

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1458,9 +1458,11 @@ class C: pass
 class D(C):
     1()
 class E(D): pass
+# Something needs to change
 
 [file b.py.2]
 import a
+# Something needs to change
 
 [triggered]
 2: a, a
@@ -1775,7 +1777,7 @@ p = Point(dict(x=42, y=1337))
 [file a.py.2]
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
-p = Point(dict(x=42, y=1337))
+p = Point(dict(x=42, y=1337)) # dummy change
 [out]
 ==
 


### PR DESCRIPTION
Rework the fine-grained test harness to use `dmypy_server` for performing fine-grained updates instead of using `update` directly. This allows it to test the change detection logic in the server, which is actually quite fiddly.

I want to land this before landing any other changes that affect the change detection logic (such as #4623,  #4664, or some in-progress work optimizing deletes).

This found one bug already running our existing test suite. I've skipped the test and filed the bug as #4698.

This does not appear to slow down the fine-grained tests any.