### PR TITLE
Add an optional timeout to dmypy_server

### DIFF
--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -30,6 +30,8 @@ subparsers = parser.add_subparsers()
 start_parser = p = subparsers.add_parser('start', help="Start daemon")
 p.add_argument('--log-file', metavar='FILE', type=str,
                help="Direct daemon stdout/stderr to FILE")
+p.add_argument('--timeout', metavar='TIMEOUT', type=int,
+               help="Server shutdown timeout (in seconds)")
 p.add_argument('flags', metavar='FLAG', nargs='*', type=str,
                help="Regular mypy flags (precede with --)")
 
@@ -37,6 +39,8 @@ restart_parser = p = subparsers.add_parser('restart',
     help="Restart daemon (stop or kill followed by start)")
 p.add_argument('--log-file', metavar='FILE', type=str,
                help="Direct daemon stdout/stderr to FILE")
+p.add_argument('--timeout', metavar='TIMEOUT', type=int,
+               help="Server shutdown timeout (in seconds)")
 p.add_argument('flags', metavar='FLAG', nargs='*', type=str,
                help="Regular mypy flags (precede with --)")
 
@@ -63,6 +67,8 @@ p.add_argument('--junit-xml', help="write junit.xml to the given file")
 hang_parser = p = subparsers.add_parser('hang', help="Hang for 100 seconds")
 
 daemon_parser = p = subparsers.add_parser('daemon', help="Run daemon in foreground")
+p.add_argument('--timeout', metavar='TIMEOUT', type=int,
+               help="Server shutdown timeout (in seconds)")
 p.add_argument('flags', metavar='FLAG', nargs='*', type=str,
                help="Regular mypy flags (precede with --)")
 
@@ -148,7 +154,8 @@ def start_server(args: argparse.Namespace) -> None:
     """Start the server from command arguments and wait for it."""
     # Lazy import so this import doesn't slow down other commands.
     from mypy.dmypy_server import daemonize, Server, process_start_options
-    if daemonize(Server(process_start_options(args.flags)).serve, args.log_file) != 0:
+    if daemonize(Server(process_start_options(args.flags), timeout=args.timeout).serve,
+                 args.log_file) != 0:
         sys.exit(1)
     wait_for_server()
 
@@ -284,7 +291,7 @@ def do_daemon(args: argparse.Namespace) -> None:
     """Serve requests in the foreground."""
     # Lazy import so this import doesn't slow down other commands.
     from mypy.dmypy_server import Server, process_start_options
-    Server(process_start_options(args.flags)).serve()
+    Server(process_start_options(args.flags), timeout=args.timeout).serve()
 
 
 @action(help_parser)

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -144,7 +144,11 @@ class Server:
                     json.dump({'pid': os.getpid(), 'sockname': sock.getsockname()}, f)
                     f.write('\n')  # I like my JSON with trailing newline
                 while True:
-                    conn, addr = sock.accept()
+                    try:
+                        conn, addr = sock.accept()
+                    except socket.timeout:
+                        print("Exiting due to inactivity.")
+                        sys.exit(0)
                     try:
                         data = receive(conn)
                     except OSError as err:
@@ -168,9 +172,6 @@ class Server:
                     if command == 'stop':
                         sock.close()
                         sys.exit(0)
-            except socket.timeout:
-                print("Exiting due to inactivity.")
-                sys.exit(0)
             finally:
                 os.unlink(STATUS_FILE)
         finally:


### PR DESCRIPTION
This allows it to shut down after a period of inactivity to avoid
hogging memory.

Also don't crash the server on an error communicating with the client.