### PR TITLE
Improve performance of deletions in initial fine-grained cache load

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -571,7 +571,9 @@ class BuildManager:
       flush_errors:    A function for processing errors after each SCC
       saved_cache:     Dict with saved cache state for coarse-grained dmypy
                        (read-write!)
-      cache_enabled:   Whether cache usage is enabled
+      cache_enabled:   Whether cache usage is enabled. This is set based on options,
+                       but is disabled if fine-grained cache loading fails
+                       and after an initial fine-grained load.
       stats:           Dict with various instrumentation numbers
     """
 
@@ -609,7 +611,8 @@ class BuildManager:
         self.rechecked_modules = set()  # type: Set[str]
         self.plugin = plugin
         self.flush_errors = flush_errors
-        self.cache_enabled = options.incremental and options.cache_dir != os.devnull
+        self.cache_enabled = options.incremental and (
+            not options.fine_grained_incremental or options.use_fine_grained_cache)
         self.saved_cache = saved_cache if saved_cache is not None else {}  # type: SavedCache
         self.stats = {}  # type: Dict[str, Any]  # Values are ints or floats
 

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -280,9 +280,6 @@ class Server:
             result = mypy.build.build(sources=sources,
                                       options=self.options,
                                       alt_lib_path=self.alt_lib_path)
-            # build will clear use_fine_grained_cache if it needs to give up
-            # on doing a cache load.
-            cache_load_succeeded = self.options.use_fine_grained_cache
         except mypy.errors.CompileError as e:
             output = ''.join(s + '\n' for s in e.messages)
             if e.use_stdout:
@@ -300,7 +297,7 @@ class Server:
         # If we are using the fine-grained cache, build hasn't actually done
         # the typechecking on the updated files yet.
         # Run a fine-grained update starting from the cached data
-        if cache_load_succeeded:
+        if result.used_cache:
             # Pull times and hashes out of the saved_cache and stick them into
             # the fswatcher, so we pick up the changes.
             for state in self.fine_grained_manager.graph.values():

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -310,6 +310,11 @@ class Server:
 
             # Run an update
             changed = self.find_changed(sources)
+            for state in self.fine_grained_manager.graph.values():
+                if not state.is_fresh():
+                    assert state.path is not None
+                    changed.append((state.id, state.path))
+
             if changed:
                 messages = self.fine_grained_manager.update(changed)
             self.fscache.flush()

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -280,6 +280,9 @@ class Server:
             result = mypy.build.build(sources=sources,
                                       options=self.options,
                                       alt_lib_path=self.alt_lib_path)
+            # build will clear use_fine_grained_cache if it needs to give up
+            # on doing a cache load.
+            cache_load_succeeded = self.options.use_fine_grained_cache
         except mypy.errors.CompileError as e:
             output = ''.join(s + '\n' for s in e.messages)
             if e.use_stdout:
@@ -297,7 +300,7 @@ class Server:
         # If we are using the fine-grained cache, build hasn't actually done
         # the typechecking on the updated files yet.
         # Run a fine-grained update starting from the cached data
-        if self.options.use_fine_grained_cache:
+        if cache_load_succeeded:
             # Pull times and hashes out of the saved_cache and stick them into
             # the fswatcher, so we pick up the changes.
             for state in self.fine_grained_manager.graph.values():

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -22,8 +22,7 @@ def fixup_module_pass_one(tree: MypyFile, modules: Dict[str, MypyFile],
     node_fixer.visit_symbol_table(tree.names)
 
 
-def fixup_module_pass_two(tree: MypyFile, modules: Dict[str, MypyFile],
-                          quick_and_dirty: bool) -> None:
+def fixup_module_pass_two(tree: MypyFile, modules: Dict[str, MypyFile]) -> None:
     compute_all_mros(tree.names, modules)
 
 

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -136,7 +136,9 @@ def snapshot_symbol_table(name_prefix: str, table: SymbolTable) -> Dict[str, Sna
         common = (fullname, symbol.kind, symbol.module_public)
         if symbol.kind == MODULE_REF:
             # This is a cross-reference to another module.
-            assert isinstance(node, MypyFile)
+            # If the reference is busted because the other module is missing,
+            # the node will be a "stale_info" TypeInfo produced by fixup,
+            # but that doesn't really matter to us here.
             result[name] = ('Moduleref', common)
         elif symbol.kind == TVAR:
             assert isinstance(node, TypeVarExpr)

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -174,8 +174,8 @@ class FineGrainedBuildManager:
         # for the cache. This is kind of a hack and it might be better to have
         # this directly reflected in load_graph's interface.
         self.options.cache_dir = os.devnull
+        self.options.use_fine_grained_cache = False
         manager.saved_cache = {}
-        manager.only_load_from_cache = False
         # Active triggers during the last update
         self.triggered = []  # type: List[str]
 

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -171,10 +171,8 @@ class FineGrainedBuildManager:
         # Module that we haven't processed yet but that are known to be stale.
         self.stale = []  # type: List[Tuple[str, str]]
         # Disable the cache so that load_graph doesn't try going back to disk
-        # for the cache. This is kind of a hack and it might be better to have
-        # this directly reflected in load_graph's interface.
-        self.options.cache_dir = os.devnull
-        self.options.use_fine_grained_cache = False
+        # for the cache.
+        self.manager.cache_enabled = False
         manager.saved_cache = {}
         # Active triggers during the last update
         self.triggered = []  # type: List[str]

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -174,8 +174,14 @@ class FineGrainedBuildManager:
         # for the cache.
         self.manager.cache_enabled = False
         manager.saved_cache = {}
+
+        # Some hints to the test suite about what is going on:
         # Active triggers during the last update
         self.triggered = []  # type: List[str]
+        # Modules passed to update during the last update
+        self.changed_modules = []  # type: List[Tuple[str, str]]
+        # Modules processed during the last update
+        self.updated_modules = []  # type: List[str]
 
     def update(self, changed_modules: List[Tuple[str, str]]) -> List[str]:
         """Update previous build result by processing changed modules.
@@ -196,10 +202,13 @@ class FineGrainedBuildManager:
         """
         assert changed_modules, 'No changed modules'
 
+        self.changed_modules = changed_modules
+
         # Reset global caches for the new build.
         find_module_clear_caches()
 
         self.triggered = []
+        self.updated_modules = []
         changed_modules = dedupe_modules(changed_modules + self.stale)
         initial_set = {id for id, _ in changed_modules}
         self.manager.log_fine_grained('==== update %s ====' % ', '.join(
@@ -256,6 +265,7 @@ class FineGrainedBuildManager:
             - Whether there was a blocking error in the module
         """
         self.manager.log_fine_grained('--- update single %r ---' % module)
+        self.updated_modules.append(module)
 
         # TODO: If new module brings in other modules, we parse some files multiple times.
         manager = self.manager

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -5,7 +5,7 @@ import sys
 import time
 import shutil
 
-from typing import List, Dict, Tuple, Callable, Any, Optional
+from typing import List, Iterable, Dict, Tuple, Callable, Any, Optional
 
 from mypy import defaults
 from mypy.test.config import test_temp_dir
@@ -96,6 +96,21 @@ def assert_string_arrays_equal(expected: List[str], actual: List[str],
             show_align_message(expected[first_diff], actual[first_diff])
 
         raise AssertionError(msg)
+
+
+def assert_module_equivalence(name: str,
+                              expected: Optional[Iterable[str]], actual: Iterable[str]) -> None:
+    if expected is not None:
+        expected_normalized = sorted(expected)
+        actual_normalized = sorted(set(actual).difference({"__main__"}))
+        assert_string_arrays_equal(
+            expected_normalized,
+            actual_normalized,
+            ('Actual modules ({}) do not match expected modules ({}) '
+             'for "[{} ...]"').format(
+                 ', '.join(actual_normalized),
+                 ', '.join(expected_normalized),
+                 name))
 
 
 def update_testcase_output(testcase: DataDrivenTestCase, output: List[str]) -> None:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -11,7 +11,7 @@ from mypy.build import BuildSource, find_module_clear_caches
 from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.test.helpers import (
-    assert_string_arrays_equal, normalize_error_messages,
+    assert_string_arrays_equal, normalize_error_messages, assert_module_equivalence,
     retry_on_error, update_testcase_output, parse_options,
     copy_and_fudge_mtime
 )
@@ -190,28 +190,14 @@ class TypeCheckSuite(DataSuite):
                 self.verify_cache(module_data, a, res.manager)
             if incremental_step > 1:
                 suffix = '' if incremental_step == 2 else str(incremental_step - 1)
-                self.check_module_equivalence(
+                assert_module_equivalence(
                     'rechecked' + suffix,
                     testcase.expected_rechecked_modules.get(incremental_step - 1),
                     res.manager.rechecked_modules)
-                self.check_module_equivalence(
+                assert_module_equivalence(
                     'stale' + suffix,
                     testcase.expected_stale_modules.get(incremental_step - 1),
                     res.manager.stale_modules)
-
-    def check_module_equivalence(self, name: str,
-                                 expected: Optional[Set[str]], actual: Set[str]) -> None:
-        if expected is not None:
-            expected_normalized = sorted(expected)
-            actual_normalized = sorted(actual.difference({"__main__"}))
-            assert_string_arrays_equal(
-                expected_normalized,
-                actual_normalized,
-                ('Actual modules ({}) do not match expected modules ({}) '
-                 'for "[{} ...]"').format(
-                    ', '.join(actual_normalized),
-                    ', '.join(expected_normalized),
-                    name))
 
     def verify_cache(self, module_data: List[Tuple[str, str, str]], a: List[str],
                      manager: build.BuildManager) -> None:

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -10,7 +10,7 @@ information.
 import os
 import re
 
-from typing import List, Tuple, Optional, cast
+from typing import List, Set, Tuple, Optional, cast
 
 from mypy import build
 from mypy.build import BuildManager, BuildSource, Graph
@@ -21,7 +21,9 @@ from mypy.test.config import test_temp_dir
 from mypy.test.data import (
     DataDrivenTestCase, DataSuite, UpdateFile, module_from_path
 )
-from mypy.test.helpers import assert_string_arrays_equal, parse_options, copy_and_fudge_mtime
+from mypy.test.helpers import (
+    assert_string_arrays_equal, parse_options, copy_and_fudge_mtime, assert_module_equivalence,
+)
 from mypy.server.mergecheck import check_consistency
 from mypy.dmypy_server import Server
 from mypy.main import expand_dir
@@ -96,6 +98,7 @@ class FineGrainedSuite(DataSuite):
 
         steps = testcase.find_steps()
         all_triggered = []
+
         for operations in steps:
             step += 1
             for op in operations:
@@ -108,10 +111,26 @@ class FineGrainedSuite(DataSuite):
             sources = self.parse_sources(main_src, step)
             new_messages = self.run_check(server, sources)
 
+            assert server.fine_grained_manager
+
+            updated, changed = [], []
             if server.fine_grained_manager:
                 if CHECK_CONSISTENCY:
                     check_consistency(server.fine_grained_manager)
                 all_triggered.append(server.fine_grained_manager.triggered)
+
+                updated = server.fine_grained_manager.updated_modules
+                changed = [mod for mod, file in server.fine_grained_manager.changed_modules]
+
+            assert_module_equivalence(
+                'stale' + str(step - 1),
+                testcase.expected_stale_modules.get(step - 1),
+                changed)
+            assert_module_equivalence(
+                'rechecked' + str(step - 1),
+                testcase.expected_rechecked_modules.get(step - 1),
+                updated)
+
             new_messages = normalize_messages(new_messages)
 
             a.append('==')

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -111,8 +111,6 @@ class FineGrainedSuite(DataSuite):
             sources = self.parse_sources(main_src, step)
             new_messages = self.run_check(server, sources)
 
-            assert server.fine_grained_manager
-
             updated = []  # type: List[str]
             changed = []  # type: List[str]
             if server.fine_grained_manager:

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -113,7 +113,8 @@ class FineGrainedSuite(DataSuite):
 
             assert server.fine_grained_manager
 
-            updated, changed = [], []
+            updated = []  # type: List[str]
+            changed = []  # type: List[str]
             if server.fine_grained_manager:
                 if CHECK_CONSISTENCY:
                     check_consistency(server.fine_grained_manager)

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -624,6 +624,22 @@ c.f(1)
 ==
 a.py:2: error: Too many arguments for "f"
 
+[case testRenameAndDeleteModule]
+import a
+[file a.py]
+from b1 import f
+f()
+[file b1.py]
+def f() -> None: pass
+[file b2.py.2]
+def f() -> None: pass
+[delete b1.py.2]
+[file a.py.2]
+from b2 import f
+f()
+[out]
+==
+
 [case testDeleteFileWithinPackage]
 import a
 [file a.py]

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -976,7 +976,7 @@ main:2: error: Too few arguments for "foo" of "Foo"
 
 -- This series of tests is designed to test adding a new module that
 -- doesn't appear in the cache, for cache mode. They are run in
--- cache mode oly because stale and rechecked differ heavily between
+-- cache mode only because stale and rechecked differ heavily between
 -- the modes.
 [case testAddModuleAfterCache1-skip-nocache]
 # cmd: mypy main a.py
@@ -1148,7 +1148,7 @@ def f() -> None: pass
 from b2 import f
 f()
 
--- in no cache mode, there is no way to know about b1 yet
+-- in cache mode, there is no way to know about b1 yet
 [stale a, b2]
 
 [out]
@@ -1163,8 +1163,9 @@ f()
 def f() -> None: pass
 [delete b.py.2]
 
--- in no cache mode, there is no way to know about b yet,
--- but a should still get triggered
+-- in cache mode, there is no way to know about b yet,
+-- but a should get flagged as changed by the initial cache
+-- check, since one of its dependencies is missing.
 [stale a]
 
 [out]

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -624,22 +624,6 @@ c.f(1)
 ==
 a.py:2: error: Too many arguments for "f"
 
-[case testRenameAndDeleteModule]
-import a
-[file a.py]
-from b1 import f
-f()
-[file b1.py]
-def f() -> None: pass
-[file b2.py.2]
-def f() -> None: pass
-[delete b1.py.2]
-[file a.py.2]
-from b2 import f
-f()
-[out]
-==
-
 [case testDeleteFileWithinPackage]
 import a
 [file a.py]
@@ -991,10 +975,10 @@ x = Foo()
 main:2: error: Too few arguments for "foo" of "Foo"
 
 -- This series of tests is designed to test adding a new module that
--- doesn't appear in the cache, for cache mode. They aren't run only
--- in cache mode, though, because they are still perfectly good
--- regular tests.
-[case testAddModuleAfterCache1]
+-- doesn't appear in the cache, for cache mode. They are run in
+-- cache mode oly because stale and rechecked differ heavily between
+-- the modes.
+[case testAddModuleAfterCache1-skip-nocache]
 # cmd: mypy main a.py
 # cmd2: mypy main a.py b.py
 # cmd3: mypy main a.py b.py
@@ -1006,14 +990,22 @@ import b
 b.foo(0)
 [file b.py.2]
 def foo() -> None: pass
+
+[stale a, b]
+[rechecked a, b]
+
 [file b.py.3]
 def foo(x: int) -> None: pass
+
+[stale2 b]
+[rechecked2 b]
+
 [out]
 ==
 a.py:2: error: Too many arguments for "foo"
 ==
 
-[case testAddModuleAfterCache2]
+[case testAddModuleAfterCache2-skip-nocache]
 # cmd: mypy main a.py
 # cmd2: mypy main a.py b.py
 # cmd3: mypy main a.py b.py
@@ -1024,30 +1016,51 @@ import b
 b.foo(0)
 [file b.py.2]
 def foo() -> None: pass
+
+[stale b]
+[rechecked a, b]
+
 [file b.py.3]
 def foo(x: int) -> None: pass
+
+[stale2 b]
+
 [out]
 ==
 a.py:2: error: Too many arguments for "foo"
 ==
 
-[case testAddModuleAfterCache3]
+[case testAddModuleAfterCache3-skip-nocache]
 # cmd: mypy main a.py
 # cmd2: mypy main a.py b.py c.py d.py e.py f.py g.py
 # flags: --ignore-missing-imports --follow-imports=skip
 import a
 [file a.py]
 import b, c, d, e, f, g
+b.foo(10)
 [file b.py.2]
+def foo() -> None: pass
 [file c.py.2]
 [file d.py.2]
 [file e.py.2]
 [file f.py.2]
 [file g.py.2]
+
+-- No files should be stale or reprocessed in the first step since the large number
+-- of missing files will force build to give up on cache loading.
+[stale]
+
+[file b.py.3]
+def foo(x: int) -> None: pass
+[stale2 b]
+
 [out]
 ==
+a.py:2: error: Too many arguments for "foo"
+==
 
-[case testAddModuleAfterCache4]
+
+[case testAddModuleAfterCache4-skip-nocache]
 # cmd: mypy main a.py
 # cmd2: mypy main a.py b.py
 # cmd3: mypy main a.py b.py
@@ -1066,7 +1079,7 @@ def foo(x: int) -> None: pass
 b.py:2: error: Too many arguments for "foo"
 ==
 
-[case testAddModuleAfterCache5]
+[case testAddModuleAfterCache5-skip-nocache]
 # cmd: mypy main a.py
 # cmd2: mypy main a.py b.py
 # cmd3: mypy main a.py b.py
@@ -1080,14 +1093,20 @@ def foo() -> None: pass
 [file b.py.2]
 import a
 a.foo(10)
+
+[stale a, b]
+
 [file a.py.3]
 def foo(x: int) -> None: pass
+
+[stale2 a]
+
 [out]
 ==
 b.py:2: error: Too many arguments for "foo"
 ==
 
-[case testAddModuleAfterCache6]
+[case testAddModuleAfterCache6-skip-nocache]
 # cmd: mypy main a.py
 # cmd2: mypy main a.py b.py
 # cmd3: mypy main a.py b.py
@@ -1096,17 +1115,63 @@ import a
 [file a.py]
 import b
 b.foo()
+
 [file a.py.2]
 import b
 b.foo(0)
 [file b.py.2]
 def foo() -> None: pass
+
+[stale a, b]
+
 [file b.py.3]
 def foo(x: int) -> None: pass
+
+[stale2 b]
+
 [out]
 ==
 a.py:2: error: Too many arguments for "foo"
 ==
+
+[case testRenameAndDeleteModuleAfterCache-skip-nocache]
+import a
+[file a.py]
+from b1 import f
+f()
+[file b1.py]
+def f() -> None: pass
+[file b2.py.2]
+def f() -> None: pass
+[delete b1.py.2]
+[file a.py.2]
+from b2 import f
+f()
+
+-- in no cache mode, there is no way to know about b1 yet
+[stale a, b2]
+
+[out]
+==
+
+[case testDeleteModuleAfterCache-skip-nocache]
+import a
+[file a.py]
+from b import f
+f()
+[file b.py]
+def f() -> None: pass
+[delete b.py.2]
+
+-- in no cache mode, there is no way to know about b yet,
+-- but a should still get triggered
+[stale a]
+
+[out]
+==
+a.py:1: error: Cannot find module named 'b'
+a.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+
 
 [case testRefreshImportIfMypyElse1]
 import a

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -15,6 +15,11 @@
 --   <optional output from batch pass>
 --   ==
 --   <optional output from first incremental pass>
+--
+--
+-- Modules that are expected to be detected as changed can be checked with [stale ...]
+-- while modules that are reprocessed by update (which can include cached files
+-- that need to be loaded) can be checked with [rechecked ...]
 
 [case testReprocessFunction]
 import m

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -17,9 +17,20 @@
 --   <optional output from first incremental pass>
 --
 --
--- Modules that are expected to be detected as changed can be checked with [stale ...]
--- while modules that are reprocessed by update (which can include cached files
--- that need to be loaded) can be checked with [rechecked ...]
+-- Modules that are expected to be detected as changed by dmypy_server
+-- can be checked with [stale ...]
+-- Generally this should mean added, deleted, or changed files, though there
+-- are important edge cases related to the cache: deleted files won't be detected
+-- as changed in the initial run with the cache while modules that depended on them
+-- should be.
+--
+-- Modules that are require a full-module reprocessing by update can be checked with
+-- [rechecked ...]. This should include any files detected as having changed as well
+-- as any files that contain targets that need to be reprocessed but which haven't
+-- been loaded yet. If there is no [rechecked...] directive, it inherits the value of
+-- [stale ...].
+--
+-- Specifications for later runs can be given with [stale2 ...], [stale3 ...], etc.
 
 [case testReprocessFunction]
 import m


### PR DESCRIPTION
To do this we just fully ditch `process_graph` for doing initial cache loads, since we don't want to do anything but load the graph and trees from the cache.

This has the side effect of disabling any writes to the cache while doing a successful cache load, so for consistency we also disable cache writes when a fine-grained cache load fails and we give up on it.