### PR TITLE
Fine-grained: Support "from m import *"

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -59,7 +59,7 @@ from mypy.server.deps import get_dependencies
 # mode only that is useful during development. This produces only a subset of
 # output compared to --verbose output. We use a global flag to enable this so
 # that it's easy to enable this when running tests.
-DEBUG_FINE_GRAINED = False
+DEBUG_FINE_GRAINED = True # False
 
 
 PYTHON_EXTENSIONS = ['.pyi', '.py']

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -59,7 +59,7 @@ from mypy.server.deps import get_dependencies
 # mode only that is useful during development. This produces only a subset of
 # output compared to --verbose output. We use a global flag to enable this so
 # that it's easy to enable this when running tests.
-DEBUG_FINE_GRAINED = True # False
+DEBUG_FINE_GRAINED = False
 
 
 PYTHON_EXTENSIONS = ['.pyi', '.py']

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -352,8 +352,12 @@ class Errors:
     def clear_errors_in_targets(self, path: str, targets: Set[str]) -> None:
         """Remove errors in specific fine-grained targets within a file."""
         if path in self.error_info_map:
-            new_errors = [info for info in self.error_info_map[path]
-                          if info.target not in targets]
+            new_errors = []
+            for info in self.error_info_map[path]:
+                if info.target not in targets:
+                    new_errors.append(info)
+                elif info.only_once:
+                    self.only_once_messages.remove(info.message)
             self.error_info_map[path] = new_errors
 
     def generate_unused_ignore_notes(self, file: str) -> None:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -21,7 +21,7 @@ class ErrorInfo:
     # related to this error. Each item is a (path, line number) tuple.
     import_ctx = None  # type: List[Tuple[str, int]]
 
-    # The source file that was the source of this error.
+    # The path to source file that was the source of this error.
     file = ''
 
     # The fully-qualified id of the source module for this error.
@@ -51,7 +51,7 @@ class ErrorInfo:
     # Only report this particular messages once per program.
     only_once = False
 
-    # Actual origin of the error message
+    # Actual origin of the error message as tuple (path, line number)
     origin = None  # type: Tuple[str, int]
 
     # Fine-grained incremental target where this was reported
@@ -348,6 +348,13 @@ class Errors:
                 return
             self.only_once_messages.add(info.message)
         self._add_error_info(file, info)
+
+    def clear_errors_in_targets(self, path: str, targets: Set[str]) -> None:
+        """Remove errors in specific fine-grained targets within a file."""
+        if path in self.error_info_map:
+            new_errors = [info for info in self.error_info_map[path]
+                          if info.target not in targets]
+            self.error_info_map[path] = new_errors
 
     def generate_unused_ignore_notes(self, file: str) -> None:
         ignored_lines = self.ignored_lines[file]

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -315,11 +315,13 @@ class ImportAll(ImportBase):
     """from m import *"""
     id = None  # type: str
     relative = None  # type: int
+    imported_names = None  # type: List[str]
 
     def __init__(self, id: str, relative: int) -> None:
         super().__init__()
         self.id = id
         self.relative = relative
+        self.imported_names = []
 
     def accept(self, visitor: StatementVisitor[T]) -> T:
         return visitor.visit_import_all(self)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4007,9 +4007,9 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             report_internal_error(err, self.errors.file, node.line, self.errors, self.options)
 
     def lookup_current_scope(self, name: str) -> Optional[SymbolTableNode]:
-        if self.is_func_scope():
+        if self.locals[-1] is not None:
             return self.locals[-1].get(name)
-        elif self.is_class_scope():
+        elif self.type is not None:
             return self.type.names.get(name)
         else:
             return self.globals.get(name)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1659,7 +1659,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 # False, and we can skip checking '_' because it's been explicitly included.
                 if (new_node and new_node.module_public and
                         (not name.startswith('_') or '__all__' in m.names)):
-                    existing_symbol = self.globals.get(name)
+                    existing_symbol = self.lookup_current_scope(name)
                     if existing_symbol:
                         # Import can redefine a variable. They get special treatment.
                         if self.process_import_over_existing_name(
@@ -4005,6 +4005,14 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             node.accept(self)
         except Exception as err:
             report_internal_error(err, self.errors.file, node.line, self.errors, self.options)
+
+    def lookup_current_scope(self, name: str) -> Optional[SymbolTableNode]:
+        if self.is_func_scope():
+            return self.locals[-1].get(name)
+        elif self.is_class_scope():
+            return self.type.names.get(name)
+        else:
+            return self.globals.get(name)
 
 
 def replace_implicit_first_type(sig: FunctionLike, new: Type) -> FunctionLike:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1669,6 +1669,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                                                           new_node.type_override,
                                                           normalized=new_node.normalized,
                                                           alias_tvars=new_node.alias_tvars), i)
+                    i.imported_names.append(name)
         else:
             # Don't add any dummy symbols for 'from x import *' if 'x' is unknown.
             pass

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -195,7 +195,9 @@ class NodeStripVisitor(TraverserVisitor):
                 for name, as_name in node.ids:
                     imported_name = as_name or name
                     initial = imported_name.split('.')[0]
-                    self.reset_imported_name(initial)
+                    symnode = self.names[initial]
+                    symnode.kind = UNBOUND_IMPORTED
+                    symnode.node = None
 
     def visit_import_all(self, node: ImportAll) -> None:
         # Reset entries in the symbol table that were added through the statement.
@@ -203,11 +205,6 @@ class NodeStripVisitor(TraverserVisitor):
         for name in node.imported_names:
             del self.names[name]
         node.imported_names = []
-
-    def reset_imported_name(self, name: str) -> None:
-        symnode = self.names[name]
-        symnode.kind = UNBOUND_IMPORTED
-        symnode.node = None
 
     def visit_name_expr(self, node: NameExpr) -> None:
         # Global assignments are processed in semantic analysis pass 1, and we

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -202,8 +202,9 @@ class NodeStripVisitor(TraverserVisitor):
     def visit_import_all(self, node: ImportAll) -> None:
         # Reset entries in the symbol table that were added through the statement.
         # (The description in visit_import is relevant here as well.)
-        for name in node.imported_names:
-            del self.names[name]
+        if self.names:
+            for name in node.imported_names:
+                del self.names[name]
         node.imported_names = []
 
     def visit_name_expr(self, node: NameExpr) -> None:

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -65,6 +65,7 @@ def strip_target(node: Union[MypyFile, FuncItem, OverloadedFuncDef]) -> None:
 class NodeStripVisitor(TraverserVisitor):
     def __init__(self) -> None:
         self.type = None  # type: Optional[TypeInfo]
+        # Currently active module/class symbol table
         self.names = None  # type: Optional[SymbolTable]
         self.file_node = None  # type: Optional[MypyFile]
         self.is_class_body = False
@@ -125,14 +126,16 @@ class NodeStripVisitor(TraverserVisitor):
 
     @contextlib.contextmanager
     def enter_class(self, info: TypeInfo) -> Iterator[None]:
-        # TODO: Update and restore self.names
         old_type = self.type
         old_is_class_body = self.is_class_body
+        old_names = self.names
         self.type = info
         self.is_class_body = True
+        self.names = info.names
         yield
         self.type = old_type
         self.is_class_body = old_is_class_body
+        self.names = old_names
 
     @contextlib.contextmanager
     def enter_method(self, info: TypeInfo) -> Iterator[None]:

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -200,6 +200,9 @@ class NodeStripVisitor(TraverserVisitor):
                     symnode.node = None
 
     def visit_import_all(self, node: ImportAll) -> None:
+        # If the node is unreachable, we don't want to reset entries from a reachable import.
+        if node.is_unreachable:
+            return
         # Reset entries in the symbol table that were added through the statement.
         # (The description in visit_import is relevant here as well.)
         if self.names:

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -92,7 +92,7 @@ from mypy.nodes import (
     ComparisonExpr, GeneratorExpr, DictionaryComprehension, StarExpr, PrintStmt, ForStmt, WithStmt,
     TupleExpr, ListExpr, OperatorAssignmentStmt, DelStmt, YieldFromExpr, Decorator, Block,
     TypeInfo, FuncBase, OverloadedFuncDef, RefExpr, SuperExpr, Var, NamedTupleExpr, TypedDictExpr,
-    LDEF, MDEF, GDEF, FuncItem, TypeAliasExpr, NewTypeExpr,
+    LDEF, MDEF, GDEF, FuncItem, TypeAliasExpr, NewTypeExpr, ImportAll,
     op_methods, reverse_op_methods, ops_with_inplace_method, unary_op_methods
 )
 from mypy.traverser import TraverserVisitor
@@ -101,7 +101,7 @@ from mypy.types import (
     TupleType, TypeType, TypeVarType, TypedDictType, UnboundType, UninhabitedType, UnionType,
     FunctionLike, ForwardRef, Overloaded
 )
-from mypy.server.trigger import make_trigger
+from mypy.server.trigger import make_trigger, make_wildcard_trigger
 from mypy.util import correct_relative_import
 from mypy.scope import Scope
 
@@ -258,6 +258,15 @@ class DependencyVisitor(TraverserVisitor):
                                                self.is_package_init_file)
         for name, as_name in o.names:
             self.add_dependency(make_trigger(module_id + '.' + name))
+
+    def visit_import_all(self, o: ImportAll) -> None:
+        module_id, _ = correct_relative_import(self.scope.current_module_id(),
+                                               o.relative,
+                                               o.id,
+                                               self.is_package_init_file)
+        # The current target needs to be rechecked if anything "significant" changes in the
+        # target module namespace (as the imported definitions will need to be updated).
+        self.add_dependency(make_wildcard_trigger(module_id))
 
     def visit_block(self, o: Block) -> None:
         if not o.is_unreachable:

--- a/mypy/server/trigger.py
+++ b/mypy/server/trigger.py
@@ -12,6 +12,10 @@ def make_trigger(name: str) -> str:
 def make_wildcard_trigger(module: str) -> str:
     """Special trigger fired when any top-level name is changed in a module.
 
+    Note that this is different from a module trigger, as module triggers are only
+    fired if the module is created, deleted, or replaced with a non-module, whereas
+    a wildcard trigger is triggered for namespace changes.
+
     This is used for "from m import *" dependencies.
     """
     return '<%s%s>' % (module, WILDCARD_TAG)

--- a/mypy/server/trigger.py
+++ b/mypy/server/trigger.py
@@ -1,5 +1,15 @@
 """AST triggers that are used for fine-grained dependency handling."""
 
+WILDCARD_TAG = '[wildcard]'
+
 
 def make_trigger(name: str) -> str:
     return '<%s>' % name
+
+
+def make_wildcard_trigger(module: str) -> str:
+    """Special trigger fired when any name is changes in a module.
+
+    This is used for "from m import *" dependencies.
+    """
+    return '<%s%s>' % (module, WILDCARD_TAG)

--- a/mypy/server/trigger.py
+++ b/mypy/server/trigger.py
@@ -1,5 +1,7 @@
 """AST triggers that are used for fine-grained dependency handling."""
 
+# Used as a suffix for triggers to handle "from m import *" dependencies (see also
+# make_wildcard_trigger)
 WILDCARD_TAG = '[wildcard]'
 
 
@@ -8,7 +10,7 @@ def make_trigger(name: str) -> str:
 
 
 def make_wildcard_trigger(module: str) -> str:
-    """Special trigger fired when any name is changes in a module.
+    """Special trigger fired when any top-level name is changed in a module.
 
     This is used for "from m import *" dependencies.
     """

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -606,9 +606,18 @@ def calculate_active_triggers(manager: BuildManager,
         package_nesting_level = id.count('.')
         for item in diff:
             if (item.count('.') <= package_nesting_level + 1
-                    and not item.split('.')[-1].startswith('_')):
+                    and item.split('.')[-1] not in ('__builtins__',
+                                                    '__file__',
+                                                    '__name__',
+                                                    '__package__',
+                                                    '__doc__')):
                 # Activate catch-all wildcard trigger for top-level module changes (used for
-                # "from m import *").
+                # "from m import *"). This also gets triggered by changes to module-private
+                # entries, but as these unneeded dependencies only result in extra processing,
+                # it's a minor problem.
+                #
+                # TODO: Some __* names cause mistriggers. Fix the underlying issue instead of
+                #     special casing them here.
                 diff.add(id + WILDCARD_TAG)
                 break
         names |= diff

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -655,17 +655,14 @@ def propagate_changes_using_dependencies(
         todo = find_targets_recursive(manager, triggered, deps,
                                       manager.modules, up_to_date_modules)
         # Also process targets that used to have errors, as otherwise some
-        # errors might be lost. Only do this when there are no other triggered
-        # targets to avoid repeated work.
-        if not triggered:
-            for target in targets_with_errors:
-                id = module_prefix(manager.modules, target)
-                if id is not None and id not in up_to_date_modules:
-                    if id not in todo:
-                        todo[id] = set()
-                    manager.log_fine_grained('process target with error: %s' % target)
-                    todo[id].update(lookup_target(manager.modules, target))
-            targets_with_errors = set()
+        # errors might be lost.
+        for target in targets_with_errors:
+            id = module_prefix(manager.modules, target)
+            if id is not None and id not in up_to_date_modules:
+                if id not in todo:
+                    todo[id] = set()
+                manager.log_fine_grained('process target with error: %s' % target)
+                todo[id].update(lookup_target(manager.modules, target))
         triggered = set()
         # TODO: Preserve order (set is not optimal)
         for id, nodes in sorted(todo.items(), key=lambda x: x[0]):
@@ -681,6 +678,7 @@ def propagate_changes_using_dependencies(
         # previously considered up to date. For example, there may be a
         # dependency loop that loops back to an originally processed module.
         up_to_date_modules = set()
+        targets_with_errors = set()
         if is_verbose(manager):
             manager.log_fine_grained('triggered: %r' % list(triggered))
 

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -929,4 +929,4 @@ def target_from_node(module: str,
         else:
             return '%s.%s' % (module, node.name())
     else:
-        assert False
+        assert False, "Lambda expressions can't be deferred in fine-grained incremental mode"

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -595,8 +595,10 @@ def calculate_active_triggers(manager: BuildManager,
         else:
             snapshot2 = snapshot_symbol_table(id, new.names)
         diff = compare_symbol_table_snapshots(id, snapshot1, snapshot2)
+        package_nesting_level = id.count('.')
         for item in diff:
-            if item.count('.') <= 1 and not item.split('.')[-1].startswith('_'):
+            if (item.count('.') <= package_nesting_level + 1
+                    and not item.split('.')[-1].startswith('_')):
                 # Activate catch-all wildcard trigger for top-level module changes (used for
                 # "from m import *").
                 diff.add(id + WILDCARD_TAG)

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -596,3 +596,10 @@ def foo(x: Point) -> int:
 <m.Point> -> <m.foo>, <m.p>, m, m.Point, m.foo
 <m.p> -> m
 <mypy_extensions.TypedDict> -> m
+
+[case testImportStar]
+from a import *
+[file a.py]
+x = 0
+[out]
+<a[wildcard]> -> m

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1231,3 +1231,17 @@ def f() -> None: pass
 [out]
 ==
 main:2: error: Name 'f' is not defined
+
+[case testImportStarWithinFunction]
+def f() -> None:
+    from m import *
+    f()
+[file m.py]
+[file m.py.2]
+def f(x: int) -> None: pass
+[file m.py.3]
+def f() -> None: pass
+[out]
+==
+main:3: error: Too few arguments for "f"
+==

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1158,6 +1158,58 @@ main:2: error: Name 'f' is not defined
 ==
 main:2: error: Too few arguments for "f"
 
+[case testImportStarAddMissingDependencyWithinClass]
+class A:
+    from b import *
+    f()
+    x: C
+[file b.py]
+[file b.py.2]
+def f(x: int) -> None: pass
+[file b.py.3]
+def f(x: int) -> None: pass
+class C: pass
+[file b.py.4]
+def f() -> None: pass
+class C: pass
+[out]
+main:3: error: Name 'f' is not defined
+main:4: error: Name 'C' is not defined
+==
+main:3: error: Too few arguments for "f"
+main:4: error: Name 'C' is not defined
+==
+main:3: error: Too few arguments for "f"
+==
+
+[case testImportStarAddMissingDependencyInsidePackage1]
+from p.b import f
+f()
+[file p/__init__.py]
+[file p/b.py]
+from p.c import *
+[file p/c.py]
+[file p/c.py.2]
+def f(x: int) -> None: pass
+[out]
+main:1: error: Module 'p.b' has no attribute 'f'
+==
+main:2: error: Too few arguments for "f"
+
+[case testImportStarAddMissingDependencyInsidePackage2]
+import p.a
+[file p/__init__.py]
+[file p/a.py]
+from p.b import *
+f()
+[file p/b.py]
+[file p/b.py.2]
+def f(x: int) -> None: pass
+[out]
+p/a.py:2: error: Name 'f' is not defined
+==
+p/a.py:2: error: Too few arguments for "f"
+
 [case testImportStarRemoveDependency1]
 from b import f
 f()

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1109,3 +1109,73 @@ x = 1
 [builtins fixtures/bool.pyi]
 [out]
 ==
+
+[case testImportStarPropagateChange1]
+from b import f
+f()
+[file b.py]
+from c import *
+[file c.py]
+def f() -> None: pass
+[file c.py.2]
+def f(x: int) -> None: pass
+[out]
+==
+main:2: error: Too few arguments for "f"
+
+[case testImportStarPropagateChange2]
+from b import *
+f()
+[file b.py]
+def f() -> None: pass
+[file b.py.2]
+def f(x: int) -> None: pass
+[out]
+==
+main:2: error: Too few arguments for "f"
+
+[case testImportStarAddMissingDependency1]
+from b import f
+f()
+[file b.py]
+from c import *
+[file c.py]
+[file c.py.2]
+def f(x: int) -> None: pass
+[out]
+main:1: error: Module 'b' has no attribute 'f'
+==
+main:2: error: Too few arguments for "f"
+
+[case testImportStarAddMissingDependency2]
+from b import *
+f()
+[file b.py]
+[file b.py.2]
+def f(x: int) -> None: pass
+[out]
+main:2: error: Name 'f' is not defined
+==
+main:2: error: Too few arguments for "f"
+
+[case testImportStarRemoveDependency1]
+from b import f
+f()
+[file b.py]
+from c import *
+[file c.py]
+def f() -> None: pass
+[file c.py.2]
+[out]
+==
+main:1: error: Module 'b' has no attribute 'f'
+
+[case testImportStarRemoveDependency2]
+from b import *
+f()
+[file b.py]
+def f() -> None: pass
+[file b.py.2]
+[out]
+==
+main:2: error: Name 'f' is not defined

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1329,3 +1329,19 @@ def f() -> None: pass
 ==
 main:3: error: Too few arguments for "f"
 ==
+
+[case testImportStarMutuallyRecursive]
+import a
+[file a.py]
+from b import *
+[file b.py]
+from a import *
+[file b.py.2]
+from a import *
+x = 0
+[file b.py.3]
+from a import *
+x = ''
+[out]
+==
+==

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1108,9 +1108,9 @@ def f() -> Iterator[None]:
 [out]
 main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 ==
+main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 a.py:3: error: Cannot find module named 'b'
 a.py:3: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
-main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 ==
 main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1108,9 +1108,9 @@ def f() -> Iterator[None]:
 [out]
 main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 ==
-main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 a.py:3: error: Cannot find module named 'b'
 a.py:3: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 ==
 main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
 
@@ -1149,8 +1149,8 @@ def g() -> None:
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/list.pyi]
 [triggered]
-2: <b.h>, <b>, a.g
-3: <b.h>, <b>, a
+2: <b.h>, <b>, <b[wildcard]>, a.g
+3: <b.h>, <b>, <b[wildcard]>, a
 4: a.g
 [out]
 a.py:11: error: Too many arguments for "h"


### PR DESCRIPTION
This a adds a new per-module "wildcard" trigger that gets triggered if 
anything gets changed in module top-level. This allows tracking
"from m import *" dependencies which depend on every name in the
target module.

Fixes #4668.

Also fixed #4671 since it was triggered by some of the new tests.
