### PR TITLE
stubgenc: Generate PEP-526 style variable annotations

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -48,7 +48,7 @@ def generate_stub_for_c_module(module_name: str,
             type_str = type(obj).__name__
             if type_str not in ('int', 'str', 'bytes', 'float', 'bool'):
                 type_str = 'Any'
-            variables.append('%s = ... # type: %s' % (name, type_str))
+            variables.append('%s: %s' % (name, type_str))
     output = []
     for line in variables:
         output.append(line)
@@ -167,7 +167,7 @@ def generate_c_type_stub(module: ModuleType,
         if is_skipped_attribute(attr):
             continue
         if attr not in done:
-            variables.append('%s = ... # type: Any' % attr)
+            variables.append('%s: Any' % attr)
     all_bases = obj.mro()
     if all_bases[-1] is object:
         # TODO: Is this always object?

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -167,7 +167,7 @@ def generate_c_type_stub(module: ModuleType,
         if is_skipped_attribute(attr):
             continue
         if attr not in done:
-            variables.append('%s: Any' % attr)
+            variables.append('%s: Any = ...' % attr)
     all_bases = obj.mro()
     if all_bases[-1] is object:
         # TODO: Is this always object?

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -194,3 +194,13 @@ class StubgencSuite(Suite):
         mod = ModuleType('module', '')  # any module is fine
         generate_c_type_stub(mod, 'alias', object, output)
         assert_equal(output[0], 'class alias:')
+
+    def test_generate_c_type_stub_variable_type_annotation(self) -> None:
+        # This class mimics the stubgen unit test 'testClassVariable'
+        class TestClassVariableCls:
+            x = 1
+
+        output = []  # type: List[str]
+        mod = ModuleType('module', '')  # any module is fine
+        generate_c_type_stub(mod, 'C', TestClassVariableCls, output)
+        assert_equal(output, ['class C:', '    x: Any = ...'])


### PR DESCRIPTION
This makes the output from stubgen consistent between pure python modules and c modules.