### PR TITLE
Inferred subclass override of a ClassVar is also a ClassVar. Fixes #4715.

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1995,6 +1995,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 v = Var(lval.name)
                 v.info = self.type
                 v.is_initialized_in_class = True
+                v.is_inferred = not explicit_type
                 v.set_line(lval)
                 v._fullname = self.qualified_name(lval.name)
                 lval.node = v

--- a/test-data/unit/check-classvar.test
+++ b/test-data/unit/check-classvar.test
@@ -245,6 +245,22 @@ class A:
 class B(A):
     x = 2  # type: ClassVar[int]
 
+[case testOverrideClassVarWithImplicitClassVar]
+from typing import ClassVar
+class A:
+    x = 1  # type: ClassVar[int]
+class B(A):
+    x = 2
+
+[case testOverrideClassVarWithImplicitThenExplicit]
+from typing import ClassVar
+class A:
+    x = 1  # type: ClassVar[int]
+class B(A):
+    x = 2
+class C(B):
+    x = 3  # type: ClassVar[int]
+
 [case testOverrideOnABCSubclass]
 from abc import ABCMeta
 from typing import ClassVar


### PR DESCRIPTION
Fixes #4715. Notes:

1. It seems to me that many Vars which have explicit type annotation are currently wrongly marked as `is_inferred`, thus the fix in `semanal.py`. This fix doesn't cause any test failures, but it makes me wonder if I missed the intended semantics of `is_inferred`?
2. If that fix is correct, it looks likely that the same line should be added in other branches of that method, but that seems out of scope for this PR; the fix is only strictly needed for class attributes in this PR.
3. I put the fixup in pass 3 because it seemed necessary in order to ensure populated MRO. If that's wrong and this could be set correctly reliably in pass 2, let me know how and I'm happy to update.
4. The three-layer testcase is needed in order to demonstrate why my first fix attempt here was inadequate. My first try was just to check `is_inferred` in `checker.py` and not raise the override error for a type-inferred assignment, but the three-layer testcase still fails with that fix; we need to actually update the value of `is_classvar` on the node so checks work correctly on further subclassing.

Thanks in advance for review!