### PR TITLE
Fine-grained: Don't report errors for a file removed from the build

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -318,7 +318,7 @@ class Server:
                     FileData(st_mtime=float(meta.mtime), st_size=meta.size, md5=meta.hash))
 
             # Run an update
-            changed = self.find_changed(sources)
+            changed, removed = self.find_changed(sources)
 
             # Find anything that has had its dependency list change
             for state in self.fine_grained_manager.graph.values():
@@ -326,8 +326,8 @@ class Server:
                     assert state.path is not None
                     changed.append((state.id, state.path))
 
-            if changed:
-                messages = self.fine_grained_manager.update(changed)
+            if changed or removed:
+                messages = self.fine_grained_manager.update(changed, removed)
         else:
             # Stores the initial state of sources as a side effect.
             self.fswatcher.find_changed()
@@ -343,13 +343,13 @@ class Server:
 
         t0 = time.time()
         self.update_sources(sources)
-        changed = self.find_changed(sources)
+        changed, removed = self.find_changed(sources)
         t1 = time.time()
-        if not changed:
+        if not (changed or removed):
             # Nothing changed -- just produce the same result as before.
             messages = self.previous_messages
         else:
-            messages = self.fine_grained_manager.update(changed)
+            messages = self.fine_grained_manager.update(changed, removed)
         t2 = time.time()
         self.fine_grained_manager.manager.log(
             "fine-grained increment: find_changed: {:.3f}s, update: {:.3f}s".format(
@@ -364,20 +364,20 @@ class Server:
         paths = [source.path for source in sources if source.path is not None]
         self.fswatcher.add_watched_paths(paths)
 
-    def find_changed(self, sources: List[mypy.build.BuildSource]) -> List[Tuple[str, str]]:
+    def find_changed(self, sources: List[mypy.build.BuildSource]) -> Tuple[List[Tuple[str, str]],
+                                                                           List[Tuple[str, str]]]:
         changed_paths = self.fswatcher.find_changed()
         changed = [(source.module, source.path)
                    for source in sources
                    if source.path in changed_paths]
         modules = {source.module for source in sources}
         omitted = [source for source in self.previous_sources if source.module not in modules]
+        removed = []
         for source in omitted:
             path = source.path
             assert path
-            # Note that a file could be removed from the list of root sources but have no changes.
-            if path in changed_paths:
-                changed.append((source.module, path))
-        return changed
+            removed.append((source.module, path))
+        return changed, removed
 
     def cmd_hang(self) -> Dict[str, object]:
         """Hang for 100 seconds, as a debug hack."""

--- a/mypy/test/testmerge.py
+++ b/mypy/test/testmerge.py
@@ -124,7 +124,7 @@ class ASTMergeSuite(DataSuite):
     def build_increment(self, manager: FineGrainedBuildManager,
                         module_id: str, path: str) -> Tuple[MypyFile,
                                                             Dict[Expression, Type]]:
-        manager.update([(module_id, path)])
+        manager.update([(module_id, path)], [])
         module = manager.manager.modules[module_id]
         type_map = manager.graph[module_id].type_map()
         return module, type_map

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -975,7 +975,7 @@ x = Foo()
 main:2: error: Too few arguments for "foo" of "Foo"
 
 -- This series of tests is designed to test adding a new module that
--- doesn't appear in the cache, for cache mode. They are run in
+-- does not appear in the cache, for cache mode. They are run in
 -- cache mode only because stale and rechecked differ heavily between
 -- the modes.
 [case testAddModuleAfterCache1-skip-nocache]
@@ -1033,6 +1033,7 @@ a.py:2: error: Too many arguments for "foo"
 [case testAddModuleAfterCache3-skip-nocache]
 # cmd: mypy main a.py
 # cmd2: mypy main a.py b.py c.py d.py e.py f.py g.py
+# cmd3: mypy main a.py b.py c.py d.py e.py f.py g.py
 # flags: --ignore-missing-imports --follow-imports=skip
 import a
 [file a.py]
@@ -1344,4 +1345,20 @@ from a import *
 x = ''
 [out]
 ==
+==
+
+[case testDeleteFileWithErrors]
+# cmd: mypy main a.py
+# cmd2: mypy main
+# flags: --follow-imports=skip --ignore-missing-imports
+import a
+[file a.py]
+def f() -> None:
+    1()
+''()
+[file b.py.2]
+# unrelated change
+[out]
+a.py:2: error: "int" not callable
+a.py:3: error: "str" not callable
 ==


### PR DESCRIPTION
It's not sufficient to pass a list of changed files to a fine-grained
incremental build since this doesn't give enough information to decide
whether a file has been removed from a build (even if it still exists).
Modified daemon to pass modules removed from the build separately.

Fixes #4719.