### PR TITLE
Fine-grained: Fix AST strip of multiple assignment and multiple lvalues

### DIFF
--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -43,7 +43,8 @@ from typing import Union, Iterator, Optional
 from mypy.nodes import (
     Node, FuncDef, NameExpr, MemberExpr, RefExpr, MypyFile, FuncItem, ClassDef, AssignmentStmt,
     ImportFrom, Import, TypeInfo, SymbolTable, Var, CallExpr, Decorator, OverloadedFuncDef,
-    SuperExpr, UNBOUND_IMPORTED, GDEF, MDEF, IndexExpr, SymbolTableNode, ImportAll
+    SuperExpr, UNBOUND_IMPORTED, GDEF, MDEF, IndexExpr, SymbolTableNode, ImportAll, TupleExpr,
+    ListExpr
 )
 from mypy.semanal_shared import create_indirect_imported_name
 from mypy.traverser import TraverserVisitor
@@ -151,15 +152,21 @@ class NodeStripVisitor(TraverserVisitor):
     def visit_assignment_stmt(self, node: AssignmentStmt) -> None:
         node.type = node.unanalyzed_type
         if self.type and not self.is_class_body:
-            # TODO: Handle multiple assignment
-            if len(node.lvalues) == 1:
-                lvalue = node.lvalues[0]
-                if isinstance(lvalue, MemberExpr) and lvalue.is_new_def:
-                    # Remove defined attribute from the class symbol table. If is_new_def is
-                    # true for a MemberExpr, we know that it must be an assignment through
-                    # self, since only those can define new attributes.
-                    del self.type.names[lvalue.name]
+            for lvalue in node.lvalues:
+                self.process_lvalue_in_method(lvalue)
         super().visit_assignment_stmt(node)
+
+    def process_lvalue_in_method(self, lvalue: Node) -> None:
+        if isinstance(lvalue, MemberExpr):
+            if lvalue.is_new_def:
+                # Remove defined attribute from the class symbol table. If is_new_def is
+                # true for a MemberExpr, we know that it must be an assignment through
+                # self, since only those can define new attributes.
+                assert self.type is not None
+                del self.type.names[lvalue.name]
+        elif isinstance(lvalue, (TupleExpr, ListExpr)):
+            for item in lvalue.items:
+                self.process_lvalue_in_method(item)
 
     def visit_import_from(self, node: ImportFrom) -> None:
         if node.assignments:

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -2996,3 +2996,56 @@ y = 0
 [out]
 ==
 ==
+
+[case testMultipleAssignment]
+import a
+[file a.py]
+from b import f
+
+def h(x: str) -> None: pass
+
+class C:
+    def __init__(self) -> None:
+        self.a, self.b = f()
+
+    def g(self) -> None:
+        h(self.a)
+[file b.py]
+from typing import Tuple
+def f() -> Tuple[str, int]: pass
+[file b.py.2]
+from typing import Tuple
+def f() -> Tuple[int, object]: pass
+[file b.py.3]
+from typing import Tuple
+def f() -> Tuple[str, int]: pass
+[out]
+==
+a.py:10: error: Argument 1 to "h" has incompatible type "int"; expected "str"
+==
+
+[case testMultipleLvalues]
+import a
+[file a.py]
+from b import f
+
+def h(x: str) -> None: pass
+
+class C:
+    def __init__(self) -> None:
+        self.a = self.b = f()
+
+    def g(self) -> None:
+        h(self.a)
+        h(self.b)
+[file b.py]
+def f() -> str: pass
+[file b.py.2]
+def f() -> int: pass
+[file b.py.3]
+def f() -> str: pass
+[out]
+==
+a.py:10: error: Argument 1 to "h" has incompatible type "int"; expected "str"
+a.py:11: error: Argument 1 to "h" has incompatible type "int"; expected "str"
+==


### PR DESCRIPTION
These used to generate false positives when refreshed.