### PR TITLE
Fix xml report generation

### DIFF
--- a/mypy/report.py
+++ b/mypy/report.py
@@ -37,6 +37,7 @@ type_of_any_name_map = collections.OrderedDict([
     (TypeOfAny.from_omitted_generics, "Omitted Generics"),
     (TypeOfAny.from_error, "Error"),
     (TypeOfAny.special_form, "Special Form"),
+    (TypeOfAny.implementation_artifact, "Implementation Artifact"),
 ])  # type: collections.OrderedDict[TypeOfAny, str]
 
 reporter_classes = {}  # type: Dict[str, Tuple[Callable[[Reports, str], AbstractReporter], bool]]

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -302,11 +302,11 @@ z = g.does_not_exist()  # type: ignore  # Error
 
 [file report/any-exprs.txt]
 [outfile report/types-of-anys.txt]
- Name   Unannotated   Explicit   Unimported   Omitted Generics   Error   Special Form
----------------------------------------------------------------------------------------
-    n             2          3            2                  1       3              0
----------------------------------------------------------------------------------------
-Total             2          3            2                  1       3              0
+ Name   Unannotated   Explicit   Unimported   Omitted Generics   Error   Special Form   Implementation Artifact
+-----------------------------------------------------------------------------------------------------------------
+    n             2          3            2                  1       3              0                         0
+-----------------------------------------------------------------------------------------------------------------
+Total             2          3            2                  1       3              0                         0
 
 [case testAnyExpressionsReportUnqualifiedError]
 # cmd: mypy --any-exprs-report report n.py
@@ -316,11 +316,11 @@ z = does_not_exist()  # type: ignore  # Error
 
 [file report/any-exprs.txt]
 [outfile report/types-of-anys.txt]
- Name   Unannotated   Explicit   Unimported   Omitted Generics   Error   Special Form
----------------------------------------------------------------------------------------
-    n             0          0            0                  0       3              0
----------------------------------------------------------------------------------------
-Total             0          0            0                  0       3              0
+ Name   Unannotated   Explicit   Unimported   Omitted Generics   Error   Special Form   Implementation Artifact
+-----------------------------------------------------------------------------------------------------------------
+    n             0          0            0                  0       3              0                         0
+-----------------------------------------------------------------------------------------------------------------
+Total             0          0            0                  0       3              0                         0
 
 [case testAnyExpressionsReportUntypedDef]
 # cmd: mypy --any-exprs-report report n.py
@@ -332,8 +332,8 @@ def foo():
 
 [file report/any-exprs.txt]
 [outfile report/types-of-anys.txt]
- Name   Unannotated   Explicit   Unimported   Omitted Generics   Error   Special Form
----------------------------------------------------------------------------------------
-    n             0          0            0                  0       0              0
----------------------------------------------------------------------------------------
-Total             0          0            0                  0       0              0
+ Name   Unannotated   Explicit   Unimported   Omitted Generics   Error   Special Form   Implementation Artifact
+-----------------------------------------------------------------------------------------------------------------
+    n             0          0            0                  0       0              0                         0
+-----------------------------------------------------------------------------------------------------------------
+Total             0          0            0                  0       0              0                         0


### PR DESCRIPTION
Add TypeOfAny.implementation_artifact to the map from any TypeOfAny to
prettified names. This prevents xml report generation from crashing
when encountering one.