### PR TITLE
Fine-grained: Fix path equivalence assertion

### DIFF
--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -541,8 +541,8 @@ def find_relative_leaf_module(modules: List[Tuple[str, str]], graph: Graph) -> T
 
 
 def assert_equivalent_paths(path1: str, path2: str) -> None:
-    path1 = os.path.normpath(path1)
-    path2 = os.path.normpath(path2)
+    path1 = os.path.normpath(os.path.abspath(path1))
+    path2 = os.path.normpath(os.path.abspath(path2))
     assert path1 == path2, '%s != %s' % (path1, path2)
 
 


### PR DESCRIPTION
The old check could cause crashes, since some module paths
are absolute while others are relative. The root cause for
this is still unknown, but this should at least fix the
crashes.