### PR TITLE
Update test helper code to handle .pyi files correctly

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -363,7 +363,7 @@ class DataDrivenTestCase:
 
 
 def module_from_path(path: str) -> str:
-    path = re.sub(r'\.py$', '', path)
+    path = re.sub(r'\.pyi?$', '', path)
     # We can have a mix of Unix-style and Windows-style separators.
     parts = re.split(r'[/\\]', path)
     assert parts[0] == test_temp_dir


### PR DESCRIPTION
I noticed that module names for stub files were generated
incorrectly. This shouldn't affect existing tests.