### PR TITLE
Only allow snake_case keys in configuration file (#4753)

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -760,8 +760,6 @@ def parse_section(prefix: str, template: Options,
     results = {}  # type: Dict[str, object]
     report_dirs = {}  # type: Dict[str, str]
     for key in section:
-        orig_key = key
-        key = key.replace('-', '_')
         if key in config_types:
             ct = config_types[key]
         else:
@@ -770,9 +768,9 @@ def parse_section(prefix: str, template: Options,
                 if key.endswith('_report'):
                     report_type = key[:-7].replace('_', '-')
                     if report_type in reporter_classes:
-                        report_dirs[report_type] = section[orig_key]
+                        report_dirs[report_type] = section[key]
                     else:
-                        print("%s: Unrecognized report type: %s" % (prefix, orig_key),
+                        print("%s: Unrecognized report type: %s" % (prefix, key),
                               file=sys.stderr)
                     continue
                 if key.startswith('x_'):
@@ -782,26 +780,25 @@ def parse_section(prefix: str, template: Options,
                           "individual flags instead (see 'mypy -h' for the list of flags enabled "
                           "in strict mode)" % prefix, file=sys.stderr)
                 else:
-                    print("%s: Unrecognized option: %s = %s" % (prefix, key, section[orig_key]),
+                    print("%s: Unrecognized option: %s = %s" % (prefix, key, section[key]),
                           file=sys.stderr)
                 continue
             ct = type(dv)
         v = None  # type: Any
         try:
             if ct is bool:
-                v = section.getboolean(orig_key)  # type: ignore  # Until better stub
+                v = section.getboolean(key)  # type: ignore  # Until better stub
             elif callable(ct):
                 try:
-                    v = ct(section.get(orig_key))
+                    v = ct(section.get(key))
                 except argparse.ArgumentTypeError as err:
-                    print("%s: %s: %s" % (prefix, orig_key, err), file=sys.stderr)
+                    print("%s: %s: %s" % (prefix, key, err), file=sys.stderr)
                     continue
             else:
-                print("%s: Don't know what type %s should have" % (prefix, orig_key),
-                      file=sys.stderr)
+                print("%s: Don't know what type %s should have" % (prefix, key), file=sys.stderr)
                 continue
         except ValueError as err:
-            print("%s: %s: %s" % (prefix, orig_key, err), file=sys.stderr)
+            print("%s: %s: %s" % (prefix, key, err), file=sys.stderr)
             continue
         if key == 'silent_imports':
             print("%s: silent_imports has been replaced by "

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -789,18 +789,19 @@ def parse_section(prefix: str, template: Options,
         v = None  # type: Any
         try:
             if ct is bool:
-                v = section.getboolean(key)  # type: ignore  # Until better stub
+                v = section.getboolean(orig_key)  # type: ignore  # Until better stub
             elif callable(ct):
                 try:
-                    v = ct(section.get(key))
+                    v = ct(section.get(orig_key))
                 except argparse.ArgumentTypeError as err:
-                    print("%s: %s: %s" % (prefix, key, err), file=sys.stderr)
+                    print("%s: %s: %s" % (prefix, orig_key, err), file=sys.stderr)
                     continue
             else:
-                print("%s: Don't know what type %s should have" % (prefix, key), file=sys.stderr)
+                print("%s: Don't know what type %s should have" % (prefix, orig_key),
+                      file=sys.stderr)
                 continue
         except ValueError as err:
-            print("%s: %s: %s" % (prefix, key, err), file=sys.stderr)
+            print("%s: %s: %s" % (prefix, orig_key, err), file=sys.stderr)
             continue
         if key == 'silent_imports':
             print("%s: silent_imports has been replaced by "

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -449,6 +449,17 @@ main.py:2: error: Revealed type is 'Any'
 x_bad = 0
 [out]
 
+[case testConfigNormalizedFlag]
+# cmd: mypy a.py
+[file mypy.ini]
+[[mypy]
+disallow-untyped-defs = True
+[file a.py]
+def f():
+    pass
+[out]
+a.py:1: error: Function is missing a type annotation
+
 [case testDotInFilenameOKScript]
 # cmd: mypy a.b.py c.d.pyi
 [file a.b.py]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -241,6 +241,18 @@ bad = 0
 mypy.ini: [mypy]: Unrecognized option: bad = 0
 == Return code: 0
 
+[case testConfigErrorBadFlag]
+# cmd: mypy a.py
+[file mypy.ini]
+[[mypy]
+disallow-untyped-defs = True
+[file a.py]
+def f():
+    pass
+[out]
+mypy.ini: [mypy]: Unrecognized option: disallow-untyped-defs = True
+== Return code: 0
+
 [case testConfigErrorBadBoolean]
 # cmd: mypy -c pass
 [file mypy.ini]
@@ -448,17 +460,6 @@ main.py:2: error: Revealed type is 'Any'
 [[mypy-foo]
 x_bad = 0
 [out]
-
-[case testConfigNormalizedFlag]
-# cmd: mypy a.py
-[file mypy.ini]
-[[mypy]
-disallow-untyped-defs = True
-[file a.py]
-def f():
-    pass
-[out]
-a.py:1: error: Function is missing a type annotation
 
 [case testDotInFilenameOKScript]
 # cmd: mypy a.b.py c.d.pyi


### PR DESCRIPTION
We must use the original key when reading the value from the config file, since it may have been specified in a dash-notation.

Fixes #4753.