### PR TITLE
Fix adding a class in a new module and using it

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1698,7 +1698,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             var._fullname = self.qualified_name(name)
         var.is_ready = True
         if is_import:
-            any_type = AnyType(TypeOfAny.from_unimported_type)
+            any_type = AnyType(TypeOfAny.from_unimported_type, missing_import_name=var._fullname)
         else:
             any_type = AnyType(TypeOfAny.from_error)
         var.type = any_type

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -645,6 +645,8 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
         return triggers
 
     def visit_any(self, typ: AnyType) -> List[str]:
+        if typ.missing_import_name is not None:
+            return [make_trigger(typ.missing_import_name)]
         return []
 
     def visit_none_type(self, typ: NoneTyp) -> List[str]:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -315,7 +315,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     # context. This is slightly problematic as it allows using the type 'Any'
                     # as a base class -- however, this will fail soon at runtime so the problem
                     # is pretty minor.
-                    return AnyType(TypeOfAny.from_unimported_type)
+                    return AnyType(TypeOfAny.from_unimported_type,
+                                   missing_import_name=sym.node.type.missing_import_name)
                 # Allow unbound type variables when defining an alias
                 if not (self.aliasing and sym.kind == TVAR and
                         (not self.tvar_scope or self.tvar_scope.get_binding(sym) is None)):

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -604,10 +604,18 @@ x = 0
 [out]
 <a[wildcard]> -> m
 
-[case testMissingModuleClass]
+[case testMissingModuleClass1]
 from b import A  # type: ignore
 def f(x: A) -> None:
     x.foo()
 [out]
 <m.A> -> <m.f>, m.f
 <b.A> -> m
+
+[case testMissingModuleClass2]
+from p.b import A  # type: ignore
+def f(x: A) -> None:
+    x.foo()
+[out]
+<m.A> -> <m.f>, m.f
+<p.b.A> -> m

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -603,3 +603,11 @@ from a import *
 x = 0
 [out]
 <a[wildcard]> -> m
+
+[case testMissingModuleClass]
+from b import A  # type: ignore
+def f(x: A) -> None:
+    x.foo()
+[out]
+<m.A> -> <m.f>, m.f
+<b.A> -> m

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1404,3 +1404,43 @@ class Foo:
 ==
 ==
 a.py:3: error: Argument 1 to "foo" of "Foo" has incompatible type "int"; expected "str"
+
+[case testAddAndUseClass4]
+[file a.py]
+[file a.py.2]
+from b import *
+def bar(f: Foo) -> None:
+    f.foo(12)
+[file b.py.2]
+class Foo:
+    def foo(self, s: str) -> None: pass
+[out]
+==
+a.py:3: error: Argument 1 to "foo" of "Foo" has incompatible type "int"; expected "str"
+
+[case testAddAndUseClass4]
+[file a.py]
+[file a.py.2]
+from p.b import *
+def bar(f: Foo) -> None:
+    f.foo(12)
+[file p/__init__.py]
+[file p/b.py.2]
+class Foo:
+    def foo(self, s: str) -> None: pass
+[out]
+==
+a.py:3: error: Argument 1 to "foo" of "Foo" has incompatible type "int"; expected "str"
+
+[case testAddAndUseClass5]
+[file a.py]
+[file a.py.2]
+from b import *
+def bar(f: Foo) -> None:
+    f.foo(12)
+[file b.py.2]
+class Foo:
+    def foo(self, s: str) -> None: pass
+[out]
+==
+a.py:3: error: Argument 1 to "foo" of "Foo" has incompatible type "int"; expected "str"

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1362,3 +1362,45 @@ def f() -> None:
 a.py:2: error: "int" not callable
 a.py:3: error: "str" not callable
 ==
+
+[case testAddAndUseClass1]
+[file a.py]
+[file a.py.2]
+from b import Foo
+def bar(f: Foo) -> None:
+    f.foo(12)
+[file b.py.2]
+class Foo:
+    def foo(self, s: str) -> None: pass
+[out]
+==
+a.py:3: error: Argument 1 to "foo" of "Foo" has incompatible type "int"; expected "str"
+
+[case testAddAndUseClass2]
+[file a.py]
+[file a.py.3]
+from b import Foo
+def bar(f: Foo) -> None:
+    f.foo(12)
+[file b.py.2]
+class Foo:
+    def foo(self, s: str) -> None: pass
+[out]
+==
+==
+a.py:3: error: Argument 1 to "foo" of "Foo" has incompatible type "int"; expected "str"
+
+[case testAddAndUseClass3]
+# flags: --ignore-missing-imports
+[file a.py]
+[file a.py.2]
+from b import Foo
+def bar(f: Foo) -> None:
+    f.foo(12)
+[file b.py.3]
+class Foo:
+    def foo(self, s: str) -> None: pass
+[out]
+==
+==
+a.py:3: error: Argument 1 to "foo" of "Foo" has incompatible type "int"; expected "str"


### PR DESCRIPTION
We add a field to AnyType indicating---if it was created because of a
failed import---what the full name of the imported name is (that is,
the name in the importing module).

An eventual better solution might be to *always* generate dependencies to the locally imported name of variables. That would fix #4512 as well.