### PR TITLE
Support __new__ in fine grained mode

### DIFF
--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -244,6 +244,8 @@ class DependencyVisitor(TraverserVisitor):
                                     target=make_trigger(info.fullname() + '.' + name))
             self.add_dependency(make_trigger(base_info.fullname() + '.__init__'),
                                 target=make_trigger(info.fullname() + '.__init__'))
+            self.add_dependency(make_trigger(base_info.fullname() + '.__new__'),
+                                target=make_trigger(info.fullname() + '.__new__'))
 
     def visit_import(self, o: Import) -> None:
         for id, as_id in o.ids:
@@ -310,6 +312,7 @@ class DependencyVisitor(TraverserVisitor):
             if isinstance(typ, FunctionLike) and typ.is_type_obj():
                 class_name = typ.type_object().fullname()
                 self.add_dependency(make_trigger(class_name + '.__init__'))
+                self.add_dependency(make_trigger(class_name + '.__new__'))
             if isinstance(rvalue, IndexExpr) and isinstance(rvalue.analyzed, TypeAliasExpr):
                 self.add_type_dependencies(rvalue.analyzed.type)
         else:
@@ -434,6 +437,7 @@ class DependencyVisitor(TraverserVisitor):
         if isinstance(typ, FunctionLike) and typ.is_type_obj():
             class_name = typ.type_object().fullname()
             self.add_dependency(make_trigger(class_name + '.__init__'))
+            self.add_dependency(make_trigger(class_name + '.__new__'))
 
     def visit_name_expr(self, o: NameExpr) -> None:
         if o.kind == LDEF:

--- a/test-data/unit/deps-classes.test
+++ b/test-data/unit/deps-classes.test
@@ -18,6 +18,7 @@ def f(a: Any) -> None:
 class A: pass
 [out]
 <m.N.__init__> -> m.f
+<m.N.__new__> -> m.f
 <m.N.a> -> m.f
 <m.N> -> m.f
 <a.A> -> <m.N.a>, <m.N>, m
@@ -35,6 +36,7 @@ class A: pass
 class B: pass
 [out]
 <m.N.__init__> -> m.f
+<m.N.__new__> -> m.f
 <m.N.a> -> m.f
 <m.N> -> m.f
 <a.A> -> <m.N.a>, <m.N>, m
@@ -48,8 +50,10 @@ M = NamedTuple('M', [('z', 'N')])
 y = M(x)
 [out]
 <m.M.__init__> -> m
+<m.M.__new__> -> m
 <m.M> -> <m.y>, m
 <m.N.__init__> -> m
+<m.N.__new__> -> m
 <m.N> -> <m.M.z>, <m.M>, <m.x>, <m.y>, m
 <m.x> -> m
 <m.y> -> m
@@ -67,6 +71,7 @@ def f(a: Any) -> None:
 class A: pass
 [out]
 <m.N.__init__> -> m.f
+<m.N.__new__> -> m.f
 <m.N.a> -> m.f
 <m.N> -> m.N, m.f
 <a.A> -> <m.N.a>, <m.N>, m, m.N
@@ -111,6 +116,7 @@ class D:
 [out]
 -- TODO: Is it okay to have targets like m.S1@4.__init__?
 <m.C.__init__> -> <m.S1@4.__init__>, <m.S2@8.__init__>
+<m.C.__new__> -> <m.S1@4.__new__>, <m.S2@8.__new__>
 <m.C> -> m.C, m.D.g, m.f
 <m.D.g> -> m.D.g
 <m.D> -> m.D
@@ -127,6 +133,7 @@ class D(C):
         super().foo()
 [out]
 <m.C.__init__> -> <m.D.__init__>, m.D.__init__
+<m.C.__new__> -> <m.D.__new__>
 <m.C.foo> -> <m.D.foo>
 <m.C> -> m, m.C, m.D
 <m.D.__init__> -> m.D.__init__
@@ -144,8 +151,10 @@ def foo() -> None:
     D(6)
 [out]
 <m.C.__init__> -> <m.D.__init__>
+<m.C.__new__> -> <m.D.__new__>
 <m.C> -> m, m.C, m.D
 <m.D.__init__> -> m.foo
+<m.D.__new__> -> m.foo
 <m.D> -> m.D, m.foo
 
 [case testClassBasedEnum]
@@ -165,7 +174,9 @@ class B: pass
 <m.A.X> -> m.g
 -- The __init__ is superfluous but benign
 <m.A.__init__> -> m.g
+<m.A.__new__> -> m.g
 <m.A> -> <m.f>, m.A, m.f, m.g
 <m.B.__init__> -> m
+<m.B.__new__> -> m
 -- The <m.A.X> dependecy target is superfluous but benign
 <m.B> -> <m.A.X>, m

--- a/test-data/unit/deps-expressions.test
+++ b/test-data/unit/deps-expressions.test
@@ -54,6 +54,7 @@ def g() -> None:
 [out]
 <m.A.__init__> -> m.g
 <m.A.__iter__> -> m.g
+<m.A.__new__> -> m.g
 <m.A> -> m.A, m.g
 <m.f1> -> m.g
 <m.f2> -> m.g
@@ -86,6 +87,7 @@ def g() -> None:
 [out]
 <m.A.__init__> -> m.g
 <m.A.__iter__> -> m.g
+<m.A.__new__> -> m.g
 <m.A> -> m.A, m.g
 <m.f1> -> m.g
 <m.f2> -> m.g
@@ -136,6 +138,7 @@ def g() -> None:
 [out]
 <m.A.__init__> -> m.g
 <m.A.__iter__> -> m.g
+<m.A.__new__> -> m.g
 <m.A> -> m.A, m.g
 
 [case testCast]
@@ -165,6 +168,7 @@ def g() -> None:
     x = A[B, C](f())
 [out]
 <m.A.__init__> -> m.g
+<m.A.__new__> -> m.g
 <m.A> -> m.A, m.g
 <m.B> -> m.B, m.g
 <m.C> -> m.C, m.g
@@ -271,9 +275,11 @@ def f() -> int:
 [out]
 <m.A.__init__> -> m.f
 <m.A.__lt__> -> m.f
+<m.A.__new__> -> m.f
 <m.A> -> m.A, m.f
 <m.B.__gt__> -> m.f
 <m.B.__init__> -> m.f
+<m.B.__new__> -> m.f
 <m.B> -> <m.A.__lt__>, m.A.__lt__, m.B, m.f
 
 [case testIsOp-skip]
@@ -286,8 +292,10 @@ def f() -> bool:
 [out]
 -- fails because of https://github.com/python/mypy/issues/4055
 <m.A.__init__> -> m.f
+<m.A.__new__> -> m.f
 <m.A> -> m.A, m.f
 <m.B.__init__> -> m.f
+<m.B.__new__> -> m.f
 <m.B> -> m.B, m.f
 
 [case testInOp]
@@ -300,8 +308,10 @@ def f() -> int:
 [out]
 <m.A.__contains__> -> m.f
 <m.A.__init__> -> m.f
+<m.A.__new__> -> m.f
 <m.A> -> m.A, m.f
 <m.B.__init__> -> m.f
+<m.B.__new__> -> m.f
 <m.B> -> <m.A.__contains__>, m.A.__contains__, m.B, m.f
 
 [case testComparisonExprWithMultipleOperands]
@@ -316,13 +326,16 @@ def f() -> int:
 [out]
 <m.A.__init__> -> m.f
 <m.A.__lt__> -> m.f
+<m.A.__new__> -> m.f
 <m.A> -> m.A, m.f
 <m.B.__gt__> -> m.f
 <m.B.__init__> -> m.f
 <m.B.__le__> -> m.f
+<m.B.__new__> -> m.f
 <m.B> -> <m.A.__lt__>, <m.C.__ge__>, m.A.__lt__, m.B, m.C.__ge__, m.f
 <m.C.__ge__> -> m.f
 <m.C.__init__> -> m.f
+<m.C.__new__> -> m.f
 <m.C> -> m.C, m.f
 
 [case testOperatorWithTupleOperand]

--- a/test-data/unit/deps-generics.test
+++ b/test-data/unit/deps-generics.test
@@ -64,9 +64,11 @@ def f() -> None:
     a = A(B())
 [out]
 <m.A.__init__> -> m.f
+<m.A.__new__> -> m.f
 <m.A.x> -> m.A.__init__
 <m.A> -> m.A, m.f
 <m.B.__init__> -> m.f
+<m.B.__new__> -> m.f
 <m.B> -> m.B, m.f
 <m.T> -> <m.A.__init__>, <m.A.x>, m.A, m.A.__init__
 
@@ -92,6 +94,7 @@ class B(A[C]): pass
 class C: pass
 [out]
 <m.A.__init__> -> <m.B.__init__>
+<m.A.__new__> -> <m.B.__new__>
 <m.A> -> m.A, m.B
 <m.B> -> m.B
 <m.C> -> m.B, m.C
@@ -106,6 +109,7 @@ class A(Generic[T]): pass
 class B(A[T]): pass
 [out]
 <m.A.__init__> -> <m.B.__init__>
+<m.A.__new__> -> <m.B.__new__>
 <m.A> -> m.A, m.B
 <m.B> -> m.B
 <m.T> -> m.A, m.B

--- a/test-data/unit/deps-statements.test
+++ b/test-data/unit/deps-statements.test
@@ -173,10 +173,12 @@ def g() -> None:
         f3()
 [builtins fixtures/exception.pyi]
 [out]
--- The dependency on the ctor is basically spurious but not a problem
+-- The dependencies on the ctor is basically spurious but not a problem
 <m.A.__init__> -> m.g
+<m.A.__new__> -> m.g
 <m.A> -> m.A, m.g
 <m.B.__init__> -> m.g
+<m.B.__new__> -> m.g
 <m.B.f> -> m.g
 <m.B> -> m.B, m.g
 <m.f1> -> m.g
@@ -198,10 +200,12 @@ def g() -> None:
         f2()
 [builtins fixtures/exception.pyi]
 [out]
--- The dependency on the ctor is basically spurious but not a problem
+-- The dependencies on the ctor is basically spurious but not a problem
 <m.A.__init__> -> m.g
+<m.A.__new__> -> m.g
 <m.A> -> m.A, m.g
 <m.B.__init__> -> m.g
+<m.B.__new__> -> m.g
 <m.B> -> m.B, m.g
 <m.f1> -> m.g
 <m.f2> -> m.g
@@ -496,6 +500,7 @@ def f() -> Iterator[int]:
 [out]
 <m.A.__init__> -> m.f
 <m.A.__iter__> -> m.f
+<m.A.__new__> -> m.f
 <m.A> -> m.A, m.f
 
 [case testFunctionDecorator]
@@ -577,6 +582,7 @@ def g() -> None: pass
 [builtins fixtures/isinstancelist.pyi]
 [out]
 <m.A.__init__> -> <m.B.__init__>
+<m.A.__new__> -> <m.B.__new__>
 <m.A> -> <m.f>, m, m.A, m.B, m.f
 <m.B> -> <m.f>, m.B, m.f
 <m.f> -> m
@@ -602,6 +608,7 @@ class C:
 [builtins fixtures/isinstancelist.pyi]
 [out]
 <m.A.__init__> -> <m.B.__init__>
+<m.A.__new__> -> <m.B.__new__>
 <m.A> -> <m.C.f>, m, m.A, m.B, m.C.f
 <m.B> -> <m.C.f>, m.B, m.C.f
 <m.C.f> -> m
@@ -670,5 +677,6 @@ class C:
 [out]
 <m.N> -> <m.f>, m, m.f
 <m.C.__init__> -> <m.N.__init__>
+<m.C.__new__> -> <m.N.__new__>
 <m.C.x> -> <m.N.x>
 <m.C> -> m, m.N

--- a/test-data/unit/deps-statements.test
+++ b/test-data/unit/deps-statements.test
@@ -173,7 +173,7 @@ def g() -> None:
         f3()
 [builtins fixtures/exception.pyi]
 [out]
--- The dependencies on the ctor is basically spurious but not a problem
+-- The dependencies on the ctor are basically spurious but not a problem
 <m.A.__init__> -> m.g
 <m.A.__new__> -> m.g
 <m.A> -> m.A, m.g
@@ -200,7 +200,7 @@ def g() -> None:
         f2()
 [builtins fixtures/exception.pyi]
 [out]
--- The dependencies on the ctor is basically spurious but not a problem
+-- The dependencies on the ctor are basically spurious but not a problem
 <m.A.__init__> -> m.g
 <m.A.__new__> -> m.g
 <m.A> -> m.A, m.g

--- a/test-data/unit/deps-types.test
+++ b/test-data/unit/deps-types.test
@@ -146,6 +146,7 @@ def h() -> None:
     ff(A())
 [out]
 <m.A.__init__> -> m.h
+<m.A.__new__> -> m.h
 <m.A> -> <m.f>, <m.ff>, m.A, m.f, m.h
 <m.B> -> <m.f>, <m.ff>, m.B, m.f
 <m.f> -> m, m.h
@@ -164,6 +165,7 @@ class I: pass
 <m.A> -> m
 <m.x> -> m
 <mod.I.__init__> -> m
+<mod.I.__new__> -> m
 <mod.I> -> <m.x>, m
 
 [case testAliasDepsNormalModExtended]
@@ -180,6 +182,7 @@ class I: pass
 <a.A> -> m
 <a> -> m
 <mod.I.__init__> -> a
+<mod.I.__new__> -> a
 <mod.I> -> <m.x>, m, a, mod.I
 
 [case testAliasDepsNormalFunc]
@@ -192,6 +195,7 @@ class I: pass
 [out]
 <m.A> -> m.f
 <mod.I.__init__> -> m
+<mod.I.__new__> -> m
 <mod.I> -> <m.f>, m, m.f
 
 [case testAliasDepsNormalFuncExtended]
@@ -208,6 +212,7 @@ class I: pass
 <a.A> -> m.f
 <a> -> m
 <mod.I.__init__> -> a
+<mod.I.__new__> -> a
 <mod.I> -> <m.f>, m.f, a, mod.I
 
 [case testAliasDepsNormalClass]
@@ -237,6 +242,7 @@ class I: pass
 <m.C> -> m.C
 <a.A> -> m
 <mod.I.__init__> -> <m.C.__init__>
+<mod.I.__new__> -> <m.C.__new__>
 <mod.I> -> m, m.C
 
 [case testAliasDepsGenericMod]
@@ -254,6 +260,7 @@ class S: pass
 <m.A> -> m
 <m.x> -> m
 <mod.D.__init__> -> m
+<mod.D.__new__> -> m
 <mod.D> -> <m.x>, m
 <mod.I> -> <m.x>, m
 <mod.S> -> <m.x>, m
@@ -273,6 +280,7 @@ class S: pass
 [out]
 <m.A> -> m.f
 <mod.D.__init__> -> m
+<mod.D.__new__> -> m
 <mod.D> -> <m.f>, m, m.f
 <mod.I> -> <m.f>, m, m.f
 <mod.S> -> <m.f>, m, m.f
@@ -314,6 +322,7 @@ class S: pass
 <m.A> -> m
 <m.C> -> m.C
 <mod.D.__init__> -> m
+<mod.D.__new__> -> m
 <mod.D> -> <m.C.x>, m
 <mod.I> -> <m.C.x>, m
 <mod.S> -> <m.C.x>, m
@@ -330,6 +339,7 @@ class I: pass
 <m.A> -> m
 <m.x> -> m
 <mod.I.__init__> -> m
+<mod.I.__new__> -> m
 <mod.I> -> <m.x>, m
 
 [case testAliasDepsForwardFunc]
@@ -342,6 +352,7 @@ class I: pass
 [out]
 <m.A> -> m.f
 <mod.I.__init__> -> m
+<mod.I.__new__> -> m
 <mod.I> -> <m.f>, m, m.f
 
 [case testAliasDepsForwardClass]
@@ -355,6 +366,7 @@ class I: pass
 <m.A> -> m
 <m.C> -> m.C
 <mod.I.__init__> -> m
+<mod.I.__new__> -> m
 <mod.I> -> <m.C.x>, m
 
 [case testAliasDepsChainedMod]
@@ -369,6 +381,7 @@ class I: pass
 <m.B> -> m
 <m.x> -> m
 <mod.I.__init__> -> m
+<mod.I.__new__> -> m
 <mod.I> -> <m.x>, m
 
 [case testAliasDepsChainedFunc]
@@ -383,6 +396,7 @@ class I: pass
 <m.A> -> m
 <m.B> -> m.f
 <mod.I.__init__> -> m
+<mod.I.__new__> -> m
 <mod.I> -> <m.f>, m, m.f
 
 [case testAliasDepsChainedFuncExtended]
@@ -400,6 +414,7 @@ class I: pass
 <a.A> -> m
 <a> -> m
 <mod.I.__init__> -> m
+<mod.I.__new__> -> m
 <mod.I> -> <m.f>, m, m.f
 
 [case testAliasDepsChainedClass]
@@ -415,6 +430,7 @@ class I: pass
 <m.B> -> m
 <m.C> -> m.C
 <mod.I.__init__> -> <m.C.__init__>, m
+<mod.I.__new__> -> <m.C.__new__>, m
 <mod.I> -> m, m.C
 
 [case testAliasDepsNestedMod]
@@ -434,6 +450,7 @@ class S: pass
 <m.B> -> m
 <m.x> -> m
 <mod.D.__init__> -> m
+<mod.D.__new__> -> m
 <mod.D> -> <m.x>, m
 <mod.I> -> <m.x>, m
 <mod.S> -> <m.x>, m
@@ -460,6 +477,7 @@ class S: pass
 <a.A> -> m
 <a> -> m
 <mod.D.__init__> -> m, a
+<mod.D.__new__> -> m, a
 <mod.D> -> <m.x>, m, a, mod.D
 <mod.I> -> <m.x>, m, a, mod.I
 <mod.S> -> <m.x>, m, a, mod.S
@@ -483,6 +501,7 @@ class S: pass
 <m.A> -> m
 <m.B> -> m.f
 <mod.D.__init__> -> m
+<mod.D.__new__> -> m
 <mod.D> -> <m.f>, m, m.f
 <mod.I> -> <m.f>, m, m.f
 <mod.S> -> <m.f>, m, m.f
@@ -509,6 +528,7 @@ class S: pass
 <a.A> -> m
 <a> -> m
 <mod.D.__init__> -> m, a
+<mod.D.__new__> -> m, a
 <mod.D> -> <m.f>, m, m.f, a, mod.D
 <mod.I> -> <m.f>, m, m.f, a, mod.I
 <mod.S> -> <m.f>, m, m.f, a, mod.S
@@ -532,6 +552,7 @@ class S: pass
 <m.A> -> m.f
 <m.E> -> m.f
 <mod.D.__init__> -> m
+<mod.D.__new__> -> m
 <mod.D> -> <m.f>, m, m.f
 <mod.I> -> <m.f>, m, m.f
 <mod.S> -> <m.f>, m, m.f
@@ -554,6 +575,7 @@ class S: pass
 <m.B> -> m
 <m.C> -> m.C
 <mod.D.__init__> -> m
+<mod.D.__new__> -> m
 <mod.D> -> <m.C.x>, m
 <mod.I> -> <m.C.x>, m
 <mod.S> -> <m.C.x>, m
@@ -574,6 +596,7 @@ class S: pass
 [out]
 <m.A> -> m.fun
 <mod.I.__init__> -> m
+<mod.I.__new__> -> m
 <mod.I> -> m, m.fun
 
 [case testAliasDepsRuntime]
@@ -591,8 +614,10 @@ class S: pass
 <m.A> -> m
 <m.x> -> m
 <mod.D.__init__> -> m
+<mod.D.__new__> -> m
 <mod.D> -> <m.x>, m
 <mod.I.__init__> -> m
+<mod.I.__new__> -> m
 <mod.I> -> <m.x>, m
 <mod.S> -> <m.x>, m
 
@@ -616,8 +641,10 @@ class S: pass
 <a.A> -> m
 <a> -> m
 <mod.D.__init__> -> m
+<mod.D.__new__> -> m
 <mod.D> -> <m.x>, m, mod.D
 <mod.I.__init__> -> a
+<mod.I.__new__> -> a
 <mod.I> -> <m.x>, m, a, mod.I
 <mod.S> -> <m.x>, m, mod.S
 <mod.T> -> mod.D
@@ -635,6 +662,7 @@ class I: pass
 <m.A> -> m
 <m.P> -> m.P
 <mod.I.__init__> -> m
+<mod.I.__new__> -> m
 <mod.I> -> <m.P.x>, <m.P>, m, m.P
 
 [case testAliasDepsNamedTupleFunctional]
@@ -651,6 +679,7 @@ class I: pass
 <a.A> -> m
 <a> -> m
 <mod.I.__init__> -> a
+<mod.I.__new__> -> a
 <mod.I> -> <m.P.x>, <m.P>, m, a, mod.I
 
 [case testAliasDepsTypedDict]
@@ -666,6 +695,7 @@ class I: pass
 <m.A> -> m
 <m.P> -> m.P
 <mod.I.__init__> -> m
+<mod.I.__new__> -> m
 <mod.I> -> <m.P>, m, m.P
 <mypy_extensions.TypedDict> -> m
 
@@ -684,6 +714,7 @@ class I: pass
 <a.A> -> m
 <a> -> m
 <mod.I.__init__> -> a
+<mod.I.__new__> -> a
 <mod.I> -> <m.P>, a, mod.I
 <mypy_extensions.TypedDict> -> m
 
@@ -699,6 +730,7 @@ class I: pass
 <m.A> -> m.f
 <m.f> -> m.f
 <mod.I.__init__> -> m
+<mod.I.__new__> -> m
 <mod.I> -> <m.f.x>, m, m.f
 
 [case testFuncBasedEnum]
@@ -716,5 +748,6 @@ class B: pass
 [out]
 <m.A.X> -> m.g
 <m.A.__init__> -> m.g
+<m.A.__new__> -> m.g
 <m.A> -> <m.f>, m.f, m.g
 <mod.B> -> m

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -45,6 +45,7 @@ def f() -> None:
 class A: pass
 [out]
 <m.A.__init__> -> m.f
+<m.A.__new__> -> m.f
 <m.A> -> m.A, m.f
 
 [case testAccessModuleAttribute]
@@ -54,6 +55,7 @@ def f() -> None:
     x
 [out]
 <m.A.__init__> -> m
+<m.A.__new__> -> m
 <m.A> -> <m.x>, m, m.A
 <m.x> -> m, m.f
 
@@ -109,6 +111,7 @@ class B(A):
     pass
 [out]
 <m.A.__init__> -> <m.B.__init__>
+<m.A.__new__> -> <m.B.__new__>
 <m.A> -> m, m.A, m.B
 <m.B> -> m.B
 
@@ -120,6 +123,7 @@ class B(A):
         self.x = 1
 [out]
 <m.A.__init__> -> <m.B.__init__>
+<m.A.__new__> -> <m.B.__new__>
 <m.A.f> -> m.B.f
 <m.A.x> -> <m.B.x>
 <m.A> -> m, m.A, m.B
@@ -136,10 +140,12 @@ class C(B):
         self.x = 1
 [out]
 <m.A.__init__> -> <m.B.__init__>, <m.C.__init__>
+<m.A.__new__> -> <m.B.__new__>, <m.C.__new__>
 <m.A.f> -> m.C.f
 <m.A.x> -> <m.C.x>
 <m.A> -> m, m.A, m.B
 <m.B.__init__> -> <m.C.__init__>
+<m.B.__new__> -> <m.C.__new__>
 <m.B.f> -> m.C.f
 <m.B.x> -> <m.C.x>
 <m.B> -> m, m.B, m.C
@@ -160,6 +166,7 @@ class A:
 <m.B.x> -> m.B.f
 <m.B> -> m.B
 <n.A.__init__> -> <m.B.__init__>
+<n.A.__new__> -> <m.B.__new__>
 <n.A.f> -> m.B.f
 <n.A.g> -> <m.B.g>
 <n.A.x> -> <m.B.x>
@@ -174,6 +181,7 @@ class B(A):
         self.g()
 [out]
 <m.A.__init__> -> <m.B.__init__>
+<m.A.__new__> -> <m.B.__new__>
 <m.A.f> -> m.B.f
 <m.A.g> -> <m.B.g>
 <m.A> -> m, m.A, m.B
@@ -241,8 +249,10 @@ def f() -> None:
     A(C())
 [out]
 <m.A.__init__> -> m.f
+<m.A.__new__> -> m.f
 <m.A> -> m.A, m.f
 <m.C.__init__> -> m.f
+<m.C.__new__> -> m.f
 <m.C> -> <m.A.__init__>, m.A.__init__, m.C, m.f
 
 [case testNonTrivialConstructor]
@@ -282,6 +292,7 @@ class A:
         def f(self) -> None: pass
 [out]
 <m.A.B.__init__> -> m.f
+<m.A.B.__new__> -> m.f
 <m.A.B.f> -> m.f
 <m.A.B> -> m.A.B, m.f
 <m.A> -> m.A, m.f
@@ -296,6 +307,7 @@ class A:
             self.x = 1
 [out]
 <m.A.B.__init__> -> m.f
+<m.A.B.__new__> -> m.f
 <m.A.B.x> -> m.A.B.f, m.f
 <m.A.B> -> m.A.B, m.f
 <m.A> -> m.A, m.f
@@ -337,8 +349,9 @@ def f(x: object) -> None:
         x.g()
 [builtins fixtures/isinstancelist.pyi]
 [out]
--- The dependency on the ctor is basically spurious but not a problem
+-- The dependencies on the ctor is basically spurious but not a problem
 <m.A.__init__> -> m.f
+<m.A.__new__> -> m.f
 <m.A.g> -> m.f
 <m.A> -> m.A, m.f
 
@@ -355,8 +368,9 @@ def f(x: A) -> None:
 [builtins fixtures/isinstancelist.pyi]
 [out]
 <m.A> -> <m.f>, m.A, m.f
--- The dependency on the ctor is basically spurious but not a problem
+-- The dependencies on the ctor is basically spurious but not a problem
 <m.B.__init__> -> m.f
+<m.B.__new__> -> m.f
 <m.B> -> m.B, m.f
 
 [case testAttributeWithClassType1]
@@ -384,6 +398,7 @@ class A: pass
 <m.B.x> -> m.B.f
 <m.B> -> m.B
 <m.A.__init__> -> m.B.f
+<m.A.__new__> -> m.B.f
 <m.A> -> <m.B.x>, m, m.B.f
 
 [case testAttributeWithClassType3]
@@ -465,6 +480,7 @@ class A: pass
 [out]
 <m.x> -> m
 <n.A.__init__> -> m
+<n.A.__new__> -> m
 <n.A> -> <m.x>, m
 
 [case testGlobalVariableAnnotation]
@@ -521,6 +537,7 @@ class A:
 <m.A.x> -> m.A.f
 <m.A> -> m.A
 <m.C.__init__> -> m.A.f
+<m.C.__new__> -> m.A.f
 <m.C> -> <m.A.x>, m.A.f, m.C
 
 [case testPartialNoneTypeAttributeCrash2]
@@ -536,6 +553,7 @@ class A:
 <m.A.x> -> m.A.f
 <m.A> -> m.A
 <m.C.__init__> -> m.A.f
+<m.C.__new__> -> m.A.f
 <m.C> -> <m.A.x>, m.A.f, m.C
 
 [case testRelativeImport]
@@ -575,6 +593,7 @@ def foo(x: Point) -> int:
 [builtins fixtures/dict.pyi]
 [out]
 <m.A.__init__> -> m
+<m.A.__new__> -> m
 <m.A> -> <m.Point>, <m.foo>, <m.p>, m, m.A, m.foo
 <m.Point> -> <m.foo>, <m.p>, m, m.foo
 <m.p> -> m
@@ -592,6 +611,7 @@ def foo(x: Point) -> int:
 [builtins fixtures/dict.pyi]
 [out]
 <m.A.__init__> -> m
+<m.A.__new__> -> m
 <m.A> -> <m.Point>, <m.foo>, <m.p>, m, m.A, m.foo
 <m.Point> -> <m.foo>, <m.p>, m, m.Point, m.foo
 <m.p> -> m

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -349,7 +349,7 @@ def f(x: object) -> None:
         x.g()
 [builtins fixtures/isinstancelist.pyi]
 [out]
--- The dependencies on the ctor is basically spurious but not a problem
+-- The dependencies on the ctor are basically spurious but not a problem
 <m.A.__init__> -> m.f
 <m.A.__new__> -> m.f
 <m.A.g> -> m.f
@@ -368,7 +368,7 @@ def f(x: A) -> None:
 [builtins fixtures/isinstancelist.pyi]
 [out]
 <m.A> -> <m.f>, m.A, m.f
--- The dependencies on the ctor is basically spurious but not a problem
+-- The dependencies on the ctor are basically spurious but not a problem
 <m.B.__init__> -> m.f
 <m.B.__new__> -> m.f
 <m.B> -> m.B, m.f

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3555,3 +3555,24 @@ class C:
 [out]
 ==
 a.py:3: error: Argument 1 to "C" has incompatible type "int"; expected "str"
+
+[case testDunderNewUpdatedCallable]
+import a
+[file a.py]
+from typing import Callable, Any
+import b
+
+def func(arg: Callable[[int], Any]) -> None:
+    pass
+func(b.C)
+[file b.py]
+class C:
+    def __new__(cls, x: int) -> C:
+        pass
+[file b.py.2]
+class C:
+    def __new__(cls, x: str) -> C:
+        pass
+[out]
+==
+a.py:6: error: Argument 1 to "func" has incompatible type "Type[C]"; expected "Callable[[int], Any]"

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3458,3 +3458,100 @@ a.py:1: error: "int" not callable
 [delete nonexistent_stub.pyi.2]
 [out]
 ==
+
+[case testDunderNewUpdatedMod]
+import a
+[file a.py]
+import b
+
+b.C(int())
+[file b.py]
+class C:
+    def __new__(cls, x: int) -> C:
+        pass
+[file b.py.2]
+class C:
+    def __new__(cls, x: str) -> C:
+        pass
+[out]
+==
+a.py:3: error: Argument 1 to "C" has incompatible type "int"; expected "str"
+
+[case testDunderNewUpdatedFunc]
+import a
+[file a.py]
+import b
+def func() -> None:
+    b.C(int())
+[file b.py]
+class C:
+    def __new__(cls, x: int) -> C:
+        pass
+[file b.py.2]
+class C:
+    def __new__(cls, x: str) -> C:
+        pass
+[out]
+==
+a.py:3: error: Argument 1 to "C" has incompatible type "int"; expected "str"
+
+[case testDunderNewUpdatedMethod]
+import a
+[file a.py]
+import b
+class A:
+    def func(self) -> None:
+        b.C(int())
+[file b.py]
+class C:
+    def __new__(cls, x: str) -> C:
+        pass
+[file b.py.2]
+class C:
+    def __new__(cls, x: int) -> C:
+        pass
+[out]
+a.py:4: error: Argument 1 to "C" has incompatible type "int"; expected "str"
+==
+
+[case testDunderNewUpdatedSubclass]
+import a
+[file a.py]
+import b
+
+b.D(int())
+[file b.py]
+from c import C
+class D(C): pass
+[file c.py]
+class C:
+    def __new__(cls, x: str) -> C:
+        pass
+[file c.py.2]
+class C:
+    def __new__(cls, x: int) -> C:
+        pass
+[out]
+a.py:3: error: Argument 1 to "D" has incompatible type "int"; expected "str"
+==
+
+[case testDunderNewUpdatedAlias]
+import a
+[file a.py]
+import b
+
+b.D(int())
+[file b.py]
+from c import C
+D = C
+[file c.py]
+class C:
+    def __new__(cls, x: int) -> C:
+        pass
+[file c.py.2]
+class C:
+    def __new__(cls, x: str) -> C:
+        pass
+[out]
+==
+a.py:3: error: Argument 1 to "C" has incompatible type "int"; expected "str"

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3459,42 +3459,6 @@ a.py:1: error: "int" not callable
 [out]
 ==
 
-[case testDunderNewUpdatedMod]
-import a
-[file a.py]
-import b
-
-b.C(int())
-[file b.py]
-class C:
-    def __new__(cls, x: int) -> C:
-        pass
-[file b.py.2]
-class C:
-    def __new__(cls, x: str) -> C:
-        pass
-[out]
-==
-a.py:3: error: Argument 1 to "C" has incompatible type "int"; expected "str"
-
-[case testDunderNewUpdatedFunc]
-import a
-[file a.py]
-import b
-def func() -> None:
-    b.C(int())
-[file b.py]
-class C:
-    def __new__(cls, x: int) -> C:
-        pass
-[file b.py.2]
-class C:
-    def __new__(cls, x: str) -> C:
-        pass
-[out]
-==
-a.py:3: error: Argument 1 to "C" has incompatible type "int"; expected "str"
-
 [case testDunderNewUpdatedMethod]
 import a
 [file a.py]
@@ -3576,3 +3540,44 @@ class C:
 [out]
 ==
 a.py:6: error: Argument 1 to "func" has incompatible type "Type[C]"; expected "Callable[[int], Any]"
+
+[case testDunderNewDefine]
+import a
+[file a.py]
+import b
+class A:
+    def func(self) -> None:
+        b.C()
+[file b.py]
+class C:
+    pass
+[file b.py.2]
+class C:
+    def __new__(cls, x: int) -> C:
+        pass
+[out]
+==
+a.py:4: error: Too few arguments for "C"
+
+[case testDunderNewInsteadOfInit]
+import a
+[file a.py]
+import b
+class A:
+    def func(self) -> None:
+        b.C(int())
+[file b.py]
+class C:
+    def __init__(cls, x: int) -> None:
+        pass
+[file b.py.2]
+class C:
+    def __new__(cls, x: int) -> C:
+        pass
+[file b.py.3]
+class C:
+    pass
+[out]
+==
+==
+a.py:4: error: Too many arguments for "C"


### PR DESCRIPTION
This is a straightforward PR that essentially adds same dependencies on ``__new__`` as we have on ``__init__`` for a class as a callable.

Just in case I add few dedicated tests.