### PR TITLE
Add tests for '# type: ignore' in fine grained mode

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -133,6 +133,7 @@ class Errors:
     # (See mypy.server.update for more about targets.)
     # Current module id.
     target_module = None  # type: Optional[str]
+    ignored_targets = None  # type: Set[str]
     scope = None  # type: Optional[Scope]
 
     def __init__(self, show_error_context: bool = False,
@@ -153,6 +154,7 @@ class Errors:
         self.only_once_messages = set()
         self.scope = None
         self.target_module = None
+        self.ignored_targets = set()
 
     def reset(self) -> None:
         self.initialize()
@@ -272,6 +274,8 @@ class Errors:
             if file in self.ignored_lines and line in self.ignored_lines[file]:
                 # Annotation requests us to ignore all errors on this line.
                 self.used_ignored_lines[file].add(line)
+                if info.target:
+                    self.ignored_targets.add(info.target)
                 return
             if file in self.ignored_files:
                 return
@@ -389,13 +393,13 @@ class Errors:
         return msgs
 
     def targets(self) -> Set[str]:
-        """Return a set of all targets that contain errors."""
+        """Return a set of all targets that contain errors including ignored ones."""
         # TODO: Make sure that either target is always defined or that not being defined
         #       is okay for fine-grained incremental checking.
         return set(info.target
                    for errs in self.error_info_map.values()
                    for info in errs
-                   if info.target)
+                   if info.target) | self.ignored_targets
 
     def render_messages(self, errors: List[ErrorInfo]) -> List[Tuple[Optional[str], int, int,
                                                                      str, str]]:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -133,7 +133,6 @@ class Errors:
     # (See mypy.server.update for more about targets.)
     # Current module id.
     target_module = None  # type: Optional[str]
-    ignored_targets = None  # type: Set[str]
     scope = None  # type: Optional[Scope]
 
     def __init__(self, show_error_context: bool = False,
@@ -154,7 +153,6 @@ class Errors:
         self.only_once_messages = set()
         self.scope = None
         self.target_module = None
-        self.ignored_targets = set()
 
     def reset(self) -> None:
         self.initialize()
@@ -274,8 +272,6 @@ class Errors:
             if file in self.ignored_lines and line in self.ignored_lines[file]:
                 # Annotation requests us to ignore all errors on this line.
                 self.used_ignored_lines[file].add(line)
-                if info.target:
-                    self.ignored_targets.add(info.target)
                 return
             if file in self.ignored_files:
                 return
@@ -393,13 +389,13 @@ class Errors:
         return msgs
 
     def targets(self) -> Set[str]:
-        """Return a set of all targets that contain errors including ignored ones."""
+        """Return a set of all targets that contain errors."""
         # TODO: Make sure that either target is always defined or that not being defined
         #       is okay for fine-grained incremental checking.
         return set(info.target
                    for errs in self.error_info_map.values()
                    for info in errs
-                   if info.target) | self.ignored_targets
+                   if info.target)
 
     def render_messages(self, errors: List[ErrorInfo]) -> List[Tuple[Optional[str], int, int,
                                                                      str, str]]:

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -559,7 +559,8 @@ class C:
 ==
 a.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
-[case testIgnoredAttrReprocessedModule-skip-cache]
+[case testIgnoredAttrReprocessedModule-skip]
+# See https://github.com/python/mypy/issues/4782
 import a
 [file a.py]
 import b

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -426,6 +426,200 @@ main:3: error: Module has no attribute "g"
 ==
 main:3: error: Module has no attribute "g"
 
+[case testIgnoreWorksAfterUpdate]
+import a
+[file a.py]
+import b
+int() + str()  # type: ignore
+[file b.py]
+x = 1
+[file b.py.2]
+x = 2
+[file b.py.3]
+x = 3
+[delete b.py.4]
+[out]
+==
+==
+==
+a.py:1: error: Cannot find module named 'b'
+a.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+
+[case testIgnoreWorksWithMissingImports]
+import a
+[file a.py]
+import b
+import xyz  # type: ignore
+xyz.whatever
+[file b.py]
+x = 1
+[file b.py.2]
+x = 2
+[file b.py.3]
+x = 3
+[file xyz.py.4]
+[out]
+==
+==
+==
+a.py:3: error: "object" has no attribute "whatever"
+
+[case testAddedIgnoreWithMissingImports]
+import a
+[file a.py]
+from b import x
+y: int = x
+[file b.py]
+from xyz import x
+[file b.py.2]
+from xyz import x  # type: ignore
+[file xyz.py.3]
+x = str()
+[out]
+b.py:1: error: Cannot find module named 'xyz'
+b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+==
+==
+a.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testRemovedIgnoreWithMissingImport]
+import a
+[file a.py]
+from b import x
+y: int = x
+[file b.py]
+from xyz import x  # type: ignore
+[file b.py.2]
+from xyz import x
+[file xyz.py.3]
+x = str()
+[out]
+==
+b.py:1: error: Cannot find module named 'xyz'
+b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+==
+a.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testRemovedModuleUnderIgnore]
+import a
+[file a.py]
+import c
+from b import x  # type: ignore
+y: int = x
+[file b.py]
+x = str()
+[file c.py]
+x = 1
+[delete b.py.2]
+[file c.py.3]
+x = 3
+[out]
+a.py:3: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+==
+==
+
+[case AddedModuleUnderIgnore]
+import a
+[file a.py]
+import c
+from b import x  # type: ignore
+y: int = x
+[file c.py]
+x = 1
+[file c.py.2]
+x = 2
+[file b.py.3]
+# empty
+[out]
+==
+==
+
+[case testIgnoreInBetween]
+import a
+[file a.py]
+import b
+x: int = b.x
+[file b.py]
+import c
+x = c.C.x  # type: ignore
+[file c.py]
+class C:
+    pass
+[file c.py.2]
+class C:
+    x: int
+[file c.py.3]
+# empty
+[file c.py.4]
+class C:
+    x: str
+[out]
+==
+==
+==
+a.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testIgnoredAttrReprocessedModule-skip-cache]
+import a
+[file a.py]
+import b
+x = b.x  # type: ignore
+y: int = x
+[file b.py]
+import c
+[file b.py.2]
+import c
+x = c.x
+[file c.py]
+x: str
+[out]
+==
+a.py:3: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testIgnoredAttrReprocessedBase]
+import a
+[file a.py]
+import b
+def fun() -> None:
+    x = b.C.x  # type: ignore
+    y: int = x
+[file b.py]
+import c
+class C:
+    pass
+[file b.py.2]
+import c
+class C(c.B):
+    pass
+[file c.py]
+class B:
+    x: str
+[out]
+==
+a.py:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testIgnoredAttrReprocessedMeta]
+import a
+[file a.py]
+import b
+def fun() -> None:
+    x = b.C.x  # type: ignore
+    y: int = x
+[file b.py]
+import c
+class C:
+    pass
+[file b.py.2]
+import c
+class C(metaclass=c.M):
+    pass
+[file c.py]
+class M(type):
+    x: str
+[out]
+==
+a.py:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
 [case testAddBaseClassMethodCausingInvalidOverride]
 import m
 class B(m.A):


### PR DESCRIPTION
Currently there very few tests for `# type: ignore` in fine grained mode. This PR adds several basic tests.

This PR actually discovered one bug with ignored errors. I attempted to fix it, but my fix only works without cache. @JukkaL could you please take a look at this?