### PR TITLE
Add more tests for generic callables in fine grained mode

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -696,7 +696,10 @@ class MessageBuilder:
         module = find_defining_module(self.modules, callee)
         if module:
             assert callee.definition is not None
-            self.note('{} defined here'.format(callable_name(callee)), callee.definition,
+            fname = callable_name(callee)
+            if not fname:  # an alias to function with a different name
+                fname = 'called function'
+            self.note('{} defined here'.format(fname), callee.definition,
                       file=module.path, origin=context)
 
     def duplicate_argument_value(self, callee: CallableType, index: int,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -698,7 +698,7 @@ class MessageBuilder:
             assert callee.definition is not None
             fname = callable_name(callee)
             if not fname:  # an alias to function with a different name
-                fname = 'called function'
+                fname = 'Called function'
             self.note('{} defined here'.format(fname), callee.definition,
                       file=module.path, origin=context)
 

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -284,7 +284,7 @@ class DependencyVisitor(TraverserVisitor):
                                        target=make_trigger(analyzed.fullname()))
             for val in analyzed.values:
                 self.add_type_dependencies(val, target=make_trigger(analyzed.fullname()))
-            # We need to add re-analyze the definition if bound or value is deleted.
+            # We need to re-analyze the definition if bound or value is deleted.
             super().visit_call_expr(rvalue)
         elif isinstance(rvalue, CallExpr) and isinstance(rvalue.analyzed, NamedTupleExpr):
             # Depend on types of named tuple items.

--- a/test-data/unit/deps-generics.test
+++ b/test-data/unit/deps-generics.test
@@ -125,8 +125,8 @@ T = TypeVar('T', bound=Tuple[A, B])
 def f(x: T) -> T:
     return x
 [out]
-<m.A> -> <m.T>, <m.f>, m.A, m.f
-<m.B> -> <m.T>, <m.f>, m.B, m.f
+<m.A> -> <m.T>, <m.f>, m, m.A, m.f
+<m.B> -> <m.T>, <m.f>, m, m.B, m.f
 <m.T> -> <m.f>, m.f
 
 [case testTypeVarBoundOperations]
@@ -144,7 +144,7 @@ def f(x: T) -> None:
 [out]
 <m.A.__add__> -> m.f
 <m.A.f> -> m.f
-<m.A> -> <m.T>, <m.f>, m.A, m.f
+<m.A> -> <m.T>, <m.f>, m, m.A, m.f
 <m.T> -> <m.f>, m.f
 
 [case testTypeVarValues]
@@ -159,10 +159,10 @@ S = TypeVar('S', C, D)
 def f(x: T) -> S:
     pass
 [out]
-<m.A> -> <m.T>, <m.f>, m.A, m.f
-<m.B> -> <m.T>, <m.f>, m.B, m.f
-<m.C> -> <m.S>, <m.f>, m.C, m.f
-<m.D> -> <m.S>, <m.f>, m.D, m.f
+<m.A> -> <m.T>, <m.f>, m, m.A, m.f
+<m.B> -> <m.T>, <m.f>, m, m.B, m.f
+<m.C> -> <m.S>, <m.f>, m, m.C, m.f
+<m.D> -> <m.S>, <m.f>, m, m.D, m.f
 <m.S> -> <m.f>, m.f
 <m.T> -> <m.f>, m.f
 
@@ -176,8 +176,8 @@ class G(Generic[S]):
     def f(self) -> S:
         pass
 [out]
-<m.C> -> <m.G.f>, <m.S>, m.C, m.G.f
-<m.D> -> <m.G.f>, <m.S>, m.D, m.G.f
+<m.C> -> <m.G.f>, <m.S>, m, m.C, m.G.f
+<m.D> -> <m.G.f>, <m.S>, m, m.D, m.G.f
 <m.G> -> m.G
 <m.S> -> <m.G.f>, m.G, m.G.f
 
@@ -194,8 +194,8 @@ class G(Generic[T]):
         x.x
 [out]
 <m.A.x> -> m.G.f
-<m.A> -> <m.G.f>, <m.T>, m.A, m.G.f
+<m.A> -> <m.G.f>, <m.T>, m, m.A, m.G.f
 <m.B.x> -> m.G.f
-<m.B> -> <m.G.f>, <m.T>, m.B, m.G.f
+<m.B> -> <m.G.f>, <m.T>, m, m.B, m.G.f
 <m.G> -> m.G
 <m.T> -> <m.G.f>, m.G, m.G.f

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3886,6 +3886,173 @@ main:3: error: Value of type variable "submod.T" of "D" cannot be "S"
 main:3: error: Value of type variable "submod.U" of "D" cannot be "I"
 ==
 
+[case testGenericFineCallableNormal]
+import a
+[file a.py]
+import b
+x: int = b.f(int())
+[file b.py]
+from c import g
+f = g
+[file c.py]
+from typing import TypeVar
+class B: pass
+T = TypeVar('T')
+def g(x: T) -> T:
+    pass
+[file c.py.2]
+from typing import TypeVar
+class B: pass
+T = TypeVar('T', str, B)
+def g(x: T) -> T:
+    pass
+[out]
+==
+a.py:2: error: Value of type variable "T" of function cannot be "int"
+
+[case testGenericFineCallableNamed]
+import a
+[file a.py]
+import b
+x: int = b.f(x=int())
+[file b.py]
+from c import g
+f = g
+[file c.py]
+from typing import TypeVar
+class B: pass
+T = TypeVar('T')
+def g(x: T) -> T:
+    pass
+[file c.py.2]
+from typing import TypeVar
+class B: pass
+T = TypeVar('T')
+def g(y: T) -> T:
+    pass
+[out]
+==
+a.py:2: error: Unexpected keyword argument "x"
+c.py:4: note: called function defined here
+
+[case testGenericFineCallableInBound]
+import a
+[file a.py]
+import b
+x: int = b.f()(int())
+[file b.py]
+from c import g
+f = g
+[file c.py]
+from typing import Callable, TypeVar
+class B: pass
+T = TypeVar('T')
+def g() -> Callable[[T], T]:
+    pass
+[file c.py.2]
+from typing import Callable, TypeVar
+class B: pass
+T = TypeVar('T', str, B)
+def g() -> Callable[[T], T]:
+    pass
+[out]
+==
+a.py:2: error: Value of type variable "T" of function cannot be "int"
+
+[case testGenericFineCallableAddedBound]
+import a
+[file a.py]
+import b
+x: int = b.f(int())
+[file b.py]
+from c import g
+f = g
+[file c.py]
+from typing import TypeVar
+class B: pass
+T = TypeVar('T')
+def g(x: T) -> T:
+    pass
+[file c.py.2]
+from typing import TypeVar
+class B: pass
+T = TypeVar('T', bound=B)
+def g(x: T) -> T:
+    pass
+[out]
+==
+a.py:2: error: Value of type variable "T" of function cannot be "int"
+
+[case testGenericFineCallableBoundDeleted-skip-nocache]
+import a
+[file a.py]
+import b
+x: int = b.f(int())
+[file b.py]
+from c import g
+f = g
+[file c.py]
+from typing import TypeVar
+import d
+T = TypeVar('T', bound=d.B)
+def g(x: T) -> T:
+    pass
+[file d.py]
+class B:
+    pass
+[file d.py.2]
+# empty
+[out]
+a.py:2: error: Value of type variable "T" of function cannot be "int"
+==
+c.py:3: error: Name 'd.B' is not defined
+
+[case testGenericFineCallableToNonGeneric]
+import a
+[file a.py]
+import b
+x: int = b.f(x=int())
+[file b.py]
+from c import g
+f = g
+[file c.py]
+from typing import TypeVar
+T = TypeVar('T')
+def g(x: T) -> T:
+    pass
+[file c.py.2]
+from typing import TypeVar
+class T: pass
+def g(x: T) -> T:
+    pass
+[out]
+==
+a.py:2: error: Incompatible types in assignment (expression has type "T", variable has type "int")
+a.py:2: error: Argument "x" has incompatible type "int"; expected "T"
+
+[case testGenericFineCallableToGenericClass]
+import a
+[file a.py]
+import b
+x: int = b.f(x=int())
+[file b.py]
+from c import g
+f = g
+[file c.py]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+def g(x: T) -> T:
+    pass
+[file c.py.2]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class g(Generic[T]):
+    def __init__(self, x: T) -> None:
+        pass
+[out]
+==
+a.py:2: error: Incompatible types in assignment (expression has type "g[int]", variable has type "int")
+
 [case testRefreshClassBasedEnum]
 import aa
 [file aa.py]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3933,7 +3933,7 @@ def g(y: T) -> T:
 [out]
 ==
 a.py:2: error: Unexpected keyword argument "x"
-c.py:4: note: called function defined here
+c.py:4: note: Called function defined here
 
 [case testGenericFineCallableInBound]
 import a
@@ -3984,6 +3984,7 @@ def g(x: T) -> T:
 a.py:2: error: Value of type variable "T" of function cannot be "int"
 
 [case testGenericFineCallableBoundDeleted-skip-nocache]
+# See https://github.com/python/mypy/issues/4783
 import a
 [file a.py]
 import b


### PR DESCRIPTION
This PR adds some more tests for generic callables in fine grained in addition to several tests added as part of type variables support PR.

These tests uncovered two bugs that I also fix here. For some reason, one of the tests fails without cache, I spent some time but still don't see why. @JukkaL I will be grateful for your advise.