### PR TITLE
Make create_source_list not exit, use it for testfinegrained

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -223,7 +223,7 @@ class Server:
         """Check a list of files."""
         try:
             self.last_sources = mypy.main.create_source_list(files, self.options)
-        except Exception as err:
+        except mypy.main.InvalidSourceList as err:
             return {'out': '', 'err': str(err), 'status': 2}
         return self.check(self.last_sources)
 

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -221,19 +221,10 @@ class Server:
 
     def cmd_check(self, files: Sequence[str]) -> Dict[str, object]:
         """Check a list of files."""
-        # TODO: Move this into check(), in case one of the args is a directory.
-        # Capture stdout/stderr and catch SystemExit while processing the source list.
-        save_stdout = sys.stdout
-        save_stderr = sys.stderr
         try:
-            sys.stdout = stdout = io.StringIO()
-            sys.stderr = stderr = io.StringIO()
             self.last_sources = mypy.main.create_source_list(files, self.options)
-        except SystemExit as err:
-            return {'out': stdout.getvalue(), 'err': stderr.getvalue(), 'status': err.code}
-        finally:
-            sys.stdout = save_stdout
-            sys.stderr = save_stderr
+        except Exception as err:
+            return {'out': '', 'err': str(err), 'status': 2}
         return self.check(self.last_sources)
 
     def cmd_recheck(self) -> Dict[str, object]:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -546,7 +546,10 @@ def process_options(args: List[str],
         targets = [BuildSource(None, None, '\n'.join(special_opts.command))]
         return targets, options
     else:
-        targets = create_source_list(special_opts.files, options)
+        try:
+            targets = create_source_list(special_opts.files, options)
+        except Exception as e:
+            fail(str(e))
         return targets, options
 
 
@@ -555,18 +558,12 @@ def create_source_list(files: Sequence[str], options: Options) -> List[BuildSour
     targets = []
     for f in files:
         if f.endswith(PY_EXTENSIONS):
-            try:
-                targets.append(BuildSource(f, crawl_up(f)[1], None))
-            except InvalidPackageName as e:
-                fail(str(e))
+            targets.append(BuildSource(f, crawl_up(f)[1], None))
         elif os.path.isdir(f):
-            try:
-                sub_targets = expand_dir(f)
-            except InvalidPackageName as e:
-                fail(str(e))
+            sub_targets = expand_dir(f)
             if not sub_targets:
-                fail("There are no .py[i] files in directory '{}'"
-                     .format(f))
+                raise Exception("There are no .py[i] files in directory '{}'"
+                                .format(f))
             targets.extend(sub_targets)
         else:
             mod = os.path.basename(f) if options.scripts_are_modules else None

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -19,14 +19,14 @@ from mypy.options import Options
 from mypy.server.update import FineGrainedBuildManager
 from mypy.test.config import test_temp_dir
 from mypy.test.data import (
-    DataDrivenTestCase, DataSuite, UpdateFile, module_from_path
+    DataDrivenTestCase, DataSuite, UpdateFile
 )
 from mypy.test.helpers import (
     assert_string_arrays_equal, parse_options, copy_and_fudge_mtime, assert_module_equivalence,
 )
 from mypy.server.mergecheck import check_consistency
 from mypy.dmypy_server import Server
-from mypy.main import expand_dir
+from mypy.main import expand_dir, create_source_list
 
 import pytest  # type: ignore  # no pytest in typeshed
 
@@ -74,11 +74,11 @@ class FineGrainedSuite(DataSuite):
         with open(main_path, 'w') as f:
             f.write(main_src)
 
-        server = Server(self.get_options(main_src, testcase, build_cache=False),
-                        alt_lib_path=test_temp_dir)
+        options = self.get_options(main_src, testcase, build_cache=False)
+        server = Server(options, alt_lib_path=test_temp_dir)
 
         step = 1
-        sources = self.parse_sources(main_src, step)
+        sources = self.parse_sources(main_src, step, options)
         if self.use_cache:
             messages = self.build(self.get_options(main_src, testcase, build_cache=True), sources)
         else:
@@ -104,7 +104,7 @@ class FineGrainedSuite(DataSuite):
                 else:
                     # Delete file
                     os.remove(op.path)
-            sources = self.parse_sources(main_src, step)
+            sources = self.parse_sources(main_src, step, options)
             new_messages = self.run_check(server, sources)
 
             updated = []  # type: List[str]
@@ -190,7 +190,8 @@ class FineGrainedSuite(DataSuite):
         return result
 
     def parse_sources(self, program_text: str,
-                      incremental_step: int) -> List[BuildSource]:
+                      incremental_step: int,
+                      options: Options) -> List[BuildSource]:
         """Return target BuildSources for a test case.
 
         Normally, the unit tests will check all files included in the test
@@ -218,17 +219,12 @@ class FineGrainedSuite(DataSuite):
 
         if m:
             # The test case wants to use a non-default set of files.
-            paths = m.group(1).strip().split()
-            result = []
-            for path in paths:
-                path = os.path.join(test_temp_dir, path)
-                module = module_from_path(path)
-                if module == 'main':
-                    module = '__main__'
-                result.append(BuildSource(path, module, None))
-            return result
+            paths = [os.path.join(test_temp_dir, path) for path in m.group(1).strip().split()]
+            return create_source_list(paths, options)
         else:
             base = BuildSource(os.path.join(test_temp_dir, 'main'), '__main__', None)
+            # Use expand_dir instead of create_source_list to avoid complaints
+            # when there aren't any .py files in an increment
             return [base] + expand_dir(test_temp_dir)
 
 

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -207,15 +207,36 @@ main:2: error: Module has no attribute "a"
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 [builtins fixtures/module.pyi]
 
-[case testAddPackage4-skip]
-# TODO: Currently crashing (https://github.com/python/mypy/issues/4477)
+[case testAddPackage4]
 import p.a
 p.a.f(1)
 [file p/a.py.2]
 def f(x: str) -> None: pass
 [file p/__init__.py.3]
 [out]
-TODO
+main:1: error: Cannot find module named 'p'
+main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: error: Cannot find module named 'p.a'
+==
+main:1: error: Cannot find module named 'p'
+main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: error: Cannot find module named 'p.a'
+==
+main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
+
+[case testAddNonPackageSubdir]
+# cmd: mypy x.py
+# cmd2: mypy x.py foo/a.py foo/b.py
+[file x.py]
+[file foo/a.py.2]
+import b
+b.foo(5)
+[file foo/b.py.2]
+def foo(x: str) -> None: pass
+[out]
+==
+foo/a.py:2: error: Argument 1 to "foo" has incompatible type "int"; expected "str"
+
 
 
 -- Delete file


### PR DESCRIPTION
This fixes a testfinegrained bug in which the computation of module
names did not properly take into account the absence of `__init__.py`
files when file names were specified in the test.

This removes a confounding factor to fixing #4477.