### PR TITLE
Handle additions/deletions of __init__.py files in fine-grained mode

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -318,9 +318,12 @@ class Server:
     def find_changed(self, sources: List[mypy.build.BuildSource]) -> Tuple[List[Tuple[str, str]],
                                                                            List[Tuple[str, str]]]:
         changed_paths = self.fswatcher.find_changed()
+        # Find anything that has been added or modified
         changed = [(source.module, source.path)
                    for source in sources
                    if source.path in changed_paths]
+
+        # Now find anything that has been removed from the build
         modules = {source.module for source in sources}
         omitted = [source for source in self.previous_sources if source.module not in modules]
         removed = []
@@ -328,6 +331,16 @@ class Server:
             path = source.path
             assert path
             removed.append((source.module, path))
+
+        # Find anything that has had its module path change because of added or removed __init__s
+        last = {s.path: s.module for s in self.previous_sources}
+        for s in sources:
+            assert s.path
+            if s.path in last and last[s.path] != s.module:
+                # Mark it as removed from its old name and changed at its new name
+                removed.append((last[s.path], s.path))
+                changed.append((s.module, s.path))
+
         return changed, removed
 
     def cmd_hang(self) -> Dict[str, object]:

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -237,6 +237,73 @@ def foo(x: str) -> None: pass
 ==
 foo/a.py:2: error: Argument 1 to "foo" has incompatible type "int"; expected "str"
 
+[case testAddPackage5]
+# cmd: mypy main p/a.py
+# cmd2: mypy main p/a.py
+# cmd3: mypy main p/a.py p/__init__.py
+import p.a
+p.a.f(1)
+[file p/a.py]
+[file p/a.py.2]
+def f(x: str) -> None: pass
+[file p/__init__.py.3]
+[out]
+main:4: error: Cannot find module named 'p'
+main:4: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:4: error: Cannot find module named 'p.a'
+==
+main:4: error: Cannot find module named 'p'
+main:4: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:4: error: Cannot find module named 'p.a'
+==
+main:5: error: Argument 1 to "f" has incompatible type "int"; expected "str"
+
+[case testAddPackage6]
+# flags: --follow-imports=skip --ignore-missing-imports
+# cmd: mypy x.py
+# cmd2: mypy x.py p/a.py
+[file x.py]
+import p.a
+p.a.f(1)
+[file p/a.py.2]
+def f(x: str) -> None: pass
+[file p/__init__.py.2]
+[out]
+==
+-- It is a bug (#4797) that this isn't an error, but not a fine-grained specific one
+
+[case testAddPackage7]
+# flags: --follow-imports=skip
+# cmd: mypy x.py
+# cmd2: mypy x.py p/a.py
+[file x.py]
+from p.a import f
+f(1)
+[file p/a.py.2]
+def f(x: str) -> None: pass
+[file p/__init__.py.2]
+[out]
+x.py:1: error: Cannot find module named 'p.a'
+x.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+==
+x.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
+
+
+[case testAddPackage8]
+# cmd: mypy x.py p/a.py
+# cmd2: mypy x.py p/a.py p/__init__.py
+# cmd3: mypy x.py p/a.py p/__init__.py
+[file x.py]
+[file p/a.py]
+1+'hi'
+[file p/__init__.py.2]
+[file p/a.py.3]
+'1'+'hi'
+[out]
+p/a.py:1: error: Unsupported operand types for + ("int" and "str")
+==
+p/a.py:1: error: Unsupported operand types for + ("int" and "str")
+==
 
 
 -- Delete file
@@ -713,8 +780,7 @@ main:1: error: Cannot find module named 'p'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 main:1: error: Cannot find module named 'p.a'
 
-[case testDeletePackage4-skip]
-# TODO: Currently crashing (https://github.com/python/mypy/issues/4477)
+[case testDeletePackage4]
 import p.a
 p.a.f(1)
 [file p/a.py]
@@ -723,7 +789,62 @@ def f(x: str) -> None: pass
 [delete p/__init__.py.2]
 [delete p/a.py.3]
 [out]
-TODO
+main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
+==
+main:1: error: Cannot find module named 'p'
+main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: error: Cannot find module named 'p.a'
+==
+main:1: error: Cannot find module named 'p'
+main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: error: Cannot find module named 'p.a'
+
+[case testDeletePackage5]
+# cmd1: mypy main p/a.py p/__init__.py
+# cmd2: mypy main p/a.py
+# cmd3: mypy main
+
+import p.a
+p.a.f(1)
+[file p/a.py]
+def f(x: str) -> None: pass
+[file p/__init__.py]
+[delete p/__init__.py.2]
+[delete p/a.py.3]
+[out]
+main:6: error: Argument 1 to "f" has incompatible type "int"; expected "str"
+==
+main:5: error: Cannot find module named 'p'
+main:5: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:5: error: Cannot find module named 'p.a'
+==
+main:5: error: Cannot find module named 'p'
+main:5: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:5: error: Cannot find module named 'p.a'
+
+
+[case testDeletePackage6]
+# cmd1: mypy p/a.py p/b.py p/__init__.py
+# cmd2: mypy p/a.py p/b.py
+# cmd3: mypy p/a.py p/b.py
+[file p/a.py]
+def f(x: str) -> None: pass
+[file p/b.py]
+from p.a import f
+f(12)
+[file p/__init__.py]
+[delete p/__init__.py.2]
+[file p/b.py.3]
+from a import f
+f(12)
+[out]
+p/b.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
+==
+p/b.py:1: error: Cannot find module named 'p.a'
+p/b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+==
+p/b.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
+
 
 -- TODO:
 -- - add one file which imports another new file, blocking error in new file


### PR DESCRIPTION
The key insight is that we can detect what modules are affected by
addition/deletion of __init__.py files by looking for paths in the
source list that have different module names in the previous and
current build.

Fixes #4477.