### PR TITLE
Don't write cache files in fine-grained incremental mode

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1978,7 +1978,10 @@ class State:
 
     def write_cache(self) -> None:
         assert self.tree is not None, "Internal error: method must be called on parsed file only"
-        if not self.path or self.options.cache_dir == os.devnull:
+        # We don't support writing cache files in fine-grained incremental mode.
+        if (not self.path
+                or self.options.cache_dir == os.devnull
+                or self.options.fine_grained_incremental):
             return
         if self.manager.options.quick_and_dirty:
             is_errors = self.manager.errors.is_errors_for_file(self.path)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -136,14 +136,16 @@ class Options:
         # Write junit.xml to given file
         self.junit_xml = None  # type: Optional[str]
 
-        # Caching options
+        # Caching and incremental checking options
         self.incremental = False
         self.cache_dir = defaults.CACHE_DIR
         self.debug_cache = False
         self.quick_and_dirty = False
         self.skip_version_check = False
         self.fine_grained_incremental = False
+        # Include fine-grained dependencies in written cache files
         self.cache_fine_grained = False
+        # Read cache files in fine-grained incremental mode (cache must include dependencies)
         self.use_fine_grained_cache = False
 
         # Paths of user plugins

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -504,7 +504,6 @@ def update_module_isolated(module: str,
     state.type_check_second_pass()
     state.compute_fine_grained_deps()
     state.finish_passes()
-    # TODO: state.write_cache()?
     # TODO: state.mark_as_rechecked()?
 
     graph[module] = state


### PR DESCRIPTION
I checked that this only affects one fine-grained test case that
uses cache, testAddModuleAfterCache3_cached-skip-nocache. This might
only affect cases where many cache files are missing.

I've seen cases were apparently some cache files are missing, and this
might help with the issue. However, this is bit of a shot in the dark.