### PR TITLE
Fix some stale_info() related crashes by giving it a proper mro

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -86,15 +86,15 @@ class NodeFixer(NodeVisitor[None]):
                         value.type_override = stnode.type_override
                         if (self.quick_and_dirty and value.kind == TYPE_ALIAS and
                                 stnode.type_override is None):
-                            value.type_override = Instance(stale_info(), [])
+                            value.type_override = Instance(stale_info(self.modules), [])
                         value.alias_tvars = stnode.alias_tvars or []
                     elif not self.quick_and_dirty:
                         assert stnode is not None, "Could not find cross-ref %s" % (cross_ref,)
                     else:
                         # We have a missing crossref in quick mode, need to put something
-                        value.node = stale_info()
+                        value.node = stale_info(self.modules)
                         if value.kind == TYPE_ALIAS:
-                            value.type_override = Instance(stale_info(), [])
+                            value.type_override = Instance(stale_info(self.modules), [])
             else:
                 if isinstance(value.node, TypeInfo):
                     # TypeInfo has no accept().  TODO: Add it?
@@ -170,7 +170,7 @@ class TypeFixer(TypeVisitor[None]):
         else:
             # Looks like a missing TypeInfo in quick mode, put something there
             assert self.quick_and_dirty, "Should never get here in normal mode"
-            inst.type = stale_info()
+            inst.type = stale_info(self.modules)
         for a in inst.args:
             a.accept(self)
 
@@ -290,12 +290,14 @@ def lookup_qualified_stnode(modules: Dict[str, MypyFile], name: str,
         names = node.names
 
 
-def stale_info() -> TypeInfo:
+def stale_info(modules: Dict[str, MypyFile]) -> TypeInfo:
     suggestion = "<stale cache: consider running mypy without --quick>"
     dummy_def = ClassDef(suggestion, Block([]))
     dummy_def.fullname = suggestion
 
     info = TypeInfo(SymbolTable(), dummy_def, "<stale>")
-    info.mro = [info]
-    info.bases = []
+    obj_type = lookup_qualified(modules, 'builtins.object', False)
+    assert isinstance(obj_type, TypeInfo)
+    info.bases = [Instance(obj_type, [])]
+    info.mro = [info, obj_type]
     return info

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2502,7 +2502,7 @@ a.f()
 import a
 reveal_type(a.f)
 [out2]
-tmp/b.py:2: error: Revealed type is 'Any'
+tmp/b.py:2: error: Revealed type is 'def () -> <stale cache: consider running mypy without --quick>'
 
 [case testQuickAndDirtyDeleteClassUsedInAnnotation]
 # flags: --quick-and-dirty
@@ -2521,6 +2521,32 @@ a.f().x
 tmp/b.py:2: error: Revealed type is 'def () -> <stale cache: consider running mypy without --quick>'
 tmp/b.py:3: error: "<stale cache: consider running mypy without --quick>" has no attribute "x"
 
+[case testQuickAndDirtyDeleteSuperClass]
+# flags: --quick-and-dirty
+import a
+[file a.py]
+from b import Foo
+z = (1, Foo())
+
+class Bar:
+    pass
+[file b.py]
+from e import Quux
+class Baz:
+    pass
+class Foo(Baz, Quux):
+    pass
+[file e.py]
+from a import Bar
+class Quux(Bar):
+    pass
+
+[file a.py.2]
+from b import Foo
+z = (1, Foo())
+[out]
+[out2]
+
 [case testQuickAndDirtyDeleteClassUsedAsBase]
 # flags: --quick-and-dirty
 import a
@@ -2535,7 +2561,8 @@ import a
 reveal_type(a.D)
 a.D().x
 [out2]
-tmp/b.py:2: error: Revealed type is 'Any'
+tmp/b.py:2: error: Revealed type is 'def () -> a.D'
+tmp/b.py:3: error: "D" has no attribute "x"
 
 [case testQuickAndDirtyDeleteNestedClassUsedInAnnotation]
 # flags: --quick-and-dirty

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -712,6 +712,32 @@ c.f(1)
 ==
 a.py:2: error: Too many arguments for "f"
 
+[case testDeleteFileWSuperClass]
+# flags: --ignore-missing-imports
+[file a.py]
+from c import Bar
+from b import Foo
+z = (1, Foo())
+[file b.py]
+from e import Quux
+from d import Baz
+class Foo(Baz, Quux):
+    pass
+
+[file e.py]
+from c import Bar
+class Quux(Bar):
+    pass
+[file c.py]
+class Bar:
+    pass
+[file d.py]
+class Baz:
+    pass
+[delete c.py.2]
+[out]
+==
+
 [case testDeleteFileWithinPackage]
 import a
 [file a.py]


### PR DESCRIPTION
`join` expects any pair of Instances to have a least upper bound, and
contains assertions to this effect. This is true because all instances
should eventually descend from object.  To preserve this invariant,
make the `stale_info()` TypeInfos properly descend from
builtins.object.

This fixes a fine-grained incremental crash observed in the wild
as well as a quick-and-dirty crash.

Bogus TypeInfo's are generated by `fixup.stale_info()` in
quick-and-dirty mode (when there is a reference to a deleted item) and
when loading from a fine fine-grained cache (when a module has been
deleted).

This changes the behavior of a couple --quick-and-dirty tests. But
since the whole premise of --quick-and-dirty is that it is wrong in
complicated cases (which certainly includes deleting objects referened
through an import cycle!), it doesn't really matter what the actual
output is, just that we don't *crash*.