### PR TITLE
Dump a bunch more spew on stubgen failures

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -156,9 +156,7 @@ def find_module_path_and_all(module: str, pyversion: Tuple[int, int],
                 # Print some debugging output that might help diagnose problems.
                 print('=== debug dump follows ===')
                 traceback.print_exc()
-                print('sys.path:')
-                for entry in sys.path:
-                    print('    %r' % entry)
+                dump_sys_path()
                 print('PYTHONPATH: %s' % os.getenv("PYTHONPATH"))
                 dump_dir(os.getcwd())
                 print('=== end of debug dump ===')
@@ -176,6 +174,18 @@ def find_module_path_and_all(module: str, pyversion: Tuple[int, int],
         module_all = None
     return module_path, module_all
 
+
+def dump_sys_path() -> None:
+    print('sys.path:')
+    for entry in sys.path:
+        print('    %r' % entry)
+        if entry in sys.path_importer_cache:
+            x = sys.path_importer_cache[entry]
+            print('      path_importer: %r / %r' % (x, getattr(x, '__dict__', None)))
+            try:
+                print('      stat: %s ' % str(os.stat(entry)))
+            except Exception as e:
+                pass
 
 def dump_dir(path: str) -> None:
     for root, dirs, files in os.walk(os.getcwd()):

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -187,6 +187,7 @@ def dump_sys_path() -> None:
             except Exception as e:
                 pass
 
+
 def dump_dir(path: str) -> None:
     for root, dirs, files in os.walk(os.getcwd()):
         print('%s:' % root)


### PR DESCRIPTION
In particular, print a bunch of internal information from the module
loader, as well as os.stat() of everything on sys.path.