### PR TITLE
Add tests for overloads in fine grained mode

### DIFF
--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -360,6 +360,7 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
     def visit_overloaded(self, t: Overloaded) -> None:
         for item in t.items():
             item.accept(self)
+        # Fallback can be None for overloaded types that haven't been semantically analyzed.
         if t.fallback is not None:
             t.fallback.accept(self)
 

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -360,7 +360,8 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
     def visit_overloaded(self, t: Overloaded) -> None:
         for item in t.items():
             item.accept(self)
-        t.fallback.accept(self)
+        if t.fallback is not None:
+            t.fallback.accept(self)
 
     def visit_deleted_type(self, typ: DeletedType) -> None:
         pass

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -107,7 +107,12 @@ class NodeStripVisitor(TraverserVisitor):
         if not self.recurse_into_functions:
             return
         node.expanded = []
+        print('func', node.type, node.unanalyzed_type)
         node.type = node.unanalyzed_type
+        # Type variable binder binds tvars before the type is analized.
+        # It should be refactored, before that we just undo this change here.
+        if node.type:
+            node.type.variables = []
         with self.enter_method(node.info) if node.info else nothing():
             super().visit_func_def(node)
 

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -109,8 +109,9 @@ class NodeStripVisitor(TraverserVisitor):
             return
         node.expanded = []
         node.type = node.unanalyzed_type
-        # Type variable binder binds tvars before the type is analized.
+        # Type variable binder binds tvars before the type is analyzed.
         # It should be refactored, before that we just undo this change here.
+        # TODO: this will be not necessary when https://github.com/python/mypy/issues/4814 is fixed.
         if node.type:
             assert isinstance(node.type, CallableType)
             node.type.variables = []

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -111,7 +111,7 @@ class NodeStripVisitor(TraverserVisitor):
         node.type = node.unanalyzed_type
         # Type variable binder binds tvars before the type is analyzed.
         # It should be refactored, before that we just undo this change here.
-        # TODO: this will be not necessary when https://github.com/python/mypy/issues/4814 is fixed.
+        # TODO: this will be not necessary when #4814 is fixed.
         if node.type:
             assert isinstance(node.type, CallableType)
             node.type.variables = []

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -48,6 +48,7 @@ from mypy.nodes import (
 )
 from mypy.semanal_shared import create_indirect_imported_name
 from mypy.traverser import TraverserVisitor
+from mypy.types import CallableType
 
 
 def strip_target(node: Union[MypyFile, FuncItem, OverloadedFuncDef]) -> None:
@@ -111,6 +112,7 @@ class NodeStripVisitor(TraverserVisitor):
         # Type variable binder binds tvars before the type is analized.
         # It should be refactored, before that we just undo this change here.
         if node.type:
+            assert isinstance(node.type, CallableType)
             node.type.variables = []
         with self.enter_method(node.info) if node.info else nothing():
             super().visit_func_def(node)

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -107,7 +107,6 @@ class NodeStripVisitor(TraverserVisitor):
         if not self.recurse_into_functions:
             return
         node.expanded = []
-        print('func', node.type, node.unanalyzed_type)
         node.type = node.unanalyzed_type
         # Type variable binder binds tvars before the type is analized.
         # It should be refactored, before that we just undo this change here.

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -199,7 +199,11 @@ class DependencyVisitor(TraverserVisitor):
         self.scope.leave()
 
     def visit_decorator(self, o: Decorator) -> None:
-        self.add_dependency(make_trigger(o.func.fullname()))
+        # We don't need to recheck outer scope for an overload, only overload itself.
+        # Also if any decorator is nested, it is not externally visible, so we don't need to
+        # generate dependency.
+        if not o.func.is_overload and self.scope.current_function_name() is None:
+            self.add_dependency(make_trigger(o.func.fullname()))
         super().visit_decorator(o)
 
     def visit_class_def(self, o: ClassDef) -> None:

--- a/test-data/unit/deps-statements.test
+++ b/test-data/unit/deps-statements.test
@@ -585,7 +585,6 @@ def g() -> None: pass
 <m.A.__new__> -> <m.B.__new__>
 <m.A> -> <m.f>, m, m.A, m.B, m.f
 <m.B> -> <m.f>, m.B, m.f
-<m.f> -> m
 <m.g> -> m.f
 
 [case testOverloadedMethod]
@@ -611,7 +610,6 @@ class C:
 <m.A.__new__> -> <m.B.__new__>
 <m.A> -> <m.C.f>, m, m.A, m.B, m.C.f
 <m.B> -> <m.C.f>, m.B, m.C.f
-<m.C.f> -> m
 <m.C.g> -> m.C.f
 <m.C> -> m.C
 

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -784,3 +784,170 @@ def f(x: A) -> None:
 [out]
 <m.A> -> <m.f>, m.f
 <p.b.A> -> m
+
+[case testDepsFromOverloadMod]
+import mod
+x = mod.f
+[file mod.py]
+from typing import overload
+@overload
+def f(x: int) -> None: pass
+@overload
+def f(x: str) -> str: pass
+def f(x):
+    pass
+[out]
+<m.x> -> m
+<mod.f> -> m
+<mod> -> m
+
+[case testDepsFromOverloadFunc]
+import mod
+def f() -> None:
+    x = mod.f
+[file mod.py]
+from typing import overload
+@overload
+def f(x: int) -> None: pass
+@overload
+def f(x: str) -> str: pass
+def f(x):
+    pass
+[out]
+<mod.f> -> m.f
+<mod> -> m, m.f
+
+[case testDepsToOverloadMod]
+from typing import overload, Any
+import mod
+@overload
+def f(x: int) -> None: pass
+@overload
+def f(x: str) -> str: pass
+def f(x: Any) -> Any:
+    mod.f()
+[file mod.py]
+def f() -> int:
+    pass
+[out]
+<m.f> -> m
+<mod.f> -> m.f
+<mod> -> m, m.f
+
+[case testDepsToOverloadFunc]
+from typing import overload, Any
+import mod
+def outer() -> None:
+    @overload
+    def f(x: int) -> None: pass
+    @overload
+    def f(x: str) -> str: pass
+    def f(x: Any) -> Any:
+        mod.f()
+[file mod.py]
+def f() -> int:
+    pass
+[out]
+<m.f> -> m.outer
+<mod.f> -> m.outer
+<mod> -> m, m.outer
+
+[case testDepsFromOverloadToOverload]
+from typing import overload, Any
+import mod
+def outer() -> None:
+    @overload
+    def f(x: int) -> None: pass
+    @overload
+    def f(x: str) -> str: pass
+    def f(x: Any) -> Any:
+        mod.f(str())
+[file mod.py]
+from typing import overload
+@overload
+def f(x: int) -> None: pass
+@overload
+def f(x: str) -> str: pass
+def f(x):
+    pass
+[out]
+<m.f> -> m.outer
+<mod.f> -> m.outer
+<mod> -> m, m.outer
+
+[case testDepsFromOverloadToOverloadDefault]
+from typing import overload, Any
+import mod
+def outer() -> None:
+    @overload
+    def f(x: int) -> None: pass
+    @overload
+    def f(x: str, cb=mod.f) -> str: pass
+    def f(*args: Any, **kwargs: Any) -> Any:
+        pass
+[file mod.py]
+from typing import overload
+@overload
+def f(x: int) -> None: pass
+@overload
+def f(x: str) -> str: pass
+def f(x):
+    pass
+[builtins fixtures/dict.pyi]
+[out]
+<m.f> -> m.outer
+<mod.f> -> m.outer
+<mod> -> m, m.outer
+
+[case testDepsToOverloadGeneric]
+# __dump_all__
+import mod
+from typing import overload, Any
+@overload
+def f(x: mod.TA) -> mod.TA: pass
+@overload
+def f(x: mod.TB, y: int) -> mod.TB: pass
+def f(*args: Any, **kwargs: Any) -> Any:
+    pass
+[file mod.py]
+from typing import TypeVar
+import submod
+TA = TypeVar('TA', submod.A, submod.B)
+TB = TypeVar('TB', bound=submod.C)
+[file submod.py]
+class A: pass
+class B: pass
+class C: pass
+[builtins fixtures/dict.pyi]
+[out]
+<m.f> -> m
+<mod.TA> -> <m.f>, m.f
+<mod.TB> -> <m.f>, m.f
+<mod> -> m
+<submod.A> -> <m.f>, <mod.TA>, m.f, mod, submod.A
+<submod.B> -> <m.f>, <mod.TA>, m.f, mod, submod.B
+<submod.C> -> <m.f>, <mod.TB>, m.f, mod, submod.C
+<submod> -> mod
+
+[case testDepsOverloadExternalVsImplementationType]
+import mod
+from typing import overload
+@overload
+def f(x: mod.A) -> mod.A: pass
+@overload
+def f(x: mod.B) -> mod.B: pass
+def f(x: mod.Base) -> mod.Base:
+    pass
+[file mod.py]
+class Base:
+    pass
+class A(Base):
+    pass
+class B(Base):
+    pass
+[out]
+<m.f> -> m
+<mod.A> -> <m.f>, m.f
+<mod.B> -> <m.f>, m.f
+<mod.Base> -> <m.f>, m.f
+<mod> -> m

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -669,7 +669,6 @@ def decb(arg: C) -> Callable[[F], F]:
 class C:
     pass
 [out]
-<m.func> -> m.outer
 <mod.C.__init__> -> m.outer
 <mod.C.__new__> -> m.outer
 <mod.C> -> m.outer
@@ -690,7 +689,6 @@ from typing import Callable
 def dec(func: Callable[[int], int]) -> Callable[[str], str]:
     pass
 [out]
-<m.func> -> m.outer
 <mod.dec> -> m.outer
 <mod> -> m, m.outer
 
@@ -733,7 +731,6 @@ class C:
     def dec(self, func: Callable[..., int]) -> Callable[..., str]:
         pass
 [out]
-<m.Inner@4.func> -> m.outer
 <m.outer> -> m.outer
 <mod.C.__init__> -> m.outer
 <mod.C.__new__> -> m.outer
@@ -786,20 +783,35 @@ def f(x: A) -> None:
 <p.b.A> -> m
 
 [case testDepsFromOverloadMod]
+# __dump_all__
 import mod
 x = mod.f
 [file mod.py]
-from typing import overload
+from typing import overload, Any
+import submod
 @overload
-def f(x: int) -> None: pass
+def f(x: int) -> submod.A: pass
 @overload
-def f(x: str) -> str: pass
-def f(x):
-    pass
+def f(x: str) -> submod.B: pass
+def f(x) -> Any:
+    y: submod.C
+    y.x
+[file submod.py]
+class A: pass
+class B: pass
+class C:
+    x: D
+class D: pass
 [out]
 <m.x> -> m
 <mod.f> -> m
 <mod> -> m
+<submod.A> -> <m.x>, <mod.f>, mod.f, submod.A
+<submod.B> -> <m.x>, <mod.f>, mod.f, submod.B
+<submod.C.x> -> mod.f
+<submod.C> -> mod.f, submod.C
+<submod.D> -> <submod.C.x>, submod, submod.D
+<submod> -> mod
 
 [case testDepsFromOverloadFunc]
 import mod
@@ -825,13 +837,12 @@ def f(x: int) -> None: pass
 @overload
 def f(x: str) -> str: pass
 def f(x: Any) -> Any:
-    mod.f()
+    mod.g()
 [file mod.py]
-def f() -> int:
+def g() -> int:
     pass
 [out]
-<m.f> -> m
-<mod.f> -> m.f
+<mod.g> -> m.f
 <mod> -> m, m.f
 
 [case testDepsToOverloadFunc]
@@ -839,17 +850,20 @@ from typing import overload, Any
 import mod
 def outer() -> None:
     @overload
-    def f(x: int) -> None: pass
+    def f(x: int) -> mod.A: pass
     @overload
-    def f(x: str) -> str: pass
+    def f(x: str) -> mod.B: pass
     def f(x: Any) -> Any:
-        mod.f()
+        mod.g()
 [file mod.py]
-def f() -> int:
+def g() -> int:
     pass
+class A: pass
+class B: pass
 [out]
-<m.f> -> m.outer
-<mod.f> -> m.outer
+<mod.A> -> <m.outer>, m.outer
+<mod.B> -> <m.outer>, m.outer
+<mod.g> -> m.outer
 <mod> -> m, m.outer
 
 [case testDepsFromOverloadToOverload]
@@ -861,42 +875,64 @@ def outer() -> None:
     @overload
     def f(x: str) -> str: pass
     def f(x: Any) -> Any:
-        mod.f(str())
+        mod.g(str())
 [file mod.py]
 from typing import overload
 @overload
-def f(x: int) -> None: pass
+def g(x: int) -> None: pass
 @overload
-def f(x: str) -> str: pass
-def f(x):
+def g(x: str) -> str: pass
+def g(x):
     pass
 [out]
-<m.f> -> m.outer
-<mod.f> -> m.outer
+<mod.g> -> m.outer
 <mod> -> m, m.outer
 
-[case testDepsFromOverloadToOverloadDefault]
+[case testDepsFromOverloadToOverloadDefaultClass]
+from typing import overload, Any
+import mod
+class Outer:
+    @overload
+    def f(self, x: int) -> None: pass
+    @overload
+    def f(self, x: str, cb=mod.g) -> str: pass
+    def f(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+[file mod.py]
+from typing import overload
+@overload
+def g(x: int) -> None: pass
+@overload
+def g(x: str) -> str: pass
+def g(x):
+    pass
+[builtins fixtures/dict.pyi]
+[out]
+<m.Outer> -> m.Outer
+<mod.g> -> m.Outer.f
+<mod> -> m, m.Outer.f
+
+[case testDepsFromOverloadToOverloadDefaultNested]
 from typing import overload, Any
 import mod
 def outer() -> None:
     @overload
     def f(x: int) -> None: pass
     @overload
-    def f(x: str, cb=mod.f) -> str: pass
+    def f(x: str, cb=mod.g) -> str: pass
     def f(*args: Any, **kwargs: Any) -> Any:
         pass
 [file mod.py]
 from typing import overload
 @overload
-def f(x: int) -> None: pass
+def g(x: int) -> None: pass
 @overload
-def f(x: str) -> str: pass
-def f(x):
+def g(x: str) -> str: pass
+def g(x):
     pass
 [builtins fixtures/dict.pyi]
 [out]
-<m.f> -> m.outer
-<mod.f> -> m.outer
+<mod.g> -> m.outer
 <mod> -> m, m.outer
 
 [case testDepsToOverloadGeneric]
@@ -920,7 +956,6 @@ class B: pass
 class C: pass
 [builtins fixtures/dict.pyi]
 [out]
-<m.f> -> m
 <mod.TA> -> <m.f>, m.f
 <mod.TB> -> <m.f>, m.f
 <mod> -> m
@@ -946,7 +981,6 @@ class A(Base):
 class B(Base):
     pass
 [out]
-<m.f> -> m
 <mod.A> -> <m.f>, m.f
 <mod.B> -> <m.f>, m.f
 <mod.Base> -> <m.f>, m.f

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -929,7 +929,7 @@ class C: pass
 <submod.C> -> <m.f>, <mod.TB>, m.f, mod, submod.C
 <submod> -> mod
 
-[case testDepsOverloadExternalVsImplementationType]
+[case testDepsOverloadBothExternalAndImplementationType]
 import mod
 from typing import overload
 @overload

--- a/test-data/unit/diff.test
+++ b/test-data/unit/diff.test
@@ -762,3 +762,106 @@ class C(List[str]): pass
 [builtins fixtures/list.pyi]
 [out]
 __main__.C
+
+[case testOverloads]
+from typing import overload
+class C: pass
+@overload
+def a(x: int) -> None: pass
+@overload
+def a(x: str) -> str: pass
+def a(x):
+    pass
+@overload
+def b(x: int) -> None: pass
+@overload
+def b(x: str) -> str: pass
+def b(x):
+    pass
+@overload
+def c(x: int) -> None: pass
+@overload
+def c(x: str) -> str: pass
+def c(x):
+    pass
+@overload
+def d(x: int) -> None: pass
+@overload
+def d(x: str) -> str: pass
+def d(x):
+    pass
+[file next.py]
+from typing import overload
+class C: pass
+@overload
+def a(x: int) -> None: pass
+@overload
+def a(x: str) -> str: pass
+def a(x):
+    pass
+@overload
+def b(x: str) -> str: pass
+@overload
+def b(x: int) -> None: pass
+def b(x):
+    pass
+@overload
+def c(x: int) -> None: pass
+@overload
+def c(x: str) -> str: pass
+@overload
+def c(x: C) -> C: pass
+def c(x):
+    pass
+def d(x: int) -> None:
+    pass
+@overload
+def e(x: int) -> None: pass
+@overload
+def e(x: str) -> str: pass
+def e(x):
+    pass
+[out]
+__main__.b
+__main__.c
+__main__.d
+__main__.e
+
+[case testOverloadsExternalOnly]
+from typing import overload
+class Base: pass
+class A(Base): pass
+class B(Base): pass
+class C(Base): pass
+@overload
+def f(x: A) -> A: pass
+@overload
+def f(x: B) -> B: pass
+def f(x: Base) -> Base:
+    pass
+@overload
+def g(x: A) -> A: pass
+@overload
+def g(x: B) -> B: pass
+def g(x: Base) -> Base:
+    pass
+[file next.py]
+from typing import overload
+class Base: pass
+class A(Base): pass
+class B(Base): pass
+class C(Base): pass
+@overload
+def f(x: A) -> A: pass
+@overload
+def f(x: B) -> B: pass
+def f(x: object) -> object:
+    pass
+@overload
+def g(x: A) -> A: pass
+@overload
+def g(x: C) -> C: pass
+def g(x: Base) -> Base:
+    pass
+[out]
+__main__.g

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -4854,3 +4854,236 @@ class C:
 ==
 ==
 a.py:4: error: Too many arguments for "C"
+
+[case testOverloadsSimpleFrom]
+import a
+[file a.py]
+import mod
+def f() -> None:
+    x: str = mod.f(str())
+[file mod.py]
+from typing import overload
+@overload
+def f(x: int) -> None: pass
+@overload
+def f(x: str) -> str: pass
+def f(x):
+    pass
+[file mod.py.2]
+from typing import overload
+@overload
+def f(x: int) -> None: pass
+@overload
+def f(x: str) -> int: pass
+def f(x):
+    pass
+[out]
+==
+a.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+[case testOverloadsSimpleTo]
+import a
+[file a.py]
+from typing import overload, Any
+import mod
+def outer() -> None:
+    @overload
+    def f(x: int) -> None: pass
+    @overload
+    def f(x: str) -> str: pass
+    def f(x: Any) -> Any:
+        y: int = mod.f()
+[file mod.py]
+def f() -> int:
+    pass
+[file mod.py.2]
+def f() -> str:
+    pass
+[out]
+==
+a.py:9: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testOverloadsRemovedOverload]
+import a
+[file a.py]
+import mod
+def f() -> None:
+    x: str = mod.f(str())
+[file mod.py]
+class C: pass
+from typing import overload
+@overload
+def f(x: int) -> None: pass
+@overload
+def f(x: str) -> str: pass
+@overload
+def f(x: C) -> int: pass
+def f(x):
+    pass
+[file mod.py.2]
+class C: pass
+from typing import overload
+@overload
+def f(x: int) -> None: pass
+@overload
+def f(x: C) -> int: pass
+def f(x):
+    pass
+[out]
+==
+a.py:3: error: No overload variant of "f" matches argument types [builtins.str]
+
+[case testOverloadsDeleted]
+import a
+[file a.py]
+import mod
+def f() -> None:
+    x: str = mod.f(str())
+[file mod.py]
+from typing import overload
+@overload
+def f(x: int) -> None: pass
+@overload
+def f(x: str) -> str: pass
+def f(x):
+    pass
+[file mod.py.2]
+from typing import overload
+[out]
+==
+a.py:3: error: "object" has no attribute "f"
+
+[case testOverloadsUpdatedTypeRecheckImplementation]
+import a
+[file a.py]
+from typing import overload
+import mod
+def outer() -> None:
+    @overload
+    def f(x: mod.D) -> mod.D: pass
+    @overload
+    def f(x: mod.E) -> mod.E: pass
+    def f(x: mod.C) -> mod.C:
+        x.x = int()
+        return x
+[file mod.py]
+import submod
+class C(submod.B):
+    pass
+class D(C):
+    pass
+class E(C):
+    pass
+[file submod.py]
+import base
+class B(base.AI):
+    pass
+[file submod.py.2]
+import base
+class B(base.AS):
+    pass
+[file base.py]
+class AI:
+    x: int
+class AS:
+    x: str
+[out]
+==
+a.py:9: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+[case testOverloadsUpdatedTypeRechekConsistency]
+import a
+[file a.py]
+from typing import overload
+import mod
+def outer() -> None:
+    @overload
+    def f(x: mod.D) -> mod.D: pass
+    @overload
+    def f(x: mod.E) -> mod.E: pass
+    def f(x: mod.C) -> mod.C:
+        pass
+[file mod.py]
+class C:
+    pass
+class D(C):
+    pass
+class E(C):
+    pass
+[file mod.py.2]
+class C:
+    pass
+class D(C):
+    pass
+class E:
+    pass
+[out]
+==
+a.py:8: error: Overloaded function implementation does not accept all possible arguments of signature 2
+a.py:8: error: Overloaded function implementation cannot produce return type of signature 2
+
+[case testOverloadsGenericTypevarUpdated]
+import a
+[file a.py]
+import b
+b.f(int())
+[file b.py]
+from typing import overload
+import c
+class C: pass
+@overload
+def f(x: C) -> None: pass
+@overload
+def f(x: c.T) -> c.T: pass
+def f(x):
+    pass
+[file c.py]
+from typing import TypeVar
+T = TypeVar('T', int, str)
+[file c.py.2]
+from typing import TypeVar
+T = TypeVar('T', bound=str)
+[out]
+==
+a.py:2: error: No overload variant of "f" matches argument types [builtins.int]
+
+[case testOverloadsGenericToNonGeneric]
+import a
+[file a.py]
+import b
+b.f(int())
+[file b.py]
+from typing import overload
+import c
+class C: pass
+@overload
+def f(x: C) -> None: pass
+@overload
+def f(x: c.T) -> c.T: pass
+def f(x):
+    pass
+[file c.py]
+from typing import TypeVar
+T = TypeVar('T', bound=int)
+[file c.py.2]
+from typing import TypeVar
+class T: pass
+[out]
+==
+a.py:2: error: No overload variant of "f" matches argument types [builtins.int]
+
+[case testOverloadsToNonOverloaded-skip]
+
+[out]
+
+[case testOverloadsToOverloaded-skip]
+
+[out]
+
+[case testOverloadedToClass-skip]
+
+[out]
+
+[case testOverloadedInitSupertype-skip]
+
+[out]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -4899,7 +4899,7 @@ def f() -> str:
     pass
 [out]
 ==
-a.py:9: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:9: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testOverloadsRemovedOverload]
 import mod
@@ -4927,7 +4927,7 @@ def f(x):
     pass
 [out]
 ==
-a.py:3: error: No overload variant of "f" matches argument types [builtins.str]
+main:3: error: No overload variant of "f" matches argument types [builtins.str]
 
 [case testOverloadsDeleted]
 import mod
@@ -4946,7 +4946,7 @@ from typing import overload
 [builtins fixtures/module.pyi]
 [out]
 ==
-a.py:3: error: "object" has no attribute "f"
+main:3: error: Module has no attribute "f"
 
 [case testOverloadsUpdatedTypeRecheckImplementation]
 from typing import overload
@@ -4982,7 +4982,7 @@ class AS:
     x: str
 [out]
 ==
-a.py:9: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+main:9: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testOverloadsUpdatedTypeRechekConsistency]
 from typing import overload
@@ -5010,8 +5010,8 @@ class E:
     pass
 [out]
 ==
-a.py:8: error: Overloaded function implementation does not accept all possible arguments of signature 2
-a.py:8: error: Overloaded function implementation cannot produce return type of signature 2
+main:8: error: Overloaded function implementation does not accept all possible arguments of signature 2
+main:8: error: Overloaded function implementation cannot produce return type of signature 2
 
 [case testOverloadsGenericTypevarUpdated]
 import a
@@ -5160,8 +5160,6 @@ class C:
 mod.py:9: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testOverloadedMethodSupertype]
-import a
-[file a.py]
 from typing import overload, Any
 import b
 class Child(b.Parent):
@@ -5190,4 +5188,59 @@ class Parent:
     def f(self, arg: Any) -> Any: ...
 [out]
 ==
-a.py:4: error: Signature of "f" incompatible with supertype "Parent"
+main:4: error: Signature of "f" incompatible with supertype "Parent"
+
+[case testOverloadedInitSupertype]
+import a
+[file a.py]
+from b import B
+B(int())
+[file b.py]
+import c
+class B(c.C):
+    pass
+[file c.py]
+from typing import overload
+class C:
+    def __init__(self, x: int) -> None:
+        pass
+[file c.py.2]
+from typing import overload
+class C:
+    @overload
+    def __init__(self, x: str) -> None: pass
+    @overload
+    def __init__(self, x: str, y: int) -> None: pass
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+[builtins fixtures/dict.pyi]
+[out]
+==
+a.py:2: error: No overload variant of "B" matches argument types [builtins.int]
+
+[case testOverloadedToNormalMethodMetaclass]
+import a
+[file a.py]
+import b
+b.B.f(int())
+[file b.py]
+import c
+class B(metaclass=c.M):
+    pass
+[file c.py]
+from typing import overload
+class M(type):
+    @overload
+    def f(cls, x: str) -> str: pass
+    @overload
+    def f(cls, x: int) -> None: pass
+    def f(cls, x):
+        pass
+[file c.py.2]
+from typing import overload
+class M(type):
+    def f(cls, x: str) -> str:
+        pass
+[out]
+==
+a.py:2: error: Argument 1 to "f" of "M" has incompatible type "int"; expected "str"

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -5072,18 +5072,103 @@ class T: pass
 ==
 a.py:2: error: No overload variant of "f" matches argument types [builtins.int]
 
-[case testOverloadsToNonOverloaded-skip]
-
+[case testOverloadsToNonOverloaded]
+import a
+[file a.py]
+import mod
+def f() -> None:
+    x: str = mod.f(str())
+[file mod.py]
+from typing import overload
+@overload
+def f(x: int) -> None: pass
+@overload
+def f(x: str) -> str: pass
+def f(x):
+    pass
+[file mod.py.2]
+from typing import overload
+def f(x: int) -> int:
+    pass
 [out]
+==
+a.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+a.py:3: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 
-[case testOverloadsToOverloaded-skip]
-
+[case testOverloadsToOverloaded]
+import a
+[file a.py]
+import mod
+def f() -> None:
+    x: str = mod.f(str())
+[file mod.py]
+from typing import overload
+def f(x: str) -> str:
+    pass
+[file mod.py.2]
+from typing import overload
+@overload
+def f(x: int) -> None: pass
+@overload
+def f(x: str) -> int: pass
+def f(x):
+    pass
 [out]
+==
+a.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
-[case testOverloadedToClass-skip]
-
+[case testOverloadedToClass]
+import a
+[file a.py]
+import mod
+def f() -> None:
+    x: str = mod.f(str())
+[file mod.py]
+from typing import overload
+@overload
+def f(x: int) -> None: pass
+@overload
+def f(x: str) -> str: pass
+def f(x):
+    pass
+[file mod.py.2]
+from typing import overload
+class f:
+    def __init__(self, x: str) -> None:
+        pass
 [out]
+==
+a.py:3: error: Incompatible types in assignment (expression has type "f", variable has type "str")
 
-[case testOverloadedInitSupertype-skip]
-
+[case testOverloadedMethodSupertype]
+import a
+[file a.py]
+from typing import overload, Any
+import b
+class Child(b.Parent):
+    @overload
+    def f(self, arg: int) -> int: ...
+    @overload
+    def f(self, arg: str) -> str: ...
+    def f(self, arg: Any) -> Any: ...
+[file b.py]
+from typing import overload, Any
+class C: pass
+class Parent:
+    @overload
+    def f(self, arg: int) -> int: ...
+    @overload
+    def f(self, arg: str) -> str: ...
+    def f(self, arg: Any) -> Any: ...
+[file b.py.2]
+from typing import overload, Any
+class C: pass
+class Parent:
+    @overload
+    def f(self, arg: int) -> int: ...
+    @overload
+    def f(self, arg: str) -> C: ...
+    def f(self, arg: Any) -> Any: ...
 [out]
+==
+a.py:4: error: Signature of "f" incompatible with supertype "Parent"

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -5140,6 +5140,34 @@ class f:
 ==
 a.py:3: error: Incompatible types in assignment (expression has type "f", variable has type "str")
 
+[case testDepsFromOverloadUpdatedAttrRecheckImpl]
+import mod
+x = mod.f
+[file mod.py]
+from typing import overload, Any
+import submod
+@overload
+def f(x: int) -> submod.A: pass
+@overload
+def f(x: str) -> submod.B: pass
+def f(x) -> Any:
+    y: submod.C
+    y.x = int()
+[file submod.py]
+import other
+class A: pass
+class B: pass
+C = other.C
+[file other.py]
+class C:
+    x: int
+[file other.py.2]
+class C:
+    x: str
+[out]
+==
+mod.py:9: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+
 [case testOverloadedMethodSupertype]
 import a
 [file a.py]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -4881,9 +4881,7 @@ def f(x):
 ==
 a.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
-[case testOverloadsSimpleTo]
-import a
-[file a.py]
+[case testOverloadsSimpleToNested]
 from typing import overload, Any
 import mod
 def outer() -> None:
@@ -4904,8 +4902,6 @@ def f() -> str:
 a.py:9: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testOverloadsRemovedOverload]
-import a
-[file a.py]
 import mod
 def f() -> None:
     x: str = mod.f(str())
@@ -4934,8 +4930,6 @@ def f(x):
 a.py:3: error: No overload variant of "f" matches argument types [builtins.str]
 
 [case testOverloadsDeleted]
-import a
-[file a.py]
 import mod
 def f() -> None:
     x: str = mod.f(str())
@@ -4949,21 +4943,20 @@ def f(x):
     pass
 [file mod.py.2]
 from typing import overload
+[builtins fixtures/module.pyi]
 [out]
 ==
 a.py:3: error: "object" has no attribute "f"
 
 [case testOverloadsUpdatedTypeRecheckImplementation]
-import a
-[file a.py]
 from typing import overload
 import mod
-def outer() -> None:
+class Outer:
     @overload
-    def f(x: mod.D) -> mod.D: pass
+    def f(self, x: mod.D) -> mod.D: pass
     @overload
-    def f(x: mod.E) -> mod.E: pass
-    def f(x: mod.C) -> mod.C:
+    def f(self, x: mod.E) -> mod.E: pass
+    def f(self, x: mod.C) -> mod.C:
         x.x = int()
         return x
 [file mod.py]
@@ -4992,16 +4985,14 @@ class AS:
 a.py:9: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testOverloadsUpdatedTypeRechekConsistency]
-import a
-[file a.py]
 from typing import overload
 import mod
-def outer() -> None:
+class Outer:
     @overload
-    def f(x: mod.D) -> mod.D: pass
+    def f(self, x: mod.D) -> mod.D: pass
     @overload
-    def f(x: mod.E) -> mod.E: pass
-    def f(x: mod.C) -> mod.C:
+    def f(self, x: mod.E) -> mod.E: pass
+    def f(self, x: mod.C) -> mod.C:
         pass
 [file mod.py]
 class C:
@@ -5095,7 +5086,7 @@ def f(x: int) -> int:
 a.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 a.py:3: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 
-[case testOverloadsToOverloaded]
+[case testOverloadsUpdateFunctionToOverloaded]
 import a
 [file a.py]
 import mod
@@ -5117,7 +5108,7 @@ def f(x):
 ==
 a.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
-[case testOverloadedToClass]
+[case testOverloadedUpdateToClass]
 import a
 [file a.py]
 import mod


### PR DESCRIPTION
This PR adds tests for overloads in fine grained mode and fixes two (rather minor) uncovered crashes.

During work on this something came to my mind. The `TypeVarScope` and all the code around function type variables binding needs significant clean-up or refactoring, maybe we should add this to our plans?