### PR TITLE
remove warn_unused_ignores from mypy_self_check

### DIFF
--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -7,7 +7,6 @@ no_implicit_optional = True
 disallow_any_generics = True
 disallow_any_unimported = True
 warn_redundant_casts = True
-warn_unused_ignores = True
 warn_unused_configs = True
 
 # needs py2 compatibility


### PR DESCRIPTION
This check causes CI failures for typeshed PRs that fix unused ignores, such as python/typeshed#1982, python/typeshed#1881 and python/typeshed#1937. Currently, merging such PRs without leaving CI broken requires a complicated dance of merging into typeshed, syncing typeshed into mypy, and removing the ignores here. Removing the config option removes the need for coordinated changes in the mypy and typeshed repos, at the cost of perhaps leaving some stray type: ignores in the mypy codebase.