### PR TITLE
Add test cases for strict optional in fine grained mode

### DIFF
--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -26,7 +26,7 @@ from mypy.test.helpers import (
 )
 from mypy.server.mergecheck import check_consistency
 from mypy.dmypy_server import Server
-from mypy.main import expand_dir, create_source_list
+from mypy.main import expand_dir, create_source_list, parse_config_file
 
 import pytest  # type: ignore  # no pytest in typeshed
 
@@ -75,6 +75,14 @@ class FineGrainedSuite(DataSuite):
             f.write(main_src)
 
         options = self.get_options(main_src, testcase, build_cache=False)
+        for name, _ in testcase.files:
+            if 'mypy.ini' in name:
+                config = name  # type: Optional[str]
+                break
+        else:
+            config = None
+        if config:
+            parse_config_file(options, config)
         server = Server(options, alt_lib_path=test_temp_dir)
 
         step = 1

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -88,7 +88,10 @@ class FineGrainedSuite(DataSuite):
         step = 1
         sources = self.parse_sources(main_src, step, options)
         if self.use_cache:
-            messages = self.build(self.get_options(main_src, testcase, build_cache=True), sources)
+            build_options = self.get_options(main_src, testcase, build_cache=True)
+            if config:
+                parse_config_file(build_options, config)
+            messages = self.build(build_options, sources)
         else:
             messages = self.run_check(server, sources)
 

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -4045,6 +4045,52 @@ y: int = x
 ==
 a.py:4: error: Incompatible types in assignment (expression has type "Optional[int]", variable has type "int")
 
+[case testPerFileStrictOptionalModuleOnly]
+import a
+[file mypy.ini]
+[[mypy]
+strict_optional = False
+[[mypy-a.*]
+strict_optional = True
+[file a.py]
+from typing import Optional
+import b
+y: int = b.x
+class Dummy:
+    def f(self) -> None:
+        pass
+[file b.py]
+from typing import Optional
+import c
+x: int
+y: int = c.x
+class Dummy:
+    def f(self) -> None:
+        pass
+[file c.py]
+from typing import Optional
+x: int
+[file c.py.2]
+from typing import Optional
+x: Optional[int]
+[file b.py.3]
+from typing import Optional
+import c
+x: Optional[int]
+y: int = c.x
+[file a.py.4]
+from typing import Optional
+import b
+y: Optional[int] = b.x
+class Dummy:
+    def f(self) -> None:
+        pass
+[out]
+==
+==
+a.py:3: error: Incompatible types in assignment (expression has type "Optional[int]", variable has type "int")
+==
+
 [case testPerFileStrictOptionalFunction]
 import a
 [file mypy.ini]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3885,6 +3885,133 @@ class User:
 [out]
 ==
 
+[case testNoStrictOptionalModule]
+import a
+a.y = a.x
+[file a.py]
+from typing import Optional
+x: int
+y: int
+[file a.py.2]
+from typing import Optional
+x: Optional[int]
+y: int
+[file a.py.3]
+from typing import Optional
+x: Optional[str]
+y: int
+[out]
+==
+==
+main:2: error: Incompatible types in assignment (expression has type "Optional[str]", variable has type "int")
+
+[case testNoStrictOptionalFunction]
+import a
+from typing import Optional
+def f() -> None:
+    x: Optional[int]
+    a.g(x)
+[file a.py]
+from typing import Optional
+def g(x: Optional[int]) -> None:
+    pass
+[file a.py.2]
+from typing import Optional
+def g(x: int) -> None:
+    pass
+[file a.py.3]
+from typing import Optional
+def g(x: str) -> None:
+    pass
+[out]
+==
+==
+main:5: error: Argument 1 to "g" has incompatible type "Optional[int]"; expected "str"
+
+[case testNoStrictOptionalMethod]
+import a
+from typing import Optional
+class C:
+    def f(self) -> None:
+        x: Optional[int]
+        a.B().g(x)
+[file a.py]
+from typing import Optional
+class B:
+    def g(self, x: Optional[int]) -> None:
+        pass
+[file a.py.2]
+from typing import Optional
+class B:
+    def g(self, x: int) -> None:
+        pass
+[file a.py.3]
+from typing import Optional
+class B:
+    def g(self, x: str) -> None:
+        pass
+[out]
+==
+==
+main:6: error: Argument 1 to "g" of "B" has incompatible type "Optional[int]"; expected "str"
+
+[case testStrictOptionalModule]
+# flags: --strict-optional
+import a
+a.y = a.x
+[file a.py]
+from typing import Optional
+x: int
+y: int
+[file a.py.2]
+from typing import Optional
+x: Optional[int]
+y: int
+[out]
+==
+main:3: error: Incompatible types in assignment (expression has type "Optional[int]", variable has type "int")
+
+[case testStrictOptionalFunction]
+# flags: --strict-optional
+import a
+from typing import Optional
+def f() -> None:
+    x: Optional[int]
+    a.g(x)
+[file a.py]
+from typing import Optional
+def g(x: Optional[int]) -> None:
+    pass
+[file a.py.2]
+from typing import Optional
+def g(x: int) -> None:
+    pass
+[out]
+==
+main:6: error: Argument 1 to "g" has incompatible type "Optional[int]"; expected "int"
+
+[case testStrictOptionalMethod]
+# flags: --strict-optional
+import a
+from typing import Optional
+class C:
+    def f(self) -> None:
+        x: Optional[int]
+        a.B().g(x)
+[file a.py]
+from typing import Optional
+class B:
+    def g(self, x: Optional[int]) -> None:
+        pass
+[file a.py.2]
+from typing import Optional
+class B:
+    def g(self, x: int) -> None:
+        pass
+[out]
+==
+main:7: error: Argument 1 to "g" of "B" has incompatible type "Optional[int]"; expected "int"
+
 [case testTypeVarValuesFunction]
 import a
 [file a.py]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -31,6 +31,9 @@
 -- [stale ...].
 --
 -- Specifications for later runs can be given with [stale2 ...], [stale3 ...], etc.
+--
+-- Test runner can parse options from mypy.ini file. Updating this file in between
+-- incremental runs is not yet supported.
 
 [case testReprocessFunction]
 import m
@@ -4011,6 +4014,113 @@ class B:
 [out]
 ==
 main:7: error: Argument 1 to "g" of "B" has incompatible type "Optional[int]"; expected "int"
+
+[case testPerFileStrictOptionalModule]
+import a
+[file mypy.ini]
+[[mypy]
+strict_optional = False
+[[mypy-a.*]
+strict_optional = True
+[file a.py]
+from typing import Optional
+import b
+x: int
+y: int = x
+[file b.py]
+from typing import Optional
+x: int
+y: int = x
+[file b.py.2]
+from typing import Optional
+x: Optional[int]
+y: int = x
+[file a.py.3]
+from typing import Optional
+import b
+x: Optional[int]
+y: int = x
+[out]
+==
+==
+a.py:4: error: Incompatible types in assignment (expression has type "Optional[int]", variable has type "int")
+
+[case testPerFileStrictOptionalFunction]
+import a
+[file mypy.ini]
+[[mypy]
+strict_optional = False
+[[mypy-b.*]
+strict_optional = True
+[file a.py]
+from typing import Optional
+import b
+def f() -> None:
+    x: int
+    x = b.g(x)
+[file b.py]
+from typing import Optional
+import c
+def g(x: Optional[int]) -> Optional[int]:
+    return c.h(x)
+[file c.py]
+from typing import Optional
+def h(x: Optional[int]) -> int:
+    pass
+[file c.py.2]
+from typing import Optional
+def h(x: int) -> int:
+    pass
+[file b.py.3]
+from typing import Optional
+import c
+def g(x: int) -> Optional[int]:
+    return c.h(x)
+[out]
+==
+b.py:4: error: Argument 1 to "h" has incompatible type "Optional[int]"; expected "int"
+==
+
+[case testPerFileStrictOptionalMethod]
+import a
+[file mypy.ini]
+[[mypy]
+strict_optional = False
+[[mypy-b.*]
+strict_optional = True
+[file a.py]
+from typing import Optional
+import b
+class A:
+    def f(self) -> None:
+        x: int
+        x = b.B().g(x)
+[file b.py]
+from typing import Optional
+import c
+class B:
+    def g(self, x: Optional[int]) -> Optional[int]:
+        return c.C().h(x)
+[file c.py]
+from typing import Optional
+class C:
+    def h(self, x: Optional[int]) -> int:
+        pass
+[file c.py.2]
+from typing import Optional
+class C:
+    def h(self, x: int) -> int:
+        pass
+[file b.py.3]
+from typing import Optional
+import c
+class B:
+    def g(self, x: int) -> Optional[int]:
+        return c.C().h(x)
+[out]
+==
+b.py:5: error: Argument 1 to "h" of "C" has incompatible type "Optional[int]"; expected "int"
+==
 
 [case testTypeVarValuesFunction]
 import a


### PR DESCRIPTION
This adds 9 = 3 * 3 test cases where first multiplier 3 is (module, function, method) target, and the second multiplier 3 is (alway off, always on, per file).