### PR TITLE
fine-grained: Don't crash when module imported by a __init__ is deleted

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -286,6 +286,11 @@ def lookup_qualified_stnode(modules: Dict[str, MypyFile], name: str,
         if not rest:
             return stnode
         node = stnode.node
+        # In fine-grained mode, could be a cross-reference to a deleted module
+        if node is None:
+            if not quick_and_dirty:
+                assert rest, "Cannot find %s" % (name,)
+            return None
         assert isinstance(node, TypeInfo)
         names = node.names
 

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -322,6 +322,26 @@ def f() -> None: pass
 ==
 ==
 
+[case testDeleteDepOfDunderInit1]
+[file p/__init__.py]
+from .foo import Foo
+[file p/foo.py]
+class Foo: pass
+[file p/__init__.py.2]
+[delete p/foo.py.2]
+[out]
+==
+
+[case testDeleteDepOfDunderInit2]
+[file p/__init__.py]
+from p.foo import Foo
+[file p/foo.py]
+class Foo: pass
+[file p/__init__.py.2]
+[delete p/foo.py.2]
+[out]
+==
+
 [case testDeletionTriggersImportFrom]
 import a
 [file a.py]


### PR DESCRIPTION
This could occur if p/__init__.py is importing Foo from p.q
and p.q is deleted. Fixup will see that p.q doesn't exist and
so will look for q in p. p might be an unpatched cross-ref, which
we need to handle by returning stale_info().