### PR TITLE
Add tests for change of node kind (like TypeVar -> module) in fine grained

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3284,6 +3284,12 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
     # Expressions
     #
 
+    def add_symbol_alias_deps(self, n: Optional[SymbolTableNode]) -> None:
+        """Add type alias dependencies for a RefExpr node."""
+        if n and n.is_aliasing:
+            assert n.alias_name is not None
+            self.add_type_alias_deps([n.alias_name])
+
     def visit_name_expr(self, expr: NameExpr) -> None:
         n = self.lookup(expr.name, expr)
         if n:
@@ -3291,9 +3297,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 self.fail("'{}' is a type variable and only valid in type "
                           "context".format(expr.name), expr)
             else:
-                if n.is_aliasing:
-                    assert n.alias_name is not None
-                    self.add_type_alias_deps([n.alias_name])
+                self.add_symbol_alias_deps(n)
                 expr.kind = n.kind
                 expr.node = n.node
                 expr.fullname = n.fullname
@@ -3471,9 +3475,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             # else:
             #     names = file.names
             n = file.names.get(expr.name, None) if file is not None else None
-            if n and n.is_aliasing:
-                assert n.alias_name is not None
-                self.add_type_alias_deps([n.alias_name])
+            self.add_symbol_alias_deps(n)
             n = self.dereference_module_cross_ref(n)
             if n and not n.module_hidden:
                 n = self.normalize_type_alias(n, expr)
@@ -3531,9 +3533,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                         type_info = self.type
             if type_info:
                 n = type_info.names.get(expr.name)
-                if n and n.is_aliasing:
-                    assert n.alias_name is not None
-                    self.add_type_alias_deps([n.alias_name])
+                self.add_symbol_alias_deps(n)
                 if n is not None and (n.kind == MODULE_REF or isinstance(n.node, TypeInfo)):
                     n = self.normalize_type_alias(n, expr)
                     if not n:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3462,6 +3462,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             #     names = file.names
             n = file.names.get(expr.name, None) if file is not None else None
             if n and n.is_aliasing:
+                assert n.alias_name is not None
                 self.add_type_alias_deps([n.alias_name])
             n = self.dereference_module_cross_ref(n)
             if n and not n.module_hidden:
@@ -3521,6 +3522,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             if type_info:
                 n = type_info.names.get(expr.name)
                 if n and n.is_aliasing:
+                    assert n.alias_name is not None
                     self.add_type_alias_deps([n.alias_name])
                 if n is not None and (n.kind == MODULE_REF or isinstance(n.node, TypeInfo)):
                     n = self.normalize_type_alias(n, expr)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1833,6 +1833,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         """Make a dummy Instance with no methods. It is used as a fallback type
         to detect errors for non-Instance aliases (i.e. Unions, Tuples, Callables).
         """
+        # TODO: this has None fullname (and also can't be serialized), fix this.
         kind = (' to Callable' if isinstance(tp, CallableType) else
                 ' to Tuple' if isinstance(tp, TupleType) else
                 ' to Union' if isinstance(tp, UnionType) else '')
@@ -3460,6 +3461,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             # else:
             #     names = file.names
             n = file.names.get(expr.name, None) if file is not None else None
+            if n and n.is_aliasing:
+                self.add_type_alias_deps([n.alias_name])
             n = self.dereference_module_cross_ref(n)
             if n and not n.module_hidden:
                 n = self.normalize_type_alias(n, expr)
@@ -3517,6 +3520,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                         type_info = self.type
             if type_info:
                 n = type_info.names.get(expr.name)
+                if n and n.is_aliasing:
+                    self.add_type_alias_deps([n.alias_name])
                 if n is not None and (n.kind == MODULE_REF or isinstance(n.node, TypeInfo)):
                     n = self.normalize_type_alias(n, expr)
                     if not n:

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -236,7 +236,7 @@ class NodeStripVisitor(TraverserVisitor):
             if node.kind == MDEF and node.is_new_def:
                 self.strip_class_attr(node.name)
             self.strip_ref_expr(node)
-        # [*] although we always strip type
+        # [*] although we always strip type, thus returning the Var to the state after pass 1.
         if isinstance(node.node, Var):
             node.node.type = None
 

--- a/mypy/typevars.py
+++ b/mypy/typevars.py
@@ -12,7 +12,8 @@ def fill_typevars(typ: TypeInfo) -> Union[Instance, TupleType]:
     For a generic G type with parameters T1, .., Tn, return G[T1, ..., Tn].
     """
     tv = []  # type: List[Type]
-    for i in range(len(typ.type_vars)):
+    # TODO: why do we need to keep both typ.type_vars and typ.defn.type_vars?
+    for i in range(len(typ.defn.type_vars)):
         tv.append(TypeVarType(typ.defn.type_vars[i]))
     inst = Instance(typ, tv)
     if typ.tuple_type is None:

--- a/test-data/unit/deps-types.test
+++ b/test-data/unit/deps-types.test
@@ -875,6 +875,29 @@ class I: pass
 <mod.I.__new__> -> m
 <mod.I> -> <m.f.x>, m, m.f
 
+[case testAliasDepsFromImportUnqualified]
+from a import C
+x: C
+def f() -> None:
+    C()
+class A:
+    def meth(self) -> None:
+        def inner() -> C:
+            pass
+[file a.py]
+from b import D
+C = D
+[file b.py]
+class D:
+    pass
+[out]
+<m.A> -> m.A
+<m.x> -> m
+<a.C> -> m, m.A.meth, m.f
+<b.D.__init__> -> m.f
+<b.D.__new__> -> m.f
+<b.D> -> <m.A.meth>, <m.x>, m, m.A.meth, m.f
+
 [case testFuncBasedEnum]
 from enum import Enum
 from mod import B

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -5043,6 +5043,76 @@ class A: pass
 ==
 ==
 
+[case testChangeGenericFunctionToVariable]
+import a
+x: int
+y: int = a.f(x)
+class Dummy:
+    def g(self) -> None:
+        a.f(x)
+[file a.py]
+from typing import TypeVar
+T = TypeVar('T')
+def f(x: T) -> T:
+    pass
+[file a.py.2]
+from typing import TypeVar
+T = TypeVar('T')
+f = 42
+[out]
+==
+main:3: error: "int" not callable
+main:6: error: "int" not callable
+
+[case testChangeGenericClassToVariable]
+import a
+x: int
+a.A(x)
+class Dummy:
+    def g(self) -> None:
+        a.A(x)
+[file a.py]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class A(Generic[T]):
+    def __init__(self, x: T) -> None:
+        pass
+[file a.py.2]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+A = 'no way'
+[out]
+==
+main:3: error: "str" not callable
+main:6: error: "str" not callable
+
+[case testChangeGenericMethodToVariable]
+import a
+x: int
+y: int = a.A(x).f()
+class Dummy:
+    def g(self) -> None:
+        a.A(x).f()
+[file a.py]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class A(Generic[T]):
+    def __init__(self, x: T) -> None:
+        pass
+    def f(self) -> T:
+        pass
+[file a.py.2]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class A(Generic[T]):
+    f: T
+    def __init__(self, x: T) -> None:
+        pass
+[out]
+==
+main:3: error: "int" not callable
+main:6: error: "int" not callable
+
 [case testRefreshNestedClassWithSelfReference]
 import a
 [file a.py]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -4898,6 +4898,32 @@ main:2: error: Invalid type "D"
 main:4: error: Module not callable
 main:7: error: Invalid type "D"
 
+[case testChangeTypeAliasToModuleUnqualified]
+from a import C
+x: C
+def f() -> None:
+    C()
+class A:
+    def meth(self) -> None:
+        def inner() -> C:
+            pass
+[file a.py]
+from b import D
+C = D
+[file b.py]
+class D:
+    pass
+[file D.py.2]
+[file b.py.3]
+import D
+[builtins fixtures/module.pyi]
+[out]
+==
+==
+main:2: error: Invalid type "D"
+main:4: error: Module not callable
+main:7: error: Invalid type "D"
+
 [case testChangeFunctionToVariableAndRefreshUsingStaleDependency]
 import a
 import c

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -4769,6 +4769,135 @@ C = Enum('C', [('X', 0), ('Y', 1)])
 a.py:4: error: Argument 1 to "f" has incompatible type "C"; expected "int"
 a.py:5: error: Argument 1 to "f" has incompatible type "C"; expected "int"
 
+[case testChangeTypeVarToFunction]
+import a
+from typing import Generic
+Alias = C[C[a.T]]
+
+class C(Generic[a.T]):
+    def meth(self, x: a.T) -> None:
+        pass
+def outer() -> None:
+    def func(x: a.T) -> Alias[a.T]:
+        pass
+[file a.py]
+from typing import TypeVar
+T = TypeVar('T')
+[file a.py.2]
+from typing import TypeVar
+def T() -> None:
+    pass
+[out]
+==
+main:3: error: "C" expects no type arguments, but 1 given
+main:3: error: Invalid type "a.T"
+main:5: error: Free type variable expected in Generic[...]
+main:6: error: Invalid type "a.T"
+main:9: error: Invalid type "a.T"
+main:9: error: Bad number of arguments for type alias, expected: 0, given: 1
+main:9: error: "C" expects no type arguments, but 1 given
+
+[case testChangeTypeVarToModule]
+import a
+from typing import Generic
+Alias = C[C[a.T]]
+
+class C(Generic[a.T]):
+    def meth(self, x: a.T) -> None:
+        pass
+def outer() -> None:
+    def func(x: a.T) -> Alias[a.T]:
+        pass
+[file a.py]
+from typing import TypeVar
+T = TypeVar('T')
+[file T.py.2]
+[file a.py.3]
+from typing import TypeVar
+import T
+[out]
+==
+==
+main:3: error: "C" expects no type arguments, but 1 given
+main:5: error: Free type variable expected in Generic[...]
+main:6: error: Invalid type "T"
+main:9: error: Bad number of arguments for type alias, expected: 0, given: 1
+main:9: error: "C" expects no type arguments, but 1 given
+main:9: error: Invalid type "T"
+
+[case testChangeClassToModule]
+import a
+x: a.C
+def f() -> None:
+    a.C()
+class A:
+    def meth(self) -> None:
+        def inner() -> a.C:
+            pass
+[file a.py]
+class C:
+    pass
+[file C.py.2]
+[file a.py.3]
+import C
+[builtins fixtures/module.pyi]
+[out]
+==
+==
+main:2: error: Invalid type "C"
+main:4: error: Module not callable
+main:7: error: Invalid type "C"
+
+[case testChangeTypeVarToTypeAlias]
+import a
+from typing import Generic
+Alias = C[C[a.T]]
+
+class C(Generic[a.T]):
+    def meth(self, x: a.T) -> None:
+        pass
+def outer() -> None:
+    def func(x: a.T) -> Alias[a.T]:
+        pass
+[file a.py]
+from typing import TypeVar
+T = TypeVar('T')
+[file a.py.2]
+from typing import TypeVar
+T = int
+[out]
+==
+main:3: error: "C" expects no type arguments, but 1 given
+main:5: error: Free type variable expected in Generic[...]
+main:9: error: Bad number of arguments for type alias, expected: 0, given: 1
+main:9: error: "C" expects no type arguments, but 1 given
+
+[case testChangeTypeAliasToModule]
+import a
+x: a.C
+def f() -> None:
+    a.C()
+class A:
+    def meth(self) -> None:
+        def inner() -> a.C:
+            pass
+[file a.py]
+import b
+C = b.D
+[file b.py]
+class D:
+    pass
+[file D.py.2]
+[file b.py.3]
+import D
+[builtins fixtures/module.pyi]
+[out]
+==
+==
+main:2: error: Invalid type "D"
+main:4: error: Module not callable
+main:7: error: Invalid type "D"
+
 [case testChangeFunctionToVariableAndRefreshUsingStaleDependency]
 import a
 import c


### PR DESCRIPTION
This PR adds tests for change of node kind in fine grained mode. For example `f` can be a generic function or a type alias before an update and class or module alias after. This also fixes some bugs discovered by added tests:
* Missing deps from unsubscripted alias in runtime context.
* Always strip type of `Var` nodes (those are created in first pass of semantic analysis, but with `None` type).
* Keep `ClassDef.type_vars` and `TypeInfo.type_vars` in sync (as possible).
* Always carry over `SymbolTableNode.is_aliasing` during imports.

The last one is relatively serious, because type aliases will not work correctly in fine grained if used with `import *` or `from mod import Alias`. (I actually just noticed that I use `import mod` and then `mod.Alias` in 95% of all alias fine grained cases, therefore I added few tests for the former.)

This also fixes line endings in `typevars.py`.