### PR TITLE
Add a per-module `follow_imports_for_stubs` option

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -142,6 +142,15 @@ overridden by the pattern sections matching the module name.
   of the *imported* module, not the module containing the import
   statement.
 
+- ``follow_imports_for_stubs`` (Boolean, default false) determines
+  whether to respect the ``follow_imports`` setting even for stub
+  (``.pyi``) files.
+  Used in conjunction with ``follow_imports=skip``, this can be used
+  to suppress the import of a module from ``typeshed``, replacing it
+  with `Any`.
+  Used in conjuncation with ``follow_imports=error``, this can be used
+  to make any use of a particular ``typeshed`` module an error.
+
 - ``ignore_missing_imports`` (Boolean, default False) suppress error
   messages about imports that cannot be resolved.  Note that if
   pattern matching is used, the pattern should match the name of the

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1532,7 +1532,8 @@ class State:
                 follow_imports = self.options.follow_imports
                 if (follow_imports != 'normal'
                         and not root_source  # Honor top-level modules
-                        and path.endswith('.py')  # Stubs are always normal
+                        and (path.endswith('.py')  # Stubs are always normal
+                             or self.options.follow_imports_for_stubs)  # except when they aren't
                         and id != 'builtins'):  # Builtins is always normal
                     if follow_imports == 'silent':
                         # Still import it, but silence non-blocker errors.

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -20,6 +20,7 @@ class Options:
     PER_MODULE_OPTIONS = {
         "ignore_missing_imports",
         "follow_imports",
+        "follow_imports_for_stubs",
         "disallow_any_generics",
         "disallow_any_unimported",
         "disallow_any_expr",
@@ -60,6 +61,9 @@ class Options:
         self.report_dirs = {}  # type: Dict[str, str]
         self.ignore_missing_imports = False
         self.follow_imports = 'normal'  # normal|silent|skip|error
+        # Whether to respect the follow_imports setting even for stub files.
+        # Intended to be used for disabling specific stubs.
+        self.follow_imports_for_stubs = False  # type: bool
 
         # disallow_any options
         self.disallow_any_generics = False

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1088,3 +1088,28 @@ p.b.bar("wrong")
 p/a.py:4: error: Argument 1 to "foo" has incompatible type "str"; expected "int"
 p/b/__init__.py:5: error: Argument 1 to "bar" has incompatible type "str"; expected "int"
 c.py:2: error: Argument 1 to "bar" has incompatible type "str"; expected "int"
+
+[case testFollowImportStubs1]
+# cmd: mypy main.py
+[file mypy.ini]
+[[mypy]
+[[mypy-math.*]
+follow_imports = error
+follow_imports_for_stubs = True
+[file main.py]
+import math
+math.frobnicate()
+[out]
+main.py:1: note: Import of 'math' ignored
+main.py:1: note: (Using --follow-imports=error, module not passed on command line)
+
+[case testFollowImportStubs2]
+# cmd: mypy main.py
+[file mypy.ini]
+[[mypy]
+[[mypy-math.*]
+follow_imports = skip
+follow_imports_for_stubs = True
+[file main.py]
+import math
+math.frobnicate()


### PR DESCRIPTION
Used in conjunction with follow_imports=skip, this can be used
to suppress the import of a module from typeshed.
Used in conjuncation with ``follow_imports=error``, this can be used
to make any use of a particular ``typeshed`` module an error.