### PR TITLE
Refactor import diagnostics, fix diagnostics in some fine-grained cases

### DIFF
--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -120,7 +120,7 @@ from typing import (
 )
 
 from mypy.build import (
-    BuildManager, State, BuildSource, BuildResult, Graph, load_graph,
+    BuildManager, State, BuildSource, BuildResult, Graph, load_graph, module_not_found,
     PRI_INDIRECT, DEBUG_FINE_GRAINED,
 )
 from mypy.checker import DeferredNode
@@ -603,7 +603,7 @@ def verify_dependencies(state: State, manager: BuildManager) -> None:
             assert state.tree
             line = state.dep_line_map.get(dep, 1)
             assert state.path
-            manager.module_not_found(state.path, state.id, line, dep)
+            module_not_found(manager, line, state, dep)
 
 
 def collect_dependencies(new_modules: Mapping[str, Optional[MypyFile]],

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -594,18 +594,6 @@ def get_all_changed_modules(root_module: str,
     return changed_modules
 
 
-def verify_dependencies(state: State, manager: BuildManager) -> None:
-    """Report errors for import targets in module that don't exist."""
-    # Strip out indirect dependencies. See comment in build.load_graph().
-    dependencies = [dep for dep in state.dependencies if state.priorities.get(dep) != PRI_INDIRECT]
-    for dep in dependencies + state.suppressed:  # TODO: ancestors?
-        if dep not in manager.modules and not state.options.ignore_missing_imports:
-            assert state.tree
-            line = state.dep_line_map.get(dep, 1)
-            assert state.path
-            module_not_found(manager, line, state, dep)
-
-
 def collect_dependencies(new_modules: Mapping[str, Optional[MypyFile]],
                          deps: Dict[str, Set[str]],
                          graph: Dict[str, State]) -> None:
@@ -879,7 +867,7 @@ def reprocess_nodes(manager: BuildManager,
     update_deps(module_id, nodes, graph, deps, options)
 
     # Report missing imports.
-    verify_dependencies(graph[module_id], manager)
+    graph[module_id].verify_dependencies()
 
     return new_triggered
 

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -222,7 +222,7 @@ class FineGrainedSuite(DataSuite):
         m = re.search('# cmd: mypy ([a-zA-Z0-9_./ ]+)$', program_text, flags=re.MULTILINE)
         regex = '# cmd{}: mypy ([a-zA-Z0-9_./ ]+)$'.format(incremental_step)
         alt_m = re.search(regex, program_text, flags=re.MULTILINE)
-        if alt_m is not None and incremental_step > 1:
+        if alt_m is not None:
             # Optionally return a different command if in a later step
             # of incremental mode, otherwise default to reusing the
             # original cmd.

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1640,11 +1640,14 @@ a.py:3: error: Argument 1 to "foo" of "Foo" has incompatible type "int"; expecte
 import b
 from c import x
 [file b.py]
+1+'lol'
 [file c.py]
 x = 1
 [file c.py.2]
 x = '2'
+[file b.py.3]
 [out]
+==
 ==
 
 [case testSkipButDontIgnore2]
@@ -1656,6 +1659,8 @@ import b
 [file b.py]
 [file c.py]
 x = 1
+[file b.py]
+1+'x'
 [file c.py.2]
 x = '2'
 [file c.py.3]
@@ -1702,11 +1707,11 @@ x = '2'
 a.py:2: note: Import of 'b' ignored
 a.py:2: note: (Using --follow-imports=error, module not passed on command line)
 
--- This test fails because p.b doesn't seem to trigger p properly...
+-- TODO: This test fails because p.b does not depend on p (#4847)
 [case testErrorButDontIgnore3-skip]
 # cmd1: mypy a.py c.py p/b.py p/__init__.py
 # cmd2: mypy a.py c.py p/b.py
-# flags: --follow-imports=error --verbose
+# flags: --follow-imports=error
 [file a.py]
 from c import x
 from p.b import y

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1632,3 +1632,112 @@ class Foo:
 [out]
 ==
 a.py:3: error: Argument 1 to "foo" of "Foo" has incompatible type "int"; expected "str"
+
+[case testSkipButDontIgnore1]
+# cmd: mypy a.py c.py
+# flags: --follow-imports=skip
+[file a.py]
+import b
+from c import x
+[file b.py]
+[file c.py]
+x = 1
+[file c.py.2]
+x = '2'
+[out]
+==
+
+[case testSkipButDontIgnore2]
+# cmd: mypy a.py c.py
+# flags: --follow-imports=skip
+[file a.py]
+from c import x
+import b
+[file b.py]
+[file c.py]
+x = 1
+[file c.py.2]
+x = '2'
+[file c.py.3]
+x = 2
+[delete b.py.3]
+[out]
+==
+==
+a.py:2: error: Cannot find module named 'b'
+a.py:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+
+[case testErrorButDontIgnore1]
+# cmd: mypy a.py c.py
+# flags: --follow-imports=error
+[file a.py]
+from c import x
+import b
+[file b.py]
+[file c.py]
+x = 1
+[file c.py.2]
+x = '2'
+[out]
+a.py:2: note: Import of 'b' ignored
+a.py:2: note: (Using --follow-imports=error, module not passed on command line)
+==
+a.py:2: note: Import of 'b' ignored
+a.py:2: note: (Using --follow-imports=error, module not passed on command line)
+
+[case testErrorButDontIgnore2]
+# cmd1: mypy a.py c.py b.py
+# cmd2: mypy a.py c.py
+# flags: --follow-imports=error
+[file a.py]
+from c import x
+import b
+[file b.py]
+[file c.py]
+x = 1
+[file c.py.2]
+x = '2'
+[out]
+==
+a.py:2: note: Import of 'b' ignored
+a.py:2: note: (Using --follow-imports=error, module not passed on command line)
+
+-- This test fails because p.b doesn't seem to trigger p properly...
+[case testErrorButDontIgnore3-skip]
+# cmd1: mypy a.py c.py p/b.py p/__init__.py
+# cmd2: mypy a.py c.py p/b.py
+# flags: --follow-imports=error --verbose
+[file a.py]
+from c import x
+from p.b import y
+[file p/b.py]
+y = 12
+[file p/__init__.py]
+[file c.py]
+x = 1
+[file c.py.2]
+x = '2'
+[out]
+==
+p/b.py: note: Ancestor package 'p' ignored
+p/b.py: note: (Using --follow-imports=error, submodule passed on command line)
+
+[case testErrorButDontIgnore4]
+# cmd: mypy a.py z.py p/b.py p/__init__.py
+# cmd2: mypy a.py p/b.py
+# flags: --follow-imports=error
+[file a.py]
+from p.b import y
+[file p/b.py]
+from z import x
+y = 12
+[file p/__init__.py]
+[file z.py]
+x = 1
+[delete z.py.2]
+[out]
+==
+p/b.py: note: Ancestor package 'p' ignored
+p/b.py: note: (Using --follow-imports=error, submodule passed on command line)
+p/b.py:1: error: Cannot find module named 'z'
+p/b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)


### PR DESCRIPTION
Refactor all of the import diagnostics so that they can be used
outside of `State`'s `__init__` method.

Then use that to fix some problems with import diagnostics in fine-grained mode.
Fixes #4798.

This refactor also lays the ground work for fixing (coarse) incremental mode's interaction
with `--warn-unused-ignores`