### PR TITLE
Fix stubgen --recursive to only generate stubs for requested submodules.

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -851,7 +851,7 @@ def walk_packages(packages: List[str]) -> Iterator[str]:
         path = getattr(package, '__path__', None)
         if path is None:
             # It's a module inside a package.  There's nothing else to walk/yield.
-            return
+            continue
         for importer, qualified_name, ispkg in pkgutil.walk_packages(path,
                                                                      prefix=package.__name__ + ".",
                                                                      onerror=lambda r: None):

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -846,9 +846,13 @@ def get_qualified_name(o: Expression) -> str:
 
 def walk_packages(packages: List[str]) -> Iterator[str]:
     for package_name in packages:
-        package = __import__(package_name)
+        package = importlib.import_module(package_name)
         yield package.__name__
-        for importer, qualified_name, ispkg in pkgutil.walk_packages(package.__path__,
+        path = getattr(package, '__path__', None)
+        if path is None:
+            # It's a module inside a package.  There's nothing else to walk/yield.
+            return
+        for importer, qualified_name, ispkg in pkgutil.walk_packages(path,
                                                                      prefix=package.__name__ + ".",
                                                                      onerror=lambda r: None):
             yield qualified_name

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -11,12 +11,34 @@ from typing import List, Tuple
 from mypy.test.helpers import Suite, assert_equal, assert_string_arrays_equal
 from mypy.test.data import DataSuite, DataDrivenTestCase
 from mypy.errors import CompileError
-from mypy.stubgen import generate_stub, generate_stub_for_module, parse_options, Options
+from mypy.stubgen import (
+    generate_stub, generate_stub_for_module, parse_options, walk_packages, Options
+)
 from mypy.stubgenc import generate_c_type_stub, infer_method_sig
 from mypy.stubutil import (
     parse_signature, parse_all_signatures, build_signature, find_unique_signatures,
     infer_sig_from_docstring
 )
+
+
+class StubgenCliParseSuite(Suite):
+    def test_walk_packages(self) -> None:
+        assert_equal(
+            set(walk_packages(["mypy.errors"])),
+            {"mypy.errors"})
+
+        assert_equal(
+            set(walk_packages(["mypy.errors", "mypy.stubgen"])),
+            {"mypy.errors", "mypy.stubgen"})
+
+        all_mypy_packages = set(walk_packages(["mypy"]))
+        self.assertTrue(all_mypy_packages.issuperset({
+            "mypy",
+            "mypy.errors",
+            "mypy.stubgen",
+            "mypy.test",
+            "mypy.test.helpers",
+        }))
 
 
 class StubgenUtilSuite(Suite):


### PR DESCRIPTION
This fixes #4844 

I'm not completely sure where/how to add unit tests for this.  I'm happy to do that if someone can point me in the right direction though.

As it stands, I have tested this manually against `urllib` and `urllib.parse` and verified that the current code only generates `out/urllib/parse.pyi` in the latter case but generates all the stubs for `urllib` in the former case.