### PR TITLE
Support module aliases in fine grained mode

### DIFF
--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -162,8 +162,14 @@ class NodeStripVisitor(TraverserVisitor):
 
     def visit_assignment_stmt(self, node: AssignmentStmt) -> None:
         node.type = node.unanalyzed_type
-        if self.type and not self.is_class_body:
-            for lvalue in node.lvalues:
+        for lvalue in node.lvalues:
+            if self.names and isinstance(lvalue, NameExpr):
+                name = lvalue.name
+                if name in self.names and self.names[name].is_module_alias:
+                    snode = self.names[name]
+                    snode.node = snode.unanalyzed_node
+                    snode.kind = snode.unanalyzed_kind
+            if self.type and not self.is_class_body:
                 self.process_lvalue_in_method(lvalue)
         super().visit_assignment_stmt(node)
 

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -436,6 +436,10 @@ class DependencyVisitor(TraverserVisitor):
     def process_global_ref_expr(self, o: RefExpr) -> None:
         if o.fullname is not None:
             self.add_dependency(make_trigger(o.fullname))
+        if isinstance(o.node, MypyFile):
+            for name in o.node.aka_names:
+                if self.scope.module and not name.startswith(self.scope.module):
+                    self.add_dependency(make_trigger(name))
 
         # If this is a reference to a type, generate a dependency to its
         # constructor.

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -5139,6 +5139,72 @@ class A(Generic[T]):
 main:3: error: "int" not callable
 main:6: error: "int" not callable
 
+[case testChangeModuleToFunction]
+import b
+b.c.x
+def f(x: int) -> None:
+    b.c.x
+class A:
+    def meth(self) -> None:
+        def inner() -> int:
+            return b.c.x
+[file b.py]
+import c
+[file b.py.2]
+def c() -> None: pass
+[file c.py]
+x: int
+[builtins fixtures/module.pyi]
+[out]
+==
+main:2: error: "Callable[[], None]" has no attribute "x"
+main:4: error: "Callable[[], None]" has no attribute "x"
+main:8: error: "Callable[[], None]" has no attribute "x"
+
+[case testChangeModuleToTypeAlias]
+import a
+x: int = a.C.x
+def f(x: int) -> None:
+    x = a.C.x
+class A:
+    def meth(self) -> None:
+        def inner() -> int:
+            return a.C.x
+[file a.py]
+import b
+C = b.D
+[file b.py]
+import D
+[file b.py.2]
+class D:
+    x: str
+[file D.py]
+x: int
+[builtins fixtures/module.pyi]
+[out]
+==
+main:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:8: error: Incompatible return value type (got "str", expected "int")
+
+[case testRefreshModuleAlias]
+import a
+a.n.x
+[file a.py]
+from b import m
+n = m
+[file b.py]
+import m
+[file b.py.2]
+import m2 as m
+[file m.py]
+x = 1
+[file m2.py]
+[builtins fixtures/module.pyi]
+[out]
+==
+main:2: error: Module has no attribute "x"
+
 [case testRefreshNestedClassWithSelfReference]
 import a
 [file a.py]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/4532

This also fixes two bugs discovered when a module is replaced with a function, or a module alias is replaced with a type alias.

The idea is trivial, we just record alternative names for a given module ("a.k.a" names) and then add dependencies on them as well, in addition to the original module name ("real" name). The non-trivial part is `aststrip.py` part, because module aliasing does some irreversible changes during second pass, so I record the "unanalized" (i.e. after first pass) node and kind, and then restore them in `aststrip.py` (I cannot just set them to `None`, because they are not `None` after first pass and some code relies on this).