### PR TITLE
Fix error message when assigning to read-only property

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -311,7 +311,7 @@ def analyze_var(name: str, var: Var, itype: Instance, info: TypeInfo, node: Cont
         t = expand_type_by_instance(typ, itype)
         if is_lvalue and var.is_property and not var.is_settable_property:
             # TODO allow setting attributes in subclass (although it is probably an error)
-            msg.read_only_property(name, info, node)
+            msg.read_only_property(name, itype.type, node)
         if is_lvalue and var.is_classvar:
             msg.cant_assign_to_classvar(name, node)
         result = t
@@ -319,7 +319,7 @@ def analyze_var(name: str, var: Var, itype: Instance, info: TypeInfo, node: Cont
             if is_lvalue:
                 if var.is_property:
                     if not var.is_settable_property:
-                        msg.read_only_property(name, info, node)
+                        msg.read_only_property(name, itype.type, node)
                 else:
                     msg.cant_assign_to_method(node)
 

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -760,7 +760,7 @@ b = B() # E
 b.x.y # E
 [builtins fixtures/property.pyi]
 [out]
-main:7: error: Property "x" defined in "B" is read-only
+main:7: error: Property "x" defined in "A" is read-only
 main:8: error: Cannot instantiate abstract class 'B' with abstract attribute 'x'
 main:9: error: "int" has no attribute "y"
 

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -40,7 +40,7 @@ x.y = 5 # E: "X" has no attribute "y"
 
 class A(X): pass
 a: A
-a.x = 5 # E: Property "x" defined in "A" is read-only
+a.x = 5 # E: Property "x" defined in "X" is read-only
 
 [case testNewNamedTupleCreateWithPositionalArguments]
 # flags: --python-version 3.6
@@ -553,7 +553,7 @@ class Child(Base):
         reveal_type(self[0])  # E: Revealed type is 'builtins.int'
         self[0] = 3  # E: Unsupported target for indexed assignment
         reveal_type(self.x)  # E: Revealed type is 'builtins.int'
-        self.x = 3  # E: Property "x" defined in "Child" is read-only
+        self.x = 3  # E: Property "x" defined in "Base" is read-only
         self[1]  # E: Tuple index out of range
         return self.x
     def good_override(self) -> int:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1077,6 +1077,20 @@ class A:
 A().f = '' # E: Property "f" defined in "A" is read-only
 [builtins fixtures/property.pyi]
 
+[case testAssigningToInheritedReadOnlyProperty]
+class A:
+    @property
+    def f(self) -> str: pass
+class B(A): pass
+class C(A):
+    @property
+    def f(self) -> str: pass
+
+A().f = '' # E: Property "f" defined in "A" is read-only
+B().f = '' # E: Property "f" defined in "A" is read-only
+C().f = '' # E: Property "f" defined in "C" is read-only
+[builtins fixtures/property.pyi]
+
 [case testPropertyGetterBody]
 import typing
 class A:

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -46,8 +46,8 @@ x.z = 5 # E: "X" has no attribute "z"
 
 class A(X): pass
 a = None  # type: A
-a.x = 5 # E: Property "x" defined in "A" is read-only
-a.y = 5 # E: Property "y" defined in "A" is read-only
+a.x = 5 # E: Property "x" defined in "X" is read-only
+a.y = 5 # E: Property "y" defined in "X" is read-only
 -- a.z = 5 # not supported yet
 
 


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/4756

Consider the following program:

```python
class Parent:
    @property
    def foobar(self) -> int: ...

class Child(Parent): pass

Child().foobar = 10
```

Previously, mypy would report that the property `foobar` was defined in 'Child'. Now, it correctly reports it was defined in 'Parent'.