### PR TITLE
Speed up test cases by simplifying test stubs

### DIFF
--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4142,6 +4142,7 @@ class MyDestr(Destroyable):
 reveal_type(Arc[MyDestr]())  # E: Revealed type is '__main__.Arc[__main__.MyDestr*]'
 reveal_type(Arc1[MyDestr]())  # E: Revealed type is '__main__.Arc1[__main__.MyDestr*]'
 [builtins fixtures/bool.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testSixMetaclassErrors]
 import six

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -748,6 +748,7 @@ divmod('foo', f)  # E: Unsupported operand types for divmod ("str" and "float")
 divmod('foo', d)  # E: Unsupported operand types for divmod ("str" and "Decimal")
 
 [builtins fixtures/divmod.pyi]
+[typing fixtures/typing-full.pyi]
 
 
 -- Unary operators
@@ -1774,6 +1775,7 @@ d = {**a, **b, 'c': 3}
 e = {1: 'a', **a}  # E: Argument 1 to "update" of "dict" has incompatible type "Dict[str, int]"; expected "Mapping[int, str]"
 f = {**b}  # type: Dict[int, int]  # E: List item 0 has incompatible type "Dict[str, int]"; expected "Mapping[int, int]"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testDictIncompatibleTypeErrorMessage]
 from typing import Dict, Callable

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1686,6 +1686,7 @@ from typing import TypeVar, Container
 T = TypeVar('T')
 def f(x: Container[T]) -> T: ...
 reveal_type(f((1, 2))) # E: Revealed type is 'builtins.int*'
+[typing fixtures/typing-full.pyi]
 
 [case testClassMethodInGenericClassWithGenericConstructorArg]
 from typing import TypeVar, Generic

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -504,6 +504,7 @@ reveal_type(close(arg)) # E: Revealed type is 'builtins.int*'
 reveal_type(close_all([F()])) # E: Revealed type is 'builtins.int*'
 reveal_type(close_all([arg])) # E: Revealed type is 'builtins.int*'
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testProtocolGenericInference2]
 from typing import Generic, TypeVar, Protocol
@@ -767,6 +768,7 @@ t: Traversable
 t = D[int]() # OK
 t = C() # E: Incompatible types in assignment (expression has type "C", variable has type "Traversable")
 [builtins fixtures/list.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testRecursiveProtocols2]
 from typing import Protocol, TypeVar
@@ -822,6 +824,7 @@ t = A() # OK
 t = B() # E: Incompatible types in assignment (expression has type "B", variable has type "P1")
 t = C() # E: Incompatible types in assignment (expression has type "C", variable has type "P1")
 [builtins fixtures/list.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testMutuallyRecursiveProtocolsTypesWithSubteMismatch]
 from typing import Protocol, Sequence, List
@@ -1737,6 +1740,7 @@ bar((1, 2))
 bar(1) # E: Argument 1 to "bar" has incompatible type "int"; expected "Sized"
 
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testBasicSupportsIntProtocol]
 from typing import SupportsInt
@@ -1752,6 +1756,7 @@ foo(Bar())
 foo('no way') # E: Argument 1 to "foo" has incompatible type "str"; expected "SupportsInt"
 
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-full.pyi]
 
 -- Additional tests and corner cases for protocols
 -- ----------------------------------------------

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -834,6 +834,7 @@ fb(aa) # E: Argument 1 to "fb" has incompatible type "Tuple[A, A]"; expected "Tu
 from typing import Container
 a = None  # type: Container[str]
 a = ()
+[typing fixtures/typing-full.pyi]
 
 [case testSubtypingTupleIsSized]
 from typing import Sized

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -347,6 +347,7 @@ def as_mutable_mapping(p: Point) -> MutableMapping[str, int]:
               # N: 'Point' is missing following 'MutableMapping' protocol member: \
               # N:     __setitem__
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testCanConvertTypedDictToAny]
 from mypy_extensions import TypedDict

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -614,6 +614,7 @@ g(d) # E: Argument 1 to "g" has incompatible type "Dict[str, int]"; expected "Di
 h(c) # E: Argument 1 to "h" has incompatible type "Dict[str, float]"; expected "Dict[str, int]"
 h(d)
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testInvariantListArgNote]
 from typing import List, Union

--- a/test-data/unit/fixtures/dict.pyi
+++ b/test-data/unit/fixtures/dict.pyi
@@ -1,6 +1,8 @@
 # Builtins stub used in dictionary-related test cases.
 
-from typing import TypeVar, Generic, Iterable, Iterator, Mapping, Tuple, overload, Optional, Union
+from typing import (
+    TypeVar, Generic, Iterable, Iterator, Mapping, Tuple, overload, Optional, Union, Sequence
+)
 
 T = TypeVar('T')
 KT = TypeVar('KT')
@@ -11,7 +13,7 @@ class object:
 
 class type: pass
 
-class dict(Generic[KT, VT]):
+class dict(Mapping[KT, VT]):
     @overload
     def __init__(self, **kwargs: VT) -> None: pass
     @overload
@@ -19,7 +21,7 @@ class dict(Generic[KT, VT]):
     def __getitem__(self, key: KT) -> VT: pass
     def __setitem__(self, k: KT, v: VT) -> None: pass
     def __iter__(self) -> Iterator[KT]: pass
-    def __contains__(self, item: object) -> bool: pass
+    def __contains__(self, item: object) -> int: pass
     def update(self, a: Mapping[KT, VT]) -> None: pass
     @overload
     def get(self, k: KT) -> Optional[VT]: pass
@@ -33,7 +35,7 @@ class int: # for convenience
 class str: pass # for keyword argument key type
 class unicode: pass # needed for py2 docstrings
 
-class list(Generic[T]): # needed by some test cases
+class list(Sequence[T]): # needed by some test cases
     def __getitem__(self, x: int) -> T: pass
     def __iter__(self) -> Iterator[T]: pass
     def __mul__(self, x: int) -> list[T]: pass

--- a/test-data/unit/fixtures/list.pyi
+++ b/test-data/unit/fixtures/list.pyi
@@ -1,6 +1,6 @@
 # Builtins stub used in list-related test cases.
 
-from typing import TypeVar, Generic, Iterable, Iterator, overload
+from typing import TypeVar, Generic, Iterable, Iterator, Sequence, overload
 
 T = TypeVar('T')
 
@@ -10,7 +10,7 @@ class object:
 class type: pass
 class ellipsis: pass
 
-class list(Generic[T]):
+class list(Sequence[T]):
     @overload
     def __init__(self) -> None: pass
     @overload

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -1,10 +1,6 @@
 # Stub for typing module. Many of the definitions have special handling in
 # the type checker, so they can just be initialized to anything.
 
-from abc import abstractmethod
-
-class GenericMeta(type): pass
-
 cast = 0
 overload = 0
 Any = 0
@@ -38,48 +34,25 @@ S = TypeVar('S')
 # Note: definitions below are different from typeshed, variances are declared
 # to silence the protocol variance checks. Maybe it is better to use type: ignore?
 
-@runtime
-class Container(Protocol[T_contra]):
-    @abstractmethod
-    # Use int because bool isn't in the default test builtins
-    def __contains__(self, arg: T_contra) -> int: pass
-
-@runtime
 class Sized(Protocol):
-    @abstractmethod
     def __len__(self) -> int: pass
 
 @runtime
 class Iterable(Protocol[T_co]):
-    @abstractmethod
     def __iter__(self) -> 'Iterator[T_co]': pass
 
-@runtime
 class Iterator(Iterable[T_co], Protocol):
-    @abstractmethod
     def __next__(self) -> T_co: pass
 
 class Generator(Iterator[T], Generic[T, U, V]):
-    @abstractmethod
     def __iter__(self) -> 'Generator[T, U, V]': pass
 
-@runtime
-class Sequence(Iterable[T_co], Protocol):
-    @abstractmethod
+class Sequence(Iterable[T_co]):
     def __getitem__(self, n: Any) -> T_co: pass
 
-@runtime
-class Mapping(Protocol[T_contra, T_co]):
+class Mapping(Generic[T_contra, T_co]):
     def __getitem__(self, key: T_contra) -> T_co: pass
 
-@runtime
-class MutableMapping(Mapping[T_contra, U], Protocol):
-    def __setitem__(self, k: T_contra, v: U) -> None: pass
-
-class SupportsInt(Protocol):
-    def __int__(self) -> int: pass
-
-def runtime(cls: T) -> T:
-    return cls
+def runtime(cls: type) -> type: pass
 
 TYPE_CHECKING = 1


### PR DESCRIPTION
This makes the set of pytest tests that I normally run locally about
20% faster.