### PR TITLE
Remove some low-value, slow tests

### DIFF
--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -109,13 +109,6 @@ f(re.match('x*', 'xxy'))
 [out]
 xx
 
-[case testVariableLengthTuple_python2]
-from typing import Tuple, cast
-x = cast(Tuple[int, ...], ())
-print(x)
-[out]
-()
-
 [case testFromFuturePrintFunction_python2]
 from __future__ import print_function
 print('a', 'b')
@@ -162,7 +155,6 @@ _program.py:5: error: Argument 1 to "f" has incompatible type "unicode"; expecte
 _program.py:6: error: Argument 1 to "f" has incompatible type "unicode"; expected "str"
 
 [case testStrUnicodeCompatibility_python2]
-import typing
 def f(s): # type: (unicode) -> None
     pass
 f(u'')
@@ -170,7 +162,6 @@ f('')
 [out]
 
 [case testStrUnicodeCompatibilityInBuiltins_python2]
-import typing
 'x'.count('x')
 'x'.count(u'x')
 [out]
@@ -183,16 +174,6 @@ def f(a): # type: (Sequence[T]) -> None
 f(tuple())
 [out]
 ()
-
-[case testReadOnlyProperty_python2]
-import typing
-class A:
-    @property
-    def foo(self): # type: () -> int
-        return 1
-print(A().foo + 2)
-[out]
-3
 
 [case testIOTypes_python2]
 from typing import IO, TextIO, BinaryIO, Any
@@ -259,19 +240,6 @@ print 'ok'
 [out]
 ok
 
-[case testUnionType_python2]
-from typing import Union
-y = None  # type: Union[int, str]
-def f(x): # type: (Union[int, str]) -> str
-    if isinstance(x, int):
-        x = str(x)
-    return x
-print f(12)
-print f('ab')
-[out]
-12
-ab
-
 [case testStrAdd_python2]
 import typing
 s = ''
@@ -294,21 +262,13 @@ s = ''.join([u''])  # Error
 _program.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 _program.py:6: error: Incompatible types in assignment (expression has type "unicode", variable has type "str")
 
-[case testNamedTuple_python2]
-import typing
-from collections import namedtuple
-X = namedtuple('X', ['a', 'b'])
-x = X(a=1, b='s')
-print x.a, x.b
-[out]
-1 s
-
 [case testNamedTupleError_python2]
 import typing
 from collections import namedtuple
 X = namedtuple('X', ['a', 'b'])
 x = X(a=1, b='s')
 x.c
+x.a
 [out]
 _program.py:5: error: "X" has no attribute "c"
 
@@ -332,27 +292,6 @@ print 4j / 2.0
 6j
 2j
 
-[case testNamedTupleWithTypes_python2]
-from typing import NamedTuple
-N = NamedTuple('N', [('a', int), ('b', str)])
-n = N(1, 'x')
-print n
-a, b = n
-print a, b
-print n[0]
-[out]
-N(a=1, b='x')
-1 x
-1
-
-[case testUnionTypeAlias_python2]
-from typing import Union
-U = Union[int, str]
-u = 1 # type: U
-u = 1.1
-[out]
-_program.py:4: error: Incompatible types in assignment (expression has type "float", variable has type "Union[int, str]")
-
 [case testSuperNew_python2]
 from typing import Dict, Any
 class MyType(type):
@@ -364,24 +303,6 @@ class A(object):
 print(type(A()).__name__)
 [out]
 Ax
-
-[case testSequenceIndexAndCount_python2]
-from typing import Sequence
-def f(x): # type: (Sequence[int]) -> None
-    print(x.index(1))
-    print(x.count(1))
-f([0, 0, 1, 1, 1])
-[out]
-2
-3
-
-[case testOptional_python2]
-from typing import Optional
-def f(): # type: () -> Optional[int]
-    pass
-x = f()
-y = 1
-y = x
 
 [case testUnicodeAndOverloading_python2]
 from m import f

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -11,44 +11,6 @@ print('hello, world')
 [out]
 hello, world
 
--- Skipped because different typing package versions have different repr()s.
-[case testAbstractBaseClasses-skip]
-import re
-from typing import Sized, Sequence, Iterator, Iterable, Mapping, AbstractSet
-
-def check(o, t):
-    rep = re.sub('0x[0-9a-fA-F]+', '0x...', repr(o))
-    rep = rep.replace('sequenceiterator', 'str_iterator')
-    trep = str(t).replace('_abcoll.Sized', 'collections.abc.Sized')
-    print(rep, trep, isinstance(o, t))
-
-def f():
-    check('x', Sized)
-    check([1], Sequence)
-    check({1:3}, Sequence)
-    check(iter('x'), Iterator)
-    check('x', Iterable)
-    check({}, Mapping)
-    check(set([1]), AbstractSet)
-
-f()
-[out]
-'x' <class 'collections.abc.Sized'> True
-[1] typing.Sequence True
-{1: 3} typing.Sequence False
-<str_iterator object at 0x...> typing.Iterator True
-'x' typing.Iterable True
-{} typing.Mapping True
-{1} typing.AbstractSet True
-
-[case testSized]
-from typing import Sized
-class A(Sized):
-    def __len__(self): return 5
-print(len(A()))
-[out]
-5
-
 [case testReversed]
 from typing import Reversible
 class A(Reversible):
@@ -101,7 +63,6 @@ print(abs(A()))
 5.5
 
 [case testAbs2]
-
 n = None  # type: int
 f = None  # type: float
 n = abs(1)
@@ -109,8 +70,8 @@ abs(1) + 'x'  # Error
 f = abs(1.1)
 abs(1.1) + 'x'  # Error
 [out]
-_program.py:5: error: Unsupported operand types for + ("int" and "str")
-_program.py:7: error: Unsupported operand types for + ("float" and "str")
+_program.py:4: error: Unsupported operand types for + ("int" and "str")
+_program.py:6: error: Unsupported operand types for + ("float" and "str")
 
 [case testRound]
 from typing import SupportsRound
@@ -130,17 +91,6 @@ print(list.__add__([1, 2], [3, 4]))
 [out]
 [[1, 2, 3, 4]
 
-[case testClassDataAttribute]
-import typing
-class A:
-    x = 0
-print(A.x)
-A.x += 1
-print(A.x)
-[out]
-0
-1
-
 [case testInheritedClassAttribute]
 import typing
 class A:
@@ -153,34 +103,6 @@ print(B.x)
 [out]
 f
 1
-
-[case testFunctionDecorator]
-from typing import TypeVar, cast
-ftype = TypeVar('ftype')
-def logged(f: ftype) -> ftype:
-    def g(*args, **kwargs):
-        print('enter', f.__name__)
-        r = f(*args, **kwargs)
-        print('exit', f.__name__)
-        return r
-    return cast(ftype, g)
-
-@logged
-def foo(s: str) -> str:
-    print('foo', s)
-    return s + '!'
-
-print(foo('y'))
-print(foo('x'))
-[out]
-enter foo
-foo y
-exit foo
-y!
-enter foo
-foo x
-exit foo
-x!
 
 [case testModuleAttributes]
 import math
@@ -259,28 +181,6 @@ x = 1 / 2
 x = 1.5
 [out]
 
-[case testStaticmethod]
-import typing
-class A:
-    @staticmethod
-    def f(x: str) -> int: return int(x)
-print(A.f('12'))
-print(A().f('34'))
-[out]
-12
-34
-
-[case testClassmethod]
-import typing
-class A:
-    @classmethod
-    def f(cls, x: str) -> int: return int(x)
-print(A.f('12'))
-print(A().f('34'))
-[out]
-12
-34
-
 [case testIntMethods]
 import typing
 print(int.from_bytes(b'ab', 'big'))
@@ -306,12 +206,6 @@ print(float.fromhex('0x1.8'))
 True
 1.5
 
-[case testArray]
-import typing
-import array
-array.array('b', [1, 2])
-[out]
-
 [case testDictFromkeys]
 import typing
 d = dict.fromkeys('foo')
@@ -320,16 +214,6 @@ d2 = dict.fromkeys([1, 2], b'')
 d2[2] = b'foo'
 [out]
 
-[case testReadOnlyProperty]
-class A:
-    x = 2
-    @property
-    def f(self) -> int:
-        return self.x + 1
-print(A().f)
-[out]
-3
-
 [case testIsinstanceWithTuple]
 from typing import cast, Any
 x = cast(Any, (1, 'x'))
@@ -337,20 +221,6 @@ if isinstance(x, tuple):
     print(x[0], x[1])
 [out]
 1 x
-
-[case testTypevarValues]
-from typing import TypeVar
-T = TypeVar('T', str, bytes)
-def f(x: T) -> T:
-    if isinstance(x, str):
-        return 'foo'
-    else:
-        return b'bar'
-print(f(''))
-print(f(b''))
-[out]
-foo
-b'bar'
 
 [case testAnyStr]
 from typing import AnyStr
@@ -447,26 +317,7 @@ f(re.match(b'x*', b'xxy'))
 [out]
 b'xx'
 
-[case testMultipleTypevarsWithValues]
-from typing import TypeVar
-
-T = TypeVar('T', int, str)
-S = TypeVar('S', int, str)
-
-def f(t: T, s: S) -> None:
-    t + s
-[out]
-_program.py:7: error: Unsupported operand types for + ("int" and "str")
-_program.py:7: error: Unsupported operand types for + ("str" and "int")
-
-[case testSystemExitCode]
-import typing
-print(SystemExit(5).code)
-[out]
-5
-
 [case testIntFloatDucktyping]
-
 x = None  # type: float
 x = 2.2
 x = 2
@@ -599,12 +450,6 @@ print(tuple(a))
 [out]
 (1, 2, 3)
 
-[case testListConcatenateWithIterable]
-import typing
-[1] + iter([2, 3])
-[out]
-_program.py:2: error: Unsupported operand types for + ("List[int]" and "Iterator[int]")
-
 [case testInferHeterogeneousListOfIterables]
 from typing import Sequence
 s = ['x', 'y'] # type: Sequence[str]
@@ -639,24 +484,11 @@ print(sys.stdin.buffer.mode)
 <stdin>
 rb
 
-[case testSetUnion]
-import typing
-s = {'x', 'y'}
-print('>', sorted(s.union('foo')))
-[out]
-> ['f', 'o', 'x', 'y']
-
 [case testFromFuturePrintFunction]
 from __future__ import print_function
 print('a', 'b')
 [out]
 a b
-
-[case testLenOfTuple]
-import typing
-print(len((1, 'x')))
-[out]
-2
 
 [case testListMethods]
 import typing
@@ -794,63 +626,6 @@ a + 1
 [out]
 _program.py:4: error: Unsupported operand types for + ("List[str]" and "int")
 
-[case testNamedTuple]
-import typing
-from collections import namedtuple
-X = namedtuple('X', ['a', 'b'])
-x = X(a=1, b='s')
-print(x.a, x.b)
-[out]
-1 s
-
-[case testNamedTupleShortSyntax]
-import typing
-from collections import namedtuple
-X = namedtuple('X', ' a  b ')
-x = X(a=1, b='s')
-print(x.a, x.b)
-[out]
-1 s
-
-[case testNamedTupleError]
-import typing
-from collections import namedtuple
-X = namedtuple('X', ['a', 'b'])
-x = X(a=1, b='s')
-x.c
-[out]
-_program.py:5: error: "X" has no attribute "c"
-
-[case testNamedTupleTupleOperations]
-from typing import Iterable
-from collections import namedtuple
-X = namedtuple('X', ['a', 'b'])
-def f(x: Iterable[int]) -> None: pass
-x = X(a=1, b='s')
-f(x)
-print(len(x))
-print(x.index(1))
-print(x.count(1))
-print(x + x)
-[out]
-2
-0
-1
-(1, 's', 1, 's')
-
-[case testNamedTupleWithTypes]
-from typing import NamedTuple
-N = NamedTuple('N', [('a', int), ('b', str)])
-n = N(1, 'x')
-print(n)
-a, b = n
-print(a, b)
-print(n[0])
-[out]
-N(a=1, b='x')
-1 x
-1
-
 [case testRelativeImport]
 import typing
 from m import x
@@ -886,16 +661,6 @@ def f(x: str) -> None: pass
 [out]
 _program.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 
-[case testAssignToComplexReal]
-import typing
-x = 4j
-y = x.real
-y = x         # Error
-x.real = 2.0  # Error
-[out]
-_program.py:4: error: Incompatible types in assignment (expression has type "complex", variable has type "float")
-_program.py:5: error: Property "real" defined in "complex" is read-only
-
 [case testComplexArithmetic]
 import typing
 print(5 + 8j)
@@ -916,31 +681,6 @@ y = ''
 _program.py:3: error: Incompatible types in assignment (expression has type "str", variable has type "complex")
 _program.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "complex")
 
-[case testUnionTypeAlias]
-from typing import Union
-U = Union[int, str]
-u = 1 # type: U
-u = 1.1
-[out]
-_program.py:4: error: Incompatible types in assignment (expression has type "float", variable has type "Union[int, str]")
-
-[case testTupleTypeAlias]
-from typing import Tuple
-A = Tuple[int, str]
-u = 1, 'x' # type: A
-u = 1
-[out]
-_program.py:4: error: Incompatible types in assignment (expression has type "int", variable has type "Tuple[int, str]")
-
-[case testCallableTypeAlias]
-from typing import Callable
-A = Callable[[int], None]
-def f(x: A) -> None:
-    x(1)
-    x('')
-[out]
-_program.py:5: error: Argument 1 has incompatible type "str"; expected "int"
-
 [case testSuperNew]
 from typing import Dict, Any
 class MyType(type):
@@ -950,23 +690,6 @@ class A(metaclass=MyType): pass
 print(type(A()).__name__)
 [out]
 Ax
-
-[case testSequenceIndexAndCount]
-from typing import Sequence
-def f(x: Sequence[int]) -> None:
-    print(x.index(1))
-    print(x.count(1))
-f([0, 0, 1, 1, 1])
-[out]
-2
-3
-
-[case testEscapeInTripleQuotedStrLiteral]
-print('''\'''')
-print(r"""\"""$""")
-[out]
-'
-\"""$
 
 [case testSubclassBothGenericAndNonGenericABC]
 from typing import Generic, TypeVar
@@ -980,28 +703,6 @@ class E(A, B[T], Generic[T]): pass
 class F(B[T], A, Generic[T]): pass
 def f(e: E[int], f: F[int]) -> None: pass
 [out]
-
-[case testOptional]
-from typing import Optional
-def f() -> Optional[int]: pass
-x = f()
-y = 1
-y = x
-
-[case testAppendToStarArg]
-import typing
-def f(*x: int) -> None:
-    x.append(1)
-f(1)
-[out]
-_program.py:3: error: "Tuple[int, ...]" has no attribute "append"
-
-[case testExit]
-print('a')
-exit(2)
-print('b')
-[out]
-a
 
 [case testTypeVariableTypeComparability]
 from typing import TypeVar
@@ -1045,17 +746,6 @@ float()
 complex()
 slice(1)
 bool()
-
-[case testVariableLengthTuple]
-from typing import Tuple
-def p(t: Tuple[int, ...]) -> None:
-    for n in t:
-        print(n)
-p((1, 3, 2))
-[out]
-1
-3
-2
 
 [case testVariableLengthTupleError]
 from typing import Tuple


### PR DESCRIPTION
The removed tests use real stubs and/or run Python and thus are pretty
slow to run. Most of them either test stubs in straightforward ways
(which is not very useful, since the coverage is bound to be spotty)
or some very basic functionality (which is covered by other tests).

The removals speed up the Python evaluation suite by about 25% on my
laptop (there is a high variance, though). There are probably others
that could safely be removed but I tried to be pretty conservative here.