### PR TITLE
fix test_typed_pkg test failure on Mac

### DIFF
--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -29,6 +29,18 @@ def check_mypy_run(cmd_line: List[str],
     assert returncode == expected_returncode, returncode
 
 
+def is_in_venv() -> bool:
+    """Returns whether we are running inside a venv.
+
+    Based on https://stackoverflow.com/a/42580137.
+
+    """
+    if hasattr(sys, 'real_prefix'):
+        return True
+    else:
+        return hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix
+
+
 class TestPEP561(TestCase):
     @contextmanager
     def install_package(self, pkg: str,
@@ -38,9 +50,7 @@ class TestPEP561(TestCase):
         install_cmd = [python_executable, '-m', 'pip', 'install', '.']
         # if we aren't in a virtualenv, install in the
         # user package directory so we don't need sudo
-        # In a virtualenv, real_prefix is patched onto
-        # sys
-        if not hasattr(sys, 'real_prefix') or python_executable != sys.executable:
+        if not is_in_venv() or python_executable != sys.executable:
             install_cmd.append('--user')
         returncode, lines = run_command(install_cmd, cwd=working_dir)
         if returncode != 0:

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -38,7 +38,8 @@ def is_in_venv() -> bool:
     if hasattr(sys, 'real_prefix'):
         return True
     else:
-        return hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix
+        # https://github.com/python/typeshed/pull/2047
+        return hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix  # type: ignore
 
 
 class TestPEP561(TestCase):


### PR DESCRIPTION
Fixes #4883 

The check for whether we're in a venv turns out to be unreliable. See https://stackoverflow.com/questions/1871549/determine-if-python-is-running-inside-virtualenv for background.

Note that if you're testing this on a Mac that previously ran into the bug, you'll have to manually remove any global typedpkg installs for the test to work.