### PR TITLE
Allow incompatible overriding of __slots__

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1390,6 +1390,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if second_type is None:
                 self.msg.cannot_determine_type_in_base(name, base2.name(), ctx)
             ok = True
+        # __slots__ is special and the type can vary across class hierarchy.
+        if name == '__slots__':
+            ok = True
         if not ok:
             self.msg.base_class_definitions_incompatible(name, base1, base2,
                                                          ctx)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4186,6 +4186,9 @@ class F(six.with_metaclass(t.M)): pass
 @six.add_metaclass(t.M)
 class G: pass
 
+-- Misc
+-- ----
+
 [case testCorrectEnclosingClassPushedInDeferred]
 class C:
     def __getattr__(self, attr: str) -> int:
@@ -4296,3 +4299,13 @@ class C: pass
 
 @undefined         # E: Name 'undefined' is not defined
 class D: pass
+
+[case testSlotsCompatibility]
+class A:
+    __slots__ = ()
+class B(A):
+    __slots__ = ('a', 'b')
+class C:
+    __slots__ = ('x',)
+class D(B, C):
+    __slots__ = ('aa', 'bb', 'cc')

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1250,3 +1250,12 @@ def g(si: Iterable[str]):
     pass
 f(E)
 g(E)
+
+[case testInvalidSlots]
+class A:
+    __slots__ = 1
+class B:
+    __slots__ = (1, 2)
+[out]
+_testInvalidSlots.py:2: error: Incompatible types in assignment (expression has type "int", base class "object" defined the type as "Union[str, Iterable[str], None]")
+_testInvalidSlots.py:4: error: Incompatible types in assignment (expression has type "Tuple[int, int]", base class "object" defined the type as "Union[str, Iterable[str], None]")


### PR DESCRIPTION
`__slots__` is magic and there's no need for subclasses to have
compatible definitions.