### PR TITLE
Add simple memory profiler

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -28,6 +28,9 @@ from mypy.fswatcher import FileSystemWatcher, FileData
 from mypy.options import Options
 
 
+MEM_PROFILE = False  # If True, dump memory profile after initialization
+
+
 def daemonize(func: Callable[[], None], log_file: Optional[str] = None) -> int:
     """Arrange to call func() in a grandchild of the current process.
 
@@ -289,8 +292,9 @@ class Server:
             # Stores the initial state of sources as a side effect.
             self.fswatcher.find_changed()
 
-        # from mypy.memprofile import print_memory_profile
-        # print_memory_profile(run_gc=False)
+        if MEM_PROFILE:
+            from mypy.memprofile import print_memory_profile
+            print_memory_profile(run_gc=False)
 
         status = 1 if messages else 0
         return {'out': ''.join(s + '\n' for s in messages), 'err': '', 'status': status}

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -289,6 +289,9 @@ class Server:
             # Stores the initial state of sources as a side effect.
             self.fswatcher.find_changed()
 
+        #from mypy.memprofile import print_memory_profile
+        #print_memory_profile(run_gc=False)
+
         status = 1 if messages else 0
         return {'out': ''.join(s + '\n' for s in messages), 'err': '', 'status': status}
 

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -289,8 +289,8 @@ class Server:
             # Stores the initial state of sources as a side effect.
             self.fswatcher.find_changed()
 
-        #from mypy.memprofile import print_memory_profile
-        #print_memory_profile(run_gc=False)
+        # from mypy.memprofile import print_memory_profile
+        # print_memory_profile(run_gc=False)
 
         status = 1 if messages else 0
         return {'out': ''.join(s + '\n' for s in messages), 'err': '', 'status': status}

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -82,8 +82,9 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
     serious = False
     blockers = False
     try:
-        # Keep a dummy reference (res) for memory profiling below.
-        res = type_check_only(sources, bin_dir, options, flush_errors)
+        # Keep a dummy reference (res) for memory profiling below, as otherwise
+        # the result could be freed.
+        res = type_check_only(sources, bin_dir, options, flush_errors)  # noqa
     except CompileError as e:
         blockers = True
         if not e.use_stdout:
@@ -97,8 +98,8 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
         t1 = time.time()
         util.write_junit_xml(t1 - t0, serious, messages, options.junit_xml)
 
-    #from mypy.memprofile import print_memory_profile
-    #print_memory_profile()
+    # from mypy.memprofile import print_memory_profile
+    # print_memory_profile()
 
     if messages:
         code = 2 if blockers else 1

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -82,7 +82,8 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
     serious = False
     blockers = False
     try:
-        type_check_only(sources, bin_dir, options, flush_errors)
+        # Keep a dummy reference (res) for memory profiling below.
+        res = type_check_only(sources, bin_dir, options, flush_errors)
     except CompileError as e:
         blockers = True
         if not e.use_stdout:
@@ -95,6 +96,10 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
     if options.junit_xml:
         t1 = time.time()
         util.write_junit_xml(t1 - t0, serious, messages, options.junit_xml)
+
+    #from mypy.memprofile import print_memory_profile
+    #print_memory_profile()
+
     if messages:
         code = 2 if blockers else 1
         sys.exit(code)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -27,6 +27,8 @@ from mypy.version import __version__
 
 orig_stat = os.stat
 
+MEM_PROFILE = False  # If True, dump memory profile
+
 
 def stat_proxy(path: str) -> os.stat_result:
     try:
@@ -98,8 +100,9 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
         t1 = time.time()
         util.write_junit_xml(t1 - t0, serious, messages, options.junit_xml)
 
-    # from mypy.memprofile import print_memory_profile
-    # print_memory_profile()
+    if MEM_PROFILE:
+        from mypy.memprofile import print_memory_profile
+        print_memory_profile()
 
     if messages:
         code = 2 if blockers else 1

--- a/mypy/memprofile.py
+++ b/mypy/memprofile.py
@@ -6,7 +6,6 @@ owned by particular AST nodes, etc.
 
 from collections import defaultdict
 import gc
-import resource
 import sys
 from typing import List, Dict, Set, Iterable, Tuple, cast
 
@@ -61,7 +60,11 @@ def collect_memory_stats() -> Tuple[Dict[str, int],
 
 
 def print_memory_profile(run_gc: bool = True) -> None:
-    system_memuse = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if not sys.platform.startswith('win'):
+        import resource
+        system_memuse = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    else:
+        system_memuse = -1  # TODO: Support this on Windows
     if run_gc:
         gc.collect()
     freqs, memuse = collect_memory_stats()

--- a/mypy/memprofile.py
+++ b/mypy/memprofile.py
@@ -1,0 +1,111 @@
+"""Utility for dumping memory usage stats.
+
+This is tailored to mypy and knows (a little) about which list objects are
+owned by particular AST nodes, etc.
+"""
+
+from collections import defaultdict
+import gc
+import resource
+import sys
+from typing import List, Dict, Set, Iterable, Tuple, cast
+
+from mypy.nodes import FakeInfo, Node
+from mypy.types import Type
+
+
+def collect_memory_stats() -> Tuple[Dict[str, int],
+                                    Dict[str, int]]:
+    """Return stats about memory use.
+
+    Return a tuple with these items:
+      - Dict from object kind to number of instances of that kind
+      - Dict from object kind to total bytes used by all instances of that kind
+    """
+    objs = gc.get_objects()
+    find_recursive_objects(objs)
+
+    inferred = {}
+    for obj in objs:
+        if type(obj) is FakeInfo:
+            # Processing these would cause a crash.
+            continue
+        n = type(obj).__name__
+        if hasattr(obj, '__dict__'):
+            # Keep track of which class a particular __dict__ is associated with.
+            inferred[id(obj.__dict__)] = '%s (__dict__)' % n
+        if isinstance(obj, (Node, Type)):
+            if hasattr(obj, '__dict__'):
+                for x in obj.__dict__.values():
+                    if isinstance(x, list):
+                        # Keep track of which node a list is associated with.
+                        inferred[id(x)] = '%s (list)' % n
+            else:
+                for base in type.mro(type(obj)):
+                    for k in getattr(base, '__slots__', ()):
+                        x = getattr(obj, k, None)
+                        if isinstance(x, list):
+                            inferred[id(x)] = '%s (list)' % n
+
+    freqs = {}  # type: Dict[str, int]
+    memuse = {}  # type: Dict[str, int]
+    for obj in objs:
+        if id(obj) in inferred:
+            name = inferred[id(obj)]
+        else:
+            name = type(obj).__name__
+        freqs[name] = freqs.get(name, 0) + 1
+        memuse[name] = memuse.get(name, 0) + sys.getsizeof(obj)
+
+    return freqs, memuse
+
+
+def print_memory_profile(run_gc: bool = True) -> None:
+    system_memuse = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if run_gc:
+        gc.collect()
+    freqs, memuse = collect_memory_stats()
+    print('%7s  %7s  %7s  %s' % ('Freq', 'Size(k)', 'AvgSize', 'Type'))
+    print('-------------------------------------------')
+    totalmem = 0
+    i = 0
+    for n, mem in sorted(memuse.items(), key=lambda x: -x[1]):
+        f = freqs[n]
+        if i < 50:
+            print('%7d  %7d  %7.0f  %s' % (f, mem // 1024, mem / f, n))
+        i += 1
+        totalmem += mem
+    print()
+    print('Mem usage RSS   ', system_memuse // 1024)
+    print('Total reachable ', totalmem // 1024)
+
+
+def find_recursive_objects(objs: List[object]) -> None:
+    """Find additional objects referenced by objs and append them to objs.
+
+    We use this since gc.get_objects() does not return objects without pointers
+    in them such as strings.
+    """
+    seen = set(id(o) for o in objs)
+
+    def visit(o: object) -> None:
+        if id(o) not in seen:
+            objs.append(o)
+            seen.add(id(o))
+
+    for obj in objs[:]:
+        if type(obj) is FakeInfo:
+            # Processing these would cause a crash.
+            continue
+        if type(obj) in (dict, defaultdict):
+            for key, val in cast(Dict[object, object], obj).items():
+                visit(key)
+                visit(val)
+        if type(obj) in (list, tuple, set):
+            for x in cast(Iterable[object], obj):
+                visit(x)
+        if hasattr(obj, '__slots__'):
+            for base in type.mro(type(obj)):
+                for slot in getattr(base, '__slots__', ()):
+                    if hasattr(obj, slot):
+                        visit(getattr(obj, slot))


### PR DESCRIPTION
It displays memory usage per instance type at one point in time,
number of instances per type, and total memory use.

It has some knowledge of how mypy objects are represented so that
it can determine which AST node owns a particular list object,
for example.

This is disabled by default. Added commented out call sites
that can be manually uncommented to get memory usage reports.
