### PR TITLE
Rework (and heavily optimize!) mypy.ini per-module configuration

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -29,10 +29,15 @@ characters.
   the global flags. The ``setup.cfg`` file is an exception to this.
 
 - Additional sections named ``[mypy-PATTERN1,PATTERN2,...]`` may be
-  present, where ``PATTERN1``, ``PATTERN2`` etc. are `fnmatch patterns
-  <https://docs.python.org/3.6/library/fnmatch.html>`_
-  separated by commas.  These sections specify additional flags that
-  only apply to *modules* whose name matches at least one of the patterns.
+  present, where ``PATTERN1``, ``PATTERN2`` etc. are comma-separated
+  patterns of the form ``dotted_module_name`` or ``dotted_module_name.*``.
+  These sections specify additional flags that only apply to *modules*
+  whose name matches at least one of the patterns.
+
+  A pattern of the form ``dotted_module_name`` matches only the named module,
+  while ``dotted_module_name.*`` matches ``dotted_module_name`` and any
+  submodules (so ``foo.bar.*`` would match all of ``foo.bar``,
+  ``foo.bar.baz``, and ``foo.bar.baz.quux``).
 
 .. note::
 
@@ -137,8 +142,12 @@ overridden by the pattern sections matching the module name.
 
 .. note::
 
-   If multiple pattern sections match a module they are processed in
-   order of their occurrence in the config file.
+   If multiple pattern sections match a module, the options from the
+   most specific section are used where they disagree.  This means
+   that ``foo.bar`` will take values from sections with the patterns
+   ``foo.bar``, ``foo.bar.*``, and ``foo.*``, but when they specify
+   different values, it will use values from ``foo.bar`` before
+   ``foo.bar.*`` before ``foo.*``.
 
 - ``follow_imports`` (string, default ``normal``) directs what to do
   with imports when the imported module is found as a ``.py`` file and

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -94,6 +94,7 @@ sub.pkg is not a valid Python package name
 mypy: can't decode file 'a.py': unknown encoding: uft-8
 == Return code: 2
 
+-- '
 [case testCannotIgnoreDuplicateModule]
 # cmd: mypy one/mod/__init__.py two/mod/__init__.py
 [file one/mod/__init__.py]
@@ -157,9 +158,9 @@ def f():
 [file mypy.ini]
 [[mypy]
 disallow_untyped_defs = True
-[[mypy-y*]
+[[mypy-y]
 disallow_untyped_defs = False
-[[mypy-z*]
+[[mypy-z]
 disallow_untyped_calls = True
 [file x.py]
 def f(a):
@@ -181,7 +182,7 @@ z.py:1: error: Function is missing a type annotation
 z.py:4: error: Call to untyped function "f" in typed context
 x.py:1: error: Function is missing a type annotation
 
-[case testPerFileConfigSectionMultipleMatches]
+[case testPerFileConfigSectionMultipleMatchesDisallowed]
 # cmd: mypy xx.py xy.py yx.py yy.py
 [file mypy.ini]
 [[mypy]
@@ -202,18 +203,15 @@ def g(a: int) -> int: return f(a)
 def f(a): pass
 def g(a: int) -> int: return f(a)
 [out]
-yy.py:2: error: Call to untyped function "f" in typed context
-yx.py:1: error: Function is missing a type annotation
-yx.py:2: error: Call to untyped function "f" in typed context
-xy.py:1: error: Function is missing a type annotation
-xy.py:2: error: Call to untyped function "f" in typed context
-xx.py:1: error: Function is missing a type annotation
+mypy.ini: [mypy-*x*]: Invalid pattern. Patterns must be 'module_name' or 'module_name.*'
+mypy.ini: [mypy-*y*]: Invalid pattern. Patterns must be 'module_name' or 'module_name.*'
+== Return code: 0
 
 [case testMultipleGlobConfigSection]
 # cmd: mypy x.py y.py z.py
 [file mypy.ini]
 [[mypy]
-[[mypy-x*,z*]
+[[mypy-x.*,z.*]
 disallow_untyped_defs = True
 [file x.py]
 def f(a): pass
@@ -266,10 +264,11 @@ mypy.ini: [mypy]: ignore_missing_imports: Not a boolean: nah
 # cmd: mypy -c pass
 [file mypy.ini]
 [[mypy]
-[[mypy-*]
+[[mypy-foo.*]
 python_version = 3.4
 [out]
 mypy.ini: [mypy-*]: Per-module sections should only specify per-module flags (python_version)
+mypy.ini: [mypy-*]: Invalid pattern. Patterns must be 'module_name' or 'module_name.*'
 == Return code: 0
 
 [case testConfigMypyPath]
@@ -572,7 +571,7 @@ main.py:3: error: Argument 1 to "f" becomes "Any" due to an unfollowed import
 # cmd: mypy m.py
 [file mypy.ini]
 [[mypy]
-[[mypy-m*]
+[[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -597,7 +596,7 @@ m.py:9: error: Explicit "Any" is not allowed
 
 [file mypy.ini]
 [[mypy]
-[[mypy-m*]
+[[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -617,7 +616,7 @@ m.py:5: error: Explicit "Any" is not allowed
 
 [file mypy.ini]
 [[mypy]
-[[mypy-m*]
+[[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -631,7 +630,7 @@ m.py:2: error: Explicit "Any" is not allowed
 
 [file mypy.ini]
 [[mypy]
-[[mypy-m*]
+[[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -651,7 +650,7 @@ m.py:6: error: Explicit "Any" is not allowed
 
 [file mypy.ini]
 [[mypy]
-[[mypy-m*]
+[[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -673,7 +672,7 @@ m.py:4: error: Explicit "Any" is not allowed
 
 [file mypy.ini]
 [[mypy]
-[[mypy-m*]
+[[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -698,7 +697,7 @@ m.py:10: error: Explicit "Any" is not allowed
 
 [file mypy.ini]
 [[mypy]
-[[mypy-m*]
+[[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -716,7 +715,7 @@ m.py:5: error: Explicit "Any" is not allowed
 
 [file mypy.ini]
 [[mypy]
-[[mypy-m*]
+[[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -733,7 +732,7 @@ m.py:3: error: Explicit "Any" is not allowed
 
 [file mypy.ini]
 [[mypy]
-[[mypy-m*]
+[[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -748,7 +747,7 @@ m.py:3: error: Explicit "Any" is not allowed
 
 [file mypy.ini]
 [[mypy]
-[[mypy-m*]
+[[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -766,7 +765,7 @@ m.py:4: error: Explicit "Any" is not allowed
 
 [file mypy.ini]
 [[mypy]
-[[mypy-m*]
+[[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -784,7 +783,7 @@ m.py:4: error: Explicit "Any" is not allowed
 
 [file mypy.ini]
 [[mypy]
-[[mypy-m*]
+[[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -1008,28 +1007,40 @@ class ShouldNotBeFine(x): ...
 [out]
 y.py:5: error: Class cannot subclass 'x' (has type 'Any')
 
-[case testDeterministicSectionOrdering]
+[case testSectionInheritance]
 # cmd: mypy a
 [file a/__init__.py]
+0()
+[file a/foo.py]
+0()
 [file a/b/__init__.py]
 [file a/b/c/__init__.py]
+0()
 [file a/b/c/d/__init__.py]
 [file a/b/c/d/e/__init__.py]
-0()
+from typing import List
+def g(x: List) -> None: pass
+g(None)
 [file mypy.ini]
 [[mypy]
+disallow_any_generics = False
 [[mypy-a.*]
 ignore_errors = True
 [[mypy-a.b.*]
+disallow_any_generics = True
 ignore_errors = True
 [[mypy-a.b.c.*]
 ignore_errors = True
 [[mypy-a.b.c.d.*]
 ignore_errors = True
+[[mypy-a.b.c.d.e.*]
+ignore_errors = True
+strict_optional = True
 [[mypy-a.b.c.d.e]
 ignore_errors = False
 [out]
-a/b/c/d/e/__init__.py:1: error: "int" not callable
+a/b/c/d/e/__init__.py:2: error: Missing type parameters for generic type
+a/b/c/d/e/__init__.py:3: error: Argument 1 to "g" has incompatible type "None"; expected "List[Any]"
 
 [case testDisallowUntypedDefsAndGenerics]
 # cmd: mypy a.py
@@ -1048,6 +1059,7 @@ a.py:1: error: Function is missing a type annotation
 [out]
 mypy: can't read file 'nope.py': No such file or directory
 == Return code: 2
+--'
 
 [case testParseError]
 # cmd: mypy a.py
@@ -1113,3 +1125,25 @@ follow_imports_for_stubs = True
 [file main.py]
 import math
 math.frobnicate()
+
+[case testConfigWarnUnusedSection1]
+# cmd: mypy foo.py quux.py spam/eggs.py
+# flags: --follow-imports=skip
+[file mypy.ini]
+[[mypy]
+warn_unused_configs = True
+[[mypy-bar]
+[[mypy-foo]
+[[mypy-baz.*]
+[[mypy-quux.*]
+[[mypy-spam.*]
+[[mypy-spam.eggs]
+[[mypy-emarg.*]
+[[mypy-emarg.hatch]
+[file foo.py]
+[file quux.py]
+[file spam/__init__.py]
+[file spam/eggs.py]
+[out]
+Warning: unused section(s) in mypy.ini: [mypy-bar], [mypy-baz.*], [mypy-emarg.*], [mypy-emarg.hatch]
+== Return code: 0


### PR DESCRIPTION
Currently, we compute the options for each module by scanning through
the full list of per-module configuration options and seeing if the
pattern matches against the module name.
This is incredibly slow for large configuration files. On the internal S repo,
mypy spends 23 seconds (!!) just computing per-module options.

To fix this, we instead precompute an Options object for each config
section, and in `clone_for_module` do a search for the most specific
configured Options (so for foo.bar, we try foo.bar, foo.bar.*,
foo.*, in that order).

This cuts down the processing time from 23s to about 80ms.

The catch is that this is actually a backwards-incompatible semantics
change, in two ways:
 * Patterns can be of the form `foo.bar` and `foo.bar.*`, but can no longer be
   general purpose globs. We produce an error message to detect this misusage.
 * Patterns are now always applied based on specificity and not on the order they
   appear in the file. This means that some poorly-formed configuration files that
   contained options that were always overridden may have their meaning changed.
   This is probably not too common, so we don't do anything to deal with it.
   We could emit a warning when specificity-order and file-order disagree, but
   it seems wrong to lock people into the old behavior, and it seems like a silly
   thing to make configurable.


I had a really pretty trie-based solution that I wrote before realizing I could do it this way and it would probably be good enough. The trie-based solution is faster, but not enough faster to justify the extra complication :(