### PR TITLE
Exclude .git from flake8's checking

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ exclude =
   out,
   .venv,
   .mypy_cache,
+  .git,
   .cache,
   # Sphinx configuration is irrelevant
   docs/source/conf.py,


### PR DESCRIPTION
This prevents flake8 from becoming filled with rage whenever there is
a branch name that ends in '.py'.  (Which is happening now, since
there is a 'setup.py' typeshed branch.)

I'm just gonna merge this as soon as it passes tests because it is low risk and driving me nuts.