### PR TITLE
Restore dict based typesafe caching

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -160,7 +160,8 @@ def find_module_path_and_all(module: str, pyversion: Tuple[int, int],
             module_all = getattr(mod, '__all__', None)
     else:
         # Find module by going through search path.
-        module_path = mypy.build.FindModuleCache().find_module(module, ['.'] + search_path,
+        module_path = mypy.build.FindModuleCache().find_module(module,
+                                                               ('.',) + tuple(search_path),
                                                                interpreter)
         if not module_path:
             raise SystemExit(


### PR DESCRIPTION
This also restores `isfile_case` caching and fixes a type error (and legitimate bug) (!).

The last remaining follow up from #4693 is to run only one Python subprocess.