### PR TITLE
Do the mtime-updating optimization in fine-grained mode

### DIFF
--- a/mypy/fswatcher.py
+++ b/mypy/fswatcher.py
@@ -75,7 +75,8 @@ class FileSystemWatcher:
                     # File is new.
                     changed.add(path)
                     self._update(path)
-                elif st.st_size != old.st_size or st.st_mtime != old.st_mtime:
+                # Round mtimes down, to match the mtimes we write to meta files
+                elif st.st_size != old.st_size or int(st.st_mtime) != int(old.st_mtime):
                     # Only look for changes if size or mtime has changed as an
                     # optimization, since calculating md5 is expensive.
                     new_md5 = self.fs.md5(path)


### PR DESCRIPTION
When doing a fine-grained cold load, if the mtimes don't match but the
source files still do, update the meta cache with the correct
mtime. This can substantially speed up future cold runs.
(We already do this optimization in regular incremental mode,
so it is just a matter of extending it.)

This shaves about 6s off the *second* cold run on S.