### PR TITLE
#4897: allow `raise E` where E: Type[Exn]

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2357,20 +2357,19 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     def type_check_raise(self, e: Expression, s: RaiseStmt,
                          optional: bool = False) -> None:
         typ = self.expr_checker.accept(e)
-        typeinfo = None
-        if isinstance(typ, FunctionLike) and typ.is_type_obj():
-            typeinfo = typ.type_object()
-        elif isinstance(typ, TypeType):
+        if isinstance(typ, TypeType):
             if isinstance(typ.item, AnyType):
                 return
-            typeinfo = typ.item.type
-        if typeinfo is not None:
-            # Cases like "raise/from ExceptionClass".
-            base = self.lookup_typeinfo('builtins.BaseException')
-            if base in typeinfo.mro or typeinfo.fallback_to_any:
-                # Good!
-                return
-            # Else fall back to the checks below (which will fail).
+            typ = typ.item
+        if isinstance(typ, FunctionLike):
+            if typ.is_type_obj():
+                # Cases like "raise/from ExceptionClass".
+                typeinfo = typ.type_object()
+                base = self.lookup_typeinfo('builtins.BaseException')
+                if base in typeinfo.mro or typeinfo.fallback_to_any:
+                    # Good!
+                    return
+                # Else fall back to the checks below (which will fail).
         if isinstance(typ, TupleType) and self.options.python_version[0] == 2:
             # allow `raise type, value, traceback`
             # https://docs.python.org/2/reference/simple_stmts.html#the-raise-statement

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -416,8 +416,13 @@ x = None # type: typing.Type[BaseException]
 raise x
 [builtins fixtures/exception.pyi]
 
-[case testRaiseFromStatement]
+[case testRaiseNonExceptionTypeFails]
+import typing
+x = int # type: typing.Type[int]
+raise x # E: Exception must be derived from BaseException
+[builtins fixtures/exception.pyi]
 
+[case testRaiseFromStatement]
 e = None # type: BaseException
 f = None # type: MyError
 a = None # type: A

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -410,6 +410,12 @@ raise object # E: Exception must be derived from BaseException
 raise f # E: Exception must be derived from BaseException
 [builtins fixtures/exception.pyi]
 
+[case testRaiseExceptionType]
+import typing
+x = None # type: typing.Type[BaseException]
+raise x
+[builtins fixtures/exception.pyi]
+
 [case testRaiseFromStatement]
 
 e = None # type: BaseException
@@ -1615,4 +1621,3 @@ N = TypedDict('N', {'x': int})
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
 [out]
-

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -639,6 +639,16 @@ except ((E1, E2)): pass
 except (((E1, E2))): pass
 [builtins fixtures/exception.pyi]
 
+[case testExceptWithTypeType]
+import typing
+E = BaseException  # type: typing.Type[BaseException]
+
+try:
+    pass
+except E:
+    pass
+[builtins fixtures/exception.pyi]
+
 [case testExceptWithMultipleTypes2]
 import typing
 class E1(BaseException): pass


### PR DESCRIPTION
That is, where E is annotated as a Type, rather than being inferred as a
FunctionLike which is a type object.

This also allows `raise E` where E is Type[Any], which *seems* right but
I was not certain about.

Fixes #4897