### PR TITLE
Fix some problems with mypy version number handling

### DIFF
--- a/mypy/version.py
+++ b/mypy/version.py
@@ -1,11 +1,11 @@
 import os
 from mypy import git
 
-__version__ = '0.600-dev'
+__version__ = '0.600+dev'
 base_version = __version__
 
 mypy_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-if git.is_git_repo(mypy_dir) and git.have_git():
+if __version__.endswith('+dev') and git.is_git_repo(mypy_dir) and git.have_git():
     __version__ += '-' + git.git_revision(mypy_dir).decode('utf-8')
     if git.is_dirty(mypy_dir):
         __version__ += '-dirty'

--- a/setup.py
+++ b/setup.py
@@ -14,15 +14,11 @@ if sys.version_info < (3, 4, 0):
 # alternative forms of installing, as suggested by README.md).
 from setuptools import setup
 from setuptools.command.build_py import build_py
-from mypy.version import base_version, __version__
+from mypy.version import __version__ as version
 from mypy import git
 
 git.verify_git_integrity_or_abort(".")
 
-if any(dist_arg in sys.argv[1:] for dist_arg in ('bdist_wheel', 'sdist')):
-    version = base_version
-else:
-    version = __version__
 description = 'Optional static typing for Python'
 long_description = '''
 Mypy -- Optional Static Typing for Python


### PR DESCRIPTION
Two things:
* Unlike earlier pips, when doing an install locally by passing the
  directory path, pip 10 invokes setup.py with 'bdist_wheel', which
  breaks some of our use cases, since we used that to decide whether
  or not to try to include a git hash in the version.
  Instead, just always try to include a git hash in the version
  for development versions, and never include one for release versions.
* pip whines about the "-dev" version numbers not being valid versions
  per PEP 440 and threatens that they may stop working.
  Change it to +dev, which is valid (though our use of it may not be.)