### PR TITLE
Compute mangled fullnames properly for nested classes inside functions

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -263,10 +263,7 @@ def lookup_qualified_stnode(modules: Dict[str, MypyFile], name: str,
     while True:
         if '.' not in head:
             if not quick_and_dirty:
-                # Not yet: assert '.' in head, "Cannot find %s" % (name,)
-                stale = stale_info(modules)
-                stale.fallback_to_any = True
-                return SymbolTableNode(GDEF, stale)
+                assert '.' in head, "Cannot find %s" % (name,)
             return None
         head, tail = head.rsplit('.', 1)
         rest.append(tail)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -995,7 +995,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             defn.info._fullname = defn.info.name()
         if self.is_func_scope() or self.type:
             kind = MDEF
-            if self.is_nested_func_scope():
+            if self.is_nested_within_func_scope():
                 kind = LDEF
             node = SymbolTableNode(kind, defn.info)
             self.add_symbol(defn.name, node, defn)
@@ -3109,8 +3109,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
     def is_func_scope(self) -> bool:
         return self.locals[-1] is not None
 
-    # Are we underneath a function scope, even if we are in a nested class also
-    def is_nested_func_scope(self) -> bool:
+    def is_nested_within_func_scope(self) -> bool:
+        """Are we underneath a function scope, even if we are in a nested class also"""
         return any(l is not None for l in self.locals)
 
     def is_class_scope(self) -> bool:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -995,7 +995,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             defn.info._fullname = defn.info.name()
         if self.is_func_scope() or self.type:
             kind = MDEF
-            if self.is_func_scope():
+            if self.is_nested_func_scope():
                 kind = LDEF
             node = SymbolTableNode(kind, defn.info)
             self.add_symbol(defn.name, node, defn)
@@ -3108,6 +3108,10 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
 
     def is_func_scope(self) -> bool:
         return self.locals[-1] is not None
+
+    # Are we underneath a function scope, even if we are in a nested class also
+    def is_nested_func_scope(self) -> bool:
+        return any(l is not None for l in self.locals)
 
     def is_class_scope(self) -> bool:
         return self.type is not None and not self.is_func_scope()

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -1314,3 +1314,16 @@ C = str
 [out2]
 -- TODO: Should be 'builtins.str'
 tmp/a.py:2: error: Revealed type is 'Any'
+
+[case testSerializeNestedClassStuff]
+# flags: --verbose
+import a
+[file a.py]
+import b
+[file a.py.2]
+import b
+#
+[file b.py]
+def foo() -> None:
+    class Foo:
+        class Bar: pass


### PR DESCRIPTION
This reverts #4927 and fixes the (a?) bug that it was working around.

Previously, mangled local fullnames were only computed if the class was directly inside a function, and not for nested classes inside a function.