### PR TITLE
Turn off cache writing/validation for non-incremental tests

### DIFF
--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -146,6 +146,11 @@ class TypeCheckSuite(DataSuite):
             options.strict_optional = True
         if incremental_step:
             options.incremental = True
+        else:
+            options.incremental = False
+            # Don't waste time writing cache unless we are specifically looking for it
+            if 'writescache' not in testcase.name.lower():
+                options.cache_dir = os.devnull
 
         sources = []
         for module_name, program_path, program_text in module_data:
@@ -183,7 +188,8 @@ class TypeCheckSuite(DataSuite):
         assert_string_arrays_equal(output, a, msg.format(testcase.file, testcase.line))
 
         if res:
-            self.verify_cache(module_data, res.errors, res.manager, res.graph)
+            if options.cache_dir != os.devnull:
+                self.verify_cache(module_data, res.errors, res.manager, res.graph)
 
             if incremental_step > 1:
                 suffix = '' if incremental_step == 2 else str(incremental_step - 1)

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -308,3 +308,27 @@ class C:
         pass
 [out]
 main:2: error: The return type of "__init__" must be None
+
+-- WritesCache signals to testcheck to do the cache validation
+[case testWritesCache]
+import a
+import d
+[file a.py]
+import b
+import c
+[file b.py]
+[file c.py]
+[file d.py]
+
+[case testWritesCacheErrors]
+import a
+import d
+[file a.py]
+import b
+import c
+[file b.py]
+[file c.py]
+[file d.py]
+import e
+[file e.py]
+1+'no'  # E: Unsupported operand types for + ("int" and "str")


### PR DESCRIPTION
To provide some regression testing against cache writing getting
totally busted, add two tests for specifically this.

Fixes #4875