### PR TITLE
Fix metaclass of Enum-subclasses functional API

### DIFF
--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -80,6 +80,7 @@ class EnumCallAnalyzer:
         base = self.api.named_type_or_none(fullname)
         assert base is not None
         info = self.api.basic_new_typeinfo(name, base)
+        info.metaclass_type = info.calculate_metaclass_type()
         info.is_enum = True
         for item in items:
             var = Var(item)

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -392,6 +392,16 @@ x = y
 [out]
 main:8: error: Incompatible types in assignment (expression has type "__main__.B.E", variable has type "__main__.A.E")
 
+[case testFunctionalEnumProtocols]
+from enum import IntEnum
+Color = IntEnum('Color', 'red green blue')
+reveal_type(Color['green'])  # E: Revealed type is '__main__.Color'
+for c in Color:
+    reveal_type(c)  # E: Revealed type is '__main__.Color*'
+reveal_type(list(Color))  # E: Revealed type is 'builtins.list[__main__.Color*]'
+
+[builtins fixtures/list.pyi]
+
 [case testEnumWorkWithForward]
 from enum import Enum
 a: E = E.x

--- a/test-data/unit/lib-stub/enum.pyi
+++ b/test-data/unit/lib-stub/enum.pyi
@@ -1,7 +1,11 @@
-from typing import Any, TypeVar, Union
+from typing import Any, TypeVar, Union, Type, Sized, Iterator, Mapping
 
-class EnumMeta(type):
-    pass
+_T = TypeVar('_T')
+
+class EnumMeta(type, Sized):
+    def __iter__(self: Type[_T]) -> Iterator[_T]: pass
+    def __reversed__(self: Type[_T]) -> Iterator[_T]: pass
+    def __getitem__(self: Type[_T], name: str) -> _T: pass
 
 class Enum(metaclass=EnumMeta):
     def __new__(cls, value: Any) -> None: pass
@@ -16,8 +20,6 @@ class Enum(metaclass=EnumMeta):
 
 class IntEnum(int, Enum):
     value = 0  # type: int
-
-_T = TypeVar('_T')
 
 def unique(enumeration: _T) -> _T: pass
 


### PR DESCRIPTION
Fix #4941. The semantic analyses of class and functional API and enums are performed separately.

The bug was introduced by myself in #4319.