### PR TITLE
Don't decode files while computing their hash

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -44,7 +44,7 @@ from mypy.semanal_pass3 import SemanticAnalyzerPass3
 from mypy.checker import TypeChecker
 from mypy.indirection import TypeIndirectionVisitor
 from mypy.errors import Errors, CompileError, report_internal_error
-from mypy.util import DecodeError
+from mypy.util import DecodeError, decode_python_encoding
 from mypy.report import Reports
 from mypy import moduleinfo
 from mypy.fixup import fixup_module
@@ -205,7 +205,7 @@ def _build(sources: List[BuildSource],
     gc.set_threshold(50000)
 
     data_dir = default_data_dir(bin_dir)
-    fscache = fscache or FileSystemCache(options.python_version)
+    fscache = fscache or FileSystemCache()
 
     # Determine the default module search path.
     lib_path = default_lib_path(data_dir,
@@ -1810,7 +1810,8 @@ class State:
             if self.path and source is None:
                 try:
                     path = manager.maybe_swap_for_shadow_path(self.path)
-                    source = manager.fscache.read_with_python_encoding(path)
+                    source = decode_python_encoding(manager.fscache.read(path),
+                                                    manager.options.python_version)
                     self.source_hash = manager.fscache.md5(path)
                 except IOError as ioerr:
                     # ioerr.strerror differs for os.stat failures between Windows and

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -122,7 +122,7 @@ class Server:
         if os.path.isfile(STATUS_FILE):
             os.unlink(STATUS_FILE)
 
-        self.fscache = FileSystemCache(self.options.python_version)
+        self.fscache = FileSystemCache()
 
         options.incremental = True
         options.fine_grained_incremental = True

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -206,7 +206,9 @@ def generate_stub(path: str,
                   include_private: bool = False
                   ) -> None:
 
-    source, _ = mypy.util.read_with_python_encoding(path, pyversion)
+    with open(path, 'rb') as f:
+        data = f.read()
+    source = mypy.util.decode_python_encoding(data, pyversion)
     options = MypyOptions()
     options.python_version = pyversion
     try:

--- a/mypy/test/testgraph.py
+++ b/mypy/test/testgraph.py
@@ -39,7 +39,7 @@ class GraphSuite(Suite):
     def _make_manager(self) -> BuildManager:
         errors = Errors()
         options = Options()
-        fscache = FileSystemCache(options.python_version)
+        fscache = FileSystemCache()
         manager = BuildManager(
             data_dir='',
             lib_path=[],

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -3,6 +3,7 @@
 import re
 import subprocess
 import hashlib
+from io import BytesIO
 from xml.sax.saxutils import escape
 from typing import TypeVar, List, Tuple, Optional, Sequence, Dict
 
@@ -68,40 +69,34 @@ class DecodeError(Exception):
     """
 
 
-def read_with_python_encoding(path: str, pyversion: Tuple[int, int]) -> Tuple[str, str]:
+def decode_python_encoding(source: bytes, pyversion: Tuple[int, int]) -> str:
     """Read the Python file with while obeying PEP-263 encoding detection.
 
     Returns:
       A tuple: the source as a string, and the hash calculated from the binary representation.
     """
-    source_bytearray = bytearray()
     encoding = 'utf8' if pyversion[0] >= 3 else 'ascii'
 
-    with open(path, 'rb') as f:
-        # read first two lines and check if PEP-263 coding is present
-        source_bytearray.extend(f.readline())
-        source_bytearray.extend(f.readline())
-        m = hashlib.md5(source_bytearray)
+    # look at first two lines and check if PEP-263 coding is present
+    f = BytesIO(source)
+    source_start = f.readline() + f.readline()
 
-        # check for BOM UTF-8 encoding and strip it out if present
-        if source_bytearray.startswith(b'\xef\xbb\xbf'):
-            encoding = 'utf8'
-            source_bytearray = source_bytearray[3:]
-        else:
-            _encoding, _ = find_python_encoding(source_bytearray, pyversion)
-            # check that the coding isn't mypy. We skip it since
-            # registering may not have happened yet
-            if _encoding != 'mypy':
-                encoding = _encoding
+    # check for BOM UTF-8 encoding and strip it out if present
+    if source_start.startswith(b'\xef\xbb\xbf'):
+        encoding = 'utf8'
+        source = source[3:]
+    else:
+        _encoding, _ = find_python_encoding(source_start, pyversion)
+        # check that the coding isn't mypy. We skip it since
+        # registering may not have happened yet
+        if _encoding != 'mypy':
+            encoding = _encoding
 
-        remainder = f.read()
-        m.update(remainder)
-        source_bytearray.extend(remainder)
-        try:
-            source_text = source_bytearray.decode(encoding)
-        except LookupError as lookuperr:
-            raise DecodeError(str(lookuperr))
-        return source_text, m.hexdigest()
+    try:
+        source_text = source.decode(encoding)
+    except LookupError as lookuperr:
+        raise DecodeError(str(lookuperr))
+    return source_text
 
 
 _python2_interpreter = None  # type: Optional[str]

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -3,7 +3,6 @@
 import re
 import subprocess
 import hashlib
-from io import BytesIO
 from xml.sax.saxutils import escape
 from typing import TypeVar, List, Tuple, Optional, Sequence, Dict
 
@@ -77,20 +76,13 @@ def decode_python_encoding(source: bytes, pyversion: Tuple[int, int]) -> str:
     """
     encoding = 'utf8' if pyversion[0] >= 3 else 'ascii'
 
-    # look at first two lines and check if PEP-263 coding is present
-    f = BytesIO(source)
-    source_start = f.readline() + f.readline()
-
     # check for BOM UTF-8 encoding and strip it out if present
-    if source_start.startswith(b'\xef\xbb\xbf'):
+    if source.startswith(b'\xef\xbb\xbf'):
         encoding = 'utf8'
         source = source[3:]
     else:
-        _encoding, _ = find_python_encoding(source_start, pyversion)
-        # check that the coding isn't mypy. We skip it since
-        # registering may not have happened yet
-        if _encoding != 'mypy':
-            encoding = _encoding
+        # look at first two lines and check if PEP-263 coding is present
+        encoding, _ = find_python_encoding(source, pyversion)
 
     try:
         source_text = source.decode(encoding)


### PR DESCRIPTION
Instead, cache undecoded bytes and decode in client code.  Happily,
this allows us to get rid of FileSystemCache's dependency on the
python version.

This is a big performance win for daemon cold runs on codebases that
make use of custom encodings where decoding is expensive.

This gives about a 5s speed up on cold runs on S when the cache mtimes don't match.