### PR TITLE
allow __getattr__ in nested scopes; support module-level __getattr__

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1334,7 +1334,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                     missing = True
             # If it is still not resolved, and the module is a stub
             # check for a module level __getattr__
-            if module and not node and module.is_stub and '__getattr__' in module.names:
+            if (module and not node and (module.is_stub or self.options.python_version >= (3, 7))
+                    and '__getattr__' in module.names):
                 getattr_defn = module.names['__getattr__']
                 if isinstance(getattr_defn.node, FuncDef):
                     if isinstance(getattr_defn.node.type, CallableType):
@@ -2676,7 +2677,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                     expr.kind = n.kind
                     expr.fullname = n.fullname
                     expr.node = n.node
-            elif file is not None and file.is_stub and '__getattr__' in file.names:
+            elif (file is not None and (file.is_stub or self.options.python_version >= (3, 7))
+                    and '__getattr__' in file.names):
                 # If there is a module-level __getattr__, then any attribute on the module is valid
                 # per PEP 484.
                 getattr_defn = file.names['__getattr__']

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1887,6 +1887,18 @@ b = a.bar
 [out]
 main:9: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
+[case testNestedGetAttr]
+def foo() -> object:
+    def __getattr__() -> None:  # no error because not in a class
+        pass
+    return __getattr__
+
+class X:
+    def foo(self) -> object:
+        def __getattr__() -> None:  # no error because not directly inside a class
+            pass
+        return __getattr__
+
 [case testGetAttrSignature]
 class A:
     def __getattr__(self, x: str) -> A: pass

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1877,18 +1877,24 @@ def __getattr__(name): ...
 
 [builtins fixtures/module.pyi]
 
-[case testModuleLevelGetattrNotStub]
-
+[case testModuleLevelGetattrNotStub36]
+# flags: --python-version 3.6
 import has_getattr
-reveal_type(has_getattr.any_attribute)
+reveal_type(has_getattr.any_attribute)  # E: Revealed type is 'Any'  # E: Module has no attribute "any_attribute"
 
 [file has_getattr.py]
-def __getattr__(name): ...
+def __getattr__(name) -> str: ...
 
-[out]
-tmp/has_getattr.py:1: error: __getattr__ is not valid at the module level outside a stub file
-main:3: error: Revealed type is 'Any'
-main:3: error: Module has no attribute "any_attribute"
+[builtins fixtures/module.pyi]
+
+[case testModuleLevelGetattrNotStub37]
+# flags: --python-version 3.7
+
+import has_getattr
+reveal_type(has_getattr.any_attribute)  # E: Revealed type is 'builtins.str'
+
+[file has_getattr.py]
+def __getattr__(name) -> str: ...
 
 [builtins fixtures/module.pyi]
 
@@ -1915,18 +1921,25 @@ def __getattr__(name: str) -> int: ...
 
 [builtins fixtures/module.pyi]
 
-[case testModuleLevelGetattrImportFromNotStub]
-from non_stub import name
-reveal_type(name)
+[case testModuleLevelGetattrImportFromNotStub36]
+# flags: --python-version 3.6
+from non_stub import name  # E: Module 'non_stub' has no attribute 'name'
+reveal_type(name)  # E: Revealed type is 'Any'
 
 [file non_stub.py]
 from typing import Any
 def __getattr__(name: str) -> Any: ...
 
-[out]
-tmp/non_stub.py:2: error: __getattr__ is not valid at the module level outside a stub file
-main:1: error: Module 'non_stub' has no attribute 'name'
-main:2: error: Revealed type is 'Any'
+[builtins fixtures/module.pyi]
+
+[case testModuleLevelGetattrImportFromNotStub37]
+# flags: --python-version 3.7
+from non_stub import name
+reveal_type(name)  # E: Revealed type is 'Any'
+
+[file non_stub.py]
+from typing import Any
+def __getattr__(name: str) -> Any: ...
 
 [builtins fixtures/module.pyi]
 


### PR DESCRIPTION
Fixes #4950 and implements PEP 562 for mypy.