### PR TITLE
Fine-grained: Support async def/for/with and await

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2530,12 +2530,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         """Analyse async iterable expression and return iterator and iterator item types."""
         echk = self.expr_checker
         iterable = echk.accept(expr)
-
-        self.check_subtype(iterable,
-                           self.named_generic_type('typing.AsyncIterable',
-                                                   [AnyType(TypeOfAny.special_form)]),
-                           expr, messages.ASYNC_ITERABLE_EXPECTED)
-
         method = echk.analyze_external_member_access('__aiter__', iterable, expr)
         iterator = echk.check_call(method, [], [], expr)[0]
         method = echk.analyze_external_member_access('__anext__', iterator, expr)
@@ -2558,11 +2552,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             return iterator, joined
         else:
             # Non-tuple iterable.
-            self.check_subtype(iterable,
-                               self.named_generic_type('typing.Iterable',
-                                                       [AnyType(TypeOfAny.special_form)]),
-                               expr, messages.ITERABLE_EXPECTED)
-
             if self.options.python_version[0] >= 3:
                 nextmethod = '__next__'
             else:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1422,7 +1422,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 elif (local_errors.is_errors() and
                     # is_valid_var_arg is True for any Iterable
                         self.is_valid_var_arg(right_type)):
-                    itertype = self.chk.analyze_iterable_item_type(right)
+                    _, itertype = self.chk.analyze_iterable_item_type(right)
                     method_type = CallableType(
                         [left_type],
                         [nodes.ARG_POS],
@@ -2290,9 +2290,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         for index, sequence, conditions, is_async in zip(e.indices, e.sequences,
                                                          e.condlists, e.is_async):
             if is_async:
-                sequence_type = self.chk.analyze_async_iterable_item_type(sequence)
+                _, sequence_type = self.chk.analyze_async_iterable_item_type(sequence)
             else:
-                sequence_type = self.chk.analyze_iterable_item_type(sequence)
+                _, sequence_type = self.chk.analyze_iterable_item_type(sequence)
             self.chk.analyze_index_variables(index, sequence_type, True, e)
             for condition in conditions:
                 self.accept(condition)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -887,6 +887,8 @@ class ForStmt(Statement):
     index_type = None  # type: Optional[mypy.types.Type]
     # Inferred iterable item type
     inferred_item_type = None  # type: Optional[mypy.types.Type]
+    # Inferred iterator type
+    inferred_iterator_type = None  # type: Optional[mypy.types.Type]
     # Expression to iterate
     expr = None  # type: Expression
     body = None  # type: Block

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -427,8 +427,12 @@ class DependencyVisitor(TraverserVisitor):
     def visit_with_stmt(self, o: WithStmt) -> None:
         super().visit_with_stmt(o)
         for e in o.expr:
-            self.add_attribute_dependency_for_expr(e, '__enter__')
-            self.add_attribute_dependency_for_expr(e, '__exit__')
+            if not o.is_async:
+                self.add_attribute_dependency_for_expr(e, '__enter__')
+                self.add_attribute_dependency_for_expr(e, '__exit__')
+            else:
+                self.add_attribute_dependency_for_expr(e, '__aenter__')
+                self.add_attribute_dependency_for_expr(e, '__aexit__')
         if o.target_type:
             self.add_type_dependencies(o.target_type)
 

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -92,7 +92,7 @@ from mypy.nodes import (
     ComparisonExpr, GeneratorExpr, DictionaryComprehension, StarExpr, PrintStmt, ForStmt, WithStmt,
     TupleExpr, ListExpr, OperatorAssignmentStmt, DelStmt, YieldFromExpr, Decorator, Block,
     TypeInfo, FuncBase, OverloadedFuncDef, RefExpr, SuperExpr, Var, NamedTupleExpr, TypedDictExpr,
-    LDEF, MDEF, GDEF, FuncItem, TypeAliasExpr, NewTypeExpr, ImportAll, EnumCallExpr,
+    LDEF, MDEF, GDEF, FuncItem, TypeAliasExpr, NewTypeExpr, ImportAll, EnumCallExpr, AwaitExpr,
     op_methods, reverse_op_methods, ops_with_inplace_method, unary_op_methods
 )
 from mypy.traverser import TraverserVisitor
@@ -166,7 +166,6 @@ class DependencyVisitor(TraverserVisitor):
         self.is_package_init_file = False
 
     # TODO (incomplete):
-    #   await
     #   protocols
 
     def visit_mypy_file(self, o: MypyFile) -> None:
@@ -566,6 +565,10 @@ class DependencyVisitor(TraverserVisitor):
     def visit_yield_from_expr(self, e: YieldFromExpr) -> None:
         super().visit_yield_from_expr(e)
         self.add_iter_dependency(e.expr)
+
+    def visit_await_expr(self, e: AwaitExpr) -> None:
+        super().visit_await_expr(e)
+        self.add_attribute_dependency_for_expr(e.expr, '__await__')
 
     # Helpers
 

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -163,7 +163,6 @@ async def f() -> None:
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-full.pyi]
 [out]
-main:4: error: AsyncIterable expected
 main:4: error: "List[int]" has no attribute "__aiter__"
 
 [case testAsyncForTypeComments]
@@ -247,14 +246,10 @@ async def wrong_iterable(obj: Iterable[int]):
     {i: i for i in asyncify(obj)}
 
 [out]
-main:18: error: AsyncIterable expected
-main:18: error: "Iterable[int]" has no attribute "__aiter__"; maybe "__iter__"?
-main:19: error: Iterable expected
-main:19: error: "asyncify[int]" has no attribute "__iter__"; maybe "__aiter__"?
-main:20: error: AsyncIterable expected
-main:20: error: "Iterable[int]" has no attribute "__aiter__"; maybe "__iter__"?
-main:21: error: Iterable expected
-main:21: error: "asyncify[int]" has no attribute "__iter__"; maybe "__aiter__"?
+main:18: error: "Iterable[int]" has no attribute "__aiter__"; maybe "__iter__"? (not async iterable)
+main:19: error: "asyncify[int]" has no attribute "__iter__"; maybe "__aiter__"? (not iterable)
+main:20: error: "Iterable[int]" has no attribute "__aiter__"; maybe "__iter__"? (not async iterable)
+main:21: error: "asyncify[int]" has no attribute "__iter__"; maybe "__aiter__"? (not iterable)
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-full.pyi]
 
@@ -538,7 +533,7 @@ async def h() -> None:
 from typing import AsyncGenerator
 
 async def gen() -> AsyncGenerator[int, None]:
-    for i in (1, 2, 3):
+    for i in [1, 2, 3]:
         yield i
 
 def h() -> None:
@@ -549,8 +544,7 @@ def h() -> None:
 [typing fixtures/typing-full.pyi]
 
 [out]
-main:9: error: Iterable expected
-main:9: error: "AsyncGenerator[int, None]" has no attribute "__iter__"; maybe "__aiter__"?
+main:9: error: "AsyncGenerator[int, None]" has no attribute "__iter__"; maybe "__aiter__"? (not iterable)
 
 [case testAsyncGeneratorNoYieldFrom]
 # flags: --fast-parser --python-version 3.6

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -163,7 +163,7 @@ async def f() -> None:
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-full.pyi]
 [out]
-main:4: error: "List[int]" has no attribute "__aiter__"
+main:4: error: "List[int]" has no attribute "__aiter__" (not async iterable)
 
 [case testAsyncForTypeComments]
 

--- a/test-data/unit/check-incomplete-fixture.test
+++ b/test-data/unit/check-incomplete-fixture.test
@@ -76,8 +76,7 @@ for y in x:
 -- avoid things getting worse.
 main:2: error: "tuple" expects no type arguments, but 1 given
 main:3: error: Value of type "tuple" is not indexable
-main:4: error: Iterable expected
-main:4: error: "tuple" has no attribute "__iter__"
+main:4: error: "tuple" has no attribute "__iter__" (not iterable)
 
 [case testClassmethodMissingFromStubs]
 class A:

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1563,7 +1563,7 @@ class A:
             pass
 [builtins fixtures/for.pyi]
 [out]
-main:5: error: "None" has no attribute "__iter__"
+main:5: error: "None" has no attribute "__iter__" (not iterable)
 
 [case testPartialTypeErrorSpecialCase2]
 # This used to crash.
@@ -1584,7 +1584,7 @@ class A:
             pass
 [builtins fixtures/for.pyi]
 [out]
-main:4: error: "None" has no attribute "__iter__"
+main:4: error: "None" has no attribute "__iter__" (not iterable)
 
 
 -- Multipass

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -869,8 +869,7 @@ a: Any
 d: Dict[str, Tuple[List[Tuple[str, str]], str]]
 x, _ = d.get(a, (None, None))
 
-for y in x: pass # E: Iterable expected \
-                 # E: Item "None" of "Optional[List[Tuple[str, str]]]" has no attribute "__iter__"
+for y in x: pass # E: Item "None" of "Optional[List[Tuple[str, str]]]" has no attribute "__iter__" (not iterable)
 if x:
     for s, t in x:
         reveal_type(s) # E: Revealed type is 'builtins.str'
@@ -886,8 +885,7 @@ x = None
 d: Dict[str, Tuple[List[Tuple[str, str]], str]]
 x, _ = d.get(a, (None, None))
 
-for y in x: pass # E: Iterable expected \
-                 # E: Item "None" of "Optional[List[Tuple[str, str]]]" has no attribute "__iter__"
+for y in x: pass # E: Item "None" of "Optional[List[Tuple[str, str]]]" has no attribute "__iter__" (not iterable)
 if x:
     for s, t in x:
         reveal_type(s) # E: Revealed type is 'builtins.str'

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -1024,3 +1024,46 @@ class B(Base):
 <mod.B> -> <m.f>, m.f
 <mod.Base> -> <m.f>, m.f
 <mod> -> m
+
+[case testCustomIterator]
+class A:
+    def __iter__(self) -> B: pass
+class B:
+    def __iter__(self) -> B: pass
+    def __next__(self) -> C: pass
+class C:
+    pass
+def f() -> None:
+    for x in A(): pass
+[out]
+<m.A.__getitem__> -> m.f
+<m.A.__init__> -> m.f
+<m.A.__iter__> -> m.f
+<m.A.__new__> -> m.f
+<m.A> -> m.A, m.f
+<m.B.__next__> -> m.f
+<m.B> -> <m.A.__iter__>, <m.B.__iter__>, m.A.__iter__, m.B, m.B.__iter__
+<m.C> -> <m.B.__next__>, m.B.__next__, m.C
+
+[case testCustomIterator_python2]
+class A:
+    def __iter__(self): # type: () -> B
+        pass
+class B:
+    def __iter__(self): # type: () -> B
+        pass
+    def next(self): # type: () -> C
+        pass
+class C:
+    pass
+def f(): # type: () -> None
+    for x in A(): pass
+[out]
+<m.A.__getitem__> -> m.f
+<m.A.__init__> -> m.f
+<m.A.__iter__> -> m.f
+<m.A.__new__> -> m.f
+<m.A> -> m.A, m.f
+<m.B.next> -> m.f
+<m.B> -> <m.A.__iter__>, <m.B.__iter__>, m.A.__iter__, m.B, m.B.__iter__
+<m.C> -> <m.B.next>, m.B.next, m.C

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -5846,3 +5846,40 @@ class C:
 [out]
 ==
 main:4: error: Incompatible return value type (got "str", expected "int")
+
+[case test__aiter__and__anext__]
+from a import C
+
+async def f() -> int:
+    async for x in C():
+        pass
+    return x
+
+[file a.py]
+class C:
+    def __aiter__(self) -> D: pass
+class D:
+    def __aiter__(self) -> D: pass
+    async def __anext__(self) -> int: return 0
+
+[file a.py.2]
+class C:
+    def __aiter__(self) -> D: pass
+class D:
+    def __aiter__(self) -> D: pass
+    async def __anext__(self) -> str: return ''
+
+[file a.py.3]
+class C:
+    def __aiter__(self) -> E: pass
+class E:
+    def __aiter__(self) -> E: pass
+    async def __anext__(self) -> object: return 0
+
+[builtins fixtures/async_await.pyi]
+[typing fixtures/typing-full.pyi]
+[out]
+==
+main:6: error: Incompatible return value type (got "str", expected "int")
+==
+main:6: error: Incompatible return value type (got "object", expected "int")

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -5800,3 +5800,49 @@ class M(type):
 [out]
 ==
 a.py:2: error: Argument 1 to "f" of "M" has incompatible type "int"; expected "str"
+
+[case testAwaitAndAsyncDef-skip-cache]
+from a import g
+
+async def f() -> int:
+    return await g()
+
+[file a.py]
+async def g() -> int:
+    return 0
+
+[file a.py.2]
+async def g() -> str:
+    return ''
+
+[builtins fixtures/async_await.pyi]
+[typing fixtures/typing-full.pyi]
+[out]
+==
+main:4: error: Incompatible return value type (got "str", expected "int")
+
+[case testAwaitAnd__await__-skip-cache]
+from a import C
+
+async def f(c: C) -> int:
+    return await c
+
+[file a.py]
+from typing import Any, Generator
+class C:
+    def __await__(self) -> Generator[Any, None, int]:
+        yield
+        return 0
+
+[file a.py.2]
+from typing import Any, Generator
+class C:
+    def __await__(self) -> Generator[Any, None, str]:
+        yield
+        return ''
+
+[builtins fixtures/async_await.pyi]
+[typing fixtures/typing-full.pyi]
+[out]
+==
+main:4: error: Incompatible return value type (got "str", expected "int")

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -5883,3 +5883,40 @@ class E:
 main:6: error: Incompatible return value type (got "str", expected "int")
 ==
 main:6: error: Incompatible return value type (got "object", expected "int")
+
+[case testAsyncWith2-skip-cache]
+from a import C
+
+async def f() -> int:
+    async with C() as x:
+        return x
+
+[file a.py]
+class C:
+    async def __aenter__(self) -> int: pass
+    async def __aexit__(self, x, y, z) -> None: pass
+
+[file a.py.2]
+class C:
+    async def __aenter__(self) -> str: pass
+    async def __aexit__(self, x, y, z) -> None: pass
+
+[file a.py.3]
+from typing import Awaitable
+class C:
+    async def __aenter__(self) -> int: pass
+    async def __aexit__(self, x, y, z) -> None: pass
+
+[file a.py.4]
+from typing import Awaitable
+class C:
+    async def __aenter__(self) -> int: pass
+
+[builtins fixtures/async_await.pyi]
+[typing fixtures/typing-full.pyi]
+[out]
+==
+main:5: error: Incompatible return value type (got "str", expected "int")
+==
+==
+main:4: error: "C" has no attribute "__aexit__"


### PR DESCRIPTION
Some of the changes motivated cleaning up some duplicate error 
messages.

Also noticed missing `__next__`/`next` dependency in ordinary for
statements and fixed it as well.

Work towards #4951.