### PR TITLE
Fine-grained: Trigger when abstract attributes change

### DIFF
--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -211,6 +211,8 @@ def snapshot_definition(node: Optional[SymbolNode],
                  snapshot_optional_type(node._promote))
         prefix = node.fullname()
         symbol_table = snapshot_symbol_table(prefix, node.names)
+        # Special dependency for abstract attribute handling.
+        symbol_table['(abstract)'] = ('Abstract', tuple(sorted(node.abstract_attributes)))
         return ('TypeInfo', common, attrs, symbol_table)
     else:
         # Other node types are handled elsewhere.

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -257,6 +257,10 @@ class DependencyVisitor(TraverserVisitor):
             # If the set of abstract attributes change, this may invalidate class
             # instantiation, or change the generated error message, since Python checks
             # class abstract status when creating an instance.
+            #
+            # TODO: We should probably add this dependency only from the __init__ of the
+            #     current class, and independent of bases (to trigger changes in message
+            #     wording, as errors may enumerate all abstract attributes).
             self.add_dependency(make_trigger(base_info.fullname() + '.(abstract)'),
                                 target=make_trigger(info.fullname() + '.__init__'))
             # If the base class abstract attributes change, subclass abstract

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -254,6 +254,14 @@ class DependencyVisitor(TraverserVisitor):
                                 target=make_trigger(info.fullname() + '.__init__'))
             self.add_dependency(make_trigger(base_info.fullname() + '.__new__'),
                                 target=make_trigger(info.fullname() + '.__new__'))
+            # If the set of abstract attributes change, this may invalidate class
+            # instantiation, or change the generated error message, since Python checks
+            # class abstract status when creating an instance.
+            self.add_dependency(make_trigger(base_info.fullname() + '.(abstract)'),
+                                target=make_trigger(info.fullname() + '.__init__'))
+            # If the base class abstract attributes change, subclass abstract
+            # attributes need to be recalculated.
+            self.add_dependency(make_trigger(base_info.fullname() + '.(abstract)'))
 
     def visit_import(self, o: Import) -> None:
         for id, as_id in o.ids:

--- a/test-data/unit/deps-classes.test
+++ b/test-data/unit/deps-classes.test
@@ -115,6 +115,7 @@ class D:
         class S2(C): pass
 [out]
 -- TODO: Is it okay to have targets like m.S1@4.__init__?
+<m.C.(abstract)> -> <m.S1@4.__init__>, <m.S2@8.__init__>, m.D.g, m.f
 <m.C.__init__> -> <m.S1@4.__init__>, <m.S2@8.__init__>
 <m.C.__new__> -> <m.S1@4.__new__>, <m.S2@8.__new__>
 <m.C> -> m.C, m.D.g, m.f
@@ -132,6 +133,7 @@ class D(C):
         super().__init__(x)
         super().foo()
 [out]
+<m.C.(abstract)> -> <m.D.__init__>, m
 <m.C.__init__> -> <m.D.__init__>, m.D.__init__
 <m.C.__new__> -> <m.D.__new__>
 <m.C.foo> -> <m.D.foo>
@@ -150,6 +152,7 @@ class D(C):
 def foo() -> None:
     D(6)
 [out]
+<m.C.(abstract)> -> <m.D.__init__>, m
 <m.C.__init__> -> <m.D.__init__>
 <m.C.__new__> -> <m.D.__new__>
 <m.C> -> m, m.C, m.D

--- a/test-data/unit/deps-generics.test
+++ b/test-data/unit/deps-generics.test
@@ -93,6 +93,7 @@ class A(Generic[T]): pass
 class B(A[C]): pass
 class C: pass
 [out]
+<m.A.(abstract)> -> <m.B.__init__>, m
 <m.A.__init__> -> <m.B.__init__>
 <m.A.__new__> -> <m.B.__new__>
 <m.A> -> m.A, m.B
@@ -108,6 +109,7 @@ T = TypeVar('T')
 class A(Generic[T]): pass
 class B(A[T]): pass
 [out]
+<m.A.(abstract)> -> <m.B.__init__>, m
 <m.A.__init__> -> <m.B.__init__>
 <m.A.__new__> -> <m.B.__new__>
 <m.A> -> m.A, m.B

--- a/test-data/unit/deps-statements.test
+++ b/test-data/unit/deps-statements.test
@@ -581,6 +581,7 @@ def f(x: A) -> A:
 def g() -> None: pass
 [builtins fixtures/isinstancelist.pyi]
 [out]
+<m.A.(abstract)> -> <m.B.__init__>, m
 <m.A.__init__> -> <m.B.__init__>
 <m.A.__new__> -> <m.B.__new__>
 <m.A> -> <m.f>, m, m.A, m.B, m.f
@@ -606,6 +607,7 @@ class C:
     def g(self) -> None: pass
 [builtins fixtures/isinstancelist.pyi]
 [out]
+<m.A.(abstract)> -> <m.B.__init__>, m
 <m.A.__init__> -> <m.B.__init__>
 <m.A.__new__> -> <m.B.__new__>
 <m.A> -> <m.C.f>, m, m.A, m.B, m.C.f
@@ -674,6 +676,7 @@ class C:
     x: int
 [out]
 <m.N> -> <m.f>, m, m.f
+<m.C.(abstract)> -> <m.N.__init__>, m
 <m.C.__init__> -> <m.N.__init__>
 <m.C.__new__> -> <m.N.__new__>
 <m.C.x> -> <m.N.x>

--- a/test-data/unit/deps-types.test
+++ b/test-data/unit/deps-types.test
@@ -383,6 +383,7 @@ class I: pass
 [out]
 <m.C> -> m.C
 <a.A> -> m
+<mod.I.(abstract)> -> <m.C.__init__>, m
 <mod.I.__init__> -> <m.C.__init__>
 <mod.I.__new__> -> <m.C.__new__>
 <mod.I> -> m, m.C
@@ -571,6 +572,7 @@ class I: pass
 <m.A> -> m
 <m.B> -> m
 <m.C> -> m.C
+<mod.I.(abstract)> -> <m.C.__init__>, m
 <mod.I.__init__> -> <m.C.__init__>, m
 <mod.I.__new__> -> <m.C.__new__>, m
 <mod.I> -> m, m.C

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -110,6 +110,7 @@ class A:
 class B(A):
     pass
 [out]
+<m.A.(abstract)> -> <m.B.__init__>, m
 <m.A.__init__> -> <m.B.__init__>
 <m.A.__new__> -> <m.B.__new__>
 <m.A> -> m, m.A, m.B
@@ -122,6 +123,7 @@ class B(A):
     def f(self) -> None:
         self.x = 1
 [out]
+<m.A.(abstract)> -> <m.B.__init__>, m
 <m.A.__init__> -> <m.B.__init__>
 <m.A.__new__> -> <m.B.__new__>
 <m.A.f> -> m.B.f
@@ -139,11 +141,13 @@ class C(B):
     def f(self) -> None:
         self.x = 1
 [out]
+<m.A.(abstract)> -> <m.B.__init__>, <m.C.__init__>, m
 <m.A.__init__> -> <m.B.__init__>, <m.C.__init__>
 <m.A.__new__> -> <m.B.__new__>, <m.C.__new__>
 <m.A.f> -> m.C.f
 <m.A.x> -> <m.C.x>
 <m.A> -> m, m.A, m.B
+<m.B.(abstract)> -> <m.C.__init__>, m
 <m.B.__init__> -> <m.C.__init__>
 <m.B.__new__> -> <m.C.__new__>
 <m.B.f> -> m.C.f
@@ -165,6 +169,7 @@ class A:
 [out]
 <m.B.x> -> m.B.f
 <m.B> -> m.B
+<n.A.(abstract)> -> <m.B.__init__>, m
 <n.A.__init__> -> <m.B.__init__>
 <n.A.__new__> -> <m.B.__new__>
 <n.A.f> -> m.B.f
@@ -180,6 +185,7 @@ class B(A):
     def f(self) -> None:
         self.g()
 [out]
+<m.A.(abstract)> -> <m.B.__init__>, m
 <m.A.__init__> -> <m.B.__init__>
 <m.A.__new__> -> <m.B.__new__>
 <m.A.f> -> m.B.f
@@ -1083,6 +1089,7 @@ class A(B):
 <m.D.x> -> m
 <m.D> -> m.D
 <mod.A> -> <m.D.x>, m
+<mod.C.(abstract)> -> <m.D.__init__>, m
 <mod.C.__init__> -> <m.D.__init__>
 <mod.C.__new__> -> <m.D.__new__>
 <mod.C.x> -> <m.D.x>
@@ -1105,6 +1112,7 @@ class A(B):
 <m.D.x> -> m.D.__init__
 <m.D> -> m.D
 <mod.A> -> <m.D.x>, m, m.D.__init__
+<mod.C.(abstract)> -> <m.D.__init__>, m
 <mod.C.__init__> -> <m.D.__init__>, m.D.__init__
 <mod.C.__new__> -> <m.D.__new__>
 <mod.C.x> -> <m.D.x>

--- a/test-data/unit/diff.test
+++ b/test-data/unit/diff.test
@@ -879,3 +879,19 @@ def outer() -> None:
     def inner(y: B) -> A:
         pass
 [out]
+
+[case testAddAbstractMethod]
+from abc import abstractmethod
+class A:
+    @abstractmethod
+    def f(self) -> None: pass
+[file next.py]
+from abc import abstractmethod
+class A:
+    @abstractmethod
+    def f(self) -> None: pass
+    @abstractmethod
+    def g(self) -> None: pass
+[out]
+__main__.A.(abstract)
+__main__.A.g

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -6074,3 +6074,95 @@ def deco(f: F) -> F:
 [out]
 ==
 main:5: error: Return type of "m" incompatible with supertype "B"
+
+[case testAddAbstractMethod]
+from b import D
+D()
+[file b.py]
+from a import C
+class D(C):
+    def f(self) -> None: pass
+[file a.py]
+from abc import abstractmethod
+class C:
+    @abstractmethod
+    def f(self) -> None: pass
+[file a.py.2]
+from abc import abstractmethod
+class C:
+    @abstractmethod
+    def f(self) -> None: pass
+    @abstractmethod
+    def g(self) -> None: pass
+[file a.py.3]
+from abc import abstractmethod
+class C:
+    @abstractmethod
+    def f(self) -> None: pass
+    def g(self) -> None: pass
+[out]
+==
+main:2: error: Cannot instantiate abstract class 'D' with abstract attribute 'g'
+==
+
+[case testMakeMethodNoLongerAbstract1]
+[file z.py]
+from abc import abstractmethod, ABCMeta
+class I(metaclass=ABCMeta):
+    @abstractmethod
+    def f(self) -> None: pass
+    @abstractmethod
+    def g(self) -> None: pass
+[file b.py]
+import z
+def x() -> Foo: return Foo()
+class Foo(z.I):
+    def f(self) -> None: pass
+    def g(self) -> None: pass
+
+[file z.py.2]
+from abc import abstractmethod, ABCMeta
+class I(metaclass=ABCMeta):
+    def f(self) -> None: pass
+    @abstractmethod
+    def g(self) -> None: pass
+
+[file b.py.2]
+import z
+def x() -> Foo: return Foo()
+class Foo(z.I):
+    def g(self) -> None: pass
+[out]
+==
+
+[case testMakeMethodNoLongerAbstract2]
+-- this version never failed, but it is just a file-renaming
+-- away from the above test that did
+[file a.py]
+from abc import abstractmethod, ABCMeta
+class I(metaclass=ABCMeta):
+    @abstractmethod
+    def f(self) -> None: pass
+    @abstractmethod
+    def g(self) -> None: pass
+[file b.py]
+import a
+def x() -> Foo: return Foo()
+class Foo(a.I):
+    def f(self) -> None: pass
+    def g(self) -> None: pass
+
+[file a.py.2]
+from abc import abstractmethod, ABCMeta
+class I(metaclass=ABCMeta):
+    def f(self) -> None: pass
+    @abstractmethod
+    def g(self) -> None: pass
+
+[file b.py.2]
+import a
+def x() -> Foo: return Foo()
+class Foo(a.I):
+    def g(self) -> None: pass
+[out]
+==

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -6105,6 +6105,21 @@ class C:
 main:2: error: Cannot instantiate abstract class 'D' with abstract attribute 'g'
 ==
 
+[case testMakeClassAbstract]
+from a import C
+c = C()
+[file a.py]
+from abc import abstractmethod
+class C: pass
+[file a.py.2]
+from abc import abstractmethod
+class C:
+    @abstractmethod
+    def f(self) -> None: pass
+[out]
+==
+main:2: error: Cannot instantiate abstract class 'C' with abstract attribute 'f'
+
 [case testMakeMethodNoLongerAbstract1]
 [file z.py]
 from abc import abstractmethod, ABCMeta


### PR DESCRIPTION
Add new kind of trigger `<ClsName.(abstract)>` which gets triggered when
the set of abstract attributes in a class change.

This is a more efficient alternative to #4922.