### PR TITLE
Fix fine-grained crash caused by unneeded extra parse_file()s

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1669,10 +1669,6 @@ class State:
     def is_interface_fresh(self) -> bool:
         return self.externally_same
 
-    def has_new_submodules(self) -> bool:
-        """Return if this module has new submodules after being loaded from a warm cache."""
-        return self.meta is not None and self.child_modules != set(self.meta.child_modules)
-
     def mark_as_rechecked(self) -> None:
         """Marks this module as having been fully re-analyzed by the type-checker."""
         self.manager.rechecked_modules.add(self.id)
@@ -2405,11 +2401,6 @@ def load_graph(sources: List[BuildSource], manager: BuildManager,
                 if dep in st.suppressed:
                     st.suppressed.remove(dep)
                     st.dependencies.append(dep)
-    for id, g in graph.items():
-        if g.has_new_submodules():
-            g.parse_file()
-            g.fix_suppressed_dependencies(graph)
-            g.mark_interface_stale()
     return graph
 
 

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -399,8 +399,9 @@ def ensure_trees_loaded(manager: BuildManager, graph: Dict[str, State],
     """Ensure that the modules in initial and their deps have loaded trees."""
     to_process = find_unloaded_deps(manager, graph, initial)
     if to_process:
-        manager.log_fine_grained("Calling process_fresh_modules on set of size {} ({})".format(
-            len(to_process), to_process))
+        if is_verbose(manager):
+            manager.log_fine_grained("Calling process_fresh_modules on set of size {} ({})".format(
+                len(to_process), sorted(to_process)))
         process_fresh_modules(graph, to_process, manager)
 
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -946,7 +946,8 @@ from parent import b
 
 [file parent/b.py.2]
 
-[stale parent, parent.a, parent.b]
+[stale parent.a, parent.b]
+[rechecked parent, parent.a, parent.b]
 
 [case testIncrementalReferenceExistingFileWithImportFrom]
 from parent import a, b

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -436,6 +436,18 @@ main:1: error: Cannot find module named 'p.q'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 ==
 
+[case testDeleteSubpackageWithNontrivialParent1]
+[file p/__init__.py]
+def g() -> None:
+    pass
+[file p/b.py.2]
+def foo() -> None: pass
+foo()
+[delete p/b.py.3]
+[out]
+==
+==
+
 [case testDeleteModuleWithError]
 import a
 [file a.py]


### PR DESCRIPTION
load_graph() contains code to parse ancestor modules that
get new children. Since load_graph() did not communicate that
these modules had been parsed to fine-grained mode, this caused
problems with fine-grained mode.

That code was added in #1865 to fix a bug where 'import from'
of a newly added submodule would not work in incremental mode
because it didn't appear in the parent module's symbol table.
The need to reload the parent to fix this was obviated by #2061,
which makes semantic analysis directly inspect the modules map
when doing 'import from' to find possible submodules.

Since the code isn't needed any more and it is causing trouble,
we just remove it.

I would like to cherry-pick this into 0.600 (#4946).