### PR TITLE
Recompute lib_path on every fine-grained incremental run

### DIFF
--- a/mypy/test/testerrorstream.py
+++ b/mypy/test/testerrorstream.py
@@ -40,7 +40,6 @@ def test_error_stream(testcase: DataDrivenTestCase) -> None:
     try:
         build.build(sources=sources,
                     options=options,
-                    alt_lib_path=test_temp_dir,
                     flush_errors=flush_errors)
     except CompileError as e:
         assert e.messages == []

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -5,6 +5,11 @@ incremental steps. We verify that each step produces the expected output.
 
 See the comment at the top of test-data/unit/fine-grained.test for more
 information.
+
+N.B.: Unlike most of the other test suites, testfinegrained does not
+rely on an alt_lib_path for finding source files. This means that they
+can test interactions with the lib_path that is built implicitly based
+on specified sources.
 """
 
 import os
@@ -84,7 +89,7 @@ class FineGrainedSuite(DataSuite):
             config = None
         if config:
             parse_config_file(options, config)
-        server = Server(options, alt_lib_path=test_temp_dir)
+        server = Server(options)
 
         step = 1
         sources = self.parse_sources(main_src, step, options)
@@ -186,8 +191,7 @@ class FineGrainedSuite(DataSuite):
               sources: List[BuildSource]) -> List[str]:
         try:
             result = build.build(sources=sources,
-                                 options=options,
-                                 alt_lib_path=test_temp_dir)
+                                 options=options)
         except CompileError as e:
             return e.messages
         return result.errors

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -484,6 +484,28 @@ def f(x: int) -> None: pass
 [out]
 ==
 
+[case testDeleteSubpackageInit1]
+# cmd: mypy q/r/s.py
+# flags: --follow-imports=skip --ignore-missing-imports
+[file q/__init__.py]
+[file q/r/__init__.py]
+[file q/r/s.py]
+[delete q/__init__.py.2]
+[out]
+==
+
+[case testAddSubpackageInit2]
+# cmd: mypy q/r/s.py
+# flags: --follow-imports=skip --ignore-missing-imports
+[file q/r/__init__.py]
+[file q/r/s.py]
+1
+[file q/r/s.py.2]
+2
+[file q/__init__.py.2]
+[out]
+==
+
 [case testModifyTwoFilesNoError2]
 import a
 [file a.py]


### PR DESCRIPTION
This fixes some crashes and false positives when creating or removing
__init__.py files that do not appear in the build.

This just factors out the existing implementation of lib_path
computation and reuses it. It is somewhat inefficient and should be
improved on if we are going to call it on every fine-grained update.

I would like to cherry-pick this into 0.600 (#4946).
There is going to be a follow up PR immediately that optimizes the `lib_path` recomputation, but the case for cherry-picking that is a lot harder to make than for just a straightforward bug fix.
The cost of recomputing every time is about ~125ms on S.