### PR TITLE
Fix refresh of functions with implicit optional arguments

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -174,11 +174,15 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         # Names of type aliases encountered while analysing a type will be collected here.
         self.aliases_used = set()  # type: Set[str]
 
-    def visit_unbound_type(self, t: UnboundType, ignore_optional: bool = False) -> Type:
-        if t.optional and not ignore_optional:
+    def visit_unbound_type(self, t: UnboundType) -> Type:
+        typ = self.visit_unbound_type_nonoptional(t)
+        if t.optional:
             # We don't need to worry about double-wrapping Optionals or
             # wrapping Anys: Union simplification will take care of that.
-            return make_optional_type(self.visit_unbound_type(t, ignore_optional=True))
+            return make_optional_type(typ)
+        return typ
+
+    def visit_unbound_type_nonoptional(self, t: UnboundType) -> Type:
         sym = self.lookup(t.name, t, suppress_errors=self.third_pass)
         if '.' in t.name:
             # Handle indirect references to imported names.

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -174,12 +174,11 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         # Names of type aliases encountered while analysing a type will be collected here.
         self.aliases_used = set()  # type: Set[str]
 
-    def visit_unbound_type(self, t: UnboundType) -> Type:
-        if t.optional:
-            t.optional = False
+    def visit_unbound_type(self, t: UnboundType, ignore_optional: bool = False) -> Type:
+        if t.optional and not ignore_optional:
             # We don't need to worry about double-wrapping Optionals or
             # wrapping Anys: Union simplification will take care of that.
-            return make_optional_type(self.visit_unbound_type(t))
+            return make_optional_type(self.visit_unbound_type(t, ignore_optional=True))
         sym = self.lookup(t.name, t, suppress_errors=self.third_pass)
         if '.' in t.name:
             # Handle indirect references to imported names.

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2014,7 +2014,7 @@ class C:
 
 x = C(foo=12)
 x.a # E: "C" has no attribute "a"
-C(foo='') # E: Argument "foo" to "C" has incompatible type "str"; expected "int"
+C(foo='') # E: Argument "foo" to "C" has incompatible type "str"; expected "Optional[int]"
 [builtins fixtures/__new__.pyi]
 
 [case testConstructInstanceWithDynamicallyTyped__new__]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -6310,3 +6310,15 @@ class Foo(a.I):
     def g(self) -> None: pass
 [out]
 ==
+
+[case testImplicitOptionalRefresh1]
+# flags: --strict-optional
+from x import f
+def foo(x: int=None) -> None:
+    f()
+[file x.py]
+def f() -> int: return 0
+[file x.py.2]
+def f() -> str: return '0'
+[out]
+==

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -6314,7 +6314,7 @@ class Foo(a.I):
 [case testImplicitOptionalRefresh1]
 # flags: --strict-optional
 from x import f
-def foo(x: int=None) -> None:
+def foo(x: int = None) -> None:
     f()
 [file x.py]
 def f() -> int: return 0


### PR DESCRIPTION
Type analysis would clear t.optional, so it wouldn't be there on
future runs.

This bug also apparently caused `__new__` methods to not pick up
Optional from implicit optional arguments?