### PR TITLE
Fix some aststrip import bugs

### DIFF
--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -180,6 +180,8 @@ class NodeStripVisitor(TraverserVisitor):
                 self.process_lvalue_in_method(item)
 
     def visit_import_from(self, node: ImportFrom) -> None:
+        # Imports can include both overriding symbols and fresh ones,
+        # and we need to clear both.
         node.assignments = []
 
         # If the node is unreachable, don't reset entries: they point to something else!
@@ -200,7 +202,7 @@ class NodeStripVisitor(TraverserVisitor):
                     self.names[imported_name] = sym
 
     def visit_import(self, node: Import) -> None:
-        node.assignments = []
+        assert not node.assignments
 
         # If the node is unreachable, don't reset entries: they point to something else!
         if node.is_unreachable: return
@@ -216,6 +218,8 @@ class NodeStripVisitor(TraverserVisitor):
                 symnode.node = None
 
     def visit_import_all(self, node: ImportAll) -> None:
+        # Imports can include both overriding symbols and fresh ones,
+        # and we need to clear both.
         node.assignments = []
 
         # If the node is unreachable, we don't want to reset entries from a reachable import.

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1588,7 +1588,8 @@ x = ''
 ==
 ==
 
-[case testImportStarSomethingMoved1]
+[case testImportStarSomethingMoved]
+import p
 [file p.py]
 from r2 import *
 [file r2.py]

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1588,6 +1588,39 @@ x = ''
 ==
 ==
 
+[case testImportStarSomethingMoved1]
+[file p.py]
+from r2 import *
+[file r2.py]
+class A: pass
+
+[file p.py.2]
+from r1 import *
+from r2 import *
+[file r2.py.2]
+
+[file r1.py.2]
+class A: pass
+
+[out]
+==
+
+[case testImportPartialAssign]
+import a
+[file a.py]
+from c import *
+from b import A, x
+[file b.py]
+A = 10
+x = 1
+[file b.py.2]
+class A: pass
+x = 1
+[file c.py]
+x = 10
+[out]
+==
+
 [case testDeleteFileWithErrors]
 # cmd: mypy main a.py
 # cmd2: mypy main


### PR DESCRIPTION
Strip `assignments` in ImportAll nodes and clear `names` even
if there are assignments.

Diff looks bigger than it really is because some conditional code was made unconditional. Suggest ignoring whitespace changes when looking at it, which github just added a handy checkbox under "diff settings" to do!