### PR TITLE
Add mention of --check-untyped-defs option to docs

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -30,7 +30,8 @@ flagged as an error.
   do not have any annotations (neither for any argument nor for the
   return type) are not type-checked, and even the most blatant type
   errors (e.g. ``2 + 'a'``) pass silently.  The solution is to add
-  annotations.
+  annotations. Where that isn't possible, functions without annotations
+  can be checked using ``--check-untyped-defs``.
 
   Example:
 


### PR DESCRIPTION
On my first try of `mypy`, I was disappointed that I couldn't find a way to get `mypy` to complain about this source:

~~~py
def fn_a(x: int) -> None:
	pass

def fn_b():
	fn_a('silly argument')
~~~

I would have found it helpful if the *No errors reported for obviously wrong code* section had mentioned the `--check-untyped-defs` option. I suspect others might also benefit from adding this brief mention.

Thanks very much.