### PR TITLE
Create socket file in /tmp

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -80,7 +80,7 @@ def daemonize(func: Callable[[], None], log_file: Optional[str] = None) -> int:
 
 # Server code.
 
-SOCKET_NAME = 'dmypy.sock'  # In current directory.
+SOCKET_NAME = '/tmp/dmypy.sock'
 
 
 def process_start_options(flags: List[str]) -> Options:

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import socket
 import sys
+import tempfile
 import time
 import traceback
 
@@ -81,7 +82,7 @@ def daemonize(func: Callable[[], None], log_file: Optional[str] = None) -> int:
 
 # Server code.
 
-SOCKET_NAME = '/tmp/dmypy.sock'
+SOCKET_NAME = 'dmypy.sock'
 
 
 def process_start_options(flags: List[str]) -> Options:

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -10,6 +10,7 @@ import gc
 import io
 import json
 import os
+import shutil
 import socket
 import sys
 import time
@@ -187,7 +188,7 @@ class Server:
             finally:
                 os.unlink(STATUS_FILE)
         finally:
-            os.unlink(self.sockname)
+            shutil.rmtree(self.sock_directory)
             exc_info = sys.exc_info()
             if exc_info[0] and exc_info[0] is not SystemExit:
                 traceback.print_exception(*exc_info)  # type: ignore
@@ -197,11 +198,10 @@ class Server:
 
     def create_listening_socket(self) -> socket.socket:
         """Create the socket and set it up for listening."""
-        self.sockname = os.path.abspath(SOCKET_NAME)
-        if os.path.exists(self.sockname):
-            os.unlink(self.sockname)
+        self.sock_directory = tempfile.mkdtemp()
+        sockname = os.path.join(self.sock_directory, SOCKET_NAME)
         sock = socket.socket(socket.AF_UNIX)
-        sock.bind(self.sockname)
+        sock.bind(sockname)
         sock.listen(1)
         return sock
 


### PR DESCRIPTION
When the mypy daemon runs in Windows Subsystem for Linux (WSL) under a [DriveFs](https://blogs.msdn.microsoft.com/wsl/2016/04/22/windows-subsystem-for-linux-overview/) directory, it would fail to bind to the socket file.

From mypy/dmypy_server.py:
```
sock = socket.socket(socket.AF_UNIX)
sock.bind(self.sockname)  # <-- stuck here
sock.listen(1)
```

This pull request changes the path to `/tmp`, so on Windows it will be always created under the `VolFs`, which provides full support for Linux file system features.