### PR TITLE
Fix access to operators on metaclass through typevar

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2431,6 +2431,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Does type have member with the given name?"""
         # TODO: refactor this to use checkmember.analyze_member_access, otherwise
         # these two should be carefully kept in sync.
+        if isinstance(typ, TypeVarType):
+            typ = typ.upper_bound
+        if isinstance(typ, TupleType):
+            typ = typ.fallback
         if isinstance(typ, Instance):
             return typ.type.has_readable_member(member)
         if isinstance(typ, CallableType) and typ.is_type_obj():
@@ -2440,8 +2444,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         elif isinstance(typ, UnionType):
             result = all(self.has_member(x, member) for x in typ.relevant_items())
             return result
-        elif isinstance(typ, TupleType):
-            return self.has_member(typ.fallback, member)
         elif isinstance(typ, TypeType):
             # Type[Union[X, ...]] is always normalized to Union[Type[X], ...],
             # so we don't need to care about unions here.

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2445,9 +2445,14 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         elif isinstance(typ, TypeType):
             # Type[Union[X, ...]] is always normalized to Union[Type[X], ...],
             # so we don't need to care about unions here.
-            if isinstance(typ.item, Instance) and typ.item.type.metaclass_type is not None:
-                return self.has_member(typ.item.type.metaclass_type, member)
-            if isinstance(typ.item, AnyType):
+            item = typ.item
+            if isinstance(item, TypeVarType):
+                item = item.upper_bound
+            if isinstance(item, TupleType):
+                item = item.fallback
+            if isinstance(item, Instance) and item.type.metaclass_type is not None:
+                return self.has_member(item.type.metaclass_type, member)
+            if isinstance(item, AnyType):
                 return True
             return False
         else:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3459,6 +3459,23 @@ class Concrete(metaclass=Meta):
 reveal_type(Concrete + X())  # E: Revealed type is 'builtins.str'
 Concrete + "hello"  # E: Unsupported operand types for + ("Type[Concrete]" and "str")
 
+[case testMetaclassOperatorTypeVar]
+from typing import Type, TypeVar
+
+class MetaClass(type):
+    def __mul__(cls, other: int) -> str:
+        return ""
+
+class Test(metaclass=MetaClass):
+    pass
+
+S = TypeVar("S", bound=Test)
+
+def f(x: Type[Test]) -> str:
+    return x * 0
+def g(x: Type[S]) -> str:
+    return x * 0
+
 [case testMetaclassGetitem]
 class M(type):
     def __getitem__(self, key) -> int: return 1

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3474,7 +3474,7 @@ S = TypeVar("S", bound=Test)
 def f(x: Type[Test]) -> str:
     return x * 0
 def g(x: Type[S]) -> str:
-    return x * 0
+    return reveal_type(x * 0)  # E: Revealed type is 'builtins.str'
 
 [case testMetaclassGetitem]
 class M(type):

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1604,17 +1604,33 @@ def f(a: T, b: T) -> T:
         return b
 [builtins fixtures/ops.pyi]
 
-[case testTypeVariableTypeLessThan]
+[case testTypeVarLessThan]
 from typing import TypeVar
 T = TypeVar('T')
 def f(a: T, b: T) -> T:
-    if a < b:
+    if a < b:  # E: Unsupported left operand type for < ("T")
         return a
     else:
         return b
 [builtins fixtures/ops.pyi]
-[out]
-main:4: error: Unsupported left operand type for < ("T")
+
+[case testTypeVarReversibleOperator]
+from typing import TypeVar
+class A:
+    def __mul__(cls, other: int) -> str: return ""
+T = TypeVar("T", bound=A)
+def f(x: T) -> str:
+    return reveal_type(x * 0)  # E: Revealed type is 'builtins.str'
+
+[case testTypeVarReversibleOperatorTuple]
+from typing import TypeVar, Tuple
+class A(Tuple[int, int]):
+    def __mul__(cls, other: Tuple[int, int]) -> str: return ""
+T = TypeVar("T", bound=A)
+def f(x: T) -> str:
+    return reveal_type(x * (1, 2) )  # E: Revealed type is 'builtins.str'
+
+[builtins fixtures/tuple.pyi]
 
 
 -- Subtyping generic callables

--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -14,6 +14,7 @@ class tuple(Sequence[Tco], Generic[Tco]):
     def __iter__(self) -> Iterator[Tco]: pass
     def __contains__(self, item: object) -> bool: pass
     def __getitem__(self, x: int) -> Tco: pass
+    def __rmul__(self, n: int) -> tuple: pass
     def count(self, obj: Any) -> int: pass
 class function: pass
 class ellipsis: pass

--- a/test-data/unit/lib-stub/builtins.pyi
+++ b/test-data/unit/lib-stub/builtins.pyi
@@ -7,6 +7,7 @@ class type:
 # These are provided here for convenience.
 class int:
     def __add__(self, other: 'int') -> 'int': pass
+    def __rmul__(self, other: 'int') -> 'int': pass
 class float: pass
 
 class str:


### PR DESCRIPTION
Fix #4929: typevars were not handled correctly on `has_member`.

The test uses multiplication instead of addition since adding `__radd__` to the stub reveals several inconsistencies in unrelated tests.