### PR TITLE
Cleanup runtests.py

### DIFF
--- a/waiter.py
+++ b/waiter.py
@@ -9,16 +9,12 @@ import os
 from multiprocessing import cpu_count
 import pipes
 import re
-from subprocess import Popen, STDOUT, DEVNULL
+from subprocess import Popen, STDOUT
 import sys
 import tempfile
 import time
 import json
 from collections import defaultdict
-
-
-class WaiterError(Exception):
-    pass
 
 
 class LazySubprocess:
@@ -400,16 +396,6 @@ def parse_test_stats_from_output(output: str, fail_type: Optional[str]) -> Tuple
             counts[key] = int(count)
         return (sum(c for k, c in counts.items() if k != 'deselected'),
                 counts.get('failed', 0))
-
-    # myunit
-    m = re.search('^([0-9]+)/([0-9]+) test cases failed(, ([0-9]+) skipped)?.$', output,
-                  re.MULTILINE)
-    if m:
-        return int(m.group(2)), int(m.group(1))
-    m = re.search('^([0-9]+) test cases run(, ([0-9]+) skipped)?, all passed.$', output,
-                  re.MULTILINE)
-    if m:
-        return int(m.group(1)), 0
 
     # Couldn't find test counts, so fall back to single test per tasks.
     if fail_type is not None:


### PR DESCRIPTION
Continue #1673. Remove unused functions and some other minor changes in the test runner.

The main intention is to remove noise so that changes required for moving further tests to pytest (and eventually dropping the test runner) will be easier to understand.