### PR TITLE
Update protocol caches when generating fg caches on incremental build

### DIFF
--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -81,22 +81,13 @@ class FineGrainedSuite(DataSuite):
             f.write(main_src)
 
         options = self.get_options(main_src, testcase, build_cache=False)
-        for name, _ in testcase.files:
-            if 'mypy.ini' in name:
-                config = name  # type: Optional[str]
-                break
-        else:
-            config = None
-        if config:
-            parse_config_file(options, config)
+        build_options = self.get_options(main_src, testcase, build_cache=True)
         server = Server(options)
 
+        build_steps = self.get_build_steps(main_src)
         step = 1
         sources = self.parse_sources(main_src, step, options)
-        if self.use_cache:
-            build_options = self.get_options(main_src, testcase, build_cache=True)
-            if config:
-                parse_config_file(build_options, config)
+        if step <= build_steps:
             messages = self.build(build_options, sources)
         else:
             messages = self.run_check(server, sources)
@@ -122,7 +113,11 @@ class FineGrainedSuite(DataSuite):
                     # Delete file
                     os.remove(op.path)
             sources = self.parse_sources(main_src, step, options)
-            new_messages = self.run_check(server, sources)
+
+            if step <= build_steps:
+                new_messages = self.build(build_options, sources)
+            else:
+                new_messages = self.run_check(server, sources)
 
             updated = []  # type: List[str]
             changed = []  # type: List[str]
@@ -179,6 +174,11 @@ class FineGrainedSuite(DataSuite):
         if options.follow_imports == 'normal':
             options.follow_imports = 'error'
 
+        for name, _ in testcase.files:
+            if 'mypy.ini' in name:
+                parse_config_file(options, name)
+                break
+
         return options
 
     def run_check(self, server: Server, sources: List[BuildSource]) -> List[str]:
@@ -204,6 +204,14 @@ class FineGrainedSuite(DataSuite):
             filtered = sorted(filtered)
             result.append(('%d: %s' % (n + 2, ', '.join(filtered))).strip())
         return result
+
+    def get_build_steps(self, program_text: str) -> int:
+        if not self.use_cache:
+            return 0
+        m = re.search('# num_build_steps: ([0-9]+)$', program_text, flags=re.MULTILINE)
+        if m is not None:
+            return int(m.group(1))
+        return 1
 
     def parse_sources(self, program_text: str,
                       incremental_step: int,

--- a/mypy/test/testfinegrainedcache.py
+++ b/mypy/test/testfinegrainedcache.py
@@ -11,3 +11,5 @@ import mypy.test.testfinegrained
 class FineGrainedCacheSuite(mypy.test.testfinegrained.FineGrainedSuite):
     use_cache = True
     test_name_suffix = '_cached'
+    files = (
+        mypy.test.testfinegrained.FineGrainedSuite.files + ['fine-grained-cache-incremental.test'])

--- a/test-data/unit/fine-grained-cache-incremental.test
+++ b/test-data/unit/fine-grained-cache-incremental.test
@@ -1,0 +1,167 @@
+-- Test cases for building caches for fine-grained mode using incremental
+-- builds.
+--
+-- '# num_build_steps: N' specifies how many build steps to do before
+-- switching to running using the daemon.
+
+
+-- Add file
+-- --------
+
+
+[case testIncrCacheBasic1]
+# num_build_steps: 2
+import a
+[file a.py]
+from b import x
+def f() -> int:
+    return 0
+[file b.py]
+x = 1
+[file a.py.2]
+from b import x
+def f() -> int:
+    return 0 + x
+[file b.py.3]
+x = 'hi'
+[out]
+==
+==
+a.py:3: error: Unsupported operand types for + ("int" and "str")
+
+[case testIncrCacheBasic2]
+# num_build_steps: 2
+import a
+[file a.py]
+from b import x
+def f() -> int:
+    return 0+x
+[file b.py]
+x = 1
+[file b.py.2]
+from c import x
+[file c.py.2]
+x = 1
+[file c.py.3]
+x = 'hi'
+[out]
+==
+==
+a.py:3: error: Unsupported operand types for + ("int" and "str")
+
+[case testIncrCacheProtocol1]
+# num_build_steps: 2
+import a
+[file a.py]
+import b
+from typing import Protocol
+class P(Protocol):
+    x: int
+def f() -> None:
+    def g(x: P) -> None:
+        pass
+    g(b.C())
+[file c.py]
+[file c.py.2]
+# yo
+[file b.py]
+class C:
+    x: int
+[file b.py.3]
+class C:
+    x: str
+-- If we did a *full* reload (because the proto cache failed to load),
+-- nothing would show up as stale
+[stale2 b]
+[rechecked2 a, b]
+[out]
+==
+==
+a.py:8: error: Argument 1 to "g" has incompatible type "C"; expected "P"
+a.py:8: note: Following member(s) of "C" have conflicts:
+a.py:8: note:     x: expected "int", got "str"
+
+[case testIncrCacheProtocol2]
+# num_build_steps: 3
+import a
+[file a.py]
+import b
+from typing import Protocol
+class P(Protocol):
+    x: int
+class Q(Protocol):
+    x: int
+def f() -> None:
+    def g(x: P) -> None:
+        pass
+    g(b.C())
+[file c.py]
+[file c.py.2]
+# uh
+[file c.py.3]
+from a import Q
+import b
+def f() -> None:
+    def g(x: Q) -> None:
+        pass
+    g(b.C())
+[file b.py]
+class C:
+    x: int
+[file b.py.4]
+class C:
+    x: str
+-- If we did a *full* reload (because the proto cache failed to load),
+-- nothing would show up as stale
+[stale3 b]
+[rechecked3 a, b, c]
+[out]
+==
+==
+==
+c.py:6: error: Argument 1 to "g" has incompatible type "C"; expected "Q"
+c.py:6: note: Following member(s) of "C" have conflicts:
+c.py:6: note:     x: expected "int", got "str"
+a.py:10: error: Argument 1 to "g" has incompatible type "C"; expected "P"
+a.py:10: note: Following member(s) of "C" have conflicts:
+a.py:10: note:     x: expected "int", got "str"
+
+[case testIncrCacheProtocol3]
+# num_build_steps: 2
+import a
+[file a.py]
+import b
+from typing import Protocol
+class P(Protocol):
+    x: int
+def f() -> None:
+    def g(x: P) -> None:
+        pass
+    g(b.C())
+[file c.py]
+[file c.py.2]
+# yo
+[file b.py]
+class C:
+    x: int
+[file b.py.3]
+class C:
+    x: int
+    y: int
+[file b.py.4]
+class C:
+    x: str
+    y: int
+-- If we did a *full* reload (because the proto cache failed to load),
+-- nothing would show up as stale
+[stale2 b]
+[rechecked2 b]
+[stale3 b]
+[rechecked3 a, b]
+[out]
+==
+==
+==
+a.py:8: error: Argument 1 to "g" has incompatible type "C"; expected "P"
+a.py:8: note: Following member(s) of "C" have conflicts:
+a.py:8: note:     x: expected "int", got "str"


### PR DESCRIPTION
Previously using `--cache-fine-grained` and `--incremental` together
would produce invalid protocol caches, which would prevent using
`--incremental` to quickly generate fine-grained cache artifacts.

This also adds machinery to `testfinegrained` to test building cache
artifacts using incremental runs.