### PR TITLE
Allow multiple shadow files to be specified

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -468,7 +468,8 @@ Here are some more useful flags:
   make transformations to a file before type checking without having to change
   the file in-place.  (For example, tooling could use this to display the type
   of an expression by wrapping it with a call to reveal_type in the shadow
-  file and then parsing the output.)
+  file and then parsing the output.) This argument may be specified multiple times
+  to make mypy substitute multiple different files with their shadow replacements.
 
 .. _no-implicit-optional:
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -655,9 +655,14 @@ class BuildManager:
         self.fscache = fscache
         self.find_module_cache = FindModuleCache(self.fscache)
 
-        # a mapping from files to their corresponding shadow files
+        # a mapping from source files to their corresponding shadow files
+        # for efficient lookup
         self.shadow_map = {}  # type: Dict[str, str]
-        # a mapping from incoming files to files that exist in the shadow map
+        if self.options.shadow_file is not None:
+            self.shadow_map = {source_file: shadow_file
+                               for (source_file, shadow_file)
+                               in self.options.shadow_file}
+        # a mapping from typechecked files to files to their possible shadow files
         self.shadow_equivalence_map = {}  # type: Dict[str, Optional[str]]
 
     def use_fine_grained_cache(self) -> bool:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -662,7 +662,7 @@ class BuildManager:
             self.shadow_map = {source_file: shadow_file
                                for (source_file, shadow_file)
                                in self.options.shadow_file}
-        # a mapping from typechecked files to files to their possible shadow files
+        # a mapping from each file being typechecked to its possible shadow file
         self.shadow_equivalence_map = {}  # type: Dict[str, Optional[str]]
 
     def use_fine_grained_cache(self) -> bool:

--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -149,6 +149,11 @@ class FileSystemCache:
             self.read(path)
         return self.hash_cache[path]
 
+    def samefile(self, f1: str, f2: str) -> bool:
+        s1 = self.stat(f1)
+        s2 = self.stat(f2)
+        return os.path.samestat(s1, s2)
+
 
 def copy_os_error(e: OSError) -> OSError:
     new = OSError(*e.args)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -463,7 +463,7 @@ def process_options(args: List[str],
     parser.add_argument('--strict', action='store_true', dest='special-opts:strict',
                         help=strict_help)
     parser.add_argument('--shadow-file', nargs=2, metavar=('SOURCE_FILE', 'SHADOW_FILE'),
-                        dest='shadow_file',
+                        dest='shadow_file', action='append',
                         help='Typecheck SHADOW_FILE in place of SOURCE_FILE.')
     # hidden options
     # --debug-cache will disable any cache-related compressions/optimizations,

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -185,7 +185,7 @@ class Options:
         self.use_builtins_fixtures = False
 
         # -- experimental options --
-        self.shadow_file = None  # type: Optional[Tuple[str, str]]
+        self.shadow_file = None  # type: Optional[List[Tuple[str, str]]]
         self.show_column_numbers = False  # type: bool
         self.dump_graph = False
         self.dump_deps = False

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1126,6 +1126,45 @@ follow_imports_for_stubs = True
 import math
 math.frobnicate()
 
+[case testShadowFile1]
+# cmd: mypy --shadow-file source.py shadow.py source.py
+[file source.py]
+def foo() -> str:
+    return "bar"
+[file shadow.py]
+def bar() -> str:
+    return 14
+[out]
+source.py:2: error: Incompatible return value type (got "int", expected "str")
+
+[case testShadowFile2]
+# cmd: mypy --shadow-file s1.py shad1.py --shadow-file s2.py shad2.py --shadow-file s3.py shad3.py s1.py s2.py s3.py s4.py
+[file s1.py]
+def foo() -> str:
+    return "bar"
+[file shad1.py]
+def bar() -> str:
+    return 14
+[file s2.py]
+def baz() -> str:
+    return 14
+[file shad2.py]
+def baz() -> int:
+    return 14
+[file s3.py]
+def qux() -> str:
+    return "bar"
+[file shad3.py]
+def foo() -> int:
+    return [42]
+[file s4.py]
+def foo() -> str:
+    return 9
+[out]
+s4.py:2: error: Incompatible return value type (got "int", expected "str")
+s3.py:2: error: Incompatible return value type (got "List[int]", expected "int")
+s1.py:2: error: Incompatible return value type (got "int", expected "str")
+
 [case testConfigWarnUnusedSection1]
 # cmd: mypy foo.py quux.py spam/eggs.py
 # flags: --follow-imports=skip


### PR DESCRIPTION
This pull request allows the `--shadow-file` argument to be specified multiple times, allowing multiple different source files to be replaced by their corresponding shadow files.

Tests have also been added to ensure the original and new behaviors both work.