### PR TITLE
Add support for setuptools eggs with PEP 561 searching

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -831,10 +831,12 @@ class FindModuleCache:
         self.dirs = {}  # type: Dict[Tuple[str, Tuple[str, ...]], List[str]]
         # Cache find_module: (id, lib_path, python_version) -> result.
         self.results = {}  # type: Dict[Tuple[str, Tuple[str, ...], Optional[str]], Optional[str]]
+        self.package_dirs = {}  # type: Dict[Optional[str], List[str]]
 
     def clear(self) -> None:
         self.results.clear()
         self.dirs.clear()
+        self.package_dirs.clear()
 
     def find_lib_path_dirs(self, dir_chain: str, lib_path: Tuple[str, ...]) -> List[str]:
         # Cache some repeated work within distinct find_module calls: finding which
@@ -854,6 +856,69 @@ class FindModuleCache:
             if self.fscache.isdir(dir):
                 dirs.append(dir)
         return dirs
+
+    def _get_egg_packages(self, base_dir: str) -> List[str]:
+        egg_dirs = []
+        for item in self.fscache.listdir(base_dir):
+            if item.endswith('.egg'):
+                # eggs are either directories with packages and distribution data,
+                # or zipped versions of the same.
+                # TODO(ethanhs) support zip eggs?
+                absitem = os.path.join(base_dir, item)
+                if self.fscache.isdir(absitem):
+                    egg_dirs.append(absitem)
+            elif item.endswith('.egg-link') and self.fscache.isfile(os.path.join(base_dir, item)):
+                # egg-links are portable "symlink" stand-ins. The first line is a relative
+                # or absolute path to an egg distribution, the second line is the base of
+                # the relative path, if applicable.
+                src_lines = self.fscache.read(os.path.join(base_dir, item)).decode().splitlines()
+                if len(src_lines) == 1:
+                    # For backwards compatibility, it is possible there is
+                    # only one line in the link.
+                    path = src_lines[0]
+                elif len(src_lines) == 2:
+                    # This is the more common "relative" path form.
+                    rel_path, base = src_lines
+                    if not os.path.abspath(rel_path):
+                        path = os.path.normpath(os.path.join(base, rel_path))
+                    else:
+                        path = rel_path
+                else:
+                    # this should never happen
+                    continue
+                if self.fscache.isdir(path):
+                    if path.endswith('.egg'):
+                        # if the symlink points directly to an egg, we can just add that directory
+                        egg_dirs.append(path)
+                    elif path.endswith('.egg-info'):
+                        # if it is an egg-info directory, we need to add the directory above
+                        egg_dirs.append(os.path.dirname(path))
+                    else:
+                        # Otherwise, we were given the directory above an egg or egg-info,
+                        # so we need to search for one of them.
+                        egg_dirs.extend(self._get_egg_packages(path))
+        return egg_dirs
+
+    def get_package_dirs(self, python_executable: Optional[str]) -> List[str]:
+        """Find all directories packages could be installed in.
+
+        This includes *.egg directories, *.egg-links, and site-package directories"""
+        # Cache finding package directories, as this sometimes requires reading
+        # a file (which is expensive!)
+        if python_executable not in self.package_dirs:
+            self.package_dirs[python_executable] = self._get_package_dirs(python_executable)
+        return self.package_dirs[python_executable]
+
+    def _get_package_dirs(self, python_executable: Optional[str]) -> List[str]:
+        # Search for egg directories. This is an annoying complexity introduced by setuptools.
+        # It is documented here: https://github.com/pypa/setuptools/blob/master/docs/formats.txt
+        possible_package_dirs = _get_site_packages_dirs(python_executable)
+        # annoyingly, Debian based OSes list non-existent site-package directories...
+        site_dirs = [dir for dir in possible_package_dirs if self.fscache.exists(dir)]
+        package_dirs = site_dirs[:]
+        for dir in site_dirs:
+            package_dirs.extend(self._get_egg_packages(dir))
+        return package_dirs
 
     def find_module(self, id: str, lib_path: Tuple[str, ...],
                     python_executable: Optional[str]) -> Optional[str]:
@@ -880,7 +945,7 @@ class FindModuleCache:
         third_party_inline_dirs = []
         third_party_stubs_dirs = []
         # Third-party stub/typed packages
-        for pkg_dir in _get_site_packages_dirs(python_executable):
+        for pkg_dir in self.get_package_dirs(python_executable):
             stub_name = components[0] + '-stubs'
             typed_file = os.path.join(pkg_dir, components[0], 'py.typed')
             stub_dir = os.path.join(pkg_dir, stub_name)
@@ -892,6 +957,7 @@ class FindModuleCache:
             elif fscache.isfile(typed_file):
                 path = os.path.join(pkg_dir, dir_chain)
                 third_party_inline_dirs.append(path)
+
         candidate_base_dirs = self.find_lib_path_dirs(dir_chain, lib_path) + \
             third_party_stubs_dirs + third_party_inline_dirs
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -887,16 +887,20 @@ class FindModuleCache:
                     # this should never happen
                     continue
                 if self.fscache.isdir(path):
-                    if path.endswith('.egg'):
+                    if path.endswith('.egg') and self.fscache.isdir(path):
                         # if the symlink points directly to an egg, we can just add that directory
                         egg_dirs.append(path)
                     elif path.endswith('.egg-info'):
                         # if it is an egg-info directory, we need to add the directory above
                         egg_dirs.append(os.path.dirname(path))
                     else:
-                        # Otherwise, we were given the directory above an egg or egg-info,
-                        # so we need to search for one of them.
-                        egg_dirs.extend(self._get_egg_packages(path))
+                        if self.fscache.exists(os.path.join(path, item[:-9])):
+                            # Egg links share the same prefix, so we can guess if they exist.
+                            egg_dirs.append(path)
+                        else:
+                            # Otherwise, we were given the directory above an egg,
+                            # so we need to search for one of them.
+                            egg_dirs.extend(self._get_egg_packages(path))
         return egg_dirs
 
     def get_package_dirs(self, python_executable: Optional[str]) -> List[str]:

--- a/mypy/sitepkgs.py
+++ b/mypy/sitepkgs.py
@@ -7,7 +7,8 @@ library found in Python 2. This file is run each mypy run, so it should be kept 
 possible.
 """
 
-
+import sys
+sys.path = sys.path[1:]  # remove current directory to avoid importing mypy.types
 from distutils.sysconfig import get_python_lib
 import site
 MYPY = False

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -77,10 +77,11 @@ class TestPEP561(TestCase):
         try:
             yield
         finally:
-            returncode, lines = run_command([python_executable, '-m', 'pip', 'uninstall',
-                                             '-y', pkg], cwd=package_path)
-            if returncode != 0:
-                self.fail('\n'.join(lines))
+            if not virtualenv:
+                returncode, lines = run_command([python_executable, '-m', 'pip', 'uninstall',
+                                                '-y', pkg], cwd=package_path)
+                if returncode != 0:
+                    self.fail('\n'.join(lines))
 
     def test_get_pkg_dirs(self) -> None:
         """Check that get_package_dirs works."""

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -6,10 +6,12 @@ from typing import Iterator, List
 from unittest import TestCase, main
 
 import mypy.api
-from mypy.build import FindModuleCache, _get_site_packages_dirs
-from mypy.test.config import package_path
+from mypy.build import _get_site_packages_dirs
+from mypy.test.config import package_path, test_temp_dir
 from mypy.test.helpers import run_command
 from mypy.util import try_find_python2_interpreter
+
+test_dir = 'test-packages-data'
 
 SIMPLE_PROGRAM = """
 from typedpkg.sample import ex
@@ -43,16 +45,22 @@ def is_in_venv() -> bool:
 
 class TestPEP561(TestCase):
     @contextmanager
-    def install_package(self, pkg: str,
+    def install_package(self, pkg: str, editable: bool = False, use_pip: bool = True,
                         python_executable: str = sys.executable) -> Iterator[None]:
         """Context manager to temporarily install a package from test-data/packages/pkg/"""
         working_dir = os.path.join(package_path, pkg)
-        install_cmd = [python_executable, '-m', 'pip', 'install', '.']
+        if use_pip:
+            install_cmd = ['-m', 'pip', 'install']
+            if editable:
+                install_cmd.append('e')
+            install_cmd.append('.')
+        else:
+            install_cmd = ['setup.py', 'install']
         # if we aren't in a virtualenv, install in the
         # user package directory so we don't need sudo
         if not is_in_venv() or python_executable != sys.executable:
             install_cmd.append('--user')
-        returncode, lines = run_command(install_cmd, cwd=working_dir)
+        returncode, lines = run_command([python_executable] + install_cmd, cwd=working_dir)
         if returncode != 0:
             self.fail('\n'.join(lines))
         try:
@@ -75,41 +83,45 @@ class TestPEP561(TestCase):
         installing/uninstalling will break tests.
         """
         test_file = 'simple.py'
-        if not os.path.isdir('test-packages-data'):
-            os.mkdir('test-packages-data')
+        if not os.path.isdir(test_dir):
+            os.mkdir(test_dir)
         old_cwd = os.getcwd()
-        os.chdir('test-packages-data')
+        os.chdir(test_dir)
         with open(test_file, 'w') as f:
             f.write(SIMPLE_PROGRAM)
         try:
+            # First test each type of install works
+
+            # Normal pip and install (most packages are installed this way)
             with self.install_package('typedpkg-stubs'):
                 check_mypy_run(
                     [test_file],
                     "simple.py:4: error: Revealed type is 'builtins.list[builtins.str]'\n"
                 )
+            # Editable install (test egg-links)
+            with self.install_package('typedpkg-stubs', editable=True):
+                check_mypy_run(
+                    [test_file],
+                    "simple.py:4: error: Revealed type is 'builtins.list[builtins.str]'\n"
+                )
+            # Uncompressed egg install (setuptools with zip_safe=False)
+            with self.install_package('typedpkg-stubs', editable=True, use_pip=False):
+                check_mypy_run(
+                    [test_file],
+                    "simple.py:4: error: Revealed type is 'builtins.list[builtins.str]'\n"
+                )
 
-            # The Python 2 tests are intentionally placed after a Python 3 test to check
+            # The Python 2 tests are intentionally placed after Python 3 tests to check
             # the package_dir_cache is behaving correctly.
             python2 = try_find_python2_interpreter()
             if python2:
-                with self.install_package('typedpkg-stubs', python2):
+                with self.install_package('typedpkg-stubs', python_executable=python2):
                     check_mypy_run(
                         ['--python-executable={}'.format(python2), test_file],
                         "simple.py:4: error: Revealed type is 'builtins.list[builtins.str]'\n"
                     )
-                with self.install_package('typedpkg', python2):
-                    check_mypy_run(
-                        ['--python-executable={}'.format(python2), 'simple.py'],
-                        "simple.py:4: error: Revealed type is 'builtins.tuple[builtins.str]'\n"
-                    )
 
-                with self.install_package('typedpkg', python2):
-                    with self.install_package('typedpkg-stubs', python2):
-                        check_mypy_run(
-                            ['--python-executable={}'.format(python2), test_file],
-                            "simple.py:4: error: Revealed type is 'builtins.list[builtins.str]'\n"
-                        )
-
+            # Now test ordering of module resolution order
             with self.install_package('typedpkg'):
                 check_mypy_run(
                     [test_file],
@@ -124,7 +136,7 @@ class TestPEP561(TestCase):
                     )
         finally:
             os.chdir(old_cwd)
-            shutil.rmtree('test-packages-data')
+            shutil.rmtree(test_dir)
 
 
 if __name__ == '__main__':

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -120,14 +120,6 @@ class TestPEP561(TestCase):
                     [test_file],
                     "simple.py:4: error: Revealed type is 'builtins.list[builtins.str]'\n"
                 )
-            # Uncompressed egg install (setuptools with zip_safe=False)
-            python = make_venv('typedpkg-stubs', False, sys.executable)
-            with self.install_package('typedpkg-stubs', use_pip=False, python_executable=python, virtualenv=True):
-                check_mypy_run(
-                    ['--python-executable={}'.format(python), test_file],
-                    "simple.py:4: error: Revealed type is 'builtins.list[builtins.str]'\n"
-                )
-            shutil.rmtree(os.path.join(package_path, 'typedpkg-stubsvenv'))
 
             # The Python 2 tests are intentionally placed after Python 3 tests to check
             # the package_dir_cache is behaving correctly.

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -52,7 +52,7 @@ class TestPEP561(TestCase):
         if use_pip:
             install_cmd = ['-m', 'pip', 'install']
             if editable:
-                install_cmd.append('e')
+                install_cmd.append('-e')
             install_cmd.append('.')
         else:
             install_cmd = ['setup.py', 'install']
@@ -105,7 +105,7 @@ class TestPEP561(TestCase):
                     "simple.py:4: error: Revealed type is 'builtins.list[builtins.str]'\n"
                 )
             # Uncompressed egg install (setuptools with zip_safe=False)
-            with self.install_package('typedpkg-stubs', editable=True, use_pip=False):
+            with self.install_package('typedpkg-stubs', use_pip=False):
                 check_mypy_run(
                     [test_file],
                     "simple.py:4: error: Revealed type is 'builtins.list[builtins.str]'\n"

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -23,7 +23,7 @@ reveal_type(a)
 def make_venv(pkg: str, python_executable: str) -> str:
     """Create virtualenv and return path to new executable"""
     base = pkg + 'venv'
-    run_command([sys.executable, '-m', 'virtualenv', '-p={}'.format(python_executable), base])
+    run_command([sys.executable, '-m', 'virtualenv', '-p{}'.format(python_executable), base])
     if sys.platform == 'win32':
         return os.path.join(base, 'Scripts', 'python.exe')
     else:

--- a/test-data/packages/typedpkg-stubs/setup.py
+++ b/test-data/packages/typedpkg-stubs/setup.py
@@ -2,7 +2,7 @@
 This setup file installs packages to test mypy's PEP 561 implementation
 """
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='typedpkg-stubs',
@@ -10,4 +10,5 @@ setup(
     version='0.1',
     package_data={'typedpkg-stubs': ['sample.pyi', '__init__.pyi']},
     packages=['typedpkg-stubs'],
+    zip_safe=False,
 )

--- a/test-data/packages/typedpkg/setup.py
+++ b/test-data/packages/typedpkg/setup.py
@@ -2,7 +2,7 @@
 This setup file installs packages to test mypy's PEP 561 implementation
 """
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='typedpkg',
@@ -11,4 +11,5 @@ setup(
     package_data={'typedpkg': ['py.typed']},
     packages=['typedpkg'],
     include_package_data=True,
+    zip_safe=False,
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,3 +9,4 @@ pytest-cov>=2.4.0
 typed-ast>=1.1.0,<1.2.0
 typing>=3.5.2; python_version < '3.5'
 py>=1.5.2
+virtualenv


### PR DESCRIPTION
Setuptools installs packages differently from wheels or normal
distutils, using "eggs". Eggs have three main formats that differ from the
normal method: editable, compressed, and uncompressed. This change adds
support for editable and uncompressed egg installs.

Before reviewing I *highly* recommend reading https://github.com/pypa/setuptools/blob/master/docs/formats.txt which describes the egg format.

There is also a work around for the fact that Ubuntu (and I believe all Debian based Linuxes) list non-existent site-package directories...

This fixes much of #5007, I will work on compressed egg installs on the flight to Cleveland :)