### PR TITLE
getting_started: Clarify Python 2 situation

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -13,6 +13,9 @@ you can install mypy with:
 
     $ python3 -m pip install mypy
 
+Note that ``mypy`` itself requires Python 3, but you can still check Python 2
+code using ``mypy`` as discussed in :ref:`python2`.
+
 Installing from source
 **********************
 


### PR DESCRIPTION
The Getting Started page currently makes it sound like
mypy is only for Python 3.  Add a clarifying note that
although mypy itself requires Python 3 it can be used
to check Python 2 code.