### PR TITLE
Add an 'auto' command to dmypy that starts/restarts the server as needed

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -85,12 +85,12 @@ def daemonize(func: Callable[[], None], log_file: Optional[str] = None) -> int:
 SOCKET_NAME = 'dmypy.sock'
 
 
-def process_start_options(flags: List[str]) -> Options:
+def process_start_options(flags: List[str], allow_sources: bool) -> Options:
     import mypy.main
     sources, options = mypy.main.process_options(['-i'] + flags,
                                                  require_targets=False,
                                                  server_options=True)
-    if sources:
+    if sources and not allow_sources:
         sys.exit("dmypy: start/restart does not accept sources")
     if options.report_dirs:
         sys.exit("dmypy: start/restart cannot generate reports")
@@ -117,6 +117,8 @@ class Server:
                  timeout: Optional[int] = None) -> None:
         """Initialize the server with the desired mypy flags."""
         self.options = options
+        # Snapshot the options info before we muck with it, to detect changes
+        self.options_snapshot = dict(options.__dict__)
         self.timeout = timeout
         self.fine_grained_manager = None  # type: Optional[FineGrainedBuildManager]
 
@@ -225,6 +227,21 @@ class Server:
         return {}
 
     last_sources = None  # type: List[mypy.build.BuildSource]
+
+    def cmd_auto(self, args: Sequence[str]) -> Dict[str, object]:
+        """Check a list of files, triggering a restart if needed."""
+        try:
+            self.last_sources, options = mypy.main.process_options(
+                ['-i'] + list(args),
+                require_targets=True,
+                server_options=True,
+                fscache=self.fscache)
+            # Signal that we need to restart if the options have changed
+            if self.options_snapshot != options.__dict__:
+                return {'error': 'Must restart', 'out': 'configuration changed'}
+        except InvalidSourceList as err:
+            return {'out': '', 'err': str(err), 'status': 2}
+        return self.check(self.last_sources)
 
     def cmd_check(self, files: Sequence[str]) -> Dict[str, object]:
         """Check a list of files."""


### PR DESCRIPTION
If the daemon is not running, auto starts the daemon.
In addition, when invoked with auto, the daemon checks
its configuration and restarts if it has changed.

This should be more or less the behavior that most projects smaller
than a hundred or two kloc want, so it is nice to include.

Bigger projects will still want to do things like switching on branch
changes/rebases and downloading cache artifacts from a CI system,
which still requires external scripting. Potentially we could add
plugin hooks in the future to allow registering code that can signal
when a restart is needed and be called when the daemon is started.

Is there a better name for this than 'auto', though?