### PR TITLE
Fix an aststrip crash bug

### DIFF
--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -229,7 +229,8 @@ class NodeStripVisitor(TraverserVisitor):
         # (The description in visit_import is relevant here as well.)
         if self.names:
             for name in node.imported_names:
-                del self.names[name]
+                if name in self.names:
+                    del self.names[name]
         node.imported_names = []
 
     def visit_for_stmt(self, node: ForStmt) -> None:

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1606,6 +1606,23 @@ class A: pass
 [out]
 ==
 
+[case testImportStarOverlap]
+from b import *
+from c import *  # type: ignore
+[file b.py]
+from d import T
+[file c.py]
+from d import T
+[file c.py.2]
+from d import T
+z = 10
+[file d.py]
+from typing import TypeVar
+T = TypeVar('T')
+[out]
+==
+
+
 [case testImportPartialAssign]
 import a
 [file a.py]


### PR DESCRIPTION
Found in Zulip. In some cases (involving errors), two import *s could
list overlapping imported_names.