### PR TITLE
Remove "builtins." from output for overloads and builtins.None

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -754,7 +754,8 @@ class MessageBuilder:
         arg_types_str = ', '.join(self.format(arg) for arg in arg_types)
         num_args = len(arg_types)
         if num_args == 0:
-            self.fail('All overload variants{} require at least one argument'.format(name_str))
+            self.fail('All overload variants{} require at least one argument'.format(name_str),
+                      context)
         elif num_args == 1:
             self.fail('No overload variant{} matches argument type {}'
                       .format(name_str, arg_types_str), context)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -747,11 +747,12 @@ class MessageBuilder:
     def no_variant_matches_arguments(self, overload: Overloaded, arg_types: List[Type],
                                      context: Context) -> None:
         name = callable_name(overload)
+        arg_types_str = "[{}]".format(', '.join(self.format_bare(arg) for arg in arg_types))
         if name:
             self.fail('No overload variant of {} matches argument types {}'
-                      .format(name, arg_types), context)
+                      .format(name, arg_types_str), context)
         else:
-            self.fail('No overload variant matches argument types {}'.format(arg_types), context)
+            self.fail('No overload variant matches argument types {}'.format(arg_types_str), context)
 
     def wrong_number_values_to_unpack(self, provided: int, expected: int,
                                       context: Context) -> None:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -747,12 +747,20 @@ class MessageBuilder:
     def no_variant_matches_arguments(self, overload: Overloaded, arg_types: List[Type],
                                      context: Context) -> None:
         name = callable_name(overload)
-        arg_types_str = "[{}]".format(', '.join(self.format_bare(arg) for arg in arg_types))
         if name:
-            self.fail('No overload variant of {} matches argument types {}'
-                      .format(name, arg_types_str), context)
+            name_str = ' of {}'.format(name)
         else:
-            self.fail('No overload variant matches argument types {}'.format(arg_types_str), context)
+            name_str = ''
+        arg_types_str = ', '.join(self.format(arg) for arg in arg_types)
+        num_args = len(arg_types)
+        if num_args == 0:
+            self.fail('All overload variants{} require at least one argument'.format(name_str))
+        elif num_args == 1:
+            self.fail('No overload variant{} matches argument type {}'
+                      .format(name_str, arg_types_str), context)
+        else:
+            self.fail('No overload variant{} matches argument types {}'
+                      .format(name_str, arg_types_str), context)
 
     def wrong_number_values_to_unpack(self, provided: int, expected: int,
                                       context: Context) -> None:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1680,8 +1680,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         return 'Any'
 
     def visit_none_type(self, t: NoneTyp) -> str:
-        # Fully qualify to make this distinct from the None value.
-        return "builtins.None"
+        return "None"
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> str:
         return "<nothing>"

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -525,7 +525,7 @@ B().f(1)
 a = B() # type: A
 a.f(1)
 a.f('')
-a.f(B()) # E: No overload variant of "f" of "A" matches argument types [B]
+a.f(B()) # E: No overload variant of "f" of "A" matches argument type "B"
 
 [case testOverloadedAbstractMethodWithAlternativeDecoratorOrder]
 from foo import *
@@ -552,7 +552,7 @@ B().f(1)
 a = B() # type: A
 a.f(1)
 a.f('')
-a.f(B()) # E: No overload variant of "f" of "A" matches argument types [B]
+a.f(B()) # E: No overload variant of "f" of "A" matches argument type "B"
 
 [case testOverloadedAbstractMethodVariantMissingDecorator1]
 from foo import *

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -525,7 +525,7 @@ B().f(1)
 a = B() # type: A
 a.f(1)
 a.f('')
-a.f(B()) # E: No overload variant of "f" of "A" matches argument types [foo.B]
+a.f(B()) # E: No overload variant of "f" of "A" matches argument types [B]
 
 [case testOverloadedAbstractMethodWithAlternativeDecoratorOrder]
 from foo import *
@@ -552,7 +552,7 @@ B().f(1)
 a = B() # type: A
 a.f(1)
 a.f('')
-a.f(B()) # E: No overload variant of "f" of "A" matches argument types [foo.B]
+a.f(B()) # E: No overload variant of "f" of "A" matches argument types [B]
 
 [case testOverloadedAbstractMethodVariantMissingDecorator1]
 from foo import *

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -441,8 +441,8 @@ async def g() -> AsyncGenerator[int, None]:
     yield 'not an int'  # E: Incompatible types in "yield" (actual type "str", expected type "int")
     # return without a value is fine
     return
-reveal_type(g)  # E: Revealed type is 'def () -> typing.AsyncGenerator[builtins.int, builtins.None]'
-reveal_type(g())  # E: Revealed type is 'typing.AsyncGenerator[builtins.int, builtins.None]'
+reveal_type(g)  # E: Revealed type is 'def () -> typing.AsyncGenerator[builtins.int, None]'
+reveal_type(g())  # E: Revealed type is 'typing.AsyncGenerator[builtins.int, None]'
 
 async def h() -> None:
     async for item in g():
@@ -481,7 +481,7 @@ async def genfunc() -> AsyncGenerator[int, None]:
 async def user() -> None:
     gen = genfunc()
 
-    reveal_type(gen.__aiter__())  # E: Revealed type is 'typing.AsyncGenerator[builtins.int*, builtins.None]'
+    reveal_type(gen.__aiter__())  # E: Revealed type is 'typing.AsyncGenerator[builtins.int*, None]'
 
     reveal_type(await gen.__anext__())  # E: Revealed type is 'builtins.int*'
 

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -523,7 +523,7 @@ class Overloader(NamedTuple):
 
 reveal_type(Overloader(1).method('string'))  # E: Revealed type is 'builtins.str'
 reveal_type(Overloader(1).method(1))  # E: Revealed type is 'builtins.int'
-Overloader(1).method(('tuple',))  # E: No overload variant of "method" of "Overloader" matches argument types [Tuple[builtins.str]]
+Overloader(1).method(('tuple',))  # E: No overload variant of "method" of "Overloader" matches argument types [Tuple[str]]
 
 [case testNewNamedTupleMethodInheritance]
 from typing import NamedTuple, TypeVar

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -523,7 +523,7 @@ class Overloader(NamedTuple):
 
 reveal_type(Overloader(1).method('string'))  # E: Revealed type is 'builtins.str'
 reveal_type(Overloader(1).method(1))  # E: Revealed type is 'builtins.int'
-Overloader(1).method(('tuple',))  # E: No overload variant of "method" of "Overloader" matches argument types [Tuple[str]]
+Overloader(1).method(('tuple',))  # E: No overload variant of "method" of "Overloader" matches argument type "Tuple[str]"
 
 [case testNewNamedTupleMethodInheritance]
 from typing import NamedTuple, TypeVar

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -408,7 +408,7 @@ class HasNone(NamedTuple):
     x: int
     y: Optional[int] = None
 
-reveal_type(HasNone(1))  # E: Revealed type is 'Tuple[builtins.int, Union[builtins.int, builtins.None], fallback=__main__.HasNone]'
+reveal_type(HasNone(1))  # E: Revealed type is 'Tuple[builtins.int, Union[builtins.int, None], fallback=__main__.HasNone]'
 
 class Parameterized(NamedTuple):
     x: int
@@ -438,7 +438,7 @@ class HasNone(NamedTuple):
     x: int
     y: Optional[int] = None
 
-reveal_type(HasNone(1))  # E: Revealed type is 'Tuple[builtins.int, Union[builtins.int, builtins.None], fallback=__main__.HasNone]'
+reveal_type(HasNone(1))  # E: Revealed type is 'Tuple[builtins.int, Union[builtins.int, None], fallback=__main__.HasNone]'
 HasNone(None)  # E: Argument 1 to "HasNone" has incompatible type "None"; expected "int"
 HasNone(1, y=None)
 HasNone(1, y=2)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1224,7 +1224,7 @@ class D:
 [builtins fixtures/bool.pyi]
 [out]
 main:5: error: Revealed type is 'Any'
-main:5: error: No overload variant of "__get__" of "D" matches argument types [builtins.None, Type[__main__.A]]
+main:5: error: No overload variant of "__get__" of "D" matches argument types [None, Type[__main__.A]]
 main:6: error: Revealed type is 'Any'
 main:6: error: No overload variant of "__get__" of "D" matches argument types [__main__.A, Type[__main__.A]]
 
@@ -1324,7 +1324,7 @@ class D(Generic[T, V]):
 [builtins fixtures/bool.pyi]
 [out]
 main:5: error: Revealed type is 'Any'
-main:5: error: No overload variant of "__get__" of "D" matches argument types [builtins.None, Type[__main__.A]]
+main:5: error: No overload variant of "__get__" of "D" matches argument types [None, Type[__main__.A]]
 
 [case testAccessingNonDataDescriptorSubclass]
 from typing import Any

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1224,9 +1224,9 @@ class D:
 [builtins fixtures/bool.pyi]
 [out]
 main:5: error: Revealed type is 'Any'
-main:5: error: No overload variant of "__get__" of "D" matches argument types [None, Type[A]]
+main:5: error: No overload variant of "__get__" of "D" matches argument types "None", "Type[A]"
 main:6: error: Revealed type is 'Any'
-main:6: error: No overload variant of "__get__" of "D" matches argument types [A, Type[A]]
+main:6: error: No overload variant of "__get__" of "D" matches argument types "A", "Type[A]"
 
 
 [case testAccessingGenericNonDataDescriptor]
@@ -1324,7 +1324,7 @@ class D(Generic[T, V]):
 [builtins fixtures/bool.pyi]
 [out]
 main:5: error: Revealed type is 'Any'
-main:5: error: No overload variant of "__get__" of "D" matches argument types [None, Type[A]]
+main:5: error: No overload variant of "__get__" of "D" matches argument types "None", "Type[A]"
 
 [case testAccessingNonDataDescriptorSubclass]
 from typing import Any
@@ -2094,7 +2094,7 @@ class C:
 c = C(1)
 c.a # E: "C" has no attribute "a"
 C('', '')
-C('') # E: No overload variant of "C" matches argument types [str]
+C('') # E: No overload variant of "C" matches argument type "str"
 [builtins fixtures/__new__.pyi]
 
 
@@ -2516,7 +2516,7 @@ def new(uc: Type[U]) -> U:
 u = new(User)
 [builtins fixtures/classmethod.pyi]
 [out]
-tmp/foo.pyi:16: error: No overload variant of "User" matches argument types [str]
+tmp/foo.pyi:16: error: No overload variant of "User" matches argument type "str"
 tmp/foo.pyi:17: error: Too many arguments for "foo" of "User"
 
 [case testTypeUsingTypeCInUpperBound]
@@ -2712,7 +2712,7 @@ def f(a: int) -> None: pass
 def mock() -> type: return User
 
 f(User)
-f(mock())  # E: No overload variant of "f" matches argument types [type]
+f(mock())  # E: No overload variant of "f" matches argument type "type"
 [builtins fixtures/classmethod.pyi]
 [out]
 
@@ -2728,7 +2728,7 @@ def f(a: Type[User]) -> None: pass
 @overload
 def f(a: type) -> None: pass
 
-f(3)  # E: No overload variant of "f" matches argument types [int]
+f(3)  # E: No overload variant of "f" matches argument type "int"
 [builtins fixtures/classmethod.pyi]
 [out]
 
@@ -2745,7 +2745,7 @@ def f(a: Type[User]) -> None: pass
 def f(a: int) -> None: pass
 
 f(User)
-f(User())  # E: No overload variant of "f" matches argument types [User]
+f(User())  # E: No overload variant of "f" matches argument type "User"
 [builtins fixtures/classmethod.pyi]
 [out]
 
@@ -2766,10 +2766,10 @@ def f(a: Type[B]) -> None: pass
 @overload
 def f(a: int) -> None: pass
 
-f(A)  # E: No overload variant of "f" matches argument types [Type[A]]
+f(A)  # E: No overload variant of "f" matches argument type "Type[A]"
 f(B)
 f(C)
-f(AType)  # E: No overload variant of "f" matches argument types [Type[A]]
+f(AType)  # E: No overload variant of "f" matches argument type "Type[A]"
 f(BType)
 f(CType)
 [builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1224,9 +1224,9 @@ class D:
 [builtins fixtures/bool.pyi]
 [out]
 main:5: error: Revealed type is 'Any'
-main:5: error: No overload variant of "__get__" of "D" matches argument types [None, Type[__main__.A]]
+main:5: error: No overload variant of "__get__" of "D" matches argument types [None, Type[A]]
 main:6: error: Revealed type is 'Any'
-main:6: error: No overload variant of "__get__" of "D" matches argument types [__main__.A, Type[__main__.A]]
+main:6: error: No overload variant of "__get__" of "D" matches argument types [A, Type[A]]
 
 
 [case testAccessingGenericNonDataDescriptor]
@@ -1324,7 +1324,7 @@ class D(Generic[T, V]):
 [builtins fixtures/bool.pyi]
 [out]
 main:5: error: Revealed type is 'Any'
-main:5: error: No overload variant of "__get__" of "D" matches argument types [None, Type[__main__.A]]
+main:5: error: No overload variant of "__get__" of "D" matches argument types [None, Type[A]]
 
 [case testAccessingNonDataDescriptorSubclass]
 from typing import Any
@@ -2094,7 +2094,7 @@ class C:
 c = C(1)
 c.a # E: "C" has no attribute "a"
 C('', '')
-C('') # E: No overload variant of "C" matches argument types [builtins.str]
+C('') # E: No overload variant of "C" matches argument types [str]
 [builtins fixtures/__new__.pyi]
 
 
@@ -2516,7 +2516,7 @@ def new(uc: Type[U]) -> U:
 u = new(User)
 [builtins fixtures/classmethod.pyi]
 [out]
-tmp/foo.pyi:16: error: No overload variant of "User" matches argument types [builtins.str]
+tmp/foo.pyi:16: error: No overload variant of "User" matches argument types [str]
 tmp/foo.pyi:17: error: Too many arguments for "foo" of "User"
 
 [case testTypeUsingTypeCInUpperBound]
@@ -2712,7 +2712,7 @@ def f(a: int) -> None: pass
 def mock() -> type: return User
 
 f(User)
-f(mock())  # E: No overload variant of "f" matches argument types [builtins.type]
+f(mock())  # E: No overload variant of "f" matches argument types [type]
 [builtins fixtures/classmethod.pyi]
 [out]
 
@@ -2728,7 +2728,7 @@ def f(a: Type[User]) -> None: pass
 @overload
 def f(a: type) -> None: pass
 
-f(3)  # E: No overload variant of "f" matches argument types [builtins.int]
+f(3)  # E: No overload variant of "f" matches argument types [int]
 [builtins fixtures/classmethod.pyi]
 [out]
 
@@ -2745,7 +2745,7 @@ def f(a: Type[User]) -> None: pass
 def f(a: int) -> None: pass
 
 f(User)
-f(User())  # E: No overload variant of "f" matches argument types [foo.User]
+f(User())  # E: No overload variant of "f" matches argument types [User]
 [builtins fixtures/classmethod.pyi]
 [out]
 
@@ -2766,10 +2766,10 @@ def f(a: Type[B]) -> None: pass
 @overload
 def f(a: int) -> None: pass
 
-f(A)  # E: No overload variant of "f" matches argument types [def () -> foo.A]
+f(A)  # E: No overload variant of "f" matches argument types [Type[A]]
 f(B)
 f(C)
-f(AType)  # E: No overload variant of "f" matches argument types [Type[foo.A]]
+f(AType)  # E: No overload variant of "f" matches argument types [Type[A]]
 f(BType)
 f(CType)
 [builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -866,7 +866,7 @@ from typing import overload
 a, b, c = None, None, None  # type: (A, B, C)
 a[b]
 a[c]
-a[1]  # E: No overload variant of "__getitem__" of "A" matches argument types [builtins.int]
+a[1]  # E: No overload variant of "__getitem__" of "A" matches argument types [int]
 
 i, s = None, None  # type: (int, str)
 i = a[b]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -866,7 +866,7 @@ from typing import overload
 a, b, c = None, None, None  # type: (A, B, C)
 a[b]
 a[c]
-a[1]  # E: No overload variant of "__getitem__" of "A" matches argument types [int]
+a[1]  # E: No overload variant of "__getitem__" of "A" matches argument type "int"
 
 i, s = None, None  # type: (int, str)
 i = a[b]

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -130,9 +130,9 @@ def f(a,        # type: A
       **kwargs  # type: F
       ):
     reveal_type(a)      # E: Revealed type is '__main__.A'
-    reveal_type(b)      # E: Revealed type is 'Union[__main__.B, builtins.None]'
+    reveal_type(b)      # E: Revealed type is 'Union[__main__.B, None]'
     reveal_type(args)   # E: Revealed type is 'builtins.tuple[__main__.C]'
-    reveal_type(d)      # E: Revealed type is 'Union[__main__.D, builtins.None]'
+    reveal_type(d)      # E: Revealed type is 'Union[__main__.D, None]'
     reveal_type(e)      # E: Revealed type is '__main__.E'
     reveal_type(kwargs) # E: Revealed type is 'builtins.dict[builtins.str, __main__.F]'
 [builtins fixtures/dict.pyi]
@@ -155,9 +155,9 @@ def f(a,        # type: A
       ):
       # type: (...) -> int
     reveal_type(a)      # E: Revealed type is '__main__.A'
-    reveal_type(b)      # E: Revealed type is 'Union[__main__.B, builtins.None]'
+    reveal_type(b)      # E: Revealed type is 'Union[__main__.B, None]'
     reveal_type(args)   # E: Revealed type is 'builtins.tuple[__main__.C]'
-    reveal_type(d)      # E: Revealed type is 'Union[__main__.D, builtins.None]'
+    reveal_type(d)      # E: Revealed type is 'Union[__main__.D, None]'
     reveal_type(e)      # E: Revealed type is '__main__.E'
     reveal_type(kwargs) # E: Revealed type is 'builtins.dict[builtins.str, __main__.F]'
     return "not an int"  # E: Incompatible return value type (got "str", expected "int")
@@ -197,7 +197,7 @@ def f(a,        # type: A
       # kwargs not tested due to lack of 2.7 dict fixtures
       ):
     reveal_type(a)      # E: Revealed type is '__main__.A'
-    reveal_type(b)      # E: Revealed type is 'Union[__main__.B, builtins.None]'
+    reveal_type(b)      # E: Revealed type is 'Union[__main__.B, None]'
     reveal_type(args)   # E: Revealed type is 'builtins.tuple[__main__.C]'
 [builtins fixtures/dict.pyi]
 [out]
@@ -215,7 +215,7 @@ def f(a,        # type: A
       ):
       # type: (...) -> int
     reveal_type(a)      # E: Revealed type is '__main__.A'
-    reveal_type(b)      # E: Revealed type is 'Union[__main__.B, builtins.None]'
+    reveal_type(b)      # E: Revealed type is 'Union[__main__.B, None]'
     reveal_type(args)   # E: Revealed type is 'builtins.tuple[__main__.C]'
     return "not an int"  # E: Incompatible return value type (got "str", expected "int")
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -534,7 +534,7 @@ class A:
 a = None # type: A
 a.g()
 a.g(B())
-a.g(a) # E: No overload variant matches argument types [foo.A]
+a.g(a) # E: No overload variant matches argument types [A]
 
 [case testMethodAsDataAttributeInferredFromDynamicallyTypedMethod]
 

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -534,7 +534,7 @@ class A:
 a = None # type: A
 a.g()
 a.g(B())
-a.g(a) # E: No overload variant matches argument types [A]
+a.g(a) # E: No overload variant matches argument type "A"
 
 [case testMethodAsDataAttributeInferredFromDynamicallyTypedMethod]
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -960,7 +960,7 @@ U = Union[int]
 x: O
 y: U
 
-reveal_type(x)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+reveal_type(x)  # E: Revealed type is 'Union[builtins.int, None]'
 reveal_type(y)  # E: Revealed type is 'builtins.int'
 
 U[int]  # E: Bad number of arguments for type alias, expected: 0, given: 1

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3798,9 +3798,9 @@ class A:
 
 [builtins fixtures/list.pyi]
 [out1]
-main:2: error: Revealed type is 'def (x: Union[builtins.int, builtins.None]) -> a.a.A'
+main:2: error: Revealed type is 'def (x: Union[builtins.int, None]) -> a.a.A'
 [out2]
-main:2: error: Revealed type is 'def (x: Union[builtins.int, builtins.None]) -> a.a.A'
+main:2: error: Revealed type is 'def (x: Union[builtins.int, None]) -> a.a.A'
 
 [case testAttrsIncrementalConverterManyStyles]
 import a

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -867,7 +867,7 @@ T = TypeVar('T')
 def f(x: Union[T, List[int]]) -> Union[T, List[int]]: pass
 reveal_type(f(1)) # E: Revealed type is 'Union[builtins.int*, builtins.list[builtins.int]]'
 reveal_type(f([])) # E: Revealed type is 'builtins.list[builtins.int]'
-reveal_type(f(None)) # E: Revealed type is 'Union[builtins.None, builtins.list[builtins.int]]'
+reveal_type(f(None)) # E: Revealed type is 'Union[None, builtins.list[builtins.int]]'
 [builtins fixtures/list.pyi]
 
 [case testUnionWithGenericTypeItemContextInMethod]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1470,7 +1470,7 @@ def f(blocks: Any): # E: Name 'Any' is not defined
 [case testSpecialCaseEmptyListInitialization2]
 def f(blocks: object):
     to_process = [] # E: Need type annotation for 'to_process'
-    to_process = list(blocks) # E: No overload variant of "list" matches argument types [builtins.object]
+    to_process = list(blocks) # E: No overload variant of "list" matches argument types [object]
 [builtins fixtures/list.pyi]
 [out]
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1470,7 +1470,7 @@ def f(blocks: Any): # E: Name 'Any' is not defined
 [case testSpecialCaseEmptyListInitialization2]
 def f(blocks: object):
     to_process = [] # E: Need type annotation for 'to_process'
-    to_process = list(blocks) # E: No overload variant of "list" matches argument types [object]
+    to_process = list(blocks) # E: No overload variant of "list" matches argument type "object"
 [builtins fixtures/list.pyi]
 [out]
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1551,7 +1551,7 @@ if object():
 [case testPartiallyInitializedVariableDoesNotEscapeScope1]
 def f() -> None:
     x = None
-    reveal_type(x)  # E: Revealed type is 'builtins.None'
+    reveal_type(x)  # E: Revealed type is 'None'
 x = 1
 [out]
 
@@ -2088,7 +2088,7 @@ def f() -> None:
     x = 1
 
 # TODO: "Any" could be a better type here to avoid multiple error messages
-reveal_type(x) # E: Revealed type is 'builtins.None'
+reveal_type(x) # E: Revealed type is 'None'
 
 [case testLocalPartialTypesWithGlobalInitializedToNone2]
 # flags: --local-partial-types
@@ -2099,7 +2099,7 @@ def f():
     x = 1
 
 # TODO: "Any" could be a better type here to avoid multiple error messages
-reveal_type(x) # E: Revealed type is 'builtins.None'
+reveal_type(x) # E: Revealed type is 'None'
 
 [case testLocalPartialTypesWithGlobalInitializedToNone3]
 # flags: --local-partial-types --no-strict-optional
@@ -2122,7 +2122,7 @@ def f() -> None:
 
 x = ''
 def g() -> None:
-    reveal_type(x) # E: Revealed type is 'Union[builtins.str, builtins.None]'
+    reveal_type(x) # E: Revealed type is 'Union[builtins.str, None]'
 
 [case testLocalPartialTypesWithGlobalInitializedToNone4]
 # flags: --local-partial-types --no-strict-optional
@@ -2133,7 +2133,7 @@ def f() -> None:
 
 # TODO: This should probably be 'builtins.str', since there could be a
 #     call that causes a non-None value to be assigned
-reveal_type(a)  # E: Revealed type is 'builtins.None'
+reveal_type(a)  # E: Revealed type is 'None'
 a = ''
 reveal_type(a)  # E: Revealed type is 'builtins.str'
 [builtins fixtures/list.pyi]
@@ -2262,7 +2262,7 @@ class A:
 class B(A):
     x = None
 
-reveal_type(B.x) # E: Revealed type is 'builtins.None'
+reveal_type(B.x) # E: Revealed type is 'None'
 
 [case testLocalPartialTypesWithInheritance2]
 # flags: --local-partial-types --strict-optional
@@ -2298,8 +2298,8 @@ class C(B):
     x = None
 
 # TODO: Inferring None below is unsafe (https://github.com/python/mypy/issues/3208)
-reveal_type(B.x)  # E: Revealed type is 'builtins.None'
-reveal_type(C.x)  # E: Revealed type is 'builtins.None'
+reveal_type(B.x)  # E: Revealed type is 'None'
+reveal_type(C.x)  # E: Revealed type is 'None'
 
 [case testLocalPartialTypesWithInheritance2-skip]
 # flags: --local-partial-types
@@ -2316,7 +2316,7 @@ class B(A):
     x = None
     x = Y()
 
-reveal_type(B.x) # E: revealed type is 'Union[__main__.Y, builtins.None]'
+reveal_type(B.x) # E: revealed type is 'Union[__main__.Y, None]'
 
 [case testLocalPartialTypesBinderSpecialCase]
 # flags: --local-partial-types

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1780,9 +1780,9 @@ y: Optional[int]
 if y in x:
     reveal_type(y)  # E: Revealed type is 'builtins.int'
 else:
-    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, None]'
 if y not in x:
-    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, None]'
 else:
     reveal_type(y)  # E: Revealed type is 'builtins.int'
 [builtins fixtures/list.pyi]
@@ -1796,9 +1796,9 @@ x: List[Optional[int]]
 y: Optional[int]
 
 if y not in x:
-    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, None]'
 else:
-    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, None]'
 [builtins fixtures/list.pyi]
 [out]
 
@@ -1810,9 +1810,9 @@ x: List[str]
 y: Optional[int]
 
 if y in x:
-    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, None]'
 else:
-    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, None]'
 [builtins fixtures/list.pyi]
 [out]
 
@@ -1827,7 +1827,7 @@ nested_any: List[List[Any]]
 if lst in nested_any:
     reveal_type(lst) # E: Revealed type is 'builtins.list[builtins.int]'
 if x in nested_any:
-    reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(x) # E: Revealed type is 'Union[builtins.int, None]'
 [builtins fixtures/list.pyi]
 [out]
 
@@ -1842,7 +1842,7 @@ y: Optional[B]
 if y in (B(), C()):
     reveal_type(y) # E: Revealed type is '__main__.B'
 else:
-    reveal_type(y) # E: Revealed type is 'Union[__main__.B, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[__main__.B, None]'
 [builtins fixtures/tuple.pyi]
 [out]
 
@@ -1856,7 +1856,7 @@ nt: NT
 
 y: Optional[int]
 if y not in nt:
-    reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.int, None]'
 else:
     reveal_type(y) # E: Revealed type is 'builtins.int'
 [builtins fixtures/tuple.pyi]
@@ -1871,9 +1871,9 @@ y: Optional[str]
 if y in x:
     reveal_type(y) # E: Revealed type is 'builtins.str'
 else:
-    reveal_type(y) # E: Revealed type is 'Union[builtins.str, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.str, None]'
 if y not in x:
-    reveal_type(y) # E: Revealed type is 'Union[builtins.str, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.str, None]'
 else:
     reveal_type(y) # E: Revealed type is 'builtins.str'
 [builtins fixtures/dict.pyi]
@@ -1890,9 +1890,9 @@ y = None  # type: Optional[int]
 if y in x:  # type: ignore
     reveal_type(y)  # E: Revealed type is 'builtins.int'
 else:
-    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, None]'
 if y not in x:  # type: ignore
-    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y)  # E: Revealed type is 'Union[builtins.int, None]'
 else:
     reveal_type(y)  # E: Revealed type is 'builtins.int'
 
@@ -1907,14 +1907,14 @@ z: List[object]
 
 y: Optional[int]
 if y in x:
-    reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.int, None]'
 else:
-    reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.int, None]'
 
 if y not in z:
-    reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.int, None]'
 else:
-    reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.int, None]'
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/list.pyi]
 [out]
@@ -1930,13 +1930,13 @@ class C(Container[int]):
 y: Optional[int]
 # We never trust user defined types
 if y in C():
-    reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.int, None]'
 else:
-    reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.int, None]'
 if y not in C():
-    reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.int, None]'
 else:
-    reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.int, None]'
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/list.pyi]
 [out]
@@ -1950,9 +1950,9 @@ y: Optional[str]
 if y in {'a', 'b', 'c'}:
     reveal_type(y) # E: Revealed type is 'builtins.str'
 else:
-    reveal_type(y) # E: Revealed type is 'Union[builtins.str, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.str, None]'
 if y not in s:
-    reveal_type(y) # E: Revealed type is 'Union[builtins.str, builtins.None]'
+    reveal_type(y) # E: Revealed type is 'Union[builtins.str, None]'
 else:
     reveal_type(y) # E: Revealed type is 'builtins.str'
 [builtins fixtures/set.pyi]

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -44,7 +44,7 @@ x = None  # type:  Optional[int]
 if isinstance(x, int):
   reveal_type(x)  # E: Revealed type is 'builtins.int'
 else:
-  reveal_type(x)  # E: Revealed type is 'builtins.None'
+  reveal_type(x)  # E: Revealed type is 'None'
 [builtins fixtures/isinstance.pyi]
 
 [case testIfCases]
@@ -53,14 +53,14 @@ x = None  # type:  Optional[int]
 if x:
   reveal_type(x)  # E: Revealed type is 'builtins.int'
 else:
-  reveal_type(x)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+  reveal_type(x)  # E: Revealed type is 'Union[builtins.int, None]'
 [builtins fixtures/bool.pyi]
 
 [case testIfNotCases]
 from typing import Optional
 x = None  # type:  Optional[int]
 if not x:
-  reveal_type(x)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+  reveal_type(x)  # E: Revealed type is 'Union[builtins.int, None]'
 else:
   reveal_type(x)  # E: Revealed type is 'builtins.int'
 [builtins fixtures/bool.pyi]
@@ -71,24 +71,24 @@ x = None  # type:  Optional[int]
 if x is not None:
   reveal_type(x)  # E: Revealed type is 'builtins.int'
 else:
-  reveal_type(x)  # E: Revealed type is 'builtins.None'
+  reveal_type(x)  # E: Revealed type is 'None'
 [builtins fixtures/bool.pyi]
 
 [case testIsNoneCases]
 from typing import Optional
 x = None  # type:  Optional[int]
 if x is None:
-  reveal_type(x)  # E: Revealed type is 'builtins.None'
+  reveal_type(x)  # E: Revealed type is 'None'
 else:
   reveal_type(x)  # E: Revealed type is 'builtins.int'
-reveal_type(x)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+reveal_type(x)  # E: Revealed type is 'Union[builtins.int, None]'
 [builtins fixtures/bool.pyi]
 
 [case testAnyCanBeNone]
 from typing import Optional, Any
 x = None  # type:  Any
 if x is None:
-  reveal_type(x)  # E: Revealed type is 'builtins.None'
+  reveal_type(x)  # E: Revealed type is 'None'
 else:
   reveal_type(x)  # E: Revealed type is 'Any'
 [builtins fixtures/bool.pyi]
@@ -101,21 +101,21 @@ reveal_type(y1)  # E: Revealed type is 'builtins.str'
 y2 = x or 1
 reveal_type(y2)  # E: Revealed type is 'Union[builtins.str, builtins.int]'
 z1 = 'a' or x
-reveal_type(z1)  # E: Revealed type is 'Union[builtins.str, builtins.None]'
+reveal_type(z1)  # E: Revealed type is 'Union[builtins.str, None]'
 z2 = int() or x
-reveal_type(z2)  # E: Revealed type is 'Union[builtins.int, builtins.str, builtins.None]'
+reveal_type(z2)  # E: Revealed type is 'Union[builtins.int, builtins.str, None]'
 
 [case testAndCases]
 from typing import Optional
 x = None  # type: Optional[str]
 y1 = x and 'b'
-reveal_type(y1)  # E: Revealed type is 'Union[builtins.str, builtins.None]'
+reveal_type(y1)  # E: Revealed type is 'Union[builtins.str, None]'
 y2 = x and 1  # x could be '', so...
-reveal_type(y2)  # E: Revealed type is 'Union[builtins.str, builtins.None, builtins.int]'
+reveal_type(y2)  # E: Revealed type is 'Union[builtins.str, None, builtins.int]'
 z1 = 'b' and x
-reveal_type(z1)  # E: Revealed type is 'Union[builtins.str, builtins.None]'
+reveal_type(z1)  # E: Revealed type is 'Union[builtins.str, None]'
 z2 = int() and x
-reveal_type(z2)  # E: Revealed type is 'Union[builtins.int, builtins.str, builtins.None]'
+reveal_type(z2)  # E: Revealed type is 'Union[builtins.int, builtins.str, None]'
 
 [case testLambdaReturningNone]
 f = lambda: None
@@ -159,7 +159,7 @@ if bool():
   # in scope of the assignment, x is an int
   reveal_type(x)  # E: Revealed type is 'builtins.int'
 # out of scope of the assignment, it's an Optional[int]
-reveal_type(x)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+reveal_type(x)  # E: Revealed type is 'Union[builtins.int, None]'
 [builtins fixtures/bool.pyi]
 
 [case testInferOptionalTypeLocallyBound]
@@ -174,7 +174,7 @@ a = None  # type: Any
 if bool():
   x = a
   reveal_type(x)  # E: Revealed type is 'Any'
-reveal_type(x)  # E: Revealed type is 'Union[Any, builtins.None]'
+reveal_type(x)  # E: Revealed type is 'Union[Any, None]'
 [builtins fixtures/bool.pyi]
 
 [case testInferOptionalTypeFromOptional]
@@ -182,7 +182,7 @@ from typing import Optional
 y = None  # type: Optional[int]
 x = None
 x = y
-reveal_type(x)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+reveal_type(x)  # E: Revealed type is 'Union[builtins.int, None]'
 
 [case testInferOptionalListType]
 x = [None]
@@ -264,8 +264,8 @@ def f(a: Optional[int], b: Optional[int]) -> None:
 def g(a: int, b: Optional[int]) -> None:
     reveal_type(a or b)
 [out]
-main:3: error: Revealed type is 'Union[builtins.int, builtins.None]'
-main:5: error: Revealed type is 'Union[builtins.int, builtins.None]'
+main:3: error: Revealed type is 'Union[builtins.int, None]'
+main:5: error: Revealed type is 'Union[builtins.int, None]'
 
 [case testOptionalTypeOrTypeComplexUnion]
 from typing import Union
@@ -313,7 +313,7 @@ def f() -> Generator[None, None, None]:
 [case testNoneAndStringIsNone]
 a = None
 b = "foo"
-reveal_type(a and b)  # E: Revealed type is 'builtins.None'
+reveal_type(a and b)  # E: Revealed type is 'None'
 
 [case testNoneMatchesObjectInOverload]
 import a
@@ -385,11 +385,11 @@ def lookup_field(name, obj):
         attr = None
 
 [case testTernaryWithNone]
-reveal_type(None if bool() else 0)  # E: Revealed type is 'Union[builtins.None, builtins.int]'
+reveal_type(None if bool() else 0)  # E: Revealed type is 'Union[None, builtins.int]'
 [builtins fixtures/bool.pyi]
 
 [case testListWithNone]
-reveal_type([0, None, 0])    # E: Revealed type is 'builtins.list[Union[builtins.int, builtins.None]]'
+reveal_type([0, None, 0])    # E: Revealed type is 'builtins.list[Union[builtins.int, None]]'
 [builtins fixtures/list.pyi]
 
 [case testOptionalWhitelistSuppressesOptionalErrors]
@@ -455,9 +455,9 @@ raise BaseException from None
 from typing import Generator
 def f() -> Generator[str, None, None]: pass
 x = f()
-reveal_type(x)  # E: Revealed type is 'typing.Generator[builtins.str, builtins.None, builtins.None]'
+reveal_type(x)  # E: Revealed type is 'typing.Generator[builtins.str, None, None]'
 l = [f()]
-reveal_type(l)  # E: Revealed type is 'builtins.list[typing.Generator*[builtins.str, builtins.None, builtins.None]]'
+reveal_type(l)  # E: Revealed type is 'builtins.list[typing.Generator*[builtins.str, None, None]]'
 [builtins fixtures/list.pyi]
 
 [case testNoneListTernary]
@@ -480,7 +480,7 @@ x = ''  # type: Optional[str]
 if x == '<string>':
     reveal_type(x)  # E: Revealed type is 'builtins.str'
 else:
-    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.None]'
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, None]'
 [builtins fixtures/ops.pyi]
 
 [case testInferEqualsNotOptionalWithUnion]
@@ -489,7 +489,7 @@ x = ''  # type: Union[str, int, None]
 if x == '<string>':
     reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int]'
 else:
-    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int, builtins.None]'
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int, None]'
 [builtins fixtures/ops.pyi]
 
 [case testInferEqualsNotOptionalWithOverlap]
@@ -498,16 +498,16 @@ x = ''  # type: Union[str, int, None]
 if x == object():
     reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int]'
 else:
-    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int, builtins.None]'
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int, None]'
 [builtins fixtures/ops.pyi]
 
 [case testInferEqualsStillOptionalWithNoOverlap]
 from typing import Optional
 x = ''  # type: Optional[str]
 if x == 0:
-    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.None]'
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, None]'
 else:
-    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.None]'
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, None]'
 [builtins fixtures/ops.pyi]
 
 [case testInferEqualsStillOptionalWithBothOptional]
@@ -515,9 +515,9 @@ from typing import Union
 x = ''  # type: Union[str, int, None]
 y = ''  # type: Union[str, None]
 if x == y:
-    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int, builtins.None]'
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int, None]'
 else:
-    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int, builtins.None]'
+    reveal_type(x)  # E: Revealed type is 'Union[builtins.str, builtins.int, None]'
 [builtins fixtures/ops.pyi]
 
 [case testWarnNoReturnWorksWithStrictOptional]
@@ -586,14 +586,14 @@ def u(x: T, y: S) -> Union[S, T]: pass
 a = None # type: Any
 
 # Test both orders
-reveal_type(u(C(), None))  # E: Revealed type is 'Union[builtins.None, __main__.C*]'
-reveal_type(u(None, C()))  # E: Revealed type is 'Union[__main__.C*, builtins.None]'
+reveal_type(u(C(), None))  # E: Revealed type is 'Union[None, __main__.C*]'
+reveal_type(u(None, C()))  # E: Revealed type is 'Union[__main__.C*, None]'
 
-reveal_type(u(a, None))  # E: Revealed type is 'Union[builtins.None, Any]'
-reveal_type(u(None, a))  # E: Revealed type is 'Union[Any, builtins.None]'
+reveal_type(u(a, None))  # E: Revealed type is 'Union[None, Any]'
+reveal_type(u(None, a))  # E: Revealed type is 'Union[Any, None]'
 
-reveal_type(u(1, None))  # E: Revealed type is 'Union[builtins.None, builtins.int*]'
-reveal_type(u(None, 1))  # E: Revealed type is 'Union[builtins.int*, builtins.None]'
+reveal_type(u(1, None))  # E: Revealed type is 'Union[None, builtins.int*]'
+reveal_type(u(None, 1))  # E: Revealed type is 'Union[builtins.int*, None]'
 
 [case testOptionalAndAnyBaseClass]
 from typing import Any, Optional
@@ -610,21 +610,21 @@ B = None  # type: Any
 class A(B): pass
 
 def f(a: Optional[A]):
-    reveal_type(a) # E: Revealed type is 'Union[__main__.A, builtins.None]'
+    reveal_type(a) # E: Revealed type is 'Union[__main__.A, None]'
     if a is not None:
         reveal_type(a) # E: Revealed type is '__main__.A'
     else:
-        reveal_type(a) # E: Revealed type is 'builtins.None'
-    reveal_type(a) # E: Revealed type is 'Union[__main__.A, builtins.None]'
+        reveal_type(a) # E: Revealed type is 'None'
+    reveal_type(a) # E: Revealed type is 'Union[__main__.A, None]'
 [builtins fixtures/isinstance.pyi]
 
 [case testFlattenOptionalUnion]
 from typing import Optional, Union
 
 x: Optional[Union[int, str]]
-reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.str, builtins.None]'
+reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.str, None]'
 y: Optional[Union[int, None]]
-reveal_type(y) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+reveal_type(y) # E: Revealed type is 'Union[builtins.int, None]'
 
 [case testOverloadWithNoneAndOptional]
 from typing import overload, Optional
@@ -636,9 +636,9 @@ def f(x: Optional[int]) -> Optional[str]: ...
 def f(x): return x
 
 reveal_type(f(1)) # E: Revealed type is 'builtins.str'
-reveal_type(f(None)) # E: Revealed type is 'Union[builtins.str, builtins.None]'
+reveal_type(f(None)) # E: Revealed type is 'Union[builtins.str, None]'
 x: Optional[int]
-reveal_type(f(x)) # E: Revealed type is 'Union[builtins.str, builtins.None]'
+reveal_type(f(x)) # E: Revealed type is 'Union[builtins.str, None]'
 
 [case testUnionTruthinessTracking]
 from typing import Optional, Any
@@ -654,7 +654,7 @@ from typing import Optional
 x: object
 y: Optional[int]
 x = y
-reveal_type(x) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+reveal_type(x) # E: Revealed type is 'Union[builtins.int, None]'
 [out]
 
 [case testNarrowOptionalOutsideLambda]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -328,7 +328,7 @@ class B: pass
 from foo import *
 [file foo.pyi]
 from typing import overload
-f(C()) # E: No overload variant of "f" matches argument types [C]
+f(C()) # E: No overload variant of "f" matches argument type "C"
 f(A())
 f(B())
 
@@ -362,7 +362,7 @@ class B: pass
 from foo import *
 [file foo.pyi]
 from typing import overload
-A().f(C()) # E: No overload variant of "f" of "A" matches argument types [C]
+A().f(C()) # E: No overload variant of "f" of "A" matches argument type "C"
 A().f(A())
 A().f(B())
 
@@ -399,11 +399,11 @@ from typing import overload
 a, b = None, None # type: (A, B)
 a = f(a)
 b = f(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-f(b)     # E: No overload variant of "f" matches argument types [B]
+f(b)     # E: No overload variant of "f" matches argument type "B"
 b = f(b, a)
 a = f(b, a) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-f(a, a)     # E: No overload variant of "f" matches argument types [A, A]
-f(b, b)     # E: No overload variant of "f" matches argument types [B, B]
+f(a, a)     # E: No overload variant of "f" matches argument types "A", "A"
+f(b, b)     # E: No overload variant of "f" matches argument types "B", "B"
 
 @overload
 def f(x: 'A') -> 'A': pass
@@ -438,7 +438,7 @@ from typing import overload
 a, b = None, None # type: (A, B)
 a = A(a)
 a = A(b)
-a = A(object()) # E: No overload variant of "A" matches argument types [object]
+a = A(object()) # E: No overload variant of "A" matches argument type "object"
 
 class A:
   @overload
@@ -559,7 +559,7 @@ f(A(), A, A)
 f(B())
 f(B(), B)
 f(B(), B, B)
-f(object()) # E: No overload variant of "f" matches argument types [object]
+f(object()) # E: No overload variant of "f" matches argument type "object"
 class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
@@ -574,8 +574,8 @@ def f(x: 'A', *more: 'B') -> 'A': pass
 def f(x: 'B', *more: 'A') -> 'A': pass
 f(A(), B())
 f(A(), B(), B())
-f(A(), A(), B()) # E: No overload variant of "f" matches argument types [A, A, B]
-f(A(), B(), A()) # E: No overload variant of "f" matches argument types [A, B, A]
+f(A(), A(), B()) # E: No overload variant of "f" matches argument types "A", "A", "B"
+f(A(), B(), A()) # E: No overload variant of "f" matches argument types "A", "B", "A"
 class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
@@ -741,7 +741,7 @@ A() < B()
 B() < A()
 B() < B()
 A() < object() # E: Unsupported operand types for < ("A" and "object")
-B() < object() # E: No overload variant of "__lt__" of "B" matches argument types [object]
+B() < object() # E: No overload variant of "__lt__" of "B" matches argument type "object"
 
 [case testOverloadedForwardMethodAndCallingReverseMethod]
 from foo import *
@@ -757,7 +757,7 @@ class B:
 A() + A()
 A() + 1
 A() + B()
-A() + '' # E: No overload variant of "__add__" of "A" matches argument types [str]
+A() + '' # E: No overload variant of "__add__" of "A" matches argument type "str"
 
 [case testOverrideOverloadedMethodWithMoreGeneralArgumentTypes]
 from foo import *
@@ -842,7 +842,7 @@ def f(x: str) -> None: pass
 f(1.1)
 f('')
 f(1)
-f(()) # E: No overload variant of "f" matches argument types [Tuple[]]
+f(()) # E: No overload variant of "f" matches argument type "Tuple[]"
 [builtins fixtures/primitives.pyi]
 [out]
 
@@ -908,10 +908,10 @@ from typing import overload
 def f(x: int, y: str) -> int: pass
 @overload
 def f(*x: str) -> str: pass
-f(*(1,))() # E: No overload variant of "f" matches argument types [Tuple[int]]
+f(*(1,))() # E: No overload variant of "f" matches argument type "Tuple[int]"
 f(*('',))() # E: "str" not callable
 f(*(1, ''))() # E: "int" not callable
-f(*(1, '', 1))() # E: No overload variant of "f" matches argument types [Tuple[int, str, int]]
+f(*(1, '', 1))() # E: No overload variant of "f" matches argument type "Tuple[int, str, int]"
 
 [case testPreferExactSignatureMatchInOverload]
 from foo import *
@@ -958,7 +958,7 @@ class mystr(str): pass
 
 f('x')() # E: "str" not callable
 f(1)() # E: "bool" not callable
-f(1.1) # E: No overload variant of "f" matches argument types [float]
+f(1.1) # E: No overload variant of "f" matches argument type "float"
 f(mystr())() # E: "mystr" not callable
 [builtins fixtures/primitives.pyi]
 
@@ -977,7 +977,7 @@ U = TypeVar('U', bound=mystr)
 V = TypeVar('V')
 def g(x: U, y: V) -> None:
     f(x)() # E: "mystr" not callable
-    f(y) # E: No overload variant of "f" matches argument types [V]
+    f(y) # E: No overload variant of "f" matches argument type "V"
     a = f([x]) # E: "f" does not return a value
     f([y]) # E: Value of type variable "T" of "f" cannot be "V"
     f([x, y]) # E: Value of type variable "T" of "f" cannot be "object"
@@ -1011,7 +1011,7 @@ def f(x: AnyStr) -> str: pass
 f(1)() # E: "int" not callable
 f('1')() # E: "str" not callable
 f(b'1')() # E: "str" not callable
-f(1.0) # E: No overload variant of "f" matches argument types [float]
+f(1.0) # E: No overload variant of "f" matches argument type "float"
 
 @overload
 def g(x: AnyStr, *a: AnyStr) -> None: pass
@@ -1157,7 +1157,7 @@ from typing import overload, Callable
 def f(a: Callable[[], int]) -> None: pass
 @overload
 def f(a: str) -> None: pass
-f(0)  # E: No overload variant of "f" matches argument types [int]
+f(0)  # E: No overload variant of "f" matches argument type "int"
 
 [case testCustomRedefinitionDecorator]
 from typing import Any, Callable, Type

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -328,7 +328,7 @@ class B: pass
 from foo import *
 [file foo.pyi]
 from typing import overload
-f(C()) # E: No overload variant of "f" matches argument types [foo.C]
+f(C()) # E: No overload variant of "f" matches argument types [C]
 f(A())
 f(B())
 
@@ -362,7 +362,7 @@ class B: pass
 from foo import *
 [file foo.pyi]
 from typing import overload
-A().f(C()) # E: No overload variant of "f" of "A" matches argument types [foo.C]
+A().f(C()) # E: No overload variant of "f" of "A" matches argument types [C]
 A().f(A())
 A().f(B())
 
@@ -399,11 +399,11 @@ from typing import overload
 a, b = None, None # type: (A, B)
 a = f(a)
 b = f(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-f(b)     # E: No overload variant of "f" matches argument types [foo.B]
+f(b)     # E: No overload variant of "f" matches argument types [B]
 b = f(b, a)
 a = f(b, a) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-f(a, a)     # E: No overload variant of "f" matches argument types [foo.A, foo.A]
-f(b, b)     # E: No overload variant of "f" matches argument types [foo.B, foo.B]
+f(a, a)     # E: No overload variant of "f" matches argument types [A, A]
+f(b, b)     # E: No overload variant of "f" matches argument types [B, B]
 
 @overload
 def f(x: 'A') -> 'A': pass
@@ -438,7 +438,7 @@ from typing import overload
 a, b = None, None # type: (A, B)
 a = A(a)
 a = A(b)
-a = A(object()) # E: No overload variant of "A" matches argument types [builtins.object]
+a = A(object()) # E: No overload variant of "A" matches argument types [object]
 
 class A:
   @overload
@@ -559,7 +559,7 @@ f(A(), A, A)
 f(B())
 f(B(), B)
 f(B(), B, B)
-f(object()) # E: No overload variant of "f" matches argument types [builtins.object]
+f(object()) # E: No overload variant of "f" matches argument types [object]
 class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
@@ -574,8 +574,8 @@ def f(x: 'A', *more: 'B') -> 'A': pass
 def f(x: 'B', *more: 'A') -> 'A': pass
 f(A(), B())
 f(A(), B(), B())
-f(A(), A(), B()) # E: No overload variant of "f" matches argument types [foo.A, foo.A, foo.B]
-f(A(), B(), A()) # E: No overload variant of "f" matches argument types [foo.A, foo.B, foo.A]
+f(A(), A(), B()) # E: No overload variant of "f" matches argument types [A, A, B]
+f(A(), B(), A()) # E: No overload variant of "f" matches argument types [A, B, A]
 class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
@@ -741,7 +741,7 @@ A() < B()
 B() < A()
 B() < B()
 A() < object() # E: Unsupported operand types for < ("A" and "object")
-B() < object() # E: No overload variant of "__lt__" of "B" matches argument types [builtins.object]
+B() < object() # E: No overload variant of "__lt__" of "B" matches argument types [object]
 
 [case testOverloadedForwardMethodAndCallingReverseMethod]
 from foo import *
@@ -757,7 +757,7 @@ class B:
 A() + A()
 A() + 1
 A() + B()
-A() + '' # E: No overload variant of "__add__" of "A" matches argument types [builtins.str]
+A() + '' # E: No overload variant of "__add__" of "A" matches argument types [str]
 
 [case testOverrideOverloadedMethodWithMoreGeneralArgumentTypes]
 from foo import *
@@ -908,10 +908,10 @@ from typing import overload
 def f(x: int, y: str) -> int: pass
 @overload
 def f(*x: str) -> str: pass
-f(*(1,))() # E: No overload variant of "f" matches argument types [Tuple[builtins.int]]
+f(*(1,))() # E: No overload variant of "f" matches argument types [Tuple[int]]
 f(*('',))() # E: "str" not callable
 f(*(1, ''))() # E: "int" not callable
-f(*(1, '', 1))() # E: No overload variant of "f" matches argument types [Tuple[builtins.int, builtins.str, builtins.int]]
+f(*(1, '', 1))() # E: No overload variant of "f" matches argument types [Tuple[int, str, int]]
 
 [case testPreferExactSignatureMatchInOverload]
 from foo import *
@@ -958,7 +958,7 @@ class mystr(str): pass
 
 f('x')() # E: "str" not callable
 f(1)() # E: "bool" not callable
-f(1.1) # E: No overload variant of "f" matches argument types [builtins.float]
+f(1.1) # E: No overload variant of "f" matches argument types [float]
 f(mystr())() # E: "mystr" not callable
 [builtins fixtures/primitives.pyi]
 
@@ -977,7 +977,7 @@ U = TypeVar('U', bound=mystr)
 V = TypeVar('V')
 def g(x: U, y: V) -> None:
     f(x)() # E: "mystr" not callable
-    f(y) # E: No overload variant of "f" matches argument types [V`-2]
+    f(y) # E: No overload variant of "f" matches argument types [V]
     a = f([x]) # E: "f" does not return a value
     f([y]) # E: Value of type variable "T" of "f" cannot be "V"
     f([x, y]) # E: Value of type variable "T" of "f" cannot be "object"
@@ -1011,7 +1011,7 @@ def f(x: AnyStr) -> str: pass
 f(1)() # E: "int" not callable
 f('1')() # E: "str" not callable
 f(b'1')() # E: "str" not callable
-f(1.0) # E: No overload variant of "f" matches argument types [builtins.float]
+f(1.0) # E: No overload variant of "f" matches argument types [float]
 
 @overload
 def g(x: AnyStr, *a: AnyStr) -> None: pass
@@ -1157,7 +1157,7 @@ from typing import overload, Callable
 def f(a: Callable[[], int]) -> None: pass
 @overload
 def f(a: str) -> None: pass
-f(0)  # E: No overload variant of "f" matches argument types [builtins.int]
+f(0)  # E: No overload variant of "f" matches argument types [int]
 
 [case testCustomRedefinitionDecorator]
 from typing import Any, Callable, Type

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -1303,7 +1303,7 @@ reveal_type(f(C2())) # E: Revealed type is 'builtins.str'
 class D(C1, C2): pass # Compatible with both P1 and P2
 # FIXME: the below is not right, see #1322
 reveal_type(f(D())) # E: Revealed type is 'Any'
-f(C()) # E: No overload variant of "f" matches argument types [C]
+f(C()) # E: No overload variant of "f" matches argument type "C"
 [builtins fixtures/isinstance.pyi]
 
 -- Unions of protocol types

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -1303,7 +1303,7 @@ reveal_type(f(C2())) # E: Revealed type is 'builtins.str'
 class D(C1, C2): pass # Compatible with both P1 and P2
 # FIXME: the below is not right, see #1322
 reveal_type(f(D())) # E: Revealed type is 'Any'
-f(C()) # E: No overload variant of "f" matches argument types [__main__.C]
+f(C()) # E: No overload variant of "f" matches argument types [C]
 [builtins fixtures/isinstance.pyi]
 
 -- Unions of protocol types

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -293,8 +293,8 @@ class A:
     @overload
     def __init__(self, x: str) -> None: pass
 [out2]
-tmp/a.py:2: error: No overload variant of "A" matches argument types [object]
-tmp/a.py:7: error: No overload variant of "__init__" of "A" matches argument types [object]
+tmp/a.py:2: error: No overload variant of "A" matches argument type "object"
+tmp/a.py:7: error: No overload variant of "__init__" of "A" matches argument type "object"
 
 [case testSerialize__new__]
 import a

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -293,8 +293,8 @@ class A:
     @overload
     def __init__(self, x: str) -> None: pass
 [out2]
-tmp/a.py:2: error: No overload variant of "A" matches argument types [builtins.object]
-tmp/a.py:7: error: No overload variant of "__init__" of "A" matches argument types [builtins.object]
+tmp/a.py:2: error: No overload variant of "A" matches argument types [object]
+tmp/a.py:7: error: No overload variant of "__init__" of "A" matches argument types [object]
 
 [case testSerialize__new__]
 import a

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -728,7 +728,7 @@ from typing import Optional
 x: Optional[int]
 def f(x: int) -> None: pass
 [out2]
-tmp/a.py:2: error: Revealed type is 'Union[builtins.int, builtins.None]'
+tmp/a.py:2: error: Revealed type is 'Union[builtins.int, None]'
 tmp/a.py:3: error: Argument 1 to "f" has incompatible type "Optional[int]"; expected "int"
 
 --
@@ -1017,7 +1017,7 @@ reveal_type(b.x)
 [file b.py]
 x: None
 [out2]
-tmp/a.py:2: error: Revealed type is 'builtins.None'
+tmp/a.py:2: error: Revealed type is 'None'
 
 --
 -- TypedDict

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -351,7 +351,7 @@ a, b = None, None # type: (A, B)
 a1, b1 = a, a # type: (A, B)  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 a2, b2 = b, b # type: (A, B)  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 a3, b3 = a # type: (A, B)     # E: '__main__.A' object is not iterable
-a4, b4 = None # type: (A, B)  # E: 'builtins.None' object is not iterable
+a4, b4 = None # type: (A, B)  # E: 'None' object is not iterable
 a5, b5 = a, b, a # type: (A, B)  # E: Too many values to unpack (2 expected, 3 provided)
 
 ax, bx = a, b # type: (A, B)
@@ -365,7 +365,7 @@ class B: pass
 a, b = None, None # type: (A, B)
 def f(): pass
 
-a, b = None # E: 'builtins.None' object is not iterable
+a, b = None # E: 'None' object is not iterable
 a, b = a   # E: '__main__.A' object is not iterable
 a, b = f   # E: 'def () -> Any' object is not iterable
 

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -263,9 +263,9 @@ A = List[T]
 from typing import Union
 void = type(None)
 x: void
-reveal_type(x)  # E: Revealed type is 'builtins.None'
+reveal_type(x)  # E: Revealed type is 'None'
 y: Union[int, void]
-reveal_type(y)  # E: Revealed type is 'Union[builtins.int, builtins.None]'
+reveal_type(y)  # E: Revealed type is 'Union[builtins.int, None]'
 [builtins fixtures/bool.pyi]
 
 [case testNoneAliasStrict]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -906,8 +906,8 @@ reveal_type(d.get('x', a)) # E: Revealed type is 'Union[builtins.list[builtins.i
 from mypy_extensions import TypedDict
 D = TypedDict('D', {'x': int, 'y': str})
 d: D
-d.get() # E: No overload variant of "get" of "Mapping" matches argument types []
-d.get('x', 1, 2) # E: No overload variant of "get" of "Mapping" matches argument types [str, int, int]
+d.get() # E: All overload variants of "get" of "Mapping" take at least one argument
+d.get('x', 1, 2) # E: No overload variant of "get" of "Mapping" matches argument types "str", "int", "int"
 x = d.get('z') # E: TypedDict "D" has no key 'z'
 reveal_type(x) # E: Revealed type is 'Any'
 s = ''
@@ -1205,7 +1205,7 @@ def f(x: int) -> None: ...
 def f(x): pass
 
 a: A
-f(a)  # E: No overload variant of "f" matches argument types [A]
+f(a)  # E: No overload variant of "f" matches argument type "A"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -906,7 +906,7 @@ reveal_type(d.get('x', a)) # E: Revealed type is 'Union[builtins.list[builtins.i
 from mypy_extensions import TypedDict
 D = TypedDict('D', {'x': int, 'y': str})
 d: D
-d.get() # E: All overload variants of "get" of "Mapping" take at least one argument
+d.get() # E: All overload variants of "get" of "Mapping" require at least one argument
 d.get('x', 1, 2) # E: No overload variant of "get" of "Mapping" matches argument types "str", "int", "int"
 x = d.get('z') # E: TypedDict "D" has no key 'z'
 reveal_type(x) # E: Revealed type is 'Any'

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -907,7 +907,7 @@ from mypy_extensions import TypedDict
 D = TypedDict('D', {'x': int, 'y': str})
 d: D
 d.get() # E: No overload variant of "get" of "Mapping" matches argument types []
-d.get('x', 1, 2) # E: No overload variant of "get" of "Mapping" matches argument types [builtins.str, builtins.int, builtins.int]
+d.get('x', 1, 2) # E: No overload variant of "get" of "Mapping" matches argument types [str, int, int]
 x = d.get('z') # E: TypedDict "D" has no key 'z'
 reveal_type(x) # E: Revealed type is 'Any'
 s = ''
@@ -1205,7 +1205,7 @@ def f(x: int) -> None: ...
 def f(x): pass
 
 a: A
-f(a)  # E: No overload variant of "f" matches argument types [TypedDict('__main__.A', {'x': builtins.int})]
+f(a)  # E: No overload variant of "f" matches argument types [A]
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -880,11 +880,11 @@ from mypy_extensions import TypedDict
 class A: pass
 D = TypedDict('D', {'x': int, 'y': str})
 d: D
-reveal_type(d.get('x')) # E: Revealed type is 'Union[builtins.int, builtins.None]'
-reveal_type(d.get('y')) # E: Revealed type is 'Union[builtins.str, builtins.None]'
+reveal_type(d.get('x')) # E: Revealed type is 'Union[builtins.int, None]'
+reveal_type(d.get('y')) # E: Revealed type is 'Union[builtins.str, None]'
 reveal_type(d.get('x', A())) # E: Revealed type is 'Union[builtins.int, __main__.A]'
 reveal_type(d.get('x', 1)) # E: Revealed type is 'builtins.int'
-reveal_type(d.get('y', None)) # E: Revealed type is 'Union[builtins.str, builtins.None]'
+reveal_type(d.get('y', None)) # E: Revealed type is 'Union[builtins.str, None]'
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
 
@@ -949,8 +949,8 @@ d: D
 reveal_type(d.get('x', {})) \
     # E: Revealed type is 'TypedDict('__main__.C', {'a'?: builtins.int})'
 reveal_type(d.get('x', None)) \
-    # E: Revealed type is 'Union[TypedDict('__main__.C', {'a': builtins.int}), builtins.None]'
-reveal_type(d.get('x', {}).get('a')) # E: Revealed type is 'Union[builtins.int, builtins.None]'
+    # E: Revealed type is 'Union[TypedDict('__main__.C', {'a': builtins.int}), None]'
+reveal_type(d.get('x', {}).get('a')) # E: Revealed type is 'Union[builtins.int, None]'
 reveal_type(d.get('x', {})['a']) # E: Revealed type is 'builtins.int'
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -900,7 +900,7 @@ x: object
 a: Any
 d: Dict[str, Tuple[List[Tuple[str, str]], str]]
 x, _ = d.get(a, (None, None))
-reveal_type(x) # E: Revealed type is 'Union[builtins.list[Tuple[builtins.str, builtins.str]], builtins.None]'
+reveal_type(x) # E: Revealed type is 'Union[builtins.list[Tuple[builtins.str, builtins.str]], None]'
 
 if x:
     for y in x: pass

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -6303,7 +6303,7 @@ def f(x):
     pass
 [out]
 ==
-main:3: error: No overload variant of "f" matches argument types [str]
+main:3: error: No overload variant of "f" matches argument type "str"
 
 [case testOverloadsDeleted]
 import mod
@@ -6412,7 +6412,7 @@ from typing import TypeVar
 T = TypeVar('T', bound=str)
 [out]
 ==
-a.py:2: error: No overload variant of "f" matches argument types [int]
+a.py:2: error: No overload variant of "f" matches argument type "int"
 
 [case testOverloadsGenericToNonGeneric]
 import a
@@ -6437,7 +6437,7 @@ from typing import TypeVar
 class T: pass
 [out]
 ==
-a.py:2: error: No overload variant of "f" matches argument types [int]
+a.py:2: error: No overload variant of "f" matches argument type "int"
 
 [case testOverloadsToNonOverloaded]
 import a
@@ -6592,7 +6592,7 @@ class C:
 [builtins fixtures/dict.pyi]
 [out]
 ==
-a.py:2: error: No overload variant of "B" matches argument types [int]
+a.py:2: error: No overload variant of "B" matches argument type "int"
 
 [case testOverloadedToNormalMethodMetaclass]
 import a

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1351,13 +1351,13 @@ def f() -> Iterator[None]:
 2: <b>, __main__
 3: <b>, __main__, a
 [out]
-main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
+main:2: error: Revealed type is 'contextlib.GeneratorContextManager[None]'
 ==
 a.py:3: error: Cannot find module named 'b'
 a.py:3: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
-main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
+main:2: error: Revealed type is 'contextlib.GeneratorContextManager[None]'
 ==
-main:2: error: Revealed type is 'contextlib.GeneratorContextManager[builtins.None]'
+main:2: error: Revealed type is 'contextlib.GeneratorContextManager[None]'
 
 [case testDecoratorSpecialCase1]
 import a

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -6303,7 +6303,7 @@ def f(x):
     pass
 [out]
 ==
-main:3: error: No overload variant of "f" matches argument types [builtins.str]
+main:3: error: No overload variant of "f" matches argument types [str]
 
 [case testOverloadsDeleted]
 import mod
@@ -6412,7 +6412,7 @@ from typing import TypeVar
 T = TypeVar('T', bound=str)
 [out]
 ==
-a.py:2: error: No overload variant of "f" matches argument types [builtins.int]
+a.py:2: error: No overload variant of "f" matches argument types [int]
 
 [case testOverloadsGenericToNonGeneric]
 import a
@@ -6437,7 +6437,7 @@ from typing import TypeVar
 class T: pass
 [out]
 ==
-a.py:2: error: No overload variant of "f" matches argument types [builtins.int]
+a.py:2: error: No overload variant of "f" matches argument types [int]
 
 [case testOverloadsToNonOverloaded]
 import a
@@ -6592,7 +6592,7 @@ class C:
 [builtins fixtures/dict.pyi]
 [out]
 ==
-a.py:2: error: No overload variant of "B" matches argument types [builtins.int]
+a.py:2: error: No overload variant of "B" matches argument types [int]
 
 [case testOverloadedToNormalMethodMetaclass]
 import a

--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -319,7 +319,7 @@ def f(x): # type: (unicode) -> int
 def f(x): # type: (bytearray) -> int
   pass
 [out]
-_program.py:2: error: No overload variant of "f" matches argument types [int]
+_program.py:2: error: No overload variant of "f" matches argument type "int"
 
 [case testByteArrayStrCompatibility_python2]
 def f(x): # type: (str) -> None

--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -319,7 +319,7 @@ def f(x): # type: (unicode) -> int
 def f(x): # type: (bytearray) -> int
   pass
 [out]
-_program.py:2: error: No overload variant of "f" matches argument types [builtins.int]
+_program.py:2: error: No overload variant of "f" matches argument types [int]
 
 [case testByteArrayStrCompatibility_python2]
 def f(x): # type: (str) -> None

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1044,7 +1044,7 @@ reveal_type(d.get(s))
 _testTypedDictGet.py:7: error: Revealed type is 'builtins.int'
 _testTypedDictGet.py:8: error: Revealed type is 'builtins.str'
 _testTypedDictGet.py:9: error: TypedDict "D" has no key 'z'
-_testTypedDictGet.py:10: error: No overload variant of "get" of "Mapping" matches argument types []
+_testTypedDictGet.py:10: error: All overload variants of "get" of "Mapping" take at least one argument
 _testTypedDictGet.py:12: error: Revealed type is 'builtins.object*'
 
 [case testTypedDictMappingMethods]

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1044,7 +1044,7 @@ reveal_type(d.get(s))
 _testTypedDictGet.py:7: error: Revealed type is 'builtins.int'
 _testTypedDictGet.py:8: error: Revealed type is 'builtins.str'
 _testTypedDictGet.py:9: error: TypedDict "D" has no key 'z'
-_testTypedDictGet.py:10: error: All overload variants of "get" of "Mapping" take at least one argument
+_testTypedDictGet.py:10: error: All overload variants of "get" of "Mapping" require at least one argument
 _testTypedDictGet.py:12: error: Revealed type is 'builtins.object*'
 
 [case testTypedDictMappingMethods]

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -1405,7 +1405,7 @@ MypyFile:1(
     f
     Args(
       Var(x))
-    def (x: Union[builtins.int, builtins.None])
+    def (x: Union[builtins.int, None])
     Block:2(
       PassStmt:2())))
 
@@ -1419,7 +1419,7 @@ MypyFile:1(
     f
     Args(
       Var(x))
-    def (x: Union[builtins.int, builtins.None, builtins.str])
+    def (x: Union[builtins.int, None, builtins.str])
     Block:2(
       PassStmt:2())))
 
@@ -1446,7 +1446,7 @@ MypyFile:1(
   AssignmentStmt:2(
     NameExpr(x [__main__.x])
     IntExpr(1)
-    Union[builtins.int, builtins.None]))
+    Union[builtins.int, None]))
 
 [case testInvalidOptionalType]
 from typing import Optional

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -414,7 +414,7 @@ class B(A[C]):
   def g(self, c: C) -> None:
     self.f(c)
 [out]
-CallExpr(8) : builtins.None
+CallExpr(8) : None
 MemberExpr(8) : def (a: C)
 NameExpr(8) : C
 NameExpr(8) : B
@@ -430,7 +430,7 @@ class B(A[C, T], Generic[T]):
   def g(self, c: C) -> None:
     self.f(c)
 [out]
-CallExpr(9) : builtins.None
+CallExpr(9) : None
 MemberExpr(9) : def (a: C)
 NameExpr(9) : C
 NameExpr(9) : B[T`1]
@@ -446,7 +446,7 @@ b = None # type: B
 c = None # type: C
 b.f(c)
 [out]
-CallExpr(9) : builtins.None
+CallExpr(9) : None
 MemberExpr(9) : def (a: C)
 NameExpr(9) : B
 NameExpr(9) : C
@@ -597,11 +597,11 @@ class A(Generic[T]): pass
 class B: pass
 class C(B): pass
 [out]
-CallExpr(4) : builtins.None
+CallExpr(4) : None
 CallExpr(4) : A[B]
-CallExpr(5) : builtins.None
+CallExpr(5) : None
 CallExpr(5) : A[B]
-CallExpr(6) : builtins.None
+CallExpr(6) : None
 CallExpr(6) : A[B]
 
 [case testInferGenericTypeForLocalVariable]
@@ -1114,7 +1114,7 @@ m(fun,
 [out]
 IntExpr(13) : builtins.int
 ListExpr(13) : builtins.list[builtins.int]
-CallExpr(14) : builtins.None
+CallExpr(14) : None
 NameExpr(14) : def (s: builtins.int) -> builtins.int
 NameExpr(14) : def (fun: def (builtins.int) -> builtins.int, iter: builtins.list[builtins.int])
 NameExpr(15) : builtins.list[builtins.int]


### PR DESCRIPTION
Part of #5072.

Overloads are probably the most common user-facing feature that still outputs "builtins" in error messages; this diff fixes them to use standard type formatting.

I also change `builtins.None` to `None`, since `builtins.None` is a syntax error. A comment claimed that we use `builtins.None` to distinguish the type from the value, but I don't think there are a lot of contexts where that confusion is likely.