### PR TITLE
Refactoring: Cleanup DataSuite fields

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -659,7 +659,7 @@ class DataSuite:
 
     base_path = test_temp_dir
 
-    # Allow mypyc to update to using a recent version of mypy. See #4779
+    # Allow external users of the test code to override the data prefix
     data_prefix = test_data_prefix
 
     required_out_section = False

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -162,7 +162,7 @@ def parse_test_cases(parent: 'DataSuiteCollector', suite: 'DataSuite',
                         ('Stale modules after pass {} must be a subset of rechecked '
                          'modules ({}:{})').format(passnum, path, p[i0].line))
 
-            if suite.optional_out:
+            if not suite.required_out_section:
                 ok = True
 
             if ok:
@@ -249,7 +249,6 @@ class DataDrivenTestCase(pytest.Item):  # type: ignore  # inheriting from Any
         if self.skip:
             pytest.skip()
         suite = self.parent.obj()
-        suite.update_data = self.config.getoption('--update-data', False)
         suite.setup()
         suite.run_case(self)
 
@@ -657,16 +656,19 @@ def has_stable_flags(testcase: DataDrivenTestCase) -> bool:
 class DataSuite:
     # option fields - class variables
     files = None  # type: List[str]
-    base_path = '.'
+
+    base_path = test_temp_dir
+
+    # Allow mypyc to update to using a recent version of mypy. See #4779
     data_prefix = test_data_prefix
-    optional_out = False
+
+    required_out_section = False
+
     native_sep = False
+
     # Name suffix automatically added to each test case in the suite (can be
     # used to distinguish test cases in suites that share data files)
     test_name_suffix = ''
-
-    # Assigned from MypyDataCase.runtest
-    update_data = False
 
     def setup(self) -> None:
         """Setup fixtures (ad-hoc)"""

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -82,8 +82,6 @@ typecheck_files = [
 
 class TypeCheckSuite(DataSuite):
     files = typecheck_files
-    base_path = test_temp_dir
-    optional_out = True
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         incremental = ('incremental' in testcase.name.lower()
@@ -180,7 +178,7 @@ class TypeCheckSuite(DataSuite):
         else:
             raise AssertionError()
 
-        if output != a and self.update_data:
+        if output != a and testcase.config.getoption('--update-data', False):
             update_testcase_output(testcase, a)
         assert_string_arrays_equal(output, a, msg.format(testcase.file, testcase.line))
 

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -29,8 +29,6 @@ cmdline_files = [
 
 class PythonCmdlineSuite(DataSuite):
     files = cmdline_files
-    base_path = test_temp_dir
-    optional_out = True
     native_sep = True
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:

--- a/mypy/test/testdeps.py
+++ b/mypy/test/testdeps.py
@@ -33,8 +33,6 @@ class GetDependenciesSuite(DataSuite):
         'deps-statements.test',
         'deps-classes.test',
     ]
-    base_path = test_temp_dir
-    optional_out = True
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         src = '\n'.join(testcase.input)

--- a/mypy/test/testdiff.py
+++ b/mypy/test/testdiff.py
@@ -17,8 +17,6 @@ from mypy.test.helpers import assert_string_arrays_equal
 
 class ASTDiffSuite(DataSuite):
     files = ['diff.test']
-    base_path = test_temp_dir
-    optional_out = True
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         first_src = '\n'.join(testcase.input)

--- a/mypy/test/testerrorstream.py
+++ b/mypy/test/testerrorstream.py
@@ -4,7 +4,6 @@ from typing import List, Callable, Optional
 import os
 
 from mypy import defaults, build
-from mypy.test.config import test_temp_dir
 from mypy.test.helpers import assert_string_arrays_equal
 from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.build import BuildSource
@@ -15,6 +14,8 @@ from mypy.types import Type
 
 
 class ErrorStreamSuite(DataSuite):
+    required_out_section = True
+    base_path = '.'
     files = ['errorstream.test']
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -47,8 +47,6 @@ class FineGrainedSuite(DataSuite):
         'fine-grained-blockers.test',
         'fine-grained-modules.test',
     ]
-    base_path = test_temp_dir
-    optional_out = True
     # Whether to use the fine-grained cache in the testing. This is overridden
     # by a trivial subclass to produce a suite that uses the cache.
     use_cache = False

--- a/mypy/test/testmerge.py
+++ b/mypy/test/testmerge.py
@@ -45,8 +45,6 @@ NOT_DUMPED_MODULES = (
 
 class ASTMergeSuite(DataSuite):
     files = ['merge.test']
-    base_path = test_temp_dir
-    optional_out = True
 
     def setup(self) -> None:
         super().setup()

--- a/mypy/test/testparse.py
+++ b/mypy/test/testparse.py
@@ -9,6 +9,8 @@ from mypy.options import Options
 
 
 class ParserSuite(DataSuite):
+    required_out_section = True
+    base_path = '.'
     files = ['parse.test',
              'parse-python2.test']
 
@@ -48,6 +50,8 @@ INPUT_FILE_NAME = 'file'
 
 
 class ParseErrorSuite(DataSuite):
+    required_out_section = True
+    base_path = '.'
     files = ['parse-errors.test']
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -35,8 +35,6 @@ class PythonEvaluationSuite(DataSuite):
     files = ['pythoneval.test',
              'python2eval.test',
              'pythoneval-asyncio.test']
-    base_path = test_temp_dir
-    optional_out = True
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         test_python_evaluation(testcase)

--- a/mypy/test/testsemanal.py
+++ b/mypy/test/testsemanal.py
@@ -45,8 +45,6 @@ def get_semanal_options() -> Options:
 
 class SemAnalSuite(DataSuite):
     files = semanal_files
-    base_path = test_temp_dir
-    optional_out = True
     native_sep = True
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
@@ -99,8 +97,6 @@ def test_semanal(testcase: DataDrivenTestCase) -> None:
 
 class SemAnalErrorSuite(DataSuite):
     files = ['semanal-errors.test']
-    base_path = test_temp_dir
-    optional_out = True
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         test_semanal_error(testcase)
@@ -128,8 +124,8 @@ def test_semanal_error(testcase: DataDrivenTestCase) -> None:
 # SymbolNode table export test cases
 
 class SemAnalSymtableSuite(DataSuite):
+    required_out_section = True
     files = ['semanal-symtable.test']
-    base_path = test_temp_dir
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         """Perform a test case."""
@@ -158,8 +154,8 @@ class SemAnalSymtableSuite(DataSuite):
 
 # Type info export test cases
 class SemAnalTypeInfoSuite(DataSuite):
+    required_out_section = True
     files = ['semanal-typeinfo.test']
-    base_path = test_temp_dir
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         """Perform a test case."""

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -112,6 +112,8 @@ class StubgenUtilSuite(Suite):
 
 
 class StubgenPythonSuite(DataSuite):
+    required_out_section = True
+    base_path = '.'
     files = ['stubgen.test']
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:

--- a/mypy/test/testtransform.py
+++ b/mypy/test/testtransform.py
@@ -17,6 +17,7 @@ from mypy.options import Options
 
 
 class TransformSuite(DataSuite):
+    required_out_section = True
     # Reuse semantic analysis test cases.
     files = ['semanal-basic.test',
              'semanal-expressions.test',
@@ -26,7 +27,6 @@ class TransformSuite(DataSuite):
              'semanal-statements.test',
              'semanal-abstractclasses.test',
              'semanal-python2.test']
-    base_path = test_temp_dir
     native_sep = True
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:

--- a/mypy/test/testtypegen.py
+++ b/mypy/test/testtypegen.py
@@ -19,8 +19,8 @@ from mypy.options import Options
 
 
 class TypeExportSuite(DataSuite):
+    required_out_section = True
     files = ['typexport-basic.test']
-    base_path = test_temp_dir
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         try:


### PR DESCRIPTION
Simple changes to DataSuite, I believe they make things somewhat more readable and explicit.

* Default `base_path` to `test_temp_dir`; this clearly marks tests that do something unusual 
* Rename `optional_out` to `required_out_section` and default to `False`
* Remove `update_data`, and inline the only place it is used. The flag might be reintroduced if the functionality will be shared with other suites
* Document reason for `data_prefix`, since it is not written anywhere
