### PR TITLE
Add additional support for file encoding comments

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -55,6 +55,8 @@ def find_python_encoding(text: bytes, pyversion: Tuple[int, int]) -> Tuple[str, 
         # Handle some aliases that Python is happy to accept and that are used in the wild.
         if encoding.startswith(('iso-latin-1-', 'latin-1-')) or encoding == 'iso-latin-1':
             encoding = 'latin-1'
+        elif encoding.startswith('utf-8-'):
+            encoding = 'utf8'
         return encoding, line
     else:
         default_encoding = 'utf8' if pyversion[0] >= 3 else 'ascii'


### PR DESCRIPTION
Emacs File Encoding comments support encodings such as "utf-8-unix" for UTF-8 encoded files that use Unix-newlines (a.k.a. \n). MyPy keeps failing due to my files using "utf-8-unix". The code I added will also support "utf-8-mac" (\r) and "utf-8-dos" (\r\n).

I am currently using this fix on my own system with success.