### PR TITLE
Add self-check to pytests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ install:
   - pip install .
 
 script:
-  - python runtests.py -j12 -x lint -x package
+  - python runtests.py -j12 -x lint -x self-check
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then flake8; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.5.1' ]]; then python runtests.py package; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ build: off
 
 test_script:
     # Ignore lint and mypy self check (both run in Travis)
-    - "%PYTHON%\\python.exe runtests.py -x lint -x package -x pytest"
+    - "%PYTHON%\\python.exe runtests.py -x lint -x self-check -x pytest"
     - "%PYTHON%\\python.exe runtests.py pytest -p -k -p \"not (PythonEvaluationSuite and python2)\""
 
 skip_commits:

--- a/mypy/test/testselfcheck.py
+++ b/mypy/test/testselfcheck.py
@@ -1,0 +1,29 @@
+"""Self check mypy package"""
+import sys
+from typing import List
+
+import pytest  # type: ignore
+
+from mypy.test.helpers import Suite
+from mypy.api import run
+
+
+class SelfCheckSuite(Suite):
+    def test_mypy_package(self) -> None:
+        run_mypy(['-p', 'mypy'])
+
+    def test_testrunner(self) -> None:
+        run_mypy(['runtests.py', 'waiter.py'])
+
+
+def run_mypy(args: List[str]) -> None:
+    __tracebackhide__ = True
+    outval, errval, status = run(args + ['--config-file', 'mypy_self_check.ini',
+                                         '--show-traceback',
+                                         '--no-site-packages'])
+    if status != 0:
+        sys.stdout.write(outval)
+        errval = '\n'.join(line for line in errval.split('\n')
+                           if 'mypy_self_check.ini' not in line)
+        sys.stderr.write(errval)
+        pytest.fail(msg="Self check failed", pytrace=False)


### PR DESCRIPTION
Yet another item for #1673.

This PR uses the api for the self-check. 

Example of a failed-run output:
```
~/workspace/mypy$ pytest -n0 -k test_mypy_package
================================ test session starts ================================
platform darwin -- Python 3.6.5, pytest-3.2.5, py-1.5.2, pluggy-0.4.0
rootdir: ~/workspace/mypy, inifile: pytest.ini
plugins: xdist-1.20.1, forked-0.2, cov-2.5.1
collected 6240 items                                                                 

mypy/test/testselfcheck.py F

===================================== FAILURES ======================================
_________________________ SelfCheckSuite.test_mypy_package __________________________
Self check failed
------------------------------- Captured stdout call --------------------------------
mypy/binder.py:254: error: No return value expected
=============================== 6239 tests deselected ===============================
==================== 1 failed, 6239 deselected in 23.75 seconds =====================
```

`$ ./runtests.py self-check` results in a similar output, though slightly more verbose, as usual.