### PR TITLE
Fix an aststrip crash

### DIFF
--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -213,9 +213,7 @@ class NodeStripVisitor(TraverserVisitor):
             for name, as_name in node.ids:
                 imported_name = as_name or name
                 initial = imported_name.split('.')[0]
-                symnode = self.names[initial]
-                symnode.kind = UNBOUND_IMPORTED
-                symnode.node = None
+                self.names[initial] = SymbolTableNode(UNBOUND_IMPORTED, None)
 
     def visit_import_all(self, node: ImportAll) -> None:
         # Imports can include both overriding symbols and fresh ones,

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1622,6 +1622,40 @@ T = TypeVar('T')
 [out]
 ==
 
+[case testImportStarOverlap2]
+from b import *
+import typing
+def foo(x: typing.List[int]) -> int:
+    return x[0]
+[file b.py]
+import typing
+z = 10
+[file b.py.2]
+import typing
+z = '10'
+[builtins fixtures/list.pyi]
+[out]
+==
+
+
+[case testImportStarOverlap3]
+from b import *
+from c import typing
+def foo(x: typing.List[int]) -> int:
+    return x[0]
+[file b.py]
+import typing
+z = 10
+[file b.py.2]
+import typing
+z = '10'
+[file c.py]
+import typing
+z = 10
+[builtins fixtures/list.pyi]
+[out]
+==
+
 
 [case testImportPartialAssign]
 import a


### PR DESCRIPTION
Bug found testing on Zulip.

Don't blithely index into self.names, since stripping ImportAll
deletes entries.