### PR TITLE
Do not serialize symbol table nodes added by 'add_submodules_to_parent_modules'

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2500,6 +2500,7 @@ class SymbolTableNode:
                  'implicit',
                  'is_aliasing',
                  'alias_name',
+                 'no_serialize'
                  )
 
     # TODO: This is a mess. Refactor!

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2513,7 +2513,9 @@ class SymbolTableNode:
                  normalized: bool = False,
                  alias_tvars: Optional[List[str]] = None,
                  implicit: bool = False,
-                 module_hidden: bool = False) -> None:
+                 module_hidden: bool = False,
+                 *,
+                 no_serialize: bool = False) -> None:
         self.kind = kind
         self.node = node
         self.type_override = typ
@@ -2525,6 +2527,7 @@ class SymbolTableNode:
         self.cross_ref = None  # type: Optional[str]
         self.is_aliasing = False
         self.alias_name = None  # type: Optional[str]
+        self.no_serialize = no_serialize
 
     @property
     def fullname(self) -> Optional[str]:
@@ -2660,7 +2663,7 @@ class SymbolTable(Dict[str, SymbolTableNode]):
             # module that gets added to every module by
             # SemanticAnalyzerPass2.visit_file(), but it shouldn't be
             # accessed by users of the module.
-            if key == '__builtins__':
+            if key == '__builtins__' or value.no_serialize:
                 continue
             data[key] = value.serialize(fullname, key)
         return data

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1301,7 +1301,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 child_mod = self.modules.get(id)
                 if child_mod:
                     sym = SymbolTableNode(MODULE_REF, child_mod,
-                                          module_public=module_public)
+                                          module_public=module_public,
+                                          no_serialize=True)
                     parent_mod.names[child] = sym
             id = parent
 


### PR DESCRIPTION
A hot fix for a complicated crash due to a poisoned cache (discovered internally).