### PR TITLE
Add a test case for the bug fixed by #5094

### DIFF
--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4358,6 +4358,22 @@ import b
 [file b.py.2]
 # uh
 -- b gets rechecked because it changed, but nothing is stale
--- since the interface didn't change
+-- since the interface did not change
 [stale]
 [rechecked b]
+
+[case testParentPatchingMess]
+# cmd: mypy -m d d.k d.k.a d.k.v t
+[file d/__init__.py]
+[file d/k/__init__.py]
+from d.k.a import x
+[file d/k/a.py]
+x = 10
+[file d/k/v.py]
+from d.k.e import x  # type: ignore
+
+[file t.py]
+from d import k
+[file t.py.2]
+from d import k
+# dummy change

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4363,6 +4363,7 @@ import b
 [rechecked b]
 
 [case testParentPatchingMess]
+# flags: --ignore-missing-imports --follow-imports=skip
 # cmd: mypy -m d d.k d.k.a d.k.v t
 [file d/__init__.py]
 [file d/k/__init__.py]
@@ -4370,7 +4371,7 @@ from d.k.a import x
 [file d/k/a.py]
 x = 10
 [file d/k/v.py]
-from d.k.e import x  # type: ignore
+from d.k.e import x
 
 [file t.py]
 from d import k


### PR DESCRIPTION
It looks like what happened is that since d.k.e doesn't exist, d.k.v
doesn't depend on d or d.k. However, it still performs parent patching
on them. Since there isn't a dependency, this can occur *before* d is
processed, which causes the parent patched symbol table entries to be
present when serialization occurs. This causes bogus cache entries to
be written.