### PR TITLE
Preserve the name of first argument in methods when serializing

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1254,6 +1254,13 @@ class MessageBuilder:
                     s = ', ' + s
                 s = definition_args[0] + s
             s = '{}({})'.format(tp.definition.name(), s)
+        elif tp.name:
+            first_arg = tp.def_extras.get('first_arg')
+            if first_arg:
+                if s:
+                    s = ', ' + s
+                s = first_arg + s
+            s = '{}({})'.format(tp.name.split()[0], s)  # skip "of Class" part
         else:
             s = '({})'.format(s)
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -931,18 +931,18 @@ class CallableType(FunctionLike):
         assert data['.class'] == 'CallableType'
         # TODO: Set definition to the containing SymbolNode?
         call_type = CallableType([deserialize_type(t) for t in data['arg_types']],
-                            data['arg_kinds'],
-                            data['arg_names'],
-                            deserialize_type(data['ret_type']),
-                            Instance.deserialize(data['fallback']),
-                            name=data['name'],
-                            variables=[TypeVarDef.deserialize(v) for v in data['variables']],
-                            is_ellipsis_args=data['is_ellipsis_args'],
-                            implicit=data['implicit'],
-                            is_classmethod_class=data['is_classmethod_class'],
-                            bound_args=[(None if t is None else deserialize_type(t))
-                                        for t in data['bound_args']],
-                            )
+                                 data['arg_kinds'],
+                                 data['arg_names'],
+                                 deserialize_type(data['ret_type']),
+                                 Instance.deserialize(data['fallback']),
+                                 name=data['name'],
+                                 variables=[TypeVarDef.deserialize(v) for v in data['variables']],
+                                 is_ellipsis_args=data['is_ellipsis_args'],
+                                 implicit=data['implicit'],
+                                 is_classmethod_class=data['is_classmethod_class'],
+                                 bound_args=[(None if t is None else deserialize_type(t))
+                                            for t in data['bound_args']],
+                                 )
         call_type.def_extras = data['def_extras']
         return call_type
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4378,3 +4378,35 @@ from d import k
 [file t.py.2]
 from d import k
 # dummy change
+
+[case testCachedBadProtocolNote]
+import b
+[file a.py]
+from mypy_extensions import TypedDict
+Point = TypedDict('Point', {'x': int, 'y': int})
+[file b.py]
+from typing import Iterable
+from a import Point
+p: Point
+it: Iterable[int] = p
+[file b.py.2]
+from typing import Iterable
+from a import Point
+p: Point
+it: Iterable[int] = p  # change
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dict.pyi]
+[out]
+tmp/b.py:4: error: Incompatible types in assignment (expression has type "Point", variable has type "Iterable[int]")
+tmp/b.py:4: note: Following member(s) of "Point" have conflicts:
+tmp/b.py:4: note:     Expected:
+tmp/b.py:4: note:         def __iter__(self) -> Iterator[int]
+tmp/b.py:4: note:     Got:
+tmp/b.py:4: note:         def __iter__(self) -> Iterator[str]
+[out2]
+tmp/b.py:4: error: Incompatible types in assignment (expression has type "Point", variable has type "Iterable[int]")
+tmp/b.py:4: note: Following member(s) of "Point" have conflicts:
+tmp/b.py:4: note:     Expected:
+tmp/b.py:4: note:         def __iter__(self) -> Iterator[int]
+tmp/b.py:4: note:     Got:
+tmp/b.py:4: note:         def __iter__(self) -> Iterator[str]


### PR DESCRIPTION
This is useful to give nicer error messages after serialization.

This is a step towards #4772 
Unblocks #1412 (much faster `pythoneval` tests).