### PR TITLE
Fix testcmdline when it is run with py.test -n0

### DIFF
--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -11,7 +11,7 @@ import sys
 
 from typing import List
 
-from mypy.test.config import test_temp_dir
+from mypy.test.config import test_temp_dir, PREFIX
 from mypy.test.data import fix_cobertura_filename
 from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.test.helpers import assert_string_arrays_equal, normalize_error_messages
@@ -48,10 +48,12 @@ def test_python_cmdline(testcase: DataDrivenTestCase) -> None:
     args.append('--no-site-packages')
     # Type check the program.
     fixed = [python3_path, '-m', 'mypy']
+    env = {'PYTHONPATH': PREFIX}
     process = subprocess.Popen(fixed + args,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.STDOUT,
-                               cwd=test_temp_dir)
+                               cwd=test_temp_dir,
+                               env=env)
     outb = process.stdout.read()
     # Split output into lines.
     out = [s.rstrip('\n\r') for s in str(outb, 'utf8').splitlines()]

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -48,7 +48,8 @@ def test_python_cmdline(testcase: DataDrivenTestCase) -> None:
     args.append('--no-site-packages')
     # Type check the program.
     fixed = [python3_path, '-m', 'mypy']
-    env = {'PYTHONPATH': PREFIX}
+    env = os.environ.copy()
+    env['PYTHONPATH'] = PREFIX
     process = subprocess.Popen(fixed + args,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.STDOUT,


### PR DESCRIPTION
The test runner sets PYTHONPATH when parallelized but not with -n0.
Our subprocess was depending on this to find mypy. We should set up
the state we care about ourselves, so just do that.

The common failure mode here was the tests failing, but I also ran
into a more terrifying mode where it was invoking my installed system
mypy!

This is basically the same fix elazarg proposed in #4127 but that
never went anywhere for unclear reasons.

Fixes #4127.