### PR TITLE
Allow wildcards inside of configuration section names

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -31,14 +31,30 @@ characters.
 
 - Additional sections named ``[mypy-PATTERN1,PATTERN2,...]`` may be
   present, where ``PATTERN1``, ``PATTERN2``, etc., are comma-separated
-  patterns of the form ``dotted_module_name`` or ``dotted_module_name.*``.
+  patterns of fully-qualified module names, with some components optionally
+  replaced by `*`s (e.g. ``foo.bar``, ``foo.bar.*``, ``foo.*.baz``).
   These sections specify additional flags that only apply to *modules*
   whose name matches at least one of the patterns.
 
-  A pattern of the form ``dotted_module_name`` matches only the named module,
-  while ``dotted_module_name.*`` matches ``dotted_module_name`` and any
+  A pattern of the form ``qualified_module_name`` matches only the named module,
+  while ``qualified_module_name.*`` matches ``dotted_module_name`` and any
   submodules (so ``foo.bar.*`` would match all of ``foo.bar``,
   ``foo.bar.baz``, and ``foo.bar.baz.quux``).
+
+  Patterns may also be "unstructured" wildcards, in which ``*``s may
+  appear in the middle of a name (e.g
+  ``site.*.migrations.*``). Internal ``*``s match one or more module
+  component.
+
+  When options conflict, the precedence order for the configuration sections is:
+    1. Sections with concrete module names (``foo.bar``)
+    2. Sections with "unstructured" wildcard patterns (``foo.*.baz``),
+       with sections later in the configuration file overriding
+       sections earlier.
+    3. Sections with "well-structured" wildcard patterns
+       (``foo.bar.*``), with more specific overriding more general.
+    4. Command line options.
+    5. Top-level configuration file options.
 
 .. note::
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -41,10 +41,10 @@ characters.
   submodules (so ``foo.bar.*`` would match all of ``foo.bar``,
   ``foo.bar.baz``, and ``foo.bar.baz.quux``).
 
-  Patterns may also be "unstructured" wildcards, in which ``*``s may
+  Patterns may also be "unstructured" wildcards, in which stars may
   appear in the middle of a name (e.g
-  ``site.*.migrations.*``). Internal ``*``s match one or more module
-  component.
+  ``site.*.migrations.*``). Internal stars match one or more module
+  components.
 
   When options conflict, the precedence order for the configuration sections is:
     1. Sections with concrete module names (``foo.bar``)

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -43,8 +43,8 @@ characters.
 
   Patterns may also be "unstructured" wildcards, in which stars may
   appear in the middle of a name (e.g
-  ``site.*.migrations.*``). Internal stars match one or more module
-  components.
+  ``site.*.migrations.*``). Stars match zero or more module
+  components (so ``site.*.migrations.*`` can match ``site.migrations``).
 
   When options conflict, the precedence order for the configuration sections is:
     1. Sections with concrete module names (``foo.bar``)
@@ -55,6 +55,10 @@ characters.
        (``foo.bar.*``), with more specific overriding more general.
     4. Command line options.
     5. Top-level configuration file options.
+
+The difference in precedence order between "structured" patterns (by
+specificity) and "unstructured" patterns (by order in the file) is
+unfortunate, and is subject to change in future versions.
 
 .. note::
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -746,8 +746,9 @@ def parse_config_file(options: Options, filename: Optional[str]) -> None:
                     glob = glob.replace(os.altsep, '.')
 
                 if (any(c in glob for c in '?[]!') or
-                        ('*' in glob and (not glob.endswith('.*') or '*' in glob[:-2]))):
-                    print("%s: Invalid pattern. Patterns must be 'module_name' or 'module_name.*'"
+                    any('*' in x and x != '*' for x in glob.split('.'))):
+                    print("%s: Patterns must be fully-qualified module names, optionally "
+                          "with '*' in some components (e.g spam.*.eggs.*)'"
                           % prefix,
                           file=sys.stderr)
                 else:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -746,7 +746,7 @@ def parse_config_file(options: Options, filename: Optional[str]) -> None:
                     glob = glob.replace(os.altsep, '.')
 
                 if (any(c in glob for c in '?[]!') or
-                    any('*' in x and x != '*' for x in glob.split('.'))):
+                        any('*' in x and x != '*' for x in glob.split('.'))):
                     print("%s: Patterns must be fully-qualified module names, optionally "
                           "with '*' in some components (e.g spam.*.eggs.*)"
                           % prefix,

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -748,7 +748,7 @@ def parse_config_file(options: Options, filename: Optional[str]) -> None:
                 if (any(c in glob for c in '?[]!') or
                     any('*' in x and x != '*' for x in glob.split('.'))):
                     print("%s: Patterns must be fully-qualified module names, optionally "
-                          "with '*' in some components (e.g spam.*.eggs.*)'"
+                          "with '*' in some components (e.g spam.*.eggs.*)"
                           % prefix,
                           file=sys.stderr)
                 else:

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -220,7 +220,8 @@ class Options:
 
         # Config precedence is as follows:
         #  1. Concrete section names: foo.bar.baz
-        #  2. "Unstructured" glob patterns: foo.*.baz, in the order they appear in the file (last wins)
+        #  2. "Unstructured" glob patterns: foo.*.baz, in the order
+        #     they appear in the file (last wins)
         #  3. "Well-structured" wildcard patterns: foo.bar.*, in specificity order.
 
         # Since structured configs inherit from structured configs above them in the hierarchy,
@@ -305,10 +306,12 @@ class Options:
     def compile_glob(self, s: str) -> Pattern[str]:
         # Compile one of the glob patterns to a regex so that '.*' can
         # match *zero or more* module sections. This means we compile
-        # '.*' into '(\..*)?'. We also need to escape .s in the glob, so
-        # we hackily rewrite .s to ,s to accomplish this.
-        s = s.replace('.', ',').replace(',*', '(\..*)?').replace(',', '\.')
-        return re.compile(s + '\\Z')
+        # '.*' into '(\..*)?'.
+        parts = s.split('.')
+        expr = re.escape(parts[0]) if parts[0] != '*' else '.*'
+        for part in parts[1:]:
+            expr += re.escape('.' + part) if part != '*' else '(\..*)?'
+        return re.compile(expr + '\\Z')
 
     def select_options_affecting_cache(self) -> Mapping[str, object]:
         return {opt: getattr(self, opt) for opt in self.OPTIONS_AFFECTING_CACHE}

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -242,7 +242,7 @@ class Options:
         for glob in unstructured_glob_keys:
             self.glob_options.append((glob, re.compile(fnmatch.translate(glob))))
 
-        # We (for ease of implementation), treat unstructured glob
+        # We (for ease of implementation) treat unstructured glob
         # sections as used if any real modules use them or if any
         # concrete config sections use them. This means we need to
         # track which get used while constructing.
@@ -256,7 +256,8 @@ class Options:
             new_options = options.apply_changes(self.per_module_options[key])
             self.per_module_cache[key] = new_options
 
-        # Add the more structured sections into unused configs .
+        # Add the more structured sections into unused configs, since
+        # they only count as used if actually used by a real module.
         self.unused_configs.update(structured_keys)
 
     def clone_for_module(self, module: str) -> 'Options':

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -203,8 +203,8 @@ def g(a: int) -> int: return f(a)
 def f(a): pass
 def g(a: int) -> int: return f(a)
 [out]
-mypy.ini: [mypy-*x*]: Invalid pattern. Patterns must be 'module_name' or 'module_name.*'
-mypy.ini: [mypy-*y*]: Invalid pattern. Patterns must be 'module_name' or 'module_name.*'
+mypy.ini: [mypy-*x*]: Patterns must be fully-qualified module names, optionally with '*' in some components (e.g spam.*.eggs.*)
+mypy.ini: [mypy-*y*]: Patterns must be fully-qualified module names, optionally with '*' in some components (e.g spam.*.eggs.*)
 == Return code: 0
 
 [case testMultipleGlobConfigSection]
@@ -268,7 +268,7 @@ mypy.ini: [mypy]: ignore_missing_imports: Not a boolean: nah
 python_version = 3.4
 [out]
 mypy.ini: [mypy-*]: Per-module sections should only specify per-module flags (python_version)
-mypy.ini: [mypy-*]: Invalid pattern. Patterns must be 'module_name' or 'module_name.*'
+mypy.ini: [mypy-*]: Patterns must be fully-qualified module names, optionally with '*' in some components (e.g spam.*.eggs.*)
 == Return code: 0
 
 [case testConfigMypyPath]
@@ -1179,10 +1179,37 @@ warn_unused_configs = True
 [[mypy-spam.eggs]
 [[mypy-emarg.*]
 [[mypy-emarg.hatch]
+[[mypy-a.*.b]
+[[mypy-a.*.c]
+[[mypy-a.x.b]
 [file foo.py]
 [file quux.py]
 [file spam/__init__.py]
 [file spam/eggs.py]
 [out]
-Warning: unused section(s) in mypy.ini: [mypy-bar], [mypy-baz.*], [mypy-emarg.*], [mypy-emarg.hatch]
+Warning: unused section(s) in mypy.ini: [mypy-bar], [mypy-baz.*], [mypy-emarg.*], [mypy-emarg.hatch], [mypy-a.*.c], [mypy-a.x.b]
 == Return code: 0
+
+[case testConfigNonsense]
+# cmd: mypy emarg
+[file mypy.ini]
+[[mypy]
+ignore_errors = true
+[[mypy-emarg.*]
+ignore_errors = false
+[[mypy-emarg.*.vilip.*]
+ignore_errors = true
+[[mypy-emarg.hatch.vilip.mankangulisk]
+ignore_errors = false
+[file emarg/__init__.py]
+[file emarg/foo.py]
+fail
+[file emarg/hatch/__init__.py]
+[file emarg/hatch/vilip/__init__.py]
+[file emarg/hatch/vilip/nus.py]
+fail
+[file emarg/hatch/vilip/mankangulisk.py]
+fail
+[out]
+emarg/foo.py:1: error: Name 'fail' is not defined
+emarg/hatch/vilip/mankangulisk.py:1: error: Name 'fail' is not defined

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1178,6 +1178,9 @@ warn_unused_configs = True
 [[mypy-spam.eggs]
 [[mypy-emarg.*]
 [[mypy-emarg.hatch]
+-- Currently we don't treat an unstructured pattern like a.*.b as unused
+-- if it matches another section (like a.x.b). This would be reasonable
+-- to change.
 [[mypy-a.*.b]
 [[mypy-a.*.c]
 [[mypy-a.x.b]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -268,7 +268,6 @@ mypy.ini: [mypy]: ignore_missing_imports: Not a boolean: nah
 python_version = 3.4
 [out]
 mypy.ini: [mypy-*]: Per-module sections should only specify per-module flags (python_version)
-mypy.ini: [mypy-*]: Patterns must be fully-qualified module names, optionally with '*' in some components (e.g spam.*.eggs.*)
 == Return code: 0
 
 [case testConfigMypyPath]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1196,19 +1196,19 @@ Warning: unused section(s) in mypy.ini: [mypy-bar], [mypy-baz.*], [mypy-emarg.*]
 ignore_errors = true
 [[mypy-emarg.*]
 ignore_errors = false
-[[mypy-emarg.*.vilip.*]
+[[mypy-emarg.*.villip.*]
 ignore_errors = true
-[[mypy-emarg.hatch.vilip.mankangulisk]
+[[mypy-emarg.hatch.villip.mankangulisk]
 ignore_errors = false
 [file emarg/__init__.py]
 [file emarg/foo.py]
 fail
 [file emarg/hatch/__init__.py]
-[file emarg/hatch/vilip/__init__.py]
-[file emarg/hatch/vilip/nus.py]
+[file emarg/hatch/villip/__init__.py]
+[file emarg/hatch/villip/nus.py]
 fail
-[file emarg/hatch/vilip/mankangulisk.py]
+[file emarg/hatch/villip/mankangulisk.py]
 fail
 [out]
 emarg/foo.py:1: error: Name 'fail' is not defined
-emarg/hatch/vilip/mankangulisk.py:1: error: Name 'fail' is not defined
+emarg/hatch/villip/mankangulisk.py:1: error: Name 'fail' is not defined

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1192,7 +1192,7 @@ warn_unused_configs = True
 Warning: unused section(s) in mypy.ini: [mypy-bar], [mypy-baz.*], [mypy-emarg.*], [mypy-emarg.hatch], [mypy-a.*.c], [mypy-a.x.b]
 == Return code: 0
 
-[case testConfigNonsense]
+[case testConfigUnstructuredGlob]
 # cmd: mypy emarg
 [file mypy.ini]
 [[mypy]
@@ -1205,6 +1205,8 @@ ignore_errors = true
 ignore_errors = false
 [file emarg/__init__.py]
 [file emarg/foo.py]
+fail
+[file emarg/villip.py]
 fail
 [file emarg/hatch/__init__.py]
 [file emarg/hatch/villip/__init__.py]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1193,10 +1193,12 @@ Warning: unused section(s) in mypy.ini: [mypy-bar], [mypy-baz.*], [mypy-emarg.*]
 == Return code: 0
 
 [case testConfigUnstructuredGlob]
-# cmd: mypy emarg
+# cmd: mypy emarg foo
 [file mypy.ini]
 [[mypy]
 ignore_errors = true
+[[mypy-*.lol]
+ignore_errors = false
 [[mypy-emarg.*]
 ignore_errors = false
 [[mypy-emarg.*.villip.*]
@@ -1214,6 +1216,10 @@ fail
 fail
 [file emarg/hatch/villip/mankangulisk.py]
 fail
+[file foo/__init__.py]
+[file foo/lol.py]
+fail
 [out]
+foo/lol.py:1: error: Name 'fail' is not defined
 emarg/foo.py:1: error: Name 'fail' is not defined
 emarg/hatch/villip/mankangulisk.py:1: error: Name 'fail' is not defined


### PR DESCRIPTION
This is to support Django-style usecases with patterns like
`site.*.migrations.*`.

The implementation works by mixing in the old-style glob matching with
the new structured matching.

Fixes #5014.