### PR TITLE
Fix crash in astdiff.py related to ec11a500f.

### DIFF
--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -213,7 +213,8 @@ class NodeStripVisitor(TraverserVisitor):
             for name, as_name in node.ids:
                 imported_name = as_name or name
                 initial = imported_name.split('.')[0]
-                self.names[initial] = SymbolTableNode(UNBOUND_IMPORTED, None)
+                if initial in self.names:
+                    self.names[initial] = SymbolTableNode(UNBOUND_IMPORTED, None)
 
     def visit_import_all(self, node: ImportAll) -> None:
         # Imports can include both overriding symbols and fresh ones,


### PR DESCRIPTION
I had been seeing the same crash that patch aimed to fix running against Quip's
codebase, but have been unable to reduce it to a test case. With this patch,
we're now able to use dmypy.

Traceback from crash after ec11a500f:

  File "/usr/local/lib/python3.6/site-packages/mypy/server/update.py", line 760, in propagate_changes_using_dependencies
    triggered |= reprocess_nodes(manager, graph, id, nodes, deps)
  File "/usr/local/lib/python3.6/site-packages/mypy/server/update.py", line 920, in reprocess_nodes
    new_symbols_snapshot = snapshot_symbol_table(file_node.fullname(), file_node.names)
  File "/usr/local/lib/python3.6/site-packages/mypy/server/astdiff.py", line 159, in snapshot_symbol_table
    result[name] = snapshot_definition(node, common)
  File "/usr/local/lib/python3.6/site-packages/mypy/server/astdiff.py", line 214, in snapshot_definition
    symbol_table = snapshot_symbol_table(prefix, node.names)
  File "/usr/local/lib/python3.6/site-packages/mypy/server/astdiff.py", line 154, in snapshot_symbol_table
    assert symbol.kind != UNBOUND_IMPORTED