### PR TITLE
Always patch indirect dependencies

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2057,9 +2057,9 @@ class State:
                     manager.options.dump_deps):
                 manager.all_types.update(self.type_map())
 
-            if self.options.incremental:
-                self._patch_indirect_dependencies(self.type_checker().module_refs,
-                                                  self.type_map())
+            # We should always patch indirect dependencies, even in full (non-incremental) builds,
+            # because the cache still may be written, and it must be correct.
+            self._patch_indirect_dependencies(self.type_checker().module_refs, self.type_map())
 
             if self.options.dump_inference_stats:
                 dump_type_stats(self.tree, self.xpath, inferred=True,

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -139,7 +139,8 @@ class TypeCheckSuite(DataSuite):
         options.show_traceback = True
         if 'optional' in testcase.file:
             options.strict_optional = True
-        if incremental_step:
+        if incremental_step and options.incremental:
+            # Don't overwrite # flags: --no-incremental in incremental test cases
             options.incremental = True
         else:
             options.incremental = False

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4410,3 +4410,21 @@ tmp/b.py:4: note:     Expected:
 tmp/b.py:4: note:         def __iter__(self) -> Iterator[int]
 tmp/b.py:4: note:     Got:
 tmp/b.py:4: note:         def __iter__(self) -> Iterator[str]
+
+[case testIndirectDepsAlwaysPatched-writescache]
+# flags: --no-incremental
+# flags2: --incremental
+from b import C
+def f() -> None:
+    x: int = C().x
+[file b.py]
+from c import C
+[file c.pyi]
+class C:
+    x: int
+[file c.pyi.2]
+class C:
+    x: str
+[out]
+[out2]
+main:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")


### PR DESCRIPTION
The bug and fix are straightforward: previously caches generated in full (non-incremental) mode lacked _all_ indirect dependencies. This makes it also a bit scary, there are probably lots of invalid caches out there waiting to explode.

cc @dzbarsky