### PR TITLE
docs: fix minor typos

### DIFF
--- a/docs/source/additional_features.rst
+++ b/docs/source/additional_features.rst
@@ -307,7 +307,7 @@ build::
 
 This flag adds extra information for the daemon to the cache. In
 order to use this extra information, you will also need to use the
-``--use-fine-grained-cache`` option with ``dymypy start`` or
+``--use-fine-grained-cache`` option with ``dmypy start`` or
 ``dmypy restart``. Example::
 
     $ dmypy start -- --use-fine-grained-cache <options...>

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -417,7 +417,7 @@ understand how mypy handles a particular piece of code. Example:
    reveal_type((1, 'hello'))  # Revealed type is 'Tuple[builtins.int, builtins.str]'
 
 You can also use ``reveal_locals()`` at any line in a file
-to see the types of all local varaibles at once. Example:
+to see the types of all local variables at once. Example:
 
 .. code-block:: python
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -183,7 +183,7 @@ overridden by the pattern sections matching the module name.
   Used in conjunction with ``follow_imports=skip``, this can be used
   to suppress the import of a module from ``typeshed``, replacing it
   with `Any`.
-  Used in conjuncation with ``follow_imports=error``, this can be used
+  Used in conjunction with ``follow_imports=error``, this can be used
   to make any use of a particular ``typeshed`` module an error.
 
 - ``ignore_missing_imports`` (Boolean, default False) suppress error

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -346,7 +346,7 @@ This also works for attributes defined within methods:
 
 As a special case, you can use a non-optional type when initializing an
 attribute to ``None`` inside a class body *and* using a type comment,
-since when using a type comment, an initializer is syntacticaly required,
+since when using a type comment, an initializer is syntactically required,
 and ``None`` is used as a dummy, placeholder initializer:
 
 .. code-block:: python

--- a/docs/source/mypy_daemon.rst
+++ b/docs/source/mypy_daemon.rst
@@ -70,7 +70,7 @@ Additional features
 
 You have precise control over the lifetime of the daemon process:
 
-* ``dymypy stop`` stops the daemon.
+* ``dmypy stop`` stops the daemon.
 
 * ``dmypy restart -- <flags>`` restarts the daemon. The flags are the same
   as with ``dmypy start``. This is equivalent to a stop command followed


### PR DESCRIPTION
Fix some minor typos in the documentation.