### PR TITLE
Fix iterable unpacking so star args are always of type list

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2017,7 +2017,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             item_type = self.iterable_item_type(cast(Instance, rvalue_type))
             for lv in lvalues:
                 if isinstance(lv, StarExpr):
-                    self.check_assignment(lv.expr, self.temp_node(rvalue_type, context),
+                    items_type = self.named_generic_type('builtins.list', [item_type])
+                    self.check_assignment(lv.expr, self.temp_node(items_type, context),
                                           infer_lvalue_type)
                 else:
                     self.check_assignment(lv, self.temp_node(item_type, context),

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -563,6 +563,29 @@ class A: pass
 [builtins fixtures/list.pyi]
 [out]
 
+[case testAssignmentToStarFromIterable]
+from typing import List, Tuple, Iterable
+
+class CustomIterable(Iterable[int]): pass
+
+a: List[int]
+b: Tuple[int, ...]
+c: Tuple[int, int, int]
+d: Iterable[int]
+e: CustomIterable
+
+a1, *a2 = a
+b1, *b2 = b
+c1, *c2 = c
+d1, *d2 = d
+e1, *e2 = e
+
+reveal_type(a2)  # E: Revealed type is 'builtins.list[builtins.int*]'
+reveal_type(b2)  # E: Revealed type is 'builtins.list[builtins.int*]'
+reveal_type(c2)  # E: Revealed type is 'builtins.list[builtins.int*]'
+reveal_type(d2)  # E: Revealed type is 'builtins.list[builtins.int]'
+reveal_type(e2)  # E: Revealed type is 'builtins.list[builtins.int]'
+[builtins fixtures/tuple.pyi]
 
 -- Nested tuple assignment
 -- ----------------------------

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -752,7 +752,7 @@ good: Union[List[int], List[str]]
 
 x, *y, z = lst = good
 reveal_type(x) # E: Revealed type is 'Union[builtins.int*, builtins.str*]'
-reveal_type(y) # E: Revealed type is 'Union[builtins.list[builtins.int], builtins.list[builtins.str]]'
+reveal_type(y) # E: Revealed type is 'Union[builtins.list[builtins.int*], builtins.list[builtins.str*]]'
 reveal_type(z) # E: Revealed type is 'Union[builtins.int*, builtins.str*]'
 reveal_type(lst) # E: Revealed type is 'Union[builtins.list[builtins.int], builtins.list[builtins.str]]'
 [builtins fixtures/list.pyi]


### PR DESCRIPTION
Consider the following program:

    from typing import Iterable, Iterator, Tuple

    class SomeIterable(Iterable[int]):
        def __iter__(self) -> Iterator[int]:
            return [1, 2, 3].__iter__()

    a = SomeIterable()
    b: Tuple[int, ...] = (1, 2, 3)

    a1, *a2 = a
    b1, *b2 = b

    reveal_type(a2)
    reveal_type(b2)

Previously, the revealed types were `SomeIterable` and `builtins.tuple[int]`: mypy assumed that `a2` and `b2` will have the same type as whatever is on the right-hand side.

However, at runtime, both `a2` and `b2` are actually of type `List[int]`.

This pull request fixes this bug.