### PR TITLE
support for PyCharm test debugging, and add tox environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dmypy.json
 # Packages
 *.egg
 *.egg-info
+*.eggs
 
 # IDEs
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ htmlcov
 
 # pytest cache
 .pytest_cache/
+
+.tox

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -58,6 +58,14 @@ def test_python_cmdline(testcase: DataDrivenTestCase) -> None:
     outb = process.stdout.read()
     # Split output into lines.
     out = [s.rstrip('\n\r') for s in str(outb, 'utf8').splitlines()]
+
+    is_running_in_py_charm = "PYCHARM_HOSTED" in os.environ
+    if is_running_in_py_charm:
+        pos = next((p for p, i in enumerate(out) if i.startswith('pydev debugger: ')), None)
+        if pos is not None:
+            del out[pos]  # the attaching debugger message itself
+            del out[pos]  # plus the extra new line added
+
     result = process.wait()
     # Remove temp file.
     os.remove(program_path)

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -59,8 +59,7 @@ def test_python_cmdline(testcase: DataDrivenTestCase) -> None:
     # Split output into lines.
     out = [s.rstrip('\n\r') for s in str(outb, 'utf8').splitlines()]
 
-    is_running_in_py_charm = "PYCHARM_HOSTED" in os.environ
-    if is_running_in_py_charm:
+    if "PYCHARM_HOSTED" in os.environ:
         pos = next((p for p, i in enumerate(out) if i.startswith('pydev debugger: ')), None)
         if pos is not None:
             del out[pos]  # the attaching debugger message itself

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,5 +19,3 @@ python_files = test*.py
 python_classes =
 python_functions =
 
-# always run in parallel (requires pytest-xdist, see test-requirements.txt)
-addopts = -nauto --cov-append --cov-report=

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,3 +19,6 @@ python_files = test*.py
 python_classes =
 python_functions =
 
+# always run in parallel (requires pytest-xdist, see test-requirements.txt)
+addopts = -nauto
+

--- a/runtests.py
+++ b/runtests.py
@@ -83,10 +83,11 @@ class Driver:
         if not pytest_files:
             return
         pytest_args = pytest_files + self.arglist + self.pyt_arglist
+        always_append = ['-n', 'auto', '--cov-append', ' --cov-report=']
         if coverage and self.coverage:
-            args = [sys.executable, '-m', 'pytest', '--cov=mypy'] + pytest_args
+            args = [sys.executable, '-m', 'pytest', '--cov=mypy'] + always_append + pytest_args
         else:
-            args = [sys.executable, '-m', 'pytest'] + pytest_args
+            args = [sys.executable, '-m', 'pytest', ] + always_append + pytest_args
 
         self.waiter.add(LazySubprocess('pytest', args, env=self.env,
                                        passthrough=self.verbosity),

--- a/runtests.py
+++ b/runtests.py
@@ -83,11 +83,10 @@ class Driver:
         if not pytest_files:
             return
         pytest_args = pytest_files + self.arglist + self.pyt_arglist
-        always_append = ['-n', 'auto', '--cov-append', '--cov-report=']
         if coverage and self.coverage:
-            args = [sys.executable, '-m', 'pytest', '--cov=mypy'] + always_append + pytest_args
+            args = [sys.executable, '-m', 'pytest', '--cov=mypy'] + pytest_args
         else:
-            args = [sys.executable, '-m', 'pytest', ] + always_append + pytest_args
+            args = [sys.executable, '-m', 'pytest'] + pytest_args
 
         self.waiter.add(LazySubprocess('pytest', args, env=self.env,
                                        passthrough=self.verbosity),

--- a/runtests.py
+++ b/runtests.py
@@ -83,7 +83,7 @@ class Driver:
         if not pytest_files:
             return
         pytest_args = pytest_files + self.arglist + self.pyt_arglist
-        always_append = ['-n', 'auto', '--cov-append', ' --cov-report=']
+        always_append = ['-n', 'auto', '--cov-append', '--cov-report=']
         if coverage and self.coverage:
             args = [sys.executable, '-m', 'pytest', '--cov=mypy'] + always_append + pytest_args
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,8 @@ exclude =
   typeshed/*,
   # during runtests.py flake8 might be started when there's still examples in the temp dir
   tmp-test-dirs/*
-
+  .tox
+  .eggs
 
 # Things to ignore:
 #   E251: spaces around default arg value (against our style)

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist = py34,
 
 [testenv]
 description = run the test driver with {basepython}
-deps = -r ./test-requirements.txt
+deps = -rtest-requirements.txt
 commands = python runtests.py -x lint -x package {posargs}
 
 [testenv:lint]
@@ -27,14 +27,14 @@ commands = python runtests.py testselfcheck -p '-n0' -p '-v'
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs
 basepython = python3.6
-deps = -r docs/requirements-docs.txt
+deps = -rdocs/requirements-docs.txt
 commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
 
 [testenv:dev]
 description = generate a DEV environment, that has all project libraries
 usedevelop = True
 basepython = python3.6
-deps = -r ./test-requirements.txt
-       -r docs/requirements-docs.txt
+deps = -rtest-requirements.txt
+       -rdocs/requirements-docs.txt
 commands = python -m pip list --format=columns
            python -c 'import sys; print(sys.executable)'

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist = py34,
 [testenv]
 description = run the test driver with {basepython}
 deps = -rtest-requirements.txt
-commands = python runtests.py -x lint -x package {posargs}
+commands = python runtests.py -x lint -x self-check {posargs}
 
 [testenv:lint]
 description = check the code style

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands = python runtests.py lint {posargs}
 [testenv:type]
 description = type check ourselves
 basepython = python3.6
-commands = python runtests.py testselfcheck -p '-n0' -p '-v'
+commands = python runtests.py self-check -p '-n0' -p '-v'
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,40 @@
+[tox]
+minversion = 2.9.1
+skip_missing_interpreters = true
+envlist = py34,
+          py35,
+          py36,
+          py37,
+          lint,
+          type,
+          docs
+
+[testenv]
+description = run the test driver with {basepython}
+deps = -r ./test-requirements.txt
+commands = python runtests.py -x lint -x package {posargs}
+
+[testenv:lint]
+description = check the code style
+basepython = python3.6
+commands = python runtests.py lint {posargs}
+
+[testenv:type]
+description = type check ourselves
+basepython = python3.6
+commands = python runtests.py testselfcheck -p '-n0' -p '-v'
+
+[testenv:docs]
+description = invoke sphinx-build to build the HTML docs
+basepython = python3.6
+deps = -r docs/requirements-docs.txt
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
+
+[testenv:dev]
+description = generate a DEV environment, that has all project libraries
+usedevelop = True
+basepython = python3.6
+deps = -r ./test-requirements.txt
+       -r docs/requirements-docs.txt
+commands = python -m pip list --format=columns
+           python -c 'import sys; print(sys.executable)'


### PR DESCRIPTION
Most open source projects use tox as a way of automating project setup. It means the user can just invoke tox and that will setup automatically environments in what to develop and run tests. Additionally, PyCharm is a highly popular IDE, that allows users not that friendly to the command line to quickly become productive. 

This PR makes some changes to ensure that out of box clone of mypy allows running the tests from within PyCharm (and that they pass). Plus, it exposes targets that also run inside the CI locally (e.g. running tests for Python 3.4, 3.5, 3.6, 3.7). 

Once you have tox installed on a system or user level (``pip install tox``):

```bash
cd mypy
tox -av
default environments:
py34 -> run the test driver with python3.4
py35 -> run the test driver with python3.5
py36 -> run the test driver with python3.6
py37 -> run the test driver with python3.7
lint -> check the code style
type -> type check ourselves
docs -> invoke sphinx-build to build the HTML docs

additional environments:
dev  -> generate a DEV environment, that has all project libraries
```

E.g. to generate the documentation locally all one needs to do is ``tox -e docs``, and can then view it by opening the HTML up from a browser inside ``.tox/docs_out`` folder. Tox is kinda like make, but cross-platform (https://tox.readthedocs.org), written in Python and built-in isolation and virtualenv creation.

These are most of the changes, I've did to help me to develop the feature https://github.com/python/mypy/pull/5139. Ideally this would be merged before that, leaving the PR to contain the feature only.