### PR TITLE
Remove unused imports

### DIFF
--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Sequence, Optional
+from typing import Dict, Sequence, Optional
 
 import mypy.subtypes
 from mypy.sametypes import is_same_type

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -26,18 +26,14 @@ import stat
 import subprocess
 import sys
 import time
-from os.path import dirname, basename
+from os.path import dirname
 import errno
 
 from typing import (AbstractSet, Any, cast, Dict, Iterable, Iterator, List,
                     Mapping, NamedTuple, Optional, Set, Tuple, Union, Callable)
-# Can't use TYPE_CHECKING because it's not in the Python 3.5.1 stdlib
-MYPY = False
-if MYPY:
-    from typing import Deque
 
 from mypy import sitepkgs
-from mypy.nodes import (MODULE_REF, MypyFile, Node, ImportBase, Import, ImportFrom, ImportAll)
+from mypy.nodes import (MypyFile, ImportBase, Import, ImportFrom, ImportAll)
 from mypy.semanal_pass1 import SemanticAnalyzerPass1
 from mypy.semanal import SemanticAnalyzerPass2, apply_semantic_analyzer_patches
 from mypy.semanal_pass3 import SemanticAnalyzerPass3

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -17,7 +17,7 @@ from mypy.maptype import map_instance_to_supertype
 from mypy.expandtype import expand_type_by_instance, expand_type, freshen_function_type_vars
 from mypy.infer import infer_type_arguments
 from mypy.typevars import fill_typevars
-from mypy.plugin import Plugin, AttributeContext
+from mypy.plugin import AttributeContext
 from mypy import messages
 from mypy import subtypes
 from mypy import meet

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -2,7 +2,6 @@
 
 from typing import Iterable, List, Optional, Sequence
 
-from mypy import experiments
 from mypy.types import (
     CallableType, Type, TypeVisitor, UnboundType, AnyType, NoneTyp, TypeVarType, Instance,
     TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType, DeletedType,

--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -14,7 +14,7 @@ import socket
 import sys
 import time
 
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, TypeVar
+from typing import Any, Callable, Dict, Mapping, Optional, Tuple
 
 from mypy.dmypy_util import STATUS_FILE, receive
 from mypy.util import write_junit_xml

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -6,8 +6,6 @@ This implements a daemon process which keeps useful state in memory
 to enable fine-grained incremental reprocessing of changes.
 """
 
-import gc
-import io
 import json
 import os
 import shutil
@@ -24,7 +22,6 @@ import mypy.errors
 from mypy.find_sources import create_source_list, InvalidSourceList
 from mypy.server.update import FineGrainedBuildManager
 from mypy.dmypy_util import STATUS_FILE, receive
-from mypy.gclogger import GcLogger
 from mypy.fscache import FileSystemCache
 from mypy.fswatcher import FileSystemWatcher, FileData
 from mypy.options import Options

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -3,9 +3,8 @@ from typing import Optional, Container, Callable
 from mypy.types import (
     Type, TypeVisitor, UnboundType, AnyType, NoneTyp, TypeVarId, Instance, TypeVarType,
     CallableType, TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType,
-    DeletedType, TypeTranslator, TypeList, UninhabitedType, TypeType, TypeOfAny
+    DeletedType, TypeTranslator, UninhabitedType, TypeType, TypeOfAny
 )
-from mypy import experiments
 
 
 def erase_type(typ: Type) -> Type:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -3,7 +3,7 @@ from typing import Dict, Iterable, List, TypeVar, Mapping, cast
 from mypy.types import (
     Type, Instance, CallableType, TypeVisitor, UnboundType, AnyType,
     NoneTyp, TypeVarType, Overloaded, TupleType, TypedDictType, UnionType,
-    ErasedType, TypeList, PartialType, DeletedType, UninhabitedType, TypeType, TypeVarId,
+    ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, TypeVarId,
     FunctionLike, TypeVarDef
 )
 

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -3,7 +3,7 @@
 from mypy.nodes import (
     Expression, NameExpr, MemberExpr, IndexExpr, TupleExpr,
     ListExpr, StrExpr, BytesExpr, UnicodeExpr, EllipsisExpr, CallExpr,
-    ARG_POS, ARG_NAMED, get_member_expr_fullname
+    get_member_expr_fullname
 )
 from mypy.fastparse import parse_type_comment
 from mypy.types import (

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -2,7 +2,7 @@ from functools import wraps
 import sys
 
 from typing import (
-    Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, cast, List, Set, overload
+    Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, cast, List, overload
 )
 from mypy.sharedparse import (
     special_function_elide_names, argument_elide_name,
@@ -29,7 +29,6 @@ from mypy.types import (
     TypeOfAny
 )
 from mypy import defaults
-from mypy import experiments
 from mypy import messages
 from mypy.errors import Errors
 from mypy.options import Options

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -17,7 +17,7 @@ two in a typesafe way.
 from functools import wraps
 import sys
 
-from typing import Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, cast, List, Set
+from typing import Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, cast, List
 from mypy.sharedparse import (
     special_function_elide_names, argument_elide_name,
 )
@@ -28,7 +28,7 @@ from mypy.nodes import (
     DelStmt, BreakStmt, ContinueStmt, PassStmt, GlobalDecl,
     WhileStmt, ForStmt, IfStmt, TryStmt, WithStmt,
     TupleExpr, GeneratorExpr, ListComprehension, ListExpr, ConditionalExpr,
-    DictExpr, SetExpr, NameExpr, IntExpr, StrExpr, BytesExpr, UnicodeExpr,
+    DictExpr, SetExpr, NameExpr, IntExpr, StrExpr, UnicodeExpr,
     FloatExpr, CallExpr, SuperExpr, MemberExpr, IndexExpr, SliceExpr, OpExpr,
     UnaryExpr, LambdaExpr, ComparisonExpr, DictionaryComprehension,
     SetComprehension, ComplexExpr, EllipsisExpr, YieldExpr, Argument,
@@ -38,7 +38,6 @@ from mypy.nodes import (
 from mypy.types import (
     Type, CallableType, AnyType, UnboundType, EllipsisType, TypeOfAny
 )
-from mypy import experiments
 from mypy import messages
 from mypy.errors import Errors
 from mypy.fastparse import TypeConverter, parse_type_comment

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -5,12 +5,11 @@ from typing import Any, Dict, Optional
 from mypy.nodes import (
     MypyFile, SymbolNode, SymbolTable, SymbolTableNode,
     TypeInfo, FuncDef, OverloadedFuncDef, Decorator, Var,
-    TypeVarExpr, ClassDef, Block,
-    LDEF, MDEF, GDEF, TYPE_ALIAS
+    TypeVarExpr, ClassDef, Block, TYPE_ALIAS
 )
 from mypy.types import (
-    CallableType, EllipsisType, Instance, Overloaded, TupleType, TypedDictType,
-    TypeList, TypeVarType, UnboundType, UnionType, TypeVisitor,
+    CallableType, Instance, Overloaded, TupleType, TypedDictType,
+    TypeVarType, UnboundType, UnionType, TypeVisitor,
     TypeType, NOT_READY
 )
 from mypy.visitor import NodeVisitor

--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -28,11 +28,10 @@ You should perform all file system reads through the API to actually take
 advantage of the benefits.
 """
 
-import functools
 import hashlib
 import os
 import stat
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Set
 
 
 class FileSystemCache:

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -1,10 +1,6 @@
 from typing import Dict, Iterable, List, Optional, Set
-from abc import abstractmethod
 
-from mypy.visitor import NodeVisitor
 from mypy.types import SyntheticTypeVisitor
-from mypy.nodes import MODULE_REF
-import mypy.nodes as nodes
 import mypy.types as types
 from mypy.util import split_module_names
 

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -1,11 +1,11 @@
 """Calculation of the least upper bound types (joins)."""
 
 from collections import OrderedDict
-from typing import cast, List, Optional
+from typing import List, Optional
 
 from mypy.types import (
     Type, AnyType, NoneTyp, TypeVisitor, Instance, UnboundType, TypeVarType, CallableType,
-    TupleType, TypedDictType, ErasedType, TypeList, UnionType, FunctionLike, Overloaded,
+    TupleType, TypedDictType, ErasedType, UnionType, FunctionLike, Overloaded,
     PartialType, DeletedType, UninhabitedType, TypeType, true_or_false, TypeOfAny
 )
 from mypy.maptype import map_instance_to_supertype

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -9,13 +9,13 @@ import subprocess
 import sys
 import time
 
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple, Callable
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Callable
 
 from mypy import build
 from mypy import defaults
 from mypy import experiments
 from mypy import util
-from mypy.build import BuildSource, BuildResult, PYTHON_EXTENSIONS
+from mypy.build import BuildSource, BuildResult
 from mypy.find_sources import create_source_list, InvalidSourceList
 from mypy.fscache import FileSystemCache
 from mypy.errors import CompileError

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -1,11 +1,10 @@
 from collections import OrderedDict
-from typing import List, Optional, cast, Tuple
+from typing import List, Optional, Tuple
 
 from mypy.join import is_similar_callables, combine_similar_callables, join_type_list
-from mypy.sametypes import is_same_type
 from mypy.types import (
     Type, AnyType, TypeVisitor, UnboundType, NoneTyp, TypeVarType, Instance, CallableType,
-    TupleType, TypedDictType, ErasedType, TypeList, UnionType, PartialType, DeletedType,
+    TupleType, TypedDictType, ErasedType, UnionType, PartialType, DeletedType,
     UninhabitedType, TypeType, TypeOfAny
 )
 from mypy.subtypes import is_equivalent, is_subtype, is_protocol_implementation

--- a/mypy/memprofile.py
+++ b/mypy/memprofile.py
@@ -7,7 +7,7 @@ owned by particular AST nodes, etc.
 from collections import defaultdict
 import gc
 import sys
-from typing import List, Dict, Set, Iterable, Tuple, cast
+from typing import List, Dict, Iterable, Tuple, cast
 
 from mypy.nodes import FakeInfo, Node
 from mypy.types import Type

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -3,7 +3,7 @@ import re
 import pprint
 import sys
 
-from typing import Dict, List, Mapping, MutableMapping, Optional, Pattern, Set, Tuple
+from typing import Dict, List, Mapping, Optional, Pattern, Set, Tuple
 
 from mypy import defaults
 

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Set, cast, Union, Optional
+from typing import Union, Optional
 
 from mypy.errors import Errors
 from mypy.options import Options

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from mypy.nodes import (
-    ARG_OPT, ARG_POS, MDEF, Argument, Block, CallExpr, Expression, FuncBase,
+    ARG_POS, MDEF, Argument, Block, CallExpr, Expression, FuncBase,
     FuncDef, PassStmt, RefExpr, SymbolTableNode, Var
 )
 from mypy.plugin import ClassDefContext

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -1,18 +1,16 @@
 from collections import OrderedDict
-from typing import Dict, List, Optional, Set, Tuple, cast
+from typing import Dict, List, Set, Tuple
 
 from mypy.nodes import (
-    ARG_OPT, ARG_POS, MDEF, Argument, AssignmentStmt, Block, CallExpr,
+    ARG_OPT, ARG_POS, MDEF, Argument, AssignmentStmt, CallExpr,
     Context, Decorator, Expression, FuncDef, JsonDict, NameExpr,
     SymbolTableNode, TempNode, TypeInfo, Var,
 )
 from mypy.plugin import ClassDefContext
 from mypy.plugins.common import _add_method, _get_decorator_bool_argument
 from mypy.types import (
-    CallableType, Instance, NoneTyp, Type, TypeVarDef, TypeVarType,
-    deserialize_type
+    CallableType, Instance, NoneTyp, TypeVarDef, TypeVarType,
 )
-from mypy.typevars import fill_typevars
 
 # The set of decorators that generate dataclasses.
 dataclass_makers = {

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -3,7 +3,7 @@ from typing import Sequence
 from mypy.types import (
     Type, UnboundType, AnyType, NoneTyp, TupleType, TypedDictType,
     UnionType, CallableType, TypeVarType, Instance, TypeVisitor, ErasedType,
-    TypeList, Overloaded, PartialType, DeletedType, UninhabitedType, TypeType
+    Overloaded, PartialType, DeletedType, UninhabitedType, TypeType
 )
 
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -44,18 +44,18 @@ from mypy.nodes import (
     ImportFrom, ImportAll, Block, LDEF, NameExpr, MemberExpr,
     IndexExpr, TupleExpr, ListExpr, ExpressionStmt, ReturnStmt,
     RaiseStmt, AssertStmt, OperatorAssignmentStmt, WhileStmt,
-    ForStmt, BreakStmt, ContinueStmt, IfStmt, TryStmt, WithStmt, DelStmt, PassStmt,
+    ForStmt, BreakStmt, ContinueStmt, IfStmt, TryStmt, WithStmt, DelStmt,
     GlobalDecl, SuperExpr, DictExpr, CallExpr, RefExpr, OpExpr, UnaryExpr,
     SliceExpr, CastExpr, RevealExpr, TypeApplication, Context, SymbolTable,
     SymbolTableNode, TVAR, ListComprehension, GeneratorExpr,
-    LambdaExpr, MDEF, FuncBase, Decorator, SetExpr, TypeVarExpr, NewTypeExpr,
+    LambdaExpr, MDEF, Decorator, SetExpr, TypeVarExpr,
     StrExpr, BytesExpr, PrintStmt, ConditionalExpr, PromoteExpr,
-    ComparisonExpr, StarExpr, ARG_POS, ARG_NAMED, ARG_NAMED_OPT, type_aliases,
-    YieldFromExpr, NamedTupleExpr, TypedDictExpr, NonlocalDecl, SymbolNode,
+    ComparisonExpr, StarExpr, ARG_POS, ARG_NAMED, type_aliases,
+    YieldFromExpr, NamedTupleExpr, NonlocalDecl, SymbolNode,
     SetComprehension, DictionaryComprehension, TYPE_ALIAS, TypeAliasExpr,
-    YieldExpr, ExecStmt, Argument, BackquoteExpr, ImportBase, AwaitExpr,
-    IntExpr, FloatExpr, UnicodeExpr, EllipsisExpr, TempNode, EnumCallExpr, ImportedName,
-    COVARIANT, CONTRAVARIANT, INVARIANT, UNBOUND_IMPORTED, LITERAL_YES, ARG_OPT, nongen_builtins,
+    YieldExpr, ExecStmt, BackquoteExpr, ImportBase, AwaitExpr,
+    IntExpr, FloatExpr, UnicodeExpr, TempNode, ImportedName,
+    COVARIANT, CONTRAVARIANT, INVARIANT, UNBOUND_IMPORTED, LITERAL_YES, nongen_builtins,
     collections_type_aliases, get_member_expr_fullname, REVEAL_TYPE, REVEAL_LOCALS
 )
 from mypy.literals import literal
@@ -66,9 +66,9 @@ from mypy.traverser import TraverserVisitor
 from mypy.errors import Errors, report_internal_error
 from mypy.messages import CANNOT_ASSIGN_TO_TYPE, MessageBuilder
 from mypy.types import (
-    FunctionLike, UnboundType, TypeVarDef, TypeType, TupleType, UnionType, StarType, function_type,
-    TypedDictType, NoneTyp, CallableType, Overloaded, Instance, Type, TypeVarType, AnyType,
-    TypeTranslator, TypeOfAny, TypeVisitor, UninhabitedType, ErasedType, DeletedType
+    FunctionLike, UnboundType, TypeVarDef, TupleType, UnionType, StarType, function_type,
+    CallableType, Overloaded, Instance, Type, AnyType,
+    TypeTranslator, TypeOfAny
 )
 from mypy.nodes import implicit_module_attrs
 from mypy.typeanal import (
@@ -81,9 +81,8 @@ from mypy.sametypes import is_same_type
 from mypy.options import Options
 from mypy import experiments
 from mypy.plugin import Plugin, ClassDefContext, SemanticAnalyzerPluginInterface
-from mypy import join
 from mypy.util import get_prefix, correct_relative_import
-from mypy.semanal_shared import SemanticAnalyzerInterface, set_callable_name, PRIORITY_FALLBACKS
+from mypy.semanal_shared import SemanticAnalyzerInterface, set_callable_name
 from mypy.scope import Scope
 from mypy.semanal_namedtuple import NamedTupleAnalyzer, NAMEDTUPLE_PROHIBITED_NAMES
 from mypy.semanal_typeddict import TypedDictAnalyzer

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -32,7 +32,6 @@ from mypy.semanal_shared import create_indirect_imported_name
 from mypy.options import Options
 from mypy.sametypes import is_same_type
 from mypy.visitor import NodeVisitor
-from mypy.util import correct_relative_import
 
 
 class SemanticAnalyzerPass1(NodeVisitor[None]):

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -10,8 +10,7 @@ belongs to a module involved in an import loop.
 """
 
 from collections import OrderedDict
-from contextlib import contextmanager
-from typing import Dict, List, Callable, Optional, Union, Set, cast, Tuple, Iterator
+from typing import Dict, List, Callable, Optional, Union, cast, Tuple
 
 from mypy import messages, experiments
 from mypy.nodes import (

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -50,16 +50,16 @@ Summary of how this works for certain kinds of differences:
   fine-grained dependencies.
 """
 
-from typing import Set, List, TypeVar, Dict, Tuple, Optional, Sequence, Union
+from typing import Set, Dict, Tuple, Optional, Sequence, Union
 
 from mypy.nodes import (
-    SymbolTable, SymbolTableNode, TypeInfo, Var, MypyFile, SymbolNode, Decorator, TypeVarExpr,
+    SymbolTable, TypeInfo, Var, SymbolNode, Decorator, TypeVarExpr,
     OverloadedFuncDef, FuncItem, MODULE_REF, TYPE_ALIAS, UNBOUND_IMPORTED, TVAR
 )
 from mypy.types import (
-    Type, TypeVisitor, UnboundType, TypeList, AnyType, NoneTyp, UninhabitedType,
+    Type, TypeVisitor, UnboundType, AnyType, NoneTyp, UninhabitedType,
     ErasedType, DeletedType, Instance, TypeVarType, CallableType, TupleType, TypedDictType,
-    UnionType, Overloaded, PartialType, TypeType, function_type
+    UnionType, Overloaded, PartialType, TypeType
 )
 from mypy.util import get_prefix
 

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -48,7 +48,7 @@ See the main entry point merge_asts for more details.
 from typing import Dict, List, cast, TypeVar, Optional
 
 from mypy.nodes import (
-    Node, MypyFile, SymbolTable, Block, AssignmentStmt, NameExpr, MemberExpr, RefExpr, TypeInfo,
+    MypyFile, SymbolTable, Block, AssignmentStmt, NameExpr, MemberExpr, RefExpr, TypeInfo,
     FuncDef, ClassDef, NamedTupleExpr, SymbolNode, Var, Statement, SuperExpr, NewTypeExpr,
     OverloadedFuncDef, LambdaExpr, TypedDictExpr, EnumCallExpr, FuncBase, TypeAliasExpr, CallExpr,
     CastExpr,

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -90,9 +90,9 @@ from mypy.nodes import (
     Node, Expression, MypyFile, FuncDef, ClassDef, AssignmentStmt, NameExpr, MemberExpr, Import,
     ImportFrom, CallExpr, CastExpr, TypeVarExpr, TypeApplication, IndexExpr, UnaryExpr, OpExpr,
     ComparisonExpr, GeneratorExpr, DictionaryComprehension, StarExpr, PrintStmt, ForStmt, WithStmt,
-    TupleExpr, ListExpr, OperatorAssignmentStmt, DelStmt, YieldFromExpr, Decorator, Block,
+    TupleExpr, OperatorAssignmentStmt, DelStmt, YieldFromExpr, Decorator, Block,
     TypeInfo, FuncBase, OverloadedFuncDef, RefExpr, SuperExpr, Var, NamedTupleExpr, TypedDictExpr,
-    LDEF, MDEF, GDEF, FuncItem, TypeAliasExpr, NewTypeExpr, ImportAll, EnumCallExpr, AwaitExpr,
+    LDEF, MDEF, GDEF, TypeAliasExpr, NewTypeExpr, ImportAll, EnumCallExpr, AwaitExpr,
     op_methods, reverse_op_methods, ops_with_inplace_method, unary_op_methods
 )
 from mypy.traverser import TraverserVisitor

--- a/mypy/server/mergecheck.py
+++ b/mypy/server/mergecheck.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, List, Tuple
 
-from mypy.nodes import SymbolNode, Var, Decorator, OverloadedFuncDef, FuncDef
+from mypy.nodes import SymbolNode, Var, Decorator, FuncDef
 from mypy.server.objgraph import get_reachable_graph, get_path
 
 

--- a/mypy/server/objgraph.py
+++ b/mypy/server/objgraph.py
@@ -1,8 +1,7 @@
 """Find all objects reachable from a root object."""
 
-from collections import deque
 from collections.abc import Iterable
-from typing import List, Dict, Iterator, Optional, Tuple, Mapping
+from typing import List, Dict, Iterator, Tuple, Mapping
 import weakref
 import types
 

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -112,27 +112,23 @@ This is module is tested using end-to-end fine-grained incremental mode
 test cases (test-data/unit/fine-grained*.test).
 """
 
-import os
 import time
-import os.path
 from typing import (
-    Dict, List, Set, Tuple, Iterable, Union, Optional, Mapping, NamedTuple, Callable,
+    Dict, List, Set, Tuple, Iterable, Union, Optional, NamedTuple, Callable,
     Sequence
 )
 
 from mypy.build import (
-    BuildManager, State, BuildSource, BuildResult, Graph, load_graph, module_not_found,
-    process_fresh_modules,
-    PRI_INDIRECT, DEBUG_FINE_GRAINED,
+    BuildManager, State, BuildSource, BuildResult, Graph, load_graph,
+    process_fresh_modules, DEBUG_FINE_GRAINED,
 )
 from mypy.checker import DeferredNode
-from mypy.errors import Errors, CompileError
+from mypy.errors import CompileError
 from mypy.nodes import (
-    MypyFile, FuncDef, TypeInfo, Expression, SymbolNode, Var, FuncBase, ClassDef, Decorator,
-    Import, ImportFrom, OverloadedFuncDef, SymbolTable, LambdaExpr
+    MypyFile, FuncDef, TypeInfo, SymbolNode, Decorator,
+    OverloadedFuncDef, SymbolTable, LambdaExpr
 )
 from mypy.options import Options
-from mypy.types import Type
 from mypy.fscache import FileSystemCache
 from mypy.semanal import apply_semantic_analyzer_patches
 from mypy.server.astdiff import (

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -3,13 +3,11 @@
 from typing import List, Dict, Optional
 from collections import defaultdict
 
-from mypy.types import Type, NoneTyp, AnyType, UninhabitedType, TypeVarId, TypeOfAny
+from mypy.types import Type, AnyType, UninhabitedType, TypeVarId, TypeOfAny
 from mypy.constraints import Constraint, SUPERTYPE_OF
 from mypy.join import join_types
 from mypy.meet import meet_types
 from mypy.subtypes import is_subtype
-
-from mypy import experiments
 
 
 def solve_constraints(vars: List[TypeVarId], constraints: List[Constraint],

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -1,11 +1,10 @@
 """Utilities for calculating and reporting statistics about types."""
 
-import cgi
 import os.path
 import typing
 
 from collections import Counter
-from typing import Dict, List, cast, Tuple, Optional
+from typing import Dict, List, cast, Optional
 
 from mypy.traverser import TraverserVisitor
 from mypy.typeanal import collect_all_inner_types

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -3,7 +3,7 @@
 import re
 import os
 
-from typing import Any, List, Tuple, Optional, Union, Sequence, Dict
+from typing import Any, List, Tuple, Optional, Union, Sequence
 
 from mypy.util import short_type, IdMapper
 import mypy.nodes

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -48,7 +48,7 @@ import traceback
 from collections import defaultdict
 
 from typing import (
-    Any, List, Dict, Tuple, Iterable, Iterator, Mapping, Optional, NamedTuple, Set, Union, cast
+    Any, List, Dict, Tuple, Iterable, Iterator, Mapping, Optional, NamedTuple, Set, cast
 )
 
 import mypy.build
@@ -63,11 +63,11 @@ from mypy.nodes import (
     IfStmt, ReturnStmt, ImportAll, ImportFrom, Import, FuncDef, FuncBase, TempNode,
     ARG_POS, ARG_STAR, ARG_STAR2, ARG_NAMED, ARG_NAMED_OPT,
 )
-from mypy.stubgenc import parse_all_signatures, find_unique_signatures, generate_stub_for_c_module
-from mypy.stubutil import is_c_module, write_header
+from mypy.stubgenc import generate_stub_for_c_module
+from mypy.stubutil import is_c_module, write_header, parse_all_signatures, find_unique_signatures
 from mypy.options import Options as MypyOptions
 from mypy.types import (
-    Type, TypeStrVisitor, AnyType, CallableType,
+    Type, TypeStrVisitor, CallableType,
     UnboundType, NoneTyp, TupleType, TypeList,
 )
 from mypy.visitor import NodeVisitor

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -9,10 +9,7 @@ import re
 from typing import List, Dict, Tuple, Optional
 from types import ModuleType
 
-from mypy.stubutil import (
-    parse_all_signatures, find_unique_signatures, is_c_module, write_header,
-    infer_sig_from_docstring
-)
+from mypy.stubutil import is_c_module, write_header, infer_sig_from_docstring
 
 
 def generate_stub_for_c_module(module_name: str,

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -1,7 +1,7 @@
 import re
 import sys
 
-from typing import Any, Optional, Tuple, Sequence, MutableSequence, List, MutableMapping, IO
+from typing import Optional, Tuple, Sequence, MutableSequence, List, MutableMapping, IO
 from types import ModuleType
 
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1,10 +1,10 @@
-from typing import List, Optional, Dict, Callable, Tuple, Iterator, Set, Union, cast
+from typing import List, Optional, Callable, Tuple, Iterator, Set, Union, cast
 from contextlib import contextmanager
 
 from mypy.types import (
     Type, AnyType, UnboundType, TypeVisitor, FormalArgument, NoneTyp, function_type,
     Instance, TypeVarType, CallableType, TupleType, TypedDictType, UnionType, Overloaded,
-    ErasedType, TypeList, PartialType, DeletedType, UninhabitedType, TypeType, is_named_instance,
+    ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, is_named_instance,
     FunctionLike, TypeOfAny
 )
 import mypy.applytype

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -2,24 +2,21 @@
 
 import os
 import re
-import shutil
 import sys
 
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Set, Tuple
 
-from mypy import build, defaults
+from mypy import build
 from mypy.build import BuildSource, Graph
 from mypy.test.config import test_temp_dir
-from mypy.test.data import DataDrivenTestCase, DataSuite, FileOperation, UpdateFile, DeleteFile
+from mypy.test.data import DataDrivenTestCase, DataSuite, FileOperation, UpdateFile
 from mypy.test.helpers import (
     assert_string_arrays_equal, normalize_error_messages, assert_module_equivalence,
     retry_on_error, update_testcase_output, parse_options,
     copy_and_fudge_mtime
 )
 from mypy.errors import CompileError
-from mypy.options import Options
 
-from mypy import experiments
 
 # List of files that contain test case descriptions.
 typecheck_files = [

--- a/mypy/test/testerrorstream.py
+++ b/mypy/test/testerrorstream.py
@@ -1,16 +1,12 @@
 """Tests for mypy incremental error output."""
-from typing import List, Callable, Optional
+from typing import List
 
-import os
-
-from mypy import defaults, build
+from mypy import build
 from mypy.test.helpers import assert_string_arrays_equal
 from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.build import BuildSource
 from mypy.errors import CompileError
 from mypy.options import Options
-from mypy.nodes import CallExpr, StrExpr
-from mypy.types import Type
 
 
 class ErrorStreamSuite(DataSuite):

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -15,13 +15,12 @@ on specified sources.
 import os
 import re
 
-from typing import List, Set, Tuple, Optional, cast
+from typing import List, cast
 
 from mypy import build
-from mypy.build import BuildManager, BuildSource
+from mypy.build import BuildSource
 from mypy.errors import CompileError
 from mypy.options import Options
-from mypy.server.update import FineGrainedBuildManager
 from mypy.test.config import test_temp_dir
 from mypy.test.data import (
     DataDrivenTestCase, DataSuite, UpdateFile

--- a/mypy/test/testmerge.py
+++ b/mypy/test/testmerge.py
@@ -5,22 +5,20 @@ import shutil
 from typing import List, Tuple, Dict, Optional
 
 from mypy import build
-from mypy.build import BuildManager, BuildSource, BuildResult, State, Graph
+from mypy.build import BuildSource, BuildResult
 from mypy.defaults import PYTHON3_VERSION
-from mypy.errors import Errors, CompileError
+from mypy.errors import CompileError
 from mypy.nodes import (
     Node, MypyFile, SymbolTable, SymbolTableNode, TypeInfo, Expression, Var, TypeVarExpr,
     UNBOUND_IMPORTED
 )
 from mypy.options import Options
-from mypy.server.astmerge import merge_asts
 from mypy.server.subexpr import get_subexpressions
 from mypy.server.update import FineGrainedBuildManager
-from mypy.strconv import StrConv, indent
+from mypy.strconv import StrConv
 from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.test.helpers import assert_string_arrays_equal, normalize_error_messages
-from mypy.test.testtypegen import ignore_node
 from mypy.types import TypeStrVisitor, Type
 from mypy.util import short_type, IdMapper
 

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -6,7 +6,7 @@ from typing import Iterator, List
 from unittest import TestCase, main
 
 import mypy.api
-from mypy.build import FindModuleCache, _get_site_packages_dirs
+from mypy.build import _get_site_packages_dirs
 from mypy.test.config import package_path
 from mypy.test.helpers import run_command
 from mypy.util import try_find_python2_interpreter

--- a/mypy/test/testtransform.py
+++ b/mypy/test/testtransform.py
@@ -1,7 +1,6 @@
 """Identity AST transform test cases"""
 
 import os.path
-from typing import List
 
 from mypy import build
 from mypy.build import BuildSource

--- a/mypy/test/testtypegen.py
+++ b/mypy/test/testtypegen.py
@@ -2,7 +2,7 @@
 
 import re
 
-from typing import Set, List
+from typing import Set
 
 from mypy import build
 from mypy.build import BuildSource

--- a/mypy/tvar_scope.py
+++ b/mypy/tvar_scope.py
@@ -1,5 +1,5 @@
 from typing import Optional, Dict, Union
-from mypy.types import TypeVarDef, TypeVarId
+from mypy.types import TypeVarDef
 from mypy.nodes import TypeVarExpr, SymbolTableNode
 
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1,6 +1,5 @@
 """Semantic analysis of types"""
 
-from abc import abstractmethod
 from collections import OrderedDict
 from typing import Callable, List, Optional, Set, Tuple, Iterator, TypeVar, Iterable, Dict, Union
 
@@ -16,15 +15,14 @@ from mypy.types import (
     Type, UnboundType, TypeVarType, TupleType, TypedDictType, UnionType, Instance, AnyType,
     CallableType, NoneTyp, DeletedType, TypeList, TypeVarDef, TypeVisitor, SyntheticTypeVisitor,
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType, get_typ_args, set_typ_args,
-    CallableArgument, get_type_vars, TypeQuery, union_items, TypeOfAny, ForwardRef, Overloaded,
-    TypeTranslator
+    CallableArgument, get_type_vars, TypeQuery, union_items, TypeOfAny, ForwardRef, Overloaded
 )
 
 from mypy.nodes import (
     TVAR, TYPE_ALIAS, UNBOUND_IMPORTED, TypeInfo, Context, SymbolTableNode, Var, Expression,
     IndexExpr, RefExpr, nongen_builtins, check_arg_names, check_arg_kinds, ARG_POS, ARG_NAMED,
     ARG_OPT, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2, TypeVarExpr, FuncDef, CallExpr, NameExpr,
-    Decorator, Node, ImportedName, type_aliases
+    Decorator, ImportedName, type_aliases
 )
 from mypy.tvar_scope import TypeVarScope
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -2,9 +2,8 @@
 
 import re
 import subprocess
-import hashlib
 from xml.sax.saxutils import escape
-from typing import TypeVar, List, Tuple, Optional, Sequence, Dict
+from typing import TypeVar, List, Tuple, Optional, Dict
 
 
 T = TypeVar('T')

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -1,7 +1,7 @@
 """Generic abstract syntax tree node visitor"""
 
 from abc import abstractmethod
-from typing import Dict, TypeVar, Generic
+from typing import TypeVar, Generic
 
 if False:
     # break import cycle only needed for mypy


### PR DESCRIPTION
PyCharm has a pretty powerful engine which reports unused imports. I decided to go through and remove all the validly unused imports it reported. I tried to split it into separate commits for a bit easier review.

I did make one code change which should have no real effect. `stubgen.py` was importing `parse_all_signatures, find_unique_signatures` from `stubgenc.py` which were really just re-exported from `stubutil.py`. I just removed this unneeded re-exporting and directly imported them in `stubgen.py`.