### PR TITLE
Fix leaking error messages during overload selection

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1238,7 +1238,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         for typ in plausible_targets:
             overload_messages = self.msg.clean_copy()
             prev_messages = self.msg
+            assert self.msg is self.chk.msg
             self.msg = overload_messages
+            self.chk.msg = overload_messages
             try:
                 # Passing `overload_messages` as the `arg_messages` parameter doesn't
                 # seem to reliably catch all possible errors.
@@ -1253,6 +1255,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     callable_name=callable_name,
                     object_type=object_type)
             finally:
+                self.chk.msg = prev_messages
                 self.msg = prev_messages
 
             is_match = not overload_messages.is_errors()

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -2620,3 +2620,32 @@ class FakeAttribute(Generic[T]):
     @overload
     def dummy(self, instance: T, owner: Type[T]) -> int: ...
     def dummy(self, instance: Optional[T], owner: Type[T]) -> Union['FakeAttribute[T]', int]: ...
+
+[case testOverloadLambdaUnpackingInference]
+# flags: --py2
+from typing import Callable, TypeVar, overload
+
+T = TypeVar('T')
+S = TypeVar('S')
+
+@overload
+def foo(func, item):
+    # type: (Callable[[T], S], T) -> S
+    pass
+
+@overload
+def foo():
+    # type: () -> None
+    pass
+
+def foo(*args):
+    pass
+
+def add_proxy(x, y):
+    # type: (int, str) -> str
+    pass
+
+# The lambda definition is a syntax error in Python 3
+tup = (1, '2')
+reveal_type(foo(lambda (x, y): add_proxy(x, y), tup))  # E: Revealed type is 'builtins.str*'
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5210 (?)

When mypy tries selecting an appropriate overload alternative, it swaps out the current 'msg' object with a placeholder. If this placeholder does not accumulate any error messages, we know that alternative is a successful match.

Previously, we replaced only `checkexpr.ExpressionChecker`'s msg object with the placeholder. However, since checkexpr can sometimes call `checker.TypeChecker`, we need to replace its msg object as well to prevent error messages that would normally be silenced from leaking.

More broadly, the current overload implementation broke the invariant that both msg fields refer to the same underlying MessageBuilder object. This pull request fixes that oversight.