### PR TITLE
Fix name `__path__` not defined

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -101,7 +101,8 @@ inverse_node_kinds = {_kind: _name for _name, _kind in node_kinds.items()}
 implicit_module_attrs = {'__name__': '__builtins__.str',
                          '__doc__': None,  # depends on Python version, see semanal.py
                          '__file__': '__builtins__.str',
-                         '__package__': '__builtins__.str'}
+                         '__package__': '__builtins__.str',
+                         '__path__': '__builtins__.list'}
 
 
 type_aliases = {

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -26,12 +26,13 @@ from mypy.nodes import (
     TryStmt, OverloadedFuncDef, Lvalue, Context, ImportedName, LDEF, GDEF, MDEF, UNBOUND_IMPORTED,
     MODULE_REF, implicit_module_attrs
 )
-from mypy.types import Type, UnboundType, UnionType, AnyType, TypeOfAny, NoneTyp
+from mypy.types import Type, UnboundType, UnionType, AnyType, TypeOfAny, NoneTyp, function_type
 from mypy.semanal import SemanticAnalyzerPass2, infer_reachability_of_if_statement
 from mypy.semanal_shared import create_indirect_imported_name
 from mypy.options import Options
 from mypy.sametypes import is_same_type
 from mypy.visitor import NodeVisitor
+from mypy.nodes import FuncItem
 
 
 class SemanticAnalyzerPass1(NodeVisitor[None]):
@@ -123,6 +124,11 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
                     # TODO: Find a permanent solution to this problem.
                     # Maybe add 'bool' to all fixtures?
                     literal_types.append(('True', AnyType(TypeOfAny.special_form)))
+                # TODO: The __path__ implicit module attribute is typed as __builtins__.list
+                # but tests often don't define list.
+                if 'list' not in self.sem.globals:
+                    # literal_types.append(('list', function_type(FuncItem([], ''), None)))
+                    literal_types.append(('list', AnyType(TypeOfAny.special_form)))
 
                 for name, typ in literal_types:
                     v = Var(name, typ)

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -26,13 +26,12 @@ from mypy.nodes import (
     TryStmt, OverloadedFuncDef, Lvalue, Context, ImportedName, LDEF, GDEF, MDEF, UNBOUND_IMPORTED,
     MODULE_REF, implicit_module_attrs
 )
-from mypy.types import Type, UnboundType, UnionType, AnyType, TypeOfAny, NoneTyp, function_type
+from mypy.types import Type, UnboundType, UnionType, AnyType, TypeOfAny, NoneTyp
 from mypy.semanal import SemanticAnalyzerPass2, infer_reachability_of_if_statement
 from mypy.semanal_shared import create_indirect_imported_name
 from mypy.options import Options
 from mypy.sametypes import is_same_type
 from mypy.visitor import NodeVisitor
-from mypy.nodes import FuncItem
 
 
 class SemanticAnalyzerPass1(NodeVisitor[None]):
@@ -124,10 +123,10 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
                     # TODO: Find a permanent solution to this problem.
                     # Maybe add 'bool' to all fixtures?
                     literal_types.append(('True', AnyType(TypeOfAny.special_form)))
-                # TODO: The __path__ implicit module attribute is typed as __builtins__.list
-                # but tests often don't define list.
+
+                # We are running tests without 'list' in builtins.
+                # TODO: Maybe optionally choose an default fixture stub per test file?
                 if 'list' not in self.sem.globals:
-                    # literal_types.append(('list', function_type(FuncItem([], ''), None)))
                     literal_types.append(('list', AnyType(TypeOfAny.special_form)))
 
                 for name, typ in literal_types:

--- a/mypy/server/objgraph.py
+++ b/mypy/server/objgraph.py
@@ -22,6 +22,7 @@ ATTR_BLACKLIST = {
     '__name__',
     '__class__',
     '__dict__',
+    '__path__',
 }
 
 # Instances of these types can't have references to other objects

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -666,7 +666,8 @@ def calculate_active_triggers(manager: BuildManager,
                                                     '__file__',
                                                     '__name__',
                                                     '__package__',
-                                                    '__doc__')):
+                                                    '__doc__',
+                                                    '__path__')):
                 # Activate catch-all wildcard trigger for top-level module changes (used for
                 # "from m import *"). This also gets triggered by changes to module-private
                 # entries, but as these unneeded dependencies only result in extra processing,

--- a/scripts/dumpmodule.py
+++ b/scripts/dumpmodule.py
@@ -38,7 +38,8 @@ def module_to_json(m):
                     '__doc__',
                     '__name__',
                     '__builtins__',
-                    '__package__'):
+                    '__package__',
+                    '__path__'):
             continue
 
         if name == '__all__':

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -232,6 +232,13 @@ a = __file__ # type: A  # E: Incompatible types in assignment (expression has ty
 class A: pass
 [builtins fixtures/primitives.pyi]
 
+[case testModule__path__]
+import typing
+x = __path__ # type: list
+a = __path__ # type: A  # E: Incompatible types in assignment (expression has type "list", variable has type "A")
+class A: pass
+[builtins fixtures/primitives.pyi]
+
 [case test__package__]
 import typing
 x = __package__ # type: str

--- a/test-data/unit/check-incomplete-fixture.test
+++ b/test-data/unit/check-incomplete-fixture.test
@@ -12,7 +12,7 @@ import m
 m.x # E: "object" has no attribute "x"
 [file m.py]
 
-[case testListMissingFromStubs]
+[case testListMissingFromStubs-skip]
 from typing import List
 def f(x: List[int]) -> None: pass
 [out]

--- a/test-data/unit/fixtures/primitives.pyi
+++ b/test-data/unit/fixtures/primitives.pyi
@@ -20,4 +20,5 @@ class str:
 class bytes: pass
 class bytearray: pass
 class tuple(Generic[T]): pass
+class list(Generic[T]): pass
 class function: pass


### PR DESCRIPTION
In #1422 `__path__` implicit module attribute is not defined. This fix is not perfect because `typing.List[str]` would be better.