### PR TITLE
Support additional args to namedtuple()

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -201,7 +201,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Type check a call expression."""
         if e.analyzed:
             if isinstance(e.analyzed, NamedTupleExpr) and not e.analyzed.is_typed:
-                # Type check the arguments, but ignore the results.
+                # Type check the arguments, but ignore the results. This relies
+                # on the typeshed stubs to type check the arguments.
                 self.visit_call_expr_inner(e)
             # It's really a special form that only looks like a call.
             return self.accept(e.analyzed, self.type_context[-1])

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -200,8 +200,14 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def visit_call_expr(self, e: CallExpr, allow_none_return: bool = False) -> Type:
         """Type check a call expression."""
         if e.analyzed:
+            if isinstance(e.analyzed, NamedTupleExpr) and not e.analyzed.is_typed:
+                # Type check the arguments, but ignore the results.
+                self.visit_call_expr_inner(e)
             # It's really a special form that only looks like a call.
             return self.accept(e.analyzed, self.type_context[-1])
+        return self.visit_call_expr_inner(e, allow_none_return=allow_none_return)
+
+    def visit_call_expr_inner(self, e: CallExpr, allow_none_return: bool = False) -> Type:
         if isinstance(e.callee, NameExpr) and isinstance(e.callee.node, TypeInfo) and \
                 e.callee.node.typeddict_type is not None:
             # Use named fallback for better error messages.

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1906,10 +1906,12 @@ class NamedTupleExpr(Expression):
     # The class representation of this named tuple (its tuple_type attribute contains
     # the tuple item types)
     info = None  # type: TypeInfo
+    is_typed = False  # whether this class was created with typing.NamedTuple
 
-    def __init__(self, info: 'TypeInfo') -> None:
+    def __init__(self, info: 'TypeInfo', is_typed: bool = False) -> None:
         super().__init__()
         self.info = info
+        self.is_typed = is_typed
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_namedtuple_expr(self)

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -158,8 +158,6 @@ class NamedTupleAnalyzer:
             name += '@' + str(call.line)
         if len(defaults) > 0:
             default_items = {
-                # We don't have the actual argument expressions any more, so we
-                # just use Ellipsis for all defaults.
                 arg_name: default
                 for arg_name, default in zip(items[-len(defaults):], defaults)
             }
@@ -174,8 +172,8 @@ class NamedTupleAnalyzer:
         call.analyzed.set_line(call.line, call.column)
         return info
 
-    def parse_namedtuple_args(self, call: CallExpr,
-                              fullname: str) -> Tuple[List[str], List[Type], List[Expression], bool]:
+    def parse_namedtuple_args(self, call: CallExpr, fullname: str
+                              ) -> Tuple[List[str], List[Type], List[Expression], bool]:
         """Parse a namedtuple() call into data needed to construct a type.
 
         Returns a 4-tuple:
@@ -246,9 +244,9 @@ class NamedTupleAnalyzer:
             defaults = defaults[:len(items)]
         return items, types, defaults, ok
 
-    def parse_namedtuple_fields_with_types(
-        self, nodes: List[Expression], context: Context
-    ) -> Tuple[List[str], List[Type], int, bool]:
+    def parse_namedtuple_fields_with_types(self, nodes: List[Expression], context: Context
+                                           ) -> Tuple[List[str], List[Type], List[Expression],
+                                                      bool]:
         items = []  # type: List[str]
         types = []  # type: List[Type]
         for item in nodes:
@@ -268,12 +266,12 @@ class NamedTupleAnalyzer:
                 types.append(self.api.anal_type(type))
             else:
                 return self.fail_namedtuple_arg("Tuple expected as NamedTuple() field", item)
-        return items, types, 0, True
+        return items, types, [], True
 
-    def fail_namedtuple_arg(self, message: str,
-                            context: Context) -> Tuple[List[str], List[Type], int, bool]:
+    def fail_namedtuple_arg(self, message: str, context: Context
+                            ) -> Tuple[List[str], List[Type], List[Expression], bool]:
         self.fail(message, context)
-        return [], [], 0, False
+        return [], [], [], False
 
     def build_namedtuple_typeinfo(self, name: str, items: List[str], types: List[Type],
                                   default_items: Mapping[str, Expression]) -> TypeInfo:

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -244,8 +244,9 @@ class NamedTupleAnalyzer:
             num_defaults = len(items)
         return items, types, num_defaults, ok
 
-    def parse_namedtuple_fields_with_types(self, nodes: List[Expression],
-                                           context: Context) -> Tuple[List[str], List[Type], int, bool]:
+    def parse_namedtuple_fields_with_types(
+        self, nodes: List[Expression], context: Context
+    ) -> Tuple[List[str], List[Type], int, bool]:
         items = []  # type: List[str]
         types = []  # type: List[Type]
         for item in nodes:

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -158,6 +158,8 @@ class NamedTupleAnalyzer:
             name += '@' + str(call.line)
         if num_defaults > 0:
             default_items = {
+                # We don't have the actual argument expressions any more, so we
+                # just use Ellipsis for all defaults.
                 arg_name: EllipsisExpr()
                 for arg_name in items[-num_defaults:]
             }
@@ -191,7 +193,7 @@ class NamedTupleAnalyzer:
         if len(args) > 2:
             # Typed namedtuple doesn't support additional arguments.
             if fullname == 'typing.NamedTuple':
-                return self.fail_namedtuple_arg("Too many arguments for namedtuple()", call)
+                return self.fail_namedtuple_arg("Too many arguments for NamedTuple()", call)
             for i, arg_name in enumerate(call.arg_names[2:], 2):
                 if arg_name == 'defaults':
                     arg = args[i]

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -148,7 +148,7 @@ class NamedTupleAnalyzer:
             is_typed = True
         else:
             return None
-        items, types, num_defaults, ok = self.parse_namedtuple_args(call, fullname, is_typed)
+        items, types, num_defaults, ok = self.parse_namedtuple_args(call, fullname)
         if not ok:
             # Error. Construct dummy return value.
             return self.build_namedtuple_typeinfo('namedtuple', [], [], {})
@@ -172,8 +172,8 @@ class NamedTupleAnalyzer:
         call.analyzed.set_line(call.line, call.column)
         return info
 
-    def parse_namedtuple_args(self, call: CallExpr, fullname: str,
-                              is_typed: bool) -> Tuple[List[str], List[Type], int, bool]:
+    def parse_namedtuple_args(self, call: CallExpr,
+                              fullname: str) -> Tuple[List[str], List[Type], int, bool]:
         """Parse a namedtuple() call into data needed to construct a type.
 
         Returns a 4-tuple:
@@ -190,7 +190,7 @@ class NamedTupleAnalyzer:
         num_defaults = 0
         if len(args) > 2:
             # Typed namedtuple doesn't support additional arguments.
-            if is_typed:
+            if fullname == 'typing.NamedTuple':
                 return self.fail_namedtuple_arg("Too many arguments for namedtuple()", call)
             for i, arg_name in enumerate(call.arg_names[2:], 2):
                 if arg_name == 'defaults':

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -244,13 +244,6 @@ class NamedTupleAnalyzer:
             num_defaults = len(items)
         return items, types, num_defaults, ok
 
-    def extract_defaults_from_arg(self, call: CallExpr, arg: Expression) -> int:
-        if not isinstance(arg, (ListExpr, TupleExpr)):
-            self.fail("List or tuple literal expected as the defaults argument to namedtuple()",
-                      call)
-            return 0
-
-
     def parse_namedtuple_fields_with_types(self, nodes: List[Expression],
                                            context: Context) -> Tuple[List[str], List[Type], int, bool]:
         items = []  # type: List[str]

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -3,7 +3,7 @@
 This is conceptually part of mypy.semanal (semantic analyzer pass 2).
 """
 
-from typing import Tuple, List, Dict, Optional, cast
+from typing import Tuple, List, Dict, Mapping, Optional, cast
 
 from mypy.types import (
     Type, TupleType, NoneTyp, AnyType, TypeOfAny, TypeVarType, TypeVarDef, CallableType, TypeType
@@ -274,7 +274,7 @@ class NamedTupleAnalyzer:
         return [], [], 0, False
 
     def build_namedtuple_typeinfo(self, name: str, items: List[str], types: List[Type],
-                                  default_items: Dict[str, Expression]) -> TypeInfo:
+                                  default_items: Mapping[str, Expression]) -> TypeInfo:
         strtype = self.api.named_type('__builtins__.str')
         implicit_any = AnyType(TypeOfAny.special_form)
         basetuple_type = self.api.named_type('__builtins__.tuple', [implicit_any])

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -79,6 +79,18 @@ x = X(1, 'x')
 a, b = x
 a, b, c = x  # E: Need more than 2 values to unpack (3 expected)
 
+[case testNamedTupleDefaults]
+# flags: --python-version 3.7
+from collections import namedtuple
+
+X = namedtuple('X', ['x', 'y'], defaults=(1,))
+
+X()  # E: Too few arguments for "X"
+X(0)  # ok
+X(0, 1)  # ok
+X(0, 1, 2)  # E: Too many arguments for "X"
+
+[builtins fixtures/list.pyi]
 
 [case testNamedTupleWithItemTypes]
 from typing import NamedTuple

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1,7 +1,7 @@
 [case testNamedTupleUsedAsTuple]
 from collections import namedtuple
 
-X = namedtuple('X', ['x', 'y'])
+X = namedtuple('X', 'x y')
 x = None  # type: X
 a, b = x
 b = x[0]
@@ -28,7 +28,7 @@ X = namedtuple('X', 'x, _y, _z')  # E: namedtuple() field names cannot start wit
 [case testNamedTupleAccessingAttributes]
 from collections import namedtuple
 
-X = namedtuple('X', ['x', 'y'])
+X = namedtuple('X', 'x y')
 x = None  # type: X
 x.x
 x.y
@@ -38,7 +38,7 @@ x.z # E: "X" has no attribute "z"
 [case testNamedTupleAttributesAreReadOnly]
 from collections import namedtuple
 
-X = namedtuple('X', ['x', 'y'])
+X = namedtuple('X', 'x y')
 x = None  # type: X
 x.x = 5 # E: Property "x" defined in "X" is read-only
 x.y = 5 # E: Property "y" defined in "X" is read-only
@@ -54,32 +54,46 @@ a.y = 5 # E: Property "y" defined in "X" is read-only
 [case testNamedTupleCreateWithPositionalArguments]
 from collections import namedtuple
 
-X = namedtuple('X', ['x', 'y'])
+X = namedtuple('X', 'x y')
 x = X(1, 'x')
 x.x
 x.z      # E: "X" has no attribute "z"
 x = X(1) # E: Too few arguments for "X"
 x = X(1, 2, 3)  # E: Too many arguments for "X"
 
+[builtins fixtures/list.pyi]
+
 [case testCreateNamedTupleWithKeywordArguments]
 from collections import namedtuple
 
-X = namedtuple('X', ['x', 'y'])
+X = namedtuple('X', 'x y')
 x = X(x=1, y='x')
 x = X(1, y='x')
 x = X(x=1, z=1) # E: Unexpected keyword argument "z" for "X"
 x = X(y=1) # E: Missing positional argument "x" in call to "X"
 
-
 [case testNamedTupleCreateAndUseAsTuple]
 from collections import namedtuple
 
-X = namedtuple('X', ['x', 'y'])
+X = namedtuple('X', 'x y')
 x = X(1, 'x')
 a, b = x
 a, b, c = x  # E: Need more than 2 values to unpack (3 expected)
 
-[case testNamedTupleDefaults]
+[case testNamedTupleAdditionalArgs]
+from collections import namedtuple
+
+A = namedtuple('A', 'a b')
+B = namedtuple('B', 'a b', rename=1)
+C = namedtuple('C', 'a b', rename='not a bool')  # E: Argument "rename" to "namedtuple" has incompatible type "str"; expected "int"
+# This works correctly but also produces "mypy/test-data/unit/lib-stub/collections.pyi:3: note: "namedtuple" defined here"
+# Don't know how to express that in a test.
+# D = namedtuple('D', 'a b', unrecognized_arg=False)  # E: Unexpected keyword argument "unrecognized_arg" for "namedtuple"
+E = namedtuple('E', 'a b', 0)  # E: Too many positional arguments for "namedtuple"
+
+[builtins fixtures/bool.pyi]
+
+[case testNamedTupleDefaults-skip]
 # flags: --python-version 3.7
 from collections import namedtuple
 
@@ -235,6 +249,7 @@ import collections
 MyNamedTuple = collections.namedtuple('MyNamedTuple', ['spam', 'eggs'])
 MyNamedTuple.x # E: "Type[MyNamedTuple]" has no attribute "x"
 
+[builtins fixtures/list.pyi]
 
 [case testNamedTupleEmptyItems]
 from typing import NamedTuple
@@ -275,6 +290,8 @@ x._replace(x=3, y=5)
 x._replace(z=5)  # E: Unexpected keyword argument "z" for "_replace" of "X"
 x._replace(5)  # E: Too many positional arguments for "_replace" of "X"
 
+[builtins fixtures/list.pyi]
+
 [case testNamedTupleReplaceAsClass]
 from collections import namedtuple
 
@@ -283,6 +300,7 @@ x = None  # type: X
 X._replace(x, x=1, y=2)
 X._replace(x=1, y=2)  # E: Missing positional argument "self" in call to "_replace" of "X"
 
+[builtins fixtures/list.pyi]
 
 [case testNamedTupleReplaceTyped]
 from typing import NamedTuple

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -61,8 +61,6 @@ x.z      # E: "X" has no attribute "z"
 x = X(1) # E: Too few arguments for "X"
 x = X(1, 2, 3)  # E: Too many arguments for "X"
 
-[builtins fixtures/list.pyi]
-
 [case testCreateNamedTupleWithKeywordArguments]
 from collections import namedtuple
 
@@ -88,7 +86,7 @@ B = namedtuple('B', 'a b', rename=1)
 C = namedtuple('C', 'a b', rename='not a bool')  # E: Argument "rename" to "namedtuple" has incompatible type "str"; expected "int"
 # This works correctly but also produces "mypy/test-data/unit/lib-stub/collections.pyi:3: note: "namedtuple" defined here"
 # Don't know how to express that in a test.
-# D = namedtuple('D', 'a b', unrecognized_arg=False)  # E: Unexpected keyword argument "unrecognized_arg" for "namedtuple"
+# D = namedtuple('D', 'a b', unrecognized_arg=False)  E: Unexpected keyword argument "unrecognized_arg" for "namedtuple"
 E = namedtuple('E', 'a b', 0)  # E: Too many positional arguments for "namedtuple"
 
 [builtins fixtures/bool.pyi]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -83,13 +83,17 @@ from collections import namedtuple
 
 A = namedtuple('A', 'a b')
 B = namedtuple('B', 'a b', rename=1)
-C = namedtuple('C', 'a b', rename='not a bool')  # E: Argument "rename" to "namedtuple" has incompatible type "str"; expected "int"
-# This works correctly but also produces "mypy/test-data/unit/lib-stub/collections.pyi:3: note: "namedtuple" defined here"
-# Don't know how to express that in a test.
-# D = namedtuple('D', 'a b', unrecognized_arg=False)  E: Unexpected keyword argument "unrecognized_arg" for "namedtuple"
-E = namedtuple('E', 'a b', 0)  # E: Too many positional arguments for "namedtuple"
+C = namedtuple('C', 'a b', rename='not a bool')
+D = namedtuple('D', 'a b', unrecognized_arg=False)
+E = namedtuple('E', 'a b', 0)
 
 [builtins fixtures/bool.pyi]
+
+[out]
+main:5: error: Argument "rename" to "namedtuple" has incompatible type "str"; expected "int"
+main:6: error: Unexpected keyword argument "unrecognized_arg" for "namedtuple"
+<ROOT>/test-data/unit/lib-stub/collections.pyi:3: note: "namedtuple" defined here
+main:7: error: Too many positional arguments for "namedtuple"
 
 [case testNamedTupleDefaults]
 # flags: --python-version 3.7

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -91,7 +91,7 @@ E = namedtuple('E', 'a b', 0)  # E: Too many positional arguments for "namedtupl
 
 [builtins fixtures/bool.pyi]
 
-[case testNamedTupleDefaults-skip]
+[case testNamedTupleDefaults]
 # flags: --python-version 3.7
 from collections import namedtuple
 
@@ -101,6 +101,9 @@ X()  # E: Too few arguments for "X"
 X(0)  # ok
 X(0, 1)  # ok
 X(0, 1, 2)  # E: Too many arguments for "X"
+
+Y = namedtuple('Y', ['x', 'y'], defaults=(1, 2, 3))  # E: Too many defaults given in call to namedtuple()
+Z = namedtuple('Z', ['x', 'y'], defaults='not a tuple')  # E: Argument "defaults" to "namedtuple" has incompatible type "str"; expected "Optional[Iterable[Any]]"  # E: List or tuple literal expected as the defaults argument to namedtuple()
 
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -123,6 +123,9 @@ Point3 = NewType('Point3', Vector3)
 p3 = Point3(Vector3(1, 3))
 reveal_type(p3.x)  # E: Revealed type is 'builtins.int'
 reveal_type(p3.y)  # E: Revealed type is 'builtins.int'
+
+[builtins fixtures/list.pyi]
+
 [out]
 
 [case testNewTypeWithCasts]

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -13,14 +13,6 @@ s = b'foo'
 from typing import TypeVar
 T = TypeVar(u'T')
 
-[case testNamedTupleUnicode]
-from typing import NamedTuple
-from collections import namedtuple
-N = NamedTuple(u'N', [(u'x', int)])
-n = namedtuple(u'n', u'x y')
-
-[builtins fixtures/dict.pyi]
-
 [case testPrintStatement]
 print ''() # E: "str" not callable
 print 1, 1() # E: "int" not callable

--- a/test-data/unit/fixtures/args.pyi
+++ b/test-data/unit/fixtures/args.pyi
@@ -27,3 +27,4 @@ class int:
 class str: pass
 class bool: pass
 class function: pass
+class ellipsis: pass

--- a/test-data/unit/fixtures/ops.pyi
+++ b/test-data/unit/fixtures/ops.pyi
@@ -55,3 +55,5 @@ class float: pass
 class BaseException: pass
 
 def __print(a1=None, a2=None, a3=None, a4=None): pass
+
+class ellipsis: pass

--- a/test-data/unit/lib-stub/collections.pyi
+++ b/test-data/unit/lib-stub/collections.pyi
@@ -1,3 +1,11 @@
-import typing
+from typing import Any, Iterable, Union, Optional
 
-namedtuple = object()
+def namedtuple(
+    typename: str,
+    field_names: Union[str, Iterable[str]],
+    *,
+    # really int but many tests don't have bool available
+    rename: int = ...,
+    module: Optional[str] = ...,
+    defaults: Optional[Iterable[Any]] = ...
+) -> Any: ...

--- a/test-data/unit/lib-stub/collections.pyi
+++ b/test-data/unit/lib-stub/collections.pyi
@@ -4,7 +4,7 @@ def namedtuple(
     typename: str,
     field_names: Union[str, Iterable[str]],
     *,
-    # really int but many tests don't have bool available
+    # really bool but many tests don't have bool available
     rename: int = ...,
     module: Optional[str] = ...,
     defaults: Optional[Iterable[Any]] = ...

--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -262,13 +262,17 @@ s = ''.join([u''])  # Error
 _program.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 _program.py:6: error: Incompatible types in assignment (expression has type "unicode", variable has type "str")
 
-[case testNamedTupleError_python2]
-import typing
+[case testNamedTuple_python2]
+from typing import NamedTuple
 from collections import namedtuple
 X = namedtuple('X', ['a', 'b'])
 x = X(a=1, b='s')
 x.c
 x.a
+
+N = NamedTuple(u'N', [(u'x', int)])
+n = namedtuple(u'n', u'x y')
+
 [out]
 _program.py:5: error: "X" has no attribute "c"
 

--- a/test-data/unit/semanal-namedtuple.test
+++ b/test-data/unit/semanal-namedtuple.test
@@ -138,10 +138,6 @@ MypyFile:1(
 from collections import namedtuple
 N = namedtuple('N') # E: Too few arguments for namedtuple()
 
-[case testNamedTupleWithTooManyArguments]
-from collections import namedtuple
-N = namedtuple('N', ['x'], 'y') # E: Too many arguments for namedtuple()
-
 [case testNamedTupleWithInvalidName]
 from collections import namedtuple
 N = namedtuple(1, ['x']) # E: namedtuple() expects a string literal as the first argument


### PR DESCRIPTION
By letting typeshed do the work.

Fixes #2124, #2127, #4788.