### PR TITLE
Move metaclass documentation to appear later in the docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,7 +32,6 @@ Mypy is a static type checker for Python 3 and Python 2.7.
    kinds_of_types
    class_basics
    protocols
-   metaclasses
    python2
    dynamic_typing
    casts
@@ -40,6 +39,7 @@ Mypy is a static type checker for Python 3 and Python 2.7.
    stubs
    generics
    more_types
+   metaclasses
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Metaclasses are a pretty specialized topic so moving them a bit
further towards the end of the documentation.