### PR TITLE
Relax union math logic to allow signatures with different arg kinds

### DIFF
--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -2157,7 +2157,7 @@ reveal_type(foo(compat))  # E: Revealed type is 'Union[builtins.int, builtins.st
 not_compat: Union[WrapperCo[A], WrapperContra[C]]
 foo(not_compat)  # E: Argument 1 to "foo" has incompatible type "Union[WrapperCo[A], WrapperContra[C]]"; expected "Union[WrapperCo[B], WrapperContra[B]]"
 
-[case testOverloadInferUnionSkipIfParameterNamesAreDifferent]
+[case testOverloadInferUnionIfParameterNamesAreDifferent]
 from typing import overload, Union
 
 class A: ...
@@ -2215,6 +2215,8 @@ def f(x: A) -> Child: ...
 def f(x: B, y: B = B()) -> Parent: ...
 def f(*args): ...
 
+# TODO: It would be nice if we could successfully do union math
+# in this case. See comments in checkexpr.union_overload_matches.
 x: Union[A, B]
 f(x)       # E: Argument 1 to "f" has incompatible type "Union[A, B]"; expected "A"
 f(x, B())  # E: Argument 1 to "f" has incompatible type "Union[A, B]"; expected "B"

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -2173,7 +2173,7 @@ def f(x): ...
 x: Union[A, B]
 reveal_type(f(A()))  # E: Revealed type is '__main__.B'
 reveal_type(f(B()))  # E: Revealed type is '__main__.C'
-f(x)                 # E: Argument 1 to "f" has incompatible type "Union[A, B]"; expected "A"
+reveal_type(f(x))    # E: Revealed type is 'Union[__main__.B, __main__.C]'
 
 [case testOverloadInferUnionReturnFunctionsWithKwargs]
 from typing import overload, Union, Optional
@@ -2191,20 +2191,54 @@ def f(x: A, y: Optional[B] = None) -> C: ...
 def f(x: A, z: Optional[C] = None) -> B: ...
 def f(x, y=None, z=None): ...
 
-reveal_type(f(A(), B()))
-reveal_type(f(A(), C()))
+reveal_type(f(A(), B()))  # E: Revealed type is '__main__.C'
+reveal_type(f(A(), C()))  # E: Revealed type is '__main__.B'
 
 arg: Union[B, C]
-reveal_type(f(A(), arg))
-reveal_type(f(A()))
+reveal_type(f(A(), arg))  # E: Revealed type is 'Union[__main__.C, __main__.B]'
+reveal_type(f(A()))       # E: Revealed type is '__main__.D'
 
 [builtins fixtures/tuple.pyi]
-[out]
-main:16: error: Revealed type is '__main__.C'
-main:17: error: Revealed type is '__main__.B'
-main:20: error: Revealed type is '__main__.C'
-main:20: error: Argument 2 to "f" has incompatible type "Union[B, C]"; expected "Optional[B]"
-main:21: error: Revealed type is '__main__.D'
+
+[case testOverloadInferUnionWithDifferingLengths]
+from typing import overload, Union
+
+class Parent: ...
+class Child(Parent): ...
+
+class A: ...
+class B: ...
+
+@overload
+def f(x: A) -> Child: ...
+@overload
+def f(x: B, y: B = B()) -> Parent: ...
+def f(*args): ...
+
+x: Union[A, B]
+f(x)       # E: Argument 1 to "f" has incompatible type "Union[A, B]"; expected "A"
+f(x, B())  # E: Argument 1 to "f" has incompatible type "Union[A, B]"; expected "B"
+
+[case testOverloadInferUnionWithMixOfPositionalAndOptionalArgs]
+# flags: --strict-optional
+from typing import overload, Union, Optional
+
+class A: ...
+class B: ...
+
+@overload
+def f(x: A) -> int: ...
+@overload
+def f(x: Optional[B] = None) -> str: ...
+def f(*args): ...
+
+x: Union[A, B]
+y: Optional[A]
+z: Union[A, Optional[B]]
+reveal_type(f(x))  # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(f(y))  # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(f(z))  # E: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(f())   # E: Revealed type is 'builtins.str'
 
 [case testOverloadingInferUnionReturnWithTypevarWithValueRestriction]
 from typing import overload, Union, TypeVar, Generic


### PR DESCRIPTION
Resolves https://github.com/python/mypy/issues/5204.

This commit relaxes the union math logic so that it allows signatures with arg kinds that are nearly identical except that one arg is positional and the other is optional.

This commit also removes the "names must be the same" restriction mostly so that the original example given in https://github.com/python/mypy/issues/4576 will pass. (In retrospect, I think this check didn't really buy us much -- even if the alternatives share the same arg names, there's no guarantee the actual implementation signature will also share the same.)