### PR TITLE
Require abstract classes in stubs to be explicitly marked

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -867,7 +867,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         if abstract and not abstract_in_this_class:
             attrs = ", ".join('"{}"'.format(attr) for attr in sorted(abstract))
             self.fail("Class {} has abstract attributes {}".format(typ.fullname(), attrs), typ)
-            self.note("If it is meant to be abstract, add 'abc.ABCMeta' as an explicit metaclass", typ)
+            self.note("If it is meant to be abstract, add 'abc.ABCMeta' as an explicit metaclass",
+                      typ)
 
     def setup_type_promotion(self, defn: ClassDef) -> None:
         """Setup extra, ad-hoc subtyping relationships between classes (promotion).

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -828,6 +828,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         """
         concrete = set()  # type: Set[str]
         abstract = []  # type: List[str]
+        abstract_in_this_class = []  # type: List[str]
         for base in typ.mro:
             for name, symnode in base.names.items():
                 node = symnode.node
@@ -844,13 +845,17 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                     if fdef.is_abstract and name not in concrete:
                         typ.is_abstract = True
                         abstract.append(name)
+                        if base is typ:
+                            abstract_in_this_class.append(name)
                 elif isinstance(node, Var):
                     if node.is_abstract_var and name not in concrete:
                         typ.is_abstract = True
                         abstract.append(name)
+                        if base is typ:
+                            abstract_in_this_class.append(name)
                 concrete.add(name)
         typ.abstract_attributes = sorted(abstract)
-        if abstract:
+        if abstract and not abstract_in_this_class:
             self.fail('Class {} has abstract attributes {}'.format(typ.fullname(), sorted(abstract)), typ)
 
     def setup_type_promotion(self, defn: ClassDef) -> None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -850,6 +850,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                         abstract.append(name)
                 concrete.add(name)
         typ.abstract_attributes = sorted(abstract)
+        if abstract:
+            self.fail('Class {} has abstract attributes {}'.format(typ.fullname(), sorted(abstract)), typ)
 
     def setup_type_promotion(self, defn: ClassDef) -> None:
         """Setup extra, ad-hoc subtyping relationships between classes (promotion).

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -860,8 +860,9 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         if (typ.declared_metaclass and typ.declared_metaclass.type.fullname() == 'abc.ABCMeta'):
             return
         if abstract and not abstract_in_this_class:
-            self.fail('Class {} has abstract attributes {}'.format(typ.fullname(), sorted(abstract)), typ)
-            self.note('If it is meant to be abstract, add "abc.ABCMeta" as an explicit metaclass.', typ)
+            attrs = ", ".join('"{}"'.format(attr) for attr in sorted(abstract))
+            self.fail("Class {} has abstract attributes {}".format(typ.fullname(), attrs), typ)
+            self.note("If it is meant to be abstract, add 'abc.ABCMeta' as an explicit metaclass", typ)
 
     def setup_type_promotion(self, defn: ClassDef) -> None:
         """Setup extra, ad-hoc subtyping relationships between classes (promotion).

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -855,8 +855,13 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                             abstract_in_this_class.append(name)
                 concrete.add(name)
         typ.abstract_attributes = sorted(abstract)
+        if not self.is_stub_file:
+            return
+        if (typ.declared_metaclass and typ.declared_metaclass.type.fullname() == 'abc.ABCMeta'):
+            return
         if abstract and not abstract_in_this_class:
             self.fail('Class {} has abstract attributes {}'.format(typ.fullname(), sorted(abstract)), typ)
+            self.note('If it is meant to be abstract, add "abc.ABCMeta" as an explicit metaclass.', typ)
 
     def setup_type_promotion(self, defn: ClassDef) -> None:
         """Setup extra, ad-hoc subtyping relationships between classes (promotion).

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -854,10 +854,15 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                         if base is typ:
                             abstract_in_this_class.append(name)
                 concrete.add(name)
+        # In stubs, abstract classes need to be explicitly marked because it is too
+        # easy to accidentally leave a concrete class abstract by forgetting to
+        # implement some methods.
         typ.abstract_attributes = sorted(abstract)
         if not self.is_stub_file:
             return
         if (typ.declared_metaclass and typ.declared_metaclass.type.fullname() == 'abc.ABCMeta'):
+            return
+        if typ.is_protocol:
             return
         if abstract and not abstract_in_this_class:
             attrs = ", ".join('"{}"'.format(attr) for attr in sorted(abstract))

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4376,3 +4376,44 @@ class C1(object):
 main:4: error: Revealed local types are:
 main:4: error: t: builtins.str
 main:4: error: y: builtins.float
+
+[case testAbstractClasses]
+import a
+import b
+
+[file a.pyi]
+from abc import ABCMeta, abstractmethod
+
+class A:  # OK, has @abstractmethod
+    @abstractmethod
+    def f(self) -> None:
+        pass
+
+class B(A):  # E: Class a.B has abstract attributes "f"  # N: If it is meant to be abstract, add 'abc.ABCMeta' as an explicit metaclass
+    pass
+
+class C(A, metaclass=ABCMeta):  # OK, has ABCMeta as a metaclass
+    pass
+
+class D(A):  # OK, implements the abstract method
+    def f(self) -> None:
+        pass
+
+[file b.py]
+# All of these are OK because this is not a stub file.
+from abc import ABCMeta, abstractmethod
+
+class A:
+    @abstractmethod
+    def f(self) -> None:
+        pass
+
+class B(A):
+    pass
+
+class C(A, metaclass=ABCMeta):
+    pass
+
+class D(A):
+    def f(self) -> None:
+        pass

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4383,6 +4383,7 @@ import b
 
 [file a.pyi]
 from abc import ABCMeta, abstractmethod
+from typing import Protocol
 
 class A:  # OK, has @abstractmethod
     @abstractmethod
@@ -4399,9 +4400,18 @@ class D(A):  # OK, implements the abstract method
     def f(self) -> None:
         pass
 
+class E(Protocol):  # OK, is a protocol
+    @abstractmethod
+    def f(self) -> None:
+        pass
+
+class F(E, Protocol):  # OK, is a protocol
+    pass
+
 [file b.py]
 # All of these are OK because this is not a stub file.
 from abc import ABCMeta, abstractmethod
+from typing import Protocol
 
 class A:
     @abstractmethod
@@ -4417,3 +4427,11 @@ class C(A, metaclass=ABCMeta):
 class D(A):
     def f(self) -> None:
         pass
+
+class E(Protocol):
+    @abstractmethod
+    def f(self) -> None:
+        pass
+
+class F(E, Protocol):
+    pass

--- a/test-data/unit/fixtures/async_await.pyi
+++ b/test-data/unit/fixtures/async_await.pyi
@@ -2,7 +2,9 @@ import typing
 
 T = typing.TypeVar('T')
 U = typing.TypeVar('U')
-class list(typing.Sequence[T]): pass
+class list(typing.Sequence[T]):
+    def __iter__(self) -> typing.Iterator[T]: ...
+    def __getitem__(self, i: int) -> T: ...
 
 class object:
     def __init__(self) -> None: pass

--- a/test-data/unit/fixtures/typing-full.pyi
+++ b/test-data/unit/fixtures/typing-full.pyi
@@ -6,7 +6,7 @@
 # Many of the definitions have special handling in the type checker, so they
 # can just be initialized to anything.
 
-from abc import abstractmethod
+from abc import abstractmethod, ABCMeta
 
 class GenericMeta(type): pass
 
@@ -98,7 +98,7 @@ class Awaitable(Protocol[T]):
     @abstractmethod
     def __await__(self) -> Generator[Any, Any, T]: pass
 
-class AwaitableGenerator(Generator[T, U, V], Awaitable[V], Generic[T, U, V, S]):
+class AwaitableGenerator(Generator[T, U, V], Awaitable[V], Generic[T, U, V, S], metaclass=ABCMeta):
     pass
 
 class Coroutine(Awaitable[V], Generic[T, U, V]):
@@ -128,7 +128,7 @@ class Sequence(Iterable[T_co], Protocol):
     def __getitem__(self, n: Any) -> T_co: pass
 
 @runtime
-class Mapping(Iterable[T], Protocol[T, T_co]):
+class Mapping(Iterable[T], Protocol[T, T_co], metaclass=ABCMeta):
     def __getitem__(self, key: T) -> T_co: pass
     @overload
     def get(self, k: T) -> Optional[T_co]: pass
@@ -139,7 +139,7 @@ class Mapping(Iterable[T], Protocol[T, T_co]):
     def __contains__(self, arg: object) -> int: pass
 
 @runtime
-class MutableMapping(Mapping[T, U], Protocol):
+class MutableMapping(Mapping[T, U], Protocol, metaclass=ABCMeta):
     def __setitem__(self, k: T, v: U) -> None: pass
 
 class SupportsInt(Protocol):


### PR DESCRIPTION
Fixes #3692.

In typeshed, we have had many bugs because of classes that were not meant to be abstract, but were inferred by mypy to be abstract because they didn't implement some methods from an abstract base class. I call such classes "accidentally abstract"; python/typeshed#1476 has a list of cases where this bug appeared.

It is hard to catch these bugs because they only show up in user code when somebody tries to instantiate the class, and when reviewing changes to typeshed you have to manually go over all methods to find instances of this bug. Therefore, I'd like to have mypy point out accidentally abstract classes automatically.

This PR throws an error if a class:
- Has any abstract method;
- Does not itself have any method decorated with `@abstractmethod` (i.e., all abstract methods are inherited);
- Does not have `ABCMeta` as an explicit metaclass, or `Protocol` as an explicit base class;
- Is defined in a stub file.
This generates about five false positives in typeshed's Python 3 code, which we can fix by manually adding `ABCMeta` as a metaclass. On the other hand, there have been at least 30 accidentally abstract classes in typeshed that would have been caught by this patch, although I've fixed most of them by now.

This PR is going to fail tests for now because not all typeshed classes are fixed yet. If we're in agreement that this PR is acceptable, I will work on getting typeshed ready for it by adding the right `ABCMeta` metaclasses.