### PR TITLE
Use __getattr__ to mark partial stub packages

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1741,7 +1741,7 @@ class State:
                  # If `temporary` is True, this State is beeing created to just
                  # quickly parse/load the tree, without an intention to further
                  # process it. With this flag, any changes to external state as well
-                 # as error reprting should be avoided.
+                 # as error reporting should be avoided.
                  temporary: bool = False,
                  ) -> None:
         assert id or path or source is not None, "Neither id, path nor source given"

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2349,8 +2349,8 @@ def in_partial_package(id: str, manager: BuildManager) -> bool:
         if parent_mod:
             if parent_mod.is_partial_stub_package:
                 return True
-            if not parent_mod.is_stub:
-                # Bail out soon, only stub package can be partial, not runtime one.
+            else:
+                # Bail out soon, complete subpackage found
                 return False
         id = parent
     return False

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2337,7 +2337,7 @@ def in_partial_package(id: str, manager: BuildManager) -> bool:
     while '.' in id:
         parent, _ = id.rsplit('.', 1)
         if parent in manager.modules:
-            parent_mod = manager.modules[parent]
+            parent_mod = manager.modules[parent]  # type: Optional[MypyFile]
         else:
             # Parent is not in build, try quickly if we can find it.
             try:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2276,6 +2276,7 @@ def find_module_and_diagnose(manager: BuildManager,
     """Find a module by name, respecting follow_imports and producing diagnostics.
 
     If the module is not found, then the ModuleNotFound exception is raised.
+
     Args:
       id: module to find
       options: the options for the module being loaded

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -219,6 +219,7 @@ class MypyFile(SymbolNode):
     is_stub = False
     # Is this loaded from the cache and thus missing the actual body of the file?
     is_cache_skeleton = False
+    is_partial_stub_package = False
 
     def __init__(self,
                  defs: List[Statement],

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -260,7 +260,7 @@ class MypyFile(SymbolNode):
                 'names': self.names.serialize(self._fullname),
                 'is_stub': self.is_stub,
                 'path': self.path,
-                'is_partial_stub_package': self.is_partial_stub_package
+                'is_partial_stub_package': self.is_partial_stub_package,
                 }
 
     @classmethod

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -257,6 +257,7 @@ class MypyFile(SymbolNode):
                 'names': self.names.serialize(self._fullname),
                 'is_stub': self.is_stub,
                 'path': self.path,
+                'is_partial_stub_package': self.is_partial_stub_package
                 }
 
     @classmethod
@@ -268,6 +269,7 @@ class MypyFile(SymbolNode):
         tree.names = SymbolTable.deserialize(data['names'])
         tree.is_stub = data['is_stub']
         tree.path = data['path']
+        tree.is_partial_stub_package = data['is_partial_stub_package']
         tree.is_cache_skeleton = True
         return tree
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -219,6 +219,9 @@ class MypyFile(SymbolNode):
     is_stub = False
     # Is this loaded from the cache and thus missing the actual body of the file?
     is_cache_skeleton = False
+    # Is this representns an __init__.pyi stub with a module __getattr__
+    # (i.e. a partial stub package), for such packages we suppress any missing
+    # module errors in addition to missing attribute errors.
     is_partial_stub_package = False
 
     def __init__(self,

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -219,7 +219,7 @@ class MypyFile(SymbolNode):
     is_stub = False
     # Is this loaded from the cache and thus missing the actual body of the file?
     is_cache_skeleton = False
-    # Is this representns an __init__.pyi stub with a module __getattr__
+    # Does this represent an __init__.pyi stub with a module __getattr__
     # (i.e. a partial stub package), for such packages we suppress any missing
     # module errors in addition to missing attribute errors.
     is_partial_stub_package = False

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -155,7 +155,7 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
         func._fullname = sem.qualified_name(func.name())
         at_module = sem.is_module_scope()
         if (at_module and func.name() == '__getattr__' and
-                '__init__.pyi' in self.sem.cur_mod_node.path):
+                self.sem.cur_mod_node.is_package_init_file() and self.sem.cur_mod_node.is_stub):
             self.sem.cur_mod_node.is_partial_stub_package = True
         if at_module and func.name() in sem.globals:
             # Already defined in this module.

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -26,7 +26,7 @@ from mypy.nodes import (
     TryStmt, OverloadedFuncDef, Lvalue, Context, ImportedName, LDEF, GDEF, MDEF, UNBOUND_IMPORTED,
     MODULE_REF, implicit_module_attrs
 )
-from mypy.types import Type, UnboundType, UnionType, AnyType, TypeOfAny, NoneTyp
+from mypy.types import Type, UnboundType, UnionType, AnyType, TypeOfAny, NoneTyp, CallableType
 from mypy.semanal import SemanticAnalyzerPass2, infer_reachability_of_if_statement
 from mypy.semanal_shared import create_indirect_imported_name
 from mypy.options import Options
@@ -156,7 +156,14 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
         at_module = sem.is_module_scope()
         if (at_module and func.name() == '__getattr__' and
                 self.sem.cur_mod_node.is_package_init_file() and self.sem.cur_mod_node.is_stub):
-            self.sem.cur_mod_node.is_partial_stub_package = True
+            if isinstance(func.type, CallableType):
+                ret = func.type.ret_type
+                if isinstance(ret, UnboundType) and not ret.args:
+                    sym = self.sem.lookup_qualified(ret.name, func, suppress_errors=True)
+                    # We only interpred package as partial if __getattr__ return type
+                    # is either types.ModuleType of Any.
+                    if sym and sym.node and sym.node.fullname() in ('types.ModuleType', 'typing.Any'):
+                        self.sem.cur_mod_node.is_partial_stub_package = True
         if at_module and func.name() in sem.globals:
             # Already defined in this module.
             original_sym = sem.globals[func.name()]

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -162,7 +162,8 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
                     sym = self.sem.lookup_qualified(ret.name, func, suppress_errors=True)
                     # We only interpred package as partial if __getattr__ return type
                     # is either types.ModuleType of Any.
-                    if sym and sym.node and sym.node.fullname() in ('types.ModuleType', 'typing.Any'):
+                    if sym and sym.node and sym.node.fullname() in ('types.ModuleType',
+                                                                    'typing.Any'):
                         self.sem.cur_mod_node.is_partial_stub_package = True
         if at_module and func.name() in sem.globals:
             # Already defined in this module.

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -154,6 +154,9 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
         func.is_conditional = sem.block_depth[-1] > 0
         func._fullname = sem.qualified_name(func.name())
         at_module = sem.is_module_scope()
+        if (at_module and func.name() == '__getattr__' and
+                '__init__.pyi' in self.sem.cur_mod_node.path):
+            self.sem.cur_mod_node.is_partial_stub_package = True
         if at_module and func.name() in sem.globals:
             # Already defined in this module.
             original_sym = sem.globals[func.name()]

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -160,7 +160,7 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
                 ret = func.type.ret_type
                 if isinstance(ret, UnboundType) and not ret.args:
                     sym = self.sem.lookup_qualified(ret.name, func, suppress_errors=True)
-                    # We only interpred package as partial if __getattr__ return type
+                    # We only interpret a package as partial if the __getattr__ return type
                     # is either types.ModuleType of Any.
                     if sym and sym.node and sym.node.fullname() in ('types.ModuleType',
                                                                     'typing.Any'):

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2241,6 +2241,22 @@ def __getattr__(attr: str) -> int: pass
 main:1: error: Cannot find module named 'a.b'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 
+[case testModuleGetattrInit8]
+import a.b.c.d
+
+x = a.b.c.d.f()
+[file a/__init__.pyi]
+from typing import Any
+def __getattr__(attr: str) -> Any: pass
+[file a/b/__init__.pyi]
+# empty (i.e. complete subpackage)
+[builtins fixtures/module.pyi]
+[out]
+main:1: error: Cannot find module named 'a.b.c'
+main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: error: Cannot find module named 'a.b.c.d'
+main:3: error: Module has no attribute "c"
+
 [case testIndirectFromImportWithinCycleUsedAsBaseClass-skip]
 -- TODO: Fails because of missing ImportedName handling in mypy.typeanal
 import a

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2173,6 +2173,54 @@ from c import x
 x = str()
 y = int()
 
+[case testModuleGetattrInit1]
+from a import b
+
+x = b.f()
+[file a/__init__.pyi]
+from typing import Any
+def __getattr__(attr: str) -> Any: pass
+[out]
+
+[case testModuleGetattrInit2]
+import a.b
+
+x = a.b.f()
+[file a/__init__.pyi]
+from typing import Any
+def __getattr__(attr: str) -> Any: pass
+[out]
+
+[case testModuleGetattrInit3]
+import a.b
+
+x = a.b.f()
+[file a/__init__.py]
+from typing import Any
+def __getattr__(attr: str) -> Any: pass
+[out]
+main:1: error: Cannot find module named 'a.b'
+main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:3: error: "object" has no attribute "b"
+
+[case testModuleGetattrInit4]
+import a.b.c
+
+x = a.b.c.f()
+[file a/__init__.pyi]
+from typing import Any
+def __getattr__(attr: str) -> Any: pass
+[out]
+
+[case testModuleGetattrInit5]
+from a.b import f
+
+x = f()
+[file a/__init__.pyi]
+from typing import Any
+def __getattr__(attr: str) -> Any: pass
+[out]
+
 [case testIndirectFromImportWithinCycleUsedAsBaseClass-skip]
 -- TODO: Fails because of missing ImportedName handling in mypy.typeanal
 import a

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2277,6 +2277,26 @@ def __getattr__(attr: str) -> Any: ...
 main:1: error: Cannot find module named 'a.b.c'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 
+[case testModuleGetattrInit10]
+# flags: --config-file tmp/mypy.ini
+import a.b.c  # silenced
+import a.b.d  # error
+
+[file a/__init__.pyi]
+from typing import Any
+def __getattr__(attr: str) -> Any: ...
+[file a/b/__init__.pyi]
+# empty (i.e. complete subpackage)
+
+[file mypy.ini]
+[[mypy]
+[[mypy-a.b.c]
+ignore_missing_imports = True
+[builtins fixtures/module.pyi]
+[out]
+main:3: error: Cannot find module named 'a.b.d'
+main:3: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+
 [case testIndirectFromImportWithinCycleUsedAsBaseClass-skip]
 -- TODO: Fails because of missing ImportedName handling in mypy.typeanal
 import a

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2179,7 +2179,8 @@ from a import b
 x = b.f()
 [file a/__init__.pyi]
 from typing import Any
-def __getattr__(attr: str) -> Any: pass
+def __getattr__(attr: str) -> Any: ...
+[builtins fixtures/module.pyi]
 [out]
 
 [case testModuleGetattrInit2]
@@ -2188,7 +2189,8 @@ import a.b
 x = a.b.f()
 [file a/__init__.pyi]
 from typing import Any
-def __getattr__(attr: str) -> Any: pass
+def __getattr__(attr: str) -> Any: ...
+[builtins fixtures/module.pyi]
 [out]
 
 [case testModuleGetattrInit3]
@@ -2197,11 +2199,12 @@ import a.b
 x = a.b.f()
 [file a/__init__.py]
 from typing import Any
-def __getattr__(attr: str) -> Any: pass
+def __getattr__(attr: str) -> Any: ...
+[builtins fixtures/module.pyi]
 [out]
 main:1: error: Cannot find module named 'a.b'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
-main:3: error: "object" has no attribute "b"
+main:3: error: Module has no attribute "b"
 
 [case testModuleGetattrInit4]
 import a.b.c
@@ -2209,7 +2212,8 @@ import a.b.c
 x = a.b.c.f()
 [file a/__init__.pyi]
 from typing import Any
-def __getattr__(attr: str) -> Any: pass
+def __getattr__(attr: str) -> Any: ...
+[builtins fixtures/module.pyi]
 [out]
 
 [case testModuleGetattrInit5]
@@ -2218,7 +2222,8 @@ from a.b import f
 x = f()
 [file a/__init__.pyi]
 from typing import Any
-def __getattr__(attr: str) -> Any: pass
+def __getattr__(attr: str) -> Any: ...
+[builtins fixtures/module.pyi]
 [out]
 
 [case testModuleGetattrInit5a]
@@ -2227,7 +2232,8 @@ from a.b import f
 x = f()
 [file a/__init__.pyi]
 from types import ModuleType
-def __getattr__(attr: str) -> ModuleType: pass
+def __getattr__(attr: str) -> ModuleType: ...
+[builtins fixtures/module.pyi]
 [out]
 
 
@@ -2236,7 +2242,8 @@ from a.b import f
 
 x = f()
 [file a/__init__.pyi]
-def __getattr__(attr: str) -> int: pass
+def __getattr__(attr: str) -> int: ...
+[builtins fixtures/module.pyi]
 [out]
 main:1: error: Cannot find module named 'a.b'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
@@ -2247,7 +2254,7 @@ import a.b.c.d
 x = a.b.c.d.f()
 [file a/__init__.pyi]
 from typing import Any
-def __getattr__(attr: str) -> Any: pass
+def __getattr__(attr: str) -> Any: ...
 [file a/b/__init__.pyi]
 # empty (i.e. complete subpackage)
 [builtins fixtures/module.pyi]
@@ -2262,7 +2269,7 @@ import a.b.c  # Error
 import a.d  # OK
 [file a/__init__.pyi]
 from typing import Any
-def __getattr__(attr: str) -> Any: pass
+def __getattr__(attr: str) -> Any: ...
 [file a/b/__init__.pyi]
 # empty (i.e. complete subpackage)
 [builtins fixtures/module.pyi]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2204,7 +2204,6 @@ def __getattr__(attr: str) -> Any: ...
 [out]
 main:1: error: Cannot find module named 'a.b'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
-main:3: error: Module has no attribute "b"
 
 [case testModuleGetattrInit4]
 import a.b.c
@@ -2262,7 +2261,6 @@ def __getattr__(attr: str) -> Any: ...
 main:1: error: Cannot find module named 'a.b.c'
 main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
 main:1: error: Cannot find module named 'a.b.c.d'
-main:3: error: Module has no attribute "c"
 
 [case testModuleGetattrInit8a]
 import a.b.c  # Error

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2221,6 +2221,26 @@ from typing import Any
 def __getattr__(attr: str) -> Any: pass
 [out]
 
+[case testModuleGetattrInit5a]
+from a.b import f
+
+x = f()
+[file a/__init__.pyi]
+from types import ModuleType
+def __getattr__(attr: str) -> ModuleType: pass
+[out]
+
+
+[case testModuleGetattrInit5b]
+from a.b import f
+
+x = f()
+[file a/__init__.pyi]
+def __getattr__(attr: str) -> int: pass
+[out]
+main:1: error: Cannot find module named 'a.b'
+main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+
 [case testIndirectFromImportWithinCycleUsedAsBaseClass-skip]
 -- TODO: Fails because of missing ImportedName handling in mypy.typeanal
 import a

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2257,6 +2257,19 @@ main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" 
 main:1: error: Cannot find module named 'a.b.c.d'
 main:3: error: Module has no attribute "c"
 
+[case testModuleGetattrInit8a]
+import a.b.c  # Error
+import a.d  # OK
+[file a/__init__.pyi]
+from typing import Any
+def __getattr__(attr: str) -> Any: pass
+[file a/b/__init__.pyi]
+# empty (i.e. complete subpackage)
+[builtins fixtures/module.pyi]
+[out]
+main:1: error: Cannot find module named 'a.b.c'
+main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+
 [case testIndirectFromImportWithinCycleUsedAsBaseClass-skip]
 -- TODO: Fails because of missing ImportedName handling in mypy.typeanal
 import a


### PR DESCRIPTION
There is a problem with annotating large frameworks -- they are large. Therefore it is hard to produce good stubs in a single pass. A possible better workflow would be to allow indicating that a given (sub-)package is incomplete.

I propose to use `__getattr__` for the role of such indicator. A motivation is that currently adding a `__getattr__` to `package/__init__.pyi` already makes `from package import mod` work, but `import package.mod` still fails (plus simplicity of implementation). Here are the rules that I propose:
* One can declare a (sub-)package as incomplete by adding a `__getattr__` to its `__init__.pyi`
* If the return type of this function is `types.ModuleType` or `Any`, we assume that all imports from this (sub-)package succeed.
* Incomplete package can contain a complete subpackage:
```python
# file a/__init__.pyi
from types import ModuleType
def __getattr__(attr: str) -> ModuleType: ...

# file a/b/__init__.pyi
# empty (i.e. complete package)

# file main.py
import a.d  # OK
import a.b.c  # Error module not found
```

Note: these rules apply only to stubs (i.e. `.pyi` files). I add several tests to illustrate this behaviour.
This PR shouldn't give any significant performance penalty because the added parsing/loading only happens when an error would be reported (for our internal workflow the penalty will be zero because of the flags we use).

This PR will allow gradually adding stub modules to a large framework package, without generating loads of false positives for user code.

Note: PEP 561 introduces the notion of a partial stub package, implemented in https://github.com/python/mypy/pull/5227. I think however this is a bit different use case that I don't want to mix with this one for two reasons:
* Partial packages in PEP 561 are mainly focused on interaction between stubs and inline/runtime packages.
* The proposed feature may be also used in typeshed, not only for installed stub packages.