### PR TITLE
Only apply overloading union math to "real" unions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1129,7 +1129,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         erased_targets = None  # type: Optional[List[CallableType]]
         unioned_result = None  # type: Optional[Tuple[Type, Type]]
         unioned_errors = None  # type: Optional[MessageBuilder]
-        if any(isinstance(arg, UnionType) for arg in arg_types):
+        if any(isinstance(arg, UnionType) and len(arg.relevant_items()) > 1  # "real" union
+               for arg in arg_types):
             erased_targets = self.overload_erased_call_targets(plausible_targets, arg_types,
                                                                arg_kinds, arg_names, context)
             unioned_callable = self.union_overload_matches(erased_targets)

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -3669,3 +3669,37 @@ reveal_type(Child.foo("..."))               # E: Revealed type is 'builtins.str'
 reveal_type(Child.foo(x))                   # E: Revealed type is 'Union[Type[__main__.Child*], builtins.str]'
 reveal_type(Child.foo(3)().child_only())    # E: Revealed type is 'builtins.int'
 [builtins fixtures/classmethod.pyi]
+
+[case testOptionalIsNotAUnionIfNoStrictOverload]
+# flags: --no-strict-optional
+from typing import Optional, overload
+
+class B: pass
+class C(B): pass
+
+@overload
+def rp(x: C) -> C: ...
+@overload
+def rp(x: B) -> B: ...
+def rp(x):
+    pass
+
+x: Optional[C]
+reveal_type(rp(x))  # E: Revealed type is '__main__.C'
+[out]
+
+[case testOptionalIsNotAUnionIfNoStrictOverloadStr]
+# flags: -2 --no-strict-optional
+
+from typing import Optional
+from m import relpath
+a = '' # type: Optional[str]
+reveal_type(relpath(a))  # E: Revealed type is 'builtins.str'
+
+[file m.pyi]
+from typing import overload
+@overload
+def relpath(path: str) -> str: ...
+@overload
+def relpath(path: unicode) -> unicode: ...
+[out]

--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -401,3 +401,13 @@ def f():  # no annotation
 path = 'test'
 path = os.path.join(f(), 'test.py')
 [out]
+
+[case testOverloadRelpathRegression]
+# flags: --no-strict-optional
+
+from typing import Optional
+from os.path import relpath
+a = '' # type: Optional[str]
+reveal_type(relpath(a))
+[out]
+_testOverloadRelpathRegression.py:6: error: Revealed type is 'builtins.str'

--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -401,13 +401,3 @@ def f():  # no annotation
 path = 'test'
 path = os.path.join(f(), 'test.py')
 [out]
-
-[case testOverloadRelpathRegression]
-# flags: --no-strict-optional
-
-from typing import Optional
-from os.path import relpath
-a = '' # type: Optional[str]
-reveal_type(relpath(a))
-[out]
-_testOverloadRelpathRegression.py:6: error: Revealed type is 'builtins.str'


### PR DESCRIPTION
By "real" unions I mean unions with more than one relevant item.

Fixes https://github.com/python/mypy/issues/5238

(I have found another bug in union math logic while looking at this code, but it is a bit more subtle, so we will fix it separately).