### PR TITLE
fine-grained: Don't strip ForStmt.index_type

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -956,6 +956,8 @@ class ForStmt(Statement):
     index = None  # type: Lvalue
     # Type given by type comments for index, can be None
     index_type = None  # type: Optional[mypy.types.Type]
+    # Original, not semantically analyzed type in annotation (used for reprocessing)
+    unanalyzed_index_type = None  # type: Optional[mypy.types.Type]
     # Inferred iterable item type
     inferred_item_type = None  # type: Optional[mypy.types.Type]
     # Inferred iterator type
@@ -975,6 +977,7 @@ class ForStmt(Statement):
         super().__init__()
         self.index = index
         self.index_type = index_type
+        self.unanalyzed_index_type = index_type
         self.expr = expr
         self.body = body
         self.else_body = else_body

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -233,8 +233,8 @@ class NodeStripVisitor(TraverserVisitor):
         node.imported_names = []
 
     def visit_for_stmt(self, node: ForStmt) -> None:
-        node.index_type = None
         node.inferred_item_type = None
+        node.inferred_iterator_type = None
         super().visit_for_stmt(node)
 
     def visit_name_expr(self, node: NameExpr) -> None:

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -233,6 +233,7 @@ class NodeStripVisitor(TraverserVisitor):
         node.imported_names = []
 
     def visit_for_stmt(self, node: ForStmt) -> None:
+        node.index_type = node.unanalyzed_index_type
         node.inferred_item_type = None
         node.inferred_iterator_type = None
         super().visit_for_stmt(node)

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7219,7 +7219,7 @@ x = []  # type: List
 [out]
 ==
 
-[case testRefreshForWithTypeComment]
+[case testRefreshForWithTypeComment1]
 [file a.py]
 from typing import List
 import b
@@ -7235,3 +7235,17 @@ x = '1'
 [builtins fixtures/list.pyi]
 [out]
 ==
+
+[case testRefreshForWithTypeComment2]
+from typing import List, Any
+import m
+def f(x: List[Any]) -> None:
+    for a in x:  # type: m.A
+        pass
+[file m.py]
+class A: pass
+[file m.py.2]
+[builtins fixtures/list.pyi]
+[out]
+==
+main:4: error: Name 'm.A' is not defined

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7218,3 +7218,20 @@ x = []  # type: List
 [builtins fixtures/list.pyi]
 [out]
 ==
+
+[case testRefreshForWithTypeComment]
+[file a.py]
+from typing import List
+import b
+def foo(l: List[int]) -> None:
+    for x in l:  # type: object
+        pass
+    x = object()
+    b.x
+[file b.py]
+x = 1
+[file b.py.2]
+x = '1'
+[builtins fixtures/list.pyi]
+[out]
+==


### PR DESCRIPTION
index_type is populated during parsing, so stripping it
causes trouble.

Also *do* strip inferred_iterator_type, which is populated during
checking.