### PR TITLE
Force-enable strict optional only when checking for unsafe overlaps

### DIFF
--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -3717,3 +3717,49 @@ def relpath(path: str) -> str: ...
 @overload
 def relpath(path: unicode) -> unicode: ...
 [out]
+
+[case testOverloadsWithNoneComingSecondAreAlwaysFlaggedInNoStrictOptional]
+# flags: --no-strict-optional
+from typing import overload
+
+@overload
+def none_first(x: None) -> None: ...
+@overload
+def none_first(x: int) -> int: ...
+def none_first(x: int) -> int:
+    return x
+
+@overload
+def none_second(x: int) -> int: ...
+@overload
+def none_second(x: None) -> None: ...  # E: Overloaded function signature 2 will never be matched: signature 1's parameter type(s) are the same or broader
+def none_second(x: int) -> int:
+    return x
+
+[case testOverloadsWithNoneComingSecondIsOkInStrictOptional]
+# flags: --strict-optional
+from typing import overload, Optional
+
+@overload
+def none_first(x: None) -> None: ...
+@overload
+def none_first(x: int) -> int: ...
+def none_first(x: Optional[int]) -> Optional[int]:
+    return x
+
+@overload
+def none_second(x: int) -> int: ...
+@overload
+def none_second(x: None) -> None: ...
+def none_second(x: Optional[int]) -> Optional[int]:
+    return x
+
+@overload
+def none_loose_impl(x: None) -> None: ...
+@overload
+def none_loose_impl(x: int) -> int: ...
+def none_loose_impl(x: int) -> int:
+    return x
+[out]
+main:22: error: Overloaded function implementation does not accept all possible arguments of signature 1
+main:22: error: Overloaded function implementation cannot produce return type of signature 1


### PR DESCRIPTION
Resolves https://github.com/python/mypy/issues/5246

Previously, we force-enabled strict optional checks when performing all overload definition checks. This ended up causing mypy to miss some errors in definitions when `--no-strict-optional` mode is enabled.

This commit will now force-enable strict optional only when checking if overloads are unsafely overlapping: we use the existing mode when checking if one variant completely eclipses another or when checking the implementation.