### PR TITLE
Ignore vscode settings folder in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dmypy.json
 # IDEs
 .idea
 *.swp
+.vscode
 
 # Operating Systems
 .DS_Store


### PR DESCRIPTION
I've started using VS Code for editing things, so it'd be handy to ignore this.