### PR TITLE
Remove an assert triggered by UnboundType leaking from semanal.py

### DIFF
--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -27,7 +27,8 @@ def erase_type(typ: Type) -> Type:
 class EraseTypeVisitor(TypeVisitor[Type]):
 
     def visit_unbound_type(self, t: UnboundType) -> Type:
-        assert False, 'Not supported'
+        # TODO: replace with an assert after UnboundType can't leak from semantic analysis.
+        return AnyType(TypeOfAny.from_error)
 
     def visit_any(self, t: AnyType) -> Type:
         return t

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -332,3 +332,35 @@ import c
 import e
 [file e.py]
 1+'no'  # E: Unsupported operand types for + ("int" and "str")
+
+[case testModuleAsTypeNoCrash]
+import mock
+from typing import Union
+
+class A: ...
+class B: ...
+
+x: Union[mock, A]  # E: Invalid type "mock"
+
+if isinstance(x, B):
+    pass
+[file mock.py]
+[builtins fixtures/isinstance.pyi]
+[out]
+
+[case testModuleAsTypeNoCrash2]
+import mock
+from typing import overload, Any, Union
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: str) -> Union[mock, str]: ...  # E: Invalid type "mock"
+def f(x):
+    pass
+
+x: Any
+f(x)
+[file mock.py]
+[builtins fixtures/isinstance.pyi]
+[out]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/4543

This is also a temporary solution for https://github.com/python/mypy/issues/4987. A permanent one would be to turn `UnboundType`s into `Any`s directly in `semanal.py`.