### PR TITLE
Retrieve class or static info from node instead of type

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1246,7 +1246,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 fdef = original_node.func
                 original_class_or_static = fdef.is_class or fdef.is_static
             else:
-                assert False, str(base_attr.node)
+                original_class_or_static = False  # a variable can't be class or static
             if isinstance(original_type, AnyType) or isinstance(typ, AnyType):
                 pass
             elif isinstance(original_type, FunctionLike) and isinstance(typ, FunctionLike):

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -645,12 +645,6 @@ class FunctionLike(Type):
     @abstractmethod
     def get_name(self) -> Optional[str]: pass
 
-    @abstractmethod
-    def is_classmethod(self) -> bool: pass
-
-    @abstractmethod
-    def is_staticmethod(self) -> bool: pass
-
 
 FormalArgument = NamedTuple('FormalArgument', [
     ('name', Optional[str]),
@@ -833,12 +827,6 @@ class CallableType(FunctionLike):
 
     def get_name(self) -> Optional[str]:
         return self.name
-
-    def is_classmethod(self) -> bool:
-        return isinstance(self.definition, FuncBase) and self.definition.is_class
-
-    def is_staticmethod(self) -> bool:
-        return isinstance(self.definition, FuncBase) and self.definition.is_static
 
     def max_fixed_args(self) -> int:
         n = len(self.arg_types)
@@ -1057,12 +1045,6 @@ class Overloaded(FunctionLike):
 
     def get_name(self) -> Optional[str]:
         return self._items[0].name
-
-    def is_classmethod(self) -> bool:
-        return self._items[0].is_classmethod()
-
-    def is_staticmethod(self) -> bool:
-        return self._items[0].is_staticmethod()
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_overloaded(self)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4376,3 +4376,19 @@ class C1(object):
 main:4: error: Revealed local types are:
 main:4: error: t: builtins.str
 main:4: error: y: builtins.float
+
+[case testClassMethodOverride]
+from typing import Callable, Any
+
+def deco(f: Callable[..., Any]) -> Callable[..., Any]: ...
+
+class B:
+    @classmethod
+    def meth(cls, x: int) -> int: ...
+
+class C(B):
+    @classmethod
+    @deco
+    def meth(cls, x: int) -> int: ...
+[builtins fixtures/classmethod.pyi]
+[out]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5259

This partially undo changes made in https://github.com/python/mypy/pull/5224/files. It is more safe to retrieve class and static flags directly from nodes, since callable types have often definition not set (especially after de-serialization). Also being class or static method is not really a property of type itself, it is rather an "access flag" for a given name in symbol table (similar to how a variable can be settable).