### PR TITLE
Be more careful with sys.path editing in sitepkgs

### DIFF
--- a/mypy/sitepkgs.py
+++ b/mypy/sitepkgs.py
@@ -7,10 +7,13 @@ library found in Python 2. This file is run each mypy run, so it should be kept 
 possible.
 """
 
-import sys
-sys.path = sys.path[1:]  # we don't want to pick up mypy.types
+if __name__ == '__main__':
+    import sys
+    sys.path = sys.path[1:]  # we don't want to pick up mypy.types
+
 from distutils.sysconfig import get_python_lib
 import site
+
 MYPY = False
 if MYPY:
     from typing import List


### PR DESCRIPTION
The `sitepkgs.py` script (support for PEP 561) was dropping `sys.path[0]`, but it is also imported by mypy itself, and this broke the `typed_ast` import when run under Bazel. Bazel puts very few things on `sys.path`, and `sys.path[0]` is important -- it has the dependencies.  I *hope* that the editing is only necessary when it's run as an independent script (through `subprocess`) by the PEP 561 code.