### PR TITLE
Move linting to pytest

### DIFF
--- a/mypy/test/testselfcheck.py
+++ b/mypy/test/testselfcheck.py
@@ -1,5 +1,8 @@
 """Self check mypy package"""
 
+import pytest  # type: ignore  # no pytest in typeshed
+from flake8.api import legacy as flake8  # type: ignore  # no falke8 in typeshed
+
 from mypy.test.helpers import Suite, run_mypy
 
 
@@ -9,3 +12,11 @@ class SelfCheckSuite(Suite):
 
     def test_testrunner(self) -> None:
         run_mypy(['runtests.py', 'waiter.py'])
+
+
+class LintSuite(Suite):
+    def test_flake8(self) -> None:
+        style_guide = flake8.get_style_guide()
+        report = style_guide.check_files('.')
+        if report.total_errors != 0:
+            pytest.fail('Lint error', pytrace=False)

--- a/runtests.py
+++ b/runtests.py
@@ -94,14 +94,6 @@ class Driver:
                                        passthrough=self.verbosity),
                         sequential=True)
 
-    def add_flake8(self, cwd: Optional[str] = None) -> None:
-        name = 'lint'
-        if not self.allow(name):
-            return
-        largs = ['flake8', '-j0']
-        env = self.env
-        self.waiter.add(LazySubprocess(name, largs, cwd=cwd, env=env))
-
     def list_tasks(self) -> None:
         for id, task in enumerate(self.waiter.queue):
             print('{id}:{task}'.format(id=id, task=task.name))
@@ -308,7 +300,6 @@ def main() -> None:
     driver.prepend_path('MYPYPATH', [driver.cwd])
     driver.prepend_path('PYTHONPATH', [driver.cwd])
 
-    driver.add_flake8()
     add_pytest(driver)
     add_stdlibsamples(driver)
 


### PR DESCRIPTION
Use flake8's [legacy api](http://flake8.pycqa.org/en/latest/user/python-api.html) since there's no non-legacy one.

Another item for #1673 (only `stdlibsamples` left).