### PR TITLE
Migrate stdlibsamples test to pytest

### DIFF
--- a/mypy/test/testsamples.py
+++ b/mypy/test/testsamples.py
@@ -34,6 +34,18 @@ class SamplesSuite(Suite):
                 mypy_args.append('--python-version=3.5')
             run_mypy(mypy_args + [f])
 
+    def test_stdlibsamples(self) -> None:
+        seen = set()  # type: Set[str]
+        stdlibsamples_dir = os.path.join('test-data', 'stdlib-samples', '3.2', 'test')
+        modules = []  # type: List[str]
+        for f in find_files(stdlibsamples_dir, prefix='test_', suffix='.py'):
+            if f not in seen:
+                seen.add(f)
+                modules.append(f)
+        if modules:
+            # TODO: Remove need for --no-strict-optional
+            run_mypy(['--no-strict-optional'] + modules)
+
 
 def find_files(base: str, prefix: str = '', suffix: str = '') -> List[str]:
     return [os.path.join(root, f)

--- a/runtests.py
+++ b/runtests.py
@@ -158,21 +158,6 @@ def add_pytest(driver: Driver) -> None:
                       [('self-check', name) for name in SELFCHECK_FILES])
 
 
-def add_stdlibsamples(driver: Driver) -> None:
-    seen = set()  # type: Set[str]
-    stdlibsamples_dir = join(driver.cwd, 'test-data', 'stdlib-samples', '3.2', 'test')
-    modules = []  # type: List[str]
-    for f in find_files(stdlibsamples_dir, prefix='test_', suffix='.py'):
-        module = file_to_module(f[len(stdlibsamples_dir) + 1:])
-        if module not in seen:
-            seen.add(module)
-            modules.append(module)
-    if modules:
-        # TODO: Remove need for --no-strict-optional
-        driver.add_mypy_modules('stdlibsamples (3.2)', modules,
-                                cwd=stdlibsamples_dir, extra_args=['--no-strict-optional'])
-
-
 def usage(status: int) -> None:
     print('Usage: %s [-h | -v | -q | --lf | --ff | [-x] FILTER | -a ARG | -p ARG]'
           '... [-- FILTER ...]'
@@ -310,7 +295,6 @@ def main() -> None:
 
     driver.add_flake8()
     add_pytest(driver)
-    add_stdlibsamples(driver)
 
     if list_only:
         driver.list_tasks()


### PR DESCRIPTION
Check as files instead of as modules, without changing cwd.

As far as I understand, this should be the last step of #1673 before removal of `runtests.py` and `waiter.py`.

(completes #5142)