### PR TITLE
Specify the config file when doing a self check (!)

### DIFF
--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -39,11 +39,6 @@ def run_mypy(args: List[str]) -> None:
         pytest.fail(msg="Sample check failed", pytrace=False)
 
 
-def use_builtins_fixtures(options: Options) -> None:
-    root_dir = dirname(dirname(dirname(__file__)))
-    options.path_prefix = os.path.join(root_dir, 'test-data', 'unit', 'lib-stub')
-
-
 def assert_string_arrays_equal(expected: List[str], actual: List[str],
                                msg: str) -> None:
     """Assert that two string arrays are equal.

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -39,7 +39,7 @@ def run_mypy(args: List[str]) -> None:
         pytest.fail(msg="Sample check failed", pytrace=False)
 
 
-def use_builtins_fixtures(options):
+def use_builtins_fixtures(options: Options) -> None:
     root_dir = dirname(dirname(dirname(__file__)))
     options.path_prefix = os.path.join(root_dir, 'test-data', 'unit', 'lib-stub')
 

--- a/mypy/test/testselfcheck.py
+++ b/mypy/test/testselfcheck.py
@@ -5,7 +5,7 @@ from mypy.test.helpers import Suite, run_mypy
 
 class SelfCheckSuite(Suite):
     def test_mypy_package(self) -> None:
-        run_mypy(['-p', 'mypy'])
+        run_mypy(['--config-file', 'mypy_self_check.ini', '-p', 'mypy'])
 
     def test_testrunner(self) -> None:
-        run_mypy(['runtests.py', 'waiter.py'])
+        run_mypy(['--config-file', 'mypy_self_check.ini', 'runtests.py', 'waiter.py'])

--- a/mypy/test/testselfcheck.py
+++ b/mypy/test/testselfcheck.py
@@ -8,4 +8,5 @@ class SelfCheckSuite(Suite):
         run_mypy(['--config-file', 'mypy_self_check.ini', '-p', 'mypy'])
 
     def test_testrunner(self) -> None:
-        run_mypy(['--config-file', 'mypy_self_check.ini', 'runtests.py', 'waiter.py'])
+        run_mypy(['--config-file', 'mypy_self_check.ini',
+                  '--no-warn-unused-configs', 'runtests.py', 'waiter.py'])

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -7,7 +7,6 @@ no_implicit_optional = True
 disallow_any_generics = True
 disallow_any_unimported = True
 warn_redundant_casts = True
-warn_unused_configs = True
 
 # needs py2 compatibility
 [mypy-mypy.test.testextensions]

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -7,6 +7,7 @@ no_implicit_optional = True
 disallow_any_generics = True
 disallow_any_unimported = True
 warn_redundant_casts = True
+warn_unused_configs = True
 
 # needs py2 compatibility
 [mypy-mypy.test.testextensions]


### PR DESCRIPTION
Fortunately only one error crept in while we weren't doing that.

Remove `warn_unused_configs` from the file so we can use the same file
for the mypy package and the test runner with no trouble.