### PR TITLE
Fix crash in module __getattr__

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1416,6 +1416,10 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                     else:
                         name = id
                     ast_node = Var(name, type=typ)
+                    if self.type:
+                        ast_node._fullname = self.type.fullname() + "." + name
+                    else:
+                        ast_node._fullname = self.qualified_name(name)
                     symbol = SymbolTableNode(GDEF, ast_node)
                     self.add_symbol(name, symbol, imp)
                     continue
@@ -3083,7 +3087,11 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                         n = names.get(parts[i], None)
                         if n and isinstance(n.node, ImportedName):
                             n = self.dereference_module_cross_ref(n)
-                    # TODO: What if node is Var or FuncDef?
+                    # If it is a variable of function, the error will be reported during the
+                    # type checking phase. We return None, since there is no symbol to return
+                    # for x.y if x is a Var or FuncDef.
+                    elif isinstance(n.node, (Var, FuncDef)):
+                        return None
                     if not n:
                         if not suppress_errors:
                             self.name_not_defined(name, ctx)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3087,11 +3087,9 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                         n = names.get(parts[i], None)
                         if n and isinstance(n.node, ImportedName):
                             n = self.dereference_module_cross_ref(n)
-                    # If it is a variable of function, the error will be reported during the
-                    # type checking phase. We return None, since there is no symbol to return
-                    # for x.y if x is a Var or FuncDef.
-                    elif isinstance(n.node, (Var, FuncDef)):
-                        return None
+                    # TODO: What if node is Var or FuncDef?
+                    # Currently, missing these cases results in controversial behavior, when
+                    # lookup_qualified(x.y.z) returns Var(x).
                     if not n:
                         if not suppress_errors:
                             self.name_not_defined(name, ctx)

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2467,7 +2467,18 @@ y = a.b.c.d.f()
 
 [case testModuleGetattrBusted]
 from a import A
-x: A.B
+x: A
+reveal_type(x)  # E: Revealed type is 'Any'
+[file a.pyi]
+from typing import Any
+def __getattr__(attr: str) -> Any: ...
+[builtins fixtures/module.pyi]
+[out]
+
+[case testModuleGetattrBusted2]
+from a import A
+def f(x: A.B) -> None: ...
+reveal_type(f)  # E: Revealed type is 'def (x: Any)'
 [file a.pyi]
 from typing import Any
 def __getattr__(attr: str) -> Any: ...

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2464,3 +2464,12 @@ y = a.b.c.d.f()
 [file a/b/__init__.py]
 # empty
 [out]
+
+[case testModuleGetattrBusted]
+from a import A
+x: A.B
+[file a.pyi]
+from typing import Any
+def __getattr__(attr: str) -> Any: ...
+[builtins fixtures/module.pyi]
+[out]


### PR DESCRIPTION
The examples in tests crash with:
```
  File "/Users/ilevkivskyi/src/mypy/mypy/semanal.py", line 1613, in anal_type
    typ = t.accept(a)
  File "/Users/ilevkivskyi/src/mypy/mypy/types.py", line 204, in accept
    return visitor.visit_unbound_type(self)
  File "/Users/ilevkivskyi/src/mypy/mypy/typeanal.py", line 179, in visit_unbound_type
    typ = self.visit_unbound_type_nonoptional(t)
  File "/Users/ilevkivskyi/src/mypy/mypy/typeanal.py", line 215, in visit_unbound_type_nonoptional
    tvar_def = self.tvar_scope.get_binding(sym)
  File "/Users/ilevkivskyi/src/mypy/mypy/tvar_scope.py", line 78, in get_binding
    assert fullname is not None
AssertionError: 
```
While debugging this I found some other controversial code. But I don't want to touch it in this same PR (also best solution for that other problem is not clear to me).