### PR TITLE
Allow __getattr__ during semantic analysis

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3101,6 +3101,10 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
 
     def create_getattr_var(self, getattr_defn: SymbolTableNode,
                            name: str, fullname: str) -> Optional[SymbolTableNode]:
+        """Create a dummy global symbol using __getattr__ return type.
+
+        If not possible, return None.
+        """
         if isinstance(getattr_defn.node, (FuncDef, Var)):
             if isinstance(getattr_defn.node.type, CallableType):
                 typ = getattr_defn.node.type.ret_type

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3083,6 +3083,18 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                         n = names.get(parts[i], None)
                         if n and isinstance(n.node, ImportedName):
                             n = self.dereference_module_cross_ref(n)
+                        elif '__getattr__' in names:
+                            getattr_defn = names['__getattr__']
+                            if isinstance(getattr_defn.node, (FuncDef, Var)):
+                                if isinstance(getattr_defn.node.type, CallableType):
+                                    typ = getattr_defn.node.type.ret_type
+                                else:
+                                    typ = AnyType(TypeOfAny.from_error)
+                                name = parts[i]
+                                v = Var(name, type=typ)
+                                v._fullname = name
+                                n = SymbolTableNode(GDEF, v)
+                                names[name] = n
                     # TODO: What if node is Var or FuncDef?
                     if not n:
                         if not suppress_errors:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1405,23 +1405,14 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             # If it is still not resolved, check for a module level __getattr__
             if (module and not node and (module.is_stub or self.options.python_version >= (3, 7))
                     and '__getattr__' in module.names):
-                getattr_defn = module.names['__getattr__']
-                if isinstance(getattr_defn.node, (FuncDef, Var)):
-                    if isinstance(getattr_defn.node.type, CallableType):
-                        typ = getattr_defn.node.type.ret_type
-                    else:
-                        typ = AnyType(TypeOfAny.from_error)
-                    if as_id:
-                        name = as_id
-                    else:
-                        name = id
-                    ast_node = Var(name, type=typ)
-                    if self.type:
-                        ast_node._fullname = self.type.fullname() + "." + name
-                    else:
-                        ast_node._fullname = self.qualified_name(name)
-                    symbol = SymbolTableNode(GDEF, ast_node)
-                    self.add_symbol(name, symbol, imp)
+                name = as_id if as_id else id
+                if self.type:
+                    fullname = self.type.fullname() + "." + name
+                else:
+                    fullname = self.qualified_name(name)
+                gvar = self.create_getattr_var(module.names['__getattr__'], name, fullname)
+                if gvar:
+                    self.add_symbol(name, gvar, imp)
                     continue
             if node and node.kind != UNBOUND_IMPORTED and not node.module_hidden:
                 if not node:
@@ -3088,17 +3079,11 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                         if n and isinstance(n.node, ImportedName):
                             n = self.dereference_module_cross_ref(n)
                         elif '__getattr__' in names:
-                            getattr_defn = names['__getattr__']
-                            if isinstance(getattr_defn.node, (FuncDef, Var)):
-                                if isinstance(getattr_defn.node.type, CallableType):
-                                    typ = getattr_defn.node.type.ret_type
-                                else:
-                                    typ = AnyType(TypeOfAny.from_error)
-                                name = parts[i]
-                                v = Var(name, type=typ)
-                                v._fullname = name
-                                n = SymbolTableNode(GDEF, v)
-                                names[name] = n
+                            gvar = self.create_getattr_var(names['__getattr__'],
+                                                           parts[i], parts[i])
+                            if gvar:
+                                names[name] = gvar
+                                n = gvar
                     # TODO: What if node is Var or FuncDef?
                     # Currently, missing these cases results in controversial behavior, when
                     # lookup_qualified(x.y.z) returns Var(x).
@@ -3113,6 +3098,18 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 n = self.rebind_symbol_table_node(n)
                 return n
             return None
+
+    def create_getattr_var(self, getattr_defn: SymbolTableNode,
+                           name: str, fullname: str) -> Optional[SymbolTableNode]:
+        if isinstance(getattr_defn.node, (FuncDef, Var)):
+            if isinstance(getattr_defn.node.type, CallableType):
+                typ = getattr_defn.node.type.ret_type
+            else:
+                typ = AnyType(TypeOfAny.from_error)
+            v = Var(name, type=typ)
+            v._fullname = fullname
+            return SymbolTableNode(GDEF, v)
+        return None
 
     def rebind_symbol_table_node(self, n: SymbolTableNode) -> Optional[SymbolTableNode]:
         """If node refers to old version of module, return reference to new version.

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4451,3 +4451,21 @@ class C(B):
     def meth(cls, x: int) -> int: ...
 [builtins fixtures/classmethod.pyi]
 [out]
+
+[case testGetAttrImportAnnotation]
+import a
+x: a.A
+[file a.pyi]
+from typing import Any
+def __getattr__(attr: str) -> Any: ...
+[builtins fixtures/module.pyi]
+[out]
+
+[case testGetAttrImportBaseClass]
+import a
+class B(a.A): ...
+[file a.pyi]
+from typing import Any
+def __getattr__(attr: str) -> Any: ...
+[builtins fixtures/module.pyi]
+[out]


### PR DESCRIPTION
Previously module `__getattr__` was used during type checking (runtime context). But it was only partially allowed in semantic analysis (after `from a import A`, `A` can be used in annotations/base classes). This PR allows the same support for `a.A`, i.e. it can be used in annotations and base classes (provided `__getattr__` has a suitable return type `Any`).