### PR TITLE
List possible overload variants when none match

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1198,12 +1198,17 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         elif len(erased_targets) > 0:
             # Pick the first plausible erased target as the fallback
             # TODO: Adjust the error message here to make it clear there was no match.
+            #       In order to do this, we need to find a clean way of associating
+            #       a note with whatever error message 'self.check_call' will generate.
+            #       In particular, the note's line and column numbers need to be the same
+            #       as the error's.
             target = erased_targets[0]  # type: Type
         else:
             # There was no plausible match: give up
-            if not self.chk.should_suppress_optional_error(arg_types):
-                arg_messages.no_variant_matches_arguments(callee, arg_types, context)
             target = AnyType(TypeOfAny.from_error)
+            if not self.chk.should_suppress_optional_error(arg_types):
+                arg_messages.no_variant_matches_arguments(
+                    plausible_targets, callee, arg_types, context)
 
         return self.check_call(target, args, arg_kinds, context, arg_names,
                                arg_messages=arg_messages,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1245,7 +1245,7 @@ class MessageBuilder:
 
     def pretty_overload(self, targets: List[CallableType], func: Overloaded, context: Context,
                         offset: int, max_items: int) -> None:
-        if len(targets) == 0:
+        if not targets:
             targets = func.items()
         for item in targets[:max_items]:
             self.note('@overload', context, offset=2 * offset)

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -525,7 +525,12 @@ B().f(1)
 a = B() # type: A
 a.f(1)
 a.f('')
-a.f(B()) # E: No overload variant of "f" of "A" matches argument type "B"
+a.f(B()) # E: No overload variant of "f" of "A" matches argument type "B" \
+         # N: Possible overload variant(s): \
+         # N:     @overload \
+         # N:     def f(self, x: int) -> int \
+         # N:     @overload \
+         # N:     def f(self, x: str) -> str
 
 [case testOverloadedAbstractMethodWithAlternativeDecoratorOrder]
 from foo import *
@@ -552,7 +557,12 @@ B().f(1)
 a = B() # type: A
 a.f(1)
 a.f('')
-a.f(B()) # E: No overload variant of "f" of "A" matches argument type "B"
+a.f(B()) # E: No overload variant of "f" of "A" matches argument type "B" \
+         # N: Possible overload variant(s): \
+         # N:     @overload \
+         # N:     def f(self, x: int) -> int \
+         # N:     @overload \
+         # N:     def f(self, x: str) -> str
 
 [case testOverloadedAbstractMethodVariantMissingDecorator1]
 from foo import *

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -526,10 +526,8 @@ a = B() # type: A
 a.f(1)
 a.f('')
 a.f(B()) # E: No overload variant of "f" of "A" matches argument type "B" \
-         # N: Possible overload variant(s): \
-         # N:     @overload \
+         # N: Possible overload variants: \
          # N:     def f(self, x: int) -> int \
-         # N:     @overload \
          # N:     def f(self, x: str) -> str
 
 [case testOverloadedAbstractMethodWithAlternativeDecoratorOrder]
@@ -558,10 +556,8 @@ a = B() # type: A
 a.f(1)
 a.f('')
 a.f(B()) # E: No overload variant of "f" of "A" matches argument type "B" \
-         # N: Possible overload variant(s): \
-         # N:     @overload \
+         # N: Possible overload variants: \
          # N:     def f(self, x: int) -> int \
-         # N:     @overload \
          # N:     def f(self, x: str) -> str
 
 [case testOverloadedAbstractMethodVariantMissingDecorator1]

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -524,10 +524,8 @@ class Overloader(NamedTuple):
 reveal_type(Overloader(1).method('string'))  # E: Revealed type is 'builtins.str'
 reveal_type(Overloader(1).method(1))  # E: Revealed type is 'builtins.int'
 Overloader(1).method(('tuple',))  # E: No overload variant of "method" of "Overloader" matches argument type "Tuple[str]" \
-                                  # N: Possible overload variant(s): \
-                                  # N:     @overload \
+                                  # N: Possible overload variants: \
                                   # N:     def method(self, y: str) -> str \
-                                  # N:     @overload \
                                   # N:     def method(self, y: int) -> int
 
 [case testNewNamedTupleMethodInheritance]

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -523,7 +523,12 @@ class Overloader(NamedTuple):
 
 reveal_type(Overloader(1).method('string'))  # E: Revealed type is 'builtins.str'
 reveal_type(Overloader(1).method(1))  # E: Revealed type is 'builtins.int'
-Overloader(1).method(('tuple',))  # E: No overload variant of "method" of "Overloader" matches argument type "Tuple[str]"
+Overloader(1).method(('tuple',))  # E: No overload variant of "method" of "Overloader" matches argument type "Tuple[str]" \
+                                  # N: Possible overload variant(s): \
+                                  # N:     @overload \
+                                  # N:     def method(self, y: str) -> str \
+                                  # N:     @overload \
+                                  # N:     def method(self, y: int) -> int
 
 [case testNewNamedTupleMethodInheritance]
 from typing import NamedTuple, TypeVar

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1225,17 +1225,13 @@ class D:
 [out]
 main:5: error: Revealed type is 'Any'
 main:5: error: No overload variant of "__get__" of "D" matches argument types "None", "Type[A]"
-main:5: note: Possible overload variant(s):
-main:5: note:     @overload
+main:5: note: Possible overload variants:
 main:5: note:     def __get__(self, inst: None, own: Type[Base]) -> D
-main:5: note:     @overload
 main:5: note:     def __get__(self, inst: Base, own: Type[Base]) -> str
 main:6: error: Revealed type is 'Any'
 main:6: error: No overload variant of "__get__" of "D" matches argument types "A", "Type[A]"
-main:6: note: Possible overload variant(s):
-main:6: note:     @overload
+main:6: note: Possible overload variants:
 main:6: note:     def __get__(self, inst: None, own: Type[Base]) -> D
-main:6: note:     @overload
 main:6: note:     def __get__(self, inst: Base, own: Type[Base]) -> str
 
 
@@ -1335,10 +1331,8 @@ class D(Generic[T, V]):
 [out]
 main:5: error: Revealed type is 'Any'
 main:5: error: No overload variant of "__get__" of "D" matches argument types "None", "Type[A]"
-main:5: note: Possible overload variant(s):
-main:5: note:     @overload
+main:5: note: Possible overload variants:
 main:5: note:     def __get__(self, inst: None, own: None) -> D[A, int]
-main:5: note:     @overload
 main:5: note:     def __get__(self, inst: A, own: Type[A]) -> int
 
 
@@ -2134,10 +2128,9 @@ c = C(1)
 c.a # E: "C" has no attribute "a"
 C('', '')
 C('') # E: No overload variant of "C" matches argument type "str" \
-      # N: Possible overload variant(s): \
-      # N:     @overload \
+      # N: Possible overload variant: \
       # N:     def __new__(cls, foo: int) -> C \
-      # N:     <1 more overload(s) not shown>
+      # N:     <1 more non-matching overload not shown>
 [builtins fixtures/__new__.pyi]
 
 
@@ -2560,10 +2553,9 @@ u = new(User)
 [builtins fixtures/classmethod.pyi]
 [out]
 tmp/foo.pyi:16: error: No overload variant of "User" matches argument type "str"
-tmp/foo.pyi:16: note: Possible overload variant(s):
-tmp/foo.pyi:16: note:     @overload
+tmp/foo.pyi:16: note: Possible overload variant:
 tmp/foo.pyi:16: note:     def __init__(self, arg: int) -> U
-tmp/foo.pyi:16: note:     <1 more overload(s) not shown>
+tmp/foo.pyi:16: note:     <1 more non-matching overload not shown>
 tmp/foo.pyi:17: error: Too many arguments for "foo" of "User"
 
 [case testTypeUsingTypeCInUpperBound]
@@ -2778,10 +2770,8 @@ def f(a: Type[User]) -> None: pass
 def f(a: type) -> None: pass
 
 f(3)  # E: No overload variant of "f" matches argument type "int" \
-      # N: Possible overload variant(s): \
-      # N:     @overload \
+      # N: Possible overload variants: \
       # N:     def f(a: Type[User]) -> None \
-      # N:     @overload \
       # N:     def f(a: type) -> None
 [builtins fixtures/classmethod.pyi]
 [out]
@@ -2800,10 +2790,8 @@ def f(a: int) -> None: pass
 
 f(User)
 f(User())  # E: No overload variant of "f" matches argument type "User" \
-           # N: Possible overload variant(s): \
-           # N:     @overload \
+           # N: Possible overload variants: \
            # N:     def f(a: Type[User]) -> None \
-           # N:     @overload \
            # N:     def f(a: int) -> None
 [builtins fixtures/classmethod.pyi]
 [out]
@@ -2826,18 +2814,14 @@ def f(a: Type[B]) -> None: pass
 def f(a: int) -> None: pass
 
 f(A)  # E: No overload variant of "f" matches argument type "Type[A]" \
-      # N: Possible overload variant(s): \
-      # N:     @overload \
+      # N: Possible overload variants: \
       # N:     def f(a: Type[B]) -> None \
-      # N:     @overload \
       # N:     def f(a: int) -> None
 f(B)
 f(C)
 f(AType)  # E: No overload variant of "f" matches argument type "Type[A]" \
-          # N: Possible overload variant(s): \
-          # N:     @overload \
+          # N: Possible overload variants: \
           # N:     def f(a: Type[B]) -> None \
-          # N:     @overload \
           # N:     def f(a: int) -> None
 f(BType)
 f(CType)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1325,6 +1325,12 @@ class D(Generic[T, V]):
 [out]
 main:5: error: Revealed type is 'Any'
 main:5: error: No overload variant of "__get__" of "D" matches argument types "None", "Type[A]"
+main:5: note: Possible overload variant(s):
+main:5: note:     @overload
+main:5: note:     def __get__(self, inst: None, own: None) -> D[A, int]
+main:5: note:     @overload
+main:5: note:     def __get__(self, inst: A, own: Type[A]) -> int
+
 
 [case testAccessingNonDataDescriptorSubclass]
 from typing import Any
@@ -2117,7 +2123,11 @@ class C:
 c = C(1)
 c.a # E: "C" has no attribute "a"
 C('', '')
-C('') # E: No overload variant of "C" matches argument type "str"
+C('') # E: No overload variant of "C" matches argument type "str" \
+      # N: Possible overload variant(s): \
+      # N:     @overload \
+      # N:     def __new__(cls, foo: int) -> C \
+      # N:     <1 more overload(s) not shown>
 [builtins fixtures/__new__.pyi]
 
 
@@ -2540,6 +2550,10 @@ u = new(User)
 [builtins fixtures/classmethod.pyi]
 [out]
 tmp/foo.pyi:16: error: No overload variant of "User" matches argument type "str"
+tmp/foo.pyi:16: note: Possible overload variant(s):
+tmp/foo.pyi:16: note:     @overload
+tmp/foo.pyi:16: note:     def __init__(self, arg: int) -> U
+tmp/foo.pyi:16: note:     <1 more overload(s) not shown>
 tmp/foo.pyi:17: error: Too many arguments for "foo" of "User"
 
 [case testTypeUsingTypeCInUpperBound]
@@ -2753,7 +2767,12 @@ def f(a: Type[User]) -> None: pass
 @overload
 def f(a: type) -> None: pass
 
-f(3)  # E: No overload variant of "f" matches argument type "int"
+f(3)  # E: No overload variant of "f" matches argument type "int" \
+      # N: Possible overload variant(s): \
+      # N:     @overload \
+      # N:     def f(a: Type[User]) -> None \
+      # N:     @overload \
+      # N:     def f(a: type) -> None
 [builtins fixtures/classmethod.pyi]
 [out]
 
@@ -2770,7 +2789,12 @@ def f(a: Type[User]) -> None: pass
 def f(a: int) -> None: pass
 
 f(User)
-f(User())  # E: No overload variant of "f" matches argument type "User"
+f(User())  # E: No overload variant of "f" matches argument type "User" \
+           # N: Possible overload variant(s): \
+           # N:     @overload \
+           # N:     def f(a: Type[User]) -> None \
+           # N:     @overload \
+           # N:     def f(a: int) -> None
 [builtins fixtures/classmethod.pyi]
 [out]
 
@@ -2791,10 +2815,20 @@ def f(a: Type[B]) -> None: pass
 @overload
 def f(a: int) -> None: pass
 
-f(A)  # E: No overload variant of "f" matches argument type "Type[A]"
+f(A)  # E: No overload variant of "f" matches argument type "Type[A]" \
+      # N: Possible overload variant(s): \
+      # N:     @overload \
+      # N:     def f(a: Type[B]) -> None \
+      # N:     @overload \
+      # N:     def f(a: int) -> None
 f(B)
 f(C)
-f(AType)  # E: No overload variant of "f" matches argument type "Type[A]"
+f(AType)  # E: No overload variant of "f" matches argument type "Type[A]" \
+          # N: Possible overload variant(s): \
+          # N:     @overload \
+          # N:     def f(a: Type[B]) -> None \
+          # N:     @overload \
+          # N:     def f(a: int) -> None
 f(BType)
 f(CType)
 [builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1225,8 +1225,18 @@ class D:
 [out]
 main:5: error: Revealed type is 'Any'
 main:5: error: No overload variant of "__get__" of "D" matches argument types "None", "Type[A]"
+main:5: note: Possible overload variant(s):
+main:5: note:     @overload
+main:5: note:     def __get__(self, inst: None, own: Type[Base]) -> D
+main:5: note:     @overload
+main:5: note:     def __get__(self, inst: Base, own: Type[Base]) -> str
 main:6: error: Revealed type is 'Any'
 main:6: error: No overload variant of "__get__" of "D" matches argument types "A", "Type[A]"
+main:6: note: Possible overload variant(s):
+main:6: note:     @overload
+main:6: note:     def __get__(self, inst: None, own: Type[Base]) -> D
+main:6: note:     @overload
+main:6: note:     def __get__(self, inst: Base, own: Type[Base]) -> str
 
 
 [case testAccessingGenericNonDataDescriptor]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -121,10 +121,9 @@ from dataclasses import dataclass, field
 class Person:
     name: str
     age: int = field(init=None)  # E: No overload variant of "field" matches argument type "None" \
-                                 # N: Possible overload variant(s): \
-                                 # N:     @overload \
+                                 # N: Possible overload variant: \
                                  # N:     def field(*, init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ..., metadata: Optional[Mapping[str, Any]] = ...) -> Any \
-                                 # N:     <2 more overload(s) not shown>
+                                 # N:     <2 more non-matching overloads not shown>
 
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -120,7 +120,11 @@ from dataclasses import dataclass, field
 @dataclass
 class Person:
     name: str
-    age: int = field(init=None)  # E: No overload variant of "field" matches argument type "None"
+    age: int = field(init=None)  # E: No overload variant of "field" matches argument type "None" \
+                                 # N: Possible overload variant(s): \
+                                 # N:     @overload \
+                                 # N:     def field(*, init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ..., metadata: Optional[Mapping[str, Any]] = ...) -> Any \
+                                 # N:     <2 more overload(s) not shown>
 
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -866,7 +866,12 @@ from typing import overload
 a, b, c = None, None, None  # type: (A, B, C)
 a[b]
 a[c]
-a[1]  # E: No overload variant of "__getitem__" of "A" matches argument type "int"
+a[1]  # E: No overload variant of "__getitem__" of "A" matches argument type "int" \
+      # N: Possible overload variant(s): \
+      # N:     @overload \
+      # N:     def __getitem__(self, B) -> int \
+      # N:     @overload \
+      # N:     def __getitem__(self, C) -> str
 
 i, s = None, None  # type: (int, str)
 i = a[b]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -867,10 +867,8 @@ a, b, c = None, None, None  # type: (A, B, C)
 a[b]
 a[c]
 a[1]  # E: No overload variant of "__getitem__" of "A" matches argument type "int" \
-      # N: Possible overload variant(s): \
-      # N:     @overload \
+      # N: Possible overload variants: \
       # N:     def __getitem__(self, B) -> int \
-      # N:     @overload \
       # N:     def __getitem__(self, C) -> str
 
 i, s = None, None  # type: (int, str)

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -534,7 +534,11 @@ class A:
 a = None # type: A
 a.g()
 a.g(B())
-a.g(a) # E: No overload variant matches argument type "A"
+a.g(a) # E: No overload variant matches argument type "A" \
+       # N: Possible overload variant(s): \
+       # N:     @overload \
+       # N:     def f(self, b: B) -> None \
+       # N:     <1 more overload(s) not shown>
 
 [case testMethodAsDataAttributeInferredFromDynamicallyTypedMethod]
 

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -535,10 +535,9 @@ a = None # type: A
 a.g()
 a.g(B())
 a.g(a) # E: No overload variant matches argument type "A" \
-       # N: Possible overload variant(s): \
-       # N:     @overload \
+       # N: Possible overload variant: \
        # N:     def f(self, b: B) -> None \
-       # N:     <1 more overload(s) not shown>
+       # N:     <1 more non-matching overload not shown>
 
 [case testMethodAsDataAttributeInferredFromDynamicallyTypedMethod]
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1470,7 +1470,11 @@ def f(blocks: Any): # E: Name 'Any' is not defined
 [case testSpecialCaseEmptyListInitialization2]
 def f(blocks: object):
     to_process = [] # E: Need type annotation for 'to_process'
-    to_process = list(blocks) # E: No overload variant of "list" matches argument type "object"
+    to_process = list(blocks) # E: No overload variant of "list" matches argument type "object" \
+                              # N: Possible overload variant(s): \
+                              # N:     @overload \
+                              # N:     def [T] __init__(self, x: Iterable[T]) -> List[T] \
+                              # N:     <1 more overload(s) not shown>
 [builtins fixtures/list.pyi]
 [out]
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1471,10 +1471,9 @@ def f(blocks: Any): # E: Name 'Any' is not defined
 def f(blocks: object):
     to_process = [] # E: Need type annotation for 'to_process'
     to_process = list(blocks) # E: No overload variant of "list" matches argument type "object" \
-                              # N: Possible overload variant(s): \
-                              # N:     @overload \
+                              # N: Possible overload variant: \
                               # N:     def [T] __init__(self, x: Iterable[T]) -> List[T] \
-                              # N:     <1 more overload(s) not shown>
+                              # N:     <1 more non-matching overload not shown>
 [builtins fixtures/list.pyi]
 [out]
 

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -2229,7 +2229,7 @@ foo(*y)  # E: No overload variant of "foo" matches argument type "List[str]" \
          # N: Possible overload variants: \
          # N:     def foo(x: int, y: int, z: int, *args: int) -> C \
          # N:     def foo(x: int) -> A \
-         # N:     <1 more matching overload not shown, out of 3 total overloads>
+         # N:     def foo(x: int, y: int) -> B
 [builtins fixtures/list.pyi]
 
 [case testOverloadMultipleVarargDefinition]
@@ -4038,3 +4038,43 @@ main:11: error: Argument 6 to "f" has incompatible type "Union[int, str]"; expec
 main:11: error: Argument 7 to "f" has incompatible type "Union[int, str]"; expected "int"
 main:11: error: Argument 8 to "f" has incompatible type "Union[int, str]"; expected "int"
 main:11: note: Not all union combinations were tried because there are too many unions
+
+[case testOverloadErrorMessageManyMatches]
+from typing import overload
+
+class A: pass
+class B: pass
+class C: pass
+class D: pass
+
+@overload
+def f(x: A) -> None: ...
+@overload
+def f(x: B) -> None: ...
+@overload
+def f(x: C) -> None: ...
+@overload
+def f(x: D) -> None: ...
+@overload
+def f(x: int, y: int) -> None: ...
+def f(*args): pass
+
+f(3)  # E: No overload variant of "f" matches argument type "int" \
+      # N: Possible overload variants: \
+      # N:     def f(x: A) -> None \
+      # N:     def f(x: B) -> None \
+      # N:     <2 more similar overloads not shown, out of 5 total overloads>
+
+@overload
+def g(x: A) -> None: ...
+@overload
+def g(x: B) -> None: ...
+@overload
+def g(x: C) -> None: ...
+def g(*args): pass
+
+g(3)  # E: No overload variant of "g" matches argument type "int" \
+      # N: Possible overload variants: \
+      # N:     def g(x: A) -> None \
+      # N:     def g(x: B) -> None \
+      # N:     def g(x: C) -> None

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -386,7 +386,12 @@ class B: pass
 from foo import *
 [file foo.pyi]
 from typing import overload
-f(C()) # E: No overload variant of "f" matches argument type "C"
+f(C()) # E: No overload variant of "f" matches argument type "C" \
+       # N: Possible overload variant(s): \
+       # N:     @overload \
+       # N:     def f(x: A) -> None \
+       # N:     @overload \
+       # N:     def f(x: B) -> None
 f(A())
 f(B())
 
@@ -420,7 +425,12 @@ class B: pass
 from foo import *
 [file foo.pyi]
 from typing import overload
-A().f(C()) # E: No overload variant of "f" of "A" matches argument type "C"
+A().f(C()) # E: No overload variant of "f" of "A" matches argument type "C" \
+           # N: Possible overload variant(s): \
+           # N:     @overload \
+           # N:     def f(self, x: A) -> None \
+           # N:     @overload \
+           # N:     def f(self, x: B) -> None
 A().f(A())
 A().f(B())
 
@@ -457,11 +467,23 @@ from typing import overload
 a, b = None, None # type: (A, B)
 a = f(a)
 b = f(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-f(b)     # E: No overload variant of "f" matches argument type "B"
+f(b)     # E: No overload variant of "f" matches argument type "B" \
+         # N: Possible overload variant(s): \
+         # N:     @overload \
+         # N:     def f(x: A) -> A \
+         # N:     <1 more overload(s) not shown>
 b = f(b, a)
 a = f(b, a) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-f(a, a)     # E: No overload variant of "f" matches argument types "A", "A"
-f(b, b)     # E: No overload variant of "f" matches argument types "B", "B"
+f(a, a)     # E: No overload variant of "f" matches argument types "A", "A" \
+            # N: Possible overload variant(s): \
+            # N:     @overload \
+            # N:     def f(x: B, y: A) -> B \
+            # N:     <1 more overload(s) not shown>
+f(b, b)     # E: No overload variant of "f" matches argument types "B", "B" \
+            # N: Possible overload variant(s): \
+            # N:     @overload \
+            # N:     def f(x: B, y: A) -> B \
+            # N:     <1 more overload(s) not shown>
 
 @overload
 def f(x: 'A') -> 'A': pass
@@ -496,7 +518,12 @@ from typing import overload
 a, b = None, None # type: (A, B)
 a = A(a)
 a = A(b)
-a = A(object()) # E: No overload variant of "A" matches argument type "object"
+a = A(object()) # E: No overload variant of "A" matches argument type "object" \
+                # N: Possible overload variant(s): \
+                # N:     @overload \
+                # N:     def __init__(self, a: A) -> A \
+                # N:     @overload \
+                # N:     def __init__(self, b: B) -> A
 
 class A:
   @overload
@@ -617,7 +644,12 @@ f(A(), A, A)
 f(B())
 f(B(), B)
 f(B(), B, B)
-f(object()) # E: No overload variant of "f" matches argument type "object"
+f(object()) # E: No overload variant of "f" matches argument type "object" \
+            # N: Possible overload variant(s): \
+            # N:     @overload \
+            # N:     def f(x: A, *more: Any) -> A \
+            # N:     @overload \
+            # N:     def f(x: B, *more: Any) -> A
 class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
@@ -632,8 +664,18 @@ def f(x: 'A', *more: 'B') -> 'A': pass
 def f(x: 'B', *more: 'A') -> 'A': pass
 f(A(), B())
 f(A(), B(), B())
-f(A(), A(), B()) # E: No overload variant of "f" matches argument types "A", "A", "B"
-f(A(), B(), A()) # E: No overload variant of "f" matches argument types "A", "B", "A"
+f(A(), A(), B()) # E: No overload variant of "f" matches argument types "A", "A", "B" \
+                 # N: Possible overload variant(s): \
+                 # N:     @overload \
+                 # N:     def f(x: A, *more: B) -> A \
+                 # N:     @overload \
+                 # N:     def f(x: B, *more: A) -> A
+f(A(), B(), A()) # E: No overload variant of "f" matches argument types "A", "B", "A" \
+                 # N: Possible overload variant(s): \
+                 # N:     @overload \
+                 # N:     def f(x: A, *more: B) -> A \
+                 # N:     @overload \
+                 # N:     def f(x: B, *more: A) -> A
 class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
@@ -798,7 +840,12 @@ A() < B()
 B() < A()
 B() < B()
 A() < object() # E: Unsupported operand types for < ("A" and "object")
-B() < object() # E: No overload variant of "__lt__" of "B" matches argument type "object"
+B() < object() # E: No overload variant of "__lt__" of "B" matches argument type "object" \
+               # N: Possible overload variant(s): \
+               # N:     @overload \
+               # N:     def __lt__(self, B) -> int \
+               # N:     @overload \
+               # N:     def __lt__(self, A) -> int
 
 [case testOverloadedForwardMethodAndCallingReverseMethod]
 from foo import *
@@ -814,7 +861,12 @@ class B:
 A() + A()
 A() + 1
 A() + B()
-A() + '' # E: No overload variant of "__add__" of "A" matches argument type "str"
+A() + '' # E: No overload variant of "__add__" of "A" matches argument type "str" \
+         # N: Possible overload variant(s): \
+         # N:     @overload \
+         # N:     def __add__(self, A) -> int \
+         # N:     @overload \
+         # N:     def __add__(self, int) -> int
 
 [case testOverrideOverloadedMethodWithMoreGeneralArgumentTypes]
 from foo import *
@@ -899,7 +951,12 @@ def f(x: str) -> None: pass
 f(1.1)
 f('')
 f(1)
-f(()) # E: No overload variant of "f" matches argument type "Tuple[]"
+f(()) # E: No overload variant of "f" matches argument type "Tuple[]" \
+      # N: Possible overload variant(s): \
+      # N:     @overload \
+      # N:     def f(x: float) -> None \
+      # N:     @overload \
+      # N:     def f(x: str) -> None
 [builtins fixtures/primitives.pyi]
 [out]
 
@@ -965,10 +1022,18 @@ from typing import overload
 def f(x: int, y: str) -> int: pass
 @overload
 def f(*x: str) -> str: pass
-f(*(1,))() # E: No overload variant of "f" matches argument type "Tuple[int]"
+f(*(1,))() # E: No overload variant of "f" matches argument type "Tuple[int]" \
+           # N: Possible overload variant(s): \
+           # N:     @overload \
+           # N:     def f(*x: str) -> str \
+           # N:     <1 more overload(s) not shown>
 f(*('',))() # E: "str" not callable
 f(*(1, ''))() # E: "int" not callable
-f(*(1, '', 1))() # E: No overload variant of "f" matches argument type "Tuple[int, str, int]"
+f(*(1, '', 1))() # E: No overload variant of "f" matches argument type "Tuple[int, str, int]" \
+                 # N: Possible overload variant(s): \
+                 # N:     @overload \
+                 # N:     def f(*x: str) -> str \
+                 # N:     <1 more overload(s) not shown>
 
 [case testPreferExactSignatureMatchInOverload]
 from foo import *
@@ -1015,7 +1080,12 @@ class mystr(str): pass
 
 f('x')() # E: "str" not callable
 f(1)() # E: "bool" not callable
-f(1.1) # E: No overload variant of "f" matches argument type "float"
+f(1.1) # E: No overload variant of "f" matches argument type "float" \
+       # N: Possible overload variant(s): \
+       # N:     @overload \
+       # N:     def [T <: str] f(x: T) -> T \
+       # N:     @overload \
+       # N:     def f(x: int) -> bool
 f(mystr())() # E: "mystr" not callable
 [builtins fixtures/primitives.pyi]
 
@@ -1034,7 +1104,12 @@ U = TypeVar('U', bound=mystr)
 V = TypeVar('V')
 def g(x: U, y: V) -> None:
     f(x)() # E: "mystr" not callable
-    f(y) # E: No overload variant of "f" matches argument type "V"
+    f(y) # E: No overload variant of "f" matches argument type "V" \
+         # N: Possible overload variant(s): \
+         # N:     @overload \
+         # N:     def [T <: str] f(x: T) -> T \
+         # N:     @overload \
+         # N:     def [T <: str] f(x: List[T]) -> None
     a = f([x]) # E: "f" does not return a value
     f([y]) # E: Value of type variable "T" of "f" cannot be "V"
     f([x, y]) # E: Value of type variable "T" of "f" cannot be "object"
@@ -1301,7 +1376,12 @@ from typing import overload, Callable
 def f(a: Callable[[], int]) -> None: pass
 @overload
 def f(a: str) -> None: pass
-f(0)  # E: No overload variant of "f" matches argument type "int"
+f(0)  # E: No overload variant of "f" matches argument type "int" \
+      # N: Possible overload variant(s): \
+      # N:     @overload \
+      # N:     def f(a: Callable[[], int]) -> None \
+      # N:     @overload \
+      # N:     def f(a: str) -> None
 
 [case testCustomRedefinitionDecorator]
 from typing import Any, Callable, Type
@@ -2171,7 +2251,13 @@ x: List[int]
 reveal_type(foo(*x))  # E: Revealed type is '__main__.C'
 
 y: List[str]
-foo(*y)  # E: No overload variant of "foo" matches argument type "List[str]"
+foo(*y)  # E: No overload variant of "foo" matches argument type "List[str]" \
+         # N: Possible overload variant(s): \
+         # N:     @overload \
+         # N:     def foo(x: int, y: int, z: int, *args: int) -> C \
+         # N:     @overload \
+         # N:     def foo(x: int) -> A \
+         # N:     <1 more overload(s) not shown>
 [builtins fixtures/list.pyi]
 
 [case testOverloadMultipleVarargDefinition]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -387,10 +387,8 @@ from foo import *
 [file foo.pyi]
 from typing import overload
 f(C()) # E: No overload variant of "f" matches argument type "C" \
-       # N: Possible overload variant(s): \
-       # N:     @overload \
+       # N: Possible overload variants: \
        # N:     def f(x: A) -> None \
-       # N:     @overload \
        # N:     def f(x: B) -> None
 f(A())
 f(B())
@@ -426,10 +424,8 @@ from foo import *
 [file foo.pyi]
 from typing import overload
 A().f(C()) # E: No overload variant of "f" of "A" matches argument type "C" \
-           # N: Possible overload variant(s): \
-           # N:     @overload \
+           # N: Possible overload variants: \
            # N:     def f(self, x: A) -> None \
-           # N:     @overload \
            # N:     def f(self, x: B) -> None
 A().f(A())
 A().f(B())
@@ -468,22 +464,19 @@ a, b = None, None # type: (A, B)
 a = f(a)
 b = f(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 f(b)     # E: No overload variant of "f" matches argument type "B" \
-         # N: Possible overload variant(s): \
-         # N:     @overload \
+         # N: Possible overload variant: \
          # N:     def f(x: A) -> A \
-         # N:     <1 more overload(s) not shown>
+         # N:     <1 more non-matching overload not shown>
 b = f(b, a)
 a = f(b, a) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 f(a, a)     # E: No overload variant of "f" matches argument types "A", "A" \
-            # N: Possible overload variant(s): \
-            # N:     @overload \
+            # N: Possible overload variant: \
             # N:     def f(x: B, y: A) -> B \
-            # N:     <1 more overload(s) not shown>
+            # N:     <1 more non-matching overload not shown>
 f(b, b)     # E: No overload variant of "f" matches argument types "B", "B" \
-            # N: Possible overload variant(s): \
-            # N:     @overload \
+            # N: Possible overload variant: \
             # N:     def f(x: B, y: A) -> B \
-            # N:     <1 more overload(s) not shown>
+            # N:     <1 more non-matching overload not shown>
 
 @overload
 def f(x: 'A') -> 'A': pass
@@ -519,10 +512,8 @@ a, b = None, None # type: (A, B)
 a = A(a)
 a = A(b)
 a = A(object()) # E: No overload variant of "A" matches argument type "object" \
-                # N: Possible overload variant(s): \
-                # N:     @overload \
+                # N: Possible overload variants: \
                 # N:     def __init__(self, a: A) -> A \
-                # N:     @overload \
                 # N:     def __init__(self, b: B) -> A
 
 class A:
@@ -645,10 +636,8 @@ f(B())
 f(B(), B)
 f(B(), B, B)
 f(object()) # E: No overload variant of "f" matches argument type "object" \
-            # N: Possible overload variant(s): \
-            # N:     @overload \
+            # N: Possible overload variants: \
             # N:     def f(x: A, *more: Any) -> A \
-            # N:     @overload \
             # N:     def f(x: B, *more: Any) -> A
 class A: pass
 class B: pass
@@ -665,16 +654,12 @@ def f(x: 'B', *more: 'A') -> 'A': pass
 f(A(), B())
 f(A(), B(), B())
 f(A(), A(), B()) # E: No overload variant of "f" matches argument types "A", "A", "B" \
-                 # N: Possible overload variant(s): \
-                 # N:     @overload \
+                 # N: Possible overload variants: \
                  # N:     def f(x: A, *more: B) -> A \
-                 # N:     @overload \
                  # N:     def f(x: B, *more: A) -> A
 f(A(), B(), A()) # E: No overload variant of "f" matches argument types "A", "B", "A" \
-                 # N: Possible overload variant(s): \
-                 # N:     @overload \
+                 # N: Possible overload variants: \
                  # N:     def f(x: A, *more: B) -> A \
-                 # N:     @overload \
                  # N:     def f(x: B, *more: A) -> A
 class A: pass
 class B: pass
@@ -841,10 +826,8 @@ B() < A()
 B() < B()
 A() < object() # E: Unsupported operand types for < ("A" and "object")
 B() < object() # E: No overload variant of "__lt__" of "B" matches argument type "object" \
-               # N: Possible overload variant(s): \
-               # N:     @overload \
+               # N: Possible overload variants: \
                # N:     def __lt__(self, B) -> int \
-               # N:     @overload \
                # N:     def __lt__(self, A) -> int
 
 [case testOverloadedForwardMethodAndCallingReverseMethod]
@@ -862,10 +845,8 @@ A() + A()
 A() + 1
 A() + B()
 A() + '' # E: No overload variant of "__add__" of "A" matches argument type "str" \
-         # N: Possible overload variant(s): \
-         # N:     @overload \
+         # N: Possible overload variants: \
          # N:     def __add__(self, A) -> int \
-         # N:     @overload \
          # N:     def __add__(self, int) -> int
 
 [case testOverrideOverloadedMethodWithMoreGeneralArgumentTypes]
@@ -952,10 +933,8 @@ f(1.1)
 f('')
 f(1)
 f(()) # E: No overload variant of "f" matches argument type "Tuple[]" \
-      # N: Possible overload variant(s): \
-      # N:     @overload \
+      # N: Possible overload variants: \
       # N:     def f(x: float) -> None \
-      # N:     @overload \
       # N:     def f(x: str) -> None
 [builtins fixtures/primitives.pyi]
 [out]
@@ -1023,17 +1002,15 @@ def f(x: int, y: str) -> int: pass
 @overload
 def f(*x: str) -> str: pass
 f(*(1,))() # E: No overload variant of "f" matches argument type "Tuple[int]" \
-           # N: Possible overload variant(s): \
-           # N:     @overload \
+           # N: Possible overload variant: \
            # N:     def f(*x: str) -> str \
-           # N:     <1 more overload(s) not shown>
+           # N:     <1 more non-matching overload not shown>
 f(*('',))() # E: "str" not callable
 f(*(1, ''))() # E: "int" not callable
 f(*(1, '', 1))() # E: No overload variant of "f" matches argument type "Tuple[int, str, int]" \
-                 # N: Possible overload variant(s): \
-                 # N:     @overload \
+                 # N: Possible overload variant: \
                  # N:     def f(*x: str) -> str \
-                 # N:     <1 more overload(s) not shown>
+                 # N:     <1 more non-matching overload not shown>
 
 [case testPreferExactSignatureMatchInOverload]
 from foo import *
@@ -1081,10 +1058,8 @@ class mystr(str): pass
 f('x')() # E: "str" not callable
 f(1)() # E: "bool" not callable
 f(1.1) # E: No overload variant of "f" matches argument type "float" \
-       # N: Possible overload variant(s): \
-       # N:     @overload \
+       # N: Possible overload variants: \
        # N:     def [T <: str] f(x: T) -> T \
-       # N:     @overload \
        # N:     def f(x: int) -> bool
 f(mystr())() # E: "mystr" not callable
 [builtins fixtures/primitives.pyi]
@@ -1105,10 +1080,8 @@ V = TypeVar('V')
 def g(x: U, y: V) -> None:
     f(x)() # E: "mystr" not callable
     f(y) # E: No overload variant of "f" matches argument type "V" \
-         # N: Possible overload variant(s): \
-         # N:     @overload \
+         # N: Possible overload variants: \
          # N:     def [T <: str] f(x: T) -> T \
-         # N:     @overload \
          # N:     def [T <: str] f(x: List[T]) -> None
     a = f([x]) # E: "f" does not return a value
     f([y]) # E: Value of type variable "T" of "f" cannot be "V"
@@ -1157,10 +1130,8 @@ f(1)() # E: "int" not callable
 f('1')() # E: "str" not callable
 f(b'1')() # E: "str" not callable
 f(1.0) # E: No overload variant of "f" matches argument type "float" \
-       # N: Possible overload variant(s): \
-       # N:     @overload \
+       # N: Possible overload variants: \
        # N:     def f(x: int) -> int \
-       # N:     @overload \
        # N:     def [AnyStr in (bytes, str)] f(x: AnyStr) -> str
 
 @overload
@@ -1382,10 +1353,8 @@ def f(a: Callable[[], int]) -> None: pass
 @overload
 def f(a: str) -> None: pass
 f(0)  # E: No overload variant of "f" matches argument type "int" \
-      # N: Possible overload variant(s): \
-      # N:     @overload \
+      # N: Possible overload variants: \
       # N:     def f(a: Callable[[], int]) -> None \
-      # N:     @overload \
       # N:     def f(a: str) -> None
 
 [case testCustomRedefinitionDecorator]
@@ -2257,12 +2226,10 @@ reveal_type(foo(*x))  # E: Revealed type is '__main__.C'
 
 y: List[str]
 foo(*y)  # E: No overload variant of "foo" matches argument type "List[str]" \
-         # N: Possible overload variant(s): \
-         # N:     @overload \
+         # N: Possible overload variants: \
          # N:     def foo(x: int, y: int, z: int, *args: int) -> C \
-         # N:     @overload \
          # N:     def foo(x: int) -> A \
-         # N:     <1 more overload(s) not shown>
+         # N:     <1 more matching overload not shown, out of 3 total overloads>
 [builtins fixtures/list.pyi]
 
 [case testOverloadMultipleVarargDefinition]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1142,7 +1142,7 @@ def i(x: List[str]) -> int: pass  # E: Overloaded function signatures 1 and 2 ov
 def i(x: List[T]) -> None: pass
 [builtins fixtures/list.pyi]
 
-[case testOverlapWithTypeVarsWithValues]
+[case testOverloadOverlapWithTypeVarsWithValues]
 from foo import *
 [file foo.pyi]
 from typing import overload, TypeVar
@@ -1156,7 +1156,12 @@ def f(x: AnyStr) -> str: pass
 f(1)() # E: "int" not callable
 f('1')() # E: "str" not callable
 f(b'1')() # E: "str" not callable
-f(1.0) # E: No overload variant of "f" matches argument type "float"
+f(1.0) # E: No overload variant of "f" matches argument type "float" \
+       # N: Possible overload variant(s): \
+       # N:     @overload \
+       # N:     def f(x: int) -> int \
+       # N:     @overload \
+       # N:     def [AnyStr in (bytes, str)] f(x: AnyStr) -> str
 
 @overload
 def g(x: AnyStr, *a: AnyStr) -> None: pass

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -1304,10 +1304,8 @@ class D(C1, C2): pass # Compatible with both P1 and P2
 # TODO: Should this return a union instead?
 reveal_type(f(D())) # E: Revealed type is 'builtins.int'
 f(C()) # E: No overload variant of "f" matches argument type "C" \
-       # N: Possible overload variant(s): \
-       # N:     @overload \
+       # N: Possible overload variants: \
        # N:     def f(x: P1) -> int \
-       # N:     @overload \
        # N:     def f(x: P2) -> str
 [builtins fixtures/isinstance.pyi]
 
@@ -2010,7 +2008,7 @@ main:18: note:         @overload
 main:18: note:         def f(self, x: int) -> int
 main:18: note:         @overload
 main:18: note:         def f(self, x: str) -> str
-main:18: note:         <2 more overload(s) not shown>
+main:18: note:         <2 more overloads not shown>
 main:18: note:     Got:
 main:18: note:         def f(self) -> None
 

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -1303,7 +1303,12 @@ reveal_type(f(C2())) # E: Revealed type is 'builtins.str'
 class D(C1, C2): pass # Compatible with both P1 and P2
 # TODO: Should this return a union instead?
 reveal_type(f(D())) # E: Revealed type is 'builtins.int'
-f(C()) # E: No overload variant of "f" matches argument type "C"
+f(C()) # E: No overload variant of "f" matches argument type "C" \
+       # N: Possible overload variant(s): \
+       # N:     @overload \
+       # N:     def f(x: P1) -> int \
+       # N:     @overload \
+       # N:     def f(x: P2) -> str
 [builtins fixtures/isinstance.pyi]
 
 -- Unions of protocol types

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -294,16 +294,12 @@ class A:
     def __init__(self, x: str) -> None: pass
 [out2]
 tmp/a.py:2: error: No overload variant of "A" matches argument type "object"
-tmp/a.py:2: note: Possible overload variant(s):
-tmp/a.py:2: note:     @overload
+tmp/a.py:2: note: Possible overload variants:
 tmp/a.py:2: note:     def A(self, x: int) -> A
-tmp/a.py:2: note:     @overload
 tmp/a.py:2: note:     def A(self, x: str) -> A
 tmp/a.py:7: error: No overload variant of "__init__" of "A" matches argument type "object"
-tmp/a.py:7: note: Possible overload variant(s):
-tmp/a.py:7: note:     @overload
+tmp/a.py:7: note: Possible overload variants:
 tmp/a.py:7: note:     def __init__(self, x: int) -> None
-tmp/a.py:7: note:     @overload
 tmp/a.py:7: note:     def __init__(self, x: str) -> None
 
 [case testSerialize__new__]

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -294,7 +294,17 @@ class A:
     def __init__(self, x: str) -> None: pass
 [out2]
 tmp/a.py:2: error: No overload variant of "A" matches argument type "object"
+tmp/a.py:2: note: Possible overload variant(s):
+tmp/a.py:2: note:     @overload
+tmp/a.py:2: note:     def A(self, x: int) -> A
+tmp/a.py:2: note:     @overload
+tmp/a.py:2: note:     def A(self, x: str) -> A
 tmp/a.py:7: error: No overload variant of "__init__" of "A" matches argument type "object"
+tmp/a.py:7: note: Possible overload variant(s):
+tmp/a.py:7: note:     @overload
+tmp/a.py:7: note:     def __init__(self, x: int) -> None
+tmp/a.py:7: note:     @overload
+tmp/a.py:7: note:     def __init__(self, x: str) -> None
 
 [case testSerialize__new__]
 import a

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1205,7 +1205,12 @@ def f(x: int) -> None: ...
 def f(x): pass
 
 a: A
-f(a)  # E: No overload variant of "f" matches argument type "A"
+f(a)  # E: No overload variant of "f" matches argument type "A" \
+      # N: Possible overload variant(s): \
+      # N:     @overload \
+      # N:     def f(x: str) -> None \
+      # N:     @overload \
+      # N:     def f(x: int) -> None
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -907,16 +907,12 @@ from mypy_extensions import TypedDict
 D = TypedDict('D', {'x': int, 'y': str})
 d: D
 d.get() # E: All overload variants of "get" of "Mapping" require at least one argument \
-        # N: Possible overload variant(s): \
-        # N:     @overload \
+        # N: Possible overload variants: \
         # N:     def get(self, k: str) -> object \
-        # N:     @overload \
         # N:     def [V] get(self, k: str, default: object) -> object
 d.get('x', 1, 2) # E: No overload variant of "get" of "Mapping" matches argument types "str", "int", "int" \
-                 # N: Possible overload variant(s): \
-                 # N:     @overload \
+                 # N: Possible overload variants: \
                  # N:     def get(self, k: str) -> object \
-                 # N:     @overload \
                  # N:     def [V] get(self, k: str, default: Union[int, V]) -> object
 x = d.get('z') # E: TypedDict "D" has no key 'z'
 reveal_type(x) # E: Revealed type is 'Any'
@@ -1216,10 +1212,8 @@ def f(x): pass
 
 a: A
 f(a)  # E: No overload variant of "f" matches argument type "A" \
-      # N: Possible overload variant(s): \
-      # N:     @overload \
+      # N: Possible overload variants: \
       # N:     def f(x: str) -> None \
-      # N:     @overload \
       # N:     def f(x: int) -> None
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -906,8 +906,18 @@ reveal_type(d.get('x', a)) # E: Revealed type is 'Union[builtins.list[builtins.i
 from mypy_extensions import TypedDict
 D = TypedDict('D', {'x': int, 'y': str})
 d: D
-d.get() # E: All overload variants of "get" of "Mapping" require at least one argument
-d.get('x', 1, 2) # E: No overload variant of "get" of "Mapping" matches argument types "str", "int", "int"
+d.get() # E: All overload variants of "get" of "Mapping" require at least one argument \
+        # N: Possible overload variant(s): \
+        # N:     @overload \
+        # N:     def get(self, k: str) -> object \
+        # N:     @overload \
+        # N:     def [V] get(self, k: str, default: object) -> object
+d.get('x', 1, 2) # E: No overload variant of "get" of "Mapping" matches argument types "str", "int", "int" \
+                 # N: Possible overload variant(s): \
+                 # N:     @overload \
+                 # N:     def get(self, k: str) -> object \
+                 # N:     @overload \
+                 # N:     def [V] get(self, k: str, default: Union[int, V]) -> object
 x = d.get('z') # E: TypedDict "D" has no key 'z'
 reveal_type(x) # E: Revealed type is 'Any'
 s = ''

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -2113,10 +2113,8 @@ main:3: error: Revealed type is 'builtins.int'
 ==
 main:3: error: Revealed type is 'Any'
 main:3: error: No overload variant of "foo" of "Wrapper" matches argument type "int"
-main:3: note: Possible overload variant(s):
-main:3: note:     @overload
+main:3: note: Possible overload variants:
 main:3: note:     def foo(cls: Wrapper, x: int) -> int
-main:3: note:     @overload
 main:3: note:     def foo(cls: Wrapper, x: str) -> str
 
 [case testRefreshGenericClass]
@@ -6339,10 +6337,8 @@ def f(x):
 [out]
 ==
 main:3: error: No overload variant of "f" matches argument type "str"
-main:3: note: Possible overload variant(s):
-main:3: note:     @overload
+main:3: note: Possible overload variants:
 main:3: note:     def f(x: int) -> None
-main:3: note:     @overload
 main:3: note:     def f(x: C) -> int
 
 [case testOverloadsDeleted]
@@ -6453,10 +6449,8 @@ T = TypeVar('T', bound=str)
 [out]
 ==
 a.py:2: error: No overload variant of "f" matches argument type "int"
-a.py:2: note: Possible overload variant(s):
-a.py:2: note:     @overload
+a.py:2: note: Possible overload variants:
 a.py:2: note:     def f(x: C) -> None
-a.py:2: note:     @overload
 a.py:2: note:     def [c.T <: str] f(x: c.T) -> c.T
 
 [case testOverloadsGenericToNonGeneric]
@@ -6483,10 +6477,8 @@ class T: pass
 [out]
 ==
 a.py:2: error: No overload variant of "f" matches argument type "int"
-a.py:2: note: Possible overload variant(s):
-a.py:2: note:     @overload
+a.py:2: note: Possible overload variants:
 a.py:2: note:     def f(x: C) -> None
-a.py:2: note:     @overload
 a.py:2: note:     def f(x: T) -> T
 
 [case testOverloadsToNonOverloaded]
@@ -6643,10 +6635,9 @@ class C:
 [out]
 ==
 a.py:2: error: No overload variant of "B" matches argument type "int"
-a.py:2: note: Possible overload variant(s):
-a.py:2: note:     @overload
+a.py:2: note: Possible overload variant:
 a.py:2: note:     def __init__(self, x: str) -> B
-a.py:2: note:     <1 more overload(s) not shown>
+a.py:2: note:     <1 more non-matching overload not shown>
 
 [case testOverloadedToNormalMethodMetaclass]
 import a

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -2113,6 +2113,11 @@ main:3: error: Revealed type is 'builtins.int'
 ==
 main:3: error: Revealed type is 'Any'
 main:3: error: No overload variant of "foo" of "Wrapper" matches argument type "int"
+main:3: note: Possible overload variant(s):
+main:3: note:     @overload
+main:3: note:     def foo(cls: Wrapper, x: int) -> int
+main:3: note:     @overload
+main:3: note:     def foo(cls: Wrapper, x: str) -> str
 
 [case testRefreshGenericClass]
 from typing import TypeVar, Generic
@@ -6334,6 +6339,11 @@ def f(x):
 [out]
 ==
 main:3: error: No overload variant of "f" matches argument type "str"
+main:3: note: Possible overload variant(s):
+main:3: note:     @overload
+main:3: note:     def f(x: int) -> None
+main:3: note:     @overload
+main:3: note:     def f(x: C) -> int
 
 [case testOverloadsDeleted]
 import mod
@@ -6443,6 +6453,11 @@ T = TypeVar('T', bound=str)
 [out]
 ==
 a.py:2: error: No overload variant of "f" matches argument type "int"
+a.py:2: note: Possible overload variant(s):
+a.py:2: note:     @overload
+a.py:2: note:     def f(x: C) -> None
+a.py:2: note:     @overload
+a.py:2: note:     def [c.T <: str] f(x: c.T) -> c.T
 
 [case testOverloadsGenericToNonGeneric]
 import a
@@ -6468,6 +6483,11 @@ class T: pass
 [out]
 ==
 a.py:2: error: No overload variant of "f" matches argument type "int"
+a.py:2: note: Possible overload variant(s):
+a.py:2: note:     @overload
+a.py:2: note:     def f(x: C) -> None
+a.py:2: note:     @overload
+a.py:2: note:     def f(x: T) -> T
 
 [case testOverloadsToNonOverloaded]
 import a
@@ -6623,6 +6643,10 @@ class C:
 [out]
 ==
 a.py:2: error: No overload variant of "B" matches argument type "int"
+a.py:2: note: Possible overload variant(s):
+a.py:2: note:     @overload
+a.py:2: note:     def __init__(self, x: str) -> B
+a.py:2: note:     <1 more overload(s) not shown>
 
 [case testOverloadedToNormalMethodMetaclass]
 import a

--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -320,6 +320,11 @@ def f(x): # type: (unicode) -> int
   pass
 [out]
 _program.py:2: error: No overload variant of "f" matches argument type "int"
+_program.py:2: note: Possible overload variant(s):
+_program.py:2: note:     @overload
+_program.py:2: note:     def f(x: bytearray) -> int
+_program.py:2: note:     @overload
+_program.py:2: note:     def f(x: unicode) -> int
 
 [case testByteArrayStrCompatibility_python2]
 def f(x): # type: (str) -> None

--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -320,10 +320,8 @@ def f(x): # type: (unicode) -> int
   pass
 [out]
 _program.py:2: error: No overload variant of "f" matches argument type "int"
-_program.py:2: note: Possible overload variant(s):
-_program.py:2: note:     @overload
+_program.py:2: note: Possible overload variants:
 _program.py:2: note:     def f(x: bytearray) -> int
-_program.py:2: note:     @overload
 _program.py:2: note:     def f(x: unicode) -> int
 
 [case testByteArrayStrCompatibility_python2]

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1045,6 +1045,11 @@ _testTypedDictGet.py:7: error: Revealed type is 'builtins.int'
 _testTypedDictGet.py:8: error: Revealed type is 'builtins.str'
 _testTypedDictGet.py:9: error: TypedDict "D" has no key 'z'
 _testTypedDictGet.py:10: error: All overload variants of "get" of "Mapping" require at least one argument
+_testTypedDictGet.py:10: note: Possible overload variant(s):
+_testTypedDictGet.py:10: note:     @overload
+_testTypedDictGet.py:10: note:     def get(self, k: str) -> object
+_testTypedDictGet.py:10: note:     @overload
+_testTypedDictGet.py:10: note:     def [_T] get(self, k: str, default: object) -> object 
 _testTypedDictGet.py:12: error: Revealed type is 'builtins.object*'
 
 [case testTypedDictMappingMethods]

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1045,10 +1045,8 @@ _testTypedDictGet.py:7: error: Revealed type is 'builtins.int'
 _testTypedDictGet.py:8: error: Revealed type is 'builtins.str'
 _testTypedDictGet.py:9: error: TypedDict "D" has no key 'z'
 _testTypedDictGet.py:10: error: All overload variants of "get" of "Mapping" require at least one argument
-_testTypedDictGet.py:10: note: Possible overload variant(s):
-_testTypedDictGet.py:10: note:     @overload
+_testTypedDictGet.py:10: note: Possible overload variants:
 _testTypedDictGet.py:10: note:     def get(self, k: str) -> object
-_testTypedDictGet.py:10: note:     @overload
 _testTypedDictGet.py:10: note:     def [_T] get(self, k: str, default: object) -> object 
 _testTypedDictGet.py:12: error: Revealed type is 'builtins.object*'
 


### PR DESCRIPTION
Resolves https://github.com/python/mypy/issues/672 and supersedes https://github.com/python/mypy/pull/5054.

Currently, if a user calls an overloaded function and mypy is unable to find a match, mypy will display display a warning like 'No overload variant of "func" matches argument types" with no additional context.

This pull request will list several matching variants in addition to that message. If possible, mypy will attempt to show only overloads that have a compatible number of arguments. The number of overloads shown is always capped at a maximum of 2.

This pull request does *not* attempt to report a custom error when...

1. Union-math fails. Rationale: the pending PR will change how unions are handled dramatically enough to the point where any error handling here would be pointless.

2. Mypy is able to infer what signature the user most likely meant by looking at the erased types. Rationale: I attempted to implement this feature but was unable to make it consistently work without adding several ugly hacks around how mypy records errors so decided to defer implementing this feature.