### PR TITLE
Make NamedTuple attributes read-only

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -524,7 +524,7 @@ def get_member_flags(name: str, info: TypeInfo) -> Set[int]:
         if v.var.is_staticmethod or v.var.is_classmethod:
             return {IS_CLASS_OR_STATIC}
     # just a variable
-    if isinstance(v, Var):
+    if isinstance(v, Var) and not v.is_property:
         flags = {IS_SETTABLE}
         if v.is_classvar:
             flags.add(IS_CLASSVAR)

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -51,6 +51,23 @@ a.y = 5 # E: Property "y" defined in "X" is read-only
 -- a.z = 5 # not supported yet
 
 
+[case testTypingNamedTupleAttributesAreReadOnly]
+from typing import NamedTuple
+from typing_extensions import Protocol
+
+class HasX(Protocol): 
+    x: str
+    
+class A(NamedTuple):
+    x: str
+
+a: HasX = A("foo")
+a.x = "bar"
+[out]
+main:10: error: Incompatible types in assignment (expression has type "A", variable has type "HasX")
+main:10: note: Protocol member HasX.x expected settable variable, got read-only attribute
+
+
 [case testNamedTupleCreateWithPositionalArguments]
 from collections import namedtuple
 


### PR DESCRIPTION
It seems `namedtuple`s are covered already, but `typing.NamedTuple`s are not. This fixes #5293 .