### PR TITLE
Fail fast if site-packages are in the path

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -276,19 +276,17 @@ def compute_search_paths(sources: List[BuildSource],
         mypypath.insert(0, alt_lib_path)
 
     package_path = tuple(_get_site_packages_dirs(options.python_executable))
-    for site in package_path:
-        if site in mypypath:
-            print("site-packages is in the MYPYPATH. Please remove it.", file=sys.stderr)
-        elif site in python_path:
-            print("site-packages is in the PYTHONPAT. Please change directory so it is not.",
+    for site_dir in package_path:
+        assert site_dir not in lib_path
+        if site_dir in mypypath:
+            print("{} is in the MYPYPATH. Please remove it.".format(site_dir), file=sys.stderr)
+        elif site_dir in python_path:
+            print("{} is in the PYTHONPATH. Please change directory so it is not.".format(site_dir),
                   file=sys.stderr)
-        elif site in lib_path:
-            print("this should never, ever happen", file=sys.stderr)
         else:
             # this site not in any of the other paths, we are safe.
             continue
         sys.exit(1)
-
     return SearchPaths(tuple(reversed(python_path)),
                        tuple(mypypath),
                        package_path,

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -280,13 +280,13 @@ def compute_search_paths(sources: List[BuildSource],
         assert site_dir not in lib_path
         if site_dir in mypypath:
             print("{} is in the MYPYPATH. Please remove it.".format(site_dir), file=sys.stderr)
+            sys.exit(1)
         elif site_dir in python_path:
-            print("{} is in the PYTHONPATH. Please change directory so it is not.".format(site_dir),
+            print("{} is in the PYTHONPATH. Please change directory"
+                  " so it is not.".format(site_dir),
                   file=sys.stderr)
-        else:
-            # this site not in any of the other paths, we are safe.
-            continue
-        sys.exit(1)
+            sys.exit(1)
+
     return SearchPaths(tuple(reversed(python_path)),
                        tuple(mypypath),
                        package_path,

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -275,9 +275,23 @@ def compute_search_paths(sources: List[BuildSource],
     if alt_lib_path:
         mypypath.insert(0, alt_lib_path)
 
+    package_path = tuple(_get_site_packages_dirs(options.python_executable))
+    for site in package_path:
+        if site in mypypath:
+            print("site-packages is in the MYPYPATH. Please remove it.", file=sys.stderr)
+        elif site in python_path:
+            print("site-packages is in the PYTHONPAT. Please change directory so it is not.",
+                  file=sys.stderr)
+        elif site in lib_path:
+            print("this should never, ever happen", file=sys.stderr)
+        else:
+            # this site not in any of the other paths, we are safe.
+            continue
+        sys.exit(1)
+
     return SearchPaths(tuple(reversed(python_path)),
                        tuple(mypypath),
-                       tuple(_get_site_packages_dirs(options.python_executable)),
+                       package_path,
                        tuple(lib_path))
 
 


### PR DESCRIPTION
With my refactoring in #5256, I realized that it would be pretty straightforward to give some nicer warnings if site-packages were in any of the PATHs.