### PR TITLE
Allow calling Type[T] where T has generic bound

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -690,16 +690,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             callee = self.analyze_type_type_callee(item.upper_bound,
                                                    context)  # type: Optional[Type]
             if isinstance(callee, CallableType):
-                if callee.is_generic():
-                    callee = None
-                else:
-                    callee = callee.copy_modified(ret_type=item)
+                callee = callee.copy_modified(ret_type=item)
             elif isinstance(callee, Overloaded):
-                if callee.items()[0].is_generic():
-                    callee = None
-                else:
-                    callee = Overloaded([c.copy_modified(ret_type=item)
-                                         for c in callee.items()])
+                callee = Overloaded([c.copy_modified(ret_type=item)
+                                     for c in callee.items()])
             if callee:
                 return callee
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1778,6 +1778,16 @@ def f(c: Type[T]) -> T: ...
 x: Any
 reveal_type(f(x))  # E: Revealed type is 'Any'
 
+[case testCallTypeTWithGenericBound]
+from typing import Generic, TypeVar, Type
+T = TypeVar('T')
+S = TypeVar('S', bound='A')
+
+class A(Generic[T]): pass
+
+def f(cls: Type[S]) -> None:
+    cls()
+
 [case testQualifiedTypeVariableName]
 import b
 def f(x: b.T) -> b.T: return x


### PR DESCRIPTION
Fix #3631 : looks like it was an explicit decision, made before we had self types.

The code modified in this PR was introduced [here](https://github.com/python/mypy/pull/1569/files#r64440131) at #1569. There are no tests for the current behavior, and it seems like we actually want to allow it.

I did not add tests for `classmethod`/`staticmethod` since it's unrelated (and it works).
