### PR TITLE
Export the type of the format string in string interpolation

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -80,6 +80,7 @@ class StringFormatterChecker:
         """Check the types of the 'replacements' in a string interpolation
         expression: str % replacements
         """
+        self.exprchk.accept(expr)
         specifiers = self.parse_conversion_specifiers(expr.value)
         has_mapping_keys = self.analyze_conversion_specifiers(specifiers, expr)
         if isinstance(expr, BytesExpr) and (3, 0) <= self.chk.options.python_version < (3, 5):

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -1,7 +1,7 @@
 -- Test cases for exporting node types from the type checker.
 --
 -- Each test case consists of at least two sections.
--- The first section contains [case NAME-skip] followed by the input code,
+-- The first section contains [case NAME] followed by the input code,
 -- while the second section contains [out] followed by the output from the type
 -- checker.
 --
@@ -1145,6 +1145,14 @@ IntExpr(3) : builtins.int
 ListExpr(3) : builtins.list[builtins.str]
 OpExpr(3) : builtins.list[builtins.str]
 
+[case testStringFormatting]
+## .*
+'%d' % 1
+[builtins fixtures/primitives.pyi]
+[out]
+IntExpr(2) : builtins.int
+OpExpr(2) : builtins.str
+StrExpr(2) : builtins.str
 
 -- TODO
 --


### PR DESCRIPTION
Previously the type of `"%d"` in `"%d" % 1` was not added to the type
map. This is a problem because mypyc expects that every expression has
an inferred type.