### PR TITLE
Add internal options flag for exporting global type map

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -195,6 +195,8 @@ class Options:
         self.local_partial_types = False
         # Some behaviors are changed when using Bazel (https://bazel.build).
         self.bazel = False
+        # If True, export inferred types for all expressions as BuildResult.types
+        self.export_types = False
         # List of package roots -- directories under these are packages even
         # if they don't have __init__.py.
         self.package_root = []  # type: List[str]

--- a/mypy/test/testdeps.py
+++ b/mypy/test/testdeps.py
@@ -83,6 +83,7 @@ class GetDependenciesSuite(DataSuite):
         options.show_traceback = True
         options.cache_dir = os.devnull
         options.python_version = python_version
+        options.export_types = True
         try:
             result = build.build(sources=[BuildSource('main', None, source)],
                                  options=options,

--- a/mypy/test/testtypegen.py
+++ b/mypy/test/testtypegen.py
@@ -34,6 +34,7 @@ class TypeExportSuite(DataSuite):
             options.strict_optional = False  # TODO: Enable strict optional checking
             options.use_builtins_fixtures = True
             options.show_traceback = True
+            options.export_types = True
             result = build.build(sources=[BuildSource('main', None, src)],
                                  options=options,
                                  alt_lib_path=test_temp_dir)


### PR DESCRIPTION
Previously type map export was enabled by ad hoc rules. This makes it
more explicit, and allows it to be used by mypyc.