### PR TITLE
Only use __getattr__ when node is not found

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3078,7 +3078,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                         n = names.get(parts[i], None)
                         if n and isinstance(n.node, ImportedName):
                             n = self.dereference_module_cross_ref(n)
-                        elif '__getattr__' in names:
+                        elif not n and '__getattr__' in names:
                             gvar = self.create_getattr_var(names['__getattr__'],
                                                            parts[i], parts[i])
                             if gvar:

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2484,3 +2484,14 @@ from typing import Any
 def __getattr__(attr: str) -> Any: ...
 [builtins fixtures/module.pyi]
 [out]
+
+[case testNoGetattrInterference]
+import testmod as t
+def f(x: t.Cls) -> None:
+    reveal_type(x)  # E: Revealed type is 'testmod.Cls'
+[file testmod.pyi]
+from typing import Any
+def __getattr__(attr: str) -> Any: ...
+class Cls: ...
+[builtins fixtures/module.pyi]
+[out]


### PR DESCRIPTION
Fixes #5331 