### PR TITLE
Reorganize command line documentation

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -3,542 +3,543 @@
 The mypy command line
 =====================
 
-This section documents many of mypy's command line flags.  A quick
-summary of command line flags can always be printed using the ``-h``
-flag (or its long form ``--help``)::
-
-  $ mypy -h
-  usage: mypy [-h] [-v] [-V] [--python-version x.y] [--platform PLATFORM] [-2]
-              [--ignore-missing-imports]
-              [--follow-imports {normal,silent,skip,error}]
-              [--disallow-any-unimported] [--disallow-any-expr]
-              [--disallow-any-decorated] [--disallow-any-explicit]
-              [--disallow-any-generics] [--disallow-untyped-calls]
-              [--disallow-untyped-defs] [--disallow-incomplete-defs]
-              [--check-untyped-defs] [--disallow-subclassing-any]
-              [--warn-incomplete-stub] [--disallow-untyped-decorators]
-              [--warn-redundant-casts] [--no-warn-no-return] [--warn-return-any]
-              [--warn-unused-ignores] [--warn-unused-configs]
-              [--show-error-context] [--no-implicit-optional] [--no-incremental]
-              [--quick-and-dirty] [--cache-dir DIR] [--cache-fine-grained]
-              [--skip-version-check] [--no-strict-optional]
-              [--strict-optional-whitelist [GLOB [GLOB ...]]]
-              [--always-true NAME] [--always-false NAME] [--junit-xml JUNIT_XML]
-              [--pdb] [--show-traceback] [--stats] [--inferstats]
-              [--custom-typing MODULE] [--custom-typeshed-dir DIR]
-              [--scripts-are-modules] [--config-file CONFIG_FILE]
-              [--show-column-numbers] [--find-occurrences CLASS.MEMBER]
-              [--strict] [--shadow-file SOURCE_FILE SHADOW_FILE]
-              [--any-exprs-report DIR] [--cobertura-xml-report DIR]
-              [--html-report DIR] [--linecount-report DIR]
-              [--linecoverage-report DIR] [--memory-xml-report DIR]
-              [--txt-report DIR] [--xml-report DIR] [--xslt-html-report DIR]
-              [--xslt-txt-report DIR] [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT]
-              [files [files ...]]
-
-  (etc., too long to show everything here)
-
-Specifying files and directories to be checked
-**********************************************
-
-You've already seen ``mypy program.py`` as a way to type check the
-file ``program.py``.  More generally you can pass any number of files
-and directories on the command line and they will all be type checked
-together.
-
-- Files ending in ``.py`` (and stub files ending in ``.pyi``) are
-  checked as Python modules.
-
-- Files not ending in ``.py`` or ``.pyi`` are assumed to be Python
-  scripts and checked as such.
-
-- Directories representing Python packages (i.e. containing a
-  ``__init__.py[i]`` file) are checked as Python packages; all
-  submodules and subpackages will be checked (subpackages must
-  themselves have a ``__init__.py[i]`` file).
-
-- Directories that don't represent Python packages (i.e. not directly
-  containing an ``__init__.py[i]`` file) are checked as follows:
-
-  - All ``*.py[i]`` files contained directly therein are checked as
-    toplevel Python modules;
-
-  - All packages contained directly therein (i.e. immediate
-    subdirectories with an ``__init__.py[i]`` file) are checked as
-    toplevel Python packages.
-
-One more thing about checking modules and packages: if the directory
-*containing* a module or package specified on the command line has an
-``__init__.py[i]`` file, mypy assigns these an absolute module name by
-crawling up the path until no ``__init__.py[i]`` file is found.  For
-example, suppose we run the command ``mypy foo/bar/baz.py`` where
-``foo/bar/__init__.py`` exists but ``foo/__init__.py`` does not.  Then
-the module name assumed is ``bar.baz`` and the directory ``foo`` is
-added to mypy's module search path.  On the other hand, if
-``foo/bar/__init__.py`` did not exist, ``foo/bar`` would be added to
-the module search path instead, and the module name assumed is just
-``baz``.
-
-If a script (a file not ending in ``.py[i]``) is processed, the module
-name assumed is always ``__main__`` (matching the behavior of the
-Python interpreter).
-
-Other ways of specifying code to be checked
-*******************************************
-
-The flag ``-m`` (long form: ``--module``) lets you specify a module
-name to be found using the default module search path.  The module
-name may contain dots.  For example::
-
-  $ mypy -m html.parser
-
-will type check the module ``html.parser`` (this happens to be a
-library stub).
-
-The flag ``-p`` (long form: ``--package``) is similar to ``-m`` but
-you give it a package name and it will type check all submodules and
-subpackages (recursively) of that package.  (If you pass a package
-name to ``-m`` it will just type check the package's ``__init__.py``
-and anything imported from there.)  For example::
-
-  $ mypy -p html
-
-will type check the entire ``html`` package (of library stubs). One can
-specify multiple packages and modules on the command line, for example::
-
-  $ mypy --package p.a --package p.b --module c
-
-Finally the flag ``-c`` (long form: ``--command``) will take a string
-from the command line and type check it as a small program.  For
-example::
-
-  $ mypy -c 'x = [1, 2]; print(x())'
-
-will type check that little program (and complain that ``List[int]``
-is not callable).
-
-Reading a list of files from a file
-***********************************
-
-Finally, any command-line argument starting with ``@`` reads additional
-command-line arguments from the file following the ``@`` character.
-This is primarily useful if you have a file containing a list of files
-that you want to be type-checked: instead of using shell syntax like::
-
-  mypy $(cat file_of_files)
-
-you can use this instead::
-
-  mypy @file_of_files
-
-Such a file can also contain other flags, but a preferred way of
-reading flags (not files) from a file is to use a
-:ref:`configuration file <config-file>`.
-
-
-.. _finding-imports:
-
-How imports are found
-*********************
-
-When mypy encounters an `import` statement it tries to find the module
-on the file system, similar to the way Python finds it.
-However, there are some differences.
-
-First, mypy has its own search path.
-This is computed from the following items:
-
-- The ``MYPYPATH`` environment variable
-  (a colon-separated list of directories).
-- The directories containing the sources given on the command line
-  (see below).
-- The installed packages marked as safe for type checking (see
-  :ref:`PEP 561 support <installed-packages>`)
-- The relevant directories of the
-  `typeshed <https://github.com/python/typeshed>`_ repo.
-
-For sources given on the command line, the path is adjusted by crawling
-up from the given file or package to the nearest directory that does not
-contain an ``__init__.py`` or ``__init__.pyi`` file.
-
-Second, mypy searches for stub files in addition to regular Python files
-and packages.
-The rules for searching for a module ``foo`` are as follows:
-
-- The search looks in each of the directories in the search path
-  (see above) until a match is found.
-- If a package named ``foo`` is found (i.e. a directory
-  ``foo`` containing an ``__init__.py`` or ``__init__.pyi`` file)
-  that's a match.
-- If a stub file named ``foo.pyi`` is found, that's a match.
-- If a Python module named ``foo.py`` is found, that's a match.
-
-These matches are tried in order, so that if multiple matches are found
-in the same directory on the search path
-(e.g. a package and a Python file, or a stub file and a Python file)
-the first one in the above list wins.
-
-In particular, if a Python file and a stub file are both present in the
-same directory on the search path, only the stub file is used.
-(However, if the files are in different directories, the one found
-in the earlier directory is used.)
-
-NOTE: These rules are relevant to the following section too:
-the ``--follow-imports`` flag described below is applied *after* the
-above algorithm has determined which package, stub or module to use.
-
-.. _follow-imports:
-
-Following imports or not?
-*************************
-
-When you're first attacking a large existing codebase with mypy, you
-may only want to check selected files.  For example, you may only want
-to check those files to which you have already added annotations.
-This is easily accomplished using a shell pipeline like this::
-
-  mypy $(find . -name \*.py | xargs grep -l '# type:')
-
-(While there are many improvements possible to make this example more
-robust, this is not the place for a tutorial in shell programming.)
-
-However, by default mypy doggedly tries to :ref:`follow imports
-<finding-imports>`.  This may cause several types of problems that you
-may want to silence during your initial conquest:
-
-- Your code may import library modules for which no stub files exist
-  yet.  This can cause a lot of errors like the following::
-
-    main.py:1: error: No library stub file for standard library module 'antigravity'
-    main.py:2: error: No library stub file for module 'flask'
-    main.py:3: error: Cannot find module named 'sir_not_appearing_in_this_film'
-
-  If you see only a few of these you may be able to silence them by
-  putting ``# type: ignore`` on the respective ``import`` statements,
-  but it's usually easier to silence all such errors by using
-  :ref:`--ignore-missing-imports <ignore-missing-imports>`.
-
-- Your project's directory structure may hinder mypy in finding
-  certain modules that are part of your project, e.g. modules hidden
-  away in a subdirectory that's not a package.  You can usually deal
-  with this by setting the ``MYPYPATH`` variable (see
-  :ref:`finding-imports`).
-
-- When following imports mypy may find a module that's part of your
-  project but which you haven't annotated yet, mypy may report errors
-  for the top level code in that module (where the top level includes
-  class bodies and function/method default values).  Here the
-  ``--follow-imports`` flag comes in handy.
-
-The ``--follow-imports`` flag takes a mandatory string value that can
-take one of four values.  It only applies to modules for which a
-``.py`` file is found (but no corresponding ``.pyi`` stub file) and
-that are not given on the command line.  Passing a package or
-directory on the command line implies all modules in that package or
-directory.  The four possible values are:
-
-- ``normal`` (the default) follow imports normally and type check all
-  top level code (as well as the bodies of all functions and methods
-  with at least one type annotation in the signature).
-
-- ``silent`` follow imports normally and even "type check" them
-  normally, but *suppress any error messages*. This is typically the
-  best option for a new codebase.
-
-- ``skip`` *don't* follow imports, silently replacing the module (and
-  everything imported *from* it) with an object of type ``Any``.
-  (This option used to be known as ``--silent-imports`` and while it
-  is very powerful it can also cause hard-to-debug errors, hence the
-  recommendation of using ``silent`` instead.)
-
-- ``error`` the same behavior as ``skip`` but not quite as silent --
-  it flags the import as an error, like this::
-
-    main.py:1: note: Import of 'submodule' ignored
-    main.py:1: note: (Using --follow-imports=error, module not passed on command line)
-
-.. _disallow-any:
-
-Disallow Any Flags
-******************
-
-The ``--disallow-any`` family of flags disallows various types of ``Any`` in a module.
-The following options are available:
-
-- ``--disallow-any-unimported`` disallows usage of types that come from unfollowed imports
-  (such types become aliases for ``Any``). Unfollowed imports occur either
-  when the imported module does not exist or when ``--follow-imports=skip``
-  is set.
-
-- ``--disallow-any-expr`` disallows all expressions in the module that have type ``Any``.
-  If an expression of type ``Any`` appears anywhere in the module
-  mypy will output an error unless the expression is immediately
-  used as an argument to ``cast`` or assigned to a variable with an
-  explicit type annotation. In addition, declaring a variable of type ``Any``
-  or casting to type ``Any`` is not allowed. Note that calling functions
-  that take parameters of type ``Any`` is still allowed.
-
-- ``--disallow-any-decorated`` disallows functions that have ``Any`` in their signature
-  after decorator transformation.
-
-- ``--disallow-any-explicit`` disallows explicit ``Any`` in type positions such as type
-  annotations and generic type parameters.
-
-- ``--disallow-any-generics`` disallows usage of generic types that do not specify explicit
-  type parameters. Moreover, built-in collections (such as ``list`` and
-  ``dict``) become disallowed as you should use their aliases from the typing
-  module (such as ``List[int]`` and ``Dict[str, str]``).
-
-
-.. _additional-command-line-flags:
-
-Additional command line flags
-*****************************
-
-Here are some more useful flags:
-
-.. _ignore-missing-imports:
-
-- ``--ignore-missing-imports`` suppresses error messages about imports
-  that cannot be resolved (see :ref:`follow-imports` for some examples).
-  This doesn't suppress errors about missing names in successfully resolved
-  modules. For example, if one has the following files::
-
-    package/__init__.py
-    package/mod.py
-
-  Then mypy will generate the following errors with ``--ignore-missing-imports``:
-
-  .. code-block:: python
-
-     import package.unknown  # No error, ignored
-     x = package.unknown.func()  # OK
-
-     from package import unknown  # No error, ignored
-     from package.mod import NonExisting  # Error: Module has no attribute 'NonExisting'
-
-- ``--no-strict-optional`` disables strict checking of ``Optional[...]``
-  types and ``None`` values. With this option, mypy doesn't
-  generally check the use of ``None`` values -- they are valid
-  everywhere. See :ref:`no_strict_optional` for more about this feature.
-
-  **Note:** Strict optional checking was enabled by default starting in
-  mypy 0.600, and in previous versions it had to be explicitly enabled
-  using ``--strict-optional`` (which is still accepted).
-
-- ``--disallow-untyped-defs`` reports an error whenever it encounters
-  a function definition without type annotations.
-
-- ``--check-untyped-defs`` is less severe than the previous option --
-  it type checks the body of every function, regardless of whether it
-  has type annotations.  (By default the bodies of functions without
-  annotations are not type checked.)  It will assume all arguments
-  have type ``Any`` and always infer ``Any`` as the return type.
-
-- ``--disallow-incomplete-defs`` reports an error whenever it
-  encounters a partly annotated function definition.
-
-- ``--disallow-untyped-calls`` reports an error whenever a function
-  with type annotations calls a function defined without annotations.
-
-- ``--disallow-untyped-decorators`` reports an error whenever a function
-  with type annotations is decorated with a decorator without annotations.
-
-.. _disallow-subclassing-any:
-
-- ``--disallow-subclassing-any`` reports an error whenever a class
-  subclasses a value of type ``Any``.  This may occur when the base
-  class is imported from a module that doesn't exist (when using
-  :ref:`--ignore-missing-imports <ignore-missing-imports>`) or is
-  ignored due to :ref:`--follow-imports=skip <follow-imports>` or a
-  ``# type: ignore`` comment on the ``import`` statement.  Since the
-  module is silenced, the imported class is given a type of ``Any``.
-  By default mypy will assume that the subclass correctly inherited
-  the base class even though that may not actually be the case.  This
-  flag makes mypy raise an error instead.
-
-.. _incremental:
-
-- Incremental mode enables a module cache, using results from
-  previous runs to speed up type checking. Incremental mode can help
-  when most parts of your program haven't changed since the previous
-  mypy run.
-
-  Incremental mode is the default and may be disabled with
-  ``--no-incremental``.
-
-- ``--cache-dir DIR`` is a companion flag to incremental mode, which
-  specifies where the cache files are written.  By default this is
-  ``.mypy_cache`` in the current directory.  While the cache is only
-  read in incremental mode, it is written even in non-incremental
-  mode, in order to "warm" the cache.  To disable writing the cache,
-  use ``--cache-dir=/dev/null`` (UNIX) or ``--cache-dir=nul``
-  (Windows).  Cache files belonging to a different mypy version are
-  ignored.  This flag can be useful for controlling cache use when using
-  :ref:`remote caching <remote-cache>`.
-
-.. _quick-mode:
-
-- ``--quick-and-dirty`` is an experimental, unsafe variant of
-  :ref:`incremental mode <incremental>`.  Quick mode is faster than
-  regular incremental mode, because it only re-checks modules that
-  were modified since their cache file was last written (regular
-  incremental mode also re-checks all modules that depend on one or
-  more modules that were re-checked).  Quick mode is unsafe because it
-  may miss problems caused by a change in a dependency.  Quick mode
-  updates the cache, but regular incremental mode ignores cache files
-  written by quick mode.
-
-- ``--python-executable EXECUTABLE`` will have mypy collect type information
-  from `PEP 561`_ compliant packages installed for the Python executable
-  ``EXECUTABLE``. If not provided, mypy will use PEP 561 compliant packages
-  installed for the Python executable running mypy. See
-  :ref:`installed-packages` for more on making PEP 561 compliant packages.
-  This flag will attempt to set ``--python-version`` if not already set.
-
-- ``--python-version X.Y`` will make mypy typecheck your code as if it were
-  run under Python version X.Y. Without this option, mypy will default to using
-  whatever version of Python is running mypy. Note that the ``-2`` and
-  ``--py2`` flags are aliases for ``--python-version 2.7``. See
-  :ref:`version_and_platform_checks` for more about this feature. This flag
-  will attempt to find a Python executable of the corresponding version to
-  search for `PEP 561`_ compliant packages. If you'd like to disable this,
-  see ``--no-site-packages`` below.
-
-- ``--no-site-packages`` will disable searching for `PEP 561`_ compliant
-  packages. This will also disable searching for a usable Python executable.
-  Use this  flag if mypy cannot find a Python executable for the version of
-  Python being checked, and you don't need to use PEP 561 typed packages.
-  Otherwise, use ``--python-executable``.
-
-- ``--platform PLATFORM`` will make mypy typecheck your code as if it were
-  run under the given operating system. Without this option, mypy will
-  default to using whatever operating system you are currently using. See
-  :ref:`version_and_platform_checks` for more about this feature.
-
-.. _always-true:
-
-- ``--always-true NAME`` will treat all variables named ``NAME`` as
-  compile-time constants that are always true.  May be repeated.
-
-- ``--always-false NAME`` will treat all variables named ``NAME`` as
-  compile-time constants that are always false.  May be repeated.
-
-- ``--show-column-numbers`` will add column offsets to error messages,
-  for example, the following indicates an error in line 12, column 9
-  (note that column offsets are 0-based):
-
-  .. code-block:: python
-
-     main.py:12:9: error: Unsupported operand types for / ("int" and "str")
-
-- ``--scripts-are-modules`` will give command line arguments that
-  appear to be scripts (i.e. files whose name does not end in ``.py``)
-  a module name derived from the script name rather than the fixed
-  name ``__main__``.  This allows checking more than one script in a
-  single mypy invocation.  (The default ``__main__`` is technically
-  more correct, but if you have many scripts that import a large
-  package, the behavior enabled by this flag is often more
-  convenient.)
-
-- ``--custom-typeshed-dir DIR`` specifies the directory where mypy looks for
-  typeshed stubs, instead of the typeshed that ships with mypy.  This is
-  primarily intended to make it easier to test typeshed changes before
-  submitting them upstream, but also allows you to use a forked version of
-  typeshed.
-
-.. _config-file-flag:
-
-- ``--config-file CONFIG_FILE`` causes configuration settings to be
-  read from the given file.  By default settings are read from ``mypy.ini``
-  or ``setup.cfg`` in the current directory, or ``.mypy.ini`` in the user home
-  directory.  Settings override mypy's built-in defaults and command line flags
-  can override settings. See :ref:`config-file` for the syntax of configuration
-  files.
-
-- ``--junit-xml JUNIT_XML`` will make mypy generate a JUnit XML test
-  result document with type checking results. This can make it easier
-  to integrate mypy with continuous integration (CI) tools.
-
-- ``--find-occurrences CLASS.MEMBER`` will make mypy print out all
-  usages of a class member based on static type information. This
-  feature is experimental.
-
-- ``--cobertura-xml-report DIR`` causes mypy to generate a Cobertura
-  XML type checking coverage report.
-
-- ``--warn-no-return`` causes mypy to generate errors for missing return
-  statements on some execution paths. Mypy doesn't generate these errors
-  for functions with ``None`` or ``Any`` return types. Mypy
-  also currently ignores functions with an empty body or a body that is
-  just ellipsis (``...``), since these can be valid as abstract methods.
-  This option is on by default.
-
-- ``--warn-return-any`` causes mypy to generate a warning when returning a value
-  with type ``Any`` from a function declared with a non- ``Any`` return type.
-
-- ``--strict`` mode enables all optional error checking flags.  You can see the
-  list of flags enabled by strict mode in the full ``mypy -h`` output.
-
-.. _shadow-file:
-
-- ``--shadow-file SOURCE_FILE SHADOW_FILE``: when mypy is asked to typecheck
-  ``SOURCE_FILE``, this makes it read from and typecheck the contents of
-  ``SHADOW_FILE`` instead. However, diagnostics will continue to refer to
-  ``SOURCE_FILE``. Specifying this argument multiple times
-  (``--shadow-file X1 Y1 --shadow-file X2 Y2``)
-  will allow mypy to perform multiple substitutions.
-
-  This allows tooling to create temporary files with helpful modifications
-  without having to change the source file in place. For example, suppose we
-  have a pipeline that adds ``reveal_type`` for certain variables.
-  This pipeline is run on ``original.py`` to produce ``temp.py``.
-  Running ``mypy --shadow-file original.py temp.py original.py`` will then
-  cause mypy to typecheck the contents of ``temp.py`` instead of  ``original.py``,
-  but error messages will still reference ``original.py``.
-
-.. _no-implicit-optional:
-
-- ``--no-implicit-optional`` causes mypy to stop treating arguments
-  with a ``None`` default value as having an implicit ``Optional[...]``
-  type.
-
-For the remaining flags you can read the full ``mypy -h`` output.
+This section documents mypy's command line interface. You can view
+a quick summary of the available flags by running ``mypy --help``.
 
 .. note::
 
    Command line flags are liable to change between releases.
 
+
+Specifying what to type check
+*****************************
+
+By default, you can specify what code you want mypy to type check
+by passing in the paths to what you want to have type checked::
+
+    $ mypy foo.py bar.py some_directory
+
+Note that directories are checked recursively.
+
+Mypy also lets you specify what code to type check in several other
+ways. A short summary of the relevant flags is included below:
+for full details, see :ref:`running-mypy`.
+
+``-m MODULE``, ``--module MODULE``
+    Asks mypy to type check the provided module. This flag may be
+    repeated multiple times.
+
+    Mypy *will not* recursively type check any submodules of the provided
+    module.
+
+``-p PACKAGE``, ``--package PACKAGE``
+    Asks mypy to type check the provided package. This flag may be
+    repeated multiple times.
+
+    Mypy *will* recursively type check any submodules of the provided
+    package. This flag is identical to ``-module`` apart from this
+    behavior.
+
+``-c PROGRAM_TEXT``, ``--command PROGRAM_TEXT``
+    Asks mypy to type check the provided string as a program.
+    
+
+.. _config-file-flag:
+
+Config file
+***********
+
+``--config-file CONFIG_FILE``
+    This flag makes mypy read configuration settings from the given file.
+  
+    By default settings are read from ``mypy.ini`` or ``setup.cfg`` in the
+    current directory, or ``.mypy.ini`` in the user's home directory.
+    Settings override mypy's built-in defaults and command line flags
+    can override settings. 
+    
+    See :ref:`config-file` for the syntax of configuration files.
+
+``--warn-unused-configs``
+    This flag makes mypy warn about unused ``[mypy-<pattern>]`` config
+    file sections.
+
+
+.. _import-discovery:
+
+Import discovery
+****************
+
+The following flags customize how exactly mypy discovers and follows
+imports.
+
+``--ignore-missing-imports``
+    This flag makes mypy ignore all missing imports. It is equivalent
+    to adding ``# type: ignore`` comments to all unresolved imports
+    within your codebase.
+
+    Note that this flag does *not* suppress errors about missing names
+    in successfully resolved modules. For example, if one has the
+    following files::
+
+        package/__init__.py
+        package/mod.py
+
+    Then mypy will generate the following errors with ``--ignore-missing-imports``:
+
+    .. code-block:: python
+
+        import package.unknown      # No error, ignored
+        x = package.unknown.func()  # OK. 'func' is assumed to be of type 'Any'
+
+        from package import unknown          # No error, ignored
+        from package.mod import NonExisting  # Error: Module has no attribute 'NonExisting'
+
+    For more details, see :ref:`ignore-missing-imports`.
+
+``--follow-imports {normal,silent,skip,error}``
+    This flag adjusts how mypy follows imported modules that were not
+    explicitly passed in via the command line.
+
+    The default option is ``normal``: mypy will follow and type check
+    all modules. For more information on what the other options do,
+    see :ref:`Following imports <follow-imports>`.
+
+``--python-executable EXECUTABLE`` 
+    This flag will have mypy collect type information from `PEP 561`_
+    compliant packages installed for the Python executable ``EXECUTABLE``. 
+    If not provided, mypy will use PEP 561 compliant packages installed for
+    the Python executable running mypy. 
+    
+    See :ref:`installed-packages` for more on making PEP 561 compliant packages.
+    This flag will attempt to set ``--python-version`` if not already set.
+
+``--no-site-packages``
+    This flag will disable searching for `PEP 561`_ compliant packages. This
+    will also disable searching for a usable Python executable.
+  
+    Use this  flag if mypy cannot find a Python executable for the version of
+    Python being checked, and you don't need to use PEP 561 typed packages.
+    Otherwise, use ``--python-executable``.
+
+``--no-silence-site-packages``
+    By default, mypy will suppress any error messages generated within PEP 561
+    compliant packages. Adding this flag will disable this behavior.
+
+
+Platform configuration
+**********************
+
+By default, mypy will assume that you intend to run your code using the same
+operating system and Python version you are using to run mypy itself. The
+following flags let you modify this behavior.
+
+For more information on how to use these flags, see :ref:`version_and_platform_checks`.
+
+``--python-version X.Y`` 
+    This flag will make mypy type check your code as if it were
+    run under Python version X.Y. Without this option, mypy will default to using
+    whatever version of Python is running mypy. Note that the ``-2`` and
+    ``--py2`` flags are aliases for ``--python-version 2.7``. 
+    
+    This flag will attempt to find a Python executable of the corresponding 
+    version to search for `PEP 561`_ compliant packages. If you'd like to
+    disable this, use the ``--no-site-packages`` flag (see 
+    :ref:`import-discovery` for more details).
+
+``-2``, ``--py2``
+    Equivalent to running ``--python-version 2.7``.
+
+``--platform PLATFORM``
+    This flag will make mypy type check your code as if it were
+    run under the given operating system. Without this option, mypy will
+    default to using whatever operating system you are currently using. 
+    
+    The ``PLATFORM`` parameter may be any string supported by
+    `sys.platform <https://docs.python.org/3/library/sys.html#sys.platform>`_.
+
+.. _always-true:
+
+``--always-true NAME`` 
+    This flag will treat all variables named ``NAME`` as
+    compile-time constants that are always true.  This flag may
+    be repeated.
+
+``--always-false NAME`` 
+    This flag will treat all variables named ``NAME`` as
+    compile-time constants that are always false.  This flag may
+    be repeated.
+
+.. _disallow-any:
+
+Disallow Any 
+************
+
+The ``--disallow-any`` family of flags disallows various types of ``Any`` in a module.
+The following options are available:
+
+``--disallow-any-unimported``
+    This flag disallows usage of types that come from unfollowed imports
+    (such types become aliases for ``Any``). Unfollowed imports occur either
+    when the imported module does not exist or when ``--follow-imports=skip``
+    is set.
+
+``--disallow-any-expr``
+    This flag disallows all expressions in the module that have type ``Any``.
+    If an expression of type ``Any`` appears anywhere in the module
+    mypy will output an error unless the expression is immediately
+    used as an argument to ``cast`` or assigned to a variable with an
+    explicit type annotation.
+    
+    In addition, declaring a variable of type ``Any``
+    or casting to type ``Any`` is not allowed. Note that calling functions
+    that take parameters of type ``Any`` is still allowed.
+
+``--disallow-any-decorated``
+    This flag disallows functions that have ``Any`` in their signature
+    after decorator transformation.
+
+``--disallow-any-explicit``
+    This flag disallows explicit ``Any`` in type positions such as type
+    annotations and generic type parameters.
+
+``--disallow-any-generics``
+    This flag disallows usage of generic types that do not specify explicit
+    type parameters. Moreover, built-in collections (such as ``list`` and
+    ``dict``) become disallowed as you should use their aliases from the typing
+    module (such as ``List[int]`` and ``Dict[str, str]``).
+
+.. _disallow-subclassing-any:
+
+``--disallow-subclassing-any`` 
+    This flag reports an error whenever a class subclasses a value of 
+    type ``Any``.  This may occur when the base class is imported from 
+    a module that doesn't exist (when using
+    :ref:`--ignore-missing-imports <ignore-missing-imports>`) or is
+    ignored due to :ref:`--follow-imports=skip <follow-imports>` or a
+    ``# type: ignore`` comment on the ``import`` statement.  
+    
+    Since the module is silenced, the imported class is given a type of ``Any``.
+    By default mypy will assume that the subclass correctly inherited
+    the base class even though that may not actually be the case.  This
+    flag makes mypy raise an error instead.
+
+.. _untyped-definitions-and-calls:
+
+Untyped definitions and calls
+*****************************
+
+The following flags configure how mypy handles untyped function
+definitions or calls.
+
+``--disallow-untyped-calls``
+    This flag reports an error whenever a function with type annotations
+    calls a function defined without annotations.
+
+``--disallow-untyped-defs`` 
+    This flag reports an error whenever it encounters a function definition
+    without type annotations.
+
+``--disallow-incomplete-defs`` 
+    This flag reports an error whenever it encounters a partly annotated
+    function definition.
+
+``--check-untyped-defs`` 
+    This flag is less severe than the previous two options -- it type checks
+    the body of every function, regardless of whether it has type annotations.
+    (By default the bodies of functions without annotations are not type
+    checked.)
+    
+    It will assume all arguments have type ``Any`` and always infer ``Any``
+    as the return type.
+
+``--disallow-untyped-decorators``
+    This flag reports an error whenever a function with type annotations
+    is decorated with a decorator without annotations.
+
+
+None and Optional handling
+**************************
+
+The following flags adjust how mypy handles values of type `None`.
+For more details, see :ref:`no_strict_optional`.
+
+.. _no-implicit-optional:
+
+``--no-implicit-optional``
+    This flag causes mypy to stop treating arguments with a ``None``
+    default value as having an implicit ``Optional[...]`` type.
+
+    For example, by default mypy will assume that the ``x`` parameter
+    is of type ``Optional[int]`` in the code snippet below since
+    the default pararameter is ``None``:
+
+    .. code-block:: python
+
+        def foo(x: int = None) -> None:
+            print(x)
+
+    If this flag is set, the above snippet will no longer type check:
+    we must now explicitly indicate that the type is ``Optional[int]``:
+
+    .. code-block:: python
+
+        def foo(x: Optional[int] = None) -> None:
+            print(x)
+
+``--no-strict-optional``
+    This flag disables strict checking of ``Optional[...]``
+    types and ``None`` values. With this option, mypy doesn't
+    generally check the use of ``None`` values -- they are valid
+    everywhere. See :ref:`no_strict_optional` for more about this feature.
+
+.. note::
+    Strict optional checking was enabled by default starting in
+    mypy 0.600, and in previous versions it had to be explicitly enabled
+    using ``--strict-optional`` (which is still accepted).
+
+
+Configuring warnings
+********************
+
+The follow flags enable warnings for code that is sound but is
+potentially problematic or redundant in some way.
+
+``--warn-redundant-casts``
+    This flag will make mypy report an error whenever your code uses
+    an unnecessary cast that can safely be removed.
+
+``--warn-unused-ignores``
+    This flag will make mypy report an error whenever your code uses
+    a ``# type: ignore`` comment on a line that is not actually
+    generating an error message.
+
+    This flag, along with the ``--warn-unsued-casts`` flag, are both
+    particularly useful when you are upgrading mypy. Previously,
+    you may have needed to add casts or ``# type: ignore`` annotations
+    to work around bugs in mypy or missing stubs for 3rd party libraries.
+
+    These two flags let you discover cases where either workarounds are
+    no longer necessary.
+
+``--no-warn-no-return``
+    By default, mypy will generate errors when a function is missing
+    return statements in some execution paths. The only exceptions
+    are when:
+
+    -   The function has a ``None`` or ``Any`` return type
+    -   The function has an empty body or a body that is just
+        ellipsis (``...``). Empty functions are often used for
+        abstract methods.
+
+    Passing in ``--no-warn-no-return`` will disable these error
+    messages in all cases.
+
+``--warn-return-any``
+    This flag causes mypy to generate a warning when returning a value
+    with type ``Any`` from a function declared with a non- ``Any`` return type.
+
+Miscellaneous strictness flags
+******************************
+
+This section documents any other flags that do not neatly fall under any
+of the above sections.
+
+``--strict``
+    This flag mode enables all optional error checking flags.  You can see the
+    list of flags enabled by strict mode in the full ``mypy --help`` output.
+
+    Note: the exact list of flags enabled by running ``--strict`` may change
+    over time.
+
+Configuring error messages
+**************************
+
+The following flags let you adjust how much detail mypy displays
+in error messages.
+
+``--show-error-context``
+    This flag will precede all errors with "note" messages explaining the
+    context of the error. For example, consider the following program:
+
+    .. code-block:: python
+
+        class Test:
+            def foo(self, x: int) -> int:
+                return x + "bar"
+
+    Mypy normally displays an error message that looks like this::
+
+        main.py:3: error: Unsupported operand types for + ("int" and "str")
+
+    If we enable this flag, the error message now looks like this::
+
+        main.py: note: In member "foo" of class "Test":
+        main.py:3: error: Unsupported operand types for + ("int" and "str")
+
+``--show-column-numbers``
+    This flag will add column offsets to error messages,
+    for example, the following indicates an error in line 12, column 9
+    (note that column offsets are 0-based)::
+
+        main.py:12:9: error: Unsupported operand types for / ("int" and "str")
+
+
+.. _incremental:
+
+Incremental mode
+****************
+
+By default, mypy will store type information into a cache. Mypy
+will use this information to avoid unnecessary recomputation when
+it type checks your code again.  This can help speed up the type
+checking process, especially when most parts of your program have
+not changed since the previous mypy run.
+
+If you want to speed up how long it takes to recheck your code
+beyond what incremental mode can offer, try running mypy in
+:ref:`daemon mode <mypy_daemon>`.
+
+``--no-incremental``
+    This flag disables incremental mode: mypy will no longer reference
+    the cache when re-run.
+
+    Note that mypy will still write out to the cache even when
+    incremental mode is disabled: see the ``--cache-dir`` flag below
+    for more details.
+
+``--cache-dir DIR``
+    By default, mypy stores all cache data inside of a folder named
+    ``.mypy_cache`` in the current directory. This flag lets you
+    change this folder. This flag can also be useful for controlling
+    cache use when using :ref:`remote caching <remote-cache>`.
+
+    Mypy will also always write to the cache even when incremental
+    mode is disabled so it can "warm up" the cache. To disable
+    writing to the cache, use ``--cache-dir=/dev/null`` (UNIX) 
+    or ``--cache-dir=nul`` (Windows).  
+
+``--skip-version-check``
+    By default, mypy will ignore cache data generated by a different
+    version of mypy. This flag disables that behavior.
+
+.. _quick-mode:
+
+``--quick-and-dirty`` 
+    This flag enables an experimental, unsafe variant of incremental mode.
+    Quick mode is faster than regular incremental mode because it only
+    re-checks modules that were modified since their cache file was
+    last written: regular incremental mode also re-checks all modules
+    that depend on one or more modules that were re-checked.
+    
+    Quick mode is unsafe because it may miss problems caused by a change
+    in a dependency.  Quick mode updates the cache, but regular incremental
+    mode ignores cache files written by quick mode.
+
+    We recommend that you try using the :ref:`mypy_daemon` before
+    attempting to use this feature.
+
+Advanced flags
+**************
+
+The following flags are useful mostly for people who are interested
+in developing or debugging mypy internals.
+
+``--pdb``
+    This flag will invoke the Python debugger when mypy encounters
+    a fatal error.
+
+``--show-traceback``, ``--tb``
+    If set, this flag will display a full traceback when mypy
+    encounters a fatal error.
+
+``--custom-typing MODULE``
+    This flag lets you use a custom module as a substitute for the
+    ``typing`` module.
+
+``--custom-typeshed-dir DIR``
+    This flag specifies the directory where mypy looks for typeshed
+    stubs, instead of the typeshed that ships with mypy.  This is
+    primarily intended to make it easier to test typeshed changes before
+    submitting them upstream, but also allows you to use a forked version of
+    typeshed.
+
+.. _shadow-file:
+
+``--shadow-file SOURCE_FILE SHADOW_FILE``
+    When mypy is asked to type check ``SOURCE_FILE``, this flag makes mypy
+    read from and type check the contents of ``SHADOW_FILE`` instead. However,
+    diagnostics will continue to refer to ``SOURCE_FILE``.
+    
+    Specifying this argument multiple times (``--shadow-file X1 Y1 --shadow-file X2 Y2``)
+    will allow mypy to perform multiple substitutions.
+
+    This allows tooling to create temporary files with helpful modifications
+    without having to change the source file in place. For example, suppose we
+    have a pipeline that adds ``reveal_type`` for certain variables.
+    This pipeline is run on ``original.py`` to produce ``temp.py``.
+    Running ``mypy --shadow-file original.py temp.py original.py`` will then
+    cause mypy to type check the contents of ``temp.py`` instead of  ``original.py``,
+    but error messages will still reference ``original.py``.
+
+Report generation 
+*****************
+
+If these flags are set, mypy will generate a report in the specified
+format into the specified directory.
+
+``--any-exprs-report DIR``
+    Causes mypy to generate a text file report documenting how many
+    expressions of type ``Any`` are present within your codebase.
+
+``--linecount-report DIR``
+    Causes mypy to generate a text file report documenting the functions
+    and lines that are typed and untyped within your codebase.
+
+``--linecoverage-report DIR``
+    Causes mypy to generate a JSON file that maps each source file's
+    absolute filename to a list of line numbers that belong to typed
+    functions in that file.
+
+``--cobertura-xml-report DIR``
+    Causes mypy to generate a Cobertura XML type checking coverage report.
+
+    You must install the `lxml`_ library to generate this report.
+
+``--html-report DIR``, ``--xslt-html-report DIR``
+    Causes mypy to generate an HTML type checking coverage report.
+
+    You must install the `lxml`_ library to generate this report.
+
+``--txt-report DIR``, ``--xslt-txt-report DIR``
+    Causes mypy to generate a text file type checking coverage report.
+
+    You must install the `lxml`_ library to generate this report.
+
+``--junit-xml JUNIT_XML`` 
+    Causes mypy to generate a JUnit XML test result document with
+    type checking results. This can make it easier to integrate mypy
+    with continuous integration (CI) tools.
+
+
+Miscellaneous 
+*************
+
+``--find-occurrences CLASS.MEMBER`` 
+    This flag will make mypy print out all usages of a class member
+    based on static type information. This feature is experimental.
+
+``--scripts-are-modules`` 
+    This flag will give command line arguments that appear to be
+    scripts (i.e. files whose name does not end in ``.py``)
+    a module name derived from the script name rather than the fixed
+    name ``__main__``.  
+    
+    This lets you check more than one script in a single mypy invocation.
+    (The default ``__main__`` is technically more correct, but if you
+    have many scripts that import a large package, the behavior enabled
+    by this flag is often more convenient.)
+
 .. _PEP 561: https://www.python.org/dev/peps/pep-0561/
 
-.. _integrating-mypy:
+.. _lxml: https://pypi.org/project/lxml/
 
-Integrating mypy into another Python application
-************************************************
-
-It is possible to integrate mypy into another Python 3 application by
-importing ``mypy.api`` and calling the ``run`` function with a parameter of type ``List[str]``, containing
-what normally would have been the command line arguments to mypy.
-
-Function ``run`` returns a ``Tuple[str, str, int]``, namely
-``(<normal_report>, <error_report>, <exit_status>)``, in which ``<normal_report>``
-is what mypy normally writes to ``sys.stdout``, ``<error_report>`` is what mypy
-normally writes to ``sys.stderr`` and ``exit_status`` is the exit status mypy normally
-returns to the operating system.
-
-A trivial example of using the api is the following::
-
-    import sys
-    from mypy import api
-
-    result = api.run(sys.argv[1:])
-
-    if result[0]:
-        print('\nType checking report:\n')
-        print(result[0])  # stdout
-
-    if result[1]:
-        print('\nError report:\n')
-        print(result[1])  # stderr
-
-    print ('\nExit status:', result[2])

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -239,6 +239,8 @@ definitions or calls.
     This flag reports an error whenever it encounters a function definition
     without type annotations.
 
+.. _disallow-incomplete-defs:
+
 ``--disallow-incomplete-defs`` 
     This flag reports an error whenever it encounters a partly annotated
     function definition.

--- a/docs/source/extending_mypy.rst
+++ b/docs/source/extending_mypy.rst
@@ -1,0 +1,52 @@
+.. _extending-mypy:
+
+Extending and integrating mypy
+==============================
+
+.. _integrating-mypy:
+
+Integrating mypy into another Python application
+************************************************
+
+It is possible to integrate mypy into another Python 3 application by
+importing ``mypy.api`` and calling the ``run`` function with a parameter of type ``List[str]``, containing
+what normally would have been the command line arguments to mypy.
+
+Function ``run`` returns a ``Tuple[str, str, int]``, namely
+``(<normal_report>, <error_report>, <exit_status>)``, in which ``<normal_report>``
+is what mypy normally writes to ``sys.stdout``, ``<error_report>`` is what mypy
+normally writes to ``sys.stderr`` and ``exit_status`` is the exit status mypy normally
+returns to the operating system.
+
+A trivial example of using the api is the following
+
+.. code-block:: python
+
+    import sys
+    from mypy import api
+
+    result = api.run(sys.argv[1:])
+
+    if result[0]:
+        print('\nType checking report:\n')
+        print(result[0])  # stdout
+
+    if result[1]:
+        print('\nError report:\n')
+        print(result[1])  # stderr
+
+    print ('\nExit status:', result[2])
+
+Extending mypy using plugins
+****************************
+
+Mypy supports a plugin system that lets you customize the way mypy type checks
+code. This can be useful if you want to extend mypy so it can type check code
+that uses a library that is difficult to express using just PEP 484 types, for
+example.
+
+*Warning:* The plugin system is extremely experimental and prone to change. If you want
+to contribute a plugin to mypy, we recommend you start by contacting the mypy
+core developers either on `gitter <https://gitter.im/python/typing>`_ or on mypy's
+`issue tracker <https://github.com/python/mypy/issues>`_.
+

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -1,3 +1,5 @@
+.. _getting-started:
+
 Getting started
 ===============
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,10 +45,12 @@ Mypy is a static type checker for Python 3 and Python 2.7.
    :maxdepth: 2
    :caption: Configuring and running mypy
 
+   running_mypy
    command_line
    config_file
    mypy_daemon
    installed_packages
+   extending_mypy
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -537,7 +537,7 @@ argument list ``index: Union[int, slice]`` and a return type of
 ``Union[T, Sequence[T]]``. If there are no annotations on the
 implementation, then the body is not type checked. If you want to
 force mypy to check the body anyways, use the ``--check-untyped-defs``
-flag (:ref:`more details here <additional-command-line-flags>`).
+flag (:ref:`more details here <untyped-definitions-and-calls>`).
 
 The variants must also also be compatible with the implementation
 type hints. In the ``MyList`` example, mypy will check that the

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -278,9 +278,8 @@ would be added to the module search path instead, and the module name
 assumed is just ``baz``.
 
 If a script (a file not ending in ``.py[i]``) is processed, the module
-name assumed is always ``__main__`` (matching the behavior of the
-Python interpreter).
-
+name assumed is ``__main__`` (matching the behavior of the
+Python interpreter), unless ``--scripts-are-modules`` is passed.
 
 
 .. _finding-imports:

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -1,0 +1,333 @@
+.. _running-mypy:
+
+Running mypy and managing imports
+=================================
+
+The :ref:`getting-started` page should have already introduced you
+to the basics of how to run mypy -- pass in the files and directories
+you want to type check via the command line::
+
+    $ mypy foo.py bar.py some_directory
+
+This page discusses in more detail how exactly to specify what files
+you want mypy to type check, how mypy discovers imported modules,
+and recommendations on how to handle any issues you may encounter
+along the way.
+
+If you are interested in learning about how to configure the
+actual way mypy type checks your code, see our 
+:ref:`command-line` guide.
+
+
+.. _specifying-code-to-be-checked:
+
+Specifying code to be checked
+*****************************
+
+Mypy lets you specify what files it should type check in several
+different ways.
+
+1.  First, you can pass in paths to Python files and directories you
+    want to type check. For example::
+
+        $ mypy file_1.py foo/file_2.py file_3.pyi some/directory
+
+    The above command tells mypy it should type check all of the provided
+    files together. In addition, mypy will recursively type check the
+    entire contents of any provided directories.
+
+    For more details about how exactly this is done, see
+    :ref:`Mapping file paths to modules <mapping-paths-to-modules>`.
+
+2.  Second, you can use the ``-m`` flag (long form: ``--module``) to
+    specify a module name to be type checked. The name of a module
+    is identical to the name you would use to import that module
+    within a Python program. For example, running::
+
+        $ mypy -m html.parser
+
+    ...will type check the module ``html.parser`` (this happens to be
+    a library stub).
+
+    Mypy will use an algorithm very similar to the one Python uses to
+    find where modules and imports are located on the file system.
+    For more details, see :ref:`finding-imports`. 
+
+3.  Third, you can the ``-p`` (long form: ``--package``) flag to
+    specify a package to be (recursively) type checked. This flag
+    is almost identical to the ``-m`` flag except that if you give it
+    a package name, mypy will recursively type check all submodules
+    and subpackages of that package. For example, running::
+
+        $ mypy -p html
+
+    ...will type check the entire ``html`` package (of library stubs).
+    In contrast, if we had used the ``-m`` flag, mypy would have type
+    checked just ``html``'s ``__init__.py`` file and anything imported
+    from there.
+
+    Note that we can specify multiple packages and modules on the
+    command line. For example::
+
+      $ mypy --package p.a --package p.b --module c
+
+4.  Fourth, you can also instruct mypy to directly type check small
+    strings as programs by using the ``-c`` (long form: ``--command``)
+    flag. For example::
+
+        $ mypy -c 'x = [1, 2]; print(x())'
+
+    ...will type check the above string as a mini-program (and in this case,
+    will report that ``List[int]`` is not callable).
+
+
+Reading a list of files from a file
+***********************************
+
+Finally, any command-line argument starting with ``@`` reads additional
+command-line arguments from the file following the ``@`` character.
+This is primarily useful if you have a file containing a list of files
+that you want to be type-checked: instead of using shell syntax like::
+
+    $ mypy $(cat file_of_files.txt)
+
+you can use this instead::
+
+    $ mypy @file_of_files.txt
+
+This file can technically also contain any command line flag, not
+just file paths. However, if you want to configure many different
+flags, the recommended approach is to use a 
+:ref:`configuration file <config-file>` instead.
+
+
+
+How mypy handles imports
+************************
+
+When mypy encounters an ``import`` statement, it will first 
+:ref:`attempt to locate <finding-imports>` that module 
+or type stubs for that module in the file system. Mypy will then
+type check the imported module. There are three different outcomes
+of this process:
+
+1.  Mypy is unable to follow the import: the module either does not
+    exist, or is a third party library that does not use type hints.
+
+2.  Mypy is able to follow and type check the import, but you did
+    not want mypy to type check that module at all.
+
+3.  Mypy is able to successfully both follow and type check the
+    module, and you want mypy to type check that module.
+
+The third outcome is what mypy will do in the ideal case. The following
+sections will discuss what to do in the other two cases.
+
+.. _ignore-missing-imports:
+
+Missing imports
+---------------
+
+When you import a module, mypy may report that it is unable to
+follow the import.
+
+This could happen if the code is importing a non-existant module
+or if the code is importing a library that does not use type hints.
+Specifically, the library is neither declared to be a 
+:ref:`PEP 561 compliant package <installed-packages>` nor has registered
+any stubs on `typeshed <https://github.com/python/typeshed>`_, the
+repository of stubs for the standard library and popular 3rd party libraries.
+
+This can cause a lot of errors that look like the following::
+
+    main.py:1: error: No library stub file for standard library module 'antigravity'
+    main.py:2: error: No library stub file for module 'flask'
+    main.py:3: error: Cannot find module named 'this_module_does_not_exist'
+
+If the module genuinely does not exist, you should of course fix the
+import statement. If the module is a module within your codebase that mypy
+is somehow unable to discover, we recommend reading the :ref:`finding-imports`
+section below to help you debug the issue.
+
+If the module is a library that does not use type hints, the easiest fix
+is to silence the error messages by adding a ``# type: ignore`` comment on
+each respective import statement.
+
+If you have many of these errors, you can silence them all at once by using
+the ``--ignore-missing-imports`` flag. We recommend using this flag only
+as a last resort: it's equivalent to adding a ``# type: ignore`` comment
+to all unresolved imports in your codebase.
+
+A more involved solution would be to reverse-engineer how the library
+works, create type hints for the library, and point mypy at those
+type hints either by passing in in via the command line or by adding
+the location of your custom stubs to the ``MYPYPATH`` environment variable.
+
+If you want to share your work, you can either open a pull request on
+typeshed or modify the library itself to be 
+:ref:`PEP 561 compliant <installed-packages>`.
+
+
+.. _follow-imports:
+
+Following imports
+-----------------
+
+Mypy is designed to :ref:`doggedly follow all imports <finding-imports>`,
+even if the imported module is not a file you explicitly wanted mypy to check.
+
+For example, suppose we have two modules ``mycode.foo`` and ``mycode.bar``:
+the former has type hints and the latter does not. We run 
+``mypy -m mycode.foo`` and mypy discovers that ``mycode.foo`` imports
+``mycode.bar``.
+
+How do we want mypy to type check ``mycode.bar``? We can configure the
+desired behavior by using the ``--follow-imports`` flag. This flag
+accepts one of four string values:
+
+-   ``normal`` (the default) follows all imports normally and 
+    type checks all top level code (as well as the bodies of all
+    functions and methods with at least one type annotation in
+    the signature).
+
+-   ``silent`` behaves in the same way as ``normal`` but will
+    additionally *suppress* any error messages.
+
+-   ``skip`` will *not* follow imports and instead will silently
+    replace the module (and *anything imported from it*) with an
+    object of type ``Any``.
+
+    (Note: this option used to be known as ``--silent-imports``.)
+
+-   ``error`` behaves in the same way as ``skip`` but is not quite as
+    silent -- it will flag the import as an error, like this::
+
+        main.py:1: note: Import of 'mycode.bar' ignored
+        main.py:1: note: (Using --follow-imports=error, module not passed on command line)
+
+If you are starting a new codebase and plan on using type hints from
+the start, we recommend you use either ``--follow-imports=normal``
+(the default) or ``--follow-imports=error``. Either option will help
+make sure you are not skipping checking any part of your codebase by
+accident.
+
+If you are planning on adding type hints to a large, existing code base,
+we recommend you start by trying to make your entire codebase (including
+files that do not use type hints) pass under ``--follow-options=normal``.
+This is usually not too difficult to do: mypy is designed to report as
+few error messages as possible when it is looking at unannotated code.
+
+If doing this is intractable, we recommend passing mypy just the files
+you want to type check and use ``--follow-imports=silent``. Even if
+mypy is unable to perfectly type check a file, it can still glean some
+useful information by parsing it (for example, understanding what methods
+a given object has). See :ref:`existing-code` for more recommendations.
+
+We do not recommend using ``skip`` unless you know what you are doing:
+while this option can be quite powerful, it can also cause many
+hard-to-debug errors.
+
+
+
+.. _mapping-paths-to-modules:
+
+Mapping file paths to modules
+*****************************
+
+One of the main ways you can tell mypy what files to type check
+is by providing mypy the paths to those files. For example::
+
+    $ mypy file_1.py foo/file_2.py file_3.pyi some/directory
+
+This section describes how exactly mypy maps the provided paths
+to modules to type check.
+
+- Files ending in ``.py`` (and stub files ending in ``.pyi``) are
+  checked as Python modules.
+
+- Files not ending in ``.py`` or ``.pyi`` are assumed to be Python
+  scripts and checked as such.
+
+- Directories representing Python packages (i.e. containing a
+  ``__init__.py[i]`` file) are checked as Python packages; all
+  submodules and subpackages will be checked (subpackages must
+  themselves have a ``__init__.py[i]`` file).
+
+- Directories that don't represent Python packages (i.e. not directly
+  containing an ``__init__.py[i]`` file) are checked as follows:
+
+  - All ``*.py[i]`` files contained directly therein are checked as
+    toplevel Python modules;
+
+  - All packages contained directly therein (i.e. immediate
+    subdirectories with an ``__init__.py[i]`` file) are checked as
+    toplevel Python packages.
+
+One more thing about checking modules and packages: if the directory
+*containing* a module or package specified on the command line has an
+``__init__.py[i]`` file, mypy assigns these an absolute module name by
+crawling up the path until no ``__init__.py[i]`` file is found. 
+
+For example, suppose we run the command ``mypy foo/bar/baz.py`` where
+``foo/bar/__init__.py`` exists but ``foo/__init__.py`` does not.  Then
+the module name assumed is ``bar.baz`` and the directory ``foo`` is
+added to mypy's module search path. 
+
+On the other hand, if ``foo/bar/__init__.py`` did not exist, ``foo/bar``
+would be added to the module search path instead, and the module name
+assumed is just ``baz``.
+
+If a script (a file not ending in ``.py[i]``) is processed, the module
+name assumed is always ``__main__`` (matching the behavior of the
+Python interpreter).
+
+
+
+.. _finding-imports:
+
+How imports are found
+*********************
+
+When mypy encounters an ``import`` statement or receives module
+names from the command line via the ``--module`` or ``--package``
+flags, mypy tries to find the module on the file system similar
+to the way Python finds it. However, there are some differences.
+
+First, mypy has its own search path.
+This is computed from the following items:
+
+- The ``MYPYPATH`` environment variable
+  (a colon-separated list of directories).
+- The directories containing the sources given on the command line
+  (see below).
+- The installed packages marked as safe for type checking (see
+  :ref:`PEP 561 support <installed-packages>`)
+- The relevant directories of the
+  `typeshed <https://github.com/python/typeshed>`_ repo.
+
+For sources given on the command line, the path is adjusted by crawling
+up from the given file or package to the nearest directory that does not
+contain an ``__init__.py`` or ``__init__.pyi`` file.
+
+Second, mypy searches for stub files in addition to regular Python files
+and packages.
+The rules for searching for a module ``foo`` are as follows:
+
+- The search looks in each of the directories in the search path
+  (see above) until a match is found.
+- If a package named ``foo`` is found (i.e. a directory
+  ``foo`` containing an ``__init__.py`` or ``__init__.pyi`` file)
+  that's a match.
+- If a stub file named ``foo.pyi`` is found, that's a match.
+- If a Python module named ``foo.py`` is found, that's a match.
+
+These matches are tried in order, so that if multiple matches are found
+in the same directory on the search path
+(e.g. a package and a Python file, or a stub file and a Python file)
+the first one in the above list wins.
+
+In particular, if a Python file and a stub file are both present in the
+same directory on the search path, only the stub file is used.
+(However, if the files are in different directories, the one found
+in the earlier directory is used.)
+

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -53,7 +53,7 @@ different ways.
     find where modules and imports are located on the file system.
     For more details, see :ref:`finding-imports`. 
 
-3.  Third, you can the ``-p`` (long form: ``--package``) flag to
+3.  Third, you can use the ``-p`` (long form: ``--package``) flag to
     specify a package to be (recursively) type checked. This flag
     is almost identical to the ``-m`` flag except that if you give it
     a package name, mypy will recursively type check all submodules

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -213,7 +213,7 @@ accident.
 
 If you are planning on adding type hints to a large, existing code base,
 we recommend you start by trying to make your entire codebase (including
-files that do not use type hints) pass under ``--follow-options=normal``.
+files that do not use type hints) pass under ``--follow-imports=normal``.
 This is usually not too difficult to do: mypy is designed to report as
 few error messages as possible when it is looking at unannotated code.
 


### PR DESCRIPTION
This commit reorganizes our documentation about the command line along with several miscellaneous fixes.

In short, I moved the stuff about running mypy/managing imports to a separate file and reorganized the command line section.

Specific major changes include:

1.  I split up information about running mypy and information about mypy's command line flags into two separate pages: "Running mypy and managing imports" and "The mypy command line".

    Rationale: I felt the current documentation on running mypy is very dense: it includes a lot of info on managing imports, how mypy discovers files, etc that I think were really only of interest to advanced programmers who are in the middle of trying to get mypy to run on a complex code base.

    I think splitting up the text into two makes it easier for both beginners and experts to get the info they're looking for.

2.  I rewrote the section about how mypy handles the `--ignore-missing-imports` and `--follow-imports` flags (Now located in "Running mypy..." > "How mypy handles imports").

    In particular, it more clearly distinguishes how to handle missing imports vs handling imports to files you didn't want type check: the former is applicable to everybody; the latter is only really applicable to people who are progressively adding type hints.

3.  I moved information about how mypy searches the file system and resolves imports to the bottom of the "Running mypy..." section.

    I think most people don't really need that info to start: running `mypy my_whole_codebase` is generally a good starting point.

4.  I reorganized the command line section to mirror how the flags are grouped when you run `mypy --help`.

Some minor changes:

1.  I switched to using [definition lists][0] instead of bullet points to document flags: I think it looks cleaner.

2.  I removed the `mypy --help` summary from the command line page: I don't really think anybody was reading that at all.

3.  I added documentations about the `--warn-unused-casts`, `-warn-unused-ignores`, `--show-error-contexts`, `--warn-unsed-configs`, and the different report flags. Those flags were apparently undocumented.

    I did *not* document `--cache-fine-grained` and `--memory-xml-report` mostly because I don't actually understand what exactly those do.

4.  I added moved the note about integrating mypy into a separate page, and added a brief note about plugins to that page.


  [0]: https://sphinx-rtd-theme.readthedocs.io/en/latest/demo/lists_tables.html#definition-lists