### PR TITLE
 Implement a basic meet for overloaded types

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -321,7 +321,12 @@ class TypeMeetVisitor(TypeVisitor[Type]):
         if isinstance(s, FunctionLike):
             if s.items() == t.items():
                 return Overloaded(t.items())
-            return meet_types(t.fallback, s.fallback)
+            elif is_subtype(s, t):
+                return s
+            elif is_subtype(t, s):
+                return t
+            else:
+                return meet_types(t.fallback, s.fallback)
         return meet_types(t.fallback, s)
 
     def visit_tuple_type(self, t: TupleType) -> Type:

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4078,3 +4078,25 @@ g(3)  # E: No overload variant of "g" matches argument type "int" \
       # N:     def g(x: A) -> None \
       # N:     def g(x: B) -> None \
       # N:     def g(x: C) -> None
+
+[case testOverloadedInIter]
+from lib import f, g
+
+for fun in [f, g]:
+    reveal_type(fun)  # E: Revealed type is 'Overload(def (x: builtins.int) -> builtins.str, def (x: builtins.str) -> builtins.int)'
+[file lib.pyi]
+from typing import overload
+
+@overload
+def f(x: int) -> str: ...
+@overload
+def f(x: str) -> int: ...
+
+@overload
+def g(x: int) -> str: ...
+@overload
+def g(x: str) -> int: ...
+
+[builtins fixtures/list.pyi]
+[typing fixtures/typing-full.pyi]
+[out]


### PR DESCRIPTION
The algorithm is super basic. But it is still better than crashing with `NotImplementedError`.