### PR TITLE
Support type aliases in builtins

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -19,7 +19,7 @@ from mypy.nodes import (
     UnicodeExpr, OpExpr, UnaryExpr, LambdaExpr, TempNode, SymbolTableNode,
     Context, Decorator, PrintStmt, BreakStmt, PassStmt, ContinueStmt,
     ComparisonExpr, StarExpr, EllipsisExpr, RefExpr, PromoteExpr,
-    Import, ImportFrom, ImportAll, ImportBase,
+    Import, ImportFrom, ImportAll, ImportBase, TypeAlias,
     ARG_POS, ARG_STAR, LITERAL_TYPE, MDEF, GDEF,
     CONTRAVARIANT, COVARIANT, INVARIANT,
 )
@@ -3171,6 +3171,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # Assume that the name refers to a type.
         sym = self.lookup_qualified(name)
         node = sym.node
+        if isinstance(node, TypeAlias):
+            assert isinstance(node.target, Instance)
+            node = node.target.type
         assert isinstance(node, TypeInfo)
         any_type = AnyType(TypeOfAny.from_omitted_generics)
         return Instance(node, [any_type] * len(node.defn.type_vars))

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1309,7 +1309,10 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         if not sym:
             return None
         node = sym.node
-        assert isinstance(node, TypeInfo)
+        if isinstance(node, TypeAlias):
+            assert isinstance(node.target, Instance)
+            node = node.target.type
+        assert isinstance(node, TypeInfo), node
         if args is not None:
             # TODO: assert len(args) == len(node.defn.type_vars)
             return Instance(node, args)

--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -404,3 +404,11 @@ def f():  # no annotation
 path = 'test'
 path = os.path.join(f(), 'test.py')
 [out]
+
+[case testBytesWorkInPython2WithFullStubs_python2]
+MYPY = False
+if MYPY:
+    import lib
+[file lib.pyi]
+x = b'abc'
+[out]


### PR DESCRIPTION
This fixes a recently discovered internal crash. This should probably go into the release, since this is a regression.