### PR TITLE
Add builtin aliases when updating typing

### DIFF
--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -522,7 +522,14 @@ def update_module_isolated(module: str,
 
     # Process the changed file.
     state.parse_file()
+    assert state.tree is not None, "file must be at least parsed"
     # TODO: state.fix_suppressed_dependencies()?
+    if module == 'typing':
+        # We need to manually add typing aliases to builtins, like we
+        # do in process_stale_scc. Because this can't be done until
+        # builtins is also loaded, there isn't an obvious way to
+        # refactor this.
+        manager.semantic_analyzer.add_builtin_aliases(state.tree)
     try:
         state.semantic_analysis()
     except CompileError as err:
@@ -533,7 +540,6 @@ def update_module_isolated(module: str,
     state.semantic_analysis_apply_patches()
 
     # Merge old and new ASTs.
-    assert state.tree is not None, "file must be at least parsed"
     new_modules_dict = {module: state.tree}  # type: Dict[str, Optional[MypyFile]]
     replace_modules_with_new_variants(manager, graph, {orig_module: orig_tree}, new_modules_dict)
 

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1233,9 +1233,10 @@ main:2: error: Module 'a' has no attribute 'f'
 [case testRefreshTyping]
 from typing import Sized
 from c import A
+import z
 
 # Force typing to get refreshed by using a protocol from it
-x : Sized = A()
+x: Sized = A()
 
 [file c.py]
 class D:
@@ -1246,11 +1247,11 @@ class C:
     def __len__(self) -> int: return 0
 A = C
 [file z.py]
-from typing import Tuple, List
+from typing import List
 T = List[int]
 [file z.py.2]
-from typing import Tuple, List
-T = List[int]
+from typing import List
+T = List[int]  # yo
 [builtins fixtures/list.pyi]
 [out]
 ==

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1230,6 +1230,31 @@ def f() -> None: pass
 ==
 main:2: error: Module 'a' has no attribute 'f'
 
+[case testRefreshTyping]
+from typing import Sized
+from c import A
+
+# Force typing to get refreshed by using a protocol from it
+x : Sized = A()
+
+[file c.py]
+class D:
+    def __len__(self) -> int: return 0
+A = D
+[file c.py.2]
+class C:
+    def __len__(self) -> int: return 0
+A = C
+[file z.py]
+from typing import Tuple, List
+T = List[int]
+[file z.py.2]
+from typing import Tuple, List
+T = List[int]
+[builtins fixtures/list.pyi]
+[out]
+==
+
 [case testNamedTupleRefresh]
 from typing import NamedTuple
 from a import f


### PR DESCRIPTION
typing updates can be provoked by triggering protocols from typing.

Failing to do this can manifest as crashes and spurious "invalid type"
messages.