### PR TITLE
Fix linkcheck errors

### DIFF
--- a/docs/source/additional_features.rst
+++ b/docs/source/additional_features.rst
@@ -9,7 +9,7 @@ of the previous sections.
 The attrs package
 *****************
 
-`attrs <https://www.attrs.org/en/stable>`_ is a package that lets you define
+`attrs <http://www.attrs.org/en/stable>`_ is a package that lets you define
 classes without writing boilerplate code. Mypy can detect uses of the
 package and will generate the necessary method definitions for decorated
 classes using the type annotations it finds.
@@ -75,7 +75,7 @@ Caveats/Known Issues
   will complain about not understanding the argument and the type annotation in
   ``__init__`` will be replaced by ``Any``.
 
-* `Validator decorators <http://www.attrs.org/en/stable/examples.html#decorator>`_
+* `Validator decorators <http://www.attrs.org/en/stable/examples.html#validators>`_
   and `default decorators <http://www.attrs.org/en/stable/examples.html#defaults>`_
   are not type-checked against the attribute they are setting/validating.
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -184,7 +184,7 @@ resources:
 * Read :ref:`existing-code` if you have a significant existing
   codebase without many type annotations.
 
-* Read the `blog post <http://blog.zulip.org/2016/10/13/static-types-in-python-oh-mypy/>`_
+* Read the `blog post <https://blog.zulip.org/2016/10/13/static-types-in-python-oh-mypy/>`_
   about the Zulip project's experiences with adopting mypy.
 
 * If you prefer watching talks instead of reading, here are


### PR DESCRIPTION
Fix attrs' links

 - www.attrs.org doesn't have a SSL certificate, so don't link to HTTPS.
 - Fix invalid anchor tag for validator decorators.

Use HTTPS scheme for Zulip blog link

Fixes the following linkcheck errors:

```
(line   12) broken    https://www.attrs.org/en/stable - HTTPSConnectionPool(host='www.attrs.org', port=443): Max retries exceeded with url: /en/stable (Caused by SSLError(SSLCertVerificationError("hostname 'www.attrs.org' doesn't match either of '*.readthedocs.org', 'readthedocs.org'")))
(line   78) broken    http://www.attrs.org/en/stable/examples.html#decorator - Anchor 'decorator' not found
```

```
(line  187) redirect  http://blog.zulip.org/2016/10/13/static-types-in-python-oh-mypy/ - permanently to https://blog.zulip.org/2016/10/13/static-types-in-python-oh-mypy/
```