### PR TITLE
Allow use of entry-points like strings in mypy.ini to register plugins

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -585,12 +585,14 @@ def load_plugins(options: Options, errors: Errors) -> Plugin:
         func_name = 'plugin'
         plugin_dir = None  # type: Optional[str]
         fnam = os.path.basename(plugin_path)
-        if fnam.endswith('.py'):
+        if plugin_path.endswith('.py'):
             if not os.path.isfile(plugin_path):
                 plugin_error("Can't find plugin '{}'".format(plugin_path))
             plugin_dir = os.path.dirname(plugin_path)
             module_name = fnam[:-3]
             sys.path.insert(0, plugin_dir)
+        elif re.search(r'\/', plugin_path):
+            plugin_error("Plugin '{}' does not have a .py extension".format(fnam))
         else:
             if ':' in plugin_path:
                 module_name, func_name = plugin_path.rsplit(':', 1)
@@ -608,7 +610,7 @@ def load_plugins(options: Options, errors: Errors) -> Plugin:
                 del sys.path[0]
 
         if not hasattr(module, func_name):
-            plugin_error('Plugin \'{}\' does not define entry point function "%s"'.format(
+            plugin_error('Plugin \'{}\' does not define entry point function "{}"'.format(
                 plugin_path, func_name))
 
         try:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -580,12 +580,12 @@ def load_plugins(options: Options, errors: Errors) -> Plugin:
     custom_plugins = []  # type: List[Plugin]
     errors.set_file(options.config_file, None)
     for plugin_path in options.plugins:
-        # Plugin paths are relative to the config file location.
         func_name = 'plugin'
         plugin_dir = None  # type: Optional[str]
         if ':' in os.path.basename(plugin_path):
             plugin_path, func_name = plugin_path.rsplit(':', 1)
         if plugin_path.endswith('.py'):
+            # Plugin paths can be relative to the config file location.
             plugin_path = os.path.join(os.path.dirname(options.config_file), plugin_path)
             if not os.path.isfile(plugin_path):
                 plugin_error("Can't find plugin '{}'".format(plugin_path))
@@ -593,7 +593,7 @@ def load_plugins(options: Options, errors: Errors) -> Plugin:
             fnam = os.path.basename(plugin_path)
             module_name = fnam[:-3]
             sys.path.insert(0, plugin_dir)
-        elif re.search(r'\/', plugin_path):
+        elif re.search(r'[\\/]', plugin_path):
             fnam = os.path.basename(plugin_path)
             plugin_error("Plugin '{}' does not have a .py extension".format(fnam))
         else:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -602,8 +602,7 @@ def load_plugins(options: Options, errors: Errors) -> Plugin:
         try:
             module = importlib.import_module(module_name)
         except Exception:
-            print('Error importing plugin {}\n'.format(plugin_path))
-            raise  # Propagate to display traceback
+            plugin_error("Error importing plugin '{}'".format(plugin_path))
         finally:
             if plugin_dir is not None:
                 assert sys.path[0] == plugin_dir

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -581,23 +581,23 @@ def load_plugins(options: Options, errors: Errors) -> Plugin:
     errors.set_file(options.config_file, None)
     for plugin_path in options.plugins:
         # Plugin paths are relative to the config file location.
-        plugin_path = os.path.join(os.path.dirname(options.config_file), plugin_path)
         func_name = 'plugin'
         plugin_dir = None  # type: Optional[str]
-        fnam = os.path.basename(plugin_path)
+        if ':' in os.path.basename(plugin_path):
+            plugin_path, func_name = plugin_path.rsplit(':', 1)
         if plugin_path.endswith('.py'):
+            plugin_path = os.path.join(os.path.dirname(options.config_file), plugin_path)
             if not os.path.isfile(plugin_path):
                 plugin_error("Can't find plugin '{}'".format(plugin_path))
             plugin_dir = os.path.dirname(plugin_path)
+            fnam = os.path.basename(plugin_path)
             module_name = fnam[:-3]
             sys.path.insert(0, plugin_dir)
         elif re.search(r'\/', plugin_path):
+            fnam = os.path.basename(plugin_path)
             plugin_error("Plugin '{}' does not have a .py extension".format(fnam))
         else:
-            if ':' in plugin_path:
-                module_name, func_name = plugin_path.rsplit(':', 1)
-            else:
-                module_name = plugin_path
+            module_name = plugin_path
 
         try:
             module = importlib.import_module(module_name)

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Set, Tuple
 
 from mypy import build
 from mypy.build import BuildSource, Graph, SearchPaths
-from mypy.test.config import test_temp_dir
+from mypy.test.config import test_temp_dir, test_data_prefix
 from mypy.test.data import DataDrivenTestCase, DataSuite, FileOperation, UpdateFile
 from mypy.test.helpers import (
     assert_string_arrays_equal, normalize_error_messages, assert_module_equivalence,
@@ -152,6 +152,9 @@ class TypeCheckSuite(DataSuite):
             sources.append(BuildSource(program_path, module_name,
                                        None if incremental_step else program_text))
 
+        plugin_dir = os.path.join(test_data_prefix, 'plugins')
+        sys.path.insert(0, plugin_dir)
+
         res = None
         try:
             res = build.build(sources=sources,
@@ -160,6 +163,10 @@ class TypeCheckSuite(DataSuite):
             a = res.errors
         except CompileError as e:
             a = e.messages
+        finally:
+            assert sys.path[0] == plugin_dir
+            del sys.path[0]
+
         a = normalize_error_messages(a)
 
         # Make sure error messages match

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -3,13 +3,21 @@
 -- Note: Plugins used by tests live under test-data/unit/plugins. Defining
 --       plugin files in test cases does not work reliably.
 
-[case testFunctionPlugin]
+[case testFunctionPluginFile]
 # flags: --config-file tmp/mypy.ini
 def f() -> str: ...
 reveal_type(f())  # E: Revealed type is 'builtins.int'
 [file mypy.ini]
 [[mypy]
 plugins=<ROOT>/test-data/unit/plugins/fnplugin.py
+
+[case testFunctionPlugin]
+# flags: --config-file tmp/mypy.ini
+def f() -> str: ...
+reveal_type(f())  # E: Revealed type is 'builtins.int'
+[file mypy.ini]
+[[mypy]
+plugins=fnplugin
 
 [case testFunctionPluginFullnameIsNotNone]
 # flags: --config-file tmp/mypy.ini
@@ -35,13 +43,34 @@ reveal_type(h())  # E: Revealed type is 'Any'
 plugins=<ROOT>/test-data/unit/plugins/fnplugin.py,
   <ROOT>/test-data/unit/plugins/plugin2.py
 
-[case testMissingPlugin]
+[case testTwoPluginsMixedType]
+# flags: --config-file tmp/mypy.ini
+def f(): ...
+def g(): ...
+def h(): ...
+reveal_type(f())  # E: Revealed type is 'builtins.int'
+reveal_type(g())  # E: Revealed type is 'builtins.str'
+reveal_type(h())  # E: Revealed type is 'Any'
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/fnplugin.py, plugin2
+
+[case testMissingPluginFile]
 # flags: --config-file tmp/mypy.ini
 [file mypy.ini]
 [[mypy]
 plugins=missing.py
 [out]
 tmp/mypy.ini:2: error: Can't find plugin 'tmp/missing.py'
+--' (work around syntax highlighting)
+
+[case testMissingPlugin]
+# flags: --config-file tmp/mypy.ini
+[file mypy.ini]
+[[mypy]
+plugins=missing
+[out]
+tmp/mypy.ini:2: error: Error importing plugin 'missing'
 --' (work around syntax highlighting)
 
 [case testMultipleSectionsDefinePlugin]
@@ -73,6 +102,22 @@ tmp/mypy.ini:2: error: Plugin 'badext.pyi' does not have a .py extension
  plugins = <ROOT>/test-data/unit/plugins/noentry.py
 [out]
 tmp/mypy.ini:2: error: Plugin '<ROOT>/test-data/unit/plugins/noentry.py' does not define entry point function "plugin"
+
+[case testCustomPluginEntryPointFile]
+# flags: --config-file tmp/mypy.ini
+def f() -> str: ...
+reveal_type(f())  # E: Revealed type is 'builtins.int'
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/customentry.py:register
+
+[case testCustomPluginEntryPoint]
+# flags: --config-file tmp/mypy.ini
+def f() -> str: ...
+reveal_type(f())  # E: Revealed type is 'builtins.int'
+[file mypy.ini]
+[[mypy]
+plugins=customentry:register
 
 [case testInvalidPluginEntryPointReturnValue]
 # flags: --config-file tmp/mypy.ini

--- a/test-data/unit/plugins/customentry.py
+++ b/test-data/unit/plugins/customentry.py
@@ -1,0 +1,14 @@
+from mypy.plugin import Plugin
+
+class MyPlugin(Plugin):
+    def get_function_hook(self, fullname):
+        if fullname == '__main__.f':
+            return my_hook
+        assert fullname is not None
+        return None
+
+def my_hook(ctx):
+    return ctx.api.named_generic_type('builtins.int', [])
+
+def register(version):
+    return MyPlugin


### PR DESCRIPTION
This addresses issue https://github.com/python/mypy/issues/3916.  Unlike [my last attempt](https://github.com/python/mypy/pull/4734) this does *not* use `pkg_resources`.

It is currently possible for third-parties to author plugins and load them via mypy.ini, using a path to a plugin file. e.g.

```ini
[mypy]
plugins = path/plugin1.py, path/plugin2.py
```

This PR extends the syntax to allow plugins to be specified using entry-points-like strings:

```ini
[mypy]
plugins = path/plugin1.py, plugin2:register
```

Reservations [have been expressed](https://github.com/python/mypy/issues/3916#issuecomment-327037502) about the still-experimental nature of the plugin API.  In rebuttal, I would say:
- It's already possible to load third-party plugins, it's just inconvenient
- Allowing developers to synchronize release of their plugins with their libraries will ensure compatibility and help reduce spurious bug reports.

Perhaps a compromise is to simply not advertise this feature extensively yet.  It will enable projects like attrs, which are at the bleeding edge of static type checking and well aware of the unsupported risks involved, to push the tooling forward, while shouldering the responsibility of making adjustments to our plugin if the API changes. 

