### PR TITLE
Add experimental hidden flag to tweak dependencies

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2217,7 +2217,8 @@ class State:
             return
         self.fine_grained_deps = get_dependencies(target=self.tree,
                                                   type_map=self.type_map(),
-                                                  python_version=self.options.python_version)
+                                                  python_version=self.options.python_version,
+                                                  options=self.manager.options)
 
     def valid_references(self) -> Set[str]:
         assert self.ancestors is not None
@@ -2570,7 +2571,8 @@ def dispatch(sources: List[BuildSource], manager: BuildManager) -> Graph:
     if manager.options.dump_deps:
         # This speeds up startup a little when not using the daemon mode.
         from mypy.server.deps import dump_all_dependencies
-        dump_all_dependencies(manager.modules, manager.all_types, manager.options.python_version)
+        dump_all_dependencies(manager.modules, manager.all_types,
+                              manager.options.python_version, manager.options)
     return graph
 
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -612,6 +612,11 @@ def process_options(args: List[str],
     # --local-partial-types disallows partial types spanning module top level and a function
     # (implicitly defined in fine-grained incremental mode)
     parser.add_argument('--local-partial-types', action='store_true', help=argparse.SUPPRESS)
+    # --tweaked-deps adds some more dependencies that are not semantically needed, but
+    # may be helpful to determine relative importance of classes and functions for overall
+    # type precision in a code base. It also _removes_ some deps, so this flag should be never
+    # used except for generating code stats.
+    parser.add_argument('--tweaked-deps', action='store_true', help=argparse.SUPPRESS)
     # --bazel changes some behaviors for use with Bazel (https://bazel.build).
     parser.add_argument('--bazel', action='store_true', help=argparse.SUPPRESS)
     # --package-root adds a directory below which directories are considered

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -612,11 +612,12 @@ def process_options(args: List[str],
     # --local-partial-types disallows partial types spanning module top level and a function
     # (implicitly defined in fine-grained incremental mode)
     parser.add_argument('--local-partial-types', action='store_true', help=argparse.SUPPRESS)
-    # --tweaked-deps adds some more dependencies that are not semantically needed, but
+    # --logical-deps adds some more dependencies that are not semantically needed, but
     # may be helpful to determine relative importance of classes and functions for overall
     # type precision in a code base. It also _removes_ some deps, so this flag should be never
-    # used except for generating code stats.
-    parser.add_argument('--tweaked-deps', action='store_true', help=argparse.SUPPRESS)
+    # used except for generating code stats. This also automatically enables --cache-fine-grained.
+    # NOTE: This is an experimental option that may be modified or removed at any time.
+    parser.add_argument('--logical-deps', action='store_true', help=argparse.SUPPRESS)
     # --bazel changes some behaviors for use with Bazel (https://bazel.build).
     parser.add_argument('--bazel', action='store_true', help=argparse.SUPPRESS)
     # --package-root adds a directory below which directories are considered
@@ -780,6 +781,10 @@ def process_options(args: List[str],
     # Let quick_and_dirty imply incremental.
     if options.quick_and_dirty:
         options.incremental = True
+
+    # Let logical_deps imply cache_fine_grained (otherwise the former is useless).
+    if options.logical_deps:
+        options.cache_fine_grained = True
 
     # Set target.
     if special_opts.modules + special_opts.packages:

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -193,6 +193,7 @@ class Options:
         self.show_column_numbers = False  # type: bool
         self.dump_graph = False
         self.dump_deps = False
+        self.tweaked_deps = False
         # If True, partial types can't span a module top level and a function
         self.local_partial_types = False
         # Some behaviors are changed when using Bazel (https://bazel.build).

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -193,7 +193,7 @@ class Options:
         self.show_column_numbers = False  # type: bool
         self.dump_graph = False
         self.dump_deps = False
-        self.tweaked_deps = False
+        self.logical_deps = False
         # If True, partial types can't span a module top level and a function
         self.local_partial_types = False
         # Some behaviors are changed when using Bazel (https://bazel.build).

--- a/mypy/test/testdeps.py
+++ b/mypy/test/testdeps.py
@@ -15,7 +15,7 @@ from mypy.options import Options
 from mypy.server.deps import get_dependencies
 from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase, DataSuite
-from mypy.test.helpers import assert_string_arrays_equal
+from mypy.test.helpers import assert_string_arrays_equal, parse_options
 from mypy.types import Type
 from mypy.typestate import TypeState
 
@@ -41,7 +41,13 @@ class GetDependenciesSuite(DataSuite):
             python_version = defaults.PYTHON2_VERSION
         else:
             python_version = defaults.PYTHON3_VERSION
-        messages, files, type_map = self.build(src, python_version)
+        options = parse_options(src, testcase, incremental_step=1)
+        options.use_builtins_fixtures = True
+        options.show_traceback = True
+        options.cache_dir = os.devnull
+        options.python_version = python_version
+        options.export_types = True
+        messages, files, type_map = self.build(src, options)
         a = messages
         if files is None or type_map is None:
             if not a:
@@ -53,7 +59,7 @@ class GetDependenciesSuite(DataSuite):
                                                                            'typing',
                                                                            'mypy_extensions',
                                                                            'enum'):
-                    new_deps = get_dependencies(files[module], type_map, python_version)
+                    new_deps = get_dependencies(files[module], type_map, python_version, options)
                     for source in new_deps:
                         deps[source].update(new_deps[source])
 
@@ -75,15 +81,9 @@ class GetDependenciesSuite(DataSuite):
 
     def build(self,
               source: str,
-              python_version: Tuple[int, int]) -> Tuple[List[str],
-                                                        Optional[Dict[str, MypyFile]],
-                                                        Optional[Dict[Expression, Type]]]:
-        options = Options()
-        options.use_builtins_fixtures = True
-        options.show_traceback = True
-        options.cache_dir = os.devnull
-        options.python_version = python_version
-        options.export_types = True
+              options: Options) -> Tuple[List[str],
+                                         Optional[Dict[str, MypyFile]],
+                                         Optional[Dict[Expression, Type]]]:
         try:
             result = build.build(sources=[BuildSource('main', None, source)],
                                  options=options,

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -1135,8 +1135,8 @@ def f(b: B) -> None:
 <m.B> -> <m.f>, m.B, m.f
 <m.g> -> m.f
 
-[case testTweakedDecorator]
-# flags: --tweaked-deps
+[case testLogicalDecorator]
+# flags: --logical-deps
 from mod import dec
 @dec
 def f() -> None:
@@ -1149,8 +1149,22 @@ def dec(f: Callable[[], None]) -> Callable[[], None]:
 <m.f> -> m
 <mod.dec> -> <m.f>, m
 
-[case testTweakedDecoratorMember]
-# flags: --tweaked-deps
+[case testLogicalDecoratorWithArgs]
+# flags: --logical-deps
+from mod import dec
+@dec(str())
+def f() -> None:
+    pass
+[file mod.py]
+from typing import Callable
+def dec(arg: str) -> Callable[[Callable[[], None]], Callable[[], None]]:
+    pass
+[out]
+<m.f> -> m
+<mod.dec> -> <m.f>, m
+
+[case testLogicalDecoratorMember]
+# flags: --logical-deps
 import mod
 @mod.dec
 def f() -> None:
@@ -1164,8 +1178,8 @@ def dec(f: Callable[[], None]) -> Callable[[], None]:
 <mod.dec> -> <m.f>, m
 <mod> -> m
 
-[case testTweakedDefinition]
-# flags: --tweaked-deps
+[case testLogicalDefinition]
+# flags: --logical-deps
 from mod import func
 b = func()
 [file mod.py]
@@ -1175,8 +1189,24 @@ def func() -> int:
 <m.b> -> m
 <mod.func> -> <m.b>, m
 
-[case testTweakedDefinitionMember]
-# flags: --tweaked-deps
+[case testLogicalDefinitionIrrelevant]
+# flags: --logical-deps
+from mod import func
+def outer() -> None:
+    a = func()
+b: int = func()
+c = int()
+c = func()
+[file mod.py]
+def func() -> int:
+    pass
+[out]
+<m.b> -> m
+<m.c> -> m
+<mod.func> -> m, m.outer
+
+[case testLogicalDefinitionMember]
+# flags: --logical-deps
 import mod
 b = mod.func()
 [file mod.py]
@@ -1187,8 +1217,8 @@ def func() -> int:
 <mod.func> -> <m.b>, m
 <mod> -> m
 
-[case testTweakedDefinitionClass]
-# flags: --tweaked-deps
+[case testLogicalDefinitionClass]
+# flags: --logical-deps
 from mod import Cls
 b = Cls()
 [file mod.py]
@@ -1202,8 +1232,8 @@ class Cls(Base): pass
 <mod.Cls.__new__> -> m
 <mod.Cls> -> <m.b>, m
 
-[case testTweakedBaseAttribute]
-# flags: --tweaked-deps
+[case testLogicalBaseAttribute]
+# flags: --logical-deps
 from mod import C
 class D(C):
     x: int

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -1134,3 +1134,88 @@ def f(b: B) -> None:
 <m.B.__setitem__> -> m.f
 <m.B> -> <m.f>, m.B, m.f
 <m.g> -> m.f
+
+[case testTweakedDecorator]
+# flags: --tweaked-deps
+from mod import dec
+@dec
+def f() -> None:
+    pass
+[file mod.py]
+from typing import Callable
+def dec(f: Callable[[], None]) -> Callable[[], None]:
+    pass
+[out]
+<m.f> -> m
+<mod.dec> -> <m.f>, m
+
+[case testTweakedDecoratorMember]
+# flags: --tweaked-deps
+import mod
+@mod.dec
+def f() -> None:
+    pass
+[file mod.py]
+from typing import Callable
+def dec(f: Callable[[], None]) -> Callable[[], None]:
+    pass
+[out]
+<m.f> -> m
+<mod.dec> -> <m.f>, m
+<mod> -> m
+
+[case testTweakedDefinition]
+# flags: --tweaked-deps
+from mod import func
+b = func()
+[file mod.py]
+def func() -> int:
+    pass
+[out]
+<m.b> -> m
+<mod.func> -> <m.b>, m
+
+[case testTweakedDefinitionMember]
+# flags: --tweaked-deps
+import mod
+b = mod.func()
+[file mod.py]
+def func() -> int:
+    pass
+[out]
+<m.b> -> m
+<mod.func> -> <m.b>, m
+<mod> -> m
+
+[case testTweakedDefinitionClass]
+# flags: --tweaked-deps
+from mod import Cls
+b = Cls()
+[file mod.py]
+class Base:
+    def __init__(self) -> None: pass
+class Cls(Base): pass
+[out]
+<m.b> -> m
+<mod.Base.__init__> -> <m.b>
+<mod.Cls.__init__> -> m
+<mod.Cls.__new__> -> m
+<mod.Cls> -> <m.b>, m
+
+[case testTweakedBaseAttribute]
+# flags: --tweaked-deps
+from mod import C
+class D(C):
+    x: int
+[file mod.py]
+class C:
+    x: int
+    y: int
+[out]
+<m.D.x> -> m
+<m.D> -> m.D
+<mod.C.(abstract)> -> <m.D.__init__>, m
+<mod.C.__init__> -> <m.D.__init__>
+<mod.C.__new__> -> <m.D.__new__>
+<mod.C.x> -> <m.D.x>
+<mod.C> -> m, m.D


### PR DESCRIPTION
This flag will tweak fine grained dependencies to reflect propagation of type (im)precision instead of actual semantic dependencies. The flag should never be used to run actual type check, _only_ to analyze type coverage in a code base.

The flag could be useful when annotating legacy code, to check which functions (decorators, base classes, variables) are most important to annotate first.