### PR TITLE
Update --logical-deps to handle missing imports

### DIFF
--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -1249,3 +1249,46 @@ class C:
 <mod.C.__new__> -> <m.D.__new__>
 <mod.C.x> -> <m.D.x>
 <mod.C> -> m, m.D
+
+[case testLogicalIgnoredImport1]
+# flags: --logical-deps --ignore-missing-imports
+import foo
+def f() -> None:
+    foo.x
+[out]
+<foo.x> -> m.f
+<foo> -> m, m.f
+
+[case testLogicalIgnoredImport2]
+# flags: --logical-deps --ignore-missing-imports
+import foo.bar
+import a.b.c.d
+def f() -> None:
+    foo.bar.x
+    foo.bar.x.y
+    a.b.c.d.e
+[out]
+<a.b.c.d.e> -> m.f
+<a.b.c.d> -> m, m.f
+<a.b.c> -> m.f
+<a.b> -> m.f
+<a> -> m.f
+<foo.bar.x.y> -> m.f
+<foo.bar.x> -> m.f
+<foo.bar> -> m, m.f
+<foo> -> m.f
+
+[case testLogicalIgnoredFromImport]
+# flags: --logical-deps --ignore-missing-imports
+from foo.bar import f, C
+def g() -> None:
+    f()
+    C.ff()
+def gg(x: C) -> None:
+    z = x.y
+    z.zz
+[out]
+<foo.bar.C.ff> -> m.g
+<foo.bar.C.y> -> m.gg
+<foo.bar.C> -> <m.gg>, m, m.g, m.gg
+<foo.bar.f> -> m, m.g


### PR DESCRIPTION
Generate dependencies from definitions in modules that are imported
but not included in the build. For example, if you have 
`from m import f` and then `f()` we generate a dependency from `m.f` 
even if `m` is not included in the build.

This only covers a subset of some of the more common cases, since full
support seems tricky. In particular, using a type such as `m.C` in an
annotation if `m` is missing does not generate a dependency from
`m.C`.