### PR TITLE
Support classes and type aliases in plugin hooks

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -284,6 +284,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             fullname = None
         else:
             fullname = e.callee.fullname
+            if (isinstance(e.callee.node, TypeAlias) and
+                    isinstance(e.callee.node.target, Instance)):
+                fullname = e.callee.node.target.type.fullname()
             if (fullname is None
                     and isinstance(e.callee, MemberExpr)
                     and isinstance(callee_type, FunctionLike)):
@@ -575,6 +578,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if isinstance(callee, CallableType):
             if callable_name is None and callee.name:
                 callable_name = callee.name
+            if callee.is_type_obj() and isinstance(callee.ret_type, Instance):
+                callable_name = callee.ret_type.type.fullname()
             if (isinstance(callable_node, RefExpr)
                 and callable_node.fullname in ('enum.Enum', 'enum.IntEnum',
                                                'enum.Flag', 'enum.IntFlag')):

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -130,6 +130,44 @@ class Signal(Generic[T]):
 plugins=<ROOT>/test-data/unit/plugins/type_anal_hook.py
 [builtins fixtures/dict.pyi]
 
+[case testFunctionPluginHookForClass]
+# flags: --config-file tmp/mypy.ini
+import mod
+from mod import AttrInt
+
+Alias = AttrInt
+AnotherAlias = mod.Attr
+
+class C:
+    x = Alias()
+    y = mod.AttrInt(required=True)
+    z = AnotherAlias(int, required=False)
+
+c = C()
+reveal_type(c.x)  # E: Revealed type is 'Union[builtins.int, None]'
+reveal_type(c.y)  # E: Revealed type is 'builtins.int*'
+reveal_type(c.z)  # E: Revealed type is 'Union[builtins.int*, None]'
+
+[file mod.py]
+from typing import Generic, TypeVar, Type
+T = TypeVar('T')
+
+class Attr(Generic[T]):
+    def __init__(self, tp: Type[T], required: bool = False) -> None:
+        pass
+    def __get__(self, instance: object, owner: type) -> T:
+        pass
+
+class AttrInt(Attr[int]):
+    def __init__(self, required: bool = False) -> None:
+        pass
+
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/class_callable.py
+[builtins fixtures/bool.pyi]
+[out]
+
 [case testFunctionPluginHookForReturnedCallable]
 # flags: --config-file tmp/mypy.ini
 from m import decorator1, decorator2

--- a/test-data/unit/plugins/class_callable.py
+++ b/test-data/unit/plugins/class_callable.py
@@ -1,0 +1,32 @@
+from mypy.plugin import Plugin
+from mypy.nodes import NameExpr
+from mypy.types import UnionType, NoneTyp, Instance
+
+class AttrPlugin(Plugin):
+    def get_function_hook(self, fullname):
+        if fullname.startswith('mod.Attr'):
+            return attr_hook
+        return None
+
+def attr_hook(ctx):
+    assert isinstance(ctx.default_return_type, Instance)
+    if ctx.default_return_type.type.fullname() == 'mod.Attr':
+        attr_base = ctx.default_return_type
+    else:
+        attr_base = None
+    for base in ctx.default_return_type.type.bases:
+        if base.type.fullname() == 'mod.Attr':
+            attr_base = base
+            break
+    assert attr_base is not None
+    last_arg_exprs = ctx.args[-1]
+    if any(isinstance(expr, NameExpr) and expr.name == 'True' for expr in last_arg_exprs):
+        return attr_base
+    assert len(attr_base.args) == 1
+    arg_type = attr_base.args[0]
+    return Instance(attr_base.type, [UnionType([arg_type, NoneTyp()])],
+                    line=ctx.default_return_type.line,
+                    column=ctx.default_return_type.column)
+
+def plugin(version):
+    return AttrPlugin


### PR DESCRIPTION
A step towards https://github.com/python/mypy/issues/4964

This only solves a small part of the problem that currently blocks progress in several plugins.

This PR adds basic support for class instantiation (including via aliases) in plugins. The proposed simple convention is that `get_function_hook` is called with the class qualified name.

We might also consider falling back to `get_method_hook` with `__init__` qualified name, if the above returns `None`, and then to `__new__`.

cc: @dgelessus