### PR TITLE
Refs #5383: Document that aliasing dataclass fails

### DIFF
--- a/docs/source/additional_features.rst
+++ b/docs/source/additional_features.rst
@@ -83,22 +83,27 @@ do **not** work:
     from dataclasses import dataclass
 
     dataclass_alias = dataclass
-    dataclass_alias2 = dataclass(order=False)
     def dataclass_wrapper(cls):
       return dataclass(cls)
 
     @dataclass_alias
-    class BadlyDecoratedClass1: arg1: int
-
-    @dataclass_alias2
-    class BadlyDecoratedClass2: arg1: int
+    class AliasDecorated:
+      """
+      Mypy doesn't recognize this as a dataclass because it is decorated by an
+      alias of `dataclass` rather than by `dataclass` itself.
+      """
+      arg1: int
 
     @dataclass_wrapper
-    class BadlyDecoratedClass3: arg1: int
+    class DynamicallyDecoarted:
+      """
+      Mypy doesn't recognize this as a dataclass because it is decorated by a
+      function returning `dataclass` rather than by `dataclass` itself.
+      """
+      arg1: int
 
-    BadlyDecoratedClass1(arg1=1) # error: Unexpected keyword argument
-    BadlyDecoratedClass2(arg1=1) # error: Unexpected keyword argument
-    BadlyDecoratedClass3(arg1=1) # error: Unexpected keyword argument
+    AliasDecorated(arg1=1) # error: Unexpected keyword argument
+    DynamicallyDecoarted(arg1=1) # error: Unexpected keyword argument
 
 .. _attrs_package:
 

--- a/docs/source/additional_features.rst
+++ b/docs/source/additional_features.rst
@@ -92,7 +92,7 @@ do **not** work:
       Mypy doesn't recognize this as a dataclass because it is decorated by an
       alias of `dataclass` rather than by `dataclass` itself.
       """
-      arg1: int
+      attribute: int
 
     @dataclass_wrapper
     class DynamicallyDecoarted:
@@ -100,10 +100,10 @@ do **not** work:
       Mypy doesn't recognize this as a dataclass because it is decorated by a
       function returning `dataclass` rather than by `dataclass` itself.
       """
-      arg1: int
+      attribute: int
 
-    AliasDecorated(arg1=1) # error: Unexpected keyword argument
-    DynamicallyDecoarted(arg1=1) # error: Unexpected keyword argument
+    AliasDecorated(attribute=1) # error: Unexpected keyword argument
+    DynamicallyDecoarted(attribute=1) # error: Unexpected keyword argument
 
 .. _attrs_package:
 

--- a/docs/source/additional_features.rst
+++ b/docs/source/additional_features.rst
@@ -68,8 +68,37 @@ class can be used:
 For more information see `official docs <https://docs.python.org/3/library/dataclasses.html>`_
 and `PEP 557 <https://www.python.org/dev/peps/pep-0557/>`_.
 
-**Note:** Some functions in the ``dataclasses`` module, such as ``replace()`` and ``asdict()``,
+Caveats/Known Issues
+====================
+
+Some functions in the ``dataclasses`` module, such as ``replace()`` and ``asdict()``,
 have imprecise (too permissive) types. This will be fixed in future releases.
+
+Mypy does not yet recognize aliases of ``dataclasses.dataclass``, and will
+probably never recognize dynamically computed decorators. The following examples
+do **not** work:
+
+.. code-block:: python
+
+    from dataclasses import dataclass
+
+    dataclass_alias = dataclass
+    dataclass_alias2 = dataclass(order=False)
+    def dataclass_wrapper(cls):
+      return dataclass(cls)
+
+    @dataclass_alias
+    class BadlyDecoratedClass1: arg1: int
+
+    @dataclass_alias2
+    class BadlyDecoratedClass2: arg1: int
+
+    @dataclass_wrapper
+    class BadlyDecoratedClass3: arg1: int
+
+    BadlyDecoratedClass1(arg1=1) # error: Unexpected keyword argument
+    BadlyDecoratedClass2(arg1=1) # error: Unexpected keyword argument
+    BadlyDecoratedClass3(arg1=1) # error: Unexpected keyword argument
 
 .. _attrs_package:
 


### PR DESCRIPTION
This documentation is a temporary solution. It should be altered or
removed when #5383 is fixed.

I inserted the whole example from #5383. If you think that's too much, feel free to modify. I've granted edit permissions to maintainers.