### PR TITLE
Update versions for pytest and xdist

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+attrs>=18.0
 flake8
 flake8-bugbear; python_version >= '3.5'
 flake8-pyi; python_version >= '3.6'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,8 +3,8 @@ flake8-bugbear; python_version >= '3.5'
 flake8-pyi; python_version >= '3.6'
 lxml==4.2.3
 psutil==5.4.0
-pytest>=3.0
-pytest-xdist>=1.18
+pytest>=3.4
+pytest-xdist>=1.22
 pytest-cov>=2.4.0
 typed-ast>=1.1.0,<1.2.0
 typing>=3.5.2; python_version < '3.5'


### PR DESCRIPTION
This should fix Travis. Travis is currently failing like this:
```
pkg_resources.VersionConflict: (pytest 3.3.0 (/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages), Requirement.parse('pytest>=3.4'))
```