### PR TITLE
Semantically analyze bases in class defs for benefit of mypyc

### DIFF
--- a/test-data/unit/deps-generics.test
+++ b/test-data/unit/deps-generics.test
@@ -96,9 +96,9 @@ class C: pass
 <m.A.(abstract)> -> <m.B.__init__>, m
 <m.A.__init__> -> <m.B.__init__>
 <m.A.__new__> -> <m.B.__new__>
-<m.A> -> m.A, m.B
+<m.A> -> m, m.A, m.B
 <m.B> -> m.B
-<m.C> -> m.B, m.C
+<m.C> -> m, m.B, m.C
 <m.T> -> m.A
 
 [case testGenericBaseClass2]
@@ -112,9 +112,9 @@ class B(A[T]): pass
 <m.A.(abstract)> -> <m.B.__init__>, m
 <m.A.__init__> -> <m.B.__init__>
 <m.A.__new__> -> <m.B.__new__>
-<m.A> -> m.A, m.B
+<m.A> -> m, m.A, m.B
 <m.B> -> m.B
-<m.T> -> m.A, m.B
+<m.T> -> m, m.A, m.B
 
 [case testTypeVarBound]
 from typing import TypeVar, Tuple


### PR DESCRIPTION
This is a follow up to #5376. Semantically analyzer bases in class defs
so that mypyc can just directly compile the base expressions in order to compute
its base classes.

In #5376, I did the analysis unconditionally because it seemed cheap enough that
it wasn't worth bothering with a conditional mechanism. Is this change big enough
that we should be making it conditional? It causes some more dependencies to be
found, but I'm not sure that will matter much. It also breaks inheriting from the builtin
collections in typeshed; I landed https://github.com/python/typeshed/pull/2352 to
fix the one place where that came up.