### PR TITLE
CI upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,37 @@
-sudo: false
+if: tag IS present OR type = pull_request OR (branch = master AND type = push)   # we only CI the master, tags and PRs
+
 language: python
 # cache package wheels (1 cache per python version)
 cache: pip
-python:
-  - "3.4"
+dist: xenial
+sudo: required
+
+env:
+  TOXENV=py
+  EXTRA_ARGS=-n 12
+
+jobs:
+  include:
+  - python: 3.4
+    dist: trusty
   # Specifically request 3.5.1 because we need to be compatible with that.
-  - "3.5.1"
-  - "3.6"
-  - "3.7-dev"
+  - python: 3.5.1
+    dist: trusty
+  - python: 3.6    # 3.6.3  pip  9.0.1
+  - python: 3.7    # 3.7.0  pip 10.0.1
+  - python: 3.8-dev
+  - python: 3.7
+    env:
+    - TOXENV=type
+    - EXTRA_ARGS=
+  - python: 3.7
+    env:
+    - TOXENV=lint
+    - EXTRA_ARGS=
 
 install:
-  - pip install -U pip setuptools wheel
-  - pip install -r test-requirements.txt
-  - python2 -m pip install --user typing
-  - pip install .
+- pip install -U tox
+- tox --notest
 
 script:
-  - pytest -n12
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then flake8 -j12; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.5.1' ]]; then python3 -m mypy --config-file mypy_self_check.ini -p mypy; fi
+- tox -- $EXTRA_ARGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: required
 
 env:
   TOXENV=py
-  EXTRA_ARGS=-n 12
+  EXTRA_ARGS="-n 12"
 
 jobs:
   include:
@@ -30,6 +30,7 @@ jobs:
     - EXTRA_ARGS=
 
 install:
+- pip install -U pip setuptools
 - pip install -U tox
 - tox --notest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ if: tag IS present OR type = pull_request OR (branch = master AND type = push)  
 language: python
 # cache package wheels (1 cache per python version)
 cache: pip
+# newer python versions are available only on xenial (while some older only on trusty) Ubuntu distribution
 dist: xenial
 sudo: required
 
@@ -12,19 +13,26 @@ env:
 
 jobs:
   include:
-  - python: 3.4
+  - name: "run test suite with python 3.4"
+    python: 3.4
     dist: trusty
   # Specifically request 3.5.1 because we need to be compatible with that.
-  - python: 3.5.1
+  - name: "run test suite with python 3.5.1"
+    python: 3.5.1
     dist: trusty
-  - python: 3.6    # 3.6.3  pip  9.0.1
-  - python: 3.7    # 3.7.0  pip 10.0.1
-  - python: 3.8-dev
-  - python: 3.7
+  - name: "run test suite with python 3.6"
+    python: 3.6    # 3.6.3  pip  9.0.1
+  - name: "run test suite with python 3.7"
+    python: 3.7    # 3.7.0  pip 10.0.1
+  - name: "run test suite with python 3.8-dev"
+    python: 3.8-dev
+  - name: "type check our own code"
+    python: 3.7
     env:
     - TOXENV=type
     - EXTRA_ARGS=
-  - python: 3.7
+  - name: "check code style with flake8"
+    python: 3.7
     env:
     - TOXENV=lint
     - EXTRA_ARGS=

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,24 +4,22 @@ cache:
 environment:
   matrix:
 
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.x"
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
 
 install:
     - "git config core.symlinks true"
     - "git reset --hard"
-    - "%PYTHON%\\python.exe -m pip install -r test-requirements.txt"
-    - "C:\\Python27\\python.exe -m pip install typing"
     - "git submodule update --init typeshed"
     - "cd typeshed && git config core.symlinks true && git reset --hard && cd .."
-    - "%PYTHON%\\python.exe -m pip install ."
+    - "%PYTHON%\\python.exe -m pip install -U setuptools tox"
+    - "%PYTHON%\\python.exe -m tox -e py37 --notest"
 
 build: off
 
 test_script:
-    # lint and mypy self check run in Travis
-    - "%PYTHON%\\python.exe -m pytest -k \"not (PythonEvaluationSuite and python2)\""
+    - "%PYTHON%\\python.exe -m tox -e py37"
 
 skip_commits:
   files:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+    "setuptools >= 30.0.2",
+    "wheel >= 0.29.0"
+]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ attrs>=18.0
 flake8
 flake8-bugbear; python_version >= '3.5'
 flake8-pyi; python_version >= '3.6'
-lxml==4.2.3
+lxml==4.2.4
 psutil==5.4.0
 pytest>=3.4
 pytest-xdist>=1.22

--- a/tox.ini
+++ b/tox.ini
@@ -11,29 +11,30 @@ envlist = py34,
 
 [testenv]
 description = run the test driver with {basepython}
+passenv = PYTEST_XDIST_WORKER_COUNT
 deps = -rtest-requirements.txt
 commands = pytest {posargs}
 
 [testenv:lint]
 description = check the code style
-basepython = python3.6
+basepython = python3.7
 commands = flake8 -j0 {posargs}
 
 [testenv:type]
 description = type check ourselves
-basepython = python3.6
+basepython = python3.7
 commands = python3 -m mypy --config-file mypy_self_check.ini -p mypy
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs
-basepython = python3.6
+basepython = python3.7
 deps = -rdocs/requirements-docs.txt
 commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
 
 [testenv:dev]
 description = generate a DEV environment, that has all project libraries
 usedevelop = True
-basepython = python3.6
+basepython = python3.7
 deps = -rtest-requirements.txt
        -rdocs/requirements-docs.txt
 commands = python -m pip list --format=columns


### PR DESCRIPTION
- Travis test with python3.7 and python3.8-dev
- Travis use tox to setup/run tests
- Bump tox default envs from python3.6 to python3.7