### PR TITLE
Make runtests.py use the "py -3" launcher on Windows

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 from os import system
-from sys import argv, exit
+from sys import argv, exit, platform
 
 prog, *args = argv
 
+if platform == 'win32':
+    python_name = 'py -3'
+else:
+    python_name = 'python3'
+
 cmds = {
-    'self': 'python3 -m mypy --config-file mypy_self_check.ini -p mypy',
+    'self': python_name + ' -m mypy --config-file mypy_self_check.ini -p mypy',
     'lint': 'flake8 -j0',
     'pytest': 'pytest'
 }


### PR DESCRIPTION
Most Windows installations don't have an exe named "python3" -- the convention is to instead use the "py" launcher.

As a note, we probably already have some helper method that gets the correct Python exe name somewhere, but iirc the intent was to keep runtests.py simple, so I just implemented it directly.