### PR TITLE
Fix two daemon crashes with forward references in decorators

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -396,6 +396,9 @@ class ASTConverter(ast3.NodeTransformer):
                        args,
                        self.as_required_block(n.body, n.lineno),
                        func_type)
+        if isinstance(func_def.type, CallableType):
+            # semanal.py does some in-place modifications we want to avoid
+            func_def.unanalyzed_type = func_def.type.copy_modified()
         if is_coroutine:
             func_def.is_coroutine = True
         if func_type is not None:

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -366,6 +366,9 @@ class ASTConverter(ast27.NodeTransformer):
                        args,
                        body,
                        func_type)
+        if isinstance(func_def.type, CallableType):
+            # semanal.py does some in-place modifications we want to avoid
+            func_def.unanalyzed_type = func_def.type.copy_modified()
         if func_type is not None:
             func_type.definition = func_def
             func_type.line = n.lineno

--- a/mypy/typevars.py
+++ b/mypy/typevars.py
@@ -3,7 +3,6 @@ from typing import Union, List
 from mypy.nodes import TypeInfo
 
 from mypy.erasetype import erase_typevars
-from mypy.sametypes import is_same_type
 from mypy.types import Instance, TypeVarType, TupleType, Type
 
 
@@ -22,4 +21,4 @@ def fill_typevars(typ: TypeInfo) -> Union[Instance, TupleType]:
 
 
 def has_no_typevars(typ: Type) -> bool:
-    return is_same_type(typ, erase_typevars(typ))
+    return typ == erase_typevars(typ)

--- a/mypy/typevars.py
+++ b/mypy/typevars.py
@@ -21,4 +21,10 @@ def fill_typevars(typ: TypeInfo) -> Union[Instance, TupleType]:
 
 
 def has_no_typevars(typ: Type) -> bool:
+    # We test if a type contains type variables by erasing all type variables
+    # and comparing the result to the original type. We use comparison by equality that
+    # in turn uses `__eq__` defined for types. Note: we can't use `is_same_type` because
+    # it is not safe with unresolved forward references, while this function may be called
+    # before forward references resolution patch pass. Note also that it is not safe to use
+    # `is` comparison because `erase_typevars` doesn't preserve type identity.
     return typ == erase_typevars(typ)

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7384,3 +7384,67 @@ x = 1
 Func = Callable[..., Any]
 [out]
 ==
+
+[case testIdLikeDecoForwardCrash_python2]
+# flags: --py2
+import b
+[file b.py]
+from typing import Callable, Any, TypeVar
+
+F = TypeVar('F_BadName', bound=Callable[..., Any])  # type: ignore
+def deco(func):  # type: ignore
+    # type: (F) -> F
+    pass
+
+@deco
+def test(x, y):
+    # type: (int, int) -> str
+    pass
+[file b.py.2]
+from typing import Callable, Any, TypeVar
+
+F = TypeVar('F_BadName', bound=Callable[..., Any])  # type: ignore
+def deco(func):  # type: ignore
+    # type: (F) -> F
+    pass
+
+@deco
+def test(x, y):
+    # type: (int, int) -> str
+    pass
+x = 1
+[out]
+==
+
+[case testIdLikeDecoForwardCrashAlias_python2]
+# flags: --py2
+import b
+[file b.py]
+from typing import Callable, Any, TypeVar
+
+F = TypeVar('F', bound=Func)
+def deco(func):
+    # type: (F) -> F
+    pass
+
+@deco
+def test(x, y):
+    # type: (int, int) -> str
+    pass
+Func = Callable[..., Any]
+[file b.py.2]
+from typing import Callable, Any, TypeVar
+
+F = TypeVar('F', bound=Func)
+def deco(func):
+    # type: (F) -> F
+    pass
+
+@deco
+def test(x, y):
+    # type: (int, int) -> str
+    pass
+x = 1
+Func = Callable[..., Any]
+[out]
+==

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7356,3 +7356,31 @@ def test(x: int, y: int) -> str:
 x = 1
 [out]
 ==
+
+[case testIdLikeDecoForwardCrashAlias]
+import b
+[file b.py]
+from typing import Callable, Any, TypeVar
+
+F = TypeVar('F', bound=Func)
+def deco(func: F) -> F:
+    pass
+
+@deco
+def test(x: int, y: int) -> str:
+    pass
+Func = Callable[..., Any]
+[file b.py.2]
+from typing import Callable, Any, TypeVar
+
+F = TypeVar('F', bound=Func)
+def deco(func: F) -> F:
+    pass
+
+@deco
+def test(x: int, y: int) -> str:
+    pass
+x = 1
+Func = Callable[..., Any]
+[out]
+==

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7330,3 +7330,29 @@ class A: pass
 [out]
 ==
 main:4: error: Name 'm.A' is not defined
+
+[case testIdLikeDecoForwardCrash]
+import b
+[file b.py]
+from typing import Callable, Any, TypeVar
+
+F = TypeVar('F_BadName', bound=Callable[..., Any])  # type: ignore
+def deco(func: F) -> F:  # type: ignore
+    pass
+
+@deco
+def test(x: int, y: int) -> str:
+    pass
+[file b.py.2]
+from typing import Callable, Any, TypeVar
+
+F = TypeVar('F_BadName', bound=Callable[..., Any])  # type: ignore
+def deco(func: F) -> F:  # type: ignore
+    pass
+
+@deco
+def test(x: int, y: int) -> str:
+    pass
+x = 1
+[out]
+==


### PR DESCRIPTION
There are two similar crashes:
* One is caused by using `is_same_type` in `has_type_vars` during third pass of semantic analysis (too soon), I solve this by using equality instead (the only difference between `is_same_type` and equality test is that the former does some union simplification and other type equivalence, while these are not needed in the context of `has_type_vars`).
* Another is caused by in-place changes to callable types done by semantic analysis, to avoid this I take a copy in `defn.unanalyzed_type`.