### PR TITLE
Fix two crashes in duplicate decorated functions

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -391,10 +391,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # valid overloads.
             return None
         if len(defn.items) == 1:
-            # don't report this error for duplicate decorated functions
-            if (isinstance(defn.items[0], Decorator) and
-                    any(refers_to_fullname(d, 'typing.overload') for d in defn.items[0].decorators)):
-                self.fail('Single overload definition, multiple required', defn)
+            self.fail('Single overload definition, multiple required', defn)
 
         if defn.is_property:
             # HACK: Infer the type of the property.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -391,7 +391,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # valid overloads.
             return None
         if len(defn.items) == 1:
-            self.fail('Single overload definition, multiple required', defn)
+            # don't report this error for duplicate decorated functions
+            if (isinstance(defn.items[0], Decorator) and
+                    any(refers_to_fullname(d, 'typing.overload') for d in defn.items[0].decorators)):
+                self.fail('Single overload definition, multiple required', defn)
 
         if defn.is_property:
             # HACK: Infer the type of the property.

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -427,12 +427,14 @@ class OverloadedFuncDef(FuncBase, SymbolNode, Statement):
     """
 
     items = None  # type: List[OverloadPart]
+    unanalyzed_items = None  # type: List[OverloadPart]
     impl = None  # type: Optional[OverloadPart]
 
     def __init__(self, items: List['OverloadPart']) -> None:
         super().__init__()
         assert len(items) > 0
         self.items = items
+        self.unanalyzed_items = items.copy()
         self.impl = None
         self.set_line(items[0].line)
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -437,7 +437,12 @@ class OverloadedFuncDef(FuncBase, SymbolNode, Statement):
         self.set_line(items[0].line)
 
     def name(self) -> str:
-        return self.items[0].name()
+        if self.items:
+            return self.items[0].name()
+        else:
+            # This may happen for malformed overload
+            assert self.impl is not None
+            return self.impl.name()
 
     def accept(self, visitor: StatementVisitor[T]) -> T:
         return visitor.visit_overloaded_func_def(self)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -555,11 +555,9 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                         self.name_already_defined(defn.name(), defn.items[idx], first_item)
                     if defn.impl:
                         self.name_already_defined(defn.name(), defn.impl, first_item)
-                # Remove the non-overloads, if there were at least one overload
-                # (otherwise this is just a duplicate definition)
-                if len(non_overload_indexes) < len(defn.items) - 1:
-                    for idx in reversed(non_overload_indexes):
-                        del defn.items[idx]
+                # Remove the non-overloads
+                for idx in reversed(non_overload_indexes):
+                    del defn.items[idx]
             # If we found an implementation, remove it from the overloads to
             # consider.
             if defn.impl is not None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -518,7 +518,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                     # The first item was already visited
                     item.is_overload = True
                     item.accept(self)
-                # TODO support decorated overloaded functions properly
+                # TODO: support decorated overloaded functions properly
                 if isinstance(item, Decorator):
                     callable = function_type(item.func, self.builtin_type('builtins.function'))
                     assert isinstance(callable, CallableType)
@@ -555,9 +555,11 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                         self.name_already_defined(defn.name(), defn.items[idx], first_item)
                     if defn.impl:
                         self.name_already_defined(defn.name(), defn.impl, first_item)
-                # Remove the non-overloads
-                for idx in reversed(non_overload_indexes):
-                    del defn.items[idx]
+                # Remove the non-overloads, if there were at least one overload
+                # (otherwise this is just a duplicate definition)
+                if len(non_overload_indexes) < len(defn.items) - 1:
+                    for idx in reversed(non_overload_indexes):
+                        del defn.items[idx]
             # If we found an implementation, remove it from the overloads to
             # consider.
             if defn.impl is not None:

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -130,10 +130,8 @@ class NodeStripVisitor(TraverserVisitor):
     def visit_overloaded_func_def(self, node: OverloadedFuncDef) -> None:
         if not self.recurse_into_functions:
             return
-        if node.impl:
-            # Revert change made during semantic analysis pass 2.
-            assert node.items[-1] is not node.impl
-            node.items.append(node.impl)
+        # Revert change made during semantic analysis pass 2.
+        node.items = node.unanalyzed_items.copy()
         super().visit_overloaded_func_def(node)
 
     @contextlib.contextmanager

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7300,6 +7300,70 @@ def A(x: str) -> str: pass
 ==
 a.py:4: error: Incompatible import of "A" (imported name has type "Callable[[str], str]", local name has type "Type[List[Any]]")
 
+[case testFakeOverloadCrash]
+import b
+[file a.py]
+def dec(fun):
+    pass
+a = 1
+[file a.py.2]
+def dec(fun):
+    pass
+a = 2
+[file b.py]
+from a import dec
+@dec
+def a():
+    pass
+@dec
+def a():
+    pass
+[out]
+b.py:5: error: Name 'a' already defined on line 2
+==
+b.py:5: error: Name 'a' already defined on line 2
+
+[case testFakeOverloadCrash2]
+# this test just should not crash
+import a
+[file a.py]
+T = TypeVar("T")
+
+def foo(func):
+    return func
+
+@foo
+def bar(x: T) -> T:
+    pass
+
+@foo
+def bar(x: T) -> T:
+    pass
+[file a.py.2]
+T = TypeVar("T")
+
+def foo(func):
+    return func
+
+@foo
+def bar(x: T) -> T:
+    pass
+
+@foo
+def bar(x: T) -> T:
+    pass
+x = 1
+[out]
+a.py:1: error: Name 'TypeVar' is not defined
+a.py:7: error: Invalid type "a.T"
+a.py:10: error: Name 'bar' already defined on line 6
+a.py:11: error: Invalid type "a.T"
+==
+a.py:1: error: Name 'TypeVar' is not defined
+a.py:7: error: Invalid type "a.T"
+a.py:10: error: Name 'bar' already defined on line 6
+a.py:11: error: Invalid type "a.T"
+
 [case testRefreshForWithTypeComment1]
 [file a.py]
 from typing import List

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7355,12 +7355,10 @@ def bar(x: T) -> T:
 x = 1
 [out]
 a.py:1: error: Name 'TypeVar' is not defined
-a.py:7: error: Invalid type "a.T"
 a.py:10: error: Name 'bar' already defined on line 6
 a.py:11: error: Invalid type "a.T"
 ==
 a.py:1: error: Name 'TypeVar' is not defined
-a.py:7: error: Invalid type "a.T"
 a.py:10: error: Name 'bar' already defined on line 6
 a.py:11: error: Invalid type "a.T"
 


### PR DESCRIPTION
Fixes #5394 
Fixes #5181 

The problem is that duplicate decorated functions are parsed as `OverloadedFuncDef` even if the actual decorator used is not `typing.overload`. This PR fixes possible crashes related to this. I could imagine there may be some extra spurious errors in some scenarios (in addition to duplicate definition correctly reported by mypy), but at least it should not crash.