### PR TITLE
Visit resolved forward refs by third pass type visitor

### DIFF
--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -700,7 +700,7 @@ class TypeVariableChecker(TypeTranslator):
                 self.fail('Type argument "{}" of "{}" must be '
                           'a subtype of "{}"'.format(
                               arg, info.name(), tvar.upper_bound), t)
-        return t
+        return super().visit_instance(t)
 
     def check_type_var_values(self, type: TypeInfo, actuals: List[Type], arg_name: str,
                               valids: List[Type], arg_number: int, context: Context) -> None:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4498,3 +4498,26 @@ from typing import Any
 def __getattr__(attr: str) -> Any: ...
 [builtins fixtures/module.pyi]
 [out]
+
+[case testForwardInstanceWithWrongArgCount]
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+class G(Generic[T]): ...
+
+A = G
+x: A[B[int, int]]  # E: "G" expects 1 type argument, but 2 given
+B = G
+[out]
+
+[case testForwardInstanceWithNoArgs]
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+class G(Generic[T]): ...
+
+A = G
+x: A[B]
+reveal_type(x)  # E: Revealed type is '__main__.G[__main__.G[Any]]'
+B = G
+[out]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4521,3 +4521,16 @@ x: A[B]
 reveal_type(x)  # E: Revealed type is '__main__.G[__main__.G[Any]]'
 B = G
 [out]
+
+[case testForwardInstanceWithBound]
+from typing import TypeVar, Generic
+
+T = TypeVar('T', bound=str)
+class G(Generic[T]): ...
+
+A = G
+x: A[B[int]]
+B = G
+[out]
+main:7: error: Type argument "builtins.int" of "G" must be a subtype of "builtins.str"
+main:7: error: Type argument "__main__.G[builtins.int]" of "G" must be a subtype of "builtins.str"

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4534,3 +4534,18 @@ B = G
 [out]
 main:7: error: Type argument "builtins.int" of "G" must be a subtype of "builtins.str"
 main:7: error: Type argument "__main__.G[builtins.int]" of "G" must be a subtype of "builtins.str"
+
+[case testExtremeForwardReferencing]
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+class B(Generic[T]): ...
+
+y: A
+z: A[int]
+x = [y, z]
+reveal_type(x)
+
+A = B
+[builtins fixtures/list.pyi]
+[out]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4544,7 +4544,7 @@ class B(Generic[T]): ...
 y: A
 z: A[int]
 x = [y, z]
-reveal_type(x)
+reveal_type(x)  # E: Revealed type is 'builtins.list[__main__.B*[Any]]'
 
 A = B
 [builtins fixtures/list.pyi]

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1306,3 +1306,14 @@ def print_custom_table() -> None:
         reveal_type(row)
 [out]
 _testLoadsOfOverloads.py:24: error: Revealed type is 'builtins.str*'
+
+[case testReduceWithAnyInstance]
+from typing import Iterable
+from functools import reduce
+M = Iterable
+def f(m1: M, m2):
+    ...
+def g(ms: 'T[M]') -> None:
+    reduce(f, ms)
+T = Iterable
+[out]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/4649

This also fixes similar cases of crashes with extreme forward referencing. The idea is quite straightforward, previously forward references just resolved during third pass were not accepted by the third pass visitor itself, this is now fixed.