### PR TITLE
Add a `FlexibleAlias` to `mypy_extensions`

### DIFF
--- a/extensions/mypy_extensions.py
+++ b/extensions/mypy_extensions.py
@@ -139,3 +139,23 @@ class NoReturn: pass
 
 def trait(cls):
     return cls
+
+
+# TODO: We may want to try to properly apply this to any type
+# variables left over...
+class _FlexibleAliasClsApplied:
+    def __init__(self, val):
+        self.val = val
+
+    def __getitem__(self, args):
+        return self.val
+
+
+class _FlexibleAliasCls:
+    def __getitem__(self, args):
+        return _FlexibleAliasClsApplied(args[-1])
+
+
+FlexibleAlias = _FlexibleAliasCls()
+
+Id = _FlexibleAliasCls()

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -857,7 +857,12 @@ def expand_type_alias(target: Type, alias_tvars: List[str], args: List[Type],
              % (exp_len, act_len), ctx)
         return set_any_tvars(target, alias_tvars or [],
                              ctx.line, ctx.column, implicit=False)
-    return replace_alias_tvars(target, alias_tvars, args, ctx.line, ctx.column)
+    typ = replace_alias_tvars(target, alias_tvars, args, ctx.line, ctx.column)
+    # HACK: Implement FlexibleAlias[T, typ] by expanding it to typ here.
+    if (isinstance(typ, Instance)
+            and typ.type.fullname() == 'mypy_extensions.FlexibleAlias'):
+        typ = typ.args[-1]
+    return typ
 
 
 def replace_alias_tvars(tp: Type, vars: List[str], subs: List[Type],

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -426,3 +426,95 @@ reveal_type(D.meth(1))  # E: Revealed type is 'Union[__main__.D*, builtins.int]'
 reveal_type(D().meth(1))  # E: Revealed type is 'Union[__main__.D*, builtins.int]'
 [builtins fixtures/classmethod.pyi]
 [out]
+
+[case testFlexibleAlias1]
+from typing import TypeVar, List, Tuple
+from mypy_extensions import FlexibleAlias
+
+T = TypeVar('T')
+U = TypeVar('U')
+
+AnInt = FlexibleAlias[T, int]
+
+x: AnInt[str]
+reveal_type(x)  # E: Revealed type is 'builtins.int'
+
+TwoArgs = FlexibleAlias[Tuple[T, U], bool]
+TwoArgs2 = FlexibleAlias[Tuple[T, U], List[U]]
+
+def welp(x: TwoArgs[str, int]) -> None:
+    reveal_type(x)  # E: Revealed type is 'builtins.bool'
+
+def welp2(x: TwoArgs2[str, int]) -> None:
+    reveal_type(x)  # E: Revealed type is 'builtins.list[builtins.int]'
+
+
+Id = FlexibleAlias[T, T]
+
+def take_id(x: Id[int]) -> None:
+    reveal_type(x)  # E: Revealed type is 'builtins.int'
+
+def id(x: Id[T]) -> T:
+    return x
+
+# TODO: This doesn't work and maybe it should?
+# Indirection = AnInt[T]
+# y: Indirection[str]
+# reveal_type(y)  # E : Revealed type is 'builtins.int'
+
+# But this does
+Indirection2 = FlexibleAlias[T, AnInt[T]]
+z: Indirection2[str]
+reveal_type(z)  # E: Revealed type is 'builtins.int'
+
+Indirection3 = FlexibleAlias[Tuple[T, U], AnInt[T]]
+w: Indirection3[str, int]
+reveal_type(w)  # E: Revealed type is 'builtins.int'
+
+[builtins fixtures/dict.pyi]
+
+[case testFlexibleAlias2]
+# flags: --always-true=BOGUS
+from typing import TypeVar, Any
+from mypy_extensions import FlexibleAlias
+
+T = TypeVar('T')
+
+BOGUS = True
+if BOGUS:
+    Bogus = FlexibleAlias[T, Any]
+else:
+    Bogus = FlexibleAlias[T, T]
+
+class A:
+    x: Bogus[str]
+
+reveal_type(A().x)  # E: Revealed type is 'Any'
+
+def foo(x: Bogus[int]) -> None:
+    reveal_type(x)  # E: Revealed type is 'Any'
+
+[builtins fixtures/dict.pyi]
+
+[case testFlexibleAlias3]
+# flags: --always-false=BOGUS
+from typing import TypeVar, Any
+from mypy_extensions import FlexibleAlias
+
+T = TypeVar('T')
+
+BOGUS = True
+if BOGUS:
+    Bogus = FlexibleAlias[T, Any]
+else:
+    Bogus = FlexibleAlias[T, T]
+
+class A:
+    x: Bogus[str]
+
+reveal_type(A().x)  # E: Revealed type is 'builtins.str'
+
+def foo(x: Bogus[int]) -> None:
+    reveal_type(x)  # E: Revealed type is 'builtins.int'
+
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/lib-stub/mypy_extensions.pyi
+++ b/test-data/unit/lib-stub/mypy_extensions.pyi
@@ -1,8 +1,8 @@
 # NOTE: Requires fixtures/dict.pyi
-
-from typing import Dict, Type, TypeVar, Optional, Any
+from typing import Dict, Type, TypeVar, Optional, Any, Generic
 
 _T = TypeVar('_T')
+_U = TypeVar('_U')
 
 
 def Arg(type: _T = ..., name: Optional[str] = ...) -> _T: ...
@@ -25,3 +25,5 @@ def TypedDict(typename: str, fields: Dict[str, Type[_T]], *, total: Any = ...) -
 def trait(cls: Any) -> Any: ...
 
 class NoReturn: pass
+
+class FlexibleAlias(Generic[_T, _U]): ...


### PR DESCRIPTION
Currently there is no way to define generic type aliases that do not
depend on their type arguments or that are just directly a type
variable.

`FlexibleAlias[T, typ]` creates a type that depends on `T` but that is
expanded to `typ` during type alias expansion.

One target use case for this is in creating conditionally defined type
aliases that depend on their argument under certain configurations but
not under others, for example:
```
if BOGUS:
    Bogus = FlexibleAlias[T, Any]
else:
    Bogus = FlexibleAlias[T, T]
```