### PR TITLE
Remove the `Id` class from mypy_extensions

### DIFF
--- a/extensions/mypy_extensions.py
+++ b/extensions/mypy_extensions.py
@@ -157,5 +157,3 @@ class _FlexibleAliasCls:
 
 
 FlexibleAlias = _FlexibleAliasCls()
-
-Id = _FlexibleAliasCls()


### PR DESCRIPTION
Argh, I forgot to remove this when doing cleanup.