### PR TITLE
Move descriptor access logic to checkmember module

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -35,7 +35,10 @@ from mypy.types import (
 from mypy.sametypes import is_same_type, is_same_types
 from mypy.messages import MessageBuilder, make_inferred_type_note
 import mypy.checkexpr
-from mypy.checkmember import map_type_from_supertype, bind_self, erase_to_bound, type_object_type
+from mypy.checkmember import (
+    map_type_from_supertype, bind_self, erase_to_bound, type_object_type,
+    analyze_descriptor_access
+)
 from mypy import messages
 from mypy.subtypes import (
     is_subtype, is_equivalent, is_proper_subtype, is_more_precise,
@@ -2241,8 +2244,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # (which allow you to override the descriptor with any value), but preserves
             # the type of accessing the attribute (even after the override).
             if attribute_type.type.has_readable_member('__get__'):
-                attribute_type = self.expr_checker.analyze_descriptor_access(
-                    instance_type, attribute_type, context)
+                attribute_type = analyze_descriptor_access(
+                    instance_type, attribute_type, self.named_type,
+                    self.msg, context, chk=self)
             rvalue_type = self.check_simple_assignment(attribute_type, rvalue, context)
             return rvalue_type, True
 

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -308,8 +308,7 @@ def analyze_descriptor_access(instance_type: Type, descriptor_type: Type,
                               builtin_type: Callable[[str], Instance],
                               msg: MessageBuilder,
                               context: Context, *,
-                              chk: 'mypy.checker.TypeChecker',
-                              ) -> Type:
+                              chk: 'mypy.checker.TypeChecker') -> Type:
     """Type check descriptor access.
 
     Arguments:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4521,7 +4521,17 @@ D.dynamic  # E: "Type[D]" has no attribute "dynamic"
 [out]
 
 [case testSelfDescriptorAssign]
+from typing import Any
 
+class Descr:
+    def __get__(self, inst: Any, owner: Any) -> int: ...
+
+class C:
+    def __init__(self, x: Descr) -> None:
+        self.x = x
+
+c = C(Descr())
+reveal_type(c.x)  # E: Revealed type is '__main__.Descr'
 [out]
 
 [case testForwardInstanceWithWrongArgCount]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4499,6 +4499,31 @@ def __getattr__(attr: str) -> Any: ...
 [builtins fixtures/module.pyi]
 [out]
 
+[case testGetAttrDescriptor]
+from typing import TypeVar, Generic, Any
+
+T = TypeVar('T')
+class C(Generic[T]):
+    normal: T
+    def __getattr__(self, attr: str) -> T: ...
+
+class Descr:
+    def __get__(self, inst: Any, owner: Any) -> int: ...
+
+class D(C[Descr]):
+    other: Descr
+
+d: D
+reveal_type(d.normal)  # E: Revealed type is 'builtins.int'
+reveal_type(d.dynamic)  # E: Revealed type is '__main__.Descr*'
+reveal_type(D.other)  # E: Revealed type is 'builtins.int'
+D.dynamic  # E: "Type[D]" has no attribute "dynamic"
+[out]
+
+[case testSelfDescriptorAssign]
+
+[out]
+
 [case testForwardInstanceWithWrongArgCount]
 from typing import TypeVar, Generic
 


### PR DESCRIPTION
Fixes #5455 

This does a minor refactoring and also fixes two corner cases:
* Descriptors are not invoked for access via `__getattr__`
* Descriptors are not invoked if they were assigned to `self` (as opposite to defined in _class body_)
