### PR TITLE
Support callback protocols

### DIFF
--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -186,6 +186,8 @@ Any)`` function signature. Example:
     arbitrary_call(open)  # Error: does not return an int
     arbitrary_call(1)     # Error: 'int' is not callable
 
+In situations where more precise or complex types of callbacks are
+necessary one can use flexible :ref:`callback protocols <callback_protocols>`.
 Lambdas are also supported. The lambda argument and return value types
 cannot be given explicitly; they are always inferred based on context
 using bidirectional type inference:

--- a/docs/source/protocols.rst
+++ b/docs/source/protocols.rst
@@ -415,9 +415,10 @@ in ``typing`` such as ``Iterable``.
 Callback protocols
 ******************
 
-Protocols can be used to define flexible callback types that are impossible
-to express using the ``Callable[...]`` syntax, for example variadic, overloaded,
-and complex generic callbacks. They are defined with a special ``__call__`` member:
+Protocols can be used to define flexible callback types that are hard
+(or even impossible) to express using the ``Callable[...]`` syntax, such as variadic,
+overloaded, and complex generic callbacks. They are defined with a special ``__call__``
+member:
 
 .. code-block:: python
 
@@ -441,8 +442,8 @@ and complex generic callbacks. They are defined with a special ``__call__`` memb
                             # different name and kind in the callback
 
 Callback protocols and ``Callable[...]`` types can be used interchangeably.
-To indicate an "anonymous" positional-only argument use double underscore,
-for example:
+Keyword argument names in ``__call__`` methods must be identical, unless
+a double underscore prefix is used. For example:
 
 .. code-block:: python
 

--- a/docs/source/protocols.rst
+++ b/docs/source/protocols.rst
@@ -409,3 +409,53 @@ in ``typing`` such as ``Iterable``.
    ``isinstance()`` with protocols is not completely safe at runtime.
    For example, signatures of methods are not checked. The runtime
    implementation only checks that all protocol members are defined.
+
+.. _callback_protocols:
+
+Callback protocols
+******************
+
+Protocols can be used to define flexible callback types that are impossible
+to express using the ``Callable[...]`` syntax, for example variadic, overloaded,
+and complex generic callbacks. They are defined with a special ``__call__`` member:
+
+.. code-block:: python
+
+   from typing import Optional, Iterable, List
+   from typing_extensions import Protocol
+
+   class Combiner(Protocol):
+       def __call__(self, *vals: bytes, maxlen: Optional[int] = None) -> List[bytes]: ...
+
+   def batch_proc(data: Iterable[bytes], cb_results: Combiner) -> bytes:
+       for item in data:
+           ...
+
+   def good_cb(*vals: bytes, maxlen: Optional[int] = None) -> List[bytes]:
+       ...
+   def bad_cb(*vals: bytes, maxitems: Optional[int]) -> List[bytes]:
+       ...
+
+   batch_proc([], good_cb)  # OK
+   batch_proc([], bad_cb)   # Error! Argument 2 has incompatible type because of
+                            # different name and kind in the callback
+
+Callback protocols and ``Callable[...]`` types can be used interchangeably.
+To indicate an "anonymous" positional-only argument use double underscore,
+for example:
+
+.. code-block:: python
+
+   from typing import Callable, TypeVar
+   from typing_extensions import Protocol
+
+   T = TypeVar('T')
+
+   class Copy(Protocol):
+       def __call__(self, __origin: T) -> T: ...
+
+   copy_a: Callable[[T], T]
+   copy_b: Copy
+
+   copy_a = copy_b  # OK
+   copy_b = copy_a  # Also OK

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1308,10 +1308,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         """
         # Use boolean variable to clarify code.
         fail = False
-        # __call__ is special among dunders, because arguments can be passed
-        # as keyword args (unlike other dunders).
-        ignore_names = name != '__call__'
-        if not is_subtype(override, original, ignore_pos_arg_names=ignore_names):
+        if not is_subtype(override, original, ignore_pos_arg_names=True):
             fail = True
         elif (not isinstance(original, Overloaded) and
               isinstance(override, Overloaded) and

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3170,6 +3170,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 call = find_member('__call__', subtype, subtype)
                 if call:
                     self.msg.note_call(subtype, call, context)
+            if isinstance(subtype, (CallableType, Overloaded)) and isinstance(supertype, Instance):
+                if supertype.type.is_protocol and supertype.type.protocol_members == ['__call__']:
+                    call = find_member('__call__', supertype, subtype)
+                    assert call is not None
+                    self.msg.note_call(supertype, call, context)
             return False
 
     def contains_none(self, t: Type) -> bool:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1308,7 +1308,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         """
         # Use boolean variable to clarify code.
         fail = False
-        if not is_subtype(override, original, ignore_pos_arg_names=True):
+        # __call__ is special among dunders, because arguments can be passed
+        # as keyword args (unlike other dunders).
+        ignore_names = name != '__call__'
+        if not is_subtype(override, original, ignore_pos_arg_names=ignore_names):
             fail = True
         elif (not isinstance(original, Overloaded) and
               isinstance(override, Overloaded) and

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -1,7 +1,9 @@
 from collections import OrderedDict
 from typing import List, Optional, Tuple
 
-from mypy.join import is_similar_callables, combine_similar_callables, join_type_list
+from mypy.join import (
+    is_similar_callables, combine_similar_callables, join_type_list, unpack_callback_protocol
+)
 from mypy.types import (
     Type, AnyType, TypeVisitor, UnboundType, NoneTyp, TypeVarType, Instance, CallableType,
     TupleType, TypedDictType, ErasedType, UnionType, PartialType, DeletedType,
@@ -297,6 +299,10 @@ class TypeMeetVisitor(TypeVisitor[Type]):
                         return UninhabitedType()
                     else:
                         return NoneTyp()
+        elif isinstance(self.s, FunctionLike) and t.type.is_protocol:
+            call = unpack_callback_protocol(t)
+            if call:
+                return meet_types(call, self.s)
         elif isinstance(self.s, TypeType):
             return meet_types(t, self.s)
         elif isinstance(self.s, TupleType):
@@ -313,8 +319,11 @@ class TypeMeetVisitor(TypeVisitor[Type]):
                 # Return a plain None or <uninhabited> instead of a weird function.
                 return self.default(self.s)
             return result
-        else:
-            return self.default(self.s)
+        elif isinstance(self.s, Instance) and self.s.type.is_protocol:
+            call = unpack_callback_protocol(self.s)
+            if call:
+                return meet_types(t, call)
+        return self.default(self.s)
 
     def visit_overloaded(self, t: Overloaded) -> Type:
         # TODO: Implement a better algorithm that covers at least the same cases
@@ -329,6 +338,10 @@ class TypeMeetVisitor(TypeVisitor[Type]):
                 return t
             else:
                 return meet_types(t.fallback, s.fallback)
+        elif isinstance(self.s, Instance) and self.s.type.is_protocol:
+            call = unpack_callback_protocol(self.s)
+            if call:
+                return meet_types(t, call)
         return meet_types(t.fallback, s)
 
     def visit_tuple_type(self, t: TupleType) -> Type:

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -307,8 +307,7 @@ class TypeMeetVisitor(TypeVisitor[Type]):
             return meet_types(t, self.s)
         elif isinstance(self.s, TupleType):
             return meet_types(t, self.s)
-        else:
-            return self.default(self.s)
+        return self.default(self.s)
 
     def visit_callable_type(self, t: CallableType) -> Type:
         if isinstance(self.s, CallableType) and is_similar_callables(t, self.s):

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -490,7 +490,7 @@ def is_protocol_implementation(left: Instance, right: Instance,
                 return False
 
     if not proper_subtype:
-        # Nominal check currently ignores arg names, except for __call__
+        # Nominal check currently ignores arg names, but __call__ is special for protocols
         ignore_names = right.type.protocol_members != ['__call__']
         subtype_kind = SubtypeVisitor.build_subtype_kind(ignore_pos_arg_names=ignore_names)
     else:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4636,3 +4636,10 @@ class C:
 reveal_type(C.foo)  # E: Revealed type is 'builtins.int*'
 reveal_type(C().foo)  # E: Revealed type is 'builtins.int*'
 [out]
+
+[case tesBadCallOverride]
+class Base:
+    def __call__(self, arg: int) -> None: ...
+class Sub(Base):
+    def __call__(self, zzz: int) -> None: ...  # E: Signature of "__call__" incompatible with supertype "Base"
+[out]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4636,10 +4636,3 @@ class C:
 reveal_type(C.foo)  # E: Revealed type is 'builtins.int*'
 reveal_type(C().foo)  # E: Revealed type is 'builtins.int*'
 [out]
-
-[case tesBadCallOverride]
-class Base:
-    def __call__(self, arg: int) -> None: ...
-class Sub(Base):
-    def __call__(self, zzz: int) -> None: ...  # E: Signature of "__call__" incompatible with supertype "Base"
-[out]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2243,6 +2243,26 @@ func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[int], int]
 [builtins fixtures/tuple.pyi]
 [out]
 
+[case testCallableImplementsProtocolGenericNotGeneric]
+from typing import Protocol, TypeVar, Tuple
+
+T = TypeVar('T')
+
+class Caller(Protocol):
+    def __call__(self, x: int) -> int: ...
+
+def call(x: T) -> T: ...
+
+def bad(x: T) -> Tuple[T, T]: ...
+
+def func(caller: Caller) -> None:
+    pass
+
+func(call)
+func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[T], Tuple[T, T]]"; expected "Caller"
+[builtins fixtures/tuple.pyi]
+[out]
+
 [case testCallableImplementsProtocolOverload]
 from typing import Protocol, overload, Union
 
@@ -2306,4 +2326,64 @@ def anon(caller: CallerAnon) -> None:
 func(call)
 func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[str], None]"; expected "Caller"
 anon(bad)
+[out]
+
+[case testCallableProtocolVsProtocol]
+from typing import Protocol
+
+class One(Protocol):
+    def __call__(self, x: str) -> None: ...
+
+class Other(Protocol):
+    def __call__(self, x: str) -> None: ...
+
+class Bad(Protocol):
+    def __call__(self, zzz: str) -> None: ...
+
+def func(caller: One) -> None:
+    pass
+
+a: Other
+b: Bad
+
+func(a)
+func(b)  # E: Argument 1 to "func" has incompatible type "Bad"; expected "One"
+[out]
+
+[case testJoinProtocolCallback]
+from typing import Protocol, Callable
+
+class A: ...
+class B(A): ...
+class C(B): ...
+class D(B): ...
+
+class Call(Protocol):
+    def __call__(self, x: B) -> C: ...
+Normal = Callable[[A], D]
+
+a: Call
+b: Normal
+
+reveal_type([a, b])  # E: Revealed type is 'builtins.list[def (__main__.B) -> __main__.B]'
+[builtins fixtures/list.pyi]
+[out]
+
+[case testMeetProtocolCallback]
+from typing import Protocol, Callable
+
+class A: ...
+class B(A): ...
+class C(B): ...
+class D(B): ...
+
+class Call(Protocol):
+    def __call__(self, __x: C) -> B: ...
+Normal = Callable[[D], A]
+
+def a(x: Call) -> None: ...
+def b(x: Normal) -> None: ...
+
+reveal_type([a, b])  # E: Revealed type is 'builtins.list[def (x: def (__main__.B) -> __main__.B)]'
+[builtins fixtures/list.pyi]
 [out]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2268,3 +2268,16 @@ def func(caller: Caller) -> None:
 func(call)
 func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[Union[int, str]], Union[int, str]]"; expected "Caller"
 [out]
+
+[case testCallableImplementsProtocolExtraNote]
+from typing import Protocol
+
+class Caller(Protocol):
+    def __call__(self, x: str, *args: int) -> None: ...
+
+def bad(x: int, *args: str) -> None:
+    pass
+
+cb: Caller = bad  # E: Incompatible types in assignment (expression has type "Callable[[int, VarArg(str)], None]", variable has type "Caller") \
+                  # N: "Caller.__call__" has type "Callable[[Arg(str, 'x'), VarArg(int)], None]"
+[out]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2187,3 +2187,84 @@ else:
     reveal_type(cls)  # E: Revealed type is 'Type[__main__.E]'
 [builtins fixtures/isinstance.pyi]
 [out]
+
+[case testCallableImplementsProtocol]
+from typing import Protocol
+
+class Caller(Protocol):
+    def __call__(self, x: str, *args: int) -> None: ...
+
+def call(x: str, *args: int) -> None:
+    pass
+def bad(x: int, *args: str) -> None:
+    pass
+
+def func(caller: Caller) -> None:
+    pass
+
+func(call)
+func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[int, VarArg(str)], None]"; expected "Caller"
+[out]
+
+[case testCallableImplementsProtocolGeneric]
+from typing import Protocol, TypeVar, Tuple
+
+T = TypeVar('T')
+S = TypeVar('S')
+
+class Caller(Protocol[T, S]):
+    def __call__(self, x: T, y: S) -> Tuple[T, S]: ...
+
+def call(x: int, y: str) -> Tuple[int, str]: ...
+
+def func(caller: Caller[T, S]) -> Tuple[T, S]:
+    pass
+
+reveal_type(func(call))  # E: Revealed type is 'Tuple[builtins.int*, builtins.str*]'
+[builtins fixtures/tuple.pyi]
+[out]
+
+[case testCallableImplementsProtocolGenericTight]
+from typing import Protocol, TypeVar
+
+T = TypeVar('T')
+
+class Caller(Protocol):
+    def __call__(self, x: T) -> T: ...
+
+def call(x: T) -> T: ...
+def bad(x: int) -> int: ...
+
+def func(caller: Caller) -> None:
+    pass
+
+func(call)
+func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[int], int]"; expected "Caller"
+[builtins fixtures/tuple.pyi]
+[out]
+
+[case testCallableImplementsProtocolOverload]
+from typing import Protocol, overload, Union
+
+class Caller(Protocol):
+    @overload
+    def __call__(self, x: int) -> int: ...
+    @overload
+    def __call__(self, x: str) -> str: ...
+
+@overload
+def call(x: int) -> int: ...
+@overload
+def call(x: str) -> str: ...
+def call(x: Union[int, str]) -> Union[int, str]:
+    pass
+
+def bad(x: Union[int, str]) -> Union[int, str]:
+    pass
+
+def func(caller: Caller) -> None:
+    pass
+
+func(call)
+func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[Union[int, str]], Union[int, str]]"; expected "Caller"
+[out]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2281,3 +2281,29 @@ def bad(x: int, *args: str) -> None:
 cb: Caller = bad  # E: Incompatible types in assignment (expression has type "Callable[[int, VarArg(str)], None]", variable has type "Caller") \
                   # N: "Caller.__call__" has type "Callable[[Arg(str, 'x'), VarArg(int)], None]"
 [out]
+
+[case testCallableImplementsProtocolArgName]
+from typing import Protocol
+
+class Caller(Protocol):
+    def __call__(self, x: str) -> None: ...
+
+class CallerAnon(Protocol):
+    def __call__(self, __x: str) -> None: ...
+
+def call(x: str) -> None:
+    pass
+def bad(y: str) -> None:
+    pass
+
+def func(caller: Caller) -> None:
+    pass
+
+def anon(caller: CallerAnon) -> None:
+    pass
+
+
+func(call)
+func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[str], None]"; expected "Caller"
+anon(bad)
+[out]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2366,6 +2366,7 @@ a: Call
 b: Normal
 
 reveal_type([a, b])  # E: Revealed type is 'builtins.list[def (__main__.B) -> __main__.B]'
+reveal_type([b, a])  # E: Revealed type is 'builtins.list[def (__main__.B) -> __main__.B]'
 [builtins fixtures/list.pyi]
 [out]
 
@@ -2385,5 +2386,6 @@ def a(x: Call) -> None: ...
 def b(x: Normal) -> None: ...
 
 reveal_type([a, b])  # E: Revealed type is 'builtins.list[def (x: def (__main__.B) -> __main__.B)]'
+reveal_type([b, a])  # E: Revealed type is 'builtins.list[def (x: def (__main__.B) -> __main__.B)]'
 [builtins fixtures/list.pyi]
 [out]


### PR DESCRIPTION
Fixes #5453 

The issue proposed an interesting idea. Allow callables as subtypes of protocols with `__call__`. IMO this is not just reasonable and type safe, but is also more clear that the extended callable syntax in `mypy_extensions`. For example:
```python
class Combiner(Protocol):
    def __call__(self, *vals: bytes, maxlen: Optional[int] = None) -> List[bytes]: ...

def batch_proc(data: Iterable[bytes], cb_results: Combiner) -> bytes:
    ...
```

The callback protocols:
* Have cleaner familiar syntax in contrast to `Callable[[VarArg(bytes), DefaultNamedArg(Optional[int], 'maxlen')], List[bytes]]` (compare to above)
* Allow to be more explicit/flexible about binding of type variables in generic callbacks (see tests for examples)
* Support overloaded callbacks (this is simply impossible with the current extended callable syntax)
* Are easy to implement

If this will get some traction, I would actually propose to deprecate extended callable syntax in favor of callback protocols.