### PR TITLE
Add machinery for marking places we subvert the type system

### DIFF
--- a/mypy/bogus_type.py
+++ b/mypy/bogus_type.py
@@ -1,0 +1,22 @@
+"""A Bogus[T] type alias for marking when we subvert the type system
+
+We need this for compiling with mypyc, which inserts runtime
+typechecks that cause problems when we subvert the type system. So
+when compiling with mypyc, we turn those places into Any, while
+keeping the types around for normal typechecks.
+
+Since this causes the runtype types to be Any, this is best used
+in places where efficient access to properties is not important.
+For those cases some other technique should be used.
+"""
+
+from mypy_extensions import FlexibleAlias
+from typing import TypeVar, Any
+
+T = TypeVar('T')
+
+SUPPRESS_BOGUS_TYPES = False
+if SUPPRESS_BOGUS_TYPES:
+    Bogus = FlexibleAlias[T, Any]
+else:
+    Bogus = FlexibleAlias[T, T]

--- a/mypy/bogus_type.py
+++ b/mypy/bogus_type.py
@@ -5,7 +5,7 @@ typechecks that cause problems when we subvert the type system. So
 when compiling with mypyc, we turn those places into Any, while
 keeping the types around for normal typechecks.
 
-Since this causes the runtype types to be Any, this is best used
+Since this causes the runtime types to be Any, this is best used
 in places where efficient access to properties is not important.
 For those cases some other technique should be used.
 """

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -176,8 +176,11 @@ class SymbolNode(Node):
     # TODO do not use methods for these
 
     @abstractmethod
-    def name(self) -> Bogus[str]: pass
+    def name(self) -> str: pass
 
+    # fullname can often be None even though the type system
+    # disagrees. We mark this with Bogus to let mypyc know not to
+    # worry about it.
     @abstractmethod
     def fullname(self) -> Bogus[str]: pass
 
@@ -197,7 +200,7 @@ class MypyFile(SymbolNode):
     """The abstract syntax tree of a single source file."""
 
     # Module name ('__main__' for initial file)
-    _name = None      # type: Bogus[str]
+    _name = ''      # type: str
     # Fully qualified module name
     _fullname = None  # type: Bogus[str]
     # Path to the file (None if not known)
@@ -238,7 +241,7 @@ class MypyFile(SymbolNode):
         else:
             self.ignored_lines = set()
 
-    def name(self) -> Bogus[str]:
+    def name(self) -> str:
         return self._name
 
     def fullname(self) -> Bogus[str]:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -199,8 +199,6 @@ class SymbolNode(Node):
 class MypyFile(SymbolNode):
     """The abstract syntax tree of a single source file."""
 
-    # Module name ('__main__' for initial file)
-    _name = ''      # type: str
     # Fully qualified module name
     _fullname = None  # type: Bogus[str]
     # Path to the file (None if not known)
@@ -242,7 +240,7 @@ class MypyFile(SymbolNode):
             self.ignored_lines = set()
 
     def name(self) -> str:
-        return self._name
+        return '' if not self._fullname else self._fullname.split('.')[-1]
 
     def fullname(self) -> Bogus[str]:
         return self._fullname
@@ -256,7 +254,6 @@ class MypyFile(SymbolNode):
 
     def serialize(self) -> JsonDict:
         return {'.class': 'MypyFile',
-                '_name': self._name,
                 '_fullname': self._fullname,
                 'names': self.names.serialize(self._fullname),
                 'is_stub': self.is_stub,
@@ -268,7 +265,6 @@ class MypyFile(SymbolNode):
     def deserialize(cls, data: JsonDict) -> 'MypyFile':
         assert data['.class'] == 'MypyFile', data
         tree = MypyFile([], [])
-        tree._name = data['_name']
         tree._fullname = data['_fullname']
         tree.names = SymbolTable.deserialize(data['names'])
         tree.is_stub = data['is_stub']

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -61,7 +61,6 @@ class TransformVisitor(NodeVisitor[Node]):
         # NOTE: The 'names' and 'imports' instance variables will be empty!
         new = MypyFile(self.statements(node.defs), [], node.is_bom,
                        ignored_lines=set(node.ignored_lines))
-        new._name = node._name
         new._fullname = node._fullname
         new.path = node.path
         new.names = SymbolTable()

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -18,6 +18,7 @@ from mypy.nodes import (
 )
 from mypy.sharedparse import argument_elide_name
 from mypy.util import IdMapper
+from mypy.bogus_type import Bogus
 
 T = TypeVar('T')
 
@@ -341,8 +342,8 @@ class AnyType(Type):
         return visitor.visit_any(self)
 
     def copy_modified(self,
-                      type_of_any: TypeOfAny = _dummy,
-                      original_any: Optional['AnyType'] = _dummy,
+                      type_of_any: Bogus[TypeOfAny] = _dummy,
+                      original_any: Bogus[Optional['AnyType']] = _dummy,
                       ) -> 'AnyType':
         if type_of_any is _dummy:
             type_of_any = self.type_of_any
@@ -743,22 +744,22 @@ class CallableType(FunctionLike):
             self.def_extras = {}
 
     def copy_modified(self,
-                      arg_types: List[Type] = _dummy,
-                      arg_kinds: List[int] = _dummy,
-                      arg_names: List[Optional[str]] = _dummy,
-                      ret_type: Type = _dummy,
-                      fallback: Instance = _dummy,
-                      name: Optional[str] = _dummy,
-                      definition: SymbolNode = _dummy,
-                      variables: List[TypeVarDef] = _dummy,
-                      line: int = _dummy,
-                      column: int = _dummy,
-                      is_ellipsis_args: bool = _dummy,
-                      implicit: bool = _dummy,
-                      special_sig: Optional[str] = _dummy,
-                      from_type_type: bool = _dummy,
-                      bound_args: List[Optional[Type]] = _dummy,
-                      def_extras: Dict[str, Any] = _dummy) -> 'CallableType':
+                      arg_types: Bogus[List[Type]] = _dummy,
+                      arg_kinds: Bogus[List[int]] = _dummy,
+                      arg_names: Bogus[List[Optional[str]]] = _dummy,
+                      ret_type: Bogus[Type] = _dummy,
+                      fallback: Bogus[Instance] = _dummy,
+                      name: Bogus[Optional[str]] = _dummy,
+                      definition: Bogus[SymbolNode] = _dummy,
+                      variables: Bogus[List[TypeVarDef]] = _dummy,
+                      line: Bogus[int] = _dummy,
+                      column: Bogus[int] = _dummy,
+                      is_ellipsis_args: Bogus[bool] = _dummy,
+                      implicit: Bogus[bool] = _dummy,
+                      special_sig: Bogus[Optional[str]] = _dummy,
+                      from_type_type: Bogus[bool] = _dummy,
+                      bound_args: Bogus[List[Optional[Type]]] = _dummy,
+                      def_extras: Bogus[Dict[str, Any]] = _dummy) -> 'CallableType':
         return CallableType(
             arg_types=arg_types if arg_types is not _dummy else self.arg_types,
             arg_kinds=arg_kinds if arg_kinds is not _dummy else self.arg_kinds,
@@ -1457,8 +1458,9 @@ class TypeType(Type):
     # a generic class instance, a union, Any, a type variable...
     item = None  # type: Type
 
-    def __init__(self, item: Union[Instance, AnyType, TypeVarType, TupleType, NoneTyp,
-                                   CallableType], *, line: int = -1, column: int = -1) -> None:
+    def __init__(self, item: Bogus[Union[Instance, AnyType, TypeVarType, TupleType, NoneTyp,
+                                         CallableType]], *,
+                 line: int = -1, column: int = -1) -> None:
         """To ensure Type[Union[A, B]] is always represented as Union[Type[A], Type[B]], item of
         type UnionType must be handled through make_normalized static method.
         """

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -342,6 +342,7 @@ class AnyType(Type):
         return visitor.visit_any(self)
 
     def copy_modified(self,
+                      # Mark with Bogus because _dummy is just an object (with type Any)
                       type_of_any: Bogus[TypeOfAny] = _dummy,
                       original_any: Bogus[Optional['AnyType']] = _dummy,
                       ) -> 'AnyType':

--- a/mypy_bootstrap.ini
+++ b/mypy_bootstrap.ini
@@ -8,7 +8,7 @@ disallow_any_generics = True
 disallow_any_unimported = True
 warn_redundant_casts = True
 warn_unused_configs = True
-always_false = SUPPRESS_BOGUS_TYPES
+always_true = SUPPRESS_BOGUS_TYPES
 
 # needs py2 compatibility
 [mypy-mypy.test.testextensions]

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(name='mypy',
       classifiers=classifiers,
       cmdclass={'build_py': CustomPythonBuild},
       install_requires = ['typed-ast >= 1.1.0, < 1.2.0',
+                          'mypy_extensions >= 0.4.0, < 0.5.0',
                           ],
       extras_require = {
           ':python_version < "3.5"': 'typing >= 3.5.3',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ flake8
 flake8-bugbear; python_version >= '3.5'
 flake8-pyi; python_version >= '3.6'
 lxml==4.2.4
-git+git://github.com/python/mypy.git@5ed6919604c38a4ecfe3ec20d00687c267d8c6ca#egg=mypy_extensions&subdirectory=extensions
+mypy_extensions==0.4.0
 psutil==5.4.0
 pytest>=3.4
 pytest-xdist>=1.22

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,7 @@ flake8
 flake8-bugbear; python_version >= '3.5'
 flake8-pyi; python_version >= '3.6'
 lxml==4.2.4
+git+git://github.com/python/mypy.git@5ed6919604c38a4ecfe3ec20d00687c267d8c6ca#egg=mypy_extensions&subdirectory=extensions
 psutil==5.4.0
 pytest>=3.4
 pytest-xdist>=1.22


### PR DESCRIPTION
We need this for compiling with mypyc, which inserts runtime
typechecks that cause problems when we subvert the type system. So
when compiling with mypyc, we turn those places into Any, while
keeping the types around for normal typechecks.

Since this causes the runtype types to be Any, this is best used
in places where efficient access to properties is not important.
For those cases some other technique should be used.