### PR TITLE
Rework `replace_object_state` to not depend on `__slots__`

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -188,7 +188,7 @@ def correct_relative_import(cur_mod_id: str,
     return cur_mod_id + (("." + target) if target else ""), ok
 
 
-FIELDS_CACHE = {}  # type: Dict[Type[object], List[str]]
+fields_cache = {}  # type: Dict[Type[object], List[str]]
 
 
 def replace_object_state(new: object, old: object) -> None:
@@ -203,13 +203,14 @@ def replace_object_state(new: object, old: object) -> None:
         new.__dict__ = old.__dict__
 
     cls = old.__class__
-    # Maintain a cache of type -> attributes
-    if cls not in FIELDS_CACHE:
+    # Maintain a cache of type -> attributes defined by descriptors in the class
+    # (that is, attributes from __slots__ and C extension classes)
+    if cls not in fields_cache:
         members = inspect.getmembers(
             cls,
             lambda o: inspect.isgetsetdescriptor(o) or inspect.ismemberdescriptor(o))
-        FIELDS_CACHE[cls] = [x for x, y in members if x != '__weakref__']
-    for attr in FIELDS_CACHE[cls]:
+        fields_cache[cls] = [x for x, y in members if x != '__weakref__']
+    for attr in fields_cache[cls]:
         try:
             if hasattr(old, attr):
                 setattr(new, attr, getattr(old, attr))

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -7,7 +7,7 @@ import re
 import subprocess
 import sys
 from xml.sax.saxutils import escape
-from typing import TypeVar, List, Tuple, Optional, Dict, Sequence, Type
+from typing import TypeVar, List, Tuple, Optional, Dict, Sequence
 
 
 T = TypeVar('T')
@@ -190,7 +190,7 @@ def correct_relative_import(cur_mod_id: str,
     return cur_mod_id + (("." + target) if target else ""), ok
 
 
-FIELDS_CACHE = {}  # type: Dict[Type[object], List[str]]
+FIELDS_CACHE = {}  # type: Dict[object, List[str]]
 
 
 def replace_object_state(new: object, old: object) -> None:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -9,6 +9,9 @@ import sys
 from xml.sax.saxutils import escape
 from typing import TypeVar, List, Tuple, Optional, Dict, Sequence
 
+MYPY = False
+if MYPY:
+    from typing import Type
 
 T = TypeVar('T')
 
@@ -190,7 +193,7 @@ def correct_relative_import(cur_mod_id: str,
     return cur_mod_id + (("." + target) if target else ""), ok
 
 
-FIELDS_CACHE = {}  # type: Dict[object, List[str]]
+FIELDS_CACHE = {}  # type: Dict[Type[object], List[str]]
 
 
 def replace_object_state(new: object, old: object) -> None:


### PR DESCRIPTION
Classes from C extension modules (like those generated by mypyc) will
have attributes that are neither from `__dict__` nor `__slots__`.

(`replace_object_state` is used by astmerge to do the merging)