### PR TITLE
Make FakeInfo a more general-purpose TypeInfo placeholder

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -435,7 +435,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 assert isinstance(inner_type, CallableType)
                 impl_type = inner_type
 
-        is_descriptor_get = defn.info is not None and defn.name() == "__get__"
+        is_descriptor_get = defn.info and defn.name() == "__get__"
         for i, item in enumerate(defn.items):
             # TODO overloads involving decorators
             assert isinstance(item, Decorator)
@@ -979,7 +979,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # just decides whether it's worth calling
         # check_overlapping_op_methods().
 
-        assert defn.info is not None
+        assert defn.info
 
         # First check for a valid signature
         method_type = CallableType([AnyType(TypeOfAny.special_form),
@@ -2765,7 +2765,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             self.msg.typed_function_untyped_decorator(func.name(), dec_expr)
 
     def check_incompatible_property_override(self, e: Decorator) -> None:
-        if not e.var.is_settable_property and e.func.info is not None:
+        if not e.var.is_settable_property and e.func.info:
             name = e.func.name()
             for base in e.func.info.mro[1:]:
                 base_attr = base.names.get(name)
@@ -3322,7 +3322,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     var.type = AnyType(TypeOfAny.from_error)
 
     def is_defined_in_base_class(self, var: Var) -> bool:
-        if var.info is not None:
+        if var.info:
             for base in var.info.mro[1:]:
                 if base.get(var.name()) is not None:
                     return True

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -23,10 +23,11 @@ from mypy.nodes import (
     AwaitExpr, TempNode, Expression, Statement,
     ARG_POS, ARG_OPT, ARG_STAR, ARG_NAMED, ARG_NAMED_OPT, ARG_STAR2,
     check_arg_names,
+    FakeInfo,
 )
 from mypy.types import (
     Type, CallableType, AnyType, UnboundType, TupleType, TypeList, EllipsisType, CallableArgument,
-    TypeOfAny
+    TypeOfAny, Instance,
 )
 from mypy import defaults
 from mypy import messages
@@ -59,7 +60,8 @@ V = TypeVar('V')
 
 # There is no way to create reasonable fallbacks at this stage,
 # they must be patched later.
-_dummy_fallback = None  # type: Any
+MISSING_FALLBACK = FakeInfo("fallback can't be filled out until semanal")
+_dummy_fallback = Instance(MISSING_FALLBACK, [], -1)
 
 TYPE_COMMENT_SYNTAX_ERROR = 'syntax error in type comment'
 TYPE_COMMENT_AST_ERROR = 'invalid type comment or annotation'

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -34,9 +34,10 @@ from mypy.nodes import (
     SetComprehension, ComplexExpr, EllipsisExpr, YieldExpr, Argument,
     Expression, Statement, BackquoteExpr, PrintStmt, ExecStmt,
     ARG_POS, ARG_OPT, ARG_STAR, ARG_NAMED, ARG_STAR2, OverloadPart, check_arg_names,
+    FakeInfo,
 )
 from mypy.types import (
-    Type, CallableType, AnyType, UnboundType, EllipsisType, TypeOfAny
+    Type, CallableType, AnyType, UnboundType, EllipsisType, TypeOfAny, Instance,
 )
 from mypy import messages
 from mypy.errors import Errors
@@ -70,7 +71,8 @@ V = TypeVar('V')
 
 # There is no way to create reasonable fallbacks at this stage,
 # they must be patched later.
-_dummy_fallback = None  # type: Any
+MISSING_FALLBACK = FakeInfo("fallback can't be filled out until semanal")
+_dummy_fallback = Instance(MISSING_FALLBACK, [], -1)
 
 TYPE_COMMENT_SYNTAX_ERROR = 'syntax error in type comment'
 TYPE_COMMENT_AST_ERROR = 'invalid type comment'

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -64,7 +64,7 @@ class TypeIndirectionVisitor(SyntheticTypeVisitor[Set[str]]):
 
     def visit_instance(self, t: types.Instance) -> Set[str]:
         out = self._visit(*t.args)
-        if t.type is not None:
+        if t.type:
             # Uses of a class depend on everything in the MRO,
             # as changes to classes in the MRO can add types to methods,
             # change property types, change the MRO itself, etc.

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -251,7 +251,7 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
         if (isinstance(s.lvalues[0], NameExpr) and s.lvalues[0].kind == MDEF
                 and isinstance(s.lvalues[0].node, Var)):
             var = s.lvalues[0].node
-            if var.info is not None and var.is_inferred and not var.is_classvar:
+            if var.info and var.is_inferred and not var.is_classvar:
                 for base in var.info.mro[1:]:
                     tnode = base.names.get(var.name())
                     if (tnode is not None and isinstance(tnode.node, Var)

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -1070,7 +1070,7 @@ def target_from_node(module: str,
             return None
         return module
     elif isinstance(node, (OverloadedFuncDef, FuncDef)):
-        if node.info is not None:
+        if node.info:
             return '%s.%s' % (node.info.fullname(), node.name())
         else:
             return '%s.%s' % (module, node.name())

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -560,6 +560,7 @@ def find_node_type(node: Union[Var, FuncBase], itype: Instance, subtype: Type) -
         else:
             typ = signature
     itype = map_instance_to_supertype(itype, node.info)
+    assert typ is not None
     typ = expand_type_by_instance(typ, itype)
     return typ
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -413,7 +413,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 variables = self.bind_function_type_variables(t, t)
             ret = t.copy_modified(arg_types=self.anal_array(t.arg_types, nested=nested),
                                   ret_type=self.anal_type(t.ret_type, nested=nested),
-                                  fallback=t.fallback or self.named_type('builtins.function'),
+                                  fallback=(t.fallback if t.fallback.type
+                                            else self.named_type('builtins.function')),
                                   variables=self.anal_var_defs(variables))
         return ret
 
@@ -437,7 +438,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             else:
                 return AnyType(TypeOfAny.from_error)
         any_type = AnyType(TypeOfAny.special_form)
-        fallback = t.fallback if t.fallback else self.named_type('builtins.tuple', [any_type])
+        fallback = (t.fallback if t.fallback.type
+                    else self.named_type('builtins.tuple', [any_type]))
         return TupleType(self.anal_array(t.items), fallback, t.line)
 
     def visit_typeddict_type(self, t: TypedDictType) -> Type:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -490,9 +490,7 @@ class DeletedType(Type):
 
 
 # Fake TypeInfo to be used as a placeholder during Instance de-serialization.
-NOT_READY = mypy.nodes.FakeInfo(mypy.nodes.SymbolTable(),
-                                mypy.nodes.ClassDef('<NOT READY>', mypy.nodes.Block([])),
-                                '<NOT READY>')
+NOT_READY = mypy.nodes.FakeInfo('De-serialization failure: TypeInfo not fixed')
 
 
 class Instance(Type):
@@ -506,7 +504,7 @@ class Instance(Type):
     def __init__(self, typ: mypy.nodes.TypeInfo, args: List[Type],
                  line: int = -1, column: int = -1, erased: bool = False) -> None:
         super().__init__(line, column)
-        assert typ is NOT_READY or typ.fullname() not in ["builtins.Any", "typing.Any"]
+        assert not typ or typ.fullname() not in ["builtins.Any", "typing.Any"]
         self.type = typ
         self.args = args
         self.erased = erased  # True if result of type variable substitution


### PR DESCRIPTION
There are a lot of places in mypy currently that shove None into
fields expecting TypeInfo. Since mypyc does not appreciate this kind
of behavior, use FakeInfo instances instead of None. FakeInfo is
generalized to allow different assertion messages and to override
`__bool__` so that it can be conveniently checked against.