### PR TITLE
Start moving things mypyc won't support to a new file

### DIFF
--- a/mypy/mypyc_hacks.py
+++ b/mypy/mypyc_hacks.py
@@ -1,0 +1,8 @@
+"""Stuff that we had to move out of its right place because of mypyc limitations."""
+
+# Moved from util.py, because it inherits from Exception
+class DecodeError(Exception):
+    """Exception raised when a file cannot be decoded due to an unknown encoding type.
+
+    Essentially a wrapper for the LookupError raised by `bytearray.decode`
+    """

--- a/mypy/mypyc_hacks.py
+++ b/mypy/mypyc_hacks.py
@@ -35,3 +35,59 @@ class TypeOfAny(Enum):
     from_another_any = 'from_another_any'
     # Does this Any come from an implementation limitation/bug?
     implementation_artifact = 'implementation_artifact'
+
+
+# Moved from nodes.py, because it inherits from dict
+from typing import Dict, List, Any
+
+JsonDict = Dict[str, Any]
+
+MYPY = False
+if MYPY:
+    from mypy.nodes import SymbolTableNode
+
+class SymbolTable(Dict[str, 'SymbolTableNode']):
+    def __str__(self) -> str:
+        from mypy.nodes import implicit_module_attrs, SymbolTableNode
+
+        a = []  # type: List[str]
+        for key, value in self.items():
+            # Filter out the implicit import of builtins.
+            if isinstance(value, SymbolTableNode):
+                if (value.fullname != 'builtins' and
+                        (value.fullname or '').split('.')[-1] not in
+                        implicit_module_attrs):
+                    a.append('  ' + str(key) + ' : ' + str(value))
+            else:
+                a.append('  <invalid item>')
+        a = sorted(a)
+        a.insert(0, 'SymbolTable(')
+        a[-1] += ')'
+        return '\n'.join(a)
+
+    def copy(self) -> 'SymbolTable':
+        return SymbolTable((key, node.copy())
+                           for key, node in self.items())
+
+    def serialize(self, fullname: str) -> JsonDict:
+        data = {'.class': 'SymbolTable'}  # type: JsonDict
+        for key, value in self.items():
+            # Skip __builtins__: it's a reference to the builtins
+            # module that gets added to every module by
+            # SemanticAnalyzerPass2.visit_file(), but it shouldn't be
+            # accessed by users of the module.
+            if key == '__builtins__' or value.no_serialize:
+                continue
+            data[key] = value.serialize(fullname, key)
+        return data
+
+    @classmethod
+    def deserialize(cls, data: JsonDict) -> 'SymbolTable':
+        from mypy.nodes import SymbolTableNode
+
+        assert data['.class'] == 'SymbolTable'
+        st = SymbolTable()
+        for key, value in data.items():
+            if key != '.class':
+                st[key] = SymbolTableNode.deserialize(value)
+        return st

--- a/mypy/mypyc_hacks.py
+++ b/mypy/mypyc_hacks.py
@@ -6,3 +6,32 @@ class DecodeError(Exception):
 
     Essentially a wrapper for the LookupError raised by `bytearray.decode`
     """
+
+
+# Moved from types.py, because it inherits from Enum, which uses a
+# metaclass in a nontrivial way.
+from enum import Enum
+
+
+class TypeOfAny(Enum):
+    """
+    This class describes different types of Any. Each 'Any' can be of only one type at a time.
+    """
+    # Was this Any type was inferred without a type annotation?
+    unannotated = 'unannotated'
+    # Does this Any come from an explicit type annotation?
+    explicit = 'explicit'
+    # Does this come from an unfollowed import? See --disallow-any-unimported option
+    from_unimported_type = 'from_unimported_type'
+    # Does this Any type come from omitted generics?
+    from_omitted_generics = 'from_omitted_generics'
+    # Does this Any come from an error?
+    from_error = 'from_error'
+    # Is this a type that can't be represented in mypy's type system? For instance, type of
+    # call to NewType...). Even though these types aren't real Anys, we treat them as such.
+    # Also used for variables named '_'.
+    special_form = 'special_form'
+    # Does this Any come from interaction with another Any?
+    from_another_any = 'from_another_any'
+    # Does this Any come from an implementation limitation/bug?
+    implementation_artifact = 'implementation_artifact'

--- a/mypy/mypyc_hacks.py
+++ b/mypy/mypyc_hacks.py
@@ -1,5 +1,6 @@
 """Stuff that we had to move out of its right place because of mypyc limitations."""
 
+
 # Moved from util.py, because it inherits from Exception
 class DecodeError(Exception):
     """Exception raised when a file cannot be decoded due to an unknown encoding type.
@@ -46,9 +47,10 @@ MYPY = False
 if MYPY:
     from mypy.nodes import SymbolTableNode
 
+
 class SymbolTable(Dict[str, 'SymbolTableNode']):
     def __str__(self) -> str:
-        from mypy.nodes import implicit_module_attrs, SymbolTableNode
+        from mypy.nodes import implicit_module_attrs, SymbolTableNode  # noqa
 
         a = []  # type: List[str]
         for key, value in self.items():
@@ -83,7 +85,7 @@ class SymbolTable(Dict[str, 'SymbolTableNode']):
 
     @classmethod
     def deserialize(cls, data: JsonDict) -> 'SymbolTable':
-        from mypy.nodes import SymbolTableNode
+        from mypy.nodes import SymbolTableNode  # noqa
 
         assert data['.class'] == 'SymbolTable'
         st = SymbolTable()

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -4,7 +4,6 @@ import sys
 import copy
 from abc import abstractmethod
 from collections import OrderedDict
-from enum import Enum
 from typing import (
     Any, TypeVar, Dict, List, Tuple, cast, Generic, Set, Optional, Union, Iterable, NamedTuple,
     Callable, Sequence, Iterator
@@ -18,6 +17,8 @@ from mypy.nodes import (
 )
 from mypy.sharedparse import argument_elide_name
 from mypy.util import IdMapper
+
+from mypy.mypyc_hacks import TypeOfAny
 
 T = TypeVar('T')
 
@@ -279,30 +280,6 @@ class TypeList(Type):
 
 
 _dummy = object()  # type: Any
-
-
-class TypeOfAny(Enum):
-    """
-    This class describes different types of Any. Each 'Any' can be of only one type at a time.
-    """
-    # Was this Any type was inferred without a type annotation?
-    unannotated = 'unannotated'
-    # Does this Any come from an explicit type annotation?
-    explicit = 'explicit'
-    # Does this come from an unfollowed import? See --disallow-any-unimported option
-    from_unimported_type = 'from_unimported_type'
-    # Does this Any type come from omitted generics?
-    from_omitted_generics = 'from_omitted_generics'
-    # Does this Any come from an error?
-    from_error = 'from_error'
-    # Is this a type that can't be represented in mypy's type system? For instance, type of
-    # call to NewType...). Even though these types aren't real Anys, we treat them as such.
-    # Also used for variables named '_'.
-    special_form = 'special_form'
-    # Does this Any come from interaction with another Any?
-    from_another_any = 'from_another_any'
-    # Does this Any come from an implementation limitation/bug?
-    implementation_artifact = 'implementation_artifact'
 
 
 class AnyType(Type):

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -8,6 +8,7 @@ import sys
 from xml.sax.saxutils import escape
 from typing import TypeVar, List, Tuple, Optional, Dict, Sequence
 
+from mypy.mypyc_hacks import DecodeError
 
 T = TypeVar('T')
 
@@ -61,13 +62,6 @@ def find_python_encoding(text: bytes, pyversion: Tuple[int, int]) -> Tuple[str, 
     else:
         default_encoding = 'utf8' if pyversion[0] >= 3 else 'ascii'
         return default_encoding, -1
-
-
-class DecodeError(Exception):
-    """Exception raised when a file cannot be decoded due to an unknown encoding type.
-
-    Essentially a wrapper for the LookupError raised by `bytearray.decode`
-    """
 
 
 def decode_python_encoding(source: bytes, pyversion: Tuple[int, int]) -> str:


### PR DESCRIPTION
There are a handful of features that mypyc is unlikely to properly support soon (if ever), like inheriting from non-object built-in classes and having nontrivial metaclasses. Start moving classes that do this out into a `mypyc_hacks` module.

So far this moves files from `util`, `nodes`, and `types`. (All of which I have working under mypyc!)