### PR TITLE
Add partial overload checks

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3516,8 +3516,7 @@ def conditional_type_map(expr: Expression,
                 # Expression is always of one of the types in proposed_type_ranges
                 return {}, None
             elif not is_overlapping_types(current_type, proposed_type,
-                                          prohibit_none_typevar_overlap=True,
-                                          default_return=True):
+                                          prohibit_none_typevar_overlap=True):
                 # Expression is never of any type in proposed_type_ranges
                 return None, {}
             else:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3744,9 +3744,6 @@ def is_unsafe_overlapping_overload_signatures(signature: CallableType,
     Assumes that 'signature' appears earlier in the list of overload
     alternatives then 'other' and that their argument counts are overlapping.
     """
-    def is_more_precise_or_partially_overlapping(t: Type, s: Type) -> bool:
-        return is_more_precise_no_promote(t, s) or is_overlapping_types_no_promote(t, s)
-
     # Try detaching callables from the containing class so that all TypeVars
     # are treated as being free.
     #
@@ -3767,13 +3764,13 @@ def is_unsafe_overlapping_overload_signatures(signature: CallableType,
     # This discrepancy is unfortunately difficult to get rid of, so we repeat the
     # checks twice in both directions for now.
     return (is_callable_compatible(signature, other,
-                                  is_compat=is_more_precise_or_partially_overlapping,
+                                  is_compat=is_overlapping_types_no_promote,
                                   is_compat_return=lambda l, r: not is_subtype_no_promote(l, r),
                                   ignore_return=False,
                                   check_args_covariantly=True,
                                   allow_partial_overlap=True) or
             is_callable_compatible(other, signature,
-                                   is_compat=is_more_precise_or_partially_overlapping,
+                                   is_compat=is_overlapping_types_no_promote,
                                    is_compat_return=lambda l, r: not is_subtype_no_promote(r, l),
                                    ignore_return=False,
                                    check_args_covariantly=False,
@@ -4024,10 +4021,6 @@ def is_static(func: Union[FuncBase, Decorator]) -> bool:
 
 def is_subtype_no_promote(left: Type, right: Type) -> bool:
     return is_subtype(left, right, ignore_promotions=True)
-
-
-def is_more_precise_no_promote(left: Type, right: Type) -> bool:
-    return is_more_precise(left, right, ignore_promotions=True)
 
 
 def is_overlapping_types_no_promote(left: Type, right: Type) -> bool:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3497,7 +3497,7 @@ def conditional_type_map(expr: Expression,
                 return {}, None
             elif not is_overlapping_types(current_type, proposed_type,
                                           prohibit_none_typevar_overlap=True,
-                                          default_return=False):
+                                          default_return=True):
                 # Expression is never of any type in proposed_type_ranges
                 return None, {}
             else:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5,7 +5,7 @@ import fnmatch
 from contextlib import contextmanager
 
 from typing import (
-    Dict, Set, List, cast, Tuple, TypeVar, Union, Optional, NamedTuple, Iterator
+    Dict, Set, List, cast, Tuple, TypeVar, Union, Optional, NamedTuple, Iterator, Iterable
 )
 
 from mypy.errors import Errors, report_internal_error
@@ -30,7 +30,7 @@ from mypy.types import (
     Type, AnyType, CallableType, FunctionLike, Overloaded, TupleType, TypedDictType,
     Instance, NoneTyp, strip_type, TypeType, TypeOfAny,
     UnionType, TypeVarId, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarDef,
-    true_only, false_only, function_type, is_named_instance, union_items,
+    true_only, false_only, function_type, is_named_instance, union_items, TypeQuery
 )
 from mypy.sametypes import is_same_type, is_same_types
 from mypy.messages import MessageBuilder, make_inferred_type_note
@@ -55,7 +55,7 @@ from mypy.visitor import NodeVisitor
 from mypy.join import join_types
 from mypy.treetransform import TransformVisitor
 from mypy.binder import ConditionalTypeBinder, get_declaration
-from mypy.meet import is_overlapping_types, is_partially_overlapping_types
+from mypy.meet import is_overlapping_erased_types, is_overlapping_types
 from mypy.options import Options
 from mypy.plugin import Plugin, CheckerPluginInterface
 from mypy.sharedparse import BINARY_MAGIC_METHODS
@@ -471,6 +471,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         if is_unsafe_overlapping_overload_signatures(sig1, sig2):
                             self.msg.overloaded_signatures_overlap(
                                 i + 1, i + j + 2, item.func)
+                        elif is_unsafe_partially_overlapping_overload_signatures(sig1, sig2):
+                            self.msg.overloaded_signatures_partial_overlap(
+                                i + 1, i + j + 2, item.func)
 
             if impl_type is not None:
                 assert defn.impl is not None
@@ -495,12 +498,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
                 # Is the overload alternative's arguments subtypes of the implementation's?
                 if not is_callable_compatible(impl, sig1,
-                                              is_compat=is_subtype,
+                                              is_compat=is_subtype_no_promote,
                                               ignore_return=True):
                     self.msg.overloaded_signatures_arg_specific(i + 1, defn.impl)
 
                 # Is the overload alternative's return type a subtype of the implementation's?
-                if not is_subtype(sig1.ret_type, impl.ret_type):
+                if not is_subtype_no_promote(sig1.ret_type, impl.ret_type):
                     self.msg.overloaded_signatures_ret_specific(i + 1, defn.impl)
 
     # Here's the scoop about generators and coroutines.
@@ -1154,7 +1157,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             first = forward_tweaked
             second = reverse_tweaked
 
-        return is_unsafe_overlapping_overload_signatures(first, second)
+        return is_unsafe_partially_overlapping_overload_signatures(first, second)
 
     def check_inplace_operator_method(self, defn: FuncBase) -> None:
         """Check an inplace operator method such as __iadd__.
@@ -3135,7 +3138,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     else:
                         optional_type, comp_type = second_type, first_type
                         optional_expr = node.operands[1]
-                    if is_overlapping_types(optional_type, comp_type):
+                    if is_overlapping_erased_types(optional_type, comp_type):
                         return {optional_expr: remove_optional(optional_type)}, {}
             elif node.operators in [['in'], ['not in']]:
                 expr = node.operands[0]
@@ -3146,7 +3149,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                             right_type.type.fullname() != 'builtins.object'))
                 if (right_type and right_ok and is_optional(left_type) and
                         literal(expr) == LITERAL_TYPE and not is_literal_none(expr) and
-                        is_overlapping_types(left_type, right_type)):
+                        is_overlapping_erased_types(left_type, right_type)):
                     if node.operators == ['in']:
                         return {expr: remove_optional(left_type)}, {}
                     if node.operators == ['not in']:
@@ -3494,7 +3497,8 @@ def conditional_type_map(expr: Expression,
                and is_proper_subtype(current_type, proposed_type)):
                 # Expression is always of one of the types in proposed_type_ranges
                 return {}, None
-            elif not is_overlapping_types(current_type, proposed_type):
+            elif not is_overlapping_types(current_type, proposed_type,
+                                          prohibit_none_typevar_overlap=True):
                 # Expression is never of any type in proposed_type_ranges
                 return None, {}
             else:
@@ -3710,9 +3714,48 @@ def are_argument_counts_overlapping(t: CallableType, s: CallableType) -> bool:
 
 def is_unsafe_overlapping_overload_signatures(signature: CallableType,
                                               other: CallableType) -> bool:
-    """Check if two overloaded function signatures may be unsafely overlapping.
+    """Check if two overloaded signatures are unsafely overlapping, ignoring partial overlaps.
 
-    We consider two functions 's' and 't' to be unsafely overlapping both if
+    We consider two functions 's' and 't' to be unsafely overlapping if both
+    of the following are true:
+
+    1.  s's parameters are all more precise or partially overlapping with t's
+    2.  s's return type is NOT a subtype of t's.
+
+    This function will perform a modified version of the above two checks:
+    we do not check for partial overlaps. This lets us vary our error messages
+    depending on the severity of the overlap.
+
+    See 'is_unsafe_partially_overlapping_overload_signatures' for the full checks.
+
+    Assumes that 'signature' appears earlier in the list of overload
+    alternatives then 'other' and that their argument counts are overlapping.
+    """
+    # if "foo" in signature.name or "bar" in signature.name or "chain_call" in signature.name:
+    #    print("in first")
+
+    signature = detach_callable(signature)
+    other = detach_callable(other)
+
+    return (is_callable_compatible(signature, other,
+                                  is_compat=is_more_precise_no_promote,
+                                  is_compat_return=lambda l, r: not is_subtype_no_promote(l, r),
+                                  ignore_return=False,
+                                  check_args_covariantly=True,
+                                  allow_partial_overlap=True) or
+            is_callable_compatible(other, signature,
+                                   is_compat=is_more_precise_no_promote,
+                                   is_compat_return=lambda l, r: not is_subtype_no_promote(r, l),
+                                   ignore_return=False,
+                                   check_args_covariantly=False,
+                                   allow_partial_overlap=True))
+
+
+def is_unsafe_partially_overlapping_overload_signatures(signature: CallableType,
+                                                        other: CallableType) -> bool:
+    """Check if two overloaded signatures are unsafely overlapping, ignoring partial overlaps.
+
+    We consider two functions 's' and 't' to be unsafely overlapping if both
     of the following are true:
 
     1.  s's parameters are all more precise or partially overlapping with t's
@@ -3721,26 +3764,105 @@ def is_unsafe_overlapping_overload_signatures(signature: CallableType,
     Assumes that 'signature' appears earlier in the list of overload
     alternatives then 'other' and that their argument counts are overlapping.
     """
-    # TODO: Handle partially overlapping parameter types
-    #
-    # For example, the signatures "f(x: Union[A, B]) -> int" and "f(x: Union[B, C]) -> str"
-    # is unsafe: the parameter types are partially overlapping.
-    #
-    # To fix this, we need to either modify meet.is_overlapping_types or add a new
-    # function and use "is_more_precise(...) or is_partially_overlapping(...)" for the is_compat
-    # checks.
-    #
-    # (We already have a rudimentary implementation of 'is_partially_overlapping', but it only
-    # attempts to handle the obvious cases -- see its docstring for more info.)
+    # if "foo" in signature.name or "bar" in signature.name or "chain_call" in signature.name:
+    #    print("in second")
 
     def is_more_precise_or_partially_overlapping(t: Type, s: Type) -> bool:
-        return is_more_precise(t, s) or is_partially_overlapping_types(t, s)
+        return is_more_precise_no_promote(t, s) or is_overlapping_types_no_promote(t, s)
 
-    return is_callable_compatible(signature, other,
+    # Try detaching callables from the containing class so that all TypeVars
+    # are treated as being free.
+    #
+    # This lets us identify cases where the two signatures use completely
+    # incompatible types -- e.g. see the testOverloadingInferUnionReturnWithMixedTypevars
+    # test case.
+    signature = detach_callable(signature)
+    other = detach_callable(other)
+
+    # Note: We repeat this check twice in both directions due to a slight
+    # asymmetry in 'is_callable_compatible'. When checking for partial overlaps,
+    # we attempt to unify 'signature' and 'other' both against each other.
+    #
+    # If 'signature' cannot be unified with 'other', we end early. However,
+    # if 'other' cannot be modified with 'signature', the function continues
+    # using the older version of 'other'.
+    #
+    # This discrepancy is unfortunately difficult to get rid of, so we repeat the
+    # checks twice in both directions for now.
+    return (is_callable_compatible(signature, other,
                                   is_compat=is_more_precise_or_partially_overlapping,
-                                  is_compat_return=lambda l, r: not is_subtype(l, r),
+                                  is_compat_return=lambda l, r: not is_subtype_no_promote(l, r),
+                                  ignore_return=False,
                                   check_args_covariantly=True,
-                                  allow_partial_overlap=True)
+                                  allow_partial_overlap=True) or
+            is_callable_compatible(other, signature,
+                                   is_compat=is_more_precise_or_partially_overlapping,
+                                   is_compat_return=lambda l, r: not is_subtype_no_promote(r, l),
+                                   ignore_return=False,
+                                   check_args_covariantly=False,
+                                   allow_partial_overlap=True))
+
+
+def detach_callable(typ: CallableType) -> CallableType:
+    """Ensures that the callable's type variables are 'detached' and independent of the context.
+
+    A callable normally keeps track of the type variables it uses within its 'variables' field.
+    However, if the callable is from a method and that method is using a class type variable,
+    the callable will not keep track of that type variable since it belongs to the class.
+
+    This function will traverse the callable and find all used type vars and add them to the
+    variables field if it isn't already present.
+
+    The caller can then unify on all type variables whether or not the callable is originally
+    from a class or not."""
+    type_list = typ.arg_types + [typ.ret_type]
+    # old_type_list = list(type_list)
+
+    appear_map = {}  # type: Dict[str, List[int]]
+    for i, inner_type in enumerate(type_list):
+        typevars_available = inner_type.accept(TypeVarExtractor())
+        for var in typevars_available:
+            if var.fullname not in appear_map:
+                appear_map[var.fullname] = []
+            appear_map[var.fullname].append(i)
+
+    used_type_var_names = set()
+    for var_name, appearances in appear_map.items():
+        used_type_var_names.add(var_name)
+
+    all_type_vars = typ.accept(TypeVarExtractor())
+    new_variables = []
+    for var in set(all_type_vars):
+        if var.fullname not in used_type_var_names:
+            continue
+        new_variables.append(TypeVarDef(
+            name=var.name,
+            fullname=var.fullname,
+            id=var.id,
+            values=var.values,
+            upper_bound=var.upper_bound,
+            variance=var.variance,
+        ))
+    out = typ.copy_modified(
+        variables=new_variables,
+        arg_types=type_list[:-1],
+        ret_type=type_list[-1],
+    )
+    return out
+
+
+class TypeVarExtractor(TypeQuery[List[TypeVarType]]):
+    def __init__(self) -> None:
+        super().__init__(self._merge)
+
+    def _merge(self, iter: Iterable[List[TypeVarType]]) -> List[TypeVarType]:
+        out = []
+        for item in iter:
+            out.extend(item)
+        return out
+
+    def visit_type_var(self, t: TypeVarType) -> List[TypeVarType]:
+        return [t]
 
 
 def overload_can_never_match(signature: CallableType, other: CallableType) -> bool:
@@ -3754,69 +3876,6 @@ def overload_can_never_match(signature: CallableType, other: CallableType) -> bo
     return is_callable_compatible(signature, other,
                                   is_compat=is_more_precise,
                                   ignore_return=True)
-
-
-def is_unsafe_overlapping_operator_signatures(signature: Type, other: Type) -> bool:
-    """Check if two operator method signatures may be unsafely overlapping.
-
-    Two signatures s and t are overlapping if both can be valid for the same
-    statically typed values and the return types are incompatible.
-
-    Assume calls are first checked against 'signature', then against 'other'.
-    Thus if 'signature' is more general than 'other', there is no unsafe
-    overlapping.
-
-    TODO: Clean up this function and make it not perform type erasure.
-
-    Context: This function was previously used to make sure both overloaded
-    functions and operator methods were not unsafely overlapping.
-
-    We changed the semantics for we should handle overloaded definitions,
-    but not operator functions. (We can't reuse the same semantics for both:
-    the overload semantics are too restrictive here).
-
-    We should rewrite this method so that:
-
-    1.  It uses many of the improvements made to overloads: in particular,
-        eliminating type erasure.
-
-    2.  It contains just the logic necessary for operator methods.
-    """
-    if isinstance(signature, CallableType):
-        if isinstance(other, CallableType):
-            # TODO varargs
-            # TODO keyword args
-            # TODO erasure
-            # TODO allow to vary covariantly
-            # Check if the argument counts are overlapping.
-            min_args = max(signature.min_args, other.min_args)
-            max_args = min(len(signature.arg_types), len(other.arg_types))
-            if min_args > max_args:
-                # Argument counts are not overlapping.
-                return False
-            # Signatures are overlapping iff if they are overlapping for the
-            # smallest common argument count.
-            for i in range(min_args):
-                t1 = signature.arg_types[i]
-                t2 = other.arg_types[i]
-                if not is_overlapping_types(t1, t2):
-                    return False
-            # All arguments types for the smallest common argument count are
-            # overlapping => the signature is overlapping. The overlapping is
-            # safe if the return types are identical.
-            if is_same_type(signature.ret_type, other.ret_type):
-                return False
-            # If the first signature has more general argument types, the
-            # latter will never be called
-            if is_more_general_arg_prefix(signature, other):
-                return False
-            # Special case: all args are subtypes, and returns are subtypes
-            if (all(is_proper_subtype(s, o)
-                    for (s, o) in zip(signature.arg_types, other.arg_types)) and
-                    is_subtype(signature.ret_type, other.ret_type)):
-                return False
-            return not is_more_precise_signature(signature, other)
-    return True
 
 
 def is_more_general_arg_prefix(t: FunctionLike, s: FunctionLike) -> bool:
@@ -3836,41 +3895,12 @@ def is_more_general_arg_prefix(t: FunctionLike, s: FunctionLike) -> bool:
     return False
 
 
-def is_equivalent_type_var_def(tv1: TypeVarDef, tv2: TypeVarDef) -> bool:
-    """Are type variable definitions equivalent?
-
-    Ignore ids, locations in source file and names.
-    """
-    return (
-        tv1.variance == tv2.variance
-        and is_same_types(tv1.values, tv2.values)
-        and ((tv1.upper_bound is None and tv2.upper_bound is None)
-             or (tv1.upper_bound is not None
-                 and tv2.upper_bound is not None
-                 and is_same_type(tv1.upper_bound, tv2.upper_bound))))
-
-
 def is_same_arg_prefix(t: CallableType, s: CallableType) -> bool:
     return is_callable_compatible(t, s,
                                   is_compat=is_same_type,
                                   ignore_return=True,
                                   check_args_covariantly=True,
                                   ignore_pos_arg_names=True)
-
-
-def is_more_precise_signature(t: CallableType, s: CallableType) -> bool:
-    """Is t more precise than s?
-    A signature t is more precise than s if all argument types and the return
-    type of t are more precise than the corresponding types in s.
-    Assume that the argument kinds and names are compatible, and that the
-    argument counts are overlapping.
-    """
-    # TODO generic function types
-    # Only consider the common prefix of argument types.
-    for argt, args in zip(t.arg_types, s.arg_types):
-        if not is_more_precise(argt, args):
-            return False
-    return is_more_precise(t.ret_type, s.ret_type)
 
 
 def infer_operator_assignment_method(typ: Type, operator: str) -> Tuple[bool, str]:
@@ -4014,3 +4044,15 @@ def is_static(func: Union[FuncBase, Decorator]) -> bool:
     elif isinstance(func, FuncBase):
         return func.is_static
     assert False, "Unexpected func type: {}".format(type(func))
+
+
+def is_subtype_no_promote(left: Type, right: Type) -> bool:
+    return is_subtype(left, right, ignore_promotions=True)
+
+
+def is_more_precise_no_promote(left: Type, right: Type) -> bool:
+    return is_more_precise(left, right, ignore_promotions=True)
+
+
+def is_overlapping_types_no_promote(left: Type, right: Type) -> bool:
+    return is_overlapping_types(left, right, ignore_promotions=True)

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -39,7 +39,9 @@ def narrow_declared_type(declared: Type, narrowed: Type) -> Type:
     if isinstance(declared, UnionType):
         return UnionType.make_simplified_union([narrow_declared_type(x, narrowed)
                                                 for x in declared.relevant_items()])
-    elif not is_overlapping_types(declared, narrowed, prohibit_none_typevar_overlap=True, default_return=True):
+    elif not is_overlapping_types(declared, narrowed,
+                                  prohibit_none_typevar_overlap=True,
+                                  default_return=True):
         if experiments.STRICT_OPTIONAL:
             return UninhabitedType()
         else:
@@ -95,7 +97,17 @@ def get_possible_variants(typ: Type) -> List[Type]:
     else:
         return [typ]
 
+def wrap(func):
+    def wrapper(*args, **kwargs):
+        global level
+        print('!!', args, kwargs)
+        out = func(*args, **kwargs)
+        print('   out:', out)
+        print()
+        return out
+    return wrapper
 
+@wrap
 def is_overlapping_types(left: Type,
                          right: Type,
                          ignore_promotions: bool = False,
@@ -107,7 +119,6 @@ def is_overlapping_types(left: Type,
     If 'prohibit_none_typevar_overlap' is True, we disallow None from overlapping with
     TypeVars (in both strict-optional and non-strict-optional mode).
     """
-    default_return = False
 
     def _is_overlapping_types(left: Type, right: Type) -> bool:
         '''Encode the kind of overlapping check to perform.
@@ -269,7 +280,7 @@ def is_overlapping_types(left: Type,
     # We ought to have handled every case by now: we conclude the
     # two types are not overlapping, either completely or partially.
 
-    return False
+    return default_return
 
 
 def is_overlapping_erased_types(left: Type, right: Type, *,

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -277,6 +277,9 @@ def is_overlapping_types(left: Type,
 
     # We ought to have handled every case by now: we conclude the
     # two types are not overlapping, either completely or partially.
+    #
+    # Note: it's unclear however, whether returning False is the right thing
+    # to do when inferring reachability -- see  https://github.com/python/mypy/issues/5529
 
     assert type(left) != type(right)
     return False

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -97,17 +97,7 @@ def get_possible_variants(typ: Type) -> List[Type]:
     else:
         return [typ]
 
-def wrap(func):
-    def wrapper(*args, **kwargs):
-        global level
-        print('!!', args, kwargs)
-        out = func(*args, **kwargs)
-        print('   out:', out)
-        print()
-        return out
-    return wrapper
 
-@wrap
 def is_overlapping_types(left: Type,
                          right: Type,
                          ignore_promotions: bool = False,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -976,6 +976,12 @@ class MessageBuilder:
         self.fail('Overloaded function signatures {} and {} overlap with '
                   'incompatible return types'.format(index1, index2), context)
 
+    def overloaded_signatures_partial_overlap(self, index1: int, index2: int,
+                                              context: Context) -> None:
+        self.fail('Overloaded function signatures {} and {} '.format(index1, index2)
+                  + 'are partially overlapping: the two signatures may return '
+                  + 'incompatible types given certain calls', context)
+
     def overloaded_signature_will_never_match(self, index1: int, index2: int,
                                               context: Context) -> None:
         self.fail(

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1955,13 +1955,61 @@ class B:
     def __radd__(*self) -> int: pass
     def __rsub__(*self: 'B') -> int: pass
 
-[case testReverseOperatorTypeVar]
+[case testReverseOperatorTypeVar1]
+from typing import TypeVar, Any
+T = TypeVar("T", bound='Real')
+class Real:
+    def __add__(self, other: Any) -> str: ...
+class Fraction(Real):
+    def __radd__(self, other: T) -> T: ...  # E: Signatures of "__radd__" of "Fraction" and "__add__" of "T" are unsafely overlapping
+
+# Note: When doing A + B and if B is a subtype of A, we will always call B.__radd__(A) first
+# and only try A.__add__(B) second if necessary.
+reveal_type(Real() + Fraction())      # E: Revealed type is '__main__.Real*'
+
+# Note: When doing A + A, we only ever call A.__add__(A), never A.__radd__(A).
+reveal_type(Fraction() + Fraction())  # E: Revealed type is 'builtins.str'
+
+[case testReverseOperatorTypeVar2a]
 from typing import TypeVar
 T = TypeVar("T", bound='Real')
 class Real:
     def __add__(self, other: Fraction) -> str: ...
 class Fraction(Real):
-    def __radd__(self, other: T) -> T: ...  # TODO: This should be unsafely overlapping
+    def __radd__(self, other: T) -> T: ...  # E: Signatures of "__radd__" of "Fraction" and "__add__" of "T" are unsafely overlapping
+
+reveal_type(Real() + Fraction())      # E: Revealed type is '__main__.Real*'
+reveal_type(Fraction() + Fraction())  # E: Revealed type is 'builtins.str'
+
+
+[case testReverseOperatorTypeVar2b]
+from typing import TypeVar
+T = TypeVar("T", Real, Fraction)
+class Real:
+    def __add__(self, other: Fraction) -> str: ...
+class Fraction(Real):
+    def __radd__(self, other: T) -> T: ...  # E: Signatures of "__radd__" of "Fraction" and "__add__" of "Real" are unsafely overlapping
+
+reveal_type(Real() + Fraction())      # E: Revealed type is '__main__.Real*'
+reveal_type(Fraction() + Fraction())  # E: Revealed type is 'builtins.str'
+
+[case testReverseOperatorTypeVar3]
+from typing import TypeVar, Any
+T = TypeVar("T", bound='Real')
+class Real:
+    def __add__(self, other: FractionChild) -> str: ...
+class Fraction(Real):
+    def __radd__(self, other: T) -> T: ...  # E: Signatures of "__radd__" of "Fraction" and "__add__" of "T" are unsafely overlapping
+class FractionChild(Fraction): pass
+
+reveal_type(Real() + Fraction())                # E: Revealed type is '__main__.Real*'
+reveal_type(FractionChild() + Fraction())       # E: Revealed type is '__main__.FractionChild*'
+reveal_type(FractionChild() + FractionChild())  # E: Revealed type is 'builtins.str'
+
+# Runtime error: we try calling __add__, it doesn't match, and we don't try __radd__ since
+# the LHS and the RHS are not the same.
+Fraction() + Fraction()                         # E: Unsupported operand types for + ("Fraction" and "Fraction") \
+                                                # N: __radd__ will not be called when evaluating 'Fraction + Fraction': must define __add__
 
 [case testReverseOperatorTypeType]
 from typing import TypeVar, Type

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -2005,3 +2005,81 @@ def f(x: Union[A, str]) -> None:
     if isinstance(x, A):
         x.method_only_in_a()
 [builtins fixtures/isinstance.pyi]
+
+[case testIsInstanceInitialNoneCheckSkipsImpossibleCasesNoStrictOptional]
+# flags: --strict-optional
+from typing import Optional, Union
+
+class A: pass
+
+def foo1(x: Union[A, str, None]) -> None:
+    if x is None:
+        reveal_type(x)      # E: Revealed type is 'None'
+    elif isinstance(x, A):
+        reveal_type(x)      # E: Revealed type is '__main__.A'
+    else:
+        reveal_type(x)      # E: Revealed type is 'builtins.str'
+
+def foo2(x: Optional[str]) -> None:
+    if x is None:
+        reveal_type(x)      # E: Revealed type is 'None'
+    elif isinstance(x, A):
+        reveal_type(x)
+    else:
+        reveal_type(x)      # E: Revealed type is 'builtins.str'
+[builtins fixtures/isinstance.pyi]
+
+[case testIsInstanceInitialNoneCheckSkipsImpossibleCasesInNoStrictOptional]
+# flags: --no-strict-optional
+from typing import Optional, Union
+
+class A: pass
+
+def foo1(x: Union[A, str, None]) -> None:
+    if x is None:
+        # Since None is a subtype of all types in no-strict-optional,
+        # we can't really narrow the type here
+        reveal_type(x)      # E: Revealed type is 'Union[__main__.A, builtins.str, None]'
+    elif isinstance(x, A):
+        # Note that Union[None, A] == A in no-strict-optional
+        reveal_type(x)      # E: Revealed type is '__main__.A'
+    else:
+        reveal_type(x)      # E: Revealed type is 'builtins.str'
+
+def foo2(x: Optional[str]) -> None:
+    if x is None:
+        reveal_type(x)      # E: Revealed type is 'Union[builtins.str, None]'
+    elif isinstance(x, A):
+        # Mypy should, however, be able to skip impossible cases
+        reveal_type(x)
+    else:
+        reveal_type(x)      # E: Revealed type is 'Union[builtins.str, None]'
+[builtins fixtures/isinstance.pyi]
+
+[case testNoneCheckDoesNotNarrowWhenUsingTypeVars]
+# flags: --strict-optional
+from typing import TypeVar
+
+T = TypeVar('T')
+
+def foo(x: T) -> T:
+    out = None
+    out = x
+    if out is None:
+        pass
+    return out
+[builtins fixtures/isinstance.pyi]
+
+[case testNoneCheckDoesNotNarrowWhenUsingTypeVarsNoStrictOptional]
+# flags: --no-strict-optional
+from typing import TypeVar
+
+T = TypeVar('T')
+
+def foo(x: T) -> T:
+    out = None
+    out = x
+    if out is None:
+        pass
+    return out
+[builtins fixtures/isinstance.pyi]

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -2089,3 +2089,41 @@ def foo(x: T) -> T:
         pass
     return out
 [builtins fixtures/isinstance.pyi]
+
+[case testNoneAndGenericTypesOverlapNoStrictOptional]
+# flags: --no-strict-optional
+from typing import Union, Optional, List
+
+# Note: this test is indirectly making sure meet.is_overlapping_types
+# correctly ignores 'None' in unions.
+
+def foo(x: Optional[List[str]]) -> None:
+    reveal_type(x)                  # E: Revealed type is 'Union[builtins.list[builtins.str], None]'
+    assert isinstance(x, list)
+    reveal_type(x)                  # E: Revealed type is 'builtins.list[builtins.str]'
+
+def bar(x: Union[List[str], List[int], None]) -> None:
+    reveal_type(x)                  # E: Revealed type is 'Union[builtins.list[builtins.str], builtins.list[builtins.int], None]'
+    assert isinstance(x, list)
+    reveal_type(x)                  # E: Revealed type is 'Union[builtins.list[builtins.str], builtins.list[builtins.int]]'
+[builtins fixtures/isinstancelist.pyi]
+
+[case testNoneAndGenericTypesOverlapStrictOptional]
+# flags: --strict-optional
+from typing import Union, Optional, List
+
+# This test is the same as the one above, except for strict-optional.
+# It isn't testing anything explicitly and mostly exists for the sake 
+# of completeness.
+
+def foo(x: Optional[List[str]]) -> None:
+    reveal_type(x)                  # E: Revealed type is 'Union[builtins.list[builtins.str], None]'
+    assert isinstance(x, list)
+    reveal_type(x)                  # E: Revealed type is 'builtins.list[builtins.str]'
+
+def bar(x: Union[List[str], List[int], None]) -> None:
+    reveal_type(x)                  # E: Revealed type is 'Union[builtins.list[builtins.str], builtins.list[builtins.int], None]'
+    assert isinstance(x, list)
+    reveal_type(x)                  # E: Revealed type is 'Union[builtins.list[builtins.str], builtins.list[builtins.int]]'
+[builtins fixtures/isinstancelist.pyi]
+

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -2058,6 +2058,12 @@ def foo2(x: Optional[str]) -> None:
 
 [case testNoneCheckDoesNotNarrowWhenUsingTypeVars]
 # flags: --strict-optional
+
+# Note: this test (and the following one) are testing checker.conditional_type_map:
+# if you set the 'prohibit_none_typevar_overlap' keyword argument to False when calling
+# 'is_overlapping_types', the binder will incorrectly infer that 'out' has a type of
+# Union[T, None] after the if statement.
+
 from typing import TypeVar
 
 T = TypeVar('T')

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -373,11 +373,9 @@ def foo(t: List[T], s: T) -> int: ...  # E: Overloaded function signatures 1 and
 def foo(t: T, s: T) -> str: ...
 def foo(t, s): pass
 
-# TODO: Why are we getting a different error message here?
-# Shouldn't we be getting the same error message?
 class Wrapper(Generic[T]):
     @overload
-    def foo(self, t: List[T], s: T) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    def foo(self, t: List[T], s: T) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
     @overload
     def foo(self, t: T, s: T) -> str: ...
     def foo(self, t, s): pass
@@ -388,7 +386,7 @@ class Dummy(Generic[T]): pass
 # cause the constraint solver to not infer T = object like it did in the
 # first example?
 @overload
-def bar(d: Dummy[T], t: List[T], s: T) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def bar(d: Dummy[T], t: List[T], s: T) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def bar(d: Dummy[T], t: T, s: T) -> str: ...
 def bar(d: Dummy[T], t, s): pass
@@ -1872,7 +1870,7 @@ def r(x: Any) -> Any:...
 @overload
 def g(x: A) -> A: ...
 @overload
-def g(x: Tuple[A1, ...]) -> B: ...  # E: Overloaded function signatures 2 and 3 are partially overlapping: the two signatures may return incompatible types given certain calls
+def g(x: Tuple[A1, ...]) -> B: ...  # E: Overloaded function signatures 2 and 3 overlap with incompatible return types
 @overload
 def g(x: Tuple[A, A]) -> C: ...
 @overload
@@ -2067,15 +2065,14 @@ def bar(x: T, y: T) -> int: ...
 def bar(x, y): ...
 
 class Wrapper(Generic[T]):
-    # TODO: Why do these have different error messages?
     @overload
-    def foo(self, x: None, y: None) -> str: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    def foo(self, x: None, y: None) -> str: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
     @overload
     def foo(self, x: T, y: None) -> int: ...
     def foo(self, x): ...
 
     @overload
-    def bar(self, x: None, y: int) -> str: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    def bar(self, x: None, y: int) -> str: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
     @overload
     def bar(self, x: T, y: T) -> int: ...
     def bar(self, x, y): ...
@@ -2581,7 +2578,7 @@ class C: ...
 class D: ...
 
 @overload
-def f(x: Union[A, B]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f(x: Union[A, B]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f(x: Union[B, C]) -> str: ...
 def f(x): ...
@@ -2613,7 +2610,7 @@ class C: ...
 class D: ...
 
 @overload
-def f(x: List[Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f(x: List[Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f(x: List[Union[B, C]]) -> str: ...
 def f(x): ...
@@ -2631,7 +2628,7 @@ def h(x: List[Union[C, D]]) -> str: ...
 def h(x): ...
 
 @overload
-def i(x: List[Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def i(x: List[Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def i(x: List[Union[A, B, C]]) -> str: ...
 def i(x): ...
@@ -2644,7 +2641,7 @@ from typing import TypeVar, overload
 T = TypeVar('T')
 
 @overload
-def f(x: int) -> str: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f(x: int) -> str: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f(x: T) -> T: ...
 def f(x): ...
@@ -2661,13 +2658,13 @@ from typing import TypeVar, overload, List
 T = TypeVar('T')
 
 @overload
-def f1(x: List[int]) -> str: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f1(x: List[int]) -> str: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f1(x: List[T]) -> T: ...
 def f1(x): ...
 
 @overload
-def f2(x: List[int]) -> List[str]: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f2(x: List[int]) -> List[str]: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f2(x: List[T]) -> List[T]: ...
 def f2(x): ...
@@ -2693,15 +2690,16 @@ T = TypeVar('T')
 
 class Wrapper(Generic[T]):
     @overload
-    def f(self, x: int) -> str: ...   # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    def f(self, x: int) -> str: ...   # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
     @overload
     def f(self, x: T) -> T: ...
     def f(self, x): ...
 
-    # TODO: This shouldn't trigger an error message.
+    # TODO: This shouldn't trigger an error message?
     # Related to testTypeCheckOverloadImplementationTypeVarDifferingUsage2?
+    # See https://github.com/python/mypy/issues/5510
     @overload
-    def g(self, x: int) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    def g(self, x: int) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
     @overload
     def g(self, x: T) -> T: ...
     def g(self, x): ...
@@ -2713,27 +2711,27 @@ T = TypeVar('T')
 
 class Wrapper(Generic[T]):
     @overload
-    def f1(self, x: List[int]) -> str: ...   # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    def f1(self, x: List[int]) -> str: ...   # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
     @overload
     def f1(self, x: List[T]) -> T: ...
     def f1(self, x): ...
 
     @overload
-    def f2(self, x: List[int]) -> List[str]: ...   # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    def f2(self, x: List[int]) -> List[str]: ...   # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
     @overload
     def f2(self, x: List[T]) -> List[T]: ...
     def f2(self, x): ...
 
-    # TODO: This shouldn't trigger an error message.
-    # Related to testTypeCheckOverloadImplementationTypeVarDifferingUsage2?
+    # TODO: This shouldn't trigger an error message?
+    # See https://github.com/python/mypy/issues/5510
     @overload
-    def g1(self, x: List[int]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    def g1(self, x: List[int]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
     @overload
     def g1(self, x: List[T]) -> T: ...
     def g1(self, x): ...
 
     @overload
-    def g2(self, x: List[int]) -> List[int]: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    def g2(self, x: List[int]) -> List[int]: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
     @overload
     def g2(self, x: List[T]) -> List[T]: ...
     def g2(self, x): ...
@@ -2762,7 +2760,7 @@ A = TypedDict('A', {'x': int, 'y': Union[int, str]})
 B = TypedDict('B', {'x': int, 'y': Union[str, float]})
 
 @overload
-def f(x: A) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f(x: A) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f(x: B) -> str: ...
 def f(x): pass
@@ -2783,13 +2781,13 @@ B = TypedDict('B', {'a': bool}, total=False)
 C = TypedDict('C', {'x': str, 'y': int}, total=False)
 
 @overload
-def f(x: A) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f(x: A) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f(x: B) -> str: ...
 def f(x): pass
 
 @overload
-def g(x: A) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def g(x: A) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def g(x: C) -> str: ...
 def g(x): pass
@@ -2803,13 +2801,13 @@ A = TypedDict('A', {'x': int, 'y': str})
 B = TypedDict('B', {'x': Union[int, str], 'y': str, 'z': int}, total=False)
 
 @overload
-def f1(x: A) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f1(x: A) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f1(x: B) -> str: ...
 def f1(x): pass
 
 @overload
-def f2(x: B) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f2(x: B) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f2(x: A) -> str: ...
 def f2(x): pass
@@ -2831,7 +2829,7 @@ class C(TypedDict, total=False):
     z: int
 
 @overload
-def f(x: B) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f(x: B) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f(x: C) -> str: ...
 def f(x): pass
@@ -2851,7 +2849,7 @@ class ListSubclass(List[T]): pass
 class Unrelated(Generic[T]): pass
 
 @overload
-def f(x: List[Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f(x: List[Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f(x: ListSubclass[Union[B, C]]) -> str: ...
 def f(x): pass
@@ -2874,7 +2872,7 @@ class C: pass
 class ListSubclass(List[Union[B, C]]): pass
 
 @overload
-def f(x: List[Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f(x: List[Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f(x: ListSubclass) -> str: ...
 def f(x): pass
@@ -2893,7 +2891,7 @@ S = TypeVar('S')
 class DictSubclass(Dict[str, S]): pass
 
 @overload
-def f(x: Dict[str, Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f(x: Dict[str, Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f(x: DictSubclass[Union[B, C]]) -> str: ...
 def f(x): pass
@@ -2910,13 +2908,13 @@ class C: pass
 S = TypeVar('S', A, B)
 
 @overload
-def f(x: S) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f(x: S) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f(x: Union[B, C]) -> str: ...
 def f(x): pass
 
 @overload
-def g(x: Union[B, C]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def g(x: Union[B, C]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def g(x: S) -> str: ...
 def g(x): pass
@@ -2931,7 +2929,7 @@ class B: pass
 class C: pass
 
 @overload
-def f(x: T, y: T, z: Union[A, B]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f(x: T, y: T, z: Union[A, B]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f(x: T, y: T, z: Union[B, C]) -> str: ...
 def f(x, y, z): pass
@@ -2944,7 +2942,7 @@ class B: pass
 class C: pass
 
 @overload
-def f(x: Callable[[Union[A, B]], int]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+def f(x: Callable[[Union[A, B]], int]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def f(x: Callable[[Union[B, C]], int]) -> str: ...
 def f(x): pass
@@ -3839,7 +3837,7 @@ T = TypeVar('T')
 
 class FakeAttribute(Generic[T]):
     @overload
-    def dummy(self, instance: None, owner: Type[T]) -> 'FakeAttribute[T]': ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    def dummy(self, instance: None, owner: Type[T]) -> 'FakeAttribute[T]': ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
     @overload
     def dummy(self, instance: T, owner: Type[T]) -> int: ...
     def dummy(self, instance: Optional[T], owner: Type[T]) -> Union['FakeAttribute[T]', int]: ...
@@ -4622,7 +4620,7 @@ T = TypeVar('T')
 
 def f() -> None:
     @overload
-    def g(x: str) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    def g(x: str) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
     @overload
     def g(x: T) -> T: ...
     def g(x):

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -334,8 +334,8 @@ def bar(x: Union[T, C]) -> Union[T, int]:
 
 [builtins fixtures/isinstancelist.pyi]
 
-[case testTypeCheckOverloadImplementationTypeVarDifferingUsage]
-from typing import overload, Union, List, TypeVar
+[case testTypeCheckOverloadImplementationTypeVarDifferingUsage1]
+from typing import overload, Union, List, TypeVar, Generic
 
 T = TypeVar('T')
 
@@ -348,6 +348,50 @@ def foo(t: Union[List[T], T]) -> T:
         return t[0]
     else:
         return t
+
+class Wrapper(Generic[T]):
+    @overload
+    def foo(self, t: List[T]) -> T: ...
+    @overload
+    def foo(self, t: T) -> T: ...
+    def foo(self, t: Union[List[T], T]) -> T:
+        if isinstance(t, list):
+            return t[0]
+        else:
+            return t
+[builtins fixtures/isinstancelist.pyi]
+
+[case testTypeCheckOverloadImplementationTypeVarDifferingUsage2]
+from typing import overload, Union, List, TypeVar, Generic
+
+T = TypeVar('T')
+
+# Note: this is unsafe when T = object
+@overload
+def foo(t: List[T], s: T) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+@overload
+def foo(t: T, s: T) -> str: ...
+def foo(t, s): pass
+
+# TODO: Why are we getting a different error message here?
+# Shouldn't we be getting the same error message?
+class Wrapper(Generic[T]):
+    @overload
+    def foo(self, t: List[T], s: T) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    @overload
+    def foo(self, t: T, s: T) -> str: ...
+    def foo(self, t, s): pass
+
+class Dummy(Generic[T]): pass
+
+# Same root issue: why does the additional constraint bound T <: T
+# cause the constraint solver to not infer T = object like it did in the
+# first example?
+@overload
+def bar(d: Dummy[T], t: List[T], s: T) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def bar(d: Dummy[T], t: T, s: T) -> str: ...
+def bar(d: Dummy[T], t, s): pass
 [builtins fixtures/isinstancelist.pyi]
 
 [case testTypeCheckOverloadedFunctionBody]
@@ -1524,14 +1568,25 @@ reveal_type(f(z='', x=a, y=1))  # E: Revealed type is 'Any'
 [case testOverloadWithOverlappingItemsAndAnyArgument5]
 from typing import overload, Any, Union
 
+class A: pass
+class B(A): pass
+
 @overload
-def f(x: int) -> int: ...
+def f(x: B) -> B: ...
 @overload
-def f(x: Union[int, float]) -> float: ...
+def f(x: Union[A, B]) -> A: ...
 def f(x): pass
+
+# Note: overloads ignore promotions so we treat 'int' and 'float' as distinct types
+@overload
+def g(x: int) -> int: ...   # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+@overload
+def g(x: Union[int, float]) -> float: ...
+def g(x): pass
 
 a: Any
 reveal_type(f(a))  # E: Revealed type is 'Any'
+reveal_type(g(a))  # E: Revealed type is 'Any'
 
 [case testOverloadWithOverlappingItemsAndAnyArgument6]
 from typing import overload, Any
@@ -1817,7 +1872,7 @@ def r(x: Any) -> Any:...
 @overload
 def g(x: A) -> A: ...
 @overload
-def g(x: Tuple[A1, ...]) -> B: ...  # E: Overloaded function signatures 2 and 3 overlap with incompatible return types
+def g(x: Tuple[A1, ...]) -> B: ...  # E: Overloaded function signatures 2 and 3 are partially overlapping: the two signatures may return incompatible types given certain calls
 @overload
 def g(x: Tuple[A, A]) -> C: ...
 @overload
@@ -2004,7 +2059,7 @@ def foo(x: None, y: None) -> str: ...  # E: Overloaded function signatures 1 and
 def foo(x: T, y: T) -> int: ...
 def foo(x): ...
 
-# TODO: We should allow this; T can't be bound to two distinct types
+# What if 'T' is 'object'?
 @overload
 def bar(x: None, y: int) -> str: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
@@ -2012,17 +2067,17 @@ def bar(x: T, y: T) -> int: ...
 def bar(x, y): ...
 
 class Wrapper(Generic[T]):
-    # TODO: This should be an error
+    # TODO: Why do these have different error messages?
     @overload
-    def foo(self, x: None, y: None) -> str: ...
+    def foo(self, x: None, y: None) -> str: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
     @overload
-    def foo(self, x: T, y: None) -> str: ...
+    def foo(self, x: T, y: None) -> int: ...
     def foo(self, x): ...
 
     @overload
-    def bar(self, x: None, y: int) -> str: ...
+    def bar(self, x: None, y: int) -> str: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
     @overload
-    def bar(self, x: T, y: T) -> str: ...
+    def bar(self, x: T, y: T) -> int: ...
     def bar(self, x, y): ...
 
 [case testOverloadFlagsPossibleMatches]
@@ -2526,7 +2581,7 @@ class C: ...
 class D: ...
 
 @overload
-def f(x: Union[A, B]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+def f(x: Union[A, B]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
 @overload
 def f(x: Union[B, C]) -> str: ...
 def f(x): ...
@@ -2534,14 +2589,54 @@ def f(x): ...
 @overload
 def g(x: Union[A, B]) -> int: ...
 @overload
-def g(x: Union[C, D]) -> str: ...
+def g(x: Union[B, C]) -> int: ...
 def g(x): ...
 
 @overload
-def h(x: Union[A, B]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+def h(x: Union[A, B]) -> int: ...
 @overload
-def h(x: Union[A, B, C]) -> str: ...
+def h(x: Union[C, D]) -> str: ...
 def h(x): ...
+
+@overload
+def i(x: Union[A, B]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+@overload
+def i(x: Union[A, B, C]) -> str: ...
+def i(x): ...
+
+[case testOverloadWithPartiallyOverlappingUnionsNested]
+from typing import overload, Union, List
+
+class A: ...
+class B: ...
+class C: ...
+class D: ...
+
+@overload
+def f(x: List[Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f(x: List[Union[B, C]]) -> str: ...
+def f(x): ...
+
+@overload
+def g(x: List[Union[A, B]]) -> int: ...
+@overload
+def g(x: List[Union[B, C]]) -> int: ...
+def g(x): ...
+
+@overload
+def h(x: List[Union[A, B]]) -> int: ...
+@overload
+def h(x: List[Union[C, D]]) -> str: ...
+def h(x): ...
+
+@overload
+def i(x: List[Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def i(x: List[Union[A, B, C]]) -> str: ...
+def i(x): ...
+
+[builtins fixtures/list.pyi]
 
 [case testOverloadPartialOverlapWithUnrestrictedTypeVar]
 from typing import TypeVar, overload
@@ -2549,10 +2644,310 @@ from typing import TypeVar, overload
 T = TypeVar('T')
 
 @overload
-def f(x: int) -> str: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+def f(x: int) -> str: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
 @overload
 def f(x: T) -> T: ...
 def f(x): ...
+
+@overload
+def g(x: int) -> int: ...
+@overload
+def g(x: T) -> T: ...
+def g(x): ...
+
+[case testOverloadPartialOverlapWithUnrestrictedTypeVarNested]
+from typing import TypeVar, overload, List
+
+T = TypeVar('T')
+
+@overload
+def f1(x: List[int]) -> str: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f1(x: List[T]) -> T: ...
+def f1(x): ...
+
+@overload
+def f2(x: List[int]) -> List[str]: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f2(x: List[T]) -> List[T]: ...
+def f2(x): ...
+
+@overload
+def g1(x: List[int]) -> int: ...
+@overload
+def g1(x: List[T]) -> T: ...
+def g1(x): ...
+
+@overload
+def g2(x: List[int]) -> List[int]: ...
+@overload
+def g2(x: List[T]) -> List[T]: ...
+def g2(x): ...
+
+[builtins fixtures/list.pyi]
+
+[case testOverloadPartialOverlapWithUnrestrictedTypeVarInClass]
+from typing import TypeVar, overload, Generic
+
+T = TypeVar('T')
+
+class Wrapper(Generic[T]):
+    @overload
+    def f(self, x: int) -> str: ...   # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    @overload
+    def f(self, x: T) -> T: ...
+    def f(self, x): ...
+
+    # TODO: This shouldn't trigger an error message.
+    # Related to testTypeCheckOverloadImplementationTypeVarDifferingUsage2?
+    @overload
+    def g(self, x: int) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    @overload
+    def g(self, x: T) -> T: ...
+    def g(self, x): ...
+
+[case testOverloadPartialOverlapWithUnrestrictedTypeVarInClassNested]
+from typing import TypeVar, overload, Generic, List
+
+T = TypeVar('T')
+
+class Wrapper(Generic[T]):
+    @overload
+    def f1(self, x: List[int]) -> str: ...   # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    @overload
+    def f1(self, x: List[T]) -> T: ...
+    def f1(self, x): ...
+
+    @overload
+    def f2(self, x: List[int]) -> List[str]: ...   # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    @overload
+    def f2(self, x: List[T]) -> List[T]: ...
+    def f2(self, x): ...
+
+    # TODO: This shouldn't trigger an error message.
+    # Related to testTypeCheckOverloadImplementationTypeVarDifferingUsage2?
+    @overload
+    def g1(self, x: List[int]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    @overload
+    def g1(self, x: List[T]) -> T: ...
+    def g1(self, x): ...
+
+    @overload
+    def g2(self, x: List[int]) -> List[int]: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+    @overload
+    def g2(self, x: List[T]) -> List[T]: ...
+    def g2(self, x): ...
+
+[builtins fixtures/list.pyi]
+
+[case testOverloadTypedDictDifferentRequiredKeysMeansDictsAreDisjoint]
+from typing import overload
+from mypy_extensions import TypedDict
+
+A = TypedDict('A', {'x': int, 'y': int})
+B = TypedDict('B', {'x': int, 'y': str})
+
+@overload
+def f(x: A) -> int: ...
+@overload
+def f(x: B) -> str: ...
+def f(x): pass
+[builtins fixtures/dict.pyi]
+
+[case testOverloadedTypedDictPartiallyOverlappingRequiredKeys]
+from typing import overload, Union
+from mypy_extensions import TypedDict
+
+A = TypedDict('A', {'x': int, 'y': Union[int, str]})
+B = TypedDict('B', {'x': int, 'y': Union[str, float]})
+
+@overload
+def f(x: A) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f(x: B) -> str: ...
+def f(x): pass
+
+@overload
+def g(x: A) -> int: ...
+@overload
+def g(x: B) -> object: ...
+def g(x): pass
+[builtins fixtures/dict.pyi]
+
+[case testOverloadedTypedDictFullyNonTotalDictsAreAlwaysPartiallyOverlapping]
+from typing import overload
+from mypy_extensions import TypedDict
+
+A = TypedDict('A', {'x': int, 'y': str}, total=False)
+B = TypedDict('B', {'a': bool}, total=False)
+C = TypedDict('C', {'x': str, 'y': int}, total=False)
+
+@overload
+def f(x: A) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f(x: B) -> str: ...
+def f(x): pass
+
+@overload
+def g(x: A) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def g(x: C) -> str: ...
+def g(x): pass
+[builtins fixtures/dict.pyi]
+
+[case testOverloadedTotalAndNonTotalTypedDictsCanPartiallyOverlap]
+from typing import overload, Union
+from mypy_extensions import TypedDict
+
+A = TypedDict('A', {'x': int, 'y': str})
+B = TypedDict('B', {'x': Union[int, str], 'y': str, 'z': int}, total=False)
+
+@overload
+def f1(x: A) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f1(x: B) -> str: ...
+def f1(x): pass
+
+@overload
+def f2(x: B) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f2(x: A) -> str: ...
+def f2(x): pass
+
+[builtins fixtures/dict.pyi]
+
+[case testOverloadedTypedDictsWithSomeOptionalKeysArePartiallyOverlapping]
+from typing import overload, Union
+from mypy_extensions import TypedDict
+
+class A(TypedDict):
+    x: int
+    y: int
+
+class B(TypedDict, total=False):
+    z: str
+
+class C(TypedDict, total=False):
+    z: int
+
+@overload
+def f(x: B) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f(x: C) -> str: ...
+def f(x): pass
+
+[builtins fixtures/dict.pyi]
+
+[case testOverloadedPartiallyOverlappingInheritedTypes1]
+from typing import overload, List, Union, TypeVar, Generic
+
+class A: pass
+class B: pass
+class C: pass
+
+T = TypeVar('T')
+
+class ListSubclass(List[T]): pass
+class Unrelated(Generic[T]): pass
+
+@overload
+def f(x: List[Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f(x: ListSubclass[Union[B, C]]) -> str: ...
+def f(x): pass
+
+@overload
+def g(x: List[Union[A, B]]) -> int: ...
+@overload
+def g(x: Unrelated[Union[B, C]]) -> str: ...
+def g(x): pass
+
+[builtins fixtures/list.pyi]
+
+[case testOverloadedPartiallyOverlappingInheritedTypes2]
+from typing import overload, List, Union
+
+class A: pass
+class B: pass
+class C: pass
+
+class ListSubclass(List[Union[B, C]]): pass
+
+@overload
+def f(x: List[Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f(x: ListSubclass) -> str: ...
+def f(x): pass
+
+[builtins fixtures/list.pyi]
+
+[case testOverloadedPartiallyOverlappingInheritedTypes3]
+from typing import overload, Union, Dict, TypeVar
+
+class A: pass
+class B: pass
+class C: pass
+
+S = TypeVar('S')
+
+class DictSubclass(Dict[str, S]): pass
+
+@overload
+def f(x: Dict[str, Union[A, B]]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f(x: DictSubclass[Union[B, C]]) -> str: ...
+def f(x): pass
+
+[builtins fixtures/dict.pyi]
+
+[case testOverloadedPartiallyOverlappingTypeVarsAndUnion]
+from typing import overload, TypeVar, Union
+
+class A: pass
+class B: pass
+class C: pass
+
+S = TypeVar('S', A, B)
+
+@overload
+def f(x: S) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f(x: Union[B, C]) -> str: ...
+def f(x): pass
+
+@overload
+def g(x: Union[B, C]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def g(x: S) -> str: ...
+def g(x): pass
+
+[case testOverloadPartiallyOverlappingTypeVarsIdentical]
+from typing import overload, TypeVar, Union
+
+T = TypeVar('T')
+
+class A: pass
+class B: pass
+class C: pass
+
+@overload
+def f(x: T, y: T, z: Union[A, B]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f(x: T, y: T, z: Union[B, C]) -> str: ...
+def f(x, y, z): pass
+
+[case testOverloadedPartiallyOverlappingCallables]
+from typing import overload, Union, Callable
+
+class A: pass
+class B: pass
+class C: pass
+
+@overload
+def f(x: Callable[[Union[A, B]], int]) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
+@overload
+def f(x: Callable[[Union[B, C]], int]) -> str: ...
+def f(x): pass
 
 [case testOverloadNotConfusedForProperty]
 from typing import overload
@@ -3444,7 +3839,7 @@ T = TypeVar('T')
 
 class FakeAttribute(Generic[T]):
     @overload
-    def dummy(self, instance: None, owner: Type[T]) -> 'FakeAttribute[T]': ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+    def dummy(self, instance: None, owner: Type[T]) -> 'FakeAttribute[T]': ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
     @overload
     def dummy(self, instance: T, owner: Type[T]) -> int: ...
     def dummy(self, instance: Optional[T], owner: Type[T]) -> Union['FakeAttribute[T]', int]: ...
@@ -4227,7 +4622,7 @@ T = TypeVar('T')
 
 def f() -> None:
     @overload
-    def g(x: str) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+    def g(x: str) -> int: ...  # E: Overloaded function signatures 1 and 2 are partially overlapping: the two signatures may return incompatible types given certain calls
     @overload
     def g(x: T) -> T: ...
     def g(x):
@@ -4257,3 +4652,54 @@ def f() -> None:
 
 [builtins fixtures/dict.pyi]
 [out]
+
+[case testOverloadsIgnorePromotions]
+from typing import overload, List, Union, _promote
+
+class Parent: pass
+class Child(Parent): pass
+
+children: List[Child]
+parents: List[Parent]
+
+@overload
+def f(x: Child) -> List[Child]: pass    # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+@overload
+def f(x: Parent) -> List[Parent]: pass
+def f(x: Union[Child, Parent]) -> Union[List[Child], List[Parent]]:
+    if isinstance(x, Child):
+        reveal_type(x)      # E: Revealed type is '__main__.Child'
+        return children
+    else:
+        reveal_type(x)      # E: Revealed type is '__main__.Parent'
+        return parents
+
+ints: List[int]
+floats: List[float]
+
+@overload
+def g(x: int) -> List[int]: pass
+@overload
+def g(x: float) -> List[float]: pass
+def g(x: Union[int, float]) -> Union[List[int], List[float]]:
+    if isinstance(x, int):
+        reveal_type(x)      # E: Revealed type is 'builtins.int'
+        return ints
+    else:
+        reveal_type(x)      # E: Revealed type is 'builtins.float'
+        return floats
+
+[builtins fixtures/isinstancelist.pyi]
+
+[case testOverloadsTypesAndUnions]
+from typing import overload, Type, Union
+
+class A: pass
+class B: pass
+
+@overload
+def f(x: Type[A]) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+@overload
+def f(x: Union[Type[A], Type[B]]) -> str: ...
+def f(x: Union[Type[A], Type[B]]) -> Union[int, str]:
+    return 1

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -564,3 +564,43 @@ if typing.TYPE_CHECKING:
 reveal_type(x)  # E: Revealed type is '__main__.B'
 
 [builtins fixtures/isinstancelist.pyi]
+
+[case testUnreachableWhenSuperclassIsAny]
+# flags: --strict-optional
+from typing import Any
+
+# This can happen if we're importing a class from a missing module
+Parent: Any
+class Child(Parent):
+    def foo(self) -> int:
+        reveal_type(self)       # E: Revealed type is '__main__.Child'
+        if self is None:
+            reveal_type(self)
+            return None
+        reveal_type(self)       # E: Revealed type is '__main__.Child'
+        return 3
+
+    def bar(self) -> int:
+        self = super(Child, self).something()
+        reveal_type(self)       # E: Revealed type is '__main__.Child'
+        if self is None:
+            reveal_type(self)
+            return None
+        reveal_type(self)       # E: Revealed type is '__main__.Child'
+        return 3
+[builtins fixtures/isinstance.pyi]
+
+[case testUnreachableWhenSuperclassIsAnyNoStrictOptional]
+# flags: --no-strict-optional
+from typing import Any
+
+Parent: Any
+class Child(Parent):
+    def foo(self) -> int:
+        reveal_type(self)       # E: Revealed type is '__main__.Child'
+        if self is None:
+            reveal_type(self)   # E: Revealed type is '__main__.Child'
+            return None
+        reveal_type(self)       # E: Revealed type is '__main__.Child'
+        return 3
+[builtins fixtures/isinstance.pyi]

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -396,9 +396,7 @@ print('y' in x)
 True
 False
 
-[case testOverlappingOperatorMethods-skip]
-# TODO: This test will be repaired by my follow-up PR improving support for
-# detecting partially-overlapping types in general
+[case testOverlappingOperatorMethods]
 
 class X: pass
 class A:


### PR DESCRIPTION
This pull request adds more robust support for detecting partially overlapping types. Specifically, it detects overlaps with...

1. TypedDicts
2. Tuples
3. Unions
4. TypeVars
5. Generic types containing variations of the above.

It also swaps out the code for detecting overlaps with operators and removes some associated (and now unused) code.

This pull request builds on top of https://github.com/python/mypy/pull/5474 and https://github.com/python/mypy/pull/5475 -- once those two PRs are merged, I'll rebase this diff if necessary.

This pull request also supercedes https://github.com/python/mypy/pull/5475 -- that PR contains basically the same code as these three PRs, just smushed together.
