### PR TITLE
Eliminate some conditional method defs in fastparse

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1003,7 +1003,13 @@ class TypeConverter(ast3.NodeTransformer):
         self.line = line
         self.node_stack = []  # type: List[ast3.AST]
 
-    def _visit_implementation(self, node: Optional[ast3.AST]) -> Optional[Type]:
+    @overload
+    def visit(self, node: ast3.expr) -> Type: ...
+
+    @overload  # noqa
+    def visit(self, node: Optional[ast3.AST]) -> Optional[Type]: ...
+
+    def visit(self, node: Optional[ast3.AST]) -> Optional[Type]:  # noqa
         """Modified visit -- keep track of the stack of nodes"""
         if node is None:
             return None
@@ -1012,15 +1018,6 @@ class TypeConverter(ast3.NodeTransformer):
             return super().visit(node)
         finally:
             self.node_stack.pop()
-
-    @overload
-    def visit(self, node: ast3.expr) -> Type: ...
-
-    @overload  # noqa
-    def visit(self, node: Optional[ast3.AST]) -> Optional[Type]: ...
-
-    def visit(self, node: Optional[ast3.AST]) -> Optional[Type]:  # noqa
-        return self._visit_implementation(node)
 
     def parent(self) -> Optional[ast3.AST]:
         """Return the AST node above the one we are processing"""

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -74,7 +74,7 @@ TYPE_COMMENT_AST_ERROR = 'invalid type comment or annotation'
 
 # Older versions of typing don't allow using overload outside stubs,
 # so provide a dummy.
-if sys.version_info < (3, 6):
+if not MYPY and sys.version_info < (3, 6):
     def overload(x: Any) -> Any:  # noqa
         return x
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -67,6 +67,13 @@ TYPE_COMMENT_SYNTAX_ERROR = 'syntax error in type comment'
 TYPE_COMMENT_AST_ERROR = 'invalid type comment or annotation'
 
 
+# Older versions of typing don't allow using overload outside stubs,
+# so provide a dummy.
+if sys.version_info < (3, 6):
+    def overload(x: Any) -> Any:  # noqa
+        return x
+
+
 def parse(source: Union[str, bytes],
           fnam: str,
           module: Optional[str],


### PR DESCRIPTION
It seems like they might not be necessary anymore, and mypyc doesn't
support it.