### PR TITLE
Fix missing Optional in DictExpr.item

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -385,13 +385,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def check_typeddict_call_with_dict(self, callee: TypedDictType,
                                        kwargs: DictExpr,
                                        context: Context) -> Type:
-        item_name_exprs = [item[0] for item in kwargs.items]
         item_args = [item[1] for item in kwargs.items]
 
         item_names = []  # List[str]
-        for item_name_expr in item_name_exprs:
+        for item_name_expr, item_arg in kwargs.items:
             if not isinstance(item_name_expr, StrExpr):
-                self.chk.fail(messages.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, item_name_expr)
+                key_context = item_name_expr or item_arg
+                self.chk.fail(messages.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, key_context)
                 return AnyType(TypeOfAny.from_error)
             item_names.append(item_name_expr.value)
 

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -139,7 +139,8 @@ class _Hasher(ExpressionVisitor[Optional[Key]]):
 
     def visit_dict_expr(self, e: DictExpr) -> Optional[Key]:
         if all(a and literal(a) == literal(b) == LITERAL_YES for a, b in e.items):
-            rest = tuple((literal_hash(a), literal_hash(b)) for a, b in e.items)  # type: Any
+            rest = tuple((literal_hash(a) if a else None, literal_hash(b))
+                         for a, b in e.items)  # type: Any
             return ('Dict',) + rest
         return None
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1694,9 +1694,9 @@ class ListExpr(Expression):
 class DictExpr(Expression):
     """Dictionary literal expression {key: value, ...}."""
 
-    items = None  # type: List[Tuple[Expression, Expression]]
+    items = None  # type: List[Tuple[Optional[Expression], Expression]]
 
-    def __init__(self, items: List[Tuple[Expression, Expression]]) -> None:
+    def __init__(self, items: List[Tuple[Optional[Expression], Expression]]) -> None:
         super().__init__()
         self.items = items
 

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -242,15 +242,18 @@ class TypedDictAnalyzer:
         assert total is not None
         return items, types, total, ok
 
-    def parse_typeddict_fields_with_types(self, dict_items: List[Tuple[Expression, Expression]],
-                                          context: Context) -> Tuple[List[str], List[Type], bool]:
+    def parse_typeddict_fields_with_types(
+            self,
+            dict_items: List[Tuple[Optional[Expression], Expression]],
+            context: Context) -> Tuple[List[str], List[Type], bool]:
         items = []  # type: List[str]
         types = []  # type: List[Type]
         for (field_name_expr, field_type_expr) in dict_items:
             if isinstance(field_name_expr, (StrExpr, BytesExpr, UnicodeExpr)):
                 items.append(field_name_expr.value)
             else:
-                self.fail_typeddict_arg("Invalid TypedDict() field name", field_name_expr)
+                name_context = field_name_expr or field_type_expr
+                self.fail_typeddict_arg("Invalid TypedDict() field name", name_context)
                 return [], [], False
             try:
                 type = expr_to_unanalyzed_type(field_type_expr)

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -403,7 +403,7 @@ class TransformVisitor(NodeVisitor[Node]):
         return ListExpr(self.expressions(node.items))
 
     def visit_dict_expr(self, node: DictExpr) -> DictExpr:
-        return DictExpr([(self.expr(key), self.expr(value))
+        return DictExpr([(self.expr(key) if key else None, self.expr(value))
                          for key, value in node.items])
 
     def visit_tuple_expr(self, node: TupleExpr) -> TupleExpr:

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1131,6 +1131,12 @@ from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x'})  # E: TypedDict() expects a dictionary literal as the second argument
 [builtins fixtures/dict.pyi]
 
+[case testCannotCreateTypedDictTypeWithKwargs]
+from mypy_extensions import TypedDict
+d = {'x': int, 'y': int}
+Point = TypedDict('Point', {**d})  # E: Invalid TypedDict() field name
+[builtins fixtures/dict.pyi]
+
 -- NOTE: The following code works at runtime but is not yet supported by mypy.
 --       Keyword arguments may potentially be supported in the future.
 [case testCannotCreateTypedDictTypeWithNonpositionalArgs]


### PR DESCRIPTION
The key part of an entry in DictExpr can be None if one of the entries
in a dictionary is '**x'. Fixing the type errors revealed a crash bug
such a dict is used to create a TypedDict.