### PR TITLE
Fixes #1727: constructor after classmethod counts

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -88,23 +88,6 @@ class DataclassTransformer:
                 args=[attr.to_argument(info) for attr in attributes if attr.is_in_init],
                 return_type=NoneTyp(),
             )
-            for stmt in self._ctx.cls.defs.body:
-                # Fix up the types of classmethods since, by default,
-                # they will be based on the parent class' init.
-                if isinstance(stmt, Decorator) and stmt.func.is_class:
-                    func_type = stmt.func.type
-                    if isinstance(func_type, CallableType):
-                        func_type.arg_types[0] = self._ctx.api.class_type(self._ctx.cls.info)
-                if isinstance(stmt, OverloadedFuncDef) and stmt.is_class:
-                    func_type = stmt.type
-                    if isinstance(func_type, Overloaded):
-                        class_type = ctx.api.class_type(ctx.cls.info)
-                        for item in func_type.items():
-                            item.arg_types[0] = class_type
-                        if stmt.impl is not None:
-                            assert isinstance(stmt.impl, Decorator)
-                            if isinstance(stmt.impl.func.type, CallableType):
-                                stmt.impl.func.type.arg_types[0] = class_type
 
         # Add an eq method, but only if the class doesn't already have one.
         if decorator_arguments['eq'] and info.get('__eq__') is None:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -616,6 +616,18 @@ main:3: error: Incompatible types in assignment (expression has type "B", variab
 main:4: error: Incompatible types in assignment (expression has type "A", variable has type "D")
 main:5: error: Incompatible types in assignment (expression has type "D2", variable has type "D")
 
+[case testClassmethodBeforeInit]
+class C:
+    @classmethod
+    def create(cls, arg: int) -> 'C':
+        return cls(arg)
+
+    def __init__(self, arg: 'int') -> None:
+        self._arg: int = arg
+
+reveal_type(C.create)  # E: Revealed type is 'def (arg: builtins.int) -> __main__.C'
+[builtins fixtures/classmethod.pyi]
+
 
 -- Attribute access in class body
 -- ------------------------------

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -631,6 +631,33 @@ class C:
 reveal_type(C.create)  # E: Revealed type is 'def (arg: builtins.int) -> __main__.C'
 [builtins fixtures/classmethod.pyi]
 
+[case testClassmethodBeforeInitInNestedClass]
+class A:
+    @classmethod
+    def create(cls, arg: int) -> 'A':
+        reveal_type(cls) # E: Revealed type is 'def (arg: builtins.int) -> __main__.A'
+        reveal_type(cls(arg)) # E: Revealed type is '__main__.A'
+        cls() # E: Too few arguments for "A"
+        return cls(arg)
+
+    class B:
+        @classmethod
+        def create(cls, arg: str) -> 'A.B':
+            reveal_type(cls) # E: Revealed type is 'def (arg: builtins.str) -> __main__.A.B'
+            reveal_type(cls(arg)) # E: Revealed type is '__main__.A.B'
+            cls() # E: Too few arguments for "B"
+            return cls(arg)
+
+        def __init__(self, arg: 'str') -> None:
+            self._arg: str = arg
+
+    def __init__(self, arg: 'int') -> None:
+        self._arg: int = arg
+
+reveal_type(A.create)  # E: Revealed type is 'def (arg: builtins.int) -> __main__.A'
+reveal_type(A.B.create)  # E: Revealed type is 'def (arg: builtins.str) -> __main__.A.B'
+[builtins fixtures/classmethod.pyi]
+
 [case testClassmethodBeforeInitInGenericClass]
 from typing import Generic, TypeVar
 T = TypeVar('T')

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -620,12 +620,29 @@ main:5: error: Incompatible types in assignment (expression has type "D2", varia
 class C:
     @classmethod
     def create(cls, arg: int) -> 'C':
+        reveal_type(cls) # E: Revealed type is 'def (arg: builtins.int) -> __main__.C'
+        reveal_type(cls(arg)) # E: Revealed type is '__main__.C'
+        cls() # E: Too few arguments for "C"
         return cls(arg)
 
     def __init__(self, arg: 'int') -> None:
         self._arg: int = arg
 
 reveal_type(C.create)  # E: Revealed type is 'def (arg: builtins.int) -> __main__.C'
+[builtins fixtures/classmethod.pyi]
+
+[case testClassmethodBeforeInitInGenericClass]
+from typing import Generic, TypeVar
+T = TypeVar('T')
+class C(Generic[T]):
+    @classmethod
+    def create(cls, arg: T) -> 'C':
+        cls() # E: Too few arguments for "C"
+        return cls(arg, arg)
+
+    def __init__(self, arg1: T, arg2: T) -> None:
+        self._arg1 = arg1
+        self._arg2 = arg2
 [builtins fixtures/classmethod.pyi]
 
 

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -523,6 +523,21 @@ class A:
   def __init__(self, b: 'B') -> None: pass
 class B: pass
 
+[case testOverloadedInitAndClassMethod]
+from foo import *
+[file foo.pyi]
+from typing import overload
+class A:
+  @classmethod
+  def from_int(cls, x: int) -> 'A':
+    reveal_type(cls) # E: Revealed type is 'Any'
+    return cls(x)
+  @overload
+  def __init__(self, a: int) -> None: pass
+  @overload
+  def __init__(self, b: str) -> None: pass
+[builtins fixtures/classmethod.pyi]
+
 [case testIntersectionTypeCompatibility]
 from foo import *
 [file foo.pyi]

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -29,6 +29,19 @@ class A:
 <m.A.g> -> m.f
 <m.A> -> <m.f>, m.A, m.f
 
+[case testCallClassMethod]
+def f() -> None:
+    A.g()
+class A:
+    @classmethod
+    def g(cls) -> None: pass
+[out]
+<m.A.__init__> -> m.f
+<m.A.__new__> -> m.f
+<m.A.g> -> m, m.f
+<m.A> -> m.A, m.f
+[builtins fixtures/classmethod.pyi]
+
 [case testAccessAttribute]
 def f(a: A) -> None:
     a.x

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -2143,6 +2143,51 @@ main:3: note: Possible overload variants:
 main:3: note:     def foo(cls: Wrapper, x: int) -> int
 main:3: note:     def foo(cls: Wrapper, x: str) -> str
 
+[case testInitMovesAroundClassmethod]
+[file m.py]
+class C:
+    def __init__(self, x: int) -> None:
+        self._x = x
+    @classmethod
+    def create(cls, x: int) -> 'C':
+        return cls(x)
+[file m.py.2]
+class C:
+    @classmethod
+    def create(cls, x: int) -> 'C':
+        return cls(x)
+    def __init__(self, x: int) -> None:
+        self._x = x
+[file m.py.3]
+class C:
+    def __init__(self, x: int) -> None:
+        self._x = x
+    @classmethod
+    def create(cls, x: int) -> 'C':
+        return cls(x)
+[builtins fixtures/classmethod.pyi]
+[out]
+==
+==
+
+[case testInitDisappearsClassmethodStays]
+[file m.py]
+class C:
+    def __init__(self, x: int) -> None:
+        self._x = x
+    @classmethod
+    def create(cls, x: int) -> 'C':
+        return cls(x)
+[file m.py.2]
+class C:
+    @classmethod
+    def create(cls, x: int) -> 'C':
+        return cls(x)
+[builtins fixtures/classmethod.pyi]
+[out]
+==
+m.py:4: error: Too many arguments for "C"
+
 [case testRefreshGenericClass]
 from typing import TypeVar, Generic
 from a import A


### PR DESCRIPTION
This is a fix for https://github.com/python/mypy/issues/1727.

Instead of prepare classmethod definitions while analyzing class, let's postpone this until the class is fully analyzed.

`dataclass` magic creates `__init__` after the class is already created, so they fix up all the classmethods. This is no longer needed.