### PR TITLE
Allow overloaded overrides if they don't extend domain

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1341,6 +1341,20 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 self.msg.signature_incompatible_with_supertype(
                     defn.name(), name, base.name(), context)
 
+    def get_op_other_domain(self, tp: FunctionLike) -> Optional[Type]:
+        if isinstance(tp, CallableType):
+            if tp.arg_kinds and tp.arg_kinds[0] == ARG_POS:
+                return tp.arg_types[0]
+            return None
+        elif isinstance(tp, Overloaded):
+            raw_items = [self.get_op_other_domain(it) for it in tp.items()]
+            items = [it for it in raw_items if it]
+            if items:
+                return UnionType.make_simplified_union(items)
+            return None
+        else:
+            assert False, "Need to check all FunctionLike subtypes here"
+
     def check_override(self, override: FunctionLike, original: FunctionLike,
                        name: str, name_in_super: str, supertype: str,
                        original_class_or_static: bool,
@@ -1357,15 +1371,18 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         """
         # Use boolean variable to clarify code.
         fail = False
+        dunder_note = False
         if not is_subtype(override, original, ignore_pos_arg_names=True):
             fail = True
-        elif (not isinstance(original, Overloaded) and
-              isinstance(override, Overloaded) and
-              self.is_forward_op_method(name)):
-            # Operator method overrides cannot introduce overloading, as
+        elif isinstance(override, Overloaded) and self.is_forward_op_method(name):
+            # Operator method overrides cannot extend the domain, as
             # this could be unsafe with reverse operator methods.
-            fail = True
-
+            original_domain = self.get_op_other_domain(original)
+            override_domain = self.get_op_other_domain(override)
+            if (original_domain and override_domain and
+                    not is_subtype(override_domain, original_domain)):
+                fail = True
+                dunder_note = True
         if isinstance(original, FunctionLike) and isinstance(override, FunctionLike):
             if original_class_or_static and not override_class_or_static:
                 fail = True
@@ -1427,6 +1444,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 # Fall back to generic incompatibility message.
                 self.msg.signature_incompatible_with_supertype(
                     name, name_in_super, supertype, node)
+            if dunder_note:
+                self.note("Overloaded operator methods can't have wider argument types"
+                          " in overrides", node)
 
     def visit_class_def(self, defn: ClassDef) -> None:
         """Type check a class definition."""

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1571,7 +1571,8 @@ from typing import overload
 class A:
     def __add__(self, x: int) -> int: pass
 class B(A):
-    @overload  # E: Signature of "__add__" incompatible with supertype "A"
+    @overload  # E: Signature of "__add__" incompatible with supertype "A" \
+               # N: Overloaded operator methods can't have wider argument types in overrides
     def __add__(self, x: int) -> int: pass
     @overload
     def __add__(self, x: str) -> str: pass
@@ -1665,7 +1666,8 @@ class A:
     @overload
     def __add__(self, x: str) -> 'A': pass
 class B(A):
-    @overload
+    @overload  # E: Signature of "__add__" incompatible with supertype "A" \
+               # N: Overloaded operator methods can't have wider argument types in overrides
     def __add__(self, x: int) -> A: pass
     @overload
     def __add__(self, x: str) -> A: pass
@@ -1830,8 +1832,7 @@ class Num1:
     def __radd__(self, other: Num1) -> Num1: ...
 
 class Num2(Num1):
-    # TODO: This should not be an error. See https://github.com/python/mypy/issues/4985
-    @overload    # E: Signature of "__add__" incompatible with supertype "Num1"
+    @overload
     def __add__(self, other: Num2) -> Num2: ...  
     @overload
     def __add__(self, other: Num1) -> Num2: ...

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4125,6 +4125,59 @@ main:11: error: Argument 7 to "f" has incompatible type "Union[int, str]"; expec
 main:11: error: Argument 8 to "f" has incompatible type "Union[int, str]"; expected "int"
 main:11: note: Not all union combinations were tried because there are too many unions
 
+[case testSafeDunderOverlapInSubclass]
+from typing import overload
+
+class A:
+    def f(self, x : 'A') -> 'A': ...
+
+class B(A):
+    @overload
+    def f(self, x : 'B') -> 'B': ...
+    @overload
+    def f(self, x : 'A') -> 'A' : ...
+    def f(self, x):
+        pass
+[out]
+
+[case testUnsafeDunderOverlapInSubclass]
+from typing import overload
+
+class A:
+    def __add__(self, x : 'A') -> 'A':
+        if isinstance(x, A):
+            return A()
+        else:
+            return NotImplemented
+
+# This is unsafe override because of the problem below
+class B(A):
+     @overload  # E: Signature of "__add__" incompatible with supertype "A" \
+                # N: Overloaded operator methods can't have wider argument types in overrides
+     def __add__(self, x : 'Other') -> 'B' : ...
+     @overload
+     def __add__(self, x : 'A') -> 'A': ...
+     def __add__(self, x):
+        if isinstance(x, Other):
+            return B()
+        elif isinstance(x, A):
+            return A()
+        else:
+            return NotImplemented
+
+class Other:
+    def __radd__(self, x: 'A') -> 'Other':
+        if isinstance(x, A):
+            return Other()
+        else:
+            return NotImplemented
+
+actually_b: A = B()
+reveal_type(actually_b + Other())  # E: Revealed type is '__main__.Other'
+# Runtime type is B, this is why we report the error on overriding.
+[builtins fixtures/isinstance.pyi]
+[out]
+
 [case testOverloadErrorMessageManyMatches]
 from typing import overload
 


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/4985

Mypy previously disallowed introducing overloads for operator methods in overrides because this can interact unsafely with reverse methods. However it looks like this is safe for the situations where the domain of the override is not extended.

In fact the same unsafety exists for non-overloaded op-methods (see example in https://github.com/python/mypy/issues/4985#issuecomment-414095444), but it looks like we are fine with this, I have found few existing tests explicitly testing for this.