### PR TITLE
Bounded/constrained type variables don't shadow Any in overloads

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3752,9 +3752,10 @@ def overload_can_never_match(signature: CallableType, other: CallableType) -> bo
 
     Assumes that both signatures have overlapping argument counts.
     """
-    signature = expand_type(signature, {tvar.id: tvar.erase_to_union_or_bound()
-                            for tvar in signature.variables})
-    return is_callable_compatible(signature, other,
+    exp_signature = expand_type(signature, {tvar.id: tvar.erase_to_union_or_bound()
+                                for tvar in signature.variables})
+    assert isinstance(exp_signature, CallableType)
+    return is_callable_compatible(exp_signature, other,
                                   is_compat=is_more_precise,
                                   ignore_return=True)
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3752,6 +3752,8 @@ def overload_can_never_match(signature: CallableType, other: CallableType) -> bo
 
     Assumes that both signatures have overlapping argument counts.
     """
+    signature = expand_type(signature, {tvar.id: tvar.erase_to_union_or_bound()
+                            for tvar in signature.variables})
     return is_callable_compatible(signature, other,
                                   is_compat=is_more_precise,
                                   ignore_return=True)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3752,6 +3752,13 @@ def overload_can_never_match(signature: CallableType, other: CallableType) -> bo
 
     Assumes that both signatures have overlapping argument counts.
     """
+    # The extra erasure is needed to prevent spurious errors
+    # in situations where an `Any` overload is used as a fallback
+    # for an overload with type variables. The spurious error appears
+    # because the type variables turn into `Any` during unification in
+    # the below subtype check and (surprisingly?) `is_proper_subtype(Any, Any)`
+    # returns `True`.
+    # TODO: find a cleaner solution instead of this ad-hoc erasure.
     exp_signature = expand_type(signature, {tvar.id: tvar.erase_to_union_or_bound()
                                 for tvar in signature.variables})
     assert isinstance(exp_signature, CallableType)

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1111,8 +1111,8 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
     def visit_type_var(self, left: TypeVarType) -> bool:
         if isinstance(self.right, TypeVarType) and left.id == self.right.id:
             return True
-        if left.values and is_subtype(UnionType.make_simplified_union(left.values), self.right,
-                                      ignore_promotions=self.ignore_promotions):
+        if left.values and self._is_proper_subtype(UnionType.make_simplified_union(left.values),
+                                                   self.right):
             return True
         return self._is_proper_subtype(left.upper_bound, self.right)
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -156,6 +156,12 @@ class TypeVarDef(mypy.nodes.Context):
         return TypeVarDef(old.name, old.fullname, new_id, old.values,
                           old.upper_bound, old.variance, old.line, old.column)
 
+    def erase_to_union_or_bound(self) -> Type:
+        if self.values:
+            return UnionType.make_simplified_union(self.values)
+        else:
+            return self.upper_bound
+
     def __repr__(self) -> str:
         if self.values:
             return '{} in {}'.format(self.name, tuple(self.values))
@@ -561,10 +567,7 @@ class TypeVarType(Type):
         return visitor.visit_type_var(self)
 
     def erase_to_union_or_bound(self) -> Type:
-        if self.values:
-            return UnionType.make_simplified_union(self.values)
-        else:
-            return self.upper_bound
+        return self.binder.erase_to_union_or_bound()
 
     def __hash__(self) -> int:
         return hash(self.id)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -567,7 +567,10 @@ class TypeVarType(Type):
         return visitor.visit_type_var(self)
 
     def erase_to_union_or_bound(self) -> Type:
-        return self.binder.erase_to_union_or_bound()
+        if self.values:
+            return UnionType.make_simplified_union(self.values)
+        else:
+            return self.upper_bound
 
     def __hash__(self) -> int:
         return hash(self.id)

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4257,3 +4257,49 @@ def f() -> None:
 
 [builtins fixtures/dict.pyi]
 [out]
+
+[case testOverloadConstrainedTypevarNotShadowingAny]
+from lib import attr
+from typing import Any
+
+reveal_type(attr(1))  # E: Revealed type is 'builtins.int*'
+reveal_type(attr("hi"))  # E: Revealed type is 'builtins.int'
+x: Any
+reveal_type(attr(x)) # E: Revealed type is 'Any'
+attr("hi", 1)  # E: No overload variant of "attr" matches argument types "str", "int" \
+               # N: Possible overload variant: \
+               # N:     def [T in (int, float)] attr(default: T = ..., blah: int = ...) -> T \
+               # N:     <1 more non-matching overload not shown>
+[file lib.pyi]
+from typing import overload, Any, TypeVar
+
+T = TypeVar('T', int, float)
+
+@overload
+def attr(default: T = ..., blah: int = ...) -> T: ...
+@overload
+def attr(default: Any = ...) -> int: ...
+[out]
+
+[case testOverloadBoundedTypevarNotShadowingAny]
+from lib import attr
+from typing import Any
+
+reveal_type(attr(1))  # E: Revealed type is 'builtins.int*'
+reveal_type(attr("hi"))  # E: Revealed type is 'builtins.int'
+x: Any
+reveal_type(attr(x)) # E: Revealed type is 'Any'
+attr("hi", 1)  # E: No overload variant of "attr" matches argument types "str", "int" \
+               # N: Possible overload variant: \
+               # N:     def [T <: int] attr(default: T = ..., blah: int = ...) -> T \
+               # N:     <1 more non-matching overload not shown>
+[file lib.pyi]
+from typing import overload, TypeVar, Any
+
+T = TypeVar('T', bound=int)
+
+@overload
+def attr(default: T = ..., blah: int = ...) -> T: ...
+@overload
+def attr(default: Any = ...) -> int: ...
+[out]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4303,3 +4303,21 @@ def attr(default: T = ..., blah: int = ...) -> T: ...
 @overload
 def attr(default: Any = ...) -> int: ...
 [out]
+
+[case testAnyIsOKAsFallbackInOverloads]
+import stub
+[file stub.pyi]
+from typing import TypeVar, Any, overload
+
+T = TypeVar('T')
+
+@overload
+def foo(x: T) -> T: ...
+@overload
+def foo(x: Any) -> Any: ...
+
+@overload
+def bar(x: T) -> T: ...
+@overload
+def bar(x: Any) -> int: ...
+[out]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/4227

The problem is that after unification with `Any` type variables can also become `Any`. I am aware that this may introduce (rare) cases when we don't detect never-matched overload. However, since this error does not introduce any unsafety, false negatives are clearly better than false positives.