### PR TITLE
Fix untyped decorator check for class instances

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4007,7 +4007,7 @@ def is_untyped_decorator(typ: Optional[Type]) -> bool:
     if not typ:
         return True
     if isinstance(typ, CallableType):
-        return typ.implicit
+        return not is_typed_callable(typ)
     elif isinstance(typ, Instance):
         method = typ.type.get_method('__call__')
         if method and method.type:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4014,6 +4014,8 @@ def is_untyped_decorator(typ: Optional[Type]) -> bool:
             return not is_typed_callable(method.type)
         else:
             return False
+    elif isinstance(typ, Overloaded):
+        return any(is_untyped_decorator(item) for item in typ.items())
     return True
 
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4008,7 +4008,7 @@ def is_untyped_decorator(typ: Optional[Type]) -> bool:
         return True
     if isinstance(typ, CallableType):
         return typ.implicit
-    if isinstance(typ, Instance):
+    elif isinstance(typ, Instance):
         method = typ.type.get_method('__call__')
         if method and method.type:
             return not is_typed_callable(method.type)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4004,9 +4004,15 @@ def is_typed_callable(c: Optional[Type]) -> bool:
 
 
 def is_untyped_decorator(typ: Optional[Type]) -> bool:
-    if not typ or not isinstance(typ, CallableType):
+    if not typ:
         return True
-    return typ.implicit
+    if isinstance(typ, CallableType):
+        return typ.implicit
+    if isinstance(typ, Instance):
+        method = typ.type.get_method('__call__')
+        if method and method.type:
+            return not is_typed_callable(method.type)
+    return True
 
 
 def is_static(func: Union[FuncBase, Decorator]) -> bool:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4010,8 +4010,10 @@ def is_untyped_decorator(typ: Optional[Type]) -> bool:
         return not is_typed_callable(typ)
     elif isinstance(typ, Instance):
         method = typ.type.get_method('__call__')
-        if method and method.type:
+        if method:
             return not is_typed_callable(method.type)
+        else:
+            return False
     return True
 
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4017,7 +4017,7 @@ def is_typed_callable(c: Optional[Type]) -> bool:
 def is_untyped_decorator(typ: Optional[Type]) -> bool:
     if not typ:
         return True
-    if isinstance(typ, CallableType):
+    elif isinstance(typ, CallableType):
         return not is_typed_callable(typ)
     elif isinstance(typ, Instance):
         method = typ.type.get_method('__call__')

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -144,9 +144,24 @@ class UntypedDecorator:
     def __call__(self, c):
         return function
 
-@UntypedDecorator()  # E: Untyped decorator makes function "f" untyped
 @TypedDecorator()
 def f() -> None: pass
+
+@UntypedDecorator()  # E: Untyped decorator makes function "g" untyped
+def g() -> None: pass
+
+@TypedDecorator()
+@UntypedDecorator()  # E: Untyped decorator makes function "h" untyped
+def h() -> None: pass
+
+@UntypedDecorator()  # E: Untyped decorator makes function "i" untyped
+@TypedDecorator()
+def i() -> None: pass
+
+reveal_type(f)  # E: Revealed type is 'def (*Any, **Any) -> Any'
+reveal_type(g)  # E: Revealed type is 'Any'
+reveal_type(h)  # E: Revealed type is 'def (*Any, **Any) -> Any'
+reveal_type(i)  # E: Revealed type is 'Any'
 
 [case testDisallowUntypedDecoratorsNonCallableInstance]
 # flags: --disallow-untyped-decorators

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -148,6 +148,14 @@ class UntypedDecorator:
 @TypedDecorator()
 def f() -> None: pass
 
+[case testDisallowUntypedDecoratorsNonCallableInstance]
+# flags: --disallow-untyped-decorators
+class Decorator:
+    pass
+
+@Decorator()  # E: "Decorator" not callable
+def f() -> None: pass
+
 [case testSubclassingAny]
 # flags: --disallow-subclassing-any
 from typing import Any

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -132,6 +132,22 @@ def d3(p) -> Any:
 @d1  # E: Untyped decorator makes function "f" untyped
 def f() -> None: pass
 
+[case testDisallowUntypedDecoratorsCallableInstance]
+# flags: --disallow-untyped-decorators
+from typing import Callable
+
+class TypedDecorator:
+    def __call__(self, c: Callable) -> Callable:
+        return function
+
+class UntypedDecorator:
+    def __call__(self, c):
+        return function
+
+@UntypedDecorator()  # E: Untyped decorator makes function "f" untyped
+@TypedDecorator()
+def f() -> None: pass
+
 [case testSubclassingAny]
 # flags: --disallow-subclassing-any
 from typing import Any

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4867,4 +4867,9 @@ def dec(x) -> Any:
 def f(name: str) -> int:
     return 0
 
+@dec('abc')
+def g(name: str) -> int:
+    return 0
+
 reveal_type(f)  # E: Revealed type is 'def (name: builtins.str) -> builtins.int'
+reveal_type(g)  # E: Revealed type is 'def (name: builtins.str) -> builtins.int'

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4257,3 +4257,22 @@ def f() -> None:
 
 [builtins fixtures/dict.pyi]
 [out]
+
+[case testDisallowUntypedDecoratorsOverload]
+# flags: --disallow-untyped-decorators
+from typing import Any, Callable, overload, TypeVar
+
+F = TypeVar('F', bound=Callable[..., Any])
+
+@overload
+def dec(x: F) -> F: ...
+@overload
+def dec(x: str) -> Callable[[F], F]: ...
+def dec(x) -> Any:
+    pass
+
+@dec
+def f(name: str) -> int:
+    return 0
+
+reveal_type(f)  # E: Revealed type is 'def (name: builtins.str) -> builtins.int'


### PR DESCRIPTION
Running `mypy --disallow-untyped-decorators` when the decorator is a typed callable instance produces an error even though `reveal_type` shows the correct type.

Related to #4191 but I'll leave that one for a different PR.