### PR TITLE
Use extras_require over install_requires in mypy_extensions

### DIFF
--- a/extensions/setup.py
+++ b/extensions/setup.py
@@ -37,7 +37,7 @@ setup(
     license='MIT License',
     py_modules=['mypy_extensions'],
     classifiers=classifiers,
-    install_requires=[
-        'typing >= 3.5.3; python_version < "3.5"',
-    ],
+    extras_require={
+        ':python_version < "3.5"': 'typing >= 3.5.3',
+    },
 )


### PR DESCRIPTION
There are still old versions of setuptools hanging around that don't understand environment markers in install_requires (e.g. in Debian Jessie, see common-workflow-language/cwltool#872) and it would be nice if mypy_extensions would be installable on those versions of setuptools, especially since the main mypy setup.py uses extras_require for all its environment markers.