### PR TITLE
Don't strip nodes not analyzed in second pass

### DIFF
--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -44,7 +44,7 @@ from mypy.nodes import (
     Node, FuncDef, NameExpr, MemberExpr, RefExpr, MypyFile, FuncItem, ClassDef, AssignmentStmt,
     ImportFrom, Import, TypeInfo, SymbolTable, Var, CallExpr, Decorator, OverloadedFuncDef,
     SuperExpr, UNBOUND_IMPORTED, GDEF, MDEF, IndexExpr, SymbolTableNode, ImportAll, TupleExpr,
-    ListExpr, ForStmt
+    ListExpr, ForStmt, Block
 )
 from mypy.semanal_shared import create_indirect_imported_name
 from mypy.traverser import TraverserVisitor
@@ -82,6 +82,11 @@ class NodeStripVisitor(TraverserVisitor):
         self.file_node = file_node
         self.recurse_into_functions = False
         file_node.accept(self)
+
+    def visit_block(self, b: Block) -> None:
+        if b.is_unreachable:
+            return
+        super().visit_block(b)
 
     def visit_class_def(self, node: ClassDef) -> None:
         """Strip class body and type info, but don't strip methods."""

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7530,3 +7530,44 @@ x = 1
 Func = Callable[..., Any]
 [out]
 ==
+
+[case testIfMypyUnreachableClass]
+from a import x
+
+MYPY = False
+if MYPY:
+    pass
+else:
+    class A:
+        pass
+y: int = x
+[file a.py]
+x = 1
+[file a.py.2]
+x = 2
+[builtins fixtures/bool.pyi]
+[out]
+==
+
+[case testIfTypeCheckingUnreachableClass]
+from a import x
+from typing import TYPE_CHECKING
+
+if not TYPE_CHECKING:
+    class A(int):
+        pass
+else:
+    A = int
+
+y: A = x
+[file a.py]
+x = 1
+[file a.py.2]
+x = 2
+[file a.py.3]
+x = 'no way'
+[builtins fixtures/bool.pyi]
+[out]
+==
+==
+main:10: error: Incompatible types in assignment (expression has type "str", variable has type "int")


### PR DESCRIPTION
Fixes #5531 

The fix is quite straightforward. Alternatively we could try to make `aststrip` idempotent (i.e. it should not crash on non-analysed nodes), but I think this fix is more robust and simpler.