### PR TITLE
Add decorator for delegating arguments

### DIFF
--- a/extensions/mypy_extensions.py
+++ b/extensions/mypy_extensions.py
@@ -157,3 +157,10 @@ class _FlexibleAliasCls:
 
 
 FlexibleAlias = _FlexibleAliasCls()
+
+
+def delegate(base_func, exclude=()):
+    def decorator(func):
+        return func
+
+    return decorator

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2772,7 +2772,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if e.func.info and not e.func.is_dynamic():
             self.check_method_override(e)
 
-    def _delegated_sig(self, delegate_sig, sig, exclude):
+    def _delegated_sig(self,
+                       delegate_sig: CallableType,
+                       sig: CallableType,
+                       exclude: List[str]):
         # TODO: also delegate *args (currently only does **kwargs)
         exclude += sig.arg_names
         args = [(name,

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -43,6 +43,7 @@ typecheck_files = [
     'check-lists.test',
     'check-namedtuple.test',
     'check-typeddict.test',
+    'check-delegate.test',
     'check-type-aliases.test',
     'check-ignore.test',
     'check-type-promotion.test',

--- a/test-data/unit/check-delegate.test
+++ b/test-data/unit/check-delegate.test
@@ -1,0 +1,67 @@
+-- Delegating arguments
+
+[case testSimpleDelegation]
+from mypy_extensions import delegate
+
+def raw(name: str = 'he', age: int = 42):
+    return '%s is %s' % (name, age)
+
+@delegate(raw)
+def cooked(**kwargs):
+    return raw(**kwargs)
+
+reveal_type(cooked)  # E: Revealed type is 'def (*, name: builtins.str =, age: builtins.int =) -> Any'
+cooked(x=56)  # E: Unexpected keyword argument "x" for "cooked"
+[builtins fixtures/dict.pyi]
+
+
+[case testDelegationWithPositionalArg]
+from mypy_extensions import delegate
+
+def raw(foo, name='he', age=42):
+    return '%s is %s' % (name, age)
+
+@delegate(raw)
+def cooked(foo, bar, **kwargs):
+    return raw(foo, **kwargs)
+
+reveal_type(cooked)  # E: Revealed type is 'def (foo: Any, bar: Any, *, name: Any =, age: Any =) -> Any'
+cooked(3)  # E: Too few arguments for "cooked"
+cooked(3, 4)
+cooked(3, 4, 5)  # E: Too many positional arguments for "cooked"
+cooked(3, 4, name='bob')
+cooked(3, 4, x='bob')  # E: Unexpected keyword argument "x" for "cooked"
+[builtins fixtures/dict.pyi]
+
+
+[case testDelegationWithKeywordOnlyArg]
+from mypy_extensions import delegate
+
+def raw(*, name, age):
+    return '%s is %s' % (name, age)
+
+@delegate(raw)
+def cooked(foo, bar, **kwargs):
+    return raw(foo, **kwargs)
+
+reveal_type(cooked)  # E: Revealed type is 'def (foo: Any, bar: Any, *, name: Any, age: Any) -> Any'
+cooked(3, 4, name='bob', age=34)
+cooked(3, 4, name='bob')  # E: Missing named argument "age" for "cooked"
+cooked(3, 4, x='bob')  # E: Unexpected keyword argument "x" for "cooked"
+[builtins fixtures/dict.pyi]
+
+
+[case testDelegationWithExclude]
+from mypy_extensions import delegate
+
+def raw(name='he', age=42):
+    return '%s is %s' % (name, age)
+
+@delegate(raw, exclude=['name'])
+def cooked(**kwargs):
+    return raw(name='bob', **kwargs)
+
+reveal_type(cooked)  # E: Revealed type is 'def (*, age: Any =) -> Any'
+cooked(age=32)
+cooked(name='me')  # E: Unexpected keyword argument "name" for "cooked"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/lib-stub/mypy_extensions.pyi
+++ b/test-data/unit/lib-stub/mypy_extensions.pyi
@@ -1,5 +1,5 @@
 # NOTE: Requires fixtures/dict.pyi
-from typing import Dict, Type, TypeVar, Optional, Any, Generic
+from typing import Dict, Type, TypeVar, Optional, Any, Generic, Callable, List
 
 _T = TypeVar('_T')
 _U = TypeVar('_U')
@@ -27,3 +27,6 @@ def trait(cls: Any) -> Any: ...
 class NoReturn: pass
 
 class FlexibleAlias(Generic[_T, _U]): ...
+
+
+def delegate(base_func: Callable, exclude: List[str] = ()) -> Callable: ...


### PR DESCRIPTION
This is an attempt to implement python/typing#270. (I would suggest for now only reading the 2016 comments, after that it turns in a different direction which is for now irrelevant)

I've never contributed to this project before so I'm hesitant to try and do it all at once, hence I'm presenting this first draft to see if I'm on the right track (am I?) and ask some questions. If someone thinks I should just go ahead and fill in the remaining gaps as I see fit, I can do that too.

I've put this in mypy_extensions because it seems like the appropriate place to start (is there an alternative?) but eventually I would love to see this in the standard library. The applications go well beyond type checking, for example IDEs could use it for parameter hints and autocompletion. However they're not likely to implement that unless this is in the standard library.

Two major open questions are:

1. What if a function is decorated with `delegate` and also other decorators? In most cases mypy doesn't support decent type checking with other decorators, so if we took them into account the result of `delegate` would either be lost or trivial. Even if there is a decorator that changes the signature in a way that mypy can understand, reading the function definition with the decorators and trying to figure out the correct signature may be *very* confusing for a reader. Therefore I'm considering ignoring all other decorators when determining the signature of the function - `delegate` has the final say. That also doesn't sound great. Thoughts?
2. How should `*args` be delegated? Currently only `**kwargs` are handled, and they are replaced by any keyword arguments in the base function (whether optional, required, or variadic). I'm thinking `*args` should similarly be replaced by any positional arguments in the base function. Thoughts?