### PR TITLE
Original node wins in case of a redefinition (especially if it is a class)

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3288,8 +3288,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             self.locals[-1][name] = node
         elif self.type:
             existing = self.type.names.get(name)
-            if existing and isinstance(existing.node, TypeInfo) and existing.node != node.node:
-                # Classes can never be redefined
+            if existing and existing.node != node.node:
                 self.name_already_defined(name, context, existing)
                 return
             self.type.names[name] = node

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -348,6 +348,7 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
                 if not (node.kind == MODULE_REF and
                         self.sem.locals[-1][name].node == node.node):
                     self.sem.name_already_defined(name, context, self.sem.locals[-1][name])
+                    return
             self.sem.locals[-1][name] = node
         else:
             assert self.sem.type is None  # Pass 1 doesn't look inside classes
@@ -364,5 +365,6 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
                     ok = True
                 if not ok:
                     self.sem.name_already_defined(name, context, existing)
+                    return
             elif not existing:
                 self.sem.globals[name] = node

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4884,3 +4884,110 @@ def f(x: str) -> None: pass
 [out]
 [out2]
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
+
+-- These tests should just not crash
+[case testOverrideByBadVar]
+import a
+[file a.py]
+import lib
+x = 1
+[file a.py.2]
+import lib
+x = 2
+[file lib.py]
+class Slow:
+    pass
+
+s: Slow
+from cext import Slow  # type: ignore
+[out]
+[out2]
+
+[case testOverrideByBadVarAlias]
+import a
+[file a.py]
+import lib
+x = 1
+[file a.py.2]
+import lib
+x = 2
+[file lib.py]
+class Slow:
+    pass
+
+A = Slow
+from cext import Slow  # type: ignore
+[out]
+[out2]
+
+[case testOverrideByBadVarClass]
+import a
+[file a.py]
+import lib
+x = 1
+[file a.py.2]
+import lib
+x = 2
+[file lib.py]
+class C:
+    class Slow:
+        pass
+    s: Slow
+    from cext import Slow  # type: ignore
+[out]
+[out2]
+
+[case testOverrideByBadVarClassAlias]
+import a
+[file a.py]
+import lib
+x = 1
+[file a.py.2]
+import lib
+x = 2
+[file lib.py]
+class C:
+    class Slow:
+        pass
+    A = Slow
+    from cext import Slow  # type: ignore
+[out]
+[out2]
+
+[case testOverrideByBadVarExisting]
+import a
+[file a.py]
+import lib
+x = 1
+[file a.py.2]
+import lib
+x = 2
+[file lib.py]
+class Slow:
+    pass
+
+s: Slow
+from cext import Slow  # type: ignore
+[file cext.py]
+Slow = 1
+[out]
+[out2]
+
+[case testOverrideByBadVarAliasExisting]
+import a
+[file a.py]
+import lib
+x = 1
+[file a.py.2]
+import lib
+x = 2
+[file lib.py]
+class Slow:
+    pass
+
+A = Slow
+from cext import Slow  # type: ignore
+[file cext.py]
+Slow = 1
+[out]
+[out2]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4992,6 +4992,42 @@ Slow = 1
 [out]
 [out2]
 
+[case testOverrideByBadFunction]
+import a
+[file a.py]
+import lib
+x = 1
+[file a.py.2]
+import lib
+x = 2
+[file lib.py]
+class C:
+    class Slow:
+        pass
+
+    s: Slow
+    def Slow() -> None: ...  # type: ignore
+[out]
+[out2]
+
+[case testOverrideByBadVarLocal]
+import a
+[file a.py]
+import lib
+x = 1
+[file a.py.2]
+import lib
+x = 2
+[file lib.py]
+def outer() -> None:
+    class Slow:
+        pass
+
+    s: Slow
+    from cext import Slow  # type: ignore
+[out]
+[out2]
+
 [case testFollowImportSkipNotInvalidatedOnPresent]
 # flags: --follow-imports=skip
 # cmd: mypy -m main


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5534

In principle we can be even more strict (see a little exception for class scope) but then we need to work on https://github.com/python/typeshed/issues/2423 first.

