### PR TITLE
Update -2 argument dest to match --python-version.

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -277,27 +277,31 @@ def infer_python_version_and_executable(options: Options,
     This function mutates options based on special_opts to infer the correct Python version and
     executable to use.
     """
+    # Check Options in case python_version is set in a config file, but prefer command
+    # line arguments.
+    python_version = special_opts.python_version or options.python_version
+
     # Infer Python version and/or executable if one is not given
 
     # TODO: (ethanhs) Look at folding these checks and the site packages subprocess calls into
     # one subprocess call for speed.
-    if special_opts.python_executable is not None and special_opts.python_version is not None:
+    if special_opts.python_executable is not None and python_version is not None:
         py_exe_ver = _python_version_from_executable(special_opts.python_executable)
-        if py_exe_ver != special_opts.python_version:
+        if py_exe_ver != python_version:
             raise PythonExecutableInferenceError(
                 'Python version {} did not match executable {}, got version {}.'.format(
-                    special_opts.python_version, special_opts.python_executable, py_exe_ver
+                    python_version, special_opts.python_executable, py_exe_ver
                 ))
         else:
-            options.python_version = special_opts.python_version
+            options.python_version = python_version
             options.python_executable = special_opts.python_executable
-    elif special_opts.python_executable is None and special_opts.python_version is not None:
-        options.python_version = special_opts.python_version
+    elif special_opts.python_executable is None and python_version is not None:
+        options.python_version = python_version
         py_exe = None
         if not special_opts.no_executable:
-            py_exe = _python_executable_from_version(special_opts.python_version)
+            py_exe = _python_executable_from_version(python_version)
         options.python_executable = py_exe
-    elif special_opts.python_version is None and special_opts.python_executable is not None:
+    elif python_version is None and special_opts.python_executable is not None:
         options.python_version = _python_version_from_executable(
             special_opts.python_executable)
         options.python_executable = special_opts.python_executable
@@ -454,7 +458,7 @@ def process_options(args: List[str],
         help='Type check code assuming it will be running on Python x.y',
         dest='special-opts:python_version')
     platform_group.add_argument(
-        '-2', '--py2', dest='python_version', action='store_const',
+        '-2', '--py2', dest='special-opts:python_version', action='store_const',
         const=defaults.PYTHON2_VERSION,
         help="Use Python 2 mode (same as --python-version 2.7)")
     platform_group.add_argument(

--- a/mypy/test/testargs.py
+++ b/mypy/test/testargs.py
@@ -60,6 +60,17 @@ class ArgSuite(Suite):
         assert str(e.value) == 'Python version (2, 10) did not match executable {}, got' \
                                ' version {}.'.format(sys.executable, sys.version_info[:2])
 
+        # If a configuration file specifies python_version, it will be set on options.
+        # Use that when python_version isn't in special_opts.
+        special_opts = argparse.Namespace()
+        special_opts.python_executable = None
+        special_opts.python_version = None
+        special_opts.no_executable = None
+        options = Options()
+        options.python_version = (2, 10)
+        with pytest.raises(PythonExecutableInferenceError) as e:
+            infer_python_version_and_executable(options, special_opts)
+
         # test that --no-site-packages will disable executable inference
         matching_version = base + ['--python-version={}'.format(sys_ver_str),
                                    '--no-site-packages']

--- a/mypy/test/testargs.py
+++ b/mypy/test/testargs.py
@@ -61,15 +61,18 @@ class ArgSuite(Suite):
                                ' version {}.'.format(sys.executable, sys.version_info[:2])
 
         # If a configuration file specifies python_version, it will be set on options.
-        # Use that when python_version isn't in special_opts.
+        # Use that to figure out how to determine a value for python_executable, when
+        # special_opts.python_version is None.
         special_opts = argparse.Namespace()
         special_opts.python_executable = None
         special_opts.python_version = None
         special_opts.no_executable = None
         options = Options()
-        options.python_version = (2, 10)
-        with pytest.raises(PythonExecutableInferenceError) as e:
-            infer_python_version_and_executable(options, special_opts)
+        options.python_executable = None
+        options.python_version = sys.version_info[:2]
+        infer_python_version_and_executable(options, special_opts)
+        assert options.python_version == sys.version_info[:2]
+        assert options.python_executable == sys.executable
 
         # test that --no-site-packages will disable executable inference
         matching_version = base + ['--python-version={}'.format(sys_ver_str),


### PR DESCRIPTION
And check config for python_version when looking for a python
executable.

---

See issue #5576.

I didn't add any automated tests because I wasn't sure what you guys would have wanted for that. This stuff makes use of subprocess so either that'd be mocked out or it would depend on python2.7 being installed? I'm not sure.

And I'm uncertain that changing `infer_python_version_and_executable()` as I did is a good idea. Or if you'd prefer that `python_executable` on the `special_opts` namespace be set, if it's `None`, to the value of that attribute on the `Options` instance somewhere in `process_options()` before calling `infer_python_version_and_executable()`?