### PR TITLE
Support compiling the plugin infrastructure with mypyc

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -54,7 +54,7 @@ from mypy.parse import parse
 from mypy.stats import dump_type_stats
 from mypy.types import Type
 from mypy.version import __version__
-from mypy.plugin import Plugin, DefaultPlugin, ChainedPlugin
+from mypy.plugin import Plugin, DefaultPlugin, ChainedPlugin, plugin_types
 from mypy.defaults import PYTHON3_VERSION_MIN
 from mypy.server.deps import get_dependencies
 from mypy.fscache import FileSystemCache
@@ -569,7 +569,7 @@ def load_plugins(options: Options, errors: Errors) -> Plugin:
             plugin_error(
                 'Type object expected as the return value of "plugin"; got {!r} (in {})'.format(
                     plugin_type, plugin_path))
-        if not issubclass(plugin_type, Plugin):
+        if not issubclass(plugin_type, plugin_types):
             plugin_error(
                 'Return value of "plugin" must be a subclass of "mypy.plugin.Plugin" '
                 '(in {})'.format(plugin_path))

--- a/mypy/interpreted_plugin.py
+++ b/mypy/interpreted_plugin.py
@@ -1,0 +1,69 @@
+"""Hack for handling non-mypyc compiled plugins with a mypyc-compiled mypy"""
+
+from typing import Optional, Callable, Any
+from mypy.options import Options
+from mypy.types import Type, CallableType
+
+
+MYPY = False
+if MYPY:
+    import mypy.plugin
+
+
+class InterpretedPlugin:
+    """Base class of type checker plugins as exposed to external code.
+
+    This is a hack around mypyc not currently supporting interpreted subclasses
+    of compiled classes.
+    mypy.plugin will arrange for interpreted code to be find this class when it looks
+    for Plugin, and this class has a __new__ method that returns a WrapperPlugin object
+    that proxies to this interpreted version.
+    """
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> 'mypy.plugin.Plugin':
+        from mypy.plugin import WrapperPlugin
+        plugin = object.__new__(cls)  # type: ignore
+        plugin.__init__(*args, **kwargs)
+        return WrapperPlugin(plugin)
+
+    def __init__(self, options: Options) -> None:
+        self.options = options
+        self.python_version = options.python_version
+
+    def get_type_analyze_hook(self, fullname: str
+                              ) -> Optional[Callable[['mypy.plugin.AnalyzeTypeContext'], Type]]:
+        return None
+
+    def get_function_hook(self, fullname: str
+                          ) -> Optional[Callable[['mypy.plugin.FunctionContext'], Type]]:
+        return None
+
+    def get_method_signature_hook(self, fullname: str
+                                  ) -> Optional[Callable[['mypy.plugin.MethodSigContext'],
+                                                         CallableType]]:
+        return None
+
+    def get_method_hook(self, fullname: str
+                        ) -> Optional[Callable[['mypy.plugin.MethodContext'], Type]]:
+        return None
+
+    def get_attribute_hook(self, fullname: str
+                           ) -> Optional[Callable[['mypy.plugin.AttributeContext'], Type]]:
+        return None
+
+    def get_class_decorator_hook(self, fullname: str
+                                 ) -> Optional[Callable[['mypy.plugin.ClassDefContext'], None]]:
+        return None
+
+    def get_metaclass_hook(self, fullname: str
+                           ) -> Optional[Callable[['mypy.plugin.ClassDefContext'], None]]:
+        return None
+
+    def get_base_class_hook(self, fullname: str
+                            ) -> Optional[Callable[['mypy.plugin.ClassDefContext'], None]]:
+        return None
+
+    def get_customize_class_mro_hook(self, fullname: str
+                                     ) -> Optional[Callable[['mypy.plugin.ClassDefContext'],
+                                                            None]]:
+        return None

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -1,7 +1,5 @@
 """Plugin system for extending mypy."""
 
-import sys
-import os.path
 import types
 
 from abc import abstractmethod
@@ -21,6 +19,7 @@ from mypy.types import (
 from mypy.messages import MessageBuilder
 from mypy.options import Options
 import mypy.interpreted_plugin
+
 
 @trait
 class TypeAnalyzerPluginInterface:


### PR DESCRIPTION
The tricky part here is that fundamentally the plugin infrastructure needs to work
with classes that were not compiled by mypyc. Since mypyc doesn't currently
allow interpreted classes to inherit from mypyc classes, this poses a problem.

The solution is to introduce an `InterpretedPlugin` class that is not compiled by
mypyc that we arrange for interpreted modules to see as `Plugin`. Interpreted
plugins can safely subclass from this module, which arranges to wrap instances
of it in a `WrapperPlugin` class that inherits from `Plugin` and proxies to the
`InterpretedPlugin`.

There is a slightly different approach that would have worked where we do most
of the same stuff but keep `Plugin` interpreted and add an `InternalPlugin` instead
of relying on magic to expose `InterpretedPlugin` to interpreted classes, but I decided 
against that because it exposes this nonsense to more parts of mypy, and I would like
to rip it all out eventually anyways.

This is all kind of unfortunate.