### PR TITLE
Reformat and reorganize the config file docs

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -126,6 +126,8 @@ imports.
     compliant packages. Adding this flag will disable this behavior.
 
 
+.. _platform-configuration:
+
 Platform configuration
 **********************
 
@@ -208,8 +210,6 @@ The following options are available:
     ``dict``) become disallowed as you should use their aliases from the typing
     module (such as ``List[int]`` and ``Dict[str, str]``).
 
-.. _disallow-subclassing-any:
-
 ``--disallow-subclassing-any`` 
     This flag reports an error whenever a class subclasses a value of 
     type ``Any``.  This may occur when the base class is imported from 
@@ -239,8 +239,6 @@ definitions or calls.
     This flag reports an error whenever it encounters a function definition
     without type annotations.
 
-.. _disallow-incomplete-defs:
-
 ``--disallow-incomplete-defs`` 
     This flag reports an error whenever it encounters a partly annotated
     function definition.
@@ -258,6 +256,7 @@ definitions or calls.
     This flag reports an error whenever a function with type annotations
     is decorated with a decorator without annotations.
 
+.. _none-and-optional-handling:
 
 None and Optional handling
 **************************
@@ -299,6 +298,7 @@ For more details, see :ref:`no_strict_optional`.
     mypy 0.600, and in previous versions it had to be explicitly enabled
     using ``--strict-optional`` (which is still accepted).
 
+.. _configuring-warnings:
 
 Configuring warnings
 ********************
@@ -352,6 +352,8 @@ of the above sections.
 
     Note: the exact list of flags enabled by running ``--strict`` may change
     over time.
+
+.. _configuring-error-messages:
 
 Configuring error messages
 **************************
@@ -439,6 +441,8 @@ beyond what incremental mode can offer, try running mypy in
 
     We recommend that you try using the :ref:`mypy_daemon` before
     attempting to use this feature.
+
+.. _advanced-flags:
 
 Advanced flags
 **************

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -171,12 +171,15 @@ For more information on how to use these flags, see :ref:`version_and_platform_c
     compile-time constants that are always false.  This flag may
     be repeated.
 
-.. _disallow-any:
+.. _disallow-dynamic-typing:
 
-Disallow Any 
-************
+Disallow dynamic typing
+***********************
 
-The ``--disallow-any`` family of flags disallows various types of ``Any`` in a module.
+The ``Any`` type is used represent a value that has a :ref:`dynamic type <dynamic-typing>`.
+The ``--disallow-any`` family of flags will disallow various uses of the ``Any`` type in
+a module -- this lets us strategically disallow the use of dynamic typing in a controlled way.
+
 The following options are available:
 
 ``--disallow-any-unimported``

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -32,7 +32,7 @@ characters.
 - Additional sections named ``[mypy-PATTERN1,PATTERN2,...]`` may be
   present, where ``PATTERN1``, ``PATTERN2``, etc., are comma-separated
   patterns of fully-qualified module names, with some components optionally
-  replaced by `*`s (e.g. ``foo.bar``, ``foo.bar.*``, ``foo.*.baz``).
+  replaced by the '*' character (e.g. ``foo.bar``, ``foo.bar.*``, ``foo.*.baz``).
   These sections specify additional flags that only apply to *modules*
   whose name matches at least one of the patterns.
 
@@ -65,234 +65,346 @@ unfortunate, and is subject to change in future versions.
    The ``warn_unused_configs`` flag may be useful to debug misspelled
    section names.
 
-Global flags
-************
-
-The following global flags may only be set in the global section
-(``[mypy]``).
-
-- ``python_version`` (string) specifies the Python version used to
-  parse and check the target program.  The format is ``DIGIT.DIGIT``
-  for example ``2.7``.  The default is the version of the Python
-  interpreter used to run mypy.
-
-- ``platform`` (string) specifies the OS platform for the target
-  program, for example ``darwin`` or ``win32`` (meaning OS X or
-  Windows, respectively).  The default is the current platform as
-  revealed by Python's ``sys.platform`` variable.
-
-- ``always_true`` (comma-separated list of strings) gives variable
-  names that will be treated as compile-time constants that are always
-  true.
-
-- ``always_false`` (comma-separated list of strings) gives variable
-  names that will be treated as compile-time constants that are always
-  false.
-
-- ``custom_typing_module`` (string) specifies the name of an
-  alternative module which is to be considered equivalent to the
-  ``typing`` module.
-
-- ``custom_typeshed_dir`` (string) specifies the name of an
-  alternative directory which is used to look for stubs instead of the
-  default ``typeshed`` directory.
-
-- ``mypy_path`` (string) specifies the paths to use, after trying the paths
-  from ``MYPYPATH`` environment variable.  Useful if you'd like to keep stubs
-  in your repo, along with the config file.
-
-- ``warn_incomplete_stub`` (Boolean, default False) warns for missing
-  type annotation in typeshed.  This is only relevant in combination
-  with ``disallow_untyped_defs`` or ``disallow_incomplete_defs``.
-
-- ``warn_redundant_casts`` (Boolean, default False) warns about
-  casting an expression to its inferred type.
-
-- ``warn_unused_configs`` (Boolean, default False) warns about
-  per-module sections in the config file that didn't match any
-  files processed in the current run.
-
-- ``scripts_are_modules`` (Boolean, default False) makes script ``x``
-  become module ``x`` instead of ``__main__``.  This is useful when
-  checking multiple scripts in a single run.
-
-- ``verbosity`` (integer, default 0) controls how much debug output
-  will be generated.  Higher numbers are more verbose.
-
-- ``pdb`` (Boolean, default False) invokes pdb on fatal error.
-
-- ``show_traceback`` (Boolean, default False) shows traceback on fatal
-  error.
-
-- ``dump_type_stats`` (Boolean, default False) dumps stats about type
-  definitions.
-
-- ``dump_inference_stats`` (Boolean, default False) dumps stats about
-  type inference.
-
-- ``incremental`` (Boolean, default True) enables :ref:`incremental
-  mode <incremental>`.
-
-- ``cache_dir`` (string, default ``.mypy_cache``) stores module cache
-  info in the given folder in :ref:`incremental mode <incremental>`.
-  The cache is only read in incremental mode, but it is always written
-  unless the value is set to ``/dev/null`` (UNIX) or ``nul``
-  (Windows).
-
-- ``quick_and_dirty`` (Boolean, default False) enables :ref:`quick
-  mode <quick-mode>`.
-
-- ``show_error_context`` (Boolean, default False) shows
-  context notes before errors.
-
-- ``show_column_numbers`` (Boolean, default False) shows column numbers in
-  error messages.
-
-
-.. _per-module-flags:
-
-Per-module flags
-****************
-
-The following flags may vary per module.  They may also be specified in
-the global section; the global section provides defaults which are
-overridden by the pattern sections matching the module name.
-
 .. note::
 
-   If multiple pattern sections match a module, the options from the
-   most specific section are used where they disagree.  This means
-   that ``foo.bar`` will take values from sections with the patterns
-   ``foo.bar``, ``foo.bar.*``, and ``foo.*``, but when they specify
-   different values, it will use values from ``foo.bar`` before
-   ``foo.bar.*`` before ``foo.*``.
+   Configuration flags are liable to change between releases.
 
-- ``follow_imports`` (string, default ``normal``) directs what to do
-  with imports when the imported module is found as a ``.py`` file and
-  not part of the files, modules and packages on the command line.
-  The four possible values are ``normal``, ``silent``, ``skip`` and
-  ``error``.  For explanations see the discussion for the
-  :ref:`--follow-imports <follow-imports>` command line flag.  Note
-  that if pattern matching is used, the pattern should match the name
-  of the *imported* module, not the module containing the import
-  statement.
-
-- ``follow_imports_for_stubs`` (Boolean, default false) determines
-  whether to respect the ``follow_imports`` setting even for stub
-  (``.pyi``) files.
-  Used in conjunction with ``follow_imports=skip``, this can be used
-  to suppress the import of a module from ``typeshed``, replacing it
-  with `Any`.
-  Used in conjunction with ``follow_imports=error``, this can be used
-  to make any use of a particular ``typeshed`` module an error.
-
-- ``ignore_missing_imports`` (Boolean, default False) suppress error
-  messages about imports that cannot be resolved.  Note that if
-  pattern matching is used, the pattern should match the name of the
-  *imported* module, not the module containing the import statement.
-
-- ``silent_imports`` (Boolean, deprecated) equivalent to
-  ``follow_imports=skip`` plus ``ignore_missing_imports=True``.
-
-- ``almost_silent`` (Boolean, deprecated) equivalent to
-  ``follow_imports=skip``.
-
-- ``strict_optional`` (Boolean, default True) enables or disables
-  strict Optional checks. If False, mypy treats ``None`` as
-  compatible with every type.
-
-  **Note:** This was False by default
-  in mypy versions earlier than 0.600.
-
-- ``disallow_any_unimported`` (Boolean, default false) disallows usage of types that come
-  from unfollowed imports (such types become aliases for ``Any``).
-
-- ``disallow_any_expr`` (Boolean, default false) disallows all expressions in the module
-  that have type ``Any``.
-
-- ``disallow_any_decorated`` (Boolean, default false) disallows functions that have ``Any``
-  in their signature after decorator transformation.
-
-- ``disallow_any_explicit`` (Boolean, default false) disallows explicit ``Any`` in type
-  positions such as type annotations and generic type parameters.
-
-- ``disallow_any_generics`` (Boolean, default false) disallows usage of generic types that
-  do not specify explicit type parameters.
-
-- ``disallow_incomplete_defs`` (Boolean, default false) disallow defining
-  functions with incomplete type annotations.  See
-  :ref:`--disallow-incomplete-defs <disallow-incomplete-defs>` option.
-
-- ``disallow_subclassing_any`` (Boolean, default False) disallows
-  subclassing a value of type ``Any``.  See
-  :ref:`--disallow-subclassing-any <disallow-subclassing-any>` option.
-
-- ``disallow_untyped_calls`` (Boolean, default False) disallows
-  calling functions without type annotations from functions with type
-  annotations.
-
-- ``disallow_untyped_defs`` (Boolean, default False) disallows
-  defining functions without type annotations or with incomplete type
-  annotations.
-
-- ``check_untyped_defs`` (Boolean, default False) type-checks the
-  interior of functions without type annotations.
-
-- ``debug_cache`` (Boolean, default False) writes the incremental
-  cache JSON files using a more readable, but slower format.
-
-- ``show_none_errors`` (Boolean, default True) shows errors related
-  to strict ``None`` checking, if the global ``strict_optional`` flag
-  is enabled.
-
-- ``ignore_errors`` (Boolean, default False) ignores all non-fatal
-  errors.
-
-- ``warn_no_return`` (Boolean, default True) shows errors for
-  missing return statements on some execution paths.
-
-- ``warn_return_any`` (Boolean, default False) shows a warning when
-  returning a value with type ``Any`` from a function declared with a
-  non- ``Any`` return type.
-
-- ``warn_unused_ignores`` (Boolean, default False) warns about
-  unneeded ``# type: ignore`` comments.
-
-- ``strict_boolean`` (Boolean, default False) makes using non-boolean
-  expressions in conditions an error.
-
-- ``no_implicit_optional`` (Boolean, default false) changes the treatment of
-  arguments with a default value of None by not implicitly making their type Optional
 
 Examples
 ********
 
-You might put this in your ``mypy.ini`` file at the root of your repo:
+Here is an example of a ``mypy.ini`` file.
 
-.. code-block:: text
+.. code-block:: ini
 
     [mypy]
     python_version = 2.7
-    [mypy-foo.*]
+    warn_return_any = True
+    warn_unused_configs = True
+
+    [mypy-mycode.foo.*]
     disallow_untyped_defs = True
 
-This automatically sets ``--python-version 2.7`` (a.k.a. ``--py2``)
-for all mypy runs in this tree, and also selectively turns on the
-``--disallow-untyped-defs`` flag for all modules in the ``foo``
-package.  This issues an error for function definitions without
-type annotations in that subdirectory only.
+    [mypy-mycode.bar]
+    warn_return_any = False
 
-If you would like to ignore specific imports, instead of ignoring all missing
-imports with ``--ignore-missing-imports``, use a section of the configuration
-file per module such as the following to ignore missing imports from
-``lib_module``:
-
-.. code-block:: text
-
-    [mypy-lib_module]
+    [mypy-somelibrary]
     ignore_missing_imports = True
 
+If you place this file at the root of your repo and run mypy, mypy will:
 
-.. note::
+1.  Type-check your entire project assuming it will be run using Python 2.7.
+    (This is equivalent to using the ``--python-version 2.7`` or ``--2`` flag).
 
-   Configuration flags are liable to change between releases.
+2.  Report an error whenever a function returns a value that is inferred
+    to have type ``Any``.
+
+3.  Report any config options that are unused by mypy. (This will help us catch typos
+    when making changes to our config file).
+
+4.  Selectively disallow untyped function definitions only within the ``mycode.foo``
+    package -- that is, only for function definitions defined in the
+    ``mycode/foo`` directory.
+    
+5.  Selectively *disable* the "function is returning any" warnings within only
+    ``mycode.bar``. This overrides the global default.
+
+6.  Suppress any error messages generated when your codebase tries importing the module 
+    ``somelibrary``. (We assume here that ``somelibrary`` is some 3rd party
+    library missing type hints).
+
+
+.. _per-module-flags:
+
+Per-module and global options
+*****************************
+
+The following config options may be set either globally (in the ``[mypy]`` section)
+or on a per-module basis (in sections like ``[mypy-foo.bar]``).
+
+If you set an option both globally and for a specific module, the module configuration
+options take precedence. This lets you set global defaults and override them on a
+module-by-module basis. If multiple pattern sections match a module, the options from the
+most specific section are used where they disagree. See above for more details.
+
+.. _config-file-import-discovery-per-module:
+
+Import discovery
+----------------
+
+For more information, see the :ref:`import discovery <import-discovery>`
+section of the command line docs.
+
+Note: this section describes options that can be used both globally and per-module.
+See below for a list of import discovery options that may be used
+:ref:`only globally <config-file-import-discovery-global>`.
+
+``ignore_missing_imports`` (boolean, default False) 
+    Suppress error messages about imports that cannot be resolved.
+
+    Note that if pattern matching is used, the pattern should match the
+    name of the *imported* module, not the module containing the import
+    statement.
+
+``follow_imports`` (string, default ``normal``) 
+    Directs what to do with imports when the imported module is found
+    as a ``.py`` file and not part of the files, modules and packages 
+    provided on the command line.
+
+    The four possible values are ``normal``, ``silent``, ``skip`` and
+    ``error``.  For explanations see the discussion for the
+    :ref:`--follow-imports <follow-imports>` command line flag. 
+    
+    Note that if pattern matching is used, the pattern should match the
+    name of the *imported* module, not the module containing the import
+    statement.
+
+``follow_imports_for_stubs`` (boolean, default False)
+    Determines whether to respect the ``follow_imports`` setting even for
+    stub (``.pyi``) files.
+
+    Used in conjunction with ``follow_imports=skip``, this can be used
+    to suppress the import of a module from ``typeshed``, replacing it
+    with `Any`.
+
+    Used in conjunction with ``follow_imports=error``, this can be used
+    to make any use of a particular ``typeshed`` module an error.
+
+Disallow Any
+------------
+
+For more information, see the :ref:`disallowing any <disallow-any>`
+section of the command line docs.
+
+``disallow_any_unimported`` (boolean, default False)
+    Disallows usage of types that come from unfollowed imports (anything imported from
+    an unfollowed import is automatically given a type of ``Any``).
+
+``disallow_any_expr`` (boolean, default False)
+    Disallows all expressions in the module that have type ``Any``.
+
+``disallow_any_decorated`` (boolean, default False)
+    Disallows functions that have ``Any`` in their signature after decorator transformation.
+
+``disallow_any_explicit`` (boolean, default False)
+    Disallows explicit ``Any`` in type positions such as type annotations and generic
+    type parameters.
+
+``disallow_any_generics`` (boolean, default False)
+    Disallows usage of generic types that do not specify explicit type parameters.
+
+``disallow_subclassing_any`` (boolean, default False)
+    Disallows subclassing a value of type ``Any``.
+
+
+Untyped definitions and calls
+-----------------------------
+
+For more information, see the :ref:`untyped definitions and calls <untyped-definitions-and-calls>`
+section of the command line docs.
+
+``disallow_untyped_calls`` (boolean, default False)
+    Disallows calling functions without type annotations from functions with type
+    annotations.
+
+``disallow_untyped_defs`` (boolean, default False)
+    Disallows defining functions without type annotations or with incomplete type
+    annotations.
+
+``disallow_incomplete_defs`` (boolean, default False)
+    Disallow defining functions with incomplete type annotations. 
+
+``check_untyped_defs`` (boolean, default False)
+    Type-checks the interior of functions without type annotations.
+
+``disallow_untyped_decorators`` (boolean, default False)
+    Reports an error whenever a function with type annotations is decorated with a
+    decorator without annotations.
+
+.. _config-file-none-and-optional-handling:
+
+None and optional handling
+--------------------------
+
+For more information, see the :ref:`None and optional handling <none-and-optional-handling>`
+section of the command line docs.
+
+``no_implicit_optional`` (boolean, default False)
+    Changes the treatment of arguments with a default value of None by not implicitly
+    making their type Optional.
+
+``strict_optional`` (boolean, default True)
+    Enables or disables strict Optional checks. If False, mypy treats ``None``
+    as compatible with every type.
+
+    **Note:** This was False by default in mypy versions earlier than 0.600.
+
+
+Configuring warnings
+--------------------
+
+For more information, see the :ref:`configuring warnings <configuring-warnings>`
+section of the command line docs.
+
+``warn_unused_ignores`` (boolean, default False)
+    Warns about unneeded ``# type: ignore`` comments.
+
+``warn_no_return`` (boolean, default True) 
+    Shows errors for missing return statements on some execution paths.
+
+``warn_return_any`` (boolean, default False)
+    Shows a warning when returning a value with type ``Any`` from a function
+    declared with a non- ``Any`` return type.
+
+.. _config-file-suppressing-errors:
+
+Suppressing errors
+------------------
+
+Note: these configuration options are available in the config file only. There is
+no analog available via the command line options.
+
+``show_none_errors`` (boolean, default True)
+    Shows errors related to strict ``None`` checking, if the global ``strict_optional``
+    flag is enabled.
+
+``ignore_errors`` (boolean, default False)
+    Ignores all non-fatal errors.
+
+
+Global-only options
+*******************
+
+The following options may only be set in the global section (``[mypy]``).
+
+.. _config-file-import-discovery-global:
+
+Import discovery
+----------------
+
+For more information, see the :ref:`import discovery <import-discovery>`
+section of the command line docs.
+
+Note: this section describes only global-only import discovery options. See above for
+a list of import discovery options that may be used 
+:ref:`both per-module and globally <config-file-import-discovery-per-module>`.
+
+``python_executable`` (string)
+    Specifies the path to the Python executable to inspect to collect
+    a list of available :ref:`PEP 561 packages <installed-packages>`. Defaults to
+    the executable used to run mypy.
+
+``no_silence_site_packages`` (boolean, default False)
+    By default, mypy will suppress any error messages generated within PEP 561
+    compliant packages. Settin this to True will disable this behavior.
+
+``mypy_path`` (string)
+    Specifies the paths to use, after trying the paths from ``MYPYPATH`` environment
+    variable.  Useful if you'd like to keep stubs in your repo, along with the config file.
+
+
+Platform configuration
+----------------------
+
+For more information, see the :ref:`platform configuration <platform-configuration>`
+section of the command line docs.
+
+``python_version`` (string) 
+    Specifies the Python version used to parse and check the target
+    program.  The string should be in the format ``DIGIT.DIGIT`` --
+    for example ``2.7``.  The default is the version of the Python
+    interpreter used to run mypy.
+
+``platform`` (string)
+    Specifies the OS platform for the target program, for example
+    ``darwin`` or ``win32`` (meaning OS X or Windows, respectively).
+    The default is the current platform as revealed by Python's
+    ``sys.platform`` variable.
+
+``always_true`` (comma-separated list of strings)
+    This option lets you specify variables that mypy will treat as
+    compile-time constants that are always true.
+    
+``always_false`` (comma-separated list of strings) 
+    This option lets you specify variables that mypy will treat as
+    compile-time constants that are always false.
+
+
+Incremental mode
+----------------
+
+For more information, see the :ref:`incremental mode <incremental>`
+section of the command line docs.
+
+``incremental`` (boolean, default True) 
+    Enables :ref:`incremental mode <incremental>`.
+
+``cache_dir`` (string, default ``.mypy_cache``) 
+    The default location mypy will store incremental cache info in.
+    Note that the cache is only read when incremental mode is enabled
+    but is always written to, unless the value is set to ``/dev/nul``
+    (UNIX) or ``nul`` (Windows).
+
+``skip_version_check`` (boolean, default False)
+    By default, mypy will ignore cache data generated by a different
+    version of mypy. This flag disables that behavior.
+    
+``quick_and_dirty`` (boolean, default False)
+    Enables :ref:`quick mode <quick-mode>`.
+
+
+Configuring error messages
+--------------------------
+
+For more information, see the :ref:`configuring error messages <configuring-error-messages>`
+section of the command line docs.
+
+``show_error_context`` (boolean, default False) 
+    If set to true, prefixes each error with the relevant context.
+
+``show_column_numbers`` (boolean, default False)
+    If set to true, shows column numbers in error messages.
+
+
+Advanced options
+----------------
+
+For more information, see the :ref:`advanced flags <advanced-flags>`
+section of the command line docs.
+
+``pdb`` (boolean, default False)
+    Invokes pdb on fatal error.
+
+``show_traceback`` (boolean, default False)
+    Shows traceback on fatal error.
+
+``custom_typing_module`` (string) 
+    Specifies a custom module to use as a substitute for the ``typing`` module.
+
+``custom_typeshed_dir`` (string)
+    Specifies an alternative directory to look for stubs instead of the
+    default ``typeshed`` directory.
+
+``warn_incomplete_stub`` (boolean, default False)
+    Warns about missing type annotations in typeshed.  This is only relevant
+    in combination with ``disallow_untyped_defs`` or ``disallow_incomplete_defs``.
+
+
+Miscellaneous
+-------------
+
+``warn_redundant_casts`` (boolean, default False)
+    Warns about casting an expression to its inferred type.
+
+``scripts_are_modules`` (boolean, default False)
+    Makes script ``x`` become module ``x`` instead of ``__main__``.  This is
+    useful when checking multiple scripts in a single run.
+
+``warn_unused_configs`` (boolean, default False)
+    Warns about per-module sections in the config file that do not
+    match any files processed when invoking mypy.
+
+``verbosity`` (integer, default 0)
+    Controls how much debug output will be generated.  Higher numbers are more verbose.
+
+

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -122,8 +122,8 @@ assume here is some 3rd party library you've installed and are importing. These 
     package -- that is, only for function definitions defined in the
     ``mycode/foo`` directory.
     
-2.  Selectively *disable* the "function is returning any" warnings within only
-    ``mycode.bar``. This overrides the global default we set earlier.
+2.  Selectively *disable* the "function is returning any" warnings within 
+    ``mycode.bar`` only. This overrides the global default we set earlier.
 
 3.  Suppress any error messages generated when your codebase tries importing the
     module ``somelibrary``. This is useful if ``somelibrary`` is some 3rd party library
@@ -139,7 +139,7 @@ or on a per-module basis (in sections like ``[mypy-foo.bar]``).
 
 If you set an option both globally and for a specific module, the module configuration
 options take precedence. This lets you set global defaults and override them on a
-module-by-module basis. If multiple pattern sections match a module, the :ref:`options from the
+module-by-module basis. If multiple pattern sections match a module, :ref:`the options from the
 most specific section are used where they disagree <config-precedence>`.
 
 .. _config-file-import-discovery-per-module:
@@ -356,7 +356,7 @@ section of the command line docs.
     Enables :ref:`incremental mode <incremental>`.
 
 ``cache_dir`` (string, default ``.mypy_cache``) 
-    Specifies the location mypy will store incremental cache info in.
+    Specifies the location where mypy stores incremental cache info.
     Note that the cache is only read when incremental mode is enabled
     but is always written to, unless the value is set to ``/dev/nul``
     (UNIX) or ``nul`` (Windows).

--- a/docs/source/dynamic_typing.rst
+++ b/docs/source/dynamic_typing.rst
@@ -1,4 +1,4 @@
-.. _dynamic_typing:
+.. _dynamic-typing:
 
 
 Dynamically typed code

--- a/docs/source/installed_packages.rst
+++ b/docs/source/installed_packages.rst
@@ -3,7 +3,7 @@
 Using installed packages
 ========================
 
-`PEP 561 <https://www.python.org/dev/peps/pep-0561/>`_ specifies how to mark
+`PEP 561 <https://www.python.org/dev/peps/pep-0561/>`__ specifies how to mark
 a package as supporting type checking. Below is a summary of how to create
 PEP 561 compatible packages and have mypy use them in type checking.
 
@@ -31,7 +31,7 @@ If you do not want to use typed packages, use the ``--no-site-packages`` flag
 to disable searching.
 
 Note that stub-only packages (defined in
-`PEP 561 <https://www.python.org/dev/peps/pep-0561/#stub-only-packages>`_)
+`PEP 561 <https://www.python.org/dev/peps/pep-0561/#stub-only-packages>`__)
 cannot be used with ``MYPYPATH``. If you want mypy to find the package, it must
 be installed. For a package ``foo``, the name of the stub-only package
 (``foo-stubs``) is not a legal package name, so mypy will not find it, unless

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -93,7 +93,7 @@ the error:
    if wait(2) > 1:   # Error: can't compare None and int
        ...
 
-The ``Any`` type is discussed in more detail in section :ref:`dynamic_typing`.
+The ``Any`` type is discussed in more detail in section :ref:`dynamic-typing`.
 
 .. note::
 

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -437,8 +437,8 @@ this example -- it's not recommended if you can avoid it:
 However, making code "optional clean" can take some work! You can also use
 :ref:`the mypy configuration file <config-file>` to migrate your code
 to strict optional checking one file at a time, since there exists
-the :ref:`per-module flag <per-module-flags>` ``strict_optional`` to
-control strict optional mode.
+the :ref:`per-module flag <config-file-none-and-optional-handling>`
+``strict_optional`` to control strict optional mode.
 
 Often it's still useful to document whether a variable can be
 ``None``. For example, this function accepts a ``None`` argument,

--- a/docs/source/revision_history.rst
+++ b/docs/source/revision_history.rst
@@ -82,7 +82,7 @@ detailed release notes):
         of the analysis (i.e. the ``--python-version`` flag).
 
       * Split ``--disallow-any`` flag into
-        :ref:`separate boolean flags <disallow-any>`.
+        :ref:`separate boolean flags <disallow-dynamic-typing>`.
 
       * The ``--old-html-report`` flag was removed.
 
@@ -107,7 +107,7 @@ detailed release notes):
 
     * Publish ``mypy`` version 0.520 on PyPI.
 
-    * Add :ref:`fine-grained control of Any types <disallow-any>`.
+    * Add :ref:`fine-grained control of Any types <disallow-dynamic-typing>`.
 
     * Add :ref:`typeddict`.
 

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -153,19 +153,36 @@ If the module is a library that does not use type hints, the easiest fix
 is to silence the error messages by adding a ``# type: ignore`` comment on
 each respective import statement.
 
-If you have many of these errors, you can silence them all at once by using
-the ``--ignore-missing-imports`` flag. We recommend using this flag only
-as a last resort: it's equivalent to adding a ``# type: ignore`` comment
-to all unresolved imports in your codebase.
+If you have many of these errors from a specific library, it may be more
+convenient to silence all of those errors at once using the
+:ref:`mypy config file <config-file>`. For example, suppose your codebase
+makes heavy use of an (untyped) library named `foobar`. You can silence all
+import errors associated with that library and that library alone by adding
+the following section to your config file::
+
+    [mypy-foobar]
+    ignore_missing_imports = True
+
+Note: this option is equivalent to adding a ``# type: ignore`` to every
+import of ``foobar`` in your codebase. For more information, see the
+documentation about configuring
+:ref:`import discovery <config-file-import-discovery-per-module>` in config files.
+
+If you would like to silence *all* missing import errors in your codebase,
+you can do so by using the ``--ignore-missing-imports`` flag. We recommend
+using this flag only as a last resort: it's equivalent to adding a
+``# type: ignore`` to all unresolved imports in your codebase.
 
 A more involved solution would be to reverse-engineer how the library
 works, create type hints for the library, and point mypy at those
 type hints either by passing in in via the command line or by adding
-the location of your custom stubs to the ``MYPYPATH`` environment variable.
+the location of your custom stubs to either the ``MYPYPATH`` environment
+variable or the ``mypy_path`` 
+:ref:`config file option <config-file-import-discovery-global>`.
 
-If you want to share your work, you can either open a pull request on
-typeshed or modify the library itself to be 
-:ref:`PEP 561 compliant <installed-packages>`.
+If you want to share your work, you can try contributing your stubs back
+to the library -- see our documentation on creating
+:ref:`PEP 561 compliant packages <installed-packages>`.
 
 
 .. _follow-imports:
@@ -297,6 +314,7 @@ This is computed from the following items:
 
 - The ``MYPYPATH`` environment variable
   (a colon-separated list of directories).
+- The ``mypy_path`` :ref:`config file option <config-file-import-discovery-global>`.
 - The directories containing the sources given on the command line
   (see below).
 - The installed packages marked as safe for type checking (see

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -776,7 +776,7 @@ def process_options(args: List[str],
     # Process deprecated options
     if special_opts.disallow_any:
         print("--disallow-any option was split up into multiple flags. "
-              "See http://mypy.readthedocs.io/en/latest/command_line.html#disallow-any-flags")
+              "See http://mypy.readthedocs.io/en/latest/command_line.html#disallow-dynamic-typing")
     if options.strict_boolean:
         print("Warning: --strict-boolean is deprecated; "
               "see https://github.com/python/mypy/issues/3195", file=sys.stderr)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -469,8 +469,8 @@ def process_options(args: List[str],
         help="Additional variable to be considered False (may be repeated)")
 
     disallow_any_group = parser.add_argument_group(
-        title='Any type restrictions',
-        description="Disallow the use of the 'Any' type under certain conditions.")
+        title='Dynamic typing',
+        description="Disallow the use of the dynamic 'Any' type under certain conditions.")
     disallow_any_group.add_argument(
         '--disallow-any-unimported', default=False, action='store_true',
         help="Disallow Any types resulting from unfollowed imports")


### PR DESCRIPTION
Sorry again for another big-ish docs PR. This time, I'm cleaning up the config file docs.

Here are a list of notable changes made:

1.  I moved the example to come before we list the options, not after.

    I feel this makes the first section of the page more digestible: we have a big block of text, but at least now we can see some of that  information in practice immediately after.

2.  I combined the two examples into one (and rewrote the explanations in list form, to help mitigate the increase in complexity).

3.  I swapped the global-only and per-module sections.

    After auditing the options, it seemed to me that the global-only options were generally less useful then the per-module options. I also think it makes sense to present the more flexible options first, rather then last.

4.  I organized the options into the same categories I introduced when organizing mypy's command line interface.

5.  I switched to using the same definition list format we use in the command line docs for consistency.

6.  I removed the `dump_type_stats`, `dump_inference_stats`, `debug_cache`, and the `strict_boolean` options.

    These are all options we have either suppressed or deprecated.

7.  I added in documentation for the `python_executable`, `no_site_packages`, and `disallow_untyped_decorators` options.

8.  I renamed some links/deleted some now-unnecessary links.

One change I made that was unrelated to the config file was adding docs about the `mypy_path` and the per-module `ignore_missing_imports` options to the "Running mypy" page.

Some interesting inconsistencies I noticed (but took no action on, in a probably-futile attempt to keep this diff small):

1.  The `warn_redundant_casts` section is global-only, not per-module like the other warning options.

    I left this option in the global misc section for now.

2.  There does not appear to be any way of writing a config file that does the same thing as `--no-site-packages`.

    I think we should either add an option for this or allow expressions like `python_executable = None`. (Currently, we try parsing `None` as a string -- this makes mypy promptly crash with a FileNotFoundError). For now, I did nothing.

Final note: I mostly kept the descriptions the same/minimal, apart from some minor wording tweaks here and there -- I wanted to have the command line docs act as the main source of truth.