### PR TITLE
Fix small regression in subtype cache performance

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -35,16 +35,21 @@ TypeParameterChecker = Callable[[Type, Type, int], bool]
 
 def check_type_parameter(lefta: Type, righta: Type, variance: int) -> bool:
     if variance == COVARIANT:
-        return is_subtype(lefta, righta, check_type_parameter)
+        return is_subtype(lefta, righta)
     elif variance == CONTRAVARIANT:
-        return is_subtype(righta, lefta, check_type_parameter)
+        return is_subtype(righta, lefta)
     else:
-        return is_equivalent(lefta, righta, check_type_parameter)
+        return is_equivalent(lefta, righta)
+
+
+def ignore_type_parameter(s: Type, t: Type, v: int) -> bool:
+    return True
 
 
 def is_subtype(left: Type, right: Type,
-               type_parameter_checker: Optional[TypeParameterChecker] = None,
-               *, ignore_pos_arg_names: bool = False,
+               *,
+               ignore_type_params: bool = False,
+               ignore_pos_arg_names: bool = False,
                ignore_declared_variance: bool = False,
                ignore_promotions: bool = False) -> bool:
     """Is 'left' subtype of 'right'?
@@ -58,7 +63,6 @@ def is_subtype(left: Type, right: Type,
     between the type arguments (e.g., A and B), taking the variance of the
     type var into account.
     """
-    type_parameter_checker = type_parameter_checker or check_type_parameter
     if (isinstance(right, AnyType) or isinstance(right, UnboundType)
             or isinstance(right, ErasedType)):
         return True
@@ -66,7 +70,8 @@ def is_subtype(left: Type, right: Type,
         # Normally, when 'left' is not itself a union, the only way
         # 'left' can be a subtype of the union 'right' is if it is a
         # subtype of one of the items making up the union.
-        is_subtype_of_item = any(is_subtype(left, item, type_parameter_checker,
+        is_subtype_of_item = any(is_subtype(left, item,
+                                            ignore_type_params=ignore_type_params,
                                             ignore_pos_arg_names=ignore_pos_arg_names,
                                             ignore_declared_variance=ignore_declared_variance,
                                             ignore_promotions=ignore_promotions)
@@ -82,58 +87,58 @@ def is_subtype(left: Type, right: Type,
         elif is_subtype_of_item:
             return True
         # otherwise, fall through
-    return left.accept(SubtypeVisitor(right, type_parameter_checker,
+    return left.accept(SubtypeVisitor(right,
+                                      ignore_type_params=ignore_type_params,
                                       ignore_pos_arg_names=ignore_pos_arg_names,
                                       ignore_declared_variance=ignore_declared_variance,
                                       ignore_promotions=ignore_promotions))
 
 
-def ignore_tvars(s: Type, t: Type, v: int) -> bool:
-    return True
-
-
 def is_subtype_ignoring_tvars(left: Type, right: Type) -> bool:
-    return is_subtype(left, right, ignore_tvars)
+    return is_subtype(left, right, ignore_type_params=True)
 
 
-def is_equivalent(a: Type,
-                  b: Type,
-                  type_parameter_checker: Optional[TypeParameterChecker] = None,
+def is_equivalent(a: Type, b: Type,
                   *,
+                  ignore_type_params: bool = False,
                   ignore_pos_arg_names: bool = False
                   ) -> bool:
     return (
-        is_subtype(a, b, type_parameter_checker, ignore_pos_arg_names=ignore_pos_arg_names)
-        and is_subtype(b, a, type_parameter_checker, ignore_pos_arg_names=ignore_pos_arg_names))
+        is_subtype(a, b, ignore_type_params=ignore_type_params,
+                   ignore_pos_arg_names=ignore_pos_arg_names)
+        and is_subtype(b, a, ignore_type_params=ignore_type_params,
+                       ignore_pos_arg_names=ignore_pos_arg_names))
 
 
 class SubtypeVisitor(TypeVisitor[bool]):
 
     def __init__(self, right: Type,
-                 type_parameter_checker: TypeParameterChecker,
-                 *, ignore_pos_arg_names: bool = False,
+                 *,
+                 ignore_type_params: bool,
+                 ignore_pos_arg_names: bool = False,
                  ignore_declared_variance: bool = False,
                  ignore_promotions: bool = False) -> None:
         self.right = right
-        self.check_type_parameter = type_parameter_checker
+        self.ignore_type_params = ignore_type_params
         self.ignore_pos_arg_names = ignore_pos_arg_names
         self.ignore_declared_variance = ignore_declared_variance
         self.ignore_promotions = ignore_promotions
+        self.check_type_parameter = (ignore_type_parameter if ignore_type_params else
+                                       check_type_parameter)
         self._subtype_kind = SubtypeVisitor.build_subtype_kind(
-            type_parameter_checker=type_parameter_checker,
+            ignore_type_params=ignore_type_params,
             ignore_pos_arg_names=ignore_pos_arg_names,
             ignore_declared_variance=ignore_declared_variance,
             ignore_promotions=ignore_promotions)
 
     @staticmethod
     def build_subtype_kind(*,
-                           type_parameter_checker: Optional[TypeParameterChecker] = None,
+                           ignore_type_params: bool = False,
                            ignore_pos_arg_names: bool = False,
                            ignore_declared_variance: bool = False,
                            ignore_promotions: bool = False) -> SubtypeKind:
-        type_parameter_checker = type_parameter_checker or check_type_parameter
-        return ('subtype',
-                type_parameter_checker,
+        return (False,  # is proper subtype?
+                ignore_type_params,
                 ignore_pos_arg_names,
                 ignore_declared_variance,
                 ignore_promotions)
@@ -146,7 +151,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
 
     def _is_subtype(self, left: Type, right: Type) -> bool:
         return is_subtype(left, right,
-                          type_parameter_checker=self.check_type_parameter,
+                          ignore_type_params=self.ignore_type_params,
                           ignore_pos_arg_names=self.ignore_pos_arg_names,
                           ignore_declared_variance=self.ignore_declared_variance,
                           ignore_promotions=self.ignore_promotions)
@@ -304,7 +309,8 @@ class SubtypeVisitor(TypeVisitor[bool]):
             if not left.names_are_wider_than(right):
                 return False
             for name, l, r in left.zip(right):
-                if not is_equivalent(l, r, self.check_type_parameter):
+                if not is_equivalent(l, r,
+                                     ignore_type_params=self.ignore_type_params):
                     return False
                 # Non-required key is not compatible with a required key since
                 # indexing may fail unexpectedly if a required key is missing.
@@ -1034,7 +1040,7 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
 
     @staticmethod
     def build_subtype_kind(*, ignore_promotions: bool = False) -> SubtypeKind:
-        return ('subtype_proper', ignore_promotions)
+        return (True, ignore_promotions)
 
     def _lookup_cache(self, left: Instance, right: Instance) -> bool:
         return TypeState.is_cached_subtype_check(self._subtype_kind, left, right)

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -30,6 +30,7 @@ IS_SETTABLE = 1
 IS_CLASSVAR = 2
 IS_CLASS_OR_STATIC = 3
 
+
 TypeParameterChecker = Callable[[Type, Type, int], bool]
 
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -89,9 +89,11 @@ def is_subtype(left: Type, right: Type,
                                       ignore_promotions=ignore_promotions))
 
 
+def ignore_tvars(s: Type, t: Type, v: int) -> bool:
+    return True
+
+
 def is_subtype_ignoring_tvars(left: Type, right: Type) -> bool:
-    def ignore_tvars(s: Type, t: Type, v: int) -> bool:
-        return True
     return is_subtype(left, right, ignore_tvars)
 
 
@@ -1033,7 +1035,7 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
 
     @staticmethod
     def build_subtype_kind(*, ignore_promotions: bool = False) -> SubtypeKind:
-        return ('subtype_proper', ignore_promotions)
+        return ('subtype_proper', None, False, False, ignore_promotions)
 
     def _lookup_cache(self, left: Instance, right: Instance) -> bool:
         return TypeState.is_cached_subtype_check(self._subtype_kind, left, right)

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -125,7 +125,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
         self.ignore_declared_variance = ignore_declared_variance
         self.ignore_promotions = ignore_promotions
         self.check_type_parameter = (ignore_type_parameter if ignore_type_params else
-                                       check_type_parameter)
+                                     check_type_parameter)
         self._subtype_kind = SubtypeVisitor.build_subtype_kind(
             ignore_type_params=ignore_type_params,
             ignore_pos_arg_names=ignore_pos_arg_names,

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -20,7 +20,7 @@ from mypy.nodes import (
 from mypy.maptype import map_instance_to_supertype
 from mypy.expandtype import expand_type_by_instance
 from mypy.sametypes import is_same_type
-from mypy.typestate import TypeState, SubtypeKind, TypeParameterChecker
+from mypy.typestate import TypeState, SubtypeKind
 
 from mypy import experiments
 
@@ -29,6 +29,8 @@ from mypy import experiments
 IS_SETTABLE = 1
 IS_CLASSVAR = 2
 IS_CLASS_OR_STATIC = 3
+
+TypeParameterChecker = Callable[[Type, Type, int], bool]
 
 
 def check_type_parameter(lefta: Type, righta: Type, variance: int) -> bool:
@@ -1032,7 +1034,7 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
 
     @staticmethod
     def build_subtype_kind(*, ignore_promotions: bool = False) -> SubtypeKind:
-        return ('subtype_proper', None, False, False, ignore_promotions)
+        return ('subtype_proper', ignore_promotions)
 
     def _lookup_cache(self, left: Instance, right: Instance) -> bool:
         return TypeState.is_cached_subtype_check(self._subtype_kind, left, right)

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -20,7 +20,7 @@ from mypy.nodes import (
 from mypy.maptype import map_instance_to_supertype
 from mypy.expandtype import expand_type_by_instance
 from mypy.sametypes import is_same_type
-from mypy.typestate import TypeState, SubtypeKind
+from mypy.typestate import TypeState, SubtypeKind, TypeParameterChecker
 
 from mypy import experiments
 
@@ -29,9 +29,6 @@ from mypy import experiments
 IS_SETTABLE = 1
 IS_CLASSVAR = 2
 IS_CLASS_OR_STATIC = 3
-
-
-TypeParameterChecker = Callable[[Type, Type, int], bool]
 
 
 def check_type_parameter(lefta: Type, righta: Type, variance: int) -> bool:

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -3,22 +3,23 @@ A shared state for all TypeInfos that holds global cache and dependency informat
 and potentially other mutable TypeInfo state. This module contains mutable global state.
 """
 
-from typing import Any, Dict, Set, Tuple, Optional
+from typing import Any, Dict, Set, Tuple, Optional, Callable
 
 MYPY = False
 if MYPY:
     from typing import ClassVar
-    from mypy.subtypes import TypeParameterChecker
 from mypy.nodes import TypeInfo
-from mypy.types import Instance
+from mypy.types import Instance, Type
 from mypy.server.trigger import make_trigger
 
 # Represents that the 'left' instance is a subtype of the 'right' instance
 SubtypeRelationship = Tuple[Instance, Instance]
 
+TypeParameterChecker = Callable[[Type, Type, int], bool]
+
 # A tuple encoding the specific conditions under which we performed the subtype check.
 # (e.g. did we want a proper subtype? A regular subtype while ignoring variance?)
-SubtypeKind = Tuple[str, Optional['TypeParameterChecker'], bool, bool, bool]
+SubtypeKind = Tuple[str, Optional[TypeParameterChecker], bool, bool, bool]
 
 # A cache that keeps track of whether the given TypeInfo is a part of a particular
 # subtype relationship

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -17,7 +17,7 @@ SubtypeRelationship = Tuple[Instance, Instance]
 
 # A tuple encoding the specific conditions under which we performed the subtype check.
 # (e.g. did we want a proper subtype? A regular subtype while ignoring variance?)
-SubtypeKind = Tuple[Any, ...]
+SubtypeKind = Tuple[bool, ...]
 
 # A cache that keeps track of whether the given TypeInfo is a part of a particular
 # subtype relationship

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -3,23 +3,21 @@ A shared state for all TypeInfos that holds global cache and dependency informat
 and potentially other mutable TypeInfo state. This module contains mutable global state.
 """
 
-from typing import Any, Dict, Set, Tuple, Optional, Callable
+from typing import Any, Dict, Set, Tuple, Optional
 
 MYPY = False
 if MYPY:
     from typing import ClassVar
 from mypy.nodes import TypeInfo
-from mypy.types import Instance, Type
+from mypy.types import Instance
 from mypy.server.trigger import make_trigger
 
 # Represents that the 'left' instance is a subtype of the 'right' instance
 SubtypeRelationship = Tuple[Instance, Instance]
 
-TypeParameterChecker = Callable[[Type, Type, int], bool]
-
 # A tuple encoding the specific conditions under which we performed the subtype check.
 # (e.g. did we want a proper subtype? A regular subtype while ignoring variance?)
-SubtypeKind = Tuple[str, Optional[TypeParameterChecker], bool, bool, bool]
+SubtypeKind = Tuple[Any, ...]
 
 # A cache that keeps track of whether the given TypeInfo is a part of a particular
 # subtype relationship


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5514

The root cause is that https://github.com/python/mypy/pull/5474 added `type_parameter_checker` (a function) as one of the keys of subtype kinds. This function is a nested one, so in fact a _new_ function was created on every call to `is_subtype_ignoring_tvars()` causing many thousands parasitic keys created in subtype caches. In addition there are two smaller things listed below.

The performance win is around 5%
This PR:
* Moves the mentioned function to global scope, this causes only 6 subtype kinds present during self-check.
* Prevents similar regressions in future by switching only boolean flags as subtype kind keys.
* Removes two one liners that stay in a very hot code path (cache lookup is hit 140K times during self-check).
* Avoids creation of empty sets on cache look-up, create them only when writing to cache.
