### PR TITLE
Revert "Update -2 argument dest to match --python-version."

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -284,31 +284,27 @@ def infer_python_version_and_executable(options: Options,
     This function mutates options based on special_opts to infer the correct Python version and
     executable to use.
     """
-    # Check Options in case python_version is set in a config file, but prefer command
-    # line arguments.
-    python_version = special_opts.python_version or options.python_version
-
     # Infer Python version and/or executable if one is not given
 
     # TODO: (ethanhs) Look at folding these checks and the site packages subprocess calls into
     # one subprocess call for speed.
-    if special_opts.python_executable is not None and python_version is not None:
+    if special_opts.python_executable is not None and special_opts.python_version is not None:
         py_exe_ver = _python_version_from_executable(special_opts.python_executable)
-        if py_exe_ver != python_version:
+        if py_exe_ver != special_opts.python_version:
             raise PythonExecutableInferenceError(
                 'Python version {} did not match executable {}, got version {}.'.format(
-                    python_version, special_opts.python_executable, py_exe_ver
+                    special_opts.python_version, special_opts.python_executable, py_exe_ver
                 ))
         else:
-            options.python_version = python_version
+            options.python_version = special_opts.python_version
             options.python_executable = special_opts.python_executable
-    elif special_opts.python_executable is None and python_version is not None:
-        options.python_version = python_version
+    elif special_opts.python_executable is None and special_opts.python_version is not None:
+        options.python_version = special_opts.python_version
         py_exe = None
         if not special_opts.no_executable:
-            py_exe = _python_executable_from_version(python_version)
+            py_exe = _python_executable_from_version(special_opts.python_version)
         options.python_executable = py_exe
-    elif python_version is None and special_opts.python_executable is not None:
+    elif special_opts.python_version is None and special_opts.python_executable is not None:
         options.python_version = _python_version_from_executable(
             special_opts.python_executable)
         options.python_executable = special_opts.python_executable
@@ -465,7 +461,7 @@ def process_options(args: List[str],
         help='Type check code assuming it will be running on Python x.y',
         dest='special-opts:python_version')
     platform_group.add_argument(
-        '-2', '--py2', dest='special-opts:python_version', action='store_const',
+        '-2', '--py2', dest='python_version', action='store_const',
         const=defaults.PYTHON2_VERSION,
         help="Use Python 2 mode (same as --python-version 2.7)")
     platform_group.add_argument(

--- a/mypy/test/testargs.py
+++ b/mypy/test/testargs.py
@@ -60,20 +60,6 @@ class ArgSuite(Suite):
         assert str(e.value) == 'Python version (2, 10) did not match executable {}, got' \
                                ' version {}.'.format(sys.executable, sys.version_info[:2])
 
-        # If a configuration file specifies python_version, it will be set on options.
-        # Use that to figure out how to determine a value for python_executable, when
-        # special_opts.python_version is None.
-        special_opts = argparse.Namespace()
-        special_opts.python_executable = None
-        special_opts.python_version = None
-        special_opts.no_executable = None
-        options = Options()
-        options.python_executable = None
-        options.python_version = sys.version_info[:2]
-        infer_python_version_and_executable(options, special_opts)
-        assert options.python_version == sys.version_info[:2]
-        assert options.python_executable == sys.executable
-
         # test that --no-site-packages will disable executable inference
         matching_version = base + ['--python-version={}'.format(sys_ver_str),
                                    '--no-site-packages']


### PR DESCRIPTION
Reverts python/mypy#5578 @ethanhs @sqwishy 

It looks like the original PR caused breakages. We can re-apply later when we will have a fix.

In particular PEP 561 packages are now not available in virtual environments, for example three of mypy tests fail when running then in a venv:
```
_______________________________________________________________ TestPEP561.test_typedpkg_python2 ________________________________________________________________
[gw7] darwin -- Python 3.6.6 /Users/ilevkivskyi/mypy_dev/bin/python

self = <mypy.test.testpep561.TestPEP561 testMethod=test_typedpkg_python2>

    def test_typedpkg_python2(self) -> None:
        python2 = try_find_python2_interpreter()
        if python2:
            with self.virtualenv(python2) as venv:
                venv_dir, py2 = venv
                self.install_package('typedpkg', py2)
                check_mypy_run(
                    [self.tempfile],
                    py2,
                    expected_out=self.msg_tuple,
>                   venv_dir=venv_dir,
                )

mypy/test/testpep561.py:170: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cmd_line = ['/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpc0rr57i4/simple.py', '--python-executable=/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmp_5okw9zi/bin/python']
python_executable = '/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmp_5okw9zi/bin/python'
expected_out = "/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpc0rr57i4/simple.py:5: error: Revealed type is 'builtins.tuple[builtins.str]'\n"
expected_err = '', expected_returncode = 1, venv_dir = '/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmp_5okw9zi'

    def check_mypy_run(cmd_line: List[str],
                       python_executable: str = sys.executable,
                       expected_out: str = '',
                       expected_err: str = '',
                       expected_returncode: int = 1,
                       venv_dir: Optional[str] = None) -> None:
        """Helper to run mypy and check the output."""
        if venv_dir is not None:
            old_dir = os.getcwd()
            os.chdir(venv_dir)
        try:
            if python_executable != sys.executable:
                cmd_line.append('--python-executable={}'.format(python_executable))
            out, err, returncode = mypy.api.run(cmd_line)
>           assert out == expected_out, err
E           AssertionError: usage: mypy [-h] [-v] [-V] [more options; see below]
E                         [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
E             mypy: error: Python version (3, 6) did not match executable /var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmp_5okw9zi/bin/python, got version (2, 7).
E             
E           assert '' == "/var/folders/ff/8tg5kw8x3jg...tins.tuple[builtins.str]'\n"
E             + /var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpc0rr57i4/simple.py:5: error: Revealed type is 'builtins.tuple[builtins.str]'

mypy/test/testpep561.py:39: AssertionError
--------------------------------------------------------------------- Captured stderr call ----------------------------------------------------------------------
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AssertionError
_______________________________________________________________ TestPEP561.test_typedpkg_editable _______________________________________________________________
[gw0] darwin -- Python 3.6.6 /Users/ilevkivskyi/mypy_dev/bin/python

self = <mypy.test.testpep561.TestPEP561 testMethod=test_typedpkg_editable>

    def test_typedpkg_editable(self) -> None:
        with self.virtualenv() as venv:
            venv_dir, python_executable = venv
            self.install_package('typedpkg', python_executable, editable=True)
            check_mypy_run(
                [self.tempfile],
                python_executable,
                expected_out=self.msg_tuple,
>               venv_dir=venv_dir,
            )

mypy/test/testpep561.py:192: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cmd_line = ['/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpt1nk7wi5/simple.py', '--python-executable=/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpte9h7lad/bin/python']
python_executable = '/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpte9h7lad/bin/python'
expected_out = "/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpt1nk7wi5/simple.py:5: error: Revealed type is 'builtins.tuple[builtins.str]'\n"
expected_err = '', expected_returncode = 1, venv_dir = '/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpte9h7lad'

    def check_mypy_run(cmd_line: List[str],
                       python_executable: str = sys.executable,
                       expected_out: str = '',
                       expected_err: str = '',
                       expected_returncode: int = 1,
                       venv_dir: Optional[str] = None) -> None:
        """Helper to run mypy and check the output."""
        if venv_dir is not None:
            old_dir = os.getcwd()
            os.chdir(venv_dir)
        try:
            if python_executable != sys.executable:
                cmd_line.append('--python-executable={}'.format(python_executable))
            out, err, returncode = mypy.api.run(cmd_line)
>           assert out == expected_out, err
E           AssertionError: 
E           assert "/var/folders...pe is 'Any'\n" == "/var/folders/...ltins.str]'\n"
E             Skipping 61 identical leading characters in diff, use -v to show
E             + simple.py:5: error: Revealed type is 'builtins.tuple[builtins.str]'
E             - simple.py:2: error: Cannot find module named 'typedpkg.sample'
E             - /var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpt1nk7wi5/simple.py:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
E             - /var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpt1nk7wi5/simple.py:3: error: Cannot find module named 'typedpkg'
E             - /var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpt1nk7wi5/simple.py:5: error: Revealed type...
E             
E             ...Full output truncated (1 line hidden), use '-vv' to show

mypy/test/testpep561.py:39: AssertionError
____________________________________________________________ TestPEP561.test_typedpkg_stubs_python2 _____________________________________________________________
[gw7] darwin -- Python 3.6.6 /Users/ilevkivskyi/mypy_dev/bin/python

self = <mypy.test.testpep561.TestPEP561 testMethod=test_typedpkg_stubs_python2>

    def test_typedpkg_stubs_python2(self) -> None:
        python2 = try_find_python2_interpreter()
        if python2:
            with self.virtualenv(python2) as venv:
                venv_dir, py2 = venv
                self.install_package('typedpkg-stubs', py2)
                check_mypy_run(
                    [self.tempfile],
                    py2,
                    expected_out=self.msg_dne + self.msg_list,
>                   venv_dir=venv_dir,
                )

mypy/test/testpep561.py:157: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cmd_line = ['/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpdsnd7z59/simple.py', '--python-executable=/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpgjk1xd6p/bin/python']
python_executable = '/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpgjk1xd6p/bin/python'
expected_out = "/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpdsnd7z59/simple.py:3: error: Module 'typedpkg' has no attribute '...s/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpdsnd7z59/simple.py:5: error: Revealed type is 'builtins.list[builtins.str]'\n"
expected_err = '', expected_returncode = 1, venv_dir = '/var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpgjk1xd6p'

    def check_mypy_run(cmd_line: List[str],
                       python_executable: str = sys.executable,
                       expected_out: str = '',
                       expected_err: str = '',
                       expected_returncode: int = 1,
                       venv_dir: Optional[str] = None) -> None:
        """Helper to run mypy and check the output."""
        if venv_dir is not None:
            old_dir = os.getcwd()
            os.chdir(venv_dir)
        try:
            if python_executable != sys.executable:
                cmd_line.append('--python-executable={}'.format(python_executable))
            out, err, returncode = mypy.api.run(cmd_line)
>           assert out == expected_out, err
E           AssertionError: usage: mypy [-h] [-v] [-V] [more options; see below]
E                         [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
E             mypy: error: Python version (3, 6) did not match executable /var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpgjk1xd6p/bin/python, got version (2, 7).
E             
E           assert '' == "/var/folders/ff/8tg5kw8x3jg...ltins.list[builtins.str]'\n"
E             + /var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpdsnd7z59/simple.py:3: error: Module 'typedpkg' has no attribute 'dne'
E             + /var/folders/ff/8tg5kw8x3jg3z9cw0359hllxss39wp/T/tmpdsnd7z59/simple.py:5: error: Revealed type is 'builtins.list[builtins.str]'

mypy/test/testpep561.py:39: AssertionError
```