### PR TITLE
Fix a mypyc compilation error in 3.5

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -80,7 +80,7 @@ def _overload(x: Any) -> Any:
 
 
 # mypyc doesn't like unreachable code, so trick mypy into thinking the branch is reachable
-if sys.version_info < (3, 6) or bool():
+if bool() or sys.version_info < (3, 6):
     overload = _overload  # noqa
 
 


### PR DESCRIPTION
The call to bool() used to disguise the branch wasn't being
semantically analyzed when the version check matched, so work around
that. The actual solution here is to actually handle this case, but
this works for now.