### PR TITLE
Let -2 argument dest match --python-version's

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -461,7 +461,7 @@ def process_options(args: List[str],
         help='Type check code assuming it will be running on Python x.y',
         dest='special-opts:python_version')
     platform_group.add_argument(
-        '-2', '--py2', dest='python_version', action='store_const',
+        '-2', '--py2', dest='special-opts:python_version', action='store_const',
         const=defaults.PYTHON2_VERSION,
         help="Use Python 2 mode (same as --python-version 2.7)")
     platform_group.add_argument(


### PR DESCRIPTION
Hi. This addresses issue #5576. The pull request #5578 had stuff in it that broke things so this is a smaller change.

Currently, `mypy -2` behaves differently from `mypy --python-version 2.7` in that only the latter will look for typing information in the Python 2 site packages. When `-2` only is passed it ends up setting a value on a different namespace. With this change, the value is set up the same namespace and attribute that `--python-version` sets. (See also https://github.com/python/mypy/issues/5576#issuecomment-418872062)

There is still this inconsistency when loading the python version from the ini file, this will have to be addressed in another issue and pull request since the desired behaviour is unclear.