### PR TITLE
Add Final annotations to mypy code itself

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 MYPY = False
 if MYPY:
-    from typing import DefaultDict, Final
+    from typing import DefaultDict
 
 from mypy.types import Type, AnyType, PartialType, UnionType, TypeOfAny
 from mypy.subtypes import is_subtype
@@ -15,7 +15,6 @@ from mypy.literals import Key, literal, literal_hash, subkeys
 from mypy.nodes import IndexExpr, MemberExpr, NameExpr
 
 
-BindableTypes = (IndexExpr, MemberExpr, NameExpr)  # type: Final
 BindableExpression = Union[IndexExpr, MemberExpr, NameExpr]
 
 
@@ -129,7 +128,7 @@ class ConditionalTypeBinder:
         return None
 
     def put(self, expr: Expression, typ: Type) -> None:
-        if not isinstance(expr, BindableTypes):
+        if not isinstance(expr, (IndexExpr, MemberExpr, NameExpr)):
             return
         if not literal(expr):
             return
@@ -248,7 +247,7 @@ class ConditionalTypeBinder:
             # just collect the types.
             self.type_assignments[expr].append((type, declared_type))
             return
-        if not isinstance(expr, BindableTypes):
+        if not isinstance(expr, (IndexExpr, MemberExpr, NameExpr)):
             return None
         if not literal(expr):
             return

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 MYPY = False
 if MYPY:
-    from typing import DefaultDict
+    from typing import DefaultDict, Final
 
 from mypy.types import Type, AnyType, PartialType, UnionType, TypeOfAny
 from mypy.subtypes import is_subtype
@@ -15,7 +15,7 @@ from mypy.literals import Key, literal, literal_hash, subkeys
 from mypy.nodes import IndexExpr, MemberExpr, NameExpr
 
 
-BindableTypes = (IndexExpr, MemberExpr, NameExpr)
+BindableTypes = (IndexExpr, MemberExpr, NameExpr)  # type: Final
 BindableExpression = Union[IndexExpr, MemberExpr, NameExpr]
 
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -34,7 +34,7 @@ from typing import (AbstractSet, Any, cast, Dict, Iterable, Iterator, List,
                     Mapping, NamedTuple, Optional, Set, Tuple, Union, Callable)
 MYPY = False
 if MYPY:
-    from typing import ClassVar
+    from typing import ClassVar, Final
 
 from mypy import sitepkgs
 from mypy.nodes import (MypyFile, ImportBase, Import, ImportFrom, ImportAll)
@@ -67,10 +67,10 @@ from mypy.mypyc_hacks import BuildManagerBase
 # mode only that is useful during development. This produces only a subset of
 # output compared to --verbose output. We use a global flag to enable this so
 # that it's easy to enable this when running tests.
-DEBUG_FINE_GRAINED = False
+DEBUG_FINE_GRAINED = False  # type: Final
 
 
-PYTHON_EXTENSIONS = ['.pyi', '.py']
+PYTHON_EXTENSIONS = ['.pyi', '.py']  # type: Final
 
 
 Graph = Dict[str, 'State']
@@ -484,12 +484,12 @@ def cache_meta_from_dict(meta: Dict[str, Any],
 # Priorities used for imports.  (Here, top-level includes inside a class.)
 # These are used to determine a more predictable order in which the
 # nodes in an import cycle are processed.
-PRI_HIGH = 5  # top-level "from X import blah"
-PRI_MED = 10  # top-level "import X"
-PRI_LOW = 20  # either form inside a function
-PRI_MYPY = 25  # inside "if MYPY" or "if TYPE_CHECKING"
-PRI_INDIRECT = 30  # an indirect dependency
-PRI_ALL = 99  # include all priorities
+PRI_HIGH = 5  # type: Final  # top-level "from X import blah"
+PRI_MED = 10  # type: Final  # top-level "import X"
+PRI_LOW = 20  # type: Final  # either form inside a function
+PRI_MYPY = 25  # type: Final  # inside "if MYPY" or "if TYPE_CHECKING"
+PRI_INDIRECT = 30  # type: Final  # an indirect dependency
+PRI_ALL = 99  # type: Final  # include all priorities
 
 
 def import_priority(imp: ImportBase, toplevel_priority: int) -> int:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -34,7 +34,8 @@ from typing import (AbstractSet, Any, cast, Dict, Iterable, Iterator, List,
                     Mapping, NamedTuple, Optional, Set, Tuple, Union, Callable)
 MYPY = False
 if MYPY:
-    from typing import ClassVar, Final
+    from typing import ClassVar
+    from typing_extensions import Final
 
 from mypy import sitepkgs
 from mypy.nodes import (MypyFile, ImportBase, Import, ImportFrom, ImportAll)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -65,7 +65,7 @@ from mypy import experiments
 
 MYPY = False
 if MYPY:
-    from typing import Final
+    from typing_extensions import Final
 
 
 T = TypeVar('T')

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -63,10 +63,14 @@ from mypy.scope import Scope
 
 from mypy import experiments
 
+MYPY = False
+if MYPY:
+    from typing import Final
+
 
 T = TypeVar('T')
 
-DEFAULT_LAST_PASS = 1  # Pass numbers start at 0
+DEFAULT_LAST_PASS = 1  # type: Final  # Pass numbers start at 0
 
 
 # A node which is postponed to be processed during the next pass.

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -8,7 +8,7 @@ from typing import (
 )
 MYPY = False
 if MYPY:
-    from typing import ClassVar
+    from typing import ClassVar, Final
 
 from mypy.errors import report_internal_error
 from mypy.typeanal import (
@@ -71,7 +71,7 @@ ArgChecker = Callable[[Type, Type, int, Type, int, int, CallableType, Context, M
 # may cause performance issues. The reason is that although union math algorithm we use
 # nicely captures most corner cases, its worst case complexity is exponential,
 # see https://github.com/python/mypy/pull/5255#discussion_r196896335 for discussion.
-MAX_UNIONS = 5
+MAX_UNIONS = 5  # type: Final
 
 
 class TooManyUnions(Exception):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -8,7 +8,8 @@ from typing import (
 )
 MYPY = False
 if MYPY:
-    from typing import ClassVar, Final
+    from typing import ClassVar
+    from typing_extensions import Final
 
 from mypy.errors import report_internal_error
 from mypy.typeanal import (

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -14,6 +14,7 @@ if False:
     # break import cycle only needed for mypy
     import mypy.checker
     import mypy.checkexpr
+    from typing import Final
 from mypy import messages
 from mypy.messages import MessageBuilder
 
@@ -32,7 +33,7 @@ def compile_format_re() -> Pattern[str]:
     return re.compile(format_re)
 
 
-FORMAT_RE = compile_format_re()
+FORMAT_RE = compile_format_re()  # type: Final
 
 
 class ConversionSpecifier:

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -10,11 +10,13 @@ from mypy.types import (
 from mypy.nodes import (
     StrExpr, BytesExpr, UnicodeExpr, TupleExpr, DictExpr, Context, Expression, StarExpr
 )
-if False:
+
+MYPY = False
+if MYPY:
     # break import cycle only needed for mypy
     import mypy.checker
     import mypy.checkexpr
-    from typing import Final
+    from typing_extensions import Final
 from mypy import messages
 from mypy.messages import MessageBuilder
 

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -13,8 +13,9 @@ import mypy.subtypes
 from mypy.sametypes import is_same_type
 from mypy.erasetype import erase_typevars
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 
 SUBTYPE_OF = 0  # type: Final[int]

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -13,9 +13,12 @@ import mypy.subtypes
 from mypy.sametypes import is_same_type
 from mypy.erasetype import erase_typevars
 
+if False:
+    from typing import Final
 
-SUBTYPE_OF = 0  # type: int
-SUPERTYPE_OF = 1  # type: int
+
+SUBTYPE_OF = 0  # type: Final[int]
+SUPERTYPE_OF = 1  # type: Final[int]
 
 
 class Constraint:

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -1,5 +1,6 @@
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 PYTHON2_VERSION = (2, 7)  # type: Final
 PYTHON3_VERSION = (3, 6)  # type: Final

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -1,8 +1,11 @@
-PYTHON2_VERSION = (2, 7)
-PYTHON3_VERSION = (3, 6)
-PYTHON3_VERSION_MIN = (3, 4)
-CACHE_DIR = '.mypy_cache'
-CONFIG_FILE = 'mypy.ini'
-SHARED_CONFIG_FILES = ('setup.cfg',)
-USER_CONFIG_FILES = ('~/.mypy.ini',)
-CONFIG_FILES = (CONFIG_FILE,) + SHARED_CONFIG_FILES + USER_CONFIG_FILES
+if False:
+    from typing import Final
+
+PYTHON2_VERSION = (2, 7)  # type: Final
+PYTHON3_VERSION = (3, 6)  # type: Final
+PYTHON3_VERSION_MIN = (3, 4)  # type: Final
+CACHE_DIR = '.mypy_cache'  # type: Final
+CONFIG_FILE = 'mypy.ini'  # type: Final
+SHARED_CONFIG_FILES = ('setup.cfg',)  # type: Final
+USER_CONFIG_FILES = ('~/.mypy.ini',)  # type: Final
+CONFIG_FILES = (CONFIG_FILE,) + SHARED_CONFIG_FILES + USER_CONFIG_FILES  # type: Final

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -28,8 +28,11 @@ from mypy.options import Options
 from mypy.typestate import reset_global_state
 from mypy.version import __version__
 
+if False:
+    from typing import Final
 
-MEM_PROFILE = False  # If True, dump memory profile after initialization
+
+MEM_PROFILE = False  # type: Final  # If True, dump memory profile after initialization
 
 
 def daemonize(func: Callable[[], None], log_file: Optional[str] = None) -> int:
@@ -83,7 +86,7 @@ def daemonize(func: Callable[[], None], log_file: Optional[str] = None) -> int:
 
 # Server code.
 
-SOCKET_NAME = 'dmypy.sock'
+SOCKET_NAME = 'dmypy.sock'  # type: Final
 
 
 def process_start_options(flags: List[str], allow_sources: bool) -> Options:
@@ -382,7 +385,7 @@ class Server:
 # Misc utilities.
 
 
-MiB = 2**20
+MiB = 2**20  # type: Final
 
 
 def get_meminfo() -> Dict[str, Any]:

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -28,8 +28,9 @@ from mypy.options import Options
 from mypy.typestate import reset_global_state
 from mypy.version import __version__
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 
 MEM_PROFILE = False  # type: Final  # If True, dump memory profile after initialization

--- a/mypy/dmypy_util.py
+++ b/mypy/dmypy_util.py
@@ -7,8 +7,10 @@ import json
 import socket
 
 from typing import Any
-if False:
-    from typing import Final
+
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 STATUS_FILE = '.dmypy.json'  # type: Final
 

--- a/mypy/dmypy_util.py
+++ b/mypy/dmypy_util.py
@@ -7,8 +7,10 @@ import json
 import socket
 
 from typing import Any
+if False:
+    from typing import Final
 
-STATUS_FILE = '.dmypy.json'
+STATUS_FILE = '.dmypy.json'  # type: Final
 
 
 def receive(sock: socket.socket) -> Any:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -7,7 +7,7 @@ from typing import (
 MYPY = False
 if MYPY:
     import typing  # for typing.Type, which conflicts with types.Type
-    from typing import ClassVar
+    from typing import Final
 
 from mypy.sharedparse import (
     special_function_elide_names, argument_elide_name,
@@ -65,11 +65,11 @@ V = TypeVar('V')
 
 # There is no way to create reasonable fallbacks at this stage,
 # they must be patched later.
-MISSING_FALLBACK = FakeInfo("fallback can't be filled out until semanal")
-_dummy_fallback = Instance(MISSING_FALLBACK, [], -1)
+MISSING_FALLBACK = FakeInfo("fallback can't be filled out until semanal")  # type: Final
+_dummy_fallback = Instance(MISSING_FALLBACK, [], -1)  # type: Final
 
-TYPE_COMMENT_SYNTAX_ERROR = 'syntax error in type comment'
-TYPE_COMMENT_AST_ERROR = 'invalid type comment or annotation'
+TYPE_COMMENT_SYNTAX_ERROR = 'syntax error in type comment'  # type: Final
+TYPE_COMMENT_AST_ERROR = 'invalid type comment or annotation'  # type: Final
 
 
 # Older versions of typing don't allow using overload outside stubs,
@@ -223,7 +223,7 @@ class ASTConverter(ast3.NodeTransformer):
         ast3.BitXor: '^',
         ast3.BitAnd: '&',
         ast3.FloorDiv: '//'
-    }  # type: ClassVar[Dict[typing.Type[ast3.AST], str]]
+    }  # type: Final[Dict[typing.Type[ast3.AST], str]]
 
     def from_operator(self, op: ast3.operator) -> str:
         op_name = ASTConverter.op_map.get(type(op))
@@ -243,7 +243,7 @@ class ASTConverter(ast3.NodeTransformer):
         ast3.IsNot: 'is not',
         ast3.In: 'in',
         ast3.NotIn: 'not in'
-    }  # type: ClassVar[Dict[typing.Type[ast3.AST], str]]
+    }  # type: Final[Dict[typing.Type[ast3.AST], str]]
 
     def from_comp_operator(self, op: ast3.cmpop) -> str:
         op_name = ASTConverter.comp_op_map.get(type(op))

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -7,7 +7,7 @@ from typing import (
 MYPY = False
 if MYPY:
     import typing  # for typing.Type, which conflicts with types.Type
-    from typing import Final
+    from typing_extensions import Final
 
 from mypy.sharedparse import (
     special_function_elide_names, argument_elide_name,

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -21,7 +21,7 @@ from typing import Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, Dic
 MYPY = False
 if MYPY:
     import typing  # for typing.Type, which conflicts with types.Type
-    from typing import ClassVar
+    from typing import Final
 
 from mypy.sharedparse import (
     special_function_elide_names, argument_elide_name,
@@ -76,11 +76,11 @@ V = TypeVar('V')
 
 # There is no way to create reasonable fallbacks at this stage,
 # they must be patched later.
-MISSING_FALLBACK = FakeInfo("fallback can't be filled out until semanal")
-_dummy_fallback = Instance(MISSING_FALLBACK, [], -1)
+MISSING_FALLBACK = FakeInfo("fallback can't be filled out until semanal")  # type: Final
+_dummy_fallback = Instance(MISSING_FALLBACK, [], -1)  # type: Final
 
-TYPE_COMMENT_SYNTAX_ERROR = 'syntax error in type comment'
-TYPE_COMMENT_AST_ERROR = 'invalid type comment'
+TYPE_COMMENT_SYNTAX_ERROR = 'syntax error in type comment'  # type: Final
+TYPE_COMMENT_AST_ERROR = 'invalid type comment'  # type: Final
 
 
 def parse(source: Union[str, bytes],
@@ -199,7 +199,7 @@ class ASTConverter(ast27.NodeTransformer):
         ast27.BitXor: '^',
         ast27.BitAnd: '&',
         ast27.FloorDiv: '//'
-    }  # type: ClassVar[Dict[typing.Type[ast27.AST], str]]
+    }  # type: Final[Dict[typing.Type[ast27.AST], str]]
 
     def from_operator(self, op: ast27.operator) -> str:
         op_name = ASTConverter.op_map.get(type(op))
@@ -221,7 +221,7 @@ class ASTConverter(ast27.NodeTransformer):
         ast27.IsNot: 'is not',
         ast27.In: 'in',
         ast27.NotIn: 'not in'
-    }  # type: ClassVar[Dict[typing.Type[ast27.AST], str]]
+    }  # type: Final[Dict[typing.Type[ast27.AST], str]]
 
     def from_comp_operator(self, op: ast27.cmpop) -> str:
         op_name = ASTConverter.comp_op_map.get(type(op))

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -21,7 +21,7 @@ from typing import Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, Dic
 MYPY = False
 if MYPY:
     import typing  # for typing.Type, which conflicts with types.Type
-    from typing import Final
+    from typing_extensions import Final
 
 from mypy.sharedparse import (
     special_function_elide_names, argument_elide_name,

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -8,9 +8,9 @@ from mypy.build import BuildSource, PYTHON_EXTENSIONS
 from mypy.fscache import FileSystemCache
 from mypy.options import Options
 
-
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 PY_EXTENSIONS = tuple(PYTHON_EXTENSIONS)  # type: Final
 

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -9,7 +9,10 @@ from mypy.fscache import FileSystemCache
 from mypy.options import Options
 
 
-PY_EXTENSIONS = tuple(PYTHON_EXTENSIONS)
+if False:
+    from typing import Final
+
+PY_EXTENSIONS = tuple(PYTHON_EXTENSIONS)  # type: Final
 
 
 class InvalidSourceList(Exception):

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -11,6 +11,9 @@ from mypy.nodes import (
 )
 from mypy.visitor import ExpressionVisitor
 
+if False:
+    from typing import Final
+
 # [Note Literals and literal_hash]
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
@@ -231,4 +234,4 @@ class _Hasher(ExpressionVisitor[Optional[Key]]):
         return None
 
 
-_hasher = _Hasher()
+_hasher = _Hasher()  # type: Final

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -11,8 +11,9 @@ from mypy.nodes import (
 )
 from mypy.visitor import ExpressionVisitor
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 # [Note Literals and literal_hash]
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -24,10 +24,13 @@ from mypy.report import reporter_classes
 
 from mypy.version import __version__
 
+if False:
+    from typing import Final
 
-orig_stat = os.stat
 
-MEM_PROFILE = False  # If True, dump memory profile
+orig_stat = os.stat  # type: Final
+
+MEM_PROFILE = False  # type: Final  # If True, dump memory profile
 
 
 def stat_proxy(path: str) -> os.stat_result:
@@ -217,8 +220,8 @@ class AugmentedHelpFormatter(argparse.RawDescriptionHelpFormatter):
 flag_prefix_pairs = [
     ('allow', 'disallow'),
     ('show', 'hide'),
-]
-flag_prefix_map = {}  # type: Dict[str, str]
+]  # type: Final
+flag_prefix_map = {}  # type: Final[Dict[str, str]]
 for a, b in flag_prefix_pairs:
     flag_prefix_map[a] = b
     flag_prefix_map[b] = a
@@ -311,7 +314,7 @@ def infer_python_version_and_executable(options: Options,
 
 
 HEADER = """%(prog)s [-h] [-v] [-V] [more options; see below]
-            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]"""
+            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]"""  # type: Final
 
 
 DESCRIPTION = """
@@ -335,10 +338,10 @@ You can also use a config file to configure mypy instead of using
 command line flags. For more details, see:
 
 - http://mypy.readthedocs.io/en/latest/config_file.html
-"""
+"""  # type: Final
 
 FOOTER = """Environment variables:
-  Define MYPYPATH for additional module search path entries."""
+  Define MYPYPATH for additional module search path entries."""  # type: Final
 
 
 def process_options(args: List[str],
@@ -973,7 +976,7 @@ config_types = {
     'always_true': lambda s: [p.strip() for p in s.split(',')],
     'always_false': lambda s: [p.strip() for p in s.split(',')],
     'package_root': lambda s: [p.strip() for p in s.split(',')],
-}
+}  # type: Final
 
 
 def parse_config_file(options: Options, filename: Optional[str]) -> None:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -24,8 +24,9 @@ from mypy.report import reporter_classes
 
 from mypy.version import __version__
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 
 orig_stat = os.stat  # type: Final

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -30,8 +30,9 @@ from mypy.nodes import (
     CallExpr
 )
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 # Constants that represent simple type checker error message, i.e. messages
 # that do not have any parameters.

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -46,24 +46,29 @@ NO_RETURN_EXPECTED = 'Return statement in function which does not return'  # typ
 INVALID_EXCEPTION = 'Exception must be derived from BaseException'  # type: Final
 INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'  # type: Final
 INVALID_RETURN_TYPE_FOR_GENERATOR = \
-    'The return type of a generator function should be "Generator" or one of its supertypes'  # type: Final
+    'The return type of a generator function should be "Generator"' \
+    ' or one of its supertypes'  # type: Final
 INVALID_RETURN_TYPE_FOR_ASYNC_GENERATOR = \
     'The return type of an async generator function should be "AsyncGenerator" or one of its ' \
     'supertypes'  # type: Final
 INVALID_GENERATOR_RETURN_ITEM_TYPE = \
-    'The return type of a generator function must be None in its third type parameter in Python 2'  # type: Final
+    'The return type of a generator function must be None in' \
+    ' its third type parameter in Python 2'  # type: Final
 YIELD_VALUE_EXPECTED = 'Yield value expected'  # type: Final
 INCOMPATIBLE_TYPES = 'Incompatible types'  # type: Final
 INCOMPATIBLE_TYPES_IN_ASSIGNMENT = 'Incompatible types in assignment'  # type: Final
 INCOMPATIBLE_REDEFINITION = 'Incompatible redefinition'  # type: Final
 INCOMPATIBLE_TYPES_IN_AWAIT = 'Incompatible types in "await"'  # type: Final
-INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AENTER = 'Incompatible types in "async with" for "__aenter__"'  # type: Final
-INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AEXIT = 'Incompatible types in "async with" for "__aexit__"'  # type: Final
+INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AENTER = \
+    'Incompatible types in "async with" for "__aenter__"'  # type: Final
+INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AEXIT = \
+    'Incompatible types in "async with" for "__aexit__"'  # type: Final
 INCOMPATIBLE_TYPES_IN_ASYNC_FOR = 'Incompatible types in "async for"'  # type: Final
 
 INCOMPATIBLE_TYPES_IN_YIELD = 'Incompatible types in "yield"'  # type: Final
 INCOMPATIBLE_TYPES_IN_YIELD_FROM = 'Incompatible types in "yield from"'  # type: Final
-INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION = 'Incompatible types in string interpolation'  # type: Final
+INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION = \
+    'Incompatible types in string interpolation'  # type: Final
 MUST_HAVE_NONE_RETURN_TYPE = 'The return type of "{}" must be None'  # type: Final
 INVALID_TUPLE_INDEX_TYPE = 'Invalid tuple index type'  # type: Final
 TUPLE_INDEX_OUT_OF_RANGE = 'Tuple index out of range'  # type: Final
@@ -78,13 +83,16 @@ INCONSISTENT_ABSTRACT_OVERLOAD = \
 READ_ONLY_PROPERTY_OVERRIDES_READ_WRITE = \
     'Read-only property cannot override read-write property'  # type: Final
 FORMAT_REQUIRES_MAPPING = 'Format requires a mapping'  # type: Final
-RETURN_TYPE_CANNOT_BE_CONTRAVARIANT = "Cannot use a contravariant type variable as return type"  # type: Final
-FUNCTION_PARAMETER_CANNOT_BE_COVARIANT = "Cannot use a covariant type variable as a parameter"  # type: Final
+RETURN_TYPE_CANNOT_BE_CONTRAVARIANT = \
+    "Cannot use a contravariant type variable as return type"  # type: Final
+FUNCTION_PARAMETER_CANNOT_BE_COVARIANT = \
+    "Cannot use a covariant type variable as a parameter"  # type: Final
 INCOMPATIBLE_IMPORT_OF = "Incompatible import of"  # type: Final
 FUNCTION_TYPE_EXPECTED = "Function is missing a type annotation"  # type: Final
 ONLY_CLASS_APPLICATION = "Type application is only supported for generic classes"  # type: Final
 RETURN_TYPE_EXPECTED = "Function is missing a return type annotation"  # type: Final
-ARGUMENT_TYPE_EXPECTED = "Function is missing a type annotation for one or more arguments"  # type: Final
+ARGUMENT_TYPE_EXPECTED = \
+    "Function is missing a type annotation for one or more arguments"  # type: Final
 KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE = \
     'Keyword argument only valid with "str" key type in call to "dict"'  # type: Final
 ALL_MUST_BE_SEQ_STR = 'Type of __all__ must be {}, not {}'  # type: Final
@@ -95,11 +103,13 @@ TYPEDDICT_KEY_MUST_BE_STRING_LITERAL = \
 MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'  # type: Final
 NON_BOOLEAN_IN_CONDITIONAL = 'Condition must be a boolean'  # type: Final
 DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'  # type: Final
-GENERIC_INSTANCE_VAR_CLASS_ACCESS = 'Access to generic instance variables via class is ambiguous'  # type: Final
+GENERIC_INSTANCE_VAR_CLASS_ACCESS = \
+    'Access to generic instance variables via class is ambiguous'  # type: Final
 CANNOT_ISINSTANCE_TYPEDDICT = 'Cannot use isinstance() with a TypedDict type'  # type: Final
 CANNOT_ISINSTANCE_NEWTYPE = 'Cannot use isinstance() with a NewType type'  # type: Final
 BARE_GENERIC = 'Missing type parameters for generic type'  # type: Final
-IMPLICIT_GENERIC_ANY_BUILTIN = 'Implicit generic "Any". Use \'{}\' and specify generic parameters'  # type: Final
+IMPLICIT_GENERIC_ANY_BUILTIN = \
+    'Implicit generic "Any". Use \'{}\' and specify generic parameters'  # type: Final
 INCOMPATIBLE_TYPEVAR_VALUE = 'Value of type variable "{}" of {} cannot be {}'  # type: Final
 UNSUPPORTED_ARGUMENT_2_FOR_SUPER = 'Unsupported argument 2 for "super"'  # type: Final
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -30,74 +30,77 @@ from mypy.nodes import (
     CallExpr
 )
 
+if False:
+    from typing import Final
+
 # Constants that represent simple type checker error message, i.e. messages
 # that do not have any parameters.
 
-NO_RETURN_VALUE_EXPECTED = 'No return value expected'
-MISSING_RETURN_STATEMENT = 'Missing return statement'
-INVALID_IMPLICIT_RETURN = 'Implicit return in function which does not return'
-INCOMPATIBLE_RETURN_VALUE_TYPE = 'Incompatible return value type'
-RETURN_VALUE_EXPECTED = 'Return value expected'
-NO_RETURN_EXPECTED = 'Return statement in function which does not return'
-INVALID_EXCEPTION = 'Exception must be derived from BaseException'
-INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'
+NO_RETURN_VALUE_EXPECTED = 'No return value expected'  # type: Final
+MISSING_RETURN_STATEMENT = 'Missing return statement'  # type: Final
+INVALID_IMPLICIT_RETURN = 'Implicit return in function which does not return'  # type: Final
+INCOMPATIBLE_RETURN_VALUE_TYPE = 'Incompatible return value type'  # type: Final
+RETURN_VALUE_EXPECTED = 'Return value expected'  # type: Final
+NO_RETURN_EXPECTED = 'Return statement in function which does not return'  # type: Final
+INVALID_EXCEPTION = 'Exception must be derived from BaseException'  # type: Final
+INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'  # type: Final
 INVALID_RETURN_TYPE_FOR_GENERATOR = \
-    'The return type of a generator function should be "Generator" or one of its supertypes'
+    'The return type of a generator function should be "Generator" or one of its supertypes'  # type: Final
 INVALID_RETURN_TYPE_FOR_ASYNC_GENERATOR = \
     'The return type of an async generator function should be "AsyncGenerator" or one of its ' \
-    'supertypes'
+    'supertypes'  # type: Final
 INVALID_GENERATOR_RETURN_ITEM_TYPE = \
-    'The return type of a generator function must be None in its third type parameter in Python 2'
-YIELD_VALUE_EXPECTED = 'Yield value expected'
-INCOMPATIBLE_TYPES = 'Incompatible types'
-INCOMPATIBLE_TYPES_IN_ASSIGNMENT = 'Incompatible types in assignment'
-INCOMPATIBLE_REDEFINITION = 'Incompatible redefinition'
-INCOMPATIBLE_TYPES_IN_AWAIT = 'Incompatible types in "await"'
-INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AENTER = 'Incompatible types in "async with" for "__aenter__"'
-INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AEXIT = 'Incompatible types in "async with" for "__aexit__"'
-INCOMPATIBLE_TYPES_IN_ASYNC_FOR = 'Incompatible types in "async for"'
+    'The return type of a generator function must be None in its third type parameter in Python 2'  # type: Final
+YIELD_VALUE_EXPECTED = 'Yield value expected'  # type: Final
+INCOMPATIBLE_TYPES = 'Incompatible types'  # type: Final
+INCOMPATIBLE_TYPES_IN_ASSIGNMENT = 'Incompatible types in assignment'  # type: Final
+INCOMPATIBLE_REDEFINITION = 'Incompatible redefinition'  # type: Final
+INCOMPATIBLE_TYPES_IN_AWAIT = 'Incompatible types in "await"'  # type: Final
+INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AENTER = 'Incompatible types in "async with" for "__aenter__"'  # type: Final
+INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AEXIT = 'Incompatible types in "async with" for "__aexit__"'  # type: Final
+INCOMPATIBLE_TYPES_IN_ASYNC_FOR = 'Incompatible types in "async for"'  # type: Final
 
-INCOMPATIBLE_TYPES_IN_YIELD = 'Incompatible types in "yield"'
-INCOMPATIBLE_TYPES_IN_YIELD_FROM = 'Incompatible types in "yield from"'
-INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION = 'Incompatible types in string interpolation'
-MUST_HAVE_NONE_RETURN_TYPE = 'The return type of "{}" must be None'
-INVALID_TUPLE_INDEX_TYPE = 'Invalid tuple index type'
-TUPLE_INDEX_OUT_OF_RANGE = 'Tuple index out of range'
-INVALID_SLICE_INDEX = 'Slice index must be an integer or None'
-CANNOT_INFER_LAMBDA_TYPE = 'Cannot infer type of lambda'
-CANNOT_INFER_ITEM_TYPE = 'Cannot infer iterable item type'
-CANNOT_ACCESS_INIT = 'Cannot access "__init__" directly'
-CANNOT_ASSIGN_TO_METHOD = 'Cannot assign to a method'
-CANNOT_ASSIGN_TO_TYPE = 'Cannot assign to a type'
+INCOMPATIBLE_TYPES_IN_YIELD = 'Incompatible types in "yield"'  # type: Final
+INCOMPATIBLE_TYPES_IN_YIELD_FROM = 'Incompatible types in "yield from"'  # type: Final
+INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION = 'Incompatible types in string interpolation'  # type: Final
+MUST_HAVE_NONE_RETURN_TYPE = 'The return type of "{}" must be None'  # type: Final
+INVALID_TUPLE_INDEX_TYPE = 'Invalid tuple index type'  # type: Final
+TUPLE_INDEX_OUT_OF_RANGE = 'Tuple index out of range'  # type: Final
+INVALID_SLICE_INDEX = 'Slice index must be an integer or None'  # type: Final
+CANNOT_INFER_LAMBDA_TYPE = 'Cannot infer type of lambda'  # type: Final
+CANNOT_INFER_ITEM_TYPE = 'Cannot infer iterable item type'  # type: Final
+CANNOT_ACCESS_INIT = 'Cannot access "__init__" directly'  # type: Final
+CANNOT_ASSIGN_TO_METHOD = 'Cannot assign to a method'  # type: Final
+CANNOT_ASSIGN_TO_TYPE = 'Cannot assign to a type'  # type: Final
 INCONSISTENT_ABSTRACT_OVERLOAD = \
-    'Overloaded method has both abstract and non-abstract variants'
+    'Overloaded method has both abstract and non-abstract variants'  # type: Final
 READ_ONLY_PROPERTY_OVERRIDES_READ_WRITE = \
-    'Read-only property cannot override read-write property'
-FORMAT_REQUIRES_MAPPING = 'Format requires a mapping'
-RETURN_TYPE_CANNOT_BE_CONTRAVARIANT = "Cannot use a contravariant type variable as return type"
-FUNCTION_PARAMETER_CANNOT_BE_COVARIANT = "Cannot use a covariant type variable as a parameter"
-INCOMPATIBLE_IMPORT_OF = "Incompatible import of"
-FUNCTION_TYPE_EXPECTED = "Function is missing a type annotation"
-ONLY_CLASS_APPLICATION = "Type application is only supported for generic classes"
-RETURN_TYPE_EXPECTED = "Function is missing a return type annotation"
-ARGUMENT_TYPE_EXPECTED = "Function is missing a type annotation for one or more arguments"
+    'Read-only property cannot override read-write property'  # type: Final
+FORMAT_REQUIRES_MAPPING = 'Format requires a mapping'  # type: Final
+RETURN_TYPE_CANNOT_BE_CONTRAVARIANT = "Cannot use a contravariant type variable as return type"  # type: Final
+FUNCTION_PARAMETER_CANNOT_BE_COVARIANT = "Cannot use a covariant type variable as a parameter"  # type: Final
+INCOMPATIBLE_IMPORT_OF = "Incompatible import of"  # type: Final
+FUNCTION_TYPE_EXPECTED = "Function is missing a type annotation"  # type: Final
+ONLY_CLASS_APPLICATION = "Type application is only supported for generic classes"  # type: Final
+RETURN_TYPE_EXPECTED = "Function is missing a return type annotation"  # type: Final
+ARGUMENT_TYPE_EXPECTED = "Function is missing a type annotation for one or more arguments"  # type: Final
 KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE = \
-    'Keyword argument only valid with "str" key type in call to "dict"'
-ALL_MUST_BE_SEQ_STR = 'Type of __all__ must be {}, not {}'
+    'Keyword argument only valid with "str" key type in call to "dict"'  # type: Final
+ALL_MUST_BE_SEQ_STR = 'Type of __all__ must be {}, not {}'  # type: Final
 INVALID_TYPEDDICT_ARGS = \
-    'Expected keyword arguments, {...}, or dict(...) in TypedDict constructor'
+    'Expected keyword arguments, {...}, or dict(...) in TypedDict constructor'  # type: Final
 TYPEDDICT_KEY_MUST_BE_STRING_LITERAL = \
-    'Expected TypedDict key to be string literal'
-MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'
-NON_BOOLEAN_IN_CONDITIONAL = 'Condition must be a boolean'
-DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'
-GENERIC_INSTANCE_VAR_CLASS_ACCESS = 'Access to generic instance variables via class is ambiguous'
-CANNOT_ISINSTANCE_TYPEDDICT = 'Cannot use isinstance() with a TypedDict type'
-CANNOT_ISINSTANCE_NEWTYPE = 'Cannot use isinstance() with a NewType type'
-BARE_GENERIC = 'Missing type parameters for generic type'
-IMPLICIT_GENERIC_ANY_BUILTIN = 'Implicit generic "Any". Use \'{}\' and specify generic parameters'
-INCOMPATIBLE_TYPEVAR_VALUE = 'Value of type variable "{}" of {} cannot be {}'
-UNSUPPORTED_ARGUMENT_2_FOR_SUPER = 'Unsupported argument 2 for "super"'
+    'Expected TypedDict key to be string literal'  # type: Final
+MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'  # type: Final
+NON_BOOLEAN_IN_CONDITIONAL = 'Condition must be a boolean'  # type: Final
+DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'  # type: Final
+GENERIC_INSTANCE_VAR_CLASS_ACCESS = 'Access to generic instance variables via class is ambiguous'  # type: Final
+CANNOT_ISINSTANCE_TYPEDDICT = 'Cannot use isinstance() with a TypedDict type'  # type: Final
+CANNOT_ISINSTANCE_NEWTYPE = 'Cannot use isinstance() with a NewType type'  # type: Final
+BARE_GENERIC = 'Missing type parameters for generic type'  # type: Final
+IMPLICIT_GENERIC_ANY_BUILTIN = 'Implicit generic "Any". Use \'{}\' and specify generic parameters'  # type: Final
+INCOMPATIBLE_TYPEVAR_VALUE = 'Value of type variable "{}" of {} cannot be {}'  # type: Final
+UNSUPPORTED_ARGUMENT_2_FOR_SUPER = 'Unsupported argument 2 for "super"'  # type: Final
 
 ARG_CONSTRUCTOR_NAMES = {
     ARG_POS: "Arg",
@@ -106,7 +109,7 @@ ARG_CONSTRUCTOR_NAMES = {
     ARG_NAMED_OPT: "DefaultNamedArg",
     ARG_STAR: "VarArg",
     ARG_STAR2: "KwArg",
-}
+}  # type: Final
 
 
 class MessageBuilder:
@@ -1557,7 +1560,7 @@ def temp_message_builder() -> MessageBuilder:
 # For hard-coding suggested missing member alternatives.
 COMMON_MISTAKES = {
     'add': ('append', 'extend'),
-}  # type: Dict[str, Sequence[str]]
+}  # type: Final[Dict[str, Sequence[str]]]
 
 
 def best_matches(current: str, options: Iterable[str]) -> List[str]:

--- a/mypy/moduleinfo.py
+++ b/mypy/moduleinfo.py
@@ -14,6 +14,9 @@ no stub for a module.
 
 from typing import Set
 
+if False:
+    from typing import Final
+
 
 third_party_modules = {
     # From Python 3 Wall of Superpowers (https://python3wos.appspot.com/)
@@ -228,7 +231,7 @@ third_party_modules = {
 
     # for use in tests
     '__dummy_third_party1',
-}
+}  # type: Final
 
 # Modules and packages common to Python 2.7 and 3.x.
 common_std_lib_modules = {
@@ -430,7 +433,7 @@ common_std_lib_modules = {
     # fake names to use in tests
     '__dummy_stdlib1',
     '__dummy_stdlib2',
-}
+}  # type: Final
 
 # Python 2 standard library modules.
 python2_std_lib_modules = common_std_lib_modules | {
@@ -506,7 +509,7 @@ python2_std_lib_modules = common_std_lib_modules | {
     'whichdb',
     'xmllib',
     'xmlrpclib',
-}
+}  # type: Final
 
 # Python 3 standard library modules (based on Python 3.5.0).
 python3_std_lib_modules = common_std_lib_modules | {
@@ -547,7 +550,7 @@ python3_std_lib_modules = common_std_lib_modules | {
     'xmlrpc',
     'xxlimited',
     'zipapp',
-}
+}  # type: Final
 
 
 def is_third_party_module(id: str) -> bool:

--- a/mypy/moduleinfo.py
+++ b/mypy/moduleinfo.py
@@ -14,8 +14,9 @@ no stub for a module.
 
 from typing import Set
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 
 third_party_modules = {

--- a/mypy/mypyc_hacks.py
+++ b/mypy/mypyc_hacks.py
@@ -1,35 +1,5 @@
 """Stuff that we had to move out of its right place because of mypyc limitations."""
 
-
-# Moved from types.py, because it inherits from Enum, which uses a
-# metaclass in a nontrivial way.
-from enum import Enum
-
-
-class TypeOfAny(Enum):
-    """
-    This class describes different types of Any. Each 'Any' can be of only one type at a time.
-    """
-    # Was this Any type was inferred without a type annotation?
-    unannotated = 'unannotated'
-    # Does this Any come from an explicit type annotation?
-    explicit = 'explicit'
-    # Does this come from an unfollowed import? See --disallow-any-unimported option
-    from_unimported_type = 'from_unimported_type'
-    # Does this Any type come from omitted generics?
-    from_omitted_generics = 'from_omitted_generics'
-    # Does this Any come from an error?
-    from_error = 'from_error'
-    # Is this a type that can't be represented in mypy's type system? For instance, type of
-    # call to NewType...). Even though these types aren't real Anys, we treat them as such.
-    # Also used for variables named '_'.
-    special_form = 'special_form'
-    # Does this Any come from interaction with another Any?
-    from_another_any = 'from_another_any'
-    # Does this Any come from an implementation limitation/bug?
-    implementation_artifact = 'implementation_artifact'
-
-
 from typing import Dict, Any
 import sys
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1504,22 +1504,22 @@ op_methods = {
     '>': '__gt__',
     '<=': '__le__',
     'in': '__contains__',
-}  # type: Dict[str, str]
+}  # type: Final[Dict[str, str]]
 
-op_methods_to_symbols = {v: k for (k, v) in op_methods.items()}
+op_methods_to_symbols = {v: k for (k, v) in op_methods.items()}  # type: Final
 op_methods_to_symbols['__div__'] = '/'
 
-comparison_fallback_method = '__cmp__'
+comparison_fallback_method = '__cmp__'  # type: Final
 ops_falling_back_to_cmp = {'__ne__', '__eq__',
                            '__lt__', '__le__',
-                           '__gt__', '__ge__'}
+                           '__gt__', '__ge__'}  # type: Final
 
 
 ops_with_inplace_method = {
-    '+', '-', '*', '/', '%', '//', '**', '@', '&', '|', '^', '<<', '>>'}
+    '+', '-', '*', '/', '%', '//', '**', '@', '&', '|', '^', '<<', '>>'}  # type: Final
 
 inplace_operator_methods = set(
-    '__i' + op_methods[op][2:] for op in ops_with_inplace_method)
+    '__i' + op_methods[op][2:] for op in ops_with_inplace_method)  # type: Final
 
 reverse_op_methods = {
     '__add__': '__radd__',
@@ -1542,7 +1542,7 @@ reverse_op_methods = {
     '__ge__': '__le__',
     '__gt__': '__lt__',
     '__le__': '__ge__',
-}
+}  # type: Final
 
 # Suppose we have some class A. When we do A() + A(), Python will only check
 # the output of A().__add__(A()) and skip calling the __radd__ method entirely.
@@ -1563,16 +1563,16 @@ op_methods_that_shortcut = {
     '__xor__',
     '__lshift__',
     '__rshift__',
-}
+}  # type: Final
 
-normal_from_reverse_op = dict((m, n) for n, m in reverse_op_methods.items())
-reverse_op_method_set = set(reverse_op_methods.values())
+normal_from_reverse_op = dict((m, n) for n, m in reverse_op_methods.items())  # type: Final
+reverse_op_method_set = set(reverse_op_methods.values())  # type: Final
 
 unary_op_methods = {
     '-': '__neg__',
     '+': '__pos__',
     '~': '__invert__',
-}
+}  # type: Final
 
 
 class OpExpr(Expression):

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -10,7 +10,8 @@ from mypy_extensions import trait
 
 MYPY = False
 if MYPY:
-    from typing import DefaultDict, Final
+    from typing import DefaultDict
+    from typing_extensions import Final
 
 import mypy.strconv
 from mypy.util import short_type

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -10,7 +10,7 @@ from mypy_extensions import trait
 
 MYPY = False
 if MYPY:
-    from typing import DefaultDict, ClassVar
+    from typing import DefaultDict, Final
 
 import mypy.strconv
 from mypy.util import short_type
@@ -64,29 +64,29 @@ JsonDict = Dict[str, Any]
 #
 # TODO rename to use more descriptive names
 
-LDEF = 0  # type: int
-GDEF = 1  # type: int
-MDEF = 2  # type: int
-MODULE_REF = 3  # type: int
+LDEF = 0  # type: Final[int]
+GDEF = 1  # type: Final[int]
+MDEF = 2  # type: Final[int]
+MODULE_REF = 3  # type: Final[int]
 # Type variable declared using TypeVar(...) has kind TVAR. It's not
 # valid as a type unless bound in a TypeVarScope.  That happens within:
 # (1) a generic class that uses the type variable as a type argument or
 # (2) a generic function that refers to the type variable in its signature.
-TVAR = 4  # type: int
+TVAR = 4  # type: Final[int]
 
 # Placeholder for a name imported via 'from ... import'. Second phase of
 # semantic will replace this the actual imported reference. This is
 # needed so that we can detect whether a name has been imported during
 # XXX what?
-UNBOUND_IMPORTED = 5  # type: int
+UNBOUND_IMPORTED = 5  # type: Final[int]
 
 # RevealExpr node kinds
-REVEAL_TYPE = 0  # type: int
-REVEAL_LOCALS = 1  # type: int
+REVEAL_TYPE = 0  # type: Final[int]
+REVEAL_LOCALS = 1  # type: Final[int]
 
-LITERAL_YES = 2
-LITERAL_TYPE = 1
-LITERAL_NO = 0
+LITERAL_YES = 2  # type: Final
+LITERAL_TYPE = 1  # type: Final
+LITERAL_NO = 0  # type: Final
 
 node_kinds = {
     LDEF: 'Ldef',
@@ -95,14 +95,14 @@ node_kinds = {
     MODULE_REF: 'ModuleRef',
     TVAR: 'Tvar',
     UNBOUND_IMPORTED: 'UnboundImported',
-}
-inverse_node_kinds = {_kind: _name for _name, _kind in node_kinds.items()}
+}  # type: Final
+inverse_node_kinds = {_kind: _name for _name, _kind in node_kinds.items()}  # type: Final
 
 
 implicit_module_attrs = {'__name__': '__builtins__.str',
                          '__doc__': None,  # depends on Python version, see semanal.py
                          '__file__': '__builtins__.str',
-                         '__package__': '__builtins__.str'}
+                         '__package__': '__builtins__.str'}  # type: Final
 
 
 # These aliases exist because built-in class objects are not subscriptable.
@@ -116,17 +116,17 @@ type_aliases = {
     'typing.Counter': 'collections.Counter',
     'typing.DefaultDict': 'collections.defaultdict',
     'typing.Deque': 'collections.deque',
-}
+}  # type: Final
 
 reverse_builtin_aliases = {
     'builtins.list': 'typing.List',
     'builtins.dict': 'typing.Dict',
     'builtins.set': 'typing.Set',
     'builtins.frozenset': 'typing.FrozenSet',
-}
+}  # type: Final
 
 nongen_builtins = {'builtins.tuple': 'typing.Tuple',
-                   'builtins.enumerate': ''}
+                   'builtins.enumerate': ''}  # type: Final
 nongen_builtins.update((name, alias) for alias, name in type_aliases.items())
 
 
@@ -379,7 +379,7 @@ class ImportedName(SymbolNode):
 
 FUNCBASE_FLAGS = [
     'is_property', 'is_class', 'is_static', 'is_final'
-]
+]  # type: Final
 
 
 class FuncBase(Node):
@@ -510,7 +510,7 @@ class Argument(Node):
 FUNCITEM_FLAGS = FUNCBASE_FLAGS + [
     'is_overload', 'is_generator', 'is_coroutine', 'is_async_generator',
     'is_awaitable_coroutine',
-]
+]  # type: Final
 
 
 class FuncItem(FuncBase):
@@ -570,7 +570,7 @@ class FuncItem(FuncBase):
 
 FUNCDEF_FLAGS = FUNCITEM_FLAGS + [
     'is_decorated', 'is_conditional', 'is_abstract',
-]
+]  # type: Final
 
 
 class FuncDef(FuncItem, SymbolNode, Statement):
@@ -707,7 +707,7 @@ VAR_FLAGS = [
     'is_self', 'is_initialized_in_class', 'is_staticmethod',
     'is_classmethod', 'is_property', 'is_settable_property', 'is_suppressed_import',
     'is_classvar', 'is_abstract_var', 'is_final', 'final_unset_in_class', 'final_set_in_init'
-]
+]  # type: Final
 
 
 class Var(SymbolNode):
@@ -1372,17 +1372,17 @@ class MemberExpr(RefExpr):
 # Kinds of arguments
 
 # Positional argument
-ARG_POS = 0  # type: int
+ARG_POS = 0  # type: Final[int]
 # Positional, optional argument (functions only, not calls)
-ARG_OPT = 1  # type: int
+ARG_OPT = 1  # type: Final[int]
 # *arg argument
-ARG_STAR = 2  # type: int
+ARG_STAR = 2  # type: Final[int]
 # Keyword argument x=y in call, or keyword-only function arg
-ARG_NAMED = 3  # type: int
+ARG_NAMED = 3  # type: Final[int]
 # **arg argument
-ARG_STAR2 = 4  # type: int
+ARG_STAR2 = 4  # type: Final[int]
 # In an argument list, keyword-only and also optional
-ARG_NAMED_OPT = 5
+ARG_NAMED_OPT = 5  # type: Final[int]
 
 
 class CallExpr(Expression):
@@ -1891,9 +1891,9 @@ class TypeApplication(Expression):
 #
 # If T is contravariant in Foo[T], Foo[object] is a subtype of
 # Foo[int], but not vice versa.
-INVARIANT = 0  # type: int
-COVARIANT = 1  # type: int
-CONTRAVARIANT = 2  # type: int
+INVARIANT = 0  # type: Final[int]
+COVARIANT = 1  # type: Final[int]
+CONTRAVARIANT = 2  # type: Final[int]
 
 
 class TypeVarExpr(SymbolNode, Expression):
@@ -2223,7 +2223,7 @@ class TypeInfo(SymbolNode):
     FLAGS = [
         'is_abstract', 'is_enum', 'fallback_to_any', 'is_named_tuple',
         'is_newtype', 'is_protocol', 'runtime_protocol', 'is_final',
-    ]  # type: ClassVar[List[str]]
+    ]  # type: Final[List[str]]
 
     def __init__(self, names: 'SymbolTable', defn: ClassDef, module_name: str) -> None:
         """Initialize a TypeInfo."""
@@ -2484,9 +2484,9 @@ class FakeInfo(TypeInfo):
         raise AssertionError(object.__getattribute__(self, 'msg'))
 
 
-VAR_NO_INFO = FakeInfo('Var is lacking info')  # type: TypeInfo
-CLASSDEF_NO_INFO = FakeInfo('ClassDef is lacking info')  # type: TypeInfo
-FUNC_NO_INFO = FakeInfo('FuncBase for non-methods lack info')  # type: TypeInfo
+VAR_NO_INFO = FakeInfo('Var is lacking info')  # type: Final[TypeInfo]
+CLASSDEF_NO_INFO = FakeInfo('ClassDef is lacking info')  # type: Final[TypeInfo]
+FUNC_NO_INFO = FakeInfo('FuncBase for non-methods lack info')  # type: Final[TypeInfo]
 
 
 class TypeAlias(SymbolNode):
@@ -2879,7 +2879,7 @@ deserialize_map = {
     for key, obj in globals().items()
     if type(obj) is not FakeInfo
     and isinstance(obj, type) and issubclass(obj, SymbolNode) and obj is not SymbolNode
-}
+}  # type: Final
 
 
 def check_arg_kinds(arg_kinds: List[int], nodes: List[T], fail: Callable[[str, T], None]) -> None:

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -6,16 +6,16 @@ import sys
 from typing import Dict, List, Mapping, Optional, Pattern, Set, Tuple
 MYPY = False
 if MYPY:
-    from typing import ClassVar
+    from typing import ClassVar, Final
 
 from mypy import defaults
 from mypy.util import get_class_descriptors, replace_object_state
 
 
 class BuildType:
-    STANDARD = 0  # type: ClassVar[int]
-    MODULE = 1  # type: ClassVar[int]
-    PROGRAM_TEXT = 2  # type: ClassVar[int]
+    STANDARD = 0  # type: Final[int]
+    MODULE = 1  # type: Final[int]
+    PROGRAM_TEXT = 2  # type: Final[int]
 
 
 PER_MODULE_OPTIONS = {
@@ -47,11 +47,11 @@ PER_MODULE_OPTIONS = {
     "warn_no_return",
     "warn_return_any",
     "warn_unused_ignores",
-}
+}  # type: Final
 
 OPTIONS_AFFECTING_CACHE = ((PER_MODULE_OPTIONS |
                             {"quick_and_dirty", "platform", "bazel"})
-                           - {"debug_cache"})
+                           - {"debug_cache"})  # type: Final
 
 
 class Options:

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -6,7 +6,7 @@ import sys
 from typing import Dict, List, Mapping, Optional, Pattern, Set, Tuple
 MYPY = False
 if MYPY:
-    from typing import ClassVar, Final
+    from typing_extensions import Final
 
 from mypy import defaults
 from mypy.util import get_class_descriptors, replace_object_state

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -20,8 +20,9 @@ from mypy.types import (
 )
 from mypy.typevars import fill_typevars
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 
 # The names of the different functions that create classes or arguments.

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -20,21 +20,24 @@ from mypy.types import (
 )
 from mypy.typevars import fill_typevars
 
+if False:
+    from typing import Final
+
 
 # The names of the different functions that create classes or arguments.
 attr_class_makers = {
     'attr.s',
     'attr.attrs',
     'attr.attributes',
-}
+}  # type: Final
 attr_dataclass_makers = {
     'attr.dataclass',
-}
+}  # type: Final
 attr_attrib_makers = {
     'attr.ib',
     'attr.attrib',
     'attr.attr',
-}
+}  # type: Final
 
 
 class Converter:

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -12,8 +12,9 @@ from mypy.types import (
     CallableType, Instance, NoneTyp, Overloaded, TypeVarDef, TypeVarType,
 )
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 # The set of decorators that generate dataclasses.
 dataclass_makers = {

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -12,11 +12,14 @@ from mypy.types import (
     CallableType, Instance, NoneTyp, Overloaded, TypeVarDef, TypeVarType,
 )
 
+if False:
+    from typing import Final
+
 # The set of decorators that generate dataclasses.
 dataclass_makers = {
     'dataclass',
     'dataclasses.dataclass',
-}
+}  # type: Final
 
 
 class DataclassAttribute:

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -47,7 +47,9 @@ type_of_any_name_map = collections.OrderedDict([
     (TypeOfAny.implementation_artifact, "Implementation Artifact"),
 ])  # type: Final[collections.OrderedDict[int, str]]
 
-reporter_classes = {}  # type: Final[Dict[str, Tuple[Callable[[Reports, str], AbstractReporter], bool]]]
+ReporterClasses = Dict[str, Tuple[Callable[['Reports', str], 'AbstractReporter'], bool]]
+
+reporter_classes = {}  # type: Final[ReporterClasses]
 
 
 class Reports:

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -24,6 +24,9 @@ from mypy.traverser import TraverserVisitor
 from mypy.types import Type, TypeOfAny
 from mypy.version import __version__
 
+if False:
+    from typing import Final
+
 try:
     # mypyc doesn't properly handle import from of submodules that we
     # don't have stubs for, hence the hacky double import
@@ -41,9 +44,9 @@ type_of_any_name_map = collections.OrderedDict([
     (TypeOfAny.from_error, "Error"),
     (TypeOfAny.special_form, "Special Form"),
     (TypeOfAny.implementation_artifact, "Implementation Artifact"),
-])  # type: collections.OrderedDict[TypeOfAny, str]
+])  # type: Final[collections.OrderedDict[str, str]]
 
-reporter_classes = {}  # type: Dict[str, Tuple[Callable[[Reports, str], AbstractReporter], bool]]
+reporter_classes = {}  # type: Final[Dict[str, Tuple[Callable[[Reports, str], AbstractReporter], bool]]]
 
 
 class Reports:
@@ -163,7 +166,7 @@ class AnyExpressionsReporter(AbstractReporter):
     def __init__(self, reports: Reports, output_dir: str) -> None:
         super().__init__(reports, output_dir)
         self.counts = {}  # type: Dict[str, Tuple[int, int]]
-        self.any_types_counter = {}  # type: Dict[str, typing.Counter[TypeOfAny]]
+        self.any_types_counter = {}  # type: Dict[str, typing.Counter[str]]
         stats.ensure_dir_exists(output_dir)
 
     def on_file(self,
@@ -233,7 +236,7 @@ class AnyExpressionsReporter(AbstractReporter):
         self._write_out_report('any-exprs.txt', column_names, rows, total_row)
 
     def _report_types_of_anys(self) -> None:
-        total_counter = collections.Counter()  # type: typing.Counter[TypeOfAny]
+        total_counter = collections.Counter()  # type: typing.Counter[str]
         for counter in self.any_types_counter.values():
             for any_type, value in counter.items():
                 total_counter[any_type] += value
@@ -456,7 +459,7 @@ class MemoryXmlReporter(AbstractReporter):
     def _get_any_info_for_line(visitor: stats.StatisticsVisitor, lineno: int) -> str:
         if lineno in visitor.any_line_map:
             result = "Any Types on this line: "
-            counter = collections.Counter()  # type: typing.Counter[TypeOfAny]
+            counter = collections.Counter()  # type: typing.Counter[str]
             for typ in visitor.any_line_map[lineno]:
                 counter[typ.type_of_any] += 1
             for any_type, occurrences in counter.items():

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -44,7 +44,7 @@ type_of_any_name_map = collections.OrderedDict([
     (TypeOfAny.from_error, "Error"),
     (TypeOfAny.special_form, "Special Form"),
     (TypeOfAny.implementation_artifact, "Implementation Artifact"),
-])  # type: Final[collections.OrderedDict[str, str]]
+])  # type: Final[collections.OrderedDict[int, str]]
 
 reporter_classes = {}  # type: Final[Dict[str, Tuple[Callable[[Reports, str], AbstractReporter], bool]]]
 
@@ -166,7 +166,7 @@ class AnyExpressionsReporter(AbstractReporter):
     def __init__(self, reports: Reports, output_dir: str) -> None:
         super().__init__(reports, output_dir)
         self.counts = {}  # type: Dict[str, Tuple[int, int]]
-        self.any_types_counter = {}  # type: Dict[str, typing.Counter[str]]
+        self.any_types_counter = {}  # type: Dict[str, typing.Counter[int]]
         stats.ensure_dir_exists(output_dir)
 
     def on_file(self,
@@ -236,7 +236,7 @@ class AnyExpressionsReporter(AbstractReporter):
         self._write_out_report('any-exprs.txt', column_names, rows, total_row)
 
     def _report_types_of_anys(self) -> None:
-        total_counter = collections.Counter()  # type: typing.Counter[str]
+        total_counter = collections.Counter()  # type: typing.Counter[int]
         for counter in self.any_types_counter.values():
             for any_type, value in counter.items():
                 total_counter[any_type] += value
@@ -459,7 +459,7 @@ class MemoryXmlReporter(AbstractReporter):
     def _get_any_info_for_line(visitor: stats.StatisticsVisitor, lineno: int) -> str:
         if lineno in visitor.any_line_map:
             result = "Any Types on this line: "
-            counter = collections.Counter()  # type: typing.Counter[str]
+            counter = collections.Counter()  # type: typing.Counter[int]
             for typ in visitor.any_line_map[lineno]:
                 counter[typ.type_of_any] += 1
             for any_type, occurrences in counter.items():

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -24,8 +24,9 @@ from mypy.traverser import TraverserVisitor
 from mypy.types import Type, TypeOfAny
 from mypy.version import __version__
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 try:
     # mypyc doesn't properly handle import from of submodules that we

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -90,16 +90,18 @@ from mypy.semanal_enum import EnumCallAnalyzer
 from mypy.semanal_newtype import NewTypeAnalyzer
 from mypy.typestate import TypeState
 
+if False:
+    from typing import Final
 
 T = TypeVar('T')
 
 
 # Inferred truth value of an expression.
-ALWAYS_TRUE = 1
-MYPY_TRUE = 2  # True in mypy, False at runtime
-ALWAYS_FALSE = 3
-MYPY_FALSE = 4  # False in mypy, True at runtime
-TRUTH_VALUE_UNKNOWN = 5
+ALWAYS_TRUE = 1  # type: Final
+MYPY_TRUE = 2  # type: Final  # True in mypy, False at runtime
+ALWAYS_FALSE = 3  # type: Final
+MYPY_FALSE = 4  # type: Final  # False in mypy, True at runtime
+TRUTH_VALUE_UNKNOWN = 5  # type: Final
 
 inverted_truth_mapping = {
     ALWAYS_TRUE: ALWAYS_FALSE,
@@ -107,13 +109,13 @@ inverted_truth_mapping = {
     TRUTH_VALUE_UNKNOWN: TRUTH_VALUE_UNKNOWN,
     MYPY_TRUE: MYPY_FALSE,
     MYPY_FALSE: MYPY_TRUE,
-}
+}  # type: Final
 
 # Map from obsolete name to the current spelling.
 obsolete_name_mapping = {
     'typing.Function': 'typing.Callable',
     'typing.typevar': 'typing.TypeVar',
-}
+}  # type: Final
 
 # Hard coded type promotions (shared between all Python versions).
 # These add extra ad-hoc edges to the subtyping relation. For example,
@@ -122,14 +124,14 @@ obsolete_name_mapping = {
 TYPE_PROMOTIONS = {
     'builtins.int': 'builtins.float',
     'builtins.float': 'builtins.complex',
-}
+}  # type: Final
 
 # Hard coded type promotions for Python 3.
 #
 # Note that the bytearray -> bytes promotion is a little unsafe
 # as some functions only accept bytes objects. Here convenience
 # trumps safety.
-TYPE_PROMOTIONS_PYTHON3 = TYPE_PROMOTIONS.copy()
+TYPE_PROMOTIONS_PYTHON3 = TYPE_PROMOTIONS.copy()  # type: Final
 TYPE_PROMOTIONS_PYTHON3.update({
     'builtins.bytearray': 'builtins.bytes',
 })
@@ -139,7 +141,7 @@ TYPE_PROMOTIONS_PYTHON3.update({
 # These promotions are unsafe, but we are doing them anyway
 # for convenience and also for Python 3 compatibility
 # (bytearray -> str).
-TYPE_PROMOTIONS_PYTHON2 = TYPE_PROMOTIONS.copy()
+TYPE_PROMOTIONS_PYTHON2 = TYPE_PROMOTIONS.copy()  # type: Final
 TYPE_PROMOTIONS_PYTHON2.update({
     'builtins.str': 'builtins.unicode',
     'builtins.bytearray': 'builtins.str',
@@ -150,9 +152,9 @@ TYPE_PROMOTIONS_PYTHON2.update({
 # nested functions. In the first phase we add the function to the symbol table
 # but don't process body. In the second phase we process function body. This
 # way we can have mutually recursive nested functions.
-FUNCTION_BOTH_PHASES = 0  # Everything in one go
-FUNCTION_FIRST_PHASE_POSTPONE_SECOND = 1  # Add to symbol table but postpone body
-FUNCTION_SECOND_PHASE = 2  # Only analyze body
+FUNCTION_BOTH_PHASES = 0  # type: Final  # Everything in one go
+FUNCTION_FIRST_PHASE_POSTPONE_SECOND = 1  # type: Final  # Add to symbol table but postpone body
+FUNCTION_SECOND_PHASE = 2  # type: Final  # Only analyze body
 
 # Map from the full name of a missing definition to the test fixture (under
 # test-data/unit/fixtures/) that provides the definition. This is used for
@@ -167,7 +169,7 @@ SUGGESTED_TEST_FIXTURES = {
     'builtins.isinstance': 'isinstancelist.pyi',
     'builtins.property': 'property.pyi',
     'builtins.classmethod': 'classmethod.pyi',
-}
+}  # type: Final
 
 
 class SemanticAnalyzerPass2(NodeVisitor[None],

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -90,8 +90,9 @@ from mypy.semanal_enum import EnumCallAnalyzer
 from mypy.semanal_newtype import NewTypeAnalyzer
 from mypy.typestate import TypeState
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 T = TypeVar('T')
 

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -20,13 +20,18 @@ from mypy.options import Options
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy import join
 
+if False:
+    from typing import Final
+
 # Matches "_prohibited" in typing.py, but adds __annotations__, which works at runtime but can't
 # easily be supported in a static checker.
 NAMEDTUPLE_PROHIBITED_NAMES = ('__new__', '__init__', '__slots__', '__getnewargs__',
                                '_fields', '_field_defaults', '_field_types',
                                '_make', '_replace', '_asdict', '_source',
-                               '__annotations__')
+                               '__annotations__')  # type: Final
 
+NAMEDTUP_CLASS_ERROR = ('Invalid statement in NamedTuple definition; '
+                        'expected "field_name: field_type [= default]"')  # type: Final
 
 class NamedTupleAnalyzer:
     def __init__(self, options: Options, api: SemanticAnalyzerInterface) -> None:
@@ -56,8 +61,6 @@ class NamedTupleAnalyzer:
 
     def check_namedtuple_classdef(
             self, defn: ClassDef) -> Tuple[List[str], List[Type], Dict[str, Expression]]:
-        NAMEDTUP_CLASS_ERROR = ('Invalid statement in NamedTuple definition; '
-                                'expected "field_name: field_type [= default]"')
         if self.options.python_version < (3, 6):
             self.fail('NamedTuple class syntax is only supported in Python 3.6', defn)
             return [], [], {}

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -20,8 +20,9 @@ from mypy.options import Options
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy import join
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 # Matches "_prohibited" in typing.py, but adds __annotations__, which works at runtime but can't
 # easily be supported in a static checker.

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -34,6 +34,7 @@ NAMEDTUPLE_PROHIBITED_NAMES = ('__new__', '__init__', '__slots__', '__getnewargs
 NAMEDTUP_CLASS_ERROR = ('Invalid statement in NamedTuple definition; '
                         'expected "field_name: field_type [= default]"')  # type: Final
 
+
 class NamedTupleAnalyzer:
     def __init__(self, options: Options, api: SemanticAnalyzerInterface) -> None:
         self.options = options

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -11,16 +11,18 @@ from mypy.util import correct_relative_import
 from mypy.types import Type, FunctionLike, Instance
 from mypy.tvar_scope import TypeVarScope
 
+if False:
+    from typing import Final
 
 # Priorities for ordering of patches within the final "patch" phase of semantic analysis
 # (after pass 3):
 
 # Fix forward references (needs to happen first)
-PRIORITY_FORWARD_REF = 0
+PRIORITY_FORWARD_REF = 0  # type: Final
 # Fix fallbacks (does joins)
-PRIORITY_FALLBACKS = 1
+PRIORITY_FALLBACKS = 1  # type: Final
 # Checks type var values (does subtype checks)
-PRIORITY_TYPEVAR_VALUES = 2
+PRIORITY_TYPEVAR_VALUES = 2  # type: Final
 
 
 @trait

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -11,8 +11,9 @@ from mypy.util import correct_relative_import
 from mypy.types import Type, FunctionLike, Instance
 from mypy.tvar_scope import TypeVarScope
 
+MYPY = False
 if False:
-    from typing import Final
+    from typing_extensions import Final
 
 # Priorities for ordering of patches within the final "patch" phase of semantic analysis
 # (after pass 3):

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -19,8 +19,9 @@ from mypy.typeanal import check_for_explicit_any, has_any_from_unimported_type
 from mypy.messages import MessageBuilder
 from mypy import join
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 TPDICT_CLASS_ERROR = ('Invalid statement in TypedDict definition; '
                       'expected "field_name: field_type"')  # type: Final

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -19,6 +19,12 @@ from mypy.typeanal import check_for_explicit_any, has_any_from_unimported_type
 from mypy.messages import MessageBuilder
 from mypy import join
 
+if False:
+    from typing import Final
+
+TPDICT_CLASS_ERROR = ('Invalid statement in TypedDict definition; '
+                      'expected "field_name: field_type"')  # type: Final
+
 
 class TypedDictAnalyzer:
     def __init__(self,
@@ -97,8 +103,6 @@ class TypedDictAnalyzer:
                                  oldfields: Optional[List[str]] = None) -> Tuple[List[str],
                                                                                  List[Type],
                                                                                  Set[str]]:
-        TPDICT_CLASS_ERROR = ('Invalid statement in TypedDict definition; '
-                              'expected "field_name: field_type"')
         if self.options.python_version < (3, 6):
             self.fail('TypedDict class syntax is only supported in Python 3.6', defn)
             return [], [], set()

--- a/mypy/server/mergecheck.py
+++ b/mypy/server/mergecheck.py
@@ -5,8 +5,9 @@ from typing import Dict, List, Tuple
 from mypy.nodes import SymbolNode, Var, Decorator, FuncDef
 from mypy.server.objgraph import get_reachable_graph, get_path
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 
 # If True, print more verbose output on failure.

--- a/mypy/server/mergecheck.py
+++ b/mypy/server/mergecheck.py
@@ -5,9 +5,12 @@ from typing import Dict, List, Tuple
 from mypy.nodes import SymbolNode, Var, Decorator, FuncDef
 from mypy.server.objgraph import get_reachable_graph, get_path
 
+if False:
+    from typing import Final
+
 
 # If True, print more verbose output on failure.
-DUMP_MISMATCH_NODES = False
+DUMP_MISMATCH_NODES = False  # type: Final
 
 
 def check_consistency(o: object) -> None:

--- a/mypy/server/objgraph.py
+++ b/mypy/server/objgraph.py
@@ -5,8 +5,9 @@ from typing import List, Dict, Iterator, Tuple, Mapping
 import weakref
 import types
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 
 method_descriptor_type = type(object.__dir__)  # type: Final

--- a/mypy/server/objgraph.py
+++ b/mypy/server/objgraph.py
@@ -5,24 +5,27 @@ from typing import List, Dict, Iterator, Tuple, Mapping
 import weakref
 import types
 
+if False:
+    from typing import Final
 
-method_descriptor_type = type(object.__dir__)
-method_wrapper_type = type(object().__ne__)
-wrapper_descriptor_type = type(object.__ne__)
+
+method_descriptor_type = type(object.__dir__)  # type: Final
+method_wrapper_type = type(object().__ne__)  # type: Final
+wrapper_descriptor_type = type(object.__ne__)  # type: Final
 
 FUNCTION_TYPES = (types.BuiltinFunctionType,
                   types.FunctionType,
                   types.MethodType,
                   method_descriptor_type,
                   wrapper_descriptor_type,
-                  method_wrapper_type)
+                  method_wrapper_type)  # type: Final
 
 ATTR_BLACKLIST = {
     '__doc__',
     '__name__',
     '__class__',
     '__dict__',
-}
+}  # type: Final
 
 # Instances of these types can't have references to other objects
 ATOMIC_TYPE_BLACKLIST = {
@@ -32,7 +35,7 @@ ATOMIC_TYPE_BLACKLIST = {
     str,
     type(None),
     object,
-}
+}  # type: Final
 
 # Don't look at most attributes of these types
 COLLECTION_TYPE_BLACKLIST = {
@@ -40,12 +43,12 @@ COLLECTION_TYPE_BLACKLIST = {
     set,
     dict,
     tuple,
-}
+}  # type: Final
 
 # Don't return these objects
 TYPE_BLACKLIST = {
     weakref.ReferenceType,
-}
+}  # type: Final
 
 
 def isproperty(o: object, attr: str) -> bool:

--- a/mypy/server/trigger.py
+++ b/mypy/server/trigger.py
@@ -1,7 +1,8 @@
 """AST triggers that are used for fine-grained dependency handling."""
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 # Used as a suffix for triggers to handle "from m import *" dependencies (see also
 # make_wildcard_trigger)

--- a/mypy/server/trigger.py
+++ b/mypy/server/trigger.py
@@ -1,8 +1,12 @@
 """AST triggers that are used for fine-grained dependency handling."""
 
+if False:
+    from typing import Final
+
 # Used as a suffix for triggers to handle "from m import *" dependencies (see also
 # make_wildcard_trigger)
-WILDCARD_TAG = '[wildcard]'
+
+WILDCARD_TAG = '[wildcard]'  # type: Final
 
 
 def make_trigger(name: str) -> str:

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -141,8 +141,11 @@ from mypy.server.target import module_prefix, split_target
 from mypy.server.trigger import make_trigger, WILDCARD_TAG
 from mypy.typestate import TypeState
 
+if False:
+    from typing import Final
 
-MAX_ITER = 1000
+
+MAX_ITER = 1000  # type: Final
 
 
 class FineGrainedBuildManager:

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -141,8 +141,9 @@ from mypy.server.target import module_prefix, split_target
 from mypy.server.trigger import make_trigger, WILDCARD_TAG
 from mypy.typestate import TypeState
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 
 MAX_ITER = 1000  # type: Final

--- a/mypy/sharedparse.py
+++ b/mypy/sharedparse.py
@@ -1,7 +1,8 @@
 from typing import Optional
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 """Shared logic between our three mypy parser files."""
 

--- a/mypy/sharedparse.py
+++ b/mypy/sharedparse.py
@@ -1,5 +1,8 @@
 from typing import Optional
 
+if False:
+    from typing import Final
+
 """Shared logic between our three mypy parser files."""
 
 
@@ -36,14 +39,14 @@ _NON_BINARY_MAGIC_METHODS = {
     "__setitem__",
     "__str__",
     "__unicode__",
-}
+}  # type: Final
 
 MAGIC_METHODS_ALLOWING_KWARGS = {
     "__init__",
     "__init_subclass__",
     "__new__",
     "__call__",
-}
+}  # type: Final
 
 BINARY_MAGIC_METHODS = {
     "__add__",
@@ -90,13 +93,13 @@ BINARY_MAGIC_METHODS = {
     "__rxor__",
     "__sub__",
     "__xor__",
-}
+}  # type: Final
 
 assert not (_NON_BINARY_MAGIC_METHODS & BINARY_MAGIC_METHODS)
 
-MAGIC_METHODS = _NON_BINARY_MAGIC_METHODS | BINARY_MAGIC_METHODS
+MAGIC_METHODS = _NON_BINARY_MAGIC_METHODS | BINARY_MAGIC_METHODS  # type: Final
 
-MAGIC_METHODS_POS_ARGS_ONLY = MAGIC_METHODS - MAGIC_METHODS_ALLOWING_KWARGS
+MAGIC_METHODS_POS_ARGS_ONLY = MAGIC_METHODS - MAGIC_METHODS_ALLOWING_KWARGS  # type: Final
 
 
 def special_function_elide_names(name: str) -> bool:

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -18,8 +18,9 @@ from mypy.nodes import (
     MemberExpr, OpExpr, ComparisonExpr, IndexExpr, UnaryExpr, YieldFromExpr, RefExpr, ClassDef
 )
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 
 TYPE_EMPTY = 0  # type: Final

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -66,7 +66,7 @@ class StatisticsVisitor(TraverserVisitor):
 
         self.line_map = {}  # type: Dict[int, int]
 
-        self.type_of_any_counter = Counter()  # type: typing.Counter[str]
+        self.type_of_any_counter = Counter()  # type: typing.Counter[int]
         self.any_line_map = {}  # type: Dict[int, List[AnyType]]
 
         self.output = []  # type: List[str]

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -18,12 +18,15 @@ from mypy.nodes import (
     MemberExpr, OpExpr, ComparisonExpr, IndexExpr, UnaryExpr, YieldFromExpr, RefExpr, ClassDef
 )
 
+if False:
+    from typing import Final
 
-TYPE_EMPTY = 0
-TYPE_UNANALYZED = 1  # type of non-typechecked code
-TYPE_PRECISE = 2
-TYPE_IMPRECISE = 3
-TYPE_ANY = 4
+
+TYPE_EMPTY = 0  # type: Final
+TYPE_UNANALYZED = 1  # type: Final  # type of non-typechecked code
+TYPE_PRECISE = 2  # type: Final
+TYPE_IMPRECISE = 3  # type: Final
+TYPE_ANY = 4  # type: Final
 
 precision_names = [
     'empty',
@@ -31,7 +34,7 @@ precision_names = [
     'precise',
     'imprecise',
     'any',
-]
+]  # type: Final
 
 
 class StatisticsVisitor(TraverserVisitor):
@@ -63,7 +66,7 @@ class StatisticsVisitor(TraverserVisitor):
 
         self.line_map = {}  # type: Dict[int, int]
 
-        self.type_of_any_counter = Counter()  # type: typing.Counter[TypeOfAny]
+        self.type_of_any_counter = Counter()  # type: typing.Counter[str]
         self.any_line_map = {}  # type: Dict[int, List[AnyType]]
 
         self.output = []  # type: List[str]

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -73,6 +73,9 @@ from mypy.types import (
 )
 from mypy.visitor import NodeVisitor
 
+if False:
+    from typing import Final
+
 Options = NamedTuple('Options', [('pyversion', Tuple[int, int]),
                                  ('no_import', bool),
                                  ('doc_dir', str),
@@ -236,12 +239,12 @@ def generate_stub(path: str,
 
 # What was generated previously in the stub file. We keep track of these to generate
 # nicely formatted output (add empty line between non-empty classes, for example).
-EMPTY = 'EMPTY'
-FUNC = 'FUNC'
-CLASS = 'CLASS'
-EMPTY_CLASS = 'EMPTY_CLASS'
-VAR = 'VAR'
-NOT_IN_ALL = 'NOT_IN_ALL'
+EMPTY = 'EMPTY'  # type: Final
+FUNC = 'FUNC'  # type: Final
+CLASS = 'CLASS'  # type: Final
+EMPTY_CLASS = 'EMPTY_CLASS'  # type: Final
+VAR = 'VAR'  # type: Final
+NOT_IN_ALL = 'NOT_IN_ALL'  # type: Final
 
 
 class AnnotationPrinter(TypeStrVisitor):

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -73,8 +73,9 @@ from mypy.types import (
 )
 from mypy.visitor import NodeVisitor
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 Options = NamedTuple('Options', [('pyversion', Tuple[int, int]),
                                  ('no_import', bool),

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -24,8 +24,9 @@ from mypy.typestate import TypeState, SubtypeKind
 
 from mypy import experiments
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 
 # Flags for detected protocol members

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -24,11 +24,14 @@ from mypy.typestate import TypeState, SubtypeKind
 
 from mypy import experiments
 
+if False:
+    from typing import Final
+
 
 # Flags for detected protocol members
-IS_SETTABLE = 1
-IS_CLASSVAR = 2
-IS_CLASS_OR_STATIC = 3
+IS_SETTABLE = 1  # type: Final
+IS_CLASSVAR = 2  # type: Final
+IS_CLASS_OR_STATIC = 3  # type: Final
 
 
 TypeParameterChecker = Callable[[Type, Type, int], bool]

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -30,6 +30,8 @@ from mypy.plugin import Plugin, TypeAnalyzerPluginInterface, AnalyzeTypeContext
 from mypy.semanal_shared import SemanticAnalyzerCoreInterface
 from mypy import nodes, messages
 
+if False:
+    from typing import Final
 
 T = TypeVar('T')
 
@@ -40,7 +42,7 @@ type_constructors = {
     'typing.Tuple',
     'typing.Type',
     'typing.Union',
-}
+}  # type: Final
 
 ARG_KINDS_BY_CONSTRUCTOR = {
     'mypy_extensions.Arg': ARG_POS,
@@ -49,7 +51,7 @@ ARG_KINDS_BY_CONSTRUCTOR = {
     'mypy_extensions.DefaultNamedArg': ARG_NAMED_OPT,
     'mypy_extensions.VarArg': ARG_STAR,
     'mypy_extensions.KwArg': ARG_STAR2,
-}
+}  # type: Final
 
 
 def analyze_type_alias(node: Expression,

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -30,8 +30,9 @@ from mypy.plugin import Plugin, TypeAnalyzerPluginInterface, AnalyzeTypeContext
 from mypy.semanal_shared import SemanticAnalyzerCoreInterface
 from mypy import nodes, messages
 
-if False:
-    from typing import Final
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 T = TypeVar('T')
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -38,23 +38,23 @@ class TypeOfAny:
     This class describes different types of Any. Each 'Any' can be of only one type at a time.
     """
     # Was this Any type was inferred without a type annotation?
-    unannotated = 'unannotated'  # type: Final
+    unannotated = 1  # type: Final
     # Does this Any come from an explicit type annotation?
-    explicit = 'explicit'  # type: Final
+    explicit = 2  # type: Final
     # Does this come from an unfollowed import? See --disallow-any-unimported option
-    from_unimported_type = 'from_unimported_type'  # type: Final
+    from_unimported_type = 3  # type: Final
     # Does this Any type come from omitted generics?
-    from_omitted_generics = 'from_omitted_generics'  # type: Final
+    from_omitted_generics = 4  # type: Final
     # Does this Any come from an error?
-    from_error = 'from_error'  # type: Final
+    from_error = 5  # type: Final
     # Is this a type that can't be represented in mypy's type system? For instance, type of
     # call to NewType...). Even though these types aren't real Anys, we treat them as such.
     # Also used for variables named '_'.
-    special_form = 'special_form'  # type: Final
+    special_form = 6  # type: Final
     # Does this Any come from interaction with another Any?
-    from_another_any = 'from_another_any'  # type: Final
+    from_another_any = 7  # type: Final
     # Does this Any come from an implementation limitation/bug?
-    implementation_artifact = 'implementation_artifact'  # type: Final
+    implementation_artifact = 8  # type: Final
 
 
 def deserialize_type(data: Union[JsonDict, str]) -> 'Type':
@@ -318,7 +318,7 @@ class AnyType(Type):
     __slots__ = ('type_of_any', 'source_any', 'missing_import_name')
 
     def __init__(self,
-                 type_of_any: str,
+                 type_of_any: int,
                  source_any: Optional['AnyType'] = None,
                  missing_import_name: Optional[str] = None,
                  line: int = -1,
@@ -349,7 +349,7 @@ class AnyType(Type):
 
     def copy_modified(self,
                       # Mark with Bogus because _dummy is just an object (with type Any)
-                      type_of_any: Bogus[str] = _dummy,
+                      type_of_any: Bogus[int] = _dummy,
                       original_any: Bogus[Optional['AnyType']] = _dummy,
                       ) -> 'AnyType':
         if type_of_any is _dummy:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -310,7 +310,7 @@ class TypeList(Type):
         assert False, "Synthetic types don't serialize"
 
 
-_dummy = object()  # type: Any
+_dummy = object()  # type: Final[Any]
 
 
 class AnyType(Type):

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -10,7 +10,8 @@ from typing import (
 
 MYPY = False
 if MYPY:
-    from typing import ClassVar, Final
+    from typing import ClassVar
+    from typing_extensions import Final
 
 import mypy.nodes
 from mypy import experiments

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -7,7 +7,8 @@ from typing import Any, Dict, Set, Tuple, Optional
 
 MYPY = False
 if MYPY:
-    from typing import ClassVar, Final
+    from typing import ClassVar
+    from typing_extensions import Final
 from mypy.nodes import TypeInfo
 from mypy.types import Instance
 from mypy.server.trigger import make_trigger

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Set, Tuple, Optional
 
 MYPY = False
 if MYPY:
-    from typing import ClassVar
+    from typing import ClassVar, Final
 from mypy.nodes import TypeInfo
 from mypy.types import Instance
 from mypy.server.trigger import make_trigger
@@ -38,7 +38,7 @@ class TypeState:
     # instances of the given TypeInfo. The cache also keeps track of the specific
     # *kind* of subtyping relationship, which we represent as an arbitrary hashable tuple.
     # We need the caches, since subtype checks for structural types are very slow.
-    _subtype_caches = {}  # type: ClassVar[SubtypeCache]
+    _subtype_caches = {}  # type: Final[SubtypeCache]
 
     # This contains protocol dependencies generated after running a full build,
     # or after an update. These dependencies are special because:
@@ -59,13 +59,13 @@ class TypeState:
     # of type a.A to a function expecting something compatible with protocol p.P,
     # we'd have 'a.A' -> {'p.P', ...} in the map. This map is flushed after every incremental
     # update.
-    _attempted_protocols = {}  # type: ClassVar[Dict[str, Set[str]]]
+    _attempted_protocols = {}  # type: Final[Dict[str, Set[str]]]
     # We also snapshot protocol members of the above protocols. For example, if we pass
     # a value of type a.A to a function expecting something compatible with Iterable, we'd have
     # 'a.A' -> {'__iter__', ...} in the map. This map is also flushed after every incremental
     # update. This map is needed to only generate dependencies like <a.A.__iter__> -> <a.A>
     # instead of a wildcard to avoid unnecessarily invalidating classes.
-    _checked_against_members = {}  # type: ClassVar[Dict[str, Set[str]]]
+    _checked_against_members = {}  # type: Final[Dict[str, Set[str]]]
     # TypeInfos that appeared as a left type (subtype) in a subtype check since latest
     # dependency snapshot update. This is an optimisation for fine grained mode; during a full
     # run we only take a dependency snapshot at the very end, so this set will contain all
@@ -73,12 +73,12 @@ class TypeState:
     # dependencies generated from (typically) few TypeInfos that were subtype-checked
     # (i.e. appeared as r.h.s. in an assignment or an argument in a function call in
     # a re-checked target) during the update.
-    _rechecked_types = set()  # type: ClassVar[Set[TypeInfo]]
+    _rechecked_types = set()  # type: Final[Set[TypeInfo]]
 
     @classmethod
     def reset_all_subtype_caches(cls) -> None:
         """Completely reset all known subtype caches."""
-        cls._subtype_caches = {}
+        cls._subtype_caches.clear()
 
     @classmethod
     def reset_subtype_caches_for(cls, info: TypeInfo) -> None:
@@ -112,9 +112,9 @@ class TypeState:
     def reset_protocol_deps(cls) -> None:
         """Reset dependencies after a full run or before a daemon shutdown."""
         cls.proto_deps = {}
-        cls._attempted_protocols = {}
-        cls._checked_against_members = {}
-        cls._rechecked_types = set()
+        cls._attempted_protocols.clear()
+        cls._checked_against_members.clear()
+        cls._rechecked_types.clear()
 
     @classmethod
     def record_protocol_subtype_check(cls, left_type: TypeInfo, right_type: TypeInfo) -> None:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -11,7 +11,8 @@ from typing import TypeVar, List, Tuple, Optional, Dict, Sequence
 
 MYPY = False
 if MYPY:
-    from typing import Type, Final
+    from typing import Type
+    from typing_extensions import Final
 
 T = TypeVar('T')
 

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -11,13 +11,13 @@ from typing import TypeVar, List, Tuple, Optional, Dict, Sequence
 
 MYPY = False
 if MYPY:
-    from typing import Type
+    from typing import Type, Final
 
 T = TypeVar('T')
 
-ENCODING_RE = re.compile(br'([ \t\v]*#.*(\r\n?|\n))??[ \t\v]*#.*coding[:=][ \t]*([-\w.]+)')
+ENCODING_RE = re.compile(br'([ \t\v]*#.*(\r\n?|\n))??[ \t\v]*#.*coding[:=][ \t]*([-\w.]+)')  # type: Final
 
-default_python2_interpreter = ['python2', 'python', '/usr/bin/python', 'C:\\Python27\\python.exe']
+default_python2_interpreter = ['python2', 'python', '/usr/bin/python', 'C:\\Python27\\python.exe']  # type: Final
 
 
 def split_module_names(mod_name: str) -> List[str]:
@@ -121,7 +121,7 @@ PASS_TEMPLATE = """<?xml version="1.0" encoding="utf-8"?>
   <testcase classname="mypy" file="mypy" line="1" name="mypy" time="{time:.3f}">
   </testcase>
 </testsuite>
-"""
+"""  # type: Final
 
 FAIL_TEMPLATE = """<?xml version="1.0" encoding="utf-8"?>
 <testsuite errors="0" failures="1" name="mypy" skips="0" tests="1" time="{time:.3f}">
@@ -129,7 +129,7 @@ FAIL_TEMPLATE = """<?xml version="1.0" encoding="utf-8"?>
     <failure message="mypy produced messages">{text}</failure>
   </testcase>
 </testsuite>
-"""
+"""  # type: Final
 
 ERROR_TEMPLATE = """<?xml version="1.0" encoding="utf-8"?>
 <testsuite errors="1" failures="0" name="mypy" skips="0" tests="1" time="{time:.3f}">
@@ -137,7 +137,7 @@ ERROR_TEMPLATE = """<?xml version="1.0" encoding="utf-8"?>
     <error message="mypy produced errors">{text}</error>
   </testcase>
 </testsuite>
-"""
+"""  # type: Final
 
 
 def write_junit_xml(dt: float, serious: bool, messages: List[str], path: str) -> None:
@@ -193,7 +193,7 @@ def correct_relative_import(cur_mod_id: str,
     return cur_mod_id + (("." + target) if target else ""), ok
 
 
-fields_cache = {}  # type: Dict[Type[object], List[str]]
+fields_cache = {}  # type: Final[Dict[Type[object], List[str]]]
 
 
 def get_class_descriptors(cls: 'Type[object]') -> Sequence[str]:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -16,9 +16,11 @@ if MYPY:
 
 T = TypeVar('T')
 
-ENCODING_RE = re.compile(br'([ \t\v]*#.*(\r\n?|\n))??[ \t\v]*#.*coding[:=][ \t]*([-\w.]+)')  # type: Final
+ENCODING_RE = \
+    re.compile(br'([ \t\v]*#.*(\r\n?|\n))??[ \t\v]*#.*coding[:=][ \t]*([-\w.]+)')  # type: Final
 
-default_python2_interpreter = ['python2', 'python', '/usr/bin/python', 'C:\\Python27\\python.exe']  # type: Final
+default_python2_interpreter = \
+    ['python2', 'python', '/usr/bin/python', 'C:\\Python27\\python.exe']  # type: Final
 
 
 def split_module_names(mod_name: str) -> List[str]:


### PR DESCRIPTION
This adds `Final` annotations to most module-level and class-level names I have found. Some of these are important to get performance boost after compiling with mypyc, other are just added for completeness. This PR also makes two runtime changes:
* `TypeOfAny` switched from an enum to using small integer constants, this is important for performance
* `binder.BindableTypes` is now inlined in two `isinstance()` checks. I first made it `Final`, but then realised that it will be much more efficient to just inline it, since these `isinstance()` checks are in a hot code path.

Note: after a new version of `typing_extensions` is released on PyPI we can skip all the `if MYPY: ...` checks.

The corresponding mypyc PR is https://github.com/JukkaL/mypyc/pull/439