### PR TITLE
Add support for building with mypyc to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,11 +73,12 @@ package_data += find_package_data(os.path.join('mypy', 'typeshed'), ['*.py', '*.
 
 package_data += find_package_data(os.path.join('mypy', 'xml'), ['*.xsd', '*.xslt', '*.css'])
 
+USE_MYPYC = False
 if len(sys.argv) > 1 and sys.argv[1] == '--use-mypyc':
     sys.argv.pop(1)
     USE_MYPYC = True
-else:
-    USE_MYPYC = False
+if os.getenv('MYPY_USE_MYPYC', None) == '1':
+    USE_MYPYC = True
 
 if USE_MYPYC:
     MYPYC_BLACKLIST = (

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ if USE_MYPYC:
     del sys.modules['mypy.git']
 
     from mypyc.build import mypycify, MypycifyBuildExt
-    opt_level = os.getenv('MYPYC_OPT_LEVEL', '')
+    opt_level = os.getenv('MYPYC_OPT_LEVEL', '3')
     ext_modules = mypycify(mypyc_targets, ['--config-file=mypy_bootstrap.ini'], opt_level)
     cmdclass['build_ext'] = MypycifyBuildExt
 else:

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ class CustomPythonBuild(build_py):
         build_py.run(self)
 
 
-cmdclass={'build_py': CustomPythonBuild}
+cmdclass = {'build_py': CustomPythonBuild}
 
 package_data = ['py.typed']
 
@@ -99,7 +99,7 @@ if USE_MYPYC:
     # Start with all the .py files
     all_real_pys = [x for x in everything if not x.startswith('typeshed/')]
     # Strip out anything in our blacklist
-    mypyc_targets = [x for x in all_real_pys if not x in MYPYC_BLACKLIST]
+    mypyc_targets = [x for x in all_real_pys if x not in MYPYC_BLACKLIST]
     # Strip out any test code
     mypyc_targets = [x for x in mypyc_targets if not x.startswith('test/')]
     # ... and add back in the one test module we need

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ if USE_MYPYC:
     opt_level = os.getenv('MYPYC_OPT_LEVEL', '3')
     ext_modules = mypycify(mypyc_targets, ['--config-file=mypy_bootstrap.ini'], opt_level)
     cmdclass['build_ext'] = MypycifyBuildExt
+    description += " (mypyc-compiled version)"
 else:
     ext_modules = []
 

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ package_data += find_package_data(os.path.join('mypy', 'typeshed'), ['*.py', '*.
 package_data += find_package_data(os.path.join('mypy', 'xml'), ['*.xsd', '*.xslt', '*.css'])
 
 USE_MYPYC = False
+# To compile with mypyc, a mypyc checkout must be present on the PYTHONPATH
 if len(sys.argv) > 1 and sys.argv[1] == '--use-mypyc':
     sys.argv.pop(1)
     USE_MYPYC = True

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,15 @@ if USE_MYPYC:
     # Fix the paths to be full
     mypyc_targets = [os.path.join('mypy', x) for x in mypyc_targets]
 
+    # This bit is super unfortunate: we want to use the mypy packaged
+    # with mypyc. It will arrange for the path to be setup so it can
+    # find it, but we've already imported parts, so we remove the
+    # modules that we've imported already, which will let the right
+    # versions be imported by mypyc.
+    del sys.modules['mypy']
+    del sys.modules['mypy.version']
+    del sys.modules['mypy.git']
+
     from mypyc.build import mypycify, MypycifyBuildExt
     opt_level = os.getenv('MYPYC_OPT_LEVEL', '')
     ext_modules = mypycify(mypyc_targets, ['--config-file=mypy_bootstrap.ini'], opt_level)


### PR DESCRIPTION
The mypyc build defaults to off and can be enabled either by passing `--use-mypyc` or setting `MYPY_USE_MYPYC=1` as an environment variable.

A demo of building and releasing mypyc-compiled mypy builds using this is at https://github.com/msullivan/travis-testing