### PR TITLE
Fix version number from 0.640-dev to 0.640+dev

### DIFF
--- a/mypy/version.py
+++ b/mypy/version.py
@@ -1,7 +1,7 @@
 import os
 from mypy import git
 
-__version__ = '0.640-dev'
+__version__ = '0.640+dev'
 base_version = __version__
 
 mypy_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
PEP 440 is of the opinion that 0.640-dev is an invalid version number,
and recent pip versions whine about it.

Also, using '-dev' is a mismatch with the code later in the file that
checks whether the version name ends in '+dev' and so prevents the git
revision from being added.