### PR TITLE
Update imported Vars in the third pass

### DIFF
--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -85,7 +85,7 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
                     continue
                 if mod_name != self.sem.cur_mod_id:  # imported
                     new_sym = self.sem.modules[mod_name].names.get(name)
-                    if isinstance(new_sym.node, (TypeInfo, TypeAlias)):
+                    if new_sym and isinstance(new_sym.node, (TypeInfo, TypeAlias)):
                         # This Var was replaced with a class (like named tuple)
                         # or alias, update this.
                         sym.node = new_sym.node

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -77,8 +77,12 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
     def update_imported_vars(self) -> None:
         for sym in self.cur_mod_node.names.values():
             if sym and isinstance(sym.node, Var):
-                var = sym.node
-                mod_name, _, name = var.fullname().rpartition('.')
+                fullname = sym.node.fullname()
+                if '.' not in fullname:
+                    continue
+                mod_name, _, name = fullname.rpartition('.')
+                if mod_name not in self.sem.modules:
+                    continue
                 if mod_name != self.sem.cur_mod_id:  # imported
                     new_sym = self.sem.modules[mod_name].names.get(name)
                     if isinstance(new_sym.node, (TypeInfo, TypeAlias)):

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5123,6 +5123,50 @@ def outer() -> None:
 [out]
 [out2]
 
+[case testRecursiveAliasImported]
+import a
+[file a.py]
+import lib
+x: int
+[file a.py.2]
+import lib
+x: lib.A
+reveal_type(x)
+[file lib.pyi]
+from typing import List
+from other import B
+A = List[B]  # type: ignore
+[file other.pyi]
+from typing import List
+from lib import A
+B = List[A]
+[builtins fixtures/list.pyi]
+[out]
+[out2]
+tmp/a.py:3: error: Revealed type is 'builtins.list[builtins.list[builtins.list[Any]]]'
+
+[case testRecursiveNamedTupleTypedDict]
+import a
+[file a.py]
+import lib
+x: int
+[file a.py.2]
+import lib
+x: lib.A
+reveal_type(x.x['x'])
+[file lib.pyi]
+from typing import NamedTuple
+from other import B
+A = NamedTuple('A', [('x', B)])  # type: ignore
+[file other.pyi]
+from mypy_extensions import TypedDict
+from lib import A
+B = TypedDict('B', {'x': A})
+[builtins fixtures/dict.pyi]
+[out]
+[out2]
+tmp/a.py:3: error: Revealed type is 'Tuple[TypedDict('other.B', {'x': Any}), fallback=lib.A]'
+
 [case testFollowImportSkipNotInvalidatedOnPresent]
 # flags: --follow-imports=skip
 # cmd: mypy -m main

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -691,6 +691,23 @@ my_eval(A([B(1), B(2)])) # OK
 [builtins fixtures/isinstancelist.pyi]
 [out]
 
+[case testNamedTupleImportCycle]
+import b
+[file a.py]
+class C:
+    pass
+
+from b import tp
+x: tp
+reveal_type(x.x)  # E: Revealed type is 'builtins.int'
+
+[file b.py]
+from a import C
+from typing import NamedTuple
+
+tp = NamedTuple('tp', [('x', int)])
+[out]
+
 [case testUnsafeOverlappingNamedTuple]
 from typing import NamedTuple
 

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -427,6 +427,56 @@ reveal_type(D().meth(1))  # E: Revealed type is 'Union[__main__.D*, builtins.int
 [builtins fixtures/classmethod.pyi]
 [out]
 
+[case testAliasInImportCycle]
+# cmd: mypy -m t t2
+[file t.py]
+MYPY = False
+if MYPY:
+    from t2 import A
+x: A
+[file t2.py]
+import t
+from typing import Callable
+A = Callable[[], None]
+[builtins fixtures/bool.pyi]
+[out]
+
+[case testAliasInImportCycle2]
+import a
+[file a.pyi]
+from b import Parameter
+
+class _ParamType:
+    p: Parameter
+
+_ConvertibleType = _ParamType
+
+def convert_type(ty: _ConvertibleType):
+    ...
+
+[file b.pyi]
+from a import _ConvertibleType
+
+class Parameter:
+    type: _ConvertibleType
+[out]
+
+[case testNamedTupleImportCycle]
+import b
+[file a.py]
+class C:
+    pass
+
+from b import tp
+x: tp
+
+[file b.py]
+from a import C
+from typing import NamedTuple
+
+tp = NamedTuple('tp', [('x', int)])
+[out]
+
 [case testFlexibleAlias1]
 from typing import TypeVar, List, Tuple
 from mypy_extensions import FlexibleAlias

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -461,22 +461,6 @@ class Parameter:
     type: _ConvertibleType
 [out]
 
-[case testNamedTupleImportCycle]
-import b
-[file a.py]
-class C:
-    pass
-
-from b import tp
-x: tp
-
-[file b.py]
-from a import C
-from typing import NamedTuple
-
-tp = NamedTuple('tp', [('x', int)])
-[out]
-
 [case testFlexibleAlias1]
 from typing import TypeVar, List, Tuple
 from mypy_extensions import FlexibleAlias

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1375,3 +1375,21 @@ def f(x: a.N) -> None:
 [out]
 tmp/b.py:4: error: Revealed type is 'TypedDict('a.N', {'a': builtins.str})'
 tmp/b.py:5: error: Revealed type is 'builtins.str'
+
+[case testTypedDictImportCycle]
+import b
+[file a.py]
+class C:
+    pass
+
+from b import tp
+x: tp
+reveal_type(x['x'])  # E: Revealed type is 'builtins.int'
+
+[file b.py]
+from a import C
+from mypy_extensions import TypedDict
+
+tp = TypedDict('tp', {'x': int})
+[builtins fixtures/dict.pyi]
+[out]


### PR DESCRIPTION
Fixes #5275 
Fixes #4498 
Fixes #4442 

This is a simple band-aid fix for `Invalid type` in import cycles where type aliases, named tuples, or typed dicts appear.

Ideally we could refactor semantic analysis to have deferred nodes, but this is _much_ harder.
