### PR TITLE
Defer subclass methods if superclass has not been analyzed

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -336,7 +336,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         assert not self.current_node_deferred
         # TODO: Handle __all__
 
-    def defer_node(self, node: DeferredNodeType, enclosing_class: TypeInfo) -> None:
+    def defer_node(self, node: DeferredNodeType, enclosing_class: Optional[TypeInfo]) -> None:
         if self.errors.type_name:
             type_name = self.errors.type_name[-1]
         else:
@@ -1290,6 +1290,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     #      necessary; now it's "just in case"
                     return self.check_method_override_for_base_with_name(defn, method,
                                                                          base)
+        return False
 
     def check_method_override_for_base_with_name(
             self, defn: Union[FuncBase, Decorator], name: str, base: TypeInfo) -> bool:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1263,7 +1263,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
     def check_method_or_accessor_override_for_base(self, defn: Union[FuncBase, Decorator],
                                                    base: TypeInfo) -> bool:
-        """Check if method definition is compatible with a base class."""
+        """Check if method definition is compatible with a base class.
+
+        Return True if the node was deferred because one of the corresponding
+        superclass nodes is not ready.
+        """
         if base:
             name = defn.name()
             base_attr = base.names.get(name)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -317,7 +317,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             del self.cur_mod_node
             del self.globals
 
-    def refresh_partial(self, node: Union[MypyFile, FuncItem, OverloadedFuncDef],
+    def refresh_partial(self, node: Union[MypyFile, FuncItem, OverloadedFuncDef, Decorator],
                         patches: List[Tuple[int, Callable[[], None]]]) -> None:
         """Refresh a stale target in fine-grained incremental mode."""
         self.patches = patches

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -73,7 +73,7 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
         del self.cur_mod_node
         self.patches = []
 
-    def refresh_partial(self, node: Union[MypyFile, FuncItem, OverloadedFuncDef],
+    def refresh_partial(self, node: Union[MypyFile, FuncItem, OverloadedFuncDef, Decorator],
                         patches: List[Tuple[int, Callable[[], None]]]) -> None:
         """Refresh a stale target in fine-grained incremental mode."""
         self.options = self.sem.options

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -52,7 +52,7 @@ from mypy.types import CallableType
 from mypy.typestate import TypeState
 
 
-def strip_target(node: Union[MypyFile, FuncItem, OverloadedFuncDef]) -> None:
+def strip_target(node: Union[MypyFile, FuncItem, OverloadedFuncDef, Decorator]) -> None:
     """Reset a fine-grained incremental target to state after semantic analysis pass 1.
 
     NOTE: Currently we opportunistically only reset changes that are known to otherwise

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -1058,7 +1058,7 @@ def is_verbose(manager: BuildManager) -> bool:
 
 
 def target_from_node(module: str,
-                     node: Union[FuncDef, MypyFile, OverloadedFuncDef, LambdaExpr]
+                     node: Union[FuncDef, MypyFile, OverloadedFuncDef, LambdaExpr, Decorator]
                      ) -> Optional[str]:
     """Return the target name corresponding to a deferred node.
 
@@ -1079,4 +1079,5 @@ def target_from_node(module: str,
         else:
             return '%s.%s' % (module, node.name())
     else:
-        assert False, "Lambda expressions can't be deferred in fine-grained incremental mode"
+        assert False, "Lambda expressions and decorators can't be deferred in" \
+                      " fine-grained incremental mode"

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -5117,3 +5117,39 @@ class C:
     def x(self) -> int: pass
 [builtins fixtures/property.pyi]
 [out]
+
+[case testCyclicDecorator]
+import b
+[file a.py]
+import b
+import c
+
+class A(b.B):
+    @c.deco
+    def meth(self) -> int: ...
+[file b.py]
+import a
+import c
+
+class B:
+    @c.deco
+    def meth(self) -> int: ...
+[file c.py]
+from typing import TypeVar, Tuple, Callable
+T = TypeVar('T')
+def deco(f: Callable[..., T]) -> Callable[..., Tuple[T, int]]: ...
+[out]
+
+[case testCyclicOverride]
+import a
+[file b.py]
+import a
+class Sub(a.Base):
+    def x(self) -> int: pass
+
+[file a.py]
+import b
+class Base:
+    def __init__(self):
+        self.x = 1
+[out]


### PR DESCRIPTION
Fixes #5560 
Fixes #5548 

Half of the PR is updating various function signatures to also accept `Decorator`. I still prohibit `Decorator` as a target in fine-grained mode, but I think there should be no harm to defer it in normal mode.