### PR TITLE
Don't duplicate functions for typevar value restrictions under mypyc

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1243,7 +1243,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if tvar.values:
                 subst.append([(tvar.id, value)
                               for value in tvar.values])
-        if subst:
+        # Make a copy of the function to check for each combination of
+        # value restricted type variables. (Except when running mypyc,
+        # where we need one canonical version of the function.)
+        if subst and not self.options.mypyc:
             result = []  # type: List[Tuple[FuncItem, CallableType]]
             for substitutions in itertools.product(*subst):
                 mapping = dict(substitutions)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -39,6 +39,7 @@ PER_MODULE_OPTIONS = {
     "ignore_errors",
     "ignore_missing_imports",
     "local_partial_types",
+    "mypyc",
     "no_implicit_optional",
     "show_none_errors",
     "strict_boolean",
@@ -172,6 +173,10 @@ class Options:
         self.cache_fine_grained = False
         # Read cache files in fine-grained incremental mode (cache must include dependencies)
         self.use_fine_grained_cache = False
+
+        # Tune certain behaviors when being used as a front-end to mypyc. Set per-module
+        # in modules being compiled. Not in the config file or command line.
+        self.mypyc = False
 
         # Paths of user plugins
         self.plugins = []  # type: List[str]

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2235,6 +2235,13 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         for t in values + [upper_bound]:
             check_for_explicit_any(t, self.options, self.is_typeshed_stub_file, self.msg,
                                    context=s)
+
+        # mypyc suppresses making copies of a function to check each
+        # possible type, so set the upper bound to Any to prevent that
+        # from causing errors.
+        if values and self.options.mypyc:
+            upper_bound = AnyType(TypeOfAny.implementation_artifact)
+
         # Yes, it's a valid type variable definition! Add it to the symbol table.
         node = self.lookup(name, s)
         assert node is not None


### PR DESCRIPTION
mypyc wants one canonical version of a function that is typechecked,
so make that happen.

Adds a per-module mypyc option that should be set by mypyc on modules
that are being compiled.

This allows fixing a mypyc issue that is breaking self-compilation right now.