### PR TITLE
Fix meet for tuple with instance

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -490,16 +490,18 @@ class TypeMeetVisitor(TypeVisitor[Type]):
             # TODO: What if the fallbacks are different?
             return TupleType(items, t.fallback)
         # meet(Tuple[t1, t2, <...>], Tuple[s, ...]) == Tuple[meet(t1, s), meet(t2, s), <...>].
-        elif (isinstance(self.s, Instance) and
-              (self.s.type.fullname() == 'builtins.tuple' or is_proper_subtype(t, self.s))
-              and self.s.args):
-            return t.copy_modified(items=[meet_types(it, self.s.args[0]) for it in t.items])
+        elif isinstance(self.s, Instance):
+            # meet(Tuple[t1, t2, <...>], Tuple[s, ...]) == Tuple[meet(t1, s), meet(t2, s), <...>].
+            if self.s.type.fullname() == 'builtins.tuple' and self.s.args:
+                return t.copy_modified(items=[meet_types(it, self.s.args[0]) for it in t.items])
+            elif is_proper_subtype(t, self.s):
+                # A named tuple that inherits from a normal class
+                return t
         elif (isinstance(self.s, Instance) and t.fallback.type == self.s.type):
             # Uh oh, a broken named tuple type (https://github.com/python/mypy/issues/3016).
             # Do something reasonable until that bug is fixed.
             return t
-        else:
-            return self.default(self.s)
+        return self.default(self.s)
 
     def visit_typeddict_type(self, t: TypedDictType) -> Type:
         if isinstance(self.s, TypedDictType):

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -489,7 +489,6 @@ class TypeMeetVisitor(TypeVisitor[Type]):
                 items.append(self.meet(t.items[i], self.s.items[i]))
             # TODO: What if the fallbacks are different?
             return TupleType(items, t.fallback)
-        # meet(Tuple[t1, t2, <...>], Tuple[s, ...]) == Tuple[meet(t1, s), meet(t2, s), <...>].
         elif isinstance(self.s, Instance):
             # meet(Tuple[t1, t2, <...>], Tuple[s, ...]) == Tuple[meet(t1, s), meet(t2, s), <...>].
             if self.s.type.fullname() == 'builtins.tuple' and self.s.args:

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -496,10 +496,6 @@ class TypeMeetVisitor(TypeVisitor[Type]):
             elif is_proper_subtype(t, self.s):
                 # A named tuple that inherits from a normal class
                 return t
-        elif (isinstance(self.s, Instance) and t.fallback.type == self.s.type):
-            # Uh oh, a broken named tuple type (https://github.com/python/mypy/issues/3016).
-            # Do something reasonable until that bug is fixed.
-            return t
         return self.default(self.s)
 
     def visit_typeddict_type(self, t: TypedDictType) -> Type:

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -56,7 +56,10 @@ class TypeFixture:
         self.f3i = self.make_type_info('F3', is_abstract=True, mro=[self.fi])
 
         # Class TypeInfos
-        self.std_tuplei = self.make_type_info('builtins.tuple')        # class tuple
+        self.std_tuplei = self.make_type_info('builtins.tuple',
+                                              mro=[self.oi],
+                                              typevars=['T'],
+                                              variances=[COVARIANT])   # class tuple
         self.type_typei = self.make_type_info('builtins.type')         # class type
         self.functioni = self.make_type_info('builtins.function')  # function TODO
         self.ai = self.make_type_info('A', mro=[self.oi])              # class A
@@ -99,7 +102,7 @@ class TypeFixture:
                                              variances=[variance])
 
         # Instance types
-        self.std_tuple = Instance(self.std_tuplei, [])        # tuple
+        self.std_tuple = Instance(self.std_tuplei, [self.anyt])        # tuple
         self.type_type = Instance(self.type_typei, [])        # type
         self.function = Instance(self.functioni, [])  # function TODO
         self.a = Instance(self.ai, [])          # A

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -732,3 +732,19 @@ class CallableTuple(Thing):
 
 o = CallableTuple('hello ', 12)
 o()
+
+[case testNamedTupleSubclassMulti]
+from typing import NamedTuple
+
+class Base:
+    pass
+class BaseTuple(NamedTuple):
+    value: float
+class MyTuple(BaseTuple, Base):
+    pass
+
+def f(o: Base) -> None:
+    if isinstance(o, MyTuple):
+        reveal_type(o.value)  # E: Revealed type is 'builtins.float'
+[builtins fixtures/isinstance.pyi]
+[out]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5640

Since generic tuple types are not supported, `map_instance_to_supertype` is not needed here. This solution doesn't work for general multiple inheritance, for example the test case will not work with `if isinstance(o, BaseTuple)`, but this is exactly the same as for e.g. two instance types.