### PR TITLE
Fully analyze named tuple subclasses in third pass

### DIFF
--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -609,7 +609,8 @@ class ForwardReferenceResolver(TypeTranslator):
                                                       line=t.line)).accept(self)
         if self.check_recursion(t):
             # We also need to break a potential cycle with normal (non-synthetic) instance types.
-            return Instance(t.type, [AnyType(TypeOfAny.from_error)] * len(t.type.defn.type_vars))
+            return Instance(t.type, [AnyType(TypeOfAny.from_error)] * len(t.type.defn.type_vars),
+                            line=t.line)
         return super().visit_instance(t)
 
     def visit_type_var(self, t: TypeVarType) -> Type:

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -352,7 +352,9 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
                     new_bases.append(alt_base)
             node.bases = new_bases
             if node.tuple_type:
-                node.tuple_type = transform(node.tuple_type)
+                new_tuple_type = transform(node.tuple_type)
+                assert isinstance(new_tuple_type, TupleType)
+                node.tuple_type = new_tuple_type
 
     def transform_types_in_lvalue(self, lvalue: Lvalue,
                                   transform: Callable[[Type], Type]) -> None:

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -700,8 +700,8 @@ class Command(NamedTuple):  # type: ignore
 class HelpCommand(Command):
     pass
 
-HelpCommand(subcommands=[])
-reveal_type(HelpCommand)  # E: Revealed type is 'def (subcommands: builtins.list[Any]) -> Tuple[builtins.list[Tuple[builtins.list[Any], fallback=__main__.Command]], fallback=__main__.HelpCommand]'
+hc = HelpCommand(subcommands=[])
+reveal_type(hc)  # E: Revealed type is 'Tuple[builtins.list[Tuple[builtins.list[Any], fallback=__main__.Command]], fallback=__main__.HelpCommand]'
 [builtins fixtures/list.pyi]
 [out]
 

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -691,6 +691,20 @@ my_eval(A([B(1), B(2)])) # OK
 [builtins fixtures/isinstancelist.pyi]
 [out]
 
+[case testSubclassOfRecursiveNamedTuple]
+from typing import List, NamedTuple
+
+class Command(NamedTuple):  # type: ignore
+    subcommands: List['Command']
+
+class HelpCommand(Command):
+    pass
+
+HelpCommand(subcommands=[])
+reveal_type(HelpCommand)  # E: Revealed type is 'def (subcommands: builtins.list[Any]) -> Tuple[builtins.list[Tuple[builtins.list[Any], fallback=__main__.Command]], fallback=__main__.HelpCommand]'
+[builtins fixtures/list.pyi]
+[out]
+
 [case testUnsafeOverlappingNamedTuple]
 from typing import NamedTuple
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1342,6 +1342,21 @@ reveal_type(m['director']['name']) # E: Revealed type is 'builtins.str'
 [builtins fixtures/dict.pyi]
 [out]
 
+[case testSubclassOfRecursiveTypedDict]
+from typing import List
+from mypy_extensions import TypedDict
+
+class Command(TypedDict):  # type: ignore
+    subcommands: List['Command']
+
+class HelpCommand(Command):
+    pass
+
+hc = HelpCommand(subcommands=[])
+reveal_type(hc)  # E: Revealed type is 'TypedDict('__main__.HelpCommand', {'subcommands': builtins.list[TypedDict('__main__.Command', {'subcommands': builtins.list[Any]})]})'
+[builtins fixtures/list.pyi]
+[out]
+
 [case testTypedDictForwardAsUpperBound]
 from typing import TypeVar, Generic
 from mypy_extensions import TypedDict


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5195

The fix is straightforward, previously `tuple_type` was not analyzed for named tuple subclasses.
I also copy the line number for instance types when transforming them.