### PR TITLE
Make classmethod's first argument be Type[...]

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -867,8 +867,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             self.fail(msg, defn)
                             if note:
                                 self.note(note, defn)
-                        if defn.is_class and isinstance(arg_type, CallableType):
-                            arg_type.is_classmethod_class = True
                     elif isinstance(arg_type, TypeVarType):
                         # Refuse covariant parameter type variables
                         # TODO: check recursively for inner type variables

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -14,7 +14,7 @@ from mypy.nodes import (
 from mypy.tvar_scope import TypeVarScope
 from mypy.types import (
     Type, Instance, CallableType, TypedDictType, UnionType, NoneTyp, TypeVarType,
-    AnyType, TypeList, UnboundType, TypeOfAny
+    AnyType, TypeList, UnboundType, TypeOfAny, TypeType,
 )
 from mypy.messages import MessageBuilder
 from mypy.options import Options
@@ -93,7 +93,7 @@ class SemanticAnalyzerPluginInterface:
         raise NotImplementedError
 
     @abstractmethod
-    def class_type(self, info: TypeInfo) -> Type:
+    def class_type(self, self_type: Type) -> Type:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -495,23 +495,6 @@ def _add_init(ctx: 'mypy.plugin.ClassDefContext', attributes: List[Attribute],
         [attribute.argument(ctx) for attribute in attributes if attribute.init],
         NoneTyp()
     )
-    for stmt in ctx.cls.defs.body:
-        # The type of classmethods will be wrong because it's based on the parent's __init__.
-        # Set it correctly.
-        if isinstance(stmt, Decorator) and stmt.func.is_class:
-            func_type = stmt.func.type
-            if isinstance(func_type, CallableType):
-                func_type.arg_types[0] = ctx.api.class_type(ctx.cls.info)
-        if isinstance(stmt, OverloadedFuncDef) and stmt.is_class:
-            func_type = stmt.type
-            if isinstance(func_type, Overloaded):
-                class_type = ctx.api.class_type(ctx.cls.info)
-                for item in func_type.items():
-                    item.arg_types[0] = class_type
-                if stmt.impl is not None:
-                    assert isinstance(stmt.impl, Decorator)
-                    if isinstance(stmt.impl.func.type, CallableType):
-                        stmt.impl.func.type.arg_types[0] = class_type
 
 
 class MethodAdder:

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -92,23 +92,6 @@ class DataclassTransformer:
                 args=[attr.to_argument(info) for attr in attributes if attr.is_in_init],
                 return_type=NoneTyp(),
             )
-            for stmt in self._ctx.cls.defs.body:
-                # Fix up the types of classmethods since, by default,
-                # they will be based on the parent class' init.
-                if isinstance(stmt, Decorator) and stmt.func.is_class:
-                    func_type = stmt.func.type
-                    if isinstance(func_type, CallableType):
-                        func_type.arg_types[0] = self._ctx.api.class_type(self._ctx.cls.info)
-                if isinstance(stmt, OverloadedFuncDef) and stmt.is_class:
-                    func_type = stmt.type
-                    if isinstance(func_type, Overloaded):
-                        class_type = ctx.api.class_type(ctx.cls.info)
-                        for item in func_type.items():
-                            item.arg_types[0] = class_type
-                        if stmt.impl is not None:
-                            assert isinstance(stmt.impl, Decorator)
-                            if isinstance(stmt.impl.func.type, CallableType):
-                                stmt.impl.func.type.arg_types[0] = class_type
 
         # Add an eq method, but only if the class doesn't already have one.
         if decorator_arguments['eq'] and info.get('__eq__') is None:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -706,7 +706,6 @@ class CallableType(FunctionLike):
                  column: int = -1,
                  is_ellipsis_args: bool = False,
                  implicit: bool = False,
-                 is_classmethod_class: bool = False,
                  special_sig: Optional[str] = None,
                  from_type_type: bool = False,
                  bound_args: Sequence[Optional[Type]] = (),
@@ -730,7 +729,6 @@ class CallableType(FunctionLike):
         self.variables = variables
         self.is_ellipsis_args = is_ellipsis_args
         self.implicit = implicit
-        self.is_classmethod_class = is_classmethod_class
         self.special_sig = special_sig
         self.from_type_type = from_type_type
         if not bound_args:
@@ -780,7 +778,6 @@ class CallableType(FunctionLike):
             is_ellipsis_args=(
                 is_ellipsis_args if is_ellipsis_args is not _dummy else self.is_ellipsis_args),
             implicit=implicit if implicit is not _dummy else self.implicit,
-            is_classmethod_class=self.is_classmethod_class,
             special_sig=special_sig if special_sig is not _dummy else self.special_sig,
             from_type_type=from_type_type if from_type_type is not _dummy else self.from_type_type,
             bound_args=bound_args if bound_args is not _dummy else self.bound_args,
@@ -815,9 +812,6 @@ class CallableType(FunctionLike):
 
     def is_type_obj(self) -> bool:
         return self.fallback.type.is_metaclass()
-
-    def is_concrete_type_obj(self) -> bool:
-        return self.is_type_obj() and self.is_classmethod_class
 
     def type_object(self) -> mypy.nodes.TypeInfo:
         assert self.is_type_obj()
@@ -990,7 +984,6 @@ class CallableType(FunctionLike):
                 'variables': [v.serialize() for v in self.variables],
                 'is_ellipsis_args': self.is_ellipsis_args,
                 'implicit': self.implicit,
-                'is_classmethod_class': self.is_classmethod_class,
                 'bound_args': [(None if t is None else t.serialize())
                                for t in self.bound_args],
                 'def_extras': dict(self.def_extras),
@@ -1009,7 +1002,6 @@ class CallableType(FunctionLike):
                             variables=[TypeVarDef.deserialize(v) for v in data['variables']],
                             is_ellipsis_args=data['is_ellipsis_args'],
                             implicit=data['implicit'],
-                            is_classmethod_class=data['is_classmethod_class'],
                             bound_args=[(None if t is None else deserialize_type(t))
                                         for t in data['bound_args']],
                             def_extras=data['def_extras']

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -367,6 +367,19 @@ A([1], '2')  # E: Cannot infer type argument 1 of "A"
 
 [builtins fixtures/list.pyi]
 
+[case testAttrsGenericClassmethod]
+from typing import TypeVar, Generic, Optional
+import attr
+T = TypeVar('T')
+@attr.s(auto_attribs=True)
+class A(Generic[T]):
+    x: Optional[T]
+    @classmethod
+    def clsmeth(cls) -> None:
+       reveal_type(cls)  # E: Revealed type is 'Type[__main__.A[T`1]]'
+
+[builtins fixtures/classmethod.pyi]
+
 [case testAttrsForwardReference]
 import attr
 @attr.s(auto_attribs=True)
@@ -416,7 +429,7 @@ class A:
     b: str = attr.ib()
     @classmethod
     def new(cls) -> A:
-       reveal_type(cls)  # E: Revealed type is 'def (a: builtins.int, b: builtins.str) -> __main__.A'
+       reveal_type(cls)  # E: Revealed type is 'Type[__main__.A]'
        return cls(6, 'hello')
     @classmethod
     def bad(cls) -> A:
@@ -451,7 +464,7 @@ class A:
 
     @classmethod
     def foo(cls, x: Union[int, str]) -> Union[int, str]:
-        reveal_type(cls)            # E: Revealed type is 'def (a: Any, b: Any =) -> __main__.A'
+        reveal_type(cls)            # E: Revealed type is 'Type[__main__.A]'
         reveal_type(cls.other())    # E: Revealed type is 'builtins.str'
         return x
 

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -388,7 +388,7 @@ def f(a: Type[N]):
     a()
 [builtins fixtures/list.pyi]
 [out]
-main:8: error: Unsupported type Type["N"]
+main:9: error: Too few arguments for "N"
 
 [case testNewNamedTupleWithDefaults]
 # flags: --fast-parser --python-version 3.6
@@ -587,7 +587,7 @@ class XMethBad(NamedTuple):
 class MagicalFields(NamedTuple):
     x: int
     def __slots__(self) -> None: pass  # E: Cannot overwrite NamedTuple attribute "__slots__"
-    def __new__(cls) -> None: pass  # E: Name '__new__' already defined (possibly by an import)
+    def __new__(cls) -> None: pass  # E: Cannot overwrite NamedTuple attribute "__new__"
     def _source(self) -> int: pass  # E: Cannot overwrite NamedTuple attribute "_source"
     __annotations__ = {'x': float}  # E: NamedTuple field name cannot start with an underscore: __annotations__ \
         # E: Invalid statement in NamedTuple definition; expected "field_name: field_type [= default]" \
@@ -640,7 +640,7 @@ class HasClassMethod(NamedTuple):
 
     @classmethod
     def new(cls, f: str) -> 'HasClassMethod':
-        reveal_type(cls)  # E: Revealed type is 'def (x: builtins.str) -> Tuple[builtins.str, fallback=__main__.HasClassMethod]'
+        reveal_type(cls)  # E: Revealed type is 'Type[Tuple[builtins.str, fallback=__main__.HasClassMethod]]'
         reveal_type(HasClassMethod)  # E: Revealed type is 'def (x: builtins.str) -> Tuple[builtins.str, fallback=__main__.HasClassMethod]'
         return cls(x=f)
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -349,7 +349,11 @@ class A:
 T = TypeVar('T')
 class B(Generic[T]):
     def __new__(cls, foo: T) -> 'B[T]':
-        return object.__new__(cls)
+        x = object.__new__(cls)
+        # object.__new__ doesn't have a great type :(
+        reveal_type(x)  # E: Revealed type is 'Any'
+        return x
+
 [builtins fixtures/__new__.pyi]
 
 [case testInnerFunctionNotOverriding]
@@ -5131,14 +5135,42 @@ class C:
 [builtins fixtures/property.pyi]
 [out]
 
-[case testClassMethodBeforeInit]
-class Foo(object):
+[case testClassMethodBeforeInit1]
+class Foo:
     @classmethod
-    def bar(cls):
-        # type: () -> Foo
+    def bar(cls) -> Foo:
         return cls("bar")
 
-    def __init__(self, baz):
-        # type: (str) -> None
+    def __init__(self, baz: str) -> None:
         self.baz = baz
+[builtins fixtures/classmethod.pyi]
+
+[case testClassMethodBeforeInit2]
+class Foo:
+    @classmethod
+    def bar(cls) -> Foo:
+        return cls(Bar())
+
+    def __init__(self, baz: 'Bar') -> None:
+        self.baz = baz
+
+class Bar: pass
+[builtins fixtures/classmethod.pyi]
+
+[case testClassMethodBeforeInit3]
+from typing import overload
+class Foo:
+    @classmethod
+    @overload
+    def bar(cls, x: int) -> Foo: ...
+    @classmethod
+    @overload
+    def bar(cls, x: str) -> Foo: ...
+    @classmethod
+    def bar(cls, x: object) -> Foo:
+        return cls(x)
+
+    def __init__(self, baz: object) -> None:
+        self.baz = baz
+
 [builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -339,6 +339,19 @@ class B(A):
     def __new__(cls) -> int:
         return 1
 
+[case testOverride__new__AndCallObject]
+from typing import TypeVar, Generic
+
+class A:
+    def __new__(cls, x: int) -> 'A':
+        return object.__new__(cls)
+
+T = TypeVar('T')
+class B(Generic[T]):
+    def __new__(cls, foo: T) -> 'B[T]':
+        return object.__new__(cls)
+[builtins fixtures/__new__.pyi]
+
 [case testInnerFunctionNotOverriding]
 class A:
     def f(self) -> int: pass
@@ -1828,7 +1841,7 @@ class Num1:
 
 class Num2(Num1):
     @overload
-    def __add__(self, other: Num2) -> Num2: ...  
+    def __add__(self, other: Num2) -> Num2: ...
     @overload
     def __add__(self, other: Num1) -> Num2: ...
     def __add__(self, other): pass
@@ -3001,7 +3014,7 @@ def f(a: Type[N]):
     a()
 [builtins fixtures/list.pyi]
 [out]
-main:3: error: Unsupported type Type["N"]
+main:4: error: Too few arguments for "N"
 
 [case testTypeUsingTypeCJoin]
 from typing import Type
@@ -5117,3 +5130,15 @@ class C:
     def x(self) -> int: pass
 [builtins fixtures/property.pyi]
 [out]
+
+[case testClassMethodBeforeInit]
+class Foo(object):
+    @classmethod
+    def bar(cls):
+        # type: () -> Foo
+        return cls("bar")
+
+    def __init__(self, baz):
+        # type: (str) -> None
+        self.baz = baz
+[builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -249,7 +249,7 @@ class A:
 
     @classmethod
     def foo(cls, x: Union[int, str]) -> Union[int, str]:
-        reveal_type(cls)            # E: Revealed type is 'def (a: builtins.int, b: builtins.str) -> __main__.A'
+        reveal_type(cls)            # E: Revealed type is 'Type[__main__.A]'
         reveal_type(cls.other())    # E: Revealed type is 'builtins.str'
         return x
 
@@ -421,6 +421,23 @@ s: str = a.bar()  # E: Incompatible types in assignment (expression has type "in
 
 [builtins fixtures/list.pyi]
 
+[case testDataclassGenericsClassmethod]
+# flags: --python-version 3.6
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar('T')
+
+@dataclass
+class A(Generic[T]):
+  x: T
+
+  @classmethod
+  def foo(cls) -> None:
+      reveal_type(cls)            # E: Revealed type is 'Type[__main__.A[T`1]]'
+
+[builtins fixtures/classmethod.pyi]
+
 [case testDataclassesForwardRefs]
 from dataclasses import dataclass
 
@@ -466,3 +483,16 @@ app.rating
 app.database_name  # E: "SpecializedApplication" has no attribute "database_name"
 
 [builtins fixtures/list.pyi]
+
+[case testDataclassFactory]
+from typing import Type, TypeVar
+from dataclasses import dataclass
+
+T = TypeVar('T', bound='A')
+
+@dataclass
+class A:
+    @classmethod
+    def make(cls: Type[T]) -> T:
+        return cls()
+[builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -434,7 +434,9 @@ class A(Generic[T]):
 
   @classmethod
   def foo(cls) -> None:
-      reveal_type(cls)            # E: Revealed type is 'Type[__main__.A[T`1]]'
+      reveal_type(cls)  # E: Revealed type is 'Type[__main__.A[T`1]]'
+      reveal_type(cls(1))  # E: Revealed type is '__main__.A[builtins.int*]'
+      reveal_type(cls('wooooo'))  # E: Revealed type is '__main__.A[builtins.str*]'
 
 [builtins fixtures/classmethod.pyi]
 
@@ -494,5 +496,7 @@ T = TypeVar('T', bound='A')
 class A:
     @classmethod
     def make(cls: Type[T]) -> T:
+        reveal_type(cls)  # E: Revealed type is 'Type[T`-1]'
+        reveal_type(cls())  # E: Revealed type is 'T`-1'
         return cls()
 [builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4072,7 +4072,7 @@ class Wrapper:
 
     @classmethod    # E: Overloaded function implementation cannot produce return type of signature 1
     def foo(cls, x: Union[int, str]) -> str:
-        reveal_type(cls)          # E: Revealed type is 'def () -> __main__.Wrapper'
+        reveal_type(cls)          # E: Revealed type is 'Type[__main__.Wrapper]'
         reveal_type(cls.other())  # E: Revealed type is 'builtins.str'
         return "..."
 

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -345,11 +345,11 @@ class D:
 
 class E:
     def __new__(cls) -> E:
-        reveal_type(cls)  # E: Revealed type is 'def () -> __main__.E'
+        reveal_type(cls)  # E: Revealed type is 'Type[__main__.E]'
         return cls()
 
     def __init_subclass__(cls) -> None:
-        reveal_type(cls)  # E: Revealed type is 'def () -> __main__.E'
+        reveal_type(cls)  # E: Revealed type is 'Type[__main__.E]'
 
 [case testSelfTypePropertyUnion]
 from typing import Union

--- a/test-data/unit/fixtures/__new__.pyi
+++ b/test-data/unit/fixtures/__new__.pyi
@@ -1,9 +1,11 @@
 # builtins stub with object.__new__
 
+from typing import Any
+
 class object:
     def __init__(self) -> None: pass
 
-    def __new__(cls): pass
+    def __new__(cls) -> Any: pass
 
 class type:
     def __init__(self, x) -> None: pass

--- a/test-data/unit/semanal-classes.test
+++ b/test-data/unit/semanal-classes.test
@@ -470,7 +470,7 @@ MypyFile:1(
         Args(
           Var(cls)
           Var(z))
-        def (cls: def () -> __main__.A, z: builtins.int) -> builtins.str
+        def (cls: Type[__main__.A], z: builtins.int) -> builtins.str
         Class
         Block:3(
           PassStmt:3())))))
@@ -490,7 +490,7 @@ MypyFile:1(
         f
         Args(
           Var(cls))
-        def (cls: def () -> __main__.A) -> builtins.str
+        def (cls: Type[__main__.A]) -> builtins.str
         Class
         Block:3(
           PassStmt:3())))))


### PR DESCRIPTION
Currently the first argument to `__new__` and classmethods is a
callable type that is constructed during semantic analysis by
typechecker code (!) that looks for the `__init__`/`__new__` methods.

This causes a number of problems, including not being able to call
`object.__new__` in a subclass's `__new__` if it took arguments
(#4190) and giving the wrong type if `__init__` appeared after the
class method (#1727).

Taking a `Type` instead lets us solve those problems, and postpone
computing the callable version of the type until typechecking if it is
needed.

This also lets us drop a bunch of plugin code that tries to fix up the
types of its cls arguments post-hoc, sometimes incorrectly (#5263).

Fixes #1727.
Fixes #4190.
Fixes #5263.