### PR TITLE
Fix bug with inferring bad arguments to overloads

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -627,7 +627,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 callee = self.infer_function_type_arguments(
                     callee, args, arg_kinds, formal_to_actual, context)
 
-            arg_types = self.infer_arg_types_in_context2(
+            arg_types = self.infer_arg_types_in_context(
                 callee, args, arg_kinds, formal_to_actual)
 
             self.check_argument_count(callee, arg_types, arg_kinds,
@@ -655,13 +655,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 callee = callee.copy_modified(ret_type=ret_type)
             return callee.ret_type, callee
         elif isinstance(callee, Overloaded):
-            # Type check arguments in empty context. They will be checked again
-            # later in a context derived from the signature; these types are
-            # only used to pick a signature variant.
-            self.msg.disable_errors()
-            arg_types = self.infer_arg_types_in_context(None, args)
-            self.msg.enable_errors()
-
+            arg_types = self.infer_arg_types_in_empty_context(args)
             return self.check_overload_call(callee=callee,
                                             args=args,
                                             arg_types=arg_types,
@@ -672,7 +666,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                             context=context,
                                             arg_messages=arg_messages)
         elif isinstance(callee, AnyType) or not self.chk.in_checked_function():
-            self.infer_arg_types_in_context(None, args)
+            self.infer_arg_types_in_empty_context(args)
             if isinstance(callee, AnyType):
                 return (AnyType(TypeOfAny.from_another_any, source_any=callee),
                         AnyType(TypeOfAny.from_another_any, source_any=callee))
@@ -744,38 +738,24 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         self.msg.unsupported_type_type(item, context)
         return AnyType(TypeOfAny.from_error)
 
-    def infer_arg_types_in_context(self, callee: Optional[CallableType],
-                                   args: List[Expression]) -> List[Type]:
-        """Infer argument expression types using a callable type as context.
+    def infer_arg_types_in_empty_context(self, args: List[Expression]) -> List[Type]:
+        """Infer argument expression types in an empty context.
 
-        For example, if callee argument 2 has type List[int], infer the
-        argument expression with List[int] type context.
+        In short, we basically recurse on each argument without considering
+        in what context the argument was called.
         """
         # TODO Always called with callee as None, i.e. empty context.
         res = []  # type: List[Type]
 
-        fixed = len(args)
-        if callee:
-            fixed = min(fixed, callee.max_fixed_args())
-
-        ctx = None
-        for i, arg in enumerate(args):
-            if i < fixed:
-                if callee and i < len(callee.arg_types):
-                    ctx = callee.arg_types[i]
-                arg_type = self.accept(arg, ctx)
-            else:
-                if callee and callee.is_var_arg:
-                    arg_type = self.accept(arg, callee.arg_types[-1])
-                else:
-                    arg_type = self.accept(arg)
+        for arg in args:
+            arg_type = self.accept(arg)
             if has_erased_component(arg_type):
                 res.append(NoneTyp())
             else:
                 res.append(arg_type)
         return res
 
-    def infer_arg_types_in_context2(
+    def infer_arg_types_in_context(
             self, callee: CallableType, args: List[Expression], arg_kinds: List[int],
             formal_to_actual: List[List[int]]) -> List[Type]:
         """Infer argument expression types using a callable type as context.
@@ -859,7 +839,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             # inferred again later.
             self.msg.disable_errors()
 
-            arg_types = self.infer_arg_types_in_context2(
+            arg_types = self.infer_arg_types_in_context(
                 callee_type, args, arg_kinds, formal_to_actual)
 
             self.msg.enable_errors()
@@ -933,7 +913,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 inferred_args[i] = None
         callee_type = self.apply_generic_arguments(callee_type, inferred_args, context)
 
-        arg_types = self.infer_arg_types_in_context2(
+        arg_types = self.infer_arg_types_in_context(
             callee_type, args, arg_kinds, formal_to_actual)
 
         inferred_args = infer_function_type_arguments(

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4873,3 +4873,36 @@ def g(name: str) -> int:
 
 reveal_type(f)  # E: Revealed type is 'def (name: builtins.str) -> builtins.int'
 reveal_type(g)  # E: Revealed type is 'def (name: builtins.str) -> builtins.int'
+
+[case testOverloadBadArgumentsInferredToAny1]
+from typing import Union, Any, overload
+
+def bar(x: int) -> Union[int, Any]: ...
+
+@overload
+def foo(x: str) -> None: ...
+@overload
+def foo(x: int) -> None: ...
+def foo(x) -> None: pass
+
+foo(bar('lol'))  # E: Argument 1 to "bar" has incompatible type "str"; expected "int"
+
+[case testOverloadBadArgumentsInferredToAny2]
+from typing import Union, Iterable, Tuple, TypeVar, Generic, overload, Any
+
+class A:
+    def foo(self) -> Iterable[int]: pass
+
+def bar(x: int) -> Union[A, int]: ...
+
+_T = TypeVar('_T')
+
+@overload
+def foo() -> None: ...
+@overload
+def foo(iterable: Iterable[_T]) -> None: ...
+def foo(iterable = None) -> None: pass
+
+foo(bar('lol').foo())  # E: Argument 1 to "bar" has incompatible type "str"; expected "int" \
+                       # E: Item "int" of "Union[A, int]" has no attribute "foo"
+


### PR DESCRIPTION
Currently, it seems that when checking overloads, mypy starts by inferring the argument types in an empty context and swallows any errors generated in the process.

Mostly likely what the old overload implementation did next was recheck the arguments against the selected overload variant, regenerating any errors as necessary.

However, in the new overload implementation, it's unclear if we consistently do the same thing, mostly due to how we slice and dice the arguments to do things like union math.

This pull request does the low-effort thing and just removes the error suppression.

This pull request also does some unrelated clean-up -- apparently, the `callee` argument to 'infer_arg_types_in_context` is always 'None'.

Fixes https://github.com/python/mypy/issues/5659.