### PR TITLE
Fix crash on overriding class level type alias

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -868,6 +868,10 @@ class MessageBuilder:
                 ' to Union' if isinstance(item, UnionType) else '')
         self.fail('The type alias{} is invalid in runtime context'.format(kind), ctx)
 
+    def cannot_overide_alias(self, name: str, base: str, ctx: Context) -> None:
+        self.fail('Cannot override type alias "{}" defined'
+                  ' in base class "{}"'.format(name, base), ctx)
+
     def could_not_infer_type_arguments(self, callee_type: CallableType, n: int,
                                        context: Context) -> None:
         callee_name = callable_name(callee_type)

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -611,3 +611,33 @@ except E as e:
     reveal_type(e)  # E: Revealed type is '__main__.E'
 [builtins fixtures/exception.pyi]
 [out]
+
+[case testNoOverrideAliasInSubclassMethod]
+from typing import Any, Callable
+
+class Parent:
+    foo = Callable[..., int]
+
+class Child(Parent):
+    def foo(self, val: int) -> int: ...  # E: Cannot override type alias "foo" defined in base class "Parent"
+[out]
+
+[case testNoOverrideAliasInSubclassVar]
+from typing import Any, Callable
+
+class Parent:
+    foo = Callable[..., int]
+
+class Child(Parent):
+    foo: Callable[..., int]  # E: Cannot override type alias "foo" defined in base class "Parent"
+[out]
+
+[case testNoOverrideAliasInSubclassAlias]
+from typing import Any, Callable
+
+class Parent:
+    foo = Callable[..., int]
+
+class Child(Parent):
+    foo = Callable[..., int]  # E: Cannot override type alias "foo" defined in base class "Parent"
+[out]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5425

The solution is to just prohibit overriding type aliases in subclass. In some sense they are implicitly final, because we need to know them statically (they can be used as type sin annotations).

The assert that was triggered missed two cases for superclass node: `TypeAlias` and `Var`, for `Var` I just return `Any` since there are no way to determine type if deferring failed (currently there is fixed number of type-checking passes).