### PR TITLE
Do a submodule update in `trigger_wheel_build.sh`

### DIFF
--- a/misc/trigger_wheel_build.sh
+++ b/misc/trigger_wheel_build.sh
@@ -15,6 +15,7 @@ COMMIT=$(git rev-parse HEAD)
 cd build/mypy
 git fetch
 git checkout $COMMIT
+git submodule update
 pip install -r test-requirements.txt
 V=$(python3 -m mypy --version)
 V=$(echo "$V" | cut -d" " -f2)


### PR DESCRIPTION
Do a submodule update after checking out the mypy commit we are switching to,
since having a not updated submodule can cause the version to be reported as
`-dirty`.