### PR TITLE
Make return type implicitly None for type checked __init__ and __init_subclass__

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -406,10 +406,10 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                             add_symbol = False
                     if add_symbol:
                         self.type.names[defn.name()] = SymbolTableNode(MDEF, defn)
-                if (defn.type is not None and
-                        defn.name() in ('__init__', '__init_subclass__') and
-                        isinstance(defn.type.ret_type, AnyType)):
-                    defn.type = defn.type.copy_modified(ret_type=NoneTyp())
+                if defn.type is not None and defn.name() in ('__init__', '__init_subclass__'):
+                    assert isinstance(defn.type, CallableType)
+                    if isinstance(defn.type.ret_type, AnyType):
+                        defn.type = defn.type.copy_modified(ret_type=NoneTyp())
                 self.prepare_method_signature(defn, self.type)
             elif self.is_func_scope():
                 # Nested function

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -68,8 +68,7 @@ from mypy.messages import CANNOT_ASSIGN_TO_TYPE, MessageBuilder
 from mypy.types import (
     FunctionLike, UnboundType, TypeVarDef, TupleType, UnionType, StarType, function_type,
     CallableType, Overloaded, Instance, Type, AnyType,
-    TypeTranslator, TypeOfAny, TypeType,
-)
+    TypeTranslator, TypeOfAny, TypeType, NoneTyp)
 from mypy.nodes import implicit_module_attrs
 from mypy.typeanal import (
     TypeAnalyser, analyze_type_alias, no_subscript_builtin_alias,
@@ -407,6 +406,10 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                             add_symbol = False
                     if add_symbol:
                         self.type.names[defn.name()] = SymbolTableNode(MDEF, defn)
+                if (defn.type is not None and
+                        defn.name() in ('__init__', '__init_subclass__') and
+                        isinstance(defn.type.ret_type, AnyType)):
+                    defn.type = defn.type.copy_modified(ret_type=NoneTyp())
                 self.prepare_method_signature(defn, self.type)
             elif self.is_func_scope():
                 # Nested function

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -68,7 +68,8 @@ from mypy.messages import CANNOT_ASSIGN_TO_TYPE, MessageBuilder
 from mypy.types import (
     FunctionLike, UnboundType, TypeVarDef, TupleType, UnionType, StarType, function_type,
     CallableType, Overloaded, Instance, Type, AnyType,
-    TypeTranslator, TypeOfAny, TypeType, NoneTyp)
+    TypeTranslator, TypeOfAny, TypeType, NoneTyp,
+)
 from mypy.nodes import implicit_module_attrs
 from mypy.typeanal import (
     TypeAnalyser, analyze_type_alias, no_subscript_builtin_alias,

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -578,6 +578,18 @@ class A:
     def __init__(self, x: int): pass
 [out]
 
+[case testDecoratedConstructorWithImplicitReturnValueType]
+import typing
+from typing import Callable
+
+def deco(fn: Callable) -> Callable:
+    return fn
+
+class A:
+    @deco
+    def __init__(self, x: int): pass
+[out]
+
 [case testInitSubclassWithReturnValueType]
 import typing
 class A:
@@ -589,6 +601,18 @@ main:3: error: The return type of "__init_subclass__" must be None
 import typing
 class A:
     def __init_subclass__(cls, x: int=1): pass
+[out]
+
+[case testDecoratedInitSubclassWithImplicitReturnValueType]
+import typing
+from typing import Callable
+
+def deco(fn: Callable) -> Callable:
+    return fn
+
+class A:
+    @deco
+    def __init_subclass__(self, x: int=1): pass
 [out]
 
 [case testGlobalFunctionInitWithReturnType]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -590,6 +590,19 @@ class A:
     def __init__(self, x: int): pass
 [out]
 
+[case testOverloadedConstructorWithImplicitReturnValueType]
+from foo import *
+[file foo.pyi]
+from typing import overload
+class Foo:
+    @overload
+    def __init__(self, a: int):
+        pass
+
+    @overload
+    def __init__(self, a: str):
+        pass
+
 [case testInitSubclassWithReturnValueType]
 import typing
 class A:
@@ -614,6 +627,19 @@ class A:
     @deco
     def __init_subclass__(cls, x: int=1): pass
 [out]
+
+[case testOverloadedConstructorWithImplicitReturnValueType]
+from foo import *
+[file foo.pyi]
+from typing import overload
+class Foo:
+    @overload
+    def __init_subclass__(cls, a: int):
+        pass
+
+    @overload
+    def __init_subclass__(cls, a: str):
+        pass
 
 [case testGlobalFunctionInitWithReturnType]
 import typing

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -577,7 +577,6 @@ import typing
 class A:
     def __init__(self, x: int): pass
 [out]
-main:3: error: The return type of "__init__" must be None
 
 [case testInitSubclassWithReturnValueType]
 import typing
@@ -591,7 +590,6 @@ import typing
 class A:
     def __init_subclass__(cls, x: int=1): pass
 [out]
-main:3: error: The return type of "__init_subclass__" must be None
 
 [case testGlobalFunctionInitWithReturnType]
 import typing

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -628,7 +628,7 @@ class A:
     def __init_subclass__(cls, x: int=1): pass
 [out]
 
-[case testOverloadedConstructorWithImplicitReturnValueType]
+[case testOverloadedInitSubclassWithImplicitReturnValueType]
 from foo import *
 [file foo.pyi]
 from typing import overload

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -603,6 +603,36 @@ class Foo:
     def __init__(self, a: str):
         pass
 
+[case testConstructorWithAnyReturnValueType]
+import typing
+from typing import Any
+class A:
+    def __init__(self) -> Any: pass # E: The return type of "__init__" must be None
+
+[case testDecoratedConstructorWithAnyReturnValueType]
+import typing
+from typing import Callable, Any
+
+def deco(fn: Callable) -> Callable:
+    return fn
+
+class A:
+    @deco
+    def __init__(self) -> Any: pass # E: The return type of "__init__" must be None
+
+[case testOverloadedConstructorWithAnyReturnValueType]
+from foo import *
+[file foo.pyi]
+from typing import overload, Any
+class Foo:
+    @overload
+    def __init__(self, a: int) -> Any: # E: The return type of "__init__" must be None
+        pass
+
+    @overload
+    def __init__(self, a: str) -> Any: # E: The return type of "__init__" must be None
+        pass
+
 [case testInitSubclassWithReturnValueType]
 import typing
 class A:
@@ -639,6 +669,37 @@ class Foo:
 
     @overload
     def __init_subclass__(cls, a: str):
+        pass
+
+[case testInitSubclassWithAnyReturnValueType]
+import typing
+from typing import Any
+class A:
+    def __init_subclass__(cls) -> Any: pass # E: The return type of "__init_subclass__" must be None
+
+[case testDecoratedInitSubclassWithAnyReturnValueType]
+import typing
+from typing import Callable, Any
+
+def deco(fn: Callable) -> Callable:
+    return fn
+
+class A:
+    @deco
+    def __init_subclass__(cls) -> Any: pass # E: The return type of "__init_subclass__" must be None
+[out]
+
+[case testOverloadedInitSubclassWithAnyReturnValueType]
+from foo import *
+[file foo.pyi]
+from typing import overload, Any
+class Foo:
+    @overload
+    def __init_subclass__(cls, a: int) -> Any: # E: The return type of "__init_subclass__" must be None
+        pass
+
+    @overload
+    def __init_subclass__(cls, a: str) -> Any: # E: The return type of "__init_subclass__" must be None
         pass
 
 [case testGlobalFunctionInitWithReturnType]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -612,7 +612,7 @@ def deco(fn: Callable) -> Callable:
 
 class A:
     @deco
-    def __init_subclass__(self, x: int=1): pass
+    def __init_subclass__(cls, x: int=1): pass
 [out]
 
 [case testGlobalFunctionInitWithReturnType]


### PR DESCRIPTION
Implements https://github.com/python/mypy/issues/604#issuecomment-348525995.