### PR TITLE
Use '.' as the separator in our development versions to match PEP 440

### DIFF
--- a/mypy/version.py
+++ b/mypy/version.py
@@ -6,7 +6,7 @@ base_version = __version__
 
 mypy_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 if __version__.endswith('+dev') and git.is_git_repo(mypy_dir) and git.have_git():
-    __version__ += '-' + git.git_revision(mypy_dir).decode('utf-8')
+    __version__ += '.' + git.git_revision(mypy_dir).decode('utf-8')
     if git.is_dirty(mypy_dir):
-        __version__ += '-dirty'
+        __version__ += '.dirty'
 del mypy_dir


### PR DESCRIPTION
PEP 440 allows '.', '-', and '_' as separators in the development
version part of a version number but specifies normalizing them to
'.'. Change to using '.' so as to be consistent between mypy's
reported version numbers and the normalized ones used in wheel
filenames.