### PR TITLE
Don't report "function does not return a value" in dynamic functions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -315,7 +315,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 self.check_protocol_issubclass(e)
         if isinstance(ret_type, UninhabitedType) and not ret_type.ambiguous:
             self.chk.binder.unreachable()
-        if not allow_none_return and self.always_returns_none(e.callee):
+        # Warn on calls to functions that always return None. The check
+        # of ret_type is both a common-case optimization and prevents reporting
+        # the error in dynamic functions (where it will be Any).
+        if (not allow_none_return and isinstance(ret_type, NoneTyp)
+                and self.always_returns_none(e.callee)):
             self.chk.msg.does_not_return_value(callee_type, e)
             return AnyType(TypeOfAny.from_error)
         return ret_type

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2376,3 +2376,11 @@ def Y(x: Optional[str] = X(x_in)): ...
 
 xx: Optional[int] = X(x_in)
 [out]
+
+[case testNoComplainNoneReturnFromUntyped]
+def foo() -> None:
+    pass
+
+def lol():
+    1+'uh'
+    x = foo()

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2382,5 +2382,4 @@ def foo() -> None:
     pass
 
 def lol():
-    1+'uh'
     x = foo()


### PR DESCRIPTION
Fixes a regression (that causes trouble in internal codebases) introduced in #5663.