### PR TITLE
Namespaces refactor part 2

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -122,7 +122,6 @@ class BuildSourceSet:
 def build(sources: List[BuildSource],
           options: Options,
           alt_lib_path: Optional[str] = None,
-          bin_dir: Optional[str] = None,
           flush_errors: Optional[Callable[[List[str], bool], None]] = None,
           fscache: Optional[FileSystemCache] = None,
           ) -> BuildResult:
@@ -144,8 +143,6 @@ def build(sources: List[BuildSource],
       options: build options
       alt_lib_path: an additional directory for looking up library modules
         (takes precedence over other directories)
-      bin_dir: directory containing the mypy script, used for finding data
-        directories; if omitted, use '.' as the data directory
       flush_errors: optional function to flush errors after a file is processed
       fscache: optionally a file-system cacher
 
@@ -160,8 +157,7 @@ def build(sources: List[BuildSource],
     flush_errors = flush_errors or default_flush_errors
 
     try:
-        result = _build(sources, options, alt_lib_path, bin_dir,
-                        flush_errors, fscache)
+        result = _build(sources, options, alt_lib_path, flush_errors, fscache)
         result.errors = messages
         return result
     except CompileError as e:
@@ -178,7 +174,6 @@ def build(sources: List[BuildSource],
 def _build(sources: List[BuildSource],
            options: Options,
            alt_lib_path: Optional[str],
-           bin_dir: Optional[str],
            flush_errors: Callable[[List[str], bool], None],
            fscache: Optional[FileSystemCache],
            ) -> BuildResult:
@@ -424,7 +419,7 @@ class BuildManager(BuildManagerBase):
 
     Attributes:
       data_dir:        Mypy data directory (contains stubs)
-      lib_path:        Library path for looking up modules
+      search_paths:    SearchPaths instance indicating where to look for modules
       modules:         Mapping of module ID to MypyFile (shared by the passes)
       semantic_analyzer:
                        Semantic analyzer, pass 2

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -65,10 +65,6 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
 
     t0 = time.time()
     # To log stat() calls: os.stat = stat_proxy
-    if script_path:
-        bin_dir = find_bin_directory(script_path)  # type: Optional[str]
-    else:
-        bin_dir = None
     sys.setrecursionlimit(2 ** 14)
     if args is None:
         args = sys.argv[1:]
@@ -93,7 +89,7 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
     try:
         # Keep a dummy reference (res) for memory profiling below, as otherwise
         # the result could be freed.
-        res = build.build(sources, options, None, bin_dir, flush_errors, fscache)
+        res = build.build(sources, options, None, flush_errors, fscache)
     except CompileError as e:
         blockers = True
         if not e.use_stdout:
@@ -122,20 +118,6 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
         util.hard_exit(code)
     elif code:
         sys.exit(code)
-
-
-def find_bin_directory(script_path: str) -> str:
-    """Find the directory that contains this script.
-
-    This is used by build to find stubs and other data files.
-    """
-    # Follow up to 5 symbolic links (cap to avoid cycles).
-    for i in range(5):
-        if os.path.islink(script_path):
-            script_path = readlinkabs(script_path)
-        else:
-            break
-    return os.path.dirname(script_path)
 
 
 def readlinkabs(link: str) -> str:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -93,7 +93,7 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
     try:
         # Keep a dummy reference (res) for memory profiling below, as otherwise
         # the result could be freed.
-        res = type_check_only(sources, bin_dir, options, flush_errors, fscache)  # noqa
+        res = build.build(sources, options, None, bin_dir, flush_errors, fscache)
     except CompileError as e:
         blockers = True
         if not e.use_stdout:
@@ -146,18 +146,6 @@ def readlinkabs(link: str) -> str:
     if os.path.isabs(path):
         return path
     return os.path.join(os.path.dirname(link), path)
-
-
-def type_check_only(sources: List[BuildSource], bin_dir: Optional[str],
-                    options: Options,
-                    flush_errors: Optional[Callable[[List[str], bool], None]],
-                    fscache: FileSystemCache) -> BuildResult:
-    # Type-check the program and dependencies.
-    return build.build(sources=sources,
-                       bin_dir=bin_dir,
-                       options=options,
-                       flush_errors=flush_errors,
-                       fscache=fscache)
 
 
 class SplitNamespace(argparse.Namespace):

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -107,6 +107,7 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
     if MEM_PROFILE:
         from mypy.memprofile import print_memory_profile
         print_memory_profile()
+    del res  # Now it's safe to delete
 
     code = 0
     if messages:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -86,6 +86,7 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
 
     serious = False
     blockers = False
+    res = None
     try:
         # Keep a dummy reference (res) for memory profiling below, as otherwise
         # the result could be freed.

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -320,10 +320,10 @@ def get_site_packages_dirs(python_executable: Optional[str],
 
 
 def compute_search_paths(sources: List[BuildSource],
-                     options: Options,
-                     data_dir: str,
-                     fscache: FileSystemCache,
-                     alt_lib_path: Optional[str] = None) -> SearchPaths:
+                         options: Options,
+                         data_dir: str,
+                         fscache: FileSystemCache,
+                         alt_lib_path: Optional[str] = None) -> SearchPaths:
     """Compute the search paths as specified in PEP 561.
 
     There are the following 4 members created:

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -119,9 +119,10 @@ from typing import (
 )
 
 from mypy.build import (
-    BuildManager, State, BuildSource, BuildResult, Graph, load_graph,
+    BuildManager, State, BuildResult, Graph, load_graph,
     process_fresh_modules, DEBUG_FINE_GRAINED,
 )
+from mypy.modulefinder import BuildSource
 from mypy.checker import FineGrainedDeferredNode
 from mypy.errors import CompileError
 from mypy.nodes import (

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Set, Tuple
 
 from mypy import build
 from mypy.build import Graph
-from mypy.modulefinder import BuildSource, SearchPaths
+from mypy.modulefinder import BuildSource, SearchPaths, FindModuleCache
 from mypy.test.config import test_temp_dir, test_data_prefix
 from mypy.test.data import DataDrivenTestCase, DataSuite, FileOperation, UpdateFile
 from mypy.test.helpers import (
@@ -287,7 +287,7 @@ class TypeCheckSuite(DataSuite):
             out = []
             search_paths = SearchPaths((test_temp_dir,), (), (), ())
             for module_name in module_names.split(' '):
-                path = build.FindModuleCache(search_paths).find_module(module_name)
+                path = FindModuleCache(search_paths).find_module(module_name)
                 assert path is not None, "Can't find ad hoc case file"
                 with open(path) as f:
                     program_text = f.read()

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -271,13 +271,14 @@ class TypeCheckSuite(DataSuite):
         Return a list of tuples (module name, file name, program text).
         """
         m = re.search('# cmd: mypy -m ([a-zA-Z0-9_. ]+)$', program_text, flags=re.MULTILINE)
-        regex = '# cmd{}: mypy -m ([a-zA-Z0-9_. ]+)$'.format(incremental_step)
-        alt_m = re.search(regex, program_text, flags=re.MULTILINE)
-        if alt_m is not None and incremental_step > 1:
-            # Optionally return a different command if in a later step
-            # of incremental mode, otherwise default to reusing the
-            # original cmd.
-            m = alt_m
+        if incremental_step > 1:
+            alt_regex = '# cmd{}: mypy -m ([a-zA-Z0-9_. ]+)$'.format(incremental_step)
+            alt_m = re.search(alt_regex, program_text, flags=re.MULTILINE)
+            if alt_m is not None:
+                # Optionally return a different command if in a later step
+                # of incremental mode, otherwise default to reusing the
+                # original cmd.
+                m = alt_m
 
         if m:
             # The test case wants to use a non-default main
@@ -286,8 +287,9 @@ class TypeCheckSuite(DataSuite):
             module_names = m.group(1)
             out = []
             search_paths = SearchPaths((test_temp_dir,), (), (), ())
+            cache = FindModuleCache(search_paths)
             for module_name in module_names.split(' '):
-                path = FindModuleCache(search_paths).find_module(module_name)
+                path = cache.find_module(module_name)
                 assert path is not None, "Can't find ad hoc case file"
                 with open(path) as f:
                     program_text = f.read()


### PR DESCRIPTION
This is more mindless refactoring.

- Inline `type_check_only()` -- there was only one call and all it did was rearrange the arguments
- Drop `bin_dir` argument -- nothing uses it
- Fix some imports in test/testcheck.py, dmypy_server.py and server/update.py
- Two other small refactors in test/testcheck.py
- Fix some mis-indented parameters