### PR TITLE
Namespace packages (PEP 420)

### DIFF
--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -221,7 +221,7 @@ class FindModuleCache:
             levels = [highest_init_level(fscache, id, path) for path in near_misses]
             index = levels.index(max(levels))
             return near_misses[index]
-            
+
         return None
 
     def find_modules_recursive(self, module: str) -> List[BuildSource]:

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -202,7 +202,7 @@ class FindModuleCache:
         # complicated because if there's a classic subpackage
         # somewhere it should still be preferred over a namespace
         # subpackage with the same name earlier on the path.
-        if self.options.namespace_packages and near_misses:
+        if self.options and self.options.namespace_packages and near_misses:
             for index in range(id.count('.')):
                 if len(near_misses) > 1:
                     reduced_list = [path

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -215,7 +215,7 @@ class FindModuleCache:
         # indicates the highest level at which a __init__.py[i] file
         # is found; if no __init__ was found it returns 0, if we find
         # only foo/bar/__init__.py it returns 1, and if we have
-        # foo/__init__.py it returns 2 (regardless of what's un
+        # foo/__init__.py it returns 2 (regardless of what's in
         # foo/bar).  It doesn't look higher than that.
         if self.options and self.options.namespace_packages and near_misses:
             levels = [highest_init_level(fscache, id, path) for path in near_misses]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1,4 +1,5 @@
 -- Type checker test cases dealing with modules and imports.
+-- Towards the end there are tests for PEP 420 (namespace packages, i.e. __init__.py-less packages).
 
 [case testAccessImportedDefinitions]
 import m
@@ -2525,3 +2526,51 @@ def __radd__(self) -> int: ...
 
 [case testFunctionWithInPlaceDunderName]
 def __iadd__(self) -> int: ...
+
+-- Tests for PEP 420 namespace packages.
+[case testClassicPackage]
+from foo.bar import x
+[file foo/__init__.py]
+# empty
+[file foo/bar.py]
+x = 0
+
+[case testClassicNotPackage]
+from foo.bar import x
+[file foo/bar.py]
+x = 0
+[out]
+main:1: error: Cannot find module named 'foo.bar'
+main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+
+[case testNamespacePackage]
+# flags: --namespace-packages
+from foo.bar import x
+[file foo/bar.py]
+x = 0
+
+[case testNamespacePackageWithMypyPath]
+# flags: --namespace-packages --config-file tmp/mypy.ini
+from foo.bax import x
+from foo.bay import y
+from foo.baz import z
+[file xx/foo/bax.py]
+x = 0
+[file yy/foo/bay.py]
+y = 0
+[file foo/baz.py]
+z = 0
+[file mypy.ini]
+[[mypy]
+mypy_path = tmp/xx, tmp/yy
+
+[case testClassicPackageIgnoresEarlierNamespacePackage]
+# flags: --namespace-packages --config-file tmp/mypy.ini
+from foo.bar import y
+[file xx/foo/bar.py]
+[file yy/foo/bar.py]
+y = 0
+[file yy/foo/__init__.py]
+[file mypy.ini]
+[[mypy]
+mypy_path = tmp/xx, tmp/yy

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2581,3 +2581,15 @@ y = 0
 [file mypy.ini]
 [[mypy]
 mypy_path = tmp/xx, tmp/yy
+
+[case testNamespacePackagePickFirstOnMypyPath]
+# flags: --namespace-packages --config-file tmp/mypy.ini
+from foo.bar import x
+reveal_type(x)  # E: Revealed type is 'builtins.int'
+[file xx/foo/bar.py]
+x = 0
+[file yy/foo/bar.py]
+x = ''
+[file mypy.ini]
+[[mypy]
+mypy_path = tmp/xx, tmp/yy

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2609,11 +2609,12 @@ mypy_path = tmp/xx, tmp/yy
 
 [case testClassicPackageInsideNamespacePackage]
 # flags: --namespace-packages --config-file tmp/mypy.ini
-from foo.bar.baz import x
+from foo.bar.baz.boo import x
 reveal_type(x)  # E: Revealed type is 'builtins.int'
-[file xx/foo/bar/baz.py]
+[file xx/foo/bar/baz/boo.py]
 x = ''
-[file yy/foo/bar/baz.py]
+[file xx/foo/bar/baz/__init__.py]
+[file yy/foo/bar/baz/boo.py]
 x = 0
 [file yy/foo/bar/__init__.py]
 [file mypy.ini]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2528,6 +2528,7 @@ def __radd__(self) -> int: ...
 def __iadd__(self) -> int: ...
 
 -- Tests for PEP 420 namespace packages.
+
 [case testClassicPackage]
 from foo.bar import x
 [file foo/__init__.py]
@@ -2546,6 +2547,7 @@ main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" 
 [case testNamespacePackage]
 # flags: --namespace-packages
 from foo.bar import x
+reveal_type(x)  # E: Revealed type is 'builtins.int'
 [file foo/bar.py]
 x = 0
 
@@ -2554,6 +2556,9 @@ x = 0
 from foo.bax import x
 from foo.bay import y
 from foo.baz import z
+reveal_type(x)  # E: Revealed type is 'builtins.int'
+reveal_type(y)  # E: Revealed type is 'builtins.int'
+reveal_type(z)  # E: Revealed type is 'builtins.int'
 [file xx/foo/bax.py]
 x = 0
 [file yy/foo/bay.py]
@@ -2567,7 +2572,9 @@ mypy_path = tmp/xx, tmp/yy
 [case testClassicPackageIgnoresEarlierNamespacePackage]
 # flags: --namespace-packages --config-file tmp/mypy.ini
 from foo.bar import y
+reveal_type(y)  # E: Revealed type is 'builtins.int'
 [file xx/foo/bar.py]
+x = ''
 [file yy/foo/bar.py]
 y = 0
 [file yy/foo/__init__.py]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2615,7 +2615,7 @@ reveal_type(x)  # E: Revealed type is 'builtins.int'
 x = ''
 [file yy/foo/bar/baz.py]
 x = 0
-[file xx/foo/bar/__init__.py]
+[file yy/foo/bar/__init__.py]
 [file mypy.ini]
 [[mypy]
 mypy_path = tmp/xx, tmp/yy

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2593,3 +2593,29 @@ x = ''
 [file mypy.ini]
 [[mypy]
 mypy_path = tmp/xx, tmp/yy
+
+[case testNamespacePackageInsideClassicPackage]
+# flags: --namespace-packages --config-file tmp/mypy.ini
+from foo.bar.baz import x
+reveal_type(x)  # E: Revealed type is 'builtins.int'
+[file xx/foo/bar/baz.py]
+x = ''
+[file yy/foo/bar/baz.py]
+x = 0
+[file yy/foo/__init__.py]
+[file mypy.ini]
+[[mypy]
+mypy_path = tmp/xx, tmp/yy
+
+[case testClassicPackageInsideNamespacePackage]
+# flags: --namespace-packages --config-file tmp/mypy.ini
+from foo.bar.baz import x
+reveal_type(x)  # E: Revealed type is 'builtins.int'
+[file xx/foo/bar/baz.py]
+x = ''
+[file yy/foo/bar/baz.py]
+x = 0
+[file xx/foo/bar/__init__.py]
+[file mypy.ini]
+[[mypy]
+mypy_path = tmp/xx, tmp/yy


### PR DESCRIPTION
Tentative implementation of PEP 420. Fixes #1645.

Clarification of the implementation:

- `candidate_base_dirs` is a list of `(dir, verify)` tuples, laboriously pre-computed.
- The old code just looped over this list, looking for `dir/<module>`, and if found, it would verify that there were `__init__.py` files in all the right places (except if `verify` is false); the first success would be the hit;
- In PEP 420 mode, if the above approach finds no hits, we do something different for those paths that failed due to `__init__` verification; essentially we narrow down the list of candidate paths by checking for `__init__` files from the top down. Hopefully the last test added clarifies this.