### PR TITLE
Use sys.executable for invoking mypy in runtests if it is Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,12 @@ whenever you change branches, merge, rebase, or pull.
 Tests
 -----
 
-See [Test README.md](test-data/unit/README.md)
+The basic way to run tests:
+
+    $ pip3 install -r test-requirements.txt
+    $ ./runtests.py
+
+For more on the tests, see [Test README.md](test-data/unit/README.md)
 
 
 Development status

--- a/runtests.py
+++ b/runtests.py
@@ -6,7 +6,7 @@ prog, *args = argv
 
 
 # Use the Python provided to execute the script, or fall back to a sane default
-if version_info > (3, 0, 0):
+if version_info >= (3, 4, 0):
         python_name = executable
 else:
     if platform == 'win32':

--- a/runtests.py
+++ b/runtests.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 from os import system
-from sys import argv, exit, platform
+from sys import argv, exit, platform, executable, version_info
 
 prog, *args = argv
 
 if platform == 'win32':
-    python_name = 'py -3'
+    # use the executable the script was invoked with
+    # or default to Python 3.x
+    if version_info > (3, 0, 0):
+        python_name = executable
+    else:
+        python_name = 'py -3'
 else:
     python_name = 'python3'
 

--- a/runtests.py
+++ b/runtests.py
@@ -4,15 +4,15 @@ from sys import argv, exit, platform, executable, version_info
 
 prog, *args = argv
 
-if platform == 'win32':
-    # use the executable the script was invoked with
-    # or default to Python 3.x
-    if version_info > (3, 0, 0):
+
+# Use the Python provided to execute the script, or fall back to a sane default
+if version_info > (3, 0, 0):
         python_name = executable
-    else:
-        python_name = 'py -3'
 else:
-    python_name = 'python3'
+    if platform == 'win32':
+        python_name = 'py -3'
+    else:
+        python_name = 'python3'
 
 cmds = {
     'self': python_name + ' -m mypy --config-file mypy_self_check.ini -p mypy',


### PR DESCRIPTION
I recently installed Python 3.7, which means that the `py` launcher will use it as default (even though I had installed it for testing...). I have Python 3.6 as the default for executing scripts, and the main development environment I use.

This change will use the Python executable used to run the script, instead of the default Python 3 executable (via `py -3`), if possible, or will fall back to the old behavior if the default to run a script is a Python 2 executable.

@Michael0x2a hopefully this doesn't break anything for you?