### PR TITLE
Fix the code sample on the "Duck type compatibility" docs page

### DIFF
--- a/docs/source/duck_type_compatibility.rst
+++ b/docs/source/duck_type_compatibility.rst
@@ -16,11 +16,13 @@ and also behaves as expected:
 
 .. code-block:: python
 
-   def degrees_to_radians(x: float) -> float:
+   import math
+
+   def degrees_to_radians(degrees: float) -> float:
        return math.pi * degrees / 180
 
    n = 90  # Inferred type 'int'
-   print(degrees_to_radians(n))   # Okay!
+   print(degrees_to_radians(n))  # Okay!
 
 You can also often use :ref:`protocol-types` to achieve a similar effect in
 a more principled and extensible fashion. Protocols don't apply to


### PR DESCRIPTION
This PR fixes two issues with said code sample:
  - The math import was missing.
  - The function argument didn't match the variable name used in the function body.

Also made comment spacing consistent.