### PR TITLE
Micro-optimization of TypeInfo.__bool__

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2296,6 +2296,12 @@ class TypeInfo(SymbolNode):
     def __repr__(self) -> str:
         return '<TypeInfo %s>' % self.fullname()
 
+    def __bool__(self) -> bool:
+        # We defined this here instead of just overriding it in
+        # FakeInfo so that mypyc can generate a direct call instead of
+        # using the generic bool handling.
+        return not isinstance(self, FakeInfo)
+
     def has_readable_member(self, name: str) -> bool:
         return self.get(name) is not None
 
@@ -2472,14 +2478,11 @@ class FakeInfo(TypeInfo):
     # for missing TypeInfos in a number of places where the excuses
     # for not being Optional are a little weaker.
     #
-    # It defines a __bool__ method so that it can be conveniently
-    # tested against in the same way that it would be if things were
-    # properly optional.
+    # TypeInfo defines a __bool__ method that returns False for FakeInfo
+    # so that it can be conveniently tested against in the same way that it
+    # would be if things were properly optional.
     def __init__(self, msg: str) -> None:
         self.msg = msg
-
-    def __bool__(self) -> bool:
-        return False
 
     def __getattribute__(self, attr: str) -> None:
         raise AssertionError(object.__getattribute__(self, 'msg'))


### PR DESCRIPTION
In conjunction with a change that makes mypyc able to directly
generate calls to `__bool__`, this allows us to generate a much more
direct check for truthiness of TypeInfo.