### PR TITLE
Minor Callable optimizations

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -778,10 +778,10 @@ def is_callable_compatible(left: CallableType, right: CallableType,
     if right.is_ellipsis_args:
         return True
 
-    left_star = left.var_arg
-    left_star2 = left.kw_arg
-    right_star = right.var_arg
-    right_star2 = right.kw_arg
+    left_star = left.var_arg()
+    left_star2 = left.kw_arg()
+    right_star = right.var_arg()
+    right_star2 = right.kw_arg()
 
     # Match up corresponding arguments and check them for compatibility. In
     # every pair (argL, argR) of corresponding arguments from L and R, argL must


### PR DESCRIPTION
Replace the `var_arg` and `kw_arg` attributes with methods in
`CallableType`.  This speeds up type checking slightly and improves memory
use, as we only construct the values as needed.

Subtype checks for callables are now slower, but that's fine since we
construct callables at least 10x as frequently as we perform callable
subtype checks.

Also remove a somewhat expensive assertion.

This seems to give about 2-3% performance improvement on self-check
(not compiled).