### PR TITLE
Optimize mypy.fastparse (Python 3 only)

### DIFF
--- a/mypy/__main__.py
+++ b/mypy/__main__.py
@@ -8,10 +8,4 @@ def console_entry() -> None:
 
 
 if __name__ == '__main__':
-    import cProfile
-    import pstats
-
-    cProfile.run('main(None)', 'profstats')
-    p = pstats.Stats('profstats')
-    p.sort_stats('time').print_stats(40)
-    #main(None)
+    main(None)

--- a/mypy/__main__.py
+++ b/mypy/__main__.py
@@ -8,4 +8,10 @@ def console_entry() -> None:
 
 
 if __name__ == '__main__':
-    main(None)
+    import cProfile
+    import pstats
+
+    cProfile.run('main(None)', 'profstats')
+    p = pstats.Stats('profstats')
+    p.sort_stats('time').print_stats(40)
+    #main(None)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1067,6 +1067,13 @@ class TypeConverter:
     def translate_expr_list(self, l: Sequence[ast3.expr]) -> List[Type]:
         return [self.visit(e) for e in l]
 
+    def visit_raw_str(self, s: str) -> Type:
+        # An escape hatch that allows the AST walker in fastparse2 to
+        # directly hook into the Python 3.5 type converter in some cases
+        # without needing to create an intermediary `Str` object.
+        return (parse_type_comment(s.strip(), self.line, self.errors) or
+                AnyType(TypeOfAny.from_error))
+
     def visit_Call(self, e: Call) -> Type:
         # Parse the arg constructor
         f = e.func

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -636,9 +636,9 @@ class ASTConverter:
         else:
             target_type = None
         s = WithStmt([self.visit(i.context_expr) for i in n.items],
-                        [self.visit(i.optional_vars) for i in n.items],
-                        self.as_required_block(n.body, n.lineno),
-                        target_type)
+                     [self.visit(i.optional_vars) for i in n.items],
+                     self.as_required_block(n.body, n.lineno),
+                     target_type)
         s.is_async = True
         return self.set_line(s, n)
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -202,7 +202,6 @@ class ASTConverter:
         res = []  # type: List[Expression]
         for e in l:
             exp = self.visit(e)
-            # assert isinstance(exp, Expression)
             res.append(exp)
         return res
 
@@ -210,7 +209,6 @@ class ASTConverter:
         res = []  # type: List[Statement]
         for e in l:
             stmt = self.visit(e)
-            # assert isinstance(stmt, Statement)
             res.append(stmt)
         return res
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -330,15 +330,16 @@ class ASTConverter:
     # arguments = (arg* args, arg? vararg, arg* kwonlyargs, expr* kw_defaults,
     #              arg? kwarg, expr* defaults)
     def visit_FunctionDef(self, n: ast3.FunctionDef) -> Union[FuncDef, Decorator]:
-        node = self.do_func_def(n)
-        node.set_line(n.lineno, n.col_offset)
-        return node
+        f = self.do_func_def(n)
+        f.set_line(n.lineno, n.col_offset)  # Overrides set_line -- can't use self.set_line
+        return f
 
     # AsyncFunctionDef(identifier name, arguments args,
     #                  stmt* body, expr* decorator_list, expr? returns, string? type_comment)
     def visit_AsyncFunctionDef(self, n: ast3.AsyncFunctionDef) -> Union[FuncDef, Decorator]:
-        node = self.do_func_def(n, is_coroutine=True)
-        return self.set_line(node, n)
+        f = self.do_func_def(n, is_coroutine=True)
+        f.set_line(n.lineno, n.col_offset)  # Overrides set_line -- can't use self.set_line
+        return f
 
     def do_func_def(self, n: Union[ast3.FunctionDef, ast3.AsyncFunctionDef],
                     is_coroutine: bool = False) -> Union[FuncDef, Decorator]:
@@ -786,7 +787,8 @@ class ASTConverter:
 
         e = LambdaExpr(self.transform_args(n.args, n.lineno),
                        self.as_required_block([body], n.lineno))
-        return self.set_line(e, n)
+        e.set_line(n.lineno, n.col_offset)  # Overrides set_line -- can't use self.set_line
+        return e
 
     # IfExp(expr test, expr body, expr orelse)
     def visit_IfExp(self, n: ast3.IfExp) -> ConditionalExpr:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1066,13 +1066,6 @@ class TypeConverter:
         if self.errors:
             self.errors.report(line, column, msg, severity='note')
 
-    def visit_raw_str(self, s: str) -> Type:
-        # An escape hatch that allows the AST walker in fastparse2 to
-        # directly hook into the Python 3.5 type converter in some cases
-        # without needing to create an intermediary `Str` object.
-        return (parse_type_comment(s.strip(), self.line, self.errors) or
-                AnyType(TypeOfAny.from_error))
-
     def translate_expr_list(self, l: Sequence[ast3.expr]) -> List[Type]:
         return [self.visit(e) for e in l]
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -167,7 +167,7 @@ def is_no_type_check_decorator(expr: ast3.expr) -> bool:
     return False
 
 
-class ASTConverter(ast3.NodeTransformer):
+class ASTConverter:
     def __init__(self,
                  options: Options,
                  is_stub: bool,
@@ -185,13 +185,12 @@ class ASTConverter(ast3.NodeTransformer):
     def fail(self, msg: str, line: int, column: int) -> None:
         self.errors.report(line, column, msg, blocker=True)
 
-    def generic_visit(self, node: ast3.AST) -> None:
-        raise RuntimeError('AST node not implemented: ' + str(type(node)))
-
     def visit(self, node: Optional[ast3.AST]) -> Any:  # same as in typed_ast stub
         if node is None:
             return None
-        return super().visit(node)
+        method = 'visit_' + node.__class__.__name__
+        visitor = getattr(self, method)
+        return visitor(node)
 
     def translate_expr_list(self, l: Sequence[ast3.AST]) -> List[Expression]:
         res = []  # type: List[Expression]

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -492,7 +492,7 @@ class ASTConverter:
             new_args.append(self.make_argument(args.kwarg, None, ARG_STAR2, no_type_check))
             names.append(args.kwarg)
 
-        check_arg_names([name.arg for name in names], names, self.fail_arg)
+        check_arg_names([arg.variable.name() for arg in new_args], names, self.fail_arg)
 
         return new_args
 
@@ -501,13 +501,15 @@ class ASTConverter:
         if no_type_check:
             arg_type = None
         else:
-            if arg.annotation is not None and arg.type_comment is not None:
+            annotation = arg.annotation
+            type_comment = arg.type_comment
+            if annotation is not None and type_comment is not None:
                 self.fail(messages.DUPLICATE_TYPE_SIGNATURES, arg.lineno, arg.col_offset)
             arg_type = None
-            if arg.annotation is not None:
-                arg_type = TypeConverter(self.errors, line=arg.lineno).visit(arg.annotation)
-            elif arg.type_comment is not None:
-                arg_type = parse_type_comment(arg.type_comment, arg.lineno, self.errors)
+            if annotation is not None:
+                arg_type = TypeConverter(self.errors, line=arg.lineno).visit(annotation)
+            elif type_comment is not None:
+                arg_type = parse_type_comment(type_comment, arg.lineno, self.errors)
         return Argument(Var(arg.arg), arg_type, self.visit(default), kind)
 
     def fail_arg(self, msg: str, arg: ast3.arg) -> None:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -742,7 +742,7 @@ class Var(SymbolNode):
         super().__init__()
         self._name = name   # Name without module prefix
         # TODO: Should be Optional[str]
-        self._fullname = cast(Bogus[str], None)  # Name with module prefix
+        self._fullname = cast('Bogus[str]', None)  # Name with module prefix
         # TODO: Should be Optional[TypeInfo]
         self.info = VAR_NO_INFO
         self.type = type  # type: Optional[mypy.types.Type] # Declared or inferred type, or None


### PR DESCRIPTION
This implements various small optimizations to make AST conversion
from the typed_ast AST faster in compiled mypy. This makes compiled
mypy about 4% faster on self-check, and it also makes non-compiled
mypy around 1% faster on self-check.

Notable included optimizations:
* Implement visit methods more efficiently. Don't inherit visitors from
  `typed_ast` visitor classes.
* Refactor decorated methods away, as they are slow with mypyc.
* Refactor away many non-native attribute lookups.
* Refactor away some nested functions as they are slow with mypyc.

Also removed some dead code.

I'll implement the same optimizations for Python 2 AST conversion once
this PR has been accepted to avoid having to update two PRs based
on review.