### PR TITLE
Remove fscache arg from two functions in modulefinder.py

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -178,7 +178,7 @@ def _build(sources: List[BuildSource],
     data_dir = default_data_dir()
     fscache = fscache or FileSystemCache()
 
-    search_paths = compute_search_paths(sources, options, data_dir, fscache, alt_lib_path)
+    search_paths = compute_search_paths(sources, options, data_dir, alt_lib_path)
 
     reports = Reports(data_dir, options.report_dirs)
     source_set = BuildSourceSet(sources)

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -334,9 +334,7 @@ class Server:
         t0 = time.time()
         self.update_sources(sources)
         changed, removed = self.find_changed(sources)
-        # TODO: Why create a new FileSystemCache rather than using self.fscache?
-        manager.search_paths = compute_search_paths(
-            sources, manager.options, manager.data_dir, FileSystemCache())
+        manager.search_paths = compute_search_paths(sources, manager.options, manager.data_dir)
         t1 = time.time()
         messages = self.fine_grained_manager.update(changed, removed)
         t2 = time.time()

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -329,8 +329,7 @@ def default_lib_path(data_dir: str,
 
 
 @functools.lru_cache(maxsize=None)
-def get_site_packages_dirs(python_executable: Optional[str],
-                           fscache: FileSystemCache) -> Tuple[List[str], List[str]]:
+def get_site_packages_dirs(python_executable: Optional[str]) -> Tuple[List[str], List[str]]:
     """Find package directories for given python.
 
     This runs a subprocess call, which generates a list of the egg directories, and the site
@@ -357,7 +356,7 @@ def get_site_packages_dirs(python_executable: Optional[str],
     egg_dirs = []
     for dir in site_packages:
         pth = os.path.join(dir, 'easy-install.pth')
-        if fscache.isfile(pth):
+        if os.path.isfile(pth):
             with open(pth) as f:
                 egg_dirs.extend([make_abspath(d.rstrip(), dir) for d in f.readlines()])
     return egg_dirs, site_packages
@@ -366,7 +365,6 @@ def get_site_packages_dirs(python_executable: Optional[str],
 def compute_search_paths(sources: List[BuildSource],
                          options: Options,
                          data_dir: str,
-                         fscache: FileSystemCache,
                          alt_lib_path: Optional[str] = None) -> SearchPaths:
     """Compute the search paths as specified in PEP 561.
 
@@ -423,7 +421,7 @@ def compute_search_paths(sources: List[BuildSource],
     if alt_lib_path:
         mypypath.insert(0, alt_lib_path)
 
-    egg_dirs, site_packages = get_site_packages_dirs(options.python_executable, fscache)
+    egg_dirs, site_packages = get_site_packages_dirs(options.python_executable)
     for site_dir in site_packages:
         assert site_dir not in lib_path
         if site_dir in mypypath:

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -6,7 +6,6 @@ from typing import Tuple, List, Generator, Optional
 from unittest import TestCase, main
 
 import mypy.api
-from mypy.build import FileSystemCache
 from mypy.modulefinder import get_site_packages_dirs
 from mypy.test.config import package_path
 from mypy.test.helpers import run_command
@@ -130,7 +129,7 @@ class TestPEP561(TestCase):
 
     def test_get_pkg_dirs(self) -> None:
         """Check that get_package_dirs works."""
-        dirs = get_site_packages_dirs(sys.executable, FileSystemCache())
+        dirs = get_site_packages_dirs(sys.executable)
         assert dirs
 
     def test_typedpkg_stub_package(self) -> None:


### PR DESCRIPTION
In get_site_packages_dirs() the fscache argument was only used to
check for easy-install.pth, and that check appears to be done only
once.  And compute_search_paths() just passes it to
get_site_packages_dirs().  All this required a few places to create a
throwaway FileSystemCache instance.  It seems simpler to just os
os.path.isfile() and drop the fscache argument.