### PR TITLE
Use a raw string for a regex

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -341,7 +341,7 @@ class Options:
         parts = s.split('.')
         expr = re.escape(parts[0]) if parts[0] != '*' else '.*'
         for part in parts[1:]:
-            expr += re.escape('.' + part) if part != '*' else '(\..*)?'
+            expr += re.escape('.' + part) if part != '*' else r'(\..*)?'
         return re.compile(expr + '\\Z')
 
     def select_options_affecting_cache(self) -> Mapping[str, object]:


### PR DESCRIPTION
Running tests I noticed a warning about this.