### PR TITLE
Increase the GC threshold 3x

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -173,7 +173,7 @@ def _build(sources: List[BuildSource],
            fscache: Optional[FileSystemCache],
            ) -> BuildResult:
     # This seems the most reasonable place to tune garbage collection.
-    gc.set_threshold(50000)
+    gc.set_threshold(150 * 1000)
 
     data_dir = default_data_dir()
     fscache = fscache or FileSystemCache()


### PR DESCRIPTION
This seems to speed up compiled mypy by up to about 4%, with marginal
changes to memory use.