### PR TITLE
Optimize mypy.fastparse2

### DIFF
--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -396,7 +396,7 @@ class ASTConverter:
             dec.set_line(lineno, n.col_offset)
             return dec
         else:
-            func_def.set_line(lineno, n.col_offset)
+            func_def.set_line(lineno, n.col_offset)  # Overrides set_line -- can't use self.set_line
             return func_def
 
     def set_type_optional(self, type: Optional[Type], initializer: Optional[Expression]) -> None:
@@ -771,7 +771,8 @@ class ASTConverter:
             body.body = decompose_stmts + body.body
 
         e = LambdaExpr(args, body)
-        return self.set_line(e, n)
+        e.set_line(n.lineno, n.col_offset)  # Overrides set_line -- can't use self.set_line
+        return e
 
     # IfExp(expr test, expr body, expr orelse)
     def visit_IfExp(self, n: ast27.IfExp) -> ConditionalExpr:

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -69,8 +69,6 @@ except ImportError:
               'Python 3.3 and greater.', file=sys.stderr)
     sys.exit(1)
 
-T = TypeVar('T', bound=Union[ast27.expr, ast27.stmt])
-U = TypeVar('U', bound=Node)
 N = TypeVar('N', bound=Node)
 
 # There is no way to create reasonable fallbacks at this stage,
@@ -118,16 +116,6 @@ def parse(source: Union[str, bytes],
         errors.raise_error()
 
     return tree
-
-
-def with_line(f: Callable[['ASTConverter', T], U]) -> Callable[['ASTConverter', T], U]:
-    # mypyc doesn't properly populate all the fields that @wraps expects
-    # @wraps(f)
-    def wrapper(self: 'ASTConverter', ast: T) -> U:
-        node = f(self, ast)
-        node.set_line(ast.lineno, ast.col_offset)
-        return node
-    return wrapper
 
 
 def is_no_type_check_decorator(expr: ast27.expr) -> bool:

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -442,7 +442,9 @@ class ASTConverter:
 
         # **kwarg
         if n.kwarg is not None:
-            typ = self.get_type(len(args) + (0 if n.vararg is None else 1), type_comments, converter)
+            typ = self.get_type(len(args) + (0 if n.vararg is None else 1),
+                                type_comments,
+                                converter)
             new_args.append(Argument(Var(n.kwarg), typ, None, ARG_STAR2))
             names.append(n.kwarg)
 
@@ -461,7 +463,8 @@ class ASTConverter:
         else:
             return []
 
-    def convert_arg(self, index: int, arg: ast27.expr, line: int, decompose_stmts: List[Statement]) -> Var:
+    def convert_arg(self, index: int, arg: ast27.expr, line: int,
+                    decompose_stmts: List[Statement]) -> Var:
         if isinstance(arg, Name):
             v = arg.id
         elif isinstance(arg, ast27_Tuple):
@@ -722,14 +725,14 @@ class ASTConverter:
             raise RuntimeError('unknown BoolOp ' + str(type(n)))
 
         # potentially inefficient!
-        def group(vals: List[Expression]) -> OpExpr:
-            if len(vals) == 2:
-                return OpExpr(op, vals[0], vals[1])
-            else:
-                return OpExpr(op, vals[0], group(vals[1:]))
-
-        e = group(self.translate_expr_list(n.values))
+        e = self.group(self.translate_expr_list(n.values), op)
         return self.set_line(e, n)
+
+    def group(self, vals: List[Expression], op: str) -> OpExpr:
+        if len(vals) == 2:
+            return OpExpr(op, vals[0], vals[1])
+        else:
+            return OpExpr(op, vals[0], self.group(vals[1:], op))
 
     # BinOp(expr left, operator op, expr right)
     def visit_BinOp(self, n: ast27.BinOp) -> OpExpr:

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -911,7 +911,7 @@ class ASTConverter:
             # The following line is a bit hacky, but is the best way to maintain
             # compatibility with how mypy currently parses the contents of bytes literals.
             contents = str(s)[2:-1]
-            e = StrExpr(contents)
+            e = StrExpr(contents)  # type: Union[StrExpr, UnicodeExpr]
             return self.set_line(e, n)
         else:
             e = UnicodeExpr(n.s)

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -396,7 +396,8 @@ class ASTConverter:
             dec.set_line(lineno, n.col_offset)
             return dec
         else:
-            func_def.set_line(lineno, n.col_offset)  # Overrides set_line -- can't use self.set_line
+            # Overrides set_line -- can't use self.set_line
+            func_def.set_line(lineno, n.col_offset)
             return func_def
 
     def set_type_optional(self, type: Optional[Type], initializer: Optional[Expression]) -> None:
@@ -792,8 +793,8 @@ class ASTConverter:
 
     # Set(expr* elts)
     def visit_Set(self, n: ast27.Set) -> SetExpr:
-         e = SetExpr(self.translate_expr_list(n.elts))
-         return self.set_line(e, n)
+        e = SetExpr(self.translate_expr_list(n.elts))
+        return self.set_line(e, n)
 
     # ListComp(expr elt, comprehension* generators)
     def visit_ListComp(self, n: ast27.ListComp) -> ListComprehension:
@@ -890,7 +891,7 @@ class ASTConverter:
         elif isinstance(value, complex):
             expr = ComplexExpr(value)
         else:
-            raise RuntimeError('num not implemented for ' + str(type(new.n)))
+            raise RuntimeError('num not implemented for ' + str(type(n.n)))
 
         if is_inverse:
             expr = UnaryExpr('-', expr)
@@ -939,7 +940,7 @@ class ASTConverter:
 
     # Name(identifier id, expr_context ctx)
     def visit_Name(self, n: Name) -> NameExpr:
-        e =  NameExpr(n.id)
+        e = NameExpr(n.id)
         return self.set_line(e, n)
 
     # List(expr* elts, expr_context ctx)
@@ -947,9 +948,9 @@ class ASTConverter:
         expr_list = [self.visit(e) for e in n.elts]  # type: List[Expression]
         if isinstance(n.ctx, ast27.Store):
             # [x, y] = z and (x, y) = z means exactly the same thing
-            e = TupleExpr(expr_list)
-            return self.set_line(e, n)
-        e = ListExpr(expr_list)
+            e = TupleExpr(expr_list)  # type: Union[ListExpr, TupleExpr]
+        else:
+            e = ListExpr(expr_list)
         return self.set_line(e, n)
 
     # Tuple(expr* elts, expr_context ctx)

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -440,7 +440,7 @@ class StrConv(NodeVisitor[str]):
         return self.dump([o.base, o.index], o)
 
     def visit_super_expr(self, o: 'mypy.nodes.SuperExpr') -> str:
-        return self.dump([o.name], o)
+        return self.dump([o.name, o.call], o)
 
     def visit_type_application(self, o: 'mypy.nodes.TypeApplication') -> str:
         return self.dump([o.expr, ('Types', o.types)], o)

--- a/test-data/unit/parse-python2.test
+++ b/test-data/unit/parse-python2.test
@@ -417,3 +417,394 @@ MypyFile:1(
               Args(
                 NameExpr(A)
                 NameExpr(self)))))))))
+
+[case testTypeCommentsInPython2]
+x = 1 # type: List[int]
+
+def f(x, y=0):
+    # type: (List[int], str) -> None
+    pass
+[out]
+MypyFile:1(
+  AssignmentStmt:1(
+    NameExpr(x)
+    IntExpr(1)
+    List?[int?])
+  FuncDef:3(
+    f
+    Args(
+      Var(x)
+      default(
+        Var(y)
+        IntExpr(0)))
+    def (x: List?[int?], y: str? =) -> None?
+    Block:3(
+      PassStmt:5())))
+
+[case testMultiLineTypeCommentInPython2]
+def f(x,  # type: List[int]
+      y,
+      z=1, # type: str
+      ):
+    # type: (...) -> None
+    pass
+[out]
+MypyFile:1(
+  FuncDef:1(
+    f
+    Args(
+      Var(x)
+      Var(y)
+      default(
+        Var(z)
+        IntExpr(1)))
+    def (x: List?[int?], y: Any, z: str? =) -> None?
+    Block:1(
+      PassStmt:6())))
+
+[case testIfStmtInPython2]
+if x:
+    y
+elif z:
+    a
+else:
+    b
+[out]
+MypyFile:1(
+  IfStmt:1(
+    If(
+      NameExpr(x))
+    Then(
+      ExpressionStmt:2(
+        NameExpr(y)))
+    Else(
+      IfStmt:3(
+        If(
+          NameExpr(z))
+        Then(
+          ExpressionStmt:4(
+            NameExpr(a)))
+        Else(
+          ExpressionStmt:6(
+            NameExpr(b)))))))
+
+[case testWhileStmtInPython2]
+while x:
+    y
+else:
+    z
+[out]
+MypyFile:1(
+  WhileStmt:1(
+    NameExpr(x)
+    Block:1(
+      ExpressionStmt:2(
+        NameExpr(y)))
+    Else(
+      ExpressionStmt:4(
+        NameExpr(z)))))
+
+[case testForStmtInPython2]
+for x, y in z:
+    a
+else:
+    b
+[out]
+MypyFile:1(
+  ForStmt:1(
+    TupleExpr:1(
+      NameExpr(x)
+      NameExpr(y))
+    NameExpr(z)
+    Block:1(
+      ExpressionStmt:2(
+        NameExpr(a)))
+    Else(
+      ExpressionStmt:4(
+        NameExpr(b)))))
+
+[case testWithStmtInPython2]
+with x as y:
+    z
+[out]
+MypyFile:1(
+  WithStmt:1(
+    Expr(
+      NameExpr(x))
+    Target(
+      NameExpr(y))
+    Block:1(
+      ExpressionStmt:2(
+        NameExpr(z)))))
+
+[case testExpressionsInPython2]
+x[y]
+x + y
+~z
+x.y
+([x, y])
+{x, y}
+{x: y}
+x < y > z
+[out]
+MypyFile:1(
+  ExpressionStmt:1(
+    IndexExpr:1(
+      NameExpr(x)
+      NameExpr(y)))
+  ExpressionStmt:2(
+    OpExpr:2(
+      +
+      NameExpr(x)
+      NameExpr(y)))
+  ExpressionStmt:3(
+    UnaryExpr:3(
+      ~
+      NameExpr(z)))
+  ExpressionStmt:4(
+    MemberExpr:4(
+      NameExpr(x)
+      y))
+  ExpressionStmt:5(
+    ListExpr:5(
+      NameExpr(x)
+      NameExpr(y)))
+  ExpressionStmt:6(
+    SetExpr:6(
+      NameExpr(x)
+      NameExpr(y)))
+  ExpressionStmt:7(
+    DictExpr:7(
+      NameExpr(x)
+      NameExpr(y)))
+  ExpressionStmt:8(
+    ComparisonExpr:8(
+      <
+      >
+      NameExpr(x)
+      NameExpr(y)
+      NameExpr(z))))
+
+[case testSlicingInPython2]
+x[y:]
+x[y:z]
+x[::y]
+[out]
+MypyFile:1(
+  ExpressionStmt:1(
+    IndexExpr:1(
+      NameExpr(x)
+      SliceExpr:-1(
+        NameExpr(y)
+        <empty>)))
+  ExpressionStmt:2(
+    IndexExpr:2(
+      NameExpr(x)
+      SliceExpr:-1(
+        NameExpr(y)
+        NameExpr(z))))
+  ExpressionStmt:3(
+    IndexExpr:3(
+      NameExpr(x)
+      SliceExpr:-1(
+        <empty>
+        <empty>
+        NameExpr(y)))))
+
+[case testStarArgsInPython2]
+def f(*x): # type: (*int) -> None
+    pass
+f(x, *y)
+[out]
+MypyFile:1(
+  FuncDef:1(
+    f
+    def (*x: int?) -> None?
+    VarArg(
+      Var(x))
+    Block:1(
+      PassStmt:2()))
+  ExpressionStmt:3(
+    CallExpr:3(
+      NameExpr(f)
+      Args(
+        NameExpr(x)
+        NameExpr(y))
+      VarArg)))
+
+[case testKwArgsInPython2]
+def f(**x): # type: (**int) -> None
+    pass
+f(x, **y)
+[out]
+MypyFile:1(
+  FuncDef:1(
+    f
+    def (**x: int?) -> None?
+    DictVarArg(
+      Var(x))
+    Block:1(
+      PassStmt:2()))
+  ExpressionStmt:3(
+    CallExpr:3(
+      NameExpr(f)
+      Args(
+        NameExpr(x))
+      DictVarArg(
+        NameExpr(y)))))
+
+[case testBoolOpInPython2]
+x and y or z
+[out]
+MypyFile:1(
+  ExpressionStmt:1(
+    OpExpr:1(
+      or
+      OpExpr:1(
+        and
+        NameExpr(x)
+        NameExpr(y))
+      NameExpr(z))))
+
+[case testImportsInPython2]
+from x import y, z as zz
+import m
+import n as nn
+from aa import *
+[out]
+MypyFile:1(
+  ImportFrom:1(x, [y, z : zz])
+  Import:2(m)
+  Import:3(n : nn)
+  ImportAll:4(aa))
+
+[case testTryFinallyInPython2]
+try:
+    x
+finally:
+    y
+[out]
+MypyFile:1(
+  TryStmt:1(
+    Block:1(
+      ExpressionStmt:2(
+        NameExpr(x)))
+    Finally(
+      ExpressionStmt:4(
+        NameExpr(y)))))
+
+[case testRaiseInPython2]
+raise
+raise x
+[out]
+MypyFile:1(
+  RaiseStmt:1()
+  RaiseStmt:2(
+    NameExpr(x)))
+
+[case testAssignmentInPython2]
+x = y
+x, (y, z) = aa
+[out]
+MypyFile:1(
+  AssignmentStmt:1(
+    NameExpr(x)
+    NameExpr(y))
+  AssignmentStmt:2(
+    TupleExpr:2(
+      NameExpr(x)
+      TupleExpr:2(
+        NameExpr(y)
+        NameExpr(z)))
+    NameExpr(aa)))
+
+[case testAugmentedAssignmentInPython2]
+x += y
+x *= 2
+[out]
+MypyFile:1(
+  OperatorAssignmentStmt:1(
+    +
+    NameExpr(x)
+    NameExpr(y))
+  OperatorAssignmentStmt:2(
+    *
+    NameExpr(x)
+    IntExpr(2)))
+
+[case testDelStatementInPython2]
+del x
+del x.y, x[y]
+[out]
+MypyFile:1(
+  DelStmt:1(
+    NameExpr(x))
+  DelStmt:2(
+    TupleExpr:2(
+      MemberExpr:2(
+        NameExpr(x)
+        y)
+      IndexExpr:2(
+        NameExpr(x)
+        NameExpr(y)))))
+
+[case testClassDecoratorInPython2]
+@dec()
+class C:
+    pass
+[out]
+MypyFile:1(
+  ClassDef:1(
+    C
+    Decorators(
+      CallExpr:1(
+        NameExpr(dec)
+        Args()))
+    PassStmt:3()))
+
+[case testFunctionDecaratorInPython2]
+@dec()
+def f():
+    pass
+[out]
+MypyFile:1(
+  Decorator:1(
+    Var(f)
+    CallExpr:1(
+      NameExpr(dec)
+      Args())
+    FuncDef:2(
+      f
+      Block:2(
+        PassStmt:3()))))
+
+[case testOverloadedFunctionInPython2]
+@overload
+def g():
+    pass
+@overload
+def g():
+    pass
+def g():
+    pass
+[out]
+MypyFile:1(
+  OverloadedFuncDef:1(
+    Decorator:1(
+      Var(g)
+      NameExpr(overload)
+      FuncDef:2(
+        g
+        Block:2(
+          PassStmt:3())))
+    Decorator:4(
+      Var(g)
+      NameExpr(overload)
+      FuncDef:5(
+        g
+        Block:5(
+          PassStmt:6())))
+    FuncDef:7(
+      g
+      Block:7(
+        PassStmt:8()))))

--- a/test-data/unit/parse-python2.test
+++ b/test-data/unit/parse-python2.test
@@ -211,7 +211,7 @@ MypyFile:1(
       IntExpr(1)
       IntExpr(2))))
 
-[case testLambdaInListComprehensionInPython2]
+[case testListComprehensionInPython2]
 ([ 0 for x in 1, 2 if 3 ])
 [out]
 MypyFile:1(
@@ -395,3 +395,25 @@ MypyFile:1(
       TupleExpr:1(
         IntExpr(1)
         IntExpr(2)))))
+
+[case testSuperInPython2]
+class A:
+    def f(self):
+        super(A, self).x
+[out]
+MypyFile:1(
+  ClassDef:1(
+    A
+    FuncDef:2(
+      f
+      Args(
+        Var(self))
+      Block:2(
+        ExpressionStmt:3(
+          SuperExpr:3(
+            x
+            CallExpr:3(
+              NameExpr(super)
+              Args(
+                NameExpr(A)
+                NameExpr(self)))))))))

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -2356,7 +2356,10 @@ super().x
 MypyFile:1(
   ExpressionStmt:1(
     SuperExpr:1(
-      x)))
+      x
+      CallExpr:1(
+        NameExpr(super)
+        Args()))))
 
 [case testKeywordAndDictArgs]
 f(x = y, **kwargs)


### PR DESCRIPTION
These seem to speed up Python 2 type checking runtimes by up to
around 3%, when compiled with mypyc.

This is similar to #5722, but for Python 2. Also added some parser
tests, since Python 2 coverage was spotty. (It's still not quite at full
coverage, though.)