### PR TITLE
Mark --quick-and-dirty as deprecated.

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -436,7 +436,7 @@ beyond what incremental mode can offer, try running mypy in
 .. _quick-mode:
 
 ``--quick-and-dirty``
-    This flag enables an experimental, unsafe variant of incremental mode.
+    This flag enables a **deprecated**, unsafe variant of incremental mode.
     Quick mode is faster than regular incremental mode because it only
     re-checks modules that were modified since their cache file was
     last written: regular incremental mode also re-checks all modules
@@ -448,6 +448,7 @@ beyond what incremental mode can offer, try running mypy in
 
     We recommend that you try using the :ref:`mypy_daemon` before
     attempting to use this feature.
+    Quick mode is deprecated and will soon be removed.
 
 .. _advanced-flags:
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -367,7 +367,7 @@ section of the command line docs.
     check and regenerate the cache if it was written by older versions of mypy.)
     
 ``quick_and_dirty`` (bool, default False)
-    Enables :ref:`quick mode <quick-mode>`.
+    Enables :ref:`quick mode <quick-mode>`.  **Deprecated.**
 
 
 Configuring error messages

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -575,9 +575,6 @@ def process_options(args: List[str],
         '--cache-fine-grained', action='store_true',
         help="Include fine-grained dependency information in the cache for the mypy daemon")
     incremental_group.add_argument(
-        '--quick-and-dirty', action='store_true',
-        help="Use cache even if dependencies out of date (implies --incremental)")
-    incremental_group.add_argument(
         '--skip-version-check', action='store_true',
         help="Allow using cache written by older mypy version")
 
@@ -713,6 +710,8 @@ def process_options(args: List[str],
     parser.add_argument('--no-fast-parser', action='store_true',
                         dest='special-opts:no_fast_parser',
                         help=argparse.SUPPRESS)
+    parser.add_argument('--quick-and-dirty', action='store_true',
+                        help=argparse.SUPPRESS)
 
     code_group = parser.add_argument_group(
         title="Running code",
@@ -769,7 +768,8 @@ def process_options(args: List[str],
     # Process deprecated options
     if special_opts.disallow_any:
         print("--disallow-any option was split up into multiple flags. "
-              "See http://mypy.readthedocs.io/en/latest/command_line.html#disallow-dynamic-typing")
+              "See http://mypy.readthedocs.io/en/latest/command_line.html#disallow-dynamic-typing",
+              file=sys.stderr)
     if options.strict_boolean:
         print("Warning: --strict-boolean is deprecated; "
               "see https://github.com/python/mypy/issues/3195", file=sys.stderr)
@@ -792,7 +792,10 @@ def process_options(args: List[str],
         print("Warning: --fast-parser is now the default (and only) parser.")
     if special_opts.no_fast_parser:
         print("Warning: --no-fast-parser no longer has any effect.  The fast parser "
-              "is now mypy's default and only parser.")
+              "is now mypy's default and only parser.", file=sys.stderr)
+    if options.quick_and_dirty:
+        print("Warning: --quick-and-dirty is deprecated.  It will disappear in the next release.",
+              file=sys.stderr)
 
     try:
         infer_python_version_and_executable(options, special_opts)


### PR DESCRIPTION
Note that #5728 is not fixed by this yet! The behavior is unchanged except it is no longer listed in the `--help` output.

Also add `file=sys.stderr` to a few of the `print()` calls for other deprecated options.

Also mark it deprecated in the docs (but don't delete those docs yet).