### PR TITLE
Fix infinite loop on corrupted fine-grained cache

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2145,6 +2145,8 @@ def dispatch(sources: List[BuildSource], manager: BuildManager) -> Graph:
         if proto_deps is not None:
             TypeState.proto_deps = proto_deps
         elif manager.stats.get('fresh_metas', 0) > 0:
+            # Clear the stats so we don't infinite loop because of positive fresh_metas
+            manager.stats.clear()
             # There were some cache files read, but no protocol dependencies loaded.
             manager.log("Error reading protocol dependencies cache -- aborting cache load")
             manager.cache_enabled = False

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4350,6 +4350,21 @@ import b
 [stale a, b, builtins]
 [rechecked a, b, builtins]
 
+[case testIncrementalBustedFineGrainedCache3]
+# flags: --cache-fine-grained
+import a
+import b
+[file a.py]
+[file b.py]
+-- This is a heinous hack, but we simulate having a invalid cache by deleting
+-- the proto deps file.
+[delete ../.mypy_cache/3.6/@proto_deps.meta.json.2]
+[file b.py.2]
+# uh
+-- Every file should get reloaded, since the cache was invalidated
+[stale a, b, builtins]
+[rechecked a, b, builtins]
+
 [case testIncrementalWorkingFineGrainedCache]
 # flags: --cache-fine-grained
 # flags2: --cache-fine-grained


### PR DESCRIPTION
This hit me when mypyc was causing crashes after having written out
part of the cache, but subsequent runs would instead infinite loop.