### PR TITLE
Make Frame stop being a dict subclass

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -18,7 +18,7 @@ from mypy.nodes import IndexExpr, MemberExpr, NameExpr
 BindableExpression = Union[IndexExpr, MemberExpr, NameExpr]
 
 
-class Frame(Dict[Key, Type]):
+class Frame:
     """A Frame represents a specific point in the execution of a program.
     It carries information about the current types of expressions at
     that point, arising either from assignments to those expressions
@@ -31,14 +31,11 @@ class Frame(Dict[Key, Type]):
     """
 
     def __init__(self) -> None:
+        self.types = {}  # type: Dict[Key, Type]
         self.unreachable = False
 
-
-class DeclarationsFrame(Dict[Key, Optional[Type]]):
-    """Same as above, but allowed to have None values."""
-
-    def __init__(self) -> None:
-        self.unreachable = False
+    def __getitem__(self, k: Key) -> Type:
+        return self.types[k]
 
 
 if MYPY:
@@ -89,7 +86,7 @@ class ConditionalTypeBinder:
 
         # Maps literal_hash(expr) to get_declaration(expr)
         # for every expr stored in the binder
-        self.declarations = DeclarationsFrame()
+        self.declarations = {}  # type: Dict[Key, Optional[Type]]
         # Set of other keys to invalidate if a key is changed, e.g. x -> {x.a, x[0]}
         # Whenever a new key (e.g. x.a.b) is added, we update this
         self.dependencies = {}  # type: Dict[Key, Set[Key]]
@@ -117,13 +114,13 @@ class ConditionalTypeBinder:
         return f
 
     def _put(self, key: Key, type: Type, index: int=-1) -> None:
-        self.frames[index][key] = type
+        self.frames[index].types[key] = type
 
     def _get(self, key: Key, index: int=-1) -> Optional[Type]:
         if index < 0:
             index += len(self.frames)
         for i in range(index, -1, -1):
-            if key in self.frames[i]:
+            if key in self.frames[i].types:
                 return self.frames[i][key]
         return None
 
@@ -161,8 +158,8 @@ class ConditionalTypeBinder:
     def _cleanse_key(self, key: Key) -> None:
         """Remove all references to a key from the binder."""
         for frame in self.frames:
-            if key in frame:
-                del frame[key]
+            if key in frame.types:
+                del frame.types[key]
 
     def update_from_options(self, frames: List[Frame]) -> bool:
         """Update the frame to reflect that each key will be updated
@@ -174,11 +171,11 @@ class ConditionalTypeBinder:
 
         frames = [f for f in frames if not f.unreachable]
         changed = False
-        keys = set(key for f in frames for key in f)
+        keys = set(key for f in frames for key in f.types)
 
         for key in keys:
             current_value = self._get(key)
-            resulting_values = [f.get(key, current_value) for f in frames]
+            resulting_values = [f.types.get(key, current_value) for f in frames]
             if any(x is None for x in resulting_values):
                 # We didn't know anything about key before
                 # (current_value must be None), and we still don't
@@ -322,7 +319,7 @@ class ConditionalTypeBinder:
         assert key is not None
         enclosers = ([get_declaration(expr)] +
                      [f[key] for f in self.frames
-                      if key in f and is_subtype(type, f[key])])
+                      if key in f.types and is_subtype(type, f[key])])
         return enclosers[-1]
 
     def allow_jump(self, index: int) -> None:
@@ -332,7 +329,7 @@ class ConditionalTypeBinder:
             index += len(self.options_on_return)
         frame = Frame()
         for f in self.frames[index + 1:]:
-            frame.update(f)
+            frame.types.update(f.types)
             if f.unreachable:
                 frame.unreachable = True
         self.options_on_return[index].append(frame)

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -34,9 +34,6 @@ class Frame:
         self.types = {}  # type: Dict[Key, Type]
         self.unreachable = False
 
-    def __getitem__(self, k: Key) -> Type:
-        return self.types[k]
-
 
 if MYPY:
     # This is the type of stored assignments for union type rvalues.
@@ -121,7 +118,7 @@ class ConditionalTypeBinder:
             index += len(self.frames)
         for i in range(index, -1, -1):
             if key in self.frames[i].types:
-                return self.frames[i][key]
+                return self.frames[i].types[key]
         return None
 
     def put(self, expr: Expression, typ: Type) -> None:
@@ -318,8 +315,8 @@ class ConditionalTypeBinder:
         key = literal_hash(expr)
         assert key is not None
         enclosers = ([get_declaration(expr)] +
-                     [f[key] for f in self.frames
-                      if key in f.types and is_subtype(type, f[key])])
+                     [f.types[key] for f in self.frames
+                      if key in f.types and is_subtype(type, f.types[key])])
         return enclosers[-1]
 
     def allow_jump(self, index: int) -> None:


### PR DESCRIPTION
This allows the 'unreachable' flag to not need to be accessed via
GetAttr, and for dict operations to be done via dict primitives
(though I'm going to put up a mypyc change soon that makes that second
part always true.)

Amazingly, this gives a ~200ms speedup on self check (like 6%!).