### PR TITLE
Point trigger_wheel_build.sh at the new mypy_mypyc-wheels repo

### DIFF
--- a/misc/trigger_wheel_build.sh
+++ b/misc/trigger_wheel_build.sh
@@ -3,10 +3,9 @@
 # Trigger a build of mypyc compiled mypy wheels by updating the mypy
 # submodule in the git repo that drives those builds.
 
-# TODO: This is a testing repo and will need to be retargeted at the
-# real location once it exists. $WHEELS_PUSH_TOKEN is stored in travis
-# and is an API token for the mypy-build-bot account.
-git clone --recurse-submodules https://${WHEELS_PUSH_TOKEN}@github.com/msullivan/travis-testing.git build
+# $WHEELS_PUSH_TOKEN is stored in travis and is an API token for the
+# mypy-build-bot account.
+git clone --recurse-submodules https://${WHEELS_PUSH_TOKEN}@github.com/mypyc/mypy_mypyc-wheels.git build
 
 git config --global user.email "nobody"
 git config --global user.name "mypy wheels autopush"
@@ -22,4 +21,5 @@ V=$(echo "$V" | cut -d" " -f2)
 cd ..
 git commit -am "Build wheels for mypy $V"
 git tag v$V
-git push --tags origin master
+# Push a tag, but no need to push the change to master
+git push --tags


### PR DESCRIPTION
Also only push the tags, since pushing the changes to master
clutters up the history without accomplishing anything.