### PR TITLE
 Add option to raise exception on internal errors

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -594,6 +594,8 @@ def report_internal_error(err: Exception, file: Optional[str], line: int,
         pdb.post_mortem(sys.exc_info()[2])
 
     # If requested, print traceback, else print note explaining how to get one.
+    if options.raise_exceptions:
+        raise err
     if not options.show_traceback:
         if not options.pdb:
             print('{}: note: please use --show-traceback to print a traceback '

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -619,6 +619,9 @@ def process_options(args: List[str],
         '--show-traceback', '--tb', action='store_true',
         help="Show traceback on fatal error")
     internals_group.add_argument(
+        '--raise-exceptions', action='store_true', help="Raise exception on fatal error"
+    )
+    internals_group.add_argument(
         '--custom-typing', metavar='MODULE', dest='custom_typing_module',
         help="Use a custom typing module")
     internals_group.add_argument(

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -196,6 +196,7 @@ class Options:
         self.verbosity = 0  # More verbose messages (for troubleshooting)
         self.pdb = False
         self.show_traceback = False
+        self.raise_exceptions = False
         self.dump_type_stats = False
         self.dump_inference_stats = False
 


### PR DESCRIPTION
For using external debugging tools like PyCharm, the most helpful thing
to do on an internal error is to just raise an exception, rather than
printing a stacktrace or dropping to PDB.