### PR TITLE
check type of module_all earlier

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -172,6 +172,8 @@ def find_module_path_and_all(module: str, pyversion: Tuple[int, int],
             raise SystemExit(
                 "Can't find module '{}' (consider using --search-path)".format(module))
         module_all = None
+    if not (isinstance(module_all, list) and all(isinstance(v, str) for v in module_all)):
+        raise CantImport(module)
     return module_path, module_all
 
 

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -174,7 +174,7 @@ def find_module_path_and_all(module: str, pyversion: Tuple[int, int],
         module_all = None
     if not (
         module_all is None or
-        ((isinstance(module_all, list) and all(isinstance(v, str) for v in module_all))
+        (isinstance(module_all, list) and all(isinstance(v, str) for v in module_all))
     ):
         raise CantImport(module)
     return module_path, module_all

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -172,7 +172,10 @@ def find_module_path_and_all(module: str, pyversion: Tuple[int, int],
             raise SystemExit(
                 "Can't find module '{}' (consider using --search-path)".format(module))
         module_all = None
-    if not (isinstance(module_all, list) and all(isinstance(v, str) for v in module_all)):
+    if not (
+        module_all is None or
+        ((isinstance(module_all, list) and all(isinstance(v, str) for v in module_all))
+    ):
         raise CantImport(module)
     return module_path, module_all
 


### PR DESCRIPTION
currently mypy.stubgen crashes when processing `aiofiles/__init__.py`, because `__all__` is `Tuple[Callable[..., object]]` and doesn't continue to process any further modules

See https://github.com/Tinche/aiofiles/pull/53 for the upstream fix