### PR TITLE
Remove fine-grained deps from "__init__" on class attribute access

### DIFF
--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -586,7 +586,11 @@ class DependencyVisitor(TraverserVisitor):
         self.process_global_ref_expr(o)
 
     def visit_member_expr(self, e: MemberExpr) -> None:
-        super().visit_member_expr(e)
+        if isinstance(e.expr, RefExpr) and isinstance(e.expr.node, TypeInfo):
+            # Special case class attribute so that we don't depend on "__init__".
+            self.add_dependency(make_trigger(e.expr.node.fullname()))
+        else:
+            super().visit_member_expr(e)
         if e.kind is not None:
             # Reference to a module attribute
             self.process_global_ref_expr(e)

--- a/test-data/unit/deps-classes.test
+++ b/test-data/unit/deps-classes.test
@@ -175,11 +175,56 @@ def g() -> None:
 class B: pass
 [out]
 <m.A.X> -> m.g
--- The __init__ is superfluous but benign
-<m.A.__init__> -> m.g
-<m.A.__new__> -> m.g
 <m.A> -> <m.f>, m.A, m.f, m.g
 <m.B.__init__> -> m
 <m.B.__new__> -> m
 -- The <m.A.X> dependecy target is superfluous but benign
 <m.B> -> <m.A.X>, m
+
+[case testClassAttribute]
+class C:
+    x = 0
+
+def f() -> None:
+    C.x
+
+def g() -> None:
+    C.x = 1
+[out]
+<m.C.x> -> m.f, m.g
+<m.C> -> m.C, m.f, m.g
+
+[case testStaticAndClassMethods]
+class C:
+    @staticmethod
+    def foo() -> None:
+        h()
+
+    @classmethod
+    def bar(cls) -> None:
+        h()
+
+def fstatic() -> None:
+    C.foo()
+
+def fclass() -> None:
+    C.bar()
+
+cc = C()
+
+def gstatic() -> None:
+    cc.foo()
+
+def gclass() -> None:
+    cc.bar()
+
+def h() -> None: pass
+[builtins fixtures/classmethod.pyi]
+[out]
+<m.C.__init__> -> m
+<m.C.__new__> -> m
+<m.C.bar> -> m, m.fclass, m.gclass
+<m.C.foo> -> m, m.fstatic, m.gstatic
+<m.C> -> <m.cc>, m, m.C, m.fclass, m.fstatic
+<m.cc> -> m, m.gclass, m.gstatic
+<m.h> -> m.C.bar, m.C.foo

--- a/test-data/unit/deps-types.test
+++ b/test-data/unit/deps-types.test
@@ -186,8 +186,6 @@ class M(type):
 class C(metaclass=M):
     pass
 [out]
-<mod.C.__init__> -> m.f
-<mod.C.__new__> -> m.f
 <mod.C.x> -> m.f
 <mod.C> -> m, m.f
 <mod.M.x> -> m.f
@@ -928,8 +926,6 @@ def g() -> None:
 class B: pass
 [out]
 <m.A.X> -> m.g
-<m.A.__init__> -> m.g
-<m.A.__new__> -> m.g
 <m.A> -> <m.f>, m.f, m.g
 <mod.B> -> m
 


### PR DESCRIPTION
The main motivation is to improve the precision of logical
dependencies, as the previously generated dependencies were
unnecessary. Removing extra dependencies also gives a slight
performance improvement.