### PR TITLE
Don't create logical dependencies when importing names

### DIFF
--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -330,6 +330,9 @@ class DependencyVisitor(TraverserVisitor):
             self.add_dependency(make_trigger(id), self.scope.current_target())
 
     def visit_import_from(self, o: ImportFrom) -> None:
+        if self.use_logical_deps():
+            # Just importing a name doesn't create a logical dependency.
+            return
         module_id, _ = correct_relative_import(self.scope.current_module_id(),
                                                o.relative,
                                                o.id,

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -1287,8 +1287,8 @@ def gg(x: C) -> None:
 [out]
 <foo.bar.C.ff> -> m.g
 <foo.bar.C.y> -> m.gg
-<foo.bar.C> -> <m.gg>, m, m.g, m.gg
-<foo.bar.f> -> m, m.g
+<foo.bar.C> -> <m.gg>, m.g, m.gg
+<foo.bar.f> -> m.g
 
 [case testLogical__init__]
 # flags: --logical-deps


### PR DESCRIPTION
Only uses of names should be included as logical dependencies.