### PR TITLE
Fix fine-grained dependencies for super()

### DIFF
--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -641,9 +641,18 @@ class DependencyVisitor(TraverserVisitor):
         return None
 
     def visit_super_expr(self, e: SuperExpr) -> None:
-        super().visit_super_expr(e)
+        # Arguments in "super(C, self)" won't generate useful logical deps.
+        if not self.use_logical_deps():
+            super().visit_super_expr(e)
         if e.info is not None:
-            self.add_dependency(make_trigger(e.info.fullname() + '.' + e.name))
+            name = e.name
+            for base in non_trivial_bases(e.info):
+                self.add_dependency(make_trigger(base.fullname() + '.' + name))
+                if name in base.names:
+                    # No need to depend on further base classes, since we found
+                    # the target.  This is safe since if the target gets
+                    # deleted or modified, we'll trigger it.
+                    break
 
     def visit_call_expr(self, e: CallExpr) -> None:
         super().visit_call_expr(e)

--- a/test-data/unit/deps-classes.test
+++ b/test-data/unit/deps-classes.test
@@ -136,10 +136,8 @@ class D(C):
 <m.C.(abstract)> -> <m.D.__init__>, m
 <m.C.__init__> -> <m.D.__init__>, m.D.__init__
 <m.C.__new__> -> <m.D.__new__>
-<m.C.foo> -> <m.D.foo>
+<m.C.foo> -> <m.D.foo>, m.D.__init__
 <m.C> -> m, m.C, m.D
-<m.D.__init__> -> m.D.__init__
-<m.D.foo> -> m.D.__init__
 <m.D> -> m.D
 
 [case testClassMissingInit]

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -1329,9 +1329,11 @@ class B(A):
 class C(B):
     pass
 class D(C):
-    def __init__(self): # type: () -> None
+    def __init__(self):
+        # type: () -> None
         super(B, self).__init__()
-    def mm(self): # type: () -> None
+    def mm(self):
+        # type: () -> None
         super(B, self).m()
 [out]
 <m.A.__init__> -> m.D.__init__

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -1315,3 +1315,35 @@ def h() -> None:
 <m.D.__init__> -> m.h
 <m.D.__new__> -> m.h
 <m.D> -> m.D, m.h
+
+[case testLogicalSuperPython2]
+# flags: --logical-deps --py2
+class A:
+    def __init__(self):
+        pass
+    def m(self):
+        pass
+class B(A):
+    def m(self):
+        pass
+class C(B):
+    pass
+class D(C):
+    def __init__(self): # type: () -> None
+        super(B, self).__init__()
+    def mm(self): # type: () -> None
+        super(B, self).m()
+[out]
+<m.A.__init__> -> m.D.__init__
+<m.A.m> -> <m.B.m>, m.B.m
+<m.A.mm> -> m.D.mm
+<m.A> -> m, m.A, m.B
+<m.B.__init__> -> m.D.__init__
+<m.B.m> -> m.D.mm
+<m.B.mm> -> m.D.mm
+<m.B> -> m, m.B, m.C
+<m.C.__init__> -> m.D.__init__
+<m.C.m> -> m.D.mm
+<m.C.mm> -> m.D.mm
+<m.C> -> m, m.C, m.D
+<m.D> -> m.D


### PR DESCRIPTION
This fixes both normal and logical dependencies. We now generate
dependencies from potential target attributes in base classes. Also,
we don't generate logical dependencies based on the type object
in Python 2 style `super()` expressions, since they aren't
relevant.