### PR TITLE
Fix decorators on class __init__ methods

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3019,10 +3019,16 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                                    callable_name=fullname)
         self.check_untyped_after_decorator(sig, e.func)
         sig = set_callable_name(sig, e.func)
-        e.var.type = sig
-        e.var.is_ready = True
         if e.func.is_property:
             self.check_incompatible_property_override(e)
+        e.var.type = sig
+        e.var.is_ready = True
+        if isinstance(sig, CallableType):
+            if e.func.is_property:
+                assert isinstance(sig, CallableType)
+                e.is_callable = isinstance(sig.ret_type, CallableType)
+            else:
+                e.is_callable = True
         if e.func.info and not e.func.is_dynamic():
             self.check_method_override(e)
 

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -77,7 +77,7 @@ def analyze_member_access(name: str,
 
         # Look up the member. First look up the method dictionary.
         method = info.get_method(name)
-        if method:
+        if method and not method.is_class:
             if method.is_property:
                 assert isinstance(method, OverloadedFuncDef)
                 first_item = cast(Decorator, method.items[0])
@@ -87,7 +87,7 @@ def analyze_member_access(name: str,
                 msg.cant_assign_to_method(node)
             signature = function_type(method, builtin_type('builtins.function'))
             signature = freshen_function_type_vars(signature)
-            if name == '__new__':
+            if name == '__new__' or method.is_static:
                 # __new__ is special and behaves like a static method -- don't strip
                 # the first argument.
                 pass

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -7,9 +7,9 @@ from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.fixup import lookup_qualified_stnode
 from mypy.nodes import (
     Context, Argument, Var, ARG_OPT, ARG_POS, TypeInfo, AssignmentStmt,
-    TupleExpr, ListExpr, NameExpr, CallExpr, RefExpr, FuncBase,
-    is_class_var, TempNode, Decorator, MemberExpr, Expression, FuncDef, Block,
-    PassStmt, SymbolTableNode, MDEF, JsonDict, OverloadedFuncDef
+    TupleExpr, ListExpr, NameExpr, CallExpr, RefExpr, is_class_var,
+    TempNode, Decorator, MemberExpr, Expression, FuncDef, Block,
+    PassStmt, SymbolTableNode, MDEF, JsonDict, OverloadedFuncDef, get_callable
 )
 from mypy.plugins.common import (
     _get_argument, _get_bool_argument, _get_decorator_bool_argument
@@ -405,9 +405,8 @@ def _parse_converter(ctx: 'mypy.plugin.ClassDefContext',
     # TODO: Support complex converters, e.g. lambdas, calls, etc.
     if converter:
         if isinstance(converter, RefExpr) and converter.node:
-            if (isinstance(converter.node, FuncBase)
-                    and converter.node.type
-                    and isinstance(converter.node.type, FunctionLike)):
+            method = get_callable(converter.node)
+            if method and method.type and isinstance(method.type, FunctionLike):
                 return Converter(converter.node.fullname())
             elif isinstance(converter.node, TypeInfo):
                 return Converter(converter.node.fullname())

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -1,8 +1,8 @@
 from typing import List, Optional, Any
 
 from mypy.nodes import (
-    ARG_POS, MDEF, Argument, Block, CallExpr, Expression, FuncBase,
-    FuncDef, PassStmt, RefExpr, SymbolTableNode, Var
+    ARG_POS, MDEF, Argument, Block, CallExpr, Expression, FuncDef,
+    PassStmt, RefExpr, SymbolTableNode, Var, get_callable
 )
 from mypy.plugin import ClassDefContext
 from mypy.semanal import set_callable_name
@@ -53,8 +53,9 @@ def _get_argument(call: CallExpr, name: str) -> Optional[Expression]:
     callee_type = None
     # mypyc hack to workaround mypy misunderstanding multiple inheritance (#3603)
     callee_node = call.callee.node  # type: Any
-    if (isinstance(callee_node, (Var, FuncBase))
-            and callee_node.type):
+    if not isinstance(callee_node, Var):
+        callee_node = get_callable(callee_node)
+    if callee_node and callee_node.type:
         callee_node_type = callee_node.type
         if isinstance(callee_node_type, Overloaded):
             # We take the last overload.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2518,6 +2518,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 self.check_decorated_function_is_method('classmethod', dec)
             elif (refers_to_fullname(d, 'builtins.property') or
                   refers_to_fullname(d, 'abc.abstractproperty')):
+                # TODO: Stop treating properties as special cases and treat as generalized
+                # TODO: descriptors
                 removed.append(i)
                 dec.func.is_property = True
                 dec.var.is_property = True

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2518,8 +2518,6 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 self.check_decorated_function_is_method('classmethod', dec)
             elif (refers_to_fullname(d, 'builtins.property') or
                   refers_to_fullname(d, 'abc.abstractproperty')):
-                # TODO: Stop treating properties as special cases and treat as generalized
-                # TODO: descriptors
                 removed.append(i)
                 dec.func.is_property = True
                 dec.var.is_property = True

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -5610,3 +5610,29 @@ from typing import TypeVar, Tuple, Callable
 T = TypeVar('T')
 def deco(f: Callable[..., T]) -> Callable[..., Tuple[T, int]]: ...
 [out]
+
+[case testDecoratedInit]
+from typing import Callable, Any
+def dec(func: Callable[[Any], None]) -> Callable[[Any], None]:
+    return func
+
+class A:
+    @dec
+    def __init__(self):
+        pass
+
+reveal_type(A())  # E: Revealed type is '__main__.A'
+[out]
+
+[case testAbstractInit]
+from abc import abstractmethod
+class A:
+    @abstractmethod
+    def __init__(self): ...
+
+class B(A):
+    def __init__(self):
+        pass
+
+reveal_type(B())  # E: Revealed type is '__main__.B'
+[out]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2383,3 +2383,16 @@ def foo() -> None:
 
 def lol():
     x = foo()
+
+
+[case testNonCallableDecorator]
+def dec(func) -> int:
+    return 1
+
+@dec
+def f():
+    pass
+
+reveal_type(f)  # E: Revealed type is 'builtins.int'
+f()             # E: "int" not callable
+[out]


### PR DESCRIPTION
This fixes a few issues around decorators, specifically resolves #5398 and #1706. Not sure if this is exactly the way you want to fix this. Probably better would be to get rid of the `Decorator` class altogether, but this provides a workable fix. My reasoning on it is this:
* Many places check whether a `Node` is callable by checking whether it is an instance of `FuncBase`.
* Replace these with a `get_callable` method, which will return a `FuncBase` if it makes sense to construct one for the passed in `Node`, otherwise return `None`.
* This method currently only checks if a `Node` is a `FuncBase` or a callable `Decorator`, but could conceivably be expanded to cover other cases with minimal additional work.
* In the case of a `Decorator` return an instance of the `CallableDecorator` class, which inherits from `FuncItem` iff the decorated function is still callable.
This works, but creates problems in a few places in the codebase that explicitly assume that an instance of `FuncBase` is not decorated. I have fixed the instances of this I could find, and all of the existing tests pass, but we probably want to do more testing on this to be sure.

Stray observations:
* It would be nice if we didn't have to treat `property` and similar descriptor-based decorators as special cases and could work with them more directly. Possibly by having their implementations in typeshed be `Generic`s with appropriate types. This would probably require more robust type annotation than we currently support though.
* It may make sense to either rename `Var.is_staticmethod` and `Var.is_classmethod` to `Var.is_static` and `Var.is_class` or rename `FuncBase.is_static` and `FuncBase.is_class` to `FuncBase.is_staticmethod` and `FuncBase.is_classmethod`. They duplicate the same functionality, and this would help remove some unneeded type checks in a few places.
* I experimented with having properties just return their property type, rather than being treated as a special type of callable. This made a few things nicer, in particular fixing the false positive in `testInferListInitializedToEmptyInClassBodyAndOverriden`, but created problems in other places. This may be worth investigating further.
* This change may make it easier to implement properties with different get/set types as suggested in #3004, I will need to investigate further.
* This change probably means that there is a lot of code related to handling `Decorator`s that is no longer needed, but I am not familiar enough with the codebase to say that for sure.
* This fix requires that the decorator is explicitly annotated to return a `Callable`. It seems like this should be something we could determine through type inference, but I'm not sure how easy that would be to do.

I look forward to your criticisms.