### PR TITLE
Remove redundant logical dependencies for decorated functions

### DIFF
--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -203,12 +203,13 @@ class DependencyVisitor(TraverserVisitor):
         self.scope.leave()
 
     def visit_decorator(self, o: Decorator) -> None:
-        # We don't need to recheck outer scope for an overload, only overload itself.
-        # Also if any decorator is nested, it is not externally visible, so we don't need to
-        # generate dependency.
-        if not o.func.is_overload and self.scope.current_function_name() is None:
-            self.add_dependency(make_trigger(o.func.fullname()))
-        if self.use_logical_deps():
+        if not self.use_logical_deps():
+            # We don't need to recheck outer scope for an overload, only overload itself.
+            # Also if any decorator is nested, it is not externally visible, so we don't need to
+            # generate dependency.
+            if not o.func.is_overload and self.scope.current_function_name() is None:
+                self.add_dependency(make_trigger(o.func.fullname()))
+        else:
             # Add logical dependencies from decorators to the function. For example,
             # if we have
             #     @dec

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -1146,7 +1146,6 @@ from typing import Callable
 def dec(f: Callable[[], None]) -> Callable[[], None]:
     pass
 [out]
-<m.f> -> m
 <mod.dec> -> <m.f>, m
 
 [case testLogicalDecoratorWithArgs]
@@ -1160,7 +1159,6 @@ from typing import Callable
 def dec(arg: str) -> Callable[[Callable[[], None]], Callable[[], None]]:
     pass
 [out]
-<m.f> -> m
 <mod.dec> -> <m.f>, m
 
 [case testLogicalDecoratorMember]
@@ -1174,7 +1172,6 @@ from typing import Callable
 def dec(f: Callable[[], None]) -> Callable[[], None]:
     pass
 [out]
-<m.f> -> m
 <mod.dec> -> <m.f>, m
 <mod> -> m
 


### PR DESCRIPTION
A decorated function used to have a logical dependency to the
definition scope, which didn't make much sense. They are still
required for fine-grained incremental checking.