### PR TITLE
Explain that you can sometimes safely omit __init__ return type

### DIFF
--- a/docs/source/class_basics.rst
+++ b/docs/source/class_basics.rst
@@ -8,7 +8,7 @@ rules.
 Instance and class attributes
 *****************************
 
-Mypy type checker detects if you are trying to access a missing
+The mypy type checker detects if you are trying to access a missing
 attribute, which is a very common programming error. For this to work
 correctly, instance and class attributes must be defined or
 initialized within the class. Mypy infers the types of attributes:
@@ -80,13 +80,13 @@ to it explicitly using ``self``:
 Class attribute annotations
 ***************************
 
-Mypy supports annotations for class and instance 
+Mypy supports annotations for class and instance
 variables in class bodies and methods. Use ``ClassVar`` to
-indicate to the static type checker that this variable 
-should not be set on instances. 
+indicate to the static type checker that this variable
+should not be set on instances.
 
-A class attribute without the ``ClassVar`` annotation can be used as 
-a class variable. Mypy won't prevent it from being used as an 
+A class attribute without the ``ClassVar`` annotation can be used as
+a class variable. Mypy won't prevent it from being used as an
 instance variable.
 
 .. code-block:: python
@@ -99,12 +99,12 @@ The following are worth noting about ``ClassVar``:
 
 - It accepts only types and cannot be further subscribed.
 
-- It is not a class itself, and should not be used with 
-isinstance() or issubclass(). 
+- It is not a class itself, and should not be used with
+  isinstance() or issubclass().
 
-- It does not change Python runtime behavior, but it can 
-be used by third-party type checkers. For example, a type checker 
-might flag the following code as an error:
+- It does not change Python runtime behavior, but it can
+  be used by third-party type checkers. For example, a type checker
+  might flag the following code as an error:
 
 .. code-block:: python
 
@@ -113,13 +113,43 @@ might flag the following code as an error:
   a.z = {}                # This is OK
 
 
-Also `` y: ClassVar = 0 `` is valid (without square brackets). The type of 
+Also `` y: ClassVar = 0 `` is valid (without square brackets). The type of
 the variable will be implicitly ``Any``. This behavior will change in the future.
 
 .. note::
-   A ``ClassVar`` parameter cannot include any type variables, 
+   A ``ClassVar`` parameter cannot include any type variables,
    regardless of the level of nesting: ``ClassVar[T]`` and ``ClassVar[List[Set[T]]]``
    are both invalid if ``T`` is a type variable.
+
+Annotating `__init__` methods
+*****************************
+
+The ``__init__`` method is somewhat special -- it doesn't return a
+value.  This is best expressed as ``-> None``.  However, since many feel
+this is redundant, it is allowed to omit the return type declaration
+on ``__init__`` methods **if at least one argument is annotated**.  For
+example, in the following classes ``__init__`` is considered fully
+annotated:
+
+.. code-block:: python
+
+   class C1:
+       def __init__(self) -> None:
+           self.var = 42
+
+   class C2:
+       def __init__(self, arg: int):
+           self.var = arg
+
+However, if ``__init__`` has no annotated arguments and no return type
+annotation, it is considered an untyped method:
+
+.. code-block:: python
+
+   class C3:
+       def __init__(self):
+           # This body is not type checked
+           self.var = 42 + 'abc'
 
 Overriding statically typed methods
 ***********************************


### PR DESCRIPTION
Fixes #5790