### PR TITLE
Use actual variable name for failed enum calls

### DIFF
--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -36,7 +36,7 @@ class EnumCallAnalyzer:
 
     def check_enum_call(self,
                         node: Expression,
-                        var_name: Optional[str],
+                        var_name: str,
                         is_func_scope: bool) -> Optional[TypeInfo]:
         """Check if a call defines an Enum.
 
@@ -62,7 +62,7 @@ class EnumCallAnalyzer:
         items, values, ok = self.parse_enum_call_args(call, fullname.split('.')[-1])
         if not ok:
             # Error. Construct dummy return value.
-            return self.build_enum_call_typeinfo('Enum', [], fullname)
+            return self.build_enum_call_typeinfo(var_name, [], fullname)
         name = cast(Union[StrExpr, UnicodeExpr], call.args[0]).value
         if name != var_name or is_func_scope:
             # Give it a unique name derived from the line number.

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5366,3 +5366,26 @@ except Exception as e:
 [builtins fixtures/exception.pyi]
 [out]
 [out2]
+
+[case testBadEnumLoading]
+import a
+[file a.py]
+from b import E
+x: E
+y = 1
+
+[file a.py.2]
+from b import E
+x: E
+y = 2
+
+[file b.py]
+from typing import List
+from enum import Enum
+
+def f() -> List[str]: ...
+
+E = Enum('E', f())  # type: ignore
+[builtins fixtures/list.pyi]
+[out]
+[out2]


### PR DESCRIPTION
This fixes a crash discovered in internal codebases.