### PR TITLE
Don't wait for tests before triggering mypyc wheel build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ jobs:
     - TOXENV=lint
     - EXTRA_ARGS=
   - name: "trigger a build of wheels"
-    stage: deploy
     python: 3.7
     script: if [[ $TRAVIS_BRANCH = "master" && $TRAVIS_PULL_REQUEST = "false" ]]; then ./misc/trigger_wheel_build.sh; fi
 


### PR DESCRIPTION
Triggering a build of mypy_mypyc wheels for a broken revision is not
actually a big deal, and waiting for the tests before starting to
build the wheels unnecessarily lengthens the critical path to
deploying a new version.