### PR TITLE
Add path expansion for write_junit_xml output argument

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -150,7 +150,14 @@ def write_junit_xml(dt: float, serious: bool, messages: List[str], path: str) ->
         xml = FAIL_TEMPLATE.format(text=escape('\n'.join(messages)), time=dt)
     else:
         xml = ERROR_TEMPLATE.format(text=escape('\n'.join(messages)), time=dt)
-    with open(path, 'wb') as f:
+
+    # checks for a directory structure in path and creates folders if needed
+    xml_path = os.path.expanduser(os.path.expandvars(path))
+    xml_dirs = os.path.dirname(os.path.abspath(xml_path))
+    if not os.path.isdir(xml_dirs):
+        os.makedirs(xml_dirs)
+
+    with open(xml_path, 'wb') as f:
         f.write(xml.encode('utf-8'))
 
 

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -152,12 +152,11 @@ def write_junit_xml(dt: float, serious: bool, messages: List[str], path: str) ->
         xml = ERROR_TEMPLATE.format(text=escape('\n'.join(messages)), time=dt)
 
     # checks for a directory structure in path and creates folders if needed
-    xml_path = os.path.expandvars(path)
-    xml_dirs = os.path.dirname(os.path.abspath(xml_path))
+    xml_dirs = os.path.dirname(os.path.abspath(path))
     if not os.path.isdir(xml_dirs):
         os.makedirs(xml_dirs)
 
-    with open(xml_path, 'wb') as f:
+    with open(path, 'wb') as f:
         f.write(xml.encode('utf-8'))
 
 

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -152,7 +152,7 @@ def write_junit_xml(dt: float, serious: bool, messages: List[str], path: str) ->
         xml = ERROR_TEMPLATE.format(text=escape('\n'.join(messages)), time=dt)
 
     # checks for a directory structure in path and creates folders if needed
-    xml_path = os.path.expanduser(os.path.expandvars(path))
+    xml_path = os.path.expandvars(path)
     xml_dirs = os.path.dirname(os.path.abspath(xml_path))
     if not os.path.isdir(xml_dirs):
         os.makedirs(xml_dirs)


### PR DESCRIPTION
Hi - this is a small addition to allow the `--junit-xml` arg to accept a string path as well as a file.

Example:

```
$ mypy file1.py --junit-xml=a.xml

$ mypy file1.py --junit.xml "this/is/a/test.xml"
$ tree this/
this/
└── is
    └── a
        └── test.xml

2 directories, 1 file
```