### PR TITLE
Correct lint errors and silence W504

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -110,10 +110,10 @@ class ConditionalTypeBinder:
         self.options_on_return.append([])
         return f
 
-    def _put(self, key: Key, type: Type, index: int=-1) -> None:
+    def _put(self, key: Key, type: Type, index: int = -1) -> None:
         self.frames[index].types[key] = type
 
-    def _get(self, key: Key, index: int=-1) -> Optional[Type]:
+    def _get(self, key: Key, index: int = -1) -> Optional[Type]:
         if index < 0:
             index += len(self.frames)
         for i in range(index, -1, -1):

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -865,7 +865,7 @@ def atomic_write(filename: str, line1: str, line2: str) -> bool:
             for line in lines:
                 f.write(line)
         os.replace(tmp_filename, filename)
-    except os.error as err:
+    except os.error:
         return False
     return True
 

--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -151,7 +151,7 @@ def do_start(args: argparse.Namespace) -> None:
     """
     try:
         get_status()
-    except BadStatus as err:
+    except BadStatus:
         # Bad or missing status file or dead process; good to start.
         pass
     else:
@@ -435,7 +435,7 @@ def check_status(data: Dict[str, Any]) -> Tuple[int, str]:
         raise BadStatus("pid field is not an int")
     try:
         os.kill(pid, 0)
-    except OSError as err:
+    except OSError:
         raise BadStatus("Daemon has died")
     if 'sockname' not in data:
         raise BadStatus("Invalid status file (no sockname field)")
@@ -456,7 +456,7 @@ def read_status() -> Dict[str, object]:
     with open(STATUS_FILE) as f:
         try:
             data = json.load(f)
-        except Exception as err:
+        except Exception:
             raise BadStatus("Malformed status file (not JSON)")
     if not isinstance(data, dict):
         raise BadStatus("Invalid status file (not a dict)")
@@ -467,7 +467,7 @@ def is_running() -> bool:
     """Check if the server is running cleanly"""
     try:
         get_status()
-    except BadStatus as err:
+    except BadStatus:
         return False
     return True
 

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -170,7 +170,7 @@ class Server:
                         sys.exit(0)
                     try:
                         data = receive(conn)
-                    except OSError as err:
+                    except OSError:
                         conn.close()  # Maybe the client hung up
                         continue
                     resp = {}  # type: Dict[str, Any]
@@ -192,7 +192,7 @@ class Server:
                                 raise
                     try:
                         conn.sendall(json.dumps(resp).encode('utf8'))
-                    except OSError as err:
+                    except OSError:
                         pass  # Maybe the client hung up
                     conn.close()
                     if command == 'stop':

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1917,7 +1917,7 @@ class TypeVarExpr(SymbolNode, Expression):
     def __init__(self, name: str, fullname: str,
                  values: List['mypy.types.Type'],
                  upper_bound: 'mypy.types.Type',
-                 variance: int=INVARIANT) -> None:
+                 variance: int = INVARIANT) -> None:
         super().__init__()
         self._name = name
         self._fullname = fullname

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -11,7 +11,7 @@ from mypy.subtypes import is_subtype
 
 
 def solve_constraints(vars: List[TypeVarId], constraints: List[Constraint],
-                      strict: bool =True) -> List[Optional[Type]]:
+                      strict: bool = True) -> List[Optional[Type]]:
     """Solve type constraints.
 
     Return the best type(s) for type variables; each type can be None if the value of the variable

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -348,7 +348,7 @@ class ImportTracker:
             if alias:
                 self.reverse_alias[alias] = name
 
-    def add_import(self, module: str, alias: Optional[str]=None) -> None:
+    def add_import(self, module: str, alias: Optional[str] = None) -> None:
         name = module.split('.')[0]
         self.module_for[alias or name] = None
         self.direct_imports[name] = module
@@ -625,7 +625,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         self.add('%s = namedtuple(%s, %s)\n' % (lvalue.name, name, items))
         self._state = CLASS
 
-    def is_type_expression(self, expr: Expression, top_level: bool=True) -> bool:
+    def is_type_expression(self, expr: Expression, top_level: bool = True) -> bool:
         """Return True for things that look like type expressions
 
         Used to know if assignments look like typealiases
@@ -994,7 +994,7 @@ def default_python2_interpreter() -> str:
     raise SystemExit("Can't find a Python 2 interpreter -- please use the -p option")
 
 
-def usage(exit_nonzero: bool=True) -> None:
+def usage(exit_nonzero: bool = True) -> None:
     usage = textwrap.dedent("""\
         usage: stubgen [--py2] [--no-import] [--doc-dir PATH]
                        [--search-path PATH] [-p PATH] [-o PATH]

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -479,7 +479,7 @@ def expand_errors(input: List[str], output: List[str], fnam: str) -> None:
         # The first in the split things isn't a comment
         for possible_err_comment in input[i].split(' # ')[1:]:
             m = re.search(
-                '^([ENW]):((?P<col>\d+):)? (?P<message>.*)$',
+                r'^([ENW]):((?P<col>\d+):)? (?P<message>.*)$',
                 possible_err_comment.strip())
             if m:
                 if m.group(1) == 'E':
@@ -572,11 +572,11 @@ def split_test_cases(parent: 'DataSuiteCollector', suite: 'DataSuite',
     """
     with open(file, encoding='utf-8') as f:
         data = f.read()
-    cases = re.split('^\[case ([a-zA-Z_0-9]+)'
-                     '(-writescache)?'
-                     '(-only_when_cache|-only_when_nocache)?'
-                     '(-skip)?'
-                     '\][ \t]*$\n', data,
+    cases = re.split(r'^\[case ([a-zA-Z_0-9]+)'
+                     r'(-writescache)?'
+                     r'(-only_when_cache|-only_when_nocache)?'
+                     r'(-skip)?'
+                     r'\][ \t]*$\n', data,
                      flags=re.DOTALL | re.MULTILINE)
     line_no = cases[0].count('\n') + 1
     for i in range(1, len(cases), 5):

--- a/mypy/test/testmerge.py
+++ b/mypy/test/testmerge.py
@@ -114,7 +114,7 @@ class ASTMergeSuite(DataSuite):
             result = build.build(sources=[BuildSource(main_path, None, None)],
                                  options=options,
                                  alt_lib_path=test_temp_dir)
-        except CompileError as e:
+        except CompileError:
             # TODO: Is it okay to return None?
             return None
         return result

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -20,7 +20,7 @@ class TypeFixture:
     The members are initialized to contain various type-related values.
     """
 
-    def __init__(self, variance: int=COVARIANT) -> None:
+    def __init__(self, variance: int = COVARIANT) -> None:
         # The 'object' class
         self.oi = self.make_type_info('builtins.object')               # class object
         self.o = Instance(self.oi, [])                        # object

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -209,7 +209,7 @@ def get_class_descriptors(cls: 'Type[object]') -> Sequence[str]:
     return fields_cache[cls]
 
 
-def replace_object_state(new: object, old: object, copy_dict: bool=False) -> None:
+def replace_object_state(new: object, old: object, copy_dict: bool = False) -> None:
     """Copy state of old node to the new node.
 
     This handles cases where there is __dict__ and/or attribute descriptors

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,12 +35,13 @@ exclude =
 #   W601: has_key() deprecated (false positives)
 #   E701: multiple statements on one line (colon) (we use this for classes with empty body)
 #   W503: line break before binary operator
+#   W504: line break after binary operator
 #   E704: multiple statements on one line (def)
 #   E402: module level import not at top of file
 #   B3??: Python 3 compatibility warnings
 #   B006: use of mutable defaults in function signatures
 #   B007: Loop control variable not used within the loop body.
-ignore = E251,E128,F401,W601,E701,W503,E704,E402,B3,B006,B007
+ignore = E251,E128,F401,W601,E701,W503,W504,E704,E402,B3,B006,B007
 
 [coverage:run]
 branch = true


### PR DESCRIPTION
Flake8 3.6.0 is a bit more strict on some things, so this fixes the complaints and silences W504 (line break after operator) since that is very common in our code (and we seem to silence W503 too).

For an example of what the failing flake8 output looks like, see https://travis-ci.org/python/mypy/jobs/445480219.
