### PR TITLE
Make descriptor assignments more like normal assignments

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1787,7 +1787,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 elif (isinstance(lvalue, MemberExpr) and
                         lvalue.kind is None):  # Ignore member access to modules
                     instance_type = self.expr_checker.accept(lvalue.expr)
-                    rvalue_type, infer_lvalue_type = self.check_member_assignment(
+                    rvalue_type, lvalue_type, infer_lvalue_type = self.check_member_assignment(
                         instance_type, lvalue_type, rvalue, lvalue)
                 else:
                     rvalue_type = self.check_simple_assignment(lvalue_type, rvalue, lvalue)
@@ -2491,7 +2491,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             return rvalue_type
 
     def check_member_assignment(self, instance_type: Type, attribute_type: Type,
-                                rvalue: Expression, context: Context) -> Tuple[Type, bool]:
+                                rvalue: Expression, context: Context) -> Tuple[Type, Type, bool]:
         """Type member assignment.
 
         This defers to check_simple_assignment, unless the member expression
@@ -2505,28 +2505,28 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if ((isinstance(instance_type, FunctionLike) and instance_type.is_type_obj()) or
                 isinstance(instance_type, TypeType)):
             rvalue_type = self.check_simple_assignment(attribute_type, rvalue, context)
-            return rvalue_type, True
+            return rvalue_type, attribute_type, True
 
         if not isinstance(attribute_type, Instance):
+            # TODO: support __set__() for union types.
             rvalue_type = self.check_simple_assignment(attribute_type, rvalue, context)
-            return rvalue_type, True
+            return rvalue_type, attribute_type, True
 
+        get_type = analyze_descriptor_access(
+                       instance_type, attribute_type, self.named_type,
+                       self.msg, context, chk=self)
         if not attribute_type.type.has_readable_member('__set__'):
             # If there is no __set__, we type-check that the assigned value matches
             # the return type of __get__. This doesn't match the python semantics,
             # (which allow you to override the descriptor with any value), but preserves
             # the type of accessing the attribute (even after the override).
-            if attribute_type.type.has_readable_member('__get__'):
-                attribute_type = analyze_descriptor_access(
-                    instance_type, attribute_type, self.named_type,
-                    self.msg, context, chk=self)
-            rvalue_type = self.check_simple_assignment(attribute_type, rvalue, context)
-            return rvalue_type, True
+            rvalue_type = self.check_simple_assignment(get_type, rvalue, context)
+            return rvalue_type, get_type, True
 
         dunder_set = attribute_type.type.get_method('__set__')
         if dunder_set is None:
             self.msg.fail("{}.__set__ is not callable".format(attribute_type), context)
-            return AnyType(TypeOfAny.from_error), False
+            return AnyType(TypeOfAny.from_error), get_type, False
 
         function = function_type(dunder_set, self.named_type('builtins.function'))
         bound_method = bind_self(function, attribute_type)
@@ -2539,19 +2539,19 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         if not isinstance(inferred_dunder_set_type, CallableType):
             self.fail("__set__ is not callable", context)
-            return AnyType(TypeOfAny.from_error), True
+            return AnyType(TypeOfAny.from_error), get_type, True
 
         if len(inferred_dunder_set_type.arg_types) < 2:
             # A message already will have been recorded in check_call
-            return AnyType(TypeOfAny.from_error), False
+            return AnyType(TypeOfAny.from_error), get_type, False
 
         set_type = inferred_dunder_set_type.arg_types[1]
         # Special case: if the rvalue_type is a subtype of both '__get__' and '__set__' types,
         # then we invoke the binder to narrow type by this assignment. Technically, this is not
-        # type-safe, but in practice this is what a user expects.
+        # safe, but in practice this is what a user expects.
         rvalue_type = self.check_simple_assignment(set_type, rvalue, context)
-        infer = is_subtype(rvalue_type, set_type) and is_subtype(rvalue_type, attribute_type)
-        return set_type, infer
+        infer = is_subtype(rvalue_type, set_type) and is_subtype(rvalue_type, get_type)
+        return rvalue_type if infer else set_type, get_type, infer
 
     def check_indexed_assignment(self, lvalue: IndexExpr,
                                  rvalue: Expression, context: Context) -> None:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2513,8 +2513,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             return rvalue_type, attribute_type, True
 
         get_type = analyze_descriptor_access(
-                       instance_type, attribute_type, self.named_type,
-                       self.msg, context, chk=self)
+            instance_type, attribute_type, self.named_type,
+            self.msg, context, chk=self)
         if not attribute_type.type.has_readable_member('__set__'):
             # If there is no __set__, we type-check that the assigned value matches
             # the return type of __get__. This doesn't match the python semantics,

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1383,9 +1383,9 @@ class A:
     g = D('10')
 a = A()
 a.f = 1
-a.f = '' # E:  Incompatible types in assignment (expression has type "str", variable has type "int")
+a.f = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 a.g = ''
-a.g = 1 # E:  Incompatible types in assignment (expression has type "int", variable has type "str")
+a.g = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testAccessingGenericDescriptorFromClass]
 # flags: --strict-optional

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1301,7 +1301,7 @@ class A:
     f = D()
 a = A()
 a.f = ''
-a.f = 1 # E: Argument 2 to "__set__" of "D" has incompatible type "int"; expected "str"
+a.f = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testReadingDescriptorWithoutDunderGet]
 from typing import Union, Any
@@ -1383,9 +1383,9 @@ class A:
     g = D('10')
 a = A()
 a.f = 1
-a.f = '' # E: Argument 2 to "__set__" of "D" has incompatible type "str"; expected "int"
+a.f = '' # E:  Incompatible types in assignment (expression has type "str", variable has type "int")
 a.g = ''
-a.g = 1 # E: Argument 2 to "__set__" of "D" has incompatible type "int"; expected "str"
+a.g = 1 # E:  Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testAccessingGenericDescriptorFromClass]
 # flags: --strict-optional
@@ -1479,7 +1479,7 @@ class A:
     f = D()
 a = A()
 a.f = ''
-a.f = 1 # E: Argument 2 to "__set__" of "C" has incompatible type "int"; expected "str"
+a.f = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testReadingDescriptorSubclassWithoutDunderGet]
 from typing import Union, Any
@@ -1520,9 +1520,9 @@ class A:
     g = D('10')  # type: D[A, str]
 a = A()
 a.f = 1
-a.f = '' # E: Argument 2 to "__set__" of "C" has incompatible type "str"; expected "int"
+a.f = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 a.g = ''
-a.g = 1 # E: Argument 2 to "__set__" of "C" has incompatible type "int"; expected "str"
+a.g = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testSetDescriptorOnClass]
 from typing import TypeVar, Type, Generic
@@ -5610,3 +5610,59 @@ from typing import TypeVar, Tuple, Callable
 T = TypeVar('T')
 def deco(f: Callable[..., T]) -> Callable[..., Tuple[T, int]]: ...
 [out]
+
+[case testOptionalDescriptorsBinder]
+# flags: --strict-optional
+from typing import Type, TypeVar, Optional
+T = TypeVar('T')
+
+class IntDescr:
+  def __get__(self, obj: T, typ: Type[T]) -> Optional[int]: ...
+  def __set__(self, obj: T, value: Optional[int]) -> None: ...
+
+class C:
+  spec = IntDescr()
+
+  def meth_spec(self) -> int:
+    if self.spec is None:
+      self.spec = 0
+    return self.spec
+[builtins fixtures/bool.pyi]
+
+[case testUnionDescriptorsBinder]
+from typing import Type, TypeVar, Union
+T = TypeVar('T')
+
+class A: ...
+class B: ...
+
+class UnionDescr:
+  def __get__(self, obj: T, typ: Type[T]) -> Union[A, B]: ...
+  def __set__(self, obj: T, value: Union[A, B]) -> None: ...
+
+class C:
+  spec = UnionDescr()
+
+  def meth_spec(self) -> A:
+    self.spec = A()
+    return self.spec
+[builtins fixtures/bool.pyi]
+
+[case testSubclassDescriptorsBinder]
+from typing import Type, TypeVar, Optional
+T = TypeVar('T')
+
+class A: ...
+class B(A): ...
+
+class SubDescr:
+  def __get__(self, obj: T, typ: Type[T]) -> A: ...
+  def __set__(self, obj: T, value: A) -> None: ...
+
+class C:
+  spec = SubDescr()
+
+  def meth_spec(self) -> B:
+    self.spec = B()
+    return self.spec
+[builtins fixtures/bool.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -5617,16 +5617,16 @@ from typing import Type, TypeVar, Optional
 T = TypeVar('T')
 
 class IntDescr:
-  def __get__(self, obj: T, typ: Type[T]) -> Optional[int]: ...
-  def __set__(self, obj: T, value: Optional[int]) -> None: ...
+    def __get__(self, obj: T, typ: Type[T]) -> Optional[int]: ...
+    def __set__(self, obj: T, value: Optional[int]) -> None: ...
 
 class C:
-  spec = IntDescr()
+    spec = IntDescr()
 
-  def meth_spec(self) -> int:
-    if self.spec is None:
-      self.spec = 0
-    return self.spec
+    def meth_spec(self) -> None:
+        if self.spec is None:
+            self.spec = 0
+        reveal_type(self.spec)  # E: Revealed type is 'builtins.int'
 [builtins fixtures/bool.pyi]
 
 [case testUnionDescriptorsBinder]
@@ -5637,15 +5637,15 @@ class A: ...
 class B: ...
 
 class UnionDescr:
-  def __get__(self, obj: T, typ: Type[T]) -> Union[A, B]: ...
-  def __set__(self, obj: T, value: Union[A, B]) -> None: ...
+    def __get__(self, obj: T, typ: Type[T]) -> Union[A, B]: ...
+    def __set__(self, obj: T, value: Union[A, B]) -> None: ...
 
 class C:
-  spec = UnionDescr()
+    spec = UnionDescr()
 
-  def meth_spec(self) -> A:
-    self.spec = A()
-    return self.spec
+    def meth_spec(self) -> None:
+        self.spec = A()
+        reveal_type(self.spec)  # E: Revealed type is '__main__.A'
 [builtins fixtures/bool.pyi]
 
 [case testSubclassDescriptorsBinder]
@@ -5656,13 +5656,13 @@ class A: ...
 class B(A): ...
 
 class SubDescr:
-  def __get__(self, obj: T, typ: Type[T]) -> A: ...
-  def __set__(self, obj: T, value: A) -> None: ...
+    def __get__(self, obj: T, typ: Type[T]) -> A: ...
+    def __set__(self, obj: T, value: A) -> None: ...
 
 class C:
-  spec = SubDescr()
+    spec = SubDescr()
 
-  def meth_spec(self) -> B:
-    self.spec = B()
-    return self.spec
+    def meth_spec(self) -> None:
+        self.spec = B()
+        reveal_type(self.spec)  # E: Revealed type is '__main__.B'
 [builtins fixtures/bool.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5851

This makes descriptor assignments behave more like normal assignments. This includes:
* The same error message as for normal assignment
* Using binder to restrict types (but under a bit more strict condition)

I was not able to refactor all the logic to `checkmember.py`, but this is probably OK. Also this PR can introduce potential unsafety as discussed in the issue, but this is probably not much different from using binder in some other situations.