### PR TITLE
Fix dataclass inherited field ordering

### DIFF
--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -78,9 +78,43 @@ class Person(Mammal):
     name: str
     age: int
 
-reveal_type(Person)  # E: Revealed type is 'def (name: builtins.str, age: builtins.int) -> __main__.Person'
-Person('John', 32)
-Person('John', 21, None)  # E: Too many arguments for "Person"
+@dataclass
+class SpecialPerson(Person):
+    special_factor: float
+
+@dataclass
+class ExtraSpecialPerson(SpecialPerson):
+    age: int
+    special_factor: float
+    name: str
+
+reveal_type(Person)  # E: Revealed type is 'def (age: builtins.int, name: builtins.str) -> __main__.Person'
+reveal_type(SpecialPerson)  # E: Revealed type is 'def (age: builtins.int, name: builtins.str, special_factor: builtins.float) -> __main__.SpecialPerson'
+reveal_type(ExtraSpecialPerson)  # E: Revealed type is 'def (age: builtins.int, name: builtins.str, special_factor: builtins.float) -> __main__.ExtraSpecialPerson'
+Person(32, 'John')
+Person(21, 'John', None)  # E: Too many arguments for "Person"
+SpecialPerson(21, 'John', 0.5)
+ExtraSpecialPerson(21, 'John', 0.5)
+
+[builtins fixtures/list.pyi]
+
+[case testDataclassesOverridingWithDefaults]
+# Issue #5681 https://github.com/python/mypy/issues/5681
+# flags: --python-version 3.6
+from dataclasses import dataclass
+from typing import Any
+
+@dataclass
+class Base:
+    some_int: Any
+    some_str: str = 'foo'
+
+
+@dataclass
+class C(Base):
+    some_int: int
+
+reveal_type(C)  # E: Revealed type is 'def (some_int: builtins.int, some_str: builtins.str =) -> __main__.C'
 
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4625,7 +4625,7 @@ main:2: error: Argument 2 to "B" has incompatible type "str"; expected "int"
 
 [case testIncrementalDataclassesThreeFiles]
 from c import C
-C(5, 'foo', True)
+C('foo', 5, True)
 
 [file a.py]
 from dataclasses import dataclass
@@ -4662,6 +4662,7 @@ class C(A, B):
 [out1]
 [out2]
 tmp/c.py:7: error: Incompatible types in assignment (expression has type "bool", base class "B" defined the type as "str")
+main:2: error: Argument 2 to "C" has incompatible type "int"; expected "bool"
 
 [case testIncrementalDataclassesThreeRuns]
 from a import A


### PR DESCRIPTION
Fixes #5681.

This is how the dataclasses module behaves on Python 3.7.0:

    % cat test.py
    from dataclasses import dataclass

    @dataclass
    class Mammal:
        age: int

    @dataclass
    class Person(Mammal):
        name: str
        age: int

    @dataclass
    class SpecialPerson(Person):
        special_factor: float

    @dataclass
    class ExtraSpecialPerson(SpecialPerson):
        age: int
        special_factor: float
        name: str

    print(Person(32, 'John'))
    print(SpecialPerson(21, 'John', 0.5))
    print(ExtraSpecialPerson(21, 'John', 0.5))

    % python test.py
    Person(age=32, name='John')
    SpecialPerson(age=21, name='John', special_factor=0.5)
    ExtraSpecialPerson(age=21, name='John', special_factor=0.5)