### PR TITLE
Invalidate all cache files if plugins change

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -310,6 +310,8 @@ def load_plugins(options: Options, errors: Errors) -> Tuple[Plugin, Dict[str, st
 
     Return a plugin that encapsulates all plugins chained together. Always
     at least include the default plugin (it's last in the chain).
+    The second return value is a snapshot of versions/hashes of loaded user
+    plugins (for cache validation).
     """
     import importlib
     snapshot = {}  # type: Dict[str, str]
@@ -377,6 +379,9 @@ def load_plugins(options: Options, errors: Errors) -> Tuple[Plugin, Dict[str, st
                 '(in {})'.format(plugin_path))
         try:
             custom_plugins.append(plugin_type(options))
+            # We record _both_ hash and the version to detect more
+            # possible changes (e.g. if there is a change in modules
+            # imported by a plugin).
             if hasattr(module, '__file__'):
                 with open(module.__file__, 'rb') as f:
                     digest = hashlib.md5(f.read()).hexdigest()

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -888,6 +888,7 @@ def find_cache_meta(id: str, path: str, manager: BuildManager) -> Optional[Cache
         # Check if plugins are still the same.
         if manager.plugins_snapshot != manager.old_plugins_snapshot:
             manager.log('Metadata abandoned for {}: plugins differ'.format(id))
+            return None
 
     manager.add_stats(fresh_metas=1)
     return m
@@ -2210,6 +2211,9 @@ def dispatch(sources: List[BuildSource], manager: BuildManager) -> Graph:
         process_fine_grained_cache_graph(graph, manager)
     else:
         process_graph(graph, manager)
+        # Update plugins snapshot.
+        write_plugins_snapshot(manager)
+        manager.old_plugins_snapshot = manager.plugins_snapshot
         if manager.options.cache_fine_grained or manager.options.fine_grained_incremental:
             # If we are running a daemon or are going to write cache for further fine grained use,
             # then we need to collect fine grained protocol dependencies.

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -250,6 +250,12 @@ class Server:
                 return {'restart': 'configuration changed'}
             if __version__ != version:
                 return {'restart': 'mypy version changed'}
+            if self.fine_grained_manager:
+                manager = self.fine_grained_manager.manager
+                start_plugins_snapshot = manager.plugins_snapshot
+                _, current_plugins_snapshot = mypy.build.load_plugins(options, manager.errors)
+                if current_plugins_snapshot != start_plugins_snapshot:
+                    return {'restart': 'plugins changed'}
         except InvalidSourceList as err:
             return {'out': '', 'err': str(err), 'status': 2}
         return self.check(sources)

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -127,6 +127,10 @@ class TypeCheckSuite(DataSuite):
                 if isinstance(op, UpdateFile):
                     # Modify/create file
                     copy_and_fudge_mtime(op.source_path, op.target_path)
+                    # Unload already loaded plugins, if they are updated.
+                    if op.module.endswith('_plugin') and op.module in sys.modules:
+                        del sys.modules[op.module]
+
                 else:
                     # Delete file
                     # Use retries to work around potential flakiness on Windows (AppVeyor).

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -116,6 +116,11 @@ class TypeCheckSuite(DataSuite):
         original_program_text = '\n'.join(testcase.input)
         module_data = self.parse_module(original_program_text, incremental_step)
 
+        # Unload already loaded plugins, they may be updated.
+        for file, _ in testcase.files:
+            module = module_from_path(file)
+            if module.endswith('_plugin') and module in sys.modules:
+                del sys.modules[module]
         if incremental_step == 0 or incremental_step == 1:
             # In run 1, copy program text to program file.
             for module_name, program_path, program_text in module_data:
@@ -124,11 +129,6 @@ class TypeCheckSuite(DataSuite):
                         f.write(program_text)
                     break
         elif incremental_step > 1:
-            # Unload already loaded plugins, they may be updated.
-            for file, _ in testcase.files:
-                module = module_from_path(file)
-                if module.endswith('_plugin') and module in sys.modules:
-                    del sys.modules[module]
             # In runs 2+, copy *.[num] files to * files.
             for op in operations:
                 if isinstance(op, UpdateFile):

--- a/mypy/test/testgraph.py
+++ b/mypy/test/testgraph.py
@@ -51,6 +51,7 @@ class GraphSuite(Suite):
             options=options,
             version_id=__version__,
             plugin=Plugin(options),
+            plugins_snapshot={},
             errors=errors,
             flush_errors=lambda msgs, serious: None,
             fscache=fscache,

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5448,3 +5448,54 @@ plugins=basic_plugin.py
 [out]
 [out2]
 tmp/a.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testChangedPluginsInvalidateCache2]
+# flags: --config-file tmp/mypy.ini
+import a
+[file a.py]
+from b import x
+y: int = x
+
+[file a.py.2]
+from b import x
+y: int = x
+touch = 1
+
+[file b.py]
+class C: ...
+def f() -> C: ...
+x = f()
+
+[file basic_plugin.py]
+from mypy.plugin import Plugin
+from version_plugin import __version__, choice
+
+class MyPlugin(Plugin):
+    def get_function_hook(self, fullname):
+        if fullname.endswith('.f'):
+            return my_hook
+        assert fullname is not None
+        return None
+
+def my_hook(ctx):
+    if choice:
+        return ctx.api.named_generic_type('builtins.int', [])
+    else:
+        return ctx.api.named_generic_type('builtins.str', [])
+
+def plugin(version):
+    return MyPlugin
+
+[file version_plugin.py]
+__version__ = 0.1
+choice = True
+
+[file version_plugin.py.2]
+__version__ = 0.2
+choice = False
+[file mypy.ini]
+[[mypy]
+plugins=basic_plugin.py
+[out]
+[out2]
+tmp/a.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -24,6 +24,10 @@
 -- # flags2: --another-flag
 -- (and flags3 for the third run, and so on).
 --
+-- Incremental tests involving plugins that get updated are also supported.
+-- All plugin files that are updated *must* end in '_plugin', so they will
+-- be unloaded from 'sys.modules' between incremental steps.
+--
 -- Any files that we expect to be rechecked should be annotated in the [rechecked]
 -- annotation, and any files expect to be stale (aka have a modified interface)
 -- should be annotated in the [stale] annotation. Note that a file that ends up
@@ -5389,3 +5393,58 @@ E = Enum('E', f())  # type: ignore
 [builtins fixtures/list.pyi]
 [out]
 [out2]
+
+[case testChangedPluginsInvalidateCache]
+# flags: --config-file tmp/mypy.ini
+import a
+[file a.py]
+from b import x
+y: int = x
+
+[file a.py.2]
+from b import x
+y: int = x
+touch = 1
+
+[file b.py]
+class C: ...
+def f() -> C: ...
+x = f()
+
+[file basic_plugin.py]
+from mypy.plugin import Plugin
+
+class MyPlugin(Plugin):
+    def get_function_hook(self, fullname):
+        if fullname.endswith('.f'):
+            return my_hook
+        assert fullname is not None
+        return None
+
+def my_hook(ctx):
+    return ctx.api.named_generic_type('builtins.int', [])
+
+def plugin(version):
+    return MyPlugin
+
+[file basic_plugin.py.2]
+from mypy.plugin import Plugin
+
+class MyPlugin(Plugin):
+    def get_function_hook(self, fullname):
+        if fullname.endswith('.f'):
+            return my_hook
+        assert fullname is not None
+        return None
+
+def my_hook(ctx):
+    return ctx.api.named_generic_type('builtins.str', [])
+
+def plugin(version):
+    return MyPlugin
+[file mypy.ini]
+[[mypy]
+plugins=basic_plugin.py
+[out]
+[out2]
+tmp/a.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/3592

This invalidates _all_ cache files if at least one plugin changes its `__version__` or hash of its content (this will not catch situations when there are changes in modules imported by a plugin, _and_ version is also imported, but such situations are probably very rare).

I was not sure where to place the check to invalidate all caches at the same time, so I invalidate them one by one.