### PR TITLE
Always set correct kind for module __getattr__

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3017,7 +3017,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                         typ = AnyType(TypeOfAny.from_error)
                 else:
                     typ = AnyType(TypeOfAny.from_error)
-                expr.kind = MDEF
+                expr.kind = GDEF
                 expr.fullname = '{}.{}'.format(file.fullname(), expr.name)
                 expr.node = Var(expr.name, type=typ)
             else:

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2637,6 +2637,15 @@ roles.role = 1
 [file roles.pyi]
 def __getattr__(name): ...
 
+[case testModuleGetAttrAssignUnannotatedDouble]
+import roles
+
+# this also should not crash
+roles.role.attr = 1
+
+[file roles.pyi]
+def __getattr__(name): ...
+
 [case testModuleGetAttrAssignAny]
 import roles
 

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2659,3 +2659,21 @@ roles.role = 1  # E: Incompatible types in assignment (expression has type "int"
 
 [file roles.pyi]
 def __getattr__(name: str) -> str: ...
+
+[case testModuleGetAttrAssignSubmodule]
+import roles
+roles.role = 1
+roles.missing.attr = 1
+
+[file roles/__init__.pyi]
+from typing import Any
+def __getattr__(name: str) -> Any: ...
+
+[case testModuleGetAttrAssignSubmoduleStrict]
+import roles
+roles.role = 1  # E: Incompatible types in assignment (expression has type "int", variable has type Module)
+
+[file roles/__init__.pyi]
+from types import ModuleType
+def __getattr__(name: str) -> ModuleType: ...
+[builtins fixtures/module.pyi]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2627,3 +2627,29 @@ import foo.bar.baz
 reveal_type(foo.bar.baz.x)  # E: Revealed type is 'builtins.int'
 [file foo/bar/baz.py]
 x = 0
+
+[case testModuleGetAttrAssignUnannotated]
+import roles
+
+# this should not crash
+roles.role = 1
+
+[file roles.pyi]
+def __getattr__(name): ...
+
+[case testModuleGetAttrAssignAny]
+import roles
+
+roles.role = 1
+
+[file roles.pyi]
+from typing import Any
+def __getattr__(name: str) -> Any: ...
+
+[case testModuleGetAttrAssignError]
+import roles
+
+roles.role = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+[file roles.pyi]
+def __getattr__(name: str) -> str: ...

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2630,7 +2630,6 @@ x = 0
 
 [case testModuleGetAttrAssignUnannotated]
 import roles
-
 # this should not crash
 roles.role = 1
 
@@ -2639,7 +2638,6 @@ def __getattr__(name): ...
 
 [case testModuleGetAttrAssignUnannotatedDouble]
 import roles
-
 # this also should not crash
 roles.role.attr = 1
 
@@ -2648,7 +2646,6 @@ def __getattr__(name): ...
 
 [case testModuleGetAttrAssignAny]
 import roles
-
 roles.role = 1
 
 [file roles.pyi]


### PR DESCRIPTION
Fixes #5866

There are two places where `__getattr__` generated `Var`s are created, and somehow in one of them it was given a `MDEF` kind (which caused a crash), although it is a _module_ attribute.