### PR TITLE
Add hooks for running tests on an installed version of mypy

### DIFF
--- a/misc/test_installed_version.sh
+++ b/misc/test_installed_version.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -ex
+
+# Usage: misc/test_installed_version.sh [wheel] [python command]
+# Installs a version of mypy into a virtualenv and tests it.
+
+# A bunch of stuff about mypy's code organization and test setup makes
+# it annoying to test an installed version of mypy. If somebody has a
+# better way please let me know.
+
+TO_INSTALL="${1-.}"
+PYTHON="${2-python3}"
+VENV="$(mktemp -d --tmpdir mypy-test-venv.XXXXXXXXXX)"
+trap "rm -rf '$VENV'" EXIT
+
+"$PYTHON" -m virtualenv "$VENV"
+source "$VENV/bin/activate"
+
+pip install -r test-requirements.txt
+pip install $TO_INSTALL
+
+# pytest looks for configuration files in the parent directories of
+# where the tests live. Since we are trying to run the tests from
+# their installed location, we copy those into the venv. Ew ew ew.
+cp pytest.ini conftest.py "$VENV/"
+
+ROOT="$PWD"
+
+# Change directory so we can't pick up any of the stuff in the root
+cd /
+
+# Find the directory that mypy tests were installed into
+MYPY_TEST_DIR="$(python3 -c 'import mypy.test; print(mypy.test.__path__[0])')"
+# Run the mypy tests
+MYPY_TEST_PREFIX="$ROOT" python3 -m pytest "$MYPY_TEST_DIR"/test*.py

--- a/misc/test_installed_version.sh
+++ b/misc/test_installed_version.sh
@@ -12,7 +12,7 @@ PYTHON="${2-python3}"
 VENV="$(mktemp -d --tmpdir mypy-test-venv.XXXXXXXXXX)"
 trap "rm -rf '$VENV'" EXIT
 
-"$PYTHON" -m virtualenv "$VENV"
+"$PYTHON" -m venv "$VENV"
 source "$VENV/bin/activate"
 
 pip install -r test-requirements.txt
@@ -26,7 +26,7 @@ cp pytest.ini conftest.py "$VENV/"
 ROOT="$PWD"
 
 # Change directory so we can't pick up any of the stuff in the root
-cd /
+cd "$VENV"
 
 # Find the directory that mypy tests were installed into
 MYPY_TEST_DIR="$(python3 -c 'import mypy.test; print(mypy.test.__path__[0])')"

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -401,7 +401,10 @@ def compute_search_paths(sources: List[BuildSource],
         # Use stub builtins (to speed up test cases and to make them easier to
         # debug).  This is a test-only feature, so assume our files are laid out
         # as in the source tree.
-        root_dir = os.path.dirname(os.path.dirname(__file__))
+        # We also need to allow overriding where to look for it. Argh.
+        root_dir = os.getenv('MYPY_TEST_PREFIX', None)
+        if not root_dir:
+            root_dir = os.path.dirname(os.path.dirname(__file__))
         lib_path.appendleft(os.path.join(root_dir, 'test-data', 'unit', 'lib-stub'))
     # alt_lib_path is used by some tests to bypass the normal lib_path mechanics.
     # If we don't have one, grab directories of source files.

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -884,8 +884,7 @@ def walk_packages(packages: List[str]) -> Iterator[str]:
                 # using the inspect module
                 subpackages = [package.__name__ + "." + name
                                for name, val in inspect.getmembers(package)
-                               if inspect.ismodule(val)
-                               if val.__name__ == package.__name__ + "." + name]
+                               if inspect.ismodule(val)]
                 # recursively iterate through the subpackages
                 for submodule in walk_packages(subpackages):
                     yield submodule

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -884,7 +884,8 @@ def walk_packages(packages: List[str]) -> Iterator[str]:
                 # using the inspect module
                 subpackages = [package.__name__ + "." + name
                                for name, val in inspect.getmembers(package)
-                               if inspect.ismodule(val)]
+                               if inspect.ismodule(val)
+                               if val.__name__ == package.__name__ + "." + name]
                 # recursively iterate through the subpackages
                 for submodule in walk_packages(subpackages):
                     yield submodule

--- a/mypy/test/config.py
+++ b/mypy/test/config.py
@@ -1,7 +1,11 @@
 import os.path
 
-this_file_dir = os.path.dirname(os.path.realpath(__file__))
-PREFIX = os.path.dirname(os.path.dirname(this_file_dir))
+provided_prefix = os.getenv('MYPY_TEST_PREFIX', None)
+if provided_prefix:
+    PREFIX = provided_prefix
+else:
+    this_file_dir = os.path.dirname(os.path.realpath(__file__))
+    PREFIX = os.path.dirname(os.path.dirname(this_file_dir))
 
 # Location of test data files such as test case descriptions.
 test_data_prefix = os.path.join(PREFIX, 'test-data', 'unit')

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -13,9 +13,9 @@ from abc import abstractmethod
 import pytest  # type: ignore  # no pytest in typeshed
 from typing import List, Tuple, Set, Optional, Iterator, Any, Dict, NamedTuple, Union
 
-from mypy.test.config import test_data_prefix, test_temp_dir
+from mypy.test.config import test_data_prefix, test_temp_dir, PREFIX
 
-root_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..'))
+root_dir = os.path.normpath(PREFIX)
 
 # File modify/create operation: copy module contents from source_path.
 UpdateFile = NamedTuple('UpdateFile', [('module', str),

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -15,7 +15,7 @@ from mypy.test.config import test_temp_dir, PREFIX
 from mypy.test.data import fix_cobertura_filename
 from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.test.helpers import assert_string_arrays_equal, normalize_error_messages
-from mypy.version import __version__, base_version
+import mypy.version
 
 # Path to Python 3 interpreter
 python3_path = sys.executable
@@ -122,7 +122,9 @@ def normalize_file_output(content: List[str], current_abs_path: str) -> List[str
     """Normalize file output for comparison."""
     timestamp_regex = re.compile(r'\d{10}')
     result = [x.replace(current_abs_path, '$PWD') for x in content]
-    result = [re.sub(r'\b' + re.escape(__version__) + r'\b', '$VERSION', x) for x in result]
+    version = mypy.version.__version__
+    result = [re.sub(r'\b' + re.escape(version) + r'\b', '$VERSION', x) for x in result]
+    base_version = getattr(mypy.version, 'base_version', version)
     result = [re.sub(r'\b' + re.escape(base_version) + r'\b', '$VERSION', x) for x in result]
     result = [timestamp_regex.sub('$TIMESTAMP', x) for x in result]
     return result

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -124,6 +124,8 @@ def normalize_file_output(content: List[str], current_abs_path: str) -> List[str
     result = [x.replace(current_abs_path, '$PWD') for x in content]
     version = mypy.version.__version__
     result = [re.sub(r'\b' + re.escape(version) + r'\b', '$VERSION', x) for x in result]
+    # We generate a new mypy.version when building mypy wheels that
+    # lacks base_version, so handle that case.
     base_version = getattr(mypy.version, 'base_version', version)
     result = [re.sub(r'\b' + re.escape(base_version) + r'\b', '$VERSION', x) for x in result]
     result = [timestamp_regex.sub('$TIMESTAMP', x) for x in result]


### PR DESCRIPTION
The main motivation for all of this is to be able to validate
mypy_mypyc wheels.

Because the tests are an integrated subpackage of mypy, I couldn't
figure out a way to run the tests from the source directory against an
installed mypy, and I was reluctant to do a major overhaul of the
source organization, in part because some other projects take
advantage of some of the test infrastructure (mypyc, sqlalchemy-stubs).

So instead we run the tests from where they get installed with the
package. To support this, we allow overriding where the tests look for
test-data using a `MYPY_TEST_PREFIX` environment variable.