### PR TITLE
Make stubgen less aggressive about walking C extension modules

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -885,7 +885,7 @@ def walk_packages(packages: List[str]) -> Iterator[str]:
                 subpackages = [package.__name__ + "." + name
                                for name, val in inspect.getmembers(package)
                                if inspect.ismodule(val)
-                               if val.__name__ == package.__name__ + "." + name]
+                               and val.__name__ == package.__name__ + "." + name]
                 # recursively iterate through the subpackages
                 for submodule in walk_packages(subpackages):
                     yield submodule

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -884,7 +884,8 @@ def walk_packages(packages: List[str]) -> Iterator[str]:
                 # using the inspect module
                 subpackages = [package.__name__ + "." + name
                                for name, val in inspect.getmembers(package)
-                               if inspect.ismodule(val)]
+                               if inspect.ismodule(val)
+                               if val.__name__ == package.__name__ + "." + name]
                 # recursively iterate through the subpackages
                 for submodule in walk_packages(subpackages):
                     yield submodule


### PR DESCRIPTION
PR #5814 made stubgen try to walk as a module any attribute of a C
of a C extension module of module type. This is too aggressive: mypyc
generated extension modules will often have attributes of module type
from imports that do not correspond to actual modules.

This causes a stubgen test to fail under mypy_mypyc while trying to
import `mypy.errors.os`, since `mypy.errors` imports `os`.

Only walk such a submodule when its `__name__` matches it being a
submodule.