### PR TITLE
Lazily import write_junit_xml from dmypy

### DIFF
--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -17,7 +17,6 @@ import time
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from mypy.dmypy_util import STATUS_FILE, receive
-from mypy.util import write_junit_xml
 from mypy.version import __version__
 
 # Argument parser.  Subparsers are tied to action functions by the
@@ -334,6 +333,8 @@ def check_output(response: Dict[str, Any], verbose: bool, junit_xml: Optional[st
     if verbose:
         show_stats(response)
     if junit_xml:
+        # Lazy import so this import doesn't slow things down when not writing junit
+        from mypy.util import write_junit_xml
         messages = (out + err).splitlines()
         write_junit_xml(response['roundtrip_time'], bool(err), messages, junit_xml)
     if status_code:


### PR DESCRIPTION
This speeds `dmypy status` and `dmypy check` on my test MBP by a
whopping 120ms! (But only about 40ms on my Linux laptop.)