### PR TITLE
Make test_installed_version.sh work on OS X and CentOS 5.

### DIFF
--- a/misc/test_installed_version.sh
+++ b/misc/test_installed_version.sh
@@ -9,7 +9,7 @@
 
 TO_INSTALL="${1-.}"
 PYTHON="${2-python3}"
-VENV="$(mktemp -d --tmpdir mypy-test-venv.XXXXXXXXXX)"
+VENV="$(mktemp -d -t mypy-test-venv.XXXXXXXXXX)"
 trap "rm -rf '$VENV'" EXIT
 
 "$PYTHON" -m venv "$VENV"


### PR DESCRIPTION
`--tmpdir` is a GNUism and a relatively recent one, at that.