### PR TITLE
Fix crash when reveal_locals() encounters a class definition

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2880,23 +2880,24 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 # Each SymbolTableNode has an attribute node that is nodes.Var
                 # look for variable nodes that marked as is_inferred
                 # Each symboltable node has a Var node as .node
-                local_nodes = cast(
-                    List[Var],
-                    [
-                        n.node for name, n in self.globals.items()
-                        if getattr(n.node, 'is_inferred', False)
-                    ]
-                )
+                local_nodes = [n.node
+                               for name, n in self.globals.items()
+                               if getattr(n.node, 'is_inferred', False)
+                                  and isinstance(n.node, Var)
+                              ]
             elif self.is_class_scope():
                 # type = None  # type: Optional[TypeInfo]
                 if self.type is not None:
-                    local_nodes = cast(List[Var], [st.node for st in self.type.names.values()])
+                    local_nodes = [st.node
+                                   for st in self.type.names.values()
+                                   if isinstance(st.node, Var)
+                                  ]
             elif self.is_func_scope():
                 # locals = None  # type: List[Optional[SymbolTable]]
                 if self.locals is not None:
                     symbol_table = self.locals[-1]
                     if symbol_table is not None:
-                        local_nodes = cast(List[Var], [st.node for st in symbol_table.values()])
+                        local_nodes = [st.node for st in symbol_table.values() if isinstance(st.node, Var)]
             expr.analyzed = RevealExpr(kind=REVEAL_LOCALS, local_nodes=local_nodes)
             expr.analyzed.line = expr.line
             expr.analyzed.column = expr.column

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2883,21 +2883,21 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 local_nodes = [n.node
                                for name, n in self.globals.items()
                                if getattr(n.node, 'is_inferred', False)
-                                  and isinstance(n.node, Var)
-                              ]
+                               and isinstance(n.node, Var)]
             elif self.is_class_scope():
                 # type = None  # type: Optional[TypeInfo]
                 if self.type is not None:
                     local_nodes = [st.node
                                    for st in self.type.names.values()
-                                   if isinstance(st.node, Var)
-                                  ]
+                                   if isinstance(st.node, Var)]
             elif self.is_func_scope():
                 # locals = None  # type: List[Optional[SymbolTable]]
                 if self.locals is not None:
                     symbol_table = self.locals[-1]
                     if symbol_table is not None:
-                        local_nodes = [st.node for st in symbol_table.values() if isinstance(st.node, Var)]
+                        local_nodes = [st.node
+                                       for st in symbol_table.values()
+                                       if isinstance(st.node, Var)]
             expr.analyzed = RevealExpr(kind=REVEAL_LOCALS, local_nodes=local_nodes)
             expr.analyzed.line = expr.line
             expr.analyzed.column = expr.column

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4940,12 +4940,13 @@ class D(B, C):
 class C1(object):
     t = 'a'
     y = 3.0
+    class Inner(object): pass
     reveal_locals()
 
 [out]
-main:4: error: Revealed local types are:
-main:4: error: t: builtins.str
-main:4: error: y: builtins.float
+main:5: error: Revealed local types are:
+main:5: error: t: builtins.str
+main:5: error: y: builtins.float
 
 [case testAbstractClasses]
 import a

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2301,23 +2301,26 @@ main:2: error: Revealed type is 'def () -> builtins.int'
 [case testRevealLocalsFunction]
 a = 1.0
 
+class A: pass
+
 def f(a: int, b: int) -> int:
     reveal_locals()
     c = a + b
+    class C: pass
     reveal_locals()
     return c
 
 reveal_locals()
 [out]
-main:4: error: Revealed local types are:
-main:4: error: a: builtins.int
-main:4: error: b: builtins.int
 main:6: error: Revealed local types are:
 main:6: error: a: builtins.int
 main:6: error: b: builtins.int
-main:6: error: c: builtins.int
 main:9: error: Revealed local types are:
-main:9: error: a: builtins.float
+main:9: error: a: builtins.int
+main:9: error: b: builtins.int
+main:9: error: c: builtins.int
+main:12: error: Revealed local types are:
+main:12: error: a: builtins.float
 
 [case testNoComplainOverloadNone]
 # flags: --no-strict-optional


### PR DESCRIPTION
Fixes #5915.

The root cause were some improper casts when creating the `local_nodes` list. These were easy to fix by adding `isinstance(node, Var)` checks to the list comprehensions.