### PR TITLE
Type check typed dict as caller **kwargs

### DIFF
--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -76,7 +76,8 @@ def map_actuals_to_formals(caller_kinds: List[int],
                 # We don't exactly know which **kwargs are provided by the
                 # caller. Assume that they will fill the remaining arguments.
                 for j in range(ncallee):
-                    # TODO tuple varargs complicate this
+                    # TODO: If there are also tuple varargs, we might be missing some potential
+                    #       matches if the tuple was short enough to not match everything.
                     no_certain_match = (
                         not map[j] or caller_kinds[map[j][0]] == nodes.ARG_STAR)
                     if ((callee_names[j] and no_certain_match)

--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -180,7 +180,7 @@ class ArgTypeExpander:
                 self.kwargs_used.add(formal_name)
                 return actual_type.items[formal_name]
             elif (isinstance(actual_type, Instance)
-                      and (actual_type.type.fullname() == 'builtins.dict')):
+                  and (actual_type.type.fullname() == 'builtins.dict')):
                 # Dict **arg.
                 # TODO: Handle arbitrary Mapping
                 return actual_type.args[1]

--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -73,7 +73,7 @@ def map_actuals_to_formals(caller_kinds: List[int],
                     elif nodes.ARG_STAR2 in callee_kinds:
                         map[callee_kinds.index(nodes.ARG_STAR2)].append(i)
             else:
-                # We don't exactly which **kwargs are provided by the
+                # We don't exactly know which **kwargs are provided by the
                 # caller. Assume that they will fill the remaining arguments.
                 for j in range(ncallee):
                     # TODO tuple varargs complicate this
@@ -114,8 +114,8 @@ class ArgTypeExpander:
 
     Example:
 
-       . def f(x: int, *args: str) -> None: ...
-       . f(*(1, 'x', 1.1)
+       def f(x: int, *args: str) -> None: ...
+       f(*(1, 'x', 1.1))
 
     We'd call expand_actual_type three times:
 
@@ -123,8 +123,8 @@ class ArgTypeExpander:
       2. The second call would provide 'str' as one of the actual types for '*args'.
       2. The third call would provide 'float' as one of the actual types for '*args'.
 
-    Construct a separate instance for each call since instances have per-call
-    state.
+    A single instance can process all the arguments for a single call. Each call
+    needs a separate instance since instances have per-call state.
     """
 
     def __init__(self) -> None:
@@ -140,11 +140,11 @@ class ArgTypeExpander:
                            formal_kind: int) -> Type:
         """Return the actual (caller) type(s) of a formal argument with the given kinds.
 
-        If the actual argument is a tuple *args, return the individual tuple item(s) that
-        map(s) to the formal arg.
+        If the actual argument is a tuple *args, return the next individual tuple item that
+        maps to the formal arg.
 
-        If the actual argument is a TypedDict **kwargs, return the matching typed dict dict
-        value type(s) based on formal argument name and kind.
+        If the actual argument is a TypedDict **kwargs, return the next matching typed dict
+        value type based on formal argument name and kind.
 
         This is supposed to be called for each formal, in order. Call multiple times per
         formal if multiple actuals map to a formal.

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1144,7 +1144,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                         messages.unexpected_keyword_argument(callee, act_name, context)
                     is_unexpected_arg_error = True
             elif ((kind == nodes.ARG_STAR and nodes.ARG_STAR not in callee.arg_kinds)
-                      or kind == nodes.ARG_STAR2):
+                  or kind == nodes.ARG_STAR2):
                 actual_type = actual_types[i]
                 if isinstance(actual_type, (TupleType, TypedDictType)):
                     if all_actuals.count(i) < len(actual_type.items):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -704,8 +704,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             self.check_argument_count(callee, arg_types, arg_kinds,
                                       arg_names, formal_to_actual, context, self.msg)
 
-            self.check_argument_types(arg_types, arg_kinds, callee,
-                                      formal_to_actual, context,
+            self.check_argument_types(arg_types, arg_kinds, callee.arg_names,
+                                      callee, formal_to_actual, context,
                                       messages=arg_messages)
 
             if (callee.is_type_obj() and (len(arg_types) == 1)
@@ -1139,7 +1139,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 ok = False
         return ok
 
-    def check_argument_types(self, arg_types: List[Type], arg_kinds: List[int],
+    def check_argument_types(self,
+                             arg_types: List[Type],
+                             arg_kinds: List[int],
+                             formal_names: List[Optional[str]],
                              callee: CallableType,
                              formal_to_actual: List[List[int]],
                              context: Context,
@@ -1173,7 +1176,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                         and arg_kinds[actual] == nodes.ARG_STAR):
                     # The tuple is exhausted. Continue with further arguments.
                     continue
-                actual_type = get_actual_type(arg_type, arg_kinds[actual],
+                actual_type = get_actual_type(arg_type, arg_kinds[actual], formal_names[i],
                                               tuple_counter)
                 check_arg(actual_type, arg_type, arg_kinds[actual],
                           callee.arg_types[i],
@@ -1188,6 +1191,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     while tuple_counter[0] < len(tuplet.items):
                         actual_type = get_actual_type(arg_type,
                                                       arg_kinds[actual],
+                                                      callee.arg_names[i],
                                                       tuple_counter)
                         check_arg(actual_type, arg_type, arg_kinds[actual],
                                   callee.arg_types[i],
@@ -1669,8 +1673,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 raise Finished
 
         try:
-            self.check_argument_types(arg_types, arg_kinds, callee, formal_to_actual,
-                                      context=context, check_arg=check_arg)
+            self.check_argument_types(arg_types, arg_kinds, callee.arg_names, callee,
+                                      formal_to_actual, context=context, check_arg=check_arg)
             return True
         except Finished:
             return False

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1064,7 +1064,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         Return False if there were any errors. Otherwise return True
         """
         if messages:
-            assert context, "Internal error: messages gives without context"
+            assert context, "Internal error: messages given without context"
         elif context is None:
             context = TempNode(AnyType(TypeOfAny.special_form))  # Avoid "is None" checks
 
@@ -1121,7 +1121,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Check for extra actual arguments.
 
         Return tuple (was everything ok,
-                      was there an extra keyword argument error).
+                      was there an extra keyword argument error [used to avoid duplicate errors]).
         """
 
         is_unexpected_arg_error = False  # Keep track of errors to avoid duplicate errors

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1193,13 +1193,12 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                         not self.is_valid_keyword_var_arg(actual_type)):
                     is_mapping = is_subtype(actual_type, self.chk.named_type('typing.Mapping'))
                     messages.invalid_keyword_var_arg(actual_type, is_mapping, context)
-                expanded_actuals = mapper.expand_actual_type(
+                expanded_actual = mapper.expand_actual_type(
                     actual_type, actual_kind,
                     callee.arg_names[i], callee.arg_kinds[i])
-                for actual_item in expanded_actuals:
-                    check_arg(actual_item, actual_type, arg_kinds[actual],
-                              callee.arg_types[i],
-                              actual + 1, i + 1, callee, context, messages)
+                check_arg(expanded_actual, actual_type, arg_kinds[actual],
+                          callee.arg_types[i],
+                          actual + 1, i + 1, callee, context, messages)
 
     def check_arg(self, caller_type: Type, original_caller_type: Type,
                   caller_kind: int,

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -13,7 +13,7 @@ import mypy.subtypes
 from mypy.sametypes import is_same_type
 from mypy.erasetype import erase_typevars
 from mypy.nodes import COVARIANT, CONTRAVARIANT
-from mypy.argmap import get_actual_type
+from mypy.argmap import ArgTypeMapper
 
 MYPY = False
 if MYPY:
@@ -54,7 +54,7 @@ def infer_constraints_for_callable(
     Return a list of constraints.
     """
     constraints = []  # type: List[Constraint]
-    tuple_counter = [0]
+    mapper = ArgTypeMapper()
 
     for i, actuals in enumerate(formal_to_actual):
         for actual in actuals:
@@ -62,11 +62,12 @@ def infer_constraints_for_callable(
             if actual_arg_type is None:
                 continue
 
-            actual_type = get_actual_type(actual_arg_type, arg_kinds[actual],
-                                          callee.arg_names[i], tuple_counter)
-            c = infer_constraints(callee.arg_types[i], actual_type,
-                                  SUPERTYPE_OF)
-            constraints.extend(c)
+            actual_types = mapper.get_actual_type(actual_arg_type, arg_kinds[actual],
+                                                  callee.arg_names[i])
+            for actual_type in actual_types:
+                c = infer_constraints(callee.arg_types[i], actual_type,
+                                      SUPERTYPE_OF)
+                constraints.extend(c)
 
     return constraints
 

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -63,7 +63,7 @@ def infer_constraints_for_callable(
                 continue
 
             actual_type = get_actual_type(actual_arg_type, arg_kinds[actual],
-                                          tuple_counter)
+                                          callee.arg_names, tuple_counter)
             c = infer_constraints(callee.arg_types[i], actual_type,
                                   SUPERTYPE_OF)
             constraints.extend(c)

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -62,12 +62,10 @@ def infer_constraints_for_callable(
             if actual_arg_type is None:
                 continue
 
-            actual_types = mapper.expand_actual_type(actual_arg_type, arg_kinds[actual],
-                                                     callee.arg_names[i], callee.arg_kinds[i])
-            for actual_type in actual_types:
-                c = infer_constraints(callee.arg_types[i], actual_type,
-                                      SUPERTYPE_OF)
-                constraints.extend(c)
+            actual_type = mapper.expand_actual_type(actual_arg_type, arg_kinds[actual],
+                                                    callee.arg_names[i], callee.arg_kinds[i])
+            c = infer_constraints(callee.arg_types[i], actual_type, SUPERTYPE_OF)
+            constraints.extend(c)
 
     return constraints
 

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -13,7 +13,7 @@ import mypy.subtypes
 from mypy.sametypes import is_same_type
 from mypy.erasetype import erase_typevars
 from mypy.nodes import COVARIANT, CONTRAVARIANT
-from mypy.argmap import ArgTypeMapper
+from mypy.argmap import ArgTypeExpander
 
 MYPY = False
 if MYPY:
@@ -54,7 +54,7 @@ def infer_constraints_for_callable(
     Return a list of constraints.
     """
     constraints = []  # type: List[Constraint]
-    mapper = ArgTypeMapper()
+    mapper = ArgTypeExpander()
 
     for i, actuals in enumerate(formal_to_actual):
         for actual in actuals:
@@ -62,8 +62,8 @@ def infer_constraints_for_callable(
             if actual_arg_type is None:
                 continue
 
-            actual_types = mapper.get_actual_type(actual_arg_type, arg_kinds[actual],
-                                                  callee.arg_names[i])
+            actual_types = mapper.expand_actual_type(actual_arg_type, arg_kinds[actual],
+                                                     callee.arg_names[i], callee.arg_kinds[i])
             for actual_type in actual_types:
                 c = infer_constraints(callee.arg_types[i], actual_type,
                                       SUPERTYPE_OF)

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -63,7 +63,7 @@ def infer_constraints_for_callable(
                 continue
 
             actual_type = get_actual_type(actual_arg_type, arg_kinds[actual],
-                                          callee.arg_names, tuple_counter)
+                                          callee.arg_names[i], tuple_counter)
             c = infer_constraints(callee.arg_types[i], actual_type,
                                   SUPERTYPE_OF)
             constraints.extend(c)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -674,7 +674,8 @@ class MessageBuilder:
             if (arg_kind == ARG_STAR2
                     and isinstance(arg_type, TypedDictType)
                     and m <= len(callee.arg_names)
-                    and callee.arg_names[m - 1] is not None):
+                    and callee.arg_names[m - 1] is not None
+                    and callee.arg_kinds[m - 1] != ARG_STAR2):
                 arg_name = callee.arg_names[m - 1]
                 assert arg_name is not None
                 arg_type_str, expected_type_str = self.format_distinctly(

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -722,6 +722,20 @@ class MessageBuilder:
         msg = 'Too many arguments' + for_function(callee)
         self.fail(msg, context)
 
+    def too_many_arguments_from_typed_dict(self,
+                                           callee: CallableType,
+                                           arg_type: TypedDictType,
+                                           context: Context) -> None:
+        # Try to determine the name of the extra argument.
+        for key in arg_type.items:
+            if key not in callee.arg_names:
+                msg = 'Extra argument "{}" from **args'.format(key) + for_function(callee)
+                break
+        else:
+            self.too_many_arguments(callee, context)
+            return
+        self.fail(msg, context)
+
     def too_many_positional_arguments(self, callee: CallableType,
                                       context: Context) -> None:
         msg = 'Too many positional arguments' + for_function(callee)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -676,6 +676,7 @@ class MessageBuilder:
                     and m <= len(callee.arg_names)
                     and callee.arg_names[m - 1] is not None):
                 arg_name = callee.arg_names[m - 1]
+                assert arg_name is not None
                 arg_type_str, expected_type_str = self.format_distinctly(
                     arg_type.items[arg_name],
                     expected_type,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -671,6 +671,16 @@ class MessageBuilder:
                 if arg_name is not None:
                     arg_label = '"{}"'.format(arg_name)
 
+            if (arg_kind == ARG_STAR2
+                    and isinstance(arg_type, TypedDictType)
+                    and m <= len(callee.arg_names)
+                    and callee.arg_names[m - 1] is not None):
+                arg_name = callee.arg_names[m - 1]
+                arg_type_str, expected_type_str = self.format_distinctly(
+                    arg_type.items[arg_name],
+                    expected_type,
+                    bare=True)
+                arg_label = '"{}"'.format(arg_name)
             msg = 'Argument {} {}has incompatible type {}; expected {}'.format(
                 arg_label, target, self.quote_type_string(arg_type_str),
                 self.quote_type_string(expected_type_str))

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1434,5 +1434,6 @@ f4(**a) # E: Too many arguments for "f4"
 f5(**a) # E: Too few arguments for "f5"
 
 # TODO:
+# - constraint inference
 # - duplicate args due to **a
 # - caller takes **kwargs

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1436,8 +1436,14 @@ f5(**a) # E: Too few arguments for "f5"
 f6(**a) # E: Extra argument "y" from **args for "f6"
 f1(1, **a) # E: "f1" gets multiple values for keyword argument "x"
 
+[case testTypedDictAsStarStarArgConstraints]
+from typing import TypeVar, Union
+from mypy_extensions import TypedDict
 
-# TODO:
-# - constraint inference
-# - caller takes **kwargs
-# ? non-total typeddict shouldn't generate extra arg errors
+T = TypeVar('T')
+S = TypeVar('S')
+def f1(x: T, y: S) -> Union[T, S]: ...
+
+A = TypedDict('A', {'y': int, 'x': str})
+a: A
+reveal_type(f1(**a)) # E: Revealed type is 'Union[builtins.str*, builtins.int*]'

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1467,3 +1467,27 @@ g(1, **a) # E: "g" gets multiple values for keyword argument "x"
 g(1, **b) # E: "g" gets multiple values for keyword argument "x" \
           # E: Argument "x" to "g" has incompatible type "str"; expected "int"
 [builtins fixtures/dict.pyi]
+
+[case testTypedDictAsStarStarTwice]
+from mypy_extensions import TypedDict
+
+A = TypedDict('A', {'x': int, 'y': str})
+B = TypedDict('B', {'z': bytes})
+C = TypedDict('C', {'x': str, 'z': bytes})
+
+def f1(x: int, y: str, z: bytes) -> None: ...
+def f2(x: int, y: float, z: bytes) -> None: ...
+def f3(x: int, y: str, z: float) -> None: ...
+
+a: A
+b: B
+c: C
+f1(**a, **b)
+f1(**b, **a)
+f2(**a, **b) # E: Argument "y" to "f2" has incompatible type "str"; expected "float"
+f3(**a, **b) # E: Argument "z" to "f3" has incompatible type "bytes"; expected "float"
+f3(**b, **a) # E: Argument "z" to "f3" has incompatible type "bytes"; expected "float"
+f1(**a, **c) # E: "f1" gets multiple values for keyword argument "x" \
+             # E: Argument "x" to "f1" has incompatible type "str"; expected "int"
+f1(**c, **a) # E: "f1" gets multiple values for keyword argument "x" \
+             # E: Argument "x" to "f1" has incompatible type "str"; expected "int"

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1413,3 +1413,20 @@ from mypy_extensions import TypedDict
 tp = TypedDict('tp', {'x': int})
 [builtins fixtures/dict.pyi]
 [out]
+
+[case testTypedDictAsStarStarArg]
+from mypy_extensions import TypedDict
+
+A = TypedDict('A', {'x': int, 'y': str})
+
+def f(x: int, y: str) -> None: ...
+def g(x: int, y: int) -> None: ...
+
+a: A
+f(**a)
+g(**a) # E: Argument 1 to "g" has incompatible type "**A"; expected "int"
+
+# TODO:
+# - missing arguments
+# - too many arguments
+# - caller takes **kwargs

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1418,13 +1418,16 @@ tp = TypedDict('tp', {'x': int})
 from mypy_extensions import TypedDict
 
 A = TypedDict('A', {'x': int, 'y': str})
+class B: pass
 
 def f(x: int, y: str) -> None: ...
 def g(x: int, y: int) -> None: ...
+def h(x: B, y: str) -> None: ...
 
 a: A
 f(**a)
-g(**a) # E: Argument 1 to "g" has incompatible type "**A"; expected "int"
+g(**a) # E: Argument "y" to "g" has incompatible type "str"; expected "int"
+h(**a) # E: Argument "x" to "h" has incompatible type "int"; expected "B"
 
 # TODO:
 # - missing arguments

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1425,15 +1425,19 @@ def f2(x: int, y: int) -> None: ...
 def f3(x: B, y: str) -> None: ...
 def f4(x: int) -> None: pass
 def f5(x: int, y: str, z: int) -> None: pass
+def f6(x: int, z: str) -> None: pass
 
 a: A
 f1(**a)
 f2(**a) # E: Argument "y" to "f2" has incompatible type "str"; expected "int"
 f3(**a) # E: Argument "x" to "f3" has incompatible type "int"; expected "B"
-f4(**a) # E: Too many arguments for "f4"
+f4(**a) # E: Extra argument "y" from **args for "f4"
 f5(**a) # E: Too few arguments for "f5"
+f6(**a) # E: Extra argument "y" from **args for "f6"
+f1(1, **a) # E: "f1" gets multiple values for keyword argument "x"
+
 
 # TODO:
 # - constraint inference
-# - duplicate args due to **a
 # - caller takes **kwargs
+# ? non-total typeddict shouldn't generate extra arg errors

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1447,3 +1447,23 @@ def f1(x: T, y: S) -> Union[T, S]: ...
 A = TypedDict('A', {'y': int, 'x': str})
 a: A
 reveal_type(f1(**a)) # E: Revealed type is 'Union[builtins.str*, builtins.int*]'
+
+[case testTypedDictAsStarStarArgCalleeKwargs]
+from mypy_extensions import TypedDict
+
+A = TypedDict('A', {'x': int, 'y': str})
+B = TypedDict('B', {'x': str, 'y': str})
+
+def f(**kwargs: str) -> None: ...
+def g(x: int, **kwargs: str) -> None: ...
+
+a: A
+b: B
+f(**a) # E: Argument 1 to "f" has incompatible type "**A"; expected "str"
+f(**b)
+g(**a)
+g(**b) # E: Argument "x" to "g" has incompatible type "str"; expected "int"
+g(1, **a) # E: "g" gets multiple values for keyword argument "x"
+g(1, **b) # E: "g" gets multiple values for keyword argument "x" \
+          # E: Argument "x" to "g" has incompatible type "str"; expected "int"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1420,16 +1420,19 @@ from mypy_extensions import TypedDict
 A = TypedDict('A', {'x': int, 'y': str})
 class B: pass
 
-def f(x: int, y: str) -> None: ...
-def g(x: int, y: int) -> None: ...
-def h(x: B, y: str) -> None: ...
+def f1(x: int, y: str) -> None: ...
+def f2(x: int, y: int) -> None: ...
+def f3(x: B, y: str) -> None: ...
+def f4(x: int) -> None: pass
+def f5(x: int, y: str, z: int) -> None: pass
 
 a: A
-f(**a)
-g(**a) # E: Argument "y" to "g" has incompatible type "str"; expected "int"
-h(**a) # E: Argument "x" to "h" has incompatible type "int"; expected "B"
+f1(**a)
+f2(**a) # E: Argument "y" to "f2" has incompatible type "str"; expected "int"
+f3(**a) # E: Argument "x" to "f3" has incompatible type "int"; expected "B"
+f4(**a) # E: Too many arguments for "f4"
+f5(**a) # E: Too few arguments for "f5"
 
 # TODO:
-# - missing arguments
-# - too many arguments
+# - duplicate args due to **a
 # - caller takes **kwargs

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -111,6 +111,20 @@ f(*it1)
 f(*it2) # E: Argument 1 to "f" has incompatible type "*Iterable[str]"; expected "int"
 [builtins fixtures/for.pyi]
 
+[case testCallVarargsFunctionWithTwoTupleStarArgs]
+from typing import TypeVar, Tuple
+
+T1 = TypeVar('T1')
+T2 = TypeVar('T2')
+T3 = TypeVar('T3')
+T4 = TypeVar('T4')
+
+def f(a: T1, b: T2, c: T3, d: T4) -> Tuple[T1, T2, T3, T4]: ...
+x: Tuple[int, str]
+y: Tuple[float, bool]
+reveal_type(f(*x, *y)) # E: Revealed type is 'Tuple[builtins.int*, builtins.str*, builtins.float*, builtins.bool*]'
+[builtins fixtures/list.pyi]
+
 [case testCallVarargsFunctionWithIterableAndPositional]
 
 from typing import Iterable

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -553,7 +553,7 @@ main:10: error: Incompatible types in assignment (expression has type "List[<not
 main:11: error: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[A]")
 main:11: error: Argument 1 to "f" of "G" has incompatible type "*List[A]"; expected "B"
 
-[case testCallerTupleVarArgsAndGenerics]
+[case testCallerTupleVarArgsAndGenericCalleeVarArg]
 # flags: --strict-optional
 from typing import TypeVar
 
@@ -561,6 +561,8 @@ T = TypeVar('T')
 
 def f(*args: T) -> T: ...
 reveal_type(f(*(1, None)))  # E: Revealed type is 'Union[builtins.int, None]'
+reveal_type(f(1, *(None, 1)))  # E: Revealed type is 'Union[builtins.int, None]'
+reveal_type(f(1, *(1, None)))  # E: Revealed type is 'Union[builtins.int, None]'
 [builtins fixtures/tuple.pyi]
 
 

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -551,6 +551,16 @@ main:10: error: Incompatible types in assignment (expression has type "List[<not
 main:11: error: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[A]")
 main:11: error: Argument 1 to "f" of "G" has incompatible type "*List[A]"; expected "B"
 
+[case testCallerTupleVarArgsAndGenerics]
+# flags: --strict-optional
+from typing import TypeVar
+
+T = TypeVar('T')
+
+def f(*args: T) -> T: ...
+reveal_type(f(*(1, None)))  # E: Revealed type is 'Union[builtins.int, None]'
+[builtins fixtures/tuple.pyi]
+
 
 -- Comment signatures
 -- ------------------

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -125,8 +125,10 @@ f(*it1, '') # E: Argument 2 to "f" has incompatible type "str"; expected "int"
 
 def f(*x: int) -> None: pass
 it1 = (1, 2)
+it2 = ('',)
 f(*it1, 1, 2)
 f(*it1, 1, *it1, 2)
+f(*it1, 1, *it2, 2)  # E: Argument 3 to "f" has incompatible type "*Tuple[str]"; expected "int"
 f(*it1, '') # E: Argument 2 to "f" has incompatible type "str"; expected "int"
 [builtins fixtures/for.pyi]
 


### PR DESCRIPTION
Expand and type check TypedDict types when used as `**kwargs` in calls.

Also refactored the implementation of checking function arguments and
removed some apparently useless code.

Fixes #5198 and another related issue: type checking calls with multiple
`*args` arguments.