### PR TITLE
Change some protocols into ABCs in test stubs to reflect real stubs

### DIFF
--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -343,9 +343,7 @@ Point = TypedDict('Point', {'x': int, 'y': int})
 def as_dict(p: Point) -> Dict[str, int]:
     return p  # E: Incompatible return value type (got "Point", expected "Dict[str, int]")
 def as_mutable_mapping(p: Point) -> MutableMapping[str, int]:
-    return p  # E: Incompatible return value type (got "Point", expected "MutableMapping[str, int]") \
-              # N: 'Point' is missing following 'MutableMapping' protocol member: \
-              # N:     __setitem__
+    return p  # E: Incompatible return value type (got "Point", expected "MutableMapping[str, int]")
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
 

--- a/test-data/unit/fixtures/isinstancelist.pyi
+++ b/test-data/unit/fixtures/isinstancelist.pyi
@@ -1,4 +1,6 @@
-from typing import Iterable, Iterator, TypeVar, List, Mapping, overload, Tuple, Set, Union, Generic
+from typing import (
+    Iterable, Iterator, TypeVar, List, Mapping, overload, Tuple, Set, Union, Generic, Sequence
+)
 
 class object:
     def __init__(self) -> None: pass
@@ -27,7 +29,7 @@ VT = TypeVar('VT')
 class tuple(Generic[T]):
     def __len__(self) -> int: pass
 
-class list(Generic[T]):
+class list(Sequence[T]):
     def __iter__(self) -> Iterator[T]: pass
     def __mul__(self, x: int) -> list[T]: pass
     def __setitem__(self, x: int, v: T) -> None: pass

--- a/test-data/unit/fixtures/typing-full.pyi
+++ b/test-data/unit/fixtures/typing-full.pyi
@@ -122,13 +122,11 @@ class AsyncIterator(AsyncIterable[T], Protocol):
     @abstractmethod
     def __anext__(self) -> Awaitable[T]: pass
 
-@runtime
-class Sequence(Iterable[T_co], Protocol):
+class Sequence(Iterable[T_co]):
     @abstractmethod
     def __getitem__(self, n: Any) -> T_co: pass
 
-@runtime
-class Mapping(Iterable[T], Protocol[T, T_co], metaclass=ABCMeta):
+class Mapping(Generic[T, T_co], Iterable[T], metaclass=ABCMeta):
     def __getitem__(self, key: T) -> T_co: pass
     @overload
     def get(self, k: T) -> Optional[T_co]: pass
@@ -138,8 +136,7 @@ class Mapping(Iterable[T], Protocol[T, T_co], metaclass=ABCMeta):
     def __len__(self) -> int: ...
     def __contains__(self, arg: object) -> int: pass
 
-@runtime
-class MutableMapping(Mapping[T, U], Protocol, metaclass=ABCMeta):
+class MutableMapping(Mapping[T, U], metaclass=ABCMeta):
     def __setitem__(self, k: T, v: U) -> None: pass
 
 class SupportsInt(Protocol):


### PR DESCRIPTION
`Sequence`, `Mapping` and `MutableMapping` are not protocols in
typeshed stubs. They shouldn't be protocols in test stubs.