### PR TITLE
Speed up tests by simplifying test stubs

### DIFF
--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1656,6 +1656,7 @@ a = None  # type: A
 b = None  # type: B
 b = a # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 a = b
+[typing fixtures/typing-full.pyi]
 
 [case testDucktypeTransitivityDecorator]
 from typing import _promote
@@ -1668,6 +1669,7 @@ a = None  # type: A
 c = None  # type: C
 c = a # E: Incompatible types in assignment (expression has type "A", variable has type "C")
 a = c
+[typing fixtures/typing-full.pyi]
 
 
 -- Hard coded type promotions

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -337,6 +337,7 @@ U = Enum('U', *['a'])
 V = Enum('U', **{'a': 1})
 W = Enum('W', 'a b')
 W.c
+[typing fixtures/typing-full.pyi]
 [out]
 main:2: error: Too few arguments for Enum()
 main:3: error: Enum() expects a string, tuple, list or dict literal as the second argument
@@ -454,4 +455,3 @@ main:3: error: Revealed type is 'm.F'
 [out2]
 main:2: error: Revealed type is 'm.E'
 main:3: error: Revealed type is 'm.F'
-

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -806,6 +806,7 @@ from typing import no_type_check
 @no_type_check
 def foo(x: 'bar', y: {'x': 4}) -> 42:
     1 + 'x'
+[typing fixtures/typing-full.pyi]
 
 [case testNoTypeCheckDecoratorOnMethod2]
 import typing
@@ -817,6 +818,7 @@ def foo(x: 's', y: {'x': 4}) -> 42:
 @typing.no_type_check
 def bar() -> None:
     1 + 'x'
+[typing fixtures/typing-full.pyi]
 
 [case testCallingNoTypeCheckFunction]
 import typing
@@ -827,6 +829,7 @@ def foo(x: {1:2}) -> [1]:
 
 foo()
 foo(1, 'b')
+[typing fixtures/typing-full.pyi]
 
 [case testCallingNoTypeCheckFunction2]
 import typing
@@ -837,6 +840,7 @@ def f() -> None:
 @typing.no_type_check
 def foo(x: {1:2}) -> [1]:
     1 + 'x'
+[typing fixtures/typing-full.pyi]
 
 [case testNoTypeCheckDecoratorSemanticError]
 import typing
@@ -844,6 +848,7 @@ import typing
 @typing.no_type_check
 def foo(x: {1:2}) -> [1]:
     x = y
+[typing fixtures/typing-full.pyi]
 
 
 -- Forward references to decorated functions

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1247,6 +1247,7 @@ a = x1
 a = x2
 a = x3 # E: Incompatible types in assignment (expression has type "List[B]", variable has type "List[A]")
 [builtins fixtures/list.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testListWithDucktypeCompatibilityAndTransitivity]
 from typing import List, _promote
@@ -1263,6 +1264,7 @@ a = x1
 a = x2
 a = x3 # E: Incompatible types in assignment (expression has type "List[B]", variable has type "List[A]")
 [builtins fixtures/list.pyi]
+[typing fixtures/typing-full.pyi]
 
 
 -- Inferring type of variable when initialized to an empty collection

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1711,6 +1711,7 @@ isinstance(x, Iterable[T])  # E: Parameterized generics cannot be used with clas
 isinstance(x, (int, Iterable[int]))  # E: Parameterized generics cannot be used with class or instance checks
 isinstance(x, (int, (str, Iterable[int])))  # E: Parameterized generics cannot be used with class or instance checks
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testIsinstanceTypeArgsAliases]
 from typing import Iterable, TypeVar
@@ -1724,6 +1725,7 @@ isinstance(x, It)
 isinstance(x, It2[int])  # E: Parameterized generics cannot be used with class or instance checks
 isinstance(x, It2)  # E: Parameterized generics cannot be used with class or instance checks
 [builtins fixtures/isinstance.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testIssubclassTypeArgs]
 from typing import Iterable, TypeVar
@@ -1734,6 +1736,7 @@ issubclass(x, Iterable[int])  # E: Parameterized generics cannot be used with cl
 issubclass(x, Iterable[T])  # E: Parameterized generics cannot be used with class or instance checks
 issubclass(x, (int, Iterable[int]))  # E: Parameterized generics cannot be used with class or instance checks
 [builtins fixtures/isinstance.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testIsinstanceAndNarrowTypeVariable]
 from typing import TypeVar

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1048,6 +1048,7 @@ def f(n: A) -> A:
 
 f(B()) + 'x'  # E: Unsupported left operand type for + ("B")
 f(A()) + 'x'  # E: Unsupported left operand type for + ("A")
+[typing fixtures/typing-full.pyi]
 
 [case testOverloadingAndIntFloatSubtyping]
 from foo import *
@@ -4806,6 +4807,7 @@ def g(x: Union[int, float]) -> Union[List[int], List[float]]:
         return floats
 
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testOverloadsTypesAndUnions]
 from typing import overload, Type, Union

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -1308,6 +1308,7 @@ f(C()) # E: No overload variant of "f" matches argument type "C" \
        # N:     def f(x: P1) -> int \
        # N:     def f(x: P2) -> str
 [builtins fixtures/isinstance.pyi]
+[typing fixtures/typing-full.pyi]
 
 -- Unions of protocol types
 -- ------------------------
@@ -1482,6 +1483,7 @@ if isinstance(x, R):
     reveal_type(x)  # E: Revealed type is '__main__.R'
     reveal_type(x.meth())  # E: Revealed type is 'builtins.int'
 [builtins fixtures/isinstance.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testRuntimeIterableProtocolCheck]
 from typing import Iterable, List, Union
@@ -1491,6 +1493,7 @@ x: Union[int, List[str]]
 if isinstance(x, Iterable):
     reveal_type(x) # E: Revealed type is 'builtins.list[builtins.str]'
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testConcreteClassesInProtocolsIsInstance]
 from typing import Protocol, runtime, TypeVar, Generic
@@ -1550,6 +1553,7 @@ else:
     reveal_type(c2) # E: Revealed type is '__main__.C2'
 
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testConcreteClassesUnionInProtocolsIsInstance]
 from typing import Protocol, runtime, TypeVar, Generic, Union
@@ -1583,6 +1587,7 @@ if isinstance(x, P2):
 else:
     reveal_type(x) # E: Revealed type is '__main__.C1[builtins.int]'
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-full.pyi]
 
 -- Non-Instances and protocol types (Callable vs __call__ etc.)
 -- ------------------------------------------------------------
@@ -2186,6 +2191,7 @@ if issubclass(cls, P):
 else:
     reveal_type(cls)  # E: Revealed type is 'Type[__main__.E]'
 [builtins fixtures/isinstance.pyi]
+[typing fixtures/typing-full.pyi]
 [out]
 
 [case testCallableImplementsProtocol]

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -863,6 +863,7 @@ a = ()
 from typing import Sized
 a = None  # type: Sized
 a = ()
+[typing fixtures/typing-full.pyi]
 
 [case testTupleWithStarExpr1]
 

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1625,6 +1625,7 @@ T = List[int]
 from typing import List
 T = List[int]  # yo
 [builtins fixtures/list.pyi]
+[typing fixtures/typing-full.pyi]
 [out]
 ==
 
@@ -5119,6 +5120,7 @@ from enum import Enum
 
 class C(Enum):
     X = 0
+[typing fixtures/typing-full.pyi]
 [out]
 ==
 a.py:5: error: "Type[C]" has no attribute "Y"
@@ -5212,6 +5214,7 @@ C = Enum('C', 'X Y')
 from enum import Enum
 
 C = Enum('C', 'X')
+[typing fixtures/typing-full.pyi]
 [out]
 ==
 a.py:5: error: "Type[C]" has no attribute "Y"

--- a/test-data/unit/lib-stub/builtins.pyi
+++ b/test-data/unit/lib-stub/builtins.pyi
@@ -6,8 +6,8 @@ class type:
 
 # These are provided here for convenience.
 class int:
-    def __add__(self, other: 'int') -> 'int': pass
-    def __rmul__(self, other: 'int') -> 'int': pass
+    def __add__(self, other: int) -> int: pass
+    def __rmul__(self, other: int) -> int: pass
 class float: pass
 
 class str:

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -11,10 +11,8 @@ Generic = 0
 Protocol = 0  # This is not yet defined in typeshed, see PR typeshed/#1220
 Tuple = 0
 Callable = 0
-_promote = 0
 NamedTuple = 0
 Type = 0
-no_type_check = 0
 ClassVar = 0
 Final = 0
 NoReturn = 0
@@ -27,34 +25,23 @@ Set = 0
 
 T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
-T_contra = TypeVar('T_contra', contravariant=True)
 U = TypeVar('U')
 V = TypeVar('V')
-S = TypeVar('S')
 
-# Note: definitions below are different from typeshed, variances are declared
-# to silence the protocol variance checks. Maybe it is better to use type: ignore?
-
-class Sized(Protocol):
-    def __len__(self) -> int: pass
-
-@runtime
 class Iterable(Protocol[T_co]):
-    def __iter__(self) -> 'Iterator[T_co]': pass
+    def __iter__(self) -> Iterator[T_co]: pass
 
 class Iterator(Iterable[T_co], Protocol):
     def __next__(self) -> T_co: pass
 
 class Generator(Iterator[T], Generic[T, U, V]):
-    def __iter__(self) -> 'Generator[T, U, V]': pass
+    def __iter__(self) -> Generator[T, U, V]: pass
 
 class Sequence(Iterable[T_co]):
     def __getitem__(self, n: Any) -> T_co: pass
 
-class Mapping(Generic[T_contra, T_co]):
-    def __getitem__(self, key: T_contra) -> T_co: pass
-
-def runtime(cls: type) -> type: pass
+class Mapping(Generic[T, T_co]):
+    def __getitem__(self, key: T) -> T_co: pass
 
 # This is an unofficial extension.
 def final(meth: T) -> T: pass

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -1371,6 +1371,7 @@ MypyFile:1(
 from typing import _promote
 @_promote(str)
 class S: pass
+[typing fixtures/typing-full.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [_promote])


### PR DESCRIPTION
This seems to give almost a 4% speedup for the tests that I run most often
(on Linux).