### PR TITLE
Add LiteralType and stub methods to type visitors

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -5,7 +5,7 @@ from typing import Iterable, List, Optional, Sequence
 from mypy.types import (
     CallableType, Type, TypeVisitor, UnboundType, AnyType, NoneTyp, TypeVarType, Instance,
     TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType, DeletedType,
-    UninhabitedType, TypeType, TypeVarId, TypeQuery, is_named_instance, TypeOfAny
+    UninhabitedType, TypeType, TypeVarId, TypeQuery, is_named_instance, TypeOfAny, LiteralType,
 )
 from mypy.maptype import map_instance_to_supertype
 from mypy import nodes
@@ -505,6 +505,9 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             return self.infer_against_any(template.items.values(), actual)
         else:
             return []
+
+    def visit_literal_type(self, template: LiteralType) -> List[Constraint]:
+        raise NotImplementedError()
 
     def visit_union_type(self, template: UnionType) -> List[Constraint]:
         assert False, ("Unexpected UnionType in ConstraintBuilderVisitor"

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -3,7 +3,7 @@ from typing import Optional, Container, Callable
 from mypy.types import (
     Type, TypeVisitor, UnboundType, AnyType, NoneTyp, TypeVarId, Instance, TypeVarType,
     CallableType, TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType,
-    DeletedType, TypeTranslator, UninhabitedType, TypeType, TypeOfAny
+    DeletedType, TypeTranslator, UninhabitedType, TypeType, TypeOfAny, LiteralType,
 )
 from mypy.nodes import ARG_STAR, ARG_STAR2
 
@@ -76,6 +76,10 @@ class EraseTypeVisitor(TypeVisitor[Type]):
         return t.fallback.accept(self)
 
     def visit_typeddict_type(self, t: TypedDictType) -> Type:
+        return t.fallback.accept(self)
+
+    def visit_literal_type(self, t: LiteralType) -> Type:
+        # TODO: Verify this implementation is correct
         return t.fallback.accept(self)
 
     def visit_union_type(self, t: UnionType) -> Type:

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -79,8 +79,10 @@ class EraseTypeVisitor(TypeVisitor[Type]):
         return t.fallback.accept(self)
 
     def visit_literal_type(self, t: LiteralType) -> Type:
-        # TODO: Verify this implementation is correct
-        return t.fallback.accept(self)
+        # The fallback for literal types should always be either
+        # something like int or str, or an enum class -- types that
+        # don't contain any TypeVars. So there's no need to visit it.
+        return t
 
     def visit_union_type(self, t: UnionType) -> Type:
         erased_items = [erase_type(item) for item in t.items]

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -4,7 +4,7 @@ from mypy.types import (
     Type, Instance, CallableType, TypeVisitor, UnboundType, AnyType,
     NoneTyp, TypeVarType, Overloaded, TupleType, TypedDictType, UnionType,
     ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, TypeVarId,
-    FunctionLike, TypeVarDef
+    FunctionLike, TypeVarDef, LiteralType,
 )
 
 
@@ -110,6 +110,10 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
 
     def visit_typeddict_type(self, t: TypedDictType) -> Type:
         return t.copy_modified(item_types=self.expand_types(t.items.values()))
+
+    def visit_literal_type(self, t: LiteralType) -> Type:
+        # TODO: Verify this implementation is correct
+        return t
 
     def visit_union_type(self, t: UnionType) -> Type:
         # After substituting for type variables in t.items,

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -9,7 +9,7 @@ from mypy.nodes import (
 )
 from mypy.types import (
     CallableType, Instance, Overloaded, TupleType, TypedDictType,
-    TypeVarType, UnboundType, UnionType, TypeVisitor,
+    TypeVarType, UnboundType, UnionType, TypeVisitor, LiteralType,
     TypeType, NOT_READY
 )
 from mypy.visitor import NodeVisitor
@@ -205,6 +205,9 @@ class TypeFixer(TypeVisitor[None]):
                 it.accept(self)
         if tdt.fallback is not None:
             tdt.fallback.accept(self)
+
+    def visit_literal_type(self, lt: LiteralType) -> None:
+        lt.fallback.accept(self)
 
     def visit_type_var(self, tvt: TypeVarType) -> None:
         if tvt.values:

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -90,6 +90,9 @@ class TypeIndirectionVisitor(SyntheticTypeVisitor[Set[str]]):
     def visit_typeddict_type(self, t: types.TypedDictType) -> Set[str]:
         return self._visit(t.items.values()) | self._visit(t.fallback)
 
+    def visit_literal_type(self, t: types.LiteralType) -> Set[str]:
+        return self._visit(t.fallback)
+
     def visit_star_type(self, t: types.StarType) -> Set[str]:
         return set()
 

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -5,8 +5,8 @@ from typing import List, Optional
 
 from mypy.types import (
     Type, AnyType, NoneTyp, TypeVisitor, Instance, UnboundType, TypeVarType, CallableType,
-    TupleType, TypedDictType, ErasedType, UnionType, FunctionLike, Overloaded,
-    PartialType, DeletedType, UninhabitedType, TypeType, true_or_false, TypeOfAny
+    TupleType, TypedDictType, ErasedType, UnionType, FunctionLike, Overloaded, LiteralType,
+    PartialType, DeletedType, UninhabitedType, TypeType, true_or_false, TypeOfAny,
 )
 from mypy.maptype import map_instance_to_supertype
 from mypy.subtypes import (
@@ -266,6 +266,9 @@ class TypeJoinVisitor(TypeVisitor[Type]):
             return join_types(self.s, t.fallback)
         else:
             return self.default(self.s)
+
+    def visit_literal_type(self, t: LiteralType) -> Type:
+        raise NotImplementedError()
 
     def visit_partial_type(self, t: PartialType) -> Type:
         # We only have partial information so we can't decide the join result. We should

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -7,7 +7,7 @@ from mypy.join import (
 from mypy.types import (
     Type, AnyType, TypeVisitor, UnboundType, NoneTyp, TypeVarType, Instance, CallableType,
     TupleType, TypedDictType, ErasedType, UnionType, PartialType, DeletedType,
-    UninhabitedType, TypeType, TypeOfAny, Overloaded, FunctionLike,
+    UninhabitedType, TypeType, TypeOfAny, Overloaded, FunctionLike, LiteralType,
 )
 from mypy.subtypes import (
     is_equivalent, is_subtype, is_protocol_implementation, is_callable_compatible,
@@ -519,6 +519,9 @@ class TypeMeetVisitor(TypeVisitor[Type]):
             return TypedDictType(items, required_keys, fallback)
         else:
             return self.default(self.s)
+
+    def visit_literal_type(self, t: LiteralType) -> Type:
+        raise NotImplementedError()
 
     def visit_partial_type(self, t: PartialType) -> Type:
         # We can't determine the meet of partial types. We should never get here.

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -3,7 +3,7 @@ from typing import Sequence
 from mypy.types import (
     Type, UnboundType, AnyType, NoneTyp, TupleType, TypedDictType,
     UnionType, CallableType, TypeVarType, Instance, TypeVisitor, ErasedType,
-    Overloaded, PartialType, DeletedType, UninhabitedType, TypeType
+    Overloaded, PartialType, DeletedType, UninhabitedType, TypeType, LiteralType,
 )
 
 
@@ -111,6 +111,14 @@ class SameTypeVisitor(TypeVisitor[bool]):
                 if not is_same_type(left_item_type, right_item_type):
                     return False
             return True
+        else:
+            return False
+
+    def visit_literal_type(self, left: LiteralType) -> bool:
+        if isinstance(self.right, LiteralType):
+            if left.value != self.right.value:
+                return False
+            return is_same_type(left.fallback, self.right.fallback)
         else:
             return False
 

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -59,7 +59,7 @@ from mypy.nodes import (
 from mypy.types import (
     Type, TypeVisitor, UnboundType, AnyType, NoneTyp, UninhabitedType,
     ErasedType, DeletedType, Instance, TypeVarType, CallableType, TupleType, TypedDictType,
-    UnionType, Overloaded, PartialType, TypeType
+    UnionType, Overloaded, PartialType, TypeType, LiteralType,
 )
 from mypy.util import get_prefix
 
@@ -314,6 +314,9 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
                       for key, item_type in typ.items.items())
         required = tuple(sorted(typ.required_keys))
         return ('TypedDictType', items, required)
+
+    def visit_literal_type(self, typ: LiteralType) -> SnapshotItem:
+        return ('LiteralType', typ.value, snapshot_type(typ.fallback))
 
     def visit_union_type(self, typ: UnionType) -> SnapshotItem:
         # Sort and remove duplicates so that we can use equality to test for

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -58,7 +58,7 @@ from mypy.traverser import TraverserVisitor
 from mypy.types import (
     Type, SyntheticTypeVisitor, Instance, AnyType, NoneTyp, CallableType, DeletedType, PartialType,
     TupleType, TypeType, TypeVarType, TypedDictType, UnboundType, UninhabitedType, UnionType,
-    Overloaded, TypeVarDef, TypeList, CallableArgument, EllipsisType, StarType
+    Overloaded, TypeVarDef, TypeList, CallableArgument, EllipsisType, StarType, LiteralType,
 )
 from mypy.util import get_prefix, replace_object_state
 from mypy.typestate import TypeState
@@ -389,6 +389,9 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
     def visit_typeddict_type(self, typ: TypedDictType) -> None:
         for value_type in typ.items.values():
             value_type.accept(self)
+        typ.fallback.accept(self)
+
+    def visit_literal_type(self, typ: LiteralType) -> None:
         typ.fallback.accept(self)
 
     def visit_unbound_type(self, typ: UnboundType) -> None:

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -99,7 +99,7 @@ from mypy.traverser import TraverserVisitor
 from mypy.types import (
     Type, Instance, AnyType, NoneTyp, TypeVisitor, CallableType, DeletedType, PartialType,
     TupleType, TypeType, TypeVarType, TypedDictType, UnboundType, UninhabitedType, UnionType,
-    FunctionLike, ForwardRef, Overloaded, TypeOfAny
+    FunctionLike, ForwardRef, Overloaded, TypeOfAny, LiteralType,
 )
 from mypy.server.trigger import make_trigger, make_wildcard_trigger
 from mypy.util import correct_relative_import
@@ -948,6 +948,9 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
             triggers.extend(self.get_type_triggers(item))
         triggers.extend(self.get_type_triggers(typ.fallback))
         return triggers
+
+    def visit_literal_type(self, typ: LiteralType) -> List[str]:
+        return self.get_type_triggers(typ.fallback)
 
     def visit_unbound_type(self, typ: UnboundType) -> List[str]:
         return []

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -5,7 +5,7 @@ from mypy.types import (
     Type, AnyType, UnboundType, TypeVisitor, FormalArgument, NoneTyp, function_type,
     Instance, TypeVarType, CallableType, TupleType, TypedDictType, UnionType, Overloaded,
     ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, is_named_instance,
-    FunctionLike, TypeOfAny
+    FunctionLike, TypeOfAny, LiteralType,
 )
 import mypy.applytype
 import mypy.constraints
@@ -326,6 +326,9 @@ class SubtypeVisitor(TypeVisitor[bool]):
             return True
         else:
             return False
+
+    def visit_literal_type(self, t: LiteralType) -> bool:
+        raise NotImplementedError()
 
     def visit_overloaded(self, left: Overloaded) -> bool:
         right = self.right
@@ -1167,6 +1170,9 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
                     return False
             return True
         return self._is_proper_subtype(left.fallback, right)
+
+    def visit_literal_type(self, left: LiteralType) -> bool:
+        raise NotImplementedError()
 
     def visit_overloaded(self, left: Overloaded) -> bool:
         # TODO: What's the right thing to do here?

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -15,7 +15,8 @@ from mypy.types import (
     Type, UnboundType, TypeVarType, TupleType, TypedDictType, UnionType, Instance, AnyType,
     CallableType, NoneTyp, DeletedType, TypeList, TypeVarDef, TypeVisitor, SyntheticTypeVisitor,
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType, get_typ_args, set_typ_args,
-    CallableArgument, get_type_vars, TypeQuery, union_items, TypeOfAny, ForwardRef, Overloaded
+    CallableArgument, get_type_vars, TypeQuery, union_items, TypeOfAny, ForwardRef, Overloaded,
+    LiteralType,
 )
 
 from mypy.nodes import (
@@ -459,6 +460,9 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         ])
         return TypedDictType(items, set(t.required_keys), t.fallback)
 
+    def visit_literal_type(self, t: LiteralType) -> Type:
+        raise NotImplementedError()
+
     def visit_star_type(self, t: StarType) -> Type:
         return StarType(self.anal_type(t.type), t.line)
 
@@ -753,6 +757,9 @@ class TypeAnalyserPass3(TypeVisitor[None]):
     def visit_typeddict_type(self, t: TypedDictType) -> None:
         for item_type in t.items.values():
             item_type.accept(self)
+
+    def visit_literal_type(self, t: LiteralType) -> None:
+        raise NotImplementedError()
 
     def visit_union_type(self, t: UnionType) -> None:
         for item in t.items:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -33,12 +33,15 @@ JsonDict = Dict[str, Any]
 # Literals can contain enum-values: we special-case those and
 # store the value as a string.
 #
+# TODO: confirm that we're happy with representing enums (and the
+# other types) in the manner described above.
+#
 # Note: this type also happens to correspond to types that can be
 # directly converted into JSON. The serialize/deserialize methods
 # of 'LiteralType' rely on this, as well 'server.astdiff.SnapshotTypeVisitor'
 # and 'types.TypeStrVisitor'. If we end up adding any non-JSON-serializable
 # types to this list, we should make sure to edit those methods to match.
-LiteralInnerExpr = Union[int, str, bool, None]
+LiteralValue = Union[int, str, bool, None]
 
 # If we only import type_visitor in the middle of the file, mypy
 # breaks, and if we do it at the top, it breaks at runtime because of
@@ -1254,9 +1257,20 @@ class TypedDictType(Type):
 
 
 class LiteralType(Type):
+    """The type of a Literal instance. Literal[Value]
+
+    A Literal always consists of:
+
+    1. A native Python object corresponding to the contained inner value
+    2. A fallback for this Literal. The fallback also corresponds to the
+       parent type this Literal subtypes.
+
+    For example, 'Literal[42]' is represented as
+    'LiteralType(value=42, fallback=instance_of_int)'
+    """
     __slots__ = ('value', 'fallback')
 
-    def __init__(self, value: LiteralInnerExpr, fallback: Instance,
+    def __init__(self, value: LiteralValue, fallback: Instance,
                  line: int = -1, column: int = -1) -> None:
         super().__init__(line, column)
         self.value = value
@@ -1744,7 +1758,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         return 'TypedDict({}{}{})'.format(prefix, s, suffix)
 
     def visit_literal_type(self, t: LiteralType) -> str:
-        return 'Literal[{}]'.format(t.value)
+        return 'Literal[{}]'.format(repr(t.value))
 
     def visit_star_type(self, t: StarType) -> str:
         s = t.type.accept(self)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -27,6 +27,19 @@ T = TypeVar('T')
 
 JsonDict = Dict[str, Any]
 
+# The set of all valid expressions that can currently be contained
+# inside of a Literal[...].
+#
+# Literals can contain enum-values: we special-case those and
+# store the value as a string.
+#
+# Note: this type also happens to correspond to types that can be
+# directly converted into JSON. The serialize/deserialize methods
+# of 'LiteralType' rely on this, as well 'server.astdiff.SnapshotTypeVisitor'
+# and 'types.TypeStrVisitor'. If we end up adding any non-JSON-serializable
+# types to this list, we should make sure to edit those methods to match.
+LiteralInnerExpr = Union[int, str, bool, None]
+
 # If we only import type_visitor in the middle of the file, mypy
 # breaks, and if we do it at the top, it breaks at runtime because of
 # import cycle issues, so we do it at the top while typechecking and
@@ -1240,6 +1253,43 @@ class TypedDictType(Type):
             yield (item_name, None, right_item_type)
 
 
+class LiteralType(Type):
+    __slots__ = ('value', 'fallback')
+
+    def __init__(self, value: LiteralInnerExpr, fallback: Instance,
+                 line: int = -1, column: int = -1) -> None:
+        super().__init__(line, column)
+        self.value = value
+        self.fallback = fallback
+
+    def accept(self, visitor: 'TypeVisitor[T]') -> T:
+        return visitor.visit_literal_type(self)
+
+    def __hash__(self) -> int:
+        return hash((self.value, self.fallback))
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, LiteralType):
+            return self.fallback == other.fallback and self.value == other.value
+        else:
+            return NotImplemented
+
+    def serialize(self) -> Union[JsonDict, str]:
+        return {
+            '.class': 'LiteralType',
+            'value': self.value,
+            'fallback': self.fallback.serialize(),
+        }
+
+    @classmethod
+    def deserialize(cls, data: JsonDict) -> 'LiteralType':
+        assert data['.class'] == 'LiteralType'
+        return LiteralType(
+            value=data['value'],
+            fallback=Instance.deserialize(data['fallback']),
+        )
+
+
 class StarType(Type):
     """The star type *type_parameter.
 
@@ -1692,6 +1742,9 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
             else:
                 suffix = ', fallback={}'.format(t.fallback.accept(self))
         return 'TypedDict({}{}{})'.format(prefix, s, suffix)
+
+    def visit_literal_type(self, t: LiteralType) -> str:
+        return 'Literal[{}]'.format(t.value)
 
     def visit_star_type(self, t: StarType) -> str:
         s = t.type.accept(self)


### PR DESCRIPTION
This diff adds a 'LiteralType' class to types.py and adds a corresponding stub method to all of the type visitors.

Most of these stub methods just throw a 'NotImplementedError', though I did pencil in a few implementations that looked obvious.

The reason I'm doing this now instead of later is because I want to start by getting these kind of big, gross, multi-file changes out of the way early and try and have any subsequent pull requests be more focused.

I also want to formally confirm that the correct approach here *is* to create a new 'LiteralType' class before I start on the rest of the implementation work. (Other possible approaches would be to tack on some extra attribute to 'Instance', or make 'LiteralType' a subclass of 'Instance'.)

No tests, sorry. My plan is to work on modifying the parsing and semantic analysis steps next before returning back to these the unimplemented methods and add tests then -- here's the tracking issue for these TODOs: https://github.com/python/mypy/issues/5935

Tests shouldn't be necessary, in any case: everything I added just now is basically dead code.