### PR TITLE
Fix some intermittent test failures due to failure to import plugin

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -341,7 +341,10 @@ def load_plugins(options: Options, errors: Errors) -> Tuple[Plugin, Dict[str, st
             plugin_path = os.path.join(os.path.dirname(options.config_file), plugin_path)
             if not os.path.isfile(plugin_path):
                 plugin_error("Can't find plugin '{}'".format(plugin_path))
-            plugin_dir = os.path.dirname(plugin_path)
+            # Use an absolute path to avoid populating the cache entry
+            # for 'tmp' during tests, since it will be different in
+            # different tests.
+            plugin_dir = os.path.abspath(os.path.dirname(plugin_path))
             fnam = os.path.basename(plugin_path)
             module_name = fnam[:-3]
             sys.path.insert(0, plugin_dir)


### PR DESCRIPTION
While trying to test mypy_mypyc wheels in travis on OS X, I pretty
consistently got failures trying to import a plugin module. I had
trouble reproducing it anywhere else, but the issue turned out to be a
cousin of the dreaded stubgen flake (#4811), where caching in
importlib causes a file to be missed even though it is present now.

Here we solve it by using absolute paths in the `load_plugins`
manipulations of sys.path.