### PR TITLE
Preserve tabs when creating XML reports (#5942)

### DIFF
--- a/mypy/report.py
+++ b/mypy/report.py
@@ -417,7 +417,8 @@ class MemoryXmlReporter(AbstractReporter):
 
     # XML doesn't like control characters, but they are sometimes
     # legal in source code (e.g. comments, string literals).
-    control_fixer = str.maketrans(''.join(chr(i) for i in range(32)), '?' * 32)
+    # Tabs (#x09) are allowed in XML content.
+    control_fixer = str.maketrans(''.join(chr(i) for i in range(32) if i != 9), '?' * 31)
 
     def on_file(self,
                 tree: MypyFile,

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -77,7 +77,7 @@ def untyped_function():
 # cmd: mypy --html-report report n.py
 [file n.py]
 class A(object):
-    pass  # hex 1f here: ()
+	pass  # line indented with tab; hex 1f here: ()
 
 [file report/mypy-html.css]
 [file report/index.html]
@@ -96,7 +96,7 @@ class A(object):
 <span id="L2" class="lineno"><a class="lineno" href="#L2">2</a></span>
 </pre></td>
 <td class="table-code"><pre><span class="line-empty" title="No Anys on this line!">class A(object):</span>
-<span class="line-empty" title="No Anys on this line!">    pass  # hex 1f here: (?)</span>
+<span class="line-empty" title="No Anys on this line!">	pass  # line indented with tab; hex 1f here: (?)</span>
 </pre></td>
 </tr></tbody>
 </table>


### PR DESCRIPTION
Control characters are replaced with question marks, to avoid
outputting invalid XML. However, XML does allow tabs in content,
so make an exception for those.