### PR TITLE
Stop suggesting MYPYPATH on missing imports

### DIFF
--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -159,11 +159,12 @@ If the module is a part of your own codebase, try:
 If the module is a third party library, you must make sure that there are
 type hints available for that library. Mypy by default will not attempt to
 infer the types of any 3rd party libraries you may have installed
-unless they declare themselves to be :ref:`PEP 561 compliant stub package <installed-packages>`
-or have registered themselves on `typeshed <https://github.com/python/typeshed>`_,
+unless they either have declared themselves to be
+:ref:`PEP 561 compliant stub package <installed-packages>` or have registered
+themselves on `typeshed <https://github.com/python/typeshed>`_,
 the repository of types for the standard library and some 3rd party libraries.
 
-If you are getting a "no library stub file" error, this means the library you
+If you are getting an import-related error, this means the library you
 are trying to use has done neither of these things. In that case, you can try:
 
 1.  Searching to see if there is a :ref:`PEP 561 compliant stub package <installed-packages>`.
@@ -214,7 +215,7 @@ type hints nor have to time to write your own, you can *silence* the errors:
         [mypy]
         ignore_missing_imports = True
 
-    We recommend using either option only as a last resort: it's equivalent
+    We recommend using this approach only as a last resort: it's equivalent
     to adding a ``# type: ignore`` to all unresolved imports in your codebase.
 
 If the module is a part of the standard library, try:
@@ -230,8 +231,8 @@ If the module is a part of the standard library, try:
     Changes to typeshed will come bundled with mypy the next time it's released.
     In the meantime, you can add a ``# type: ignore`` to silence any relevant
     errors. After upgrading, we recommend running mypy using the
-    ``--warn-unused-ignores`` flag to help you find any ``# type: ignores``
-    you no longer need.
+    ``--warn-unused-ignores`` flag to help you find any ``# type: ignore``
+    annotations you no longer need.
      
 .. _follow-imports:
 

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -146,7 +146,15 @@ If the module is a part of your own codebase, try:
 2.  Reading the :ref:`finding-imports` section below to make sure you
     understand how exactly mypy searches for and finds modules and modify
     how you're invoking mypy accordingly.
-3.  Adding the path to that module to the ``MYPYPATH`` environment variable.
+3.  Adding the directory containing that module to either the ``MYPYPATH``
+    environment variable or the ``mypy_path``
+    :ref:`config file option <config-file-import-discovery-global>`.
+
+    Note: if the module you are trying to import is actually a *submodule* of
+    some package, you should add the directory containing the *entire* package
+    to ``MYPYPATH``. For example, suppose you are trying to add the module
+    ``foo.bar.baz``, which is located at ``~/foo-project/src/foo/bar/baz.py``.
+    In this case, you should add ``~/foo-project/src`` to ``MYPYPATH``.
 
 If the module is a third party library, you must make sure that there are
 type hints available for that library. Mypy by default will not attempt to
@@ -198,9 +206,16 @@ type hints nor have to time to write your own, you can *silence* the errors:
     :ref:`import discovery <config-file-import-discovery-per-module>` in config files.
 
 3.  To silence *all* missing import errors for *all* libraries in your codebase,
-    invoke mypy with the ``--ignore-missing-imports`` command line flag. We
-    recommend using this flag only as a last resort: it's equivalent to adding
-    a ``# type: ignore`` to all unresolved imports in your codebase.
+    invoke mypy with the ``--ignore-missing-imports`` command line flag or set
+    the ``ignore_missing_imports``
+    :ref:`config file option <config-file-import-discovery-per-module` to True
+    in the *global* section of your mypy config file::
+
+        [mypy]
+        ignore_missing_imports = True
+
+    We recommend using either option only as a last resort: it's equivalent
+    to adding a ``# type: ignore`` to all unresolved imports in your codebase.
 
 If the module is a part of the standard library, try:
 

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -131,60 +131,93 @@ Missing imports
 When you import a module, mypy may report that it is unable to
 follow the import.
 
-This could happen if the code is importing a non-existent module
-or if the code is importing a library that does not use type hints.
-Specifically, the library is neither declared to be a 
-:ref:`PEP 561 compliant package <installed-packages>` nor has registered
-any stubs on `typeshed <https://github.com/python/typeshed>`_, the
-repository of stubs for the standard library and popular 3rd party libraries.
-
 This can cause a lot of errors that look like the following::
 
     main.py:1: error: No library stub file for standard library module 'antigravity'
     main.py:2: error: No library stub file for module 'flask'
     main.py:3: error: Cannot find module named 'this_module_does_not_exist'
 
-If the module genuinely does not exist, you should of course fix the
-import statement. If the module is a module within your codebase that mypy
-is somehow unable to discover, we recommend reading the :ref:`finding-imports`
-section below to help you debug the issue.
+There are several different things you can try doing, depending on the exact
+nature of the module.
 
-If the module is a library that does not use type hints, the easiest fix
-is to silence the error messages by adding a ``# type: ignore`` comment on
-each respective import statement.
+If the module is a part of your own codebase, try:
 
-If you have many of these errors from a specific library, it may be more
-convenient to silence all of those errors at once using the
-:ref:`mypy config file <config-file>`. For example, suppose your codebase
-makes heavy use of an (untyped) library named `foobar`. You can silence all
-import errors associated with that library and that library alone by adding
-the following section to your config file::
+1.  Making sure your import does not contain a typo.
+2.  Reading the :ref:`finding-imports` section below to make sure you
+    understand how exactly mypy searches for and finds modules and modify
+    how you're invoking mypy accordingly.
+3.  Adding the path to that module to the ``MYPYPATH`` environment variable.
 
-    [mypy-foobar]
-    ignore_missing_imports = True
+If the module is a third party library, you must make sure that there are
+type hints available for that library. Mypy by default will not attempt to
+infer the types of any 3rd party libraries you may have installed
+unless they declare themselves to be :ref:`PEP 561 compliant stub package <installed-packages>`
+or have registered themselves on `typeshed <https://github.com/python/typeshed>`_,
+the repository of types for the standard library and some 3rd party libraries.
 
-Note: this option is equivalent to adding a ``# type: ignore`` to every
-import of ``foobar`` in your codebase. For more information, see the
-documentation about configuring
-:ref:`import discovery <config-file-import-discovery-per-module>` in config files.
+If you are getting a "no library stub file" error, this means the library you
+are trying to use has done neither of these things. In that case, you can try:
 
-If you would like to silence *all* missing import errors in your codebase,
-you can do so by using the ``--ignore-missing-imports`` flag. We recommend
-using this flag only as a last resort: it's equivalent to adding a
-``# type: ignore`` to all unresolved imports in your codebase.
+1.  Searching to see if there is a :ref:`PEP 561 compliant stub package <installed-packages>`.
+    corresponding to your third party library. Stub packages let you install
+    type hints independently from the library itself.
 
-A more involved solution would be to reverse-engineer how the library
-works, create type hints for the library, and point mypy at those
-type hints either by passing in in via the command line or by adding
-the location of your custom stubs to either the ``MYPYPATH`` environment
-variable or the ``mypy_path`` 
-:ref:`config file option <config-file-import-discovery-global>`.
+2.  :ref:`Writing your own stub files <stub-files>` containing type hints for
+    the library. You can point mypy at your type hints either by passing
+    them in via the command line, by adding the location to the 
+    `MYPYPATH` environment variable, or by using the  ``mypy_path`` 
+    :ref:`config file option <config-file-import-discovery-global>`. 
 
-If you want to share your work, you can try contributing your stubs back
-to the library -- see our documentation on creating
-:ref:`PEP 561 compliant packages <installed-packages>`.
+    Note that if you decide to write your own stub files, they don't need
+    to be complete! A good strategy is to add stubs for just the parts
+    of the library you need and iterate on them over time.
 
+    If you want to share your work, you can try contributing your stubs back
+    to the library -- see our documentation on creating
+    :ref:`PEP 561 compliant packages <installed-packages>`.
 
+If the module is a third party library, but you cannot find any existing
+type hints nor have to time to write your own, you can *silence* the errors:
+
+1.  To silence a *single* missing import error, add a `# type: ignore` at the end of the
+    line containing the import.
+
+2.  To silence *all* missing import imports errors from a single library, add
+    a section to your :ref:`mypy config file <config-file>` for that library setting
+    ``ignore_missing_imports`` to True. For example, suppose your codebase
+    makes heavy use of an (untyped) library named ``foobar``. You can silence
+    all import errors associated with that library and that library alone by
+    adding the following section to your config file::
+
+        [mypy-foobar]
+        ignore_missing_imports = True
+
+    Note: this option is equivalent to adding a ``# type: ignore`` to every
+    import of ``foobar`` in your codebase. For more information, see the
+    documentation about configuring
+    :ref:`import discovery <config-file-import-discovery-per-module>` in config files.
+
+3.  To silence *all* missing import errors for *all* libraries in your codebase,
+    invoke mypy with the ``--ignore-missing-imports`` command line flag. We
+    recommend using this flag only as a last resort: it's equivalent to adding
+    a ``# type: ignore`` to all unresolved imports in your codebase.
+
+If the module is a part of the standard library, try:
+
+1.  Updating mypy and re-running it. It's possible type hints for that corner
+    of the standard library were added in a later version of mypy.
+
+2.  Filing a bug report on `typeshed <https://github.com/python/typeshed>`_,
+    the repository of type hints for the standard library that comes bundled
+    with mypy. You can expedite this process by also submitting a pull request
+    fixing the bug.
+
+    Changes to typeshed will come bundled with mypy the next time it's released.
+    In the meantime, you can add a ``# type: ignore`` to silence any relevant
+    errors. After upgrading, we recommend running mypy using the
+    ``--warn-unused-ignores`` flag to help you find any ``# type: ignores``
+    you no longer need.
+     
 .. _follow-imports:
 
 Following imports

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2131,10 +2131,9 @@ def module_not_found(manager: BuildManager, line: int, caller_state: State,
         errors.report(line, 0, "No library stub file for module '{}'".format(target))
         errors.report(line, 0, stub_msg, severity='note', only_once=True)
     else:
+        note = "See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports"
         errors.report(line, 0, "Cannot find module named '{}'".format(target))
-        errors.report(line, 0, '(Perhaps setting MYPYPATH '
-                      'or using the "--ignore-missing-imports" flag would help)',
-                      severity='note', only_once=True)
+        errors.report(line, 0, note, severity='note', only_once=True)
     errors.set_import_context(save_import_context)
 
 

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -59,8 +59,8 @@ class SimpleMsg(Enum):
 class NamespaceMsg(Enum):
     cfm_beta = ("{tempfile}:4: error: Cannot find module named "
                 "'typedpkg_ns.ns.dne'")
-    help_note = ('{tempfile}:4: note: (Perhaps setting MYPYPATH or using the '
-                 '"--ignore-missing-imports" flag would help)')
+    help_note = ('{tempfile}:4: note: See https://mypy.readthedocs.io/en/latest/'
+                 'running_mypy.html#missing-imports')
     bool_str = ('{tempfile}:10: error: Argument 1 has incompatible type '
                 '"bool"; expected "str"')
     int_bool = ('{tempfile}:11: error: Argument 1 has incompatible type '

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -439,7 +439,7 @@ main:2: note: (Using --follow-imports=error, module not passed on command line)
 from mod import x
 [out]
 main:1: error: Cannot find module named 'mod'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testIgnoreMissingImportsTrue]
 # flags: --ignore-missing-imports
@@ -594,7 +594,7 @@ def f(x: MyType) -> None:
     pass
 [out]
 main:2: error: Cannot find module named 'missing'
-main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:4: error: Argument 1 to "f" becomes "Any" due to an unfollowed import
 
 [case testDisallowImplicitAnyVariableDefinition]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2082,7 +2082,7 @@ x = 1
 [stale]
 [out2]
 tmp/n.py:1: error: Cannot find module named 'm'
-tmp/n.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+tmp/n.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testDeleteFileWithinCycle]
 import a
@@ -2748,10 +2748,10 @@ a.f() # Comment change
 [stale3 b]
 [out2]
 tmp/b.py:1: error: Cannot find module named 'a'
-tmp/b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+tmp/b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 [out3]
 tmp/b.py:1: error: Cannot find module named 'a'
-tmp/b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+tmp/b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 [out4]
 
 [case testQuickAndDirtyRenameModule]
@@ -4063,7 +4063,7 @@ import a
 
 [out2]
 main:2: error: Cannot find module named 'a'
-main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testIncrementalInheritanceAddAnnotation]
 # flags: --strict-optional
@@ -4206,7 +4206,7 @@ def f(x: int) -> None: pass
 [out]
 [out2]
 main:1: error: Cannot find module named 'p.q'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 [out3]
 main:2: error: Too few arguments for "f"
 
@@ -4808,10 +4808,10 @@ def __getattr__(attr: str) -> Any: ...
 [builtins fixtures/module.pyi]
 [out]
 tmp/c.py:1: error: Cannot find module named 'a.b.c'
-tmp/c.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+tmp/c.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 [out2]
 tmp/c.py:1: error: Cannot find module named 'a.b.c'
-tmp/c.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+tmp/c.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testAddedMissingStubs]
 # flags: --ignore-missing-imports

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -201,7 +201,7 @@ import nonexistent
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Unsupported left operand type for + ("None")
 
 [case testTypeCheckWithUnknownModule2]
@@ -213,7 +213,7 @@ m.x = ''
 x = 1
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Unsupported left operand type for + ("None")
 main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
@@ -226,7 +226,7 @@ m.x = ''
 x = 1
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Unsupported left operand type for + ("None")
 main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
@@ -235,7 +235,7 @@ import nonexistent, another
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:1: error: Cannot find module named 'another'
 main:2: error: Unsupported left operand type for + ("None")
 
@@ -244,7 +244,7 @@ import nonexistent as x
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Unsupported left operand type for + ("None")
 
 [case testTypeCheckWithUnknownModuleUsingFromImport]
@@ -252,7 +252,7 @@ from nonexistent import x
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Unsupported left operand type for + ("None")
 
 [case testTypeCheckWithUnknownModuleUsingImportStar]
@@ -260,7 +260,7 @@ from nonexistent import *
 None + ''
 [out]
 main:1: error: Cannot find module named 'nonexistent'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Unsupported left operand type for + ("None")
 
 [case testAccessingUnknownModule]
@@ -269,7 +269,7 @@ xyz.foo()
 xyz()
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testAccessingUnknownModule2]
 import xyz, bar
@@ -277,7 +277,7 @@ xyz.foo()
 bar()
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:1: error: Cannot find module named 'bar'
 
 [case testAccessingUnknownModule3]
@@ -286,7 +286,7 @@ xyz.foo()
 z()
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Name 'xyz' is not defined
 
 [case testAccessingNameImportedFromUnknownModule]
@@ -295,14 +295,14 @@ y.foo()
 z()
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testAccessingNameImportedFromUnknownModule2]
 from xyz import *
 y
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Name 'y' is not defined
 
 [case testAccessingNameImportedFromUnknownModule3]
@@ -311,7 +311,7 @@ y
 z
 [out]
 main:1: error: Cannot find module named 'xyz'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Name 'y' is not defined
 
 [case testUnknownModuleRedefinition]
@@ -319,7 +319,7 @@ import xab
 def xab(): pass
 [out]
 main:1: error: Cannot find module named 'xab'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testAccessingUnknownModuleFromOtherModule]
 import x
@@ -330,7 +330,7 @@ import nonexistent
 [builtins fixtures/module.pyi]
 [out]
 tmp/x.py:1: error: Cannot find module named 'nonexistent'
-tmp/x.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+tmp/x.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:3: error: Module has no attribute "z"
 
 [case testUnknownModuleImportedWithinFunction]
@@ -340,7 +340,7 @@ def foobar(): pass
 foobar('')
 [out]
 main:2: error: Cannot find module named 'foobar'
-main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:4: error: Too many arguments for "foobar"
 
 [case testUnknownModuleImportedWithinFunction2]
@@ -350,7 +350,7 @@ def x(): pass
 x('')
 [out]
 main:2: error: Cannot find module named 'foobar'
-main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:4: error: Too many arguments for "x"
 
 [case testRelativeImports]
@@ -2091,7 +2091,7 @@ import c
 -- TODO: it would be better for this to be in the other order
 tmp/b.py:1: error: Cannot find module named 'c'
 main:1: error: Cannot find module named 'c'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testIndirectFromImportWithinCycle1]
 import a
@@ -2225,7 +2225,7 @@ def __getattr__(attr: str) -> Any: ...
 [builtins fixtures/module.pyi]
 [out]
 main:1: error: Cannot find module named 'a.b'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testModuleGetattrInit4]
 import a.b.c
@@ -2267,7 +2267,7 @@ def __getattr__(attr: str) -> int: ...
 [builtins fixtures/module.pyi]
 [out]
 main:1: error: Cannot find module named 'a.b'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testModuleGetattrInit8]
 import a.b.c.d
@@ -2281,7 +2281,7 @@ def __getattr__(attr: str) -> Any: ...
 [builtins fixtures/module.pyi]
 [out]
 main:1: error: Cannot find module named 'a.b.c.d'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:1: error: Cannot find module named 'a.b.c'
 
 [case testModuleGetattrInit8a]
@@ -2295,7 +2295,7 @@ def __getattr__(attr: str) -> Any: ...
 [builtins fixtures/module.pyi]
 [out]
 main:1: error: Cannot find module named 'a.b.c'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testModuleGetattrInit10]
 # flags: --config-file tmp/mypy.ini
@@ -2315,7 +2315,7 @@ ignore_missing_imports = True
 [builtins fixtures/module.pyi]
 [out]
 main:3: error: Cannot find module named 'a.b.d'
-main:3: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testIndirectFromImportWithinCycleUsedAsBaseClass-skip]
 -- TODO: Fails because of missing ImportedName handling in mypy.typeanal
@@ -2542,7 +2542,7 @@ from foo.bar import x
 x = 0
 [out]
 main:1: error: Cannot find module named 'foo.bar'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testNamespacePackage]
 # flags: --namespace-packages

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -156,7 +156,7 @@ import asyncio
 import Bastion
 [out]
 main:1: error: Cannot find module named 'asyncio'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: No library stub file for standard library module 'Bastion'
 main:2: note: (Stub files are from https://github.com/python/typeshed)
 

--- a/test-data/unit/check-semanal-error.test
+++ b/test-data/unit/check-semanal-error.test
@@ -19,7 +19,7 @@ m.x = m.y
 1() # E
 [out]
 main:1: error: Cannot find module named 'm'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:4: error: "int" not callable
 
 [case testMissingModuleImport2]
@@ -29,7 +29,7 @@ x.a = x.b
 1() # E
 [out]
 main:1: error: Cannot find module named 'm'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:4: error: "int" not callable
 
 [case testMissingModuleImport3]
@@ -38,7 +38,7 @@ x # E
 1() # E
 [out]
 main:1: error: Cannot find module named 'm'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Name 'x' is not defined
 main:3: error: "int" not callable
 

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -78,7 +78,7 @@ else:
 [builtins fixtures/bool.pyi]
 [out]
 main:6: error: Cannot find module named 'pow123'
-main:6: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:6: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testMypyConditional]
 import typing
@@ -97,7 +97,7 @@ else:
     import xyz753
 [out]
 main:3: error: Cannot find module named 'pow123'
-main:3: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testTypeCheckingConditionalFromImport]
 from typing import TYPE_CHECKING
@@ -107,7 +107,7 @@ else:
     import xyz753
 [out]
 main:3: error: Cannot find module named 'pow123'
-main:3: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testNegatedTypeCheckingConditional]
 import typing
@@ -118,7 +118,7 @@ else:
 [builtins fixtures/bool.pyi]
 [out]
 main:5: error: Cannot find module named 'xyz753'
-main:5: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:5: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testUndefinedTypeCheckingConditional]
 if not TYPE_CHECKING: # E
@@ -129,7 +129,7 @@ else:
 [out]
 main:1: error: Name 'TYPE_CHECKING' is not defined
 main:4: error: Cannot find module named 'xyz753'
-main:4: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:4: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testConditionalClassDefPY3]
 def f(): pass
@@ -443,7 +443,7 @@ class A:
             # TODO: This is inconsistent with how top-level functions work
             #     (https://github.com/python/mypy/issues/4324)
             import b as a # E: Cannot find module named 'b' \
-            # N: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+            # N: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
         else:
             import a
         a.x

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -295,7 +295,7 @@ baz(bar(foo(42)))
 baz(bar(foo('oof')))
 [out]
 file.py:1: error: Cannot find module named 'no_stubs'
-file.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+file.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 file.py:6: error: Argument 1 to "foo" has incompatible type "str"; expected "int"
 
 [case testIgnoreErrorsConfig]
@@ -440,7 +440,7 @@ reveal_type(missing.x)  # Expect Any
 ignore_missing_imports = False
 [out]
 main.py:1: error: Cannot find module named 'missing'
-main.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main.py:2: error: Revealed type is 'Any'
 
 [case testConfigSilentMissingImportsOn]
@@ -487,7 +487,7 @@ import a.b
 whatever
 [out]
 main.py:1: error: Cannot find module named 'a.b'
-main.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main.py:1: error: Cannot find module named 'a'
 
 [case testPythonVersionTooOld10]

--- a/test-data/unit/fine-grained-blockers.test
+++ b/test-data/unit/fine-grained-blockers.test
@@ -112,7 +112,7 @@ x x
 def f() -> None: pass
 [out]
 main:1: error: Cannot find module named 'a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 a.py:1: error: invalid syntax
 ==
@@ -255,7 +255,7 @@ x x
 a.py:1: error: invalid syntax
 ==
 main:1: error: Cannot find module named 'a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 b.py:1: error: Cannot find module named 'a'
 
 [case testDeleteFileWithBlockingError-only_when_cache]
@@ -276,7 +276,7 @@ x x
 a.py:1: error: invalid syntax
 ==
 b.py:1: error: Cannot find module named 'a'
-b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:1: error: Cannot find module named 'a'
 
 [case testModifyFileWhileBlockingErrorElsewhere]
@@ -349,7 +349,7 @@ class A: pass
 [out]
 ==
 main:1: error: Cannot find module named 'a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 main:4: error: "A" has no attribute "f"
 
@@ -367,7 +367,7 @@ class A:
 [out]
 ==
 main:1: error: Cannot find module named 'a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 main:1: error: Module 'a' has no attribute 'A'
 

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -53,7 +53,7 @@ def f() -> None: pass
 [out]
 ==
 b.py:1: error: Cannot find module named 'a'
-b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 
 [case testAddFileFixesAndGeneratesError1]
@@ -69,10 +69,10 @@ def f() -> None: pass
 [out]
 ==
 b.py:1: error: Cannot find module named 'a'
-b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 b.py:1: error: Cannot find module named 'a'
-b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 b.py:2: error: Too many arguments for "f"
 
@@ -89,10 +89,10 @@ def f() -> None: pass
 [out]
 ==
 b.py:1: error: Cannot find module named 'a'
-b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 b.py:1: error: Cannot find module named 'a'
-b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 b.py:2: error: Too many arguments for "f"
 
@@ -119,10 +119,10 @@ f(1)
 [out]
 ==
 b.py:1: error: Cannot find module named 'a'
-b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 b.py:1: error: Cannot find module named 'a'
-b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testAddFilePreservesError2]
 import b
@@ -162,7 +162,7 @@ import a
 [out]
 ==
 b.py:2: error: Cannot find module named 'a'
-b.py:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+b.py:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testImportLineNumber2]
 import b
@@ -175,11 +175,11 @@ from c import f
 [out]
 ==
 b.py:2: error: Cannot find module named 'a'
-b.py:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+b.py:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 b.py:3: error: Cannot find module named 'c'
 ==
 b.py:2: error: Cannot find module named 'a'
-b.py:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+b.py:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 b.py:3: error: Cannot find module named 'c'
 
 [case testAddPackage1]
@@ -190,7 +190,7 @@ p.a.f(1)
 def f(x: str) -> None: pass
 [out]
 main:1: error: Cannot find module named 'p.a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:1: error: Cannot find module named 'p'
 ==
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
@@ -204,7 +204,7 @@ from p.a import f
 def f(x: str) -> None: pass
 [out]
 main:1: error: Cannot find module named 'p'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 
@@ -216,11 +216,11 @@ p.a.f(1)
 def f(x: str) -> None: pass
 [out]
 main:1: error: Cannot find module named 'p.a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:1: error: Cannot find module named 'p'
 ==
 main:1: error: Cannot find module named 'p.a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 [builtins fixtures/module.pyi]
@@ -233,11 +233,11 @@ def f(x: str) -> None: pass
 [file p/__init__.py.3]
 [out]
 main:1: error: Cannot find module named 'p.a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:1: error: Cannot find module named 'p'
 ==
 main:1: error: Cannot find module named 'p.a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:1: error: Cannot find module named 'p'
 ==
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
@@ -267,11 +267,11 @@ def f(x: str) -> None: pass
 [file p/__init__.py.3]
 [out]
 main:4: error: Cannot find module named 'p.a'
-main:4: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:4: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:4: error: Cannot find module named 'p'
 ==
 main:4: error: Cannot find module named 'p.a'
-main:4: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:4: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:4: error: Cannot find module named 'p'
 ==
 main:5: error: Argument 1 to "f" has incompatible type "int"; expected "str"
@@ -302,7 +302,7 @@ def f(x: str) -> None: pass
 [file p/__init__.py.2]
 [out]
 x.py:1: error: Cannot find module named 'p.a'
-x.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+x.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 x.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 
@@ -375,7 +375,7 @@ def f(x: int) -> None: pass
 [out]
 ==
 a.py:1: error: Cannot find module named 'b'
-a.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 a.py:4: error: Too few arguments for "f"
 
@@ -389,7 +389,7 @@ def f() -> None: pass
 [out]
 ==
 main:1: error: Cannot find module named 'a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 
 [case testDeletionOfSubmoduleTriggersImportFrom1-only_when_nocache]
@@ -405,7 +405,7 @@ from p import q
 main:1: error: Module 'p' has no attribute 'q'
 -- TODO: The following messages are different compared to non-incremental mode
 main:1: error: Cannot find module named 'p.q'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 
 -- TODO: Fix this bug. It is a real bug that was been papered over
@@ -421,7 +421,7 @@ from p import q
 [out]
 ==
 main:1: error: Cannot find module named 'p.q'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 
 [case testDeletionOfSubmoduleTriggersImportFrom2]
@@ -436,7 +436,7 @@ def f(x: int) -> None: pass
 [out]
 ==
 main:1: error: Cannot find module named 'p.q'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 main:2: error: Too few arguments for "f"
 
@@ -451,7 +451,7 @@ def f(x: int) -> None: pass
 [out]
 ==
 main:1: error: Cannot find module named 'p.q'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 
 [case testDeleteSubpackageWithNontrivialParent1]
@@ -482,7 +482,7 @@ def f() -> str:
 a.py:2: error: Incompatible return value type (got "int", expected "str")
 ==
 main:1: error: Cannot find module named 'a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testDeleteModuleWithErrorInsidePackage]
 import a.b
@@ -497,7 +497,7 @@ def f() -> str:
 a/b.py:2: error: Incompatible return value type (got "str", expected "int")
 ==
 main:1: error: Cannot find module named 'a.b'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testModifyTwoFilesNoError1]
 import a
@@ -636,7 +636,7 @@ def g() -> None: pass
 b.f()
 [out]
 a.py:1: error: Cannot find module named 'b'
-a.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 a.py:2: error: Cannot find module named 'c'
 ==
 
@@ -657,7 +657,7 @@ def g() -> None: pass
 b.f(1)
 [out]
 a.py:1: error: Cannot find module named 'b'
-a.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 a.py:2: error: Cannot find module named 'c'
 ==
 c.py:3: error: Too many arguments for "f"
@@ -674,7 +674,7 @@ def f() -> None: pass
 def g() -> None: pass
 [out]
 main:1: error: Cannot find module named 'a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Cannot find module named 'b'
 ==
 main:3: error: Too many arguments for "f"
@@ -694,7 +694,7 @@ def g() -> None: pass
 [out]
 ==
 main:1: error: Cannot find module named 'a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Cannot find module named 'b'
 
 [case testDeleteTwoFilesNoErrors]
@@ -735,7 +735,7 @@ b.py:3: error: Too many arguments for "f"
 a.py:3: error: Too many arguments for "g"
 ==
 main:1: error: Cannot find module named 'a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Cannot find module named 'b'
 
 [case testAddFileWhichImportsLibModule]
@@ -746,7 +746,7 @@ import sys
 x = sys.platform
 [out]
 main:1: error: Cannot find module named 'a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 main:2: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
@@ -760,7 +760,7 @@ x = broken.x
 z
 [out]
 main:2: error: Cannot find module named 'a'
-main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 a.py:3: error: Name 'z' is not defined
 <ROOT>/test-data/unit/lib-stub/broken.pyi:2: error: Name 'y' is not defined
@@ -825,7 +825,7 @@ def g() -> None: pass
 a.py:2: error: Too many arguments for "g"
 ==
 a.py:1: error: Cannot find module named 'm.x'
-a.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testDeletePackage1]
 import p.a
@@ -840,7 +840,7 @@ def f(x: str) -> None: pass
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
 main:1: error: Cannot find module named 'p.a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:1: error: Cannot find module named 'p'
 
 [case testDeletePackage2]
@@ -856,7 +856,7 @@ def f(x: str) -> None: pass
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
 main:1: error: Cannot find module named 'p'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testDeletePackage3]
 import p.a
@@ -871,10 +871,10 @@ def f(x: str) -> None: pass
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
 main:1: error: Cannot find module named 'p.a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 main:1: error: Cannot find module named 'p.a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:1: error: Cannot find module named 'p'
 
 [case testDeletePackage4]
@@ -889,11 +889,11 @@ def f(x: str) -> None: pass
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
 main:1: error: Cannot find module named 'p.a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:1: error: Cannot find module named 'p'
 ==
 main:1: error: Cannot find module named 'p.a'
-main:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:1: error: Cannot find module named 'p'
 
 [case testDeletePackage5]
@@ -912,11 +912,11 @@ def f(x: str) -> None: pass
 main:6: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
 main:5: error: Cannot find module named 'p.a'
-main:5: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:5: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:5: error: Cannot find module named 'p'
 ==
 main:5: error: Cannot find module named 'p.a'
-main:5: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:5: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:5: error: Cannot find module named 'p'
 
 
@@ -938,7 +938,7 @@ f(12)
 p/b.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
 p/b.py:1: error: Cannot find module named 'p.a'
-p/b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+p/b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 p/b.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 
@@ -1411,7 +1411,7 @@ def f() -> None: pass
 [out]
 ==
 a.py:1: error: Cannot find module named 'b'
-a.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 
 [case testRefreshImportIfMypyElse1]
@@ -1806,7 +1806,7 @@ x = 2
 ==
 ==
 a.py:2: error: Cannot find module named 'b'
-a.py:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+a.py:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testErrorButDontIgnore1]
 # cmd: mypy a.py c.py
@@ -1881,7 +1881,7 @@ x = 1
 p/b.py: note: Ancestor package 'p' ignored
 p/b.py: note: (Using --follow-imports=error, submodule passed on command line)
 p/b.py:1: error: Cannot find module named 'z'
-p/b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+p/b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testTurnPackageToModule]
 [file a.py]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -451,7 +451,7 @@ x = 3
 ==
 ==
 a.py:1: error: Cannot find module named 'b'
-a.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testIgnoreWorksWithMissingImports]
 import a
@@ -485,7 +485,7 @@ from xyz import x  # type: ignore
 x = str()
 [out]
 b.py:1: error: Cannot find module named 'xyz'
-b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 ==
 a.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
@@ -504,7 +504,7 @@ x = str()
 [out]
 ==
 b.py:1: error: Cannot find module named 'xyz'
-b.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 a.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
@@ -1753,7 +1753,7 @@ def f() -> Iterator[None]:
 main:2: error: Revealed type is 'contextlib.GeneratorContextManager[None]'
 ==
 a.py:3: error: Cannot find module named 'b'
-a.py:3: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+a.py:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Revealed type is 'contextlib.GeneratorContextManager[None]'
 ==
 main:2: error: Revealed type is 'contextlib.GeneratorContextManager[None]'
@@ -1800,7 +1800,7 @@ def g() -> None:
 a.py:11: error: Too many arguments for "h"
 ==
 a.py:10: error: Cannot find module named 'b'
-a.py:10: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+a.py:10: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 a.py:11: error: Too many arguments for "h"
 ==
@@ -1834,7 +1834,7 @@ def f(x: List[int]) -> Iterator[None]:
 [out]
 ==
 a.py:3: error: Cannot find module named 'b'
-a.py:3: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+a.py:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 ==
 
@@ -2453,7 +2453,7 @@ def g() -> None: pass
 [out]
 ==
 main:2: error: Cannot find module named 'm'
-main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:7: error: Overloaded function signature 2 will never be matched: signature 1's parameter type(s) are the same or broader
 main:9: error: Cannot find module named 'n'
 
@@ -2482,7 +2482,7 @@ def g() -> None: pass
 [out]
 ==
 main:2: error: Cannot find module named 'm'
-main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:12: error: Overloaded function signature 2 will never be matched: signature 1's parameter type(s) are the same or broader
 main:14: error: Cannot find module named 'n'
 

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1211,7 +1211,7 @@ bar: Type[C]
 bar * 4 + bar + 3  # should not produce more errors
 [out]
 _testMetaclassOpAccessAny.py:2: error: Cannot find module named 'nonexistent'
-_testMetaclassOpAccessAny.py:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+_testMetaclassOpAccessAny.py:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testEnumIterationAndPreciseElementType]
 # Regression test for #2305

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -198,21 +198,21 @@ import typing
 import m
 [out]
 main:2: error: Cannot find module named 'm'
-main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testMissingModule2]
 import typing
 from m import x
 [out]
 main:2: error: Cannot find module named 'm'
-main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testMissingModule3]
 import typing
 from m import *
 [out]
 main:2: error: Cannot find module named 'm'
-main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testMissingModuleRelativeImport]
 import typing
@@ -221,7 +221,7 @@ import m
 from .x import y
 [out]
 tmp/m/__init__.py:1: error: Cannot find module named 'm.x'
-tmp/m/__init__.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+tmp/m/__init__.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testMissingModuleRelativeImport2]
 import typing
@@ -231,7 +231,7 @@ import m.a
 from .x import y
 [out]
 tmp/m/a.py:1: error: Cannot find module named 'm.x'
-tmp/m/a.py:1: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+tmp/m/a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testModuleNotImported]
 import typing
@@ -280,7 +280,7 @@ import typing
 import m.n
 [out]
 main:2: error: Cannot find module named 'm.n'
-main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Cannot find module named 'm'
 
 [case testMissingPackage2]
@@ -289,7 +289,7 @@ from m.n import x
 from a.b import *
 [out]
 main:2: error: Cannot find module named 'm.n'
-main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:3: error: Cannot find module named 'a.b'
 
 [case testErrorInImportedModule]
@@ -319,7 +319,7 @@ m.n.x
 x = 1
 [out]
 main:2: error: Cannot find module named 'm.n'
-main:2: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Cannot find module named 'm'
 
 [case testBreakOutsideLoop]


### PR DESCRIPTION
This pull request replaces the "Perhaps setting MYPYPATH..." note with a link to https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports

It also updates the docs to make that page a little more actionable: it now clearly distinguishes between different scenarios a user might find themselves in and gives concrete steps to try for each case.

It also modifies the docs to suggest that users try searching for or writing their stubs first and try silencing errors second.

Resolves https://github.com/python/mypy/issues/5241.