### PR TITLE
[WIP] Cast power function results to float

### DIFF
--- a/test-data/stdlib-samples/3.2/random.py
+++ b/test-data/stdlib-samples/3.2/random.py
@@ -362,7 +362,7 @@ class Random(_random.Random):
             u = 1.0 - u
             c = 1.0 - c
             low, high = high, low
-        return low + (high - low) * cast(float, (u * c) ** 0.5
+        return low + (high - low) * cast(float, (u * c) ** 0.5)
 
 ## -------------------- normal distribution --------------------
 

--- a/test-data/stdlib-samples/3.2/random.py
+++ b/test-data/stdlib-samples/3.2/random.py
@@ -362,7 +362,7 @@ class Random(_random.Random):
             u = 1.0 - u
             c = 1.0 - c
             low, high = high, low
-        return low + (high - low) * (u * c) ** 0.5
+        return low + (high - low) * cast(float, (u * c) ** 0.5
 
 ## -------------------- normal distribution --------------------
 
@@ -531,12 +531,12 @@ class Random(_random.Random):
                 b = (_e + alpha)/_e
                 p = b*u
                 if p <= 1.0:
-                    x = p ** (1.0/alpha)
+                    x = cast(float, p ** (1.0/alpha))
                 else:
                     x = -_log((b-p)/alpha)
                 u1 = random()
                 if p > 1.0:
-                    if u1 <= x ** (alpha - 1.0):
+                    if u1 <= cast(float, x ** (alpha - 1.0)):
                         break
                 elif u1 <= _exp(-x):
                     break
@@ -620,7 +620,7 @@ class Random(_random.Random):
         # Jain, pg. 495
 
         u = 1.0 - self.random()
-        return 1.0 / u ** (1.0/alpha)
+        return 1.0 / cast(float, u ** (1.0/alpha))
 
 ## -------------------- Weibull --------------------
 
@@ -633,7 +633,7 @@ class Random(_random.Random):
         # Jain, pg. 499; bug fix courtesy Bill Arms
 
         u = 1.0 - self.random()
-        return alpha * (-_log(u)) ** (1.0/beta)
+        return alpha * cast(float, (-_log(u)) ** (1.0/beta))
 
 ## --------------- Operating System Random Source  ------------------
 

--- a/test-data/stdlib-samples/3.2/test/test_random.py
+++ b/test-data/stdlib-samples/3.2/test/test_random.py
@@ -418,13 +418,13 @@ class MersenneTwister_TestBasicOps(TestBasicOps[random.Random]):
         self.assertTrue(stop < x <= start)
         self.assertEqual((x+stop)%step, 0)
 
-def gamma(z: float, sqrt2pi: float = (2.0*pi)**0.5) -> float:
+def gamma(z: float, sqrt2pi: float = cast(float, (2.0*pi)**0.5)) -> float:
     # Reflection to right half of complex plane
     if z < 0.5:
         return pi / sin(pi*z) / gamma(1.0-z)
     # Lanczos approximation with g=7
     az = z + (7.0 - 0.5)
-    return az ** (z-0.5) / exp(az) * sqrt2pi * fsum([
+    return cast(float, az ** (z-0.5)) / exp(az) * sqrt2pi * fsum([
         0.9999999999995183,
         676.5203681218835 / z,
         -1259.139216722289 / (z+1.0),


### PR DESCRIPTION
This is necessary due to python/typeshed#2662, where `float.__pow__()` now returns `complex` in the general case.

Please don't merge yet, discussion in python/typeshed#1406.