### PR TITLE
Add support for literal fallbacks

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -31,7 +31,7 @@ from mypy.types import (
     Type, AnyType, CallableType, FunctionLike, Overloaded, TupleType, TypedDictType,
     Instance, NoneTyp, strip_type, TypeType, TypeOfAny,
     UnionType, TypeVarId, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarDef,
-    true_only, false_only, function_type, is_named_instance, union_items, TypeQuery,
+    true_only, false_only, function_type, is_named_instance, union_items, TypeQuery, LiteralType,
     is_optional, remove_optional
 )
 from mypy.sametypes import is_same_type, is_same_types
@@ -1065,7 +1065,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         forward_inst = reverse_type.arg_types[1]
         if isinstance(forward_inst, TypeVarType):
             forward_inst = forward_inst.upper_bound
-        if isinstance(forward_inst, (FunctionLike, TupleType, TypedDictType)):
+        if isinstance(forward_inst, (FunctionLike, TupleType, TypedDictType, LiteralType)):
             forward_inst = forward_inst.fallback
         if isinstance(forward_inst, TypeType):
             item = forward_inst.item

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -18,7 +18,7 @@ from mypy.typeanal import (
 from mypy.types import (
     Type, AnyType, CallableType, Overloaded, NoneTyp, TypeVarDef,
     TupleType, TypedDictType, Instance, TypeVarType, ErasedType, UnionType,
-    PartialType, DeletedType, UninhabitedType, TypeType, TypeOfAny,
+    PartialType, DeletedType, UninhabitedType, TypeType, TypeOfAny, LiteralType,
     true_only, false_only, is_named_instance, function_type, callable_type, FunctionLike,
     StarType, is_optional, remove_optional, is_invariant_instance
 )
@@ -323,7 +323,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         type_name = None
         if isinstance(object_type, Instance):
             type_name = object_type.type.fullname()
-        elif isinstance(object_type, TypedDictType):
+        elif isinstance(object_type, (TypedDictType, LiteralType)):
             info = object_type.fallback.type.get_containing_type_info(method_name)
             type_name = info.fullname() if info is not None else None
         elif isinstance(object_type, TupleType):
@@ -3121,7 +3121,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         # these two should be carefully kept in sync.
         if isinstance(typ, TypeVarType):
             typ = typ.upper_bound
-        if isinstance(typ, TupleType):
+        if isinstance(typ, (TupleType, LiteralType)):
             typ = typ.fallback
         if isinstance(typ, Instance):
             return typ.type.has_readable_member(member)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -4,7 +4,7 @@ from typing import cast, Callable, List, Optional, TypeVar
 
 from mypy.types import (
     Type, Instance, AnyType, TupleType, TypedDictType, CallableType, FunctionLike, TypeVarDef,
-    Overloaded, TypeVarType, UnionType, PartialType, UninhabitedType, TypeOfAny,
+    Overloaded, TypeVarType, UnionType, PartialType, UninhabitedType, TypeOfAny, LiteralType,
     DeletedType, NoneTyp, TypeType, function_type, get_type_vars,
 )
 from mypy.nodes import (
@@ -131,12 +131,7 @@ def analyze_member_access(name: str,
                    for subtype in typ.relevant_items()]
         msg.disable_type_names -= 1
         return UnionType.make_simplified_union(results)
-    elif isinstance(typ, TupleType):
-        # Actually look up from the fallback instance type.
-        return analyze_member_access(name, typ.fallback, node, is_lvalue, is_super,
-                                     is_operator, builtin_type, not_ready_callback, msg,
-                                     original_type=original_type, chk=chk)
-    elif isinstance(typ, TypedDictType):
+    elif isinstance(typ, (TupleType, TypedDictType, LiteralType)):
         # Actually look up from the fallback instance type.
         return analyze_member_access(name, typ.fallback, node, is_lvalue, is_super,
                                      is_operator, builtin_type, not_ready_callback, msg,

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -640,23 +640,76 @@ c: Literal[15]
 -- to rewrite them in the future.
 --
 
-[case testLiteralInheritedMethodsInteractCorrectly-skip]
-# TODO: fix this test. The method calls are not using the fallbacks.
-from typing_extensions import Literal
-
-a: Literal[3]
-b: int
-c: Literal['foo']
-
-reveal_type(a + a)  # E: Revealed type is 'builtins.int'
-reveal_type(a + b)  # E: Revealed type is 'builtins.int'
-reveal_type(b + a)  # E: Revealed type is 'builtins.int'
-reveal_type(c.strip())  # E: Revealed type is 'builtins.str'
-[out]
-
 [case testLiteralActualAssignment-skip]
 # TODO: fix this test. The 1 is currently always given a type of 'int'
 from typing_extensions import Literal
 
 a: Literal[1] = 1
+[out]
+
+--
+-- Tests that make sure we're correctly using the fallback
+--
+
+[case testLiteralFallbackOperatorsWorkCorrectly]
+from typing_extensions import Literal
+
+a: Literal[3]
+b: int
+c: Literal[4]
+d: Literal['foo']
+e: str
+
+reveal_type(a + a)      # E: Revealed type is 'builtins.int'
+reveal_type(a + b)      # E: Revealed type is 'builtins.int'
+reveal_type(b + a)      # E: Revealed type is 'builtins.int'
+reveal_type(a + 1)      # E: Revealed type is 'builtins.int'
+reveal_type(1 + a)      # E: Revealed type is 'builtins.int'
+reveal_type(a + c)      # E: Revealed type is 'builtins.int'
+reveal_type(c + a)      # E: Revealed type is 'builtins.int'
+
+reveal_type(d + d)      # E: Revealed type is 'builtins.str'
+reveal_type(d + e)      # E: Revealed type is 'builtins.str'
+reveal_type(e + d)      # E: Revealed type is 'builtins.str'
+reveal_type(d + 'foo')  # E: Revealed type is 'builtins.str'
+reveal_type('foo' + d)  # E: Revealed type is 'builtins.str'
+
+reveal_type(a.__add__(b))  # E: Revealed type is 'builtins.int'
+reveal_type(b.__add__(a))  # E: Revealed type is 'builtins.int'
+
+a *= b                  # E: Incompatible types in assignment (expression has type "int", variable has type "Literal[3]")
+b *= a
+
+reveal_type(b)          # E: Revealed type is 'builtins.int'
+[out]
+
+[case testLiteralFallbackInheritedMethodsWorkCorrectly]
+from typing_extensions import Literal
+a: Literal['foo']
+b: str
+
+reveal_type(a.startswith(a))    # E: Revealed type is 'builtins.bool'
+reveal_type(b.startswith(a))    # E: Revealed type is 'builtins.bool'
+reveal_type(a.startswith(b))    # E: Revealed type is 'builtins.bool'
+reveal_type(a.strip())          # E: Revealed type is 'builtins.str'
+[builtins fixtures/ops.pyi]
+[out]
+
+[case testLiteralFallbackMethodsDoNotCoerceToLiteral]
+from typing_extensions import Literal
+
+a: Literal[3]
+b: int
+c: Literal["foo"]
+
+a = a * a  # E: Incompatible types in assignment (expression has type "int", variable has type "Literal[3]")
+a = a * b  # E: Incompatible types in assignment (expression has type "int", variable has type "Literal[3]")
+a = b * a  # E: Incompatible types in assignment (expression has type "int", variable has type "Literal[3]")
+
+b = a * a
+b = a * b
+b = b * a
+
+c = c.strip()  # E: Incompatible types in assignment (expression has type "str", variable has type "Literal['foo']")
+[builtins fixtures/ops.pyi]
 [out]

--- a/test-data/unit/fixtures/ops.pyi
+++ b/test-data/unit/fixtures/ops.pyi
@@ -31,6 +31,7 @@ class str:
     def __add__(self, x: 'str') -> 'str': pass
     def __eq__(self, x: object) -> bool: pass
     def startswith(self, x: 'str') -> bool: pass
+    def strip(self) -> 'str': pass
 
 class unicode: pass
 


### PR DESCRIPTION
This pull request modifies the 'checkmember' related code to use the LiteralType fallback as appropriate. This lets us use the underlying int, bool, str, etc methods for Literals -- basically, adds support for things like this:

    foo: Literal["foobar"]
    bar = foo.strip()
    reveal_type(bar)  # E: Revealed type of 'builtins.str'

Note: I'm not 100% sure whether or not I've modified all the correct places. I used PyCharm to detect all case where we used TypedDictType's "fallback" field and attempted to add similar code for LiteralType, but I don't think this technique was necessarily foolproof.