### PR TITLE
[daemon] add --status-file arg to dmypy

### DIFF
--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -19,7 +19,7 @@ import traceback
 
 from typing import Any, Callable, Dict, Mapping, Optional, Tuple, List
 
-from mypy.dmypy_util import STATUS_FILE, receive
+from mypy.dmypy_util import DEFAULT_STATUS_FILE, receive
 from mypy.ipc import IPCClient, IPCException
 from mypy.dmypy_os import alive, kill
 
@@ -37,6 +37,7 @@ class AugmentedHelpFormatter(argparse.RawDescriptionHelpFormatter):
 parser = argparse.ArgumentParser(description="Client for mypy daemon mode",
                                  fromfile_prefix_chars='@')
 parser.set_defaults(action=None)
+parser.add_argument('--status-file', default=DEFAULT_STATUS_FILE, help='status file to retrieve daemon details')
 subparsers = parser.add_subparsers()
 
 start_parser = p = subparsers.add_parser('start', help="Start daemon")
@@ -163,7 +164,7 @@ def do_start(args: argparse.Namespace) -> None:
     since we don't want to duplicate mypy's huge list of flags.
     """
     try:
-        get_status()
+        get_status(args.status_file)
     except BadStatus:
         # Bad or missing status file or dead process; good to start.
         pass
@@ -197,12 +198,12 @@ def start_server(args: argparse.Namespace, allow_sources: bool = False) -> None:
     # Lazy import so this import doesn't slow down other commands.
     from mypy.dmypy_server import daemonize, process_start_options
     start_options = process_start_options(args.flags, allow_sources)
-    if daemonize(start_options, timeout=args.timeout, log_file=args.log_file):
+    if daemonize(start_options, args.status_file, timeout=args.timeout, log_file=args.log_file):
         sys.exit(2)
-    wait_for_server()
+    wait_for_server(args.status_file)
 
 
-def wait_for_server(timeout: float = 5.0) -> None:
+def wait_for_server(status_file: str, timeout: float = 5.0) -> None:
     """Wait until the server is up.
 
     Exit if it doesn't happen within the timeout.
@@ -210,7 +211,7 @@ def wait_for_server(timeout: float = 5.0) -> None:
     endtime = time.time() + timeout
     while time.time() < endtime:
         try:
-            data = read_status()
+            data = read_status(status_file)
         except BadStatus:
             # If the file isn't there yet, retry later.
             time.sleep(0.1)
@@ -236,16 +237,16 @@ def do_run(args: argparse.Namespace) -> None:
     since we don't want to duplicate mypy's huge list of flags.
     (The -- is only necessary if flags are specified.)
     """
-    if not is_running():
+    if not is_running(args.status_file):
         # Bad or missing status file or dead process; good to start.
         start_server(args, allow_sources=True)
     t0 = time.time()
-    response = request('run', version=__version__, args=args.flags)
+    response = request(args.status_file, 'run', version=__version__, args=args.flags)
     # If the daemon signals that a restart is necessary, do it
     if 'restart' in response:
         print('Restarting: {}'.format(response['restart']))
         restart_server(args, allow_sources=True)
-        response = request('run', version=__version__, args=args.flags)
+        response = request(args.status_file, 'run', version=__version__, args=args.flags)
 
     t1 = time.time()
     response['roundtrip_time'] = t1 - t0
@@ -258,13 +259,13 @@ def do_status(args: argparse.Namespace) -> None:
 
     This verifies that it is responsive to requests.
     """
-    status = read_status()
+    status = read_status(args.status_file)
     if args.verbose:
         show_stats(status)
     # Both check_status() and request() may raise BadStatus,
     # which will be handled by main().
     check_status(status)
-    response = request('status', timeout=5)
+    response = request(args.status_file, 'status', timeout=5)
     if args.verbose or 'error' in response:
         show_stats(response)
     if 'error' in response:
@@ -276,7 +277,7 @@ def do_status(args: argparse.Namespace) -> None:
 def do_stop(args: argparse.Namespace) -> None:
     """Stop daemon via a 'stop' request."""
     # May raise BadStatus, which will be handled by main().
-    response = request('stop', timeout=5)
+    response = request(args.status_file, 'stop', timeout=5)
     if response:
         show_stats(response)
         fail("Daemon is stuck; consider %s kill" % sys.argv[0])
@@ -287,7 +288,7 @@ def do_stop(args: argparse.Namespace) -> None:
 @action(kill_parser)
 def do_kill(args: argparse.Namespace) -> None:
     """Kill daemon process with SIGKILL."""
-    pid, _ = get_status()
+    pid, _ = get_status(args.status_file)
     try:
         kill(pid)
     except OSError as err:
@@ -300,7 +301,7 @@ def do_kill(args: argparse.Namespace) -> None:
 def do_check(args: argparse.Namespace) -> None:
     """Ask the daemon to check a list of files."""
     t0 = time.time()
-    response = request('check', files=args.files)
+    response = request(args.status_file, 'check', files=args.files)
     t1 = time.time()
     response['roundtrip_time'] = t1 - t0
     check_output(response, args.verbose, args.junit_xml)
@@ -323,9 +324,9 @@ def do_recheck(args: argparse.Namespace) -> None:
     """
     t0 = time.time()
     if args.remove is not None or args.update is not None:
-        response = request('recheck', remove=args.remove, update=args.update)
+        response = request(args.status_file, 'recheck', remove=args.remove, update=args.update)
     else:
-        response = request('recheck')
+        response = request(args.status_file, 'recheck')
     t1 = time.time()
     response['roundtrip_time'] = t1 - t0
     check_output(response, args.verbose, args.junit_xml)
@@ -369,7 +370,7 @@ def show_stats(response: Mapping[str, object]) -> None:
 @action(hang_parser)
 def do_hang(args: argparse.Namespace) -> None:
     """Hang for 100 seconds, as a debug hack."""
-    print(request('hang', timeout=1))
+    print(request(args.status_file, 'hang', timeout=1))
 
 
 @action(daemon_parser)
@@ -390,7 +391,7 @@ def do_daemon(args: argparse.Namespace) -> None:
     else:
         options = process_start_options(args.flags, allow_sources=False)
         timeout = args.timeout
-    Server(options, timeout=timeout).serve()
+    Server(options, args.status_file, timeout=timeout).serve()
 
 
 @action(help_parser)
@@ -402,7 +403,7 @@ def do_help(args: argparse.Namespace) -> None:
 # Client-side infrastructure.
 
 
-def request(command: str, *, timeout: Optional[int] = None,
+def request(status_file: str, command: str, *, timeout: Optional[int] = None,
             **kwds: object) -> Dict[str, Any]:
     """Send a request to the daemon.
 
@@ -419,7 +420,7 @@ def request(command: str, *, timeout: Optional[int] = None,
     args = dict(kwds)
     args.update(command=command)
     bdata = json.dumps(args).encode('utf8')
-    _, name = get_status()
+    _, name = get_status(status_file)
     try:
         with IPCClient(name, timeout) as client:
                 client.write(bdata)
@@ -431,14 +432,14 @@ def request(command: str, *, timeout: Optional[int] = None,
         return response
 
 
-def get_status() -> Tuple[int, str]:
+def get_status(status_file: str) -> Tuple[int, str]:
     """Read status file and check if the process is alive.
 
     Return (pid, connection_name) on success.
 
     Raise BadStatus if something's wrong.
     """
-    data = read_status()
+    data = read_status(status_file)
     return check_status(data)
 
 
@@ -464,15 +465,15 @@ def check_status(data: Dict[str, Any]) -> Tuple[int, str]:
     return pid, connection_name
 
 
-def read_status() -> Dict[str, object]:
+def read_status(status_file: str) -> Dict[str, object]:
     """Read status file.
 
     Raise BadStatus if the status file doesn't exist or contains
     invalid JSON or the JSON is not a dict.
     """
-    if not os.path.isfile(STATUS_FILE):
+    if not os.path.isfile(status_file):
         raise BadStatus("No status file found")
-    with open(STATUS_FILE) as f:
+    with open(status_file) as f:
         try:
             data = json.load(f)
         except Exception:
@@ -482,10 +483,10 @@ def read_status() -> Dict[str, object]:
     return data
 
 
-def is_running() -> bool:
+def is_running(status_file: str) -> bool:
     """Check if the server is running cleanly"""
     try:
-        get_status()
+        get_status(status_file)
     except BadStatus:
         return False
     return True

--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -37,7 +37,8 @@ class AugmentedHelpFormatter(argparse.RawDescriptionHelpFormatter):
 parser = argparse.ArgumentParser(description="Client for mypy daemon mode",
                                  fromfile_prefix_chars='@')
 parser.set_defaults(action=None)
-parser.add_argument('--status-file', default=DEFAULT_STATUS_FILE, help='status file to retrieve daemon details')
+parser.add_argument('--status-file', default=DEFAULT_STATUS_FILE,
+                    help='status file to retrieve daemon details')
 subparsers = parser.add_subparsers()
 
 start_parser = p = subparsers.add_parser('start', help="Start daemon")

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -25,7 +25,7 @@ import mypy.errors
 import mypy.main
 from mypy.find_sources import create_source_list, InvalidSourceList
 from mypy.server.update import FineGrainedBuildManager
-from mypy.dmypy_util import STATUS_FILE, receive
+from mypy.dmypy_util import receive
 from mypy.ipc import IPCServer, IPCException
 from mypy.fscache import FileSystemCache
 from mypy.fswatcher import FileSystemWatcher, FileData
@@ -45,6 +45,7 @@ if sys.platform == 'win32':
     from subprocess import STARTUPINFO
 
     def daemonize(options: Options,
+                  status_file: str,
                   timeout: Optional[int] = None,
                   log_file: Optional[str] = None) -> int:
         """Create the daemon process via "dmypy daemon" and pass options via command line
@@ -57,7 +58,7 @@ if sys.platform == 'win32':
 
         It also pickles the options to be unpickled by mypy.
         """
-        command = [sys.executable, '-m', 'mypy.dmypy', 'daemon']
+        command = [sys.executable, '-m', 'mypy.dmypy', '--status_file', status_file, 'daemon']
         pickeled_options = pickle.dumps((options.snapshot(), timeout, log_file))
         command.append('--options-data="{}"'.format(base64.b64encode(pickeled_options).decode()))
         info = STARTUPINFO(dwFlags=0x1,  # STARTF_USESHOWWINDOW aka use wShowWindow's value
@@ -118,6 +119,7 @@ else:
             os._exit(1)
 
     def daemonize(options: Options,
+                  status_file: str,
                   timeout: Optional[int] = None,
                   log_file: Optional[str] = None) -> int:
         """Run the mypy daemon in a grandchild of the current process
@@ -125,7 +127,7 @@ else:
         Return 0 for success, exit status for failure, negative if
         subprocess killed by signal.
         """
-        return _daemonize_cb(Server(options, timeout).serve, log_file)
+        return _daemonize_cb(Server(options, status_file, timeout).serve, log_file)
 
 # Server code.
 
@@ -165,6 +167,7 @@ class Server:
     # serve() is called in the grandchild (by daemonize()).
 
     def __init__(self, options: Options,
+                 status_file: str,
                  timeout: Optional[int] = None) -> None:
         """Initialize the server with the desired mypy flags."""
         self.options = options
@@ -173,8 +176,8 @@ class Server:
         self.timeout = timeout
         self.fine_grained_manager = None  # type: Optional[FineGrainedBuildManager]
 
-        if os.path.isfile(STATUS_FILE):
-            os.unlink(STATUS_FILE)
+        if os.path.isfile(status_file):
+            os.unlink(status_file)
 
         self.fscache = FileSystemCache()
 
@@ -190,13 +193,14 @@ class Server:
         # Fine-grained incremental doesn't support general partial types
         # (details in https://github.com/python/mypy/issues/4492)
         options.local_partial_types = True
+        self.status_file = status_file
 
     def serve(self) -> None:
         """Serve requests, synchronously (no thread or fork)."""
         command = None
         try:
             server = IPCServer(CONNECTION_NAME, self.timeout)
-            with open(STATUS_FILE, 'w') as f:
+            with open(self.status_file, 'w') as f:
                 json.dump({'pid': os.getpid(), 'connection_name': server.connection_name}, f)
                 f.write('\n')  # I like my JSON with a trailing newline
             while True:
@@ -233,7 +237,7 @@ class Server:
             # that could cause us to remove a future server's
             # status file.)
             if command != 'stop':
-                os.unlink(STATUS_FILE)
+                os.unlink(self.status_file)
             try:
                 server.cleanup()  # try to remove the socket dir on Linux
             except OSError:
@@ -265,7 +269,7 @@ class Server:
         # RPC. Otherwise a race condition exists where a subsequent
         # command can see a status file from a dying server and think
         # it is a live one.
-        os.unlink(STATUS_FILE)
+        os.unlink(self.status_file)
         return {}
 
     def cmd_run(self, version: str, args: Sequence[str]) -> Dict[str, object]:

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -58,7 +58,7 @@ if sys.platform == 'win32':
 
         It also pickles the options to be unpickled by mypy.
         """
-        command = [sys.executable, '-m', 'mypy.dmypy', '--status_file', status_file, 'daemon']
+        command = [sys.executable, '-m', 'mypy.dmypy', '--status-file', status_file, 'daemon']
         pickeled_options = pickle.dumps((options.snapshot(), timeout, log_file))
         command.append('--options-data="{}"'.format(base64.b64encode(pickeled_options).decode()))
         info = STARTUPINFO(dwFlags=0x1,  # STARTF_USESHOWWINDOW aka use wShowWindow's value

--- a/mypy/dmypy_util.py
+++ b/mypy/dmypy_util.py
@@ -13,7 +13,7 @@ MYPY = False
 if MYPY:
     from typing_extensions import Final
 
-STATUS_FILE = '.dmypy.json'  # type: Final
+DEFAULT_STATUS_FILE = '.dmypy.json'  # type: Final
 
 
 def receive(connection: IPCBase) -> Any:

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -29,6 +29,7 @@ from mypy.test.helpers import (
     assert_string_arrays_equal, parse_options, copy_and_fudge_mtime, assert_module_equivalence,
 )
 from mypy.server.mergecheck import check_consistency
+from mypy.dmypy_util import DEFAULT_STATUS_FILE
 from mypy.dmypy_server import Server
 from mypy.main import parse_config_file
 from mypy.find_sources import create_source_list
@@ -79,7 +80,7 @@ class FineGrainedSuite(DataSuite):
 
         options = self.get_options(main_src, testcase, build_cache=False)
         build_options = self.get_options(main_src, testcase, build_cache=True)
-        server = Server(options)
+        server = Server(options, DEFAULT_STATUS_FILE)
 
         num_regular_incremental_steps = self.get_build_steps(main_src)
         step = 1


### PR DESCRIPTION
Adds an argument to avoid hardcoding the path to the status file. The intent is to allow for multiple daemons running at the same time with different arguments. This is must for running both py2 and py3 mode during development of straddled code.