### PR TITLE
Rewrite IPC to use multiprocessing.connection

### DIFF
--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -424,6 +424,8 @@ def request(command: str, *, timeout: Optional[int] = None,
         with IPCClient(name, timeout) as client:
                 client.send_bytes(bdata)
                 response = receive(client)
+        if command == 'stop':
+            print(is_running(), file=sys.stderr)
     except (OSError, IPCException) as err:
         return {'error': str(err)}
     # TODO: Other errors, e.g. ValueError, UnicodeError

--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -422,7 +422,7 @@ def request(command: str, *, timeout: Optional[int] = None,
     _, name = get_status()
     try:
         with IPCClient(name, timeout) as client:
-                client.write(bdata)
+                client.send_bytes(bdata)
                 response = receive(client)
     except (OSError, IPCException) as err:
         return {'error': str(err)}

--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -424,8 +424,6 @@ def request(command: str, *, timeout: Optional[int] = None,
         with IPCClient(name, timeout) as client:
                 client.send_bytes(bdata)
                 response = receive(client)
-        if command == 'stop':
-            print(is_running(), file=sys.stderr)
     except (OSError, IPCException) as err:
         return {'error': str(err)}
     # TODO: Other errors, e.g. ValueError, UnicodeError

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -223,7 +223,6 @@ class Server:
                         connection.send_bytes(json.dumps(resp).encode('utf8'))
                     except OSError:
                         pass  # Maybe the client hung up
-                    connection.close()
                     if command == 'stop':
                         reset_global_state()
                         sys.exit(0)

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -79,7 +79,6 @@ class IPCClient:
             with socket.socket(getattr(socket, family)) as s:
                 if timeout is not None:
                     s.settimeout(timeout)
-                s.setblocking(True)
                 s.connect(address)
             self.connection = Connection(s.detach())
 
@@ -141,7 +140,6 @@ class IPCServer(Listener):
                 s, self._last_accepted = self._socket.accept()
             except socket.timeout:
                 raise IPCException('Timed out waiting for client to connect.')
-            s.setblocking(True)
             return Connection(s.detach())
 
     @property

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -134,13 +134,14 @@ class IPCServer(Listener):
                     _, err = ov.GetOverlappedResult(False)
                     if err != 0:
                         raise IPCException('Timed out waiting for client to connect.')
-            return Connection(handle)
+            self.connection = Connection(handle)
         else:
             try:
                 s, self._last_accepted = self._socket.accept()
             except socket.timeout:
                 raise IPCException('Timed out waiting for client to connect.')
-            return Connection(s.detach())
+            self.connection = Connection(s.detatch())
+        return self.connection
 
     @property
     def connection_name(self) -> str:
@@ -157,5 +158,5 @@ class IPCServer(Listener):
                  exc_val: Optional[BaseException] = None,
                  exc_tb: Optional[TracebackType] = None,
                  ) -> bool:
-        self.close()
+        self.connection.close()
         return False


### PR DESCRIPTION
This re-writes the IPC module to use the communication primitives in `multiprocessing.connection` so we don't duplicate as much work. It also means we can replace out JSON serialization to passing objects (which should probably go in a separate PR).

In short, this makes IPC much more robust.

There are a few missing definitions and other issues in typeshed for `multiprocessing.connection`, I am planning on making a PR for that momentarily.