### PR TITLE
Micro-optimize Instance.__init__

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -551,7 +551,6 @@ class Instance(Type):
     def __init__(self, typ: mypy.nodes.TypeInfo, args: List[Type],
                  line: int = -1, column: int = -1, erased: bool = False) -> None:
         super().__init__(line, column)
-        assert not typ or typ.fullname() not in ["builtins.Any", "typing.Any"]
         self.type = typ
         self.args = args
         self.erased = erased  # True if result of type variable substitution


### PR DESCRIPTION
Remove a somewhat expensive assert that doesn't seem very useful.

This probably doesn't result in measurable savings, though.