### PR TITLE
Document that TypedDicts are compatible with Mapping[str, object]

### DIFF
--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -820,15 +820,15 @@ arbitrarily complex types. For example, you can define nested
 TypedDicts and containers with TypedDict items.
 Unlike most other types, mypy uses structural compatibility checking
 (or structural subtyping) with TypedDicts. A TypedDict object with
-extra items is compatible with a narrower TypedDict, assuming item
-types are compatible (*totality* also affects
+extra items is a compatible with (a subtype of) a narrower
+TypedDict, assuming item types are compatible (*totality* also affects
 subtyping, as discussed below).
 
-A TypedDict object is not compatible with the regular ``Dict[...]``
-type, since ``Dict`` allows arbitrary keys to be added and removed,
-unlike TypedDict. However, any TypedDict object is compatible with
-the ``Mapping[str, object]`` type, since ``typing.Mapping`` only
-provides read-only access to the dictionary items:
+A TypedDict object is not a subtype of the regular ``Dict[...]``
+type (and vice versa), since ``Dict`` allows arbitrary keys to be
+added and removed, unlike TypedDict. However, any TypedDict object is
+a subtype of (that is, compatible with) ``Mapping[str, object]``, since
+``typing.Mapping`` only provides read-only access to the dictionary items:
 
 .. code-block:: python
 

--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -200,7 +200,7 @@ Our first attempt at writing this function might look like this:
 
     from typing import Union, Optional
 
-    def mouse_event(x1: int, 
+    def mouse_event(x1: int,
                     y1: int,
                     x2: Optional[int] = None,
                     y2: Optional[int] = None) -> Union[ClickEvent, DragEvent]:
@@ -245,7 +245,7 @@ to more accurately describe the function's behavior:
     # Mypy will also check and make sure the signature is
     # consistent with the provided variants.
 
-    def mouse_event(x1: int, 
+    def mouse_event(x1: int,
                     y1: int,
                     x2: Optional[int] = None,
                     y2: Optional[int] = None) -> Union[ClickEvent, DragEvent]:
@@ -374,7 +374,7 @@ First, if multiple variants match due to an argument being of type
     output2 = summarize(dynamic_var)
 
 Second, if multiple variants match due to one or more of the arguments
-being a union, mypy will make the inferred type be the union of the 
+being a union, mypy will make the inferred type be the union of the
 matching variant returns:
 
 .. code-block:: python
@@ -390,9 +390,9 @@ matching variant returns:
    overload variants can change how mypy type checks your program.
 
    To minimize potential issues, we recommend that you:
-   
+
    1. Make sure your overload variants are listed in the same order as
-      the runtime checks (e.g. ``isinstance`` checks) in your implementation.   
+      the runtime checks (e.g. ``isinstance`` checks) in your implementation.
    2. Order your variants and runtime checks from most to least specific.
       (See the following section for an example).
 
@@ -533,7 +533,7 @@ Type checking the implementation
 The body of an implementation is type-checked against the
 type hints provided on the implementation. For example, in the
 ``MyList`` example up above, the code in the body is checked with
-argument list ``index: Union[int, slice]`` and a return type of 
+argument list ``index: Union[int, slice]`` and a return type of
 ``Union[T, Sequence[T]]``. If there are no annotations on the
 implementation, then the body is not type checked. If you want to
 force mypy to check the body anyways, use the ``--check-untyped-defs``
@@ -823,6 +823,20 @@ Unlike most other types, mypy uses structural compatibility checking
 extra items is compatible with a narrower TypedDict, assuming item
 types are compatible (*totality* also affects
 subtyping, as discussed below).
+
+A TypedDict object is not compatible with the regular ``Dict[...]``
+type, since ``Dict`` allows arbitrary keys to be added and removed,
+unlike TypedDict. However, any TypedDict object is compatible with
+the ``Mapping[str, object]`` type, since ``typing.Mapping`` only
+provides read-only access to the dictionary items:
+
+.. code-block:: python
+
+   def print_typed_dict(obj: Mapping[str, object]) -> None:
+       for key, value in obj.items():
+           print('{}: {}'.format(key, value))
+
+   print_typed_dict(Movie(name='Toy Story', year=1995))  # OK
 
 .. note::
 


### PR DESCRIPTION
In particular, they are *not* compatible with any dictionary types.