### PR TITLE
Refactor mypy.checkmember

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -755,8 +755,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     callee)
         elif isinstance(callee, Instance):
             call_function = analyze_member_access('__call__', callee, context,
-                                                  False, False, False, self.named_type,
-                                                  self.msg, original_type=callee, chk=self.chk)
+                                                  False, False, False, self.msg,
+                                                  original_type=callee, chk=self.chk)
             return self.check_call(call_function, args, arg_kinds, context, arg_names,
                                    callable_node, arg_messages)
         elif isinstance(callee, TypeVarType):
@@ -1707,7 +1707,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             original_type = self.accept(e.expr)
             member_type = analyze_member_access(
                 e.name, original_type, e, is_lvalue, False, False,
-                self.named_type, self.msg, original_type=original_type, chk=self.chk)
+                self.msg, original_type=original_type, chk=self.chk)
             return member_type
 
     def analyze_external_member_access(self, member: str, base_type: Type,
@@ -1717,8 +1717,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """
         # TODO remove; no private definitions in mypy
         return analyze_member_access(member, base_type, context, False, False, False,
-                                     self.named_type, self.msg, original_type=base_type,
-                                     chk=self.chk)
+                                     self.msg, original_type=base_type, chk=self.chk)
 
     def visit_int_expr(self, e: IntExpr) -> Type:
         """Type check an integer literal (trivial)."""
@@ -1877,8 +1876,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """
         local_errors = local_errors or self.msg
         method_type = analyze_member_access(method, base_type, context, False, False, True,
-                                            self.named_type, local_errors,
-                                            original_type=base_type, chk=self.chk)
+                                            local_errors, original_type=base_type, chk=self.chk)
         return self.check_method_call(
             method, base_type, method_type, args, arg_kinds, context, local_errors)
 
@@ -1939,7 +1937,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 is_lvalue=False,
                 is_super=False,
                 is_operator=True,
-                builtin_type=self.named_type,
                 msg=local_errors,
                 original_type=base_type,
                 chk=self.chk,
@@ -2886,7 +2883,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     declared_self = args[0].variable.type or fill_typevars(e.info)
                     return analyze_member_access(name=e.name, typ=fill_typevars(e.info), node=e,
                                                  is_lvalue=False, is_super=True, is_operator=False,
-                                                 builtin_type=self.named_type,
                                                  msg=self.msg, override_info=base,
                                                  original_type=declared_self, chk=self.chk)
             assert False, 'unreachable'

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1933,12 +1933,12 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             member = analyze_member_access(
                 name=op_name,
                 typ=base_type,
-                node=context,
                 is_lvalue=False,
                 is_super=False,
                 is_operator=True,
-                msg=local_errors,
                 original_type=base_type,
+                context=context,
+                msg=local_errors,
                 chk=self.chk,
             )
             if local_errors.is_errors():
@@ -2881,10 +2881,16 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                             'enclosing function', e)
                         return AnyType(TypeOfAny.from_error)
                     declared_self = args[0].variable.type or fill_typevars(e.info)
-                    return analyze_member_access(name=e.name, typ=fill_typevars(e.info), node=e,
-                                                 is_lvalue=False, is_super=True, is_operator=False,
-                                                 msg=self.msg, override_info=base,
-                                                 original_type=declared_self, chk=self.chk)
+                    return analyze_member_access(name=e.name,
+                                                 typ=fill_typevars(e.info),
+                                                 is_lvalue=False,
+                                                 is_super=True,
+                                                 is_operator=False,
+                                                 original_type=declared_self,
+                                                 override_info=base,
+                                                 context=e,
+                                                 msg=self.msg,
+                                                 chk=self.chk)
             assert False, 'unreachable'
         else:
             # Invalid super. This has been reported by the semantic analyzer.

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -756,8 +756,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         elif isinstance(callee, Instance):
             call_function = analyze_member_access('__call__', callee, context,
                                                   False, False, False, self.named_type,
-                                                  self.not_ready_callback, self.msg,
-                                                  original_type=callee, chk=self.chk)
+                                                  self.msg, original_type=callee, chk=self.chk)
             return self.check_call(call_function, args, arg_kinds, context, arg_names,
                                    callable_node, arg_messages)
         elif isinstance(callee, TypeVarType):
@@ -1708,8 +1707,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             original_type = self.accept(e.expr)
             member_type = analyze_member_access(
                 e.name, original_type, e, is_lvalue, False, False,
-                self.named_type, self.not_ready_callback, self.msg,
-                original_type=original_type, chk=self.chk)
+                self.named_type, self.msg, original_type=original_type, chk=self.chk)
             return member_type
 
     def analyze_external_member_access(self, member: str, base_type: Type,
@@ -1719,8 +1717,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """
         # TODO remove; no private definitions in mypy
         return analyze_member_access(member, base_type, context, False, False, False,
-                                     self.named_type, self.not_ready_callback, self.msg,
-                                     original_type=base_type, chk=self.chk)
+                                     self.named_type, self.msg, original_type=base_type,
+                                     chk=self.chk)
 
     def visit_int_expr(self, e: IntExpr) -> Type:
         """Type check an integer literal (trivial)."""
@@ -1879,7 +1877,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """
         local_errors = local_errors or self.msg
         method_type = analyze_member_access(method, base_type, context, False, False, True,
-                                            self.named_type, self.not_ready_callback, local_errors,
+                                            self.named_type, local_errors,
                                             original_type=base_type, chk=self.chk)
         return self.check_method_call(
             method, base_type, method_type, args, arg_kinds, context, local_errors)
@@ -1942,7 +1940,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 is_super=False,
                 is_operator=True,
                 builtin_type=self.named_type,
-                not_ready_callback=self.not_ready_callback,
                 msg=local_errors,
                 original_type=base_type,
                 chk=self.chk,
@@ -2890,7 +2887,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     return analyze_member_access(name=e.name, typ=fill_typevars(e.info), node=e,
                                                  is_lvalue=False, is_super=True, is_operator=False,
                                                  builtin_type=self.named_type,
-                                                 not_ready_callback=self.not_ready_callback,
                                                  msg=self.msg, override_info=base,
                                                  original_type=declared_self, chk=self.chk)
             assert False, 'unreachable'

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -35,7 +35,6 @@ class MemberContext:
                  is_lvalue: bool,
                  is_super: bool,
                  is_operator: bool,
-                 builtin_type: Callable[[str], Instance],
                  msg: MessageBuilder, *,
                  original_type: Type,
                  chk: 'mypy.checker.TypeChecker') -> None:
@@ -43,18 +42,19 @@ class MemberContext:
         self.is_lvalue = is_lvalue
         self.is_super = is_super
         self.is_operator = is_operator
-        self.builtin_type = builtin_type
         self.msg = msg
         self.original_type = original_type
         self.chk = chk
+
+    def builtin_type(self, name: str) -> Instance:
+        return self.chk.named_type(name)
 
     def not_ready_callback(self, name: str, context: Context) -> None:
         self.chk.handle_cannot_determine_type(name, context)
 
     def copy_modified(self, messages: MessageBuilder) -> 'MemberContext':
         return MemberContext(self.context, self.is_lvalue, self.is_super, self.is_operator,
-                             self.builtin_type, messages, original_type=self.original_type,
-                             chk=self.chk)
+                             messages, original_type=self.original_type, chk=self.chk)
 
 
 def analyze_member_access(name: str,
@@ -63,7 +63,6 @@ def analyze_member_access(name: str,
                           is_lvalue: bool,
                           is_super: bool,
                           is_operator: bool,
-                          builtin_type: Callable[[str], Instance],
                           msg: MessageBuilder, *,
                           original_type: Type,
                           chk: 'mypy.checker.TypeChecker',
@@ -86,7 +85,6 @@ def analyze_member_access(name: str,
                        is_lvalue,
                        is_super,
                        is_operator,
-                       builtin_type,
                        msg,
                        original_type=original_type,
                        chk=chk)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -36,7 +36,6 @@ class MemberContext:
                  is_super: bool,
                  is_operator: bool,
                  builtin_type: Callable[[str], Instance],
-                 not_ready_callback: Callable[[str, Context], None],
                  msg: MessageBuilder, *,
                  original_type: Type,
                  chk: 'mypy.checker.TypeChecker') -> None:
@@ -45,15 +44,17 @@ class MemberContext:
         self.is_super = is_super
         self.is_operator = is_operator
         self.builtin_type = builtin_type
-        self.not_ready_callback = not_ready_callback
         self.msg = msg
         self.original_type = original_type
         self.chk = chk
 
+    def not_ready_callback(self, name: str, context: Context) -> None:
+        self.chk.handle_cannot_determine_type(name, context)
+
     def copy_modified(self, messages: MessageBuilder) -> 'MemberContext':
         return MemberContext(self.context, self.is_lvalue, self.is_super, self.is_operator,
-                             self.builtin_type, self.not_ready_callback, messages,
-                             original_type=self.original_type, chk=self.chk)
+                             self.builtin_type, messages, original_type=self.original_type,
+                             chk=self.chk)
 
 
 def analyze_member_access(name: str,
@@ -63,7 +64,6 @@ def analyze_member_access(name: str,
                           is_super: bool,
                           is_operator: bool,
                           builtin_type: Callable[[str], Instance],
-                          not_ready_callback: Callable[[str, Context], None],
                           msg: MessageBuilder, *,
                           original_type: Type,
                           chk: 'mypy.checker.TypeChecker',
@@ -87,7 +87,6 @@ def analyze_member_access(name: str,
                        is_super,
                        is_operator,
                        builtin_type,
-                       not_ready_callback,
                        msg,
                        original_type=original_type,
                        chk=chk)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -560,7 +560,7 @@ def analyze_class_attribute_access(itype: Instance,
     # can't be accessed on the class object.
     if node.implicit and isinstance(node.node, Var) and node.node.is_final:
         mx.msg.fail('Cannot access final instance '
-                     'attribute "{}" on class object'.format(node.node.name()), mx.context)
+                    'attribute "{}" on class object'.format(node.node.name()), mx.context)
 
     # An assignment to final attribute on class object is also always an error,
     # independently of types.
@@ -591,7 +591,7 @@ def analyze_class_attribute_access(itype: Instance,
 
     if isinstance(node.node, TypeVarExpr):
         mx.msg.fail('Type variable "{}.{}" cannot be used as an expression'.format(
-                     itype.type.name(), name), mx.context)
+                    itype.type.name(), name), mx.context)
         return AnyType(TypeOfAny.from_error)
 
     if isinstance(node.node, TypeInfo):

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -238,7 +238,7 @@ def _analyze_member_access(name: str, typ: Type, ctx: MemberContext,
                     return result
                 else:
                     # We don't want errors on metaclass lookup for classes with Any fallback
-                    msg = ignore_messages
+                    ctx = ctx.copy_modified(messages=ignore_messages)
         if item is not None:
             fallback = item.type.metaclass_type or fallback
         return _analyze_member_access(name, fallback, ctx)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -211,8 +211,8 @@ def _analyze_member_access(name: str, typ: Type, mx: MemberContext,
         if isinstance(typ.item, Instance):
             item = typ.item
         elif isinstance(typ.item, AnyType):
-            ctx = mx.copy_modified(messages=ignore_messages)
-            return _analyze_member_access(name, fallback, ctx)
+            mx = mx.copy_modified(messages=ignore_messages)
+            return _analyze_member_access(name, fallback, mx)
         elif isinstance(typ.item, TypeVarType):
             if isinstance(typ.item.upper_bound, Instance):
                 item = typ.item.upper_bound
@@ -226,16 +226,16 @@ def _analyze_member_access(name: str, typ: Type, mx: MemberContext,
                 item = typ.item.item.type.metaclass_type
         if item and not mx.is_operator:
             # See comment above for why operators are skipped
-            result = analyze_class_attribute_access(item, name, ctx)
+            result = analyze_class_attribute_access(item, name, mx)
             if result:
                 if not (isinstance(result, AnyType) and item.type.fallback_to_any):
                     return result
                 else:
                     # We don't want errors on metaclass lookup for classes with Any fallback
-                    ctx = mx.copy_modified(messages=ignore_messages)
+                    mx = mx.copy_modified(messages=ignore_messages)
         if item is not None:
             fallback = item.type.metaclass_type or fallback
-        return _analyze_member_access(name, fallback, ctx)
+        return _analyze_member_access(name, fallback, mx)
 
     if mx.chk.should_suppress_optional_error([typ]):
         return AnyType(TypeOfAny.from_error)


### PR DESCRIPTION
The most important change is passing around a single instance
that replaces a bunch of arguments that got repeatedly passed
around previously. Also remove some redundant arguments.

This change makes it much easier to split long functions (in a
follow-up PR).