### PR TITLE
Implement a sqlite-based store for the cache

### DIFF
--- a/misc/convert-cache.py
+++ b/misc/convert-cache.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Script for converting between cache formats."""
+"""Script for converting between cache formats.
+
+We support a filesystem tree based cache and a sqlite based cache.
+See mypy/metastore.py for details.
+"""
 
 import sys
 import os
@@ -10,7 +14,7 @@ from typing import Any
 from mypy.metastore import FilesystemMetadataStore, SqliteMetadataStore
 
 
-def parse_args() -> Any:
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument('--to-sqlite', action='store_true', default=False,
                         help='Convert to a sqlite cache (default: convert from)')
@@ -18,11 +22,8 @@ def parse_args() -> Any:
                         help="Output cache location (default: same as input)")
     parser.add_argument('input_dir',
                         help="Input directory for the cache")
-    return parser.parse_args()
+    args parser.parse_args()
 
-
-def main() -> None:
-    args = parse_args()
     input_dir = args.input_dir
     output_dir = args.output_dir or input_dir
     if args.to_sqlite:
@@ -31,8 +32,8 @@ def main() -> None:
         input, output = SqliteMetadataStore(input_dir), FilesystemMetadataStore(output_dir)
 
     for s in input.list_all():
-        # print("Copying", s)
-        assert output.write(s, input.read(s), input.getmtime(s))
+        if s.endswith('.json'):
+            assert output.write(s, input.read(s), input.getmtime(s)), "Failed to write cache file!"
     output.commit()
 
 

--- a/misc/convert-cache.py
+++ b/misc/convert-cache.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Script for converting between cache formats."""
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import argparse
+from typing import Any
+from mypy.metastore import FilesystemMetadataStore, SqliteMetadataStore
+
+
+def parse_args() -> Any:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--to-sqlite', action='store_true', default=False,
+                        help='Convert to a sqlite cache (default: convert from)')
+    parser.add_argument('--output_dir', action='store', default=None,
+                        help="Output cache location (default: same as input)")
+    parser.add_argument('input_dir',
+                        help="Input directory for the cache")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    input_dir = args.input_dir
+    output_dir = args.output_dir or input_dir
+    if args.to_sqlite:
+        input, output = FilesystemMetadataStore(input_dir), SqliteMetadataStore(output_dir)
+    else:
+        input, output = SqliteMetadataStore(input_dir), FilesystemMetadataStore(output_dir)
+
+    for s in input.list_all():
+        # print("Copying", s)
+        assert output.write(s, input.read(s), input.getmtime(s))
+    output.commit()
+
+
+if __name__ == '__main__':
+    main()

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -699,7 +699,7 @@ def write_protocol_deps_cache(proto_deps: Dict[str, Set[str]],
     per-file fine grained dependency caches.
     """
     metastore = manager.metastore
-    proto_meta, proto_cache = get_protocol_deps_cache_name(manager)
+    proto_meta, proto_cache = get_protocol_deps_cache_name()
     meta_snapshot = {}  # type: Dict[str, str]
     error = False
     for id, st in graph.items():
@@ -725,10 +725,12 @@ def write_protocol_deps_cache(proto_deps: Dict[str, Set[str]],
                               blocker=True)
 
 
+PLUGIN_SNAPSHOT_FILE = '@plugins_snapshot.json'  # type: Final
+
+
 def write_plugins_snapshot(manager: BuildManager) -> None:
     """Write snapshot of versions and hashes of currently active plugins."""
-    name = '@plugins_snapshot.json'
-    if not manager.metastore.write(name, json.dumps(manager.plugins_snapshot)):
+    if not manager.metastore.write(PLUGIN_SNAPSHOT_FILE, json.dumps(manager.plugins_snapshot)):
         manager.errors.set_file(_cache_dir_prefix(manager), None)
         manager.errors.report(0, 0, "Error writing plugins snapshot",
                               blocker=True)
@@ -736,8 +738,7 @@ def write_plugins_snapshot(manager: BuildManager) -> None:
 
 def read_plugins_snapshot(manager: BuildManager) -> Optional[Dict[str, str]]:
     """Read cached snapshot of versions and hashes of plugins from previous run."""
-    name = '@plugins_snapshot.json'
-    snapshot = _load_json_file(name, manager,
+    snapshot = _load_json_file(PLUGIN_SNAPSHOT_FILE, manager,
                                log_sucess='Plugins snapshot ',
                                log_error='Could not load plugins snapshot: ')
     if snapshot is None:
@@ -756,7 +757,7 @@ def read_protocol_cache(manager: BuildManager,
     See docstring for write_protocol_cache for details about which kinds of
     dependencies are read.
     """
-    proto_meta, proto_cache = get_protocol_deps_cache_name(manager)
+    proto_meta, proto_cache = get_protocol_deps_cache_name()
     meta_snapshot = _load_json_file(proto_meta, manager,
                                     log_sucess='Proto meta ',
                                     log_error='Could not load protocol metadata: ')
@@ -833,7 +834,7 @@ def get_cache_names(id: str, path: str, manager: BuildManager) -> Tuple[str, str
     return (prefix + '.meta.json', prefix + '.data.json', deps_json)
 
 
-def get_protocol_deps_cache_name(manager: BuildManager) -> Tuple[str, str]:
+def get_protocol_deps_cache_name() -> Tuple[str, str]:
     """Return file names for fine grained protocol dependencies cache.
 
     Since these dependencies represent a global state of the program, they

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -822,7 +822,13 @@ def get_cache_names(id: str, path: str, manager: BuildManager) -> Tuple[str, str
     """
     pair = manager.options.cache_map.get(path)
     if pair is not None:
-        return (pair[0], pair[1], None)
+        # The cache map paths were specified relative to the base directory,
+        # but the filesystem metastore APIs operates relative to the cache
+        # prefix directory.
+        # Solve this by rewriting the paths as relative to the root dir.
+        # This only makes sense when using the filesystem backed cache.
+        root = _cache_dir_prefix(manager)
+        return (os.path.relpath(pair[0], root), os.path.relpath(pair[1], root), None)
     prefix = os.path.join(*id.split('.'))
     is_package = os.path.basename(path).startswith('__init__.py')
     if is_package:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -570,6 +570,9 @@ def process_options(args: List[str],
         '--cache-dir', action='store', metavar='DIR',
         help="Store module cache info in the given folder in incremental mode "
              "(defaults to '{}')".format(defaults.CACHE_DIR))
+    add_invertible_flag('--sqlite-cache', default=False,
+                        help="Use a sqlite database to store the cache",
+                        group=incremental_group)
     incremental_group.add_argument(
         '--cache-fine-grained', action='store_true',
         help="Include fine-grained dependency information in the cache for the mypy daemon")

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -796,6 +796,9 @@ def process_options(args: List[str],
 
     # Process --cache-map.
     if special_opts.cache_map:
+        if options.sqlite_cache:
+            parser.error("--cache-map is incompatible with --sqlite-cache")
+
         process_cache_map(parser, special_opts, options)
 
     # Let quick_and_dirty imply incremental.

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -18,24 +18,46 @@ from typing import Dict, List, Set, Iterable, Any, Optional
 
 
 class MetadataStore:
-    @abstractmethod
-    def getmtime(self, name: str) -> float: ...
+    """Generic interface for metadata storage."""
 
     @abstractmethod
-    def read(self, name: str) -> str: ...
+    def getmtime(self, name: str) -> float:
+        """Read the mtime of a metadata entry..
+
+        Raises FileNotFound if the entry does not exist.
+        """
+        pass
 
     @abstractmethod
-    def write(self, name: str, data: str, mtime: Optional[float] = None) -> bool: ...
+    def read(self, name: str) -> str:
+        """Read the contents of a metadata entry.
+
+        Raises FileNotFound if the entry does not exist.
+        """
+        pass
 
     @abstractmethod
-    def remove(self, name: str) -> None: ...
+    def write(self, name: str, data: str, mtime: Optional[float] = None) -> bool:
+        """Write a metadata entry.
+
+        If mtime is specified, set it as the mtime of the entry. Otherwise,
+        the current time is used.
+
+        Returns True if the entry is succesfully written, False otherwise.
+        """
+
+    @abstractmethod
+    def remove(self, name: str) -> None:
+        """Delete a metadata entry"""
+        pass
 
     @abstractmethod
     def commit(self) -> None:
         """If the backing store requires a commit, do it.
 
-        But N.B. that this is not *guarenteed* to do anything, just to be necessary
-        with the sqlite backend.
+        But N.B. that this is not *guaranteed* to do anything, and
+        there is no guarantee that changes are not made until it is
+        called.
         """
         pass
 
@@ -74,8 +96,6 @@ class FilesystemMetadataStore(MetadataStore):
                 os.utime(path, times=(mtime, mtime))
 
         except os.error:
-            import traceback
-            traceback.print_exc()
             return False
         return True
 
@@ -89,8 +109,7 @@ class FilesystemMetadataStore(MetadataStore):
         for dir, _, files in os.walk(self.cache_dir_prefix):
             dir = os.path.relpath(dir, self.cache_dir_prefix)
             for file in files:
-                if file.endswith('.json'):
-                    yield os.path.join(dir, file)
+                yield os.path.join(dir, file)
 
 
 SCHEMA = '''
@@ -119,7 +138,10 @@ def connect_db(db_file: str) -> sqlite3.Connection:
 
 class SqliteMetadataStore(MetadataStore):
     def __init__(self, cache_dir_prefix: str) -> None:
-        if cache_dir_prefix.startswith('/dev/null'):
+        # We check startswith instead of equality because the version
+        # will have already been appended by the time the cache dir is
+        # passed here.
+        if cache_dir_prefix.startswith(os.devnull):
             self.db = None
             return
 
@@ -127,6 +149,7 @@ class SqliteMetadataStore(MetadataStore):
         self.db = connect_db(os.path.join(cache_dir_prefix, 'cache.db'))
 
     def _query(self, name: str, field: str) -> Any:
+        # Raises FileNotFound for consistency with the file system version
         if not self.db:
             raise FileNotFoundError()
 

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -69,7 +69,6 @@ class FilesystemMetadataStore(MetadataStore):
             os.makedirs(os.path.dirname(path), exist_ok=True)
             with open(tmp_filename, 'w') as f:
                 f.write(data)
-                f.write('\n')
             os.replace(tmp_filename, path)
             if mtime is not None:
                 os.utime(path, times=(mtime, mtime))

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -1,0 +1,172 @@
+"""Interfaces for accessing metadata.
+
+We provide two implementations.
+ * The "classic" file system implementation, which uses a directory
+   structure of files.
+ * A hokey sqlite backed implementation, which basically simulates
+   the file system in an effort to work around poor file system performance
+   on OS X.
+"""
+
+import binascii
+import sqlite3
+import os
+import time
+
+from abc import abstractmethod
+from typing import Dict, List, Set, Iterable, Any, Optional
+
+
+class MetadataStore:
+    @abstractmethod
+    def getmtime(self, name: str) -> float: ...
+
+    @abstractmethod
+    def read(self, name: str) -> str: ...
+
+    @abstractmethod
+    def write(self, name: str, data: str, mtime: Optional[float] = None) -> bool: ...
+
+    @abstractmethod
+    def remove(self, name: str) -> None: ...
+
+    @abstractmethod
+    def commit(self) -> None:
+        """If the backing store requires a commit, do it.
+
+        But N.B. that this is not *guarenteed* to do anything, just to be necessary
+        with the sqlite backend.
+        """
+        pass
+
+    @abstractmethod
+    def list_all(self) -> Iterable[str]: ...
+
+
+def random_string() -> str:
+    return binascii.hexlify(os.urandom(8)).decode('ascii')
+
+
+class FilesystemMetadataStore(MetadataStore):
+    def __init__(self, cache_dir_prefix: str) -> None:
+        self.cache_dir_prefix = cache_dir_prefix
+
+    def getmtime(self, name: str) -> float:
+        return int(os.path.getmtime(os.path.join(self.cache_dir_prefix, name)))
+
+    def read(self, name: str) -> str:
+        assert os.path.normpath(name) != os.path.abspath(name), "Don't use absolute paths!"
+
+        with open(os.path.join(self.cache_dir_prefix, name), 'r') as f:
+            return f.read()
+
+    def write(self, name: str, data: str, mtime: Optional[float] = None) -> bool:
+        assert os.path.normpath(name) != os.path.abspath(name), "Don't use absolute paths!"
+
+        path = os.path.join(self.cache_dir_prefix, name)
+        tmp_filename = path + '.' + random_string()
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(tmp_filename, 'w') as f:
+                f.write(data)
+                f.write('\n')
+            os.replace(tmp_filename, path)
+            if mtime is not None:
+                os.utime(path, times=(mtime, mtime))
+
+        except os.error:
+            import traceback
+            traceback.print_exc()
+            return False
+        return True
+
+    def remove(self, name: str) -> None:
+        os.remove(os.path.join(self.cache_dir_prefix, name))
+
+    def commit(self) -> None:
+        pass
+
+    def list_all(self) -> Iterable[str]:
+        for dir, _, files in os.walk(self.cache_dir_prefix):
+            dir = os.path.relpath(dir, self.cache_dir_prefix)
+            for file in files:
+                if file.endswith('.json'):
+                    yield os.path.join(dir, file)
+
+
+SCHEMA = '''
+CREATE TABLE IF NOT EXISTS files (
+    path TEXT UNIQUE NOT NULL,
+    mtime REAL,
+    data TEXT
+);
+CREATE INDEX IF NOT EXISTS path_idx on files(path);
+'''
+# No migrations yet
+MIGRATIONS = [
+]  # type: List[str]
+
+
+def connect_db(db_file: str) -> sqlite3.Connection:
+    db = sqlite3.dbapi2.connect(db_file)
+    db.executescript(SCHEMA)
+    for migr in MIGRATIONS:
+        try:
+            db.executescript(migr)
+        except sqlite3.OperationalError:
+            pass
+    return db
+
+
+class SqliteMetadataStore(MetadataStore):
+    def __init__(self, cache_dir_prefix: str) -> None:
+        if cache_dir_prefix.startswith('/dev/null'):
+            self.db = None
+            return
+
+        os.makedirs(cache_dir_prefix, exist_ok=True)
+        self.db = connect_db(os.path.join(cache_dir_prefix, 'cache.db'))
+
+    def _query(self, name: str, field: str) -> Any:
+        if not self.db:
+            raise FileNotFoundError()
+
+        cur = self.db.execute('SELECT {} FROM files WHERE path = ?'.format(field), (name,))
+        results = cur.fetchall()
+        if not results:
+            raise FileNotFoundError()
+        assert len(results) == 1
+        return results[0][0]
+
+    def getmtime(self, name: str) -> float:
+        return self._query(name, 'mtime')
+
+    def read(self, name: str) -> str:
+        return self._query(name, 'data')
+
+    def write(self, name: str, data: str, mtime: Optional[float] = None) -> bool:
+        if not self.db:
+            return False
+        try:
+            if mtime is None:
+                mtime = time.time()
+            self.db.execute('INSERT OR REPLACE INTO files(path, mtime, data) VALUES(?, ?, ?)',
+                            (name, mtime, data))
+        except sqlite3.OperationalError:
+            return False
+        return True
+
+    def remove(self, name: str) -> None:
+        if not self.db:
+            raise FileNotFoundError()
+
+        self.db.execute('DELETE FROM files WHERE path = ?', (name,))
+
+    def commit(self) -> None:
+        if self.db:
+            self.db.commit()
+
+    def list_all(self) -> Iterable[str]:
+        if self.db:
+            for row in self.db.execute('SELECT path FROM files'):
+                yield row[0]

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -75,9 +75,9 @@ class FilesystemMetadataStore(MetadataStore):
         # will have already been appended by the time the cache dir is
         # passed here.
         if cache_dir_prefix.startswith(os.devnull):
-            self.cache_dir_prefix = cache_dir_prefix  # type: Optional[str]
-        else:
             self.cache_dir_prefix = None
+        else:
+            self.cache_dir_prefix = cache_dir_prefix
 
     def getmtime(self, name: str) -> float:
         if not self.cache_dir_prefix:

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -167,6 +167,7 @@ class Options:
         # Caching and incremental checking options
         self.incremental = True
         self.cache_dir = defaults.CACHE_DIR
+        self.sqlite_cache = False
         self.debug_cache = False
         self.quick_and_dirty = False
         self.skip_version_check = False

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4327,7 +4327,7 @@ def foo() -> None:
 tmp/main.py:2: error: "int" has no attribute "foo"
 
 [case testIncrementalBustedFineGrainedCache1]
-# flags: --cache-fine-grained
+# flags: --cache-fine-grained --no-sqlite-cache
 import a
 import b
 [file a.py]
@@ -4355,7 +4355,7 @@ import b
 [rechecked a, b, builtins]
 
 [case testIncrementalBustedFineGrainedCache3]
-# flags: --cache-fine-grained
+# flags: --cache-fine-grained --no-sqlite-cache
 import a
 import b
 [file a.py]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1257,6 +1257,6 @@ import d
 [case testCacheMap]
 -- This just checks that a valid --cache-map triple is accepted.
 -- (Errors are too verbose to check.)
-# cmd: mypy a.py --cache-map a.py a.meta.json a.data.json
+# cmd: mypy a.py --no-sqlite-cache --cache-map a.py a.meta.json a.data.json
 [file a.py]
 [out]

--- a/test-data/unit/fine-grained-cache-incremental.test
+++ b/test-data/unit/fine-grained-cache-incremental.test
@@ -169,6 +169,7 @@ a.py:8: note: Following member(s) of "C" have conflicts:
 a.py:8: note:     x: expected "int", got "str"
 
 [case testIncrCacheBustedProtocol]
+# flags: --no-sqlite-cache
 [file a.py]
 [file b.py]
 -- This is a heinous hack, but we simulate having a invalid cache by clobbering
@@ -185,6 +186,7 @@ a.py:8: note:     x: expected "int", got "str"
 ==
 
 [case testInvalidateCachePart]
+# flags: --no-sqlite-cache
 # cmd: mypy a1.py a2.py b.py p/__init__.py p/c.py
 [file a1.py]
 import p


### PR DESCRIPTION
File system operations on OS X are pretty slow, and untarring a large
archive of mypy cache information can get pretty slow. Work around
this by using a sqlite database to store the entire cache in one file.

To do this we introduce a generic interface for storing metadata,
called `MetadataStore`. It presents an essentially key/value
interface. We provide two implementations, one using the existing file
system backing and one using sqlite.

It is enabled with the option `--sqlite-cache`, but is not the default
yet.

I'm not sure what the right thing to do about testing is. I've tested
it with the default changed, and everything passes.