### PR TITLE
Refactor: split long function in mypy.semanal

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -609,38 +609,9 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             # redefinitions already.
             return
 
+        # We know this is an overload def. Infer properties and perform some checks.
         self.process_final_in_overload(defn)
-
-        # We know this is an overload def -- let's handle classmethod and staticmethod
-        class_status = []
-        static_status = []
-        for item in defn.items:
-            if isinstance(item, Decorator):
-                inner = item.func
-            elif isinstance(item, FuncDef):
-                inner = item
-            else:
-                assert False, "The 'item' variable is an unexpected type: {}".format(type(item))
-            class_status.append(inner.is_class)
-            static_status.append(inner.is_static)
-
-        if defn.impl is not None:
-            if isinstance(defn.impl, Decorator):
-                inner = defn.impl.func
-            elif isinstance(defn.impl, FuncDef):
-                inner = defn.impl
-            else:
-                assert False, "Unexpected impl type: {}".format(type(defn.impl))
-            class_status.append(inner.is_class)
-            static_status.append(inner.is_static)
-
-        if len(set(class_status)) != 1:
-            self.msg.overload_inconsistently_applies_decorator('classmethod', defn)
-        elif len(set(static_status)) != 1:
-            self.msg.overload_inconsistently_applies_decorator('staticmethod', defn)
-        else:
-            defn.is_class = class_status[0]
-            defn.is_static = static_status[0]
+        self.process_static_or_class_method_in_overload(defn)
 
         if self.type and not self.is_func_scope():
             self.type.names[defn.name()] = SymbolTableNode(MDEF, defn)
@@ -680,6 +651,37 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                           bad_final)
         if defn.impl is not None and defn.impl.is_final:
             defn.is_final = True
+
+    def process_static_or_class_method_in_overload(self, defn: OverloadedFuncDef) -> None:
+        class_status = []
+        static_status = []
+        for item in defn.items:
+            if isinstance(item, Decorator):
+                inner = item.func
+            elif isinstance(item, FuncDef):
+                inner = item
+            else:
+                assert False, "The 'item' variable is an unexpected type: {}".format(type(item))
+            class_status.append(inner.is_class)
+            static_status.append(inner.is_static)
+
+        if defn.impl is not None:
+            if isinstance(defn.impl, Decorator):
+                inner = defn.impl.func
+            elif isinstance(defn.impl, FuncDef):
+                inner = defn.impl
+            else:
+                assert False, "Unexpected impl type: {}".format(type(defn.impl))
+            class_status.append(inner.is_class)
+            static_status.append(inner.is_static)
+
+        if len(set(class_status)) != 1:
+            self.msg.overload_inconsistently_applies_decorator('classmethod', defn)
+        elif len(set(static_status)) != 1:
+            self.msg.overload_inconsistently_applies_decorator('staticmethod', defn)
+        else:
+            defn.is_class = class_status[0]
+            defn.is_static = static_status[0]
 
     def analyze_property_with_multi_part_definition(self, defn: OverloadedFuncDef) -> None:
         """Analyze a property defined using multiple methods (e.g., using @x.setter).

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -581,13 +581,17 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             defn: OverloadedFuncDef) -> Tuple[List[CallableType],
                                               Optional[FuncDef],
                                               List[int]]:
-        """Find overload signatures, the implementation, and items with missing @overload."""
+        """Find overload signatures, the implementation, and items with missing @overload.
+
+        Assume that the first was already analyzed. As a side effect:
+        analyzes remaining items and updates 'is_overload' flags.
+        """
         types = []
         non_overload_indexes = []
         impl = None
         for i, item in enumerate(defn.items):
             if i != 0:
-                # The first item was already visited
+                # Assume that the first item was already visited
                 item.is_overload = True
                 item.accept(self)
             # TODO: support decorated overloaded functions properly
@@ -598,7 +602,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                            for dec in item.decorators):
                     if i == len(defn.items) - 1 and not self.is_stub_file:
                         # Last item outside a stub is impl
-                        defn.impl = item
+                        impl = item
                     else:
                         # Oops it wasn't an overload after all. A clear error
                         # will vary based on where in the list it is, record

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -545,6 +545,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             # implementation (if outside a stub), and any missing @overload
             # decorators.
             types, impl, non_overload_indexes = self.find_overload_sigs_and_impl(defn)
+            defn.impl = impl
             if non_overload_indexes:
                 self.handle_missing_overload_decorators(defn, non_overload_indexes,
                                                         some_overload_decorators=len(types) > 0)
@@ -552,7 +553,6 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             # special.
             if impl is not None:
                 assert impl is defn.items[-1]
-                defn.impl = impl
                 defn.items = defn.items[:-1]
             elif not non_overload_indexes:
                 self.handle_missing_overload_implementation(defn)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -549,8 +549,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             if non_overload_indexes:
                 self.handle_missing_overload_decorators(defn, non_overload_indexes,
                                                         some_overload_decorators=len(types) > 0)
-            # If we found an implementation, remove it from the overload item list, as it's
-            # special.
+            # If we found an implementation, remove it from the overload item list,
+            # as it's special.
             if impl is not None:
                 assert impl is defn.items[-1]
                 defn.items = defn.items[:-1]
@@ -562,8 +562,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             defn.type.line = defn.line
 
         if not defn.items:
-            # It was not any kind of overload def after all. We've visited the
-            # redefinitions already.
+            # It was not a real overload after all, but function redefinition. We've
+            # visited the redefinition(s) already.
             return
 
         # We know this is an overload def. Infer properties and perform some checks.
@@ -622,7 +622,10 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                                            defn: OverloadedFuncDef,
                                            non_overload_indexes: List[int],
                                            some_overload_decorators: bool) -> None:
-        """Generate errors for overload items without @overload."""
+        """Generate errors for overload items without @overload.
+
+        Side effect: remote non-overload items.
+        """
         if some_overload_decorators:
             # Some of them were overloads, but not all.
             for idx in non_overload_indexes:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -54,7 +54,7 @@ from mypy.nodes import (
     YieldFromExpr, NamedTupleExpr, NonlocalDecl, SymbolNode,
     SetComprehension, DictionaryComprehension, TypeAlias, TypeAliasExpr,
     YieldExpr, ExecStmt, BackquoteExpr, ImportBase, AwaitExpr,
-    IntExpr, FloatExpr, UnicodeExpr, TempNode, ImportedName,
+    IntExpr, FloatExpr, UnicodeExpr, TempNode, ImportedName, OverloadPart,
     COVARIANT, CONTRAVARIANT, INVARIANT, UNBOUND_IMPORTED, LITERAL_YES, nongen_builtins,
     get_member_expr_fullname, REVEAL_TYPE, REVEAL_LOCALS
 )
@@ -579,7 +579,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
     def find_overload_sigs_and_impl(
             self,
             defn: OverloadedFuncDef) -> Tuple[List[CallableType],
-                                              Optional[FuncDef],
+                                              Optional[OverloadPart],
                                               List[int]]:
         """Find overload signatures, the implementation, and items with missing @overload.
 
@@ -588,7 +588,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         """
         types = []
         non_overload_indexes = []
-        impl = None
+        impl = None  # type: Optional[OverloadPart]
         for i, item in enumerate(defn.items):
             if i != 0:
                 # Assume that the first item was already visited


### PR DESCRIPTION
This splits `SemanticAnalyzerPass2._visit_overloaded_func_def` into
multiple shorter functions. No behavior is changed, and the original
structure is mostly preserved.

Also do some other minor refactorings, and update comments and
docstrings.