### PR TITLE
Add plugin docs

### DIFF
--- a/docs/source/extending_mypy.rst
+++ b/docs/source/extending_mypy.rst
@@ -48,11 +48,10 @@ dynamic patterns is impractical and often just impossible.
 
 Mypy supports a plugin system that lets you customize the way mypy type checks
 code. This can be useful if you want to extend mypy so it can type check code
-that uses a library that is difficult to express using just PEP 484 types, for
-example.
+that uses a library that is difficult to express using just PEP 484 types.
 
 The plugin system is focused on improving mypy's understanding
-of *semantics* of third party frameworks; there is currently no way to define
+of *semantics* of third party frameworks. There is currently no way to define
 new first class kinds of types.
 
 .. note::

--- a/docs/source/extending_mypy.rst
+++ b/docs/source/extending_mypy.rst
@@ -41,7 +41,7 @@ Extending mypy using plugins
 ****************************
 
 Python is a highly dynamic language and has extensive metaprogramming
-capabilities. Many poppular libraries use these to create APIs that may
+capabilities. Many popular libraries use these to create APIs that may
 be more flexible and/or natural for humans, but are hard to express using
 static types. Extending the PEP 484 type system to accommodate all existing
 dynamic patterns is impractical and often just impossible.
@@ -52,7 +52,7 @@ that uses a library that is difficult to express using just PEP 484 types, for
 example.
 
 The plugin system is focused on improving mypy's understanding
-of *semantics* of third party frameworks, there is currently no way to define
+of *semantics* of third party frameworks; there is currently no way to define
 new first class kinds of types.
 
 .. note::
@@ -66,10 +66,11 @@ new first class kinds of types.
 Configuring mypy to use plugins
 *******************************
 
-Plugins can be specified using a :ref:`config file <config-file>` using one
-of the two formats: full path to the plugin file, or a module name (if the plugin
-is installed using ``pip install`` in the same virtual environment
-where mypy is running). The two formats can be mixed, for example:
+Plugins are Python files that can be specified in a mypy
+:ref:`config file <config-file>` using one of the two formats: relative or
+absolute path to the plugin to the plugin file, or a module name (if the plugin
+is installed using ``pip install`` in the same virtual environment where mypy
+is running). The two formats can be mixed, for example:
 
 .. code-block:: ini
 
@@ -86,28 +87,49 @@ can be specified after colon:
     plugins = custom_plugin:custom_entry_point
 
 In following sections we describe basics of the plugin system with
-some examples. For more technical details please read docstrings
-in ``mypy/plugin.py``. Also you can find good examples in the bundled
-plugins located in ``mypy/plugins``.
+some examples. For more technical details please read docstrings in
+`mypy/plugin.py <https://github.com/python/mypy/blob/master/mypy/plugin.py>`_
+in mypy source code. Also you can find good examples in the bundled plugins
+located in `mypy/plugins <https://github.com/python/mypy/tree/master/mypy/plugins>`_.
 
-Large scale overview
-********************
+High-level overview
+*******************
 
 Every entry point function should accept a single string argument
-that is a full mypy version and return a subclass of ``mypy.plugins.Plugin``.
-At several steps during semantic analysis and type checking mypy calls special
-``get_xxx`` methods listed :ref:`below <plugin-hooks>` on user plugins.
-The first plugin that returns non-None object will be used to customize the
-corresponding aspect of analyzing/checking the current abstract syntax tree node.
+that is a full mypy version and return a subclass of ``mypy.plugins.Plugin``:
+
+.. code-block:: python
+
+   from mypy.plugin import Plugin
+
+   class CustomPlugin(Plugin):
+       def get_type_analyze_hook(self, fullname: str):
+           # see explanation below
+           ...
+
+   def plugin(version: str):
+       # ignore version argument if the plugin works with all mypy versions.
+       return CustomPlugin
+
+During different phases of analyzing the code (first in semantic analysis,
+and then in type checking) mypy calls plugin methods such as
+``get_type_analyze_hook()`` on user plugins. This particular method for example
+can return a callback that mypy will use to analyze unbound types with given
+full name. See full plugin hook methods list :ref:`below <plugin-hooks>`.
+
+Mypy maintains a list of plugins it gets from the config file plus the default
+(built-in) plugin that is always enabled. Mypy calls a method once for each
+plugin in the list until one of the methods returns a non-``None`` value.
+This callback will be then used to customize the corresponding aspect of
+analyzing/checking the current abstract syntax tree node.
 
 The callback returned by the ``get_xxx`` method will be given a detailed
 current context and an API to create new nodes, new types, emit error messages
-etc., and the result will be used for further processing. Such two-step plugin
-choice procedure exists to allow effectively coordinate multiple plugins.
+etc., and the result will be used for further processing.
 
 Plugin developers should ensure that their plugins work well in incremental and
-daemon modes. In particular, plugins should not hold global state, and should
-always add semantic dependencies for generated nodes.
+daemon modes. In particular, plugins should not hold global state due to caching
+of plugin hook results.
 
 .. _plugin_hooks:
 
@@ -115,43 +137,53 @@ Current list of plugin hooks
 ****************************
 
 **get_type_analyze_hook()** customizes behaviour of the type analyzer.
-For example, PEP 484 doesn't support definig variadic generic types:
+For example, PEP 484 doesn't support defining variadic generic types:
 
 .. code-block:: python
 
-    from lib import Vector
+   from lib import Vector
 
-    a: Vector[int, int]
-    b: Vector[int, int, int]
+   a: Vector[int, int]
+   b: Vector[int, int, int]
 
 When analyzing this code, mypy will call ``get_type_analyze_hook("lib.Vector")``,
 so the plugin can return some valid type for each variable.
 
 **get_function_hook()** is used to adjust the return type of a function call.
 This is a good choice if the return type of some function depends on *values*
-of some arguments. This hook will be also called for instantiation of classes.
+of some arguments that can't be expressed using literal types (for example
+a function may return an ``int`` for positive arguments and a ``float`` for
+negative arguments). This hook will be also called for instantiation of classes.
 For example:
 
 .. code-block:: python
 
-   from orm import Property
+   from contextlib import contextmanager
+   from typing import TypeVar, Callable
 
-   p = Property()  # a plugin can infer orm.Property[orm.Null]
+   T = TypeVar('T')
+
+   @contextmanager  # built-in plugin can infer a precise type here
+   def stopwatch(timer: Callable[[], T]) -> Iterator[T]:
+       ...
+       yield timer()
 
 **get_method_hook()** is the same as ``get_function_hook()`` but for methods
 instead of module level functions.
 
 **get_method_signature_hook()** is used to adjust the signature of a method.
-This includes special Python methods. For example in this code:
+This includes special Python methods except ``__init__()`` and ``__new__()``.
+For example in this code:
 
 .. code-block:: python
 
-   from lib import MagicCollection
+   from ctypes import Array, c_int
 
-   var: MagicCollection
-   x = var[0]
+   x: Array[c_int]
+   x[0] = 42
 
-mypy will call ``get_method_signature_hook("lib.MagicCollection.__getitem__")``.
+mypy will call ``get_method_signature_hook("ctypes.Array.__setitem__")``
+so that the plugin can mimic the ``ctypes`` auto-convert behavior.
 
 **get_attribute_hook** can be used to give more precise type of an instance
 attribute. Note however, that this method is only called for variables that
@@ -159,7 +191,7 @@ already exist in the class symbol table. If you want to add some generated
 variables/methods to the symbol table you can use one of the three hooks
 below.
 
-**get_class_decorator_hook()** can bu used to update class definition for
+**get_class_decorator_hook()** can be used to update class definition for
 given class decorators. For example, you can add some attributes to the class
 to match runtime behaviour:
 
@@ -190,7 +222,9 @@ where right hand side is a function call:
 
 For such definition, mypy will call ``get_dynamic_class_hook("lib.dynamic_class")``.
 The plugin should create the corresponding ``mypy.nodes.TypeInfo`` object, and
-place it into a relevant symbol table.
+place it into a relevant symbol table. (Instances of this class represent
+classes in mypy and hold essential information such as qualified name,
+method resolution order, etc.)
 
 **get_customize_class_mro_hook()** can be used to modify class MRO (for example
 insert some entries there) before the class body is analyzed.

--- a/docs/source/extending_mypy.rst
+++ b/docs/source/extending_mypy.rst
@@ -40,13 +40,211 @@ A trivial example of using the api is the following
 Extending mypy using plugins
 ****************************
 
+Python is a highly dynamic language and has extensive metaprogramming
+capabilities. Many poppular libraries use these to create APIs that may
+be more flexible and/or natural for humans, but are hard to express using
+static types. Extending the PEP 484 type system to accommodate all existing
+dynamic patterns is impractical and often just impossible.
+
 Mypy supports a plugin system that lets you customize the way mypy type checks
 code. This can be useful if you want to extend mypy so it can type check code
 that uses a library that is difficult to express using just PEP 484 types, for
 example.
 
-*Warning:* The plugin system is extremely experimental and prone to change. If you want
-to contribute a plugin to mypy, we recommend you start by contacting the mypy
-core developers either on `gitter <https://gitter.im/python/typing>`_ or on mypy's
-`issue tracker <https://github.com/python/mypy/issues>`_.
+The plugin system is focused on improving mypy's understanding
+of *semantics* of third party frameworks, there is currently no way to define
+new first class kinds of types.
+
+.. note::
+
+   The plugin system is experimental and prone to change. If you want to write
+   a mypy plugin, we recommend you start by contacting the mypy core developers
+   on `gitter <https://gitter.im/python/typing>`_. In particular, there are
+   no guarantees about backwards compatibility. Backwards incompatible changes
+   may be made without a deprecation period.
+
+Configuring mypy to use plugins
+*******************************
+
+Plugins can be specified using a :ref:`config file <config-file>` using one
+of the two formats: full path to the plugin file
+
+.. code-block:: ini
+
+    [mypy]
+    plugins = /path/to/plugin.py
+
+Large scale overview
+********************
+
+Plugins are collected from the corresponding config option
+  (either a paths to Python files, or installed Python modules)
+  and imported using importlib
+* Every module should get an entry point function (called 'plugin' by default,
+  but may be overridden in the config file), that should accept a single string
+  argument that is a full mypy version (includes git commit hash for dev versions)
+  and return a subclass of mypy.plugins.Plugin
+* All plugin class constructors should match the signature of mypy.plugin.Plugin
+  (i.e. should accept an mypy.options.Options object), and *must* call super().__init__
+* At several steps during semantic analysis and type checking mypy calls special `get_xxx`
+  methods on user plugins with a single string argument that is a full name of a relevant
+  node (see mypy.plugin.Plugin method docstrings for details)
+* The plugins are called in the order they are passed in the config option. Every plugin must
+  decide whether to act on a given full name. The first plugin that returns non-None object
+  will be used
+* The above decision should be made using the limited common API specified by
+  mypy.plugin.CommonPluginApi
+* The callback returned by the plugin will be called with a larger context that includes
+  relevant current state (e.g. a default return type, or a default attribute type) and
+  a wider relevant API provider (e.g. SemanticAnalyzerPluginInterface or
+  CheckerPluginInterface)
+* The result of this is used for further processing. See various `XxxContext` named tuples
+  for details about which information is given to each hook.
+
+The above two-step plugin choice procedure exists to allow effectively coordinate
+multiple plugins.
+
+Plugin developers should ensure that their plugins work well in incremental and
+daemon modes. In particular, plugins should not hold global state, and should always call
+add_plugin_dependency() in plugin hooks called during semantic analysis.
+
+There is no dedicated cache storage for plugins, but plugins can store per-TypeInfo data
+in a special .metadata attribute that is serialized to cache between incremental runs.
+To avoid collisions between plugins they are encouraged to store their state
+under a dedicated key coinciding with plugin name in the metadata dictionary.
+Every value stored there must be JSON-serializable.
+
+
+Current list of plugin hooks
+****************************
+
+get_type_analyze_hook()
+    """Customize behaviour of the type analyzer for given full names.
+
+    This method is called during the semantic analysis pass whenever mypy sees an
+    unbound type. For example, while analysing this code:
+
+        from lib import Special, Other
+
+        var: Special
+        def func(x: Other[int]) -> None:
+            ...
+
+    this method will be called with 'lib.Special', and then with 'lib.Other'.
+    The callback returned by plugin must return an analyzed type,
+    i.e. an instance of `mypy.types.Type`.
+
+get_function_hook()
+    """Adjust the return type of a function call.
+
+    This method is called after type checking a call. Plugin may adjust the return
+    type inferred by mypy, and/or emmit some error messages. Note, this hook is also
+    called for class instantiation calls, so that in this example:
+
+        from lib import Class, do_stuff
+
+        do_stuff(42)
+        Class()
+
+    This method will be called with 'lib.do_stuff' and then with 'lib.Class'.
+
+get_method_signature_hook()
+    """Adjust the signature of a method.
+
+    This method is called before type checking a method call. Plugin
+    may infer a better type for the method. The hook is called for both special and
+    user-defined methods. This function is called with the method full name using
+    the class where it was _defined_. For example, in this code:
+
+        from lib import Special
+
+        class Base:
+            def method(self, arg: Any) -> Any:
+                ...
+        class Derived(Base):
+            ...
+
+        var: Derived
+        var.method(42)
+
+        x: Special
+        y = x[0]
+
+    this method is called with '__main__.Base.method', and then with
+    'lib.Special.__getitem__'.
+
+def get_method_hook(self, fullname: str
+                    ) -> Optional[Callable[[MethodContext], Type]]:
+    """Adjust return type of a method call.
+
+    This is the same as get_function_hook(), but is called with the
+    method full name (again, using the class where the method is defined).
+
+def get_attribute_hook(self, fullname: str
+                       ) -> Optional[Callable[[AttributeContext], Type]]:
+    """Adjust type of a class attribute.
+
+    This method is called with attribute full name using the class where the attribute was
+    defined (or Var.info.fullname() for generated attributes). Currently, this hook is only
+    called for names that exist in the class MRO, for example in:
+
+        class Base:
+            x: Any
+            def __getattr__(self, attr: str) -> Any: ...
+
+        class Derived(Base):
+            ...
+
+        var: Derived
+        var.x
+        var.y
+
+    this method is only called with '__main__.Base.x'.
+
+def get_class_decorator_hook(self, fullname: str
+                             ) -> Optional[Callable[[ClassDefContext], None]]:
+    """Update class definition for given class decorators.
+
+    The plugin can modify a TypeInfo _in place_ (for example add some generated
+    methods to the symbol table). This hook is called after the class body was
+    semantically analyzed.
+
+    The hook is called with full names of all class decorators, for example
+
+def get_metaclass_hook(self, fullname: str
+                       ) -> Optional[Callable[[ClassDefContext], None]]:
+    """Update class definition for given declared metaclasses.
+
+    Same as get_class_decorator_hook() but for metaclasses. Note:
+    this hook will be only called for explicit metaclasses, not for
+    inherited ones.
+
+def get_base_class_hook(self, fullname: str
+                        ) -> Optional[Callable[[ClassDefContext], None]]:
+    """Update class definition for given base classes.
+
+    Same as get_class_decorator_hook() but for base classes. Base classes
+    don't need to refer to TypeInfo's, if a base class refers to a variable with
+    Any type, this hook will still be called.
+
+def get_customize_class_mro_hook(self, fullname: str
+                                 ) -> Optional[Callable[[ClassDefContext], None]]:
+    """Customize MRO for given classes.
+
+    The plugin can modify the class MRO _in place_. This method is called
+    with the class full name before its body was semantically analyzed.
+
+def get_dynamic_class_hook(self, fullname: str
+                           ) -> Optional[Callable[[DynamicClassDefContext], None]]:
+    """Semantically analyze a dynamic class definition.
+
+    This plugin hook allows to semantically analyze dynamic class definitions like:
+
+        from lib import dynamic_class
+
+        X = dynamic_class('X', [])
+
+    For such definition, this hook will be called with 'lib.dynamic_class'.
+    The plugin should create the corresponding TypeInfo, and place it into a relevant
+    symbol table, e.g. using ctx.api.add_symbol_table_node().
 


### PR DESCRIPTION
This adds documentation for the plugin system. To avoid duplication, I add shorter and more basic info to the docs, while adding more technical details to the module/class/method docstrings.

To save time I would propose to make one-two rounds of review here and then polish the docs in subsequent PRs.