### PR TITLE
Support using mypyc under windows

### DIFF
--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -144,7 +144,9 @@ class FileSystemCache:
         seq[stat.ST_NLINK] = 1
         seq[stat.ST_SIZE] = 0
         tpl = tuple(seq)
-        st = os.stat_result(tpl)
+        # FIXME: this works around typeshed claiming stat_result is from posix
+        # (typeshed #2683)
+        st = getattr(os, 'stat_result')(tpl)
         self.stat_cache[path] = st
         # Make listdir() and read() also pretend this file exists.
         self.fake_package_cache.add(dirname)

--- a/setup.py
+++ b/setup.py
@@ -102,13 +102,13 @@ if USE_MYPYC:
 
     everything = find_package_data('mypy', ['*.py'])
     # Start with all the .py files
-    all_real_pys = [x for x in everything if not x.startswith('typeshed/')]
+    all_real_pys = [x for x in everything if not x.startswith('typeshed' + os.sep)]
     # Strip out anything in our blacklist
     mypyc_targets = [x for x in all_real_pys if x not in MYPYC_BLACKLIST]
     # Strip out any test code
-    mypyc_targets = [x for x in mypyc_targets if not x.startswith('test/')]
+    mypyc_targets = [x for x in mypyc_targets if not x.startswith('test' + os.sep)]
     # ... and add back in the one test module we need
-    mypyc_targets.append('test/visitors.py')
+    mypyc_targets.append(os.path.join('test', 'visitors.py'))
 
     # Fix the paths to be full
     mypyc_targets = [os.path.join('mypy', x) for x in mypyc_targets]


### PR DESCRIPTION
THe main thing is fixing some predictable slash direction bugs
in the --use-mypyc support in setup.py.

There is also a temporary hack to work around a typeshed
involving the provenance of os.stat_result.