### PR TITLE
Remove the test of LiteralType with a float

### DIFF
--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -906,7 +906,6 @@ class SameTypeSuite(Suite):
         self.fx = TypeFixture()
 
     def test_literal_type(self) -> None:
-        a = self.fx.a
         b = self.fx.b  # Reminder: b is a subclass of a
         d = self.fx.d
 

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -910,10 +910,6 @@ class SameTypeSuite(Suite):
         b = self.fx.b  # Reminder: b is a subclass of a
         d = self.fx.d
 
-        # Literals are not allowed to contain floats, but we're going to
-        # test them anyways, just to make sure the semantics are robust
-        # against these kinds of things.
-        lit0 = LiteralType(cast(int, 1.0), a)
         lit1 = LiteralType(1, b)
         lit2 = LiteralType(2, b)
         lit3 = LiteralType("foo", d)
@@ -922,7 +918,6 @@ class SameTypeSuite(Suite):
         self.assert_same(UnionType([lit1, lit2]), UnionType([lit1, lit2]))
         self.assert_same(UnionType([lit1, lit2]), UnionType([lit2, lit1]))
         self.assert_not_same(lit1, b)
-        self.assert_not_same(lit0, lit1)
         self.assert_not_same(lit1, lit2)
         self.assert_not_same(lit1, lit3)
 


### PR DESCRIPTION
One of the tests of LiteralType does some tests with a float literal,
to "make sure that the semantics are robust against this kind of
thing". Unfortunately, they are not. mypyc raises a TypeError
when the float is passed in.