### PR TITLE
Fix string parsing errors with literal types

### DIFF
--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -118,9 +118,11 @@ def expr_to_unanalyzed_type(expr: Expression, _parent: Optional[Expression] = No
             assert node is not None
             if isinstance(node, UnboundType) and node.original_str_expr is None:
                 node.original_str_expr = expr.value
-            return node
+                return node
+            else:
+                return RawLiteralType(expr.value, 'builtins.str', expr.line, expr.column)
         except SyntaxError:
-            return RawLiteralType(expr.value, 'builtins.str', line=expr.line, column=expr.column)
+            return RawLiteralType(expr.value, 'builtins.str', expr.line, expr.column)
     elif isinstance(expr, UnaryExpr):
         typ = expr_to_unanalyzed_type(expr.expr)
         if isinstance(typ, RawLiteralType) and isinstance(typ.value, int) and expr.op == '-':

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -5,7 +5,7 @@ from mypy.nodes import (
     ListExpr, StrExpr, BytesExpr, UnicodeExpr, EllipsisExpr, CallExpr,
     get_member_expr_fullname
 )
-from mypy.fastparse import parse_type_comment
+from mypy.fastparse import parse_type_comment, parse_type_string
 from mypy.types import (
     Type, UnboundType, TypeList, EllipsisType, AnyType, Optional, CallableArgument, TypeOfAny,
     RawLiteralType,
@@ -112,17 +112,7 @@ def expr_to_unanalyzed_type(expr: Expression, _parent: Optional[Expression] = No
         return TypeList([expr_to_unanalyzed_type(t, expr) for t in expr.items],
                         line=expr.line, column=expr.column)
     elif isinstance(expr, (StrExpr, BytesExpr, UnicodeExpr)):
-        # Parse string literal type.
-        try:
-            node = parse_type_comment(expr.value, expr.line, None)
-            assert node is not None
-            if isinstance(node, UnboundType) and node.original_str_expr is None:
-                node.original_str_expr = expr.value
-                return node
-            else:
-                return RawLiteralType(expr.value, 'builtins.str', expr.line, expr.column)
-        except SyntaxError:
-            return RawLiteralType(expr.value, 'builtins.str', expr.line, expr.column)
+        return parse_type_string(expr.value, expr.line, expr.column)
     elif isinstance(expr, UnaryExpr):
         typ = expr_to_unanalyzed_type(expr.expr)
         if isinstance(typ, RawLiteralType) and isinstance(typ.value, int) and expr.op == '-':

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1177,7 +1177,9 @@ class TypeConverter:
             node = parse_type_comment(n.s.strip(), self.line, errors=None)
             if isinstance(node, UnboundType) and node.original_str_expr is None:
                 node.original_str_expr = n.s
-            return node or AnyType(TypeOfAny.from_error)
+                return node
+            else:
+                return RawLiteralType(n.s, 'builtins.str', line=self.line)
         except SyntaxError:
             return RawLiteralType(n.s, 'builtins.str', line=self.line)
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -156,7 +156,7 @@ def parse_type_comment(type_comment: str, line: int, errors: Optional[Errors]) -
 
 def parse_type_string(expr_string: str, line: int, column: int) -> Type:
     """Parses a type that was originally present inside of an explicit string.
-    
+
     For example, suppose we have the type `Foo["blah"]`. We should parse the
     string expression "blah" using this function.
     """

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -154,6 +154,19 @@ def parse_type_comment(type_comment: str, line: int, errors: Optional[Errors]) -
         return TypeConverter(errors, line=line).visit(typ.body)
 
 
+def parse_type_string(expr_string: str, line: int, column: int) -> Type:
+    """Parses a type that was originally present inside of an explicit string."""
+    try:
+        node = parse_type_comment(expr_string.strip(), line=line, errors=None)
+        if isinstance(node, UnboundType) and node.original_str_expr is None:
+            node.original_str_expr = expr_string
+            return node
+        else:
+            return RawLiteralType(expr_string, 'builtins.str', line, column)
+    except SyntaxError:
+        return RawLiteralType(expr_string, 'builtins.str', line, column)
+
+
 def is_no_type_check_decorator(expr: ast3.expr) -> bool:
     if isinstance(expr, Name):
         return expr.id == 'no_type_check'
@@ -1173,15 +1186,7 @@ class TypeConverter:
 
     # Str(string s)
     def visit_Str(self, n: Str) -> Type:
-        try:
-            node = parse_type_comment(n.s.strip(), self.line, errors=None)
-            if isinstance(node, UnboundType) and node.original_str_expr is None:
-                node.original_str_expr = n.s
-                return node
-            else:
-                return RawLiteralType(n.s, 'builtins.str', line=self.line)
-        except SyntaxError:
-            return RawLiteralType(n.s, 'builtins.str', line=self.line)
+        return parse_type_string(n.s, line=self.line, column=-1)
 
     # Subscript(expr value, slice slice, expr_context ctx)
     def visit_Subscript(self, n: ast3.Subscript) -> Type:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -155,7 +155,11 @@ def parse_type_comment(type_comment: str, line: int, errors: Optional[Errors]) -
 
 
 def parse_type_string(expr_string: str, line: int, column: int) -> Type:
-    """Parses a type that was originally present inside of an explicit string."""
+    """Parses a type that was originally present inside of an explicit string.
+    
+    For example, suppose we have the type `Foo["blah"]`. We should parse the
+    string expression "blah" using this function.
+    """
     try:
         node = parse_type_comment(expr_string.strip(), line=line, errors=None)
         if isinstance(node, UnboundType) and node.original_str_expr is None:

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -108,6 +108,113 @@ reveal_type(y)                      # E: Revealed type is 'Union[Tuple[Literal[2
 reveal_type(bar)                    # E: Revealed type is 'def (x: Tuple[Literal[2]])'
 [out]
 
+[case testLiteralValidExpressionsInStringsPython3]
+from wrapper import *
+
+[file wrapper.pyi]
+from typing_extensions import Literal
+
+alias_1 = Literal['a+b']
+alias_2 = Literal['1+2']
+alias_3 = Literal['3']
+alias_4 = Literal['True']
+alias_5 = Literal['None']
+alias_6 = Literal['"foo"']
+expr_of_alias_1: alias_1
+expr_of_alias_2: alias_2
+expr_of_alias_3: alias_3
+expr_of_alias_4: alias_4
+expr_of_alias_5: alias_5
+expr_of_alias_6: alias_6
+reveal_type(expr_of_alias_1)  # E: Revealed type is 'Literal['a+b']'
+reveal_type(expr_of_alias_2)  # E: Revealed type is 'Literal['1+2']'
+reveal_type(expr_of_alias_3)  # E: Revealed type is 'Literal['3']'
+reveal_type(expr_of_alias_4)  # E: Revealed type is 'Literal['True']'
+reveal_type(expr_of_alias_5)  # E: Revealed type is 'Literal['None']'
+reveal_type(expr_of_alias_6)  # E: Revealed type is 'Literal['"foo"']'
+
+expr_ann_1: Literal['a+b']
+expr_ann_2: Literal['1+2']
+expr_ann_3: Literal['3']
+expr_ann_4: Literal['True']
+expr_ann_5: Literal['None']
+expr_ann_6: Literal['"foo"']
+reveal_type(expr_ann_1)  # E: Revealed type is 'Literal['a+b']'
+reveal_type(expr_ann_2)  # E: Revealed type is 'Literal['1+2']'
+reveal_type(expr_ann_3)  # E: Revealed type is 'Literal['3']'
+reveal_type(expr_ann_4)  # E: Revealed type is 'Literal['True']'
+reveal_type(expr_ann_5)  # E: Revealed type is 'Literal['None']'
+reveal_type(expr_ann_6)  # E: Revealed type is 'Literal['"foo"']'
+
+expr_str_1: "Literal['a+b']"
+expr_str_2: "Literal['1+2']"
+expr_str_3: "Literal['3']"
+expr_str_4: "Literal['True']"
+expr_str_5: "Literal['None']"
+expr_str_6: "Literal['\"foo\"']"
+reveal_type(expr_str_1)  # E: Revealed type is 'Literal['a+b']'
+reveal_type(expr_str_2)  # E: Revealed type is 'Literal['1+2']'
+reveal_type(expr_str_3)  # E: Revealed type is 'Literal['3']'
+reveal_type(expr_str_4)  # E: Revealed type is 'Literal['True']'
+reveal_type(expr_str_5)  # E: Revealed type is 'Literal['None']'
+reveal_type(expr_str_6)  # E: Revealed type is 'Literal['"foo"']'
+
+expr_com_1 = ...   # type: Literal['a+b']
+expr_com_2 = ...   # type: Literal['1+2']
+expr_com_3 = ...   # type: Literal['3']
+expr_com_4 = ...   # type: Literal['True']
+expr_com_5 = ...   # type: Literal['None']
+expr_com_6 = ...   # type: Literal['"foo"']
+reveal_type(expr_com_1)  # E: Revealed type is 'Literal['a+b']'
+reveal_type(expr_com_2)  # E: Revealed type is 'Literal['1+2']'
+reveal_type(expr_com_3)  # E: Revealed type is 'Literal['3']'
+reveal_type(expr_com_4)  # E: Revealed type is 'Literal['True']'
+reveal_type(expr_com_5)  # E: Revealed type is 'Literal['None']'
+reveal_type(expr_com_6)  # E: Revealed type is 'Literal['"foo"']'
+[builtins fixtures/bool.pyi]
+[out]
+
+[case testLiteralValidExpressionsInStringsPython2]
+# flags: --python-version=2.7
+from wrapper import *
+
+[file wrapper.pyi]
+from typing_extensions import Literal
+
+alias_1 = Literal['a+b']
+alias_2 = Literal['1+2']
+alias_3 = Literal['3']
+alias_4 = Literal['True']
+alias_5 = Literal['None']
+alias_6 = Literal['"foo"']
+expr_of_alias_1: alias_1
+expr_of_alias_2: alias_2
+expr_of_alias_3: alias_3
+expr_of_alias_4: alias_4
+expr_of_alias_5: alias_5
+expr_of_alias_6: alias_6
+reveal_type(expr_of_alias_1)  # E: Revealed type is 'Literal['a+b']'
+reveal_type(expr_of_alias_2)  # E: Revealed type is 'Literal['1+2']'
+reveal_type(expr_of_alias_3)  # E: Revealed type is 'Literal['3']'
+reveal_type(expr_of_alias_4)  # E: Revealed type is 'Literal['True']'
+reveal_type(expr_of_alias_5)  # E: Revealed type is 'Literal['None']'
+reveal_type(expr_of_alias_6)  # E: Revealed type is 'Literal['"foo"']'
+
+expr_com_1 = ...   # type: Literal['a+b']
+expr_com_2 = ...   # type: Literal['1+2']
+expr_com_3 = ...   # type: Literal['3']
+expr_com_4 = ...   # type: Literal['True']
+expr_com_5 = ...   # type: Literal['None']
+expr_com_6 = ...   # type: Literal['"foo"']
+reveal_type(expr_com_1)  # E: Revealed type is 'Literal['a+b']'
+reveal_type(expr_com_2)  # E: Revealed type is 'Literal['1+2']'
+reveal_type(expr_com_3)  # E: Revealed type is 'Literal['3']'
+reveal_type(expr_com_4)  # E: Revealed type is 'Literal['True']'
+reveal_type(expr_com_5)  # E: Revealed type is 'Literal['None']'
+reveal_type(expr_com_6)  # E: Revealed type is 'Literal['"foo"']'
+[builtins fixtures/bool.pyi]
+[out]
+
 [case testLiteralRenamingImportWorks]
 from typing_extensions import Literal as Foo
 


### PR DESCRIPTION
While testing literal types on our internal codebases, I discovered that the current parsing logic for literal types did not correct handle strings inside literal types. In particular, suppose we have the type `Literal["3"]`. Previously, the parser would attempt to parse `"3"` as a regular type and return a `RawLiteralType(3, "builtins.int")`, which caused the type to ultimately become `Literal[3]`.

This diff modifies the string-handled code to guarantee that a string expression will only ever resolve to an UnboundType or a `RawLiteralType(..., "builtins.str")`.