### PR TITLE
Complement cheatsheet for Optionals

### DIFF
--- a/docs/source/cheat_sheet.rst
+++ b/docs/source/cheat_sheet.rst
@@ -46,9 +46,13 @@ Built-in types
 
    # Use Optional[] for values that could be None
    x = some_function()  # type: Optional[str]
+   # To indicate to mypy that the value is not None, 2 cases:
+   # If it still may be None sometimes, use an if-statement
    if x is not None:
-      print x
-
+       print x.upper()
+   # If it can never be None (e.g. due to some invariants), use an assert
+   assert x is not None
+   print x.upper()
 
 Functions
 *********

--- a/docs/source/cheat_sheet.rst
+++ b/docs/source/cheat_sheet.rst
@@ -46,11 +46,10 @@ Built-in types
 
    # Use Optional[] for values that could be None
    x = some_function()  # type: Optional[str]
-   # To indicate to mypy that the value is not None, 2 cases:
-   # If it still may be None sometimes, use an if-statement
+   # Mypy understands a value can't be None in an if-statement
    if x is not None:
        print x.upper()
-   # If it can never be None (e.g. due to some invariants), use an assert
+   # If a value can never be None due to some invariants, use an assert
    assert x is not None
    print x.upper()
 

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -72,11 +72,10 @@ Built-in types
 
    # Use Optional[] for values that could be None
    x: Optional[str] = some_function()
-   # To indicate to mypy that the value is not None, 2 cases:
-   # If it still may be None sometimes, use an if-statement
+   # Mypy understands a value can't be None in an if-statement
    if x is not None:
        print(x.upper())
-   # If it can never be None (e.g. due to some invariants), use an assert
+   # If a value can never be None due to some invariants, use an assert
    assert x is not None
    print(x.upper())
 

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -72,9 +72,13 @@ Built-in types
 
    # Use Optional[] for values that could be None
    x: Optional[str] = some_function()
+   # To indicate to mypy that the value is not None, 2 cases:
+   # If it still may be None sometimes, use an if-statement
    if x is not None:
-       print(x)
-
+       print(x.upper())
+   # If it can never be None (e.g. due to some invariants), use an assert
+   assert x is not None
+   print(x.upper())
 
 Functions
 *********


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5037

Add a paragrah to explain there are 2 ways to make the typechecker
understand that an optional is not `None`: use a if condition or an
`assert`.

