### PR TITLE
Bump typed-ast minimum version to 1.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ setup(name='mypy' if not USE_MYPYC else 'mypy-mypyc',
                                         ]},
       classifiers=classifiers,
       cmdclass=cmdclass,
-      install_requires = ['typed-ast >= 1.1.0, < 1.2.0',
+      install_requires = ['typed-ast >= 1.1.1, < 1.2.0',
                           'mypy_extensions >= 0.4.0, < 0.5.0',
                           ],
       extras_require = {

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,7 +8,7 @@ psutil==5.4.0
 pytest>=3.4
 pytest-xdist>=1.22
 pytest-cov>=2.4.0
-typed-ast>=1.1.0,<1.2.0
+typed-ast>=1.1.1,<1.2.0
 typing>=3.5.2; python_version < '3.5'
 py>=1.5.2
 virtualenv


### PR DESCRIPTION
This pull request bumps the minimum allowed version of typed-ast to version 1.1.1. This is mostly so that we can have https://github.com/python/typed_ast/pull/49, which we need to correctly handle Literals containing unicode strings when analyzing Python 2 source code.