### PR TITLE
Refactor argument mapping

### DIFF
--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -22,67 +22,67 @@ def map_actuals_to_formals(actual_kinds: List[int],
     """
     nformals = len(formal_kinds)
     map = [[] for i in range(nformals)]  # type: List[List[int]]
-    j = 0
-    for i, actual_kind in enumerate(actual_kinds):
+    fi = 0
+    for ai, actual_kind in enumerate(actual_kinds):
         if actual_kind == nodes.ARG_POS:
-            if j < nformals:
-                if formal_kinds[j] in [nodes.ARG_POS, nodes.ARG_OPT,
-                                       nodes.ARG_NAMED, nodes.ARG_NAMED_OPT]:
-                    map[j].append(i)
-                    j += 1
-                elif formal_kinds[j] == nodes.ARG_STAR:
-                    map[j].append(i)
+            if fi < nformals:
+                if formal_kinds[fi] in [nodes.ARG_POS, nodes.ARG_OPT,
+                                        nodes.ARG_NAMED, nodes.ARG_NAMED_OPT]:
+                    map[fi].append(ai)
+                    fi += 1
+                elif formal_kinds[fi] == nodes.ARG_STAR:
+                    map[fi].append(ai)
         elif actual_kind == nodes.ARG_STAR:
             # We need to know the actual type to map varargs.
-            actualt = actual_arg_type(i)
+            actualt = actual_arg_type(ai)
             if isinstance(actualt, TupleType):
                 # A tuple actual maps to a fixed number of formals.
                 for _ in range(len(actualt.items)):
-                    if j < nformals:
-                        if formal_kinds[j] != nodes.ARG_STAR2:
-                            map[j].append(i)
+                    if fi < nformals:
+                        if formal_kinds[fi] != nodes.ARG_STAR2:
+                            map[fi].append(ai)
                         else:
                             break
-                        if formal_kinds[j] != nodes.ARG_STAR:
-                            j += 1
+                        if formal_kinds[fi] != nodes.ARG_STAR:
+                            fi += 1
             else:
                 # Assume that it is an iterable (if it isn't, there will be
                 # an error later).
-                while j < nformals:
-                    if formal_kinds[j] in (nodes.ARG_NAMED, nodes.ARG_NAMED_OPT, nodes.ARG_STAR2):
+                while fi < nformals:
+                    if formal_kinds[fi] in (nodes.ARG_NAMED, nodes.ARG_NAMED_OPT, nodes.ARG_STAR2):
                         break
                     else:
-                        map[j].append(i)
-                    if formal_kinds[j] == nodes.ARG_STAR:
+                        map[fi].append(ai)
+                    if formal_kinds[fi] == nodes.ARG_STAR:
                         break
-                    j += 1
+                    fi += 1
         elif actual_kind in (nodes.ARG_NAMED, nodes.ARG_NAMED_OPT):
             assert actual_names is not None, "Internal error: named kinds without names given"
-            name = actual_names[i]
+            name = actual_names[ai]
             if name in formal_names:
-                map[formal_names.index(name)].append(i)
+                map[formal_names.index(name)].append(ai)
             elif nodes.ARG_STAR2 in formal_kinds:
-                map[formal_kinds.index(nodes.ARG_STAR2)].append(i)
+                map[formal_kinds.index(nodes.ARG_STAR2)].append(ai)
         else:
             assert actual_kind == nodes.ARG_STAR2
-            actualt = actual_arg_type(i)
+            actualt = actual_arg_type(ai)
             if isinstance(actualt, TypedDictType):
                 for name, value in actualt.items.items():
                     if name in formal_names:
-                        map[formal_names.index(name)].append(i)
+                        map[formal_names.index(name)].append(ai)
                     elif nodes.ARG_STAR2 in formal_kinds:
-                        map[formal_kinds.index(nodes.ARG_STAR2)].append(i)
+                        map[formal_kinds.index(nodes.ARG_STAR2)].append(ai)
             else:
                 # We don't exactly know which **kwargs are provided by the
                 # caller. Assume that they will fill the remaining arguments.
-                for j in range(nformals):
+                for fi in range(nformals):
                     # TODO: If there are also tuple varargs, we might be missing some potential
                     #       matches if the tuple was short enough to not match everything.
                     no_certain_match = (
-                        not map[j] or actual_kinds[map[j][0]] == nodes.ARG_STAR)
-                    if ((formal_names[j] and no_certain_match)
-                            or formal_kinds[j] == nodes.ARG_STAR2):
-                        map[j].append(i)
+                        not map[fi] or actual_kinds[map[fi][0]] == nodes.ARG_STAR)
+                    if ((formal_names[fi] and no_certain_match)
+                            or formal_kinds[fi] == nodes.ARG_STAR2):
+                        map[fi].append(ai)
     return map
 
 

--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -6,11 +6,11 @@ from mypy.types import Type, Instance, TupleType, AnyType, TypeOfAny, TypedDictT
 from mypy import nodes
 
 
-def map_actuals_to_formals(caller_kinds: List[int],
-                           caller_names: Optional[Sequence[Optional[str]]],
-                           callee_kinds: List[int],
-                           callee_names: Sequence[Optional[str]],
-                           caller_arg_type: Callable[[int],
+def map_actuals_to_formals(actual_kinds: List[int],
+                           actual_names: Optional[Sequence[Optional[str]]],
+                           formal_kinds: List[int],
+                           formal_names: Sequence[Optional[str]],
+                           actual_arg_type: Callable[[int],
                                                      Type]) -> List[List[int]]:
     """Calculate mapping between actual (caller) args and formals.
 
@@ -20,58 +20,58 @@ def map_actuals_to_formals(caller_kinds: List[int],
     The caller_arg_type argument should evaluate to the type of the actual
     argument type with the given index.
     """
-    ncallee = len(callee_kinds)
+    ncallee = len(formal_kinds)
     map = [[] for i in range(ncallee)]  # type: List[List[int]]
     j = 0
-    for i, actual_kind in enumerate(caller_kinds):
+    for i, actual_kind in enumerate(actual_kinds):
         if actual_kind == nodes.ARG_POS:
             if j < ncallee:
-                if callee_kinds[j] in [nodes.ARG_POS, nodes.ARG_OPT,
+                if formal_kinds[j] in [nodes.ARG_POS, nodes.ARG_OPT,
                                        nodes.ARG_NAMED, nodes.ARG_NAMED_OPT]:
                     map[j].append(i)
                     j += 1
-                elif callee_kinds[j] == nodes.ARG_STAR:
+                elif formal_kinds[j] == nodes.ARG_STAR:
                     map[j].append(i)
         elif actual_kind == nodes.ARG_STAR:
             # We need to know the actual type to map varargs.
-            argt = caller_arg_type(i)
+            argt = actual_arg_type(i)
             if isinstance(argt, TupleType):
                 # A tuple actual maps to a fixed number of formals.
                 for _ in range(len(argt.items)):
                     if j < ncallee:
-                        if callee_kinds[j] != nodes.ARG_STAR2:
+                        if formal_kinds[j] != nodes.ARG_STAR2:
                             map[j].append(i)
                         else:
                             break
-                        if callee_kinds[j] != nodes.ARG_STAR:
+                        if formal_kinds[j] != nodes.ARG_STAR:
                             j += 1
             else:
                 # Assume that it is an iterable (if it isn't, there will be
                 # an error later).
                 while j < ncallee:
-                    if callee_kinds[j] in (nodes.ARG_NAMED, nodes.ARG_NAMED_OPT, nodes.ARG_STAR2):
+                    if formal_kinds[j] in (nodes.ARG_NAMED, nodes.ARG_NAMED_OPT, nodes.ARG_STAR2):
                         break
                     else:
                         map[j].append(i)
-                    if callee_kinds[j] == nodes.ARG_STAR:
+                    if formal_kinds[j] == nodes.ARG_STAR:
                         break
                     j += 1
         elif actual_kind in (nodes.ARG_NAMED, nodes.ARG_NAMED_OPT):
-            assert caller_names is not None, "Internal error: named kinds without names given"
-            name = caller_names[i]
-            if name in callee_names:
-                map[callee_names.index(name)].append(i)
-            elif nodes.ARG_STAR2 in callee_kinds:
-                map[callee_kinds.index(nodes.ARG_STAR2)].append(i)
+            assert actual_names is not None, "Internal error: named kinds without names given"
+            name = actual_names[i]
+            if name in formal_names:
+                map[formal_names.index(name)].append(i)
+            elif nodes.ARG_STAR2 in formal_kinds:
+                map[formal_kinds.index(nodes.ARG_STAR2)].append(i)
         else:
             assert actual_kind == nodes.ARG_STAR2
-            argt = caller_arg_type(i)
+            argt = actual_arg_type(i)
             if isinstance(argt, TypedDictType):
                 for name, value in argt.items.items():
-                    if name in callee_names:
-                        map[callee_names.index(name)].append(i)
-                    elif nodes.ARG_STAR2 in callee_kinds:
-                        map[callee_kinds.index(nodes.ARG_STAR2)].append(i)
+                    if name in formal_names:
+                        map[formal_names.index(name)].append(i)
+                    elif nodes.ARG_STAR2 in formal_kinds:
+                        map[formal_kinds.index(nodes.ARG_STAR2)].append(i)
             else:
                 # We don't exactly know which **kwargs are provided by the
                 # caller. Assume that they will fill the remaining arguments.
@@ -79,28 +79,27 @@ def map_actuals_to_formals(caller_kinds: List[int],
                     # TODO: If there are also tuple varargs, we might be missing some potential
                     #       matches if the tuple was short enough to not match everything.
                     no_certain_match = (
-                        not map[j] or caller_kinds[map[j][0]] == nodes.ARG_STAR)
-                    print(no_certain_match, callee_names[j], callee_kinds[j])
-                    if ((callee_names[j] and no_certain_match)
-                            or callee_kinds[j] == nodes.ARG_STAR2):
+                        not map[j] or actual_kinds[map[j][0]] == nodes.ARG_STAR)
+                    if ((formal_names[j] and no_certain_match)
+                            or formal_kinds[j] == nodes.ARG_STAR2):
                         map[j].append(i)
     return map
 
 
-def map_formals_to_actuals(caller_kinds: List[int],
-                           caller_names: Optional[Sequence[Optional[str]]],
-                           callee_kinds: List[int],
-                           callee_names: List[Optional[str]],
-                           caller_arg_type: Callable[[int],
+def map_formals_to_actuals(actual_kinds: List[int],
+                           actual_names: Optional[Sequence[Optional[str]]],
+                           formal_kinds: List[int],
+                           formal_names: List[Optional[str]],
+                           actual_arg_type: Callable[[int],
                                                      Type]) -> List[List[int]]:
     """Calculate the reverse mapping of map_actuals_to_formals."""
-    formal_to_actual = map_actuals_to_formals(caller_kinds,
-                                              caller_names,
-                                              callee_kinds,
-                                              callee_names,
-                                              caller_arg_type)
+    formal_to_actual = map_actuals_to_formals(actual_kinds,
+                                              actual_names,
+                                              formal_kinds,
+                                              formal_names,
+                                              actual_arg_type)
     # Now reverse the mapping.
-    actual_to_formal = [[] for _ in caller_kinds]  # type: List[List[int]]
+    actual_to_formal = [[] for _ in actual_kinds]  # type: List[List[int]]
     for formal, actuals in enumerate(formal_to_actual):
         for actual in actuals:
             actual_to_formal[actual].append(formal)

--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -65,9 +65,9 @@ def map_actuals_to_formals(actual_kinds: List[int],
                 map[formal_kinds.index(nodes.ARG_STAR2)].append(i)
         else:
             assert actual_kind == nodes.ARG_STAR2
-            argt = actual_arg_type(i)
-            if isinstance(argt, TypedDictType):
-                for name, value in argt.items.items():
+            actualt = actual_arg_type(i)
+            if isinstance(actualt, TypedDictType):
+                for name, value in actualt.items.items():
                     if name in formal_names:
                         map[formal_names.index(name)].append(i)
                     elif nodes.ARG_STAR2 in formal_kinds:

--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -34,10 +34,10 @@ def map_actuals_to_formals(actual_kinds: List[int],
                     map[j].append(i)
         elif actual_kind == nodes.ARG_STAR:
             # We need to know the actual type to map varargs.
-            argt = actual_arg_type(i)
-            if isinstance(argt, TupleType):
+            actualt = actual_arg_type(i)
+            if isinstance(actualt, TupleType):
                 # A tuple actual maps to a fixed number of formals.
-                for _ in range(len(argt.items)):
+                for _ in range(len(actualt.items)):
                     if j < nformals:
                         if formal_kinds[j] != nodes.ARG_STAR2:
                             map[j].append(i)

--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -23,8 +23,8 @@ def map_actuals_to_formals(caller_kinds: List[int],
     ncallee = len(callee_kinds)
     map = [[] for i in range(ncallee)]  # type: List[List[int]]
     j = 0
-    for i, kind in enumerate(caller_kinds):
-        if kind == nodes.ARG_POS:
+    for i, actual_kind in enumerate(caller_kinds):
+        if actual_kind == nodes.ARG_POS:
             if j < ncallee:
                 if callee_kinds[j] in [nodes.ARG_POS, nodes.ARG_OPT,
                                        nodes.ARG_NAMED, nodes.ARG_NAMED_OPT]:
@@ -32,7 +32,7 @@ def map_actuals_to_formals(caller_kinds: List[int],
                     j += 1
                 elif callee_kinds[j] == nodes.ARG_STAR:
                     map[j].append(i)
-        elif kind == nodes.ARG_STAR:
+        elif actual_kind == nodes.ARG_STAR:
             # We need to know the actual type to map varargs.
             argt = caller_arg_type(i)
             if isinstance(argt, TupleType):
@@ -56,7 +56,7 @@ def map_actuals_to_formals(caller_kinds: List[int],
                     if callee_kinds[j] == nodes.ARG_STAR:
                         break
                     j += 1
-        elif kind in (nodes.ARG_NAMED, nodes.ARG_NAMED_OPT):
+        elif actual_kind in (nodes.ARG_NAMED, nodes.ARG_NAMED_OPT):
             assert caller_names is not None, "Internal error: named kinds without names given"
             name = caller_names[i]
             if name in callee_names:
@@ -64,7 +64,7 @@ def map_actuals_to_formals(caller_kinds: List[int],
             elif nodes.ARG_STAR2 in callee_kinds:
                 map[callee_kinds.index(nodes.ARG_STAR2)].append(i)
         else:
-            assert kind == nodes.ARG_STAR2
+            assert actual_kind == nodes.ARG_STAR2
             argt = caller_arg_type(i)
             if isinstance(argt, TypedDictType):
                 for name, value in argt.items.items():
@@ -80,6 +80,7 @@ def map_actuals_to_formals(caller_kinds: List[int],
                     #       matches if the tuple was short enough to not match everything.
                     no_certain_match = (
                         not map[j] or caller_kinds[map[j][0]] == nodes.ARG_STAR)
+                    print(no_certain_match, callee_names[j], callee_kinds[j])
                     if ((callee_names[j] and no_certain_match)
                             or callee_kinds[j] == nodes.ARG_STAR2):
                         map[j].append(i)

--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -20,12 +20,12 @@ def map_actuals_to_formals(actual_kinds: List[int],
     The caller_arg_type argument should evaluate to the type of the actual
     argument type with the given index.
     """
-    ncallee = len(formal_kinds)
-    map = [[] for i in range(ncallee)]  # type: List[List[int]]
+    nformals = len(formal_kinds)
+    map = [[] for i in range(nformals)]  # type: List[List[int]]
     j = 0
     for i, actual_kind in enumerate(actual_kinds):
         if actual_kind == nodes.ARG_POS:
-            if j < ncallee:
+            if j < nformals:
                 if formal_kinds[j] in [nodes.ARG_POS, nodes.ARG_OPT,
                                        nodes.ARG_NAMED, nodes.ARG_NAMED_OPT]:
                     map[j].append(i)
@@ -38,7 +38,7 @@ def map_actuals_to_formals(actual_kinds: List[int],
             if isinstance(argt, TupleType):
                 # A tuple actual maps to a fixed number of formals.
                 for _ in range(len(argt.items)):
-                    if j < ncallee:
+                    if j < nformals:
                         if formal_kinds[j] != nodes.ARG_STAR2:
                             map[j].append(i)
                         else:
@@ -48,7 +48,7 @@ def map_actuals_to_formals(actual_kinds: List[int],
             else:
                 # Assume that it is an iterable (if it isn't, there will be
                 # an error later).
-                while j < ncallee:
+                while j < nformals:
                     if formal_kinds[j] in (nodes.ARG_NAMED, nodes.ARG_NAMED_OPT, nodes.ARG_STAR2):
                         break
                     else:
@@ -75,7 +75,7 @@ def map_actuals_to_formals(actual_kinds: List[int],
             else:
                 # We don't exactly know which **kwargs are provided by the
                 # caller. Assume that they will fill the remaining arguments.
-                for j in range(ncallee):
+                for j in range(nformals):
                     # TODO: If there are also tuple varargs, we might be missing some potential
                     #       matches if the tuple was short enough to not match everything.
                     no_certain_match = (


### PR DESCRIPTION
This only does some variable renamings, mainly to make things more 
consistent. We know use actuals/formals instead of caller/callee, as 
the latter look too similar.