### PR TITLE
 Update tests to prepare for variable redefinition with new type

### DIFF
--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -15,6 +15,8 @@ a = None # type: A
 b = None # type: B
 c = None # type: C
 
+def f(): i, j, a, b, c # Prevent redefinition
+
 j = c  # E: Incompatible types in assignment (expression has type "C", variable has type "J")
 a = i  # E: Incompatible types in assignment (expression has type "I", variable has type "A")
 a = j  # E: Incompatible types in assignment (expression has type "J", variable has type "A")
@@ -46,6 +48,8 @@ j = None # type: J
 a = None # type: A
 o = None # type: object
 
+def f(): i, j, a, o # Prevent redefinition
+
 j = i # E: Incompatible types in assignment (expression has type "I", variable has type "J")
 a = i # E: Incompatible types in assignment (expression has type "I", variable has type "A")
 a = j # E: Incompatible types in assignment (expression has type "J", variable has type "A")
@@ -65,18 +69,21 @@ class J(I): pass
 class A(J): pass
 
 [case testInheritingAbstractClassInSubclass]
-
 from abc import abstractmethod, ABCMeta
 
 i = None # type: I
 a = None # type: A
 b = None # type: B
 
-i = a # E: Incompatible types in assignment (expression has type "A", variable has type "I")
-b = a # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    i = a # E: Incompatible types in assignment (expression has type "A", variable has type "I")
+if int():
+    b = a # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-a = b
-i = b
+if int():
+    a = b
+if int():
+    i = b
 
 class I(metaclass=ABCMeta):
   @abstractmethod
@@ -116,12 +123,17 @@ class B: pass
 i, a, b = None, None, None # type: (I, A, B)
 o = None # type: object
 
-a = cast(I, o) # E: Incompatible types in assignment (expression has type "I", variable has type "A")
-b = cast(B, i) # Ok; a subclass of B might inherit I
-i = cast(I, b) # Ok; a subclass of B might inherit I
+if int():
+    a = cast(I, o) # E: Incompatible types in assignment (expression has type "I", variable has type "A")
+if int():
+    b = cast(B, i) # Ok; a subclass of B might inherit I
+if int():
+    i = cast(I, b) # Ok; a subclass of B might inherit I
 
-i = cast(I, o)
-i = cast(I, a)
+if int():
+    i = cast(I, o)
+if int():
+    i = cast(I, a)
 
 [case testInstantiatingClassThatImplementsAbstractMethod]
 from abc import abstractmethod, ABCMeta
@@ -218,15 +230,21 @@ class C(B):
 
 var: Type[A]
 var()
-var = A # E: Can only assign concrete classes to a variable of type "Type[A]"
-var = B # E: Can only assign concrete classes to a variable of type "Type[A]"
-var = C # OK
+if int():
+    var = A # E: Can only assign concrete classes to a variable of type "Type[A]"
+if int():
+    var = B # E: Can only assign concrete classes to a variable of type "Type[A]"
+if int():
+    var = C # OK
 
 var_old = None # type: Type[A] # Old syntax for variable annotations
 var_old()
-var_old = A # E: Can only assign concrete classes to a variable of type "Type[A]"
-var_old = B # E: Can only assign concrete classes to a variable of type "Type[A]"
-var_old = C # OK
+if int():
+    var_old = A # E: Can only assign concrete classes to a variable of type "Type[A]"
+if int():
+    var_old = B # E: Can only assign concrete classes to a variable of type "Type[A]"
+if int():
+    var_old = C # OK
 [out]
 
 [case testInstantiationAbstractsInTypeForClassMethods]
@@ -362,7 +380,6 @@ main:11: error: Return type of "h" incompatible with supertype "I"
 
 
 [case testAccessingAbstractMethod]
-
 from abc import abstractmethod, ABCMeta
 
 class I(metaclass=ABCMeta):
@@ -371,14 +388,16 @@ class I(metaclass=ABCMeta):
 
 i, a, b = None, None, None # type: (I, int, str)
 
-a = i.f(a) # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-b = i.f(b) # E: Argument 1 to "f" of "I" has incompatible type "str"; expected "int"
+if int():
+    a = i.f(a) # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    b = i.f(b) # E: Argument 1 to "f" of "I" has incompatible type "str"; expected "int"
 i.g()      # E: "I" has no attribute "g"
 
-b = i.f(a)
+if int():
+    b = i.f(a)
 
 [case testAccessingInheritedAbstractMethod]
-
 from abc import abstractmethod, ABCMeta
 
 class J(metaclass=ABCMeta):
@@ -388,8 +407,10 @@ class I(J): pass
 
 i, a, b = None, None, None # type: (I, int, str)
 
-a = i.f(1) # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-b = i.f(1)
+if int():
+    a = i.f(1) # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    b = i.f(1)
 
 
 -- Any (dynamic) types

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -125,7 +125,7 @@ main:4: error: Too many arguments for "f"
 def f() -> None:
   x = None # type: A
   y = None # type: B
-  if 1:
+  if int():
       x = x
       x = y # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 class A: pass
@@ -144,7 +144,7 @@ class B: pass
 [case testFunctionArguments]
 import typing
 def f(x: 'A', y: 'B') -> None:
-  if 1:
+  if int():
     x = y # E: Incompatible types in assignment (expression has type "B", variable has type "A")
     x = x
     y = B()
@@ -239,12 +239,12 @@ a = __file__ # type: int  # E: Incompatible types in assignment (expression has 
 [case testLocalVariableShadowing]
 
 a = None # type: A
-if 1:
+if int():
     a = B()  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
     a = A()
 def f() -> None:
   a = None # type: B
-  if 1:
+  if int():
       a = A()     # E: Incompatible types in assignment (expression has type "A", variable has type "B")
       a = B()
 a = B()       # E: Incompatible types in assignment (expression has type "B", variable has type "A")

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -2,45 +2,43 @@
 [out]
 
 [case testAssignmentAndVarDef]
-
 a = None # type: A
 b = None # type: B
-a = a
-a = b # Fail
+if int():
+    a = a
+if int():
+    a = b # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 class A: pass
 class B: pass
-[out]
-main:5: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testConstructionAndAssignment]
-
 x = None # type: A
 x = A()
-x = B()
+if int():
+    x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 class A:
     def __init__(self): pass
 class B:
     def __init__(self): pass
-[out]
-main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testInheritInitFromObject]
-
 x = None # type: A
-x = A()
-x = B()
+if int():
+    x = A()
+if int():
+    x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 class A(object): pass
 class B(object): pass
-[out]
-main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testImplicitInheritInitFromObject]
-
 x = None # type: A
 o = None # type: object
-x = o # E: Incompatible types in assignment (expression has type "object", variable has type "A")
-x = A()
-o = x
+if int():
+    x = o # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+if int():
+    x = A()
+if int():
+    o = x
 class A: pass
 class B: pass
 [out]
@@ -71,8 +69,10 @@ main:3: error: Incompatible types in assignment (expression has type "A", variab
 [case testDeclaredVariableInParentheses]
 
 (x) = None # type: int
-x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-x = 1
+if int():
+    x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    x = 1
 
 
 -- Simple functions and calling
@@ -122,40 +122,34 @@ main:4: error: Too many arguments for "f"
 
 
 [case testLocalVariables]
-
 def f() -> None:
   x = None # type: A
   y = None # type: B
-  x = x
-  x = y # Fail
+  if 1:
+      x = x
+      x = y # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 class A: pass
 class B: pass
-[out]
-main:6: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testLocalVariableScope]
-
 def f() -> None:
-  x = None # type: A
+  x: A
   x = A()
 def g() -> None:
-  x = None # type: B
-  x = A() # Fail
+  x: B
+  x = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 class A: pass
 class B: pass
-[out]
-main:7: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 [case testFunctionArguments]
 import typing
 def f(x: 'A', y: 'B') -> None:
-  x = y # Fail
-  x = x
-  y = B()
+  if 1:
+    x = y # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    x = x
+    y = B()
 class A: pass
 class B: pass
-[out]
-main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testLocalVariableInitialization]
 import typing
@@ -245,29 +239,28 @@ a = __file__ # type: int  # E: Incompatible types in assignment (expression has 
 [case testLocalVariableShadowing]
 
 a = None # type: A
-a = B()       # Fail
-a = A()
+if 1:
+    a = B()  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    a = A()
 def f() -> None:
   a = None # type: B
-  a = A()     # Fail
-  a = B()
-a = B()       # Fail
+  if 1:
+      a = A()     # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+      a = B()
+a = B()       # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 a = A()
 
 class A: pass
 class B: pass
-[out]
-main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
-main:7: error: Incompatible types in assignment (expression has type "A", variable has type "B")
-main:9: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testGlobalDefinedInBlockWithType]
 
 class A: pass
 while A:
     a = None # type: A
-    a = A()
-    a = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+    if int():
+        a = A()
+        a = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
 
 
 -- # type: signatures

--- a/test-data/unit/check-bound.test
+++ b/test-data/unit/check-bound.test
@@ -14,19 +14,17 @@ T = TypeVar('T', bound=A)
 U = TypeVar('U')
 def f(x: T) -> T: pass
 def g(x: U) -> U:
-    return f(x) # Fail
+    return f(x) # E: Value of type variable "T" of "f" cannot be "U"
 
 f(A())
 f(B())
-f(D()) # Fail
+f(D()) # E: Value of type variable "T" of "f" cannot be "D"
 
 b = B()
-b = f(b)
-b = f(C()) # Fail
-[out]
-main:12: error: Value of type variable "T" of "f" cannot be "U"
-main:16: error: Value of type variable "T" of "f" cannot be "D"
-main:20: error: Incompatible types in assignment (expression has type "C", variable has type "B")
+if int():
+    b = f(b)
+if int():
+    b = f(C()) # E: Incompatible types in assignment (expression has type "C", variable has type "B")
 
 
 [case testBoundOnGenericClass]
@@ -200,6 +198,7 @@ def foo(x: int) -> int:
 
 a = 1
 b = foo(a)
-b = 'a' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    b = 'a' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 twice(a) # E: Value of type variable "T" of "twice" cannot be "int"
 [builtins fixtures/args.pyi]

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -103,7 +103,8 @@ s: str = n.a  # E: Incompatible types in assignment (expression has type "int", 
 i: int = n.b  # E: Incompatible types in assignment (expression has type "str", \
                           variable has type "int")
 x, y = n
-x = y  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    x = y  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testNewNamedTupleConstructorArgumentTypes]
 # flags: --python-version 3.6
@@ -131,9 +132,12 @@ class X(N):
 x = X(1, 2)  # E: Argument 2 to "X" has incompatible type "int"; expected "str"
 s = ''
 i = 0
-s = x.a  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-i, s = x
-s, s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    s = x.a  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    i, s = x
+if int():
+    s, s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testNewNamedTupleSelfTypeWithNamedTupleAsBase]
 # flags: --python-version 3.6
@@ -149,9 +153,10 @@ class B(A):
         self.f(self.b)  # E: Argument 1 to "f" of "B" has incompatible type "str"; expected "int"
         i = 0
         s = ''
-        i, s = self
-        i, i = self  # E: Incompatible types in assignment (expression has type "str", \
-                          variable has type "int")
+        if int():
+            i, s = self
+            i, i = self  # E: Incompatible types in assignment (expression has type "str", \
+                              variable has type "int")
 [out]
 
 [case testNewNamedTupleTypeReferenceToClassDerivedFrom]
@@ -166,15 +171,14 @@ class B(A):
     def f(self, x: 'B') -> None:
         i = 0
         s = ''
-        self = x
-        i, s = x
-        i, s = x.a, x.b
-        i, s = x.a, x.a  # E: Incompatible types in assignment (expression has type "int", \
-                              variable has type "str")
-        i, i = self  # E: Incompatible types in assignment (expression has type "str", \
-                          variable has type "int")
-
-[out]
+        if int():
+            self = x
+            i, s = x
+            i, s = x.a, x.b
+            i, s = x.a, x.a  # E: Incompatible types in assignment (expression has type "int", \
+                                  variable has type "str")
+            i, i = self  # E: Incompatible types in assignment (expression has type "str", \
+                              variable has type "int")
 
 [case testNewNamedTupleSubtyping]
 # flags: --python-version 3.6
@@ -188,13 +192,20 @@ class B(A): pass
 a = A(1, '')
 b = B(1, '')
 t: Tuple[int, str]
-b = a  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = t  # E: Incompatible types in assignment (expression has type "Tuple[int, str]", variable has type "A")
-b = t  # E: Incompatible types in assignment (expression has type "Tuple[int, str]", variable has type "B")
-t = a
-t = (1, '')
-t = b
-a = b
+if int():
+    b = a  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = t  # E: Incompatible types in assignment (expression has type "Tuple[int, str]", variable has type "A")
+if int():
+    b = t  # E: Incompatible types in assignment (expression has type "Tuple[int, str]", variable has type "B")
+if int():
+    t = a
+if int():
+    t = (1, '')
+if int():
+    t = b
+if int():
+    a = b
 
 [case testNewNamedTupleSimpleTypeInference]
 # flags: --python-version 3.6

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -73,7 +73,7 @@ main:4: error: Incompatible types in assignment (expression has type "object", v
 import typing
 class A:
     def f(self, a: 'A', b: 'B') -> None:
-        if 1:
+        if int():
             a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
             b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
             a = A()
@@ -952,7 +952,7 @@ class A:
         class B:
             def __init__(self, a: 'A') -> None: pass
         b = B(A())
-        if 1:
+        if int():
             b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
             b = B() # E: Too few arguments for "B"
 [out]
@@ -962,7 +962,7 @@ class A:
 def f() -> None:
     class A: pass
     a = None # type: A
-    if 1:
+    if int():
         a = A()
         a = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
 [out]
@@ -3114,7 +3114,7 @@ def new(uc: Type[U]) -> U:
     uc.foo()
     u = uc()
     u.foo()
-    if 1:
+    if int():
         u = uc(0)
         u.foo()
         u = uc('')  # Error
@@ -4403,7 +4403,7 @@ def parse_ast(name_dict: NameDict) -> None:
         pass
     x = name_dict['']
     reveal_type(x) # E: Revealed type is '__main__.NameInfo*'
-    if 1:
+    if int():
         x = NameInfo(Base()) # OK
         x = Base() # E: Incompatible types in assignment (expression has type "Base", variable has type "NameInfo")
 [builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -73,17 +73,15 @@ main:4: error: Incompatible types in assignment (expression has type "object", v
 import typing
 class A:
     def f(self, a: 'A', b: 'B') -> None:
-        a = B() # Fail
-        b = A() # Fail
-        a = A()
-        b = B()
-        a = a
-        a = b # Fail
+        if 1:
+            a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+            b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+            a = A()
+            b = B()
+            a = a
+            a = b # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 class B: pass
 [out]
-main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
-main:5: error: Incompatible types in assignment (expression has type "A", variable has type "B")
-main:9: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testReturnFromMethod]
 import typing
@@ -722,25 +720,25 @@ a.__init__(a)  # E: Cannot access "__init__" directly
 
 [case testDeepInheritanceHierarchy]
 import typing
-d = C() # type: D  # Fail
-d = B()      # Fail
-d = A()      # Fail
-d = D2()     # Fail
+d = C() # type: D  # E: Incompatible types in assignment (expression has type "C", variable has type "D")
+if int():
+    d = B()      # E: Incompatible types in assignment (expression has type "B", variable has type "D")
+if int():
+    d = A()      # E: Incompatible types in assignment (expression has type "A", variable has type "D")
+if int():
+    d = D2()     # E: Incompatible types in assignment (expression has type "D2", variable has type "D")
 a = D() # type: A
-a = D2()
+if int():
+    a = D2()
 b = D() # type: B
-b = D2()
+if int():
+    b = D2()
 
 class A: pass
 class B(A): pass
 class C(B): pass
 class D(C): pass
 class D2(C): pass
-[out]
-main:2: error: Incompatible types in assignment (expression has type "C", variable has type "D")
-main:3: error: Incompatible types in assignment (expression has type "B", variable has type "D")
-main:4: error: Incompatible types in assignment (expression has type "A", variable has type "D")
-main:5: error: Incompatible types in assignment (expression has type "D2", variable has type "D")
 
 
 -- Attribute access in class body
@@ -754,9 +752,11 @@ class A:
     x = B()
     y = x
     b = x # type: B
-    b = x
+    if int():
+        b = x
     c = x # type: A # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    c = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    if int():
+        c = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 [out]
 
 [case testMethodRefInClassBody]
@@ -766,10 +766,12 @@ class A:
     def f(self) -> None: pass
     g = f
     h = f # type: Callable[[A], None]
-    h = f
-    g = h
+    if int():
+        h = f
+        g = h
     ff = f # type: Callable[[B], None]  # E: Incompatible types in assignment (expression has type "Callable[[A], None]", variable has type "Callable[[B], None]")
-    g = ff                # E: Incompatible types in assignment (expression has type "Callable[[B], None]", variable has type "Callable[[A], None]")
+    if int():
+        g = ff  # E: Incompatible types in assignment (expression has type "Callable[[B], None]", variable has type "Callable[[A], None]")
 [out]
 
 
@@ -783,10 +785,14 @@ class B: pass
 class A:
     for x in [A()]:
         y = x
-        y = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    x = A()
-    y = A()
-    x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        if int():
+            y = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    if int():
+        x = A()
+    if int():
+        y = A()
+    if int():
+        x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 [builtins fixtures/for.pyi]
 [out]
 
@@ -933,8 +939,10 @@ import typing
 class A:
     class B: pass
     b = B()
-    b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-    b = B(b) # E: Too many arguments for "B"
+    if int():
+        b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+    if int():
+        b = B(b) # E: Too many arguments for "B"
 [out]
 
 [case testConstructNestedClassWithCustomInit]
@@ -944,8 +952,9 @@ class A:
         class B:
             def __init__(self, a: 'A') -> None: pass
         b = B(A())
-        b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-        b = B() # E: Too few arguments for "B"
+        if 1:
+            b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+            b = B() # E: Too few arguments for "B"
 [out]
 
 [case testDeclareVariableWithNestedClassType]
@@ -953,18 +962,21 @@ class A:
 def f() -> None:
     class A: pass
     a = None # type: A
-    a = A()
-    a = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+    if 1:
+        a = A()
+        a = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
 [out]
 
 [case testExternalReferenceToClassWithinClass]
-
 class A:
     class B: pass
 b = None # type: A.B
-b = A.B()
-b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-b = A.B(b) # E: Too many arguments for "B"
+if int():
+    b = A.B()
+if int():
+    b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b = A.B(b) # E: Too many arguments for "B"
 
 [case testAliasNestedClass]
 class Outer:
@@ -1654,8 +1666,9 @@ class A: pass
 class B: pass
 a = None  # type: A
 b = None  # type: B
-b = a # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = b
+if int():
+    b = a # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+    a = b
 [typing fixtures/typing-full.pyi]
 
 [case testDucktypeTransitivityDecorator]
@@ -1667,8 +1680,9 @@ class B: pass
 class C: pass
 a = None  # type: A
 c = None  # type: C
-c = a # E: Incompatible types in assignment (expression has type "A", variable has type "C")
-a = c
+if int():
+    c = a # E: Incompatible types in assignment (expression has type "A", variable has type "C")
+    a = c
 [typing fixtures/typing-full.pyi]
 
 
@@ -2576,7 +2590,8 @@ class B:
 integer = 0
 b = B()
 b.at = '3'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-integer = b.at  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    integer = b.at  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 -- CallableType objects
 -- ----------------
@@ -2589,9 +2604,12 @@ b = B()
 
 a()  # E: Too few arguments for "__call__" of "A"
 a(a, a)  # E: Too many arguments for "__call__" of "A"
-a = a(a)
-a = a(b)  # E: Argument 1 to "__call__" of "A" has incompatible type "B"; expected "A"
-b = a(a)  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = a(a)
+if int():
+    a = a(b)  # E: Argument 1 to "__call__" of "A" has incompatible type "B"; expected "A"
+if int():
+    b = a(a)  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 class A:
     def __call__(self, x: A) -> A:
@@ -2692,9 +2710,11 @@ C('') # E: No overload variant of "C" matches argument type "str" \
 import typing
 class A(int): pass
 n = 0
-n = A()
+if int():
+    n = A()
 a = A()
-a = 0 # E: Incompatible types in assignment (expression has type "int", variable has type "A")
+if int():
+    a = 0 # E: Incompatible types in assignment (expression has type "int", variable has type "A")
 
 [case testForwardReferenceToNestedClass]
 def f(o: 'B.C') -> None:
@@ -3094,19 +3114,20 @@ def new(uc: Type[U]) -> U:
     uc.foo()
     u = uc()
     u.foo()
-    u = uc(0)
-    u.foo()
-    u = uc('')
-    u.foo(0)
-    return uc()
+    if 1:
+        u = uc(0)
+        u.foo()
+        u = uc('')  # Error
+        u.foo(0)  # Error
+        return uc()
 u = new(User)
 [builtins fixtures/classmethod.pyi]
 [out]
-tmp/foo.pyi:16: error: No overload variant of "User" matches argument type "str"
-tmp/foo.pyi:16: note: Possible overload variant:
-tmp/foo.pyi:16: note:     def __init__(self, arg: int) -> U
-tmp/foo.pyi:16: note:     <1 more non-matching overload not shown>
-tmp/foo.pyi:17: error: Too many arguments for "foo" of "User"
+tmp/foo.pyi:17: error: No overload variant of "User" matches argument type "str"
+tmp/foo.pyi:17: note: Possible overload variant:
+tmp/foo.pyi:17: note:     def __init__(self, arg: int) -> U
+tmp/foo.pyi:17: note:     <1 more non-matching overload not shown>
+tmp/foo.pyi:18: error: Too many arguments for "foo" of "User"
 
 [case testTypeUsingTypeCInUpperBound]
 from typing import TypeVar, Type
@@ -4382,8 +4403,9 @@ def parse_ast(name_dict: NameDict) -> None:
         pass
     x = name_dict['']
     reveal_type(x) # E: Revealed type is '__main__.NameInfo*'
-    x = NameInfo(Base()) # OK
-    x = Base() # E: Incompatible types in assignment (expression has type "Base", variable has type "NameInfo")
+    if 1:
+        x = NameInfo(Base()) # OK
+        x = Base() # E: Incompatible types in assignment (expression has type "Base", variable has type "NameInfo")
 [builtins fixtures/isinstancelist.pyi]
 [out]
 
@@ -5209,8 +5231,10 @@ b: B
 c: C
 d: D
 d = A()  # E: Incompatible types in assignment (expression has type "A", variable has type "D")
-d = B()  # E: Incompatible types in assignment (expression has type "B", variable has type "D")
-d = C()  # E: Incompatible types in assignment (expression has type "C", variable has type "D")
+if int():
+    d = B()  # E: Incompatible types in assignment (expression has type "B", variable has type "D")
+if int():
+    d = C()  # E: Incompatible types in assignment (expression has type "C", variable has type "D")
 a = D()
 b = D()
 c = D()

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3114,7 +3114,7 @@ def new(uc: Type[U]) -> U:
     uc.foo()
     u = uc()
     u.foo()
-    if int():
+    if 1:
         u = uc(0)
         u.foo()
         u = uc('')  # Error

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -48,21 +48,21 @@ A().f(1, 'hello', 'hi') # E:1: Too many arguments for "f" of "A"
 # flags: --show-column-numbers
 x = 15
 y = 'hello'
-x = 2; y = x; y += 1
+if int():
+    x = 2; y = x; y += 1
 [out]
-main:4:8: error: Incompatible types in assignment (expression has type "int", variable has type "str")
-main:4:15: error: Unsupported operand types for + ("str" and "int")
+main:5:12: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+main:5:19: error: Unsupported operand types for + ("str" and "int")
 
 [case testColumnsSimpleIsinstance]
 # flags: --show-column-numbers
 import typing
 def f(x: object, n: int, s: str) -> None:
-    n = x # E:5: Incompatible types in assignment (expression has type "object", variable has type "int")
-    if isinstance(x, int):
-        n = x
-        s = x # E:9: Incompatible types in assignment (expression has type "int", variable has type "str")
-    n = x # E:5: Incompatible types in assignment (expression has type "object", variable has type "int")
+    if int():
+        n = x # E:9: Incompatible types in assignment (expression has type "object", variable has type "int")
+        if isinstance(x, int):
+            n = x
+            s = x # E:13: Incompatible types in assignment (expression has type "int", variable has type "str")
+        n = x # E:9: Incompatible types in assignment (expression has type "object", variable has type "int")
 [builtins fixtures/isinstance.pyi]
 [out]
-
-

--- a/test-data/unit/check-dynamic-typing.test
+++ b/test-data/unit/check-dynamic-typing.test
@@ -7,9 +7,12 @@ from typing import Any
 d = None # type: Any
 a = None # type: A
 
-a = d # Everything ok
-d = a
-d = d
+if int():
+    a = d # Everything ok
+if int():
+    d = a
+if int():
+    d = d
 d.x = a
 d.x = d
 
@@ -20,12 +23,17 @@ from typing import Any
 d = None # type: Any
 a, b = None, None # type: (A, B)
 
-d, a = b, b    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-d, d = d, d, d # E: Too many values to unpack (2 expected, 3 provided)
+if int():
+    d, a = b, b    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    d, d = d, d, d # E: Too many values to unpack (2 expected, 3 provided)
 
-a, b = d, d
-d, d = a, b
-a, b = d
+if int():
+    a, b = d, d
+if int():
+    d, d = a, b
+if int():
+    a, b = d
 s, t = d
 
 class A: pass
@@ -40,12 +48,17 @@ class B: pass
 from typing import Any
 a, b = None, None # type: (A, B)
 
-b = f(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b = f(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-a = f(a)
-a = f(b)
-a = f(None)
-a = f(f)
+if int():
+    a = f(a)
+if int():
+    a = f(b)
+if int():
+    a = f(None)
+if int():
+    a = f(f)
 
 def f(x: Any) -> 'A':
     pass
@@ -79,25 +92,43 @@ n = 0
 d in a  # E: Unsupported right operand type for in ("A")
 d and a
 d or a
-c = d and b # E: Incompatible types in assignment (expression has type "Union[Any, bool]", variable has type "C")
-c = d or b  # E: Incompatible types in assignment (expression has type "Union[Any, bool]", variable has type "C")
+if int():
+    c = d and b # E: Incompatible types in assignment (expression has type "Union[Any, bool]", variable has type "C")
+if int():
+    c = d or b  # E: Incompatible types in assignment (expression has type "Union[Any, bool]", variable has type "C")
 
-c = d + a
-c = d - a
-c = d * a
-c = d / a
-c = d // a
-c = d % a
-c = d ** a
-b = d == a
-b = d != a
-b = d < a
-b = d <= a
-b = d > a
-b = d >= a
-b = d in c
-b = d and b
-b = d or b
+if int():
+    c = d + a
+if int():
+    c = d - a
+if int():
+    c = d * a
+if int():
+    c = d / a
+if int():
+    c = d // a
+if int():
+    c = d % a
+if int():
+    c = d ** a
+if int():
+    b = d == a
+if int():
+    b = d != a
+if int():
+    b = d < a
+if int():
+    b = d <= a
+if int():
+    b = d > a
+if int():
+    b = d >= a
+if int():
+    b = d in c
+if int():
+    b = d and b
+if int():
+    b = d or b
 
 class A: pass
 class C:
@@ -122,22 +153,37 @@ n = 0
 
 a and d
 a or d
-c = a in d
-c = b and d # E: Incompatible types in assignment (expression has type "Union[bool, Any]", variable has type "C")
-c = b or d  # E: Incompatible types in assignment (expression has type "Union[bool, Any]", variable has type "C")
-b = a + d
-b = a / d
+if int():
+    c = a in d
+if int():
+    c = b and d # E: Incompatible types in assignment (expression has type "Union[bool, Any]", variable has type "C")
+if int():
+    c = b or d  # E: Incompatible types in assignment (expression has type "Union[bool, Any]", variable has type "C")
+if int():
+    b = a + d
+if int():
+    b = a / d
 
-c = a + d
-c = a - d
-c = a * d
-c = a / d
-c = a // d
-c = a % d
-c = a ** d
-b = a in d
-b = b and d
-b = b or d
+if int():
+    c = a + d
+if int():
+    c = a - d
+if int():
+    c = a * d
+if int():
+    c = a / d
+if int():
+    c = a // d
+if int():
+    c = a % d
+if int():
+    c = a ** d
+if int():
+    b = a in d
+if int():
+    b = b and d
+if int():
+    b = b or d
 
 class A:
     def __add__(self, a: 'A') -> 'C':
@@ -174,9 +220,11 @@ from typing import Any
 d = None # type: Any
 a = None # type: A
 b = None # type: bool
-a = not d # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
-b = not d
-a = -d
+if int():
+    a = not d # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
+if int():
+    b = not d
+    a = -d
 class A: pass
 [builtins fixtures/bool.pyi]
 [out]
@@ -186,10 +234,13 @@ from typing import Any
 d = None # type: Any
 a = None # type: A
 
-a = d.foo(a()) # E: "A" not callable
+if int():
+    a = d.foo(a()) # E: "A" not callable
 
-a = d.x
-a = d.foo(a, a)
+if int():
+    a = d.x
+if int():
+    a = d.foo(a, a)
 d.x = a
 d.x.y.z  # E: "A" has no attribute "y"
 
@@ -201,10 +252,12 @@ from typing import Any
 d = None # type: Any
 a = None # type: A
 
-a = d[a()] # E: "A" not callable
+if int():
+    a = d[a()] # E: "A" not callable
 d[a()] = a # E: "A" not callable
 
-a = d[a]
+if int():
+    a = d[a]
 d[a] = a
 d[a], d[a] = a, a
 
@@ -215,8 +268,10 @@ from typing import Tuple, Any
 t2 = None # type: Tuple[A, A]
 d = None # type: Any
 
-t2 = (d, d, d)  # E: Incompatible types in assignment (expression has type "Tuple[Any, Any, Any]", variable has type "Tuple[A, A]")
-t2 = (d, d)
+if int():
+    t2 = (d, d, d)  # E: Incompatible types in assignment (expression has type "Tuple[Any, Any, Any]", variable has type "Tuple[A, A]")
+if int():
+    t2 = (d, d)
 
 class A: pass
 [builtins fixtures/tuple.pyi]
@@ -228,10 +283,14 @@ class B: pass
 d = None # type: Any
 a = None # type: A
 b = None # type: B
-b = cast(A, d) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = cast(A, d)
-b = cast(Any, d)
-a = cast(Any, f())
+if int():
+    b = cast(A, d) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = cast(A, d)
+if int():
+    b = cast(Any, d)
+if int():
+    a = cast(Any, f())
 def f() -> None: pass
 
 [case testCompatibilityOfDynamicWithOtherTypes]
@@ -302,11 +361,14 @@ h = None # type: Callable[[A], None]
 
 f()     # E: Too few arguments for "f"
 f(x, x) # E: Too many arguments for "f"
-g = f   # E: Incompatible types in assignment (expression has type "Callable[[Any], Any]", variable has type "Callable[[], None]")
+if int():
+    g = f   # E: Incompatible types in assignment (expression has type "Callable[[Any], Any]", variable has type "Callable[[], None]")
 f(a)
 f(x)
-a = f(a)
-h = f
+if int():
+    a = f(a)
+if int():
+    h = f
 
 def f(x): pass
 
@@ -319,13 +381,19 @@ g1 = None # type: Callable[[A], None]
 g2 = None # type: Callable[[A, A], None]
 a = None # type: A
 
-g1 = f0 # E: Incompatible types in assignment (expression has type "Callable[[], Any]", variable has type "Callable[[A], None]")
-g2 = f0 # E: Incompatible types in assignment (expression has type "Callable[[], Any]", variable has type "Callable[[A, A], None]")
-g0 = f2 # E: Incompatible types in assignment (expression has type "Callable[[Any, Any], Any]", variable has type "Callable[[], None]")
-g1 = f2 # E: Incompatible types in assignment (expression has type "Callable[[Any, Any], Any]", variable has type "Callable[[A], None]")
+if int():
+    g1 = f0 # E: Incompatible types in assignment (expression has type "Callable[[], Any]", variable has type "Callable[[A], None]")
+if int():
+    g2 = f0 # E: Incompatible types in assignment (expression has type "Callable[[], Any]", variable has type "Callable[[A, A], None]")
+if int():
+    g0 = f2 # E: Incompatible types in assignment (expression has type "Callable[[Any, Any], Any]", variable has type "Callable[[], None]")
+if int():
+    g1 = f2 # E: Incompatible types in assignment (expression has type "Callable[[Any, Any], Any]", variable has type "Callable[[A], None]")
 
-g0 = g0
-g2 = f2
+if int():
+    g0 = g0
+if int():
+    g2 = f2
 f0()
 f2(a, a)
 
@@ -345,12 +413,15 @@ g2 = None # type: Callable[[A, A], None]
 g3 = None # type: Callable[[A, A, A], None]
 g4 = None # type: Callable[[A, A, A, A], None]
 
-f01(a, a)       # Fail
-f13()           # Fail
-f13(a, a, a, a) # Fail
-g2 = f01 # Fail
-g0 = f13 # Fail
-g4 = f13 # Fail
+f01(a, a)       # E: Too many arguments for "f01"
+f13()           # E: Too few arguments for "f13"
+f13(a, a, a, a) # E: Too many arguments for "f13"
+if int():
+    g2 = f01 # E: Incompatible types in assignment (expression has type "Callable[[Any], Any]", variable has type "Callable[[A, A], None]")
+if int():
+    g0 = f13 # E: Incompatible types in assignment (expression has type "Callable[[Any, Any, Any], Any]", variable has type "Callable[[], None]")
+if int():
+    g4 = f13 # E: Incompatible types in assignment (expression has type "Callable[[Any, Any, Any], Any]", variable has type "Callable[[A, A, A, A], None]")
 
 f01()
 f01(a)
@@ -358,27 +429,24 @@ f13(a)
 f13(a, a)
 f13(a, a, a)
 
-g0 = f01
-g1 = f01
-g1 = f13
-g2 = f13
-g3 = f13
+if int():
+    g0 = f01
+if int():
+    g1 = f01
+if int():
+    g1 = f13
+if int():
+    g2 = f13
+if int():
+    g3 = f13
 
 def f01(x = b): pass
 def f13(x, y = b, z = b): pass
 
 class A: pass
 class B: pass
-[out]
-main:10: error: Too many arguments for "f01"
-main:11: error: Too few arguments for "f13"
-main:12: error: Too many arguments for "f13"
-main:13: error: Incompatible types in assignment (expression has type "Callable[[Any], Any]", variable has type "Callable[[A, A], None]")
-main:14: error: Incompatible types in assignment (expression has type "Callable[[Any, Any, Any], Any]", variable has type "Callable[[], None]")
-main:15: error: Incompatible types in assignment (expression has type "Callable[[Any, Any, Any], Any]", variable has type "Callable[[A, A, A, A], None]")
 
 [case testSkipTypeCheckingWithImplicitSignature]
-
 a = None # type: A
 def f():
     a()
@@ -392,7 +460,6 @@ class A: pass
 [builtins fixtures/bool.pyi]
 
 [case testSkipTypeCheckingWithImplicitSignatureAndDefaultArgs]
-
 a = None # type: A
 def f(x=a()):
     a()
@@ -407,17 +474,22 @@ g1 = None # type: Callable[[A], None]
 g2 = None # type: Callable[[A, A], None]
 a = None # type: A
 
-g0 = a.f # E: Incompatible types in assignment (expression has type "Callable[[Any], Any]", variable has type "Callable[[], None]")
-g2 = a.f # E: Incompatible types in assignment (expression has type "Callable[[Any], Any]", variable has type "Callable[[A, A], None]")
-a = a.f  # E: Incompatible types in assignment (expression has type "Callable[[Any], Any]", variable has type "A")
+if int():
+    g0 = a.f # E: Incompatible types in assignment (expression has type "Callable[[Any], Any]", variable has type "Callable[[], None]")
+if int():
+    g2 = a.f # E: Incompatible types in assignment (expression has type "Callable[[Any], Any]", variable has type "Callable[[A, A], None]")
+if int():
+    a = a.f  # E: Incompatible types in assignment (expression has type "Callable[[Any], Any]", variable has type "A")
 
 class A:
     def g(self) -> None:
         a = self.f(a)
     def f(self, x): pass
 
-g1 = a.f
-a = a.f(a)
+if int():
+    g1 = a.f
+if int():
+    a = a.f(a)
 
 [case testSkipTypeCheckingImplicitMethod]
 
@@ -434,10 +506,13 @@ g0 = None # type: Callable[[], None]
 g1 = None # type: Callable[[A], None]
 a = None # type: A
 
-g0 = a.f # E: Incompatible types in assignment (expression has type "Callable[[Any], Any]", variable has type "Callable[[], None]")
+if int():
+    g0 = a.f # E: Incompatible types in assignment (expression has type "Callable[[Any], Any]", variable has type "Callable[[], None]")
 
-g1 = a.f
-a = a.f(a)
+if int():
+    g1 = a.f
+if int():
+    a = a.f(a)
 
 class B:
     def f(self, x):
@@ -475,17 +550,16 @@ f1 = None # type: Callable[[A], A]
 f2 = None # type: Callable[[A, A], A]
 a = None # type: A
 
-A(a)   # Fail
-f1 = A # Fail
+A(a)   # E: Too few arguments for "A"
+if int():
+    f1 = A # E: Incompatible types in assignment (expression has type "Type[A]", variable has type "Callable[[A], A]")
 
 A(a, a)
-f2 = A
+if int():
+    f2 = A
 
 class A:
   def __init__(self, a, b): pass
-[out]
-main:6: error: Too few arguments for "A"
-main:7: error: Incompatible types in assignment (expression has type "Type[A]", variable has type "Callable[[A], A]")
 
 [case testUsingImplicitTypeObjectWithIs]
 
@@ -509,6 +583,8 @@ t2 = None # type: Tuple[A, Any]
 t3 = None # type: Tuple[Any, Any]
 t4 = None # type: Tuple[A, A]
 t5 = None # type: Tuple[Any, Any, Any]
+
+def f(): t1, t2, t3, t4, t5 # Prevent redefinition
 
 t3 = t5 # E: Incompatible types in assignment (expression has type "Tuple[Any, Any, Any]", variable has type "Tuple[Any, Any]")
 t5 = t4 # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[Any, Any, Any]")
@@ -571,7 +647,8 @@ from typing import Any, Callable
 f1 = None # type: Callable[[Any], None]
 f2 = None # type: Callable[[Any, Any], None]
 
-f1 = f2 # E: Incompatible types in assignment (expression has type "Callable[[Any, Any], None]", variable has type "Callable[[Any], None]")
+if int():
+    f1 = f2 # E: Incompatible types in assignment (expression has type "Callable[[Any, Any], None]", variable has type "Callable[[Any], None]")
 
 
 -- Overriding

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -8,7 +8,8 @@ class Medal(Enum):
     bronze = 3
 reveal_type(Medal.bronze)  # E: Revealed type is '__main__.Medal'
 m = Medal.gold
-m = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "Medal")
+if int():
+    m = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "Medal")
 
 [case testEnumFromEnumMetaBasics]
 from enum import EnumMeta
@@ -21,7 +22,8 @@ class Medal(metaclass=EnumMeta):
     def __init__(self, *args): pass
 reveal_type(Medal.bronze)  # E: Revealed type is '__main__.Medal'
 m = Medal.gold
-m = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "Medal")
+if int():
+    m = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "Medal")
 
 [case testEnumFromEnumMetaSubclass]
 from enum import EnumMeta
@@ -34,7 +36,8 @@ class Medal(Achievement):
     def __init__(self, *args): pass
 reveal_type(Medal.bronze)  # E: Revealed type is '__main__.Medal'
 m = Medal.gold
-m = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "Medal")
+if int():
+    m = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "Medal")
 
 [case testEnumFromEnumMetaGeneric]
 from enum import EnumMeta
@@ -74,11 +77,11 @@ class N(IntEnum):
     x = 1
     y = 1
 n = 1
-n = N.x  # Subclass of int, so it's okay
+if int():
+    n = N.x  # Subclass of int, so it's okay
 s = ''
-s = N.y
-[out]
-main:8: error: Incompatible types in assignment (expression has type "N", variable has type "str")
+if int():
+    s = N.y # E: Incompatible types in assignment (expression has type "N", variable has type "str")
 
 [case testIntEnum_functionTakingIntEnum]
 from enum import IntEnum
@@ -220,10 +223,10 @@ class C(Flag):
     a = 1
     b = 2
 x = C.a
-x = 1
-x = x | C.b
-[out]
-main:6: error: Incompatible types in assignment (expression has type "int", variable has type "C")
+if int():
+    x = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "C")
+if int():
+    x = x | C.b
 
 [case testEnumIntFlag]
 from enum import IntFlag
@@ -231,10 +234,10 @@ class C(IntFlag):
     a = 1
     b = 2
 x = C.a
-x = 1
-x = x | C.b
-[out]
-main:6: error: Incompatible types in assignment (expression has type "int", variable has type "C")
+if int():
+    x = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "C")
+if int():
+    x = x | C.b
 
 [case testAnonymousEnum]
 from enum import Enum
@@ -258,9 +261,8 @@ class B:
         a = 1
 x = A.E.a
 y = B.E.a
-x = y
-[out]
-main:10: error: Incompatible types in assignment (expression has type "__main__.B.E", variable has type "__main__.A.E")
+if int():
+    x = y # E: Incompatible types in assignment (expression has type "__main__.B.E", variable has type "__main__.A.E")
 
 [case testFunctionalEnumString]
 from enum import Enum, IntEnum
@@ -389,9 +391,8 @@ class B:
     E = Enum('E', 'a b')
 x = A.E.a
 y = B.E.a
-x = y
-[out]
-main:8: error: Incompatible types in assignment (expression has type "__main__.B.E", variable has type "__main__.A.E")
+if int():
+    x = y # E: Incompatible types in assignment (expression has type "__main__.B.E", variable has type "__main__.A.E")
 
 [case testFunctionalEnumProtocols]
 from enum import IntEnum

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -33,26 +33,34 @@ class B(A): pass
 [case testIntLiteral]
 a = 0
 b = None # type: A
-b = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "A")
-a = 1
+if int():
+    b = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "A")
+if int():
+    a = 1
 class A:
     pass
 
 [case testStrLiteral]
 a = ''
 b = None # type: A
-b = 'x' # E: Incompatible types in assignment (expression has type "str", variable has type "A")
-a = 'x'
-a = r"x"
-a = """foo"""
+if int():
+    b = 'x' # E: Incompatible types in assignment (expression has type "str", variable has type "A")
+if int():
+    a = 'x'
+if int():
+    a = r"x"
+if int():
+    a = """foo"""
 class A:
     pass
 
 [case testFloatLiteral]
 a = 0.0
 b = None # type: A
-b = 1.1 # E: Incompatible types in assignment (expression has type "float", variable has type "A")
-a = 1.1
+if str():
+    b = 1.1 # E: Incompatible types in assignment (expression has type "float", variable has type "A")
+if str():
+    a = 1.1
 class A:
     pass
 [file builtins.py]
@@ -66,8 +74,10 @@ class str: pass
 [case testComplexLiteral]
 a = 0.0j
 b = None # type: A
-b = 1.1j # E: Incompatible types in assignment (expression has type "complex", variable has type "A")
-a = 1.1j
+if str():
+    b = 1.1j # E: Incompatible types in assignment (expression has type "complex", variable has type "A")
+if str():
+    a = 1.1j
 class A:
     pass
 [file builtins.py]
@@ -80,10 +90,14 @@ class str: pass
 
 [case testBytesLiteral]
 b, a = None, None # type: (bytes, A)
-b = b'foo'
-b = br"foo"
-b = b'''foo'''
-a = b'foo' # E: Incompatible types in assignment (expression has type "bytes", variable has type "A")
+if str():
+    b = b'foo'
+if str():
+    b = br"foo"
+if str():
+    b = b'''foo'''
+if str():
+    a = b'foo' # E: Incompatible types in assignment (expression has type "bytes", variable has type "A")
 class A: pass
 [file builtins.py]
 class object:
@@ -96,9 +110,11 @@ class str: pass
 
 [case testUnicodeLiteralInPython3]
 s = None  # type: str
-s = u'foo'
+if int():
+    s = u'foo'
 b = None  # type: bytes
-b = u'foo' # E: Incompatible types in assignment (expression has type "str", variable has type "bytes")
+if int():
+    b = u'foo' # E: Incompatible types in assignment (expression has type "str", variable has type "bytes")
 [builtins fixtures/primitives.pyi]
 
 
@@ -107,28 +123,15 @@ b = u'foo' # E: Incompatible types in assignment (expression has type "str", var
 
 
 [case testAdd]
-
 a, b, c = None, None, None # type: (A, B, C)
-c = a + c  # Fail
-a = a + b  # Fail
-c = b + a  # Fail
-c = a + b
-
-class A:
-    def __add__(self, x: 'B') -> 'C': pass
-class B: pass
-class C: pass
-[out]
-main:3: error: Unsupported operand types for + ("A" and "C")
-main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
-main:5: error: Unsupported left operand type for + ("B")
-[case testAdd]
-
-a, b, c = None, None, None # type: (A, B, C)
-c = a + c  # Fail
-a = a + b  # Fail
-c = b + a  # Fail
-c = a + b
+if int():
+    c = a + c  # E: Unsupported operand types for + ("A" and "C")
+if int():
+    a = a + b  # E: Incompatible types in assignment (expression has type "C", variable has type "A")
+if int():
+    c = b + a  # E: Unsupported left operand type for + ("B")
+if int():
+    c = a + b
 
 class A:
     def __add__(self, x: 'B') -> 'C':
@@ -137,18 +140,17 @@ class B:
     pass
 class C:
     pass
-[out]
-main:3: error: Unsupported operand types for + ("A" and "C")
-main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
-main:5: error: Unsupported left operand type for + ("B")
 
 [case testSub]
-
 a, b, c = None, None, None # type: (A, B, C)
-c = a - c  # Fail
-a = a - b  # Fail
-c = b - a  # Fail
-c = a - b
+if int():
+    c = a - c  # E: Unsupported operand types for - ("A" and "C")
+if int():
+    a = a - b  # E: Incompatible types in assignment (expression has type "C", variable has type "A")
+if int():
+    c = b - a  # E: Unsupported left operand type for - ("B")
+if int():
+    c = a - b
 
 class A:
     def __sub__(self, x: 'B') -> 'C':
@@ -157,18 +159,17 @@ class B:
     pass
 class C:
     pass
-[out]
-main:3: error: Unsupported operand types for - ("A" and "C")
-main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
-main:5: error: Unsupported left operand type for - ("B")
 
 [case testMul]
-
 a, b, c = None, None, None # type: (A, B, C)
-c = a * c  # Fail
-a = a * b  # Fail
-c = b * a  # Fail
-c = a * b
+if int():
+    c = a * c  # E: Unsupported operand types for * ("A" and "C")
+if int():
+    a = a * b  # E: Incompatible types in assignment (expression has type "C", variable has type "A")
+if int():
+    c = b * a  # E: Unsupported left operand type for * ("B")
+if int():
+    c = a * b
 
 class A:
     def __mul__(self, x: 'B') -> 'C':
@@ -177,17 +178,17 @@ class B:
     pass
 class C:
     pass
-[out]
-main:3: error: Unsupported operand types for * ("A" and "C")
-main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
-main:5: error: Unsupported left operand type for * ("B")
 
 [case testMatMul]
 a, b, c = None, None, None # type: (A, B, C)
-c = a @ c  # E: Unsupported operand types for @ ("A" and "C")
-a = a @ b  # E: Incompatible types in assignment (expression has type "C", variable has type "A")
-c = b @ a  # E: Unsupported left operand type for @ ("B")
-c = a @ b
+if int():
+    c = a @ c  # E: Unsupported operand types for @ ("A" and "C")
+if int():
+    a = a @ b  # E: Incompatible types in assignment (expression has type "C", variable has type "A")
+if int():
+    c = b @ a  # E: Unsupported left operand type for @ ("B")
+if int():
+    c = a @ b
 
 class A:
     def __matmul__(self, x: 'B') -> 'C':
@@ -198,12 +199,14 @@ class C:
     pass
 
 [case testDiv]
-
 a, b, c = None, None, None # type: (A, B, C)
-c = a / c  # Fail
-a = a / b  # Fail
-c = b / a  # Fail
-c = a / b
+if int():
+    c = a / c  # E: Unsupported operand types for / ("A" and "C")
+    a = a / b  # E: Incompatible types in assignment (expression has type "C", variable has type "A")
+if int():
+    c = b / a  # E: Unsupported left operand type for / ("B")
+if int():
+    c = a / b
 
 class A:
     def __truediv__(self, x: 'B') -> 'C':
@@ -212,18 +215,16 @@ class B:
     pass
 class C:
     pass
-[out]
-main:3: error: Unsupported operand types for / ("A" and "C")
-main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
-main:5: error: Unsupported left operand type for / ("B")
 
 [case testIntDiv]
-
 a, b, c = None, None, None # type: (A, B, C)
-c = a // c  # Fail
-a = a // b  # Fail
-c = b // a  # Fail
-c = a // b
+if int():
+    c = a // c  # E: Unsupported operand types for // ("A" and "C")
+    a = a // b  # E: Incompatible types in assignment (expression has type "C", variable has type "A")
+if int():
+    c = b // a  # E: Unsupported left operand type for // ("B")
+if int():
+    c = a // b
 
 class A:
     def __floordiv__(self, x: 'B') -> 'C':
@@ -232,18 +233,17 @@ class B:
     pass
 class C:
     pass
-[out]
-main:3: error: Unsupported operand types for // ("A" and "C")
-main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
-main:5: error: Unsupported left operand type for // ("B")
 
 [case testMod]
-
 a, b, c = None, None, None # type: (A, B, C)
-c = a % c  # Fail
-a = a % b  # Fail
-c = b % a  # Fail
-c = a % b
+if int():
+    c = a % c  # E: Unsupported operand types for % ("A" and "C")
+if int():
+    a = a % b  # E: Incompatible types in assignment (expression has type "C", variable has type "A")
+if int():
+    c = b % a  # E: Unsupported left operand type for % ("B")
+if int():
+    c = a % b
 
 class A:
     def __mod__(self, x: 'B') -> 'C':
@@ -252,18 +252,17 @@ class B:
     pass
 class C:
     pass
-[out]
-main:3: error: Unsupported operand types for % ("A" and "C")
-main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
-main:5: error: Unsupported left operand type for % ("B")
 
 [case testPow]
-
 a, b, c = None, None, None # type: (A, B, C)
-c = a ** c  # Fail
-a = a ** b  # Fail
-c = b ** a  # Fail
-c = a ** b
+if int():
+    c = a ** c  # E: Unsupported operand types for ** ("A" and "C")
+if int():
+    a = a ** b  # E: Incompatible types in assignment (expression has type "C", variable has type "A")
+if int():
+    c = b ** a  # E: Unsupported left operand type for ** ("B")
+if int():
+    c = a ** b
 
 class A:
     def __pow__(self, x: 'B') -> 'C':
@@ -272,10 +271,6 @@ class B:
     pass
 class C:
     pass
-[out]
-main:3: error: Unsupported operand types for ** ("A" and "C")
-main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
-main:5: error: Unsupported left operand type for ** ("B")
 
 [case testMiscBinaryOperators]
 
@@ -306,14 +301,19 @@ main:6: error: Unsupported operand types for << ("A" and "B")
 main:7: error: Unsupported operand types for >> ("A" and "A")
 
 [case testBooleanAndOr]
-
 a, b = None, None # type: (A, bool)
-b = b and b
-b = b or b
-b = b and a # E: Incompatible types in assignment (expression has type "Union[bool, A]", variable has type "bool")
-b = a and b # E: Incompatible types in assignment (expression has type "Union[A, bool]", variable has type "bool")
-b = b or a  # E: Incompatible types in assignment (expression has type "Union[bool, A]", variable has type "bool")
-b = a or b  # E: Incompatible types in assignment (expression has type "Union[A, bool]", variable has type "bool")
+if int():
+    b = b and b
+if int():
+    b = b or b
+if int():
+    b = b and a # E: Incompatible types in assignment (expression has type "Union[bool, A]", variable has type "bool")
+if int():
+    b = a and b # E: Incompatible types in assignment (expression has type "Union[A, bool]", variable has type "bool")
+if int():
+    b = b or a  # E: Incompatible types in assignment (expression has type "Union[bool, A]", variable has type "bool")
+if int():
+    b = a or b  # E: Incompatible types in assignment (expression has type "Union[A, bool]", variable has type "bool")
 class A: pass
 
 [builtins fixtures/bool.pyi]
@@ -344,14 +344,19 @@ reveal_type(s and b or b)  # E: Revealed type is 'builtins.bool'
 [builtins fixtures/bool.pyi]
 
 [case testNonBooleanOr]
-
 c, d, b = None, None, None # type: (C, D, bool)
-c = c or c
-c = c or d
-c = d or c
-b = c or c # E: Incompatible types in assignment (expression has type "C", variable has type "bool")
-d = c or d # E: Incompatible types in assignment (expression has type "C", variable has type "D")
-d = d or c # E: Incompatible types in assignment (expression has type "C", variable has type "D")
+if int():
+    c = c or c
+if int():
+    c = c or d
+if int():
+    c = d or c
+if int():
+    b = c or c # E: Incompatible types in assignment (expression has type "C", variable has type "bool")
+if int():
+    d = c or d # E: Incompatible types in assignment (expression has type "C", variable has type "D")
+if int():
+    d = d or c # E: Incompatible types in assignment (expression has type "C", variable has type "D")
 class C: pass
 class D(C): pass
 [builtins fixtures/bool.pyi]
@@ -359,14 +364,22 @@ class D(C): pass
 [case testInOperator]
 from typing import Iterator, Iterable, Any
 a, b, c, d, e = None, None, None, None, None # type: (A, B, bool, D, Any)
-c = c in a  # Fail
-a = b in a  # Fail
-c = a in b  # Fail
-c = b in d  # Fail
-c = b in a
-c = a in d
-c = e in d
-c = a in e
+if int():
+    c = c in a  # E: Unsupported operand types for in ("bool" and "A")
+if int():
+    a = b in a  # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
+if int():
+    c = a in b  # E: Unsupported right operand type for in ("B")
+if int():
+    c = b in d  # E: Unsupported operand types for in ("B" and "D")
+if int():
+    c = b in a
+if int():
+    c = a in d
+if int():
+    c = e in d
+if int():
+    c = a in e
 
 class A:
     def __contains__(self, x: 'B') -> bool: pass
@@ -374,23 +387,26 @@ class B: pass
 class D(Iterable[A]):
     def __iter__(self) -> Iterator[A]: pass
 [builtins fixtures/bool.pyi]
-[out]
-main:3: error: Unsupported operand types for in ("bool" and "A")
-main:4: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main:5: error: Unsupported right operand type for in ("B")
-main:6: error: Unsupported operand types for in ("B" and "D")
 
 [case testNotInOperator]
 from typing import Iterator, Iterable, Any
 a, b, c, d, e = None, None, None, None, None # type: (A, B, bool, D, Any)
-c = c not in a  # Fail
-a = b not in a  # Fail
-c = a not in b  # Fail
-c = b not in d  # Fail
-c = b not in a
-c = a not in d
-c = e in d
-c = a in e
+if int():
+    c = c not in a  # E: Unsupported operand types for in ("bool" and "A")
+if int():
+    a = b not in a  # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
+if int():
+    c = a not in b  # E: Unsupported right operand type for in ("B")
+if int():
+    c = b not in d  # E: Unsupported operand types for in ("B" and "D")
+if int():
+    c = b not in a
+if int():
+    c = a not in d
+if int():
+    c = e in d
+if int():
+    c = a in e
 
 class A:
     def __contains__(self, x: 'B') -> bool: pass
@@ -398,47 +414,45 @@ class B: pass
 class D(Iterable[A]):
     def __iter__(self) -> Iterator[A]: pass
 [builtins fixtures/bool.pyi]
-[out]
-main:3: error: Unsupported operand types for in ("bool" and "A")
-main:4: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main:5: error: Unsupported right operand type for in ("B")
-main:6: error: Unsupported operand types for in ("B" and "D")
 
 [case testNonBooleanContainsReturnValue]
-
 a, b = None, None # type: (A, bool)
-b = a not in a
-b = a in a
+if int():
+    b = a not in a
+if int():
+    b = a in a # E: Incompatible types in assignment (expression has type "object", variable has type "bool")
 
 class A:
   def __contains__(self, x: 'A') -> object: pass
 [builtins fixtures/bool.pyi]
-[out]
-main:4: error: Incompatible types in assignment (expression has type "object", variable has type "bool")
 
 [case testEq]
 
 a, b = None, None # type: (A, bool)
-a = a == b # Fail
-a = a != b # Fail
-b = a == b
-b = a != b
+if int():
+    a = a == b # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
+if int():
+    a = a != b # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
+if int():
+    b = a == b
+if int():
+    b = a != b
 
 class A:
   def __eq__(self, o: object) -> bool: pass
   def __ne__(self, o: object) -> bool: pass
 [builtins fixtures/bool.pyi]
-[out]
-main:3: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main:4: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 [case testLtAndGt]
-
 a, b, bo = None, None, None # type: (A, B, bool)
-a = a < b # Fail
-a = a > b # Fail
-bo = a < b
-bo = a > b
+if int():
+    a = a < b # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
+if int():
+    a = a > b # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
+if int():
+    bo = a < b
+if int():
+    bo = a > b
 
 class A:
     def __lt__(self, o: 'B') -> bool: pass
@@ -447,9 +461,6 @@ class B:
     def __lt__(self, o: 'B') -> bool: pass
     def __gt__(self, o: 'B') -> bool: pass
 [builtins fixtures/bool.pyi]
-[out]
-main:3: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main:4: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 [case testCmp_python2]
 
@@ -504,12 +515,15 @@ class B:
 [builtins fixtures/bool.pyi]
 
 [case testLeAndGe]
-
 a, b, bo = None, None, None # type: (A, B, bool)
-a = a <= b # Fail
-a = a >= b # Fail
-bo = a <= b
-bo = a >= b
+if int():
+    a = a <= b # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
+if int():
+    a = a >= b # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
+if int():
+    bo = a <= b
+if int():
+    bo = a >= b
 
 class A:
     def __le__(self, o: 'B') -> bool: pass
@@ -518,9 +532,6 @@ class B:
     def __le__(self, o: 'B') -> bool: pass
     def __ge__(self, o: 'B') -> bool: pass
 [builtins fixtures/bool.pyi]
-[out]
-main:3: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main:4: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 [case testChainedComp]
 
@@ -543,10 +554,11 @@ main:5: error: Unsupported operand types for > ("A" and "A")
 
 
 [case testChainedCompBoolRes]
-
 a, b, bo = None, None, None # type: (A, B, bool)
-bo = a < b < b
-a = a < b < b # Fail
+if int():
+    bo = a < b < b
+if int():
+    a = a < b < b # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 class A:
     def __lt__(self, o: 'B') -> bool: pass
@@ -555,19 +567,21 @@ class B:
     def __lt__(self, o: 'B') -> bool: pass
     def __gt__(self, o: 'B') -> bool: pass
 [builtins fixtures/bool.pyi]
-[out]
-main:4: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 
 [case testChainedCompResTyp]
-
 x, y = None, None # type: (X, Y)
 a, b, p, bo = None, None, None, None # type: (A, B, P, bool)
-b = y == y == y
-bo = y == y == y # Fail
-a = x < y
-a = x < y == y # Fail
-p = x < y == y
+if int():
+    b = y == y == y
+if int():
+    bo = y == y == y # E: Incompatible types in assignment (expression has type "B", variable has type "bool")
+if int():
+    a = x < y
+if int():
+    a = x < y == y # E: Incompatible types in assignment (expression has type "P", variable has type "A")
+if int():
+    p = x < y == y
 
 class P:
     pass
@@ -584,34 +598,33 @@ class Y:
     def __gt__(self, o: 'Y') -> A: pass
     def __eq__(self, o: 'Y') -> B: pass
 [builtins fixtures/bool.pyi]
-[out]
-main:5: error: Incompatible types in assignment (expression has type "B", variable has type "bool")
-main:7: error: Incompatible types in assignment (expression has type "P", variable has type "A")
 
 
 [case testIs]
-
 a, b = None, None # type: (A, bool)
-a = a is b # Fail
-b = a is b
-b = b is a
-b = a is None
+if int():
+    a = a is b # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
+if int():
+    b = a is b
+if int():
+    b = b is a
+if int():
+    b = a is None
 class A: pass
 [builtins fixtures/bool.pyi]
-[out]
-main:3: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 [case testIsNot]
-
 a, b = None, None # type: (A, bool)
-a = a is not b # Fail
-b = a is not b
-b = b is not a
-b = a is not None
+if int():
+    a = a is not b # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
+if int():
+    b = a is not b
+if int():
+    b = b is not a
+if int():
+    b = a is not None
 class A: pass
 [builtins fixtures/bool.pyi]
-[out]
-main:3: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 [case testIsRightOperand]
 
@@ -628,20 +641,23 @@ class B:
     def __radd__(self, x: A) -> str: pass
 s = None  # type: str
 n = None  # type: int
-n = A() + 1
-s = A() + B()
-n = A() + B() # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    n = A() + 1
+if int():
+    s = A() + B()
+if int():
+    n = A() + B() # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testReverseBinaryOperator2]
-
 class A:
     def __add__(self, x: 'A') -> object: pass
 class B:
     def __radd__(self, x: A) -> str: pass
 s = None  # type: str
 n = None  # type: int
-s = A() + B()
-n = A() + B() # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    s = A() + B()
+    n = A() + B() # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testReverseBinaryOperator3]
 
@@ -660,7 +676,6 @@ class A: pass
 A() + cast(Any, 1)
 
 [case testReverseComparisonOperator]
-
 class C:
     def __gt__(self, x: 'A') -> object: pass
 class A:
@@ -669,10 +684,12 @@ class B:
     def __gt__(self, x: A) -> str: pass
 s = None  # type: str
 n = None  # type: int
-n = A() < C()
-s = A() < B()
-n = A() < B() # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-s = object() < B() # E: Unsupported operand types for > ("B" and "object")
+if int():
+    n = A() < C()
+    s = A() < B()
+if int():
+    n = A() < B() # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+    s = object() < B() # E: Unsupported operand types for > ("B" and "object")
 
 [case testReversibleComparisonWithExtraArgument]
 class C:
@@ -762,62 +779,60 @@ divmod('foo', d)  # E: Unsupported operand types for divmod ("str" and "Decimal"
 [case testUnaryMinus]
 
 a, b = None, None # type: (A, B)
-a = -a   # Fail
-b = -b   # Fail
-b = -a
+if int():
+    a = -a   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    b = -b   # E: Unsupported operand type for unary - ("B")
+if int():
+    b = -a
 
 class A:
     def __neg__(self) -> 'B':
         pass
 class B:
     pass
-[out]
-main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
-main:4: error: Unsupported operand type for unary - ("B")
 
 [case testUnaryPlus]
-
 a, b = None, None # type: (A, B)
-a = +a   # Fail
-b = +b   # Fail
-b = +a
+if int():
+    a = +a   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    b = +b   # E: Unsupported operand type for unary + ("B")
+if int():
+    b = +a
 
 class A:
     def __pos__(self) -> 'B':
         pass
 class B:
     pass
-[out]
-main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
-main:4: error: Unsupported operand type for unary + ("B")
 
 [case testUnaryNot]
-
 a, b = None, None # type: (A, bool)
-a = not b  # Fail
-b = not a
-b = not b
+if int():
+    a = not b  # E: Incompatible types in assignment (expression has type "bool", variable has type "A")
+if int():
+    b = not a
+if int():
+    b = not b
 class A:
     pass
 [builtins fixtures/bool.pyi]
-[out]
-main:3: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 [case testUnaryBitwiseNeg]
-
 a, b = None, None # type: (A, B)
-a = ~a   # Fail
-b = ~b   # Fail
-b = ~a
+if int():
+    a = ~a   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    b = ~b   # E: Unsupported operand type for ~ ("B")
+if int():
+    b = ~a
 
 class A:
     def __invert__(self) -> 'B':
         pass
 class B:
     pass
-[out]
-main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
-main:4: error: Unsupported operand type for ~ ("B")
 
 
 -- Indexing
@@ -827,20 +842,20 @@ main:4: error: Unsupported operand type for ~ ("B")
 [case testIndexing]
 
 a, b, c = None, None, None # type: (A, B, C)
-c = a[c]  # Fail
-a = a[b]  # Fail
-c = b[a]  # Fail
-c = a[b]
+if int():
+    c = a[c]  # E: Invalid index type "C" for "A"; expected type "B"
+if int():
+    a = a[b]  # E: Incompatible types in assignment (expression has type "C", variable has type "A")
+if int():
+    c = b[a]  # E: Value of type "B" is not indexable
+if int():
+    c = a[b]
 
 class A:
     def __getitem__(self, x: 'B') -> 'C':
         pass
 class B: pass
 class C: pass
-[out]
-main:3: error: Invalid index type "C" for "A"; expected type "B"
-main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
-main:5: error: Value of type "B" is not indexable
 
 [case testIndexingAsLvalue]
 
@@ -876,10 +891,14 @@ a[1]  # E: No overload variant of "__getitem__" of "A" matches argument type "in
       # N:     def __getitem__(self, C) -> str
 
 i, s = None, None  # type: (int, str)
-i = a[b]
-s = a[b]  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-i = a[c]  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-s = a[c]
+if int():
+    i = a[b]
+if int():
+    s = a[b]  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    i = a[c]  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    s = a[c]
 
 class A:
     @overload
@@ -904,16 +923,22 @@ class B: pass
 class C(A): pass
 a, b, c = None, None, None # type: (A, B, C)
 
-a = cast(A, a())       # E: "A" not callable
-a = cast(Any, a())     # E: "A" not callable
-b = cast(A, a)         # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = cast(A, a())       # E: "A" not callable
+if int():
+    a = cast(Any, a())     # E: "A" not callable
+    b = cast(A, a)         # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-a = cast(A, b)
-a = cast(A, a)
-c = cast(C, a)
-a = cast(A, c)
-a = cast(Any, b)
-b = cast(Any, a)
+if int():
+    a = cast(A, b)
+if int():
+    a = cast(A, a)
+    c = cast(C, a)
+if int():
+    a = cast(A, c)
+if int():
+    a = cast(Any, b)
+    b = cast(Any, a)
 [out]
 
 [case testAnyCast]
@@ -933,12 +958,15 @@ main:3: error: "A" not callable
 
 
 [case testNoneReturnTypeBasics]
-
 a, o = None, None # type: (A, object)
-a = f()         # E: "f" does not return a value
-o = a()         # E: Function does not return a value
-o = A().g(a)    # E: "g" of "A" does not return a value
-o = A.g(a, a)   # E: "g" of "A" does not return a value
+if int():
+    a = f()         # E: "f" does not return a value
+if int():
+    o = a()         # E: Function does not return a value
+if int():
+    o = A().g(a)    # E: "g" of "A" does not return a value
+if int():
+    o = A.g(a, a)   # E: "g" of "A" does not return a value
 A().g(f())      # E: "f" does not return a value
 x: A = f()      # E: "f" does not return a value
 f()
@@ -1014,17 +1042,24 @@ class A:
 
 
 [case testGetSlice]
-
 a, b = None, None # type: (A, B)
-a = a[1:2] # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-a = a[1:]  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-a = a[:2]  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-a = a[:]   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    a = a[1:2] # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    a = a[1:]  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    a = a[:2]  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    a = a[:]   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 
-b = a[1:2]
-b = a[1:]
-b = a[:2]
-b = a[:]
+if int():
+    b = a[1:2]
+if int():
+    b = a[1:]
+if int():
+    b = a[:2]
+if int():
+    b = a[:]
 
 class A:
   def __getitem__(self, s: slice) -> 'B': pass
@@ -1254,12 +1289,12 @@ u'%s' % (u'abc',)
 [case testTrivialLambda]
 from typing import Callable
 f = lambda: 1 # type: Callable[[], int]
-f = lambda: ''.x
-f = lambda: ''
-[out]
-main:3: error: "str" has no attribute "x"
-main:4: error: Incompatible types in assignment (expression has type "Callable[[], str]", variable has type "Callable[[], int]")
-main:4: error: Incompatible return value type (got "str", expected "int")
+if int():
+    f = lambda: ''.x # E: "str" has no attribute "x"
+if int():
+    f = lambda: '' \
+        # E: Incompatible types in assignment (expression has type "Callable[[], str]", variable has type "Callable[[], int]") \
+        # E: Incompatible return value type (got "str", expected "int")
 
 [case testVoidLambda]
 import typing
@@ -1315,10 +1350,12 @@ def f(x: int): pass
 
 [case testListComprehensionWithNonDirectMapping]
 from typing import List
-a = None # type: List[A]
-b = None # type: List[B]
-b = [f(x) for x in a]
-a = [f(x) for x in a] # E: List comprehension has incompatible type List[B]; expected List[A]
+a: List[A]
+b: List[B]
+if int():
+    b = [f(x) for x in a]
+if int():
+    a = [f(x) for x in a] # E: List comprehension has incompatible type List[B]; expected List[A]
 ([f(x) for x in b])   # E: Argument 1 to "f" has incompatible type "B"; expected "A"
 class A: pass
 class B: pass
@@ -1386,7 +1423,7 @@ main:6: error: Incompatible types in assignment (expression has type "Dict[A, B]
 
 [case testDictionaryComprehensionWithNonDirectMapping]
 from typing import Dict, List, Tuple
-abd = None # type: Dict[A, B]
+abd: Dict[A, B]
 abl = None # type: List[Tuple[A, B]]
 abd = {a: f(b) for a, b in abl}
 class A: pass
@@ -1408,9 +1445,11 @@ from typing import Iterator
 # The implementation is mostly identical to list comprehensions, so only a few
 # test cases is ok.
 a = None # type: Iterator[int]
-a = (x for x in a)
+if int():
+    a = (x for x in a)
 b = None # type: Iterator[str]
-b = (x for x in a) # E: Generator has incompatible item type "int"; expected "str"
+if int():
+    b = (x for x in a) # E: Generator has incompatible item type "int"; expected "str"
 [builtins fixtures/for.pyi]
 
 [case testGeneratorIncompatibleErrorMessage]
@@ -1418,7 +1457,8 @@ from typing import Callable, Iterator, List
 
 a = []  # type: List[Callable[[], str]]
 b = None  # type: Iterator[Callable[[], int]]
-b = (x for x in a)  # E: Generator has incompatible item type "Callable[[], str]"; expected "Callable[[], int]"
+if int():
+    b = (x for x in a)  # E: Generator has incompatible item type "Callable[[], str]"; expected "Callable[[], int]"
 [builtins fixtures/list.pyi]
 
 -- Conditional expressions
@@ -1429,8 +1469,10 @@ b = (x for x in a)  # E: Generator has incompatible item type "Callable[[], str]
 import typing
 y = ''
 x = 1 if y else 2
-x = 3
-x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    x = 3
+if int():
+    x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testConditionalExpressionWithEmptyCondition]
 import typing
@@ -1442,18 +1484,24 @@ import typing
 class A: pass
 class B(A): pass
 x = B() if bool() else A()
-x = A()
-x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "A")
+if int():
+    x = A()
+if int():
+    x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "A")
 y = A() if bool() else B()
-y = A()
-y = '' # E: Incompatible types in assignment (expression has type "str", variable has type "A")
+if int():
+    y = A()
+if int():
+    y = '' # E: Incompatible types in assignment (expression has type "str", variable has type "A")
 [builtins fixtures/bool.pyi]
 
 [case testConditionalExpressionAndTypeContext]
 import typing
 x = [1] if bool() else []
-x = [1]
-x = ['x'] # E: List item 0 has incompatible type "str"; expected "int"
+if int():
+    x = [1]
+if int():
+    x = ['x'] # E: List item 0 has incompatible type "str"; expected "int"
 [builtins fixtures/list.pyi]
 
 [case testConditionalExpressionUnion]
@@ -1564,10 +1612,12 @@ class C(B):
 [case testEllipsis]
 
 a = None # type: A
-a = ...  # E: Incompatible types in assignment (expression has type "ellipsis", variable has type "A")
+if str():
+    a = ...  # E: Incompatible types in assignment (expression has type "ellipsis", variable has type "A")
 b = ...
 c = ...
-b = c
+if str():
+    b = c
 ....__class__
 ....a  # E: "ellipsis" has no attribute "a"
 

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -339,7 +339,7 @@ class C:
 from typing import Final
 
 x: Final = 1
-x
+x  # Dummy reference to allow renaming once implemented
 x = 2  # E: Cannot assign to final name "x"
 def f() -> int:
     global x
@@ -353,7 +353,7 @@ def f2() -> None:
     x2 = 1  # E: Cannot assign to final name "x2"
 
 y = 1
-y
+y  # Dummy reference to allow renaming once implemented
 y: Final = 2  # E: Name 'y' already defined on line 17 \
               # E: Cannot redefine an existing name as final
 y = 3  # No error here, first definition wins

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -339,22 +339,28 @@ class C:
 from typing import Final
 
 x: Final = 1
+x
 x = 2  # E: Cannot assign to final name "x"
 def f() -> int:
     global x
-    x = 3  # E: Cannot assign to final name "x"
+    x = 3  # No error here is okay since we reported an error above
     return x
 
+x2: Final = 1
+x2
+def f2() -> None:
+    global x2
+    x2 = 1  # E: Cannot assign to final name "x2"
+
 y = 1
-y: Final = 2  # E: Name 'y' already defined on line 10 \
-              # E: Cannot redefine an existing name as final
-y = 3  # No error here, first definition wins
+y
+y: Final = 2  # E: Cannot redefine an existing name as final
+y = 3  # E: Cannot assign to final name "y"
 
 z: Final = 1
-z: Final = 2  # E: Name 'z' already defined on line 14 \
+z: Final = 2  # E: Name 'z' already defined on line 22 \
               # E: Cannot redefine an existing name as final
 z = 3  # E: Cannot assign to final name "z"
-[out]
 
 [case testFinalReassignModuleReexport]
 from typing import Final
@@ -414,7 +420,7 @@ class C:
     x: Final = 1
     x = 2  # E: Cannot assign to final name "x"
 
-    y = 1
+    y = 1  # E: Cannot assign to final name "y"
     y: Final = 2  # E: Cannot redefine an existing name as final
 [out]
 

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -343,7 +343,7 @@ x
 x = 2  # E: Cannot assign to final name "x"
 def f() -> int:
     global x
-    x = 3  # No error here is okay since we reported an error above
+    x = 3  # E: Cannot assign to final name "x"
     return x
 
 x2: Final = 1
@@ -354,8 +354,9 @@ def f2() -> None:
 
 y = 1
 y
-y: Final = 2  # E: Cannot redefine an existing name as final
-y = 3  # E: Cannot assign to final name "y"
+y: Final = 2  # E: Name 'y' already defined on line 17 \
+              # E: Cannot redefine an existing name as final
+y = 3  # No error here, first definition wins
 
 z: Final = 1
 z: Final = 2  # E: Name 'z' already defined on line 22 \
@@ -420,7 +421,7 @@ class C:
     x: Final = 1
     x = 2  # E: Cannot assign to final name "x"
 
-    y = 1  # E: Cannot assign to final name "y"
+    y = 1
     y: Final = 2  # E: Cannot redefine an existing name as final
 [out]
 

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -469,10 +469,12 @@ import standard, optional
 
 [file standard.py]
 x = 0
-x = None
+if int():
+    x = None
 [file optional.py]
 x = 0
-x = None  # E: Incompatible types in assignment (expression has type "None", variable has type "int")
+if int():
+    x = None  # E: Incompatible types in assignment (expression has type "None", variable has type "int")
 
 [file mypy.ini]
 [[mypy]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1286,7 +1286,7 @@ from typing import Any
 x = None # type: Any
 if x:
     def f(x: int) -> None:
-        if 1:
+        if int():
             x = 1
             x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
@@ -1307,12 +1307,12 @@ x = None # type: Any
 if x:
     def f(x: int) -> None:
         'x' + x   # fail
-        if 1:
+        if int():
             x = 1
 else:
     def f(x: int) -> None:
         x + 'x'   # fail
-        if 1:
+        if int():
             x = 1
 f(1)
 f('x') # fail
@@ -1533,7 +1533,7 @@ x = None # type: Any
 class A:
     if x:
         def f(self, x: int) -> None:
-            if 1:
+            if int():
                 x = 1
                 x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
@@ -1566,12 +1566,12 @@ class A:
     if x:
         def f(self, x: int) -> None:
             'x' + x   # fail
-            if 1:
+            if int():
                 x = 1
     else:
         def f(self, x: int) -> None:
             x + 'x'   # fail
-            if 1:
+            if int():
                 x = 1
 A().f(1)
 A().f('x') # fail

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -12,11 +12,16 @@
 from typing import Callable
 f = None # type: Callable[[A], B]
 a, b = None, None # type: (A, B)
-a = f(a)    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-b = f(b)    # E: Argument 1 has incompatible type "B"; expected "A"
-b = f()     # E: Too few arguments
-b = f(a, a) # E: Too many arguments
-b = f(a)
+if int():
+    a = f(a)    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    b = f(b)    # E: Argument 1 has incompatible type "B"; expected "A"
+if int():
+    b = f()     # E: Too few arguments
+if int():
+    b = f(a, a) # E: Too many arguments
+if int():
+    b = f(a)
 
 class A: pass
 class B: pass
@@ -65,15 +70,24 @@ class B(A): pass
 f = None # type: Callable[[B], A]
 g = None # type: Callable[[A], A]  # subtype of f
 h = None # type: Callable[[B], B]  # subtype of f
-g = h  # E: Incompatible types in assignment (expression has type "Callable[[B], B]", variable has type "Callable[[A], A]")
-h = f  # E: Incompatible types in assignment (expression has type "Callable[[B], A]", variable has type "Callable[[B], B]")
-h = g  # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[B], B]")
-g = f  # E: Incompatible types in assignment (expression has type "Callable[[B], A]", variable has type "Callable[[A], A]")
-f = g
-f = h
-f = f
-g = g
-h = h
+if int():
+    g = h  # E: Incompatible types in assignment (expression has type "Callable[[B], B]", variable has type "Callable[[A], A]")
+if int():
+    h = f  # E: Incompatible types in assignment (expression has type "Callable[[B], A]", variable has type "Callable[[B], B]")
+if int():
+    h = g  # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[B], B]")
+if int():
+    g = f  # E: Incompatible types in assignment (expression has type "Callable[[B], A]", variable has type "Callable[[A], A]")
+if int():
+    f = g
+if int():
+    f = h
+if int():
+    f = f
+if int():
+    g = g
+if int():
+    h = h
 
 [case testSubtypingFunctionsDoubleCorrespondence]
 
@@ -112,13 +126,20 @@ ff = f
 gg = g
 hh = h
 
-ff = gg
-ff_nonames = ff
-ff_nonames = f_nonames # reset
-ff = ff_nonames # E: Incompatible types in assignment (expression has type "Callable[[int, str], None]", variable has type "Callable[[Arg(int, 'a'), Arg(str, 'b')], None]")
-ff = f # reset
-gg = ff # E: Incompatible types in assignment (expression has type "Callable[[Arg(int, 'a'), Arg(str, 'b')], None]", variable has type "Callable[[Arg(int, 'a'), DefaultArg(str, 'b')], None]")
-gg = hh # E: Incompatible types in assignment (expression has type "Callable[[Arg(int, 'aa'), DefaultArg(str, 'b')], None]", variable has type "Callable[[Arg(int, 'a'), DefaultArg(str, 'b')], None]")
+if int():
+    ff = gg
+if int():
+    ff_nonames = ff
+if int():
+    ff_nonames = f_nonames # reset
+if int():
+    ff = ff_nonames # E: Incompatible types in assignment (expression has type "Callable[[int, str], None]", variable has type "Callable[[Arg(int, 'a'), Arg(str, 'b')], None]")
+if int():
+    ff = f # reset
+if int():
+    gg = ff # E: Incompatible types in assignment (expression has type "Callable[[Arg(int, 'a'), Arg(str, 'b')], None]", variable has type "Callable[[Arg(int, 'a'), DefaultArg(str, 'b')], None]")
+if int():
+    gg = hh # E: Incompatible types in assignment (expression has type "Callable[[Arg(int, 'aa'), DefaultArg(str, 'b')], None]", variable has type "Callable[[Arg(int, 'a'), DefaultArg(str, 'b')], None]")
 
 [case testSubtypingFunctionsArgsKwargs]
 from typing import Any, Callable
@@ -134,17 +155,27 @@ ss_2 = specific_2
 ee_def = everything
 ee_var = everywhere
 
-ss_1 = ee_def
-ss_1 = specific_1
-ss_2 = ee_def
-ss_2 = specific_2
-ee_def = everywhere
-ee_def = everything
-ee_var = everything
-ee_var = everywhere
+if int():
+    ss_1 = ee_def
+if int():
+    ss_1 = specific_1
+if int():
+    ss_2 = ee_def
+if int():
+    ss_2 = specific_2
+if int():
+    ee_def = everywhere
+if int():
+    ee_def = everything
+if int():
+    ee_var = everything
+if int():
+    ee_var = everywhere
 
-ee_var = specific_1 # The difference between Callable[..., blah] and one with a *args: Any, **kwargs: Any is that the ... goes loosely both ways.
-ee_def = specific_1 # E: Incompatible types in assignment (expression has type "Callable[[int, str], None]", variable has type "Callable[[VarArg(Any), KwArg(Any)], None]")
+if int():
+    ee_var = specific_1 # The difference between Callable[..., blah] and one with a *args: Any, **kwargs: Any is that the ... goes loosely both ways.
+if int():
+    ee_def = specific_1 # E: Incompatible types in assignment (expression has type "Callable[[int, str], None]", variable has type "Callable[[VarArg(Any), KwArg(Any)], None]")
 
 [builtins fixtures/dict.pyi]
 
@@ -174,33 +205,42 @@ def g(a: int, b: str) -> None: pass
 ff = f
 gg = g
 
-ff = g
-gg = f # E: Incompatible types in assignment (expression has type "Callable[[int, str], None]", variable has type "Callable[[Arg(int, 'a'), Arg(str, 'b')], None]")
+if int():
+    ff = g
+if int():
+    gg = f # E: Incompatible types in assignment (expression has type "Callable[[int, str], None]", variable has type "Callable[[Arg(int, 'a'), Arg(str, 'b')], None]")
 
 [case testLackOfNamesFastparse]
-
-
 def f(__a: int, __b: str) -> None: pass
 def g(a: int, b: str) -> None: pass
 
 ff = f
 gg = g
 
-ff = g
-gg = f # E: Incompatible types in assignment (expression has type "Callable[[int, str], None]", variable has type "Callable[[Arg(int, 'a'), Arg(str, 'b')], None]")
+if int():
+    ff = g
+if int():
+    gg = f # E: Incompatible types in assignment (expression has type "Callable[[int, str], None]", variable has type "Callable[[Arg(int, 'a'), Arg(str, 'b')], None]")
 
 [case testFunctionTypeCompatibilityWithOtherTypes]
 from typing import Callable
 f = None # type: Callable[[], None]
 a, o = None, None # type: (A, object)
-a = f   # E: Incompatible types in assignment (expression has type "Callable[[], None]", variable has type "A")
-f = a   # E: Incompatible types in assignment (expression has type "A", variable has type "Callable[[], None]")
-f = o   # E: Incompatible types in assignment (expression has type "object", variable has type "Callable[[], None]")
-f = f() # E: Function does not return a value
+if int():
+    a = f   # E: Incompatible types in assignment (expression has type "Callable[[], None]", variable has type "A")
+if int():
+    f = a   # E: Incompatible types in assignment (expression has type "A", variable has type "Callable[[], None]")
+if int():
+    f = o   # E: Incompatible types in assignment (expression has type "object", variable has type "Callable[[], None]")
+if int():
+    f = f() # E: Function does not return a value
 
-f = f
-f = None
-o = f
+if int():
+    f = f
+if int():
+    f = None
+if int():
+    o = f
 
 class A: pass
 
@@ -208,26 +248,39 @@ class A: pass
 from typing import Callable
 f = None # type: Callable[[], None]
 g = None # type: Callable[[], object]
-f = g  # E: Incompatible types in assignment (expression has type "Callable[[], object]", variable has type "Callable[[], None]")
-g = f  # OK
+if int():
+    f = g  # E: Incompatible types in assignment (expression has type "Callable[[], object]", variable has type "Callable[[], None]")
+if int():
+    g = f  # OK
 
-f = f
-g = g
+if int():
+    f = f
+if int():
+    g = g
 
 [case testFunctionSubtypingWithMultipleArgs]
 from typing import Callable
 f = None # type: Callable[[A, A], None]
 g = None # type: Callable[[A, B], None]
 h = None # type: Callable[[B, B], None]
-f = g  # E: Incompatible types in assignment (expression has type "Callable[[A, B], None]", variable has type "Callable[[A, A], None]")
-f = h  # E: Incompatible types in assignment (expression has type "Callable[[B, B], None]", variable has type "Callable[[A, A], None]")
-g = h  # E: Incompatible types in assignment (expression has type "Callable[[B, B], None]", variable has type "Callable[[A, B], None]")
-g = f
-h = f
-h = g
-f = f
-g = g
-h = h
+if int():
+    f = g  # E: Incompatible types in assignment (expression has type "Callable[[A, B], None]", variable has type "Callable[[A, A], None]")
+if int():
+    f = h  # E: Incompatible types in assignment (expression has type "Callable[[B, B], None]", variable has type "Callable[[A, A], None]")
+if int():
+    g = h  # E: Incompatible types in assignment (expression has type "Callable[[B, B], None]", variable has type "Callable[[A, B], None]")
+if int():
+    g = f
+if int():
+    h = f
+if int():
+    h = g
+if int():
+    f = f
+if int():
+    g = g
+if int():
+    h = h
 
 class A: pass
 class B(A): pass
@@ -238,26 +291,35 @@ f = None # type: Callable[[], None]
 g = None # type: Callable[[A], None]
 h = None # type: Callable[[A, A], None]
 
-f = g   # E: Incompatible types in assignment (expression has type "Callable[[A], None]", variable has type "Callable[[], None]")
-f = h   # E: Incompatible types in assignment (expression has type "Callable[[A, A], None]", variable has type "Callable[[], None]")
-h = f   # E: Incompatible types in assignment (expression has type "Callable[[], None]", variable has type "Callable[[A, A], None]")
-h = g   # E: Incompatible types in assignment (expression has type "Callable[[A], None]", variable has type "Callable[[A, A], None]")
+if int():
+    f = g   # E: Incompatible types in assignment (expression has type "Callable[[A], None]", variable has type "Callable[[], None]")
+if int():
+    f = h   # E: Incompatible types in assignment (expression has type "Callable[[A, A], None]", variable has type "Callable[[], None]")
+if int():
+    h = f   # E: Incompatible types in assignment (expression has type "Callable[[], None]", variable has type "Callable[[A, A], None]")
+if int():
+    h = g   # E: Incompatible types in assignment (expression has type "Callable[[A], None]", variable has type "Callable[[A, A], None]")
 
-f = f
-g = g
-h = h
+if int():
+    f = f
+if int():
+    g = g
+if int():
+    h = h
 
 class A: pass
 [out]
 
 [case testCompatibilityOfSimpleTypeObjectWithStdType]
-
 t = None # type: type
 a = None # type: A
 
-a = A # E: Incompatible types in assignment (expression has type "Type[A]", variable has type "A")
-t = f # E: Incompatible types in assignment (expression has type "Callable[[], None]", variable has type "type")
-t = A
+if int():
+    a = A # E: Incompatible types in assignment (expression has type "Type[A]", variable has type "A")
+if int():
+    t = f # E: Incompatible types in assignment (expression has type "Callable[[], None]", variable has type "type")
+if int():
+    t = A
 
 class A:
     def __init__(self, a: 'A') -> None: pass
@@ -272,12 +334,17 @@ f = None # type: Callable[[AA], A]
 g = None # type: Callable[[B], B]
 h = None # type: Callable[[A], AA]
 
-h = i  # E: Incompatible types in assignment (expression has type overloaded function, variable has type "Callable[[A], AA]")
-f = j
+if int():
+    h = i  # E: Incompatible types in assignment (expression has type overloaded function, variable has type "Callable[[A], AA]")
+if int():
+    f = j
 
-f = i
-g = i
-g = j
+if int():
+    f = i
+if int():
+    g = i
+if int():
+    g = j
 
 class A: pass
 class AA(A): pass
@@ -308,17 +375,27 @@ g3 = None # type: Callable[[C], C]
 g4 = None # type: Callable[[A], B]
 a, b, c = None, None, None # type: (A, B, C)
 
-b = f(a)  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = f(b)  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-b = f(c)  # E: Incompatible types in assignment (expression has type "C", variable has type "B")
-g4 = f    # E: Incompatible types in assignment (expression has type overloaded function, variable has type "Callable[[A], B]")
+if int():
+    b = f(a)  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = f(b)  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    b = f(c)  # E: Incompatible types in assignment (expression has type "C", variable has type "B")
+if int():
+    g4 = f    # E: Incompatible types in assignment (expression has type overloaded function, variable has type "Callable[[A], B]")
 
-g1 = f
-g2 = f
-g3 = f
-a = f(a)
-b = f(b)
-c = f(c)
+if int():
+    g1 = f
+if int():
+    g2 = f
+if int():
+    g3 = f
+if int():
+    a = f(a)
+if int():
+    b = f(b)
+if int():
+    c = f(c)
 
 class A: pass
 class B: pass
@@ -353,7 +430,8 @@ from typing import Callable, Type
 class A: pass
 x = None  # type: Callable[..., A]
 y = None  # type: Type[A]
-y = x  # E: Incompatible types in assignment (expression has type "Callable[..., A]", variable has type "Type[A]")
+if int():
+    y = x  # E: Incompatible types in assignment (expression has type "Callable[..., A]", variable has type "Type[A]")
 
 -- Default argument values
 -- -----------------------
@@ -362,13 +440,19 @@ y = x  # E: Incompatible types in assignment (expression has type "Callable[...,
 [case testCallingFunctionsWithDefaultArgumentValues]
 
 a, b = None, None # type: (A, B)
-a = f()     # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-b = f(b)    # E: Argument 1 to "f" has incompatible type "B"; expected "Optional[A]"
-b = f(a, a) # E: Too many arguments for "f"
+if int():
+    a = f()     # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    b = f(b)    # E: Argument 1 to "f" has incompatible type "B"; expected "Optional[A]"
+if int():
+    b = f(a, a) # E: Too many arguments for "f"
 
-b = f()
-b = f(a)
-b = f(AA())
+if int():
+    b = f()
+if int():
+    b = f(a)
+if int():
+    b = f(AA())
 
 def f(x: 'A'  =  None) -> 'B': pass
 
@@ -607,16 +691,15 @@ a.g(a) # E: Too many arguments
 import typing
 def f(a: 'A') -> None:
     def g(b: 'B') -> None:
-         b = a # fail
-         aa = a # type: A # ok
-         b = B()
-    g(a) # fail
+        if int():
+            b = a \
+            # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+            aa = a # type: A # ok
+            b = B()
+    g(a) # E: Argument 1 to "g" has incompatible type "A"; expected "B"
     g(B())
 class A: pass
 class B: pass
-[out]
-main:4: error: Incompatible types in assignment (expression has type "A", variable has type "B")
-main:7: error: Argument 1 to "g" has incompatible type "A"; expected "B"
 
 [case testReturnAndNestedFunction]
 import typing
@@ -752,7 +835,8 @@ def dec(f): pass
 @dec
 def f(x: 'A') -> None:
     a = x # type: A
-    x = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+    if int():
+        x = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
 class A: pass
 [out]
 
@@ -1202,8 +1286,9 @@ from typing import Any
 x = None # type: Any
 if x:
     def f(x: int) -> None:
-        x = 1
-        x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+        if 1:
+            x = 1
+            x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
 
 [case testCallConditionalFunction]
@@ -1221,18 +1306,20 @@ from typing import Any
 x = None # type: Any
 if x:
     def f(x: int) -> None:
-        x = 'x'   # fail
-        x = 1
+        'x' + x   # fail
+        if 1:
+            x = 1
 else:
     def f(x: int) -> None:
         x + 'x'   # fail
-        x = 1
+        if 1:
+            x = 1
 f(1)
 f('x') # fail
 [out]
-main:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:9: error: Unsupported operand types for + ("int" and "str")
-main:12: error: Argument 1 to "f" has incompatible type "str"; expected "int"
+main:5: error: Unsupported operand types for + ("str" and "int")
+main:10: error: Unsupported operand types for + ("int" and "str")
+main:14: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 
 [case testNestedConditionalFunctionDefinitionWithIfElse]
 from typing import Any
@@ -1240,18 +1327,16 @@ x = None # type: Any
 def top() -> None:
     if x:
         def f(x: int) -> None:
-            x = 'x'   # fail
-            x = 1
+            if int():
+                x = 'x'  # E: Incompatible types in assignment \
+                          (expression has type "str", variable has type "int")
+                x = 1
     else:
         def f(x: int) -> None:
-            x + 'x'   # fail
+            x + 'x'   # E: Unsupported operand types for + ("int" and "str")
             x = 1
     f(1)
-    f('x') # fail
-[out]
-main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:10: error: Unsupported operand types for + ("int" and "str")
-main:13: error: Argument 1 to "f" has incompatible type "str"; expected "int"
+    f('x') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 
 [case testUnconditionalRedefinitionOfConditionalFunction]
 from typing import Any
@@ -1448,8 +1533,9 @@ x = None # type: Any
 class A:
     if x:
         def f(self, x: int) -> None:
-            x = 1
-            x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+            if 1:
+                x = 1
+                x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
 
 [case testCallConditionalMethodInClassBody]
@@ -1479,18 +1565,20 @@ x = None # type: Any
 class A:
     if x:
         def f(self, x: int) -> None:
-            x = 'x'   # fail
-            x = 1
+            'x' + x   # fail
+            if 1:
+                x = 1
     else:
         def f(self, x: int) -> None:
             x + 'x'   # fail
-            x = 1
+            if 1:
+                x = 1
 A().f(1)
 A().f('x') # fail
 [out]
-main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:10: error: Unsupported operand types for + ("int" and "str")
-main:13: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+main:6: error: Unsupported operand types for + ("str" and "int")
+main:11: error: Unsupported operand types for + ("int" and "str")
+main:15: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
 
 [case testUnconditionalRedefinitionOfConditionalMethod]
 from typing import Any
@@ -1822,7 +1910,8 @@ f(x=4) + '' # E: Unsupported operand types for + ("int" and "str")
 [case testCallableWithArbitraryArgsInErrorMessage]
 from typing import Callable
 def f(x: Callable[..., int]) -> None:
-    x = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "Callable[..., int]")
+    if int():
+        x = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "Callable[..., int]")
 [out]
 
 [case testCallableWithArbitraryArgsInGenericFunction]

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -13,12 +13,15 @@ ac = None # type: A[C]
 ad = None # type: A[D]
 b = None # type: B
 
-b = ad # E: Incompatible types in assignment (expression has type "A[D]", variable has type "B")
-ad = b # E: Incompatible types in assignment (expression has type "B", variable has type "A[D]")
-b = ac # E: Incompatible types in assignment (expression has type "A[C]", variable has type "B")
+if int():
+    b = ad # E: Incompatible types in assignment (expression has type "A[D]", variable has type "B")
+    ad = b # E: Incompatible types in assignment (expression has type "B", variable has type "A[D]")
+if int():
+    b = ac # E: Incompatible types in assignment (expression has type "A[C]", variable has type "B")
 
-b = b
-ac = b
+if int():
+    b = b
+    ac = b
 
 class C: pass
 class A(Generic[T]): pass
@@ -32,13 +35,17 @@ a = None # type: A
 bc = None # type: B[C]
 bd = None # type: B[D]
 
-bc = bd # E: Incompatible types in assignment (expression has type "B[D]", variable has type "B[C]")
-bd = bc # E: Incompatible types in assignment (expression has type "B[C]", variable has type "B[D]")
-bc = a  # E: Incompatible types in assignment (expression has type "A", variable has type "B[C]")
-bd = a  # E: Incompatible types in assignment (expression has type "A", variable has type "B[D]")
+if int():
+    bc = bd # E: Incompatible types in assignment (expression has type "B[D]", variable has type "B[C]")
+    bd = bc # E: Incompatible types in assignment (expression has type "B[C]", variable has type "B[D]")
+if int():
+    bc = a  # E: Incompatible types in assignment (expression has type "A", variable has type "B[C]")
+    bd = a  # E: Incompatible types in assignment (expression has type "A", variable has type "B[D]")
 
-a = bc
-a = bd
+if int():
+    a = bc
+if int():
+    a = bd
 
 class A: pass
 class B(A, Generic[T]): pass
@@ -54,15 +61,19 @@ ad = None # type: A[D]
 bcc = None # type: B[C, C]
 bdc = None # type: B[D, C]
 
-ad = bcc # E: Incompatible types in assignment (expression has type "B[C, C]", variable has type "A[D]")
-ad = bdc # E: Incompatible types in assignment (expression has type "B[D, C]", variable has type "A[D]")
-bcc = ac # E: Incompatible types in assignment (expression has type "A[C]", variable has type "B[C, C]")
-bdc = ac # E: Incompatible types in assignment (expression has type "A[C]", variable has type "B[D, C]")
+if int():
+    ad = bcc # E: Incompatible types in assignment (expression has type "B[C, C]", variable has type "A[D]")
+if int():
+    ad = bdc # E: Incompatible types in assignment (expression has type "B[D, C]", variable has type "A[D]")
+    bcc = ac # E: Incompatible types in assignment (expression has type "A[C]", variable has type "B[C, C]")
+    bdc = ac # E: Incompatible types in assignment (expression has type "A[C]", variable has type "B[D, C]")
 
-bcc = bcc
-bdc = bdc
-ac = bcc
-ac = bdc
+if int():
+    bcc = bcc
+    bdc = bdc
+    ac = bcc
+if int():
+    ac = bdc
 
 class A(Generic[T]): pass
 class B(A[S], Generic[T, S]): pass
@@ -82,12 +93,15 @@ cef = None # type: C[E, F]
 cff = None # type: C[F, F]
 cfe = None # type: C[F, E]
 
-ae = cef # E: Incompatible types in assignment (expression has type "C[E, F]", variable has type "A[A[E]]")
-af = cfe # E: Incompatible types in assignment (expression has type "C[F, E]", variable has type "A[A[F]]")
+if int():
+    ae = cef # E: Incompatible types in assignment (expression has type "C[E, F]", variable has type "A[A[E]]")
+    af = cfe # E: Incompatible types in assignment (expression has type "C[F, E]", variable has type "A[A[F]]")
 
-ae = cfe
-af = cef
-af = cff
+if int():
+    ae = cfe
+    af = cef
+if int():
+    af = cff
 
 class A(Generic[T]): pass
 class B(A[S], Generic[T, S]): pass
@@ -280,9 +294,10 @@ a = None # type: A
 bc = None # type: B[C]
 bd = None # type: B[D]
 
-a = bc # E: Incompatible types in assignment (expression has type "B[C]", variable has type "A")
-bc = a
-bd = a
+if int():
+    a = bc # E: Incompatible types in assignment (expression has type "B[C]", variable has type "A")
+    bc = a
+    bd = a
 
 class B(Generic[T]): pass
 class A(B): pass
@@ -427,12 +442,14 @@ adc = None # type: A[D, C]
 ic = None # type: I[C]
 id = None # type: I[D]
 
-ic = acd # E: Incompatible types in assignment (expression has type "A[C, D]", variable has type "I[C]")
-id = adc # E: Incompatible types in assignment (expression has type "A[D, C]", variable has type "I[D]")
-adc = ic # E: Incompatible types in assignment (expression has type "I[C]", variable has type "A[D, C]")
+if int():
+    ic = acd # E: Incompatible types in assignment (expression has type "A[C, D]", variable has type "I[C]")
+    id = adc # E: Incompatible types in assignment (expression has type "A[D, C]", variable has type "I[D]")
+    adc = ic # E: Incompatible types in assignment (expression has type "I[C]", variable has type "A[D, C]")
 
-ic = adc
-id = acd
+if int():
+    ic = adc
+    id = acd
 
 class I(Generic[T]):
     @abstractmethod
@@ -451,14 +468,17 @@ class I(Generic[S]): pass
 class B(I[C]): pass
 class A(B): pass
 
-ie = a # E: Incompatible types in assignment (expression has type "A", variable has type "I[E]")
-a = ic # E: Incompatible types in assignment (expression has type "I[C]", variable has type "A")
-a = id # E: Incompatible types in assignment (expression has type "I[D]", variable has type "A")
-a = b  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-id = a # E: Incompatible types in assignment (expression has type "A", variable has type "I[D]")
+if int():
+    ie = a # E: Incompatible types in assignment (expression has type "A", variable has type "I[E]")
+    a = ic # E: Incompatible types in assignment (expression has type "I[C]", variable has type "A")
+if int():
+    a = id # E: Incompatible types in assignment (expression has type "I[D]", variable has type "A")
+if int():
+    a = b  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    id = a # E: Incompatible types in assignment (expression has type "A", variable has type "I[D]")
 
-ic = a
-b = a
+    ic = a
+    b = a
 
 class C: pass
 class D: pass
@@ -483,11 +503,14 @@ from abc import abstractmethod, ABCMeta
 t = TypeVar('t')
 a, i, j = None, None, None # type: (A[object], I[object], J[object])
 (ii, jj) = (i, j)
-ii = a
-jj = a
-jj = i
-a = i # E: Incompatible types in assignment (expression has type "I[object]", variable has type "A[object]")
-a = j # E: Incompatible types in assignment (expression has type "J[object]", variable has type "A[object]")
+if int():
+    ii = a
+    jj = a
+if int():
+    jj = i
+    a = i # E: Incompatible types in assignment (expression has type "I[object]", variable has type "A[object]")
+if int():
+    a = j # E: Incompatible types in assignment (expression has type "J[object]", variable has type "A[object]")
 
 class J(Generic[t]): pass
 class X(metaclass=ABCMeta): pass
@@ -528,8 +551,9 @@ T = TypeVar('T')
 a = None # type: A
 ic, id = None, None # type: (I[C], I[D])
 
-id = a # Fail
-ic = a
+if int():
+    id = a # E: Incompatible types in assignment (expression has type "A", variable has type "I[D]")
+    ic = a
 
 class I(Generic[T]):
     @abstractmethod
@@ -545,8 +569,6 @@ class A(B):
     def f(self, a: 'C', b: 'C') -> None: pass
 class C: pass
 class D: pass
-[out]
-main:7: error: Incompatible types in assignment (expression has type "A", variable has type "I[D]")
 
 [case testSubclassingGenericABCWithDeepHierarchy2]
 from typing import Any, TypeVar, Generic
@@ -704,8 +726,9 @@ a = None  # type: G[A]
 b = None  # type: G[B]
 c = None  # type: G[C]
 
-b = a  # E: Incompatible types in assignment (expression has type "G[A]", variable has type "G[B]")
-b = c
+if int():
+    b = a  # E: Incompatible types in assignment (expression has type "G[A]", variable has type "G[B]")
+    b = c
 [builtins fixtures/bool.pyi]
 [out]
 
@@ -722,8 +745,9 @@ a = None  # type: G[A]
 b = None  # type: G[B]
 c = None  # type: G[C]
 
-b = a
-b = c  # E: Incompatible types in assignment (expression has type "G[C]", variable has type "G[B]")
+if int():
+    b = a
+    b = c  # E: Incompatible types in assignment (expression has type "G[C]", variable has type "G[B]")
 [builtins fixtures/bool.pyi]
 [out]
 
@@ -740,8 +764,9 @@ a = None  # type: G[A]
 b = None  # type: G[B]
 c = None  # type: G[C]
 
-b = a  # E: Incompatible types in assignment (expression has type "G[A]", variable has type "G[B]")
-b = c  # E: Incompatible types in assignment (expression has type "G[C]", variable has type "G[B]")
+if int():
+    b = a  # E: Incompatible types in assignment (expression has type "G[A]", variable has type "G[B]")
+    b = c  # E: Incompatible types in assignment (expression has type "G[C]", variable has type "G[B]")
 [builtins fixtures/bool.pyi]
 [out]
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -214,13 +214,13 @@ class A(Generic[S, T]):
     def f(self) -> None:
         s = None # type: S
         t = None # type: T
-        if 1:
+        if int():
             s = t # E: Incompatible types in assignment (expression has type "T", variable has type "S")
             t = s # E: Incompatible types in assignment (expression has type "S", variable has type "T")
         a = self # type: A[S, B] # E: Incompatible types in assignment (expression has type "A[S, T]", variable has type "A[S, B]")
         b = self # type: A[T, T] # E: Incompatible types in assignment (expression has type "A[S, T]", variable has type "A[T, T]")
         c = self # type: A[S, T]
-        if 1:
+        if int():
             t = t
 
 class B: pass
@@ -241,10 +241,10 @@ T = TypeVar('T')
 class A(Generic[T]):
     def f(self) -> T:
         a = object() # type: T  # E: Incompatible types in assignment (expression has type "object", variable has type "T")
-        if 1:
+        if int():
             a = object()    # E: Incompatible types in assignment (expression has type "object", variable has type "T")
         b = self.f() # type: object
-        if 1:
+        if int():
             b = self.f()
         return None
 [out]
@@ -372,7 +372,7 @@ class p(Generic[T, S]):
     def __init__(self, t: T, a: S) -> None: pass
 def f(s: S, t: T) -> p[T, A]:
     a = t # type: S # E: Incompatible types in assignment (expression has type "T", variable has type "S")
-    if 1:
+    if int():
         s = t           # E: Incompatible types in assignment (expression has type "T", variable has type "S")
     p_s_a = None  # type: p[S, A]
     if s:
@@ -391,7 +391,7 @@ class p(Generic[T, S]):
     def __init__(self, t: T, a: S) -> None: pass
 class A(Generic[T]):
     def f(self, s: S, t: T) -> p[S, T]:
-        if 1:
+        if int():
             s = t # E: Incompatible types in assignment (expression has type "T", variable has type "S")
         p_s_s = None  # type: p[S, S]
         if s:
@@ -399,7 +399,7 @@ class A(Generic[T]):
         p_t_t = None  # type: p[T, T]
         if t:
             return p_t_t # E: Incompatible return value type (got "p[T, T]", expected "p[S, T]")
-        if 1:
+        if int():
             t = t
             s = s
             p_s_t = None  # type: p[S, T]
@@ -759,7 +759,7 @@ if not isinstance(x, int):
    x.x = 'a' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 def f(x: T) -> UNode[T]:
-    if 1:
+    if int():
         return Node(x)
     else:
         return 1
@@ -1440,7 +1440,7 @@ def f() -> None:
     T = TypeVar('T')
     def g(x: T) -> T: pass
     a = g(1)
-    if 1:
+    if int():
         a = 1
         a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
@@ -1559,32 +1559,32 @@ def outer(t: T) -> None:
     def f5(x: T) -> T: ...
 
     y1 = f1
-    if 1:
+    if int():
         y1 = f2
         y1 = f3 # E: Incompatible types in assignment (expression has type "Callable[[T], A]", variable has type "Callable[[A], A]")
         y1 = f4 # E: Incompatible types in assignment (expression has type "Callable[[A], T]", variable has type "Callable[[A], A]")
         y1 = f5 # E: Incompatible types in assignment (expression has type "Callable[[T], T]", variable has type "Callable[[A], A]")
 
     y2 = f2
-    if 1:
+    if int():
         y2 = f1 # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[A], B]")
 
     y3 = f3
-    if 1:
+    if int():
         y3 = f1 # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[T], A]")
         y3 = f2
         y3 = f4 # E: Incompatible types in assignment (expression has type "Callable[[A], T]", variable has type "Callable[[T], A]")
         y3 = f5 # E: Incompatible types in assignment (expression has type "Callable[[T], T]", variable has type "Callable[[T], A]")
 
     y4 = f4
-    if 1:
+    if int():
         y4 = f1 # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[A], T]")
         y4 = f2
         y4 = f3 # E: Incompatible types in assignment (expression has type "Callable[[T], A]", variable has type "Callable[[A], T]")
         y4 = f5 # E: Incompatible types in assignment (expression has type "Callable[[T], T]", variable has type "Callable[[A], T]")
 
     y5 = f5
-    if 1:
+    if int():
         y5 = f1
         y5 = f2
         y5 = f3

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -6,16 +6,15 @@
 from typing import TypeVar, Generic
 T = TypeVar('T')
 a, b, c = None, None, None # type: (A[B], B, C)
-c = a.f() # Fail
-b = a.f()
+if int():
+    c = a.f() # E: Incompatible types in assignment (expression has type "B", variable has type "C")
+    b = a.f()
 
 class A(Generic[T]):
     def f(self) -> T: pass
 
 class B: pass
 class C: pass
-[out]
-main:4: error: Incompatible types in assignment (expression has type "B", variable has type "C")
 
 [case testGenericMethodArgument]
 from typing import TypeVar, Generic
@@ -69,18 +68,18 @@ main:4: error: Incompatible types in assignment (expression has type "C", variab
 from typing import TypeVar, Generic
 T = TypeVar('T')
 b, bb, c = None, None, None # type: (A[B], A[B], A[C])
-c = b # Fail
-b = c # Fail
+if int():
+    c = b # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[C]")
+    b = c # E: Incompatible types in assignment (expression has type "A[C]", variable has type "A[B]")
 
-b = b
-b = bb
+if int():
+    b = b
+if int():
+    b = bb
 
 class A(Generic[T]): pass
 class B: pass
 class C(B): pass
-[out]
-main:4: error: Incompatible types in assignment (expression has type "A[B]", variable has type "A[C]")
-main:5: error: Incompatible types in assignment (expression has type "A[C]", variable has type "A[B]")
 
 [case testGenericTypeCompatibilityWithAny]
 from typing import Any, TypeVar, Generic
@@ -104,19 +103,18 @@ a = None # type: A[B]
 b = None # type: A[B]
 c = None # type: A[C]
 
-a.v = c # Fail
-c = a.v # Fail
+a.v = c # E: Incompatible types in assignment (expression has type "A[C]", variable has type "A[B]")
+if int():
+    c = a.v # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[C]")
 a.v = b
-b = a.v
+if int():
+    b = a.v
 
 class A(Generic[T]):
     v = None # type: A[T]
 
 class B: pass
 class C: pass
-[out]
-main:7: error: Incompatible types in assignment (expression has type "A[C]", variable has type "A[B]")
-main:8: error: Incompatible types in assignment (expression has type "A[B]", variable has type "A[C]")
 
 [case testMultipleGenericTypeParametersWithMemberVars]
 from typing import TypeVar, Generic
@@ -126,20 +124,19 @@ a = None # type: A[B, C]
 s = None # type: B
 t = None # type: C
 
-t = a.s # Fail
-s = a.t # Fail
+if int():
+    t = a.s # E: Incompatible types in assignment (expression has type "B", variable has type "C")
+    s = a.t # E: Incompatible types in assignment (expression has type "C", variable has type "B")
 
-s = a.s
-t = a.t
+if int():
+    s = a.s
+    t = a.t
 
 class A(Generic[S, T]):
     s = None # type: S
     t = None # type: T
 class B: pass
 class C: pass
-[out]
-main:8: error: Incompatible types in assignment (expression has type "B", variable has type "C")
-main:9: error: Incompatible types in assignment (expression has type "C", variable has type "B")
 
 [case testMultipleGenericTypeParametersWithMethods]
 from typing import TypeVar, Generic
@@ -169,12 +166,15 @@ bc = None # type: A[B, C]
 bb = None # type: A[B, B]
 cb = None # type: A[C, B]
 
-bb = bc # Fail
-bb = cb # Fail
-bc = bb # Fail
+if int():
+    bb = bc # E: Incompatible types in assignment (expression has type "A[B, C]", variable has type "A[B, B]")
+if int():
+    bb = cb # E: Incompatible types in assignment (expression has type "A[C, B]", variable has type "A[B, B]")
+    bc = bb # E: Incompatible types in assignment (expression has type "A[B, B]", variable has type "A[B, C]")
 
-bb = bb
-bc = bc
+if int():
+    bb = bb
+    bc = bc
 
 class A(Generic[S, T]):
     s = None # type: S
@@ -182,10 +182,6 @@ class A(Generic[S, T]):
 
 class B: pass
 class C(B):pass
-[out]
-main:8: error: Incompatible types in assignment (expression has type "A[B, C]", variable has type "A[B, B]")
-main:9: error: Incompatible types in assignment (expression has type "A[C, B]", variable has type "A[B, B]")
-main:10: error: Incompatible types in assignment (expression has type "A[B, B]", variable has type "A[B, C]")
 
 
 -- Simple generic type bodies
@@ -218,19 +214,17 @@ class A(Generic[S, T]):
     def f(self) -> None:
         s = None # type: S
         t = None # type: T
-        s = t # Fail
-        t = s # Fail
-        a = self # type: A[S, B] # Fail
-        b = self # type: A[T, T] # Fail
+        if 1:
+            s = t # E: Incompatible types in assignment (expression has type "T", variable has type "S")
+            t = s # E: Incompatible types in assignment (expression has type "S", variable has type "T")
+        a = self # type: A[S, B] # E: Incompatible types in assignment (expression has type "A[S, T]", variable has type "A[S, B]")
+        b = self # type: A[T, T] # E: Incompatible types in assignment (expression has type "A[S, T]", variable has type "A[T, T]")
         c = self # type: A[S, T]
-        t = t
+        if 1:
+            t = t
 
 class B: pass
 [out]
-main:8: error: Incompatible types in assignment (expression has type "T", variable has type "S")
-main:9: error: Incompatible types in assignment (expression has type "S", variable has type "T")
-main:10: error: Incompatible types in assignment (expression has type "A[S, T]", variable has type "A[S, B]")
-main:11: error: Incompatible types in assignment (expression has type "A[S, T]", variable has type "A[T, T]")
 
 [case testCompatibilityOfNoneWithTypeVar]
 from typing import TypeVar, Generic
@@ -246,14 +240,14 @@ from typing import TypeVar, Generic
 T = TypeVar('T')
 class A(Generic[T]):
     def f(self) -> T:
-        a = object() # type: T  # Fail
-        a = object()    # Fail
+        a = object() # type: T  # E: Incompatible types in assignment (expression has type "object", variable has type "T")
+        if 1:
+            a = object()    # E: Incompatible types in assignment (expression has type "object", variable has type "T")
         b = self.f() # type: object
-        b = self.f()
+        if 1:
+            b = self.f()
         return None
 [out]
-main:5: error: Incompatible types in assignment (expression has type "object", variable has type "T")
-main:6: error: Incompatible types in assignment (expression has type "object", variable has type "T")
 
 
 -- Operations with generic types
@@ -268,13 +262,16 @@ a = None # type: A[B, C]
 b = None # type: B
 c = None # type: C
 
-b = a + b # Fail
-c = a + c # Fail
-c = a[c]  # Fail
-b = a[b]  # Fail
+if int():
+    b = a + b # E: Incompatible types in assignment (expression has type "C", variable has type "B")
+    c = a + c # E: Unsupported operand types for + ("A[B, C]" and "C")
+if int():
+    c = a[c]  # E: Incompatible types in assignment (expression has type "B", variable has type "C")
+    b = a[b]  # E: Invalid index type "B" for "A[B, C]"; expected type "C"
 
-c = a + b
-b = a[c]
+if int():
+    c = a + b
+    b = a[c]
 
 class A(Generic[S, T]):
     def __add__(self, a: S) -> T: pass
@@ -282,11 +279,6 @@ class A(Generic[S, T]):
 
 class B: pass
 class C: pass
-[out]
-main:8: error: Incompatible types in assignment (expression has type "C", variable has type "B")
-main:9: error: Unsupported operand types for + ("A[B, C]" and "C")
-main:10: error: Incompatible types in assignment (expression has type "B", variable has type "C")
-main:11: error: Invalid index type "B" for "A[B, C]"; expected type "C"
 
 [case testOperatorAssignmentWithIndexLvalue1]
 from typing import TypeVar, Generic
@@ -347,11 +339,13 @@ aac = None # type: A[A[C]]
 ab = None # type: A[B]
 ac = None # type: A[C]
 
-ac = aab.x # Fail
-ac.y = aab # Fail
+if int():
+    ac = aab.x # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[C]")
+ac.y = aab # E: Incompatible types in assignment (expression has type "A[A[B]]", variable has type "A[A[C]]")
 
-ab = aab.x
-ac = aac.x
+if int():
+    ab = aab.x
+    ac = aac.x
 ab.y = aab
 ac.y = aac
 
@@ -363,9 +357,6 @@ class B:
     pass
 class C:
     pass
-[out]
-main:8: error: Incompatible types in assignment (expression has type "A[B]", variable has type "A[C]")
-main:9: error: Incompatible types in assignment (expression has type "A[A[B]]", variable has type "A[A[C]]")
 
 
 -- Generic functions
@@ -381,7 +372,8 @@ class p(Generic[T, S]):
     def __init__(self, t: T, a: S) -> None: pass
 def f(s: S, t: T) -> p[T, A]:
     a = t # type: S # E: Incompatible types in assignment (expression has type "T", variable has type "S")
-    s = t           # E: Incompatible types in assignment (expression has type "T", variable has type "S")
+    if 1:
+        s = t           # E: Incompatible types in assignment (expression has type "T", variable has type "S")
     p_s_a = None  # type: p[S, A]
     if s:
         return p_s_a # E: Incompatible return value type (got "p[S, A]", expected "p[T, A]")
@@ -399,17 +391,19 @@ class p(Generic[T, S]):
     def __init__(self, t: T, a: S) -> None: pass
 class A(Generic[T]):
     def f(self, s: S, t: T) -> p[S, T]:
-        s = t # E: Incompatible types in assignment (expression has type "T", variable has type "S")
+        if 1:
+            s = t # E: Incompatible types in assignment (expression has type "T", variable has type "S")
         p_s_s = None  # type: p[S, S]
         if s:
             return p_s_s # E: Incompatible return value type (got "p[S, S]", expected "p[S, T]")
         p_t_t = None  # type: p[T, T]
         if t:
             return p_t_t # E: Incompatible return value type (got "p[T, T]", expected "p[S, T]")
-        t = t
-        s = s
-        p_s_t = None  # type: p[S, T]
-        return p_s_t
+        if 1:
+            t = t
+            s = s
+            p_s_t = None  # type: p[S, T]
+            return p_s_t
 [out]
 
 [case testProhibitTypeApplicationToGenericFunctions]
@@ -977,9 +971,12 @@ class C:
     a = A  # This is a variable
     b = Union[int, str]  # This is an alias
     c: Type[object] = Iterable[int]  # This is however also a variable
-    a = B
-    b = int  # E: Cannot assign multiple types to name "b" without an explicit "Type[...]" annotation
-    c = int
+    if int():
+        a = B
+    if int():
+        b = int  # E: Cannot assign multiple types to name "b" without an explicit "Type[...]" annotation
+    if int():
+        c = int
     def f(self, x: a) -> None: pass  # E: Invalid type "__main__.C.a"
     def g(self, x: b) -> None: pass
     def h(self, x: c) -> None: pass  # E: Invalid type "__main__.C.c"
@@ -1259,9 +1256,12 @@ list_a = [a]
 list_b = [b]
 list_b2 = [b2]
 
-a, b = list_a   # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-b, a = list_a   # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-b2, b2 = list_b # E: Incompatible types in assignment (expression has type "B", variable has type "B2")
+if int():
+    a, b = list_a   # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b, a = list_a   # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b2, b2 = list_b # E: Incompatible types in assignment (expression has type "B", variable has type "B2")
 
 a, a = list_a
 b, b2, b = list_b2
@@ -1416,13 +1416,17 @@ def f(a: List[T]) -> T: pass
 
 a, b = None, None # type: (A, B)
 
-b = f([a]) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = f([b]) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-a = f(b)   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    b = f([a]) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+    a = f([b]) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    a = f(b)   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 
-a = f([a])
-b = f([b])
-b = f(b)
+if int():
+    a = f([a])
+    b = f([b])
+if int():
+    b = f(b)
 [builtins fixtures/list.pyi]
 
 
@@ -1436,8 +1440,9 @@ def f() -> None:
     T = TypeVar('T')
     def g(x: T) -> T: pass
     a = g(1)
-    a = 1
-    a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+    if 1:
+        a = 1
+        a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
 
 [case testClassLevelTypeVariable]
@@ -1446,8 +1451,10 @@ class A:
     T = TypeVar('T')
     def g(self, x: T) -> T: pass
 a = A().g(1)
-a = 1
-a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    a = 1
+if int():
+    a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testGenericInnerClass]
 from typing import TypeVar, Generic
@@ -1500,28 +1507,44 @@ def f3(x: B) -> B: ...
 def f4(x: int) -> A: ...
 
 y1 = f1
-y1 = f1
-y1 = f2
-y1 = f3
-y1 = f4 # E: Incompatible types in assignment (expression has type "Callable[[int], A]", variable has type "Callable[[A], A]")
+if int():
+    y1 = f1
+if int():
+    y1 = f2
+if int():
+    y1 = f3
+if int():
+    y1 = f4 # E: Incompatible types in assignment (expression has type "Callable[[int], A]", variable has type "Callable[[A], A]")
 
 y2 = f2
-y2 = f2
-y2 = f1 # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[A], B]")
-y2 = f3 # E: Incompatible types in assignment (expression has type "Callable[[B], B]", variable has type "Callable[[A], B]")
-y2 = f4 # E: Incompatible types in assignment (expression has type "Callable[[int], A]", variable has type "Callable[[A], B]")
+if int():
+    y2 = f2
+if int():
+    y2 = f1 # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[A], B]")
+if int():
+    y2 = f3 # E: Incompatible types in assignment (expression has type "Callable[[B], B]", variable has type "Callable[[A], B]")
+if int():
+    y2 = f4 # E: Incompatible types in assignment (expression has type "Callable[[int], A]", variable has type "Callable[[A], B]")
 
 y3 = f3
-y3 = f3
-y3 = f1
-y3 = f2
-y3 = f4 # E: Incompatible types in assignment (expression has type "Callable[[int], A]", variable has type "Callable[[B], B]")
+if int():
+    y3 = f3
+if int():
+    y3 = f1
+if int():
+    y3 = f2
+if int():
+    y3 = f4 # E: Incompatible types in assignment (expression has type "Callable[[int], A]", variable has type "Callable[[B], B]")
 
 y4 = f4
-y4 = f4
-y4 = f1 # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[int], A]")
-y4 = f2
-y4 = f3 # E: Incompatible types in assignment (expression has type "Callable[[B], B]", variable has type "Callable[[int], A]")
+if int():
+    y4 = f4
+if int():
+    y4 = f1 # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[int], A]")
+if int():
+    y4 = f2
+if int():
+    y4 = f3 # E: Incompatible types in assignment (expression has type "Callable[[B], B]", variable has type "Callable[[int], A]")
 
 [case testSubtypingWithGenericInnerFunctions]
 from typing import TypeVar
@@ -1536,31 +1559,36 @@ def outer(t: T) -> None:
     def f5(x: T) -> T: ...
 
     y1 = f1
-    y1 = f2
-    y1 = f3 # E: Incompatible types in assignment (expression has type "Callable[[T], A]", variable has type "Callable[[A], A]")
-    y1 = f4 # E: Incompatible types in assignment (expression has type "Callable[[A], T]", variable has type "Callable[[A], A]")
-    y1 = f5 # E: Incompatible types in assignment (expression has type "Callable[[T], T]", variable has type "Callable[[A], A]")
+    if 1:
+        y1 = f2
+        y1 = f3 # E: Incompatible types in assignment (expression has type "Callable[[T], A]", variable has type "Callable[[A], A]")
+        y1 = f4 # E: Incompatible types in assignment (expression has type "Callable[[A], T]", variable has type "Callable[[A], A]")
+        y1 = f5 # E: Incompatible types in assignment (expression has type "Callable[[T], T]", variable has type "Callable[[A], A]")
 
     y2 = f2
-    y2 = f1 # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[A], B]")
+    if 1:
+        y2 = f1 # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[A], B]")
 
     y3 = f3
-    y3 = f1 # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[T], A]")
-    y3 = f2
-    y3 = f4 # E: Incompatible types in assignment (expression has type "Callable[[A], T]", variable has type "Callable[[T], A]")
-    y3 = f5 # E: Incompatible types in assignment (expression has type "Callable[[T], T]", variable has type "Callable[[T], A]")
+    if 1:
+        y3 = f1 # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[T], A]")
+        y3 = f2
+        y3 = f4 # E: Incompatible types in assignment (expression has type "Callable[[A], T]", variable has type "Callable[[T], A]")
+        y3 = f5 # E: Incompatible types in assignment (expression has type "Callable[[T], T]", variable has type "Callable[[T], A]")
 
     y4 = f4
-    y4 = f1 # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[A], T]")
-    y4 = f2
-    y4 = f3 # E: Incompatible types in assignment (expression has type "Callable[[T], A]", variable has type "Callable[[A], T]")
-    y4 = f5 # E: Incompatible types in assignment (expression has type "Callable[[T], T]", variable has type "Callable[[A], T]")
+    if 1:
+        y4 = f1 # E: Incompatible types in assignment (expression has type "Callable[[A], A]", variable has type "Callable[[A], T]")
+        y4 = f2
+        y4 = f3 # E: Incompatible types in assignment (expression has type "Callable[[T], A]", variable has type "Callable[[A], T]")
+        y4 = f5 # E: Incompatible types in assignment (expression has type "Callable[[T], T]", variable has type "Callable[[A], T]")
 
     y5 = f5
-    y5 = f1
-    y5 = f2
-    y5 = f3
-    y5 = f4
+    if 1:
+        y5 = f1
+        y5 = f2
+        y5 = f3
+        y5 = f4
 [out]
 
 [case testSubtypingWithGenericFunctionUsingTypevarWithValues]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -399,7 +399,7 @@ class A(Generic[T]):
         p_t_t = None  # type: p[T, T]
         if t:
             return p_t_t # E: Incompatible return value type (got "p[T, T]", expected "p[S, T]")
-        if int():
+        if 1:
             t = t
             s = s
             p_s_t = None  # type: p[S, T]

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -63,8 +63,10 @@ tmp/m.py:1: error: invalid syntax
 
 [case testIgnoreAssignmentTypeError]
 x = 1
-x = '' # type: ignore
-x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    x = '' # type: ignore
+if int():
+    x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testIgnoreInvalidOverride]
 class A:

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1114,13 +1114,14 @@ class C: pass
 
 [file c/submodule.py]
 val = 3  # type: int
-val = "foo"
+if int():
+    val = "foo"
 
 [builtins fixtures/module_all.pyi]
 [rechecked main, c, c.submodule]
 [stale c]
 [out2]
-tmp/c/submodule.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+tmp/c/submodule.py:3: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/main.py:7: error: "C" has no attribute "foo"
 
 [case testIncrementalRemoteError]
@@ -1339,8 +1340,9 @@ from mod4 import C
 class B:
     def makeC(self) -> C:
         val = 3  # type: int
-        val = "str"   # deliberately triggering error
-        return C()
+        if 1:
+            val = "str"   # deliberately triggering error
+            return C()
 
 [file mod3.py.2]
 from mod4 import C
@@ -1354,7 +1356,7 @@ class C:
 [rechecked mod3, mod2, mod1]
 [stale mod3, mod2]
 [out1]
-tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+tmp/mod3.py:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 
 [out2]
@@ -1378,8 +1380,9 @@ from mod4 import C
 class B:
     def makeC(self) -> C:
         val = 3  # type: int
-        val = "str"   # deliberately triggering error
-        return C()
+        if 1:
+            val = "str"   # deliberately triggering error
+            return C()
 
 [file mod4.py]
 class C:
@@ -1392,11 +1395,11 @@ class C:
 [rechecked mod4, mod3, mod2, mod1]
 [stale mod4]
 [out1]
-tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+tmp/mod3.py:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 
 [out2]
-tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+tmp/mod3.py:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/mod1.py:3: error: Revealed type is 'builtins.str'
 
 [case testIncrementalIncidentalChangeWithBugFixCausesPropagation]
@@ -1417,8 +1420,9 @@ from mod4 import C
 class B:
     def makeC(self) -> C:
         val = 3  # type: int
-        val = "str"   # deliberately triggering error
-        return C()
+        if 1:
+            val = "str"   # deliberately triggering error
+            return C()
 
 [file mod3.py.2]
 from mod4 import C
@@ -1436,7 +1440,7 @@ class C:
 [rechecked mod4, mod3, mod2, mod1]
 [stale mod4, mod3, mod2]
 [out1]
-tmp/mod3.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+tmp/mod3.py:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 tmp/mod1.py:3: error: Revealed type is 'builtins.int'
 
 [out2]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1340,7 +1340,7 @@ from mod4 import C
 class B:
     def makeC(self) -> C:
         val = 3  # type: int
-        if int():
+        if 1:
             val = "str"   # deliberately triggering error
             return C()
 
@@ -1380,7 +1380,7 @@ from mod4 import C
 class B:
     def makeC(self) -> C:
         val = 3  # type: int
-        if int():
+        if 1:
             val = "str"   # deliberately triggering error
             return C()
 
@@ -1420,7 +1420,7 @@ from mod4 import C
 class B:
     def makeC(self) -> C:
         val = 3  # type: int
-        if int():
+        if 1:
             val = "str"   # deliberately triggering error
             return C()
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1340,7 +1340,7 @@ from mod4 import C
 class B:
     def makeC(self) -> C:
         val = 3  # type: int
-        if 1:
+        if int():
             val = "str"   # deliberately triggering error
             return C()
 
@@ -1380,7 +1380,7 @@ from mod4 import C
 class B:
     def makeC(self) -> C:
         val = 3  # type: int
-        if 1:
+        if int():
             val = "str"   # deliberately triggering error
             return C()
 
@@ -1420,7 +1420,7 @@ from mod4 import C
 class B:
     def makeC(self) -> C:
         val = 3  # type: int
-        if 1:
+        if int():
             val = "str"   # deliberately triggering error
             return C()
 

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -11,9 +11,12 @@ ab = None # type: A[B]
 ao = None # type: A[object]
 b = None # type: B
 
-ao = f()
-ab = f()
-b = f() # E: Incompatible types in assignment (expression has type "A[<nothing>]", variable has type "B")
+if int():
+    ao = f()
+if int():
+    ab = f()
+if int():
+    b = f() # E: Incompatible types in assignment (expression has type "A[<nothing>]", variable has type "B")
 
 def f() -> 'A[T]': pass
 
@@ -27,9 +30,12 @@ ab = None # type: A[B]
 ao = None # type: A[object]
 b = None # type: B
 
-ao = A()
-ab = A()
-b = A() # E: Incompatible types in assignment (expression has type "A[<nothing>]", variable has type "B")
+if int():
+    ao = A()
+if int():
+    ab = A()
+if int():
+    b = A() # E: Incompatible types in assignment (expression has type "A[<nothing>]", variable has type "B")
 
 class A(Generic[T]): pass
 class B: pass
@@ -43,13 +49,19 @@ ab = None # type: A[B]
 ao = None # type: A[object]
 ac = None # type: A[C]
 
-ac = f(b) # E: Argument 1 to "f" has incompatible type "B"; expected "C"
-ab = f(c) # E: Argument 1 to "f" has incompatible type "C"; expected "B"
+if int():
+    ac = f(b) # E: Argument 1 to "f" has incompatible type "B"; expected "C"
+if int():
+    ab = f(c) # E: Argument 1 to "f" has incompatible type "C"; expected "B"
 
-ao = f(b)
-ab = f(b)
-ao = f(c)
-ac = f(c)
+if int():
+    ao = f(b)
+if int():
+    ab = f(b)
+if int():
+    ao = f(c)
+if int():
+    ac = f(c)
 
 def f(a: T) -> 'A[T]':
     pass
@@ -74,11 +86,13 @@ def g() -> None:
     b = None # type: B
 
     x = f(o)
-    ab = x # E: Incompatible types in assignment (expression has type "A[object]", variable has type "A[B]")
-    ao = x
+    if 1:
+        ab = x # E: Incompatible types in assignment (expression has type "A[object]", variable has type "A[B]")
+        ao = x
     y = f(b)
-    ao = y # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
-    ab = y
+    if 1:
+        ao = y # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
+        ab = y
 
 def f(a: T) -> 'A[T]': pass
 
@@ -104,10 +118,11 @@ def g() -> None:
     ab = None # type: A[B]
     b = None # type: B
     x, y = f(b), f(b)
-    ao = x # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
-    ao = y # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
-    ab = x
-    ab = y
+    if 1:
+        ao = x # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
+        ao = y # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
+        ab = x
+        ab = y
 
 def f(a: T) -> 'A[T]': pass
 class A(Generic[T]): pass
@@ -122,10 +137,11 @@ def h() -> None:
     ab = None # type: A[B]
     b = None # type: B
     x, y = g(f(b))
-    ao = x # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
-    ao = y # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
-    ab = x
-    ab = y
+    if 1:
+        ao = x # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
+        ao = y # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
+        ab = x
+        ab = y
 
 def f(a: T) -> 'A[T]': pass
 def g(a: T) -> List[T]: pass
@@ -148,21 +164,23 @@ o = None # type: object
 ab = None # type: A[B]
 ao = None # type: A[object]
 
-ab, ao = f(b) # Fail
-ao, ab = f(b) # Fail
+if int():
+    ab, ao = f(b) # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
+if int():
+    ao, ab = f(b) # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
 
-ao, ao = f(b)
-ab, ab = f(b)
-ao, ao = f(o)
+if int():
+    ao, ao = f(b)
+if int():
+    ab, ab = f(b)
+if int():
+    ao, ao = f(o)
 
 def f(a: T) -> 'Tuple[A[T], A[T]]': pass
 
 class A(Generic[T]): pass
 class B: pass
 [builtins fixtures/tuple.pyi]
-[out]
-main:8: error: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
-main:9: error: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
 
 [case testInferenceWithTypeVariableTwiceInReturnTypeAndMultipleVariables]
 from typing import TypeVar, Tuple, Generic
@@ -173,14 +191,21 @@ o = None # type: object
 ab = None # type: A[B]
 ao = None # type: A[object]
 
-ao, ao, ab = f(b, b)     # Fail
-ao, ab, ao = g(b, b)     # Fail
-ao, ab, ab, ab = h(b, b) # Fail
-ab, ab, ao, ab = h(b, b) # Fail
+if int():
+    ao, ao, ab = f(b, b)     # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
+if int():
+    ao, ab, ao = g(b, b)     # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
+if int():
+    ao, ab, ab, ab = h(b, b) # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
+if int():
+    ab, ab, ao, ab = h(b, b) # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
 
-ao, ab, ab = f(b, b)
-ab, ab, ao = g(b, b)
-ab, ab, ab, ab = h(b, b)
+if int():
+    ao, ab, ab = f(b, b)
+if int():
+    ab, ab, ao = g(b, b)
+if int():
+    ab, ab, ab, ab = h(b, b)
 
 def f(a: S, b: T) -> 'Tuple[A[S], A[T], A[T]]': pass
 def g(a: S, b: T) -> 'Tuple[A[S], A[S], A[T]]': pass
@@ -189,11 +214,6 @@ def h(a: S, b: T) -> 'Tuple[A[S], A[S], A[T], A[T]]': pass
 class A(Generic[T]): pass
 class B: pass
 [builtins fixtures/tuple.pyi]
-[out]
-main:9: error: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
-main:10: error: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
-main:11: error: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
-main:12: error: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
 
 
 -- Multiple tvar instances in arguments
@@ -210,14 +230,21 @@ b = None # type: B
 c = None # type: C
 o = None # type: object
 
-ab = f(b, o) # E: Argument 2 to "f" has incompatible type "object"; expected "B"
-ab = f(o, b) # E: Argument 1 to "f" has incompatible type "object"; expected "B"
-ac = f(b, c) # E: Argument 1 to "f" has incompatible type "B"; expected "C"
-ac = f(c, b) # E: Argument 2 to "f" has incompatible type "B"; expected "C"
+if int():
+    ab = f(b, o) # E: Argument 2 to "f" has incompatible type "object"; expected "B"
+if int():
+    ab = f(o, b) # E: Argument 1 to "f" has incompatible type "object"; expected "B"
+if int():
+    ac = f(b, c) # E: Argument 1 to "f" has incompatible type "B"; expected "C"
+if int():
+    ac = f(c, b) # E: Argument 2 to "f" has incompatible type "B"; expected "C"
 
-ao = f(b, c)
-ao = f(c, b)
-ab = f(c, b)
+if int():
+    ao = f(b, c)
+if int():
+    ao = f(c, b)
+if int():
+    ab = f(c, b)
 
 def f(a: T, b: T) -> 'A[T]': pass
 
@@ -239,11 +266,13 @@ ao = None # type: A[object]
 b = None # type: B
 o = None # type: object
 
-aab = f(f(o)) # E: Argument 1 to "f" has incompatible type "object"; expected "B"
+if int():
+    aab = f(f(o)) # E: Argument 1 to "f" has incompatible type "object"; expected "B"
 
-aab = f(f(b))
-aao = f(f(b))
-ao = f(f(b))
+if int():
+    aab = f(f(b))
+    aao = f(f(b))
+    ao = f(f(b))
 
 def f(a: T) -> 'A[T]': pass
 
@@ -258,10 +287,12 @@ ao = None # type: A[object]
 b = None # type: B
 o = None # type: object
 
-ab = f(g(o)) # E: Argument 1 to "g" has incompatible type "object"; expected "B"
+if int():
+    ab = f(g(o)) # E: Argument 1 to "g" has incompatible type "object"; expected "B"
 
-ab = f(g(b))
-ao = f(g(b))
+if int():
+    ab = f(g(b))
+    ao = f(g(b))
 
 def f(a: T) -> T: pass
 
@@ -278,12 +309,16 @@ ao = None # type: A[object]
 b = None # type: B
 o = None # type: object
 
-ab = f(g(o), g(b)) # E: Argument 1 to "g" has incompatible type "object"; expected "B"
-ab = f(g(b), g(o)) # E: Argument 1 to "g" has incompatible type "object"; expected "B"
+if int():
+    ab = f(g(o), g(b)) # E: Argument 1 to "g" has incompatible type "object"; expected "B"
+if int():
+    ab = f(g(b), g(o)) # E: Argument 1 to "g" has incompatible type "object"; expected "B"
 
-ab = f(g(b), g(b))
-ao = f(g(b), g(o))
-ao = f(g(o), g(b))
+if int():
+    ab = f(g(b), g(b))
+    ao = f(g(b), g(o))
+if int():
+    ao = f(g(o), g(b))
 
 def f(a: T, b: T) -> T:
     pass
@@ -309,10 +344,13 @@ ab = None # type: A[B]
 ac = None # type: A[C]
 
 ab.g(f(o))        # E: Argument 1 to "f" has incompatible type "object"; expected "B"
-ac = f(b).g(f(c)) # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[C]")
-ac = f(c).g(f(b)) # E: Argument 1 to "f" has incompatible type "B"; expected "C"
+if int():
+    ac = f(b).g(f(c)) # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[C]")
+if int():
+    ac = f(c).g(f(b)) # E: Argument 1 to "f" has incompatible type "B"; expected "C"
 
-ab = f(b).g(f(c))
+if int():
+    ab = f(b).g(f(c))
 ab.g(f(c))
 
 def f(a: T) -> 'A[T]': pass
@@ -333,6 +371,7 @@ from typing import List
 aa = None # type: List[A]
 ao = None # type: List[object]
 a = None # type: A
+def f(): a, aa, ao # Prevent redefinition
 
 a = [] # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "A")
 
@@ -349,6 +388,7 @@ ab = None # type: List[B]
 ao = None # type: List[object]
 a = None # type: A
 b = None # type: B
+def f(): aa, ab, ao # Prevent redefinition
 
 aa = [b] # E: List item 0 has incompatible type "B"; expected "A"
 ab = [a] # E: List item 0 has incompatible type "A"; expected "B"
@@ -370,6 +410,7 @@ ab = None # type: List[B]
 ao = None # type: List[object]
 a = None # type: A
 b = None # type: B
+def f(): ab, aa, ao # Prevent redefinition
 
 ab = [b, a] # E: List item 1 has incompatible type "A"; expected "B"
 ab = [a, b] # E: List item 0 has incompatible type "A"; expected "B"
@@ -387,8 +428,9 @@ def f() -> None:
     a = []     # E: Need type annotation for 'a'
     b = [None]
     c = [B()]
-    c = [object()] # E: List item 0 has incompatible type "object"; expected "B"
-    c = [B()]
+    if 1:
+        c = [object()] # E: List item 0 has incompatible type "object"; expected "B"
+        c = [B()]
 class B: pass
 [builtins fixtures/list.pyi]
 [out]
@@ -400,6 +442,7 @@ aab = None # type: List[List[B]]
 ab = None # type: List[B]
 b = None # type: B
 o = None # type: object
+def f(): aao, aab # Prevent redefinition
 
 aao = [[o], ab] # E: List item 1 has incompatible type "List[B]"; expected "List[object]"
 aab = [[], [o]] # E: List item 0 has incompatible type "object"; expected "B"
@@ -529,7 +572,8 @@ class set(Generic[t]):
     def __init__(self, iterable: Iterable[t]) -> None: pass
 b = bool()
 l = set([b])
-l = set([object()]) # E: List item 0 has incompatible type "object"; expected "bool"
+if int():
+    l = set([object()]) # E: List item 0 has incompatible type "object"; expected "bool"
 [builtins fixtures/for.pyi]
 
 
@@ -554,8 +598,9 @@ class C(Generic[s, t]): pass
 [case testInferLambdaArgumentTypeUsingContext]
 from typing import Callable
 f = None # type: Callable[[B], A]
-f = lambda x: x.o
-f = lambda x: x.x # E: "B" has no attribute "x"
+if int():
+    f = lambda x: x.o
+    f = lambda x: x.x # E: "B" has no attribute "x"
 class A: pass
 class B:
   o = None # type: A
@@ -563,8 +608,9 @@ class B:
 [case testInferLambdaReturnTypeUsingContext]
 from typing import List, Callable
 f = None # type: Callable[[], List[A]]
-f = lambda: []
-f = lambda: [B()]  # E: List item 0 has incompatible type "B"; expected "A"
+if int():
+    f = lambda: []
+    f = lambda: [B()]  # E: List item 0 has incompatible type "B"; expected "A"
 class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
@@ -690,11 +736,16 @@ a = m # type: List[A] # E: Incompatible types in assignment (expression has type
 [case testOrOperationInferredFromContext]
 from typing import List
 a, b, c = None, None, None # type: (List[A], List[B], List[C])
-a = a or []
-a = [] or a
-b = b or [C()]
-a = a or b # E: Incompatible types in assignment (expression has type "Union[List[A], List[B]]", variable has type "List[A]")
-b = b or c # E: Incompatible types in assignment (expression has type "Union[List[B], List[C]]", variable has type "List[B]")
+if int():
+    a = a or []
+if int():
+    a = [] or a
+if int():
+    b = b or [C()]
+if int():
+    a = a or b # E: Incompatible types in assignment (expression has type "Union[List[A], List[B]]", variable has type "List[A]")
+if int():
+    b = b or c # E: Incompatible types in assignment (expression has type "Union[List[B], List[C]]", variable has type "List[B]")
 
 class A: pass
 class B: pass
@@ -712,8 +763,10 @@ t = TypeVar('t')
 s = TypeVar('s')
 # Some type variables can be inferred using context, but not all of them.
 a = None # type: List[A]
-a = f(A(), B())
-a = f(B(), B()) # E: Argument 1 to "f" has incompatible type "B"; expected "A"
+if int():
+    a = f(A(), B())
+if int():
+    a = f(B(), B()) # E: Argument 1 to "f" has incompatible type "B"; expected "A"
 def f(a: s, b: t) -> List[s]: pass
 class A: pass
 class B: pass
@@ -725,8 +778,10 @@ s = TypeVar('s')
 t = TypeVar('t')
 # Like testSomeTypeVarsInferredFromContext, but tvars in different order.
 a = None # type: List[A]
-a = f(A(), B())
-a = f(B(), B()) # E: Argument 1 to "f" has incompatible type "B"; expected "A"
+if int():
+    a = f(A(), B())
+if int():
+    a = f(B(), B()) # E: Argument 1 to "f" has incompatible type "B"; expected "A"
 def f(a: s, b: t) -> List[s]: pass
 class A: pass
 class B: pass
@@ -747,8 +802,10 @@ class A: pass
 from typing import List
 i = None # type: List[int]
 s = None # type: List[str]
-i = i = []
-i = s = [] # E: Incompatible types in assignment (expression has type "List[str]", variable has type "List[int]")
+if int():
+    i = i = []
+if int():
+    i = s = [] # E: Incompatible types in assignment (expression has type "List[str]", variable has type "List[int]")
 [builtins fixtures/list.pyi]
 
 [case testContextForAttributeDeclaredInInit]
@@ -765,8 +822,9 @@ a.x = [''] # E: List item 0 has incompatible type "str"; expected "int"
 [case testListMultiplyInContext]
 from typing import List
 a = None  # type: List[int]
-a = [None] * 3
-a = [''] * 3 # E: List item 0 has incompatible type "str"; expected "int"
+if int():
+    a = [None] * 3
+    a = [''] * 3 # E: List item 0 has incompatible type "str"; expected "int"
 [builtins fixtures/list.pyi]
 
 [case testUnionTypeContext]

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -86,11 +86,11 @@ def g() -> None:
     b = None # type: B
 
     x = f(o)
-    if 1:
+    if int():
         ab = x # E: Incompatible types in assignment (expression has type "A[object]", variable has type "A[B]")
         ao = x
     y = f(b)
-    if 1:
+    if int():
         ao = y # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
         ab = y
 
@@ -118,7 +118,7 @@ def g() -> None:
     ab = None # type: A[B]
     b = None # type: B
     x, y = f(b), f(b)
-    if 1:
+    if int():
         ao = x # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
         ao = y # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
         ab = x
@@ -137,7 +137,7 @@ def h() -> None:
     ab = None # type: A[B]
     b = None # type: B
     x, y = g(f(b))
-    if 1:
+    if int():
         ao = x # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
         ao = y # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
         ab = x
@@ -428,7 +428,7 @@ def f() -> None:
     a = []     # E: Need type annotation for 'a'
     b = [None]
     c = [B()]
-    if 1:
+    if int():
         c = [object()] # E: List item 0 has incompatible type "object"; expected "B"
         c = [B()]
 class B: pass

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1052,7 +1052,7 @@ def f() -> None:
     if int():
         a = B() \
             # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    for a in []: pass # E: Need type annotation for 'a'
+    for a in []: pass
     a = A()
     if int():
         a = B() \
@@ -2435,9 +2435,8 @@ _ = '' # E: Incompatible types in assignment (expression has type "str", variabl
 
 [case testUnusedTargetNotClass]
 class C:
-    _, _ = 0, 0
-    _ = ''
-reveal_type(C._) # E: Revealed type is 'builtins.str'
+    _ = 0
+    _ = ''  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testUnusedTargetTupleUnpacking]
 def foo() -> None:

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -22,7 +22,7 @@ import typing
 def f() -> None:
     x = A()
     y = B()
-    if 1:
+    if int():
         x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         x = A()
         x = y   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
@@ -44,7 +44,7 @@ def g() -> None: pass
 import typing
 def f(a: 'A') -> None:
     b = a
-    if 1:
+    if int():
         b = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         b = a
         a = b
@@ -59,7 +59,7 @@ g = None # type: B
 
 def f() -> None:
     a = g
-    if 1:
+    if int():
         a = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
         a = B()
 
@@ -98,7 +98,7 @@ def f() -> None:
     a = A(), B()
     aa = None # type: A
     bb = None # type: B
-    if 1:
+    if int():
         bb = a[0] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
         aa = a[1] # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         aa = a[0]
@@ -129,7 +129,7 @@ a_s = None # type: A[str]
 def f() -> None:
     a_int = A() # type: A[int]
     a = a_int
-    if 1:
+    if int():
         a = a_s # E: Incompatible types in assignment (expression has type "A[str]", variable has type "A[int]")
         a = a_i
 [builtins fixtures/tuple.pyi]
@@ -168,7 +168,7 @@ class A: pass
 import typing
 def f() -> None:
     a, b = A(), B()
-    if 1:
+    if int():
         a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
@@ -185,7 +185,7 @@ from typing import Tuple
 def f() -> None:
     t = None # type: Tuple[A, B]
     a, b = t
-    if 1:
+    if int():
         a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
@@ -202,7 +202,7 @@ from typing import Tuple
 def f() -> None:
     t = None # type: Tuple[A, B]
     a1, (a, b) = A(), t
-    if 1:
+    if int():
         a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
@@ -218,7 +218,7 @@ class B: pass
 import typing
 def f() -> None:
     a, (b, c) = A(), (B(), C())
-    if 1:
+    if int():
         a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
@@ -237,7 +237,7 @@ class C: pass
 import typing
 def f() -> None:
     a, (b, c) = A(), [B(), C()]
-    if 1:
+    if int():
         a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
@@ -311,7 +311,7 @@ def f() -> None:
     list_d = [D()]
     a, b = list_c
     c, d, e = list_d
-    if 1:
+    if int():
         a = D() # E: Incompatible types in assignment (expression has type "D", variable has type "C")
         b = D() # E: Incompatible types in assignment (expression has type "D", variable has type "C")
         c = C() # E: Incompatible types in assignment (expression has type "C", variable has type "D")
@@ -340,7 +340,7 @@ def f() -> None:
     list_d = [D()]
     c1, (a, b) = C(), list_c
     c2, (c, d, e) = C(), list_d
-    if 1:
+    if int():
         a = D() # E: Incompatible types in assignment (expression has type "D", variable has type "C")
         b = D() # E: Incompatible types in assignment (expression has type "D", variable has type "C")
         c = C() # E: Incompatible types in assignment (expression has type "C", variable has type "D")
@@ -423,7 +423,7 @@ def f() -> None:
     a = id
     b = None # type: int
     c = None # type: str
-    if 1:
+    if int():
         b = a(c) # E: Incompatible types in assignment (expression has type "str", variable has type "int")
         b = a(b)
         c = a(c)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -6,30 +6,30 @@
 import typing
 x = A()
 y = B()
-x = B() # Fail
-x = A()
-x = y   # Fail
-x = x
+if int():
+    x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    x = A()
+if int():
+    x = y   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    x = x
 class A: pass
 class B: pass
-[out]
-main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
-main:6: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testInferSimpleLvarType]
 import typing
 def f() -> None:
     x = A()
     y = B()
-    x = B() # Fail
-    x = A()
-    x = y   # Fail
-    x = x
+    if 1:
+        x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        x = A()
+        x = y   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        x = x
 class A: pass
 class B: pass
 [out]
-main:5: error: Incompatible types in assignment (expression has type "B", variable has type "A")
-main:7: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testLvarInitializedToVoid]
 import typing
@@ -44,9 +44,10 @@ def g() -> None: pass
 import typing
 def f(a: 'A') -> None:
     b = a
-    b = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    b = a
-    a = b
+    if 1:
+        b = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        b = a
+        a = b
 
 class A: pass
 class B: pass
@@ -58,8 +59,9 @@ g = None # type: B
 
 def f() -> None:
     a = g
-    a = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-    a = B()
+    if 1:
+        a = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+        a = B()
 
 class A: pass
 class B: pass
@@ -96,10 +98,11 @@ def f() -> None:
     a = A(), B()
     aa = None # type: A
     bb = None # type: B
-    bb = a[0] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-    aa = a[1] # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    aa = a[0]
-    bb = a[1]
+    if 1:
+        bb = a[0] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+        aa = a[1] # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        aa = a[0]
+        bb = a[1]
 
 class A: pass
 class B: pass
@@ -126,8 +129,9 @@ a_s = None # type: A[str]
 def f() -> None:
     a_int = A() # type: A[int]
     a = a_int
-    a = a_s # E: Incompatible types in assignment (expression has type "A[str]", variable has type "A[int]")
-    a = a_i
+    if 1:
+        a = a_s # E: Incompatible types in assignment (expression has type "A[str]", variable has type "A[int]")
+        a = a_i
 [builtins fixtures/tuple.pyi]
 [out]
 
@@ -164,12 +168,13 @@ class A: pass
 import typing
 def f() -> None:
     a, b = A(), B()
-    a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+    if 1:
+        a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-    a = A()
-    b = B()
+        a = A()
+        b = B()
 
 class A: pass
 class B: pass
@@ -180,12 +185,13 @@ from typing import Tuple
 def f() -> None:
     t = None # type: Tuple[A, B]
     a, b = t
-    a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+    if 1:
+        a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-    a = A()
-    b = B()
+        a = A()
+        b = B()
 
 class A: pass
 class B: pass
@@ -196,12 +202,13 @@ from typing import Tuple
 def f() -> None:
     t = None # type: Tuple[A, B]
     a1, (a, b) = A(), t
-    a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+    if 1:
+        a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-    a = A()
-    b = B()
+        a = A()
+        b = B()
 
 class A: pass
 class B: pass
@@ -211,14 +218,15 @@ class B: pass
 import typing
 def f() -> None:
     a, (b, c) = A(), (B(), C())
-    a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-    c = A() # E: Incompatible types in assignment (expression has type "A", variable has type "C")
+    if 1:
+        a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+        c = A() # E: Incompatible types in assignment (expression has type "A", variable has type "C")
 
-    a = A()
-    b = B()
-    c = C()
+        a = A()
+        b = B()
+        c = C()
 
 class A: pass
 class B: pass
@@ -229,14 +237,15 @@ class C: pass
 import typing
 def f() -> None:
     a, (b, c) = A(), [B(), C()]
-    a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-    c = A() # E: Incompatible types in assignment (expression has type "A", variable has type "C")
+    if 1:
+        a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+        c = A() # E: Incompatible types in assignment (expression has type "A", variable has type "C")
 
-    a = A()
-    b = B()
-    c = C()
+        a = A()
+        b = B()
+        c = C()
 
 class A: pass
 class B: pass
@@ -302,20 +311,21 @@ def f() -> None:
     list_d = [D()]
     a, b = list_c
     c, d, e = list_d
-    a = D() # E: Incompatible types in assignment (expression has type "D", variable has type "C")
-    b = D() # E: Incompatible types in assignment (expression has type "D", variable has type "C")
-    c = C() # E: Incompatible types in assignment (expression has type "C", variable has type "D")
-    b = c   # E: Incompatible types in assignment (expression has type "D", variable has type "C")
+    if 1:
+        a = D() # E: Incompatible types in assignment (expression has type "D", variable has type "C")
+        b = D() # E: Incompatible types in assignment (expression has type "D", variable has type "C")
+        c = C() # E: Incompatible types in assignment (expression has type "C", variable has type "D")
+        b = c   # E: Incompatible types in assignment (expression has type "D", variable has type "C")
 
-    a = C()
-    b = C()
-    c = D()
-    d = D()
-    e = D()
+        a = C()
+        b = C()
+        c = D()
+        d = D()
+        e = D()
 
-    a = b
-    c = d
-    d = e
+        a = b
+        c = d
+        d = e
 [builtins fixtures/for.pyi]
 [out]
 
@@ -330,20 +340,21 @@ def f() -> None:
     list_d = [D()]
     c1, (a, b) = C(), list_c
     c2, (c, d, e) = C(), list_d
-    a = D() # E: Incompatible types in assignment (expression has type "D", variable has type "C")
-    b = D() # E: Incompatible types in assignment (expression has type "D", variable has type "C")
-    c = C() # E: Incompatible types in assignment (expression has type "C", variable has type "D")
-    b = c   # E: Incompatible types in assignment (expression has type "D", variable has type "C")
+    if 1:
+        a = D() # E: Incompatible types in assignment (expression has type "D", variable has type "C")
+        b = D() # E: Incompatible types in assignment (expression has type "D", variable has type "C")
+        c = C() # E: Incompatible types in assignment (expression has type "C", variable has type "D")
+        b = c   # E: Incompatible types in assignment (expression has type "D", variable has type "C")
 
-    a = C()
-    b = C()
-    c = D()
-    d = D()
-    e = D()
+        a = C()
+        b = C()
+        c = D()
+        d = D()
+        e = D()
 
-    a = b
-    c = d
-    d = e
+        a = b
+        c = d
+        d = e
 [builtins fixtures/for.pyi]
 [out]
 
@@ -368,9 +379,12 @@ class Nums(Iterable[int]):
     def __iter__(self): pass
     def __next__(self): pass
 a, b = Nums()
-a = b = 1
-a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-b = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    a = b = 1
+if int():
+    a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    b = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [builtins fixtures/for.pyi]
 
 
@@ -385,13 +399,16 @@ a = None # type: A
 b = None # type: B
 c = None # type: Tuple[A, object]
 
-b = id(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = id(b) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-a = id(c) # E: Incompatible types in assignment (expression has type "Tuple[A, object]", variable has type "A")
+if int():
+    b = id(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+    a = id(b) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    a = id(c) # E: Incompatible types in assignment (expression has type "Tuple[A, object]", variable has type "A")
 
-a = id(a)
-b = id(b)
-c = id(c)
+if int():
+    a = id(a)
+    b = id(b)
+    c = id(c)
 
 def id(a: T) -> T: pass
 
@@ -406,9 +423,10 @@ def f() -> None:
     a = id
     b = None # type: int
     c = None # type: str
-    b = a(c) # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-    b = a(b)
-    c = a(c)
+    if 1:
+        b = a(c) # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+        b = a(b)
+        c = a(c)
 def id(x: T) -> T:
     return x
 [out]
@@ -437,10 +455,14 @@ T = TypeVar('T')
 a = None # type: A
 b = None # type: B
 
-b = f(a, b) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-b = f(b, a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = f(a, b)
-a = f(b, a)
+if int():
+    b = f(a, b) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b = f(b, a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = f(a, b)
+if int():
+    a = f(b, a)
 
 def f(a: T, b: T) -> T: pass
 
@@ -456,23 +478,24 @@ taa = None # type: Tuple[A, A]
 tab = None # type: Tuple[A, B]
 tba = None # type: Tuple[B, A]
 
-taa = f(a, b) # Fail
-taa = f(b, a) # Fail
-tba = f(a, b) # Fail
+if int():
+    taa = f(a, b) # E: Argument 2 to "f" has incompatible type "B"; expected "A"
+if int():
+    taa = f(b, a) # E: Argument 1 to "f" has incompatible type "B"; expected "A"
+if int():
+    tba = f(a, b) # E: Argument 1 to "f" has incompatible type "A"; expected "B" \
+                  # E: Argument 2 to "f" has incompatible type "B"; expected "A"
 
-tab = f(a, b)
-tba = f(b, a)
+if int():
+    tab = f(a, b)
+if int():
+    tba = f(b, a)
 
 def f(a: T, b: S) -> Tuple[T, S]: pass
 
 class A: pass
 class B: pass
 [builtins fixtures/tuple.pyi]
-[out]
-main:9: error: Argument 2 to "f" has incompatible type "B"; expected "A"
-main:10: error: Argument 1 to "f" has incompatible type "B"; expected "A"
-main:11: error: Argument 1 to "f" has incompatible type "A"; expected "B"
-main:11: error: Argument 2 to "f" has incompatible type "B"; expected "A"
 
 [case testConstraintSolvingWithSimpleGenerics]
 from typing import TypeVar, Generic
@@ -481,18 +504,23 @@ ao = None # type: A[object]
 ab = None # type: A[B]
 ac = None # type: A[C]
 
-ab = f(ao) # E: Argument 1 to "f" has incompatible type "A[object]"; expected "A[B]"
-ao = f(ab) # E: Argument 1 to "f" has incompatible type "A[B]"; expected "A[object]"
-ab = f(ac) # E: Argument 1 to "f" has incompatible type "A[C]"; expected "A[B]"
-ab = g(ao) # E: Argument 1 to "g" has incompatible type "A[object]"; expected "A[B]"
-ao = g(ab) # E: Argument 1 to "g" has incompatible type "A[B]"; expected "A[object]"
+if int():
+    ab = f(ao) # E: Argument 1 to "f" has incompatible type "A[object]"; expected "A[B]"
+    ao = f(ab) # E: Argument 1 to "f" has incompatible type "A[B]"; expected "A[object]"
+if int():
+    ab = f(ac) # E: Argument 1 to "f" has incompatible type "A[C]"; expected "A[B]"
+if int():
+    ab = g(ao) # E: Argument 1 to "g" has incompatible type "A[object]"; expected "A[B]"
+    ao = g(ab) # E: Argument 1 to "g" has incompatible type "A[B]"; expected "A[object]"
 
-ab = f(ab)
-ac = f(ac)
-ao = f(ao)
+if int():
+    ab = f(ab)
+    ac = f(ac)
+    ao = f(ao)
 
-ab = g(ab)
-ao = g(ao)
+if int():
+    ab = g(ab)
+    ao = g(ao)
 
 def f(a: 'A[T]') -> 'A[T]': pass
 
@@ -524,13 +552,19 @@ T = TypeVar('T')
 a = None # type: A
 o = None # type: object
 
-a = f(o)    # E: Incompatible types in assignment (expression has type "object", variable has type "A")
-a = g(a, o) # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+if int():
+    a = f(o)    # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+if int():
+    a = g(a, o) # E: Incompatible types in assignment (expression has type "object", variable has type "A")
 
-o = f()
-o = f(o)
-a = f(a)
-a = g(a)
+if int():
+    o = f()
+if int():
+    o = f(o)
+if int():
+    a = f(a)
+if int():
+    a = g(a)
 
 def f(a: T = None) -> T: pass
 def g(a: T, b: T = None) -> T: pass
@@ -647,9 +681,11 @@ def f(x: bool) -> A: pass
 def mymap(f: Callable[[t], s], a: List[t]) -> List[s]: pass
 
 l = mymap(f, [b])
-l = [A()]
+if int():
+    l = [A()]
 lb = [b]
-l = lb # E: Incompatible types in assignment (expression has type "List[bool]", variable has type "List[A]")
+if int():
+    l = lb # E: Incompatible types in assignment (expression has type "List[bool]", variable has type "List[A]")
 [builtins fixtures/for.pyi]
 
 [case testGenericFunctionWithTypeTypeAsCallable]
@@ -792,11 +828,15 @@ S = TypeVar('S')
 def k1(x: int, y: List[T]) -> List[Union[T, int]]: pass
 def k2(x: S, y: List[T]) -> List[Union[T, int]]: pass
 a = k2
-a = k2
-a = k1 # E: Incompatible types in assignment (expression has type "Callable[[int, List[T]], List[Union[T, int]]]", variable has type "Callable[[S, List[T]], List[Union[T, int]]]")
+if int():
+    a = k2
+if int():
+    a = k1 # E: Incompatible types in assignment (expression has type "Callable[[int, List[T]], List[Union[T, int]]]", variable has type "Callable[[S, List[T]], List[Union[T, int]]]")
 b = k1
-b = k1
-b = k2
+if int():
+    b = k1
+if int():
+    b = k2
 [builtins fixtures/list.pyi]
 
 [case testAmbiguousUnionContextAndMultipleInheritance]
@@ -840,8 +880,10 @@ def d_ab() -> Dict[A, B]: return {}
 def d_aa() -> Dict[A, A]: return {}
 a, b = None, None # type: (A, B)
 d = {a:b}
-d = d_ab()
-d = d_aa() # E: Incompatible types in assignment (expression has type "Dict[A, A]", variable has type "Dict[A, B]")
+if int():
+    d = d_ab()
+if int():
+    d = d_aa() # E: Incompatible types in assignment (expression has type "Dict[A, A]", variable has type "Dict[A, B]")
 [builtins fixtures/dict.pyi]
 
 [case testSetLiteral]
@@ -850,9 +892,12 @@ a, x = None, None # type: (int, Any)
 def s_i() -> Set[int]: return set()
 def s_s() -> Set[str]: return set()
 s = {a}
-s = {x}
-s = s_i()
-s = s_s() # E: Incompatible types in assignment (expression has type "Set[str]", variable has type "Set[int]")
+if int():
+    s = {x}
+if int():
+    s = s_i()
+if int():
+    s = s_s() # E: Incompatible types in assignment (expression has type "Set[str]", variable has type "Set[int]")
 [builtins fixtures/set.pyi]
 
 [case testSetWithStarExpr]
@@ -990,23 +1035,28 @@ def f() -> None: pass
 import typing
 for a in [A()]: pass
 a = A()
-a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-for a in []: pass
-a = A()
-a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    for a in []: pass
+    a = A()
+    a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 class A: pass
 class B: pass
 [builtins fixtures/for.pyi]
 
 [case testReusingInferredForIndex2]
-import typing
 def f() -> None:
     for a in [A()]: pass
     a = A()
-    a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    for a in []: pass
+    a
+    if int():
+        a = B() \
+            # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    for a in []: pass # E: Need type annotation for 'a'
     a = A()
-    a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    if int():
+        a = B() \
+            # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 class A: pass
 class B: pass
 [builtins fixtures/for.pyi]
@@ -1018,42 +1068,51 @@ class B: pass
 
 
 [case testMultipleAssignmentWithPartialDefinition]
-
 a = None # type: A
-x, a = a, a
-x = a
-a = x
-x = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
-a = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+if int():
+    x, a = a, a
+    if int():
+        x = a
+    a = x
+    if int():
+        x = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+    a = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
 class A: pass
 
 [case testMultipleAssignmentWithPartialDefinition2]
-
 a = None # type: A
-a, x = [a, a]
-x = a
-a = x
-x = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
-a = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+if int():
+    a, x = [a, a]
+    if int():
+        x = a
+    a = x
+    if int():
+        x = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+    a = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
 class A: pass
 [builtins fixtures/for.pyi]
 
 [case testMultipleAssignmentWithPartialDefinition3]
 from typing import Any, cast
 a = None # type: A
-x, a = cast(Any, a)
-x = a
-a = x
-x = object()
-a = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+if int():
+    x, a = cast(Any, a)
+    if int():
+        x = a
+    a = x
+    if int():
+        x = object()
+    a = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
 class A: pass
 
 [case testInferGlobalDefinedInBlock]
 import typing
 if A:
     a = A()
-    a = A()
-    a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    if int():
+        a = A()
+    if int():
+        a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 class A: pass
 class B: pass
 
@@ -1204,8 +1263,9 @@ from typing import List
 a = None # type: List[A]
 o = None # type: List[object]
 a2 = a or []
-a = a2
-a2 = o # E: Incompatible types in assignment (expression has type "List[object]", variable has type "List[A]")
+if int():
+    a = a2
+    a2 = o # E: Incompatible types in assignment (expression has type "List[object]", variable has type "List[A]")
 class A: pass
 [builtins fixtures/list.pyi]
 
@@ -1243,9 +1303,12 @@ a = None  # type: List[A]
 x1 = [A(), B()]
 x2 = [B(), A()]
 x3 = [B(), B()]
-a = x1
-a = x2
-a = x3 # E: Incompatible types in assignment (expression has type "List[B]", variable has type "List[A]")
+if int():
+    a = x1
+if int():
+    a = x2
+if int():
+    a = x3 # E: Incompatible types in assignment (expression has type "List[B]", variable has type "List[A]")
 [builtins fixtures/list.pyi]
 [typing fixtures/typing-full.pyi]
 
@@ -1260,9 +1323,12 @@ a = None  # type: List[A]
 x1 = [A(), C()]
 x2 = [C(), A()]
 x3 = [B(), C()]
-a = x1
-a = x2
-a = x3 # E: Incompatible types in assignment (expression has type "List[B]", variable has type "List[A]")
+if int():
+    a = x1
+if int():
+    a = x2
+if int():
+    a = x3 # E: Incompatible types in assignment (expression has type "List[B]", variable has type "List[A]")
 [builtins fixtures/list.pyi]
 [typing fixtures/typing-full.pyi]
 
@@ -2002,7 +2068,8 @@ T = TypeVar('T', bound=str)
 def f() -> Tuple[T]:
     ...
 x = None
-(x,) = f()
+if int():
+    (x,) = f()
 [out]
 
 [case testNoCrashOnPartialVariable3]
@@ -2364,12 +2431,13 @@ def foo() -> None:
 
 [case testUnusedTargetNotGlobal]
 _ = 0
-_ = ''  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+_ = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testUnusedTargetNotClass]
 class C:
-    _ = 0
-    _ = ''  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+    _, _ = 0, 0
+    _ = ''
+reveal_type(C._) # E: Revealed type is 'builtins.str'
 
 [case testUnusedTargetTupleUnpacking]
 def foo() -> None:
@@ -2420,7 +2488,7 @@ def foo() -> None:
 def foo() -> None:
     from m import _
     _()
-    _ = 0  # E: Incompatible types in assignment (expression has type "int", variable has type "Callable[[], Any]")
+    _ = ''  # E: Incompatible types in assignment (expression has type "str", variable has type "Callable[[], Any]")
 [file d.py]
 def foo() -> None:
     from m import f as _
@@ -2428,7 +2496,7 @@ def foo() -> None:
     _ = 0  # E: Incompatible types in assignment (expression has type "int", variable has type "Callable[[], Any]")
 [builtins fixtures/module.pyi]
 
-[case testUnusedTargetNotClass]
+[case testUnusedTargetNotClass2]
 def foo() -> None:
     class _:
         pass

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -136,7 +136,7 @@ if int():
 from typing import Union
 
 def f(x: Union[int, str]) -> None:
-    if int(): # Without this, the assignment below would create a new variable "x" of type "int"
+    if 1: # Without this, the assignment below could create a new variable "x" of type "int"
         x = 1
         if x:
             x = 'a'

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1,6 +1,7 @@
 [case testForcedAssignment]
 x = 1 # type: object
 y = 1
+def f(): x, y  # Prevent independent redefinition
 y = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
 x = 2
 y = x
@@ -108,11 +109,12 @@ class B(A):
 def foo(): pass
 
 x = A()
-x = B()
-x.z
-x = foo()
-x.z          # E: "A" has no attribute "z"
-x.y
+if int():
+    x = B()
+    x.z
+    x = foo()
+    x.z          # E: "A" has no attribute "z"
+    x.y
 
 [case testSingleMultiAssignment-skip]
 x = 'a'
@@ -121,22 +123,25 @@ x = 'a'
 [case testUnionMultiAssignment]
 from typing import Union
 x = None # type: Union[int, str]
-x = 1
-x = 'a'
-x + 1    # E: Unsupported operand types for + ("str" and "int")
-x = 1
-(x, y) = ('a', 1)
-x + 1    # E: Unsupported operand types for + ("str" and "int")
+if int():
+    x = 1
+    x = 'a'
+    x + 1    # E: Unsupported operand types for + ("str" and "int")
+    x = 1
+    (x, y) = ('a', 1)
+    x + 1    # E: Unsupported operand types for + ("str" and "int")
 [builtins fixtures/isinstancelist.pyi]
 
 [case testUnionIfZigzag]
 from typing import Union
 
 def f(x: Union[int, str]) -> None:
-    x = 1
-    if x:
-        x = 'a'
+    if 1: # Without this, the assignment below would create a new variable "x" of type "int"
         x = 1
+        if x:
+            x = 'a'
+            x = 1
+        x + 1
     x + 1
 [builtins fixtures/isinstancelist.pyi]
 
@@ -201,6 +206,7 @@ class B(A):
     z = 1
 
 x = A()
+def f(): x # Prevent redefinition of x
 x = B()
 x.z
 try:
@@ -241,6 +247,7 @@ class B(A):
     z = 1
 
 x = A()
+def f(): x # Prevent redefinition of x
 x = B()
 try:
     raise BaseException()
@@ -300,6 +307,7 @@ class B(A):
     b = 1
 
 x = A()
+def f(): x  # Prevent redefinition
 x = B()
 try:
     x = A()
@@ -316,6 +324,7 @@ class B(A):
     b = 1
 
 x = A()
+def f(): x  # Prevent redefinition
 x = B()
 try:
     x = A()
@@ -333,6 +342,7 @@ class B(A):
     b = 1
 
 x = A()
+def f(): x  # Prevent redefinition
 x = B()
 try:
     x = A()
@@ -351,6 +361,7 @@ class B(A):
 
 while 2:
     x = A()
+    def f(): x  # Prevents redefinition
     x = B()
     try:
         x = A()
@@ -447,11 +458,12 @@ from typing import Union
 def foo() -> Union[int, str]: pass
 
 x = foo()
-x = 1
-x = x + 1
-x = foo()
-x = x + 1                # E: Unsupported operand types for + ("str" and "int") \
-                         # N: Left operand is of type "Union[int, str]"
+if int():
+    x = 1
+    x = x + 1
+    x = foo()
+    x = x + 1                # E: Unsupported operand types for + ("str" and "int") \
+                             # N: Left operand is of type "Union[int, str]"
 if isinstance(x, str):
    x = x + 1             # E: Unsupported operand types for + ("str" and "int")
    x = 1
@@ -709,6 +721,7 @@ from typing import Union, List
 
 while bool():
     x = None # type: Union[int, str, List[int]]
+    def f(): x  # Prevent redefinition
     x = 1
     if isinstance(x, int):
         x + 1
@@ -760,6 +773,7 @@ from typing import Union
 def foo() -> Union[int, str]: pass
 
 x = foo()
+def f(): x  # Prevent redefinition
 x + 1     # E: Unsupported operand types for + ("str" and "int") \
           # N: Left operand is of type "Union[int, str]"
 x + 'a'   # E: Unsupported operand types for + ("int" and "str") \
@@ -786,6 +800,7 @@ from typing import Union
 def foo() -> Union[int, str]: pass
 
 x = foo()
+def f(): x  # Prevent redefinition
 x + 1      # E: Unsupported operand types for + ("str" and "int") \
            # N: Left operand is of type "Union[int, str]"
 x = 'a'
@@ -805,6 +820,7 @@ from typing import Union
 def foo() -> Union[int, str]: pass
 
 x = foo()
+def f(): x  # Prevent redefinition
 x + 1      # E: Unsupported operand types for + ("str" and "int") \
            # N: Left operand is of type "Union[int, str]"
 x = 'a'
@@ -825,6 +841,7 @@ from typing import Union
 def foo() -> Union[int, str]: pass
 
 x = foo()
+def f(): x  # Prevent redefinition
 x = 1
 
 while bool():
@@ -852,6 +869,7 @@ from typing import Union
 def foo() -> Union[int, str]: pass
 
 x = foo()
+def f(): x  # Prevent redefinition
 x = 1
 
 while bool():
@@ -883,6 +901,7 @@ from typing import Union
 def foo() -> Union[int, str]: pass
 
 x = foo()
+def f(): x # Prevent redefinition
 x = 1
 
 for y in [1]:
@@ -914,6 +933,7 @@ from typing import Union
 def foo() -> Union[int, str]: pass
 
 x = foo()
+def f(): x  # Prevent redefinition
 x = 1
 
 for y in [1]:

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -136,7 +136,7 @@ if int():
 from typing import Union
 
 def f(x: Union[int, str]) -> None:
-    if 1: # Without this, the assignment below would create a new variable "x" of type "int"
+    if int(): # Without this, the assignment below would create a new variable "x" of type "int"
         x = 1
         if x:
             x = 'a'

--- a/test-data/unit/check-lists.test
+++ b/test-data/unit/check-lists.test
@@ -6,9 +6,12 @@ from typing import List
 a1, b1, c1 = None, None, None # type: (A, B, C)
 a2, b2, c2 = None, None, None # type: (A, B, C)
 
-a1, [b1, c1] = a2, [b2, c2]
-a1, [a1, [b1, c1]] = a2, [a2, [b2, c2]]
-a1, [a1, [a1, b1]] = a1, [a1, [a1, c1]]  # E: Incompatible types in assignment (expression has type "C", variable has type "B")
+if int():
+    a1, [b1, c1] = a2, [b2, c2]
+if int():
+    a1, [a1, [b1, c1]] = a2, [a2, [b2, c2]]
+if int():
+    a1, [a1, [a1, b1]] = a1, [a1, [a1, c1]]  # E: Incompatible types in assignment (expression has type "C", variable has type "B")
 
 class A: pass
 class B: pass
@@ -35,10 +38,14 @@ from typing import List
 a, b, c = None, None, None # type: (A, B, C)
 t = a, b
 
-[a, b], c = t, c
-[a, c], c = t, c  # E: Incompatible types in assignment (expression has type "B", variable has type "C")
-[a, a, a], c = t, c  # E: Need more than 2 values to unpack (3 expected)
-[a], c = t, c  # E: Too many values to unpack (1 expected, 2 provided)
+if int():
+    [a, b], c = t, c
+if int():
+    [a, c], c = t, c  # E: Incompatible types in assignment (expression has type "B", variable has type "C")
+if int():
+    [a, a, a], c = t, c  # E: Need more than 2 values to unpack (3 expected)
+if int():
+    [a], c = t, c  # E: Too many values to unpack (1 expected, 2 provided)
 
 class A: pass
 class B: pass

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -1285,15 +1285,16 @@ a: Literal[3]
 b: int
 c: Literal["foo"]
 
-a = a * a  # E: Incompatible types in assignment (expression has type "int", variable has type "Literal[3]")
-a = a * b  # E: Incompatible types in assignment (expression has type "int", variable has type "Literal[3]")
-a = b * a  # E: Incompatible types in assignment (expression has type "int", variable has type "Literal[3]")
+if int():
+    a = a * a  # E: Incompatible types in assignment (expression has type "int", variable has type "Literal[3]")
+    a = a * b  # E: Incompatible types in assignment (expression has type "int", variable has type "Literal[3]")
+    a = b * a  # E: Incompatible types in assignment (expression has type "int", variable has type "Literal[3]")
 
-b = a * a
-b = a * b
-b = b * a
+    b = a * a
+    b = a * b
+    b = b * a
 
-c = c.strip()  # E: Incompatible types in assignment (expression has type "str", variable has type "Literal['foo']")
+    c = c.strip()  # E: Incompatible types in assignment (expression has type "str", variable has type "Literal['foo']")
 [builtins fixtures/ops.pyi]
 [out]
 

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -81,7 +81,7 @@ def f() -> None: pass
 import typing
 def f() -> None:
     from m import a, b, f, A, B
-    if 1:
+    if int():
         a = b \
             # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         a = a
@@ -103,7 +103,7 @@ import typing
 class C:
     def f(self) -> None:
         from m import *
-        if 1:
+        if int():
             a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
             a = a
             f()

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -81,12 +81,15 @@ def f() -> None: pass
 import typing
 def f() -> None:
     from m import a, b, f, A, B
-    a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    a = a
-    f()
-    f(a)    # E: Too many arguments for "f"
-    a = A()
-    a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    if 1:
+        a = b \
+            # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        a = a
+        f()
+        f(a)    # E: Too many arguments for "f"
+        a = A()
+        a = B() \
+            # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 [file m.py]
 class A: pass
 class B: pass
@@ -100,12 +103,13 @@ import typing
 class C:
     def f(self) -> None:
         from m import *
-        a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-        a = a
-        f()
-        f(a)    # E: Too many arguments for "f"
-        a = A()
-        a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        if 1:
+            a = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+            a = a
+            f()
+            f(a)    # E: Too many arguments for "f"
+            a = A()
+            a = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 [file m.py]
 class A: pass
 class B: pass
@@ -176,10 +180,14 @@ x = object()
 import m
 
 i, s = None, None # type: (int, str)
-i = m.x
-i = m.y
-s = m.x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-s = m.y # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    i = m.x
+if int():
+    i = m.y
+if int():
+    s = m.x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    s = m.y # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 [file m.py]
 x = y = 1
 [builtins fixtures/primitives.pyi]
@@ -362,7 +370,8 @@ m.a.x = m.a.y # Error
 import typing
 from .b import A, B, x, y
 z = x
-z = y # Error
+if int():
+    z = y # Error
 [file m/b.py]
 import typing
 class A: pass
@@ -370,7 +379,7 @@ class B: pass
 x = A()
 y = B()
 [out]
-tmp/m/a.py:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
+tmp/m/a.py:5: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testRelativeImports2]
@@ -631,7 +640,8 @@ from m import f
 def g() -> None:
     global f
     f = None
-    f = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "Callable[[], Any]")
+    if int():
+        f = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "Callable[[], Any]")
 [file m.py]
 def f(): pass
 [out]
@@ -1705,14 +1715,18 @@ a = 3
 import m, n, o
 
 x = m
-x = n  # E: Cannot assign multiple modules to name 'x' without explicit 'types.ModuleType' annotation
-x = o  # E: Cannot assign multiple modules to name 'x' without explicit 'types.ModuleType' annotation
+if int():
+    x = n  # E: Cannot assign multiple modules to name 'x' without explicit 'types.ModuleType' annotation
+if int():
+    x = o  # E: Cannot assign multiple modules to name 'x' without explicit 'types.ModuleType' annotation
 
 y = o
-y, z = m, n  # E: Cannot assign multiple modules to name 'y' without explicit 'types.ModuleType' annotation
+if int():
+    y, z = m, n  # E: Cannot assign multiple modules to name 'y' without explicit 'types.ModuleType' annotation
 
 xx = m
-xx = m
+if int():
+    xx = m
 reveal_type(xx.a)  # E: Revealed type is 'builtins.str'
 
 [file m.py]
@@ -1875,7 +1889,8 @@ import mod
 import othermod
 alias = mod.submod
 reveal_type(alias.whatever('/'))  # E: Revealed type is 'builtins.str*'
-alias = othermod  # E: Cannot assign multiple modules to name 'alias' without explicit 'types.ModuleType' annotation
+if int():
+    alias = othermod  # E: Cannot assign multiple modules to name 'alias' without explicit 'types.ModuleType' annotation
 [file mod.py]
 import submod
 [file submod.py]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -231,7 +231,7 @@ class B(A):
         self.f(self.b)  # E: Argument 1 to "f" of "B" has incompatible type "str"; expected "int"
         i = 0
         s = ''
-        if 1:
+        if int():
             i, s = self
             i, i = self  # E: Incompatible types in assignment (expression has type "str", \
                               variable has type "int")
@@ -246,7 +246,7 @@ class B(A):
     def f(self, x: 'B') -> None:
         i = 0
         s = ''
-        if 1:
+        if int():
             self = x
             i, s = x
             i, s = x.a, x.b
@@ -565,7 +565,7 @@ import a
 
 def f(x: a.N) -> None:
     reveal_type(x)
-    if 1:
+    if int():
         x = a.N(1)
         reveal_type(x)
 [out]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -148,7 +148,8 @@ s = n.a # type: str  # E: Incompatible types in assignment (expression has type 
 i = n.b # type: int  # E: Incompatible types in assignment (expression has type "str", \
                           variable has type "int")
 x, y = n
-x = y  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    x = y  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 
 [case testNamedTupleWithTupleFieldNamesWithItemTypes]
@@ -161,7 +162,8 @@ s = n.a # type: str  # E: Incompatible types in assignment (expression has type 
 i = n.b # type: int  # E: Incompatible types in assignment (expression has type "str", \
                           variable has type "int")
 x, y = n
-x = y  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    x = y  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 
 [case testNamedTupleConstructorArgumentTypes]
@@ -182,9 +184,12 @@ class X(N):
 x = X(1, 2)  # E: Argument 2 to "X" has incompatible type "int"; expected "str"
 s = ''
 i = 0
-s = x.a  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-i, s = x
-s, s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    s = x.a  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    i, s = x
+if int():
+    s, s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testNamedTupleAsBaseClass2]
 from typing import NamedTuple
@@ -194,9 +199,12 @@ class X(NamedTuple('N', [('a', int),
 x = X(1, 2)  # E: Argument 2 to "X" has incompatible type "int"; expected "str"
 s = ''
 i = 0
-s = x.a  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-i, s = x
-s, s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    s = x.a  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    i, s = x
+if int():
+    s, s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 
 [case testNamedTuplesTwoAsBaseClasses]
@@ -223,9 +231,10 @@ class B(A):
         self.f(self.b)  # E: Argument 1 to "f" of "B" has incompatible type "str"; expected "int"
         i = 0
         s = ''
-        i, s = self
-        i, i = self  # E: Incompatible types in assignment (expression has type "str", \
-                          variable has type "int")
+        if 1:
+            i, s = self
+            i, i = self  # E: Incompatible types in assignment (expression has type "str", \
+                              variable has type "int")
 
 
 [out]
@@ -237,13 +246,14 @@ class B(A):
     def f(self, x: 'B') -> None:
         i = 0
         s = ''
-        self = x
-        i, s = x
-        i, s = x.a, x.b
-        i, s = x.a, x.a  # E: Incompatible types in assignment (expression has type "int", \
-                              variable has type "str")
-        i, i = self  # E: Incompatible types in assignment (expression has type "str", \
-                          variable has type "int")
+        if 1:
+            self = x
+            i, s = x
+            i, s = x.a, x.b
+            i, s = x.a, x.a  # E: Incompatible types in assignment (expression has type "int", \
+                                  variable has type "str")
+            i, i = self  # E: Incompatible types in assignment (expression has type "str", \
+                              variable has type "int")
 
 [out]
 
@@ -254,13 +264,20 @@ class B(A): pass
 a = A(1, '')
 b = B(1, '')
 t = None  # type: Tuple[int, str]
-b = a  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = t  # E: Incompatible types in assignment (expression has type "Tuple[int, str]", variable has type "A")
-b = t  # E: Incompatible types in assignment (expression has type "Tuple[int, str]", variable has type "B")
-t = a
-t = (1, '')
-t = b
-a = b
+if int():
+    b = a  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = t  # E: Incompatible types in assignment (expression has type "Tuple[int, str]", variable has type "A")
+if int():
+    b = t  # E: Incompatible types in assignment (expression has type "Tuple[int, str]", variable has type "B")
+if int():
+    t = a
+if int():
+    t = (1, '')
+if int():
+    t = b
+if int():
+    a = b
 
 
 [case testNamedTupleSimpleTypeInference]
@@ -268,12 +285,16 @@ from typing import NamedTuple, Tuple
 A = NamedTuple('A', [('a', int)])
 l = [A(1), A(2)]
 a = A(1)
-a = l[0]
+if int():
+    a = l[0]
 (i,) = l[0]
-i, i = l[0]  # E: Need more than 1 value to unpack (2 expected)
-l = [A(1)]
-a = (1,)  # E: Incompatible types in assignment (expression has type "Tuple[int]", \
-               variable has type "A")
+if int():
+    i, i = l[0]  # E: Need more than 1 value to unpack (2 expected)
+if int():
+    l = [A(1)]
+if int():
+    a = (1,)  # E: Incompatible types in assignment (expression has type "Tuple[int]", \
+                   variable has type "A")
 [builtins fixtures/list.pyi]
 
 [case testNamedTupleMissingClassAttribute]
@@ -416,7 +437,8 @@ def f(x: A) -> None: pass
 class B(NamedTuple('B', []), A): pass
 f(B())
 x = None  # type: A
-x = B()
+if int():
+    x = B()
 
 # Sanity check: fail if baseclass does not match
 class C: pass
@@ -425,7 +447,8 @@ class D(NamedTuple('D', []), A): pass
 
 g(D())  # E: Argument 1 to "g" has incompatible type "D"; expected "C"
 y = None  # type: C
-y = D()  # E: Incompatible types in assignment (expression has type "D", variable has type "C")
+if int():
+    y = D()  # E: Incompatible types in assignment (expression has type "D", variable has type "C")
 
 [case testNamedTupleSelfTypeMethod]
 from typing import TypeVar, NamedTuple
@@ -542,11 +565,12 @@ import a
 
 def f(x: a.N) -> None:
     reveal_type(x)
-    x = a.N(1)
-    reveal_type(x)
+    if 1:
+        x = a.N(1)
+        reveal_type(x)
 [out]
 tmp/b.py:4: error: Revealed type is 'Tuple[Any, fallback=a.N]'
-tmp/b.py:6: error: Revealed type is 'Tuple[Any, fallback=a.N]'
+tmp/b.py:7: error: Revealed type is 'Tuple[Any, fallback=a.N]'
 
 [case testSimpleSelfReferentialNamedTuple]
 from typing import NamedTuple

--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -75,7 +75,8 @@ strict2: int = None  # E: Incompatible types in assignment (expression has type 
 # flags: --strict-optional --python-version 3.6
 def f() -> None:
     x: int
-    x = None  # E: Incompatible types in assignment (expression has type "None", variable has type "int")
+    if int():
+        x = None  # E: Incompatible types in assignment (expression has type "None", variable has type "int")
 [out]
 
 [case testNewSyntaxWithStrictOptionalClasses]
@@ -150,4 +151,3 @@ v = 1
 reveal_type(f'{v}') # E: Revealed type is 'builtins.str'
 reveal_type(f'{1}') # E: Revealed type is 'builtins.str'
 [builtins fixtures/f_string.pyi]
-

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -310,17 +310,15 @@ main:4: error: Invalid type "__main__.T"
 from typing import NewType
 
 a = 3
-a = NewType('a', int)
+def f(): a
+a = NewType('a', int) # E: Cannot redefine 'a' as a NewType
 
 b = NewType('b', int)
-b = NewType('b', float)  # this line throws two errors
+def g(): b
+b = NewType('b', float)  # E: Cannot assign to a type \
+                         # E: Cannot redefine 'b' as a NewType
 
-c = NewType('c', str)   # type: str
-[out]
-main:4: error: Cannot redefine 'a' as a NewType
-main:7: error: Cannot assign to a type
-main:7: error: Cannot redefine 'b' as a NewType
-main:9: error: Cannot declare the type of a NewType declaration
+c = NewType('c', str)  # type: str  # E: Cannot declare the type of a NewType declaration
 
 [case testNewTypeAddingExplicitTypesFails]
 from typing import NewType

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -549,8 +549,10 @@ def f(x: T) -> ONode[T]:
         return None
 
 x = None # type: ONode[int]
-x = f(1)
-x = f('x') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
+if int():
+    x = f(1)
+if int():
+    x = f('x') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 
 x.x = 1 # E: Item "None" of "Optional[Node[int]]" has no attribute "x"
 if x is not None:
@@ -743,8 +745,9 @@ def g(x: Optional[int]) -> int:
     if x is not None:
         return x
     reveal_type(x)  # E: Revealed type is 'None'
-    x = f()
-    reveal_type(x)  # E: Revealed type is 'Union[builtins.int, Any]'
-    return x
+    if 1:
+        x = f()
+        reveal_type(x)  # E: Revealed type is 'Union[builtins.int, Any]'
+        return x
 
 [builtins fixtures/bool.pyi]

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -745,7 +745,7 @@ def g(x: Optional[int]) -> int:
     if x is not None:
         return x
     reveal_type(x)  # E: Revealed type is 'None'
-    if 1:
+    if int():
         x = f()
         reveal_type(x)  # E: Revealed type is 'Union[builtins.int, Any]'
         return x

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -745,7 +745,7 @@ def g(x: Optional[int]) -> int:
     if x is not None:
         return x
     reveal_type(x)  # E: Revealed type is 'None'
-    if int():
+    if 1:
         x = f()
         reveal_type(x)  # E: Revealed type is 'Union[builtins.int, Any]'
         return x

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -186,7 +186,7 @@ def f(x: 'B') -> 'A': ...
 
 def f(x: Any) -> Any:
     foo = 1
-    if 1:
+    if int():
         foo = "bar"  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 @overload
@@ -196,7 +196,7 @@ def g(x: 'B') -> 'A': ...
 
 def g(x):
     foo = 1
-    if 1:
+    if int():
         foo = "bar"
 
 reveal_type(f(A()))  # E: Revealed type is '__main__.B'
@@ -400,12 +400,12 @@ from foo import *
 from typing import overload
 @overload
 def f(x: 'A'):
-    if 1:
+    if int():
         x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         x = A()
 @overload
 def f(x: 'B'):
-    if 1:
+    if int():
         x = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
         x = B()
 class A: pass
@@ -419,12 +419,12 @@ from typing import overload
 class A:
     @overload
     def f(self, x: 'A'):
-        if 1:
+        if int():
             x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
             x = A()
     @overload
     def f(self, x: 'B'):
-        if 1:
+        if int():
             x = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
             x = B()
 class B: pass

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -186,7 +186,8 @@ def f(x: 'B') -> 'A': ...
 
 def f(x: Any) -> Any:
     foo = 1
-    foo = "bar"  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+    if 1:
+        foo = "bar"  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 @overload
 def g(x: 'A') -> 'B': ...
@@ -195,7 +196,8 @@ def g(x: 'B') -> 'A': ...
 
 def g(x):
     foo = 1
-    foo = "bar"
+    if 1:
+        foo = "bar"
 
 reveal_type(f(A()))  # E: Revealed type is '__main__.B'
 reveal_type(f(B()))  # E: Revealed type is '__main__.A'
@@ -398,12 +400,14 @@ from foo import *
 from typing import overload
 @overload
 def f(x: 'A'):
-    x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    x = A()
+    if 1:
+        x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        x = A()
 @overload
 def f(x: 'B'):
-    x = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-    x = B()
+    if 1:
+        x = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+        x = B()
 class A: pass
 class B: pass
 [out]
@@ -415,12 +419,14 @@ from typing import overload
 class A:
     @overload
     def f(self, x: 'A'):
-        x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-        x = A()
+        if 1:
+            x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+            x = A()
     @overload
     def f(self, x: 'B'):
-        x = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-        x = B()
+        if 1:
+            x = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+            x = B()
 class B: pass
 [out]
 
@@ -449,10 +455,14 @@ from foo import *
 [file foo.pyi]
 from typing import overload
 a, b = None, None # type: (A, B)
-b = f(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = f(b) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-a = f(a)
-b = f(b)
+if int():
+    b = f(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = f(b) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    a = f(a)
+if int():
+    b = f(b)
 
 @overload
 def f(x: 'A') -> 'A': pass
@@ -486,10 +496,14 @@ from foo import *
 [file foo.pyi]
 from typing import overload
 a, b = None, None # type: (A, B)
-b = a.f(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = a.f(b) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-a = a.f(a)
-b = a.f(b)
+if int():
+    b = a.f(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = a.f(b) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    a = a.f(a)
+if int():
+    b = a.f(b)
 
 class A:
   @overload
@@ -503,14 +517,18 @@ from foo import *
 [file foo.pyi]
 from typing import overload
 a, b = None, None # type: (A, B)
-a = f(a)
-b = f(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = f(a)
+if int():
+    b = f(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 f(b)     # E: No overload variant of "f" matches argument type "B" \
          # N: Possible overload variant: \
          # N:     def f(x: A) -> A \
          # N:     <1 more non-matching overload not shown>
-b = f(b, a)
-a = f(b, a) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    b = f(b, a)
+if int():
+    a = f(b, a) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 f(a, a)     # E: No overload variant of "f" matches argument types "A", "A" \
             # N: Possible overload variant: \
             # N:     def f(x: B, y: A) -> B \
@@ -533,11 +551,12 @@ from foo import *
 from typing import overload, TypeVar, Generic
 t = TypeVar('t')
 ab, ac, b, c = None, None, None, None # type: (A[B], A[C], B, C)
-b = f(ab)
-c = f(ac)
-b = f(ac) # E: Incompatible types in assignment (expression has type "C", variable has type "B")
-b = f(b)
-c = f(b)  # E: Incompatible types in assignment (expression has type "B", variable has type "C")
+if int():
+    b = f(ab)
+    c = f(ac)
+    b = f(ac) # E: Incompatible types in assignment (expression has type "C", variable has type "B")
+    b = f(b)
+    c = f(b)  # E: Incompatible types in assignment (expression has type "B", variable has type "C")
 @overload
 def f(x: 'A[t]') -> t: pass
 @overload
@@ -572,8 +591,10 @@ from typing import overload, Callable
 o = None # type: object
 a = None # type: A
 
-a = f # E: Incompatible types in assignment (expression has type overloaded function, variable has type "A")
-o = f
+if int():
+    a = f # E: Incompatible types in assignment (expression has type overloaded function, variable has type "A")
+if int():
+    o = f
 
 @overload
 def f(a: 'A') -> None: pass
@@ -587,8 +608,9 @@ from foo import *
 from typing import overload
 t, a = None, None # type: (type, A)
 
-a = A # E: Incompatible types in assignment (expression has type "Type[A]", variable has type "A")
-t = A
+if int():
+    a = A # E: Incompatible types in assignment (expression has type "Type[A]", variable has type "A")
+    t = A
 
 class A:
     @overload
@@ -602,10 +624,14 @@ from foo import *
 [file foo.pyi]
 from typing import overload
 a, b = None, None # type: int, str
-a = A()[a]
-b = A()[a] # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-b = A()[b]
-a = A()[b] # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    a = A()[a]
+if int():
+    b = A()[a] # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    b = A()[b]
+if int():
+    a = A()[b] # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 class A:
     @overload
@@ -619,10 +645,12 @@ from foo import *
 from typing import TypeVar, Generic, overload
 t = TypeVar('t')
 a, b, c = None, None, None # type: (A, B, C[A])
-a = c[a]
-b = c[a] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = c[b]
-b = c[b] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = c[a]
+    b = c[a] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = c[b]
+    b = c[b] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 class C(Generic[t]):
     @overload
@@ -730,10 +758,14 @@ def f(t: type) -> 'A': pass
 @overload
 def f(t: 'A') -> 'B': pass
 a, b = None, None # type: (A, B)
-a = f(A)
-b = f(a)
-b = f(A) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = f(a) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    a = f(A)
+if int():
+    b = f(a)
+if int():
+    b = f(A) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = f(a) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 class A:
    @overload
    def __init__(self) -> None: pass
@@ -755,6 +787,7 @@ list_str = [] # type: List[str]
 list_object = [] # type: List[object]
 n = f(list_int)
 m = f(list_str)
+def p(): n, m # Prevent redefinition
 n = 1
 m = 1
 n = 'x' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
@@ -3546,17 +3579,20 @@ def narrow_int(x: Union[int, str]) -> Union[int, NoReturn]:
 
 def test_narrow_int() -> None:
     a: Union[int, str]
-    a = narrow_int(a)
-    reveal_type(a)  # E: Revealed type is 'builtins.int'
+    if int():
+        a = narrow_int(a)
+        reveal_type(a)  # E: Revealed type is 'builtins.int'
 
     b: int
-    b = narrow_int(b)
-    reveal_type(b)  # E: Revealed type is 'builtins.int'
+    if int():
+        b = narrow_int(b)
+        reveal_type(b)  # E: Revealed type is 'builtins.int'
 
     c: str
-    c = narrow_int(c)
-    reveal_type(c)  # Note: branch is now dead, so no type is revealed
-                    # TODO: maybe we should make mypy report a warning instead?
+    if int():
+        c = narrow_int(c)
+        reveal_type(c)  # Note: branch is now dead, so no type is revealed
+                        # TODO: maybe we should make mypy report a warning instead?
 
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-full.pyi]
@@ -3575,17 +3611,20 @@ def narrow_int(x: Union[int, str]) -> Union[int, NoReturn]:
 
 def test_narrow_int() -> None:
     a: Union[int, str]
-    a = narrow_int(a)
-    reveal_type(a)  # E: Revealed type is 'builtins.int'
+    if int():
+        a = narrow_int(a)
+        reveal_type(a)  # E: Revealed type is 'builtins.int'
 
     b: int
-    b = narrow_int(b)
-    reveal_type(b)  # E: Revealed type is 'builtins.int'
+    if int():
+        b = narrow_int(b)
+        reveal_type(b)  # E: Revealed type is 'builtins.int'
 
     c: str
-    c = narrow_int(c)
-    reveal_type(c)  # Note: branch is now dead, so no type is revealed
-                    # TODO: maybe we should make mypy report a warning instead?
+    if int():
+        c = narrow_int(c)
+        reveal_type(c)  # Note: branch is now dead, so no type is revealed
+                        # TODO: maybe we should make mypy report a warning instead?
 
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-full.pyi]
@@ -3605,16 +3644,19 @@ def narrow_none(x: Optional[T]) -> Union[NoReturn, T]:
 
 def test_narrow_none() -> None:
     a: Optional[int]
-    a = narrow_none(a)
-    reveal_type(a)  # E: Revealed type is 'Union[builtins.int, None]'
+    if int():
+        a = narrow_none(a)
+        reveal_type(a)  # E: Revealed type is 'Union[builtins.int, None]'
 
     b: int
-    b = narrow_none(b)
-    reveal_type(b)  # E: Revealed type is 'builtins.int'
+    if int():
+        b = narrow_none(b)
+        reveal_type(b)  # E: Revealed type is 'builtins.int'
 
     c: None
-    c = narrow_none(c)
-    reveal_type(c)  # Note: branch is now dead, so no type is revealed
+    if int():
+        c = narrow_none(c)
+        reveal_type(c)  # Note: branch is now dead, so no type is revealed
 
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-full.pyi]
@@ -3634,16 +3676,19 @@ def narrow_none(x: Optional[T]) -> Union[NoReturn, T]:
 
 def test_narrow_none() -> None:
     a: Optional[int]
-    a = narrow_none(a)
-    reveal_type(a)  # E: Revealed type is 'builtins.int'
+    if int():
+        a = narrow_none(a)
+        reveal_type(a)  # E: Revealed type is 'builtins.int'
 
     b: int
-    b = narrow_none(b)
-    reveal_type(b)  # E: Revealed type is 'builtins.int'
+    if int():
+        b = narrow_none(b)
+        reveal_type(b)  # E: Revealed type is 'builtins.int'
 
     c: None
-    c = narrow_none(c)
-    reveal_type(c)  # Branch is now dead
+    if int():
+        c = narrow_none(c)
+        reveal_type(c)  # Branch is now dead
 
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-full.pyi]
@@ -3663,16 +3708,19 @@ def narrow_none_v2(x: Optional[T]) -> T:
 
 def test_narrow_none_v2() -> None:
     a: Optional[int]
-    a = narrow_none_v2(a)
-    reveal_type(a)  # E: Revealed type is 'Union[builtins.int, None]'
+    if int():
+        a = narrow_none_v2(a)
+        reveal_type(a)  # E: Revealed type is 'Union[builtins.int, None]'
 
     b: int
-    b = narrow_none_v2(b)
-    reveal_type(b)  # E: Revealed type is 'builtins.int'
+    if int():
+        b = narrow_none_v2(b)
+        reveal_type(b)  # E: Revealed type is 'builtins.int'
 
     c: None
-    c = narrow_none_v2(c)
-    reveal_type(c)  # Note: branch is now dead, so no type is revealed
+    if int():
+        c = narrow_none_v2(c)
+        reveal_type(c)  # Note: branch is now dead, so no type is revealed
 
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-full.pyi]
@@ -3691,16 +3739,19 @@ def narrow_none_v2(x: Optional[T]) -> T:
 
 def test_narrow_none_v2() -> None:
     a: Optional[int]
-    a = narrow_none_v2(a)
-    reveal_type(a)  # E: Revealed type is 'builtins.int'
+    if int():
+        a = narrow_none_v2(a)
+        reveal_type(a)  # E: Revealed type is 'builtins.int'
 
     b: int
-    b = narrow_none_v2(b)
-    reveal_type(b)  # E: Revealed type is 'builtins.int'
+    if int():
+        b = narrow_none_v2(b)
+        reveal_type(b)  # E: Revealed type is 'builtins.int'
 
     c: None
-    c = narrow_none_v2(c)
-    reveal_type(c)  # Note: branch is now dead, so no type is revealed
+    if int():
+        c = narrow_none_v2(c)
+        reveal_type(c)  # Note: branch is now dead, so no type is revealed
 
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-full.pyi]
@@ -3723,12 +3774,14 @@ def narrow_to_not_a(x: T) -> Union[NoReturn, T]:
 
 def test() -> None:
     val: Union[A, B]
-    val = narrow_to_not_a(val)
-    reveal_type(val)   # E: Revealed type is '__main__.B'
+    if int():
+        val = narrow_to_not_a(val)
+        reveal_type(val)   # E: Revealed type is '__main__.B'
 
     val2: A
-    val2 = narrow_to_not_a(val2)
-    reveal_type(val2)  # Branch now dead
+    if int():
+        val2 = narrow_to_not_a(val2)
+        reveal_type(val2)  # Branch now dead
 
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-full.pyi]
@@ -3749,14 +3802,14 @@ def narrow_to_not_a_v2(x: T) -> T:
     assert not isinstance(x, A)
     return x
 
-def test_v2() -> None:
-    val: Union[A, B]
-    val = narrow_to_not_a_v2(val)
-    reveal_type(val)   # E: Revealed type is '__main__.B'
+def test_v2(val: Union[A, B], val2: A) -> None:
+    if int():
+        val = narrow_to_not_a_v2(val)
+        reveal_type(val)   # E: Revealed type is '__main__.B'
 
-    val2: A
-    val2 = narrow_to_not_a_v2(val2)
-    reveal_type(val2)  # Branch now dead
+    if int():
+        val2 = narrow_to_not_a_v2(val2)
+        reveal_type(val2)  # Branch now dead
 
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -149,14 +149,20 @@ c1: C1
 c2: C2
 y: AnotherP
 
-x = c
-x = B()  # E: Incompatible types in assignment (expression has type "B", variable has type "P")
-x = c1 # E: Incompatible types in assignment (expression has type "C1", variable has type "P") \
-    # N: 'C1' is missing following 'P' protocol member: \
-    # N:     meth2
-x = c2
-x = y
-y = x
+if int():
+    x = c
+if int():
+    x = B()  # E: Incompatible types in assignment (expression has type "B", variable has type "P")
+if int():
+    x = c1 # E: Incompatible types in assignment (expression has type "C1", variable has type "P") \
+        # N: 'C1' is missing following 'P' protocol member: \
+        # N:     meth2
+if int():
+    x = c2
+if int():
+    x = y
+if int():
+    y = x
 
 [case testSimpleProtocolTwoMethodsExtend]
 from typing import Protocol
@@ -182,10 +188,12 @@ x: P2
 reveal_type(x.meth1()) # E: Revealed type is 'builtins.int'
 reveal_type(x.meth2()) # E: Revealed type is 'builtins.str'
 
-x = C() # OK
-x = Cbad() # E: Incompatible types in assignment (expression has type "Cbad", variable has type "P2") \
-    # N: 'Cbad' is missing following 'P2' protocol member: \
-    # N:     meth2
+if int():
+    x = C() # OK
+if int():
+    x = Cbad() # E: Incompatible types in assignment (expression has type "Cbad", variable has type "P2") \
+        # N: 'Cbad' is missing following 'P2' protocol member: \
+        # N:     meth2
 
 [case testProtocolMethodVsAttributeErrors]
 from typing import Protocol
@@ -442,18 +450,24 @@ class B(A): pass
 
 x1: Pco[B]
 y1: Pco[A]
-x1 = y1 # E: Incompatible types in assignment (expression has type "Pco[A]", variable has type "Pco[B]")
-y1 = x1 # E: Incompatible types in assignment (expression has type "Pco[B]", variable has type "Pco[A]")
+if int():
+    x1 = y1 # E: Incompatible types in assignment (expression has type "Pco[A]", variable has type "Pco[B]")
+if int():
+    y1 = x1 # E: Incompatible types in assignment (expression has type "Pco[B]", variable has type "Pco[A]")
 
 x2: Pcontra[B]
 y2: Pcontra[A]
-y2 = x2 # E: Incompatible types in assignment (expression has type "Pcontra[B]", variable has type "Pcontra[A]")
-x2 = y2 # E: Incompatible types in assignment (expression has type "Pcontra[A]", variable has type "Pcontra[B]")
+if int():
+    y2 = x2 # E: Incompatible types in assignment (expression has type "Pcontra[B]", variable has type "Pcontra[A]")
+if int():
+    x2 = y2 # E: Incompatible types in assignment (expression has type "Pcontra[A]", variable has type "Pcontra[B]")
 
 x3: Pinv[B]
 y3: Pinv[A]
-y3 = x3 # E: Incompatible types in assignment (expression has type "Pinv[B]", variable has type "Pinv[A]")
-x3 = y3 # E: Incompatible types in assignment (expression has type "Pinv[A]", variable has type "Pinv[B]")
+if int():
+    y3 = x3 # E: Incompatible types in assignment (expression has type "Pinv[B]", variable has type "Pinv[A]")
+if int():
+    x3 = y3 # E: Incompatible types in assignment (expression has type "Pinv[A]", variable has type "Pinv[B]")
 
 [case testProtocolVarianceWithCallableAndList]
 from typing import Protocol, TypeVar, Callable, List
@@ -687,12 +701,12 @@ class Bad:
         pass
 
 def f(s: Shape) -> None: pass
-s: Shape
-
 f(NonProtoShape())
 f(Circle())
-s = Triangle()
-s = Bad()
+s: Shape
+if int():
+    s = Triangle()
+    s = Bad()
 
 n2: NonProtoShape = s
 [out]
@@ -766,7 +780,8 @@ class D(Generic[T]):
 
 t: Traversable
 t = D[int]() # OK
-t = C() # E: Incompatible types in assignment (expression has type "C", variable has type "Traversable")
+if int():
+    t = C() # E: Incompatible types in assignment (expression has type "C", variable has type "Traversable")
 [builtins fixtures/list.pyi]
 [typing fixtures/typing-full.pyi]
 
@@ -821,8 +836,9 @@ class B:
 
 t: P1
 t = A() # OK
-t = B() # E: Incompatible types in assignment (expression has type "B", variable has type "P1")
-t = C() # E: Incompatible types in assignment (expression has type "C", variable has type "P1")
+if int():
+    t = B() # E: Incompatible types in assignment (expression has type "B", variable has type "P1")
+    t = C() # E: Incompatible types in assignment (expression has type "C", variable has type "P1")
 [builtins fixtures/list.pyi]
 [typing fixtures/typing-full.pyi]
 
@@ -955,10 +971,12 @@ x: PInst
 y: PClass
 
 x = CInst()
-x = CClass() # E: Incompatible types in assignment (expression has type "CClass", variable has type "PInst") \
+if int():
+    x = CClass() # E: Incompatible types in assignment (expression has type "CClass", variable has type "PInst") \
              # N: Protocol member PInst.v expected instance variable, got class variable
 y = CClass()
-y = CInst()  # E: Incompatible types in assignment (expression has type "CInst", variable has type "PClass") \
+if int():
+    y = CInst()  # E: Incompatible types in assignment (expression has type "CInst", variable has type "PClass") \
              # N: Protocol member PClass.v expected class variable, got instance variable
 
 [case testPropertyInProtocols]
@@ -1042,12 +1060,15 @@ class C:
 
 x: P
 x = C()
-x = B()
+if int():
+    x = B()
 
 y: PC
 y = B()
-y = C() # E: Incompatible types in assignment (expression has type "C", variable has type "PC") \
-        # N: Protocol member PC.meth expected class or static method
+if int():
+    y = C() \
+      # E: Incompatible types in assignment (expression has type "C", variable has type "PC") \
+      # N: Protocol member PC.meth expected class or static method
 [builtins fixtures/classmethod.pyi]
 
 [case testOverloadedMethodsInProtocols]
@@ -1067,17 +1088,18 @@ class D:
         pass
 
 x: P = C()
-x = D()
+if int():
+    x = D()
 [out]
-main:17: error: Incompatible types in assignment (expression has type "D", variable has type "P")
-main:17: note: Following member(s) of "D" have conflicts:
-main:17: note:     Expected:
-main:17: note:         @overload
-main:17: note:         def f(self, x: int) -> int
-main:17: note:         @overload
-main:17: note:         def f(self, x: str) -> str
-main:17: note:     Got:
-main:17: note:         def f(self, x: int) -> None
+main:18: error: Incompatible types in assignment (expression has type "D", variable has type "P")
+main:18: note: Following member(s) of "D" have conflicts:
+main:18: note:     Expected:
+main:18: note:         @overload
+main:18: note:         def f(self, x: int) -> int
+main:18: note:         @overload
+main:18: note:         def f(self, x: str) -> str
+main:18: note:     Got:
+main:18: note:         def f(self, x: int) -> None
 
 [case testCannotInstantiateProtocolWithOverloadedUnimplementedMethod]
 from typing import overload, Protocol
@@ -1333,9 +1355,10 @@ class B: ...
 x: Union[P1, P2]
 
 x = C1()
-x = C2()
-x = C()
-x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "Union[P1, P2]")
+if int():
+    x = C2()
+    x = C()
+    x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "Union[P1, P2]")
 
 [case testUnionsOfNormalClassesWithProtocols]
 from typing import Protocol, Union
@@ -1431,15 +1454,17 @@ class C:
 
 var: Type[P]
 var()
-var = P # E: Can only assign concrete classes to a variable of type "Type[P]"
-var = B # OK
-var = C # OK
+if int():
+    var = P # E: Can only assign concrete classes to a variable of type "Type[P]"
+    var = B # OK
+    var = C # OK
 
 var_old = None # type: Type[P] # Old syntax for variable annotations
 var_old()
-var_old = P # E: Can only assign concrete classes to a variable of type "Type[P]"
-var_old = B # OK
-var_old = C # OK
+if int():
+    var_old = P # E: Can only assign concrete classes to a variable of type "Type[P]"
+    var_old = B # OK
+    var_old = C # OK
 
 [case testInstantiationProtocolInTypeForClassMethods]
 from typing import Type, Protocol

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -3,10 +3,14 @@
 
 [case testUnicode]
 u = u'foo'
-u = unicode()
-s = ''
-s = u'foo' # E: Incompatible types in assignment (expression has type "unicode", variable has type "str")
-s = b'foo'
+if int():
+    u = unicode()
+if int():
+    s = ''
+if int():
+    s = u'foo' # E: Incompatible types in assignment (expression has type "unicode", variable has type "str")
+if int():
+    s = b'foo'
 [builtins_py2 fixtures/python2.pyi]
 
 [case testTypeVariableUnicode]
@@ -34,8 +38,10 @@ class A:
         # type: (int) -> str
         pass
 s = A() / 1
-s = ''
-s = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    s = ''
+if int():
+    s = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testStrUnicodeCompatibility]
 import typing

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -663,13 +663,14 @@ import b
 import b
 t: type
 t = b.A
-t = b.f # E
+if int():
+    t = b.f # E
 [file b.py]
 class A: pass
 def f() -> None: pass
 [builtins fixtures/tuple.pyi]
 [out2]
-tmp/a.py:4: error: Incompatible types in assignment (expression has type "Callable[[], None]", variable has type "type")
+tmp/a.py:5: error: Incompatible types in assignment (expression has type "Callable[[], None]", variable has type "type")
 
 [case testSerializeOverloadedVsTypeObjectDistinction]
 import a
@@ -679,7 +680,8 @@ import b
 import b
 t: type
 t = b.A
-t = b.f # E
+if int():
+    t = b.f # E
 [file b.pyi]
 from typing import overload
 class A:
@@ -693,7 +695,7 @@ def f() -> None: pass
 def f(x: int) -> None: pass
 [builtins fixtures/tuple.pyi]
 [out2]
-tmp/a.py:4: error: Incompatible types in assignment (expression has type overloaded function, variable has type "type")
+tmp/a.py:5: error: Incompatible types in assignment (expression has type overloaded function, variable has type "type")
 
 [case testSerializeNamedTupleInMethod4]
 from ntcrash import C

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -471,32 +471,29 @@ class B: pass
 main:7: error: Incompatible types in assignment (expression has type "object", variable has type "BaseException")
 
 [case testTypeErrorInBlock]
-
 while object:
-  x = None # type: A
-  x = object()
-  x = B()
+    x = None # type: A
+    if int():
+        x = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+        x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 class A: pass
 class B: pass
-[out]
-main:4: error: Incompatible types in assignment (expression has type "object", variable has type "A")
-main:5: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testTypeErrorInvolvingBaseException]
 
 x, a = None, None # type: (BaseException, A)
-a = BaseException()  # Fail
-a = object()         # Fail
-x = object()         # Fail
-x = A()              # Fail
-x = BaseException()
+if int():
+    a = BaseException()  # E: Incompatible types in assignment (expression has type "BaseException", variable has type "A")
+if int():
+    a = object()         # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+if int():
+    x = object()         # E: Incompatible types in assignment (expression has type "object", variable has type "BaseException")
+if int():
+    x = A()              # E: Incompatible types in assignment (expression has type "A", variable has type "BaseException")
+if int():
+    x = BaseException()
 class A: pass
 [builtins fixtures/exception.pyi]
-[out]
-main:3: error: Incompatible types in assignment (expression has type "BaseException", variable has type "A")
-main:4: error: Incompatible types in assignment (expression has type "object", variable has type "A")
-main:5: error: Incompatible types in assignment (expression has type "object", variable has type "BaseException")
-main:6: error: Incompatible types in assignment (expression has type "A", variable has type "BaseException")
 
 [case testSimpleTryExcept2]
 import typing
@@ -786,6 +783,7 @@ import typing
 class E1(BaseException): pass
 class E2(BaseException): pass
 e = 1
+def f(): e  # Prevent redefinition
 e = 1
 try: pass
 except E1 as e: pass
@@ -1426,28 +1424,36 @@ import typing
 class A: pass
 class B: pass
 x = y = A()
-x = A()
-y = A()
-x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-y = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    x = A()
+if int():
+    y = A()
+if int():
+    x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    y = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testChainedAssignment2]
 import typing
 def f() -> None:
     x = 1
     y = 'x'
-    x = y = 'x' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-    x = y = 1   # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+    if 1:
+        x = y = 'x' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+        x = y = 1   # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 [builtins fixtures/primitives.pyi]
 [out]
 
 [case testChainedAssignmentWithType]
-
 x = y = None # type: int
-x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-y = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-x = 1
-y = 1
+if int():
+    x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    y = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    x = 1
+if int():
+    y = 1
 
 
 -- Star assignment
@@ -1457,10 +1463,14 @@ y = 1
 [case testAssignListToStarExpr]
 from typing import List
 bs, cs = None, None # type: List[A], List[B]
-*bs, b = bs
-*bs, c = cs  # E: Incompatible types in assignment (expression has type "List[B]", variable has type "List[A]")
-*ns, c = cs
-nc = cs
+if int():
+    *bs, b = bs
+if int():
+    *bs, c = cs  # E: Incompatible types in assignment (expression has type "List[B]", variable has type "List[A]")
+    if int():
+        *ns, c = cs
+if int():
+    nc = cs
 
 class A: pass
 class B: pass
@@ -1547,13 +1557,14 @@ main:8: error: Incompatible types in assignment (expression has type "A", variab
 [case testAugmentedAssignmentIntFloat]
 weight0 = 65.5
 reveal_type(weight0)  # E: Revealed type is 'builtins.float'
-weight0 = 65
-reveal_type(weight0)  # E: Revealed type is 'builtins.int'
-weight0 *= 'a'  # E: Incompatible types in assignment (expression has type "str", variable has type "float")
-weight0 *= 0.5
-reveal_type(weight0)  # E: Revealed type is 'builtins.float'
-weight0 *= object()  # E: Unsupported operand types for * ("float" and "object")
-reveal_type(weight0) # E: Revealed type is 'builtins.float'
+if int():
+    weight0 = 65
+    reveal_type(weight0)  # E: Revealed type is 'builtins.int'
+    weight0 *= 'a'  # E: Incompatible types in assignment (expression has type "str", variable has type "float")
+    weight0 *= 0.5
+    reveal_type(weight0)  # E: Revealed type is 'builtins.float'
+    weight0 *= object()  # E: Unsupported operand types for * ("float" and "object")
+    reveal_type(weight0) # E: Revealed type is 'builtins.float'
 
 [builtins fixtures/float.pyi]
 

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1438,7 +1438,7 @@ import typing
 def f() -> None:
     x = 1
     y = 'x'
-    if 1:
+    if int():
         x = y = 'x' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
         x = y = 1   # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 [builtins fixtures/primitives.pyi]

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -12,9 +12,10 @@ class B:
 class A(B):
   def f(self) -> 'A':
     a, b = None, None # type: (A, B)
-    a = super().f() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    a = super().g() # E: "g" undefined in superclass
-    b = super().f()
+    if 1:
+        a = super().f() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        a = super().g() # E: "g" undefined in superclass
+        b = super().f()
     return a
 [out]
 

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -12,7 +12,7 @@ class B:
 class A(B):
   def f(self) -> 'A':
     a, b = None, None # type: (A, B)
-    if 1:
+    if int():
         a = super().f() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
         a = super().g() # E: "g" undefined in superclass
         b = super().f()

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -10,18 +10,28 @@ t3 = None # type: Tuple[A, A]
 t4 = None # type: Tuple[A, B]
 t5 = None # type: Tuple[B, A]
 
-t1 = t2 # E: Incompatible types in assignment (expression has type "Tuple[B]", variable has type "Tuple[A]")
-t1 = t3 # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A]")
-t3 = t1 # E: Incompatible types in assignment (expression has type "Tuple[A]", variable has type "Tuple[A, A]")
-t3 = t4 # E: Incompatible types in assignment (expression has type "Tuple[A, B]", variable has type "Tuple[A, A]")
-t3 = t5 # E: Incompatible types in assignment (expression has type "Tuple[B, A]", variable has type "Tuple[A, A]")
+if int():
+    t1 = t2 # E: Incompatible types in assignment (expression has type "Tuple[B]", variable has type "Tuple[A]")
+if int():
+    t1 = t3 # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A]")
+if int():
+    t3 = t1 # E: Incompatible types in assignment (expression has type "Tuple[A]", variable has type "Tuple[A, A]")
+if int():
+    t3 = t4 # E: Incompatible types in assignment (expression has type "Tuple[A, B]", variable has type "Tuple[A, A]")
+if int():
+    t3 = t5 # E: Incompatible types in assignment (expression has type "Tuple[B, A]", variable has type "Tuple[A, A]")
 
 # Ok
-t1 = t1
-t2 = t2
-t3 = t3
-t4 = t4
-t5 = t5
+if int():
+    t1 = t1
+if int():
+    t2 = t2
+if int():
+    t3 = t3
+if int():
+    t4 = t4
+if int():
+    t5 = t5
 
 class A: pass
 class B: pass
@@ -33,13 +43,14 @@ t1 = None # type: Tuple[A, A]
 t2 = None # type: Tuple[A, B]
 t3 = None # type: Tuple[B, A]
 
-t2 = t1  # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A, B]")
-t2 = t3  # E: Incompatible types in assignment (expression has type "Tuple[B, A]", variable has type "Tuple[A, B]")
-t3 = t1  # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[B, A]")
-t3 = t2  # E: Incompatible types in assignment (expression has type "Tuple[A, B]", variable has type "Tuple[B, A]")
+if int():
+    t2 = t1  # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A, B]")
+    t2 = t3  # E: Incompatible types in assignment (expression has type "Tuple[B, A]", variable has type "Tuple[A, B]")
+    t3 = t1  # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[B, A]")
+    t3 = t2  # E: Incompatible types in assignment (expression has type "Tuple[A, B]", variable has type "Tuple[B, A]")
 
-t1 = t2
-t1 = t3
+    t1 = t2
+    t1 = t3
 
 class A: pass
 class B(A): pass
@@ -50,14 +61,19 @@ from typing import Tuple
 a, o = None, None # type: (A, object)
 t = None # type: Tuple[A, A]
 
-a = t # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "A")
-t = o # E: Incompatible types in assignment (expression has type "object", variable has type "Tuple[A, A]")
-t = a # E: Incompatible types in assignment (expression has type "A", variable has type "Tuple[A, A]")
+if int():
+    a = t # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "A")
+if int():
+    t = o # E: Incompatible types in assignment (expression has type "object", variable has type "Tuple[A, A]")
+if int():
+    t = a # E: Incompatible types in assignment (expression has type "A", variable has type "Tuple[A, A]")
 # TODO: callable types + tuples
 
 # Ok
-o = t
-t = None
+if int():
+    o = t
+if int():
+    t = None
 
 class A: pass
 [builtins fixtures/tuple.pyi]
@@ -67,8 +83,10 @@ from typing import Tuple
 t1 = None # type: Tuple[A, Tuple[A, A]]
 t2 = None # type: Tuple[B, Tuple[B, B]]
 
-t2 = t1 # E: Incompatible types in assignment (expression has type "Tuple[A, Tuple[A, A]]", variable has type "Tuple[B, Tuple[B, B]]")
-t1 = t2
+if int():
+    t2 = t1 # E: Incompatible types in assignment (expression has type "Tuple[A, Tuple[A, A]]", variable has type "Tuple[B, Tuple[B, B]]")
+if int():
+    t1 = t2
 
 class A: pass
 class B(A): pass
@@ -79,8 +97,10 @@ from typing import Tuple
 t1 = None # type: Tuple[A, Tuple[A, A]]
 t2 = None # type: Tuple[B, Tuple[B, B]]
 
-t2 = t1 # E: Incompatible types in assignment (expression has type "Tuple[A, Tuple[A, A]]", variable has type "Tuple[B, Tuple[B, B]]")
-t1 = t2
+if int():
+    t2 = t1 # E: Incompatible types in assignment (expression has type "Tuple[A, Tuple[A, A]]", variable has type "Tuple[B, Tuple[B, B]]")
+if int():
+    t1 = t2
 
 class A: pass
 class B(A): pass
@@ -91,8 +111,10 @@ from typing import Tuple
 t1 = None # type: Tuple[A, A]
 t2 = None # type: tuple
 
-t1 = t2 # E: Incompatible types in assignment (expression has type "Tuple[Any, ...]", variable has type "Tuple[A, A]")
-t2 = t1
+if int():
+    t1 = t2 # E: Incompatible types in assignment (expression has type "Tuple[Any, ...]", variable has type "Tuple[A, A]")
+if int():
+    t2 = t1
 
 class A: pass
 [builtins fixtures/tuple.pyi]
@@ -117,11 +139,16 @@ t3 = None # type: Tuple[A, B]
 
 a, b, c = None, None, None # type: (A, B, C)
 
-t2 = ()        # E: Incompatible types in assignment (expression has type "Tuple[]", variable has type "Tuple[A]")
-t2 = (a, a)    # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A]")
-t3 = (a, a)    # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A, B]")
-t3 = (b, b)    # E: Incompatible types in assignment (expression has type "Tuple[B, B]", variable has type "Tuple[A, B]")
-t3 = (a, b, a) # E: Incompatible types in assignment (expression has type "Tuple[A, B, A]", variable has type "Tuple[A, B]")
+if int():
+    t2 = ()        # E: Incompatible types in assignment (expression has type "Tuple[]", variable has type "Tuple[A]")
+if int():
+    t2 = (a, a)    # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A]")
+if int():
+    t3 = (a, a)    # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A, B]")
+if int():
+    t3 = (b, b)    # E: Incompatible types in assignment (expression has type "Tuple[B, B]", variable has type "Tuple[A, B]")
+if int():
+    t3 = (a, b, a) # E: Incompatible types in assignment (expression has type "Tuple[A, B, A]", variable has type "Tuple[A, B]")
 
 t1 = ()
 t1 = (a,)
@@ -158,22 +185,32 @@ x = None # type: Tuple[A, B, C]
 y = None # type: Tuple[A, C, E]
 n = 0
 
-a = t1[1] # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-b = t1[0] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = t1[1] # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    b = t1[0] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 t1[2]     # E: Tuple index out of range
 t1[3]     # E: Tuple index out of range
 t2[1]     # E: Tuple index out of range
 reveal_type(t1[n])     # E: Revealed type is 'Union[__main__.A, __main__.B]'
 reveal_type(t3[n:])    # E: Revealed type is 'Union[__main__.A, __main__.B, __main__.C, __main__.D, __main__.E]'
-b = t1[(0)] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b = t1[(0)] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-a = t1[0]
-b = t1[1]
-b = t1[-1]
-a = t1[(0)]
-x = t3[0:3] # type (A, B, C)
-y = t3[0:5:2] # type (A, C, E)
-x = t3[:-2] # type (A, B, C)
+if int():
+    a = t1[0]
+if int():
+    b = t1[1]
+if int():
+    b = t1[-1]
+if int():
+    a = t1[(0)]
+if int():
+    x = t3[0:3] # type (A, B, C)
+if int():
+    y = t3[0:5:2] # type (A, C, E)
+if int():
+    x = t3[:-2] # type (A, B, C)
 
 class A: pass
 class B: pass
@@ -188,15 +225,21 @@ t1 = None  # type: Tuple[A, B]
 t2 = None  # type: Tuple[A]
 a, b = None, None  # type: A, B
 
-a = t1[-1] # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-b = t1[-2] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = t1[-1] # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    b = t1[-2] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 t1[-3]     # E: Tuple index out of range
 t1[-4]     # E: Tuple index out of range
-b = t2[(-1)] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b = t2[(-1)] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-a = t1[-2]
-b = t1[-1]
-a = t2[(-1)]
+if int():
+    a = t1[-2]
+if int():
+    b = t1[-1]
+if int():
+    a = t2[(-1)]
 
 class A: pass
 class B: pass
@@ -230,12 +273,17 @@ a, b = None, None # type: (A, B)
 reveal_type(a1)  # E: Revealed type is '__main__.A'
 reveal_type(b1)  # E: Revealed type is '__main__.B'
 
-a, a = t1 # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-b, b = t1 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a, b, b = t2 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a, a = t1 # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    b, b = t1 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a, b, b = t2 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-a, b = t1
-a, b, a1 = t2
+if int():
+    a, b = t1
+if int():
+    a, b, a1 = t2
 
 class A: pass
 class B: pass
@@ -255,16 +303,17 @@ def avoid_confusing_test_parser() -> None:
     reveal_type(a1)  # E: Revealed type is '__main__.A'
     reveal_type(b1)  # E: Revealed type is '__main__.B'
 
-    [a, a] = t1 # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    [b, b] = t1 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-    [a, b, b] = t2 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+    if int():
+        [a, a] = t1 # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        [b, b] = t1 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+        [a, b, b] = t2 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-    [a, b] = t1
-    [a, b, a1] = t2
+        [a, b] = t1
+        [a, b, a1] = t2
 
-    [a2, b2] = t1
-    reveal_type(a2)  # E: Revealed type is '__main__.A'
-    reveal_type(b2)  # E: Revealed type is '__main__.B'
+        [a2, b2] = t1
+        reveal_type(a2)  # E: Revealed type is '__main__.A'
+        reveal_type(b2)  # E: Revealed type is '__main__.B'
 
 class A: pass
 class B: pass
@@ -284,16 +333,17 @@ def avoid_confusing_test_parser():
     reveal_type(a1)  # E: Revealed type is '__main__.A'
     reveal_type(b1)  # E: Revealed type is '__main__.B'
 
-    [a, a] = t1 # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    [b, b] = t1 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-    [a, b, b] = t2 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+    if int():
+        [a, a] = t1 # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        [b, b] = t1 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+        [a, b, b] = t2 # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-    [a, b] = t1
-    [a, b, a1] = t2
+        [a, b] = t1
+        [a, b, a1] = t2
 
-    [a2, b2] = t1
-    reveal_type(a2)  # E: Revealed type is '__main__.A'
-    reveal_type(b2)  # E: Revealed type is '__main__.B'
+        [a2, b2] = t1
+        reveal_type(a2)  # E: Revealed type is '__main__.A'
+        reveal_type(b2)  # E: Revealed type is '__main__.B'
 
 class A: pass
 class B: pass
@@ -316,29 +366,34 @@ class A: pass
 
 a, b = None, None # type: (A, B)
 
-a, b = a, a # Fail
-a, b = b, a # Fail
+if int():
+    a, b = a, a # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a, b = b, a \
+      # E: Incompatible types in assignment (expression has type "B", variable has type "A") \
+      # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-a, b = a, b
-a, a = a, a
+if int():
+    a, b = a, b
+if int():
+    a, a = a, a
 
 class A: pass
 class B: pass
 [builtins fixtures/tuple.pyi]
-[out]
-main:4: error: Incompatible types in assignment (expression has type "A", variable has type "B")
-main:5: error: Incompatible types in assignment (expression has type "B", variable has type "A")
-main:5: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 [case testSubtypingInMultipleAssignment]
-
 a, b = None, None # type: (A, B)
 
-b, b = a, b # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-b, b = b, a # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b, b = a, b # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b, b = b, a # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-a, b = b, b
-b, a = b, b
+if int():
+    a, b = b, b
+if int():
+    b, a = b, b
 
 class A: pass
 class B(A): pass
@@ -394,27 +449,37 @@ class BB: pass
 [builtins fixtures/tuple.pyi]
 
 [case testMultipleDeclarationWithParentheses]
-
 (a, b) = (None, None) # type: int, str
-a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-a = 1
-b = ''
+if int():
+    a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+    b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    a = 1
+    b = ''
 
 [case testMultipleAssignmentWithExtraParentheses]
 
 a, b = None, None # type: (A, B)
 
-(a, b) = (a, a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-(a, b) = (b, b) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-((a), (b)) = ((a), (a))  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-((a), (b)) = ((b), (b))  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-[a, b] = a, a  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-[a, b] = b, b  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    (a, b) = (a, a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    (a, b) = (b, b) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    ((a), (b)) = ((a), (a))  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    ((a), (b)) = ((b), (b))  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    [a, b] = a, a  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    [a, b] = b, b  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 
-(a, b) = (a, b)
-((a), (b)) = ((a), (b))
-[a, b] = a, b
+if int():
+    (a, b) = (a, b)
+if int():
+    ((a), (b)) = ((a), (b))
+if int():
+    [a, b] = a, b
 
 class A: pass
 class B: pass
@@ -423,10 +488,14 @@ class B: pass
 [case testMultipleAssignmentUsingSingleTupleType]
 from typing import Tuple
 a, b = None, None  # type: Tuple[int, str]
-a = 1
-b = ''
-a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    a = 1
+if int():
+    b = ''
+if int():
+    a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testMultipleAssignmentWithMixedVariables]
 a = b, c = 1, 1
@@ -450,18 +519,24 @@ aa, bb, *cc = t  # E: Need type annotation for 'cc'
 from typing import List
 li, lo = None, None # type: List[int], List[object]
 a, b, *c = 1, 2  # type: int, int, List[int]
-c = lo  # E: Incompatible types in assignment (expression has type "List[object]", variable has type "List[int]")
-c = li
+if int():
+    c = lo  # E: Incompatible types in assignment (expression has type "List[object]", variable has type "List[int]")
+if int():
+    c = li
 [builtins fixtures/list.pyi]
 
 [case testAssignmentToStarCount1]
 from typing import List
 ca = None # type: List[int]
 c = [1]
-a, b, *c = 1,  # E: Need more than 1 value to unpack (2 expected)
-a, b, *c = 1, 2
-a, b, *c = 1, 2, 3
-a, b, *c = 1, 2, 3, 4
+if int():
+    a, b, *c = 1,  # E: Need more than 1 value to unpack (2 expected)
+if int():
+    a, b, *c = 1, 2
+if int():
+    a, b, *c = 1, 2, 3
+if int():
+    a, b, *c = 1, 2, 3, 4
 [builtins fixtures/list.pyi]
 
 [case testAssignmentToStarCount2]
@@ -472,10 +547,14 @@ t2 = 1, 2
 t3 = 1, 2, 3
 t4 = 1, 2, 3, 4
 c = [1]
-a, b, *c = t1  # E: Need more than 1 value to unpack (2 expected)
-a, b, *c = t2
-a, b, *c = t3
-a, b, *c = t4
+if int():
+    a, b, *c = t1  # E: Need more than 1 value to unpack (2 expected)
+if int():
+    a, b, *c = t2
+if int():
+    a, b, *c = t3
+if int():
+    a, b, *c = t4
 [builtins fixtures/list.pyi]
 
 [case testAssignmentToStarFromAny]
@@ -490,10 +569,13 @@ class C: pass
 [case testAssignmentToComplexStar]
 from typing import List
 li = None # type: List[int]
-a, *(li) = 1,
+if int():
+    a, *(li) = 1,
 a, *(b, c) = 1, 2  # E: Need more than 1 value to unpack (2 expected)
-a, *(b, c) = 1, 2, 3
-a, *(b, c) = 1, 2, 3, 4  # E: Too many values to unpack (2 expected, 3 provided)
+if int():
+    a, *(b, c) = 1, 2, 3
+if int():
+    a, *(b, c) = 1, 2, 3, 4  # E: Too many values to unpack (2 expected, 3 provided)
 [builtins fixtures/list.pyi]
 
 [case testAssignmentToStarFromTupleType]
@@ -501,26 +583,29 @@ from typing import List, Tuple
 li = None # type: List[int]
 la = None # type: List[A]
 ta = None # type: Tuple[A, A, A]
-a, *la = ta
-a, *li = ta  # E
-a, *na = ta
-na = la
-na = a  # E
+if int():
+    a, *la = ta
+if int():
+    a, *li = ta  # E: List item 0 has incompatible type "A"; expected "int" \
+                 # E: List item 1 has incompatible type "A"; expected "int"
+if int():
+    a, *na = ta
+    if int():
+        na = la
+        na = a  # E: Incompatible types in assignment (expression has type "A", variable has type "List[A]")
 
 class A: pass
 [builtins fixtures/list.pyi]
-[out]
-main:6: error: List item 0 has incompatible type "A"; expected "int"
-main:6: error: List item 1 has incompatible type "A"; expected "int"
-main:9: error: Incompatible types in assignment (expression has type "A", variable has type "List[A]")
 
 [case testAssignmentToStarFromTupleInference]
 from typing import List
 li = None # type: List[int]
 la = None # type: List[A]
 a, *l = A(), A()
-l = li  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "List[A]")
-l = la
+if int():
+    l = li  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "List[A]")
+if int():
+    l = la
 
 class A: pass
 [builtins fixtures/list.pyi]
@@ -531,8 +616,10 @@ from typing import List
 li = None # type: List[int]
 la = None # type: List[A]
 a, *l = [A(), A()]
-l = li  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "List[A]")
-l = la
+if int():
+    l = li  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "List[A]")
+if int():
+    l = la
 
 class A: pass
 [builtins fixtures/list.pyi]
@@ -544,8 +631,10 @@ li = None # type: List[int]
 la = None # type: List[A]
 ta = None # type: Tuple[A, A, A]
 a, *l = ta
-l = li  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "List[A]")
-l = la
+if int():
+    l = li  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "List[A]")
+if int():
+    l = la
 
 class A: pass
 [builtins fixtures/list.pyi]
@@ -556,8 +645,10 @@ from typing import List
 li = None # type: List[int]
 la = None # type: List[A]
 a, *l = la
-l = li  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "List[A]")
-l = la
+if int():
+    l = li  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "List[A]")
+if int():
+    l = la
 
 class A: pass
 [builtins fixtures/list.pyi]
@@ -596,15 +687,16 @@ reveal_type(e2)  # E: Revealed type is 'builtins.list[builtins.int]'
 a1, b1, c1 = None, None, None # type: (A, B, C)
 a2, b2, c2 = None, None, None # type: (A, B, C)
 
-a1, (b1, c1) = a2, (b2, c2)
-a1, (a1, (b1, c1)) = a2, (a2, (b2, c2))
-a1, (a1, (a1, b1)) = a1, (a1, (a1, c1))  # Fail
+if int():
+    a1, (b1, c1) = a2, (b2, c2)
+if int():
+    a1, (a1, (b1, c1)) = a2, (a2, (b2, c2))
+if int():
+    a1, (a1, (a1, b1)) = a1, (a1, (a1, c1))  # E: Incompatible types in assignment (expression has type "C", variable has type "B")
 
 class A: pass
 class B: pass
 class C: pass
-[out]
-main:7: error: Incompatible types in assignment (expression has type "C", variable has type "B")
 
 [case testNestedTupleAssignment2]
 
@@ -612,28 +704,30 @@ a1, b1, c1 = None, None, None # type: (A, B, C)
 a2, b2, c2 = None, None, None # type: (A, B, C)
 t = a1, b1
 
-a2, b2 = t
-(a2, b2), c2 = t, c1
-(a2, c2), c2 = t, c1  # Fail
-t, c2 = (a2, b2), c2
-t, c2 = (a2, a2), c2  # Fail
-t = a1, a1, a1  # Fail
-t = a1  # Fail
-a2, a2, a2 = t  # Fail
-a2, = t  # Fail
-a2 = t  # Fail
+if int():
+    a2, b2 = t
+if int():
+    (a2, b2), c2 = t, c1
+if int():
+    (a2, c2), c2 = t, c1  # E: Incompatible types in assignment (expression has type "B", variable has type "C")
+if int():
+    t, c2 = (a2, b2), c2
+if int():
+    t, c2 = (a2, a2), c2  # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A, B]")
+if int():
+    t = a1, a1, a1  # E: Incompatible types in assignment (expression has type "Tuple[A, A, A]", variable has type "Tuple[A, B]")
+if int():
+    t = a1  # E: Incompatible types in assignment (expression has type "A", variable has type "Tuple[A, B]")
+if int():
+    a2, a2, a2 = t  # E: Need more than 2 values to unpack (3 expected)
+if int():
+    a2, = t  # E: Too many values to unpack (1 expected, 2 provided)
+if int():
+    a2 = t  # E: Incompatible types in assignment (expression has type "Tuple[A, B]", variable has type "A")
 
 class A: pass
 class B: pass
 class C: pass
-[out]
-main:8: error: Incompatible types in assignment (expression has type "B", variable has type "C")
-main:10: error: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A, B]")
-main:11: error: Incompatible types in assignment (expression has type "Tuple[A, A, A]", variable has type "Tuple[A, B]")
-main:12: error: Incompatible types in assignment (expression has type "A", variable has type "Tuple[A, B]")
-main:13: error: Need more than 2 values to unpack (3 expected)
-main:14: error: Too many values to unpack (1 expected, 2 provided)
-main:15: error: Incompatible types in assignment (expression has type "Tuple[A, B]", variable has type "A")
 
 
 -- Error messages
@@ -678,14 +772,20 @@ i = 0
 s = ''
 b = bool()
 
-s = t.__len__()  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-i = t.__str__()  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-i = s in t       # E: Incompatible types in assignment (expression has type "bool", variable has type "int")
+if int():
+    s = t.__len__()  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    i = t.__str__()  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    i = s in t       # E: Incompatible types in assignment (expression has type "bool", variable has type "int")
 t.foo            # E: "Tuple[int, str]" has no attribute "foo"
 
-i = t.__len__()
-s = t.__str__()
-b = s in t
+if int():
+    i = t.__len__()
+if int():
+    s = t.__str__()
+if int():
+    b = s in t
 
 [file builtins.py]
 from typing import TypeVar, Generic
@@ -739,7 +839,8 @@ for x in B(), A():
 [case testTupleIterable]
 y = 'a'
 x = sum((1,2))
-y = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    y = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 [builtins fixtures/tuple.pyi]
 
 
@@ -754,14 +855,15 @@ from typing import Tuple
 class A(Tuple[int, str]):
     def f(self, x: int) -> None:
         a, b = 1, ''
-        a, b = self
-        b, a = self  # Error
+        if int():
+            a, b = self
+            b, a = self  # Error
         self.f('')   # Error
 [builtins fixtures/tuple.pyi]
 [out]
-tmp/m.pyi:6: error: Incompatible types in assignment (expression has type "int", variable has type "str")
-tmp/m.pyi:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-tmp/m.pyi:7: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+tmp/m.pyi:7: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+tmp/m.pyi:7: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+tmp/m.pyi:8: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
 
 [case testValidTupleBaseClass2]
 from typing import Tuple
@@ -968,12 +1070,14 @@ x, y = g(z) # E: Argument 1 to "g" has incompatible type "int"; expected "Tuple[
 
 [case testTupleWithUndersizedContext]
 a = ([1], 'x')
-a = ([], 'x', 1)  # E: Incompatible types in assignment (expression has type "Tuple[List[int], str, int]", variable has type "Tuple[List[int], str]")
+if int():
+    a = ([], 'x', 1)  # E: Incompatible types in assignment (expression has type "Tuple[List[int], str, int]", variable has type "Tuple[List[int], str]")
 [builtins fixtures/tuple.pyi]
 
 [case testTupleWithOversizedContext]
 a = (1, [1], 'x')
-a = (1, [])  # E: Incompatible types in assignment (expression has type "Tuple[int, List[int]]", variable has type "Tuple[int, List[int], str]")
+if int():
+    a = (1, [])  # E: Incompatible types in assignment (expression has type "Tuple[int, List[int]]", variable has type "Tuple[int, List[int], str]")
 [builtins fixtures/tuple.pyi]
 
 [case testTupleWithoutContext]

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -58,15 +58,18 @@ U = Union[int, str]
 
 [case testProhibitReassigningAliases]
 A = float
-A = int  # E: Cannot assign multiple types to name "A" without an explicit "Type[...]" annotation
+if int():
+    A = int  # E: Cannot assign multiple types to name "A" without an explicit "Type[...]" annotation
 [out]
 
 [case testProhibitReassigningSubscriptedAliases]
 from typing import Callable
 A = Callable[[], float]
-A = Callable[[], int]  # E: Cannot assign multiple types to name "A" without an explicit "Type[...]" annotation \
-                       # E: Value of type "int" is not indexable
-                       # the second error is because of `Callable = 0` in lib-stub/typing.pyi
+if int():
+    A = Callable[[], int] \
+      # E: Cannot assign multiple types to name "A" without an explicit "Type[...]" annotation \
+      # E: Value of type "int" is not indexable
+      # the second error is because of `Callable = 0` in lib-stub/typing.pyi
 [builtins fixtures/list.pyi]
 [out]
 
@@ -75,7 +78,8 @@ from typing import TypeVar, Union, Tuple
 T = TypeVar('T')
 
 A = Tuple[T, T]
-A = Union[T, int]  # E: Cannot assign multiple types to name "A" without an explicit "Type[...]" annotation \
+if int():
+    A = Union[T, int]  # E: Cannot assign multiple types to name "A" without an explicit "Type[...]" annotation \
                    # E: Value of type "int" is not indexable
                    # the second error is because of `Union = 0` in lib-stub/typing.pyi
 [out]
@@ -85,7 +89,8 @@ from typing import TypeVar, Sequence, Type
 T = TypeVar('T')
 
 A: Type[float] = int
-A = float  # OK
+if int():
+    A = float  # OK
 x: A  # E: Invalid type "__main__.A"
 def bad(tp: A) -> None:  # E: Invalid type "__main__.A"
     pass

--- a/test-data/unit/check-type-checks.test
+++ b/test-data/unit/check-type-checks.test
@@ -2,35 +2,37 @@
 
 
 [case testSimpleIsinstance]
-
 x = None  # type: object
 n = None  # type: int
 s = None  # type: str
-n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
+if int():
+    n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
 if isinstance(x, int):
     n = x
     s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
+if int():
+    n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
 [builtins fixtures/isinstance.pyi]
 
 [case testSimpleIsinstance2]
 import typing
 def f(x: object, n: int, s: str) -> None:
-    n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
-    if isinstance(x, int):
-        n = x
-        s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-    n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
+    if 1:
+        n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
+        if isinstance(x, int):
+            n = x
+            s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+        n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
 [builtins fixtures/isinstance.pyi]
 [out]
 
 [case testSimpleIsinstance3]
-
 class A:
     x = None  # type: object
     n = None  # type: int
     s = None  # type: str
-    n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
+    if int():
+        n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
     if isinstance(x, int):
         n = x
         s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
@@ -73,28 +75,30 @@ def f(x: object, y: object, n: int, s: str) -> None:
 [case testIsinstanceAndElif]
 import typing
 def f(x: object, n: int, s: str) -> None:
-    n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
-    if isinstance(x, int):
-        n = x
-        s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-    elif isinstance(x, str):
-        s = x
-        n = x # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-    else:
+    if 1:
         n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
-        s = x # E: Incompatible types in assignment (expression has type "object", variable has type "str")
-    n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
+        if isinstance(x, int):
+            n = x
+            s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+        elif isinstance(x, str):
+            s = x
+            n = x # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+        else:
+            n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
+            s = x # E: Incompatible types in assignment (expression has type "object", variable has type "str")
+        n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
 [builtins fixtures/isinstance.pyi]
 [out]
 
 [case testIsinstanceAndAnyType]
 from typing import Any
 def f(x: Any, n: int, s: str) -> None:
-    s = x
-    if isinstance(x, int):
-        n = x
-        s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-    s = x
+    if 1:
+        s = x
+        if isinstance(x, int):
+            n = x
+            s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+        s = x
 [builtins fixtures/isinstance.pyi]
 [out]
 

--- a/test-data/unit/check-type-checks.test
+++ b/test-data/unit/check-type-checks.test
@@ -17,7 +17,7 @@ if int():
 [case testSimpleIsinstance2]
 import typing
 def f(x: object, n: int, s: str) -> None:
-    if 1:
+    if int():
         n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
         if isinstance(x, int):
             n = x
@@ -75,7 +75,7 @@ def f(x: object, y: object, n: int, s: str) -> None:
 [case testIsinstanceAndElif]
 import typing
 def f(x: object, n: int, s: str) -> None:
-    if 1:
+    if int():
         n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
         if isinstance(x, int):
             n = x
@@ -93,7 +93,7 @@ def f(x: object, n: int, s: str) -> None:
 [case testIsinstanceAndAnyType]
 from typing import Any
 def f(x: Any, n: int, s: str) -> None:
-    if 1:
+    if int():
         s = x
         if isinstance(x, int):
             n = x

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -809,7 +809,7 @@ from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 
 def f(p: Point) -> None:
-    if 1:
+    if int():
         p = {'x': 2, 'y': 3}
         p = {'x': 2}  # E: Key 'y' missing for TypedDict "Point"
         p = dict(x=2, y=3)

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -809,9 +809,10 @@ from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 
 def f(p: Point) -> None:
-    p = {'x': 2, 'y': 3}
-    p = {'x': 2}  # E: Key 'y' missing for TypedDict "Point"
-    p = dict(x=2, y=3)
+    if 1:
+        p = {'x': 2, 'y': 3}
+        p = {'x': 2}  # E: Key 'y' missing for TypedDict "Point"
+        p = dict(x=2, y=3)
 
 f({'x': 1, 'y': 3})
 f({'x': 1, 'y': 'z'})  # E: Incompatible types (expression has type "str", TypedDict item "y" has type "int")
@@ -834,7 +835,8 @@ p2: Point
 p2 = dict(x='bye')  # E: Key 'y' missing for TypedDict "Point"
 
 p3 = Point(x=1, y=2)
-p3 = {'x': 'hi'}  # E: Key 'y' missing for TypedDict "Point"
+if int():
+    p3 = {'x': 'hi'}  # E: Key 'y' missing for TypedDict "Point"
 
 p4: Point = {'x': 1, 'y': 2}
 
@@ -848,7 +850,8 @@ B = TypedDict('B', {'x': int, 'y': str})
 T = TypeVar('T')
 def join(x: T, y: T) -> T: return x
 ab = join(A(x=1, y=1), B(x=1, y=''))
-ab = {'x': 1, 'z': 1} # E: Expected TypedDict key 'x' but found keys ('x', 'z')
+if int():
+    ab = {'x': 1, 'z': 1} # E: Expected TypedDict key 'x' but found keys ('x', 'z')
 [builtins fixtures/dict.pyi]
 
 [case testCannotCreateAnonymousTypedDictInstanceUsingDictLiteralWithMissingItems]
@@ -859,7 +862,8 @@ B = TypedDict('B', {'x': int, 'y': int, 'z': str})
 T = TypeVar('T')
 def join(x: T, y: T) -> T: return x
 ab = join(A(x=1, y=1, z=1), B(x=1, y=1, z=''))
-ab = {} # E: Expected TypedDict keys ('x', 'y') but found no keys
+if int():
+    ab = {} # E: Expected TypedDict keys ('x', 'y') but found no keys
 [builtins fixtures/dict.pyi]
 
 

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -96,7 +96,7 @@ T = TypeVar('T', int, str)
 def f(x: T) -> T:
     a = None  # type: T
     b = None # type: T
-    if 1:
+    if int():
         a = x
         b = x
         a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
@@ -418,7 +418,7 @@ class C(Generic[Y]):
 def f(x: X, y: Y, z: int) -> None:
     C(y)
     C(x)  # Error
-    if 1:
+    if int():
         z = x # Error
         z = y # Error
     y.foo # Error
@@ -502,7 +502,7 @@ from typing import TypeVar, overload, Callable
 T = TypeVar('T', int, str)
 def f(x: T) -> None:
      y = m(g, x)
-     if 1:
+     if int():
          x = y
          y = object() # Error
 

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -96,7 +96,7 @@ T = TypeVar('T', int, str)
 def f(x: T) -> T:
     a = None  # type: T
     b = None # type: T
-    if int():
+    if 1:
         a = x
         b = x
         a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -16,9 +16,10 @@ def f(x: T) -> List[T]: pass
 i = [1]
 s = ['x']
 o = [object()]
-i = f(1)
-s = f('')
-o = f(1) # E: Incompatible types in assignment (expression has type "List[int]", variable has type "List[object]")
+if int():
+    i = f(1)
+    s = f('')
+    o = f(1) # E: Incompatible types in assignment (expression has type "List[int]", variable has type "List[object]")
 [builtins fixtures/list.pyi]
 
 [case testCallGenericFunctionWithTypeVarValueRestrictionAndAnyArgs]
@@ -95,11 +96,12 @@ T = TypeVar('T', int, str)
 def f(x: T) -> T:
     a = None  # type: T
     b = None # type: T
-    a = x
-    b = x
-    a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-    b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-    return x
+    if 1:
+        a = x
+        b = x
+        a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+        b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+        return x
 [out]
 
 [case testIsinstanceAndTypeVarValues]
@@ -267,10 +269,12 @@ class C(Generic[X]):
     def __init__(self, x: X) -> None: pass
 x = None  # type: C[str]
 y = C(S())
-x = y
-y = x
+if int():
+    x = y
+    y = x
 c_int = C(1) # type: C[int]
-y = c_int # E: Incompatible types in assignment (expression has type "C[int]", variable has type "C[str]")
+if int():
+    y = c_int # E: Incompatible types in assignment (expression has type "C[int]", variable has type "C[str]")
 
 [case testGenericTypeBodyWithTypevarValues]
 from typing import TypeVar, Generic
@@ -414,15 +418,16 @@ class C(Generic[Y]):
 def f(x: X, y: Y, z: int) -> None:
     C(y)
     C(x)  # Error
-    z = x # Error
-    z = y # Error
+    if 1:
+        z = x # Error
+        z = y # Error
     y.foo # Error
 [out]
 main:8: error: Value of type variable "Y" of "C" cannot be "X"
-main:9: error: Incompatible types in assignment (expression has type "X", variable has type "int")
-main:10: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:11: error: "int" has no attribute "foo"
-main:11: error: "str" has no attribute "foo"
+main:10: error: Incompatible types in assignment (expression has type "X", variable has type "int")
+main:11: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:12: error: "int" has no attribute "foo"
+main:12: error: "str" has no attribute "foo"
 
 [case testTypeVarWithValueInferredFromObjectReturnTypeContext]
 from typing import TypeVar
@@ -497,8 +502,9 @@ from typing import TypeVar, overload, Callable
 T = TypeVar('T', int, str)
 def f(x: T) -> None:
      y = m(g, x)
-     x = y
-     y = object()
+     if 1:
+         x = y
+         y = object() # Error
 
 A = TypeVar('A')
 R = TypeVar('R')
@@ -509,8 +515,8 @@ def g(x: int) -> int: return x
 @overload
 def g(x: str) -> str: return x
 [out]
-tmp/foo.pyi:7: error: Incompatible types in assignment (expression has type "object", variable has type "int")
-tmp/foo.pyi:7: error: Incompatible types in assignment (expression has type "object", variable has type "str")
+tmp/foo.pyi:8: error: Incompatible types in assignment (expression has type "object", variable has type "int")
+tmp/foo.pyi:8: error: Incompatible types in assignment (expression has type "object", variable has type "str")
 
 [case testGenericFunctionSubtypingWithTypevarValues]
 from typing import TypeVar
@@ -520,11 +526,15 @@ U = TypeVar('U', str, A, int)
 def f(x: T) -> T: pass
 def g(x: U) -> U: pass
 a = f
-a = f
-a = g
+if int():
+    a = f
+if int():
+    a = g
 b = g
-b = g
-b = f # E: Incompatible types in assignment (expression has type "Callable[[T], T]", variable has type "Callable[[U], U]")
+if int():
+    b = g
+if int():
+    b = f # E: Incompatible types in assignment (expression has type "Callable[[T], T]", variable has type "Callable[[U], U]")
 
 [case testInnerFunctionWithTypevarValues]
 from typing import TypeVar

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -27,11 +27,11 @@ from typing import Union
 def f(x: Union[int, str]) -> None:
     if isinstance(x, int):
         y = 1
-        if 1:
+        if int():
             y = x
     else:
         z = 2
-        if 1:
+        if int():
             z = x # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [builtins fixtures/isinstance.pyi]
 [out]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -27,10 +27,12 @@ from typing import Union
 def f(x: Union[int, str]) -> None:
     if isinstance(x, int):
         y = 1
-        y = x
+        if 1:
+            y = x
     else:
         z = 2
-        z = x # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+        if 1:
+            z = x # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [builtins fixtures/isinstance.pyi]
 [out]
 
@@ -60,16 +62,20 @@ x = None # type: Union[A, C]
 y = None # type: int
 z = None # type: str
 
-y = w.y
+if int():
+    y = w.y
 v.y           # E: Item "C" of "Union[C, D]" has no attribute "y" \
               # E: Item "D" of "Union[C, D]" has no attribute "y"
 u.y           # E: Item "C" of "Union[A, C, D]" has no attribute "y" \
               # E: Item "D" of "Union[A, C, D]" has no attribute "y"
-z = w.y       # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    z = w.y       # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 w.y = 'a'     # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-y = x.y       # E: Item "C" of "Union[A, C]" has no attribute "y"
+if int():
+    y = x.y       # E: Item "C" of "Union[A, C]" has no attribute "y"
 zz = x.y      # E: Item "C" of "Union[A, C]" has no attribute "y"
-z = zz        # E: Incompatible types in assignment (expression has type "Union[int, Any]", variable has type "str")
+if int():
+    z = zz        # E: Incompatible types in assignment (expression has type "Union[int, Any]", variable has type "str")
 
 [builtins fixtures/isinstance.pyi]
 
@@ -90,7 +96,8 @@ i = None # type: int
 x.foo()
 y.foo()
 i = x.foo()
-i = y.foo()   # E: Incompatible types in assignment (expression has type "Union[int, str]", variable has type "int")
+if int():
+    i = y.foo()   # E: Incompatible types in assignment (expression has type "Union[int, str]", variable has type "int")
 
 [builtins fixtures/isinstance.pyi]
 
@@ -105,12 +112,17 @@ x[2] + 1 # E: Unsupported operand types for + ("str" and "int") \
 [case testUnionAsOverloadArg]
 from foo import *
 x = 0
-x = f(1)
-x = f('')
+if int():
+    x = f(1)
+if int():
+    x = f('')
 s = ''
-s = f(int)
-s = f(1)    # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-x = f(int)  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    s = f(int)
+if int():
+    s = f(1)    # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+if int():
+    x = f(int)  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [file foo.pyi]
 from typing import Union, overload

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -64,9 +64,10 @@ else:
 [file m.py]
 import typing
 x = 1
-x = 'a'
+if int():
+    x = 'a'
 [out]
-tmp/m.py:3: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+tmp/m.py:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testNegatedMypyConditional]
 import typing
@@ -636,13 +637,14 @@ class Child(Parent):
         return 3
 
     def bar(self) -> int:
-        self = super(Child, self).something()
-        reveal_type(self)       # E: Revealed type is '__main__.Child'
-        if self is None:
-            reveal_type(self)
-            return None
-        reveal_type(self)       # E: Revealed type is '__main__.Child'
-        return 3
+        if 1:
+            self = super(Child, self).something()
+            reveal_type(self)       # E: Revealed type is '__main__.Child'
+            if self is None:
+                reveal_type(self)
+                return None
+            reveal_type(self)       # E: Revealed type is '__main__.Child'
+            return 3
 [builtins fixtures/isinstance.pyi]
 
 [case testUnreachableWhenSuperclassIsAnyNoStrictOptional]

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -637,7 +637,7 @@ class Child(Parent):
         return 3
 
     def bar(self) -> int:
-        if 1:
+        if int():
             self = super(Child, self).something()
             reveal_type(self)       # E: Revealed type is '__main__.Child'
             if self is None:

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -637,7 +637,7 @@ class Child(Parent):
         return 3
 
     def bar(self) -> int:
-        if int():
+        if 1:
             self = super(Child, self).something()
             reveal_type(self)       # E: Revealed type is '__main__.Child'
             if self is None:

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -10,10 +10,11 @@ from typing import Tuple
 def f( *b: 'B') -> None:
     ab = None # type: Tuple[B, ...]
     ac = None # type: Tuple[C, ...]
-    b = ac # E: Incompatible types in assignment (expression has type "Tuple[C, ...]", variable has type "Tuple[B, ...]")
-    ac = b # E: Incompatible types in assignment (expression has type "Tuple[B, ...]", variable has type "Tuple[C, ...]")
-    b = ab
-    ab = b
+    if int():
+        b = ac # E: Incompatible types in assignment (expression has type "Tuple[C, ...]", variable has type "Tuple[B, ...]")
+        ac = b # E: Incompatible types in assignment (expression has type "Tuple[B, ...]", variable has type "Tuple[C, ...]")
+        b = ab
+        ab = b
 
 class B: pass
 class C: pass
@@ -159,16 +160,25 @@ b = None # type: B
 c = None # type: C
 o = None # type: object
 
-a = f(o) # E: Incompatible types in assignment (expression has type "object", variable has type "A")
-b = f(b, a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-b = f(a, b) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = f(o) # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+if int():
+    b = f(b, a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b = f(a, b) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
-o = f()
-a = f(a)
-a = f(b)
-a = f(a, b, a)
-o = f(a, b, o)
-c = f(c)
+if int():
+    o = f()
+if int():
+    a = f(a)
+if int():
+    a = f(b)
+if int():
+    a = f(a, b, a)
+if int():
+    o = f(a, b, o)
+if int():
+    c = f(c)
 
 def f( *a: T) -> T:
     pass
@@ -184,14 +194,21 @@ T = TypeVar('T')
 a = None # type: A
 o = None # type: object
 
-a = f(o) # E: Incompatible types in assignment (expression has type "object", variable has type "A")
-a = f(a, o) # E: Incompatible types in assignment (expression has type "object", variable has type "A")
-a = f(a, a, o) # E: Incompatible types in assignment (expression has type "object", variable has type "A")
-a = f(a, a, a, o) # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+if int():
+    a = f(o) # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+if int():
+    a = f(a, o) # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+if int():
+    a = f(a, a, o) # E: Incompatible types in assignment (expression has type "object", variable has type "A")
+if int():
+    a = f(a, a, a, o) # E: Incompatible types in assignment (expression has type "object", variable has type "A")
 
-a = f(a)
-a = f(a, a)
-a = f(a, a, a)
+if int():
+    a = f(a)
+if int():
+    a = f(a, a)
+if int():
+    a = f(a, a, a)
 
 def f(a: T, b: T = None, *c: T) -> T:
     pass
@@ -442,18 +459,30 @@ from foo import *
 from typing import overload
 a, b = None, None # type: (A, B)
 
-b = f()        # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-b = f(a)       # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-b = f(a, b)    # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = f(b)       # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-a = f(b, b)    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-b = f(a, *[b]) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-b = f(*())     # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-b = f(*(a,))   # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-b = f(*(a, b)) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = f(*(b,))   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-a = f(*(b, b)) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-a = f(*[b])    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    b = f()        # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b = f(a)       # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b = f(a, b)    # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = f(b)       # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    a = f(b, b)    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    b = f(a, *[b]) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b = f(*())     # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b = f(*(a,))   # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    b = f(*(a, b)) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+if int():
+    a = f(*(b,))   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    a = f(*(b, b)) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+if int():
+    a = f(*[b])    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 a = f()
 a = f(a)
@@ -489,17 +518,27 @@ S = TypeVar('S')
 T = TypeVar('T')
 a, b, aa = None, None, None # type: (A, B, List[A])
 
-a, b = f(*aa)    # Fail
-b, b = f(*aa)    # Fail
-a, a = f(b, *aa) # Fail
-b, b = f(b, *aa) # Fail
-b, b = f(b, b, *aa) # Fail
-a, b = f(a, *a)  # Fail
-a, b = f(*a)     # Fail
+if int():
+    a, b = f(*aa)    # E: Argument 1 to "f" has incompatible type "*List[A]"; expected "B"
+if int():
+    b, b = f(*aa)    # E: Argument 1 to "f" has incompatible type "*List[A]"; expected "B"
+if int():
+    a, a = f(b, *aa) # E: Argument 1 to "f" has incompatible type "B"; expected "A"
+if int():
+    b, b = f(b, *aa) # E: Argument 2 to "f" has incompatible type "*List[A]"; expected "B"
+if int():
+    b, b = f(b, b, *aa) # E: Argument 3 to "f" has incompatible type "*List[A]"; expected "B"
+if int():
+    a, b = f(a, *a)  # E: List or tuple expected as variable arguments
+if int():
+    a, b = f(*a)     # E: List or tuple expected as variable arguments
 
-a, a = f(*aa)
-b, a = f(b, *aa)
-b, a = f(b, a, *aa)
+if int():
+    a, a = f(*aa)
+if int():
+    b, a = f(b, *aa)
+if int():
+    b, a = f(b, a, *aa)
 
 def f(a: S, *b: T) -> Tuple[S, T]:
     pass
@@ -507,14 +546,6 @@ def f(a: S, *b: T) -> Tuple[S, T]:
 class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
-[out]
-main:6: error: Argument 1 to "f" has incompatible type "*List[A]"; expected "B"
-main:7: error: Argument 1 to "f" has incompatible type "*List[A]"; expected "B"
-main:8: error: Argument 1 to "f" has incompatible type "B"; expected "A"
-main:9: error: Argument 2 to "f" has incompatible type "*List[A]"; expected "B"
-main:10: error: Argument 3 to "f" has incompatible type "*List[A]"; expected "B"
-main:11: error: List or tuple expected as variable arguments
-main:12: error: List or tuple expected as variable arguments
 
 [case testCallerVarArgsTupleWithTypeInference]
 from typing import TypeVar, Tuple
@@ -522,14 +553,20 @@ S = TypeVar('S')
 T = TypeVar('T')
 a, b = None, None # type: (A, B)
 
-a, a = f(*(a, b))   # E: Argument 1 to "f" has incompatible type "*Tuple[A, B]"; expected "A"
-b, b = f(a, *(b,))  # E: Argument 1 to "f" has incompatible type "A"; expected "B"
-a, a = f(*(a, b))   # E: Argument 1 to "f" has incompatible type "*Tuple[A, B]"; expected "A"
-b, b = f(a, *(b,))  # E: Argument 1 to "f" has incompatible type "A"; expected "B"
-a, b = f(*(a, b, b)) # E: Too many arguments for "f"
-
-a, b = f(*(a, b))
-a, b = f(a, *(b,))
+if int():
+    a, a = f(*(a, b))   # E: Argument 1 to "f" has incompatible type "*Tuple[A, B]"; expected "A"
+if int():
+    b, b = f(a, *(b,))  # E: Argument 1 to "f" has incompatible type "A"; expected "B"
+if int():
+    a, a = f(*(a, b))   # E: Argument 1 to "f" has incompatible type "*Tuple[A, B]"; expected "A"
+if int():
+    b, b = f(a, *(b,))  # E: Argument 1 to "f" has incompatible type "A"; expected "B"
+if int():
+    a, b = f(*(a, b, b)) # E: Too many arguments for "f"
+if int():
+    a, b = f(*(a, b))
+if int():
+    a, b = f(a, *(b,))
 
 def f(a: S, b: T) -> Tuple[S, T]: pass
 
@@ -546,12 +583,21 @@ ao = None # type: List[object]
 aa = None # type: List[A]
 ab = None # type: List[B]
 
-a, aa = G().f(*[a])  # Fail
-aa, a = G().f(*[a])  # Fail
-ab, aa = G().f(*[a]) # Fail
+if int():
+    a, aa = G().f(*[a]) \
+      # E: Incompatible types in assignment (expression has type "List[A]", variable has type "A") \
+      # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[A]")
+if int():
+    aa, a = G().f(*[a]) # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "A")
+if int():
+    ab, aa = G().f(*[a]) \
+      # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[A]") \
+      # E: Argument 1 to "f" of "G" has incompatible type "*List[A]"; expected "B"
 
-ao, ao = G().f(*[a]) # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[object]")
-aa, aa = G().f(*[a]) # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[A]")
+if int():
+    ao, ao = G().f(*[a]) # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[object]")
+if int():
+    aa, aa = G().f(*[a]) # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[A]")
 
 class G(Generic[T]):
     def f(self, *a: S) -> Tuple[List[S], List[T]]:
@@ -560,12 +606,6 @@ class G(Generic[T]):
 class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
-[out]
-main:9: error: Incompatible types in assignment (expression has type "List[A]", variable has type "A")
-main:9: error: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[A]")
-main:10: error: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "A")
-main:11: error: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[A]")
-main:11: error: Argument 1 to "f" of "G" has incompatible type "*List[A]"; expected "B"
 
 [case testCallerTupleVarArgsAndGenericCalleeVarArg]
 # flags: --strict-optional
@@ -653,7 +693,8 @@ f(a) # E: Argument 1 to "f" has incompatible type "List[int]"; expected "List[Un
      # N: Consider using "Sequence" instead, which is covariant
 x = [1]
 y = ['a']
-x = y # E: Incompatible types in assignment (expression has type "List[str]", variable has type "List[int]")
+if int():
+    x = y # E: Incompatible types in assignment (expression has type "List[str]", variable has type "List[int]")
 [builtins fixtures/list.pyi]
 
 [case testInvariantTypeConfusingNames]

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -42,9 +42,12 @@ c = add([cast(A, b)], [a])
 [case testUnusedTypeIgnore]
 # flags: --warn-unused-ignores
 a = 1
-a = 'a' # type: ignore
-a = 2 # type: ignore # N: unused 'type: ignore' comment
-a = 'b' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    a = 'a' # type: ignore
+if int():
+    a = 2 # type: ignore # N: unused 'type: ignore' comment
+if int():
+    a = 'b' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testUnusedTypeIgnoreImport]
 # flags: --warn-unused-ignores

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1036,14 +1036,16 @@ import m
 class B(m.A):
     def a(self) -> None:
         x = 1
-        x = self.x
+        if int():
+            x = self.x
 
     def f(self) -> None:
         self.x = 1
 
     def z(self) -> None:
         x = 1
-        x = self.x
+        if int():
+            x = self.x
 [file m.py]
 class A: pass
 [file m.py.2]
@@ -1052,9 +1054,9 @@ class A:
         self.x = 'a'
 [out]
 ==
-main:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:8: error: Incompatible types in assignment (expression has type "int", variable has type "str")
-main:12: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:9: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+main:14: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testChangeBaseClassAttributeType]
 import m
@@ -1208,14 +1210,15 @@ m/__init__.py:3: error: Too few arguments for "g"
 import m
 def f() -> None:
     x = 1
-    x = m.x
+    if int():
+        x = m.x
 [file m.py]
 x = 1
 [file m.py.2]
 x = ''
 [out]
 ==
-main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testTwoStepsDueToModuleAttribute]
 import m
@@ -1223,37 +1226,8 @@ x = m.f()
 
 def g() -> None:
     y = 1
-    y = x # E
-[file m.py]
-def f() -> int: pass
-[file m.py.2]
-def f() -> str: pass
-[out]
-==
-main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-
-[case testTwoStepsDueToMultipleNamespaces]
-import m
-
-x = m.f()
-
-def g() -> None:
-    xx = 1
-    xx = x
-
-class A:
-    def a(self) -> None:
-        self.y = m.f()
-    def b(self) -> None:
-        yy = 1
-        yy = self.y
-
-class B:
-    def c(self) -> None:
-        self.z = m.f()
-    def b(self) -> None:
-        zz = 1
-        zz = self.z
+    if int():
+        y = x # E
 [file m.py]
 def f() -> int: pass
 [file m.py.2]
@@ -1261,8 +1235,40 @@ def f() -> str: pass
 [out]
 ==
 main:7: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:14: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-main:21: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testTwoStepsDueToMultipleNamespaces]
+import m
+x = m.f()
+
+def g() -> None:
+    xx = 1
+    if int():
+        xx = x # E
+
+class A:
+    def a(self) -> None:
+        self.y = m.f()
+    def b(self) -> None:
+        yy = 1
+        if int():
+            yy = self.y
+
+class B:
+    def c(self) -> None:
+        self.z = m.f()
+    def b(self) -> None:
+        zz = 1
+        if int():
+            zz = self.z
+[file m.py]
+def f() -> int: pass
+[file m.py.2]
+def f() -> str: pass
+[out]
+==
+main:7: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:15: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:23: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testConstructorSignatureChanged]
 import m
@@ -1420,14 +1426,15 @@ from m import x
 
 def f() -> None:
     y = 1
-    y = x
+    if int():
+        y = x
 [file m.py]
 x = 1
 [file m.py.2]
 x = ''
 [out]
 ==
-main:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testImportFromSubmoduleOfPackage]
 from m import n
@@ -1480,7 +1487,8 @@ from m import A
 
 def f(x: A.B) -> None:
     z = 1
-    z = x.y
+    if int():
+        z = x.y
 [file m.py]
 class A:
     class B:
@@ -1493,7 +1501,7 @@ class A:
             self.y = ''
 [out]
 ==
-main:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testReprocessMethodInNestedClass]
 from m import f
@@ -1502,7 +1510,8 @@ class A:
     class B:
         def g(self) -> None:
             x = 1
-            x = f()
+            if int():
+                x = f()
 [file m.py]
 def f() -> int: pass
 [file m.py.2]
@@ -1510,9 +1519,9 @@ def f() -> str: pass
 [file n.py.3]
 [out]
 ==
-main:7: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:8: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 ==
-main:7: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:8: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testReprocessMethodInNestedClassSemanal]
 import a
@@ -3517,10 +3526,11 @@ A = str
 [file b.py]
 import a
 def f(x: a.A):
-    x = int()
+    if int():
+        x = int()
 [out]
 ==
-b.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+b.py:4: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testAliasFineNormalClass]
 import b
@@ -3613,11 +3623,12 @@ def f(x: A):
 A = int
 [file b.py.2]
 def f(x: A):
-    x = int()
+    if int():
+        x = int()
 A = str
 [out]
 ==
-b.py:2: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+b.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testAliasFineChainedFunc]
 import b
@@ -3631,10 +3642,11 @@ B = a.A
 [file b.py]
 import aa
 def f(x: aa.B):
-    x = int()
+    if int():
+        x = int()
 [out]
 ==
-b.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+b.py:4: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testAliasFineChainedClass]
 import b
@@ -3669,11 +3681,12 @@ import a
 B = Dict[str, a.A]
 [file b.py]
 import aa
+
 x: aa.B = {'first': {str(): int()}}
 [builtins fixtures/dict.pyi]
 [out]
 ==
-b.py:2: error: Dict entry 0 has incompatible type "str": "int"; expected "str": "str"
+b.py:3: error: Dict entry 0 has incompatible type "str": "int"; expected "str": "str"
 
 [case testAliasFineNestedFunc]
 import b
@@ -3690,11 +3703,12 @@ B = Dict[str, a.A]
 [file b.py]
 import aa
 def f(x: aa.B):
-    x = {'first': {str(): int()}}
+    if int():
+        x = {'first': {str(): int()}}
 [builtins fixtures/dict.pyi]
 [out]
 ==
-b.py:3: error: Dict entry 0 has incompatible type "str": "int"; expected "str": "str"
+b.py:4: error: Dict entry 0 has incompatible type "str": "int"; expected "str": "str"
 
 [case testAliasFineNestedFuncDirect]
 import b
@@ -3711,11 +3725,12 @@ E = Dict
 [file b.py]
 import aa
 def f(x: aa.E[str, aa.a.A]):
-    x = {'first': {str(): int()}}
+    if int():
+        x = {'first': {str(): int()}}
 [builtins fixtures/dict.pyi]
 [out]
 ==
-b.py:3: error: Dict entry 0 has incompatible type "str": "int"; expected "str": "str"
+b.py:4: error: Dict entry 0 has incompatible type "str": "int"; expected "str": "str"
 
 [case testAliasFineNonGenericToGeneric]
 import b
@@ -5066,11 +5081,12 @@ x = ''
 from a import C
 c: C
 c = C.X
-c = 1
+if int():
+    c = 1
 [out]
 ==
 ==
-aa.py:4: error: Incompatible types in assignment (expression has type "int", variable has type "C")
+aa.py:5: error: Incompatible types in assignment (expression has type "int", variable has type "C")
 
 [case testRefreshClassBasedIntEnum]
 import aa
@@ -5092,14 +5108,16 @@ x = ''
 from a import C
 c: C
 c = C.X
-c = 1
-n: int
-n = C.X
-n = c
+if int():
+    c = 1
+    n: int
+    n = C.X
+    if int():
+        n = c
 [out]
 ==
 ==
-aa.py:4: error: Incompatible types in assignment (expression has type "int", variable has type "C")
+aa.py:5: error: Incompatible types in assignment (expression has type "int", variable has type "C")
 
 [case testClassBasedEnumPropagation1]
 import a
@@ -5164,11 +5182,12 @@ x = ''
 from a import C
 c: C
 c = C.X
-c = 1
+if int():
+   c = 1
 [out]
 ==
 ==
-aa.py:4: error: Incompatible types in assignment (expression has type "int", variable has type "C")
+aa.py:5: error: Incompatible types in assignment (expression has type "int", variable has type "C")
 
 [case testRefreshFuncBasedIntEnum]
 import aa
@@ -5189,14 +5208,15 @@ x = ''
 from a import C
 c: C
 c = C.X
-c = 1
-n: int
-n = C.X
+if int():
+    c = 1  # Error
+    n: int
+    n = C.X
 n = c
 [out]
 ==
 ==
-aa.py:4: error: Incompatible types in assignment (expression has type "int", variable has type "C")
+aa.py:5: error: Incompatible types in assignment (expression has type "int", variable has type "C")
 
 [case testFuncBasedEnumPropagation1]
 import a
@@ -7073,7 +7093,8 @@ from a import f
 
 def g() -> Iterator[int]:
     a = "string"
-    a = yield from f()
+    if int():
+        a = yield from f()
 
 [file a.py]
 from typing import Generator
@@ -7093,7 +7114,7 @@ def f() -> Generator[int, None, A]:
 
 [out]
 ==
-main:6: error: Incompatible types in assignment (expression has type "A", variable has type "str")
+main:7: error: Incompatible types in assignment (expression has type "A", variable has type "str")
 
 [case testFString]
 from a import g

--- a/test-data/unit/hacks.txt
+++ b/test-data/unit/hacks.txt
@@ -1,0 +1,110 @@
+Weird legacy stuff in test cases
+================================
+
+Due to historical reasons, test cases contain things that may appear
+baffling without extra context. This file attempts to describe most of
+them.
+
+Strict optional is disabled be default
+--------------------------------------
+
+Strict optional checking is enabled in mypy by default, but test cases
+must enable it explicitly, either through `# flags: --strict-optional`
+or by including `optional` as a substring in your test file name.
+
+The reason for this is that many test cases written before strict
+optional was implemented use the idiom `x = None # type: t`, and
+updating all of these test cases would take a lot of work.
+
+Dummy if statements to prevent redefinition
+-------------------------------------------
+
+Many test cases use if statements to prevent an assignment from creating
+a new variable. This in anticipation of allowing assignments to redefine
+variables by default. Conditional assignments will continue to refine
+a previously defined variable instead of defining a new one. When the
+test cases were written, we didn't anticipate that variables could be
+allowed to be redefined, and adding if statements was the easiest way
+to migrate these tests.
+
+Example:
+
+```
+x = 0
+if int():
+    x = ''  # Always generates an error since this is not a redefinition
+
+y = 0
+y = ''  # This could be valid if a new 'y' is defined here
+```
+
+Note that some of the checks may turn out to be redundant, as the
+exact rules for what constitues a redefinition are still up for
+debate. This is okay since the extra if statements generally don't
+otherwise affect semantics.
+
+There are a few ways this is used, depending on the context:
+
+* `if int():` is the most common one. Assignments in the if body won't
+  redefine variables defined before the if statement.
+* `if 1:` is used if the body of the if statement returns a value, and
+  mypy would complain about a missing return statement otherwise. This
+  works since `if 1:` is treated as an always taken condition, whereas
+  `if int():` is not recognized as such.
+* `if str():` is used if the builtins fixture doesn't define `int` for
+  some reason.
+
+Function definition to prevent redefinition
+-------------------------------------------
+
+Sometimes test cases assume that a variable is not redefined, and we
+insert a dummy function definition to prevent this, since variables won't
+be able to be redefined across a function definition. Example:
+
+```
+x = 0
+
+def f(): pass
+
+x = ''  # Does not redefine x because of the definition of f() above
+```
+
+Dummy variable reference to allow redefinition
+----------------------------------------------
+
+The plan is to only allow a variable to be redefined if the value has
+been accessed. This wouldn't count as redefinition, since `x` is never
+read:
+
+```
+x = 0
+x = ''  # Not a redefinition
+```
+
+Sometimes we add a dummy variable access to allow redefinition in the
+future, or to trigger the redefinition machinery even if redefinition
+should not be okay:
+
+```
+x = 0
+x
+x = ''  # Could be a redefinition
+```
+
+The reason for this special case is type comments with dummy
+initializers, where the second assignment should never be treated
+as a redefinition:
+
+```
+x = None  # type: int
+x = ''  # Should not redefine x, since it has only been declared
+```
+
+Similarly, if there is only a variable annotation, the first
+assignment won't redefine the variable, as this would override
+the declared type:
+
+```
+x: int
+x = ''  # Should not redefine x
+```

--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -245,22 +245,24 @@ import typing
 s = ''
 u = u''
 n = 0
-n = s + '' # E
-s = s + u'' # E
+if int():
+    n = s + '' # E
+    s = s + u'' # E
 [out]
-_program.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-_program.py:6: error: Incompatible types in assignment (expression has type "unicode", variable has type "str")
+_program.py:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+_program.py:7: error: Incompatible types in assignment (expression has type "unicode", variable has type "str")
 
 [case testStrJoin_python2]
-import typing
 s = ''
 u = u''
 n = 0
-n = ''.join([''])   # Error
-s = ''.join([u''])  # Error
+if int():
+    n = ''.join([''])   # Error
+if int():
+    s = ''.join([u''])  # Error
 [out]
 _program.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-_program.py:6: error: Incompatible types in assignment (expression has type "unicode", variable has type "str")
+_program.py:7: error: Incompatible types in assignment (expression has type "unicode", variable has type "str")
 
 [case testNamedTuple_python2]
 from typing import NamedTuple
@@ -280,11 +282,12 @@ _program.py:5: error: "X" has no attribute "c"
 import typing
 x = 4j
 y = x.real
-y = x         # Error
+if int():
+    y = x         # Error
 x.imag = 2.0  # Error
 [out]
-_program.py:4: error: Incompatible types in assignment (expression has type "complex", variable has type "float")
-_program.py:5: error: Property "imag" defined in "complex" is read-only
+_program.py:5: error: Incompatible types in assignment (expression has type "complex", variable has type "float")
+_program.py:6: error: Property "imag" defined in "complex" is read-only
 
 [case testComplexArithmetic_python2]
 import typing

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -353,14 +353,18 @@ abs(2.2) + 'x'
 _program.py:6: error: Unsupported operand types for + ("float" and "str")
 
 [case testROperatorMethods]
-
 b = None  # type: bytes
 s = None  # type: str
-s = b'foo' * 5 # Error
-b = 5 * b'foo'
-b = b'foo' * 5
-s = 5 * 'foo'
-s = 'foo' * 5
+if int():
+    s = b'foo' * 5 # Error
+if int():
+    b = 5 * b'foo'
+if int():
+    b = b'foo' * 5
+if int():
+    s = 5 * 'foo'
+if int():
+    s = 'foo' * 5
 [out]
 _program.py:4: error: Incompatible types in assignment (expression has type "bytes", variable has type "str")
 
@@ -674,14 +678,15 @@ print(4J / 2.0)
 2j
 
 [case testComplexArithmetic2]
-import typing
 x = 5 + 8j
-x = ''
+if int():
+    x = '' # E
 y = 3j * 2.0
-y = ''
+if int():
+    y = '' # E
 [out]
 _program.py:3: error: Incompatible types in assignment (expression has type "str", variable has type "complex")
-_program.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "complex")
+_program.py:6: error: Incompatible types in assignment (expression has type "str", variable has type "complex")
 
 [case testSuperNew]
 from typing import Dict, Any


### PR DESCRIPTION
After the planned change, test cases no longer can rely on code
like this generating an error, since the two assignments will
create two logically separate variables with independent types:

```
x = 0
x = ''  # Currently an error, but likely not in the future
```

Instead, the idea is to use an if statement to prevent redefinition.
This works since redefinition will only happen unconditionally:

```
x = 0
if int():
    x = ''  # Will continue to be an error
```

Even this may stop working in the future, and we may need to
another major test case update then. If we always use the
`if int():` idiom, finding things that need changing will be
easy. (Sometimes `if int():` didn't work and I used `if 1:`
instead.)

In new test cases we should generally avoid using assignment
statements such as the above to generate errors. Instead, we
can use `reveal_type()` and calls to functions with incompatible
argument types, for example.