### PR TITLE
Don't map actual **kwargs to formal *args

### DIFF
--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -81,8 +81,10 @@ def map_actuals_to_formals(actual_kinds: List[int],
                     no_certain_match = (
                         not formal_to_actual[fi]
                         or actual_kinds[formal_to_actual[fi][0]] == nodes.ARG_STAR)
-                    if ((formal_names[fi] and no_certain_match)
-                            or formal_kinds[fi] == nodes.ARG_STAR2):
+                    if ((formal_names[fi]
+                            and no_certain_match
+                            and formal_kinds[fi] != nodes.ARG_STAR) or
+                            formal_kinds[fi] == nodes.ARG_STAR2):
                         formal_to_actual[fi].append(ai)
     return formal_to_actual
 

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -403,3 +403,16 @@ class A:
 tmp/m.py:1: error: Unsupported operand types for + ("int" and "str")
 main:2: error: Unexpected keyword argument "x" for "A"
 tmp/m.py:3: note: "A" defined here
+
+[case testStarArgsAndKwArgsSpecialCase]
+from typing import Dict, Mapping
+
+def f(*vargs: int, **kwargs: object) -> None:
+	pass
+
+d = {} # type: Dict[str, object]
+f(**d)
+
+m = {} # type: Mapping[str, object]
+f(**m)
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
The fix was originally proposed by @elazarg.

Fixes #1969.