### PR TITLE
Fix "Could not find builtin symbol 'NoneType'" in the ctypes plugin

### DIFF
--- a/mypy/plugins/ctypes.py
+++ b/mypy/plugins/ctypes.py
@@ -6,7 +6,9 @@ from typing import List, Optional
 import mypy.plugin
 from mypy.maptype import map_instance_to_supertype
 from mypy.subtypes import is_subtype
-from mypy.types import AnyType, CallableType, Instance, Type, TypeOfAny, UnionType, union_items
+from mypy.types import (
+    AnyType, CallableType, Instance, NoneTyp, Type, TypeOfAny, UnionType, union_items
+)
 
 
 def _get_bytes_type(api: 'mypy.plugin.CheckerPluginInterface') -> Instance:
@@ -70,7 +72,7 @@ def _autoconvertible_to_cdata(tp: Type, api: 'mypy.plugin.CheckerPluginInterface
                     # Pointer-like _SimpleCData subclasses can also be converted from
                     # an int or None.
                     allowed_types.append(api.named_generic_type('builtins.int', []))
-                    allowed_types.append(api.named_generic_type('builtins.NoneType', []))
+                    allowed_types.append(NoneTyp())
 
     return UnionType.make_simplified_union(allowed_types)
 

--- a/test-data/unit/check-ctypes.test
+++ b/test-data/unit/check-ctypes.test
@@ -80,6 +80,13 @@ reveal_type(ca.value)  # E: Revealed type is 'builtins.bytes'
 reveal_type(ca.raw)  # E: Revealed type is 'builtins.bytes'
 [builtins fixtures/floatdict.pyi]
 
+[case testCtypesCharPArrayDoesNotCrash]
+import ctypes
+
+# The following line used to crash with "Could not find builtin symbol 'NoneType'"
+ca = (ctypes.c_char_p * 0)()
+[builtins fixtures/floatdict.pyi]
+
 [case testCtypesCharArrayAttrsPy2]
 # flags: --py2
 import ctypes


### PR DESCRIPTION
The error was triggered by creating an array of pointers. The stack
trace:

    $ pytest -n0 -k testCtypesCharPArrayDoesNotCrash
    (...)
    data: /Users/kuba/projects/mypy/test-data/unit/check-ctypes.test:83:
    SystemExit: 2
    ---------------------------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------------------------
    Traceback (most recent call last):
      File "/Users/kuba/.ve37/bin/pytest", line 11, in <module>
        sys.exit(main())
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/_pytest/config/__init__.py", line 77, in main
        return config.hook.pytest_cmdline_main(config=config)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/hooks.py", line 284, in __call__
        return self._hookexec(self, self.get_hookimpls(), kwargs)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/manager.py", line 67, in _hookexec
        return self._inner_hookexec(hook, methods, kwargs)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/manager.py", line 61, in <lambda>
        firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
        res = hook_impl.function(*args)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/_pytest/main.py", line 218, in pytest_cmdline_main
        return wrap_session(config, _main)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/_pytest/main.py", line 185, in wrap_session
        session.exitstatus = doit(config, session) or 0
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/_pytest/main.py", line 225, in _main
        config.hook.pytest_runtestloop(session=session)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/hooks.py", line 284, in __call__
        return self._hookexec(self, self.get_hookimpls(), kwargs)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/manager.py", line 67, in _hookexec
        return self._inner_hookexec(hook, methods, kwargs)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/manager.py", line 61, in <lambda>
        firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
        res = hook_impl.function(*args)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/_pytest/main.py", line 246, in pytest_runtestloop
        item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/hooks.py", line 284, in __call__
        return self._hookexec(self, self.get_hookimpls(), kwargs)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/manager.py", line 67, in _hookexec
        return self._inner_hookexec(hook, methods, kwargs)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/manager.py", line 61, in <lambda>
        firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
        res = hook_impl.function(*args)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/_pytest/runner.py", line 76, in pytest_runtest_protocol
        runtestprotocol(item, nextitem=nextitem)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/_pytest/runner.py", line 91, in runtestprotocol
        reports.append(call_and_report(item, "call", log))
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/_pytest/runner.py", line 171, in call_and_report
        call = call_runtest_hook(item, when, **kwds)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/_pytest/runner.py", line 195, in call_runtest_hook
        treat_keyboard_interrupt_as_exception=item.config.getvalue("usepdb"),
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/_pytest/runner.py", line 211, in __init__
        self.result = func()
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/_pytest/runner.py", line 193, in <lambda>
        lambda: ihook(item=item, **kwds),
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/hooks.py", line 284, in __call__
        return self._hookexec(self, self.get_hookimpls(), kwargs)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/manager.py", line 67, in _hookexec
        return self._inner_hookexec(hook, methods, kwargs)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/manager.py", line 61, in <lambda>
        firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
        res = hook_impl.function(*args)
      File "/Users/kuba/.ve37/lib/python3.7/site-packages/_pytest/runner.py", line 121, in pytest_runtest_call
        item.runtest()
      File "/Users/kuba/projects/mypy/mypy/test/data.py", line 212, in runtest
        suite.run_case(self)
      File "/Users/kuba/projects/mypy/mypy/test/testcheck.py", line 113, in run_case
        self.run_case_once(testcase)
      File "/Users/kuba/projects/mypy/mypy/test/testcheck.py", line 173, in run_case_once
        alt_lib_path=test_temp_dir)
      File "/Users/kuba/projects/mypy/mypy/build.py", line 157, in build
        result = _build(sources, options, alt_lib_path, flush_errors, fscache)
      File "/Users/kuba/projects/mypy/mypy/build.py", line 207, in _build
        graph = dispatch(sources, manager)
      File "/Users/kuba/projects/mypy/mypy/build.py", line 2216, in dispatch
        process_graph(graph, manager)
      File "/Users/kuba/projects/mypy/mypy/build.py", line 2514, in process_graph
        process_stale_scc(graph, scc, manager)
      File "/Users/kuba/projects/mypy/mypy/build.py", line 2623, in process_stale_scc
        graph[id].type_check_first_pass()
      File "/Users/kuba/projects/mypy/mypy/build.py", line 1778, in type_check_first_pass
        self.type_checker().check_first_pass()
      File "/Users/kuba/projects/mypy/mypy/checker.py", line 282, in check_first_pass
        self.accept(d)
      File "/Users/kuba/projects/mypy/mypy/checker.py", line 393, in accept
        stmt.accept(self)
      File "/Users/kuba/projects/mypy/mypy/nodes.py", line 968, in accept
        return visitor.visit_assignment_stmt(self)
      File "/Users/kuba/projects/mypy/mypy/checker.py", line 1696, in visit_assignment_stmt
        self.check_assignment(s.lvalues[-1], s.rvalue, s.type is None, s.new_syntax)
      File "/Users/kuba/projects/mypy/mypy/checker.py", line 1813, in check_assignment
        self.infer_variable_type(inferred, lvalue, self.expr_checker.accept(rvalue),
      File "/Users/kuba/projects/mypy/mypy/checkexpr.py", line 3123, in accept
        typ = node.accept(self)
      File "/Users/kuba/projects/mypy/mypy/nodes.py", line 1421, in accept
        return visitor.visit_call_expr(self)
      File "/Users/kuba/projects/mypy/mypy/checkexpr.py", line 232, in visit_call_expr
        return self.visit_call_expr_inner(e, allow_none_return=allow_none_return)
      File "/Users/kuba/projects/mypy/mypy/checkexpr.py", line 302, in visit_call_expr_inner
        ret_type = self.check_call_expr_with_callee_type(callee_type, e, fullname, object_type)
      File "/Users/kuba/projects/mypy/mypy/checkexpr.py", line 647, in check_call_expr_with_callee_type
        object_type=object_type)[0]
      File "/Users/kuba/projects/mypy/mypy/checkexpr.py", line 705, in check_call
        callable_node, arg_messages)
      File "/Users/kuba/projects/mypy/mypy/checkexpr.py", line 684, in check_call
        object_type)
      File "/Users/kuba/projects/mypy/mypy/checkexpr.py", line 786, in check_callable_call
        callable_name, object_type, context)
      File "/Users/kuba/projects/mypy/mypy/checkexpr.py", line 563, in apply_function_plugin
        callee.ret_type, formal_arg_exprs, context, self.chk))
      File "/Users/kuba/projects/mypy/mypy/plugins/ctypes.py", line 114, in array_constructor_callback
        allowed = _autoconvertible_to_cdata(et, ctx.api)
      File "/Users/kuba/projects/mypy/mypy/plugins/ctypes.py", line 73, in _autoconvertible_to_cdata
        allowed_types.append(api.named_generic_type('builtins.NoneType', []))
      File "/Users/kuba/projects/mypy/mypy/checker.py", line 3501, in named_generic_type
        info = self.lookup_typeinfo(name)
      File "/Users/kuba/projects/mypy/mypy/checker.py", line 3507, in lookup_typeinfo
        sym = self.lookup_qualified(fullname)
      File "/Users/kuba/projects/mypy/mypy/checker.py", line 3566, in lookup_qualified
        "defines this symbol.)".format(last))
    KeyError: "Could not find builtin symbol 'NoneType'. (Are you running a test case? If so, make sure to include a fixture that defines this symbol.)"