### PR TITLE
Make `refresh_top_level()` more like `visit_file()` in the third pass

### DIFF
--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -133,6 +133,7 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
         """Reanalyze a stale module top-level in fine-grained incremental mode."""
         for d in file_node.defs:
             self.accept(d)
+        self.analyze_symbol_table(file_node.names)
 
     def accept(self, node: Node) -> None:
         try:

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -192,7 +192,7 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
                 self.analyze(tdef.analyzed.info.typeddict_type, tdef.analyzed, warn=True)
             elif isinstance(tdef.analyzed, NamedTupleExpr):
                 self.analyze(tdef.analyzed.info.tuple_type, tdef.analyzed, warn=True)
-                self.analyze_synthetic_info(tdef.analyzed.info)
+                self.analyze_info(tdef.analyzed.info)
         super().visit_class_def(tdef)
         self.analyze_symbol_table(tdef.info.names)
         self.scope.leave()
@@ -273,7 +273,7 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
                 if analyzed.info:
                     # Currently NewTypes only have __init__, but to be future proof,
                     # we analyze all symbols.
-                    self.analyze_synthetic_info(analyzed.info)
+                    self.analyze_info(analyzed.info)
                 if analyzed.info and analyzed.info.mro:
                     analyzed.info.mro = []  # Force recomputation
                     self.sem.calculate_class_mro(analyzed.info.defn)
@@ -288,7 +288,7 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
                 self.analyze(analyzed.info.typeddict_type, analyzed, warn=True)
             if isinstance(analyzed, NamedTupleExpr):
                 self.analyze(analyzed.info.tuple_type, analyzed, warn=True)
-                self.analyze_synthetic_info(analyzed.info)
+                self.analyze_info(analyzed.info)
         if isinstance(s.lvalues[0], RefExpr) and isinstance(s.lvalues[0].node, Var):
             self.analyze(s.lvalues[0].node.type, s.lvalues[0].node)
         # Subclass attribute assignments with no type annotation should be
@@ -472,18 +472,12 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
 
             self.patches.append((PRIORITY_TYPEVAR_VALUES, self.make_scoped_patch(patch2)))
 
-    def analyze_synthetic_info(self, info: TypeInfo) -> None:
+    def analyze_info(self, info: TypeInfo) -> None:
         # Similar to above but for nodes with synthetic TypeInfos (NamedTuple and NewType).
         for name in info.names:
             sym = info.names[name]
             if isinstance(sym.node, (FuncDef, Decorator)):
-                # Since we are analyzing a synthetic type info, the methods there
-                # are not real independent targets, and should be processed when
-                # the enclosing synthetic type is processed.
-                old_recurse = self.recurse_into_functions
-                self.recurse_into_functions = True
                 self.accept(sym.node)
-                self.recurse_into_functions = old_recurse
             if isinstance(sym.node, Var):
                 self.analyze(sym.node.type, sym.node)
 

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8134,3 +8134,53 @@ x = 'no way'
 ==
 ==
 main:10: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testNamedTupleForwardFunctionDirect]
+# flags: --ignore-missing-imports
+from typing import NamedTuple
+from b import B
+
+NT = NamedTuple('NT', [('x', B)])
+[file b.py.2]
+def func(x): pass
+B = func
+[out]
+
+[case testNamedTupleForwardFunctionIndirect]
+# flags: --ignore-missing-imports
+from typing import NamedTuple
+from a import A
+
+NT = NamedTuple('NT', [('x', A)])
+[file a.py]
+from b import B
+A = B
+[file b.py.2]
+def func(x): pass
+B = func
+[out]
+
+[case testAliasForwardFunctionDirect]
+# flags: --ignore-missing-imports
+from typing import Optional
+from b import B
+
+Alias = Optional[B]
+[file b.py.2]
+def func(x): pass
+B = int()
+[out]
+
+[case testAliasForwardFunctionIndirect]
+# flags: --ignore-missing-imports
+from typing import Optional
+from a import A
+
+Alias = Optional[A]
+[file a.py]
+from b import B
+A = B
+[file b.py.2]
+def func(x): pass
+B = func
+[out]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8135,35 +8135,6 @@ x = 'no way'
 ==
 main:10: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
-[case testNamedTupleForwardFunctionDirect]
-# flags: --ignore-missing-imports
-from typing import NamedTuple
-from b import B
-
-NT = NamedTuple('NT', [('x', B)])
-[file b.py.2]
-def func(x): pass
-B = func
-[out]
-==
-main:5: error: Invalid type "b.B"
-
-[case testNamedTupleForwardFunctionIndirect]
-# flags: --ignore-missing-imports
-from typing import NamedTuple
-from a import A
-
-NT = NamedTuple('NT', [('x', A)])
-[file a.py]
-from b import B
-A = B
-[file b.py.2]
-def func(x): pass
-B = func
-[out]
-==
-main:5: error: Invalid type "a.A"
-
 [case testAliasForwardFunctionDirect]
 # flags: --ignore-missing-imports
 from typing import Optional

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8145,6 +8145,8 @@ NT = NamedTuple('NT', [('x', B)])
 def func(x): pass
 B = func
 [out]
+==
+main:5: error: Invalid type "b.B"
 
 [case testNamedTupleForwardFunctionIndirect]
 # flags: --ignore-missing-imports
@@ -8159,6 +8161,8 @@ A = B
 def func(x): pass
 B = func
 [out]
+==
+main:5: error: Invalid type "a.A"
 
 [case testAliasForwardFunctionDirect]
 # flags: --ignore-missing-imports
@@ -8170,6 +8174,8 @@ Alias = Optional[B]
 def func(x): pass
 B = int()
 [out]
+==
+main:5: error: Invalid type "b.B"
 
 [case testAliasForwardFunctionIndirect]
 # flags: --ignore-missing-imports
@@ -8184,3 +8190,5 @@ A = B
 def func(x): pass
 B = func
 [out]
+==
+main:5: error: Invalid type "a.A"


### PR DESCRIPTION
Fixes #6032 (first part)

This is a very straightforward fix. I am actually surprised no one found this before (maybe because mypy daemon is not so widely used yet).

In future, it would be great to have a mechanism to avoid such mistakes, by somehow making `refresh_top_level()` to do all the special things `visit_file()` does. I don't have any ideas now, but it probably makes sense to consider this during semantic analyzer refactoring (another possible solution is to avoid any such special things, but this should be clearly documented).