### PR TITLE
Better error message when __eq__ has unexpected signature

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -405,10 +405,10 @@ class Errors:
                                                                      str, str]]:
         """Translate the messages into a sequence of tuples.
 
-        Each tuple is of form (path, line, col, message.  The rendered
-        sequence includes information about error contexts. The path
-        item may be None. If the line item is negative, the line
-        number is not defined for the tuple.
+        Each tuple is of form (path, line, col, severity, message).
+        The rendered sequence includes information about error contexts.
+        The path item may be None. If the line item is negative, the
+        line number is not defined for the tuple.
         """
         result = []  # type: List[Tuple[Optional[str], int, int, str, str]]
         # (path, line, column, severity, message)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -182,28 +182,31 @@ class MessageBuilder:
 
     def report(self, msg: str, context: Optional[Context], severity: str,
                file: Optional[str] = None, origin: Optional[Context] = None,
-               offset: int = 0) -> None:
+               offset: int = 0, strip_msg: bool = True) -> None:
         """Report an error or note (unless disabled)."""
         if self.disable_count <= 0:
+            msg = msg.strip() if strip_msg else msg
             self.errors.report(context.get_line() if context else -1,
                                context.get_column() if context else -1,
-                               msg.strip(), severity=severity, file=file, offset=offset,
+                               msg, severity=severity, file=file, offset=offset,
                                origin_line=origin.get_line() if origin else None)
 
     def fail(self, msg: str, context: Optional[Context], file: Optional[str] = None,
-             origin: Optional[Context] = None) -> None:
+             origin: Optional[Context] = None, strip_msg: bool = True) -> None:
         """Report an error message (unless disabled)."""
-        self.report(msg, context, 'error', file=file, origin=origin)
+        self.report(msg, context, 'error', file=file, origin=origin, strip_msg=strip_msg)
 
     def note(self, msg: str, context: Context, file: Optional[str] = None,
-             origin: Optional[Context] = None, offset: int = 0) -> None:
+             origin: Optional[Context] = None, offset: int = 0,
+             strip_msg: bool = True) -> None:
         """Report a note (unless disabled)."""
-        self.report(msg, context, 'note', file=file, origin=origin, offset=offset)
+        self.report(msg, context, 'note', file=file, origin=origin,
+                    offset=offset, strip_msg=strip_msg)
 
     def warn(self, msg: str, context: Context, file: Optional[str] = None,
-             origin: Optional[Context] = None) -> None:
+             origin: Optional[Context] = None, strip_msg: bool = True) -> None:
         """Report a warning message (unless disabled)."""
-        self.report(msg, context, 'warning', file=file, origin=origin)
+        self.report(msg, context, 'warning', file=file, origin=origin, strip_msg=strip_msg)
 
     def quote_type_string(self, type_string: str) -> str:
         """Quotes a type representation for use in messages."""

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -203,6 +203,14 @@ class MessageBuilder:
         self.report(msg, context, 'note', file=file, origin=origin,
                     offset=offset, strip_msg=strip_msg)
 
+    def note_multiline(self, messages: str, context: Context, file: Optional[str] = None,
+             origin: Optional[Context] = None, offset: int = 0,
+             strip_msg: bool = True) -> None:
+        """Report as many notes as lines in the message (unless disabled)."""
+        for msg in messages.splitlines():
+            self.report(msg, context, 'note', file=file, origin=origin,
+                        offset=offset, strip_msg=strip_msg)
+
     def warn(self, msg: str, context: Context, file: Optional[str] = None,
              origin: Optional[Context] = None, strip_msg: bool = True) -> None:
         """Report a warning message (unless disabled)."""
@@ -862,6 +870,21 @@ class MessageBuilder:
         target = self.override_target(name, name_in_supertype, supertype)
         self.fail('Argument {} of "{}" incompatible with {}'
                   .format(arg_num, name, target), context)
+
+        if name in ("__eq__", "__ne__"):
+            multiline_msg = self.comparison_method_example_msg(name)
+            self.note_multiline(multiline_msg, context, strip_msg=False)
+
+    def comparison_method_example_msg(self, method_name: str) -> str:
+        return '''It is recommended for "{method_name}" to work with arbitrary objects.
+The snippet below shows an example of how you can implement "{method_name}":
+
+class Foo(...):
+    ...
+    def {method_name}(self, other: object) -> bool:
+        if not isinstance(other, Foo):
+            raise NotImplementedError
+        return <logic to compare two Foo instances>'''.format(method_name=method_name)
 
     def return_type_incompatible_with_supertype(
             self, name: str, name_in_supertype: str, supertype: str,

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -282,6 +282,33 @@ class B(A):
 main:7: error: Argument 1 of "f" incompatible with supertype "A"
 main:9: error: Return type of "h" incompatible with supertype "A"
 
+[case testEqNeMethodsOverridingWithNonObjects]
+class A:
+  def __eq__(self, other: A) -> bool: pass  # Fail
+  def __ne__(self, other: A) -> bool: pass  # Fail
+[builtins fixtures/attr.pyi]
+[out]
+main:2: error: Argument 1 of "__eq__" incompatible with supertype "object"
+main:2: note: It is recommended for "__eq__" to work with arbitrary objects.
+main:2: note: The snippet below shows an example of how you can implement "__eq__":
+main:2: note:
+main:2: note: class Foo(...):
+main:2: note:     ...
+main:2: note:     def __eq__(self, other: object) -> bool:
+main:2: note:         if not isinstance(other, Foo):
+main:2: note:             raise NotImplementedError
+main:2: note:         return <logic to compare two Foo instances>
+main:3: error: Argument 1 of "__ne__" incompatible with supertype "object"
+main:3: note: It is recommended for "__ne__" to work with arbitrary objects.
+main:3: note: The snippet below shows an example of how you can implement "__ne__":
+main:3: note:
+main:3: note: class Foo(...):
+main:3: note:     ...
+main:3: note:     def __ne__(self, other: object) -> bool:
+main:3: note:         if not isinstance(other, Foo):
+main:3: note:             raise NotImplementedError
+main:3: note:         return <logic to compare two Foo instances>
+
 [case testMethodOverridingWithIncompatibleArgumentCount]
 import typing
 class A:


### PR DESCRIPTION
Hey there,

This PR tackles an old issue #2055 opened in 2016 - to get started in the mypy source code.

This PR will add a message and an example when the arguments of the dunder methods  `__eq__` or `__ne__` do not match the expected signature. With this PR, the added message looks like this:
```
It is recommended for "{method_name}" to work with arbitrary objects.
The snippet below shows an example of how you can implement "{method_name}":

class Foo(...):
    ...
    def {method_name}(self, other: object) -> bool:
        if not isinstance(other, Foo):
            raise NotImplementedError
        return <logic to compare two Foo instances>
```

The 3 commits can and should be reviewed individually since they represent independent bulks of work:
1. Fix a docstring of errors.render_messages
2. Add an option so that reporting an error/warning/note eventually doesn't strip the message. This was necessary because the new message needs to preserve indentation.
3. The core of the work: add the message when one of these methods is used and add a test

To me, the details that can open to a discussion:
* the message itself. Can it be simpler/better?
* is the `note_multiline`-method approach acceptable for having multiple messages at once
* is the `strip_msg` boolean acceptable?
* did I understand the test framework correctly and is the test sufficient?

Looking forward for some reviews
Cheers,
David