### PR TITLE
Add pynamodb plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "typeshed"]
 	path = mypy/typeshed
-	url = https://github.com/python/typeshed
+	url = https://github.com/ikonst/typeshed
+	branch = pynamodb-attr-nullable

--- a/mypy/plugins/pynamodb.py
+++ b/mypy/plugins/pynamodb.py
@@ -1,0 +1,40 @@
+from typing import Callable, Optional
+
+from mypy.nodes import NameExpr, CallExpr
+from mypy.plugin import MethodContext, Plugin
+from mypy.types import Instance, Type
+
+ATTR_FULL_NAME = 'pynamodb.attributes.Attribute'
+
+
+class MypyPlugin(Plugin):
+    def get_function_hook(self, fullname: str) -> Optional[Callable[[MethodContext], Type]]:
+        return _function_hook_callback
+
+
+def _function_hook_callback(ctx: MethodContext) -> Type:
+    if (
+        not isinstance(ctx.default_return_type, Instance) or
+        not ctx.default_return_type.type.has_base(ATTR_FULL_NAME) or
+        # TODO: any better way to tell apart a construction from other functions?
+        not isinstance(ctx.context, CallExpr) or
+        not ctx.context.callee.fullname == ctx.default_return_type.type.fullname()
+    ):
+        return ctx.default_return_type
+
+    attr_type = ctx.default_return_type
+    base_types = [base for base in attr_type.type.bases if base.type.fullname() == 'pynamodb.attributes.Attribute']
+    if not base_types:
+        return ctx.default_return_type
+    base_type = base_types[0]
+    underlying_type = base_type.args[0]
+
+    for arg_name, arg_expr in zip(ctx.context.arg_names, ctx.context.args):
+        if isinstance(arg_expr, NameExpr) and arg_expr.fullname == 'builtins.True':
+            return ctx.api.named_generic_type('pynamodb.attributes._NullableAttribute', [attr_type, underlying_type])
+
+    return ctx.default_return_type
+
+
+def plugin(version: str):
+    return MypyPlugin

--- a/mypy/plugins/pynamodb.py
+++ b/mypy/plugins/pynamodb.py
@@ -23,16 +23,21 @@ def _function_hook_callback(ctx: MethodContext) -> Type:
         return ctx.default_return_type
 
     attr_type = ctx.default_return_type
-    base_types = [base for base in attr_type.type.bases if base.type.fullname() == 'pynamodb.attributes.Attribute']
+    base_types = [base for base in attr_type.type.bases
+                  if base.type.fullname() == 'pynamodb.attributes.Attribute']
     if not base_types:
         return ctx.default_return_type
     base_type = base_types[0]
     underlying_type = base_type.args[0]
 
-    # If initializer gets named arg null=True, wrap in _NullableAttribute to make the underlying type optional
+    # If initializer gets named arg null=True,
+    # wrap in _NullableAttribute to make the underlying type optional
     for arg_name, arg_expr in zip(ctx.context.arg_names, ctx.context.args):
         if isinstance(arg_expr, NameExpr) and arg_expr.fullname == 'builtins.True':
-            return ctx.api.named_generic_type('pynamodb.attributes._NullableAttribute', [attr_type, underlying_type])
+            return ctx.api.named_generic_type('pynamodb.attributes._NullableAttribute', [
+                attr_type,
+                underlying_type,
+            ])
 
     return ctx.default_return_type
 

--- a/mypy/plugins/pynamodb.py
+++ b/mypy/plugins/pynamodb.py
@@ -7,7 +7,7 @@ from mypy.types import Instance, Type
 ATTR_FULL_NAME = 'pynamodb.attributes.Attribute'
 
 
-class MypyPlugin(Plugin):
+class PynamodbPlugin(Plugin):
     def get_function_hook(self, fullname: str) -> Optional[Callable[[MethodContext], Type]]:
         return _function_hook_callback
 
@@ -38,4 +38,4 @@ def _function_hook_callback(ctx: MethodContext) -> Type:
 
 
 def plugin(version: str):
-    return MypyPlugin
+    return PynamodbPlugin

--- a/mypy/plugins/pynamodb.py
+++ b/mypy/plugins/pynamodb.py
@@ -29,6 +29,7 @@ def _function_hook_callback(ctx: MethodContext) -> Type:
     base_type = base_types[0]
     underlying_type = base_type.args[0]
 
+    # If initializer gets named arg null=True, wrap in _NullableAttribute to make the underlying type optional
     for arg_name, arg_expr in zip(ctx.context.arg_names, ctx.context.args):
         if isinstance(arg_expr, NameExpr) and arg_expr.fullname == 'builtins.True':
             return ctx.api.named_generic_type('pynamodb.attributes._NullableAttribute', [attr_type, underlying_type])


### PR DESCRIPTION
This plugin will implement aspects of the pynamodb library that cannot be expressed through the stubs alone.

This first version makes attributes with `nullable=True` have their underlying value be optional, i.e. given
```py
class MyModel(Model):
   my_attr = NumberAttribute(null=True)
```
then `MyModel.my_attr` will be typed `_NullableAttribute[NumberAttribute, Number]` and `MyModel().my_attr` will be typed `Optional[Number]`.