### PR TITLE
Disable promotions in isinstance checks

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3756,11 +3756,12 @@ def conditional_type_map(expr: Expression,
             proposed_type = UnionType([type_range.item for type_range in proposed_type_ranges])
         if current_type:
             if (not any(type_range.is_upper_bound for type_range in proposed_type_ranges)
-               and is_proper_subtype(current_type, proposed_type)):
+               and is_proper_subtype(current_type, proposed_type, ignore_promotions=True)):
                 # Expression is always of one of the types in proposed_type_ranges
                 return {}, None
             elif not is_overlapping_types(current_type, proposed_type,
-                                          prohibit_none_typevar_overlap=True):
+                                          prohibit_none_typevar_overlap=True,
+                                          ignore_promotions=True):
                 # Expression is never of any type in proposed_type_ranges
                 return None, {}
             else:

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1313,6 +1313,23 @@ def f(x: Union[A, B]) -> None:
         f(x)
 [builtins fixtures/isinstance.pyi]
 
+[case testIsinstanceWithOverlappingPromotionTypes]
+from typing import Union
+
+class FloatLike: pass
+class IntLike(FloatLike): pass
+
+def f1(x: Union[float, int]) -> None:
+    # We ignore promotions in isinstance checks
+    if isinstance(x, float):
+        reveal_type(x)  # E: Revealed type is 'builtins.float'
+
+def f2(x: Union[FloatLike, IntLike]) -> None:
+    # ...but not regular subtyping relationships
+    if isinstance(x, FloatLike):
+        reveal_type(x)  # E: Revealed type is 'Union[__main__.FloatLike, __main__.IntLike]'
+[builtins fixtures/isinstance.pyi]
+
 [case testIsinstanceOfSuperclass]
 class A: pass
 class B(A): pass


### PR DESCRIPTION
This pull request resolves https://github.com/python/mypy/issues/6060 by modifying `conditional_type_map` function in `checker.py` to ignore promotions.
