### PR TITLE
Migrate remaining failure messages to mypy.messages (part1: mypy.checker)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2542,10 +2542,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             dunder_set_type, [TempNode(instance_type), TempNode(AnyType(TypeOfAny.special_form))],
             [nodes.ARG_POS, nodes.ARG_POS], context)
 
-        if not isinstance(inferred_dunder_set_type, CallableType):
-            self.fail(messages.DESCRIPTOR_SET_NOT_CALLABLE
-                      .format(inferred_dunder_set_type), context)
-            return AnyType(TypeOfAny.from_error), get_type, True
+        # should be handled by get_method above
+        assert isinstance(inferred_dunder_set_type, CallableType)
 
         if len(inferred_dunder_set_type.arg_types) < 2:
             # A message already will have been recorded in check_call

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -885,7 +885,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                     msg = messages.INVALID_SELF_TYPE_OR_EXTRA_ARG
                                     note = '(Hint: typically annotations omit the type for self)'
                                 else:
-                                    msg = messages.ERASED_SELF_TYPE_NOT_SUPERTYPE.format(erased, ref_type)
+                                    msg = messages.ERASED_SELF_TYPE_NOT_SUPERTYPE.format(
+                                        erased, ref_type)
                             else:
                                 msg = messages.MISSING_OR_INVALID_SELF_TYPE
                             self.fail(msg, defn)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1218,7 +1218,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if len(self.scope.stack) == 1:
             # module scope
             if name == '__getattribute__':
-                self.msg.fail('__getattribute__ is not valid at the module level', context)
+                self.msg.fail(messages.MODULE_LEVEL_GETATTRIBUTE, context)
                 return
             # __getattr__ is fine at the module level as of Python 3.7 (PEP 562). We could
             # show an error for Python < 3.7, but that would be annoying in code that supports
@@ -2520,7 +2520,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         dunder_set = attribute_type.type.get_method('__set__')
         if dunder_set is None:
-            self.msg.fail("{}.__set__ is not callable".format(attribute_type), context)
+            self.msg.fail(messages.DESCRIPTOR_SET_NOT_CALLABLE.format(attribute_type), context)
             return AnyType(TypeOfAny.from_error), get_type, False
 
         function = function_type(dunder_set, self.named_type('builtins.function'))
@@ -2543,7 +2543,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             [nodes.ARG_POS, nodes.ARG_POS], context)
 
         if not isinstance(inferred_dunder_set_type, CallableType):
-            self.fail(messages.DESCRIPTOR_SET_NOT_CALLABLE, context)
+            self.fail(messages.DESCRIPTOR_SET_NOT_CALLABLE
+                      .format(inferred_dunder_set_type), context)
             return AnyType(TypeOfAny.from_error), get_type, True
 
         if len(inferred_dunder_set_type.arg_types) < 2:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2654,7 +2654,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                                allow_none_return=allow_none_func_call)
 
                 if defn.is_async_generator:
-                    self.fail(messages.RETURN_IN_GENERATOR, s)
+                    self.fail(messages.RETURN_IN_ASYNC_GENERATOR, s)
                     return
                 # Returning a value of type Any is always fine.
                 if isinstance(typ, AnyType):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -383,8 +383,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             if (isinstance(tp, CallableType) and tp.is_type_obj() and
                     tp.type_object().is_protocol and
                     not tp.type_object().runtime_protocol):
-                self.chk.fail('Only @runtime protocols can be used with'
-                              ' instance and class checks', e)
+                self.chk.fail(messages.RUNTIME_PROTOCOL_EXPECTED, e)
 
     def check_protocol_issubclass(self, e: CallExpr) -> None:
         for expr in mypy.checker.flatten(e.args[1]):
@@ -745,7 +744,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         elif (callee.is_type_obj() and callee.type_object().is_protocol
               # Exception for Type[...]
               and not callee.from_type_type):
-            self.chk.fail('Cannot instantiate protocol class "{}"'
+            self.chk.fail(messages.CANNOT_INSTANTIATE_PROTOCOL
                           .format(callee.type_object().name()), context)
 
         formal_to_actual = map_actuals_to_formals(
@@ -2852,15 +2851,15 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def check_super_arguments(self, e: SuperExpr) -> None:
         """Check arguments in a super(...) call."""
         if ARG_STAR in e.call.arg_kinds:
-            self.chk.fail('Varargs not supported with "super"', e)
+            self.chk.fail(messages.SUPER_VARARGS_NOT_SUPPORTED, e)
         elif e.call.args and set(e.call.arg_kinds) != {ARG_POS}:
-            self.chk.fail('"super" only accepts positional arguments', e)
+            self.chk.fail(messages.SUPER_POSITIONAL_ARGS_REQUIRED, e)
         elif len(e.call.args) == 1:
-            self.chk.fail('"super" with a single argument not supported', e)
+            self.chk.fail(messages.SUPER_WITH_SINGLE_ARG_NOT_SUPPORTED, e)
         elif len(e.call.args) > 2:
-            self.chk.fail('Too many arguments for "super"', e)
+            self.chk.fail(messages.TOO_MANY_ARGS_FOR_SUPER, e)
         elif self.chk.options.python_version[0] == 2 and len(e.call.args) == 0:
-            self.chk.fail('Too few arguments for "super"', e)
+            self.chk.fail(messages.TOO_FEW_ARGS_FOR_SUPER, e)
         elif len(e.call.args) == 2:
             type_obj_type = self.accept(e.call.args[0])
             instance_type = self.accept(e.call.args[1])
@@ -2876,7 +2875,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 if not isinstance(item, Instance):
                     # A complicated type object type. Too tricky, give up.
                     # TODO: Do something more clever here.
-                    self.chk.fail('Unsupported argument 1 for "super"', e)
+                    self.chk.fail(messages.UNSUPPORTED_ARG_1_FOR_SUPER, e)
                     return
                 type_info = item.type
             elif isinstance(type_obj_type, AnyType):
@@ -2892,19 +2891,19 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     if not isinstance(instance_type, (Instance, TupleType)):
                         # Too tricky, give up.
                         # TODO: Do something more clever here.
-                        self.chk.fail(messages.UNSUPPORTED_ARGUMENT_2_FOR_SUPER, e)
+                        self.chk.fail(messages.UNSUPPORTED_ARG_2_FOR_SUPER, e)
                         return
                 if isinstance(instance_type, TupleType):
                     # Needed for named tuples and other Tuple[...] subclasses.
                     instance_type = instance_type.fallback
                 if type_info not in instance_type.type.mro:
-                    self.chk.fail('Argument 2 for "super" not an instance of argument 1', e)
+                    self.chk.fail(messages.SUPER_ARG_2_NOT_INSTANCE_OF_ARG_1, e)
             elif isinstance(instance_type, TypeType) or (isinstance(instance_type, FunctionLike)
                                                          and instance_type.is_type_obj()):
                 # TODO: Check whether this is a valid type object here.
                 pass
             elif not isinstance(instance_type, AnyType):
-                self.chk.fail(messages.UNSUPPORTED_ARGUMENT_2_FOR_SUPER, e)
+                self.chk.fail(messages.UNSUPPORTED_ARG_2_FOR_SUPER, e)
 
     def analyze_super(self, e: SuperExpr, is_lvalue: bool) -> Type:
         """Type check a super expression."""
@@ -2923,7 +2922,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     if not self.chk.in_checked_function():
                         return AnyType(TypeOfAny.unannotated)
                     if self.chk.scope.active_class() is not None:
-                        self.chk.fail('super() outside of a method is not supported', e)
+                        self.chk.fail(messages.SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED, e)
                         return AnyType(TypeOfAny.from_error)
                     method = self.chk.scope.top_function()
                     assert method is not None
@@ -2931,9 +2930,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     # super() in a function with empty args is an error; we
                     # need something in declared_self.
                     if not args:
-                        self.chk.fail(
-                            'super() requires one or more positional arguments in '
-                            'enclosing function', e)
+                        self.chk.fail(messages.SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED, e)
                         return AnyType(TypeOfAny.from_error)
                     declared_self = args[0].variable.type or fill_typevars(e.info)
                     return analyze_member_access(name=e.name,

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -400,7 +400,7 @@ def analyze_descriptor_access(instance_type: Type,
     dunder_get = descriptor_type.type.get_method('__get__')
 
     if dunder_get is None:
-        msg.fail("{}.__get__ is not callable".format(descriptor_type), context)
+        msg.fail(messages.DESCRIPTOR_GET_NOT_CALLABLE.format(descriptor_type), context)
         return AnyType(TypeOfAny.from_error)
 
     function = function_type(dunder_get, builtin_type('builtins.function'))
@@ -427,7 +427,7 @@ def analyze_descriptor_access(instance_type: Type,
         return inferred_dunder_get_type
 
     if not isinstance(inferred_dunder_get_type, CallableType):
-        msg.fail("{}.__get__ is not callable".format(descriptor_type), context)
+        msg.fail(messages.DESCRIPTOR_GET_NOT_CALLABLE.format(descriptor_type), context)
         return AnyType(TypeOfAny.from_error)
 
     return inferred_dunder_get_type.ret_type
@@ -586,8 +586,8 @@ def analyze_class_attribute_access(itype: Instance,
     # If a final attribute was declared on `self` in `__init__`, then it
     # can't be accessed on the class object.
     if node.implicit and isinstance(node.node, Var) and node.node.is_final:
-        mx.msg.fail('Cannot access final instance '
-                    'attribute "{}" on class object'.format(node.node.name()), mx.context)
+        mx.msg.fail(messages.CANNOT_ACCESS_FINAL_INSTANCE_ATTR
+                    .format(node.node.name()), mx.context)
 
     # An assignment to final attribute on class object is also always an error,
     # independently of types.
@@ -617,7 +617,7 @@ def analyze_class_attribute_access(itype: Instance,
         return AnyType(TypeOfAny.special_form)
 
     if isinstance(node.node, TypeVarExpr):
-        mx.msg.fail('Type variable "{}.{}" cannot be used as an expression'.format(
+        mx.msg.fail(messages.CANNOT_USE_TYPEVAR_AS_EXPRESSION.format(
                     itype.type.name(), name), mx.context)
         return AnyType(TypeOfAny.from_error)
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -44,7 +44,7 @@ RETURN_VALUE_EXPECTED = 'Return value expected'  # type: Final
 NO_RETURN_EXPECTED = 'Return statement in function which does not return'  # type: Final
 INVALID_EXCEPTION = 'Exception must be derived from BaseException'  # type: Final
 INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'  # type: Final
-RETURN_IN_GENERATOR = "'return' with value in async generator is not allowed"  # type: Final
+RETURN_IN_ASYNC_GENERATOR = "'return' with value in async generator is not allowed"  # type: Final
 INVALID_RETURN_TYPE_FOR_GENERATOR = \
     'The return type of a generator function should be "Generator"' \
     ' or one of its supertypes'  # type: Final
@@ -112,7 +112,7 @@ GENERIC_INSTANCE_VAR_CLASS_ACCESS = \
     'Access to generic instance variables via class is ambiguous'  # type: Final
 BARE_GENERIC = 'Missing type parameters for generic type'  # type: Final
 IMPLICIT_GENERIC_ANY_BUILTIN = \
-    'Implicit generic "Any". Use \'{}\' and specify generic parameters'  # type: Final
+    'Implicit generic "Any". Use "{}" and specify generic parameters'  # type: Final
 
 # TypeVar
 INCOMPATIBLE_TYPEVAR_VALUE = 'Value of type variable "{}" of {} cannot be {}'  # type: Final
@@ -138,7 +138,7 @@ SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED = \
 MISSING_OR_INVALID_SELF_TYPE = \
     "Self argument missing for a non-static method (or an invalid type for self)"  # type: Final
 ERASED_SELF_TYPE_NOT_SUPERTYPE = \
-    "The erased type of self '{}' is not a supertype of its class '{}'"  # type: Final
+    'The erased type of self "{}" is not a supertype of its class "{}"'  # type: Final
 INVALID_SELF_TYPE_OR_EXTRA_ARG = \
     "Invalid type for self, or extra argument type in function annotation"  # type: Final
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -109,6 +109,22 @@ IMPLICIT_GENERIC_ANY_BUILTIN = \
     'Implicit generic "Any". Use \'{}\' and specify generic parameters'  # type: Final
 INCOMPATIBLE_TYPEVAR_VALUE = 'Value of type variable "{}" of {} cannot be {}'  # type: Final
 UNSUPPORTED_ARGUMENT_2_FOR_SUPER = 'Unsupported argument 2 for "super"'  # type: Final
+MULTIPLE_OVERLOADS_REQUIRED = 'Single overload definition, multiple required'  # type: Final
+MISSING_OR_INVALID_SELF_TYPE = \
+    "Self argument missing for a non-static method (or an invalid type for self)"  # type: Final
+ERASED_SELF_TYPE_NOT_SUPERTYPE = \
+    "The erased type of self '{}' is not a supertype of its class '{}'"  # type: Final
+INVALID_SELF_TYPE_OR_EXTRA_ARG = \
+    "Invalid type for self, or extra argument type in function annotation"  # type: Final
+CANNOT_INHERIT_FROM_FINAL = 'Cannot inherit from final class "{}"'  # type: Final
+DEPENDENT_FINAL_IN_CLASS_BODY = \
+    "Final name declared in class body cannot depend on type variables"  # type: Final
+CANNOT_OVERRIDE_INSTANCE_VAR = \
+    'Cannot override instance variable (previously declared on base class "{}") with class variable'  # type: Final
+CANNOT_OVERRIDE_CLASS_VAR = \
+    'Cannot override class variable (previously declared on base class "{}") with instance variable'  # type: Final
+DESCRIPTOR_SET_NOT_CALLABLE = "__set__ is not callable"  # type: Final
+RETURN_IN_GENERATOR = "'return' with value in async generator is not allowed"  # type: Final
 
 ARG_CONSTRUCTOR_NAMES = {
     ARG_POS: "Arg",

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -120,9 +120,11 @@ CANNOT_INHERIT_FROM_FINAL = 'Cannot inherit from final class "{}"'  # type: Fina
 DEPENDENT_FINAL_IN_CLASS_BODY = \
     "Final name declared in class body cannot depend on type variables"  # type: Final
 CANNOT_OVERRIDE_INSTANCE_VAR = \
-    'Cannot override instance variable (previously declared on base class "{}") with class variable'  # type: Final
+    'Cannot override instance variable (previously declared on base class "{}") with class ' \
+    'variable'  # type: Final
 CANNOT_OVERRIDE_CLASS_VAR = \
-    'Cannot override class variable (previously declared on base class "{}") with instance variable'  # type: Final
+    'Cannot override class variable (previously declared on base class "{}") with instance ' \
+    'variable'  # type: Final
 DESCRIPTOR_SET_NOT_CALLABLE = "__set__ is not callable"  # type: Final
 RETURN_IN_GENERATOR = "'return' with value in async generator is not allowed"  # type: Final
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -34,8 +34,7 @@ MYPY = False
 if MYPY:
     from typing_extensions import Final
 
-# Constants that represent simple type checker error message, i.e. messages
-# that do not have any parameters.
+# Type checker error message constants --
 
 NO_RETURN_VALUE_EXPECTED = 'No return value expected'  # type: Final
 MISSING_RETURN_STATEMENT = 'Missing return statement'  # type: Final
@@ -45,6 +44,7 @@ RETURN_VALUE_EXPECTED = 'Return value expected'  # type: Final
 NO_RETURN_EXPECTED = 'Return statement in function which does not return'  # type: Final
 INVALID_EXCEPTION = 'Exception must be derived from BaseException'  # type: Final
 INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'  # type: Final
+RETURN_IN_GENERATOR = "'return' with value in async generator is not allowed"  # type: Final
 INVALID_RETURN_TYPE_FOR_GENERATOR = \
     'The return type of a generator function should be "Generator"' \
     ' or one of its supertypes'  # type: Final
@@ -80,6 +80,7 @@ CANNOT_ASSIGN_TO_METHOD = 'Cannot assign to a method'  # type: Final
 CANNOT_ASSIGN_TO_TYPE = 'Cannot assign to a type'  # type: Final
 INCONSISTENT_ABSTRACT_OVERLOAD = \
     'Overloaded method has both abstract and non-abstract variants'  # type: Final
+MULTIPLE_OVERLOADS_REQUIRED = 'Single overload definition, multiple required'  # type: Final
 READ_ONLY_PROPERTY_OVERRIDES_READ_WRITE = \
     'Read-only property cannot override read-write property'  # type: Final
 FORMAT_REQUIRES_MAPPING = 'Format requires a mapping'  # type: Final
@@ -102,31 +103,65 @@ TYPEDDICT_KEY_MUST_BE_STRING_LITERAL = \
     'Expected TypedDict key to be string literal'  # type: Final
 MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'  # type: Final
 DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'  # type: Final
+DESCRIPTOR_SET_NOT_CALLABLE = "{}.__set__ is not callable"  # type: Final
+DESCRIPTOR_GET_NOT_CALLABLE = "{}.__get__ is not callable"  # type: Final
+MODULE_LEVEL_GETATTRIBUTE = '__getattribute__ is not valid at the module level'  # type: Final
+
+# Generic
 GENERIC_INSTANCE_VAR_CLASS_ACCESS = \
     'Access to generic instance variables via class is ambiguous'  # type: Final
 BARE_GENERIC = 'Missing type parameters for generic type'  # type: Final
 IMPLICIT_GENERIC_ANY_BUILTIN = \
     'Implicit generic "Any". Use \'{}\' and specify generic parameters'  # type: Final
+
+# TypeVar
 INCOMPATIBLE_TYPEVAR_VALUE = 'Value of type variable "{}" of {} cannot be {}'  # type: Final
-UNSUPPORTED_ARGUMENT_2_FOR_SUPER = 'Unsupported argument 2 for "super"'  # type: Final
-MULTIPLE_OVERLOADS_REQUIRED = 'Single overload definition, multiple required'  # type: Final
+CANNOT_USE_TYPEVAR_AS_EXPRESSION = \
+    'Type variable "{}.{}" cannot be used as an expression'  # type: Final
+
+# Super
+TOO_MANY_ARGS_FOR_SUPER = 'Too many arguments for "super"'  # type: Final
+TOO_FEW_ARGS_FOR_SUPER = 'Too few arguments for "super"'  # type: Final
+SUPER_WITH_SINGLE_ARG_NOT_SUPPORTED = '"super" with a single argument not supported'  # type: Final
+UNSUPPORTED_ARG_1_FOR_SUPER = 'Unsupported argument 1 for "super"'  # type: Final
+UNSUPPORTED_ARG_2_FOR_SUPER = 'Unsupported argument 2 for "super"'  # type: Final
+SUPER_VARARGS_NOT_SUPPORTED = 'Varargs not supported with "super"'  # type: Final
+SUPER_POSITIONAL_ARGS_REQUIRED = '"super" only accepts positional arguments'  # type: Final
+SUPER_ARG_2_NOT_INSTANCE_OF_ARG_1 = \
+    'Argument 2 for "super" not an instance of argument 1'  # type: Final
+SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED = \
+    'super() outside of a method is not supported'  # type: Final
+SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED = \
+    'super() requires one or more positional arguments in enclosing function'  # type: Final
+
+# Self-type
 MISSING_OR_INVALID_SELF_TYPE = \
     "Self argument missing for a non-static method (or an invalid type for self)"  # type: Final
 ERASED_SELF_TYPE_NOT_SUPERTYPE = \
     "The erased type of self '{}' is not a supertype of its class '{}'"  # type: Final
 INVALID_SELF_TYPE_OR_EXTRA_ARG = \
     "Invalid type for self, or extra argument type in function annotation"  # type: Final
+
+# Final
 CANNOT_INHERIT_FROM_FINAL = 'Cannot inherit from final class "{}"'  # type: Final
 DEPENDENT_FINAL_IN_CLASS_BODY = \
     "Final name declared in class body cannot depend on type variables"  # type: Final
+CANNOT_ACCESS_FINAL_INSTANCE_ATTR = \
+    'Cannot access final instance attribute "{}" on class object'  # type: Final
+
+# ClassVar
 CANNOT_OVERRIDE_INSTANCE_VAR = \
     'Cannot override instance variable (previously declared on base class "{}") with class ' \
     'variable'  # type: Final
 CANNOT_OVERRIDE_CLASS_VAR = \
     'Cannot override class variable (previously declared on base class "{}") with instance ' \
     'variable'  # type: Final
-DESCRIPTOR_SET_NOT_CALLABLE = "__set__ is not callable"  # type: Final
-RETURN_IN_GENERATOR = "'return' with value in async generator is not allowed"  # type: Final
+
+# Protocol
+RUNTIME_PROTOCOL_EXPECTED = \
+    'Only @runtime protocols can be used with instance and class checks'  # type: Final
+CANNOT_INSTANTIATE_PROTOCOL = 'Cannot instantiate protocol class "{}"'  # type: Final
+
 
 ARG_CONSTRUCTOR_NAMES = {
     ARG_POS: "Arg",

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4193,9 +4193,9 @@ TTA = TypeVar('TTA', bound='Type[A]')
 TM = TypeVar('TM', bound='M')
 
 class M(type):
-    def g1(cls: 'Type[A]') -> A: pass #  E: The erased type of self 'Type[__main__.A]' is not a supertype of its class '__main__.M'
-    def g2(cls: Type[TA]) -> TA: pass #  E: The erased type of self 'Type[__main__.A]' is not a supertype of its class '__main__.M'
-    def g3(cls: TTA) -> TTA: pass #  E: The erased type of self 'Type[__main__.A]' is not a supertype of its class '__main__.M'
+    def g1(cls: 'Type[A]') -> A: pass #  E: The erased type of self "Type[__main__.A]" is not a supertype of its class "__main__.M"
+    def g2(cls: Type[TA]) -> TA: pass #  E: The erased type of self "Type[__main__.A]" is not a supertype of its class "__main__.M"
+    def g3(cls: TTA) -> TTA: pass #  E: The erased type of self "Type[__main__.A]" is not a supertype of its class "__main__.M"
     def g4(cls: TM) -> TM: pass
 m: M
 

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -259,11 +259,11 @@ from typing import TypeVar, Type
 
 T = TypeVar('T', bound=str)
 class A:
-    def foo(self: T) -> T:   # E: The erased type of self 'builtins.str' is not a supertype of its class '__main__.A'
+    def foo(self: T) -> T:   # E: The erased type of self "builtins.str" is not a supertype of its class "__main__.A"
         return self
 
     @classmethod
-    def cfoo(cls: Type[T]) -> T:  # E: The erased type of self 'Type[builtins.str]' is not a supertype of its class 'Type[__main__.A]'
+    def cfoo(cls: Type[T]) -> T:  # E: The erased type of self "Type[builtins.str]" is not a supertype of its class "Type[__main__.A]"
         return cls()
 
 Q = TypeVar('Q', bound='B')
@@ -283,7 +283,7 @@ class C:
         return cls()
 
 class D:
-    def foo(self: Q) -> Q:  # E: The erased type of self '__main__.B' is not a supertype of its class '__main__.D'
+    def foo(self: Q) -> Q:  # E: The erased type of self "__main__.B" is not a supertype of its class "__main__.D"
         return self
 
     @staticmethod
@@ -291,7 +291,7 @@ class D:
         return self
 
     @classmethod
-    def cfoo(cls: Type[Q]) -> Q:  # E: The erased type of self 'Type[__main__.B]' is not a supertype of its class 'Type[__main__.D]'
+    def cfoo(cls: Type[Q]) -> Q:  # E: The erased type of self "Type[__main__.B]" is not a supertype of its class "Type[__main__.D]"
         return cls()
 
 [builtins fixtures/classmethod.pyi]
@@ -323,10 +323,10 @@ class A:
         pass
 
 class B:
-    def __new__(cls: Type[T]) -> T:  # E: The erased type of self 'Type[__main__.A]' is not a supertype of its class 'Type[__main__.B]'
+    def __new__(cls: Type[T]) -> T:  # E: The erased type of self "Type[__main__.A]" is not a supertype of its class "Type[__main__.B]"
         return cls()
 
-    def __init_subclass__(cls: Type[T]) -> None:  # E: The erased type of self 'Type[__main__.A]' is not a supertype of its class 'Type[__main__.B]'
+    def __init_subclass__(cls: Type[T]) -> None:  # E: The erased type of self "Type[__main__.A]" is not a supertype of its class "Type[__main__.B]"
         pass
 
 class C:
@@ -337,10 +337,10 @@ class C:
         pass
 
 class D:
-    def __new__(cls: D) -> D:  # E: The erased type of self '__main__.D' is not a supertype of its class 'Type[__main__.D]'
+    def __new__(cls: D) -> D:  # E: The erased type of self "__main__.D" is not a supertype of its class "Type[__main__.D]"
         return cls
 
-    def __init_subclass__(cls: D) -> None:  # E: The erased type of self '__main__.D' is not a supertype of its class 'Type[__main__.D]'
+    def __init_subclass__(cls: D) -> None:  # E: The erased type of self "__main__.D" is not a supertype of its class "Type[__main__.D]"
         pass
 
 class E:

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -957,11 +957,11 @@ def h(s: dict) -> None: pass
 def i(s: set) -> None: pass
 def j(s: frozenset) -> None: pass
 [out]
-m.py:3: error: Implicit generic "Any". Use 'typing.Tuple' and specify generic parameters
-m.py:4: error: Implicit generic "Any". Use 'typing.List' and specify generic parameters
-m.py:5: error: Implicit generic "Any". Use 'typing.Dict' and specify generic parameters
-m.py:6: error: Implicit generic "Any". Use 'typing.Set' and specify generic parameters
-m.py:7: error: Implicit generic "Any". Use 'typing.FrozenSet' and specify generic parameters
+m.py:3: error: Implicit generic "Any". Use "typing.Tuple" and specify generic parameters
+m.py:4: error: Implicit generic "Any". Use "typing.List" and specify generic parameters
+m.py:5: error: Implicit generic "Any". Use "typing.Dict" and specify generic parameters
+m.py:6: error: Implicit generic "Any". Use "typing.Set" and specify generic parameters
+m.py:7: error: Implicit generic "Any". Use "typing.FrozenSet" and specify generic parameters
 
 [case testDisallowAnyGenericsTypingCollections]
 # cmd: mypy m.py


### PR DESCRIPTION
Consolidate all mypy error messages into one place (`mypy.messages`).  This opens the door to some interesting features, such as adding language localization or a more systematic way of working with error messages, akin to error codes (#2417).  It also helps create more consistent messages.  e.g. it's now more apparent that there are a few outliers that use single quotes around type names.

I'm breaking this up change up into several PRs by module, this is the first and simplest.  Once all are complete, this will address #6116.

It's pretty straight-foward.  The biggest challenge is coming up with good constant names.  Let me know what you think.


