### PR TITLE
fix: fixed the type annotation in examples

### DIFF
--- a/docs/source/type_inference_and_annotations.rst
+++ b/docs/source/type_inference_and_annotations.rst
@@ -213,6 +213,6 @@ to be annotated with a starred type:
 
 .. code-block:: python
 
-    p, q, *rs = 1, 2  # type: int, int, *List[int]
+    p, q, *rs = 1, 2  # type: int, int, List[int]
 
 Here, the type of ``rs`` is set to ``List[int]``.


### PR DESCRIPTION
mypy==0.650
```
p, q, *rs = 1, 2  # type: int, int, *List[int]

>>> error: syntax error in type comment
```

```
p, q, *rs = 1, 2  # type: int, int, List[int]

>>> error: syntax error in type comment
```