### PR TITLE
Remove RawLiteralType synthetic type

### DIFF
--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -8,7 +8,7 @@ from mypy.nodes import (
 from mypy.fastparse import parse_type_string
 from mypy.types import (
     Type, UnboundType, TypeList, EllipsisType, AnyType, Optional, CallableArgument, TypeOfAny,
-    RawLiteralType,
+    RawLiteral,
 )
 
 
@@ -39,9 +39,19 @@ def expr_to_unanalyzed_type(expr: Expression, _parent: Optional[Expression] = No
     if isinstance(expr, NameExpr):
         name = expr.name
         if name == 'True':
-            return RawLiteralType(True, 'builtins.bool', line=expr.line, column=expr.column)
+            return AnyType(
+                TypeOfAny.invalid_type,
+                raw_literal=RawLiteral(True, 'builtins.bool'),
+                line=expr.line,
+                column=expr.column,
+            )
         elif name == 'False':
-            return RawLiteralType(False, 'builtins.bool', line=expr.line, column=expr.column)
+            return AnyType(
+                TypeOfAny.invalid_type,
+                raw_literal=RawLiteral(False, 'builtins.bool'),
+                line=expr.line,
+                column=expr.column,
+            )
         else:
             return UnboundType(name, line=expr.line, column=expr.column)
     elif isinstance(expr, MemberExpr):
@@ -122,17 +132,27 @@ def expr_to_unanalyzed_type(expr: Expression, _parent: Optional[Expression] = No
                                  assume_str_is_unicode=True)
     elif isinstance(expr, UnaryExpr):
         typ = expr_to_unanalyzed_type(expr.expr)
-        if isinstance(typ, RawLiteralType) and isinstance(typ.value, int) and expr.op == '-':
-            typ.value *= -1
-            return typ
-        else:
-            raise TypeTranslationError()
+        if isinstance(typ, AnyType) and typ.raw_literal is not None:
+            if isinstance(typ.raw_literal.value, int) and expr.op == '-':
+                typ.raw_literal.value *= -1
+                return typ
+        raise TypeTranslationError()
     elif isinstance(expr, IntExpr):
-        return RawLiteralType(expr.value, 'builtins.int', line=expr.line, column=expr.column)
+        return AnyType(
+            TypeOfAny.invalid_type,
+            raw_literal=RawLiteral(expr.value, 'builtins.int'),
+            line=expr.line,
+            column=expr.column,
+        )
     elif isinstance(expr, FloatExpr):
         # Floats are not valid parameters for RawLiteralType, so we just
         # pass in 'None' for now. We'll report the appropriate error at a later stage.
-        return RawLiteralType(None, 'builtins.float', line=expr.line, column=expr.column)
+        return AnyType(
+            TypeOfAny.invalid_type,
+            raw_literal=RawLiteral(None, 'builtins.float'),
+            line=expr.line,
+            column=expr.column,
+        )
     elif isinstance(expr, EllipsisExpr):
         return EllipsisType(expr.line)
     else:

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -90,9 +90,6 @@ class TypeIndirectionVisitor(SyntheticTypeVisitor[Set[str]]):
     def visit_typeddict_type(self, t: types.TypedDictType) -> Set[str]:
         return self._visit(t.items.values()) | self._visit(t.fallback)
 
-    def visit_raw_literal_type(self, t: types.RawLiteralType) -> Set[str]:
-        assert False, "Unexpected RawLiteralType after semantic analysis phase"
-
     def visit_literal_type(self, t: types.LiteralType) -> Set[str]:
         return self._visit(t.fallback)
 

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -180,6 +180,7 @@ class SemanticAnalyzerPluginInterface:
                   tvar_scope: Optional[TypeVarScope] = None,
                   allow_tuple_literal: bool = False,
                   allow_unbound_tvars: bool = False,
+                  report_invalid_types: bool = True,
                   third_pass: bool = False) -> Type:
         """Analyze an unbound type."""
         raise NotImplementedError

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1283,7 +1283,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             return
         defn.metaclass = metas.pop()
 
-    def expr_to_analyzed_type(self, expr: Expression) -> Type:
+    def expr_to_analyzed_type(self, expr: Expression, report_invalid_types: bool = True) -> Type:
         if isinstance(expr, CallExpr):
             expr.accept(self)
             info = self.named_tuple_analyzer.check_namedtuple(expr, None, self.is_func_scope())
@@ -1295,7 +1295,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             fallback = Instance(info, [])
             return TupleType(info.tuple_type.items, fallback=fallback)
         typ = expr_to_unanalyzed_type(expr)
-        return self.anal_type(typ)
+        return self.anal_type(typ, report_invalid_types=report_invalid_types)
 
     def verify_base_classes(self, defn: ClassDef) -> bool:
         info = defn.info
@@ -1686,6 +1686,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                       tvar_scope: Optional[TypeVarScope] = None,
                       allow_tuple_literal: bool = False,
                       allow_unbound_tvars: bool = False,
+                      report_invalid_types: bool = True,
                       third_pass: bool = False) -> TypeAnalyser:
         if tvar_scope is None:
             tvar_scope = self.tvar_scope
@@ -1696,6 +1697,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                             self.is_typeshed_stub_file,
                             allow_unbound_tvars=allow_unbound_tvars,
                             allow_tuple_literal=allow_tuple_literal,
+                            report_invalid_types=report_invalid_types,
                             allow_unnormalized=self.is_stub_file,
                             third_pass=third_pass)
         tpan.in_dynamic_func = bool(self.function_stack and self.function_stack[-1].is_dynamic())
@@ -1706,10 +1708,12 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                   tvar_scope: Optional[TypeVarScope] = None,
                   allow_tuple_literal: bool = False,
                   allow_unbound_tvars: bool = False,
+                  report_invalid_types: bool = True,
                   third_pass: bool = False) -> Type:
         a = self.type_analyzer(tvar_scope=tvar_scope,
                                allow_unbound_tvars=allow_unbound_tvars,
                                allow_tuple_literal=allow_tuple_literal,
+                               report_invalid_types=report_invalid_types,
                                third_pass=third_pass)
         typ = t.accept(a)
         self.add_type_alias_deps(a.aliases_used)
@@ -2394,7 +2398,12 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                     self.fail("TypeVar cannot have both values and an upper bound", context)
                     return None
                 try:
-                    upper_bound = self.expr_to_analyzed_type(param_value)
+                    upper_bound = self.expr_to_analyzed_type(param_value,
+                                                             report_invalid_types=False)
+                    if isinstance(upper_bound, AnyType) and upper_bound.from_invalid_type:
+                        self.fail("TypeVar 'bound' must be a type", param_value)
+                        # Note: we do not return 'None' here: we want to continue using the
+                        # AnyType as the upper bound.
                 except TypeTranslationError:
                     self.fail("TypeVar 'bound' must be a type", param_value)
                     return None

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -114,11 +114,12 @@ class NewTypeAnalyzer:
             self.fail(msg, context)
             return None
 
-        old_type = self.api.anal_type(unanalyzed_type)
+        old_type = self.api.anal_type(unanalyzed_type, report_invalid_types=False)
 
         # The caller of this function assumes that if we return a Type, it's always
         # a valid one. So, we translate AnyTypes created from errors into None.
-        if isinstance(old_type, AnyType) and old_type.type_of_any == TypeOfAny.from_error:
+        bad_anys = (TypeOfAny.from_error, TypeOfAny.invalid_type)
+        if isinstance(old_type, AnyType) and old_type.type_of_any in bad_anys:
             self.fail(msg, context)
             return None
 

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -91,6 +91,7 @@ class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
                   tvar_scope: Optional[TypeVarScope] = None,
                   allow_tuple_literal: bool = False,
                   allow_unbound_tvars: bool = False,
+                  report_invalid_types: bool = True,
                   third_pass: bool = False) -> Type:
         raise NotImplementedError
 

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -267,7 +267,18 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
                 snapshot_types(typ.args))
 
     def visit_any(self, typ: AnyType) -> SnapshotItem:
-        return snapshot_simple_type(typ)
+        if typ.raw_literal:
+            return (
+                'Any',
+                typ.type_of_any,
+                typ.raw_literal.value,
+                typ.raw_literal.base_type_name,
+            )
+        else:
+            return (
+                'Any',
+                typ.type_of_any,
+            )
 
     def visit_none_type(self, typ: NoneTyp) -> SnapshotItem:
         return snapshot_simple_type(typ)

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -59,7 +59,6 @@ from mypy.types import (
     Type, SyntheticTypeVisitor, Instance, AnyType, NoneTyp, CallableType, DeletedType, PartialType,
     TupleType, TypeType, TypeVarType, TypedDictType, UnboundType, UninhabitedType, UnionType,
     Overloaded, TypeVarDef, TypeList, CallableArgument, EllipsisType, StarType, LiteralType,
-    RawLiteralType,
 )
 from mypy.util import get_prefix, replace_object_state
 from mypy.typestate import TypeState
@@ -391,9 +390,6 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
         for value_type in typ.items.values():
             value_type.accept(self)
         typ.fallback.accept(self)
-
-    def visit_raw_literal_type(self, t: RawLiteralType) -> None:
-        assert False, "Unexpected RawLiteralType after semantic analysis phase"
 
     def visit_literal_type(self, typ: LiteralType) -> None:
         typ.fallback.accept(self)

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -20,7 +20,7 @@ T = TypeVar('T')
 
 from mypy.types import (
     Type, AnyType, CallableType, Overloaded, TupleType, TypedDictType, LiteralType,
-    RawLiteralType, Instance, NoneTyp, TypeType,
+    Instance, NoneTyp, TypeType,
     UnionType, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarDef,
     UnboundType, ErasedType, ForwardRef, StarType, EllipsisType, TypeList, CallableArgument,
 )
@@ -125,10 +125,6 @@ class SyntheticTypeVisitor(TypeVisitor[T]):
 
     @abstractmethod
     def visit_ellipsis_type(self, t: EllipsisType) -> T:
-        pass
-
-    @abstractmethod
-    def visit_raw_literal_type(self, t: RawLiteralType) -> T:
         pass
 
 
@@ -281,9 +277,6 @@ class TypeQuery(SyntheticTypeVisitor[T]):
 
     def visit_typeddict_type(self, t: TypedDictType) -> T:
         return self.query_types(t.items.values())
-
-    def visit_raw_literal_type(self, t: RawLiteralType) -> T:
-        return self.strategy([])
 
     def visit_literal_type(self, t: LiteralType) -> T:
         return self.strategy([])

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -269,8 +269,7 @@ tmp/m.py:14: error: Revealed type is 'builtins.int'
 from typing import NewType
 
 a = NewType('b', int)  # E: String argument 1 'b' to NewType(...) does not match variable name 'a'
-b = NewType('b', 3)    # E: Argument 2 to NewType(...) must be a valid type \
-                       # E: Invalid type: try using Literal[3] instead?
+b = NewType('b', 3)    # E: Argument 2 to NewType(...) must be a valid type
 c = NewType(2, int)    # E: Argument 1 to NewType(...) must be a string literal
 foo = "d"
 d = NewType(foo, int)  # E: Argument 1 to NewType(...) must be a string literal

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -980,7 +980,7 @@ e = TypeVar('e', int, str, x=1)   # E: Unexpected argument to TypeVar(): x
 f = TypeVar('f', (int, str), int) # E: Type expected
 g = TypeVar('g', int)             # E: TypeVar cannot have only a single constraint
 h = TypeVar('h', x=(int, str))    # E: Unexpected argument to TypeVar(): x
-i = TypeVar('i', bound=1)         # E: Invalid type: try using Literal[1] instead?
+i = TypeVar('i', bound=1)         # E: TypeVar 'bound' must be a type.
 [out]
 
 [case testMoreInvalidTypevarArguments]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -980,7 +980,7 @@ e = TypeVar('e', int, str, x=1)   # E: Unexpected argument to TypeVar(): x
 f = TypeVar('f', (int, str), int) # E: Type expected
 g = TypeVar('g', int)             # E: TypeVar cannot have only a single constraint
 h = TypeVar('h', x=(int, str))    # E: Unexpected argument to TypeVar(): x
-i = TypeVar('i', bound=1)         # E: TypeVar 'bound' must be a type.
+i = TypeVar('i', bound=1)         # E: TypeVar 'bound' must be a type
 [out]
 
 [case testMoreInvalidTypevarArguments]


### PR DESCRIPTION
This diff changes how we track raw literal types in the semantic analysis phase. It makes the following changes:

1.  Removes the `RawLiteralType` synthetic type.

2.  Adds a new `TypeOfAny`: `TypeOfAny.invalid_type` as suggested in https://github.com/python/mypy/issues/4030.

3.  Modifies `AnyType` so it can optionally contain a new `RawLiteral` class. This class contains information about the underlying literal that produced that particular `TypeOfAny`.

4.  Adjusts mypy to stop recommending using `Literal[...]` when doing `A = NewType('A', 4)` or `T = TypeVar('T', bound=4)`.

    (The former suggestion is a bad one: you can't create a NewType of a Literal[...] type. The latter suggestion is a valid but stupid one: `T = TypeVar('T', bound=Literal[4])` is basically the same thing as `T = Literal[4]`.)

    This resolves https://github.com/python/mypy/issues/5989.

The net effect of this diff is that:

1.  RawLiteralTypes no longer leak during fine-grained mode, which should partially help unblock https://github.com/python/mypy/pull/6075.

2.  The way mypy handles literal expressions in types is "inverted".

    Previously, we by default assumed literal expressions would belong inside `Literal[...]` and tacked on some logic to make them convert into error `AnyTypes`. Now, we do the reverse: we start with an error `AnyType` and convert those into `Literal[...]`s as needed.

    This more closely mirrors the way mypy *used* to work before we started work on Literal types. It should also hopefully help reduce some of the cognitive burden of working on other parts of the semantic analysis code, since we no longer need to worry about the `RawLiteralType` synthetic type.

3.  We now have more flexibility in how we choose to handle invalid types: since they're just `Anys`, we have more opportunities to intercept and customize the exact way in which we handle errors.

    Also see https://github.com/python/mypy/issues/4030 for additional context. (This diff lays out some of the foundation work for that diff).