### PR TITLE
Speed up mypy startup by avoiding imports

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -51,7 +51,6 @@ from mypy.types import Type
 from mypy.version import __version__
 from mypy.plugin import Plugin, ChainedPlugin, plugin_types
 from mypy.plugins.default import DefaultPlugin
-from mypy.server.deps import get_dependencies
 from mypy.fscache import FileSystemCache
 from mypy.metastore import MetadataStore, FilesystemMetadataStore, SqliteMetadataStore
 from mypy.typestate import TypeState, reset_global_state
@@ -1847,6 +1846,7 @@ class State:
             # TODO: Not a reliable test, as we could have a package named typeshed.
             # TODO: Consider relaxing this -- maybe allow some typeshed changes to be tracked.
             return
+        from mypy.server.deps import get_dependencies  # Lazy import to speed up startup
         self.fine_grained_deps = get_dependencies(target=self.tree,
                                                   type_map=self.type_map(),
                                                   python_version=self.options.python_version,

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -510,10 +510,11 @@ class BuildManager(BuildManagerBase):
         self.stale_modules = set()  # type: Set[str]
         self.rechecked_modules = set()  # type: Set[str]
         self.flush_errors = flush_errors
+        has_reporters = reports is not None and reports.reporters
         self.cache_enabled = (options.incremental
                               and (not options.fine_grained_incremental
                                    or options.use_fine_grained_cache)
-                              and not reports.reporters)
+                              and not has_reporters)
         self.fscache = fscache
         self.find_module_cache = FindModuleCache(self.search_paths, self.fscache, self.options)
         if options.sqlite_cache:

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -10,3 +10,17 @@ CONFIG_FILE = 'mypy.ini'  # type: Final
 SHARED_CONFIG_FILES = ('setup.cfg',)  # type: Final
 USER_CONFIG_FILES = ('~/.mypy.ini',)  # type: Final
 CONFIG_FILES = (CONFIG_FILE,) + SHARED_CONFIG_FILES + USER_CONFIG_FILES  # type: Final
+
+# This must include all reporters defined in mypy.report. This is defined here
+# to make reporter names available without importing mypy.report -- this speeds
+# up startup.
+REPORTER_NAMES = ['linecount',
+                  'any-exprs',
+                  'linecoverage',
+                  'memory-xml',
+                  'cobertura-xml',
+                  'xml',
+                  'xslt-html',
+                  'xslt-txt',
+                  'html',
+                  'txt']  # type: Final

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -20,7 +20,6 @@ from mypy.find_sources import create_source_list, InvalidSourceList
 from mypy.fscache import FileSystemCache
 from mypy.errors import CompileError
 from mypy.options import Options, BuildType, PER_MODULE_OPTIONS
-from mypy.report import reporter_classes
 
 from mypy.version import __version__
 
@@ -606,7 +605,7 @@ def process_options(args: List[str],
     report_group = parser.add_argument_group(
         title='Report generation',
         description='Generate a report in the specified format.')
-    for report_type in sorted(reporter_classes):
+    for report_type in sorted(defaults.REPORTER_NAMES):
         report_group.add_argument('--%s-report' % report_type.replace('_', '-'),
                                   metavar='DIR',
                                   dest='special-opts:%s_report' % report_type)
@@ -968,7 +967,7 @@ def parse_section(prefix: str, template: Options,
             if dv is None:
                 if key.endswith('_report'):
                     report_type = key[:-7].replace('_', '-')
-                    if report_type in reporter_classes:
+                    if report_type in defaults.REPORTER_NAMES:
                         report_dirs[report_type] = section[key]
                     else:
                         print("%s: Unrecognized report type: %s" % (prefix, key),

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -23,6 +23,7 @@ from mypy.options import Options
 from mypy.traverser import TraverserVisitor
 from mypy.types import Type, TypeOfAny
 from mypy.version import __version__
+from mypy.defaults import REPORTER_NAMES
 
 MYPY = False
 if MYPY:
@@ -749,3 +750,7 @@ register_reporter('xslt-txt', XsltTxtReporter, needs_lxml=True)
 
 alias_reporter('xslt-html', 'html')
 alias_reporter('xslt-txt', 'txt')
+
+# Reporter class names are defined twice to speed up mypy startup, as this
+# module is slow to import. Ensure that the two definitions match.
+assert set(reporter_classes) == set(REPORTER_NAMES)

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -5,7 +5,6 @@ import pathlib
 import re
 import subprocess
 import sys
-from xml.sax.saxutils import escape
 from typing import TypeVar, List, Tuple, Optional, Dict, Sequence
 
 MYPY = False
@@ -143,7 +142,7 @@ ERROR_TEMPLATE = """<?xml version="1.0" encoding="utf-8"?>
 
 
 def write_junit_xml(dt: float, serious: bool, messages: List[str], path: str) -> None:
-    """XXX"""
+    from xml.sax.saxutils import escape
     if not messages and not serious:
         xml = PASS_TEMPLATE.format(time=dt)
     elif not serious:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -1,5 +1,4 @@
 """Utility functions with no non-trivial dependencies."""
-import inspect
 import os
 import pathlib
 import re
@@ -204,6 +203,7 @@ fields_cache = {}  # type: Final[Dict[Type[object], List[str]]]
 
 
 def get_class_descriptors(cls: 'Type[object]') -> Sequence[str]:
+    import inspect  # Lazy import for minor startup speed win
     # Maintain a cache of type -> attributes defined by descriptors in the class
     # (that is, attributes from __slots__ and C extension classes)
     if cls not in fields_cache:


### PR DESCRIPTION
Move some imports that aren't always needed to functions bodies. This
speeds up mypy startup by up to 120ms on my laptop (when not compiled). 
Tests are a bit faster as well.
