### PR TITLE
Fix a handful of Windows IPC and IPC test issues

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -128,7 +128,7 @@ else:
 
 # Server code.
 
-CONNECTION_NAME = 'dmypy.sock'  # type: Final
+CONNECTION_NAME = 'dmypy'  # type: Final
 
 
 def process_start_options(flags: List[str], allow_sources: bool) -> Options:

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -68,7 +68,11 @@ class IPCBase:
         """Write bytes to an IPC connection."""
         if sys.platform == 'win32':
             try:
-                _winapi.WriteFile(self.connection, data)
+                # Only send data if there is data to send, to avoid it
+                # being confused with the empty message sent to terminate
+                # the connection.
+                if data:
+                    _winapi.WriteFile(self.connection, data)
                 # this empty write is to copy the behavior of socket.sendall,
                 # which also sends an empty message to signify it is done writing
                 _winapi.WriteFile(self.connection, b'')
@@ -144,7 +148,10 @@ class IPCServer(IPCBase):
 
     def __init__(self, name: str, timeout: Optional[int] = None) -> None:
         if sys.platform == 'win32':
-            name = r'\\.\pipe\{}-{}.pipe'.format(name, base64.b64encode(os.urandom(6)))
+            name = r'\\.\pipe\{}-{}.pipe'.format(
+                name, base64.urlsafe_b64encode(os.urandom(6)).decode())
+        else:
+            name = '{}.sock'.format(name)
         super().__init__(name)
         if sys.platform == 'win32':
             self.connection = _winapi.CreateNamedPipe(self.name,

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -70,7 +70,8 @@ class IPCBase:
             try:
                 # Only send data if there is data to send, to avoid it
                 # being confused with the empty message sent to terminate
-                # the connection.
+                # the connection. (We will still send the end-of-message
+                # empty message below, which will cause read to return.)
                 if data:
                     _winapi.WriteFile(self.connection, data)
                 # this empty write is to copy the behavior of socket.sendall,


### PR DESCRIPTION
 * The client-side timeout was only 1ms, which is too short.
 * Fix a bug in the transmission of empty messages. Receive interprets
   an empty message as representing the end of message, so the server
   might close the connection after the first empty message (the data)
   is sent.
   Fix this by only sending the "end of message" empty message when
   the data is empty.
 * The second transaction in test_connect_twice does not read from
   the server, which can cause server crashes when the server tries
   to write. This would emit a traceback but not actually cause the
   test to fail. Fix this, and add an assert so it would cause a test
   failure.
   (However, servers perhaps ought to be robust to this sort of thing!
    dmypy_server is not.)
 * Clean up and regularize the names of pipes.

The first two issues, I think, were the ones responsible for our CI
flakes, which this should hopefully fix.