### PR TITLE
Fix IPC timeout incoherence

### DIFF
--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -94,10 +94,10 @@ class IPCBase:
 class IPCClient(IPCBase):
     """The client side of an IPC connection."""
 
-    def __init__(self, name: str, timeout: Optional[int]) -> None:
+    def __init__(self, name: str, timeout: Optional[float]) -> None:
         super().__init__(name)
         if sys.platform == 'win32':
-            timeout = timeout or 0xFFFFFFFF  # NMPWAIT_WAIT_FOREVER
+            timeout = int(timeout * 1000) if timeout else 0xFFFFFFFF  # NMPWAIT_WAIT_FOREVER
             try:
                 _winapi.WaitNamedPipe(self.name, timeout)
             except FileNotFoundError:

--- a/mypy/test/testipc.py
+++ b/mypy/test/testipc.py
@@ -28,7 +28,7 @@ class IPCTests(TestCase):
         p = Process(target=server, args=(msg, queue), daemon=True)
         p.start()
         connection_name = queue.get()
-        with IPCClient(connection_name, timeout=1000) as client:
+        with IPCClient(connection_name, timeout=1) as client:
             assert client.read() == msg.encode()
             client.write(b'test')
         queue.close()
@@ -41,11 +41,11 @@ class IPCTests(TestCase):
         p = Process(target=server, args=(msg, queue), daemon=True)
         p.start()
         connection_name = queue.get()
-        with IPCClient(connection_name, timeout=1000) as client:
+        with IPCClient(connection_name, timeout=1) as client:
             assert client.read() == msg.encode()
             client.write(b'')  # don't let the server hang up yet, we want to connect again.
 
-        with IPCClient(connection_name, timeout=1000) as client:
+        with IPCClient(connection_name, timeout=1) as client:
             assert client.read() == msg.encode()
             client.write(b'test')
         queue.close()


### PR DESCRIPTION
Make IPCClient's timeout parameter be consistently seconds,
rather than seconds on unix and milliseconds on windows.