### PR TITLE
Add option to tag known messages with an error code

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -189,7 +189,8 @@ def _build(sources: List[BuildSource],
         reports = Reports(data_dir, options.report_dirs)
 
     source_set = BuildSourceSet(sources)
-    errors = Errors(options.show_error_context, options.show_column_numbers)
+    errors = Errors(options.show_error_context, options.show_column_numbers,
+                    options.show_error_codes)
     plugin, snapshot = load_plugins(options, errors)
 
     # Construct a build manager object to hold state during the build.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1304,7 +1304,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if base_attr:
                 # First, check if we override a final (always an error, even with Any types).
                 if is_final_node(base_attr.node):
-                    self.msg.cant_override_final(name, base.name(), defn)
+                    self.msg.cannot_override_final(name, base.name(), defn)
                 # Second, final can't override anything writeable independently of types.
                 if defn.is_final:
                     self.check_no_writable(name, base_attr.node, defn)
@@ -1641,7 +1641,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # Final attributes can never be overridden, but can override
         # non-final read-only attributes.
         if is_final_node(second.node):
-            self.msg.cant_override_final(name, base2.name(), ctx)
+            self.msg.cannot_override_final(name, base2.name(), ctx)
         if is_final_node(first.node):
             self.check_no_writable(name, second.node, ctx)
         # __slots__ is special and the type can vary across class hierarchy.
@@ -1988,7 +1988,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # if we are overriding a final method with variable.
             # Other override attempts will be flagged as assignment to constant
             # in `check_final()`.
-            self.msg.cant_override_final(node.name(), base.name(), node)
+            self.msg.cannot_override_final(node.name(), base.name(), node)
             return False
         if node.is_final:
             self.check_no_writable(node.name(), base_node, node)
@@ -2014,7 +2014,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         else:
             ok = True
         if not ok:
-            self.msg.final_cant_override_writable(name, ctx)
+            self.msg.final_cannot_override_writable(name, ctx)
 
     def get_final_context(self) -> bool:
         """Check whether we a currently checking a final declaration."""
@@ -2067,11 +2067,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         # `check_compatibility_final_super()`.
                         if sym and isinstance(sym.node, Var):
                             if sym.node.is_final and not is_final_decl:
-                                self.msg.cant_assign_to_final(name, sym.node.info is None, s)
+                                self.msg.cannot_assign_to_final(name, sym.node.info is None, s)
                                 # ...but only once
                                 break
                 if lv.node.is_final and not is_final_decl:
-                    self.msg.cant_assign_to_final(name, lv.node.info is None, s)
+                    self.msg.cannot_assign_to_final(name, lv.node.info is None, s)
 
     def check_assignment_to_multiple_lvalues(self, lvalues: List[Lvalue], rvalue: Expression,
                                              context: Context,

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -799,8 +799,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     if (fdef.info and fdef.name() in ('__init__', '__init_subclass__') and
                             not isinstance(typ.ret_type, NoneTyp) and
                             not self.dynamic_funcs[-1]):
-                        self.fail(messages.MUST_HAVE_NONE_RETURN_TYPE.format(fdef.name()),
-                                  item)
+                        self.msg.must_have_none_return_type(fdef)
 
                     self.check_for_missing_annotations(fdef)
                     if self.options.disallow_any_unimported:
@@ -2679,7 +2678,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     # Functions returning a value of type None are allowed to have a None return.
                     if is_lambda or isinstance(typ, NoneTyp):
                         return
-                    self.fail(messages.NO_RETURN_VALUE_EXPECTED, s)
+                    self.msg.no_return_exepected(s)
                 else:
                     self.check_subtype(
                         subtype_label='got',

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5,7 +5,7 @@ import fnmatch
 from contextlib import contextmanager
 
 from typing import (
-    Dict, Set, List, cast, Tuple, TypeVar, Union, Optional, NamedTuple, Iterator, Iterable,
+    Any, Dict, Set, List, cast, Tuple, TypeVar, Union, Optional, NamedTuple, Iterator, Iterable,
     Sequence
 )
 
@@ -294,7 +294,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                                     [self.named_type('builtins.unicode')])
                 if not is_subtype(all_.type, seq_str):
                     str_seq_s, all_s = self.msg.format_distinctly(seq_str, all_.type)
-                    self.fail(messages.ALL_MUST_BE_SEQ_STR.format(str_seq_s, all_s),
+                    self.fail(messages.ErrorCodes.ALL_MUST_BE_SEQ_STR.format(str_seq_s, all_s),
                             all_node)
 
             self.tscope.leave()
@@ -432,7 +432,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # valid overloads.
             return None
         if len(defn.items) == 1:
-            self.fail(messages.MULTIPLE_OVERLOADS_REQUIRED, defn)
+            self.fail(messages.ErrorCodes.MULTIPLE_OVERLOADS_REQUIRED, defn)
 
         if defn.is_property:
             # HACK: Infer the type of the property.
@@ -443,7 +443,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if fdef.func.is_abstract:
                 num_abstract += 1
         if num_abstract not in (0, len(defn.items)):
-            self.fail(messages.INCONSISTENT_ABSTRACT_OVERLOAD, defn)
+            self.fail(messages.ErrorCodes.INCONSISTENT_ABSTRACT_OVERLOAD, defn)
         if defn.impl:
             defn.impl.accept(self)
         if defn.info:
@@ -744,11 +744,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             del partial_types[var]
                     else:
                         # Trying to redefine something like partial empty list as function.
-                        self.fail(messages.INCOMPATIBLE_REDEFINITION, defn)
+                        self.fail(messages.ErrorCodes.INCOMPATIBLE_REDEFINITION, defn)
                 else:
                     # TODO: Update conditional type binder.
                     self.check_subtype(new_type, orig_type, defn,
-                                       messages.INCOMPATIBLE_REDEFINITION,
+                                       messages.ErrorCodes.INCOMPATIBLE_REDEFINITION,
                                        'redefinition with type',
                                        'original type')
 
@@ -825,24 +825,24 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 # Refuse contravariant return type variable
                 if isinstance(typ.ret_type, TypeVarType):
                     if typ.ret_type.variance == CONTRAVARIANT:
-                        self.fail(messages.RETURN_TYPE_CANNOT_BE_CONTRAVARIANT,
+                        self.fail(messages.ErrorCodes.RETURN_TYPE_CANNOT_BE_CONTRAVARIANT,
                              typ.ret_type)
 
                 # Check that Generator functions have the appropriate return type.
                 if defn.is_generator:
                     if defn.is_async_generator:
                         if not self.is_async_generator_return_type(typ.ret_type):
-                            self.fail(messages.INVALID_RETURN_TYPE_FOR_ASYNC_GENERATOR, typ)
+                            self.fail(messages.ErrorCodes.INVALID_RETURN_TYPE_FOR_ASYNC_GENERATOR, typ)
                     else:
                         if not self.is_generator_return_type(typ.ret_type, defn.is_coroutine):
-                            self.fail(messages.INVALID_RETURN_TYPE_FOR_GENERATOR, typ)
+                            self.fail(messages.ErrorCodes.INVALID_RETURN_TYPE_FOR_GENERATOR, typ)
 
                     # Python 2 generators aren't allowed to return values.
                     if (self.options.python_version[0] == 2 and
                             isinstance(typ.ret_type, Instance) and
                             typ.ret_type.type.fullname() == 'typing.Generator'):
                         if not isinstance(typ.ret_type.args[2], (NoneTyp, AnyType)):
-                            self.fail(messages.INVALID_GENERATOR_RETURN_ITEM_TYPE, typ)
+                            self.fail(messages.ErrorCodes.INVALID_GENERATOR_RETURN_ITEM_TYPE, typ)
 
                 # Fix the type if decorated with `@types.coroutine` or `@asyncio.coroutine`.
                 if defn.is_awaitable_coroutine:
@@ -881,13 +881,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             if typ.arg_names[i] in ['self', 'cls']:
                                 if (self.options.python_version[0] < 3
                                         and is_same_type(erased, arg_type) and not isclass):
-                                    msg = messages.INVALID_SELF_TYPE_OR_EXTRA_ARG
+                                    msg = messages.ErrorCodes.INVALID_SELF_TYPE_OR_EXTRA_ARG
                                     note = '(Hint: typically annotations omit the type for self)'
                                 else:
-                                    msg = messages.ERASED_SELF_TYPE_NOT_SUPERTYPE.format(
+                                    msg = messages.ErrorCodes.ERASED_SELF_TYPE_NOT_SUPERTYPE.format(
                                         erased, ref_type)
                             else:
-                                msg = messages.MISSING_OR_INVALID_SELF_TYPE
+                                msg = messages.ErrorCodes.MISSING_OR_INVALID_SELF_TYPE
                             self.fail(msg, defn)
                             if note:
                                 self.note(note, defn)
@@ -901,7 +901,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             ctx = arg_type  # type: Context
                             if ctx.line < 0:
                                 ctx = typ
-                            self.fail(messages.FUNCTION_PARAMETER_CANNOT_BE_COVARIANT, ctx)
+                            self.fail(messages.ErrorCodes.FUNCTION_PARAMETER_CANNOT_BE_COVARIANT, ctx)
                     if typ.arg_kinds[i] == nodes.ARG_STAR:
                         # builtins.tuple[T] is typing.Tuple[T, ...]
                         arg_type = self.named_generic_type('builtins.tuple',
@@ -947,9 +947,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     # entirely pass/Ellipsis.
                     if isinstance(return_type, UninhabitedType):
                         # This is a NoReturn function
-                        self.msg.note(messages.INVALID_IMPLICIT_RETURN, defn)
+                        self.msg.note(messages.ErrorCodes.INVALID_IMPLICIT_RETURN, defn)
                     else:
-                        self.msg.fail(messages.MISSING_RETURN_STATEMENT, defn)
+                        self.msg.fail(messages.ErrorCodes.MISSING_RETURN_STATEMENT, defn)
 
             self.return_types.pop()
 
@@ -980,20 +980,20 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         check_incomplete_defs = self.options.disallow_incomplete_defs and has_explicit_annotation
         if show_untyped and (self.options.disallow_untyped_defs or check_incomplete_defs):
             if fdef.type is None and self.options.disallow_untyped_defs:
-                self.fail(messages.FUNCTION_TYPE_EXPECTED, fdef)
+                self.fail(messages.ErrorCodes.FUNCTION_TYPE_EXPECTED, fdef)
             elif isinstance(fdef.type, CallableType):
                 ret_type = fdef.type.ret_type
                 if is_unannotated_any(ret_type):
-                    self.fail(messages.RETURN_TYPE_EXPECTED, fdef)
+                    self.fail(messages.ErrorCodes.RETURN_TYPE_EXPECTED, fdef)
                 elif fdef.is_generator:
                     if is_unannotated_any(self.get_generator_return_type(ret_type,
                                                                         fdef.is_coroutine)):
-                        self.fail(messages.RETURN_TYPE_EXPECTED, fdef)
+                        self.fail(messages.ErrorCodes.RETURN_TYPE_EXPECTED, fdef)
                 elif fdef.is_coroutine and isinstance(ret_type, Instance):
                     if is_unannotated_any(self.get_coroutine_return_type(ret_type)):
-                        self.fail(messages.RETURN_TYPE_EXPECTED, fdef)
+                        self.fail(messages.ErrorCodes.RETURN_TYPE_EXPECTED, fdef)
                 if any(is_unannotated_any(t) for t in fdef.type.arg_types):
-                    self.fail(messages.ARGUMENT_TYPE_EXPECTED, fdef)
+                    self.fail(messages.ErrorCodes.ARGUMENT_TYPE_EXPECTED, fdef)
 
     def is_trivial_body(self, block: Block) -> bool:
         body = block.body
@@ -1217,7 +1217,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if len(self.scope.stack) == 1:
             # module scope
             if name == '__getattribute__':
-                self.msg.fail(messages.MODULE_LEVEL_GETATTRIBUTE, context)
+                self.msg.fail(messages.ErrorCodes.MODULE_LEVEL_GETATTRIBUTE, context)
                 return
             # __getattr__ is fine at the module level as of Python 3.7 (PEP 562). We could
             # show an error for Python < 3.7, but that would be annoying in code that supports
@@ -1526,7 +1526,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             self.check_protocol_variance(defn)
         for base in typ.mro[1:]:
             if base.is_final:
-                self.fail(messages.CANNOT_INHERIT_FROM_FINAL.format(base.name()), defn)
+                self.fail(messages.ErrorCodes.CANNOT_INHERIT_FROM_FINAL.format(base.name()), defn)
         with self.tscope.class_scope(defn.info), self.enter_partial_types(is_class=True):
             old_binder = self.binder
             self.binder = ConditionalTypeBinder()
@@ -1667,7 +1667,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if lvalue_type is None:
                 # TODO: This is broken.
                 lvalue_type = AnyType(TypeOfAny.special_form)
-            message = '{} "{}"'.format(messages.INCOMPATIBLE_IMPORT_OF,
+            message = '{} "{}"'.format(messages.ErrorCodes.INCOMPATIBLE_IMPORT_OF,
                                        cast(NameExpr, assign.rvalue).name)
             self.check_simple_assignment(lvalue_type, assign.rvalue, node,
                                          msg=message, lvalue_name='local name',
@@ -1719,7 +1719,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         self.check_final(s)
         if (s.is_final_def and s.type and not has_no_typevars(s.type)
                 and self.scope.active_class() is not None):
-            self.fail(messages.DEPENDENT_FINAL_IN_CLASS_BODY, s)
+            self.fail(messages.ErrorCodes.DEPENDENT_FINAL_IN_CLASS_BODY, s)
 
     def check_assignment(self, lvalue: Lvalue, rvalue: Expression, infer_lvalue_type: bool = True,
                          new_syntax: bool = False) -> None:
@@ -1913,7 +1913,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     lvalue_node.is_staticmethod = True
 
             return self.check_subtype(compare_type, base_type, lvalue,
-                                      messages.INCOMPATIBLE_TYPES_IN_ASSIGNMENT,
+                                      messages.ErrorCodes.INCOMPATIBLE_TYPES_IN_ASSIGNMENT,
                                       'expression has type',
                                       'base class "%s" defined the type as' % base.name())
         return True
@@ -1963,10 +1963,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if not isinstance(base_node, Var):
             return True
         if node.is_classvar and not base_node.is_classvar:
-            self.fail(messages.CANNOT_OVERRIDE_INSTANCE_VAR.format(base.name()), node)
+            self.fail(messages.ErrorCodes.CANNOT_OVERRIDE_INSTANCE_VAR, node, (base.name(),))
             return False
         elif not node.is_classvar and base_node.is_classvar:
-            self.fail(messages.CANNOT_OVERRIDE_CLASS_VAR.format(base.name()), node)
+            self.fail(messages.ErrorCodes.CANNOT_OVERRIDE_CLASS_VAR, node, (base.name(),))
             return False
         return True
 
@@ -2468,7 +2468,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
     def check_simple_assignment(self, lvalue_type: Optional[Type], rvalue: Expression,
                                 context: Context,
-                                msg: str = messages.INCOMPATIBLE_TYPES_IN_ASSIGNMENT,
+                                msg: messages.ErrorCodes = messages.ErrorCodes.INCOMPATIBLE_TYPES_IN_ASSIGNMENT,
                                 lvalue_name: str = 'variable',
                                 rvalue_name: str = 'expression') -> Type:
         if self.is_stub and isinstance(rvalue, EllipsisExpr):
@@ -2525,7 +2525,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         dunder_set = attribute_type.type.get_method('__set__')
         if dunder_set is None:
-            self.msg.fail(messages.DESCRIPTOR_SET_NOT_CALLABLE.format(attribute_type), context)
+            self.msg.fail(messages.ErrorCodes.DESCRIPTOR_SET_NOT_CALLABLE, context,
+                          (attribute_type,))
             return AnyType(TypeOfAny.from_error), get_type, False
 
         function = function_type(dunder_set, self.named_type('builtins.function'))
@@ -2636,7 +2637,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 return_type = self.return_types[-1]
 
             if isinstance(return_type, UninhabitedType):
-                self.fail(messages.NO_RETURN_EXPECTED, s)
+                self.fail(messages.ErrorCodes.NO_RETURN_EXPECTED, s)
                 return
 
             if s.expr:
@@ -2657,7 +2658,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                                allow_none_return=allow_none_func_call)
 
                 if defn.is_async_generator:
-                    self.fail(messages.RETURN_IN_ASYNC_GENERATOR, s)
+                    self.fail(messages.ErrorCodes.RETURN_IN_ASYNC_GENERATOR, s)
                     return
                 # Returning a value of type Any is always fine.
                 if isinstance(typ, AnyType):
@@ -2686,7 +2687,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         supertype_label='expected',
                         supertype=return_type,
                         context=s,
-                        msg=messages.INCOMPATIBLE_RETURN_VALUE_TYPE)
+                        msg=messages.ErrorCodes.INCOMPATIBLE_RETURN_VALUE_TYPE)
             else:
                 # Empty returns are valid in Generators with Any typed returns, but not in
                 # coroutines.
@@ -2698,7 +2699,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     return
 
                 if self.in_checked_function():
-                    self.fail(messages.RETURN_VALUE_EXPECTED, s)
+                    self.fail(messages.ErrorCodes.RETURN_VALUE_EXPECTED, s)
 
     def visit_if_stmt(self, s: IfStmt) -> None:
         """Type check an if statement."""
@@ -2763,7 +2764,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             self.expr_checker.accept(s.msg)
 
         if isinstance(s.expr, TupleExpr) and len(s.expr.items) > 0:
-            self.warn(messages.MALFORMED_ASSERT, s)
+            self.warn(messages.ErrorCodes.MALFORMED_ASSERT, s)
 
         # If this is asserting some isinstance check, bind that type in the following code
         true_map, _ = self.find_isinstance_check(s.expr)
@@ -2805,7 +2806,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         expected_type = self.named_type('builtins.BaseException')  # type: Type
         if optional:
             expected_type = UnionType([expected_type, NoneTyp()])
-        self.check_subtype(typ, expected_type, s, messages.INVALID_EXCEPTION)
+        self.check_subtype(typ, expected_type, s, messages.ErrorCodes.INVALID_EXCEPTION)
 
     def visit_try_stmt(self, s: TryStmt) -> None:
         """Type check a try statement."""
@@ -2909,17 +2910,17 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if isinstance(ttype, FunctionLike):
                 item = ttype.items()[0]
                 if not item.is_type_obj():
-                    self.fail(messages.INVALID_EXCEPTION_TYPE, n)
+                    self.fail(messages.ErrorCodes.INVALID_EXCEPTION_TYPE, n)
                     return AnyType(TypeOfAny.from_error)
                 exc_type = item.ret_type
             elif isinstance(ttype, TypeType):
                 exc_type = ttype.item
             else:
-                self.fail(messages.INVALID_EXCEPTION_TYPE, n)
+                self.fail(messages.ErrorCodes.INVALID_EXCEPTION_TYPE, n)
                 return AnyType(TypeOfAny.from_error)
 
             if not is_subtype(exc_type, self.named_type('builtins.BaseException')):
-                self.fail(messages.INVALID_EXCEPTION_TYPE, n)
+                self.fail(messages.ErrorCodes.INVALID_EXCEPTION_TYPE, n)
                 return AnyType(TypeOfAny.from_error)
 
             all_types.append(exc_type)
@@ -2960,7 +2961,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         iterator = echk.check_method_call_by_name('__aiter__', iterable, [], [], expr)[0]
         awaitable = echk.check_method_call_by_name('__anext__', iterator, [], [], expr)[0]
         item_type = echk.check_awaitable_expr(awaitable, expr,
-                                              messages.INCOMPATIBLE_TYPES_IN_ASYNC_FOR)
+                                              messages.ErrorCodes.INCOMPATIBLE_TYPES_IN_ASYNC_FOR)
         return iterator, item_type
 
     def analyze_iterable_item_type(self, expr: Expression) -> Tuple[Type, Type]:
@@ -3019,7 +3020,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         sig = self.function_type(e.func)  # type: Type
         for d in reversed(e.decorators):
             if refers_to_fullname(d, 'typing.overload'):
-                self.fail(messages.MULTIPLE_OVERLOADS_REQUIRED, e)
+                self.fail(messages.ErrorCodes.MULTIPLE_OVERLOADS_REQUIRED, e)
                 continue
             dec = self.expr_checker.accept(d)
             temp = self.temp_node(sig)
@@ -3059,7 +3060,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         base_attr.node.is_property and
                         cast(Decorator,
                              base_attr.node.items[0]).var.is_settable_property):
-                    self.fail(messages.READ_ONLY_PROPERTY_OVERRIDES_READ_WRITE, e)
+                    self.fail(messages.ErrorCodes.READ_ONLY_PROPERTY_OVERRIDES_READ_WRITE, e)
 
     def visit_with_stmt(self, s: WithStmt) -> None:
         for expr, target in zip(s.expr, s.target):
@@ -3082,14 +3083,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         ctx = echk.accept(expr)
         obj = echk.check_method_call_by_name('__aenter__', ctx, [], [], expr)[0]
         obj = echk.check_awaitable_expr(
-            obj, expr, messages.INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AENTER)
+            obj, expr, messages.ErrorCodes.INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AENTER)
         if target:
             self.check_assignment(target, self.temp_node(obj, expr), infer_lvalue_type)
         arg = self.temp_node(AnyType(TypeOfAny.special_form), expr)
         res = echk.check_method_call_by_name(
             '__aexit__', ctx, [arg] * 3, [nodes.ARG_POS] * 3, expr)[0]
         echk.check_awaitable_expr(
-            res, expr, messages.INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AEXIT)
+            res, expr, messages.ErrorCodes.INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AEXIT)
 
     def check_with_item(self, expr: Expression, target: Optional[Expression],
                         infer_lvalue_type: bool) -> None:
@@ -3423,7 +3424,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     #
 
     def check_subtype(self, subtype: Type, supertype: Type, context: Context,
-                      msg: str = messages.INCOMPATIBLE_TYPES,
+                      msg: messages.ErrorCodes = messages.ErrorCodes.INCOMPATIBLE_TYPES,
                       subtype_label: Optional[str] = None,
                       supertype_label: Optional[str] = None) -> bool:
         """Generate an error if the subtype is not compatible with
@@ -3443,8 +3444,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     extra_info.append(supertype_label + ' ' + supertype_str)
                 note_msg = make_inferred_type_note(context, subtype,
                                                    supertype, supertype_str)
-            if extra_info:
-                msg += ' (' + ', '.join(extra_info) + ')'
+            # FIXME:
+            # if extra_info:
+            #     msg += ' (' + ', '.join(extra_info) + ')'
             self.fail(msg, context)
             if note_msg:
                 self.note(note_msg, context)
@@ -3694,9 +3696,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             temp.set_line(context.get_line())
         return temp
 
-    def fail(self, msg: str, context: Context) -> None:
+    def fail(self, msg: messages.ErrorCodes, context: Context,
+             format: Optional[Tuple[Any, ...]] = None) -> None:
         """Produce an error message."""
-        self.msg.fail(msg, context)
+        self.msg.fail(msg, context, format)
 
     def warn(self, msg: str, context: Context) -> None:
         """Produce a warning message."""

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -404,7 +404,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     tp.type_object().is_protocol):
                 attr_members = non_method_protocol_members(tp.type_object())
                 if attr_members:
-                    self.chk.msg.report_non_method_protocol(tp.type_object(),
+                    self.chk.msg.issubclass_on_non_method_protocol(tp.type_object(),
                                                             attr_members, e)
 
     def check_typeddict_call(self, callee: TypedDictType,
@@ -720,7 +720,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                    arg_names, callable_node, arg_messages, callable_name,
                                    object_type)
         else:
-            return self.msg.not_callable(callee, context), AnyType(TypeOfAny.from_error)
+            return (self.msg.type_has_no_attr(callee, callee, '__call__', context),
+                    AnyType(TypeOfAny.from_error))
 
     def check_callable_call(self,
                             callee: CallableType,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -395,7 +395,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             if (isinstance(tp, CallableType) and tp.is_type_obj() and
                     tp.type_object().is_protocol and
                     not tp.type_object().runtime_protocol):
-                self.chk.fail(messages.RUNTIME_PROTOCOL_EXPECTED, e)
+                self.chk.fail(messages.ErrorCodes.RUNTIME_PROTOCOL_EXPECTED, e)
 
     def check_protocol_issubclass(self, e: CallExpr) -> None:
         for expr in mypy.checker.flatten(e.args[1]):
@@ -434,7 +434,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             return self.check_typeddict_call_with_kwargs(
                 callee, OrderedDict(), context)
 
-        self.chk.fail(messages.INVALID_TYPEDDICT_ARGS, context)
+        self.chk.fail(messages.ErrorCodes.INVALID_TYPEDDICT_ARGS, context)
         return AnyType(TypeOfAny.from_error)
 
     def check_typeddict_call_with_dict(self, callee: TypedDictType,
@@ -446,7 +446,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         for item_name_expr, item_arg in kwargs.items:
             if not isinstance(item_name_expr, StrExpr):
                 key_context = item_name_expr or item_arg
-                self.chk.fail(messages.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, key_context)
+                self.chk.fail(messages.ErrorCodes.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, key_context)
                 return AnyType(TypeOfAny.from_error)
             item_names.append(item_name_expr.value)
 
@@ -472,7 +472,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 item_value = kwargs[item_name]
                 self.chk.check_simple_assignment(
                     lvalue_type=item_expected_type, rvalue=item_value, context=item_value,
-                    msg=messages.INCOMPATIBLE_TYPES,
+                    msg=messages.ErrorCodes.INCOMPATIBLE_TYPES,
                     lvalue_name='TypedDict item "{}"'.format(item_name),
                     rvalue_name='expression')
 
@@ -758,7 +758,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         elif (callee.is_type_obj() and callee.type_object().is_protocol
               # Exception for Type[...]
               and not callee.from_type_type):
-            self.chk.fail(messages.CANNOT_INSTANTIATE_PROTOCOL
+            self.chk.fail(messages.ErrorCodes.CANNOT_INSTANTIATE_PROTOCOL
                           .format(callee.type_object().name()), context)
 
         formal_to_actual = map_actuals_to_formals(
@@ -1006,7 +1006,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 if isinstance(first_arg, (NoneTyp, UninhabitedType)):
                     inferred_args[0] = self.named_type('builtins.str')
                 elif not first_arg or not is_subtype(self.named_type('builtins.str'), first_arg):
-                    self.msg.fail(messages.KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE,
+                    self.msg.fail(messages.ErrorCodes.KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE,
                                   context)
         else:
             # In dynamically typed functions use implicit 'Any' types for
@@ -2403,7 +2403,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 if n >= 0 and n < len(left_type.items):
                     return left_type.items[n]
                 else:
-                    self.chk.fail(messages.TUPLE_INDEX_OUT_OF_RANGE, e)
+                    self.chk.fail(messages.ErrorCodes.TUPLE_INDEX_OUT_OF_RANGE, e)
                     return AnyType(TypeOfAny.from_error)
             else:
                 return self.nonliteral_tuple_index_helper(left_type, index)
@@ -2445,7 +2445,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         expected_type = UnionType.make_union([self.named_type('builtins.int'),
                                               self.named_type('builtins.slice')])
         if not self.chk.check_subtype(index_type, expected_type, index,
-                                      messages.INVALID_TUPLE_INDEX_TYPE,
+                                      messages.ErrorCodes.INVALID_TUPLE_INDEX_TYPE,
                                       'actual type', 'expected type'):
             return AnyType(TypeOfAny.from_error)
         else:
@@ -2549,14 +2549,14 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 tp = type_object_type(item.type, self.named_type)
                 return self.apply_type_arguments_to_callable(tp, item.args, tapp)
             else:
-                self.chk.fail(messages.ONLY_CLASS_APPLICATION, tapp)
+                self.chk.fail(messages.ErrorCodes.ONLY_CLASS_APPLICATION, tapp)
                 return AnyType(TypeOfAny.from_error)
         # Type application of a normal generic class in runtime context.
         # This is typically used as `x = G[int]()`.
         tp = self.accept(tapp.expr)
         if isinstance(tp, (CallableType, Overloaded)):
             if not tp.is_type_obj():
-                self.chk.fail(messages.ONLY_CLASS_APPLICATION, tapp)
+                self.chk.fail(messages.ErrorCodes.ONLY_CLASS_APPLICATION, tapp)
             return self.apply_type_arguments_to_callable(tp, tapp.types, tapp)
         if isinstance(tp, AnyType):
             return AnyType(TypeOfAny.from_another_any, source_any=tp)
@@ -2884,7 +2884,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             return callable_ctx, None
         if callable_ctx.arg_kinds != arg_kinds:
             # Incompatible context; cannot use it to infer types.
-            self.chk.fail(messages.CANNOT_INFER_LAMBDA_TYPE, e)
+            self.chk.fail(messages.ErrorCodes.CANNOT_INFER_LAMBDA_TYPE, e)
             return None, None
 
         return callable_ctx, callable_ctx
@@ -2898,15 +2898,15 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def check_super_arguments(self, e: SuperExpr) -> None:
         """Check arguments in a super(...) call."""
         if ARG_STAR in e.call.arg_kinds:
-            self.chk.fail(messages.SUPER_VARARGS_NOT_SUPPORTED, e)
+            self.chk.fail(messages.ErrorCodes.SUPER_VARARGS_NOT_SUPPORTED, e)
         elif e.call.args and set(e.call.arg_kinds) != {ARG_POS}:
-            self.chk.fail(messages.SUPER_POSITIONAL_ARGS_REQUIRED, e)
+            self.chk.fail(messages.ErrorCodes.SUPER_POSITIONAL_ARGS_REQUIRED, e)
         elif len(e.call.args) == 1:
-            self.chk.fail(messages.SUPER_WITH_SINGLE_ARG_NOT_SUPPORTED, e)
+            self.chk.fail(messages.ErrorCodes.SUPER_WITH_SINGLE_ARG_NOT_SUPPORTED, e)
         elif len(e.call.args) > 2:
-            self.chk.fail(messages.TOO_MANY_ARGS_FOR_SUPER, e)
+            self.chk.fail(messages.ErrorCodes.TOO_MANY_ARGS_FOR_SUPER, e)
         elif self.chk.options.python_version[0] == 2 and len(e.call.args) == 0:
-            self.chk.fail(messages.TOO_FEW_ARGS_FOR_SUPER, e)
+            self.chk.fail(messages.ErrorCodes.TOO_FEW_ARGS_FOR_SUPER, e)
         elif len(e.call.args) == 2:
             type_obj_type = self.accept(e.call.args[0])
             instance_type = self.accept(e.call.args[1])
@@ -2922,7 +2922,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 if not isinstance(item, Instance):
                     # A complicated type object type. Too tricky, give up.
                     # TODO: Do something more clever here.
-                    self.chk.fail(messages.UNSUPPORTED_ARG_1_FOR_SUPER, e)
+                    self.chk.fail(messages.ErrorCodes.UNSUPPORTED_ARG_1_FOR_SUPER, e)
                     return
                 type_info = item.type
             elif isinstance(type_obj_type, AnyType):
@@ -2938,19 +2938,19 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     if not isinstance(instance_type, (Instance, TupleType)):
                         # Too tricky, give up.
                         # TODO: Do something more clever here.
-                        self.chk.fail(messages.UNSUPPORTED_ARG_2_FOR_SUPER, e)
+                        self.chk.fail(messages.ErrorCodes.UNSUPPORTED_ARG_2_FOR_SUPER, e)
                         return
                 if isinstance(instance_type, TupleType):
                     # Needed for named tuples and other Tuple[...] subclasses.
                     instance_type = instance_type.fallback
                 if type_info not in instance_type.type.mro:
-                    self.chk.fail(messages.SUPER_ARG_2_NOT_INSTANCE_OF_ARG_1, e)
+                    self.chk.fail(messages.ErrorCodes.SUPER_ARG_2_NOT_INSTANCE_OF_ARG_1, e)
             elif isinstance(instance_type, TypeType) or (isinstance(instance_type, FunctionLike)
                                                          and instance_type.is_type_obj()):
                 # TODO: Check whether this is a valid type object here.
                 pass
             elif not isinstance(instance_type, AnyType):
-                self.chk.fail(messages.UNSUPPORTED_ARG_2_FOR_SUPER, e)
+                self.chk.fail(messages.ErrorCodes.UNSUPPORTED_ARG_2_FOR_SUPER, e)
 
     def analyze_super(self, e: SuperExpr, is_lvalue: bool) -> Type:
         """Type check a super expression."""
@@ -2969,7 +2969,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     if not self.chk.in_checked_function():
                         return AnyType(TypeOfAny.unannotated)
                     if self.chk.scope.active_class() is not None:
-                        self.chk.fail(messages.SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED, e)
+                        self.chk.fail(messages.ErrorCodes.SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED, e)
                         return AnyType(TypeOfAny.from_error)
                     method = self.chk.scope.top_function()
                     assert method is not None
@@ -2977,7 +2977,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     # super() in a function with empty args is an error; we
                     # need something in declared_self.
                     if not args:
-                        self.chk.fail(messages.SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED, e)
+                        self.chk.fail(messages.ErrorCodes.SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED, e)
                         return AnyType(TypeOfAny.from_error)
                     declared_self = args[0].variable.type or fill_typevars(e.info)
                     return analyze_member_access(name=e.name,
@@ -3002,7 +3002,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             if index:
                 t = self.accept(index)
                 self.chk.check_subtype(t, expected,
-                                       index, messages.INVALID_SLICE_INDEX)
+                                       index, messages.ErrorCodes.INVALID_SLICE_INDEX)
         return self.named_type('builtins.slice')
 
     def visit_list_comprehension(self, e: ListComprehension) -> Type:
@@ -3273,11 +3273,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if e.expr is None:
             if (not isinstance(expected_item_type, (NoneTyp, AnyType))
                     and self.chk.in_checked_function()):
-                self.chk.fail(messages.YIELD_VALUE_EXPECTED, e)
+                self.chk.fail(messages.ErrorCodes.YIELD_VALUE_EXPECTED, e)
         else:
             actual_item_type = self.accept(e.expr, expected_item_type)
             self.chk.check_subtype(actual_item_type, expected_item_type, e,
-                                   messages.INCOMPATIBLE_TYPES_IN_YIELD,
+                                   messages.ErrorCodes.INCOMPATIBLE_TYPES_IN_YIELD,
                                    'actual type', 'expected type')
         return self.chk.get_generator_receive_type(return_type, False)
 
@@ -3288,9 +3288,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         actual_type = self.accept(e.expr, expected_type)
         if isinstance(actual_type, AnyType):
             return AnyType(TypeOfAny.from_another_any, source_any=actual_type)
-        return self.check_awaitable_expr(actual_type, e, messages.INCOMPATIBLE_TYPES_IN_AWAIT)
+        return self.check_awaitable_expr(actual_type, e, messages.ErrorCodes.INCOMPATIBLE_TYPES_IN_AWAIT)
 
-    def check_awaitable_expr(self, t: Type, ctx: Context, msg: str) -> Type:
+    def check_awaitable_expr(self, t: Type, ctx: Context, msg: messages.ErrorCodes) -> Type:
         """Check the argument to `await` and extract the type of value.
 
         Also used by `async for` and `async with`.
@@ -3334,7 +3334,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 iter_type = AnyType(TypeOfAny.from_error)
             else:
                 iter_type = self.check_awaitable_expr(subexpr_type, e,
-                                                      messages.INCOMPATIBLE_TYPES_IN_YIELD_FROM)
+                                                      messages.ErrorCodes.INCOMPATIBLE_TYPES_IN_YIELD_FROM)
 
         # Check that the iterator's item type matches the type yielded by the Generator function
         # containing this `yield from` expression.
@@ -3342,7 +3342,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         actual_item_type = self.chk.get_generator_yield_type(iter_type, False)
 
         self.chk.check_subtype(actual_item_type, expected_item_type, e,
-                           messages.INCOMPATIBLE_TYPES_IN_YIELD_FROM,
+                           messages.ErrorCodes.INCOMPATIBLE_TYPES_IN_YIELD_FROM,
                            'actual type', 'expected type')
 
         # Determine the type of the entire yield from expression.

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -147,7 +147,7 @@ def analyze_instance_member_access(name: str,
     if name == '__init__' and not mx.is_super:
         # Accessing __init__ in statically typed code would compromise
         # type safety unless used via super().
-        mx.msg.fail(messages.CANNOT_ACCESS_INIT, mx.context)
+        mx.msg.fail(messages.ErrorCodes.CANNOT_ACCESS_INIT, mx.context)
         return AnyType(TypeOfAny.from_error)
 
     # The base object has an instance type.
@@ -405,7 +405,7 @@ def analyze_descriptor_access(instance_type: Type,
     dunder_get = descriptor_type.type.get_method('__get__')
 
     if dunder_get is None:
-        msg.fail(messages.DESCRIPTOR_GET_NOT_CALLABLE.format(descriptor_type), context)
+        msg.fail(messages.ErrorCodes.DESCRIPTOR_GET_NOT_CALLABLE.format(descriptor_type), context)
         return AnyType(TypeOfAny.from_error)
 
     function = function_type(dunder_get, builtin_type('builtins.function'))
@@ -432,7 +432,7 @@ def analyze_descriptor_access(instance_type: Type,
         return inferred_dunder_get_type
 
     if not isinstance(inferred_dunder_get_type, CallableType):
-        msg.fail(messages.DESCRIPTOR_GET_NOT_CALLABLE.format(descriptor_type), context)
+        msg.fail(messages.ErrorCodes.DESCRIPTOR_GET_NOT_CALLABLE.format(descriptor_type), context)
         return AnyType(TypeOfAny.from_error)
 
     return inferred_dunder_get_type.ret_type
@@ -586,12 +586,12 @@ def analyze_class_attribute_access(itype: Instance,
         if is_method:
             mx.msg.cannot_assign_to_method(mx.context)
         if isinstance(node.node, TypeInfo):
-            mx.msg.fail(messages.CANNOT_ASSIGN_TO_TYPE, mx.context)
+            mx.msg.fail(messages.ErrorCodes.CANNOT_ASSIGN_TO_TYPE, mx.context)
 
     # If a final attribute was declared on `self` in `__init__`, then it
     # can't be accessed on the class object.
     if node.implicit and isinstance(node.node, Var) and node.node.is_final:
-        mx.msg.fail(messages.CANNOT_ACCESS_FINAL_INSTANCE_ATTR
+        mx.msg.fail(messages.ErrorCodes.CANNOT_ACCESS_FINAL_INSTANCE_ATTR
                     .format(node.node.name()), mx.context)
 
     # An assignment to final attribute on class object is also always an error,
@@ -609,7 +609,7 @@ def analyze_class_attribute_access(itype: Instance,
             assert isinstance(symnode, Var)
             return mx.chk.handle_partial_var_type(t, mx.is_lvalue, symnode, mx.context)
         if not is_method and (isinstance(t, TypeVarType) or get_type_vars(t)):
-            mx.msg.fail(messages.GENERIC_INSTANCE_VAR_CLASS_ACCESS, mx.context)
+            mx.msg.fail(messages.ErrorCodes.GENERIC_INSTANCE_VAR_CLASS_ACCESS, mx.context)
         is_classmethod = ((is_decorated and cast(Decorator, node.node).func.is_class)
                           or (isinstance(node.node, FuncBase) and node.node.is_class))
         result = add_class_tvars(t, itype, is_classmethod, mx.builtin_type, mx.original_type)
@@ -622,7 +622,7 @@ def analyze_class_attribute_access(itype: Instance,
         return AnyType(TypeOfAny.special_form)
 
     if isinstance(node.node, TypeVarExpr):
-        mx.msg.fail(messages.CANNOT_USE_TYPEVAR_AS_EXPRESSION.format(
+        mx.msg.fail(messages.ErrorCodes.CANNOT_USE_TYPEVAR_AS_EXPRESSION.format(
                     itype.type.name(), name), mx.context)
         return AnyType(TypeOfAny.from_error)
 

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -133,7 +133,7 @@ def _analyze_member_access(name: str,
         return AnyType(TypeOfAny.from_error)
     if mx.chk.should_suppress_optional_error([typ]):
         return AnyType(TypeOfAny.from_error)
-    return mx.msg.has_no_attr(mx.original_type, typ, name, mx.context)
+    return mx.msg.type_has_no_attr(mx.original_type, typ, name, mx.context)
 
 
 # The several functions that follow implement analyze_member_access for various
@@ -169,7 +169,7 @@ def analyze_instance_member_access(name: str,
             first_item = cast(Decorator, method.items[0])
             return analyze_var(name, first_item.var, typ, info, mx)
         if mx.is_lvalue:
-            mx.msg.cant_assign_to_method(mx.context)
+            mx.msg.cannot_assign_to_method(mx.context)
         signature = function_type(method, mx.builtin_type('builtins.function'))
         signature = freshen_function_type_vars(signature)
         if name == '__new__':
@@ -360,7 +360,7 @@ def analyze_member_var_access(name: str,
     else:
         if mx.chk and mx.chk.should_suppress_optional_error([itype]):
             return AnyType(TypeOfAny.from_error)
-        return mx.msg.has_no_attr(mx.original_type, itype, name, mx.context)
+        return mx.msg.type_has_no_attr(mx.original_type, itype, name, mx.context)
 
 
 def check_final_member(name: str, info: TypeInfo, msg: MessageBuilder, ctx: Context) -> None:
@@ -368,7 +368,7 @@ def check_final_member(name: str, info: TypeInfo, msg: MessageBuilder, ctx: Cont
     for base in info.mro:
         sym = base.names.get(name)
         if sym and is_final_node(sym.node):
-            msg.cant_assign_to_final(name, attr_assign=True, ctx=ctx)
+            msg.cannot_assign_to_final(name, attr_assign=True, ctx=ctx)
 
 
 def analyze_descriptor_access(instance_type: Type,
@@ -476,7 +476,7 @@ def analyze_var(name: str,
             # TODO allow setting attributes in subclass (although it is probably an error)
             mx.msg.read_only_property(name, itype.type, mx.context)
         if mx.is_lvalue and var.is_classvar:
-            mx.msg.cant_assign_to_classvar(name, mx.context)
+            mx.msg.cannot_assign_to_classvar(name, mx.context)
         result = t
         if var.is_initialized_in_class and isinstance(t, FunctionLike) and not t.is_type_obj():
             if mx.is_lvalue:
@@ -484,7 +484,7 @@ def analyze_var(name: str,
                     if not var.is_settable_property:
                         mx.msg.read_only_property(name, itype.type, mx.context)
                 else:
-                    mx.msg.cant_assign_to_method(mx.context)
+                    mx.msg.cannot_assign_to_method(mx.context)
 
             if not var.is_staticmethod:
                 # Class-level function objects and classmethods become bound methods:
@@ -584,7 +584,7 @@ def analyze_class_attribute_access(itype: Instance,
     is_method = is_decorated or isinstance(node.node, FuncBase)
     if mx.is_lvalue:
         if is_method:
-            mx.msg.cant_assign_to_method(mx.context)
+            mx.msg.cannot_assign_to_method(mx.context)
         if isinstance(node.node, TypeInfo):
             mx.msg.fail(messages.CANNOT_ASSIGN_TO_TYPE, mx.context)
 

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -192,7 +192,7 @@ class StringFormatterChecker:
                 if expected_type is None:
                     return
                 self.chk.check_subtype(rep_type, expected_type, replacements,
-                                       messages.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
+                                       messages.ErrorCodes.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
                                        'expression has type',
                                        'placeholder with key \'%s\' has type' % specifier.key)
         else:
@@ -201,7 +201,7 @@ class StringFormatterChecker:
             dict_type = self.chk.named_generic_type('builtins.dict',
                                                     [any_type, any_type])
             self.chk.check_subtype(rep_type, dict_type, replacements,
-                                   messages.FORMAT_REQUIRES_MAPPING,
+                                   messages.ErrorCodes.FORMAT_REQUIRES_MAPPING,
                                    'expression has type', 'expected type for mapping is')
 
     def build_replacement_checkers(self, specifiers: List[ConversionSpecifier],
@@ -268,7 +268,7 @@ class StringFormatterChecker:
         def check_type(type: Type) -> None:
             assert expected_type is not None
             self.chk.check_subtype(type, expected_type, context,
-                              messages.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
+                              messages.ErrorCodes.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
                               'expression has type', 'placeholder has type')
 
         def check_expr(expr: Expression) -> None:
@@ -290,7 +290,7 @@ class StringFormatterChecker:
         def check_type(type: Type) -> None:
             assert expected_type is not None
             self.chk.check_subtype(type, expected_type, context,
-                              messages.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
+                              messages.ErrorCodes.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
                               'expression has type', 'placeholder has type')
 
         def check_expr(expr: Expression) -> None:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -60,6 +60,9 @@ class ErrorInfo:
     # Fine-grained incremental target where this was reported
     target = None  # type: Optional[str]
 
+    # Error code identifying the message, for grouping/filtering
+    id = None  # type: Optional[str]
+
     def __init__(self,
                  import_ctx: List[Tuple[str, int]],
                  file: str,
@@ -73,7 +76,8 @@ class ErrorInfo:
                  blocker: bool,
                  only_once: bool,
                  origin: Optional[Tuple[str, int]] = None,
-                 target: Optional[str] = None) -> None:
+                 target: Optional[str] = None,
+                 id: Optional[str] = None) -> None:
         self.import_ctx = import_ctx
         self.file = file
         self.module = module
@@ -87,6 +91,7 @@ class ErrorInfo:
         self.only_once = only_once
         self.origin = origin or (file, line)
         self.target = target
+        self.id = id
 
 
 class Errors:
@@ -230,7 +235,8 @@ class Errors:
                file: Optional[str] = None,
                only_once: bool = False,
                origin_line: Optional[int] = None,
-               offset: int = 0) -> None:
+               offset: int = 0,
+               id: Optional[str] = None) -> None:
         """Report message at the given line using the current error context.
 
         Args:
@@ -261,7 +267,7 @@ class Errors:
                          function, line, column, severity, message,
                          blocker, only_once,
                          origin=(self.file, origin_line) if origin_line else None,
-                         target=self.current_target())
+                         target=self.current_target(), id=id)
         self.add_error_info(info)
 
     def _add_error_info(self, file: str, info: ErrorInfo) -> None:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -518,8 +518,9 @@ class Errors:
             result.extend(a)
         return result
 
-    def remove_duplicates(self, errors: List[Tuple[Optional[str], int, int, str, str, Optional[str]]]
-                          ) -> List[Tuple[Optional[str], int, int, Optional[str], str, str]]:
+    def remove_duplicates(self,
+                          errors: List[Tuple[Optional[str], int, int, str, str, Optional[str]]]
+                          ) -> List[Tuple[Optional[str], int, int, str, str, Optional[str]]]:
         """Remove duplicates from a sorted error list."""
         res = []  # type: List[Tuple[Optional[str], int, int, str, str, Optional[str]]]
         i = 0

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -217,7 +217,7 @@ class ASTConverter:
     def note(self, msg: str, line: int, column: int) -> None:
         self.errors.report(line, column, msg, severity='note')
 
-    def fail(self, msg: str, line: int, column: int) -> None:
+    def fail(self, msg: messages.ErrorCodes, line: int, column: int) -> None:
         self.errors.report(line, column, msg, blocker=True)
 
     def visit(self, node: Optional[AST]) -> Any:
@@ -404,7 +404,7 @@ class ASTConverter:
                         isinstance(func_type_ast.argtypes[0], ast3_Ellipsis)):
                     if n.returns:
                         # PEP 484 disallows both type annotations and type comments
-                        self.fail(messages.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
+                        self.fail(messages.ErrorCodes.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
                     arg_types = [a.type_annotation
                                  if a.type_annotation is not None
                                  else AnyType(TypeOfAny.unannotated)
@@ -412,7 +412,7 @@ class ASTConverter:
                 else:
                     # PEP 484 disallows both type annotations and type comments
                     if n.returns or any(a.type_annotation is not None for a in args):
-                        self.fail(messages.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
+                        self.fail(messages.ErrorCodes.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
                     translated_args = (TypeConverter(self.errors, line=lineno)
                                        .translate_expr_list(func_type_ast.argtypes))
                     arg_types = [a if a is not None else AnyType(TypeOfAny.unannotated)
@@ -540,7 +540,7 @@ class ASTConverter:
             annotation = arg.annotation
             type_comment = arg.type_comment
             if annotation is not None and type_comment is not None:
-                self.fail(messages.DUPLICATE_TYPE_SIGNATURES, arg.lineno, arg.col_offset)
+                self.fail(messages.ErrorCodes.DUPLICATE_TYPE_SIGNATURES, arg.lineno, arg.col_offset)
             arg_type = None
             if annotation is not None:
                 arg_type = TypeConverter(self.errors, line=arg.lineno).visit(annotation)

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -169,7 +169,7 @@ class ASTConverter:
         # Cache of visit_X methods keyed by type of visited object
         self.visitor_cache = {}  # type: Dict[type, Callable[[Optional[AST]], Any]]
 
-    def fail(self, msg: str, line: int, column: int) -> None:
+    def fail(self, msg: messages.ErrorCodes, line: int, column: int) -> None:
         self.errors.report(line, column, msg, blocker=True)
 
     def visit(self, node: Optional[AST]) -> Any:  # same as in typed_ast stub
@@ -351,7 +351,7 @@ class ASTConverter:
                 else:
                     # PEP 484 disallows both type annotations and type comments
                     if any(a.type_annotation is not None for a in args):
-                        self.fail(messages.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
+                        self.fail(messages.ErrorCodes.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
                     arg_types = [a if a is not None else AnyType(TypeOfAny.unannotated) for
                                  a in converter.translate_expr_list(func_type_ast.argtypes)]
                 return_type = converter.visit(func_type_ast.returns)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -600,6 +600,9 @@ def process_options(args: List[str],
     add_invertible_flag('--show-error-codes', default=False,
                         help="Show error codes in error messages",
                         group=error_group)
+    error_group.add_argument(
+        '--list-error-codes', action='store_true',
+        help="List known error codes and exit")
 
     strict_help = "Strict mode; enables the following flags: {}".format(
         ", ".join(strict_flag_names))
@@ -701,6 +704,13 @@ def process_options(args: List[str],
     # filename for the config file and know if the user requested all strict options.
     dummy = argparse.Namespace()
     parser.parse_args(args, dummy)
+
+    if dummy.list_error_codes:
+        import mypy.messages
+        for msg_id in sorted(mypy.messages.message_ids):
+            print(msg_id)
+        raise SystemExit(0)
+
     config_file = dummy.config_file
     if config_file is not None and not os.path.exists(config_file):
         parser.error("Cannot find config file '%s'" % config_file)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -728,6 +728,7 @@ def process_options(args: List[str],
     # Parse command line for real, using a split namespace.
     special_opts = argparse.Namespace()
     parser.parse_args(args, SplitNamespace(options, special_opts, 'special-opts:'))
+    delattr(options, 'list_error_codes')
 
     # The python_version is either the default, which can be overridden via a config file,
     # or stored in special_opts and is passed via the command line.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -707,7 +707,7 @@ def process_options(args: List[str],
 
     if dummy.list_error_codes:
         import mypy.messages
-        for msg_id in sorted(mypy.messages.message_ids):
+        for msg_id in sorted(mypy.messages.MessageBuilder.get_message_ids()):
             print(msg_id)
         raise SystemExit(0)
 
@@ -728,6 +728,8 @@ def process_options(args: List[str],
     # Parse command line for real, using a split namespace.
     special_opts = argparse.Namespace()
     parser.parse_args(args, SplitNamespace(options, special_opts, 'special-opts:'))
+
+    # unneeded attribute transfered from parser
     delattr(options, 'list_error_codes')
 
     # The python_version is either the default, which can be overridden via a config file,

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -597,6 +597,9 @@ def process_options(args: List[str],
     add_invertible_flag('--show-column-numbers', default=False,
                         help="Show column numbers in error messages",
                         group=error_group)
+    add_invertible_flag('--show-error-codes', default=False,
+                        help="Show error codes in error messages",
+                        group=error_group)
 
     strict_help = "Strict mode; enables the following flags: {}".format(
         ", ".join(strict_flag_names))

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -235,6 +235,9 @@ class MessageBuilder:
     def get_message_ids(cls) -> Set[str]:
         return _message_ids
 
+    def active_message_id(self) -> Optional[str]:
+        return self.active_msg_ids[-1] if len(self.active_msg_ids) else None
+
     #
     # Helpers
     #

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -244,7 +244,7 @@ class MessageBuilder:
 
     @classmethod
     def get_message_ids(cls) -> Set[str]:
-        return _message_ids
+        return _message_ids.union(x.name for x in ErrorCodes)
 
     def active_message_id(self) -> Optional[str]:
         return self.active_msg_ids[-1] if len(self.active_msg_ids) else None
@@ -299,14 +299,16 @@ class MessageBuilder:
              format: Optional[Tuple[Any, ...]] = None,
              file: Optional[str] = None, origin: Optional[Context] = None) -> None:
         """Report an error message (unless disabled)."""
-        # FIXME: remove
+        # FIXME: remove once conversion to Enum is complete
         if isinstance(msg, str):
             val = msg
+            msg_id = None
         else:
             val = msg.value
+            msg_id = msg.name
         if format is not None:
             val = val.format(format)
-        self.report(val, context, 'error', file=file, origin=origin)
+        self.report(val, context, 'error', file=file, origin=origin, id=msg_id)
 
     def note(self, msg: str, context: Context, file: Optional[str] = None,
              origin: Optional[Context] = None, offset: int = 0) -> None:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -11,6 +11,7 @@ checker but we are moving away from this convention.
 """
 
 from collections import OrderedDict, deque
+from functools import wraps
 import re
 import difflib
 from textwrap import dedent
@@ -177,22 +178,25 @@ ARG_CONSTRUCTOR_NAMES = {
 }  # type: Final
 
 
-message_ids = set()  # type: Set[str]
+_message_ids = set()  # type: Set[str]
 
 
-def tracked(func: T) -> T:
-    msg_id = func.__name__
-    message_ids.add(msg_id)
+def tracked(id: Optional[str] = None) -> Callable[[T], T]:
+    def deco(func: T) -> T:
+        msg_id = id if id is not None else func.__name__
+        _message_ids.add(msg_id)
 
-    def wrapped(self: 'MessageBuilder', *args: Any, **kwargs: Any) -> Any:
-        assert len(self.active_msg_id) == 0 or self.active_msg_id[-1] != msg_id
-        self.active_msg_id.append(msg_id)
-        try:
-            return func(self, *args, **kwargs)
-        finally:
-            self.active_msg_id.pop()
+        @wraps(func)
+        def wrapped(self: 'MessageBuilder', *args: Any, **kwargs: Any) -> Any:
+            assert self.active_message_id() != msg_id
+            self.active_msg_ids.append(msg_id)
+            try:
+                return func(self, *args, **kwargs)
+            finally:
+                self.active_msg_ids.pop()
 
-    return wrapped  # type: ignore
+        return wrapped  # type: ignore
+    return deco
 
 
 class MessageBuilder:
@@ -218,14 +222,18 @@ class MessageBuilder:
     # Hack to deduplicate error messages from union types
     disable_type_names = 0
 
-    active_msg_id = None  # type: Deque[str]
+    active_msg_ids = None  # type: Deque[str]
 
     def __init__(self, errors: Errors, modules: Dict[str, MypyFile]) -> None:
         self.errors = errors
         self.modules = modules
         self.disable_count = 0
         self.disable_type_names = 0
-        self.active_msg_id = deque()
+        self.active_msg_ids = deque()
+
+    @classmethod
+    def get_message_ids(cls) -> Set[str]:
+        return _message_ids
 
     #
     # Helpers
@@ -264,8 +272,8 @@ class MessageBuilder:
         """Report an error or note (unless disabled)."""
         if self.disable_count <= 0:
             msg_id = id
-            if msg_id is None and len(self.active_msg_id):
-                msg_id = self.active_msg_id[-1]
+            if msg_id is None:
+                msg_id = self.active_message_id()
 
             self.errors.report(context.get_line() if context else -1,
                                context.get_column() if context else -1,
@@ -501,16 +509,16 @@ class MessageBuilder:
     # get some information as arguments, and they build an error message based
     # on them.
 
-    @tracked
+    @tracked()
     def no_return_exepected(self, context: Context) -> None:
         self.fail('No return value expected', context)
 
-    @tracked
+    @tracked()
     def must_have_none_return_type(self, context: FuncDef) -> None:
         self.fail('The return type of "{}" must be None'.format(context.name()), context)
 
-    @tracked
-    def has_no_attr(self, original_type: Type, typ: Type, member: str, context: Context) -> Type:
+    @tracked()
+    def type_has_no_attr(self, original_type: Type, typ: Type, member: str, context: Context) -> Type:
         """Report a missing or non-accessible member.
 
         original_type is the top-level type on which the error occurred.
@@ -601,7 +609,7 @@ class MessageBuilder:
                     typ_format, self.format(original_type), member, extra), context)
         return AnyType(TypeOfAny.from_error)
 
-    @tracked
+    @tracked()
     def unsupported_operand_types(self, op: str, left_type: Any,
                                   right_type: Any, context: Context) -> None:
         """Report unsupported operand types for a binary operation.
@@ -627,7 +635,7 @@ class MessageBuilder:
                 op, left_str, right_str)
         self.fail(msg, context)
 
-    @tracked
+    @tracked()
     def unsupported_left_operand(self, op: str, typ: Type,
                                  context: Context) -> None:
         if self.disable_type_names:
@@ -637,18 +645,13 @@ class MessageBuilder:
                 op, self.format(typ))
         self.fail(msg, context)
 
-    @tracked
-    def not_callable(self, typ: Type, context: Context) -> Type:
-        self.fail('{} not callable'.format(self.format(typ)), context)
-        return AnyType(TypeOfAny.from_error)
-
-    @tracked
+    @tracked()
     def untyped_function_call(self, callee: CallableType, context: Context) -> Type:
         name = callable_name(callee) or '(unknown)'
         self.fail('Call to untyped function {} in typed context'.format(name), context)
         return AnyType(TypeOfAny.from_error)
 
-    @tracked
+    @tracked()
     def incompatible_argument(self, n: int, m: int, callee: CallableType, arg_type: Type,
                               arg_kind: int, context: Context) -> None:
         """Report an error about an incompatible argument type.
@@ -798,13 +801,13 @@ class MessageBuilder:
             for note_msg in notes:
                 self.note(note_msg, context)
 
-    @tracked
+    @tracked()
     def invalid_index_type(self, index_type: Type, expected_type: Type, base_str: str,
                            context: Context) -> None:
         self.fail('Invalid index type {} for {}; expected type {}'.format(
             self.format(index_type), base_str, self.format(expected_type)), context)
 
-    @tracked
+    @tracked('wrong_number_of_arguments')
     def too_few_arguments(self, callee: CallableType, context: Context,
                           argument_names: Optional[Sequence[Optional[str]]]) -> None:
         if (argument_names is not None and not all(k is None for k in argument_names)
@@ -822,17 +825,17 @@ class MessageBuilder:
             msg = 'Too few arguments' + for_function(callee)
         self.fail(msg, context)
 
-    @tracked
+    @tracked()
     def missing_named_argument(self, callee: CallableType, context: Context, name: str) -> None:
         msg = 'Missing named argument "{}"'.format(name) + for_function(callee)
         self.fail(msg, context)
 
-    @tracked
+    @tracked('wrong_number_of_arguments')
     def too_many_arguments(self, callee: CallableType, context: Context) -> None:
         msg = 'Too many arguments' + for_function(callee)
         self.fail(msg, context)
 
-    @tracked
+    @tracked()
     def too_many_arguments_from_typed_dict(self,
                                            callee: CallableType,
                                            arg_type: TypedDictType,
@@ -847,13 +850,13 @@ class MessageBuilder:
             return
         self.fail(msg, context)
 
-    @tracked
+    @tracked()
     def too_many_positional_arguments(self, callee: CallableType,
                                       context: Context) -> None:
         msg = 'Too many positional arguments' + for_function(callee)
         self.fail(msg, context)
 
-    @tracked
+    @tracked()
     def unexpected_keyword_argument(self, callee: CallableType, name: str,
                                     context: Context) -> None:
         msg = 'Unexpected keyword argument "{}"'.format(name) + for_function(callee)
@@ -867,14 +870,14 @@ class MessageBuilder:
             self.note('{} defined here'.format(fname), callee.definition,
                       file=module.path, origin=context)
 
-    @tracked
+    @tracked()
     def duplicate_argument_value(self, callee: CallableType, index: int,
                                  context: Context) -> None:
         self.fail('{} gets multiple values for keyword argument "{}"'.
                   format(callable_name(callee) or 'Function', callee.arg_names[index]),
                   context)
 
-    @tracked
+    @tracked()
     def does_not_return_value(self, callee_type: Optional[Type], context: Context) -> None:
         """Report an error about use of an unusable type."""
         name = None  # type: Optional[str]
@@ -885,7 +888,7 @@ class MessageBuilder:
         else:
             self.fail('Function does not return a value', context)
 
-    @tracked
+    @tracked()
     def deleted_as_rvalue(self, typ: DeletedType, context: Context) -> None:
         """Report an error about using an deleted type as an rvalue."""
         if typ.source is None:
@@ -894,7 +897,7 @@ class MessageBuilder:
             s = " '{}'".format(typ.source)
         self.fail('Trying to read deleted variable{}'.format(s), context)
 
-    @tracked
+    @tracked()
     def deleted_as_lvalue(self, typ: DeletedType, context: Context) -> None:
         """Report an error about using an deleted type as an lvalue.
 
@@ -907,7 +910,7 @@ class MessageBuilder:
             s = " '{}'".format(typ.source)
         self.fail('Assignment to variable{} outside except: block'.format(s), context)
 
-    @tracked
+    @tracked()
     def no_variant_matches_arguments(self,
                                      plausible_targets: List[CallableType],
                                      overload: Overloaded,
@@ -932,7 +935,7 @@ class MessageBuilder:
 
         self.pretty_overload_matches(plausible_targets, overload, context, offset=2, max_items=2)
 
-    @tracked
+    @tracked()
     def wrong_number_values_to_unpack(self, provided: int, expected: int,
                                       context: Context) -> None:
         if provided < expected:
@@ -946,17 +949,17 @@ class MessageBuilder:
             self.fail('Too many values to unpack ({} expected, {} provided)'.format(
                 expected, provided), context)
 
-    @tracked
+    @tracked()
     def type_not_iterable(self, type: Type, context: Context) -> None:
         self.fail('\'{}\' object is not iterable'.format(type), context)
 
-    @tracked
+    @tracked()
     def incompatible_operator_assignment(self, op: str,
                                          context: Context) -> None:
         self.fail('Result type of {} incompatible in assignment'.format(op),
                   context)
 
-    @tracked
+    @tracked()
     def overload_signature_incompatible_with_supertype(
             self, name: str, name_in_super: str, supertype: str,
             overload: Overloaded, context: Context) -> None:
@@ -967,7 +970,7 @@ class MessageBuilder:
         note_template = 'Overload variants must be defined in the same order as they are in "{}"'
         self.note(note_template.format(supertype), context)
 
-    @tracked
+    @tracked()
     def signature_incompatible_with_supertype(
             self, name: str, name_in_super: str, supertype: str,
             context: Context) -> None:
@@ -975,7 +978,7 @@ class MessageBuilder:
         self.fail('Signature of "{}" incompatible with {}'.format(
             name, target), context)
 
-    @tracked
+    @tracked()
     def argument_incompatible_with_supertype(
             self, arg_num: int, name: str, type_name: Optional[str],
             name_in_supertype: str, supertype: str, context: Context) -> None:
@@ -996,7 +999,7 @@ class MessageBuilder:
                 return <logic to compare two {class_name} instances>
         '''.format(class_name=class_name))
 
-    @tracked
+    @tracked()
     def return_type_incompatible_with_supertype(
             self, name: str, name_in_supertype: str, supertype: str,
             context: Context) -> None:
@@ -1004,7 +1007,6 @@ class MessageBuilder:
         self.fail('Return type of "{}" incompatible with {}'
                   .format(name, target), context)
 
-    @tracked
     def override_target(self, name: str, name_in_super: str,
                         supertype: str) -> str:
         target = 'supertype "{}"'.format(supertype)
@@ -1012,7 +1014,7 @@ class MessageBuilder:
             target = '"{}" of {}'.format(name_in_super, target)
         return target
 
-    @tracked
+    @tracked()
     def incompatible_type_application(self, expected_arg_count: int,
                                       actual_arg_count: int,
                                       context: Context) -> None:
@@ -1026,7 +1028,7 @@ class MessageBuilder:
             self.fail('Type application has too few types ({} expected)'
                       .format(expected_arg_count), context)
 
-    @tracked
+    @tracked()
     def alias_invalid_in_runtime_context(self, item: Type, ctx: Context) -> None:
         kind = (' to Callable' if isinstance(item, CallableType) else
                 ' to Tuple' if isinstance(item, TupleType) else
@@ -1035,7 +1037,7 @@ class MessageBuilder:
                 '')
         self.fail('The type alias{} is invalid in runtime context'.format(kind), ctx)
 
-    @tracked
+    @tracked()
     def could_not_infer_type_arguments(self, callee_type: CallableType, n: int,
                                        context: Context) -> None:
         callee_name = callable_name(callee_type)
@@ -1044,11 +1046,11 @@ class MessageBuilder:
         else:
             self.fail('Cannot infer function type argument', context)
 
-    @tracked
+    @tracked()
     def invalid_var_arg(self, typ: Type, context: Context) -> None:
         self.fail('List or tuple expected as variable arguments', context)
 
-    @tracked
+    @tracked()
     def invalid_keyword_var_arg(self, typ: Type, is_mapping: bool, context: Context) -> None:
         if isinstance(typ, Instance) and is_mapping:
             self.fail('Keywords must be strings', context)
@@ -1060,11 +1062,11 @@ class MessageBuilder:
                 'Argument after ** must be a mapping{}'.format(suffix),
                 context)
 
-    @tracked
+    @tracked()
     def undefined_in_superclass(self, member: str, context: Context) -> None:
         self.fail('"{}" undefined in superclass'.format(member), context)
 
-    @tracked
+    @tracked()
     def first_argument_for_super_must_be_type(self, actual: Type, context: Context) -> None:
         if isinstance(actual, Instance):
             # Don't include type of instance, because it can look confusingly like a type
@@ -1074,60 +1076,60 @@ class MessageBuilder:
             type_str = self.format(actual)
         self.fail('Argument 1 for "super" must be a type object; got {}'.format(type_str), context)
 
-    @tracked
+    @tracked('wrong_number_of_str_format_args')
     def too_few_string_formatting_arguments(self, context: Context) -> None:
         self.fail('Not enough arguments for format string', context)
 
-    @tracked
+    @tracked('wrong_number_of_str_format_args')
     def too_many_string_formatting_arguments(self, context: Context) -> None:
         self.fail('Not all arguments converted during string formatting', context)
 
-    @tracked
+    @tracked()
     def unsupported_placeholder(self, placeholder: str, context: Context) -> None:
         self.fail('Unsupported format character \'%s\'' % placeholder, context)
 
-    @tracked
+    @tracked()
     def string_interpolation_with_star_and_key(self, context: Context) -> None:
         self.fail('String interpolation contains both stars and mapping keys', context)
 
-    @tracked
+    @tracked()
     def requires_int_or_char(self, context: Context) -> None:
         self.fail('%c requires int or char', context)
 
-    @tracked
+    @tracked()
     def key_not_in_mapping(self, key: str, context: Context) -> None:
         self.fail('Key \'%s\' not found in mapping' % key, context)
 
-    @tracked
+    @tracked()
     def string_interpolation_mixing_key_and_non_keys(self, context: Context) -> None:
         self.fail('String interpolation mixes specifier with and without mapping keys', context)
 
-    @tracked
+    @tracked()
     def cannot_determine_type(self, name: str, context: Context) -> None:
         self.fail("Cannot determine type of '%s'" % name, context)
 
-    @tracked
+    @tracked()
     def cannot_determine_type_in_base(self, name: str, base: str, context: Context) -> None:
         self.fail("Cannot determine type of '%s' in base class '%s'" % (name, base), context)
 
-    @tracked
+    @tracked()
     def no_formal_self(self, name: str, item: CallableType, context: Context) -> None:
         self.fail('Attribute function "%s" with type %s does not accept self argument'
                   % (name, self.format(item)), context)
 
-    @tracked
+    @tracked()
     def incompatible_self_argument(self, name: str, arg: Type, sig: CallableType,
                                    is_classmethod: bool, context: Context) -> None:
         kind = 'class attribute function' if is_classmethod else 'attribute function'
         self.fail('Invalid self argument %s to %s "%s" with type %s'
                   % (self.format(arg), kind, name, self.format(sig)), context)
 
-    @tracked
+    @tracked()
     def incompatible_conditional_function_def(self, defn: FuncDef) -> None:
         self.fail('All conditional function variants must have identical '
                   'signatures', defn)
 
-    @tracked
+    @tracked()
     def cannot_instantiate_abstract_class(self, class_name: str,
                                           abstract_attributes: List[str],
                                           context: Context) -> None:
@@ -1137,7 +1139,7 @@ class MessageBuilder:
                                    attrs),
                   context)
 
-    @tracked
+    @tracked()
     def base_class_definitions_incompatible(self, name: str, base1: TypeInfo,
                                             base2: TypeInfo,
                                             context: Context) -> None:
@@ -1145,24 +1147,24 @@ class MessageBuilder:
                   'with definition in base class "{}"'.format(
                       name, base1.name(), base2.name()), context)
 
-    @tracked
-    def cant_assign_to_method(self, context: Context) -> None:
+    @tracked()
+    def cannot_assign_to_method(self, context: Context) -> None:
         self.fail(CANNOT_ASSIGN_TO_METHOD, context)
 
-    @tracked
-    def cant_assign_to_classvar(self, name: str, context: Context) -> None:
+    @tracked()
+    def cannot_assign_to_classvar(self, name: str, context: Context) -> None:
         self.fail('Cannot assign to class variable "%s" via instance' % name, context)
 
-    @tracked
-    def final_cant_override_writable(self, name: str, ctx: Context) -> None:
+    @tracked()
+    def final_cannot_override_writable(self, name: str, ctx: Context) -> None:
         self.fail('Cannot override writable attribute "{}" with a final one'.format(name), ctx)
 
-    @tracked
-    def cant_override_final(self, name: str, base_name: str, ctx: Context) -> None:
+    @tracked()
+    def cannot_override_final(self, name: str, base_name: str, ctx: Context) -> None:
         self.fail('Cannot override final attribute "{}"'
                   ' (previously declared in base class "{}")'.format(name, base_name), ctx)
 
-    def cant_assign_to_final(self, name: str, attr_assign: bool, ctx: Context) -> None:
+    def cannot_assign_to_final(self, name: str, attr_assign: bool, ctx: Context) -> None:
         """Warn about a prohibited assignment to a final attribute.
 
         Pass `attr_assign=True` if the assignment assigns to an attribute.
@@ -1170,21 +1172,21 @@ class MessageBuilder:
         kind = "attribute" if attr_assign else "name"
         self.fail('Cannot assign to final {} "{}"'.format(kind, name), ctx)
 
-    @tracked
-    def protocol_members_cant_be_final(self, ctx: Context) -> None:
+    @tracked()
+    def protocol_members_cannot_be_final(self, ctx: Context) -> None:
         self.fail("Protocol member cannot be final", ctx)
 
-    @tracked
+    @tracked()
     def final_without_value(self, ctx: Context) -> None:
         self.fail("Final name must be initialized with a value", ctx)
 
-    @tracked
+    @tracked()
     def read_only_property(self, name: str, type: TypeInfo,
                            context: Context) -> None:
         self.fail('Property "{}" defined in "{}" is read-only'.format(
             name, type.name()), context)
 
-    @tracked
+    @tracked()
     def incompatible_typevar_value(self,
                                    callee: CallableType,
                                    typ: Type,
@@ -1195,26 +1197,26 @@ class MessageBuilder:
                                                     self.format(typ)),
                   context)
 
-    @tracked
+    @tracked()
     def overload_inconsistently_applies_decorator(self, decorator: str, context: Context) -> None:
         self.fail(
             'Overload does not consistently use the "@{}" '.format(decorator)
             + 'decorator on all function signatures.',
             context)
 
-    @tracked
+    @tracked()
     def overloaded_signatures_overlap(self, index1: int, index2: int, context: Context) -> None:
         self.fail('Overloaded function signatures {} and {} overlap with '
                   'incompatible return types'.format(index1, index2), context)
 
-    @tracked
+    @tracked()
     def overloaded_signatures_partial_overlap(self, index1: int, index2: int,
                                               context: Context) -> None:
         self.fail('Overloaded function signatures {} and {} '.format(index1, index2)
                   + 'are partially overlapping: the two signatures may return '
                   + 'incompatible types given certain calls', context)
 
-    @tracked
+    @tracked()
     def overloaded_signature_will_never_match(self, index1: int, index2: int,
                                               context: Context) -> None:
         self.fail(
@@ -1224,30 +1226,28 @@ class MessageBuilder:
                 index2=index2),
             context)
 
-    @tracked
+    @tracked()
     def overloaded_signatures_typevar_specific(self, index: int, context: Context) -> None:
         self.fail('Overloaded function implementation cannot satisfy signature {} '.format(index) +
                   'due to inconsistencies in how they use type variables', context)
 
-    @tracked
+    @tracked()
     def overloaded_signatures_arg_specific(self, index: int, context: Context) -> None:
         self.fail('Overloaded function implementation does not accept all possible arguments '
                   'of signature {}'.format(index), context)
 
-    @tracked
+    @tracked()
     def overloaded_signatures_ret_specific(self, index: int, context: Context) -> None:
         self.fail('Overloaded function implementation cannot produce return type '
                   'of signature {}'.format(index), context)
 
-    @tracked
     def warn_both_operands_are_from_unions(self, context: Context) -> None:
         self.note('Both left and right operands are unions', context)
 
-    @tracked
     def warn_operand_was_from_union(self, side: str, original: Type, context: Context) -> None:
         self.note('{} operand is of type {}'.format(side, self.format(original)), context)
 
-    @tracked
+    @tracked()
     def operator_method_signatures_overlap(
             self, reverse_class: TypeInfo, reverse_method: str, forward_class: Type,
             forward_method: str, context: Context) -> None:
@@ -1257,38 +1257,38 @@ class MessageBuilder:
                       forward_method, self.format(forward_class)),
                   context)
 
-    @tracked
+    @tracked()
     def forward_operator_not_callable(
             self, forward_method: str, context: Context) -> None:
         self.fail('Forward operator "{}" is not callable'.format(
             forward_method), context)
 
-    @tracked
+    @tracked()
     def signatures_incompatible(self, method: str, other_method: str,
                                 context: Context) -> None:
         self.fail('Signatures of "{}" and "{}" are incompatible'.format(
             method, other_method), context)
 
-    @tracked
+    @tracked()
     def yield_from_invalid_operand_type(self, expr: Type, context: Context) -> Type:
         text = self.format(expr) if self.format(expr) != 'object' else expr
         self.fail('"yield from" can\'t be applied to {}'.format(text), context)
         return AnyType(TypeOfAny.from_error)
 
-    @tracked
+    @tracked()
     def invalid_signature(self, func_type: Type, context: Context) -> None:
         self.fail('Invalid signature "{}"'.format(func_type), context)
 
-    @tracked
+    @tracked()
     def invalid_signature_for_special_method(
             self, func_type: Type, context: Context, method_name: str) -> None:
         self.fail('Invalid signature "{}" for "{}"'.format(func_type, method_name), context)
 
-    @tracked
+    @tracked()
     def reveal_type(self, typ: Type, context: Context) -> None:
         self.fail('Revealed type is \'{}\''.format(typ), context)
 
-    @tracked
+    @tracked()
     def reveal_locals(self, type_map: Dict[str, Optional[Type]], context: Context) -> None:
         # To ensure that the output is predictable on Python < 3.6,
         # use an ordered dictionary sorted by variable name
@@ -1297,28 +1297,29 @@ class MessageBuilder:
         for line in ['{}: {}'.format(k, v) for k, v in sorted_locals.items()]:
             self.fail(line, context)
 
-    @tracked
+    @tracked()
     def unsupported_type_type(self, item: Type, context: Context) -> None:
         self.fail('Unsupported type Type[{}]'.format(self.format(item)), context)
 
-    @tracked
+    @tracked()
     def redundant_cast(self, typ: Type, context: Context) -> None:
         self.note('Redundant cast to {}'.format(self.format(typ)), context)
 
-    @tracked
+    # filtered by disallow_any_unimported
+    @tracked()
     def unimported_type_becomes_any(self, prefix: str, typ: Type, ctx: Context) -> None:
         self.fail("{} becomes {} due to an unfollowed import".format(prefix, self.format(typ)),
                   ctx)
 
-    @tracked
+    @tracked()
     def need_annotation_for_var(self, node: SymbolNode, context: Context) -> None:
         self.fail("Need type annotation for '{}'".format(node.name()), context)
 
-    @tracked
+    @tracked()
     def explicit_any(self, ctx: Context) -> None:
         self.fail('Explicit "Any" is not allowed', ctx)
 
-    @tracked
+    @tracked()
     def unexpected_typeddict_keys(
             self,
             typ: TypedDictType,
@@ -1354,7 +1355,7 @@ class MessageBuilder:
             found = 'only {}'.format(found)
         self.fail('Expected {} but found {}'.format(expected, found), context)
 
-    @tracked
+    @tracked()
     def typeddict_key_must_be_string_literal(
             self,
             typ: TypedDictType,
@@ -1363,7 +1364,7 @@ class MessageBuilder:
             'TypedDict key must be a string literal; expected one of {}'.format(
                 format_item_name_list(typ.items.keys())), context)
 
-    @tracked
+    @tracked()
     def typeddict_key_not_found(
             self,
             typ: TypedDictType,
@@ -1375,7 +1376,7 @@ class MessageBuilder:
         else:
             self.fail("TypedDict {} has no key '{}'".format(self.format(typ), item_name), context)
 
-    @tracked
+    @tracked()
     def typeddict_key_cannot_be_deleted(
             self,
             typ: TypedDictType,
@@ -1388,7 +1389,7 @@ class MessageBuilder:
             self.fail("Key '{}' of TypedDict {} cannot be deleted".format(
                 item_name, self.format(typ)), context)
 
-    @tracked
+    @tracked()
     def type_arguments_not_allowed(self, context: Context) -> None:
         self.fail('Parameterized generics cannot be used with class or instance checks', context)
 
@@ -1399,13 +1400,14 @@ class MessageBuilder:
             message = 'Expression type contains "Any" (has type {})'.format(self.format(typ))
         self.fail(message, context)
 
-    @tracked
+    @tracked()
     def incorrectly_returning_any(self, typ: Type, context: Context) -> None:
         message = 'Returning Any from function declared to return {}'.format(
             self.format(typ))
         self.warn(message, context)
 
-    @tracked
+    # filtered by disallow_any_decorated
+    @tracked()
     def untyped_decorated_function(self, typ: Type, context: Context) -> None:
         if isinstance(typ, AnyType):
             self.fail("Function is untyped after decorator transformation", context)
@@ -1413,11 +1415,12 @@ class MessageBuilder:
             self.fail('Type of decorated function contains type "Any" ({})'.format(
                 self.format(typ)), context)
 
-    @tracked
+    # filtered by disallow_untyped_decorators
+    @tracked()
     def typed_function_untyped_decorator(self, func_name: str, context: Context) -> None:
         self.fail('Untyped decorator makes function "{}" untyped'.format(func_name), context)
 
-    @tracked
+    @tracked()
     def bad_proto_variance(self, actual: int, tvar_name: str, expected: int,
                            context: Context) -> None:
         msg = capitalize("{} type variable '{}' used in protocol where"
@@ -1426,24 +1429,24 @@ class MessageBuilder:
                                                       variance_string(expected)))
         self.fail(msg, context)
 
-    @tracked
+    @tracked()
     def concrete_only_assign(self, typ: Type, context: Context) -> None:
         self.fail("Can only assign concrete classes to a variable of type {}"
                   .format(self.format(typ)), context)
 
-    @tracked
+    @tracked()
     def concrete_only_call(self, typ: Type, context: Context) -> None:
         self.fail("Only concrete class can be given where {} is expected"
                   .format(self.format(typ)), context)
 
-    @tracked
+    @tracked()
     def cannot_use_function_with_type(
             self, method_name: str, type_name: str, context: Context) -> None:
         self.fail("Cannot use {}() with a {} type".format(method_name, type_name), context)
 
-    @tracked
-    def report_non_method_protocol(self, tp: TypeInfo, members: List[str],
-                                   context: Context) -> None:
+    @tracked()
+    def issubclass_on_non_method_protocol(self, tp: TypeInfo, members: List[str],
+                                          context: Context) -> None:
         self.fail("Only protocols that don't have non-method members can be"
                   " used with issubclass()", context)
         if len(members) < 3:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -261,11 +261,15 @@ class MessageBuilder:
                offset: int = 0, id: Optional[str] = None) -> None:
         """Report an error or note (unless disabled)."""
         if self.disable_count <= 0:
+            msg_id = id
+            if msg_id is None and len(self.active_msg_id):
+                msg_id = self.active_msg_id[-1]
+
             self.errors.report(context.get_line() if context else -1,
                                context.get_column() if context else -1,
                                msg, severity=severity, file=file, offset=offset,
                                origin_line=origin.get_line() if origin else None,
-                               id=id if id is not None else self.active_msg_id)
+                               id=msg_id)
 
     def fail(self, msg: str, context: Optional[Context], file: Optional[str] = None,
              origin: Optional[Context] = None) -> None:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -182,6 +182,11 @@ _message_ids = set()  # type: Set[str]
 
 
 def tracked(id: Optional[str] = None) -> Callable[[T], T]:
+    """Identify a MessageBuilder method that represents a message to be tracked.
+
+    Arguments:
+      id: provide an explicit message id. by default, if this is not provided the message id is the name of the method
+    """
     def deco(func: T) -> T:
         msg_id = id if id is not None else func.__name__
         _message_ids.add(msg_id)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -181,11 +181,12 @@ ARG_CONSTRUCTOR_NAMES = {
 _message_ids = set()  # type: Set[str]
 
 
-def tracked(id: Optional[str] = None) -> Callable[[T], T]:
-    """Identify a MessageBuilder method that represents a message to be tracked.
+def register(id: Optional[str] = None) -> Callable[[T], T]:
+    """Identify a MessageBuilder method that represents a message to be register.
 
     Arguments:
-      id: provide an explicit message id. by default, if this is not provided the message id is the name of the method
+      id: provide an explicit message id. by default, if this is not provided the message id is
+          the name of the method
     """
     def deco(func: T) -> T:
         msg_id = id if id is not None else func.__name__
@@ -517,16 +518,17 @@ class MessageBuilder:
     # get some information as arguments, and they build an error message based
     # on them.
 
-    @tracked()
+    @register()
     def no_return_exepected(self, context: Context) -> None:
         self.fail('No return value expected', context)
 
-    @tracked()
+    @register()
     def must_have_none_return_type(self, context: FuncDef) -> None:
         self.fail('The return type of "{}" must be None'.format(context.name()), context)
 
-    @tracked()
-    def type_has_no_attr(self, original_type: Type, typ: Type, member: str, context: Context) -> Type:
+    @register()
+    def type_has_no_attr(self, original_type: Type, typ: Type, member: str,
+                         context: Context) -> Type:
         """Report a missing or non-accessible member.
 
         original_type is the top-level type on which the error occurred.
@@ -617,7 +619,7 @@ class MessageBuilder:
                     typ_format, self.format(original_type), member, extra), context)
         return AnyType(TypeOfAny.from_error)
 
-    @tracked()
+    @register()
     def unsupported_operand_types(self, op: str, left_type: Any,
                                   right_type: Any, context: Context) -> None:
         """Report unsupported operand types for a binary operation.
@@ -643,7 +645,7 @@ class MessageBuilder:
                 op, left_str, right_str)
         self.fail(msg, context)
 
-    @tracked()
+    @register()
     def unsupported_left_operand(self, op: str, typ: Type,
                                  context: Context) -> None:
         if self.disable_type_names:
@@ -653,13 +655,13 @@ class MessageBuilder:
                 op, self.format(typ))
         self.fail(msg, context)
 
-    @tracked()
+    @register()
     def untyped_function_call(self, callee: CallableType, context: Context) -> Type:
         name = callable_name(callee) or '(unknown)'
         self.fail('Call to untyped function {} in typed context'.format(name), context)
         return AnyType(TypeOfAny.from_error)
 
-    @tracked()
+    @register()
     def incompatible_argument(self, n: int, m: int, callee: CallableType, arg_type: Type,
                               arg_kind: int, context: Context) -> None:
         """Report an error about an incompatible argument type.
@@ -809,13 +811,13 @@ class MessageBuilder:
             for note_msg in notes:
                 self.note(note_msg, context)
 
-    @tracked()
+    @register()
     def invalid_index_type(self, index_type: Type, expected_type: Type, base_str: str,
                            context: Context) -> None:
         self.fail('Invalid index type {} for {}; expected type {}'.format(
             self.format(index_type), base_str, self.format(expected_type)), context)
 
-    @tracked('wrong_number_of_arguments')
+    @register('wrong_number_of_arguments')
     def too_few_arguments(self, callee: CallableType, context: Context,
                           argument_names: Optional[Sequence[Optional[str]]]) -> None:
         if (argument_names is not None and not all(k is None for k in argument_names)
@@ -833,17 +835,17 @@ class MessageBuilder:
             msg = 'Too few arguments' + for_function(callee)
         self.fail(msg, context)
 
-    @tracked()
+    @register()
     def missing_named_argument(self, callee: CallableType, context: Context, name: str) -> None:
         msg = 'Missing named argument "{}"'.format(name) + for_function(callee)
         self.fail(msg, context)
 
-    @tracked('wrong_number_of_arguments')
+    @register('wrong_number_of_arguments')
     def too_many_arguments(self, callee: CallableType, context: Context) -> None:
         msg = 'Too many arguments' + for_function(callee)
         self.fail(msg, context)
 
-    @tracked()
+    @register()
     def too_many_arguments_from_typed_dict(self,
                                            callee: CallableType,
                                            arg_type: TypedDictType,
@@ -858,13 +860,13 @@ class MessageBuilder:
             return
         self.fail(msg, context)
 
-    @tracked()
+    @register()
     def too_many_positional_arguments(self, callee: CallableType,
                                       context: Context) -> None:
         msg = 'Too many positional arguments' + for_function(callee)
         self.fail(msg, context)
 
-    @tracked()
+    @register()
     def unexpected_keyword_argument(self, callee: CallableType, name: str,
                                     context: Context) -> None:
         msg = 'Unexpected keyword argument "{}"'.format(name) + for_function(callee)
@@ -878,14 +880,14 @@ class MessageBuilder:
             self.note('{} defined here'.format(fname), callee.definition,
                       file=module.path, origin=context)
 
-    @tracked()
+    @register()
     def duplicate_argument_value(self, callee: CallableType, index: int,
                                  context: Context) -> None:
         self.fail('{} gets multiple values for keyword argument "{}"'.
                   format(callable_name(callee) or 'Function', callee.arg_names[index]),
                   context)
 
-    @tracked()
+    @register()
     def does_not_return_value(self, callee_type: Optional[Type], context: Context) -> None:
         """Report an error about use of an unusable type."""
         name = None  # type: Optional[str]
@@ -896,7 +898,7 @@ class MessageBuilder:
         else:
             self.fail('Function does not return a value', context)
 
-    @tracked()
+    @register()
     def deleted_as_rvalue(self, typ: DeletedType, context: Context) -> None:
         """Report an error about using an deleted type as an rvalue."""
         if typ.source is None:
@@ -905,7 +907,7 @@ class MessageBuilder:
             s = " '{}'".format(typ.source)
         self.fail('Trying to read deleted variable{}'.format(s), context)
 
-    @tracked()
+    @register()
     def deleted_as_lvalue(self, typ: DeletedType, context: Context) -> None:
         """Report an error about using an deleted type as an lvalue.
 
@@ -918,7 +920,7 @@ class MessageBuilder:
             s = " '{}'".format(typ.source)
         self.fail('Assignment to variable{} outside except: block'.format(s), context)
 
-    @tracked()
+    @register()
     def no_variant_matches_arguments(self,
                                      plausible_targets: List[CallableType],
                                      overload: Overloaded,
@@ -943,7 +945,7 @@ class MessageBuilder:
 
         self.pretty_overload_matches(plausible_targets, overload, context, offset=2, max_items=2)
 
-    @tracked()
+    @register()
     def wrong_number_values_to_unpack(self, provided: int, expected: int,
                                       context: Context) -> None:
         if provided < expected:
@@ -957,17 +959,17 @@ class MessageBuilder:
             self.fail('Too many values to unpack ({} expected, {} provided)'.format(
                 expected, provided), context)
 
-    @tracked()
+    @register()
     def type_not_iterable(self, type: Type, context: Context) -> None:
         self.fail('\'{}\' object is not iterable'.format(type), context)
 
-    @tracked()
+    @register()
     def incompatible_operator_assignment(self, op: str,
                                          context: Context) -> None:
         self.fail('Result type of {} incompatible in assignment'.format(op),
                   context)
 
-    @tracked()
+    @register()
     def overload_signature_incompatible_with_supertype(
             self, name: str, name_in_super: str, supertype: str,
             overload: Overloaded, context: Context) -> None:
@@ -978,7 +980,7 @@ class MessageBuilder:
         note_template = 'Overload variants must be defined in the same order as they are in "{}"'
         self.note(note_template.format(supertype), context)
 
-    @tracked()
+    @register()
     def signature_incompatible_with_supertype(
             self, name: str, name_in_super: str, supertype: str,
             context: Context) -> None:
@@ -986,7 +988,7 @@ class MessageBuilder:
         self.fail('Signature of "{}" incompatible with {}'.format(
             name, target), context)
 
-    @tracked()
+    @register()
     def argument_incompatible_with_supertype(
             self, arg_num: int, name: str, type_name: Optional[str],
             name_in_supertype: str, supertype: str, context: Context) -> None:
@@ -1007,7 +1009,7 @@ class MessageBuilder:
                 return <logic to compare two {class_name} instances>
         '''.format(class_name=class_name))
 
-    @tracked()
+    @register()
     def return_type_incompatible_with_supertype(
             self, name: str, name_in_supertype: str, supertype: str,
             context: Context) -> None:
@@ -1022,7 +1024,7 @@ class MessageBuilder:
             target = '"{}" of {}'.format(name_in_super, target)
         return target
 
-    @tracked()
+    @register()
     def incompatible_type_application(self, expected_arg_count: int,
                                       actual_arg_count: int,
                                       context: Context) -> None:
@@ -1036,7 +1038,7 @@ class MessageBuilder:
             self.fail('Type application has too few types ({} expected)'
                       .format(expected_arg_count), context)
 
-    @tracked()
+    @register()
     def alias_invalid_in_runtime_context(self, item: Type, ctx: Context) -> None:
         kind = (' to Callable' if isinstance(item, CallableType) else
                 ' to Tuple' if isinstance(item, TupleType) else
@@ -1045,7 +1047,7 @@ class MessageBuilder:
                 '')
         self.fail('The type alias{} is invalid in runtime context'.format(kind), ctx)
 
-    @tracked()
+    @register()
     def could_not_infer_type_arguments(self, callee_type: CallableType, n: int,
                                        context: Context) -> None:
         callee_name = callable_name(callee_type)
@@ -1054,11 +1056,11 @@ class MessageBuilder:
         else:
             self.fail('Cannot infer function type argument', context)
 
-    @tracked()
+    @register()
     def invalid_var_arg(self, typ: Type, context: Context) -> None:
         self.fail('List or tuple expected as variable arguments', context)
 
-    @tracked()
+    @register()
     def invalid_keyword_var_arg(self, typ: Type, is_mapping: bool, context: Context) -> None:
         if isinstance(typ, Instance) and is_mapping:
             self.fail('Keywords must be strings', context)
@@ -1070,11 +1072,11 @@ class MessageBuilder:
                 'Argument after ** must be a mapping{}'.format(suffix),
                 context)
 
-    @tracked()
+    @register()
     def undefined_in_superclass(self, member: str, context: Context) -> None:
         self.fail('"{}" undefined in superclass'.format(member), context)
 
-    @tracked()
+    @register()
     def first_argument_for_super_must_be_type(self, actual: Type, context: Context) -> None:
         if isinstance(actual, Instance):
             # Don't include type of instance, because it can look confusingly like a type
@@ -1084,60 +1086,60 @@ class MessageBuilder:
             type_str = self.format(actual)
         self.fail('Argument 1 for "super" must be a type object; got {}'.format(type_str), context)
 
-    @tracked('wrong_number_of_str_format_args')
+    @register('wrong_number_of_str_format_args')
     def too_few_string_formatting_arguments(self, context: Context) -> None:
         self.fail('Not enough arguments for format string', context)
 
-    @tracked('wrong_number_of_str_format_args')
+    @register('wrong_number_of_str_format_args')
     def too_many_string_formatting_arguments(self, context: Context) -> None:
         self.fail('Not all arguments converted during string formatting', context)
 
-    @tracked()
+    @register()
     def unsupported_placeholder(self, placeholder: str, context: Context) -> None:
         self.fail('Unsupported format character \'%s\'' % placeholder, context)
 
-    @tracked()
+    @register()
     def string_interpolation_with_star_and_key(self, context: Context) -> None:
         self.fail('String interpolation contains both stars and mapping keys', context)
 
-    @tracked()
+    @register()
     def requires_int_or_char(self, context: Context) -> None:
         self.fail('%c requires int or char', context)
 
-    @tracked()
+    @register()
     def key_not_in_mapping(self, key: str, context: Context) -> None:
         self.fail('Key \'%s\' not found in mapping' % key, context)
 
-    @tracked()
+    @register()
     def string_interpolation_mixing_key_and_non_keys(self, context: Context) -> None:
         self.fail('String interpolation mixes specifier with and without mapping keys', context)
 
-    @tracked()
+    @register()
     def cannot_determine_type(self, name: str, context: Context) -> None:
         self.fail("Cannot determine type of '%s'" % name, context)
 
-    @tracked()
+    @register()
     def cannot_determine_type_in_base(self, name: str, base: str, context: Context) -> None:
         self.fail("Cannot determine type of '%s' in base class '%s'" % (name, base), context)
 
-    @tracked()
+    @register()
     def no_formal_self(self, name: str, item: CallableType, context: Context) -> None:
         self.fail('Attribute function "%s" with type %s does not accept self argument'
                   % (name, self.format(item)), context)
 
-    @tracked()
+    @register()
     def incompatible_self_argument(self, name: str, arg: Type, sig: CallableType,
                                    is_classmethod: bool, context: Context) -> None:
         kind = 'class attribute function' if is_classmethod else 'attribute function'
         self.fail('Invalid self argument %s to %s "%s" with type %s'
                   % (self.format(arg), kind, name, self.format(sig)), context)
 
-    @tracked()
+    @register()
     def incompatible_conditional_function_def(self, defn: FuncDef) -> None:
         self.fail('All conditional function variants must have identical '
                   'signatures', defn)
 
-    @tracked()
+    @register()
     def cannot_instantiate_abstract_class(self, class_name: str,
                                           abstract_attributes: List[str],
                                           context: Context) -> None:
@@ -1147,7 +1149,7 @@ class MessageBuilder:
                                    attrs),
                   context)
 
-    @tracked()
+    @register()
     def base_class_definitions_incompatible(self, name: str, base1: TypeInfo,
                                             base2: TypeInfo,
                                             context: Context) -> None:
@@ -1155,19 +1157,19 @@ class MessageBuilder:
                   'with definition in base class "{}"'.format(
                       name, base1.name(), base2.name()), context)
 
-    @tracked()
+    @register()
     def cannot_assign_to_method(self, context: Context) -> None:
         self.fail(CANNOT_ASSIGN_TO_METHOD, context)
 
-    @tracked()
+    @register()
     def cannot_assign_to_classvar(self, name: str, context: Context) -> None:
         self.fail('Cannot assign to class variable "%s" via instance' % name, context)
 
-    @tracked()
+    @register()
     def final_cannot_override_writable(self, name: str, ctx: Context) -> None:
         self.fail('Cannot override writable attribute "{}" with a final one'.format(name), ctx)
 
-    @tracked()
+    @register()
     def cannot_override_final(self, name: str, base_name: str, ctx: Context) -> None:
         self.fail('Cannot override final attribute "{}"'
                   ' (previously declared in base class "{}")'.format(name, base_name), ctx)
@@ -1180,21 +1182,21 @@ class MessageBuilder:
         kind = "attribute" if attr_assign else "name"
         self.fail('Cannot assign to final {} "{}"'.format(kind, name), ctx)
 
-    @tracked()
+    @register()
     def protocol_members_cannot_be_final(self, ctx: Context) -> None:
         self.fail("Protocol member cannot be final", ctx)
 
-    @tracked()
+    @register()
     def final_without_value(self, ctx: Context) -> None:
         self.fail("Final name must be initialized with a value", ctx)
 
-    @tracked()
+    @register()
     def read_only_property(self, name: str, type: TypeInfo,
                            context: Context) -> None:
         self.fail('Property "{}" defined in "{}" is read-only'.format(
             name, type.name()), context)
 
-    @tracked()
+    @register()
     def incompatible_typevar_value(self,
                                    callee: CallableType,
                                    typ: Type,
@@ -1205,26 +1207,26 @@ class MessageBuilder:
                                                     self.format(typ)),
                   context)
 
-    @tracked()
+    @register()
     def overload_inconsistently_applies_decorator(self, decorator: str, context: Context) -> None:
         self.fail(
             'Overload does not consistently use the "@{}" '.format(decorator)
             + 'decorator on all function signatures.',
             context)
 
-    @tracked()
+    @register()
     def overloaded_signatures_overlap(self, index1: int, index2: int, context: Context) -> None:
         self.fail('Overloaded function signatures {} and {} overlap with '
                   'incompatible return types'.format(index1, index2), context)
 
-    @tracked()
+    @register()
     def overloaded_signatures_partial_overlap(self, index1: int, index2: int,
                                               context: Context) -> None:
         self.fail('Overloaded function signatures {} and {} '.format(index1, index2)
                   + 'are partially overlapping: the two signatures may return '
                   + 'incompatible types given certain calls', context)
 
-    @tracked()
+    @register()
     def overloaded_signature_will_never_match(self, index1: int, index2: int,
                                               context: Context) -> None:
         self.fail(
@@ -1234,17 +1236,17 @@ class MessageBuilder:
                 index2=index2),
             context)
 
-    @tracked()
+    @register()
     def overloaded_signatures_typevar_specific(self, index: int, context: Context) -> None:
         self.fail('Overloaded function implementation cannot satisfy signature {} '.format(index) +
                   'due to inconsistencies in how they use type variables', context)
 
-    @tracked()
+    @register()
     def overloaded_signatures_arg_specific(self, index: int, context: Context) -> None:
         self.fail('Overloaded function implementation does not accept all possible arguments '
                   'of signature {}'.format(index), context)
 
-    @tracked()
+    @register()
     def overloaded_signatures_ret_specific(self, index: int, context: Context) -> None:
         self.fail('Overloaded function implementation cannot produce return type '
                   'of signature {}'.format(index), context)
@@ -1255,7 +1257,7 @@ class MessageBuilder:
     def warn_operand_was_from_union(self, side: str, original: Type, context: Context) -> None:
         self.note('{} operand is of type {}'.format(side, self.format(original)), context)
 
-    @tracked()
+    @register()
     def operator_method_signatures_overlap(
             self, reverse_class: TypeInfo, reverse_method: str, forward_class: Type,
             forward_method: str, context: Context) -> None:
@@ -1265,38 +1267,38 @@ class MessageBuilder:
                       forward_method, self.format(forward_class)),
                   context)
 
-    @tracked()
+    @register()
     def forward_operator_not_callable(
             self, forward_method: str, context: Context) -> None:
         self.fail('Forward operator "{}" is not callable'.format(
             forward_method), context)
 
-    @tracked()
+    @register()
     def signatures_incompatible(self, method: str, other_method: str,
                                 context: Context) -> None:
         self.fail('Signatures of "{}" and "{}" are incompatible'.format(
             method, other_method), context)
 
-    @tracked()
+    @register()
     def yield_from_invalid_operand_type(self, expr: Type, context: Context) -> Type:
         text = self.format(expr) if self.format(expr) != 'object' else expr
         self.fail('"yield from" can\'t be applied to {}'.format(text), context)
         return AnyType(TypeOfAny.from_error)
 
-    @tracked()
+    @register()
     def invalid_signature(self, func_type: Type, context: Context) -> None:
         self.fail('Invalid signature "{}"'.format(func_type), context)
 
-    @tracked()
+    @register()
     def invalid_signature_for_special_method(
             self, func_type: Type, context: Context, method_name: str) -> None:
         self.fail('Invalid signature "{}" for "{}"'.format(func_type, method_name), context)
 
-    @tracked()
+    @register()
     def reveal_type(self, typ: Type, context: Context) -> None:
         self.fail('Revealed type is \'{}\''.format(typ), context)
 
-    @tracked()
+    @register()
     def reveal_locals(self, type_map: Dict[str, Optional[Type]], context: Context) -> None:
         # To ensure that the output is predictable on Python < 3.6,
         # use an ordered dictionary sorted by variable name
@@ -1305,29 +1307,29 @@ class MessageBuilder:
         for line in ['{}: {}'.format(k, v) for k, v in sorted_locals.items()]:
             self.fail(line, context)
 
-    @tracked()
+    @register()
     def unsupported_type_type(self, item: Type, context: Context) -> None:
         self.fail('Unsupported type Type[{}]'.format(self.format(item)), context)
 
-    @tracked()
+    @register()
     def redundant_cast(self, typ: Type, context: Context) -> None:
         self.note('Redundant cast to {}'.format(self.format(typ)), context)
 
     # filtered by disallow_any_unimported
-    @tracked()
+    @register()
     def unimported_type_becomes_any(self, prefix: str, typ: Type, ctx: Context) -> None:
         self.fail("{} becomes {} due to an unfollowed import".format(prefix, self.format(typ)),
                   ctx)
 
-    @tracked()
+    @register()
     def need_annotation_for_var(self, node: SymbolNode, context: Context) -> None:
         self.fail("Need type annotation for '{}'".format(node.name()), context)
 
-    @tracked()
+    @register()
     def explicit_any(self, ctx: Context) -> None:
         self.fail('Explicit "Any" is not allowed', ctx)
 
-    @tracked()
+    @register()
     def unexpected_typeddict_keys(
             self,
             typ: TypedDictType,
@@ -1363,7 +1365,7 @@ class MessageBuilder:
             found = 'only {}'.format(found)
         self.fail('Expected {} but found {}'.format(expected, found), context)
 
-    @tracked()
+    @register()
     def typeddict_key_must_be_string_literal(
             self,
             typ: TypedDictType,
@@ -1372,7 +1374,7 @@ class MessageBuilder:
             'TypedDict key must be a string literal; expected one of {}'.format(
                 format_item_name_list(typ.items.keys())), context)
 
-    @tracked()
+    @register()
     def typeddict_key_not_found(
             self,
             typ: TypedDictType,
@@ -1384,7 +1386,7 @@ class MessageBuilder:
         else:
             self.fail("TypedDict {} has no key '{}'".format(self.format(typ), item_name), context)
 
-    @tracked()
+    @register()
     def typeddict_key_cannot_be_deleted(
             self,
             typ: TypedDictType,
@@ -1397,7 +1399,7 @@ class MessageBuilder:
             self.fail("Key '{}' of TypedDict {} cannot be deleted".format(
                 item_name, self.format(typ)), context)
 
-    @tracked()
+    @register()
     def type_arguments_not_allowed(self, context: Context) -> None:
         self.fail('Parameterized generics cannot be used with class or instance checks', context)
 
@@ -1408,14 +1410,14 @@ class MessageBuilder:
             message = 'Expression type contains "Any" (has type {})'.format(self.format(typ))
         self.fail(message, context)
 
-    @tracked()
+    @register()
     def incorrectly_returning_any(self, typ: Type, context: Context) -> None:
         message = 'Returning Any from function declared to return {}'.format(
             self.format(typ))
         self.warn(message, context)
 
     # filtered by disallow_any_decorated
-    @tracked()
+    @register()
     def untyped_decorated_function(self, typ: Type, context: Context) -> None:
         if isinstance(typ, AnyType):
             self.fail("Function is untyped after decorator transformation", context)
@@ -1424,11 +1426,11 @@ class MessageBuilder:
                 self.format(typ)), context)
 
     # filtered by disallow_untyped_decorators
-    @tracked()
+    @register()
     def typed_function_untyped_decorator(self, func_name: str, context: Context) -> None:
         self.fail('Untyped decorator makes function "{}" untyped'.format(func_name), context)
 
-    @tracked()
+    @register()
     def bad_proto_variance(self, actual: int, tvar_name: str, expected: int,
                            context: Context) -> None:
         msg = capitalize("{} type variable '{}' used in protocol where"
@@ -1437,22 +1439,22 @@ class MessageBuilder:
                                                       variance_string(expected)))
         self.fail(msg, context)
 
-    @tracked()
+    @register()
     def concrete_only_assign(self, typ: Type, context: Context) -> None:
         self.fail("Can only assign concrete classes to a variable of type {}"
                   .format(self.format(typ)), context)
 
-    @tracked()
+    @register()
     def concrete_only_call(self, typ: Type, context: Context) -> None:
         self.fail("Only concrete class can be given where {} is expected"
                   .format(self.format(typ)), context)
 
-    @tracked()
+    @register()
     def cannot_use_function_with_type(
             self, method_name: str, type_name: str, context: Context) -> None:
         self.fail("Cannot use {}() with a {} type".format(method_name, type_name), context)
 
-    @tracked()
+    @register()
     def issubclass_on_non_method_protocol(self, tp: TypeInfo, members: List[str],
                                           context: Context) -> None:
         self.fail("Only protocols that don't have non-method members can be"

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -15,6 +15,7 @@ from functools import wraps
 import re
 import difflib
 from textwrap import dedent
+from enum import Enum
 
 from typing import (
     cast, List, Dict, Any, Sequence, Iterable, Tuple, Set, Optional, Union, Deque, TypeVar,
@@ -43,129 +44,133 @@ T = TypeVar('T', bound=Callable[..., Any])
 
 # Type checker error message constants --
 
-MISSING_RETURN_STATEMENT = 'Missing return statement'  # type: Final
-INVALID_IMPLICIT_RETURN = 'Implicit return in function which does not return'  # type: Final
-INCOMPATIBLE_RETURN_VALUE_TYPE = 'Incompatible return value type'  # type: Final
-RETURN_VALUE_EXPECTED = 'Return value expected'  # type: Final
-NO_RETURN_EXPECTED = 'Return statement in function which does not return'  # type: Final
-INVALID_EXCEPTION = 'Exception must be derived from BaseException'  # type: Final
-INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'  # type: Final
-RETURN_IN_ASYNC_GENERATOR = "'return' with value in async generator is not allowed"  # type: Final
-INVALID_RETURN_TYPE_FOR_GENERATOR = \
-    'The return type of a generator function should be "Generator"' \
-    ' or one of its supertypes'  # type: Final
-INVALID_RETURN_TYPE_FOR_ASYNC_GENERATOR = \
-    'The return type of an async generator function should be "AsyncGenerator" or one of its ' \
-    'supertypes'  # type: Final
-INVALID_GENERATOR_RETURN_ITEM_TYPE = \
-    'The return type of a generator function must be None in' \
-    ' its third type parameter in Python 2'  # type: Final
-YIELD_VALUE_EXPECTED = 'Yield value expected'  # type: Final
-INCOMPATIBLE_TYPES = 'Incompatible types'  # type: Final
-INCOMPATIBLE_TYPES_IN_ASSIGNMENT = 'Incompatible types in assignment'  # type: Final
-INCOMPATIBLE_REDEFINITION = 'Incompatible redefinition'  # type: Final
-INCOMPATIBLE_TYPES_IN_AWAIT = 'Incompatible types in "await"'  # type: Final
-INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AENTER = \
-    'Incompatible types in "async with" for "__aenter__"'  # type: Final
-INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AEXIT = \
-    'Incompatible types in "async with" for "__aexit__"'  # type: Final
-INCOMPATIBLE_TYPES_IN_ASYNC_FOR = 'Incompatible types in "async for"'  # type: Final
+CANNOT_ASSIGN_TO_METHOD = 'Cannot assign to a method'
+INCOMPATIBLE_TYPEVAR_VALUE = 'Value of type variable "{}" of {} cannot be {}'
 
-INCOMPATIBLE_TYPES_IN_YIELD = 'Incompatible types in "yield"'  # type: Final
-INCOMPATIBLE_TYPES_IN_YIELD_FROM = 'Incompatible types in "yield from"'  # type: Final
-INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION = \
-    'Incompatible types in string interpolation'  # type: Final
-INVALID_TUPLE_INDEX_TYPE = 'Invalid tuple index type'  # type: Final
-TUPLE_INDEX_OUT_OF_RANGE = 'Tuple index out of range'  # type: Final
-INVALID_SLICE_INDEX = 'Slice index must be an integer or None'  # type: Final
-CANNOT_INFER_LAMBDA_TYPE = 'Cannot infer type of lambda'  # type: Final
-CANNOT_INFER_ITEM_TYPE = 'Cannot infer iterable item type'  # type: Final
-CANNOT_ACCESS_INIT = 'Cannot access "__init__" directly'  # type: Final
-CANNOT_ASSIGN_TO_METHOD = 'Cannot assign to a method'  # type: Final
-CANNOT_ASSIGN_TO_TYPE = 'Cannot assign to a type'  # type: Final
-INCONSISTENT_ABSTRACT_OVERLOAD = \
-    'Overloaded method has both abstract and non-abstract variants'  # type: Final
-MULTIPLE_OVERLOADS_REQUIRED = 'Single overload definition, multiple required'  # type: Final
-READ_ONLY_PROPERTY_OVERRIDES_READ_WRITE = \
-    'Read-only property cannot override read-write property'  # type: Final
-FORMAT_REQUIRES_MAPPING = 'Format requires a mapping'  # type: Final
-RETURN_TYPE_CANNOT_BE_CONTRAVARIANT = \
-    "Cannot use a contravariant type variable as return type"  # type: Final
-FUNCTION_PARAMETER_CANNOT_BE_COVARIANT = \
-    "Cannot use a covariant type variable as a parameter"  # type: Final
-INCOMPATIBLE_IMPORT_OF = "Incompatible import of"  # type: Final
-FUNCTION_TYPE_EXPECTED = "Function is missing a type annotation"  # type: Final
-ONLY_CLASS_APPLICATION = "Type application is only supported for generic classes"  # type: Final
-RETURN_TYPE_EXPECTED = "Function is missing a return type annotation"  # type: Final
-ARGUMENT_TYPE_EXPECTED = \
-    "Function is missing a type annotation for one or more arguments"  # type: Final
-KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE = \
-    'Keyword argument only valid with "str" key type in call to "dict"'  # type: Final
-ALL_MUST_BE_SEQ_STR = 'Type of __all__ must be {}, not {}'  # type: Final
-INVALID_TYPEDDICT_ARGS = \
-    'Expected keyword arguments, {...}, or dict(...) in TypedDict constructor'  # type: Final
-TYPEDDICT_KEY_MUST_BE_STRING_LITERAL = \
-    'Expected TypedDict key to be string literal'  # type: Final
-MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'  # type: Final
-DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'  # type: Final
-DESCRIPTOR_SET_NOT_CALLABLE = "{}.__set__ is not callable"  # type: Final
-DESCRIPTOR_GET_NOT_CALLABLE = "{}.__get__ is not callable"  # type: Final
-MODULE_LEVEL_GETATTRIBUTE = '__getattribute__ is not valid at the module level'  # type: Final
 
-# Generic
-GENERIC_INSTANCE_VAR_CLASS_ACCESS = \
-    'Access to generic instance variables via class is ambiguous'  # type: Final
-BARE_GENERIC = 'Missing type parameters for generic type'  # type: Final
-IMPLICIT_GENERIC_ANY_BUILTIN = \
-    'Implicit generic "Any". Use "{}" and specify generic parameters'  # type: Final
+class ErrorCodes(Enum):
+    MISSING_RETURN_STATEMENT = 'Missing return statement'
+    INVALID_IMPLICIT_RETURN = 'Implicit return in function which does not return'
 
-# TypeVar
-INCOMPATIBLE_TYPEVAR_VALUE = 'Value of type variable "{}" of {} cannot be {}'  # type: Final
-CANNOT_USE_TYPEVAR_AS_EXPRESSION = \
-    'Type variable "{}.{}" cannot be used as an expression'  # type: Final
+    INCOMPATIBLE_RETURN_VALUE_TYPE = 'Incompatible return value type'
+    RETURN_VALUE_EXPECTED = 'Return value expected'
+    NO_RETURN_EXPECTED = 'Return statement in function which does not return'
+    INVALID_EXCEPTION = 'Exception must be derived from BaseException'
+    INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'
+    RETURN_IN_ASYNC_GENERATOR = "'return' with value in async generator is not allowed"
+    INVALID_RETURN_TYPE_FOR_GENERATOR = \
+        'The return type of a generator function should be "Generator"' \
+        ' or one of its supertypes'
+    INVALID_RETURN_TYPE_FOR_ASYNC_GENERATOR = \
+        'The return type of an async generator function should be "AsyncGenerator" or one of its ' \
+        'supertypes'
+    INVALID_GENERATOR_RETURN_ITEM_TYPE = \
+        'The return type of a generator function must be None in' \
+        ' its third type parameter in Python 2'
+    YIELD_VALUE_EXPECTED = 'Yield value expected'
+    INCOMPATIBLE_TYPES = 'Incompatible types'
+    INCOMPATIBLE_REDEFINITION = 'Incompatible redefinition'
+    INCOMPATIBLE_TYPES_IN_ASSIGNMENT = 'Incompatible types in assignment'
+    INCOMPATIBLE_TYPES_IN_AWAIT = 'Incompatible types in "await"'
+    INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AENTER = \
+        'Incompatible types in "async with" for "__aenter__"'
+    INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AEXIT = \
+        'Incompatible types in "async with" for "__aexit__"'
+    INCOMPATIBLE_TYPES_IN_ASYNC_FOR = 'Incompatible types in "async for"'
 
-# Super
-TOO_MANY_ARGS_FOR_SUPER = 'Too many arguments for "super"'  # type: Final
-TOO_FEW_ARGS_FOR_SUPER = 'Too few arguments for "super"'  # type: Final
-SUPER_WITH_SINGLE_ARG_NOT_SUPPORTED = '"super" with a single argument not supported'  # type: Final
-UNSUPPORTED_ARG_1_FOR_SUPER = 'Unsupported argument 1 for "super"'  # type: Final
-UNSUPPORTED_ARG_2_FOR_SUPER = 'Unsupported argument 2 for "super"'  # type: Final
-SUPER_VARARGS_NOT_SUPPORTED = 'Varargs not supported with "super"'  # type: Final
-SUPER_POSITIONAL_ARGS_REQUIRED = '"super" only accepts positional arguments'  # type: Final
-SUPER_ARG_2_NOT_INSTANCE_OF_ARG_1 = \
-    'Argument 2 for "super" not an instance of argument 1'  # type: Final
-SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED = \
-    'super() outside of a method is not supported'  # type: Final
-SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED = \
-    'super() requires one or more positional arguments in enclosing function'  # type: Final
+    INCOMPATIBLE_TYPES_IN_YIELD = 'Incompatible types in "yield"'
+    INCOMPATIBLE_TYPES_IN_YIELD_FROM = 'Incompatible types in "yield from"'
+    INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION = \
+        'Incompatible types in string interpolation'
+    INVALID_TUPLE_INDEX_TYPE = 'Invalid tuple index type'
+    TUPLE_INDEX_OUT_OF_RANGE = 'Tuple index out of range'
+    INVALID_SLICE_INDEX = 'Slice index must be an integer or None'
+    CANNOT_INFER_LAMBDA_TYPE = 'Cannot infer type of lambda'
+    CANNOT_INFER_ITEM_TYPE = 'Cannot infer iterable item type'
+    CANNOT_ACCESS_INIT = 'Cannot access "__init__" directly'
+    CANNOT_ASSIGN_TO_TYPE = 'Cannot assign to a type'
+    INCONSISTENT_ABSTRACT_OVERLOAD = \
+        'Overloaded method has both abstract and non-abstract variants'
+    MULTIPLE_OVERLOADS_REQUIRED = 'Single overload definition, multiple required'
+    READ_ONLY_PROPERTY_OVERRIDES_READ_WRITE = \
+        'Read-only property cannot override read-write property'
+    FORMAT_REQUIRES_MAPPING = 'Format requires a mapping'
+    RETURN_TYPE_CANNOT_BE_CONTRAVARIANT = \
+        "Cannot use a contravariant type variable as return type"
+    FUNCTION_PARAMETER_CANNOT_BE_COVARIANT = \
+        "Cannot use a covariant type variable as a parameter"
+    INCOMPATIBLE_IMPORT_OF = "Incompatible import of"
+    FUNCTION_TYPE_EXPECTED = "Function is missing a type annotation"
+    ONLY_CLASS_APPLICATION = "Type application is only supported for generic classes"
+    RETURN_TYPE_EXPECTED = "Function is missing a return type annotation"
+    ARGUMENT_TYPE_EXPECTED = \
+        "Function is missing a type annotation for one or more arguments"
+    KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE = \
+        'Keyword argument only valid with "str" key type in call to "dict"'
+    ALL_MUST_BE_SEQ_STR = 'Type of __all__ must be {}, not {}'
+    INVALID_TYPEDDICT_ARGS = \
+        'Expected keyword arguments, {...}, or dict(...) in TypedDict constructor'
+    TYPEDDICT_KEY_MUST_BE_STRING_LITERAL = \
+        'Expected TypedDict key to be string literal'
+    MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'
+    DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'
+    DESCRIPTOR_SET_NOT_CALLABLE = "{}.__set__ is not callable"
+    DESCRIPTOR_GET_NOT_CALLABLE = "{}.__get__ is not callable"
+    MODULE_LEVEL_GETATTRIBUTE = '__getattribute__ is not valid at the module level'
 
-# Self-type
-MISSING_OR_INVALID_SELF_TYPE = \
-    "Self argument missing for a non-static method (or an invalid type for self)"  # type: Final
-ERASED_SELF_TYPE_NOT_SUPERTYPE = \
-    'The erased type of self "{}" is not a supertype of its class "{}"'  # type: Final
-INVALID_SELF_TYPE_OR_EXTRA_ARG = \
-    "Invalid type for self, or extra argument type in function annotation"  # type: Final
+    # Generic
+    GENERIC_INSTANCE_VAR_CLASS_ACCESS = \
+        'Access to generic instance variables via class is ambiguous'
+    BARE_GENERIC = 'Missing type parameters for generic type'
+    IMPLICIT_GENERIC_ANY_BUILTIN = \
+        'Implicit generic "Any". Use "{}" and specify generic parameters'
 
-# Final
-CANNOT_INHERIT_FROM_FINAL = 'Cannot inherit from final class "{}"'  # type: Final
-DEPENDENT_FINAL_IN_CLASS_BODY = \
-    "Final name declared in class body cannot depend on type variables"  # type: Final
-CANNOT_ACCESS_FINAL_INSTANCE_ATTR = \
-    'Cannot access final instance attribute "{}" on class object'  # type: Final
+    # TypeVar
+    CANNOT_USE_TYPEVAR_AS_EXPRESSION = \
+        'Type variable "{}.{}" cannot be used as an expression'
 
-# ClassVar
-CANNOT_OVERRIDE_INSTANCE_VAR = \
-    'Cannot override instance variable (previously declared on base class "{}") with class ' \
-    'variable'  # type: Final
-CANNOT_OVERRIDE_CLASS_VAR = \
-    'Cannot override class variable (previously declared on base class "{}") with instance ' \
-    'variable'  # type: Final
+    # Super
+    TOO_MANY_ARGS_FOR_SUPER = 'Too many arguments for "super"'
+    TOO_FEW_ARGS_FOR_SUPER = 'Too few arguments for "super"'
+    SUPER_WITH_SINGLE_ARG_NOT_SUPPORTED = '"super" with a single argument not supported'
+    UNSUPPORTED_ARG_1_FOR_SUPER = 'Unsupported argument 1 for "super"'
+    UNSUPPORTED_ARG_2_FOR_SUPER = 'Unsupported argument 2 for "super"'
+    SUPER_VARARGS_NOT_SUPPORTED = 'Varargs not supported with "super"'
+    SUPER_POSITIONAL_ARGS_REQUIRED = '"super" only accepts positional arguments'
+    SUPER_ARG_2_NOT_INSTANCE_OF_ARG_1 = \
+        'Argument 2 for "super" not an instance of argument 1'
+    SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED = \
+        'super() outside of a method is not supported'
+    SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED = \
+        'super() requires one or more positional arguments in enclosing function'
 
-# Protocol
-RUNTIME_PROTOCOL_EXPECTED = \
-    'Only @runtime protocols can be used with instance and class checks'  # type: Final
-CANNOT_INSTANTIATE_PROTOCOL = 'Cannot instantiate protocol class "{}"'  # type: Final
+    # Self-type
+    MISSING_OR_INVALID_SELF_TYPE = \
+        "Self argument missing for a non-static method (or an invalid type for self)"
+    ERASED_SELF_TYPE_NOT_SUPERTYPE = \
+        'The erased type of self "{}" is not a supertype of its class "{}"'
+    INVALID_SELF_TYPE_OR_EXTRA_ARG = \
+        "Invalid type for self, or extra argument type in function annotation"
+
+    # Final
+    CANNOT_INHERIT_FROM_FINAL = 'Cannot inherit from final class "{}"'
+    DEPENDENT_FINAL_IN_CLASS_BODY = \
+        "Final name declared in class body cannot depend on type variables"
+    CANNOT_ACCESS_FINAL_INSTANCE_ATTR = \
+        'Cannot access final instance attribute "{}" on class object'
+
+    # ClassVar
+    CANNOT_OVERRIDE_INSTANCE_VAR = \
+        'Cannot override instance variable (previously declared on base class "{}") with class ' \
+        'variable'
+    CANNOT_OVERRIDE_CLASS_VAR = \
+        'Cannot override class variable (previously declared on base class "{}") with instance ' \
+        'variable'
+
+    # Protocol
+    RUNTIME_PROTOCOL_EXPECTED = \
+        'Only @runtime protocols can be used with instance and class checks'
+    CANNOT_INSTANTIATE_PROTOCOL = 'Cannot instantiate protocol class "{}"'
 
 
 ARG_CONSTRUCTOR_NAMES = {
@@ -290,10 +295,18 @@ class MessageBuilder:
                                origin_line=origin.get_line() if origin else None,
                                id=msg_id)
 
-    def fail(self, msg: str, context: Optional[Context], file: Optional[str] = None,
-             origin: Optional[Context] = None) -> None:
+    def fail(self, msg: ErrorCodes, context: Optional[Context],
+             format: Optional[Tuple[Any, ...]] = None,
+             file: Optional[str] = None, origin: Optional[Context] = None) -> None:
         """Report an error message (unless disabled)."""
-        self.report(msg, context, 'error', file=file, origin=origin)
+        # FIXME: remove
+        if isinstance(msg, str):
+            val = msg
+        else:
+            val = msg.value
+        if format is not None:
+            val = val.format(format)
+        self.report(val, context, 'error', file=file, origin=origin)
 
     def note(self, msg: str, context: Context, file: Optional[str] = None,
              origin: Optional[Context] = None, offset: int = 0) -> None:
@@ -704,7 +717,7 @@ class MessageBuilder:
                     msg = '{} (expression has type {}, target has type {})'
                     arg_type_str, callee_type_str = self.format_distinctly(arg_type,
                                                                            callee.arg_types[n - 1])
-                    self.fail(msg.format(INCOMPATIBLE_TYPES_IN_ASSIGNMENT,
+                    self.fail(msg.format(ErrorCodes.INCOMPATIBLE_TYPES_IN_ASSIGNMENT.value,
                                          arg_type_str, callee_type_str),
                               context)
                 return

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -206,6 +206,7 @@ class Options:
         # -- experimental options --
         self.shadow_file = None  # type: Optional[List[List[str]]]
         self.show_column_numbers = False  # type: bool
+        self.show_error_codes = False  # type: bool
         self.dump_graph = False
         self.dump_deps = False
         self.logical_deps = False

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -230,7 +230,7 @@ def typed_dict_pop_callback(ctx: MethodContext) -> Type:
             and len(ctx.arg_types[0]) == 1):
         key = try_getting_str_literal(ctx.args[0][0], ctx.arg_types[0][0])
         if key is None:
-            ctx.api.fail(messages.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, ctx.context)
+            ctx.api.fail(messages.ErrorCodes.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, ctx.context)
             return AnyType(TypeOfAny.from_error)
 
         if key in ctx.type.required_keys:
@@ -276,7 +276,7 @@ def typed_dict_setdefault_callback(ctx: MethodContext) -> Type:
             and len(ctx.arg_types[0]) == 1):
         key = try_getting_str_literal(ctx.args[0][0], ctx.arg_types[0][0])
         if key is None:
-            ctx.api.fail(messages.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, ctx.context)
+            ctx.api.fail(messages.ErrorCodes.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, ctx.context)
             return AnyType(TypeOfAny.from_error)
 
         value_type = ctx.type.items.get(key)
@@ -301,7 +301,7 @@ def typed_dict_delitem_callback(ctx: MethodContext) -> Type:
             and len(ctx.arg_types[0]) == 1):
         key = try_getting_str_literal(ctx.args[0][0], ctx.arg_types[0][0])
         if key is None:
-            ctx.api.fail(messages.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, ctx.context)
+            ctx.api.fail(messages.ErrorCodes.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, ctx.context)
             return AnyType(TypeOfAny.from_error)
 
         if key in ctx.type.required_keys:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1827,7 +1827,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         if self.loop_depth > 0:
             self.fail("Cannot use Final inside a loop", s)
         if self.type and self.type.is_protocol:
-            self.msg.protocol_members_cant_be_final(s)
+            self.msg.protocol_members_cannot_be_final(s)
         if (isinstance(s.rvalue, TempNode) and s.rvalue.no_rhs and
                 not self.is_stub_file and not self.is_class_scope()):
             if not invalid_bare_final:  # Skip extra error messages.
@@ -2622,7 +2622,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 if self.is_class_scope():
                     assert self.type is not None, "No type set at class scope"
                     if self.type.is_protocol:
-                        self.msg.protocol_members_cant_be_final(d)
+                        self.msg.protocol_members_cannot_be_final(d)
                     else:
                         dec.func.is_final = True
                         dec.var.is_final = True

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -62,7 +62,7 @@ from mypy.tvar_scope import TypeVarScope
 from mypy.typevars import fill_typevars
 from mypy.visitor import NodeVisitor
 from mypy.errors import Errors, report_internal_error
-from mypy.messages import CANNOT_ASSIGN_TO_TYPE, MessageBuilder
+from mypy.messages import ErrorCodes, MessageBuilder
 from mypy.types import (
     FunctionLike, UnboundType, TypeVarDef, TupleType, UnionType, StarType, function_type,
     CallableType, Overloaded, Instance, Type, AnyType, LiteralType, LiteralValue,
@@ -2254,7 +2254,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         if isinstance(node, TypeVarExpr):
             self.fail('Invalid assignment target', ctx)
         elif isinstance(node, TypeInfo):
-            self.fail(CANNOT_ASSIGN_TO_TYPE, ctx)
+            self.fail(ErrorCodes.CANNOT_ASSIGN_TO_TYPE, ctx)
 
     def store_declared_types(self, lvalue: Lvalue, typ: Type) -> None:
         if isinstance(typ, StarType) and not isinstance(lvalue, StarExpr):

--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -12,6 +12,7 @@ from mypy.nodes import (
 )
 from mypy.semanal_shared import SemanticAnalyzerInterface
 from mypy.options import Options
+from mypy.messages import ErrorCodes
 
 
 class EnumCallAnalyzer:
@@ -157,5 +158,5 @@ class EnumCallAnalyzer:
 
     # Helpers
 
-    def fail(self, msg: str, ctx: Context) -> None:
+    def fail(self, msg: ErrorCodes, ctx: Context) -> None:
         self.api.fail(msg, ctx)

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -14,7 +14,7 @@ from mypy.semanal_shared import SemanticAnalyzerInterface
 from mypy.options import Options
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.typeanal import check_for_explicit_any, has_any_from_unimported_type
-from mypy.messages import MessageBuilder
+from mypy.messages import MessageBuilder, ErrorCodes
 
 
 class NewTypeAnalyzer:
@@ -152,5 +152,5 @@ class NewTypeAnalyzer:
     def make_argument(self, name: str, type: Type) -> Argument:
         return Argument(Var(name), type, None, ARG_POS)
 
-    def fail(self, msg: str, ctx: Context) -> None:
+    def fail(self, msg: ErrorCodes, ctx: Context) -> None:
         self.api.fail(msg, ctx)

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -501,7 +501,7 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
 
         for t in collect_any_types(typ):
             if t.type_of_any == TypeOfAny.from_omitted_generics:
-                self.fail(messages.BARE_GENERIC, t)
+                self.fail(messages.ErrorCodes.BARE_GENERIC, t)
 
     def lookup_qualified(self, name: str, ctx: Context,
                          suppress_errors: bool = False) -> Optional[SymbolTableNode]:
@@ -514,7 +514,7 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
             self, node: Optional[SymbolTableNode]) -> Optional[SymbolTableNode]:
         return self.sem.dereference_module_cross_ref(node)
 
-    def fail(self, msg: str, ctx: Context, serious: bool = False, *,
+    def fail(self, msg: messages.ErrorCodes, ctx: Context, serious: bool = False, *,
              blocker: bool = False) -> None:
         self.sem.fail(msg, ctx, serious, blocker=blocker)
 
@@ -780,5 +780,5 @@ class TypeVariableChecker(TypeTranslator):
                 else:
                     class_name = '"{}"'.format(type.name())
                     actual_type_name = '"{}"'.format(actual.type.name())
-                    self.fail(messages.INCOMPATIBLE_TYPEVAR_VALUE.format(
+                    self.fail(messages.ErrorCodes.INCOMPATIBLE_TYPEVAR_VALUE.format(
                         arg_name, class_name, actual_type_name), context)

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -10,6 +10,7 @@ from mypy.nodes import (
 from mypy.util import correct_relative_import
 from mypy.types import Type, FunctionLike, Instance
 from mypy.tvar_scope import TypeVarScope
+from mypy.messages import ErrorCodes
 
 MYPY = False
 if False:
@@ -43,7 +44,7 @@ class SemanticAnalyzerCoreInterface:
         raise NotImplementedError
 
     @abstractmethod
-    def fail(self, msg: str, ctx: Context, serious: bool = False, *,
+    def fail(self, msg: ErrorCodes, ctx: Context, serious: bool = False, *,
              blocker: bool = False) -> None:
         raise NotImplementedError
 


### PR DESCRIPTION
Adds `--show-error-codes` for tagging known error messages (and their notes) with error codes.  This is a stepping stone toward native message filtering (#2417), but it is useful on its own for users who want to implement their  own basic message filtering without relying on brittle regex against messages.   Also adds `--list-error-codes` to get a list of all known error codes. 


### Design goal

Provide a way of registering message ids that is:
  1. accessible from `main`, so that they can be listed with `--list-error-codes`
  2. concise
  3. able to handle the 3 types of error messages in a fairly consistent way:
    1. static messages, with no args to format:  currently have constants in `mypy.messages`
    2. messages with basic string args to format: currently have constants in `mypy.messages` (mostly)
    3. messages with more complex formatting:  currently have methods on `MessageBuilder`
  4. type safe for the code reporting the error, to avoid mistakes with the necessary arguments for the given message type

### Current Design

The design that I settled on is this:
- convert all messages to methods of `MessageBuilder`
- use a `@tracked` decorator to identify which methods emit messages which should be tracked
  - by default, the name of the method is the message id, but this can be overridden
  - multiple methods can have the same id, which places them all into the same group, which can be filtered together

### Questions
- naming:  I was a bit non-committal on the terminology to use: "message id", "error code"?  Internally I went with "message id", but the cli uses "error code"
- should there be a less verbose way of tracking constant error messages?  I created a descriptor-based prototype of this that I did not include, which allowed simple messages to be added to `MessageBuilder` like this:
  ```python
    no_return_exepected = ErrorReporter('No return value expected')
    invalid_implicit_return = ErrorReporter('Implicit return in function which does not return')
  ```
  this would be called like a normal `MessageBuilder` failure message:  `self.msg.invalid_implicit_return(ctx)`.  I was concerned it was a bit too magical. 

### What's next
This PR is not complete.  My idea is to finish converting message constants to `MessageBuilder` methods, as I already have with `no_return_exepected` and `must_have_none_return_type`, but  I wanted to get feedback on the design before doing this tedious work.

Once this is complete we can begin expanding tracked messages and adding native filtering of tracked messages.
