### PR TITLE
Fix dmypy run when no target given

### DIFF
--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -1,6 +1,6 @@
 """Client for mypy daemon mode.
 
-Highly experimental!  Only supports UNIX-like systems.
+Experimental!
 
 This manages a daemon process which keeps useful state in memory
 rather than having to read it back from disk on each run.

--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -1,7 +1,5 @@
 """Client for mypy daemon mode.
 
-Experimental!
-
 This manages a daemon process which keeps useful state in memory
 rather than having to read it back from disk on each run.
 """

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -4,6 +4,7 @@ This implements a daemon process which keeps useful state in memory
 to enable fine-grained incremental reprocessing of changes.
 """
 
+import argparse
 import base64
 import io
 import json
@@ -278,7 +279,9 @@ class Server:
                     ['-i'] + list(args),
                     require_targets=True,
                     server_options=True,
-                    fscache=self.fscache)
+                    fscache=self.fscache,
+                    program='dmypy',
+                    header=argparse.SUPPRESS)
             # Signal that we need to restart if the options have changed
             if self.options_snapshot != options.snapshot():
                 return {'restart': 'configuration changed'}

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -1,7 +1,5 @@
 """Server for mypy daemon mode.
 
-Only supports UNIX-like systems.
-
 This implements a daemon process which keeps useful state in memory
 to enable fine-grained incremental reprocessing of changes.
 """

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -297,6 +297,8 @@ def process_options(args: List[str],
                     require_targets: bool = True,
                     server_options: bool = False,
                     fscache: Optional[FileSystemCache] = None,
+                    program: str = 'mypy',
+                    header: str = HEADER,
                     ) -> Tuple[List[BuildSource], Options]:
     """Parse command line arguments.
 
@@ -304,8 +306,8 @@ def process_options(args: List[str],
     call fscache.set_package_root() to set the cache's package root.
     """
 
-    parser = argparse.ArgumentParser(prog='mypy',
-                                     usage=HEADER,
+    parser = argparse.ArgumentParser(prog=program,
+                                     usage=header,
                                      description=DESCRIPTION,
                                      epilog=FOOTER,
                                      fromfile_prefix_chars='@',

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -10,8 +10,10 @@ from typing import TypeVar, List, Tuple, Optional, Dict, Sequence, TextIO
 
 MYPY = False
 if MYPY:
-    from typing import Type
+    from typing import Type, ContextManager
     from typing_extensions import Final
+else:
+    ContextManager = object
 
 T = TypeVar('T')
 
@@ -262,7 +264,7 @@ def hard_exit(status: int = 0) -> None:
 # The following is a backport of stream redirect utilities from Lib/contextlib.py
 
 
-class _RedirectStream(contextlib.AbstractContextManager):
+class _RedirectStream(ContextManager):
 
     _stream = None  # type: str
 

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -1,10 +1,12 @@
 """Utility functions with no non-trivial dependencies."""
+import contextlib
 import os
 import pathlib
 import re
 import subprocess
 import sys
-from typing import TypeVar, List, Tuple, Optional, Dict, Sequence
+from types import TracebackType
+from typing import TypeVar, List, Tuple, Optional, Dict, Sequence, TextIO
 
 MYPY = False
 if MYPY:
@@ -255,3 +257,49 @@ def hard_exit(status: int = 0) -> None:
     sys.stdout.flush()
     sys.stderr.flush()
     os._exit(status)
+
+
+# The following is a backport of stream redirect utilities from Lib/contextlib.py
+
+
+class _RedirectStream(contextlib.AbstractContextManager):
+
+    _stream = None  # type: str
+
+    def __init__(self, new_target: TextIO) -> None:
+        self._new_target = new_target
+        # We use a list of old targets to make this CM re-entrant
+        self._old_targets = []  # type: List[TextIO]
+
+    def __enter__(self) -> TextIO:
+        self._old_targets.append(getattr(sys, self._stream))
+        setattr(sys, self._stream, self._new_target)
+        return self._new_target
+
+    def __exit__(self,
+                 exc_ty: 'Optional[Type[BaseException]]' = None,
+                 exc_val: Optional[BaseException] = None,
+                 exc_tb: Optional[TracebackType] = None,
+                 ) -> bool:
+        setattr(sys, self._stream, self._old_targets.pop())
+        return False
+
+
+class redirect_stdout(_RedirectStream):
+    """Context manager for temporarily redirecting stdout to another file.
+        # How to send help() to stderr
+        with redirect_stdout(sys.stderr):
+            help(dir)
+        # How to write help() to a file
+        with open('help.txt', 'w') as f:
+            with redirect_stdout(f):
+                help(pow)
+    """
+
+    _stream = "stdout"
+
+
+class redirect_stderr(_RedirectStream):
+    """Context manager for temporarily redirecting stderr to another file."""
+
+    _stream = "stderr"

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -262,7 +262,7 @@ def hard_exit(status: int = 0) -> None:
 # The following is a backport of stream redirect utilities from Lib/contextlib.py
 
 
-class _RedirectStream(contextlib.AbstractContextManager):
+class _RedirectStream:
 
     _stream = None  # type: str
 

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -10,10 +10,8 @@ from typing import TypeVar, List, Tuple, Optional, Dict, Sequence, TextIO
 
 MYPY = False
 if MYPY:
-    from typing import Type, ContextManager
+    from typing import Type
     from typing_extensions import Final
-else:
-    ContextManager = object
 
 T = TypeVar('T')
 
@@ -264,7 +262,7 @@ def hard_exit(status: int = 0) -> None:
 # The following is a backport of stream redirect utilities from Lib/contextlib.py
 
 
-class _RedirectStream(ContextManager):
+class _RedirectStream(contextlib.AbstractContextManager):
 
     _stream = None  # type: str
 

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -260,6 +260,7 @@ def hard_exit(status: int = 0) -> None:
 
 
 # The following is a backport of stream redirect utilities from Lib/contextlib.py
+# We need this for 3.4 support. They can be removed in March 2019!
 
 
 class _RedirectStream:

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -122,3 +122,13 @@ Daemon stopped
 import bar
 [file bar.py]
 pass
+
+[case testDaemonRunNoTarget]
+$ dmypy run -- --follow-imports=error
+Daemon started
+usage: mypy [-h] [-v] [-V] [more options; see below]
+            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
+mypy: error: Missing target module, package, files, or command.
+== Return code: 2
+$ dmypy stop
+Daemon stopped

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -126,9 +126,7 @@ pass
 [case testDaemonRunNoTarget]
 $ dmypy run -- --follow-imports=error
 Daemon started
-usage: mypy [-h] [-v] [-V] [more options; see below]
-            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
-mypy: error: Missing target module, package, files, or command.
+dmypy: error: Missing target module, package, files, or command.
 == Return code: 2
 $ dmypy stop
 Daemon stopped

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -126,7 +126,7 @@ pass
 [case testDaemonRunNoTarget]
 $ dmypy run -- --follow-imports=error
 Daemon started
-dmypy: error: Missing target module, package, files, or command.
+mypy-daemon: error: Missing target module, package, files, or command.
 == Return code: 2
 $ dmypy stop
 Daemon stopped


### PR DESCRIPTION
`dmypy run` without a target given will cause the daemon to die unexpectedly on calling `mypy.main.process_options` with improper arguments.

This catches the `SystemExit` the argument parser throws and captures `sys.stderr` for the output of the parser. I had to backport redirect_stderr since that is not available in 3.4, but the backport can be removed in a couple of months when we drop support for 3.4.

I'm not entirely sure if passing the way I'm passing the error messages is a good idea or not, but it certainly is better than dying with just `[WinError 233] No process is on the other end of the pipe`.