### PR TITLE
Add the specified Python version and platform to junit.xml

### DIFF
--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -356,7 +356,9 @@ def check_output(response: Dict[str, Any], verbose: bool,
         # Lazy import so this import doesn't slow things down when not writing junit
         from mypy.util import write_junit_xml
         messages = (out + err).splitlines()
-        write_junit_xml(response['roundtrip_time'], bool(err), messages, junit_xml)
+        # NOTE: We don't have access to the selected Python version and platform here
+        write_junit_xml(response['roundtrip_time'], bool(err), messages, junit_xml,
+                        "mypy-daemon")
     if perf_stats_file:
         telemetry = response.get('stats', {})
         with open(perf_stats_file, 'w') as f:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -101,7 +101,10 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
               file=sys.stderr)
     if options.junit_xml:
         t1 = time.time()
-        util.write_junit_xml(t1 - t0, serious, messages, options.junit_xml)
+        util.write_junit_xml(t1 - t0, serious, messages, options.junit_xml,
+                             "mypy-%d.%d-%s" % (options.python_version[0],
+                                                options.python_version[1],
+                                                options.platform))
 
     if MEM_PROFILE:
         from mypy.memprofile import print_memory_profile

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -119,37 +119,38 @@ def try_find_python2_interpreter() -> Optional[str]:
 
 
 PASS_TEMPLATE = """<?xml version="1.0" encoding="utf-8"?>
-<testsuite errors="0" failures="0" name="mypy" skips="0" tests="1" time="{time:.3f}">
-  <testcase classname="mypy" file="mypy" line="1" name="mypy" time="{time:.3f}">
+<testsuite errors="0" failures="0" name="{name}" skips="0" tests="1" time="{time:.3f}">
+  <testcase classname="{name}" file="{name}" line="1" name="{name}" time="{time:.3f}">
   </testcase>
 </testsuite>
 """  # type: Final
 
 FAIL_TEMPLATE = """<?xml version="1.0" encoding="utf-8"?>
-<testsuite errors="0" failures="1" name="mypy" skips="0" tests="1" time="{time:.3f}">
-  <testcase classname="mypy" file="mypy" line="1" name="mypy" time="{time:.3f}">
+<testsuite errors="0" failures="1" name="{name}" skips="0" tests="1" time="{time:.3f}">
+  <testcase classname="{name}" file="{name}" line="1" name="{name}" time="{time:.3f}">
     <failure message="mypy produced messages">{text}</failure>
   </testcase>
 </testsuite>
 """  # type: Final
 
 ERROR_TEMPLATE = """<?xml version="1.0" encoding="utf-8"?>
-<testsuite errors="1" failures="0" name="mypy" skips="0" tests="1" time="{time:.3f}">
-  <testcase classname="mypy" file="mypy" line="1" name="mypy" time="{time:.3f}">
+<testsuite errors="1" failures="0" name="{name}" skips="0" tests="1" time="{time:.3f}">
+  <testcase classname="{name}" file="{name}" line="1" name="{name}" time="{time:.3f}">
     <error message="mypy produced errors">{text}</error>
   </testcase>
 </testsuite>
 """  # type: Final
 
 
-def write_junit_xml(dt: float, serious: bool, messages: List[str], path: str) -> None:
+def write_junit_xml(dt: float, serious: bool, messages: List[str], path: str,
+                    name: str = "mypy") -> None:
     from xml.sax.saxutils import escape
     if not messages and not serious:
-        xml = PASS_TEMPLATE.format(time=dt)
+        xml = PASS_TEMPLATE.format(time=dt, name=name)
     elif not serious:
-        xml = FAIL_TEMPLATE.format(text=escape('\n'.join(messages)), time=dt)
+        xml = FAIL_TEMPLATE.format(text=escape('\n'.join(messages)), time=dt, name=name)
     else:
-        xml = ERROR_TEMPLATE.format(text=escape('\n'.join(messages)), time=dt)
+        xml = ERROR_TEMPLATE.format(text=escape('\n'.join(messages)), time=dt, name=name)
 
     # checks for a directory structure in path and creates folders if needed
     xml_dirs = os.path.dirname(os.path.abspath(path))


### PR DESCRIPTION
This makes it easier to recognize which build has errors when errors from different versions or platforms may be displayed in the same UI.

(Alas, we can't do this in dmypy because its check command doesn't know the options passed to the start command.)