### PR TITLE
Make _RedirectStream._stream a ClassVar to workaround mypyc bug

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -10,7 +10,7 @@ from typing import TypeVar, List, Tuple, Optional, Dict, Sequence, TextIO
 
 MYPY = False
 if MYPY:
-    from typing import Type
+    from typing import Type, ClassVar
     from typing_extensions import Final
 
 T = TypeVar('T')
@@ -266,7 +266,7 @@ def hard_exit(status: int = 0) -> None:
 
 class _RedirectStream:
 
-    _stream = None  # type: str
+    _stream = None  # type: ClassVar[str]
 
     def __init__(self, new_target: TextIO) -> None:
         self._new_target = new_target


### PR DESCRIPTION
There is a mypyc bug in which if mypy thinks that an attribute is
"redeclared" in a subclass, mypyc emits it twice in the struct and
then chokes.

Make `_RedirectStream._stream` a `ClassVar` to avoid this.

(I need to add mypyc to our CI.)