### PR TITLE
Add star imported modules as dependencies

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1775,9 +1775,13 @@ class State:
     def semantic_analysis(self) -> None:
         assert self.tree is not None, "Internal error: method must be called on parsed file only"
         patches = []  # type: List[Tuple[int, Callable[[], None]]]
+        self.manager.semantic_analyzer.imports.clear()
         with self.wrap_context():
             self.manager.semantic_analyzer.visit_file(self.tree, self.xpath, self.options, patches)
         self.patches = patches
+        for dep in self.manager.semantic_analyzer.imports:
+            self.dependencies.append(dep)
+            self.priorities[dep] = PRI_LOW
 
     def semantic_analysis_pass_three(self) -> None:
         assert self.tree is not None, "Internal error: method must be called on parsed file only"

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -212,6 +212,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
     is_stub_file = False   # Are we analyzing a stub file?
     _is_typeshed_stub_file = False  # Are we analyzing a typeshed stub file?
     imports = None  # type: Set[str]  # Imported modules (during phase 2 analysis)
+                                      # Note: some imports (and therefore dependencies) might
+                                      # not be found in phase 1, for example due to * imports.
     errors = None  # type: Errors     # Keeps track of generated errors
     plugin = None  # type: Plugin     # Mypy plugin for special casing of library features
 
@@ -1631,6 +1633,9 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 # if '__all__' exists, all nodes not included have had module_public set to
                 # False, and we can skip checking '_' because it's been explicitly included.
                 if (node.module_public and (not name.startswith('_') or '__all__' in m.names)):
+                    if isinstance(node.node, MypyFile):
+                    # Star import of submodule from a package, add it as a dependency.
+                        self.imports.add(node.node.fullname())
                     existing_symbol = self.lookup_current_scope(name)
                     if existing_symbol:
                         # Import can redefine a variable. They get special treatment.

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4904,3 +4904,17 @@ a: Literal[2] = 2
 main:2: error: Revealed type is 'builtins.int'
 [out2]
 main:2: error: Revealed type is 'Literal[2]'
+
+[case testAddedSubStarImport]
+# cmd: mypy -m a pack pack.mod b
+# cmd2: mypy -m other
+[file a.py]
+from pack import *
+[file pack/__init__.py]
+[file pack/mod.py]
+[file b.py]
+import pack.mod
+[file other.py]
+import a
+[out]
+[out2]


### PR DESCRIPTION
Fixes #6110 

I tried few approaches, and this one seems the most clean to me. Essentially, we just add some more imports (dependencies) after the second pass, where the star imports are resolved.