### PR TITLE
Re-enable promotions in isinstance checks

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3766,12 +3766,11 @@ def conditional_type_map(expr: Expression,
             proposed_type = UnionType([type_range.item for type_range in proposed_type_ranges])
         if current_type:
             if (not any(type_range.is_upper_bound for type_range in proposed_type_ranges)
-               and is_proper_subtype(current_type, proposed_type, ignore_promotions=True)):
+               and is_proper_subtype(current_type, proposed_type)):
                 # Expression is always of one of the types in proposed_type_ranges
                 return {}, None
             elif not is_overlapping_types(current_type, proposed_type,
-                                          prohibit_none_typevar_overlap=True,
-                                          ignore_promotions=True):
+                                          prohibit_none_typevar_overlap=True):
                 # Expression is never of any type in proposed_type_ranges
                 return None, {}
             else:
@@ -3779,8 +3778,7 @@ def conditional_type_map(expr: Expression,
                 proposed_precise_type = UnionType([type_range.item
                                           for type_range in proposed_type_ranges
                                           if not type_range.is_upper_bound])
-                remaining_type = restrict_subtype_away(current_type, proposed_precise_type,
-                                                       ignore_promotions=True)
+                remaining_type = restrict_subtype_away(current_type, proposed_precise_type)
                 return {expr: proposed_type}, {expr: remaining_type}
         else:
             return {expr: proposed_type}, {}

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1313,7 +1313,8 @@ def f(x: Union[A, B]) -> None:
         f(x)
 [builtins fixtures/isinstance.pyi]
 
-[case testIsinstanceWithOverlappingPromotionTypes]
+[case testIsinstanceWithOverlappingPromotionTypes-skip]
+# Currently disabled: see https://github.com/python/mypy/issues/6180 for context
 from typing import Union
 
 class FloatLike: pass


### PR DESCRIPTION
This pull request reverts https://github.com/python/mypy/pull/6114 and https://github.com/python/mypy/pull/6142: see https://github.com/python/mypy/issues/6180 for rationale.

In short, the original fix ended up being more disruptive then anticipated: it's modifying str and unicode semantics, and we should put a little more thought into reasoning about that particular case before moving ahead with any fix here.

This should also help unblock the upcoming 0.660 release.