### PR TITLE
Move message constants to mypy.message_registry

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -17,7 +17,7 @@ if MYPY:
     import mypy.checker
     import mypy.checkexpr
     from typing_extensions import Final
-from mypy import messages
+from mypy import message_registry
 from mypy.messages import MessageBuilder
 
 FormatStringExpr = Union[StrExpr, BytesExpr, UnicodeExpr]
@@ -192,7 +192,7 @@ class StringFormatterChecker:
                 if expected_type is None:
                     return
                 self.chk.check_subtype(rep_type, expected_type, replacements,
-                                       messages.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
+                                       message_registry.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
                                        'expression has type',
                                        'placeholder with key \'%s\' has type' % specifier.key)
         else:
@@ -201,7 +201,7 @@ class StringFormatterChecker:
             dict_type = self.chk.named_generic_type('builtins.dict',
                                                     [any_type, any_type])
             self.chk.check_subtype(rep_type, dict_type, replacements,
-                                   messages.FORMAT_REQUIRES_MAPPING,
+                                   message_registry.FORMAT_REQUIRES_MAPPING,
                                    'expression has type', 'expected type for mapping is')
 
     def build_replacement_checkers(self, specifiers: List[ConversionSpecifier],
@@ -268,7 +268,7 @@ class StringFormatterChecker:
         def check_type(type: Type) -> None:
             assert expected_type is not None
             self.chk.check_subtype(type, expected_type, context,
-                              messages.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
+                              message_registry.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
                               'expression has type', 'placeholder has type')
 
         def check_expr(expr: Expression) -> None:
@@ -290,7 +290,7 @@ class StringFormatterChecker:
         def check_type(type: Type) -> None:
             assert expected_type is not None
             self.chk.check_subtype(type, expected_type, context,
-                              messages.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
+                              message_registry.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
                               'expression has type', 'placeholder has type')
 
         def check_expr(expr: Expression) -> None:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -34,7 +34,7 @@ from mypy.types import (
     TypeOfAny, Instance, RawExpressionType,
 )
 from mypy import defaults
-from mypy import messages
+from mypy import message_registry
 from mypy.errors import Errors
 from mypy.options import Options
 
@@ -404,7 +404,7 @@ class ASTConverter:
                         isinstance(func_type_ast.argtypes[0], ast3_Ellipsis)):
                     if n.returns:
                         # PEP 484 disallows both type annotations and type comments
-                        self.fail(messages.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
+                        self.fail(message_registry.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
                     arg_types = [a.type_annotation
                                  if a.type_annotation is not None
                                  else AnyType(TypeOfAny.unannotated)
@@ -412,7 +412,7 @@ class ASTConverter:
                 else:
                     # PEP 484 disallows both type annotations and type comments
                     if n.returns or any(a.type_annotation is not None for a in args):
-                        self.fail(messages.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
+                        self.fail(message_registry.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
                     translated_args = (TypeConverter(self.errors, line=lineno)
                                        .translate_expr_list(func_type_ast.argtypes))
                     arg_types = [a if a is not None else AnyType(TypeOfAny.unannotated)
@@ -540,7 +540,7 @@ class ASTConverter:
             annotation = arg.annotation
             type_comment = arg.type_comment
             if annotation is not None and type_comment is not None:
-                self.fail(messages.DUPLICATE_TYPE_SIGNATURES, arg.lineno, arg.col_offset)
+                self.fail(message_registry.DUPLICATE_TYPE_SIGNATURES, arg.lineno, arg.col_offset)
             arg_type = None
             if annotation is not None:
                 arg_type = TypeConverter(self.errors, line=arg.lineno).visit(annotation)

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -43,7 +43,7 @@ from mypy.nodes import (
 from mypy.types import (
     Type, CallableType, AnyType, UnboundType, EllipsisType, TypeOfAny, Instance,
 )
-from mypy import messages
+from mypy import message_registry
 from mypy.errors import Errors
 from mypy.fastparse import TypeConverter, parse_type_comment, bytes_to_human_readable_repr
 from mypy.options import Options
@@ -351,7 +351,7 @@ class ASTConverter:
                 else:
                     # PEP 484 disallows both type annotations and type comments
                     if any(a.type_annotation is not None for a in args):
-                        self.fail(messages.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
+                        self.fail(message_registry.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
                     arg_types = [a if a is not None else AnyType(TypeOfAny.unannotated) for
                                  a in converter.translate_expr_list(func_type_ast.argtypes)]
                 return_type = converter.visit(func_type_ast.returns)

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -1,0 +1,139 @@
+"""Message constants for generating error messages during type checking.
+
+Literal messages should be defined as constants in this module so they won't get out of sync
+if used in more than one place, and so that they can be easily introspected. These messages are
+ultimately consumed by messages.MessageBuilder.fail(). For more non-trivial message generation,
+add a method to MessageBuilder and call this instead.
+"""
+
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
+
+
+# Type checker error message constants --
+
+NO_RETURN_VALUE_EXPECTED = 'No return value expected'  # type: Final
+MISSING_RETURN_STATEMENT = 'Missing return statement'  # type: Final
+INVALID_IMPLICIT_RETURN = 'Implicit return in function which does not return'  # type: Final
+INCOMPATIBLE_RETURN_VALUE_TYPE = 'Incompatible return value type'  # type: Final
+RETURN_VALUE_EXPECTED = 'Return value expected'  # type: Final
+NO_RETURN_EXPECTED = 'Return statement in function which does not return'  # type: Final
+INVALID_EXCEPTION = 'Exception must be derived from BaseException'  # type: Final
+INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'  # type: Final
+RETURN_IN_ASYNC_GENERATOR = "'return' with value in async generator is not allowed"  # type: Final
+INVALID_RETURN_TYPE_FOR_GENERATOR = \
+    'The return type of a generator function should be "Generator"' \
+    ' or one of its supertypes'  # type: Final
+INVALID_RETURN_TYPE_FOR_ASYNC_GENERATOR = \
+    'The return type of an async generator function should be "AsyncGenerator" or one of its ' \
+    'supertypes'  # type: Final
+INVALID_GENERATOR_RETURN_ITEM_TYPE = \
+    'The return type of a generator function must be None in' \
+    ' its third type parameter in Python 2'  # type: Final
+YIELD_VALUE_EXPECTED = 'Yield value expected'  # type: Final
+INCOMPATIBLE_TYPES = 'Incompatible types'  # type: Final
+INCOMPATIBLE_TYPES_IN_ASSIGNMENT = 'Incompatible types in assignment'  # type: Final
+INCOMPATIBLE_REDEFINITION = 'Incompatible redefinition'  # type: Final
+INCOMPATIBLE_TYPES_IN_AWAIT = 'Incompatible types in "await"'  # type: Final
+INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AENTER = \
+    'Incompatible types in "async with" for "__aenter__"'  # type: Final
+INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AEXIT = \
+    'Incompatible types in "async with" for "__aexit__"'  # type: Final
+INCOMPATIBLE_TYPES_IN_ASYNC_FOR = 'Incompatible types in "async for"'  # type: Final
+
+INCOMPATIBLE_TYPES_IN_YIELD = 'Incompatible types in "yield"'  # type: Final
+INCOMPATIBLE_TYPES_IN_YIELD_FROM = 'Incompatible types in "yield from"'  # type: Final
+INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION = \
+    'Incompatible types in string interpolation'  # type: Final
+MUST_HAVE_NONE_RETURN_TYPE = 'The return type of "{}" must be None'  # type: Final
+INVALID_TUPLE_INDEX_TYPE = 'Invalid tuple index type'  # type: Final
+TUPLE_INDEX_OUT_OF_RANGE = 'Tuple index out of range'  # type: Final
+INVALID_SLICE_INDEX = 'Slice index must be an integer or None'  # type: Final
+CANNOT_INFER_LAMBDA_TYPE = 'Cannot infer type of lambda'  # type: Final
+CANNOT_ACCESS_INIT = 'Cannot access "__init__" directly'  # type: Final
+CANNOT_ASSIGN_TO_METHOD = 'Cannot assign to a method'  # type: Final
+CANNOT_ASSIGN_TO_TYPE = 'Cannot assign to a type'  # type: Final
+INCONSISTENT_ABSTRACT_OVERLOAD = \
+    'Overloaded method has both abstract and non-abstract variants'  # type: Final
+MULTIPLE_OVERLOADS_REQUIRED = 'Single overload definition, multiple required'  # type: Final
+READ_ONLY_PROPERTY_OVERRIDES_READ_WRITE = \
+    'Read-only property cannot override read-write property'  # type: Final
+FORMAT_REQUIRES_MAPPING = 'Format requires a mapping'  # type: Final
+RETURN_TYPE_CANNOT_BE_CONTRAVARIANT = \
+    "Cannot use a contravariant type variable as return type"  # type: Final
+FUNCTION_PARAMETER_CANNOT_BE_COVARIANT = \
+    "Cannot use a covariant type variable as a parameter"  # type: Final
+INCOMPATIBLE_IMPORT_OF = "Incompatible import of"  # type: Final
+FUNCTION_TYPE_EXPECTED = "Function is missing a type annotation"  # type: Final
+ONLY_CLASS_APPLICATION = "Type application is only supported for generic classes"  # type: Final
+RETURN_TYPE_EXPECTED = "Function is missing a return type annotation"  # type: Final
+ARGUMENT_TYPE_EXPECTED = \
+    "Function is missing a type annotation for one or more arguments"  # type: Final
+KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE = \
+    'Keyword argument only valid with "str" key type in call to "dict"'  # type: Final
+ALL_MUST_BE_SEQ_STR = 'Type of __all__ must be {}, not {}'  # type: Final
+INVALID_TYPEDDICT_ARGS = \
+    'Expected keyword arguments, {...}, or dict(...) in TypedDict constructor'  # type: Final
+TYPEDDICT_KEY_MUST_BE_STRING_LITERAL = \
+    'Expected TypedDict key to be string literal'  # type: Final
+MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'  # type: Final
+DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'  # type: Final
+DESCRIPTOR_SET_NOT_CALLABLE = "{}.__set__ is not callable"  # type: Final
+DESCRIPTOR_GET_NOT_CALLABLE = "{}.__get__ is not callable"  # type: Final
+MODULE_LEVEL_GETATTRIBUTE = '__getattribute__ is not valid at the module level'  # type: Final
+
+# Generic
+GENERIC_INSTANCE_VAR_CLASS_ACCESS = \
+    'Access to generic instance variables via class is ambiguous'  # type: Final
+BARE_GENERIC = 'Missing type parameters for generic type'  # type: Final
+IMPLICIT_GENERIC_ANY_BUILTIN = \
+    'Implicit generic "Any". Use "{}" and specify generic parameters'  # type: Final
+
+# TypeVar
+INCOMPATIBLE_TYPEVAR_VALUE = 'Value of type variable "{}" of {} cannot be {}'  # type: Final
+CANNOT_USE_TYPEVAR_AS_EXPRESSION = \
+    'Type variable "{}.{}" cannot be used as an expression'  # type: Final
+
+# Super
+TOO_MANY_ARGS_FOR_SUPER = 'Too many arguments for "super"'  # type: Final
+TOO_FEW_ARGS_FOR_SUPER = 'Too few arguments for "super"'  # type: Final
+SUPER_WITH_SINGLE_ARG_NOT_SUPPORTED = '"super" with a single argument not supported'  # type: Final
+UNSUPPORTED_ARG_1_FOR_SUPER = 'Unsupported argument 1 for "super"'  # type: Final
+UNSUPPORTED_ARG_2_FOR_SUPER = 'Unsupported argument 2 for "super"'  # type: Final
+SUPER_VARARGS_NOT_SUPPORTED = 'Varargs not supported with "super"'  # type: Final
+SUPER_POSITIONAL_ARGS_REQUIRED = '"super" only accepts positional arguments'  # type: Final
+SUPER_ARG_2_NOT_INSTANCE_OF_ARG_1 = \
+    'Argument 2 for "super" not an instance of argument 1'  # type: Final
+SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED = \
+    'super() outside of a method is not supported'  # type: Final
+SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED = \
+    'super() requires one or more positional arguments in enclosing function'  # type: Final
+
+# Self-type
+MISSING_OR_INVALID_SELF_TYPE = \
+    "Self argument missing for a non-static method (or an invalid type for self)"  # type: Final
+ERASED_SELF_TYPE_NOT_SUPERTYPE = \
+    'The erased type of self "{}" is not a supertype of its class "{}"'  # type: Final
+INVALID_SELF_TYPE_OR_EXTRA_ARG = \
+    "Invalid type for self, or extra argument type in function annotation"  # type: Final
+
+# Final
+CANNOT_INHERIT_FROM_FINAL = 'Cannot inherit from final class "{}"'  # type: Final
+DEPENDENT_FINAL_IN_CLASS_BODY = \
+    "Final name declared in class body cannot depend on type variables"  # type: Final
+CANNOT_ACCESS_FINAL_INSTANCE_ATTR = \
+    'Cannot access final instance attribute "{}" on class object'  # type: Final
+
+# ClassVar
+CANNOT_OVERRIDE_INSTANCE_VAR = \
+    'Cannot override instance variable (previously declared on base class "{}") with class ' \
+    'variable'  # type: Final
+CANNOT_OVERRIDE_CLASS_VAR = \
+    'Cannot override class variable (previously declared on base class "{}") with instance ' \
+    'variable'  # type: Final
+
+# Protocol
+RUNTIME_PROTOCOL_EXPECTED = \
+    'Only @runtime protocols can be used with instance and class checks'  # type: Final
+CANNOT_INSTANTIATE_PROTOCOL = 'Cannot instantiate protocol class "{}"'  # type: Final

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1,10 +1,9 @@
-"""Facilities and constants for generating error messages during type checking.
+"""Facilities for generating error messages during type checking.
 
 Don't add any non-trivial message construction logic to the type
 checker, as it can compromise clarity and make messages less
-consistent. Add such logic to this module instead. Literal messages used
-in multiple places should also be defined as constants in this module so
-they won't get out of sync.
+consistent. Add such logic to this module instead. Literal messages, including those
+with format args, should be defined as constants in mypy.message_registry.
 
 Historically we tried to avoid all message string literals in the type
 checker but we are moving away from this convention.
@@ -30,137 +29,11 @@ from mypy.nodes import (
     ReturnStmt, NameExpr, Var, CONTRAVARIANT, COVARIANT, SymbolNode,
     CallExpr
 )
+from mypy import message_registry
 
 MYPY = False
 if MYPY:
     from typing_extensions import Final
-
-# Type checker error message constants --
-
-NO_RETURN_VALUE_EXPECTED = 'No return value expected'  # type: Final
-MISSING_RETURN_STATEMENT = 'Missing return statement'  # type: Final
-INVALID_IMPLICIT_RETURN = 'Implicit return in function which does not return'  # type: Final
-INCOMPATIBLE_RETURN_VALUE_TYPE = 'Incompatible return value type'  # type: Final
-RETURN_VALUE_EXPECTED = 'Return value expected'  # type: Final
-NO_RETURN_EXPECTED = 'Return statement in function which does not return'  # type: Final
-INVALID_EXCEPTION = 'Exception must be derived from BaseException'  # type: Final
-INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'  # type: Final
-RETURN_IN_ASYNC_GENERATOR = "'return' with value in async generator is not allowed"  # type: Final
-INVALID_RETURN_TYPE_FOR_GENERATOR = \
-    'The return type of a generator function should be "Generator"' \
-    ' or one of its supertypes'  # type: Final
-INVALID_RETURN_TYPE_FOR_ASYNC_GENERATOR = \
-    'The return type of an async generator function should be "AsyncGenerator" or one of its ' \
-    'supertypes'  # type: Final
-INVALID_GENERATOR_RETURN_ITEM_TYPE = \
-    'The return type of a generator function must be None in' \
-    ' its third type parameter in Python 2'  # type: Final
-YIELD_VALUE_EXPECTED = 'Yield value expected'  # type: Final
-INCOMPATIBLE_TYPES = 'Incompatible types'  # type: Final
-INCOMPATIBLE_TYPES_IN_ASSIGNMENT = 'Incompatible types in assignment'  # type: Final
-INCOMPATIBLE_REDEFINITION = 'Incompatible redefinition'  # type: Final
-INCOMPATIBLE_TYPES_IN_AWAIT = 'Incompatible types in "await"'  # type: Final
-INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AENTER = \
-    'Incompatible types in "async with" for "__aenter__"'  # type: Final
-INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AEXIT = \
-    'Incompatible types in "async with" for "__aexit__"'  # type: Final
-INCOMPATIBLE_TYPES_IN_ASYNC_FOR = 'Incompatible types in "async for"'  # type: Final
-
-INCOMPATIBLE_TYPES_IN_YIELD = 'Incompatible types in "yield"'  # type: Final
-INCOMPATIBLE_TYPES_IN_YIELD_FROM = 'Incompatible types in "yield from"'  # type: Final
-INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION = \
-    'Incompatible types in string interpolation'  # type: Final
-MUST_HAVE_NONE_RETURN_TYPE = 'The return type of "{}" must be None'  # type: Final
-INVALID_TUPLE_INDEX_TYPE = 'Invalid tuple index type'  # type: Final
-TUPLE_INDEX_OUT_OF_RANGE = 'Tuple index out of range'  # type: Final
-INVALID_SLICE_INDEX = 'Slice index must be an integer or None'  # type: Final
-CANNOT_INFER_LAMBDA_TYPE = 'Cannot infer type of lambda'  # type: Final
-CANNOT_ACCESS_INIT = 'Cannot access "__init__" directly'  # type: Final
-CANNOT_ASSIGN_TO_METHOD = 'Cannot assign to a method'  # type: Final
-CANNOT_ASSIGN_TO_TYPE = 'Cannot assign to a type'  # type: Final
-INCONSISTENT_ABSTRACT_OVERLOAD = \
-    'Overloaded method has both abstract and non-abstract variants'  # type: Final
-MULTIPLE_OVERLOADS_REQUIRED = 'Single overload definition, multiple required'  # type: Final
-READ_ONLY_PROPERTY_OVERRIDES_READ_WRITE = \
-    'Read-only property cannot override read-write property'  # type: Final
-FORMAT_REQUIRES_MAPPING = 'Format requires a mapping'  # type: Final
-RETURN_TYPE_CANNOT_BE_CONTRAVARIANT = \
-    "Cannot use a contravariant type variable as return type"  # type: Final
-FUNCTION_PARAMETER_CANNOT_BE_COVARIANT = \
-    "Cannot use a covariant type variable as a parameter"  # type: Final
-INCOMPATIBLE_IMPORT_OF = "Incompatible import of"  # type: Final
-FUNCTION_TYPE_EXPECTED = "Function is missing a type annotation"  # type: Final
-ONLY_CLASS_APPLICATION = "Type application is only supported for generic classes"  # type: Final
-RETURN_TYPE_EXPECTED = "Function is missing a return type annotation"  # type: Final
-ARGUMENT_TYPE_EXPECTED = \
-    "Function is missing a type annotation for one or more arguments"  # type: Final
-KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE = \
-    'Keyword argument only valid with "str" key type in call to "dict"'  # type: Final
-ALL_MUST_BE_SEQ_STR = 'Type of __all__ must be {}, not {}'  # type: Final
-INVALID_TYPEDDICT_ARGS = \
-    'Expected keyword arguments, {...}, or dict(...) in TypedDict constructor'  # type: Final
-TYPEDDICT_KEY_MUST_BE_STRING_LITERAL = \
-    'Expected TypedDict key to be string literal'  # type: Final
-MALFORMED_ASSERT = 'Assertion is always true, perhaps remove parentheses?'  # type: Final
-DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'  # type: Final
-DESCRIPTOR_SET_NOT_CALLABLE = "{}.__set__ is not callable"  # type: Final
-DESCRIPTOR_GET_NOT_CALLABLE = "{}.__get__ is not callable"  # type: Final
-MODULE_LEVEL_GETATTRIBUTE = '__getattribute__ is not valid at the module level'  # type: Final
-
-# Generic
-GENERIC_INSTANCE_VAR_CLASS_ACCESS = \
-    'Access to generic instance variables via class is ambiguous'  # type: Final
-BARE_GENERIC = 'Missing type parameters for generic type'  # type: Final
-IMPLICIT_GENERIC_ANY_BUILTIN = \
-    'Implicit generic "Any". Use "{}" and specify generic parameters'  # type: Final
-
-# TypeVar
-INCOMPATIBLE_TYPEVAR_VALUE = 'Value of type variable "{}" of {} cannot be {}'  # type: Final
-CANNOT_USE_TYPEVAR_AS_EXPRESSION = \
-    'Type variable "{}.{}" cannot be used as an expression'  # type: Final
-
-# Super
-TOO_MANY_ARGS_FOR_SUPER = 'Too many arguments for "super"'  # type: Final
-TOO_FEW_ARGS_FOR_SUPER = 'Too few arguments for "super"'  # type: Final
-SUPER_WITH_SINGLE_ARG_NOT_SUPPORTED = '"super" with a single argument not supported'  # type: Final
-UNSUPPORTED_ARG_1_FOR_SUPER = 'Unsupported argument 1 for "super"'  # type: Final
-UNSUPPORTED_ARG_2_FOR_SUPER = 'Unsupported argument 2 for "super"'  # type: Final
-SUPER_VARARGS_NOT_SUPPORTED = 'Varargs not supported with "super"'  # type: Final
-SUPER_POSITIONAL_ARGS_REQUIRED = '"super" only accepts positional arguments'  # type: Final
-SUPER_ARG_2_NOT_INSTANCE_OF_ARG_1 = \
-    'Argument 2 for "super" not an instance of argument 1'  # type: Final
-SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED = \
-    'super() outside of a method is not supported'  # type: Final
-SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED = \
-    'super() requires one or more positional arguments in enclosing function'  # type: Final
-
-# Self-type
-MISSING_OR_INVALID_SELF_TYPE = \
-    "Self argument missing for a non-static method (or an invalid type for self)"  # type: Final
-ERASED_SELF_TYPE_NOT_SUPERTYPE = \
-    'The erased type of self "{}" is not a supertype of its class "{}"'  # type: Final
-INVALID_SELF_TYPE_OR_EXTRA_ARG = \
-    "Invalid type for self, or extra argument type in function annotation"  # type: Final
-
-# Final
-CANNOT_INHERIT_FROM_FINAL = 'Cannot inherit from final class "{}"'  # type: Final
-DEPENDENT_FINAL_IN_CLASS_BODY = \
-    "Final name declared in class body cannot depend on type variables"  # type: Final
-CANNOT_ACCESS_FINAL_INSTANCE_ATTR = \
-    'Cannot access final instance attribute "{}" on class object'  # type: Final
-
-# ClassVar
-CANNOT_OVERRIDE_INSTANCE_VAR = \
-    'Cannot override instance variable (previously declared on base class "{}") with class ' \
-    'variable'  # type: Final
-CANNOT_OVERRIDE_CLASS_VAR = \
-    'Cannot override class variable (previously declared on base class "{}") with instance ' \
-    'variable'  # type: Final
-
-# Protocol
-RUNTIME_PROTOCOL_EXPECTED = \
-    'Only @runtime protocols can be used with instance and class checks'  # type: Final
-CANNOT_INSTANTIATE_PROTOCOL = 'Cannot instantiate protocol class "{}"'  # type: Final
 
 
 ARG_CONSTRUCTOR_NAMES = {
@@ -647,7 +520,7 @@ class MessageBuilder:
                     msg = '{} (expression has type {}, target has type {})'
                     arg_type_str, callee_type_str = self.format_distinctly(arg_type,
                                                                            callee.arg_types[n - 1])
-                    self.fail(msg.format(INCOMPATIBLE_TYPES_IN_ASSIGNMENT,
+                    self.fail(msg.format(message_registry.INCOMPATIBLE_TYPES_IN_ASSIGNMENT,
                                          arg_type_str, callee_type_str),
                               context)
                 return
@@ -1061,7 +934,7 @@ class MessageBuilder:
                       name, base1.name(), base2.name()), context)
 
     def cant_assign_to_method(self, context: Context) -> None:
-        self.fail(CANNOT_ASSIGN_TO_METHOD, context)
+        self.fail(message_registry.CANNOT_ASSIGN_TO_METHOD, context)
 
     def cant_assign_to_classvar(self, name: str, context: Context) -> None:
         self.fail('Cannot assign to class variable "%s" via instance' % name, context)
@@ -1097,9 +970,8 @@ class MessageBuilder:
                                    typ: Type,
                                    typevar_name: str,
                                    context: Context) -> None:
-        self.fail(INCOMPATIBLE_TYPEVAR_VALUE.format(typevar_name,
-                                                    callable_name(callee) or 'function',
-                                                    self.format(typ)),
+        self.fail(message_registry.INCOMPATIBLE_TYPEVAR_VALUE
+                  .format(typevar_name, callable_name(callee) or 'function', self.format(typ)),
                   context)
 
     def overload_inconsistently_applies_decorator(self, decorator: str, context: Context) -> None:

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -1,7 +1,7 @@
 from functools import partial
 from typing import Callable, Optional
 
-from mypy import messages
+from mypy import message_registry
 from mypy.nodes import StrExpr, IntExpr, DictExpr, UnaryExpr
 from mypy.plugin import (
     Plugin, FunctionContext, MethodContext, MethodSigContext, AttributeContext, ClassDefContext
@@ -230,7 +230,7 @@ def typed_dict_pop_callback(ctx: MethodContext) -> Type:
             and len(ctx.arg_types[0]) == 1):
         key = try_getting_str_literal(ctx.args[0][0], ctx.arg_types[0][0])
         if key is None:
-            ctx.api.fail(messages.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, ctx.context)
+            ctx.api.fail(message_registry.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, ctx.context)
             return AnyType(TypeOfAny.from_error)
 
         if key in ctx.type.required_keys:
@@ -276,7 +276,7 @@ def typed_dict_setdefault_callback(ctx: MethodContext) -> Type:
             and len(ctx.arg_types[0]) == 1):
         key = try_getting_str_literal(ctx.args[0][0], ctx.arg_types[0][0])
         if key is None:
-            ctx.api.fail(messages.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, ctx.context)
+            ctx.api.fail(message_registry.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, ctx.context)
             return AnyType(TypeOfAny.from_error)
 
         value_type = ctx.type.items.get(key)
@@ -301,7 +301,7 @@ def typed_dict_delitem_callback(ctx: MethodContext) -> Type:
             and len(ctx.arg_types[0]) == 1):
         key = try_getting_str_literal(ctx.args[0][0], ctx.arg_types[0][0])
         if key is None:
-            ctx.api.fail(messages.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, ctx.context)
+            ctx.api.fail(message_registry.TYPEDDICT_KEY_MUST_BE_STRING_LITERAL, ctx.context)
             return AnyType(TypeOfAny.from_error)
 
         if key in ctx.type.required_keys:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -62,7 +62,8 @@ from mypy.tvar_scope import TypeVarScope
 from mypy.typevars import fill_typevars
 from mypy.visitor import NodeVisitor
 from mypy.errors import Errors, report_internal_error
-from mypy.messages import CANNOT_ASSIGN_TO_TYPE, MessageBuilder
+from mypy.messages import MessageBuilder
+from mypy import message_registry
 from mypy.types import (
     FunctionLike, UnboundType, TypeVarDef, TupleType, UnionType, StarType, function_type,
     CallableType, Overloaded, Instance, Type, AnyType, LiteralType, LiteralValue,
@@ -2259,7 +2260,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         if isinstance(node, TypeVarExpr):
             self.fail('Invalid assignment target', ctx)
         elif isinstance(node, TypeInfo):
-            self.fail(CANNOT_ASSIGN_TO_TYPE, ctx)
+            self.fail(message_registry.CANNOT_ASSIGN_TO_TYPE, ctx)
 
     def store_declared_types(self, lvalue: Lvalue, typ: Type) -> None:
         if isinstance(typ, StarType) and not isinstance(lvalue, StarExpr):

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -12,7 +12,7 @@ belongs to a module involved in an import loop.
 from collections import OrderedDict
 from typing import Dict, List, Callable, Optional, Union, cast, Tuple
 
-from mypy import messages, state
+from mypy import message_registry, state
 from mypy.nodes import (
     Node, Expression, MypyFile, FuncDef, Decorator, RefExpr, Context, TypeInfo, ClassDef,
     Block, TypedDictExpr, NamedTupleExpr, AssignmentStmt, IndexExpr, TypeAliasExpr, NameExpr,
@@ -501,7 +501,7 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
 
         for t in collect_any_types(typ):
             if t.type_of_any == TypeOfAny.from_omitted_generics:
-                self.fail(messages.BARE_GENERIC, t)
+                self.fail(message_registry.BARE_GENERIC, t)
 
     def lookup_qualified(self, name: str, ctx: Context,
                          suppress_errors: bool = False) -> Optional[SymbolTableNode]:
@@ -780,5 +780,5 @@ class TypeVariableChecker(TypeTranslator):
                 else:
                     class_name = '"{}"'.format(type.name())
                     actual_type_name = '"{}"'.format(actual.type.name())
-                    self.fail(messages.INCOMPATIBLE_TYPEVAR_VALUE.format(
+                    self.fail(message_registry.INCOMPATIBLE_TYPEVAR_VALUE.format(
                         arg_name, class_name, actual_type_name), context)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -29,7 +29,7 @@ from mypy.tvar_scope import TypeVarScope
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.plugin import Plugin, TypeAnalyzerPluginInterface, AnalyzeTypeContext
 from mypy.semanal_shared import SemanticAnalyzerCoreInterface
-from mypy import nodes, messages
+from mypy import nodes, message_registry
 
 MYPY = False
 if MYPY:
@@ -273,7 +273,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             if len(t.args) == 0 and not t.empty_tuple_index:
                 # Bare 'Tuple' is same as 'tuple'
                 if self.options.disallow_any_generics and not self.is_typeshed_stub:
-                    self.fail(messages.BARE_GENERIC, t)
+                    self.fail(message_registry.BARE_GENERIC, t)
                 return self.named_type('builtins.tuple', line=t.line, column=t.column)
             if len(t.args) == 2 and isinstance(t.args[1], EllipsisType):
                 # Tuple[T, ...] (uniform, variable-length tuple)
@@ -341,7 +341,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             # in the third pass.
             if not self.is_typeshed_stub and info.fullname() in nongen_builtins:
                 alternative = nongen_builtins[info.fullname()]
-                self.fail(messages.IMPLICIT_GENERIC_ANY_BUILTIN.format(alternative), t)
+                self.fail(message_registry.IMPLICIT_GENERIC_ANY_BUILTIN.format(alternative), t)
                 any_type = AnyType(TypeOfAny.from_error, line=t.line)
             else:
                 any_type = AnyType(TypeOfAny.from_omitted_generics, line=t.line)


### PR DESCRIPTION
This is the next step toward message filtering (#2417), and a precursor to PR #6152.

By moving constants to their own module we can easily inspect them to get both their name and value, for use within a message filtering system.
