### PR TITLE
Refactor: remove MODULE_REF symbol table node kind

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -32,7 +32,7 @@ from mypy.nodes import (
     DictionaryComprehension, ComplexExpr, EllipsisExpr, StarExpr, AwaitExpr, YieldExpr,
     YieldFromExpr, TypedDictExpr, PromoteExpr, NewTypeExpr, NamedTupleExpr, TypeVarExpr,
     TypeAliasExpr, BackquoteExpr, EnumCallExpr, TypeAlias, SymbolNode,
-    ARG_POS, ARG_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2, MODULE_REF, LITERAL_TYPE, REVEAL_TYPE
+    ARG_POS, ARG_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2, LITERAL_TYPE, REVEAL_TYPE
 )
 from mypy.literals import literal
 from mypy import nodes
@@ -84,8 +84,8 @@ def extract_refexpr_names(expr: RefExpr) -> Set[str]:
     Note that currently, the only two subclasses of RefExpr are NameExpr and
     MemberExpr."""
     output = set()  # type: Set[str]
-    while expr.kind == MODULE_REF or expr.fullname is not None:
-        if expr.kind == MODULE_REF and expr.fullname is not None:
+    while isinstance(expr.node, MypyFile) or expr.fullname is not None:
+        if isinstance(expr.node, MypyFile) and expr.fullname is not None:
             # If it's None, something's wrong (perhaps due to an
             # import cycle or a suppressed error).  For now we just
             # skip it.

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -72,7 +72,7 @@ MDEF = 2  # type: Final[int]
 # valid as a type unless bound in a TypeVarScope.  That happens within:
 # (1) a generic class that uses the type variable as a type argument or
 # (2) a generic function that refers to the type variable in its signature.
-TVAR = 4  # type: Final[int]
+TVAR = 3  # type: Final[int]
 
 # Placeholder for a name imported via 'from ... import'. Second phase of
 # semantic will replace this the actual imported reference. This is
@@ -2675,16 +2675,15 @@ class SymbolTableNode:
     The most fundamental attributes are 'kind' and 'node'.  The 'node'
     attribute defines the AST node that the name refers to.
 
-    For many bindings, including those targeting variables, functions
-    and classes, the kind is one of LDEF, GDEF or MDEF, depending on the
-    scope of the definition. These three kinds can usually be used
+    For most bindings, including those targeting variables, functions,
+    classes and modules, the kind is one of LDEF, GDEF or MDEF, depending
+    on the scope of the definition. These three kinds can usually be used
     interchangeably and the difference between local, global and class
     scopes is mostly descriptive, with no semantic significance.
     However, some tools that consume mypy ASTs may care about these so
     they should be correct.
 
-    A few definitions get special kinds, including type variables (TVAR),
-    imported modules and module aliases (MODULE_REF)
+    Type variables have a special kind (TVAR).
 
     Attributes:
         kind: Kind of node. Possible values:
@@ -2692,7 +2691,6 @@ class SymbolTableNode:
                - GDEF: global (module-level) definition
                - MDEF: class member definition
                - TVAR: TypeVar(...) definition in any scope
-               - MODULE_REF: reference to a module
                - UNBOUND_IMPORTED: temporary kind for imported names (we
                  don't know the final kind yet)
         node: AST node of definition (among others, this can be

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -68,7 +68,6 @@ JsonDict = Dict[str, Any]
 LDEF = 0  # type: Final[int]
 GDEF = 1  # type: Final[int]
 MDEF = 2  # type: Final[int]
-MODULE_REF = 3  # type: Final[int]
 # Type variable declared using TypeVar(...) has kind TVAR. It's not
 # valid as a type unless bound in a TypeVarScope.  That happens within:
 # (1) a generic class that uses the type variable as a type argument or
@@ -93,7 +92,6 @@ node_kinds = {
     LDEF: 'Ldef',
     GDEF: 'Gdef',
     MDEF: 'Mdef',
-    MODULE_REF: 'ModuleRef',
     TVAR: 'Tvar',
     UNBOUND_IMPORTED: 'UnboundImported',
 }  # type: Final
@@ -2811,8 +2809,7 @@ class SymbolTableNode:
             data['implicit'] = True
         if self.plugin_generated:
             data['plugin_generated'] = True
-        if self.kind == MODULE_REF:
-            assert self.node is not None, "Missing module cross ref in %s for %s" % (prefix, name)
+        if isinstance(self.node, MypyFile):
             data['cross_ref'] = self.node.fullname()
         else:
             if self.node is not None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2584,7 +2584,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                                 ctx)
                         # never create module alias except on initial var definition
                         elif lval.is_inferred_def:
-                            lnode.kind = GDEF  # TYPE: fix kind
+                            lnode.kind = self.current_symbol_kind()
                             lnode.node = rnode.node
 
     def visit_decorator(self, dec: Decorator) -> None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -40,7 +40,7 @@ from typing import (
 
 from mypy.nodes import (
     MypyFile, TypeInfo, Node, AssignmentStmt, FuncDef, OverloadedFuncDef,
-    ClassDef, Var, GDEF, MODULE_REF, FuncItem, Import, Expression, Lvalue,
+    ClassDef, Var, GDEF, FuncItem, Import, Expression, Lvalue,
     ImportFrom, ImportAll, Block, LDEF, NameExpr, MemberExpr,
     IndexExpr, TupleExpr, ListExpr, ExpressionStmt, ReturnStmt,
     RaiseStmt, AssertStmt, OperatorAssignmentStmt, WhileStmt,
@@ -287,7 +287,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
 
         with state.strict_optional_set(options.strict_optional):
             if 'builtins' in self.modules:
-                self.globals['__builtins__'] = SymbolTableNode(MODULE_REF,
+                self.globals['__builtins__'] = SymbolTableNode(GDEF,
                                                                self.modules['builtins'])
 
             for name in implicit_module_attrs:
@@ -1449,7 +1449,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             if parent_mod and self.allow_patching(parent_mod, child):
                 child_mod = self.modules.get(id)
                 if child_mod:
-                    sym = SymbolTableNode(MODULE_REF, child_mod,
+                    sym = SymbolTableNode(GDEF, child_mod,
                                           module_public=module_public,
                                           no_serialize=True)
                 else:
@@ -1478,7 +1478,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                           context: Context, module_hidden: bool = False) -> None:
         if id in self.modules:
             m = self.modules[id]
-            self.add_symbol(as_id, SymbolTableNode(MODULE_REF, m,
+            self.add_symbol(as_id, SymbolTableNode(GDEF, m,  # TODO: fix scope
                                                    module_public=module_public,
                                                    module_hidden=module_hidden), context)
         else:
@@ -1500,7 +1500,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             if not node or node.kind == UNBOUND_IMPORTED:
                 mod = self.modules.get(possible_module_id)
                 if mod is not None:
-                    node = SymbolTableNode(MODULE_REF, mod)
+                    node = SymbolTableNode(GDEF, mod)  # TODO: fix scope
                     self.add_submodules_to_parent_modules(possible_module_id, True)
                 elif possible_module_id in self.missing_modules:
                     missing = True
@@ -1572,7 +1572,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             fullname = node.node.fullname()
             if fullname in self.modules:
                 # This is a module reference.
-                return SymbolTableNode(MODULE_REF, self.modules[fullname])
+                return SymbolTableNode(GDEF, self.modules[fullname])  # TODO: fix scope
             if fullname in seen:
                 # Looks like a reference cycle. Just break it.
                 # TODO: Generate a more specific error message.
@@ -2565,7 +2565,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 self.process_module_assignment(lvs, rv, ctx)
         elif isinstance(rval, RefExpr):
             rnode = self.lookup_type_node(rval)
-            if rnode and rnode.kind == MODULE_REF:
+            if rnode and isinstance(rnode.node, MypyFile):
                 for lval in lvals:
                     if not isinstance(lval, NameExpr):
                         continue
@@ -2574,14 +2574,14 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                         continue
                     lnode = self.lookup(lval.name, ctx)
                     if lnode:
-                        if lnode.kind == MODULE_REF and lnode.node is not rnode.node:
+                        if isinstance(lnode.node, MypyFile) and lnode.node is not rnode.node:
                             self.fail(
                                 "Cannot assign multiple modules to name '{}' "
                                 "without explicit 'types.ModuleType' annotation".format(lval.name),
                                 ctx)
                         # never create module alias except on initial var definition
                         elif lval.is_inferred_def:
-                            lnode.kind = MODULE_REF
+                            lnode.kind = GDEF  # TYPE: fix kind
                             lnode.node = rnode.node
 
     def visit_decorator(self, dec: Decorator) -> None:
@@ -3048,7 +3048,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         base = expr.expr
         base.accept(self)
         # Bind references to module attributes.
-        if isinstance(base, RefExpr) and base.kind == MODULE_REF:
+        if isinstance(base, RefExpr) and isinstance(base.node, MypyFile):
             # This branch handles the case foo.bar where foo is a module.
             # In this case base.node is the module's MypyFile and we look up
             # bar in its namespace.  This must be done for all types of bar.
@@ -3124,8 +3124,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
 
             if type_info:
                 n = type_info.names.get(expr.name)
-                if n is not None and (n.kind == MODULE_REF or isinstance(n.node, (TypeInfo,
-                                                                                  TypeAlias))):
+                if n is not None and isinstance(n.node, (MypyFile, TypeInfo, TypeAlias)):
                     if not n:
                         return
                     expr.kind = n.kind
@@ -3591,7 +3590,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             assert self.locals[-1] is not None
             if name in self.locals[-1]:
                 # Flag redefinition unless this is a reimport of a module.
-                if not (node.kind == MODULE_REF and
+                if not (isinstance(node.node, MypyFile) and
                         self.locals[-1][name].node == node.node):
                     self.name_already_defined(name, context, self.locals[-1][name])
                     return
@@ -3665,7 +3664,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         elif isinstance(original_ctx, SymbolNode):
             node = original_ctx
 
-        if isinstance(original_ctx, SymbolTableNode) and original_ctx.kind == MODULE_REF:
+        if isinstance(original_ctx, SymbolTableNode) and isinstance(original_ctx.node, MypyFile):
             # Since this is an import, original_ctx.node points to the module definition.
             # Therefore its line number is always 1, which is not useful for this
             # error message.

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -24,7 +24,7 @@ from mypy.nodes import (
     MypyFile, SymbolTable, SymbolTableNode, Var, Block, AssignmentStmt, FuncDef, Decorator,
     ClassDef, TypeInfo, ImportFrom, Import, ImportAll, IfStmt, WhileStmt, ForStmt, WithStmt,
     TryStmt, OverloadedFuncDef, Lvalue, Context, ImportedName, LDEF, GDEF, MDEF, UNBOUND_IMPORTED,
-    MODULE_REF, implicit_module_attrs, AssertStmt,
+    implicit_module_attrs, AssertStmt,
 )
 from mypy.types import Type, UnboundType, UnionType, AnyType, TypeOfAny, NoneTyp, CallableType
 from mypy.semanal import SemanticAnalyzerPass2
@@ -360,7 +360,7 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
             assert self.sem.locals[-1] is not None
             if name in self.sem.locals[-1]:
                 # Flag redefinition unless this is a reimport of a module.
-                if not (node.kind == MODULE_REF and
+                if not (isinstance(node.node, MypyFile) and
                         self.sem.locals[-1][name].node == node.node):
                     self.sem.name_already_defined(name, context, self.sem.locals[-1][name])
                     return

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -54,7 +54,7 @@ from typing import Set, Dict, Tuple, Optional, Sequence, Union
 
 from mypy.nodes import (
     SymbolTable, TypeInfo, Var, SymbolNode, Decorator, TypeVarExpr, TypeAlias,
-    FuncBase, OverloadedFuncDef, FuncItem, MODULE_REF, UNBOUND_IMPORTED, TVAR
+    FuncBase, OverloadedFuncDef, FuncItem, MypyFile, UNBOUND_IMPORTED, TVAR
 )
 from mypy.types import (
     Type, TypeVisitor, UnboundType, AnyType, NoneTyp, UninhabitedType,
@@ -134,7 +134,7 @@ def snapshot_symbol_table(name_prefix: str, table: SymbolTable) -> Dict[str, Sna
         # TODO: cross_ref?
         fullname = node.fullname() if node else None
         common = (fullname, symbol.kind, symbol.module_public)
-        if symbol.kind == MODULE_REF:
+        if isinstance(symbol.node, MypyFile):
             # This is a cross-reference to another module.
             # If the reference is busted because the other module is missing,
             # the node will be a "stale_info" TypeInfo produced by fixup,

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -357,7 +357,7 @@ class StrConv(NodeVisitor[str]):
             id = self.format_id(target_node)
         else:
             id = ''
-        if isinstance(target_node, mypy.nodes.MypyFile):
+        if isinstance(target_node, mypy.nodes.MypyFile) and name == fullname:
             n += id
         elif kind == mypy.nodes.GDEF or (fullname != name and
                                        fullname is not None):

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -360,7 +360,7 @@ class StrConv(NodeVisitor[str]):
         if isinstance(target_node, mypy.nodes.MypyFile) and name == fullname:
             n += id
         elif kind == mypy.nodes.GDEF or (fullname != name and
-                                       fullname is not None):
+                                         fullname is not None):
             # Append fully qualified name for global references.
             n += ' [{}{}]'.format(fullname, id)
         elif kind == mypy.nodes.LDEF:

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -357,7 +357,9 @@ class StrConv(NodeVisitor[str]):
             id = self.format_id(target_node)
         else:
             id = ''
-        if kind == mypy.nodes.GDEF or (fullname != name and
+        if isinstance(target_node, mypy.nodes.MypyFile):
+            n += id
+        elif kind == mypy.nodes.GDEF or (fullname != name and
                                        fullname is not None):
             # Append fully qualified name for global references.
             n += ' [{}{}]'.format(fullname, id)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -20,10 +20,10 @@ from mypy.types import (
 )
 
 from mypy.nodes import (
-    TVAR, MODULE_REF, UNBOUND_IMPORTED, TypeInfo, Context, SymbolTableNode, Var, Expression,
+    TVAR, UNBOUND_IMPORTED, TypeInfo, Context, SymbolTableNode, Var, Expression,
     IndexExpr, RefExpr, nongen_builtins, check_arg_names, check_arg_kinds, ARG_POS, ARG_NAMED,
     ARG_OPT, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2, TypeVarExpr, FuncDef, CallExpr, NameExpr,
-    Decorator, ImportedName, TypeAlias
+    Decorator, ImportedName, TypeAlias, MypyFile
 )
 from mypy.tvar_scope import TypeVarScope
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
@@ -398,9 +398,9 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         # this type using a forward reference wrapper. It will be revisited in
         # the third pass.
         allow_forward_ref = not (self.third_pass or
-                                 isinstance(sym.node, (FuncDef, Decorator)) or
+                                 isinstance(sym.node, (FuncDef, Decorator, MypyFile)) or
                                  isinstance(sym.node, Var) and sym.node.is_ready or
-                                 sym.kind in (MODULE_REF, TVAR))
+                                 sym.kind == TVAR)
         if allow_forward_ref:
             # We currently can't support subscripted forward refs in functions;
             # see https://github.com/python/mypy/pull/3952#discussion_r139950690

--- a/test-data/unit/semanal-symtable.test
+++ b/test-data/unit/semanal-symtable.test
@@ -32,7 +32,7 @@ x = 1
 [out]
 __main__:
   SymbolTable(
-    m : ModuleRef/MypyFile (m))
+    m : Gdef/MypyFile (m))
 m:
   SymbolTable(
     x : Gdef/Var (m.x))


### PR DESCRIPTION
Instead, use a `node` that is a `MypyFile` to distinguish references to
a module.

This arguably makes things a little more consistent.