### PR TITLE
Add Python 3.7 Trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,6 +147,7 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'Topic :: Software Development',
 ]
 


### PR DESCRIPTION
The only thing we technically don't yet support is that in 3.7,
`async` and `await` are always keywords.  But this is at best a false
negative.  Similarly, mypy doesn't change its behavior based on the
presence of `from __future__ import annotations` -- it always
implements the 3.7 behavior for annotations.