### PR TITLE
Change version in junit.xml to have underscore

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -192,7 +192,7 @@ class Server:
         self.status_file = status_file
 
     def _response_metadata(self) -> Dict[str, str]:
-        py_version = '{}.{}'.format(self.options.python_version[0], self.options.python_version[1])
+        py_version = '{}_{}'.format(self.options.python_version[0], self.options.python_version[1])
         return {
             'platform': self.options.platform,
             'python_version': py_version,

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -101,7 +101,7 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
               file=sys.stderr)
     if options.junit_xml:
         t1 = time.time()
-        py_version = '{}.{}'.format(options.python_version[0], options.python_version[1])
+        py_version = '{}_{}'.format(options.python_version[0], options.python_version[1])
         util.write_junit_xml(t1 - t0, serious, messages, options.junit_xml,
                              py_version, options.platform)
 


### PR DESCRIPTION
To make the canonical junit name better

(Replaces #6208.)
