### PR TITLE
Expand "getting started" docs to discuss type hints in more detail

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -336,7 +336,7 @@ potentially problematic or redundant in some way.
     a ``# type: ignore`` comment on a line that is not actually
     generating an error message.
 
-    This flag, along with the ``--warn-unsued-casts`` flag, are both
+    This flag, along with the ``--warn-unused-casts`` flag, are both
     particularly useful when you are upgrading mypy. Previously,
     you may have needed to add casts or ``# type: ignore`` annotations
     to work around bugs in mypy or missing stubs for 3rd party libraries.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -28,16 +28,16 @@ Once mypy is installed, run it by using the ``mypy`` tool:
 
 This command makes mypy *type check* your ``program.py`` file and print
 out any errors it finds. Mypy will type check your code *statically*: this
-means that it will check for error without ever running your code, just
+means that it will check for errors without ever running your code, just
 like a linter.
 
 This means that you are always free to ignore the errors mypy reports and
 treat them as just warnings, if you so wish: mypy runs independently from
 Python itself.
 
-However, if you try running mypy on your existing Python code, it will most
-likely report little to no errors: you must add *type annotations* to your
-code to take full advantage of mypy. See the section below for details.
+However, if you try directly running mypy on your existing Python code, it
+will most likely report little to no errors: you must add *type annotations*
+to your code to take full advantage of mypy. See the section below for details.
 
 .. note::
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -62,12 +62,12 @@ A function without type annotations is considered to be *dynamically typed* by m
 By default, mypy will **not** type check dynamically typed functions. This means
 that with a few exceptions, mypy will not report any errors with regular unannotated Python.
 
-This is the case even if we misuse the function: for example, mypy would currently
-not report any errors if we tried running ``greeting(3)`` or ``greeting(b"Alice")``
+This is the case even if you misuse the function: for example, mypy would currently
+not report any errors if you tried running ``greeting(3)`` or ``greeting(b"Alice")``
 even though those function calls would result in errors at runtime.
 
-We can teach mypy to detect these kinds of bugs by adding *type annotations* (also
-known as *type hints*). For example, we can teach mypy that ``greeting`` both accepts
+You can teach mypy to detect these kinds of bugs by adding *type annotations* (also
+known as *type hints*). For example, you can teach mypy that ``greeting`` both accepts
 and returns a string like so:
 
 .. code-block:: python
@@ -75,7 +75,7 @@ and returns a string like so:
    def greeting(name: str) -> str:
        return 'Hello ' + name
 
-Our function is now *statically typed*: mypy can use the provided type hints to detect
+This function is now *statically typed*: mypy can use the provided type hints to detect
 incorrect usages of the ``greeting`` function. For example, it will reject the following
 calls since the arguments have invalid types:
 
@@ -118,8 +118,8 @@ More function signatures
 
 Here are a few more examples of adding type hints to function signatures.
 
-If a function does not explicitly return a value we give the return
-type as ``None``. Using a ``None`` result in a statically typed
+If a function does not explicitly return a value, give it a return
+type of ``None``. Using a ``None`` result in a statically typed
 context results in a type check error:
 
 .. code-block:: python
@@ -129,7 +129,7 @@ context results in a type check error:
 
    a = p()  # Error: "p" does not return a value
 
-Make sure to remember to include ``None``: if we don't, the function
+Make sure to remember to include ``None``: if you don't, the function
 will be dynamically typed. For example:
 
 .. code-block:: python
@@ -169,9 +169,9 @@ So far, we've added type hints that use only basic concrete types like
 ``str`` and ``float``. What if we want to express more complex types,
 such as "a list of strings" or "an iterable of ints"? 
 
-We can find many of these more complex static types inside of the ``typing``
-module. For example, if we want to indicate that some function can accept
-a list of strings, we can use the ``List`` type from the ``typing`` module:
+You can find many of these more complex static types inside of the ``typing``
+module. For example, to indicate that some function can accept a list of
+strings, use the ``List`` type from the ``typing`` module:
 
 .. code-block:: python
 
@@ -192,11 +192,11 @@ accept one or more *type parameters*. In this case, we *parameterized* ``List``
 by writing ``List[str]``. This lets mypy know that ``greet_all`` accepts specifically
 lists containing strings, and not lists containing ints or any other type.
 
-In this particular case, our type signature is perhaps a little too rigid.
+In this particular case, the type signature is perhaps a little too rigid.
 After all, there's no reason why this function must accept *specifically* a list --
-it would run just fine if we pass in a tuple, a set, or any custom iterable.
+it would run just fine if you were to pass in a tuple, a set, or any other custom iterable.
 
-We can express this idea by using the ``Iterable`` type instead of ``List``:
+You can express this idea using the ``Iterable`` type instead of ``List``:
 
 .. code-block:: python
 
@@ -206,8 +206,8 @@ We can express this idea by using the ``Iterable`` type instead of ``List``:
        for name in names:
            print('Hello ' + name)
 
-As a final example, suppose want to write a function that can accept *either*
-ints or strings, but no other types. We can express this using the ``Union`` type:
+As another example, suppose you want to write a function that can accept *either*
+ints or strings, but no other types. You can express this using the ``Union`` type:
 
 .. code-block:: python
 
@@ -219,11 +219,11 @@ ints or strings, but no other types. We can express this using the ``Union`` typ
        else:
            return user_id
 
-Similarly, suppose that we want our function to accept only strings or None. We can
+Similarly, suppose that you want the function to accept only strings or None. You can
 again use ``Union`` and use ``Union[str, None]`` -- or alternatively, use the type
 ``Optional[str]``. These two types are identical and interchangeable: ``Optional[str]``
 is just a shorthand or *alias* for ``Union[str, None]``. It exists mostly as a convenience
-to help our function signatures look a little cleaner:
+to help function signatures look a little cleaner:
 
 .. code-block:: python
 
@@ -276,25 +276,29 @@ of type ``List[float]`` and that ``num`` must be of type ``float``:
                output.append(num)
        return output
 
-Mypy will warn you if it is unable to determine the type of some variable.
-For example, suppose we assign an empty dictionary to some global variable:
+Mypy will warn you if it is unable to determine the type of some variable --
+for example, when assigning an empty dictionary to some global value:
 
 .. code-block:: python
 
     my_global_dict = {}  # Error: Need type annotation for 'my_global_dict'
 
-We can teach mypy what type ``my_global_dict`` is meant to have by giving it
-a type hint. For example, if we knew this variable is supposed to be a dict
-of ints to floats, we could annotate it like so:
+You can teach mypy what type ``my_global_dict`` is meant to have by giving it
+a type hint. For example, if you knew this variable is supposed to be a dict
+of ints to floats, you could annotate it using either variable annotations
+(introduced in Python 3.6 by :ref:`PEP 526 <pep526_>`_) or using a comment-based
+syntax like so:
 
 .. code-block:: python
 
-   # If you are using Python 3.6+, you can use variable annotations.
-   # See https://www.python.org/dev/peps/pep-0526/ for more on variable annotations.
+   # If you're using Python 3.6+
    my_global_dict: Dict[int, float] = {}
 
-   # If you are using older versions of Python, you can use the comment-based syntax:
+   # If you want compatibility with older versions of Python
    my_global_dict = {}  # type: Dict[int, float]
+
+.. _pep526: https://www.python.org/dev/peps/pep-0526/
+
 
 .. _stubs-intro:
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -88,7 +88,7 @@ and returns a string like so:
        return 'Hello ' + name
 
 Our function is now *statically typed*: mypy can use the provided type hints to detect
-incorrect ussages of the ``greeting`` function. For example, it will reject the following
+incorrect usages of the ``greeting`` function. For example, it will reject the following
 calls since the arguments have invalid types:
 
 .. code-block:: python
@@ -111,7 +111,7 @@ See our section on :ref:`typing Python 2 code <python2>` for more details.
 Being able to pick whether you want a function to be dynamically or statically
 typed can be very helpful. For example, if you are migrating an existing
 Python codebase to use static types, it's usually easier to migrate by incrementally
-adding type hints to your code rather then adding them all at once. Similarly,
+adding type hints to your code rather than adding them all at once. Similarly,
 when you are prototyping a new feature, it may be convenient to initially implement
 the code using dynamic typing and only add type hints later once the code is more stable.
 
@@ -267,7 +267,7 @@ of type ``List[float]`` and that ``num`` must be of type ``float``:
                output.append(num)
        return output
 
-Mypy will warn you if it is unable to determine what the type of some variable is.
+Mypy will warn you if it is unable to determine the type of some variable.
 For example, suppose we assign an empty dictionary to some global variable:
 
 .. code-block:: python

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,12 +16,16 @@ Mypy is a static type checker for Python 3 and Python 2.7.
    getting_started
    existing_code
 
+.. _overview-cheat-sheets:
+
 .. toctree::
    :maxdepth: 2
    :caption: Cheat sheets
 
    cheat_sheet_py3
    cheat_sheet
+
+.. _overview-type-system-reference:
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -186,7 +186,7 @@ are trying to use has done neither of these things. In that case, you can try:
     :ref:`PEP 561 compliant packages <installed-packages>`.
 
 If the module is a third party library, but you cannot find any existing
-type hints nor have to time to write your own, you can *silence* the errors:
+type hints nor have time to write your own, you can *silence* the errors:
 
 1.  To silence a *single* missing import error, add a `# type: ignore` at the end of the
     line containing the import.


### PR DESCRIPTION
This pull request expands our "getting started" docs so they discuss how to use type hints in more detail.

In general, I'm hoping this pull request will accomplish two main things:

1. Give users a better "tour" of the available PEP 484 types.

2. Do a better job of giving users a "heads-up" of common gotchas: for example, how dynamically typed functions aren't type-checked.

Here's a list of specific changes I made:

1. I combined "Installing mypy" and "Running mypy" into one section.

2. I modified the "Function signatures" section to focus more on the distinction between dynamic and static typing: I suspect that's a common tripup new users run into.

   I also changed the examples so they'll actually produce a runtime error if you misuse them.

3. I moved the existing text on annotating no-argument functions or functions with default arguments into a separate "More function signatures" to try and keep the new "Function signatures and dynamic vs static typing" section focused.

4. I expanded the section about using the "typing" module to be more thorough. In particular, I wanted to expose the user to the concept of concrete generic types (List), abstract generic types/protocols (Iterable), and to more non-conventional types like Union.

   I think these three examples are broadly representative of the different "flavors" of PEP 484 types and so should help new users be a little more aware of the kinds of things they can do with types.

   The main thing that's missing is an introduction to custom generic classes and functions: that's probably too complex of a topic to belong in this page.

5. I added a section on local type inference: it's a new concept for people who are more used to languages like Java or C# so felt like it was worth mentioning.

   This section also covers the other stumbling block I think new users are likely to run into: the "Need type annotation for 'variable'" error message.

6. I added a section on customizing mypy via the command line flags. I don't think enough users are aware that you can do this, despite how useful the flags can be.