### PR TITLE
Enable strictness flags that require no source code changes

### DIFF
--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -254,7 +254,7 @@ class FileSystemCache:
     def samefile(self, f1: str, f2: str) -> bool:
         s1 = self.stat(f1)
         s2 = self.stat(f2)
-        return os.path.samestat(s1, s2)  # type: ignore
+        return os.path.samestat(s1, s2)
 
 
 def copy_os_error(e: OSError) -> OSError:

--- a/mypy/interpreted_plugin.py
+++ b/mypy/interpreted_plugin.py
@@ -23,7 +23,7 @@ class InterpretedPlugin:
 
     def __new__(cls, *args: Any, **kwargs: Any) -> 'mypy.plugin.Plugin':
         from mypy.plugin import WrapperPlugin
-        plugin = object.__new__(cls)  # type: ignore
+        plugin = object.__new__(cls)
         plugin.__init__(*args, **kwargs)
         return WrapperPlugin(plugin)
 

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -39,7 +39,7 @@ def parse_test_case(case: 'DataDrivenTestCase') -> None:
     if case.suite.native_sep:
         join = os.path.join
     else:
-        join = posixpath.join  # type: ignore
+        join = posixpath.join
 
     out_section_missing = case.suite.required_out_section
     normalize_output = True

--- a/mypy_bootstrap.ini
+++ b/mypy_bootstrap.ini
@@ -1,5 +1,8 @@
 [mypy]
+disallow_untyped_calls = True
 disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
 disallow_subclassing_any = True
 warn_no_return = True
 strict_optional = True
@@ -15,3 +18,4 @@ platform = mypyc
 # needs py2 compatibility
 [mypy-mypy.test.testextensions]
 disallow_untyped_defs = False
+check_untyped_defs = False

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -1,5 +1,8 @@
 [mypy]
+disallow_untyped_calls = True
 disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
 disallow_subclassing_any = True
 warn_no_return = True
 strict_optional = True
@@ -13,3 +16,4 @@ show_traceback = True
 # needs py2 compatibility
 [mypy-mypy.test.testextensions]
 disallow_untyped_defs = False
+check_untyped_defs = False


### PR DESCRIPTION
This diff tightens up mypy's self-check slightly by enabling some of the `--strict` flags that mypy is currently already passing.

I also thought about enabling `--warn-unused-ignores` since there were only four places where we need to delete a `# type: ignore` comment, but ultimately decided against it: I don't want to complicate typeshed contributions (since typeshed's tests run mypy's self-check) and because one of those ignores looked like it was related to weird mypyc shenanigans (the lxml import in mypy/report.py).

I did go ahead and remove the other three `# type: ignores` though.