### PR TITLE
Initial work towards new semantic analyzer

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -506,6 +506,8 @@ class BuildManager(BuildManagerBase):
         self.missing_modules = set()  # type: Set[str]
         self.plugin = plugin
         if options.new_semantic_analyzer:
+            # Set of namespaces (module or class) that are being populated during semantic
+            # analysis and may have missing definitions.
             self.incomplete_namespaces = set()  # type: Set[str]
             self.new_semantic_analyzer = NewSemanticAnalyzer(
                 self.modules,
@@ -1812,8 +1814,7 @@ class State:
         patches = []  # type: List[Tuple[int, Callable[[], None]]]
         self.manager.semantic_analyzer.imports.clear()
         with self.wrap_context():
-            self.manager.semantic_analyzer.visit_file(self.tree, self.xpath, self.options,
-                                                      patches)
+            self.manager.semantic_analyzer.visit_file(self.tree, self.xpath, self.options, patches)
         self.patches = patches
         for dep in self.manager.semantic_analyzer.imports:
             self.dependencies.append(dep)

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -506,8 +506,13 @@ class BuildManager(BuildManagerBase):
         self.missing_modules = set()  # type: Set[str]
         self.plugin = plugin
         if options.new_semantic_analyzer:
-            self.new_semantic_analyzer = NewSemanticAnalyzer(self.modules, self.missing_modules,
-                                                             self.errors, self.plugin)
+            self.incomplete_namespaces = set()  # type: Set[str]
+            self.new_semantic_analyzer = NewSemanticAnalyzer(
+                self.modules,
+                self.missing_modules,
+                self.incomplete_namespaces,
+                self.errors,
+                self.plugin)
         else:
             self.semantic_analyzer = SemanticAnalyzerPass2(self.modules, self.missing_modules,
                                                            self.errors, self.plugin)

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -32,8 +32,11 @@ if MYPY:
 
 from mypy.nodes import (MypyFile, ImportBase, Import, ImportFrom, ImportAll)
 from mypy.semanal_pass1 import SemanticAnalyzerPass1
+from mypy.newsemanal.semanal_pass1 import ReachabilityAnalyzer
 from mypy.semanal import SemanticAnalyzerPass2, apply_semantic_analyzer_patches
 from mypy.semanal_pass3 import SemanticAnalyzerPass3
+from mypy.newsemanal.semanal import NewSemanticAnalyzer
+from mypy.newsemanal.semanal_main import semantic_analysis_for_scc
 from mypy.checker import TypeChecker
 from mypy.indirection import TypeIndirectionVisitor
 from mypy.errors import Errors, CompileError, report_internal_error
@@ -502,10 +505,14 @@ class BuildManager(BuildManagerBase):
         self.modules = {}  # type: Dict[str, MypyFile]
         self.missing_modules = set()  # type: Set[str]
         self.plugin = plugin
-        self.semantic_analyzer = SemanticAnalyzerPass2(self.modules, self.missing_modules,
-                                                  self.errors, self.plugin)
-        self.semantic_analyzer_pass3 = SemanticAnalyzerPass3(self.modules, self.errors,
-                                                             self.semantic_analyzer)
+        if options.new_semantic_analyzer:
+            self.new_semantic_analyzer = NewSemanticAnalyzer(self.modules, self.missing_modules,
+                                                             self.errors, self.plugin)
+        else:
+            self.semantic_analyzer = SemanticAnalyzerPass2(self.modules, self.missing_modules,
+                                                           self.errors, self.plugin)
+            self.semantic_analyzer_pass3 = SemanticAnalyzerPass3(self.modules, self.errors,
+                                                                 self.semantic_analyzer)
         self.all_types = {}  # type: Dict[Expression, Type]  # Enabled by export_types
         self.indirection_detector = TypeIndirectionVisitor()
         self.stale_modules = set()  # type: Set[str]
@@ -1721,20 +1728,43 @@ class State:
 
         modules[self.id] = self.tree
 
-        # Do the first pass of semantic analysis: add top-level
-        # definitions in the file to the symbol table.  We must do
-        # this before processing imports, since this may mark some
-        # import statements as unreachable.
-        first = SemanticAnalyzerPass1(manager.semantic_analyzer)
-        with self.wrap_context():
-            first.visit_file(self.tree, self.xpath, self.id, self.options)
+        self.semantic_analysis_pass1()
 
-        # Initialize module symbol table, which was populated by the
-        # semantic analyzer.
-        # TODO: Why can't SemanticAnalyzerPass1 .analyze() do this?
-        self.tree.names = manager.semantic_analyzer.globals
+        if not self.options.new_semantic_analyzer:
+            # Initialize module symbol table, which was populated by the
+            # semantic analyzer.
+            # TODO: Why can't SemanticAnalyzerPass1 .analyze() do this?
+            self.tree.names = manager.semantic_analyzer.globals
 
         self.check_blockers()
+
+    def semantic_analysis_pass1(self) -> None:
+        """Perform pass 1 of semantic analysis, which happens immediately after parsing.
+
+        This pass can't assume that any other modules have been processed yet.
+        """
+        options = self.options
+        assert self.tree is not None
+        if options.new_semantic_analyzer:
+            # Do the first pass of semantic analysis: analyze the reachability
+            # of blocks and import statements. We must do this before
+            # processing imports, since this may mark some import statements as
+            # unreachable.
+            #
+            # TODO: Once we remove the old semantic analyzer, this no longer should
+            #     be considered as a semantic analysis pass -- it's an independent
+            #     pass.
+            analyzer = ReachabilityAnalyzer()
+            with self.wrap_context():
+                analyzer.visit_file(self.tree, self.xpath, self.id, options)
+        else:
+            # Do the first pass of semantic analysis: add top-level
+            # definitions in the file to the symbol table.  We must do
+            # this before processing imports, since this may mark some
+            # import statements as unreachable.
+            first = SemanticAnalyzerPass1(self.manager.semantic_analyzer)
+            with self.wrap_context():
+                first.visit_file(self.tree, self.xpath, self.id, options)
 
     def compute_dependencies(self) -> None:
         """Compute a module's dependencies after parsing it.
@@ -1777,7 +1807,8 @@ class State:
         patches = []  # type: List[Tuple[int, Callable[[], None]]]
         self.manager.semantic_analyzer.imports.clear()
         with self.wrap_context():
-            self.manager.semantic_analyzer.visit_file(self.tree, self.xpath, self.options, patches)
+            self.manager.semantic_analyzer.visit_file(self.tree, self.xpath, self.options,
+                                                      patches)
         self.patches = patches
         for dep in self.manager.semantic_analyzer.imports:
             self.dependencies.append(dep)
@@ -2649,12 +2680,15 @@ def process_stale_scc(graph: Graph, scc: List[str], manager: BuildManager) -> No
         typing_mod = graph['typing'].tree
         assert typing_mod, "The typing module was not parsed"
         manager.semantic_analyzer.add_builtin_aliases(typing_mod)
-    for id in stale:
-        graph[id].semantic_analysis()
-    for id in stale:
-        graph[id].semantic_analysis_pass_three()
-    for id in stale:
-        graph[id].semantic_analysis_apply_patches()
+    if manager.options.new_semantic_analyzer:
+        semantic_analysis_for_scc(graph, scc)
+    else:
+        for id in stale:
+            graph[id].semantic_analysis()
+        for id in stale:
+            graph[id].semantic_analysis_pass_three()
+        for id in stale:
+            graph[id].semantic_analysis_apply_patches()
     for id in stale:
         graph[id].type_check_first_pass()
     more = True

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -582,6 +582,8 @@ def process_options(args: List[str],
              "the contents of SHADOW_FILE instead.")
     add_invertible_flag('--fast-exit', default=False, help=argparse.SUPPRESS,
                         group=internals_group)
+    add_invertible_flag('--new-semantic-analyzer', default=False, help=argparse.SUPPRESS,
+                        group=internals_group)
 
     error_group = parser.add_argument_group(
         title='Error reporting',

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1147,6 +1147,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 # Special case 'builtins.object'. It was alredy created, just patch the
                 # actual ClassDef object.
                 info = self.globals['object'].node
+                assert isinstance(info, TypeInfo)
                 defn.info = info
                 info.defn = defn
             else:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -68,8 +68,8 @@ from mypy.plugin import (
     DynamicClassDefContext
 )
 from mypy.util import get_prefix, correct_relative_import, unmangle
-from mypy.semanal_shared import SemanticAnalyzerInterface, set_callable_name
 from mypy.scope import Scope
+from mypy.newsemanal.semanal_shared import SemanticAnalyzerInterface, set_callable_name
 from mypy.newsemanal.semanal_namedtuple import NamedTupleAnalyzer, NAMEDTUPLE_PROHIBITED_NAMES
 from mypy.newsemanal.semanal_typeddict import TypedDictAnalyzer
 from mypy.newsemanal.semanal_enum import EnumCallAnalyzer

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1,4 +1,4 @@
-"""The semantic analyzer passes 1 and 2.
+"""The new semantic analyzer (work in progress).
 
 Bind names to definitions and do various other simple consistency
 checks. For example, consider this program:
@@ -13,23 +13,7 @@ analysis).  Also, it would bind both references to 'x' to the same
 module-level variable (Var) node.  The second assignment would also
 be analyzed, and the type of 'y' marked as being inferred.
 
-Semantic analysis is the first analysis pass after parsing, and it is
-subdivided into three passes:
-
- * SemanticAnalyzerPass1 is defined in mypy.semanal_pass1.
-
- * SemanticAnalyzerPass2 is the second pass.  It does the bulk of the work.
-   It assumes that dependent modules have been semantically analyzed,
-   up to the second pass, unless there is a import cycle.
-
- * SemanticAnalyzerPass3 is the third pass. It's in mypy.semanal_pass3.
-
 Semantic analysis of types is implemented in module mypy.typeanal.
-
-TODO: Check if the third pass slows down type checking significantly.
-  We could probably get rid of it -- for example, we could collect all
-  analyzed types in a collection and check them without having to
-  traverse the entire AST.
 """
 
 from contextlib import contextmanager
@@ -164,16 +148,14 @@ SUGGESTED_TEST_FIXTURES = {
 }  # type: Final
 
 
-class SemanticAnalyzerPass2(NodeVisitor[None],
-                            SemanticAnalyzerInterface,
-                            SemanticAnalyzerPluginInterface):
+class NewSemanticAnalyzer(NodeVisitor[None],
+                          SemanticAnalyzerInterface,
+                          SemanticAnalyzerPluginInterface):
     """Semantically analyze parsed mypy files.
 
     The analyzer binds names and does various consistency checks for a
     parse tree. Note that type checking is performed as a separate
     pass.
-
-    This is the second phase of semantic analysis.
     """
 
     # Module name space

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1582,6 +1582,11 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 self.add_symbol(imported_id, symbol, imp)
             elif module and not missing:
                 # Missing attribute.
+                if import_id in self.incomplete_namespaces:
+                    # We don't know whether the name will be there, since the namespace
+                    # is incomplete. Defer the current target.
+                    self.deferred = True
+                    return
                 message = "Module '{}' has no attribute '{}'".format(import_id, id)
                 extra = self.undefined_name_extra_info('{}.{}'.format(import_id, id))
                 if extra:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -333,6 +333,12 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         self._is_typeshed_stub_file = self.errors.is_typeshed_file(file_node.path)
         self.globals = file_node.names
         self.tvar_scope = TypeVarScope()
+
+        self.named_tuple_analyzer = NamedTupleAnalyzer(options, self)
+        self.typed_dict_analyzer = TypedDictAnalyzer(options, self, self.msg)
+        self.enum_call_analyzer = EnumCallAnalyzer(options, self)
+        self.newtype_analyzer = NewTypeAnalyzer(options, self, self.msg)
+
         if active_type:
             scope.enter_class(active_type)
             self.enter_class(active_type.defn.info)

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -796,6 +796,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             self.fail('Type signature has too many arguments', fdef, blocker=True)
 
     def visit_class_def(self, defn: ClassDef) -> None:
+        self.setup_class_def_analysis(defn)
         with self.scope.class_scope(defn.info):
             with self.tvar_scope_frame(self.tvar_scope.class_frame()):
                 self.analyze_class(defn)
@@ -809,7 +810,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             return
         if self.analyze_namedtuple_classdef(defn):
             return
-        self.setup_class_def_analysis(defn)
         self.analyze_base_classes(defn)
         defn.info.is_protocol = is_protocol
         self.analyze_metaclass(defn)

--- a/mypy/newsemanal/semanal_enum.py
+++ b/mypy/newsemanal/semanal_enum.py
@@ -10,7 +10,7 @@ from mypy.nodes import (
     UnicodeExpr, TupleExpr, ListExpr, DictExpr, Var, SymbolTableNode, GDEF, MDEF, ARG_POS,
     EnumCallExpr
 )
-from mypy.semanal_shared import SemanticAnalyzerInterface
+from mypy.newsemanal.semanal_shared import SemanticAnalyzerInterface
 from mypy.options import Options
 
 

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -1,0 +1,49 @@
+"""Top-level logic for the new semantic analyzer."""
+
+from typing import List
+
+from mypy.nodes import Node, SymbolTable
+
+MYPY = False
+if MYPY:
+    from mypy.build import Graph, State
+
+
+def semantic_analysis_for_scc(graph: 'Graph', scc: List[str]) -> None:
+    # Assume pass 1 has already been peformed.
+    process_top_levels(graph, scc)
+    process_functions(graph, scc)
+
+
+def process_top_levels(graph: 'Graph', scc: List[str]) -> None:
+    # Process top levels until everything has been bound.
+    # TODO: Limit the number of iterations
+    worklist = scc[:]
+    while worklist:
+        deferred = []  # type: List[str]
+        while worklist:
+            next_id = worklist.pop()
+            deferred += graph[next_id].semantic_analyze_target(next_id)
+        worklist = deferred
+
+
+def process_functions(graph: 'Graph', scc: List[str]) -> None:
+    # Process functions.
+    deferred = []  # type: List[str]
+    for id in scc:
+        tree = graph[id].tree
+        assert tree is not None
+        symtable = tree.names
+        targets = get_all_leaf_targets(symtable)
+        for target in targets:
+            deferred += graph[id].semantic_analyze_target(id)
+    assert not deferred  # There can't be cross-function forward refs
+
+
+def get_all_leaf_targets(symtable: SymbolTable) -> List[str]:
+    assert False
+    return []
+
+
+def semanatic_analyze_target(id: str, state: 'State') -> List[str]:
+    assert False

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -10,7 +10,7 @@ if MYPY:
 
 
 def semantic_analysis_for_scc(graph: 'Graph', scc: List[str]) -> None:
-    # Assume pass 1 has already been peformed.
+    # Assume reachability analysis has already been performed.
     process_top_levels(graph, scc)
     process_functions(graph, scc)
 
@@ -41,6 +41,7 @@ def process_top_levels(graph: 'Graph', scc: List[str]) -> None:
 
 
 def process_functions(graph: 'Graph', scc: List[str]) -> None:
+    # TODO: This doesn't quite work yet
     # Process functions.
     deferred = []  # type: List[str]
     for id in scc:
@@ -54,6 +55,7 @@ def process_functions(graph: 'Graph', scc: List[str]) -> None:
 
 
 def get_all_leaf_targets(symtable: SymbolTable) -> List[str]:
+    # TODO: Implement
     return []
 
 

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -49,7 +49,7 @@ def process_functions(graph: 'Graph', scc: List[str]) -> None:
         symtable = tree.names
         targets = get_all_leaf_targets(symtable)
         for target in targets:
-            deferred += semantic_analyze_target(next_id, graph[next_id])
+            deferred += semantic_analyze_target(target, graph[id])
     assert not deferred  # There can't be cross-function forward refs
 
 
@@ -57,7 +57,8 @@ def get_all_leaf_targets(symtable: SymbolTable) -> List[str]:
     return []
 
 
-def semantic_analyze_target(module: str, state: 'State') -> List[str]:
+def semantic_analyze_target(target: str, state: 'State') -> List[str]:
+    # TODO: Support refreshing function targets (currently only works for module top levels)
     tree = state.tree
     assert tree is not None
     analyzer = state.manager.new_semantic_analyzer
@@ -71,6 +72,6 @@ def semantic_analyze_target(module: str, state: 'State') -> List[str]:
                                active_type=None):
         analyzer.refresh_partial(tree, [])
     if analyzer.deferred:
-        return [module]
+        return [target]
     else:
         return []

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -23,7 +23,7 @@ def process_top_levels(graph: 'Graph', scc: List[str]) -> None:
         deferred = []  # type: List[str]
         while worklist:
             next_id = worklist.pop()
-            deferred += graph[next_id].semantic_analyze_target(next_id)
+            deferred += semantic_analyze_target(next_id, graph[next_id])
         worklist = deferred
 
 
@@ -36,14 +36,26 @@ def process_functions(graph: 'Graph', scc: List[str]) -> None:
         symtable = tree.names
         targets = get_all_leaf_targets(symtable)
         for target in targets:
-            deferred += graph[id].semantic_analyze_target(id)
+            deferred += semantic_analyze_target(next_id, graph[next_id])
     assert not deferred  # There can't be cross-function forward refs
 
 
 def get_all_leaf_targets(symtable: SymbolTable) -> List[str]:
-    assert False
     return []
 
 
-def semanatic_analyze_target(id: str, state: 'State') -> List[str]:
-    assert False
+def semantic_analyze_target(id: str, state: 'State') -> List[str]:
+    tree = state.tree
+    assert tree is not None
+    analyzer = state.manager.new_semantic_analyzer
+    # TODO: Move initialization to somewhere else
+    analyzer.global_decls = [set()]
+    analyzer.nonlocal_decls = [set()]
+    tree.names = SymbolTable()
+    analyzer.globals = tree.names
+    with analyzer.file_context(file_node=tree,
+                               fnam=tree.path,
+                               options=state.options,
+                               active_type=None):
+        analyzer.refresh_partial(tree, [])
+    return []

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -18,6 +18,10 @@ def semantic_analysis_for_scc(graph: 'Graph', scc: List[str]) -> None:
 def process_top_levels(graph: 'Graph', scc: List[str]) -> None:
     # Process top levels until everything has been bound.
     # TODO: Limit the number of iterations
+    for id in scc:
+        state = graph[id]
+        assert state.tree is not None
+        state.manager.new_semantic_analyzer.prepare_file(state.tree)
     worklist = scc[:]
     while worklist:
         deferred = []  # type: List[str]
@@ -44,14 +48,13 @@ def get_all_leaf_targets(symtable: SymbolTable) -> List[str]:
     return []
 
 
-def semantic_analyze_target(id: str, state: 'State') -> List[str]:
+def semantic_analyze_target(module: str, state: 'State') -> List[str]:
     tree = state.tree
     assert tree is not None
     analyzer = state.manager.new_semantic_analyzer
     # TODO: Move initialization to somewhere else
     analyzer.global_decls = [set()]
     analyzer.nonlocal_decls = [set()]
-    tree.names = SymbolTable()
     analyzer.globals = tree.names
     with analyzer.file_context(file_node=tree,
                                fnam=tree.path,

--- a/mypy/newsemanal/semanal_newtype.py
+++ b/mypy/newsemanal/semanal_newtype.py
@@ -10,7 +10,7 @@ from mypy.nodes import (
     AssignmentStmt, NewTypeExpr, CallExpr, NameExpr, RefExpr, Context, StrExpr, BytesExpr,
     UnicodeExpr, Block, FuncDef, Argument, TypeInfo, Var, SymbolTableNode, GDEF, MDEF, ARG_POS
 )
-from mypy.semanal_shared import SemanticAnalyzerInterface
+from mypy.newsemanal.semanal_shared import SemanticAnalyzerInterface
 from mypy.options import Options
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.newsemanal.typeanal import check_for_explicit_any, has_any_from_unimported_type

--- a/mypy/newsemanal/semanal_pass1.py
+++ b/mypy/newsemanal/semanal_pass1.py
@@ -1,390 +1,80 @@
-"""The semantic analyzer pass 1.
+"""Block/import reachability analysis."""
 
-This sets up externally visible names defined in a module but doesn't
-follow imports and mostly ignores local definitions.  It helps enable
-(some) cyclic references between modules, such as module 'a' that
-imports module 'b' and used names defined in 'b' *and* vice versa.  The
-first pass can be performed before dependent modules have been
-processed.
-
-Since this pass can't assume that other modules have been processed,
-this pass cannot detect certain definitions that can only be recognized
-in later passes. Examples of these include TypeVar and NamedTuple
-definitions, as these look like regular assignments until we are able to
-bind names, which only happens in pass 2.
-
-This pass also infers the reachability of certain if statements, such as
-those with platform checks. This lets us filter out unreachable imports
-at an early stage.
-"""
-
-from typing import List, Tuple
-
-from mypy import state
 from mypy.nodes import (
-    MypyFile, SymbolTable, SymbolTableNode, Var, Block, AssignmentStmt, FuncDef, Decorator,
-    ClassDef, TypeInfo, ImportFrom, Import, ImportAll, IfStmt, WhileStmt, ForStmt, WithStmt,
-    TryStmt, OverloadedFuncDef, Lvalue, Context, ImportedName, LDEF, GDEF, MDEF, UNBOUND_IMPORTED,
-    implicit_module_attrs, AssertStmt,
+    MypyFile, AssertStmt, IfStmt, Block, AssignmentStmt, ExpressionStmt, ReturnStmt, ForStmt
 )
-from mypy.types import Type, UnboundType, UnionType, AnyType, TypeOfAny, NoneTyp, CallableType
-from mypy.newsemanal.semanal import SemanticAnalyzerPass2
-from mypy.reachability import infer_reachability_of_if_statement, assert_will_always_fail
-from mypy.semanal_shared import create_indirect_imported_name
+from mypy.traverser import TraverserVisitor
 from mypy.options import Options
-from mypy.sametypes import is_same_type
-from mypy.visitor import NodeVisitor
-from mypy.renaming import VariableRenameVisitor
+from mypy.reachability import infer_reachability_of_if_statement, assert_will_always_fail
 
 
-class SemanticAnalyzerPass1(NodeVisitor[None]):
-    """First phase of semantic analysis.
+class ReachabilityAnalyzer(TraverserVisitor):
+    """Analyze reachability of blocks and imports.
 
-    See docstring of 'visit_file()' below and the module docstring for a
-    description of what this does.
+    This determines static reachability of blocks and imports due to version and
+    platform checks, among others.
+
+    The main entry point is 'visit_file'.
+
+    Reachability of imports needs to be determined very early in the build since
+    this affects which modules will ultimately be processed.
+
+    Consider this example:
+
+      import sys
+
+      def do_stuff():
+          # type: () -> None:
+          if sys.python_version < (3,):
+              import xyz  # Only available in Python 2
+              xyz.whatever()
+          ...
+
+    The block containing 'import xyz' is unreachable in Python 3 mode. The import
+    shouldn't be processed in Python 3 mode, even if the module happens to exist.
     """
 
-    def __init__(self, sem: SemanticAnalyzerPass2) -> None:
-        self.sem = sem
-
     def visit_file(self, file: MypyFile, fnam: str, mod_id: str, options: Options) -> None:
-        """Perform the first analysis pass.
-
-        Populate module global table.  Resolve the full names of
-        definitions not nested within functions and construct type
-        info structures, but do not resolve inter-definition
-        references such as base classes.
-
-        Also add implicit definitions such as __name__.
-
-        In this phase we don't resolve imports. For 'from ... import',
-        we generate dummy symbol table nodes for the imported names,
-        and these will get resolved in later phases of semantic
-        analysis.
-        """
-        if options.allow_redefinition:
-            # Perform renaming across the AST to allow variable redefinitions
-            file.accept(VariableRenameVisitor())
-        sem = self.sem
-        self.sem.options = options  # Needed because we sometimes call into it
         self.pyversion = options.python_version
         self.platform = options.platform
-        sem.cur_mod_id = mod_id
-        sem.cur_mod_node = file
-        sem.errors.set_file(fnam, mod_id, scope=sem.scope)
-        sem.globals = SymbolTable()
-        sem.global_decls = [set()]
-        sem.nonlocal_decls = [set()]
-        sem.block_depth = [0]
+        self.cur_mod_id = mod_id
+        self.cur_mod_node = file
+        self.options = options
 
-        sem.scope.enter_file(mod_id)
-
-        defs = file.defs
-
-        with state.strict_optional_set(options.strict_optional):
-            # Add implicit definitions of module '__name__' etc.
-            for name, t in implicit_module_attrs.items():
-                # unicode docstrings should be accepted in Python 2
-                if name == '__doc__':
-                    if self.pyversion >= (3, 0):
-                        typ = UnboundType('__builtins__.str')  # type: Type
-                    else:
-                        typ = UnionType([UnboundType('__builtins__.str'),
-                                        UnboundType('__builtins__.unicode')])
-                else:
-                    assert t is not None, 'type should be specified for {}'.format(name)
-                    typ = UnboundType(t)
-                v = Var(name, typ)
-                v._fullname = self.sem.qualified_name(name)
-                self.sem.globals[name] = SymbolTableNode(GDEF, v)
-
-            for i, d in enumerate(defs):
-                d.accept(self)
-                if isinstance(d, AssertStmt) and assert_will_always_fail(d, options):
-                    # We've encountered an assert that's always false,
-                    # e.g. assert sys.platform == 'lol'.  Truncate the
-                    # list of statements.  This mutates file.defs too.
-                    del defs[i + 1:]
-                    break
-
-            # Add implicit definition of literals/keywords to builtins, as we
-            # cannot define a variable with them explicitly.
-            if mod_id == 'builtins':
-                literal_types = [
-                    ('None', NoneTyp()),
-                    # reveal_type is a mypy-only function that gives an error with
-                    # the type of its arg.
-                    ('reveal_type', AnyType(TypeOfAny.special_form)),
-                    # reveal_locals is a mypy-only function that gives an error with the types of
-                    # locals
-                    ('reveal_locals', AnyType(TypeOfAny.special_form)),
-                ]  # type: List[Tuple[str, Type]]
-
-                # TODO(ddfisher): This guard is only needed because mypy defines
-                # fake builtins for its tests which often don't define bool.  If
-                # mypy is fast enough that we no longer need those, this
-                # conditional check should be removed.
-                if 'bool' in self.sem.globals:
-                    bool_type = self.sem.named_type('bool')
-                    literal_types.extend([
-                        ('True', bool_type),
-                        ('False', bool_type),
-                        ('__debug__', bool_type),
-                    ])
-                else:
-                    # We are running tests without 'bool' in builtins.
-                    # TODO: Find a permanent solution to this problem.
-                    # Maybe add 'bool' to all fixtures?
-                    literal_types.append(('True', AnyType(TypeOfAny.special_form)))
-
-                for name, typ in literal_types:
-                    v = Var(name, typ)
-                    v._fullname = self.sem.qualified_name(name)
-                    self.sem.globals[name] = SymbolTableNode(GDEF, v)
-
-            del self.sem.options
-
-        sem.scope.leave()
-
-    def visit_block(self, b: Block) -> None:
-        if b.is_unreachable:
-            return
-        self.sem.block_depth[-1] += 1
-        for node in b.body:
-            node.accept(self)
-        self.sem.block_depth[-1] -= 1
-
-    def visit_assignment_stmt(self, s: AssignmentStmt) -> None:
-        if self.sem.is_module_scope():
-            for lval in s.lvalues:
-                self.analyze_lvalue(lval, explicit_type=s.type is not None)
-
-    def visit_func_def(self, func: FuncDef, decorated: bool = False) -> None:
-        """Process a func def.
-
-        decorated is true if we are processing a func def in a
-        Decorator that needs a _fullname and to have its body analyzed but
-        does not need to be added to the symbol table.
-        """
-        sem = self.sem
-        if sem.type is not None:
-            # Don't process methods during pass 1.
-            return
-        func.is_conditional = sem.block_depth[-1] > 0
-        func._fullname = sem.qualified_name(func.name())
-        at_module = sem.is_module_scope() and not decorated
-        if (at_module and func.name() == '__getattr__' and
-                self.sem.cur_mod_node.is_package_init_file() and self.sem.cur_mod_node.is_stub):
-            if isinstance(func.type, CallableType):
-                ret = func.type.ret_type
-                if isinstance(ret, UnboundType) and not ret.args:
-                    sym = self.sem.lookup_qualified(ret.name, func, suppress_errors=True)
-                    # We only interpret a package as partial if the __getattr__ return type
-                    # is either types.ModuleType of Any.
-                    if sym and sym.node and sym.node.fullname() in ('types.ModuleType',
-                                                                    'typing.Any'):
-                        self.sem.cur_mod_node.is_partial_stub_package = True
-        if at_module and func.name() in sem.globals:
-            # Already defined in this module.
-            original_sym = sem.globals[func.name()]
-            if (original_sym.kind == UNBOUND_IMPORTED or
-                    isinstance(original_sym.node, ImportedName)):
-                # Ah this is an imported name. We can't resolve them now, so we'll postpone
-                # this until the main phase of semantic analysis.
-                return
-            if not sem.set_original_def(original_sym.node, func):
-                # Report error.
-                sem.check_no_global(func.name(), func)
-        else:
-            if at_module:
-                sem.globals[func.name()] = SymbolTableNode(GDEF, func)
-            # Also analyze the function body (needed in case there are unreachable
-            # conditional imports).
-            sem.function_stack.append(func)
-            sem.scope.enter_function(func)
-            sem.enter()
-            func.body.accept(self)
-            sem.leave()
-            sem.scope.leave()
-            sem.function_stack.pop()
-
-    def visit_overloaded_func_def(self, func: OverloadedFuncDef) -> None:
-        if self.sem.type is not None:
-            # Don't process methods during pass 1.
-            return
-        kind = self.kind_by_scope()
-        if kind == GDEF:
-            self.sem.check_no_global(func.name(), func, True)
-        func._fullname = self.sem.qualified_name(func.name())
-        if kind == GDEF:
-            self.sem.globals[func.name()] = SymbolTableNode(kind, func)
-        if func.impl:
-            impl = func.impl
-            # Also analyze the function body (in case there are conditional imports).
-            sem = self.sem
-
-            if isinstance(impl, FuncDef):
-                sem.function_stack.append(impl)
-                sem.scope.enter_function(func)
-                sem.enter()
-                impl.body.accept(self)
-            elif isinstance(impl, Decorator):
-                sem.function_stack.append(impl.func)
-                sem.scope.enter_function(func)
-                sem.enter()
-                impl.func.body.accept(self)
-            else:
-                assert False, "Implementation of an overload needs to be FuncDef or Decorator"
-            sem.leave()
-            sem.scope.leave()
-            sem.function_stack.pop()
-
-    def visit_class_def(self, cdef: ClassDef) -> None:
-        kind = self.kind_by_scope()
-        if kind == LDEF:
-            return
-        elif kind == GDEF:
-            self.sem.check_no_global(cdef.name, cdef)
-        cdef.fullname = self.sem.qualified_name(cdef.name)
-        info = TypeInfo(SymbolTable(), cdef, self.sem.cur_mod_id)
-        info.set_line(cdef.line, cdef.column)
-        cdef.info = info
-        if kind == GDEF:
-            self.sem.globals[cdef.name] = SymbolTableNode(kind, info)
-        self.process_nested_classes(cdef)
-
-    def process_nested_classes(self, outer_def: ClassDef) -> None:
-        self.sem.enter_class(outer_def.info)
-        for node in outer_def.defs.body:
-            if isinstance(node, ClassDef):
-                node.info = TypeInfo(SymbolTable(), node, self.sem.cur_mod_id)
-                if outer_def.fullname:
-                    node.info._fullname = outer_def.fullname + '.' + node.info.name()
-                else:
-                    node.info._fullname = node.info.name()
-                node.fullname = node.info._fullname
-                symbol = SymbolTableNode(MDEF, node.info)
-                outer_def.info.names[node.name] = symbol
-                self.process_nested_classes(node)
-            elif isinstance(node, (ImportFrom, Import, ImportAll, IfStmt)):
-                node.accept(self)
-        self.sem.leave_class()
-
-    def visit_import_from(self, node: ImportFrom) -> None:
-        # We can't bind module names during the first pass, as the target module might be
-        # unprocessed. However, we add dummy unbound imported names to the symbol table so
-        # that we at least know that the name refers to a module.
-        at_module = self.sem.is_module_scope()
-        node.is_top_level = at_module
-        if not at_module:
-            return
-        for name, as_name in node.names:
-            imported_name = as_name or name
-            if imported_name not in self.sem.globals:
-                sym = create_indirect_imported_name(self.sem.cur_mod_node,
-                                                    node.id,
-                                                    node.relative,
-                                                    name)
-                if sym:
-                    self.add_symbol(imported_name, sym, context=node)
-
-    def visit_import(self, node: Import) -> None:
-        node.is_top_level = self.sem.is_module_scope()
-        # This is similar to visit_import_from -- see the comment there.
-        if not self.sem.is_module_scope():
-            return
-        for id, as_id in node.ids:
-            imported_id = as_id or id
-            # For 'import a.b.c' we create symbol 'a'.
-            imported_id = imported_id.split('.')[0]
-            if imported_id not in self.sem.globals:
-                self.add_symbol(imported_id, SymbolTableNode(UNBOUND_IMPORTED, None), node)
-
-    def visit_import_all(self, node: ImportAll) -> None:
-        node.is_top_level = self.sem.is_module_scope()
-
-    def visit_while_stmt(self, s: WhileStmt) -> None:
-        if self.sem.is_module_scope():
-            s.body.accept(self)
-            if s.else_body:
-                s.else_body.accept(self)
-
-    def visit_for_stmt(self, s: ForStmt) -> None:
-        if self.sem.is_module_scope():
-            self.analyze_lvalue(s.index, explicit_type=s.index_type is not None)
-            s.body.accept(self)
-            if s.else_body:
-                s.else_body.accept(self)
-
-    def visit_with_stmt(self, s: WithStmt) -> None:
-        if self.sem.is_module_scope():
-            for n in s.target:
-                if n:
-                    self.analyze_lvalue(n, explicit_type=s.target_type is not None)
-            s.body.accept(self)
-
-    def visit_decorator(self, d: Decorator) -> None:
-        if self.sem.type is not None:
-            # Don't process methods during pass 1.
-            return
-        d.var._fullname = self.sem.qualified_name(d.var.name())
-        self.add_symbol(d.var.name(), SymbolTableNode(self.kind_by_scope(), d), d)
-        self.visit_func_def(d.func, decorated=True)
+        for i, defn in enumerate(file.defs):
+            defn.accept(self)
+            if isinstance(defn, AssertStmt) and assert_will_always_fail(defn, options):
+                # We've encountered an assert that's always false,
+                # e.g. assert sys.platform == 'lol'.  Truncate the
+                # list of statements.  This mutates file.defs too.
+                del file.defs[i + 1:]
+                break
 
     def visit_if_stmt(self, s: IfStmt) -> None:
-        infer_reachability_of_if_statement(s, self.sem.options)
+        infer_reachability_of_if_statement(s, self.options)
         for node in s.body:
             node.accept(self)
         if s.else_body:
             s.else_body.accept(self)
 
-    def visit_try_stmt(self, s: TryStmt) -> None:
-        if self.sem.is_module_scope():
-            self.sem.analyze_try_stmt(s, self, add_global=self.sem.is_module_scope())
+    def visit_block(self, b: Block) -> None:
+        if b.is_unreachable:
+            return
+        super().visit_block(b)
 
-    def analyze_lvalue(self, lvalue: Lvalue, explicit_type: bool = False) -> None:
-        self.sem.analyze_lvalue(lvalue, add_global=self.sem.is_module_scope(),
-                                explicit_type=explicit_type)
+    # The remaining methods are an optimization: don't visit nested expressions
+    # of common statements, since they can have no effect.
 
-    def kind_by_scope(self) -> int:
-        if self.sem.is_module_scope():
-            return GDEF
-        elif self.sem.is_class_scope():
-            return MDEF
-        elif self.sem.is_func_scope():
-            return LDEF
-        else:
-            assert False, "Couldn't determine scope"
+    def visit_assignment_stmt(self, s: AssignmentStmt) -> None:
+        pass
 
-    def add_symbol(self, name: str, node: SymbolTableNode,
-                   context: Context) -> None:
-        # NOTE: This is closely related to SemanticAnalyzerPass2.add_symbol. Since both methods
-        #     will be called on top-level definitions, they need to co-operate. If you change
-        #     this, you may have to change the other method as well.
-        if self.sem.is_func_scope():
-            assert self.sem.locals[-1] is not None
-            if name in self.sem.locals[-1]:
-                # Flag redefinition unless this is a reimport of a module.
-                if not (isinstance(node.node, MypyFile) and
-                        self.sem.locals[-1][name].node == node.node):
-                    self.sem.name_already_defined(name, context, self.sem.locals[-1][name])
-                    return
-            self.sem.locals[-1][name] = node
-        else:
-            assert self.sem.type is None  # Pass 1 doesn't look inside classes
-            existing = self.sem.globals.get(name)
-            if (existing
-                    and (not isinstance(node.node, MypyFile) or existing.node != node.node)
-                    and existing.kind != UNBOUND_IMPORTED
-                    and not isinstance(existing.node, ImportedName)):
-                # Modules can be imported multiple times to support import
-                # of multiple submodules of a package (e.g. a.x and a.y).
-                ok = False
-                # Only report an error if the symbol collision provides a different type.
-                if existing.type and node.type and is_same_type(existing.type, node.type):
-                    ok = True
-                if not ok:
-                    self.sem.name_already_defined(name, context, existing)
-                    return
-            elif not existing:
-                self.sem.globals[name] = node
+    def visit_expression_stmt(self, s: ExpressionStmt) -> None:
+        pass
+
+    def visit_return_stmt(self, s: ReturnStmt) -> None:
+        pass
+
+    def visit_for_stmt(self, s: ForStmt) -> None:
+        s.body.accept(self)
+        if s.else_body is not None:
+            s.else_body.accept(self)

--- a/mypy/newsemanal/semanal_pass3.py
+++ b/mypy/newsemanal/semanal_pass3.py
@@ -30,7 +30,7 @@ from mypy.traverser import TraverserVisitor
 from mypy.newsemanal.typeanal import TypeAnalyserPass3, collect_any_types
 from mypy.typevars import has_no_typevars
 from mypy.semanal_shared import PRIORITY_FORWARD_REF, PRIORITY_TYPEVAR_VALUES
-from mypy.newsemanal.semanal import SemanticAnalyzerPass2
+from mypy.newsemanal.semanal import NewSemanticAnalyzer
 from mypy.subtypes import is_subtype
 from mypy.sametypes import is_same_type
 from mypy.scope import Scope
@@ -45,7 +45,7 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
     """
 
     def __init__(self, modules: Dict[str, MypyFile], errors: Errors,
-                 sem: SemanticAnalyzerPass2) -> None:
+                 sem: NewSemanticAnalyzer) -> None:
         self.modules = modules
         self.errors = errors
         self.sem = sem

--- a/mypy/newsemanal/semanal_pass3.py
+++ b/mypy/newsemanal/semanal_pass3.py
@@ -29,12 +29,12 @@ from mypy.options import Options
 from mypy.traverser import TraverserVisitor
 from mypy.newsemanal.typeanal import TypeAnalyserPass3, collect_any_types
 from mypy.typevars import has_no_typevars
-from mypy.semanal_shared import PRIORITY_FORWARD_REF, PRIORITY_TYPEVAR_VALUES
+from mypy.newsemanal.semanal_shared import PRIORITY_FORWARD_REF, PRIORITY_TYPEVAR_VALUES
 from mypy.newsemanal.semanal import NewSemanticAnalyzer
 from mypy.subtypes import is_subtype
 from mypy.sametypes import is_same_type
 from mypy.scope import Scope
-from mypy.semanal_shared import SemanticAnalyzerCoreInterface
+from mypy.newsemanal.semanal_shared import SemanticAnalyzerCoreInterface
 
 
 class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):

--- a/mypy/newsemanal/semanal_shared.py
+++ b/mypy/newsemanal/semanal_shared.py
@@ -1,0 +1,158 @@
+"""Shared definitions used by different parts of semantic analysis."""
+
+from abc import abstractmethod, abstractproperty
+from typing import Optional, List, Callable
+from mypy_extensions import trait
+
+from mypy.nodes import (
+    Context, SymbolTableNode, MypyFile, ImportedName, FuncDef, Node, TypeInfo, Expression, GDEF
+)
+from mypy.util import correct_relative_import
+from mypy.types import Type, FunctionLike, Instance
+from mypy.tvar_scope import TypeVarScope
+
+MYPY = False
+if False:
+    from typing_extensions import Final
+
+# Priorities for ordering of patches within the final "patch" phase of semantic analysis
+# (after pass 3):
+
+# Fix forward references (needs to happen first)
+PRIORITY_FORWARD_REF = 0  # type: Final
+# Fix fallbacks (does joins)
+PRIORITY_FALLBACKS = 1  # type: Final
+# Checks type var values (does subtype checks)
+PRIORITY_TYPEVAR_VALUES = 2  # type: Final
+
+
+@trait
+class SemanticAnalyzerCoreInterface:
+    """A core abstract interface to generic semantic analyzer functionality.
+
+    This is implemented by both semantic analyzer passes 2 and 3.
+    """
+
+    @abstractmethod
+    def lookup_qualified(self, name: str, ctx: Context,
+                         suppress_errors: bool = False) -> Optional[SymbolTableNode]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def lookup_fully_qualified(self, name: str) -> SymbolTableNode:
+        raise NotImplementedError
+
+    @abstractmethod
+    def fail(self, msg: str, ctx: Context, serious: bool = False, *,
+             blocker: bool = False) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def note(self, msg: str, ctx: Context) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def dereference_module_cross_ref(
+            self, node: Optional[SymbolTableNode]) -> Optional[SymbolTableNode]:
+        raise NotImplementedError
+
+
+@trait
+class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
+    """A limited abstract interface to some generic semantic analyzer pass 2 functionality.
+
+    We use this interface for various reasons:
+
+    * Looser coupling
+    * Cleaner import graph
+    * Less need to pass around callback functions
+    """
+
+    @abstractmethod
+    def lookup(self, name: str, ctx: Context,
+               suppress_errors: bool = False) -> Optional[SymbolTableNode]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def named_type(self, qualified_name: str, args: Optional[List[Type]] = None) -> Instance:
+        raise NotImplementedError
+
+    @abstractmethod
+    def named_type_or_none(self, qualified_name: str,
+                           args: Optional[List[Type]] = None) -> Optional[Instance]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def accept(self, node: Node) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def anal_type(self, t: Type, *,
+                  tvar_scope: Optional[TypeVarScope] = None,
+                  allow_tuple_literal: bool = False,
+                  allow_unbound_tvars: bool = False,
+                  report_invalid_types: bool = True,
+                  third_pass: bool = False) -> Optional[Type]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def basic_new_typeinfo(self, name: str, basetype_or_fallback: Instance) -> TypeInfo:
+        raise NotImplementedError
+
+    @abstractmethod
+    def schedule_patch(self, priority: int, fn: Callable[[], None]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_symbol_table_node(self, name: str, stnode: SymbolTableNode) -> None:
+        """Add node to global symbol table (or to nearest class if there is one)."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def parse_bool(self, expr: Expression) -> Optional[bool]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def qualified_name(self, n: str) -> str:
+        raise NotImplementedError
+
+    @abstractproperty
+    def is_typeshed_stub_file(self) -> bool:
+        raise NotImplementedError
+
+
+def create_indirect_imported_name(file_node: MypyFile,
+                                  module: str,
+                                  relative: int,
+                                  imported_name: str) -> Optional[SymbolTableNode]:
+    """Create symbol table entry for a name imported from another module.
+
+    These entries act as indirect references.
+    """
+    target_module, ok = correct_relative_import(
+        file_node.fullname(),
+        relative,
+        module,
+        file_node.is_package_init_file())
+    if not ok:
+        return None
+    target_name = '%s.%s' % (target_module, imported_name)
+    link = ImportedName(target_name)
+    # Use GDEF since this refers to a module-level definition.
+    return SymbolTableNode(GDEF, link)
+
+
+def set_callable_name(sig: Type, fdef: FuncDef) -> Type:
+    if isinstance(sig, FunctionLike):
+        if fdef.info:
+            if fdef.info.fullname() == 'mypy_extensions._TypedDict':
+                # Avoid exposing the internal _TypedDict name.
+                class_name = 'TypedDict'
+            else:
+                class_name = fdef.info.name()
+            return sig.with_name(
+                '{} of {}'.format(fdef.name(), class_name))
+        else:
+            return sig.with_name(fdef.name())
+    else:
+        return sig

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -28,7 +28,7 @@ from mypy.nodes import (
 from mypy.tvar_scope import TypeVarScope
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.plugin import Plugin, TypeAnalyzerPluginInterface, AnalyzeTypeContext
-from mypy.semanal_shared import SemanticAnalyzerCoreInterface
+from mypy.newsemanal.semanal_shared import SemanticAnalyzerCoreInterface
 from mypy import nodes, message_registry
 
 MYPY = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -52,7 +52,7 @@ PER_MODULE_OPTIONS = {
 }  # type: Final
 
 OPTIONS_AFFECTING_CACHE = ((PER_MODULE_OPTIONS |
-                            {"platform", "bazel", "plugins"})
+                            {"platform", "bazel", "plugins", "new_semantic_analyzer"})
                            - {"debug_cache"})  # type: Final
 
 
@@ -83,6 +83,9 @@ class Options:
         self.follow_imports_for_stubs = False
         # PEP 420 namespace packages
         self.namespace_packages = False
+
+        # Use the new semantic analyzer
+        self.new_semantic_analyzer = False
 
         # disallow_any options
         self.disallow_any_generics = False

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -181,7 +181,7 @@ class SemanticAnalyzerPluginInterface:
                   allow_tuple_literal: bool = False,
                   allow_unbound_tvars: bool = False,
                   report_invalid_types: bool = True,
-                  third_pass: bool = False) -> Type:
+                  third_pass: bool = False) -> Optional[Type]:
         """Analyze an unbound type."""
         raise NotImplementedError
 

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -82,6 +82,7 @@ typecheck_files = [
     'check-final.test',
     'check-redefine.test',
     'check-literal.test',
+    'check-newsemanal.test',
 ]
 
 

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -3,8 +3,22 @@
 [case testNewAnalyzerEmpty]
 # flags: --new-semantic-analyzer
 
-[case testNewAnalyzerSimple]
+[case testNewAnalyzerSimpleAssignment]
 # flags: --new-semantic-analyzer
 x = 1
 x.y # E: "int" has no attribute "y"
 y # E: Name 'y' is not defined
+
+[case testNewAnalyzerSimpleAnnotation]
+# flags: --new-semantic-analyzer
+x: int = 0
+y: str = 0 \
+    # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+[case testNewAnalyzerSimpleClass]
+# flags: --new-semantic-analyzer
+class A:
+    x: int
+a: A
+a.x
+a.y # E: "A" has no attribute "y"

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -22,3 +22,8 @@ class A:
 a: A
 a.x
 a.y # E: "A" has no attribute "y"
+
+[case testNewAnalyzerErrorInClassBody]
+# flags: --new-semantic-analyzer
+class A:
+    x # E: Name 'x' is not defined

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1,9 +1,10 @@
 -- Test cases for the new semantic analyzer
 
+[case testNewAnalyzerEmpty]
+# flags: --new-semantic-analyzer
 
 [case testNewAnalyzerSimple]
 # flags: --new-semantic-analyzer
 x = 1
-reveal_type(x)
-x.y
-y
+x.y # E: "int" has no attribute "y"
+y # E: Name 'y' is not defined

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1,0 +1,9 @@
+-- Test cases for the new semantic analyzer
+
+
+[case testNewAnalyzerSimple]
+# flags: --new-semantic-analyzer
+x = 1
+reveal_type(x)
+x.y
+y

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -40,3 +40,46 @@ a.b = a # E: Incompatible types in assignment (expression has type "A", variable
 a.b = b
 b.a = a
 b.a = b # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+
+[case testNewAnalyzerTypeAnnotationCycle1]
+# flags: --new-semantic-analyzer
+import a
+[file a.py]
+import b
+class A: pass
+y: b.B
+y()
+[file b.py]
+import a
+class B: pass
+x: a.A
+x()
+[out]
+tmp/b.py:4: error: "A" not callable
+tmp/a.py:4: error: "B" not callable
+
+[case testNewAnalyzerTypeAnnotationCycle2]
+# flags: --new-semantic-analyzer
+import a
+[file a.py]
+from b import B
+class A: pass
+y: B
+y()
+[file b.py]
+from a import A
+class B: pass
+x: A
+x()
+[out]
+tmp/b.py:4: error: "A" not callable
+tmp/a.py:4: error: "B" not callable
+
+[case testNewAnalyzerTypeAnnotationCycle3]
+# flags: --new-semantic-analyzer
+import b
+[file a.py]
+from b import bad # E: Module 'b' has no attribute 'bad'
+[file b.py]
+from a import bad2 # E: Module 'a' has no attribute 'bad2'
+[out]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -27,3 +27,16 @@ a.y # E: "A" has no attribute "y"
 # flags: --new-semantic-analyzer
 class A:
     x # E: Name 'x' is not defined
+
+[case testNewAnalyzerTypeAnnotationForwardReference]
+# flags: --new-semantic-analyzer
+class A:
+    b: B
+class B:
+    a: A
+a: A
+b: B
+a.b = a # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+a.b = b
+b.a = a
+b.a = b # E: Incompatible types in assignment (expression has type "B", variable has type "A")


### PR DESCRIPTION
Implement basic deferred nodes functionality and remove most of old 
pass 1 functionality. Also fork `mypy.semanal_shared` since I needed
to tweak the signature of `anal_type` in an incompatible way (there are
not other changes in that module).

A *lot* of things still don't work, including functions and more than two
passes. There are a small number of tests for the new semantic 
analyzer, but I made no attempt at achieving good test coverage yet.

Work towards #6204.