### PR TITLE
New semantic analyzer: Support multiple passes, typing imports

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2685,7 +2685,8 @@ def process_stale_scc(graph: Graph, scc: List[str], manager: BuildManager) -> No
         # SemanticAnalyzerPass2.add_builtin_aliases for details.
         typing_mod = graph['typing'].tree
         assert typing_mod, "The typing module was not parsed"
-        manager.semantic_analyzer.add_builtin_aliases(typing_mod)
+        if not manager.options.new_semantic_analyzer:
+            manager.semantic_analyzer.add_builtin_aliases(typing_mod)
     if manager.options.new_semantic_analyzer:
         semantic_analysis_for_scc(graph, scc)
     else:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -148,6 +148,11 @@ SUGGESTED_TEST_FIXTURES = {
 }  # type: Final
 
 
+# Special cased built-in classes that are needed for basic functionality and need to be
+# available very early on.
+CORE_BUILTIN_CLASSES = ['object', 'bool']  # type: Final
+
+
 class NewSemanticAnalyzer(NodeVisitor[None],
                           SemanticAnalyzerInterface,
                           SemanticAnalyzerPluginInterface):
@@ -320,12 +325,17 @@ class NewSemanticAnalyzer(NodeVisitor[None],
     def prepare_builtins_namespace(self, file_node: MypyFile) -> None:
         names = file_node.names
 
-        # Add empty definition for 'object', since it's required for basic operation.
-        # This will be completed later on.
-        cdef = ClassDef('object', Block([]))  # Dummy ClassDef, will be replaced later
-        info = TypeInfo(SymbolTable(), cdef, 'builtins')
-        info._fullname = 'builtins.object'
-        names['object'] = SymbolTableNode(GDEF, info)
+        # Add empty definition for core built-in classes, since they are required for basic
+        # operation. These will be completed later on.
+        for name in CORE_BUILTIN_CLASSES:
+            cdef = ClassDef(name, Block([]))  # Dummy ClassDef, will be replaced later
+            info = TypeInfo(SymbolTable(), cdef, 'builtins')
+            info._fullname = 'builtins.%s' % name
+            names[name] = SymbolTableNode(GDEF, info)
+
+        bool_info = names['bool'].node
+        assert isinstance(bool_info, TypeInfo)
+        bool_type = Instance(bool_info, [])
 
         literal_types = [
             ('None', NoneTyp()),
@@ -335,9 +345,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             # reveal_locals is a mypy-only function that gives an error with the types of
             # locals
             ('reveal_locals', AnyType(TypeOfAny.special_form)),
+            ('True', bool_type),
+            ('False', bool_type),
+            ('__debug__', bool_type),
         ]  # type: List[Tuple[str, Type]]
-
-        # TODO: True, False and __debug__
 
         for name, typ in literal_types:
             v = Var(name, typ)
@@ -1077,7 +1088,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
         For example, consider this class:
 
-        . class Foo(Bar, Generic[T]): ...
+          class Foo(Bar, Generic[T]): ...
 
         Now we will remove Generic[T] from bases of Foo and infer that the
         type variable 'T' is a type argument of Foo.
@@ -1186,11 +1197,13 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         if not defn.info:
             defn.fullname = self.qualified_name(defn.name)
             # TODO: Nested classes
-            if self.is_module_scope() and self.qualified_name(defn.name) == 'builtins.object':
-                # Special case 'builtins.object'. A TypeInfo was already
+            if (self.is_module_scope()
+                    and self.cur_mod_id == 'builtins'
+                    and defn.name in CORE_BUILTIN_CLASSES):
+                # Special case core built-in classes. A TypeInfo was already
                 # created for it before semantic analysis, but with a dummy
                 # ClassDef. Patch the real ClassDef object.
-                info = self.globals['object'].node
+                info = self.globals[defn.name].node
                 assert isinstance(info, TypeInfo)
                 defn.info = info
                 info.defn = defn
@@ -1846,8 +1859,14 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
     def visit_assignment_stmt(self, s: AssignmentStmt) -> None:
         s.is_final_def = self.unwrap_final(s)
-        self.analyze_lvalues(s)
+        prev_incomplete = self.num_incomplete_refs
         s.rvalue.accept(self)
+        if self.num_incomplete_refs != prev_incomplete:
+            # Initializer couldn't be fully analyzed. Defer the current node and give up.
+            self.deferred = True
+            self.incomplete = True
+            return
+        self.analyze_lvalues(s)
         self.check_final_implicit_def(s)
         self.check_classvar(s)
         self.process_type_annotation(s)
@@ -2164,8 +2183,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                        explicit_type: bool = False,
                        is_final: bool = False) -> None:
         """Analyze an lvalue or assignment target.
-
-        Note that this is used in both pass 1 and 2.
 
         Args:
             lval: The target lvalue
@@ -3211,13 +3228,13 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             # This branch handles the case foo.bar where foo is a module.
             # In this case base.node is the module's MypyFile and we look up
             # bar in its namespace.  This must be done for all types of bar.
-            file = cast(Optional[MypyFile], base.node)  # can't use isinstance due to issue #2999
+            file = base.node
             # TODO: Should we actually use this? Not sure if this makes a difference.
             # if file.fullname() == self.cur_mod_id:
             #     names = self.globals
             # else:
             #     names = file.names
-            n = file.names.get(expr.name, None) if file is not None else None
+            n = file.names.get(expr.name, None)
             n = self.dereference_module_cross_ref(n)
             if n and not n.module_hidden:
                 if not n:
@@ -3246,6 +3263,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 expr.fullname = '{}.{}'.format(file.fullname(), expr.name)
                 expr.node = Var(expr.name, type=typ)
             else:
+                if file.fullname() in self.incomplete_namespaces:
+                    self.deferred = True
+                    self.num_incomplete_refs += 1
+                    return
                 # We only catch some errors here; the rest will be
                 # caught during type checking.
                 #

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -11,6 +11,10 @@ if MYPY:
     from mypy.build import Graph, State
 
 
+# Perform up to this many semantic analysis iterations until giving up trying to bind all names.
+MAX_ITERATIONS = 10
+
+
 def semantic_analysis_for_scc(graph: 'Graph', scc: List[str]) -> None:
     # Assume reachability analysis has already been performed.
     process_top_levels(graph, scc)
@@ -31,17 +35,22 @@ def process_top_levels(graph: 'Graph', scc: List[str]) -> None:
     state.manager.incomplete_namespaces.update(scc)
 
     worklist = scc[:]
+    iteration = 0
     while worklist:
-        deferred = []  # type: List[str]
+        iteration += 1
+        if iteration == MAX_ITERATIONS:
+            # Give up. Likely it's impossible to bind all names.
+            state.manager.incomplete_namespaces.clear()
+        all_deferred = []  # type: List[str]
         while worklist:
             next_id = worklist.pop()
             state = graph[next_id]
             assert state.tree is not None
-            deferred += semantic_analyze_target(next_id, state, state.tree, None)
-            # Assume this namespace is ready.
-            # TODO: It could still be incomplete if some definitions couldn't be bound.
-            state.manager.incomplete_namespaces.discard(next_id)
-        worklist = deferred
+            deferred, incomplete = semantic_analyze_target(next_id, state, state.tree, None)
+            all_deferred += deferred
+            if not incomplete:
+                state.manager.incomplete_namespaces.discard(next_id)
+        worklist = all_deferred
 
 
 def process_functions(graph: 'Graph', scc: List[str]) -> None:
@@ -54,8 +63,10 @@ def process_functions(graph: 'Graph', scc: List[str]) -> None:
         symtable = tree.names
         targets = get_all_leaf_targets(symtable, module, None)
         for target, node, active_type in targets:
-            deferred += semantic_analyze_target(target, graph[module], node, active_type)
-    assert not deferred  # There can't be cross-function forward refs
+            deferred, incomplete = semantic_analyze_target(target, graph[module], node,
+                                                           active_type)
+            assert not deferred  # There can't be cross-function forward refs
+            assert not incomplete  # Ditto
 
 
 TargetInfo = Tuple[str, Union[MypyFile, FuncDef], Optional[TypeInfo]]
@@ -82,7 +93,7 @@ def get_all_leaf_targets(symtable: SymbolTable,
 def semantic_analyze_target(target: str,
                             state: 'State',
                             node: Union[MypyFile, FuncDef],
-                            active_type: Optional[TypeInfo]) -> List[str]:
+                            active_type: Optional[TypeInfo]) -> Tuple[List[str], bool]:
     # TODO: Support refreshing function targets (currently only works for module top levels)
     tree = state.tree
     assert tree is not None
@@ -97,6 +108,6 @@ def semantic_analyze_target(target: str,
                                active_type=active_type):
         analyzer.refresh_partial(node, [])
     if analyzer.deferred:
-        return [target]
+        return [target], analyzer.incomplete
     else:
-        return []
+        return [], analyzer.incomplete

--- a/mypy/newsemanal/semanal_namedtuple.py
+++ b/mypy/newsemanal/semanal_namedtuple.py
@@ -116,7 +116,10 @@ class NamedTupleAnalyzer:
         return items, types, default_items
 
     def process_namedtuple_definition(self, s: AssignmentStmt, is_func_scope: bool) -> None:
-        """Check if s defines a namedtuple; if yes, store the definition in symbol table."""
+        """Check if s defines a namedtuple; if yes, store the definition in symbol table.
+
+        Assume that s has already been successfully analyzed.
+        """
         if len(s.lvalues) != 1 or not isinstance(s.lvalues[0], NameExpr):
             return
         lvalue = s.lvalues[0]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -79,7 +79,6 @@ import b
 from b import bad # E: Module 'b' has no attribute 'bad'
 [file b.py]
 from a import bad2 # E: Module 'a' has no attribute 'bad2'
-[out]
 
 [case testNewAnalyzerSimpleFunction]
 # flags: --new-semantic-analyzer
@@ -101,3 +100,32 @@ class A:
 
     def g(self) -> int:
         return self.f() # E: Incompatible return value type (got "str", expected "int")
+
+[case testNewAnalyzerFunctionForwardRef]
+# flags: --new-semantic-analyzer
+def f() -> None:
+    x = g(1) # E: Argument 1 to "g" has incompatible type "int"; expected "str"
+    reveal_type(x) # E: Revealed type is 'builtins.str'
+
+def g(x: str) -> str:
+    return x
+
+[case testNewAnalyzerExportedImportThreePasses]
+# flags: --new-semantic-analyzer
+import b
+
+[file a.py]
+from b import b1 as a2
+from b import b2 as a3
+
+def a1() -> int: pass
+
+reveal_type(a3()) # E: Revealed type is 'builtins.int'
+
+[file b.py]
+from a import a1 as b2
+from a import a2 as b3
+
+def b1() -> str: pass
+
+reveal_type(b3()) # E: Revealed type is 'builtins.str'

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -129,3 +129,40 @@ from a import a2 as b3
 def b1() -> str: pass
 
 reveal_type(b3()) # E: Revealed type is 'builtins.str'
+
+[case testNewAnalyzerBool]
+# flags: --new-semantic-analyzer
+reveal_type(True) # E: Revealed type is 'builtins.bool'
+reveal_type(False) # E: Revealed type is 'builtins.bool'
+
+[case testNewAnalyzerNewTypeMultiplePasses]
+# flags: --new-semantic-analyzer
+import b
+
+[file a.py]
+from typing import NewType
+import b
+class A: pass
+N2 = NewType('N2', b.N1)
+def f1(x: A) -> None: pass
+def f2(x: b.N1) -> None: pass
+def f3(x: N2) -> None: pass
+a = A()
+n1 = b.N1(a)
+n2 = N2(n1)
+f1(a)
+f1(n1)
+f1(n2)
+f2(a) # E: Argument 1 to "f2" has incompatible type "A"; expected "N1"
+f2(n1)
+f2(n2)
+f3(a) # E: Argument 1 to "f3" has incompatible type "A"; expected "N2"
+f3(n1) # E: Argument 1 to "f3" has incompatible type "N1"; expected "N2"
+f3(n2)
+
+# Test N2 etc.
+
+[file b.py]
+from typing import NewType
+import a
+N1 = NewType('N1', a.A)


### PR DESCRIPTION
Currently additional passes are only performed to resolve
"from import" statements and assignments. This allows
resolving indirect (exported) imports and NewType 
definitions within import cycles.

Add a fixed maximum number of iterations that should always be
enough. If we hit the maximum, it's very likely that the remaining
unbound definitions are impossible to bind, or that there is a
definition cycle.

This also includes some fixes to support importing `typing`
in tests and adds support for `True` and `False` (and a few
other small changes).