### PR TITLE
Include mypy_bootstrap.ini in PyPI packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,6 @@ recursive-include extensions *
 recursive-include docs *
 recursive-include mypy/typeshed *.py *.pyi
 recursive-include mypy/xml *.xsd *.xslt *.css
+include mypy_bootstrap.ini
 include mypy_self_check.ini
 include LICENSE


### PR DESCRIPTION
When attempting to build mypy (using mypyc) from the 0.660 source release on PyPI, the install/bdist_wheel steps fail because the source distribution does not include mypy_bootstrap.ini.  This adds the file to the package manifest so that future releases include it for reproducible mypy-mypyc builds from source tarballs.