### PR TITLE
New semantic analyzer: Support class-based TypedDicts

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1248,7 +1248,11 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         return remove_dups(tvars)
 
     def prepare_class_def(self, defn: ClassDef, info: Optional[TypeInfo] = None) -> None:
-        """Prepare for the analysis of a class definition."""
+        """Prepare for the analysis of a class definition.
+
+        Create an empty TypeInfo and store it in a symbol table, or if the 'info'
+        argument is provided, store it instead (used for magic type definitions).
+        """
         if not defn.info:
             defn.fullname = self.qualified_name(defn.name)
             # TODO: Nested classes

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -895,8 +895,16 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
         base_types, base_error = result
 
+        is_typeddict, info = self.typed_dict_analyzer.analyze_typeddict_classdef(defn)
+        if is_typeddict:
+            if info is None:
+                self.mark_incomplete()
+            else:
+                self.prepare_class_def(defn, info)
+            return
+
         # Create TypeInfo for class now that base classes and the MRO can be calculated.
-        self.setup_class_def_analysis(defn)
+        self.prepare_class_def(defn)
 
         defn.type_vars = tvar_defs
         defn.info.type_vars = [tvar.fullname for tvar in tvar_defs]
@@ -906,8 +914,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         with self.scope.class_scope(defn.info):
             self.configure_base_classes(defn, base_types)
 
-            if self.typed_dict_analyzer.analyze_typeddict_classdef(defn):
-                return
             if self.analyze_namedtuple_classdef(defn):
                 return
 
@@ -1241,24 +1247,14 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 tvars.extend(base_tvars)
         return remove_dups(tvars)
 
-    def setup_class_def_analysis(self, defn: ClassDef) -> None:
+    def prepare_class_def(self, defn: ClassDef, info: Optional[TypeInfo] = None) -> None:
         """Prepare for the analysis of a class definition."""
         if not defn.info:
             defn.fullname = self.qualified_name(defn.name)
             # TODO: Nested classes
-            if (self.is_module_scope()
-                    and self.cur_mod_id == 'builtins'
-                    and defn.name in CORE_BUILTIN_CLASSES):
-                # Special case core built-in classes. A TypeInfo was already
-                # created for it before semantic analysis, but with a dummy
-                # ClassDef. Patch the real ClassDef object.
-                info = self.globals[defn.name].node
-                assert isinstance(info, TypeInfo)
-                defn.info = info
-                info.defn = defn
-            else:
-                info = TypeInfo(SymbolTable(), defn, self.cur_mod_id)
-                defn.info = info
+            info = info or self.make_empty_type_info(defn)
+            defn.info = info
+            info.defn = defn
             if self.is_module_scope():
                 info._fullname = self.qualified_name(defn.name)
                 self.globals[defn.name] = SymbolTableNode(GDEF, info)
@@ -1285,6 +1281,19 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 defn.fullname = defn.info._fullname
                 self.globals[local_name] = node
 
+    def make_empty_type_info(self, defn: ClassDef) -> TypeInfo:
+        if (self.is_module_scope()
+                and self.cur_mod_id == 'builtins'
+                and defn.name in CORE_BUILTIN_CLASSES):
+            # Special case core built-in classes. A TypeInfo was already
+            # created for it before semantic analysis, but with a dummy
+            # ClassDef. Patch the real ClassDef object.
+            info = self.globals[defn.name].node
+            assert isinstance(info, TypeInfo)
+        else:
+            info = TypeInfo(SymbolTable(), defn, self.cur_mod_id)
+        return info
+
     def analyze_base_classes(
             self,
             base_type_exprs: List[Expression]) -> Optional[Tuple[List[Tuple[Type, Expression]],
@@ -1300,6 +1309,12 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         is_error = False
         bases = []
         for base_expr in base_type_exprs:
+            if (isinstance(base_expr, RefExpr) and
+                    base_expr.fullname in ('typing.NamedTuple',
+                                           'mypy_extensions.TypedDict')):
+                # Ignore magic bases for now.
+                continue
+
             try:
                 base = self.expr_to_analyzed_type(base_expr)
             except TypeTranslationError:

--- a/mypy/newsemanal/semanal_typeddict.py
+++ b/mypy/newsemanal/semanal_typeddict.py
@@ -37,9 +37,15 @@ class TypedDictAnalyzer:
 
         Assume that base classes have been analyzed already.
 
-        Return (is this a TypedDict, new TypeInfo).
-        If we couldn't finish due to incomplete reference, return (True, None).
-        If this is not a TypedDict, return (False, None).
+        Note: Unlike normal classes, we won't create a TypeInfo until
+        the whole definition of the TypeDict (including the body and all
+        key names and types) is complete.  This is mostly because we
+        store the corresponding TypedDictType in the TypeInfo.
+
+        Return (is this a TypedDict, new TypeInfo). Specifics:
+         * If we couldn't finish due to incomplete reference anywhere in
+           the definition, return (True, None).
+         * If this is not a TypedDict, return (False, None).
         """
         possible = False
         for base_expr in defn.base_type_exprs:

--- a/mypy/newsemanal/semanal_typeddict.py
+++ b/mypy/newsemanal/semanal_typeddict.py
@@ -1,7 +1,4 @@
-"""Semantic analysis of TypedDict definitions.
-
-This is conceptually part of mypy.semanal (semantic analyzer pass 2).
-"""
+"""Semantic analysis of TypedDict definitions."""
 
 from collections import OrderedDict
 from typing import Optional, List, Set, Tuple, cast
@@ -35,8 +32,15 @@ class TypedDictAnalyzer:
         self.api = api
         self.msg = msg
 
-    def analyze_typeddict_classdef(self, defn: ClassDef) -> bool:
-        # special case for TypedDict
+    def analyze_typeddict_classdef(self, defn: ClassDef) -> Tuple[bool, Optional[TypeInfo]]:
+        """Analyze a class that may define a TypedDict.
+
+        Assume that base classes have been analyzed already.
+
+        Return (is this a TypedDict, new TypeInfo).
+        If we couldn't finish due to incomplete reference, return (True, None).
+        If this is not a TypedDict, return (False, None).
+        """
         possible = False
         for base_expr in defn.base_type_exprs:
             if isinstance(base_expr, RefExpr):
@@ -45,64 +49,72 @@ class TypedDictAnalyzer:
                         self.is_typeddict(base_expr)):
                     possible = True
         if possible:
-            node = self.api.lookup(defn.name, defn)
-            if node is not None:
-                node.kind = GDEF  # TODO in process_namedtuple_definition also applies here
-                if (len(defn.base_type_exprs) == 1 and
-                        isinstance(defn.base_type_exprs[0], RefExpr) and
-                        defn.base_type_exprs[0].fullname == 'mypy_extensions.TypedDict'):
-                    # Building a new TypedDict
-                    fields, types, required_keys = self.check_typeddict_classdef(defn)
-                    info = self.build_typeddict_typeinfo(defn.name, fields, types, required_keys)
-                    defn.info.replaced = info
-                    defn.info = info
-                    node.node = info
-                    defn.analyzed = TypedDictExpr(info)
-                    defn.analyzed.line = defn.line
-                    defn.analyzed.column = defn.column
-                    return True
-                # Extending/merging existing TypedDicts
-                if any(not isinstance(expr, RefExpr) or
-                       expr.fullname != 'mypy_extensions.TypedDict' and
-                       not self.is_typeddict(expr) for expr in defn.base_type_exprs):
-                    self.fail("All bases of a new TypedDict must be TypedDict types", defn)
-                typeddict_bases = list(filter(self.is_typeddict, defn.base_type_exprs))
-                keys = []  # type: List[str]
-                types = []
-                required_keys = set()
-                for base in typeddict_bases:
-                    assert isinstance(base, RefExpr)
-                    assert isinstance(base.node, TypeInfo)
-                    assert isinstance(base.node.typeddict_type, TypedDictType)
-                    base_typed_dict = base.node.typeddict_type
-                    base_items = base_typed_dict.items
-                    valid_items = base_items.copy()
-                    for key in base_items:
-                        if key in keys:
-                            self.fail('Cannot overwrite TypedDict field "{}" while merging'
-                                      .format(key), defn)
-                            valid_items.pop(key)
-                    keys.extend(valid_items.keys())
-                    types.extend(valid_items.values())
-                    required_keys.update(base_typed_dict.required_keys)
-                new_keys, new_types, new_required_keys = self.check_typeddict_classdef(defn, keys)
-                keys.extend(new_keys)
-                types.extend(new_types)
-                required_keys.update(new_required_keys)
-                info = self.build_typeddict_typeinfo(defn.name, keys, types, required_keys)
-                defn.info.replaced = info
-                defn.info = info
-                node.node = info
+            if (len(defn.base_type_exprs) == 1 and
+                    isinstance(defn.base_type_exprs[0], RefExpr) and
+                    defn.base_type_exprs[0].fullname == 'mypy_extensions.TypedDict'):
+                # Building a new TypedDict
+                fields, types, required_keys = self.analyze_typeddict_classdef_fields(defn)
+                if fields is None:
+                    return True, None  # Defer
+                info = self.build_typeddict_typeinfo(defn.name, fields, types, required_keys)
                 defn.analyzed = TypedDictExpr(info)
                 defn.analyzed.line = defn.line
                 defn.analyzed.column = defn.column
-                return True
-        return False
+                return True, info
+            # Extending/merging existing TypedDicts
+            if any(not isinstance(expr, RefExpr) or
+                   expr.fullname != 'mypy_extensions.TypedDict' and
+                   not self.is_typeddict(expr) for expr in defn.base_type_exprs):
+                self.fail("All bases of a new TypedDict must be TypedDict types", defn)
+            typeddict_bases = list(filter(self.is_typeddict, defn.base_type_exprs))
+            keys = []  # type: List[str]
+            types = []
+            required_keys = set()
+            for base in typeddict_bases:
+                assert isinstance(base, RefExpr)
+                assert isinstance(base.node, TypeInfo)
+                assert isinstance(base.node.typeddict_type, TypedDictType)
+                base_typed_dict = base.node.typeddict_type
+                base_items = base_typed_dict.items
+                valid_items = base_items.copy()
+                for key in base_items:
+                    if key in keys:
+                        self.fail('Cannot overwrite TypedDict field "{}" while merging'
+                                  .format(key), defn)
+                        valid_items.pop(key)
+                keys.extend(valid_items.keys())
+                types.extend(valid_items.values())
+                required_keys.update(base_typed_dict.required_keys)
+            new_keys, new_types, new_required_keys = self.analyze_typeddict_classdef_fields(defn,
+                                                                                            keys)
+            if new_keys is None:
+                return True, None  # Defer
+            keys.extend(new_keys)
+            types.extend(new_types)
+            required_keys.update(new_required_keys)
+            info = self.build_typeddict_typeinfo(defn.name, keys, types, required_keys)
+            defn.analyzed = TypedDictExpr(info)
+            defn.analyzed.line = defn.line
+            defn.analyzed.column = defn.column
+            return True, info
+        return False, None
 
-    def check_typeddict_classdef(self, defn: ClassDef,
-                                 oldfields: Optional[List[str]] = None) -> Tuple[List[str],
-                                                                                 List[Type],
-                                                                                 Set[str]]:
+    def analyze_typeddict_classdef_fields(
+            self,
+            defn: ClassDef,
+            oldfields: Optional[List[str]] = None) -> Tuple[Optional[List[str]],
+                                                            List[Type],
+                                                            Set[str]]:
+        """Analyze fields defined in a TypedDict class definition.
+
+        This doesn't consider inherited fields (if any). Also consider totality,
+        if given.
+
+        Return tuple with these items:
+         * List of keys (or None if found an incomplete reference --> deferral)
+         * List of types for each key
+         * Set of required keys
+        """
         if self.options.python_version < (3, 6):
             self.fail('TypedDict class syntax is only supported in Python 3.6', defn)
             return [], [], set()
@@ -133,7 +145,8 @@ class TypedDictAnalyzer:
                     types.append(AnyType(TypeOfAny.unannotated))
                 else:
                     analyzed = self.api.anal_type(stmt.type)
-                    assert analyzed is not None  # TODO: Handle None values
+                    if analyzed is None:
+                        return None, [], set()  # Need to defer
                     types.append(analyzed)
                 # ...despite possible minor failures that allow further analyzis.
                 if stmt.type is None or hasattr(stmt, 'new_syntax') and not stmt.new_syntax:
@@ -151,7 +164,10 @@ class TypedDictAnalyzer:
         return fields, types, required_keys
 
     def process_typeddict_definition(self, s: AssignmentStmt, is_func_scope: bool) -> None:
-        """Check if s defines a TypedDict; if yes, store the definition in symbol table."""
+        """Check if s defines an assignment-based TypedDict type.
+
+        If yes, store the definition in symbol table.
+        """
         if len(s.lvalues) != 1 or not isinstance(s.lvalues[0], NameExpr):
             return
         lvalue = s.lvalues[0]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -219,3 +219,52 @@ class A:
 
 class C(B):
     c: int
+
+[case testNewAnalyzerTypedDictClass]
+# flags: --new-semantic-analyzer
+from mypy_extensions import TypedDict
+import a
+class T1(TypedDict):
+    x: A
+class A: pass
+reveal_type(T1(x=A())) # E
+
+[file a.py]
+from mypy_extensions import TypedDict
+from b import TD1 as TD2, TD3
+class T2(TD3):
+    x: int
+reveal_type(T2(x=2)) # E
+
+[file b.py]
+from a import TypedDict as TD1
+from a import TD2 as TD3
+
+[out]
+tmp/a.py:5: error: Revealed type is 'TypedDict('a.T2', {'x': builtins.int})'
+main:7: error: Revealed type is 'TypedDict('__main__.T1', {'x': __main__.A})'
+
+
+[case testNewAnalyzerTypedDictClassInheritance]
+# flags: --new-semantic-analyzer
+from mypy_extensions import TypedDict
+
+class T2(T1):
+    y: int
+
+class T1(TypedDict):
+    x: str
+
+class T3(TypedDict):
+    x: str
+
+class T4(T3):
+    y: A
+
+class A: pass
+
+T2(x=0, y=0) # E: Incompatible types (expression has type "int", TypedDict item "x" has type "str")
+x: T2
+reveal_type(x) # E: Revealed type is 'TypedDict('__main__.T2', {'x': builtins.str, 'y': builtins.int})'
+y: T4
+reveal_type(y) # E: Revealed type is 'TypedDict('__main__.T4', {'x': builtins.str, 'y': __main__.A})'


### PR DESCRIPTION
To support deferrals, we only create a TypeInfo once there
are no incomplete references within the definition. This
required some restructuring.