### PR TITLE
New semantic analyzer: Fix redefinitions

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -370,7 +370,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         self.patches = patches
         self.deferred = False  # Set to true if another analysis pass is needed
         self.incomplete = False  # Set to true if current module namespace is missing things
-        # These names couldn't be added to the symbol table
+        # These names couldn't be added to the symbol table due to incomplete deps.
         self.missing_names = set()  # type: Set[str]
 
         if isinstance(node, MypyFile):

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -599,7 +599,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         self.process_final_in_overload(defn)
         self.process_static_or_class_method_in_overload(defn)
 
-        if self.type and not self.is_func_scope():
+        # TODO: Fix this
+        if self.is_class_scope():
             self.type.names[defn.name()] = SymbolTableNode(MDEF, defn)
             defn.info = self.type
         elif self.is_func_scope():
@@ -2222,7 +2223,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         if add_global and lval.name not in self.globals:
             # Define new global name.
             v = self.make_name_lvalue_var(lval, GDEF, not explicit_type)
-            self.globals[lval.name] = SymbolTableNode(GDEF, v)
+            self.add_symbol(lval.name, v, lval)
         elif isinstance(lval.node, Var) and lval.is_new_def:
             if lval.kind == GDEF:
                 # Since the is_new_def flag is set, this must have been analyzed
@@ -2251,7 +2252,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             if is_final and unmangle(lval.name) + "'" in self.type.names:
                 self.fail("Cannot redefine an existing name as final", lval)
             v = self.make_name_lvalue_var(lval, MDEF, not explicit_type)
-            self.type.names[lval.name] = SymbolTableNode(MDEF, v)
+            self.add_symbol(lval.name, v, lval)
         else:
             self.make_name_lvalue_point_to_existing_def(lval, explicit_type, is_final)
 

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -601,6 +601,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
         # TODO: Fix this
         if self.is_class_scope():
+            assert self.type is not None
             self.type.names[defn.name()] = SymbolTableNode(MDEF, defn)
             defn.info = self.type
         elif self.is_func_scope():

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -132,11 +132,12 @@ def semantic_analyze_target(target: str,
     analyzer.global_decls = [set()]
     analyzer.nonlocal_decls = [set()]
     analyzer.globals = tree.names
-    with analyzer.file_context(file_node=tree,
-                               fnam=tree.path,
-                               options=state.options,
-                               active_type=active_type):
-        analyzer.refresh_partial(node, [])
+    with state.wrap_context():
+        with analyzer.file_context(file_node=tree,
+                                   fnam=tree.path,
+                                   options=state.options,
+                                   active_type=active_type):
+            analyzer.refresh_partial(node, [])
     if analyzer.deferred:
         return [target], analyzer.incomplete
     else:

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -268,3 +268,16 @@ x: T2
 reveal_type(x) # E: Revealed type is 'TypedDict('__main__.T2', {'x': builtins.str, 'y': builtins.int})'
 y: T4
 reveal_type(y) # E: Revealed type is 'TypedDict('__main__.T4', {'x': builtins.str, 'y': __main__.A})'
+
+[case testNewAnalyzerRedefinitionAndDeferral]
+# flags: --new-semantic-analyzer
+import a
+
+[file a.py]
+from b import x as y
+x = 0
+
+def y(): pass # E: Name 'y' already defined on line 2
+reveal_type(y) # E: Revealed type is 'builtins.int'
+[file b.py]
+from a import x

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -304,3 +304,19 @@ class C: pass
 class C2: pass # E: Name 'C2' already defined (possibly by an import)
 [file b.py]
 from a import C
+
+[case testNewAnalyzerImportStarForwardRef]
+# flags: --new-semantic-analyzer
+import a
+
+[file a.py]
+x: A
+reveal_type(x) # E: Revealed type is 'b.A'
+
+from b import *
+
+class A: pass # E: Name 'A' already defined (possibly by an import)
+
+[file b.py]
+class A: pass
+from a import x

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -305,6 +305,21 @@ class C2: pass # E: Name 'C2' already defined (possibly by an import)
 [file b.py]
 from a import C
 
+[case testNewAnalyzerRedefinitionAndDeferral3]
+# flags: --new-semantic-analyzer
+import a
+
+[file a.py]
+from b import f as g
+def f(): pass
+
+a, *b = g()
+class b(): pass # E: Name 'b' already defined on line 4
+reveal_type(b) # E: Revealed type is 'Any'
+
+[file b.py]
+from a import f
+
 [case testNewAnalyzerImportStarForwardRef]
 # flags: --new-semantic-analyzer
 import a

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -279,5 +279,15 @@ x = 0
 
 def y(): pass # E: Name 'y' already defined on line 2
 reveal_type(y) # E: Revealed type is 'builtins.int'
+
+y2 = y
+class y2: pass # E: Name 'y2' already defined on line 7
+reveal_type(y2) # E: Revealed type is 'builtins.int'
+
+y3, y4 = y, y
+from b import f as y3 # E: Incompatible import of "y3" (imported name has type "Callable[[], Any]", local name has type "int")
+reveal_type(y3) # E: Revealed type is 'builtins.int'
 [file b.py]
 from a import x
+
+def f(): pass

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -287,7 +287,20 @@ reveal_type(y2) # E: Revealed type is 'builtins.int'
 y3, y4 = y, y
 from b import f as y3 # E: Incompatible import of "y3" (imported name has type "Callable[[], Any]", local name has type "int")
 reveal_type(y3) # E: Revealed type is 'builtins.int'
+
 [file b.py]
 from a import x
 
 def f(): pass
+
+[case testNewAnalyzerRedefinitionAndDeferral2]
+# flags: --new-semantic-analyzer
+import a
+
+[file a.py]
+from b import C as C2
+class C: pass
+
+class C2: pass # E: Name 'C2' already defined (possibly by an import)
+[file b.py]
+from a import C


### PR DESCRIPTION
When we can't resolve a definition due to some missing dependencies,
we now don't record any additional definitions of the same name. This
is important since the first definition should always win. This applies
to things like assignments, function definitions, imports and class
definitions (anything that defines a name in the current scope).

Example of where things would go wrong:

```
from m import C  # Assume C can't be resolved yet

class C:  # Could be exposed, even though it's not the first def
    pass
```

Star imports are a bit special, since they could define arbitrary names
if the target module is incomplete. We use a special name `*` to
mark this. It disallows the definition of all names.

We don't track the scopes of definitions for simplicity. If definition
of `x` goes wrong, we also refuse to define it in any nested scope.
This may result in some extra deferrals, but otherwise shouldn't be
a problem.

This also refactors symbol table management. The key thing here is
that we want symbol table additions to go through a single function
so that we can skip them if they are defining something that was
already defined, but the previous definition couldn't be resolved. 

Some places still haven't been updated, but these are related to
features that aren't supported yet by the new analyzer. Also removed
some code related function redefinition, but again this isn't supported
yet and will have to be fixed anyway.