### PR TITLE
fix a typo in documentation

### DIFF
--- a/docs/source/extending_mypy.rst
+++ b/docs/source/extending_mypy.rst
@@ -35,7 +35,7 @@ A trivial example of using the api is the following
         print('\nError report:\n')
         print(result[1])  # stderr
 
-    print ('\nExit status:', result[2])
+    print('\nExit status:', result[2])
 
 Extending mypy using plugins
 ****************************

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -38,7 +38,7 @@ if result[1]:
     print('\nError report:\n')
     print(result[1])  # stderr
 
-print ('\nExit status:', result[2])
+print('\nExit status:', result[2])
 
 """
 


### PR DESCRIPTION
Hi,

I was reading the documentation and found this small typo in the code examples.