### PR TITLE
Associate deps cache files with the depended upon module

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -727,6 +727,7 @@ class BuildManager(BuildManagerBase):
 def deps_to_json(x: Dict[str, Set[str]]) -> str:
     return json.dumps({k: list(v) for k, v in x.items()})
 
+
 # File for storing metadata about all the fine-grained dependency caches
 DEPS_META_FILE = '@deps.meta.json'  # type: Final
 # File for storing fine-grained dependencies that didn't a parent in the build

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -261,6 +261,7 @@ CacheMeta = NamedTuple('CacheMeta',
 
 FgDepMeta = TypedDict('FgDepMeta', {'path': str, 'mtime': int})
 
+
 def cache_meta_from_dict(meta: Dict[str, Any], data_json: str) -> CacheMeta:
     """Build a CacheMeta object from a json metadata dictionary
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -765,12 +765,13 @@ def write_deps_cache(rdeps: Dict[str, Dict[str, Set[str]]],
 def invert_deps_inner(
         deps: Dict[str, Set[str]],
         graph: Graph) -> Tuple[Dict[str, Dict[str, Set[str]]], Dict[str, Set[str]]]:
-    from mypy.server.target import module_prefix
+    from mypy.server.target import module_prefix, trigger_to_target
+
     rdeps = {}  # type: Dict[str, Dict[str, Set[str]]]
     extra_deps = {}  # type: Dict[str, Set[str]]
     for trigger, targets in deps.items():
         assert trigger[0] == '<'
-        module = module_prefix(graph, trigger[1:-1])
+        module = module_prefix(graph, trigger_to_target(trigger))
         if module and graph[module].tree:
             mod_rdeps = rdeps.setdefault(module, {})
             mod_rdeps.setdefault(trigger, set()).update(targets)

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -727,7 +727,7 @@ def deps_to_json(x: Dict[str, Set[str]]) -> str:
 
 
 DEPS_META_FILE = '@deps.meta.json'  # type: Final
-DEPS_EXTRA_FILE = '@extra.meta.json'  # type: Final
+DEPS_ROOT_FILE = '@root.meta.json'  # type: Final
 
 
 def write_deps_cache(rdeps: Dict[str, Dict[str, Set[str]]],
@@ -741,7 +741,7 @@ def write_deps_cache(rdeps: Dict[str, Dict[str, Set[str]]],
     if module 'n' depends on 'm', that produces entries in m.deps.json.
     When there is a dependency on a module that does not exist in the
     build, it is stored with its first existing parent module. If no
-    such module exists, it is stored with the fake module '@extra'.
+    such module exists, it is stored with the fake module '@root'.
 
     This means that the validity of the fine-grained dependency caches
     are a global property, so we store validity checking information for
@@ -758,10 +758,10 @@ def write_deps_cache(rdeps: Dict[str, Dict[str, Set[str]]],
     fg_deps_meta = manager.fg_deps_meta.copy()
 
     for id in rdeps:
-        if id != '@extra':
+        if id != '@root':
             _, _, deps_json = get_cache_names(id, graph[id].xpath, manager)
         else:
-            deps_json = DEPS_EXTRA_FILE
+            deps_json = DEPS_ROOT_FILE
         assert deps_json
         manager.log("Writing deps cache", deps_json)
         if not manager.metastore.write(deps_json, deps_to_json(rdeps[id])):
@@ -803,7 +803,7 @@ def invert_deps(
     for trigger, targets in deps.items():
         module = module_prefix(graph, trigger_to_target(trigger))
         if not module or not graph[module].tree:
-            module = '@extra'
+            module = '@root'
 
         mod_rdeps = rdeps.setdefault(module, {})
         mod_rdeps.setdefault(trigger, set()).update(targets)
@@ -818,7 +818,7 @@ def process_deps(proto_deps: Dict[str, Set[str]],
 
     Returns a dictionary from module ids to all dependencies on that
     module. Dependencies not associated with a module in the build are
-    associated with the fake module '@extra'.
+    associated with the fake module '@root'.
     """
 
     from mypy.server.update import merge_dependencies

--- a/mypy/server/target.py
+++ b/mypy/server/target.py
@@ -1,6 +1,16 @@
 from typing import Iterable, Tuple, List, Optional
 
 
+def trigger_to_target(s: str) -> str:
+    assert s[0] == '<'
+    # Strip off the angle brackets
+    s = s[1:-1]
+    # If there is a [wildcard] or similar, strip that off too
+    if s[-1] == ']':
+        s = s.split('[')[0]
+    return s
+
+
 def module_prefix(modules: Iterable[str], target: str) -> Optional[str]:
     result = split_target(modules, target)
     if result is None:

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -138,7 +138,7 @@ from mypy.server.astdiff import (
 from mypy.server.astmerge import merge_asts
 from mypy.server.aststrip import strip_target
 from mypy.server.deps import get_dependencies_of_target
-from mypy.server.target import module_prefix, split_target
+from mypy.server.target import module_prefix, split_target, trigger_to_target
 from mypy.server.trigger import make_trigger, WILDCARD_TAG
 from mypy.typestate import TypeState
 
@@ -835,7 +835,7 @@ def find_targets_recursive(
         for target in current:
             if target.startswith('<'):
                 # XXX: slow??
-                module_id = module_prefix(graph, target[1:-1])
+                module_id = module_prefix(graph, trigger_to_target(target))
                 if module_id:
                     ensure_deps_loaded(module_id, deps, graph)
 

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -407,7 +407,12 @@ def find_unloaded_deps(manager: BuildManager, graph: Dict[str, State],
 
 def ensure_deps_loaded(module: str,
                        deps: Dict[str, Set[str]], graph: Dict[str, State]) -> None:
-    # XXX: COMMENT
+    """Ensure that the dependencies on a module are loaded.
+
+    This also requires loading dependencies from any parent modules,
+    since dependencies will get stored with parent modules when a module
+    doesn't exist.
+    """
     if module in graph and graph[module].fine_grained_deps_loaded:
         return
     parts = module.split('.')
@@ -432,7 +437,7 @@ def ensure_trees_loaded(manager: BuildManager, graph: Dict[str, State],
 def get_all_dependencies(manager: BuildManager, graph: Dict[str, State]) -> Dict[str, Set[str]]:
     """Return the fine-grained dependency map for an entire build."""
     # Deps for each module were computed during build() or loaded from the cache.
-    deps = {}  # type: Dict[str, Set[str]]
+    deps = manager.load_fine_grained_deps('@extra')  # type: Dict[str, Set[str]]
     for id in graph:
         if graph[id].tree is not None:
             merge_dependencies(graph[id].compute_fine_grained_deps(), deps)

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -409,6 +409,8 @@ def ensure_deps_loaded(module: str,
                        deps: Dict[str, Set[str]], graph: Dict[str, State]) -> None:
     """Ensure that the dependencies on a module are loaded.
 
+    Dependencies are loaded into the 'deps' dictionary.
+
     This also requires loading dependencies from any parent modules,
     since dependencies will get stored with parent modules when a module
     doesn't exist.

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -834,7 +834,6 @@ def find_targets_recursive(
         worklist = set()
         for target in current:
             if target.startswith('<'):
-                # XXX: slow??
                 module_id = module_prefix(graph, trigger_to_target(target))
                 if module_id:
                     ensure_deps_loaded(module_id, deps, graph)

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -121,6 +121,7 @@ from typing import (
 from mypy.build import (
     BuildManager, State, BuildResult, Graph, load_graph,
     process_fresh_modules, DEBUG_FINE_GRAINED,
+    FAKE_ROOT_MODULE,
 )
 from mypy.modulefinder import BuildSource
 from mypy.checker import FineGrainedDeferredNode
@@ -439,7 +440,7 @@ def ensure_trees_loaded(manager: BuildManager, graph: Dict[str, State],
 def get_all_dependencies(manager: BuildManager, graph: Dict[str, State]) -> Dict[str, Set[str]]:
     """Return the fine-grained dependency map for an entire build."""
     # Deps for each module were computed during build() or loaded from the cache.
-    deps = manager.load_fine_grained_deps('@root')  # type: Dict[str, Set[str]]
+    deps = manager.load_fine_grained_deps(FAKE_ROOT_MODULE)  # type: Dict[str, Set[str]]
     for id in graph:
         if graph[id].tree is not None:
             merge_dependencies(graph[id].compute_fine_grained_deps(), deps)

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -417,6 +417,7 @@ def ensure_deps_loaded(module: str,
             merge_dependencies(graph[base].load_fine_grained_deps(), deps)
             graph[base].fine_grained_deps_loaded = True
 
+
 def ensure_trees_loaded(manager: BuildManager, graph: Dict[str, State],
                         initial: Sequence[str]) -> None:
     """Ensure that the modules in initial and their deps have loaded trees."""

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -439,7 +439,7 @@ def ensure_trees_loaded(manager: BuildManager, graph: Dict[str, State],
 def get_all_dependencies(manager: BuildManager, graph: Dict[str, State]) -> Dict[str, Set[str]]:
     """Return the fine-grained dependency map for an entire build."""
     # Deps for each module were computed during build() or loaded from the cache.
-    deps = manager.load_fine_grained_deps('@extra')  # type: Dict[str, Set[str]]
+    deps = manager.load_fine_grained_deps('@root')  # type: Dict[str, Set[str]]
     for id in graph:
         if graph[id].tree is not None:
             merge_dependencies(graph[id].compute_fine_grained_deps(), deps)

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -86,6 +86,7 @@ class FineGrainedSuite(DataSuite):
         step = 1
         sources = self.parse_sources(main_src, step, options)
         if step <= num_regular_incremental_steps:
+            build_options.incremental = step > 1
             messages = self.build(build_options, sources)
         else:
             messages = self.run_check(server, sources)

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -86,7 +86,6 @@ class FineGrainedSuite(DataSuite):
         step = 1
         sources = self.parse_sources(main_src, step, options)
         if step <= num_regular_incremental_steps:
-            build_options.incremental = step > 1
             messages = self.build(build_options, sources)
         else:
             messages = self.run_check(server, sources)

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3639,7 +3639,7 @@ import b
 -- This is a heinous hack, but we simulate having a invalid cache by clobbering
 -- the proto deps file with something with mtime mismatches.
 [file ../.mypy_cache/3.6/@deps.meta.json.2]
-{"snapshot": {"__main__": "a7c958b001a45bd6a2a320f4e53c4c16", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "c532c89da517a4b779bcf7a964478d67"}, "deps_meta": {"@extra": {"path": "@deps.data.json", "mtime": 0}, "__main__": {"path": "__main__.deps.json", "mtime": 0}, "a": {"path": "a.deps.json", "mtime": 0}, "b": {"path": "b.deps.json", "mtime": 0}, "builtins": {"path": "builtins.deps.json", "mtime": 0}}}
+{"snapshot": {"__main__": "a7c958b001a45bd6a2a320f4e53c4c16", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "c532c89da517a4b779bcf7a964478d67"}, "deps_meta": {"@root": {"path": "@root.deps.json", "mtime": 0}, "__main__": {"path": "__main__.deps.json", "mtime": 0}, "a": {"path": "a.deps.json", "mtime": 0}, "b": {"path": "b.deps.json", "mtime": 0}, "builtins": {"path": "builtins.deps.json", "mtime": 0}}}
 [file b.py.2]
 # uh
 -- Every file should get reloaded, since the cache was invalidated

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3637,9 +3637,9 @@ import b
 [file a.py]
 [file b.py]
 -- This is a heinous hack, but we simulate having a invalid cache by clobbering
--- the proto deps file with something with hash mismatches.
+-- the proto deps file with something with mtime mismatches.
 [file ../.mypy_cache/3.6/@deps.meta.json.2]
-{"__main__": "00000000000000000000000000000000", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "00000000000000000000000000000000"}
+{"snapshot": {"__main__": "a7c958b001a45bd6a2a320f4e53c4c16", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "c532c89da517a4b779bcf7a964478d67"}, "deps_meta": {"@extra": {"path": "@deps.data.json", "mtime": 0}, "__main__": {"path": "__main__.deps.json", "mtime": 0}, "a": {"path": "a.deps.json", "mtime": 0}, "b": {"path": "b.deps.json", "mtime": 0}, "builtins": {"path": "builtins.deps.json", "mtime": 0}}}
 [file b.py.2]
 # uh
 -- Every file should get reloaded, since the cache was invalidated

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3638,7 +3638,7 @@ import b
 [file b.py]
 -- This is a heinous hack, but we simulate having a invalid cache by clobbering
 -- the proto deps file with something with hash mismatches.
-[file ../.mypy_cache/3.6/@proto_deps.meta.json.2]
+[file ../.mypy_cache/3.6/@deps.meta.json.2]
 {"__main__": "00000000000000000000000000000000", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "00000000000000000000000000000000"}
 [file b.py.2]
 # uh
@@ -3666,7 +3666,7 @@ import b
 [file b.py]
 -- This is a heinous hack, but we simulate having a invalid cache by deleting
 -- the proto deps file.
-[delete ../.mypy_cache/3.6/@proto_deps.meta.json.2]
+[delete ../.mypy_cache/3.6/@deps.meta.json.2]
 [file b.py.2]
 # uh
 -- Every file should get reloaded, since the cache was invalidated

--- a/test-data/unit/fine-grained-cache-incremental.test
+++ b/test-data/unit/fine-grained-cache-incremental.test
@@ -203,7 +203,7 @@ a.py:8: note:     x: expected "int", got "str"
 -- This is a heinous hack, but we simulate having a invalid cache by clobbering
 -- the proto deps file with something with mtime mismatches.
 [file ../.mypy_cache/3.6/@deps.meta.json.2]
-{"snapshot": {"__main__": "a7c958b001a45bd6a2a320f4e53c4c16", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "c532c89da517a4b779bcf7a964478d67"}, "deps_meta": {"@extra": {"path": "@deps.data.json", "mtime": 0}, "__main__": {"path": "__main__.deps.json", "mtime": 0}, "a": {"path": "a.deps.json", "mtime": 0}, "b": {"path": "b.deps.json", "mtime": 0}, "builtins": {"path": "builtins.deps.json", "mtime": 0}}}
+{"snapshot": {"__main__": "a7c958b001a45bd6a2a320f4e53c4c16", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "c532c89da517a4b779bcf7a964478d67"}, "deps_meta": {"@root": {"path": "@root.deps.json", "mtime": 0}, "__main__": {"path": "__main__.deps.json", "mtime": 0}, "a": {"path": "a.deps.json", "mtime": 0}, "b": {"path": "b.deps.json", "mtime": 0}, "builtins": {"path": "builtins.deps.json", "mtime": 0}}}
 
 [file b.py.2]
 # uh

--- a/test-data/unit/fine-grained-cache-incremental.test
+++ b/test-data/unit/fine-grained-cache-incremental.test
@@ -51,6 +51,34 @@ x = 'hi'
 ==
 a.py:3: error: Unsupported operand types for + ("int" and "str")
 
+[case testIncrCacheDoubleChange1]
+# num_build_steps: 2
+import b
+import c
+[file a.py]
+def f(x: int) -> None:
+    pass
+[file b.py]
+from a import f
+f(10)
+[file c.py]
+from a import f
+f(10)
+
+[file a.py.2]
+def f(x: int) -> None:
+    pass
+# nothing changed
+
+[file a.py.3]
+def f(x: str) -> None:
+    pass
+[out]
+==
+==
+c.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
+b.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
+
 [case testIncrCacheProtocol1]
 # num_build_steps: 2
 import a

--- a/test-data/unit/fine-grained-cache-incremental.test
+++ b/test-data/unit/fine-grained-cache-incremental.test
@@ -201,9 +201,10 @@ a.py:8: note:     x: expected "int", got "str"
 [file a.py]
 [file b.py]
 -- This is a heinous hack, but we simulate having a invalid cache by clobbering
--- the proto deps file with something with hash mismatches.
+-- the proto deps file with something with mtime mismatches.
 [file ../.mypy_cache/3.6/@deps.meta.json.2]
-{"__main__": "00000000000000000000000000000000", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "00000000000000000000000000000000"}
+{"snapshot": {"__main__": "a7c958b001a45bd6a2a320f4e53c4c16", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "c532c89da517a4b779bcf7a964478d67"}, "deps_meta": {"@extra": {"path": "@deps.data.json", "mtime": 0}, "__main__": {"path": "__main__.deps.json", "mtime": 0}, "a": {"path": "a.deps.json", "mtime": 0}, "b": {"path": "b.deps.json", "mtime": 0}, "builtins": {"path": "builtins.deps.json", "mtime": 0}}}
+
 [file b.py.2]
 # uh
 -- A full reload shows up as nothing getting rechecked by fine-grained mode.

--- a/test-data/unit/fine-grained-cache-incremental.test
+++ b/test-data/unit/fine-grained-cache-incremental.test
@@ -202,7 +202,7 @@ a.py:8: note:     x: expected "int", got "str"
 [file b.py]
 -- This is a heinous hack, but we simulate having a invalid cache by clobbering
 -- the proto deps file with something with hash mismatches.
-[file ../.mypy_cache/3.6/@proto_deps.meta.json.2]
+[file ../.mypy_cache/3.6/@deps.meta.json.2]
 {"__main__": "00000000000000000000000000000000", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "00000000000000000000000000000000"}
 [file b.py.2]
 # uh


### PR DESCRIPTION
Currently the fine-grained deps cache file for a module contains all the
fine-grained dependencies *from* the module (that is, those whose
targets are in the module). This has the advantage that producing fine-grained
dependency cache files is nicely localized (just run it on a module), but
the downside that *loading* the fine-grained deps cache is a global operation,
requiring every cache file to be loaded.

To improve daemon performance, we invert this, and have the deps cache file
for a module contain the fine-grained dependencies *to* the module. This
complicates creating the cache files: we need to explicitly sort out triggers
into the appropriate cache file.

This, then, allows us to postpone loading deps cache files until the module
is updated.

Because protocol dependencies now get sorted out into modules like everything
else, this notionally eliminates the special protocol deps cache. In practice, the
protocol deps cache has morphed in a cache for 'extra' dependencies that weren't
placed somewhere else (either because the module doesn't exist or because they
were added in an incremental run) and the meta file for it has grown additional
metadata to check consistency of the deps cache. (Because deps files are now
written after metadata, we can't store info about the in the metadata files.)