### PR TITLE
Add a mypyc-requirements file with a pinned version of mypyc

### DIFF
--- a/misc/update-mypyc-version.sh
+++ b/misc/update-mypyc-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+MYPYC_DIR=~/src/mypyc
+REV=$(cd "$MYPYC_DIR" && git rev-parse HEAD)
+VERSION=$(cd "$MYPYC_DIR" && python3 -c 'from mypyc.version import __version__; print(__version__)')
+
+echo "git+https://github.com/mypyc/mypyc.git@$REV#egg=mypyc==$VERSION" > mypyc-requirements.txt
+git commit -a -m "Update pinned mypyc version to $VERSION"

--- a/mypyc-requirements.txt
+++ b/mypyc-requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/mypyc/mypyc.git@20d277be2bc1c031232be8745947be10da3b976a#egg=mypyc==0.0.1+dev.20d277be2bc1c031232be8745947be10da3b976a


### PR DESCRIPTION
With this in place, we can make mypy_mypyc-wheels use it to determine
the version of mypyc to use.

Also add a script for quickly updating the pinned version of mypyc.