### PR TITLE
Fixed overlapped I/O when more data needs to be read

### DIFF
--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -77,20 +77,8 @@ class IPCBase:
                     # we are done!
                     break
                 elif err == _winapi.ERROR_MORE_DATA:
-                    left = _winapi.PeekNamedPipe(self.connection)[1]
-                    assert left > 0
-                    ov, err = _winapi.ReadFile(self.connection, left, overlapped=True)
-                    # TODO: remove once typeshed supports Literal types
-                    assert isinstance(ov, _winapi.Overlapped)
-                    assert isinstance(err, int)
-                    read, err = ov.GetOverlappedResult(True)
-                    assert err == 0, err
-                    assert read == left, read
-                    more = ov.getbuffer()
-                    if more:
-                        bdata.extend(more)
-                    # we are done after reading the rest of the pipe contents
-                    break
+                    # read again
+                    continue
                 elif err == _winapi.ERROR_OPERATION_ABORTED:
                     raise IPCException("ReadFile operation aborted.")
         else:

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -110,12 +110,13 @@ class IPCBase:
                 assert isinstance(ov, _winapi.Overlapped)
                 assert isinstance(err, int)
                 try:
-                    if err != 0:
-                        assert err == _winapi.ERROR_IO_PENDING, err
+                    if err == _winapi.ERROR_IO_PENDING:
                         timeout = int(self.timeout * 1000) if self.timeout else _winapi.INFINITE
                         res = _winapi.WaitForSingleObject(ov.event, timeout)
                         if res != _winapi.WAIT_OBJECT_0:
                             raise IPCException("Bad result from I/O wait: {}".format(res))
+                    elif err != 0:
+                        raise IPCException("Failed writing to pipe with error: {}".format(err))
                 except BaseException:
                     ov.cancel()
                     raise

--- a/mypy/test/testipc.py
+++ b/mypy/test/testipc.py
@@ -24,7 +24,7 @@ def server(msg: str, q: 'Queue[str]') -> None:
 class IPCTests(TestCase):
     def test_transaction_large(self) -> None:
         queue = Queue()  # type: Queue[str]
-        msg = 't' * 100001  # longer than the max read size of 100_000
+        msg = 't' * 200000  # longer than the max read size of 100_000
         p = Process(target=server, args=(msg, queue), daemon=True)
         p.start()
         connection_name = queue.get()


### PR DESCRIPTION
For some reason the tests didn't capture this, but ReadFile, not GetOverlappedResult returns _winapi.ERROR_MORE_DATA, which means that we would not do another read (instead we would fail an assert). This handles the case where there is more data to be read and correctly peeks then reads the remaining data.

I also increased the size of the test message to make sure we don't miss errors like this in the future, and added more information when assertions fail.