### PR TITLE
Fix upload-pypi.py to work when /bin/sh isn't bash

### DIFF
--- a/misc/upload-pypi.py
+++ b/misc/upload-pypi.py
@@ -137,7 +137,7 @@ class Builder:
             sys.exit(1)
 
     def run_in_virtualenv(self, cmd: str) -> None:
-        self.run('source mypy-venv/bin/activate && cd mypy &&' + cmd)
+        self.run('. mypy-venv/bin/activate && cd mypy &&' + cmd)
 
     def heading(self, heading: str) -> None:
         print()


### PR DESCRIPTION
Apparently traditional sh (like that emulated by dash on ubuntu)
recognizes '.' but not 'source'.