### PR TITLE
New semantic analyzer: Add placeholder types etc.

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -32,7 +32,7 @@ if MYPY:
 
 from mypy_extensions import TypedDict
 
-from mypy.nodes import (MypyFile, ImportBase, Import, ImportFrom, ImportAll)
+from mypy.nodes import MypyFile, ImportBase, Import, ImportFrom, ImportAll, SymbolTable
 from mypy.semanal_pass1 import SemanticAnalyzerPass1
 from mypy.newsemanal.semanal_pass1 import ReachabilityAnalyzer
 from mypy.semanal import SemanticAnalyzerPass2, apply_semantic_analyzer_patches
@@ -1840,6 +1840,8 @@ class State:
             analyzer = ReachabilityAnalyzer()
             with self.wrap_context():
                 analyzer.visit_file(self.tree, self.xpath, self.id, options)
+            # TODO: Do this while contructing the AST?
+            self.tree.names = SymbolTable()
         else:
             # Do the first pass of semantic analysis: add top-level
             # definitions in the file to the symbol table.  We must do

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -507,12 +507,10 @@ class BuildManager(BuildManagerBase):
             # Set of namespaces (module or class) that are being populated during semantic
             # analysis and may have missing definitions.
             self.incomplete_namespaces = set()  # type: Set[str]
-            self.incomplete_types = set()  # type: Set[str]
             self.new_semantic_analyzer = NewSemanticAnalyzer(
                 self.modules,
                 self.missing_modules,
                 self.incomplete_namespaces,
-                self.incomplete_types,
                 self.errors,
                 self.plugin)
         else:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -507,10 +507,12 @@ class BuildManager(BuildManagerBase):
             # Set of namespaces (module or class) that are being populated during semantic
             # analysis and may have missing definitions.
             self.incomplete_namespaces = set()  # type: Set[str]
+            self.incomplete_types = set()  # type: Set[str]
             self.new_semantic_analyzer = NewSemanticAnalyzer(
                 self.modules,
                 self.missing_modules,
                 self.incomplete_namespaces,
+                self.incomplete_types,
                 self.errors,
                 self.plugin)
         else:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -31,7 +31,7 @@ from mypy.nodes import (
     ConditionalExpr, ComparisonExpr, TempNode, SetComprehension,
     DictionaryComprehension, ComplexExpr, EllipsisExpr, StarExpr, AwaitExpr, YieldExpr,
     YieldFromExpr, TypedDictExpr, PromoteExpr, NewTypeExpr, NamedTupleExpr, TypeVarExpr,
-    TypeAliasExpr, BackquoteExpr, EnumCallExpr, TypeAlias, SymbolNode,
+    TypeAliasExpr, BackquoteExpr, EnumCallExpr, TypeAlias, SymbolNode, IncompleteType,
     ARG_POS, ARG_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2, LITERAL_TYPE, REVEAL_TYPE
 )
 from mypy.literals import literal
@@ -212,6 +212,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                                         alias_definition=e.is_alias_rvalue
                                                         or lvalue)
         else:
+            if isinstance(node, IncompleteType):
+                assert False, 'IncompleteType %r leaked to checker' % node.fullname()
             # Unknown reference; use any type implicitly to avoid
             # generating extra type errors.
             result = AnyType(TypeOfAny.from_error)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -31,7 +31,7 @@ from mypy.nodes import (
     ConditionalExpr, ComparisonExpr, TempNode, SetComprehension,
     DictionaryComprehension, ComplexExpr, EllipsisExpr, StarExpr, AwaitExpr, YieldExpr,
     YieldFromExpr, TypedDictExpr, PromoteExpr, NewTypeExpr, NamedTupleExpr, TypeVarExpr,
-    TypeAliasExpr, BackquoteExpr, EnumCallExpr, TypeAlias, SymbolNode, IncompleteType,
+    TypeAliasExpr, BackquoteExpr, EnumCallExpr, TypeAlias, SymbolNode, PlaceholderTypeInfo,
     ARG_POS, ARG_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2, LITERAL_TYPE, REVEAL_TYPE
 )
 from mypy.literals import literal
@@ -212,8 +212,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                                         alias_definition=e.is_alias_rvalue
                                                         or lvalue)
         else:
-            if isinstance(node, IncompleteType):
-                assert False, 'IncompleteType %r leaked to checker' % node.fullname()
+            if isinstance(node, PlaceholderTypeInfo):
+                assert False, 'PlaceholderTypeInfo %r leaked to checker' % node.fullname()
             # Unknown reference; use any type implicitly to avoid
             # generating extra type errors.
             result = AnyType(TypeOfAny.from_error)

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -216,7 +216,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                  modules: Dict[str, MypyFile],
                  missing_modules: Set[str],
                  incomplete_namespaces: Set[str],
-                 incomplete_types: Set[str],
                  errors: Errors,
                  plugin: Plugin) -> None:
         """Construct semantic analyzer.
@@ -247,7 +246,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         # missing name in these namespaces, we need to defer the current analysis target,
         # since it's possible that the name will be there once the namespace is complete.
         self.incomplete_namespaces = incomplete_namespaces
-        self.incomplete_types = incomplete_types
         self.postpone_nested_functions_stack = [FUNCTION_BOTH_PHASES]
         self.postponed_functions_stack = []
         self.all_exports = []  # type: List[str]
@@ -842,7 +840,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         fullname = self.qualified_name(defn.name)
         if not defn.info and not self.is_core_builtin_class(defn):
             self.add_symbol(defn.name, IncompleteType(fullname), defn)
-        self.mark_incomplete_type(fullname)
 
         tag = self.track_incomplete_refs()
 
@@ -3696,12 +3693,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         current analysis target.
         """
         return fullname in self.incomplete_namespaces
-
-    def mark_incomplete_type(self, fullname: str) -> None:
-        self.incomplete_types.add(fullname)
-
-    def is_incomplete_type(self, fullname: str) -> bool:
-        return fullname in self.incomplete_types
 
     def create_getattr_var(self, getattr_defn: SymbolTableNode,
                            name: str, fullname: str) -> Optional[Var]:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1605,6 +1605,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             id = parent
 
     def allow_patching(self, parent_mod: MypyFile, child: str) -> bool:
+        if parent_mod.names is None:
+            print('defer 1')
+            self.defer()
+            return
         if child not in parent_mod.names:
             return True
         node = parent_mod.names[child].node

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -153,7 +153,7 @@ SUGGESTED_TEST_FIXTURES = {
 
 # Special cased built-in classes that are needed for basic functionality and need to be
 # available very early on.
-CORE_BUILTIN_CLASSES = ['object', 'bool', 'tuple', 'function', 'str']  # type: Final
+CORE_BUILTIN_CLASSES = ['object', 'bool', 'function']  # type: Final
 
 
 # Used for tracking incomplete references

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -838,6 +838,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             self.analyze_class(defn)
 
     def analyze_class(self, defn: ClassDef) -> None:
+        fullname = self.qualified_name(defn.name)
         self.mark_incomplete_type(fullname)
 
         tag = self.track_incomplete_refs()
@@ -857,7 +858,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             # Something was incomplete. Defer current target but also record
             # that the class is a known type.
             self.mark_incomplete(defn.name)
-            fullname = self.qualified_name(defn.name)
             return
 
         base_types, base_error = result

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -848,8 +848,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         result = self.analyze_base_classes(bases)
 
         if result is None or self.found_incomplete_ref(tag):
-            # Something was incomplete. Defer current target but also record
-            # that the class is a known type.
+            # Something was incomplete. Defer current target.
             self.mark_incomplete(defn.name)
             return
 
@@ -1105,13 +1104,13 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             except TypeTranslationError:
                 # This error will be caught later.
                 continue
-            tvars = self.analyze_class_typevar_declaration(base)
-            if tvars is not None:
+            result = self.analyze_class_typevar_declaration(base)
+            if result is not None:
                 if declared_tvars:
                     self.fail('Only single Generic[...] or Protocol[...] can be in bases', context)
                 removed.append(i)
-                declared_tvars.extend(tvars[0])
-                is_protocol = tvars[1]
+                tvars, is_protocol = result
+                declared_tvars.extend(tvars)
             if isinstance(base, UnboundType):
                 sym = self.lookup_qualified(base.name, base)
                 if sym is not None and sym.node is not None:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3045,6 +3045,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             if isinstance(n.node, TypeVarExpr) and self.tvar_scope.get_binding(n):
                 self.fail("'{}' is a type variable and only valid in type "
                           "context".format(expr.name), expr)
+            elif isinstance(n.node, IncompleteType):
+                self.defer()
             else:
                 expr.kind = n.kind
                 expr.node = n.node
@@ -3255,10 +3257,11 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             n = file.names.get(expr.name, None)
             n = self.dereference_module_cross_ref(n)
             if n and not n.module_hidden:
-                if not n:
-                    return
                 n = self.rebind_symbol_table_node(n)
                 if n:
+                    if isinstance(n.node, IncompleteType):
+                        self.defer()
+                        return
                     # TODO: What if None?
                     expr.kind = n.kind
                     expr.fullname = n.fullname

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -153,7 +153,7 @@ SUGGESTED_TEST_FIXTURES = {
 
 # Special cased built-in classes that are needed for basic functionality and need to be
 # available very early on.
-CORE_BUILTIN_CLASSES = ['object', 'bool', 'tuple', 'function']  # type: Final
+CORE_BUILTIN_CLASSES = ['object', 'bool', 'tuple', 'function', 'str']  # type: Final
 
 
 # Used for tracking incomplete references

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2027,8 +2027,9 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             lvalue = s.lvalues[-1]
             allow_tuple_literal = isinstance(lvalue, TupleExpr)
             analyzed = self.anal_type(s.type, allow_tuple_literal=allow_tuple_literal)
-            if analyzed is not None:
-                s.type = analyzed
+            if analyzed is None:
+                return
+            s.type = analyzed
             if (self.type and self.type.is_protocol and isinstance(lvalue, NameExpr) and
                     isinstance(s.rvalue, TempNode) and s.rvalue.no_rhs):
                 if isinstance(lvalue.node, Var):

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2503,6 +2503,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                                               n_values,
                                               s)
         if res is None:
+            self.mark_incomplete(name)
             return
         variance, upper_bound = res
 
@@ -2609,7 +2610,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     # the default error message for invalid types here.
                     analyzed = self.expr_to_analyzed_type(param_value,
                                                           report_invalid_types=False)
-                    assert analyzed is not None  # TODO: Handle None values
+                    if analyzed is None:
+                        None
                     upper_bound = analyzed
                     if isinstance(upper_bound, AnyType) and upper_bound.is_from_error:
                         self.fail("TypeVar 'bound' must be a type", param_value)

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2615,7 +2615,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     analyzed = self.expr_to_analyzed_type(param_value,
                                                           report_invalid_types=False)
                     if analyzed is None:
-                        None
+                        return None
                     upper_bound = analyzed
                     if isinstance(upper_bound, AnyType) and upper_bound.is_from_error:
                         self.fail("TypeVar 'bound' must be a type", param_value)

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -328,7 +328,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
     def prepare_file(self, file_node: MypyFile) -> None:
         """Prepare a freshly parsed file for semantic analysis."""
-        file_node.names = SymbolTable()
         if 'builtins' in self.modules:
             file_node.names['__builtins__'] = SymbolTableNode(GDEF,
                                                               self.modules['builtins'])
@@ -1605,10 +1604,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             id = parent
 
     def allow_patching(self, parent_mod: MypyFile, child: str) -> bool:
-        if parent_mod.names is None:
-            print('defer 1')
-            self.defer()
-            return
         if child not in parent_mod.names:
             return True
         node = parent_mod.names[child].node

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -64,7 +64,6 @@ from mypy.newsemanal.typeanal import (
     check_for_explicit_any
 )
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
-from mypy.sametypes import is_same_type
 from mypy.options import Options
 from mypy import state
 from mypy.plugin import (

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2526,11 +2526,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             self.mark_incomplete(name)
             return
         variance, upper_bound = res
-        if any(has_placeholder_type(t) for t in values + [upper_bound]):
-            # We want type variables to be fully resolved, as otherwise we could
-            # easily leak placeholder types.
-            self.mark_incomplete(name)
-            return
 
         if self.options.disallow_any_unimported:
             for idx, constraint in enumerate(values, start=1):
@@ -4170,15 +4165,3 @@ def names_modified_in_lvalue(lvalue: Lvalue) -> List[str]:
             result += names_modified_in_lvalue(item)
         return result
     return []
-
-
-def has_placeholder_type(t: Type) -> bool:
-    return t.accept(PlaceholderTypeQuery())
-
-
-class PlaceholderTypeQuery(TypeQuery[bool]):
-    def __init__(self) -> None:
-        super().__init__(any)
-
-    def visit_placeholder_type(self, t: PlaceholderType) -> bool:
-        return True

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3409,7 +3409,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 # We always allow unbound type variables in IndexExpr, since we
                 # may be analysing a type alias definition rvalue. The error will be
                 # reported elsewhere if it is not the case.
-                typearg2 = self.anal_type(typearg, allow_unbound_tvars=True, allow_placeholder=True)
+                typearg2 = self.anal_type(typearg, allow_unbound_tvars=True,
+                                          allow_placeholder=True)
                 if typearg2 is None:
                     self.defer()
                     return

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -67,10 +67,13 @@ def process_top_levels(graph: 'Graph', scc: List[str]) -> None:
     worklist = scc[:]
     iteration = 0
     while worklist:
+        print(iteration, worklist)
         iteration += 1
         if iteration == MAX_ITERATIONS:
             # Give up. Likely it's impossible to bind all names.
             state.manager.incomplete_namespaces.clear()
+        elif iteration > MAX_ITERATIONS:
+            assert False, 'Max iteration count reached in semantic analysis'
         all_deferred = []  # type: List[str]
         while worklist:
             next_id = worklist.pop()
@@ -124,6 +127,7 @@ def semantic_analyze_target(target: str,
                             state: 'State',
                             node: Union[MypyFile, FuncDef, OverloadedFuncDef, Decorator],
                             active_type: Optional[TypeInfo]) -> Tuple[List[str], bool]:
+    print('--', target)
     # TODO: Support refreshing function targets (currently only works for module top levels)
     tree = state.tree
     assert tree is not None

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -67,7 +67,6 @@ def process_top_levels(graph: 'Graph', scc: List[str]) -> None:
     worklist = scc[:]
     iteration = 0
     while worklist:
-        print(iteration, worklist)
         iteration += 1
         if iteration == MAX_ITERATIONS:
             # Give up. Likely it's impossible to bind all names.
@@ -127,7 +126,6 @@ def semantic_analyze_target(target: str,
                             state: 'State',
                             node: Union[MypyFile, FuncDef, OverloadedFuncDef, Decorator],
                             active_type: Optional[TypeInfo]) -> Tuple[List[str], bool]:
-    print('--', target)
     # TODO: Support refreshing function targets (currently only works for module top levels)
     tree = state.tree
     assert tree is not None

--- a/mypy/newsemanal/semanal_shared.py
+++ b/mypy/newsemanal/semanal_shared.py
@@ -57,10 +57,6 @@ class SemanticAnalyzerCoreInterface:
         raise NotImplementedError
 
     @abstractmethod
-    def is_incomplete_type(self, fullname: str) -> bool:
-        raise NotImplementedError
-
-    @abstractmethod
     def defer(self) -> None:
         raise NotImplementedError
 

--- a/mypy/newsemanal/semanal_shared.py
+++ b/mypy/newsemanal/semanal_shared.py
@@ -56,6 +56,14 @@ class SemanticAnalyzerCoreInterface:
             self, node: Optional[SymbolTableNode]) -> Optional[SymbolTableNode]:
         raise NotImplementedError
 
+    @abstractmethod
+    def is_incomplete_type(self, fullname: str) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def defer(self) -> None:
+        raise NotImplementedError
+
 
 @trait
 class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):

--- a/mypy/newsemanal/semanal_shared.py
+++ b/mypy/newsemanal/semanal_shared.py
@@ -57,6 +57,10 @@ class SemanticAnalyzerCoreInterface:
         raise NotImplementedError
 
     @abstractmethod
+    def record_incomplete_ref(self) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
     def defer(self) -> None:
         raise NotImplementedError
 

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -23,7 +23,7 @@ from mypy.nodes import (
     UNBOUND_IMPORTED, TypeInfo, Context, SymbolTableNode, Var, Expression,
     IndexExpr, RefExpr, nongen_builtins, check_arg_names, check_arg_kinds, ARG_POS, ARG_NAMED,
     ARG_OPT, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2, TypeVarExpr, FuncDef, CallExpr, NameExpr,
-    Decorator, ImportedName, TypeAlias, MypyFile, IncompleteType
+    Decorator, ImportedName, TypeAlias, MypyFile, PlaceholderTypeInfo
 )
 from mypy.tvar_scope import TypeVarScope
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
@@ -211,7 +211,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 #
                 # TODO: Remove this special case.
                 return AnyType(TypeOfAny.implementation_artifact)
-            if isinstance(node, IncompleteType):
+            if isinstance(node, PlaceholderTypeInfo):
                 self.api.defer()
                 return PlaceholderType(node.fullname(), self.anal_array(t.args), t.line)
             if node is None:
@@ -539,8 +539,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
 
     def visit_placeholder_type(self, t: PlaceholderType) -> Type:
         n = self.api.lookup_fully_qualified(t.fullname)
-        if isinstance(n.node, IncompleteType):
-            self.api.defer()
+        if isinstance(n.node, PlaceholderTypeInfo):
+            self.api.defer()  # Still incomplete
             return t
         else:
             # TODO: Handle non-TypeInfo

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -213,7 +213,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 return AnyType(TypeOfAny.implementation_artifact)
             if isinstance(node, IncompleteType):
                 self.api.defer()
-                return PlaceholderType(node.fullname(), t.args, t.line)
+                return PlaceholderType(node.fullname(), self.anal_array(t.args), t.line)
             if node is None:
                 # UNBOUND_IMPORTED can happen if an unknown name was imported.
                 if sym.kind != UNBOUND_IMPORTED:

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -558,6 +558,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
     def visit_placeholder_type(self, t: PlaceholderType) -> Type:
         n = self.api.lookup_fully_qualified(t.fullname)
         if isinstance(n.node, IncompleteType):
+            self.api.defer()
             return t
         else:
             # TODO: Handle non-TypeInfo

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -16,14 +16,14 @@ from mypy.types import (
     CallableType, NoneTyp, DeletedType, TypeList, TypeVarDef, TypeVisitor, SyntheticTypeVisitor,
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType, get_typ_args, set_typ_args,
     CallableArgument, get_type_vars, TypeQuery, union_items, TypeOfAny, ForwardRef, Overloaded,
-    LiteralType, RawExpressionType,
+    LiteralType, RawExpressionType, PlaceholderType
 )
 
 from mypy.nodes import (
     UNBOUND_IMPORTED, TypeInfo, Context, SymbolTableNode, Var, Expression,
     IndexExpr, RefExpr, nongen_builtins, check_arg_names, check_arg_kinds, ARG_POS, ARG_NAMED,
     ARG_OPT, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2, TypeVarExpr, FuncDef, CallExpr, NameExpr,
-    Decorator, ImportedName, TypeAlias, MypyFile
+    Decorator, ImportedName, TypeAlias, MypyFile, IncompleteType
 )
 from mypy.tvar_scope import TypeVarScope
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
@@ -211,6 +211,9 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 #
                 # TODO: Remove this special case.
                 return AnyType(TypeOfAny.implementation_artifact)
+            if isinstance(node, IncompleteType):
+                self.api.defer()
+                return PlaceholderType(node.fullname(), t.args, t.line)
             if node is None:
                 # UNBOUND_IMPORTED can happen if an unknown name was imported.
                 if sym.kind != UNBOUND_IMPORTED:
@@ -247,7 +250,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 an_args = self.anal_array(t.args)
                 return expand_type_alias(target, all_vars, an_args, self.fail, node.no_args, t)
             elif isinstance(node, TypeInfo):
-                return self.analyze_unbound_type_with_type_info(t, node)
+                return self.analyze_type_with_type_info(node, t.args, t)
             else:
                 return self.analyze_unbound_type_without_type_info(t, sym)
         else:  # sym is None
@@ -320,42 +323,42 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             return self.analyze_literal_type(t)
         return None
 
-    def analyze_unbound_type_with_type_info(self, t: UnboundType, info: TypeInfo) -> Type:
+    def analyze_type_with_type_info(self, info: TypeInfo, args: List[Type], ctx: Context) -> Type:
         """Bind unbound type when were able to find target TypeInfo.
 
         This handles simple cases like 'int', 'modname.UserClass[str]', etc.
         """
-        if len(t.args) > 0 and info.fullname() == 'builtins.tuple':
-            fallback = Instance(info, [AnyType(TypeOfAny.special_form)], t.line)
-            return TupleType(self.anal_array(t.args), fallback, t.line)
+        if len(args) > 0 and info.fullname() == 'builtins.tuple':
+            fallback = Instance(info, [AnyType(TypeOfAny.special_form)], ctx.line)
+            return TupleType(self.anal_array(args), fallback, ctx.line)
         # Analyze arguments and (usually) construct Instance type. The
         # number of type arguments and their values are
         # checked only later, since we do not always know the
         # valid count at this point. Thus we may construct an
         # Instance with an invalid number of type arguments.
-        instance = Instance(info, self.anal_array(t.args), t.line, t.column)
+        instance = Instance(info, self.anal_array(args), ctx.line, ctx.column)
         # Check type argument count.
         if len(instance.args) != len(info.type_vars):
             fix_instance(instance, self.fail)
-        if not t.args and self.options.disallow_any_generics and not self.defining_alias:
+        if not args and self.options.disallow_any_generics and not self.defining_alias:
             # We report/patch invalid built-in instances already during second pass.
             # This is done to avoid storing additional state on instances.
             # All other (including user defined) generics will be patched/reported
             # in the third pass.
             if not self.is_typeshed_stub and info.fullname() in nongen_builtins:
                 alternative = nongen_builtins[info.fullname()]
-                self.fail(message_registry.IMPLICIT_GENERIC_ANY_BUILTIN.format(alternative), t)
-                any_type = AnyType(TypeOfAny.from_error, line=t.line)
+                self.fail(message_registry.IMPLICIT_GENERIC_ANY_BUILTIN.format(alternative), ctx)
+                any_type = AnyType(TypeOfAny.from_error, line=ctx.line)
             else:
-                any_type = AnyType(TypeOfAny.from_omitted_generics, line=t.line)
+                any_type = AnyType(TypeOfAny.from_omitted_generics, line=ctx.line)
             instance.args = [any_type] * len(info.type_vars)
 
         tup = info.tuple_type
         if tup is not None:
             # The class has a Tuple[...] base class so it will be
             # represented as a tuple type.
-            if t.args:
-                self.fail('Generic tuple types not supported', t)
+            if args:
+                self.fail('Generic tuple types not supported', ctx)
                 return AnyType(TypeOfAny.from_error)
             return tup.copy_modified(items=self.anal_array(tup.items),
                                      fallback=instance)
@@ -363,8 +366,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         if td is not None:
             # The class has a TypedDict[...] base class so it will be
             # represented as a typeddict type.
-            if t.args:
-                self.fail('Generic TypedDict types not supported', t)
+            if args:
+                self.fail('Generic TypedDict types not supported', ctx)
                 return AnyType(TypeOfAny.from_error)
             # Create a named TypedDictType
             return td.copy_modified(item_types=self.anal_array(list(td.items.values())),
@@ -551,6 +554,15 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
 
     def visit_forwardref_type(self, t: ForwardRef) -> Type:
         return t
+
+    def visit_placeholder_type(self, t: PlaceholderType) -> Type:
+        n = self.api.lookup_fully_qualified(t.fullname)
+        if isinstance(n.node, IncompleteType):
+            return t
+        else:
+            # TODO: Handle non-TypeInfo
+            assert isinstance(n.node, TypeInfo)
+            return self.analyze_type_with_type_info(n.node, t.args, t)
 
     def analyze_callable_type(self, t: UnboundType) -> Type:
         fallback = self.named_type('builtins.function')

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2673,15 +2673,17 @@ class PlaceholderTypeInfo(SymbolNode):
 
     These are only present during semantic analysis when using the new
     semantic analyzer. These are created if some dependencies of a type
-    definition are not yet complete. Their purpose is to allow
-    PlaceholderType instances to be created for types that refer to
-    incomplete types. Example where this is useful:
+    definition are not yet complete. They are used to create
+    PlaceholderType instances for types that refer to incomplete types.
+    Example where this can be used:
 
       class C(Sequence[C]): ...
 
     We create a PlaceholderTypeInfo for C so that the type C in
-    Sequence[C] can be bound. Without a placeholder, the class
-    definition couldn't be analyzed.
+    Sequence[C] can be bound. (The long-term purpose of placeholder
+    types is to evolve into something that can support general
+    recursive types. The base class use case could be supported
+    through other means as well.)
 
     PlaceholderTypeInfo can only refer to something that will become
     a TypeInfo. It can't be used with type variables, in particular,

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2668,7 +2668,26 @@ class TypeAlias(SymbolNode):
                    no_args=no_args, normalized=normalized)
 
 
-class IncompleteType(SymbolNode):
+class PlaceholderTypeInfo(SymbolNode):
+    """Temporary node that will later become a type but is incomplete.
+
+    These are only present during semantic analysis when using the new
+    semantic analyzer. These are created if some dependencies of a type
+    definition are not yet complete. Their purpose is to allow
+    PlaceholderType instances to be created for types that refer to
+    incomplete types. Example where this is useful:
+
+      class C(Sequence[C]): ...
+
+    We create a PlaceholderTypeInfo for C so that the type C in
+    Sequence[C] can be bound. Without a placeholder, the class
+    definition couldn't be analyzed.
+
+    PlaceholderTypeInfo can only refer to something that will become
+    a TypeInfo. It can't be used with type variables, in particular,
+    as this would cause issues with class type variable detection.
+    """
+
     def __init__(self, fullname: str) -> None:
         self._fullname = fullname
         self.line = -1
@@ -2680,10 +2699,10 @@ class IncompleteType(SymbolNode):
         return self._fullname
 
     def serialize(self) -> JsonDict:
-        assert False, "Incomplete type can't be serialized"
+        assert False, "PlaceholderTypeInfo can't be serialized"
 
     def accept(self, visitor: NodeVisitor[T]) -> T:
-        return visitor.visit_incomplete_type(self)
+        return visitor.visit_placeholder_type_info(self)
 
 
 class SymbolTableNode:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2668,6 +2668,24 @@ class TypeAlias(SymbolNode):
                    no_args=no_args, normalized=normalized)
 
 
+class IncompleteType(SymbolNode):
+    def __init__(self, fullname: str) -> None:
+        self._fullname = fullname
+        self.line = -1
+
+    def name(self) -> str:
+        return self._fullname.split('.')[-1]
+
+    def fullname(self) -> str:
+        return self._fullname
+
+    def serialize(self) -> JsonDict:
+        assert False, "Incomplete type can't be serialized"
+
+    def accept(self, visitor: NodeVisitor[T]) -> T:
+        return visitor.visit_incomplete_type(self)
+
+
 class SymbolTableNode:
     """Description of a name binding in a symbol table.
 

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -240,6 +240,9 @@ class TypeTranslator(TypeVisitor[Type]):
     def visit_forwardref_type(self, t: ForwardRef) -> Type:
         return t
 
+    def visit_placeholder_type(self, t: PlaceholderType) -> Type:
+        return PlaceholderType(t.fullname, self.translate_types(t.args), t.line)
+
 
 @trait
 class TypeQuery(SyntheticTypeVisitor[T]):
@@ -323,6 +326,9 @@ class TypeQuery(SyntheticTypeVisitor[T]):
 
     def visit_ellipsis_type(self, t: EllipsisType) -> T:
         return self.strategy([])
+
+    def visit_placeholder_type(self, t: PlaceholderType) -> T:
+        return self.query_types(t.args)
 
     def query_types(self, types: Iterable[Type]) -> T:
         """Perform a query for a list of types.

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -23,6 +23,7 @@ from mypy.types import (
     RawExpressionType, Instance, NoneTyp, TypeType,
     UnionType, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarDef,
     UnboundType, ErasedType, ForwardRef, StarType, EllipsisType, TypeList, CallableArgument,
+    PlaceholderType,
 )
 
 
@@ -103,6 +104,9 @@ class TypeVisitor(Generic[T]):
 
     def visit_forwardref_type(self, t: ForwardRef) -> T:
         raise RuntimeError('Internal error: unresolved forward reference')
+
+    def visit_placeholder_type(self, t: PlaceholderType) -> T:
+        raise RuntimeError('Internal error: unresolved placeholder type {}'.format(t.fullname))
 
 
 @trait

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1809,9 +1809,10 @@ class PlaceholderType(Type):
     any placeholders. After semantic analysis, no placeholder types must exist.
     """
 
-    def __init__(self, fullname: str) -> None:
-        super().__init__()
+    def __init__(self, fullname: str, args: List[Type], line: int) -> None:
+        super().__init__(line)
         self.fullname = fullname  # Only used for debugging
+        self.args = args
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_placeholder_type(self)
@@ -2005,6 +2006,9 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
             return '~{}'.format(t.resolved.accept(self))
         else:
             return '~{}'.format(t.unbound.accept(self))
+
+    def visit_placeholder_type(self, t: PlaceholderType) -> str:
+        return '<placeholder {}>'.format(t.fullname)
 
     def list_str(self, a: List[Type]) -> str:
         """Convert items of an array to strings (pretty-print types)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1798,15 +1798,17 @@ class ForwardRef(Type):
 class PlaceholderType(Type):
     """Temporary, yet-unknown type during semantic analysis.
 
-    This is needed when there's a reference to a type before the symbol table
-    entry of the target type is available. Consider this example:
+    This is needed when there's a reference to a type before the real symbol
+    table entry of the target type is available (specifically, it's a
+    PlaceholderTypeInfo). Consider this example:
 
       class str(Sequence[str]): ...
 
-    We use a PlaceholderType for the 'str' in 'Sequence[str]' since we can create
+    We use a PlaceholderType for the 'str' in 'Sequence[str]' since we can't create
     a TypeInfo for 'str' until all base classes have been resolved. We'll soon
-    perform another pass which replaces the base class with a complete type without
-    any placeholders. After semantic analysis, no placeholder types must exist.
+    perform another analysis iteration which replaces the base class with a complete
+    type without any placeholders. After semantic analysis, no placeholder types must
+    exist.
     """
 
     def __init__(self, fullname: str, args: List[Type], line: int) -> None:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1799,8 +1799,8 @@ class PlaceholderType(Type):
     """Temporary, yet-unknown type during semantic analysis.
 
     This is needed when there's a reference to a type before the real symbol
-    table entry of the target type is available (specifically, it's a
-    PlaceholderTypeInfo). Consider this example:
+    table entry of the target type is available (specifically, we use a
+    temporary PlaceholderTypeInfo symbol node). Consider this example:
 
       class str(Sequence[str]): ...
 

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -358,6 +358,9 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T]):
     def visit_type_alias(self, o: 'mypy.nodes.TypeAlias') -> T:
         pass
 
+    def visit_incomplete_type(self, o: 'mypy.nodes.IncompleteType') -> T:
+        pass
+
     # Statements
 
     def visit_block(self, o: 'mypy.nodes.Block') -> T:

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -358,7 +358,7 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T]):
     def visit_type_alias(self, o: 'mypy.nodes.TypeAlias') -> T:
         pass
 
-    def visit_incomplete_type(self, o: 'mypy.nodes.IncompleteType') -> T:
+    def visit_placeholder_type_info(self, o: 'mypy.nodes.PlaceholderTypeInfo') -> T:
         pass
 
     # Statements

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -614,3 +614,33 @@ def f(x: T) -> T:
 
 reveal_type(f(D())) # E: Revealed type is '__main__.D*'
 f(E()) # E: Value of type variable "T" of "f" cannot be "E"
+
+[case testNewAnalyzerNameExprRefersToIncompleteType]
+# flags: --new-semantic-analyzer
+import a
+
+[file a.py]
+from b import f
+
+class C(D): pass
+class D: pass
+
+[file b.py]
+from a import C
+reveal_type(C()) # E: Revealed type is 'a.C'
+def f(): pass
+
+[case testNewAnalyzerMemberExprRefersToIncompleteType]
+# flags: --new-semantic-analyzer
+import a
+
+[file a.py]
+from b import f
+
+class C(D): pass
+class D: pass
+
+[file b.py]
+import a
+reveal_type(a.C()) # E: Revealed type is 'a.C'
+def f(): pass

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -555,12 +555,10 @@ class D(C[XY]): pass
 class X: pass
 class Y: pass
 
-[case testNewAnalyzerSubModule]
+[case testNewAnalyzerSubModuleInCycle]
 # flags: --new-semantic-analyzer
 import a
 [file a.py]
-from aa import x
-[file aa.py]
 MYPY = False
 if MYPY:
     from b.c import x

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -554,3 +554,18 @@ class D(C[XY]): pass
 
 class X: pass
 class Y: pass
+
+[case testNewAnalyzerSubModule]
+# flags: --new-semantic-analyzer
+import a
+[file a.py]
+from aa import x
+[file aa.py]
+MYPY = False
+if MYPY:
+    from b.c import x
+[file b/__init__.pyi]
+import b.c
+[file b/c.pyi]
+x = 0
+import a

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -598,3 +598,19 @@ class C(A[C]):
 
 class D(A[D]):
     pass
+
+[case testNewAnalyzerTypeVarBoundForwardRef]
+# flags: --new-semantic-analyzer
+from typing import TypeVar
+
+T = TypeVar('T', bound='C')
+
+class C: pass
+class D(C): pass
+class E: pass
+
+def f(x: T) -> T:
+    return x
+
+reveal_type(f(D())) # E: Revealed type is '__main__.D*'
+f(E()) # E: Value of type variable "T" of "f" cannot be "E"

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -433,6 +433,18 @@ T = TypeVar('T')
 S = TypeVar('S')
 class D(Generic[T, S]): pass
 
+[case testNewAnalyzerTypeAlias2]
+# flags: --new-semantic-analyzer
+from typing import Union
+
+class C(D): pass
+
+A = Union[C, int]
+x: A
+reveal_type(x) # E: Revealed type is 'Union[__main__.C, builtins.int]'
+
+class D: pass
+
 [case testNewAnalyzerBuiltinTypeAliases]
 # flags: --new-semantic-analyzer
 from typing import List

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -567,3 +567,14 @@ import b.c
 [file b/c.pyi]
 x = 0
 import a
+
+[case testNewAnalyzerBaseClassSelfReference]
+# flags: --new-semantic-analyzer
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+
+class A(Generic[T]): pass
+
+class C(A[C]):
+    pass

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -408,6 +408,7 @@ class C(Generic[T]):
 T = TypeVar('T')
 
 c: C[int]
+reveal_type(c) # E: Revealed type is '__main__.C[builtins.int]'
 c = C('') # E: Argument 1 to "C" has incompatible type "str"; expected "int"
 reveal_type(c.get()) # E: Revealed type is 'builtins.int*'
 
@@ -576,5 +577,12 @@ T = TypeVar('T')
 
 class A(Generic[T]): pass
 
+a1: A[C] = C()
+a2: A[D] = C() \
+    # E: Incompatible types in assignment (expression has type "C", variable has type "A[D]")
+
 class C(A[C]):
+    pass
+
+class D(A[D]):
     pass


### PR DESCRIPTION
This adds the concept of placeholder type (and placeholder `TypeInfo`),
which are types that don't have a complete definition yet. They can be
useful in certain self-referential definition such as this:

```py
class C(Sequence[C]): ...
```

In the above example, we create a placeholder `TypeInfo` for `C`
before analyzing base classes. This allow `C` in `Sequence[C]` to
be bound. Each time there's a reference to a placeholder we defer
the current target so that a proper reference can be created on a
subsequent iteration. Placeholders should not leak semantic 
analysis and will generate an error during type checking.

They aren't that useful yet, but the goal is to eventually expand them
to support general recursive types.

This PR also includes a few additional small updates, including some
refactoring of how protocol types are detected (the refactoring isn't
directly related to the rest of the PR).
