### PR TITLE
Mark abstract and protocol classes as not-instantiatable explicitly

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1808,12 +1808,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 # Special case: only non-abstract non-protocol classes can be assigned to
                 # variables with explicit type Type[A], where A is protocol or abstract.
                 if (isinstance(rvalue_type, CallableType) and rvalue_type.is_type_obj() and
-                        (rvalue_type.type_object().is_abstract or
-                         rvalue_type.type_object().is_protocol) and
+                        rvalue_type.type_object().is_not_instantiatable and
                         isinstance(lvalue_type, TypeType) and
                         isinstance(lvalue_type.item, Instance) and
-                        (lvalue_type.item.type.is_abstract or
-                         lvalue_type.item.type.is_protocol)):
+                        lvalue_type.item.type.is_not_instantiatable):
                     self.msg.concrete_only_assign(lvalue_type, rvalue)
                     return
                 if rvalue_type and infer_lvalue_type and not isinstance(lvalue_type, PartialType):

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -82,6 +82,7 @@ DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'  # type: Fi
 DESCRIPTOR_SET_NOT_CALLABLE = "{}.__set__ is not callable"  # type: Final
 DESCRIPTOR_GET_NOT_CALLABLE = "{}.__get__ is not callable"  # type: Final
 MODULE_LEVEL_GETATTRIBUTE = '__getattribute__ is not valid at the module level'  # type: Final
+CANNOT_INSTANTIATE = 'Class "{}" is not allowed to be instantiated'  # type: Final
 
 # Generic
 GENERIC_INSTANCE_VAR_CLASS_ACCESS = \

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -845,6 +845,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             if self.analyze_namedtuple_classdef(defn):
                 return
 
+            defn.info.is_not_instantiatable = is_protocol
             defn.info.is_protocol = is_protocol
             self.analyze_metaclass(defn)
             defn.info.runtime_protocol = False
@@ -988,12 +989,14 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 if isinstance(func, Decorator):
                     fdef = func.func
                     if fdef.is_abstract and name not in concrete:
+                        typ.is_not_instantiatable = True
                         typ.is_abstract = True
                         abstract.append(name)
                         if base is typ:
                             abstract_in_this_class.append(name)
                 elif isinstance(node, Var):
                     if node.is_abstract_var and name not in concrete:
+                        typ.is_not_instantiatable = True
                         typ.is_abstract = True
                         abstract.append(name)
                         if base is typ:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2167,6 +2167,7 @@ class TypeInfo(SymbolNode):
     metaclass_type = None  # type: Optional[mypy.types.Instance]
 
     names = None  # type: SymbolTable      # Names defined directly in this type
+    is_not_instantiatable = False          # Is it allowed to instantiate the class?
     is_abstract = False                    # Does the class have any abstract attributes?
     is_protocol = False                    # Is this a protocol class?
     runtime_protocol = False               # Does this protocol support isinstance checks?
@@ -2261,6 +2262,7 @@ class TypeInfo(SymbolNode):
     FLAGS = [
         'is_abstract', 'is_enum', 'fallback_to_any', 'is_named_tuple',
         'is_newtype', 'is_protocol', 'runtime_protocol', 'is_final',
+        'is_not_instantiatable',
     ]  # type: Final[List[str]]
 
     def __init__(self, names: 'SymbolTable', defn: ClassDef, module_name: str) -> None:
@@ -2274,6 +2276,7 @@ class TypeInfo(SymbolNode):
         self.mro = []
         self._fullname = defn.fullname
         self.is_abstract = False
+        self.is_not_instantiatable = False
         self.abstract_attributes = []
         self.assuming = []
         self.assuming_proper = []

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -814,6 +814,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             return
         self.setup_class_def_analysis(defn)
         self.analyze_base_classes(defn)
+        defn.info.is_not_instantiatable = is_protocol
         defn.info.is_protocol = is_protocol
         self.analyze_metaclass(defn)
         defn.info.runtime_protocol = False
@@ -959,12 +960,14 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 if isinstance(func, Decorator):
                     fdef = func.func
                     if fdef.is_abstract and name not in concrete:
+                        typ.is_not_instantiatable = True
                         typ.is_abstract = True
                         abstract.append(name)
                         if base is typ:
                             abstract_in_this_class.append(name)
                 elif isinstance(node, Var):
                     if node.is_abstract_var and name not in concrete:
+                        typ.is_not_instantiatable = True
                         typ.is_abstract = True
                         abstract.append(name)
                         if base is typ:

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -536,3 +536,20 @@ func(1, 2, [3, 4], *[5, 6, 7], **{'a': 1})  # E: [[0, 0, 0, 2], [4]]
 [file mypy.ini]
 [[mypy]
 plugins=<ROOT>/test-data/unit/plugins/arg_kinds.py
+
+[case testNotInstantiatable]
+# flags: --config-file tmp/mypy.ini
+def static_only(cls):
+    return cls
+
+@static_only
+class CannotBeInstantiated:
+    ONE = 1
+
+ins = CannotBeInstantiated()
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/staticonly.py
+
+[out]
+main:9: error: Class "CannotBeInstantiated" is not allowed to be instantiated

--- a/test-data/unit/plugins/staticonly.py
+++ b/test-data/unit/plugins/staticonly.py
@@ -1,0 +1,15 @@
+from mypy.plugin import Plugin
+
+class MyPlugin(Plugin):
+    def get_class_decorator_hook(self, fullname):
+        if fullname == '__main__.static_only':
+            return static_only_hook
+        assert fullname is not None
+        return None
+
+def static_only_hook(ctx):
+    typeinfo = ctx.cls.info
+    typeinfo.is_not_instantiatable = True
+
+def plugin(version):
+    return MyPlugin


### PR DESCRIPTION
Only show error when not-instantiatable class is instantiated. This will allow plugins to allow instantiation of certain classes, even if they are abstract or specify a protocol. Or, conversely, disallow instantiation even if class is not abstract or protocol.

The particular problem that called for this solution: [mypy-zope](https://github.com/Shoobx/mypy-zope) plugin tries to implement zope interfaces as "protocols". Zope has the adaptation pattern that looks like instantiation of an interface:

```python
adapter = IMyInterface(context)
```

since `IMyInterface` is marked as "protocol", mypy unconditionally rejects such syntax with the message

```
error: Cannot instantiate protocol class "IMyInterface"
```

The proposed change would allow zope plugin to mark `IMyInterface` as both "protocol" and instantiatable" at the same time, effectively disabling the error message.