### PR TITLE
New semantic analyzer: support named tuples

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -867,15 +867,15 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 self.prepare_class_def(defn, info)
             return
 
-        is_named_tuple, info = self.named_tuple_analyzer.analyze_namedtuple_classdef(defn, defn.info)
+        is_named_tuple, info = self.named_tuple_analyzer.analyze_namedtuple_classdef(defn)
         if is_named_tuple:
             if info is None:
                 self.mark_incomplete(defn.name)
             else:
                 self.prepare_class_def(defn, info)
                 with self.scope.class_scope(defn.info):
-                    self.named_tuple_analyzer.process_namedtuple_body(defn, info,
-                                                                      self.analyze_class_body_common)
+                    with self.named_tuple_analyzer.save_namedtuple_body(info):
+                        self.analyze_class_body_common(defn)
             return
 
         # Create TypeInfo for class now that base classes and the MRO can be calculated.

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1264,7 +1264,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
         for base, base_expr in bases:
             if isinstance(base, TupleType):
-                if info.tuple_type:
+                if info.tuple_type and info.tuple_type != base:
                     self.fail("Class has two incompatible bases derived from tuple", defn)
                     defn.has_incompatible_baseclass = True
                 info.tuple_type = base
@@ -1853,7 +1853,12 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         self.check_and_set_up_type_alias(s)
         self.newtype_analyzer.process_newtype_declaration(s)
         self.process_typevar_declaration(s)
-        self.named_tuple_analyzer.process_namedtuple_definition(s, self.is_func_scope())
+        if isinstance(s.rvalue, CallExpr) and isinstance(s.rvalue.analyzed, NamedTupleExpr):
+            existing_info = s.rvalue.analyzed.info  # type: Optional[TypeInfo]
+        else:
+            existing_info = None
+        self.named_tuple_analyzer.process_namedtuple_definition(s, self.is_func_scope(),
+                                                                existing_info)
         self.typed_dict_analyzer.process_typeddict_definition(s, self.is_func_scope())
         self.enum_call_analyzer.process_enum_call(s, self.is_func_scope())
         self.store_final_status(s)

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3694,8 +3694,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         Args:
             name: The name that we weren't able to define (or '*' if the name is unknown)
             node: The node that refers to the name (definition or lvalue)
-            becomes_typeinfo: Pass this to Placeholder (used by special forms like named tuples
-            that will create TypeInfos).
+            becomes_typeinfo: Pass this to PlaceholderNode (used by special forms like
+                named tuples that will create TypeInfos).
         """
         self.defer()
         if name == '*':

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -123,7 +123,7 @@ def process_top_level_function(analyzer: 'NewSemanticAnalyzer',
     analyzer.incomplete_namespaces.add(module)
     while deferred and more_iterations:
         iteration += 1
-        if not incomplete or iteration == MAX_ITERATIONS:
+        if not (deferred or incomplete) or iteration == MAX_ITERATIONS:
             # OK, this is one last pass, now missing names will be reported.
             more_iterations = False
             analyzer.incomplete_namespaces.discard(module)

--- a/mypy/newsemanal/semanal_namedtuple.py
+++ b/mypy/newsemanal/semanal_namedtuple.py
@@ -121,7 +121,8 @@ class NamedTupleAnalyzer:
                     default_items[name] = stmt.rvalue
         return items, types, default_items
 
-    def process_namedtuple_definition(self, s: AssignmentStmt, is_func_scope: bool) -> None:
+    def process_namedtuple_definition(self, s: AssignmentStmt, is_func_scope: bool,
+                                      existing_info: Optional[TypeInfo]) -> None:
         """Check if s defines a namedtuple; if yes, store the definition in symbol table.
 
         Assume that s has already been successfully analyzed.
@@ -130,7 +131,10 @@ class NamedTupleAnalyzer:
             return
         lvalue = s.lvalues[0]
         name = lvalue.name
-        named_tuple = self.check_namedtuple(s.rvalue, name, is_func_scope)
+        if existing_info:
+            named_tuple = existing_info
+        else:
+            named_tuple = self.check_namedtuple(s.rvalue, name, is_func_scope)
         if named_tuple is None:
             return
         # Yes, it's a valid namedtuple definition. Add it to the symbol table.

--- a/mypy/newsemanal/semanal_namedtuple.py
+++ b/mypy/newsemanal/semanal_namedtuple.py
@@ -6,7 +6,7 @@ This is conceptually part of mypy.semanal (semantic analyzer pass 2).
 from typing import Tuple, List, Dict, Mapping, Optional, Union, cast, Callable
 
 from mypy.types import (
-    Type, TupleType, AnyType, TypeOfAny, UnboundType, CallableType, TypeType
+    Type, TupleType, AnyType, TypeOfAny, TypeVarDef, CallableType, TypeType, TypeVarType
 )
 from mypy.newsemanal.semanal_shared import (
     SemanticAnalyzerInterface, set_callable_name, PRIORITY_FALLBACKS
@@ -359,7 +359,9 @@ class NamedTupleAnalyzer:
         add_field(Var('__annotations__', ordereddictype), is_initialized_in_class=True)
         add_field(Var('__doc__', strtype), is_initialized_in_class=True)
 
-        selftype = UnboundType(SELF_TVAR_NAME)
+        tvd = TypeVarDef(SELF_TVAR_NAME, info.fullname() + '.' + SELF_TVAR_NAME,
+                         -1, [], info.tuple_type)
+        selftype = TypeVarType(tvd)
 
         def add_method(funcname: str,
                        ret: Type,
@@ -379,6 +381,7 @@ class NamedTupleAnalyzer:
             assert None not in types
             signature = CallableType(cast(List[Type], types), arg_kinds, items, ret,
                                      function_type)
+            signature.variables = [tvd]
             func = FuncDef(funcname, args, Block([]))
             func.info = info
             func.is_class = is_classmethod

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -744,17 +744,63 @@ class In(NamedTuple):
 class Other: pass
 
 [case testNewAnalyzerNamedTupleCallNested]
+from typing import NamedTuple
+
+o: C.Out
+i: C.In
+
+reveal_type(o)  # E: Revealed type is 'Tuple[Tuple[builtins.str, __main__.C.Other, fallback=__main__.C.In], __main__.C.Other, fallback=__main__.C.Out]'
+reveal_type(o.x)  # E: Revealed type is 'Tuple[builtins.str, __main__.C.Other, fallback=__main__.C.In]'
+reveal_type(o.y)  # E: Revealed type is '__main__.C.Other'
+reveal_type(o.x.t)  # E: Revealed type is '__main__.C.Other'
+reveal_type(i.t)  # E: Revealed type is '__main__.C.Other'
+
+class C:
+    Out = NamedTuple('Out', [('x', In), ('y', Other)])
+    In = NamedTuple('In', [('s', str), ('t', Other)])
+    class Other: pass
+
 
 [case testNewAnalyzerNamedTupleClassNested]
+from typing import NamedTuple
+
+o: C.Out
+i: C.In
+
+reveal_type(o)  # E: Revealed type is 'Tuple[Tuple[builtins.str, __main__.C.Other, fallback=__main__.C.In], __main__.C.Other, fallback=__main__.C.Out]'
+reveal_type(o.x)  # E: Revealed type is 'Tuple[builtins.str, __main__.C.Other, fallback=__main__.C.In]'
+reveal_type(o.y)  # E: Revealed type is '__main__.C.Other'
+reveal_type(o.x.t)  # E: Revealed type is '__main__.C.Other'
+reveal_type(i.t)  # E: Revealed type is '__main__.C.Other'
+
+class C:
+    class Out(NamedTuple):
+        x: C.In
+        y: C.Other
+    class In(NamedTuple):
+        s: str
+        t: C.Other
+    class Other: pass
 
 [case testNewAnalyzerNamedTupleCallNestedMethod]
+from typing import NamedTuple
 
-[case testNewAnalyzerNamedTupleClassNestedMethod]
+c = C()
+reveal_type(c.o)  # E: Revealed type is 'Tuple[Tuple[builtins.str, __main__.Other@12, fallback=__main__.C.In@11], __main__.Other@12, fallback=__main__.C.Out@10]'
+reveal_type(c.o.x)  # E: Revealed type is 'Tuple[builtins.str, __main__.Other@12, fallback=__main__.C.In@11]'
+
+class C:
+    def get_tuple(self) -> None:
+        self.o: Out
+        Out = NamedTuple('Out', [('x', In), ('y', Other)])
+        In = NamedTuple('In', [('s', str), ('t', Other)])
+        class Other: pass
 
 [case testNewAnalyzerNamedTupleClassForwardMethod]
 from typing import NamedTuple
 
 n: NT
+reveal_type(n.get_other())  # E: Revealed type is 'Tuple[builtins.str, fallback=__main__.Other]'
 reveal_type(n.get_other().s)  # E: Revealed type is 'builtins.str'
 
 class NT(NamedTuple):
@@ -764,3 +810,17 @@ class NT(NamedTuple):
 
 class Other(NamedTuple):
     s: str
+
+[case testNewAnalyzerNamedTupleSpecialMethods]
+from typing import NamedTuple
+
+o: SubO
+
+reveal_type(SubO._make)
+reveal_type(o._replace(y=Other()))  # E: Revealed type is 'Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.SubO]'
+
+class SubO(Out): pass
+
+Out = NamedTuple('Out', [('x', In), ('y', Other)])
+In = NamedTuple('In', [('s', str), ('t', Other)])
+class Other: pass

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -704,3 +704,63 @@ class D: pass
 import a
 reveal_type(a.C()) # E: Revealed type is 'a.C'
 def f(): pass
+
+[case testNewAnalyzerNamedTupleCall]
+from typing import NamedTuple
+
+o: Out
+i: In
+
+Out = NamedTuple('Out', [('x', In), ('y', Other)])
+
+reveal_type(o)  # E: Revealed type is 'Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.Out]'
+reveal_type(o.x)  # E: Revealed type is 'Tuple[builtins.str, __main__.Other, fallback=__main__.In]'
+reveal_type(o.y)  # E: Revealed type is '__main__.Other'
+reveal_type(o.x.t)  # E: Revealed type is '__main__.Other'
+reveal_type(i.t)  # E: Revealed type is '__main__.Other'
+
+In = NamedTuple('In', [('s', str), ('t', Other)])
+class Other: pass
+
+[case testNewAnalyzerNamedTupleClass]
+from typing import NamedTuple
+
+o: Out
+i: In
+
+class Out(NamedTuple):
+    x: In
+    y: Other
+
+reveal_type(o)  # E: Revealed type is 'Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.Out]'
+reveal_type(o.x)  # E: Revealed type is 'Tuple[builtins.str, __main__.Other, fallback=__main__.In]'
+reveal_type(o.y)  # E: Revealed type is '__main__.Other'
+reveal_type(o.x.t)  # E: Revealed type is '__main__.Other'
+reveal_type(i.t)  # E: Revealed type is '__main__.Other'
+
+class In(NamedTuple):
+    s: str
+    t: Other
+class Other: pass
+
+[case testNewAnalyzerNamedTupleCallNested]
+
+[case testNewAnalyzerNamedTupleClassNested]
+
+[case testNewAnalyzerNamedTupleCallNestedMethod]
+
+[case testNewAnalyzerNamedTupleClassNestedMethod]
+
+[case testNewAnalyzerNamedTupleClassForwardMethod]
+from typing import NamedTuple
+
+n: NT
+reveal_type(n.get_other().s)  # E: Revealed type is 'builtins.str'
+
+class NT(NamedTuple):
+    x: int
+    y: int
+    def get_other(self) -> Other: pass
+
+class Other(NamedTuple):
+    s: str

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -776,6 +776,26 @@ class C:
         In = NamedTuple('In', [('s', str), ('t', Other)])
         class Other: pass
 
+[case testNewAnalyzerNamedTupleClassNestedMethod]
+from typing import NamedTuple
+
+c = C()
+reveal_type(c.o)  # E: Revealed type is 'Tuple[Tuple[builtins.str, __main__.Other@18, fallback=__main__.C.In@15], __main__.Other@18, fallback=__main__.C.Out@11]'
+reveal_type(c.o.x)  # E: Revealed type is 'Tuple[builtins.str, __main__.Other@18, fallback=__main__.C.In@15]'
+reveal_type(c.o.method())  # E: Revealed type is 'Tuple[builtins.str, __main__.Other@18, fallback=__main__.C.In@15]'
+
+class C:
+    def get_tuple(self) -> None:
+        self.o: Out
+        class Out(NamedTuple):
+            x: In
+            y: Other
+            def method(self) -> In: ...
+        class In(NamedTuple):
+            s: str
+            t: Other
+        class Other: pass
+
 [case testNewAnalyzerNamedTupleClassForwardMethod]
 from typing import NamedTuple
 
@@ -803,6 +823,61 @@ class SubO(Out): pass
 
 Out = NamedTuple('Out', [('x', In), ('y', Other)])
 In = NamedTuple('In', [('s', str), ('t', Other)])
+class Other: pass
+
+[case testNewAnalyzerNamedTupleMixed1]
+from typing import NamedTuple
+
+o: Out
+i: In
+
+class Out(NamedTuple):
+    x: In
+    y: Other
+
+reveal_type(o)  # E: Revealed type is 'Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.Out]'
+reveal_type(o.x)  # E: Revealed type is 'Tuple[builtins.str, __main__.Other, fallback=__main__.In]'
+reveal_type(o.y)  # E: Revealed type is '__main__.Other'
+reveal_type(o.x.t)  # E: Revealed type is '__main__.Other'
+reveal_type(i.t)  # E: Revealed type is '__main__.Other'
+
+In = NamedTuple('In', [('s', str), ('t', Other)])
+class Other: pass
+
+[case testNewAnalyzerNamedTupleMixed2]
+from typing import NamedTuple
+
+o: Out
+i: In
+
+Out = NamedTuple('Out', [('x', In), ('y', Other)])
+
+reveal_type(o)  # E: Revealed type is 'Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.Out]'
+reveal_type(o.x)  # E: Revealed type is 'Tuple[builtins.str, __main__.Other, fallback=__main__.In]'
+reveal_type(o.y)  # E: Revealed type is '__main__.Other'
+reveal_type(o.x.t)  # E: Revealed type is '__main__.Other'
+reveal_type(i.t)  # E: Revealed type is '__main__.Other'
+
+class In(NamedTuple):
+    s: str
+    t: Other
+class Other: pass
+
+[case testNewAnalyzerNamedTupleBaseClass]
+from typing import NamedTuple
+
+o: Out
+reveal_type(o)  # E: Revealed type is 'Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.Out]'
+reveal_type(o.x)  # E: Revealed type is 'Tuple[builtins.str, __main__.Other, fallback=__main__.In]'
+reveal_type(o.x.t)  # E: Revealed type is '__main__.Other'
+reveal_type(Out._make)  # E: Revealed type is 'def (iterable: typing.Iterable[Any], *, new: Any =, len: Any =) -> Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.Out]'
+
+class Out(NamedTuple('Out', [('x', In), ('y', Other)])):
+    pass
+
+class In(NamedTuple):
+    s: str
+    t: Other
 class Other: pass
 
 [case testNewAnalyzerIncompleteRefShadowsBuiltin1]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -816,7 +816,7 @@ from typing import NamedTuple
 
 o: SubO
 
-reveal_type(SubO._make)
+reveal_type(SubO._make)  # E: Revealed type is 'def (iterable: typing.Iterable[Any], *, new: Any =, len: Any =) -> Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.SubO]'
 reveal_type(o._replace(y=Other()))  # E: Revealed type is 'Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.SubO]'
 
 class SubO(Out): pass

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -825,44 +825,6 @@ Out = NamedTuple('Out', [('x', In), ('y', Other)])
 In = NamedTuple('In', [('s', str), ('t', Other)])
 class Other: pass
 
-[case testNewAnalyzerNamedTupleMixed1]
-from typing import NamedTuple
-
-o: Out
-i: In
-
-class Out(NamedTuple):
-    x: In
-    y: Other
-
-reveal_type(o)  # E: Revealed type is 'Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.Out]'
-reveal_type(o.x)  # E: Revealed type is 'Tuple[builtins.str, __main__.Other, fallback=__main__.In]'
-reveal_type(o.y)  # E: Revealed type is '__main__.Other'
-reveal_type(o.x.t)  # E: Revealed type is '__main__.Other'
-reveal_type(i.t)  # E: Revealed type is '__main__.Other'
-
-In = NamedTuple('In', [('s', str), ('t', Other)])
-class Other: pass
-
-[case testNewAnalyzerNamedTupleMixed2]
-from typing import NamedTuple
-
-o: Out
-i: In
-
-Out = NamedTuple('Out', [('x', In), ('y', Other)])
-
-reveal_type(o)  # E: Revealed type is 'Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.Out]'
-reveal_type(o.x)  # E: Revealed type is 'Tuple[builtins.str, __main__.Other, fallback=__main__.In]'
-reveal_type(o.y)  # E: Revealed type is '__main__.Other'
-reveal_type(o.x.t)  # E: Revealed type is '__main__.Other'
-reveal_type(i.t)  # E: Revealed type is '__main__.Other'
-
-class In(NamedTuple):
-    s: str
-    t: Other
-class Other: pass
-
 [case testNewAnalyzerNamedTupleBaseClass]
 from typing import NamedTuple
 


### PR DESCRIPTION
Fixes #6284 
Fixes #6285 

This doesn't add support for recursive definitions, but all the forward reference patterns that are supported in old semantic analyzer, should be also supported.

Some notes:
* I moved one function to `semanal_namedtuple.py`
* I never create new `TypeInfo`s in multi-iteration scenario
* I add a dummy type variable `_NT` to the bodies (otherwise type variable scope breaks), but it is probably fine because names starting with underscores are anyway prohibited in named tuples.
