### PR TITLE
Don't delete fine-grained deps cache when a module has an error

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1315,13 +1315,16 @@ def delete_cache(id: str, path: str, manager: BuildManager) -> None:
     see #4043 for an example.
     """
     path = manager.normpath(path)
-    cache_paths = get_cache_names(id, path, manager)
+    # We don't delete .deps files on errors, since the dependencies
+    # are mostly generated from other files and the metadata is
+    # tracked separately.
+    meta_path, data_path, _ = get_cache_names(id, path, manager)
+    cache_paths = [meta_path, data_path]
     manager.log('Deleting {} {} {}'.format(id, path, " ".join(x for x in cache_paths if x)))
 
     for filename in cache_paths:
         try:
-            if filename:
-                manager.metastore.remove(filename)
+            manager.metastore.remove(filename)
         except OSError as e:
             if e.errno != errno.ENOENT:
                 manager.log("Error deleting cache file {}: {}".format(filename, e.strerror))

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3630,6 +3630,19 @@ def foo() -> None:
 [out2]
 tmp/main.py:2: error: "int" has no attribute "foo"
 
+[case testIncrementalFineGrainedCacheError1]
+# flags: --cache-fine-grained --no-sqlite-cache
+import a
+[file a.py]
+[file b.py]
+x = 0
+[file a.py.2]
+from b import x
+1 + 'lol'
+[out]
+[out2]
+tmp/a.py:2: error: Unsupported operand types for + ("int" and "str")
+
 [case testIncrementalBustedFineGrainedCache1]
 # flags: --cache-fine-grained --no-sqlite-cache
 import a


### PR DESCRIPTION
The dependencies are created by other modules, so it is wrong to throw
away the dependency information, since it won't be recreated when the
module is fixed and rechecked.

Previously the behavior was to *crash*, which is bad.