### PR TITLE
New semantic analyzer: generalize placeholders to all symbol nodes

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -31,7 +31,7 @@ from mypy.nodes import (
     ConditionalExpr, ComparisonExpr, TempNode, SetComprehension,
     DictionaryComprehension, ComplexExpr, EllipsisExpr, StarExpr, AwaitExpr, YieldExpr,
     YieldFromExpr, TypedDictExpr, PromoteExpr, NewTypeExpr, NamedTupleExpr, TypeVarExpr,
-    TypeAliasExpr, BackquoteExpr, EnumCallExpr, TypeAlias, SymbolNode, PlaceholderTypeInfo,
+    TypeAliasExpr, BackquoteExpr, EnumCallExpr, TypeAlias, SymbolNode, PlaceholderNode,
     ARG_POS, ARG_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2, LITERAL_TYPE, REVEAL_TYPE
 )
 from mypy.literals import literal
@@ -212,8 +212,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                                         alias_definition=e.is_alias_rvalue
                                                         or lvalue)
         else:
-            if isinstance(node, PlaceholderTypeInfo):
-                assert False, 'PlaceholderTypeInfo %r leaked to checker' % node.fullname()
+            if isinstance(node, PlaceholderNode):
+                assert False, 'PlaceholderNode %r leaked to checker' % node.fullname()
             # Unknown reference; use any type implicitly to avoid
             # generating extra type errors.
             result = AnyType(TypeOfAny.from_error)

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2258,11 +2258,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         kind = self.current_symbol_kind()
         names = self.current_symbol_table()
         existing = names.get(name)
-        if (existing
-                and isinstance(existing.node, PlaceholderNode)
-                and existing.node.node != lvalue):
-            # Placeholder associated with another node.
-            return
 
         outer = self.is_global_or_nonlocal(name)
         if (not existing or isinstance(existing.node, PlaceholderNode)) and not outer:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2323,8 +2323,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             v.is_initialized_in_class = True
         if kind != LDEF:
             v._fullname = self.qualified_name(lvalue.name)
-        if kind == GDEF:
-            v.is_ready = False  # Type not inferred yet
+        v.is_ready = False  # Type not inferred yet
         lvalue.node = v
         lvalue.is_new_def = True
         lvalue.is_inferred_def = True

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1180,6 +1180,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             return None
         unbound = t
         sym = self.lookup_qualified(unbound.name, unbound)
+        if sym and isinstance(sym.node, PlaceholderNode):
+            self.record_incomplete_ref()
         if sym is None or not isinstance(sym.node, TypeVarExpr):
             return None
         elif sym.fullname and not self.tvar_scope.allow_binding(sym.fullname):

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3543,6 +3543,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
     def lookup(self, name: str, ctx: Context,
                suppress_errors: bool = False) -> Optional[SymbolTableNode]:
+        """Look up an unqualified name in all active namespaces."""
         implicit_name = False
         # 1a. Name declared using 'global x' takes precedence
         if name in self.global_decls[-1]:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3761,7 +3761,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     # Found built-in class target. Create alias.
                     target = self.named_type_or_none(target_name, [])
                     assert target is not None
-                    alias_node = TypeAlias(target, alias, line=-1, column=-1,  # there is no context
+                    alias_node = TypeAlias(target, alias,
+                                           line=-1, column=-1,  # there is no context
                                            no_args=True, normalized=True)
                     self.add_symbol(name, alias_node, tree)
             elif self.found_incomplete_ref(tag):

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3544,13 +3544,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
     def lookup(self, name: str, ctx: Context,
                suppress_errors: bool = False) -> Optional[SymbolTableNode]:
-        """Look up an unqualified name in all active namespaces."""
-        node = self._lookup(name, ctx, suppress_errors)
-        if node and isinstance(node.node, PlaceholderNode):
-            self.record_incomplete_ref()
-        return node
-
-    def _lookup(self, name: str, ctx: Context, suppress_errors: bool) -> Optional[SymbolTableNode]:
         implicit_name = False
         # 1a. Name declared using 'global x' takes precedence
         if name in self.global_decls[-1]:
@@ -3666,8 +3659,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                         self.name_not_defined(name, ctx)
             if n and not n.module_hidden:
                 n = self.rebind_symbol_table_node(n)
-                if n and isinstance(n.node, PlaceholderNode):
-                    self.record_incomplete_ref()
                 return n
             return None
 

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3557,6 +3557,12 @@ class NewSemanticAnalyzer(NodeVisitor[None],
     def lookup(self, name: str, ctx: Context,
                suppress_errors: bool = False) -> Optional[SymbolTableNode]:
         """Look up an unqualified name in all active namespaces."""
+        node = self._lookup(name, ctx, suppress_errors)
+        if node and isinstance(node.node, PlaceholderNode):
+            self.record_incomplete_ref()
+        return node
+
+    def _lookup(self, name: str, ctx: Context, suppress_errors: bool) -> Optional[SymbolTableNode]:
         implicit_name = False
         # 1a. Name declared using 'global x' takes precedence
         if name in self.global_decls[-1]:
@@ -3672,6 +3678,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                         self.name_not_defined(name, ctx)
             if n and not n.module_hidden:
                 n = self.rebind_symbol_table_node(n)
+                if isinstance(n.node, PlaceholderNode):
+                    self.record_incomplete_ref()
                 return n
             return None
 

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -100,11 +100,13 @@ def process_functions(graph: 'Graph', scc: List[str]) -> None:
         targets = get_all_leaf_targets(symtable, module, None)
         for target, node, active_type in targets:
             assert isinstance(node, (FuncDef, OverloadedFuncDef, Decorator))
-            process_top_level_function(analyzer, graph[module], module, node, active_type)
+            process_top_level_function(analyzer, graph[module], module, target, node, active_type)
 
 
 def process_top_level_function(analyzer: 'NewSemanticAnalyzer',
-                               state: 'State', module: str,
+                               state: 'State',
+                               module: str,
+                               target: str,
                                node: Union[FuncDef, OverloadedFuncDef, Decorator],
                                active_type: Optional[TypeInfo]) -> None:
     """Analyze single top-level function or method.
@@ -125,8 +127,7 @@ def process_top_level_function(analyzer: 'NewSemanticAnalyzer',
             # OK, this is one last pass, now missing names will be reported.
             more_iterations = False
             analyzer.incomplete_namespaces.discard(module)
-        deferred, incomplete = semantic_analyze_target(module, state, node,
-                                                       active_type, False)
+        deferred, incomplete = semantic_analyze_target(target, state, node, active_type, False)
 
     # After semantic analysis is done, discard local namespaces
     # to avoid memory hoarding.

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2669,7 +2669,7 @@ class TypeAlias(SymbolNode):
 
 
 class PlaceholderNode(SymbolNode):
-    """Temporary node that will later become a real SymbolNode.
+    """Temporary symbol node that will later become a real SymbolNode.
 
     These are only present during semantic analysis when using the new
     semantic analyzer. These are created if some essential dependencies
@@ -2685,6 +2685,15 @@ class PlaceholderNode(SymbolNode):
 
       from m import int  # Placeholder avoids mixups with builtins.int
 
+    Another case where this is useful is when there is another definition
+    or assignment:
+
+      from m import f
+      def f() -> None: ...
+
+    In the above example, the presence of PlaceholderNode allows us to
+    handle the second definition as a redefinition.
+
     They are also used to create PlaceholderType instances for types
     that refer to incomplete types. Example:
 
@@ -2697,9 +2706,7 @@ class PlaceholderNode(SymbolNode):
 
       fullname: Full name of of the PlaceholderNode.
       node: AST node that contains the definition that caused this to
-          be created. This is needed to track when a placeholder should
-          be replaced with a real node, in case there are multiple
-          definitions/assignments for the same fullname.
+          be created. This is only useful for debugging.
       becomes_typeinfo: If True, this refers something that will later
           become a TypeInfo. It can't be used with type variables, in
           particular, as this would cause issues with class type variable

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2668,7 +2668,7 @@ class TypeAlias(SymbolNode):
                    no_args=no_args, normalized=normalized)
 
 
-class PlaceholderTypeInfo(SymbolNode):
+class PlaceholderNode(SymbolNode):
     """Temporary node that will later become a type but is incomplete.
 
     These are only present during semantic analysis when using the new
@@ -2690,8 +2690,9 @@ class PlaceholderTypeInfo(SymbolNode):
     as this would cause issues with class type variable detection.
     """
 
-    def __init__(self, fullname: str) -> None:
+    def __init__(self, fullname: str, becomes_typeinfo: bool = False) -> None:
         self._fullname = fullname
+        self.becomes_typeinfo = becomes_typeinfo
         self.line = -1
 
     def name(self) -> str:
@@ -2701,10 +2702,10 @@ class PlaceholderTypeInfo(SymbolNode):
         return self._fullname
 
     def serialize(self) -> JsonDict:
-        assert False, "PlaceholderTypeInfo can't be serialized"
+        assert False, "PlaceholderNode can't be serialized"
 
     def accept(self, visitor: NodeVisitor[T]) -> T:
-        return visitor.visit_placeholder_type_info(self)
+        return visitor.visit_placeholder_node(self)
 
 
 class SymbolTableNode:

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -358,7 +358,7 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T]):
     def visit_type_alias(self, o: 'mypy.nodes.TypeAlias') -> T:
         pass
 
-    def visit_placeholder_type_info(self, o: 'mypy.nodes.PlaceholderTypeInfo') -> T:
+    def visit_placeholder_node(self, o: 'mypy.nodes.PlaceholderNode') -> T:
         pass
 
     # Statements

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -339,7 +339,7 @@ def main() -> None:
             x  # E: Name 'x' is not defined
 
 [case testNewAnalyzerCyclicDefinitions]
-gx = gy  # E: Name 'gy' is not defined
+gx = gy  # E: Cannot determine type of 'gy'
 gy = gx
 def main() -> None:
     class C:

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -344,7 +344,7 @@ gy = gx
 def main() -> None:
     class C:
         def meth(self) -> None:
-            lx = ly  # E: Name 'ly' is not defined
+            lx = ly  # E: Cannot determine type of 'ly'
             ly = lx
 
 [case testNewAnalyzerMutuallyRecursiveOverloadedFunctions]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -684,3 +684,44 @@ class D: pass
 import a
 reveal_type(a.C()) # E: Revealed type is 'a.C'
 def f(): pass
+
+[case testNewAnalyzerIncompleteRefShadowsBuiltin1]
+import a
+
+[file a.py]
+from typing import TypeVar, Generic
+
+from b import C as int
+
+x: int[str]
+
+reveal_type(x) # E: Revealed type is 'a.C[builtins.str]'
+
+T = TypeVar('T')
+class C(Generic[T]): pass
+
+[file b.py]
+from a import C
+
+[case testNewAnalyzerIncompleteRefShadowsBuiltin2]
+import b
+
+[file a.py]
+import b
+
+int = b.C
+
+class C: pass
+
+x: int
+reveal_type(x) # E: Revealed type is 'b.C'
+
+[file b.py]
+import a
+
+int = a.C
+
+class C: pass
+
+x: int
+reveal_type(x) # E: Revealed type is 'a.C'

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -397,7 +397,6 @@ class Out:
                                     return str()
 
 [case testNewAnalyzerNestedClass1]
-# flags: --new-semantic-analyzer
 class A:
     class B:
         x: int
@@ -415,8 +414,6 @@ reveal_type(b.x) # E: Revealed type is 'builtins.int'
 reveal_type(b.f()) # E: Revealed type is 'builtins.str'
 
 [case testNewAnalyzerNestedClass2]
-# flags: --new-semantic-analyzer
-
 b: A.B
 b = A.B('') # E: Argument 1 to "B" has incompatible type "str"; expected "int"
 reveal_type(b) # E: Revealed type is '__main__.A.B'
@@ -434,7 +431,6 @@ class A:
             return self.x # E: Incompatible return value type (got "int", expected "str")
 
 [case testNewAnalyzerGenerics]
-# flags: --new-semantic-analyzer
 from typing import TypeVar, Generic
 
 c: C[int]
@@ -455,7 +451,6 @@ class C(Generic[T]):
         return self.x
 
 [case testNewAnalyzerGenericsTypeVarForwardRef]
-# flags: --new-semantic-analyzer
 from typing import TypeVar, Generic
 
 class C(Generic[T]):
@@ -473,7 +468,6 @@ c = C('') # E: Argument 1 to "C" has incompatible type "str"; expected "int"
 reveal_type(c.get()) # E: Revealed type is 'builtins.int*'
 
 [case testNewAnalyzerTypeAlias]
-# flags: --new-semantic-analyzer
 from typing import Union, TypeVar, Generic
 
 C2 = C
@@ -494,7 +488,6 @@ S = TypeVar('S')
 class D(Generic[T, S]): pass
 
 [case testNewAnalyzerTypeAlias2]
-# flags: --new-semantic-analyzer
 from typing import Union
 
 class C(D): pass
@@ -506,7 +499,6 @@ reveal_type(x) # E: Revealed type is 'Union[__main__.C, builtins.int]'
 class D: pass
 
 [case testNewAnalyzerBuiltinTypeAliases]
-# flags: --new-semantic-analyzer
 from typing import List
 
 x: List[C]
@@ -516,7 +508,6 @@ class C: pass
 [builtins fixtures/list.pyi]
 
 [case testNewAnalyzerVersionCheck]
-# flags: --new-semantic-analyzer
 import sys
 
 if sys.version_info[0] < 2:
@@ -535,7 +526,6 @@ def g() -> None:
 [builtins fixtures/ops.pyi]
 
 [case testNewAnalyzerVersionCheck2]
-# flags: --new-semantic-analyzer
 import sys
 
 assert sys.version_info[0] == 3
@@ -545,7 +535,6 @@ assert sys.version_info[0] < 3
 [builtins fixtures/ops.pyi]
 
 [case testNewAnalyzerOverload]
-# flags: --new-semantic-analyzer
 from typing import overload, Union
 
 @overload
@@ -563,7 +552,6 @@ f(1.0) # E: No overload variant of "f" matches argument type "float" \
        # N:     def f(x: str) -> str
 
 [case testNewAnalyzerOverload2]
-# flags: --new-semantic-analyzer
 from typing import overload, Union
 
 class A:
@@ -583,7 +571,6 @@ a.f(1.0) # E: No overload variant of "f" of "A" matches argument type "float" \
          # N:     def f(self, x: str) -> str
 
 [case testNewAnalyzerFunctionDecorator]
-# flags: --new-semantic-analyzer
 from typing import Callable
 
 @dec
@@ -601,7 +588,6 @@ reveal_type(f1('')) # E: Revealed type is 'builtins.str'
 f2(1) # E: Argument 1 to "f2" has incompatible type "int"; expected "str"
 
 [case testNewAnalyzerTypeApplicationForwardReference]
-# flags: --new-semantic-analyzer
 from typing import TypeVar, Generic
 
 T = TypeVar('T')
@@ -615,7 +601,6 @@ class X: pass
 class Y: pass
 
 [case testNewAnalyzerTypeApplicationForwardReference2]
-# flags: --new-semantic-analyzer
 from typing import TypeVar, Generic
 
 T = TypeVar('T')
@@ -629,7 +614,6 @@ class X: pass
 class Y: pass
 
 [case testNewAnalyzerSubModuleInCycle]
-# flags: --new-semantic-analyzer
 import a
 [file a.py]
 MYPY = False
@@ -642,7 +626,6 @@ x = 0
 import a
 
 [case testNewAnalyzerBaseClassSelfReference]
-# flags: --new-semantic-analyzer
 from typing import TypeVar, Generic
 
 T = TypeVar('T')
@@ -660,7 +643,6 @@ class D(A[D]):
     pass
 
 [case testNewAnalyzerTypeVarBoundForwardRef]
-# flags: --new-semantic-analyzer
 from typing import TypeVar
 
 T = TypeVar('T', bound='C')
@@ -676,7 +658,6 @@ reveal_type(f(D())) # E: Revealed type is '__main__.D*'
 f(E()) # E: Value of type variable "T" of "f" cannot be "E"
 
 [case testNewAnalyzerNameExprRefersToIncompleteType]
-# flags: --new-semantic-analyzer
 import a
 
 [file a.py]
@@ -691,7 +672,6 @@ reveal_type(C()) # E: Revealed type is 'a.C'
 def f(): pass
 
 [case testNewAnalyzerMemberExprRefersToIncompleteType]
-# flags: --new-semantic-analyzer
 import a
 
 [file a.py]


### PR DESCRIPTION
This generalizes the concept of placeholder nodes to also cover
assignment statements and imports. Previously they were only
created for class definitions. The main motivation is to prevent 
access to definitions in outer namespaces if there is an 
incomplete definition that should take precedence.

Fixes #6299.

This also does a few other updates:

* During the final iteration, some references to placeholder nodes
  generate an error instead of producing placeholder nodes. This
  allows the analysis to terminate in certain cases of import
  cycles at least.
* Major refactoring of `analyze_name_lvalue`. The motivation is
  that some early experiments made the old structure unwieldy,
  but the refactoring may not be as important for the final design.
  This seems like a code quality improvement so I'm including it 
  here.
* If a name lvalue was bound during an earlier iteration, we don't 
  rebind it. I'd like to gradually move to this approach more 
  generally.
* Some forward references to names aren't treated as undefined 
  any more. I think that these worked by accident. Now these 
  generally generate "cannot determine type" errors.
* Most definitions won't generate incomplete namespaces any
  more, since placeholders count as definitions in this context. 
  Star imports still generate incomplete namespaces.
* Remove redundant flags from some test cases.