### PR TITLE
New semantic analyzer: clean up index expression analysis

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3405,12 +3405,12 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             # We always allow unbound type variables in IndexExpr, since we
             # may be analysing a type alias definition rvalue. The error will be
             # reported elsewhere if it is not the case.
-            typearg2 = self.anal_type(typearg, allow_unbound_tvars=True,
+            analyzed = self.anal_type(typearg, allow_unbound_tvars=True,
                                       allow_placeholder=True)
-            if typearg2 is None:
+            if analyzed is None:
                 self.defer()
                 return None
-            types.append(typearg2)
+            types.append(analyzed)
         return types
 
     def lookup_type_node(self, expr: Expression) -> Optional[SymbolTableNode]:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3390,7 +3390,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         Return None if anything was incomplete.
         """
         index = expr.index
+        tag = self.track_incomplete_refs()
         self.analyze_type_expr(index)
+        if self.found_incomplete_ref(tag):
+            return None
         types = []  # type: List[Type]
         if isinstance(index, TupleExpr):
             items = index.items

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3350,57 +3350,68 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         if expr.analyzed:
             return
         base = expr.base
-        index = expr.index
         base.accept(self)
         if (isinstance(base, RefExpr)
                 and isinstance(base.node, TypeInfo)
                 and not base.node.is_generic()):
-            index.accept(self)
-        elif (isinstance(base, RefExpr) and isinstance(base.node, TypeAlias) or
-                refers_to_class_or_function(base)):
-            # Special form -- type application (either direct or via type aliasing).
-
-            self.analyze_type_expr(index)
-
-            # Translate index to an unanalyzed type.
-            types = []  # type: List[Type]
-            if isinstance(index, TupleExpr):
-                items = index.items
-            else:
-                items = [index]
-            for item in items:
-                try:
-                    typearg = expr_to_unanalyzed_type(item)
-                except TypeTranslationError:
-                    self.fail('Type expected within [...]', expr)
-                    return
-                # We always allow unbound type variables in IndexExpr, since we
-                # may be analysing a type alias definition rvalue. The error will be
-                # reported elsewhere if it is not the case.
-                typearg2 = self.anal_type(typearg, allow_unbound_tvars=True,
-                                          allow_placeholder=True)
-                if typearg2 is None:
-                    self.defer()
-                    return
-                types.append(typearg2)
-            expr.analyzed = TypeApplication(base, types)
-            expr.analyzed.line = expr.line
-            # Types list, dict, set are not subscriptable, prohibit this if
-            # subscripted either via type alias...
-            if isinstance(base, RefExpr) and isinstance(base.node, TypeAlias):
-                alias = base.node
-                if isinstance(alias.target, Instance):
-                    name = alias.target.type.fullname()
-                    if (alias.no_args and  # this avoids bogus errors for already reported aliases
-                            name in nongen_builtins and not alias.normalized):
-                        self.fail(no_subscript_builtin_alias(name, propose_alt=False), expr)
-            # ...or directly.
-            else:
-                n = self.lookup_type_node(base)
-                if n and n.fullname in nongen_builtins:
-                    self.fail(no_subscript_builtin_alias(n.fullname, propose_alt=False), expr)
+            expr.index.accept(self)
+        elif ((isinstance(base, RefExpr) and isinstance(base.node, TypeAlias))
+              or refers_to_class_or_function(base)):
+            self.analyze_type_application(expr)
         else:
-            index.accept(self)
+            expr.index.accept(self)
+
+    def analyze_type_application(self, expr: IndexExpr) -> None:
+        """Analyze special form -- type application (either direct or via type aliasing)."""
+        types = self.analyze_type_application_args(expr)
+        if types is None:
+            return
+        base = expr.base
+        expr.analyzed = TypeApplication(base, types)
+        expr.analyzed.line = expr.line
+        # Types list, dict, set are not subscriptable, prohibit this if
+        # subscripted either via type alias...
+        if isinstance(base, RefExpr) and isinstance(base.node, TypeAlias):
+            alias = base.node
+            if isinstance(alias.target, Instance):
+                name = alias.target.type.fullname()
+                if (alias.no_args and  # this avoids bogus errors for already reported aliases
+                        name in nongen_builtins and not alias.normalized):
+                    self.fail(no_subscript_builtin_alias(name, propose_alt=False), expr)
+        # ...or directly.
+        else:
+            n = self.lookup_type_node(base)
+            if n and n.fullname in nongen_builtins:
+                self.fail(no_subscript_builtin_alias(n.fullname, propose_alt=False), expr)
+
+    def analyze_type_application_args(self, expr: IndexExpr) -> Optional[List[Type]]:
+        """Analyze type arguments (index) in a type application.
+
+        Return None if anything was incomplete.
+        """
+        index = expr.index
+        self.analyze_type_expr(index)
+        types = []  # type: List[Type]
+        if isinstance(index, TupleExpr):
+            items = index.items
+        else:
+            items = [index]
+        for item in items:
+            try:
+                typearg = expr_to_unanalyzed_type(item)
+            except TypeTranslationError:
+                self.fail('Type expected within [...]', expr)
+                return None
+            # We always allow unbound type variables in IndexExpr, since we
+            # may be analysing a type alias definition rvalue. The error will be
+            # reported elsewhere if it is not the case.
+            typearg2 = self.anal_type(typearg, allow_unbound_tvars=True,
+                                      allow_placeholder=True)
+            if typearg2 is None:
+                self.defer()
+                return None
+            types.append(typearg2)
+        return types
 
     def lookup_type_node(self, expr: Expression) -> Optional[SymbolTableNode]:
         try:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3347,8 +3347,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         expr.expr.accept(self)
 
     def visit_index_expr(self, expr: IndexExpr) -> None:
-        if expr.analyzed:
-            return
         base = expr.base
         base.accept(self)
         if (isinstance(base, RefExpr)
@@ -3357,6 +3355,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             expr.index.accept(self)
         elif ((isinstance(base, RefExpr) and isinstance(base.node, TypeAlias))
               or refers_to_class_or_function(base)):
+            # We need to do full processing on every iteration, since some type
+            # arguments may contain placeholder types.
             self.analyze_type_application(expr)
         else:
             expr.index.accept(self)


### PR DESCRIPTION
Refactor analysis of index expressions and make two small changes:

1. Don't skip analysis if the `analyzed` attribute is defined (since there
   can be placeholder types that should be fixed).
2. Detect incomplete references when performing ordinary semantic
   analysis.

I couldn't find immediately find test cases that would benefit from the 
above changes, but I believe that it makes to make the changes just in case.

Fixes #6298.