### PR TITLE
Delete pyproject.toml to work around pip bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,0 @@
-[build-system]
-requires = [
-    "setuptools >= 30.0.2",
-    "wheel >= 0.29.0"
-]


### PR DESCRIPTION
We run afoul of https://github.com/pypa/pip/issues/6163, which
prevents directly pip installing mypy from a source directory with pip
19.0 (because our setup.py imports from mypy for version number
related reasons).

Once a bugfix for that is out we can probably restore it.