### PR TITLE
Bump typed-ast requirement to 1.3.1, as 1.3.0 has a rare crash bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ setup(name='mypy' if not USE_MYPYC else 'mypy-mypyc',
                                         ]},
       classifiers=classifiers,
       cmdclass=cmdclass,
-      install_requires = ['typed-ast >= 1.3.0, < 1.4.0',
+      install_requires = ['typed-ast >= 1.3.1, < 1.4.0',
                           'mypy_extensions >= 0.4.0, < 0.5.0',
                           ],
       extras_require = {


### PR DESCRIPTION
(The fix is part of https://github.com/python/typed_ast/commit/09a1d9c6fce86251db08eb4bb8fac6f815ace5e0 -- specifically the guards on `i` in front of various `TYPE(CHILD(n, i)) == ...` checks.)