### PR TITLE
New semantic analyzer: fix metaclasses

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -842,8 +842,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
         bases = defn.base_type_exprs
 
-        # TODO: Support metaclasses
-        # self.update_metaclass(defn)
+        self.update_metaclass(defn)
         bases, tvar_defs, is_protocol = self.clean_up_bases_and_infer_type_variables(bases,
                                                                                      context=defn)
         # TODO: Support keyword arguments
@@ -1491,6 +1490,9 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 # TODO: A better approach would be to record this information
                 #       and assume that the type object supports arbitrary
                 #       attributes, similar to an 'Any' base class.
+                return
+            if isinstance(sym.node, PlaceholderNode):
+                self.defer()
                 return
             if not isinstance(sym.node, TypeInfo) or sym.node.tuple_type is not None:
                 self.fail("Invalid metaclass '%s'" % metaclass_name, defn.metaclass)

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -725,3 +725,67 @@ class C: pass
 
 x: int
 reveal_type(x) # E: Revealed type is 'a.C'
+
+[case testNewAnalyzerMetaclass1]
+class A(metaclass=B):
+    pass
+
+class B(type):
+    def f(cls) -> int:
+        return 0
+
+reveal_type(A.f()) # E: Revealed type is 'builtins.int'
+
+[case testNewAnalyzerMetaclass2]
+reveal_type(A.f()) # E: Revealed type is 'builtins.int'
+
+class A(metaclass=B):
+    pass
+
+class AA(metaclass=C): # E: Metaclasses not inheriting from 'type' are not supported
+    pass
+
+class B(type):
+    def f(cls) -> int:
+        return 0
+
+class C: pass
+
+[case testNewAnalyzerMetaclassPlaceholder]
+class B(C): pass
+
+class A(metaclass=B):
+    pass
+
+class C(type):
+    def f(cls) -> int:
+        return 0
+
+reveal_type(A.f()) # E: Revealed type is 'builtins.int'
+
+[case testNewAnalyzerMetaclass1_python2]
+class A:
+    __metaclass__ = B
+
+reveal_type(A.f()) # E: Revealed type is 'builtins.int'
+
+class B(type):
+    def f(cls):
+        # type: () -> int
+        return 0
+
+[case testNewAnalyzerMetaclass2_python2]
+reveal_type(A.f()) # E: Revealed type is 'builtins.int'
+
+class A:
+    __metaclass__ = B
+
+class AA:
+    __metaclass__ = C  # E: Metaclasses not inheriting from 'type' are not supported
+
+class B(type):
+    def f(cls):
+        # type: () -> int
+        return 0
+
+class C: pass


### PR DESCRIPTION
Fixes #6293.

I only tested the most common kinds of metaclass definitions for now.
I'll create an issue for `six.with_metaclass` etc.