### PR TITLE
Update pinned mypyc version to 0.0.1+dev.231c69c6bbb3a4a9989c64974de5…

### DIFF
--- a/mypyc-requirements.txt
+++ b/mypyc-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/mypyc/mypyc.git@97ef5c213356bc5709b60b8312945a83c49d89c4#egg=mypyc==0.0.1+dev.97ef5c213356bc5709b60b8312945a83c49d89c4
+git+https://github.com/mypyc/mypyc.git@231c69c6bbb3a4a9989c64974de51e743566fb20#egg=mypyc==0.0.1+dev.231c69c6bbb3a4a9989c64974de51e743566fb20


### PR DESCRIPTION
…1e743566fb20

This fixes a crash bug caused by https://github.com/python/typeshed/pull/2782.

It also incorporates a change disabling whole program optimization on Windows
in multi-file mode (which we use for Windows), which should speed up Windows
builds substantially.

Needs to be cherry-picked into #6271.