### PR TITLE
Fix dmypy on windows when compiled with mypyc

### DIFF
--- a/mypy/bogus_type.py
+++ b/mypy/bogus_type.py
@@ -19,7 +19,8 @@ T = TypeVar('T')
 
 # This won't ever be true at runtime, but we consider it true during
 # mypyc compilations.
-if sys.platform == 'mypyc':
+MYPYC = False
+if MYPYC:
     Bogus = FlexibleAlias[T, Any]
 else:
     Bogus = FlexibleAlias[T, T]

--- a/mypy_bootstrap.ini
+++ b/mypy_bootstrap.ini
@@ -12,5 +12,4 @@ disallow_any_unimported = True
 warn_redundant_casts = True
 warn_unused_configs = True
 show_traceback = True
-# Set the platform to something nonsense to signal to make Bogus = Any.
-platform = mypyc
+always_true = MYPYC

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -12,3 +12,4 @@ disallow_any_unimported = True
 warn_redundant_casts = True
 warn_unused_configs = True
 show_traceback = True
+always_false = MYPYC


### PR DESCRIPTION
dmypy currently crashes on windows when compiled with mypyc
(since 0.660; it has *never* worked, I believe).

The root cause here is the abusive use of the platform variable,
which we set to 'mypyc', to tell bogus_type.py that mypyc is being used.
This (obviously) interferes with our platform checks, causing mypyc to
spuriously think code is unreachable, but because of the minutae of
how our platform checks were structured and which files are compiled,
this only breaks things for the windows daemon.

Switch to using always_true/always_false instead of abusing platform.

There is a downside to this fix, though (which is the reason I abused platform in the first place instead of using always_true/always_false): mypy will no longer typecheck *without* its config file, since it needs `always_false = MYPYC` to be set. If this is a major problem, I'll need to look for another solution.