### PR TITLE
Improvements to stubs generated from docstrings

### DIFF
--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -203,7 +203,15 @@ def infer_sig_from_docstring(docstr: str, name: str) -> Optional[List[FunctionSi
     with contextlib.suppress(tokenize.TokenError):
         for token in tokenize.tokenize(io.BytesIO(docstr.encode('utf-8')).readline):
             state.add_token(token)
-    return state.get_signatures()
+    ret = state.get_signatures()
+
+    def is_unique_args(sig: FunctionSig) -> bool:
+        """return true if function argument names are unique"""
+        return len(sig.args) == len(set((x.name for x in sig.args)))
+
+    # return only signatures, that have unique argument names. mypy fails on non-uqniue arg names
+    # TODO: emit a warning for duplicate argument names
+    return [x for x in ret if is_unique_args(x)]
 
 
 def infer_arg_sig_from_docstring(docstr: str) -> List[ArgSig]:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -167,14 +167,18 @@ def generate_c_function_stub(module: ModuleType,
         for signature in inferred:
             sig = []
             for arg in signature.args:
-                if arg.name == self_var or not arg.type:
-                    # no type
-                    sig.append(arg.name)
+                if arg.name == self_var:
+                    arg_def = self_var
                 else:
-                    # type info
-                    sig.append('{}: {}'.format(arg.name, strip_or_import(arg.type,
-                                                                         module,
-                                                                         imports)))
+                    arg_def = arg.name
+
+                    if arg.type:
+                        arg_def += ": " + strip_or_import(arg.type, module, imports)
+
+                    if arg.default:
+                        arg_def += " = ..."
+
+                sig.append(arg_def)
 
             if is_overloaded:
                 output.append('@overload')

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -222,6 +222,11 @@ class StubgenUtilSuite(Suite):
                      [FunctionSig(name='func', args=[ArgSig(name='x', type=None)],
                                   ret_type='Any')])
 
+    def test_infer_sig_from_docstring_duplicate_args(self) -> None:
+        assert_equal(infer_sig_from_docstring('\nfunc(x, x) -> str\nfunc(x, y) -> int', 'func'),
+                     [FunctionSig(name='func', args=[ArgSig(name='x'), ArgSig(name='y')],
+                                  ret_type='int')])
+
     def test_infer_arg_sig_from_docstring(self) -> None:
         assert_equal(infer_arg_sig_from_docstring("(*args, **kwargs)"),
                      [ArgSig(name='*args'), ArgSig(name='**kwargs')])

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -218,6 +218,10 @@ class StubgenUtilSuite(Suite):
 
         assert_equal(infer_sig_from_docstring('\nfunc[(x: foo.bar, invalid]', 'func'), [])
 
+        assert_equal(infer_sig_from_docstring('\nfunc(x: invalid::type<with_template>)', 'func'),
+                     [FunctionSig(name='func', args=[ArgSig(name='x', type=None)],
+                                  ret_type='Any')])
+
     def test_infer_arg_sig_from_docstring(self) -> None:
         assert_equal(infer_arg_sig_from_docstring("(*args, **kwargs)"),
                      [ArgSig(name='*args'), ArgSig(name='**kwargs')])

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -222,6 +222,10 @@ class StubgenUtilSuite(Suite):
                      [FunctionSig(name='func', args=[ArgSig(name='x', type=None)],
                                   ret_type='Any')])
 
+        assert_equal(infer_sig_from_docstring('\nfunc(x: str="")', 'func'),
+                     [FunctionSig(name='func', args=[ArgSig(name='x', type='str', default=True)],
+                                  ret_type='Any')])
+
     def test_infer_sig_from_docstring_duplicate_args(self) -> None:
         assert_equal(infer_sig_from_docstring('\nfunc(x, x) -> str\nfunc(x, y) -> int', 'func'),
                      [FunctionSig(name='func', args=[ArgSig(name='x'), ArgSig(name='y')],
@@ -387,6 +391,21 @@ class StubgencSuite(Suite):
         generate_c_function_stub(mod, 'test', TestClass.test, output, imports,
                                  self_var='self', class_name='TestClass')
         assert_equal(output, ['def test(self, arg0: int) -> Any: ...'])
+        assert_equal(imports, [])
+
+    def test_generate_c_type_with_docstring_empty_default(self) -> None:
+        class TestClass:
+            def test(self, arg0: str = "") -> None:
+                """
+                test(self: TestClass, arg0: str = "")
+                """
+                pass
+        output = []  # type: List[str]
+        imports = []  # type: List[str]
+        mod = ModuleType(TestClass.__module__, '')
+        generate_c_function_stub(mod, 'test', TestClass.test, output, imports,
+                                 self_var='self', class_name='TestClass')
+        assert_equal(output, ['def test(self, arg0: str = ...) -> Any: ...'])
         assert_equal(imports, [])
 
     def test_generate_c_function_other_module_arg(self) -> None:


### PR DESCRIPTION
Few improvements/bugfixes for stub generation from docstrings:
1. Do not generate stubs with improper type names. For now it's just regex check
2. Only generate stubs for methods that have unique argument names
3. Fix missing defaults in stubs generated from docstrings