### PR TITLE
Use capitalized boolean values in documentation

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -290,7 +290,7 @@ no analog available via the command line options.
 Miscellaneous strictness flags
 ------------------------------
 
-``allow_redefinition`` (bool, default false)
+``allow_redefinition`` (bool, default False)
     Allows variables to be redefined with an arbitrary type, as long as the redefinition
     is in the same block and nesting level as the original definition.
 


### PR DESCRIPTION
The rest of the documentation uses `True`/`False`.