### PR TITLE
Add a mechanism for avoiding hashing sources on daemon start

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -910,8 +910,8 @@ def read_quickstart_file(options: Options) -> Optional[Dict[str, Tuple[float, in
             quickstart = {}
             for file, (x, y, z) in raw_quickstart.items():
                 quickstart[file] = (x, y, z)
-        except Exception:
-            pass
+        except Exception as e:
+            print("Warning: Failed to load quickstart file: {}\n".format(str(e)))
     return quickstart
 
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -906,11 +906,12 @@ def read_quickstart_file(options: Options) -> Optional[Dict[str, Tuple[float, in
         try:
             with open(options.quickstart_file, "r") as f:
                 raw_quickstart = json.load(f)
+
+            quickstart = {}
+            for file, (x, y, z) in raw_quickstart.items():
+                quickstart[file] = (x, y, z)
         except Exception:
             pass
-        quickstart = {}
-        for file, (x, y, z) in raw_quickstart.items():
-            quickstart[file] = (x, y, z)
     return quickstart
 
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -472,6 +472,9 @@ class BuildManager(BuildManagerBase):
                        but is disabled if fine-grained cache loading fails
                        and after an initial fine-grained load. This doesn't
                        determine whether we write cache files or not.
+      quickstart_state:
+                       A cache of filename -> mtime/size/hash info used to avoid
+                       needing to hash source files when using a cache with mismatching mtimes
       stats:           Dict with various instrumentation numbers, it is used
                        not only for debugging, but also required for correctness,
                        in particular to check consistency of the fine-grained dependency cache.
@@ -549,6 +552,7 @@ class BuildManager(BuildManagerBase):
         self.plugin = plugin
         self.plugins_snapshot = plugins_snapshot
         self.old_plugins_snapshot = read_plugins_snapshot(self)
+        self.quickstart_state = read_quickstart_file(options)
 
     def dump_stats(self) -> None:
         self.log("Stats:")
@@ -893,6 +897,23 @@ def read_plugins_snapshot(manager: BuildManager) -> Optional[Dict[str, str]]:
     return snapshot
 
 
+def read_quickstart_file(options: Options) -> Optional[Dict[str, Tuple[float, int, str]]]:
+    quickstart = None  # type: Optional[Dict[str, Tuple[float, int, str]]]
+    if options.quickstart_file:
+        # This is very "best effort". If the file is missing or malformed,
+        # just ignore it.
+        raw_quickstart = {}  # type: Dict[str, Any]
+        try:
+            with open(options.quickstart_file, "r") as f:
+                raw_quickstart = json.load(f)
+        except Exception:
+            pass
+        quickstart = {}
+        for file, (x, y, z) in raw_quickstart.items():
+            quickstart[file] = (x, y, z)
+    return quickstart
+
+
 def read_deps_cache(manager: BuildManager,
                     graph: Graph) -> Optional[Dict[str, FgDepMeta]]:
     """Read and validate the fine-grained dependencies cache.
@@ -1106,6 +1127,7 @@ def validate_meta(meta: Optional[CacheMeta], id: str, path: Optional[str],
         manager.log('Metadata abandoned for {}: data cache is modified'.format(id))
         return None
 
+    orig_path = path
     path = manager.normpath(path)
     try:
         st = manager.get_stat(path)
@@ -1141,6 +1163,17 @@ def validate_meta(meta: Optional[CacheMeta], id: str, path: Optional[str],
     # Bazel ensures the cache is valid.
     mtime = 0 if bazel else int(st.st_mtime)
     if not bazel and (mtime != meta.mtime or path != meta.path):
+        if manager.quickstart_state and orig_path in manager.quickstart_state:
+            # If the mtime and the size of the file recorded in the quickstart dump matches
+            # what we see on disk, we know (assume) that the hash matches the quickstart
+            # data as well. If that hash matches the hash in the metadata, then we know
+            # the file is up to date even though the mtime is wrong, without needing to hash it.
+            qmtime, qsize, qhash = manager.quickstart_state[orig_path]
+            if int(qmtime) == mtime and qsize == size and qhash == meta.hash:
+                manager.log('Metadata fresh (by quickstart) for {}: file {}'.format(id, path))
+                meta = meta._replace(mtime=mtime, path=path)
+                return meta
+
         t0 = time.time()
         try:
             source_hash = manager.fscache.md5(path)
@@ -1166,7 +1199,7 @@ def validate_meta(meta: Optional[CacheMeta], id: str, path: Optional[str],
                 'mtime': mtime,
                 'size': size,
                 'hash': source_hash,
-                'data_mtime': data_mtime,
+                'data_mtime': meta.data_mtime,
                 'dependencies': meta.dependencies,
                 'suppressed': meta.suppressed,
                 'child_modules': meta.child_modules,

--- a/mypy/dmypy.py
+++ b/mypy/dmypy.py
@@ -59,6 +59,7 @@ p.add_argument('flags', metavar='FLAG', nargs='*', type=str,
 
 status_parser = p = subparsers.add_parser('status', help="Show daemon status")
 p.add_argument('-v', '--verbose', action='store_true', help="Print detailed status")
+p.add_argument('--fswatcher-dump-file', help="Collect information about the current file state")
 
 stop_parser = p = subparsers.add_parser('stop', help="Stop daemon (asks it politely to go away)")
 
@@ -268,7 +269,9 @@ def do_status(args: argparse.Namespace) -> None:
     # Both check_status() and request() may raise BadStatus,
     # which will be handled by main().
     check_status(status)
-    response = request(args.status_file, 'status', timeout=5)
+    response = request(args.status_file, 'status',
+                       fswatcher_dump_file=args.fswatcher_dump_file,
+                       timeout=5)
     if args.verbose or 'error' in response:
         show_stats(response)
     if 'error' in response:

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -262,10 +262,16 @@ class Server:
 
     # Command functions (run in the server via RPC).
 
-    def cmd_status(self) -> Dict[str, object]:
+    def cmd_status(self, fswatcher_dump_file: Optional[str] = None) -> Dict[str, object]:
         """Return daemon status."""
         res = {}  # type: Dict[str, object]
         res.update(get_meminfo())
+        if fswatcher_dump_file:
+            data = self.fswatcher.dump_file_data() if hasattr(self, 'fswatcher') else {}
+            # Using .dumps and then writing was noticably faster than using dump
+            s = json.dumps(data)
+            with open(fswatcher_dump_file, 'w') as f:
+                f.write(s)
         return res
 
     def cmd_stop(self) -> Dict[str, object]:

--- a/mypy/fswatcher.py
+++ b/mypy/fswatcher.py
@@ -1,7 +1,7 @@
 """Watch parts of the file system for changes."""
 
 from mypy.fscache import FileSystemCache
-from typing import AbstractSet, Dict, Iterable, List, NamedTuple, Optional, Set
+from typing import AbstractSet, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
 
 
 FileData = NamedTuple('FileData', [('st_mtime', float),
@@ -31,6 +31,9 @@ class FileSystemWatcher:
         self.fs = fs
         self._paths = set()  # type: Set[str]
         self._file_data = {}  # type: Dict[str, Optional[FileData]]
+
+    def dump_file_data(self) -> Dict[str, Tuple[float, int, str]]:
+        return {k: v for k, v in self._file_data.items() if v is not None}
 
     def set_file_data(self, path: str, data: FileData) -> None:
         self._file_data[path] = data

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -613,6 +613,8 @@ def process_options(args: List[str],
     other_group = parser.add_argument_group(
         title='Miscellaneous')
     other_group.add_argument(
+        '--quickstart-file', help=argparse.SUPPRESS)
+    other_group.add_argument(
         '--junit-xml', help="Write junit.xml to the given file")
     other_group.add_argument(
         '--scripts-are-modules', action='store_true',
@@ -871,6 +873,7 @@ config_types = {
     'custom_typing_module': str,
     'custom_typeshed_dir': str,
     'mypy_path': lambda s: [p.strip() for p in re.split('[,:]', s)],
+    'quickstart_file': str,
     'junit_xml': str,
     # These two are for backwards compatibility
     'silent_imports': bool,

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -169,6 +169,11 @@ class Options:
         # Config file name
         self.config_file = None  # type: Optional[str]
 
+        # A filename containing a JSON mapping from filenames to
+        # mtime/size/hash arrays, used to avoid having to recalculate
+        # source hashes as often.
+        self.quickstart_file = None  # type: Optional[str]
+
         # Write junit.xml to given file
         self.junit_xml = None  # type: Optional[str]
 

--- a/mypy/test/testdaemon.py
+++ b/mypy/test/testdaemon.py
@@ -72,6 +72,8 @@ def parse_script(input: List[str]) -> List[List[str]]:
 def run_cmd(input: str) -> Tuple[int, str]:
     if input.startswith('dmypy '):
         input = sys.executable + ' -m mypy.' + input
+    if input.startswith('mypy '):
+        input = sys.executable + ' -m' + input
     env = os.environ.copy()
     env['PYTHONPATH'] = PREFIX
     try:

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -140,7 +140,7 @@ $ dmypy stop
 Daemon stopped
 
 -- this is carefully constructed to be able to break if the quickstart system lets
--- something through incorrectly. in particular, the files need to ahve the same size
+-- something through incorrectly. in particular, the files need to have the same size
 [case testDaemonQuickstart]
 $ {python} -c "print('x=1')" >foo.py
 $ mypy --local-partial-types --cache-fine-grained --follow-imports=error -- foo.py

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -138,3 +138,22 @@ mypy-daemon: error: Missing target module, package, files, or command.
 == Return code: 2
 $ dmypy stop
 Daemon stopped
+
+-- this is carefully constructed to be able to break if the quickstart system lets
+-- something through incorrectly. in particular, the files need to ahve the same size
+[case testDaemonQuickstart]
+$ {python} -c "print('x=1')" >foo.py
+$ mypy --local-partial-types --cache-fine-grained --follow-imports=error -- foo.py
+$ dmypy run --log-file=/tmp/fuckyou -- foo.py --follow-imports=error --use-fine-grained-cache --verbose
+Daemon started
+$ dmypy status --fswatcher-dump-file test.json
+Daemon is up and running
+$ dmypy stop
+Daemon stopped
+-- sleep guarantees timestamp changes
+$ {python} -c "import time;time.sleep(1)"
+$ {python} -c "print('lol')" >foo.py
+$ dmypy run -- foo.py --follow-imports=error --use-fine-grained-cache --quickstart-file test.json
+Daemon started
+foo.py:1: error: Name 'lol' is not defined
+== Return code: 1

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -145,7 +145,7 @@ Daemon stopped
 $ {python} -c "print('x=1')" >foo.py
 $ {python} -c "print('x=1')" >bar.py
 $ mypy --local-partial-types --cache-fine-grained --follow-imports=error --no-sqlite-cache --python-version=3.6 -- foo.py bar.py
-$ {python} -c 'import shutil; shutil.copy(".mypy_cache/3.6/bar.meta.json", "asdf.json")'
+$ {python} -c "import shutil; shutil.copy('.mypy_cache/3.6/bar.meta.json', 'asdf.json')"
 -- update bar's timestamp but don't change the file
 $ {python} -c "import time;time.sleep(1)"
 $ {python} -c "print('x=1')" >bar.py
@@ -156,7 +156,7 @@ Daemon is up and running
 $ dmypy stop
 Daemon stopped
 -- copy the original bar cache file back so that the mtime mismatches
-$ {python} -c 'import shutil; shutil.copy("asdf.json", ".mypy_cache/3.6/bar.meta.json")'
+$ {python} -c "import shutil; shutil.copy('asdf.json', '.mypy_cache/3.6/bar.meta.json')"
 -- sleep guarantees timestamp changes
 $ {python} -c "import time;time.sleep(1)"
 $ {python} -c "print('lol')" >foo.py
@@ -165,7 +165,7 @@ Daemon started
 foo.py:1: error: Name 'lol' is not defined
 == Return code: 1
 -- make sure no errors made it to the log file
-$ {python} -c 'import sys; sys.stdout.write(open("log").read())'
+$ {python} -c "import sys; sys.stdout.write(open('log').read())"
 -- make sure the meta file didn't get updated. we use this as an imperfect proxy for
 -- whether the source file got rehashed, which we don't want it to have been.
-$ {python} -c 'x = open(".mypy_cache/3.6/bar.meta.json").read(); y = open("asdf.json").read(); assert x == y'
+$ {python} -c "x = open('.mypy_cache/3.6/bar.meta.json').read(); y = open('asdf.json').read(); assert x == y"

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -145,24 +145,27 @@ Daemon stopped
 $ {python} -c "print('x=1')" >foo.py
 $ {python} -c "print('x=1')" >bar.py
 $ mypy --local-partial-types --cache-fine-grained --follow-imports=error --no-sqlite-cache --python-version=3.6 -- foo.py bar.py
+$ {python} -c 'import shutil; shutil.copy(".mypy_cache/3.6/bar.meta.json", "asdf.json")'
+-- update bar's timestamp but don't change the file
+$ {python} -c "import time;time.sleep(1)"
+$ {python} -c "print('x=1')" >bar.py
 $ dmypy run -- foo.py bar.py --follow-imports=error --use-fine-grained-cache --no-sqlite-cache --python-version=3.6
 Daemon started
 $ dmypy status --fswatcher-dump-file test.json
 Daemon is up and running
 $ dmypy stop
 Daemon stopped
---$ {python} -c 'import os; print(list(os.walk(".")))'
-$ {python} -c 'import shutil; shutil.copy(".mypy_cache/3.6/bar.meta.json", "asdf.json")'
+-- copy the original bar cache file back so that the mtime mismatches
+$ {python} -c 'import shutil; shutil.copy("asdf.json", ".mypy_cache/3.6/bar.meta.json")'
 -- sleep guarantees timestamp changes
 $ {python} -c "import time;time.sleep(1)"
 $ {python} -c "print('lol')" >foo.py
--- update bar's timestamp but don't change the file
-$ {python} -c "print('x=1')" >bar.py
-$ dmypy run -- foo.py bar.py --follow-imports=error --use-fine-grained-cache --no-sqlite-cache --python-version=3.6
--- --quickstart-file test.json
+$ dmypy run --log-file=log -- foo.py bar.py --follow-imports=error --use-fine-grained-cache --no-sqlite-cache --python-version=3.6 --quickstart-file test.json
 Daemon started
 foo.py:1: error: Name 'lol' is not defined
 == Return code: 1
+-- make sure no errors made it to the log file
+$ {python} -c 'import sys; sys.stdout.write(open("log").read())'
 -- make sure the meta file didn't get updated. we use this as an imperfect proxy for
 -- whether the source file got rehashed, which we don't want it to have been.
 $ {python} -c 'x = open(".mypy_cache/3.6/bar.meta.json").read(); y = open("asdf.json").read(); assert x == y'

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -143,17 +143,26 @@ Daemon stopped
 -- something through incorrectly. in particular, the files need to have the same size
 [case testDaemonQuickstart]
 $ {python} -c "print('x=1')" >foo.py
-$ mypy --local-partial-types --cache-fine-grained --follow-imports=error -- foo.py
-$ dmypy run -- foo.py --follow-imports=error --use-fine-grained-cache
+$ {python} -c "print('x=1')" >bar.py
+$ mypy --local-partial-types --cache-fine-grained --follow-imports=error --no-sqlite-cache --python-version=3.6 -- foo.py bar.py
+$ dmypy run -- foo.py bar.py --follow-imports=error --use-fine-grained-cache --no-sqlite-cache --python-version=3.6
 Daemon started
 $ dmypy status --fswatcher-dump-file test.json
 Daemon is up and running
 $ dmypy stop
 Daemon stopped
+--$ {python} -c 'import os; print(list(os.walk(".")))'
+$ {python} -c 'import shutil; shutil.copy(".mypy_cache/3.6/bar.meta.json", "asdf.json")'
 -- sleep guarantees timestamp changes
 $ {python} -c "import time;time.sleep(1)"
 $ {python} -c "print('lol')" >foo.py
-$ dmypy run -- foo.py --follow-imports=error --use-fine-grained-cache --quickstart-file test.json
+-- update bar's timestamp but don't change the file
+$ {python} -c "print('x=1')" >bar.py
+$ dmypy run -- foo.py bar.py --follow-imports=error --use-fine-grained-cache --no-sqlite-cache --python-version=3.6
+-- --quickstart-file test.json
 Daemon started
 foo.py:1: error: Name 'lol' is not defined
 == Return code: 1
+-- make sure the meta file didn't get updated. we use this as an imperfect proxy for
+-- whether the source file got rehashed, which we don't want it to have been.
+$ {python} -c 'x = open(".mypy_cache/3.6/bar.meta.json").read(); y = open("asdf.json").read(); assert x == y'

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -144,7 +144,7 @@ Daemon stopped
 [case testDaemonQuickstart]
 $ {python} -c "print('x=1')" >foo.py
 $ mypy --local-partial-types --cache-fine-grained --follow-imports=error -- foo.py
-$ dmypy run --log-file=/tmp/fuckyou -- foo.py --follow-imports=error --use-fine-grained-cache --verbose
+$ dmypy run -- foo.py --follow-imports=error --use-fine-grained-cache
 Daemon started
 $ dmypy status --fswatcher-dump-file test.json
 Daemon is up and running


### PR DESCRIPTION
This has two parts:
 * Add an argument to dmypy status (`--fswatcher-dump-file JSONFILE`) that tells the daemon to
   write out the state of fswatcher to a file.
 * Allow mypy/dmypy to use this information to avoid hashing source
   files if the mtime in the cache disagrees with the disk but
   the old fswatcher info agrees. (`--quickstart-file JSONFILE`)