### PR TITLE
New semantic analyzer: fix corner cases in aliases to not ready classes (and other aliases)

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2224,7 +2224,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             s.rvalue.analyzed.column = res.column
         elif isinstance(s.rvalue, RefExpr):
             s.rvalue.is_alias_rvalue = True
-        node.node = TypeAlias(res, node.node.fullname(), s.line, s.column,
+        node.node = TypeAlias(res, self.qualified_name(lvalue.name), s.line, s.column,
                               alias_tvars=alias_tvars, no_args=no_args)
         if isinstance(rvalue, RefExpr) and isinstance(rvalue.node, TypeAlias):
             node.node.normalized = rvalue.node.normalized

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -213,6 +213,9 @@ class NewSemanticAnalyzer(NodeVisitor[None],
     # Stack of functions being analyzed
     function_stack = None  # type: List[FuncItem]
 
+    # Is this the final iteration of semantic analysis?
+    final_iteration = False
+
     loop_depth = 0         # Depth of breakable loops
     cur_mod_id = ''        # Current module id (or None) (phase 2)
     is_stub_file = False   # Are we analyzing a stub file?
@@ -2074,7 +2077,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             if analyzed is None:
                 return
             if isinstance(analyzed, UnboundType) and not self.final_iteration:
-                self.defer()
                 return
             s.type = analyzed
             if (self.type and self.type.is_protocol and isinstance(lvalue, NameExpr) and

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1887,6 +1887,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
     def can_be_an_alias(self, rv: Expression) -> bool:
         if isinstance(rv, IndexExpr) and isinstance(rv.base, RefExpr):
+            self.analyze_alias(rv)
             return self.can_be_an_alias(rv.base)
         if isinstance(rv, NameExpr):
             n = self.lookup(rv.name, rv)
@@ -2086,8 +2087,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             allow_tuple_literal = isinstance(lvalue, TupleExpr)
             analyzed = self.anal_type(s.type, allow_tuple_literal=allow_tuple_literal)
             if analyzed is None:
-                return
-            if isinstance(analyzed, UnboundType) and not self.final_iteration:
                 return
             s.type = analyzed
             if (self.type and self.type.is_protocol and isinstance(lvalue, NameExpr) and

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1894,9 +1894,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 return True
         elif isinstance(rv, MemberExpr):
             fname = get_member_expr_fullname(rv)
-            n = self.lookup_qualified(fname, rv)
-            if n and isinstance(n.node, PlaceholderNode) and n.node.becomes_typeinfo:
-                return True
+            if fname:
+                n = self.lookup_qualified(fname, rv)
+                if n and isinstance(n.node, PlaceholderNode) and n.node.becomes_typeinfo:
+                    return True
         return False
 
     def visit_assignment_stmt(self, s: AssignmentStmt) -> None:

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -135,7 +135,7 @@ def process_top_level_function(analyzer: 'NewSemanticAnalyzer',
             # OK, this is one last pass, now missing names will be reported.
             more_iterations = False
             analyzer.incomplete_namespaces.discard(module)
-        deferred, incomplete = semantic_analyze_target(target, state, node, active_type, True)
+        deferred, incomplete = semantic_analyze_target(target, state, node, active_type, not more_iterations)
 
     # After semantic analysis is done, discard local namespaces
     # to avoid memory hoarding.

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -137,6 +137,7 @@ def process_top_level_function(analyzer: 'NewSemanticAnalyzer',
             analyzer.incomplete_namespaces.discard(module)
         deferred, incomplete = semantic_analyze_target(target, state, node, active_type, not more_iterations)
 
+    analyzer.incomplete_namespaces.discard(module)
     # After semantic analysis is done, discard local namespaces
     # to avoid memory hoarding.
     analyzer.saved_locals.clear()

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -135,7 +135,8 @@ def process_top_level_function(analyzer: 'NewSemanticAnalyzer',
             # OK, this is one last pass, now missing names will be reported.
             more_iterations = False
             analyzer.incomplete_namespaces.discard(module)
-        deferred, incomplete = semantic_analyze_target(target, state, node, active_type, not more_iterations)
+        deferred, incomplete = semantic_analyze_target(target, state, node, active_type,
+                                                       not more_iterations)
 
     analyzer.incomplete_namespaces.discard(module)
     # After semantic analysis is done, discard local namespaces

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -135,7 +135,7 @@ def process_top_level_function(analyzer: 'NewSemanticAnalyzer',
             # OK, this is one last pass, now missing names will be reported.
             more_iterations = False
             analyzer.incomplete_namespaces.discard(module)
-        deferred, incomplete = semantic_analyze_target(target, state, node, active_type, False)
+        deferred, incomplete = semantic_analyze_target(target, state, node, active_type, True)
 
     # After semantic analysis is done, discard local namespaces
     # to avoid memory hoarding.

--- a/mypy/newsemanal/semanal_shared.py
+++ b/mypy/newsemanal/semanal_shared.py
@@ -73,6 +73,11 @@ class SemanticAnalyzerCoreInterface:
         """Is a module or class namespace potentially missing some definitions?"""
         raise NotImplementedError
 
+    @abstractproperty
+    def final_iteration(self) -> bool:
+        """Is this the final iteration of semantic analysis?"""
+        raise NotImplementedError
+
 
 @trait
 class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -423,6 +423,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         # None of the above options worked, we give up.
         if self.api.final_iteration:
             self.fail('Invalid type "{}"'.format(name), t)
+        else:
+            self.api.defer()
         if self.third_pass and isinstance(sym.node, TypeVarExpr):
             self.note_func("Forward references to type variables are prohibited", t)
             return AnyType(TypeOfAny.from_error)
@@ -693,7 +695,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             # We report an error in only the first two cases. In the third case, we assume
             # some other region of the code has already reported a more relevant error.
             #
-            # TODO: Once we start adding support for enums, make sure we reprt a custom
+            # TODO: Once we start adding support for enums, make sure we report a custom
             # error for case 2 as well.
             if arg.type_of_any != TypeOfAny.from_error:
                 self.fail('Parameter {} of Literal[...] cannot be of type "Any"'.format(idx), ctx)

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -65,6 +65,7 @@ def analyze_type_alias(node: Expression,
                        options: Options,
                        is_typeshed_stub: bool,
                        allow_unnormalized: bool = False,
+                       allow_placeholder: bool = False,
                        in_dynamic_func: bool = False,
                        global_scope: bool = True) -> Optional[Tuple[Type, Set[str]]]:
     """Analyze r.h.s. of a (potential) type alias definition.
@@ -121,7 +122,8 @@ def analyze_type_alias(node: Expression,
         api.fail('Invalid type alias', node)
         return None
     analyzer = TypeAnalyser(api, tvar_scope, plugin, options, is_typeshed_stub,
-                            allow_unnormalized=allow_unnormalized, defining_alias=True, allow_placeholder=True)
+                            allow_unnormalized=allow_unnormalized, defining_alias=True,
+                            allow_placeholder=allow_placeholder)
     analyzer.in_dynamic_func = in_dynamic_func
     analyzer.global_scope = global_scope
     res = type.accept(analyzer)

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -421,7 +421,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         if self.allow_unbound_tvars and unbound_tvar and not self.third_pass:
             return t
         # None of the above options worked, we give up.
-        self.fail('Invalid type "{}"'.format(name), t)
+        if self.api.final_iteration:
+            self.fail('Invalid type "{}"'.format(name), t)
         if self.third_pass and isinstance(sym.node, TypeVarExpr):
             self.note_func("Forward references to type variables are prohibited", t)
             return AnyType(TypeOfAny.from_error)

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -121,7 +121,7 @@ def analyze_type_alias(node: Expression,
         api.fail('Invalid type alias', node)
         return None
     analyzer = TypeAnalyser(api, tvar_scope, plugin, options, is_typeshed_stub,
-                            allow_unnormalized=allow_unnormalized, defining_alias=True)
+                            allow_unnormalized=allow_unnormalized, defining_alias=True, allow_placeholder=True)
     analyzer.in_dynamic_func = in_dynamic_func
     analyzer.global_scope = global_scope
     res = type.accept(analyzer)

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -409,7 +409,10 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         if self.allow_unbound_tvars and unbound_tvar and not self.third_pass:
             return t
         # None of the above options worked, we give up.
+        # NOTE: 'final_iteration' is iteration when we hit the maximum number of iterations limit.
         if self.api.final_iteration:
+            # TODO: This is problematic, since we will have to wait until the maximum number
+            #       of iterations to report an invalid type.
             self.fail('Invalid type "{}"'.format(name), t)
         else:
             self.api.defer()

--- a/mypy/test/hacks.py
+++ b/mypy/test/hacks.py
@@ -45,7 +45,6 @@ new_semanal_blacklist = [
     'check-serialize.test',
     'check-statements.test',
     'check-tuples.test',
-    'check-type-aliases.test',
     'check-typeddict.test',
     'check-typevar-values.test',
     'check-unions.test',

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -363,7 +363,8 @@ def parse_options(program_text: str, testcase: DataDrivenTestCase,
         options.verbosity = testcase.config.getoption('--mypy-verbose')
 
     if os.getenv('NEWSEMANAL'):
-        options.new_semantic_analyzer = True
+        if not flag_list or '--no-new-semantic-analyzer' not in flag_list:
+            options.new_semantic_analyzer = True
 
     return options
 

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1092,3 +1092,81 @@ class C(List[B]): pass
 
 reveal_type(x[0][0])  # E: Revealed type is '__main__.C*'
 [builtins fixtures/list.pyi]
+
+[case testNewAnalyzerAliasToNotReadyNestedClass]
+import a
+[file a.py]
+from b import Out
+
+x: A
+A = Out.B
+[file b.py]
+from typing import List
+from a import x
+
+class Out:
+    class B(List[B]): pass
+
+reveal_type(x[0][0])  # E: Revealed type is 'b.Out.B*'
+[builtins fixtures/list.pyi]
+
+[case testNewAnalyzerAliasToNotReadyNestedClass2]
+from typing import List
+
+x: Out.A
+
+class Out:
+    class A(List[B]): pass
+B = Out.A
+
+reveal_type(x[0][0])  # E: Revealed type is '__main__.Out.A*'
+[builtins fixtures/list.pyi]
+
+[case testNewAnalyzerAliasToNotReadyClassGeneric]
+import a
+[file a.py]
+from typing import Tuple
+from b import B, T
+
+x: A[int]
+A = B[Tuple[T, T]]
+[file b.py]
+from typing import List, Generic, TypeVar
+from a import x
+
+class B(List[B], Generic[T]): pass
+T = TypeVar('T')
+reveal_type(x)  # E: Revealed type is 'b.B[Tuple[builtins.int, builtins.int]]'
+[builtins fixtures/list.pyi]
+
+[case testNewAnalyzerAliasToNotReadyClassInGeneric]
+import a
+[file a.py]
+from typing import Tuple
+from b import B
+
+x: A
+A = Tuple[B, B]
+[file b.py]
+from typing import List
+from a import x
+
+class B(List[B]): pass
+
+reveal_type(x)  # E: Revealed type is 'Tuple[b.B, b.B]'
+[builtins fixtures/list.pyi]
+
+[case testNewAnalyzerAliasToNotReadyClassDoubleGeneric]
+from typing import List, TypeVar, Union
+
+T = TypeVar('T')
+
+x: B[int]
+B = A[List[T]]
+A = Union[int, T]
+class C(List[B[int]]): pass
+
+reveal_type(x)  # E: Revealed type is 'Union[builtins.int, builtins.list[builtins.int]]'
+reveal_type(y[0])  # E: Revealed type is 'Union[builtins.int, builtins.list[builtins.int]]'
+y: C
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -976,20 +976,6 @@ class Test:
     def __init__(self) -> None:
         some_module = self.a
 
-[case testNewAnalyzerAliasAfterStarImport]
-import a
-[file a.py]
-from typing import Tuple
-from b import *
-
-reveal_type(x)
-x: TP
-TP = Tuple[int, str]
-[file b.py]
-from a import x
-
-reveal_type(x[1])
-
 [case testNewAnalyzerAliasToNotReadyClass]
 import a
 [file a.py]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1003,9 +1003,7 @@ from a import x
 
 class B(List[B]): pass
 
-reveal_type(x)
-reveal_type(x[0])
-reveal_type(x[0][0])
+reveal_type(x[0][0])  # E: Revealed type is 'b.B*'
 [builtins fixtures/list.pyi]
 
 [case testNewAnalyzerAliasToNotReadyClass2]
@@ -1016,5 +1014,5 @@ x: A
 class A(List[B]): pass
 B = A
 
-reveal_type(x[0][0])
+reveal_type(x[0][0])  # E: Revealed type is '__main__.A*'
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1016,3 +1016,14 @@ B = A
 
 reveal_type(x[0][0])  # E: Revealed type is '__main__.A*'
 [builtins fixtures/list.pyi]
+
+[case testNewAnalyzerAliasToNotReadyClass3]
+from typing import List
+
+x: B
+B = A
+A = C
+class C(List[B]): pass
+
+reveal_type(x[0][0])  # E: Revealed type is '__main__.C*'
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -975,3 +975,46 @@ class Test:
     import a
     def __init__(self) -> None:
         some_module = self.a
+
+[case testNewAnalyzerAliasAfterStarImport]
+import a
+[file a.py]
+from typing import Tuple
+from b import *
+
+reveal_type(x)
+x: TP
+TP = Tuple[int, str]
+[file b.py]
+from a import x
+
+reveal_type(x[1])
+
+[case testNewAnalyzerAliasToNotReadyClass]
+import a
+[file a.py]
+from b import B
+
+x: A
+A = B
+[file b.py]
+from typing import List
+from a import x
+
+class B(List[B]): pass
+
+reveal_type(x)
+reveal_type(x[0])
+reveal_type(x[0][0])
+[builtins fixtures/list.pyi]
+
+[case testNewAnalyzerAliasToNotReadyClass2]
+from typing import List
+
+x: A
+
+class A(List[B]): pass
+B = A
+
+reveal_type(x[0][0])
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1170,3 +1170,21 @@ reveal_type(x)  # E: Revealed type is 'Union[builtins.int, builtins.list[builtin
 reveal_type(y[0])  # E: Revealed type is 'Union[builtins.int, builtins.list[builtins.int]]'
 y: C
 [builtins fixtures/list.pyi]
+
+[case testNewAnalyzerForwardAliasFromUnion]
+from typing import Union, List
+
+A = Union['B', 'C']
+
+class D:
+    x: List[A]
+
+    def test(self) -> None:
+        reveal_type(self.x[0].y)  # E: Revealed type is 'builtins.int'
+
+
+class B:
+    y: int
+class C:
+    y: int
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1182,11 +1182,45 @@ class D:
     def test(self) -> None:
         reveal_type(self.x[0].y)  # E: Revealed type is 'builtins.int'
 
-
 class B:
     y: int
 class C:
     y: int
+[builtins fixtures/list.pyi]
+
+[case testNewAnalyzerAliasToNotReadyTwoDeferrals-skip]
+from typing import List
+
+x: B
+B = List[C]
+A = C
+class C(List[A]): pass
+
+reveal_type(x)
+[builtins fixtures/list.pyi]
+
+[case testNewAnalyzerAliasToNotReadyDirectBase-skip]
+from typing import List
+
+x: B
+B = List[C]
+class C(B): pass
+
+reveal_type(x)  # E: Revealed type is 'builtins.list[__main__.C]'
+reveal_type(x[0][0])  # E: Revealed type is '__main__.C'
+[builtins fixtures/list.pyi]
+
+[case testNewAnalyzerAliasToNotReadyMixed]
+from typing import List, Union
+x: A
+
+A = Union[B, C]
+
+class B(List[A]): pass
+class C(List[A]): pass
+
+reveal_type(x)  # E: Revealed type is 'Union[__main__.B, __main__.C]'
+reveal_type(x[0])  # E: Revealed type is 'Union[__main__.B, __main__.C]'
 [builtins fixtures/list.pyi]
 
 [case testNewAnalyzerListComprehension]

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -178,26 +178,30 @@ Alias = Tuple[int, T]
 [out]
 
 [case testRecursiveAliasesErrors1]
+# flags: --no-new-semantic-analyzer
+# Recursive aliases are not supported yet.
 from typing import Type, Callable, Union
 
 A = Union[A, int]
 B = Callable[[B], int]
 C = Type[C]
 [out]
-main:3: error: Recursive types not fully supported yet, nested types replaced with "Any"
-main:4: error: Recursive types not fully supported yet, nested types replaced with "Any"
 main:5: error: Recursive types not fully supported yet, nested types replaced with "Any"
+main:6: error: Recursive types not fully supported yet, nested types replaced with "Any"
+main:7: error: Recursive types not fully supported yet, nested types replaced with "Any"
 
 [case testRecursiveAliasesErrors2]
+# flags: --no-new-semantic-analyzer
+# Recursive aliases are not supported yet.
 from typing import Type, Callable, Union
 
 A = Union[B, int]
 B = Callable[[C], int]
 C = Type[A]
 [out]
-main:3: error: Recursive types not fully supported yet, nested types replaced with "Any"
-main:4: error: Recursive types not fully supported yet, nested types replaced with "Any"
 main:5: error: Recursive types not fully supported yet, nested types replaced with "Any"
+main:6: error: Recursive types not fully supported yet, nested types replaced with "Any"
+main:7: error: Recursive types not fully supported yet, nested types replaced with "Any"
 
 [case testDoubleForwardAlias]
 from typing import List
@@ -219,6 +223,8 @@ reveal_type(x[0].x) # E: Revealed type is 'builtins.str'
 [out]
 
 [case testJSONAliasApproximation]
+# flags: --no-new-semantic-analyzer
+# Recursive aliases are not supported yet.
 from typing import List, Union, Dict
 x: JSON
 JSON = Union[int, str, List[JSON], Dict[str, JSON]] # type: ignore
@@ -228,35 +234,39 @@ if isinstance(x, list):
 [builtins fixtures/isinstancelist.pyi]
 [out]
 
-[case testProhibitedForwardRefToTypeVar]
+[case testForwardRefToTypeVar]
+# flags: --new-semantic-analyzer
 from typing import TypeVar, List
-
-a: List[T]
-
+reveal_type(a)  # E: Revealed type is 'builtins.list[builtins.int]'
+a: A[int]
+A = List[T]
 T = TypeVar('T')
 [builtins fixtures/list.pyi]
 [out]
-main:3: error: Invalid type "__main__.T"
-main:3: note: Forward references to type variables are prohibited
 
-[case testUnsupportedForwardRef]
+[case testFunctionForwardRefAlias]
+# flags: --new-semantic-analyzer
 from typing import List, TypeVar
 
 T = TypeVar('T')
 
-def f(x: T) -> None:
-    y: A[T]  # E: Unsupported forward reference to "A"
+def f(x: T) -> List[T]:
+    y: A[T]
+    reveal_type(y)  # E: Revealed type is 'builtins.list[T`-1]'
+    return [x] + y
 
 A = List[T]
 [builtins fixtures/list.pyi]
 [out]
 
-[case testUnsupportedForwardRef2]
+[case testFunctionForwardRefAlias2]
+# flags: --new-semantic-analyzer
 from typing import List, TypeVar
 
 def f() -> None:
     X = List[int]
-    x: A[X]  # E: Unsupported forward reference to "A"
+    x: A[X]
+    reveal_type(x)  # E: Revealed type is 'builtins.list[builtins.list[builtins.int]]'
 
 T = TypeVar('T')
 A = List[T]
@@ -468,6 +478,7 @@ class Parameter:
 
 [case testAliasInImportCycle3]
 # cmd: mypy -m t t2
+# flags: --new-semantic-analyzer
 [file t.py]
 MYPY = False
 if MYPY:
@@ -475,10 +486,8 @@ if MYPY:
 x: A
 reveal_type(x)  # E: Revealed type is 't2.D'
 
-# Unfortunately runtime part doesn't work yet, see docstring in SemanticAnalyzerPass3.update_imported_vars()
-reveal_type(A)  # E: Revealed type is 'Any' \
-                # E: Cannot determine type of 'A'
-A()  # E: Cannot determine type of 'A'
+reveal_type(A)  # E: Revealed type is 'def () -> t2.D'
+A()
 [file t2.py]
 import t
 class D: pass

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -588,6 +588,7 @@ def foo(x: Bogus[int]) -> None:
 [builtins fixtures/dict.pyi]
 
 [case testOverrideByIdemAliasCorrectType]
+# flags: --no-new-semantic-analyzer
 C = C
 class C:  # type: ignore
     pass
@@ -614,6 +615,7 @@ class C:
 [out]
 
 [case testConditionalExceptionAlias]
+# flags: --no-new-semantic-analyzer
 try:
     E = E
 except BaseException:


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/6355

This does three non-trivial things:
* Creates placeholder with `becomes_typeinfo=True` if r.h.s. is such a placeholder (i.e. the definition is a potential type alias).
* Defers all `Invalid type` and use of corresponding unbound types until final iteration.
* Moves few tests in newly enabled test file to new semantic analyzer only (those where new behaviour is clearly better).

I added a bunch of new tests for things that was broken, plus some variations (although some of them are trivial, replacing `NameExpr` with `MemberExpr` or `IndexExpr`).

I also verified that this PR fixes the crash in mypy self-check.