### PR TITLE
Add a flag to skip mtime checks on cache files

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -553,6 +553,9 @@ def process_options(args: List[str],
     incremental_group.add_argument(
         '--skip-version-check', action='store_true',
         help="Allow using cache written by older mypy version")
+    incremental_group.add_argument(
+        '--skip-cache-mtime-checks', action='store_true',
+        help="Skip cache internal consistency checks based on mtime")
 
     internals_group = parser.add_argument_group(
         title='Mypy internals',

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -178,6 +178,7 @@ class Options:
         self.sqlite_cache = False
         self.debug_cache = False
         self.skip_version_check = False
+        self.skip_cache_mtime_checks = False
         self.fine_grained_incremental = False
         # Include fine-grained dependencies in written cache files
         self.cache_fine_grained = False


### PR DESCRIPTION
When using an externally generated sqlite cache in daemon mode,
we should already trust that the cache is valid, and all the mtime
checks are surprisingly slow. (About 1s on S on my MBP.)

Allow skipping these.

An alternative I considered was to just always skip them when using
a sqlite cache, but I think we'd need to be more careful about
when we commit if we want to guarentee cache integrity.