### PR TITLE
New semantic analyzer: check generic type arguments

### DIFF
--- a/mypy/mixedtraverser.py
+++ b/mypy/mixedtraverser.py
@@ -1,0 +1,89 @@
+from typing import Optional
+
+from mypy.nodes import (
+    MypyFile, Var, FuncItem, ClassDef, AssignmentStmt, OperatorAssignmentStmt, ForStmt, WithStmt,
+    CastExpr, TypeApplication, TypeAliasExpr, TypeVarExpr, TypedDictExpr, NamedTupleExpr,
+    EnumCallExpr, PromoteExpr, NewTypeExpr
+)
+from mypy.types import Type
+from mypy.traverser import TraverserVisitor
+from mypy.typetraverser import TypeTraverserVisitor
+
+
+class MixedTraverserVisitor(TraverserVisitor, TypeTraverserVisitor):
+    """Recursive traversal of both Node and Type objects."""
+
+    # Symbol nodes
+
+    def visit_var(self, var: Var) -> None:
+        self.visit_optional_type(var.type)
+
+    def visit_func(self, o: FuncItem) -> None:
+        super().visit_func(o)
+        self.visit_optional_type(o.type)
+
+    def visit_class_def(self, o: ClassDef) -> None:
+        super().visit_class_def(o)
+        info = o.info
+        if info:
+            for base in info.bases:
+                base.accept(self)
+
+    def visit_type_alias_expr(self, o: TypeAliasExpr) -> None:
+        super().visit_type_alias_expr(o)
+        # TODO
+
+    def visit_type_var_expr(self, o: TypeVarExpr) -> None:
+        super().visit_type_var_expr(o)
+        # TODO
+
+    def visit_typeddict_expr(self, o: TypedDictExpr) -> None:
+        super().visit_typeddict_expr(o)
+        # TODO
+
+    def visit_namedtuple_expr(self, o: NamedTupleExpr) -> None:
+        super().visit_namedtuple_expr(o)
+        # TODO
+
+    def visit_enum_call_expr(self, o: EnumCallExpr) -> None:
+        super().visit_enum_call_expr(o)
+        # TODO
+
+    def visit__promote_expr(self, o: PromoteExpr) -> None:
+        super().visit__promote_expr(o)
+        # TODO
+
+    def visit_newtype_expr(self, o: NewTypeExpr) -> None:
+        super().visit_newtype_expr(o)
+        # TODO
+
+    # Statements
+
+    def visit_assignment_stmt(self, o: AssignmentStmt) -> None:
+        super().visit_assignment_stmt(o)
+        self.visit_optional_type(o.type)
+
+    def visit_for_stmt(self, o: ForStmt) -> None:
+        super().visit_for_stmt(o)
+        self.visit_optional_type(o.index_type)
+
+    def visit_with_stmt(self, o: WithStmt) -> None:
+        super().visit_with_stmt(o)
+        self.visit_optional_type(o.target_type)
+
+    # Expressions
+
+    def visit_cast_expr(self, o: CastExpr) -> None:
+        super().visit_cast_expr(o)
+        o.type.accept(self)
+
+    def visit_type_application(self, o: TypeApplication) -> None:
+        super().visit_type_application(o)
+        for t in o.types:
+            t.accept(self)
+
+    # Helpers
+
+    def visit_optional_type(self, t: Optional[Type]) -> None:
+        if t:
+            t.accept(self)

--- a/mypy/mixedtraverser.py
+++ b/mypy/mixedtraverser.py
@@ -28,34 +28,34 @@ class MixedTraverserVisitor(TraverserVisitor, TypeTraverserVisitor):
         if info:
             for base in info.bases:
                 base.accept(self)
+            self.visit_optional_type(info.typeddict_type)
 
     def visit_type_alias_expr(self, o: TypeAliasExpr) -> None:
         super().visit_type_alias_expr(o)
-        # TODO
+        o.type.accept(self)
 
     def visit_type_var_expr(self, o: TypeVarExpr) -> None:
         super().visit_type_var_expr(o)
-        # TODO
+        o.upper_bound.accept(self)
+        for value in o.values:
+            value.accept(self)
 
     def visit_typeddict_expr(self, o: TypedDictExpr) -> None:
         super().visit_typeddict_expr(o)
-        # TODO
+        self.visit_optional_type(o.info.typeddict_type)
 
     def visit_namedtuple_expr(self, o: NamedTupleExpr) -> None:
         super().visit_namedtuple_expr(o)
-        # TODO
-
-    def visit_enum_call_expr(self, o: EnumCallExpr) -> None:
-        super().visit_enum_call_expr(o)
-        # TODO
+        assert o.info.tuple_type
+        o.info.tuple_type.accept(self)
 
     def visit__promote_expr(self, o: PromoteExpr) -> None:
         super().visit__promote_expr(o)
-        # TODO
+        o.type.accept(self)
 
     def visit_newtype_expr(self, o: NewTypeExpr) -> None:
         super().visit_newtype_expr(o)
-        # TODO
+        o.old_type.accept(self)
 
     # Statements
 

--- a/mypy/mixedtraverser.py
+++ b/mypy/mixedtraverser.py
@@ -55,7 +55,7 @@ class MixedTraverserVisitor(TraverserVisitor, TypeTraverserVisitor):
 
     def visit_newtype_expr(self, o: NewTypeExpr) -> None:
         super().visit_newtype_expr(o)
-        o.old_type.accept(self)
+        self.visit_optional_type(o.old_type)
 
     # Statements
 

--- a/mypy/mixedtraverser.py
+++ b/mypy/mixedtraverser.py
@@ -28,7 +28,6 @@ class MixedTraverserVisitor(TraverserVisitor, TypeTraverserVisitor):
         if info:
             for base in info.bases:
                 base.accept(self)
-            self.visit_optional_type(info.typeddict_type)
 
     def visit_type_alias_expr(self, o: TypeAliasExpr) -> None:
         super().visit_type_alias_expr(o)

--- a/mypy/mixedtraverser.py
+++ b/mypy/mixedtraverser.py
@@ -23,6 +23,8 @@ class MixedTraverserVisitor(TraverserVisitor, TypeTraverserVisitor):
         self.visit_optional_type(o.type)
 
     def visit_class_def(self, o: ClassDef) -> None:
+        # TODO: Should we visit generated methods/variables as well, either here or in
+        #       TraverserVisitor?
         super().visit_class_def(o)
         info = o.info
         if info:

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -30,6 +30,7 @@ from mypy.nodes import (
     Node, SymbolTable, SymbolNode, MypyFile, TypeInfo, FuncDef, Decorator, OverloadedFuncDef
 )
 from mypy.newsemanal.semanal_typeargs import TypeArgumentAnalyzer
+from mypy.state import strict_optional_set
 
 MYPY = False
 if MYPY:
@@ -197,4 +198,5 @@ def check_type_arguments(graph: 'Graph', scc: List[str]) -> None:
         assert state.tree
         analyzer = TypeArgumentAnalyzer(errors)
         with state.wrap_context():
-            state.tree.accept(analyzer)
+            with strict_optional_set(state.options.strict_optional):
+                state.tree.accept(analyzer)

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -29,6 +29,7 @@ from typing import List, Tuple, Optional, Union
 from mypy.nodes import (
     Node, SymbolTable, SymbolNode, MypyFile, TypeInfo, FuncDef, Decorator, OverloadedFuncDef
 )
+from mypy.newsemanal.semanal_typeargs import TypeArgumentAnalyzer
 
 MYPY = False
 if MYPY:
@@ -54,6 +55,7 @@ def semantic_analysis_for_scc(graph: 'Graph', scc: List[str]) -> None:
     # before functions. This limitation is unlikely to go away soon.
     process_top_levels(graph, scc)
     process_functions(graph, scc)
+    check_type_arguments(graph, scc)
 
 
 def process_top_levels(graph: 'Graph', scc: List[str]) -> None:
@@ -186,3 +188,13 @@ def semantic_analyze_target(target: str,
         return [target], analyzer.incomplete
     else:
         return [], analyzer.incomplete
+
+
+def check_type_arguments(graph: 'Graph', scc: List[str]) -> None:
+    for module in scc:
+        state = graph[module]
+        errors = state.manager.errors
+        assert state.tree
+        analyzer = TypeArgumentAnalyzer(errors)
+        with state.wrap_context():
+            state.tree.accept(analyzer)

--- a/mypy/newsemanal/semanal_typeargs.py
+++ b/mypy/newsemanal/semanal_typeargs.py
@@ -41,6 +41,8 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
             super().visit_block(o)
 
     def visit_instance(self, t: Instance) -> None:
+        # Type argument counts were checked in the main semantic analyzer pass. We assume
+        # that the counts are correct here.
         info = t.type
         for (i, arg), tvar in zip(enumerate(t.args), info.defn.type_vars):
             if tvar.values:

--- a/mypy/newsemanal/semanal_typeargs.py
+++ b/mypy/newsemanal/semanal_typeargs.py
@@ -7,7 +7,7 @@ operations, including subtype checks.
 
 from typing import List
 
-from mypy.nodes import TypeInfo, Context, MypyFile, FuncItem, ClassDef, Block
+from mypy.nodes import TypeInfo, Context, MypyFile, FuncItem, ClassDef, Block, OverloadedFuncDef
 from mypy.types import Type, Instance, TypeVarType, AnyType
 from mypy.mixedtraverser import MixedTraverserVisitor
 from mypy.subtypes import is_subtype

--- a/mypy/newsemanal/semanal_typeargs.py
+++ b/mypy/newsemanal/semanal_typeargs.py
@@ -1,0 +1,79 @@
+"""Verify that type arguments like 'int' C[int] are valid.
+
+This must happen after semantic analysis since there can be placeholder
+types until the end of semantic analysis, and these break various type
+operations, including subtype checks.
+"""
+
+from typing import List
+
+from mypy.nodes import TypeInfo, Context, MypyFile, FuncItem, ClassDef, Block
+from mypy.types import Type, Instance, TypeVarType, AnyType
+from mypy.mixedtraverser import MixedTraverserVisitor
+from mypy.subtypes import is_subtype
+from mypy.sametypes import is_same_type
+from mypy.errors import Errors
+from mypy.scope import Scope
+from mypy import message_registry
+
+
+class TypeArgumentAnalyzer(MixedTraverserVisitor):
+    def __init__(self, errors: Errors) -> None:
+        self.errors = errors
+        self.scope = Scope()
+
+    def visit_mypy_file(self, o: MypyFile) -> None:
+        self.errors.set_file(o.path, o.fullname(), scope=self.scope)
+        self.scope.enter_file(o.fullname())
+        super().visit_mypy_file(o)
+        self.scope.leave()
+
+    def visit_func(self, defn: FuncItem) -> None:
+        with self.scope.function_scope(defn):
+            super().visit_func(defn)
+
+    def visit_class_def(self, defn: ClassDef) -> None:
+        with self.scope.class_scope(defn.info):
+            super().visit_class_def(defn)
+
+    def visit_block(self, o: Block) -> None:
+        if not o.is_unreachable:
+            super().visit_block(o)
+
+    def visit_instance(self, t: Instance) -> None:
+        info = t.type
+        for (i, arg), tvar in zip(enumerate(t.args), info.defn.type_vars):
+            if tvar.values:
+                if isinstance(arg, TypeVarType):
+                    arg_values = arg.values
+                    if not arg_values:
+                        self.fail('Type variable "{}" not valid as type '
+                                  'argument value for "{}"'.format(
+                                      arg.name, info.name()), t)
+                        continue
+                else:
+                    arg_values = [arg]
+                self.check_type_var_values(info, arg_values, tvar.name, tvar.values, i + 1, t)
+            if not is_subtype(arg, tvar.upper_bound):
+                self.fail('Type argument "{}" of "{}" must be '
+                          'a subtype of "{}"'.format(
+                              arg, info.name(), tvar.upper_bound), t)
+        super().visit_instance(t)
+
+    def check_type_var_values(self, type: TypeInfo, actuals: List[Type], arg_name: str,
+                              valids: List[Type], arg_number: int, context: Context) -> None:
+        for actual in actuals:
+            if (not isinstance(actual, AnyType) and
+                    not any(is_same_type(actual, value)
+                            for value in valids)):
+                if len(actuals) > 1 or not isinstance(actual, Instance):
+                    self.fail('Invalid type argument value for "{}"'.format(
+                        type.name()), context)
+                else:
+                    class_name = '"{}"'.format(type.name())
+                    actual_type_name = '"{}"'.format(actual.type.name())
+                    self.fail(message_registry.INCOMPATIBLE_TYPEVAR_VALUE.format(
+                        arg_name, class_name, actual_type_name), context)
+
+    def fail(self, msg: str, context: Context) -> None:
+        self.errors.report(context.get_line(), context.get_column(), msg)

--- a/mypy/typetraverser.py
+++ b/mypy/typetraverser.py
@@ -1,0 +1,103 @@
+from typing import Iterable
+
+from mypy_extensions import trait
+
+from mypy.types import (
+    Type, SyntheticTypeVisitor, AnyType, UninhabitedType, NoneTyp, ErasedType, DeletedType,
+    TypeVarType, LiteralType, Instance, CallableType, TupleType, TypedDictType, UnionType,
+    Overloaded, TypeType, CallableArgument, UnboundType, TypeList, StarType, EllipsisType,
+    ForwardRef, PlaceholderType, PartialType, RawExpressionType
+)
+
+
+@trait
+class TypeTraverserVisitor(SyntheticTypeVisitor[None]):
+    """Visitor that traverses all components of a type"""
+
+    # Atomic types
+
+    def visit_any(self, t: AnyType) -> None:
+        pass
+
+    def visit_uninhabited_type(self, t: UninhabitedType) -> None:
+        pass
+
+    def visit_none_type(self, t: NoneTyp) -> None:
+        pass
+
+    def visit_erased_type(self, t: ErasedType) -> None:
+        pass
+
+    def visit_deleted_type(self, t: DeletedType) -> None:
+        pass
+
+    def visit_type_var(self, t: TypeVarType) -> None:
+        # Note that type variable values and upper bound aren't treated as
+        # components, since they are components of the type variable
+        # definition. We want to traverse everything just once.
+        pass
+
+    def visit_literal_type(self, t: LiteralType) -> None:
+        pass
+
+    # Composite types
+
+    def visit_instance(self, t: Instance) -> None:
+        self.traverse_types(t.args)
+
+    def visit_callable_type(self, t: CallableType) -> None:
+        # FIX generics
+        self.traverse_types(t.arg_types)
+        t.ret_type.accept(self)
+        t.fallback.accept(self)
+
+    def visit_tuple_type(self, t: TupleType) -> None:
+        self.traverse_types(t.items)
+        t.fallback.accept(self)
+
+    def visit_typeddict_type(self, t: TypedDictType) -> None:
+        self.traverse_types(t.items.values())
+
+    def visit_union_type(self, t: UnionType) -> None:
+        self.traverse_types(t.items)
+
+    def visit_overloaded(self, t: Overloaded) -> None:
+        self.traverse_types(t.items())
+
+    def visit_type_type(self, t: TypeType) -> None:
+        t.item.accept(self)
+
+    # Special types (not real types)
+
+    def visit_callable_argument(self, t: CallableArgument) -> None:
+        t.typ.accept(self)
+
+    def visit_unbound_type(self, t: UnboundType) -> None:
+        self.traverse_types(t.args)
+
+    def visit_type_list(self, t: TypeList) -> None:
+        self.traverse_types(t.items)
+
+    def visit_star_type(self, t: StarType) -> None:
+        t.type.accept(self)
+
+    def visit_ellipsis_type(self, t: EllipsisType) -> None:
+        pass
+
+    def visit_forwardref_type(self, t: ForwardRef) -> None:
+        pass
+
+    def visit_placeholder_type(self, t: PlaceholderType) -> None:
+        self.traverse_types(t.args)
+
+    def visit_partial_type(self, t: PartialType) -> None:
+        pass
+
+    def visit_raw_expression_type(self, t: RawExpressionType) -> None:
+        pass
+
+    # Helpers
+
+    def traverse_types(self, types: Iterable[Type]) -> None:
+        for typ in types:
+            typ.accept(self)

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1082,3 +1082,31 @@ def g(x: int) -> int: ...
 def g(x: Union[C[str], int]) -> int:  # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
     y: C[object]  # E: Type argument "builtins.object" of "C" must be a subtype of "builtins.int"
     return 0
+
+[case testNewAnalyzerTypeArgBoundCheckWithStrictOptional]
+# flags: --config-file tmp/mypy.ini
+import a
+
+[file b.py]
+from typing import TypeVar, Generic
+
+x: C[None]
+y: C[str]  # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+z: C[int]
+
+T = TypeVar('T', bound=int)
+class C(Generic[T]):
+    pass
+
+[file a.py]
+from b import C
+
+x: C[None]  # E: Type argument "None" of "C" must be a subtype of "builtins.int"
+y: C[str]  # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+z: C[int]
+
+[file mypy.ini]
+[[mypy-a]
+strict_optional = True
+[[mypy-b]
+strict_optional = False

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -975,3 +975,61 @@ class Test:
     import a
     def __init__(self) -> None:
         some_module = self.a
+
+[case testNewAnalyzerTypeArgBoundCheck]
+from typing import TypeVar, Generic
+
+class F(E): pass
+class E: pass
+T = TypeVar('T', bound=E)
+class C(Generic[T]): pass
+
+class D(B): pass
+
+x: C[D] # E: Type argument "__main__.D" of "C" must be a subtype of "__main__.E"
+y: C[F]
+
+class B: pass
+
+[case testNewAnalyzerTypeArgValueRestriction]
+from typing import TypeVar, Generic
+
+class F(E): pass
+class E: pass
+T = TypeVar('T', E, str)
+class C(Generic[T]): pass
+
+class D(B): pass
+
+x: C[D] # E: Value of type variable "T" of "C" cannot be "D"
+y: C[E]
+z: C[str]
+
+class B: pass
+
+[case testNewAnalyzerTypeArgBoundCheckWithContext]
+# flags: --show-error-context
+import a
+[file a.py]
+from typing import TypeVar, Generic
+
+T = TypeVar('T', bound=int)
+class C(Generic[T]): pass
+
+def f(x: C[str]) -> None: # E
+    y: C[str] # E
+class A(C[str]): # E
+    z: C[str] # E
+    def g(self, x: C[str]) -> None: # E
+        a: C[str] # E
+[out]
+main:2: note: In module imported here:
+tmp/a.py: note: In function "f":
+tmp/a.py:6: error: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+tmp/a.py:7: error: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+tmp/a.py: note: In class "A":
+tmp/a.py:8: error: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+tmp/a.py:9: error: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+tmp/a.py: note: In member "g" of class "A":
+tmp/a.py:10: error: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+tmp/a.py:11: error: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1033,3 +1033,52 @@ tmp/a.py:9: error: Type argument "builtins.str" of "C" must be a subtype of "bui
 tmp/a.py: note: In member "g" of class "A":
 tmp/a.py:10: error: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
 tmp/a.py:11: error: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+
+[case testNewAnalyzerTypeArgBoundCheckDifferentNodes]
+from typing import TypeVar, Generic, NamedTuple, NewType, Union, Any, cast, overload
+from mypy_extensions import TypedDict
+
+T = TypeVar('T', bound=int)
+class C(Generic[T]): pass
+class C2(Generic[T]): pass
+
+A = C[str] # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int" \
+           # E: Value of type variable "T" of "C" cannot be "str"
+B = Union[C[str], int] # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+S = TypeVar('S', bound=C[str]) # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+U = TypeVar('U', C[str], str) # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+N = NamedTuple('N', [
+    ('x', C[str])]) # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+class N2(NamedTuple):
+    x: C[str]  # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+class TD(TypedDict):
+    x: C[str]  # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+class TD2(TD):
+    y: C2[str]  # E: Type argument "builtins.str" of "C2" must be a subtype of "builtins.int"
+NT = NewType('NT',
+             C[str]) # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+class D(
+        C[str]): # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+    pass
+
+TD3 = TypedDict('TD3', {'x': C[str]}) # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+
+a: Any
+for i in a: # type: C[str]  # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+    pass
+
+with a as w: # type: C[str]  # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+    pass
+
+cast(C[str], a)  # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+C[str]()  # E: Value of type variable "T" of "C" cannot be "str"
+
+def f(s: S, y: U) -> None: pass  # No error here
+
+@overload
+def g(x: C[str]) -> int: ...  # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+@overload
+def g(x: int) -> int: ...
+def g(x: Union[C[str], int]) -> int:  # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
+    y: C[object]  # E: Type argument "builtins.object" of "C" must be a subtype of "builtins.int"
+    return 0


### PR DESCRIPTION
This adds a new pass that checks things like `int` being valid in
`C[int]`. We use a new pass since base classes can be incomplete
during semantic analysis, which breaks subtype checks that we 
rely on here.

The implementation abstracts AST traversal into separate classes,
so that the implementation of the pass is relatively simple.

Fixes #6288.