### PR TITLE
New semantic analyzer: remove obsolete code

### DIFF
--- a/mypy/newsemanal/semanal_pass3.py
+++ b/mypy/newsemanal/semanal_pass3.py
@@ -510,10 +510,6 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
     def lookup_fully_qualified(self, fullname: str) -> SymbolTableNode:
         return self.sem.lookup_fully_qualified(fullname)
 
-    def dereference_module_cross_ref(
-            self, node: Optional[SymbolTableNode]) -> Optional[SymbolTableNode]:
-        return self.sem.dereference_module_cross_ref(node)
-
     def fail(self, msg: str, ctx: Context, serious: bool = False, *,
              blocker: bool = False) -> None:
         self.sem.fail(msg, ctx, serious, blocker=blocker)

--- a/mypy/newsemanal/semanal_shared.py
+++ b/mypy/newsemanal/semanal_shared.py
@@ -56,11 +56,6 @@ class SemanticAnalyzerCoreInterface:
         raise NotImplementedError
 
     @abstractmethod
-    def dereference_module_cross_ref(
-            self, node: Optional[SymbolTableNode]) -> Optional[SymbolTableNode]:
-        raise NotImplementedError
-
-    @abstractmethod
     def record_incomplete_ref(self) -> None:
         raise NotImplementedError
 


### PR DESCRIPTION
`ImportedName` and `UNBOUND_IMPORTED` aren't used in the new
semantic analyzer.

Fixes #6321.