### PR TITLE
New semantic analyzer: support comprehensions

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3853,11 +3853,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         return base + '.' + n
 
     def enter(self, function: Union[FuncItem, GeneratorExpr, DictionaryComprehension]) -> None:
-        """Enter the function scope.
-
-        The argument can be omitted for temporary scopes (like comprehensions
-        and generator expressions) that can't have incomplete definitions.
-        """
+        """Enter a function, generator or comprehension scope."""
         names = self.saved_locals.setdefault(function, SymbolTable())
         self.locals.append(names)
         self.global_decls.append(set())

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1054,3 +1054,24 @@ class Test:
     import a
     def __init__(self) -> None:
         some_module = self.a
+
+[case testNewAnalyzerListComprehension]
+from typing import List
+a: List[A]
+a = [x for x in a]
+b: List[B] = [x for x in a] # E: List comprehension has incompatible type List[A]; expected List[B]
+class A: pass
+class B: pass
+[builtins fixtures/for.pyi]
+
+[case testNewAnalyzerDictionaryComprehension]
+from typing import Dict, List, Tuple
+abd: Dict[A, B]
+abl: List[Tuple[A, B]]
+abd = {a: b for a, b in abl}
+x: Dict[B, A] = {a: b for a, b in abl} # E: Key expression in dictionary comprehension has incompatible type "A"; expected type "B" \
+  # E: Value expression in dictionary comprehension has incompatible type "B"; expected type "A"
+y: A = {a: b for a, b in abl} # E: Incompatible types in assignment (expression has type "Dict[A, B]", variable has type "A")
+class A: pass
+class B: pass
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
We now remember the namespaces for comprehensions, since they behave
similarly to nested functions.

Fixes #6360.