### PR TITLE
New semantic analyzer: Fix import prios

### DIFF
--- a/mypy/newsemanal/semanal_pass1.py
+++ b/mypy/newsemanal/semanal_pass1.py
@@ -1,8 +1,5 @@
 """Block/import reachability analysis."""
 
-from contextlib import contextmanager
-from typing import Iterator
-
 from mypy.nodes import (
     MypyFile, AssertStmt, IfStmt, Block, AssignmentStmt, ExpressionStmt, ReturnStmt, ForStmt,
     Import, ImportAll, ImportFrom, ClassDef, FuncDef
@@ -59,18 +56,15 @@ class ReachabilityAnalyzer(TraverserVisitor):
                 break
 
     def visit_import_from(self, node: ImportFrom) -> None:
-        if self.is_global_scope:
-            node.is_top_level = True
+        node.is_top_level = self.is_global_scope
         super().visit_import_from(node)
 
     def visit_import_all(self, node: ImportAll) -> None:
-        if self.is_global_scope:
-            node.is_top_level = True
+        node.is_top_level = self.is_global_scope
         super().visit_import_all(node)
 
     def visit_import(self, node: Import) -> None:
-        if self.is_global_scope:
-            node.is_top_level = True
+        node.is_top_level = self.is_global_scope
         super().visit_import(node)
 
     def visit_if_stmt(self, s: IfStmt) -> None:

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1399,3 +1399,21 @@ a = A()
 reveal_type(a.x)  # E: Revealed type is '__main__.B'
 a.y = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "B")
 [builtins fixtures/property.pyi]
+
+[case testNewAnalyzerImportPriosB]
+import b
+[file a.py]
+from b import x
+reveal_type(x)  # E: Revealed type is 'Tuple[builtins.int, builtins.int]'
+[file b.py]
+import a
+x = (1, 2)
+
+[case testNewAnalyzerImportPriosA]
+import a
+[file a.py]
+from b import x
+reveal_type(x)  # E: Revealed type is 'Tuple[builtins.int, builtins.int]'
+[file b.py]
+import a
+x = (1, 2)

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1369,6 +1369,6 @@ reveal_type(x['test'][0])
 -- fully analyze typeshed
 typing.pyi:251: error: Class typing.Sequence has abstract attributes "__len__"
 typing.pyi:251: note: If it is meant to be abstract, add 'abc.ABCMeta' as an explicit metaclass
-codecs.pyi:49: error: Cannot overwrite NamedTuple attribute "__init__"
 ast.pyi:31: error: Name 'PyCF_ONLY_AST' already defined (possibly by an import)
+codecs.pyi:49: error: Cannot overwrite NamedTuple attribute "__init__"
 _testNewAnalyzerBasicTypeshed_newsemanal.py:4: error: Revealed type is 'builtins.int*'


### PR DESCRIPTION
Old semantic analyzer first pass is setting whether an import is a top level one or not. New semantic analyzer reachability pass didn't do this. As a result, this screwed up import priorities, and in turn, ordering of modules within SCCs. This caused many `Cannot determine type of 'foo'` errors since we don't defer module top levels.