### PR TITLE
New semantic analyzer: conditional function definitions

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3963,10 +3963,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             if existing.node != symbol.node:
                 if isinstance(symbol.node, (FuncDef, Decorator)):
                     self.add_func_redefinition(names, name, symbol)
-                if (isinstance(symbol.node, (FuncDef, Decorator))
+                if not (isinstance(symbol.node, (FuncDef, Decorator))
                         and self.set_original_def(existing.node, symbol.node)):
-                    pass
-                else:
                     self.name_already_defined(name, context, existing)
         elif name not in self.missing_names and '*' not in self.missing_names:
             names[name] = symbol

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -493,9 +493,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
     def visit_func_def(self, defn: FuncDef) -> None:
         defn.is_conditional = self.block_depth[-1] > 0
 
-        # Add module-level function to symbol table on first iteration
-        # (recurse_into_functions == False). Also add nested functions
-        # always, since they won't be processed as separate targets.
+        # We don't add module top-level functions to symbol tables
+        # when we analyze their bodies in the second phase on analysis,
+        # since they were added in the first phase. Nested functions
+        # get always added, since they aren't separate targets.
         if not self.recurse_into_functions or len(self.function_stack) > 0:
             if not defn.is_decorated and not defn.is_overload:
                 self.add_func_to_symbol_table(defn)

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -162,6 +162,7 @@ def get_all_leaf_targets(symtable: SymbolTable,
     for name, node in symtable.items():
         shortname = name
         if '-redef' in name:
+            # Restore original name from mangled name of multiply defined function
             shortname = name.split('-redef')[0]
         new_prefix = prefix + '.' + shortname
         if isinstance(node.node, (FuncDef, TypeInfo, OverloadedFuncDef, Decorator)):

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -160,7 +160,7 @@ def get_all_leaf_targets(symtable: SymbolTable,
     """Return all leaf targets in a symbol table (module-level and methods)."""
     result = []  # type: List[TargetInfo]
     for name, node in symtable.items():
-        new_prefix = prefix + '.' + name
+        new_prefix = prefix + '.' + name.rstrip('!')
         if isinstance(node.node, (FuncDef, TypeInfo, OverloadedFuncDef, Decorator)):
             if node.node.fullname() == new_prefix:
                 if isinstance(node.node, TypeInfo):

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -160,7 +160,10 @@ def get_all_leaf_targets(symtable: SymbolTable,
     """Return all leaf targets in a symbol table (module-level and methods)."""
     result = []  # type: List[TargetInfo]
     for name, node in symtable.items():
-        new_prefix = prefix + '.' + name.rstrip('!')
+        shortname = name
+        if '-redef' in name:
+            shortname = name.split('-redef')[0]
+        new_prefix = prefix + '.' + shortname
         if isinstance(node.node, (FuncDef, TypeInfo, OverloadedFuncDef, Decorator)):
             if node.node.fullname() == new_prefix:
                 if isinstance(node.node, TypeInfo):

--- a/mypy/test/hacks.py
+++ b/mypy/test/hacks.py
@@ -21,7 +21,7 @@ new_semanal_blacklist = [
     'check-expressions.test',
     'check-fastparse.test',
     'check-flags.test',
-    #'check-functions.test',
+    'check-functions.test',
     'check-generics.test',
     'check-incomplete-fixture.test',
     'check-incremental.test',

--- a/mypy/test/hacks.py
+++ b/mypy/test/hacks.py
@@ -21,7 +21,7 @@ new_semanal_blacklist = [
     'check-expressions.test',
     'check-fastparse.test',
     'check-flags.test',
-    'check-functions.test',
+    #'check-functions.test',
     'check-generics.test',
     'check-incomplete-fixture.test',
     'check-incremental.test',

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1431,6 +1431,22 @@ else:
         pass
 reveal_type(g) # E: Revealed type is 'def (x: builtins.int)'
 
+[case testNewAnalyzerConditionalFuncDefer]
+if int():
+    def f(x: A) -> None:
+        pass
+    def g(x: A) -> None:
+        pass
+else:
+    def f(x: A) -> None:
+        1()  # E: "int" not callable
+    def g(x: str) -> None:  # E: All conditional function variants must have identical signatures
+        pass
+
+reveal_type(g) # E: Revealed type is 'def (x: __main__.A)'
+
+class A: pass
+
 [case testNewAnalyzerConditionalDecoratedFunc]
 from typing import Callable
 

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1430,3 +1430,19 @@ else:
     def g(x: str) -> None:  # E: All conditional function variants must have identical signatures
         pass
 reveal_type(g) # E: Revealed type is 'def (x: builtins.int)'
+
+[case testNewAnalyzerConditionalDecoratedFunc]
+from typing import Callable
+
+def dec(f: Callable[[int], None]) -> Callable[[str], None]:
+    pass
+
+if int():
+    from m import f
+else:
+    @dec
+    def f(x: int) -> None:
+        1()  # E: "int" not callable
+reveal_type(f) # E: Revealed type is 'def (x: builtins.str)'
+[file m.py]
+def f(x: str) -> None: pass

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1431,7 +1431,7 @@ elif bool():
         pass
 else:
     def f(x: int) -> None:
-        ''()  # E: "int" not callable
+        ''()  # E: "str" not callable
 
 reveal_type(g) # E: Revealed type is 'def (x: builtins.int)'
 
@@ -1466,3 +1466,13 @@ else:
 reveal_type(f) # E: Revealed type is 'def (x: builtins.str)'
 [file m.py]
 def f(x: str) -> None: pass
+
+[case testNewAnalyzerConditionallyDefineFuncOverVar]
+from typing import Callable
+
+if int():
+    f: Callable[[str], None]
+else:
+    def f(x: str) -> None:
+        ...
+reveal_type(f) # E: Revealed type is 'def (builtins.str)'

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1476,3 +1476,9 @@ else:
     def f(x: str) -> None:
         ...
 reveal_type(f) # E: Revealed type is 'def (builtins.str)'
+
+[case testNewAnalyzerConditionallyDefineFuncOverClass]
+class C:
+    1()  # E: "int" not callable
+def C() -> None:  # E: Name 'C' already defined on line 1
+    ''()  # E: "str" not callable

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1424,11 +1424,15 @@ if int():
         pass
     def g(x: int) -> None:
         pass
-else:
+elif bool():
     def f(x: int) -> None:
         1()  # E: "int" not callable
     def g(x: str) -> None:  # E: All conditional function variants must have identical signatures
         pass
+else:
+    def f(x: int) -> None:
+        ''()  # E: "int" not callable
+
 reveal_type(g) # E: Revealed type is 'def (x: builtins.int)'
 
 [case testNewAnalyzerConditionalFuncDefer]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1417,3 +1417,16 @@ reveal_type(x)  # E: Revealed type is 'Tuple[builtins.int, builtins.int]'
 [file b.py]
 import a
 x = (1, 2)
+
+[case testNewAnalyzerConditionalFunc]
+if int():
+    def f(x: int) -> None:
+        pass
+    def g(x: int) -> None:
+        pass
+else:
+    def f(x: int) -> None:
+        1()  # E: "int" not callable
+    def g(x: str) -> None:  # E: All conditional function variants must have identical signatures
+        pass
+reveal_type(g) # E: Revealed type is 'def (x: builtins.int)'


### PR DESCRIPTION
To semantically analyze conditional function definitions (and function
redefinitions) we add redefinitions to a symbol table with a mangled
name of form `name-redefinition[N]`. This is necessary since 
functions are only analyzed if they can be accessed through a symbol
table.

I checked that this fixes most relevant test cases in 
`check-functions.test`. Using a decorated function in a redefinition
is still not working perfectly. That is also partially implemented in 
the old semantic analyzer. Conditionally defining an overloaded
function is also not supported. I'll create follow-up issues for these
remaining known limitations.

Fixes #6318.