### PR TITLE
New semantic analyzer: Fix instances that are type alias targets

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3795,8 +3795,9 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     # Found built-in class target. Create alias.
                     target = self.named_type_or_none(target_name, [])
                     assert target is not None
-                    target = fix_instance_types(target, self.fail)
-                    alias_node = TypeAlias(target, alias,
+                    # Transform List to List[Any], etc.
+                    fixed_target = fix_instance_types(target, self.fail)
+                    alias_node = TypeAlias(fixed_target, alias,
                                            line=-1, column=-1,  # there is no context
                                            no_args=True, normalized=True)
                     self.add_symbol(name, alias_node, tree)

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2340,6 +2340,9 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             v.is_initialized_in_class = True
         if kind != LDEF:
             v._fullname = self.qualified_name(lvalue.name)
+        else:
+            # fullanme should never stay None
+            v._fullname = lvalue.name
         v.is_ready = False  # Type not inferred yet
         lvalue.is_new_def = True
         lvalue.is_inferred_def = True

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2207,7 +2207,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         # so we need to replace it with non-explicit Anys
         res = make_any_non_explicit(res)
         no_args = isinstance(res, Instance) and not res.args
-        res = fix_instance_types(res, self.fail)
+        fix_instance_types(res, self.fail)
         if isinstance(s.rvalue, (IndexExpr, CallExpr)):  # CallExpr is for `void = type(None)`
             s.rvalue.analyzed = TypeAliasExpr(res, alias_tvars, no_args)
             s.rvalue.analyzed.line = s.line
@@ -3796,8 +3796,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     target = self.named_type_or_none(target_name, [])
                     assert target is not None
                     # Transform List to List[Any], etc.
-                    fixed_target = fix_instance_types(target, self.fail)
-                    alias_node = TypeAlias(fixed_target, alias,
+                    fix_instance_types(target, self.fail)
+                    alias_node = TypeAlias(target, alias,
                                            line=-1, column=-1,  # there is no context
                                            no_args=True, normalized=True)
                     self.add_symbol(name, alias_node, tree)

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -70,7 +70,7 @@ from mypy.nodes import (
     YieldExpr, ExecStmt, BackquoteExpr, ImportBase, AwaitExpr,
     IntExpr, FloatExpr, UnicodeExpr, TempNode, OverloadPart,
     PlaceholderNode, COVARIANT, CONTRAVARIANT, INVARIANT,
-    LITERAL_YES, nongen_builtins, get_member_expr_fullname, REVEAL_TYPE,
+    nongen_builtins, get_member_expr_fullname, REVEAL_TYPE,
     REVEAL_LOCALS, is_final_node
 )
 from mypy.tvar_scope import TypeVarScope
@@ -84,12 +84,11 @@ from mypy.types import (
     CallableType, Overloaded, Instance, Type, AnyType, LiteralType, LiteralValue,
     TypeTranslator, TypeOfAny, TypeType, NoneTyp, PlaceholderType
 )
-from mypy.type_visitor import TypeQuery
 from mypy.nodes import implicit_module_attrs
 from mypy.newsemanal.typeanal import (
     TypeAnalyser, analyze_type_alias, no_subscript_builtin_alias,
     TypeVariableQuery, TypeVarList, remove_dups, has_any_from_unimported_type,
-    check_for_explicit_any
+    check_for_explicit_any, fix_instance_types
 )
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.options import Options
@@ -101,7 +100,7 @@ from mypy.plugin import (
 from mypy.util import get_prefix, correct_relative_import, unmangle, split_module_names
 from mypy.scope import Scope
 from mypy.newsemanal.semanal_shared import SemanticAnalyzerInterface, set_callable_name
-from mypy.newsemanal.semanal_namedtuple import NamedTupleAnalyzer, NAMEDTUPLE_PROHIBITED_NAMES
+from mypy.newsemanal.semanal_namedtuple import NamedTupleAnalyzer
 from mypy.newsemanal.semanal_typeddict import TypedDictAnalyzer
 from mypy.newsemanal.semanal_enum import EnumCallAnalyzer
 from mypy.newsemanal.semanal_newtype import NewTypeAnalyzer
@@ -2256,6 +2255,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         # so we need to replace it with non-explicit Anys
         res = make_any_non_explicit(res)
         no_args = isinstance(res, Instance) and not res.args
+        res = fix_instance_types(res, self.fail)
         if isinstance(s.rvalue, (IndexExpr, CallExpr)):  # CallExpr is for `void = type(None)`
             s.rvalue.analyzed = TypeAliasExpr(res, alias_tvars, no_args)
             s.rvalue.analyzed.line = s.line
@@ -3840,6 +3840,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     # Found built-in class target. Create alias.
                     target = self.named_type_or_none(target_name, [])
                     assert target is not None
+                    target = fix_instance_types(target, self.fail)
                     alias_node = TypeAlias(target, alias,
                                            line=-1, column=-1,  # there is no context
                                            no_args=True, normalized=True)

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -16,7 +16,7 @@ from mypy.types import (
     CallableType, NoneTyp, DeletedType, TypeList, TypeVarDef, TypeVisitor, SyntheticTypeVisitor,
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType, get_typ_args, set_typ_args,
     CallableArgument, get_type_vars, TypeQuery, union_items, TypeOfAny, ForwardRef, Overloaded,
-    LiteralType, RawExpressionType, PlaceholderType
+    LiteralType, RawExpressionType, PlaceholderType, TypeTranslator
 )
 
 from mypy.nodes import (
@@ -248,7 +248,11 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 all_vars = node.alias_tvars
                 target = node.target
                 an_args = self.anal_array(t.args)
-                return expand_type_alias(target, all_vars, an_args, self.fail, node.no_args, t)
+                res = expand_type_alias(target, all_vars, an_args, self.fail, node.no_args, t)
+                if (isinstance(res, Instance) and len(res.args) != len(res.type.type_vars) and
+                        not self.defining_alias):
+                    fix_instance(res, self.fail)
+                return res
             elif isinstance(node, TypeInfo):
                 return self.analyze_type_with_type_info(node, t.args, t)
             else:
@@ -347,7 +351,6 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         # Instance with an invalid number of type arguments.
         instance = Instance(info, self.anal_array(args), ctx.line, ctx.column)
         # Check type argument count.
-        # TODO: remove this from here and replace with a proper separate pass.
         if len(instance.args) != len(info.type_vars) and not self.defining_alias:
             fix_instance(instance, self.fail)
         if not args and self.options.disallow_any_generics and not self.defining_alias:
@@ -1281,3 +1284,18 @@ def make_optional_type(t: Type) -> Type:
         return UnionType(items + [NoneTyp()], t.line, t.column)
     else:
         return UnionType([t, NoneTyp()], t.line, t.column)
+
+
+def fix_instance_types(t: Type, fail: Callable[[str, Context], None]) -> Type:
+    return t.accept(InstanceFixer(fail))
+
+
+class InstanceFixer(TypeTranslator):
+    def __init__(self, fail: Callable[[str, Context], None]) -> None:
+        self.fail = fail
+
+    def visit_instance(self, t: Instance) -> Type:
+        t = super().visit_instance(t)
+        if isinstance(t, Instance) and len(t.args) != len(t.type.type_vars):
+            fix_instance(t, self.fail)
+        return t

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -1294,8 +1294,8 @@ class InstanceFixer(TypeTranslator):
     def __init__(self, fail: Callable[[str, Context], None]) -> None:
         self.fail = fail
 
-    def visit_instance(self, t: Instance) -> Type:
-        t = super().visit_instance(t)
+    def visit_instance(self, typ: Instance) -> Type:
+        t = super().visit_instance(typ)
         if isinstance(t, Instance) and len(t.args) != len(t.type.type_vars):
             fix_instance(t, self.fail)
         return t

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -249,6 +249,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 target = node.target
                 an_args = self.anal_array(t.args)
                 res = expand_type_alias(target, all_vars, an_args, self.fail, node.no_args, t)
+                # The only case where expand_type_alias() can return an incorrect instance is
+                # when it is top-level instance, so no need to recurse.
                 if (isinstance(res, Instance) and len(res.args) != len(res.type.type_vars) and
                         not self.defining_alias):
                     fix_instance(res, self.fail)

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -1287,6 +1287,11 @@ def make_optional_type(t: Type) -> Type:
 
 
 def fix_instance_types(t: Type, fail: Callable[[str, Context], None]) -> Type:
+    """Recursively fix all instance types (type argument count) in a given type.
+
+    For example 'Union[Dict, List[str, int]]' will be transformed into
+    'Union[Dict[Any, Any], List[Any]]'.
+    """
     return t.accept(InstanceFixer(fail))
 
 

--- a/mypy/test/hacks.py
+++ b/mypy/test/hacks.py
@@ -23,7 +23,6 @@ new_semanal_blacklist = [
     'check-fastparse.test',
     'check-flags.test',
     'check-functions.test',
-    'check-generics.test',
     'check-incomplete-fixture.test',
     'check-incremental.test',
     'check-inference-context.test',

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -579,8 +579,9 @@ reveal_type(wrap(z)) # E: Revealed type is '__main__.Node[builtins.int, builtins
 [out]
 main:13: error: Argument 2 to "Node" has incompatible type "int"; expected "str"
 
+-- Error formatting is a bit different with new analyzer
 [case testGenericTypeAliasesWrongAliases]
-# flags: --show-column-numbers --python-version 3.6 --no-strict-optional
+# flags: --show-column-numbers --python-version 3.6 --no-strict-optional --no-new-semantic-analyzer
 from typing import TypeVar, Generic, List, Callable, Tuple, Union
 T = TypeVar('T')
 S = TypeVar('S')
@@ -1480,7 +1481,10 @@ class A(Generic[T]):
         g(self.a)
         g(n) # E: Argument 1 to "g" has incompatible type "int"; expected "T"
 
+-- This is non-trivial with new analyzer (and also in fine grained incremental):
+-- We need to store whole tvar_scope, not only active class.
 [case testFunctionInGenericInnerClassTypeVariable]
+# flags: --no-new-semantic-analyzer
 from typing import TypeVar, Generic
 
 T = TypeVar('T')

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -579,9 +579,9 @@ reveal_type(wrap(z)) # E: Revealed type is '__main__.Node[builtins.int, builtins
 [out]
 main:13: error: Argument 2 to "Node" has incompatible type "int"; expected "str"
 
--- Error formatting is a bit different with new analyzer
+-- Error formatting is a bit different (and probably better) with new analyzer
 [case testGenericTypeAliasesWrongAliases]
-# flags: --show-column-numbers --python-version 3.6 --no-strict-optional --no-new-semantic-analyzer
+# flags: --show-column-numbers --python-version 3.6 --no-strict-optional --new-semantic-analyzer
 from typing import TypeVar, Generic, List, Callable, Tuple, Union
 T = TypeVar('T')
 S = TypeVar('S')
@@ -598,8 +598,8 @@ E = Node[Node[T, T], List[T]]
 F = Node[List[T, T], S] # Error
 G = Callable[..., List[T, T]] # Error
 H = Union[int, Tuple[T, Node[T]]] # Error
-h: H # Error
-h1: H[int, str] # Two errors here, wrong number of args for H, and for Node
+h: H # This was reported on previous line
+h1: H[int, str] # Error
 
 x = None # type: D[int, str]
 reveal_type(x)
@@ -615,9 +615,7 @@ main:11:5: error: "Node" expects 2 type arguments, but 3 given
 main:15:10: error: "list" expects 1 type argument, but 2 given
 main:16:19: error: "list" expects 1 type argument, but 2 given
 main:17:25: error: "Node" expects 2 type arguments, but 1 given
-main:18:4: error: "Node" expects 2 type arguments, but 1 given
 main:19:5: error: Bad number of arguments for type alias, expected: 1, given: 2
-main:19:5: error: "Node" expects 2 type arguments, but 1 given
 main:22:1: error: Revealed type is '__main__.Node[builtins.int, builtins.str]'
 main:24:1: error: Revealed type is '__main__.Node[__main__.Node[builtins.int, builtins.int], builtins.list[builtins.int]]'
 main:26:5: error: Type variable "__main__.T" is invalid as target for type alias

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1399,3 +1399,47 @@ a = A()
 reveal_type(a.x)  # E: Revealed type is '__main__.B'
 a.y = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "B")
 [builtins fixtures/property.pyi]
+
+[case testNewAnalyzerAliasesFixedFew]
+from typing import List, Generic, TypeVar
+
+def func(x: List[C[T]]) -> T:
+    ...
+x: A
+A = List[C]
+
+reveal_type(x)  # E: Revealed type is 'builtins.list[__main__.C[Any]]'
+reveal_type(func(x))  # E: Revealed type is 'Any'
+class C(Generic[T]):
+    ...
+
+T = TypeVar('T')
+[builtins fixtures/list.pyi]
+
+[case testNewAnalyzerAliasesFixedMany]
+from typing import List, Generic, TypeVar
+
+def func(x: List[C[T]]) -> T:
+    ...
+
+x: A
+A = List[C[int, str]]  # E: "C" expects 1 type argument, but 2 given
+
+reveal_type(x)  # E: Revealed type is 'builtins.list[__main__.C[Any]]'
+reveal_type(func(x))  # E: Revealed type is 'Any'
+
+class C(Generic[T]):
+    ...
+T = TypeVar('T')
+[builtins fixtures/list.pyi]
+
+[case testNewAnalyzerBuiltinAliasesFixed]
+from typing import List, Optional
+x: Optional[List] = None
+y: List[str]
+
+reveal_type(x)  # E: Revealed type is 'Union[builtins.list[Any], None]'
+x = ['a', 'b']
+reveal_type(x)  # E: Revealed type is 'builtins.list[Any]'
+x.extend(y)
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
Fix #6420 

The fix is straightforward. I don't think this actually requires a separate pass, as it was suggested in the TODO I removed.

I also remove some unused imports and enable `check-generics.test` (without one tricky test).