### PR TITLE
New semantic analyzer: support assignment based TypedDict

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -71,7 +71,7 @@ from mypy.nodes import (
     IntExpr, FloatExpr, UnicodeExpr, TempNode, OverloadPart,
     PlaceholderNode, COVARIANT, CONTRAVARIANT, INVARIANT,
     nongen_builtins, get_member_expr_fullname, REVEAL_TYPE,
-    REVEAL_LOCALS, is_final_node
+    REVEAL_LOCALS, is_final_node, TypedDictExpr
 )
 from mypy.tvar_scope import TypeVarScope
 from mypy.typevars import fill_typevars
@@ -1886,6 +1886,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             return
         if self.analyze_namedtuple_assign(s):
             return
+        if self.analyze_typeddict_assign(s):
+            return
         self.analyze_lvalues(s)
         self.check_final_implicit_def(s)
         self.check_classvar(s)
@@ -1894,7 +1896,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         self.check_and_set_up_type_alias(s)
         self.newtype_analyzer.process_newtype_declaration(s)
         self.process_typevar_declaration(s)
-        self.typed_dict_analyzer.process_typeddict_definition(s, self.is_func_scope())
         self.enum_call_analyzer.process_enum_call(s, self.is_func_scope())
         self.store_final_status(s)
         if not s.type:
@@ -1912,6 +1913,23 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         is_named_tuple, info = self.named_tuple_analyzer.check_namedtuple(s.rvalue, name,
                                                                           self.is_func_scope())
         if not is_named_tuple:
+            return False
+        # Yes, it's a valid namedtuple, but defer if it is not ready.
+        if not info:
+            self.mark_incomplete(name, lvalue, becomes_typeinfo=True)
+        return True
+
+    def analyze_typeddict_assign(self, s: AssignmentStmt) -> bool:
+        """Check if s defines a typed dict."""
+        if isinstance(s.rvalue, CallExpr) and isinstance(s.rvalue.analyzed, TypedDictExpr):
+            return True  # This is a valid and analyzed named tuple definition, nothing to do here.
+        if len(s.lvalues) != 1 or not isinstance(s.lvalues[0], NameExpr):
+            return False
+        lvalue = s.lvalues[0]
+        name = lvalue.name
+        is_typed_dict, info = self.typed_dict_analyzer.check_typeddict(s.rvalue, name,
+                                                                       self.is_func_scope())
+        if not is_typed_dict:
             return False
         # Yes, it's a valid namedtuple, but defer if it is not ready.
         if not info:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1921,7 +1921,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
     def analyze_typeddict_assign(self, s: AssignmentStmt) -> bool:
         """Check if s defines a typed dict."""
         if isinstance(s.rvalue, CallExpr) and isinstance(s.rvalue.analyzed, TypedDictExpr):
-            return True  # This is a valid and analyzed named tuple definition, nothing to do here.
+            return True  # This is a valid and analyzed typed dict definition, nothing to do here.
         if len(s.lvalues) != 1 or not isinstance(s.lvalues[0], NameExpr):
             return False
         lvalue = s.lvalues[0]
@@ -1930,13 +1930,14 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                                                                        self.is_func_scope())
         if not is_typed_dict:
             return False
-        # Yes, it's a valid namedtuple, but defer if it is not ready.
+        # Yes, it's a valid typed dict, but defer if it is not ready.
         if not info:
             self.mark_incomplete(name, lvalue, becomes_typeinfo=True)
         else:
             # TODO: This is needed for one-to-one compatibility with old analyzer, otherwise
             # type checker will try to infer Any for the l.h.s.
             # Remove this after new analyzer is the default one!
+            lvalue.fullname = self.qualified_name(name)
             lvalue.node = self.make_name_lvalue_var(lvalue, self.current_symbol_kind(),
                                                     inferred=True)
         return True

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1933,6 +1933,12 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         # Yes, it's a valid namedtuple, but defer if it is not ready.
         if not info:
             self.mark_incomplete(name, lvalue, becomes_typeinfo=True)
+        else:
+            # TODO: This is needed for one-to-one compatibility with old analyzer, otherwise
+            # type checker will try to infer Any for the l.h.s.
+            # Remove this after new analyzer is the default one!
+            lvalue.node = self.make_name_lvalue_var(lvalue, self.current_symbol_kind(),
+                                                    inferred=True)
         return True
 
     def analyze_lvalues(self, s: AssignmentStmt) -> None:

--- a/mypy/newsemanal/semanal_typeddict.py
+++ b/mypy/newsemanal/semanal_typeddict.py
@@ -169,48 +169,36 @@ class TypedDictAnalyzer:
         required_keys = set(fields) if total else set()
         return fields, types, required_keys
 
-    def process_typeddict_definition(self, s: AssignmentStmt, is_func_scope: bool) -> None:
-        """Check if s defines an assignment-based TypedDict type.
-
-        If yes, store the definition in symbol table.
-        """
-        if len(s.lvalues) != 1 or not isinstance(s.lvalues[0], NameExpr):
-            return
-        lvalue = s.lvalues[0]
-        name = lvalue.name
-        typed_dict = self.check_typeddict(s.rvalue, name, is_func_scope)
-        if typed_dict is None:
-            return
-        # Yes, it's a valid TypedDict definition. Add it to the symbol table.
-        node = self.api.lookup(name, s)
-        if node:
-            node.kind = GDEF   # TODO locally defined TypedDict
-            node.node = typed_dict
-
     def check_typeddict(self,
                         node: Expression,
                         var_name: Optional[str],
-                        is_func_scope: bool) -> Optional[TypeInfo]:
+                        is_func_scope: bool) -> Tuple[bool, Optional[TypeInfo]]:
         """Check if a call defines a TypedDict.
 
         The optional var_name argument is the name of the variable to
         which this is assigned, if any.
 
-        If it does, return the corresponding TypeInfo. Return None otherwise.
+        Return a pair (is it a typed dict, corresponding TypeInfo).
 
         If the definition is invalid but looks like a TypedDict,
-        report errors but return (some) TypeInfo.
+        report errors but return (some) TypeInfo. If some type is not ready,
+        return (True, None).
         """
         if not isinstance(node, CallExpr):
-            return None
+            return False, None
         call = node
         callee = call.callee
         if not isinstance(callee, RefExpr):
-            return None
+            return False, None
         fullname = callee.fullname
         if fullname != 'mypy_extensions.TypedDict':
-            return None
-        items, types, total, ok = self.parse_typeddict_args(call)
+            return False, None
+        res = self.parse_typeddict_args(call)
+        if res is None:
+            # This is a valid typed dict, but some type is not ready.
+            # The caller should defer this until next iteration.
+            return True, None
+        items, types, total, ok = res
         if not ok:
             # Error. Construct dummy return value.
             info = self.build_typeddict_typeinfo('TypedDict', [], [], set())
@@ -225,15 +213,21 @@ class TypedDictAnalyzer:
                 name += '@' + str(call.line)
             required_keys = set(items) if total else set()
             info = self.build_typeddict_typeinfo(name, items, types, required_keys)
-            # Store it as a global just in case it would remain anonymous.
-            # (Or in the nearest class if there is one.)
-            stnode = SymbolTableNode(GDEF, info)
-            self.api.add_symbol_table_node(name, stnode)
+            # Store generated TypeInfo under both names, see semanal_namedtuple for more details.
+            if var_name:
+                self.api.add_symbol(var_name, info, node)
+            if name != var_name or is_func_scope:
+                self.api.add_symbol_skip_local(name, info)
         call.analyzed = TypedDictExpr(info)
         call.analyzed.set_line(call.line, call.column)
-        return info
+        return True, info
 
-    def parse_typeddict_args(self, call: CallExpr) -> Tuple[List[str], List[Type], bool, bool]:
+    def parse_typeddict_args(self, call: CallExpr) -> Optional[Tuple[List[str], List[Type], bool, bool]]:
+        """Parse typed dict call expression.
+
+        Return names, types, totality, was there an error during parsing.
+        If some type is not ready, return None.
+        """
         # TODO: Share code with check_argument_count in checkexpr.py?
         args = call.args
         if len(args) < 2:
@@ -259,7 +253,11 @@ class TypedDictAnalyzer:
                 return self.fail_typeddict_arg(
                     'TypedDict() "total" argument must be True or False', call)
         dictexpr = args[1]
-        items, types, ok = self.parse_typeddict_fields_with_types(dictexpr.items, call)
+        res = self.parse_typeddict_fields_with_types(dictexpr.items, call)
+        if res is None:
+            # One of the types is not ready, defer.
+            return None
+        items, types, ok = res
         for t in types:
             check_for_explicit_any(t, self.options, self.api.is_typeshed_stub_file, self.msg,
                                    context=call)
@@ -274,7 +272,11 @@ class TypedDictAnalyzer:
     def parse_typeddict_fields_with_types(
             self,
             dict_items: List[Tuple[Optional[Expression], Expression]],
-            context: Context) -> Tuple[List[str], List[Type], bool]:
+            context: Context) -> Optional[Tuple[List[str], List[Type], bool]]:
+        """Parse typed dict items passed as pairs (name expression, type expression).
+
+        Return names, types, was there an error. If some type is not ready, return None.
+        """
         items = []  # type: List[str]
         types = []  # type: List[Type]
         for (field_name_expr, field_type_expr) in dict_items:
@@ -290,7 +292,8 @@ class TypedDictAnalyzer:
                 self.fail_typeddict_arg('Invalid field type', field_type_expr)
                 return [], [], False
             analyzed = self.api.anal_type(type)
-            assert analyzed is not None  # TODO: Handle None values
+            if analyzed is None:
+                return None
             types.append(analyzed)
         return items, types, True
 

--- a/mypy/newsemanal/semanal_typeddict.py
+++ b/mypy/newsemanal/semanal_typeddict.py
@@ -214,15 +214,16 @@ class TypedDictAnalyzer:
             required_keys = set(items) if total else set()
             info = self.build_typeddict_typeinfo(name, items, types, required_keys)
             # Store generated TypeInfo under both names, see semanal_namedtuple for more details.
-            if var_name:
-                self.api.add_symbol(var_name, info, node)
             if name != var_name or is_func_scope:
                 self.api.add_symbol_skip_local(name, info)
+        if var_name:
+            self.api.add_symbol(var_name, info, node)
         call.analyzed = TypedDictExpr(info)
         call.analyzed.set_line(call.line, call.column)
         return True, info
 
-    def parse_typeddict_args(self, call: CallExpr) -> Optional[Tuple[List[str], List[Type], bool, bool]]:
+    def parse_typeddict_args(self, call: CallExpr) -> Optional[Tuple[List[str], List[Type],
+                                                                     bool, bool]]:
         """Parse typed dict call expression.
 
         Return names, types, totality, was there an error during parsing.

--- a/mypy/test/hacks.py
+++ b/mypy/test/hacks.py
@@ -41,7 +41,6 @@ new_semanal_blacklist = [
     'check-serialize.test',
     'check-statements.test',
     'check-tuples.test',
-    'check-typeddict.test',
     'check-typevar-values.test',
     'check-unions.test',
     'check-unreachable-code.test',

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1323,6 +1323,7 @@ reveal_type(x['a']['b']) # E: Revealed type is 'builtins.int'
 [builtins fixtures/dict.pyi]
 
 [case testSelfRecursiveTypedDictInheriting]
+# flags: --no-new-semantic-analyzer
 from mypy_extensions import TypedDict
 
 class MovieBase(TypedDict):
@@ -1338,6 +1339,7 @@ reveal_type(m['director']['name']) # E: Revealed type is 'builtins.str'
 [out]
 
 [case testSubclassOfRecursiveTypedDict]
+# flags: --no-new-semantic-analyzer
 from typing import List
 from mypy_extensions import TypedDict
 
@@ -1387,6 +1389,7 @@ tmp/b.py:4: error: Revealed type is 'TypedDict('a.N', {'a': builtins.str})'
 tmp/b.py:5: error: Revealed type is 'builtins.str'
 
 [case testTypedDictImportCycle]
+# flags: --new-semantic-analyzer
 import b
 [file a.py]
 class C:
@@ -1396,10 +1399,8 @@ from b import tp
 x: tp
 reveal_type(x['x'])  # E: Revealed type is 'builtins.int'
 
-# Unfortunately runtime part doesn't work yet, see docstring in SemanticAnalyzerPass3.update_imported_vars()
-reveal_type(tp)  # E: Revealed type is 'Any' \
-                 # E: Cannot determine type of 'tp'
-tp('x')  # E: Cannot determine type of 'tp'
+reveal_type(tp)  # E: Revealed type is 'def () -> b.tp'
+tp(x='no')  # E: Incompatible types (expression has type "str", TypedDict item "x" has type "int")
 
 [file b.py]
 from a import C

--- a/test-data/unit/lib-stub/mypy_extensions.pyi
+++ b/test-data/unit/lib-stub/mypy_extensions.pyi
@@ -1,7 +1,6 @@
 # NOTE: Requires fixtures/dict.pyi
-from typing import Dict, Type, TypeVar, Optional, Any, Generic, Mapping, NoReturn
+from typing import Dict, Type, TypeVar, Optional, Any, Generic, Mapping, NoReturn, Iterator
 import sys
-import abc
 
 _T = TypeVar('_T')
 _U = TypeVar('_U')
@@ -20,12 +19,15 @@ def VarArg(type: _T = ...) -> _T: ...
 def KwArg(type: _T = ...) -> _T: ...
 
 
-# Fallback type for all typed dicts (does not exist at runtime)
-class _TypedDict(Mapping[str, object], metaclass=abc.ABCMeta):
+# Fallback type for all typed dicts (does not exist at runtime).
+class _TypedDict(Mapping[str, object]):
+    # Needed to make this class non-abstract. It is explicitly declared abstract in
+    # typeshed, but we don't want to import abc here, as it would slow down the tests.
+    def __iter__(self) -> Iterator[str]: ...
     def copy(self: _T) -> _T: ...
     # Using NoReturn so that only calls using the plugin hook can go through.
     def setdefault(self, k: NoReturn, default: object) -> object: ...
-    # Mypy expects that 'default' has a type variable type
+    # Mypy expects that 'default' has a type variable type.
     def pop(self, k: NoReturn, default: _T = ...) -> object: ...
     def update(self: _T, __m: _T) -> None: ...
     if sys.version_info < (3, 0):
@@ -35,7 +37,7 @@ class _TypedDict(Mapping[str, object], metaclass=abc.ABCMeta):
 def TypedDict(typename: str, fields: Dict[str, Type[_T]], *, total: Any = ...) -> Type[dict]: ...
 
 # This is intended as a class decorator, but mypy rejects abstract classes
-# when a Type[_T] is expected, so we can't give it the type we want
+# when a Type[_T] is expected, so we can't give it the type we want.
 def trait(cls: Any) -> Any: ...
 
 class NoReturn: pass

--- a/test-data/unit/lib-stub/mypy_extensions.pyi
+++ b/test-data/unit/lib-stub/mypy_extensions.pyi
@@ -1,6 +1,7 @@
 # NOTE: Requires fixtures/dict.pyi
 from typing import Dict, Type, TypeVar, Optional, Any, Generic, Mapping, NoReturn
 import sys
+import abc
 
 _T = TypeVar('_T')
 _U = TypeVar('_U')
@@ -20,7 +21,7 @@ def KwArg(type: _T = ...) -> _T: ...
 
 
 # Fallback type for all typed dicts (does not exist at runtime)
-class _TypedDict(Mapping[str, object]):
+class _TypedDict(Mapping[str, object], metaclass=abc.ABCMeta):
     def copy(self: _T) -> _T: ...
     # Using NoReturn so that only calls using the plugin hook can go through.
     def setdefault(self, k: NoReturn, default: object) -> object: ...


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/6286

There are no tricks, it mostly matches one-to-one the implementation of named tuples. There is however one temporary hack, that we will be able to remove when we merge analyzers. Currently type checker depends on l.h.s pointing to a (redundant) `Var` that is always created by the old analyzer.