### PR TITLE
New semantic analyzer: fix class derived from Tuple with __init__

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -947,7 +947,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
     def analyze_namedtuple_classdef(self, defn: ClassDef) -> bool:
         """Check if this class can define a named tuple."""
-        if defn.info and defn.info.tuple_type:
+        if defn.info and defn.info.is_named_tuple:
             # Don't reprocess everything. We just need to process methods defined
             # in the named tuple class body.
             is_named_tuple, info = True, defn.info  # type: bool, Optional[TypeInfo]

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1277,11 +1277,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         base_types = []  # type: List[Instance]
         info = defn.info
 
+        info.tuple_type = None
         for base, base_expr in bases:
             if isinstance(base, TupleType):
-                # There may be an existing valid tuple type from previous semanal iterations.
-                # Use equality to check if it is the case.
-                if info.tuple_type and info.tuple_type != base:
+                if info.tuple_type:
                     self.fail("Class has two incompatible bases derived from tuple", defn)
                     defn.has_incompatible_baseclass = True
                 info.tuple_type = base

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1636,3 +1636,10 @@ class Cls: ...  # E: Name 'Cls' already defined (possibly by an import)
 
 x: C
 class C: ...
+
+[case testNewAnalyzerTupleInit]
+from typing import Tuple
+
+c: C
+class C(Tuple[int, str]):
+    def __init__(self) -> None: pass

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1368,5 +1368,4 @@ reveal_type(x['test'][0])
 -- N.B: These errors are *wrong* and the new semantic analyzer can't yet
 -- fully analyze typeshed
 ast.pyi:31: error: Name 'PyCF_ONLY_AST' already defined (possibly by an import)
-codecs.pyi:49: error: Cannot overwrite NamedTuple attribute "__init__"
 _testNewAnalyzerBasicTypeshed_newsemanal.py:4: error: Revealed type is 'builtins.int*'


### PR DESCRIPTION
NamedTuple detection was incorrect.

Fixes #6446.
