### PR TITLE
Sync typeshed

### DIFF
--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1365,7 +1365,4 @@ from typing import Dict, List, Tuple
 x: Dict[str, List[int]]
 reveal_type(x['test'][0])
 [out]
--- N.B: These errors are *wrong* and the new semantic analyzer can't yet
--- fully analyze typeshed
-ast.pyi:31: error: Name 'PyCF_ONLY_AST' already defined (possibly by an import)
 _testNewAnalyzerBasicTypeshed_newsemanal.py:4: error: Revealed type is 'builtins.int*'


### PR DESCRIPTION
This fixes the remaining error from the builtins import cycle when using 
the new semantic analyzer.