### PR TITLE
New semantic analyzer: Support multiple assignments to underscore

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1938,8 +1938,9 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             # type checker will try to infer Any for the l.h.s.
             # Remove this after new analyzer is the default one!
             lvalue.fullname = self.qualified_name(name)
-            lvalue.node = self.make_name_lvalue_var(lvalue, self.current_symbol_kind(),
-                                                    inferred=True)
+            lvalue.is_inferred_def = True
+            lvalue.kind = kind = self.current_symbol_kind()
+            lvalue.node = self.make_name_lvalue_var(lvalue, kind, inferred=True)
         return True
 
     def analyze_lvalues(self, s: AssignmentStmt) -> None:
@@ -2315,11 +2316,19 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             added = self.add_symbol(name, var, lvalue)
             # Only bind expression if we successfully added name to symbol table.
             if added:
+                lvalue.is_new_def = True
+                lvalue.is_inferred_def = True
+                lvalue.kind = kind
                 lvalue.node = var
                 if kind == GDEF:
                     lvalue.fullname = var._fullname
                 else:
                     lvalue.fullname = lvalue.name
+                if self.is_func_scope():
+                    if unmangle(name) == '_':
+                        # Special case for assignment to local named '_': always infer 'Any'.
+                        typ = AnyType(TypeOfAny.special_form)
+                        self.store_declared_types(lvalue, typ)
             if is_final and self.is_final_redefinition(kind, name):
                 self.fail("Cannot redefine an existing name as final", lvalue)
         else:
@@ -2378,9 +2387,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             # fullanme should never stay None
             v._fullname = lvalue.name
         v.is_ready = False  # Type not inferred yet
-        lvalue.is_new_def = True
-        lvalue.is_inferred_def = True
-        lvalue.kind = kind
         return v
 
     def make_name_lvalue_point_to_existing_def(

--- a/mypy/test/hacks.py
+++ b/mypy/test/hacks.py
@@ -24,7 +24,6 @@ new_semanal_blacklist = [
     'check-incomplete-fixture.test',
     'check-incremental.test',
     'check-inference-context.test',
-    'check-inference.test',
     'check-isinstance.test',
     'check-literal.test',
     'check-modules.test',

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -432,6 +432,7 @@ def id(x: T) -> T:
 [out]
 
 [case testUnderspecifiedInferenceResult]
+# flags: --new-semantic-analyzer
 from typing import TypeVar
 T = TypeVar('T')
 class A: pass
@@ -439,7 +440,8 @@ a = None # type: A
 
 def ff() -> None:
     x = f() # E: Need type annotation for 'x'
-    reveal_type(x) # E: Revealed type is 'Any'
+    reveal_type(x) # E: Revealed type is 'Any' \
+                   # E: Cannot determine type of 'x'
 
 g(None) # Ok
 f()     # Ok because not used to infer local variable type
@@ -1045,7 +1047,7 @@ class B: pass
 [builtins fixtures/for.pyi]
 
 [case testReusingInferredForIndex2]
-# flags: --allow-redefinition
+# flags: --allow-redefinition --no-new-semantic-analyzer
 
 def f() -> None:
     for a in [A()]: pass
@@ -1550,7 +1552,9 @@ def add():
     map[1] = 2
 [builtins fixtures/dict.pyi]
 
+-- Depends on #6425
 [case testSpecialCaseEmptyListInitialization]
+# flags: --no-new-semantic-analyzer
 def f(blocks: Any): # E: Name 'Any' is not defined
     to_process = [] # E: Need type annotation for 'to_process'
     to_process = list(blocks)
@@ -2455,7 +2459,7 @@ _ = 0
 _ = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testUnusedTargetNotClass]
-# flags: --allow-redefinition
+# flags: --allow-redefinition --no-new-semantic-analyzer
 class C:
     _, _ = 0, 0
     _ = ''

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -432,7 +432,7 @@ def id(x: T) -> T:
 [out]
 
 [case testUnderspecifiedInferenceResult]
-# flags: --new-semantic-analyzer
+# flags: --new-semantic-analyzer --no-strict-optional
 from typing import TypeVar
 T = TypeVar('T')
 class A: pass


### PR DESCRIPTION
I also enable the existing test file with existing tests for this feature. I discovered a bug in `make_name_lvalue_var()` that caused some existing tests to fail, so I fixed it.

I skip three tests (they already have issues). I also updated one test case because the behavior is more consistent in new analyzer (it always shows `Cannot determine type`, while old one shows this error only at global scope).