### PR TITLE
New semantic analyzer: support class variables

### DIFF
--- a/mypy/newsemanal/semanal_abstract.py
+++ b/mypy/newsemanal/semanal_abstract.py
@@ -9,23 +9,6 @@ from mypy.nodes import Node, MypyFile, SymbolTable, TypeInfo, Var, Decorator, Ov
 from mypy.errors import Errors
 
 
-def calculate_abstract_status(file: MypyFile, errors: Errors) -> None:
-    """Calculate the abstract status of all classes in the symbol table in file.
-
-    Also check that ABCMeta is used correctly.
-    """
-    process(file.names, file.is_stub, file.fullname(), errors)
-
-
-def process(names: SymbolTable, is_stub_file: bool, prefix: str, errors: Errors) -> None:
-    for name, symnode in names.items():
-        node = symnode.node
-        if isinstance(node, TypeInfo) and node.fullname().startswith(prefix):
-            calculate_class_abstract_status(node, is_stub_file, errors)
-            new_prefix = prefix + '.' + node.name()
-            process(node.names, is_stub_file, new_prefix, errors)
-
-
 def calculate_class_abstract_status(typ: TypeInfo, is_stub_file: bool, errors: Errors) -> None:
     """Calculate abstract status of a class.
 

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -27,12 +27,13 @@ will be incomplete.
 from typing import List, Tuple, Optional, Union, Callable
 
 from mypy.nodes import (
-    Node, SymbolTable, SymbolNode, MypyFile, TypeInfo, FuncDef, Decorator, OverloadedFuncDef
+    Node, SymbolTable, SymbolNode, MypyFile, TypeInfo, FuncDef, Decorator, OverloadedFuncDef,
+    Var
 )
 from mypy.newsemanal.semanal_typeargs import TypeArgumentAnalyzer
 from mypy.state import strict_optional_set
 from mypy.newsemanal.semanal import NewSemanticAnalyzer, apply_semantic_analyzer_patches
-from mypy.newsemanal.semanal_abstract import calculate_abstract_status
+from mypy.newsemanal.semanal_abstract import calculate_class_abstract_status
 from mypy.errors import Errors
 from mypy.newsemanal.semanal_infer import infer_decorator_signature_if_simple
 
@@ -68,7 +69,7 @@ def semantic_analysis_for_scc(graph: 'Graph', scc: List[str], errors: Errors) ->
     apply_semantic_analyzer_patches(patches)
     # This pass might need fallbacks calculated above.
     check_type_arguments(graph, scc, errors)
-    process_abstract_status(graph, scc, errors)
+    calculate_class_properties(graph, scc, errors)
 
 
 def process_top_levels(graph: 'Graph', scc: List[str], patches: Patches) -> None:
@@ -119,8 +120,7 @@ def process_functions(graph: 'Graph', scc: List[str], patches: Patches) -> None:
         tree = graph[module].tree
         assert tree is not None
         analyzer = graph[module].manager.new_semantic_analyzer
-        symtable = tree.names
-        targets = get_all_leaf_targets(symtable, module, None)
+        targets = get_all_leaf_targets(tree)
         for target, node, active_type in targets:
             assert isinstance(node, (FuncDef, OverloadedFuncDef, Decorator))
             process_top_level_function(analyzer,
@@ -169,23 +169,12 @@ def process_top_level_function(analyzer: 'NewSemanticAnalyzer',
 TargetInfo = Tuple[str, Union[MypyFile, FuncDef, OverloadedFuncDef, Decorator], Optional[TypeInfo]]
 
 
-def get_all_leaf_targets(symtable: SymbolTable,
-                         prefix: str,
-                         active_type: Optional[TypeInfo]) -> List[TargetInfo]:
+def get_all_leaf_targets(file: MypyFile) -> List[TargetInfo]:
     """Return all leaf targets in a symbol table (module-level and methods)."""
     result = []  # type: List[TargetInfo]
-    for name, node in symtable.items():
-        shortname = name
-        if '-redef' in name:
-            # Restore original name from mangled name of multiply defined function
-            shortname = name.split('-redef')[0]
-        new_prefix = prefix + '.' + shortname
-        if isinstance(node.node, (FuncDef, TypeInfo, OverloadedFuncDef, Decorator)):
-            if node.node.fullname() == new_prefix:
-                if isinstance(node.node, TypeInfo):
-                    result += get_all_leaf_targets(node.node.names, new_prefix, node.node)
-                else:
-                    result.append((new_prefix, node.node, active_type))
+    for fullname, node, active_type in file.local_definitions():
+        if isinstance(node.node, (FuncDef, OverloadedFuncDef, Decorator)):
+            result.append((fullname, node.node, active_type))
     return result
 
 
@@ -230,8 +219,26 @@ def check_type_arguments(graph: 'Graph', scc: List[str], errors: Errors) -> None
                 state.tree.accept(analyzer)
 
 
-def process_abstract_status(graph: 'Graph', scc: List[str], errors: Errors) -> None:
+def calculate_class_properties(graph: 'Graph', scc: List[str], errors: Errors) -> None:
     for module in scc:
         tree = graph[module].tree
         assert tree
-        calculate_abstract_status(tree, errors)
+        for _, node, _ in tree.local_definitions():
+            if isinstance(node.node, TypeInfo):
+                calculate_class_abstract_status(node.node, tree.is_stub, errors)
+                calculate_class_vars(node.node)
+
+
+def calculate_class_vars(info: TypeInfo) -> None:
+    # Subclass attribute assignments with no type annotation should be
+    # assumed to be classvar if overriding a declared classvar from the base
+    # class.
+    for name, sym in info.names.items():
+        node = sym.node
+        if isinstance(node, Var) and node.info and node.is_inferred and not node.is_classvar:
+            for base in info.mro[1:]:
+                member = base.names.get(name)
+                if (member is not None
+                        and isinstance(member.node, Var)
+                        and member.node.is_classvar):
+                    node.is_classvar = True

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -33,7 +33,7 @@ from mypy.nodes import (
 from mypy.newsemanal.semanal_typeargs import TypeArgumentAnalyzer
 from mypy.state import strict_optional_set
 from mypy.newsemanal.semanal import NewSemanticAnalyzer, apply_semantic_analyzer_patches
-from mypy.newsemanal.semanal_abstract import calculate_class_abstract_status
+from mypy.newsemanal.semanal_classprop import calculate_class_abstract_status, calculate_class_vars
 from mypy.errors import Errors
 from mypy.newsemanal.semanal_infer import infer_decorator_signature_if_simple
 
@@ -227,18 +227,3 @@ def calculate_class_properties(graph: 'Graph', scc: List[str], errors: Errors) -
             if isinstance(node.node, TypeInfo):
                 calculate_class_abstract_status(node.node, tree.is_stub, errors)
                 calculate_class_vars(node.node)
-
-
-def calculate_class_vars(info: TypeInfo) -> None:
-    # Subclass attribute assignments with no type annotation should be
-    # assumed to be classvar if overriding a declared classvar from the base
-    # class.
-    for name, sym in info.names.items():
-        node = sym.node
-        if isinstance(node, Var) and node.info and node.is_inferred and not node.is_classvar:
-            for base in info.mro[1:]:
-                member = base.names.get(name)
-                if (member is not None
-                        and isinstance(member.node, Var)
-                        and member.node.is_classvar):
-                    node.is_classvar = True

--- a/mypy/newsemanal/semanal_pass3.py
+++ b/mypy/newsemanal/semanal_pass3.py
@@ -130,18 +130,6 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
                 self.analyze_types(types, analyzed)
         if isinstance(s.lvalues[0], RefExpr) and isinstance(s.lvalues[0].node, Var):
             self.analyze(s.lvalues[0].node.type, s.lvalues[0].node)
-        # Subclass attribute assignments with no type annotation should be
-        # assumed to be classvar if overriding a declared classvar from the base
-        # class.
-        if (isinstance(s.lvalues[0], NameExpr) and s.lvalues[0].kind == MDEF
-                and isinstance(s.lvalues[0].node, Var)):
-            var = s.lvalues[0].node
-            if var.info and var.is_inferred and not var.is_classvar:
-                for base in var.info.mro[1:]:
-                    tnode = base.names.get(var.name())
-                    if (tnode is not None and isinstance(tnode.node, Var)
-                            and tnode.node.is_classvar):
-                        var.is_classvar = True
         super().visit_assignment_stmt(s)
 
     # Helpers

--- a/mypy/test/hacks.py
+++ b/mypy/test/hacks.py
@@ -11,7 +11,6 @@ new_semanal_blacklist = [
     'check-bound.test',
     'check-callable.test',
     'check-classes.test',
-    'check-classvar.test',
     'check-custom-plugin.test',
     'check-dataclasses.test',
     'check-default-plugin.test',


### PR DESCRIPTION
This adds an additional simple pass over all classes that sets
`is_classvar` flags for class variables declared in base classes.

Also refactor to share code used for symbol table iteration.

Fixes #6451.