### PR TITLE
Fixing error message to match new typeshed stub

### DIFF
--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1054,7 +1054,7 @@ _testTypedDictGet.py:9: error: TypedDict "D" has no key 'z'
 _testTypedDictGet.py:10: error: All overload variants of "get" of "Mapping" require at least one argument
 _testTypedDictGet.py:10: note: Possible overload variants:
 _testTypedDictGet.py:10: note:     def get(self, k: str) -> object
-_testTypedDictGet.py:10: note:     def [_T] get(self, k: str, default: object) -> object
+_testTypedDictGet.py:10: note:     def [_T] get(self, k: str, default: _T) -> object
 _testTypedDictGet.py:12: error: Revealed type is 'builtins.object*'
 
 [case testTypedDictMappingMethods]


### PR DESCRIPTION
As requested from https://github.com/python/typeshed/pull/2810.  Not sure how to sync the typeshed commit if that one isn't merged yet.