### PR TITLE
Add flag to tag known messages with an error code (take 2)

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -341,11 +341,10 @@ def load_plugins(options: Options, errors: Errors) -> Tuple[Plugin, Dict[str, st
             raise
 
         try:
-            error_codes = {module_name + '-' + name: msg for name, msg in error_codes.items()}
+            errors.register_error_codes(module_name, error_codes)
         except Exception:
             plugin_error('Error processing result of get_error_codes ({})'.format(module_name))
             raise
-        errors.register_error_codes(error_codes)
 
     default_plugin = DefaultPlugin(options)  # type: Plugin
     load_plugin(default_plugin, 'mypy.plugins.default')

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -41,7 +41,7 @@ from mypy.newsemanal.semanal import NewSemanticAnalyzer
 from mypy.newsemanal.semanal_main import semantic_analysis_for_scc
 from mypy.checker import TypeChecker
 from mypy.indirection import TypeIndirectionVisitor
-from mypy.errors import Errors, CompileError, report_internal_error
+from mypy.errors import Errors, CompileError, report_internal_error, initialize_error_codes
 from mypy.util import DecodeError, decode_python_encoding, is_sub_path
 if MYPY:
     from mypy.report import Reports  # Avoid unconditional slow import
@@ -59,7 +59,6 @@ from mypy.plugins.default import DefaultPlugin
 from mypy.fscache import FileSystemCache
 from mypy.metastore import MetadataStore, FilesystemMetadataStore, SqliteMetadataStore
 from mypy.typestate import TypeState, reset_global_state
-
 from mypy.mypyc_hacks import BuildManagerBase
 
 
@@ -194,8 +193,11 @@ def _build(sources: List[BuildSource],
         reports = Reports(data_dir, options.report_dirs)
 
     source_set = BuildSourceSet(sources)
-    errors = Errors(options.show_error_context, options.show_column_numbers)
+    errors = Errors(options.show_error_context, options.show_column_numbers,
+                    options.show_error_codes)
     plugin, snapshot = load_plugins(options, errors)
+
+    initialize_error_codes(errors, plugin)
 
     # Construct a build manager object to hold state during the build.
     #

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -314,6 +314,7 @@ class Server:
             return {'out': '', 'err': str(err), 'status': 2}
         except SystemExit as e:
             return {'out': stdout.getvalue(), 'err': stderr.getvalue(), 'status': e.code}
+        assert sources is not None
         return self.check(sources)
 
     def cmd_check(self, files: Sequence[str]) -> Dict[str, object]:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -551,14 +551,15 @@ class Errors:
             i += 1
         return res
 
-    def register_error_codes(self, mapping: Dict[str, str]) -> None:
+    def register_error_codes(self, namespace: str, error_codes: Dict[str, str]) -> None:
         """Add error codes and their message literals to the list of known errors.
 
         Args:
-            mapping: map of error code to message literal
+            namespace: used to indentify the source of the error code (usually a plugin)
+            error_codes: map of error code to message literal
         """
         # reverse the lookup
-        updates = {msg: name for name, msg in mapping.items()}
+        updates = {msg: namespace + ':' + name for name, msg in error_codes.items()}
         # FIXME: check for name clashes
         self.error_codes.update(updates)
 
@@ -567,7 +568,7 @@ class Errors:
         from mypy.plugins.common import extract_error_codes
         import mypy.message_registry
         # read native error codes from the message registry
-        self.register_error_codes(extract_error_codes(mypy.message_registry))
+        self.register_error_codes('mypy', extract_error_codes(mypy.message_registry))
 
 
 class CompileError(Exception):

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -392,7 +392,8 @@ class Errors:
                     srcloc = file
                 if self.show_error_codes:
                     s = '{}: {}: {}: {}'.format(srcloc, severity,
-                                                id if id is not None else 'unknown', message)
+                                                id if id is not None else 'uncategorized_error',
+                                                message)
                 else:
                     s = '{}: {}: {}'.format(srcloc, severity, message)
             else:

--- a/mypy/interpreted_plugin.py
+++ b/mypy/interpreted_plugin.py
@@ -35,6 +35,9 @@ class InterpretedPlugin:
     def set_modules(self, modules: Dict[str, MypyFile]) -> None:
         self._modules = modules
 
+    def get_error_codes(self) -> Dict[str, str]:
+        return {}
+
     def lookup_fully_qualified(self, fullname: str) -> Optional[SymbolTableNode]:
         assert self._modules is not None
         return lookup_fully_qualified(fullname, self._modules)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -720,10 +720,11 @@ def process_options(args: List[str],
     if dummy.list_error_codes:
         import mypy.errors
         errors = mypy.errors.Errors()
+        errors.initialize_error_codes()
         plugin, _ = build.load_plugins(options, errors)
-        mypy.errors.initialize_error_codes(errors, plugin)
-        for msg_id in sorted(errors.error_codes.id_to_literal):
-            print('%s  %r' % (msg_id, errors.error_codes.id_to_literal[msg_id]))
+        error_codes = {code: msg for msg, code in errors.error_codes.items()}
+        for code in sorted(error_codes):
+            print('%s  %r' % (code, error_codes[code]))
         return None, options
 
     config_file = dummy.config_file

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -112,19 +112,14 @@ class MessageBuilder:
 
     def report(self, msg: str, format_args: Tuple[Any, ...], context: Optional[Context],
                severity: str, file: Optional[str] = None, origin: Optional[Context] = None,
-               offset: int = 0, id: Optional[str] = None) -> None:
+               offset: int = 0) -> None:
         """Report an error or note (unless disabled)."""
         if self.disable_count <= 0:
-            msg_id = id
-            if msg_id is None:
-                msg_id = self.errors.error_codes.get(msg)
-            if format_args:
-                msg = msg.format(*format_args)
             self.errors.report(context.get_line() if context else -1,
                                context.get_column() if context else -1,
                                msg, severity=severity, file=file, offset=offset,
                                origin_line=origin.get_line() if origin else None,
-                               id=msg_id)
+                               format_args=format_args)
 
     def fail(self, msg: str, context: Optional[Context], file: Optional[str] = None,
              origin: Optional[Context] = None) -> None:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -39,8 +39,6 @@ MYPY = False
 if MYPY:
     from typing_extensions import Final
 
-T = TypeVar('T', bound=Callable[..., Any])
-
 ARG_CONSTRUCTOR_NAMES = {
     ARG_POS: "Arg",
     ARG_OPT: "DefaultArg",
@@ -119,7 +117,7 @@ class MessageBuilder:
         if self.disable_count <= 0:
             msg_id = id
             if msg_id is None:
-                msg_id = self.errors.error_codes.literal_to_id.get(msg)
+                msg_id = self.errors.error_codes.get(msg)
             if format_args:
                 msg = msg.format(*format_args)
             self.errors.report(context.get_line() if context else -1,

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -225,7 +225,7 @@ class Options:
         # -- experimental options --
         self.shadow_file = None  # type: Optional[List[List[str]]]
         self.show_column_numbers = False  # type: bool
-        self.show_error_codes = False  # type: bool
+        self.show_error_codes = False
         self.dump_graph = False
         self.dump_deps = False
         self.logical_deps = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -225,6 +225,7 @@ class Options:
         # -- experimental options --
         self.shadow_file = None  # type: Optional[List[List[str]]]
         self.show_column_numbers = False  # type: bool
+        self.show_error_codes = False  # type: bool
         self.dump_graph = False
         self.dump_deps = False
         self.logical_deps = False

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -358,7 +358,7 @@ class Plugin(CommonPluginApi):
         self._modules = modules
 
     def get_error_codes(self) -> Dict[str, str]:
-        """Return mapping of error code names to error messages"""
+        """Register error code names to error messages"""
         return {}
 
     def lookup_fully_qualified(self, fullname: str) -> Optional[SymbolTableNode]:
@@ -622,12 +622,6 @@ class ChainedPlugin(Plugin):
     def set_modules(self, modules: Dict[str, MypyFile]) -> None:
         for plugin in self._plugins:
             plugin.set_modules(modules)
-
-    def get_error_codes(self) -> Dict[str, str]:
-        results = {}
-        for plugin in self._plugins:
-            results.update(plugin.get_error_codes())
-        return results
 
     def get_type_analyze_hook(self, fullname: str
                               ) -> Optional[Callable[[AnalyzeTypeContext], Type]]:

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -357,6 +357,10 @@ class Plugin(CommonPluginApi):
     def set_modules(self, modules: Dict[str, MypyFile]) -> None:
         self._modules = modules
 
+    def get_error_codes(self) -> Dict[str, str]:
+        """Return mapping of error code names to error messages"""
+        return {}
+
     def lookup_fully_qualified(self, fullname: str) -> Optional[SymbolTableNode]:
         assert self._modules is not None
         return lookup_fully_qualified(fullname, self._modules)
@@ -548,6 +552,9 @@ class WrapperPlugin(Plugin):
     def set_modules(self, modules: Dict[str, MypyFile]) -> None:
         self.plugin.set_modules(modules)
 
+    def get_error_codes(self) -> Dict[str, str]:
+        return self.plugin.get_error_codes()
+
     def lookup_fully_qualified(self, fullname: str) -> Optional[SymbolTableNode]:
         return self.plugin.lookup_fully_qualified(fullname)
 
@@ -615,6 +622,12 @@ class ChainedPlugin(Plugin):
     def set_modules(self, modules: Dict[str, MypyFile]) -> None:
         for plugin in self._plugins:
             plugin.set_modules(modules)
+
+    def get_error_codes(self) -> Dict[str, str]:
+        results = {}
+        for plugin in self._plugins:
+            results.update(plugin.get_error_codes())
+        return results
 
     def get_type_analyze_hook(self, fullname: str
                               ) -> Optional[Callable[[AnalyzeTypeContext], Type]]:

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -1,5 +1,3 @@
-import re
-
 from typing import List, Optional, Any, Dict
 
 from mypy.nodes import (
@@ -10,8 +8,6 @@ from mypy.plugin import ClassDefContext
 from mypy.semanal import set_callable_name
 from mypy.types import CallableType, Overloaded, Type, TypeVarDef, LiteralType, Instance
 from mypy.typevars import fill_typevars
-
-VALID_ERROR_CODE = re.compile('[a-z0-9_]+$')
 
 
 def _get_decorator_bool_argument(
@@ -135,23 +131,13 @@ def try_getting_str_literal(expr: Expression, typ: Type) -> Optional[str]:
         return None
 
 
-def extract_error_codes(namespace: str, obj: Any) -> Dict[str, str]:
-    """Read error code attributes from an object.
-
+def extract_error_codes(obj: Any) -> Dict[str, str]:
+    """
     Any attribute of obj that is all caps (i.e. a constant) and holds a string is considered
     an error code.
 
     Arguments:
-      namespace: a prefix to be added to all error code names.  This is usually the name of the
-                 plugin that is calling this function.
       obj: object from which to read error codes.
     """
-    if namespace:
-        if not namespace.endswith('_'):
-            namespace += '_'
-        namespace = namespace.lower()
-        if not VALID_ERROR_CODE.match(namespace):
-            raise RuntimeError("Error namespace must contain only letters, "
-                               "numbers, and underscores")
-    return {namespace + name.lower(): msg for name, msg in vars(obj).items()
+    return {name.lower(): msg for name, msg in vars(obj).items()
             if name.upper() and not name.startswith('_') and isinstance(msg, str)}

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -1,4 +1,6 @@
-from typing import List, Optional, Any
+import re
+
+from typing import List, Optional, Any, Dict
 
 from mypy.nodes import (
     ARG_POS, MDEF, Argument, Block, CallExpr, Expression, FuncBase,
@@ -8,6 +10,8 @@ from mypy.plugin import ClassDefContext
 from mypy.semanal import set_callable_name
 from mypy.types import CallableType, Overloaded, Type, TypeVarDef, LiteralType, Instance
 from mypy.typevars import fill_typevars
+
+VALID_ERROR_CODE = re.compile('[a-z0-9_]+$')
 
 
 def _get_decorator_bool_argument(
@@ -129,3 +133,25 @@ def try_getting_str_literal(expr: Expression, typ: Type) -> Optional[str]:
         return expr.value
     else:
         return None
+
+
+def extract_error_codes(namespace: str, obj: Any) -> Dict[str, str]:
+    """Read error code attributes from an object.
+
+    Any attribute of obj that is all caps (i.e. a constant) and holds a string is considered
+    an error code.
+
+    Arguments:
+      namespace: a prefix to be added to all error code names.  This is usually the name of the
+                 plugin that is calling this function.
+      obj: object from which to read error codes.
+    """
+    if namespace:
+        if not namespace.endswith('_'):
+            namespace += '_'
+        namespace = namespace.lower()
+        if not VALID_ERROR_CODE.match(namespace):
+            raise RuntimeError("Error namespace must contain only letters, "
+                               "numbers, and underscores")
+    return {namespace + name.lower(): msg for name, msg in vars(obj).items()
+            if name.upper() and not name.startswith('_') and isinstance(msg, str)}

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -94,8 +94,7 @@ class DefaultPlugin(Plugin):
 
     def get_error_codes(self) -> Dict[str, str]:
         from mypy.plugins import attrs
-        error_codes = extract_error_codes('attrs', attrs.Errors)
-        return error_codes
+        return extract_error_codes(attrs.Errors)
 
 
 def open_callback(ctx: FunctionContext) -> Type:

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -1,12 +1,12 @@
 from functools import partial
-from typing import Callable, Optional
+from typing import Callable, Optional, Dict
 
 from mypy import message_registry
 from mypy.nodes import StrExpr, IntExpr, DictExpr, UnaryExpr
 from mypy.plugin import (
     Plugin, FunctionContext, MethodContext, MethodSigContext, AttributeContext, ClassDefContext
 )
-from mypy.plugins.common import try_getting_str_literal
+from mypy.plugins.common import try_getting_str_literal, extract_error_codes
 from mypy.types import (
     Type, Instance, AnyType, TypeOfAny, CallableType, NoneTyp, UnionType, TypedDictType,
     TypeVarType
@@ -91,6 +91,11 @@ class DefaultPlugin(Plugin):
         elif fullname in dataclasses.dataclass_makers:
             return dataclasses.dataclass_class_maker_callback
         return None
+
+    def get_error_codes(self) -> Dict[str, str]:
+        from mypy.plugins import attrs
+        error_codes = extract_error_codes('attrs', attrs.Errors)
+        return error_codes
 
 
 def open_callback(ctx: FunctionContext) -> Type:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -83,6 +83,7 @@ typecheck_files = [
     'check-redefine.test',
     'check-literal.test',
     'check-newsemanal.test',
+    'check-error-codes.test',
 ]
 
 

--- a/test-data/unit/check-error-codes.test
+++ b/test-data/unit/check-error-codes.test
@@ -1,0 +1,21 @@
+[case testErrorCodesAssignToMethodViaClass]
+# flags: --no-strict-optional --show-error-codes
+import typing
+class A:
+    def f(self): pass
+A.f = None # E: cannot_assign_to_method: Cannot assign to a method
+
+[case testErrorCodesNoReturnValueExpected]
+# flags: --no-strict-optional --show-error-codes
+from typing import Generator
+def f() -> Generator[int, None, None]:
+    yield 1
+    return 42  # E: no_return_value_expected: No return value expected
+[out]
+
+[case testErrorCodesIncompatibleTypevar]
+# flags: --no-strict-optional --show-error-codes
+from typing import TypeVar, Union
+AnyStr = TypeVar('AnyStr', bytes, str)
+def f(x: Union[AnyStr, int], *a: AnyStr) -> None: pass
+f('foo', b'bar') # E: incompatible_typevar_value: Value of type variable "AnyStr" of "f" cannot be "object"

--- a/test-data/unit/check-error-codes.test
+++ b/test-data/unit/check-error-codes.test
@@ -3,14 +3,14 @@
 import typing
 class A:
     def f(self): pass
-A.f = None # E: cannot_assign_to_method: Cannot assign to a method
+A.f = None # E: mypy:cannot_assign_to_method: Cannot assign to a method
 
 [case testErrorCodesNoReturnValueExpected]
 # flags: --no-strict-optional --show-error-codes
 from typing import Generator
 def f() -> Generator[int, None, None]:
     yield 1
-    return 42  # E: no_return_value_expected: No return value expected
+    return 42  # E: mypy:no_return_value_expected: No return value expected
 [out]
 
 [case testErrorCodesIncompatibleTypevar]
@@ -18,4 +18,4 @@ def f() -> Generator[int, None, None]:
 from typing import TypeVar, Union
 AnyStr = TypeVar('AnyStr', bytes, str)
 def f(x: Union[AnyStr, int], *a: AnyStr) -> None: pass
-f('foo', b'bar') # E: incompatible_typevar_value: Value of type variable "AnyStr" of "f" cannot be "object"
+f('foo', b'bar') # E: mypy:incompatible_typevar_value: Value of type variable "AnyStr" of "f" cannot be "object"


### PR DESCRIPTION
Hi all,
I'm back with a new PR to replace #6152.  I've tried to get satisfactory answers to the great questions that @JukkaL and @ilevkivskyi  posed in the last PR, which I've reposted below with answers:

> * How are new static messages defined?

This has been partially addressed by #6194, by moving many message constants to `mypy.message_registry`, however, we have a lot more to move.

> * How are new runtime constructed messages defined?

Also in `mypy.message_registry`.  String format args must be passed to `fail()` methods rather than formatting first, in order to preserve the message constant until it reaches `MessageBuilder`, so that an id can be looked up from the string literal.  I haven't made that change throughout the code yet since it will be a lot of repetitive work and I wanted to get some feedback on the design of this PR first.   That means in its current form, registered messages that are pre-formatted before being passed to `fail()` are still being marked as 'uncategorized_error' in mypy output.

> * What would the error message ids look like in mypy output or in the config file (give examples for a few common messages)?

For output examples, you can see some examples in `check-error-codes.txt`. 

Silencing error messages via a config file has been discussed [here](https://github.com/python/mypy/issues/2417#issuecomment-450581643) and [here](https://github.com/python/mypy/issues/2417#issuecomment-450851006).  This PR sets up all of the data necessary to implement filtering and the semantics of configuration and filtering messages can be solved in a separate PR.
 
> * How would the message ids be shown in mypy output?

I'm assuming this is about listing message ids.  This is not in the tests yet, but here's an example of what it looks like:

```
$ mypy --list-error-codes
mypy.plugins.default:auto_attrib_unsupported  'auto_attribs is not supported in Python 2'
mypy.plugins.default:cannot_determine_init_from_converter  'Cannot determine __init__ type from converter'
mypy.plugins.default:cant_pass_convert_and_converter  "Can't pass both `convert` and `converter`."
mypy.plugins.default:cant_pass_default_and_factory  "Can't pass both `default` and `factory`."
mypy.plugins.default:convert_is_deprecated  'convert is deprecated, use converter'
mypy.plugins.default:invalid_arg_to_type  'Invalid argument to type'
mypy.plugins.default:kw_only_unsupported  'kw_only is not supported in Python 2'
mypy.plugins.default:non_default_attr_not_allowed_after_default  'Non-default attributes not allowed after default attributes.'
mypy.plugins.default:non_kw_only_attr_not_allowed_after_kw_only  'Non keyword-only attributes are not allowed after a keyword-only attribute.'
mypy.plugins.default:old_style_classes_unsupported  'attrs only works with new-style classes'
mypy.plugins.default:too_many_names_for_attr  'Too many names for one attribute'
mypy.plugins.default:unsupported_converter  'Unsupported converter, only named functions and types are currently supported'
mypy:all_must_be_seq_str  'Type of __all__ must be {}, not {}'
mypy:argument_type_expected  'Function is missing a type annotation for one or more arguments'
mypy:bare_generic  'Missing type parameters for generic type'
mypy:cannot_access_final_instance_attr  'Cannot access final instance attribute "{}" on class object'
mypy:cannot_access_init  'Cannot access "__init__" directly'
...
```

> * At what granularity should the message ids be (i.e., should we group similar messages under one id)?

This is a great question.  My current thinking is that message grouping can be added using a separate dictionary at a later point.

> * How well does this the approach work with mypyc? In particular, mypyc is bad at compiling certain Python idioms such as decorated methods and enums. We should perhaps either use those idioms sparingly or first improve how mypyc handles them. This can be important since there are many error messages, so whatever approach we choose it will probably have many instances in the code.

I've simplified my approach from the original PR, so I think we should be in the clear, but I have not run any tests against mypyc yet.

> * How can user plugins define new error messages?

I provided an example for `attrs`, and if we like it I can propagate it to the other builtin plugins.  
That said, since I'm using the plugin module as a unique namespace to prefix the error codes,  this PR would benefit from the default plugin being broken up into a series of plugins: `mypy.plugins.attrs`, `mypy.plugins.ctypes`, and `mypy.plugins.dataclasses`.  

In addition to improving error labels for this PR, breaking up the default plugin has some other advantages: 
- it's more intuitive in general
- it will make it easier for these plugins to be migrated into their respective projects (thinking especially of `attrs` here)

If you agree, I'm happy to do that in a separate PR.

> * Do we need to do something to avoid conflicts between different plugins (e.g. both define a similar message)?

Covered above: the name of the plugin module is used.  For the core error codes I use the namespace 'mypy'.  

I decided to provide a default namespace for 3 reasons:
- better sorting of messages in `--list-error-codes`
- consistent number of `:` in mypy output with `--show-error-codes` makes for easier parsing by 3rd party scripts
- we may decide we want to breakup the core error codes into phases, such as `mypy.parse` `mypy.analysis`, `mypy.check`, etc. 

> * Does the proposed approach slow down mypy startup? This is probably not an issue, but in case we construct some complex data structures this might plausibly have a measurable effect.

TBD

