### PR TITLE
getting started guide refers to non-existant switch 

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -104,7 +104,7 @@ when you are prototyping a new feature, it may be convenient to initially implem
 the code using dynamic typing and only add type hints later once the code is more stable.
 
 Once you are finished migrating or prototyping your code, you can make mypy warn you
-if you add a dynamic function by mistake by using the ``--disallow-unchecked-defs``
+if you add a dynamic function by mistake by using the ``--disallow-untyped-defs``
 flag. See :ref:`command-line` for more information on configuring mypy.
 
 .. note::


### PR DESCRIPTION
There's a minor typo in the "Getting started" page where the switch `--disallow-unchecked-defs` is mentioned, but using this results in an error saying it's an unrecognized argument. I'm just getting started with the project personally, but I believe this should instead be `--disallow-untyped-defs`