### PR TITLE
New semantic analyzer: Report undefined names in function types

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -543,8 +543,9 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 analyzer = self.type_analyzer()
                 tag = self.track_incomplete_refs()
                 result = analyzer.visit_callable_type(defn.type, nested=False)
-                if not self.found_incomplete_ref(tag):
-                    defn.type = result
+                if self.found_incomplete_ref(tag):
+                    return
+                defn.type = result
                 self.add_type_alias_deps(analyzer.aliases_used)
                 self.check_function_signature(defn)
                 if isinstance(defn, FuncDef):

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -541,7 +541,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 # Signature must be analyzed in the surrounding scope so that
                 # class-level imported names and type variables are in scope.
                 analyzer = self.type_analyzer()
-                defn.type = analyzer.visit_callable_type(defn.type, nested=False)
+                tag = self.track_incomplete_refs()
+                result = analyzer.visit_callable_type(defn.type, nested=False)
+                if not self.found_incomplete_ref(tag):
+                    defn.type = result
                 self.add_type_alias_deps(analyzer.aliases_used)
                 self.check_function_signature(defn)
                 if isinstance(defn, FuncDef):

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1702,3 +1702,7 @@ from typing import Tuple
 c: C
 class C(Tuple[int, str]):
     def __init__(self) -> None: pass
+
+[case testNewAnalyzerFunctionError]
+def f(x: asdf) -> None:  # E: Name 'asdf' is not defined
+    pass


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/6425

The idea is straightforward (and the same as for assignments), don't store analyzed type if there are incomplete refs encountered.

Daemon support is blocked on this since we depend on reprocessing targets with errors.