### PR TITLE
join constraints with Any when constraints are in same shape

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -183,7 +183,9 @@ def any_constraints(options: List[Optional[List[Constraint]]], eager: bool) -> L
         #       every option, combine the bounds with meet/join.
         elif all(len(option) == len(valid_options[0]) for option in valid_options[1:]):
             # same length, more shape check below
-            to_join_constraint_group = [list(c_t) for c_t in zip(*valid_options)]  # type: List[List[Constraint]]
+            to_join_constraint_group = [
+                list(c_t) for c_t in zip(*valid_options)
+            ]  # type: List[List[Constraint]]
             joined_constraints = []  # type: List[Constraint]
             for to_join_constraint_list in to_join_constraint_group:
                 if any(
@@ -195,7 +197,6 @@ def any_constraints(options: List[Optional[List[Constraint]]], eager: bool) -> L
                 joined_constraints.append(to_join_constraint_list[0])
                 if not all(is_same_constraint(to_join_constraint_list[0], c)
                            for c in to_join_constraint_list[1:]):
-                    # Multiple sets of constraints that are all the same. Just pick any one of them.
                     joined_constraints[-1].target = AnyType(TypeOfAny.explicit)
             else:
                 # not break from loop

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -990,3 +990,23 @@ def union_test3():
     return x + 1
 
 [builtins fixtures/isinstancelist.pyi]
+
+[case testUninhabitedUnionDict]
+from typing import Any, Union, List
+
+def tl(t: Union[List[int], List[str]]):
+    reveal_type(t) # E: Revealed type is 'Union[builtins.list[builtins.int], builtins.list[builtins.str]]'
+
+tl([])
+
+[builtins fixtures/list.pyi]
+
+[case testUninhabitedUnionList]
+from typing import Any, Dict, Union
+
+def td(t: Union[Dict[int, Any], Dict[str, Any]]):
+    reveal_type(t) # E: Revealed type is 'Union[builtins.dict[builtins.int, Any], builtins.dict[builtins.str, Any]]'
+
+td({})
+
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fix [#6463](https://github.com/python/mypy/issues/6463), [#2164](https://github.com/python/mypy/issues/2164) by join Union with same shape with `Any`, for example, `Union[List[int], List[str]]` -> `List[Any]`, I use `Any` because `List[Union[str, int]]` is obviously wrong.

according to [this](https://github.com/python/mypy/issues/3283#issuecomment-298689038), 
> * Infer `Union[List[int], List[str]]` for the type of `[]`. This might be tricky to implement -- basically we'd need to support multiple possible answers from type inference, whereas currently we assume there's just one.

another way to fix that issue is to adjust `any_constraints` and `solve_constraints` to solve Union on any position of a type, currently it seems to work only on the 'leaf node'.

I'm not sure if this is a proper way to fix that, please have a look at your convenience.