### PR TITLE
New semantic analyzer: Sync aststrip with analyze_member_lvalue()

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2520,6 +2520,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     v._fullname = self.qualified_name(lval.name)
                     v.info = self.type
                     v.is_ready = False
+                    v.explicit_self_type = explicit_type or is_final
                     lval.def_var = v
                     lval.node = v
                     # TODO: should we also set lval.kind = MDEF?

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -748,7 +748,8 @@ class Decorator(SymbolNode, Statement):
 VAR_FLAGS = [
     'is_self', 'is_initialized_in_class', 'is_staticmethod',
     'is_classmethod', 'is_property', 'is_settable_property', 'is_suppressed_import',
-    'is_classvar', 'is_abstract_var', 'is_final', 'final_unset_in_class', 'final_set_in_init'
+    'is_classvar', 'is_abstract_var', 'is_final', 'final_unset_in_class', 'final_set_in_init',
+    'explicit_self_type',
 ]  # type: Final
 
 
@@ -777,6 +778,7 @@ class Var(SymbolNode):
                  'final_unset_in_class',
                  'final_set_in_init',
                  'is_suppressed_import',
+                 'explicit_self_type'
                  )
 
     def __init__(self, name: str, type: 'Optional[mypy.types.Type]' = None) -> None:
@@ -811,6 +813,14 @@ class Var(SymbolNode):
         # Where the value was set (only for class attributes)
         self.final_unset_in_class = False
         self.final_set_in_init = False
+        # This is True for a variable that was declared on self with an explicit type:
+        #     class C:
+        #         def __init__(self) -> None:
+        #             self.x: int
+        # This case is important because this defines a new Var, even if there is one
+        # present in a superclass (without explict type this doesn't create a new Var).
+        # See SemanticAnalyzer.analyze_member_lvalue() for details.
+        self.explicit_self_type = False
 
     def name(self) -> str:
         return self._name

--- a/mypy/server/aststripnew.py
+++ b/mypy/server/aststripnew.py
@@ -86,6 +86,7 @@ class NodeStripVisitor(TraverserVisitor):
         for name, sym in node.info.names.items():
             if isinstance(sym.node, Var) and sym.implicit:
                 explicit_self_type = sym.node.explicit_self_type
+
                 def patch() -> None:
                     existing = node.info.get(name)
                     current_existing = node.info.names.get(name)

--- a/mypy/server/aststripnew.py
+++ b/mypy/server/aststripnew.py
@@ -85,13 +85,15 @@ class NodeStripVisitor(TraverserVisitor):
         """Produce callbacks that re-add attributes defined on self."""
         for name, sym in node.info.names.items():
             if isinstance(sym.node, Var) and sym.implicit:
+                explicit_self_type = sym.node.explicit_self_type
                 def patch() -> None:
                     existing = node.info.get(name)
+                    current_existing = node.info.names.get(name)
                     # This needs to mimic the logic in SemanticAnalyzer.analyze_member_lvalue()
                     # regarding the existing variable in class body or in a superclass.
-                    # TODO: copy the logic better (always create a Var if there is explicit type)
-                    if (not existing or
-                            isinstance(existing.node, Var) and existing.node.is_abstract_var):
+                    if (existing is None or
+                            isinstance(existing.node, Var) and existing.node.is_abstract_var or
+                            current_existing is None and explicit_self_type):
                         node.info.names[name] = sym
 
                 self.patches.append(patch)

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -940,9 +940,7 @@ def reprocess_nodes(manager: BuildManager,
     if not options.new_semantic_analyzer:
         re_analyze_nodes(file_node, nodes, manager, options)
     else:
-        process_selected_targets(graph[module_id], nodes, graph)
-        for patch in patches:
-            patch()
+        process_selected_targets(graph[module_id], nodes, graph, patches)
     # Merge symbol tables to preserve identities of AST nodes. The file node will remain
     # the same, but other nodes may have been recreated with different identities, such as
     # NamedTuples defined using assignment statements.

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8711,11 +8711,6 @@ from b import B
 
 B().x
 
-[file a.py.3]
-from b import B
-
-x = B().x
-
 [file b.py]
 from c import f
 f(int())
@@ -8734,6 +8729,14 @@ def f(x: int) -> None: ...
 from typing import Union
 def f(x: Union[int, str]) -> None: ...
 
+[file a.py.3]
+from b import B
+
+# Double-check the variable is still accessible.
+B().x
+
+[targets2 c, b]
+[targets3 a]
 [out]
 ==
 ==

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8673,3 +8673,37 @@ def f(x: Union[int, str]) -> None: ...
 [out]
 ==
 ==
+
+[case testReprocessModuleTopLevelWhileMethodDefinesAttrExplicit]
+import a
+[file a.py]
+from b import B
+
+B().x
+
+[file a.py.3]
+from b import B
+
+x = B().x
+
+[file b.py]
+from c import f
+f(int())
+
+class A:
+    x: int
+
+class B(A):
+    def meth(self) -> None:
+        self.x: int
+
+[file c.py]
+def f(x: int) -> None: ...
+
+[file c.py.2]
+from typing import Union
+def f(x: Union[int, str]) -> None: ...
+
+[out]
+==
+==

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8740,3 +8740,79 @@ B().x
 [out]
 ==
 ==
+
+[case testReprocessModuleTopLevelWhileMethodDefinesAttrBothExplicitAndInClass]
+import a
+[file a.py]
+from b import B
+
+B().x
+
+[file b.py]
+from c import f
+f(int())
+
+class A:
+    x: int
+
+class B(A):
+    x: int
+    def meth(self) -> None:
+        self.x: int
+
+[file c.py]
+def f(x: int) -> None: ...
+
+[file c.py.2]
+from typing import Union
+def f(x: Union[int, str]) -> None: ...
+
+[file a.py.3]
+from b import B
+
+# Double-check the variable is still accessible.
+B().x
+
+[targets2 c, b]
+[targets3 a]
+[out]
+==
+==
+
+[case testReprocessModuleTopLevelWhileMethodDefinesAttrProtocol]
+import a
+[file a.py]
+from b import B
+
+B().x
+
+[file b.py]
+from typing import Protocol
+from c import f
+f(int())
+
+class A(Protocol):
+    x: int
+
+class B(A):
+    def meth(self) -> None:
+        self.x = 42
+
+[file c.py]
+def f(x: int) -> None: ...
+
+[file c.py.2]
+from typing import Union
+def f(x: Union[int, str]) -> None: ...
+
+[file a.py.3]
+from b import B
+
+# Double-check the variable is still accessible.
+B().x
+
+[targets2 c, b]
+[targets3 a]
+[out]
+==
+==


### PR DESCRIPTION
This is a follow-up for #6488 

The test I added is already good, because it crashes without the fix. When https://github.com/python/mypy/pull/6500 is merged I will add a check that only necessary targets are processed.