### PR TITLE
Add a mention of mypy playground to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ programs, even if they have type errors:
 
     $ python3 PROGRAM
 
+You can also try mypy in an [online playground](https://mypy-play.net/) (developed by
+Yusuke Miyazaki).
+
 [statically typed parts]: http://mypy.readthedocs.io/en/latest/basics.html#function-signatures
 
 


### PR DESCRIPTION
The playground is quite convenient for quick experimentation and gist sharing. I have been using it sometimes. It makes sense to add a link to README.