### PR TITLE
Fix dataclass plugin to work with new semantic analyzer

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -253,6 +253,15 @@ class SemanticAnalyzerPluginInterface:
         """Make qualified name using current module and enclosing class (if any)."""
         raise NotImplementedError
 
+    @abstractmethod
+    def defer(self) -> None:
+        """Call this to defer the processing of the current node.
+
+        This will request an additional iteration of semantic analysis.
+        Only available with new semantic analyzer.
+        """
+        raise NotImplementedError
+
 
 # A context for a function hook that infers the return type of a function with
 # a special signature.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3818,6 +3818,10 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         else:
             self.globals[name] = stnode
 
+    def defer(self) -> None:
+        assert not self.options.new_semantic_analyzer
+        raise NotImplementedError('This is only available with --new-semantic-analyzer')
+
 
 def replace_implicit_first_type(sig: FunctionLike, new: Type) -> FunctionLike:
     if isinstance(sig, CallableType):

--- a/mypy/test/hacks.py
+++ b/mypy/test/hacks.py
@@ -9,8 +9,6 @@ if MYPY:
 new_semanal_blacklist = [
     'check-async-await.test',
     'check-classes.test',
-    'check-custom-plugin.test',
-    'check-dataclasses.test',
     'check-enum.test',
     'check-expressions.test',
     'check-flags.test',

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -491,16 +491,18 @@ class Instr(Generic[T]): ...
 plugins=<ROOT>/test-data/unit/plugins/dyn_class.py
 
 [case testDynamicClassPluginNegatives]
-# flags: --config-file tmp/mypy.ini
+# flags: --new-semantic-analyzer --config-file tmp/mypy.ini
 from mod import declarative_base, Column, Instr, non_declarative_base
 
 Bad1 = non_declarative_base()
 Bad2 = Bad3 = declarative_base()
 
-class C1(Bad1): ...  # E: Invalid base class
-class C2(Bad2): ...  # E: Invalid base class
-class C3(Bad3): ...  # E: Invalid base class
-
+class C1(Bad1): ...  # E: Invalid base class \
+                     # E: Invalid type "__main__.Bad1"
+class C2(Bad2): ...  # E: Invalid base class \
+                     # E: Invalid type "__main__.Bad2"
+class C3(Bad3): ...  # E: Invalid base class \
+                     # E: Invalid type "__main__.Bad3"
 [file mod.py]
 from typing import Generic, TypeVar
 def declarative_base(): ...

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -393,8 +393,9 @@ class Application:
 
 [builtins fixtures/list.pyi]
 
+-- Blocked by #6454
 [case testDataclassOrderingWithCustomMethods]
-# flags: --python-version 3.6
+# flags: --python-version 3.6  --no-new-semantic-analyzer
 from dataclasses import dataclass
 
 @dataclass(order=True)

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3864,10 +3864,10 @@ class A:
 tmp/b.py:3: error: Revealed type is 'def (a: builtins.int) -> a.A'
 tmp/b.py:4: error: Revealed type is 'def (builtins.object, builtins.object) -> builtins.bool'
 tmp/b.py:5: error: Revealed type is 'def (builtins.object, builtins.object) -> builtins.bool'
-tmp/b.py:6: error: Revealed type is 'def [T] (self: T`-1, other: T`-1) -> builtins.bool'
-tmp/b.py:7: error: Revealed type is 'def [T] (self: T`-1, other: T`-1) -> builtins.bool'
-tmp/b.py:8: error: Revealed type is 'def [T] (self: T`-1, other: T`-1) -> builtins.bool'
-tmp/b.py:9: error: Revealed type is 'def [T] (self: T`-1, other: T`-1) -> builtins.bool'
+tmp/b.py:6: error: Revealed type is 'def [_DT] (self: _DT`-1, other: _DT`-1) -> builtins.bool'
+tmp/b.py:7: error: Revealed type is 'def [_DT] (self: _DT`-1, other: _DT`-1) -> builtins.bool'
+tmp/b.py:8: error: Revealed type is 'def [_DT] (self: _DT`-1, other: _DT`-1) -> builtins.bool'
+tmp/b.py:9: error: Revealed type is 'def [_DT] (self: _DT`-1, other: _DT`-1) -> builtins.bool'
 tmp/b.py:18: error: Unsupported operand types for < ("A" and "int")
 tmp/b.py:19: error: Unsupported operand types for <= ("A" and "int")
 tmp/b.py:20: error: Unsupported operand types for > ("A" and "int")

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -1400,6 +1400,7 @@ class B(A):
 
 [out]
 <m.A.(abstract)> -> <m.B.__init__>, m
+<m.A._DT> -> <m.B._DT>
 <m.A.__eq__> -> <m.B.__eq__>
 <m.A.__init__> -> <m.B.__init__>, m.B.__init__
 <m.A.__ne__> -> <m.B.__ne__>


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/6324

This enables two test files that previously had few crashes.

Changes in this PR:
* Add `defer()` to public plugin API, otherwise dataclasses will not works with forward references.
* Update one plugin test to use the new analyzer because the output is a bit more verbose, and probably not worth the hassle of making it identical to old analyzer.
* One test is skipped because of existing issue https://github.com/python/mypy/issues/6454
* Add the generated type variable used for self types to the class body (this is identical to named tuples and `attrs` plugin).