### PR TITLE
Move visit_var to NodeVisitor (from StatementVisitor)

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -828,7 +828,7 @@ class Var(SymbolNode):
     def fullname(self) -> Bogus[str]:
         return self._fullname
 
-    def accept(self, visitor: StatementVisitor[T]) -> T:
+    def accept(self, visitor: NodeVisitor[T]) -> T:
         return visitor.visit_var(self)
 
     def serialize(self) -> JsonDict:

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -227,10 +227,6 @@ class StatementVisitor(Generic[T]):
     def visit_decorator(self, o: 'mypy.nodes.Decorator') -> T:
         pass
 
-    @abstractmethod
-    def visit_var(self, o: 'mypy.nodes.Var') -> T:
-        pass
-
     # Module structure
 
     @abstractmethod
@@ -320,6 +316,12 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T]):
     def visit_mypy_file(self, o: 'mypy.nodes.MypyFile') -> T:
         pass
 
+    # TODO: We have a visit_var method, but no visit_typeinfo or any
+    # other non-Statement SymbolNode (accepting those will raise a
+    # runtime error). Maybe this should be resolved in some direction.
+    def visit_var(self, o: 'mypy.nodes.Var') -> T:
+        pass
+
     # Module structure
 
     def visit_import(self, o: 'mypy.nodes.Import') -> T:
@@ -350,9 +352,6 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T]):
         pass
 
     def visit_decorator(self, o: 'mypy.nodes.Decorator') -> T:
-        pass
-
-    def visit_var(self, o: 'mypy.nodes.Var') -> T:
         pass
 
     def visit_type_alias(self, o: 'mypy.nodes.TypeAlias') -> T:


### PR DESCRIPTION
This regularizes things some, since Var is not a Statement but is a
Node.  There is still a bunch of jankiness, since a lot of other
non-Statement SymbolNodes are still missing visit methods.