### PR TITLE
Add union math for intelligent indexing

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2,6 +2,7 @@
 
 from collections import OrderedDict
 from contextlib import contextmanager
+import itertools
 from typing import (
     cast, Dict, Set, List, Tuple, Callable, Union, Optional, Sequence, Iterator
 )
@@ -2547,15 +2548,18 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             if isinstance(index, SliceExpr):
                 return self.visit_tuple_slice_helper(left_type, index)
 
-            n = self._get_value(index)
-            if n is not None:
-                if n < 0:
-                    n += len(left_type.items)
-                if 0 <= n < len(left_type.items):
-                    return left_type.items[n]
-                else:
-                    self.chk.fail(message_registry.TUPLE_INDEX_OUT_OF_RANGE, e)
-                    return AnyType(TypeOfAny.from_error)
+            ns = self._get_values(index)
+            if ns is not None:
+                out = []
+                for n in ns:
+                    if n < 0:
+                        n += len(left_type.items)
+                    if 0 <= n < len(left_type.items):
+                        out.append(left_type.items[n])
+                    else:
+                        self.chk.fail(message_registry.TUPLE_INDEX_OUT_OF_RANGE, e)
+                        return AnyType(TypeOfAny.from_error)
+                return UnionType.make_simplified_union(out)
             else:
                 return self.nonliteral_tuple_index_helper(left_type, index)
         elif isinstance(left_type, TypedDictType):
@@ -2571,26 +2575,32 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             return result
 
     def visit_tuple_slice_helper(self, left_type: TupleType, slic: SliceExpr) -> Type:
-        begin = None
-        end = None
-        stride = None
+        begin = [None]   # type: Sequence[Optional[int]]
+        end = [None]     # type: Sequence[Optional[int]]
+        stride = [None]  # type: Sequence[Optional[int]]
 
         if slic.begin_index:
-            begin = self._get_value(slic.begin_index)
-            if begin is None:
+            begin_raw = self._get_values(slic.begin_index)
+            if begin_raw is None:
                 return self.nonliteral_tuple_index_helper(left_type, slic)
+            begin = begin_raw
 
         if slic.end_index:
-            end = self._get_value(slic.end_index)
-            if end is None:
+            end_raw = self._get_values(slic.end_index)
+            if end_raw is None:
                 return self.nonliteral_tuple_index_helper(left_type, slic)
+            end = end_raw
 
         if slic.stride:
-            stride = self._get_value(slic.stride)
-            if stride is None:
+            stride_raw = self._get_values(slic.stride)
+            if stride_raw is None:
                 return self.nonliteral_tuple_index_helper(left_type, slic)
+            stride = stride_raw
 
-        return left_type.slice(begin, stride, end)
+        items = []  # type: List[Type]
+        for b, e, s in itertools.product(begin, end, stride):
+            items.append(left_type.slice(b, e, s))
+        return UnionType.make_simplified_union(items)
 
     def nonliteral_tuple_index_helper(self, left_type: TupleType, index: Expression) -> Type:
         index_type = self.accept(index)
@@ -2607,40 +2617,59 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             else:
                 return union
 
-    def _get_value(self, index: Expression) -> Optional[int]:
+    def _get_values(self, index: Expression) -> Optional[List[int]]:
         if isinstance(index, IntExpr):
-            return index.value
+            return [index.value]
         elif isinstance(index, UnaryExpr):
             if index.op == '-':
                 operand = index.expr
                 if isinstance(operand, IntExpr):
-                    return -1 * operand.value
+                    return [-1 * operand.value]
         typ = self.accept(index)
         if isinstance(typ, Instance) and typ.last_known_value is not None:
             typ = typ.last_known_value
         if isinstance(typ, LiteralType) and isinstance(typ.value, int):
-            return typ.value
+            return [typ.value]
+        if isinstance(typ, UnionType):
+            out = []
+            for item in typ.items:
+                if isinstance(item, LiteralType) and isinstance(item.value, int):
+                    out.append(item.value)
+                else:
+                    return None
+            return out
         return None
 
     def visit_typeddict_index_expr(self, td_type: TypedDictType, index: Expression) -> Type:
         if isinstance(index, (StrExpr, UnicodeExpr)):
-            item_name = index.value
+            key_names = [index.value]
         else:
             typ = self.accept(index)
-            if isinstance(typ, Instance) and typ.last_known_value is not None:
-                typ = typ.last_known_value
-
-            if isinstance(typ, LiteralType) and isinstance(typ.value, str):
-                item_name = typ.value
+            if isinstance(typ, UnionType):
+                key_types = typ.items
             else:
-                self.msg.typeddict_key_must_be_string_literal(td_type, index)
-                return AnyType(TypeOfAny.from_error)
+                key_types = [typ]
 
-        item_type = td_type.items.get(item_name)
-        if item_type is None:
-            self.msg.typeddict_key_not_found(td_type, item_name, index)
-            return AnyType(TypeOfAny.from_error)
-        return item_type
+            key_names = []
+            for key_type in key_types:
+                if isinstance(key_type, Instance) and key_type.last_known_value is not None:
+                    key_type = key_type.last_known_value
+
+                if isinstance(key_type, LiteralType) and isinstance(key_type.value, str):
+                    key_names.append(key_type.value)
+                else:
+                    self.msg.typeddict_key_must_be_string_literal(td_type, index)
+                    return AnyType(TypeOfAny.from_error)
+
+        value_types = []
+        for key_name in key_names:
+            value_type = td_type.items.get(key_name)
+            if value_type is None:
+                self.msg.typeddict_key_not_found(td_type, key_name, index)
+                return AnyType(TypeOfAny.from_error)
+            else:
+                value_types.append(value_type)
+        return UnionType.make_simplified_union(value_types)
 
     def visit_enum_index_expr(self, enum_type: TypeInfo, index: Expression,
                               context: Context) -> Type:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1170,6 +1170,14 @@ class MessageBuilder:
             self.fail("Key '{}' of TypedDict {} cannot be deleted".format(
                 item_name, self.format(typ)), context)
 
+    def typeddict_setdefault_arguments_inconsistent(
+            self,
+            default: Type,
+            expected: Type,
+            context: Context) -> None:
+        msg = 'Argument 2 to "setdefault" of "TypedDict" has incompatible type {}; expected {}'
+        self.fail(msg.format(self.format(default), self.format(expected)), context)
+
     def type_arguments_not_allowed(self, context: Context) -> None:
         self.fail('Parameterized generics cannot be used with class or instance checks', context)
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1278,8 +1278,8 @@ class TupleType(Type):
             items = self.items
         return TupleType(items, fallback, self.line, self.column)
 
-    def slice(self, begin: Optional[int], stride: Optional[int],
-              end: Optional[int]) -> 'TupleType':
+    def slice(self, begin: Optional[int], end: Optional[int],
+              stride: Optional[int]) -> 'TupleType':
         return TupleType(self.items[begin:end:stride], self.partial_fallback,
                          self.line, self.column, self.implicit)
 

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2351,6 +2351,43 @@ UnicodeDict = TypedDict(b'UnicodeDict', {'key': int})
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
 
+[case testLiteralIntelligentIndexingMultiTypedDict]
+from typing import Union
+from typing_extensions import Literal
+from mypy_extensions import TypedDict
+
+class A: pass
+class B: pass
+class C: pass
+class D: pass
+
+class D1(TypedDict):
+    a: A
+    b: B
+    c: C
+
+class D2(TypedDict):
+    b: B
+    c: C
+    d: D
+
+x: Union[D1, D2]
+bad_keys: Literal['a', 'b', 'c', 'd']
+good_keys: Literal['b', 'c']
+
+x[bad_keys]         # E: TypedDict "D1" has no key 'd' \
+                    # E: TypedDict "D2" has no key 'a'
+x.get(bad_keys)     # E: TypedDict "D1" has no key 'd' \
+                    # E: TypedDict "D2" has no key 'a'
+x.get(bad_keys, 3)  # E: TypedDict "D1" has no key 'd' \
+                    # E: TypedDict "D2" has no key 'a'
+
+reveal_type(x[good_keys])           # N: Revealed type is 'Union[__main__.B, __main__.C]'
+reveal_type(x.get(good_keys))       # N: Revealed type is 'Union[__main__.B, __main__.C]'
+reveal_type(x.get(good_keys, 3))    # N: Revealed type is 'Union[__main__.B, builtins.int, __main__.C]'
+
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
 
 --
 -- Interactions with 'Final'

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2239,14 +2239,14 @@ tup1: Tuple[A, B, C, D, E]
 Tup2Class = NamedTuple('Tup2Class', [('a', A), ('b', B), ('c', C), ('d', D), ('e', E)])
 tup2: Tup2Class
 
-reveal_type(tup1[idx1])         # E: Revealed type is 'Union[__main__.B, __main__.C]'
-reveal_type(tup1[idx1:idx2])    # E: Revealed type is 'Union[Tuple[__main__.B, __main__.C], Tuple[__main__.B, __main__.C, __main__.D], Tuple[__main__.C], Tuple[__main__.C, __main__.D]]'
-reveal_type(tup1[0::idx1])      # E: Revealed type is 'Union[Tuple[__main__.A, __main__.B, __main__.C, __main__.D, __main__.E], Tuple[__main__.A, __main__.C, __main__.E]]'
+reveal_type(tup1[idx1])         # N: Revealed type is 'Union[__main__.B, __main__.C]'
+reveal_type(tup1[idx1:idx2])    # N: Revealed type is 'Union[Tuple[__main__.B, __main__.C], Tuple[__main__.B, __main__.C, __main__.D], Tuple[__main__.C], Tuple[__main__.C, __main__.D]]'
+reveal_type(tup1[0::idx1])      # N: Revealed type is 'Union[Tuple[__main__.A, __main__.B, __main__.C, __main__.D, __main__.E], Tuple[__main__.A, __main__.C, __main__.E]]'
 tup1[idx_bad]                   # E: Tuple index out of range
 
-reveal_type(tup2[idx1])         # E: Revealed type is 'Union[__main__.B, __main__.C]'
-reveal_type(tup2[idx1:idx2])    # E: Revealed type is 'Union[Tuple[__main__.B, __main__.C, fallback=__main__.Tup2Class], Tuple[__main__.B, __main__.C, __main__.D, fallback=__main__.Tup2Class], Tuple[__main__.C, fallback=__main__.Tup2Class], Tuple[__main__.C, __main__.D, fallback=__main__.Tup2Class]]'
-reveal_type(tup2[0::idx1])      # E: Revealed type is 'Union[Tuple[__main__.A, __main__.B, __main__.C, __main__.D, __main__.E, fallback=__main__.Tup2Class], Tuple[__main__.A, __main__.C, __main__.E, fallback=__main__.Tup2Class]]'
+reveal_type(tup2[idx1])         # N: Revealed type is 'Union[__main__.B, __main__.C]'
+reveal_type(tup2[idx1:idx2])    # N: Revealed type is 'Union[Tuple[__main__.B, __main__.C, fallback=__main__.Tup2Class], Tuple[__main__.B, __main__.C, __main__.D, fallback=__main__.Tup2Class], Tuple[__main__.C, fallback=__main__.Tup2Class], Tuple[__main__.C, __main__.D, fallback=__main__.Tup2Class]]'
+reveal_type(tup2[0::idx1])      # N: Revealed type is 'Union[Tuple[__main__.A, __main__.B, __main__.C, __main__.D, __main__.E, fallback=__main__.Tup2Class], Tuple[__main__.A, __main__.C, __main__.E, fallback=__main__.Tup2Class]]'
 tup2[idx_bad]                   # E: Tuple index out of range
 [builtins fixtures/slice.pyi]
 [out]
@@ -2277,12 +2277,12 @@ good_keys: Literal["a", "b"]
 optional_keys: Literal["d", "e"]
 bad_keys: Literal["a", "bad"]
 
-reveal_type(test[good_keys])                      # E: Revealed type is 'Union[__main__.A, __main__.B]'
-reveal_type(test.get(good_keys))                  # E: Revealed type is 'Union[__main__.A, __main__.B]'
-reveal_type(test.get(good_keys, 3))               # E: Revealed type is 'Union[__main__.A, builtins.int, __main__.B]'
-reveal_type(test.pop(optional_keys))              # E: Revealed type is 'Union[__main__.D, __main__.E]'
-reveal_type(test.pop(optional_keys, 3))           # E: Revealed type is 'Union[__main__.D, __main__.E, builtins.int]'
-reveal_type(test.setdefault(good_keys, AAndB()))  # E: Revealed type is 'Union[__main__.A, __main__.B]'
+reveal_type(test[good_keys])                      # N: Revealed type is 'Union[__main__.A, __main__.B]'
+reveal_type(test.get(good_keys))                  # N: Revealed type is 'Union[__main__.A, __main__.B]'
+reveal_type(test.get(good_keys, 3))               # N: Revealed type is 'Union[__main__.A, builtins.int, __main__.B]'
+reveal_type(test.pop(optional_keys))              # N: Revealed type is 'Union[__main__.D, __main__.E]'
+reveal_type(test.pop(optional_keys, 3))           # N: Revealed type is 'Union[__main__.D, __main__.E, builtins.int]'
+reveal_type(test.setdefault(good_keys, AAndB()))  # N: Revealed type is 'Union[__main__.A, __main__.B]'
 del test[optional_keys]
 
 

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2221,6 +2221,88 @@ c.get(str_key_bad, u)                # E: TypedDict "MyDict" has no key 'missing
 [typing fixtures/typing-full.pyi]
 [out]
 
+[case testLiteralIntelligentIndexingTupleUnions]
+from typing import Tuple, NamedTuple
+from typing_extensions import Literal
+
+class A: pass
+class B: pass
+class C: pass
+class D: pass
+class E: pass
+
+idx1: Literal[1, 2]
+idx2: Literal[3, 4]
+idx_bad: Literal[1, 20]
+
+tup1: Tuple[A, B, C, D, E]
+Tup2Class = NamedTuple('Tup2Class', [('a', A), ('b', B), ('c', C), ('d', D), ('e', E)])
+tup2: Tup2Class
+
+reveal_type(tup1[idx1])         # E: Revealed type is 'Union[__main__.B, __main__.C]'
+reveal_type(tup1[idx1:idx2])    # E: Revealed type is 'Union[Tuple[__main__.B, __main__.C], Tuple[__main__.B, __main__.C, __main__.D], Tuple[__main__.C], Tuple[__main__.C, __main__.D]]'
+reveal_type(tup1[0::idx1])      # E: Revealed type is 'Union[Tuple[__main__.A, __main__.B, __main__.C, __main__.D, __main__.E], Tuple[__main__.A, __main__.C, __main__.E]]'
+tup1[idx_bad]                   # E: Tuple index out of range
+
+reveal_type(tup2[idx1])         # E: Revealed type is 'Union[__main__.B, __main__.C]'
+reveal_type(tup2[idx1:idx2])    # E: Revealed type is 'Union[Tuple[__main__.B, __main__.C, fallback=__main__.Tup2Class], Tuple[__main__.B, __main__.C, __main__.D, fallback=__main__.Tup2Class], Tuple[__main__.C, fallback=__main__.Tup2Class], Tuple[__main__.C, __main__.D, fallback=__main__.Tup2Class]]'
+reveal_type(tup2[0::idx1])      # E: Revealed type is 'Union[Tuple[__main__.A, __main__.B, __main__.C, __main__.D, __main__.E, fallback=__main__.Tup2Class], Tuple[__main__.A, __main__.C, __main__.E, fallback=__main__.Tup2Class]]'
+tup2[idx_bad]                   # E: Tuple index out of range
+[builtins fixtures/slice.pyi]
+[out]
+
+[case testLiteralIntelligentIndexingTypedDictUnions]
+from typing_extensions import Literal, Final
+from mypy_extensions import TypedDict
+
+class A: pass
+class B: pass
+class C: pass
+class D: pass
+class E: pass
+
+class Base(TypedDict):
+    a: A
+    b: B
+    c: C
+
+class Test(Base, total=False):
+    d: D
+    e: E
+
+class AAndB(A, B): pass
+
+test: Test
+good_keys: Literal["a", "b"]
+optional_keys: Literal["d", "e"]
+bad_keys: Literal["a", "bad"]
+
+reveal_type(test[good_keys])                      # E: Revealed type is 'Union[__main__.A, __main__.B]'
+reveal_type(test.get(good_keys))                  # E: Revealed type is 'Union[__main__.A, __main__.B]'
+reveal_type(test.get(good_keys, 3))               # E: Revealed type is 'Union[__main__.A, builtins.int, __main__.B]'
+reveal_type(test.pop(optional_keys))              # E: Revealed type is 'Union[__main__.D, __main__.E]'
+reveal_type(test.pop(optional_keys, 3))           # E: Revealed type is 'Union[__main__.D, __main__.E, builtins.int]'
+reveal_type(test.setdefault(good_keys, AAndB()))  # E: Revealed type is 'Union[__main__.A, __main__.B]'
+del test[optional_keys]
+
+
+test[bad_keys]                  # E: TypedDict "Test" has no key 'bad'
+test.get(bad_keys)              # E: TypedDict "Test" has no key 'bad'
+test.get(bad_keys, 3)           # E: TypedDict "Test" has no key 'bad'
+test.pop(good_keys)             # E: Key 'a' of TypedDict "Test" cannot be deleted \
+                                # E: Key 'b' of TypedDict "Test" cannot be deleted
+test.pop(bad_keys)              # E: Key 'a' of TypedDict "Test" cannot be deleted \
+                                # E: TypedDict "Test" has no key 'bad'
+test.setdefault(good_keys, 3)   # E: Argument 2 to "setdefault" of "TypedDict" has incompatible type "int"; expected "A"
+test.setdefault(bad_keys, 3 )   # E: Argument 2 to "setdefault" of "TypedDict" has incompatible type "int"; expected "A"
+del test[good_keys]             # E: Key 'a' of TypedDict "Test" cannot be deleted \
+                                # E: Key 'b' of TypedDict "Test" cannot be deleted
+del test[bad_keys]              # E: Key 'a' of TypedDict "Test" cannot be deleted \
+                                # E: TypedDict "Test" has no key 'bad'
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
+[out]
+
 [case testLiteralIntelligentIndexingTypedDictPython2-skip]
 # flags: --python-version 2.7
 from normal_mod import NormalDict


### PR DESCRIPTION
This pull request hacks on supports for union math when using Unions of Literals to index into tuples, NamedTuples, and TypedDicts.

It also fixes a bug I apparently introduced. Currently, mypy correctly reports an error with this code:

    class Test(TypedDict):
        foo: int

    t: Test

    # Error: int can't be assigned a str value
    t.setdefault("foo", "unrelated value")

...but does not report an error with:

    key: Literal["foo"]
    t.setdefault(key, "unrelated value")

This diff should make mypy report an error in both cases.

Resolves https://github.com/python/mypy/issues/6262.