### PR TITLE
Add --no-implicit-reexport flag

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -396,6 +396,7 @@ of the above sections.
     stub files. For example:
 
     .. code-block:: python
+
        # This won't re-export the value
        from foo import bar
        # This will re-export it as bar and allow other modules to import it

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -389,6 +389,19 @@ of the above sections.
            # 'items' now has type List[List[str]]
            ...
 
+``--no-implicit-reexport``
+    By default, imported values to a module are treated as exported and mypy allows
+    other modules to import them. This flag changes the behavior to not re-export unless
+    the item is imported using from-as. Note this is always treated as enabled for
+    stub files. For example:
+
+    .. code-block:: python
+       # This won't re-export the value
+       from foo import bar
+       # This will re-export it as bar and allow other modules to import it
+       from foo import bar as bar
+
+
 ``--strict-equality``
     By default, mypy allows always-false comparisons like ``42 == 'no'``.
     Use this flag to prohibit such comparisons of non-overlapping types, and

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -294,6 +294,18 @@ Miscellaneous strictness flags
     Allows variables to be redefined with an arbitrary type, as long as the redefinition
     is in the same block and nesting level as the original definition.
 
+``implicit-reexport`` (bool, default True)
+    By default, imported values to a module are treated as exported and mypy allows
+    other modules to import them. When false, mypy will not re-export unless
+    the item is imported using from-as. Note that mypy treats stub files as if this
+    is always disabled. For example:
+
+    .. code-block:: python
+    # This won't re-export the value
+    from foo import bar
+    # This will re-export it as bar and allow other modules to import it
+    from foo import bar as bar
+
 ``strict_equality``  (bool, default False)
    Prohibit equality checks, identity checks, and container checks between
    non-overlapping types.

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -302,10 +302,10 @@ Miscellaneous strictness flags
 
     .. code-block:: python
 
-    # This won't re-export the value
-    from foo import bar
-    # This will re-export it as bar and allow other modules to import it
-    from foo import bar as bar
+       # This won't re-export the value
+       from foo import bar
+       # This will re-export it as bar and allow other modules to import it
+       from foo import bar as bar
 
 ``strict_equality``  (bool, default False)
    Prohibit equality checks, identity checks, and container checks between

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -301,6 +301,7 @@ Miscellaneous strictness flags
     is always disabled. For example:
 
     .. code-block:: python
+
     # This won't re-export the value
     from foo import bar
     # This will re-export it as bar and allow other modules to import it

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -490,6 +490,10 @@ def process_options(args: List[str],
                              " non-overlapping types",
                         group=strictness_group)
 
+    add_invertible_flag('--no-implicit-reexport', default=False, strict_flag=True,
+                        help="Treat imports as private unless aliased",
+                        group=strictness_group)
+
     incremental_group = parser.add_argument_group(
         title='Incremental mode',
         description="Adjust how mypy incrementally type checks and caches modules. "

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -490,7 +490,9 @@ def process_options(args: List[str],
                              " non-overlapping types",
                         group=strictness_group)
 
-    add_invertible_flag('--no-implicit-reexport', default=False, strict_flag=True,
+    add_invertible_flag('--no-implicit-reexport', default=True, strict_flag=True,
+                        dest='implicit_reexport',
+                        action='store_false',
                         help="Treat imports as private unless aliased",
                         group=strictness_group)
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -492,7 +492,6 @@ def process_options(args: List[str],
 
     add_invertible_flag('--no-implicit-reexport', default=True, strict_flag=True,
                         dest='implicit_reexport',
-                        action='store_false',
                         help="Treat imports as private unless aliased",
                         group=strictness_group)
 

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1605,7 +1605,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 self.add_module_symbol(id, as_id, module_public=True, context=i)
             else:
                 # Modules imported in a stub file without using 'as x' won't get exported
-                module_public = not self.is_stub_file
+                module_public = (
+                    not self.is_stub_file
+                    and not self.options.no_implicit_reexport
+                )
                 base = id.split('.')[0]
                 self.add_module_symbol(base, base, module_public=module_public,
                                        context=i, module_hidden=not module_public)
@@ -1710,7 +1713,11 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     # we know what is the new symbol node.
                     continue
                 # 'from m import x as x' exports x in a stub file.
-                module_public = not self.is_stub_file or as_id is not None
+                module_public = (
+                    not self.is_stub_file
+                    and not self.options.no_implicit_reexport
+                    or as_id is not None
+                )
                 module_hidden = not module_public and possible_module_id not in self.modules
                 # NOTE: we take the original node even for final `Var`s. This is to support
                 # a common pattern when constants are re-exported (same applies to import *).

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1713,7 +1713,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     # Imports are special, some redefinitions are allowed, so wait until
                     # we know what is the new symbol node.
                     continue
-                # 'from m import x as x' exports x in a stub file or when implicit exports are disabled.
+                # 'from m import x as x' exports x in a stub file or when implicit
+                # re-exports are disabled.
                 module_public = (
                     not self.is_stub_file
                     and self.options.implicit_reexport

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1605,9 +1605,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 self.add_module_symbol(id, as_id, module_public=True, context=i)
             else:
                 # Modules imported in a stub file without using 'as x' won't get exported
+                # When implicit re-exporting is disabled, we have the same behavior as stubs.
                 module_public = (
                     not self.is_stub_file
-                    and not self.options.no_implicit_reexport
+                    and self.options.implicit_reexport
                 )
                 base = id.split('.')[0]
                 self.add_module_symbol(base, base, module_public=module_public,
@@ -1712,10 +1713,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     # Imports are special, some redefinitions are allowed, so wait until
                     # we know what is the new symbol node.
                     continue
-                # 'from m import x as x' exports x in a stub file.
+                # 'from m import x as x' exports x in a stub file or when implicit exports are disabled.
                 module_public = (
                     not self.is_stub_file
-                    and not self.options.no_implicit_reexport
+                    and self.options.implicit_reexport
                     or as_id is not None
                 )
                 module_hidden = not module_public and possible_module_id not in self.modules

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -44,7 +44,7 @@ PER_MODULE_OPTIONS = {
     "local_partial_types",
     "mypyc",
     "no_implicit_optional",
-    "no_implicit_reexport",
+    "implicit_reexport",
     "show_none_errors",
     "strict_optional",
     "strict_optional_whitelist",
@@ -153,7 +153,7 @@ class Options:
         self.no_implicit_optional = False
 
         # Don't re-export names unless they are imported with `from ... as ...`
-        self.no_implicit_reexport = False
+        self.implicit_reexport = True
 
         # Suppress toplevel errors caused by missing annotations
         self.allow_untyped_globals = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -44,6 +44,7 @@ PER_MODULE_OPTIONS = {
     "local_partial_types",
     "mypyc",
     "no_implicit_optional",
+    "no_implicit_reexport",
     "show_none_errors",
     "strict_optional",
     "strict_optional_whitelist",
@@ -150,6 +151,9 @@ class Options:
 
         # Don't assume arguments with default values of None are Optional
         self.no_implicit_optional = False
+
+        # Don't re-export names unless they are imported with `from ... as ...`
+        self.no_implicit_reexport = False
 
         # Suppress toplevel errors caused by missing annotations
         self.allow_untyped_globals = False

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1453,7 +1453,10 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 self.add_module_symbol(id, as_id, module_public=True, context=i)
             else:
                 # Modules imported in a stub file without using 'as x' won't get exported
-                module_public = not self.is_stub_file
+                module_public = (
+                    not self.is_stub_file
+                    and not self.options.no_implicit_reexport
+                )
                 base = id.split('.')[0]
                 self.add_module_symbol(base, base, module_public=module_public,
                                        context=i, module_hidden=not module_public)
@@ -1563,7 +1566,11 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                             imported_id, existing_symbol, node, imp):
                         continue
                 # 'from m import x as x' exports x in a stub file.
-                module_public = not self.is_stub_file or as_id is not None
+                module_public = (
+                    not self.is_stub_file
+                    and not self.options.no_implicit_reexport
+                    or as_id is not None
+                )
                 module_hidden = not module_public and possible_module_id not in self.modules
                 # NOTE: we take the original node even for final `Var`s. This is to support
                 # a common pattern when constants are re-exported (same applies to import *).

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1453,9 +1453,10 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 self.add_module_symbol(id, as_id, module_public=True, context=i)
             else:
                 # Modules imported in a stub file without using 'as x' won't get exported
+                # Modules with implicit reexport disabled have the same behavior as stubs.
                 module_public = (
                     not self.is_stub_file
-                    and not self.options.no_implicit_reexport
+                    and self.options.implicit_reexport
                 )
                 base = id.split('.')[0]
                 self.add_module_symbol(base, base, module_public=module_public,
@@ -1565,10 +1566,11 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                     if self.process_import_over_existing_name(
                             imported_id, existing_symbol, node, imp):
                         continue
-                # 'from m import x as x' exports x in a stub file.
+                # 'from m import x as x' exports x in a stub file, or when implicit reexport
+                # is disabled.
                 module_public = (
                     not self.is_stub_file
-                    and not self.options.no_implicit_reexport
+                    and self.options.implicit_reexport
                     or as_id is not None
                 )
                 module_hidden = not module_public and possible_module_id not in self.modules

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1163,8 +1163,8 @@ from other_module_1 import a
 
 [file mypy.ini]
 [[mypy]
-no_implicit_reexport = False
+implicit_reexport = True
 [[mypy-other_module_2]
-no_implicit_reexport = True
+implicit_reexport = False
 [out]
 main:2: error: Module 'other_module_2' has no attribute 'a'

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1137,3 +1137,34 @@ strict_equality = True
 [[mypy-b]
 strict_equality = False
 [builtins fixtures/bool.pyi]
+
+[case testNoImplicitReexport]
+# flags: --no-implicit-reexport
+from other_module_2 import a
+
+[file other_module_1.py]
+a = 5
+
+[file other_module_2.py]
+from other_module_1 import a
+
+[out]
+main:2: error: Module 'other_module_2' has no attribute 'a'
+
+[case testNoImplicitReexportMypyIni]
+# flags: --config-file tmp/mypy.ini
+from other_module_2 import a
+
+[file other_module_1.py]
+a = 5
+
+[file other_module_2.py]
+from other_module_1 import a
+
+[file mypy.ini]
+[[mypy]
+no_implicit_reexport = False
+[[mypy-other_module_2]
+no_implicit_reexport = True
+[out]
+main:2: error: Module 'other_module_2' has no attribute 'a'

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1141,13 +1141,10 @@ strict_equality = False
 [case testNoImplicitReexport]
 # flags: --no-implicit-reexport
 from other_module_2 import a
-
 [file other_module_1.py]
 a = 5
-
 [file other_module_2.py]
 from other_module_1 import a
-
 [out]
 main:2: error: Module 'other_module_2' has no attribute 'a'
 


### PR DESCRIPTION
Adds a --no-implicit-reexport flag, intended for giving modules the same behavior as stubs for re-exporting their imports.

The goal is to make it possible to prevent bad transitive imports from causing dependency issues. And to make it easier to move things to a different module.