### PR TITLE
New semantic analyzer: add a test for int->float promotion

### DIFF
--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -581,6 +581,13 @@ a.f(1.0) # E: No overload variant of "f" of "A" matches argument type "float" \
          # N:     def f(self, x: int) -> int \
          # N:     def f(self, x: str) -> str
 
+[case testNewAnalyzerPromotion]
+y: int
+f(y)
+f(1)
+def f(x: float) -> None: pass
+[builtins fixtures/primitives.pyi]
+
 [case testNewAnalyzerFunctionDecorator]
 from typing import Callable
 


### PR DESCRIPTION
The bug open for this says that it doesn't seem to work but as far as
I can tell it seems to.

Add a test calling a forward referenced function that requires a promotion.

Closes #6398.