### PR TITLE
Sort mypyc_targets in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,9 @@ if USE_MYPYC:
 
     # Fix the paths to be full
     mypyc_targets = [os.path.join('mypy', x) for x in mypyc_targets]
+    # The targets come out of file system apis in an unspecified
+    # order. Sort them so that the mypyc output is deterministic.
+    mypyc_targets.sort()
 
     # This bit is super unfortunate: we want to use the mypy packaged
     # with mypyc. It will arrange for the path to be setup so it can


### PR DESCRIPTION
The mypy_mypyc-wheels Travis build is currently broken on linux
because of a mypyc bug that is dependent on the order of files passed
to mypyc. I am fixing the bug
(https://github.com/mypyc/mypyc/pull/539), but this was complicated by
files coming out of the file system APIs in an unspecified order.

Sort the targets passed to mypyc so that the mypyc compilation process
is deterministic.

(This I believe will *happen* to fix the mypy_mypyc-wheels build, because "suggestions" comes after "plugin" in the alphabet, but it isn't *really* fixed. I'll also be moving the mypyc pin.)