### PR TITLE
Eliminate implicit reexports

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -22,7 +22,8 @@ from mypy.nodes import (
     ComparisonExpr, StarExpr, EllipsisExpr, RefExpr, PromoteExpr,
     Import, ImportFrom, ImportAll, ImportBase, TypeAlias,
     ARG_POS, ARG_STAR, LITERAL_TYPE, MDEF, GDEF,
-    CONTRAVARIANT, COVARIANT, INVARIANT, TypeVarExpr
+    CONTRAVARIANT, COVARIANT, INVARIANT, TypeVarExpr,
+    is_final_node,
 )
 from mypy import nodes
 from mypy.literals import literal, literal_hash
@@ -39,7 +40,7 @@ from mypy.messages import MessageBuilder, make_inferred_type_note
 import mypy.checkexpr
 from mypy.checkmember import (
     map_type_from_supertype, bind_self, erase_to_bound, type_object_type,
-    analyze_descriptor_access, is_final_node
+    analyze_descriptor_access,
 )
 from mypy import message_registry
 from mypy.subtypes import (

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -1,5 +1,7 @@
 """Translate an Expression to a Type value."""
 
+from typing import Optional
+
 from mypy.nodes import (
     Expression, NameExpr, MemberExpr, IndexExpr, TupleExpr, IntExpr, FloatExpr, UnaryExpr,
     ComplexExpr, ListExpr, StrExpr, BytesExpr, UnicodeExpr, EllipsisExpr, CallExpr,
@@ -7,7 +9,7 @@ from mypy.nodes import (
 )
 from mypy.fastparse import parse_type_string
 from mypy.types import (
-    Type, UnboundType, TypeList, EllipsisType, AnyType, Optional, CallableArgument, TypeOfAny,
+    Type, UnboundType, TypeList, EllipsisType, AnyType, CallableArgument, TypeOfAny,
     RawExpressionType,
 )
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -84,7 +84,10 @@ from mypy.plugin import (
     DynamicClassDefContext
 )
 from mypy.util import get_prefix, correct_relative_import, unmangle
-from mypy.semanal_shared import SemanticAnalyzerInterface, set_callable_name
+from mypy.semanal_shared import (
+    SemanticAnalyzerInterface,
+    set_callable_name as set_callable_name,
+)
 from mypy.scope import Scope
 from mypy.semanal_namedtuple import NamedTupleAnalyzer, NAMEDTUPLE_PROHIBITED_NAMES
 from mypy.semanal_typeddict import TypedDictAnalyzer

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -12,9 +12,10 @@ from mypy.test.helpers import Suite, assert_equal, assert_string_arrays_equal
 from mypy.test.data import DataSuite, DataDrivenTestCase
 from mypy.errors import CompileError
 from mypy.stubgen import (
-    generate_stubs, parse_options, walk_packages, Options, collect_build_targets,
+    generate_stubs, parse_options, Options, collect_build_targets,
     mypy_options
 )
+from mypy.stubutil import walk_packages
 from mypy.stubgenc import generate_c_type_stub, infer_method_sig, generate_c_function_stub
 from mypy.stubdoc import (
     parse_signature, parse_all_signatures, build_signature, find_unique_signatures,

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -61,8 +61,13 @@ LiteralValue = Union[int, str, bool]
 # breaks, and if we do it at the top, it breaks at runtime because of
 # import cycle issues, so we do it at the top while typechecking and
 # then again in the middle at runtime.
+# We should be able to remove this once we are switched to the new
+# semantic analyzer!
 if MYPY:
-    from mypy.type_visitor import TypeVisitor, SyntheticTypeVisitor
+    from mypy.type_visitor import (
+        TypeVisitor as TypeVisitor,
+        SyntheticTypeVisitor as SyntheticTypeVisitor,
+    )
 
 
 class TypeOfAny:
@@ -1832,7 +1837,10 @@ class PlaceholderType(Type):
 # Import them here, after the types are defined.
 # This is intended as a re-export also.
 from mypy.type_visitor import (  # noqa
-    TypeVisitor, SyntheticTypeVisitor, TypeTranslator, TypeQuery
+    TypeVisitor as TypeVisitor,
+    SyntheticTypeVisitor as SyntheticTypeVisitor,
+    TypeTranslator as TypeTranslator,
+    TypeQuery as TypeQuery,
 )
 
 


### PR DESCRIPTION
This makes mypy check clean with the proposed --no-implicit-reexports
flag from PR #6562.

Some of the implicit reexports that were depended on were clearly
intended (type_visitor) and so made explicit, while some were clearly
unintended (Optional from mypy.types!) and fixed.

Probably worth landing this whichever way we decide on #6562, but I
think this PR is an argument in favor.