### PR TITLE
Don't resolve Callable NamedTuple fields to their return type

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -619,10 +619,13 @@ def find_node_type(node: Union[Var, FuncBase], itype: Instance, subtype: Type) -
     if typ is None:
         return AnyType(TypeOfAny.from_error)
     # We don't need to bind 'self' for static methods, since there is no 'self'.
-    if isinstance(node, FuncBase) or isinstance(typ, FunctionLike) and not node.is_staticmethod:
+    if (isinstance(node, FuncBase)
+            or (isinstance(typ, FunctionLike)
+                and node.is_initialized_in_class
+                and not node.is_staticmethod)):
         assert isinstance(typ, FunctionLike)
         signature = bind_self(typ, subtype)
-        if node.is_property and not node.info.is_named_tuple:
+        if node.is_property:
             assert isinstance(signature, CallableType)
             typ = signature.ret_type
         else:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -622,7 +622,7 @@ def find_node_type(node: Union[Var, FuncBase], itype: Instance, subtype: Type) -
     if isinstance(node, FuncBase) or isinstance(typ, FunctionLike) and not node.is_staticmethod:
         assert isinstance(typ, FunctionLike)
         signature = bind_self(typ, subtype)
-        if node.is_property:
+        if node.is_property and not node.info.is_named_tuple:
             assert isinstance(signature, CallableType)
             typ = signature.ret_type
         else:

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2444,3 +2444,29 @@ class P(Protocol[T]):
     @alias
     def meth(self, arg: T) -> T: ...
 [out]
+
+[case testNamedTupleWithNoArgsCallableField]
+from typing import Callable, NamedTuple, Protocol
+
+class N(NamedTuple):
+    func: Callable[[], str]
+
+class P(Protocol):
+    @property
+    def func(self) -> Callable[[], str]: ...
+
+p: P = N(lambda: 'foo')
+[builtins fixtures/property.pyi]
+
+[case testNamedTupleWithManyArgsCallableField]
+from typing import Callable, NamedTuple, Protocol
+
+class N(NamedTuple):
+    func: Callable[[str, str, str], str]
+
+class P(Protocol):
+    @property
+    def func(self) -> Callable[[str, str, str], str]: ...
+
+p: P = N(lambda a, b, c: 'foo')
+[builtins fixtures/property.pyi]


### PR DESCRIPTION
`NamedTuple` fields are always marked an properties. In certain situations, this causes their type to be determined incorrectly when they hold `Callable`s, resolving to the `Callable`'s return type rather than the `Callable` itself. This prevents that and fixes https://github.com/python/mypy/issues/6575.