### PR TITLE
New semantic analyzer: store import deps generated during analysis

### DIFF
--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -281,7 +281,9 @@ def semantic_analyze_target(target: str,
                 infer_decorator_signature_if_simple(node, analyzer)
     for dep in analyzer.imports:
         state.dependencies.append(dep)
-        state.priorities[dep] = mypy.build.PRI_LOW
+        priority = mypy.build.PRI_LOW
+        if priority <= state.priorities.get(dep, priority):
+            state.priorities[dep] = priority
     if analyzer.deferred:
         return [target], analyzer.incomplete, analyzer.progress
     else:

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -41,6 +41,7 @@ from mypy.newsemanal.semanal_classprop import (
 from mypy.errors import Errors
 from mypy.newsemanal.semanal_infer import infer_decorator_signature_if_simple
 from mypy.checker import FineGrainedDeferredNode
+import mypy.build
 
 MYPY = False
 if MYPY:
@@ -278,6 +279,9 @@ def semantic_analyze_target(target: str,
             analyzer.refresh_partial(refresh_node, patches, final_iteration)
             if isinstance(node, Decorator):
                 infer_decorator_signature_if_simple(node, analyzer)
+    for dep in analyzer.imports:
+        state.dependencies.append(dep)
+        state.priorities[dep] = mypy.build.PRI_LOW
     if analyzer.deferred:
         return [target], analyzer.incomplete, analyzer.progress
     else:

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2020,3 +2020,18 @@ class C(Generic[T]): ...
 
 class A: ...
 class D: ...
+
+[case testNewAnalyzerAddedSubStarImport_incremental]
+# TODO: This can be removed once testAddedSubStarImport is enabled in check-incremental.test.
+# cmd: mypy -m a pack pack.mod b
+# cmd2: mypy -m other
+[file a.py]
+from pack import *
+[file pack/__init__.py]
+[file pack/mod.py]
+[file b.py]
+import pack.mod
+[file other.py]
+import a
+[out]
+[out2]


### PR DESCRIPTION
Previously some module dependencies genererated from `from m import *`
went missing, and this could result in crashes when deserialization,
since the target module wasn't serialized yet.

This fixes one incremental mode test case.