### PR TITLE
implement @no_type_check for class defs

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -162,6 +162,9 @@ def analyze_instance_member_access(name: str,
     if override_info:
         info = override_info
 
+    if info.is_no_type_check:
+        return AnyType(TypeOfAny.special_form)
+
     if (state.find_occurrences and
             info.name() == state.find_occurrences[0] and
             name == state.find_occurrences[1]):

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2219,6 +2219,7 @@ class TypeInfo(SymbolNode):
     metaclass_type = None  # type: Optional[mypy.types.Instance]
 
     names = None  # type: SymbolTable      # Names defined directly in this type
+    is_no_type_check = False               # Was the class annotated with @no_type_check?
     is_abstract = False                    # Does the class have any abstract attributes?
     is_protocol = False                    # Is this a protocol class?
     runtime_protocol = False               # Does this protocol support isinstance checks?

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -161,6 +161,8 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
             super().visit_overloaded_func_def(fdef)
 
     def visit_class_def(self, tdef: ClassDef) -> None:
+        if tdef.info.is_no_type_check:
+            return
         # NamedTuple base classes are validated in check_namedtuple_classdef; we don't have to
         # check them again here.
         self.scope.enter_class(tdef.info)


### PR DESCRIPTION
Fixes #607 (which is incorrectly titled).

This adds `TypeInfo.is_no_type_check`, and enables `TypeInfo.fallback_to_any` for classes decorated with `@no_type_check`, which is checked in a couple of places to abort the type checker early and stub method types as `Any`.

I'm not sure confident about my use of `decorator.name in ('no_type_check', 'typing.no_type_check'` in `semanal.py`. I see `RefName.fullname = 'typing.no_type_check'` was used elsewhere but it wasn't a RefName in the AST during `semanal` and I didn't look too far into that.

This is my current test:
```
from typing import no_type_check, Any

@no_type_check
class TestClass:
    bar: {'x': 1} = 1

    def meth1(): pass
    def meth2(a: {'x': 1}) -> {'x': 1}:
        def garbage_inner(a: {'x': 1}):
            pass

    def test(a: int): pass

TestClass().test(1)
TestClass().doesntexist()

class Test(TestClass):
    def test2(self, a: int): pass

t = Test()
t.meth1()
t.doesntexist2()
t.test(1)
t.test2(1)

x: int = TestClass().bar
```

With `@no_type_check`, mypy throws a `Missing return statement` for the nested `garbage_inner` definition, but suppresses the rest of the type errors for this class and subclass.

Without `@no_type_check`, we get this nice pile of errors:
```
repro.py:4: error: Invalid type comment or annotation
repro.py:6: error: Method must have at least one argument
repro.py:7: error: Invalid type comment or annotation
repro.py:8: error: Invalid type comment or annotation
repro.py:11: error: Self argument missing for a non-static method (or an invalid type for self)
repro.py:13: error: Too many arguments for "test" of "TestClass"
repro.py:14: error: "TestClass" has no attribute "doesntexist"
repro.py:21: error: "Test" has no attribute "doesntexist2"
repro.py:22: error: Too many arguments for "test" of "TestClass"
```

TODO (I'd like advice from core contributors on these):

- [ ] I think I should write in-tree tests for this, but I could use guidance on that.
- [ ] confirm my `decorator.name` check is correct.
- [ ] is it possible to suppress the `no return` error?
- [ ] am I missing any additional obvious class type behavior in my test that should be suppressed/stubbed by the decorator?