### PR TITLE
 Allow type ignores after type comments 

### DIFF
--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -303,7 +303,8 @@ class ASTConverter:
 
     def visit_Module(self, mod: ast27.Module) -> MypyFile:
         body = self.fix_function_overloads(self.translate_stmt_list(mod.body))
-        ignores = [ti.lineno for ti in mod.type_ignores] + self.extra_type_ignores
+        ignores = [ti.lineno for ti in mod.type_ignores]
+        ignores.extend(self.extra_type_ignores)
         return MypyFile(body,
                         self.imports,
                         False,
@@ -546,7 +547,7 @@ class ASTConverter:
         typ = None
         if n.type_comment:
             extra_ignore, typ = parse_type_comment(n.type_comment, n.lineno, self.errors,
-                                     assume_str_is_unicode=self.unicode_literals)
+                                                   assume_str_is_unicode=self.unicode_literals)
             if extra_ignore:
                 self.extra_type_ignores.append(n.lineno)
 
@@ -565,17 +566,17 @@ class ASTConverter:
     # For(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
     def visit_For(self, n: ast27.For) -> ForStmt:
         if n.type_comment is not None:
-            extra_ignore, target_type = parse_type_comment(n.type_comment, n.lineno, self.errors,
-                                             assume_str_is_unicode=self.unicode_literals)
+            extra_ignore, typ = parse_type_comment(n.type_comment, n.lineno, self.errors,
+                                                   assume_str_is_unicode=self.unicode_literals)
             if extra_ignore:
                 self.extra_type_ignores.append(n.lineno)
         else:
-            target_type = None
+            typ = None
         stmt = ForStmt(self.visit(n.target),
                        self.visit(n.iter),
                        self.as_required_block(n.body, n.lineno),
                        self.as_block(n.orelse, n.lineno),
-                       target_type)
+                       typ)
         return self.set_line(stmt, n)
 
     # While(expr test, stmt* body, stmt* orelse)
@@ -595,16 +596,16 @@ class ASTConverter:
     # With(withitem* items, stmt* body, string? type_comment)
     def visit_With(self, n: ast27.With) -> WithStmt:
         if n.type_comment is not None:
-            extra_ignore, target_type = parse_type_comment(n.type_comment, n.lineno, self.errors,
-                                             assume_str_is_unicode=self.unicode_literals)
+            extra_ignore, typ = parse_type_comment(n.type_comment, n.lineno, self.errors,
+                                                   assume_str_is_unicode=self.unicode_literals)
             if extra_ignore:
                 self.extra_type_ignores.append(n.lineno)
         else:
-            target_type = None
+            typ = None
         stmt = WithStmt([self.visit(n.context_expr)],
                         [self.visit(n.optional_vars)],
                         self.as_required_block(n.body, n.lineno),
-                        target_type)
+                        typ)
         return self.set_line(stmt, n)
 
     def visit_Raise(self, n: ast27.Raise) -> RaiseStmt:

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -88,6 +88,32 @@ def f4(x: Iterable[x][x]) -> None: pass # E: Invalid type comment or annotation
 def f5(x: Callable[..., int][x]) -> None: pass # E: Invalid type comment or annotation
 def f6(x: Callable[..., int].x) -> None: pass # E: Invalid type comment or annotation
 
+[case testFastParseTypeWithIgnore]
+def f(x,  # type: x  # type: ignore
+      ):
+    # type: (...) -> None
+    pass
+
+[case testFastParseVariableTypeWithIgnore]
+
+x = 1 # type: str # type: ignore
+
+[case testFastParseVariableTypeWithIgnoreNoSpace]
+
+x = 1 # type: str #type:ignore
+
+[case testFastParseVariableTypeWithIgnoreAndComment]
+
+x = 1 # type: str # type: ignore # comment
+
+[case testFastParseTypeWithIgnoreWithStmt]
+with open('test', 'r') as f:  # type: int  # type: ignore
+    pass
+
+[case testFastParseTypeWithIgnoreForStmt]
+for i in (1, 2, 3, 100):  # type: str # type: ignore
+    pass
+
 [case testFastParseProperty]
 
 class C:

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -114,6 +114,9 @@ with open('test', 'r') as f:  # type: int  # type: ignore
 for i in (1, 2, 3, 100):  # type: str # type: ignore
     pass
 
+[case testFastParseVariableCommentThenIgnore]
+a="test" # type: int #comment # type: ignore  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+
 [case testFastParseProperty]
 
 class C:


### PR DESCRIPTION
This is a hack in fastparse, but allows for the following to pass typechecking:

`x = 1  # type: str  # type: ignore`

This also handles the edge case where there is a `# type: ignore` in a comment, which we don't want to pick up. See the tests for more examples.

Fixes https://github.com/python/mypy/issues/5967
