### PR TITLE
Remove {*ignores} in fastparse, since mypyc does not support it

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -400,7 +400,7 @@ class ASTConverter:
         return MypyFile(body,
                         self.imports,
                         False,
-                        {*ignores},
+                        set(ignores),
                         )
 
     # --- stmt ---

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -308,7 +308,7 @@ class ASTConverter:
         return MypyFile(body,
                         self.imports,
                         False,
-                        {*ignores},
+                        set(ignores),
                         )
 
     # --- stmt ---


### PR DESCRIPTION
This fixes the mypyc build.