### PR TITLE
Produce a distribution named 'mypy' when built in mypyc mode

### DIFF
--- a/misc/download-mypyc-wheels.py
+++ b/misc/download-mypyc-wheels.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Script for downloading mypy_mypyc wheels in preparation for a release
+# Script for downloading mypyc-compiled mypy wheels in preparation for a release
 
 import os
 import os.path
@@ -16,7 +16,7 @@ PLATFORMS = [
 MIN_VER = 5
 MAX_VER = 7
 BASE_URL = "https://github.com/mypyc/mypy_mypyc-wheels/releases/download"
-URL = "{base}/v{version}/mypy_mypyc-{version}-cp3{pyver}-cp3{pyver}m-{platform}.whl"
+URL = "{base}/v{version}/mypy-{version}-cp3{pyver}-cp3{pyver}m-{platform}.whl"
 
 def download(url):
     print('Downloading', url)

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ classifiers = [
     'Topic :: Software Development',
 ]
 
-setup(name='mypy' if not USE_MYPYC else 'mypy-mypyc',
+setup(name='mypy',
       version=version,
       description=description,
       long_description=long_description,


### PR DESCRIPTION
This will allow us to distribute compiled packages by default for mypy.

This will require some changes to our dropbox internal infrastructure for using mypy_mypyc wheels but it shouldn't be a big deal.