### PR TITLE
Pin tox version to 3.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
 
 install:
 - pip install -U pip setuptools
-- pip install -U tox
+- pip install -U tox==3.7.0
 - tox --notest
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
 
 install:
     - "git submodule update --init mypy/typeshed"
-    - "%PYTHON%\\python.exe -m pip install -U setuptools tox"
+    - "%PYTHON%\\python.exe -m pip install -U setuptools tox==3.7.0"
     - "%PYTHON%\\python.exe -m tox -e py37 --notest"
 
 build: off


### PR DESCRIPTION
tox 3.8.0 broke something about how we specified dependencies.
I've filed a bug with tox, but let's just pin versions for now.