### PR TITLE
Add a get_additional_deps hook to Plugin to support django-stubs

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1967,7 +1967,9 @@ class State:
         dependencies = []
         priorities = {}  # type: Dict[str, int]  # id -> priority
         dep_line_map = {}  # type: Dict[str, int]  # id -> line
-        for pri, id, line in manager.all_imported_modules_in_file(self.tree):
+        dep_entries = (manager.all_imported_modules_in_file(self.tree) +
+                       self.manager.plugin.get_additional_deps(self.tree))
+        for pri, id, line in dep_entries:
             priorities[id] = min(pri, priorities.get(id, PRI_ALL))
             if id == self.id:
                 continue

--- a/mypy/interpreted_plugin.py
+++ b/mypy/interpreted_plugin.py
@@ -1,6 +1,6 @@
 """Hack for handling non-mypyc compiled plugins with a mypyc-compiled mypy"""
 
-from typing import Optional, Callable, Any, Dict
+from typing import Optional, Callable, Any, Dict, List, Tuple
 from mypy.options import Options
 from mypy.types import Type, CallableType
 from mypy.nodes import SymbolTableNode, MypyFile
@@ -38,6 +38,9 @@ class InterpretedPlugin:
     def lookup_fully_qualified(self, fullname: str) -> Optional[SymbolTableNode]:
         assert self._modules is not None
         return lookup_fully_qualified(fullname, self._modules)
+
+    def get_additional_deps(self, file: MypyFile) -> List[Tuple[int, str, int]]:
+        return []
 
     def get_type_analyze_hook(self, fullname: str
                               ) -> Optional[Callable[['mypy.plugin.AnalyzeTypeContext'], Type]]:

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -374,10 +374,14 @@ class Plugin(CommonPluginApi):
     def get_additional_deps(self, file: MypyFile) -> List[Tuple[int, str, int]]:
         """Customize dependencies for a module.
 
-        This hook allows adding in new dependencies for a module. It is called
-        after parsing a file but before analysis.
+        This hook allows adding in new dependencies for a module. It
+        is called after parsing a file but before analysis. This can
+        be useful if a library has dependencies that are dynamic based
+        on configuration information, for example.
 
         Returns a list of (priority, module name, line number) tuples.
+
+        The line number can be -1 when there is not a known real line number.
 
         Priorities are defined in mypy.build (but maybe shouldn't be).
         10 is a good choice for priority.

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -371,6 +371,19 @@ class Plugin(CommonPluginApi):
         assert self._modules is not None
         return lookup_fully_qualified(fullname, self._modules)
 
+    def get_additional_deps(self, file: MypyFile) -> List[Tuple[int, str, int]]:
+        """Customize dependencies for a module.
+
+        This hook allows adding in new dependencies for a module. It is called
+        after parsing a file but before analysis.
+
+        Returns a list of (priority, module name, line number) tuples.
+
+        Priorities are defined in mypy.build (but maybe shouldn't be).
+        10 is a good choice for priority.
+        """
+        return []
+
     def get_type_analyze_hook(self, fullname: str
                               ) -> Optional[Callable[[AnalyzeTypeContext], Type]]:
         """Customize behaviour of the type analyzer for given full names.
@@ -395,7 +408,7 @@ class Plugin(CommonPluginApi):
         """Adjust the return type of a function call.
 
         This method is called after type checking a call. Plugin may adjust the return
-        type inferred by mypy, and/or emmit some error messages. Note, this hook is also
+        type inferred by mypy, and/or emit some error messages. Note, this hook is also
         called for class instantiation calls, so that in this example:
 
             from lib import Class, do_stuff
@@ -561,6 +574,9 @@ class WrapperPlugin(Plugin):
     def lookup_fully_qualified(self, fullname: str) -> Optional[SymbolTableNode]:
         return self.plugin.lookup_fully_qualified(fullname)
 
+    def get_additional_deps(self, file: MypyFile) -> List[Tuple[int, str, int]]:
+        return self.plugin.get_additional_deps(file)
+
     def get_type_analyze_hook(self, fullname: str
                               ) -> Optional[Callable[[AnalyzeTypeContext], Type]]:
         return self.plugin.get_type_analyze_hook(fullname)
@@ -625,6 +641,12 @@ class ChainedPlugin(Plugin):
     def set_modules(self, modules: Dict[str, MypyFile]) -> None:
         for plugin in self._plugins:
             plugin.set_modules(modules)
+
+    def get_additional_deps(self, file: MypyFile) -> List[Tuple[int, str, int]]:
+        deps = []
+        for plugin in self._plugins:
+            deps.extend(plugin.get_additional_deps(file))
+        return deps
 
     def get_type_analyze_hook(self, fullname: str
                               ) -> Optional[Callable[[AnalyzeTypeContext], Type]]:

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -71,7 +71,6 @@ tmp/mypy.ini:2: error: Can't find plugin 'tmp/missing.py'
 plugins=missing
 [out]
 tmp/mypy.ini:2: error: Error importing plugin 'missing'
---' (work around syntax highlighting)
 
 [case testMultipleSectionsDefinePlugin]
 # flags: --config-file tmp/mypy.ini
@@ -585,3 +584,17 @@ reveal_type(instance(2))  # E: Revealed type is 'builtins.float*'
 [file mypy.ini]
 [[mypy]
 plugins=<ROOT>/test-data/unit/plugins/callable_instance.py
+
+
+[case testPluginDependencies]
+# flags: --config-file tmp/mypy.ini
+
+# The top level file here doesn't do anything, but the plugin should add
+# a dependency on err that will cause err to be processed and an error reported.
+
+[file err.py]
+1 + 'lol'  # E: Unsupported operand types for + ("int" and "str")
+
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/depshook.py

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -585,7 +585,6 @@ reveal_type(instance(2))  # E: Revealed type is 'builtins.float*'
 [[mypy]
 plugins=<ROOT>/test-data/unit/plugins/callable_instance.py
 
-
 [case testPluginDependencies]
 # flags: --config-file tmp/mypy.ini
 

--- a/test-data/unit/plugins/depshook.py
+++ b/test-data/unit/plugins/depshook.py
@@ -1,0 +1,15 @@
+from typing import Optional, Callable, List, Tuple
+
+from mypy.plugin import Plugin
+from mypy.nodes import MypyFile
+
+
+class DepsPlugin(Plugin):
+    def get_additional_deps(self, file: MypyFile) -> List[Tuple[int, str, int]]:
+        if file.fullname() == '__main__':
+            return [(10, 'err', -1)]
+        return []
+
+
+def plugin(version):
+    return DepsPlugin


### PR DESCRIPTION
django-stubs needs to be able to add in additional dependencies to
modules and is currently using monkeypatching to do it.

That is 1) not great and 2) breaks under mypyc.
Add a hook to support generating additional dependencies from a plugin.

One thing I'm unsure about with this PR is the handling of priorities. I'm not sure that being able to specify priorities is necessary, but I am reluctant to leave them out of the API and then need to either have two hooks or a breaking change when it turns out that something does need them. The priority constants are all defined in mypy.build, which plugins probably shouldn't be importing, but moving them to a new file seems like overkill for a super marginal plugin use case.

This should allow a fix for https://github.com/mkurnikov/django-stubs/issues/48. @mkurnikov could you try updating django-stubs to work with this PR so that we can validate it and cherry-pick it for the release?