### PR TITLE
New semantic analyzer: support module-level __getattr__

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -34,7 +34,7 @@ from mypy_extensions import TypedDict
 
 from mypy.nodes import MypyFile, ImportBase, Import, ImportFrom, ImportAll, SymbolTable
 from mypy.semanal_pass1 import SemanticAnalyzerPass1
-from mypy.newsemanal.semanal_pass1 import ReachabilityAnalyzer
+from mypy.newsemanal.semanal_pass1 import SemanticAnalyzerPreAnalysis
 from mypy.semanal import SemanticAnalyzerPass2, apply_semantic_analyzer_patches
 from mypy.semanal_pass3 import SemanticAnalyzerPass3
 from mypy.newsemanal.semanal import NewSemanticAnalyzer
@@ -1934,7 +1934,7 @@ class State:
             # TODO: Once we remove the old semantic analyzer, this no longer should
             #     be considered as a semantic analysis pass -- it's an independent
             #     pass.
-            analyzer = ReachabilityAnalyzer()
+            analyzer = SemanticAnalyzerPreAnalysis()
             with self.wrap_context():
                 analyzer.visit_file(self.tree, self.xpath, self.id, options)
             # TODO: Do this while contructing the AST?

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -4187,7 +4187,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     and not is_same_var_from_getattr(old_node, new_node)):
                 if isinstance(new_node, (FuncDef, Decorator)):
                     self.add_func_redefinition(names, name, symbol)
-                if not (isinstance(symbol.node, (FuncDef, Decorator))
+                if not (isinstance(new_node, (FuncDef, Decorator))
                         and self.set_original_def(old_node, new_node)):
                     self.name_already_defined(name, context, existing)
         elif name not in self.missing_names and '*' not in self.missing_names:
@@ -4509,7 +4509,7 @@ def names_modified_in_lvalue(lvalue: Lvalue) -> List[NameExpr]:
     return []
 
 
-def is_same_var_from_getattr(n1: SymbolNode, n2: SymbolNode) -> bool:
+def is_same_var_from_getattr(n1: Optional[SymbolNode], n2: Optional[SymbolNode]) -> bool:
     """Do n1 and n2 refer to the same Var derived from module-level __getattr__?"""
     return (isinstance(n1, Var)
             and n1.from_module_getattr

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1628,10 +1628,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             # If it is still not resolved, check for a module level __getattr__
             if (module and not node and (module.is_stub or self.options.python_version >= (3, 7))
                     and '__getattr__' in module.names):
-                if self.type:
-                    fullname = self.type.fullname() + "." + imported_id
-                else:
-                    fullname = self.qualified_name(imported_id)
+                fullname = import_id + '.' + id
                 gvar = self.create_getattr_var(module.names['__getattr__'], imported_id, fullname)
                 if gvar:
                     self.add_symbol(imported_id, gvar, imp)
@@ -3874,13 +3871,11 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                         if (not n
                                 and '__getattr__' in names
                                 and not self.is_incomplete_namespace(namespace)):
+                            fullname = namespace + '.' + '.'.join(parts[i:])
                             gvar = self.create_getattr_var(names['__getattr__'],
-                                                           parts[i], parts[i])
+                                                           parts[i], fullname)
                             if gvar:
                                 n = SymbolTableNode(GDEF, gvar)
-                                # TODO: Enable this (the purpose is likely to preserve the
-                                #       identity of the Var node if there are multiple imports)
-                                # names[name] = n
                     # TODO: What if node is Var or FuncDef?
                     # Currently, missing these cases results in controversial behavior, when
                     # lookup_qualified(x.y.z) returns Var(x).
@@ -3942,7 +3937,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
     def create_getattr_var(self, getattr_defn: SymbolTableNode,
                            name: str, fullname: str) -> Optional[Var]:
-        """Create a dummy variable using __getattr__ return type.
+        """Create a dummy variable using module-level __getattr__ return type.
 
         If not possible, return None.
         """
@@ -3953,6 +3948,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 typ = AnyType(TypeOfAny.from_error)
             v = Var(name, type=typ)
             v._fullname = fullname
+            v.from_module_getattr = True
             return v
         return None
 
@@ -4183,13 +4179,16 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             # If the new node points to the same node as the old one,
             # or if both old and new nodes are placeholders, we don't
             # need to do anything.
-            if (existing.node != symbol.node
-                    and not (isinstance(existing.node, PlaceholderNode)
-                             and isinstance(symbol.node, PlaceholderNode))):
-                if isinstance(symbol.node, (FuncDef, Decorator)):
+            old_node = existing.node
+            new_node = symbol.node
+            if (old_node != new_node
+                    and not (isinstance(old_node, PlaceholderNode)
+                             and isinstance(new_node, PlaceholderNode))
+                    and not is_same_var_from_getattr(old_node, new_node)):
+                if isinstance(new_node, (FuncDef, Decorator)):
                     self.add_func_redefinition(names, name, symbol)
                 if not (isinstance(symbol.node, (FuncDef, Decorator))
-                        and self.set_original_def(existing.node, symbol.node)):
+                        and self.set_original_def(old_node, new_node)):
                     self.name_already_defined(name, context, existing)
         elif name not in self.missing_names and '*' not in self.missing_names:
             names[name] = symbol
@@ -4508,3 +4507,12 @@ def names_modified_in_lvalue(lvalue: Lvalue) -> List[NameExpr]:
             result += names_modified_in_lvalue(item)
         return result
     return []
+
+
+def is_same_var_from_getattr(n1: SymbolNode, n2: SymbolNode) -> bool:
+    """Do n1 and n2 refer to the same Var derived from module-level __getattr__?"""
+    return (isinstance(n1, Var)
+            and n1.from_module_getattr
+            and isinstance(n2, Var)
+            and n2.from_module_getattr
+            and n1.fullname() == n2.fullname())

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -778,7 +778,8 @@ class Var(SymbolNode):
                  'final_unset_in_class',
                  'final_set_in_init',
                  'is_suppressed_import',
-                 'explicit_self_type'
+                 'explicit_self_type',
+                 'from_module_getattr',
                  )
 
     def __init__(self, name: str, type: 'Optional[mypy.types.Type]' = None) -> None:
@@ -821,6 +822,8 @@ class Var(SymbolNode):
         # present in a superclass (without explict type this doesn't create a new Var).
         # See SemanticAnalyzer.analyze_member_lvalue() for details.
         self.explicit_self_type = False
+        # If True, this is an implicit Var created due to module-level __getattr__.
+        self.from_module_getattr = False
 
     def name(self) -> str:
         return self._name

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -5069,6 +5069,9 @@ class C(B):
 [case testGetAttrImportAnnotation]
 import a
 x: a.A
+y: a.A.B.C
+reveal_type(x)  # E: Revealed type is 'Any'
+reveal_type(y)  # E: Revealed type is 'Any'
 [file a.pyi]
 from typing import Any
 def __getattr__(attr: str) -> Any: ...

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4968,3 +4968,20 @@ class C:
 [out]
 [out2]
 tmp/a.py:3: error: Revealed type is 'Tuple[builtins.int, fallback=b.C.Hidden@5]'
+
+[case testIncrementalNodeCreatedFromGetattr]
+import a
+[file a.py]
+from b import C
+c: C
+[file b.py]
+from c import C
+[file c.pyi]
+def __getattr__(s): ...
+[file a.py.2]
+from b import C
+c: C
+reveal_type(c)
+[out]
+[out2]
+tmp/a.py:3: error: Revealed type is 'Any'

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2040,6 +2040,19 @@ def __getattr__(name: str) -> Any: ...
 
 [builtins fixtures/module.pyi]
 
+[case testModuleLevelGetattrImportFromAsTwice]
+# flags: --new-semantic-analyzer
+from has_attr import name
+from has_attr import name
+from has_attr import x
+from has_attr import y as x  # E: Name 'x' already defined (possibly by an import)
+reveal_type(name)  # E: Revealed type is 'builtins.int'
+
+[file has_attr.pyi]
+from typing import Any
+def __getattr__(name: str) -> int: ...
+
+
 [case testModuleLevelGetattrAssignedGood]
 # flags: --python-version 3.7
 import non_stub

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2030,8 +2030,6 @@ def __getattr__(name: str) -> Any: ...
 [builtins fixtures/module.pyi]
 
 [case testModuleLevelGetattrImportFromAs]
-# FIXME: #6314
-# flags: --no-new-semantic-analyzer
 from has_attr import name as n
 reveal_type(name)  # E: Revealed type is 'Any'  # E: Name 'name' is not defined
 reveal_type(n)  # E: Revealed type is 'Any'
@@ -2221,8 +2219,6 @@ def __getattr__(attr: str) -> Any: ...
 [out]
 
 [case testModuleGetattrInit2]
-# FIXME: #6314
-# flags: --no-new-semantic-analyzer
 import a.b
 
 x = a.b.f()
@@ -2245,8 +2241,6 @@ main:1: error: Cannot find module named 'a.b'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testModuleGetattrInit4]
-# FIXME: #6314
-# flags: --no-new-semantic-analyzer
 import a.b.c
 
 x = a.b.c.f()
@@ -2257,8 +2251,6 @@ def __getattr__(attr: str) -> Any: ...
 [out]
 
 [case testModuleGetattrInit5]
-# FIXME: #6314
-# flags: --no-new-semantic-analyzer
 from a.b import f
 
 x = f()
@@ -2269,8 +2261,6 @@ def __getattr__(attr: str) -> Any: ...
 [out]
 
 [case testModuleGetattrInit5a]
-# FIXME: #6314
-# flags: --no-new-semantic-analyzer
 from a.b import f
 
 x = f()
@@ -2282,6 +2272,8 @@ def __getattr__(attr: str) -> ModuleType: ...
 
 
 [case testModuleGetattrInit5b]
+# This likely won't be supported by the new semantic analyzer.
+# flags: --no-new-semantic-analyzer
 from a.b import f
 
 x = f()
@@ -2289,8 +2281,8 @@ x = f()
 def __getattr__(attr: str) -> int: ...
 [builtins fixtures/module.pyi]
 [out]
-main:1: error: Cannot find module named 'a.b'
-main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
+main:3: error: Cannot find module named 'a.b'
+main:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testModuleGetattrInit8]
 import a.b.c.d
@@ -2308,8 +2300,6 @@ main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missin
 main:1: error: Cannot find module named 'a.b.c'
 
 [case testModuleGetattrInit8a]
-# FIXME: #6314
-# flags: --no-new-semantic-analyzer
 import a.b.c  # E: Cannot find module named 'a.b.c'  # N: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 import a.d  # OK
 [file a/__init__.pyi]

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1993,9 +1993,7 @@ def f(x: str) -> None: pass
 ==
 main:3: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 
--- Depends on #6314
 [case testFineAddedMissingStubsPackagePartialGetAttr]
-# flags: --no-new-semantic-analyzer
 import package.missing
 package.missing.f(int())
 [file package/__init__.pyi]
@@ -2005,7 +2003,7 @@ def __getattr__(attr: str) -> Any: ...
 def f(x: str) -> None: pass
 [out]
 ==
-main:3: error: Argument 1 to "f" has incompatible type "int"; expected "str"
+main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 
 [case testFineAddedMissingStubsIgnore]
 from missing import f  # type: ignore


### PR DESCRIPTION
This is slightly different from how it's implemented in the old
semantic analyzer. We don't try to check the return type, since
we can't generally do this during the initial pass. The approach
used in the old semantic samalyzer is hacky and does not always
work.

Fixes #6314.