### PR TITLE
New semantic analyzer: fix type promotions special cases

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2260,7 +2260,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
             # Step 1: We first try leaving the right arguments alone and destructure
             # just the left ones. (Mypy can sometimes perform some more precise inference
-            # if we leave the right operands a union -- see testOperatorWithEmptyListAndSum.
+            # if we leave the right operands a union -- see testOperatorWithEmptyListAndSum.)
             msg = self.msg.clean_copy()
             msg.disable_count = 0
             all_results = []

--- a/mypy/newsemanal/semanal_classprop.py
+++ b/mypy/newsemanal/semanal_classprop.py
@@ -5,9 +5,47 @@ These happen after semantic analysis and before type checking.
 
 from typing import List, Set, Optional
 
-from mypy.nodes import Node, TypeInfo, Var, Decorator, OverloadedFuncDef
-from mypy.types import Instance
+from mypy.nodes import (
+    Node, TypeInfo, Var, Decorator, OverloadedFuncDef, SymbolTable, CallExpr, PromoteExpr,
+)
+from mypy.types import Instance, Type
 from mypy.errors import Errors
+from mypy.options import Options
+
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
+
+
+# Hard coded type promotions (shared between all Python versions).
+# These add extra ad-hoc edges to the subtyping relation. For example,
+# int is considered a subtype of float, even though there is no
+# subclass relationship.
+TYPE_PROMOTIONS = {
+    'builtins.int': 'float',
+    'builtins.float': 'complex',
+}  # type: Final
+
+# Hard coded type promotions for Python 3.
+#
+# Note that the bytearray -> bytes promotion is a little unsafe
+# as some functions only accept bytes objects. Here convenience
+# trumps safety.
+TYPE_PROMOTIONS_PYTHON3 = TYPE_PROMOTIONS.copy()  # type: Final
+TYPE_PROMOTIONS_PYTHON3.update({
+    'builtins.bytearray': 'bytes',
+})
+
+# Hard coded type promotions for Python 2.
+#
+# These promotions are unsafe, but we are doing them anyway
+# for convenience and also for Python 3 compatibility
+# (bytearray -> str).
+TYPE_PROMOTIONS_PYTHON2 = TYPE_PROMOTIONS.copy()  # type: Final
+TYPE_PROMOTIONS_PYTHON2.update({
+    'builtins.str': 'unicode',
+    'builtins.bytearray': 'str',
+})
 
 
 def calculate_class_abstract_status(typ: TypeInfo, is_stub_file: bool, errors: Errors) -> None:
@@ -94,3 +132,29 @@ def calculate_class_vars(info: TypeInfo) -> None:
                         and isinstance(member.node, Var)
                         and member.node.is_classvar):
                     node.is_classvar = True
+
+
+def add_type_promotion(info: TypeInfo, module_names: SymbolTable, options: Options) -> None:
+    """Setup extra, ad-hoc subtyping relationships between classes (promotion).
+
+    This includes things like 'int' being compatible with 'float'.
+    """
+    defn = info.defn
+    promote_target = None  # type: Optional[Type]
+    for decorator in defn.decorators:
+        if isinstance(decorator, CallExpr):
+            analyzed = decorator.analyzed
+            if isinstance(analyzed, PromoteExpr):
+                # _promote class decorator (undocumented feature).
+                promote_target = analyzed.type
+    if not promote_target:
+        promotions = (TYPE_PROMOTIONS_PYTHON3 if options.python_version[0] >= 3
+                      else TYPE_PROMOTIONS_PYTHON2)
+        if defn.fullname in promotions:
+            target_sym = module_names.get(promotions[defn.fullname])
+            # With test stubs, the target may not exist.
+            if target_sym:
+                target_info = target_sym.node
+                assert isinstance(target_info, TypeInfo)
+                promote_target = Instance(target_info, [])
+    defn.info._promote = promote_target

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -36,7 +36,8 @@ from mypy.newsemanal.semanal import (
     NewSemanticAnalyzer, apply_semantic_analyzer_patches, remove_imported_names_from_symtable
 )
 from mypy.newsemanal.semanal_classprop import (
-    calculate_class_abstract_status, calculate_class_vars, check_protocol_status
+    calculate_class_abstract_status, calculate_class_vars, check_protocol_status,
+    add_type_promotion
 )
 from mypy.errors import Errors
 from mypy.newsemanal.semanal_infer import infer_decorator_signature_if_simple
@@ -327,6 +328,7 @@ def calculate_class_properties(graph: 'Graph', scc: List[str], errors: Errors) -
                     calculate_class_abstract_status(node.node, tree.is_stub, errors)
                     check_protocol_status(node.node, errors)
                     calculate_class_vars(node.node)
+                    add_type_promotion(node.node, tree.names, graph[module].options)
 
 
 def check_blockers(graph: 'Graph', scc: List[str]) -> None:

--- a/mypy/test/hacks.py
+++ b/mypy/test/hacks.py
@@ -8,7 +8,6 @@ if MYPY:
 # Files to not run with new semantic analyzer.
 new_semanal_blacklist = [
     'check-async-await.test',
-    'check-expressions.test',
     'check-flags.test',
     'check-functions.test',
     'check-incremental.test',


### PR DESCRIPTION
Set up type promotions after the main semantic analyzer pass to
avoid the need to defer.  This fixes an issue with test stubs,
but the existing approach probably worked with typeshed.
Another benefit of this approach is that things are easier to
reason about, as the main semantic analysis pass is a bit
simpler.

This fixes the `testDivmod` type checker test case.