### PR TITLE
New semantic analyzer: fix deserialization crash with module __getattr__

### DIFF
--- a/mypy/lookup.py
+++ b/mypy/lookup.py
@@ -44,7 +44,7 @@ def lookup_fully_qualified(name: str, modules: Dict[str, MypyFile],
         key = rest.pop()
         if key not in names:
             if raise_on_missing:
-                assert key in names, "Cannot find %s for %s" % (key, name)
+                assert key in names, "Cannot find component %r for %r" % (key, name)
             return None
         stnode = names[key]
         if not rest:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2938,7 +2938,9 @@ class SymbolTableNode:
                 if prefix is not None:
                     fullname = self.node.fullname()
                     if (fullname is not None and '.' in fullname and
-                            fullname != prefix + '.' + name):
+                            fullname != prefix + '.' + name
+                            and not (isinstance(self.node, Var)
+                                     and self.node.from_module_getattr)):
                         data['cross_ref'] = fullname
                         return data
                 data['node'] = self.node.serialize()

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2035,3 +2035,17 @@ import pack.mod
 import a
 [out]
 [out2]
+
+[case testNewAnalyzerModuleGetattrSerialize_incremental]
+import a
+[file a.py]
+import p
+[file a.py.2]
+import p
+reveal_type(p.y)
+[file p.pyi]
+from pp import x as y
+[file pp.pyi]
+def __getattr__(attr): ...
+[out2]
+tmp/a.py:2: error: Revealed type is 'Any'


### PR DESCRIPTION
We could generate a cross ref to a dummy node from module-level
`__getattr__` which would cause a crash.