### PR TITLE
 New semantic analyzer: fix "with" statement with type annotation

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3113,9 +3113,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     def visit_with_stmt(self, s: WithStmt) -> None:
         for expr, target in zip(s.expr, s.target):
             if s.is_async:
-                self.check_async_with_item(expr, target, s.target_type is None)
+                self.check_async_with_item(expr, target, s.unanalyzed_type is None)
             else:
-                self.check_with_item(expr, target, s.target_type is None)
+                self.check_with_item(expr, target, s.unanalyzed_type is None)
         self.accept(s.body)
 
     def check_untyped_after_decorator(self, typ: Type, func: FuncDef) -> None:

--- a/mypy/mixedtraverser.py
+++ b/mypy/mixedtraverser.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from mypy.nodes import (
-    MypyFile, Var, FuncItem, ClassDef, AssignmentStmt, OperatorAssignmentStmt, ForStmt,
+    MypyFile, Var, FuncItem, ClassDef, AssignmentStmt, OperatorAssignmentStmt, ForStmt, WithStmt,
     CastExpr, TypeApplication, TypeAliasExpr, TypeVarExpr, TypedDictExpr, NamedTupleExpr,
     EnumCallExpr, PromoteExpr, NewTypeExpr
 )
@@ -67,6 +67,11 @@ class MixedTraverserVisitor(TraverserVisitor, TypeTraverserVisitor):
     def visit_for_stmt(self, o: ForStmt) -> None:
         super().visit_for_stmt(o)
         self.visit_optional_type(o.index_type)
+
+    def visit_with_stmt(self, o: WithStmt) -> None:
+        super().visit_with_stmt(o)
+        for typ in o.analyzed_types:
+            typ.accept(self)
 
     # Expressions
 

--- a/mypy/mixedtraverser.py
+++ b/mypy/mixedtraverser.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from mypy.nodes import (
-    MypyFile, Var, FuncItem, ClassDef, AssignmentStmt, OperatorAssignmentStmt, ForStmt, WithStmt,
+    MypyFile, Var, FuncItem, ClassDef, AssignmentStmt, OperatorAssignmentStmt, ForStmt,
     CastExpr, TypeApplication, TypeAliasExpr, TypeVarExpr, TypedDictExpr, NamedTupleExpr,
     EnumCallExpr, PromoteExpr, NewTypeExpr
 )
@@ -67,10 +67,6 @@ class MixedTraverserVisitor(TraverserVisitor, TypeTraverserVisitor):
     def visit_for_stmt(self, o: ForStmt) -> None:
         super().visit_for_stmt(o)
         self.visit_optional_type(o.index_type)
-
-    def visit_with_stmt(self, o: WithStmt) -> None:
-        super().visit_with_stmt(o)
-        self.visit_optional_type(o.target_type)
 
     # Expressions
 

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3139,6 +3139,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                         new_types.append(analyzed)
                         self.store_declared_types(n, analyzed)
 
+        s.analyzed_types = new_types
+
         self.visit_block(s.body)
 
     def visit_del_stmt(self, s: DelStmt) -> None:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3102,18 +3102,18 @@ class NewSemanticAnalyzer(NodeVisitor[None],
     def visit_with_stmt(self, s: WithStmt) -> None:
         types = []  # type: List[Type]
 
-        if s.target_type:
+        if s.unanalyzed_type:
             actual_targets = [t for t in s.target if t is not None]
             if len(actual_targets) == 0:
                 # We have a type for no targets
                 self.fail('Invalid type comment', s)
             elif len(actual_targets) == 1:
                 # We have one target and one type
-                types = [s.target_type]
-            elif isinstance(s.target_type, TupleType):
+                types = [s.unanalyzed_type]
+            elif isinstance(s.unanalyzed_type, TupleType):
                 # We have multiple targets and multiple types
-                if len(actual_targets) == len(s.target_type.items):
-                    types = s.target_type.items
+                if len(actual_targets) == len(s.unanalyzed_type.items):
+                    types = s.unanalyzed_type.items
                 else:
                     # But it's the wrong number of items
                     self.fail('Incompatible number of types for `with` targets', s)
@@ -3125,7 +3125,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         for e, n in zip(s.expr, s.target):
             e.accept(self)
             if n:
-                self.analyze_lvalue(n, explicit_type=s.target_type is not None)
+                self.analyze_lvalue(n, explicit_type=s.unanalyzed_type is not None)
 
                 # Since we have a target, pop the next type from types
                 if types:
@@ -3138,13 +3138,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                         # TODO: Deal with this better
                         new_types.append(analyzed)
                         self.store_declared_types(n, analyzed)
-
-        # Reverse the logic above to correctly reassign target_type
-        if new_types:
-            if len(s.target) == 1:
-                s.target_type = new_types[0]
-            elif isinstance(s.target_type, TupleType):
-                s.target_type = s.target_type.copy_modified(items=new_types)
 
         self.visit_block(s.body)
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1199,6 +1199,7 @@ class WithStmt(Statement):
     target = None  # type: List[Optional[Lvalue]]
     # Type given by type comments for target, can be None
     unanalyzed_type = None  # type: Optional[mypy.types.Type]
+    analyzed_types = None  # type: List[mypy.types.Type]
     body = None  # type: Block
     is_async = False  # True if `async with ...` (PEP 492, Python 3.5)
 
@@ -1208,6 +1209,7 @@ class WithStmt(Statement):
         self.expr = expr
         self.target = target
         self.unanalyzed_type = target_type
+        self.analyzed_types = []
         self.body = body
 
     def accept(self, visitor: StatementVisitor[T]) -> T:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1199,6 +1199,7 @@ class WithStmt(Statement):
     target = None  # type: List[Optional[Lvalue]]
     # Type given by type comments for target, can be None
     unanalyzed_type = None  # type: Optional[mypy.types.Type]
+    # Semantically analyzed types from type comment (TypeList type expanded)
     analyzed_types = None  # type: List[mypy.types.Type]
     body = None  # type: Block
     is_async = False  # True if `async with ...` (PEP 492, Python 3.5)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1198,7 +1198,7 @@ class WithStmt(Statement):
     expr = None  # type: List[Expression]
     target = None  # type: List[Optional[Lvalue]]
     # Type given by type comments for target, can be None
-    target_type = None  # type: Optional[mypy.types.Type]
+    unanalyzed_type = None  # type: Optional[mypy.types.Type]
     body = None  # type: Block
     is_async = False  # True if `async with ...` (PEP 492, Python 3.5)
 
@@ -1207,7 +1207,7 @@ class WithStmt(Statement):
         super().__init__()
         self.expr = expr
         self.target = target
-        self.target_type = target_type
+        self.unanalyzed_type = target_type
         self.body = body
 
     def accept(self, visitor: StatementVisitor[T]) -> T:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2817,18 +2817,18 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
     def visit_with_stmt(self, s: WithStmt) -> None:
         types = []  # type: List[Type]
 
-        if s.target_type:
+        if s.unanalyzed_type:
             actual_targets = [t for t in s.target if t is not None]
             if len(actual_targets) == 0:
                 # We have a type for no targets
                 self.fail('Invalid type comment', s)
             elif len(actual_targets) == 1:
                 # We have one target and one type
-                types = [s.target_type]
-            elif isinstance(s.target_type, TupleType):
+                types = [s.unanalyzed_type]
+            elif isinstance(s.unanalyzed_type, TupleType):
                 # We have multiple targets and multiple types
-                if len(actual_targets) == len(s.target_type.items):
-                    types = s.target_type.items
+                if len(actual_targets) == len(s.unanalyzed_type.items):
+                    types = s.unanalyzed_type.items
                 else:
                     # But it's the wrong number of items
                     self.fail('Incompatible number of types for `with` targets', s)
@@ -2840,7 +2840,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         for e, n in zip(s.expr, s.target):
             e.accept(self)
             if n:
-                self.analyze_lvalue(n, explicit_type=s.target_type is not None)
+                self.analyze_lvalue(n, explicit_type=s.unanalyzed_type is not None)
 
                 # Since we have a target, pop the next type from types
                 if types:
@@ -2851,13 +2851,6 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                     t = self.anal_type(t, allow_tuple_literal=allow_tuple_literal)
                     new_types.append(t)
                     self.store_declared_types(n, t)
-
-        # Reverse the logic above to correctly reassign target_type
-        if new_types:
-            if len(s.target) == 1:
-                s.target_type = new_types[0]
-            elif isinstance(s.target_type, TupleType):
-                s.target_type = s.target_type.copy_modified(items=new_types)
 
         self.visit_block(s.body)
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2852,6 +2852,8 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                     new_types.append(t)
                     self.store_declared_types(n, t)
 
+        s.analyzed_types = new_types
+
         self.visit_block(s.body)
 
     def visit_del_stmt(self, s: DelStmt) -> None:

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -320,7 +320,7 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
         if self.sem.is_module_scope():
             for n in s.target:
                 if n:
-                    self.analyze_lvalue(n, explicit_type=s.target_type is not None)
+                    self.analyze_lvalue(n, explicit_type=s.unanalyzed_type is not None)
             s.body.accept(self)
 
     def visit_decorator(self, d: Decorator) -> None:

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -309,6 +309,11 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
         self.analyze(s.index_type, s)
         super().visit_for_stmt(s)
 
+    def visit_with_stmt(self, s: WithStmt) -> None:
+        for typ in s.analyzed_types:
+            self.analyze(typ, s)
+        super().visit_with_stmt(s)
+
     def visit_cast_expr(self, e: CastExpr) -> None:
         self.analyze(e.type, e)
         super().visit_cast_expr(e)
@@ -330,6 +335,7 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
                 node.index_type = transform(node.index_type)
             self.transform_types_in_lvalue(node.index, transform)
         if isinstance(node, WithStmt):
+            node.analyzed_types = [transform(typ) for typ in node.analyzed_types]
             for n in node.target:
                 if isinstance(n, NameExpr) and isinstance(n.node, Var) and n.node.type:
                     n.node.type = transform(n.node.type)

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -309,10 +309,6 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
         self.analyze(s.index_type, s)
         super().visit_for_stmt(s)
 
-    def visit_with_stmt(self, s: WithStmt) -> None:
-        self.analyze(s.target_type, s)
-        super().visit_with_stmt(s)
-
     def visit_cast_expr(self, e: CastExpr) -> None:
         self.analyze(e.type, e)
         super().visit_cast_expr(e)
@@ -334,8 +330,6 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
                 node.index_type = transform(node.index_type)
             self.transform_types_in_lvalue(node.index, transform)
         if isinstance(node, WithStmt):
-            if node.target_type:
-                node.target_type = transform(node.target_type)
             for n in node.target:
                 if isinstance(n, NameExpr) and isinstance(n.node, Var) and n.node.type:
                     n.node.type = transform(n.node.type)

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -44,7 +44,7 @@ from mypy.nodes import (
     Node, FuncDef, NameExpr, MemberExpr, RefExpr, MypyFile, ClassDef, AssignmentStmt,
     ImportFrom, Import, TypeInfo, SymbolTable, Var, CallExpr, Decorator, OverloadedFuncDef,
     SuperExpr, UNBOUND_IMPORTED, GDEF, MDEF, IndexExpr, SymbolTableNode, ImportAll, TupleExpr,
-    ListExpr, ForStmt, Block, SymbolNode, StarExpr
+    ListExpr, ForStmt, Block, SymbolNode, StarExpr, WithStmt
 )
 from mypy.semanal_shared import create_indirect_imported_name
 from mypy.traverser import TraverserVisitor
@@ -260,6 +260,10 @@ class NodeStripVisitor(TraverserVisitor):
         node.inferred_item_type = None
         node.inferred_iterator_type = None
         super().visit_for_stmt(node)
+
+    def visit_with_stmt(self, node: WithStmt) -> None:
+        super().visit_with_stmt(node)
+        node.analyzed_types = []
 
     def visit_name_expr(self, node: NameExpr) -> None:
         # Global assignments are processed in semantic analysis pass 1 [*], and we

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -551,8 +551,6 @@ class DependencyVisitor(TraverserVisitor):
             else:
                 self.add_attribute_dependency_for_expr(e, '__aenter__')
                 self.add_attribute_dependency_for_expr(e, '__aexit__')
-        if o.target_type:
-            self.add_type_dependencies(o.target_type)
 
     def visit_print_stmt(self, o: PrintStmt) -> None:
         super().visit_print_stmt(o)

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -551,6 +551,8 @@ class DependencyVisitor(TraverserVisitor):
             else:
                 self.add_attribute_dependency_for_expr(e, '__aenter__')
                 self.add_attribute_dependency_for_expr(e, '__aexit__')
+        for typ in o.analyzed_types:
+            self.add_type_dependencies(typ)
 
     def visit_print_stmt(self, o: PrintStmt) -> None:
         super().visit_print_stmt(o)

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -296,8 +296,8 @@ class StrConv(NodeVisitor[str]):
             a.append(('Expr', [o.expr[i]]))
             if o.target[i]:
                 a.append(('Target', [o.target[i]]))
-        if o.target_type:
-            a.append(o.target_type)
+        if o.unanalyzed_type:
+            a.append(o.unanalyzed_type)
         return self.dump(a + [o.body], o)
 
     def visit_print_stmt(self, o: 'mypy.nodes.PrintStmt') -> str:

--- a/mypy/test/hacks.py
+++ b/mypy/test/hacks.py
@@ -13,7 +13,6 @@ new_semanal_blacklist = [
     'check-literal.test',
     'check-overloading.test',
     'check-python2.test',
-    'check-statements.test',
     'check-unions.test',
     'check-unreachable-code.test',
 ]  # type: Final

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -223,9 +223,10 @@ class TransformVisitor(NodeVisitor[Node]):
     def duplicate_assignment(self, node: AssignmentStmt) -> AssignmentStmt:
         new = AssignmentStmt(self.expressions(node.lvalues),
                              self.expr(node.rvalue),
-                             self.optional_type(node.type))
+                             self.optional_type(node.unanalyzed_type))
         new.line = node.line
         new.is_final_def = node.is_final_def
+        new.type = self.optional_type(node.type)
         return new
 
     def visit_operator_assignment_stmt(self,
@@ -240,11 +241,13 @@ class TransformVisitor(NodeVisitor[Node]):
                          self.optional_block(node.else_body))
 
     def visit_for_stmt(self, node: ForStmt) -> ForStmt:
-        return ForStmt(self.expr(node.index),
-                       self.expr(node.expr),
-                       self.block(node.body),
-                       self.optional_block(node.else_body),
-                       self.optional_type(node.index_type))
+        new = ForStmt(self.expr(node.index),
+                      self.expr(node.expr),
+                      self.block(node.body),
+                      self.optional_block(node.else_body),
+                      self.optional_type(node.unanalyzed_index_type))
+        new.index_type = self.optional_type(node.index_type)
+        return new
 
     def visit_return_stmt(self, node: ReturnStmt) -> ReturnStmt:
         return ReturnStmt(self.optional_expr(node.expr))
@@ -282,10 +285,12 @@ class TransformVisitor(NodeVisitor[Node]):
                        self.optional_block(node.finally_body))
 
     def visit_with_stmt(self, node: WithStmt) -> WithStmt:
-        return WithStmt(self.expressions(node.expr),
-                        self.optional_expressions(node.target),
-                        self.block(node.body),
-                        self.optional_type(node.unanalyzed_type))
+        new = WithStmt(self.expressions(node.expr),
+                       self.optional_expressions(node.target),
+                       self.block(node.body),
+                       self.optional_type(node.unanalyzed_type))
+        new.analyzed_types = [self.type(typ) for typ in node.analyzed_types]
+        return new
 
     def visit_print_stmt(self, node: PrintStmt) -> PrintStmt:
         return PrintStmt(self.expressions(node.args),

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -285,7 +285,7 @@ class TransformVisitor(NodeVisitor[Node]):
         return WithStmt(self.expressions(node.expr),
                         self.optional_expressions(node.target),
                         self.block(node.body),
-                        self.optional_type(node.target_type))
+                        self.optional_type(node.unanalyzed_type))
 
     def visit_print_stmt(self, node: PrintStmt) -> PrintStmt:
         return PrintStmt(self.expressions(node.args),


### PR DESCRIPTION
Keep the original unanalyzed type around instead of modifying
the type in-place. This fixes a crash.