### PR TITLE
New semantic analyzer: enable literal type tests

### DIFF
--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -648,7 +648,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             #
             # TODO: Once we start adding support for enums, make sure we report a custom
             # error for case 2 as well.
-            if arg.type_of_any != TypeOfAny.from_error:
+            if arg.type_of_any not in (TypeOfAny.from_error, TypeOfAny.special_form):
                 self.fail('Parameter {} of Literal[...] cannot be of type "Any"'.format(idx), ctx)
             return None
         elif isinstance(arg, RawExpressionType):

--- a/mypy/test/hacks.py
+++ b/mypy/test/hacks.py
@@ -10,7 +10,6 @@ new_semanal_blacklist = [
     'check-async-await.test',
     'check-flags.test',
     'check-incremental.test',
-    'check-literal.test',
     'check-overloading.test',
     'check-python2.test',
     'check-unions.test',

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2175,7 +2175,7 @@ str_key_bad: Final = "missing"
 class Unrelated: pass
 
 MyTuple = NamedTuple('MyTuple', [
-    ('foo', int), 
+    ('foo', int),
     ('bar', str),
 ])
 


### PR DESCRIPTION
Also fix an issue with extra generated messages when we process
a target more than once due to forward reference within a literal
type.