### PR TITLE
New semantic analyzer: fix deserialization of generated classes

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2803,6 +2803,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
     def basic_new_typeinfo(self, name: str, basetype_or_fallback: Instance) -> TypeInfo:
         class_def = ClassDef(name, Block([]))
         class_def.fullname = self.qualified_name(name)
+        if self.is_func_scope() and not self.type:
+            # Full names of generated classes should always be prefixed with the module names
+            # even if they are nested in a function, since these classes will be (de-)serialized.
+            class_def.fullname = self.cur_mod_id + '.' + class_def.fullname
 
         info = TypeInfo(SymbolTable(), class_def, self.cur_mod_id)
         class_def.info = info

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2802,11 +2802,14 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
     def basic_new_typeinfo(self, name: str, basetype_or_fallback: Instance) -> TypeInfo:
         class_def = ClassDef(name, Block([]))
-        class_def.fullname = self.qualified_name(name)
         if self.is_func_scope() and not self.type:
             # Full names of generated classes should always be prefixed with the module names
             # even if they are nested in a function, since these classes will be (de-)serialized.
-            class_def.fullname = self.cur_mod_id + '.' + class_def.fullname
+            # (Note that the caller should append @line to the name to avoid collisions.)
+            # TODO: clean this up, see #6422.
+            class_def.fullname = self.cur_mod_id + '.' + self.qualified_name(name)
+        else:
+            class_def.fullname = self.qualified_name(name)
 
         info = TypeInfo(SymbolTable(), class_def, self.cur_mod_id)
         class_def.info = info

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4949,6 +4949,25 @@ NT = NamedTuple('BadName', [('x', int)])
 [out2]
 tmp/a.py:3: error: Revealed type is 'Tuple[builtins.int, fallback=b.BadName@2]'
 
+[case testNewAnalyzerIncrementalBrokenNamedTupleNested]
+# flags: --new-semantic-analyzer
+import a
+[file a.py]
+from b import C
+x: C
+[file a.py.2]
+from b import C
+x: C
+# touch
+[file b.py]
+class C: ...
+from collections import namedtuple
+def test() -> None:
+    NT = namedtuple('BadName', ['x', 'y'])
+[builtins fixtures/list.pyi]
+[out]
+[out2]
+
 [case testNewAnalyzerIncrementalMethodNamedTuple]
 # flags: --new-semantic-analyzer
 import a


### PR DESCRIPTION
In new semantic analyzer, `qualified_name()` returns a bare name if called inside a top-level (non-method) function. I am not sure for motivation and can't say it is generally wrong. Here is the hot-fix for a case where this is definitely wrong: generated classes.