### PR TITLE
 New semantic analyzer: fix tuple args in lambda expressions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2897,8 +2897,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         inferred_type, type_override = self.infer_lambda_type_using_context(e)
         if not inferred_type:
             self.chk.return_types.append(AnyType(TypeOfAny.special_form))
-            # No useful type context.
             e.body.accept(self.chk)
+            # No useful type context. Note that type check the return type for
+            # the second time here, since we can't easily extract it from the
+            # body.
             ret_type = self.accept(e.expr(), allow_none_return=True)
             fallback = self.named_type('builtins.function')
             self.chk.return_types.pop()

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2898,6 +2898,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if not inferred_type:
             self.chk.return_types.append(AnyType(TypeOfAny.special_form))
             # No useful type context.
+            e.body.accept(self.chk)
             ret_type = self.accept(e.expr(), allow_none_return=True)
             fallback = self.named_type('builtins.function')
             self.chk.return_types.pop()

--- a/mypy/test/hacks.py
+++ b/mypy/test/hacks.py
@@ -10,7 +10,6 @@ new_semanal_blacklist = [
     'check-flags.test',
     'check-incremental.test',
     'check-overloading.test',
-    'check-python2.test',
     'check-unions.test',
     'check-unreachable-code.test',
 ]  # type: Final

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -201,7 +201,10 @@ main:1: error: Ellipses cannot accompany other argument types in function type s
 [case testLambdaTupleArgInPython2]
 f = lambda (x, y): x + y
 f((0, 0))
-reveal_type(lambda (x,): None) # E: Revealed type is 'def (Any)'
+
+def g(): # type: () -> None
+    pass
+reveal_type(lambda (x,): g()) # E: Revealed type is 'def (Any)'
 [out]
 
 [case testLambdaTupleArgInferenceInPython2]

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -201,6 +201,23 @@ main:1: error: Ellipses cannot accompany other argument types in function type s
 [case testLambdaTupleArgInPython2]
 f = lambda (x, y): x + y
 f((0, 0))
+reveal_type(lambda (x,): None) # E: Revealed type is 'def (Any)'
+[out]
+
+[case testLambdaTupleArgInferenceInPython2]
+from typing import Callable, Tuple
+
+def f(c):
+    # type: (Callable[[Tuple[int, int]], int]) -> None
+    pass
+def g(c):
+    # type: (Callable[[Tuple[int, int]], str]) -> None
+    pass
+
+f(lambda (x, y): y)
+f(lambda (x, y): x()) # E: "int" not callable
+g(lambda (x, y): y) # E: Argument 1 to "g" has incompatible type "Callable[[Tuple[int, int]], int]"; expected "Callable[[Tuple[int, int]], str]" \
+    # E: Incompatible return value type (got "int", expected "str")
 [out]
 
 [case testLambdaSingletonTupleArgInPython2]


### PR DESCRIPTION
Also enable Python 2 tests for the new semantic analyzer.

Type check initial generated assignment statements that are used to
decompose tuples in lambda bodies. They were previously ignored 
during type checking.  

The fix isn't specific to the new semantic analyzer. I suspect that the 
tests for the old semantic analyzer worked accidentally, because the 
Var node was considered ready by default.
