### PR TITLE
New semantic analyzer: allow replacing submodule with a variable

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1597,6 +1597,11 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     if self.process_import_over_existing_name(
                             imported_id, existing_symbol, node, imp):
                         continue
+                if (existing_symbol and isinstance(existing_symbol.node, MypyFile) and
+                        existing_symbol.no_serialize):  # submodule added to parent module
+                    # Special case: allow replacing submodules with variables. This pattern
+                    # is used by some libraries.
+                    del self.globals[imported_id]
                 # 'from m import x as x' exports x in a stub file.
                 module_public = not self.is_stub_file or as_id is not None
                 module_hidden = not module_public and possible_module_id not in self.modules

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -431,8 +431,8 @@ from . import command
 from . import backends
 
 [file blamodule/backends/__init__.py]
-from .Bla import Bla # E: Name 'Bla' already defined (by an import)
-Bla().method()  # E: Module not callable
+from .Bla import Bla
+Bla().method()
 
 [file blamodule/backends/Bla.py]
 from .. import *

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2049,3 +2049,20 @@ from pp import x as y
 def __getattr__(attr): ...
 [out2]
 tmp/a.py:2: error: Revealed type is 'Any'
+
+[case testNewAnanlyzerTrickyImportPackage]
+from lib import config
+import lib
+
+reveal_type(lib.config.x)  # E: Revealed type is 'builtins.int'
+reveal_type(config.x)  # E: Revealed type is 'builtins.int'
+
+[file lib/__init__.py]
+from lib.config import config
+
+[file lib/config.py]
+class Config:
+    x: int
+
+config = Config()
+[builtins fixtures/module.pyi]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2066,3 +2066,48 @@ class Config:
 
 config = Config()
 [builtins fixtures/module.pyi]
+
+[case testNewAnanlyzerTrickyImportPackageAlt]
+import lib.config
+import lib.config as tmp
+
+reveal_type(lib.config.x)  # E: Revealed type is 'builtins.int'
+# TODO: this actually doesn't match runtime behavior, variable wins.
+tmp.x  # E: Module has no attribute "x"
+
+[file lib/__init__.py]
+from lib.config import config
+
+[file lib/config.py]
+class Config:
+    x: int
+
+config = Config()
+[builtins fixtures/module.pyi]
+
+[case testNewAnanlyzerTrickyImportPackage_incremental]
+import a
+
+[file a.py]
+from lib import config
+import lib
+
+[file a.py.2]
+from lib import config
+import lib
+
+reveal_type(lib.config.x)
+reveal_type(config.x)
+
+[file lib/__init__.py]
+from lib.config import config
+
+[file lib/config.py]
+class Config:
+    x: int
+
+config = Config()
+[builtins fixtures/module.pyi]
+[out2]
+tmp/a.py:4: error: Revealed type is 'builtins.int'
+tmp/a.py:5: error: Revealed type is 'builtins.int'


### PR DESCRIPTION
Although this looks like an arbitrary exception from general rules, this:
* is an actual pattern used by some libraries
* matches old analyzer in most cases
* matches runtime semantics