### PR TITLE
Don't type check lambda return statement

### DIFF
--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1325,6 +1325,15 @@ fun(lambda: (yield from [1]))  # E: Incompatible types in "yield from" (actual t
 [builtins fixtures/list.pyi]
 [out]
 
+[case testLambdaAndReachability]
+def f() -> None:
+    aa = []
+    y = lambda x: 1
+    aa.append(1)
+    1()  # E: "int" not callable
+[builtins fixtures/list.pyi]
+
+
 -- List comprehensions
 -- -------------------
 


### PR DESCRIPTION
This fixes an issue where everything after a lambda was considered
unreachable.