### PR TITLE
New semantic analyzer: consider NewTypes as always non-abstract

### DIFF
--- a/mypy/newsemanal/semanal_classprop.py
+++ b/mypy/newsemanal/semanal_classprop.py
@@ -58,6 +58,12 @@ def calculate_class_abstract_status(typ: TypeInfo, is_stub_file: bool, errors: E
     concrete = set()  # type: Set[str]
     abstract = []  # type: List[str]
     abstract_in_this_class = []  # type: List[str]
+    if typ.is_newtype:
+        # Special case: NewTypes are considered as always non-abstract, so they can be used as:
+        #     Config = NewType('Config', Mapping[str, str])
+        #     default = Config({'cannot': 'modify'})  # OK
+        typ.abstract_attributes = []
+        return
     for base in typ.mro:
         for name, symnode in base.names.items():
             node = symnode.node

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -888,3 +888,15 @@ class A:
 
 A.B()  # E: Cannot instantiate abstract class 'B' with abstract attribute 'f'
 A.C()  # E: Cannot instantiate abstract class 'C' with abstract attribute 'f'
+
+[case testAbstractNewTypeAllowed]
+from typing import NewType, Mapping
+
+Config = NewType('Config', Mapping[str, str])
+
+bad = Mapping[str, str]()  # E: Cannot instantiate abstract class 'Mapping' with abstract attribute '__iter__'
+default = Config({'cannot': 'modify'})  # OK
+
+default[1] = 2  # E: Unsupported target for indexed assignment
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]


### PR DESCRIPTION
This matches the behavior in old analyzer, and although a bit arbitrary, this may be actually useful.