### PR TITLE
New semantic analyzer: enable additional tests

### DIFF
--- a/mypy/test/hacks.py
+++ b/mypy/test/hacks.py
@@ -8,7 +8,4 @@ if MYPY:
 # Files to not run with new semantic analyzer.
 new_semanal_blacklist = [
     'check-incremental.test',
-    'check-overloading.test',
-    'check-unions.test',
-    'check-unreachable-code.test',
 ]  # type: Final

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1521,6 +1521,8 @@ f(0)  # E: No overload variant of "f" matches argument type "int" \
       # N:     def f(a: str) -> None
 
 [case testCustomRedefinitionDecorator]
+# https://github.com/python/mypy/issues/6432
+# flags: --no-new-semantic-analyzer
 from typing import Any, Callable, Type
 
 class Chain(object):
@@ -1534,7 +1536,7 @@ class Test(object):
     def do_chain(self) -> int:
         return 2
 
-    @do_chain.chain  # E: Name 'do_chain' already defined on line 10
+    @do_chain.chain  # E: Name 'do_chain' already defined on line 12
     def do_chain(self) -> int:
         return 3
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -957,11 +957,13 @@ def takes_int(arg: int) -> None: pass
 takes_int(x)  # E: Argument 1 to "takes_int" has incompatible type <union: 6 items>; expected "int"
 
 [case testRecursiveForwardReferenceInUnion]
+# https://github.com/python/mypy/issues/6445
+# flags: --no-new-semantic-analyzer
 from typing import List, Union
 MYTYPE = List[Union[str, "MYTYPE"]]
 [builtins fixtures/list.pyi]
 [out]
-main:2: error: Recursive types not fully supported yet, nested types replaced with "Any"
+main:4: error: Recursive types not fully supported yet, nested types replaced with "Any"
 
 [case testNonStrictOptional]
 from typing import Optional, List


### PR DESCRIPTION
Two tests that trigger crashes are disabled for now.