### PR TITLE
Update the pytest version dependency

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@ flake8-pyi; python_version >= '3.6'
 lxml==4.2.4
 mypy_extensions==0.4.0
 psutil==5.4.0
-pytest>=3.4
+pytest>=4.4
 pytest-xdist>=1.22
 pytest-cov>=2.4.0
 typed-ast>=1.3.0,<1.4.0


### PR DESCRIPTION
Some mypyc CI jobs were failing because of an incompatability with new
pytest-xdists and old pytests, so bump the pytest version.
Failures haven't hit mypy CI yet but they probably will?