### PR TITLE
document ternary/conditional type inference limitations

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -339,6 +339,24 @@ style anyway).  We can write the above code without a cast by using
            g(o + 1)        # Okay; type of o is inferred as int here
            ...
 
+Note that MyPy cannot always narrow a type based on ``isinstance()``
+used within a ternary/conditional expression, e.g.:
+
+.. code-block:: python
+
+	def f(x: AnyStr, y: AnyStr) -> bytes:
+		x += y
+
+		r = x.encode('ascii') if isinstance(x, str) else x
+		# results in 'error: "bytes" has no attribute "encode"; maybe "decode"?'
+
+		if isinstance(x, str):
+			r = x.encode('ascii')  # whereas MyPy can narrow within an if statement
+		else:
+			r = x
+		...
+
+
 Type inference in mypy is designed to work well in common cases, to be
 predictable and to let the type checker give useful error
 messages. More powerful type inference strategies often have complex

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -339,23 +339,21 @@ style anyway).  We can write the above code without a cast by using
            g(o + 1)        # Okay; type of o is inferred as int here
            ...
 
-Note that MyPy cannot always narrow a type based on ``isinstance()``
+Note that Mypy cannot always narrow a type based on ``isinstance()``
 used within a ternary/conditional expression, e.g.:
 
 .. code-block:: python
 
-	def f(x: AnyStr, y: AnyStr) -> bytes:
-		x += y
-
+	def f(x: AnyStr) -> bytes:
 		r = x.encode('ascii') if isinstance(x, str) else x
 		# results in 'error: "bytes" has no attribute "encode"; maybe "decode"?'
 
 		if isinstance(x, str):
-			r = x.encode('ascii')  # whereas MyPy can narrow within an if statement
+			r = x.encode('ascii')  # whereas Mypy can narrow within an if statement
 		else:
 			r = x
+		return r
 		...
-
 
 Type inference in mypy is designed to work well in common cases, to be
 predictable and to let the type checker give useful error


### PR DESCRIPTION
As per the discussion in #4134 , it seems worth documenting that conditional expressions don't always work smoothly with type inference.  This PR makes sure to include the word ternary and conditional so that page/doc searches will turn up an explanation for this behavior in case anyone is searching for it.