### PR TITLE
New semantic analyzer: use correct fullnames for enum Vars

### DIFF
--- a/mypy/newsemanal/semanal_enum.py
+++ b/mypy/newsemanal/semanal_enum.py
@@ -89,7 +89,7 @@ class EnumCallAnalyzer:
             var = Var(item)
             var.info = info
             var.is_property = True
-            var._fullname = '{}.{}'.format(self.api.qualified_name(name), item)
+            var._fullname = '{}.{}'.format(info.fullname(), item)
             info.names[item] = SymbolTableNode(MDEF, var)
         return info
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5004,3 +5004,23 @@ reveal_type(c)
 [out]
 [out2]
 tmp/a.py:3: error: Revealed type is 'Any'
+
+[case testNewAnalyzerIncrementalNestedEnum]
+# flags: --new-semantic-analyzer
+import a
+[file a.py]
+from b import C
+x: C
+[file a.py.2]
+from b import C
+x: C
+# touch
+[file b.py]
+class C: ...
+from enum import Enum
+
+def test() -> None:
+    Color = Enum('Color', 'RED BLACK')
+[builtins fixtures/list.pyi]
+[out]
+[out2]


### PR DESCRIPTION
The fix is straightforward: use the already computed full name for enum class (that already takes care about special cases) as a base.