### PR TITLE
Fix memprofile crashes and make it work with mypyc

### DIFF
--- a/mypy/memprofile.py
+++ b/mypy/memprofile.py
@@ -11,6 +11,7 @@ from typing import List, Dict, Iterable, Tuple, cast
 
 from mypy.nodes import FakeInfo, Node
 from mypy.types import Type
+from mypy.util import get_class_descriptors
 
 
 def collect_memory_stats() -> Tuple[Dict[str, int],
@@ -39,12 +40,11 @@ def collect_memory_stats() -> Tuple[Dict[str, int],
                     if isinstance(x, list):
                         # Keep track of which node a list is associated with.
                         inferred[id(x)] = '%s (list)' % n
-            else:
-                for base in type.mro(type(obj)):
-                    for k in getattr(base, '__slots__', ()):
-                        x = getattr(obj, k, None)
-                        if isinstance(x, list):
-                            inferred[id(x)] = '%s (list)' % n
+
+            for k in get_class_descriptors(type(obj)):
+                x = getattr(obj, k, None)
+                if isinstance(x, list):
+                    inferred[id(x)] = '%s (list)' % n
 
     freqs = {}  # type: Dict[str, int]
     memuse = {}  # type: Dict[str, int]

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2580,6 +2580,9 @@ class FakeInfo(TypeInfo):
         self.msg = msg
 
     def __getattribute__(self, attr: str) -> None:
+        # Handle __class__ so that isinstance still works...
+        if attr == '__class__':
+            return object.__getattribute__(self, attr)
         raise AssertionError(object.__getattribute__(self, 'msg'))
 
 

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -207,7 +207,7 @@ def get_class_descriptors(cls: 'Type[object]') -> Sequence[str]:
         members = inspect.getmembers(
             cls,
             lambda o: inspect.isgetsetdescriptor(o) or inspect.ismemberdescriptor(o))
-        fields_cache[cls] = [x for x, y in members if x != '__weakref__']
+        fields_cache[cls] = [x for x, y in members if x != '__weakref__' and x != '__dict__']
     return fields_cache[cls]
 
 


### PR DESCRIPTION
memprofile crashes when trying to call isinstance on FakeInfos, since isinstance 
will sometimes try to access `__class__`. Make `__class__` on FakeInfo work.

Also use `get_class_descriptors` instead of traversing `__slots__` directly so that
mypyc objects can be traversed.
(Though some fixes are needed to mypyc for this to work that I haven't pushed yet.)