### PR TITLE
Allow disabling active config files.

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -57,6 +57,9 @@ Config file
     Settings override mypy's built-in defaults and command line flags
     can override settings.
 
+    Specifying ``--config-file=`` (with no filename) will ignore *all*
+    config files.
+
     See :ref:`config-file` for the syntax of configuration files.
 
 ``--warn-unused-configs``

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -700,7 +700,9 @@ def process_options(args: List[str],
     dummy = argparse.Namespace()
     parser.parse_args(args, dummy)
     config_file = dummy.config_file
-    if config_file is not None and not os.path.exists(config_file):
+    # Don't explicitly test if "config_file is not None" for this check.
+    # This lets `--config-file=` (an empty string) be used to disable all config files.
+    if config_file and not os.path.exists(config_file):
         parser.error("Cannot find config file '%s'" % config_file)
 
     # Parse config file first, so command line can override.

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -156,6 +156,14 @@ def f():
     except ZeroDivisionError, err:
         print err
 
+[case testNoConfigFile]
+# cmd: mypy main.py --config-file=
+[file mypy.ini]
+[[mypy]
+warn_unused_ignores = True
+[file main.py]
+# type: ignore
+
 [case testPerFileConfigSection]
 # cmd: mypy x.py y.py z.py
 [file mypy.ini]


### PR DESCRIPTION
With this change, passing `--config-file=` from the command line disables any active config files.