### PR TITLE
Fix crash when namedtuple, classmethod and generic types used

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -923,10 +923,10 @@ class CallableType(FunctionLike):
     def type_object(self) -> mypy.nodes.TypeInfo:
         assert self.is_type_obj()
         ret = self.ret_type
-        if isinstance(ret, TupleType):
-            ret = ret.partial_fallback
         if isinstance(ret, TypeVarType):
             ret = ret.upper_bound
+        if isinstance(ret, TupleType):
+            ret = ret.partial_fallback
         assert isinstance(ret, Instance)
         return ret.type
 

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -828,3 +828,21 @@ class Child(Base):
 
 Base(param=10)
 Child(param=10)
+
+[case testNamedTupleClassMethodWithGenericReturnValue]
+from typing import TypeVar, Type, NamedTuple
+
+T = TypeVar('T', bound='Parent')
+
+class Parent(NamedTuple):
+    x: str
+
+    @classmethod
+    def class_method(cls: Type[T]) -> T:
+        return cls(x='text')
+
+class Child(Parent):
+    pass
+
+reveal_type(Child.class_method())  # E: Revealed type is 'Tuple[builtins.str, fallback=__main__.Child]'
+[builtins fixtures/classmethod.pyi]


### PR DESCRIPTION
Fixes #5996.