### PR TITLE
New semantic analyzer: fix redefining symbols as overloaded functions or classes

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -4162,7 +4162,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         return False
 
     def add_redefinition(self, names: SymbolTable, name: str,
-                              symbol: SymbolTableNode) -> None:
+                         symbol: SymbolTableNode) -> None:
         """Add a symbol table node that reflects a redefinition as a function or a class.
 
         Redefinitions need to be added to the symbol table so that they can be found

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -4150,8 +4150,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     and not (isinstance(old_node, PlaceholderNode)
                              and isinstance(new_node, PlaceholderNode))
                     and not is_same_var_from_getattr(old_node, new_node)):
-                if isinstance(new_node, (FuncDef, Decorator)):
-                    self.add_func_redefinition(names, name, symbol)
+                if isinstance(new_node, (FuncDef, Decorator, OverloadedFuncDef, TypeInfo)):
+                    self.add_redefinition(names, name, symbol)
                 if not (isinstance(new_node, (FuncDef, Decorator))
                         and self.set_original_def(old_node, new_node)):
                     self.name_already_defined(name, context, existing)
@@ -4161,13 +4161,17 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             return True
         return False
 
-    def add_func_redefinition(self, names: SymbolTable, name: str,
+    def add_redefinition(self, names: SymbolTable, name: str,
                               symbol: SymbolTableNode) -> None:
-        """Add a symbol table node that reflects a redefinition of a function.
+        """Add a symbol table node that reflects a redefinition as a function or a class.
 
         Redefinitions need to be added to the symbol table so that they can be found
         through AST traversal, but they have dummy names of form 'name-redefinition[N]',
         where N ranges over 2, 3, ... (omitted for the first redefinition).
+
+        Note: we always store redefinitions independently of whether they are valid or not
+        (so they will be semantically analyzed), the caller should give an error for invalid
+        redefinitions (such as e.g. variable redefined as a class).
         """
         i = 1
         while True:

--- a/mypy/newsemanal/semanal_classprop.py
+++ b/mypy/newsemanal/semanal_classprop.py
@@ -72,7 +72,10 @@ def calculate_class_abstract_status(typ: TypeInfo, is_stub_file: bool, errors: E
                 # check arbitrarily the first overload item. If the
                 # different items have a different abstract status, there
                 # should be an error reported elsewhere.
-                func = node.items[0]  # type: Optional[Node]
+                if node.items:  # can be empty for invalid overloads
+                    func = node.items[0]  # type: Optional[Node]
+                else:
+                    func = None
             else:
                 func = node
             if isinstance(func, Decorator):

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2111,3 +2111,29 @@ config = Config()
 [out2]
 tmp/a.py:4: error: Revealed type is 'builtins.int'
 tmp/a.py:5: error: Revealed type is 'builtins.int'
+
+[case testNewAnalyzerRedefineAsClass]
+from typing import Any
+from other import C  # type: ignore
+
+y = 'bad'
+
+class C:  # E: Name 'C' already defined (possibly by an import)
+    def meth(self, other: int) -> None:
+        y()  # E: "str" not callable
+
+[case testNewAnalyzerRedefineAsOverload]
+from typing import overload
+
+y = 'bad'
+
+if int():
+    def f(x: int) -> None:
+        pass
+else:
+    @overload  # E: Name 'f' already defined on line 6
+    def f(x: int) -> None: ...
+    @overload
+    def f(x: str) -> None: ...
+    def f(x) -> None:
+        y()  # E: "str" not callable

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1521,8 +1521,7 @@ f(0)  # E: No overload variant of "f" matches argument type "int" \
       # N:     def f(a: str) -> None
 
 [case testCustomRedefinitionDecorator]
-# https://github.com/python/mypy/issues/6432
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import Any, Callable, Type
 
 class Chain(object):
@@ -1532,11 +1531,11 @@ class Chain(object):
 class Test(object):
     do_chain = Chain()
 
-    @do_chain.chain
+    @do_chain.chain  # E: Name 'do_chain' already defined on line 9
     def do_chain(self) -> int:
         return 2
 
-    @do_chain.chain  # E: Name 'do_chain' already defined on line 12
+    @do_chain.chain  # E: Name 'do_chain' already defined on line 11
     def do_chain(self) -> int:
         return 3
 


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/6432

This is a hot fix that simply extends the solution in PR https://github.com/python/mypy/pull/6429 to more situations. We agreed with @JukkaL that he will clean this up when he is back from PTO.

Note that we still give the errors for redefinitions that we consider invalid (see tests), but we don't crash now.