### PR TITLE
New semantic analyzer: fix a crash with imported tricky alias

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2338,7 +2338,15 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 self.progress = True
                 # We need to defer so that this change can get propagated to base classes.
                 self.defer()
-            existing.node = alias_node
+            if isinstance(existing.node, TypeAlias):
+                # Copy expansion to the existing alias, this matches how we update base classes
+                # for a TypeInfo _in place_ if there are nested placeholders.
+                existing.node.target = res
+                existing.node.alias_tvars = alias_tvars
+                existing.node.no_args = no_args
+            else:
+                # Otherwise just replace existing placeholder with type alias.
+                existing.node = alias_node
         else:
             self.add_symbol(lvalue.name, alias_node, s)
         if isinstance(rvalue, RefExpr) and isinstance(rvalue.node, TypeAlias):

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1407,6 +1407,23 @@ reveal_type(x)  # E: Revealed type is 'Union[__main__.B, __main__.C]'
 reveal_type(x[0])  # E: Revealed type is 'Union[__main__.B, __main__.C]'
 [builtins fixtures/list.pyi]
 
+[case testNewAnalyzerTrickyAliasInFuncDef]
+import a
+[file a.py]
+from b import B
+def func() -> B: ...
+reveal_type(func())  # E: Revealed type is 'builtins.list[Tuple[b.C, b.C]]'
+
+[file b.py]
+from typing import List, Tuple
+from a import func
+
+B = List[Tuple[C, C]]
+
+class C(A): ...
+class A: ...
+[builtins fixtures/list.pyi]
+
 [case testNewAnalyzerListComprehension]
 from typing import List
 a: List[A]


### PR DESCRIPTION
This fixes a crash discovered internally, see tests for a simplified repro.