### PR TITLE
New semantic analyzer: Fix crash in imports over existing name

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1592,7 +1592,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                         return
                     self.record_incomplete_ref()
                 existing_symbol = self.globals.get(imported_id)
-                if existing_symbol and not isinstance(existing_symbol.node, PlaceholderNode):
+                if (existing_symbol and not isinstance(existing_symbol.node, PlaceholderNode) and
+                        not isinstance(node.node, PlaceholderNode)):
                     # Import can redefine a variable. They get special treatment.
                     if self.process_import_over_existing_name(
                             imported_id, existing_symbol, node, imp):
@@ -1701,7 +1702,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                         # Star import of submodule from a package, add it as a dependency.
                         self.imports.add(node.node.fullname())
                     existing_symbol = self.lookup_current_scope(name)
-                    if existing_symbol:
+                    if existing_symbol and not isinstance(node.node, PlaceholderNode):
                         # Import can redefine a variable. They get special treatment.
                         if self.process_import_over_existing_name(
                                 name, existing_symbol, node, i):

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -993,6 +993,31 @@ class C: pass
 import a
 from b import C
 
+[case testNewAnalyzerImportOverExistingInCycle]
+import a
+[file a.py]
+C = 1
+from b import C  # E: Name 'C' already defined on line 1 \
+                 # E: Incompatible import of "C" (imported name has type "Type[C]", local name has type "int")
+
+[file b.py]
+import a
+
+class C(B): ...
+class B: ...
+
+[case testNewAnalyzerImportOverExistingInCycleStar]
+import a
+[file a.py]
+C = 1
+from b import *  # E: Name 'C' already defined on line 1
+
+[file b.py]
+import a
+
+class C(B): ...
+class B: ...
+
 [case testNewAnalyzerIncompleteFixture]
 from typing import Tuple
 


### PR DESCRIPTION
This fixes a crash discovered by testing the new analyzer internally.