### PR TITLE
New semantic analyzer: fix another tricky import

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1603,6 +1603,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     # Special case: allow replacing submodules with variables. This pattern
                     # is used by some libraries.
                     del self.globals[imported_id]
+                if existing_symbol and isinstance(node.node, PlaceholderNode):
+                    # Imports are special, some redefinitions are allowed, so wait until
+                    # we know what is the new symbol node.
+                    continue
                 # 'from m import x as x' exports x in a stub file.
                 module_public = not self.is_stub_file or as_id is not None
                 module_hidden = not module_public and possible_module_id not in self.modules

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2481,3 +2481,27 @@ def foo() -> None:
 
 def lol():
     x = foo()
+
+[case testConditionalImportFunction]
+import p
+[file p/__init__.py]
+
+if int():
+    from p.a import f
+elif int():
+    from p.b import f
+else:
+    from p.c import f
+
+[file p/a.py]
+def f() -> int: ...
+
+[file p/b.py]
+from p.d import f
+
+[file p/c.py]
+def f() -> int: ...
+
+[file p/d.py]
+import p
+def f() -> int: ...

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -997,8 +997,7 @@ from b import C
 import a
 [file a.py]
 C = 1
-from b import C  # E: Name 'C' already defined on line 1 \
-                 # E: Incompatible import of "C" (imported name has type "Type[C]", local name has type "int")
+from b import C  # E: Incompatible import of "C" (imported name has type "Type[C]", local name has type "int")
 
 [file b.py]
 import a


### PR DESCRIPTION
This PR makes another tricky corner case consistent with the old semantic analyzer, whose behavior also seems more consistent (imports can always redefine names if types are consistent).