### PR TITLE
Delete build-requirements.txt

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,2 +1,0 @@
-setuptools
-wheel


### PR DESCRIPTION
With the move to pyproject.toml and PEP-517 this is no longer needed.