### PR TITLE
New semantic analyzer: When defining an alias first definition wins

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2270,8 +2270,12 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         #     A = float  # OK, but this doesn't define an alias
         #     B = int
         #     B = float  # Error!
-        if existing and (isinstance(existing.node, Var) or
-                         isinstance(existing.node, TypeAlias) and not s.is_alias_def):
+        # Don't create an alias in these cases:
+        if existing and (isinstance(existing.node, Var) or  # existing variable
+                isinstance(existing.node, TypeAlias) and not s.is_alias_def or  # existing alias
+                (isinstance(existing.node, PlaceholderNode) and
+                # TODO: find a more robust way to track the order of definitions.
+                 existing.node.node.line < s.line)):  # or previous incomplete definition
             # Note: if is_alias_def=True, this is just a node from previous iteration.
             if isinstance(existing.node, TypeAlias) and not s.is_alias_def:
                 self.fail('Cannot assign multiple types to name "{}"'

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2769,7 +2769,8 @@ class PlaceholderNode(SymbolNode):
 
       fullname: Full name of of the PlaceholderNode.
       node: AST node that contains the definition that caused this to
-          be created. This is only useful for debugging.
+          be created. This is useful for tracking order of incomplete definitions
+          and for debugging.
       becomes_typeinfo: If True, this refers something that will later
           become a TypeInfo. It can't be used with type variables, in
           particular, as this would cause issues with class type variable

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2178,3 +2178,25 @@ else:
     def f(x: str) -> None: ...
     def f(x) -> None:
         y()  # E: "str" not callable
+
+[case testNewAnalyzerFirstAliasTargetWins]
+if int():
+    Alias = DesiredTarget
+else:
+    class DummyTarget:
+        pass
+    Alias = DummyTarget  # type: ignore
+
+x: Alias
+reveal_type(x.attr)  # E: Revealed type is 'builtins.int'
+
+class DesiredTarget:
+    attr: int
+
+[case testNewAnalyzerFirstVarDefinitionWins]
+x = y
+x = 1
+
+# We want to check that the first definition creates the variable.
+def x() -> None: ...  # E: Name 'x' already defined on line 1
+y = 2


### PR DESCRIPTION
In the old analyzer the first definition always wins. We should try to always preserve this logic. This is a hotfix for a problem discovered internally, we should try to find a more robust and general solution.