### PR TITLE
Use variable name to determined NamedTuple class name

### DIFF
--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5057,7 +5057,7 @@ NT = NamedTuple('BadName', [('x', int)])
 [builtins fixtures/tuple.pyi]
 [out]
 [out2]
-tmp/a.py:3: note: Revealed type is 'Tuple[builtins.int, fallback=b.BadName@2]'
+tmp/a.py:3: note: Revealed type is 'Tuple[builtins.int, fallback=b.NT]'
 
 [case testNewAnalyzerIncrementalBrokenNamedTupleNested]
 

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -9622,3 +9622,26 @@ class C:
 [out]
 ==
 main:5: error: Unsupported left operand type for + ("str")
+
+[case testReexportNamedTupleChange]
+from m import M
+
+def f(x: M) -> None: ...
+
+f(M(0))
+
+[file m.py]
+from n import M
+
+[file n.py]
+from typing import NamedTuple
+M = NamedTuple('_N', [('x', int)])
+
+[file n.py.2]
+# change the line numbers
+from typing import NamedTuple
+M = NamedTuple('_N', [('x', int)])
+
+[builtins fixtures/tuple.pyi]
+[out]
+==


### PR DESCRIPTION
This lets us avoid inserting line numbers into the name when the
variable name and argument to NamedTuple disagree. This is good,
because the line numbers are ugly and when combined with bug #6548
causes problems when a namedtuple is reexported.