### PR TITLE
Add changelog section with link to blog in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,12 @@ See [the roadmap](ROADMAP.md) if you are interested in plans for the
 future.
 
 
+Changelog
+---------
+
+Follow Mypy's updates on the blog: http://mypy-lang.blogspot.com/
+
+
 Issue tracker
 -------------
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ future.
 Changelog
 ---------
 
-Follow Mypy's updates on the blog: http://mypy-lang.blogspot.com/
+Follow mypy's updates on the blog: http://mypy-lang.blogspot.com/
 
 
 Issue tracker


### PR DESCRIPTION
There's no mention of the word "changelog" in the README, making it pretty difficult to scan for changes.

This is related to #5008.