### PR TITLE
Allow files to be specified via ini config

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -333,6 +333,11 @@ a list of import discovery options that may be used
     Specifies the paths to use, after trying the paths from ``MYPYPATH`` environment
     variable.  Useful if you'd like to keep stubs in your repo, along with the config file.
 
+``files`` (string)
+    Specifies the paths which should be checked by mypy if none are given on the command
+    line. Supports recursive file globbing with `*` (eg `*.py` for files in the same directory)
+    and `**/` (eg `**/*.py`) for files in any directory below the current one.
+
 
 Platform configuration
 ----------------------

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -335,7 +335,7 @@ a list of import discovery options that may be used
 
 ``files`` (string)
     Specifies the paths which should be checked by mypy if none are given on the command
-    line. Supports file globbing through
+    line. Supports recursive file globbing through
     [the glob library](https://docs.python.org/3/library/glob.html).
 
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -334,9 +334,11 @@ a list of import discovery options that may be used
     variable.  Useful if you'd like to keep stubs in your repo, along with the config file.
 
 ``files`` (string)
-    Specifies the paths which should be checked by mypy if none are given on the command
-    line. Supports recursive file globbing through
-    [the glob library](https://docs.python.org/3/library/glob.html).
+    A comma-separated list of paths which should be checked by mypy if none are given on the command
+    line. Supports recursive file globbing using
+    [the glob library](https://docs.python.org/3/library/glob.html), where `*` (eg `*.py`) matches
+    files in the current directory and `**/` (eg `**/*.py`) matches files in any directories below
+    the current one.
 
 
 Platform configuration

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -335,8 +335,8 @@ a list of import discovery options that may be used
 
 ``files`` (string)
     Specifies the paths which should be checked by mypy if none are given on the command
-    line. Supports recursive file globbing with `*` (eg `*.py` for files in the same directory)
-    and `**/` (eg `**/*.py`) for files in any directory below the current one.
+    line. Supports file globbing through
+    [the glob library](https://docs.python.org/3/library/glob.html).
 
 
 Platform configuration

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -336,8 +336,8 @@ a list of import discovery options that may be used
 ``files`` (string)
     A comma-separated list of paths which should be checked by mypy if none are given on the command
     line. Supports recursive file globbing using
-    [the glob library](https://docs.python.org/3/library/glob.html), where `*` (eg `*.py`) matches
-    files in the current directory and `**/` (eg `**/*.py`) matches files in any directories below
+    [the glob library](https://docs.python.org/3/library/glob.html), where `*` (e.g. `*.py`) matches
+    files in the current directory and `**/` (e.g. `**/*.py`) matches files in any directories below
     the current one.
 
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -3,6 +3,7 @@
 import argparse
 import ast
 import configparser
+import glob as fileglob
 import os
 import re
 import subprocess
@@ -730,6 +731,11 @@ def process_options(args: List[str],
     if special_opts.no_executable:
         options.python_executable = None
 
+    # Paths listed in the config file will be ignored if any paths are passed on
+    # the command line.
+    if not special_opts.files and options.files:
+        special_opts.files = options.files
+
     # Check for invalid argument combinations.
     if require_targets:
         code_methods = sum(bool(c) for c in [special_opts.modules + special_opts.packages,
@@ -866,6 +872,26 @@ def process_cache_map(parser: argparse.ArgumentParser,
         options.cache_map[source] = (meta_file, data_file)
 
 
+def split_and_match_files(paths: str) -> List[str]:
+    """Take a string representing a list of files/directories (including globbing with */**).
+
+    Where a path/glob matches no file, we still include the raw path in the resulting list.
+
+    Returns a list of file paths
+    """
+    expanded_paths = []
+
+    for path in re.split('[,:]', paths):
+        path = path.strip()
+        globbed_files = fileglob.glob(path, recursive=True)
+        if globbed_files:
+            expanded_paths.extend(globbed_files)
+        else:
+            expanded_paths.append(path)
+
+    return expanded_paths
+
+
 # For most options, the type of the default value set in options.py is
 # sufficient, and we don't have to do anything here.  This table
 # exists to specify types for values initialized to None or container
@@ -876,6 +902,7 @@ config_types = {
     'custom_typing_module': str,
     'custom_typeshed_dir': str,
     'mypy_path': lambda s: [p.strip() for p in re.split('[,:]', s)],
+    'files': split_and_match_files,
     'quickstart_file': str,
     'junit_xml': str,
     # These two are for backwards compatibility

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -873,7 +873,8 @@ def process_cache_map(parser: argparse.ArgumentParser,
 
 
 def split_and_match_files(paths: str) -> List[str]:
-    """Take a string representing a list of files/directories (including globbing with */**).
+    """Take a string representing a list of files/directories (with support for globbing
+    through the glob library).
 
     Where a path/glob matches no file, we still include the raw path in the resulting list.
 
@@ -881,7 +882,7 @@ def split_and_match_files(paths: str) -> List[str]:
     """
     expanded_paths = []
 
-    for path in re.split('[,:]', paths):
+    for path in re.split('[,:;]', paths):
         path = path.strip()
         globbed_files = fileglob.glob(path, recursive=True)
         if globbed_files:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -733,7 +733,7 @@ def process_options(args: List[str],
 
     # Paths listed in the config file will be ignored if any paths are passed on
     # the command line.
-    if not special_opts.files and options.files:
+    if options.files and not special_opts.files:
         special_opts.files = options.files
 
     # Check for invalid argument combinations.
@@ -882,7 +882,7 @@ def split_and_match_files(paths: str) -> List[str]:
     """
     expanded_paths = []
 
-    for path in re.split('[,:;]', paths):
+    for path in paths.split(','):
         path = path.strip()
         globbed_files = fileglob.glob(path, recursive=True)
         if globbed_files:

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -179,6 +179,10 @@ class Options:
         # source hashes as often.
         self.quickstart_file = None  # type: Optional[str]
 
+        # A comma/semicolon-separated list of files/directories for mypy to type check;
+        # supports globbing
+        self.files = None  # type: Optional[List[str]]
+
         # Write junit.xml to given file
         self.junit_xml = None  # type: Optional[str]
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -179,7 +179,7 @@ class Options:
         # source hashes as often.
         self.quickstart_file = None  # type: Optional[str]
 
-        # A comma/semicolon-separated list of files/directories for mypy to type check;
+        # A comma-separated list of files/directories for mypy to type check;
         # supports globbing
         self.files = None  # type: Optional[List[str]]
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1268,3 +1268,39 @@ import d
 # cmd: mypy a.py --no-sqlite-cache --cache-map a.py a.meta.json a.data.json
 [file a.py]
 [out]
+
+[case testIniFiles]
+# cmd: mypy
+[file mypy.ini]
+[[mypy]
+files = a.py, b.py
+[file a.py]
+fail
+[file b.py]
+fail
+[out]
+b.py:1: error: Name 'fail' is not defined
+a.py:1: error: Name 'fail' is not defined
+
+[case testIniFilesGlobbing]
+# cmd: mypy
+[file mypy.ini]
+[[mypy]
+files = **/*.py
+[file a/b.py]
+fail
+[file c.py]
+fail
+[out]
+a/b.py:1: error: Name 'fail' is not defined
+c.py:1: error: Name 'fail' is not defined
+
+
+[case testIniFilesCmdlineOverridesConfig]
+# cmd: mypy override.py
+[file mypy.ini]
+[[mypy]
+files = config.py
+[out]
+mypy: can't read file 'override.py': No such file or directory
+== Return code: 2


### PR DESCRIPTION
## Summary
Allow target paths to be specified through config files as an alternative to the command line.

## Reason
To simplify the enforcement of which files/directories should be validated when working in a team. Rather than having to write a separate script that specifies the files, you can simply declare them in the existing `mypy.ini` (or alternative) config file.

## Behaviour
I've tried to copy the functionality that you might expect from the typical command line, so this includes recursive file globbing. There are two main differences:

1) paths are comma- or semicolon-separated rather than just using spaces
2) by using the `glob` module we get `**` resolving to zero or more intermediate directories. In bash (at least), `*/*.py` or `**/*.py` will only match python files in the directory below the current one.

If a path (wildcarded or not) doesn't match at least one file, it bubbles up and errors in the same way as when given on the command line. If any files *are* given on the command line, the value in the config file is ignored.

## Addendum
Closes: #5909