### PR TITLE
Fixes #6743

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -95,6 +95,7 @@ inverse_node_kinds = {_kind: _name for _name, _kind in node_kinds.items()}  # ty
 
 
 implicit_module_attrs = {'__name__': '__builtins__.str',
+                         '__qualname__': '__builtins__.str',
                          '__doc__': None,  # depends on Python version, see semanal.py
                          '__file__': '__builtins__.str',
                          '__package__': '__builtins__.str'}  # type: Final

--- a/test-data/unit/check-qualname.test
+++ b/test-data/unit/check-qualname.test
@@ -1,0 +1,10 @@
+[case testQualNameTypeCheck]
+
+# flags: --python-version 2.7
+class C:
+    NAME = __qualname__ # E: NameError: name '__qualname__' is not defined
+
+# flags: --python-version 3.3
+class A:
+    NAME = __qualname__
+


### PR DESCRIPTION
Mypy will type check '__qualname__' attribute without throwing error. Important for Python versions 3.3 and up.

Fixes #6473