### PR TITLE
Track strict optional mode in typestate cache

### DIFF
--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -12,6 +12,7 @@ if MYPY:
 from mypy.nodes import TypeInfo
 from mypy.types import Instance
 from mypy.server.trigger import make_trigger
+from mypy import state
 
 # Represents that the 'left' instance is a subtype of the 'right' instance
 SubtypeRelationship = Tuple[Instance, Instance]
@@ -22,7 +23,7 @@ SubtypeKind = Tuple[bool, ...]
 
 # A cache that keeps track of whether the given TypeInfo is a part of a particular
 # subtype relationship
-SubtypeCache = Dict[TypeInfo, Dict[SubtypeKind, Set[SubtypeRelationship]]]
+SubtypeCache = Dict[TypeInfo, Dict[Tuple[bool, SubtypeKind], Set[SubtypeRelationship]]]
 
 
 class TypeState:
@@ -36,8 +37,9 @@ class TypeState:
     not needed any more (e.g. during daemon shutdown).
     """
     # '_subtype_caches' keeps track of (subtype, supertype) pairs where supertypes are
-    # instances of the given TypeInfo. The cache also keeps track of the specific
-    # *kind* of subtyping relationship, which we represent as an arbitrary hashable tuple.
+    # instances of the given TypeInfo. The cache also keeps track of whether the check
+    # was done in strict optional mode and of the specific *kind* of subtyping relationship,
+    # which we represent as an arbitrary hashable tuple.
     # We need the caches, since subtype checks for structural types are very slow.
     _subtype_caches = {}  # type: Final[SubtypeCache]
 
@@ -104,15 +106,16 @@ class TypeState:
         if info not in TypeState._subtype_caches:
             return False
         cache = TypeState._subtype_caches[info]
-        if kind not in cache:
+        key = (state.strict_optional, kind)
+        if key not in cache:
             return False
-        return (left, right) in cache[kind]
+        return (left, right) in cache[key]
 
     @staticmethod
     def record_subtype_cache_entry(kind: SubtypeKind,
                                    left: Instance, right: Instance) -> None:
         cache = TypeState._subtype_caches.setdefault(right.type, dict())
-        cache.setdefault(kind, set()).add((left, right))
+        cache.setdefault((state.strict_optional, kind), set()).add((left, right))
 
     @staticmethod
     def reset_protocol_deps() -> None:

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -23,7 +23,7 @@ SubtypeKind = Tuple[bool, ...]
 
 # A cache that keeps track of whether the given TypeInfo is a part of a particular
 # subtype relationship
-SubtypeCache = Dict[TypeInfo, Dict[Tuple[bool, SubtypeKind], Set[SubtypeRelationship]]]
+SubtypeCache = Dict[TypeInfo, Dict[SubtypeKind, Set[SubtypeRelationship]]]
 
 
 class TypeState:
@@ -106,7 +106,7 @@ class TypeState:
         if info not in TypeState._subtype_caches:
             return False
         cache = TypeState._subtype_caches[info]
-        key = (state.strict_optional, kind)
+        key = (state.strict_optional,) + kind
         if key not in cache:
             return False
         return (left, right) in cache[key]
@@ -115,7 +115,7 @@ class TypeState:
     def record_subtype_cache_entry(kind: SubtypeKind,
                                    left: Instance, right: Instance) -> None:
         cache = TypeState._subtype_caches.setdefault(right.type, dict())
-        cache.setdefault((state.strict_optional, kind), set()).add((left, right))
+        cache.setdefault((state.strict_optional,) + kind, set()).add((left, right))
 
     @staticmethod
     def reset_protocol_deps() -> None:

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -751,3 +751,28 @@ def g(x: Optional[int]) -> int:
         return x
 
 [builtins fixtures/bool.pyi]
+
+[case testStrictOptionalCovarianceCrossModule]
+# flags: --config-file tmp/mypy.ini
+from a import asdf
+x = ["lol"]
+asdf(x)
+
+[file a.py]
+from typing import List, Optional
+
+def asdf(x: List[Optional[str]]) -> None:
+    pass
+
+x = ["lol"]
+asdf(x)
+
+[file mypy.ini]
+[[mypy]
+[[mypy-a]
+strict_optional = False
+[out]
+main:4: error: Argument 1 to "asdf" has incompatible type "List[str]"; expected "List[Optional[str]]"
+main:4: note: "List" is invariant -- see http://mypy.readthedocs.io/en/latest/common_issues.html#variance
+main:4: note: Consider using "Sequence" instead, which is covariant
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
Otherwise subtype relationships that are valid with strict optional
off (like List[str] <: List[Optional[str]]) can leak into strict
optional code via the subtype cache.