### PR TITLE
Rename NoneTyp to NoneType

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -6,7 +6,7 @@ MYPY = False
 if MYPY:
     from typing import DefaultDict
 
-from mypy.types import Type, AnyType, PartialType, UnionType, TypeOfAny, NoneTyp
+from mypy.types import Type, AnyType, PartialType, UnionType, TypeOfAny, NoneType
 from mypy.subtypes import is_subtype
 from mypy.join import join_simple
 from mypy.sametypes import is_same_type
@@ -276,10 +276,10 @@ class ConditionalTypeBinder:
         # (See discussion in #3526)
         elif (isinstance(type, AnyType)
               and isinstance(declared_type, UnionType)
-              and any(isinstance(item, NoneTyp) for item in declared_type.items)
-              and isinstance(self.most_recent_enclosing_type(expr, NoneTyp()), NoneTyp)):
+              and any(isinstance(item, NoneType) for item in declared_type.items)
+              and isinstance(self.most_recent_enclosing_type(expr, NoneType()), NoneType)):
             # Replace any Nones in the union type with Any
-            new_items = [type if isinstance(item, NoneTyp) else item
+            new_items = [type if isinstance(item, NoneType) else item
                          for item in declared_type.items]
             self.put(expr, UnionType(new_items))
         elif (isinstance(type, AnyType)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -30,7 +30,7 @@ from mypy.literals import literal, literal_hash
 from mypy.typeanal import has_any_from_unimported_type, check_for_explicit_any
 from mypy.types import (
     Type, AnyType, CallableType, FunctionLike, Overloaded, TupleType, TypedDictType,
-    Instance, NoneTyp, strip_type, TypeType, TypeOfAny,
+    Instance, NoneType, strip_type, TypeType, TypeOfAny,
     UnionType, TypeVarId, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarDef,
     true_only, false_only, function_type, is_named_instance, union_items, TypeQuery, LiteralType,
     is_optional, remove_optional
@@ -668,7 +668,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         else:
             # `return_type` is a supertype of Generator, so callers won't be able to send it
             # values.  IOW, tc is None.
-            return NoneTyp()
+            return NoneType()
 
     def get_coroutine_return_type(self, return_type: Type) -> Type:
         if isinstance(return_type, AnyType):
@@ -799,7 +799,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     fdef = item
                     # Check if __init__ has an invalid, non-None return type.
                     if (fdef.info and fdef.name() in ('__init__', '__init_subclass__') and
-                            not isinstance(typ.ret_type, NoneTyp) and
+                            not isinstance(typ.ret_type, NoneType) and
                             not self.dynamic_funcs[-1]):
                         self.fail(message_registry.MUST_HAVE_NONE_RETURN_TYPE.format(fdef.name()),
                                   item)
@@ -845,7 +845,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     if (self.options.python_version[0] == 2 and
                             isinstance(typ.ret_type, Instance) and
                             typ.ret_type.type.fullname() == 'typing.Generator'):
-                        if not isinstance(typ.ret_type.args[2], (NoneTyp, AnyType)):
+                        if not isinstance(typ.ret_type.args[2], (NoneType, AnyType)):
                             self.fail(message_registry.INVALID_GENERATOR_RETURN_ITEM_TYPE, typ)
 
                 # Fix the type if decorated with `@types.coroutine` or `@asyncio.coroutine`.
@@ -944,7 +944,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 else:
                     return_type = self.return_types[-1]
 
-                if (not isinstance(return_type, (NoneTyp, AnyType))
+                if (not isinstance(return_type, (NoneType, AnyType))
                         and not self.is_trivial_body(defn.body)):
                     # Control flow fell off the end of a function that was
                     # declared to return a non-None type and is not
@@ -1253,7 +1253,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                     AnyType(TypeOfAny.special_form)],
                                    [nodes.ARG_POS, nodes.ARG_POS, nodes.ARG_POS],
                                    [None, None, None],
-                                   NoneTyp(),
+                                   NoneType(),
                                    self.named_type('builtins.function'))
         if not is_subtype(typ, method_type):
             self.msg.invalid_signature_for_special_method(typ, context, '__setattr__')
@@ -1785,7 +1785,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if isinstance(lvalue_type, PartialType) and lvalue_type.type is None:
                     # Try to infer a proper type for a variable with a partial None type.
                     rvalue_type = self.expr_checker.accept(rvalue)
-                    if isinstance(rvalue_type, NoneTyp):
+                    if isinstance(rvalue_type, NoneType):
                         # This doesn't actually provide any additional information -- multiple
                         # None initializers preserve the partial None type.
                         return
@@ -1796,7 +1796,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         if partial_types is not None:
                             if not self.current_node_deferred:
                                 inferred_type = UnionType.make_simplified_union(
-                                    [rvalue_type, NoneTyp()])
+                                    [rvalue_type, NoneType()])
                                 self.set_inferred_type(var, lvalue, inferred_type)
                             else:
                                 var.type = None
@@ -2456,7 +2456,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             self.set_inferred_type(name, lvalue, init_type)
 
     def infer_partial_type(self, name: Var, lvalue: Lvalue, init_type: Type) -> bool:
-        if isinstance(init_type, NoneTyp):
+        if isinstance(init_type, NoneType):
             partial_type = PartialType(None, name, [init_type])
         elif isinstance(init_type, Instance):
             fullname = init_type.type.fullname()
@@ -2464,7 +2464,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     (fullname == 'builtins.list' or
                      fullname == 'builtins.set' or
                      fullname == 'builtins.dict') and
-                    all(isinstance(t, (NoneTyp, UninhabitedType)) for t in init_type.args)):
+                    all(isinstance(t, (NoneType, UninhabitedType)) for t in init_type.args)):
                 partial_type = PartialType(init_type.type, name, init_type.args)
             else:
                 return False
@@ -2616,7 +2616,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 arg_types=[self.named_type('builtins.str'), item_type],
                 arg_kinds=[ARG_POS, ARG_POS],
                 arg_names=[None, None],
-                ret_type=NoneTyp(),
+                ret_type=NoneType(),
                 fallback=self.named_type('builtins.function')
             )  # type: Type
         else:
@@ -2680,7 +2680,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
             if s.expr:
                 is_lambda = isinstance(self.scope.top_function(), LambdaExpr)
-                declared_none_return = isinstance(return_type, NoneTyp)
+                declared_none_return = isinstance(return_type, NoneType)
                 declared_any_return = isinstance(return_type, AnyType)
 
                 # This controls whether or not we allow a function call that
@@ -2715,7 +2715,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if declared_none_return:
                     # Lambdas are allowed to have None returns.
                     # Functions returning a value of type None are allowed to have a None return.
-                    if is_lambda or isinstance(typ, NoneTyp):
+                    if is_lambda or isinstance(typ, NoneType):
                         return
                     self.fail(message_registry.NO_RETURN_VALUE_EXPECTED, s)
                 else:
@@ -2733,7 +2733,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         isinstance(return_type, AnyType)):
                     return
 
-                if isinstance(return_type, (NoneTyp, AnyType)):
+                if isinstance(return_type, (NoneType, AnyType)):
                     return
 
                 if self.in_checked_function():
@@ -2843,7 +2843,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             return
         expected_type = self.named_type('builtins.BaseException')  # type: Type
         if optional:
-            expected_type = UnionType([expected_type, NoneTyp()])
+            expected_type = UnionType([expected_type, NoneType()])
         self.check_subtype(typ, expected_type, s, message_registry.INVALID_EXCEPTION)
 
     def visit_try_stmt(self, s: TryStmt) -> None:
@@ -3164,7 +3164,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             self.expr_checker.accept(arg)
         if s.target:
             target_type = self.expr_checker.accept(s.target)
-            if not isinstance(target_type, NoneTyp):
+            if not isinstance(target_type, NoneType):
                 # TODO: Also verify the type of 'write'.
                 self.expr_checker.analyze_external_member_access('write', target_type, s.target)
 
@@ -3408,7 +3408,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         # two elements in node.operands, and at least one of them
                         # should represent a None.
                         vartype = type_map[expr]
-                        none_typ = [TypeRange(NoneTyp(), is_upper_bound=False)]
+                        none_typ = [TypeRange(NoneType(), is_upper_bound=False)]
                         if_vars, else_vars = conditional_type_map(expr, vartype, none_typ)
                         break
 
@@ -3522,7 +3522,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
     def contains_none(self, t: Type) -> bool:
         return (
-            isinstance(t, NoneTyp) or
+            isinstance(t, NoneType) or
             (isinstance(t, UnionType) and any(self.contains_none(ut) for ut in t.items)) or
             (isinstance(t, TupleType) and any(self.contains_none(tt) for tt in t.items)) or
             (isinstance(t, Instance) and bool(t.args)
@@ -3660,7 +3660,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         and isinstance(var.type, PartialType)
                         and var.type.type is None
                         and not permissive):
-                    var.type = NoneTyp()
+                    var.type = NoneType()
                 else:
                     if var not in self.partial_reported and not permissive:
                         self.msg.need_annotation_for_var(var, context)
@@ -3679,7 +3679,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # 'None' partial type. It has a well-defined type. In an lvalue context
             # we want to preserve the knowledge of it being a partial type.
             if not is_lvalue:
-                return NoneTyp()
+                return NoneType()
             else:
                 return typ
         else:
@@ -3702,7 +3702,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if not isinstance(typ, PartialType):
             return typ
         if typ.type is None:
-            return UnionType.make_union([AnyType(TypeOfAny.unannotated), NoneTyp()])
+            return UnionType.make_union([AnyType(TypeOfAny.unannotated), NoneType()])
         else:
             return Instance(
                 typ.type,
@@ -4200,8 +4200,8 @@ def is_valid_inferred_type(typ: Type) -> bool:
     invalid.  When doing strict Optional checking, only None and types that are
     incompletely defined (i.e. contain UninhabitedType) are invalid.
     """
-    if isinstance(typ, (NoneTyp, UninhabitedType)):
-        # With strict Optional checking, we *may* eventually infer NoneTyp when
+    if isinstance(typ, (NoneType, UninhabitedType)):
+        # With strict Optional checking, we *may* eventually infer NoneType when
         # the initializer is None, but we only do that if we can't infer a
         # specific Optional type.  This resolution happens in
         # leave_partial_types when we pop a partial types scope.

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -5,7 +5,7 @@ from typing import cast, Callable, List, Optional, TypeVar
 from mypy.types import (
     Type, Instance, AnyType, TupleType, TypedDictType, CallableType, FunctionLike, TypeVarDef,
     Overloaded, TypeVarType, UnionType, PartialType, UninhabitedType, TypeOfAny, LiteralType,
-    DeletedType, NoneTyp, TypeType, function_type, get_type_vars,
+    DeletedType, NoneType, TypeType, function_type, get_type_vars,
 )
 from mypy.nodes import (
     TypeInfo, FuncBase, Var, FuncDef, SymbolNode, Context, MypyFile, TypeVarExpr,
@@ -130,7 +130,7 @@ def _analyze_member_access(name: str,
     elif isinstance(typ, (TypedDictType, LiteralType, FunctionLike)):
         # Actually look up from the fallback instance type.
         return _analyze_member_access(name, typ.fallback, mx)
-    elif isinstance(typ, NoneTyp):
+    elif isinstance(typ, NoneType):
         return analyze_none_member_access(name, typ, mx)
     elif isinstance(typ, TypeVarType):
         return _analyze_member_access(name, typ.upper_bound, mx)
@@ -269,7 +269,7 @@ def analyze_union_member_access(name: str, typ: UnionType, mx: MemberContext) ->
     return UnionType.make_simplified_union(results)
 
 
-def analyze_none_member_access(name: str, typ: NoneTyp, mx: MemberContext) -> Type:
+def analyze_none_member_access(name: str, typ: NoneType, mx: MemberContext) -> Type:
     if mx.chk.should_suppress_optional_error([typ]):
         return AnyType(TypeOfAny.from_error)
     is_python_3 = mx.chk.options.python_version[0] >= 3
@@ -430,10 +430,10 @@ def analyze_descriptor_access(instance_type: Type,
 
     if isinstance(instance_type, FunctionLike) and instance_type.is_type_obj():
         owner_type = instance_type.items()[0].ret_type
-        instance_type = NoneTyp()
+        instance_type = NoneType()
     elif isinstance(instance_type, TypeType):
         owner_type = instance_type.item
-        instance_type = NoneTyp()
+        instance_type = NoneType()
     else:
         owner_type = instance_type
 

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -3,7 +3,7 @@
 from typing import Iterable, List, Optional, Sequence
 
 from mypy.types import (
-    CallableType, Type, TypeVisitor, UnboundType, AnyType, NoneTyp, TypeVarType, Instance,
+    CallableType, Type, TypeVisitor, UnboundType, AnyType, NoneType, TypeVarType, Instance,
     TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType, DeletedType,
     UninhabitedType, TypeType, TypeVarId, TypeQuery, is_named_instance, TypeOfAny, LiteralType,
 )
@@ -248,7 +248,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
     def visit_any(self, template: AnyType) -> List[Constraint]:
         return []
 
-    def visit_none_type(self, template: NoneTyp) -> List[Constraint]:
+    def visit_none_type(self, template: NoneType) -> List[Constraint]:
         return []
 
     def visit_uninhabited_type(self, template: UninhabitedType) -> List[Constraint]:

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -1,7 +1,7 @@
 from typing import Optional, Container, Callable
 
 from mypy.types import (
-    Type, TypeVisitor, UnboundType, AnyType, NoneTyp, TypeVarId, Instance, TypeVarType,
+    Type, TypeVisitor, UnboundType, AnyType, NoneType, TypeVarId, Instance, TypeVarType,
     CallableType, TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType,
     DeletedType, TypeTranslator, UninhabitedType, TypeType, TypeOfAny, LiteralType,
 )
@@ -33,7 +33,7 @@ class EraseTypeVisitor(TypeVisitor[Type]):
     def visit_any(self, t: AnyType) -> Type:
         return t
 
-    def visit_none_type(self, t: NoneTyp) -> Type:
+    def visit_none_type(self, t: NoneType) -> Type:
         return t
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> Type:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -2,7 +2,7 @@ from typing import Dict, Iterable, List, TypeVar, Mapping, cast
 
 from mypy.types import (
     Type, Instance, CallableType, TypeVisitor, UnboundType, AnyType,
-    NoneTyp, TypeVarType, Overloaded, TupleType, TypedDictType, UnionType,
+    NoneType, TypeVarType, Overloaded, TupleType, TypedDictType, UnionType,
     ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, TypeVarId,
     FunctionLike, TypeVarDef, LiteralType,
 )
@@ -66,7 +66,7 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
     def visit_any(self, t: AnyType) -> Type:
         return t
 
-    def visit_none_type(self, t: NoneTyp) -> Type:
+    def visit_none_type(self, t: NoneType) -> Type:
         return t
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> Type:

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -48,7 +48,7 @@ class TypeIndirectionVisitor(SyntheticTypeVisitor[Set[str]]):
     def visit_any(self, t: types.AnyType) -> Set[str]:
         return set()
 
-    def visit_none_type(self, t: types.NoneTyp) -> Set[str]:
+    def visit_none_type(self, t: types.NoneType) -> Set[str]:
         return set()
 
     def visit_uninhabited_type(self, t: types.UninhabitedType) -> Set[str]:

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from typing import List, Optional
 
 from mypy.types import (
-    Type, AnyType, NoneTyp, TypeVisitor, Instance, UnboundType, TypeVarType, CallableType,
+    Type, AnyType, NoneType, TypeVisitor, Instance, UnboundType, TypeVarType, CallableType,
     TupleType, TypedDictType, ErasedType, UnionType, FunctionLike, Overloaded, LiteralType,
     PartialType, DeletedType, UninhabitedType, TypeType, true_or_false, TypeOfAny,
 )
@@ -41,7 +41,7 @@ def join_simple(declaration: Optional[Type], s: Type, t: Type) -> Type:
     if isinstance(declaration, UnionType):
         return UnionType.make_simplified_union([s, t])
 
-    if isinstance(s, NoneTyp) and not isinstance(t, NoneTyp):
+    if isinstance(s, NoneType) and not isinstance(t, NoneType):
         s, t = t, s
 
     if isinstance(s, UninhabitedType) and not isinstance(t, UninhabitedType):
@@ -81,7 +81,7 @@ def join_types(s: Type, t: Type) -> Type:
     if isinstance(s, UnionType) and not isinstance(t, UnionType):
         s, t = t, s
 
-    if isinstance(s, NoneTyp) and not isinstance(t, NoneTyp):
+    if isinstance(s, NoneType) and not isinstance(t, NoneType):
         s, t = t, s
 
     if isinstance(s, UninhabitedType) and not isinstance(t, UninhabitedType):
@@ -113,9 +113,9 @@ class TypeJoinVisitor(TypeVisitor[Type]):
     def visit_any(self, t: AnyType) -> Type:
         return t
 
-    def visit_none_type(self, t: NoneTyp) -> Type:
+    def visit_none_type(self, t: NoneType) -> Type:
         if state.strict_optional:
-            if isinstance(self.s, (NoneTyp, UninhabitedType)):
+            if isinstance(self.s, (NoneType, UninhabitedType)):
                 return t
             elif isinstance(self.s, UnboundType):
                 return AnyType(TypeOfAny.special_form)
@@ -173,7 +173,7 @@ class TypeJoinVisitor(TypeVisitor[Type]):
             if is_equivalent(t, self.s):
                 return combine_similar_callables(t, self.s)
             result = join_similar_callables(t, self.s)
-            if any(isinstance(tp, (NoneTyp, UninhabitedType)) for tp in result.arg_types):
+            if any(isinstance(tp, (NoneType, UninhabitedType)) for tp in result.arg_types):
                 # We don't want to return unusable Callable, attempt fallback instead.
                 return join_types(t.fallback, self.s)
             return result

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -5,7 +5,7 @@ from mypy.join import (
     is_similar_callables, combine_similar_callables, join_type_list, unpack_callback_protocol
 )
 from mypy.types import (
-    Type, AnyType, TypeVisitor, UnboundType, NoneTyp, TypeVarType, Instance, CallableType,
+    Type, AnyType, TypeVisitor, UnboundType, NoneType, TypeVarType, Instance, CallableType,
     TupleType, TypedDictType, ErasedType, UnionType, PartialType, DeletedType,
     UninhabitedType, TypeType, TypeOfAny, Overloaded, FunctionLike, LiteralType,
 )
@@ -44,7 +44,7 @@ def narrow_declared_type(declared: Type, narrowed: Type) -> Type:
         if state.strict_optional:
             return UninhabitedType()
         else:
-            return NoneTyp()
+            return NoneType()
     elif isinstance(narrowed, UnionType):
         return UnionType.make_simplified_union([narrow_declared_type(declared, x)
                                                 for x in narrowed.relevant_items()])
@@ -147,7 +147,7 @@ def is_overlapping_types(left: Type,
     # If this check fails, we start checking to see if there exists a
     # *partial* overlap between types.
     #
-    # These checks will also handle the NoneTyp and UninhabitedType cases for us.
+    # These checks will also handle the NoneType and UninhabitedType cases for us.
 
     if (is_proper_subtype(left, right, ignore_promotions=ignore_promotions)
             or is_proper_subtype(right, left, ignore_promotions=ignore_promotions)):
@@ -170,7 +170,7 @@ def is_overlapping_types(left: Type,
     # we skip these checks to avoid infinitely recursing.
 
     def is_none_typevar_overlap(t1: Type, t2: Type) -> bool:
-        return isinstance(t1, NoneTyp) and isinstance(t2, TypeVarType)
+        return isinstance(t1, NoneType) and isinstance(t2, TypeVarType)
 
     if prohibit_none_typevar_overlap:
         if is_none_typevar_overlap(left, right) or is_none_typevar_overlap(right, left):
@@ -191,7 +191,7 @@ def is_overlapping_types(left: Type,
     # We must perform this check after the TypeVar checks because
     # a TypeVar could be bound to None, for example.
 
-    if state.strict_optional and isinstance(left, NoneTyp) != isinstance(right, NoneTyp):
+    if state.strict_optional and isinstance(left, NoneType) != isinstance(right, NoneType):
         return False
 
     # Next, we handle single-variant types that may be inherently partially overlapping:
@@ -380,7 +380,7 @@ class TypeMeetVisitor(TypeVisitor[Type]):
         self.s = s
 
     def visit_unbound_type(self, t: UnboundType) -> Type:
-        if isinstance(self.s, NoneTyp):
+        if isinstance(self.s, NoneType):
             if state.strict_optional:
                 return AnyType(TypeOfAny.special_form)
             else:
@@ -404,9 +404,9 @@ class TypeMeetVisitor(TypeVisitor[Type]):
                      for x in t.items]
         return UnionType.make_simplified_union(meets)
 
-    def visit_none_type(self, t: NoneTyp) -> Type:
+    def visit_none_type(self, t: NoneType) -> Type:
         if state.strict_optional:
-            if isinstance(self.s, NoneTyp) or (isinstance(self.s, Instance) and
+            if isinstance(self.s, NoneType) or (isinstance(self.s, Instance) and
                                                self.s.type.fullname() == 'builtins.object'):
                 return t
             else:
@@ -418,7 +418,7 @@ class TypeMeetVisitor(TypeVisitor[Type]):
         return t
 
     def visit_deleted_type(self, t: DeletedType) -> Type:
-        if isinstance(self.s, NoneTyp):
+        if isinstance(self.s, NoneType):
             if state.strict_optional:
                 return t
             else:
@@ -452,7 +452,7 @@ class TypeMeetVisitor(TypeVisitor[Type]):
                     if state.strict_optional:
                         return UninhabitedType()
                     else:
-                        return NoneTyp()
+                        return NoneType()
             else:
                 if is_subtype(t, self.s):
                     return t
@@ -463,7 +463,7 @@ class TypeMeetVisitor(TypeVisitor[Type]):
                     if state.strict_optional:
                         return UninhabitedType()
                     else:
-                        return NoneTyp()
+                        return NoneType()
         elif isinstance(self.s, FunctionLike) and t.type.is_protocol:
             call = unpack_callback_protocol(t)
             if call:
@@ -488,7 +488,7 @@ class TypeMeetVisitor(TypeVisitor[Type]):
         elif isinstance(self.s, TypeType) and t.is_type_obj() and not t.is_generic():
             # In this case we are able to potentially produce a better meet.
             res = meet_types(self.s.item, t.ret_type)
-            if not isinstance(res, (NoneTyp, UninhabitedType)):
+            if not isinstance(res, (NoneType, UninhabitedType)):
                 return TypeType.make_normalized(res)
             return self.default(self.s)
         elif isinstance(self.s, Instance) and self.s.type.is_protocol:
@@ -569,7 +569,7 @@ class TypeMeetVisitor(TypeVisitor[Type]):
     def visit_type_type(self, t: TypeType) -> Type:
         if isinstance(self.s, TypeType):
             typ = self.meet(t.item, self.s.item)
-            if not isinstance(typ, NoneTyp):
+            if not isinstance(typ, NoneType):
                 typ = TypeType.make_normalized(typ, line=t.line)
             return typ
         elif isinstance(self.s, Instance) and self.s.type.fullname() == 'builtins.type':
@@ -589,7 +589,7 @@ class TypeMeetVisitor(TypeVisitor[Type]):
             if state.strict_optional:
                 return UninhabitedType()
             else:
-                return NoneTyp()
+                return NoneType()
 
 
 def meet_similar_callables(t: CallableType, s: CallableType) -> CallableType:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -20,7 +20,7 @@ from mypy.erasetype import erase_type
 from mypy.errors import Errors
 from mypy.types import (
     Type, CallableType, Instance, TypeVarType, TupleType, TypedDictType, LiteralType,
-    UnionType, NoneTyp, AnyType, Overloaded, FunctionLike, DeletedType, TypeType,
+    UnionType, NoneType, AnyType, Overloaded, FunctionLike, DeletedType, TypeType,
     UninhabitedType, TypeOfAny, ForwardRef, UnboundType
 )
 from mypy.nodes import (
@@ -241,9 +241,9 @@ class MessageBuilder:
         elif isinstance(typ, UnionType):
             # Only print Unions as Optionals if the Optional wouldn't have to contain another Union
             print_as_optional = (len(typ.items) -
-                                 sum(isinstance(t, NoneTyp) for t in typ.items) == 1)
+                                 sum(isinstance(t, NoneType) for t in typ.items) == 1)
             if print_as_optional:
-                rest = [t for t in typ.items if not isinstance(t, NoneTyp)]
+                rest = [t for t in typ.items if not isinstance(t, NoneType)]
                 return 'Optional[{}]'.format(self.format_bare(rest[0]))
             else:
                 items = []
@@ -254,7 +254,7 @@ class MessageBuilder:
                     return s
                 else:
                     return '<union: {} items>'.format(len(items))
-        elif isinstance(typ, NoneTyp):
+        elif isinstance(typ, NoneType):
             return 'None'
         elif isinstance(typ, AnyType):
             return 'Any'
@@ -436,7 +436,7 @@ class MessageBuilder:
                 # checks, so we manually convert it back.
                 typ_format = self.format(typ)
                 if typ_format == '"object"' and \
-                        any(type(item) == NoneTyp for item in original_type.items):
+                        any(type(item) == NoneType for item in original_type.items):
                     typ_format = '"None"'
                 self.fail('Item {} of {} has no attribute "{}"{}'.format(
                     typ_format, self.format(original_type), member, extra), context)

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -83,7 +83,7 @@ from mypy import message_registry
 from mypy.types import (
     FunctionLike, UnboundType, TypeVarDef, TupleType, UnionType, StarType, function_type,
     CallableType, Overloaded, Instance, Type, AnyType, LiteralType, LiteralValue,
-    TypeTranslator, TypeOfAny, TypeType, NoneTyp, PlaceholderType
+    TypeTranslator, TypeOfAny, TypeType, NoneType, PlaceholderType
 )
 from mypy.type_visitor import TypeQuery
 from mypy.nodes import implicit_module_attrs
@@ -338,7 +338,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         bool_type = Instance(bool_info, [])
 
         literal_types = [
-            ('None', NoneTyp()),
+            ('None', NoneType()),
             # reveal_type is a mypy-only function that gives an error with
             # the type of its arg.
             ('reveal_type', AnyType(TypeOfAny.special_form)),
@@ -475,7 +475,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             if defn.type is not None and defn.name() in ('__init__', '__init_subclass__'):
                 assert isinstance(defn.type, CallableType)
                 if isinstance(defn.type.ret_type, AnyType):
-                    defn.type = defn.type.copy_modified(ret_type=NoneTyp())
+                    defn.type = defn.type.copy_modified(ret_type=NoneType())
             self.prepare_method_signature(defn, self.type)
 
         # Analyze function signature and initializers first.
@@ -2302,7 +2302,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
         res = None  # type: Optional[Type]
         if self.is_none_alias(rvalue):
-            res = NoneTyp()
+            res = NoneType()
             alias_tvars, depends_on, qualified_tvars = \
                 [], set(), []  # type: List[str], Set[str], List[str]
         else:

--- a/mypy/newsemanal/semanal_newtype.py
+++ b/mypy/newsemanal/semanal_newtype.py
@@ -6,7 +6,7 @@ This is conceptually part of mypy.semanal (semantic analyzer pass 2).
 from typing import Tuple, Optional
 
 from mypy.types import (
-    Type, Instance, CallableType, NoneTyp, TupleType, AnyType, PlaceholderType,
+    Type, Instance, CallableType, NoneType, TupleType, AnyType, PlaceholderType,
     TypeOfAny
 )
 from mypy.nodes import (
@@ -176,13 +176,13 @@ class NewTypeAnalyzer:
         info.is_newtype = True
 
         # Add __init__ method
-        args = [Argument(Var('self'), NoneTyp(), None, ARG_POS),
+        args = [Argument(Var('self'), NoneType(), None, ARG_POS),
                 self.make_argument('item', old_type)]
         signature = CallableType(
             arg_types=[Instance(info, []), old_type],
             arg_kinds=[arg.kind for arg in args],
             arg_names=['self', 'item'],
-            ret_type=NoneTyp(),
+            ret_type=NoneType(),
             fallback=self.api.named_type('__builtins__.function'),
             name=name)
         init_func = FuncDef('__init__', args, Block([]), typ=signature)

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -13,7 +13,7 @@ from mypy.messages import MessageBuilder
 from mypy.options import Options
 from mypy.types import (
     Type, UnboundType, TypeVarType, TupleType, TypedDictType, UnionType, Instance, AnyType,
-    CallableType, NoneTyp, DeletedType, TypeList, TypeVarDef, TypeVisitor, SyntheticTypeVisitor,
+    CallableType, NoneType, DeletedType, TypeList, TypeVarDef, TypeVisitor, SyntheticTypeVisitor,
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType, get_typ_args, set_typ_args,
     CallableArgument, get_type_vars, TypeQuery, union_items, TypeOfAny, ForwardRef, Overloaded,
     LiteralType, RawExpressionType, PlaceholderType
@@ -230,7 +230,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         Return the bound type if successful, and return None if the type is a normal type.
         """
         if fullname == 'builtins.None':
-            return NoneTyp()
+            return NoneType()
         elif fullname == 'typing.Any' or fullname == 'builtins.Any':
             return AnyType(TypeOfAny.explicit)
         elif fullname in ('typing.Final', 'typing_extensions.Final'):
@@ -412,7 +412,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
     def visit_any(self, t: AnyType) -> Type:
         return t
 
-    def visit_none_type(self, t: NoneTyp) -> Type:
+    def visit_none_type(self, t: NoneType) -> Type:
         return t
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> Type:
@@ -697,7 +697,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             fallback = self.named_type_with_normalized_str(arg.base_type_name)
             assert isinstance(fallback, Instance)
             return [LiteralType(arg.literal_value, fallback, line=arg.line, column=arg.column)]
-        elif isinstance(arg, (NoneTyp, LiteralType)):
+        elif isinstance(arg, (NoneType, LiteralType)):
             # Types that we can just add directly to the literal/potential union of literals.
             return [arg]
         elif isinstance(arg, Instance) and arg.final_value is not None:
@@ -955,7 +955,7 @@ class TypeAnalyserPass3(TypeVisitor[None]):
     def visit_any(self, t: AnyType) -> None:
         pass
 
-    def visit_none_type(self, t: NoneTyp) -> None:
+    def visit_none_type(self, t: NoneType) -> None:
         pass
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> None:
@@ -1262,14 +1262,14 @@ def make_optional_type(t: Type) -> Type:
     is called during semantic analysis and simplification only works during
     type checking.
     """
-    if isinstance(t, NoneTyp):
+    if isinstance(t, NoneType):
         return t
     elif isinstance(t, UnionType):
         items = [item for item in union_items(t)
-                 if not isinstance(item, NoneTyp)]
-        return UnionType(items + [NoneTyp()], t.line, t.column)
+                 if not isinstance(item, NoneType)]
+        return UnionType(items + [NoneType()], t.line, t.column)
     else:
-        return UnionType([t, NoneTyp()], t.line, t.column)
+        return UnionType([t, NoneType()], t.line, t.column)
 
 
 def fix_instance_types(t: Type, fail: Callable[[str, Context], None]) -> None:

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -16,7 +16,7 @@ from mypy.plugins.common import (
     _get_argument, _get_bool_argument, _get_decorator_bool_argument, add_method
 )
 from mypy.types import (
-    Type, AnyType, TypeOfAny, CallableType, NoneTyp, TypeVarDef, TypeVarType,
+    Type, AnyType, TypeOfAny, CallableType, NoneType, TypeVarDef, TypeVarType,
     Overloaded, UnionType, FunctionLike
 )
 from mypy.typevars import fill_typevars
@@ -115,7 +115,7 @@ class Attribute:
             if self.converter.is_attr_converters_optional and init_type:
                 # If the converter was attr.converter.optional(type) then add None to
                 # the allowed init_type.
-                init_type = UnionType.make_union([init_type, NoneTyp()])
+                init_type = UnionType.make_union([init_type, NoneType()])
 
             if not init_type:
                 ctx.api.fail("Cannot determine __init__ type from converter", self.context)
@@ -551,7 +551,7 @@ def _add_init(ctx: 'mypy.plugin.ClassDefContext', attributes: List[Attribute],
     adder.add_method(
         '__init__',
         [attribute.argument(ctx) for attribute in attributes if attribute.init],
-        NoneTyp()
+        NoneType()
     )
 
 

--- a/mypy/plugins/ctypes.py
+++ b/mypy/plugins/ctypes.py
@@ -8,7 +8,7 @@ from mypy import nodes
 from mypy.maptype import map_instance_to_supertype
 from mypy.subtypes import is_subtype
 from mypy.types import (
-    AnyType, CallableType, Instance, NoneTyp, Type, TypeOfAny, UnionType, union_items
+    AnyType, CallableType, Instance, NoneType, Type, TypeOfAny, UnionType, union_items
 )
 
 
@@ -73,7 +73,7 @@ def _autoconvertible_to_cdata(tp: Type, api: 'mypy.plugin.CheckerPluginInterface
                     # Pointer-like _SimpleCData subclasses can also be converted from
                     # an int or None.
                     allowed_types.append(api.named_generic_type('builtins.int', []))
-                    allowed_types.append(NoneTyp())
+                    allowed_types.append(NoneType())
 
     return UnionType.make_simplified_union(allowed_types)
 

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -8,7 +8,7 @@ from mypy.nodes import (
 )
 from mypy.plugin import ClassDefContext
 from mypy.plugins.common import add_method, _get_decorator_bool_argument
-from mypy.types import Instance, NoneTyp, TypeVarDef, TypeVarType
+from mypy.types import Instance, NoneType, TypeVarDef, TypeVarType
 from mypy.server.trigger import make_wildcard_trigger
 
 MYPY = False
@@ -97,7 +97,7 @@ class DataclassTransformer:
                 ctx,
                 '__init__',
                 args=[attr.to_argument(info) for attr in attributes if attr.is_in_init],
-                return_type=NoneTyp(),
+                return_type=NoneType(),
             )
 
         if (decorator_arguments['eq'] and info.get('__eq__') is None or

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -8,7 +8,7 @@ from mypy.plugin import (
 )
 from mypy.plugins.common import try_getting_str_literal
 from mypy.types import (
-    Type, Instance, AnyType, TypeOfAny, CallableType, NoneTyp, UnionType, TypedDictType,
+    Type, Instance, AnyType, TypeOfAny, CallableType, NoneType, UnionType, TypedDictType,
     TypeVarType
 )
 
@@ -178,7 +178,7 @@ def typed_dict_get_callback(ctx: MethodContext) -> Type:
         value_type = ctx.type.items.get(key)
         if value_type:
             if len(ctx.arg_types) == 1:
-                return UnionType.make_simplified_union([value_type, NoneTyp()])
+                return UnionType.make_simplified_union([value_type, NoneType()])
             elif (len(ctx.arg_types) == 2 and len(ctx.arg_types[1]) == 1
                   and len(ctx.args[1]) == 1):
                 default_arg = ctx.args[1][0]

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -1,7 +1,7 @@
 from typing import Sequence
 
 from mypy.types import (
-    Type, UnboundType, AnyType, NoneTyp, TupleType, TypedDictType,
+    Type, UnboundType, AnyType, NoneType, TupleType, TypedDictType,
     UnionType, CallableType, TypeVarType, Instance, TypeVisitor, ErasedType,
     Overloaded, PartialType, DeletedType, UninhabitedType, TypeType, LiteralType,
 )
@@ -59,8 +59,8 @@ class SameTypeVisitor(TypeVisitor[bool]):
     def visit_any(self, left: AnyType) -> bool:
         return isinstance(self.right, AnyType)
 
-    def visit_none_type(self, left: NoneTyp) -> bool:
-        return isinstance(self.right, NoneTyp)
+    def visit_none_type(self, left: NoneType) -> bool:
+        return isinstance(self.right, NoneType)
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> bool:
         return isinstance(self.right, UninhabitedType)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -67,7 +67,7 @@ from mypy import message_registry
 from mypy.types import (
     FunctionLike, UnboundType, TypeVarDef, TupleType, UnionType, StarType, function_type,
     CallableType, Overloaded, Instance, Type, AnyType, LiteralType, LiteralValue,
-    TypeTranslator, TypeOfAny, TypeType, NoneTyp,
+    TypeTranslator, TypeOfAny, TypeType, NoneType,
 )
 from mypy.nodes import implicit_module_attrs
 from mypy.typeanal import (
@@ -420,7 +420,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 if defn.type is not None and defn.name() in ('__init__', '__init_subclass__'):
                     assert isinstance(defn.type, CallableType)
                     if isinstance(defn.type.ret_type, AnyType):
-                        defn.type = defn.type.copy_modified(ret_type=NoneTyp())
+                        defn.type = defn.type.copy_modified(ret_type=NoneType())
                 self.prepare_method_signature(defn, self.type)
             elif self.is_func_scope():
                 # Nested function

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -6,7 +6,7 @@ This is conceptually part of mypy.semanal (semantic analyzer pass 2).
 from typing import Tuple, List, Dict, Mapping, Optional, Union, cast
 
 from mypy.types import (
-    Type, TupleType, NoneTyp, AnyType, TypeOfAny, TypeVarType, TypeVarDef, CallableType, TypeType
+    Type, TupleType, NoneType, AnyType, TypeOfAny, TypeVarType, TypeVarDef, CallableType, TypeType
 )
 from mypy.semanal_shared import SemanticAnalyzerInterface, set_callable_name, PRIORITY_FALLBACKS
 from mypy.nodes import (

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -5,7 +5,7 @@ This is conceptually part of mypy.semanal (semantic analyzer pass 2).
 
 from typing import Tuple, Optional
 
-from mypy.types import Type, Instance, CallableType, NoneTyp, TupleType, AnyType, TypeOfAny
+from mypy.types import Type, Instance, CallableType, NoneType, TupleType, AnyType, TypeOfAny
 from mypy.nodes import (
     AssignmentStmt, NewTypeExpr, CallExpr, NameExpr, RefExpr, Context, StrExpr, BytesExpr,
     UnicodeExpr, Block, FuncDef, Argument, TypeInfo, Var, SymbolTableNode, GDEF, MDEF, ARG_POS
@@ -132,13 +132,13 @@ class NewTypeAnalyzer:
         info.is_newtype = True
 
         # Add __init__ method
-        args = [Argument(Var('self'), NoneTyp(), None, ARG_POS),
+        args = [Argument(Var('self'), NoneType(), None, ARG_POS),
                 self.make_argument('item', old_type)]
         signature = CallableType(
             arg_types=[Instance(info, []), old_type],
             arg_kinds=[arg.kind for arg in args],
             arg_names=['self', 'item'],
-            ret_type=NoneTyp(),
+            ret_type=NoneType(),
             fallback=self.api.named_type('__builtins__.function'),
             name=name)
         init_func = FuncDef('__init__', args, Block([]), typ=signature)

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -27,7 +27,7 @@ from mypy.nodes import (
     TryStmt, OverloadedFuncDef, Lvalue, Context, ImportedName, LDEF, GDEF, MDEF, UNBOUND_IMPORTED,
     implicit_module_attrs, AssertStmt,
 )
-from mypy.types import Type, UnboundType, UnionType, AnyType, TypeOfAny, NoneTyp, CallableType
+from mypy.types import Type, UnboundType, UnionType, AnyType, TypeOfAny, NoneType, CallableType
 from mypy.semanal import SemanticAnalyzerPass2
 from mypy.reachability import infer_reachability_of_if_statement, assert_will_always_fail
 from mypy.semanal_shared import create_indirect_imported_name
@@ -111,7 +111,7 @@ class SemanticAnalyzerPass1(NodeVisitor[None]):
             # cannot define a variable with them explicitly.
             if mod_id == 'builtins':
                 literal_types = [
-                    ('None', NoneTyp()),
+                    ('None', NoneType()),
                     # reveal_type is a mypy-only function that gives an error with
                     # the type of its arg.
                     ('reveal_type', AnyType(TypeOfAny.special_form)),

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -57,7 +57,7 @@ from mypy.nodes import (
     FuncBase, OverloadedFuncDef, FuncItem, MypyFile, UNBOUND_IMPORTED
 )
 from mypy.types import (
-    Type, TypeVisitor, UnboundType, AnyType, NoneTyp, UninhabitedType,
+    Type, TypeVisitor, UnboundType, AnyType, NoneType, UninhabitedType,
     ErasedType, DeletedType, Instance, TypeVarType, CallableType, TupleType, TypedDictType,
     UnionType, Overloaded, PartialType, TypeType, LiteralType,
 )
@@ -268,7 +268,7 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
     def visit_any(self, typ: AnyType) -> SnapshotItem:
         return snapshot_simple_type(typ)
 
-    def visit_none_type(self, typ: NoneTyp) -> SnapshotItem:
+    def visit_none_type(self, typ: NoneType) -> SnapshotItem:
         return snapshot_simple_type(typ)
 
     def visit_uninhabited_type(self, typ: UninhabitedType) -> SnapshotItem:

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -56,7 +56,7 @@ from mypy.nodes import (
 )
 from mypy.traverser import TraverserVisitor
 from mypy.types import (
-    Type, SyntheticTypeVisitor, Instance, AnyType, NoneTyp, CallableType, DeletedType, PartialType,
+    Type, SyntheticTypeVisitor, Instance, AnyType, NoneType, CallableType, DeletedType, PartialType,
     TupleType, TypeType, TypeVarType, TypedDictType, UnboundType, UninhabitedType, UnionType,
     Overloaded, TypeVarDef, TypeList, CallableArgument, EllipsisType, StarType, LiteralType,
     RawExpressionType,
@@ -348,7 +348,7 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
     def visit_any(self, typ: AnyType) -> None:
         pass
 
-    def visit_none_type(self, typ: NoneTyp) -> None:
+    def visit_none_type(self, typ: NoneType) -> None:
         pass
 
     def visit_callable_type(self, typ: CallableType) -> None:

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -56,10 +56,10 @@ from mypy.nodes import (
 )
 from mypy.traverser import TraverserVisitor
 from mypy.types import (
-    Type, SyntheticTypeVisitor, Instance, AnyType, NoneType, CallableType, DeletedType, PartialType,
+    Type, SyntheticTypeVisitor, Instance, AnyType, NoneType, CallableType, DeletedType,
     TupleType, TypeType, TypeVarType, TypedDictType, UnboundType, UninhabitedType, UnionType,
     Overloaded, TypeVarDef, TypeList, CallableArgument, EllipsisType, StarType, LiteralType,
-    RawExpressionType,
+    RawExpressionType, PartialType,
 )
 from mypy.util import get_prefix, replace_object_state
 from mypy.typestate import TypeState

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -97,7 +97,7 @@ from mypy.nodes import (
 )
 from mypy.traverser import TraverserVisitor
 from mypy.types import (
-    Type, Instance, AnyType, NoneTyp, TypeVisitor, CallableType, DeletedType, PartialType,
+    Type, Instance, AnyType, NoneType, TypeVisitor, CallableType, DeletedType, PartialType,
     TupleType, TypeType, TypeVarType, TypedDictType, UnboundType, UninhabitedType, UnionType,
     FunctionLike, ForwardRef, Overloaded, TypeOfAny, LiteralType,
 )
@@ -891,7 +891,7 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
             return [make_trigger(typ.missing_import_name)]
         return []
 
-    def visit_none_type(self, typ: NoneTyp) -> List[str]:
+    def visit_none_type(self, typ: NoneType) -> List[str]:
         return []
 
     def visit_callable_type(self, typ: CallableType) -> List[str]:

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -18,7 +18,7 @@ def solve_constraints(vars: List[TypeVarId], constraints: List[Constraint],
     could not be solved.
 
     If a variable has no constraints, if strict=True then arbitrarily
-    pick NoneTyp as the value of the type variable.  If strict=False,
+    pick NoneType as the value of the type variable.  If strict=False,
     pick AnyType.
     """
     # Collect a list of constraints for each type variable.

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -80,7 +80,7 @@ from mypy.stubdoc import parse_all_signatures, find_unique_signatures, Sig
 from mypy.options import Options as MypyOptions
 from mypy.types import (
     Type, TypeStrVisitor, CallableType,
-    UnboundType, NoneTyp, TupleType, TypeList,
+    UnboundType, NoneType, TupleType, TypeList,
 )
 from mypy.visitor import NodeVisitor
 from mypy.find_sources import create_source_list, InvalidSourceList
@@ -171,7 +171,7 @@ class AnnotationPrinter(TypeStrVisitor):
             s += '[{}]'.format(self.list_str(t.args))
         return s
 
-    def visit_none_type(self, t: NoneTyp) -> str:
+    def visit_none_type(self, t: NoneType) -> str:
         return "None"
 
     def visit_type_list(self, t: TypeList) -> str:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Callable, Tuple, Iterator, Set, Union, cast
 from contextlib import contextmanager
 
 from mypy.types import (
-    Type, AnyType, UnboundType, TypeVisitor, FormalArgument, NoneTyp, function_type,
+    Type, AnyType, UnboundType, TypeVisitor, FormalArgument, NoneType, function_type,
     Instance, TypeVarType, CallableType, TupleType, TypedDictType, UnionType, Overloaded,
     ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, is_named_instance,
     FunctionLike, TypeOfAny, LiteralType,
@@ -164,9 +164,9 @@ class SubtypeVisitor(TypeVisitor[bool]):
     def visit_any(self, left: AnyType) -> bool:
         return True
 
-    def visit_none_type(self, left: NoneTyp) -> bool:
+    def visit_none_type(self, left: NoneType) -> bool:
         if state.strict_optional:
-            return (isinstance(self.right, NoneTyp) or
+            return (isinstance(self.right, NoneType) or
                     is_named_instance(self.right, 'builtins.object') or
                     isinstance(self.right, Instance) and self.right.type.is_protocol and
                     not self.right.type.protocol_members)
@@ -184,7 +184,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
 
     def visit_instance(self, left: Instance) -> bool:
         if left.type.fallback_to_any:
-            if isinstance(self.right, NoneTyp):
+            if isinstance(self.right, NoneType):
                 # NOTE: `None` is a *non-subclassable* singleton, therefore no class
                 # can by a subtype of it, even with an `Any` fallback.
                 # This special case is needed to treat descriptors in classes with
@@ -495,7 +495,7 @@ def is_protocol_implementation(left: Instance, right: Instance,
                 is_compat = is_proper_subtype(subtype, supertype)
             if not is_compat:
                 return False
-            if isinstance(subtype, NoneTyp) and isinstance(supertype, CallableType):
+            if isinstance(subtype, NoneType) and isinstance(supertype, CallableType):
                 # We want __hash__ = None idiom to work even without --strict-optional
                 return False
             subflags = get_member_flags(member, left.type)
@@ -1073,9 +1073,9 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
     def visit_any(self, left: AnyType) -> bool:
         return isinstance(self.right, AnyType)
 
-    def visit_none_type(self, left: NoneTyp) -> bool:
+    def visit_none_type(self, left: NoneType) -> bool:
         if state.strict_optional:
-            return (isinstance(self.right, NoneTyp) or
+            return (isinstance(self.right, NoneType) or
                     is_named_instance(self.right, 'builtins.object'))
         return True
 

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -30,7 +30,7 @@ import mypy.checker
 import mypy.types
 from mypy.state import strict_optional_set
 from mypy.types import (
-    Type, AnyType, TypeOfAny, CallableType, UnionType, NoneTyp, Instance, is_optional,
+    Type, AnyType, TypeOfAny, CallableType, UnionType, NoneType, Instance, is_optional,
 )
 from mypy.build import State
 from mypy.nodes import (
@@ -291,7 +291,7 @@ class SuggestionEngine:
             if returns:
                 ret_types = generate_type_combinations(returns)
             else:
-                ret_types = [NoneTyp()]
+                ret_types = [NoneType()]
 
         guesses = [best.copy_modified(ret_type=t) for t in ret_types]
         best = self.find_best(node, guesses)

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -9,7 +9,7 @@ from mypy.join import join_types, join_simple
 from mypy.meet import meet_types
 from mypy.sametypes import is_same_type
 from mypy.types import (
-    UnboundType, AnyType, CallableType, TupleType, TypeVarDef, Type, Instance, NoneTyp, Overloaded,
+    UnboundType, AnyType, CallableType, TupleType, TypeVarDef, Type, Instance, NoneType, Overloaded,
     TypeType, UnionType, UninhabitedType, true_only, false_only, TypeVarId, TypeOfAny, LiteralType
 )
 from mypy.nodes import ARG_POS, ARG_OPT, ARG_STAR, ARG_STAR2, CONTRAVARIANT, INVARIANT, COVARIANT
@@ -43,7 +43,7 @@ class TypesSuite(Suite):
                          AnyType(TypeOfAny.special_form), self.function)
         assert_equal(str(c), 'def (X?, Y?) -> Any')
 
-        c2 = CallableType([], [], [], NoneTyp(), self.fx.function)
+        c2 = CallableType([], [], [], NoneType(), self.fx.function)
         assert_equal(str(c2), 'def ()')
 
     def test_callable_type_with_default_args(self) -> None:
@@ -87,7 +87,7 @@ class TypesSuite(Suite):
 
         v = [TypeVarDef('Y', 'Y', -1, [], self.fx.o),
              TypeVarDef('X', 'X', -2, [], self.fx.o)]
-        c2 = CallableType([], [], [], NoneTyp(), self.function, name=None, variables=v)
+        c2 = CallableType([], [], [], NoneType(), self.function, name=None, variables=v)
         assert_equal(str(c2), 'def [Y, X] ()')
 
 
@@ -310,7 +310,7 @@ class TypeOpsSuite(Suite):
     # true_only / false_only
 
     def test_true_only_of_false_type_is_uninhabited(self) -> None:
-        to = true_only(NoneTyp())
+        to = true_only(NoneType())
         assert_type(UninhabitedType, to)
 
     def test_true_only_of_true_type_is_idempotent(self) -> None:
@@ -344,7 +344,7 @@ class TypeOpsSuite(Suite):
         assert_type(UninhabitedType, fo)
 
     def test_false_only_of_false_type_is_idempotent(self) -> None:
-        always_false = NoneTyp()
+        always_false = NoneType()
         fo = false_only(always_false)
         assert_true(always_false is fo)
 
@@ -451,10 +451,10 @@ class JoinSuite(Suite):
 
     def test_none(self) -> None:
         # Any type t joined with None results in t.
-        for t in [NoneTyp(), self.fx.a, self.fx.o, UnboundType('x'),
+        for t in [NoneType(), self.fx.a, self.fx.o, UnboundType('x'),
                   self.fx.t, self.tuple(),
                   self.callable(self.fx.a, self.fx.b), self.fx.anyt]:
-            self.assert_join(t, NoneTyp(), t)
+            self.assert_join(t, NoneType(), t)
 
     def test_unbound_type(self) -> None:
         self.assert_join(UnboundType('x'), UnboundType('x'), self.fx.anyt)
@@ -469,7 +469,7 @@ class JoinSuite(Suite):
 
     def test_any_type(self) -> None:
         # Join against 'Any' type always results in 'Any'.
-        for t in [self.fx.anyt, self.fx.a, self.fx.o, NoneTyp(),
+        for t in [self.fx.anyt, self.fx.a, self.fx.o, NoneType(),
                   UnboundType('x'), self.fx.t, self.tuple(),
                   self.callable(self.fx.a, self.fx.b)]:
             self.assert_join(t, self.fx.anyt, self.fx.anyt)
@@ -710,8 +710,8 @@ class MeetSuite(Suite):
         self.assert_meet(self.fx.a, self.fx.o, self.fx.a)
         self.assert_meet(self.fx.a, self.fx.b, self.fx.b)
         self.assert_meet(self.fx.b, self.fx.o, self.fx.b)
-        self.assert_meet(self.fx.a, self.fx.d, NoneTyp())
-        self.assert_meet(self.fx.b, self.fx.c, NoneTyp())
+        self.assert_meet(self.fx.a, self.fx.d, NoneType())
+        self.assert_meet(self.fx.b, self.fx.c, NoneType())
 
     def test_tuples(self) -> None:
         self.assert_meet(self.tuple(), self.tuple(), self.tuple())
@@ -720,14 +720,14 @@ class MeetSuite(Suite):
                          self.tuple(self.fx.a))
         self.assert_meet(self.tuple(self.fx.b, self.fx.c),
                          self.tuple(self.fx.a, self.fx.d),
-                         self.tuple(self.fx.b, NoneTyp()))
+                         self.tuple(self.fx.b, NoneType()))
 
         self.assert_meet(self.tuple(self.fx.a, self.fx.a),
                          self.fx.std_tuple,
                          self.tuple(self.fx.a, self.fx.a))
         self.assert_meet(self.tuple(self.fx.a),
                          self.tuple(self.fx.a, self.fx.a),
-                         NoneTyp())
+                         NoneType())
 
     def test_function_types(self) -> None:
         self.assert_meet(self.callable(self.fx.a, self.fx.b),
@@ -744,17 +744,17 @@ class MeetSuite(Suite):
     def test_type_vars(self) -> None:
         self.assert_meet(self.fx.t, self.fx.t, self.fx.t)
         self.assert_meet(self.fx.s, self.fx.s, self.fx.s)
-        self.assert_meet(self.fx.t, self.fx.s, NoneTyp())
+        self.assert_meet(self.fx.t, self.fx.s, NoneType())
 
     def test_none(self) -> None:
-        self.assert_meet(NoneTyp(), NoneTyp(), NoneTyp())
+        self.assert_meet(NoneType(), NoneType(), NoneType())
 
-        self.assert_meet(NoneTyp(), self.fx.anyt, NoneTyp())
+        self.assert_meet(NoneType(), self.fx.anyt, NoneType())
 
         # Any type t joined with None results in None, unless t is Any.
         for t in [self.fx.a, self.fx.o, UnboundType('x'), self.fx.t,
                   self.tuple(), self.callable(self.fx.a, self.fx.b)]:
-            self.assert_meet(t, NoneTyp(), NoneTyp())
+            self.assert_meet(t, NoneType(), NoneType())
 
     def test_unbound_type(self) -> None:
         self.assert_meet(UnboundType('x'), UnboundType('x'), self.fx.anyt)
@@ -771,7 +771,7 @@ class MeetSuite(Suite):
 
     def test_dynamic_type(self) -> None:
         # Meet against dynamic type always results in dynamic.
-        for t in [self.fx.anyt, self.fx.a, self.fx.o, NoneTyp(),
+        for t in [self.fx.anyt, self.fx.a, self.fx.o, NoneType(),
                   UnboundType('x'), self.fx.t, self.tuple(),
                   self.callable(self.fx.a, self.fx.b)]:
             self.assert_meet(t, self.fx.anyt, t)

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -9,8 +9,9 @@ from mypy.join import join_types, join_simple
 from mypy.meet import meet_types
 from mypy.sametypes import is_same_type
 from mypy.types import (
-    UnboundType, AnyType, CallableType, TupleType, TypeVarDef, Type, Instance, NoneType, Overloaded,
-    TypeType, UnionType, UninhabitedType, true_only, false_only, TypeVarId, TypeOfAny, LiteralType
+    UnboundType, AnyType, CallableType, TupleType, TypeVarDef, Type, Instance, NoneType,
+    Overloaded, TypeType, UnionType, UninhabitedType, true_only, false_only, TypeVarId, TypeOfAny,
+    LiteralType,
 )
 from mypy.nodes import ARG_POS, ARG_OPT, ARG_STAR, ARG_STAR2, CONTRAVARIANT, INVARIANT, COVARIANT
 from mypy.subtypes import is_subtype, is_more_precise, is_proper_subtype

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -6,7 +6,7 @@ It contains class TypeInfos and Type objects.
 from typing import List, Optional
 
 from mypy.types import (
-    Type, TypeVarType, AnyType, NoneTyp, Instance, CallableType, TypeVarDef, TypeType,
+    Type, TypeVarType, AnyType, NoneType, Instance, CallableType, TypeVarDef, TypeType,
     UninhabitedType, TypeOfAny
 )
 from mypy.nodes import (
@@ -41,7 +41,7 @@ class TypeFixture:
 
         # Simple types
         self.anyt = AnyType(TypeOfAny.special_form)
-        self.nonet = NoneTyp()
+        self.nonet = NoneType()
         self.uninhabited = UninhabitedType()
 
         # Abstract class TypeInfos

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -20,7 +20,7 @@ T = TypeVar('T')
 
 from mypy.types import (
     Type, AnyType, CallableType, Overloaded, TupleType, TypedDictType, LiteralType,
-    RawExpressionType, Instance, NoneTyp, TypeType,
+    RawExpressionType, Instance, NoneType, TypeType,
     UnionType, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarDef,
     UnboundType, ErasedType, ForwardRef, StarType, EllipsisType, TypeList, CallableArgument,
     PlaceholderType,
@@ -49,7 +49,7 @@ class TypeVisitor(Generic[T]):
         pass
 
     @abstractmethod
-    def visit_none_type(self, t: NoneTyp) -> T:
+    def visit_none_type(self, t: NoneType) -> T:
         pass
 
     @abstractmethod
@@ -150,7 +150,7 @@ class TypeTranslator(TypeVisitor[Type]):
     def visit_any(self, t: AnyType) -> Type:
         return t
 
-    def visit_none_type(self, t: NoneTyp) -> Type:
+    def visit_none_type(self, t: NoneType) -> Type:
         return t
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> Type:
@@ -272,7 +272,7 @@ class TypeQuery(SyntheticTypeVisitor[T]):
     def visit_uninhabited_type(self, t: UninhabitedType) -> T:
         return self.strategy([])
 
-    def visit_none_type(self, t: NoneTyp) -> T:
+    def visit_none_type(self, t: NoneType) -> T:
         return self.strategy([])
 
     def visit_erased_type(self, t: ErasedType) -> T:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -13,7 +13,7 @@ from mypy.messages import MessageBuilder
 from mypy.options import Options
 from mypy.types import (
     Type, UnboundType, TypeVarType, TupleType, TypedDictType, UnionType, Instance, AnyType,
-    CallableType, NoneTyp, DeletedType, TypeList, TypeVarDef, TypeVisitor, SyntheticTypeVisitor,
+    CallableType, NoneType, DeletedType, TypeList, TypeVarDef, TypeVisitor, SyntheticTypeVisitor,
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType, get_typ_args, set_typ_args,
     CallableArgument, get_type_vars, TypeQuery, union_items, TypeOfAny, ForwardRef, Overloaded,
     LiteralType, RawExpressionType,
@@ -108,7 +108,7 @@ def analyze_type_alias(node: Expression,
             arg = api.lookup_qualified(node.args[0].name, node.args[0])
             if (call is not None and call.node and call.node.fullname() == 'builtins.type' and
                     arg is not None and arg.node and arg.node.fullname() == 'builtins.None'):
-                return NoneTyp(), set()
+                return NoneType(), set()
             return None
         return None
     else:
@@ -262,7 +262,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         Return the bound type if successful, and return None if the type is a normal type.
         """
         if fullname == 'builtins.None':
-            return NoneTyp()
+            return NoneType()
         elif fullname == 'typing.Any' or fullname == 'builtins.Any':
             return AnyType(TypeOfAny.explicit)
         elif fullname in ('typing.Final', 'typing_extensions.Final'):
@@ -452,7 +452,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
     def visit_any(self, t: AnyType) -> Type:
         return t
 
-    def visit_none_type(self, t: NoneTyp) -> Type:
+    def visit_none_type(self, t: NoneType) -> Type:
         return t
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> Type:
@@ -727,7 +727,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             fallback = self.named_type_with_normalized_str(arg.base_type_name)
             assert isinstance(fallback, Instance)
             return [LiteralType(arg.literal_value, fallback, line=arg.line, column=arg.column)]
-        elif isinstance(arg, (NoneTyp, LiteralType)):
+        elif isinstance(arg, (NoneType, LiteralType)):
             # Types that we can just add directly to the literal/potential union of literals.
             return [arg]
         elif isinstance(arg, Instance) and arg.final_value is not None:
@@ -983,7 +983,7 @@ class TypeAnalyserPass3(TypeVisitor[None]):
     def visit_any(self, t: AnyType) -> None:
         pass
 
-    def visit_none_type(self, t: NoneTyp) -> None:
+    def visit_none_type(self, t: NoneType) -> None:
         pass
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> None:
@@ -1290,11 +1290,11 @@ def make_optional_type(t: Type) -> Type:
     is called during semantic analysis and simplification only works during
     type checking.
     """
-    if isinstance(t, NoneTyp):
+    if isinstance(t, NoneType):
         return t
     elif isinstance(t, UnionType):
         items = [item for item in union_items(t)
-                 if not isinstance(item, NoneTyp)]
-        return UnionType(items + [NoneTyp()], t.line, t.column)
+                 if not isinstance(item, NoneType)]
+        return UnionType(items + [NoneType()], t.line, t.column)
     else:
-        return UnionType([t, NoneTyp()], t.line, t.column)
+        return UnionType([t, NoneType()], t.line, t.column)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -453,7 +453,7 @@ class UninhabitedType(Type):
     This type is the bottom type.
     With strict Optional checking, it is the only common subtype between all
     other types, which allows `meet` to be well defined.  Without strict
-    Optional checking, NoneTyp fills this role.
+    Optional checking, NoneType fills this role.
 
     In general, for any type T:
         join(UninhabitedType, T) = T
@@ -496,7 +496,7 @@ class UninhabitedType(Type):
         return UninhabitedType(is_noreturn=data['is_noreturn'])
 
 
-class NoneTyp(Type):
+class NoneType(Type):
     """The type of 'None'.
 
     This type can be written by users as 'None'.
@@ -511,21 +511,26 @@ class NoneTyp(Type):
         return False
 
     def __hash__(self) -> int:
-        return hash(NoneTyp)
+        return hash(NoneType)
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, NoneTyp)
+        return isinstance(other, NoneType)
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_none_type(self)
 
     def serialize(self) -> JsonDict:
-        return {'.class': 'NoneTyp'}
+        return {'.class': 'NoneType'}
 
     @classmethod
-    def deserialize(cls, data: JsonDict) -> 'NoneTyp':
-        assert data['.class'] == 'NoneTyp'
-        return NoneTyp()
+    def deserialize(cls, data: JsonDict) -> 'NoneType':
+        assert data['.class'] == 'NoneType'
+        return NoneType()
+
+
+# NoneType used to be called NoneTyp so to avoid needlessly breaking
+# external plugins we keep that alias here.
+NoneTyp = NoneType
 
 
 class ErasedType(Type):
@@ -1633,7 +1638,7 @@ class UnionType(Type):
         if state.strict_optional:
             return self.items
         else:
-            return [i for i in self.items if not isinstance(i, NoneTyp)]
+            return [i for i in self.items if not isinstance(i, NoneType)]
 
     def serialize(self) -> JsonDict:
         return {'.class': 'UnionType',
@@ -1727,7 +1732,7 @@ class TypeType(Type):
     # a generic class instance, a union, Any, a type variable...
     item = None  # type: Type
 
-    def __init__(self, item: Bogus[Union[Instance, AnyType, TypeVarType, TupleType, NoneTyp,
+    def __init__(self, item: Bogus[Union[Instance, AnyType, TypeVarType, TupleType, NoneType,
                                          CallableType]], *,
                  line: int = -1, column: int = -1) -> None:
         """To ensure Type[Union[A, B]] is always represented as Union[Type[A], Type[B]], item of
@@ -1864,7 +1869,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
 
     Notes:
      - Represent unbound types as Foo? or Foo?[...].
-     - Represent the NoneTyp type as None.
+     - Represent the NoneType type as None.
     """
 
     def __init__(self, id_mapper: Optional[IdMapper] = None) -> None:
@@ -1889,7 +1894,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
     def visit_any(self, t: AnyType) -> str:
         return 'Any'
 
-    def visit_none_type(self, t: NoneTyp) -> str:
+    def visit_none_type(self, t: NoneType) -> str:
         return "None"
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> str:
@@ -1950,7 +1955,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
 
         s = '({})'.format(s)
 
-        if not isinstance(t.ret_type, NoneTyp):
+        if not isinstance(t.ret_type, NoneType):
             s += ' -> {}'.format(t.ret_type.accept(self))
 
         if t.variables:
@@ -2232,12 +2237,12 @@ def is_generic_instance(tp: Type) -> bool:
 
 
 def is_optional(t: Type) -> bool:
-    return isinstance(t, UnionType) and any(isinstance(e, NoneTyp) for e in t.items)
+    return isinstance(t, UnionType) and any(isinstance(e, NoneType) for e in t.items)
 
 
 def remove_optional(typ: Type) -> Type:
     if isinstance(typ, UnionType):
-        return UnionType.make_union([t for t in typ.items if not isinstance(t, NoneTyp)])
+        return UnionType.make_union([t for t in typ.items if not isinstance(t, NoneType)])
     else:
         return typ
 

--- a/mypy/typetraverser.py
+++ b/mypy/typetraverser.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from mypy_extensions import trait
 
 from mypy.types import (
-    Type, SyntheticTypeVisitor, AnyType, UninhabitedType, NoneTyp, ErasedType, DeletedType,
+    Type, SyntheticTypeVisitor, AnyType, UninhabitedType, NoneType, ErasedType, DeletedType,
     TypeVarType, LiteralType, Instance, CallableType, TupleType, TypedDictType, UnionType,
     Overloaded, TypeType, CallableArgument, UnboundType, TypeList, StarType, EllipsisType,
     ForwardRef, PlaceholderType, PartialType, RawExpressionType
@@ -22,7 +22,7 @@ class TypeTraverserVisitor(SyntheticTypeVisitor[None]):
     def visit_uninhabited_type(self, t: UninhabitedType) -> None:
         pass
 
-    def visit_none_type(self, t: NoneTyp) -> None:
+    def visit_none_type(self, t: NoneType) -> None:
         pass
 
     def visit_erased_type(self, t: ErasedType) -> None:

--- a/test-data/unit/plugins/class_callable.py
+++ b/test-data/unit/plugins/class_callable.py
@@ -1,6 +1,6 @@
 from mypy.plugin import Plugin
 from mypy.nodes import NameExpr
-from mypy.types import UnionType, NoneTyp, Instance
+from mypy.types import UnionType, NoneType, Instance
 
 class AttrPlugin(Plugin):
     def get_function_hook(self, fullname):
@@ -24,7 +24,7 @@ def attr_hook(ctx):
         return attr_base
     assert len(attr_base.args) == 1
     arg_type = attr_base.args[0]
-    return Instance(attr_base.type, [UnionType([arg_type, NoneTyp()])],
+    return Instance(attr_base.type, [UnionType([arg_type, NoneType()])],
                     line=ctx.default_return_type.line,
                     column=ctx.default_return_type.column)
 

--- a/test-data/unit/plugins/type_anal_hook.py
+++ b/test-data/unit/plugins/type_anal_hook.py
@@ -1,8 +1,10 @@
 from typing import Optional, Callable
 
 from mypy.plugin import Plugin, AnalyzeTypeContext
-from mypy.types import Type, UnboundType, TypeList, AnyType, NoneTyp, CallableType, TypeOfAny
-
+from mypy.types import Type, UnboundType, TypeList, AnyType, CallableType, TypeOfAny
+# The official name changed to NoneType but we have an alias for plugin compat reasons
+# so we'll keep testing that here.
+from mypy.types import NoneTyp
 
 class TypeAnalyzePlugin(Plugin):
     def get_type_analyze_hook(self, fullname: str


### PR DESCRIPTION
Every other type gets an e in its name. Might as well fix this one.
Keeps a NoneTyp alias to NoneType to avoid breaking external plugins.