### PR TITLE
Fix multiple inheritance check for generic classes

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1647,6 +1647,20 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         Assume base1 comes before base2 in the MRO, and that base1 and base2 don't have
         a direct subclass relationship (i.e., the compatibility requirement only derives from
         multiple inheritance).
+
+        This checks verifies that a definition taken from base1 (and mapped to the current
+        class ctx), is type compatible with the definition taken from base2 (also mapped), so
+        that unsafe subclassing like this can be detected:
+            class A(Generic[T]):
+                def foo(self, x: T) -> None: ...
+
+            class B:
+                def foo(self, x: str) -> None: ...
+
+            class C(B, A[int]): ...  # this is unsafe because...
+
+            x: A[int] = C()
+            x.foo  # ...runtime type is (str) -> None, while static type is (int) -> None
         """
         if name in ('__init__', '__new__', '__init_subclass__'):
             # __init__ and friends can be incompatible -- it's a special case.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1651,8 +1651,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if name in ('__init__', '__new__', '__init_subclass__'):
             # __init__ and friends can be incompatible -- it's a special case.
             return
-        first = base1[name]
-        second = base2[name]
+        first = base1.names[name]
+        second = base2.names[name]
         first_type = self.determine_type_of_class_member(first)
         second_type = self.determine_type_of_class_member(second)
 
@@ -1665,16 +1665,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                 right=fill_typevars_with_any(second_type.type_object()))
             else:
                 # First bind/map method types when necessary.
-                if isinstance(first.node, (FuncDef, OverloadedFuncDef, Decorator)):
-                    first_sig = self.bind_and_map_method(first, first_type,
-                                                         ctx, first.node.info)
-                else:
-                    first_sig = first_type
-                if isinstance(first.node, (FuncDef, OverloadedFuncDef, Decorator)):
-                    second_sig = self.bind_and_map_method(second, second_type,
-                                                          ctx, second.node.info)
-                else:
-                    second_sig = second_type
+                first_sig = self.bind_and_map_method(first, first_type, ctx, base1)
+                second_sig = self.bind_and_map_method(second, second_type, ctx, base2)
                 ok = is_subtype(first_sig, second_sig, ignore_pos_arg_names=True)
         elif first_type and second_type:
             ok = is_equivalent(first_type, second_type)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1418,7 +1418,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         Arguments:
             sym: a symbol that points to method definition
             typ: method type on the definition
-            sub_info: class where the method is mapped to
+            sub_info: class where the method is used
             super_info: class where the method was defined
         """
         if (isinstance(sym.node, (FuncDef, OverloadedFuncDef, Decorator))
@@ -1641,7 +1641,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         return None
 
     def check_compatibility(self, name: str, base1: TypeInfo,
-                            base2: TypeInfo, ctx: Context) -> None:
+                            base2: TypeInfo, ctx: TypeInfo) -> None:
         """Check if attribute name in base1 is compatible with base2 in multiple inheritance.
 
         Assume base1 comes before base2 in the MRO, and that base1 and base2 don't have
@@ -1667,12 +1667,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 # First bind/map method types when necessary.
                 if isinstance(first.node, (FuncDef, OverloadedFuncDef, Decorator)):
                     first_sig = self.bind_and_map_method(first, first_type,
-                                                         base1, first.node.info)
+                                                         ctx, first.node.info)
                 else:
                     first_sig = first_type
                 if isinstance(first.node, (FuncDef, OverloadedFuncDef, Decorator)):
                     second_sig = self.bind_and_map_method(second, second_type,
-                                                          base2, second.node.info)
+                                                          ctx, second.node.info)
                 else:
                     second_sig = second_type
                 ok = is_subtype(first_sig, second_sig, ignore_pos_arg_names=True)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1648,7 +1648,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         a direct subclass relationship (i.e., the compatibility requirement only derives from
         multiple inheritance).
 
-        This checks verifies that a definition taken from base1 (and mapped to the current
+        This check verifies that a definition taken from base1 (and mapped to the current
         class ctx), is type compatible with the definition taken from base2 (also mapped), so
         that unsafe subclassing like this can be detected:
             class A(Generic[T]):

--- a/test-data/unit/check-multiple-inheritance.test
+++ b/test-data/unit/check-multiple-inheritance.test
@@ -625,7 +625,7 @@ class A(Mixin1, Mixin2):
     pass
 [out]
 
-[case testGenericMultipleOverride]
+[case testGenericMultipleOverrideRemap]
 from typing import TypeVar, Generic, Tuple
 
 K = TypeVar('K')
@@ -638,5 +638,30 @@ class ItemsView(Generic[K, V]):
 class Sequence(Generic[T]):
     def __iter__(self) -> T: ...
 
+# Override compatible between bases.
 class OrderedItemsView(ItemsView[K, V], Sequence[Tuple[K, V]]):
     def __iter__(self) -> Tuple[K, V]: ...
+
+class OrderedItemsViewDirect(ItemsView[K, V], Sequence[Tuple[K, V]]):
+    pass
+
+[case testGenericMultipleOverrideReplace]
+from typing import TypeVar, Generic, Union
+
+T = TypeVar('T')
+
+class A(Generic[T]):
+    def foo(self, x: T) -> None: ...
+
+class B(A[T]): ...
+
+class C1:
+    def foo(self, x: str) -> None: ...
+
+class C2:
+    def foo(self, x: Union[str, int]) -> None: ...
+
+class D1(B[str], C1): ...
+class D2(B[Union[int, str]], C2): ...
+class D3(C2, B[str]): ...
+class D4(B[str], C2): ...  # E: Definition of "foo" in base class "A" is incompatible with definition in base class "C2"

--- a/test-data/unit/check-multiple-inheritance.test
+++ b/test-data/unit/check-multiple-inheritance.test
@@ -624,3 +624,19 @@ class Mixin2:
 class A(Mixin1, Mixin2):
     pass
 [out]
+
+[case testGenericMultipleOverride]
+from typing import TypeVar, Generic, Tuple
+
+K = TypeVar('K')
+V = TypeVar('V')
+T = TypeVar('T')
+
+class ItemsView(Generic[K, V]):
+    def __iter__(self) -> Tuple[K, V]: ...
+
+class Sequence(Generic[T]):
+    def __iter__(self) -> T: ...
+
+class OrderedItemsView(ItemsView[K, V], Sequence[Tuple[K, V]]):
+    def __iter__(self) -> Tuple[K, V]: ...

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1366,18 +1366,3 @@ x: Dict[str, List[int]]
 reveal_type(x['test'][0])
 [out]
 _testNewAnalyzerBasicTypeshed_newsemanal.py:4: error: Revealed type is 'builtins.int*'
-
-[case testGenericMultipleOverrideDict]
-from typing import Any
-
-class JSONDict(dict):
-    pass
-
-class WithChallenge(object):
-    def __getitem__(self, key: str) -> Any: ...
-
-class WithKeyHandle(object):
-    def __getitem__(self, key: str) -> Any: ...
-
-class RegisteredKey(JSONDict, WithChallenge, WithKeyHandle):
-    pass

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1366,3 +1366,18 @@ x: Dict[str, List[int]]
 reveal_type(x['test'][0])
 [out]
 _testNewAnalyzerBasicTypeshed_newsemanal.py:4: error: Revealed type is 'builtins.int*'
+
+[case testGenericMultipleOverrideDict]
+from typing import Any
+
+class JSONDict(dict):
+    pass
+
+class WithChallenge(object):
+    def __getitem__(self, key: str) -> Any: ...
+
+class WithKeyHandle(object):
+    def __getitem__(self, key: str) -> Any: ...
+
+class RegisteredKey(JSONDict, WithChallenge, WithKeyHandle):
+    pass


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5973

The fix is straightforward, I just copy a bit of logic (bind self and map type) from normal override check
to the multiple inheritance one (I also factored it out in a small method to avoid duplication).

Using this opportunity I also added/expanded some docstrings.