### PR TITLE
New semantic analyzer: Fix --disallow-untyped-defs with attrs plugin and forward references

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -39,7 +39,7 @@ Every value stored there must be JSON-serializable.
 
 import types
 
-from abc import abstractmethod
+from abc import abstractmethod, abstractproperty
 from typing import Any, Callable, List, Tuple, Optional, NamedTuple, TypeVar, Dict
 from mypy_extensions import trait
 
@@ -259,6 +259,14 @@ class SemanticAnalyzerPluginInterface:
         """Call this to defer the processing of the current node.
 
         This will request an additional iteration of semantic analysis.
+        Only available with new semantic analyzer.
+        """
+        raise NotImplementedError
+
+    @abstractproperty
+    def final_iteration(self) -> bool:
+        """Is this the final iteration of semantic analysis?
+
         Only available with new semantic analyzer.
         """
         raise NotImplementedError

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -39,7 +39,7 @@ Every value stored there must be JSON-serializable.
 
 import types
 
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 from typing import Any, Callable, List, Tuple, Optional, NamedTuple, TypeVar, Dict
 from mypy_extensions import trait
 
@@ -259,14 +259,6 @@ class SemanticAnalyzerPluginInterface:
         """Call this to defer the processing of the current node.
 
         This will request an additional iteration of semantic analysis.
-        Only available with new semantic analyzer.
-        """
-        raise NotImplementedError
-
-    @abstractproperty
-    def final_iteration(self) -> bool:
-        """Is this the final iteration of semantic analysis?
-
         Only available with new semantic analyzer.
         """
         raise NotImplementedError

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -129,11 +129,11 @@ class Attribute:
             init_type = AnyType(TypeOfAny.from_error)
 
         if init_type is None:
-            if ctx.api.options.new_semantic_analyzer and not ctx.api.final_iteration:
+            if ctx.api.options.new_semantic_analyzer:
                 # Some explicit types may be not yet set because they are not ready.
                 ctx.api.defer()
                 return None
-            elif ctx.api.options.disallow_untyped_defs:
+            if ctx.api.options.disallow_untyped_defs:
                 # This is a compromise.  If you don't have a type here then the
                 # __init__ will be untyped. But since the __init__ is added it's
                 # pointing at the decorator. So instead we also show the error in the

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -129,7 +129,7 @@ class Attribute:
             init_type = AnyType(TypeOfAny.from_error)
 
         if init_type is None:
-            if not ctx.api.final_iteration:
+            if ctx.api.options.new_semantic_analyzer and not ctx.api.final_iteration:
                 # Some explicit types may be not yet set because they are not ready.
                 ctx.api.defer()
                 return None

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -129,11 +129,11 @@ class Attribute:
             init_type = AnyType(TypeOfAny.from_error)
 
         if init_type is None:
-            if ctx.api.options.new_semantic_analyzer:
+            if ctx.api.options.new_semantic_analyzer and not ctx.api.final_iteration:
                 # Some explicit types may be not yet set because they are not ready.
                 ctx.api.defer()
                 return None
-            if ctx.api.options.disallow_untyped_defs:
+            elif ctx.api.options.disallow_untyped_defs:
                 # This is a compromise.  If you don't have a type here then the
                 # __init__ will be untyped. But since the __init__ is added it's
                 # pointing at the decorator. So instead we also show the error in the

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -88,6 +88,14 @@ def add_method(
     """Adds a new method to a class.
     """
     info = ctx.cls.info
+
+    # First remove any previously generated methods with the same name
+    # to avoid clashes and problems in new semantic analyzer.
+    if name in info.names:
+        sym = info.names[name]
+        if sym.plugin_generated and isinstance(sym.node, FuncDef):
+            ctx.cls.defs.body.remove(sym.node)
+
     self_type = self_type or fill_typevars(info)
     function_type = ctx.api.named_type('__builtins__.function')
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3820,6 +3820,11 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         assert not self.options.new_semantic_analyzer
         raise NotImplementedError('This is only available with --new-semantic-analyzer')
 
+    @property
+    def final_iteration(self) -> bool:
+        assert not self.options.new_semantic_analyzer
+        raise NotImplementedError('This is only available with --new-semantic-analyzer')
+
 
 def replace_implicit_first_type(sig: FunctionLike, new: Type) -> FunctionLike:
     if isinstance(sig, CallableType):

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3820,11 +3820,6 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         assert not self.options.new_semantic_analyzer
         raise NotImplementedError('This is only available with --new-semantic-analyzer')
 
-    @property
-    def final_iteration(self) -> bool:
-        assert not self.options.new_semantic_analyzer
-        raise NotImplementedError('This is only available with --new-semantic-analyzer')
-
 
 def replace_implicit_first_type(sig: FunctionLike, new: Type) -> FunctionLike:
     if isinstance(sig, CallableType):

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1023,3 +1023,18 @@ class A(object):
 class B(object):
     x = attr.ib(kw_only=True)  # E: kw_only is not supported in Python 2
 [builtins_py2 fixtures/bool.pyi]
+
+[case testAttrsDisallowUntypedWorks]
+# flags: --new-semantic-analyzer --disallow-untyped-defs
+import attr
+from typing import List
+
+@attr.s
+class B:
+    x: C = attr.ib()
+
+class C(List[C]):
+    pass
+
+reveal_type(B)  # E: Revealed type is 'def (x: __main__.C) -> __main__.B'
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1024,8 +1024,8 @@ class B(object):
     x = attr.ib(kw_only=True)  # E: kw_only is not supported in Python 2
 [builtins_py2 fixtures/bool.pyi]
 
-[case testAttrsDisallowUntypedWorks]
-# flags: --new-semantic-analyzer --disallow-untyped-defs
+[case testAttrsDisallowUntypedWorksForward]
+# flags: --disallow-untyped-defs
 import attr
 from typing import List
 

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1038,3 +1038,14 @@ class C(List[C]):
 
 reveal_type(B)  # E: Revealed type is 'def (x: __main__.C) -> __main__.B'
 [builtins fixtures/list.pyi]
+
+[case testDisallowUntypedWorksForwardBad]
+# flags: --disallow-untyped-defs
+import attr
+
+@attr.s  # E: Function is missing a type annotation for one or more arguments
+class B:
+    x = attr.ib()  # E: Need type annotation for 'x'
+
+reveal_type(B)  # E: Revealed type is 'def (x: Any) -> __main__.B'
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -574,3 +574,15 @@ class C(List[C]):
 
 reveal_type(B)  # E: Revealed type is 'def (x: __main__.C) -> __main__.B'
 [builtins fixtures/list.pyi]
+
+[case testDisallowUntypedWorksForwardBad]
+# flags: --disallow-untyped-defs
+from dataclasses import dataclass
+
+@dataclass
+class B:
+    x: Undefined  # E: Name 'Undefined' is not defined
+    y = undefined()  # E: Name 'undefined' is not defined
+
+reveal_type(B)  # E: Revealed type is 'def (x: Any) -> __main__.B'
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -559,3 +559,18 @@ class Foo:
     bar: Optional[int] = field(default=None)
 [builtins fixtures/list.pyi]
 [out]
+
+[case testDisallowUntypedWorksForward]
+# flags: --disallow-untyped-defs
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class B:
+    x: C
+
+class C(List[C]):
+    pass
+
+reveal_type(B)  # E: Revealed type is 'def (x: __main__.C) -> __main__.B'
+[builtins fixtures/list.pyi]

--- a/test-data/unit/fixtures/list.pyi
+++ b/test-data/unit/fixtures/list.pyi
@@ -5,7 +5,7 @@ from typing import TypeVar, Generic, Iterable, Iterator, Sequence, overload
 T = TypeVar('T')
 
 class object:
-    def __init__(self): pass
+    def __init__(self) -> None: pass
 
 class type: pass
 class ellipsis: pass


### PR DESCRIPTION
The fix essentially mirrors the one for dataclasses. Note I temporary add `final_iteration` to the old analyzer, because plugin files import everything from the old one.

The non-trivial part is removing previously generated functions in plugins to make them re-entrant.