### PR TITLE
Remove "(mypyc-compiled version)" from package description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,6 @@ if USE_MYPYC:
         multi_file=sys.platform == 'win32',
     )
     cmdclass['build_ext'] = MypycifyBuildExt
-    description += " (mypyc-compiled version)"
 else:
     ext_modules = []
 


### PR DESCRIPTION
Since that is now the default for our releases, it is showing up in
the description on pypi, which seems wrong.