### PR TITLE
Bump minimal required typed-ast version from 1.3.1 to 1.3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,9 +173,11 @@ setup(name='mypy',
                                         ]},
       classifiers=classifiers,
       cmdclass=cmdclass,
+      # When changing this, also update test-requirements.txt.
       install_requires = ['typed-ast >= 1.3.5, < 1.4.0',
                           'mypy_extensions >= 0.4.0, < 0.5.0',
                           ],
+      # Same here.
       extras_require = {
           'dmypy': 'psutil >= 5.4.0, < 5.5.0; sys_platform!="win32"',
       },

--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,7 @@ setup(name='mypy',
                                         ]},
       classifiers=classifiers,
       cmdclass=cmdclass,
-      install_requires = ['typed-ast >= 1.3.1, < 1.4.0',
+      install_requires = ['typed-ast >= 1.3.5, < 1.4.0',
                           'mypy_extensions >= 0.4.0, < 0.5.0',
                           ],
       extras_require = {

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,12 +3,12 @@ flake8
 flake8-bugbear; python_version >= '3.5'
 flake8-pyi; python_version >= '3.6'
 lxml==4.2.4
-mypy_extensions==0.4.0
-psutil==5.4.0
+mypy_extensions>=0.4.0,<0.5.0
+psutil>=5.4.0,<5.5.0; sys_platform!='win32'
 pytest>=4.4
 pytest-xdist>=1.22
 pytest-cov>=2.4.0
-typed-ast>=1.3.0,<1.4.0
+typed-ast>=1.3.5,<1.4.0
 typing>=3.5.2; python_version < '3.5'
 py>=1.5.2
 virtualenv


### PR DESCRIPTION
- 1.3.2 fixed two out of bounds reads
- 1.3.3 was a dud
- 1.3.4 made it compile under newer Python 3.8 alphas
- 1.3.5 fixed a crash with unicode names on Python 3.4/3.5