### PR TITLE
Don't crash when partial types are used in inherited attribute

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1803,7 +1803,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             self.check_getattr_method(signature, lvalue, name)
 
             # Defer PartialType's super type checking.
-            if isinstance(lvalue, RefExpr) and not isinstance(lvalue_type, PartialType):
+            if (isinstance(lvalue, RefExpr) and
+                    not (isinstance(lvalue_type, PartialType) and lvalue_type.type is None)):
                 if self.check_compatibility_all_supers(lvalue, lvalue_type, rvalue):
                     # We hit an error on this line; don't check for any others
                     return
@@ -1833,7 +1834,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         # Try to infer a partial type. No need to check the return value, as
                         # an error will be reported elsewhere.
                         self.infer_partial_type(lvalue_type.var, lvalue, rvalue_type)
-                    # Handle PartialType's super type checking here, after it's resolved.
+                    # Handle None PartialType's super type checking here, after it's resolved.
                     if (isinstance(lvalue, RefExpr) and
                             self.check_compatibility_all_supers(lvalue, lvalue_type, rvalue)):
                         # We hit an error on this line; don't check for any others

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2689,3 +2689,13 @@ reveal_type(x)  # E: Revealed type is 'builtins.list[Any]'
 reveal_type(y)  # E: Revealed type is 'builtins.dict[Any, Any]'
 
 [builtins fixtures/dict.pyi]
+
+[case testInheritedAttributeNoStrictOptional]
+# flags: --no-strict-optional
+class A:
+    x: str
+
+class B(A):
+    x = None
+    x = ''
+    reveal_type(x)  # E: Revealed type is 'builtins.str'

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2699,3 +2699,21 @@ class B(A):
     x = None
     x = ''
     reveal_type(x)  # E: Revealed type is 'builtins.str'
+
+[case testIncompatibleInheritedAttributeNoStrictOptional]
+# flags: --no-strict-optional
+class A:
+    x: str
+
+class B(A):
+    x = None
+    x = 2  # E: Incompatible types in assignment (expression has type "int", base class "A" defined the type as "str")
+
+[case testInheritedAttributeStrictOptional]
+# flags: --strict-optional
+class A:
+    x: str
+
+class B(A):
+    x = None  # E: Incompatible types in assignment (expression has type "None", base class "A" defined the type as "str")
+    x = ''


### PR DESCRIPTION
Fix #4552.