### PR TITLE
Correct --python-executable documentation

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -132,7 +132,6 @@ imports.
     the Python executable running mypy.
 
     See :ref:`installed-packages` for more on making PEP 561 compliant packages.
-    This flag will attempt to set ``--python-version`` if not already set.
 
 ``--no-site-packages``
     This flag will disable searching for `PEP 561`_ compliant packages. This


### PR DESCRIPTION
Remove mention of --python-version being set based on
--python-executable. This functionality was removed in
d2a9f9d9e8111877621eb2d2a24104f9787ae553 and --python-executable is now
only used to find PEP 561 packages. This is a documentation fix for #6205.