### PR TITLE
Output the parsed command line and file options

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -212,6 +212,7 @@ def _build(sources: List[BuildSource],
                            errors=errors,
                            flush_errors=flush_errors,
                            fscache=fscache)
+    manager.trace(repr(options))
 
     reset_global_state()
     try:


### PR DESCRIPTION
This is generally useful when debugging interactions between command line
flags and options in mypy.ini.

Fixes #6205.