### PR TITLE
Don't mark special-form AnyTypes during reports

### DIFF
--- a/mypy/report.py
+++ b/mypy/report.py
@@ -235,6 +235,7 @@ class AnyExpressionsReporter(AbstractReporter):
             coverage = (float(num_total - num_any) / float(num_total)) * 100
             coverage_str = '{:.2f}%'.format(coverage)
             rows.append([filename, str(num_any), str(num_total), coverage_str])
+        rows.sort(key=lambda x: x[0])
         total_row = ["Total", str(total_any), str(total_expr), '{:.2f}%'.format(total_coverage)]
         self._write_out_report('any-exprs.txt', column_names, rows, total_row)
 
@@ -249,6 +250,7 @@ class AnyExpressionsReporter(AbstractReporter):
         rows = []  # type: List[List[str]]
         for filename, counter in self.any_types_counter.items():
             rows.append([filename] + [str(counter[typ]) for typ in type_of_any_name_map])
+        rows.sort(key=lambda x: x[0])
         total_row = [total_row_name] + [str(total_counter[typ])
                                         for typ in type_of_any_name_map]
         self._write_out_report('types-of-anys.txt', column_names, rows, total_row)

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -380,3 +380,40 @@ empty = False
 [outfile report/linecount.txt]
       1       1      0      0 total
       1       1      0      0 a
+
+[case testAnyExprReportIgnoresSpecialForms]
+# cmd: mypy --any-exprs-report report i.py j.py k.py
+
+[file i.py]
+async def some_function() -> None:
+    pass
+
+[file j.py]
+from typing import Any
+
+async def some_function() -> Any:
+    pass
+
+[file k.py]
+from typing import NamedTuple
+
+def a() -> None:
+    _FuzzyMatch(0, 0)
+
+_FuzzyMatch = NamedTuple('_FuzzyMatch', [
+    ('match_length', int),
+    ('start_pos', int),
+])
+
+def b() -> None:
+    _FuzzyMatch(0, 0)
+
+[file report/any-exprs.txt]
+[outfile report/types-of-anys.txt]
+ Name   Unannotated   Explicit   Unimported   Omitted Generics   Error   Special Form   Implementation Artifact
+-----------------------------------------------------------------------------------------------------------------
+    k             0          0            0                  0       0              0                         0
+    j             0          1            0                  0       0              0                         0
+    i             0          0            0                  0       0              0                         0
+-----------------------------------------------------------------------------------------------------------------
+Total             0          1            0                  0       0              0                         0

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -382,7 +382,7 @@ empty = False
       1       1      0      0 a
 
 [case testAnyExprReportIgnoresSpecialForms]
-# cmd: mypy --any-exprs-report report i.py j.py k.py
+# cmd: mypy --any-exprs-report report i.py j.py k.py l.py
 
 [file i.py]
 async def some_function() -> None:
@@ -408,12 +408,17 @@ _FuzzyMatch = NamedTuple('_FuzzyMatch', [
 def b() -> None:
     _FuzzyMatch(0, 0)
 
+[file l.py]
+async def some_function(x) -> None:
+    pass
+
 [file report/any-exprs.txt]
 [outfile report/types-of-anys.txt]
  Name   Unannotated   Explicit   Unimported   Omitted Generics   Error   Special Form   Implementation Artifact
 -----------------------------------------------------------------------------------------------------------------
+    l             1          0            0                  0       0              0                         0
     k             0          0            0                  0       0              0                         0
     j             0          1            0                  0       0              0                         0
     i             0          0            0                  0       0              0                         0
 -----------------------------------------------------------------------------------------------------------------
-Total             0          1            0                  0       0              0                         0
+Total             1          1            0                  0       0              0                         0

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -416,9 +416,9 @@ async def some_function(x) -> None:
 [outfile report/types-of-anys.txt]
  Name   Unannotated   Explicit   Unimported   Omitted Generics   Error   Special Form   Implementation Artifact
 -----------------------------------------------------------------------------------------------------------------
-    l             1          0            0                  0       0              0                         0
-    k             0          0            0                  0       0              0                         0
-    j             0          1            0                  0       0              0                         0
     i             0          0            0                  0       0              0                         0
+    j             0          1            0                  0       0              0                         0
+    k             0          0            0                  0       0              0                         0
+    l             1          0            0                  0       0              0                         0
 -----------------------------------------------------------------------------------------------------------------
 Total             1          1            0                  0       0              0                         0


### PR DESCRIPTION
AnyTypes of type special-form or deriving from a special-form
should not be reported as they are a concept internal to mypy

Fixes #6765 