### PR TITLE
Show closest candidates for misspellings: from..import case

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1578,9 +1578,8 @@ def best_matches(current: str, options: Iterable[str]) -> List[str]:
                   reverse=True, key=lambda v: (ratios[v], v))
 
 
-def pretty_or(args: List[str], use_single_quotations: bool = False) -> str:
-    quotations = "'" if use_single_quotations else '"'
-    quoted = ["{0}{1}{0}".format(quotations, a) for a in args]
+def pretty_or(args: List[str]) -> str:
+    quoted = ['"' + a + '"' for a in args]
     if len(quoted) == 1:
         return quoted[0]
     if len(quoted) == 2:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1578,8 +1578,9 @@ def best_matches(current: str, options: Iterable[str]) -> List[str]:
                   reverse=True, key=lambda v: (ratios[v], v))
 
 
-def pretty_or(args: List[str]) -> str:
-    quoted = ['"' + a + '"' for a in args]
+def pretty_or(args: List[str], use_single_quotations: bool = False) -> str:
+    quotations = "'" if use_single_quotations else '"'
+    quoted = ["{0}{1}{0}".format(quotations, a) for a in args]
     if len(quoted) == 1:
         return quoted[0]
     if len(quoted) == 2:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1636,11 +1636,12 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             message += " {}".format(extra)
         # Suggest alternatives, if any match is found.
         module = self.modules.get(import_id)
-        alternatives = set(module.names.keys()).difference({source_id})
-        matches = best_matches(source_id, alternatives)[:3]
-        if matches:
-            suggestion = "; maybe {}?".format(pretty_or(matches))
-            message += "{}".format(suggestion)
+        if module:
+            alternatives = set(module.names.keys()).difference({source_id})
+            matches = best_matches(source_id, alternatives)[:3]
+            if matches:
+                suggestion = "; maybe {}?".format(pretty_or(matches))
+                message += "{}".format(suggestion)
         self.fail(message, context)
         self.add_unknown_imported_symbol(imported_id, context)
 

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1634,7 +1634,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         extra = self.undefined_name_extra_info('{}.{}'.format(import_id, source_id))
         if extra:
             message += " {}".format(extra)
-        # suggest alternatives, if any match is found
+        # Suggest alternatives, if any match is found.
         module = self.modules.get(import_id)
         alternatives = set(module.names.keys()).difference({source_id})
         matches = best_matches(source_id, alternatives)[:3]

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -78,7 +78,7 @@ from mypy.tvar_scope import TypeVarScope
 from mypy.typevars import fill_typevars
 from mypy.visitor import NodeVisitor
 from mypy.errors import Errors, report_internal_error
-from mypy.messages import MessageBuilder
+from mypy.messages import best_matches, MessageBuilder, pretty_or
 from mypy import message_registry
 from mypy.types import (
     FunctionLike, UnboundType, TypeVarDef, TupleType, UnionType, StarType, function_type,
@@ -1634,6 +1634,13 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         extra = self.undefined_name_extra_info('{}.{}'.format(import_id, source_id))
         if extra:
             message += " {}".format(extra)
+        # suggest alternatives, if any match is found
+        module = self.modules.get(import_id)
+        alternatives = set(module.names.keys()).difference({source_id})
+        matches = best_matches(source_id, alternatives)[:3]
+        if matches:
+            suggestion = "; maybe {}?".format(pretty_or(matches))
+            message += "{}".format(suggestion)
         self.fail(message, context)
         self.add_unknown_imported_symbol(imported_id, context)
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1558,7 +1558,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 self.add_symbol(imported_id, symbol, imp)
             elif module and not missing:
                 # Missing attribute.
-                message = "Module '{}' has no attribute '{}'".format(import_id, id)
+                message = "Module \"{}\" has no attribute \"{}\"".format(import_id, id)
                 extra = self.undefined_name_extra_info('{}.{}'.format(import_id, id))
                 if extra:
                     message += " {}".format(extra)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -62,7 +62,7 @@ from mypy.tvar_scope import TypeVarScope
 from mypy.typevars import fill_typevars
 from mypy.visitor import NodeVisitor
 from mypy.errors import Errors, report_internal_error
-from mypy.messages import MessageBuilder
+from mypy.messages import best_matches, MessageBuilder, pretty_or
 from mypy import message_registry
 from mypy.types import (
     FunctionLike, UnboundType, TypeVarDef, TupleType, UnionType, StarType, function_type,
@@ -1562,6 +1562,12 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 extra = self.undefined_name_extra_info('{}.{}'.format(import_id, id))
                 if extra:
                     message += " {}".format(extra)
+                # suggest alternatives, if any match is found
+                alternatives = module.names.keys()
+                matches = best_matches(id, alternatives)[:3]
+                if matches:
+                    suggestion = "; maybe {}?".format(pretty_or(matches))
+                    message += "{}".format(suggestion)
                 self.fail(message, imp)
                 self.add_unknown_symbol(as_id or id, imp, is_import=True)
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1558,7 +1558,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 self.add_symbol(imported_id, symbol, imp)
             elif module and not missing:
                 # Missing attribute.
-                message = "Module \"{}\" has no attribute \"{}\"".format(import_id, id)
+                message = "Module '{}' has no attribute '{}'".format(import_id, id)
                 extra = self.undefined_name_extra_info('{}.{}'.format(import_id, id))
                 if extra:
                     message += " {}".format(extra)
@@ -1566,7 +1566,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 alternatives = module.names.keys()
                 matches = best_matches(id, alternatives)[:3]
                 if matches:
-                    suggestion = "; maybe {}?".format(pretty_or(matches))
+                    suggestion = "; maybe {}?".format(pretty_or(matches, True))
                     message += "{}".format(suggestion)
                 self.fail(message, imp)
                 self.add_unknown_symbol(as_id or id, imp, is_import=True)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1562,7 +1562,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 extra = self.undefined_name_extra_info('{}.{}'.format(import_id, id))
                 if extra:
                     message += " {}".format(extra)
-                # suggest alternatives, if any match is found
+                # Suggest alternatives, if any match is found.
                 alternatives = set(module.names.keys()).difference({id})
                 matches = best_matches(id, alternatives)[:3]
                 if matches:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1563,10 +1563,10 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
                 if extra:
                     message += " {}".format(extra)
                 # suggest alternatives, if any match is found
-                alternatives = module.names.keys()
+                alternatives = set(module.names.keys()).difference({id})
                 matches = best_matches(id, alternatives)[:3]
                 if matches:
-                    suggestion = "; maybe {}?".format(pretty_or(matches, True))
+                    suggestion = "; maybe {}?".format(pretty_or(matches))
                     message += "{}".format(suggestion)
                 self.fail(message, imp)
                 self.add_unknown_symbol(as_id or id, imp, is_import=True)

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -67,9 +67,9 @@ tmp/a.py:4: error: "B" not callable
 [case testNewAnalyzerTypeAnnotationCycle3]
 import b
 [file a.py]
-from b import bad # E: Module 'b' has no attribute 'bad'
+from b import bad # E: Module 'b' has no attribute 'bad'; maybe "bad2"?
 [file b.py]
-from a import bad2 # E: Module 'a' has no attribute 'bad2'
+from a import bad2 # E: Module 'a' has no attribute 'bad2'; maybe "bad"?
 
 [case testNewAnalyzerTypeAnnotationCycle4]
 import b

--- a/test-data/unit/semanal-modules.test
+++ b/test-data/unit/semanal-modules.test
@@ -781,6 +781,47 @@ from m.x import nonexistent
 [out]
 tmp/m/x.py:1: error: Module 'm.x' has no attribute 'nonexistent'
 
+[case testImportMisspellingSingleCandidate]
+import f
+[file m/__init__.py]
+[file m/x.py]
+def some_function():
+    pass
+[file f.py]
+from m.x import somefunction
+[out]
+tmp/f.py:1: error: Module 'm.x' has no attribute 'somefunction'; maybe "some_function"?
+
+[case testImportMisspellingMultipleCandidates]
+import f
+[file m/__init__.py]
+[file m/x.py]
+def some_function():
+    pass
+def somef_unction():
+    pass
+[file f.py]
+from m.x import somefunction
+[out]
+tmp/f.py:1: error: Module 'm.x' has no attribute 'somefunction'; maybe "somef_unction" or "some_function"?
+
+[case testImportMisspellingMultipleCandidatesTruncated]
+import f
+[file m/__init__.py]
+[file m/x.py]
+def some_function():
+    pass
+def somef_unction():
+    pass
+def somefu_nction():
+    pass
+def somefun_ction():
+    pass
+[file f.py]
+from m.x import somefunction
+[out]
+tmp/f.py:1: error: Module 'm.x' has no attribute 'somefunction'; maybe "somefun_ction", "somefu_nction", or "somef_unction"?
+
 [case testFromImportAsInStub]
 from m import *
 x


### PR DESCRIPTION
This fixes the following case outlined in #824:

```
from subprocess import popen  # Module 'subprocess' has no attribute 'popen'
```

is now

```
from subprocess import popen  # Module 'subprocess' has no attribute 'popen'; maybe "Popen"?
```
