### PR TITLE
Clean up last traces of 'final_value' field

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1804,7 +1804,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if self.is_literal_context():
             return LiteralType(value=value, fallback=typ)
         else:
-            return typ.copy_modified(final_value=LiteralType(
+            return typ.copy_modified(last_known_value=LiteralType(
                 value=value,
                 fallback=typ,
                 line=typ.line,

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -131,5 +131,5 @@ class LastKnownValueEraser(TypeTranslator):
 
     def visit_instance(self, t: Instance) -> Type:
         if t.last_known_value:
-            return t.copy_modified(final_value=None)
+            return t.copy_modified(last_known_value=None)
         return t

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2223,7 +2223,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             assert value is not None
             typ = self.named_type_or_none(type_name)
             if typ and is_final:
-                return typ.copy_modified(final_value=LiteralType(
+                return typ.copy_modified(last_known_value=LiteralType(
                     value=value,
                     fallback=typ,
                     line=typ.line,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1978,7 +1978,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
             assert value is not None
             typ = self.named_type_or_none(type_name)
             if typ and is_final:
-                return typ.copy_modified(final_value=LiteralType(
+                return typ.copy_modified(last_known_value=LiteralType(
                     value=value,
                     fallback=typ,
                     line=typ.line,

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -163,17 +163,17 @@ class TypeTranslator(TypeVisitor[Type]):
         return t
 
     def visit_instance(self, t: Instance) -> Type:
-        final_value = None  # type: Optional[LiteralType]
+        last_known_value = None  # type: Optional[LiteralType]
         if t.last_known_value is not None:
-            raw_final_value = t.last_known_value.accept(self)
-            assert isinstance(raw_final_value, LiteralType)
-            final_value = raw_final_value
+            raw_last_known_value = t.last_known_value.accept(self)
+            assert isinstance(raw_last_known_value, LiteralType)
+            last_known_value = raw_last_known_value
         return Instance(
             typ=t.type,
             args=self.translate_types(t.args),
             line=t.line,
             column=t.column,
-            last_known_value=final_value,
+            last_known_value=last_known_value,
         )
 
     def visit_type_var(self, t: TypeVarType) -> Type:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -692,14 +692,14 @@ class Instance(Type):
 
     def copy_modified(self, *,
                       args: Bogus[List[Type]] = _dummy,
-                      final_value: Bogus[Optional['LiteralType']] = _dummy) -> 'Instance':
+                      last_known_value: Bogus[Optional['LiteralType']] = _dummy) -> 'Instance':
         return Instance(
             self.type,
             args if args is not _dummy else self.args,
             self.line,
             self.column,
             self.erased,
-            final_value if final_value is not _dummy else self.last_known_value,
+            last_known_value if last_known_value is not _dummy else self.last_known_value,
         )
 
     def has_readable_member(self, name: str) -> bool:


### PR DESCRIPTION
This pull request is a follow-up to https://github.com/python/mypy/pull/6763: it renames some parameter names and variables that got missed earlier.

One interesting side-note: it seems like 'Var' notes also contain a `final_value` field that does almost the same thing as this `last_known_value` field, but is ultimately unrelated: it was introduced back in https://github.com/python/mypy/pull/5522. I decided to leave this field alone.

(I discovered this while updating mypyc and discovered (to my surprise) that nothing broke.)