### PR TITLE
Require explicit annotations for List[object] and Dict[*, object]

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -804,7 +804,7 @@ def write_deps_cache(rdeps: Dict[str, Dict[str, Set[str]]],
             hash = st.meta.hash
         meta_snapshot[id] = hash
 
-    meta = {'snapshot': meta_snapshot, 'deps_meta': fg_deps_meta}
+    meta = {'snapshot': meta_snapshot, 'deps_meta': fg_deps_meta}  # type: Dict[str, object]
 
     if not metastore.write(DEPS_META_FILE, json.dumps(meta)):
         manager.log("Error writing fine-grained deps meta JSON file {}".format(DEPS_META_FILE))
@@ -1225,7 +1225,7 @@ def validate_meta(meta: Optional[CacheMeta], id: str, path: Optional[str],
                 'interface_hash': meta.interface_hash,
                 'version_id': manager.version_id,
                 'ignore_all': meta.ignore_all,
-            }
+            }  # type: Dict[str, object]
             if manager.options.debug_cache:
                 meta_str = json.dumps(meta_dict, indent=2, sort_keys=True)
             else:
@@ -1365,7 +1365,7 @@ def write_cache(id: str, path: str, tree: MypyFile,
             'interface_hash': interface_hash,
             'version_id': manager.version_id,
             'ignore_all': ignore_all,
-            }
+            }  # type: Dict[str, object]
 
     # Write meta cache file
     meta_str = json_dumps(meta, manager.options.debug_cache)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1935,8 +1935,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         return
 
                     if self.iterable_has_object_type(rvalue.items):
-                        # A list that contains an an instance must necessarily be of type List[object],
-                        # since there is no more specific type that can be assigned.
+                        # A list that contains an an instance must
+                        # necessarily be of type List[object], since
+                        # there is no more specific type that can be
+                        # assigned.
                         return
 
                     self.msg.need_annotation_for_var(var, rvalue)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -913,7 +913,7 @@ config_types = {
     'always_true': lambda s: [p.strip() for p in s.split(',')],
     'always_false': lambda s: [p.strip() for p in s.split(',')],
     'package_root': lambda s: [p.strip() for p in s.split(',')],
-}  # type: Final
+}  # type: Final[Dict[str, object]]
 
 
 def parse_config_file(options: Options, filename: Optional[str]) -> None:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1035,12 +1035,6 @@ class MessageBuilder:
                       forward_method, self.format(forward_class)),
                   context)
 
-    def forbidden_inference_of_object(self, expr: Type, context: Context) -> None:
-        self.fail('Variable inferred to {}, which is forbidden.'.format(
-            self.format(expr)),
-            context
-        )
-
     def forward_operator_not_callable(
             self, forward_method: str, context: Context) -> None:
         self.fail('Forward operator "{}" is not callable'.format(

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1035,6 +1035,12 @@ class MessageBuilder:
                       forward_method, self.format(forward_class)),
                   context)
 
+    def forbidden_inference_of_object(self, expr: Type, context: Context) -> None:
+        self.fail('Variable inferred to {}, which is forbidden.'.format(
+            self.format(expr)),
+            context
+        )
+
     def forward_operator_not_callable(
             self, forward_method: str, context: Context) -> None:
         self.fail('Forward operator "{}" is not callable'.format(

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2498,7 +2498,7 @@ class TypeInfo(SymbolNode):
             base,
             mro,
             ('Names', names),
-        ]
+        ]  # type: List[object]
         if self.declared_metaclass:
             items.append('DeclaredMetaclass({})'.format(type_str(self.declared_metaclass)))
         if self.metaclass_type:

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -153,7 +153,7 @@ class StrConv(NodeVisitor[str]):
         return self.dump(a, o)
 
     def visit_class_def(self, o: 'mypy.nodes.ClassDef') -> str:
-        a = [o.name, o.defs.body]
+        a = [o.name, o.defs.body]  # type: List[object]
         # Display base types unless they are implicitly just builtins.object
         # (in this case base_type_exprs is empty).
         if o.base_type_exprs:

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -455,7 +455,7 @@ class SuggestionEngine:
             'path': path,
             'func_name': func_name,
             'samples': 0
-        }
+        }  # type: Dict[str, object]
         return json.dumps([obj], sort_keys=True)
 
     def format_callable(self,


### PR DESCRIPTION
This currently breaks mypy typechecking. Including instances like 

```
def get_reachable_graph(root: object) -> Tuple[Dict[int, object],
                                               Dict[int, Tuple[int, object]]]:
    parents = {}
    seen = {id(root): root}
```

Should `seen` require explicit annotation, or presumably mypy should be smart enough to figure this out. 

(#3816)