### PR TITLE
Make typeshed submodules instructions more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ you need to pull in the typeshed repo as follows:
     $ git submodule init
     $ git submodule update
 
-Either way you should now have a subdirectory `typeshed` containing a
+Either way you should now have a subdirectory `typeshed` inside your mypy repo, your folders tree should be like `mypy/mypy/typeshed`, containing a
 clone of the typeshed repo (`https://github.com/python/typeshed`).
 
 From the mypy directory, use pip to install mypy:

--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ you need to pull in the typeshed repo as follows:
     $ git submodule init
     $ git submodule update
 
-Either way you should now have a subdirectory `typeshed` inside your mypy repo, your folders tree should be like `mypy/mypy/typeshed`, containing a
+Either way you should now have a subdirectory `typeshed` inside your mypy repo,
+your folders tree should be like `mypy/mypy/typeshed`, containing a
 clone of the typeshed repo (`https://github.com/python/typeshed`).
 
 From the mypy directory, use pip to install mypy:


### PR DESCRIPTION
This PR is not related with any existent issue.

After I clone the project I was not able to find the folder for typeshed because I was looking for it at the mypy repo folder but actually there is a second folder also called mypy where the typeshed folder will be inside, the right path is 'mypy/mypy/typeshed'.

My suggestion is make it explicit for remove this barrier that affects everyone that try to setup their project.