### PR TITLE
Sync typeshed

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -717,7 +717,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
             typename = self.print_annotation(annotation)
             if (isinstance(annotation, UnboundType) and not annotation.args and
                     annotation.name == 'Final' and
-                    self.import_tracker.module_for.get('Final') in ('typing, typing_extensions')):
+                    self.import_tracker.module_for.get('Final') in ('typing', 'typing_extensions')):
                 # Final without type argument is invalid in stubs.
                 final_arg = self.get_str_type_of_node(rvalue)
                 typename += '[{}]'.format(final_arg)

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -717,7 +717,8 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
             typename = self.print_annotation(annotation)
             if (isinstance(annotation, UnboundType) and not annotation.args and
                     annotation.name == 'Final' and
-                    self.import_tracker.module_for.get('Final') in ('typing', 'typing_extensions')):
+                    self.import_tracker.module_for.get('Final') in ('typing',
+                                                                    'typing_extensions')):
                 # Final without type argument is invalid in stubs.
                 final_arg = self.get_str_type_of_node(rvalue)
                 typename += '[{}]'.format(final_arg)

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -1371,6 +1371,14 @@ y: Final[Any]
 z: Final[object]
 t: Final[Any]
 
+[case testFinalInvalid_semanal]
+Final = 'boom'
+
+x: Final = 1
+[out]
+Final: str
+x: Final
+
 [case testNoFunctionNested_semanal]
 import a
 from typing import Dict, Any


### PR DESCRIPTION
Syncing just because we didn't do this for a while (plus to test the recent `str.__contains__()` signature updates).