### PR TITLE
Generate non-blocking error for foo few/many arguments in type comment

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -700,7 +700,6 @@ class BuildManager(BuildManagerBase):
 
         Raise CompileError if there is a parse error.
         """
-        num_errs = self.errors.num_messages()
         t0 = time.time()
         tree = parse(source, path, id, self.errors, options=self.options)
         tree._fullname = id
@@ -709,7 +708,7 @@ class BuildManager(BuildManagerBase):
                        stubs_parsed=int(tree.is_stub),
                        parse_time=time.time() - t0)
 
-        if self.errors.num_messages() != num_errs:
+        if self.errors.is_blockers():
             self.log("Bailing due to parse errors")
             self.errors.raise_error()
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -266,8 +266,9 @@ class ASTConverter:
     def note(self, msg: str, line: int, column: int) -> None:
         self.errors.report(line, column, msg, severity='note')
 
-    def fail(self, msg: str, line: int, column: int) -> None:
-        self.errors.report(line, column, msg, blocker=True)
+    def fail(self, msg: str, line: int, column: int, blocker: bool = True) -> None:
+        if blocker or not self.options.ignore_errors:
+            self.errors.report(line, column, msg, blocker=blocker)
 
     def visit(self, node: Optional[AST]) -> Any:
         if node is None:
@@ -494,9 +495,9 @@ class ASTConverter:
                 self.fail("Ellipses cannot accompany other argument types "
                           "in function type signature.", lineno, 0)
             elif len(arg_types) > len(arg_kinds):
-                self.fail('Type signature has too many arguments', lineno, 0)
+                self.fail('Type signature has too many arguments', lineno, 0, blocker=False)
             elif len(arg_types) < len(arg_kinds):
-                self.fail('Type signature has too few arguments', lineno, 0)
+                self.fail('Type signature has too few arguments', lineno, 0, blocker=False)
             else:
                 func_type = CallableType([a if a is not None else
                                           AnyType(TypeOfAny.unannotated) for a in arg_types],

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -165,8 +165,9 @@ class ASTConverter:
 
         self.extra_type_ignores = []  # type: List[int]
 
-    def fail(self, msg: str, line: int, column: int) -> None:
-        self.errors.report(line, column, msg, blocker=True)
+    def fail(self, msg: str, line: int, column: int, blocker: bool = True) -> None:
+        if blocker or not self.options.ignore_errors:
+            self.errors.report(line, column, msg, blocker=blocker)
 
     def visit(self, node: Optional[AST]) -> Any:  # same as in typed_ast stub
         if node is None:
@@ -376,9 +377,9 @@ class ASTConverter:
                 self.fail("Ellipses cannot accompany other argument types "
                           "in function type signature.", lineno, 0)
             elif len(arg_types) > len(arg_kinds):
-                self.fail('Type signature has too many arguments', lineno, 0)
+                self.fail('Type signature has too many arguments', lineno, 0, blocker=False)
             elif len(arg_types) < len(arg_kinds):
-                self.fail('Type signature has too few arguments', lineno, 0)
+                self.fail('Type signature has too few arguments', lineno, 0, blocker=False)
             else:
                 any_type = AnyType(TypeOfAny.unannotated)
                 func_type = CallableType([a if a is not None else any_type for a in arg_types],

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -85,7 +85,7 @@ from mypy.types import (
 from mypy.visitor import NodeVisitor
 from mypy.find_sources import create_source_list, InvalidSourceList
 from mypy.build import build
-from mypy.errors import CompileError
+from mypy.errors import CompileError, Errors
 from mypy.traverser import has_return_statement
 
 MYPY = False
@@ -973,12 +973,12 @@ def parse_source_file(mod: StubSource, mypy_options: MypyOptions) -> None:
     with open(mod.path, 'rb') as f:
         data = f.read()
     source = mypy.util.decode_python_encoding(data, mypy_options.python_version)
-    try:
-        mod.ast = mypy.parse.parse(source, fnam=mod.path, module=mod.module,
-                                   errors=None, options=mypy_options)
-    except mypy.errors.CompileError as e:
+    errors = Errors()
+    mod.ast = mypy.parse.parse(source, fnam=mod.path, module=mod.module,
+                               errors=errors, options=mypy_options)
+    if errors.is_blockers():
         # Syntax error!
-        for m in e.messages:
+        for m in errors.new_messages():
             sys.stderr.write('%s\n' % m)
         sys.exit(1)
 

--- a/mypy/test/testparse.py
+++ b/mypy/test/testparse.py
@@ -65,7 +65,8 @@ def test_parse_error(testcase: DataDrivenTestCase) -> None:
               Options())
         raise AssertionError('No errors reported')
     except CompileError as e:
-        assert e.module_with_blocker == '__main__'
+        if e.module_with_blocker is not None:
+            assert e.module_with_blocker == '__main__'
         # Verify that there was a compile error and that the error messages
         # are equivalent.
         assert_string_arrays_equal(

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -244,19 +244,40 @@ def f(a,        # type: A
 [out]
 
 [case testFasterParseTooManyArgumentsAnnotation]
-
 def f():  # E: Type signature has too many arguments
     # type: (int) -> None
     pass
 
-[case testFasterParseTooFewArgumentsAnnotation]
+f()
+f(1) # E: Too many arguments for "f"
 
-def f(x):  # E: Type signature has too few arguments
-    # type: () -> None
+[case testFasterParseTooFewArgumentsAnnotation]
+def f(x, y):  # E: Type signature has too few arguments
+    # type: (int) -> None
+    x()
+    y()
+
+f(1, 2)
+f(1) # E: Too few arguments for "f"
+
+[case testFasterParseTooManyArgumentsAnnotation_python2]
+def f():  # E: Type signature has too many arguments
+    # type: (int) -> None
     pass
 
-[case testFasterParseTypeCommentError_python2]
+f()
+f(1) # E: Too many arguments for "f"
 
+[case testFasterParseTooFewArgumentsAnnotation_python2]
+def f(x, y):  # E: Type signature has too few arguments
+    # type: (int) -> None
+    x()
+    y()
+
+f(1, 2)
+f(1) # E: Too few arguments for "f"
+
+[case testFasterParseTypeCommentError_python2]
 from typing import Tuple
 def f(a):
     # type: (Tuple(int, int)) -> int

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -283,19 +283,18 @@ def f(a):
     # type: (Tuple(int, int)) -> int
     pass
 [out]
-main:3: error: Invalid type comment or annotation
-main:3: note: Suggestion: use Tuple[...] instead of Tuple(...)
+main:2: error: Invalid type comment or annotation
+main:2: note: Suggestion: use Tuple[...] instead of Tuple(...)
 
 [case testFasterParseTypeErrorList_python2]
-
 from typing import List
 def f(a):
     # type: (List(int)) -> int
     pass
 [builtins_py2 fixtures/floatdict_python2.pyi]
 [out]
-main:3: error: Invalid type comment or annotation
-main:3: note: Suggestion: use List[...] instead of List(...)
+main:2: error: Invalid type comment or annotation
+main:2: note: Suggestion: use List[...] instead of List(...)
 
 [case testFasterParseTypeErrorCustom]
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1101,7 +1101,6 @@ def foo(x):
     return
 [out]
 a.py:1: error: Type signature has too many arguments
-== Return code: 2
 
 [case testModulesAndPackages]
 # cmd: mypy --package p.a --package p.b --module c

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -1443,3 +1443,13 @@ from typing import Any
 class C(Base, metaclass=abc.ABCMeta):
     @abstractmethod
     def other(self) -> Any: ...
+
+[case testInvalidNumberOfArgsInAnnotation]
+def f(x):
+    # type: () -> int
+    return ''
+
+[out]
+from typing import Any
+
+def f(x: Any): ...


### PR DESCRIPTION
Stubgen doesn't produce any output if there is a blocking error.