### PR TITLE
Fix running stubgen tests sequentially

### DIFF
--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -256,6 +256,15 @@ class StubgenPythonSuite(DataSuite):
     files = ['stubgen.test']
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
+        old_sys_path = sys.path[:]
+        if not ('' in sys.path or '.' in sys.path):
+            sys.path.insert(0, '')
+        try:
+            self.run_case_inner(testcase)
+        finally:
+            sys.path = old_sys_path
+
+    def run_case_inner(self, testcase: DataDrivenTestCase) -> None:
         extra = []
         mods = []
         source = '\n'.join(testcase.input)


### PR DESCRIPTION
This fixes some import tests by explicitly setting up `sys.path`.
Apparently `sys.path` is different when pytest runs test in parallel.

Fixes #6814.