### PR TITLE
A more robust fix for sequential stubgen tests

### DIFF
--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -6,9 +6,11 @@ import tempfile
 import re
 from types import ModuleType
 
-from typing import List, Tuple
+from typing import Any, List, Tuple, Optional
 
-from mypy.test.helpers import Suite, assert_equal, assert_string_arrays_equal
+from mypy.test.helpers import (
+    Suite, assert_equal, assert_string_arrays_equal, local_sys_path_set
+)
 from mypy.test.data import DataSuite, DataDrivenTestCase
 from mypy.errors import CompileError
 from mypy.stubgen import (
@@ -68,6 +70,10 @@ class StubgenCmdLineSuite(Suite):
         file = os.path.join(*path)
         with open(file, 'w') as f:
             f.write(content)
+
+    def run(self, result: Optional[Any] = None) -> Optional[Any]:
+        with local_sys_path_set():
+            return super().run(result)
 
 
 class StubgenCliParseSuite(Suite):
@@ -256,13 +262,8 @@ class StubgenPythonSuite(DataSuite):
     files = ['stubgen.test']
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
-        old_sys_path = sys.path[:]
-        if not ('' in sys.path or '.' in sys.path):
-            sys.path.insert(0, '')
-        try:
+        with local_sys_path_set():
             self.run_case_inner(testcase)
-        finally:
-            sys.path = old_sys_path
 
     def run_case_inner(self, testcase: DataDrivenTestCase) -> None:
         extra = []


### PR DESCRIPTION
Follow up for https://github.com/python/mypy/issues/6814
Fixes https://github.com/python/mypy/issues/6817

I also added few minor cleanups in `mypy.test.helpers` near the code I edited.