### PR TITLE
Add support for overloading coroutines.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -868,7 +868,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if defn.is_awaitable_coroutine:
                     # Update the return type to AwaitableGenerator.
                     # (This doesn't exist in typing.py, only in typing.pyi.)
-                    defn.type = self.get_awaitable_coroutine_return_type(defn, typ)
+                    typ = self.get_awaitable_coroutine_return_type(defn, typ)
+                    defn.type = typ
 
                 # Push return type.
                 self.return_types.append(typ.ret_type)

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -62,6 +62,8 @@ CANNOT_ASSIGN_TO_METHOD = 'Cannot assign to a method'  # type: Final
 CANNOT_ASSIGN_TO_TYPE = 'Cannot assign to a type'  # type: Final
 INCONSISTENT_ABSTRACT_OVERLOAD = \
     'Overloaded method has both abstract and non-abstract variants'  # type: Final
+INCONSISTENT_COROUTINE_OVERLOAD = \
+    'Overloaded method has both coroutine and non-coroutine variants'  # type: Final
 MULTIPLE_OVERLOADS_REQUIRED = 'Single overload definition, multiple required'  # type: Final
 READ_ONLY_PROPERTY_OVERRIDES_READ_WRITE = \
     'Read-only property cannot override read-write property'  # type: Final

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -5003,7 +5003,7 @@ reveal_type(f(g([])))  # E: Revealed type is 'builtins.list[builtins.int]'
 [builtins fixtures/list.pyi]
 
 [case testTypeCheckOverloadCoroutine]
-from asyncio import coroutine
+from types import coroutine
 from typing import overload
 @overload
 @coroutine

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -5001,3 +5001,18 @@ def f(x):
 
 reveal_type(f(g([])))  # E: Revealed type is 'builtins.list[builtins.int]'
 [builtins fixtures/list.pyi]
+
+[case testTypeCheckOverloadCoroutine]
+from asyncio import coroutine
+from typing import overload
+@overload
+@coroutine
+def f(x: int) -> None: ...
+@overload
+@coroutine
+def f(x: str) -> None: ...
+def f(x): pass
+
+reveal_type(f) # E: Revealed type is 'Overload(def (x: builtins.int) -> typing.AwaitableGenerator[Any, Any, Any, None], def (x: builtins.str) -> typing.AwaitableGenerator[Any, Any, Any, None])'
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]


### PR DESCRIPTION
When applying @overload to @coroutine, update the return type of the
overload to AwaitableGenerator like the underlying coroutines.

Fix #6802.