### PR TITLE
Skip tests in testpep561.py

### DIFF
--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -188,7 +188,9 @@ class TestPEP561(TestCase):
         dirs = get_site_packages_dirs(sys.executable)
         assert dirs
 
-    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within a venv.")
+    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and \
+    sys.base_prefix != sys.prefix, \
+    reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_stub_package(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -200,7 +202,9 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
-    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within a venv.")
+    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and \
+    sys.base_prefix != sys.prefix, \
+    reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -224,6 +228,9 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
+    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and \
+    sys.base_prefix != sys.prefix, \
+    reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_stubs_python2(self) -> None:
         self.simple_prog.create()
         python2 = try_find_python2_interpreter()
@@ -250,7 +257,9 @@ class TestPEP561(TestCase):
                     venv_dir=venv_dir,
                 )
 
-    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within a venv.")
+    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and \
+    sys.base_prefix != sys.prefix, \
+    reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_egg(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -262,7 +271,9 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
-    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within a venv.")
+    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and \
+    sys.base_prefix != sys.prefix, \
+    reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_editable(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -274,7 +285,9 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
-    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within a venv.")
+    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and \
+    sys.base_prefix != sys.prefix, \
+    reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_egg_editable(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -188,9 +188,9 @@ class TestPEP561(TestCase):
         dirs = get_site_packages_dirs(sys.executable)
         assert dirs
 
-    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and \
-    sys.base_prefix != sys.prefix, \
-    reason="Temporarily skip to avoid having a virtualenv within a venv.")
+    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and
+                        sys.base_prefix != sys.prefix,
+                        reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_stub_package(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -202,9 +202,9 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
-    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and \
-    sys.base_prefix != sys.prefix, \
-    reason="Temporarily skip to avoid having a virtualenv within a venv.")
+    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and
+                        sys.base_prefix != sys.prefix,
+                        reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -228,9 +228,9 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
-    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and \
-    sys.base_prefix != sys.prefix, \
-    reason="Temporarily skip to avoid having a virtualenv within a venv.")
+    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and
+                        sys.base_prefix != sys.prefix,
+                        reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_stubs_python2(self) -> None:
         self.simple_prog.create()
         python2 = try_find_python2_interpreter()
@@ -257,9 +257,9 @@ class TestPEP561(TestCase):
                     venv_dir=venv_dir,
                 )
 
-    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and \
-    sys.base_prefix != sys.prefix, \
-    reason="Temporarily skip to avoid having a virtualenv within a venv.")
+    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and
+                        sys.base_prefix != sys.prefix,
+                        reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_egg(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -271,9 +271,9 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
-    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and \
-    sys.base_prefix != sys.prefix, \
-    reason="Temporarily skip to avoid having a virtualenv within a venv.")
+    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and
+                        sys.base_prefix != sys.prefix,
+                        reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_editable(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -285,9 +285,9 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
-    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and \
-    sys.base_prefix != sys.prefix, \
-    reason="Temporarily skip to avoid having a virtualenv within a venv.")
+    @pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and
+                        sys.base_prefix != sys.prefix,
+                        reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_egg_editable(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from enum import Enum
 import os
+import pytest  # type: ignore
 import subprocess
 from subprocess import PIPE
 import sys
@@ -187,6 +188,7 @@ class TestPEP561(TestCase):
         dirs = get_site_packages_dirs(sys.executable)
         assert dirs
 
+    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within an venv.")
     def test_typedpkg_stub_package(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -198,6 +200,7 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
+    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within an venv.")
     def test_typedpkg(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -247,6 +250,7 @@ class TestPEP561(TestCase):
                     venv_dir=venv_dir,
                 )
 
+    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within an venv.")
     def test_typedpkg_egg(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -258,6 +262,7 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
+    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within an venv.")
     def test_typedpkg_editable(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -269,6 +274,7 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
+    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within an venv.")
     def test_typedpkg_egg_editable(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -188,7 +188,7 @@ class TestPEP561(TestCase):
         dirs = get_site_packages_dirs(sys.executable)
         assert dirs
 
-    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within an venv.")
+    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_stub_package(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -200,7 +200,7 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
-    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within an venv.")
+    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -250,7 +250,7 @@ class TestPEP561(TestCase):
                     venv_dir=venv_dir,
                 )
 
-    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within an venv.")
+    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_egg(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -262,7 +262,7 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
-    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within an venv.")
+    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_editable(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:
@@ -274,7 +274,7 @@ class TestPEP561(TestCase):
                 venv_dir=venv_dir,
             )
 
-    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within an venv.")
+    @pytest.mark.skipif(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix, reason="Temporarily skip to avoid having a virtualenv within a venv.")
     def test_typedpkg_egg_editable(self) -> None:
         self.simple_prog.create()
         with self.virtualenv() as venv:


### PR DESCRIPTION
Added logic to temporarily skip tests in testpep561.py that fail on Mac due to nesting of ```virtualenv ``` inside a ```venv```. This PR could be updated to only skip tests on Mac but I've left that out for now. Once this bug is fixed these tests should be added back in. 

Fixes [#6798](https://github.com/python/mypy/issues/6798)