### PR TITLE
Only honor --warn-unused-configs in non-incremental mode

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -65,6 +65,7 @@ Config file
 ``--warn-unused-configs``
     This flag makes mypy warn about unused ``[mypy-<pattern>]`` config
     file sections.
+    (This requires turning off incremental mode using ``--no-incremental``.)
 
 
 .. _import-discovery:

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -439,6 +439,7 @@ Miscellaneous
 ``warn_unused_configs`` (bool, default False)
     Warns about per-module sections in the config file that do not
     match any files processed when invoking mypy.
+    (This requires turning off incremental mode using ``incremental = False``.)
 
 ``verbosity`` (integer, default 0)
     Controls how much debug output will be generated.  Higher numbers are more verbose.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -87,7 +87,7 @@ def main(script_path: Optional[str], args: Optional[List[str]] = None) -> None:
         blockers = True
         if not e.use_stdout:
             serious = True
-    if options.warn_unused_configs and options.unused_configs:
+    if options.warn_unused_configs and options.unused_configs and not options.incremental:
         print("Warning: unused section(s) in %s: %s" %
               (options.config_file,
                ", ".join("[mypy-%s]" % glob for glob in options.per_module_options.keys()

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1193,6 +1193,7 @@ s1.py:2: error: Incompatible return value type (got "int", expected "str")
 [file mypy.ini]
 [[mypy]
 warn_unused_configs = True
+incremental = False
 [[mypy-bar]
 [[mypy-foo]
 [[mypy-baz.*]


### PR DESCRIPTION
(In incremental mode it doesn't work right, and it isn't worth fixing.)

Fixes #5957