### PR TITLE
Ignoring all or part of a file with a single # type: ignore comment.

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -318,21 +318,22 @@ class ASTConverter:
 
         for i, e in enumerate(l):
 
-            # In Python 3.8, a "# type: ignore" comment between statements at
-            # the top level of a module skips checking for everything else:
+            if module:  # and...
+                if sys.version_info >= (3, 8):
 
-            if module and sys.version_info >= (3, 8):
+                    # In Python 3.8, a "# type: ignore" comment between statements at
+                    # the top level of a module skips checking for everything else:
 
-                ignores = set(range(line + 1, self.get_line(e))) & self.type_ignores
+                    ignores = set(range(line + 1, self.get_line(e))) & self.type_ignores
 
-                if ignores:
-                    self.errors.used_ignored_lines[self.errors.file].add(min(ignores))
-                    b = Block(self.fix_function_overloads(self.translate_stmt_list(l[i:])))
-                    b.is_unreachable = True
-                    res.append(b)
-                    return res
+                    if ignores:
+                        self.errors.used_ignored_lines[self.errors.file].add(min(ignores))
+                        b = Block(self.fix_function_overloads(self.translate_stmt_list(l[i:])))
+                        b.is_unreachable = True
+                        res.append(b)
+                        return res
 
-                line = e.end_lineno if e.end_lineno is not None else e.lineno
+                    line = e.end_lineno if e.end_lineno is not None else e.lineno
 
             stmt = self.visit(e)
             res.append(stmt)

--- a/test-data/unit/check-38.test
+++ b/test-data/unit/check-38.test
@@ -106,3 +106,8 @@ def g(x: int): ...
     /
     0  # type: ignore
 )  # type: ignore  # E: unused 'type: ignore' comment
+
+[case testIgnoreRestOfModule]
+ERROR  # E: Name 'ERROR' is not defined
+# type: ignore
+IGNORE

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -218,3 +218,43 @@ def f() -> None: pass
 
 [case testCannotIgnoreBlockingError]
 yield  # type: ignore  # E: 'yield' outside function
+
+[case testIgnoreWholeModule1]
+# flags: --warn-unused-ignores
+# type: ignore
+IGNORE # type: ignore  # E: unused 'type: ignore' comment
+
+[case testIgnoreWholeModule2]
+# type: ignore
+if True:
+    IGNORE
+
+[case testIgnoreWholeModule3]
+# type: ignore
+@d
+class C: ...
+IGNORE
+
+[case testIgnoreWholeModule4]
+# type: ignore
+@d
+
+def f(): ...
+IGNORE
+
+[case testDontIgnoreWholeModule1]
+if True:
+    # type: ignore
+    ERROR # E: Name 'ERROR' is not defined
+ERROR # E: Name 'ERROR' is not defined
+
+[case testDontIgnoreWholeModule2]
+@d  # type: ignore
+class C: ...
+ERROR # E: Name 'ERROR' is not defined
+
+[case testDontIgnoreWholeModule3]
+@d  # type: ignore
+
+def f(): ...
+ERROR # E: Name 'ERROR' is not defined


### PR DESCRIPTION
Fixes #626. For background on the design choices, here is what our current ASTs allow us to find:

- In all versions of Python, we can accurately detect bare `# type: ignore` comments before the first statement in a module.
- In Python 3.8+, we can accurately detect the placement of bare `# type: ignore` comments within a list of statements (we need `end_lineno` to do this properly).
- *In no current version of Python* can we accurately detect bare `# type: ignore` comments before the first statement in an indented code block using the AST alone.

Considering these limitations, the behavior I chose here is:

- All versions of Python will ignore a whole file if it contains a bare `# type: ignore` comment *before its first statement.*
- Python 3.8+ will ignore all statements following a bare `# type: ignore` comment *at the top level of a module.*
- **Bare `# type: ignore` comments have no special meaning inside of indented code blocks.** If we were to allow this, we would need to do one of the following (and I personally don't like any of them):
  - Not recognize them at the start of a block. 🙁
  - Guess where the `for`/`while`/`with`/`class`/`def`/`try` bit ends, a la decorated definitions prior to Python 3.8. 🙁
  - Parse the raw source of the file ourselves to see where the above block-starters end. 🙁
  - Modify ast parsing to tell us where the block-starters end. 🙁

A few notes:

- Ignoring is accomplished by nesting all remaining statements in an unreachable `Block`.
- `ASTConverter.extra_type_ignores: List[int]` is now `ASTConverter.type_ignores: Set[int]` and is populated before the AST is converted.
- Tests are added in `check-ignore.test` and `check-38.test`.