### PR TITLE
Fix daemon crash when using new semantic analyzer

### DIFF
--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -950,7 +950,8 @@ def reprocess_nodes(manager: BuildManager,
         if not manager.options.new_semantic_analyzer:
             strip_target(deferred.node)
         else:
-            patches = strip_target_new(deferred.node)
+            new_patches = strip_target_new(deferred.node)
+            patches.extend(new_patches)
     if not options.new_semantic_analyzer:
         re_analyze_nodes(file_node, nodes, manager, options)
     else:

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8815,3 +8815,33 @@ B().x
 [out]
 ==
 ==
+
+[case testNewSemanticAnalyzerUpdateMethodAndClass]
+# flags: --new-semantic-analyzer
+import m
+
+m.x
+
+class A:
+    def f(self) -> None:
+        self.x = 0
+        m.y
+
+    def g(self) -> None:
+        m.x
+
+[file m.py]
+x = 0
+y = 0
+
+[file m.py.2]
+x = ''
+y = 0
+
+[file m.py.3]
+x = ''
+y = ''
+
+[out]
+==
+==


### PR DESCRIPTION
If both module top level and a method that defines an attribute
through `self.x = y` assignment were stripped, stripping the 
method could result in a crash as the attribute had already 
been removed from the class symbol table (and was sometimes 
not added back). The root cause was some patches being 
dropped.

Fixes #6834.
