### PR TITLE
New semantic analyzer: fix crash caused by leaking placeholders

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3905,7 +3905,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
     def defer(self) -> None:
         """Defer current analysis target to be analyzed again.
 
-        This must called if something in the current target is
+        This must be called if something in the current target is
         incomplete or has a placeholder node.
         """
         self.deferred = True

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -4196,13 +4196,12 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         """
         names = self.current_symbol_table()
         existing = names.get(name)
-        is_placeholder = isinstance(symbol.node, PlaceholderNode)
-        if is_placeholder and can_defer:
+        if isinstance(symbol.node, PlaceholderNode) and can_defer:
             self.defer()
         if (existing is not None
                 and context is not None
                 and (not isinstance(existing.node, PlaceholderNode)
-                     or (is_placeholder and
+                     or (isinstance(symbol.node, PlaceholderNode) and
                          # Allow replacing becomes_typeinfo=False with becomes_typeinfo=True.
                          # This can happen for type aliases and NewTypes.
                          not symbol.node.becomes_typeinfo))):

--- a/mypy/newsemanal/semanal_newtype.py
+++ b/mypy/newsemanal/semanal_newtype.py
@@ -50,7 +50,8 @@ class NewTypeAnalyzer:
         if (not call.analyzed or
                 isinstance(call.analyzed, NewTypeExpr) and not call.analyzed.info):
             # Start from labeling this as a future class, as we do for normal ClassDefs.
-            self.api.add_symbol(name, PlaceholderNode(fullname, s, becomes_typeinfo=True), s)
+            self.api.add_symbol(name, PlaceholderNode(fullname, s, becomes_typeinfo=True), s,
+                                can_defer=False)
 
         old_type, should_defer = self.check_newtype_args(name, call, s)
         if not call.analyzed:

--- a/mypy/newsemanal/semanal_shared.py
+++ b/mypy/newsemanal/semanal_shared.py
@@ -133,7 +133,8 @@ class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
 
     @abstractmethod
     def add_symbol(self, name: str, node: SymbolNode, context: Optional[Context],
-                   module_public: bool = True, module_hidden: bool = False) -> bool:
+                   module_public: bool = True, module_hidden: bool = False,
+                   can_defer: bool = True) -> bool:
         """Add symbol to the current symbol table."""
         raise NotImplementedError
 

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1009,7 +1009,8 @@ class B: ...
 import a
 [file a.py]
 C = 1
-from b import *  # E: Name 'C' already defined on line 1
+from b import *  # E: Name 'C' already defined on line 1 \
+                 # E: Incompatible import of "C" (imported name has type "Type[C]", local name has type "int")
 
 [file b.py]
 import a

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2200,3 +2200,28 @@ x = 1
 # We want to check that the first definition creates the variable.
 def x() -> None: ...  # E: Name 'x' already defined on line 1
 y = 2
+
+[case testNewAnalyzerImportStarSpecialCase]
+import unittest
+[file unittest/__init__.pyi]
+from unittest.suite import *
+
+def load_tests() -> TestSuite: ...
+[file unittest/suite.pyi]
+from typing import Union # Iterable not imported
+import unittest.case
+
+_TestType = Union[unittest.case.TestCase]
+
+class BaseTestSuite(Iterable[_TestType]):
+    ...
+
+class TestSuite(BaseTestSuite):
+    ...
+
+[file unittest/case.pyi]
+class TestCase: ...
+
+[out]
+tmp/unittest/suite.pyi:6: error: Name 'Iterable' is not defined
+tmp/unittest/suite.pyi:6: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Iterable")

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2226,3 +2226,15 @@ class TestCase: ...
 [out]
 tmp/unittest/suite.pyi:6: error: Name 'Iterable' is not defined
 tmp/unittest/suite.pyi:6: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Iterable")
+
+[case testNewAnalyzerNewTypeSpecialCase]
+from typing import NewType
+from typing_extensions import Final, Literal
+
+X = NewType('X', int)
+
+var1: Final = 1
+
+def force1(x: Literal[1]) -> None: pass
+
+force1(reveal_type(var1))            # E: Revealed type is 'Literal[1]'


### PR DESCRIPTION
This fixes a crash when processing the latest `unittest` stubs.

Previously we didn't always defer a target when placeholder nodes
were added to a symbol table. This could result in crashes.
