### PR TITLE
Renable flake8 warning about getattr with constant string

### DIFF
--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -146,7 +146,7 @@ class FileSystemCache:
         tpl = tuple(seq)
         # FIXME: this works around typeshed claiming stat_result is from posix
         # (typeshed #2683)
-        st = getattr(os, 'stat_result')(tpl)
+        st = getattr(os, 'stat_result')(tpl)  # noqa
         self.stat_cache[path] = st
         # Make listdir() and read() also pretend this file exists.
         self.fake_package_cache.add(dirname)

--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -144,9 +144,7 @@ class FileSystemCache:
         seq[stat.ST_NLINK] = 1
         seq[stat.ST_SIZE] = 0
         tpl = tuple(seq)
-        # FIXME: this works around typeshed claiming stat_result is from posix
-        # (typeshed #2683)
-        st = getattr(os, 'stat_result')(tpl)  # noqa
+        st = os.stat_result(tpl)
         self.stat_cache[path] = st
         # Make listdir() and read() also pretend this file exists.
         self.fake_package_cache.add(dirname)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -700,7 +700,7 @@ def process_options(args: List[str],
 
     # Set strict flags before parsing (if strict mode enabled), so other command
     # line options can override.
-    if getattr(dummy, 'special-opts:strict'):
+    if getattr(dummy, 'special-opts:strict'):  # noqa
         for dest, value in strict_flag_assignments:
             setattr(options, dest, value)
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1396,7 +1396,7 @@ class MessageBuilder:
 
         # If we got a "special arg" (i.e: self, cls, etc...), prepend it to the arg list
         if tp.definition is not None and tp.definition.name() is not None:
-            definition_args = getattr(tp.definition, 'arg_names')
+            definition_args = tp.definition.arg_names  # type: ignore
             if definition_args and tp.arg_names != definition_args \
                     and len(definition_args) > 0:
                 if s:

--- a/mypy/server/objgraph.py
+++ b/mypy/server/objgraph.py
@@ -78,11 +78,11 @@ def get_edges(o: object) -> Iterator[Tuple[object, object]]:
             # in closures and self pointers to other objects
 
             if hasattr(e, '__closure__'):
-                yield (s, '__closure__'), getattr(e, '__closure__')
+                yield (s, '__closure__'), e.__closure__  # type: ignore
             if hasattr(e, '__self__'):
-                se = getattr(e, '__self__')
+                se = e.__self__  # type: ignore
                 if se is not o and se is not type(o):
-                    yield (s, '__self__'), se
+                    yield s.__self__, se  # type: ignore
         else:
             if not type(e) in TYPE_BLACKLIST:
                 yield s, e

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -112,8 +112,8 @@ def is_c_property(obj: object) -> bool:
     return inspect.isdatadescriptor(obj) and hasattr(obj, 'fget')
 
 
-def is_c_property_readonly(prop: object) -> bool:
-    return getattr(prop, 'fset') is None
+def is_c_property_readonly(prop: Any) -> bool:
+    return prop.fset is None
 
 
 def is_c_type(obj: object) -> bool:
@@ -243,7 +243,7 @@ def generate_c_type_stub(module: ModuleType,
     """
     # typeshed gives obj.__dict__ the not quite correct type Dict[str, Any]
     # (it could be a mappingproxy!), which makes mypyc mad, so obfuscate it.
-    obj_dict = getattr(obj, '__dict__')  # type: Mapping[str, Any]
+    obj_dict = getattr(obj, '__dict__')  # type: Mapping[str, Any]  # noqa
     items = sorted(obj_dict.items(), key=lambda x: method_name_sort_key(x[0]))
     methods = []  # type: List[str]
     properties = []  # type: List[str]

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,8 +44,7 @@ exclude =
 #   B006: use of mutable defaults in function signatures
 #   B007: Loop control variable not used within the loop body.
 #   B011: Don't use assert False
-#   B009: Don't use getattr with constant strings (FIXME)
-ignore = E251,E128,F401,W601,E701,W503,W504,E704,E402,B3,B006,B007,B011,B009
+ignore = E251,E128,F401,W601,E701,W503,W504,E704,E402,B3,B006,B007,B011
 
 [coverage:run]
 branch = true


### PR DESCRIPTION
Most of the `getattr` calls with constant strings were to shut up mypy, so add a bunch of
`# type: ignore`s for those.

A couple were for other things (something dumb with mypyc, using an invalid identifier),
so those get `# noqa`.

Not totally sure if this is actually better, which is why I didn't put the PR up when I first wrote it,
but pushing now to see what other people think so I can clean up the branch.
(I'm leaning towards it being better, but only marginally.)