### PR TITLE
Make parse errors always blockers in fine-grained mode

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -267,7 +267,7 @@ class ASTConverter:
         self.errors.report(line, column, msg, severity='note')
 
     def fail(self, msg: str, line: int, column: int, blocker: bool = True) -> None:
-        # Fine-grained mode doesn't support non-blocking parse errors yet
+        # Fine-grained mode doesn't support non-blocking parse errors yet.
         blocker = blocker or self.options.fine_grained_incremental
         if blocker or not self.options.ignore_errors:
             self.errors.report(line, column, msg, blocker=blocker)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -267,6 +267,8 @@ class ASTConverter:
         self.errors.report(line, column, msg, severity='note')
 
     def fail(self, msg: str, line: int, column: int, blocker: bool = True) -> None:
+        # Fine-grained mode doesn't support non-blocking parse errors yet
+        blocker = blocker or self.options.fine_grained_incremental
         if blocker or not self.options.ignore_errors:
             self.errors.report(line, column, msg, blocker=blocker)
 

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -166,6 +166,8 @@ class ASTConverter:
         self.type_ignores = set()  # type: Set[int]
 
     def fail(self, msg: str, line: int, column: int, blocker: bool = True) -> None:
+        # Fine-grained mode doesn't support non-blocking parse errors yet
+        blocker = blocker or self.options.fine_grained_incremental
         if blocker or not self.options.ignore_errors:
             self.errors.report(line, column, msg, blocker=blocker)
 

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -166,7 +166,7 @@ class ASTConverter:
         self.type_ignores = set()  # type: Set[int]
 
     def fail(self, msg: str, line: int, column: int, blocker: bool = True) -> None:
-        # Fine-grained mode doesn't support non-blocking parse errors yet
+        # Fine-grained mode doesn't support non-blocking parse errors yet.
         blocker = blocker or self.options.fine_grained_incremental
         if blocker or not self.options.ignore_errors:
             self.errors.report(line, column, msg, blocker=blocker)

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8845,3 +8845,21 @@ y = ''
 [out]
 ==
 ==
+
+[case testWrongNumberOfArguments]
+
+[file a.py]
+def bar(x):
+    # type: () -> None
+    pass
+
+[file b.py]
+x = ''
+
+[file m.py.2]
+x = 1
+
+[out]
+a.py:1: error: Type signature has too few arguments
+==
+a.py:1: error: Type signature has too few arguments


### PR DESCRIPTION
Since fine-grained mode doesn't re-run the parser, non-blocking errors get lost.
There are a bunch of different approaches that could fix this but for now just
disable non-blocking errors from the parser in fine-grained mode.

Partially disables #6813.