### PR TITLE
Make expression checking always produce Any once a node has been deferred

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3276,7 +3276,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 has_any_type(typ)):
             self.msg.disallowed_any_type(typ, node)
 
-        if not self.chk.in_checked_function():
+        if not self.chk.in_checked_function() or self.chk.current_node_deferred:
             return AnyType(TypeOfAny.unannotated)
         else:
             return typ

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -5001,3 +5001,31 @@ def f(x):
 
 reveal_type(f(g([])))  # E: Revealed type is 'builtins.list[builtins.int]'
 [builtins fixtures/list.pyi]
+
+[case testOverloadDeferredNode]
+from typing import Callable, TypeVar, Generic, Any, overload
+
+_S = TypeVar('_S')
+_T = TypeVar('_T')
+_R = TypeVar('_R')
+_F = TypeVar('_F', bound=Callable[..., Any])
+
+@overload
+def partial(__func: Callable[[_T], _S], __arg: _T) -> Callable[[], _S]: ...
+@overload
+def partial(__func: Callable[[_T, _S], _S], __arg: _T) -> Callable[[_S], _R]: ...
+def partial(*args: Any) -> Any:
+    pass
+
+
+def f(f: Callable[[int], int]) -> None:
+    pass
+
+def dec(f: Callable[[_S, _T], _R]) -> Callable[[_S, _T], _R]: pass
+
+def asdf() -> None:
+    f(partial(lol, 0))
+
+@dec
+def lol(x: int, y: int) -> int:
+    pass


### PR DESCRIPTION
This fixes an issue where the Any that is inferred temporarily when a
node is deferred could cause a bad overload to be picked and produce
a spurious error even though it checked properly the *second* time.