### PR TITLE
New semantic analyzer: Fix crash in error reporting

### DIFF
--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8863,3 +8863,20 @@ x = 1
 a.py:1: error: Type signature has too few arguments
 ==
 a.py:1: error: Type signature has too few arguments
+
+[case testErrorReportingNewAnalyzer]
+# flags: --disallow-any-generics
+from a import A
+
+def f() -> None:
+    x: A
+[file a.py]
+class A: ...
+
+[file a.py.2]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class A(Generic[T]): ...
+[out]
+==
+main:5: error: Missing type parameters for generic type


### PR DESCRIPTION
This just follows the logic from `calculate_class_properties()`. I was thinking about factoring this out into a new context manager, but it doesn't really save any space.

Also `report_hang()` is still broken, but it was broken for long time and it is a separate issue.