### PR TITLE
Allow redefinition withing with statements

### DIFF
--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -104,16 +104,15 @@ def f() -> None:
 
 def g(): pass
 
-[case testCannotRedefineLocalWithinWith]
+[case testRedefineLocalWithinWith]
 # flags: --allow-redefinition
 def f() -> None:
     with g():
         x = 0
         x
-        g()  # Might raise an exception
-        x = '' \
-        # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-    reveal_type(x) # E: Revealed type is 'builtins.int'
+        g()  # Might raise an exception, but we ignore this
+        x = ''
+    reveal_type(x) # E: Revealed type is 'builtins.str'
     y = 0
     y
     y = ''


### PR DESCRIPTION
This is strictly speaking unsafe, but allowing this is convenient 
(and safe) in the vast majority of cases.

Fixes #6705.