### PR TITLE
Fix reporting of likely hangs in the new semantic analyzer

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -408,7 +408,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
     @contextmanager
     def file_context(self, file_node: MypyFile, fnam: str, options: Options,
-                     active_type: Optional[TypeInfo],
+                     active_type: Optional[TypeInfo] = None,
                      scope: Optional[Scope] = None) -> Iterator[None]:
         # TODO: Use this above in visit_file
         scope = scope or self.scope

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -148,7 +148,11 @@ def process_top_levels(graph: 'Graph', scc: List[str], patches: Patches) -> None
     while worklist:
         iteration += 1
         if iteration > MAX_ITERATIONS:
-            state.manager.new_semantic_analyzer.report_hang()
+            analyzer = state.manager.new_semantic_analyzer
+            # Just pick some module inside the current SCC for error context.
+            assert state.tree is not None
+            with analyzer.file_context(state.tree, state.tree.path, state.options):
+                analyzer.report_hang()
             break
         if final_iteration:
             # Give up. It's impossible to bind all names.

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2238,3 +2238,8 @@ var1: Final = 1
 def force1(x: Literal[1]) -> None: pass
 
 force1(reveal_type(var1))            # E: Revealed type is 'Literal[1]'
+
+[case testNewAnalyzerReportLoopInMRO]
+class A(A): ...
+[out]
+main: error: Internal error: maximum semantic analysis iteration count reached


### PR DESCRIPTION
Previously things like `class A(A): pass` resulted in a crash
instead of an error message. Now we generate an error message
with some context (but still not enough).

Partially addresses #6495.
