### PR TITLE
New semantic analyzer: fix issues with looking up qualified names

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3891,12 +3891,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     break
                 else:
                     sym = nextsym
-            if sym:
-                if sym.module_hidden:
-                    self.name_not_defined(name, ctx, namespace=namespace)
-                else:
-                    return sym
-        return None
+            if sym.module_hidden:
+                self.name_not_defined(name, ctx, namespace=namespace)
+                sym = None
+        return sym
 
     def get_module_symbol(self, node: MypyFile, parts: List[str]) -> Optional[SymbolTableNode]:
         """Look up a symbol from the module symbol table."""

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3878,10 +3878,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 elif isinstance(node, PlaceholderNode):
                     return sym
                 else:
-                    # Invalid things such as variable or function
                     if isinstance(node, Var) and isinstance(node.type, AnyType):
                         # Allow access through Var with Any type without error.
                         return self.missing_symbol(sym, name, parts[i:], node.type)
+                    # Lookup through invalid node, such as variable or function
                     nextsym = None
                 if not nextsym or nextsym.module_hidden:
                     if not suppress_errors:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3880,17 +3880,13 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     return sym
                 else:
                     # Invalid things such as variable or function
-                    nextsym = None
                     if isinstance(node, Var) and isinstance(node.type, AnyType):
                         # Allow access through Var with Any type without error.
-                        suppress_errors = True
-                        source_type = node.type
-                if not nextsym:
+                        return self.missing_symbol(sym, name, parts[i:], node.type)
+                    nextsym = None
+                if not nextsym or nextsym.module_hidden:
                     if not suppress_errors:
                         self.name_not_defined(name, ctx, namespace=namespace)
-                    return self.missing_symbol(sym, name, parts[i:], source_type)
-                if nextsym.module_hidden:
-                    self.name_not_defined(name, ctx, namespace=namespace)
                     return None
                 sym = nextsym
         return sym

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3866,10 +3866,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         else:
             parts = name.split('.')
             namespace = self.cur_mod_id
-            n = self.lookup(parts[0], ctx, suppress_errors=suppress_errors)
-            if n:
+            sym = self.lookup(parts[0], ctx, suppress_errors=suppress_errors)
+            if sym:
                 for i in range(1, len(parts)):
-                    node = n.node
+                    node = sym.node
                     error_type = None
                     if isinstance(node, TypeInfo):
                         nn = node.get(parts[i])
@@ -3902,15 +3902,15 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     if not nn:
                         if not suppress_errors:
                             self.name_not_defined(name, ctx, namespace=namespace)
-                        n = self.error_symbol(n, name, parts[i:], error_type)
+                        sym = self.error_symbol(sym, name, parts[i:], error_type)
                         break
                     else:
-                        n = nn
-                if n:
-                    if n and n.module_hidden:
+                        sym = nn
+                if sym:
+                    if sym and sym.module_hidden:
                         self.name_not_defined(name, ctx, namespace=namespace)
-            if n and not n.module_hidden:
-                return n
+            if sym and not sym.module_hidden:
+                return sym
             return None
 
     def error_symbol(self, n: SymbolTableNode, name: str, parts: List[str],

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3882,30 +3882,30 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                         # TODO: Do this for all modules in the set of modified files.
                         if namespace == self.cur_mod_id:
                             names = self.globals
-                        nn = names.get(parts[i], None)
-                        if (not nn
+                        nextsym = names.get(parts[i], None)
+                        if (not nextsym
                                 and '__getattr__' in names
                                 and not self.is_incomplete_namespace(namespace)):
                             fullname = namespace + '.' + '.'.join(parts[i:])
                             gvar = self.create_getattr_var(names['__getattr__'],
                                                            parts[i], fullname)
                             if gvar:
-                                nn = SymbolTableNode(GDEF, gvar)
+                                nextsym = SymbolTableNode(GDEF, gvar)
                     else:
-                        nn = None
+                        newsym = None
                         if isinstance(node, Var) and isinstance(node.type, AnyType):
                             suppress_errors = True
                             error_type = node.type
                         else:
                             # Invalid things such as variable or function.
-                            nn = None
-                    if not nn:
+                            nextsym = None
+                    if not nextsym:
                         if not suppress_errors:
                             self.name_not_defined(name, ctx, namespace=namespace)
                         sym = self.error_symbol(sym, name, parts[i:], error_type)
                         break
                     else:
-                        sym = nn
+                        sym = nextsym
                 if sym:
                     if sym and sym.module_hidden:
                         self.name_not_defined(name, ctx, namespace=namespace)

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3870,7 +3870,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         if sym:
             for i in range(1, len(parts)):
                 node = sym.node
-                source_type = None
                 if isinstance(node, TypeInfo):
                     nextsym = node.get(parts[i])
                 elif isinstance(node, MypyFile):

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3892,10 +3892,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 else:
                     sym = nextsym
             if sym:
-                if sym and sym.module_hidden:
+                if sym.module_hidden:
                     self.name_not_defined(name, ctx, namespace=namespace)
-        if sym and not sym.module_hidden:
-            return sym
+                else:
+                    return sym
         return None
 
     def get_module_symbol(self, node: MypyFile, parts: List[str]) -> Optional[SymbolTableNode]:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3889,10 +3889,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     if not suppress_errors:
                         self.name_not_defined(name, ctx, namespace=namespace)
                     return self.missing_symbol(sym, name, parts[i:], source_type)
+                if nextsym.module_hidden:
+                    self.name_not_defined(name, ctx, namespace=namespace)
+                    return None
                 sym = nextsym
-            if sym.module_hidden:
-                self.name_not_defined(name, ctx, namespace=namespace)
-                return None
         return sym
 
     def get_module_symbol(self, node: MypyFile, parts: List[str]) -> Optional[SymbolTableNode]:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3880,7 +3880,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 else:
                     if isinstance(node, Var) and isinstance(node.type, AnyType):
                         # Allow access through Var with Any type without error.
-                        return self.missing_symbol(sym, name, parts[i:], node.type)
+                        return self.implicit_symbol(sym, name, parts[i:], node.type)
                     # Lookup through invalid node, such as variable or function
                     nextsym = None
                 if not nextsym or nextsym.module_hidden:
@@ -3911,20 +3911,18 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 sym = SymbolTableNode(GDEF, gvar)
         return sym
 
-    def missing_symbol(self, n: SymbolTableNode, name: str, parts: List[str],
-                       source_type: Optional[AnyType]) -> SymbolTableNode:
-        if n.node is None:
+    def implicit_symbol(self, sym: SymbolTableNode, name: str, parts: List[str],
+                        source_type: AnyType) -> SymbolTableNode:
+        """Create symbol for a qualified name reference through Any type."""
+        if sym.node is None:
             basename = None
         else:
-            basename = n.node.fullname()
+            basename = sym.node.fullname()
         if basename is None:
             fullname = name
         else:
             fullname = basename + '.' + '.'.join(parts)
-        if source_type:
-            var_type = AnyType(TypeOfAny.from_another_any, source_type)
-        else:
-            var_type = AnyType(TypeOfAny.from_error)
+        var_type = AnyType(TypeOfAny.from_another_any, source_type)
         var = Var(parts[-1], var_type)
         var._fullname = fullname
         return SymbolTableNode(GDEF, var)

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3877,7 +3877,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     nextsym = self.get_module_symbol(node, parts[i:])
                     namespace = node.fullname()
                 else:
-                    newsym = None
+                    nextsym = None
                     if isinstance(node, Var) and isinstance(node.type, AnyType):
                         suppress_errors = True
                         error_type = node.type

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3876,14 +3876,14 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 elif isinstance(node, MypyFile):
                     nextsym = self.get_module_symbol(node, parts[i:])
                     namespace = node.fullname()
+                elif isinstance(node, PlaceholderNode):
+                    return sym
                 else:
+                    # Invalid things such as variable or function
                     nextsym = None
                     if isinstance(node, Var) and isinstance(node.type, AnyType):
                         suppress_errors = True
                         error_type = node.type
-                    else:
-                        # Invalid things such as variable or function.
-                        nextsym = None
                 if not nextsym:
                     if not suppress_errors:
                         self.name_not_defined(name, ctx, namespace=namespace)

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2243,3 +2243,27 @@ force1(reveal_type(var1))            # E: Revealed type is 'Literal[1]'
 class A(A): ...
 [out]
 main: error: Internal error: maximum semantic analysis iteration count reached
+
+[case testNewSemanticAnalyzerUnimportedSpecialCase]
+# flags: --ignore-missing-imports
+import other
+import p.u
+
+[file p/__init__.py]
+
+[file p/u.pyi]
+from . import c
+x: c.C
+
+[file other.py]
+from p.c import B
+
+[out]
+
+[case testNewSemanticAnalyzerQualifiedFunctionAsType]
+import m
+
+x: m.C.a.b # E: Name 'm.C.a.b' is not defined
+
+[file m.py]
+def C(): pass

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2267,3 +2267,15 @@ x: m.C.a.b # E: Name 'm.C.a.b' is not defined
 
 [file m.py]
 def C(): pass
+
+[case testNewSemanticAnalyzerModulePrivateRefInMiddleOfQualified]
+import m
+
+x: m.n.C # E: Name 'm.n.C' is not defined
+reveal_type(x) # E: Revealed type is 'Any'
+
+[file m.pyi]
+import n
+
+[file n.pyi]
+class C: pass

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2280,6 +2280,31 @@ import n
 [file n.pyi]
 class C: pass
 
+[case testNextSemanticAnalyzerModuleGetAttrInPython36]
+# flags: --python-version 3.6
+import m
+import n
+
+x: m.n.C # E: Name 'm.n.C' is not defined
+y: n.D # E: Name 'n.D' is not defined
+[file m.py]
+import n
+[file n.py]
+def __getattr__(x): pass
+
+
+[case testNextSemanticAnalyzerModuleGetAttrInPython37]
+# flags: --python-version 3.7
+import m
+import n
+
+x: m.n.C
+y: n.D
+[file m.py]
+import n
+[file n.py]
+def __getattr__(x): pass
+
 [case testNewAnalyzerReportLoopInMRO2]
 def f() -> None:
     class A(A): ...


### PR DESCRIPTION
Various fixes to `lookup_qualified`:

1. Allow qualified types that refer to unimported modules. Fixes #6866.
2. Flag module private references in the middle of a qualified name.
3. Don't allow module-level `__getattr__` in Python 3.6 and earlier
   outside stubs.
4. Better error message when qualified name includes a function/variable
   component.

Also includes a major refactor of `lookup_qualified`.

More cleanup is possible, but this PR seems big enough as is.
