### PR TITLE
Update readme: replace vim-mypy by syntastic

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ IDE, Linter Integrations, and Pre-commit
 
 Mypy can be integrated into popular IDEs:
 
-* Vim: [vim-mypy](https://github.com/Integralist/vim-mypy)
+* Vim: [syntastic](https://github.com/vim-syntastic/syntastic) in `.vimrc` add `let g:syntastic_python_checkers=['mypy']`
 * Emacs: using [Flycheck](https://github.com/flycheck/) and [Flycheck-mypy](https://github.com/lbolla/emacs-flycheck-mypy)
 * Sublime Text: [SublimeLinter-contrib-mypy](https://github.com/fredcallaway/SublimeLinter-contrib-mypy)
 * Atom: [linter-mypy](https://atom.io/packages/linter-mypy)


### PR DESCRIPTION
    Vim-mypy is not maintained and does not work with the current version.
    Syntastic is a well-maintained static grammer checking plugin for
    vim that supports multiple languages.

    Addressing (https://github.com/python/mypy/issues/6880)