### PR TITLE
New semantic analyzer: refactor file_context

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -415,6 +415,13 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                      file_node: MypyFile,
                      options: Options,
                      active_type: Optional[TypeInfo] = None) -> Iterator[None]:
+        """Configure analyzer for analyzing targets within a file/class.
+
+        Args:
+            file_node: target file
+            options: options specific to the file
+            active_type: must be the surrounding class to analyze method targets
+        """
         scope = self.scope
         self.options = options
         self.errors.set_file(file_node.path, file_node.fullname(), scope=scope)


### PR DESCRIPTION
Modify the main entry point `refresh_partial` to call `file_context`
to make things less error-prone.

Also remove arguments that are not needed.