### PR TITLE
Use Iterator in documentation examples for generator functions

### DIFF
--- a/docs/source/cheat_sheet.rst
+++ b/docs/source/cheat_sheet.rst
@@ -95,7 +95,7 @@ Functions
    x = f  # type: Callable[[int, float], float]
 
    # A generator function that yields ints is secretly just a function that
-   # returns an iterator (see below) of ints, so that's how we annotate it
+   # returns an iterator of ints, so that's how we annotate it
    def g(n):
        # type: (int) -> Iterator[int]
        i = 0

--- a/docs/source/cheat_sheet.rst
+++ b/docs/source/cheat_sheet.rst
@@ -58,7 +58,7 @@ Functions
 
 .. code-block:: python
 
-   from typing import Callable, Iterable, Union, Optional, List
+   from typing import Callable, Iterator, Union, Optional, List
 
    # This is how you annotate a function definition
    def stringify(num):
@@ -95,9 +95,9 @@ Functions
    x = f  # type: Callable[[int, float], float]
 
    # A generator function that yields ints is secretly just a function that
-   # returns an iterable (see below) of ints, so that's how we annotate it
-   def f(n):
-       # type: (int) -> Iterable[int]
+   # returns an iterator (see below) of ints, so that's how we annotate it
+   def g(n):
+       # type: (int) -> Iterator[int]
        i = 0
        while i < n:
            yield i

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -86,7 +86,7 @@ Python 3 supports an annotation syntax for function declarations.
 
 .. code-block:: python
 
-   from typing import Callable, Iterable, Union, Optional, List
+   from typing import Callable, Iterator, Union, Optional, List
 
    # This is how you annotate a function definition
    def stringify(num: int) -> str:
@@ -104,8 +104,8 @@ Python 3 supports an annotation syntax for function declarations.
    x: Callable[[int, float], float] = f
 
    # A generator function that yields ints is secretly just a function that
-   # returns an iterable (see below) of ints, so that's how we annotate it
-   def f(n: int) -> Iterable[int]:
+   # returns an iterator (see below) of ints, so that's how we annotate it
+   def g(n: int) -> Iterator[int]:
        i = 0
        while i < n:
            yield i

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -104,7 +104,7 @@ Python 3 supports an annotation syntax for function declarations.
    x: Callable[[int, float], float] = f
 
    # A generator function that yields ints is secretly just a function that
-   # returns an iterator (see below) of ints, so that's how we annotate it
+   # returns an iterator of ints, so that's how we annotate it
    def g(n: int) -> Iterator[int]:
        i = 0
        while i < n:


### PR DESCRIPTION
The current "cheat sheet" examples use `Iterable` to annotate the return type of generator functions.  This PR changes this to `Iterator`, which is more specific.

In most cases it doesn't matter, but the distinction becomes significant when defining an iterable class whose `__iter__` method is a generator function.

```
from typing import Iterable

class MyIterable:
    def __iter__(self) -> Iterable[int]:
        yield 1

mi = MyIterable()
for k in mi:  # error: "Iterable[int]" has no attribute "__next__"
    pass
```