### PR TITLE
Fix yield from TupleType.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2444,7 +2444,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             type = type.fallback
         return (is_subtype(type, self.named_generic_type('typing.Iterable',
                                                          [AnyType(TypeOfAny.special_form)])) and
-                isinstance(type, Instance))
+                isinstance(type, (Instance, TupleType)))
 
     def check_multi_assignment_from_iterable(self, lvalues: List[Lvalue], rvalue_type: Type,
                                              context: Context,

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2442,15 +2442,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     def type_is_iterable(self, type: Type) -> bool:
         if isinstance(type, CallableType) and type.is_type_obj():
             type = type.fallback
-        return (is_subtype(type, self.named_generic_type('typing.Iterable',
-                                                         [AnyType(TypeOfAny.special_form)])) and
-                isinstance(type, (Instance, TupleType)))
+        return is_subtype(type, self.named_generic_type('typing.Iterable',
+                                                        [AnyType(TypeOfAny.special_form)]))
 
     def check_multi_assignment_from_iterable(self, lvalues: List[Lvalue], rvalue_type: Type,
                                              context: Context,
                                              infer_lvalue_type: bool = True) -> None:
-        if self.type_is_iterable(rvalue_type):
-            item_type = self.iterable_item_type(cast(Instance, rvalue_type))
+        if self.type_is_iterable(rvalue_type) and isinstance(rvalue_type, Instance):
+            item_type = self.iterable_item_type(rvalue_type)
             for lv in lvalues:
                 if isinstance(lv, StarExpr):
                     items_type = self.named_generic_type('builtins.list', [item_type])

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3411,9 +3411,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             item_type = join.join_type_list(subexpr_type.items)
             any_type = AnyType(TypeOfAny.special_form)
             iter_type = self.chk.named_generic_type('typing.Generator',
-                                                    [item_type, any_type, any_type])
+                                                    [item_type, any_type, any_type])  # type: Type
         elif isinstance(subexpr_type, AnyType):
-            iter_type = AnyType(TypeOfAny.from_another_any, source_any=subexpr_type)  # type: Type
+            iter_type = AnyType(TypeOfAny.from_another_any, source_any=subexpr_type)
         elif self.chk.type_is_iterable(subexpr_type):
             if is_async_def(subexpr_type) and not has_coroutine_decorator(return_type):
                 self.chk.msg.yield_from_invalid_operand_type(subexpr_type, e)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3406,17 +3406,15 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         # Check that the expr is an instance of Iterable and get the type of the iterator produced
         # by __iter__.
-        if isinstance(subexpr_type, TupleType):
-            # Tuples get special handling here, since they "don't have __iter__"...
-            item_type = join.join_type_list(subexpr_type.items)
-            any_type = AnyType(TypeOfAny.special_form)
-            iter_type = self.chk.named_generic_type('typing.Generator',
-                                                    [item_type, any_type, any_type])  # type: Type
-        elif isinstance(subexpr_type, AnyType):
-            iter_type = AnyType(TypeOfAny.from_another_any, source_any=subexpr_type)
+        if isinstance(subexpr_type, AnyType):
+            iter_type = AnyType(TypeOfAny.from_another_any, source_any=subexpr_type)  # type: Type
         elif self.chk.type_is_iterable(subexpr_type):
             if is_async_def(subexpr_type) and not has_coroutine_decorator(return_type):
                 self.chk.msg.yield_from_invalid_operand_type(subexpr_type, e)
+            elif isinstance(subexpr_type, TupleType):
+                # Tuples get special handling here, since they "don't have __iter__"...
+                item_type = join.join_type_list(subexpr_type.items)
+                subexpr_type = self.chk.named_generic_type('typing.Iterable', [item_type])
 
             any_type = AnyType(TypeOfAny.special_form)
             generic_generator_type = self.chk.named_generic_type('typing.Generator',

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3411,10 +3411,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         elif self.chk.type_is_iterable(subexpr_type):
             if is_async_def(subexpr_type) and not has_coroutine_decorator(return_type):
                 self.chk.msg.yield_from_invalid_operand_type(subexpr_type, e)
-            elif isinstance(subexpr_type, TupleType):
-                # Tuples get special handling here, since they "don't have __iter__"...
-                item_type = join.join_type_list(subexpr_type.items)
-                subexpr_type = self.chk.named_generic_type('typing.Iterable', [item_type])
 
             any_type = AnyType(TypeOfAny.special_form)
             generic_generator_type = self.chk.named_generic_type('typing.Generator',

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3406,7 +3406,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         # Check that the expr is an instance of Iterable and get the type of the iterator produced
         # by __iter__.
-        if isinstance(subexpr_type, AnyType):
+        if isinstance(subexpr_type, TupleType):
+            # Tuples get special handling here, since they "don't have __iter__"...
+            item_type = join.join_type_list(subexpr_type.items)
+            any_type = AnyType(TypeOfAny.special_form)
+            iter_type = self.chk.named_generic_type('typing.Generator',
+                                                    [item_type, any_type, any_type])
+        elif isinstance(subexpr_type, AnyType):
             iter_type = AnyType(TypeOfAny.from_another_any, source_any=subexpr_type)  # type: Type
         elif self.chk.type_is_iterable(subexpr_type):
             if is_async_def(subexpr_type) and not has_coroutine_decorator(return_type):

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1697,12 +1697,12 @@ def g() -> Iterator[int]:
 [case testYieldFromTupleExpression]
 from typing import Generator
 def g() -> Generator[int, None, None]:
-    x = None  # type: None
-    x = yield from ()
-    x = yield from (0, 1, 2)
-    x = yield from (0, "ERROR")  # E: Incompatible types in "yield from" (actual type "object", expected type "int")
-    x = yield from ("ERROR",)  # E: Incompatible types in "yield from" (actual type "str", expected type "int")
-
+    x = yield from ()  # E: Function does not return a value
+    x = yield from (0, 1, 2)  # E: Function does not return a value
+    x = yield from (0, "ERROR")  # E: Incompatible types in "yield from" (actual type "object", expected type "int") \
+                                 # E: Function does not return a value
+    x = yield from ("ERROR",)  # E: Incompatible types in "yield from" (actual type "str", expected type "int") \
+                               # E: Function does not return a value
 
 -- dict(...)
 -- ---------

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1694,6 +1694,15 @@ def g() -> Iterator[int]:
     a = yield from f()
 [out]
 
+[case testYieldFromTupleExpression]
+from typing import Generator
+def g() -> Generator[int, None, None]:
+    x = None  # type: None
+    x = yield from ()
+    x = yield from (0, 1, 2)
+    x = yield from (0, "ERROR")  # E: Incompatible types in "yield from" (actual type "object", expected type "int")
+    x = yield from ("ERROR",)  # E: Incompatible types in "yield from" (actual type "str", expected type "int")
+
 
 -- dict(...)
 -- ---------

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1703,6 +1703,7 @@ def g() -> Generator[int, None, None]:
                                  # E: Function does not return a value
     x = yield from ("ERROR",)  # E: Incompatible types in "yield from" (actual type "str", expected type "int") \
                                # E: Function does not return a value
+[builtins fixtures/tuple.pyi]
 
 -- dict(...)
 -- ---------

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1250,6 +1250,14 @@ def g() -> Generator[int, str, float]:
     reveal_type(r)  # E: Revealed type is 'builtins.str*'
     return 3.14
 
+[case testYieldFromTupleStatement]
+from typing import Generator
+def g() -> Generator[int, None, None]:
+    yield from ()
+    yield from (0, 1, 2)
+    yield from (0, "ERROR")  # E: Incompatible types in "yield from" (actual type "object", expected type "int")
+    yield from ("ERROR",)  # E: Incompatible types in "yield from" (actual type "str", expected type "int")
+
 -- With statement
 -- --------------
 

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1257,6 +1257,7 @@ def g() -> Generator[int, None, None]:
     yield from (0, 1, 2)
     yield from (0, "ERROR")  # E: Incompatible types in "yield from" (actual type "object", expected type "int")
     yield from ("ERROR",)  # E: Incompatible types in "yield from" (actual type "str", expected type "int")
+[builtins fixtures/tuple.pyi]
 
 -- With statement
 -- --------------


### PR DESCRIPTION
Fixes #4444. Now `yield from <tuple>` works as expected!

~We just add a branch to special-case `TupleType`, since neither they nor their fallbacks are properly handled by any of the other branches.~