### PR TITLE
Allow non-blocking parse errors in fine-grained mode

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -42,7 +42,7 @@ from mypy.newsemanal.semanal import NewSemanticAnalyzer
 from mypy.newsemanal.semanal_main import semantic_analysis_for_scc
 from mypy.checker import TypeChecker
 from mypy.indirection import TypeIndirectionVisitor
-from mypy.errors import Errors, CompileError, report_internal_error
+from mypy.errors import Errors, CompileError, ErrorInfo, report_internal_error
 from mypy.util import DecodeError, decode_python_encoding, is_sub_path, get_mypy_comments
 if MYPY:
     from mypy.report import Reports  # Avoid unconditional slow import
@@ -1654,6 +1654,10 @@ class State:
     # Whether the module has an error or any of its dependencies have one.
     transitive_error = False
 
+    # Errors reported before semantic analysis, to allow fine-grained
+    # mode to keep reporting them
+    early_errors = None  # type: List[ErrorInfo]
+
     # Type checker used for checking this file.  Use type_checker() for
     # access and to construct this on demand.
     _type_checker = None  # type: Optional[TypeChecker]
@@ -1689,6 +1693,7 @@ class State:
             self.import_context = []
         self.id = id or '__main__'
         self.options = manager.options.clone_for_module(self.id)
+        self.early_errors = []
         self._type_checker = None
         if not path and source is None:
             assert id is not None
@@ -1970,6 +1975,11 @@ class State:
 
         modules[self.id] = self.tree
 
+        # Make a copy of any errors produced during parse time so that
+        # fine-grained mode can repeat them when the module is
+        # reprocessed.
+        self.early_errors = list(manager.errors.error_info_map.get(self.xpath, []))
+
         self.semantic_analysis_pass1()
 
         if not self.options.new_semantic_analyzer:
@@ -1988,9 +1998,7 @@ class State:
             self.options = self.options.apply_changes(changes)
             self.manager.errors.set_file(self.xpath, self.id)
             for lineno, error in config_errors:
-                # Unfortunately these need to be blockers, since otherwise they will
-                # be lost on daemon reprocessing.
-                self.manager.errors.report(lineno, 0, error, blocker=True)
+                self.manager.errors.report(lineno, 0, error)
 
     def semantic_analysis_pass1(self) -> None:
         """Perform pass 1 of semantic analysis, which happens immediately after parsing.

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1655,7 +1655,7 @@ class State:
     transitive_error = False
 
     # Errors reported before semantic analysis, to allow fine-grained
-    # mode to keep reporting them
+    # mode to keep reporting them.
     early_errors = None  # type: List[ErrorInfo]
 
     # Type checker used for checking this file.  Use type_checker() for

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -268,8 +268,6 @@ class ASTConverter:
         self.errors.report(line, column, msg, severity='note')
 
     def fail(self, msg: str, line: int, column: int, blocker: bool = True) -> None:
-        # Fine-grained mode doesn't support non-blocking parse errors yet.
-        blocker = blocker or self.options.fine_grained_incremental
         if blocker or not self.options.ignore_errors:
             self.errors.report(line, column, msg, blocker=blocker)
 

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -167,8 +167,6 @@ class ASTConverter:
         self.type_ignores = set()  # type: Set[int]
 
     def fail(self, msg: str, line: int, column: int, blocker: bool = True) -> None:
-        # Fine-grained mode doesn't support non-blocking parse errors yet.
-        blocker = blocker or self.options.fine_grained_incremental
         if blocker or not self.options.ignore_errors:
             self.errors.report(line, column, msg, blocker=blocker)
 

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -943,6 +943,13 @@ def reprocess_nodes(manager: BuildManager,
             targets.add(target)
     manager.errors.clear_errors_in_targets(file_node.path, targets)
 
+    # If one of the nodes is the module itself, emit any errors that
+    # happened before semantic analysis.
+    for target in targets:
+        if target == module_id:
+            for info in graph[module_id].early_errors:
+                manager.errors.add_error_info(info)
+
     # Strip semantic analysis information.
     patches = []  # type: List[Callable[[], None]]
     for deferred in nodes:

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8905,6 +8905,12 @@ def baz(x):
     # type: () -> None
     pass
 
+def f():
+    # type: () -> None
+    def g(x):
+        # type: () -> None
+        pass
+
 [file c.py]
 def bar(x):
     # type: () -> None
@@ -8920,9 +8926,11 @@ x = 1
 c.py:1: error: Type signature has too few arguments
 a.py:1: error: Type signature has too few arguments
 a.py:5: error: Type signature has too few arguments
+a.py:11: error: Type signature has too few arguments
 ==
 a.py:1: error: Type signature has too few arguments
 a.py:5: error: Type signature has too few arguments
+a.py:11: error: Type signature has too few arguments
 c.py:1: error: Type signature has too few arguments
 
 [case testErrorReportingNewAnalyzer]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8901,16 +8901,29 @@ def bar(x):
     # type: () -> None
     pass
 
+def baz(x):
+    # type: () -> None
+    pass
+
+[file c.py]
+def bar(x):
+    # type: () -> None
+    pass
+
 [file b.py]
 x = ''
 
-[file m.py.2]
+[file b.py.2]
 x = 1
 
 [out]
+c.py:1: error: Type signature has too few arguments
 a.py:1: error: Type signature has too few arguments
+a.py:5: error: Type signature has too few arguments
 ==
 a.py:1: error: Type signature has too few arguments
+a.py:5: error: Type signature has too few arguments
+c.py:1: error: Type signature has too few arguments
 
 [case testErrorReportingNewAnalyzer]
 # flags: --disallow-any-generics


### PR DESCRIPTION
We do this by storing the errors generated at parse time and replaying
them when the module is reprocessed.

This restores consistency between the daemon and non-daemon for
type comments with the wrong number of arguments.