### PR TITLE
Disable travis builds on 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ jobs:
     - TOXENV=py
     - EXTRA_ARGS="-n 12"
     - TEST_MYPYC=1
-  - name: "run test suite with python 3.8-dev"
-    python: 3.8-dev
+  # - name: "run test suite with python 3.8-dev"
+  #   python: 3.8-dev
   - name: "type check our own code"
     python: 3.7
     env:


### PR DESCRIPTION
The new argument to PyCode_New means that lxml doesn't work on 3.8
right now, so we're out of business until there's a new lxml release
that does. (If that is taking too long, we can disable the tests that
want lxml.)

There are also some other minor issues: we fail some tests with
`DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead` while running some of the eval tests.