### PR TITLE
tox.ini: passenv: TRAVIS: for -n auto

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,11 +13,10 @@ isolated_build = true
 [testenv]
 description = run the test driver with {basepython}
 setenv = cov: COVERAGE_FILE={toxworkdir}/.coverage.{envname}
-passenv = PYTEST_XDIST_WORKER_COUNT NEWSEMANAL
+passenv = PYTEST_XDIST_WORKER_COUNT NEWSEMANAL TRAVIS
 deps = -rtest-requirements.txt
 commands = python -m pytest {posargs}
            cov: python -m pytest {posargs: --cov mypy --cov-config setup.cfg}
-    
 
 [testenv:coverage]
 description = [run locally after tests]: combine coverage data and create report


### PR DESCRIPTION
This is required/useful for pytest-xdist's workaround to only use 2
workers on Travis [1].

Currently it uses 12 workers there [2].

1: https://github.com/pytest-dev/pytest-xdist/blob/9fcf8fa636bc69ee6cac9348a6ec20c87f2bb5e4/xdist/plugin.py#L11-L13
2: https://travis-ci.org/python/mypy/jobs/540201314#L256