### PR TITLE
Reenable PEP 570 tests.

### DIFF
--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -90,11 +90,6 @@ typecheck_files = [
 if sys.version_info >= (3, 8):
     typecheck_files.append('check-python38.test')
 
-    # Remove this once Travis supports 3.8.0a4+.
-    if sys.version_info >= (3, 8, 0, "alpha", 4) and os.environ.get("TRAVIS"):
-        import warnings
-        warnings.warn("PEP 570 tests in check-python38.test can be unskipped! 🎉")
-
 # Special tests for platforms with case-insensitive filesystems.
 if sys.platform in ('darwin', 'win32'):
     typecheck_files.append('check-modules-case.test')

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -107,31 +107,29 @@ def g(x: int): ...
     0  # type: ignore
 )  # type: ignore  # E: unused 'type: ignore' comment
 
--- Unskip the following PEP 570 tests once Travis supports 3.8.0a4 (or greater).
-
-[case testPEP570ArgTypesMissing-skip]
+[case testPEP570ArgTypesMissing]
 # flags: --disallow-untyped-defs
 def f(arg, /) -> None: ...  # E: Function is missing a type annotation for one or more arguments
 
-[case testPEP570ArgTypesBadDefault-skip]
+[case testPEP570ArgTypesBadDefault]
 def f(arg: int = "ERROR", /) -> None: ...  # E: Incompatible default for argument "arg" (default has type "str", argument has type "int")
 
-[case testPEP570ArgTypesDefault-skip]
+[case testPEP570ArgTypesDefault]
 def f(arg: int = 0, /) -> None:
     reveal_type(arg)  # E: Revealed type is 'builtins.int'
 
-[case testPEP570ArgTypesRequired-skip]
+[case testPEP570ArgTypesRequired]
 def f(arg: int, /) -> None:
     reveal_type(arg)  # E: Revealed type is 'builtins.int'
 
-[case testPEP570Required-skip]
+[case testPEP570Required]
 def f(arg: int, /) -> None: ...  # N: "f" defined here
 f(1)
 f("ERROR")  # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 f(arg=1)  # E: Unexpected keyword argument "arg" for "f"
 f(arg="ERROR")  # E: Unexpected keyword argument "arg" for "f"
 
-[case testPEP570Default-skip]
+[case testPEP570Default]
 def f(arg: int = 0, /) -> None: ...  # N: "f" defined here
 f()
 f(1)
@@ -139,45 +137,45 @@ f("ERROR")  # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 f(arg=1)  # E: Unexpected keyword argument "arg" for "f"
 f(arg="ERROR")  # E: Unexpected keyword argument "arg" for "f"
 
-[case testPEP570Calls-skip]
+[case testPEP570Calls]
 def f(p, /, p_or_kw, *, kw) -> None: ...  # N: "f" defined here
 f(0, 0, 0)  # E: Too many positional arguments for "f"
 f(0, 0, kw=0)
 f(0, p_or_kw=0, kw=0)
 f(p=0, p_or_kw=0, kw=0)  # E: Unexpected keyword argument "p" for "f"
 
-[case testPEP570Signatures1-skip]
+[case testPEP570Signatures1]
 def f(p1: bytes, p2: float, /, p_or_kw: int, *, kw: str) -> None:
     reveal_type(p1)  # E: Revealed type is 'builtins.bytes'
     reveal_type(p2)  # E: Revealed type is 'builtins.float'
     reveal_type(p_or_kw)  # E: Revealed type is 'builtins.int'
     reveal_type(kw)  # E: Revealed type is 'builtins.str'
 
-[case testPEP570Signatures2-skip]
+[case testPEP570Signatures2]
 def f(p1: bytes, p2: float = 0.0, /, p_or_kw: int = 0, *, kw: str) -> None:
     reveal_type(p1)  # E: Revealed type is 'builtins.bytes'
     reveal_type(p2)  # E: Revealed type is 'builtins.float'
     reveal_type(p_or_kw)  # E: Revealed type is 'builtins.int'
     reveal_type(kw)  # E: Revealed type is 'builtins.str'
 
-[case testPEP570Signatures3-skip]
+[case testPEP570Signatures3]
 def f(p1: bytes, p2: float = 0.0, /, *, kw: int) -> None:
     reveal_type(p1)  # E: Revealed type is 'builtins.bytes'
     reveal_type(p2)  # E: Revealed type is 'builtins.float'
     reveal_type(kw)  # E: Revealed type is 'builtins.int'
 
-[case testPEP570Signatures4-skip]
+[case testPEP570Signatures4]
 def f(p1: bytes, p2: int = 0, /) -> None:
     reveal_type(p1)  # E: Revealed type is 'builtins.bytes'
     reveal_type(p2)  # E: Revealed type is 'builtins.int'
 
-[case testPEP570Signatures5-skip]
+[case testPEP570Signatures5]
 def f(p1: bytes, p2: float, /, p_or_kw: int) -> None:
     reveal_type(p1)  # E: Revealed type is 'builtins.bytes'
     reveal_type(p2)  # E: Revealed type is 'builtins.float'
     reveal_type(p_or_kw)  # E: Revealed type is 'builtins.int'
 
-[case testPEP570Signatures6-skip]
+[case testPEP570Signatures6]
 def f(p1: bytes, p2: float, /) -> None:
     reveal_type(p1)  # E: Revealed type is 'builtins.bytes'
     reveal_type(p2)  # E: Revealed type is 'builtins.float'


### PR DESCRIPTION
The `3.8-dev` Travis build environment now uses Python 3.8.0a4+!

This is left over from #6900. We aren't running 3.8 test right now for other reasons, but I've confirmed that these pass fine on my local build (@JukkaL confirmed too in the PR).