### PR TITLE
Analyze UnboundType args even when UnboundType is invalid

### DIFF
--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -398,7 +398,9 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 column=t.column,
             )
 
-        # None of the above options worked, we give up.
+        # None of the above options worked. We parse the args (if there are any)
+        # to make sure there are no remaining semanal-only types, then give up.
+        t = t.copy_modified(args=self.anal_array(t.args))
         self.fail('Invalid type "{}"'.format(name), t)
 
         # TODO: Would it be better to always return Any instead of UnboundType

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -379,6 +379,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             assert sym.node is not None
             name = sym.node.name()
 
+
         # Option 1:
         # Something with an Any type -- make it an alias for Any in a type
         # context. This is slightly problematic as it allows using the type 'Any'
@@ -439,7 +440,9 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 return AnyType(TypeOfAny.from_error)
             return ForwardRef(t)
 
-        # None of the above options worked, we give up.
+        # None of the above options worked. We parse the args (if there are any)
+        # to make sure there are no remaining semanal-only types, then give up.
+        t = t.copy_modified(args=self.anal_array(t.args))
         self.fail('Invalid type "{}"'.format(name), t)
         if self.third_pass and isinstance(sym.node, TypeVarExpr):
             self.note_func("Forward references to type variables are prohibited", t)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -379,7 +379,6 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             assert sym.node is not None
             name = sym.node.name()
 
-
         # Option 1:
         # Something with an Any type -- make it an alias for Any in a type
         # context. This is slightly problematic as it allows using the type 'Any'

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -305,7 +305,7 @@ class UnboundType(Type):
 
     def copy_modified(self,
                       args: Bogus[Optional[List[Type]]] = _dummy,
-                      ) -> 'AnyType':
+                      ) -> 'UnboundType':
         if args is _dummy:
             args = self.args
         return UnboundType(

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -75,6 +75,9 @@ TPDICT_NAMES = ('mypy_extensions.TypedDict', 'typing_extensions.TypedDict')  # t
 # Supported fallback instance type names for TypedDict types.
 TPDICT_FB_NAMES = ('mypy_extensions._TypedDict', 'typing_extensions._TypedDict')  # type: Final
 
+# A placeholder used for Bogus[...] parameters
+_dummy = object()  # type: Final[Any]
+
 
 class TypeOfAny:
     """
@@ -300,6 +303,22 @@ class UnboundType(Type):
         self.original_str_expr = original_str_expr
         self.original_str_fallback = original_str_fallback
 
+    def copy_modified(self,
+                      args: Bogus[Optional[List[Type]]] = _dummy,
+                      ) -> 'AnyType':
+        if args is _dummy:
+            args = self.args
+        return UnboundType(
+            name=self.name,
+            args=args,
+            line=self.line,
+            column=self.column,
+            optional=self.optional,
+            empty_tuple_index=self.empty_tuple_index,
+            original_str_expr=self.original_str_expr,
+            original_str_fallback=self.original_str_fallback,
+        )
+
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_unbound_type(self)
 
@@ -376,9 +395,6 @@ class TypeList(Type):
 
     def serialize(self) -> JsonDict:
         assert False, "Synthetic types don't serialize"
-
-
-_dummy = object()  # type: Final[Any]
 
 
 class AnyType(Type):

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -683,6 +683,16 @@ reveal_type(x)  # E: Revealed type is 'Literal['Foo']'
 y: Foo[Foo]     # E: Literal[...] must have at least one parameter
 [out]
 
+[case testLiteralBadRawExpressionWithBadType]
+NotAType = 3
+def f() -> NotAType['also' + 'not' + 'a' + 'type']: ... # E: Invalid type "__main__.NotAType" \
+                                                        # E: Invalid type comment or annotation
+
+# Note: this makes us re-inspect the type (e.g. via '_patch_indirect_dependencies'
+# in build.py) so we can confirm the RawExpressionType did not leak out.
+indirect = f()                                          # E: Need type annotation for 'indirect'
+[out]
+
 --
 -- Check to make sure we can construct the correct range of literal
 -- types (and correctly reject invalid literal types)

--- a/test-data/unit/merge.test
+++ b/test-data/unit/merge.test
@@ -784,13 +784,13 @@ tmp/target.py:4: error: Invalid type "target.foo"
 TempNode:-1: Any
 TempNode:-1: Any
 NameExpr:3: builtins.int<0>
-NameExpr:4: foo?[A?]
+NameExpr:4: foo?[target.A<1>]
 ==>
 ## target
 TempNode:-1: Any
 TempNode:-1: Any
 NameExpr:3: builtins.int<0>
-NameExpr:4: foo?[A?]
+NameExpr:4: foo?[target.A<1>]
 
 [case testOverloaded_types]
 import target


### PR DESCRIPTION
This diff modifies the typeanal phase so that we try analyzing the args of an UnboundType even when it turns out that UnboundType is invalid. This prevents things like RawExpressionTypes from leaking out of the semantic analysis phase.

Fixes https://github.com/python/mypy/issues/6913.