### PR TITLE
test-requirements: unpin lxml

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ attrs>=18.0
 flake8
 flake8-bugbear; python_version >= '3.5'
 flake8-pyi; python_version >= '3.6'
-lxml==4.2.4
+lxml>=4.2.4
 mypy_extensions>=0.4.0,<0.5.0
 psutil>=4.0
 pytest>=4.4


### PR DESCRIPTION
It appears to have been pinned initially without a specific reason (in
79bce277).