### PR TITLE
Suggest trying master branch on crash

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -655,8 +655,8 @@ renaming the method, a work-around is to use an alias:
        def register(self, path: bytes_):
            ...
 
-I need a mypy bug fix that hasn't been released yet
----------------------------------------------------
+Using a development mypy build
+------------------------------
 
 You can install the latest development version of mypy from source. Clone the
 `mypy repository on GitHub <https://github.com/python/mypy>`_, and then run

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -618,11 +618,16 @@ def report_internal_error(err: Exception,
 
     # Print "INTERNAL ERROR" message.
     print('{}error: INTERNAL ERROR --'.format(prefix),
-          'Please try using master\n'
-          'https://mypy.rtfd.io/en/latest/common_issues.html#using-pre-release-mypy',
+          'Please try using mypy master on Github:\n'
+          'https://mypy.rtfd.io/en/latest/common_issues.html#using-development-mypy-build',
           file=stderr)
-    print('If this crash persists, please report a bug at https://github.com/python/mypy/issues',
-          file=stderr)
+    if options.show_traceback:
+        print('Please report a bug at https://github.com/python/mypy/issues',
+            file=stderr)
+    else:
+        print('If this issue continues with mypy master, '
+              'please report a bug at https://github.com/python/mypy/issues',
+            file=stderr)
     print('version: {}'.format(mypy_version),
           file=stderr)
 

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -618,8 +618,12 @@ def report_internal_error(err: Exception,
 
     # Print "INTERNAL ERROR" message.
     print('{}error: INTERNAL ERROR --'.format(prefix),
-          'please report a bug at https://github.com/python/mypy/issues',
-          'version: {}'.format(mypy_version),
+          'Please try using master\n'
+          'https://mypy.rtfd.io/en/latest/common_issues.html#using-pre-release-mypy',
+          file=stderr)
+    print('If this crash persists, please report a bug at https://github.com/python/mypy/issues',
+          file=stderr)
+    print('version: {}'.format(mypy_version),
           file=stderr)
 
     # If requested, drop into pdb. This overrides show_tb.


### PR DESCRIPTION
I noticed that several recent crash reports were from people on older mypy versions. I thought it would be good to suggest people try the latest master as that may have needed fixes. Here is a sample of the output:

```
test.py:5: error: INTERNAL ERROR -- Please try using master
https://mypy.rtfd.io/en/latest/common_issues.html#using-pre-release-mypy
If this crash persists, please report a bug at https://github.com/python/mypy/issues
version: 0.710+dev.bde68e77bc6fd209fce765f3ddcc9cb2b4c43e77.dirty
test.py:5: : note: please use --show-traceback to print a traceback when reporting a bug
```

I also edited the docs section so the title/link wouldn't be so long.