### PR TITLE
Update typed_ast dep to 1.4.0+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ setup(name='mypy',
       classifiers=classifiers,
       cmdclass=cmdclass,
       # When changing this, also update test-requirements.txt.
-      install_requires=['typed-ast >= 1.3.5, < 1.4.0',
+      install_requires=['typed_ast >= 1.4.0, < 1.5.0',
                         'mypy_extensions >= 0.4.0, < 0.5.0',
                         ],
       # Same here.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,7 +8,7 @@ psutil>=4.0
 pytest>=4.4
 pytest-xdist>=1.22
 pytest-cov>=2.4.0
-typed-ast>=1.3.5,<1.4.0
+typed_ast>=1.4.0,<1.5.0
 typing>=3.5.2; python_version < '3.5'
 py>=1.5.2
 virtualenv


### PR DESCRIPTION
Now that typed_ast 1.4.0 is released (whose main new feature is support for extra text after `# type: ignore`).