### PR TITLE
New semantic analyzer: fix falling back to outer scope in class body

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3755,7 +3755,12 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         if self.type and not self.is_func_scope() and name in self.type.names:
             node = self.type.names[name]
             if not node.implicit:
-                if node.node is None or node.node.line < self.statement.line:
+                # Only allow access to most class attributes after the definition
+                # so that it's possible to fall back to the outer scope
+                # (except for types).
+                if (node.node is None
+                        or node.node.line < self.statement.line
+                        or isinstance(node.node, TypeInfo)):
                     return node
             else:
                 # Defined through self.x assignment

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2991,7 +2991,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     # respect explicitly annotated type
                     if (isinstance(lval.node, Var) and lval.node.type is not None):
                         continue
-                    lnode = self.lookup(lval.name, ctx)
+                    lnode = self.current_symbol_table().get(lval.name)
                     if lnode:
                         if isinstance(lnode.node, MypyFile) and lnode.node is not rnode.node:
                             self.fail(

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -222,6 +222,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
     # not be found in phase 1, for example due to * imports.
     errors = None  # type: Errors     # Keeps track of generated errors
     plugin = None  # type: Plugin     # Mypy plugin for special casing of library features
+    statement = None  # type: Node    # Statement/definition being analyzed
 
     def __init__(self,
                  modules: Dict[str, MypyFile],
@@ -510,6 +511,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
     #
 
     def visit_func_def(self, defn: FuncDef) -> None:
+        self.statement = defn
         defn.is_conditional = self.block_depth[-1] > 0
 
         # Set full names even for those definitionss that aren't added
@@ -629,6 +631,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             fun_type.variables = a.bind_function_type_variables(fun_type, defn)
 
     def visit_overloaded_func_def(self, defn: OverloadedFuncDef) -> None:
+        self.statement = defn
         self.add_function_to_symbol_table(defn)
 
         if not self.recurse_into_functions:
@@ -977,6 +980,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
     #
 
     def visit_class_def(self, defn: ClassDef) -> None:
+        self.statement = defn
         with self.tvar_scope_frame(self.tvar_scope.class_frame()):
             self.analyze_class(defn)
 
@@ -1841,6 +1845,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
     #
 
     def visit_assignment_stmt(self, s: AssignmentStmt) -> None:
+        self.statement = s
         tag = self.track_incomplete_refs()
         s.rvalue.accept(self)
         if self.found_incomplete_ref(tag) or self.should_wait_rhs(s.rvalue):
@@ -2403,7 +2408,9 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             alias_node.normalized = rvalue.node.normalized
         return True
 
-    def analyze_lvalue(self, lval: Lvalue, nested: bool = False,
+    def analyze_lvalue(self,
+                       lval: Lvalue,
+                       nested: bool = False,
                        explicit_type: bool = False,
                        is_final: bool = False) -> None:
         """Analyze an lvalue or assignment target.
@@ -3020,21 +3027,25 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             self.visit_block(b)
 
     def visit_expression_stmt(self, s: ExpressionStmt) -> None:
+        self.statement = s
         s.expr.accept(self)
 
     def visit_return_stmt(self, s: ReturnStmt) -> None:
+        self.statement = s
         if not self.is_func_scope():
             self.fail("'return' outside function", s)
         if s.expr:
             s.expr.accept(self)
 
     def visit_raise_stmt(self, s: RaiseStmt) -> None:
+        self.statement = s
         if s.expr:
             s.expr.accept(self)
         if s.from_expr:
             s.from_expr.accept(self)
 
     def visit_assert_stmt(self, s: AssertStmt) -> None:
+        self.statement = s
         if s.expr:
             s.expr.accept(self)
         if s.msg:
@@ -3042,6 +3053,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
     def visit_operator_assignment_stmt(self,
                                        s: OperatorAssignmentStmt) -> None:
+        self.statement = s
         s.lvalue.accept(self)
         s.rvalue.accept(self)
         if (isinstance(s.lvalue, NameExpr) and s.lvalue.name == '__all__' and
@@ -3049,6 +3061,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             self.add_exports(s.rvalue.items)
 
     def visit_while_stmt(self, s: WhileStmt) -> None:
+        self.statement = s
         s.expr.accept(self)
         self.loop_depth += 1
         s.body.accept(self)
@@ -3056,6 +3069,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         self.visit_block_maybe(s.else_body)
 
     def visit_for_stmt(self, s: ForStmt) -> None:
+        self.statement = s
         s.expr.accept(self)
 
         # Bind index variables and check if they define new names.
@@ -3076,14 +3090,17 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         self.visit_block_maybe(s.else_body)
 
     def visit_break_stmt(self, s: BreakStmt) -> None:
+        self.statement = s
         if self.loop_depth == 0:
             self.fail("'break' outside loop", s, True, blocker=True)
 
     def visit_continue_stmt(self, s: ContinueStmt) -> None:
+        self.statement = s
         if self.loop_depth == 0:
             self.fail("'continue' outside loop", s, True, blocker=True)
 
     def visit_if_stmt(self, s: IfStmt) -> None:
+        self.statement = s
         infer_reachability_of_if_statement(s, self.options)
         for i in range(len(s.expr)):
             s.expr[i].accept(self)
@@ -3091,6 +3108,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         self.visit_block_maybe(s.else_body)
 
     def visit_try_stmt(self, s: TryStmt) -> None:
+        self.statement = s
         self.analyze_try_stmt(s, self)
 
     def analyze_try_stmt(self, s: TryStmt, visitor: NodeVisitor[None]) -> None:
@@ -3107,6 +3125,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             s.finally_body.accept(visitor)
 
     def visit_with_stmt(self, s: WithStmt) -> None:
+        self.statement = s
         types = []  # type: List[Type]
 
         if s.unanalyzed_type:
@@ -3151,6 +3170,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         self.visit_block(s.body)
 
     def visit_del_stmt(self, s: DelStmt) -> None:
+        self.statement = s
         s.expr.accept(self)
         if not self.is_valid_del_target(s.expr):
             self.fail('Invalid delete target', s)
@@ -3164,12 +3184,14 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             return False
 
     def visit_global_decl(self, g: GlobalDecl) -> None:
+        self.statement = g
         for name in g.names:
             if name in self.nonlocal_decls[-1]:
                 self.fail("Name '{}' is nonlocal and global".format(name), g)
             self.global_decls[-1].add(name)
 
     def visit_nonlocal_decl(self, d: NonlocalDecl) -> None:
+        self.statement = d
         if not self.is_func_scope():
             self.fail("nonlocal declaration not allowed at module level", d)
         else:
@@ -3189,12 +3211,14 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 self.nonlocal_decls[-1].add(name)
 
     def visit_print_stmt(self, s: PrintStmt) -> None:
+        self.statement = s
         for arg in s.args:
             arg.accept(self)
         if s.target:
             s.target.accept(self)
 
     def visit_exec_stmt(self, s: ExecStmt) -> None:
+        self.statement = s
         s.expr.accept(self)
         if s.globals:
             s.globals.accept(self)
@@ -3731,10 +3755,12 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         if self.type and not self.is_func_scope() and name in self.type.names:
             node = self.type.names[name]
             if not node.implicit:
-                if node.node is None or node.node.line < ctx.line:
+                if node.node is None or node.node.line < self.statement.line:
                     return node
-            implicit_name = True
-            implicit_node = node
+            else:
+                # Defined through self.x assignment
+                implicit_name = True
+                implicit_node = node
         # 3. Local (function) scopes
         for table in reversed(self.locals):
             if table is not None and name in table:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2564,6 +2564,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             # Bind to an existing name.
             if original_def:
                 self.bind_name_expr(lval, original_def)
+            else:
+                self.name_not_defined(lval.name, lval)
             self.check_lvalue_validity(lval.node, lval)
 
     def analyze_tuple_or_list_lvalue(self, lval: TupleExpr,

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3731,7 +3731,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         if self.type and not self.is_func_scope() and name in self.type.names:
             node = self.type.names[name]
             if not node.implicit:
-                return node
+                if node.node is None or node.node.line < ctx.line:
+                    return node
             implicit_name = True
             implicit_node = node
         # 3. Local (function) scopes

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -907,6 +907,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             self.fail('Type signature has too many arguments', fdef, blocker=True)
 
     def visit_decorator(self, dec: Decorator) -> None:
+        self.statement = dec
         dec.func.is_conditional = self.block_depth[-1] > 0
         if not dec.is_overload:
             self.add_symbol(dec.name(), dec, dec)

--- a/mypy/newsemanal/semanal_namedtuple.py
+++ b/mypy/newsemanal/semanal_namedtuple.py
@@ -431,6 +431,7 @@ class NamedTupleAnalyzer:
             func.is_class = is_classmethod
             func.type = set_callable_name(signature, func)
             func._fullname = info.fullname() + '.' + funcname
+            func.line = line
             if is_classmethod:
                 v = Var(funcname, func.type)
                 v.is_classmethod = True

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -757,7 +757,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         """Find the type variables of the function type and bind them in our tvar_scope"""
         if fun_type.variables:
             for var in fun_type.variables:
-                var_node = self.lookup_qualified(var.name, var)
+                var_node = self.lookup_qualified(var.name, defn)
                 assert var_node, "Binding for function type variable not found within function"
                 var_expr = var_node.node
                 assert isinstance(var_expr, TypeVarExpr)

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -237,7 +237,6 @@ a = __file__ # type: int  # E: Incompatible types in assignment (expression has 
 
 
 [case testLocalVariableShadowing]
-
 a = None # type: A
 if int():
     a = B()  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
@@ -254,7 +253,6 @@ class A: pass
 class B: pass
 
 [case testGlobalDefinedInBlockWithType]
-
 class A: pass
 while A:
     a = None # type: A

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2534,7 +2534,7 @@ def foo() -> None:
     _ = 0  # E: Incompatible types in assignment (expression has type "int", variable has type "Callable[[], Any]")
 [builtins fixtures/module.pyi]
 
-[case testUnusedTargetNotClass2]
+[case testUnderscoreClass]
 def foo() -> None:
     class _:
         pass

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2316,3 +2316,21 @@ class C:
         # TODO: Error message could be better
         class D(self.E): # E: Name 'self.E' is not defined
             pass
+
+
+[case testNewAnalyzerShadowOuterDefinitionBasedOnOrderSinglePass]
+# Only one semantic analysis pass
+class X: pass
+class C:
+    X = X
+    reveal_type(X)  # E: Revealed type is 'def () -> __main__.X'
+reveal_type(C.X)  # E: Revealed type is 'def () -> __main__.X'
+
+[case testNewAnalyzerShadowOuterDefinitionBasedOnOrderTwoPasses]
+c: C  # Force second semantic analysis pass
+class X: pass
+class C:
+    X = X
+    reveal_type(X)  # E: Revealed type is 'def () -> __main__.X'
+
+reveal_type(C.X)  # E: Revealed type is 'def () -> __main__.X'

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2382,3 +2382,30 @@ reveal_type(C().x()) # E: Revealed type is 'builtins.int'
 reveal_type(C().y()) # E: Revealed type is 'builtins.int'
 reveal_type(C().z) # E: Revealed type is 'builtins.str'
 reveal_type(C().str()) # E: Revealed type is 'builtins.str'
+
+[case testNewAnalyzerNameConflictsAndMultiLineDefinition]
+c: C  # Force second semantic analysis pass
+
+class X: pass
+
+class C:
+    X = (
+        X)
+
+    def str(self
+            ) -> str:
+        return 0 # E: Incompatible return value type (got "int", expected "str")
+
+reveal_type(C.X) # E:  # E: Revealed type is 'def () -> __main__.X'
+reveal_type(C().str()) # E: Revealed type is 'builtins.str'
+
+[case testNewAnalyzerNameNotDefinedYetInClassBody]
+class C:
+    X = Y  # E: Name 'Y' is not defined
+    Y = 1
+
+    f = g  # E: Name 'g' is not defined
+
+    def g(self) -> None: pass
+
+reveal_type(C.X)  # E: Revealed type is 'Any'

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2334,3 +2334,51 @@ class C:
     reveal_type(X)  # E: Revealed type is 'def () -> __main__.X'
 
 reveal_type(C.X)  # E: Revealed type is 'def () -> __main__.X'
+
+[case testNewAnalyzerAnnotationConflictsWithAttributeSinglePass]
+class C:
+    def x(self) -> int:
+        return 0
+
+    def __init__(self) -> None:
+        self.int = ''
+
+    def y(self) -> int:
+        return 0
+
+    z: str
+
+    def str(self) -> str:
+        return 0 # E: Incompatible return value type (got "int", expected "str")
+
+    zz: str # E: Invalid type "__main__.C.str"
+
+reveal_type(C().x()) # E: Revealed type is 'builtins.int'
+reveal_type(C().y()) # E: Revealed type is 'builtins.int'
+reveal_type(C().z) # E: Revealed type is 'builtins.str'
+reveal_type(C().str()) # E: Revealed type is 'builtins.str'
+
+[case testNewAnalyzerAnnotationConflictsWithAttributeTwoPasses]
+c: C  # Force second semantic analysis pass
+
+class C:
+    def x(self) -> int:
+        return 0
+
+    def __init__(self) -> None:
+        self.int = ''
+
+    def y(self) -> int:
+        return 0
+
+    z: str
+
+    def str(self) -> str:
+        return 0 # E: Incompatible return value type (got "int", expected "str")
+
+    zz: str # E: Invalid type "__main__.C.str"
+
+reveal_type(C().x()) # E: Revealed type is 'builtins.int'
+reveal_type(C().y()) # E: Revealed type is 'builtins.int'
+reveal_type(C().z) # E: Revealed type is 'builtins.str'
+reveal_type(C().str()) # E: Revealed type is 'builtins.str'

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2291,7 +2291,6 @@ import n
 [file n.py]
 def __getattr__(x): pass
 
-
 [case testNewAnalyzerModuleGetAttrInPython37]
 # flags: --python-version 3.7
 import m
@@ -2316,7 +2315,6 @@ class C:
         # TODO: Error message could be better
         class D(self.E): # E: Name 'self.E' is not defined
             pass
-
 
 [case testNewAnalyzerShadowOuterDefinitionBasedOnOrderSinglePass]
 # Only one semantic analysis pass


### PR DESCRIPTION
This fixes scoping issue where code like this was rejected:

```py
c: C  # Forces second semantic analysis pass

class X: pass

class C:
    X = X   # Should be no error here
```

The approach is to fall back to the outer scope if the definition
in the class body is not ready yet, based on the line numbers of
the definitions.

Additionally generate an error for references to names defined 
later in a class body.

This only addresses class bodies. Local scopes have a similar 
issue with references to undefined names. I'm planning to 
address that in a separate PR.

The basic fix is very simple, but various other changes were
required to support multi-line definitions and certain edge cases.

Work towards #6303.