### PR TITLE
New semantic analyzer: fix access to imported name in class body

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -42,7 +42,9 @@ from mypy.newsemanal.semanal_main import semantic_analysis_for_scc
 from mypy.checker import TypeChecker
 from mypy.indirection import TypeIndirectionVisitor
 from mypy.errors import Errors, CompileError, ErrorInfo, report_internal_error
-from mypy.util import DecodeError, decode_python_encoding, is_sub_path, get_mypy_comments
+from mypy.util import (
+    DecodeError, decode_python_encoding, is_sub_path, get_mypy_comments, module_prefix
+)
 if MYPY:
     from mypy.report import Reports  # Avoid unconditional slow import
 from mypy import moduleinfo
@@ -875,7 +877,7 @@ def invert_deps(deps: Dict[str, Set[str]],
     fake module FAKE_ROOT_MODULE if none are.
     """
     # Lazy import to speed up startup
-    from mypy.server.target import module_prefix, trigger_to_target
+    from mypy.server.target import trigger_to_target
 
     # Prepopulate the map for all the modules that have been processed,
     # so that we always generate files for processed modules (even if

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3790,17 +3790,20 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         return None
 
     def is_active_symbol_in_class_body(self, node: Optional[SymbolNode]) -> bool:
-        # Only allow access to class attributes textually after
-        # the definition, so that it's possible to fall back to the
-        # outer scope. Example:
-        #
-        #     class X: ...
-        #
-        #     class C:
-        #         X = X  # Initializer refers to outer scope
-        #
-        # Nested classes are an exception, since we want to support
-        # arbitrary forward references in type annotations.
+        """Can a symbol defined in class body accessed at current statement?
+
+        Only allow access to class attributes textually after
+        the definition, so that it's possible to fall back to the
+        outer scope. Example:
+
+            class X: ...
+
+            class C:
+                X = X  # Initializer refers to outer scope
+
+        Nested classes are an exception, since we want to support
+        arbitrary forward references in type annotations.
+        """
         return (node is None
                 or node.line < self.statement.line
                 or not self.is_defined_in_current_module(node)

--- a/mypy/server/target.py
+++ b/mypy/server/target.py
@@ -1,6 +1,3 @@
-from typing import Iterable, Tuple, List, Optional
-
-
 def trigger_to_target(s: str) -> str:
     assert s[0] == '<'
     # Strip off the angle brackets
@@ -9,22 +6,3 @@ def trigger_to_target(s: str) -> str:
     if s[-1] == ']':
         s = s.split('[')[0]
     return s
-
-
-def module_prefix(modules: Iterable[str], target: str) -> Optional[str]:
-    result = split_target(modules, target)
-    if result is None:
-        return None
-    return result[0]
-
-
-def split_target(modules: Iterable[str], target: str) -> Optional[Tuple[str, str]]:
-    remaining = []  # type: List[str]
-    while True:
-        if target in modules:
-            return target, '.'.join(remaining)
-        components = target.rsplit('.', 1)
-        if len(components) == 1:
-            return None
-        target = components[0]
-        remaining.insert(0, components[1])

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -140,8 +140,9 @@ from mypy.server.astmerge import merge_asts
 from mypy.server.aststrip import strip_target
 from mypy.server.aststripnew import strip_target_new, SavedAttributes
 from mypy.server.deps import get_dependencies_of_target
-from mypy.server.target import module_prefix, split_target, trigger_to_target
+from mypy.server.target import trigger_to_target
 from mypy.server.trigger import make_trigger, WILDCARD_TAG
+from mypy.util import module_prefix, split_target
 from mypy.typestate import TypeState
 
 MYPY = False

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -38,7 +38,7 @@ from mypy.nodes import (
     reverse_builtin_aliases,
 )
 from mypy.server.update import FineGrainedBuildManager
-from mypy.server.target import module_prefix, split_target
+from mypy.util import module_prefix, split_target
 from mypy.plugin import Plugin, FunctionContext, MethodContext
 from mypy.traverser import TraverserVisitor
 from mypy.checkexpr import has_any_type

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -4,7 +4,7 @@ import pathlib
 import re
 import subprocess
 import sys
-from typing import TypeVar, List, Tuple, Optional, Dict, Sequence
+from typing import TypeVar, List, Tuple, Optional, Dict, Sequence, Iterable
 
 MYPY = False
 if MYPY:
@@ -31,6 +31,25 @@ def split_module_names(mod_name: str) -> List[str]:
         mod_name = mod_name.rsplit('.', 1)[0]
         out.append(mod_name)
     return out
+
+
+def module_prefix(modules: Iterable[str], target: str) -> Optional[str]:
+    result = split_target(modules, target)
+    if result is None:
+        return None
+    return result[0]
+
+
+def split_target(modules: Iterable[str], target: str) -> Optional[Tuple[str, str]]:
+    remaining = []  # type: List[str]
+    while True:
+        if target in modules:
+            return target, '.'.join(remaining)
+        components = target.rsplit('.', 1)
+        if len(components) == 1:
+            return None
+        target = components[0]
+        remaining.insert(0, components[1])
 
 
 def short_type(obj: object) -> str:

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2407,3 +2407,42 @@ class C:
     def g(self) -> None: pass
 
 reveal_type(C.X)  # E: Revealed type is 'Any'
+
+[case testNewAnalyzerImportedNameUsedInClassBody]
+import m
+
+[file m.py]
+class C:
+    from mm import f
+    @dec(f)
+    def m(self): pass
+
+def dec(f): pass
+[file mm.py]
+# 1 padding to increase line number of 'f'
+# 2 padding
+# 3 padding
+# 4 padding
+# 5 padding
+# 6 padding
+def f(): pass
+
+
+[case testNewAnalyzerImportedNameUsedInClassBody2]
+import m
+
+[file m/__init__.py]
+class C:
+    from m.m import f
+    @dec(f)
+    def m(self): pass
+
+def dec(f): pass
+[file m/m.py]
+# 1 padding to increase line number of 'f'
+# 2 padding
+# 3 padding
+# 4 padding
+# 5 padding
+# 6 padding
+def f(): pass


### PR DESCRIPTION
We shouldn't use the line number of an imported name to decide
whether it's defined when the line number refers to another
file.