### PR TITLE
Fix mypy tests for contextlib change in typeshed PR 3083

### DIFF
--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1030,8 +1030,8 @@ reveal_type(g)
 with f('') as s:
     reveal_type(s)
 [out]
-_program.py:13: note: Revealed type is 'def (x: builtins.int) -> contextlib.GeneratorContextManager[builtins.str*]'
-_program.py:14: note: Revealed type is 'def (*x: builtins.str) -> contextlib.GeneratorContextManager[builtins.int*]'
+_program.py:13: note: Revealed type is 'def (x: builtins.int) -> contextlib._GeneratorContextManager[builtins.str*]'
+_program.py:14: note: Revealed type is 'def (*x: builtins.str) -> contextlib._GeneratorContextManager[builtins.int*]'
 _program.py:16: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 _program.py:17: note: Revealed type is 'builtins.str*'
 


### PR DESCRIPTION
https://github.com/python/typeshed/pull/3083 fixed an issue in the `contextlib` stub file, which broke an existing mypy test that was written based off the incorrect stub file.

*NOTE*:
This commit will have to synced with that change to fix the tests + add new `decorator` tests.