### PR TITLE
Document mypy as "beta" instead of "alpha" software

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ For more on the tests, see [Test README.md](test-data/unit/README.md)
 Development status
 ------------------
 
-Mypy is alpha software, but it has already been used in production
-for well over a year at Dropbox, and it has an extensive test suite.
+Mypy is beta software, but it has already been used in production
+for several years at Dropbox, and it has an extensive test suite.
 
 See [the roadmap](ROADMAP.md) if you are interested in plans for the
 future.

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ else:
 
 
 classifiers = [
-    'Development Status :: 3 - Alpha',
+    'Development Status :: 4 - Beta',
     'Environment :: Console',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
In https://github.com/python/mypy/issues/6740, I think we all pretty much unanimously agreed mypy ought to be labeled as "beta" at the absolute minimum.

So, might as well just do the switch now.