### PR TITLE
Enable additional tests on new semantic analyzer

### DIFF
--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -230,11 +230,11 @@ class D(object):
 [out]
 
 [case testClassNamesDefinedOnSelUsedInClassBodyReveal]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 class A(object):
     def f(self) -> None:
         self.attr = 1
-    reveal_type(attr)  # E: Revealed type is 'builtins.int'
+    attr  # E: Name 'attr' is not defined
 
 class B(object):
     attr = 0
@@ -4492,11 +4492,11 @@ x = NT(N(1))
 [out]
 
 [case testNewTypeFromForwardTypedDict]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import NewType, Tuple
 from mypy_extensions import TypedDict
 
-NT = NewType('NT', N) # E: Argument 2 to NewType(...) must be subclassable (got TypedDict('__main__.N', {'x': builtins.int}))
+NT = NewType('NT', N) # E: Argument 2 to NewType(...) must be subclassable (got "N")
 class N(TypedDict):
     x: int
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -485,12 +485,12 @@ class C:
 
 [case testFinalReassignInstanceVarClassVsInit]
 # flags: --new-semantic-analyzer
-# Methods are processed after top-level in new analyzer.
 from typing import Final
 
 class C:
     y: Final = 1
     def __init__(self) -> None:
+        # Methods are processed after top-level in new analyzer.
         self.x: Final = 1  # E: Cannot redefine an existing name as final
         self.y = 2  # E: Cannot assign to final attribute "y"
     x = 2

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -59,14 +59,14 @@ reveal_type(C().x)  # E: Revealed type is 'builtins.float'
 [out]
 
 [case testFinalInvalidDefinitions]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 # Errors are shown in a different order with the new analyzer.
 from typing import Final, Any
 
 x = y = 1  # type: Final[float]  # E: Invalid final declaration
 z: Any
-z[0]: Final[int]  # E: Unexpected type declaration \
-                  # E: Invalid final declaration
+z[0]: Final[int]  # E: Invalid final declaration \
+                  # E: Unexpected type declaration
 [out]
 
 [case testFinalDefiningInstanceVarStubs]
@@ -382,7 +382,7 @@ y
 y: Final = 3  # E: Cannot redefine an existing name as final
 
 [case testFinalReassignModuleVar3]
-# flags: --disallow-redefinition --no-new-semantic-analyzer
+# flags: --disallow-redefinition --new-semantic-analyzer
 # Error formatting is subtly different with new analyzer.
 from typing import Final
 
@@ -402,17 +402,15 @@ def f2() -> None:
 
 y = 1 # E: Cannot assign to final name "y"
 y
-y: Final = 2  # E: Name 'y' already defined on line 19 \
-              # E: Cannot redefine an existing name as final
+y: Final = 2  # E: Cannot redefine an existing name as final
 y = 3  # E: Cannot assign to final name "y"
 
 z: Final = 1
-z: Final = 2  # E: Name 'z' already defined on line 24 \
-              # E: Cannot redefine an existing name as final
+z: Final = 2  # E: Cannot redefine an existing name as final
 z = 3  # E: Cannot assign to final name "z"
 
 [case testFinalReassignModuleReexport]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 # Error formatting is subtly different with the new analyzer.
 from typing import Final
 
@@ -436,7 +434,6 @@ X: Final[int]
 [out]
 tmp/lib/const.pyi:3: error: Type in Final[...] can only be omitted if there is an initializer
 main:8: error: Cannot assign to final name "X"
-main:9: error: Name 'ID' already defined (possibly by an import)
 main:9: error: Cannot redefine an existing name as final
 main:10: error: Cannot assign to final name "ID"
 
@@ -487,16 +484,16 @@ class C:
 [out]
 
 [case testFinalReassignInstanceVarClassVsInit]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 # Methods are processed after top-level in new analyzer.
 from typing import Final
 
 class C:
     y: Final = 1
     def __init__(self) -> None:
-        self.x: Final = 1
+        self.x: Final = 1  # E: Cannot redefine an existing name as final
         self.y = 2  # E: Cannot assign to final attribute "y"
-    x = 2  # E: Cannot assign to final name "x"
+    x = 2
 [out]
 
 [case testFinalReassignInstanceVarMethod]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -56,8 +56,8 @@ main:2: error: Function is missing a return type annotation
 [case testUntypedAsyncDef]
 # flags: --disallow-untyped-defs
 async def f():  # E: Function is missing a return type annotation \
-                # N: Use "-> None" if function does not return a value                
-    pass        
+                # N: Use "-> None" if function does not return a value
+    pass
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-full.pyi]
 

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8300,9 +8300,8 @@ x = 'no way'
 ==
 main:10: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
--- Depends on #6412
 [case testNamedTupleForwardFunctionDirect]
-# flags: --ignore-missing-imports --no-new-semantic-analyzer
+# flags: --ignore-missing-imports
 from typing import NamedTuple
 from b import B
 
@@ -8314,9 +8313,8 @@ B = func
 ==
 main:5: error: Invalid type "b.B"
 
--- Depends on #6412
 [case testNamedTupleForwardFunctionIndirect]
-# flags: --ignore-missing-imports --no-new-semantic-analyzer
+# flags: --ignore-missing-imports
 from typing import NamedTuple
 from a import A
 
@@ -8331,9 +8329,8 @@ B = func
 ==
 main:5: error: Invalid type "a.A"
 
--- Depends on #6412
 [case testNamedTupleForwardFunctionIndirectReveal]
-# flags: --ignore-missing-imports --no-new-semantic-analyzer
+# flags: --ignore-missing-imports
 import m
 [file m.py]
 from typing import NamedTuple

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -756,14 +756,23 @@ class D(str): pass # ok
 [out]
 
 [case testCyclicInheritance1]
-# flags: --no-new-semantic-analyzer
-# Crashes with new semantic analyzer: https://github.com/python/mypy/issues/6495
-class A(A): pass # E: Cycle in inheritance hierarchy
+# flags: --new-semantic-analyzer
+class A(A): pass # E: Cannot resolve name "A" (possible cyclic definition)
 [out]
 
 [case testCyclicInheritance2]
+# flags: --new-semantic-analyzer
+class A(B): pass # E: Cannot resolve name "B" (possible cyclic definition)
+class B(A): pass
+[out]
+
+[case testCyclicInheritance1Old]
 # flags: --no-new-semantic-analyzer
-# Crashes with new semantic analyzer: https://github.com/python/mypy/issues/6495
+class A(A): pass # E: Cycle in inheritance hierarchy
+[out]
+
+[case testCyclicInheritance2Old]
+# flags: --no-new-semantic-analyzer
 class A(B): pass
 class B(A): pass # E: Cycle in inheritance hierarchy
 [out]


### PR DESCRIPTION
Some tests are only enabled for the new semantic analyzer. For a few
I decided to create duplicate tests, but only if the test seemed
worthwhile enough, as the old semantic analyzer isn't going to change
much any more.