### PR TITLE
Allow class-based TypedDicts in all python versions

### DIFF
--- a/mypy/newsemanal/semanal_typeddict.py
+++ b/mypy/newsemanal/semanal_typeddict.py
@@ -120,9 +120,6 @@ class TypedDictAnalyzer:
          * List of types for each key
          * Set of required keys
         """
-        if self.options.python_version < (3, 6):
-            self.fail('TypedDict class syntax is only supported in Python 3.6', defn)
-            return [], [], set()
         fields = []  # type: List[str]
         types = []  # type: List[Type]
         for stmt in defn.defs.body:

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -102,9 +102,6 @@ class TypedDictAnalyzer:
                                  oldfields: Optional[List[str]] = None) -> Tuple[List[str],
                                                                                  List[Type],
                                                                                  Set[str]]:
-        if self.options.python_version < (3, 6):
-            self.fail('TypedDict class syntax is only supported in Python 3.6', defn)
-            return [], [], set()
         fields = []  # type: List[str]
         types = []  # type: List[Type]
         for stmt in defn.defs.body:

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -128,15 +128,32 @@ reveal_type(p)  # E: Revealed type is 'TypedDict('__main__.EmptyDict', {})'
 [builtins fixtures/dict.pyi]
 
 
--- Define TypedDict (Class syntax errors)
-
 [case testCanCreateTypedDictWithClassOldVersion]
 # flags: --python-version 3.5
+
+# Test that we can use class-syntax to merge TypedDicts even in
+# versions without type annotations
+
 from mypy_extensions import TypedDict
 
-class Point(TypedDict): # E: TypedDict class syntax is only supported in Python 3.6
+MovieBase1 = TypedDict(
+    'MovieBase1', {'name': str, 'year': int})
+MovieBase2 = TypedDict(
+    'MovieBase2', {'based_on': str}, total=False)
+
+class Movie(MovieBase1, MovieBase2):
     pass
+
+def foo(x):
+    # type: (Movie) -> None
+    pass
+
+foo({})  # E: Keys ('name', 'year') missing for TypedDict "Movie"
+foo({'name': 'lol', 'year': 2009, 'based_on': 0})  # E: Incompatible types (expression has type "int", TypedDict item "based_on" has type "str")
+
 [builtins fixtures/dict.pyi]
+
+-- Define TypedDict (Class syntax errors)
 
 [case testCannotCreateTypedDictWithClassOtherBases]
 # flags: --python-version 3.6


### PR DESCRIPTION
Entries can't be *declared* in versions that don't support type
annotations, of course, but class-based TypedDict still serves a
valuable purpose in merging TypedDicts together.

This error *only* triggers on empty TypedDicts, since any non-empty
ones would have failed earlier with a syntax error. So there is no
reason to prohibit it because we can handle that case totally fine.