### PR TITLE
New analyzer: resolve name clashes between generated and existing nodes

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -4,7 +4,7 @@ import pathlib
 import re
 import subprocess
 import sys
-from typing import TypeVar, List, Tuple, Optional, Dict, Sequence, Iterable
+from typing import TypeVar, List, Tuple, Optional, Dict, Sequence, Iterable, Container
 
 MYPY = False
 if MYPY:
@@ -288,6 +288,22 @@ def hard_exit(status: int = 0) -> None:
 def unmangle(name: str) -> str:
     """Remove internal suffixes from a short name."""
     return name.rstrip("'")
+
+
+def get_unique_redefinition_name(name: str, existing: Container[str]) -> str:
+    """Get a simple redefinition name not present among existing.
+
+    For example, for name 'foo' we try 'foo-redefinition', 'foo-redefinition2',
+    'foo-redefinition3', etc. until we find one that is not in existing.
+    """
+    r_name = name + '-redefinition'
+    if r_name not in existing:
+        return r_name
+
+    i = 2
+    while r_name + str(i) in existing:
+        i += 1
+    return r_name + str(i)
 
 
 def check_python_version(program: str) -> None:

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -587,9 +587,7 @@ reveal_type(takes_base(Base(1)))  # E: Revealed type is 'builtins.int'
 reveal_type(takes_base(Child(1)))  # E: Revealed type is 'builtins.int'
 [builtins fixtures/tuple.pyi]
 
--- Depends on collecting functions via AST, not symbol tables.
 [case testNewNamedTupleIllegalNames]
-# flags: --no-new-semantic-analyzer
 from typing import Callable, NamedTuple
 
 class XMethBad(NamedTuple):
@@ -614,16 +612,16 @@ class AnnotationsAsAMethod(NamedTuple):
 
 class ReuseNames(NamedTuple):
     x: int
-    def x(self) -> str:  # E: Name 'x' already defined on line 23
+    def x(self) -> str:  # E: Name 'x' already defined on line 22
         return ''
 
     def y(self) -> int:
         return 0
-    y: str  # E: Name 'y' already defined on line 27
+    y: str  # E: Name 'y' already defined on line 26
 
 class ReuseCallableNamed(NamedTuple):
     z: Callable[[ReuseNames], int]
-    def z(self) -> int:  # E: Name 'z' already defined on line 32
+    def z(self) -> int:  # E: Name 'z' already defined on line 31
         return 0
 
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -393,9 +393,8 @@ class Application:  # E: eq must be True if order is True
 
 [builtins fixtures/list.pyi]
 
--- Blocked by #6454
 [case testDataclassOrderingWithCustomMethods]
-# flags: --python-version 3.6  --no-new-semantic-analyzer
+# flags: --python-version 3.6
 from dataclasses import dataclass
 
 @dataclass(order=True)


### PR DESCRIPTION
Fixes #6454
Fixes https://github.com/python/mypy/issues/6973

Note that the solution doesn't guarantee the order of numbers `N` in `foo-redefinitionN` coincides with the textual order of nodes. But it looks like we don't need this for anything.