### PR TITLE
Add test case for class variable forward reference

### DIFF
--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2461,3 +2461,13 @@ x: C
 reveal_type(x) # E: Revealed type is '__main__.C[Any]'
 [out]
 [out2]
+
+[case testNewAnalyzerClassVariableOrdering]
+def foo(x: str) -> None: pass
+
+class Something:
+    def run(self) -> None:
+        foo(self.IDS[0])  # E: Argument 1 to "foo" has incompatible type "int"; expected "str"
+
+    IDS = [87]
+[builtins fixtures/list.pyi]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8969,3 +8969,26 @@ class B: ...
 [builtins fixtures/list.pyi]
 [out]
 ==
+
+[case testClassVariableOrderingRefresh]
+# flags: --new-semantic-analyzer
+from b import bar
+
+def foo(x: str) -> None: pass
+
+class Something:
+    def run(self) -> None:
+        bar()
+        foo(self.IDS[0])
+
+    IDS = [87]
+
+[file b.py]
+def bar() -> int: return 0
+[file b.py.2]
+def bar() -> str: return '0'
+[builtins fixtures/list.pyi]
+[out]
+main:9: error: Argument 1 to "foo" has incompatible type "int"; expected "str"
+==
+main:9: error: Argument 1 to "foo" has incompatible type "int"; expected "str"


### PR DESCRIPTION
This is broken with the old semantic analyzer but works with the new
semantic analyzer.

Closes #4760.