### PR TITLE
Add test case for global declaration without initializer

### DIFF
--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1663,3 +1663,19 @@ N = TypedDict('N', {'x': int})
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
 [out]
+
+[case testGlobalWithoutInitialization]
+# flags: --new-semantic-analyzer
+from typing import List
+
+def foo() -> None:
+    global bar
+    # TODO: Confusing error message
+    bar = []  # type: List[str]  # E: Name 'bar' already defined (possibly by an import)
+    bar  # E: Name 'bar' is not defined
+
+def foo2():
+    global bar2
+    bar2 = []  # type: List[str]
+    bar2
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
This crashes on old semantic initializer but doesn't crash when
using the new semantic analyzer.  The error message is pretty
poor but that's better than crashing.

Closes #5923.