### PR TITLE
fix crashes with callable() and issubclass()

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3443,7 +3443,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             return None, {}
         elif isinstance(node, CallExpr):
             if refers_to_fullname(node.callee, 'builtins.isinstance'):
-                if len(node.args) != 2:  # the error will be reported later
+                if len(node.args) != 2:  # the error will be reported elsewhere
                     return {}, {}
                 expr = node.args[0]
                 if literal(expr) == LITERAL_TYPE:
@@ -3451,6 +3451,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     type = get_isinstance_type(node.args[1], type_map)
                     return conditional_type_map(expr, vartype, type)
             elif refers_to_fullname(node.callee, 'builtins.issubclass'):
+                if len(node.args) != 2:  # the error will be reported elsewhere
+                    return {}, {}
                 expr = node.args[0]
                 if literal(expr) == LITERAL_TYPE:
                     vartype = type_map[expr]
@@ -3478,6 +3480,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     yes_map, no_map = map(convert_to_typetype, (yes_map, no_map))
                     return yes_map, no_map
             elif refers_to_fullname(node.callee, 'builtins.callable'):
+                if len(node.args) != 1:  # the error will be reported elsewhere
+                    return {}, {}
                 expr = node.args[0]
                 if literal(expr) == LITERAL_TYPE:
                     vartype = type_map[expr]

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -442,3 +442,10 @@ def g(o: Thing) -> None:
         o(1,2,3)
 
 [builtins fixtures/callable.pyi]
+
+[case testCallableNoArgs]
+
+if callable():  # E: Too few arguments for "callable"
+    pass
+
+[builtins fixtures/callable.pyi]

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1830,6 +1830,18 @@ if isinstance(x): # E: Too few arguments for "isinstance"
     reveal_type(x) # E: Revealed type is 'builtins.int'
 [builtins fixtures/isinstancelist.pyi]
 
+[case testIsSubclassTooFewArgs]
+from typing import Type
+
+issubclass() # E: Too few arguments for "issubclass"
+y: Type[object]
+if issubclass(): # E: Too few arguments for "issubclass"
+    reveal_type(y) # E: Revealed type is 'Type[builtins.object]'
+if issubclass(y): # E: Too few arguments for "issubclass"
+    reveal_type(y) # E: Revealed type is 'Type[builtins.object]'
+
+[builtins fixtures/isinstancelist.pyi]
+
 [case testIsInstanceTooManyArgs]
 isinstance(1, 1, 1) # E: Too many arguments for "isinstance" \
          # E: Argument 2 to "isinstance" has incompatible type "int"; expected "Union[type, Tuple[Any, ...]]"


### PR DESCRIPTION
This fixes two possible crashes I noticed while reading the code.