### PR TITLE
New semantic analyzer: track line numbers of placeholders

### DIFF
--- a/mypy/newsemanal/semanal_newtype.py
+++ b/mypy/newsemanal/semanal_newtype.py
@@ -50,8 +50,8 @@ class NewTypeAnalyzer:
         if (not call.analyzed or
                 isinstance(call.analyzed, NewTypeExpr) and not call.analyzed.info):
             # Start from labeling this as a future class, as we do for normal ClassDefs.
-            self.api.add_symbol(name, PlaceholderNode(fullname, s, becomes_typeinfo=True), s,
-                                can_defer=False)
+            placeholder = PlaceholderNode(fullname, s, s.line, becomes_typeinfo=True)
+            self.api.add_symbol(name, placeholder, s, can_defer=False)
 
         old_type, should_defer = self.check_newtype_args(name, call, s)
         if not call.analyzed:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2792,11 +2792,12 @@ class PlaceholderNode(SymbolNode):
     something that can support general recursive types.
     """
 
-    def __init__(self, fullname: str, node: Node, becomes_typeinfo: bool = False) -> None:
+    def __init__(self, fullname: str, node: Node, line: int, *,
+                 becomes_typeinfo: bool = False) -> None:
         self._fullname = fullname
         self.node = node
         self.becomes_typeinfo = becomes_typeinfo
-        self.line = -1
+        self.line = line
 
     def name(self) -> str:
         return self._fullname.split('.')[-1]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -830,8 +830,8 @@ reveal_type(o.x.t)  # E: Revealed type is '__main__.C.Other'
 reveal_type(i.t)  # E: Revealed type is '__main__.C.Other'
 
 class C:
-    Out = NamedTuple('Out', [('x', In), ('y', Other)])
     In = NamedTuple('In', [('s', str), ('t', Other)])
+    Out = NamedTuple('Out', [('x', In), ('y', Other)])
     class Other: pass
 
 
@@ -2471,3 +2471,18 @@ class Something:
 
     IDS = [87]
 [builtins fixtures/list.pyi]
+
+[case testNewAnalyzerPlaceholderFromOuterScope]
+import b
+[file a.py]
+import b
+class A(B): ...
+class B: ...
+
+[file b.py]
+from a import A
+
+class C:
+    A = A  # Initially rvalue will be a placeholder
+
+reveal_type(C.A)  # E: Revealed type is 'def () -> a.A'


### PR DESCRIPTION
Line numbers are used sometimes to decide when a name should be looked
up from an outer scope, so they should be set for placeholders.

This actually breaks some forward references to assignment-based named
tuples. The reason is that we don't set `becomes_typeinfo=True` for
the placeholders. I'm going to open a separate issue about this, as
it's an existing issue and this change only exposes it.

Fixes #6949.