### PR TITLE
New semantic analyzer: fix crash related to dataclasses.InitVar

### DIFF
--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -520,6 +520,26 @@ app.database_name  # E: "SpecializedApplication" has no attribute "database_name
 
 [builtins fixtures/list.pyi]
 
+[case testDataclassesInitVarsAndDefer]
+# flags: --new-semantic-analyzer
+from dataclasses import InitVar, dataclass
+
+defer: Yes
+
+@dataclass
+class Application:
+  name: str
+  database_name: InitVar[str]
+
+reveal_type(Application)  # E: Revealed type is 'def (name: builtins.str, database_name: builtins.str) -> __main__.Application'
+app = Application("example", 42)  # E: Argument 2 to "Application" has incompatible type "int"; expected "str"
+app = Application("example", "apps")
+app.name
+app.database_name  # E: "Application" has no attribute "database_name"
+
+class Yes: ...
+[builtins fixtures/list.pyi]
+
 [case testDataclassFactory]
 from typing import Type, TypeVar
 from dataclasses import dataclass


### PR DESCRIPTION
Previously InitVar attributes were missing on the second semantic
analysis pass, since the dataclasses plugin removes those attributes
from the class symbol table. This caused a crash. The fix is to reset
the attribute declarations so that they will be re-added to the symbol
table on successive semantic analysis passes.

Fixes #6955.