### PR TITLE
 New semantic analyzer: Keep explicit type and inferred status in sync

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2116,6 +2116,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             return False
         lval = s.lvalues[0]
         assert isinstance(lval, RefExpr)
+        # Reset inferred status if it was set due to simple literal rvalue on previous iteration.
+        lval.is_inferred_def = s.type is None
         if self.loop_depth > 0:
             self.fail("Cannot use Final inside a loop", s)
         if self.type and self.type.is_protocol:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2118,8 +2118,13 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             return False
         lval = s.lvalues[0]
         assert isinstance(lval, RefExpr)
+
         # Reset inferred status if it was set due to simple literal rvalue on previous iteration.
-        lval.is_inferred_def = s.type is None
+        # TODO: this is a best-effort quick fix, we should avoid the need to manually sync this,
+        # see https://github.com/python/mypy/issues/6458.
+        if lval.is_new_def:
+            lval.is_inferred_def = s.type is None
+
         if self.loop_depth > 0:
             self.fail("Cannot use Final inside a loop", s)
         if self.type and self.type.is_protocol:

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2471,3 +2471,14 @@ class Something:
 
     IDS = [87]
 [builtins fixtures/list.pyi]
+
+[case testNewAnalyzerFinalLiteralInferredAsLiteralWithDeferral]
+from typing_extensions import Final, Literal
+
+defer: Yes
+
+var: Final = 42
+def force(x: Literal[42]) -> None: pass
+force(reveal_type(var))  # E: Revealed type is 'Literal[42]'
+
+class Yes: ...


### PR DESCRIPTION
This is (kind of) an actual fix for #6952

The problem is that previously `unwrap_final()` unconditionally set `s.type` to `None` for bare `Final`, even if the type was inferred from a simple literal r.h.s. on a previous iteration. At the same time `lvalue.is_inferred_def` remained `False`, so that the type was not inferred on the second iteration.

This way `s.type` and `lvalue.is_inferred_def` may get out of sync depending on the number of iterations, thus causing weird behavior in type checker.

I generally can say the current way of storing the inferred status is error-prone, but we already have https://github.com/python/mypy/issues/6458 to track this.