### PR TITLE
Mark TypedDict as not experimental

### DIFF
--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -740,11 +740,6 @@ and one
 TypedDict
 *********
 
-.. note::
-
-   TypedDict is an officially supported feature, but it is still experimental.
-
-
 Python programs often use dictionaries with string keys to represent objects.
 Here is a typical example:
 


### PR DESCRIPTION
It's no longer experimental since PEP 589 was accepted:
https://www.python.org/dev/peps/pep-0589/