### PR TITLE
New semantic analyzer: don't add submodules to symbol tables

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1876,20 +1876,17 @@ class State:
         details.
 
         However, this patching process can occur after `a` has been parsed and
-        serialized during increment mode. Consequently, we need to repeat this
+        serialized during incremental mode. Consequently, we need to repeat this
         patch when deserializing a cached file.
 
         This function should be called only when processing fresh SCCs -- the
         semantic analyzer will perform this patch for us when processing stale
         SCCs.
         """
-        Analyzer = Union[SemanticAnalyzerPass2, NewSemanticAnalyzer]  # noqa
-        if self.manager.options.new_semantic_analyzer:
-            analyzer = self.manager.new_semantic_analyzer  # type: Analyzer
-        else:
+        if not self.manager.options.new_semantic_analyzer:
             analyzer = self.manager.semantic_analyzer
-        for dep in self.dependencies:
-            analyzer.add_submodules_to_parent_modules(dep, True)
+            for dep in self.dependencies:
+                analyzer.add_submodules_to_parent_modules(dep, True)
 
     def fix_suppressed_dependencies(self, graph: Graph) -> None:
         """Corrects whether dependencies are considered stale in silent mode.

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3803,6 +3803,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         """
         module = node.fullname()
         names = node.names
+        # Rebind potential references to old version of current module in
+        # fine-grained incremental mode.
+        if module == self.cur_mod_id:
+            names = self.globals
         part = parts[0]
         sym = names.get(part, None)
         if not sym:
@@ -3826,8 +3830,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 sym = SymbolTableNode(GDEF, v)
         elif sym.module_hidden:
             sym = None
-        else:
-            sym = self.rebind_symbol_table_node(sym)
         return sym
 
     def is_missing_module(self, module: str) -> bool:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -99,9 +99,7 @@ from mypy.plugin import (
     Plugin, ClassDefContext, SemanticAnalyzerPluginInterface,
     DynamicClassDefContext
 )
-from mypy.util import (
-    get_prefix, correct_relative_import, unmangle, module_prefix
-)
+from mypy.util import correct_relative_import, unmangle, module_prefix
 from mypy.scope import Scope
 from mypy.newsemanal.semanal_shared import (
     SemanticAnalyzerInterface, set_callable_name, calculate_tuple_fallback, PRIORITY_FALLBACKS

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3813,16 +3813,16 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             submodule = module + '.' + part
             if submodule in self.modules:
                 sym = SymbolTableNode(GDEF, self.modules[submodule])
+            elif self.is_incomplete_namespace(module):
+                self.record_incomplete_ref()
             elif ('__getattr__' in names
-                    and not self.is_incomplete_namespace(module)
-                    and (node.is_stub or self.options.python_version >= (3, 7))):
+                    and (node.is_stub
+                         or self.options.python_version >= (3, 7))):
                 fullname = module + '.' + '.'.join(parts)
                 gvar = self.create_getattr_var(names['__getattr__'],
                                                parts[0], fullname)
                 if gvar:
                     sym = SymbolTableNode(GDEF, gvar)
-            elif self.is_incomplete_namespace(node.fullname()):
-                self.record_incomplete_ref()
             elif self.is_missing_module(submodule):
                 var_type = AnyType(TypeOfAny.from_unimported_type)
                 v = Var(part, type=var_type)

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3766,11 +3766,11 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         if sym:
             for i in range(1, len(parts)):
                 node = sym.node
-                name = parts[i]
+                part = parts[i]
                 if isinstance(node, TypeInfo):
-                    nextsym = node.get(name)
+                    nextsym = node.get(part)
                 elif isinstance(node, MypyFile):
-                    nextsym = self.get_module_symbol(node, name)
+                    nextsym = self.get_module_symbol(node, part)
                     namespace = node.fullname()
                 elif isinstance(node, PlaceholderNode):
                     return sym

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3803,10 +3803,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         """
         module = node.fullname()
         names = node.names
-        # Rebind potential references to old version of current module in
-        # fine-grained incremental mode.
-        if module == self.cur_mod_id:
-            names = self.globals
         part = parts[0]
         sym = names.get(part, None)
         if not sym:
@@ -3830,6 +3826,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 sym = SymbolTableNode(GDEF, v)
         elif sym.module_hidden:
             sym = None
+        else:
+            sym = self.rebind_symbol_table_node(sym)
         return sym
 
     def is_missing_module(self, module: str) -> bool:

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3821,13 +3821,13 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                                                parts[0], fullname)
                 if gvar:
                     sym = SymbolTableNode(GDEF, gvar)
+            elif self.is_incomplete_namespace(node.fullname()):
+                self.record_incomplete_ref()
             elif self.is_missing_module(submodule):
                 var_type = AnyType(TypeOfAny.from_unimported_type)
                 v = Var(part, type=var_type)
                 v._fullname = submodule
                 sym = SymbolTableNode(GDEF, v)
-            elif self.is_incomplete_namespace(node.fullname()):
-                self.record_incomplete_ref()
         elif sym.module_hidden:
             sym = None
         return sym

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1653,7 +1653,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             # If it is still not resolved, check for a module level __getattr__
             if (module and not node and (module.is_stub or self.options.python_version >= (3, 7))
                     and '__getattr__' in module.names):
-                # We use the fullname of the orignal definition so that we can
+                # We use the fullname of the original definition so that we can
                 # detect whether two imported names refer to the same thing.
                 fullname = import_id + '.' + id
                 gvar = self.create_getattr_var(module.names['__getattr__'], imported_id, fullname)
@@ -3416,9 +3416,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
     def visit_member_expr(self, expr: MemberExpr) -> None:
         base = expr.expr
         base.accept(self)
-        # Bind references to module attributes.
         if isinstance(base, RefExpr) and isinstance(base.node, MypyFile):
-            # Handle 'module.foo'.
+            # Handle module attribute.
             sym = self.get_module_symbol(base.node, expr.name)
             if sym:
                 if isinstance(sym.node, PlaceholderNode):
@@ -3822,6 +3821,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                 if gvar:
                     sym = SymbolTableNode(GDEF, gvar)
             elif self.is_missing_module(fullname):
+                # We use the fullname of the original definition so that we can
+                # detect whether two names refer to the same thing.
                 var_type = AnyType(TypeOfAny.from_unimported_type)
                 v = Var(name, type=var_type)
                 v._fullname = fullname

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2557,6 +2557,10 @@ import whatever.works
 import a.b
 x = whatever.works.f()
 y = a.b.f()
+xx: whatever.works.C
+yy: a.b.C
+xx2: whatever.works.C.D
+yy2: a.b.C.D
 [file a/__init__.pyi]
 # empty
 [out]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2511,3 +2511,8 @@ get = api.get
 import p
 
 def get() -> int: ...
+
+[case testUseObsoleteNameForTypeVar3]
+import typing
+t = typing.typevar('t') # E: Module has no attribute "typevar"
+[builtins fixtures/module.pyi]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2497,3 +2497,17 @@ def force(x: Literal[42]) -> None: pass
 force(reveal_type(var))  # E: Revealed type is 'Literal[42]'
 
 class Yes: ...
+
+[case testNewAnalyzerImportCycleWithIgnoreMissingImports]
+# flags: --ignore-missing-imports
+import p
+reveal_type(p.get)  # E: Revealed type is 'def () -> builtins.int'
+
+[file p/__init__.pyi]
+from . import api
+get = api.get
+
+[file p/api.pyi]
+import p
+
+def get() -> int: ...

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -812,6 +812,7 @@ class Baz:
 ==
 
 [case testDeleteFileWithinPackage]
+# flags: --new-semantic-analyzer
 import a
 [file a.py]
 import m.x
@@ -826,6 +827,7 @@ a.py:2: error: Too many arguments for "g"
 ==
 a.py:1: error: Cannot find module named 'm.x'
 a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
+a.py:2: error: Module has no attribute "x"
 
 [case testDeletePackage1]
 import p.a
@@ -859,6 +861,7 @@ main:1: error: Cannot find module named 'p'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testDeletePackage3]
+# flags: --new-semantic-analyzer
 import p.a
 p.a.f(1)
 [file p/__init__.py]
@@ -868,14 +871,15 @@ def f(x: str) -> None: pass
 [delete p/__init__.py.3]
 [builtins fixtures/module.pyi]
 [out]
-main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
+main:3: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
-main:1: error: Cannot find module named 'p.a'
-main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
+main:2: error: Cannot find module named 'p.a'
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
+main:3: error: Module has no attribute "a"
 ==
-main:1: error: Cannot find module named 'p.a'
-main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:1: error: Cannot find module named 'p'
+main:2: error: Cannot find module named 'p.a'
+main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
+main:2: error: Cannot find module named 'p'
 
 [case testDeletePackage4]
 import p.a

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1277,7 +1277,7 @@ main:1: note: Did you forget to import it from "typing"? (Suggestion: "from typi
 import typing
 t = typing.typevar('t')
 [out]
-main:2: error: Module 'typing' has no attribute 'typevar' (it's now called 'typing.TypeVar')
+main:3: error: Module 'typing' has no attribute 'typevar' (it's now called 'typing.TypeVar')
 
 [case testInvalidTypeAnnotation]
 import typing

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1273,11 +1273,11 @@ main:1: error: Name 'typevar' is not defined
 main:1: note: Did you forget to import it from "typing"? (Suggestion: "from typing import TypeVar")
 
 [case testUseObsoleteNameForTypeVar3]
+# flags: --no-new-semantic-analyzer
 import typing
 t = typing.typevar('t')
 [out]
 main:2: error: Module 'typing' has no attribute 'typevar' (it's now called 'typing.TypeVar')
---' (work around syntax highlighting :-/)
 
 [case testInvalidTypeAnnotation]
 import typing


### PR DESCRIPTION
Previously we added each submodule implicitly to the the symbol table of
the parent package. This PR removes this and instead we look up names from
the modules dictionary if they aren't found in the symbol table. The change
only affects the new semantic analyzer.

This provides the foundation that should make it easier to fix #6828. It also 
arguably cleans up the code.

Also refactor some related code to avoid duplication.

This isn't a pure refactor since some error messages are slightly different.
