### PR TITLE
Expand environment variables in cache_dir config

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -392,6 +392,8 @@ section of the command line docs.
 
 ``cache_dir`` (string, default ``.mypy_cache``)
     Specifies the location where mypy stores incremental cache info.
+    User home directory and environment variables will be expanded.
+
     Note that the cache is only read when incremental mode is enabled
     but is always written to, unless the value is set to ``/dev/nul``
     (UNIX) or ``nul`` (Windows).

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -208,7 +208,7 @@ def parse_section(prefix: str, template: Options,
             print("%s%s: %s" % (prefix, key, err), file=stderr)
             continue
         if key == 'cache_dir':
-            v = os.path.expanduser(v)
+            v = os.path.expandvars(os.path.expanduser(v))
         if key == 'silent_imports':
             print("%ssilent_imports has been replaced by "
                   "ignore_missing_imports=True; follow_imports=skip" % prefix, file=stderr)


### PR DESCRIPTION
This further extends parsing of the 'cache_dir' configuration option (as originally introduced by #6651) to do environment variable expansion in addition to user home directory expansion. This makes it much easier to integrate mypy with other tools as well as making it possible to create more generic configuration files.