### PR TITLE
Use some more dogfooding

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -1,10 +1,8 @@
-from typing import Dict, List, Set, Iterator, Union, Optional, Tuple, cast
 from contextlib import contextmanager
 from collections import defaultdict
 
-MYPY = False
-if MYPY:
-    from typing import DefaultDict
+from typing import Dict, List, Set, Iterator, Union, Optional, Tuple, cast
+from typing_extensions import DefaultDict
 
 from mypy.types import Type, AnyType, PartialType, UnionType, TypeOfAny, NoneType
 from mypy.subtypes import is_subtype
@@ -35,10 +33,7 @@ class Frame:
         self.unreachable = False
 
 
-if MYPY:
-    # This is the type of stored assignments for union type rvalues.
-    # We use 'if MYPY: ...' since typing-3.5.1 does not have 'DefaultDict'
-    Assigns = DefaultDict[Expression, List[Tuple[Type, Optional[Type]]]]
+Assigns = DefaultDict[Expression, List[Tuple[Type, Optional[Type]]]]
 
 
 class ConditionalTypeBinder:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -25,11 +25,7 @@ import types
 
 from typing import (AbstractSet, Any, Dict, Iterable, Iterator, List,
                     Mapping, NamedTuple, Optional, Set, Tuple, Union, Callable, TextIO)
-MYPY = False
-if MYPY:
-    from typing import ClassVar
-    from typing_extensions import Final
-
+from typing_extensions import ClassVar, Final, TYPE_CHECKING
 from mypy_extensions import TypedDict
 
 from mypy.nodes import MypyFile, ImportBase, Import, ImportFrom, ImportAll, SymbolTable
@@ -45,7 +41,7 @@ from mypy.errors import Errors, CompileError, ErrorInfo, report_internal_error
 from mypy.util import (
     DecodeError, decode_python_encoding, is_sub_path, get_mypy_comments, module_prefix
 )
-if MYPY:
+if TYPE_CHECKING:
     from mypy.report import Reports  # Avoid unconditional slow import
 from mypy import moduleinfo
 from mypy.fixup import fixup_module

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -8,6 +8,7 @@ from typing import (
     Dict, Set, List, cast, Tuple, TypeVar, Union, Optional, NamedTuple, Iterator, Iterable,
     Sequence
 )
+from typing_extensions import Final
 
 from mypy.errors import Errors, report_internal_error
 from mypy.nodes import (
@@ -67,11 +68,6 @@ from mypy.scope import Scope
 from mypy.typeops import tuple_fallback
 from mypy import state
 from mypy.traverser import has_return_statement
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
 
 T = TypeVar('T')
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5,10 +5,7 @@ from contextlib import contextmanager
 from typing import (
     cast, Dict, Set, List, Tuple, Callable, Union, Optional, Sequence, Iterator
 )
-MYPY = False
-if MYPY:
-    from typing import ClassVar
-    from typing_extensions import Final
+from typing_extensions import ClassVar, Final
 
 from mypy.errors import report_internal_error
 from mypy.typeanal import (

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -1,6 +1,7 @@
 """Type checking of attribute access"""
 
 from typing import cast, Callable, List, Optional, TypeVar, Union
+from typing_extensions import TYPE_CHECKING
 
 from mypy.types import (
     Type, Instance, AnyType, TupleType, TypedDictType, CallableType, FunctionLike, TypeVarDef,
@@ -25,8 +26,7 @@ from mypy import subtypes
 from mypy import meet
 from mypy.typeops import tuple_fallback
 
-MYPY = False
-if MYPY:  # import for forward declaration only
+if TYPE_CHECKING:  # import for forward declaration only
     import mypy.checker
 
 from mypy import state

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -3,6 +3,7 @@
 import re
 
 from typing import cast, List, Tuple, Dict, Callable, Union, Optional, Pattern
+from typing_extensions import Final, TYPE_CHECKING
 
 from mypy.types import (
     Type, AnyType, TupleType, Instance, UnionType, TypeOfAny
@@ -11,12 +12,10 @@ from mypy.nodes import (
     StrExpr, BytesExpr, UnicodeExpr, TupleExpr, DictExpr, Context, Expression, StarExpr
 )
 
-MYPY = False
-if MYPY:
+if TYPE_CHECKING:
     # break import cycle only needed for mypy
     import mypy.checker
     import mypy.checkexpr
-    from typing_extensions import Final
 from mypy import message_registry
 from mypy.messages import MessageBuilder
 

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -6,15 +6,11 @@ import os
 import re
 import sys
 
+from typing import Any, Dict, List, Mapping, Optional, Tuple, TextIO
+from typing_extensions import Final
+
 from mypy import defaults
 from mypy.options import Options, PER_MODULE_OPTIONS
-
-from typing import Any, Dict, List, Mapping, Optional, Tuple, TextIO
-
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 
 def parse_version(v: str) -> Tuple[int, int]:

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -1,6 +1,7 @@
 """Type inference constraints."""
 
 from typing import Iterable, List, Optional, Sequence
+from typing_extensions import Final
 
 from mypy.types import (
     CallableType, Type, TypeVisitor, UnboundType, AnyType, NoneType, TypeVarType, Instance,
@@ -14,11 +15,6 @@ import mypy.typeops
 from mypy.erasetype import erase_typevars
 from mypy.nodes import COVARIANT, CONTRAVARIANT
 from mypy.argmap import ArgTypeExpander
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
 
 SUBTYPE_OF = 0  # type: Final[int]
 SUPERTYPE_OF = 1  # type: Final[int]

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -1,8 +1,6 @@
 import os
 
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
+from typing_extensions import Final
 
 PYTHON2_VERSION = (2, 7)  # type: Final
 PYTHON3_VERSION = (3, 6)  # type: Final

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -17,6 +17,7 @@ import traceback
 from contextlib import redirect_stderr, redirect_stdout
 
 from typing import AbstractSet, Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing_extensions import Final
 
 import mypy.build
 import mypy.errors
@@ -32,11 +33,6 @@ from mypy.options import Options
 from mypy.suggestions import SuggestionFailure, SuggestionEngine
 from mypy.typestate import reset_global_state
 from mypy.version import __version__
-
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 MEM_PROFILE = False  # type: Final  # If True, dump memory profile after initialization
 

--- a/mypy/dmypy_util.py
+++ b/mypy/dmypy_util.py
@@ -6,12 +6,9 @@ This should be pretty lightweight and not depend on other mypy code (other than 
 import json
 
 from typing import Any
+from typing_extensions import Final
 
 from mypy.ipc import IPCBase
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 DEFAULT_STATUS_FILE = '.dmypy.json'  # type: Final
 

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -4,14 +4,11 @@ import traceback
 from collections import OrderedDict, defaultdict
 
 from typing import Tuple, List, TypeVar, Set, Dict, Optional, TextIO
+from typing_extensions import Final
 
 from mypy.scope import Scope
 from mypy.options import Options
 from mypy.version import __version__ as mypy_version
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 T = TypeVar('T')
 allowed_duplicates = ['@overload', 'Got:', 'Expected:']  # type: Final

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1,13 +1,11 @@
 import re
 import sys
 
+import typing  # for typing.Type, which conflicts with types.Type
 from typing import (
     Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, Dict, cast, List, overload, Set
 )
-MYPY = False
-if MYPY:
-    import typing  # for typing.Type, which conflicts with types.Type
-    from typing_extensions import Final, Literal
+from typing_extensions import Final, Literal
 
 from mypy.sharedparse import (
     special_function_elide_names, argument_elide_name,

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -16,11 +16,9 @@ two in a typesafe way.
 """
 import sys
 
+import typing  # for typing.Type, which conflicts with types.Type
 from typing import Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, Dict, cast, List, Set
-MYPY = False
-if MYPY:
-    import typing  # for typing.Type, which conflicts with types.Type
-    from typing_extensions import Final, Literal
+from typing_extensions import Final, Literal
 
 from mypy.sharedparse import (
     special_function_elide_names, argument_elide_name,

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -3,14 +3,11 @@
 import os.path
 
 from typing import List, Sequence, Set, Tuple, Optional, Dict
+from typing_extensions import Final
 
 from mypy.modulefinder import BuildSource, PYTHON_EXTENSIONS
 from mypy.fscache import FileSystemCache
 from mypy.options import Options
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 PY_EXTENSIONS = tuple(PYTHON_EXTENSIONS)  # type: Final
 

--- a/mypy/interpreted_plugin.py
+++ b/mypy/interpreted_plugin.py
@@ -1,13 +1,14 @@
 """Hack for handling non-mypyc compiled plugins with a mypyc-compiled mypy"""
 
 from typing import Optional, Callable, Any, Dict, List, Tuple
+from typing_extensions import TYPE_CHECKING
+
 from mypy.options import Options
 from mypy.types import Type, CallableType
 from mypy.nodes import SymbolTableNode, MypyFile
 from mypy.lookup import lookup_fully_qualified
 
-MYPY = False
-if MYPY:
+if TYPE_CHECKING:
     import mypy.plugin
 
 

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -11,11 +11,7 @@ import sys
 import tempfile
 
 from typing import Optional, Callable
-
-MYPY = False
-if MYPY:
-    from typing import Type
-    from typing_extensions import Final
+from typing_extensions import Final, Type
 
 from types import TracebackType
 

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -1,4 +1,5 @@
 from typing import Optional, Union, Any, Tuple, Iterable
+from typing_extensions import Final
 
 from mypy.nodes import (
     Expression, ComparisonExpr, OpExpr, MemberExpr, UnaryExpr, StarExpr, IndexExpr, LITERAL_YES,
@@ -10,10 +11,6 @@ from mypy.nodes import (
     TypedDictExpr, NewTypeExpr, PromoteExpr, AwaitExpr, TempNode,
 )
 from mypy.visitor import ExpressionVisitor
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 # [Note Literals and literal_hash]
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -7,6 +7,7 @@ import sys
 import time
 
 from typing import Any, Dict, List, Optional, Tuple, TextIO
+from typing_extensions import Final
 
 from mypy import build
 from mypy import defaults
@@ -22,13 +23,7 @@ from mypy.split_namespace import SplitNamespace
 
 from mypy.version import __version__
 
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
-
 orig_stat = os.stat  # type: Final
-
 MEM_PROFILE = False  # type: Final  # If True, dump memory profile
 
 

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -6,18 +6,12 @@ ultimately consumed by messages.MessageBuilder.fail(). For more non-trivial mess
 add a method to MessageBuilder and call this instead.
 """
 
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
+from typing_extensions import Final
 
 # Invalid types
-
 INVALID_TYPE_RAW_ENUM_VALUE = "Invalid type: try using Literal[{}.{}] instead?"  # type: Final
 
-
-# Type checker error message constants --
-
+# Type checker error message constants
 NO_RETURN_VALUE_EXPECTED = 'No return value expected'  # type: Final
 MISSING_RETURN_STATEMENT = 'Missing return statement'  # type: Final
 INVALID_IMPLICIT_RETURN = 'Implicit return in function which does not return'  # type: Final

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -15,6 +15,7 @@ import difflib
 from textwrap import dedent
 
 from typing import cast, List, Dict, Any, Sequence, Iterable, Tuple, Set, Optional, Union
+from typing_extensions import Final
 
 from mypy.erasetype import erase_type
 from mypy.errors import Errors
@@ -31,11 +32,6 @@ from mypy.nodes import (
 )
 from mypy.util import unmangle
 from mypy import message_registry
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
 
 ARG_CONSTRUCTOR_NAMES = {
     ARG_POS: "Arg",

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -11,10 +11,7 @@ import subprocess
 import sys
 
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
+from typing_extensions import Final
 
 from mypy.defaults import PYTHON3_VERSION_MIN
 from mypy.fscache import FileSystemCache

--- a/mypy/moduleinfo.py
+++ b/mypy/moduleinfo.py
@@ -13,11 +13,7 @@ no stub for a module.
 """
 
 from typing import Set
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
+from typing_extensions import Final
 
 third_party_modules = {
     # From https://hugovk.github.io/top-pypi-packages/

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -52,6 +52,7 @@ from contextlib import contextmanager
 from typing import (
     List, Dict, Set, Tuple, cast, TypeVar, Union, Optional, Callable, Iterator, Iterable,
 )
+from typing_extensions import Final
 
 from mypy.nodes import (
     MypyFile, TypeInfo, Node, AssignmentStmt, FuncDef, OverloadedFuncDef,
@@ -114,12 +115,7 @@ from mypy.reachability import (
 )
 from mypy.mro import calculate_mro, MroError
 
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
 T = TypeVar('T')
-
 
 # Map from the full name of a missing definition to the test fixture (under
 # test-data/unit/fixtures/) that provides the definition. This is used for

--- a/mypy/newsemanal/semanal_classprop.py
+++ b/mypy/newsemanal/semanal_classprop.py
@@ -4,6 +4,7 @@ These happen after semantic analysis and before type checking.
 """
 
 from typing import List, Set, Optional
+from typing_extensions import Final
 
 from mypy.nodes import (
     Node, TypeInfo, Var, Decorator, OverloadedFuncDef, SymbolTable, CallExpr, PromoteExpr,
@@ -11,11 +12,6 @@ from mypy.nodes import (
 from mypy.types import Instance, Type
 from mypy.errors import Errors
 from mypy.options import Options
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
 
 # Hard coded type promotions (shared between all Python versions).
 # These add extra ad-hoc edges to the subtyping relation. For example,

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -26,6 +26,7 @@ will be incomplete.
 
 import contextlib
 from typing import List, Tuple, Optional, Union, Callable, Iterator
+from typing_extensions import TYPE_CHECKING
 
 from mypy.nodes import (
     MypyFile, TypeInfo, FuncDef, Decorator, OverloadedFuncDef, Var
@@ -45,8 +46,7 @@ from mypy.checker import FineGrainedDeferredNode
 from mypy.server.aststripnew import SavedAttributes
 import mypy.build
 
-MYPY = False
-if MYPY:
+if TYPE_CHECKING:
     from mypy.build import Graph, State
 
 

--- a/mypy/newsemanal/semanal_namedtuple.py
+++ b/mypy/newsemanal/semanal_namedtuple.py
@@ -5,6 +5,7 @@ This is conceptually part of mypy.newsemanal.semanal.
 
 from contextlib import contextmanager
 from typing import Tuple, List, Dict, Mapping, Optional, Union, cast, Iterator
+from typing_extensions import Final
 
 from mypy.types import (
     Type, TupleType, AnyType, TypeOfAny, TypeVarDef, CallableType, TypeType, TypeVarType
@@ -21,10 +22,6 @@ from mypy.nodes import (
 from mypy.options import Options
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.util import get_unique_redefinition_name
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 # Matches "_prohibited" in typing.py, but adds __annotations__, which works at runtime but can't
 # easily be supported in a static checker.

--- a/mypy/newsemanal/semanal_shared.py
+++ b/mypy/newsemanal/semanal_shared.py
@@ -1,7 +1,9 @@
 """Shared definitions used by different parts of semantic analysis."""
 
 from abc import abstractmethod, abstractproperty
+
 from typing import Optional, List, Callable
+from typing_extensions import Final
 from mypy_extensions import trait
 
 from mypy.nodes import (
@@ -12,10 +14,6 @@ from mypy.util import correct_relative_import
 from mypy.types import Type, FunctionLike, Instance, TupleType, TPDICT_FB_NAMES
 from mypy.tvar_scope import TypeVarScope
 from mypy import join
-
-MYPY = False
-if False:
-    from typing_extensions import Final
 
 # Priorities for ordering of patches within the "patch" phase of semantic analysis
 # (after the main pass):

--- a/mypy/newsemanal/semanal_typeddict.py
+++ b/mypy/newsemanal/semanal_typeddict.py
@@ -2,6 +2,7 @@
 
 from collections import OrderedDict
 from typing import Optional, List, Set, Tuple, cast
+from typing_extensions import Final
 
 from mypy.types import Type, AnyType, TypeOfAny, TypedDictType, TPDICT_NAMES
 from mypy.nodes import (
@@ -14,10 +15,6 @@ from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.options import Options
 from mypy.newsemanal.typeanal import check_for_explicit_any, has_any_from_unimported_type
 from mypy.messages import MessageBuilder
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 TPDICT_CLASS_ERROR = ('Invalid statement in TypedDict definition; '
                       'expected "field_name: field_type"')  # type: Final

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -1,13 +1,12 @@
 """Semantic analysis of types"""
 
-from collections import OrderedDict
-from typing import Callable, List, Optional, Set, Tuple, Iterator, TypeVar, Iterable
-
-from itertools import chain
-
-from contextlib import contextmanager
-
 import itertools
+from itertools import chain
+from contextlib import contextmanager
+from collections import OrderedDict
+
+from typing import Callable, List, Optional, Set, Tuple, Iterator, TypeVar, Iterable
+from typing_extensions import Final
 
 from mypy.messages import MessageBuilder
 from mypy.options import Options
@@ -32,12 +31,7 @@ from mypy.plugin import Plugin, TypeAnalyzerPluginInterface, AnalyzeTypeContext
 from mypy.newsemanal.semanal_shared import SemanticAnalyzerCoreInterface
 from mypy import nodes, message_registry
 
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
 T = TypeVar('T')
-
 
 type_constructors = {
     'typing.Callable',

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -6,12 +6,8 @@ from collections import OrderedDict, defaultdict
 from typing import (
     Any, TypeVar, List, Tuple, cast, Set, Dict, Union, Optional, Callable, Sequence, Iterator
 )
+from typing_extensions import DefaultDict, Final, TYPE_CHECKING
 from mypy_extensions import trait
-
-MYPY = False
-if MYPY:
-    from typing import DefaultDict
-    from typing_extensions import Final
 
 import mypy.strconv
 from mypy.util import short_type
@@ -59,7 +55,7 @@ class Context:
         return self.column
 
 
-if MYPY:
+if TYPE_CHECKING:
     # break import cycle only needed for mypy
     import mypy.types
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -4,9 +4,7 @@ import pprint
 import sys
 
 from typing import Dict, List, Mapping, Optional, Pattern, Set, Tuple
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
+from typing_extensions import Final
 
 from mypy import defaults
 from mypy.util import get_class_descriptors, replace_object_state

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -1,6 +1,8 @@
 """Plugin for supporting the attrs library (http://www.attrs.org)"""
 from collections import OrderedDict
+
 from typing import Optional, Dict, List, cast, Tuple, Iterable
+from typing_extensions import Final
 
 import mypy.plugin  # To avoid circular imports.
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
@@ -22,10 +24,6 @@ from mypy.types import (
 from mypy.typevars import fill_typevars
 from mypy.util import unmangle
 from mypy.server.trigger import make_wildcard_trigger
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 KW_ONLY_PYTHON_2_UNSUPPORTED = "kw_only is not supported in Python 2"
 

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -1,7 +1,9 @@
 """Plugin that provides support for dataclasses."""
 
 from collections import OrderedDict
+
 from typing import Dict, List, Set, Tuple
+from typing_extensions import Final
 
 from mypy.nodes import (
     ARG_OPT, ARG_POS, MDEF, Argument, AssignmentStmt, CallExpr,
@@ -12,10 +14,6 @@ from mypy.plugin import ClassDefContext
 from mypy.plugins.common import add_method, _get_decorator_bool_argument
 from mypy.types import Instance, NoneType, TypeVarDef, TypeVarType
 from mypy.server.trigger import make_wildcard_trigger
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 # The set of decorators that generate dataclasses.
 dataclass_makers = {

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -11,9 +11,8 @@ we actually bake some of it directly in to the semantic analysis layer (see
 semanal_enum.py).
 """
 from typing import Optional
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
+from typing_extensions import Final
+
 import mypy.plugin  # To avoid circular imports.
 from mypy.types import Type, Instance, LiteralType
 

--- a/mypy/reachability.py
+++ b/mypy/reachability.py
@@ -1,6 +1,7 @@
 """Utilities related to determining the reachability of code (in semantic analysis)."""
 
 from typing import Tuple, TypeVar, Union, Optional
+from typing_extensions import Final
 
 from mypy.nodes import (
     Expression, IfStmt, Block, AssertStmt, NameExpr, UnaryExpr, MemberExpr, OpExpr, ComparisonExpr,
@@ -10,11 +11,6 @@ from mypy.nodes import (
 from mypy.options import Options
 from mypy.traverser import TraverserVisitor
 from mypy.literals import literal
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
 
 # Inferred truth value of an expression.
 ALWAYS_TRUE = 1  # type: Final

--- a/mypy/renaming.py
+++ b/mypy/renaming.py
@@ -1,4 +1,5 @@
 from typing import Dict, List
+from typing_extensions import Final
 
 from mypy.nodes import (
     Block, AssignmentStmt, NameExpr, MypyFile, FuncDef, Lvalue, ListExpr, TupleExpr,
@@ -6,11 +7,6 @@ from mypy.nodes import (
     MemberExpr, IndexExpr, Import, ClassDef
 )
 from mypy.traverser import TraverserVisitor
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
 
 # Scope kinds
 FILE = 0  # type: Final

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -6,16 +6,15 @@ import json
 import os
 import shutil
 import tokenize
-import typing
+import time
+import sys
+import itertools
 from operator import attrgetter
 from urllib.request import pathname2url
+
+import typing
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
-
-import time
-
-import sys
-
-import itertools
+from typing_extensions import Final
 
 from mypy.nodes import MypyFile, Expression, FuncDef
 from mypy import stats
@@ -24,10 +23,6 @@ from mypy.traverser import TraverserVisitor
 from mypy.types import Type, TypeOfAny
 from mypy.version import __version__
 from mypy.defaults import REPORTER_NAMES
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 try:
     # mypyc doesn't properly handle import from of submodules that we

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -37,6 +37,7 @@ from contextlib import contextmanager
 from typing import (
     List, Dict, Set, Tuple, cast, TypeVar, Union, Optional, Callable, Iterator, Iterable,
 )
+from typing_extensions import Final
 
 from mypy.nodes import (
     MypyFile, TypeInfo, Node, AssignmentStmt, FuncDef, OverloadedFuncDef,
@@ -100,12 +101,7 @@ from mypy.reachability import (
 )
 from mypy.mro import calculate_mro, MroError
 
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
 T = TypeVar('T')
-
 
 # Map from obsolete name to the current spelling.
 obsolete_name_mapping = {

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -4,6 +4,7 @@ This is conceptually part of mypy.semanal (semantic analyzer pass 2).
 """
 
 from typing import Tuple, List, Dict, Mapping, Optional, Union, cast
+from typing_extensions import Final
 
 from mypy.types import (
     Type, TupleType, AnyType, TypeOfAny, TypeVarType, TypeVarDef, CallableType, TypeType
@@ -18,10 +19,6 @@ from mypy.nodes import (
 from mypy.options import Options
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy import join
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 # Matches "_prohibited" in typing.py, but adds __annotations__, which works at runtime but can't
 # easily be supported in a static checker.

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -1,7 +1,9 @@
 """Shared definitions used by different parts of semantic analysis."""
 
 from abc import abstractmethod, abstractproperty
+
 from typing import Optional, List, Callable
+from typing_extensions import Final
 from mypy_extensions import trait
 
 from mypy.nodes import (
@@ -10,10 +12,6 @@ from mypy.nodes import (
 from mypy.util import correct_relative_import
 from mypy.types import Type, FunctionLike, Instance, TPDICT_FB_NAMES
 from mypy.tvar_scope import TypeVarScope
-
-MYPY = False
-if False:
-    from typing_extensions import Final
 
 # Priorities for ordering of patches within the final "patch" phase of semantic analysis
 # (after pass 3):

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -4,7 +4,9 @@ This is conceptually part of mypy.semanal (semantic analyzer pass 2).
 """
 
 from collections import OrderedDict
+
 from typing import Optional, List, Set, Tuple, cast
+from typing_extensions import Final
 
 from mypy.types import Type, AnyType, TypeOfAny, TypedDictType, TPDICT_NAMES
 from mypy.nodes import (
@@ -17,10 +19,6 @@ from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.options import Options
 from mypy.typeanal import check_for_explicit_any, has_any_from_unimported_type
 from mypy.messages import MessageBuilder
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 TPDICT_CLASS_ERROR = ('Invalid statement in TypedDict definition; '
                       'expected "field_name: field_type"')  # type: Final

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -80,10 +80,7 @@ Test cases for this module live in 'test-data/unit/deps*.test'.
 """
 
 from typing import Dict, List, Set, Optional, Tuple
-
-MYPY = False
-if MYPY:
-    from typing import DefaultDict
+from typing_extensions import DefaultDict
 
 from mypy.checkmember import bind_self
 from mypy.nodes import (

--- a/mypy/server/mergecheck.py
+++ b/mypy/server/mergecheck.py
@@ -1,14 +1,10 @@
 """Check for duplicate AST nodes after merge."""
 
 from typing import Dict, List, Tuple
+from typing_extensions import Final
 
 from mypy.nodes import SymbolNode, Var, Decorator, FuncDef
 from mypy.server.objgraph import get_reachable_graph, get_path
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
 
 # If True, print more verbose output on failure.
 DUMP_MISMATCH_NODES = False  # type: Final

--- a/mypy/server/objgraph.py
+++ b/mypy/server/objgraph.py
@@ -1,14 +1,11 @@
 """Find all objects reachable from a root object."""
 
 from collections.abc import Iterable
-from typing import List, Dict, Iterator, Tuple, Mapping
 import weakref
 import types
 
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
+from typing import List, Dict, Iterator, Tuple, Mapping
+from typing_extensions import Final
 
 method_descriptor_type = type(object.__dir__)  # type: Final
 method_wrapper_type = type(object().__ne__)  # type: Final

--- a/mypy/server/trigger.py
+++ b/mypy/server/trigger.py
@@ -1,8 +1,6 @@
 """AST triggers that are used for fine-grained dependency handling."""
 
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
+from typing_extensions import Final
 
 # Used as a suffix for triggers to handle "from m import *" dependencies (see also
 # make_wildcard_trigger)

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -116,6 +116,7 @@ import time
 from typing import (
     Dict, List, Set, Tuple, Union, Optional, NamedTuple, Callable, Sequence
 )
+from typing_extensions import Final
 
 from mypy.build import (
     BuildManager, State, BuildResult, Graph, load_graph,
@@ -144,11 +145,6 @@ from mypy.server.target import trigger_to_target
 from mypy.server.trigger import make_trigger, WILDCARD_TAG
 from mypy.util import module_prefix, split_target
 from mypy.typestate import TypeState
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
 
 MAX_ITER = 1000  # type: Final
 

--- a/mypy/sharedparse.py
+++ b/mypy/sharedparse.py
@@ -1,8 +1,5 @@
 from typing import Optional
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
+from typing_extensions import Final
 
 """Shared logic between our three mypy parser files."""
 

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -1,10 +1,11 @@
 """Utilities for calculating and reporting statistics about types."""
 
 import os
-import typing
-
 from collections import Counter
+
+import typing
 from typing import Dict, List, cast, Optional
+from typing_extensions import Final
 
 from mypy.traverser import TraverserVisitor
 from mypy.typeanal import collect_all_inner_types
@@ -17,11 +18,6 @@ from mypy.nodes import (
     Expression, FuncDef, TypeApplication, AssignmentStmt, NameExpr, CallExpr, MypyFile,
     MemberExpr, OpExpr, ComparisonExpr, IndexExpr, UnaryExpr, YieldFromExpr, RefExpr, ClassDef
 )
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
 
 TYPE_EMPTY = 0  # type: Final
 TYPE_UNANALYZED = 1  # type: Final  # type of non-typechecked code

--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -12,10 +12,7 @@ import tokenize
 from typing import (
     Optional, MutableMapping, MutableSequence, List, Sequence, Tuple, NamedTuple, Any
 )
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
+from typing_extensions import Final
 
 # Type alias for signatures strings in format ('func_name', '(arg, opt_arg=False)').
 Sig = Tuple[str, str]

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -55,6 +55,7 @@ from collections import defaultdict
 from typing import (
     List, Dict, Tuple, Iterable, Mapping, Optional, Set, cast
 )
+from typing_extensions import Final
 
 import mypy.build
 import mypy.parse
@@ -87,10 +88,6 @@ from mypy.find_sources import create_source_list, InvalidSourceList
 from mypy.build import build
 from mypy.errors import CompileError, Errors
 from mypy.traverser import has_return_statement
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 
 class Options:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1,5 +1,7 @@
-from typing import List, Optional, Callable, Tuple, Iterator, Set, Union, cast
 from contextlib import contextmanager
+
+from typing import List, Optional, Callable, Tuple, Iterator, Set, Union, cast
+from typing_extensions import Final
 
 from mypy.types import (
     Type, AnyType, UnboundType, TypeVisitor, FormalArgument, NoneType, function_type,
@@ -24,16 +26,10 @@ from mypy.expandtype import expand_type_by_instance
 from mypy.typestate import TypeState, SubtypeKind
 from mypy import state
 
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
-
 # Flags for detected protocol members
 IS_SETTABLE = 1  # type: Final
 IS_CLASSVAR = 2  # type: Final
 IS_CLASS_OR_STATIC = 3  # type: Final
-
 
 TypeParameterChecker = Callable[[Type, Type, int], bool]
 

--- a/mypy/test/testdeps.py
+++ b/mypy/test/testdeps.py
@@ -1,11 +1,10 @@
 """Test cases for generating node-level dependencies (for fine-grained incremental checking)"""
 
 import os
-from typing import List, Tuple, Dict, Optional, Set
-MYPY = False
-if MYPY:
-    from typing import DefaultDict
 from collections import defaultdict
+
+from typing import List, Tuple, Dict, Optional, Set
+from typing_extensions import DefaultDict
 
 from mypy import build, defaults
 from mypy.modulefinder import BuildSource
@@ -18,7 +17,6 @@ from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.test.helpers import assert_string_arrays_equal, parse_options
 from mypy.types import Type
 from mypy.typestate import TypeState
-
 
 # Only dependencies in these modules are dumped
 dumped_modules = ['__main__', 'pkg', 'pkg.mod']

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1,13 +1,12 @@
 """Semantic analysis of types"""
 
-from collections import OrderedDict
-from typing import Callable, List, Optional, Set, Tuple, Iterator, TypeVar, Iterable, Dict
-
-from itertools import chain
-
-from contextlib import contextmanager
-
 import itertools
+from itertools import chain
+from contextlib import contextmanager
+from collections import OrderedDict
+
+from typing import Callable, List, Optional, Set, Tuple, Iterator, TypeVar, Iterable, Dict
+from typing_extensions import Final
 
 from mypy.messages import MessageBuilder
 from mypy.options import Options
@@ -31,12 +30,7 @@ from mypy.plugin import Plugin, TypeAnalyzerPluginInterface, AnalyzeTypeContext
 from mypy.semanal_shared import SemanticAnalyzerCoreInterface
 from mypy import nodes, message_registry
 
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
-
 T = TypeVar('T')
-
 
 type_constructors = {
     'typing.Callable',

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3,15 +3,12 @@
 import sys
 from abc import abstractmethod
 from collections import OrderedDict
+
 from typing import (
     Any, TypeVar, Dict, List, Tuple, cast, Set, Optional, Union, Iterable, NamedTuple,
     Sequence, Iterator,
 )
-
-MYPY = False
-if MYPY:
-    from typing import ClassVar
-    from typing_extensions import Final
+from typing_extensions import ClassVar, Final, TYPE_CHECKING
 
 import mypy.nodes
 from mypy import state
@@ -63,7 +60,7 @@ LiteralValue = Union[int, str, bool]
 # then again in the middle at runtime.
 # We should be able to remove this once we are switched to the new
 # semantic analyzer!
-if MYPY:
+if TYPE_CHECKING:
     from mypy.type_visitor import (
         TypeVisitor as TypeVisitor,
         SyntheticTypeVisitor as SyntheticTypeVisitor,
@@ -795,7 +792,7 @@ class FunctionLike(Type):
     def __init__(self, line: int = -1, column: int = -1) -> None:
         super().__init__(line, column)
         self.can_be_false = False
-        if MYPY:  # Use MYPY to declare, we don't want a runtime None value
+        if TYPE_CHECKING:  # we don't want a runtime None value
             # Corresponding instance type (e.g. builtins.type)
             self.fallback = cast(Instance, None)
 

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -4,11 +4,8 @@ and potentially other mutable TypeInfo state. This module contains mutable globa
 """
 
 from typing import Dict, Set, Tuple, Optional
+from typing_extensions import ClassVar, Final
 
-MYPY = False
-if MYPY:
-    from typing import ClassVar
-    from typing_extensions import Final
 from mypy.nodes import TypeInfo
 from mypy.types import Instance
 from mypy.server.trigger import make_trigger

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -4,12 +4,9 @@ import pathlib
 import re
 import subprocess
 import sys
-from typing import TypeVar, List, Tuple, Optional, Dict, Sequence, Iterable, Container
 
-MYPY = False
-if MYPY:
-    from typing import Type
-    from typing_extensions import Final
+from typing import TypeVar, List, Tuple, Optional, Dict, Sequence, Iterable, Container
+from typing_extensions import Final, Type
 
 T = TypeVar('T')
 

--- a/setup.py
+++ b/setup.py
@@ -179,6 +179,7 @@ setup(name='mypy',
       cmdclass=cmdclass,
       # When changing this, also update test-requirements.txt.
       install_requires=['typed_ast >= 1.4.0, < 1.5.0',
+                        'typing_extensions>=3.7.4',
                         'mypy_extensions >= 0.4.0, < 0.5.0',
                         ],
       # Same here.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,7 @@ flake8>=3.7
 flake8-bugbear; python_version >= '3.5'
 flake8-pyi; python_version >= '3.6'
 lxml>=4.2.4
+typing_extensions>=3.7.4
 mypy_extensions>=0.4.0,<0.5.0
 psutil>=4.0
 pytest>=4.4


### PR DESCRIPTION
This PR does essentially two (related) things:
* `TYPE_CHECKING` is the official way for type-checking-only imports to avoid import cycles. This PR removes all uses of `if MYPY: ...` except for couple absolutely necessary files that are imported from `setup.py`.
* `typing_extensions` was designed in part as a drop-in replacement for `typing` on Python versions where some names are not yet available in `typing`.

I propose that mypy code adopts these itself. IMO this makes code look tidier (also it is 170 negative lines).

Are there any objections?