### PR TITLE
Fix MYPYC_BLACKLIST on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ if USE_MYPYC:
         # Need to be runnable as scripts
         '__main__.py',
         'sitepkgs.py',
-        'dmypy/__main__.py',
+        os.path.join('dmypy', '__main__.py'),
 
         # Needs to be interpreted to provide a hook to interpreted plugins
         'interpreted_plugin.py',


### PR DESCRIPTION
This simple error has an unfortunately far reaching effect :(

The compiled `__main__.py` file doesn't work, so dmypy is broken with mypy 0.710 on Windows, which this fixes.

Closes #7031 