### PR TITLE
Support flexible option specification in config file and inline configuration

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -209,7 +209,8 @@ def parse_section(prefix: str, template: Options,
                     v = not v
             elif callable(ct):
                 if invert:
-                    print("%sCan not invert non-boolean key %s" % (prefix, options_key), file=stderr)
+                    print("%sCan not invert non-boolean key %s" % (prefix, options_key),
+                          file=stderr)
                     continue
                 try:
                     v = ct(section.get(key))

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -163,6 +163,8 @@ def parse_section(prefix: str, template: Options,
     results = {}  # type: Dict[str, object]
     report_dirs = {}  # type: Dict[str, str]
     for key in section:
+        invert = False
+        options_key = key
         if key in config_types:
             ct = config_types[key]
         else:
@@ -177,7 +179,16 @@ def parse_section(prefix: str, template: Options,
                               file=stderr)
                     continue
                 if key.startswith('x_'):
-                    continue  # Don't complain about `x_blah` flags
+                    pass  # Don't complain about `x_blah` flags
+                elif key.startswith('no_') and hasattr(template, key[3:]):
+                    options_key = key[3:]
+                    invert = True
+                elif key.startswith('allow') and hasattr(template, 'dis' + key):
+                    options_key = 'dis' + key
+                    invert = True
+                elif key.startswith('disallow') and hasattr(template, key[3:]):
+                    options_key = key[3:]
+                    invert = True
                 elif key == 'strict':
                     print("%sStrict mode is not supported in configuration files: specify "
                           "individual flags instead (see 'mypy -h' for the list of flags enabled "
@@ -185,13 +196,21 @@ def parse_section(prefix: str, template: Options,
                 else:
                     print("%sUnrecognized option: %s = %s" % (prefix, key, section[key]),
                           file=stderr)
-                continue
+                if invert:
+                    dv = getattr(template, options_key, None)
+                else:
+                    continue
             ct = type(dv)
         v = None  # type: Any
         try:
             if ct is bool:
                 v = section.getboolean(key)  # type: ignore  # Until better stub
+                if invert:
+                    v = not v
             elif callable(ct):
+                if invert:
+                    print("%sCan not invert non-boolean key %s" % (prefix, options_key), file=stderr)
+                    continue
                 try:
                     v = ct(section.get(key))
                 except argparse.ArgumentTypeError as err:
@@ -219,7 +238,7 @@ def parse_section(prefix: str, template: Options,
             if v:
                 if 'follow_imports' not in results:
                     results['follow_imports'] = 'error'
-        results[key] = v
+        results[options_key] = v
     return results, report_dirs
 
 
@@ -269,19 +288,7 @@ def mypy_comments_to_config_map(line: str,
 
         name = name.replace('-', '_')
         if value is None:
-            if name.startswith('no_') and not hasattr(template, name):
-                name = name[3:]
-                value = 'False'
-            elif (name.startswith('allow')
-                  and not hasattr(template, name) and hasattr(template, 'dis' + name)):
-                name = 'dis' + name
-                value = 'False'
-            elif (name.startswith('disallow')
-                  and not hasattr(template, name) and hasattr(template, name[3:])):
-                name = name[3:]
-                value = 'False'
-            else:
-                value = 'True'
+            value = 'True'
         options[name] = value
 
     return options, errors

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -272,6 +272,14 @@ def mypy_comments_to_config_map(line: str,
             if name.startswith('no_') and not hasattr(template, name):
                 name = name[3:]
                 value = 'False'
+            elif (name.startswith('allow')
+                  and not hasattr(template, name) and hasattr(template, 'dis' + name)):
+                name = 'dis' + name
+                value = 'False'
+            elif (name.startswith('disallow')
+                  and not hasattr(template, name) and hasattr(template, name[3:])):
+                name = name[3:]
+                value = 'False'
             else:
                 value = 'True'
         options[name] = value

--- a/test-data/unit/check-inline-config.test
+++ b/test-data/unit/check-inline-config.test
@@ -50,6 +50,20 @@ def foo(FOO: bool, BAR: bool) -> List:  # E: Missing type parameters for generic
 
 [builtins fixtures/list.pyi]
 
+[case testInlineAllow]
+# flags: --disallow-any-generics --allow-untyped-globals
+import a
+[file a.py]
+# mypy: allow-any-generics, disallow-untyped-globals
+
+x = []  # E: Need type annotation for 'x' (hint: "x: List[<type>] = ...")
+
+from typing import List
+def foo() -> List:
+    ...
+
+[builtins fixtures/list.pyi]
+
 [case testInlineIncremental1]
 import a
 [file a.py]

--- a/test-data/unit/check-inline-config.test
+++ b/test-data/unit/check-inline-config.test
@@ -50,7 +50,7 @@ def foo(FOO: bool, BAR: bool) -> List:  # E: Missing type parameters for generic
 
 [builtins fixtures/list.pyi]
 
-[case testInlineAllow]
+[case testInlineInvert1]
 # flags: --disallow-any-generics --allow-untyped-globals
 import a
 [file a.py]
@@ -63,6 +63,14 @@ def foo() -> List:
     ...
 
 [builtins fixtures/list.pyi]
+
+[case testInlineInvert2]
+import a
+[file a.py]
+# mypy: no-always-true
+
+[out]
+tmp/a.py:1: error: Can not invert non-boolean key always_true
 
 [case testInlineIncremental1]
 import a
@@ -133,7 +141,7 @@ def foo() -> int:
 # mypy: always-true="FOO,BAR
 [out]
 main:1: error: Unrecognized option: invalid_whatever = True
-main:2: error: Unrecognized option: warn_no_return; no_strict_optional = False
+main:2: error: Unrecognized option: no_warn_no_return; no_strict_optional = True
 main:3: error: Unrecognized option: bar = True
 main:4: error: Unterminated quote in configuration comment
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1047,7 +1047,7 @@ def g(x: List) -> None: pass
 g(None)
 [file mypy.ini]
 [[mypy]
-disallow_any_generics = False
+allow_any_generics = True
 [[mypy-a.*]
 ignore_errors = True
 [[mypy-a.b.*]


### PR DESCRIPTION
Support inverting options based on `no_`, and adding or removing a `dis` prefix
in the config file (and therefore in inline configuration also).

This moves the handling of `no_` prefixes from inline configuration to the config file.
As a result, the config file is brought closer into alignment with the command line options.