### PR TITLE
New semantic analyzer: don't rename all named tuple methods

### DIFF
--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2599,3 +2599,17 @@ import a.b.c
 from a.b.a import foo
 [builtins fixtures/module.pyi]
 [out]
+
+[case testNewAnalyzerNamedTupleMethod]
+from typing import NamedTuple
+
+g: N
+
+class N(NamedTuple):
+    def f(self) -> None:
+        b = (
+            a
+            for a in [1]
+        )
+        b
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Previously we could rename named tuple methods that didn't have
a corresponding auto-generated method, resulting in duplicate
symbol nodes.

Fixes #7059.