### PR TITLE
Serialize ready state of Var nodes

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -763,7 +763,7 @@ VAR_FLAGS = [
     'is_self', 'is_initialized_in_class', 'is_staticmethod',
     'is_classmethod', 'is_property', 'is_settable_property', 'is_suppressed_import',
     'is_classvar', 'is_abstract_var', 'is_final', 'final_unset_in_class', 'final_set_in_init',
-    'explicit_self_type',
+    'explicit_self_type', 'is_ready',
 ]  # type: Final
 
 
@@ -867,6 +867,7 @@ class Var(SymbolNode):
         name = data['name']
         type = None if data['type'] is None else mypy.types.deserialize_type(data['type'])
         v = Var(name, type)
+        v.is_ready = False  # Override True default set in __init__
         v._fullname = data['fullname']
         set_flags(v, data['flags'])
         v.final_value = data.get('final_value')

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5069,3 +5069,41 @@ def test() -> None:
 [builtins fixtures/list.pyi]
 [out]
 [out2]
+
+[case testCannotDetermineTypeFromOtherModule]
+# flags: --new-semantic-analyzer
+import aa
+
+[file aa.py]
+import a
+
+[file aa.py.2]
+import a  # dummy
+
+[file a.py]
+from b import Sub
+
+Sub().foo
+Sub().foo
+
+[file b.py]
+from typing import Any
+
+class desc:
+    def __get__(self, _: Any, __: Any = None) -> int:
+        return 42
+
+class Base:
+    @property
+    def foo(self) -> int: ...
+
+class Sub(Base):
+    foo = desc(42)  # type: ignore
+
+[builtins fixtures/property.pyi]
+[out]
+tmp/a.py:3: error: Cannot determine type of 'foo'
+tmp/a.py:4: error: Cannot determine type of 'foo'
+[out2]
+tmp/a.py:3: error: Cannot determine type of 'foo'
+tmp/a.py:4: error: Cannot determine type of 'foo'


### PR DESCRIPTION
This fixes some inconsistent "Cannot determine type of 'foo'" errors
at least with the new semantic analyzer.

There is still a deviation between old and new semantic analyzers, but at
least this makes the new semantic analyzer behave consistently.

Fixes #7025.