### PR TITLE
Fix slicing tuples with nonliterals

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2520,7 +2520,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                       'actual type', 'expected type'):
             return AnyType(TypeOfAny.from_error)
         else:
-            return UnionType.make_simplified_union(left_type.items)
+            if isinstance(index, SliceExpr):
+                # if we index (1,2,3)[:name], we don't know what the return type is,
+                # beyond that it is a tuple of some sort.
+                anys = (AnyType(TypeOfAny.implementation_artifact),)
+                return self.chk.named_generic_type('builtins.tuple', anys)
+            else:
+                return UnionType.make_simplified_union(left_type.items)
 
     def _get_value(self, index: Expression) -> Optional[int]:
         if isinstance(index, IntExpr):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2521,15 +2521,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             return AnyType(TypeOfAny.from_error)
         else:
             union = UnionType.make_simplified_union(left_type.items)
-            # If we are indexing, we return the union of elements. In a slice,
-            # we return Tuple[Any, ...], unless it is homogeneous, where we return
-            # Tuple[T, ...]
             if isinstance(index, SliceExpr):
-                if union == left_type.items[0]:
-                    t = union
-                else:
-                    t = AnyType(TypeOfAny.implementation_artifact)
-                return self.chk.named_generic_type('builtins.tuple', [t])
+                return self.chk.named_generic_type('builtins.tuple', [union])
             else:
                 return union
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -84,7 +84,7 @@ class TypeOfAny:
     """
     This class describes different types of Any. Each 'Any' can be of only one type at a time.
     """
-    # Was this Any type was inferred without a type annotation?
+    # Was this Any type inferred without a type annotation?
     unannotated = 1  # type: Final
     # Does this Any come from an explicit type annotation?
     explicit = 2  # type: Final

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -193,7 +193,7 @@ t1[2]     # E: Tuple index out of range
 t1[3]     # E: Tuple index out of range
 t2[1]     # E: Tuple index out of range
 reveal_type(t1[n])     # N: Revealed type is 'Union[__main__.A, __main__.B]'
-reveal_type(t3[n:])    # N: Revealed type is 'builtins.tuple[Any]'
+reveal_type(t3[n:])    # N: Revealed type is 'builtins.tuple[Union[__main__.A, __main__.B, __main__.C, __main__.D, __main__.E]]'
 if int():
     b = t1[(0)] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
@@ -1127,7 +1127,7 @@ t[y]  # E: Invalid tuple index type (actual type "str", expected type "Union[int
 t = (0, "")
 x = 0
 y = ""
-reveal_type(t[x:])  # N: Revealed type is 'builtins.tuple[Any]'
+reveal_type(t[x:])  # N: Revealed type is 'builtins.tuple[Union[builtins.int, builtins.str]]'
 t[y:]  # E: Slice index must be an integer or None
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -193,7 +193,7 @@ t1[2]     # E: Tuple index out of range
 t1[3]     # E: Tuple index out of range
 t2[1]     # E: Tuple index out of range
 reveal_type(t1[n])     # N: Revealed type is 'Union[__main__.A, __main__.B]'
-reveal_type(t3[n:])    # N: Revealed type is 'Union[__main__.A, __main__.B, __main__.C, __main__.D, __main__.E]'
+reveal_type(t3[n:])    # N: Revealed type is 'builtins.tuple[Any]'
 if int():
     b = t1[(0)] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
@@ -1127,7 +1127,7 @@ t[y]  # E: Invalid tuple index type (actual type "str", expected type "Union[int
 t = (0, "")
 x = 0
 y = ""
-reveal_type(t[x:])  # N: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(t[x:])  # N: Revealed type is 'builtins.tuple[Any]'
 t[y:]  # E: Slice index must be an integer or None
 [builtins fixtures/tuple.pyi]
 


### PR DESCRIPTION
This fixes #7056.

The idea is that we don't know what types a tuple slice will result in, other than a tuple of some sort.

For example, `(1,'', 3.3)[:a]` could result in `Tuple[()]`, `Tuple[int]`, `Tuple[int, str]`, or `Tuple[int, str, float]`.

I also fixed a typo I noticed in TypeOfAny.