### PR TITLE
Fix mypyc crash with plugins using `get_customize_class_mro_hook`

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -74,7 +74,8 @@ from mypy.nodes import (
     PlaceholderNode, COVARIANT, CONTRAVARIANT, INVARIANT,
     nongen_builtins, get_member_expr_fullname, REVEAL_TYPE,
     REVEAL_LOCALS, is_final_node, TypedDictExpr, type_aliases_target_versions,
-    EnumCallExpr, RUNTIME_PROTOCOL_DECOS
+    EnumCallExpr, RUNTIME_PROTOCOL_DECOS,
+    FakeExpression,
 )
 from mypy.tvar_scope import TypeVarScope
 from mypy.typevars import fill_typevars
@@ -1459,7 +1460,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         if defn.fullname:
             hook = self.plugin.get_customize_class_mro_hook(defn.fullname)
             if hook:
-                hook(ClassDefContext(defn, Expression(), self))
+                hook(ClassDefContext(defn, FakeExpression(), self))
 
     def update_metaclass(self, defn: ClassDef) -> None:
         """Lookup for special metaclass declarations, and update defn fields accordingly.

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -179,6 +179,15 @@ class Expression(Node):
         raise RuntimeError('Not implemented')
 
 
+class FakeExpression(Expression):
+    """A dummy expression.
+
+    We need a dummy expression in one place, and can't instantiate Expression
+    because it is a trait and mypyc barfs.
+    """
+    pass
+
+
 # TODO:
 # Lvalue = Union['NameExpr', 'MemberExpr', 'IndexExpr', 'SuperExpr', 'StarExpr'
 #                'TupleExpr']; see #1783.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -59,6 +59,7 @@ from mypy.nodes import (
     COVARIANT, CONTRAVARIANT, INVARIANT, UNBOUND_IMPORTED, nongen_builtins,
     get_member_expr_fullname, REVEAL_TYPE, REVEAL_LOCALS, is_final_node,
     RUNTIME_PROTOCOL_DECOS,
+    FakeExpression,
 )
 from mypy.tvar_scope import TypeVarScope
 from mypy.typevars import fill_typevars
@@ -1260,7 +1261,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         if defn.fullname:
             hook = self.plugin.get_customize_class_mro_hook(defn.fullname)
             if hook:
-                hook(ClassDefContext(defn, Expression(), self))
+                hook(ClassDefContext(defn, FakeExpression(), self))
 
     def update_metaclass(self, defn: ClassDef) -> None:
         """Lookup for special metaclass declarations, and update defn fields accordingly.

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -597,3 +597,10 @@ plugins=<ROOT>/test-data/unit/plugins/callable_instance.py
 [file mypy.ini]
 [[mypy]
 plugins=<ROOT>/test-data/unit/plugins/depshook.py
+
+[case testCustomizeMroTrivial]
+# flags: --config-file tmp/mypy.ini
+class A: pass
+[file mypy.ini]
+[[mypy]
+plugins=<ROOT>/test-data/unit/plugins/customize_mro.py

--- a/test-data/unit/plugins/customize_mro.py
+++ b/test-data/unit/plugins/customize_mro.py
@@ -1,0 +1,10 @@
+from mypy.plugin import Plugin
+
+class DummyPlugin(Plugin):
+    def get_customize_class_mro_hook(self, fullname):
+        def analyze(classdef_ctx):
+            pass
+        return analyze
+
+def plugin(version):
+    return DummyPlugin


### PR DESCRIPTION
The semanal code that invoked it created an `Expression` directly,
which mypyc barfs on because it is a trait.

Fixes #6706.