### PR TITLE
Fixes to column number reporting

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3130,8 +3130,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             e = s.expr
             m = MemberExpr(e.base, '__delitem__')
             m.line = s.line
+            m.column = s.column
             c = CallExpr(m, [e.index], [nodes.ARG_POS], [None])
             c.line = s.line
+            c.column = s.column
             self.expr_checker.accept(c, allow_none_return=True)
         else:
             s.expr.accept(self.expr_checker)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -566,7 +566,8 @@ class ASTConverter:
             func_def.body.set_line(lineno)  # TODO: Why?
 
             deco = Decorator(func_def, self.translate_expr_list(n.decorator_list), var)
-            deco.set_line(n.decorator_list[0].lineno)
+            first = n.decorator_list[0]
+            deco.set_line(first.lineno, first.col_offset)
             retval = deco  # type: Union[FuncDef, Decorator]
         else:
             # FuncDef overrides set_line -- can't use self.set_line

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -517,11 +517,13 @@ class ASTConverter:
         if any(arg_types) or return_type:
             if len(arg_types) != 1 and any(isinstance(t, EllipsisType) for t in arg_types):
                 self.fail("Ellipses cannot accompany other argument types "
-                          "in function type signature.", lineno, 0)
+                          "in function type signature", lineno, n.col_offset)
             elif len(arg_types) > len(arg_kinds):
-                self.fail('Type signature has too many arguments', lineno, 0, blocker=False)
+                self.fail('Type signature has too many arguments', lineno, n.col_offset,
+                          blocker=False)
             elif len(arg_types) < len(arg_kinds):
-                self.fail('Type signature has too few arguments', lineno, 0, blocker=False)
+                self.fail('Type signature has too few arguments', lineno, n.col_offset,
+                          blocker=False)
             else:
                 func_type = CallableType([a if a is not None else
                                           AnyType(TypeOfAny.unannotated) for a in arg_types],

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -184,6 +184,7 @@ def parse(source: Union[str, bytes],
 
 def parse_type_comment(type_comment: str,
                        line: int,
+                       column: int,
                        errors: Optional[Errors],
                        assume_str_is_unicode: bool = True,
                        ) -> Tuple[bool, Optional[Type]]:
@@ -200,8 +201,11 @@ def parse_type_comment(type_comment: str,
     else:
         extra_ignore = TYPE_IGNORE_PATTERN.match(type_comment) is not None
         assert isinstance(typ, ast3_Expression)
-        return extra_ignore, TypeConverter(errors, line=line,
-                             assume_str_is_unicode=assume_str_is_unicode).visit(typ.body)
+        converted = TypeConverter(errors,
+                                  line=line,
+                                  override_column=column,
+                                  assume_str_is_unicode=assume_str_is_unicode).visit(typ.body)
+        return extra_ignore, converted
 
 
 def parse_type_string(expr_string: str, expr_fallback_name: str,
@@ -221,7 +225,7 @@ def parse_type_string(expr_string: str, expr_fallback_name: str,
     code with unicode_literals...) and setting `assume_str_is_unicode` accordingly.
     """
     try:
-        _, node = parse_type_comment(expr_string.strip(), line=line, errors=None,
+        _, node = parse_type_comment(expr_string.strip(), line=line, column=column, errors=None,
                                      assume_str_is_unicode=assume_str_is_unicode)
         if isinstance(node, UnboundType) and node.original_str_expr is None:
             node.original_str_expr = expr_string
@@ -480,7 +484,9 @@ class ASTConverter:
                     # PEP 484 disallows both type annotations and type comments
                     if n.returns or any(a.type_annotation is not None for a in args):
                         self.fail(message_registry.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
-                    translated_args = (TypeConverter(self.errors, line=lineno)
+                    translated_args = (TypeConverter(self.errors,
+                                                     line=lineno,
+                                                     override_column=n.col_offset)
                                        .translate_expr_list(func_type_ast.argtypes))
                     arg_types = [a if a is not None else AnyType(TypeOfAny.unannotated)
                                 for a in translated_args]
@@ -631,7 +637,8 @@ class ASTConverter:
             if annotation is not None:
                 arg_type = TypeConverter(self.errors, line=arg.lineno).visit(annotation)
             elif type_comment is not None:
-                extra_ignore, arg_type = parse_type_comment(type_comment, arg.lineno, self.errors)
+                extra_ignore, arg_type = parse_type_comment(type_comment, arg.lineno,
+                                                            arg.col_offset, self.errors)
                 if extra_ignore:
                     self.type_ignores.add(arg.lineno)
 
@@ -689,7 +696,8 @@ class ASTConverter:
         lvalues = self.translate_expr_list(n.targets)
         rvalue = self.visit(n.value)
         if n.type_comment is not None:
-            extra_ignore, typ = parse_type_comment(n.type_comment, n.lineno, self.errors)
+            extra_ignore, typ = parse_type_comment(n.type_comment, n.lineno, n.col_offset,
+                                                   self.errors)
             if extra_ignore:
                 self.type_ignores.add(n.lineno)
         else:
@@ -723,7 +731,8 @@ class ASTConverter:
     # For(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
     def visit_For(self, n: ast3.For) -> ForStmt:
         if n.type_comment is not None:
-            extra_ignore, target_type = parse_type_comment(n.type_comment, n.lineno, self.errors)
+            extra_ignore, target_type = parse_type_comment(n.type_comment, n.lineno, n.col_offset,
+                                                           self.errors)
             if extra_ignore:
                 self.type_ignores.add(n.lineno)
         else:
@@ -738,7 +747,8 @@ class ASTConverter:
     # AsyncFor(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
     def visit_AsyncFor(self, n: ast3.AsyncFor) -> ForStmt:
         if n.type_comment is not None:
-            extra_ignore, target_type = parse_type_comment(n.type_comment, n.lineno, self.errors)
+            extra_ignore, target_type = parse_type_comment(n.type_comment, n.lineno, n.col_offset,
+                                                           self.errors)
             if extra_ignore:
                 self.type_ignores.add(n.lineno)
         else:
@@ -769,7 +779,8 @@ class ASTConverter:
     # With(withitem* items, stmt* body, string? type_comment)
     def visit_With(self, n: ast3.With) -> WithStmt:
         if n.type_comment is not None:
-            extra_ignore, target_type = parse_type_comment(n.type_comment, n.lineno, self.errors)
+            extra_ignore, target_type = parse_type_comment(n.type_comment, n.lineno,
+                                                           n.col_offset, self.errors)
             if extra_ignore:
                 self.type_ignores.add(n.lineno)
         else:
@@ -783,7 +794,8 @@ class ASTConverter:
     # AsyncWith(withitem* items, stmt* body, string? type_comment)
     def visit_AsyncWith(self, n: ast3.AsyncWith) -> WithStmt:
         if n.type_comment is not None:
-            extra_ignore, target_type = parse_type_comment(n.type_comment, n.lineno, self.errors)
+            extra_ignore, target_type = parse_type_comment(n.type_comment, n.lineno,
+                                                           n.col_offset, self.errors)
             if extra_ignore:
                 self.type_ignores.add(n.lineno)
         else:
@@ -1207,12 +1219,20 @@ class TypeConverter:
     def __init__(self,
                  errors: Optional[Errors],
                  line: int = -1,
+                 override_column: int = -1,
                  assume_str_is_unicode: bool = True,
                  ) -> None:
         self.errors = errors
         self.line = line
+        self.override_column = override_column
         self.node_stack = []  # type: List[AST]
         self.assume_str_is_unicode = assume_str_is_unicode
+
+    def convert_column(self, column: int) -> int:
+        if self.override_column < 0:
+            return column
+        else:
+            return self.override_column
 
     def invalid_type(self, node: AST, note: Optional[str] = None) -> RawExpressionType:
         """Constructs a type representing some expression that normally forms an invalid type.
@@ -1276,6 +1296,7 @@ class TypeConverter:
         # without needing to create an intermediary `Str` object.
         _, typ = parse_type_comment(s.strip(),
                                     self.line,
+                                    -1,
                                     self.errors,
                                     self.assume_str_is_unicode)
         return typ or AnyType(TypeOfAny.from_error)
@@ -1339,13 +1360,13 @@ class TypeConverter:
         return None
 
     def visit_Name(self, n: Name) -> Type:
-        return UnboundType(n.id, line=self.line)
+        return UnboundType(n.id, line=self.line, column=self.convert_column(n.col_offset))
 
     def visit_NameConstant(self, n: NameConstant) -> Type:
         if isinstance(n.value, bool):
             return RawExpressionType(n.value, 'builtins.bool', line=self.line)
         else:
-            return UnboundType(str(n.value), line=self.line)
+            return UnboundType(str(n.value), line=self.line, column=n.col_offset)
 
     # Only for 3.8 and newer
     def visit_Constant(self, n: Constant) -> Type:
@@ -1455,7 +1476,7 @@ class TypeConverter:
 
         value = self.visit(n.value)
         if isinstance(value, UnboundType) and not value.args:
-            return UnboundType(value.name, params, line=self.line,
+            return UnboundType(value.name, params, line=self.line, column=value.column,
                                empty_tuple_index=empty_tuple_index)
         else:
             return self.invalid_type(n)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1232,6 +1232,11 @@ class TypeConverter:
         self.assume_str_is_unicode = assume_str_is_unicode
 
     def convert_column(self, column: int) -> int:
+        """Apply column override if defined; otherwise return column.
+
+        Column numbers are sometimes incorrect in the AST and the column
+        override can be used to work around that.
+        """
         if self.override_column < 0:
             return column
         else:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1485,7 +1485,7 @@ class TypeConverter:
 
     def visit_Tuple(self, n: ast3.Tuple) -> Type:
         return TupleType(self.translate_expr_list(n.elts), _dummy_fallback,
-                         implicit=True, line=self.line)
+                         implicit=True, line=self.line, column=self.convert_column(n.col_offset))
 
     # Attribute(expr value, identifier attr, expr_context ctx)
     def visit_Attribute(self, n: Attribute) -> Type:

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -389,11 +389,13 @@ class ASTConverter:
         if any(arg_types) or return_type:
             if len(arg_types) != 1 and any(isinstance(t, EllipsisType) for t in arg_types):
                 self.fail("Ellipses cannot accompany other argument types "
-                          "in function type signature.", lineno, 0)
+                          "in function type signature", lineno, n.col_offset)
             elif len(arg_types) > len(arg_kinds):
-                self.fail('Type signature has too many arguments', lineno, 0, blocker=False)
+                self.fail('Type signature has too many arguments', lineno, n.col_offset,
+                          blocker=False)
             elif len(arg_types) < len(arg_kinds):
-                self.fail('Type signature has too few arguments', lineno, 0, blocker=False)
+                self.fail('Type signature has too few arguments', lineno, n.col_offset,
+                          blocker=False)
             else:
                 any_type = AnyType(TypeOfAny.unannotated)
                 func_type = CallableType([a if a is not None else any_type for a in arg_types],

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -335,7 +335,7 @@ class ASTConverter:
     def visit_FunctionDef(self, n: ast27.FunctionDef) -> Statement:
         self.class_and_function_stack.append('F')
         lineno = n.lineno
-        converter = TypeConverter(self.errors, line=lineno,
+        converter = TypeConverter(self.errors, line=lineno, override_column=n.col_offset,
                                   assume_str_is_unicode=self.unicode_literals)
         args, decompose_stmts = self.transform_args(n.args, lineno)
 
@@ -569,7 +569,10 @@ class ASTConverter:
     def visit_Assign(self, n: ast27.Assign) -> AssignmentStmt:
         typ = None
         if n.type_comment:
-            extra_ignore, typ = parse_type_comment(n.type_comment, n.lineno, self.errors,
+            extra_ignore, typ = parse_type_comment(n.type_comment,
+                                                   n.lineno,
+                                                   n.col_offset,
+                                                   self.errors,
                                                    assume_str_is_unicode=self.unicode_literals)
             if extra_ignore:
                 self.type_ignores.add(n.lineno)
@@ -589,7 +592,10 @@ class ASTConverter:
     # For(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
     def visit_For(self, n: ast27.For) -> ForStmt:
         if n.type_comment is not None:
-            extra_ignore, typ = parse_type_comment(n.type_comment, n.lineno, self.errors,
+            extra_ignore, typ = parse_type_comment(n.type_comment,
+                                                   n.lineno,
+                                                   n.col_offset,
+                                                   self.errors,
                                                    assume_str_is_unicode=self.unicode_literals)
             if extra_ignore:
                 self.type_ignores.add(n.lineno)
@@ -619,7 +625,10 @@ class ASTConverter:
     # With(withitem* items, stmt* body, string? type_comment)
     def visit_With(self, n: ast27.With) -> WithStmt:
         if n.type_comment is not None:
-            extra_ignore, typ = parse_type_comment(n.type_comment, n.lineno, self.errors,
+            extra_ignore, typ = parse_type_comment(n.type_comment,
+                                                   n.lineno,
+                                                   n.col_offset,
+                                                   self.errors,
                                                    assume_str_is_unicode=self.unicode_literals)
             if extra_ignore:
                 self.type_ignores.add(n.lineno)

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3309,6 +3309,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             # precedence over the CallExpr semantics.
             expr.analyzed = CastExpr(expr.args[1], target)
             expr.analyzed.line = expr.line
+            expr.analyzed.column = expr.column
             expr.analyzed.accept(self)
         elif refers_to_fullname(expr.callee, 'builtins.reveal_type'):
             if not self.check_fixed_args(expr, 1, 'reveal_type'):

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -3517,6 +3517,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         base = expr.base
         expr.analyzed = TypeApplication(base, types)
         expr.analyzed.line = expr.line
+        expr.analyzed.column = expr.column
         # Types list, dict, set are not subscriptable, prohibit this if
         # subscripted either via type alias...
         if isinstance(base, RefExpr) and isinstance(base.node, TypeAlias):

--- a/mypy/newsemanal/semanal_newtype.py
+++ b/mypy/newsemanal/semanal_newtype.py
@@ -55,7 +55,7 @@ class NewTypeAnalyzer:
 
         old_type, should_defer = self.check_newtype_args(name, call, s)
         if not call.analyzed:
-            call.analyzed = NewTypeExpr(name, old_type, line=call.line)
+            call.analyzed = NewTypeExpr(name, old_type, line=call.line, column=call.column)
         if old_type is None:
             if should_defer:
                 # Base type is not ready.

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -92,7 +92,7 @@ def no_subscript_builtin_alias(name: str, propose_alt: bool = True) -> str:
 
 
 class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
-    """Semantic analyzer for types (semantic analysis pass 2).
+    """Semantic analyzer for types.
 
     Converts unbound types into bound types.
     """

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -491,7 +491,7 @@ class OverloadedFuncDef(FuncBase, SymbolNode, Statement):
         self.unanalyzed_items = items.copy()
         self.impl = None
         if len(items) > 0:
-            self.set_line(items[0].line)
+            self.set_line(items[0].line, items[0].column)
         self.is_final = False
 
     def name(self) -> str:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2168,11 +2168,13 @@ class NewTypeExpr(Expression):
     # The synthesized class representing the new type (inherits old_type)
     info = None  # type: Optional[TypeInfo]
 
-    def __init__(self, name: str, old_type: 'Optional[mypy.types.Type]', line: int) -> None:
+    def __init__(self, name: str, old_type: 'Optional[mypy.types.Type]', line: int,
+                 column: int) -> None:
         super().__init__()
         self.name = name
         self.old_type = old_type
         self.line = line
+        self.column = column
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_newtype_expr(self)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2448,6 +2448,7 @@ class SemanticAnalyzerPass2(NodeVisitor[None],
         node.kind = self.current_symbol_kind()
         type_var = TypeVarExpr(name, node.fullname, values, upper_bound, variance)
         type_var.line = call.line
+        type_var.column = call.column
         call.analyzed = type_var
         node.node = type_var
 

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -34,7 +34,7 @@ class NewTypeAnalyzer:
             return
 
         old_type = self.check_newtype_args(name, call, s)
-        call.analyzed = NewTypeExpr(name, old_type, line=call.line)
+        call.analyzed = NewTypeExpr(name, old_type, line=call.line, column=call.column)
         if old_type is None:
             return
 

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -163,7 +163,7 @@ class TypeCheckSuite(DataSuite):
             options.strict_optional = True
         if 'newsemanal' in testcase.file:
             options.new_semantic_analyzer = True
-        if 'columns' in testcase.file or True:
+        if 'columns' in testcase.file:
             options.show_column_numbers = True
 
         if incremental_step and options.incremental:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -163,7 +163,7 @@ class TypeCheckSuite(DataSuite):
             options.strict_optional = True
         if 'newsemanal' in testcase.file:
             options.new_semantic_analyzer = True
-        if 'columns' in testcase.file:
+        if 'columns' in testcase.file or True:
             options.show_column_numbers = True
 
         if incremental_step and options.incremental:

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -493,7 +493,7 @@ class TransformVisitor(NodeVisitor[Node]):
         return TypeAliasExpr(node.type, node.tvars, node.no_args)
 
     def visit_newtype_expr(self, node: NewTypeExpr) -> NewTypeExpr:
-        res = NewTypeExpr(node.name, node.old_type, line=node.line)
+        res = NewTypeExpr(node.name, node.old_type, line=node.line, column=node.column)
         res.info = node.info
         return res
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -5180,8 +5180,8 @@ A = G
 x: A[B[int]]
 B = G
 [out]
-main:7: error: Type argument "builtins.int" of "G" must be a subtype of "builtins.str"
 main:7: error: Type argument "__main__.G[builtins.int]" of "G" must be a subtype of "builtins.str"
+main:7: error: Type argument "builtins.int" of "G" must be a subtype of "builtins.str"
 
 [case testExtremeForwardReferencing]
 from typing import TypeVar, Generic

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -5171,17 +5171,18 @@ B = G
 [out]
 
 [case testForwardInstanceWithBound]
+# flags: --show-column-numbers
 from typing import TypeVar, Generic
 
 T = TypeVar('T', bound=str)
 class G(Generic[T]): ...
 
 A = G
-x: A[B[int]]
+x: A[B[int]] # E
 B = G
 [out]
-main:7: error: Type argument "__main__.G[builtins.int]" of "G" must be a subtype of "builtins.str"
-main:7: error: Type argument "builtins.int" of "G" must be a subtype of "builtins.str"
+main:8:4: error: Type argument "__main__.G[builtins.int]" of "G" must be a subtype of "builtins.str"
+main:8:6: error: Type argument "builtins.int" of "G" must be a subtype of "builtins.str"
 
 [case testExtremeForwardReferencing]
 from typing import TypeVar, Generic

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -229,6 +229,7 @@ if 1 == '': # E:4: Non-overlapping equality check (left operand type: "int", rig
 [builtins fixtures/bool.pyi]
 
 [case testColumnValueOfTypeVariableCannotBe]
+# flags: --new-semantic-analyzer
 from typing import TypeVar, Generic
 
 T = TypeVar('T', int, str)
@@ -237,6 +238,7 @@ class C(Generic[T]):
     pass
 
 def f(c: C[object]) -> None: pass # E:10: Value of type variable "T" of "C" cannot be "object"
+(C[object]()) # E:2: Value of type variable "T" of "C" cannot be "object"
 
 [case testColumnSyntaxErrorInTypeAnnotation]
 if int():

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -82,6 +82,7 @@ if int():
         y = 0  # type: bad  # E:9: Invalid type "__main__.bad"
 
 z: Iterable[bad] # E:13: Invalid type "__main__.bad"
+h: bad[int] # E:4: Invalid type "__main__.bad"
 
 [case testColumnInvalidType_python2]
 from typing import Iterable

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -197,11 +197,10 @@ if int():
       # N:5:     y
 
 [case testColumnRedundantCast]
-# flags: --warn-redundant-casts
+# flags: --warn-redundant-casts --new-semantic-analyzer
 from typing import cast
 y = 1
-# TODO: Missing column number
-x = cast(int, y) # E: Redundant cast to "int"
+x = cast(int, y) # E:5: Redundant cast to "int"
 
 [case testColumnTypeSignatureHasTooFewArguments]
 if int():

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -274,3 +274,11 @@ class B(A):
     def x(self): # type: () -> int
         pass
 [builtins_py2 fixtures/property_py2.pyi]
+
+[case testColumnOverloaded]
+from typing import overload, Any
+class A:
+    @overload # E:6: An overloaded function outside a stub file must have an implementation
+    def f(self, x: int) -> int: pass
+    @overload
+    def f(self, x: str) -> str: pass

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -204,7 +204,13 @@ x = cast(int, y) # E:5: Redundant cast to "int"
 
 [case testColumnTypeSignatureHasTooFewArguments]
 if int():
-    def f(x, y): # E:1: Type signature has too few arguments
+    def f(x, y): # E:5: Type signature has too few arguments
+        # type: (int) -> None
+        pass
+
+[case testColumnTypeSignatureHasTooFewArguments_python2]
+if int():
+    def f(x, y): # E:5: Type signature has too few arguments
         # type: (int) -> None
         pass
 

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -245,3 +245,32 @@ if int():
 [out]
 main:2:11: error: Syntax error in type annotation
 main:2:11: note: Suggestion: Is there a spurious trailing comma?
+
+[case testColumnProperty]
+class A:
+    @property
+    def x(self) -> int: pass
+
+    @x.setter
+    def x(self, x: int) -> None: pass
+
+class B(A):
+    @property  # E:6: Read-only property cannot override read-write property
+    def x(self) -> int: pass
+[builtins fixtures/property.pyi]
+
+[case testColumnProperty_python2]
+class A:
+    @property
+    def x(self): # type: () -> int
+        pass
+
+    @x.setter
+    def x(self, x): # type: (int) -> None
+        pass
+
+class B(A):
+    @property  # E:5: Read-only property cannot override read-write property
+    def x(self): # type: () -> int
+        pass
+[builtins_py2 fixtures/property_py2.pyi]

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -147,12 +147,15 @@ def f() -> None:
     1[1] = 1 # E:5: Unsupported target for indexed assignment
 [builtins fixtures/list.pyi]
 
-[case testColumnIncompatibleTypedDictValue]
+[case testColumnTypedDict]
 from typing import TypedDict
 class D(TypedDict):
     x: int
 t: D = {'x':
     'y'} # E:5: Incompatible types (expression has type "str", TypedDict item "x" has type "int")
+
+if int():
+    del t['y'] # E:5: TypedDict "D" has no key 'y'
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
 
@@ -233,3 +236,12 @@ class C(Generic[T]):
     pass
 
 def f(c: C[object]) -> None: pass # E:10: Value of type variable "T" of "C" cannot be "object"
+
+[case testColumnSyntaxErrorInTypeAnnotation]
+if int():
+    def f(x # type: int,
+          ):
+        pass
+[out]
+main:2:11: error: Syntax error in type annotation
+main:2:11: note: Suggestion: Is there a spurious trailing comma?

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -69,19 +69,31 @@ if int():
     (f(b=object())) # E:6: Unexpected keyword argument "b" for "f"
 
 [case testColumnInvalidType]
-# TODO: Add column numbers
 from typing import Iterable
 
 bad = 0
 
-def f(x: bad): # E: Invalid type "__main__.bad"
+def f(x: bad): # E:10: Invalid type "__main__.bad"
     y: bad # E:8: Invalid type "__main__.bad"
 
-def g(x): # E: Invalid type "__main__.bad"
-    # type: (bad) -> None
-    y = 0  # type: bad  # E: Invalid type "__main__.bad"
+if int():
+    def g(x): # E:5: Invalid type "__main__.bad"
+        # type: (bad) -> None
+        y = 0  # type: bad  # E:9: Invalid type "__main__.bad"
 
-z: Iterable[bad] # E: Invalid type "__main__.bad"
+z: Iterable[bad] # E:13: Invalid type "__main__.bad"
+
+[case testColumnInvalidType_python2]
+from typing import Iterable
+
+bad = 0
+
+if int():
+    def g(x): # E:5: Invalid type "__main__.bad"
+        # type: (bad) -> None
+        y = 0  # type: bad  # E:9: Invalid type "__main__.bad"
+
+    z = ()  # type: Iterable[bad] # E:5: Invalid type "__main__.bad"
 
 [case testColumnFunctionMissingTypeAnnotation]
 # flags: --disallow-untyped-defs
@@ -157,9 +169,8 @@ class D(A):
 [case testColumnMissingTypeParameters]
 # flags: --disallow-any-generics
 from typing import List, Callable
-# TODO: Missing column numbers
-def f(x: List) -> None: pass # E: Missing type parameters for generic type
-def g(x: list) -> None: pass # E: Implicit generic "Any". Use "typing.List" and specify generic parameters
+def f(x: List) -> None: pass # E:10: Missing type parameters for generic type
+def g(x: list) -> None: pass # E:10: Implicit generic "Any". Use "typing.List" and specify generic parameters
 if int():
     c: Callable # E:8: Missing type parameters for generic type
 [builtins fixtures/list.pyi]
@@ -216,5 +227,4 @@ T = TypeVar('T', int, str)
 class C(Generic[T]):
     pass
 
-# TODO: Column number missing
-def f(c: C[object]) -> None: pass # E: Value of type variable "T" of "C" cannot be "object"
+def f(c: C[object]) -> None: pass # E:10: Value of type variable "T" of "C" cannot be "object"

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2033,13 +2033,13 @@ class A:
 def f(x, y, z): # type: (..., int) -> None
     pass
 [out]
-main:1: error: Ellipses cannot accompany other argument types in function type signature.
+main:1: error: Ellipses cannot accompany other argument types in function type signature
 
 [case testEllipsisWithSomethingBeforeItFails]
 def f(x, y, z): # type: (int, ...) -> None
     pass
 [out]
-main:1: error: Ellipses cannot accompany other argument types in function type signature.
+main:1: error: Ellipses cannot accompany other argument types in function type signature
 
 [case testRejectCovariantArgument]
 from typing import TypeVar, Generic

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1069,8 +1069,8 @@ y = None # type: SameA[str] # Two errors here, for both args of A
 [builtins fixtures/list.pyi]
 [out]
 main:9:8: error: Value of type variable "T" of "A" cannot be "str"
-main:13: error: Value of type variable "T" of "A" cannot be "str"
-main:13: error: Value of type variable "S" of "A" cannot be "str"
+main:13:1: error: Value of type variable "T" of "A" cannot be "str"
+main:13:1: error: Value of type variable "S" of "A" cannot be "str"
 
 [case testGenericTypeAliasesIgnoredPotentialAlias]
 class A: ...

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2661,14 +2661,14 @@ d: Literal[3]
 # However, according to final semantics, we ought to be able to substitute "b" with
 # "3" wherever it's used and get the same behavior -- so maybe we do need to support
 # at least case "b" for consistency?
-a_wrap: Literal[4, a]  # E: Invalid type "__main__.a" \
-                       # E: Parameter 2 of Literal[...] is invalid
-b_wrap: Literal[4, b]  # E: Invalid type "__main__.b" \
-                       # E: Parameter 2 of Literal[...] is invalid
-c_wrap: Literal[4, c]  # E: Invalid type "__main__.c" \
-                       # E: Parameter 2 of Literal[...] is invalid
-d_wrap: Literal[4, d]  # E: Invalid type "__main__.d" \
-                       # E: Parameter 2 of Literal[...] is invalid
+a_wrap: Literal[4, a]  # E: Parameter 2 of Literal[...] is invalid \
+                       # E: Invalid type "__main__.a"
+b_wrap: Literal[4, b]  # E: Parameter 2 of Literal[...] is invalid \
+                       # E: Invalid type "__main__.b"
+c_wrap: Literal[4, c]  # E: Parameter 2 of Literal[...] is invalid \
+                       # E: Invalid type "__main__.c"
+d_wrap: Literal[4, d]  # E: Parameter 2 of Literal[...] is invalid \
+                       # E: Invalid type "__main__.d"
 [out]
 
 [case testLiteralWithFinalPropagation]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1801,9 +1801,9 @@ S = TypeVar('S', bound=Tuple[G[A], ...])
 class GG(Generic[S]): pass
 
 g: GG[Tuple[G[B], G[C]]] \
+  # E: Type argument "Tuple[__main__.G[__main__.B], __main__.G[__main__.C]]" of "GG" must be a subtype of "builtins.tuple[__main__.G[__main__.A]]" \
   # E: Type argument "__main__.B" of "G" must be a subtype of "__main__.A" \
-  # E: Type argument "__main__.C" of "G" must be a subtype of "__main__.A" \
-  # E: Type argument "Tuple[__main__.G[__main__.B], __main__.G[__main__.C]]" of "GG" must be a subtype of "builtins.tuple[__main__.G[__main__.A]]"
+  # E: Type argument "__main__.C" of "G" must be a subtype of "__main__.A"
 
 T = TypeVar('T', bound=A, covariant=True)
 

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1,5 +1,6 @@
 -- Test cases for function overloading
 [case testOverloadNotImportedNoCrash]
+# flags: --new-semantic-analyzer
 @overload
 def f(a): pass
 @overload
@@ -9,18 +10,18 @@ f(0)
 
 @overload  # E: Name 'overload' is not defined
 def g(a:int): pass
-def g(a): pass  # E: Name 'g' already defined on line 8
+def g(a): pass  # E: Name 'g' already defined on line 9
 g(0)
 
 @something  # E: Name 'something' is not defined
 def r(a:int): pass
-def r(a): pass  # E: Name 'r' already defined on line 13
+def r(a): pass  # E: Name 'r' already defined on line 14
 r(0)
 [out]
-main:1: error: Name 'overload' is not defined
-main:3: error: Name 'f' already defined on line 1
-main:3: error: Name 'overload' is not defined
-main:5: error: Name 'f' already defined on line 1
+main:2: error: Name 'overload' is not defined
+main:4: error: Name 'f' already defined on line 2
+main:4: error: Name 'overload' is not defined
+main:6: error: Name 'f' already defined on line 2
 
 [case testTypeCheckOverloadWithImplementation]
 from typing import overload, Any

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -196,7 +196,7 @@ def f(x, y, z): # type: (...) -> None
 def f(x, y, z): # type: (..., int) -> None
     pass
 [out]
-main:1: error: Ellipses cannot accompany other argument types in function type signature.
+main:1: error: Ellipses cannot accompany other argument types in function type signature
 
 [case testLambdaTupleArgInPython2]
 f = lambda (x, y): x + y

--- a/test-data/unit/fixtures/property.pyi
+++ b/test-data/unit/fixtures/property.pyi
@@ -10,7 +10,7 @@ class type:
 
 class function: pass
 
-property = object() # Dummy definition.
+property = object()  # Dummy definition
 
 class int: pass
 class str: pass

--- a/test-data/unit/fixtures/property_py2.pyi
+++ b/test-data/unit/fixtures/property_py2.pyi
@@ -10,7 +10,7 @@ class type:
 
 class function: pass
 
-property = object() # Dummy definition.
+property = object()  # Dummy definition
 
 class int: pass
 class str: pass

--- a/test-data/unit/fixtures/property_py2.pyi
+++ b/test-data/unit/fixtures/property_py2.pyi
@@ -1,0 +1,21 @@
+import typing
+
+_T = typing.TypeVar('_T')
+
+class object:
+    def __init__(self) -> None: pass
+
+class type:
+    def __init__(self, x: typing.Any) -> None: pass
+
+class function: pass
+
+property = object() # Dummy definition.
+
+class int: pass
+class str: pass
+class unicode: pass
+class bool: pass
+class ellipsis: pass
+
+class tuple(typing.Generic[_T]): pass


### PR DESCRIPTION
Previously many types and AST nodes didn't have 
(good) column numbers. This fixes several such issues.

In particular, this gives correct column number of simple 
types like `Foo` and `List[Foo]` in Python 3 type 
annotations.

For type comments we cheat a bit and point them to the
surrounding statement or definition, which is still a
small improvement.

For some types we may still be missing column numbers,
but this covers the most common cases.