### PR TITLE
New semantic analyzer: enable tests related to recursively defined types

### DIFF
--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4356,32 +4356,30 @@ class A(Tuple[int, str]): pass
 
 [case testCrashOnSelfRecursiveNamedTupleVar]
 # FIXME: #6445
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import NamedTuple
 
-N = NamedTuple('N', [('x', N)]) # E: Recursive types not fully supported yet, nested types replaced with "Any"
+N = NamedTuple('N', [('x', N)]) # E: Cannot resolve name "N" (possible cyclic definition)
 n: N
-[out]
+reveal_type(n) # N: Revealed type is 'Tuple[Any, fallback=__main__.N]'
 
 [case testCrashOnSelfRecursiveTypedDictVar]
 # FIXME: #6445
-# flags: --no-new-semantic-analyzer
 from mypy_extensions import TypedDict
 
 A = TypedDict('A', {'a': 'A'})  # type: ignore
 a: A
 [builtins fixtures/isinstancelist.pyi]
-[out]
 
 [case testCrashInJoinOfSelfRecursiveNamedTuples]
 # FIXME: #6445
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import NamedTuple
 
-class N(NamedTuple): # type: ignore
-    x: N
-class M(NamedTuple): # type: ignore
-    x: M
+class N(NamedTuple):
+    x: N # type: ignore
+class M(NamedTuple):
+    x: M # type: ignore
 
 n: N
 m: M
@@ -4390,18 +4388,18 @@ lst = [n, m]
 
 [case testCorrectJoinOfSelfRecursiveTypedDicts]
 # FIXME: #6445
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from mypy_extensions import TypedDict
 
-class N(TypedDict):  # E: Recursive types not fully supported yet, nested types replaced with "Any"
-    x: N
-class M(TypedDict):  # E: Recursive types not fully supported yet, nested types replaced with "Any"
-    x: M
+class N(TypedDict):
+    x: N # E: Cannot resolve name "N" (possible cyclic definition)
+class M(TypedDict):
+    x: M # E: Cannot resolve name "M" (possible cyclic definition)
 
 n: N
 m: M
 lst = [n, m]
-reveal_type(lst[0]['x'])  # N: Revealed type is 'TypedDict('__main__.N', {'x': Any})'
+reveal_type(lst[0]['x'])  # N: Revealed type is 'Any'
 [builtins fixtures/isinstancelist.pyi]
 
 [case testCrashInForwardRefToNamedTupleWithIsinstance]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2570,25 +2570,25 @@ M = NamedTuple('M', [('x', int)])
 [out]
 
 [case testSelfRefNTIncremental1]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import Tuple, NamedTuple
 
-Node = NamedTuple('Node', [ # type: ignore
+Node = NamedTuple('Node', [
         ('name', str),
-        ('children', Tuple['Node', ...]),
+        ('children', Tuple['Node', ...]), # type: ignore
     ])
 n: Node
 [builtins fixtures/tuple.pyi]
 
 [case testSelfRefNTIncremental2]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import Tuple, NamedTuple
 
-A = NamedTuple('A', [ # type: ignore
+A = NamedTuple('A', [
         ('x', str),
-        ('y', Tuple['B', ...]),
+        ('y', Tuple['B', ...]), # type: ignore
     ])
-class B(NamedTuple): # type: ignore
+class B(NamedTuple):
     x: A
     y: int
 
@@ -2596,13 +2596,13 @@ n: A
 [builtins fixtures/tuple.pyi]
 
 [case testSelfRefNTIncremental3]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import NamedTuple, Tuple
 
-class B(NamedTuple): # type: ignore
-    x: Tuple[A, int]
+class B(NamedTuple):
+    x: Tuple[A, int] # type: ignore
     y: int
-A = NamedTuple('A', [ # type: ignore
+A = NamedTuple('A', [
         ('x', str),
         ('y', 'B'),
     ])
@@ -2612,13 +2612,13 @@ lst = [m, n]
 [builtins fixtures/tuple.pyi]
 
 [case testSelfRefNTIncremental4]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import NamedTuple
 
-class B(NamedTuple): # type: ignore
-    x: A
+class B(NamedTuple):
+    x: A # type: ignore
     y: int
-class A(NamedTuple): # type: ignore
+class A(NamedTuple):
     x: str
     y: B
 
@@ -2626,14 +2626,14 @@ n: A
 [builtins fixtures/tuple.pyi]
 
 [case testSelfRefNTIncremental5]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import NamedTuple
 
-B = NamedTuple('B', [ # type: ignore
-        ('x', A),
+B = NamedTuple('B', [
+        ('x', A), # type: ignore
         ('y', int),
     ])
-A = NamedTuple('A', [ # type: ignore
+A = NamedTuple('A', [
         ('x', str),
         ('y', 'B'),
     ])
@@ -4620,7 +4620,7 @@ tmp/main.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "s
 
 [case testOverrideByIdemAlias]
 # https://github.com/python/mypy/issues/6404
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 import a
 [file a.py]
 import lib
@@ -4629,7 +4629,7 @@ x = 1
 import lib
 x = 2
 [file lib.py]
-C = C
+C = C  # type: ignore
 class C:  # type: ignore
     pass
 [out]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -574,19 +574,16 @@ tmp/b.py:4: note: Revealed type is 'Tuple[Any, fallback=a.N]'
 tmp/b.py:7: note: Revealed type is 'Tuple[Any, fallback=a.N]'
 
 [case testSimpleSelfReferentialNamedTuple]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import NamedTuple
 class MyNamedTuple(NamedTuple):
-    parent: 'MyNamedTuple'
+    parent: 'MyNamedTuple' # E: Cannot resolve name "MyNamedTuple" (possible cyclic definition)
 
 def bar(nt: MyNamedTuple) -> MyNamedTuple:
     return nt
 
 x: MyNamedTuple
-reveal_type(x.parent)
-[out]
-main:3: error: Recursive types not fully supported yet, nested types replaced with "Any"
-main:10: note: Revealed type is 'Tuple[Any, fallback=__main__.MyNamedTuple]'
+reveal_type(x.parent) # N: Revealed type is 'Any'
 
 -- Some crazy self-referential named tuples and types dicts
 -- to be sure that everything works
@@ -613,94 +610,85 @@ class B:
 [out]
 
 [case testSelfRefNT1]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import Tuple, NamedTuple
 
-Node = NamedTuple('Node', [ # E: Recursive types not fully supported yet, nested types replaced with "Any"
+Node = NamedTuple('Node', [
         ('name', str),
-        ('children', Tuple['Node', ...]),
+        ('children', Tuple['Node', ...]), # E: Cannot resolve name "Node" (possible cyclic definition)
     ])
 n: Node
-reveal_type(n) # N: Revealed type is 'Tuple[builtins.str, builtins.tuple[Tuple[builtins.str, builtins.tuple[Any], fallback=__main__.Node]], fallback=__main__.Node]'
+reveal_type(n) # N: Revealed type is 'Tuple[builtins.str, builtins.tuple[Any], fallback=__main__.Node]'
 [builtins fixtures/tuple.pyi]
 
-
 [case testSelfRefNT2]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import Tuple, NamedTuple
 
-A = NamedTuple('A', [ # E
+A = NamedTuple('A', [
         ('x', str),
-        ('y', Tuple['B', ...]),
+        ('y', Tuple['B', ...]), # E: Cannot resolve name "B" (possible cyclic definition)
     ])
-class B(NamedTuple): # E
+class B(NamedTuple):
     x: A
     y: int
 
 n: A
-reveal_type(n) # N: Revealed type is 'Tuple[builtins.str, builtins.tuple[Tuple[Tuple[builtins.str, builtins.tuple[Any], fallback=__main__.A], builtins.int, fallback=__main__.B]], fallback=__main__.A]'
+reveal_type(n) # N: Revealed type is 'Tuple[builtins.str, builtins.tuple[Any], fallback=__main__.A]'
 [builtins fixtures/tuple.pyi]
-[out]
-main:4: error: Recursive types not fully supported yet, nested types replaced with "Any"
-main:8: error: Recursive types not fully supported yet, nested types replaced with "Any"
 
 [case testSelfRefNT3]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import NamedTuple, Tuple
 
-class B(NamedTuple): # E
-    x: Tuple[A, int]
+class B(NamedTuple):
+    x: Tuple[A, int] # E: Cannot resolve name "A" (possible cyclic definition)
     y: int
 
-A = NamedTuple('A', [ # E: Recursive types not fully supported yet, nested types replaced with "Any"
+A = NamedTuple('A', [
         ('x', str),
         ('y', 'B'),
     ])
 n: B
 m: A
-reveal_type(n.x) # N: Revealed type is 'Tuple[Tuple[builtins.str, Tuple[Tuple[Any, builtins.int], builtins.int, fallback=__main__.B], fallback=__main__.A], builtins.int]'
+reveal_type(n.x) # N: Revealed type is 'Tuple[Any, builtins.int]'
 reveal_type(m[0]) # N: Revealed type is 'builtins.str'
 lst = [m, n]
 reveal_type(lst[0]) # N: Revealed type is 'Tuple[builtins.object, builtins.object]'
 [builtins fixtures/tuple.pyi]
-[out]
-main:4: error: Recursive types not fully supported yet, nested types replaced with "Any"
 
 [case testSelfRefNT4]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import NamedTuple
 
-class B(NamedTuple): # E
-    x: A
+class B(NamedTuple):
+    x: A # E: Cannot resolve name "A" (possible cyclic definition)
     y: int
 
-class A(NamedTuple): # E
+class A(NamedTuple):
     x: str
     y: B
 
 n: A
-reveal_type(n.y[0]) # N: Revealed type is 'Tuple[builtins.str, Tuple[Any, builtins.int, fallback=__main__.B], fallback=__main__.A]'
+reveal_type(n.y[0]) # N: Revealed type is 'Any'
 [builtins fixtures/tuple.pyi]
-[out]
-main:4: error: Recursive types not fully supported yet, nested types replaced with "Any"
-main:8: error: Recursive types not fully supported yet, nested types replaced with "Any"
 
 [case testSelfRefNT5]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import NamedTuple
 
-B = NamedTuple('B', [ # E: Recursive types not fully supported yet, nested types replaced with "Any"
-        ('x', A),
+B = NamedTuple('B', [
+        ('x', A), # E: Cannot resolve name "A" (possible cyclic definition)
         ('y', int),
     ])
-A = NamedTuple('A', [ # E: Recursive types not fully supported yet, nested types replaced with "Any"
+A = NamedTuple('A', [
         ('x', str),
         ('y', 'B'),
     ])
 n: A
 def f(m: B) -> None: pass
-reveal_type(n) # N: Revealed type is 'Tuple[builtins.str, Tuple[Tuple[builtins.str, Tuple[Any, builtins.int, fallback=__main__.B], fallback=__main__.A], builtins.int, fallback=__main__.B], fallback=__main__.A]'
-reveal_type(f) # N: Revealed type is 'def (m: Tuple[Tuple[builtins.str, Tuple[Any, builtins.int, fallback=__main__.B], fallback=__main__.A], builtins.int, fallback=__main__.B])'
+reveal_type(n) # N: Revealed type is 'Tuple[builtins.str, Tuple[Any, builtins.int, fallback=__main__.B], fallback=__main__.A]'
+reveal_type(f) # N: Revealed type is 'def (m: Tuple[Any, builtins.int, fallback=__main__.B])'
 [builtins fixtures/tuple.pyi]
 
 [case testRecursiveNamedTupleInBases]
@@ -745,17 +733,17 @@ tp = NamedTuple('tp', [('x', int)])
 [out]
 
 [case testSubclassOfRecursiveNamedTuple]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import List, NamedTuple
 
-class Command(NamedTuple):  # type: ignore
-    subcommands: List['Command']
+class Command(NamedTuple):
+    subcommands: List['Command'] # E: Cannot resolve name "Command" (possible cyclic definition)
 
 class HelpCommand(Command):
     pass
 
 hc = HelpCommand(subcommands=[])
-reveal_type(hc)  # N: Revealed type is 'Tuple[builtins.list[Tuple[builtins.list[Any], fallback=__main__.Command]], fallback=__main__.HelpCommand]'
+reveal_type(hc)  # N: Revealed type is 'Tuple[builtins.list[Any], fallback=__main__.HelpCommand]'
 [builtins fixtures/list.pyi]
 [out]
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1340,34 +1340,34 @@ reveal_type(x['a']['b']) # N: Revealed type is 'builtins.int'
 [builtins fixtures/dict.pyi]
 
 [case testSelfRecursiveTypedDictInheriting]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from mypy_extensions import TypedDict
 
 class MovieBase(TypedDict):
     name: str
     year: int
 
-class Movie(MovieBase): # type: ignore # warning about recursive not fully supported
-    director: 'Movie'
+class Movie(MovieBase):
+    director: 'Movie' # E: Cannot resolve name "Movie" (possible cyclic definition)
 
 m: Movie
-reveal_type(m['director']['name']) # N: Revealed type is 'builtins.str'
+reveal_type(m['director']['name']) # N: Revealed type is 'Any'
 [builtins fixtures/dict.pyi]
 [out]
 
 [case testSubclassOfRecursiveTypedDict]
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import List
 from mypy_extensions import TypedDict
 
-class Command(TypedDict):  # type: ignore
-    subcommands: List['Command']
+class Command(TypedDict):
+    subcommands: List['Command']  # E: Cannot resolve name "Command" (possible cyclic definition)
 
 class HelpCommand(Command):
     pass
 
 hc = HelpCommand(subcommands=[])
-reveal_type(hc)  # N: Revealed type is 'TypedDict('__main__.HelpCommand', {'subcommands': builtins.list[TypedDict('__main__.Command', {'subcommands': builtins.list[Any]})]})'
+reveal_type(hc)  # N: Revealed type is 'TypedDict('__main__.HelpCommand', {'subcommands': builtins.list[Any]})'
 [builtins fixtures/list.pyi]
 [out]
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -958,12 +958,12 @@ takes_int(x)  # E: Argument 1 to "takes_int" has incompatible type <union: 6 ite
 
 [case testRecursiveForwardReferenceInUnion]
 # https://github.com/python/mypy/issues/6445
-# flags: --no-new-semantic-analyzer
+# flags: --new-semantic-analyzer
 from typing import List, Union
 MYTYPE = List[Union[str, "MYTYPE"]]
 [builtins fixtures/list.pyi]
 [out]
-main:4: error: Recursive types not fully supported yet, nested types replaced with "Any"
+main:4: error: Cannot resolve name "MYTYPE" (possible cyclic definition)
 
 [case testNonStrictOptional]
 from typing import Optional, List


### PR DESCRIPTION
There is a feature regression: we no longer expand recursive definition
once. I think that this is acceptable for now. We can either try to
replicate the expansion of recursive definitions later on, or we can
wait until we have full recursive support before we do anything about
this.

Only enabled tests that do something reasonable. Recursive type aliases
and other things still don't work.

Work towards #6445.