### PR TITLE
New semantic analyser: Fix special attrs decorators

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -900,6 +900,8 @@ class NewSemanticAnalyzer(NodeVisitor[None],
 
     def visit_decorator(self, dec: Decorator) -> None:
         self.statement = dec
+        # TODO: better don't modify them at all.
+        dec.decorators = dec.original_decorators.copy()
         dec.func.is_conditional = self.block_depth[-1] > 0
         if not dec.is_overload:
             self.add_symbol(dec.name(), dec, dec)

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1049,3 +1049,18 @@ class B:  # E: Function is missing a type annotation for one or more arguments
 
 reveal_type(B)  # N: Revealed type is 'def (x: Any) -> __main__.B'
 [builtins fixtures/list.pyi]
+
+[case testAttrsDefaultDecoratorDeferred]
+defer: Yes
+
+import attr
+@attr.s
+class C(object):
+    x: int = attr.ib(default=1)
+    y: int = attr.ib()
+    @y.default
+    def inc(self):
+        return self.x + 1
+
+class Yes: ...
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1064,3 +1064,20 @@ class C(object):
 
 class Yes: ...
 [builtins fixtures/list.pyi]
+
+[case testAttrsValidatorDecoratorDeferred]
+defer: Yes
+
+import attr
+@attr.s
+class C(object):
+    x = attr.ib()
+    @x.validator
+    def check(self, attribute, value):
+        if value > 42:
+            raise ValueError("x must be smaller or equal to 42")
+C(42)
+C(43)
+
+class Yes: ...
+[builtins fixtures/exception.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/6953

I first thought about actually not modifying them in `attrs` plugin, but this is non-trivial, plus there are few places apart from the plugin where we modify decorators. So for now I just restore them after each iteration (in the same way we do this for overloads and other things).