### PR TITLE
Remove miscellaneous 'is None' checks

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -113,7 +113,7 @@ class BuildSourceSet:
             return True
         elif file._fullname in self.source_modules:
             return True
-        elif file.path is None and self.source_text_present:
+        elif self.source_text_present:
             return True
         else:
             return False

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -376,10 +376,9 @@ class Errors:
         for file, line, column, severity, message in errors:
             s = ''
             if file is not None:
-                if self.show_column_numbers and line is not None and line >= 0 \
-                        and column is not None and column >= 0:
+                if self.show_column_numbers and line >= 0  and column >= 0:
                     srcloc = '{}:{}:{}'.format(file, line, 1 + column)
-                elif line is not None and line >= 0:
+                elif line >= 0:
                     srcloc = '{}:{}'.format(file, line)
                 else:
                     srcloc = file

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -376,7 +376,7 @@ class Errors:
         for file, line, column, severity, message in errors:
             s = ''
             if file is not None:
-                if self.show_column_numbers and line >= 0  and column >= 0:
+                if self.show_column_numbers and line >= 0 and column >= 0:
                     srcloc = '{}:{}:{}'.format(file, line, 1 + column)
                 elif line >= 0:
                     srcloc = '{}:{}'.format(file, line)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -232,7 +232,7 @@ class MypyFile(SymbolNode):
 
     # Fully qualified module name
     _fullname = None  # type: Bogus[str]
-    # Path to the file (None if not known)
+    # Path to the file (empty string if not known)
     path = ''
     # Top-level definitions and statements
     defs = None  # type: List[Statement]

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -290,8 +290,7 @@ class MypyFile(SymbolNode):
         return visitor.visit_mypy_file(self)
 
     def is_package_init_file(self) -> bool:
-        return not (self.path is None) and len(self.path) != 0 \
-            and os.path.basename(self.path).startswith('__init__.')
+        return len(self.path) != 0 and os.path.basename(self.path).startswith('__init__.')
 
     def serialize(self) -> JsonDict:
         return {'.class': 'MypyFile',

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -92,7 +92,7 @@ class StrConv(NodeVisitor[str]):
         # Omit path to special file with name "main". This is used to simplify
         # test case descriptions; the file "main" is used by default in many
         # test cases.
-        if o.path is not None and o.path != 'main':
+        if o.path != 'main':
             # Insert path. Normalize directory separators to / to unify test
             # case# output in all platforms.
             a.insert(0, o.path.replace(os.sep, '/'))

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -1,7 +1,8 @@
 """Generic abstract syntax tree node visitor"""
 
 from abc import abstractmethod
-from typing import TypeVar, Generic, TYPE_CHECKING
+from typing import TypeVar, Generic
+from typing_extensions import TYPE_CHECKING
 from mypy_extensions import trait
 
 if TYPE_CHECKING:

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -1,10 +1,10 @@
 """Generic abstract syntax tree node visitor"""
 
 from abc import abstractmethod
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, TYPE_CHECKING
 from mypy_extensions import trait
 
-if False:
+if TYPE_CHECKING:
     # break import cycle only needed for mypy
     import mypy.nodes
 


### PR DESCRIPTION
I'm embarking on a (probably futile) quest to get mypy to type-check cleanly under the new `--warn-unreachable` flag.

This pull request starts off by tackling some of the low-hanging fruit. Specifically, I make three changes:

1. I removed some unnecessary 'is None' checks for the MypyFile.path field, which is annotated to be of just type `str`, not `Optional[str]`.

    As a side-effect, this ends up fixing one itty-bitty bug: previously, we would not generate reports when running something like `mypy --any-exprs-report report_dir -c 'print("foobar")`.

2. I removed unnecessary "is this line or column None" checks from errors.py: those variables are only ever ints; we use "-1" as placeholders if those values are missing from various error messages.

3. I swapped a `is False:` check in visitors.py with a `is TYPE_CHECKING:` check. (As a simplification, mypy considers the former to be unreachable when type-checking.

Each of these three changes are split out into separate commits, in case that'll help simplify code reviewing.