### PR TITLE
New analyser: use placeholder type full name correctly

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2828,7 +2828,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                         #     T = TypeVar('T', bound=Custom[Any])
                         #     class Custom(Generic[T]):
                         #         ...
-                        analyzed = PlaceholderType('<unknown>', [], context.line)
+                        analyzed = PlaceholderType(None, [], context.line)
                     upper_bound = analyzed
                     if isinstance(upper_bound, AnyType) and upper_bound.is_from_error:
                         self.fail("TypeVar 'bound' must be a type", param_value)
@@ -2893,7 +2893,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     # Type variables are special: we need to place them in the symbol table
                     # soon, even if some value is not ready yet, see process_typevar_parameters()
                     # for an example.
-                    analyzed = PlaceholderType('<unknown>', [], node.line)
+                    analyzed = PlaceholderType(None, [], node.line)
                 result.append(analyzed)
             except TypeTranslationError:
                 self.fail('Type expected', node)

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -540,8 +540,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         return t
 
     def visit_placeholder_type(self, t: PlaceholderType) -> Type:
-        n = self.api.lookup_fully_qualified(t.fullname)
-        if isinstance(n.node, PlaceholderNode):
+        n = None if t.fullname is None else self.api.lookup_fully_qualified(t.fullname)
+        if not n or isinstance(n.node, PlaceholderNode):
             self.api.defer()  # Still incomplete
             return t
         else:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1871,9 +1871,9 @@ class PlaceholderType(Type):
     exist.
     """
 
-    def __init__(self, fullname: str, args: List[Type], line: int) -> None:
+    def __init__(self, fullname: Optional[str], args: List[Type], line: int) -> None:
         super().__init__(line)
-        self.fullname = fullname  # Only used for debugging
+        self.fullname = fullname  # Must be a valid full name of an actual node (or None).
         self.args = args
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2795,3 +2795,53 @@ S = TypeVar('S', covariant=True, contravariant=True)  # E: TypeVar cannot be bot
 
 class Yes: ...
 [builtins fixtures/bool.pyi]
+
+[case testNewAnalyzerVarTypeVarNoCrash]
+from typing import Callable, TypeVar
+
+FooT = TypeVar('FooT', bound='Foo')
+class Foo: ...
+
+f = lambda x: True  # type: Callable[[FooT], bool]
+reveal_type(f)  # N: Revealed type is 'def [FooT <: __main__.Foo] (FooT`-1) -> builtins.bool'
+[builtins fixtures/bool.pyi]
+
+[case testNewAnalyzerVarTypeVarNoCrashImportCycle]
+import a
+
+[file a.py]
+from b import B
+from typing import TypeVar
+
+FooT = TypeVar('FooT', bound='Foo')
+class Foo: ...
+
+[file b.py]
+from a import FooT
+from typing import Callable
+
+f = lambda x: True  # type: Callable[[FooT], bool]
+reveal_type(f)  # N: Revealed type is 'def [FooT <: a.Foo] (FooT`-1) -> builtins.bool'
+
+class B: ...
+[builtins fixtures/bool.pyi]
+
+[case testNewAnalyzerFuncTypeVarNoCrashImportCycle]
+import a
+
+[file a.py]
+from b import B
+from typing import TypeVar
+
+FooT = TypeVar('FooT', bound='Foo')
+class Foo: ...
+
+[file b.py]
+from a import FooT
+from typing import Callable
+
+def f(x: FooT) -> bool: ...
+reveal_type(f)  # N: Revealed type is 'def [FooT <: a.Foo] (x: FooT`-1) -> builtins.bool'
+
+class B: ...
+[builtins fixtures/bool.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7102

This switches from using `'<unknown>'` to `None` as full name for placeholder types without a known node (and also update the outdated comment).