### PR TITLE
Fix type variables leaking from inference

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2622,7 +2622,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         We implement this here by giving x a valid type (replacing inferred <nothing> with Any).
         """
-        self.set_inferred_type(var, lvalue, type.accept(SetNothingToAny()))
+        fallback = type.accept(SetNothingToAny())
+        # Type variables may leak from inference, see https://github.com/python/mypy/issues/5738,
+        # we therefore need to erase them.
+        self.set_inferred_type(var, lvalue, erase_typevars(fallback))
 
     def check_simple_assignment(self, lvalue_type: Optional[Type], rvalue: Expression,
                                 context: Context,

--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -419,3 +419,12 @@ if MYPY:
 [file lib.pyi]
 x = b'abc'
 [out]
+
+[case testNestedGenericFailedInference]
+from collections import defaultdict
+def foo() -> None:
+    x = defaultdict(list)  # type: ignore
+    x['lol'].append(10)
+    reveal_type(x)
+[out]
+_testNestedGenericFailedInference.py:5: note: Revealed type is 'collections.defaultdict[Any, builtins.list[Any]]'


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7101

This fixes another manifestation of an old issue where type variables can leak where a generic function is passed as an argument to another generic function.