### PR TITLE
Fix new semantic analyser crash on unpacking to star lvalue and enable sample tests

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -34,7 +34,7 @@ from mypy.types import (
     Instance, NoneType, strip_type, TypeType, TypeOfAny,
     UnionType, TypeVarId, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarDef,
     true_only, false_only, function_type, is_named_instance, union_items, TypeQuery, LiteralType,
-    is_optional, remove_optional, TypeTranslator
+    is_optional, remove_optional, TypeTranslator, StarType
 )
 from mypy.sametypes import is_same_type
 from mypy.messages import MessageBuilder, make_inferred_type_note, append_invariance_notes
@@ -2529,6 +2529,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                      # we put Uninhabited if there is no information available from lvalue.
                      UninhabitedType() for sub_expr in lvalue.items]
             lvalue_type = TupleType(types, self.named_type('builtins.tuple'))
+        elif isinstance(lvalue, StarExpr):
+            typ, _, _ = self.check_lvalue(lvalue.expr)
+            lvalue_type = StarType(typ) if typ else None
         else:
             lvalue_type = self.expr_checker.accept(lvalue)
 

--- a/mypy/test/testsamples.py
+++ b/mypy/test/testsamples.py
@@ -47,7 +47,7 @@ class TypeshedSuite(Suite):
 class SamplesSuite(Suite):
     def test_samples(self) -> None:
         for f in find_files(os.path.join('test-data', 'samples'), suffix='.py'):
-            mypy_args = ['--no-strict-optional', '--no-new-semantic-analyzer']
+            mypy_args = ['--no-strict-optional']
             if f == os.path.join('test-data', 'samples', 'crawl2.py'):
                 # This test requires 3.5 for async functions
                 mypy_args.append('--python-version=3.5')

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2740,3 +2740,12 @@ def f() -> Callable[..., NoReturn]: ...
 
 x = f()
 reveal_type(x)  # N: Revealed type is 'def (*Any, **Any) -> <nothing>'
+
+[case testDeferralInNestedScopes]
+# flags: --new-semantic-analyzer
+
+def g() -> None:
+    def f() -> None:
+        x + 'no way'  # E: Unsupported operand types for + ("int" and "str")
+    x = int()
+    f()

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2869,4 +2869,5 @@ from typing import Tuple
 def f() -> None:
     t: Tuple[str, Tuple[str, str, str]]
     x, (y, *z) = t
+    reveal_type(z)  # N: Revealed type is 'builtins.list[builtins.str*]'
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2862,3 +2862,11 @@ reveal_type(f)  # N: Revealed type is 'def [FooT <: a.Foo] (x: FooT`-1) -> built
 
 class B: ...
 [builtins fixtures/bool.pyi]
+
+[case testNewAnalyzerNoCrashOnStarInference]
+from typing import Tuple
+
+def f() -> None:
+    t: Tuple[str, Tuple[str, str, str]]
+    x, (y, *z) = t
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7117

As explained in the issue this didn't crash with old analyser because it was compensated by another bug: `Var.is_ready` was set to `True` in some conditions thus silently inferring an `Any` type instead of deferring the node, see added test.

The actual crash was caused by the fact that star lvalue was previously checked as a generic reference expression, instead of processing it as name definition, thus triggering a bogus unexpected deferral.