### PR TITLE
New semantic analyzer: fail fast if deferring during final iteration

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -4194,6 +4194,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         This must not be called during the final analysis iteration!
         Instead, an error should be generated.
         """
+        assert not self.final_iteration, 'Must not defer during final iteration'
         self.deferred = True
 
     def track_incomplete_refs(self) -> Tag:


### PR DESCRIPTION
This produces a more useful stack trace than the existing check,
which happens after a target has already been analyzed.

I'm still keeping the old check just in case.