### PR TITLE
New analyser: Fix Any kinds for special forms

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -156,6 +156,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def analyze_ref_expr(self, e: RefExpr, lvalue: bool = False) -> Type:
         result = None  # type: Optional[Type]
         node = e.node
+
+        if isinstance(e, NameExpr) and e.is_special_form:
+            # A special form definition, nothing to check here.
+            return AnyType(TypeOfAny.special_form)
+
         if isinstance(node, Var):
             # Variable reference.
             result = self.analyze_var_ref(node, e)

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -246,7 +246,7 @@ def bar(x):
 Total      1      13     92.31%
 
 [case testAnyExprReportHigherKindedTypesAreNotAny]
-# cmd: mypy --no-new-semantic-analyzer --any-exprs-report report i.py
+# cmd: mypy --new-semantic-analyzer --any-exprs-report report i.py
 
 [file i.py]
 from enum import Enum
@@ -283,9 +283,9 @@ def g(m: Movie) -> Movie:
 [outfile report/any-exprs.txt]
  Name   Anys   Exprs   Coverage
 ---------------------------------
-    i      0      16    100.00%
+    i      0      14    100.00%
 ---------------------------------
-Total      0      16    100.00%
+Total      0      14    100.00%
 
 
 [case testAnyExpressionsReportTypesOfAny]
@@ -382,7 +382,7 @@ empty = False
       1       1      0      0 a
 
 [case testAnyExprReportIgnoresSpecialForms]
-# cmd: mypy --no-new-semantic-analyzer --any-exprs-report report i.py j.py k.py l.py
+# cmd: mypy --any-exprs-report report i.py j.py k.py l.py
 
 [file i.py]
 async def some_function() -> None:


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7118

Previously left hand sides of special forms were inferred as `TypeOfAny.from_error`. Note that _total_ number of expressions in one of the tests is now smaller because of the subtle logic in visiting definitions of special forms, but I don't think it is import to keep it one-to-one with old analyser.