### PR TITLE
Fix --strict-equality for decorated and aliased __eq__ methods

### DIFF
--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -2226,7 +2226,7 @@ F = TypeVar('F', bound=Callable[..., Any])
 def deco(f: F) -> F: ...
 
 class Custom:
-    @ deco
+    @deco
     def __eq__(self, other: object) -> bool: ...
 
 Custom() == int()

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -2217,6 +2217,30 @@ o in exp
 [builtins fixtures/list.pyi]
 [typing fixtures/typing-full.pyi]
 
+[case testCustomEqDecoratedStrictEquality]
+# flags: --strict-equality
+from typing import TypeVar, Callable, Any
+
+F = TypeVar('F', bound=Callable[..., Any])
+
+def deco(f: F) -> F: ...
+
+class Custom:
+    @ deco
+    def __eq__(self, other: object) -> bool: ...
+
+Custom() == int()
+[builtins fixtures/bool.pyi]
+
+[case testCustomEqVarStrictEquality]
+# flags: --strict-equality
+
+class Custom:
+    def compare(self, other: object) -> bool: ...
+    __eq__ = compare
+
+Custom() == int()
+[builtins fixtures/bool.pyi]
 
 [case testUnimportedHintAny]
 def f(x: Any) -> None:  # E: Name 'Any' is not defined \


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7035

The fix is straightforward: we use `get()` instead of `get_method()` and check for more symbol kinds.