### PR TITLE
Add infrastructure for testing order of processing nodes in new analyser

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -572,6 +572,10 @@ class BuildManager:
         self.plugins_snapshot = plugins_snapshot
         self.old_plugins_snapshot = read_plugins_snapshot(self)
         self.quickstart_state = read_quickstart_file(options, self.stdout)
+        # Fine grained targets (module top levels and top level functions) processed by
+        # the semantic analyzer, used only for testing. Currently used only by the new
+        # semantic analyzer.
+        self.processed_targets = []  # type: List[str]
 
     def dump_stats(self) -> None:
         self.log("Stats:")

--- a/mypy/newsemanal/semanal_main.py
+++ b/mypy/newsemanal/semanal_main.py
@@ -297,6 +297,7 @@ def semantic_analyze_target(target: str,
     - was some definition incomplete
     - were any new names were defined (or placeholders replaced)
     """
+    state.manager.processed_targets.append(target)
     tree = state.tree
     assert tree is not None
     analyzer = state.manager.new_semantic_analyzer

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -115,32 +115,30 @@ def assert_string_arrays_equal(expected: List[str], actual: List[str],
 
 
 def assert_module_equivalence(name: str,
-                              expected: Optional[Iterable[str]], actual: Iterable[str]) -> None:
-    if expected is not None:
-        expected_normalized = sorted(expected)
-        actual_normalized = sorted(set(actual).difference({"__main__"}))
-        assert_string_arrays_equal(
-            expected_normalized,
-            actual_normalized,
-            ('Actual modules ({}) do not match expected modules ({}) '
-             'for "[{} ...]"').format(
-                 ', '.join(actual_normalized),
-                 ', '.join(expected_normalized),
-                 name))
+                              expected: Iterable[str], actual: Iterable[str]) -> None:
+    expected_normalized = sorted(expected)
+    actual_normalized = sorted(set(actual).difference({"__main__"}))
+    assert_string_arrays_equal(
+        expected_normalized,
+        actual_normalized,
+        ('Actual modules ({}) do not match expected modules ({}) '
+         'for "[{} ...]"').format(
+             ', '.join(actual_normalized),
+             ', '.join(expected_normalized),
+             name))
 
 
 def assert_target_equivalence(name: str,
-                              expected: Optional[List[str]], actual: List[str]) -> None:
+                              expected: List[str], actual: List[str]) -> None:
     """Compare actual and expected targets (order sensitive)."""
-    if expected is not None:
-        assert_string_arrays_equal(
-            expected,
-            actual,
-            ('Actual targets ({}) do not match expected targets ({}) '
-             'for "[{} ...]"').format(
-                 ', '.join(actual),
-                 ', '.join(expected),
-                 name))
+    assert_string_arrays_equal(
+        expected,
+        actual,
+        ('Actual targets ({}) do not match expected targets ({}) '
+         'for "[{} ...]"').format(
+             ', '.join(actual),
+             ', '.join(expected),
+             name))
 
 
 def update_testcase_output(testcase: DataDrivenTestCase, output: List[str]) -> None:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -16,9 +16,10 @@ from mypy.test.data import (
 from mypy.test.helpers import (
     assert_string_arrays_equal, normalize_error_messages, assert_module_equivalence,
     retry_on_error, update_testcase_output, parse_options,
-    copy_and_fudge_mtime
+    copy_and_fudge_mtime, assert_target_equivalence
 )
 from mypy.errors import CompileError
+from mypy.newsemanal.semanal_main import core_modules
 
 
 # List of files that contain test case descriptions.
@@ -222,6 +223,15 @@ class TypeCheckSuite(DataSuite):
             if options.cache_dir != os.devnull:
                 self.verify_cache(module_data, res.errors, res.manager, res.graph)
 
+            if options.new_semantic_analyzer:
+                name = 'targets'
+                if incremental_step:
+                    name += str(incremental_step + 1)
+                expected = testcase.expected_fine_grained_targets.get(incremental_step + 1)
+                actual = res.manager.processed_targets
+                # Skip the initial builtin cycle.
+                actual = [t for t in actual if not any(t.startswith(mod) for mod in core_modules)]
+                assert_target_equivalence(name, expected, actual)
             if incremental_step > 1:
                 suffix = '' if incremental_step == 2 else str(incremental_step - 1)
                 assert_module_equivalence(

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -231,17 +231,20 @@ class TypeCheckSuite(DataSuite):
                 actual = res.manager.processed_targets
                 # Skip the initial builtin cycle.
                 actual = [t for t in actual if not any(t.startswith(mod) for mod in core_modules)]
-                assert_target_equivalence(name, expected, actual)
+                if expected is not None:
+                    assert_target_equivalence(name, expected, actual)
             if incremental_step > 1:
                 suffix = '' if incremental_step == 2 else str(incremental_step - 1)
-                assert_module_equivalence(
-                    'rechecked' + suffix,
-                    testcase.expected_rechecked_modules.get(incremental_step - 1),
-                    res.manager.rechecked_modules)
-                assert_module_equivalence(
-                    'stale' + suffix,
-                    testcase.expected_stale_modules.get(incremental_step - 1),
-                    res.manager.stale_modules)
+                expected_rechecked = testcase.expected_rechecked_modules.get(incremental_step - 1)
+                if expected_rechecked is not None:
+                    assert_module_equivalence(
+                        'rechecked' + suffix,
+                        expected_rechecked, res.manager.rechecked_modules)
+                expected_stale = testcase.expected_stale_modules.get(incremental_step - 1)
+                if expected_stale is not None:
+                    assert_module_equivalence(
+                        'stale' + suffix,
+                        expected_stale, res.manager.stale_modules)
 
     def verify_cache(self, module_data: List[Tuple[str, str, str]], a: List[str],
                      manager: build.BuildManager, graph: Graph) -> None:

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -133,18 +133,23 @@ class FineGrainedSuite(DataSuite):
                 changed = [mod for mod, file in server.fine_grained_manager.changed_modules]
                 targets = server.fine_grained_manager.processed_targets
 
-            assert_module_equivalence(
-                'stale' + str(step - 1),
-                testcase.expected_stale_modules.get(step - 1),
-                changed)
-            assert_module_equivalence(
-                'rechecked' + str(step - 1),
-                testcase.expected_rechecked_modules.get(step - 1),
-                updated)
-            assert_target_equivalence(
-                'targets' + str(step),
-                testcase.expected_fine_grained_targets.get(step),
-                targets)
+            expected_stale = testcase.expected_stale_modules.get(step - 1)
+            if expected_stale is not None:
+                assert_module_equivalence(
+                    'stale' + str(step - 1),
+                    expected_stale, changed)
+
+            expected_rechecked = testcase.expected_rechecked_modules.get(step - 1)
+            if expected_rechecked is not None:
+                assert_module_equivalence(
+                    'rechecked' + str(step - 1),
+                    expected_rechecked, updated)
+
+            expected = testcase.expected_fine_grained_targets.get(step)
+            if expected:
+                assert_target_equivalence(
+                    'targets' + str(step),
+                    expected, targets)
 
             new_messages = normalize_messages(new_messages)
 

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2992,3 +2992,16 @@ class C:
             def f(self) -> None: pass
 
         Method()  # E: Cannot instantiate abstract class 'Method' with abstract attribute 'f'
+
+[case testModulesAndFuncsTargetsInCycle]
+import a
+[file a.py]
+import b
+
+def func() -> int: ...
+
+[file b.py]
+import a
+
+def func() -> int: ...
+[targets a, b, b.func, a.func, __main__]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2997,11 +2997,11 @@ class C:
 import a
 [file a.py]
 import b
-
+defer: Yes
 def func() -> int: ...
-
+class Yes: ...
 [file b.py]
 import a
 
 def func() -> int: ...
-[targets a, b, b.func, a.func, __main__]
+[targets a, b, a, b.func, a.func, __main__]


### PR DESCRIPTION
See https://github.com/python/mypy/issues/6341

This PR doesn't add actual tests, just the infra. I simply expose the existing machinery we use in the fine grained mode also to the normal tests.

Using this opportunity I also refactor `assert_module_equivalence()` and `assert_target_equivalence()` by moving `is None` checks to callers.