### PR TITLE
New analyzer: update documentation of becomes_typeinfo

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2794,7 +2794,7 @@ class PlaceholderNode(SymbolNode):
       node: AST node that contains the definition that caused this to
           be created. This is useful for tracking order of incomplete definitions
           and for debugging.
-      becomes_typeinfo: If True, this refers something that will later
+      becomes_typeinfo: If True, this refers something that could later
           become a TypeInfo. It can't be used with type variables, in
           particular, as this would cause issues with class type variable
           detection.


### PR DESCRIPTION
In some cases we don't know whether something could become a TypeInfo,
but it might. Not sure if this is the best way to do this, but this
helps in some scenarios (but could cause problems in others, perhaps).

Follow-up to #7158.