### PR TITLE
Enable new semantic analyzer by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,19 @@ jobs:
     python: 3.6    # 3.6.3  pip  9.0.1
   - name: "run test suite with python 3.7"
     python: 3.7    # 3.7.0  pip 10.0.1
-  - name: "run test suite with python 3.5.1 (new semantic analyzer)"
+  - name: "run test suite with python 3.5.1 (old semantic analyzer)"
     python: 3.5.1
     dist: trusty
     env:
     - TOXENV=py
     - EXTRA_ARGS="-n 12"
-    - NEWSEMANAL=1
-  - name: "run test suite with python 3.7 (new semantic analyzer)"
+    - NEWSEMANAL=0
+  - name: "run test suite with python 3.7 (old semantic analyzer)"
     python: 3.7
     env:
     - TOXENV=py
     - EXTRA_ARGS="-n 12"
-    - NEWSEMANAL=1
+    - NEWSEMANAL=0
   - name: "run test suite with python 3.7 (compiled with mypyc)"
     python: 3.7
     env:

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -659,8 +659,8 @@ Miscellaneous
     have many scripts that import a large package, the behavior enabled
     by this flag is often more convenient.)
 
-``--new-semantic-analyzer``
-    This flag switches to an improved, experimental implementation of
+``--no-new-semantic-analyzer``
+    This flag disables the improved implementation of
     the *semantic analyzer* (the part of mypy that binds Python
     names to definitions). The old and the new semantic analyzers
     mostly behave identically. The new semantic analyzer is better at
@@ -668,9 +668,8 @@ Miscellaneous
     also fixes inconsistencies between the daemon and non-daemon modes,
     and it detects additional error conditions.
 
-    Likely, the next mypy release will use the new semantic analyzer by
-    default, and the old semantic analyzer will be removed in the next
-    release after that.
+    Likely, the old semantic analyzer will be removed in the next
+    release.
 
 .. _PEP 420: https://www.python.org/dev/peps/pep-0420/
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -470,6 +470,6 @@ Miscellaneous
 ``verbosity`` (integer, default 0)
     Controls how much debug output will be generated.  Higher numbers are more verbose.
 
-``new_semantic_analyzer`` (bool, default False)
-    Enables the experimental new semantic analyzer.
+``new_semantic_analyzer`` (bool, default True)
+    Enables the new, improved, semantic analyzer.
     (See :ref:`The mypy command line <command-line>` for more information.)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -554,7 +554,7 @@ def process_options(args: List[str],
              "the contents of SHADOW_FILE instead.")
     add_invertible_flag('--fast-exit', default=False, help=argparse.SUPPRESS,
                         group=internals_group)
-    add_invertible_flag('--new-semantic-analyzer', default=False, help=argparse.SUPPRESS,
+    add_invertible_flag('--new-semantic-analyzer', default=True, help=argparse.SUPPRESS,
                         group=internals_group)
 
     error_group = parser.add_argument_group(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -554,7 +554,8 @@ def process_options(args: List[str],
              "the contents of SHADOW_FILE instead.")
     add_invertible_flag('--fast-exit', default=False, help=argparse.SUPPRESS,
                         group=internals_group)
-    add_invertible_flag('--new-semantic-analyzer', default=True, help=argparse.SUPPRESS,
+    add_invertible_flag('--no-new-semantic-analyzer', dest='new_semantic_analyzer',
+                        default=True, help=argparse.SUPPRESS,
                         group=internals_group)
 
     error_group = parser.add_argument_group(

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -87,7 +87,12 @@ class Options:
         self.namespace_packages = False
 
         # Use the new semantic analyzer
-        self.new_semantic_analyzer = bool(os.getenv('NEWSEMANAL'))
+        new_analyzer = os.getenv('NEWSEMANAL')
+        if new_analyzer:
+            # Use NEWSEMANAL=0 to change the default (for tests).
+            self.new_semantic_analyzer = bool(int(new_analyzer))
+        else:
+            self.new_semantic_analyzer = True
 
         # disallow_any options
         self.disallow_any_generics = False


### PR DESCRIPTION
The old semantic analyzer is still there and can be used with `--no-new-semantic-analyzer`. For running tests one can use `NEWSEMANAL=0`.