### PR TITLE
Fix self-check (and therefore mypyc) on older Python versions

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4545,9 +4545,8 @@ def try_expanding_enum_to_union(typ: Type, target_fullname: str) -> Type:
     this function will return Literal[Color.RED, Color.BLUE, Color.YELLOW, Status].
     """
     if isinstance(typ, UnionType):
-        new_items = [try_expanding_enum_to_union(item, target_fullname)
-                     for item in typ.items]
-        return UnionType.make_simplified_union(new_items)
+        items = [try_expanding_enum_to_union(item, target_fullname) for item in typ.items]
+        return UnionType.make_simplified_union(items)
     elif isinstance(typ, Instance) and typ.type.is_enum and typ.type.fullname() == target_fullname:
         new_items = []
         for name, symbol in typ.type.names.items():

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1605,7 +1605,7 @@ class UnionType(Type):
             return UninhabitedType()
 
     @staticmethod
-    def make_simplified_union(items: List[Type], line: int = -1, column: int = -1) -> Type:
+    def make_simplified_union(items: Sequence[Type], line: int = -1, column: int = -1) -> Type:
         """Build union type with redundant union items removed.
 
         If only a single item remains, this may return a non-union type.
@@ -1623,6 +1623,7 @@ class UnionType(Type):
         """
         # TODO: Make this a function living somewhere outside mypy.types. Most other non-trivial
         #       type operations are not static methods, so this is inconsistent.
+        items = list(items)
         while any(isinstance(typ, UnionType) for typ in items):
             all_items = []  # type: List[Type]
             for typ in items:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1641,7 +1641,7 @@ class UnionType(Type):
             # Keep track of the truishness info for deleted subtypes which can be relevant
             cbt = cbf = False
             for j, tj in enumerate(items):
-                if (i != j and is_proper_subtype(tj, ti)):
+                if i != j and is_proper_subtype(tj, ti):
                     # We found a redundant item in the union.
                     removed.add(j)
                     cbt = cbt or tj.can_be_true


### PR DESCRIPTION
This also implements one of my old wishes: `UnionType.make_simplified_union()` should not mutate its argument.