### PR TITLE
Support selecting TypedDicts from unions

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -54,6 +54,12 @@ def narrow_declared_type(declared: Type, narrowed: Type) -> Type:
         return TypeType.make_normalized(narrow_declared_type(declared.item, narrowed.item))
     elif isinstance(declared, (Instance, TupleType, TypeType, LiteralType)):
         return meet_types(declared, narrowed)
+    elif isinstance(declared, TypedDictType) and isinstance(narrowed, Instance):
+        # Special case useful for selecting TypedDicts from unions using isinstance(x, dict).
+        if (narrowed.type.fullname() == 'builtins.dict' and
+                all(isinstance(t, AnyType) for t in narrowed.args)):
+            return declared
+        return narrowed
     return narrowed
 
 

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -59,7 +59,7 @@ def narrow_declared_type(declared: Type, narrowed: Type) -> Type:
         if (narrowed.type.fullname() == 'builtins.dict' and
                 all(isinstance(t, AnyType) for t in narrowed.args)):
             return declared
-        return narrowed
+        return meet_types(declared, narrowed)
     return narrowed
 
 
@@ -484,6 +484,8 @@ class TypeMeetVisitor(TypeVisitor[Type]):
             return meet_types(t, self.s)
         elif isinstance(self.s, LiteralType):
             return meet_types(t, self.s)
+        elif isinstance(self.s, TypedDictType):
+            return meet_types(t, self.s)
         return self.default(self.s)
 
     def visit_callable_type(self, t: CallableType) -> Type:
@@ -561,6 +563,8 @@ class TypeMeetVisitor(TypeVisitor[Type]):
             fallback = self.s.create_anonymous_fallback(value_type=mapping_value_type)
             required_keys = t.required_keys | self.s.required_keys
             return TypedDictType(items, required_keys, fallback)
+        elif isinstance(self.s, Instance) and is_subtype(t, self.s):
+            return t
         else:
             return self.default(self.s)
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1131,7 +1131,9 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
                 # Map left type to corresponding right instances.
                 left = map_instance_to_supertype(left, right.type)
                 if self.erase_instances:
-                    left = erase_type(left)
+                    erased = erase_type(left)
+                    assert isinstance(erased, Instance)
+                    left = erased
 
                 nominal = all(check_argument(ta, ra, tvar.variance) for ta, ra, tvar in
                               zip(left.args, right.args, right.type.defn.type_vars))

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -580,7 +580,6 @@ def g(x: X, y: M) -> None: pass
 reveal_type(f(g))  # N: Revealed type is '<nothing>'
 [builtins fixtures/dict.pyi]
 
-# TODO: It would be more accurate for the meet to be TypedDict instead.
 [case testMeetOfTypedDictWithCompatibleMappingSuperclassIsUninhabitedForNow]
 # flags: --strict-optional
 from mypy_extensions import TypedDict
@@ -590,7 +589,7 @@ I = Iterable[str]
 T = TypeVar('T')
 def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: X, y: I) -> None: pass
-reveal_type(f(g))  # N: Revealed type is '<nothing>'
+reveal_type(f(g))  # N: Revealed type is 'TypedDict('__main__.X', {'x': builtins.int})'
 [builtins fixtures/dict.pyi]
 
 [case testMeetOfTypedDictsWithNonTotal]
@@ -1855,6 +1854,26 @@ else:
     reveal_type(u)  # N: Revealed type is 'builtins.str'
 
 assert isinstance(u2, dict)
+reveal_type(u2)  # N: Revealed type is 'TypedDict('__main__.User', {'id': builtins.int, 'name': builtins.str})'
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
+
+[case testTypedDictIsInstanceABCs]
+from typing import TypedDict, Union, Mapping, Iterable
+
+class User(TypedDict):
+    id: int
+    name: str
+
+u: Union[int, User]
+u2: User
+
+if isinstance(u, Iterable):
+    reveal_type(u)  # N: Revealed type is 'TypedDict('__main__.User', {'id': builtins.int, 'name': builtins.str})'
+else:
+    reveal_type(u)  # N: Revealed type is 'builtins.int'
+
+assert isinstance(u2, Mapping)
 reveal_type(u2)  # N: Revealed type is 'TypedDict('__main__.User', {'id': builtins.int, 'name': builtins.str})'
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1838,3 +1838,23 @@ def func(x):
     pass
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
+
+[case testTypedDictIsInstance]
+from typing import TypedDict, Union
+
+class User(TypedDict):
+    id: int
+    name: str
+
+u: Union[str, User]
+u2: User
+
+if isinstance(u, dict):
+    reveal_type(u)  # N: Revealed type is 'TypedDict('__main__.User', {'id': builtins.int, 'name': builtins.str})'
+else:
+    reveal_type(u)  # N: Revealed type is 'builtins.str'
+
+assert isinstance(u2, dict)
+reveal_type(u2)  # N: Revealed type is 'TypedDict('__main__.User', {'id': builtins.int, 'name': builtins.str})'
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]


### PR DESCRIPTION
It is a relatively common pattern to narrow down typed dicts from unions with non-dict types using `isinstance(x, dict)`. Currently mypy infers `Dict[Any, Any]` after such checks which is suboptimal.

I propose to special-case this in `narrow_declared_type()` and `restrict_subtype_away()`. Using this opportunity I factored out special cases from the latter in a separate helper function.

Using this opportunity I also fix an old type erasure bug in `isinstance()` checks (type should be erased after mapping to supertype, not before).