### PR TITLE
Reject fake TypeInfos for TypedDict fallbacks

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -209,6 +209,12 @@ class TypeFixer(TypeVisitor[None]):
             for it in tdt.items.values():
                 it.accept(self)
         if tdt.fallback is not None:
+            if tdt.fallback.type_ref is not None:
+                if lookup_qualified(self.modules, tdt.fallback.type_ref,
+                                    self.allow_missing) is None:
+                    # We reject fake TypeInfos for TypedDict fallbacks because
+                    # the latter are used in type checking and must be valid.
+                    tdt.fallback.type_ref = 'typing._TypedDict'
             tdt.fallback.accept(self)
 
     def visit_literal_type(self, lt: LiteralType) -> None:

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -9061,3 +9061,69 @@ def f() -> str: pass
 [builtins fixtures/classmethod.pyi]
 [out]
 ==
+
+[case testTypedDictCrashFallbackAfterDeletedMeet]
+# flags: --ignore-missing-imports
+
+from z import get_data
+from a import Data
+
+for it in get_data()['things']:
+    it['id']
+
+[file z.py]
+from a import Data
+
+def get_data() -> Data: ...
+
+[file a.py]
+from typing import TypedDict, List, Union
+
+class File(TypedDict):
+    id: int
+    name: str
+
+class User(TypedDict):
+    id: int
+    path: str
+
+class Data(TypedDict):
+    things: List[Union[File, User]]
+
+[delete a.py.2]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
+[out]
+==
+
+[case testTypedDictCrashFallbackAfterDeletedJoin]
+# flags: --ignore-missing-imports
+
+from z import get_data
+from a import Data
+
+x = [get_data()[0], get_data()[1]]
+
+[file z.py]
+from a import Data
+
+def get_data() -> Data: ...
+
+[file a.py]
+from typing import TypedDict, Tuple
+
+class File(TypedDict):
+    id: int
+    name: str
+
+class User(TypedDict):
+    id: int
+    path: str
+
+Data = Tuple[User, File]
+
+[delete a.py.2]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
+[out]
+==


### PR DESCRIPTION
This avoids possible crashes during calculations of meets and joins on a cold update. 

We do this by rejecting a fake ad-hoc `TypeInfo` created by `fixup.py` if a file containing the typed dict fallback was deleted, and instead using the generic `typing._TypedDict` fallback.