### PR TITLE
Support recursive traversal into PEP 420 namespace packages

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -763,7 +763,7 @@ def process_options(args: List[str],
         search_paths = SearchPaths((os.getcwd(),), tuple(mypy_path() + options.mypy_path), (), ())
         targets = []
         # TODO: use the same cache that the BuildManager will
-        cache = FindModuleCache(search_paths, fscache)
+        cache = FindModuleCache(search_paths, fscache, options, special_opts.packages)
         for p in special_opts.packages:
             if os.sep in p or os.altsep and os.altsep in p:
                 fail("Package name '{}' cannot have a slash in it.".format(p),

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1124,6 +1124,19 @@ p/a.py:4: error: Argument 1 to "foo" has incompatible type "str"; expected "int"
 p/b/__init__.py:5: error: Argument 1 to "bar" has incompatible type "str"; expected "int"
 c.py:2: error: Argument 1 to "bar" has incompatible type "str"; expected "int"
 
+[case testSrcPEP420Packages]
+# cmd: mypy -p anamespace --namespace-packages
+[file mypy.ini]
+[[mypy]]
+mypy_path = src
+[file src/setup.cfg]
+[file src/anamespace/foo/__init__.py]
+[file src/anamespace/foo/bar.py]
+def bar(a: int, b: int) -> str:
+    return a + b
+[out]
+src/anamespace/foo/bar.py:2: error: Incompatible return value type (got "int", expected "str")
+
 [case testFollowImportStubs1]
 # cmd: mypy main.py
 [file mypy.ini]


### PR DESCRIPTION
E.g. with this file layout:

```
src/
    anamespace/
        foo/
            __init__.py
            bar.py
```

running

`$ MYPYPATH=src mypy -p foo --namespace-packages`

will traverse into `src/anamespace/foo`

Closes #6989 