### PR TITLE
For --disallow-any-generic, print the name of the type

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -88,7 +88,9 @@ MODULE_LEVEL_GETATTRIBUTE = '__getattribute__ is not valid at the module level' 
 # Generic
 GENERIC_INSTANCE_VAR_CLASS_ACCESS = \
     'Access to generic instance variables via class is ambiguous'  # type: Final
-BARE_GENERIC = 'Missing type parameters for generic type'  # type: Final
+BARE_GENERIC = 'Missing type parameters for generic type {}'  # type: Final
+# TODO: remove when the old semantic analyzer is gone
+BARE_GENERIC_OLD = 'Missing type parameters for generic type'  # type: Final
 IMPLICIT_GENERIC_ANY_BUILTIN = \
     'Implicit generic "Any". Use "{}" and specify generic parameters'  # type: Final
 

--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -443,7 +443,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                     target = self.named_type_or_none(target_name, [])
                     assert target is not None
                     # Transform List to List[Any], etc.
-                    fix_instance_types(target, self.fail, disallow_any=False)
+                    fix_instance_types(target, self.fail)
                     alias_node = TypeAlias(target, alias,
                                            line=-1, column=-1,  # there is no context
                                            no_args=True, normalized=True)
@@ -2449,9 +2449,7 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         # so we need to replace it with non-explicit Anys.
         res = make_any_non_explicit(res)
         no_args = isinstance(res, Instance) and not res.args
-        fix_instance_types(res, self.fail,
-                           disallow_any=self.options.disallow_any_generics and
-                           not self.is_typeshed_stub_file and not no_args)
+        fix_instance_types(res, self.fail)
         if isinstance(s.rvalue, (IndexExpr, CallExpr)):  # CallExpr is for `void = type(None)`
             s.rvalue.analyzed = TypeAliasExpr(res, alias_tvars, no_args)
             s.rvalue.analyzed.line = s.line

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 from typing import Callable, List, Optional, Set, Tuple, Iterator, TypeVar, Iterable
 from typing_extensions import Final
 
-from mypy.messages import MessageBuilder, quote_type_string, format_type, format_type_bare
+from mypy.messages import MessageBuilder, quote_type_string, format_type_bare
 from mypy.options import Options
 from mypy.types import (
     Type, UnboundType, TypeVarType, TupleType, TypedDictType, UnionType, Instance, AnyType,

--- a/mypy/newsemanal/typeanal.py
+++ b/mypy/newsemanal/typeanal.py
@@ -1171,22 +1171,20 @@ def make_optional_type(t: Type) -> Type:
         return UnionType([t, NoneType()], t.line, t.column)
 
 
-def fix_instance_types(t: Type, fail: Callable[[str, Context], None],
-                       disallow_any: bool) -> None:
+def fix_instance_types(t: Type, fail: Callable[[str, Context], None]) -> None:
     """Recursively fix all instance types (type argument count) in a given type.
 
     For example 'Union[Dict, List[str, int]]' will be transformed into
     'Union[Dict[Any, Any], List[Any]]' in place.
     """
-    t.accept(InstanceFixer(fail, disallow_any))
+    t.accept(InstanceFixer(fail))
 
 
 class InstanceFixer(TypeTraverserVisitor):
-    def __init__(self, fail: Callable[[str, Context], None], disallow_any: bool) -> None:
+    def __init__(self, fail: Callable[[str, Context], None]) -> None:
         self.fail = fail
-        self.disallow_any = disallow_any
 
     def visit_instance(self, typ: Instance) -> None:
         super().visit_instance(typ)
         if len(typ.args) != len(typ.type.type_vars):
-            fix_instance(typ, self.fail, self.disallow_any, use_generic_error=True)
+            fix_instance(typ, self.fail, disallow_any=False, use_generic_error=True)

--- a/mypy/semanal_pass3.py
+++ b/mypy/semanal_pass3.py
@@ -500,7 +500,7 @@ class SemanticAnalyzerPass3(TraverserVisitor, SemanticAnalyzerCoreInterface):
 
         for t in collect_any_types(typ):
             if t.type_of_any == TypeOfAny.from_omitted_generics:
-                self.fail(message_registry.BARE_GENERIC, t)
+                self.fail(message_registry.BARE_GENERIC_OLD, t)
 
     def lookup_qualified(self, name: str, ctx: Context,
                          suppress_errors: bool = False) -> Optional[SymbolTableNode]:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -267,7 +267,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             if len(t.args) == 0 and not t.empty_tuple_index:
                 # Bare 'Tuple' is same as 'tuple'
                 if self.options.disallow_any_generics and not self.is_typeshed_stub:
-                    self.fail(message_registry.BARE_GENERIC, t)
+                    self.fail(message_registry.BARE_GENERIC_OLD, t)
                 return self.named_type('builtins.tuple', line=t.line, column=t.column)
             if len(t.args) == 2 and isinstance(t.args[1], EllipsisType):
                 # Tuple[T, ...] (uniform, variable-length tuple)

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -173,12 +173,12 @@ class D(A):
     def f(self) -> None: pass # E:5: Signature of "f" incompatible with supertype "A"
 
 [case testColumnMissingTypeParameters]
-# flags: --disallow-any-generics
+# flags: --new-semantic-analyzer --disallow-any-generics
 from typing import List, Callable
-def f(x: List) -> None: pass # E:10: Missing type parameters for generic type
+def f(x: List) -> None: pass # E:10: Missing type parameters for generic type "list"
 def g(x: list) -> None: pass # E:10: Implicit generic "Any". Use "typing.List" and specify generic parameters
 if int():
-    c: Callable # E:8: Missing type parameters for generic type
+    c: Callable # E:8: Missing type parameters for generic type "Callable"
 [builtins fixtures/list.pyi]
 
 [case testColumnIncompatibleDefault]

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -175,7 +175,7 @@ class D(A):
 [case testColumnMissingTypeParameters]
 # flags: --new-semantic-analyzer --disallow-any-generics
 from typing import List, Callable
-def f(x: List) -> None: pass # E:10: Missing type parameters for generic type "list"
+def f(x: List) -> None: pass # E:10: Missing type parameters for generic type "List"
 def g(x: list) -> None: pass # E:10: Implicit generic "Any". Use "typing.List" and specify generic parameters
 if int():
     c: Callable # E:8: Missing type parameters for generic type "Callable"

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1168,6 +1168,6 @@ main:2: error: Module 'other_module_2' has no attribute 'a'
 from typing import List
 
 A = List  # OK
-B = List[A]  # E:10: Missing type parameters for generic type "list"
+B = List[A]  # E:10: Missing type parameters for generic type "A"
 x: A  # E:4: Missing type parameters for generic type "A"
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1105,7 +1105,7 @@ from typing import TypeVar, Callable
 T = TypeVar('T')
 C = Callable[[], T]
 
-def f(c: C):  # E: Missing type parameters for generic type "Callable[[], T?]"
+def f(c: C):  # E: Missing type parameters for generic type "C"
     pass
 [out]
 
@@ -1169,5 +1169,5 @@ from typing import List
 
 A = List  # OK
 B = List[A]  # E:10: Missing type parameters for generic type "list"
-x: A  # E:4: Missing type parameters for generic type "list"
+x: A  # E:4: Missing type parameters for generic type "A"
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1099,18 +1099,18 @@ def f(c: C) -> None:
 [out]
 
 [case testCheckDisallowAnyGenericsAnyGeneric]
-# flags: --disallow-any-generics
+# flags: --new-semantic-analyzer --disallow-any-generics
 from typing import TypeVar, Callable
 
 T = TypeVar('T')
 C = Callable[[], T]
 
-def f(c: C):  # E: Missing type parameters for generic type
+def f(c: C):  # E: Missing type parameters for generic type "Callable[[], T?]"
     pass
 [out]
 
 [case testStrictAnyGeneric]
-# flags: --strict
+# flags: --new-semantic-analyzer --strict
 from typing import TypeVar, Generic
 
 T = TypeVar('T')
@@ -1118,7 +1118,7 @@ T = TypeVar('T')
 class A(Generic[T]):
     pass
 
-def f(c: A) -> None:  # E: Missing type parameters for generic type
+def f(c: A) -> None:  # E: Missing type parameters for generic type "A"
     pass
 [out]
 
@@ -1164,10 +1164,10 @@ implicit_reexport = False
 main:2: error: Module 'other_module_2' has no attribute 'a'
 
 [case testImplicitAnyOKForNoArgs]
-# flags: --disallow-any-generics --show-column-numbers
+# flags: --new-semantic-analyzer --disallow-any-generics --show-column-numbers
 from typing import List
 
 A = List  # OK
-B = List[A]  # E:10: Missing type parameters for generic type
-x: A  # E:4: Missing type parameters for generic type
+B = List[A]  # E:10: Missing type parameters for generic type "list"
+x: A  # E:4: Missing type parameters for generic type "list"
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-inline-config.test
+++ b/test-data/unit/check-inline-config.test
@@ -5,7 +5,7 @@
 # mypy: disallow-any-generics, no-warn-no-return
 
 from typing import List
-def foo() -> List:  # E: Missing type parameters for generic type "list"
+def foo() -> List:  # E: Missing type parameters for generic type "List"
     20
 
 [builtins fixtures/list.pyi]
@@ -16,7 +16,7 @@ def foo() -> List:  # E: Missing type parameters for generic type "list"
 # mypy: no-warn-no-return
 
 from typing import List
-def foo() -> List:  # E: Missing type parameters for generic type "list"
+def foo() -> List:  # E: Missing type parameters for generic type "List"
     20
 
 [builtins fixtures/list.pyi]
@@ -26,7 +26,7 @@ def foo() -> List:  # E: Missing type parameters for generic type "list"
 # mypy: disallow-any-generics=true, warn-no-return=0
 
 from typing import List
-def foo() -> List:  # E: Missing type parameters for generic type "list"
+def foo() -> List:  # E: Missing type parameters for generic type "List"
     20
 
 [builtins fixtures/list.pyi]
@@ -37,7 +37,7 @@ def foo() -> List:  # E: Missing type parameters for generic type "list"
 # mypy: disallow-any-generics = true, warn-no-return = 0
 
 from typing import List
-def foo() -> List:  # E: Missing type parameters for generic type "list"
+def foo() -> List:  # E: Missing type parameters for generic type "List"
     20
 
 [builtins fixtures/list.pyi]
@@ -48,7 +48,7 @@ def foo() -> List:  # E: Missing type parameters for generic type "list"
 
 from typing import List
 
-def foo(FOO: bool, BAR: bool) -> List:  # E: Missing type parameters for generic type "list"
+def foo(FOO: bool, BAR: bool) -> List:  # E: Missing type parameters for generic type "List"
     if FOO or BAR:
         1+'lol'
     return []
@@ -100,7 +100,7 @@ from typing import List
 def foo() -> List:
     20
 [out]
-tmp/a.py:4: error: Missing type parameters for generic type "list"
+tmp/a.py:4: error: Missing type parameters for generic type "List"
 [out2]
 [out3]
 tmp/a.py:2: error: Missing return statement
@@ -123,7 +123,7 @@ def foo() -> List:
 
 [out]
 [out2]
-tmp/a.py:4: error: Missing type parameters for generic type "list"
+tmp/a.py:4: error: Missing type parameters for generic type "List"
 
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/check-inline-config.test
+++ b/test-data/unit/check-inline-config.test
@@ -1,49 +1,54 @@
 -- Checks for 'mypy: option' directives inside files
 
 [case testInlineSimple1]
+# flags: --new-semantic-analyzer
 # mypy: disallow-any-generics, no-warn-no-return
 
 from typing import List
-def foo() -> List:  # E: Missing type parameters for generic type
+def foo() -> List:  # E: Missing type parameters for generic type "list"
     20
 
 [builtins fixtures/list.pyi]
 
 [case testInlineSimple2]
+# flags: --new-semantic-analyzer
 # mypy: disallow-any-generics
 # mypy: no-warn-no-return
 
 from typing import List
-def foo() -> List:  # E: Missing type parameters for generic type
+def foo() -> List:  # E: Missing type parameters for generic type "list"
     20
 
 [builtins fixtures/list.pyi]
 
 [case testInlineSimple3]
+# flags: --new-semantic-analyzer
 # mypy: disallow-any-generics=true, warn-no-return=0
 
 from typing import List
-def foo() -> List:  # E: Missing type parameters for generic type
+def foo() -> List:  # E: Missing type parameters for generic type "list"
     20
 
 [builtins fixtures/list.pyi]
 
 
 [case testInlineSimple4]
+# flags: --new-semantic-analyzer
 # mypy: disallow-any-generics = true, warn-no-return = 0
 
 from typing import List
-def foo() -> List:  # E: Missing type parameters for generic type
+def foo() -> List:  # E: Missing type parameters for generic type "list"
     20
 
 [builtins fixtures/list.pyi]
 
 [case testInlineList]
+# flags: --new-semantic-analyzer
 # mypy: disallow-any-generics,always-false="FOO,BAR"
 
 from typing import List
 
-def foo(FOO: bool, BAR: bool) -> List:  # E: Missing type parameters for generic type
+def foo(FOO: bool, BAR: bool) -> List:  # E: Missing type parameters for generic type "list"
     if FOO or BAR:
         1+'lol'
     return []
@@ -51,7 +56,7 @@ def foo(FOO: bool, BAR: bool) -> List:  # E: Missing type parameters for generic
 [builtins fixtures/list.pyi]
 
 [case testInlineInvert1]
-# flags: --disallow-any-generics --allow-untyped-globals
+# flags: --new-semantic-analyzer --disallow-any-generics --allow-untyped-globals
 import a
 [file a.py]
 # mypy: allow-any-generics, disallow-untyped-globals
@@ -65,6 +70,7 @@ def foo() -> List:
 [builtins fixtures/list.pyi]
 
 [case testInlineInvert2]
+# flags: --new-semantic-analyzer
 import a
 [file a.py]
 # mypy: no-always-true
@@ -73,6 +79,7 @@ import a
 tmp/a.py:1: error: Can not invert non-boolean key always_true
 
 [case testInlineIncremental1]
+# flags: --new-semantic-analyzer
 import a
 [file a.py]
 # mypy: disallow-any-generics, no-warn-no-return
@@ -93,7 +100,7 @@ from typing import List
 def foo() -> List:
     20
 [out]
-tmp/a.py:4: error: Missing type parameters for generic type
+tmp/a.py:4: error: Missing type parameters for generic type "list"
 [out2]
 [out3]
 tmp/a.py:2: error: Missing return statement
@@ -101,7 +108,8 @@ tmp/a.py:2: error: Missing return statement
 [builtins fixtures/list.pyi]
 
 [case testInlineIncremental2]
-# flags2: --disallow-any-generics
+# flags: --new-semantic-analyzer
+# flags2: --new-semantic-analyzer --disallow-any-generics
 import a
 [file a.py]
 # mypy: no-warn-no-return
@@ -115,7 +123,7 @@ def foo() -> List:
 
 [out]
 [out2]
-tmp/a.py:4: error: Missing type parameters for generic type
+tmp/a.py:4: error: Missing type parameters for generic type "list"
 
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -890,7 +890,7 @@ L = List  # no error
 def f(l: L) -> None: pass  # error
 def g(l: L[str]) -> None: pass  # no error
 [out]
-m.py:5: error: Missing type parameters for generic type "list"
+m.py:5: error: Missing type parameters for generic type "L"
 
 [case testDisallowAnyGenericsGenericAlias]
 # cmd: mypy --new-semantic-analyzer --python-version=3.6 m.py
@@ -912,9 +912,9 @@ def h(s) -> A[str]:  # no error
     return 'a', 'b', 'c'
 x: A = ('a', 'b', 1)  # error
 [out]
-m.py:6: error: Missing type parameters for generic type "Tuple[T?, str, T?]"
-m.py:7: error: Missing type parameters for generic type "Tuple[T?, str, T?]"
-m.py:11: error: Missing type parameters for generic type "Tuple[T?, str, T?]"
+m.py:6: error: Missing type parameters for generic type "A"
+m.py:7: error: Missing type parameters for generic type "A"
+m.py:11: error: Missing type parameters for generic type "A"
 
 [case testDisallowAnyGenericsPlainList]
 # cmd: mypy --new-semantic-analyzer --python-version=3.6 m.py
@@ -934,11 +934,11 @@ def i(l: List[List[List[List]]]) -> None: pass  # error
 x = []  # error: need type annotation
 y: List = []  # error
 [out]
-m.py:3: error: Missing type parameters for generic type "list"
-m.py:5: error: Missing type parameters for generic type "list"
-m.py:6: error: Missing type parameters for generic type "list"
+m.py:3: error: Missing type parameters for generic type "List"
+m.py:5: error: Missing type parameters for generic type "List"
+m.py:6: error: Missing type parameters for generic type "List"
 m.py:8: error: Need type annotation for 'x' (hint: "x: List[<type>] = ...")
-m.py:9: error: Missing type parameters for generic type "list"
+m.py:9: error: Missing type parameters for generic type "List"
 
 [case testDisallowAnyGenericsCustomGenericClass]
 # cmd: mypy --new-semantic-analyzer --python-version=3.6 m.py
@@ -1002,10 +1002,10 @@ def i(s: Set) -> None: pass
 def j(s: FrozenSet) -> None: pass
 [out]
 m.py:3: error: Missing type parameters for generic type "Tuple"
-m.py:4: error: Missing type parameters for generic type "list"
-m.py:5: error: Missing type parameters for generic type "dict"
-m.py:6: error: Missing type parameters for generic type "set"
-m.py:7: error: Missing type parameters for generic type "frozenset"
+m.py:4: error: Missing type parameters for generic type "List"
+m.py:5: error: Missing type parameters for generic type "Dict"
+m.py:6: error: Missing type parameters for generic type "Set"
+m.py:7: error: Missing type parameters for generic type "FrozenSet"
 
 [case testDisallowSubclassingAny]
 # cmd: mypy m.py y.py
@@ -1063,7 +1063,7 @@ strict_optional = True
 [[mypy-a.b.c.d.e]
 ignore_errors = False
 [out]
-a/b/c/d/e/__init__.py:2: error: Missing type parameters for generic type "list"
+a/b/c/d/e/__init__.py:2: error: Missing type parameters for generic type "List"
 a/b/c/d/e/__init__.py:3: error: Argument 1 to "g" has incompatible type "None"; expected "List[Any]"
 
 [case testDisallowUntypedDefsAndGenerics]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -820,7 +820,7 @@ N = TypedDict('N', {'x': str, 'y': List})  # no error
 m.py:4: error: Explicit "Any" is not allowed
 
 [case testDisallowAnyGenericsTupleNoTypeParams]
-# cmd: mypy --python-version=3.6 m.py
+# cmd: mypy --new-semantic-analyzer --python-version=3.6 m.py
 [file mypy.ini]
 [[mypy]
 [[mypy-m]
@@ -836,12 +836,12 @@ def h(s) -> Tuple[str, str]:  # no error
     return 'a', 'b'
 x: Tuple = ()  # error
 [out]
-m.py:3: error: Missing type parameters for generic type
-m.py:4: error: Missing type parameters for generic type
-m.py:8: error: Missing type parameters for generic type
+m.py:3: error: Missing type parameters for generic type Tuple?
+m.py:4: error: Missing type parameters for generic type Tuple?
+m.py:8: error: Missing type parameters for generic type Tuple?
 
 [case testDisallowAnyGenericsTupleWithNoTypeParamsGeneric]
-# cmd: mypy m.py
+# cmd: mypy --new-semantic-analyzer m.py
 [file mypy.ini]
 [[mypy]
 [[mypy-m]
@@ -853,10 +853,10 @@ from typing import Tuple, List
 def f(s: List[Tuple]) -> None: pass  # error
 def g(s: List[Tuple[str, str]]) -> None: pass  # no error
 [out]
-m.py:3: error: Missing type parameters for generic type
+m.py:3: error: Missing type parameters for generic type "Tuple"
 
 [case testDisallowAnyGenericsTypeType]
-# cmd: mypy --python-version=3.6 m.py
+# cmd: mypy --new-semantic-analyzer --python-version=3.6 m.py
 [file mypy.ini]
 [[mypy]
 [[mypy-m]
@@ -872,11 +872,11 @@ def h(s) -> Type[str]:  # no error
     return s
 x: Type = g(0)  # error
 [out]
-m.py:4: error: Missing type parameters for generic type
-m.py:8: error: Missing type parameters for generic type
+m.py:4: error: Missing type parameters for generic type "Type"
+m.py:8: error: Missing type parameters for generic type "Type"
 
 [case testDisallowAnyGenericsAliasGenericType]
-# cmd: mypy m.py
+# cmd: mypy --new-semantic-analyzer m.py
 [file mypy.ini]
 [[mypy]
 [[mypy-m]
@@ -890,10 +890,10 @@ L = List  # no error
 def f(l: L) -> None: pass  # error
 def g(l: L[str]) -> None: pass  # no error
 [out]
-m.py:5: error: Missing type parameters for generic type
+m.py:5: error: Missing type parameters for generic type "list"
 
 [case testDisallowAnyGenericsGenericAlias]
-# cmd: mypy --python-version=3.6 m.py
+# cmd: mypy --new-semantic-analyzer --python-version=3.6 m.py
 [file mypy.ini]
 [[mypy]
 [[mypy-m]
@@ -912,12 +912,12 @@ def h(s) -> A[str]:  # no error
     return 'a', 'b', 'c'
 x: A = ('a', 'b', 1)  # error
 [out]
-m.py:6: error: Missing type parameters for generic type
-m.py:7: error: Missing type parameters for generic type
-m.py:11: error: Missing type parameters for generic type
+m.py:6: error: Missing type parameters for generic type "Tuple[T?, str, T?]"
+m.py:7: error: Missing type parameters for generic type "Tuple[T?, str, T?]"
+m.py:11: error: Missing type parameters for generic type "Tuple[T?, str, T?]"
 
 [case testDisallowAnyGenericsPlainList]
-# cmd: mypy --python-version=3.6 m.py
+# cmd: mypy --new-semantic-analyzer --python-version=3.6 m.py
 [file mypy.ini]
 [[mypy]
 [[mypy-m]
@@ -934,14 +934,14 @@ def i(l: List[List[List[List]]]) -> None: pass  # error
 x = []  # error: need type annotation
 y: List = []  # error
 [out]
-m.py:3: error: Missing type parameters for generic type
-m.py:5: error: Missing type parameters for generic type
-m.py:6: error: Missing type parameters for generic type
+m.py:3: error: Missing type parameters for generic type "list"
+m.py:5: error: Missing type parameters for generic type "list"
+m.py:6: error: Missing type parameters for generic type "list"
 m.py:8: error: Need type annotation for 'x' (hint: "x: List[<type>] = ...")
-m.py:9: error: Missing type parameters for generic type
+m.py:9: error: Missing type parameters for generic type "list"
 
 [case testDisallowAnyGenericsCustomGenericClass]
-# cmd: mypy --python-version=3.6 m.py
+# cmd: mypy --new-semantic-analyzer --python-version=3.6 m.py
 [file mypy.ini]
 [[mypy]
 [[mypy-m]
@@ -960,8 +960,8 @@ x: G[Any] = G()  # no error
 y: G = x  # error
 
 [out]
-m.py:6: error: Missing type parameters for generic type
-m.py:10: error: Missing type parameters for generic type
+m.py:6: error: Missing type parameters for generic type "G"
+m.py:10: error: Missing type parameters for generic type "G"
 
 [case testDisallowAnyGenericsBuiltinCollections]
 # cmd: mypy m.py
@@ -986,7 +986,7 @@ m.py:6: error: Implicit generic "Any". Use "typing.Set" and specify generic para
 m.py:7: error: Implicit generic "Any". Use "typing.FrozenSet" and specify generic parameters
 
 [case testDisallowAnyGenericsTypingCollections]
-# cmd: mypy m.py
+# cmd: mypy --new-semantic-analyzer m.py
 [file mypy.ini]
 [[mypy]
 [[mypy-m]
@@ -1001,11 +1001,11 @@ def h(s: Dict) -> None: pass
 def i(s: Set) -> None: pass
 def j(s: FrozenSet) -> None: pass
 [out]
-m.py:3: error: Missing type parameters for generic type
-m.py:4: error: Missing type parameters for generic type
-m.py:5: error: Missing type parameters for generic type
-m.py:6: error: Missing type parameters for generic type
-m.py:7: error: Missing type parameters for generic type
+m.py:3: error: Missing type parameters for generic type "Tuple"
+m.py:4: error: Missing type parameters for generic type "list"
+m.py:5: error: Missing type parameters for generic type "dict"
+m.py:6: error: Missing type parameters for generic type "set"
+m.py:7: error: Missing type parameters for generic type "frozenset"
 
 [case testDisallowSubclassingAny]
 # cmd: mypy m.py y.py
@@ -1032,7 +1032,7 @@ class ShouldNotBeFine(x): ...
 y.py:5: error: Class cannot subclass 'x' (has type 'Any')
 
 [case testSectionInheritance]
-# cmd: mypy a
+# cmd: mypy --new-semantic-analyzer a
 [file a/__init__.py]
 0()
 [file a/foo.py]
@@ -1063,7 +1063,7 @@ strict_optional = True
 [[mypy-a.b.c.d.e]
 ignore_errors = False
 [out]
-a/b/c/d/e/__init__.py:2: error: Missing type parameters for generic type
+a/b/c/d/e/__init__.py:2: error: Missing type parameters for generic type "list"
 a/b/c/d/e/__init__.py:3: error: Argument 1 to "g" has incompatible type "None"; expected "List[Any]"
 
 [case testDisallowUntypedDefsAndGenerics]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -836,9 +836,9 @@ def h(s) -> Tuple[str, str]:  # no error
     return 'a', 'b'
 x: Tuple = ()  # error
 [out]
-m.py:3: error: Missing type parameters for generic type Tuple?
-m.py:4: error: Missing type parameters for generic type Tuple?
-m.py:8: error: Missing type parameters for generic type Tuple?
+m.py:3: error: Missing type parameters for generic type "Tuple"
+m.py:4: error: Missing type parameters for generic type "Tuple"
+m.py:8: error: Missing type parameters for generic type "Tuple"
 
 [case testDisallowAnyGenericsTupleWithNoTypeParamsGeneric]
 # cmd: mypy --new-semantic-analyzer m.py

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8884,7 +8884,7 @@ def foo() -> List:
     20
 [out]
 ==
-a.py:4: error: Missing type parameters for generic type "list"
+a.py:4: error: Missing type parameters for generic type "List"
 ==
 ==
 a.py:2: error: Missing return statement

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8855,6 +8855,7 @@ y = ''
 ==
 
 [case testInlineConfigFineGrained1]
+# flags: --new-semantic-analyzer
 import a
 [file a.py]
 # mypy: no-warn-no-return
@@ -8883,7 +8884,7 @@ def foo() -> List:
     20
 [out]
 ==
-a.py:4: error: Missing type parameters for generic type
+a.py:4: error: Missing type parameters for generic type "list"
 ==
 ==
 a.py:2: error: Missing return statement
@@ -8942,7 +8943,7 @@ a.py:11: error: Type signature has too few arguments
 c.py:1: error: Type signature has too few arguments
 
 [case testErrorReportingNewAnalyzer]
-# flags: --disallow-any-generics
+# flags: --new-semantic-analyzer --disallow-any-generics
 from a import A
 
 def f() -> None:
@@ -8956,7 +8957,7 @@ T = TypeVar('T')
 class A(Generic[T]): ...
 [out]
 ==
-main:5: error: Missing type parameters for generic type
+main:5: error: Missing type parameters for generic type "A"
 
 [case testStripNewAnalyzer]
 # flags: --ignore-missing-imports


### PR DESCRIPTION
This makes the message easier to understand for complex types.  Only
do this for the new semantic analyzer, since the old analyzer doesn't
have the information available to do it.