### PR TITLE
Add minimum Python version to packaging metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -184,5 +184,6 @@ setup(name='mypy',
                         ],
       # Same here.
       extras_require={'dmypy': 'psutil >= 4.0'},
+      python_requires=">=3.5",
       include_package_data=True,
       )


### PR DESCRIPTION
This does not fix #7221 (which is likely to stay forever), but at least prevents more releases from being pushed with incomplete metadata.