### PR TITLE
Fix crash when broken overload appears in stub file

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -695,6 +695,10 @@ class NewSemanticAnalyzer(NodeVisitor[None],
         if not defn.items:
             # It was not a real overload after all, but function redefinition. We've
             # visited the redefinition(s) already.
+            if not defn.impl:
+                # For really broken overloads with no items and no implementation we need to keep
+                # at least one item to hold basic information like function name.
+                defn.impl = defn.unanalyzed_items[-1]
             return
 
         # We know this is an overload def. Infer properties and perform some checks.

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -5031,18 +5031,30 @@ def lol(x: int, y: int) -> int:
 
 [case testVeryBrokenOverload]
 import lib
+reveal_type(lib.func)
 [file lib.pyi]
-@overload  # E: Name 'overload' is not defined
+@overload
 def func(x: int) -> int: ...
 
-def func(x):  # E: Name 'func' already defined on line 1
+def func(x):
     return x
+[out]
+tmp/lib.pyi:1: error: Name 'overload' is not defined
+tmp/lib.pyi:4: error: Name 'func' already defined on line 1
+main:2: note: Revealed type is 'Any'
 
+-- Order of errors is different
 [case testVeryBrokenOverload2]
+# flags: --new-semantic-analyzer
 import lib
+reveal_type(lib.func)
 [file lib.pyi]
-@overload  # E: Name 'overload' is not defined
+@overload
 def func(x: int) -> int: ...
-@overload  # E: Name 'func' already defined on line 1 \
-           # E: Name 'overload' is not defined
+@overload
 def func(x: str) -> str: ...
+[out]
+tmp/lib.pyi:1: error: Name 'overload' is not defined
+tmp/lib.pyi:3: error: Name 'func' already defined on line 1
+tmp/lib.pyi:3: error: Name 'overload' is not defined
+main:3: note: Revealed type is 'Any'

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -5028,3 +5028,21 @@ def asdf() -> None:
 @dec
 def lol(x: int, y: int) -> int:
     pass
+
+[case testVeryBrokenOverload]
+import lib
+[file lib.pyi]
+@overload  # E: Name 'overload' is not defined
+def func(x: int) -> int: ...
+
+def func(x):  # E: Name 'func' already defined on line 1
+    return x
+
+[case testVeryBrokenOverload2]
+import lib
+[file lib.pyi]
+@overload  # E: Name 'overload' is not defined
+def func(x: int) -> int: ...
+@overload  # E: Name 'func' already defined on line 1 \
+           # E: Name 'overload' is not defined
+def func(x: str) -> str: ...


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7209

The fix is to never create an "empty" overload that has neither items nor implementation.