### PR TITLE
New analyzer: don't reprocess member expressions that are already bound

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -2673,6 +2673,9 @@ class NewSemanticAnalyzer(NodeVisitor[None],
             explicit_type: Assignment has type annotation
             is_final: Is the target final
         """
+        if lval.node:
+            # This has been bound already in a previous iteration.
+            return
         lval.accept(self)
         if self.is_self_member_ref(lval):
             assert self.type, "Self member outside a class"

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1064,3 +1064,11 @@ class B:
     def __init__(self) -> None:
         self.x = self.y = 1
 [out]
+
+[case testFinalInDeferredMethod]
+from typing_extensions import Final
+
+class A:
+    def __init__(self) -> None:
+        self.x = 10  # type: Final
+        undefined  # type: ignore


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7229

The fix is to not reprocess member expressions that are already bound. We already do this for name expressions.

As a small bonus this may give a minor perf boost.