### PR TITLE
Fix the logic in active self-type calculation for current scope

### DIFF
--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6077,3 +6077,15 @@ TX = TypeVar('TX', bound='X')
 class X:
     def __new__(cls, x: TX) -> TX:  # E: "__new__" must return a class instance (got "TX")
         pass
+
+[case testGenericOverride]
+from typing import Generic, TypeVar, Any
+
+T = TypeVar('T')
+
+class B(Generic[T]):
+    x: T
+
+class C(B):
+    def __init__(self) -> None:
+        self.x: Any

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6089,3 +6089,56 @@ class B(Generic[T]):
 class C(B):
     def __init__(self) -> None:
         self.x: Any
+
+[case testGenericOverridePreciseInvalid]
+from typing import Generic, TypeVar, Any
+
+T = TypeVar('T')
+
+class B(Generic[T]):
+    x: T
+
+class C(B[str]):
+    def __init__(self) -> None:
+        self.x: int  # E: Incompatible types in assignment (expression has type "int", base class "B" defined the type as "str")
+
+[case testGenericOverridePreciseValid]
+from typing import Generic, TypeVar
+
+T = TypeVar('T')
+
+class B(Generic[T]):
+    x: T
+
+class C(B[float]):
+    def __init__(self) -> None:
+        self.x: int  # We currently allow covariant overriding.
+
+[case testGenericOverrideGeneric]
+from typing import Generic, TypeVar, List
+
+T = TypeVar('T')
+
+class B(Generic[T]):
+    x: T
+
+class C(B[T]):
+    def __init__(self) -> None:
+        self.x: List[T]  # E: Incompatible types in assignment (expression has type "List[T]", base class "B" defined the type as "T")
+[builtins fixtures/list.pyi]
+
+[case testGenericOverrideGenericChained]
+from typing import Generic, TypeVar, Tuple
+
+T = TypeVar('T')
+S = TypeVar('S')
+
+class A(Generic[T]):
+    x: T
+
+class B(A[Tuple[T, S]]): ...
+
+class C(B[int, T]):
+    def __init__(self) -> None:
+        # TODO: error message could be better.
+        self.x: Tuple[str, T]  # E: Incompatible types in assignment (expression has type "Tuple[str, T]", base class "A" defined the type as "Tuple[int, T]")


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5846

The fix for crash is kind of straightforward. Previously `active_self_type()` always returned `None` at method scope (sic!)

While working on this I discovered couple other problems:
* Area around checking LSP is generally problematic (see also https://github.com/python/mypy/issues/5425 that I tried to fix earlier but failed). In particular, the are two ways to get current `TypeInfo`, one is from `lvalue.node.info` or `defn.info`, another is using `active_self_type()` (this is rather abusing it IMO). I don't try to fix this here (i.e. switch to always using one way) because this is a relatively large refactoring.
* Currently in type checker we defer nested functions instead of top-level ones. I believe this is not by design and is rather caused by absence of docstrings and unintuitive method names in `CheckerScope` class. Namely, there "top function" stays for "top of stack function", not "top-level function". I don't try to fix this here either because this is conceptually a big change.