### PR TITLE
Report precision stats for imports and add new precision report

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -748,7 +748,7 @@ class BuildManager:
                     type_map: Dict[Expression, Type],
                     options: Options) -> None:
         if self.reports is not None and self.source_set.is_source(file):
-            self.reports.file(file, type_map, options)
+            self.reports.file(file, self.modules, type_map, options)
 
     def verbosity(self) -> int:
         return self.options.verbosity
@@ -2120,7 +2120,7 @@ class State:
             self.manager.semantic_analyzer_pass3.visit_file(self.tree, self.xpath,
                                                             self.options, patches)
             if self.options.dump_type_stats:
-                dump_type_stats(self.tree, self.xpath)
+                dump_type_stats(self.tree, self.xpath, self.manager.modules)
         self.patches = patches + self.patches
 
     def semantic_analysis_apply_patches(self) -> None:
@@ -2165,7 +2165,10 @@ class State:
             self._patch_indirect_dependencies(self.type_checker().module_refs, self.type_map())
 
             if self.options.dump_inference_stats:
-                dump_type_stats(self.tree, self.xpath, inferred=True,
+                dump_type_stats(self.tree,
+                                self.xpath,
+                                modules=self.manager.modules,
+                                inferred=True,
                                 typemap=self.type_map())
             manager.report_file(self.tree, self.type_map(), self.options)
 

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -143,6 +143,9 @@ class StringFormatterChecker:
             rep_types = rhs_type.items
         elif isinstance(rhs_type, AnyType):
             return
+        elif isinstance(rhs_type, Instance) and rhs_type.type.fullname() == 'builtins.tuple':
+            # Assume that an arbitrary-length tuple has the right number of items.
+            rep_types = [rhs_type.args[0]] * len(checkers)
         else:
             rep_types = [rhs_type]
 

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -26,4 +26,5 @@ REPORTER_NAMES = ['linecount',
                   'xslt-html',
                   'xslt-txt',
                   'html',
-                  'txt']  # type: Final
+                  'txt',
+                  'lineprecision']  # type: Final

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -162,6 +162,8 @@ register_reporter('linecount', LineCountReporter)
 
 
 class AnyExpressionsReporter(AbstractReporter):
+    """Report frequencies of different kinds of Any types."""
+
     def __init__(self, reports: Reports, output_dir: str) -> None:
         super().__init__(reports, output_dir)
         self.counts = {}  # type: Dict[str, Tuple[int, int]]
@@ -354,6 +356,7 @@ class LineCoverageReporter(AbstractReporter):
     source file's absolute pathname the list of line numbers that
     belong to typed functions in that file.
     """
+
     def __init__(self, reports: Reports, output_dir: str) -> None:
         super().__init__(reports, output_dir)
         self.lines_covered = {}  # type: Dict[str, List[int]]
@@ -506,8 +509,8 @@ def get_line_rate(covered_lines: int, total_lines: int) -> str:
 
 
 class CoberturaPackage(object):
-    """Container for XML and statistics mapping python modules to Cobertura package
-    """
+    """Container for XML and statistics mapping python modules to Cobertura package."""
+
     def __init__(self, name: str) -> None:
         self.name = name
         self.classes = {}  # type: Dict[str, Any]
@@ -535,8 +538,7 @@ class CoberturaPackage(object):
 
 
 class CoberturaXmlReporter(AbstractReporter):
-    """Reporter for generating Cobertura compliant XML.
-    """
+    """Reporter for generating Cobertura compliant XML."""
 
     def __init__(self, reports: Reports, output_dir: str) -> None:
         super().__init__(reports, output_dir)

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -837,7 +837,8 @@ class LinePrecisionReporter(AbstractReporter):
         width = max(4, max(len(info.module) for info in output_files))
         titles = ('Lines', 'Precise', 'Imprecise', 'Any', 'Empty', 'Unanalyzed')
         widths = (width,) + tuple(len(t) for t in titles)
-        fmt = '{:%d}  {:%d}  {:%d}  {:%d}  {:%d}  {:%d}  {:%d}\n' % widths
+        # TODO: Need mypyc mypy pin move
+        fmt = '{:%d}  {:%d}  {:%d}  {:%d}  {:%d}  {:%d}  {:%d}\n' % widths  # type: ignore
         with open(report_file, 'w') as f:
             f.write(
                 fmt.format('Name', *titles))

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -121,7 +121,7 @@ def should_skip_path(path: str) -> bool:
         return True
     if path.startswith('..'):
         return True
-    if 'stubs' in path.split('/'):
+    if 'stubs' in path.split('/') or 'stubs' in path.split(os.sep):
         return True
     return False
 
@@ -826,7 +826,6 @@ class LinePrecisionReporter(AbstractReporter):
 
         file_info = FileInfo(path, tree._fullname)
         for lineno, _ in iterate_python_lines(path):
-            print(repr((lineno, _)))
             status = visitor.line_map.get(lineno, stats.TYPE_EMPTY)
             file_info.counts[status] += 1
 
@@ -836,10 +835,12 @@ class LinePrecisionReporter(AbstractReporter):
         output_files = sorted(self.files, key=lambda x: x.module)
         report_file = os.path.join(self.output_dir, 'lineprecision.txt')
         width = max(4, max(len(info.module) for info in output_files))
-        fmt = '{:%d}  {:5}  {:7}  {:9}  {:3}  {:5}  {:10}\n' % width
+        titles = ('Lines', 'Precise', 'Imprecise', 'Any', 'Empty', 'Unanalyzed')
+        widths = (width,) + tuple(len(t) for t in titles)
+        fmt = '{:%d}  {:%d}  {:%d}  {:%d}  {:%d}  {:%d}  {:%d}\n' % widths
         with open(report_file, 'w') as f:
             f.write(
-                fmt.format('Name', 'Lines', 'Precise', 'Imprecise', 'Any', 'Empty', 'Unanalyzed'))
+                fmt.format('Name', *titles))
             f.write('-' * (width + 51) + '\n')
             for file_info in output_files:
                 counts = file_info.counts

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -4,7 +4,7 @@ import os
 from collections import Counter
 
 import typing
-from typing import Dict, List, cast, Optional
+from typing import Dict, List, cast, Optional, Union
 from typing_extensions import Final
 
 from mypy.traverser import TraverserVisitor
@@ -17,7 +17,7 @@ from mypy import nodes
 from mypy.nodes import (
     Expression, FuncDef, TypeApplication, AssignmentStmt, NameExpr, CallExpr, MypyFile,
     MemberExpr, OpExpr, ComparisonExpr, IndexExpr, UnaryExpr, YieldFromExpr, RefExpr, ClassDef,
-    ImportFrom, Import
+    ImportFrom, Import, ImportAll
 )
 from mypy.util import correct_relative_import
 
@@ -80,6 +80,12 @@ class StatisticsVisitor(TraverserVisitor):
         super().visit_mypy_file(o)
 
     def visit_import_from(self, imp: ImportFrom) -> None:
+        self.process_import(imp)
+
+    def visit_import_all(self, imp: ImportAll) -> None:
+        self.process_import(imp)
+
+    def process_import(self, imp: Union[ImportFrom, ImportAll]) -> None:
         import_id, ok = correct_relative_import(self.cur_mod_id,
                                                 imp.relative,
                                                 imp.id,

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -16,8 +16,10 @@ from mypy.types import (
 from mypy import nodes
 from mypy.nodes import (
     Expression, FuncDef, TypeApplication, AssignmentStmt, NameExpr, CallExpr, MypyFile,
-    MemberExpr, OpExpr, ComparisonExpr, IndexExpr, UnaryExpr, YieldFromExpr, RefExpr, ClassDef
+    MemberExpr, OpExpr, ComparisonExpr, IndexExpr, UnaryExpr, YieldFromExpr, RefExpr, ClassDef,
+    ImportFrom, Import
 )
+from mypy.util import correct_relative_import
 
 TYPE_EMPTY = 0  # type: Final
 TYPE_UNANALYZED = 1  # type: Final  # type of non-typechecked code
@@ -38,11 +40,13 @@ class StatisticsVisitor(TraverserVisitor):
     def __init__(self,
                  inferred: bool,
                  filename: str,
+                 modules: Dict[str, MypyFile],
                  typemap: Optional[Dict[Expression, Type]] = None,
                  all_nodes: bool = False,
                  visit_untyped_defs: bool = True) -> None:
         self.inferred = inferred
         self.filename = filename
+        self.modules = modules
         self.typemap = typemap
         self.all_nodes = all_nodes
         self.visit_untyped_defs = visit_untyped_defs
@@ -69,6 +73,29 @@ class StatisticsVisitor(TraverserVisitor):
         self.output = []  # type: List[str]
 
         TraverserVisitor.__init__(self)
+
+    def visit_mypy_file(self, o: MypyFile) -> None:
+        self.cur_mod_node = o
+        self.cur_mod_id = o.fullname()
+        super().visit_mypy_file(o)
+
+    def visit_import_from(self, imp: ImportFrom) -> None:
+        import_id, ok = correct_relative_import(self.cur_mod_id,
+                                                imp.relative,
+                                                imp.id,
+                                                self.cur_mod_node.is_package_init_file())
+        if ok and import_id in self.modules:
+            kind = TYPE_PRECISE
+        else:
+            kind = TYPE_ANY
+        self.record_line(imp.line, kind)
+
+    def visit_import(self, imp: Import) -> None:
+        if all(id in self.modules for id, _ in imp.ids):
+            kind = TYPE_PRECISE
+        else:
+            kind = TYPE_ANY
+        self.record_line(imp.line, kind)
 
     def visit_func_def(self, o: FuncDef) -> None:
         self.line = o.line
@@ -235,12 +262,18 @@ class StatisticsVisitor(TraverserVisitor):
                                   self.line_map.get(line, TYPE_EMPTY))
 
 
-def dump_type_stats(tree: MypyFile, path: str, inferred: bool = False,
+def dump_type_stats(tree: MypyFile,
+                    path: str,
+                    modules: Dict[str, MypyFile],
+                    inferred: bool = False,
                     typemap: Optional[Dict[Expression, Type]] = None) -> None:
     if is_special_module(path):
         return
     print(path)
-    visitor = StatisticsVisitor(inferred, filename=tree.fullname(), typemap=typemap)
+    visitor = StatisticsVisitor(inferred,
+                                filename=tree.fullname(),
+                                modules=modules,
+                                typemap=typemap)
     tree.accept(visitor)
     for line in visitor.output:
         print(line)

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -18,7 +18,9 @@ from unittest import TestCase as Suite  # noqa: F401 (re-exporting)
 
 from mypy.main import process_options
 from mypy.options import Options
-from mypy.test.data import DataDrivenTestCase
+from mypy.test.data import DataDrivenTestCase, fix_cobertura_filename
+from mypy.test.config import test_temp_dir
+import mypy.version
 
 skip = pytest.mark.skip
 
@@ -423,3 +425,40 @@ def copy_and_fudge_mtime(source_path: str, target_path: str) -> None:
 
     if new_time:
         os.utime(target_path, times=(new_time, new_time))
+
+
+def check_test_output_files(testcase: DataDrivenTestCase, step: int) -> None:
+    for path, expected_content in testcase.output_files:
+        path = path[4:]  # FIXME this is bad!!
+        if not os.path.exists(path):
+            raise AssertionError(
+                'Expected file {} was not produced by test case{}'.format(
+                    path, ' on step %d' % step if testcase.output2 else ''))
+        with open(path, 'r', encoding='utf8') as output_file:
+            actual_output_content = output_file.read().splitlines()
+        normalized_output = normalize_file_output(actual_output_content,
+                                                  os.path.abspath(test_temp_dir))
+        # We always normalize things like timestamp, but only handle operating-system
+        # specific things if requested.
+        if testcase.normalize_output:
+            if testcase.suite.native_sep and os.path.sep == '\\':
+                normalized_output = [fix_cobertura_filename(line)
+                                     for line in normalized_output]
+            normalized_output = normalize_error_messages(normalized_output)
+        assert_string_arrays_equal(expected_content.splitlines(), normalized_output,
+                                   'Output file {} did not match its expected output{}'.format(
+                                       path, ' on step %d' % step if testcase.output2 else ''))
+
+
+def normalize_file_output(content: List[str], current_abs_path: str) -> List[str]:
+    """Normalize file output for comparison."""
+    timestamp_regex = re.compile(r'\d{10}')
+    result = [x.replace(current_abs_path, '$PWD') for x in content]
+    version = mypy.version.__version__
+    result = [re.sub(r'\b' + re.escape(version) + r'\b', '$VERSION', x) for x in result]
+    # We generate a new mypy.version when building mypy wheels that
+    # lacks base_version, so handle that case.
+    base_version = getattr(mypy.version, 'base_version', version)
+    result = [re.sub(r'\b' + re.escape(base_version) + r'\b', '$VERSION', x) for x in result]
+    result = [timestamp_regex.sub('$TIMESTAMP', x) for x in result]
+    return result

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -427,9 +427,12 @@ def copy_and_fudge_mtime(source_path: str, target_path: str) -> None:
         os.utime(target_path, times=(new_time, new_time))
 
 
-def check_test_output_files(testcase: DataDrivenTestCase, step: int) -> None:
+def check_test_output_files(testcase: DataDrivenTestCase,
+                            step: int,
+                            strip_prefix: str = '') -> None:
     for path, expected_content in testcase.output_files:
-        path = path[4:]  # FIXME this is bad!!
+        if path.startswith(strip_prefix):
+            path = path[len(strip_prefix):]
         if not os.path.exists(path):
             raise AssertionError(
                 'Expected file {} was not produced by test case{}'.format(

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -106,7 +106,6 @@ class TypeCheckSuite(DataSuite):
         if incremental:
             # Incremental tests are run once with a cold cache, once with a warm cache.
             # Expect success on first run, errors from testcase.output (if any) on second run.
-            # We briefly sleep to make sure file timestamps are distinct.
             num_steps = max([2] + list(testcase.output2.keys()))
             # Check that there are no file changes beyond the last run (they would be ignored).
             for dn, dirs, files in os.walk(os.curdir):

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -249,7 +249,7 @@ class TypeCheckSuite(DataSuite):
                         expected_stale, res.manager.stale_modules)
 
         if testcase.output_files:
-            check_test_output_files(testcase, incremental_step)
+            check_test_output_files(testcase, incremental_step, strip_prefix='tmp/')
 
     def verify_cache(self, module_data: List[Tuple[str, str, str]], a: List[str],
                      manager: build.BuildManager, graph: Graph) -> None:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -16,7 +16,7 @@ from mypy.test.data import (
 from mypy.test.helpers import (
     assert_string_arrays_equal, normalize_error_messages, assert_module_equivalence,
     retry_on_error, update_testcase_output, parse_options,
-    copy_and_fudge_mtime, assert_target_equivalence
+    copy_and_fudge_mtime, assert_target_equivalence, check_test_output_files
 )
 from mypy.errors import CompileError
 from mypy.newsemanal.semanal_main import core_modules
@@ -85,6 +85,7 @@ typecheck_files = [
     'check-literal.test',
     'check-newsemanal.test',
     'check-inline-config.test',
+    'check-reports.test',
 ]
 
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):
@@ -246,6 +247,9 @@ class TypeCheckSuite(DataSuite):
                     assert_module_equivalence(
                         'stale' + suffix,
                         expected_stale, res.manager.stale_modules)
+
+        if testcase.output_files:
+            check_test_output_files(testcase, incremental_step)
 
     def verify_cache(self, module_data: List[Tuple[str, str, str]], a: List[str],
                      manager: build.BuildManager, graph: Graph) -> None:

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -12,7 +12,6 @@ import sys
 from typing import List
 
 from mypy.test.config import test_temp_dir, PREFIX
-from mypy.test.data import fix_cobertura_filename
 from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.test.helpers import (
     assert_string_arrays_equal, normalize_error_messages, check_test_output_files

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -16,7 +16,6 @@ from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.test.helpers import (
     assert_string_arrays_equal, normalize_error_messages, check_test_output_files
 )
-import mypy.version
 
 # Path to Python 3 interpreter
 python3_path = sys.executable
@@ -109,17 +108,3 @@ def parse_args(line: str) -> List[str]:
     if not m:
         return []  # No args; mypy will spit out an error.
     return m.group(1).split()
-
-
-def normalize_file_output(content: List[str], current_abs_path: str) -> List[str]:
-    """Normalize file output for comparison."""
-    timestamp_regex = re.compile(r'\d{10}')
-    result = [x.replace(current_abs_path, '$PWD') for x in content]
-    version = mypy.version.__version__
-    result = [re.sub(r'\b' + re.escape(version) + r'\b', '$VERSION', x) for x in result]
-    # We generate a new mypy.version when building mypy wheels that
-    # lacks base_version, so handle that case.
-    base_version = getattr(mypy.version, 'base_version', version)
-    result = [re.sub(r'\b' + re.escape(base_version) + r'\b', '$VERSION', x) for x in result]
-    result = [timestamp_regex.sub('$TIMESTAMP', x) for x in result]
-    return result

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1290,6 +1290,14 @@ b'%c' % (123)
 [case testUnicodeInterpolation_python2]
 u'%s' % (u'abc',)
 
+[case testStringInterpolationVariableLengthTuple]
+from typing import Tuple
+def f(t: Tuple[int, ...]) -> None:
+    '%d %d' % t
+    '%d %d %d' % t
+[builtins fixtures/primitives.pyi]
+
+
 -- Lambdas
 -- -------
 

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -105,3 +105,21 @@ Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
 -------------------------------------------------------------
 __main__      3        1          0    1      1           0
 m             2        1          0    1      0           0
+
+[case testLinePrecisionRelativeImport]
+# flags: --lineprecision-report out --ignore-missing-imports
+import a
+
+[file a/__init__.py]
+from .m import f
+from .bad import g
+
+[file a/m.py]
+def f(): pass
+
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      2        1          0    0      1           0
+a             2        1          0    1      0           0
+a.m           1        0          0    1      0           0

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -41,4 +41,54 @@ def f(x: int) -> None:
 [outfile out/lineprecision.txt]
 Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
 -------------------------------------------------------------
-__main__     10        4          0    0      3           3
+__main__     10        5          0    0      2           3
+
+[case testLinePrecisionEmptyLines]
+# flags: --lineprecision-report out
+def f() -> None:
+    """docstring
+
+    long
+    """
+    x = 0
+
+    # comment
+    y = 0  # comment (non-empty)
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__     10        3          0    0      7           0
+
+[case testLinePrecisionImportFrom]
+# flags: --lineprecision-report out --ignore-missing-imports
+from m import f
+from m import g
+from bad import foo
+from bad import (  # treated as a single line
+    foo2,
+    foo3,
+)
+
+[file m.py]
+def f(): pass
+def g() -> None: pass
+
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      8        2          0    2      4           0
+m             2        1          0    1      0           0
+
+
+[case testLinePrecisionImport]
+# flags: --lineprecision-report out --ignore-missing-imports
+import m
+import bad
+import m, bad
+
+[file m.py]
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      4        1          0    2      1           0
+m             0        0          0    0      0           0

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -1,0 +1,44 @@
+[case testReportBasic]
+# flags: --xml-report out
+def f(): pass
+
+def g() -> None: pass
+[outfile out/index.xml]
+<?xml-stylesheet type="text/xsl" href="mypy-html.xslt"?><mypy-report-index name="index"><file module="__main__" name="main" total="4" any="1" empty="2" imprecise="0" precise="1" unanalyzed="0"/></mypy-report-index>
+
+[case testLinePrecisionBasic]
+# flags: --lineprecision-report out
+def f(): pass
+
+def g() -> None:
+    a = 1
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      5        2          0    1      2           0
+
+[case testLinePrecisionImpreciseType]
+# flags: --lineprecision-report out
+def f(x: list) -> None: pass
+[builtins fixtures/list.pyi]
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      2        0          1    0      1           0
+
+[case testLinePrecisionUnanalyzed]
+# flags: --lineprecision-report out
+import sys
+MYPY = False
+if not MYPY:
+    a = 1
+
+def f(x: int) -> None:
+    if isinstance(x, str):
+        b = 1
+        c = 1
+[builtins fixtures/isinstance.pyi]
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__     10        4          0    0      3           3

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -79,7 +79,6 @@ Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
 __main__      8        2          0    2      4           0
 m             2        1          0    1      0           0
 
-
 [case testLinePrecisionImport]
 # flags: --lineprecision-report out --ignore-missing-imports
 import m
@@ -92,3 +91,17 @@ Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
 -------------------------------------------------------------
 __main__      4        1          0    2      1           0
 m             0        0          0    0      0           0
+
+[case testLinePrecisionStarImport]
+# flags: --lineprecision-report out --ignore-missing-imports
+from m import *
+from bad import *
+
+[file m.py]
+def f(): pass
+def g() -> None: pass
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      3        1          0    1      1           0
+m             2        1          0    1      0           0

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -27,7 +27,7 @@ def bar() -> str:
 def untyped_function():
   return 42
 [outfile build/cobertura.xml]
-<coverage timestamp="$TIMESTAMP" version="$VERSION" line-rate="0.8000" branch-rate="0">
+<coverage timestamp="$TIMESTAMP" version="$VERSION" line-rate="0.8333" branch-rate="0">
   <sources>
     <source>$PWD</source>
   </sources>
@@ -41,6 +41,7 @@ def untyped_function():
         <class complexity="1.0" filename="pkg/a.py" name="a.py" branch-rate="0" line-rate="1.0000">
           <methods/>
           <lines>
+            <line branch="false" hits="1" number="1" precision="precise"/>
             <line branch="true" hits="1" number="3" precision="imprecise" condition-coverage="50% (1/2)"/>
             <line branch="false" hits="1" number="4" precision="precise"/>
             <line branch="false" hits="1" number="5" precision="precise"/>
@@ -125,7 +126,7 @@ T = TypeVar('T')
 <span id="L2" class="lineno"><a class="lineno" href="#L2">2</a></span>
 <span id="L3" class="lineno"><a class="lineno" href="#L3">3</a></span>
 </pre></td>
-<td class="table-code"><pre><span class="line-empty" title="No Anys on this line!">from typing import TypeVar</span>
+<td class="table-code"><pre><span class="line-precise" title="No Anys on this line!">from typing import TypeVar</span>
 <span class="line-empty" title="No Anys on this line!"></span>
 <span class="line-empty" title="No Anys on this line!">T = TypeVar('T')</span>
 </pre></td>
@@ -170,7 +171,7 @@ def bar(x):
 <span id="L5" class="lineno"><a class="lineno" href="#L5">5</a></span>
 <span id="L6" class="lineno"><a class="lineno" href="#L6">6</a></span>
 </pre></td>
-<td class="table-code"><pre><span class="line-empty" title="No Anys on this line!">from any import any_f</span>
+<td class="table-code"><pre><span class="line-precise" title="No Anys on this line!">from any import any_f</span>
 <span class="line-precise" title="No Anys on this line!">def bar(x):</span>
 <span class="line-empty" title="No Anys on this line!">    # type: (str) -&gt; None</span>
 <span class="line-precise" title="Any Types on this line:
@@ -208,7 +209,7 @@ old_stdout = sys.stdout
 <span id="L2" class="lineno"><a class="lineno" href="#L2">2</a></span>
 <span id="L3" class="lineno"><a class="lineno" href="#L3">3</a></span>
 </pre></td>
-<td class="table-code"><pre><span class="line-empty" title="No Anys on this line!">import sys</span>
+<td class="table-code"><pre><span class="line-precise" title="No Anys on this line!">import sys</span>
 <span class="line-empty" title="No Anys on this line!"></span>
 <span class="line-precise" title="No Anys on this line!">old_stdout = sys.stdout</span>
 </pre></td>

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -1,9 +1,6 @@
 -- Tests for reports
--- ------------------------------
 --
--- This file follows syntax of cmdline.test
-
--- ----------------------------------------
+-- This file follows syntax of cmdline.test.
 
 [case testConfigErrorUnknownReport]
 # cmd: mypy -c pass


### PR DESCRIPTION
Previously when reporting per-line type checking precision, imports were 
treated as empty lines, which seems inconsistent. Now treat an import as
precise if the target module exists, and as imprecise if the target module is 
missing from the build.

Also add a new report, `lineprecision`, which is mostly designed to be used 
in tests. The output is more compact and cleaner than the existing 
XML-based reports.

Make it possible to run report generation tests without using full stubs,
since using full stubs is slow.

This is still not quite perfect. If using module-level `__getattr__`, the import
should probably be treated as imprecise. Also, if a missing name is ignored
using `# type: ignore`, we may want to treat that as imprecise. For multi-line
imports, we only report precision for the first line. These would be a bit tricky 
to fix in the report generator so I decided to skip these for now.