### PR TITLE
Improve type precision stats

### DIFF
--- a/mypy/report.py
+++ b/mypy/report.py
@@ -832,6 +832,9 @@ class LinePrecisionReporter(AbstractReporter):
         self.files.append(file_info)
 
     def on_finish(self) -> None:
+        if not self.files:
+            # Nothing to do.
+            return
         output_files = sorted(self.files, key=lambda x: x.module)
         report_file = os.path.join(self.output_dir, 'lineprecision.txt')
         width = max(4, max(len(info.module) for info in output_files))

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -225,7 +225,7 @@ class StatisticsVisitor(TraverserVisitor):
             self.record_call_target_precision(o)
 
     def record_call_target_precision(self, o: CallExpr) -> None:
-        """Record precision of used formal argument types."""
+        """Record precision of formal argument types used in a call."""
         if not self.typemap or o.callee not in self.typemap:
             # Type not availabe.
             return
@@ -249,8 +249,8 @@ class StatisticsVisitor(TraverserVisitor):
                 formal = callee.arg_types[n]
                 if isinstance(formal, AnyType):
                     self.record_line(o.line, TYPE_ANY)
-                else:
-                    pass  # TODO
+                elif is_imprecise(formal):
+                    self.record_line(o.line, TYPE_IMPRECISE)
 
     def visit_member_expr(self, o: MemberExpr) -> None:
         self.process_node(o)

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -245,6 +245,9 @@ class StatisticsVisitor(TraverserVisitor):
     def visit_str_expr(self, o: StrExpr) -> None:
         self.record_precise_if_checked_scope(o)
 
+    def visit_unicode_expr(self, o: UnicodeExpr) -> None:
+        self.record_precise_if_checked_scope(o)
+
     def visit_bytes_expr(self, o: BytesExpr) -> None:
         self.record_precise_if_checked_scope(o)
 

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -236,6 +236,13 @@ class StatisticsVisitor(TraverserVisitor):
             pass  # TODO: Handle overloaded functions, etc.
 
     def record_callable_target_precision(self, o: CallExpr, callee: CallableType) -> None:
+        """Record imprecision caused by callee argument types.
+
+        This only considers arguments passed in a call expression. Arguments
+        with default values that aren't provided in a call arguably don't
+        contribute to typing imprecision at the *call site* (but they
+        contribute at the function definition).
+        """
         assert self.typemap
         typemap = self.typemap
         actual_to_formal = map_formals_to_actuals(

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -22,7 +22,7 @@ from mypy.nodes import (
     UnicodeExpr, IntExpr, FloatExpr, ComplexExpr, EllipsisExpr, ExpressionStmt, Node
 )
 from mypy.util import correct_relative_import
-from mypy.argmap import map_actuals_to_formals
+from mypy.argmap import map_formals_to_actuals
 
 TYPE_EMPTY = 0  # type: Final
 TYPE_UNANALYZED = 1  # type: Final  # type of non-typechecked code
@@ -238,7 +238,7 @@ class StatisticsVisitor(TraverserVisitor):
     def record_callable_target_precision(self, o: CallExpr, callee: CallableType) -> None:
         assert self.typemap
         typemap = self.typemap
-        actual_to_formal = map_actuals_to_formals(
+        actual_to_formal = map_formals_to_actuals(
             o.arg_kinds,
             o.arg_names,
             callee.arg_kinds,

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -19,7 +19,7 @@ from mypy.nodes import (
     Expression, FuncDef, TypeApplication, AssignmentStmt, NameExpr, CallExpr, MypyFile,
     MemberExpr, OpExpr, ComparisonExpr, IndexExpr, UnaryExpr, YieldFromExpr, RefExpr, ClassDef,
     ImportFrom, Import, ImportAll, PassStmt, BreakStmt, ContinueStmt, StrExpr, BytesExpr,
-    IntExpr, FloatExpr, ComplexExpr, EllipsisExpr
+    UnicodeExpr, IntExpr, FloatExpr, ComplexExpr, EllipsisExpr, ExpressionStmt, Node
 )
 from mypy.util import correct_relative_import
 
@@ -183,21 +183,28 @@ class StatisticsVisitor(TraverserVisitor):
                             self.type(self.typemap.get(item))
         super().visit_assignment_stmt(o)
 
+    def visit_expression_stmt(self, o: ExpressionStmt) -> None:
+        if isinstance(o.expr, (StrExpr, UnicodeExpr, BytesExpr)):
+            # Docstring
+            self.record_line(o.line, TYPE_EMPTY)
+        else:
+            super().visit_expression_stmt(o)
+
     def visit_pass_stmt(self, o: PassStmt) -> None:
-        self.record_precise_if_checked_scope(o.line)
+        self.record_precise_if_checked_scope(o)
 
     def visit_break_stmt(self, o: BreakStmt) -> None:
-        self.record_precise_if_checked_scope(o.line)
+        self.record_precise_if_checked_scope(o)
 
     def visit_continue_stmt(self, o: ContinueStmt) -> None:
-        self.record_precise_if_checked_scope(o.line)
+        self.record_precise_if_checked_scope(o)
 
     def visit_name_expr(self, o: NameExpr) -> None:
         if o.fullname in ('builtins.None',
                           'builtins.True',
                           'builtins.False',
                           'builtins.Ellipsis'):
-            self.record_precise_if_checked_scope(o.line)
+            self.record_precise_if_checked_scope(o)
         else:
             self.process_node(o)
             super().visit_name_expr(o)
@@ -236,22 +243,22 @@ class StatisticsVisitor(TraverserVisitor):
         super().visit_unary_expr(o)
 
     def visit_str_expr(self, o: StrExpr) -> None:
-        self.record_precise_if_checked_scope(o.line)
+        self.record_precise_if_checked_scope(o)
 
     def visit_bytes_expr(self, o: BytesExpr) -> None:
-        self.record_precise_if_checked_scope(o.line)
+        self.record_precise_if_checked_scope(o)
 
     def visit_int_expr(self, o: IntExpr) -> None:
-        self.record_precise_if_checked_scope(o.line)
+        self.record_precise_if_checked_scope(o)
 
     def visit_float_expr(self, o: FloatExpr) -> None:
-        self.record_precise_if_checked_scope(o.line)
+        self.record_precise_if_checked_scope(o)
 
     def visit_complex_expr(self, o: ComplexExpr) -> None:
-        self.record_precise_if_checked_scope(o.line)
+        self.record_precise_if_checked_scope(o)
 
     def visit_ellipsis(self, o: EllipsisExpr) -> None:
-        self.record_precise_if_checked_scope(o.line)
+        self.record_precise_if_checked_scope(o)
 
     # Helpers
 
@@ -261,8 +268,14 @@ class StatisticsVisitor(TraverserVisitor):
                 self.line = node.line
                 self.type(self.typemap.get(node))
 
-    def record_precise_if_checked_scope(self, line: int) -> None:
-        self.record_line(line, TYPE_PRECISE if self.is_checked_scope() else TYPE_ANY)
+    def record_precise_if_checked_scope(self, node: Node) -> None:
+        if isinstance(node, Expression) and self.typemap and node not in self.typemap:
+            kind = TYPE_UNANALYZED
+        elif self.is_checked_scope():
+            kind = TYPE_PRECISE
+        else:
+            kind = TYPE_ANY
+        self.record_line(node.line, kind)
 
     def type(self, t: Optional[Type]) -> None:
         if not t:

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -416,12 +416,6 @@ class HasAnyQuery(TypeQuery[bool]):
     def visit_any(self, t: AnyType) -> bool:
         return not is_special_form_any(t)
 
-    def visit_instance(self, t: Instance) -> bool:
-        if t.type.fullname() == 'builtins.tuple':
-            return True
-        else:
-            return super().visit_instance(t)
-
 
 def is_imprecise2(t: Type) -> bool:
     return t.accept(HasAnyQuery2())

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -18,7 +18,7 @@ from mypy import nodes
 from mypy.nodes import (
     Expression, FuncDef, TypeApplication, AssignmentStmt, NameExpr, CallExpr, MypyFile,
     MemberExpr, OpExpr, ComparisonExpr, IndexExpr, UnaryExpr, YieldFromExpr, RefExpr, ClassDef,
-    ImportFrom, Import, ImportAll, PassStmt
+    ImportFrom, Import, ImportAll, PassStmt, BreakStmt, ContinueStmt
 )
 from mypy.util import correct_relative_import
 
@@ -183,7 +183,16 @@ class StatisticsVisitor(TraverserVisitor):
         super().visit_assignment_stmt(o)
 
     def visit_pass_stmt(self, o: PassStmt) -> None:
-        self.record_line(o.line, TYPE_PRECISE if self.is_checked_scope() else TYPE_ANY)
+        self.record_precise_if_checked_scope(o.line)
+
+    def visit_break_stmt(self, o: BreakStmt) -> None:
+        self.record_precise_if_checked_scope(o.line)
+
+    def visit_continue_stmt(self, o: ContinueStmt) -> None:
+        self.record_precise_if_checked_scope(o.line)
+
+    def record_precise_if_checked_scope(self, line: int) -> None:
+        self.record_line(line, TYPE_PRECISE if self.is_checked_scope() else TYPE_ANY)
 
     def visit_name_expr(self, o: NameExpr) -> None:
         self.process_node(o)

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -233,7 +233,7 @@ class StatisticsVisitor(TraverserVisitor):
         if isinstance(callee_type, CallableType):
             self.record_callable_target_precision(o, callee_type)
         else:
-            pass # TODO
+            pass  # TODO: Handle overloaded functions, etc.
 
     def record_callable_target_precision(self, o: CallExpr, callee: CallableType) -> None:
         assert self.typemap

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -337,3 +337,20 @@ Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
 -------------------------------------------------------------
 __main__      5        3          0    1      1           0
 m             4        3          0    1      0           0
+
+[case testLinePrecisionCallAnyConstructorArg]
+# flags: --lineprecision-report out
+from m import C
+def g() -> None:
+    C(1)  # Precise
+    C(1, 2)  # Any
+[file m.py]
+from typing import Any
+class C:
+    def __init__(self, x: int, y: Any = 0) -> None:
+        pass
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      5        3          0    1      1           0
+m             4        3          0    1      0           0

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -320,3 +320,20 @@ Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
 -------------------------------------------------------------
 __main__      8        5          0    2      1           0
 m             3        2          0    1      0           0
+
+[case testLinePrecisionCallAnyMethodArg]
+# flags: --lineprecision-report out
+from m import C
+def g(c: C) -> None:
+    c.f(1)  # Precise
+    c.f(1, 2)  # Any
+[file m.py]
+from typing import Any
+class C:
+    def f(self, x: int, y: Any = 0) -> None:
+        pass
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      5        3          0    1      1           0
+m             4        3          0    1      0           0

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -284,3 +284,20 @@ Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
 -------------------------------------------------------------
 __main__      5        3          0    1      1           0
 m             3        2          0    1      0           0
+
+[case testLinePrecisionCallImpreciseArg]
+# flags: --lineprecision-report out
+from m import f
+def g() -> None:
+    f(1)  # Precise
+    f(1, [2])  # Imprecise
+[file m.py]
+from typing import List, Any
+def f(x: int, y: List[Any] = []) -> None:
+    pass
+[builtins fixtures/list.pyi]
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      5        3          1    0      1           0
+m             3        2          1    0      0           0

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -166,3 +166,83 @@ Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
 __main__      3        2          0    0      1           0
 a             7        4          0    3      0           0
 b             7        4          0    3      0           0
+
+[case testLinePrecisionLiterals]
+# flags: --lineprecision-report out
+import str_lit
+import bytes_lit
+import int_lit
+import float_lit
+import true_lit
+import false_lit
+import none_lit
+import complex_lit
+import dots_lit
+
+[file str_lit.py]
+def f() -> object:
+    return ''
+def g():
+    return ''
+
+[file bytes_lit.py]
+def f() -> object:
+    return b''
+def g():
+    return b''
+
+[file int_lit.py]
+def f() -> object:
+    return 1
+def g():
+    return 1
+
+[file float_lit.py]
+def f() -> object:
+    return 1.1
+def g():
+    return 1.1
+
+[file true_lit.py]
+def f() -> object:
+    return True
+def g():
+    return True
+
+[file false_lit.py]
+def f() -> object:
+    return False
+def g():
+    return False
+
+[file none_lit.py]
+def f() -> object:
+    return None
+def g():
+    return None
+
+[file complex_lit.py]
+def f() -> object:
+    return None
+def g():
+    return None
+
+[file dots_lit.py]
+def f() -> object:
+    return ...
+def g():
+    return ...
+
+[outfile out/lineprecision.txt]
+Name         Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+----------------------------------------------------------------
+__main__        10        9          0    0      1           0
+bytes_lit        4        2          0    2      0           0
+complex_lit      4        2          0    2      0           0
+dots_lit         4        2          0    2      0           0
+false_lit        4        2          0    2      0           0
+float_lit        4        2          0    2      0           0
+int_lit          4        2          0    2      0           0
+none_lit         4        2          0    2      0           0
+str_lit          4        2          0    2      0           0
+true_lit         4        2          0    2      0           0

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -136,3 +136,33 @@ class C:
 Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
 -------------------------------------------------------------
 __main__      7        4          0    2      1           0
+
+[case testLinePrecisionBreakAndContinueStatement]
+# flags: --lineprecision-report out
+import a
+import b
+
+[file a.py]
+def f() -> int:
+    while f():
+        break
+    return f()
+def g():
+    while g():
+        break
+
+[file b.py]
+def f() -> int:
+    while f():
+        continue
+    return f()
+def g():
+    while g():
+        continue
+
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      3        2          0    0      1           0
+a             7        4          0    3      0           0
+b             7        4          0    3      0           0

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -246,3 +246,14 @@ int_lit          4        2          0    2      0           0
 none_lit         4        2          0    2      0           0
 str_lit          4        2          0    2      0           0
 true_lit         4        2          0    2      0           0
+
+[case testLinePrecisionUnicodeLiterals_python2]
+# flags: --lineprecision-report out
+def f(): # type: () -> object
+    return u''
+def g():
+    return u''
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      5        2          0    2      1           0

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -123,3 +123,16 @@ Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
 __main__      2        1          0    0      1           0
 a             2        1          0    1      0           0
 a.m           1        0          0    1      0           0
+
+[case testLinePrecisionPassStatement]
+# flags: --lineprecision-report out
+def f() -> None:
+    pass
+def g():
+    pass
+class C:
+    pass
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      7        4          0    2      1           0

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -168,7 +168,7 @@ a             7        4          0    3      0           0
 b             7        4          0    3      0           0
 
 [case testLinePrecisionLiterals]
-# flags: --lineprecision-report out
+# flags: --lineprecision-report out --new-semantic-analyzer
 import str_lit
 import bytes_lit
 import int_lit

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -257,3 +257,30 @@ def g():
 Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
 -------------------------------------------------------------
 __main__      5        2          0    2      1           0
+
+[case testLinePrecisionIfStatement]
+# flags: --lineprecision-report out
+if int():
+    x = 1
+else:  # This is treated as empty
+    x = 2
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      5        3          0    0      2           0
+
+[case testLinePrecisionCallAnyArg]
+# flags: --lineprecision-report out
+from m import f
+def g() -> None:
+    f(1)  # Precise
+    f(1, 2)  # Any
+[file m.py]
+from typing import Any
+def f(x: int, y: Any = 0) -> None:
+    pass
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      5        3          0    1      1           0
+m             3        2          0    1      0           0

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -301,3 +301,22 @@ Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
 -------------------------------------------------------------
 __main__      5        3          1    0      1           0
 m             3        2          1    0      0           0
+
+[case testLinePrecisionCallAnyArgWithKeywords]
+# flags: --lineprecision-report out
+from m import f
+def g() -> None:
+    f(x=1)  # Precise
+    f(x=1, z=1)  # Precise
+    f(z=1, x=1)  # Precise
+    f(y=1)  # Any
+    f(y=1, x=1)  # Any
+[file m.py]
+from typing import Any
+def f(x: int = 0, y: Any = 0, z: int = 0) -> None:
+    pass
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      8        5          0    2      1           0
+m             3        2          0    1      0           0

--- a/test-data/unit/fixtures/isinstance.pyi
+++ b/test-data/unit/fixtures/isinstance.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, TypeVar, Generic, Union, cast, Any
+from typing import Tuple, TypeVar, Generic, Union, cast, Any, Type
 
 T = TypeVar('T')
 
@@ -12,8 +12,8 @@ class tuple(Generic[T]): pass
 
 class function: pass
 
-def isinstance(x: object, t: Union[type, Tuple[type, ...]]) -> bool: pass
-def issubclass(x: object, t: Union[type, Tuple[type, ...]]) -> bool: pass
+def isinstance(x: object, t: Union[Type[object], Tuple[Type[object], ...]]) -> bool: pass
+def issubclass(x: object, t: Union[Type[object], Tuple[Type[object], ...]]) -> bool: pass
 
 class int:
     def __add__(self, other: 'int') -> 'int': pass

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -27,7 +27,7 @@ def bar() -> str:
 def untyped_function():
   return 42
 [outfile build/cobertura.xml]
-<coverage timestamp="$TIMESTAMP" version="$VERSION" line-rate="0.8333" branch-rate="0">
+<coverage timestamp="$TIMESTAMP" version="$VERSION" line-rate="0.7500" branch-rate="0">
   <sources>
     <source>$PWD</source>
   </sources>
@@ -59,7 +59,9 @@ def untyped_function():
           <methods/>
           <lines>
             <line branch="false" hits="1" number="1" precision="precise"/>
+            <line branch="false" hits="1" number="2" precision="precise"/>
             <line branch="false" hits="0" number="3" precision="any"/>
+            <line branch="false" hits="0" number="4" precision="any"/>
           </lines>
         </class>
       </classes>
@@ -71,7 +73,7 @@ def untyped_function():
 [case testAnyExprReportDivisionByZero]
 # cmd: mypy --any-exprs-report=out -c 'pass'
 
-[case testClassDefIsTreatedAsEmpty]
+[case testClassDefIsNotTreatedAsEmpty]
 # cmd: mypy --html-report report n.py
 [file n.py]
 class A(object):
@@ -93,8 +95,8 @@ class A(object):
 <td class="table-lines"><pre><span id="L1" class="lineno"><a class="lineno" href="#L1">1</a></span>
 <span id="L2" class="lineno"><a class="lineno" href="#L2">2</a></span>
 </pre></td>
-<td class="table-code"><pre><span class="line-empty" title="No Anys on this line!">class A(object):</span>
-<span class="line-empty" title="No Anys on this line!">	pass  # line indented with tab; hex 1f here: (?)</span>
+<td class="table-code"><pre><span class="line-precise" title="No Anys on this line!">class A(object):</span>
+<span class="line-precise" title="No Anys on this line!">	pass  # line indented with tab; hex 1f here: (?)</span>
 </pre></td>
 </tr></tbody>
 </table>
@@ -174,7 +176,7 @@ def bar(x):
 <td class="table-code"><pre><span class="line-precise" title="No Anys on this line!">from any import any_f</span>
 <span class="line-precise" title="No Anys on this line!">def bar(x):</span>
 <span class="line-empty" title="No Anys on this line!">    # type: (str) -&gt; None</span>
-<span class="line-precise" title="Any Types on this line:
+<span class="line-any" title="Any Types on this line:
 Explicit (x1)">    any_f(x)</span>
 <span class="line-precise" title="No Anys on this line!">    assert False</span>
 <span class="line-unanalyzed" title="No Anys on this line!">    any_f(x)</span>
@@ -238,10 +240,10 @@ def bar(x):
 [outfile report/any-exprs.txt]
  Name   Anys   Exprs   Coverage
 ---------------------------------
-    i      1       7     85.71%
-    j      0       6    100.00%
+    i      1       6     83.33%
+    j      0       5    100.00%
 ---------------------------------
-Total      1      13     92.31%
+Total      1      11     90.91%
 
 [case testAnyExprReportHigherKindedTypesAreNotAny]
 # cmd: mypy --new-semantic-analyzer --any-exprs-report report i.py


### PR DESCRIPTION
This makes various improvements to type precision reporting:

* Consider literals precise in type checked code.
* Consider class headers precise (I'll improve this later).
* Consider pass/break/continue precise in type checked code.
* Consider call imprecise if target function has imprecise argument
  types, and the caller provides one of these arguments.

Some of these are still incomplete (for example, overloaded functions
aren't supported). I'll deal with these issues in follow-up PRs.