### PR TITLE
New analyzer: don't fill ImportAll.imported_names

### DIFF
--- a/mypy/newsemanal/semanal.py
+++ b/mypy/newsemanal/semanal.py
@@ -1852,7 +1852,6 @@ class NewSemanticAnalyzer(NodeVisitor[None],
                                 name, existing_symbol, node, i):
                             continue
                     self.add_imported_symbol(name, node, i)
-                    i.imported_names.append(name)
         else:
             # Don't add any dummy symbols for 'from x import *' if 'x' is unknown.
             pass

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -368,6 +368,7 @@ class ImportAll(ImportBase):
     """from m import *"""
     id = None  # type: str
     relative = None  # type: int
+    # NOTE: Only filled and used by old semantic analyzer.
     imported_names = None  # type: List[str]
 
     def __init__(self, id: str, relative: int) -> None:

--- a/mypy/server/aststripnew.py
+++ b/mypy/server/aststripnew.py
@@ -152,7 +152,6 @@ class NodeStripVisitor(TraverserVisitor):
 
     def visit_import_all(self, node: ImportAll) -> None:
         node.assignments = []
-        node.imported_names = []
 
     def visit_for_stmt(self, node: ForStmt) -> None:
         node.index_type = node.unanalyzed_index_type


### PR DESCRIPTION
It is used by aststrip.py, but not by aststripnew.py, so the new
semantic analyzer doesn't need it. Ignoring it makes some future changes
easier.