### PR TITLE
Free typechecker state and ASTs when they are no longer needed

### DIFF
--- a/mypy/freetree.py
+++ b/mypy/freetree.py
@@ -11,4 +11,11 @@ class TreeFreer(TraverserVisitor):
 
 
 def free_tree(tree: MypyFile) -> None:
+    """Free all the ASTs associated with a module.
+
+    This needs to be done recursively, since symbol tables contain
+    references to definitions, so those won't be freed but we want their
+    contents to be.
+    """
     tree.accept(TreeFreer())
+    tree.defs.clear()

--- a/mypy/freetree.py
+++ b/mypy/freetree.py
@@ -1,0 +1,14 @@
+"""Generic node traverser visitor"""
+
+from mypy.traverser import TraverserVisitor
+from mypy.nodes import Block, MypyFile
+
+
+class TreeFreer(TraverserVisitor):
+    def visit_block(self, block: Block) -> None:
+        super().visit_block(block)
+        block.body.clear()
+
+
+def free_tree(tree: MypyFile) -> None:
+    tree.accept(TreeFreer())

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -216,6 +216,12 @@ class Options:
         # in modules being compiled. Not in the config file or command line.
         self.mypyc = False
 
+        # Disable the memory optimization of freeing ASTs when
+        # possible. This isn't exposed as a command line option
+        # because it is intended for software integrating with
+        # mypy. (Like mypyc.)
+        self.preserve_asts = False
+
         # Paths of user plugins
         self.plugins = []  # type: List[str]
 

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -958,6 +958,12 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
         return triggers
 
 
+def merge_dependencies(new_deps: Dict[str, Set[str]],
+                       deps: Dict[str, Set[str]]) -> None:
+    for trigger, targets in new_deps.items():
+        deps.setdefault(trigger, set()).update(targets)
+
+
 def non_trivial_bases(info: TypeInfo) -> List[TypeInfo]:
     return [base for base in info.mro[1:]
             if base.fullname() != 'builtins.object']

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -140,7 +140,7 @@ from mypy.newsemanal.semanal_main import semantic_analysis_for_scc, semantic_ana
 from mypy.server.astmerge import merge_asts
 from mypy.server.aststrip import strip_target
 from mypy.server.aststripnew import strip_target_new, SavedAttributes
-from mypy.server.deps import get_dependencies_of_target
+from mypy.server.deps import get_dependencies_of_target, merge_dependencies
 from mypy.server.target import trigger_to_target
 from mypy.server.trigger import make_trigger, WILDCARD_TAG
 from mypy.util import module_prefix, split_target
@@ -163,7 +163,9 @@ class FineGrainedBuildManager:
         self.manager = manager
         self.graph = result.graph
         self.previous_modules = get_module_to_path_map(self.graph)
-        self.deps = get_all_dependencies(manager, self.graph)
+        self.deps = manager.fg_deps
+        # Merge in any root dependencies that may not have been loaded
+        merge_dependencies(manager.load_fine_grained_deps(FAKE_ROOT_MODULE), self.deps)
         self.previous_targets_with_errors = manager.errors.targets()
         self.previous_messages = result.errors[:]
         # Module, if any, that had blocking errors in the last run as (id, path) tuple.
@@ -378,7 +380,8 @@ class FineGrainedBuildManager:
             self.manager.log_fine_grained('triggered: %r' % sorted(filtered))
         self.triggered.extend(triggered | self.previous_targets_with_errors)
         if module in graph:
-            merge_dependencies(graph[module].compute_fine_grained_deps(), self.deps)
+            graph[module].update_fine_grained_deps(self.deps)
+            graph[module].free_state()
         remaining += propagate_changes_using_dependencies(
             manager, graph, self.deps, triggered,
             {module},
@@ -453,15 +456,11 @@ def ensure_trees_loaded(manager: BuildManager, graph: Dict[str, State],
         process_fresh_modules(graph, to_process, manager)
 
 
-def get_all_dependencies(manager: BuildManager, graph: Dict[str, State]) -> Dict[str, Set[str]]:
-    """Return the fine-grained dependency map for an entire build."""
-    # Deps for each module were computed during build() or loaded from the cache.
-    deps = manager.load_fine_grained_deps(FAKE_ROOT_MODULE)  # type: Dict[str, Set[str]]
-    for id in graph:
-        if graph[id].tree is not None:
-            merge_dependencies(graph[id].compute_fine_grained_deps(), deps)
-    TypeState.add_all_protocol_deps(deps)
-    return deps
+def fix_fg_dependencies(manager: BuildManager, deps: Dict[str, Set[str]]) -> None:
+    """Populate the dependencies with stuff that build may have missed"""
+    # This means the root module and typestate
+    merge_dependencies(manager.load_fine_grained_deps(FAKE_ROOT_MODULE), deps)
+    # TypeState.add_all_protocol_deps(deps)
 
 
 # The result of update_module_isolated when no blockers, with these items:
@@ -608,15 +607,12 @@ def update_module_isolated(module: str,
     state.type_check_first_pass()
     state.type_check_second_pass()
     t2 = time.time()
-    state.compute_fine_grained_deps()
-    t3 = time.time()
     state.finish_passes()
-    t4 = time.time()
+    t3 = time.time()
     manager.add_stats(
         semanal_time=t1 - t0,
         typecheck_time=t2 - t1,
-        deps_time=t3 - t2,
-        finish_passes_time=t4 - t3)
+        finish_passes_time=t3 - t2)
 
     graph[module] = state
 
@@ -698,14 +694,6 @@ def get_sources(fscache: FileSystemCache,
         if fscache.isfile(path):
             sources.append(BuildSource(path, id, None))
     return sources
-
-
-def merge_dependencies(new_deps: Dict[str, Set[str]],
-                       deps: Dict[str, Set[str]]) -> None:
-    for trigger, targets in new_deps.items():
-        deps.setdefault(trigger, set()).update(targets)
-    # Merge also the newly added protocol deps.
-    TypeState.update_protocol_deps(deps)
 
 
 def calculate_active_triggers(manager: BuildManager,
@@ -993,6 +981,8 @@ def reprocess_nodes(manager: BuildManager,
 
     # Report missing imports.
     graph[module_id].verify_dependencies()
+
+    graph[module_id].free_state()
 
     return new_triggered
 

--- a/mypy/test/testdeps.py
+++ b/mypy/test/testdeps.py
@@ -45,6 +45,7 @@ class GetDependenciesSuite(DataSuite):
         options.cache_dir = os.devnull
         options.python_version = python_version
         options.export_types = True
+        options.preserve_asts = True
         messages, files, type_map = self.build(src, options)
         a = messages
         if files is None or type_map is None:

--- a/mypy/test/testmerge.py
+++ b/mypy/test/testmerge.py
@@ -106,6 +106,7 @@ class ASTMergeSuite(DataSuite):
         options.incremental = True
         options.fine_grained_incremental = True
         options.use_builtins_fixtures = True
+        options.export_types = True
         options.show_traceback = True
         options.python_version = PYTHON3_VERSION
         main_path = os.path.join(test_temp_dir, 'main')
@@ -216,7 +217,13 @@ class ASTMergeSuite(DataSuite):
         for module_id in sorted(manager.manager.modules):
             if not is_dumped_module(module_id):
                 continue
-            type_map = manager.graph[module_id].type_map()
+            all_types = manager.manager.all_types
+            # Compute a module type map from the global type map
+            tree = manager.graph[module_id].tree
+            assert tree is not None
+            type_map = {node: all_types[node]
+                        for node in get_subexpressions(tree)
+                        if node in all_types}
             if type_map:
                 a.append('## {}'.format(module_id))
                 for expr in sorted(type_map, key=lambda n: (n.line, short_type(n),

--- a/mypy/test/testtypegen.py
+++ b/mypy/test/testtypegen.py
@@ -31,6 +31,7 @@ class TypeExportSuite(DataSuite):
             options.use_builtins_fixtures = True
             options.show_traceback = True
             options.export_types = True
+            options.preserve_asts = True
             result = build.build(sources=[BuildSource('main', None, src)],
                                  options=options,
                                  alt_lib_path=test_temp_dir)

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -211,15 +211,13 @@ class TypeState:
     def add_all_protocol_deps(deps: Dict[str, Set[str]]) -> None:
         """Add all known protocol dependencies to deps.
 
-        This is used by tests and debug output, and also when passing
-        all collected or loaded dependencies on to FineGrainedBuildManager
-        in its __init__.
+        This is used by tests and debug output, and also when collecting
+        all collected or loaded dependencies as part of build.
         """
         TypeState.update_protocol_deps()  # just in case
-        assert TypeState.proto_deps is not None, (
-            "This should not be called after failed cache load")
-        for trigger, targets in TypeState.proto_deps.items():
-            deps.setdefault(trigger, set()).update(targets)
+        if TypeState.proto_deps is not None:
+            for trigger, targets in TypeState.proto_deps.items():
+                deps.setdefault(trigger, set()).update(targets)
 
 
 def reset_global_state() -> None:

--- a/test-data/unit/merge.test
+++ b/test-data/unit/merge.test
@@ -716,11 +716,9 @@ class A: pass
 a: Union[A, int]
 [out]
 ## target
-TempNode:-1: Any
 NameExpr:3: target.A<0>
 ==>
 ## target
-TempNode:-1: Any
 NameExpr:3: Union[target.A<0>, builtins.int<1>]
 
 [case testTypeType_types]
@@ -735,11 +733,9 @@ class A: pass
 a: Type[A]
 [out]
 ## target
-TempNode:-1: Any
 NameExpr:3: Type[target.A<0>]
 ==>
 ## target
-TempNode:-1: Any
 NameExpr:3: Type[target.A<0>]
 
 [case testTypeVar_types]
@@ -756,14 +752,12 @@ class A(Generic[T]):
     x: T
 [out]
 ## target
-TempNode:-1: Any
 CallExpr:2: Any
 NameExpr:2: Any
 TypeVarExpr:2: Any
 NameExpr:4: T`1(upper_bound=builtins.int<0>)
 ==>
 ## target
-TempNode:-1: Any
 CallExpr:2: Any
 NameExpr:2: Any
 TypeVarExpr:2: Any
@@ -785,14 +779,10 @@ x: foo[A]
 [out]
 tmp/target.py:4: error: Variable "target.foo" is not valid as a type
 ## target
-TempNode:-1: Any
-TempNode:-1: Any
 NameExpr:3: builtins.int<0>
 NameExpr:4: foo?[target.A<1>]
 ==>
 ## target
-TempNode:-1: Any
-TempNode:-1: Any
 NameExpr:3: builtins.int<0>
 NameExpr:4: foo?[target.A<1>]
 
@@ -1046,11 +1036,9 @@ class C(Generic[T]):
 A = C[int]
 [out]
 ## target
-TempNode:-1: Any
 NameExpr:2: _x.C[builtins.int<0>]<1>
 ==>
 ## target
-TempNode:-1: Any
 NameExpr:2: _x.C[builtins.int<0>]<1>
 
 [case testRefreshVar_symtable]
@@ -1502,4 +1490,3 @@ MypyFile:1<1>(
     NameExpr(bar [target.bar<6>])
     IntExpr(5)
     Literal[5]))
-


### PR DESCRIPTION
Instead of hanging around to all of them for the entire run of the
process, free ASTs and typechecker state (especially the type map) as
soon as a module is finished being processing.

In order to have this work when generating fine-grained dependencies,
we need to produce fine-grained dependencies much earlier, so
BuildManager now has an `fg_deps` field.

In the daemon, only free typechecker state, since we want to keep ASTs
around to increase recheck speed. (A future change might use an LRU
cache to keep only some around.)