### PR TITLE
scripts/stubtest: make it run again and type-check it

### DIFF
--- a/scripts/dumpmodule.py
+++ b/scripts/dumpmodule.py
@@ -1,25 +1,12 @@
 """Dump the runtime structure of a module as JSON.
 
 This is used for testing stubs.
-
-This needs to run in Python 2.7 and 3.x.
 """
-
-from __future__ import print_function
-
 import importlib
 import json
 import sys
 import types
-from typing import Text
-
-
-if sys.version_info >= (3, 0):
-    import inspect
-    long = int
-else:
-    import inspect2 as inspect
-
+import inspect
 
 
 def dump_module(id):
@@ -75,7 +62,7 @@ def dump_value(value, depth=0):
 
 
 def dump_simple(value):
-    if type(value) in (int, bool, float, str, bytes, Text, long, list, set, dict, tuple):
+    if type(value) in (int, bool, float, str, bytes, list, set, dict, tuple):
         return {'type': type(value).__name__}
     if value is None:
         return {'type': 'None'}

--- a/scripts/dumpmodule.py
+++ b/scripts/dumpmodule.py
@@ -3,20 +3,26 @@
 This is used for testing stubs.
 """
 import importlib
+import inspect
 import json
 import sys
 import types
-import inspect
+from types import FunctionType
+from typing import Optional, Dict, Any, Set, Callable
+from typing_extensions import Final
 
 
-def dump_module(id):
+DumpNode = Dict[str, Any]
+
+
+def dump_module(id: str) -> None:
     m = importlib.import_module(id)
     data = module_to_json(m)
     print(json.dumps(data, ensure_ascii=True, indent=4, sort_keys=True))
 
 
-def module_to_json(m):
-    result = {}
+def module_to_json(m: object) -> Dict[str, DumpNode]:
+    result = {}  # type: Dict[str, DumpNode]
     for name, value in m.__dict__.items():
         # Filter out some useless attributes.
 
@@ -33,7 +39,7 @@ def module_to_json(m):
             result[name] = dump_value(value)
 
         try:
-            _, line = inspect.getsourcelines(getattr(m, name))
+            line = inspect.getsourcelines(getattr(m, name))[1]  # type: Optional[int]
         except (TypeError, OSError):
             line = None
 
@@ -42,12 +48,13 @@ def module_to_json(m):
     return result
 
 
-def dump_value(value, depth=0):
+def dump_value(value: object, depth: int = 0) -> DumpNode:
     if depth > 10:
-        return 'max_recursion_depth_exceeded'
+        # TODO: Callers don't handle this case.
+        return 'max_recursion_depth_exceeded'  # type: ignore
     if isinstance(value, type):
         return dump_class(value, depth + 1)
-    if inspect.isfunction(value):
+    if isinstance(value, FunctionType):
         return dump_function(value)
     if callable(value):
         return {'type': 'callable'}  # TODO more information
@@ -61,7 +68,7 @@ def dump_value(value, depth=0):
     return dump_simple(value)
 
 
-def dump_simple(value):
+def dump_simple(value: object) -> DumpNode:
     if type(value) in (int, bool, float, str, bytes, list, set, dict, tuple):
         return {'type': type(value).__name__}
     if value is None:
@@ -71,7 +78,7 @@ def dump_simple(value):
     return {'type': 'unknown'}
 
 
-def dump_class(value, depth):
+def dump_class(value: type, depth: int) -> DumpNode:
     return {
         'type': 'class',
         'attributes': dump_attrs(value, depth),
@@ -86,13 +93,13 @@ special_methods = [
     '__bool__',
     '__contains__',
     '__iter__',
-]
+]  # type: Final
 
 
 # Change to return a dict
-def dump_attrs(d, depth):
+def dump_attrs(d: type, depth: int) -> DumpNode:
     result = {}
-    seen = set()
+    seen = set()  # type: Set[str]
     try:
         mro = d.mro()
     except TypeError:
@@ -115,10 +122,10 @@ kind_map = {
     inspect.Parameter.VAR_POSITIONAL: 'VAR_POS',
     inspect.Parameter.KEYWORD_ONLY: 'KW_ONLY',
     inspect.Parameter.VAR_KEYWORD: 'VAR_KW',
-}
+}  # type: Final
 
 
-def param_kind(p):
+def param_kind(p: inspect.Parameter) -> str:
     s = kind_map[p.kind]
     if p.default != inspect.Parameter.empty:
         assert s in ('POS_ONLY', 'POS_OR_KW', 'KW_ONLY')
@@ -126,7 +133,7 @@ def param_kind(p):
     return s
 
 
-def dump_function(value):
+def dump_function(value: FunctionType) -> DumpNode:
     try:
         sig = inspect.signature(value)
     except ValueError:

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,9 @@ commands = flake8 {posargs}
 [testenv:type]
 description = type check ourselves
 basepython = python3.7
-commands = python -m mypy --config-file mypy_self_check.ini -p mypy
+commands =
+    python -m mypy --config-file mypy_self_check.ini -p mypy
+    python -m mypy --config-file mypy_self_check.ini scripts/stubtest.py
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
This script broke some time ago. Update it and type-check it so at least it keeps "compiling".

The script depends on `scripts/dumpmodule` so add type annotations there as well.

See individual commits for easier review.

Refs: https://github.com/python/mypy/issues/3329#issuecomment-515668522