### PR TITLE
Config option to ignore file parse errors

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -173,7 +173,8 @@ def parse(source: Union[str, bytes],
         tree.path = fnam
         tree.is_stub = is_stub_file
     except SyntaxError as e:
-        errors.report(e.lineno, e.offset, e.msg, blocker=True)
+        errors.report(e.lineno, e.offset, e.msg,
+                      blocker=not options.ignore_parse_errors)
         tree = MypyFile([], [], False, set())
 
     if raise_on_error and errors.is_errors():

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -111,7 +111,8 @@ def parse(source: Union[str, bytes],
         tree.path = fnam
         tree.is_stub = is_stub_file
     except SyntaxError as e:
-        errors.report(e.lineno, e.offset, e.msg, blocker=True)
+        errors.report(e.lineno, e.offset, e.msg,
+                      blocker=not options.ignore_parse_errors)
         tree = MypyFile([], [], False, set())
 
     if raise_on_error and errors.is_errors():

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -40,6 +40,7 @@ PER_MODULE_OPTIONS = {
     "follow_imports_for_stubs",
     "ignore_errors",
     "ignore_missing_imports",
+    "ignore_parse_errors",
     "local_partial_types",
     "mypyc",
     "no_implicit_optional",
@@ -140,6 +141,9 @@ class Options:
 
         # Files in which to ignore all non-fatal errors
         self.ignore_errors = False
+
+        # Files in which to ignore parsing errors.
+        self.ignore_parse_errors = False
 
         # Apply strict None checking
         self.strict_optional = True


### PR DESCRIPTION
**RFC quality. Not anywhere close to landing.**

The Mercurial project has some .py files that are Python 2 or
Python 3 only. Mypy's current behavior is to find all .py files
and attempt to parse them. If the parse fails, this is a blocking
error and execution aborts immediately. This behavior is obviously
not desirable for projects containing mixed Python version sources.

This commit teaches Mypy to make parse errors non-fatal/blocking.

It teaches the option system a new `ignore_parse_errors` boolean
to control whether parse errors are ignored. This option is
consulted at the low-level parser to determine whether to make
the parse error a blocker.

Open issues:

* Ignoring parse errors is a special case of "ignore file." Perhaps
  the more general feature would be better?
* The option doesn't seem to work on per-module entries in the
  mypy.ini file. I'm not sure why.
* Missing tests.
* Missing documentation updates.
* Is inserting an empty ast tree on parse failure the proper failure
  mode? I'm not sure what the implications are for using an empty
  tree versus ignoring the module completely.