### PR TITLE
Whitelist some equality checks under --strict-equality

### DIFF
--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1395,10 +1395,13 @@ frozenset({1}) == [1]  # Error
 
 {1: 2}.keys() == {1}
 {1: 2}.keys() == frozenset({1})
+{1: 2}.items() == {(1, 2)}
 
+{1: 2}.keys() == {'no'}  # Error
 {1: 2}.values() == {2}  # Error
 {1: 2}.keys() == [1]  # Error
 [out]
 _testStrictEqualityWhitelist.py:5: error: Non-overlapping equality check (left operand type: "FrozenSet[int]", right operand type: "List[int]")
-_testStrictEqualityWhitelist.py:10: error: Non-overlapping equality check (left operand type: "ValuesView[int]", right operand type: "Set[int]")
-_testStrictEqualityWhitelist.py:11: error: Non-overlapping equality check (left operand type: "KeysView[int]", right operand type: "List[int]")
+_testStrictEqualityWhitelist.py:11: error: Non-overlapping equality check (left operand type: "KeysView[int]", right operand type: "Set[str]")
+_testStrictEqualityWhitelist.py:12: error: Non-overlapping equality check (left operand type: "ValuesView[int]", right operand type: "Set[int]")
+_testStrictEqualityWhitelist.py:13: error: Non-overlapping equality check (left operand type: "KeysView[int]", right operand type: "List[int]")

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1385,3 +1385,20 @@ def thing(stuff: StuffDict) -> int: ...
 
 [out]
 _testNewAnalyzerTypedDictInStub_newsemanal.py:2: note: Revealed type is 'def (stuff: TypedDict('stub.StuffDict', {'foo': builtins.str, 'bar': builtins.int})) -> builtins.int'
+
+[case testStrictEqualityWhitelist]
+# mypy: strict-equality
+{1} == frozenset({1})
+frozenset({1}) == {1}
+
+frozenset({1}) == [1]  # Error
+
+{1: 2}.keys() == {1}
+{1: 2}.keys() == frozenset({1})
+
+{1: 2}.values() == {2}  # Error
+{1: 2}.keys() == [1]  # Error
+[out]
+_testStrictEqualityWhitelist.py:5: error: Non-overlapping equality check (left operand type: "FrozenSet[int]", right operand type: "List[int]")
+_testStrictEqualityWhitelist.py:10: error: Non-overlapping equality check (left operand type: "ValuesView[int]", right operand type: "Set[int]")
+_testStrictEqualityWhitelist.py:11: error: Non-overlapping equality check (left operand type: "KeysView[int]", right operand type: "List[int]")


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7275

As I mentioned in the issue, we can just whitelist some pairs of classes.