### PR TITLE
Remove the ForwardRef type

### DIFF
--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -110,9 +110,3 @@ class TypeIndirectionVisitor(SyntheticTypeVisitor[Set[str]]):
 
     def visit_type_type(self, t: types.TypeType) -> Set[str]:
         return self._visit(t.item)
-
-    def visit_forwardref_type(self, t: types.ForwardRef) -> Set[str]:
-        if t.resolved:
-            return self._visit(t.resolved)
-        else:
-            return set()

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -22,7 +22,7 @@ from mypy.errors import Errors
 from mypy.types import (
     Type, CallableType, Instance, TypeVarType, TupleType, TypedDictType, LiteralType,
     UnionType, NoneType, AnyType, Overloaded, FunctionLike, DeletedType, TypeType,
-    UninhabitedType, TypeOfAny, ForwardRef, UnboundType, PartialType,
+    UninhabitedType, TypeOfAny, UnboundType, PartialType,
 )
 from mypy.typetraverser import TypeTraverserVisitor
 from mypy.nodes import (
@@ -1355,11 +1355,6 @@ def format_type_inner(typ: Type,
             return '<nothing>'
     elif isinstance(typ, TypeType):
         return 'Type[{}]'.format(format(typ.item))
-    elif isinstance(typ, ForwardRef):  # may appear in semanal.py
-        if typ.resolved:
-            return format(typ.resolved)
-        else:
-            return format(typ.unbound)
     elif isinstance(typ, FunctionLike):
         func = typ
         if func.is_type_obj():

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -96,7 +96,7 @@ from mypy.traverser import TraverserVisitor
 from mypy.types import (
     Type, Instance, AnyType, NoneType, TypeVisitor, CallableType, DeletedType, PartialType,
     TupleType, TypeType, TypeVarType, TypedDictType, UnboundType, UninhabitedType, UnionType,
-    FunctionLike, ForwardRef, Overloaded, TypeOfAny, LiteralType,
+    FunctionLike, Overloaded, TypeOfAny, LiteralType,
 )
 from mypy.server.trigger import make_trigger, make_wildcard_trigger
 from mypy.util import correct_relative_import
@@ -921,9 +921,6 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
                 triggers.append(trigger.rstrip('>') + '.__init__>')
                 triggers.append(trigger.rstrip('>') + '.__new__>')
         return triggers
-
-    def visit_forwardref_type(self, typ: ForwardRef) -> List[str]:
-        assert False, 'Internal error: Leaked forward reference object {}'.format(typ)
 
     def visit_type_var(self, typ: TypeVarType) -> List[str]:
         triggers = []

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -14,7 +14,7 @@ from mypy.types import (
     Type, UnboundType, TypeVarType, TupleType, TypedDictType, UnionType, Instance, AnyType,
     CallableType, NoneType, DeletedType, TypeList, TypeVarDef, SyntheticTypeVisitor,
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType, get_typ_args, set_typ_args,
-    CallableArgument, get_type_vars, TypeQuery, union_items, TypeOfAny, ForwardRef,
+    CallableArgument, get_type_vars, TypeQuery, union_items, TypeOfAny,
     LiteralType, RawExpressionType, PlaceholderType
 )
 
@@ -567,9 +567,6 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
     def visit_type_type(self, t: TypeType) -> Type:
         return TypeType.make_normalized(self.anal_type(t.item), line=t.line)
 
-    def visit_forwardref_type(self, t: ForwardRef) -> Type:
-        return t
-
     def visit_placeholder_type(self, t: PlaceholderType) -> Type:
         n = None if t.fullname is None else self.api.lookup_fully_qualified(t.fullname)
         if not n or isinstance(n.node, PlaceholderNode):
@@ -742,8 +739,6 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     return None
                 out.extend(union_result)
             return out
-        elif isinstance(arg, ForwardRef):
-            return [arg]
         else:
             self.fail('Parameter {} of Literal[...] is invalid'.format(idx), ctx)
             return None

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1808,54 +1808,6 @@ class TypeType(Type):
         return TypeType.make_normalized(deserialize_type(data['item']))
 
 
-class ForwardRef(Type):
-    """Class to wrap forward references to other types.
-
-    This is used when a forward reference to an (unanalyzed) synthetic type is found,
-    for example:
-
-        x: A
-        A = TypedDict('A', {'x': int})
-
-    To avoid false positives and crashes in such situations, we first wrap the first
-    occurrence of 'A' in ForwardRef. Then, the wrapped UnboundType is updated in the third
-    pass of semantic analysis and ultimately fixed in the patches after the third pass.
-    So that ForwardRefs are temporary and will be completely replaced with the linked types
-    or Any (to avoid cyclic references) before the type checking stage.
-    """
-    _unbound = None  # type: UnboundType  # The original wrapped type
-    _resolved = None  # type: Optional[Type]  # The resolved forward reference (initially None)
-
-    def __init__(self, unbound: UnboundType) -> None:
-        super().__init__()
-        self._unbound = unbound
-        self._resolved = None
-
-    @property
-    def unbound(self) -> UnboundType:
-        # This is read-only to make it clear that resolution happens through resolve().
-        return self._unbound
-
-    @property
-    def resolved(self) -> Optional[Type]:
-        # Similar to above.
-        return self._resolved
-
-    def resolve(self, resolved: Type) -> None:
-        """Resolve an unbound forward reference to point to a type."""
-        assert self._resolved is None
-        self._resolved = resolved
-
-    def accept(self, visitor: 'TypeVisitor[T]') -> T:
-        return visitor.visit_forwardref_type(self)
-
-    def serialize(self) -> str:
-        name = self.unbound.name
-        # We should never get here since all forward references should be resolved
-        # and removed during semantic analysis.
-        assert False, "Internal error: Unresolved forward reference to {}".format(name)
-
-
 class PlaceholderType(Type):
     """Temporary, yet-unknown type during semantic analysis.
 
@@ -2063,12 +2015,6 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
 
     def visit_type_type(self, t: TypeType) -> str:
         return 'Type[{}]'.format(t.item.accept(self))
-
-    def visit_forwardref_type(self, t: ForwardRef) -> str:
-        if t.resolved:
-            return '~{}'.format(t.resolved.accept(self))
-        else:
-            return '~{}'.format(t.unbound.accept(self))
 
     def visit_placeholder_type(self, t: PlaceholderType) -> str:
         return '<placeholder {}>'.format(t.fullname)

--- a/mypy/typetraverser.py
+++ b/mypy/typetraverser.py
@@ -6,7 +6,7 @@ from mypy.types import (
     Type, SyntheticTypeVisitor, AnyType, UninhabitedType, NoneType, ErasedType, DeletedType,
     TypeVarType, LiteralType, Instance, CallableType, TupleType, TypedDictType, UnionType,
     Overloaded, TypeType, CallableArgument, UnboundType, TypeList, StarType, EllipsisType,
-    ForwardRef, PlaceholderType, PartialType, RawExpressionType
+    PlaceholderType, PartialType, RawExpressionType
 )
 
 
@@ -83,9 +83,6 @@ class TypeTraverserVisitor(SyntheticTypeVisitor[None]):
         t.type.accept(self)
 
     def visit_ellipsis_type(self, t: EllipsisType) -> None:
-        pass
-
-    def visit_forwardref_type(self, t: ForwardRef) -> None:
         pass
 
     def visit_placeholder_type(self, t: PlaceholderType) -> None:


### PR DESCRIPTION
Now that the old semantic analyzer has been purged, I believe we no longer need the ForwardRef type. This commit deletes that type and associated visitor functions.

(This came up during my quest to enable `--warn-unreachable` for mypy, though I'm a little hazy on how exactly -- it's been a while. I think this indirectly helps us improve type precision with our type visitors by further helping clarify the distinction between full-fledged and semantic-analysis-only types?)