### PR TITLE
Add error code arguments to plugin API

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -72,6 +72,7 @@ from mypy.scope import Scope
 from mypy.typeops import tuple_fallback
 from mypy import state
 from mypy.traverser import has_return_statement
+from mypy.errorcodes import ErrorCode
 
 T = TypeVar('T')
 
@@ -3948,9 +3949,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             temp.set_line(context.get_line())
         return temp
 
-    def fail(self, msg: str, context: Context) -> None:
+    def fail(self, msg: str, context: Context, *, code: Optional[ErrorCode] = None) -> None:
         """Produce an error message."""
-        self.msg.fail(msg, context)
+        self.msg.fail(msg, context, code=code)
 
     def note(self, msg: str, context: Context, offset: int = 0) -> None:
         """Produce a note."""

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -256,7 +256,7 @@ class SemanticAnalyzerPluginInterface:
 
     @abstractmethod
     def fail(self, msg: str, ctx: Context, serious: bool = False, *,
-             blocker: bool = False) -> None:
+             blocker: bool = False, code: Optional[ErrorCode] = None) -> None:
         """Emmit an error message at given location."""
         raise NotImplementedError
 

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -218,7 +218,7 @@ class CheckerPluginInterface:
     path = None  # type: str
 
     @abstractmethod
-    def fail(self, msg: str, ctx: Context) -> None:
+    def fail(self, msg: str, ctx: Context, *, code: Optional[ErrorCode] = None) -> None:
         """Emit an error message at given location."""
         raise NotImplementedError
 

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -134,6 +134,7 @@ from mypy.types import Type, Instance, CallableType, TypeList, UnboundType
 from mypy.messages import MessageBuilder
 from mypy.options import Options
 from mypy.lookup import lookup_fully_qualified
+from mypy.errorcodes import ErrorCode
 import mypy.interpreted_plugin
 
 
@@ -152,7 +153,7 @@ class TypeAnalyzerPluginInterface:
     options = None  # type: Options
 
     @abstractmethod
-    def fail(self, msg: str, ctx: Context) -> None:
+    def fail(self, msg: str, ctx: Context, *, code: Optional[ErrorCode] = None) -> None:
         """Emmit an error message at given location."""
         raise NotImplementedError
 

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -13,6 +13,7 @@ from mypy.nodes import (
 from mypy.util import correct_relative_import
 from mypy.types import Type, FunctionLike, Instance, TupleType, TPDICT_FB_NAMES
 from mypy.tvar_scope import TypeVarScope
+from mypy.errorcodes import ErrorCode
 from mypy import join
 
 # Priorities for ordering of patches within the "patch" phase of semantic analysis
@@ -44,7 +45,7 @@ class SemanticAnalyzerCoreInterface:
 
     @abstractmethod
     def fail(self, msg: str, ctx: Context, serious: bool = False, *,
-             blocker: bool = False) -> None:
+             blocker: bool = False, code: Optional[ErrorCode] = None) -> None:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -29,6 +29,7 @@ from mypy.tvar_scope import TypeVarScope
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.plugin import Plugin, TypeAnalyzerPluginInterface, AnalyzeTypeContext
 from mypy.semanal_shared import SemanticAnalyzerCoreInterface
+from mypy.errorcodes import ErrorCode
 from mypy import nodes, message_registry
 
 T = TypeVar('T')
@@ -746,8 +747,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
     def analyze_type(self, t: Type) -> Type:
         return t.accept(self)
 
-    def fail(self, msg: str, ctx: Context) -> None:
-        self.fail_func(msg, ctx)
+    def fail(self, msg: str, ctx: Context, *, code: Optional[ErrorCode] = None) -> None:
+        self.fail_func(msg, ctx, code=code)
 
     def note(self, msg: str, ctx: Context) -> None:
         self.note_func(msg, ctx)


### PR DESCRIPTION
Update some `fail()` methods to accept an error code argument.