### PR TITLE
Silence deprecation warning from typed-ast in tests

### DIFF
--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -107,6 +107,7 @@ def parse(source: Union[str, bytes],
     is_stub_file = fnam.endswith('.pyi')
     try:
         assert options.python_version[0] < 3 and not is_stub_file
+        # Disable deprecation warnings about <>.
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             ast = ast27.parse(source, fnam, 'exec')

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -15,6 +15,7 @@ different class hierarchies, which made it difficult to write a shared visitor b
 two in a typesafe way.
 """
 import sys
+import warnings
 
 import typing  # for typing.Type, which conflicts with types.Type
 from typing import Tuple, Union, TypeVar, Callable, Sequence, Optional, Any, Dict, cast, List
@@ -106,7 +107,9 @@ def parse(source: Union[str, bytes],
     is_stub_file = fnam.endswith('.pyi')
     try:
         assert options.python_version[0] < 3 and not is_stub_file
-        ast = ast27.parse(source, fnam, 'exec')
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            ast = ast27.parse(source, fnam, 'exec')
         tree = ASTConverter(options=options,
                             errors=errors,
                             ).visit(ast)


### PR DESCRIPTION
This fixes a deprecation warning about `<>` in Python 2 that came up every
time the full test suite was run.