### PR TITLE
Fix is_overlapping_types() logic for fallback instances

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -302,6 +302,9 @@ def is_overlapping_types(left: Type,
             return False
 
         if len(left.args) == len(right.args):
+            if not left.args:
+                # We can get here if the instance is in fact a fallback from another type.
+                return True
             # Note: we don't really care about variance here, since the overlapping check
             # is symmetric and since we want to return 'True' even for partial overlaps.
             #

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -2212,10 +2212,10 @@ Bad in subclasses  # E: Non-overlapping container check (element type: "Type[Bad
 from typing import List, Type
 
 class Meta(type): ...
+class OtherMeta(type): ...
 
 class A(metaclass=Meta): ...
-class B(metaclass=Meta): ...
-class C: ...
+class C(metaclass=OtherMeta): ...
 
 o: Type[object]
 exp: List[Meta]
@@ -2284,6 +2284,22 @@ THREE: Final = 3
 if returns_a_or_b() == 'c':  # E: Non-overlapping equality check (left operand type: "Union[Literal['a'], Literal['b']]", right operand type: "Literal['c']")
     ...
 if returns_1_or_2() is THREE:  # E: Non-overlapping identity check (left operand type: "Union[Literal[1], Literal[2]]", right operand type: "Literal[3]")
+    ...
+[builtins fixtures/bool.pyi]
+
+[case testStrictEqualityWithALiteralNewType]
+# flags: --strict-equality
+from typing import NewType
+
+UserId = NewType('UserId', int)
+FileId = NewType('FileId', str)
+
+u: UserId
+f: FileId
+
+if u == 0:  # OK
+    ...
+if f == 0:  # E: Non-overlapping equality check (left operand type: "FileId", right operand type: "Literal[0]")
     ...
 [builtins fixtures/bool.pyi]
 

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -5058,3 +5058,18 @@ tmp/lib.pyi:1: error: Name 'overload' is not defined
 tmp/lib.pyi:3: error: Name 'func' already defined on line 1
 tmp/lib.pyi:3: error: Name 'overload' is not defined
 main:3: note: Revealed type is 'Any'
+
+[case testLiteralSubtypeOverlap]
+from typing import overload
+from typing_extensions import Literal
+
+class MyInt(int): ...
+
+# Strictly speaking we can't prove this is unsafe (this depends on the implementation),
+# but such APIs seem like an anti-pattern anyways.
+@overload
+def foo(x: Literal[0]) -> None: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+@overload
+def foo(x: MyInt) -> int: ...
+def foo(x):
+    ...


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7350

This also fixes an unrelated issue that went unnoticed because of a poor test (in that case the problem was because of a callable fallback, which is a metaclass for class objects).

@Michael0x2a if you don't have time to review this soon, then I will merge without waiting to unblock an internal pin move.