### PR TITLE
Remove bad hints for missing generator return types.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1013,7 +1013,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         (fdef.arg_names[0] == 'self' or fdef.arg_names[0] == 'cls'))):
                     self.fail(message_registry.RETURN_TYPE_EXPECTED, fdef,
                               code=codes.NO_UNTYPED_DEF)
-                    if not has_return_statement(fdef):
+                    if not has_return_statement(fdef) and not fdef.is_generator:
                         self.note('Use "-> None" if function does not return a value', fdef)
                 else:
                     self.fail(message_registry.FUNCTION_TYPE_EXPECTED, fdef,

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -694,8 +694,7 @@ async def f() -> AsyncGenerator[Any, Any]:
 async def h() -> Any:
     yield 0
 
-async def g():  # E: Function is missing a return type annotation \
-                # N: Use "-> None" if function does not return a value
+async def g():  # E: Function is missing a return type annotation
     yield 0
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -265,8 +265,7 @@ def g(x: int):  # E: Function is missing a return type annotation  [no-untyped-d
 def h(x) -> None:  # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
     pass
 
-def gen():  # E: Function is missing a return type annotation  [no-untyped-def] \
-            # N: Use "-> None" if function does not return a value
+def gen():  # E: Function is missing a return type annotation  [no-untyped-def]
     yield 1
 
 def gen2(x: int):  # E: Function is missing a return type annotation  [no-untyped-def]


### PR DESCRIPTION
`-> None` isn't the correct return type annotation for non-returning generators... so stop suggesting it!