### PR TITLE
Always erase last known value from instances when using binder or partial types

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -10,6 +10,7 @@ from mypy.types import (
 from mypy.subtypes import is_subtype
 from mypy.join import join_simple
 from mypy.sametypes import is_same_type
+from mypy.erasetype import remove_instance_last_known_values
 from mypy.nodes import Expression, Var, RefExpr
 from mypy.literals import Key, literal, literal_hash, subkeys
 from mypy.nodes import IndexExpr, MemberExpr, NameExpr
@@ -250,6 +251,10 @@ class ConditionalTypeBinder:
                     restrict_any: bool = False) -> None:
         type = get_proper_type(type)
         declared_type = get_proper_type(declared_type)
+
+        # We should erase last known value in binder, because if we are using it,
+        # it means that the target is not final, and therefore can't hold a literal.
+        type = remove_instance_last_known_values(type)
 
         if self.type_assignments is not None:
             # We are in a multiassign from union, defer the actual binding,

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -249,12 +249,12 @@ class ConditionalTypeBinder:
                     type: Type,
                     declared_type: Optional[Type],
                     restrict_any: bool = False) -> None:
-        type = get_proper_type(type)
-        declared_type = get_proper_type(declared_type)
-
         # We should erase last known value in binder, because if we are using it,
         # it means that the target is not final, and therefore can't hold a literal.
         type = remove_instance_last_known_values(type)
+
+        type = get_proper_type(type)
+        declared_type = get_proper_type(declared_type)
 
         if self.type_assignments is not None:
             # We are in a multiassign from union, defer the actual binding,

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1954,6 +1954,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         partial_types = self.find_partial_types(var)
                         if partial_types is not None:
                             if not self.current_node_deferred:
+                                # Partial type can't be final, so strip any literal values.
+                                rvalue_type = remove_instance_last_known_values(rvalue_type)
                                 inferred_type = UnionType.make_simplified_union(
                                     [rvalue_type, NoneType()])
                                 self.set_inferred_type(var, lvalue, inferred_type)

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -3081,3 +3081,15 @@ takes_three(x)  # E: Argument 1 to "takes_three" has incompatible type "int"; ex
 if x == 2:  # OK
     ...
 [builtins fixtures/bool.pyi]
+
+[case testLiteralBinderLastValueErasedPartialTypes]
+# mypy: strict-equality
+
+def test() -> None:
+    x = None
+    if bool():
+        x = 1
+
+    if x == 2:  # OK
+        ...
+[builtins fixtures/bool.pyi]

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -3067,3 +3067,17 @@ reveal_type(Test3.FOO.name)  # N: Revealed type is 'builtins.str'
 reveal_type(Test4.FOO.name)  # N: Revealed type is 'builtins.str'
 reveal_type(Test5.FOO.name)  # N: Revealed type is 'builtins.str'
 [out]
+
+[case testLiteralBinderLastValueErased]
+# mypy: strict-equality
+
+from typing_extensions import Literal
+
+def takes_three(x: Literal[3]) -> None: ...
+x: object
+x = 3
+
+takes_three(x)  # E: Argument 1 to "takes_three" has incompatible type "int"; expected "Literal[3]"
+if x == 2:  # OK
+    ...
+[builtins fixtures/bool.pyi]


### PR DESCRIPTION
See the test cases for simplified example of currently problematic behaviour when using `--strict-equality`.