### PR TITLE
Enable TypedDict vs overload interaction that was disabled

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1437,9 +1437,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         order."""
 
         def has_shape(typ: Type) -> bool:
-            # TODO: Once https://github.com/python/mypy/issues/5198 is fixed,
-            #       add 'isinstance(typ, TypedDictType)' somewhere below.
-            return (isinstance(typ, TupleType)
+            return (isinstance(typ, TupleType) or isinstance(typ, TypedDictType)
                     or (isinstance(typ, Instance) and typ.type.is_named_tuple))
 
         matches = []  # type: List[CallableType]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -2551,11 +2551,9 @@ reveal_type(f(**{'x': 4, 'y': 4}))           # N: Revealed type is 'builtins.tup
 reveal_type(f(**{'a': 4, 'b': 4, 'c': 4}))   # N: Revealed type is 'builtins.tuple[builtins.int]'
 [builtins fixtures/dict.pyi]
 
-[case testOverloadKwargsSelectionWithTypedDict-skip]
-# TODO: Mypy doesn't seem to correctly destructure typed dicts in general.
-#       We should re-enable this once https://github.com/python/mypy/issues/5198 is resolved
+[case testOverloadKwargsSelectionWithTypedDict]
 from typing import overload, Tuple
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 @overload
 def f(*, x: int) -> Tuple[int]: ...
 @overload


### PR DESCRIPTION
I think this can be re-enabled since https://github.com/python/mypy/issues/5198 was fixed.