### PR TITLE
Report undefined module attributes with --ignore-missing-imports

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2347,7 +2347,7 @@ def find_module_and_diagnose(manager: BuildManager,
 
 
 def exist_added_packages(suppressed: List[str],
-                        manager: BuildManager, options: Options) -> bool:
+                         manager: BuildManager, options: Options) -> bool:
     """Find if there are any newly added packages that were previously suppressed.
 
     Exclude everything not in build for follow-imports=skip.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3982,7 +3982,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         return sym
 
     def is_missing_module(self, module: str) -> bool:
-        return self.options.ignore_missing_imports or module in self.missing_modules
+        return module in self.missing_modules
 
     def implicit_symbol(self, sym: SymbolTableNode, name: str, parts: List[str],
                         source_type: AnyType) -> SymbolTableNode:

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2755,3 +2755,13 @@ roles.role = 1  # E: Incompatible types in assignment (expression has type "int"
 from types import ModuleType
 def __getattr__(name: str) -> ModuleType: ...
 [builtins fixtures/module.pyi]
+
+[case testWeird]
+# flags: --ignore-missing-imports
+import pack.mod as alias
+
+x: alias.NonExistent  # E: Name 'alias.NonExistent' is not defined
+
+[file pack/__init__.py]
+[file pack/mod.py]
+class Existent: pass

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2756,7 +2756,7 @@ from types import ModuleType
 def __getattr__(name: str) -> ModuleType: ...
 [builtins fixtures/module.pyi]
 
-[case testWeird]
+[case testAlwaysReportMissingAttributesOnFoundModules]
 # flags: --ignore-missing-imports
 import pack.mod as alias
 


### PR DESCRIPTION
The issue was reported internally. Currently we never report missing module attributes with `--ignore-missing-imports`.