### PR TITLE
test(No return rule): add test - looping over generator case

### DIFF
--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -102,21 +102,21 @@ main:7: error: Missing return statement
 
 [case testNoReturnForExhaustiveGenerator]
 # flags: --warn-no-return
-from itertools import count, cycle
+from itertools import count, cycle, repeat
 def h() -> int:
-    for _i in count(1):
+    for _i in count(1): # count is non-exhaustive
         if bool():
             return 1
 
 def i() -> int:
-    for _i in range(3):
+    for _i in repeat(10, 3):
         if bool():
             return 1
         if bool():
             break
 
 def j() -> int:
-    for _i in cycle('ABC'):
+    for _i in cycle((1, 2, 3)): # cycle is non-exhaustive
         if bool():
             return 1
         if bool():

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -100,6 +100,31 @@ def j() -> int:
 [out]
 main:7: error: Missing return statement
 
+[case testNoReturnForExhaustiveGenerator]
+# flags: --warn-no-return
+from itertools import count, cycle
+def h() -> int:
+    for _i in count(1):
+        if bool():
+            return 1
+
+def i() -> int:
+    for _i in range(3):
+        if bool():
+            return 1
+        if bool():
+            break
+
+def j() -> int:
+    for _i in cycle('ABC'):
+        if bool():
+            return 1
+        if bool():
+            continue
+[builtins fixtures/list.pyi]
+[out]
+main:8: error: Missing return statement
+
 [case testNoReturnExcept]
 # flags: --warn-no-return
 def f() -> int:


### PR DESCRIPTION
For unconditionally looping over non-exhaustive generators, it should be acceptable to have no `return` statement. For unconditionally looping over exhaustive generators, the function should have `return` statement.

Partially addressing #2276

This should be merged after fixing https://github.com/python/mypy/issues/7374 .