### PR TITLE
Fixed mypyc github link

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Compiled version of mypy
 ------------------------
 
 We have built an compiled version of mypy using the [mypyc
-compiler](https://github.com/python/mypy/files/mypyc) for
+compiler](https://github.com/python/mypy/tree/master/mypyc) for
 mypy-annotated Python code. It is approximately 4 times faster than
 interpreted mypy and is available (and the default) for 64-bit
 Windows, macOS, and Linux.


### PR DESCRIPTION
The previous link appears to be broken, and this is what I found.