### PR TITLE
Fix serialization of redefined nodes

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -76,6 +76,7 @@ class NodeFixer(NodeVisitor[None]):
                     stnode = lookup_qualified_stnode(self.modules, cross_ref,
                                                      self.allow_missing)
                     if stnode is not None:
+                        assert stnode.node is not None
                         value.node = stnode.node
                     elif not self.allow_missing:
                         assert stnode is not None, "Could not find cross-ref %s" % (cross_ref,)

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -57,8 +57,12 @@ class NodeFixer(NodeVisitor[None]):
             if info.metaclass_type:
                 info.metaclass_type.accept(self.type_fixer)
             if info._mro_refs:
-                info.mro = [lookup_qualified_typeinfo(self.modules, name, self.allow_missing)
-                            for name in info._mro_refs]
+                # If the class is a "-redefinition", then its
+                # reference to itself might be busted, so just use the
+                # info instead of looking up the first element. Ew.
+                info.mro = [info] + [
+                    lookup_qualified_typeinfo(self.modules, name, self.allow_missing)
+                    for name in info._mro_refs[1:]]
                 info._mro_refs = None
         finally:
             self.current_info = save_info

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2986,8 +2986,10 @@ class SymbolTableNode:
             assert self.node is not None, '%s:%s' % (prefix, name)
             if prefix is not None:
                 fullname = self.node.fullname()
-                if (fullname is not None and '.' in fullname and
-                        fullname != prefix + '.' + name
+                if (fullname is not None and '.' in fullname
+                        and fullname != prefix + '.' + name
+                        # If it only doesn't match because of -redefinition, that is OK
+                        and fullname != prefix + '.' + name.split('-redefinition')[0]
                         and not (isinstance(self.node, Var)
                                  and self.node.from_module_getattr)):
                     data['cross_ref'] = fullname

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3114,6 +3114,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                         # never create module alias except on initial var definition
                         elif lval.is_inferred_def:
                             lnode.kind = self.current_symbol_kind()
+                            assert rnode.node is not None
                             lnode.node = rnode.node
 
     def process__all__(self, s: AssignmentStmt) -> None:

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -9160,3 +9160,27 @@ Data = Tuple[User, File]
 [typing fixtures/typing-full.pyi]
 [out]
 ==
+
+[case testClassRedef]
+# An issue involved serializing these caused crashes in the past
+
+[file a.py]
+class A:
+    pass
+
+x = 0
+
+[file a.py.2]
+class A:
+    a = A()
+
+x = '0'
+
+[file b.py]
+from a import A, x
+
+class A: # type: ignore
+    pass
+
+[out]
+==


### PR DESCRIPTION
Currently they will get incorrectly serialized as xrefs because
the symbol table name doesn't match the fullname.

Fix this. (Though I don't love the way I've fixed it, if somebody has
a suggestion for something nicer.)

This could cause nondeterministc crashes under python 3.5 when it led
to crossrefs to crossrefs, since random dict iteration order meant
that the referenced crossref might not be resolved. Add some asserts
to catch these things earlier.