### PR TITLE
Format suggestions using the "signature" pyannotate format instead

### DIFF
--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -650,9 +650,6 @@ class TypeFormatter(TypeStrVisitor):
         else:
             return super().visit_union_type(t)
 
-    def visit_type_var(self, t: TypeVarType) -> str:
-        return t.name
-
 
 class StrToText(TypeTranslator):
     def __init__(self, builtin_type: Callable[[str], Instance]) -> None:

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -23,8 +23,9 @@ Other things:
 """
 
 from typing import (
-    Any, List, Optional, Tuple, Dict, Callable, Union, NamedTuple, TypeVar, Iterator,
+    List, Optional, Tuple, Dict, Callable, Union, NamedTuple, TypeVar, Iterator,
 )
+from typing_extensions import TypedDict
 
 from mypy.state import strict_optional_set
 from mypy.types import (
@@ -55,6 +56,11 @@ from contextlib import contextmanager
 import itertools
 import json
 import os
+
+
+PyAnnotateSignature = TypedDict('PyAnnotateSignature',
+                                {'return_type': str, 'arg_types': List[str]})
+
 
 Callsite = NamedTuple(
     'Callsite',
@@ -101,10 +107,6 @@ class SuggestionPlugin(Plugin):
             ctx.arg_names,
             ctx.arg_types))
         return ctx.default_return_type
-
-
-# TODO: typed dict?
-PyAnnotateSignature = Dict[str, Any]
 
 
 # NOTE: We could make this a bunch faster by implementing a StatementVisitor that skips

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -23,7 +23,7 @@ Other things:
 """
 
 from typing import (
-    List, Optional, Tuple, Dict, Callable, Union, NamedTuple, TypeVar, Iterator,
+    Any, List, Optional, Tuple, Dict, Callable, Union, NamedTuple, TypeVar, Iterator,
 )
 
 from mypy.state import strict_optional_set
@@ -31,7 +31,7 @@ from mypy.types import (
     Type, AnyType, TypeOfAny, CallableType, UnionType, NoneType, Instance, TupleType,
     TypeVarType, FunctionLike,
     TypeStrVisitor, TypeTranslator,
-    is_optional, ProperType, get_proper_type,
+    is_optional, remove_optional, ProperType, get_proper_type,
 )
 from mypy.build import State, Graph
 from mypy.nodes import (
@@ -101,6 +101,10 @@ class SuggestionPlugin(Plugin):
             ctx.arg_names,
             ctx.arg_types))
         return ctx.default_return_type
+
+
+# TODO: typed dict?
+PyAnnotateSignature = Dict[str, Any]
 
 
 # NOTE: We could make this a bunch faster by implementing a StatementVisitor that skips
@@ -175,7 +179,7 @@ class SuggestionEngine:
         if self.give_json:
             return self.json_suggestion(function, suggestion)
         else:
-            return suggestion
+            return self.format_signature(suggestion)
 
     def suggest_callsites(self, function: str) -> str:
         """Find a list of call sites of function."""
@@ -247,7 +251,11 @@ class SuggestionEngine:
             if default:
                 all_arg_types.append(default)
 
-            if all_arg_types:
+            if len(all_arg_types) == 1 and isinstance(get_proper_type(all_arg_types[0]), NoneType):
+                types.append(
+                    [UnionType.make_union([all_arg_types[0],
+                                           AnyType(TypeOfAny.explicit)])])
+            elif all_arg_types:
                 types.append(generate_type_combinations(all_arg_types))
             else:
                 # If we don't have anything, we'll try Any and object
@@ -311,7 +319,7 @@ class SuggestionEngine:
                    key=lambda s: (count_errors(errors[s]), self.score_callable(s)))
         return best, count_errors(errors[best])
 
-    def get_suggestion(self, function: str) -> str:
+    def get_suggestion(self, function: str) -> PyAnnotateSignature:
         """Compute a suggestion for a function.
 
         Return the type and whether the first argument should be ignored.
@@ -355,7 +363,7 @@ class SuggestionEngine:
         if self.no_errors and errors:
             raise SuggestionFailure("No annotation without errors")
 
-        return self.format_callable(mod, is_method, best)
+        return self.pyannotate_signature(mod, is_method, best)
 
     def format_args(self,
                     arg_kinds: List[List[int]],
@@ -483,7 +491,7 @@ class SuggestionEngine:
     def builtin_type(self, s: str) -> Instance:
         return self.manager.semantic_analyzer.builtin_type(s)
 
-    def json_suggestion(self, function: str, suggestion: str) -> str:
+    def json_suggestion(self, function: str, suggestion: PyAnnotateSignature) -> str:
         """Produce a json blob for a suggestion suitable for application by pyannotate."""
         mod, func_name, node = self.find_node(function)
         # pyannotate irritatingly drops class names for class and static methods
@@ -496,7 +504,7 @@ class SuggestionEngine:
         path = os.path.abspath(self.graph[mod].xpath)
 
         obj = {
-            'type_comments': [suggestion],
+            'signature': suggestion,
             'line': node.line,
             'path': path,
             'func_name': func_name,
@@ -504,14 +512,25 @@ class SuggestionEngine:
         }
         return json.dumps([obj], sort_keys=True)
 
-    def format_callable(self,
-                        cur_module: Optional[str], is_method: bool, typ: CallableType) -> str:
-        """Format a callable type in a way suitable as an annotation... kind of"""
+    def pyannotate_signature(
+        self,
+        cur_module: Optional[str],
+        is_method: bool,
+        typ: CallableType
+    ) -> PyAnnotateSignature:
+        """Format a callable type as a pyannotate dict"""
         start = int(is_method)
-        s = "({}) -> {}".format(
-            ", ".join([self.format_type(cur_module, t) for t in typ.arg_types[start:]]),
-            self.format_type(cur_module, typ.ret_type))
-        return s
+        return {
+            'arg_types': [self.format_type(cur_module, t) for t in typ.arg_types[start:]],
+            'return_type': self.format_type(cur_module, typ.ret_type),
+        }
+
+    def format_signature(self, sig: PyAnnotateSignature) -> str:
+        """Format a callable type in a way suitable as an annotation... kind of"""
+        return "({}) -> {}".format(
+            ", ".join(sig['arg_types']),
+            sig['return_type']
+        )
 
     def format_type(self, cur_module: Optional[str], typ: Type) -> str:
         return typ.accept(TypeFormatter(cur_module, self.graph))
@@ -609,7 +628,9 @@ class TypeFormatter(TypeStrVisitor):
         elif t.args != []:
             obj += '[{}]'.format(self.list_str(t.args))
 
-        if mod == 'builtins':
+        if mod_obj == ('builtins', 'unicode'):
+            return 'Text'
+        elif mod == 'builtins':
             return obj
         else:
             delim = '.' if '.' not in obj else ':'
@@ -622,6 +643,15 @@ class TypeFormatter(TypeStrVisitor):
                 return t.partial_fallback.accept(self)
         s = self.list_str(t.items)
         return 'Tuple[{}]'.format(s)
+
+    def visit_union_type(self, t: UnionType) -> str:
+        if len(t.items) == 2 and is_optional(t):
+            return "Optional[{}]".format(remove_optional(t).accept(self))
+        else:
+            return super().visit_union_type(t)
+
+    def visit_type_var(self, t: TypeVarType) -> str:
+        return t.name
 
 
 class StrToText(TypeTranslator):

--- a/test-data/unit/fine-grained-suggest.test
+++ b/test-data/unit/fine-grained-suggest.test
@@ -64,7 +64,7 @@ def untyped(x) -> None:
     foo(x)
 [builtins fixtures/isinstancelist.pyi]
 [out]
-(Union[str, int, None], Union[int, None]) -> None
+(Union[str, int, None], Optional[int]) -> None
 ==
 
 [case testSuggestInferFunc2]
@@ -100,7 +100,7 @@ from foo import bar
 bar(None)
 [out]
 (Any) -> Any
-(None) -> None
+(Optional[Any]) -> None
 ==
 
 [case testSuggestInferFuncAny2]
@@ -185,7 +185,7 @@ def foo(s):
 from foo import foo
 foo('lol')
 [out]
-(unicode) -> unicode
+(Text) -> Text
 ==
 
 [case testSuggestInferMethod1]
@@ -211,7 +211,7 @@ def bar() -> None:
     x.foo(None)
 [builtins fixtures/isinstancelist.pyi]
 [out]
-(Union[str, int, None], Union[int, None]) -> object
+(Union[str, int, None], Optional[int]) -> object
 ==
 
 [case testSuggestInferMethod2]
@@ -238,7 +238,7 @@ def bar() -> None:
     a: Union[str, int] = x.foo(None)
 [builtins fixtures/isinstancelist.pyi]
 [out]
-(Union[str, int, None], Union[int, None]) -> Union[int, str]
+(Union[str, int, None], Optional[int]) -> Union[int, str]
 ==
 
 [case testSuggestInferMethod3]
@@ -259,7 +259,7 @@ def bar() -> None:
 [builtins fixtures/isinstancelist.pyi]
 [out]
 ==
-(Union[str, None]) -> None
+(Optional[str]) -> None
 
 [case testSuggestInferFunctionUnreachable]
 # flags: --strict-optional
@@ -304,7 +304,7 @@ def bar() -> None:
 [builtins fixtures/isinstancelist.pyi]
 [out]
 ==
-(Union[str, int, None], Union[int, None]) -> Union[int, str]
+(Union[str, int, None], Optional[int]) -> Union[int, str]
 
 [case testSuggestInferNestedMethod]
 # flags: --strict-optional
@@ -358,8 +358,8 @@ def baz() -> None:
     foo(None)
 [builtins fixtures/isinstancelist.pyi]
 [out]
-(Union[str, int, None], Union[int, None]) -> object
-(Union[str, int, None], Union[int, None]) -> None
+(Union[str, int, None], Optional[int]) -> object
+(Union[str, int, None], Optional[int]) -> None
 ==
 
 [case testSuggestInferFuncDecorator1]


### PR DESCRIPTION
This bypasses pyannotate's parsing and processing of annotations
and allows us to just specify them directly. This is useful because
pyannotate doesn't support Callable.