### PR TITLE
Add support for nicer error output

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -111,7 +111,8 @@ def main(script_path: Optional[str],
     if options.error_summary:
         if messages:
             n_errors, n_files = util.count_stats(messages)
-            stdout.write(formatter.format_error(n_errors, n_files) + '\n')
+            if n_errors:
+                stdout.write(formatter.format_error(n_errors, n_files) + '\n')
         else:
             stdout.write(formatter.format_success() + '\n')
         stdout.flush()

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -112,9 +112,9 @@ def main(script_path: Optional[str],
         if messages:
             n_errors, n_files = util.count_stats(messages)
             if n_errors:
-                stdout.write(formatter.format_error(n_errors, n_files) + '\n')
+                stdout.write(formatter.format_error(n_errors, n_files, len(sources)) + '\n')
         else:
-            stdout.write(formatter.format_success() + '\n')
+            stdout.write(formatter.format_success(len(sources)) + '\n')
         stdout.flush()
     if options.fast_exit:
         # Exit without freeing objects -- it's faster.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -63,12 +63,15 @@ def main(script_path: Optional[str],
                                        fscache=fscache)
 
     messages = []
+    formatter = util.FancyFormatter(stdout, stderr, options.show_error_codes)
 
     def flush_errors(new_messages: List[str], serious: bool) -> None:
         messages.extend(new_messages)
         f = stderr if serious else stdout
         try:
             for msg in new_messages:
+                if options.color_output:
+                    msg = formatter.colorize(msg)
                 f.write(msg + '\n')
             f.flush()
         except BrokenPipeError:
@@ -105,6 +108,13 @@ def main(script_path: Optional[str],
     code = 0
     if messages:
         code = 2 if blockers else 1
+    if options.error_summary:
+        if messages:
+            n_errors, n_files = util.count_stats(messages)
+            stdout.write(formatter.format_error(n_errors, n_files) + '\n')
+        else:
+            stdout.write(formatter.format_success() + '\n')
+        stdout.flush()
     if options.fast_exit:
         # Exit without freeing objects -- it's faster.
         #
@@ -567,6 +577,12 @@ def process_options(args: List[str],
                         group=error_group)
     add_invertible_flag('--show-error-codes', default=False,
                         help="Show error codes in error messages",
+                        group=error_group)
+    add_invertible_flag('--no-color-output', dest='color_output', default=True,
+                        help="Do not colorize error messages",
+                        group=error_group)
+    add_invertible_flag('--no-error-summary', dest='error_summary', default=True,
+                        help="Do not show error stats summary",
                         group=error_group)
 
     strict_help = "Strict mode; enables the following flags: {}".format(

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -138,6 +138,10 @@ class Options:
         # Show "note: In function "foo":" messages.
         self.show_error_context = False
 
+        # Use nicer output (when possible).
+        self.color_output = True
+        self.error_summary = True
+
         # Files in which to allow strict-Optional related errors
         # TODO: Kill this in favor of show_none_errors
         self.strict_optional_whitelist = None   # type: Optional[List[str]]

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -387,6 +387,7 @@ def parse_options(program_text: str, testcase: DataDrivenTestCase,
         options = Options()
         # TODO: Enable strict optional in test cases by default (requires *many* test case changes)
         options.strict_optional = False
+        options.error_summary = False
 
     # Allow custom python version to override testcase_pyversion
     if (not flag_list or

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -47,6 +47,8 @@ def test_python_cmdline(testcase: DataDrivenTestCase, step: int) -> None:
     args = parse_args(testcase.input[0])
     args.append('--show-traceback')
     args.append('--no-site-packages')
+    if '--error-summary' not in args:
+        args.append('--no-error-summary')
     # Type check the program.
     fixed = [python3_path, '-m', 'mypy']
     env = os.environ.copy()

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -114,6 +114,7 @@ class ExampleProg(object):
             old_dir = os.getcwd()
             os.chdir(venv_dir)
         try:
+            cmd_line.append('--no-error-summary')
             if python_executable != sys.executable:
                 cmd_line.append('--python-executable={}'.format(python_executable))
             out, err, returncode = mypy.api.run(cmd_line)

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -57,6 +57,7 @@ def test_python_evaluation(testcase: DataDrivenTestCase, cache_dir: str) -> None
         '--no-site-packages',
         '--no-strict-optional',
         '--no-silence-site-packages',
+        '--no-error-summary',
     ]
     py2 = testcase.name.lower().endswith('python2')
     if py2:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -400,6 +400,6 @@ class FancyFormatter:
         return self.style('Success: no issues found', 'green', bold=True)
 
     def format_error(self, n_errors: int, n_files: int) -> str:
-        msg = 'Found {} error{} in {} file{}'.format(n_errors, 's' if n_errors > 1 else '',
-                                                     n_files, 's' if n_files > 1 else '')
+        msg = 'Found {} error{} in {} file{}'.format(n_errors, 's' if n_errors != 1 else '',
+                                                     n_files, 's' if n_files != 1 else '')
         return self.style(msg, 'red', bold=True)

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -8,6 +8,12 @@ import sys
 from typing import TypeVar, List, Tuple, Optional, Dict, Sequence, Iterable, Container, IO
 from typing_extensions import Final, Type, Literal
 
+try:
+    import curses
+    CURSES_ENABLED = True
+except ImportError:
+    CURSES_ENABLED = False
+
 T = TypeVar('T')
 
 ENCODING_RE = \
@@ -339,9 +345,7 @@ class FancyFormatter:
             return
 
         # We in a human-facing terminal, check if it supports enough styling.
-        try:
-            import curses
-        except ImportError:
+        if not CURSES_ENABLED:
             self.dummy_term = True
             return
         try:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -4,7 +4,6 @@ import pathlib
 import re
 import subprocess
 import sys
-import curses
 
 from typing import TypeVar, List, Tuple, Optional, Dict, Sequence, Iterable, Container, IO
 from typing_extensions import Final, Type, Literal
@@ -340,7 +339,17 @@ class FancyFormatter:
             return
 
         # We in a human-facing terminal, check if it supports enough styling.
-        curses.setupterm()
+        try:
+            import curses
+        except ImportError:
+            self.dummy_term = True
+            return
+        try:
+            curses.setupterm()
+        except curses.error:
+            # Most likely terminfo not found.
+            self.dummy_term = True
+            return
         bold = curses.tigetstr('bold')
         setaf = curses.tigetstr('setaf')
         self.dummy_term = not (bold and setaf)

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -332,7 +332,7 @@ def count_stats(errors: List[str]) -> Tuple[int, int]:
 class FancyFormatter:
     """Apply color and bold font to terminal output.
 
-    This currently only works on Linus an Mac.
+    This currently only works on Linux and Mac.
     """
     def __init__(self, f_out: IO[str], f_err: IO[str],
                  show_error_codes: bool) -> None:
@@ -341,7 +341,8 @@ class FancyFormatter:
         if sys.platform not in ('linux', 'darwin'):
             self.dummy_term = True
             return
-        if not f_out.isatty() or not f_err.isatty():
+        force_color = int(os.getenv('MYPY_FORCE_COLOR', '0'))
+        if not force_color and (not f_out.isatty() or not f_err.isatty()):
             self.dummy_term = True
             return
 
@@ -417,7 +418,7 @@ class FancyFormatter:
         return out
 
     def underline_link(self, note: str) -> str:
-        match = re.search(r'http://\S*', note)
+        match = re.search(r'https?://\S*', note)
         if not match:
             return note
         start = match.start()

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1331,3 +1331,59 @@ files = config.py
 [out]
 mypy: can't read file 'override.py': No such file or directory
 == Return code: 2
+
+[case testErrorSummaryOnSuccess]
+# cmd: mypy --error-summary good.py
+[file good.py]
+x = 2 + 2
+[out]
+Success: no issues found
+== Return code: 0
+
+[case testErrorSummaryOnFail]
+# cmd: mypy --error-summary bad.py
+[file bad.py]
+42 + 'no'
+[out]
+bad.py:1: error: Unsupported operand types for + ("int" and "str")
+Found 1 error in 1 file
+
+[case testErrorSummaryOnFailNotes]
+# cmd: mypy --error-summary bad.py
+[file bad.py]
+from typing import List
+x: List[float]
+y: List[int]
+x = y
+[out]
+bad.py:4: error: Incompatible types in assignment (expression has type "List[int]", variable has type "List[float]")
+bad.py:4: note: "List" is invariant -- see http://mypy.readthedocs.io/en/latest/common_issues.html#variance
+bad.py:4: note: Consider using "Sequence" instead, which is covariant
+Found 1 error in 1 file
+
+[case testErrorSummaryOnFailTwoErrors]
+# cmd: mypy --error-summary bad.py
+[file bad.py]
+42 + 'no'
+42 + 'no'
+[out]
+bad.py:1: error: Unsupported operand types for + ("int" and "str")
+bad.py:2: error: Unsupported operand types for + ("int" and "str")
+Found 2 errors in 1 file
+
+[case testErrorSummaryOnFailTwoFiles]
+# cmd: mypy --error-summary bad.py bad2.py
+[file bad.py]
+42 + 'no'
+[file bad2.py]
+42 + 'no'
+[out]
+bad2.py:1: error: Unsupported operand types for + ("int" and "str")
+bad.py:1: error: Unsupported operand types for + ("int" and "str")
+Found 2 errors in 2 files
+
+[case testErrorSummaryOnBadUsage]
+# cmd: mypy --error-summary missing.py
+[out]
+mypy: can't read file 'missing.py': No such file or directory
+== Return code: 2

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1322,7 +1322,6 @@ fail
 a/b.py:1: error: Name 'fail' is not defined
 c.py:1: error: Name 'fail' is not defined
 
-
 [case testIniFilesCmdlineOverridesConfig]
 # cmd: mypy override.py
 [file mypy.ini]
@@ -1337,7 +1336,7 @@ mypy: can't read file 'override.py': No such file or directory
 [file good.py]
 x = 2 + 2
 [out]
-Success: no issues found
+Success: no issues found in 1 source file
 == Return code: 0
 
 [case testErrorSummaryOnFail]
@@ -1346,30 +1345,31 @@ Success: no issues found
 42 + 'no'
 [out]
 bad.py:1: error: Unsupported operand types for + ("int" and "str")
-Found 1 error in 1 file
+Found 1 error in 1 file (checked 1 source file)
 
 [case testErrorSummaryOnFailNotes]
 # cmd: mypy --error-summary bad.py
 [file bad.py]
 from typing import List
-x: List[float]
-y: List[int]
+x = []  # type: List[float]
+y = []  # type: List[int]
 x = y
 [out]
 bad.py:4: error: Incompatible types in assignment (expression has type "List[int]", variable has type "List[float]")
 bad.py:4: note: "List" is invariant -- see http://mypy.readthedocs.io/en/latest/common_issues.html#variance
 bad.py:4: note: Consider using "Sequence" instead, which is covariant
-Found 1 error in 1 file
+Found 1 error in 1 file (checked 1 source file)
 
 [case testErrorSummaryOnFailTwoErrors]
-# cmd: mypy --error-summary bad.py
+# cmd: mypy --error-summary bad.py foo.py
 [file bad.py]
 42 + 'no'
 42 + 'no'
+[file foo.py]
 [out]
 bad.py:1: error: Unsupported operand types for + ("int" and "str")
 bad.py:2: error: Unsupported operand types for + ("int" and "str")
-Found 2 errors in 1 file
+Found 2 errors in 1 file (checked 2 source files)
 
 [case testErrorSummaryOnFailTwoFiles]
 # cmd: mypy --error-summary bad.py bad2.py
@@ -1380,7 +1380,7 @@ Found 2 errors in 1 file
 [out]
 bad2.py:1: error: Unsupported operand types for + ("int" and "str")
 bad.py:1: error: Unsupported operand types for + ("int" and "str")
-Found 2 errors in 2 files
+Found 2 errors in 2 files (checked 2 source files)
 
 [case testErrorSummaryOnBadUsage]
 # cmd: mypy --error-summary missing.py

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -146,6 +146,7 @@ Daemon stopped
 $ {python} -c "print('x=1')" >foo.py
 $ {python} -c "print('x=1')" >bar.py
 $ mypy --local-partial-types --cache-fine-grained --follow-imports=error --no-sqlite-cache --python-version=3.6 -- foo.py bar.py
+Success: no issues found
 $ {python} -c "import shutil; shutil.copy('.mypy_cache/3.6/bar.meta.json', 'asdf.json')"
 -- update bar's timestamp but don't change the file
 $ {python} -c "import time;time.sleep(1)"

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -146,7 +146,7 @@ Daemon stopped
 $ {python} -c "print('x=1')" >foo.py
 $ {python} -c "print('x=1')" >bar.py
 $ mypy --local-partial-types --cache-fine-grained --follow-imports=error --no-sqlite-cache --python-version=3.6 -- foo.py bar.py
-Success: no issues found
+Success: no issues found in 2 source files
 $ {python} -c "import shutil; shutil.copy('.mypy_cache/3.6/bar.meta.json', 'asdf.json')"
 -- update bar's timestamp but don't change the file
 $ {python} -c "import time;time.sleep(1)"


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7368
Fixes https://github.com/python/mypy/issues/7410

This adds some basic support for output styling on Mac and Linux. The formatter does some basic error message parsing because passing them forward in a structured form would be a bigger change, however if you think this is worth doing I can refactor the PR in a more principled way.

To illustrate the result this is how the output would look:

![Screenshot from 2019-08-30 11:22:32](https://user-images.githubusercontent.com/12005495/64014497-2a40f880-cb1a-11e9-8c4d-4bdcdc5be9e7.png)
