### PR TITLE
Be more flexible with spaces in "# type: ignore[code]" comments

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -186,7 +186,7 @@ def parse_type_ignore_tag(tag: Optional[str]) -> List[str]:
     # TODO: Implement proper parsing and error checking
     if not tag:
         return []
-    m = re.match(r'\[([^#]*)\]', tag)
+    m = re.match(r'\s*\[([^#]*)\]', tag)
     if m is None:
         return []
     return [code.strip() for code in m.group(1).split(',')]

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -101,6 +101,22 @@ a = 'x'.foobar(b)  # type: ignore[xyz, w, attr-defined]  # E: Name 'b' is not de
 a = 'x'.foobar(b) # type: int # type: ignore[name-defined, attr-defined]
 b = 'x'.foobar(b) # type: int # type: ignore[name-defined, xyz]  # E: "str" has no attribute "foobar"  [attr-defined]
 
+[case testErrorCodeIgnoreWithExtraSpace]
+x  # type: ignore   [name-defined]
+x2 # type: ignore   [ name-defined ]
+x3 # type: ignore   [ xyz , name-defined ]
+x4 # type: ignore[xyz,name-defined]
+y  # type: ignore   [xyz]  # E: Name 'y' is not defined  [name-defined]
+y  # type: ignore[  xyz  ]  # E: Name 'y' is not defined  [name-defined]
+y  # type: ignore[ xyz , foo  ]  # E: Name 'y' is not defined  [name-defined]
+
+a = z  # type: int  # type: ignore  [name-defined]
+b = z2  # type: int  # type: ignore  [ name-defined ]
+c = z2  # type: int  # type: ignore  [ name-defined , xyz ]
+d = zz # type: int  # type: ignore  [xyz]  # E: Name 'zz' is not defined  [name-defined]
+e = zz # type: int  # type: ignore  [ xyz ]  # E: Name 'zz' is not defined  [name-defined]
+f = zz # type: int  # type: ignore  [ xyz,foo ]  # E: Name 'zz' is not defined  [name-defined]
+
 [case testErrorCodeIgnoreAfterArgComment]
 def f(x  # type: xyz  # type: ignore[name-defined]  # Comment
       ):


### PR DESCRIPTION
In particular, allow `# type: ignore [code]` (space after `ignore`).

Add tests for various cases (some of which already worked).