### PR TITLE
Show code snippets on demand

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2985,7 +2985,11 @@ def process_stale_scc(graph: Graph, scc: List[str], manager: BuildManager) -> No
         for id in stale:
             graph[id].transitive_error = True
     for id in stale:
-        manager.flush_errors(manager.errors.file_messages(graph[id].xpath), False)
+        manager.flush_errors(manager.errors.file_messages(
+            graph[id].xpath,
+            manager.fscache.read_cache.get(graph[id].xpath),
+            manager.options.show_source_code,
+            manager.options.python_version), False)
         graph[id].write_cache()
         graph[id].mark_as_rechecked()
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -202,7 +202,7 @@ def _build(sources: List[BuildSource],
     errors = Errors(options.show_error_context,
                     options.show_column_numbers,
                     options.show_error_codes,
-                    options.show_source_code,
+                    options.pretty,
                     lambda path: read_py_file(path, cached_read, options.python_version))
     plugin, snapshot = load_plugins(options, errors, stdout)
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -36,7 +36,8 @@ from mypy.checker import TypeChecker
 from mypy.indirection import TypeIndirectionVisitor
 from mypy.errors import Errors, CompileError, ErrorInfo, report_internal_error
 from mypy.util import (
-    DecodeError, decode_python_encoding, is_sub_path, get_mypy_comments, module_prefix
+    DecodeError, decode_python_encoding, is_sub_path, get_mypy_comments, module_prefix,
+    read_py_file
 )
 if TYPE_CHECKING:
     from mypy.report import Reports  # Avoid unconditional slow import
@@ -197,7 +198,12 @@ def _build(sources: List[BuildSource],
         reports = Reports(data_dir, options.report_dirs)
 
     source_set = BuildSourceSet(sources)
-    errors = Errors(fscache, options)
+    cached_read = fscache.read
+    errors = Errors(options.show_error_context,
+                    options.show_column_numbers,
+                    options.show_error_codes,
+                    options.show_source_code,
+                    lambda path: read_py_file(path, cached_read, options.python_version))
     plugin, snapshot = load_plugins(options, errors, stdout)
 
     # Construct a build manager object to hold state during the build.

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -197,9 +197,7 @@ def _build(sources: List[BuildSource],
         reports = Reports(data_dir, options.report_dirs)
 
     source_set = BuildSourceSet(sources)
-    errors = Errors(options.show_error_context,
-                    options.show_column_numbers,
-                    options.show_error_codes)
+    errors = Errors(fscache, options)
     plugin, snapshot = load_plugins(options, errors, stdout)
 
     # Construct a build manager object to hold state during the build.
@@ -2985,11 +2983,7 @@ def process_stale_scc(graph: Graph, scc: List[str], manager: BuildManager) -> No
         for id in stale:
             graph[id].transitive_error = True
     for id in stale:
-        manager.flush_errors(manager.errors.file_messages(
-            graph[id].xpath,
-            manager.fscache.read_cache.get(graph[id].xpath),
-            manager.options.show_source_code,
-            manager.options.python_version), False)
+        manager.flush_errors(manager.errors.file_messages(graph[id].xpath), False)
         graph[id].write_cache()
         graph[id].mark_as_rechecked()
 

--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Dict, Mapping, Optional, Tuple, List
 from mypy.dmypy_util import DEFAULT_STATUS_FILE, receive
 from mypy.ipc import IPCClient, IPCException
 from mypy.dmypy_os import alive, kill
-from mypy.util import check_python_version
+from mypy.util import check_python_version, get_terminal_width
 
 from mypy.version import __version__
 
@@ -469,6 +469,7 @@ def request(status_file: str, command: str, *, timeout: Optional[int] = None,
     # Tell the server whether this request was initiated from a human-facing terminal,
     # so that it can format the type checking output accordingly.
     args['is_tty'] = sys.stdout.isatty()
+    args['terminal_width'] = get_terminal_width()
     bdata = json.dumps(args).encode('utf8')
     _, name = get_status(status_file)
     try:

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -511,7 +511,7 @@ class Server:
                 # Create new list to avoid appending multiple summaries on successive runs.
                 messages = messages + [summary]
         if use_color:
-            messages = [self.formatter.colorize(m, terminal_width) for m in messages]
+            messages = [self.formatter.colorize(m) for m in messages]
         return messages
 
     def update_sources(self, sources: List[BuildSource]) -> None:

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -375,7 +375,7 @@ class Server:
         """Check using fine-grained incremental mode.
 
         If is_tty is True format the output nicely with colors and summary line
-        (unless disabled in self.options). Also path the terminal_width to formatter.
+        (unless disabled in self.options). Also pass the terminal_width to formatter.
         """
         if not self.fine_grained_manager:
             res = self.initialize_fine_grained(sources, is_tty, terminal_width)

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -191,8 +191,7 @@ class Server:
 
         # Since the object is created in the parent process we can check
         # the output terminal options here.
-        self.formatter = FancyFormatter(sys.stdout, sys.stderr, options.show_error_codes,
-                                        options.pretty)
+        self.formatter = FancyFormatter(sys.stdout, sys.stderr, options.show_error_codes)
 
     def _response_metadata(self) -> Dict[str, str]:
         py_version = '{}_{}'.format(self.options.python_version[0], self.options.python_version[1])
@@ -498,6 +497,10 @@ class Server:
     def pretty_messages(self, messages: List[str], n_sources: int,
                         is_tty: bool = False, terminal_width: Optional[int] = None) -> List[str]:
         use_color = self.options.color_output and is_tty
+        fit_width = self.options.pretty and is_tty
+        if fit_width:
+            messages = self.formatter.fit_in_terminal(messages,
+                                                      fixed_terminal_width=terminal_width)
         if self.options.error_summary:
             summary = None  # type: Optional[str]
             if messages:

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -191,7 +191,8 @@ class Server:
 
         # Since the object is created in the parent process we can check
         # the output terminal options here.
-        self.formatter = FancyFormatter(sys.stdout, sys.stderr, options.show_error_codes)
+        self.formatter = FancyFormatter(sys.stdout, sys.stderr, options.show_error_codes,
+                                        options.show_source_code)
 
     def _response_metadata(self) -> Dict[str, str]:
         py_version = '{}_{}'.format(self.options.python_version[0], self.options.python_version[1])

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -416,7 +416,7 @@ class Errors:
                         source_lines: Optional[List[str]]) -> List[str]:
         """Return a string list that represents the error messages.
 
-        Use a form suitable for displaying to the user. If add_snippets
+        Use a form suitable for displaying to the user. If self.pretty
         is True also append a relevant trimmed source code line (only for
         severity 'error').
         """
@@ -443,17 +443,20 @@ class Errors:
             if self.pretty:
                 # Add source code fragment and a location marker.
                 if severity == 'error' and source_lines and line > 0:
+                    source_line = source_lines[line - 1]
+                    if column < 0:
+                        # Something went wrong, take first non-empty column.
+                        column = len(source_line) - len(source_line.lstrip())
                     # Note, currently coloring uses the offset to detect source snippets,
                     # so these offsets should not be arbitrary.
-                    a.append(' ' * DEFAULT_SOURCE_OFFSET + source_lines[line - 1])
+                    a.append(' ' * DEFAULT_SOURCE_OFFSET + source_line)
                     a.append(' ' * (DEFAULT_SOURCE_OFFSET + column) + '^')
         return a
 
     def file_messages(self, path: str) -> List[str]:
         """Return a string list of new error messages from a given file.
 
-        Use a form suitable for displaying to the user. If add_snippets is True,
-        then one must also pass the source code and Python version.
+        Use a form suitable for displaying to the user.
         """
         if path not in self.error_info_map:
             return []

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -11,7 +11,7 @@ from mypy.options import Options
 from mypy.version import __version__ as mypy_version
 from mypy.errorcodes import ErrorCode
 from mypy import errorcodes as codes
-from mypy.util import trim_source_line, DEFAULT_SOURCE_OFFSET, get_terminal_width, MINIMUM_WIDTH
+from mypy.util import DEFAULT_SOURCE_OFFSET
 
 T = TypeVar('T')
 allowed_duplicates = ['@overload', 'Got:', 'Expected:']  # type: Final
@@ -166,9 +166,6 @@ class Errors:
         self.pretty = pretty
         # We use fscache to read source code when showing snippets.
         self.read_source = read_source
-        # If this is not None, don't try calling get_terminal_width().
-        # This is used by the daemon, where the call may return a wrong value.
-        self.fixed_terminal_width = None  # type: Optional[int]
         self.initialize()
 
     def initialize(self) -> None:
@@ -199,7 +196,6 @@ class Errors:
         new.function_or_member = self.function_or_member[:]
         new.target_module = self.target_module
         new.scope = self.scope
-        new.fixed_terminal_width = self.fixed_terminal_width
         return new
 
     def total_errors(self) -> int:
@@ -447,16 +443,10 @@ class Errors:
             if self.pretty:
                 # Add source code fragment and a location marker.
                 if severity == 'error' and source_lines and line > 0:
-                    width = self.fixed_terminal_width or get_terminal_width()
-                    # Let source have some space also on the right side.
-                    width -= DEFAULT_SOURCE_OFFSET
-                    source_line, offset = trim_source_line(source_lines[line - 1],
-                                                           width, column, MINIMUM_WIDTH)
                     # Note, currently coloring uses the offset to detect source snippets,
                     # so these offsets should not be arbitrary.
-                    a.append(' ' * DEFAULT_SOURCE_OFFSET + source_line)
-                    # Also append a marker pointing to the error start location.
-                    a.append(' ' * (DEFAULT_SOURCE_OFFSET + column - offset) + '^')
+                    a.append(' ' * DEFAULT_SOURCE_OFFSET + source_lines[line - 1])
+                    a.append(' ' * (DEFAULT_SOURCE_OFFSET + column) + '^')
         return a
 
     def file_messages(self, path: str) -> List[str]:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -457,8 +457,8 @@ class Errors:
         if path not in self.error_info_map:
             return []
         self.flushed_files.add(path)
+        source_lines = None
         if self.options and self.options.show_source_code:
-            source_lines = None
             if self.fscache:
                 try:
                     source = self.fscache.read(path)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -63,11 +63,13 @@ def main(script_path: Optional[str],
                                        fscache=fscache)
 
     messages = []
-    formatter = util.FancyFormatter(stdout, stderr, options.show_error_codes, options.pretty)
+    formatter = util.FancyFormatter(stdout, stderr, options.show_error_codes)
 
     def flush_errors(new_messages: List[str], serious: bool) -> None:
         messages.extend(new_messages)
         f = stderr if serious else stdout
+        if options.pretty:
+            formatter.fit_in_terminal(messages)
         try:
             for msg in new_messages:
                 if options.color_output:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -63,8 +63,7 @@ def main(script_path: Optional[str],
                                        fscache=fscache)
 
     messages = []
-    formatter = util.FancyFormatter(stdout, stderr, options.show_error_codes,
-                                    options.show_source_code)
+    formatter = util.FancyFormatter(stdout, stderr, options.show_error_codes, options.pretty)
 
     def flush_errors(new_messages: List[str], serious: bool) -> None:
         messages.extend(new_messages)
@@ -583,8 +582,10 @@ def process_options(args: List[str],
     add_invertible_flag('--show-error-codes', default=False,
                         help="Show error codes in error messages",
                         group=error_group)
-    add_invertible_flag('--show-source-code', default=False,
-                        help="Show source code snippets in error messages",
+    add_invertible_flag('--pretty', default=False,
+                        help="Use visually nicer output in error messages:"
+                             " Use soft word wrap, show source code snippets,"
+                             " and error location markers",
                         group=error_group)
     add_invertible_flag('--no-color-output', dest='color_output', default=True,
                         help="Do not colorize error messages",

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -66,10 +66,10 @@ def main(script_path: Optional[str],
     formatter = util.FancyFormatter(stdout, stderr, options.show_error_codes)
 
     def flush_errors(new_messages: List[str], serious: bool) -> None:
+        if options.pretty:
+            new_messages = formatter.fit_in_terminal(new_messages)
         messages.extend(new_messages)
         f = stderr if serious else stdout
-        if options.pretty:
-            formatter.fit_in_terminal(messages)
         try:
             for msg in new_messages:
                 if options.color_output:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -63,7 +63,8 @@ def main(script_path: Optional[str],
                                        fscache=fscache)
 
     messages = []
-    formatter = util.FancyFormatter(stdout, stderr, options.show_error_codes)
+    formatter = util.FancyFormatter(stdout, stderr, options.show_error_codes,
+                                    options.show_source_code)
 
     def flush_errors(new_messages: List[str], serious: bool) -> None:
         messages.extend(new_messages)
@@ -578,6 +579,9 @@ def process_options(args: List[str],
                         group=error_group)
     add_invertible_flag('--show-error-codes', default=False,
                         help="Show error codes in error messages",
+                        group=error_group)
+    add_invertible_flag('--show-source-code', default=False,
+                        help="Show source code snippets in error messages",
                         group=error_group)
     add_invertible_flag('--no-color-output', dest='color_output', default=True,
                         help="Do not colorize error messages",

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -895,7 +895,7 @@ class ClassDef(Statement):
     defs = None  # type: Block
     type_vars = None  # type: List[mypy.types.TypeVarDef]
     # Base class expressions (not semantically analyzed -- can be arbitrary expressions)
-    base_type_exprs = None  # type: List[Expression]
+    base_type_exprs = None  # type: List[Node]
     # Special base classes like Generic[...] get moved here during semantic analysis
     removed_base_type_exprs = None  # type: List[Expression]
     info = None  # type: TypeInfo  # Related TypeInfo

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -895,7 +895,7 @@ class ClassDef(Statement):
     defs = None  # type: Block
     type_vars = None  # type: List[mypy.types.TypeVarDef]
     # Base class expressions (not semantically analyzed -- can be arbitrary expressions)
-    base_type_exprs = None  # type: List[Node]
+    base_type_exprs = None  # type: List[Expression]
     # Special base classes like Generic[...] get moved here during semantic analysis
     removed_base_type_exprs = None  # type: List[Expression]
     info = None  # type: TypeInfo  # Related TypeInfo

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -244,6 +244,7 @@ class Options:
         self.shadow_file = None  # type: Optional[List[List[str]]]
         self.show_column_numbers = False  # type: bool
         self.show_error_codes = False
+        self.show_source_code = False
         self.dump_graph = False
         self.dump_deps = False
         self.logical_deps = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -244,7 +244,8 @@ class Options:
         self.shadow_file = None  # type: Optional[List[List[str]]]
         self.show_column_numbers = False  # type: bool
         self.show_error_codes = False
-        self.show_source_code = False
+        # Use soft word wrap and show trimmed source snippets with error location markers.
+        self.pretty = False
         self.dump_graph = False
         self.dump_deps = False
         self.logical_deps = False

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -197,7 +197,7 @@ class FineGrainedSuite(DataSuite):
         return options
 
     def run_check(self, server: Server, sources: List[BuildSource]) -> List[str]:
-        response = server.check(sources, is_tty=False, terminal_width=9000)
+        response = server.check(sources, is_tty=False, terminal_width=-1)
         out = cast(str, response['out'] or response['err'])
         return out.splitlines()
 

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -197,7 +197,7 @@ class FineGrainedSuite(DataSuite):
         return options
 
     def run_check(self, server: Server, sources: List[BuildSource]) -> List[str]:
-        response = server.check(sources, is_tty=False)
+        response = server.check(sources, is_tty=False, terminal_width=9000)
         out = cast(str, response['out'] or response['err'])
         return out.splitlines()
 

--- a/mypy/test/testformatter.py
+++ b/mypy/test/testformatter.py
@@ -1,0 +1,51 @@
+from unittest import TestCase, main
+
+from mypy.util import trim_source_line, split_words
+
+
+class FancyErrorFormattingTestCases(TestCase):
+    def test_trim_source(self) -> None:
+        assert trim_source_line('0123456789abcdef',
+                                max_len=16, col=5, min_width=2) == ('0123456789abcdef', 0)
+
+        # Locations near start.
+        assert trim_source_line('0123456789abcdef',
+                                max_len=7, col=0, min_width=2) == ('0123456...', 0)
+        assert trim_source_line('0123456789abcdef',
+                                max_len=7, col=4, min_width=2) == ('0123456...', 0)
+
+        # Middle locations.
+        assert trim_source_line('0123456789abcdef',
+                                max_len=7, col=5, min_width=2) == ('...1234567...', -2)
+        assert trim_source_line('0123456789abcdef',
+                                max_len=7, col=6, min_width=2) == ('...2345678...', -1)
+        assert trim_source_line('0123456789abcdef',
+                                max_len=7, col=8, min_width=2) == ('...456789a...', 1)
+
+        # Locations near the end.
+        assert trim_source_line('0123456789abcdef',
+                                max_len=7, col=11, min_width=2) == ('...789abcd...', 4)
+        assert trim_source_line('0123456789abcdef',
+                                max_len=7, col=13, min_width=2) == ('...9abcdef', 6)
+        assert trim_source_line('0123456789abcdef',
+                                max_len=7, col=15, min_width=2) == ('...9abcdef', 6)
+
+    def test_split_words(self) -> None:
+        assert split_words('Simple message') == ['Simple', 'message']
+        assert split_words('Message with "Some[Long, Types]"'
+                           ' in it') == ['Message', 'with',
+                                         '"Some[Long, Types]"', 'in', 'it']
+        assert split_words('Message with "Some[Long, Types]"'
+                           ' and [error-code]') == ['Message', 'with', '"Some[Long, Types]"',
+                                                    'and', '[error-code]']
+        assert split_words('"Type[Stands, First]" then words') == ['"Type[Stands, First]"',
+                                                                   'then', 'words']
+        assert split_words('First words "Then[Stands, Type]"') == ['First', 'words',
+                                                                   '"Then[Stands, Type]"']
+        assert split_words('"Type[Only, Here]"') == ['"Type[Only, Here]"']
+        assert split_words('OneWord') == ['OneWord']
+        assert split_words(' ') == ['', '']
+
+
+if __name__ == '__main__':
+    main()

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -26,7 +26,7 @@ DEFAULT_SOURCE_OFFSET = 4  # type: Final
 WIGGLY_LINE = '^~~~~~~~'  # type: Final
 DEFAULT_COLUMNS = 80
 
-# At least these number of columns will be shown on each side of
+# At least this number of columns will be shown on each side of
 # error location when printing source code snippet.
 MINIMUM_WIDTH = 20
 
@@ -492,7 +492,7 @@ class FancyFormatter:
         elif ': note:' in error:
             loc, msg = error.split('note:', maxsplit=1)
             return loc + self.style('note:', 'blue') + self.underline_link(msg)
-        elif self.show_source_code and error.startswith(' ' * 4):
+        elif self.show_source_code and error.startswith(' ' * DEFAULT_SOURCE_OFFSET):
             if WIGGLY_LINE not in error:
                 return self.style(error, 'none', dim=True)
             return self.style(error, 'yellow')

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -455,7 +455,7 @@ class FancyFormatter:
                        'none': ''}
 
     def style(self, text: str, color: Literal['red', 'green', 'blue', 'yellow', 'none'],
-              bold: bool = False, underline: bool = False) -> str:
+              bold: bool = False, underline: bool = False, dim: bool = False) -> str:
         """Apply simple color and style (underlined or bold)."""
         if self.dummy_term:
             return text
@@ -465,6 +465,8 @@ class FancyFormatter:
             start = ''
         if underline:
             start += self.UNDER
+        if dim:
+            start += self.DIM
         return start + self.colors[color] + text + self.NORMAL
 
     def colorize(self, error: str) -> str:
@@ -489,7 +491,7 @@ class FancyFormatter:
             return loc + self.style('note:', 'blue') + self.underline_link(msg)
         elif self.show_source_code and error.startswith(' ' * 4):
             if WIGGLY_LINE not in error:
-                return self.style(self.DIM + error, 'none')
+                return self.style(error, 'none', dim=True)
             return self.style(error, 'yellow')
         else:
             return error

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -155,12 +155,26 @@ def trim_source_line(line: str, max_len: int, col: int, min_width: int) -> Tuple
 
     Return the trimmed string and the column offset to to adjust error location.
     """
-    if len(line) < max_len:
+    if max_len < 2 * min_width + 1:
+        # In case the window is too tiny it is better to still show something.
+        max_len = 2 * min_width + 1
+
+    # Trivial case: line already fits in.
+    if len(line) <= max_len:
         return line, 0
-    if col < max_len - min_width:
+
+    # If column is not too large so that there is still min_width after it,
+    # the line doesn't need to be trimmed at the start.
+    if col + min_width < max_len:
         return line[:max_len] + '...', 0
-    offset = col - max_len + min_width
-    return '...' + line[offset:col + min_width] + '...', offset - 3
+
+    # Otherwise, if the column is not too close to the end, trim both sides.
+    if col < len(line) - min_width - 1:
+        offset = col - max_len + min_width + 1
+        return '...' + line[offset:col + min_width + 1] + '...', offset - 3
+
+    # Finally, if the column is near the end, just trim the start.
+    return '...' + line[-max_len:], len(line) - max_len - 3
 
 
 def get_mypy_comments(source: str) -> List[Tuple[int, str]]:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -435,7 +435,7 @@ def soft_wrap(msg: str, max_len: int, first_offset: int,
         next_word = words.pop(0)
         max_line_len = max_len - num_indent if lines else max_len - first_offset
         # Add 1 to account for space between words.
-        if len(next_line) + len(next_word) + 1 < max_line_len:
+        if len(next_line) + len(next_word) + 1 <= max_line_len:
             next_line += ' ' + next_word
         else:
             lines.append(next_line)

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -440,16 +440,18 @@ class FancyFormatter:
         if self.dummy_term:
             return
 
+        self.NORMAL = curses.tigetstr('sgr0').decode()
         self.BOLD = bold.decode()
         self.UNDER = under.decode()
         dim = curses.tigetstr('dim')
         # TODO: more reliable way to get gray color good for both dark and light schemes.
         self.DIM = dim.decode() if dim else PLAIN_ANSI_DIM
+
         self.BLUE = curses.tparm(set_color, curses.COLOR_BLUE).decode()
         self.GREEN = curses.tparm(set_color, curses.COLOR_GREEN).decode()
         self.RED = curses.tparm(set_color, curses.COLOR_RED).decode()
         self.YELLOW = curses.tparm(set_color, curses.COLOR_YELLOW).decode()
-        self.NORMAL = curses.tigetstr('sgr0').decode()
+
         self.colors = {'red': self.RED, 'green': self.GREEN,
                        'blue': self.BLUE, 'yellow': self.YELLOW,
                        'none': ''}
@@ -473,11 +475,12 @@ class FancyFormatter:
         """Colorize an output line by highlighting the status and error code."""
         if ': error:' in error:
             loc, msg = error.split('error:', maxsplit=1)
-            pad = len(loc) + len('error: ')
-            max_len = get_term_columns() - pad - 1  # compensate for space after 'error:'
-            msg = soft_wrap(msg, max_len, pad)
-            # If show_source_code is true, the error code is shown on a separate line,
-            # see the last branch below.
+            if self.show_source_code:
+                # Improve readability by wrapping lines when showing source code.
+                pad = len(loc) + len('error: ')
+                max_len = get_term_columns() - pad - 1  # compensate for space after 'error:'
+                msg = soft_wrap(msg, max_len, pad)
+            # If show_source_code is true, the error code is shown on a separate line.
             if not self.show_error_codes or self.show_source_code:
                 return (loc + self.style('error:', 'red', bold=True) +
                         self.highlight_quote_groups(msg))

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -15,5 +15,6 @@ warn_unused_ignores = True
 warn_unused_configs = True
 show_traceback = True
 show_error_codes = True
+show_source_code = True
 always_false = MYPYC
 plugins = misc/proper_plugin.py

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -15,6 +15,6 @@ warn_unused_ignores = True
 warn_unused_configs = True
 show_traceback = True
 show_error_codes = True
-show_source_code = True
+pretty = True
 always_false = MYPYC
 plugins = misc/proper_plugin.py

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1413,8 +1413,8 @@ some_file.py:11: error: Incompatible types in assignment (expression has type
 some_file.py:11: error: Argument 1 to "some_interesting_method" of
 "OneCustomClassName" has incompatible type "Union[int, str, float]"; expected
 "AnotherCustomClassDefinedBelow"
-...ry_important_attribute_with_long_name: OneCustomClassName = OneCustomClassNa...
-                                                               ^
+...y_important_attribute_with_long_name: OneCustomClassName = OneCustomClassNam...
+                                                              ^
 
 [case testShowSourceCodeSnippetsBlockingError]
 # cmd: mypy --pretty --show-error-codes some_file.py

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1408,13 +1408,13 @@ some_file.py:3: error: Unsupported operand types for + ("int" and "str")
     ^
 some_file.py:11: error: Incompatible types in assignment (expression has type
 "AnotherCustomClassDefinedBelow", variable has type "OneCustomClassName")
-            self.very_important_attribute_with_long_name: OneCustomClassName...
+            self.very_important_attribute_with_long_name: OneCustomClassNa...
             ^
 some_file.py:11: error: Argument 1 to "some_interesting_method" of
 "OneCustomClassName" has incompatible type "Union[int, str, float]"; expected
 "AnotherCustomClassDefinedBelow"
-...y_important_attribute_with_long_name: OneCustomClassName = OneCustomClassNam...
-                                                              ^
+    ...t_attribute_with_long_name: OneCustomClassName = OneCustomClassName()....
+                                                        ^
 
 [case testShowSourceCodeSnippetsBlockingError]
 # cmd: mypy --pretty --show-error-codes some_file.py
@@ -1422,6 +1422,6 @@ some_file.py:11: error: Argument 1 to "some_interesting_method" of
 it_looks_like_we_started_typing_something_but_then. = did_not_notice(an_extra_dot)
 [out]
 some_file.py:1: error: invalid syntax  [syntax]
-    it_looks_like_we_started_typing_something_but_then. = did_not_notice(an_...
-                                                         ^
+    ...ooks_like_we_started_typing_something_but_then. = did_not_notice(an_ex...
+                                                        ^
 == Return code: 2

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1388,33 +1388,8 @@ Found 2 errors in 2 files (checked 2 source files)
 mypy: can't read file 'missing.py': No such file or directory
 == Return code: 2
 
-[case testShowSourceCodeSnippetsDefaultFormatting]
-# cmd: mypy --show-source-code --no-color-output --python-version=3.6 some_file.py
-[file some_file.py]
-from typing import Union
-
-42 + 'no way'
-
-class OneCustomClassName:
-    def some_interesting_method(self, arg: AnotherCustomClassDefinedBelow) -> AnotherCustomClassDefinedBelow:
-        ...
-
-class AnotherCustomClassDefinedBelow:
-    def another_even_more_interesting_method(self, arg: Union[int, str, float]) -> None:
-        self.very_important_attribute_with_long_name: OneCustomClassName = OneCustomClassName().some_interesting_method(arg)
-[out]
-some_file.py:3: error: Unsupported operand types for + ("int" and "str")
-    42 + 'no way'
-    ^~~~~~~~ [operator]
-some_file.py:11: error: Incompatible types in assignment (expression has type "AnotherCustomClassDefinedBelow", variable has type "OneCustomClassName")
-            self.very_important_attribute_with_long_name: OneCustomClassName = OneCu...
-            ^~~~~~~~ [assignment]
-some_file.py:11: error: Argument 1 to "some_interesting_method" of "OneCustomClassName" has incompatible type "Union[int, str, float]"; expected "AnotherCustomClassDefinedBelow"
-    ...ry_important_attribute_with_long_name: OneCustomClassName = OneCustomClassName()...
-                                                                   ^~~~~~~~ [arg-type]
-
 [case testShowSourceCodeSnippetsWrappedFormatting]
-# cmd: mypy --show-source-code --python-version=3.6 some_file.py
+# cmd: mypy --pretty --python-version=3.6 some_file.py
 [file some_file.py]
 from typing import Union
 
@@ -1430,25 +1405,23 @@ class AnotherCustomClassDefinedBelow:
 [out]
 some_file.py:3: error: Unsupported operand types for + ("int" and "str")
     42 + 'no way'
-    ^~~~~~~~ [operator]
+    ^
 some_file.py:11: error: Incompatible types in assignment (expression has type
-                        "AnotherCustomClassDefinedBelow", variable has type
-                        "OneCustomClassName")
-            self.very_important_attribute_with_long_name: OneCustomClassName = OneCu...
-            ^~~~~~~~ [assignment]
+"AnotherCustomClassDefinedBelow", variable has type "OneCustomClassName")
+            self.very_important_attribute_with_long_name: OneCustomClassName...
+            ^
 some_file.py:11: error: Argument 1 to "some_interesting_method" of
-                        "OneCustomClassName" has incompatible type
-                        "Union[int, str, float]"; expected
-                        "AnotherCustomClassDefinedBelow"
-    ...ry_important_attribute_with_long_name: OneCustomClassName = OneCustomClassName()...
-                                                                   ^~~~~~~~ [arg-type]
+"OneCustomClassName" has incompatible type "Union[int, str, float]"; expected
+"AnotherCustomClassDefinedBelow"
+...ry_important_attribute_with_long_name: OneCustomClassName = OneCustomClassNa...
+                                                               ^
 
 [case testShowSourceCodeSnippetsBlockingError]
-# cmd: mypy --show-source-code some_file.py
+# cmd: mypy --pretty --show-error-codes some_file.py
 [file some_file.py]
 it_looks_like_we_started_typing_something_but_then. = did_not_notice(an_extra_dot)
 [out]
-some_file.py:1: error: invalid syntax
-    it_looks_like_we_started_typing_something_but_then. = did_not_notice(an_extra_do...
-                                                         ^~~~~~~~ [syntax]
+some_file.py:1: error: invalid syntax  [syntax]
+    it_looks_like_we_started_typing_something_but_then. = did_not_notice(an_...
+                                                         ^
 == Return code: 2

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1389,7 +1389,7 @@ mypy: can't read file 'missing.py': No such file or directory
 == Return code: 2
 
 [case testShowSourceCodeSnippetsDefaultFormatting]
-# cmd: mypy --show-source-code --no-color-output some_file.py
+# cmd: mypy --show-source-code --no-color-output --python-version=3.6 some_file.py
 [file some_file.py]
 from typing import Union
 
@@ -1414,7 +1414,7 @@ some_file.py:11: error: Argument 1 to "some_interesting_method" of "OneCustomCla
                                                                    ^~~~~~~~ [arg-type]
 
 [case testShowSourceCodeSnippetsWrappedFormatting]
-# cmd: mypy --show-source-code some_file.py
+# cmd: mypy --show-source-code --python-version=3.6 some_file.py
 [file some_file.py]
 from typing import Union
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1442,3 +1442,13 @@ some_file.py:11: error: Argument 1 to "some_interesting_method" of
                         "AnotherCustomClassDefinedBelow"
     ...ry_important_attribute_with_long_name: OneCustomClassName = OneCustomClassName()...
                                                                    ^~~~~~~~ [arg-type]
+
+[case testShowSourceCodeSnippetsBlockingError]
+# cmd: mypy --show-source-code some_file.py
+[file some_file.py]
+it_looks_like_we_started_typing_something_but_then. = did_not_notice(an_extra_dot)
+[out]
+some_file.py:1: error: invalid syntax
+    it_looks_like_we_started_typing_something_but_then. = did_not_notice(an_extra_do...
+                                                         ^~~~~~~~ [syntax]
+== Return code: 2

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1387,3 +1387,58 @@ Found 2 errors in 2 files (checked 2 source files)
 [out]
 mypy: can't read file 'missing.py': No such file or directory
 == Return code: 2
+
+[case testShowSourceCodeSnippetsDefaultFormatting]
+# cmd: mypy --show-source-code --no-color-output some_file.py
+[file some_file.py]
+from typing import Union
+
+42 + 'no way'
+
+class OneCustomClassName:
+    def some_interesting_method(self, arg: AnotherCustomClassDefinedBelow) -> AnotherCustomClassDefinedBelow:
+        ...
+
+class AnotherCustomClassDefinedBelow:
+    def another_even_more_interesting_method(self, arg: Union[int, str, float]) -> None:
+        self.very_important_attribute_with_long_name: OneCustomClassName = OneCustomClassName().some_interesting_method(arg)
+[out]
+some_file.py:3: error: Unsupported operand types for + ("int" and "str")
+    42 + 'no way'
+    ^~~~~~~~ [operator]
+some_file.py:11: error: Incompatible types in assignment (expression has type "AnotherCustomClassDefinedBelow", variable has type "OneCustomClassName")
+            self.very_important_attribute_with_long_name: OneCustomClassName = OneCu...
+            ^~~~~~~~ [assignment]
+some_file.py:11: error: Argument 1 to "some_interesting_method" of "OneCustomClassName" has incompatible type "Union[int, str, float]"; expected "AnotherCustomClassDefinedBelow"
+    ...ry_important_attribute_with_long_name: OneCustomClassName = OneCustomClassName()...
+                                                                   ^~~~~~~~ [arg-type]
+
+[case testShowSourceCodeSnippetsWrappedFormatting]
+# cmd: mypy --show-source-code some_file.py
+[file some_file.py]
+from typing import Union
+
+42 + 'no way'
+
+class OneCustomClassName:
+    def some_interesting_method(self, arg: AnotherCustomClassDefinedBelow) -> AnotherCustomClassDefinedBelow:
+        ...
+
+class AnotherCustomClassDefinedBelow:
+    def another_even_more_interesting_method(self, arg: Union[int, str, float]) -> None:
+        self.very_important_attribute_with_long_name: OneCustomClassName = OneCustomClassName().some_interesting_method(arg)
+[out]
+some_file.py:3: error: Unsupported operand types for + ("int" and "str")
+    42 + 'no way'
+    ^~~~~~~~ [operator]
+some_file.py:11: error: Incompatible types in assignment (expression has type
+                        "AnotherCustomClassDefinedBelow", variable has type
+                        "OneCustomClassName")
+            self.very_important_attribute_with_long_name: OneCustomClassName = OneCu...
+            ^~~~~~~~ [assignment]
+some_file.py:11: error: Argument 1 to "some_interesting_method" of
+                        "OneCustomClassName" has incompatible type
+                        "Union[int, str, float]"; expected
+                        "AnotherCustomClassDefinedBelow"
+    ...ry_important_attribute_with_long_name: OneCustomClassName = OneCustomClassName()...
+                                                                   ^~~~~~~~ [arg-type]

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -52,6 +52,32 @@ Daemon stopped
 [file foo.py]
 def f(): pass
 
+[case testDaemonRunRestartPretty]
+$ dmypy run -- foo.py --follow-imports=error --pretty
+Daemon started
+Success: no issues found in 1 source file
+$ dmypy run -- foo.py --follow-imports=error --pretty
+Success: no issues found in 1 source file
+$ {python} -c "print('[mypy]')" >mypy.ini
+$ {python} -c "print('disallow_untyped_defs = True')" >>mypy.ini
+$ dmypy run -- foo.py --follow-imports=error --pretty
+Restarting: configuration changed
+Daemon stopped
+Daemon started
+foo.py:1: error: Function is missing a return type annotation
+    def f(): pass
+    ^
+foo.py:1: note: Use "-> None" if function does not return a value
+Found 1 error in 1 file (checked 1 source file)
+== Return code: 1
+$ {python} -c "print('def f() -> None: pass')" >foo.py
+$ dmypy run -- foo.py --follow-imports=error --pretty
+Success: no issues found in 1 source file
+$ dmypy stop
+Daemon stopped
+[file foo.py]
+def f(): pass
+
 [case testDaemonRunRestartPluginVersion]
 $ dmypy run -- foo.py --no-error-summary
 Daemon started

--- a/test-data/unit/fine-grained-blockers.test
+++ b/test-data/unit/fine-grained-blockers.test
@@ -25,7 +25,7 @@ main:2: error: Too few arguments for "f"
 ==
 
 [case testParseErrorShowSource]
-# flags: --show-source-code
+# flags: --pretty --show-error-codes
 import a
 a.f()
 [file a.py]
@@ -38,13 +38,13 @@ def f(x: int) -> None: pass
 def f() -> None: pass
 [out]
 ==
-a.py:1: error: invalid syntax
+a.py:1: error: invalid syntax  [syntax]
     def f(x: int) ->
-                     ^~~~~~~~ [syntax]
+                     ^
 ==
-main:3: error: Too few arguments for "f"
+main:3: error: Too few arguments for "f"  [call-arg]
     a.f()
-    ^~~~~~~~ [call-arg]
+    ^
 ==
 
 [case testParseErrorMultipleTimes]

--- a/test-data/unit/fine-grained-blockers.test
+++ b/test-data/unit/fine-grained-blockers.test
@@ -24,6 +24,29 @@ a.py:1: error: invalid syntax
 main:2: error: Too few arguments for "f"
 ==
 
+[case testParseErrorShowSource]
+# flags: --show-source-code
+import a
+a.f()
+[file a.py]
+def f() -> None: pass
+[file a.py.2]
+def f(x: int) ->
+[file a.py.3]
+def f(x: int) -> None: pass
+[file a.py.4]
+def f() -> None: pass
+[out]
+==
+a.py:1: error: invalid syntax
+    def f(x: int) ->
+                     ^~~~~~~~ [syntax]
+==
+main:3: error: Too few arguments for "f"
+    a.f()
+    ^~~~~~~~ [call-arg]
+==
+
 [case testParseErrorMultipleTimes]
 import a
 a.f()

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -82,7 +82,7 @@ class A:
 main:4: error: Too few arguments for "g" of "A"
 
 [case testReprocessMethodShowSource]
-# flags: --show-source-code
+# flags: --pretty --show-error-codes
 import m
 class B:
     def f(self, a: m.A) -> None:
@@ -95,9 +95,9 @@ class A:
     def g(self, a: A) -> None: pass
 [out]
 ==
-main:5: error: Too few arguments for "g" of "A"
+main:5: error: Too few arguments for "g" of "A"  [call-arg]
             a.g() # E
-            ^~~~~~~~ [call-arg]
+            ^
 
 [case testFunctionMissingModuleAttribute]
 import m

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -81,6 +81,24 @@ class A:
 ==
 main:4: error: Too few arguments for "g" of "A"
 
+[case testReprocessMethodShowSource]
+# flags: --show-source-code
+import m
+class B:
+    def f(self, a: m.A) -> None:
+        a.g() # E
+[file m.py]
+class A:
+    def g(self) -> None: pass
+[file m.py.2]
+class A:
+    def g(self, a: A) -> None: pass
+[out]
+==
+main:5: error: Too few arguments for "g" of "A"
+            a.g() # E
+            ^~~~~~~~ [call-arg]
+
 [case testFunctionMissingModuleAttribute]
 import m
 def h() -> None:


### PR DESCRIPTION
This essentially fixes https://github.com/python/mypy/issues/7411

Couple ideas I think may make the much larger amount of output more readable are:
* Use dim color for the source code snippet
* Wrap long error messages so that they are not messed up with file names etc.

An example output (dark terminal on Linux):

![Screenshot from 2019-08-31 18:26:49](https://user-images.githubusercontent.com/12005495/64067230-382b7200-cc1d-11e9-9db9-631054ef5442.png)