### PR TITLE
Colorize daemon output and add summary line

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -265,7 +265,8 @@ def do_run(args: argparse.Namespace) -> None:
         # Bad or missing status file or dead process; good to start.
         start_server(args, allow_sources=True)
     t0 = time.time()
-    response = request(args.status_file, 'run', version=__version__, args=args.flags)
+    response = request(args.status_file, 'run', version=__version__, args=args.flags,
+                       no_tty=not sys.stdout.isatty())
     # If the daemon signals that a restart is necessary, do it
     if 'restart' in response:
         print('Restarting: {}'.format(response['restart']))
@@ -327,7 +328,8 @@ def do_kill(args: argparse.Namespace) -> None:
 def do_check(args: argparse.Namespace) -> None:
     """Ask the daemon to check a list of files."""
     t0 = time.time()
-    response = request(args.status_file, 'check', files=args.files)
+    response = request(args.status_file, 'check', files=args.files,
+                       no_tty=not sys.stdout.isatty())
     t1 = time.time()
     response['roundtrip_time'] = t1 - t0
     check_output(response, args.verbose, args.junit_xml, args.perf_stats_file)
@@ -350,9 +352,10 @@ def do_recheck(args: argparse.Namespace) -> None:
     """
     t0 = time.time()
     if args.remove is not None or args.update is not None:
-        response = request(args.status_file, 'recheck', remove=args.remove, update=args.update)
+        response = request(args.status_file, 'recheck', remove=args.remove, update=args.update,
+                           no_tty=not sys.stdout.isatty())
     else:
-        response = request(args.status_file, 'recheck')
+        response = request(args.status_file, 'recheck', no_tty=not sys.stdout.isatty())
     t1 = time.time()
     response['roundtrip_time'] = t1 - t0
     check_output(response, args.verbose, args.junit_xml, args.perf_stats_file)

--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -271,7 +271,8 @@ def do_run(args: argparse.Namespace) -> None:
     if 'restart' in response:
         print('Restarting: {}'.format(response['restart']))
         restart_server(args, allow_sources=True)
-        response = request(args.status_file, 'run', version=__version__, args=args.flags)
+        response = request(args.status_file, 'run', version=__version__, args=args.flags,
+                           no_tty=not sys.stdout.isatty())
 
     t1 = time.time()
     response['roundtrip_time'] = t1 - t0

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -263,6 +263,8 @@ class Server:
             if command not in {'check', 'recheck', 'run'}:
                 # Only the above commands use some error formatting.
                 del data['is_tty']
+            elif int(os.getenv('MYPY_FORCE_COLOR', '0')):
+                data['is_tty'] = True
             return method(self, **data)
 
     # Command functions (run in the server via RPC).

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -16,7 +16,7 @@ import time
 import traceback
 from contextlib import redirect_stderr, redirect_stdout
 
-from typing import AbstractSet, Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import AbstractSet, Any, Callable, Dict, List, Optional, Sequence, Tuple
 from typing_extensions import Final
 
 import mypy.build
@@ -253,13 +253,16 @@ class Server:
             if exc_info[0] and exc_info[0] is not SystemExit:
                 traceback.print_exception(*exc_info)
 
-    def run_command(self, command: str, data: Mapping[str, object]) -> Dict[str, object]:
+    def run_command(self, command: str, data: Dict[str, object]) -> Dict[str, object]:
         """Run a specific command from the registry."""
         key = 'cmd_' + command
         method = getattr(self.__class__, key, None)
         if method is None:
             return {'error': "Unrecognized command '%s'" % command}
         else:
+            if command not in {'check', 'recheck', 'run'}:
+                # Only the above commands use some error formatting.
+                del data['is_tty']
             return method(self, **data)
 
     # Command functions (run in the server via RPC).

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -113,10 +113,10 @@ def main(script_path: Optional[str],
             n_errors, n_files = util.count_stats(messages)
             if n_errors:
                 stdout.write(formatter.format_error(n_errors, n_files, len(sources),
-                                                    not options.color_output) + '\n')
+                                                    options.color_output) + '\n')
         else:
             stdout.write(formatter.format_success(len(sources),
-                                                  not options.color_output) + '\n')
+                                                  options.color_output) + '\n')
         stdout.flush()
     if options.fast_exit:
         # Exit without freeing objects -- it's faster.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -112,9 +112,11 @@ def main(script_path: Optional[str],
         if messages:
             n_errors, n_files = util.count_stats(messages)
             if n_errors:
-                stdout.write(formatter.format_error(n_errors, n_files, len(sources)) + '\n')
+                stdout.write(formatter.format_error(n_errors, n_files, len(sources),
+                                                    not options.color_output) + '\n')
         else:
-            stdout.write(formatter.format_success(len(sources)) + '\n')
+            stdout.write(formatter.format_success(len(sources),
+                                                  not options.color_output) + '\n')
         stdout.flush()
     if options.fast_exit:
         # Exit without freeing objects -- it's faster.

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -197,7 +197,7 @@ class FineGrainedSuite(DataSuite):
         return options
 
     def run_check(self, server: Server, sources: List[BuildSource]) -> List[str]:
-        response = server.check(sources, no_tty=True)
+        response = server.check(sources, is_tty=False)
         out = cast(str, response['out'] or response['err'])
         return out.splitlines()
 

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -181,6 +181,7 @@ class FineGrainedSuite(DataSuite):
         options.incremental = True
         options.use_builtins_fixtures = True
         options.show_traceback = True
+        options.error_summary = False
         options.fine_grained_incremental = not build_cache
         options.use_fine_grained_cache = self.use_cache and not build_cache
         options.cache_fine_grained = self.use_cache

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -196,7 +196,7 @@ class FineGrainedSuite(DataSuite):
         return options
 
     def run_check(self, server: Server, sources: List[BuildSource]) -> List[str]:
-        response = server.check(sources)
+        response = server.check(sources, no_tty=True)
         out = cast(str, response['out'] or response['err'])
         return out.splitlines()
 

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -440,6 +440,6 @@ class FancyFormatter:
               ' (checked {} source file{})'.format(n_errors, 's' if n_errors != 1 else '',
                                                    n_files, 's' if n_files != 1 else '',
                                                    n_sources, 's' if n_sources != 1 else '')
-        if use_color:
+        if not use_color:
             return msg
         return self.style(msg, 'red', bold=True)

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -427,14 +427,19 @@ class FancyFormatter:
                 self.style(note[start:end], 'none', underline=True) +
                 note[end:])
 
-    def format_success(self, n_sources: int) -> str:
-        return self.style('Success: no issues found in {}'
-                          ' source file{}'.format(n_sources, 's' if n_sources != 1 else ''),
-                          'green', bold=True)
+    def format_success(self, n_sources: int, no_color: bool = False) -> str:
+        msg = 'Success: no issues found in {}' \
+              ' source file{}'.format(n_sources, 's' if n_sources != 1 else '')
+        if no_color:
+            return msg
+        return self.style(msg, 'green', bold=True)
 
-    def format_error(self, n_errors: int, n_files: int, n_sources: int) -> str:
+    def format_error(self, n_errors: int, n_files: int, n_sources: int,
+                     no_color: bool = False) -> str:
         msg = 'Found {} error{} in {} file{}' \
               ' (checked {} source file{})'.format(n_errors, 's' if n_errors != 1 else '',
                                                    n_files, 's' if n_files != 1 else '',
                                                    n_sources, 's' if n_sources != 1 else '')
+        if no_color:
+            return msg
         return self.style(msg, 'red', bold=True)

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -427,19 +427,19 @@ class FancyFormatter:
                 self.style(note[start:end], 'none', underline=True) +
                 note[end:])
 
-    def format_success(self, n_sources: int, no_color: bool = False) -> str:
+    def format_success(self, n_sources: int, use_color: bool = True) -> str:
         msg = 'Success: no issues found in {}' \
               ' source file{}'.format(n_sources, 's' if n_sources != 1 else '')
-        if no_color:
+        if not use_color:
             return msg
         return self.style(msg, 'green', bold=True)
 
     def format_error(self, n_errors: int, n_files: int, n_sources: int,
-                     no_color: bool = False) -> str:
+                     use_color: bool = True) -> str:
         msg = 'Found {} error{} in {} file{}' \
               ' (checked {} source file{})'.format(n_errors, 's' if n_errors != 1 else '',
                                                    n_files, 's' if n_files != 1 else '',
                                                    n_sources, 's' if n_sources != 1 else '')
-        if no_color:
+        if use_color:
             return msg
         return self.style(msg, 'red', bold=True)

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -11,7 +11,9 @@ Daemon stopped
 $ dmypy start -- --follow-imports=error
 Daemon started
 $ dmypy check -- foo.py
+Success: no issues found in 1 source file
 $ dmypy recheck
+Success: no issues found in 1 source file
 $ dmypy stop
 Daemon stopped
 [file foo.py]
@@ -20,6 +22,7 @@ def f(): pass
 [case testDaemonRun]
 $ dmypy run -- foo.py --follow-imports=error
 Daemon started
+Success: no issues found in 1 source file
 $ dmypy stop
 Daemon stopped
 [file foo.py]
@@ -28,7 +31,9 @@ def f(): pass
 [case testDaemonRunRestart]
 $ dmypy run -- foo.py --follow-imports=error
 Daemon started
+Success: no issues found in 1 source file
 $ dmypy run -- foo.py --follow-imports=error
+Success: no issues found in 1 source file
 $ {python} -c "print('[mypy]')" >mypy.ini
 $ {python} -c "print('disallow_untyped_defs = True')" >>mypy.ini
 $ dmypy run -- foo.py --follow-imports=error
@@ -37,19 +42,21 @@ Daemon stopped
 Daemon started
 foo.py:1: error: Function is missing a return type annotation
 foo.py:1: note: Use "-> None" if function does not return a value
+Found 1 error in 1 file (checked 1 source file)
 == Return code: 1
 $ {python} -c "print('def f() -> None: pass')" >foo.py
 $ dmypy run -- foo.py --follow-imports=error
+Success: no issues found in 1 source file
 $ dmypy stop
 Daemon stopped
 [file foo.py]
 def f(): pass
 
 [case testDaemonRunRestartPluginVersion]
-$ dmypy run -- foo.py
+$ dmypy run -- foo.py --no-error-summary
 Daemon started
 $ {python} -c "print(' ')" >> plug.py
-$ dmypy run -- foo.py
+$ dmypy run -- foo.py --no-error-summary
 Restarting: plugins changed
 Daemon stopped
 Daemon started
@@ -79,14 +86,14 @@ No status file found
 $ dmypy recheck
 No status file found
 == Return code: 2
-$ dmypy start --  --follow-imports=error
+$ dmypy start --  --follow-imports=error --no-error-summary
 Daemon started
 $ dmypy status
 Daemon is up and running
 $ dmypy start
 Daemon is still alive
 == Return code: 2
-$ dmypy restart --  --follow-imports=error
+$ dmypy restart --  --follow-imports=error --no-error-summary
 Daemon stopped
 Daemon started
 $ dmypy stop
@@ -94,7 +101,7 @@ Daemon stopped
 $ dmypy status
 No status file found
 == Return code: 2
-$ dmypy restart --  --follow-imports=error
+$ dmypy restart --  --follow-imports=error --no-error-summary
 Daemon started
 $ dmypy recheck
 Command 'recheck' is only valid after a 'check' command
@@ -106,7 +113,7 @@ Daemon has died
 == Return code: 2
 
 [case testDaemonRecheck]
-$ dmypy start -- --follow-imports=error
+$ dmypy start -- --follow-imports=error --no-error-summary
 Daemon started
 $ dmypy check foo.py bar.py
 $ dmypy recheck
@@ -153,6 +160,7 @@ $ {python} -c "import time;time.sleep(1)"
 $ {python} -c "print('x=1')" >bar.py
 $ dmypy run -- foo.py bar.py --follow-imports=error --use-fine-grained-cache --no-sqlite-cache --python-version=3.6
 Daemon started
+Success: no issues found in 2 source files
 $ dmypy status --fswatcher-dump-file test.json
 Daemon is up and running
 $ dmypy stop
@@ -165,6 +173,7 @@ $ {python} -c "print('lol')" >foo.py
 $ dmypy run --log-file=log -- foo.py bar.py --follow-imports=error --use-fine-grained-cache --no-sqlite-cache --python-version=3.6 --quickstart-file test.json
 Daemon started
 foo.py:1: error: Name 'lol' is not defined
+Found 1 error in 1 file (checked 2 source files)
 == Return code: 1
 -- make sure no errors made it to the log file
 $ {python} -c "import sys; sys.stdout.write(open('log').read())"
@@ -173,7 +182,7 @@ $ {python} -c "import sys; sys.stdout.write(open('log').read())"
 $ {python} -c "x = open('.mypy_cache/3.6/bar.meta.json').read(); y = open('asdf.json').read(); assert x == y"
 
 [case testDaemonSuggest]
-$ dmypy start --log-file log.txt -- --follow-imports=error
+$ dmypy start --log-file log.txt -- --follow-imports=error --no-error-summary
 Daemon started
 $ dmypy suggest foo:foo
 Command 'suggest' is only valid after a 'check' command


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7438

This PR makes the daemon behave the same way as the normal run (i.e. use colorized output and write a summary line). I also fix a minor bug that the summary line was colorized even if `--no-color-output` was passed.

The idea is quite simple, client passes to the server info about whether we are in tty and if yes server returns nicely formatted output. I tried running various commands on Linux and piping it through `grep`.