### PR TITLE
Cache directory may be set via environment (#7016)

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -533,6 +533,9 @@ beyond what incremental mode can offer, try running mypy in
     change this folder. This flag can also be useful for controlling
     cache use when using :ref:`remote caching <remote-cache>`.
 
+    This setting will override the ``MYPY_CACHE_DIR`` environment
+    variable if it is set.
+
     Mypy will also always write to the cache even when incremental
     mode is disabled so it can "warm up" the cache. To disable
     writing to the cache, use ``--cache-dir=/dev/null`` (UNIX)

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -416,6 +416,8 @@ section of the command line docs.
 ``cache_dir`` (string, default ``.mypy_cache``)
     Specifies the location where mypy stores incremental cache info.
     User home directory and environment variables will be expanded.
+    This setting will be overridden by the ``MYPY_CACHE_DIR`` environment
+    variable.
 
     Note that the cache is only read when incremental mode is enabled
     but is always written to, unless the value is set to ``/dev/nul``

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -244,7 +244,8 @@ command line flags. For more details, see:
 """  # type: Final
 
 FOOTER = """Environment variables:
-  Define MYPYPATH for additional module search path entries."""  # type: Final
+  Define MYPYPATH for additional module search path entries.
+  Define MYPY_CACHE_DIR to override configuration cache_dir path."""  # type: Final
 
 
 def process_options(args: List[str],
@@ -703,6 +704,11 @@ def process_options(args: List[str],
     if getattr(dummy, 'special-opts:strict'):  # noqa
         for dest, value in strict_flag_assignments:
             setattr(options, dest, value)
+
+    # Override cache_dir if provided in the environment
+    environ_cache_dir = os.getenv('MYPY_CACHE_DIR', '')
+    if environ_cache_dir.strip():
+        options.cache_dir = environ_cache_dir
 
     # Parse command line for real, using a split namespace.
     special_opts = argparse.Namespace()


### PR DESCRIPTION
This adds an environment variable MYPY_CACHE_DIR which can set the
current cache directory. This variable will override the cache_dir
setting in the configuration but can be overridden via the command line.
Fixes #7016.