### PR TITLE
Handle class with tuple base as TypeVar bound

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -261,6 +261,8 @@ def analyze_type_type_member_access(name: str,
         upper_bound = get_proper_type(typ.item.upper_bound)
         if isinstance(upper_bound, Instance):
             item = upper_bound
+        elif isinstance(upper_bound, TupleType):
+            item = upper_bound.partial_fallback
     elif isinstance(typ.item, TupleType):
         item = tuple_fallback(typ.item)
     elif isinstance(typ.item, FunctionLike) and typ.item.is_type_obj():

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -262,7 +262,7 @@ def analyze_type_type_member_access(name: str,
         if isinstance(upper_bound, Instance):
             item = upper_bound
         elif isinstance(upper_bound, TupleType):
-            item = upper_bound.partial_fallback
+            item = tuple_fallback(upper_bound)
     elif isinstance(typ.item, TupleType):
         item = tuple_fallback(typ.item)
     elif isinstance(typ.item, FunctionLike) and typ.item.is_type_obj():

--- a/test-data/unit/check-bound.test
+++ b/test-data/unit/check-bound.test
@@ -169,6 +169,18 @@ def f(x: T) -> int:
 [builtins fixtures/classmethod.pyi]
 
 
+[case testBoundClassMethodWithNamedTupleBase]
+from typing import NamedTuple, Type, TypeVar
+class A(NamedTuple):
+    @classmethod
+    def foo(cls) -> None: ...
+
+T = TypeVar('T', bound=A)
+def f(x: Type[T]) -> None:
+    x.foo()
+[builtins fixtures/classmethod.pyi]
+
+
 [case testBoundStaticMethod]
 from typing import TypeVar
 class A0:

--- a/test-data/unit/check-bound.test
+++ b/test-data/unit/check-bound.test
@@ -177,6 +177,7 @@ class A(NamedTuple):
 
 T = TypeVar('T', bound=A)
 def f(x: Type[T]) -> None:
+    reveal_type(x.foo)  # N: Revealed type is 'def ()'
     x.foo()
 [builtins fixtures/classmethod.pyi]
 


### PR DESCRIPTION
Fixes #7427 
PR fixes using classes with tuple base as bound of `TypeVar`