### PR TITLE
Enable output color and effects on Windows

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -338,38 +338,61 @@ class FancyFormatter:
                  show_error_codes: bool) -> None:
         self.show_error_codes = show_error_codes
         # Check if we are in a human-facing terminal on a supported platform.
-        if sys.platform not in ('linux', 'darwin'):
+        if sys.platform not in ('linux', 'darwin', 'win32'):
             self.dummy_term = True
             return
         force_color = int(os.getenv('MYPY_FORCE_COLOR', '0'))
         if not force_color and (not f_out.isatty() or not f_err.isatty()):
             self.dummy_term = True
             return
+        if sys.platform == 'win32':
+            # Windows ANSI escape sequences are only supported on Threshold 2 and above.
+            if sys.getwindowsversion().build < 10586:
+                self.dummy_term = True
+                return
+            self.dummy_term = False
+            import ctypes
+            kernel32 = ctypes.windll.kernel32
+            ENABLE_PROCESSED_OUTPUT = 0x1
+            ENABLE_WRAP_AT_EOL_OUTPUT = 0x2
+            ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4
+            STD_OUTPUT_HANDLE = -11
+            kernel32.SetConsoleMode(kernel32.GetStdHandle(STD_OUTPUT_HANDLE),
+                                                                ENABLE_PROCESSED_OUTPUT
+                                                                | ENABLE_WRAP_AT_EOL_OUTPUT
+                                                                | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+            self.BOLD = '\033[1m'
+            self.UNDER = '\033[4m'
+            self.BLUE = '\033[94m'
+            self.GREEN = '\033[92m'
+            self.RED = '\033[91m'
+            self.YELLOW = '\033[93m'
+            self.NORMAL = '\033[0m'
+        else:
+            # We in a human-facing terminal, check if it supports enough styling.
+            if not CURSES_ENABLED:
+                self.dummy_term = True
+                return
+            try:
+                curses.setupterm()
+            except curses.error:
+                # Most likely terminfo not found.
+                self.dummy_term = True
+                return
+            bold = curses.tigetstr('bold')
+            under = curses.tigetstr('smul')
+            set_color = curses.tigetstr('setaf')
+            self.dummy_term = not (bold and under and set_color)
+            if self.dummy_term:
+                return
 
-        # We in a human-facing terminal, check if it supports enough styling.
-        if not CURSES_ENABLED:
-            self.dummy_term = True
-            return
-        try:
-            curses.setupterm()
-        except curses.error:
-            # Most likely terminfo not found.
-            self.dummy_term = True
-            return
-        bold = curses.tigetstr('bold')
-        under = curses.tigetstr('smul')
-        set_color = curses.tigetstr('setaf')
-        self.dummy_term = not (bold and under and set_color)
-        if self.dummy_term:
-            return
-
-        self.BOLD = bold.decode()
-        self.UNDER = under.decode()
-        self.BLUE = curses.tparm(set_color, curses.COLOR_BLUE).decode()
-        self.GREEN = curses.tparm(set_color, curses.COLOR_GREEN).decode()
-        self.RED = curses.tparm(set_color, curses.COLOR_RED).decode()
-        self.YELLOW = curses.tparm(set_color, curses.COLOR_YELLOW).decode()
-        self.NORMAL = curses.tigetstr('sgr0').decode()
+            self.BOLD = bold.decode()
+            self.UNDER = under.decode()
+            self.BLUE = curses.tparm(set_color, curses.COLOR_BLUE).decode()
+            self.GREEN = curses.tparm(set_color, curses.COLOR_GREEN).decode()
+            self.RED = curses.tparm(set_color, curses.COLOR_RED).decode()
+            self.YELLOW = curses.tparm(set_color, curses.COLOR_YELLOW).decode()
+            self.NORMAL = curses.tigetstr('sgr0').decode()
         self.colors = {'red': self.RED, 'green': self.GREEN,
                        'blue': self.BLUE, 'yellow': self.YELLOW,
                        'none': ''}

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -491,6 +491,7 @@ class FancyFormatter:
 
     def initialize_win_colors(self) -> None:
         # Windows ANSI escape sequences are only supported on Threshold 2 and above.
+        assert sys.platform == 'win32'
         winver = sys.getwindowsversion()
         if (winver.major < MINIMUM_WINDOWS_MAJOR_VT100
            or winver.build < MINIMUM_WINDOWS_BUILD_VT100):

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -487,9 +487,9 @@ class FancyFormatter:
             ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4
             STD_OUTPUT_HANDLE = -11
             kernel32.SetConsoleMode(kernel32.GetStdHandle(STD_OUTPUT_HANDLE),
-                                                                ENABLE_PROCESSED_OUTPUT
-                                                                | ENABLE_WRAP_AT_EOL_OUTPUT
-                                                                | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+                                    ENABLE_PROCESSED_OUTPUT
+                                    | ENABLE_WRAP_AT_EOL_OUTPUT
+                                    | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
             self.BOLD = '\033[1m'
             self.UNDER = '\033[4m'
             self.BLUE = '\033[94m'

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -492,30 +492,30 @@ class FancyFormatter:
 
     def initialize_win_colors(self) -> bool:
         # Windows ANSI escape sequences are only supported on Threshold 2 and above.
-        assert sys.platform == 'win32'
-        winver = sys.getwindowsversion()
-        if (winver.major < MINIMUM_WINDOWS_MAJOR_VT100
-           or winver.build < MINIMUM_WINDOWS_BUILD_VT100):
-            return True
-        import ctypes
-        kernel32 = ctypes.windll.kernel32
-        ENABLE_PROCESSED_OUTPUT = 0x1
-        ENABLE_WRAP_AT_EOL_OUTPUT = 0x2
-        ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4
-        STD_OUTPUT_HANDLE = -11
-        kernel32.SetConsoleMode(kernel32.GetStdHandle(STD_OUTPUT_HANDLE),
-                                ENABLE_PROCESSED_OUTPUT
-                                | ENABLE_WRAP_AT_EOL_OUTPUT
-                                | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
-        self.BOLD = '\033[1m'
-        self.UNDER = '\033[4m'
-        self.BLUE = '\033[94m'
-        self.GREEN = '\033[92m'
-        self.RED = '\033[91m'
-        self.YELLOW = '\033[93m'
-        self.NORMAL = '\033[0m'
-        self.DIM = '\033[2m'
-        return False
+        if sys.platform == 'win32':
+            winver = sys.getwindowsversion()
+            if (winver.major < MINIMUM_WINDOWS_MAJOR_VT100
+            or winver.build < MINIMUM_WINDOWS_BUILD_VT100):
+                return True
+            import ctypes
+            kernel32 = ctypes.windll.kernel32
+            ENABLE_PROCESSED_OUTPUT = 0x1
+            ENABLE_WRAP_AT_EOL_OUTPUT = 0x2
+            ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4
+            STD_OUTPUT_HANDLE = -11
+            kernel32.SetConsoleMode(kernel32.GetStdHandle(STD_OUTPUT_HANDLE),
+                                    ENABLE_PROCESSED_OUTPUT
+                                    | ENABLE_WRAP_AT_EOL_OUTPUT
+                                    | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+            self.BOLD = '\033[1m'
+            self.UNDER = '\033[4m'
+            self.BLUE = '\033[94m'
+            self.GREEN = '\033[92m'
+            self.RED = '\033[91m'
+            self.YELLOW = '\033[93m'
+            self.NORMAL = '\033[0m'
+            self.DIM = '\033[2m'
+            return False
 
     def initialize_unix_colors(self) -> bool:
         # We in a human-facing terminal, check if it supports enough styling.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9504279/64279788-a796af80-cf04-11e9-9b0a-b321983138a6.png)


It turns out it is relatively simple to do this on Windows 10 without dependencies. Note that we can get color output on Windows 7/8 but not really underlining or other VT100 features. This should be supported on all versions of Windows 10 people are running. I'm not sure Windows 7/8 support is worth it here. Windows 7 is EOL at the end of the year, and Windows 8.1 has only 5% market share.

Fixes #7437 