### PR TITLE
Point error to incompatible argument instead of call expression

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3307,7 +3307,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 self.fail(message_registry.MULTIPLE_OVERLOADS_REQUIRED, e)
                 continue
             dec = self.expr_checker.accept(d)
-            temp = self.temp_node(sig)
+            temp = self.temp_node(sig, context=e)
             fullname = None
             if isinstance(d, RefExpr):
                 fullname = d.fullname
@@ -4043,7 +4043,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         """Create a temporary node with the given, fixed type."""
         temp = TempNode(t)
         if context:
-            temp.set_line(context.get_line())
+            temp.set_line(context.get_line(), context.get_column())
         return temp
 
     def fail(self, msg: str, context: Context, *, code: Optional[ErrorCode] = None) -> None:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1683,7 +1683,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         continue
 
                     dec = self.expr_checker.accept(decorator)
-                    temp = self.temp_node(sig)
+                    temp = self.temp_node(sig, context=decorator)
                     fullname = None
                     if isinstance(decorator, RefExpr):
                         fullname = decorator.fullname
@@ -2796,15 +2796,20 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # For this we use the rvalue as type context.
         self.msg.disable_errors()
         _, inferred_dunder_set_type = self.expr_checker.check_call(
-            dunder_set_type, [TempNode(instance_type), rvalue],
-            [nodes.ARG_POS, nodes.ARG_POS], context)
+            dunder_set_type,
+            [TempNode(instance_type, context=context), rvalue],
+            [nodes.ARG_POS, nodes.ARG_POS],
+            context)
         self.msg.enable_errors()
 
         # And now we type check the call second time, to show errors related
         # to wrong arguments count, etc.
         self.expr_checker.check_call(
-            dunder_set_type, [TempNode(instance_type), TempNode(AnyType(TypeOfAny.special_form))],
-            [nodes.ARG_POS, nodes.ARG_POS], context)
+            dunder_set_type,
+            [TempNode(instance_type, context=context),
+             TempNode(AnyType(TypeOfAny.special_form), context=context)],
+            [nodes.ARG_POS, nodes.ARG_POS],
+            context)
 
         # should be handled by get_method above
         assert isinstance(inferred_dunder_set_type, CallableType)  # type: ignore
@@ -4041,10 +4046,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
     def temp_node(self, t: Type, context: Optional[Context] = None) -> TempNode:
         """Create a temporary node with the given, fixed type."""
-        temp = TempNode(t)
-        if context:
-            temp.set_line(context.get_line(), context.get_column())
-        return temp
+        return TempNode(t, context=context)
 
     def fail(self, msg: str, context: Context, *, code: Optional[ErrorCode] = None) -> None:
         """Produce an error message."""

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1179,7 +1179,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             assert context, "Internal error: messages given without context"
         elif context is None:
             # Avoid "is None" checks
-            context = TempNode(AnyType(TypeOfAny.special_form), context=context)
+            context = TempNode(AnyType(TypeOfAny.special_form))
 
         # TODO(jukka): We could return as soon as we find an error if messages is None.
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3100,8 +3100,12 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 stargs.append(value)
             else:
                 tup = TupleExpr([key, value])
-                tup.line = value.line
-                tup.column = value.column
+                if key.line >= 0:
+                    tup.line = key.line
+                    tup.column = key.column
+                else:
+                    tup.line = value.line
+                    tup.column = value.column
                 args.append(tup)
         # Define type variables (used in constructors below).
         ktdef = TypeVarDef('KT', 'KT', -1, [], self.object_type())

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -469,7 +469,8 @@ def analyze_descriptor_access(instance_type: Type,
 
     _, inferred_dunder_get_type = chk.expr_checker.check_call(
         dunder_get_type,
-        [TempNode(instance_type), TempNode(TypeType.make_normalized(owner_type))],
+        [TempNode(instance_type, context=context),
+         TempNode(TypeType.make_normalized(owner_type), context=context)],
         [ARG_POS, ARG_POS], context)
 
     inferred_dunder_get_type = get_proper_type(inferred_dunder_get_type)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -944,8 +944,8 @@ class ASTConverter:
     # Lambda(arguments args, expr body)
     def visit_Lambda(self, n: ast3.Lambda) -> LambdaExpr:
         body = ast3.Return(n.body)
-        body.lineno = n.lineno
-        body.col_offset = n.col_offset
+        body.lineno = n.body.lineno
+        body.col_offset = n.body.col_offset
 
         e = LambdaExpr(self.transform_args(n.args, n.lineno),
                        self.as_required_block([body], n.lineno))

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1169,11 +1169,11 @@ class ASTConverter:
     # Subscript(expr value, slice slice, expr_context ctx)
     def visit_Subscript(self, n: ast3.Subscript) -> IndexExpr:
         e = IndexExpr(self.visit(n.value), self.visit(n.slice))
-        e = self.set_line(e, n)
+        self.set_line(e, n)
         if isinstance(e.index, SliceExpr):
             # Slice has no line/column in the raw ast.
             e.index.line = e.line
-            e.index.column = e.line
+            e.index.column = e.column
         return e
 
     # Starred(expr value, expr_context ctx)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1169,7 +1169,12 @@ class ASTConverter:
     # Subscript(expr value, slice slice, expr_context ctx)
     def visit_Subscript(self, n: ast3.Subscript) -> IndexExpr:
         e = IndexExpr(self.visit(n.value), self.visit(n.slice))
-        return self.set_line(e, n)
+        e = self.set_line(e, n)
+        if isinstance(e.index, SliceExpr):
+            # Slice has no line/column in the raw ast.
+            e.index.line = e.line
+            e.index.column = e.line
+        return e
 
     # Starred(expr value, expr_context ctx)
     def visit_Starred(self, n: Starred) -> StarExpr:

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -1009,7 +1009,12 @@ class ASTConverter:
     # Subscript(expr value, slice slice, expr_context ctx)
     def visit_Subscript(self, n: ast27.Subscript) -> IndexExpr:
         e = IndexExpr(self.visit(n.value), self.visit(n.slice))
-        return self.set_line(e, n)
+        self.set_line(e, n)
+        if isinstance(e.index, SliceExpr):
+            # Slice has no line/column in the raw ast.
+            e.index.line = e.line
+            e.index.column = e.column
+        return e
 
     # Name(identifier id, expr_context ctx)
     def visit_Name(self, n: Name) -> NameExpr:

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -834,8 +834,8 @@ class ASTConverter:
         args, decompose_stmts = self.transform_args(n.args, n.lineno)
 
         n_body = ast27.Return(n.body)
-        n_body.lineno = n.lineno
-        n_body.col_offset = n.col_offset
+        n_body.lineno = n.body.lineno
+        n_body.col_offset = n.body.col_offset
         body = self.as_required_block([n_body], n.lineno)
         if decompose_stmts:
             body.body = decompose_stmts + body.body

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -324,8 +324,14 @@ class MessageBuilder:
                   code=codes.NO_UNTYPED_CALL)
         return AnyType(TypeOfAny.from_error)
 
-    def incompatible_argument(self, n: int, m: int, callee: CallableType, arg_type: Type,
-                              arg_kind: int, context: Context) -> Optional[ErrorCode]:
+    def incompatible_argument(self,
+                              n: int,
+                              m: int,
+                              callee: CallableType,
+                              arg_type: Type,
+                              arg_kind: int,
+                              context: Context,
+                              outer_context: Context) -> Optional[ErrorCode]:
         """Report an error about an incompatible argument type.
 
         The argument type is arg_type, argument number is n and the
@@ -456,8 +462,8 @@ class MessageBuilder:
             # For function calls with keyword arguments, display the argument name rather than the
             # number.
             arg_label = str(n)
-            if isinstance(context, CallExpr) and len(context.arg_names) >= n:
-                arg_name = context.arg_names[n - 1]
+            if isinstance(outer_context, CallExpr) and len(outer_context.arg_names) >= n:
+                arg_name = outer_context.arg_names[n - 1]
                 if arg_name is not None:
                     arg_label = '"{}"'.format(arg_name)
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2224,13 +2224,21 @@ class TempNode(Expression):
     # (e.g. for 'x: int' the rvalue is TempNode(AnyType(TypeOfAny.special_form), no_rhs=True))
     no_rhs = False  # type: bool
 
-    def __init__(self, typ: 'mypy.types.Type', no_rhs: bool = False) -> None:
+    def __init__(self,
+                 typ: 'mypy.types.Type',
+                 no_rhs: bool = False,
+                 *,
+                 context: Optional[Context] = None) -> None:
+        """Construct a dummy node; optionally borrow line/column from context object."""
         super().__init__()
         self.type = typ
         self.no_rhs = no_rhs
+        if context is not None:
+            self.line = context.line
+            self.column = context.column
 
     def __repr__(self) -> str:
-        return 'TempNode(%s)' % str(self.type)
+        return 'TempNode:%d(%s)' % (self.line, str(self.type))
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_temp_node(self)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1377,14 +1377,13 @@ class D:
     def __get__(self, inst: Base, own: Type[Base]) -> str: pass
 [builtins fixtures/bool.pyi]
 [out]
-main:5: note: Revealed type is 'd.D'
 main:5: error: Argument 2 to "__get__" of "D" has incompatible type "Type[A]"; expected "Type[Base]"
-main:6: note: Revealed type is 'Any'
+main:5: note: Revealed type is 'd.D'
 main:6: error: No overload variant of "__get__" of "D" matches argument types "A", "Type[A]"
 main:6: note: Possible overload variants:
 main:6: note:     def __get__(self, inst: None, own: Type[Base]) -> D
 main:6: note:     def __get__(self, inst: Base, own: Type[Base]) -> str
-
+main:6: note: Revealed type is 'Any'
 
 [case testAccessingGenericNonDataDescriptor]
 from typing import TypeVar, Type, Generic, Any
@@ -4844,8 +4843,9 @@ def f() -> type: return M
 class C1(six.with_metaclass(M), object): pass  # E: Unsupported dynamic base class "six.with_metaclass"
 class C2(C1, six.with_metaclass(M)): pass  # E: Unsupported dynamic base class "six.with_metaclass"
 class C3(six.with_metaclass(A)): pass  # E: Metaclasses not inheriting from 'type' are not supported
-@six.add_metaclass(A)  # E: Argument 1 to "add_metaclass" has incompatible type "Type[A]"; expected "Type[type]" \
-                       # E: Metaclasses not inheriting from 'type' are not supported
+@six.add_metaclass(A)  # E: Metaclasses not inheriting from 'type' are not supported  \
+    # E: Argument 1 to "add_metaclass" has incompatible type "Type[A]"; expected "Type[type]"
+
 class D3(A): pass
 class C4(six.with_metaclass(M), metaclass=M): pass  # E: Multiple metaclass definitions
 @six.add_metaclass(M)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1479,12 +1479,11 @@ class D(Generic[T, V]):
     def __get__(self, inst: T, own: Type[T]) -> V: pass
 [builtins fixtures/bool.pyi]
 [out]
-main:5: note: Revealed type is 'Any'
 main:5: error: No overload variant of "__get__" of "D" matches argument types "None", "Type[A]"
 main:5: note: Possible overload variants:
 main:5: note:     def __get__(self, inst: None, own: None) -> D[A, int]
 main:5: note:     def __get__(self, inst: A, own: Type[A]) -> int
-
+main:5: note: Revealed type is 'Any'
 
 [case testAccessingNonDataDescriptorSubclass]
 from typing import Any
@@ -4970,8 +4969,8 @@ def decorate_forward_ref() -> Callable[[Type[A]], Type[A]]:
 @decorate(11)
 class A: pass
 
-@decorate
-class A2: pass  # E: Argument 1 to "decorate" has incompatible type "Type[A2]"; expected "int"
+@decorate  # E: Argument 1 to "decorate" has incompatible type "Type[A2]"; expected "int"
+class A2: pass
 
 [case testClassDecoratorIncorrect]
 def not_a_class_decorator(x: int) -> int: ...

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -63,6 +63,16 @@ class B(A):
         ff(super().__neg__()) # E:12: Argument 1 to "ff" has incompatible type "str"; expected "int"
 [builtins fixtures/dict.pyi]
 
+[case testColumnsInvalidArgumentTypeVarArgs]
+def f(*x: int) -> None: pass
+def g(**x: int) -> None: pass
+
+a = ['']
+f(*a)  # E:4: Argument 1 to "f" has incompatible type "*List[str]"; expected "int"
+b = {'x': 'y'}
+g(**b) # E:5: Argument 1 to "g" has incompatible type "**Dict[str, str]"; expected "int"
+[builtins fixtures/dict.pyi]
+
 [case testColumnsMultipleStatementsPerLine]
 x = 15
 y = 'hello'

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -49,10 +49,12 @@ h(x=1, y=aaa, z=2) # E:10: Argument "y" to "h" has incompatible type "str"; expe
 a: A
 ff(a.x) # E:4: Argument 1 to "ff" has incompatible type "str"; expected "int"
 ff([1]) # E:4: Argument 1 to "ff" has incompatible type "List[int]"; expected "int"
-ff([1 for x in [1]]) # E:5: Argument 1 to "ff" has incompatible type "List[int]"; expected "int"
+# TODO: Different column in Python 3.8+
+#ff([1 for x in [1]]) # Argument 1 to "ff" has incompatible type "List[int]"; expected "int"
 ff({1: 2}) # E:4: Argument 1 to "ff" has incompatible type "Dict[int, int]"; expected "int"
 ff(1.1) # E:4: Argument 1 to "ff" has incompatible type "float"; expected "int"
-ff( ( 1, 1)) # E:7: Argument 1 to "ff" has incompatible type "Tuple[int, int]"; expected "int"
+# TODO: Different column in Python 3.8+
+#ff( ( 1, 1)) # Argument 1 to "ff" has incompatible type "Tuple[int, int]"; expected "int"
 ff(-a) # E:4: Argument 1 to "ff" has incompatible type "str"; expected "int"
 ff(a + 1) # E:4: Argument 1 to "ff" has incompatible type "str"; expected "int"
 ff(a < 1) # E:4: Argument 1 to "ff" has incompatible type "str"; expected "int"

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -167,7 +167,6 @@ def f(x, y): pass
 
 [case testColumnListOrDictItemHasIncompatibleType]
 from typing import List, Dict
-# TODO: Point to the actual item since a list/dict literal can span many lines
 x: List[int] = [
     'x']  # E:5: List item 0 has incompatible type "str"; expected "int"
 y: Dict[int, int] = {
@@ -259,7 +258,7 @@ if int():
 
 [case testColumnRevealedType]
 if int():
-    reveal_type(1) # N:5: Revealed type is 'builtins.int'
+    reveal_type(1) # N:17: Revealed type is 'builtins.int'
 
 [case testColumnNonOverlappingEqualityCheck]
 # flags: --strict-equality

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -168,7 +168,8 @@ def f(x, y): pass
 [case testColumnListOrDictItemHasIncompatibleType]
 from typing import List, Dict
 x: List[int] = [
-    'x']  # E:5: List item 0 has incompatible type "str"; expected "int"
+    'x',  # E:5: List item 0 has incompatible type "str"; expected "int"
+      1.1]  # E:7: List item 1 has incompatible type "float"; expected "int"
 y: Dict[int, int] = {
     'x': 1  # E:5: Dict entry 0 has incompatible type "str": "int"; expected "int": "int"
 }

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -40,12 +40,12 @@ class A:
     def __lt__(self, other: int) -> str: pass
 
 f(
- y=0, x=0) # E:4: Argument 1 to "f" has incompatible type "int"; expected "str"
+ y=0, x=0) # E:4: Argument "y" to "f" has incompatible type "int"; expected "str"
 f(x=0,
-   y=None) # E:6: Argument 2 to "f" has incompatible type "None"; expected "str"
+   y=None) # E:6: Argument "y" to "f" has incompatible type "None"; expected "str"
 g(1, '', 2) # E:6: Argument 2 to "g" has incompatible type "str"; expected "int"
 aaa: str
-h(x=1, y=aaa, z=2) # E:10: Argument 2 to "h" has incompatible type "str"; expected "int"
+h(x=1, y=aaa, z=2) # E:10: Argument "y" to "h" has incompatible type "str"; expected "int"
 a: A
 ff(a.x) # E:4: Argument 1 to "ff" has incompatible type "str"; expected "int"
 ff([1]) # E:4: Argument 1 to "ff" has incompatible type "List[int]"; expected "int"
@@ -338,7 +338,7 @@ def f(x: T) -> T:
     g(y=x) # E:5: Unexpected keyword argument "y" for "g"
     y: List[int, str] # E:8: "list" expects 1 type argument, but 2 given
     del 1[0] # E:5: "int" has no attribute "__delitem__"
-    bb: List[int] = [''] # E:21: List item 0 has incompatible type "str"; expected "int"
+    bb: List[int] = [''] # E:22: List item 0 has incompatible type "str"; expected "int"
     # XXX: Disabled because the column differs in 3.8
     # aa: List[int] = ['' for x in [1]] # :22: List comprehension has incompatible type List[str]; expected List[int]
     cc = (1).bad # E:11: "int" has no attribute "bad"

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -22,9 +22,46 @@ class A:
         pass
 A().f()
 A().f(1)
-(A().f('')) # E:2: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
-( A().f(1, 1)) # E:3: Argument 2 to "f" of "A" has incompatible type "int"; expected "str"
+A().f('') # E:7: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+A().f(1, 1) # E:10: Argument 2 to "f" of "A" has incompatible type "int"; expected "str"
 (A().f(1, 'hello', 'hi')) # E:2: Too many arguments for "f" of "A"
+
+[case testColumnsInvalidArgumentType]
+# flags: --strict-optional
+def f(x: int, y: str) -> None: ...
+def g(*x: int) -> None: pass
+def h(**x: int) -> None: pass
+def ff(x: int) -> None: pass
+
+class A:
+    x: str
+    def __neg__(self) -> str: pass
+    def __add__(self, other: int) -> str: pass
+    def __lt__(self, other: int) -> str: pass
+
+f(
+ y=0, x=0) # E:4: Argument 1 to "f" has incompatible type "int"; expected "str"
+f(x=0,
+   y=None) # E:6: Argument 2 to "f" has incompatible type "None"; expected "str"
+g(1, '', 2) # E:6: Argument 2 to "g" has incompatible type "str"; expected "int"
+aaa: str
+h(x=1, y=aaa, z=2) # E:10: Argument 2 to "h" has incompatible type "str"; expected "int"
+a: A
+ff(a.x) # E:4: Argument 1 to "ff" has incompatible type "str"; expected "int"
+ff([1]) # E:4: Argument 1 to "ff" has incompatible type "List[int]"; expected "int"
+ff([1 for x in [1]]) # E:5: Argument 1 to "ff" has incompatible type "List[int]"; expected "int"
+ff({1: 2}) # E:4: Argument 1 to "ff" has incompatible type "Dict[int, int]"; expected "int"
+ff(1.1) # E:4: Argument 1 to "ff" has incompatible type "float"; expected "int"
+ff( ( 1, 1)) # E:7: Argument 1 to "ff" has incompatible type "Tuple[int, int]"; expected "int"
+ff(-a) # E:4: Argument 1 to "ff" has incompatible type "str"; expected "int"
+ff(a + 1) # E:4: Argument 1 to "ff" has incompatible type "str"; expected "int"
+ff(a < 1) # E:4: Argument 1 to "ff" has incompatible type "str"; expected "int"
+ff([''][0]) # E:4: Argument 1 to "ff" has incompatible type "str"; expected "int"
+
+class B(A):
+    def f(self) -> None:
+        ff(super().__neg__()) # E:12: Argument 1 to "ff" has incompatible type "str"; expected "int"
+[builtins fixtures/dict.pyi]
 
 [case testColumnsMultipleStatementsPerLine]
 x = 15
@@ -33,7 +70,7 @@ if int():
     x = 2; y = x; y += 1
 [out]
 main:4:12: error: Incompatible types in assignment (expression has type "int", variable has type "str")
-main:4:19: error: Unsupported operand types for + ("str" and "int")
+main:4:24: error: Unsupported operand types for + ("str" and "int")
 
 [case testColumnsSimpleIsinstance]
 import typing
@@ -131,10 +168,10 @@ def f(x, y): pass
 [case testColumnListOrDictItemHasIncompatibleType]
 from typing import List, Dict
 # TODO: Point to the actual item since a list/dict literal can span many lines
-x: List[int] = [  # E:16: List item 0 has incompatible type "str"; expected "int"
-    'x']
-y: Dict[int, int] = {  # E:21: Dict entry 0 has incompatible type "str": "int"; expected "int": "int"
-    'x': 1
+x: List[int] = [
+    'x']  # E:5: List item 0 has incompatible type "str"; expected "int"
+y: Dict[int, int] = {
+    'x': 1  # E:5: Dict entry 0 has incompatible type "str": "int"; expected "int": "int"
 }
 [builtins fixtures/dict.pyi]
 
@@ -144,7 +181,7 @@ x = None
 
 [case testColumnInvalidIndexing]
 from typing import List
-([1]['']) # E:2: Invalid index type "str" for "List[int]"; expected type "int"
+([1]['']) # E:6: Invalid index type "str" for "List[int]"; expected type "int"
 (1[1]) # E:2: Value of type "int" is not indexable
 def f() -> None:
     1[1] = 1 # E:5: Unsupported target for indexed assignment

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1847,8 +1847,8 @@ main:4: note:     z: builtins.int
 [case testUndefinedRevealType]
 reveal_type(x)
 [out]
-main:1: note: Revealed type is 'Any'
 main:1: error: Name 'x' is not defined
+main:1: note: Revealed type is 'Any'
 
 [case testUserDefinedRevealType]
 def reveal_type(x: int) -> None: pass

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1671,8 +1671,8 @@ def f(x: int) -> None:
 [builtins fixtures/for.pyi]
 [out]
 main:1: error: The return type of a generator function should be "Generator" or one of its supertypes
-main:2: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 main:2: error: "f" does not return a value
+main:2: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 
 [case testYieldExpressionWithNone]
 from typing import Iterator
@@ -1919,8 +1919,8 @@ from typing import Dict, Callable
 def things() -> int:
     return 42
 
-stuff: Dict[int, Callable[[], str]] = {  # E: Dict entry 0 has incompatible type "int": "Callable[[], int]"; expected "int": "Callable[[], str]"
-    1: things
+stuff: Dict[int, Callable[[], str]] = {
+    1: things  # E: Dict entry 0 has incompatible type "int": "Callable[[], int]"; expected "int": "Callable[[], str]"
 }
 [builtins fixtures/dict.pyi]
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -616,8 +616,8 @@ main:15:10: error: "list" expects 1 type argument, but 2 given
 main:16:19: error: "list" expects 1 type argument, but 2 given
 main:17:25: error: "Node" expects 2 type arguments, but 1 given
 main:19:5: error: Bad number of arguments for type alias, expected: 1, given: 2
-main:22:1: note: Revealed type is '__main__.Node[builtins.int, builtins.str]'
-main:24:1: note: Revealed type is '__main__.Node[__main__.Node[builtins.int, builtins.int], builtins.list[builtins.int]]'
+main:22:13: note: Revealed type is '__main__.Node[builtins.int, builtins.str]'
+main:24:13: note: Revealed type is '__main__.Node[__main__.Node[builtins.int, builtins.int], builtins.list[builtins.int]]'
 main:26:5: error: Type variable "__main__.T" is invalid as target for type alias
 
 [case testGenericTypeAliasesForAliases]

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -697,8 +697,9 @@ def f(func: Callable[[T], S], *z: T, r: S = None) -> S: pass
 f(lambda x: 0 if isinstance(x, B) else 1) # E: Cannot infer type argument 1 of "f"
 f(lambda x: 0 if isinstance(x, B) else 1, A())() # E: "int" not callable
 f(lambda x: x if isinstance(x, B) else B(), A(), r=B())() # E: "B" not callable
-f( # E: Argument 1 to "f" has incompatible type "Callable[[A], A]"; expected "Callable[[A], B]"
-    lambda x: B() if isinstance(x, B) else x, # E: Incompatible return value type (got "A", expected "B")
+f(
+    lambda x:  # E: Argument 1 to "f" has incompatible type "Callable[[A], A]"; expected "Callable[[A], B]"
+        B() if isinstance(x, B) else x, # E: Incompatible return value type (got "A", expected "B")
     A(), r=B())
 [builtins fixtures/isinstance.pyi]
 

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -968,8 +968,8 @@ def foo() -> Union[int, str, A]: pass
 
 def bar() -> None:
     x = foo()
-    x + 1  # E: Unsupported operand types for + ("str" and "int") \
-           # E: Unsupported left operand type for + ("A") \
+    x + 1  # E: Unsupported left operand type for + ("A") \
+           # E: Unsupported operand types for + ("str" and "int") \
            # N: Left operand is of type "Union[int, str, A]"
     if isinstance(x, A):
        x.a

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -1579,19 +1579,19 @@ reveal_type(func(c))  # N: Revealed type is 'Union[__main__.B, __main__.A]'
 reveal_type(func(d))  # N: Revealed type is '__main__.B' \
                       # E: Argument 1 to "func" has incompatible type "Union[Literal[6], Literal[7]]"; expected "Union[Literal[3], Literal[4], Literal[5], Literal[6]]"
 
-reveal_type(func(e))  # N: Revealed type is 'Any' \
-                      # E: No overload variant of "func" matches argument type "int" \
+reveal_type(func(e))  # E: No overload variant of "func" matches argument type "int" \
                       # N: Possible overload variants: \
                       # N:     def func(x: Literal[-40]) -> A \
                       # N:     def func(x: Union[Literal[3], Literal[4], Literal[5], Literal[6]]) -> B \
-                      # N:     def func(x: Literal['foo']) -> C
+                      # N:     def func(x: Literal['foo']) -> C \
+                      # N: Revealed type is 'Any'
 
-reveal_type(func(f))  # N: Revealed type is 'Any' \
-                      # E: No overload variant of "func" matches argument type "Union[Literal[7], Literal['bar']]" \
+reveal_type(func(f))  # E: No overload variant of "func" matches argument type "Union[Literal[7], Literal['bar']]" \
                       # N: Possible overload variants: \
                       # N:     def func(x: Literal[-40]) -> A \
                       # N:     def func(x: Union[Literal[3], Literal[4], Literal[5], Literal[6]]) -> B \
-                      # N:     def func(x: Literal['foo']) -> C
+                      # N:     def func(x: Literal['foo']) -> C \
+                      # N: Revealed type is 'Any'
 [out]
 
 [case testLiteralInferredInOverloadContextUnionMathOverloadingReturnsBestType]
@@ -1941,12 +1941,12 @@ reveal_type(func1)      # N: Revealed type is 'def [TLiteral <: Literal[3]] (x: 
 
 reveal_type(func1(3))   # N: Revealed type is 'Literal[3]'
 reveal_type(func1(a))   # N: Revealed type is 'Literal[3]'
-reveal_type(func1(4))   # N: Revealed type is 'Literal[4]' \
-                        # E: Value of type variable "TLiteral" of "func1" cannot be "Literal[4]"
-reveal_type(func1(b))   # N: Revealed type is 'Literal[4]' \
-                        # E: Value of type variable "TLiteral" of "func1" cannot be "Literal[4]"
-reveal_type(func1(c))   # N: Revealed type is 'builtins.int*' \
-                        # E: Value of type variable "TLiteral" of "func1" cannot be "int"
+reveal_type(func1(4))   # E: Value of type variable "TLiteral" of "func1" cannot be "Literal[4]" \
+                        # N: Revealed type is 'Literal[4]'
+reveal_type(func1(b))   # E: Value of type variable "TLiteral" of "func1" cannot be "Literal[4]" \
+                        # N: Revealed type is 'Literal[4]'
+reveal_type(func1(c))   # E: Value of type variable "TLiteral" of "func1" cannot be "int" \
+                        # N: Revealed type is 'builtins.int*'
 
 reveal_type(func2(3))   # N: Revealed type is 'builtins.int*'
 reveal_type(func2(a))   # N: Revealed type is 'Literal[3]'
@@ -1986,21 +1986,20 @@ reveal_type(func1)          # N: Revealed type is 'def [TLiteral in (Literal[3],
 
 reveal_type(func1(3))       # N: Revealed type is 'Literal[3]'
 reveal_type(func1(i1))      # N: Revealed type is 'Literal[3]'
-reveal_type(func1(4))       # N: Revealed type is 'Literal[4]' \
-                            # E: Value of type variable "TLiteral" of "func1" cannot be "Literal[4]"
-reveal_type(func1(i2))      # N: Revealed type is 'Literal[4]' \
-                            # E: Value of type variable "TLiteral" of "func1" cannot be "Literal[4]"
-reveal_type(func1(i))       # N: Revealed type is 'builtins.int*' \
-                            # E: Value of type variable "TLiteral" of "func1" cannot be "int"
-
+reveal_type(func1(4))       # E: Value of type variable "TLiteral" of "func1" cannot be "Literal[4]" \
+                            # N: Revealed type is 'Literal[4]'
+reveal_type(func1(i2))      # E: Value of type variable "TLiteral" of "func1" cannot be "Literal[4]" \
+                            # N: Revealed type is 'Literal[4]'
+reveal_type(func1(i))       # E: Value of type variable "TLiteral" of "func1" cannot be "int" \
+                            # N: Revealed type is 'builtins.int*'
 reveal_type(func1("foo"))   # N: Revealed type is 'Literal['foo']'
 reveal_type(func1(s1))      # N: Revealed type is 'Literal['foo']'
-reveal_type(func1("bar"))   # N: Revealed type is 'Literal['bar']' \
-                            # E: Value of type variable "TLiteral" of "func1" cannot be "Literal['bar']"
-reveal_type(func1(s2))      # N: Revealed type is 'Literal['bar']' \
-                            # E: Value of type variable "TLiteral" of "func1" cannot be "Literal['bar']"
-reveal_type(func1(s))       # N: Revealed type is 'builtins.str*' \
-                            # E: Value of type variable "TLiteral" of "func1" cannot be "str"
+reveal_type(func1("bar"))   # E: Value of type variable "TLiteral" of "func1" cannot be "Literal['bar']" \
+                            # N: Revealed type is 'Literal['bar']'
+reveal_type(func1(s2))      # E: Value of type variable "TLiteral" of "func1" cannot be "Literal['bar']" \
+                            # N: Revealed type is 'Literal['bar']'
+reveal_type(func1(s))       # E: Value of type variable "TLiteral" of "func1" cannot be "str" \
+                            # N: Revealed type is 'builtins.str*'
 
 reveal_type(func2(3))       # N: Revealed type is 'builtins.int*'
 reveal_type(func2(i1))      # N: Revealed type is 'builtins.int*'
@@ -2061,8 +2060,8 @@ reveal_type(arr5)  # N: Revealed type is 'builtins.list[def (Literal[1]) -> buil
 
 # Inspect just only one interesting one
 lit: Literal[1]
-reveal_type(arr2[0](lit))  # N: Revealed type is 'Any' \
-                           # E: Cannot call function of unknown type
+reveal_type(arr2[0](lit))  # E: Cannot call function of unknown type \
+                           # N: Revealed type is 'Any'
 
 T = TypeVar('T')
 def unify(func: Callable[[T, T], None]) -> T: pass
@@ -2092,8 +2091,8 @@ lit: Literal[1]
 
 arr = [a, b]
 reveal_type(arr)  # N: Revealed type is 'builtins.list[builtins.function*]'
-reveal_type(arr[0](lit))  # N: Revealed type is 'Any' \
-                          # E: Cannot call function of unknown type
+reveal_type(arr[0](lit))  # E: Cannot call function of unknown type \
+                          # N: Revealed type is 'Any'
 
 T = TypeVar('T')
 def unify(func: Callable[[T, T], None]) -> T: pass
@@ -2177,8 +2176,8 @@ reveal_type(d.get(a_key, u))  # N: Revealed type is 'Union[builtins.int, __main_
 reveal_type(d.get(b_key, u))  # N: Revealed type is 'Union[builtins.str, __main__.Unrelated]'
 d.get(c_key, u)               # E: TypedDict "Outer" has no key 'c'
 
-reveal_type(d.pop(a_key))     # N: Revealed type is 'builtins.int' \
-                              # E: Key 'a' of TypedDict "Outer" cannot be deleted
+reveal_type(d.pop(a_key))     # E: Key 'a' of TypedDict "Outer" cannot be deleted \
+                              # N: Revealed type is 'builtins.int'
 reveal_type(d.pop(b_key))     # N: Revealed type is 'builtins.str'
 d.pop(c_key)                  # E: TypedDict "Outer" has no key 'c'
 

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1860,8 +1860,8 @@ class C:
 import stub
 
 reveal_type(stub.y)  # N: Revealed type is 'builtins.int'
-reveal_type(stub.z)  # N: Revealed type is 'Any' \
-                     # E: Module has no attribute "z"
+reveal_type(stub.z)  # E: Module has no attribute "z" \
+                     # N: Revealed type is 'Any'
 
 [file stub.pyi]
 from substub import y as y
@@ -2028,8 +2028,8 @@ def __getattr__(name): ...
 [case testModuleLevelGetattrNotStub36]
 # flags: --python-version 3.6
 import has_getattr
-reveal_type(has_getattr.any_attribute)  # N: Revealed type is 'Any'  # E: Module has no attribute "any_attribute"
-
+reveal_type(has_getattr.any_attribute)  # E: Module has no attribute "any_attribute" \
+                                        # N: Revealed type is 'Any'
 [file has_getattr.py]
 def __getattr__(name) -> str: ...
 
@@ -2093,7 +2093,7 @@ def __getattr__(name: str) -> Any: ...
 
 [case testModuleLevelGetattrImportFromAs]
 from has_attr import name as n
-reveal_type(name)  # N: Revealed type is 'Any'  # E: Name 'name' is not defined
+reveal_type(name)  # E: Name 'name' is not defined  # N: Revealed type is 'Any'
 reveal_type(n)  # N: Revealed type is 'Any'
 
 [file has_attr.pyi]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -134,7 +134,7 @@ X(0, 1)  # ok
 X(0, 1, 2)  # E: Too many arguments for "X"
 
 Y = namedtuple('Y', ['x', 'y'], defaults=(1, 2, 3))  # E: Too many defaults given in call to namedtuple()
-Z = namedtuple('Z', ['x', 'y'], defaults='not a tuple')  # E: Argument "defaults" to "namedtuple" has incompatible type "str"; expected "Optional[Iterable[Any]]"  # E: List or tuple literal expected as the defaults argument to namedtuple()
+Z = namedtuple('Z', ['x', 'y'], defaults='not a tuple')  # E: List or tuple literal expected as the defaults argument to namedtuple()  # E: Argument "defaults" to "namedtuple" has incompatible type "str"; expected "Optional[Iterable[Any]]"
 
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -3049,8 +3049,8 @@ reveal_type(x) # N: Revealed type is '__main__.C'
 [case testNewAnalyzerIdentityAssignment7]
 C = C # E: Name 'C' is not defined
 
-reveal_type(C) # N: Revealed type is 'Any' \
-               # E: Name 'C' is not defined
+reveal_type(C) # E: Name 'C' is not defined \
+               # N: Revealed type is 'Any'
 
 [case testNewAnalyzerIdentityAssignment8]
 from typing import Final

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4563,6 +4563,7 @@ def f(*args):
 x: Union[int, str]
 f(x, x, x, x, x, x, x, x)
 [out]
+main:11: note: Not all union combinations were tried because there are too many unions
 main:11: error: Argument 1 to "f" has incompatible type "Union[int, str]"; expected "int"
 main:11: error: Argument 2 to "f" has incompatible type "Union[int, str]"; expected "int"
 main:11: error: Argument 3 to "f" has incompatible type "Union[int, str]"; expected "int"
@@ -4571,7 +4572,6 @@ main:11: error: Argument 5 to "f" has incompatible type "Union[int, str]"; expec
 main:11: error: Argument 6 to "f" has incompatible type "Union[int, str]"; expected "int"
 main:11: error: Argument 7 to "f" has incompatible type "Union[int, str]"; expected "int"
 main:11: error: Argument 8 to "f" has incompatible type "Union[int, str]"; expected "int"
-main:11: note: Not all union combinations were tried because there are too many unions
 
 [case testSafeDunderOverlapInSubclass]
 from typing import overload
@@ -4959,8 +4959,9 @@ def foo() -> None: ...
 def foo(iterable: Iterable[_T]) -> None: ...
 def foo(iterable = None) -> None: pass
 
-foo(bar('lol').foo())  # E: Argument 1 to "bar" has incompatible type "str"; expected "int" \
-                       # E: Item "int" of "Union[A, int]" has no attribute "foo"
+foo(bar('lol').foo())  # E: Item "int" of "Union[A, int]" has no attribute "foo" \
+                       # E: Argument 1 to "bar" has incompatible type "str"; expected "int"
+
 
 [case testOverloadInferringArgumentsUsingContext1]
 from typing import Optional, List, overload, TypeVar

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -30,15 +30,19 @@ def f(): ...  # type: ignore
 [case testIgnoreScopeIssue1032]
 def f(a: int): ...
 f(
-    "IGNORE"
+    1,
+    2,
 )  # type: ignore
 
 [case testIgnoreScopeNested1]
+def g(x: str) -> str: ...
 def f(a: int) -> int: ...
 f(
     f(
-        "IGNORE"
-    )  # type: ignore
+        g(
+            "IGNORE"
+        )  # type: ignore
+    )
 )
 
 [case testIgnoreScopeNested2]
@@ -86,9 +90,9 @@ def g(x: int): ...
 [case testIgnoreScopeUnused1]
 # flags: --warn-unused-ignores
 (  # type: ignore  # E: unused 'type: ignore' comment
-    "IGNORE"  # type: ignore
+    "IGNORE"  # type: ignore  # E: unused 'type: ignore' comment
     +  # type: ignore  # E: unused 'type: ignore' comment
-    0  # type: ignore  # E: unused 'type: ignore' comment
+    0  # type: ignore
 )  # type: ignore  # E: unused 'type: ignore' comment
 
 [case testIgnoreScopeUnused2]

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1216,8 +1216,8 @@ from typing import Union, Tuple
 tup: Union[Tuple[int, str], Tuple[int, int, str]]
 reveal_type(tup[0])  # N: Revealed type is 'builtins.int'
 reveal_type(tup[1])  # N: Revealed type is 'Union[builtins.str, builtins.int]'
-reveal_type(tup[2])  # N: Revealed type is 'Union[Any, builtins.str]' \
-                     # E: Tuple index out of range
+reveal_type(tup[2])  # E: Tuple index out of range \
+                     # N: Revealed type is 'Union[Any, builtins.str]'
 reveal_type(tup[:])  # N: Revealed type is 'Union[Tuple[builtins.int, builtins.str], Tuple[builtins.int, builtins.int, builtins.str]]'
 
 [builtins fixtures/tuple.pyi]
@@ -1228,8 +1228,8 @@ from typing import Union, Tuple, List
 tup: Union[Tuple[int, str], List[int]]
 reveal_type(tup[0])  # N: Revealed type is 'builtins.int'
 reveal_type(tup[1])  # N: Revealed type is 'Union[builtins.str, builtins.int*]'
-reveal_type(tup[2])  # N: Revealed type is 'Union[Any, builtins.int*]' \
-                     # E: Tuple index out of range
+reveal_type(tup[2])  # E: Tuple index out of range \
+                     # N: Revealed type is 'Union[Any, builtins.int*]'
 reveal_type(tup[:])  # N: Revealed type is 'Union[Tuple[builtins.int, builtins.str], builtins.list[builtins.int*]]'
 
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1612,8 +1612,8 @@ td: Union[TDA, TDB]
 
 reveal_type(td.get('a'))  # N: Revealed type is 'builtins.int'
 reveal_type(td.get('b'))  # N: Revealed type is 'Union[builtins.str, builtins.int]'
-reveal_type(td.get('c'))  # N: Revealed type is 'Union[Any, builtins.int]' \
-                          # E: TypedDict "TDA" has no key 'c'
+reveal_type(td.get('c'))  # E: TypedDict "TDA" has no key 'c' \
+                          # N: Revealed type is 'Union[Any, builtins.int]'
 
 reveal_type(td['a'])  # N: Revealed type is 'builtins.int'
 reveal_type(td['b'])  # N: Revealed type is 'Union[builtins.str, builtins.int]'
@@ -1639,8 +1639,8 @@ td: Union[TDA, TDB]
 
 reveal_type(td.pop('a'))  # N: Revealed type is 'builtins.int'
 reveal_type(td.pop('b'))  # N: Revealed type is 'Union[builtins.str, builtins.int]'
-reveal_type(td.pop('c'))  # N: Revealed type is 'Union[Any, builtins.int]' \
-                          # E: TypedDict "TDA" has no key 'c'
+reveal_type(td.pop('c'))  # E: TypedDict "TDA" has no key 'c' \
+                          # N: Revealed type is 'Union[Any, builtins.int]'
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -302,9 +302,9 @@ reveal_type(u('', 1, 1))  # N: Revealed type is 'Union[builtins.int*, builtins.s
 from typing import Union
 class A: pass
 def f(x: Union[int, str, A]):
-    x + object() # E: Unsupported operand types for + ("int" and "object") \
+    x + object() # E: Unsupported left operand type for + ("A") \
+                 # E: Unsupported operand types for + ("int" and "object") \
                  # E: Unsupported operand types for + ("str" and "object") \
-                 # E: Unsupported left operand type for + ("A") \
                  # N: Left operand is of type "Union[int, str, A]"
 
 [case testNarrowingDownNamedTupleUnion]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1405,7 +1405,7 @@ class AnotherCustomClassDefinedBelow:
 [out]
 some_file.py:3: error: Unsupported operand types for + ("int" and "str")
     42 + 'no way'
-    ^
+         ^
 some_file.py:11: error: Incompatible types in assignment (expression has type
 "AnotherCustomClassDefinedBelow", variable has type "OneCustomClassName")
             self.very_important_attribute_with_long_name: OneCustomClassNa...
@@ -1413,8 +1413,8 @@ some_file.py:11: error: Incompatible types in assignment (expression has type
 some_file.py:11: error: Argument 1 to "some_interesting_method" of
 "OneCustomClassName" has incompatible type "Union[int, str, float]"; expected
 "AnotherCustomClassDefinedBelow"
-    ...t_attribute_with_long_name: OneCustomClassName = OneCustomClassName()....
-                                                        ^
+    ...OneCustomClassName = OneCustomClassName().some_interesting_method(arg)
+                                                                         ^
 
 [case testShowSourceCodeSnippetsBlockingError]
 # cmd: mypy --pretty --show-error-codes some_file.py

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -2574,11 +2574,11 @@ class Wrapper:
 [out]
 main:3: note: Revealed type is 'builtins.int'
 ==
-main:3: note: Revealed type is 'Any'
 main:3: error: No overload variant of "foo" of "Wrapper" matches argument type "int"
 main:3: note: Possible overload variants:
 main:3: note:     def foo(cls: Wrapper, x: int) -> int
 main:3: note:     def foo(cls: Wrapper, x: str) -> str
+main:3: note: Revealed type is 'Any'
 
 [case testRefreshGenericClass]
 from typing import TypeVar, Generic

--- a/test-data/unit/parse-python2.test
+++ b/test-data/unit/parse-python2.test
@@ -594,19 +594,19 @@ MypyFile:1(
   ExpressionStmt:1(
     IndexExpr:1(
       NameExpr(x)
-      SliceExpr:-1(
+      SliceExpr:1(
         NameExpr(y)
         <empty>)))
   ExpressionStmt:2(
     IndexExpr:2(
       NameExpr(x)
-      SliceExpr:-1(
+      SliceExpr:2(
         NameExpr(y)
         NameExpr(z))))
   ExpressionStmt:3(
     IndexExpr:3(
       NameExpr(x)
-      SliceExpr:-1(
+      SliceExpr:3(
         <empty>
         <empty>
         NameExpr(y)))))

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -1207,25 +1207,25 @@ MypyFile:1(
   ExpressionStmt:1(
     IndexExpr:1(
       NameExpr(x)
-      SliceExpr:-1(
+      SliceExpr:1(
         IntExpr(1)
         IntExpr(2))))
   ExpressionStmt:2(
     IndexExpr:2(
       NameExpr(x)
-      SliceExpr:-1(
+      SliceExpr:2(
         <empty>
         IntExpr(1))))
   ExpressionStmt:3(
     IndexExpr:3(
       NameExpr(x)
-      SliceExpr:-1(
+      SliceExpr:3(
         IntExpr(1)
         <empty>)))
   ExpressionStmt:4(
     IndexExpr:4(
       NameExpr(x)
-      SliceExpr:-1(
+      SliceExpr:4(
         <empty>
         <empty>))))
 
@@ -1240,35 +1240,35 @@ MypyFile:1(
   ExpressionStmt:1(
     IndexExpr:1(
       NameExpr(x)
-      SliceExpr:-1(
+      SliceExpr:1(
         IntExpr(1)
         IntExpr(2)
         IntExpr(3))))
   ExpressionStmt:2(
     IndexExpr:2(
       NameExpr(x)
-      SliceExpr:-1(
+      SliceExpr:2(
         IntExpr(1)
         <empty>
         IntExpr(2))))
   ExpressionStmt:3(
     IndexExpr:3(
       NameExpr(x)
-      SliceExpr:-1(
+      SliceExpr:3(
         <empty>
         IntExpr(1)
         IntExpr(2))))
   ExpressionStmt:4(
     IndexExpr:4(
       NameExpr(x)
-      SliceExpr:-1(
+      SliceExpr:4(
         <empty>
         <empty>
         IntExpr(2))))
   ExpressionStmt:5(
     IndexExpr:5(
       NameExpr(x)
-      SliceExpr:-1(
+      SliceExpr:5(
         IntExpr(1)
         IntExpr(2)))))
 
@@ -3328,92 +3328,92 @@ MypyFile:1(
 x = 'mypy'
 f'Hello {x}'
 [out]
-MypyFile:1(                     
-  AssignmentStmt:1(             
-    NameExpr(x)                 
-    StrExpr(mypy))              
-  ExpressionStmt:2(             
-    CallExpr:2(                 
-      MemberExpr:2(             
-        StrExpr()               
-        join)                   
-      Args(                     
-        ListExpr:2(             
-          StrExpr(Hello )       
-          CallExpr:2(           
-            MemberExpr:2(       
-              StrExpr({:{}})    
-              format)           
-            Args(               
+MypyFile:1(
+  AssignmentStmt:1(
+    NameExpr(x)
+    StrExpr(mypy))
+  ExpressionStmt:2(
+    CallExpr:2(
+      MemberExpr:2(
+        StrExpr()
+        join)
+      Args(
+        ListExpr:2(
+          StrExpr(Hello )
+          CallExpr:2(
+            MemberExpr:2(
+              StrExpr({:{}})
+              format)
+            Args(
               NameExpr(x))))))))
 
 [case testFStringWithConversion]
 x = 'mypy'
 F'Hello {x!r}'
 [out]
-MypyFile:1(                     
-  AssignmentStmt:1(             
-    NameExpr(x)                 
-    StrExpr(mypy))              
-  ExpressionStmt:2(             
-    CallExpr:2(                 
-      MemberExpr:2(             
-        StrExpr()               
-        join)                   
-      Args(                     
-        ListExpr:2(             
-          StrExpr(Hello )       
-          CallExpr:2(           
-            MemberExpr:2(       
-              StrExpr({!r:{}})  
-              format)           
-            Args(               
+MypyFile:1(
+  AssignmentStmt:1(
+    NameExpr(x)
+    StrExpr(mypy))
+  ExpressionStmt:2(
+    CallExpr:2(
+      MemberExpr:2(
+        StrExpr()
+        join)
+      Args(
+        ListExpr:2(
+          StrExpr(Hello )
+          CallExpr:2(
+            MemberExpr:2(
+              StrExpr({!r:{}})
+              format)
+            Args(
               NameExpr(x))))))))
 
 [case testFStringWithOnlyFormatSpecifier]
 x = 'mypy'
 f'Hello {x:<30}'
 [out]
-MypyFile:1(                     
-  AssignmentStmt:1(             
-    NameExpr(x)                 
-    StrExpr(mypy))              
-  ExpressionStmt:2(             
-    CallExpr:2(                 
-      MemberExpr:2(             
-        StrExpr()               
-        join)                   
-      Args(                     
-        ListExpr:2(             
-          StrExpr(Hello )       
-          CallExpr:2(           
-            MemberExpr:2(       
-              StrExpr({:{}})    
-              format)           
-            Args(               
+MypyFile:1(
+  AssignmentStmt:1(
+    NameExpr(x)
+    StrExpr(mypy))
+  ExpressionStmt:2(
+    CallExpr:2(
+      MemberExpr:2(
+        StrExpr()
+        join)
+      Args(
+        ListExpr:2(
+          StrExpr(Hello )
+          CallExpr:2(
+            MemberExpr:2(
+              StrExpr({:{}})
+              format)
+            Args(
               NameExpr(x))))))))
 
 [case testFStringWithFormatSpecifierAndConversion]
 x = 'mypy'
 f'Hello {x!s:<30}'
 [out]
-MypyFile:1(                     
-  AssignmentStmt:1(             
-    NameExpr(x)                 
-    StrExpr(mypy))              
-  ExpressionStmt:2(             
-    CallExpr:2(                 
-      MemberExpr:2(             
-        StrExpr()               
-        join)                   
-      Args(                     
-        ListExpr:2(             
-          StrExpr(Hello )       
-          CallExpr:2(           
-            MemberExpr:2(       
-              StrExpr({!s:{}})  
-              format)           
-            Args(               
+MypyFile:1(
+  AssignmentStmt:1(
+    NameExpr(x)
+    StrExpr(mypy))
+  ExpressionStmt:2(
+    CallExpr:2(
+      MemberExpr:2(
+        StrExpr()
+        join)
+      Args(
+        ListExpr:2(
+          StrExpr(Hello )
+          CallExpr:2(
+            MemberExpr:2(
+              StrExpr({!s:{}})
+              format)
+            Args(
               NameExpr(x))))))))
 
 [case testFStringWithFormatSpecifierExpression]
@@ -3421,24 +3421,24 @@ x = 'mypy'
 y = 30
 f'Hello {x!s:<{y+y}}'
 [out]
-MypyFile:1(                     
-  AssignmentStmt:1(             
-    NameExpr(x)                 
-    StrExpr(mypy))              
-  AssignmentStmt:2(             
-    NameExpr(y)                 
-    IntExpr(30))                
-  ExpressionStmt:3(             
-    CallExpr:3(                 
-      MemberExpr:3(             
-        StrExpr()               
-        join)                   
-      Args(                     
-        ListExpr:3(             
-          StrExpr(Hello )       
-          CallExpr:3(           
-            MemberExpr:3(       
-              StrExpr({!s:{}})  
-              format)           
-            Args(               
+MypyFile:1(
+  AssignmentStmt:1(
+    NameExpr(x)
+    StrExpr(mypy))
+  AssignmentStmt:2(
+    NameExpr(y)
+    IntExpr(30))
+  ExpressionStmt:3(
+    CallExpr:3(
+      MemberExpr:3(
+        StrExpr()
+        join)
+      Args(
+        ListExpr:3(
+          StrExpr(Hello )
+          CallExpr:3(
+            MemberExpr:3(
+              StrExpr({!s:{}})
+              format)
+            Args(
               NameExpr(x))))))))

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -295,8 +295,8 @@ reveal_type(open(file='x', mode='rb'))
 mode = 'rb'
 reveal_type(open(mode=mode, file='r'))
 [out]
-_testOpenReturnTypeInferenceSpecialCases.py:1: note: Revealed type is 'typing.TextIO'
 _testOpenReturnTypeInferenceSpecialCases.py:1: error: Too few arguments for "open"
+_testOpenReturnTypeInferenceSpecialCases.py:1: note: Revealed type is 'typing.TextIO'
 _testOpenReturnTypeInferenceSpecialCases.py:2: note: Revealed type is 'typing.BinaryIO'
 _testOpenReturnTypeInferenceSpecialCases.py:3: note: Revealed type is 'typing.BinaryIO'
 _testOpenReturnTypeInferenceSpecialCases.py:5: note: Revealed type is 'typing.IO[Any]'

--- a/test-data/unit/semanal-expressions.test
+++ b/test-data/unit/semanal-expressions.test
@@ -115,20 +115,20 @@ MypyFile:1(
   ExpressionStmt:2(
     IndexExpr:2(
       NameExpr(x [__main__.x])
-      SliceExpr:-1(
+      SliceExpr:2(
         NameExpr(y [__main__.y])
         NameExpr(z [__main__.z])
         NameExpr(x [__main__.x]))))
   ExpressionStmt:3(
     IndexExpr:3(
       NameExpr(x [__main__.x])
-      SliceExpr:-1(
+      SliceExpr:3(
         <empty>
         <empty>)))
   ExpressionStmt:4(
     IndexExpr:4(
       NameExpr(x [__main__.x])
-      SliceExpr:-1(
+      SliceExpr:4(
         <empty>
         NameExpr(y [__main__.y])))))
 


### PR DESCRIPTION
Previously we pointed to the beginning of the call expression if there
was an incompatible argument, which is not great, particularly if there 
are multiple arguments.

Also point to incompatible list/dict/set item instead of the beginning
of a list/dict/set expression.

Note that this may require some `# type: ignore` comments to be
updated.

I had to update the output of many test cases, mostly because line
ordering was changed.