### PR TITLE
Work around crash caused by mypyc/mypyc#695

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1194,7 +1194,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 or (isinstance(e, UnaryExpr) and e.op == '-'
                     and isinstance(e.expr, (IntExpr, FloatExpr)))
                 or (isinstance(e, TupleExpr)
-                    and all(self.is_constant(e) for e in e.items))
+                    and all(self.is_constant(e2) for e2 in e.items))
                 or (isinstance(e, RefExpr) and e.kind == GDEF
                     and (e.fullname in ('builtins.True', 'builtins.False', 'builtins.None')
                          or (isinstance(e.node, Var) and e.node.is_final))))


### PR DESCRIPTION
mypyc has some issues when shadowing variables in a list comprehension
so work around it for now. This only affects mypyc when compiled with
mypyc.