### PR TITLE
Produce mypyc errors when encountering bug #5423

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -94,7 +94,6 @@ DeferredNode = NamedTuple(
     'DeferredNode',
     [
         ('node', DeferredNodeType),
-        ('context_type_name', Optional[str]),  # Name of the surrounding class (for error messages)
         ('active_typeinfo', Optional[TypeInfo]),  # And its TypeInfo (for semantic analysis
                                                   # self type handling)
     ])
@@ -105,7 +104,6 @@ FineGrainedDeferredNode = NamedTuple(
     'FineGrainedDeferredNode',
     [
         ('node', FineGrainedDeferredNodeType),
-        ('context_type_name', Optional[str]),
         ('active_typeinfo', Optional[TypeInfo]),
     ])
 
@@ -329,7 +327,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 assert not self.deferred_nodes
             self.deferred_nodes = []
             done = set()  # type: Set[Union[DeferredNodeType, FineGrainedDeferredNodeType]]
-            for node, type_name, active_typeinfo in todo:
+            for node, active_typeinfo in todo:
                 if node in done:
                     continue
                 # This is useful for debugging:
@@ -371,14 +369,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             enclosing_class: for methods, the class where the method is defined
         NOTE: this can't handle nested functions/methods.
         """
-        if self.errors.type_name:
-            type_name = self.errors.type_name[-1]
-        else:
-            type_name = None
         # We don't freeze the entire scope since only top-level functions and methods
         # can be deferred. Only module/class level scope information is needed.
         # Module-level scope information is preserved in the TypeChecker instance.
-        self.deferred_nodes.append(DeferredNode(node, type_name, enclosing_class))
+        self.deferred_nodes.append(DeferredNode(node, enclosing_class))
 
     def handle_cannot_determine_type(self, name: str, context: Context) -> None:
         node = self.scope.top_non_lambda_function()

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -172,7 +172,6 @@ class Errors:
         self.error_info_map = OrderedDict()
         self.flushed_files = set()
         self.import_ctx = []
-        self.type_name = [None]
         self.function_or_member = [None]
         self.ignored_lines = OrderedDict()
         self.used_ignored_lines = defaultdict(set)
@@ -192,7 +191,6 @@ class Errors:
                      self.read_source)
         new.file = self.file
         new.import_ctx = self.import_ctx[:]
-        new.type_name = self.type_name[:]
         new.function_or_member = self.function_or_member[:]
         new.target_module = self.target_module
         new.scope = self.scope

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -580,7 +580,7 @@ class ASTConverter:
                 # Before 3.8, [typed_]ast the line number points to the first decorator.
                 # In 3.8, it points to the 'def' line, where we want it.
                 lineno += len(n.decorator_list)
-                end_lineno = None
+                end_lineno = None  # type: Optional[int]
             else:
                 # Set end_lineno to the old pre-3.8 lineno, in order to keep
                 # existing "# type: ignore" comments working:

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -83,7 +83,7 @@ class NodeFixer(NodeVisitor[None]):
                         assert stnode.node is not None
                         value.node = stnode.node
                     elif not self.allow_missing:
-                        assert stnode is not None, "Could not find cross-ref %s" % (cross_ref,)
+                        assert False, "Could not find cross-ref %s" % (cross_ref,)
                     else:
                         # We have a missing crossref in allow missing mode, need to put something
                         value.node = missing_info(self.modules)

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -1028,11 +1028,9 @@ def lookup_target(manager: BuildManager,
     node = modules[module]  # type: Optional[SymbolNode]
     file = None  # type: Optional[MypyFile]
     active_class = None
-    active_class_name = None
     for c in components:
         if isinstance(node, TypeInfo):
             active_class = node
-            active_class_name = node.name()
         if isinstance(node, MypyFile):
             file = node
         if (not isinstance(node, (MypyFile, TypeInfo))
@@ -1057,7 +1055,7 @@ def lookup_target(manager: BuildManager,
             # a deserialized TypeInfo with missing attributes.
             not_found()
             return [], None
-        result = [FineGrainedDeferredNode(file, None, None)]
+        result = [FineGrainedDeferredNode(file, None)]
         stale_info = None  # type: Optional[TypeInfo]
         if node.is_protocol:
             stale_info = node
@@ -1082,7 +1080,7 @@ def lookup_target(manager: BuildManager,
         # context will be wrong and it could be a partially initialized deserialized node.
         not_found()
         return [], None
-    return [FineGrainedDeferredNode(node, active_class_name, active_class)], None
+    return [FineGrainedDeferredNode(node, active_class)], None
 
 
 def is_verbose(manager: BuildManager) -> bool:

--- a/mypyc/test-data/commandline.test
+++ b/mypyc/test-data/commandline.test
@@ -159,3 +159,10 @@ a_str = " ".join(str(i) for i in range(10))
 wtvr = next(i for i in range(10) if i == 5)
 
 d1 = {1: 2}
+
+# Make sure we can produce an error when we hit the awful None case
+def f(l: List[object]) -> None:
+    x = None  # E: Local variable 'x' has inferred type None; add an annotation
+    for i in l:
+        if x is None:
+            x = i


### PR DESCRIPTION
Currently when we encounter #5423 (when someting is incorrectly
inferred as None), we generate code that casts a variable to None
incorrectly since we are confused about the real type.

Now produce an error message saying to add an annotation when we
detect it.

Fix up the places in mypy this caused errors.