### PR TITLE
Fix missing quotes in sample python snippet

### DIFF
--- a/docs/source/type_inference_and_annotations.rst
+++ b/docs/source/type_inference_and_annotations.rst
@@ -160,7 +160,7 @@ in the following statement:
 .. code-block:: python
 
     def foo(arg: List[int]) -> None:
-        print(Items: ', '.join(arg))
+        print('Items:', ', '.join(arg))
 
     a = []  # Error: Need type annotation for 'a'
     foo(a)


### PR DESCRIPTION
Adds missing `''` around a `print` string argument