### PR TITLE
Display exception string when loading a plugin failed

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -381,8 +381,8 @@ def load_plugins(options: Options,
 
         try:
             module = importlib.import_module(module_name)
-        except Exception:
-            plugin_error("Error importing plugin '{}'".format(plugin_path))
+        except Exception as exc:
+            plugin_error("Error importing plugin '{}': {}".format(plugin_path, exc))
         finally:
             if plugin_dir is not None:
                 assert sys.path[0] == plugin_dir

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -352,7 +352,7 @@ def load_plugins(options: Options,
 
     def plugin_error(message: str) -> None:
         errors.report(line, 0, message)
-        errors.raise_error()
+        errors.raise_error(use_stdout=False)
 
     custom_plugins = []  # type: List[Plugin]
     errors.set_file(options.config_file, None)

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -399,7 +399,7 @@ class Errors:
         """Are there any errors for the given file?"""
         return file in self.error_info_map
 
-    def raise_error(self) -> None:
+    def raise_error(self, use_stdout: bool = True) -> None:
         """Raise a CompileError with the generated messages.
 
         Render the messages suitable for displaying.
@@ -407,7 +407,7 @@ class Errors:
         # self.new_messages() will format all messages that haven't already
         # been returned from a file_messages() call.
         raise CompileError(self.new_messages(),
-                           use_stdout=True,
+                           use_stdout=use_stdout,
                            module_with_blocker=self.blocker_module())
 
     def format_messages(self, error_info: List[ErrorInfo],

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -70,7 +70,7 @@ tmp/mypy.ini:2: error: Can't find plugin 'tmp/missing.py'
 [[mypy]
 plugins=missing
 [out]
-tmp/mypy.ini:2: error: Error importing plugin 'missing'
+tmp/mypy.ini:2: error: Error importing plugin 'missing': No module named 'missing'
 
 [case testMultipleSectionsDefinePlugin]
 # flags: --config-file tmp/mypy.ini


### PR DESCRIPTION
This helps with seeing what the issue is (e.g. with django-stubs [1]).

It might be even better to have a traceback there already, no?

1: https://github.com/typeddjango/django-stubs/issues/160