### PR TITLE
Make tests use \[ to escape brackets instead of [[

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -424,7 +424,7 @@ def parse_test_data(raw_data: str, name: str) -> List[TestItem]:
     while i < len(lines):
         s = lines[i].strip()
 
-        if lines[i].startswith('[') and s.endswith(']') and not s.startswith('[['):
+        if lines[i].startswith('[') and s.endswith(']'):
             if id:
                 data = collapse_line_continuation(data)
                 data = strip_list(data)
@@ -437,7 +437,7 @@ def parse_test_data(raw_data: str, name: str) -> List[TestItem]:
                 arg = id[id.index(' ') + 1:]
                 id = id[:id.index(' ')]
             data = []
-        elif lines[i].startswith('[['):
+        elif lines[i].startswith('\\['):
             data.append(lines[i][1:])
         elif not lines[i].startswith('--'):
             data.append(lines[i])

--- a/mypyc/test-data/run.test
+++ b/mypyc/test-data/run.test
@@ -418,9 +418,8 @@ from native import primes
 print(primes(3))
 print(primes(13))
 [out]
-[[0, 0, 1, 1]
-[[0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1]
--- argh ]]
+\[0, 0, 1, 1]
+\[0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1]
 
 
 [case testListPrims]

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -8,7 +8,7 @@
 def f() -> str: ...
 reveal_type(f())  # N: Revealed type is 'builtins.int'
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/fnplugin.py
 
 [case testFunctionPlugin]
@@ -16,7 +16,7 @@ plugins=<ROOT>/test-data/unit/plugins/fnplugin.py
 def f() -> str: ...
 reveal_type(f())  # N: Revealed type is 'builtins.int'
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=fnplugin
 
 [case testFunctionPluginFullnameIsNotNone]
@@ -27,7 +27,7 @@ T = TypeVar('T')
 def g(x: T) -> T: return x  # This strips out the name of a callable
 g(f)()
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/fnplugin.py
 
 [case testTwoPlugins]
@@ -39,7 +39,7 @@ reveal_type(f())  # N: Revealed type is 'builtins.int'
 reveal_type(g())  # N: Revealed type is 'builtins.str'
 reveal_type(h())  # N: Revealed type is 'Any'
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/fnplugin.py,
   <ROOT>/test-data/unit/plugins/plugin2.py
 
@@ -52,13 +52,13 @@ reveal_type(f())  # N: Revealed type is 'builtins.int'
 reveal_type(g())  # N: Revealed type is 'builtins.str'
 reveal_type(h())  # N: Revealed type is 'Any'
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/fnplugin.py, plugin2
 
 [case testMissingPluginFile]
 # flags: --config-file tmp/mypy.ini
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=missing.py
 [out]
 tmp/mypy.ini:2: error: Can't find plugin 'tmp/missing.py'
@@ -67,7 +67,7 @@ tmp/mypy.ini:2: error: Can't find plugin 'tmp/missing.py'
 [case testMissingPlugin]
 # flags: --config-file tmp/mypy.ini
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=missing
 [out]
 tmp/mypy.ini:2: error: Error importing plugin 'missing'
@@ -75,11 +75,11 @@ tmp/mypy.ini:2: error: Error importing plugin 'missing'
 [case testMultipleSectionsDefinePlugin]
 # flags: --config-file tmp/mypy.ini
 [file mypy.ini]
-[[acme]
+\[acme]
 plugins=acmeplugin
-[[mypy]
+\[mypy]
 plugins=missing.py
-[[another]
+\[another]
 plugins=another_plugin
 [out]
 tmp/mypy.ini:4: error: Can't find plugin 'tmp/missing.py'
@@ -88,7 +88,7 @@ tmp/mypy.ini:4: error: Can't find plugin 'tmp/missing.py'
 [case testInvalidPluginExtension]
 # flags: --config-file tmp/mypy.ini
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=dir/badext.pyi
 [file dir/badext.pyi]
 [out]
@@ -97,7 +97,7 @@ tmp/mypy.ini:2: error: Plugin 'badext.pyi' does not have a .py extension
 [case testMissingPluginEntryPoint]
 # flags: --config-file tmp/mypy.ini
 [file mypy.ini]
-[[mypy]
+\[mypy]
  plugins = <ROOT>/test-data/unit/plugins/noentry.py
 [out]
 tmp/mypy.ini:2: error: Plugin '<ROOT>/test-data/unit/plugins/noentry.py' does not define entry point function "plugin"
@@ -107,7 +107,7 @@ tmp/mypy.ini:2: error: Plugin '<ROOT>/test-data/unit/plugins/noentry.py' does no
 def f() -> str: ...
 reveal_type(f())  # N: Revealed type is 'builtins.int'
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/customentry.py:register
 
 [case testCustomPluginEntryPoint]
@@ -115,7 +115,7 @@ plugins=<ROOT>/test-data/unit/plugins/customentry.py:register
 def f() -> str: ...
 reveal_type(f())  # N: Revealed type is 'builtins.int'
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=customentry:register
 
 [case testInvalidPluginEntryPointReturnValue]
@@ -123,7 +123,7 @@ plugins=customentry:register
 def f(): pass
 f()
 [file mypy.ini]
-[[mypy]
+\[mypy]
 
 plugins=<ROOT>/test-data/unit/plugins/badreturn.py
 [out]
@@ -134,7 +134,7 @@ tmp/mypy.ini:3: error: Type object expected as the return value of "plugin"; got
 def f(): pass
 f()
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/badreturn2.py
 [out]
 tmp/mypy.ini:2: error: Return value of "plugin" must be a subclass of "mypy.plugin.Plugin" (in <ROOT>/test-data/unit/plugins/badreturn2.py)
@@ -157,7 +157,7 @@ class Signal(Generic[T]):
 
 class DerivedSignal(Signal[T]): ...
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/attrhook.py
 
 [case testAttributeHookPluginForDynamicClass]
@@ -182,7 +182,7 @@ class Magic:
 class DerivedMagic(Magic): ...
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/attrhook2.py
 
 [case testTypeAnalyzeHookPlugin]
@@ -200,7 +200,7 @@ T = TypeVar('T', bound=Callable[..., None])
 class Signal(Generic[T]):
     __call__: Callable[..., None]
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/type_anal_hook.py
 [builtins fixtures/dict.pyi]
 
@@ -237,7 +237,7 @@ class AttrInt(Attr[int]):
         pass
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/class_callable.py
 [builtins fixtures/bool.pyi]
 [out]
@@ -256,7 +256,7 @@ from typing import Callable
 def decorator1() -> Callable[..., Callable[..., int]]: pass
 def decorator2() -> Callable[..., Callable[..., int]]: pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/named_callable.py
 
 [case testFunctionMethodContextsHasArgNames]
@@ -284,7 +284,7 @@ def func(classname: str, arg1: Any, arg2: Any) -> Any:
     pass
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/arg_names.py
 [builtins fixtures/classmethod.pyi]
 
@@ -313,7 +313,7 @@ def func(classname: str, arg1: Any, arg2: Any) -> Any:
     pass
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/arg_names.py
 [builtins fixtures/classmethod.pyi]
 
@@ -335,7 +335,7 @@ class Outer:
             pass
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/arg_names.py
 
 [case testFunctionMethodContextsHasArgNamesUnfilledArguments]
@@ -358,7 +358,7 @@ def func_unfilled(classname: str, arg1: Any = None, arg2: Any = None) -> Any:
     pass
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/arg_names.py
 
 [case testFunctionMethodContextsHasArgNamesStarExpressions]
@@ -382,7 +382,7 @@ def func_star_expr(classname: str, *args, **kwargs) -> Any:
     pass
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/arg_names.py
 [builtins fixtures/dict.pyi]
 
@@ -406,7 +406,7 @@ class ClassChild(Base):
     pass
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/arg_names.py
 [builtins fixtures/classmethod.pyi]
 
@@ -435,7 +435,7 @@ for x in foo:
     reveal_type(x) # N: Revealed type is 'builtins.int*'
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/method_sig_hook.py
 
 [case testMethodSignatureHookNamesFullyQualified]
@@ -459,7 +459,7 @@ reveal_type(FullyQualifiedTestClass().instance_method()) # N: Revealed type is '
 reveal_type(FullyQualifiedTestNamedTuple('')._asdict()) # N: Revealed type is 'builtins.int'
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/fully_qualified_test_hook.py
 [builtins fixtures/classmethod.pyi]
 
@@ -486,7 +486,7 @@ class Column(Generic[T]): ...
 class Instr(Generic[T]): ...
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/dyn_class.py
 
 [case testDynamicClassPluginNegatives]
@@ -513,7 +513,7 @@ class Column(Generic[T]): ...
 class Instr(Generic[T]): ...
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/dyn_class.py
 
 [case testBaseClassPluginHookWorksIncremental]
@@ -539,7 +539,7 @@ from typing import Any
 def declarative_base() -> Any: ...
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 python_version=3.6
 plugins=<ROOT>/test-data/unit/plugins/common_api_incremental.py
 [out]
@@ -556,7 +556,7 @@ class Class:
 Class().method(1, *[2], **{'a': 1})  # E: [[0, 2], [4]]
 [builtins fixtures/dict.pyi]
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/arg_kinds.py
 
 [case testArgKindsFunction]
@@ -567,7 +567,7 @@ def func(*args, **kwargs):
 func(1, 2, [3, 4], *[5, 6, 7], **{'a': 1})  # E: [[0, 0, 0, 2], [4]]
 [builtins fixtures/dict.pyi]
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/arg_kinds.py
 
 [case testHookCallableInstance]
@@ -582,7 +582,7 @@ instance = Class(3.14)
 reveal_type(instance(2))  # N: Revealed type is 'builtins.float*'
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/callable_instance.py
 
 [case testGetMethodHooksOnUnions]
@@ -604,7 +604,7 @@ else:
 
 [builtins fixtures/isinstancelist.pyi]
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/union_method.py
 
 [case testGetMethodHooksOnUnionsStrictOptional]
@@ -626,7 +626,7 @@ else:
 
 [builtins fixtures/isinstancelist.pyi]
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/union_method.py
 
 [case testGetMethodHooksOnUnionsSpecial]
@@ -643,7 +643,7 @@ reveal_type(x[int()])  # N: Revealed type is 'builtins.int'
 
 [builtins fixtures/isinstancelist.pyi]
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/union_method.py
 
 [case testPluginDependencies]
@@ -656,12 +656,12 @@ plugins=<ROOT>/test-data/unit/plugins/union_method.py
 1 + 'lol'  # E: Unsupported operand types for + ("int" and "str")
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/depshook.py
 
 [case testCustomizeMroTrivial]
 # flags: --config-file tmp/mypy.ini
 class A: pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/customize_mro.py

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -472,9 +472,9 @@ def incomplete(x) -> int:
 def incomplete(x) -> int:  # E: Function is missing a type annotation for one or more arguments
     return 0
 [file mypy.ini]
-[[mypy]
+\[mypy]
 disallow_incomplete_defs = False
-[[mypy-incomplete]
+\[mypy-incomplete]
 disallow_incomplete_defs = True
 
 
@@ -492,9 +492,9 @@ if int():
     x = None  # E: Incompatible types in assignment (expression has type "None", variable has type "int")
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 strict_optional = False
-[[mypy-optional]
+\[mypy-optional]
 strict_optional = True
 
 
@@ -519,9 +519,9 @@ f(standard.an_int)  # ints can be used as ints
 f(standard.optional_int)  # E: Argument 1 to "f" has incompatible type "None"; expected "int"
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 strict_optional = False
-[[mypy-optional]
+\[mypy-optional]
 strict_optional = True
 
 
@@ -542,9 +542,9 @@ x = 0  # type: Optional[int]
 y = None  # type: None
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 strict_optional = False
-[[mypy-optional]
+\[mypy-optional]
 strict_optional = True
 
 [case testPerFileStrictOptionalListItemImportOptional]
@@ -565,9 +565,9 @@ x = []  # type: List[Optional[int]]
 y = []  # type: List[int]
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 strict_optional = False
-[[mypy-optional]
+\[mypy-optional]
 strict_optional = True
 [builtins fixtures/list.pyi]
 
@@ -591,9 +591,9 @@ def f(x: int = None) -> None: pass
 standard.f(None)
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 strict_optional = False
-[[mypy-optional]
+\[mypy-optional]
 strict_optional = True
 
 [case testDisallowImplicitTypesIgnoreMissingTypes]
@@ -1046,7 +1046,7 @@ if not YOLO:
 if BLAH:
     1+()
 [file mypy.ini]
-[[mypy]
+\[mypy]
 ignore_missing_imports = True
 always_true = YOLO1, YOLO
 always_false = BLAH, BLAH1
@@ -1129,9 +1129,9 @@ import b
 [file b.py]
 42 == 'no'
 [file mypy.ini]
-[[mypy]
+\[mypy]
 strict_equality = True
-[[mypy-b]
+\[mypy-b]
 strict_equality = False
 [builtins fixtures/bool.pyi]
 
@@ -1192,9 +1192,9 @@ a = 5
 from other_module_1 import a
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 implicit_reexport = True
-[[mypy-other_module_2]
+\[mypy-other_module_2]
 implicit_reexport = False
 [out]
 main:2: error: Module 'other_module_2' has no attribute 'a'

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1796,10 +1796,10 @@ reveal_type(a.x)
 [file a.py]
 x = 0
 [file mypy.ini]
-[[mypy]
+\[mypy]
 follow_imports = normal
 [file mypy.ini.2]
-[[mypy]
+\[mypy]
 follow_imports = skip
 [out1]
 main:3: note: Revealed type is 'builtins.int'
@@ -1972,9 +1972,9 @@ import a
 [file a.py]
 pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 warn_no_return = False
-[[mypy-a]
+\[mypy-a]
 warn_no_return = True
 [rechecked]
 
@@ -3606,10 +3606,10 @@ import a
 [file a.py]
 x = 0
 [file mypy.ini]
-[[mypy]
+\[mypy]
 cache_fine_grained = True
 [file mypy.ini.2]
-[[mypy]
+\[mypy]
 cache_fine_grained = False
 -- Nothing should get rechecked
 [rechecked]
@@ -3621,10 +3621,10 @@ import a
 [file a.py]
 x = 0
 [file mypy.ini]
-[[mypy]
+\[mypy]
 cache_fine_grained = False
 [file mypy.ini.2]
-[[mypy]
+\[mypy]
 cache_fine_grained = True
 [rechecked a, builtins, typing]
 [stale a, builtins, typing]
@@ -4586,7 +4586,7 @@ import other
 [file other.pyi.2]
 x = 1
 [file mypy.ini]
-[[mypy]
+\[mypy]
 follow_imports_for_stubs = True
 [stale]
 [rechecked]
@@ -4793,7 +4793,7 @@ def my_hook(ctx):
 def plugin(version):
     return MyPlugin
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=basic_plugin.py
 [out]
 [out2]
@@ -4844,7 +4844,7 @@ choice = True
 __version__ = 0.2
 choice = False
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=basic_plugin.py
 [out]
 [out2]
@@ -4883,10 +4883,10 @@ def plugin(version):
     return MyPlugin
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 python_version=3.6
 [file mypy.ini.2]
-[[mypy]
+\[mypy]
 python_version=3.6
 plugins=basic_plugin.py
 [out]
@@ -4926,11 +4926,11 @@ def plugin(version):
     return MyPlugin
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 python_version=3.6
 plugins=basic_plugin.py
 [file mypy.ini.2]
-[[mypy]
+\[mypy]
 python_version=3.6
 [out]
 [out2]

--- a/test-data/unit/check-modules-case.test
+++ b/test-data/unit/check-modules-case.test
@@ -19,7 +19,7 @@ reveal_type(x)  # N: Revealed type is 'builtins.int'
 x = 1
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 mypy_path = tmp/funky_case
 
 [case testPreferPackageOverFileCase]
@@ -31,7 +31,7 @@ import a
 pass
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 mypy_path = tmp/funky
 
 [case testNotPreferPackageOverFileCase]
@@ -50,7 +50,7 @@ x = 0
 [file yy/foo/bar.py]
 x = ''
 [file mypy.ini]
-[[mypy]
+\[mypy]
 mypy_path = tmp/xx, tmp/yy
 
 [case testClassicPackageInsideNamespacePackageCase]
@@ -65,5 +65,5 @@ x = 0
 [file yy/foo/bar/__init__.py]
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 mypy_path = TmP/xX, TmP/yY

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2383,8 +2383,8 @@ def __getattr__(attr: str) -> Any: ...
 # empty (i.e. complete subpackage)
 
 [file mypy.ini]
-[[mypy]
-[[mypy-a.b.c]
+\[mypy]
+\[mypy-a.b.c]
 ignore_missing_imports = True
 [builtins fixtures/module.pyi]
 [out]
@@ -2644,7 +2644,7 @@ y = 0
 [file foo/baz.py]
 z = 0
 [file mypy.ini]
-[[mypy]
+\[mypy]
 mypy_path = tmp/xx, tmp/yy
 
 [case testClassicPackageIgnoresEarlierNamespacePackage]
@@ -2657,7 +2657,7 @@ x = ''
 y = 0
 [file yy/foo/__init__.py]
 [file mypy.ini]
-[[mypy]
+\[mypy]
 mypy_path = tmp/xx, tmp/yy
 
 [case testNamespacePackagePickFirstOnMypyPath]
@@ -2669,7 +2669,7 @@ x = 0
 [file yy/foo/bar.py]
 x = ''
 [file mypy.ini]
-[[mypy]
+\[mypy]
 mypy_path = tmp/xx, tmp/yy
 
 [case testNamespacePackageInsideClassicPackage]
@@ -2682,7 +2682,7 @@ x = ''
 x = 0
 [file yy/foo/__init__.py]
 [file mypy.ini]
-[[mypy]
+\[mypy]
 mypy_path = tmp/xx, tmp/yy
 
 [case testClassicPackageInsideNamespacePackage]
@@ -2696,7 +2696,7 @@ x = ''
 x = 0
 [file yy/foo/bar/__init__.py]
 [file mypy.ini]
-[[mypy]
+\[mypy]
 mypy_path = tmp/xx, tmp/yy
 
 [case testNamespacePackagePlainImport]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1696,12 +1696,10 @@ y: C[str]  # E: Type argument "builtins.str" of "C" must be a subtype of "builti
 z: C[int]
 
 [file mypy.ini]
-[[mypy-a]
+\[mypy-a]
 strict_optional = True
-[[mypy-b]
+\[mypy-b]
 strict_optional = False
-
--- ]]
 
 [case testNewAnalyzerProperty]
 class A:

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -768,8 +768,8 @@ x = ["lol"]
 asdf(x)
 
 [file mypy.ini]
-[[mypy]
-[[mypy-a]
+\[mypy]
+\[mypy-a]
 strict_optional = False
 [out]
 main:4: error: Argument 1 to "asdf" has incompatible type "List[str]"; expected "List[Optional[str]]"

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -137,7 +137,7 @@ def f():
 [case testConfigFile]
 # cmd: mypy main.py
 [file mypy.ini]
-[[mypy]
+\[mypy]
 python_version = 2.7
 [file main.py]
 def f():
@@ -149,7 +149,7 @@ def f():
 [case testErrorContextConfig]
 # cmd: mypy main.py
 [file mypy.ini]
-[[mypy]
+\[mypy]
 show_error_context=True
 [file main.py]
 def f() -> None:
@@ -161,7 +161,7 @@ main.py:2: error: Unsupported operand types for + ("int" and "str")
 [case testAltConfigFile]
 # cmd: mypy --config-file config.ini main.py
 [file config.ini]
-[[mypy]
+\[mypy]
 python_version = 2.7
 [file main.py]
 def f():
@@ -173,7 +173,7 @@ def f():
 [case testNoConfigFile]
 # cmd: mypy main.py --config-file=
 [file mypy.ini]
-[[mypy]
+\[mypy]
 warn_unused_ignores = True
 [file main.py]
 # type: ignore
@@ -181,11 +181,11 @@ warn_unused_ignores = True
 [case testPerFileConfigSection]
 # cmd: mypy x.py y.py z.py
 [file mypy.ini]
-[[mypy]
+\[mypy]
 disallow_untyped_defs = True
-[[mypy-y]
+\[mypy-y]
 disallow_untyped_defs = False
-[[mypy-z]
+\[mypy-z]
 disallow_untyped_calls = True
 [file x.py]
 def f(a):
@@ -210,10 +210,10 @@ x.py:1: error: Function is missing a type annotation
 [case testPerFileConfigSectionMultipleMatchesDisallowed]
 # cmd: mypy xx.py xy.py yx.py yy.py
 [file mypy.ini]
-[[mypy]
-[[mypy-*x*]
+\[mypy]
+\[mypy-*x*]
 disallow_untyped_defs = True
-[[mypy-*y*]
+\[mypy-*y*]
 disallow_untyped_calls = True
 [file xx.py]
 def f(a): pass
@@ -235,8 +235,8 @@ mypy.ini: [mypy-*y*]: Patterns must be fully-qualified module names, optionally 
 [case testMultipleGlobConfigSection]
 # cmd: mypy x.py y.py z.py
 [file mypy.ini]
-[[mypy]
-[[mypy-x.*,z.*]
+\[mypy]
+\[mypy-x.*,z.*]
 disallow_untyped_defs = True
 [file x.py]
 def f(a): pass
@@ -258,7 +258,7 @@ mypy.ini: No [mypy] section in config file
 [case testConfigErrorUnknownFlag]
 # cmd: mypy -c pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 bad = 0
 [out]
 mypy.ini: [mypy]: Unrecognized option: bad = 0
@@ -267,7 +267,7 @@ mypy.ini: [mypy]: Unrecognized option: bad = 0
 [case testConfigErrorBadFlag]
 # cmd: mypy a.py
 [file mypy.ini]
-[[mypy]
+\[mypy]
 disallow-untyped-defs = True
 [file a.py]
 def f():
@@ -279,7 +279,7 @@ mypy.ini: [mypy]: Unrecognized option: disallow-untyped-defs = True
 [case testConfigErrorBadBoolean]
 # cmd: mypy -c pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 ignore_missing_imports = nah
 [out]
 mypy.ini: [mypy]: ignore_missing_imports: Not a boolean: nah
@@ -288,8 +288,8 @@ mypy.ini: [mypy]: ignore_missing_imports: Not a boolean: nah
 [case testConfigErrorNotPerFile]
 # cmd: mypy -c pass
 [file mypy.ini]
-[[mypy]
-[[mypy-*]
+\[mypy]
+\[mypy-*]
 python_version = 3.4
 [out]
 mypy.ini: [mypy-*]: Per-module sections should only specify per-module flags (python_version)
@@ -298,7 +298,7 @@ mypy.ini: [mypy-*]: Per-module sections should only specify per-module flags (py
 [case testConfigMypyPath]
 # cmd: mypy file.py
 [file mypy.ini]
-[[mypy]
+\[mypy]
 mypy_path =
     foo:bar
     , baz
@@ -323,8 +323,8 @@ file.py:6: error: Argument 1 to "foo" has incompatible type "str"; expected "int
 [case testIgnoreErrorsConfig]
 # cmd: mypy x.py y.py
 [file mypy.ini]
-[[mypy]
-[[mypy-x]
+\[mypy]
+\[mypy-x]
 ignore_errors = True
 [file x.py]
 "" + 0
@@ -345,7 +345,7 @@ a.x + ''  # E
 a.y  # E
 a + 0  # E
 [file mypy.ini]
-[[mypy]
+\[mypy]
 follow_imports = normal
 [file a.py]
 x = 0
@@ -367,7 +367,7 @@ a.x + ''
 a.y
 a + 0
 [file mypy.ini]
-[[mypy]
+\[mypy]
 follow_imports = silent
 [file a.py]
 x = 0
@@ -386,7 +386,7 @@ reveal_type(x)  # Expect Any
 import a
 reveal_type(a.x)  # Expect Any
 [file mypy.ini]
-[[mypy]
+\[mypy]
 follow_imports = skip
 [file a.py]
 /  # No error reported
@@ -402,7 +402,7 @@ reveal_type(x)  # Expect Any
 import a  # Error reported here
 reveal_type(a.x)  # Expect Any
 [file mypy.ini]
-[[mypy]
+\[mypy]
 follow_imports = error
 [file a.py]
 /  # No error reported
@@ -415,14 +415,14 @@ main.py:4: note: Revealed type is 'Any'
 [case testConfigFollowImportsSelective]
 # cmd: mypy main.py
 [file mypy.ini]
-[[mypy]
-[[mypy-normal]
+\[mypy]
+\[mypy-normal]
 follow_imports = normal
-[[mypy-silent]
+\[mypy-silent]
 follow_imports = silent
-[[mypy-skip]
+\[mypy-skip]
 follow_imports = skip
-[[mypy-error]
+\[mypy-error]
 follow_imports = error
 [file main.py]
 import normal
@@ -458,7 +458,7 @@ main.py:8: note: Revealed type is 'Any'
 import missing  # Expect error here
 reveal_type(missing.x)  # Expect Any
 [file mypy.ini]
-[[mypy]
+\[mypy]
 ignore_missing_imports = False
 [out]
 main.py:1: error: Cannot find module named 'missing'
@@ -471,7 +471,7 @@ main.py:2: note: Revealed type is 'Any'
 import missing  # No error here
 reveal_type(missing.x)  # Expect Any
 [file mypy.ini]
-[[mypy]
+\[mypy]
 ignore_missing_imports = True
 [out]
 main.py:2: note: Revealed type is 'Any'
@@ -479,8 +479,8 @@ main.py:2: note: Revealed type is 'Any'
 [case testConfigNoErrorForUnknownXFlagInSubsection]
 # cmd: mypy -c pass
 [file mypy.ini]
-[[mypy]
-[[mypy-foo]
+\[mypy]
+\[mypy-foo]
 x_bad = 0
 [out]
 
@@ -515,7 +515,7 @@ main.py:1: error: Cannot find module named 'a'
 [case testPythonVersionTooOld10]
 # cmd: mypy -c pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 python_version = 1.0
 [out]
 mypy.ini: [mypy]: python_version: Python major version '1' out of range (must be 2 or 3)
@@ -524,7 +524,7 @@ mypy.ini: [mypy]: python_version: Python major version '1' out of range (must be
 [case testPythonVersionTooOld26]
 # cmd: mypy -c pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 python_version = 2.6
 [out]
 mypy.ini: [mypy]: python_version: Python 2.6 is not supported (must be 2.7)
@@ -533,7 +533,7 @@ mypy.ini: [mypy]: python_version: Python 2.6 is not supported (must be 2.7)
 [case testPythonVersionTooOld33]
 # cmd: mypy -c pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 python_version = 3.3
 [out]
 mypy.ini: [mypy]: python_version: Python 3.3 is not supported (must be 3.4 or higher)
@@ -542,7 +542,7 @@ mypy.ini: [mypy]: python_version: Python 3.3 is not supported (must be 3.4 or hi
 [case testPythonVersionTooNew28]
 # cmd: mypy -c pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 python_version = 2.8
 [out]
 mypy.ini: [mypy]: python_version: Python 2.8 is not supported (must be 2.7)
@@ -551,7 +551,7 @@ mypy.ini: [mypy]: python_version: Python 2.8 is not supported (must be 2.7)
 [case testPythonVersionTooNew40]
 # cmd: mypy -c pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 python_version = 4.0
 [out]
 mypy.ini: [mypy]: python_version: Python major version '4' out of range (must be 2 or 3)
@@ -560,28 +560,28 @@ mypy.ini: [mypy]: python_version: Python major version '4' out of range (must be
 [case testPythonVersionAccepted27]
 # cmd: mypy -c pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 python_version = 2.7
 [out]
 
 [case testPythonVersionAccepted34]
 # cmd: mypy -c pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 python_version = 3.4
 [out]
 
 [case testPythonVersionAccepted36]
 # cmd: mypy -c pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 python_version = 3.6
 [out]
 
 [case testDisallowAnyUnimported]
 # cmd: mypy main.py
 [file mypy.ini]
-[[mypy]
+\[mypy]
 disallow_any_unimported = True
 ignore_missing_imports = True
 [file main.py]
@@ -594,8 +594,8 @@ main.py:3: error: Argument 1 to "f" becomes "Any" due to an unfollowed import
 [case testDisallowAnyExplicitDefSignature]
 # cmd: mypy m.py
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -619,8 +619,8 @@ m.py:9: error: Explicit "Any" is not allowed
 # cmd: mypy --python-version=3.6 m.py
 
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -639,8 +639,8 @@ m.py:5: error: Explicit "Any" is not allowed
 # cmd: mypy --python-version=3.6 m.py
 
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -653,8 +653,8 @@ m.py:2: error: Explicit "Any" is not allowed
 # cmd: mypy m.py
 
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -673,8 +673,8 @@ m.py:6: error: Explicit "Any" is not allowed
 # cmd: mypy m.py
 
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -695,8 +695,8 @@ m.py:4: error: Explicit "Any" is not allowed
 # cmd: mypy m.py
 
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -720,8 +720,8 @@ m.py:10: error: Explicit "Any" is not allowed
 # cmd: mypy m.py
 
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -738,8 +738,8 @@ m.py:5: error: Explicit "Any" is not allowed
 # cmd: mypy m.py
 
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -755,8 +755,8 @@ m.py:3: error: Explicit "Any" is not allowed
 # cmd: mypy m.py
 
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -770,8 +770,8 @@ m.py:3: error: Explicit "Any" is not allowed
 # cmd: mypy m.py
 
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -788,8 +788,8 @@ m.py:4: error: Explicit "Any" is not allowed
 # cmd: mypy m.py
 
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -806,8 +806,8 @@ m.py:4: error: Explicit "Any" is not allowed
 # cmd: mypy m.py
 
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_explicit = True
 
 [file m.py]
@@ -822,8 +822,8 @@ m.py:4: error: Explicit "Any" is not allowed
 [case testDisallowAnyGenericsTupleNoTypeParams]
 # cmd: mypy --python-version=3.6 m.py
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_generics = True
 
 [file m.py]
@@ -843,8 +843,8 @@ m.py:8: error: Missing type parameters for generic type "Tuple"
 [case testDisallowAnyGenericsTupleWithNoTypeParamsGeneric]
 # cmd: mypy m.py
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_generics = True
 
 [file m.py]
@@ -858,8 +858,8 @@ m.py:3: error: Missing type parameters for generic type "Tuple"
 [case testDisallowAnyGenericsTypeType]
 # cmd: mypy --python-version=3.6 m.py
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_generics = True
 
 [file m.py]
@@ -878,8 +878,8 @@ m.py:8: error: Missing type parameters for generic type "Type"
 [case testDisallowAnyGenericsAliasGenericType]
 # cmd: mypy m.py
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_generics = True
 
 [file m.py]
@@ -895,8 +895,8 @@ m.py:5: error: Missing type parameters for generic type "L"
 [case testDisallowAnyGenericsGenericAlias]
 # cmd: mypy --python-version=3.6 m.py
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_generics = True
 
 [file m.py]
@@ -919,8 +919,8 @@ m.py:11: error: Missing type parameters for generic type "A"
 [case testDisallowAnyGenericsPlainList]
 # cmd: mypy --python-version=3.6 m.py
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_generics = True
 
 [file m.py]
@@ -943,8 +943,8 @@ m.py:9: error: Missing type parameters for generic type "List"
 [case testDisallowAnyGenericsCustomGenericClass]
 # cmd: mypy --python-version=3.6 m.py
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_generics = True
 
 [file m.py]
@@ -966,8 +966,8 @@ m.py:10: error: Missing type parameters for generic type "G"
 [case testDisallowAnyGenericsBuiltinCollections]
 # cmd: mypy m.py
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_generics = True
 
 [file m.py]
@@ -988,8 +988,8 @@ m.py:7: error: Implicit generic "Any". Use "typing.FrozenSet" and specify generi
 [case testDisallowAnyGenericsTypingCollections]
 # cmd: mypy m.py
 [file mypy.ini]
-[[mypy]
-[[mypy-m]
+\[mypy]
+\[mypy-m]
 disallow_any_generics = True
 
 [file m.py]
@@ -1010,9 +1010,9 @@ m.py:7: error: Missing type parameters for generic type "FrozenSet"
 [case testDisallowSubclassingAny]
 # cmd: mypy m.py y.py
 [file mypy.ini]
-[[mypy]
+\[mypy]
 disallow_subclassing_any = True
-[[mypy-m]
+\[mypy-m]
 disallow_subclassing_any = False
 
 [file m.py]
@@ -1046,21 +1046,21 @@ from typing import List
 def g(x: List) -> None: pass
 g(None)
 [file mypy.ini]
-[[mypy]
+\[mypy]
 allow_any_generics = True
-[[mypy-a.*]
+\[mypy-a.*]
 ignore_errors = True
-[[mypy-a.b.*]
+\[mypy-a.b.*]
 disallow_any_generics = True
 ignore_errors = True
-[[mypy-a.b.c.*]
+\[mypy-a.b.c.*]
 ignore_errors = True
-[[mypy-a.b.c.d.*]
+\[mypy-a.b.c.d.*]
 ignore_errors = True
-[[mypy-a.b.c.d.e.*]
+\[mypy-a.b.c.d.e.*]
 ignore_errors = True
 strict_optional = True
-[[mypy-a.b.c.d.e]
+\[mypy-a.b.c.d.e]
 ignore_errors = False
 [out]
 a/b/c/d/e/__init__.py:2: error: Missing type parameters for generic type "List"
@@ -1069,7 +1069,7 @@ a/b/c/d/e/__init__.py:3: error: Argument 1 to "g" has incompatible type "None"; 
 [case testDisallowUntypedDefsAndGenerics]
 # cmd: mypy a.py
 [file mypy.ini]
-[[mypy]
+\[mypy]
 disallow_untyped_defs = True
 disallow_any_generics = True
 [file a.py]
@@ -1127,7 +1127,7 @@ c.py:2: error: Argument 1 to "bar" has incompatible type "str"; expected "int"
 [case testSrcPEP420Packages]
 # cmd: mypy -p anamespace --namespace-packages
 [file mypy.ini]
-[[mypy]]
+\[mypy]]
 mypy_path = src
 [file src/setup.cfg]
 [file src/anamespace/foo/__init__.py]
@@ -1140,8 +1140,8 @@ src/anamespace/foo/bar.py:2: error: Incompatible return value type (got "int", e
 [case testFollowImportStubs1]
 # cmd: mypy main.py
 [file mypy.ini]
-[[mypy]
-[[mypy-math.*]
+\[mypy]
+\[mypy-math.*]
 follow_imports = error
 follow_imports_for_stubs = True
 [file main.py]
@@ -1154,8 +1154,8 @@ main.py:1: note: (Using --follow-imports=error, module not passed on command lin
 [case testFollowImportStubs2]
 # cmd: mypy main.py
 [file mypy.ini]
-[[mypy]
-[[mypy-math.*]
+\[mypy]
+\[mypy-math.*]
 follow_imports = skip
 follow_imports_for_stubs = True
 [file main.py]
@@ -1204,23 +1204,23 @@ s1.py:2: error: Incompatible return value type (got "int", expected "str")
 [case testConfigWarnUnusedSection1]
 # cmd: mypy foo.py quux.py spam/eggs.py
 [file mypy.ini]
-[[mypy]
+\[mypy]
 warn_unused_configs = True
 incremental = False
-[[mypy-bar]
-[[mypy-foo]
-[[mypy-baz.*]
-[[mypy-quux.*]
-[[mypy-spam.*]
-[[mypy-spam.eggs]
-[[mypy-emarg.*]
-[[mypy-emarg.hatch]
+\[mypy-bar]
+\[mypy-foo]
+\[mypy-baz.*]
+\[mypy-quux.*]
+\[mypy-spam.*]
+\[mypy-spam.eggs]
+\[mypy-emarg.*]
+\[mypy-emarg.hatch]
 -- Currently we don't treat an unstructured pattern like a.*.b as unused
 -- if it matches another section (like a.x.b). This would be reasonable
 -- to change. '
-[[mypy-a.*.b]
-[[mypy-a.*.c]
-[[mypy-a.x.b]
+\[mypy-a.*.b]
+\[mypy-a.*.c]
+\[mypy-a.x.b]
 [file foo.py]
 [file quux.py]
 [file spam/__init__.py]
@@ -1232,15 +1232,15 @@ Warning: unused section(s) in mypy.ini: [mypy-bar], [mypy-baz.*], [mypy-emarg.*]
 [case testConfigUnstructuredGlob]
 # cmd: mypy emarg foo
 [file mypy.ini]
-[[mypy]
+\[mypy]
 ignore_errors = true
-[[mypy-*.lol]
+\[mypy-*.lol]
 ignore_errors = false
-[[mypy-emarg.*]
+\[mypy-emarg.*]
 ignore_errors = false
-[[mypy-emarg.*.villip.*]
+\[mypy-emarg.*.villip.*]
 ignore_errors = true
-[[mypy-emarg.hatch.villip.mankangulisk]
+\[mypy-emarg.hatch.villip.mankangulisk]
 ignore_errors = false
 [file emarg/__init__.py]
 [file emarg/foo.py]
@@ -1299,7 +1299,7 @@ import d
 [case testIniFiles]
 # cmd: mypy
 [file mypy.ini]
-[[mypy]
+\[mypy]
 files = a.py, b.py
 [file a.py]
 fail
@@ -1312,7 +1312,7 @@ a.py:1: error: Name 'fail' is not defined
 [case testIniFilesGlobbing]
 # cmd: mypy
 [file mypy.ini]
-[[mypy]
+\[mypy]
 files = **/*.py
 [file a/b.py]
 fail
@@ -1325,7 +1325,7 @@ c.py:1: error: Name 'fail' is not defined
 [case testIniFilesCmdlineOverridesConfig]
 # cmd: mypy override.py
 [file mypy.ini]
-[[mypy]
+\[mypy]
 files = config.py
 [out]
 mypy: can't read file 'override.py': No such file or directory

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -89,7 +89,7 @@ Daemon started
 $ dmypy stop
 Daemon stopped
 [file mypy.ini]
-[[mypy]
+\[mypy]
 follow_imports = error
 plugins = plug.py
 [file foo.py]

--- a/test-data/unit/diff.test
+++ b/test-data/unit/diff.test
@@ -1139,7 +1139,7 @@ class Column(Generic[T]): ...
 class Instr(Generic[T]): ...
 
 [file mypy.ini]
-[[mypy]
+\[mypy]
 plugins=<ROOT>/test-data/unit/plugins/dyn_class.py
 [out]
 __main__.Diff

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -2111,7 +2111,7 @@ import other
 [file other.pyi.2]
 x = 1
 [file mypy.ini]
-[[mypy]
+\[mypy]
 follow_imports_for_stubs = True
 [stale]
 [rechecked]

--- a/test-data/unit/fine-grained-suggest.test
+++ b/test-data/unit/fine-grained-suggest.test
@@ -706,7 +706,7 @@ class Out:
 x: Out.In
 x.method(x)
 [out]
-[[{"func_name": "Out.In.method", "line": 3, "path": "tmp/foo.py", "samples": 0, "signature": {"arg_types": ["foo:Out.In"], "return_type": "foo.Out"}}]
+\[{"func_name": "Out.In.method", "line": 3, "path": "tmp/foo.py", "samples": 0, "signature": {"arg_types": ["foo:Out.In"], "return_type": "foo.Out"}}]
 ==
 
 [case testSuggestColonNonPackageDir]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -4574,9 +4574,9 @@ main:7: error: Argument 1 to "g" of "B" has incompatible type "Optional[int]"; e
 [case testPerFileStrictOptionalModule]
 import a
 [file mypy.ini]
-[[mypy]
+\[mypy]
 strict_optional = False
-[[mypy-a.*]
+\[mypy-a.*]
 strict_optional = True
 [file a.py]
 from typing import Optional
@@ -4604,9 +4604,9 @@ a.py:4: error: Incompatible types in assignment (expression has type "Optional[i
 [case testPerFileStrictOptionalModuleOnly]
 import a
 [file mypy.ini]
-[[mypy]
+\[mypy]
 strict_optional = False
-[[mypy-a.*]
+\[mypy-a.*]
 strict_optional = True
 [file a.py]
 from typing import Optional
@@ -4650,9 +4650,9 @@ a.py:3: error: Incompatible types in assignment (expression has type "Optional[i
 [case testPerFileStrictOptionalFunction]
 import a
 [file mypy.ini]
-[[mypy]
+\[mypy]
 strict_optional = False
-[[mypy-b.*]
+\[mypy-b.*]
 strict_optional = True
 [file a.py]
 from typing import Optional
@@ -4686,9 +4686,9 @@ b.py:4: error: Argument 1 to "h" has incompatible type "Optional[int]"; expected
 [case testPerFileStrictOptionalMethod]
 import a
 [file mypy.ini]
-[[mypy]
+\[mypy]
 strict_optional = False
-[[mypy-b.*]
+\[mypy-b.*]
 strict_optional = True
 [file a.py]
 from typing import Optional
@@ -7705,8 +7705,8 @@ def f() -> str: return '0'
 
 [case testRefreshIgnoreErrors1]
 [file mypy.ini]
-[[mypy]
-[[mypy-b]
+\[mypy]
+\[mypy-b]
 ignore_errors = True
 [file a.py]
 y = '1'
@@ -7722,8 +7722,8 @@ def fu() -> None:
 
 [case testRefreshIgnoreErrors2]
 [file mypy.ini]
-[[mypy]
-[[mypy-b]
+\[mypy]
+\[mypy-b]
 ignore_errors = True
 [file b.py]
 def fu() -> int:
@@ -7738,9 +7738,9 @@ def fu() -> int:
 
 [case testRefreshOptions]
 [file mypy.ini]
-[[mypy]
+\[mypy]
 disallow_any_generics = True
-[[mypy-b]
+\[mypy-b]
 disallow_any_generics = False
 [file a.py]
 y = '1'

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -21,12 +21,11 @@ print(list(reversed([1,2,3])))
 print(list(reversed('abc')))
 print(list(reversed(A())))
 [out]
--- Duplicate [ at line beginning.
-[[4, 3, 2, 1, 0]
-[[3, 2, 1]
-[['c', 'b', 'a']
-[['f', 'o', 'o']
--- ]]]]]
+-- Escape bracket at line beginning
+\[4, 3, 2, 1, 0]
+\[3, 2, 1]
+\['c', 'b', 'a']
+\['f', 'o', 'o']
 
 [case testIntAndFloatConversion]
 from typing import SupportsInt, SupportsFloat
@@ -90,8 +89,7 @@ x2
 import typing
 print(list.__add__([1, 2], [3, 4]))
 [out]
-[[1, 2, 3, 4]
--- ]
+\[1, 2, 3, 4]
 
 [case testInheritedClassAttribute]
 import typing

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -5,7 +5,7 @@
 [case testConfigErrorUnknownReport]
 # cmd: mypy -c pass
 [file mypy.ini]
-[[mypy]
+\[mypy]
 bad_report = .
 [out]
 mypy.ini: [mypy]: Unrecognized report type: bad_report


### PR DESCRIPTION
The main motivation here (though I also just like it more) is that
editor indentation modes won't get confused by unnested brackets when
editing test files in python-mode, which I do all the time.