### PR TITLE
[suggest] Use realpath to canonicalize path in test

### DIFF
--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -290,7 +290,7 @@ class FineGrainedSuite(DataSuite):
             if json:
                 # JSON contains already escaped \ on Windows, so requires a bit of care.
                 val = val.replace('\\\\', '\\')
-                val = val.replace(tmp_dir + os.path.sep, '')
+                val = val.replace(os.path.realpath(tmp_dir) + os.path.sep, '')
             output.extend(val.strip().split('\n'))
         return normalize_messages(output)
 


### PR DESCRIPTION
The tmp_dir we computed and the real path that was showing up in
the output didn't match on OS X in the testSuggestColonMethodJSON
test. Use realpath to fix the issue.