### PR TITLE
Fix aststrip deletion crash

### DIFF
--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -219,7 +219,8 @@ class NodeStripVisitor(TraverserVisitor):
                 # true for a MemberExpr, we know that it must be an assignment through
                 # self, since only those can define new attributes.
                 assert self.type is not None
-                del self.type.names[lvalue.name]
+                if lvalue.name in self.type.names:
+                    del self.type.names[lvalue.name]
                 key = (self.type.defn, lvalue.name)
                 if key in self.saved_class_attrs:
                     del self.saved_class_attrs[key]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -9202,3 +9202,25 @@ class A: # type: ignore
 
 [out]
 ==
+
+[case testAddAttributeThroughNewBaseClass]
+import a
+
+[file a.py]
+class C:
+    def __init__(self) -> None:
+        self.x = 0
+
+[file a.py.2]
+from b import B
+
+class C(B):
+    def __init__(self) -> None:
+        self.x = 0
+
+[file b.py.2]
+class B:
+    def __init__(self) -> None:
+        self.x = 0
+[out]
+==


### PR DESCRIPTION
Only delete from self.type.names if the key is actually in there.
I've included one test case that this fixes, though I suspect there
are others. Fixes #7238.