### PR TITLE
Switch ret. type of asyncio.gather() to list

### DIFF
--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1138,7 +1138,7 @@ reveal_type(asyncio.gather(*[asyncio.sleep(1), asyncio.sleep(1)]))
 [out]
 _testAsyncioGatherPreciseType.py:9: note: Revealed type is 'builtins.str'
 _testAsyncioGatherPreciseType.py:10: note: Revealed type is 'builtins.str'
-_testAsyncioGatherPreciseType.py:11: note: Revealed type is 'asyncio.futures.Future[builtins.tuple[Any]]'
+_testAsyncioGatherPreciseType.py:11: note: Revealed type is 'asyncio.futures.Future[builtins.list[Any]]'
 
 [case testMultipleInheritanceWorksWithTupleTypeGeneric]
 from typing import SupportsAbs, NamedTuple


### PR DESCRIPTION
This is a companion commit dependent on the change
introduced in typeshed PR 3248:

https://github.com/python/typeshed/pull/3248