### PR TITLE
Replace assert with warning

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -310,7 +310,11 @@ class Errors:
         self.add_error_info(info)
 
     def _add_error_info(self, file: str, info: ErrorInfo) -> None:
-        assert file not in self.flushed_files
+        if file in self.flushed_files:
+            self.report(info.line, None,
+                        "Trying to report an error in a file that has already been flushed."
+                        " Skipping...", severity='warning', file=file, only_once=True)
+            return
         if file not in self.error_info_map:
             self.error_info_map[file] = []
         self.error_info_map[file].append(info)


### PR DESCRIPTION
Addresses issue https://github.com/python/mypy/issues/7510 (along with a few others that have a different root cause. The conclusion from the discussion was that if we check the same file twice, something is probably weird, but mypy shouldn't crash.

I still need to add a test for this, but I didn't see a test file corresponding to this one. Suggestions on where to add it?