### PR TITLE
Fix some notes not being ignored when using an error code

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1472,8 +1472,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                  callable_name=callable_name,
                                  object_type=object_type)
         if union_interrupted:
-            self.chk.msg.note("Not all union combinations were tried"
-                              " because there are too many unions", context)
+            self.chk.fail("Not all union combinations were tried"
+                          " because there are too many unions", context)
         return result
 
     def plausible_overload_call_targets(self,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -926,7 +926,7 @@ class MessageBuilder:
                   'of signature {}'.format(index), context)
 
     def warn_both_operands_are_from_unions(self, context: Context) -> None:
-        self.note('Both left and right operands are unions', context)
+        self.note('Both left and right operands are unions', context, code=codes.OPERATOR)
 
     def warn_operand_was_from_union(self, side: str, original: Type, context: Context) -> None:
         self.note('{} operand is of type {}'.format(side, format_type(original)), context)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -929,7 +929,8 @@ class MessageBuilder:
         self.note('Both left and right operands are unions', context, code=codes.OPERATOR)
 
     def warn_operand_was_from_union(self, side: str, original: Type, context: Context) -> None:
-        self.note('{} operand is of type {}'.format(side, format_type(original)), context)
+        self.note('{} operand is of type {}'.format(side, format_type(original)), context,
+                  code=codes.OPERATOR)
 
     def operator_method_signatures_overlap(
             self, reverse_class: TypeInfo, reverse_method: str, forward_class: Type,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -575,7 +575,7 @@ class MessageBuilder:
             if not fname:  # an alias to function with a different name
                 fname = 'Called function'
             self.note('{} defined here'.format(fname), callee.definition,
-                      file=module.path, origin=context)
+                      file=module.path, origin=context, code=codes.CALL_ARG)
 
     def duplicate_argument_value(self, callee: CallableType, index: int,
                                  context: Context) -> None:

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -628,3 +628,5 @@ class Bar:
 a: Union[Foo, Bar]
 
 a + a  # type: ignore[operator]
+a + Foo()  # type: ignore[operator]
+Foo() + a  # type: ignore[operator]

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -1,4 +1,4 @@
--- Tests for error codes
+-- Tests for error codes and ignoring errors using error codes
 --
 -- These implicitly use --show-error-codes.
 
@@ -607,3 +607,9 @@ class A:
 def g(self: A) -> None: pass
 
 A.f = g  # E: Cannot assign to a method  [assignment]
+
+[case testErrorCodeDefinedHereNoteIgnore]
+import m
+m.f(kw=1)  # type: ignore[call-arg]
+[file m.py]
+def f() -> None: pass

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -613,3 +613,18 @@ import m
 m.f(kw=1)  # type: ignore[call-arg]
 [file m.py]
 def f() -> None: pass
+
+[case testErrorCodeUnionNoteIgnore]
+from typing import Union
+
+class Foo:
+    def __add__(self, x: Foo) -> Foo: pass
+    def __radd__(self, x: Foo) -> Foo: pass
+
+class Bar:
+    def __add__(self, x: Bar) -> Bar: pass
+    def __radd__(self, x: Bar) -> Bar: pass
+
+a: Union[Foo, Bar]
+
+a + a  # type: ignore[operator]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4563,7 +4563,7 @@ def f(*args):
 x: Union[int, str]
 f(x, x, x, x, x, x, x, x)
 [out]
-main:11: note: Not all union combinations were tried because there are too many unions
+main:11: error: Not all union combinations were tried because there are too many unions
 main:11: error: Argument 1 to "f" has incompatible type "Union[int, str]"; expected "int"
 main:11: error: Argument 2 to "f" has incompatible type "Union[int, str]"; expected "int"
 main:11: error: Argument 3 to "f" has incompatible type "Union[int, str]"; expected "int"


### PR DESCRIPTION
Either change the error code to match the related error, so that
both will always be ignored at the same time, or switch a note to
an error (in case the relevant error code is hard to predict).

Fixes #7562.