### PR TITLE
Fix #7570: Include mypyc/lib-rt in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ recursive-include extensions *
 recursive-include docs *
 recursive-include mypy/typeshed *.py *.pyi
 recursive-include mypy/xml *.xsd *.xslt *.css
+recursive-include mypyc/lib-rt *.c *.h
 include mypy_bootstrap.ini
 include mypy_self_check.ini
 include LICENSE


### PR DESCRIPTION
Adds mypyc/lib-rt to MANIFEST.in so that it gets included in source distributions for building with mypyc.

Verified by:
* applying this change to the v0.730 tag
* running `python setup.py sdist` to generate `mypy-0.730.tar.gz`
* creating and activating a fresh venv via `python3.7 -m venv`
* extracting the tarball
* running `pip install -U pip mypy_extensions typing_extensions typed_ast`
* running `MYPY_USE_MYPYC=1 python setup.py bdist_wheel`
