### PR TITLE
Notify client on all dmypy crashes

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -175,6 +175,7 @@ class Server:
 
         self.fscache = FileSystemCache()
 
+        options.raise_exceptions = True
         options.incremental = True
         options.fine_grained_incremental = True
         options.show_traceback = True


### PR DESCRIPTION
This is done by setting the raise_exceptions option, which will cause
the exception to continue to be propagated.
Closes #4804.

Tested by introducing a crash in the parser and verifying the message
came through.