### PR TITLE
Fix spurious errors in inherited dataclasses in incremental mode

### DIFF
--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -315,7 +315,7 @@ def _analyze_class(ctx: 'mypy.plugin.ClassDefContext',
 
         # If the issue comes from merging different classes, report it
         # at the class definition point.
-        context = attribute.context if i > len(super_attrs) else ctx.cls
+        context = attribute.context if i >= len(super_attrs) else ctx.cls
 
         if not attribute.has_default and last_default:
             ctx.api.fail(

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -304,7 +304,7 @@ def _analyze_class(ctx: 'mypy.plugin.ClassDefContext',
     last_default = False
     last_kw_only = False
 
-    for attribute in attributes:
+    for i, attribute in enumerate(attributes):
         if not attribute.init:
             continue
 
@@ -313,14 +313,18 @@ def _analyze_class(ctx: 'mypy.plugin.ClassDefContext',
             last_kw_only = True
             continue
 
+        # If the issue comes from merging different classes, report it
+        # at the class definition point.
+        context = attribute.context if i > len(super_attrs) else ctx.cls
+
         if not attribute.has_default and last_default:
             ctx.api.fail(
                 "Non-default attributes not allowed after default attributes.",
-                attribute.context)
+                context)
         if last_kw_only:
             ctx.api.fail(
                 "Non keyword-only attributes are not allowed after a keyword-only attribute.",
-                attribute.context
+                context
             )
         last_default |= attribute.has_default
 

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -1,7 +1,5 @@
 """Plugin that provides support for dataclasses."""
 
-from collections import OrderedDict
-
 from typing import Dict, List, Set, Tuple, Optional
 from typing_extensions import Final
 

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -325,14 +325,14 @@ class DataclassTransformer:
         # Ensure that arguments without a default don't follow
         # arguments that have a default.
         found_default = False
-        for i, attr in enumerate(all_attrs):
+        for attr in all_attrs:
             # If we find any attribute that is_in_init but that
             # doesn't have a default after one that does have one,
             # then that's an error.
             if found_default and attr.is_in_init and not attr.has_default:
                 # If the issue comes from merging different classes, report it
                 # at the class definition point.
-                context = (Context(line=attr.line, column=attr.column) if i > len(super_attrs)
+                context = (Context(line=attr.line, column=attr.column) if attr in attrs
                            else ctx.cls)
                 ctx.api.fail(
                     'Attributes without a default cannot follow attributes with one',

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1169,3 +1169,27 @@ C('no')  # E: Argument 1 to "C" has incompatible type "str"; expected "int"
 [file other.py]
 import lib
 [builtins fixtures/bool.pyi]
+
+[case testAttrsDefaultsMroOtherFile]
+import a
+
+[file a.py]
+import attr
+from b import A1, A2
+
+@attr.s
+class Asdf(A1, A2):  # E: Non-default attributes not allowed after default attributes.
+    pass
+
+[file b.py]
+import attr
+
+@attr.s
+class A1:
+    a: str = attr.ib('test')
+
+@attr.s
+class A2:
+    b: int = attr.ib()
+
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -746,3 +746,64 @@ class C(B):
 
 a = C(None, 'abc')
 [builtins fixtures/bool.pyi]
+
+[case testDataclassesDefaultsIncremental]
+# flags: --python-version 3.6
+import a
+
+[file a.py]
+from dataclasses import dataclass
+from b import Person
+
+@dataclass
+class Asdf(Person):
+    c: str = 'test'
+
+[file a.py.2]
+from dataclasses import dataclass
+from b import Person
+
+@dataclass
+class Asdf(Person):
+    c: str = 'test'
+
+# asdf
+
+[file b.py]
+from dataclasses import dataclass
+
+@dataclass
+class Person:
+    b: int
+    a: str = 'test'
+
+[builtins fixtures/list.pyi]
+
+[case testDataclassesDefaultsMroOtherFile]
+# flags: --python-version 3.6
+import a
+
+[file a.py]
+from dataclasses import dataclass
+from b import A1, A2
+
+@dataclass
+class Asdf(A1, A2):  # E: Attributes without a default cannot follow attributes with one
+    pass
+
+[file b.py]
+from dataclasses import dataclass
+
+# a bunch of blank lines to make sure the error doesn't accidentally line up...
+
+
+
+@dataclass
+class A1:
+    a: int
+
+@dataclass
+class A2:
+    b: str = 'test'
+
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
The dataclasses plugin incorrectly expected json to preserve
the ordering of its dictionaries, which led to spurious errors
about "Attributes without a default cannot follow attributes with one".

Worse, the errors are reported in the wrong file: they use the line
number of the attribute but the file of the dataclass being checked!

Fix the spurious error by serializing attributes in a list, since we
care about the order.

Reporting this error for attributes in parent classes is actually
useful, since multiple inheritance can cause this error. Report the
error at the class definition site causing the problem instead.
(The error message here could certainly be improved, but right
now I just want to fix the "wrong file" bugs, which are I think
the worst kind of bugs after crashes.)