### PR TITLE
Replace hardcoded links with intersphinx refs in docs

### DIFF
--- a/docs/source/additional_features.rst
+++ b/docs/source/additional_features.rst
@@ -9,9 +9,10 @@ of the previous sections.
 Dataclasses
 ***********
 
-In Python 3.7, a new ``dataclasses`` module has been added to the standard library.
+In Python 3.7, a new :py:mod:`dataclasses` module has been added to the standard library.
 This module allows defining and customizing simple boilerplate-free classes.
-They can be defined using the ``@dataclasses.dataclass`` decorator:
+They can be defined using the :py:func:`@dataclasses.dataclass
+<python:dataclasses.dataclass>` decorator:
 
 .. code-block:: python
 
@@ -65,8 +66,8 @@ class can be used:
 
     val = unbox(BoxedData(42, "<important>"))  # OK, inferred type is int
 
-For more information see `official docs <https://docs.python.org/3/library/dataclasses.html>`_
-and `PEP 557 <https://www.python.org/dev/peps/pep-0557/>`_.
+For more information see :doc:`official docs <python:library/dataclasses>`
+and :pep:`557`.
 
 Caveats/Known Issues
 ====================
@@ -110,7 +111,7 @@ do **not** work:
 The attrs package
 *****************
 
-`attrs <http://www.attrs.org/en/stable>`_ is a package that lets you define
+:doc:`attrs <attrs:index>` is a package that lets you define
 classes without writing boilerplate code. Mypy can detect uses of the
 package and will generate the necessary method definitions for decorated
 classes using the type annotations it finds.
@@ -176,7 +177,7 @@ Caveats/Known Issues
   will complain about not understanding the argument and the type annotation in
   ``__init__`` will be replaced by ``Any``.
 
-* `Validator decorators <http://www.attrs.org/en/stable/examples.html#validators>`_
+* :ref:`Validator decorators <attrs:examples_validators>`
   and `default decorators <http://www.attrs.org/en/stable/examples.html#defaults>`_
   are not type-checked against the attribute they are setting/validating.
 

--- a/docs/source/cheat_sheet.rst
+++ b/docs/source/cheat_sheet.rst
@@ -3,8 +3,7 @@
 Type hints cheat sheet (Python 2)
 =================================
 
-This document is a quick cheat sheet showing how the
-`PEP 484 <https://www.python.org/dev/peps/pep-0484/>`_ type
+This document is a quick cheat sheet showing how the :pep:`484` type
 language represents various common types in Python 2.
 
 .. note::

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -3,8 +3,7 @@
 Type hints cheat sheet (Python 3)
 =================================
 
-This document is a quick cheat sheet showing how the
-`PEP 484 <https://www.python.org/dev/peps/pep-0484/>`_ type
+This document is a quick cheat sheet showing how the :pep:`484` type
 annotation notation represents various common types in Python 3.
 
 .. note::
@@ -18,9 +17,8 @@ annotation notation represents various common types in Python 3.
 Variables
 *********
 
-Python 3.6 introduced a syntax for annotating variables in
-`PEP 526 <https://www.python.org/dev/peps/pep-0526/>`_ and
-we use it in most examples.
+Python 3.6 introduced a syntax for annotating variables in :pep:`526`
+and we use it in most examples.
 
 .. code-block:: python
 

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -78,7 +78,7 @@ imports.
 
 ``--namespace-packages``
     This flag enables import discovery to use namespace packages (see
-    `PEP 420`_).  In particular, this allows discovery of imported
+    :pep:`420`).  In particular, this allows discovery of imported
     packages that don't have an ``__init__.py`` (or ``__init__.pyi``)
     file.
 
@@ -127,23 +127,23 @@ imports.
     see :ref:`Following imports <follow-imports>`.
 
 ``--python-executable EXECUTABLE``
-    This flag will have mypy collect type information from `PEP 561`_
+    This flag will have mypy collect type information from :pep:`561`
     compliant packages installed for the Python executable ``EXECUTABLE``.
-    If not provided, mypy will use PEP 561 compliant packages installed for
+    If not provided, mypy will use :pep:`561` compliant packages installed for
     the Python executable running mypy.
 
-    See :ref:`installed-packages` for more on making PEP 561 compliant packages.
+    See :ref:`installed-packages` for more on making :pep:`561` compliant packages.
 
 ``--no-site-packages``
-    This flag will disable searching for `PEP 561`_ compliant packages. This
+    This flag will disable searching for :pep:`561` compliant packages. This
     will also disable searching for a usable Python executable.
 
     Use this  flag if mypy cannot find a Python executable for the version of
-    Python being checked, and you don't need to use PEP 561 typed packages.
+    Python being checked, and you don't need to use :pep:`561` typed packages.
     Otherwise, use ``--python-executable``.
 
 ``--no-silence-site-packages``
-    By default, mypy will suppress any error messages generated within PEP 561
+    By default, mypy will suppress any error messages generated within :pep:`561`
     compliant packages. Adding this flag will disable this behavior.
 
 
@@ -165,7 +165,7 @@ For more information on how to use these flags, see :ref:`version_and_platform_c
     ``--py2`` flags are aliases for ``--python-version 2.7``.
 
     This flag will attempt to find a Python executable of the corresponding
-    version to search for `PEP 561`_ compliant packages. If you'd like to
+    version to search for :pep:`561` compliant packages. If you'd like to
     disable this, use the ``--no-site-packages`` flag (see
     :ref:`import-discovery` for more details).
 
@@ -178,7 +178,7 @@ For more information on how to use these flags, see :ref:`version_and_platform_c
     default to using whatever operating system you are currently using.
 
     The ``PLATFORM`` parameter may be any string supported by
-    `sys.platform <https://docs.python.org/3/library/sys.html#sys.platform>`_.
+    :py:data:`sys.platform`.
 
 .. _always-true:
 
@@ -679,9 +679,5 @@ Miscellaneous
     (The default ``__main__`` is technically more correct, but if you
     have many scripts that import a large package, the behavior enabled
     by this flag is often more convenient.)
-
-.. _PEP 420: https://www.python.org/dev/peps/pep-0420/
-
-.. _PEP 561: https://www.python.org/dev/peps/pep-0561/
 
 .. _lxml: https://pypi.org/project/lxml/

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -438,8 +438,7 @@ to have Python 2.7 installed to perform this check.
 
 To target a different operating system, use the ``--platform PLATFORM`` flag.
 For example, to verify your code typechecks if it were run in Windows, pass
-in ``--platform win32``. See the documentation for
-`sys.platform <https://docs.python.org/3/library/sys.html#sys.platform>`_
+in ``--platform win32``. See the documentation for :py:data:`sys.platform`
 for examples of valid platform parameters.
 
 .. _reveal-type:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ from mypy.version import __version__ as mypy_version
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ['sphinx.ext.intersphinx']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -266,3 +266,11 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 rst_prolog = '.. |...| unicode:: U+2026   .. ellipsis\n'
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'six': ('https://six.readthedocs.io', None),
+    'attrs': ('http://www.attrs.org/en/stable', None),
+    'cython': ('http://docs.cython.org/en/latest', None),
+    'monkeytype': ('https://monkeytype.readthedocs.io/en/latest', None),
+}

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -29,10 +29,9 @@ Config file format
 ******************
 
 The configuration file format is the usual
-`ini file <https://docs.python.org/3.6/library/configparser.html>`_
-format.  It should contain section names in square brackets and flag
-settings of the form `NAME = VALUE`.  Comments start with ``#``
-characters.
+:doc:`ini file <python:library/configparser>` format. It should contain
+section names in square brackets and flag settings of the form
+`NAME = VALUE`. Comments start with ``#`` characters.
 
 - A section named ``[mypy]`` must be present.  This specifies
   the global flags. The ``setup.cfg`` file is an exception to this.
@@ -357,7 +356,7 @@ a list of import discovery options that may be used
 :ref:`both per-module and globally <config-file-import-discovery-per-module>`.
 
 ``namespace_packages`` (bool, default False)
-    Enables PEP 420 style namespace packages.  See :ref:`the
+    Enables :pep:`420` style namespace packages.  See :ref:`the
     corresponding flag <import-discovery>` for more information.
 
 ``python_executable`` (string)
@@ -367,7 +366,7 @@ a list of import discovery options that may be used
     the executable used to run mypy.
 
 ``no_silence_site_packages`` (bool, default False)
-    Enables reporting error messages generated within PEP 561 compliant packages.
+    Enables reporting error messages generated within :pep:`561` compliant packages.
     Those error messages are suppressed by default, since you are usually
     not able to control errors in 3rd party code.
 
@@ -379,9 +378,8 @@ a list of import discovery options that may be used
 
 ``files`` (string)
     A comma-separated list of paths which should be checked by mypy if none are given on the command
-    line. Supports recursive file globbing using
-    [the glob library](https://docs.python.org/3/library/glob.html), where `*` (e.g. `*.py`) matches
-    files in the current directory and `**/` (e.g. `**/*.py`) matches files in any directories below
+    line. Supports recursive file globbing using :doc:`library/glob`, where ``*`` (e.g. ``*.py``) matches
+    files in the current directory and ``**/`` (e.g. ``**/*.py``) matches files in any directories below
     the current one. User home directory and environment variables will be expanded.
 
 

--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -542,8 +542,8 @@ Check instantiation of abstract classes [abstract]
 
 Mypy generates an error if you try to instantiate an abstract base
 class (ABC). An abtract base class is a class with at least one
-abstract method or attribute. (See also `Python
-abc module documentation <https://docs.python.org/3/library/abc.html>`_.)
+abstract method or attribute. (See also :doc:`Python
+abc module documentation <python:library/abc>`)
 
 Sometimes a class is made accidentally abstract, often due to an
 unimplemented abstract method. In a case like this you need to provide

--- a/docs/source/existing_code.rst
+++ b/docs/source/existing_code.rst
@@ -20,7 +20,7 @@ These steps will get you started with mypy on an existing codebase:
 
 5. Write annotations as you modify existing code and write new code
 
-6. Use MonkeyType or PyAnnotate to automatically annotate legacy code
+6. Use :doc:`monkeytype:index` or `PyAnnotate`_ to automatically annotate legacy code
 
 We discuss all of these points in some detail below, and a few optional
 follow-up steps.
@@ -145,8 +145,7 @@ Automate annotation of legacy code
 
 There are tools for automatically adding draft annotations
 based on type profiles collected at runtime.  Tools include
-`MonkeyType <https://github.com/Instagram/MonkeyType>`_
-(Python 3) and `PyAnnotate <https://github.com/dropbox/pyannotate>`_
+:doc:`monkeytype:index` (Python 3) and `PyAnnotate`_
 (type comments only).
 
 A simple approach is to collect types from test runs. This may work
@@ -177,3 +176,5 @@ catch more bugs. For example, you can ask mypy to require annotations
 for all functions in certain modules to avoid accidentally introducing
 code that won't be type checked. Refer to :ref:`command-line` for the
 details.
+
+.. _PyAnnotate: https://github.com/dropbox/pyannotate

--- a/docs/source/extending_mypy.rst
+++ b/docs/source/extending_mypy.rst
@@ -43,12 +43,12 @@ Extending mypy using plugins
 Python is a highly dynamic language and has extensive metaprogramming
 capabilities. Many popular libraries use these to create APIs that may
 be more flexible and/or natural for humans, but are hard to express using
-static types. Extending the PEP 484 type system to accommodate all existing
+static types. Extending the :pep:`484` type system to accommodate all existing
 dynamic patterns is impractical and often just impossible.
 
 Mypy supports a plugin system that lets you customize the way mypy type checks
 code. This can be useful if you want to extend mypy so it can type check code
-that uses a library that is difficult to express using just PEP 484 types.
+that uses a library that is difficult to express using just :pep:`484` types.
 
 The plugin system is focused on improving mypy's understanding
 of *semantics* of third party frameworks. There is currently no way to define
@@ -139,7 +139,7 @@ Current list of plugin hooks
 ****************************
 
 **get_type_analyze_hook()** customizes behaviour of the type analyzer.
-For example, PEP 484 doesn't support defining variadic generic types:
+For example, :pep:`484` doesn't support defining variadic generic types:
 
 .. code-block:: python
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -88,8 +88,8 @@ the scope of the mypy project.
 How do I type check my Python 2 code?
 *************************************
 
-You can use a `comment-based function annotation syntax
-<https://www.python.org/dev/peps/pep-0484/#suggested-syntax-for-python-2-7-and-straddling-code>`_
+You can use a :pep:`comment-based function annotation syntax
+<484#suggested-syntax-for-python-2-7-and-straddling-code>`
 and use the ``--py2`` command-line option to type check your Python 2 code.
 You'll also need to install ``typing`` for Python 2 via ``pip install typing``.
 
@@ -131,8 +131,7 @@ may be more flexible if it is typed with protocols. Also, using protocol types
 removes the necessity to explicitly declare implementations of ABCs.
 As a rule of thumb, we recommend using nominal classes where possible, and
 protocols where necessary. For more details about protocol types and structural
-subtyping see :ref:`protocol-types` and
-`PEP 544 <https://www.python.org/dev/peps/pep-0544/>`_.
+subtyping see :ref:`protocol-types` and :pep:`544`.
 
 I like Python and I have no need for static typing
 **************************************************
@@ -165,7 +164,7 @@ monkey patching of methods.
 How is mypy different from Cython?
 **********************************
 
-`Cython <http://cython.org/>`_ is a variant of Python that supports
+`Cython :doc:<cython:index>` is a variant of Python that supports
 compilation to CPython C modules. It can give major speedups to
 certain classes of programs compared to CPython, and it provides
 static typing (though this is different from mypy). Mypy differs in

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -662,8 +662,8 @@ Type aliases can be generic. In this case they can be used in two ways:
 Subscripted aliases are equivalent to original types with substituted type
 variables, so the number of type arguments must match the number of free type variables
 in the generic type alias. Unsubscripted aliases are treated as original types with free
-variables replaced with ``Any``. Examples (following `PEP 484
-<https://www.python.org/dev/peps/pep-0484/#type-aliases>`_):
+variables replaced with ``Any``. Examples (following :pep:`PEP 484: Type aliases
+<484#type-aliases>`):
 
 .. code-block:: python
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -88,13 +88,11 @@ calls since the arguments have invalid types:
    greeting(b'Alice')  # Argument 1 to "greeting" has incompatible type "bytes"; expected "str"
 
 Note that this is all still valid Python 3 code! The function annotation syntax
-shown above was added to Python `as a part of Python 3.0 <pep3107_>`_.
+shown above was added to Python :pep:`as a part of Python 3.0 <3107>`.
 
 If you are trying to type check Python 2 code, you can add type hints
 using a comment-based syntax instead of the Python 3 annotation syntax.
 See our section on :ref:`typing Python 2 code <python2>` for more details.
-
-.. _pep3107: https://www.python.org/dev/peps/pep-3107/
 
 Being able to pick whether you want a function to be dynamically or statically
 typed can be very helpful. For example, if you are migrating an existing
@@ -286,7 +284,7 @@ for example, when assigning an empty dictionary to some global value:
 You can teach mypy what type ``my_global_dict`` is meant to have by giving it
 a type hint. For example, if you knew this variable is supposed to be a dict
 of ints to floats, you could annotate it using either variable annotations
-(introduced in Python 3.6 by `PEP 526 <pep526_>`_) or using a comment-based
+(introduced in Python 3.6 by :pep:`526`) or using a comment-based
 syntax like so:
 
 .. code-block:: python
@@ -296,9 +294,6 @@ syntax like so:
 
    # If you want compatibility with older versions of Python
    my_global_dict = {}  # type: Dict[int, float]
-
-.. _pep526: https://www.python.org/dev/peps/pep-0526/
-
 
 .. _stubs-intro:
 

--- a/docs/source/installed_packages.rst
+++ b/docs/source/installed_packages.rst
@@ -3,12 +3,12 @@
 Using installed packages
 ========================
 
-`PEP 561 <https://www.python.org/dev/peps/pep-0561/>`__ specifies how to mark
-a package as supporting type checking. Below is a summary of how to create
-PEP 561 compatible packages and have mypy use them in type checking.
+:pep:`561` specifies how to mark a package as supporting type checking.
+Below is a summary of how to create :pep:`561` compatible packages and have
+mypy use them in type checking.
 
-Using PEP 561 compatible packages with mypy
-*******************************************
+Using :pep:`561` compatible packages with mypy
+**********************************************
 
 Generally, you do not need to do anything to use installed packages that
 support typing for the Python executable used to run mypy. Note that most
@@ -30,17 +30,16 @@ imports and custom import hooks.
 If you do not want to use typed packages, use the ``--no-site-packages`` flag
 to disable searching.
 
-Note that stub-only packages (defined in
-`PEP 561 <https://www.python.org/dev/peps/pep-0561/#stub-only-packages>`__)
-cannot be used with ``MYPYPATH``. If you want mypy to find the package, it must
-be installed. For a package ``foo``, the name of the stub-only package
-(``foo-stubs``) is not a legal package name, so mypy will not find it, unless
-it is installed.
+Note that stub-only packages (defined in :pep:`PEP 561: Stub-only Packages
+<561#stub-only-packages>`) cannot be used with ``MYPYPATH``. If you want mypy
+to find the package, it must be installed. For a package ``foo``, the name of
+the stub-only package (``foo-stubs``) is not a legal package name, so mypy
+will not find it, unless it is installed.
 
-Making PEP 561 compatible packages
-**********************************
+Making :pep:`561` compatible packages
+*************************************
 
-PEP 561 notes three main ways to distribute type information. The first is a
+:pep:`561` notes three main ways to distribute type information. The first is a
 package that has only inline type annotations in the code itself. The second is
 a package that ships :ref:`stub files <stub-files>` with type information
 alongside the runtime code. The third method, also known as a "stub only

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -8,8 +8,7 @@ annotations are just hints for mypy and don't interfere when running your progra
 You run your program with a standard Python interpreter, and the annotations
 are treated effectively as comments.
 
-Using the Python 3 function annotation syntax (using the
-`PEP 484 <https://www.python.org/dev/peps/pep-0484/>`_ notation) or
+Using the Python 3 function annotation syntax (using the :pep`484` notation) or
 a comment-based annotation syntax for Python 2 code, you will be able to
 efficiently annotate your code and use mypy to check the code for common
 errors. Mypy has a powerful and easy-to-use type system with modern features

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -596,8 +596,8 @@ Python 3.6 introduced an alternative, class-based syntax for named tuples with t
 The type of class objects
 *************************
 
-(Freely after `PEP 484
-<https://www.python.org/dev/peps/pep-0484/#the-type-of-class-objects>`_.)
+(Freely after :pep:`PEP 484: The type of class objects
+<484#the-type-of-class-objects>`.)
 
 Sometimes you want to talk about class objects that inherit from a
 given class.  This can be spelled as ``Type[C]`` where ``C`` is a
@@ -675,8 +675,8 @@ Now mypy will infer the correct type of the result when we call
    compatible with the constructor of ``C``.  If ``C`` is a type
    variable, its upper bound must be a class object.
 
-For more details about ``Type[]`` see `PEP 484
-<https://www.python.org/dev/peps/pep-0484/#the-type-of-class-objects>`_.
+For more details about ``Type[]`` see :pep:`PEP 484: The type of
+class objects <484#the-type-of-class-objects>`.
 
 .. _text-and-anystr:
 

--- a/docs/source/metaclasses.rst
+++ b/docs/source/metaclasses.rst
@@ -3,9 +3,9 @@
 Metaclasses
 ===========
 
-A `metaclass <https://docs.python.org/3/reference/datamodel.html#metaclasses>`_
-is a class that describes the construction and behavior of other classes,
-similarly to how classes describe the construction and behavior of objects.
+A :ref:`metaclass <python:metaclasses>` is a class that describes
+the construction and behavior of other classes, similarly to how classes
+describe the construction and behavior of objects.
 The default metaclass is ``type``, but it's possible to use other metaclasses.
 Metaclasses allows one to create "a different kind of class", such as Enums,
 NamedTuples and singletons.
@@ -32,8 +32,8 @@ In Python 2, the syntax for defining a metaclass is different:
     class A(object):
         __metaclass__ = M
 
-Mypy also supports using the `six <https://pythonhosted.org/six/#six.with_metaclass>`_
-library to define metaclass in a portable way:
+Mypy also supports using :py:func:`six.with_metaclass`
+to define metaclass in a portable way:
 
 .. code-block:: python
 

--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -217,8 +217,7 @@ we pass in. It also does not prohibit a caller from passing in the wrong
 number of ints: mypy would treat calls like ``mouse_event(1, 2, 20)`` as being
 valid, for example.
 
-We can do better by using `overloading
-<https://www.python.org/dev/peps/pep-0484/#function-method-overloading>`_
+We can do better by using :pep:`overloading <484#function-method-overloading>`
 which lets us give the same function multiple type annotations (signatures)
 to more accurately describe the function's behavior:
 
@@ -569,7 +568,7 @@ Typing async/await
 
 Mypy supports the ability to type coroutines that use the ``async/await``
 syntax introduced in Python 3.5. For more information regarding coroutines and
-this new syntax, see `PEP 492 <https://www.python.org/dev/peps/pep-0492/>`_.
+this new syntax, see :pep:`492`.
 
 Functions defined using ``async def`` are typed just like normal functions.
 The return type annotation should be the same as the type of the value you

--- a/docs/source/protocols.rst
+++ b/docs/source/protocols.rst
@@ -18,9 +18,8 @@ and methods of the latter, and with compatible types.
 Structural subtyping can be seen as a static equivalent of duck
 typing, which is well known to Python programmers. Mypy provides
 support for structural subtyping via protocol classes described
-below.  See `PEP 544 <https://www.python.org/dev/peps/pep-0544/>`_ for
-the detailed specification of protocols and structural subtyping in
-Python.
+below.  See :pep:`544` for the detailed specification of protocols
+and structural subtyping in Python.
 
 .. _predefined_protocols:
 
@@ -344,8 +343,7 @@ implementation is actually compatible with the protocol.
 
 .. note::
 
-   You can use Python 3.6 variable annotations (`PEP 526
-   <https://www.python.org/dev/peps/pep-0526/>`_)
+   You can use Python 3.6 variable annotations (:pep:`526`)
    to declare protocol attributes.  On Python 2.7 and earlier Python 3
    versions you can use type comments and properties.
 

--- a/docs/source/python2.rst
+++ b/docs/source/python2.rst
@@ -6,7 +6,7 @@ Type checking Python 2 code
 For code that needs to be Python 2.7 compatible, function type
 annotations are given in comments, since the function annotation
 syntax was introduced in Python 3. The comment-based syntax is
-specified in `PEP 484 <https://www.python.org/dev/peps/pep-0484>`_.
+specified in :pep:`484`.
 
 Run mypy in Python 2 mode by using the ``--py2`` option::
 
@@ -66,7 +66,7 @@ overly long type comments and it's often tricky to see which argument
 type corresponds to which argument. The alternative, multi-line
 annotation syntax makes long annotations easier to read and write.
 
-Here is an example (from PEP 484):
+Here is an example (from :pep:`484`):
 
 .. code-block:: python
 

--- a/docs/source/python36.rst
+++ b/docs/source/python36.rst
@@ -7,7 +7,7 @@ Mypy has supported all language features new in Python 3.6 starting with mypy
 0.510. This section introduces Python 3.6 features that interact with
 type checking.
 
-Syntax for variable annotations (`PEP 526 <https://www.python.org/dev/peps/pep-0526>`_)
+Syntax for variable annotations (:pep:`526`)
 ---------------------------------------------------------------------------------------
 
 Python 3.6 introduced a new syntax for variable annotations (in
@@ -44,10 +44,10 @@ comments.  Example:
 
 .. _async_generators_and_comprehensions:
 
-Asynchronous generators (`PEP 525 <https://www.python.org/dev/peps/pep-0525>`_) and comprehensions (`PEP 530 <https://www.python.org/dev/peps/pep-0530>`_)
-----------------------------------------------------------------------------------------------------------------------------------------------------------
+Asynchronous generators (:pep:`525`) and comprehensions (:pep:`530`)
+--------------------------------------------------------------------
 
-Python 3.6 allows coroutines defined with ``async def`` (PEP 492) to be
+Python 3.6 allows coroutines defined with ``async def`` (:pep:`492`) to be
 generators, i.e. contain ``yield`` expressions. It also introduced a syntax for
 asynchronous comprehensions. This example uses the ``AsyncIterator`` type to
 define an async generator:

--- a/docs/source/stubgen.rst
+++ b/docs/source/stubgen.rst
@@ -3,13 +3,12 @@
 Automatic stub generation (stubgen)
 ===================================
 
-A stub file (see `PEP 484 <https://www.python.org/dev/peps/pep-0484/#stub-files>`_)
-contains only type hints for the public interface of a module, with empty
-function bodies. Mypy can use a stub file instead of the real implementation
-to provide type information for the module. They are useful for third-party
-modules whose authors have not yet added type hints (and when no stubs are
-available in typeshed) and C extension modules (which mypy can't directly
-process).
+A stub file (see :pep:`484`) contains only type hints for the public
+interface of a module, with empty function bodies. Mypy can use a stub
+file instead of the real implementation to provide type information
+for the module. They are useful for third-party modules whose authors
+have not yet added type hints (and when no stubs are available in
+typeshed) and C extension modules (which mypy can't directly process).
 
 Mypy includes the ``stubgen`` tool that can automatically generate
 stub files (``.pyi`` files) for Python modules and C extension modules.

--- a/docs/source/stubs.rst
+++ b/docs/source/stubs.rst
@@ -26,9 +26,8 @@ Here is an overview of how to create a stub file:
 
 Use the normal Python file name conventions for modules, e.g. ``csv.pyi``
 for module ``csv``. Use a subdirectory with ``__init__.pyi`` for packages. Note
-that `PEP 561 <https://www.python.org/dev/peps/pep-0561/>`_ stub-only packages
-must be installed, and may not be pointed at through the ``MYPYPATH``
-(see :ref:`PEP 561 support <installed-packages>`).
+that :pep:`561` stub-only packages must be installed, and may not be pointed
+at through the ``MYPYPATH`` (see :ref:`PEP 561 support <installed-packages>`).
 
 If a directory contains both a ``.py`` and a ``.pyi`` file for the
 same module, the ``.pyi`` file takes precedence. This way you can


### PR DESCRIPTION
This is the first part of adding referencing to `mypy`s docs (second part being #7624). I have configured [`intersphinx`](http://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) and replaced hardcoded links with `intersphinx` references. IMO this has a huge benefit of maintaining links consistency: while the hardcoded link is unmanageable (for example, currently the link https://pythonhosted.org/six/#six.with_metaclass points to nowhere since `attrs` documentation has moved to www.attrs.org), the `intersphinx` refs are checked implicitly - if a ref is dead, Sphinx will emit a warning when building docs<sup>1</sup>. `intersphinx` is an extension that is included in Sphinx by default, so no extra dependencies needed.

Another advantage is the referencing simplicity: for example, instead of writing

```rst
any string supported by `sys.platform <https://docs.python.org/3/library/sys.html#sys.platform>`_
```
rendered as
![image](https://user-images.githubusercontent.com/4455652/66208465-6b966c00-e6b5-11e9-9749-1d78927f80d7.png)
you do

```rst
any string supported by :py:data:`sys.platform`
```
rendered as
![image](https://user-images.githubusercontent.com/4455652/66208321-1a867800-e6b5-11e9-8de1-2ff3a7f25a9c.png)

which is IMO a lot less work when typing and has a different style when rendered, pointing out the fact that the link leads to a library documentation.

Also, Sphinx has a [`:pep:` role](http://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-pep) that generates links to PEP pages, so e.g.
```rst
PEP 561 <https://www.python.org/dev/peps/pep-0561/>`__ specifies ...
```
rendered as
![image](https://user-images.githubusercontent.com/4455652/66208666-f2e3df80-e6b5-11e9-8a2f-a1d50c909d87.png)

becomes
```rst
:pep:`561` specifies ...
```
rendered as

![image](https://user-images.githubusercontent.com/4455652/66208725-1444cb80-e6b6-11e9-976d-de3e1bca88c2.png)
----
<sup>1</sup> Of course, there's the `linkcheck` builder that checks for dead references, but it has to be run explicitly, so it's still beneficial to reduce the amount of hardcoded links to a minimum. Also, `linkcheck` doesn't check for the link formatting: if one e.g. [uses markdown instead of ReST](https://github.com/python/mypy/pull/7623/commits/f857d2080e55bfb74d5c85486b9d3b4b8ad17c28#diff-86b284998e54a73fcae70086f5aaad89L383) to format the link, this will render wrong, but `linkcheck` won't complain.