### PR TITLE
[mypyc] Stop abusing module names for static namespacing

### DIFF
--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -8,6 +8,7 @@ DUNDER_PREFIX = 'CPyDunder_'  # type: Final # Wrappers for exposing dunder metho
 REG_PREFIX = 'cpy_r_'  # type: Final # Registers
 STATIC_PREFIX = 'CPyStatic_'  # type: Final # Static variables (for literals etc.)
 TYPE_PREFIX = 'CPyType_'  # type: Final # Type object struct
+MODULE_PREFIX = 'CPyModule_'  # type: Final # Cached modules
 ATTR_PREFIX = '_'  # type: Final # Attributes
 
 ENV_ATTR_NAME = '__mypyc_env__'  # type: Final

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -1,13 +1,15 @@
 """Code generation for native function bodies."""
 
 
-from mypyc.common import REG_PREFIX, NATIVE_PREFIX, STATIC_PREFIX, TYPE_PREFIX
+from mypyc.common import (
+    REG_PREFIX, NATIVE_PREFIX, STATIC_PREFIX, TYPE_PREFIX, MODULE_PREFIX,
+)
 from mypyc.emit import Emitter
 from mypyc.ops import (
     FuncIR, OpVisitor, Goto, Branch, Return, Assign, LoadInt, LoadErrorValue, GetAttr, SetAttr,
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
     BasicBlock, Value, RType, RTuple, MethodCall, PrimitiveOp,
-    EmitterInterface, Unreachable, NAMESPACE_STATIC, NAMESPACE_TYPE,
+    EmitterInterface, Unreachable, NAMESPACE_STATIC, NAMESPACE_TYPE, NAMESPACE_MODULE,
     RaiseStandardError, FuncDecl, ClassIR,
     FUNC_STATICMETHOD, FUNC_CLASSMETHOD,
 )
@@ -255,6 +257,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
     PREFIX_MAP = {
         NAMESPACE_STATIC: STATIC_PREFIX,
         NAMESPACE_TYPE: TYPE_PREFIX,
+        NAMESPACE_MODULE: MODULE_PREFIX,
     }  # type: Final
 
     def visit_load_static(self, op: LoadStatic) -> None:

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -10,7 +10,7 @@ from mypy.errors import CompileError
 from mypy.options import Options
 
 from mypyc import genops
-from mypyc.common import PREFIX, TOP_LEVEL_NAME, INT_PREFIX
+from mypyc.common import PREFIX, TOP_LEVEL_NAME, INT_PREFIX, MODULE_PREFIX
 from mypyc.emit import EmitterContext, Emitter, HeaderDeclaration
 from mypyc.emitfunc import generate_native_function, native_function_header
 from mypyc.emitclass import generate_class_type_decl, generate_class
@@ -145,7 +145,7 @@ class ModuleGenerator:
             self.declare_internal_globals(module_name, emitter)
             self.declare_imports(module.imports, emitter)
             # Finals must be last (types can depend on declared above)
-            self.define_finals(module.final_names, emitter)
+            self.define_finals(module_name, module.final_names, emitter)
 
             for cl in module.classes:
                 if cl.is_ext_class:
@@ -192,7 +192,7 @@ class ModuleGenerator:
                 declarations.emit_lines(*declaration.decl)
 
         for module_name, module in self.modules:
-            self.declare_finals(module.final_names, declarations)
+            self.declare_finals(module_name, module.final_names, declarations)
             for cl in module.classes:
                 generate_class_type_decl(cl, emitter, declarations)
             for fn in module.functions:
@@ -456,7 +456,7 @@ class ModuleGenerator:
         self.declare_global('PyObject *', static_name)
 
     def module_internal_static_name(self, module_name: str, emitter: Emitter) -> str:
-        return emitter.static_name('module_internal', module_name)
+        return emitter.static_name(module_name + '_internal', None, prefix=MODULE_PREFIX)
 
     def declare_module(self, module_name: str, emitter: Emitter) -> None:
         # We declare two globals for each module:
@@ -465,7 +465,7 @@ class ModuleGenerator:
         # by other modules to refer to it.
         internal_static_name = self.module_internal_static_name(module_name, emitter)
         self.declare_global('CPyModule *', internal_static_name, initializer='NULL')
-        static_name = emitter.static_name('module', module_name)
+        static_name = emitter.static_name(module_name, None, prefix=MODULE_PREFIX)
         self.declare_global('CPyModule *', static_name)
         self.simple_inits.append((static_name, 'Py_None'))
 
@@ -473,14 +473,16 @@ class ModuleGenerator:
         for imp in imps:
             self.declare_module(imp, emitter)
 
-    def declare_finals(self, final_names: Iterable[Tuple[str, RType]], emitter: Emitter) -> None:
+    def declare_finals(
+            self, module: str, final_names: Iterable[Tuple[str, RType]], emitter: Emitter) -> None:
         for name, typ in final_names:
-            static_name = emitter.static_name(name, 'final')
+            static_name = emitter.static_name(name, module)
             emitter.emit_line('extern {}{};'.format(emitter.ctype_spaced(typ), static_name))
 
-    def define_finals(self, final_names: Iterable[Tuple[str, RType]], emitter: Emitter) -> None:
+    def define_finals(
+            self, module: str, final_names: Iterable[Tuple[str, RType]], emitter: Emitter) -> None:
         for name, typ in final_names:
-            static_name = emitter.static_name(name, 'final')
+            static_name = emitter.static_name(name, module)
             # Here we rely on the fact that undefined value and error value are always the same
             if isinstance(typ, RTuple):
                 # We need to inline because initializer must be static

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -48,6 +48,7 @@ from mypy.types import (
 from mypy.visitor import ExpressionVisitor, StatementVisitor
 from mypy.checkexpr import map_actuals_to_formals
 from mypy.state import strict_optional_set
+from mypy.util import split_target
 
 from mypyc.common import (
     ENV_ATTR_NAME, NEXT_LABEL_ATTR_NAME, TEMP_ATTR_NAME, LAMBDA_NAME,
@@ -66,7 +67,8 @@ from mypyc.ops import (
     exc_rtuple,
     PrimitiveOp, ControlOp, OpDescription, RegisterOp,
     is_object_rprimitive, LiteralsMap, FuncSignature, VTableAttr, VTableMethod, VTableEntries,
-    NAMESPACE_TYPE, RaiseStandardError, LoadErrorValue, NO_TRACEBACK_LINE_NO, FuncDecl,
+    NAMESPACE_TYPE, NAMESPACE_MODULE,
+    RaiseStandardError, LoadErrorValue, NO_TRACEBACK_LINE_NO, FuncDecl,
     FUNC_NORMAL, FUNC_STATICMETHOD, FUNC_CLASSMETHOD,
     RUnion, is_optional_type, optional_value_type, all_concrete_classes
 )
@@ -1387,7 +1389,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         for lval in attrs_to_cache:
             assert isinstance(lval, NameExpr)
             rval = self.py_get_attr(typ, lval.name, cdef.line)
-            self.init_final_static(lval, rval, cdef.fullname)
+            self.init_final_static(lval, rval, cdef.name)
 
     def visit_class_def(self, cdef: ClassDef) -> None:
         ir = self.mapper.type_to_ir[cdef.info]
@@ -1451,7 +1453,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 self.primitive_op(
                     py_setattr_op, [typ, self.load_static_unicode(lvalue.name), value], stmt.line)
                 if self.non_function_scope() and stmt.is_final_def:
-                    self.init_final_static(lvalue, value, cdef.fullname)
+                    self.init_final_static(lvalue, value, cdef.name)
             elif isinstance(stmt, ExpressionStmt) and isinstance(stmt.expr, StrExpr):
                 # Docstring. Ignore
                 pass
@@ -1525,13 +1527,13 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         self.imports[id] = None
 
         needs_import, out = BasicBlock(), BasicBlock()
-        first_load = self.add(LoadStatic(object_rprimitive, 'module', id))
+        first_load = self.load_module(id)
         comparison = self.binary_op(first_load, self.none_object(), 'is not', line)
         self.add_bool_branch(comparison, out, needs_import)
 
         self.activate_block(needs_import)
         value = self.primitive_op(import_op, [self.load_static_unicode(id)], line)
-        self.add(InitStatic(value, 'module', id))
+        self.add(InitStatic(value, id, namespace=NAMESPACE_MODULE))
         self.goto_and_activate(out)
 
     def visit_import(self, node: Import) -> None:
@@ -1577,7 +1579,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         id = importlib.util.resolve_name('.' * node.relative + node.id, module_package)
 
         self.gen_import(id, node.line)
-        module = self.add(LoadStatic(object_rprimitive, 'module', id))
+        module = self.load_module(id)
 
         # Copy everything into our module's dict.
         # Note that we miscompile import from inside of functions here,
@@ -1730,7 +1732,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                                     env.lookup(arg.variable).type, arg.line)
                 if not fn_info.is_nested:
                     name = fitem.fullname() + '.' + arg.variable.name()
-                    self.add(InitStatic(value, name, 'final'))
+                    self.add(InitStatic(value, name, self.module_name))
                 else:
                     assert func_reg is not None
                     self.add(SetAttr(func_reg, arg.variable.name(), value, arg.line))
@@ -1758,7 +1760,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                     elif not self.fn_info.is_nested:
                         name = fitem.fullname() + '.' + arg.variable.name()
                         self.final_names.append((name, target.type))
-                        return self.add(LoadStatic(target.type, name, 'final'))
+                        return self.add(LoadStatic(target.type, name, self.module_name))
                     else:
                         name = arg.variable.name()
                         self.fn_info.callable_class.ir.attributes[name] = target.type
@@ -2042,19 +2044,21 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         assert isinstance(lvalue.node, Var)
         if lvalue.node.final_value is None:
             if class_name is None:
-                name = lvalue.fullname
+                name = lvalue.name
             else:
                 name = '{}.{}'.format(class_name, lvalue.name)
             assert name is not None, "Full name not set for variable"
             self.final_names.append((name, rvalue_reg.type))
-            self.add(InitStatic(rvalue_reg, name, 'final'))
+            self.add(InitStatic(rvalue_reg, name, self.module_name))
 
     def load_final_static(self, fullname: str, typ: RType, line: int,
                           error_name: Optional[str] = None) -> Value:
         if error_name is None:
             error_name = fullname
         ok_block, error_block = BasicBlock(), BasicBlock()
-        value = self.add(LoadStatic(typ, fullname, 'final', line=line))
+        split_name = split_target(self.graph, fullname)
+        assert split_name is not None
+        value = self.add(LoadStatic(typ, split_name[1], split_name[0], line=line))
         self.add(Branch(value, error_block, ok_block, Branch.IS_ERROR, rare=True))
         self.activate_block(error_block)
         self.add(RaiseStandardError(RaiseStandardError.VALUE_ERROR,
@@ -5237,7 +5241,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         return self.add(LoadStatic(str_rprimitive, static_symbol, ann=value))
 
     def load_module(self, name: str) -> Value:
-        return self.add(LoadStatic(object_rprimitive, 'module', name))
+        return self.add(LoadStatic(object_rprimitive, name, namespace=NAMESPACE_MODULE))
 
     def load_module_attr_by_fullname(self, fullname: str, line: int) -> Value:
         module, _, name = fullname.rpartition('.')

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1115,6 +1115,7 @@ class SetAttr(RegisterOp):
 
 NAMESPACE_STATIC = 'static'  # type: Final # Default name space for statics, variables
 NAMESPACE_TYPE = 'type'  # type: Final # Static namespace for pointers to native type objects
+NAMESPACE_MODULE = 'module'  # type: Final # Namespace for modules
 
 
 class LoadStatic(RegisterOp):

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -530,7 +530,7 @@ L1:
     goto L10
 L2:
     r1 = error_catch
-    r2 = builtins.module :: static
+    r2 = builtins :: module
     r3 = unicode_1 :: static  ('Exception')
     r4 = getattr r2, r3
     if is_error(r4) goto L8 (error at lol:4) else goto L3

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -194,7 +194,7 @@ def g():
     r12, r13 :: None
 L0:
 L1:
-    r0 = builtins.module :: static
+    r0 = builtins :: module
     r1 = unicode_1 :: static  ('object')
     r2 = getattr r0, r1
     if is_error(r2) goto L3 (error at g:3) else goto L2
@@ -205,7 +205,7 @@ L2:
 L3:
     r4 = error_catch
     r5 = unicode_2 :: static  ('weeee')
-    r6 = builtins.module :: static
+    r6 = builtins :: module
     r7 = unicode_3 :: static  ('print')
     r8 = getattr r6, r7
     if is_error(r8) goto L7 (error at g:5) else goto L4
@@ -266,7 +266,7 @@ def a():
     r20 :: str
 L0:
 L1:
-    r0 = builtins.module :: static
+    r0 = builtins :: module
     r1 = unicode_1 :: static  ('print')
     r2 = getattr r0, r1
     if is_error(r2) goto L6 (error at a:3) else goto L2
@@ -293,7 +293,7 @@ L6:
     r7 = r11
 L7:
     r12 = unicode_3 :: static  ('goodbye!')
-    r13 = builtins.module :: static
+    r13 = builtins :: module
     r14 = unicode_1 :: static  ('print')
     r15 = getattr r13, r14
     if is_error(r15) goto L15 (error at a:6) else goto L8
@@ -500,7 +500,7 @@ L2:
     r3 = !r2
     if r3 goto L12 else goto L1 :: bool
 L3:
-    r4 = builtins.module :: static
+    r4 = builtins :: module
     r5 = unicode_3 :: static  ('print')
     r6 = getattr r4, r5
     if is_error(r6) goto L13 (error at f:7) else goto L4

--- a/mypyc/test-data/genops-basic.test
+++ b/mypyc/test-data/genops-basic.test
@@ -568,7 +568,7 @@ def f(x):
     r2, r3, r4 :: object
     r5 :: int
 L0:
-    r0 = testmodule.module :: static
+    r0 = testmodule :: module
     r1 = unicode_2 :: static  ('factorial')
     r2 = getattr r0, r1
     r3 = box(int, x)
@@ -614,7 +614,7 @@ def f(x):
     r4, r5 :: object
     r6, r7 :: None
 L0:
-    r0 = builtins.module :: static
+    r0 = builtins :: module
     r1 = unicode_1 :: static  ('print')
     r2 = getattr r0, r1
     r3 = 5
@@ -638,7 +638,7 @@ def f(x):
     r6, r7 :: None
 L0:
     r0 = 5
-    r1 = builtins.module :: static
+    r1 = builtins :: module
     r2 = unicode_1 :: static  ('print')
     r3 = getattr r1, r2
     r4 = box(short_int, r0)
@@ -1324,7 +1324,7 @@ def foo():
     r2, r3 :: object
     r4 :: bool
 L0:
-    r0 = builtins.module :: static
+    r0 = builtins :: module
     r1 = unicode_1 :: static  ('Exception')
     r2 = getattr r0, r1
     r3 = py_call(r2)
@@ -1336,7 +1336,7 @@ def bar():
     r2 :: object
     r3 :: bool
 L0:
-    r0 = builtins.module :: static
+    r0 = builtins :: module
     r1 = unicode_1 :: static  ('Exception')
     r2 = getattr r0, r1
     raise_exception(r2); r3 = 0
@@ -1363,7 +1363,7 @@ L0:
     r1 = unicode_1 :: static  ('x')
     r2 = r0[r1] :: dict
     r3 = unbox(int, r2)
-    r4 = builtins.module :: static
+    r4 = builtins :: module
     r5 = unicode_2 :: static  ('print')
     r6 = getattr r4, r5
     r7 = box(int, r3)
@@ -1390,14 +1390,14 @@ def __top_level__():
     r16, r17, r18 :: object
     r19, r20 :: None
 L0:
-    r0 = builtins.module :: static
+    r0 = builtins :: module
     r1 = builtins.None :: object
     r2 = r0 is not r1
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = unicode_0 :: static  ('builtins')
     r4 = import r3 :: str
-    builtins.module = r4 :: static
+    builtins = r4 :: module
 L2:
     r5 = 1
     r6 = __main__.globals :: static
@@ -1408,7 +1408,7 @@ L2:
     r11 = unicode_1 :: static  ('x')
     r12 = r10[r11] :: dict
     r13 = unbox(int, r12)
-    r14 = builtins.module :: static
+    r14 = builtins :: module
     r15 = unicode_2 :: static  ('print')
     r16 = getattr r14, r15
     r17 = box(int, r13)
@@ -1436,7 +1436,7 @@ def f():
     r4, r5 :: object
     r6 :: str
 L0:
-    r0 = m.module :: static
+    r0 = m :: module
     r1 = unicode_2 :: static  ('f')
     r2 = getattr r0, r1
     r3 = 1
@@ -2471,25 +2471,25 @@ def __top_level__():
     r85 :: bool
     r86 :: None
 L0:
-    r0 = builtins.module :: static
+    r0 = builtins :: module
     r1 = builtins.None :: object
     r2 = r0 is not r1
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = unicode_0 :: static  ('builtins')
     r4 = import r3 :: str
-    builtins.module = r4 :: static
+    builtins = r4 :: module
 L2:
-    r5 = typing.module :: static
+    r5 = typing :: module
     r6 = builtins.None :: object
     r7 = r5 is not r6
     if r7 goto L4 else goto L3 :: bool
 L3:
     r8 = unicode_1 :: static  ('typing')
     r9 = import r8 :: str
-    typing.module = r9 :: static
+    typing = r9 :: module
 L4:
-    r10 = typing.module :: static
+    r10 = typing :: module
     r11 = __main__.globals :: static
     r12 = unicode_2 :: static  ('List')
     r13 = getattr r10, r12
@@ -2680,7 +2680,7 @@ L0:
     r1 = r0.g
     g = r1
     r2 = unicode_3 :: static  ('Entering')
-    r3 = builtins.module :: static
+    r3 = builtins :: module
     r4 = unicode_4 :: static  ('print')
     r5 = getattr r3, r4
     r6 = py_call(r5, r2)
@@ -2689,7 +2689,7 @@ L0:
     r9 = py_call(r8)
     r10 = unbox(None, r9)
     r11 = unicode_5 :: static  ('Exited')
-    r12 = builtins.module :: static
+    r12 = builtins :: module
     r13 = unicode_4 :: static  ('print')
     r14 = getattr r12, r13
     r15 = py_call(r14, r11)
@@ -2745,7 +2745,7 @@ L0:
     r1 = r0.g
     g = r1
     r2 = unicode_6 :: static  ('---')
-    r3 = builtins.module :: static
+    r3 = builtins :: module
     r4 = unicode_4 :: static  ('print')
     r5 = getattr r3, r4
     r6 = py_call(r5, r2)
@@ -2754,7 +2754,7 @@ L0:
     r9 = py_call(r8)
     r10 = unbox(None, r9)
     r11 = unicode_6 :: static  ('---')
-    r12 = builtins.module :: static
+    r12 = builtins :: module
     r13 = unicode_4 :: static  ('print')
     r14 = getattr r12, r13
     r15 = py_call(r14, r11)
@@ -2803,7 +2803,7 @@ L0:
     r1 = r0.d
     d = r1
     r2 = unicode_7 :: static  ('d')
-    r3 = builtins.module :: static
+    r3 = builtins :: module
     r4 = unicode_4 :: static  ('print')
     r5 = getattr r3, r4
     r6 = py_call(r5, r2)
@@ -2842,7 +2842,7 @@ L0:
     r10 = py_call(r9, r6)
     r0.d = r10; r11 = is_error
     r12 = unicode_10 :: static  ('c')
-    r13 = builtins.module :: static
+    r13 = builtins :: module
     r14 = unicode_4 :: static  ('print')
     r15 = getattr r13, r14
     r16 = py_call(r15, r12)
@@ -2879,25 +2879,25 @@ def __top_level__():
     r29 :: bool
     r30 :: None
 L0:
-    r0 = builtins.module :: static
+    r0 = builtins :: module
     r1 = builtins.None :: object
     r2 = r0 is not r1
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = unicode_0 :: static  ('builtins')
     r4 = import r3 :: str
-    builtins.module = r4 :: static
+    builtins = r4 :: module
 L2:
-    r5 = typing.module :: static
+    r5 = typing :: module
     r6 = builtins.None :: object
     r7 = r5 is not r6
     if r7 goto L4 else goto L3 :: bool
 L3:
     r8 = unicode_1 :: static  ('typing')
     r9 = import r8 :: str
-    typing.module = r9 :: static
+    typing = r9 :: module
 L4:
-    r10 = typing.module :: static
+    r10 = typing :: module
     r11 = __main__.globals :: static
     r12 = unicode_2 :: static  ('Callable')
     r13 = getattr r10, r12
@@ -2965,7 +2965,7 @@ L0:
     r1 = r0.g
     g = r1
     r2 = unicode_3 :: static  ('Entering')
-    r3 = builtins.module :: static
+    r3 = builtins :: module
     r4 = unicode_4 :: static  ('print')
     r5 = getattr r3, r4
     r6 = py_call(r5, r2)
@@ -2974,7 +2974,7 @@ L0:
     r9 = py_call(r8)
     r10 = unbox(None, r9)
     r11 = unicode_5 :: static  ('Exited')
-    r12 = builtins.module :: static
+    r12 = builtins :: module
     r13 = unicode_4 :: static  ('print')
     r14 = getattr r12, r13
     r15 = py_call(r14, r11)
@@ -3011,25 +3011,25 @@ def __top_level__():
     r15 :: bool
     r16 :: None
 L0:
-    r0 = builtins.module :: static
+    r0 = builtins :: module
     r1 = builtins.None :: object
     r2 = r0 is not r1
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = unicode_0 :: static  ('builtins')
     r4 = import r3 :: str
-    builtins.module = r4 :: static
+    builtins = r4 :: module
 L2:
-    r5 = typing.module :: static
+    r5 = typing :: module
     r6 = builtins.None :: object
     r7 = r5 is not r6
     if r7 goto L4 else goto L3 :: bool
 L3:
     r8 = unicode_1 :: static  ('typing')
     r9 = import r8 :: str
-    typing.module = r9 :: static
+    typing = r9 :: module
 L4:
-    r10 = typing.module :: static
+    r10 = typing :: module
     r11 = __main__.globals :: static
     r12 = unicode_2 :: static  ('Callable')
     r13 = getattr r10, r12
@@ -3267,7 +3267,7 @@ def f():
     r3 :: object
     r4 :: int
 L0:
-    r0 = final.__main__.x :: static
+    r0 = __main__.x :: static
     if is_error(r0) goto L1 else goto L2
 L1:
     raise ValueError('value for final name "x" was not set')
@@ -3277,7 +3277,6 @@ L2:
     r3 = r0[r2] :: list
     r4 = unbox(int, r3)
     return r4
-
 
 [case testFinalStaticTuple]
 from typing import Final
@@ -3292,7 +3291,7 @@ def f():
     r1 :: bool
     r2 :: int
 L0:
-    r0 = final.__main__.x :: static
+    r0 = __main__.x :: static
     if is_error(r0) goto L1 else goto L2
 L1:
     raise ValueError('value for final name "x" was not set')
@@ -3315,7 +3314,7 @@ def f():
     r2 :: short_int
     r3 :: int
 L0:
-    r0 = final.__main__.x :: static
+    r0 = __main__.x :: static
     if is_error(r0) goto L1 else goto L2
 L1:
     raise ValueError('value for final name "x" was not set')
@@ -3324,7 +3323,6 @@ L2:
     r2 = 1
     r3 = r0 - r2 :: int
     return r3
-
 
 [case testFinalRestrictedTypeVar]
 from typing import TypeVar
@@ -3401,7 +3399,7 @@ def f(x):
     r5 :: int
     r6 :: None
 L0:
-    r0 = builtins.module :: static
+    r0 = builtins :: module
     r1 = unicode_1 :: static  ('reveal_type')
     r2 = getattr r0, r1
     r3 = box(int, x)

--- a/mypyc/test-data/genops-classes.test
+++ b/mypyc/test-data/genops-classes.test
@@ -395,25 +395,25 @@ def __top_level__():
     r81 :: bool
     r82 :: None
 L0:
-    r0 = builtins.module :: static
+    r0 = builtins :: module
     r1 = builtins.None :: object
     r2 = r0 is not r1
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = unicode_0 :: static  ('builtins')
     r4 = import r3 :: str
-    builtins.module = r4 :: static
+    builtins = r4 :: module
 L2:
-    r5 = typing.module :: static
+    r5 = typing :: module
     r6 = builtins.None :: object
     r7 = r5 is not r6
     if r7 goto L4 else goto L3 :: bool
 L3:
     r8 = unicode_1 :: static  ('typing')
     r9 = import r8 :: str
-    typing.module = r9 :: static
+    typing = r9 :: module
 L4:
-    r10 = typing.module :: static
+    r10 = typing :: module
     r11 = __main__.globals :: static
     r12 = unicode_2 :: static  ('TypeVar')
     r13 = getattr r10, r12
@@ -423,16 +423,16 @@ L4:
     r17 = getattr r10, r16
     r18 = unicode_3 :: static  ('Generic')
     r19 = r11.__setitem__(r18, r17) :: dict
-    r20 = mypy_extensions.module :: static
+    r20 = mypy_extensions :: module
     r21 = builtins.None :: object
     r22 = r20 is not r21
     if r22 goto L6 else goto L5 :: bool
 L5:
     r23 = unicode_4 :: static  ('mypy_extensions')
     r24 = import r23 :: str
-    mypy_extensions.module = r24 :: static
+    mypy_extensions = r24 :: module
 L6:
-    r25 = mypy_extensions.module :: static
+    r25 = mypy_extensions :: module
     r26 = __main__.globals :: static
     r27 = unicode_5 :: static  ('trait')
     r28 = getattr r25, r27

--- a/mypyc/test-data/genops-statements.test
+++ b/mypyc/test-data/genops-statements.test
@@ -597,7 +597,7 @@ L1:
     r3 = bool r2 :: object
     if r3 goto L3 else goto L2 :: bool
 L2:
-    r4 = builtins.module :: static
+    r4 = builtins :: module
     r5 = unicode_3 :: static  ('AssertionError')
     r6 = getattr r4, r5
     r7 = py_call(r6, s)
@@ -987,4 +987,3 @@ L6:
 L7:
     r19 = None
     return r19
-

--- a/mypyc/test-data/genops-try.test
+++ b/mypyc/test-data/genops-try.test
@@ -19,7 +19,7 @@ def g():
     r12 :: None
 L0:
 L1:
-    r0 = builtins.module :: static
+    r0 = builtins :: module
     r1 = unicode_1 :: static  ('object')
     r2 = getattr r0, r1
     r3 = py_call(r2)
@@ -27,7 +27,7 @@ L1:
 L2: (handler for L1)
     r4 = error_catch
     r5 = unicode_2 :: static  ('weeee')
-    r6 = builtins.module :: static
+    r6 = builtins :: module
     r7 = unicode_3 :: static  ('print')
     r8 = getattr r6, r7
     r9 = py_call(r8, r5)
@@ -71,7 +71,7 @@ L0:
 L1:
     if b goto L2 else goto L3 :: bool
 L2:
-    r0 = builtins.module :: static
+    r0 = builtins :: module
     r1 = unicode_1 :: static  ('object')
     r2 = getattr r0, r1
     r3 = py_call(r2)
@@ -84,7 +84,7 @@ L4:
 L5: (handler for L1, L2, L3, L4)
     r6 = error_catch
     r7 = unicode_3 :: static  ('weeee')
-    r8 = builtins.module :: static
+    r8 = builtins :: module
     r9 = unicode_4 :: static  ('print')
     r10 = getattr r8, r9
     r11 = py_call(r10, r7)
@@ -143,20 +143,20 @@ def g():
 L0:
 L1:
     r0 = unicode_1 :: static  ('a')
-    r1 = builtins.module :: static
+    r1 = builtins :: module
     r2 = unicode_2 :: static  ('print')
     r3 = getattr r1, r2
     r4 = py_call(r3, r0)
     r5 = unbox(None, r4)
 L2:
-    r6 = builtins.module :: static
+    r6 = builtins :: module
     r7 = unicode_3 :: static  ('object')
     r8 = getattr r6, r7
     r9 = py_call(r8)
     goto L8
 L3: (handler for L2)
     r10 = error_catch
-    r11 = builtins.module :: static
+    r11 = builtins :: module
     r12 = unicode_4 :: static  ('AttributeError')
     r13 = getattr r11, r12
     r14 = exc_matches r13
@@ -165,7 +165,7 @@ L4:
     r15 = get_exc_value
     e = r15
     r16 = unicode_5 :: static  ('b')
-    r17 = builtins.module :: static
+    r17 = builtins :: module
     r18 = unicode_2 :: static  ('print')
     r19 = getattr r17, r18
     r20 = py_call(r19, r16, e)
@@ -186,7 +186,7 @@ L8:
 L9: (handler for L1, L6, L7, L8)
     r24 = error_catch
     r25 = unicode_6 :: static  ('weeee')
-    r26 = builtins.module :: static
+    r26 = builtins :: module
     r27 = unicode_2 :: static  ('print')
     r28 = getattr r26, r27
     r29 = py_call(r28, r25)
@@ -238,28 +238,28 @@ L1:
     goto L9
 L2: (handler for L1)
     r0 = error_catch
-    r1 = builtins.module :: static
+    r1 = builtins :: module
     r2 = unicode_1 :: static  ('KeyError')
     r3 = getattr r1, r2
     r4 = exc_matches r3
     if r4 goto L3 else goto L4 :: bool
 L3:
     r5 = unicode_2 :: static  ('weeee')
-    r6 = builtins.module :: static
+    r6 = builtins :: module
     r7 = unicode_3 :: static  ('print')
     r8 = getattr r6, r7
     r9 = py_call(r8, r5)
     r10 = unbox(None, r9)
     goto L7
 L4:
-    r11 = builtins.module :: static
+    r11 = builtins :: module
     r12 = unicode_4 :: static  ('IndexError')
     r13 = getattr r11, r12
     r14 = exc_matches r13
     if r14 goto L5 else goto L6 :: bool
 L5:
     r15 = unicode_5 :: static  ('yo')
-    r16 = builtins.module :: static
+    r16 = builtins :: module
     r17 = unicode_3 :: static  ('print')
     r18 = getattr r16, r17
     r19 = py_call(r18, r15)
@@ -307,7 +307,7 @@ L1:
     if b goto L2 else goto L3 :: bool
 L2:
     r0 = unicode_1 :: static  ('hi')
-    r1 = builtins.module :: static
+    r1 = builtins :: module
     r2 = unicode_2 :: static  ('Exception')
     r3 = getattr r1, r2
     r4 = py_call(r3, r0)
@@ -324,7 +324,7 @@ L6: (handler for L1, L2, L3)
     r6 = r8
 L7:
     r9 = unicode_3 :: static  ('finally')
-    r10 = builtins.module :: static
+    r10 = builtins :: module
     r11 = unicode_4 :: static  ('print')
     r12 = getattr r10, r11
     r13 = py_call(r12, r9)
@@ -388,7 +388,7 @@ L1:
 L2:
     y = r6
     r9 = unicode_5 :: static  ('hello')
-    r10 = builtins.module :: static
+    r10 = builtins :: module
     r11 = unicode_6 :: static  ('print')
     r12 = getattr r10, r11
     r13 = py_call(r12, r9)


### PR DESCRIPTION
Currently this is done for modules and finals, using the fictitious
'module' and 'final' modules. This will have bad interactions with
separate/incremental compilation, so move modules into their own
namespace and just put finals in the static namespace in the obvious
way.