### PR TITLE
[mypyc] Do all vtable setup dynamically at runtime

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1503,10 +1503,12 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         tp = self.primitive_op(pytype_from_template_op,
                                [template, tp_bases, modname], cdef.line)
         # Immediately fix up the trait vtables, before doing anything with the class.
-        self.add(Call(
-            FuncDecl(cdef.name + '_trait_vtable_setup',
-                     None, self.module_name,
-                     FuncSignature([], bool_rprimitive)), [], -1))
+        ir = self.mapper.type_to_ir[cdef.info]
+        if not ir.is_trait and not ir.builtin_base:
+            self.add(Call(
+                FuncDecl(cdef.name + '_trait_vtable_setup',
+                         None, self.module_name,
+                         FuncSignature([], bool_rprimitive)), [], -1))
         # Populate a '__mypyc_attrs__' field containing the list of attrs
         self.primitive_op(py_setattr_op, [
             tp, self.load_static_unicode('__mypyc_attrs__'),

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -57,15 +57,6 @@ static inline CPyVTableItem *CPy_FindTraitVtable(PyTypeObject *trait, CPyVTableI
     }
 }
 
-// At load time, we need to patch up trait vtables to contain actual pointers
-// to the type objects of the trait, rather than an indirection.
-static inline void CPy_FixupTraitVtable(CPyVTableItem *vtable, int count) {
-    int i;
-    for (i = 0; i < count; i++) {
-        vtable[i*2] = *(CPyVTableItem *)vtable[i*2];
-    }
-}
-
 static bool _CPy_IsSafeMetaClass(PyTypeObject *metaclass) {
     // mypyc classes can't work with metaclasses in
     // general. Through some various nasty hacks we *do*

--- a/mypyc/test-data/genops-classes.test
+++ b/mypyc/test-data/genops-classes.test
@@ -369,31 +369,30 @@ def __top_level__():
     r50 :: object
     r51 :: str
     r52, r53 :: object
-    r54 :: bool
-    r55 :: str
-    r56 :: tuple
-    r57 :: bool
-    r58 :: dict
-    r59 :: str
-    r60 :: bool
-    r61, r62 :: object
-    r63 :: dict
-    r64 :: str
-    r65 :: object
-    r66 :: dict
-    r67 :: str
-    r68, r69 :: object
-    r70 :: tuple
-    r71 :: str
-    r72, r73 :: object
-    r74 :: bool
-    r75, r76 :: str
-    r77 :: tuple
-    r78 :: bool
-    r79 :: dict
-    r80 :: str
-    r81 :: bool
-    r82 :: None
+    r54 :: str
+    r55 :: tuple
+    r56 :: bool
+    r57 :: dict
+    r58 :: str
+    r59 :: bool
+    r60, r61 :: object
+    r62 :: dict
+    r63 :: str
+    r64 :: object
+    r65 :: dict
+    r66 :: str
+    r67, r68 :: object
+    r69 :: tuple
+    r70 :: str
+    r71, r72 :: object
+    r73 :: bool
+    r74, r75 :: str
+    r76 :: tuple
+    r77 :: bool
+    r78 :: dict
+    r79 :: str
+    r80 :: bool
+    r81 :: None
 L0:
     r0 = builtins.module :: static
     r1 = builtins.None :: object
@@ -462,38 +461,37 @@ L6:
     r51 = unicode_7 :: static  ('__main__')
     r52 = __main__.S_template :: type
     r53 = pytype_from_template(r52, r50, r51)
-    r54 = S_trait_vtable_setup()
-    r55 = unicode_8 :: static  ('__mypyc_attrs__')
-    r56 = () :: tuple
-    r57 = setattr r53, r55, r56
+    r54 = unicode_8 :: static  ('__mypyc_attrs__')
+    r55 = () :: tuple
+    r56 = setattr r53, r54, r55
     __main__.S = r53 :: type
-    r58 = __main__.globals :: static
-    r59 = unicode_10 :: static  ('S')
-    r60 = r58.__setitem__(r59, r53) :: dict
-    r61 = __main__.C :: type
-    r62 = __main__.S :: type
-    r63 = __main__.globals :: static
-    r64 = unicode_3 :: static  ('Generic')
-    r65 = r63[r64] :: dict
-    r66 = __main__.globals :: static
-    r67 = unicode_6 :: static  ('T')
-    r68 = r66[r67] :: dict
-    r69 = r65[r68] :: object
-    r70 = (r61, r62, r69) :: tuple
-    r71 = unicode_7 :: static  ('__main__')
-    r72 = __main__.D_template :: type
-    r73 = pytype_from_template(r72, r70, r71)
-    r74 = D_trait_vtable_setup()
-    r75 = unicode_8 :: static  ('__mypyc_attrs__')
-    r76 = unicode_11 :: static  ('__dict__')
-    r77 = (r76) :: tuple
-    r78 = setattr r73, r75, r77
-    __main__.D = r73 :: type
-    r79 = __main__.globals :: static
-    r80 = unicode_12 :: static  ('D')
-    r81 = r79.__setitem__(r80, r73) :: dict
-    r82 = None
-    return r82
+    r57 = __main__.globals :: static
+    r58 = unicode_10 :: static  ('S')
+    r59 = r57.__setitem__(r58, r53) :: dict
+    r60 = __main__.C :: type
+    r61 = __main__.S :: type
+    r62 = __main__.globals :: static
+    r63 = unicode_3 :: static  ('Generic')
+    r64 = r62[r63] :: dict
+    r65 = __main__.globals :: static
+    r66 = unicode_6 :: static  ('T')
+    r67 = r65[r66] :: dict
+    r68 = r64[r67] :: object
+    r69 = (r60, r61, r68) :: tuple
+    r70 = unicode_7 :: static  ('__main__')
+    r71 = __main__.D_template :: type
+    r72 = pytype_from_template(r71, r69, r70)
+    r73 = D_trait_vtable_setup()
+    r74 = unicode_8 :: static  ('__mypyc_attrs__')
+    r75 = unicode_11 :: static  ('__dict__')
+    r76 = (r75) :: tuple
+    r77 = setattr r72, r74, r76
+    __main__.D = r72 :: type
+    r78 = __main__.globals :: static
+    r79 = unicode_12 :: static  ('D')
+    r80 = r78.__setitem__(r79, r72) :: dict
+    r81 = None
+    return r81
 
 [case testIsInstance]
 class A: pass


### PR DESCRIPTION
This lets us eliminate the CPy_FixupTraitVtable hack where we fixed up
vtables at runtime in a hokey manner and will allow us to populate
vtables with entries loaded dynamically from other modules once we
have separate compilation.