### PR TITLE
[mypyc] Tweak how tuple structs are defined

### DIFF
--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -248,7 +248,7 @@ class RTuple(RType):
         self.unique_id = self.accept(TupleNameVisitor())
         # Nominally the max c length is 31 chars, but I'm not honestly worried about this.
         self.struct_name = 'tuple_{}'.format(self.unique_id)
-        self._ctype = 'struct {}'.format(self.struct_name)
+        self._ctype = '{}'.format(self.struct_name)
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_rtuple(self)


### PR DESCRIPTION
Change how we declare and define tuple structs to prepare for separate compilation:
 * Wrap declarations in an #ifdef/#define so that multiple modules
   can define the same tuple types (since they are structural) and
   interoperate properly.
 * Declare the undefined values eagerly instead of only when they
   are needed, since they might be needed by another compilationg group.
 * Declare them with a typedef instead of always writing struct. This
   will very slightly simplify some logic for manipulating the type string
   later but mostly just looks better.