### PR TITLE
[mypyc] Reorganization of headers and declarations

### DIFF
--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -29,7 +29,8 @@ class HeaderDeclaration:
       decl: C source code for the declaration.
       defn: Optionally, C source code for a definition.
       dependencies: The names of any objects that must be declared prior.
-      is_type: Whether the declaration is of a type.
+      is_type: Whether the declaration is of a C type. (C types will be declared in
+               external header files and not marked 'extern'.)
     """
 
     def __init__(self,

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -20,13 +20,29 @@ from mypyc.sametype import is_same_type
 
 
 class HeaderDeclaration:
+    """A representation of a declaration in C.
+
+    This is used to generate declarations in header files and
+    (optionally) definitions in source files.
+
+    Attributes:
+      decl: C source code for the declaration.
+      defn: Optionally, C source code for a definition.
+      dependencies: The names of any objects that must be declared prior.
+      is_type: Whether the declaration is of a type.
+    """
+
     def __init__(self,
-                 dependencies: Set[str], decl: List[str], defn: Optional[List[str]],
-                 needs_extern: bool = False) -> None:
-        self.dependencies = dependencies
-        self.decl = decl
+                 decl: Union[str, List[str]],
+                 defn: Optional[List[str]] = None,
+                 *,
+                 dependencies: Optional[Set[str]] = None,
+                 is_type: bool = False
+                 ) -> None:
+        self.decl = [decl] if isinstance(decl, str) else decl
         self.defn = defn
-        self.needs_extern = needs_extern
+        self.dependencies = dependencies or set()
+        self.is_type = is_type
 
 
 class EmitterContext:
@@ -220,9 +236,9 @@ class Emitter:
                     dependencies.add(typ.struct_name)
 
             self.context.declarations[tuple_type.struct_name] = HeaderDeclaration(
-                dependencies,
                 self.tuple_c_declaration(tuple_type),
-                None,
+                dependencies=dependencies,
+                is_type=True,
             )
 
     def emit_inc_ref(self, dest: str, rtype: RType) -> None:

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -85,7 +85,7 @@ def generate_function_declaration(fn: FuncIR, emitter: Emitter) -> None:
     emitter.context.declarations[emitter.native_function_name(fn.decl)] = HeaderDeclaration(
         '{};'.format(native_function_header(fn.decl, emitter)))
     if fn.name != TOP_LEVEL_NAME:
-        emitter.context.declarations[PREFIX+fn.cname(emitter.names)] = HeaderDeclaration(
+        emitter.context.declarations[PREFIX + fn.cname(emitter.names)] = HeaderDeclaration(
             '{};'.format(wrapper_function_header(fn, emitter.names)))
 
 

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -82,9 +82,11 @@ def compile_modules_to_c(result: BuildResult, module_names: List[str],
 
 
 def generate_function_declaration(fn: FuncIR, emitter: Emitter) -> None:
-    emitter.emit_line('{};'.format(native_function_header(fn.decl, emitter)))
+    emitter.context.declarations[emitter.native_function_name(fn.decl)] = HeaderDeclaration(
+        '{};'.format(native_function_header(fn.decl, emitter)))
     if fn.name != TOP_LEVEL_NAME:
-        emitter.emit_line('{};'.format(wrapper_function_header(fn, emitter.names)))
+        emitter.context.declarations[PREFIX+fn.cname(emitter.names)] = HeaderDeclaration(
+            '{};'.format(wrapper_function_header(fn, emitter.names)))
 
 
 def encode_as_c_string(s: str) -> Tuple[str, int]:
@@ -127,6 +129,7 @@ class ModuleGenerator:
 
         base_emitter = Emitter(self.context)
         base_emitter.emit_line('#include "__native.h"')
+        base_emitter.emit_line('#include "__native_internal.h"')
         emitter = base_emitter
 
         for (_, literal), identifier in self.literals.items():
@@ -140,6 +143,7 @@ class ModuleGenerator:
             if multi_file:
                 emitter = Emitter(self.context)
                 emitter.emit_line('#include "__native.h"')
+                emitter.emit_line('#include "__native_internal.h"')
 
             self.declare_module(module_name, emitter)
             self.declare_internal_globals(module_name, emitter)
@@ -166,6 +170,33 @@ class ModuleGenerator:
                 name = ('__native_{}.c'.format(emitter.names.private_name(module_name)))
                 file_contents.append((name, ''.join(emitter.fragments)))
 
+        # The external header file contains type declarations while
+        # the internal contains declarations of functions and objects
+        # (which are shared between shared libraries via dynamic
+        # linking tables and not accessed directly.)
+        ext_declarations = Emitter(self.context)
+        ext_declarations.emit_line('#ifndef MYPYC_NATIVE_H')
+        ext_declarations.emit_line('#define MYPYC_NATIVE_H')
+        ext_declarations.emit_line('#include <Python.h>')
+        ext_declarations.emit_line('#include <CPy.h>')
+
+        declarations = Emitter(self.context)
+        declarations.emit_line('#ifndef MYPYC_NATIVE_INTERNAL_H')
+        declarations.emit_line('#define MYPYC_NATIVE_INTERNAL_H')
+        declarations.emit_line('#include <Python.h>')
+        declarations.emit_line('#include <CPy.h>')
+        declarations.emit_line('#include "__native.h"')
+        declarations.emit_line()
+        declarations.emit_line('int CPyGlobalsInit(void);')
+        declarations.emit_line()
+
+        for module_name, module in self.modules:
+            self.declare_finals(module_name, module.final_names, declarations)
+            for cl in module.classes:
+                generate_class_type_decl(cl, emitter, ext_declarations, declarations)
+            for fn in module.functions:
+                generate_function_declaration(fn, declarations)
+
         sorted_decls = self.toposort_declarations()
 
         emitter = base_emitter
@@ -176,33 +207,25 @@ class ModuleGenerator:
 
         emitter.emit_line()
 
-        declarations = Emitter(self.context)
-        declarations.emit_line('#include <Python.h>')
-        declarations.emit_line('#include <CPy.h>')
-        declarations.emit_line()
-        declarations.emit_line('int CPyGlobalsInit(void);')
-        declarations.emit_line()
-
         for declaration in sorted_decls:
-            if declaration.needs_extern:
-                declarations.emit_lines(
+            decls = ext_declarations if declaration.is_type else declarations
+            if not declaration.is_type:
+                decls.emit_lines(
                     'extern {}'.format(declaration.decl[0]), *declaration.decl[1:])
                 emitter.emit_lines(*declaration.decl)
             else:
-                declarations.emit_lines(*declaration.decl)
-
-        for module_name, module in self.modules:
-            self.declare_finals(module_name, module.final_names, declarations)
-            for cl in module.classes:
-                generate_class_type_decl(cl, emitter, declarations)
-            for fn in module.functions:
-                generate_function_declaration(fn, declarations)
+                decls.emit_lines(*declaration.decl)
 
         if self.shared_lib_name:
             self.generate_shared_lib_init(emitter)
 
+        ext_declarations.emit_line('#endif')
+        declarations.emit_line('#endif')
+
         return file_contents + [('__native.c', ''.join(emitter.fragments)),
-                                ('__native.h', ''.join(declarations.fragments))]
+                                ('__native_internal.h', ''.join(declarations.fragments)),
+                                ('__native.h', ''.join(ext_declarations.fragments)),
+                                ]
 
     def generate_shared_lib_init(self, emitter: Emitter) -> None:
         """Generate the init function for a shared library.
@@ -438,6 +461,7 @@ class ModuleGenerator:
         return result
 
     def declare_global(self, type_spaced: str, name: str,
+                       *,
                        initializer: Optional[str] = None) -> None:
         if not initializer:
             defn = None
@@ -445,10 +469,8 @@ class ModuleGenerator:
             defn = ['{}{} = {};'.format(type_spaced, name, initializer)]
         if name not in self.context.declarations:
             self.context.declarations[name] = HeaderDeclaration(
-                set(),
-                ['{}{};'.format(type_spaced, name)],
-                defn,
-                needs_extern=True,
+                '{}{};'.format(type_spaced, name),
+                defn=defn,
             )
 
     def declare_internal_globals(self, module_name: str, emitter: Emitter) -> None:


### PR DESCRIPTION
This splits the headers we generate into internal headers (containing
type declarations) and external headers (containing function and
object declarations) and refactors declarations to be much more driven
by HeaderDeclaration objects. This will allow us to use
HeaderDeclaration information to populate structures for dynamic
linking in separate compilation.