### PR TITLE
[mypyc] Support separate compilation

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -188,19 +188,11 @@ def generate_c(sources: List[BuildSource], options: Options,
 
     errors = Errors()
 
-    mapper = emitmodule.prepare_groups(result, all_module_names,
-                                       compiler_options=compiler_options,
-                                       errors=errors)
-
     ops = []  # type: List[str]
-    ctext = []  # type: List[List[Tuple[str, str]]]
-    for group_sources, shared_lib_name in groups:
-        module_names = [source.module for source in group_sources]
-        ctext.append(emitmodule.compile_modules_to_c(result, module_names, shared_lib_name,
-                                                     mapper,
-                                                     compiler_options=compiler_options,
-                                                     errors=errors, ops=ops,
-                                                     groups=groups))
+    ctext = emitmodule.compile_modules_to_c(result,
+                                            compiler_options=compiler_options,
+                                            errors=errors, ops=ops,
+                                            groups=groups)
     if errors.num_errors:
         errors.flush_errors()
         sys.exit(1)
@@ -288,14 +280,15 @@ def write_file(path: str, contents: str) -> None:
             f.write(contents)
 
 
-def mypycify(paths: List[str],
-             mypy_options: Optional[List[str]] = None,
-             opt_level: str = '3',
-             multi_file: bool = False,
-             skip_cgen: bool = False,
-             verbose: bool = False,
-             strip_asserts: bool = False,
-             separate: Union[bool, List[Tuple[List[str], Optional[str]]]] = False,
+def mypycify(
+    paths: List[str],
+    mypy_options: Optional[List[str]] = None,
+    opt_level: str = '3',
+    multi_file: bool = False,
+    skip_cgen: bool = False,
+    verbose: bool = False,
+    strip_asserts: bool = False,
+    separate: Union[bool, List[Tuple[List[str], Optional[str]]]] = False,
 ) -> List[Extension]:
     """Main entry point to building using mypyc.
 
@@ -336,7 +329,9 @@ def mypycify(paths: List[str],
     use_shared_lib = len(sources) > 1 or any('.' in x.module for x in sources)
 
     if separate is True:
-        groups = [([source], None) for source in sources]  # type: List[Tuple[List[BuildSource], Optional[str]]]
+        groups = [  # type: List[Tuple[List[BuildSource], Optional[str]]]
+            ([source], None) for source in sources
+        ]
     elif isinstance(separate, list):
         groups = []
         for files, name in separate:

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -182,13 +182,22 @@ def generate_c(sources: List[BuildSource], options: Options,
     if compiler_options.verbose:
         print("Parsed and typechecked in {:.3f}s".format(t1 - t0))
 
+    all_module_names = []
+    for group_sources, _ in groups:
+        all_module_names.extend([source.module for source in group_sources])
+
     errors = Errors()
+
+    mapper = emitmodule.prepare_groups(result, all_module_names,
+                                       compiler_options=compiler_options,
+                                       errors=errors)
 
     ops = []  # type: List[str]
     ctext = []  # type: List[Tuple[str, str]]
     for group_sources, shared_lib_name in groups:
         module_names = [source.module for source in group_sources]
         ctext += emitmodule.compile_modules_to_c(result, module_names, shared_lib_name,
+                                                 mapper,
                                                  compiler_options=compiler_options,
                                                  errors=errors, ops=ops)
     if errors.num_errors:

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -112,7 +112,7 @@ shim_template = """\
 PyMODINIT_FUNC
 PyInit_{modname}(void)
 {{
-    void *init_func = PyCapsule_Import("{libname}.{full_modname}", 0);
+    void *init_func = PyCapsule_Import("{libname}.init_{full_modname}", 0);
     if (!init_func) {{
         return NULL;
     }}

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -294,10 +294,14 @@ def construct_groups(
         ]  # type: List[Tuple[List[BuildSource], Optional[str]]]
     elif isinstance(separate, list):
         groups = []
+        used_sources = set()
         for files, name in separate:
-            groups.append((
-                [src for src in sources if src.path in files],
-                name))
+            group_sources = [src for src in sources if src.path in files]
+            groups.append((group_sources, name))
+            used_sources.update(group_sources)
+        unused_sources = [src for src in sources if src not in used_sources]
+        if unused_sources:
+            groups.extend([([source], None) for source in unused_sources])
     else:
         groups = [(sources, None)]
 

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -138,7 +138,7 @@ def generate_c_extension_shim(
         dir_name: the directory to place source code
         group_name: the name of the group
     """
-    cname = '%s.c' % full_module_name.replace('.', '___')  # XXX
+    cname = '%s.c' % exported_name(full_module_name)
     cpath = os.path.join(dir_name, cname)
 
     write_file(
@@ -152,6 +152,9 @@ def generate_c_extension_shim(
 
 def group_name(modules: List[str]) -> str:
     """Produce a probably unique name for a group from a list of module names."""
+    if len(modules) == 1:
+        return exported_name(modules[0])
+
     h = hashlib.sha1()
     h.update(','.join(modules).encode())
     return h.hexdigest()[:20]

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -133,10 +133,10 @@ def generate_c_extension_shim(
     """Create a C extension shim with a passthrough PyInit function.
 
     Arguments:
-      * full_module_name: the dotted full module name
-      * module_name: the final component of the module name
-      * dir_name: the directory to place source code
-      * group_name: the name of the group
+        full_module_name: the dotted full module name
+        module_name: the final component of the module name
+        dir_name: the directory to place source code
+        group_name: the name of the group
     """
     cname = '%s.c' % full_module_name.replace('.', '___')  # XXX
     cpath = os.path.join(dir_name, cname)
@@ -338,7 +338,7 @@ def get_header_deps(cfiles: List[Tuple[str, str]]) -> List[str]:
     properly plumbing the data through.
 
     Arguments:
-      * cfiles: A list of (file name, file contents) pairs.
+        cfiles: A list of (file name, file contents) pairs.
     """
     headers = set()  # type: Set[str]
     for _, contents in cfiles:
@@ -364,18 +364,18 @@ def mypycify(
     ext_modules parameter to setup.
 
     Arguments:
-      * paths: A list of file paths to build. It may contain globs.
-      * mypy_options: Optionally, a list of command line flags to pass to mypy.
+        paths: A list of file paths to build. It may contain globs.
+        mypy_options: Optionally, a list of command line flags to pass to mypy.
                       (This can also contain additional files, for compatibility reasons.)
-      * verbose: Should mypyc be more verbose. Defaults to false.
+        verbose: Should mypyc be more verbose. Defaults to false.
 
-      * opt_level: The optimization level, as a string. Defaults to '3' (meaning '-O3').
-      * strip_asserts: Should asserts be stripped from the generated code.
+        opt_level: The optimization level, as a string. Defaults to '3' (meaning '-O3').
+        strip_asserts: Should asserts be stripped from the generated code.
 
-      * multi_file: Should each Python module be compiled into its own C source file.
+        multi_file: Should each Python module be compiled into its own C source file.
                     This can reduce compile time and memory requirements at the likely
                     cost of runtime performance of compiled code. Defaults to false.
-      * separate: Should compiled modules be placed in separate extension modules.
+        separate: Should compiled modules be placed in separate extension modules.
                   If False, all modules are placed in a single shared library.
                   If True, every module is placed in its own library.
                   Otherwise separate should be a list of

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -129,17 +129,17 @@ PyMODINIT_FUNC PyInit___init__(void) {{ return PyInit_{modname}(); }}
 
 
 def generate_c_extension_shim(
-        full_module_name: str, module_name: str, dirname: str, group_name: str) -> str:
+        full_module_name: str, module_name: str, dir_name: str, group_name: str) -> str:
     """Create a C extension shim with a passthrough PyInit function.
 
     Arguments:
       * full_module_name: the dotted full module name
       * module_name: the final component of the module name
-      * dirname: the directory to place source code
-      * libname: the name of the module where the code actually lives
+      * dir_name: the directory to place source code
+      * group_name: the name of the group
     """
     cname = '%s.c' % full_module_name.replace('.', '___')  # XXX
-    cpath = os.path.join(dirname, cname)
+    cpath = os.path.join(dir_name, cname)
 
     write_file(
         cpath,

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -472,15 +472,13 @@ def mypycify(
                 '/wd9025',  # warning about overriding /GL
             ]
 
-    # In multi-file mode, copy the runtime library in.
-    # Otherwise it just gets #included to save on compiler invocations
+    # Copy the runtime library in
     shared_cfilenames = []
-    if multi_file:
-        for name in ['CPy.c', 'getargs.c']:
-            rt_file = os.path.join(build_dir, name)
-            with open(os.path.join(include_dir(), name), encoding='utf-8') as f:
-                write_file(rt_file, f.read())
-            shared_cfilenames.append(rt_file)
+    for name in ['CPy.c', 'getargs.c']:
+        rt_file = os.path.join(build_dir, name)
+        with open(os.path.join(include_dir(), name), encoding='utf-8') as f:
+            write_file(rt_file, f.read())
+        shared_cfilenames.append(rt_file)
 
     extensions = []
     for (group_sources, lib_name), (cfilenames, deps) in zip(groups, group_cfilenames):

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -385,6 +385,11 @@ def mypycify(
                   (file name list, optional shared library name) pairs specifying
                   groups of files that should be placed in the same shared library
                   (while all other modules will be placed in its own library).
+
+                  Each group can be compiled independently, which can
+                  speed up compilation, but calls between groups can
+                  be slower than calls within a group and can't be
+                  inlined.
     """
 
     setup_mypycify_vars()
@@ -467,13 +472,15 @@ def mypycify(
                 '/wd9025',  # warning about overriding /GL
             ]
 
-    # Copy the runtime library in
+    # In multi-file mode, copy the runtime library in.
+    # Otherwise it just gets #included to save on compiler invocations
     shared_cfilenames = []
-    for name in ['CPy.c', 'getargs.c']:
-        rt_file = os.path.join(build_dir, name)
-        with open(os.path.join(include_dir(), name), encoding='utf-8') as f:
-            write_file(rt_file, f.read())
-        shared_cfilenames.append(rt_file)
+    if multi_file:
+        for name in ['CPy.c', 'getargs.c']:
+            rt_file = os.path.join(build_dir, name)
+            with open(os.path.join(include_dir(), name), encoding='utf-8') as f:
+                write_file(rt_file, f.read())
+            shared_cfilenames.append(rt_file)
 
     extensions = []
     for (group_sources, lib_name), (cfilenames, deps) in zip(groups, group_cfilenames):

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 MYPY = False
 if MYPY:
     from typing_extensions import Final
@@ -31,3 +33,7 @@ FAST_ISINSTANCE_MAX_SUBCLASSES = 2  # type: Final
 
 def decorator_helper_name(func_name: str) -> str:
     return '__mypyc_{}_decorator_helper__'.format(func_name)
+
+
+def lib_suffix(shared_lib_name: Optional[str]) -> str:
+    return '' if shared_lib_name is None else shared_lib_name[5:]

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -34,4 +34,8 @@ def decorator_helper_name(func_name: str) -> str:
 
 
 def shared_lib_name(group_name: str) -> str:
+    """Given a group name, return the actual name of its extension module.
+
+    (This just adds a prefix.)
+    """
     return 'mypyc_{}'.format(group_name)

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -33,5 +33,5 @@ def decorator_helper_name(func_name: str) -> str:
     return '__mypyc_{}_decorator_helper__'.format(func_name)
 
 
-def lib_suffix(shared_lib_name: Optional[str]) -> str:
-    return '' if shared_lib_name is None else shared_lib_name[5:]
+def shared_lib_name(group_name: str) -> str:
+    return 'mypyc_{}'.format(group_name)

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 MYPY = False
 if MYPY:
     from typing_extensions import Final

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -171,6 +171,8 @@ class Emitter:
         group.
         """
         lib_prefix = '' if not module else self.get_module_lib_prefix(module)
+        # If we are accessing static via the export table, we need to dereference
+        # the pointer also.
         star_maybe = '*' if lib_prefix else ''
         suffix = self.names.private_name(module or '', id)
         return '{}{}{}{}'.format(star_maybe, lib_prefix, prefix, suffix)

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -53,13 +53,22 @@ class HeaderDeclaration:
 class EmitterContext:
     """Shared emitter state for a compilation group."""
 
-    def __init__(self, module_names: List[str],
+    def __init__(self,
+                 names: NameGenerator,
+                 group_name: Optional[str] = None,
                  group_map: Optional[Dict[str, Optional[str]]] = None,
-                 group_name: Optional[str] = None) -> None:
+                 ) -> None:
+        """Setup shared emitter state.
+
+        Args:
+            names: The name generator to use
+            group_map: Map from module names to group name
+            group_name: Current group name
+        """
         self.temp_counter = 0
-        self.names = NameGenerator(module_names, is_separate=group_map is not None)
-        self.group_map = group_map or {}
+        self.names = names
         self.group_name = group_name
+        self.group_map = group_map or {}
         # Groups that this group depends on
         self.group_deps = set()  # type: Set[str]
 

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -58,7 +58,7 @@ class EmitterContext:
                  group_map: Optional[Dict[str, Optional[str]]] = None,
                  shared_lib_name: Optional[str] = None) -> None:
         self.temp_counter = 0
-        self.names = NameGenerator(module_names)
+        self.names = NameGenerator(module_names, is_separate=group_map is not None)
         self.group_map = group_map or {}
         self.shared_lib_name = shared_lib_name
         self.library_deps = set()  # type: Set[str]

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -5,7 +5,8 @@ from typing import List, Set, Dict, Optional, Callable, Union
 
 from mypyc.common import (
     REG_PREFIX, ATTR_PREFIX, STATIC_PREFIX, TYPE_PREFIX, NATIVE_PREFIX,
-    FAST_ISINSTANCE_MAX_SUBCLASSES
+    FAST_ISINSTANCE_MAX_SUBCLASSES,
+    lib_suffix,
 )
 from mypyc.ops import (
     Environment, BasicBlock, Value, RType, RTuple, RInstance,
@@ -53,9 +54,14 @@ class HeaderDeclaration:
 class EmitterContext:
     """Shared emitter state for an entire compilation unit."""
 
-    def __init__(self, module_names: List[str]) -> None:
+    def __init__(self, module_names: List[str],
+                 group_map: Optional[Dict[str, Optional[str]]] = None,
+                 shared_lib_name: Optional[str] = None) -> None:
         self.temp_counter = 0
         self.names = NameGenerator(module_names)
+        self.group_map = group_map or {}
+        self.shared_lib_name = shared_lib_name
+        self.library_deps = set()  # type: Set[str]
 
         # The map below is used for generating declarations and
         # definitions at the top of the C file. The main idea is that they can
@@ -130,6 +136,28 @@ class Emitter:
         self.context.temp_counter += 1
         return '__LL%d' % self.context.temp_counter
 
+    def get_lib_prefix(self, obj: Union[str, ClassIR, FuncDecl],
+                       *,
+                       is_variable: bool = False) -> str:
+        """Get the library prefix for an object.
+
+        The prefix should be prepended to the object name whenever
+        accessing it.
+
+        If the object lives in the current shared library, there is
+        no prefix.  But if it lives in a different library, we need to
+        access it indirectly via an export table.
+        """
+        module_name = obj if isinstance(obj, str) else obj.module_name
+        groups = self.context.group_map
+        target_name = groups.get(module_name)
+        if target_name and target_name != self.context.shared_lib_name:
+            self.context.library_deps.add(target_name)
+            star_maybe = '*' if is_variable else ''
+            return '{}exports{}.'.format(star_maybe, lib_suffix(target_name))
+        else:
+            return ''
+
     def static_name(self, id: str, module: Optional[str], prefix: str = STATIC_PREFIX) -> str:
         """Create name of a C static variable.
 
@@ -140,8 +168,9 @@ class Emitter:
         overlap with other calls to this method within a compilation
         unit.
         """
+        lib_prefix = '' if not module else self.get_lib_prefix(module, is_variable=True)
         suffix = self.names.private_name(module or '', id)
-        return '{}{}'.format(prefix, suffix)
+        return '{}{}{}'.format(lib_prefix, prefix, suffix)
 
     def type_struct_name(self, cl: ClassIR) -> str:
         return self.static_name(cl.name, cl.module_name, prefix=TYPE_PREFIX)

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -31,6 +31,8 @@ class HeaderDeclaration:
       dependencies: The names of any objects that must be declared prior.
       is_type: Whether the declaration is of a C type. (C types will be declared in
                external header files and not marked 'extern'.)
+      needs_export: Whether the declared object needs to be exported to
+                    other modules in the linking table.
     """
 
     def __init__(self,
@@ -38,12 +40,14 @@ class HeaderDeclaration:
                  defn: Optional[List[str]] = None,
                  *,
                  dependencies: Optional[Set[str]] = None,
-                 is_type: bool = False
+                 is_type: bool = False,
+                 needs_export: bool = False
                  ) -> None:
         self.decl = [decl] if isinstance(decl, str) else decl
         self.defn = defn
         self.dependencies = dependencies or set()
         self.is_type = is_type
+        self.needs_export = needs_export
 
 
 class EmitterContext:

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -84,14 +84,18 @@ def generate_class_type_decl(cl: ClassIR, c_emitter: Emitter,
     context = c_emitter.context
     name = emitter.type_struct_name(cl)
     context.declarations[name] = HeaderDeclaration(
-        'PyTypeObject *{};'.format(emitter.type_struct_name(cl)))
+        'PyTypeObject *{};'.format(emitter.type_struct_name(cl)),
+        needs_export=True)
 
     generate_object_struct(cl, external_emitter)
-    declare_native_getters_and_setters(cl, emitter)
     generate_full = not cl.is_trait and not cl.builtin_base
     if generate_full:
+        declare_native_getters_and_setters(cl, emitter)
+
         context.declarations[emitter.native_function_name(cl.ctor)] = HeaderDeclaration(
-            '{};'.format(native_function_header(cl.ctor, emitter)))
+            '{};'.format(native_function_header(cl.ctor, emitter)),
+            needs_export=True,
+        )
 
 
 def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
@@ -274,12 +278,14 @@ def declare_native_getters_and_setters(cl: ClassIR,
         decls[getter_name] = HeaderDeclaration(
             '{}{}({} *self);'.format(emitter.ctype_spaced(rtype),
                                      getter_name,
-                                     cl.struct_name(emitter.names))
+                                     cl.struct_name(emitter.names)),
+            needs_export=True,
         )
         decls[setter_name] = HeaderDeclaration(
             'bool {}({} *self, {}value);'.format(native_setter_name(cl, attr, emitter.names),
                                                  cl.struct_name(emitter.names),
-                                                 emitter.ctype_spaced(rtype))
+                                                 emitter.ctype_spaced(rtype)),
+            needs_export=True,
         )
 
 

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -397,14 +397,14 @@ def generate_vtable(entries: VTableEntries,
     for entry in entries:
         if isinstance(entry, VTableMethod):
             emitter.emit_line('(CPyVTableItem){}{}{},'.format(
-                emitter.get_lib_prefix(entry.method.decl),
+                emitter.get_group_prefix(entry.method.decl),
                 NATIVE_PREFIX,
                 entry.method.cname(emitter.names)))
         else:
             cl, attr, is_setter = entry
             namer = native_setter_name if is_setter else native_getter_name
             emitter.emit_line('(CPyVTableItem){}{},'.format(
-                emitter.get_lib_prefix(cl),
+                emitter.get_group_prefix(cl),
                 namer(cl, attr, emitter.names)))
     # msvc doesn't allow empty arrays; maybe allowing them at all is an extension?
     if not entries:
@@ -462,7 +462,7 @@ def generate_constructor_for_class(cl: ClassIR,
     args = ', '.join(['self'] + [REG_PREFIX + arg.name for arg in fn.sig.args])
     if init_fn is not None:
         emitter.emit_line('char res = {}{}{}({});'.format(
-            emitter.get_lib_prefix(init_fn.decl),
+            emitter.get_group_prefix(init_fn.decl),
             NATIVE_PREFIX, init_fn.cname(emitter.names), args))
         emitter.emit_line('if (res == 2) {')
         emitter.emit_line('Py_DECREF(self);')

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -462,7 +462,8 @@ def generate_constructor_for_class(cl: ClassIR,
     args = ', '.join(['self'] + [REG_PREFIX + arg.name for arg in fn.sig.args])
     if init_fn is not None:
         emitter.emit_line('char res = {}{}{}({});'.format(
-            emitter.get_lib_prefix(init_fn.decl), NATIVE_PREFIX, init_fn.cname(emitter.names), args))
+            emitter.get_lib_prefix(init_fn.decl),
+            NATIVE_PREFIX, init_fn.cname(emitter.names), args))
         emitter.emit_line('if (res == 2) {')
         emitter.emit_line('Py_DECREF(self);')
         emitter.emit_line('return NULL;')

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -224,7 +224,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             # duplicating getter/setter code.
             self.emit_line('%s = %s%s((%s *)%s); /* %s */' % (
                 dest,
-                self.emitter.get_lib_prefix(decl_cl),
+                self.emitter.get_group_prefix(decl_cl),
                 native_getter_name(decl_cl, op.attr, self.emitter.names),
                 decl_cl.struct_name(self.names),
                 obj,
@@ -252,7 +252,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             typ, decl_cl = cl.attr_details(op.attr)
             self.emit_line('%s = %s%s((%s *)%s, %s); /* %s */' % (
                 dest,
-                self.emitter.get_lib_prefix(decl_cl),
+                self.emitter.get_group_prefix(decl_cl),
                 native_setter_name(decl_cl, op.attr, self.emitter.names),
                 decl_cl.struct_name(self.names),
                 obj,
@@ -303,7 +303,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         """Call native function."""
         dest = self.get_dest_assign(op)
         args = ', '.join(self.reg(arg) for arg in op.args)
-        lib = self.emitter.get_lib_prefix(op.fn)
+        lib = self.emitter.get_group_prefix(op.fn)
         cname = op.fn.cname(self.names)
         self.emit_line('%s%s%s%s(%s);' % (dest, lib, NATIVE_PREFIX, cname, args))
 
@@ -333,7 +333,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         version = '_TRAIT' if rtype.class_ir.is_trait else ''
         if is_direct:
             # Directly call method, without going through the vtable.
-            lib = self.emitter.get_lib_prefix(method.decl)
+            lib = self.emitter.get_group_prefix(method.decl)
             self.emit_line('{}{}{}{}({});'.format(
                 dest, lib, NATIVE_PREFIX, method.cname(self.names), args))
         else:

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -60,8 +60,9 @@ def compile_modules_to_c(
             group_map[source.module] = lib_name
 
     # Generate basic IR, with missing exception and refcount handling.
+    mapper = genops.Mapper(group_map)
     literals, modules = genops.build_ir(file_nodes, result.graph, result.types,
-                                        group_map,
+                                        mapper,
                                         compiler_options, errors)
     if errors.num_errors > 0:
         return []

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -42,16 +42,24 @@ def parse_and_typecheck(sources: List[BuildSource], options: Options,
     return result
 
 
+def prepare_groups(result: BuildResult,
+                   module_names: List[str],
+                   compiler_options: CompilerOptions,
+                   errors: Errors) -> genops.Mapper:
+    file_nodes = [result.files[name] for name in module_names]
+    return genops.build_type_map(file_nodes, result.graph, result.types, errors)
+
+
 def compile_modules_to_c(result: BuildResult, module_names: List[str],
                          shared_lib_name: Optional[str],
+                         mapper: genops.Mapper,
                          compiler_options: CompilerOptions,
                          errors: Errors,
                          ops: Optional[List[str]] = None) -> List[Tuple[str, str]]:
     """Compile Python module(s) to C that can be used from Python C extension modules."""
-
     # Generate basic IR, with missing exception and refcount handling.
     file_nodes = [result.files[name] for name in module_names]
-    literals, modules = genops.build_ir(file_nodes, result.graph, result.types,
+    literals, modules = genops.build_ir(file_nodes, result.graph, result.types, mapper,
                                         compiler_options, errors)
     if errors.num_errors > 0:
         return []

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -314,6 +314,7 @@ class ModuleGenerator:
             'PyObject *capsule;',
             'static PyObject *module;',
             'if (module) {',
+            'Py_INCREF(module);',
             'return module;',
             '}',
             'module = PyModule_Create(&def);',

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -8,7 +8,7 @@ from mypy.errors import CompileError
 from mypy.options import Options
 
 from mypyc import genops
-from mypyc.common import PREFIX, TOP_LEVEL_NAME, INT_PREFIX, MODULE_PREFIX
+from mypyc.common import PREFIX, TOP_LEVEL_NAME, INT_PREFIX, MODULE_PREFIX, lib_suffix
 from mypyc.emit import EmitterContext, Emitter, HeaderDeclaration
 from mypyc.emitfunc import generate_native_function, native_function_header
 from mypyc.emitclass import generate_class_type_decl, generate_class
@@ -55,7 +55,9 @@ def compile_modules_to_c(result: BuildResult, module_names: List[str],
                          mapper: genops.Mapper,
                          compiler_options: CompilerOptions,
                          errors: Errors,
-                         ops: Optional[List[str]] = None) -> List[Tuple[str, str]]:
+                         ops: Optional[List[str]] = None,
+                         groups: Optional[List[Tuple[List[BuildSource], Optional[str]]]] = None,
+) -> List[Tuple[str, str]]:
     """Compile Python module(s) to C that can be used from Python C extension modules."""
     # Generate basic IR, with missing exception and refcount handling.
     file_nodes = [result.files[name] for name in module_names]
@@ -84,7 +86,14 @@ def compile_modules_to_c(result: BuildResult, module_names: List[str],
     # Generate C code.
     source_paths = {module_name: result.files[module_name].path
                     for module_name in module_names}
+    group_map = {}
+    if groups:
+        for group, lib_name in groups:
+            for source in group:
+                group_map[source.module] = lib_name
+
     generator = ModuleGenerator(literals, modules, source_paths, shared_lib_name,
+                                group_map,
                                 compiler_options.multi_file)
     return generator.generate_c_for_modules()
 
@@ -127,11 +136,12 @@ class ModuleGenerator:
                  modules: List[Tuple[str, ModuleIR]],
                  source_paths: Dict[str, str],
                  shared_lib_name: Optional[str],
+                 group_map: Dict[str, Optional[str]],
                  multi_file: bool) -> None:
         self.literals = literals
         self.modules = modules
         self.source_paths = source_paths
-        self.context = EmitterContext([name for name, _ in modules])
+        self.context = EmitterContext([name for name, _ in modules], group_map, shared_lib_name)
         self.names = self.context.names
         # Initializations of globals to simple values that we can't
         # do statically because the windows loader is bad.
@@ -142,7 +152,7 @@ class ModuleGenerator:
 
     @property
     def lib_suffix(self) -> str:
-        return '' if self.shared_lib_name is None else self.shared_lib_name[5:]
+        return lib_suffix(self.shared_lib_name)
 
     def generate_c_for_modules(self) -> List[Tuple[str, str]]:
         file_contents = []
@@ -196,14 +206,14 @@ class ModuleGenerator:
         # (which are shared between shared libraries via dynamic
         # linking tables and not accessed directly.)
         ext_declarations = Emitter(self.context)
-        ext_declarations.emit_line('#ifndef MYPYC_NATIVE_H')
-        ext_declarations.emit_line('#define MYPYC_NATIVE_H')
+        ext_declarations.emit_line('#ifndef MYPYC_NATIVE{}_H'.format(self.lib_suffix))
+        ext_declarations.emit_line('#define MYPYC_NATIVE{}_H'.format(self.lib_suffix))
         ext_declarations.emit_line('#include <Python.h>')
         ext_declarations.emit_line('#include <CPy.h>')
 
         declarations = Emitter(self.context)
-        declarations.emit_line('#ifndef MYPYC_NATIVE_INTERNAL_H')
-        declarations.emit_line('#define MYPYC_NATIVE_INTERNAL_H')
+        declarations.emit_line('#ifndef MYPYC_NATIVE_INTERNAL{}_H'.format(self.lib_suffix))
+        declarations.emit_line('#define MYPYC_NATIVE_INTERNAL{}_H'.format(self.lib_suffix))
         declarations.emit_line('#include <Python.h>')
         declarations.emit_line('#include <CPy.h>')
         declarations.emit_line('#include "__native{}.h"'.format(self.lib_suffix))
@@ -217,6 +227,13 @@ class ModuleGenerator:
                 generate_class_type_decl(cl, emitter, ext_declarations, declarations)
             for fn in module.functions:
                 generate_function_declaration(fn, declarations)
+
+        for lib in sorted(self.context.library_deps):
+            suffix = lib_suffix(lib)
+            declarations.emit_lines(
+                '#include "__native{}.h"'.format(suffix),
+                'struct linking_table{} exports{};'.format(suffix, suffix)
+            )
 
         sorted_decls = self.toposort_declarations()
 
@@ -293,7 +310,11 @@ class ModuleGenerator:
              .format(self.shared_lib_name)),
             'int res;',
             'PyObject *capsule;',
-            'PyObject *module = PyModule_Create(&def);',
+            'static PyObject *module;',
+            'if (module) {',
+            'return module;',
+            '}',
+            'module = PyModule_Create(&def);',
             'if (!module) {',
             'goto fail;',
             '}',
@@ -328,6 +349,18 @@ class ModuleGenerator:
                 'if (res < 0) {',
                 'goto fail;',
                 '}',
+                '',
+            )
+
+        for lib in sorted(self.context.library_deps):
+            suffix = lib_suffix(lib)
+            emitter.emit_lines(
+                'struct linking_table{} *pexports{} = PyCapsule_Import("{}.exports", 0);'.format(
+                    suffix, suffix, lib),
+                'if (!pexports{}) {{'.format(suffix),
+                'goto fail;',
+                '}',
+                'memcpy(&exports{name}, pexports{name}, sizeof(exports{name}));'.format(name=suffix),
                 '',
             )
 

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -363,6 +363,26 @@ class GroupGenerator:
 
         Then, all calls to functions in another group and accesses to statics
         from another group are done indirectly via the export table.
+
+        For example, a group containing a module b, where b contains a class B
+        and a function bar, would declare an export table like:
+            struct export_table_b {
+                PyTypeObject **CPyType_B;
+                PyObject *(*CPyDef_B)(CPyTagged cpy_r_x);
+                CPyTagged (*CPyDef_B___foo)(PyObject *cpy_r_self, CPyTagged cpy_r_y);
+                tuple_T2OI (*CPyDef_bar)(PyObject *cpy_r_x);
+                char (*CPyDef___top_level__)(void);
+            };
+        that would be initialized with:
+            static struct export_table_b exports = {
+                &CPyType_B,
+                &CPyDef_B,
+                &CPyDef_B___foo,
+                &CPyDef_bar,
+                &CPyDef___top_level__,
+            };
+        To call `b.foo`, then, a function in another group would do
+        `exports_b.CPyDef_bar(...)`.
         """
 
         decls = decl_emitter.context.declarations

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -34,10 +34,19 @@ from mypyc.errors import Errors
 # placed in the same group (fully whole-program compilation), but we
 # support finer-grained control of the group as well.
 #
+# In fully whole-program compilation, we will generate N+1 extension
+# modules: one shim per module and one shared library containing all
+# the actual code.
+# In fully separate compilation, we (unfortunately) will generate 2*N
+# extension modules: one shim per module and also one library containg
+# each module's actual code. (This might be fixable in the future,
+# but allows a clean separation between setup of the export tables
+# (see generate_export_table) and running module top levels.)
+#
 # A group is represented as a list of BuildSources containing all of
-# its modules along with the name of the group. (Which will be None
-# only if we are compiling a single file and not using shared
-# libraries).
+# its modules along with the name of the group. (Which can be None
+# only if we are compiling only a single group with a single file in it
+# and not using shared libraries).
 Group = Tuple[List[BuildSource], Optional[str]]
 Groups = List[Group]
 

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -82,11 +82,11 @@ def compile_modules_to_c(
     """Compile Python module(s) to C that can be used from Python C extension modules.
 
     Arguments:
-      * result: The BuildResult from the mypy front-end
-      * compiler_options: The compilation options
-      * errors: Where to report any errors encountered
-      * groups: The groups that we are compiling. See documentation of Groups type above.
-      * ops: Optionally, where to dump stringified ops for debugging.
+        result: The BuildResult from the mypy front-end
+        compiler_options: The compilation options
+        errors: Where to report any errors encountered
+        groups: The groups that we are compiling. See documentation of Groups type above.
+        ops: Optionally, where to dump stringified ops for debugging.
 
     Returns a list containing the generated files for each group.
     """
@@ -190,12 +190,12 @@ class GroupGenerator:
         properly plumbing the data through.
 
         Arguments:
-          * literals: The literals declared in this group
-          * modules: (name, ir) pairs for each module in the group
-          * source_paths: Map from module names to source file paths
-          * group_name: The name of the group (or None if this is single-module compilation)
-          * group_map: A map of modules to their group names
-          * multi_file: Whether to put each module in its own source file regardless
+            literals: The literals declared in this group
+            modules: (name, ir) pairs for each module in the group
+            source_paths: Map from module names to source file paths
+            group_name: The name of the group (or None if this is single-module compilation)
+            group_map: A map of modules to their group names
+            multi_file: Whether to put each module in its own source file regardless
                         of group structure.
         """
         self.literals = literals

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -176,7 +176,7 @@ def generate_hash_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
         name=name
     ))
     emitter.emit_line('{}retval = {}{}{}(self);'.format(emitter.ctype_spaced(fn.ret_type),
-                                                        emitter.get_lib_prefix(fn.decl),
+                                                        emitter.get_group_prefix(fn.decl),
                                                         NATIVE_PREFIX,
                                                         fn.cname(emitter.names)))
     emitter.emit_error_check('retval', fn.ret_type, 'return -1;')

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -175,9 +175,10 @@ def generate_hash_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
     emitter.emit_line('static Py_ssize_t {name}(PyObject *self) {{'.format(
         name=name
     ))
-    emitter.emit_line('{}retval = {}{}(self);'.format(emitter.ctype_spaced(fn.ret_type),
-                                                      NATIVE_PREFIX,
-                                                      fn.cname(emitter.names)))
+    emitter.emit_line('{}retval = {}{}{}(self);'.format(emitter.ctype_spaced(fn.ret_type),
+                                                        emitter.get_lib_prefix(fn.decl),
+                                                        NATIVE_PREFIX,
+                                                        fn.cname(emitter.names)))
     emitter.emit_error_check('retval', fn.ret_type, 'return -1;')
     if is_int_rprimitive(fn.ret_type):
         emitter.emit_line('Py_ssize_t val = CPyTagged_AsSsize_t(retval);')

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -116,12 +116,10 @@ strict_optional_dec = cast(Callable[[F], F], strict_optional_set(True))
 
 
 @strict_optional_dec  # Turn on strict optional for any type manipulations we do
-def build_ir(modules: List[MypyFile],
-             graph: Graph,
-             types: Dict[Expression, Type],
-             options: CompilerOptions,
-             errors: Errors) -> Tuple[LiteralsMap, List[Tuple[str, ModuleIR]]]:
-    result = []
+def build_type_map(modules: List[MypyFile],
+                   graph: Graph,
+                   types: Dict[Expression, Type],
+                   errors: Errors) -> 'Mapper':
     mapper = Mapper()
 
     # Collect all classes defined in the compilation unit.
@@ -147,6 +145,18 @@ def build_ir(modules: List[MypyFile],
                 prepare_class_def(module.path, module.fullname(), cdef, errors, mapper)
             else:
                 prepare_non_ext_class_def(module.path, module.fullname(), cdef, errors, mapper)
+
+    return mapper
+
+
+@strict_optional_dec  # Turn on strict optional for any type manipulations we do
+def build_ir(modules: List[MypyFile],
+             graph: Graph,
+             types: Dict[Expression, Type],
+             mapper: 'Mapper',
+             options: CompilerOptions,
+             errors: Errors) -> Tuple[LiteralsMap, List[Tuple[str, ModuleIR]]]:
+    result = []
 
     # Collect all the functions also. We collect from the symbol table
     # so that we can easily pick out the right copy of a function that

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -115,13 +115,11 @@ F = TypeVar('F', bound=Callable[..., Any])
 strict_optional_dec = cast(Callable[[F], F], strict_optional_set(True))
 
 
-def build_type_map(modules: List[MypyFile],
+def build_type_map(mapper: 'Mapper',
+                   modules: List[MypyFile],
                    graph: Graph,
                    types: Dict[Expression, Type],
-                   group_map: Dict[str, Optional[str]],
-                   errors: Errors) -> 'Mapper':
-    mapper = Mapper(group_map)
-
+                   errors: Errors) -> None:
     # Collect all classes defined in the compilation unit.
     classes = []
     for module in modules:
@@ -159,18 +157,16 @@ def build_type_map(modules: List[MypyFile],
                 prepare_func_def(module.fullname(), None, get_func_def(node.node), mapper)
             # TODO: what else?
 
-    return mapper
-
 
 @strict_optional_dec  # Turn on strict optional for any type manipulations we do
 def build_ir(modules: List[MypyFile],
              graph: Graph,
              types: Dict[Expression, Type],
-             group_map: Dict[str, Optional[str]],
+             mapper: 'Mapper',
              options: CompilerOptions,
              errors: Errors) -> Tuple[LiteralsMap, List[Tuple[str, ModuleIR]]]:
 
-    mapper = build_type_map(modules, graph, types, group_map, errors)
+    build_type_map(mapper, modules, graph, types, errors)
 
     result = []
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -115,7 +115,6 @@ F = TypeVar('F', bound=Callable[..., Any])
 strict_optional_dec = cast(Callable[[F], F], strict_optional_set(True))
 
 
-@strict_optional_dec  # Turn on strict optional for any type manipulations we do
 def build_type_map(modules: List[MypyFile],
                    graph: Graph,
                    types: Dict[Expression, Type],
@@ -146,18 +145,6 @@ def build_type_map(modules: List[MypyFile],
             else:
                 prepare_non_ext_class_def(module.path, module.fullname(), cdef, errors, mapper)
 
-    return mapper
-
-
-@strict_optional_dec  # Turn on strict optional for any type manipulations we do
-def build_ir(modules: List[MypyFile],
-             graph: Graph,
-             types: Dict[Expression, Type],
-             mapper: 'Mapper',
-             options: CompilerOptions,
-             errors: Errors) -> Tuple[LiteralsMap, List[Tuple[str, ModuleIR]]]:
-    result = []
-
     # Collect all the functions also. We collect from the symbol table
     # so that we can easily pick out the right copy of a function that
     # is conditionally defined.
@@ -170,6 +157,20 @@ def build_ir(modules: List[MypyFile],
                     and node.fullname == module.fullname() + '.' + name):
                 prepare_func_def(module.fullname(), None, get_func_def(node.node), mapper)
             # TODO: what else?
+
+    return mapper
+
+
+@strict_optional_dec  # Turn on strict optional for any type manipulations we do
+def build_ir(modules: List[MypyFile],
+             graph: Graph,
+             types: Dict[Expression, Type],
+             options: CompilerOptions,
+             errors: Errors) -> Tuple[LiteralsMap, List[Tuple[str, ModuleIR]]]:
+
+    mapper = build_type_map(modules, graph, types, errors)
+
+    result = []
 
     # Generate IR for all modules.
     module_names = [mod.fullname() for mod in modules]

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -118,8 +118,9 @@ strict_optional_dec = cast(Callable[[F], F], strict_optional_set(True))
 def build_type_map(modules: List[MypyFile],
                    graph: Graph,
                    types: Dict[Expression, Type],
+                   group_map: Dict[str, Optional[str]],
                    errors: Errors) -> 'Mapper':
-    mapper = Mapper()
+    mapper = Mapper(group_map)
 
     # Collect all classes defined in the compilation unit.
     classes = []
@@ -165,10 +166,11 @@ def build_type_map(modules: List[MypyFile],
 def build_ir(modules: List[MypyFile],
              graph: Graph,
              types: Dict[Expression, Type],
+             group_map: Dict[str, Optional[str]],
              options: CompilerOptions,
              errors: Errors) -> Tuple[LiteralsMap, List[Tuple[str, ModuleIR]]]:
 
-    mapper = build_type_map(modules, graph, types, errors)
+    mapper = build_type_map(modules, graph, types, group_map, errors)
 
     result = []
 
@@ -182,7 +184,9 @@ def build_ir(modules: List[MypyFile],
         module.accept(pbv)
 
         # Second pass.
-        builder = IRBuilder(types, graph, errors, mapper, module_names, pbv, options)
+        builder = IRBuilder(
+            module.fullname(), types, graph, errors, mapper, module_names, pbv, options
+        )
         builder.visit_mypy_file(module)
         module_ir = ModuleIR(
             list(builder.imports),
@@ -348,11 +352,12 @@ class Mapper:
     This state is shared across all modules in a compilation unit.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, group_map: Dict[str, Optional[str]]) -> None:
+        self.group_map = group_map
         self.type_to_ir = {}  # type: Dict[TypeInfo, ClassIR]
         self.func_to_decl = {}  # type: Dict[SymbolNode, FuncDecl]
         # Maps integer, float, and unicode literals to a static name
-        self.literals = OrderedDict()  # type: LiteralsMap
+        self.literals = {v: OrderedDict() for v in group_map.values()}  # type: LiteralsMap
 
     def type_to_rtype(self, typ: Optional[Type]) -> RType:
         if typ is None:
@@ -450,16 +455,21 @@ class Mapper:
             ret = object_rprimitive
         return FuncSignature(args, ret)
 
-    def literal_static_name(self, value: Union[int, float, complex, str, bytes]) -> str:
+    def literal_static_name(self, module: str,
+                            value: Union[int, float, complex, str, bytes]) -> str:
+        # Literals are shared between modules in a compilation group
+        # but not outside the group.
+        literals = self.literals[self.group_map.get(module)]
+
         # Include type to distinguish between 1 and 1.0, and so on.
         key = (type(value), value)
-        if key not in self.literals:
+        if key not in literals:
             if isinstance(value, str):
                 prefix = 'unicode_'
             else:
                 prefix = type(value).__name__ + '_'
-            self.literals[key] = prefix + str(len(self.literals))
-        return self.literals[key]
+            literals[key] = prefix + str(len(literals))
+        return literals[key]
 
 
 def prepare_func_def(module_name: str, class_name: Optional[str],
@@ -1000,6 +1010,7 @@ class FinallyNonlocalControl(CleanupNonlocalControl):
 
 class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
     def __init__(self,
+                 current_module: str,
                  types: Dict[Expression, Type],
                  graph: Graph,
                  errors: Errors,
@@ -1007,6 +1018,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                  modules: List[str],
                  pbv: PreBuildVisitor,
                  options: CompilerOptions) -> None:
+        self.current_module = current_module
         self.types = types
         self.graph = graph
         self.environment = Environment()
@@ -5212,24 +5224,27 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
     def load_globals_dict(self) -> Value:
         return self.add(LoadStatic(dict_rprimitive, 'globals', self.module_name))
 
+    def literal_static_name(self, value: Union[int, float, complex, str, bytes]) -> str:
+        return self.mapper.literal_static_name(self.current_module, value)
+
     def load_static_int(self, value: int) -> Value:
         """Loads a static integer Python 'int' object into a register."""
-        static_symbol = self.mapper.literal_static_name(value)
+        static_symbol = self.literal_static_name(value)
         return self.add(LoadStatic(int_rprimitive, static_symbol, ann=value))
 
     def load_static_float(self, value: float) -> Value:
         """Loads a static float value into a register."""
-        static_symbol = self.mapper.literal_static_name(value)
+        static_symbol = self.literal_static_name(value)
         return self.add(LoadStatic(float_rprimitive, static_symbol, ann=value))
 
     def load_static_bytes(self, value: bytes) -> Value:
         """Loads a static bytes value into a register."""
-        static_symbol = self.mapper.literal_static_name(value)
+        static_symbol = self.literal_static_name(value)
         return self.add(LoadStatic(object_rprimitive, static_symbol, ann=value))
 
     def load_static_complex(self, value: complex) -> Value:
         """Loads a static complex value into a register."""
-        static_symbol = self.mapper.literal_static_name(value)
+        static_symbol = self.literal_static_name(value)
         return self.add(LoadStatic(object_rprimitive, static_symbol, ann=value))
 
     def load_static_unicode(self, value: str) -> Value:
@@ -5238,7 +5253,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         This is useful for more than just unicode literals; for example, method calls
         also require a PyObject * form for the name of the method.
         """
-        static_symbol = self.mapper.literal_static_name(value)
+        static_symbol = self.literal_static_name(value)
         return self.add(LoadStatic(str_rprimitive, static_symbol, ann=value))
 
     def load_module(self, name: str) -> Value:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -120,7 +120,7 @@ def build_type_map(mapper: 'Mapper',
                    graph: Graph,
                    types: Dict[Expression, Type],
                    errors: Errors) -> None:
-    # Collect all classes defined in the compilation unit.
+    # Collect all classes defined in everything we are compiling
     classes = []
     for module in modules:
         module_classes = [node for node in module.defs if isinstance(node, ClassDef)]
@@ -345,7 +345,7 @@ def compute_vtable(cls: ClassIR) -> None:
 class Mapper:
     """Keep track of mappings from mypy concepts to IR concepts.
 
-    This state is shared across all modules in a compilation unit.
+    This state is shared across all modules being compiled.
     """
 
     def __init__(self, group_map: Dict[str, Optional[str]]) -> None:

--- a/mypyc/namegen.py
+++ b/mypyc/namegen.py
@@ -35,7 +35,8 @@ class NameGenerator:
     though not very usable.
     """
 
-    def __init__(self, module_names: Optional[List[str]] = None) -> None:
+    def __init__(self, module_names: List[str],
+                 *, is_separate: bool) -> None:
         """Initialize with names of all modules in the compilation unit.
 
         The names of modules are used to shorten names referring to
@@ -44,7 +45,7 @@ class NameGenerator:
         compilation unit will use long names.
         """
         module_names = module_names or []
-        self.module_map = make_module_translation_map(module_names)
+        self.module_map = make_module_translation_map(module_names, is_separate)
         self.translations = {}  # type: Dict[Tuple[str, str], str]
         self.used_names = set()  # type: Set[str]
 
@@ -88,14 +89,14 @@ def exported_name(fullname: str) -> str:
     return fullname.replace('___', '___3_').replace('.', '___')
 
 
-def make_module_translation_map(names: List[str]) -> Dict[str, str]:
+def make_module_translation_map(names: List[str], is_separate: bool = False) -> Dict[str, str]:
     num_instances = {}  # type: Dict[str, int]
     for name in names:
-        for suffix in candidate_suffixes(name):
+        for suffix in candidate_suffixes(name, is_separate):
             num_instances[suffix] = num_instances.get(suffix, 0) + 1
     result = {}
     for name in names:
-        for suffix in candidate_suffixes(name):
+        for suffix in candidate_suffixes(name, is_separate):
             if num_instances[suffix] == 1:
                 result[name] = suffix
                 break
@@ -104,9 +105,9 @@ def make_module_translation_map(names: List[str]) -> Dict[str, str]:
     return result
 
 
-def candidate_suffixes(fullname: str) -> List[str]:
+def candidate_suffixes(fullname: str, is_separate: bool = False) -> List[str]:
     components = fullname.split('.')
     result = ['']
     for i in range(len(components)):
         result.append('.'.join(components[-i - 1:]) + '.')
-    return result
+    return result if not is_separate else [result[-1]]

--- a/mypyc/namegen.py
+++ b/mypyc/namegen.py
@@ -33,16 +33,19 @@ class NameGenerator:
     The generated should be internal to a build and thus the mapping is
     arbitrary. Just generating names '1', '2', ... would be correct,
     though not very usable.
+
+    FIXME: Currently when performing seperate compilation we just
+    totally give up on shortening names.
     """
 
     def __init__(self, module_names: List[str],
                  *, is_separate: bool) -> None:
-        """Initialize with names of all modules in the compilation unit.
+        """Initialize with names of all modules in the compilation group.
 
         The names of modules are used to shorten names referring to
-        modules in the compilation unit, for convenience. Arbitary module
+        modules in the compilation group, for convenience. Arbitary module
         names are supported for generated names, but modules not in the
-        compilation unit will use long names.
+        compilation group will use long names.
         """
         module_names = module_names or []
         self.module_map = make_module_translation_map(module_names, is_separate)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1122,7 +1122,7 @@ class LoadStatic(RegisterOp):
     """dest = name :: static
 
     Load a C static variable/pointer. The namespace for statics is shared
-    for the entire compilation unit. You can optionally provide a module
+    for the entire compilation group. You can optionally provide a module
     name and a sub-namespace identifier for additional namespacing to avoid
     name conflicts. The static namespace does not overlap with other C names,
     since the final C name will get a prefix, so conflicts only must be

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1707,11 +1707,7 @@ class NonExtClassInfo:
         self.anns = non_ext_anns
 
 
-# A LiteralsMap maps from compilation group name to dicts that map from literals to names
-LiteralsMap = Dict[
-    Optional[str],
-    Dict[Tuple[Type[object], Union[int, float, str, bytes, complex]], str]
-]
+LiteralsMap = Dict[Tuple[Type[object], Union[int, float, str, bytes, complex]], str]
 
 
 class ModuleIR:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1707,7 +1707,11 @@ class NonExtClassInfo:
         self.anns = non_ext_anns
 
 
-LiteralsMap = Dict[Tuple[Type[object], Union[int, float, str, bytes, complex]], str]
+# A LiteralsMap maps from compilation group name to dicts that map from literals to names
+LiteralsMap = Dict[
+    Optional[str],
+    Dict[Tuple[Type[object], Union[int, float, str, bytes, complex]], str]
+]
 
 
 class ModuleIR:

--- a/mypyc/test-data/run-multimodule.test
+++ b/mypyc/test-data/run-multimodule.test
@@ -90,7 +90,7 @@ else:
 
 [case testMultiModuleImportClass]
 from typing import cast
-from other import C
+from other import C, a_global
 
 class D(C):
     def __init__(self, x: int) -> None:
@@ -100,21 +100,32 @@ def f(c: C) -> int:
     d = D(3)
     o: object = c
     c = cast(C, o)
-    return c.x + c.f() + d.x + d.f() + 1
+    return a_global + c.x + c.f() + d.x + d.f() + 1
 [file other.py]
+from typing_extensions import Final
+a_global: Final = int('5')
+
 class C:
     x: int
 
     def __init__(self, x: int) -> None:
         self.x = x
 
+    def __hash__(self) -> int:
+        return self.x
+
+    def __str__(self) -> str:
+        return str(self.x)
+
     def f(self) -> int:
         return 2
 [file driver.py]
-from native import f
+from native import f, D
 from other import C
 c = C(4)
-assert f(c) == 4 + 2 + 3 + 2 + 1
+assert f(c) == 5 + 4 + 2 + 3 + 2 + 1
+assert str(D(10)) == '10'
+assert hash(10) == 10
 try:
     f(1)
 except TypeError:

--- a/mypyc/test/test_commandline.py
+++ b/mypyc/test/test_commandline.py
@@ -50,7 +50,7 @@ class TestCommandLine(MypycDataSuite):
             cmd = subprocess.run([sys.executable,
                                   os.path.join(base_path, 'scripts', 'mypyc')] + args,
                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd='tmp')
-            if 'ErrorOutput' in testcase.name:
+            if 'ErrorOutput' in testcase.name or cmd.returncode != 0:
                 out += cmd.stdout
 
             if cmd.returncode == 0:

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -4,13 +4,14 @@ from mypy.nodes import Var
 
 from mypyc.emit import Emitter, EmitterContext
 from mypyc.ops import BasicBlock, Environment, int_rprimitive
+from mypyc.namegen import NameGenerator
 
 
 class TestEmitter(unittest.TestCase):
     def setUp(self) -> None:
         self.env = Environment()
         self.n = self.env.add_local(Var('n'), int_rprimitive)
-        self.context = EmitterContext(['mod'])
+        self.context = EmitterContext(NameGenerator([['mod']]))
         self.emitter = Emitter(self.context, self.env)
 
     def test_label(self) -> None:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -23,6 +23,7 @@ from mypyc.ops_list import (
 from mypyc.ops_dict import new_dict_op, dict_update_op, dict_get_item_op, dict_set_item_op
 from mypyc.ops_int import int_neg_op
 from mypyc.subtype import is_subtype
+from mypyc.namegen import NameGenerator
 
 
 class TestFunctionEmitterVisitor(unittest.TestCase):
@@ -47,7 +48,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         ir.mro = [ir]
         self.r = self.env.add_local(Var('r'), RInstance(ir))
 
-        self.context = EmitterContext(['mod'])
+        self.context = EmitterContext(NameGenerator([['mod']]))
         self.emitter = Emitter(self.context, self.env)
         self.declarations = Emitter(self.context, self.env)
         self.visitor = FunctionEmitterVisitor(self.emitter, self.declarations, 'prog.py', 'prog')
@@ -270,7 +271,7 @@ class TestGenerateFunction(unittest.TestCase):
         self.block.ops.append(Return(self.reg))
         fn = FuncIR(FuncDecl('myfunc', None, 'mod', FuncSignature([self.arg], int_rprimitive)),
                     [self.block], self.env)
-        emitter = Emitter(EmitterContext(['mod']))
+        emitter = Emitter(EmitterContext(NameGenerator([['mod']])))
         generate_native_function(fn, emitter, 'prog.py', 'prog')
         result = emitter.fragments
         assert_string_arrays_equal(
@@ -289,7 +290,7 @@ class TestGenerateFunction(unittest.TestCase):
         self.env.add_op(op)
         fn = FuncIR(FuncDecl('myfunc', None, 'mod', FuncSignature([self.arg], list_rprimitive)),
                     [self.block], self.env)
-        emitter = Emitter(EmitterContext(['mod']))
+        emitter = Emitter(EmitterContext(NameGenerator([['mod']])))
         generate_native_function(fn, emitter, 'prog.py', 'prog')
         result = emitter.fragments
         assert_string_arrays_equal(

--- a/mypyc/test/test_emitwrapper.py
+++ b/mypyc/test/test_emitwrapper.py
@@ -6,11 +6,12 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.emit import Emitter, EmitterContext
 from mypyc.emitwrapper import generate_arg_check
 from mypyc.ops import list_rprimitive, int_rprimitive
+from mypyc.namegen import NameGenerator
 
 
 class TestArgCheck(unittest.TestCase):
     def setUp(self) -> None:
-        self.context = EmitterContext(['mod'])
+        self.context = EmitterContext(NameGenerator([['mod']]))
 
     def test_check_list(self) -> None:
         emitter = Emitter(self.context)

--- a/mypyc/test/test_namegen.py
+++ b/mypyc/test/test_namegen.py
@@ -29,7 +29,7 @@ class TestNameGen(unittest.TestCase):
                                                   'foo.baz': 'baz.'}
 
     def test_name_generator(self) -> None:
-        g = NameGenerator(['foo', 'foo.zar'])
+        g = NameGenerator(['foo', 'foo.zar'], is_separate=False)
         assert g.private_name('foo', 'f') == 'foo___f'
         assert g.private_name('foo', 'C.x.y') == 'foo___C___x___y'
         assert g.private_name('foo', 'C.x.y') == 'foo___C___x___y'

--- a/mypyc/test/test_namegen.py
+++ b/mypyc/test/test_namegen.py
@@ -29,7 +29,7 @@ class TestNameGen(unittest.TestCase):
                                                   'foo.baz': 'baz.'}
 
     def test_name_generator(self) -> None:
-        g = NameGenerator(['foo', 'foo.zar'], is_separate=False)
+        g = NameGenerator([['foo', 'foo.zar']])
         assert g.private_name('foo', 'f') == 'foo___f'
         assert g.private_name('foo', 'C.x.y') == 'foo___C___x___y'
         assert g.private_name('foo', 'C.x.y') == 'foo___C___x___y'

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -184,7 +184,7 @@ class TestRun(MypycDataSuite):
 
             setup_file = os.path.abspath(os.path.join(workdir, 'setup.py'))
             # We pass the C file information to the build script via setup.py unfortunately
-            with open(setup_file, 'w') as f:
+            with open(setup_file, 'w', encoding='utf-8') as f:
                 f.write(setup_format.format(module_paths, self.separate, cfiles))
 
             if not run_setup(setup_file, ['build_ext', '--inplace']):

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -170,13 +170,12 @@ class TestRun(MypycDataSuite):
                     alt_lib_path='.')
                 errors = Errors()
                 compiler_options = CompilerOptions(multi_file=self.multi_file)
+                groups = [(sources, lib_name)]
                 cfiles = emitmodule.compile_modules_to_c(
                     result,
-                    module_names=module_names,
-                    shared_lib_name=lib_name,
-                    mapper=emitmodule.prepare_groups(result, module_names, compiler_options, errors),
                     compiler_options=compiler_options,
                     errors=errors,
+                    groups=groups,
                 )
                 if errors.num_errors:
                     errors.flush_errors()
@@ -186,7 +185,8 @@ class TestRun(MypycDataSuite):
                     print(line)
                 assert False, 'Compile error'
 
-            for cfile, ctext in cfiles:
+            assert len(cfiles) == 1
+            for cfile, ctext in cfiles[0]:
                 with open(os.path.join(workdir, cfile), 'w', encoding='utf-8') as f:
                     f.write(ctext)
 
@@ -196,7 +196,7 @@ class TestRun(MypycDataSuite):
 
             if not run_setup(setup_file, ['build_ext', '--inplace']):
                 if testcase.config.getoption('--mypyc-showc'):
-                    show_c(cfiles)
+                    show_c(cfiles[0])
                 assert False, "Compilation failed"
 
             # Assert that an output file got created
@@ -229,7 +229,7 @@ class TestRun(MypycDataSuite):
             outlines = output.splitlines()
 
             if testcase.config.getoption('--mypyc-showc'):
-                show_c(cfiles)
+                show_c(cfiles[0])
             if proc.returncode != 0:
                 print()
                 print('*** Exit status: %d' % proc.returncode)

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -174,6 +174,7 @@ class TestRun(MypycDataSuite):
                     result,
                     module_names=module_names,
                     shared_lib_name=lib_name,
+                    mapper=emitmodule.prepare_groups(result, module_names, compiler_options, errors),
                     compiler_options=compiler_options,
                     errors=errors,
                 )

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -107,6 +107,7 @@ def build_ir_for_single_file(input_lines: List[str],
     errors = Errors()
     _, modules = genops.build_ir(
         [result.files['__main__']], result.graph, result.types,
+        genops.build_type_map([result.files['__main__']], result.graph, result.types, errors),
         compiler_options, errors)
     assert errors.num_errors == 0
 

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -107,7 +107,6 @@ def build_ir_for_single_file(input_lines: List[str],
     errors = Errors()
     _, modules = genops.build_ir(
         [result.files['__main__']], result.graph, result.types,
-        genops.build_type_map([result.files['__main__']], result.graph, result.types, errors),
         compiler_options, errors)
     assert errors.num_errors == 0
 

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -107,7 +107,7 @@ def build_ir_for_single_file(input_lines: List[str],
     errors = Errors()
     _, modules = genops.build_ir(
         [result.files['__main__']], result.graph, result.types,
-        {'__main__': None},
+        genops.Mapper({'__main__': None}),
         compiler_options, errors)
     assert errors.num_errors == 0
 

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -107,6 +107,7 @@ def build_ir_for_single_file(input_lines: List[str],
     errors = Errors()
     _, modules = genops.build_ir(
         [result.files['__main__']], result.graph, result.types,
+        {'__main__': None},
         compiler_options, errors)
     assert errors.num_errors == 0
 

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -187,9 +187,10 @@ def heading(text: str) -> None:
     print('=' * 20 + ' ' + text + ' ' + '=' * 20)
 
 
-def show_c(cfiles: List[Tuple[str, str]]) -> None:
+def show_c(cfiles: List[List[Tuple[str, str]]]) -> None:
     heading('Generated C')
-    for cfile, ctext in cfiles:
-        print('== {} =='.format(cfile))
-        print_with_line_numbers(ctext)
+    for group in cfiles:
+        for cfile, ctext in group:
+            print('== {} =='.format(cfile))
+            print_with_line_numbers(ctext)
     heading('End C')

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -105,7 +105,7 @@ def build_ir_for_single_file(input_lines: List[str],
         raise CompileError(result.errors)
 
     errors = Errors()
-    _, modules = genops.build_ir(
+    modules = genops.build_ir(
         [result.files['__main__']], result.graph, result.types,
         genops.Mapper({'__main__': None}),
         compiler_options, errors)


### PR DESCRIPTION
This adds support for separate compilation to mypyc.

A `separate` argument is added to `mypycify`. If `True`, mypyc places every
module its own separate shared library. Otherwise it can take a list of groups
of source files that should be placed in a shared library together.

The shared libraries communication with each other using the C API's intended
mechanism for communicating between C extension modules: Capsules.
Each library creates a table of pointers to all of its exported data and stores a pointer
to it in a capsule stored as a module attribute. When a library is loaded, it
loads the linking table capsules from all its dependencies and copies them
into a local copy of the table. (To eliminate the need for a pointer indirection when
accessing it.)

This adds a test mode that will run all multi-module run tests in separate compilation mode.
I also manually tested mypy itself compiled in separate compilation mode.

This supports a limited form of incremental compilation already: only modules
that changed or had a header they depend on change will be recompiled by the
C compiler. The entire project still needs to go through the entire mypy/mypyc
front-end and middle-end, however. I expect to have a PR that adds support for 
hooking into incremental mode next week.

This is progress on mypyc/mypyc#682.