### PR TITLE
Avoid creating partial annotations on attrs-classes __init__ method

### DIFF
--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -75,7 +75,7 @@ A(1, [2], '3', 4, 5)  # E: Too many arguments for "A"
 # flags: --disallow-untyped-defs
 import attr
 @attr.s
-class A:  # E: Function is missing a type annotation for one or more arguments
+class A:
     a = attr.ib()  # E: Need type annotation for 'a'
     _b = attr.ib()  # E: Need type annotation for '_b'
     c = attr.ib(18)  # E: Need type annotation for 'c'
@@ -1121,7 +1121,7 @@ reveal_type(B)  # N: Revealed type is 'def (x: __main__.C) -> __main__.B'
 import attr
 
 @attr.s
-class B:  # E: Function is missing a type annotation for one or more arguments
+class B:
     x = attr.ib()  # E: Need type annotation for 'x'
 
 reveal_type(B)  # N: Revealed type is 'def (x: Any) -> __main__.B'

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1029,6 +1029,31 @@ def f(i: int, s):
 main:3: error: Function is missing a return type annotation
 main:3: error: Function is missing a type annotation for one or more arguments
 
+[case testDisallowIncompleteDefsAttrsNoAnnotations]
+# flags: --disallow-incomplete-defs
+import attr
+
+@attr.s()
+class Unannotated:
+    foo = attr.ib()
+
+[case testDisallowIncompleteDefsAttrsWithAnnotations]
+# flags: --disallow-incomplete-defs
+import attr
+
+@attr.s()
+class Annotated:
+    bar: int = attr.ib()
+
+[case testDisallowIncompleteDefsAttrsPartialAnnotations]
+# flags: --disallow-incomplete-defs
+import attr
+
+@attr.s()
+class PartiallyAnnotated:  # E: Function is missing a type annotation for one or more arguments
+    bar: int = attr.ib()
+    baz = attr.ib()
+
 [case testAlwaysTrueAlwaysFalseFlags]
 # flags: --always-true=YOLO --always-true=YOLO1 --always-false=BLAH1 --always-false BLAH --ignore-missing-imports
 from somewhere import YOLO, BLAH


### PR DESCRIPTION
This is important because `--disallow-incomplete-defs` is basically unusable otherwise, and I want to use it for e.g. HypothesisWorks/hypothesis#2071.

I'm well aware that this is a terrible hack, but it fixes #5954 for now.  @euresti had sketched out the proper fix but I just got lost in the codebase - hopefully someone will come back and fix it properly later, but for now this is good enough for me.