### PR TITLE
Allow TypedDict key with literal type during construction

### DIFF
--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -2,16 +2,14 @@ from typing import List, Optional
 
 from mypy.nodes import (
     ARG_POS, MDEF, Argument, Block, CallExpr, Expression, SYMBOL_FUNCBASE_TYPES,
-    FuncDef, PassStmt, RefExpr, SymbolTableNode, Var, StrExpr,
+    FuncDef, PassStmt, RefExpr, SymbolTableNode, Var
 )
 from mypy.plugin import ClassDefContext
 from mypy.semanal import set_callable_name
-from mypy.types import (
-    CallableType, Overloaded, Type, TypeVarDef, LiteralType, Instance, UnionType,
-    get_proper_type, get_proper_types
-)
+from mypy.types import CallableType, Overloaded, Type, TypeVarDef, get_proper_type
 from mypy.typevars import fill_typevars
 from mypy.util import get_unique_redefinition_name
+from mypy.typeops import try_getting_str_literals  # noqa: F401  # Part of public API
 
 
 def _get_decorator_bool_argument(
@@ -130,38 +128,3 @@ def add_method(
 
     info.names[name] = SymbolTableNode(MDEF, func, plugin_generated=True)
     info.defn.defs.body.append(func)
-
-
-def try_getting_str_literals(expr: Expression, typ: Type) -> Optional[List[str]]:
-    """If the given expression or type corresponds to a string literal
-    or a union of string literals, returns a list of the underlying strings.
-    Otherwise, returns None.
-
-    Specifically, this function is guaranteed to return a list with
-    one or more strings if one one the following is true:
-
-    1. 'expr' is a StrExpr
-    2. 'typ' is a LiteralType containing a string
-    3. 'typ' is a UnionType containing only LiteralType of strings
-    """
-    typ = get_proper_type(typ)
-
-    if isinstance(expr, StrExpr):
-        return [expr.value]
-
-    if isinstance(typ, Instance) and typ.last_known_value is not None:
-        possible_literals = [typ.last_known_value]  # type: List[Type]
-    elif isinstance(typ, UnionType):
-        possible_literals = list(typ.items)
-    else:
-        possible_literals = [typ]
-
-    strings = []
-    for lit in get_proper_types(possible_literals):
-        if isinstance(lit, LiteralType) and lit.fallback.type.fullname() == 'builtins.str':
-            val = lit.value
-            assert isinstance(val, str)
-            strings.append(val)
-        else:
-            return None
-    return strings

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1901,7 +1901,7 @@ v = {union: 2} # E: Expected TypedDict key to be string literal
 num2: Literal['num']
 v = {num2: 2}
 bad2: Literal['bad']
-v = {bad: 2}  # E: Expected TypedDict key to be string literal
+v = {bad2: 2}  # E: Extra key 'bad' for TypedDict "Value"
 
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1883,3 +1883,25 @@ assert isinstance(u2, Mapping)
 reveal_type(u2)  # N: Revealed type is 'TypedDict('__main__.User', {'id': builtins.int, 'name': builtins.str})'
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
+
+[case testTypedDictLiteralTypeKeyInCreation]
+from typing import TypedDict, Final, Literal
+
+class Value(TypedDict):
+    num: int
+
+num: Final = 'num'
+v: Value = {num: 5}
+v = {num: ''}  # E: Incompatible types (expression has type "str", TypedDict item "num" has type "int")
+
+bad: Final = 2
+v = {bad: 3}  # E: Expected TypedDict key to be string literal
+union: Literal['num', 'foo']
+v = {union: 2} # E: Expected TypedDict key to be string literal
+num2: Literal['num']
+v = {num2: 2}
+bad2: Literal['bad']
+v = {bad: 2}  # E: Expected TypedDict key to be string literal
+
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]


### PR DESCRIPTION
Also refactored an operation away from `mypy.plugins.common` so that it
is more cleanly reusable. Also kept an alias in the original location
to avoid breaking existing plugins.

Fixes #7644.