### PR TITLE
Support NamedTuple class syntax in all stubs

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1109,7 +1109,8 @@ class SemanticAnalyzer(NodeVisitor[None],
             # in the named tuple class body.
             is_named_tuple, info = True, defn.info  # type: bool, Optional[TypeInfo]
         else:
-            is_named_tuple, info = self.named_tuple_analyzer.analyze_namedtuple_classdef(defn)
+            is_named_tuple, info = self.named_tuple_analyzer.analyze_namedtuple_classdef(
+                defn, self.is_stub_file)
         if is_named_tuple:
             if info is None:
                 self.mark_incomplete(defn.name, defn)

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -44,6 +44,24 @@ x.x
 x.y
 x.z # E: "X" has no attribute "z"
 
+[case testNamedTupleClassPython35]
+# flags: --python-version 3.5
+from typing import NamedTuple
+
+class A(NamedTuple):
+    x = 3  # type: int
+[out]
+main:4: error: NamedTuple class syntax is only supported in Python 3.6
+
+[case testNamedTupleClassInStubPython35]
+# flags: --python-version 3.5
+import foo
+
+[file foo.pyi]
+from typing import NamedTuple
+
+class A(NamedTuple):
+    x: int
 
 [case testNamedTupleAttributesAreReadOnly]
 from collections import namedtuple


### PR DESCRIPTION
Previously, it was not supported in stubs when checking in Python 2.7 or
3.5 mode.

Closes: #3464