### PR TITLE
Fix operator error messages for __div__ and __cmp__ on python 2

### DIFF
--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -474,15 +474,15 @@ class B:
 
 a, b, c, bo = None, None, None, None # type: (A, B, C, bool)
 bo = a == a  # E: Unsupported operand types for == ("A" and "A")
-bo = a != a  # E: Argument 1 to "__cmp__" of "A" has incompatible type "A"; expected "B"
+bo = a != a  # E: Unsupported operand types for comparison ("A" and "A")
 bo = a < b
 bo = a > b
 bo = b <= b
 bo = b <= c
-bo = b >= c  # E: Argument 1 to "__cmp__" of "B" has incompatible type "C"; expected "B"
+bo = b >= c  # E: Unsupported operand types for comparison ("C" and "B")
 bo = a >= b
 bo = c >= b
-bo = c <= b  # E: Argument 1 to "__cmp__" of "C" has incompatible type "B"; expected "A"
+bo = c <= b  # E: Unsupported operand types for comparison ("B" and "C")
 bo = a == c
 bo = b == c  # E: Unsupported operand types for == ("C" and "B")
 
@@ -509,6 +509,11 @@ class C:
       pass
 
 [builtins_py2 fixtures/bool_py2.pyi]
+
+[case testDiv_python2]
+10 / 'no'  # E: Unsupported operand types for / ("int" and "str")
+'no' / 10  # E: Unsupported operand types for / ("str" and "int")
+[builtins_py2 fixtures/ops.pyi]
 
 [case cmpIgnoredPy3]
 


### PR DESCRIPTION
Currently the code for turning method call errors into operator error
messages doesn't detect __div__ and __cmp__, so fix that.

One of my main motivations here is that this fixes type ignoring these
with an error code, since previously the real error would be
`arg-type` but the note would be `operator`.

I think that longer term it is probably worth having notes automatically take
the error code of the most recent error, or some such, but that is probably worth some discussion.

I'd like to get this into the release https://github.com/python/mypy/issues/7638