### PR TITLE
Improve color and terminal width overrides

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -468,8 +468,9 @@ def request(status_file: str, command: str, *, timeout: Optional[int] = None,
     args['command'] = command
     # Tell the server whether this request was initiated from a human-facing terminal,
     # so that it can format the type checking output accordingly.
-    args['is_tty'] = sys.stdout.isatty()
-    args['terminal_width'] = get_terminal_width()
+    args['is_tty'] = sys.stdout.isatty() or int(os.getenv('MYPY_FORCE_COLOR', '0')) > 0
+    args['terminal_width'] = (int(os.getenv('MYPY_FORCE_TERMINAL_WIDTH', '0')) or
+                              get_terminal_width())
     bdata = json.dumps(args).encode('utf8')
     _, name = get_status(status_file)
     try:

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -265,8 +265,6 @@ class Server:
                 # Only the above commands use some error formatting.
                 del data['is_tty']
                 del data['terminal_width']
-            elif int(os.getenv('MYPY_FORCE_COLOR', '0')):
-                data['is_tty'] = True
             return method(self, **data)
 
     # Command functions (run in the server via RPC).

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -568,7 +568,8 @@ class FancyFormatter:
     def fit_in_terminal(self, messages: List[str],
                         fixed_terminal_width: Optional[int] = None) -> List[str]:
         """Improve readability by wrapping error messages and trimming source code."""
-        width = fixed_terminal_width or get_terminal_width()
+        width = (fixed_terminal_width or int(os.getenv('MYPY_FORCE_TERMINAL_WIDTH', '0')) or
+                 get_terminal_width())
         new_messages = messages.copy()
         for i, error in enumerate(messages):
             if ': error:' in error:


### PR DESCRIPTION
This PR:
* Fixes `MYPY_FORCE_COLOR` interaction with daemon by reading it from client instead from server.
* Adds `MYPY_FORCE_TERMINAL_WIDTH` with a similar functionality.

These (hidden) environment variables can be used by wrapper scripts.