### PR TITLE
[attrs] Remove error message about deprecated cmp

### DIFF
--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -190,7 +190,6 @@ def _determine_eq_order(ctx: 'mypy.plugin.ClassDefContext') -> Tuple[bool, bool]
 
     # cmp takes precedence due to bw-compatibility.
     if cmp is not None:
-        ctx.api.fail("cmp is deprecated, use eq and order", ctx.reason)
         return cmp, cmp
 
     # If left None, equality is on and ordering mirrors equality.

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -278,15 +278,15 @@ A(1) != 1
 
 [case testAttrsCmpEqOrderValues]
 from attr import attrib, attrs
-@attrs(cmp=True)  # E: cmp is deprecated, use eq and order
+@attrs(cmp=True)
 class DeprecatedTrue:
    ...
 
-@attrs(cmp=False)  # E: cmp is deprecated, use eq and order
+@attrs(cmp=False)
 class DeprecatedFalse:
    ...
 
-@attrs(cmp=False, eq=True)  # E: Don't mix `cmp` with `eq' and `order`  # E: cmp is deprecated, use eq and order
+@attrs(cmp=False, eq=True)  # E: Don't mix `cmp` with `eq' and `order`
 class Mixed:
    ...
 


### PR DESCRIPTION
It still works it just emits a warning so there's no need for mypy to freak out about it.