### PR TITLE
[mypyc] Make namegen not need to use suffixes to disambiguate

### DIFF
--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1416,11 +1416,12 @@ class FuncDecl:
             else:
                 self.bound_sig = FuncSignature(sig.args[1:], sig.ret_type)
 
+    @property
+    def shortname(self) -> str:
+        return self.class_name + '.' + self.name if self.class_name else self.name
+
     def cname(self, names: NameGenerator) -> str:
-        name = self.name
-        if self.class_name:
-            name += '_' + self.class_name
-        return names.private_name(self.module_name, name)
+        return names.private_name(self.module_name, self.shortname)
 
 
 class FuncIR:

--- a/mypyc/test-data/run.test
+++ b/mypyc/test-data/run.test
@@ -4345,6 +4345,9 @@ class C:
     def foo(self) -> None:
         def bar(self) -> None:
             pass
+
+def C___foo() -> None: pass
+
 class D:
     def foo(self) -> None:
         def bar(self) -> None:

--- a/mypyc/test/test_namegen.py
+++ b/mypyc/test/test_namegen.py
@@ -7,8 +7,8 @@ from mypyc.namegen import (
 
 class TestNameGen(unittest.TestCase):
     def test_candidate_suffixes(self) -> None:
-        assert candidate_suffixes('foo') == ['', 'foo_']
-        assert candidate_suffixes('foo.bar') == ['', 'bar_', 'foo_bar_']
+        assert candidate_suffixes('foo') == ['', 'foo.']
+        assert candidate_suffixes('foo.bar') == ['', 'bar.', 'foo.bar.']
 
     def test_exported_name(self) -> None:
         assert exported_name('foo') == 'foo'
@@ -16,24 +16,25 @@ class TestNameGen(unittest.TestCase):
 
     def test_make_module_translation_map(self) -> None:
         assert make_module_translation_map(
-            ['foo', 'bar']) == {'foo': 'foo_', 'bar': 'bar_'}
+            ['foo', 'bar']) == {'foo': 'foo.', 'bar': 'bar.'}
         assert make_module_translation_map(
-            ['foo.bar', 'foo.baz']) == {'foo.bar': 'bar_', 'foo.baz': 'baz_'}
+            ['foo.bar', 'foo.baz']) == {'foo.bar': 'bar.', 'foo.baz': 'baz.'}
         assert make_module_translation_map(
-            ['zar', 'foo.bar', 'foo.baz']) == {'foo.bar': 'bar_',
-                                               'foo.baz': 'baz_',
-                                               'zar': 'zar_'}
+            ['zar', 'foo.bar', 'foo.baz']) == {'foo.bar': 'bar.',
+                                               'foo.baz': 'baz.',
+                                               'zar': 'zar.'}
         assert make_module_translation_map(
-            ['foo.bar', 'fu.bar', 'foo.baz']) == {'foo.bar': 'foo_bar_',
-                                                  'fu.bar': 'fu_bar_',
-                                                  'foo.baz': 'baz_'}
+            ['foo.bar', 'fu.bar', 'foo.baz']) == {'foo.bar': 'foo.bar.',
+                                                  'fu.bar': 'fu.bar.',
+                                                  'foo.baz': 'baz.'}
 
     def test_name_generator(self) -> None:
         g = NameGenerator(['foo', 'foo.zar'])
-        assert g.private_name('foo', 'f') == 'foo_f'
-        assert g.private_name('foo', 'C.x.y') == 'foo_C_x_y'
-        assert g.private_name('foo', 'C.x.y') == 'foo_C_x_y'
-        assert g.private_name('foo.zar', 'C.x.y') == 'zar_C_x_y'
-        assert g.private_name('foo', 'C.x_y') == 'foo_C_x_y_2'
-        assert g.private_name('foo', 'C_x_y') == 'foo_C_x_y_3'
-        assert g.private_name('foo', 'C_x_y') == 'foo_C_x_y_3'
+        assert g.private_name('foo', 'f') == 'foo___f'
+        assert g.private_name('foo', 'C.x.y') == 'foo___C___x___y'
+        assert g.private_name('foo', 'C.x.y') == 'foo___C___x___y'
+        assert g.private_name('foo.zar', 'C.x.y') == 'zar___C___x___y'
+        assert g.private_name('foo', 'C.x_y') == 'foo___C___x_y'
+        assert g.private_name('foo', 'C_x_y') == 'foo___C_x_y'
+        assert g.private_name('foo', 'C_x_y') == 'foo___C_x_y'
+        assert g.private_name('foo', '___') == 'foo______3_'


### PR DESCRIPTION
Accomplish this by using a mapping that doesn't collide on valid
python identifiers. We map `.` to `___` and the (rare and unlikely,
but possible) `___` to `_3___`. (This collides `___` with `.3`,
which is fine.)

This makes naming not reliant on the order of processing things
which is important for separate compilation, since it will turn out
that most of our "internal" names actually do need to be exported
(but we would still like to shorten the module name part).

I also like the output better, even though it is a little more
verbose, since it makes it obvious what is a module separator and what
is an underscore.