### PR TITLE
Always show the cause of error in dmypy suggest

### DIFF
--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -534,10 +534,8 @@ class SuggestionEngine:
         """
         assert state.path is not None
         res = self.fgmanager.update([(state.id, state.path)], [])
-        # if res:
-        #     print('\n'.join(res))
         if check_errors and res:
-            raise SuggestionFailure("Error while trying to load %s" % state.id)
+            raise SuggestionFailure("Error while trying to load %s:\n" % state.id + '\n'.join(res))
         return res
 
     def ensure_loaded(self, state: State, force: bool = False) -> MypyFile:

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -255,3 +255,28 @@ from foo import foo
 def bar() -> None:
     x = foo('abc')  # type: str
     foo(arg='xyz')
+
+[case testDaemonSuggestErrorsShown]
+$ dmypy start --log-file log.txt -- --follow-imports=error --no-error-summary
+Daemon started
+$ dmypy check foo.py
+$ dmypy suggest tmp/foo.py:1
+() -> int
+$ {python} -c "import shutil; shutil.copy('foo.py.2', 'foo.py')"
+$ dmypy suggest tmp/foo.py:4
+Error while trying to load foo:
+foo.py:3: error: Unsupported operand types for + ("int" and "str")
+== Return code: 2
+[file foo.py]
+def foo():
+    return 0
+foo() + 'no'
+def bar():
+    return None
+[file foo.py.2]
+def foo() -> int:
+    return 0
+foo() + 'no'
+def bar():
+    return None
+[out]


### PR DESCRIPTION
This PR prints the type errors that prevented `dmypy suggest` from running. Since this will be mostly used by interactive tools, I don't pipe the errors though normal formatting and colors, but if you think it makes sense, then I can do this.