### PR TITLE
Update references to new/old semantic analyzers

### DIFF
--- a/docs/source/extending_mypy.rst
+++ b/docs/source/extending_mypy.rst
@@ -88,8 +88,8 @@ can be specified after colon:
     [mypy]
     plugins = custom_plugin:custom_entry_point
 
-In following sections we describe basics of the plugin system with
-some examples. For more technical details please read docstrings in
+In the following sections we describe the basics of the plugin system with
+some examples. For more technical details, please read the docstrings in
 `mypy/plugin.py <https://github.com/python/mypy/blob/master/mypy/plugin.py>`_
 in mypy source code. Also you can find good examples in the bundled plugins
 located in `mypy/plugins <https://github.com/python/mypy/tree/master/mypy/plugins>`_.
@@ -115,9 +115,9 @@ that is a full mypy version and return a subclass of ``mypy.plugin.Plugin``:
 
 During different phases of analyzing the code (first in semantic analysis,
 and then in type checking) mypy calls plugin methods such as
-``get_type_analyze_hook()`` on user plugins. This particular method for example
-can return a callback that mypy will use to analyze unbound types with given
-full name. See full plugin hook methods list :ref:`below <plugin_hooks>`.
+``get_type_analyze_hook()`` on user plugins. This particular method, for example,
+can return a callback that mypy will use to analyze unbound types with the given
+full name. See the full plugin hook method list :ref:`below <plugin_hooks>`.
 
 Mypy maintains a list of plugins it gets from the config file plus the default
 (built-in) plugin that is always enabled. Mypy calls a method once for each
@@ -126,7 +126,7 @@ This callback will be then used to customize the corresponding aspect of
 analyzing/checking the current abstract syntax tree node.
 
 The callback returned by the ``get_xxx`` method will be given a detailed
-current context and an API to create new nodes, new types, emit error messages
+current context and an API to create new nodes, new types, emit error messages,
 etc., and the result will be used for further processing.
 
 Plugin developers should ensure that their plugins work well in incremental and
@@ -236,12 +236,13 @@ module. It is called before semantic analysis. For example, this can
 be used if a library has dependencies that are dynamically loaded
 based on configuration information.
 
-Supporting the new semantic analyzer
-************************************
+Notes about the semantic analyzer
+*********************************
 
-Support for the new semantic analyzer (enabled through
-``--new-semantic-analyzer``) requires some changes to plugins. Here is
-a short summary of the most important changes:
+Mypy 0.710 introduced a new semantic analyzer, and the old semantic
+analyzer was removed in mypy 0.730. Support for the new semantic analyzer
+required some changes to existing plugins. Here is a short summary of the
+most important changes:
 
 * The order of processing AST nodes is different. Code outside
   functions is processed first, and functions and methods are

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1835,8 +1835,8 @@ class State:
         Also report an internal error if an unexpected exception was raised
         and raise an exception on a blocking error, unless
         check_blockers is False. Skipping blocking error reporting is used
-        in the new semantic analyzer so that we can report all blocking
-        errors for a file (across multiple targets) to maintain backward
+        in the semantic analyzer so that we can report all blocking errors
+        for a file (across multiple targets) to maintain backward
         compatibility.
         """
         save_import_context = self.manager.errors.import_context()

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -104,10 +104,9 @@ analyzer is no longer available):
    another module, such as the builtins, that is outside the current module or
    import cycle, you can safely assume that you won't receive a placeholder.
 
-When testing your plugin with the semantic analyzer, you should have a test
-case that forces a module top level to be processed multiple times. The easiest
-way to do this is to include a forward reference to a class in a top-level
-annotation. Example:
+When testing your plugin, you should have a test case that forces a module top
+level to be processed multiple times. The easiest way to do this is to include
+a forward reference to a class in a top-level annotation. Example:
 
     c: C  # Forward reference causes second analysis pass
     class C: pass

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -36,10 +36,9 @@ At large scale the plugin system works as following:
   named tuples for details about which information is given to each hook.
 
 Plugin developers should ensure that their plugins work well in incremental and
-daemon modes, and with both the old and new semantic analyzers (the old semantic
-analyzer will be removed soon). In particular, plugins should not hold global
-state, and should always call add_plugin_dependency() in plugin hooks called
-during semantic analysis. See the method docstring for more details.
+daemon modes. In particular, plugins should not hold global state, and should
+always call add_plugin_dependency() in plugin hooks called during semantic
+analysis. See the method docstring for more details.
 
 There is no dedicated cache storage for plugins, but plugins can store
 per-TypeInfo data in a special .metadata attribute that is serialized to the
@@ -48,13 +47,14 @@ are encouraged to store their state under a dedicated key coinciding with
 plugin name in the metadata dictionary. Every value stored there must be
 JSON-serializable.
 
-## New semantic analyzer
+## Notes about the semantic analyzer
 
-The new semantic analyzer (enabled through the --new-semantic-analyzer flag)
-changes how plugins are expected to work in several notable ways:
+Mypy 0.710 introduced a new semantic analyzer that changed how plugins are
+expected to work in several notable ways (from mypy 0.730 the old semantic
+analyzer is no longer available):
 
 1. The order of processing AST nodes in modules is different. The old semantic
-   analyzer processes modules in textual order, one module at a time. The new
+   analyzer processed modules in textual order, one module at a time. The new
    semantic analyzer first processes the module top levels, including bodies of
    any top-level classes and classes nested within classes. ("Top-level" here
    means "not nested within a function/method".) Functions and methods are
@@ -104,7 +104,7 @@ changes how plugins are expected to work in several notable ways:
    another module, such as the builtins, that is outside the current module or
    import cycle, you can safely assume that you won't receive a placeholder.
 
-When testing your plugin with the new semantic analyzer, you should have a test
+When testing your plugin with the semantic analyzer, you should have a test
 case that forces a module top level to be processed multiple times. The easiest
 way to do this is to include a forward reference to a class in a top-level
 annotation. Example:
@@ -117,7 +117,7 @@ pass, since all functions are processed only after the top level has been fully
 analyzed.
 
 You can use `api.options.new_semantic_analyzer` to check whether the new
-semantic analyzer is enabled.
+semantic analyzer is enabled (it's always true in mypy 0.730 and later).
 """
 
 import types
@@ -269,9 +269,9 @@ class SemanticAnalyzerPluginInterface:
                   third_pass: bool = False) -> Optional[Type]:
         """Analyze an unbound type.
 
-        Return None if the some part of the type is not ready yet (only
-        happens with the new semantic analyzer). In this case the current
-        target being analyzed will be deferred and analyzed again.
+        Return None if some part of the type is not ready yet. In this
+        case the current target being analyzed will be deferred and
+        analyzed again.
         """
         raise NotImplementedError
 
@@ -343,16 +343,12 @@ class SemanticAnalyzerPluginInterface:
         """Call this to defer the processing of the current node.
 
         This will request an additional iteration of semantic analysis.
-        Only available with new semantic analyzer.
         """
         raise NotImplementedError
 
     @abstractproperty
     def final_iteration(self) -> bool:
-        """Is this the final iteration of semantic analysis?
-
-        Only available with new semantic analyzer.
-        """
+        """Is this the final iteration of semantic analysis?"""
         raise NotImplementedError
 
 

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -92,7 +92,7 @@ def add_method(
     info = ctx.cls.info
 
     # First remove any previously generated methods with the same name
-    # to avoid clashes and problems in new semantic analyzer.
+    # to avoid clashes and problems in the semantic analyzer.
     if name in info.names:
         sym = info.names[name]
         if sym.plugin_generated and isinstance(sym.node, FuncDef):

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -96,7 +96,7 @@ class DataclassTransformer:
             'frozen': _get_decorator_bool_argument(self._ctx, 'frozen', False),
         }
 
-        # If there are no attributes, it may be that the new semantic analyzer has not
+        # If there are no attributes, it may be that the semantic analyzer has not
         # processed them yet. In order to work around this, we can simply skip generating
         # __init__ if there are no attributes, because if the user truly did not define any,
         # then the object default __init__ with an empty signature will be present anyway.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1,8 +1,9 @@
-"""The new semantic analyzer (work in progress).
+"""The semantic analyzer.
 
 Bind names to definitions and do various other simple consistency
-checks. It also detects special forms such as NamedTuple and cast().
-Multiple analysis iterations may be needed to analyze forward
+checks.  Populate symbol tables.  The semantic analyzer also detects
+special forms which reuse generic syntax such as NamedTuple and
+cast().  Multiple analysis iterations may be needed to analyze forward
 references and import cycles. Each iteration "fills in" additional
 bindings and references until everything has been bound.
 

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -1,9 +1,9 @@
-"""Top-level logic for the new semantic analyzer.
+"""Top-level logic for the semantic analyzer.
 
 The semantic analyzer binds names, resolves imports, detects various
 special constructs that don't have dedicated AST nodes after parse
-(such as 'cast' which looks like a call), and performs various simple
-consistency checks.
+(such as 'cast' which looks like a call), populates symbol tables, and
+performs various simple consistency checks.
 
 Semantic analysis of each SCC (strongly connected component; import
 cycle) is performed in one unit. Each module is analyzed as multiple

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -118,8 +118,7 @@ class NewTypeAnalyzer:
 
             names = self.api.current_symbol_table()
             existing = names.get(name)
-            # Give a better error message than generic "Name already defined",
-            # like the old semantic analyzer does.
+            # Give a better error message than generic "Name already defined".
             if (existing and
                     not isinstance(existing.node, PlaceholderNode) and not s.rvalue.analyzed):
                 self.fail("Cannot redefine '%s' as a NewType" % name, s)

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -50,13 +50,11 @@ SavedAttributes = Dict[Tuple[ClassDef, str], SymbolTableNode]
 
 def strip_target(node: Union[MypyFile, FuncDef, OverloadedFuncDef],
                  saved_attrs: SavedAttributes) -> None:
-    """Reset a fine-grained incremental target to state before main pass of semantic analysis.
+    """Reset a fine-grained incremental target to state before semantic analysis.
 
-    The most notable difference from the old version of strip_target() is that new semantic
-    analyzer doesn't have first pass where Vars and TypeInfos are pre-populated, so the stripping
-    is more thorough: all TypeInfos are killed. Therefore we need to preserve the variables
-    defined as attributes on self. This is done by patches (callbacks) returned from this function
-    that re-add these variables when called.
+    All TypeInfos are killed. Therefore we need to preserve the variables
+    defined as attributes on self. This is done by patches (callbacks)
+    returned from this function that re-add these variables when called.
 
     Args:
         node: node to strip


### PR DESCRIPTION
Since we only have a single semantic analyzer now, generally only talk
about "the semantic analyzer" instead of "the new semantic analyzer"
in documentation and docstrings.

Plugin documentation still explains the differences between the old
and the new semantic analyzers, since some plugins might not support
the new semantic analyzer yet.