### PR TITLE
Improve missing import message

### DIFF
--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -484,7 +484,7 @@ Example:
 
 .. code-block:: python
 
-    # Error: Cannot find module named 'acme'  [import]
+    # Error: Cannot find implementation or library stub for module named 'acme'  [import]
     import acme
 
 See :ref:`ignore-missing-imports` for how to work around these errors.

--- a/docs/source/existing_code.rst
+++ b/docs/source/existing_code.rst
@@ -42,8 +42,8 @@ find or that don't have stub files:
 
 .. code-block:: text
 
-    core/config.py:7: error: Cannot find module named 'frobnicate'
-    core/model.py:9: error: Cannot find module named 'acme'
+    core/config.py:7: error: Cannot find implementation or library stub for module named 'frobnicate'
+    core/model.py:9: error: Cannot find implementation or library stub for module named 'acme'
     ...
 
 This is normal, and you can easily ignore these errors. For example,

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -135,7 +135,7 @@ This can cause a lot of errors that look like the following::
 
     main.py:1: error: No library stub file for standard library module 'antigravity'
     main.py:2: error: No library stub file for module 'flask'
-    main.py:3: error: Cannot find module named 'this_module_does_not_exist'
+    main.py:3: error: Cannot find implementation or library stub for module named 'this_module_does_not_exist'
 
 There are several different things you can try doing, depending on the exact
 nature of the module.

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2436,7 +2436,12 @@ def module_not_found(manager: BuildManager, line: int, caller_state: State,
         errors.report(line, 0, stub_msg, severity='note', only_once=True, code=codes.IMPORT)
     else:
         note = "See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports"
-        errors.report(line, 0, "Cannot find module named '{}'".format(target), code=codes.IMPORT)
+        errors.report(
+            line,
+            0,
+            "Cannot find implementation or library stub for module named '{}'".format(target),
+            code=codes.IMPORT
+        )
         errors.report(line, 0, note, severity='note', only_once=True, code=codes.IMPORT)
     errors.set_import_context(save_import_context)
 

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -59,7 +59,7 @@ class SimpleMsg(Enum):
 
 
 class NamespaceMsg(Enum):
-    cfm_beta = ("{tempfile}:4: error: Cannot find module named "
+    cfm_beta = ("{tempfile}:4: error: Cannot find implementation or library stub for module named "
                 "'typedpkg_ns.ns.dne'")
     help_note = ('{tempfile}:4: note: See https://mypy.readthedocs.io/en/latest/'
                  'running_mypy.html#missing-imports')

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -495,12 +495,12 @@ if int() is str():  # E: Non-overlapping identity check (left operand type: "int
 [case testErrorCodeMissingModule]
 from defusedxml import xyz  # E: No library stub file for module 'defusedxml'  [import] \
                             # N: (Stub files are from https://github.com/python/typeshed)
-from nonexistent import foobar  # E: Cannot find module named 'nonexistent'  [import] \
+from nonexistent import foobar  # E: Cannot find implementation or library stub for module named 'nonexistent'  [import] \
     # N: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-import nonexistent2  # E: Cannot find module named 'nonexistent2'  [import]
-from nonexistent3 import *  # E: Cannot find module named 'nonexistent3'  [import]
+import nonexistent2  # E: Cannot find implementation or library stub for module named 'nonexistent2'  [import]
+from nonexistent3 import *  # E: Cannot find implementation or library stub for module named 'nonexistent3'  [import]
 from pkg import bad  # E: Module 'pkg' has no attribute 'bad'  [attr-defined]
-from pkg.bad2 import bad3  # E: Cannot find module named 'pkg.bad2'  [import]
+from pkg.bad2 import bad3  # E: Cannot find implementation or library stub for module named 'pkg.bad2'  [import]
 [file pkg/__init__.py]
 
 [case testErrorCodeAlreadyDefined]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -453,7 +453,7 @@ main:2: note: (Using --follow-imports=error, module not passed on command line)
 [case testIgnoreMissingImportsFalse]
 from mod import x
 [out]
-main:1: error: Cannot find module named 'mod'
+main:1: error: Cannot find implementation or library stub for module named 'mod'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testIgnoreMissingImportsTrue]
@@ -610,7 +610,7 @@ from missing import MyType
 def f(x: MyType) -> None:
     pass
 [out]
-main:2: error: Cannot find module named 'missing'
+main:2: error: Cannot find implementation or library stub for module named 'missing'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:4: error: Argument 1 to "f" becomes "Any" due to an unfollowed import
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2085,7 +2085,7 @@ x = 1
 [rechecked n]
 [stale]
 [out2]
-tmp/n.py:1: error: Cannot find module named 'm'
+tmp/n.py:1: error: Cannot find implementation or library stub for module named 'm'
 tmp/n.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testDeleteFileWithinCycle]
@@ -3382,7 +3382,7 @@ import a
 [out1]
 
 [out2]
-main:2: error: Cannot find module named 'a'
+main:2: error: Cannot find implementation or library stub for module named 'a'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testIncrementalInheritanceAddAnnotation]
@@ -3525,7 +3525,7 @@ def f() -> None: pass
 def f(x: int) -> None: pass
 [out]
 [out2]
-main:1: error: Cannot find module named 'p.q'
+main:1: error: Cannot find implementation or library stub for module named 'p.q'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 [out3]
 main:2: error: Too few arguments for "f"
@@ -4140,10 +4140,10 @@ def __getattr__(attr: str) -> Any: ...
 # empty
 [builtins fixtures/module.pyi]
 [out]
-tmp/c.py:1: error: Cannot find module named 'a.b.c'
+tmp/c.py:1: error: Cannot find implementation or library stub for module named 'a.b.c'
 tmp/c.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 [out2]
-tmp/c.py:1: error: Cannot find module named 'a.b.c'
+tmp/c.py:1: error: Cannot find implementation or library stub for module named 'a.b.c'
 tmp/c.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testAddedMissingStubs]

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -851,7 +851,7 @@ func(f)  # E: Argument 1 to "func" has incompatible type "Union[Literal['foo'], 
 [case testLiteralDisallowAny]
 from typing import Any
 from typing_extensions import Literal
-from missing_module import BadAlias     # E: Cannot find module named 'missing_module' \
+from missing_module import BadAlias     # E: Cannot find implementation or library stub for module named 'missing_module' \
                                         # N: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 a: Literal[Any]                         # E: Parameter 1 of Literal[...] cannot be of type "Any"

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -208,7 +208,7 @@ else:
 import nonexistent
 None + ''
 [out]
-main:1: error: Cannot find module named 'nonexistent'
+main:1: error: Cannot find implementation or library stub for module named 'nonexistent'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Unsupported left operand type for + ("None")
 
@@ -220,7 +220,7 @@ m.x = ''
 [file m.py]
 x = 1
 [out]
-main:1: error: Cannot find module named 'nonexistent'
+main:1: error: Cannot find implementation or library stub for module named 'nonexistent'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Unsupported left operand type for + ("None")
 main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
@@ -233,7 +233,7 @@ m.x = ''
 [file m.py]
 x = 1
 [out]
-main:1: error: Cannot find module named 'nonexistent'
+main:1: error: Cannot find implementation or library stub for module named 'nonexistent'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Unsupported left operand type for + ("None")
 main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
@@ -242,16 +242,16 @@ main:4: error: Incompatible types in assignment (expression has type "str", vari
 import nonexistent, another
 None + ''
 [out]
-main:1: error: Cannot find module named 'nonexistent'
+main:1: error: Cannot find implementation or library stub for module named 'nonexistent'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:1: error: Cannot find module named 'another'
+main:1: error: Cannot find implementation or library stub for module named 'another'
 main:2: error: Unsupported left operand type for + ("None")
 
 [case testTypeCheckWithUnknownModule5]
 import nonexistent as x
 None + ''
 [out]
-main:1: error: Cannot find module named 'nonexistent'
+main:1: error: Cannot find implementation or library stub for module named 'nonexistent'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Unsupported left operand type for + ("None")
 
@@ -259,7 +259,7 @@ main:2: error: Unsupported left operand type for + ("None")
 from nonexistent import x
 None + ''
 [out]
-main:1: error: Cannot find module named 'nonexistent'
+main:1: error: Cannot find implementation or library stub for module named 'nonexistent'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Unsupported left operand type for + ("None")
 
@@ -267,7 +267,7 @@ main:2: error: Unsupported left operand type for + ("None")
 from nonexistent import *
 None + ''
 [out]
-main:1: error: Cannot find module named 'nonexistent'
+main:1: error: Cannot find implementation or library stub for module named 'nonexistent'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Unsupported left operand type for + ("None")
 
@@ -276,7 +276,7 @@ import xyz
 xyz.foo()
 xyz()
 [out]
-main:1: error: Cannot find module named 'xyz'
+main:1: error: Cannot find implementation or library stub for module named 'xyz'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testAccessingUnknownModule2]
@@ -284,16 +284,16 @@ import xyz, bar
 xyz.foo()
 bar()
 [out]
-main:1: error: Cannot find module named 'xyz'
+main:1: error: Cannot find implementation or library stub for module named 'xyz'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:1: error: Cannot find module named 'bar'
+main:1: error: Cannot find implementation or library stub for module named 'bar'
 
 [case testAccessingUnknownModule3]
 import xyz as z
 xyz.foo()
 z()
 [out]
-main:1: error: Cannot find module named 'xyz'
+main:1: error: Cannot find implementation or library stub for module named 'xyz'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Name 'xyz' is not defined
 
@@ -302,14 +302,14 @@ from xyz import y, z
 y.foo()
 z()
 [out]
-main:1: error: Cannot find module named 'xyz'
+main:1: error: Cannot find implementation or library stub for module named 'xyz'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testAccessingNameImportedFromUnknownModule2]
 from xyz import *
 y
 [out]
-main:1: error: Cannot find module named 'xyz'
+main:1: error: Cannot find implementation or library stub for module named 'xyz'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Name 'y' is not defined
 
@@ -318,14 +318,14 @@ from xyz import y as z
 y
 z
 [out]
-main:1: error: Cannot find module named 'xyz'
+main:1: error: Cannot find implementation or library stub for module named 'xyz'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Name 'y' is not defined
 
 [case testUnknownModuleRedefinition]
 # Error messages differ with the new analyzer
 
-import xab  # E: Cannot find module named 'xab'  # N: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
+import xab  # E: Cannot find implementation or library stub for module named 'xab'  # N: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 def xab(): pass  # E: Name 'xab' already defined (possibly by an import)
 
 [case testAccessingUnknownModuleFromOtherModule]
@@ -336,7 +336,7 @@ x.z
 import nonexistent
 [builtins fixtures/module.pyi]
 [out]
-tmp/x.py:1: error: Cannot find module named 'nonexistent'
+tmp/x.py:1: error: Cannot find implementation or library stub for module named 'nonexistent'
 tmp/x.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:3: error: Module has no attribute "z"
 
@@ -346,7 +346,7 @@ def f():
 def foobar(): pass
 foobar('')
 [out]
-main:2: error: Cannot find module named 'foobar'
+main:2: error: Cannot find implementation or library stub for module named 'foobar'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:4: error: Too many arguments for "foobar"
 
@@ -356,7 +356,7 @@ def f():
 def x(): pass
 x('')
 [out]
-main:2: error: Cannot find module named 'foobar'
+main:2: error: Cannot find implementation or library stub for module named 'foobar'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:4: error: Too many arguments for "x"
 
@@ -2177,8 +2177,8 @@ import c
 
 [out]
 -- TODO: it would be better for this to be in the other order
-tmp/b.py:1: error: Cannot find module named 'c'
-main:1: error: Cannot find module named 'c'
+tmp/b.py:1: error: Cannot find implementation or library stub for module named 'c'
+main:1: error: Cannot find implementation or library stub for module named 'c'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testIndirectFromImportWithinCycle1]
@@ -2312,7 +2312,7 @@ from typing import Any
 def __getattr__(attr: str) -> Any: ...
 [builtins fixtures/module.pyi]
 [out]
-main:1: error: Cannot find module named 'a.b'
+main:1: error: Cannot find implementation or library stub for module named 'a.b'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testModuleGetattrInit4]
@@ -2357,12 +2357,12 @@ def __getattr__(attr: str) -> Any: ...
 # empty (i.e. complete subpackage)
 [builtins fixtures/module.pyi]
 [out]
-main:1: error: Cannot find module named 'a.b.c.d'
+main:1: error: Cannot find implementation or library stub for module named 'a.b.c.d'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:1: error: Cannot find module named 'a.b.c'
+main:1: error: Cannot find implementation or library stub for module named 'a.b.c'
 
 [case testModuleGetattrInit8a]
-import a.b.c  # E: Cannot find module named 'a.b.c'  # N: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
+import a.b.c  # E: Cannot find implementation or library stub for module named 'a.b.c'  # N: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 import a.d  # OK
 [file a/__init__.pyi]
 from typing import Any
@@ -2388,7 +2388,7 @@ def __getattr__(attr: str) -> Any: ...
 ignore_missing_imports = True
 [builtins fixtures/module.pyi]
 [out]
-main:3: error: Cannot find module named 'a.b.d'
+main:3: error: Cannot find implementation or library stub for module named 'a.b.d'
 main:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testIndirectFromImportWithinCycleUsedAsBaseClass-skip]
@@ -2619,7 +2619,7 @@ from foo.bar import x
 [file foo/bar.py]
 x = 0
 [out]
-main:1: error: Cannot find module named 'foo.bar'
+main:1: error: Cannot find implementation or library stub for module named 'foo.bar'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testNamespacePackage]

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -167,7 +167,7 @@ main:8: error: Argument 2 to "f" has incompatible type "int"; expected "Tuple[in
 import asyncio
 import Bastion
 [out]
-main:1: error: Cannot find module named 'asyncio'
+main:1: error: Cannot find implementation or library stub for module named 'asyncio'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: No library stub file for standard library module 'Bastion'
 main:2: note: (Stub files are from https://github.com/python/typeshed)

--- a/test-data/unit/check-semanal-error.test
+++ b/test-data/unit/check-semanal-error.test
@@ -18,7 +18,7 @@ m.foo()
 m.x = m.y
 1() # E
 [out]
-main:1: error: Cannot find module named 'm'
+main:1: error: Cannot find implementation or library stub for module named 'm'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:4: error: "int" not callable
 
@@ -28,7 +28,7 @@ x.foo()
 x.a = x.b
 1() # E
 [out]
-main:1: error: Cannot find module named 'm'
+main:1: error: Cannot find implementation or library stub for module named 'm'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:4: error: "int" not callable
 
@@ -37,7 +37,7 @@ from m import * # E
 x # E
 1() # E
 [out]
-main:1: error: Cannot find module named 'm'
+main:1: error: Cannot find implementation or library stub for module named 'm'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: error: Name 'x' is not defined
 main:3: error: "int" not callable

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -78,7 +78,7 @@ else:
     import pow123 # E
 [builtins fixtures/bool.pyi]
 [out]
-main:6: error: Cannot find module named 'pow123'
+main:6: error: Cannot find implementation or library stub for module named 'pow123'
 main:6: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testMypyConditional]
@@ -97,7 +97,7 @@ if typing.TYPE_CHECKING:
 else:
     import xyz753
 [out]
-main:3: error: Cannot find module named 'pow123'
+main:3: error: Cannot find implementation or library stub for module named 'pow123'
 main:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testTypeCheckingConditionalFromImport]
@@ -107,7 +107,7 @@ if TYPE_CHECKING:
 else:
     import xyz753
 [out]
-main:3: error: Cannot find module named 'pow123'
+main:3: error: Cannot find implementation or library stub for module named 'pow123'
 main:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testNegatedTypeCheckingConditional]
@@ -118,7 +118,7 @@ else:
     import xyz753
 [builtins fixtures/bool.pyi]
 [out]
-main:5: error: Cannot find module named 'xyz753'
+main:5: error: Cannot find implementation or library stub for module named 'xyz753'
 main:5: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testUndefinedTypeCheckingConditional]
@@ -129,7 +129,7 @@ else:
 [builtins fixtures/bool.pyi]
 [out]
 main:1: error: Name 'TYPE_CHECKING' is not defined
-main:4: error: Cannot find module named 'xyz753'
+main:4: error: Cannot find implementation or library stub for module named 'xyz753'
 main:4: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testConditionalClassDefPY3]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -316,7 +316,7 @@ from baz import baz
 baz(bar(foo(42)))
 baz(bar(foo('oof')))
 [out]
-file.py:1: error: Cannot find module named 'no_stubs'
+file.py:1: error: Cannot find implementation or library stub for module named 'no_stubs'
 file.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 file.py:6: error: Argument 1 to "foo" has incompatible type "str"; expected "int"
 
@@ -461,7 +461,7 @@ reveal_type(missing.x)  # Expect Any
 \[mypy]
 ignore_missing_imports = False
 [out]
-main.py:1: error: Cannot find module named 'missing'
+main.py:1: error: Cannot find implementation or library stub for module named 'missing'
 main.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main.py:2: note: Revealed type is 'Any'
 
@@ -508,9 +508,9 @@ import a.b
 [file a.b.py]
 whatever
 [out]
-main.py:1: error: Cannot find module named 'a.b'
+main.py:1: error: Cannot find implementation or library stub for module named 'a.b'
 main.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main.py:1: error: Cannot find module named 'a'
+main.py:1: error: Cannot find implementation or library stub for module named 'a'
 
 [case testPythonVersionTooOld10]
 # cmd: mypy -c pass

--- a/test-data/unit/fine-grained-blockers.test
+++ b/test-data/unit/fine-grained-blockers.test
@@ -134,7 +134,7 @@ x x
 [file a.py.3]
 def f() -> None: pass
 [out]
-main:1: error: Cannot find module named 'a'
+main:1: error: Cannot find implementation or library stub for module named 'a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 a.py:1: error: invalid syntax
@@ -277,9 +277,9 @@ x x
 ==
 a.py:1: error: invalid syntax
 ==
-main:1: error: Cannot find module named 'a'
+main:1: error: Cannot find implementation or library stub for module named 'a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-b.py:1: error: Cannot find module named 'a'
+b.py:1: error: Cannot find implementation or library stub for module named 'a'
 
 [case testDeleteFileWithBlockingError-only_when_cache]
 -- Different cache/no-cache tests because:
@@ -298,9 +298,9 @@ x x
 ==
 a.py:1: error: invalid syntax
 ==
-b.py:1: error: Cannot find module named 'a'
+b.py:1: error: Cannot find implementation or library stub for module named 'a'
 b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:1: error: Cannot find module named 'a'
+main:1: error: Cannot find implementation or library stub for module named 'a'
 
 [case testModifyFileWhileBlockingErrorElsewhere]
 import a
@@ -371,7 +371,7 @@ class A: pass
 [builtins fixtures/module.pyi]
 [out]
 ==
-main:1: error: Cannot find module named 'a'
+main:1: error: Cannot find implementation or library stub for module named 'a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 main:4: error: "A" has no attribute "f"
@@ -389,7 +389,7 @@ class A:
 [builtins fixtures/module.pyi]
 [out]
 ==
-main:1: error: Cannot find module named 'a'
+main:1: error: Cannot find implementation or library stub for module named 'a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 main:1: error: Module 'a' has no attribute 'A'

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -52,7 +52,7 @@ f()
 def f() -> None: pass
 [out]
 ==
-b.py:1: error: Cannot find module named 'a'
+b.py:1: error: Cannot find implementation or library stub for module named 'a'
 b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 
@@ -68,10 +68,10 @@ f(1)
 def f() -> None: pass
 [out]
 ==
-b.py:1: error: Cannot find module named 'a'
+b.py:1: error: Cannot find implementation or library stub for module named 'a'
 b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
-b.py:1: error: Cannot find module named 'a'
+b.py:1: error: Cannot find implementation or library stub for module named 'a'
 b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 b.py:2: error: Too many arguments for "f"
@@ -88,10 +88,10 @@ x = 'whatever'
 def f() -> None: pass
 [out]
 ==
-b.py:1: error: Cannot find module named 'a'
+b.py:1: error: Cannot find implementation or library stub for module named 'a'
 b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
-b.py:1: error: Cannot find module named 'a'
+b.py:1: error: Cannot find implementation or library stub for module named 'a'
 b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 b.py:2: error: Too many arguments for "f"
@@ -118,10 +118,10 @@ f(1)
 # unrelated change
 [out]
 ==
-b.py:1: error: Cannot find module named 'a'
+b.py:1: error: Cannot find implementation or library stub for module named 'a'
 b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
-b.py:1: error: Cannot find module named 'a'
+b.py:1: error: Cannot find implementation or library stub for module named 'a'
 b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testAddFilePreservesError2]
@@ -161,7 +161,7 @@ x = 1
 import a
 [out]
 ==
-b.py:2: error: Cannot find module named 'a'
+b.py:2: error: Cannot find implementation or library stub for module named 'a'
 b.py:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testImportLineNumber2]
@@ -174,13 +174,13 @@ from c import f
 [file x.py.3]
 [out]
 ==
-b.py:2: error: Cannot find module named 'a'
+b.py:2: error: Cannot find implementation or library stub for module named 'a'
 b.py:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-b.py:3: error: Cannot find module named 'c'
+b.py:3: error: Cannot find implementation or library stub for module named 'c'
 ==
-b.py:2: error: Cannot find module named 'a'
+b.py:2: error: Cannot find implementation or library stub for module named 'a'
 b.py:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-b.py:3: error: Cannot find module named 'c'
+b.py:3: error: Cannot find implementation or library stub for module named 'c'
 
 [case testAddPackage1]
 import p.a
@@ -189,9 +189,9 @@ p.a.f(1)
 [file p/a.py.2]
 def f(x: str) -> None: pass
 [out]
-main:1: error: Cannot find module named 'p.a'
+main:1: error: Cannot find implementation or library stub for module named 'p.a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:1: error: Cannot find module named 'p'
+main:1: error: Cannot find implementation or library stub for module named 'p'
 ==
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 
@@ -203,7 +203,7 @@ from p.a import f
 [file p/a.py.2]
 def f(x: str) -> None: pass
 [out]
-main:1: error: Cannot find module named 'p'
+main:1: error: Cannot find implementation or library stub for module named 'p'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
@@ -215,11 +215,11 @@ p.a.f(1)
 [file p/a.py.3]
 def f(x: str) -> None: pass
 [out]
-main:1: error: Cannot find module named 'p.a'
+main:1: error: Cannot find implementation or library stub for module named 'p.a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:1: error: Cannot find module named 'p'
+main:1: error: Cannot find implementation or library stub for module named 'p'
 ==
-main:1: error: Cannot find module named 'p.a'
+main:1: error: Cannot find implementation or library stub for module named 'p.a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
@@ -232,13 +232,13 @@ p.a.f(1)
 def f(x: str) -> None: pass
 [file p/__init__.py.3]
 [out]
-main:1: error: Cannot find module named 'p.a'
+main:1: error: Cannot find implementation or library stub for module named 'p.a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:1: error: Cannot find module named 'p'
+main:1: error: Cannot find implementation or library stub for module named 'p'
 ==
-main:1: error: Cannot find module named 'p.a'
+main:1: error: Cannot find implementation or library stub for module named 'p.a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:1: error: Cannot find module named 'p'
+main:1: error: Cannot find implementation or library stub for module named 'p'
 ==
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 
@@ -266,13 +266,13 @@ p.a.f(1)
 def f(x: str) -> None: pass
 [file p/__init__.py.3]
 [out]
-main:4: error: Cannot find module named 'p.a'
+main:4: error: Cannot find implementation or library stub for module named 'p.a'
 main:4: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:4: error: Cannot find module named 'p'
+main:4: error: Cannot find implementation or library stub for module named 'p'
 ==
-main:4: error: Cannot find module named 'p.a'
+main:4: error: Cannot find implementation or library stub for module named 'p.a'
 main:4: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:4: error: Cannot find module named 'p'
+main:4: error: Cannot find implementation or library stub for module named 'p'
 ==
 main:5: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 
@@ -301,7 +301,7 @@ f(1)
 def f(x: str) -> None: pass
 [file p/__init__.py.2]
 [out]
-x.py:1: error: Cannot find module named 'p.a'
+x.py:1: error: Cannot find implementation or library stub for module named 'p.a'
 x.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 x.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
@@ -374,7 +374,7 @@ def f() -> None: pass
 def f(x: int) -> None: pass
 [out]
 ==
-a.py:1: error: Cannot find module named 'b'
+a.py:1: error: Cannot find implementation or library stub for module named 'b'
 a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 a.py:4: error: Too few arguments for "f"
@@ -388,7 +388,7 @@ def f() -> None: pass
 def f() -> None: pass
 [out]
 ==
-main:1: error: Cannot find module named 'a'
+main:1: error: Cannot find implementation or library stub for module named 'a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 
@@ -404,7 +404,7 @@ from p import q
 ==
 main:1: error: Module 'p' has no attribute 'q'
 -- TODO: The following messages are different compared to non-incremental mode
-main:1: error: Cannot find module named 'p.q'
+main:1: error: Cannot find implementation or library stub for module named 'p.q'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 
@@ -420,7 +420,7 @@ from p import q
 [file p/q.py.3]
 [out]
 ==
-main:1: error: Cannot find module named 'p.q'
+main:1: error: Cannot find implementation or library stub for module named 'p.q'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 
@@ -435,7 +435,7 @@ def f() -> None: pass
 def f(x: int) -> None: pass
 [out]
 ==
-main:1: error: Cannot find module named 'p.q'
+main:1: error: Cannot find implementation or library stub for module named 'p.q'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 main:2: error: Too few arguments for "f"
@@ -450,7 +450,7 @@ def f() -> None: pass
 def f(x: int) -> None: pass
 [out]
 ==
-main:1: error: Cannot find module named 'p.q'
+main:1: error: Cannot find implementation or library stub for module named 'p.q'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 
@@ -481,7 +481,7 @@ def f() -> str:
 ==
 a.py:2: error: Incompatible return value type (got "int", expected "str")
 ==
-main:1: error: Cannot find module named 'a'
+main:1: error: Cannot find implementation or library stub for module named 'a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testDeleteModuleWithErrorInsidePackage]
@@ -496,7 +496,7 @@ def f() -> str:
 [out]
 a/b.py:2: error: Incompatible return value type (got "str", expected "int")
 ==
-main:1: error: Cannot find module named 'a.b'
+main:1: error: Cannot find implementation or library stub for module named 'a.b'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testModifyTwoFilesNoError1]
@@ -635,9 +635,9 @@ import b
 def g() -> None: pass
 b.f()
 [out]
-a.py:1: error: Cannot find module named 'b'
+a.py:1: error: Cannot find implementation or library stub for module named 'b'
 a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-a.py:2: error: Cannot find module named 'c'
+a.py:2: error: Cannot find implementation or library stub for module named 'c'
 ==
 
 [case testAddTwoFilesErrorsInBoth]
@@ -656,9 +656,9 @@ import b
 def g() -> None: pass
 b.f(1)
 [out]
-a.py:1: error: Cannot find module named 'b'
+a.py:1: error: Cannot find implementation or library stub for module named 'b'
 a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-a.py:2: error: Cannot find module named 'c'
+a.py:2: error: Cannot find implementation or library stub for module named 'c'
 ==
 c.py:3: error: Too many arguments for "f"
 b.py:3: error: Too many arguments for "g"
@@ -673,9 +673,9 @@ def f() -> None: pass
 [file b.py.2]
 def g() -> None: pass
 [out]
-main:1: error: Cannot find module named 'a'
+main:1: error: Cannot find implementation or library stub for module named 'a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:2: error: Cannot find module named 'b'
+main:2: error: Cannot find implementation or library stub for module named 'b'
 ==
 main:3: error: Too many arguments for "f"
 main:4: error: Too many arguments for "g"
@@ -693,9 +693,9 @@ def g() -> None: pass
 [delete b.py.2]
 [out]
 ==
-main:1: error: Cannot find module named 'a'
+main:1: error: Cannot find implementation or library stub for module named 'a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:2: error: Cannot find module named 'b'
+main:2: error: Cannot find implementation or library stub for module named 'b'
 
 [case testDeleteTwoFilesNoErrors]
 import a
@@ -734,9 +734,9 @@ a.f(1)
 b.py:3: error: Too many arguments for "f"
 a.py:3: error: Too many arguments for "g"
 ==
-main:1: error: Cannot find module named 'a'
+main:1: error: Cannot find implementation or library stub for module named 'a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:2: error: Cannot find module named 'b'
+main:2: error: Cannot find implementation or library stub for module named 'b'
 
 [case testAddFileWhichImportsLibModule]
 import a
@@ -745,7 +745,7 @@ a.x = 0
 import sys
 x = sys.platform
 [out]
-main:1: error: Cannot find module named 'a'
+main:1: error: Cannot find implementation or library stub for module named 'a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 main:2: error: Incompatible types in assignment (expression has type "int", variable has type "str")
@@ -759,7 +759,7 @@ import broken
 x = broken.x
 z
 [out]
-main:2: error: Cannot find module named 'a'
+main:2: error: Cannot find implementation or library stub for module named 'a'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 a.py:3: error: Name 'z' is not defined
@@ -825,7 +825,7 @@ def g() -> None: pass
 [out]
 a.py:2: error: Too many arguments for "g"
 ==
-a.py:1: error: Cannot find module named 'm.x'
+a.py:1: error: Cannot find implementation or library stub for module named 'm.x'
 a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 a.py:2: error: Module has no attribute "x"
 
@@ -841,9 +841,9 @@ def f(x: str) -> None: pass
 [out]
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
-main:1: error: Cannot find module named 'p.a'
+main:1: error: Cannot find implementation or library stub for module named 'p.a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:1: error: Cannot find module named 'p'
+main:1: error: Cannot find implementation or library stub for module named 'p'
 
 [case testDeletePackage2]
 import p
@@ -857,7 +857,7 @@ def f(x: str) -> None: pass
 [out]
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
-main:1: error: Cannot find module named 'p'
+main:1: error: Cannot find implementation or library stub for module named 'p'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testDeletePackage3]
@@ -873,13 +873,13 @@ def f(x: str) -> None: pass
 [out]
 main:3: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
-main:2: error: Cannot find module named 'p.a'
+main:2: error: Cannot find implementation or library stub for module named 'p.a'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:3: error: Module has no attribute "a"
 ==
-main:2: error: Cannot find module named 'p.a'
+main:2: error: Cannot find implementation or library stub for module named 'p.a'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:2: error: Cannot find module named 'p'
+main:2: error: Cannot find implementation or library stub for module named 'p'
 
 [case testDeletePackage4]
 import p.a
@@ -892,13 +892,13 @@ def f(x: str) -> None: pass
 [out]
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
-main:1: error: Cannot find module named 'p.a'
+main:1: error: Cannot find implementation or library stub for module named 'p.a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:1: error: Cannot find module named 'p'
+main:1: error: Cannot find implementation or library stub for module named 'p'
 ==
-main:1: error: Cannot find module named 'p.a'
+main:1: error: Cannot find implementation or library stub for module named 'p.a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:1: error: Cannot find module named 'p'
+main:1: error: Cannot find implementation or library stub for module named 'p'
 
 [case testDeletePackage5]
 # cmd1: mypy main p/a.py p/__init__.py
@@ -915,13 +915,13 @@ def f(x: str) -> None: pass
 [out]
 main:6: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
-main:5: error: Cannot find module named 'p.a'
+main:5: error: Cannot find implementation or library stub for module named 'p.a'
 main:5: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:5: error: Cannot find module named 'p'
+main:5: error: Cannot find implementation or library stub for module named 'p'
 ==
-main:5: error: Cannot find module named 'p.a'
+main:5: error: Cannot find implementation or library stub for module named 'p.a'
 main:5: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:5: error: Cannot find module named 'p'
+main:5: error: Cannot find implementation or library stub for module named 'p'
 
 
 [case testDeletePackage6]
@@ -941,7 +941,7 @@ f(12)
 [out]
 p/b.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
-p/b.py:1: error: Cannot find module named 'p.a'
+p/b.py:1: error: Cannot find implementation or library stub for module named 'p.a'
 p/b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 p/b.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
@@ -1415,7 +1415,7 @@ def f() -> None: pass
 
 [out]
 ==
-a.py:1: error: Cannot find module named 'b'
+a.py:1: error: Cannot find implementation or library stub for module named 'b'
 a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 
@@ -1811,7 +1811,7 @@ x = 2
 [out]
 ==
 ==
-a.py:2: error: Cannot find module named 'b'
+a.py:2: error: Cannot find implementation or library stub for module named 'b'
 a.py:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testErrorButDontIgnore1]
@@ -1886,7 +1886,7 @@ x = 1
 ==
 p/b.py: error: Ancestor package 'p' ignored
 p/b.py: note: (Using --follow-imports=error, submodule passed on command line)
-p/b.py:1: error: Cannot find module named 'z'
+p/b.py:1: error: Cannot find implementation or library stub for module named 'z'
 p/b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testTurnPackageToModule]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -473,7 +473,7 @@ x = 3
 ==
 ==
 ==
-a.py:1: error: Cannot find module named 'b'
+a.py:1: error: Cannot find implementation or library stub for module named 'b'
 a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testIgnoreWorksWithMissingImports]
@@ -507,7 +507,7 @@ from xyz import x  # type: ignore
 [file xyz.py.3]
 x = str()
 [out]
-b.py:1: error: Cannot find module named 'xyz'
+b.py:1: error: Cannot find implementation or library stub for module named 'xyz'
 b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 ==
@@ -526,7 +526,7 @@ from xyz import x
 x = str()
 [out]
 ==
-b.py:1: error: Cannot find module named 'xyz'
+b.py:1: error: Cannot find implementation or library stub for module named 'xyz'
 b.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 a.py:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
@@ -1834,7 +1834,7 @@ def f() -> Iterator[None]:
 [out]
 main:2: note: Revealed type is 'contextlib.GeneratorContextManager[None]'
 ==
-a.py:3: error: Cannot find module named 'b'
+a.py:3: error: Cannot find implementation or library stub for module named 'b'
 a.py:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:2: note: Revealed type is 'contextlib.GeneratorContextManager[None]'
 ==
@@ -1881,7 +1881,7 @@ def g() -> None:
 [out]
 a.py:11: error: Too many arguments for "h"
 ==
-a.py:10: error: Cannot find module named 'b'
+a.py:10: error: Cannot find implementation or library stub for module named 'b'
 a.py:10: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 a.py:11: error: Too many arguments for "h"
@@ -1915,7 +1915,7 @@ def f(x: List[int]) -> Iterator[None]:
 [builtins fixtures/list.pyi]
 [out]
 ==
-a.py:3: error: Cannot find module named 'b'
+a.py:3: error: Cannot find implementation or library stub for module named 'b'
 a.py:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 ==
 ==
@@ -2534,10 +2534,10 @@ def g() -> None: pass
 [delete n.py.2]
 [out]
 ==
-main:2: error: Cannot find module named 'm'
+main:2: error: Cannot find implementation or library stub for module named 'm'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:7: error: Overloaded function signature 2 will never be matched: signature 1's parameter type(s) are the same or broader
-main:9: error: Cannot find module named 'n'
+main:9: error: Cannot find implementation or library stub for module named 'n'
 
 [case testOverloadSpecialCase]
 from typing import overload
@@ -2563,10 +2563,10 @@ def g() -> None: pass
 [builtins fixtures/ops.pyi]
 [out]
 ==
-main:2: error: Cannot find module named 'm'
+main:2: error: Cannot find implementation or library stub for module named 'm'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 main:12: error: Overloaded function signature 2 will never be matched: signature 1's parameter type(s) are the same or broader
-main:14: error: Cannot find module named 'n'
+main:14: error: Cannot find implementation or library stub for module named 'n'
 
 [case testOverloadClassmethodDisappears]
 from typing import overload

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1262,7 +1262,7 @@ bar: Type[C]
 
 bar * 4 + bar + 3  # should not produce more errors
 [out]
-_testMetaclassOpAccessAny.py:2: error: Cannot find module named 'nonexistent'
+_testMetaclassOpAccessAny.py:2: error: Cannot find implementation or library stub for module named 'nonexistent'
 _testMetaclassOpAccessAny.py:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testEnumIterationAndPreciseElementType]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -199,21 +199,21 @@ main:2: error: Module 'm' has no attribute 'y'
 import typing
 import m
 [out]
-main:2: error: Cannot find module named 'm'
+main:2: error: Cannot find implementation or library stub for module named 'm'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testMissingModule2]
 import typing
 from m import x
 [out]
-main:2: error: Cannot find module named 'm'
+main:2: error: Cannot find implementation or library stub for module named 'm'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testMissingModule3]
 import typing
 from m import *
 [out]
-main:2: error: Cannot find module named 'm'
+main:2: error: Cannot find implementation or library stub for module named 'm'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testMissingModuleRelativeImport]
@@ -222,7 +222,7 @@ import m
 [file m/__init__.py]
 from .x import y
 [out]
-tmp/m/__init__.py:1: error: Cannot find module named 'm.x'
+tmp/m/__init__.py:1: error: Cannot find implementation or library stub for module named 'm.x'
 tmp/m/__init__.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testMissingModuleRelativeImport2]
@@ -232,7 +232,7 @@ import m.a
 [file m/a.py]
 from .x import y
 [out]
-tmp/m/a.py:1: error: Cannot find module named 'm.x'
+tmp/m/a.py:1: error: Cannot find implementation or library stub for module named 'm.x'
 tmp/m/a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
 
 [case testModuleNotImported]
@@ -281,18 +281,18 @@ main:4: error: Name 'n' is not defined
 import typing
 import m.n
 [out]
-main:2: error: Cannot find module named 'm.n'
+main:2: error: Cannot find implementation or library stub for module named 'm.n'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:2: error: Cannot find module named 'm'
+main:2: error: Cannot find implementation or library stub for module named 'm'
 
 [case testMissingPackage2]
 import typing
 from m.n import x
 from a.b import *
 [out]
-main:2: error: Cannot find module named 'm.n'
+main:2: error: Cannot find implementation or library stub for module named 'm.n'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:3: error: Cannot find module named 'a.b'
+main:3: error: Cannot find implementation or library stub for module named 'a.b'
 
 [case testErrorInImportedModule]
 import m
@@ -320,9 +320,9 @@ m.n.x
 [file m/n.py]
 x = 1
 [out]
-main:2: error: Cannot find module named 'm.n'
+main:2: error: Cannot find implementation or library stub for module named 'm.n'
 main:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
-main:2: error: Cannot find module named 'm'
+main:2: error: Cannot find implementation or library stub for module named 'm'
 
 [case testBreakOutsideLoop]
 break


### PR DESCRIPTION
It can be difficult to understand the missing module error message at times.

Changes 

> Cannot find module named '{}'

to

> Cannot find implementation or library stub for module named '{}'

This improves https://github.com/python/mypy/issues/4542

Great thanks to all that participated in that discussion, this is all of our work.

@JukkaL 