### PR TITLE
Extends is_singleton_type for single value enums variables

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4759,6 +4759,13 @@ def is_singleton_type(typ: Type) -> bool:
     constructing two distinct instances of 100001.
     """
     typ = get_proper_type(typ)
+
+    if isinstance(typ, Instance) and typ.type.is_enum and 1 == len(typ.type.names):
+        # This is a value for an Enum that has exactly one member value.
+        # No other value can be assigned to this variable
+        # That is the same as it being a singleton like None
+        return True
+
     # TODO: Also make this return True if the type is a bool LiteralType.
     # Also make this return True if the type corresponds to ... (ellipsis) or NotImplemented?
     return isinstance(typ, NoneType) or (isinstance(typ, LiteralType) and typ.is_enum_literal())

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -854,3 +854,40 @@ def process(response: Union[str, Reason] = '') -> str:
         return 'PROCESSED: ' + response
 
 [builtins fixtures/primitives.pyi]
+
+[case testEnumSingularSingleton]
+from typing import Union
+from enum import Enum
+
+class NothingEnum(Enum):
+    NothingValue = 1
+
+NOTHING = NothingEnum.NothingValue
+
+def process(response: Union[str, NothingEnum] = '') -> str:
+    if response is NOTHING:
+        reveal_type(response)  # N: Revealed type is '__main__.NothingEnum'
+        return 'No response given'
+    else:
+        # response can be only str, all other possible values exhausted
+        reveal_type(response)  # N: Revealed type is 'builtins.str'
+        return 'PROCESSED: ' + response
+
+[builtins fixtures/primitives.pyi]
+
+[case testEnumSingularSingletonUnion]
+from typing import Union
+from enum import Enum
+
+class NothingEnum(Enum):
+    NothingValue = 1
+
+NOTHING: Union[NothingEnum, str] = NothingEnum.NothingValue
+
+def process(response: Union[str, NothingEnum] = '') -> None:
+    if response is NOTHING:
+        # response could be assigned a string at any point,
+        # so the type checker cannot be sure which it is.
+        reveal_type(response)  # N: Revealed type is 'Union[builtins.str, __main__.NothingEnum]'
+
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
Since the only value that can be assigned is that same value,
this counts like a singleton.

First commit on this repo, so please double check my work.

Part one for #7642 