### PR TITLE
Add recommendation to use string literal escaping

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -569,11 +569,15 @@ string literal types or :py:data:`~typing.TYPE_CHECKING`:
 
    results: 'Queue[int]' = Queue()  # OK
 
-If you are running Python 3.7+ simply activate annotations. Read more about them in `PEP563 <https://www.python.org/dev/peps/pep-0563/>`_.
+If you are running Python 3.7+ you can use ``from __future__ import annotations``
+as a (nicer) alternative to string quotes, read more in :pep:`563`.  For example:
 
 .. code-block:: python
 
    from __future__ import annotations
+   from queue import Queue
+
+   results: Queue[int] = Queue()  # This works at runtime
 
 .. _silencing-linters:
 

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -569,6 +569,11 @@ string literal types or :py:data:`~typing.TYPE_CHECKING`:
 
    results: 'Queue[int]' = Queue()  # OK
 
+If you are running Python 3.7+ simply activate annotations. Read more about them in `PEP563 <https://www.python.org/dev/peps/pep-0563/>`_.
+
+.. code-block:: python
+
+   from __future__ import annotations
 
 .. _silencing-linters:
 

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -533,6 +533,7 @@ Here's the above example modified to use ``MYPY``:
    def listify(arg: 'bar.BarClass') -> 'List[bar.BarClass]':
        return [arg]
 
+.. _not-generic-runtime:
 
 Using classes that are generic in stubs but not at runtime
 ----------------------------------------------------------

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -91,7 +91,7 @@ GENERIC_INSTANCE_VAR_CLASS_ACCESS = \
 BARE_GENERIC = 'Missing type parameters for generic type {}'  # type: Final
 BARE_GENERIC_STRING_LITERAL_ESCAPE = \
     'Missing type parameters for generic type {}, ' \
-        'also consider using string literal escaping'  # type: Final
+    'also consider using string literal escaping'  # type: Final
 IMPLICIT_GENERIC_ANY_BUILTIN = \
     'Implicit generic "Any". Use "{}" and specify generic parameters'  # type: Final
 

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -89,9 +89,6 @@ MODULE_LEVEL_GETATTRIBUTE = '__getattribute__ is not valid at the module level' 
 GENERIC_INSTANCE_VAR_CLASS_ACCESS = \
     'Access to generic instance variables via class is ambiguous'  # type: Final
 BARE_GENERIC = 'Missing type parameters for generic type {}'  # type: Final
-BARE_GENERIC_STRING_LITERAL_ESCAPE = \
-    'Missing type parameters for generic type {}, ' \
-    'also consider using string literal escaping'  # type: Final
 IMPLICIT_GENERIC_ANY_BUILTIN = \
     'Implicit generic "Any". Use "{}" and specify generic parameters'  # type: Final
 

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -89,6 +89,9 @@ MODULE_LEVEL_GETATTRIBUTE = '__getattribute__ is not valid at the module level' 
 GENERIC_INSTANCE_VAR_CLASS_ACCESS = \
     'Access to generic instance variables via class is ambiguous'  # type: Final
 BARE_GENERIC = 'Missing type parameters for generic type {}'  # type: Final
+BARE_GENERIC_STRING_LITERAL_ESCAPE = \
+    'Missing type parameters for generic type {}, ' \
+        'also consider using string literal escaping'  # type: Final
 IMPLICIT_GENERIC_ANY_BUILTIN = \
     'Implicit generic "Any". Use "{}" and specify generic parameters'  # type: Final
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -449,7 +449,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                     target = self.named_type_or_none(target_name, [])
                     assert target is not None
                     # Transform List to List[Any], etc.
-                    fix_instance_types(target, self.fail)
+                    fix_instance_types(target, self.fail, self.note)
                     alias_node = TypeAlias(target, alias,
                                            line=-1, column=-1,  # there is no context
                                            no_args=True, normalized=True)
@@ -607,7 +607,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 # has external return type `Coroutine[Any, Any, T]`.
                 any_type = AnyType(TypeOfAny.special_form)
                 ret_type = self.named_type_or_none('typing.Coroutine',
-                    [any_type, any_type, defn.type.ret_type])
+                                                   [any_type, any_type, defn.type.ret_type])
                 assert ret_type is not None, "Internal error: typing.Coroutine not found"
                 defn.type = defn.type.copy_modified(ret_type=ret_type)
 
@@ -2489,7 +2489,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         # so we need to replace it with non-explicit Anys.
         res = make_any_non_explicit(res)
         no_args = isinstance(res, Instance) and not res.args  # type: ignore
-        fix_instance_types(res, self.fail)
+        fix_instance_types(res, self.fail, self.note)
         if isinstance(s.rvalue, (IndexExpr, CallExpr)):  # CallExpr is for `void = type(None)`
             s.rvalue.analyzed = TypeAliasExpr(res, alias_tvars, no_args)
             s.rvalue.analyzed.line = s.line

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -57,7 +57,7 @@ ARG_KINDS_BY_CONSTRUCTOR = {
 
 GENERIC_STUB_NOT_AT_RUNTIME_TYPES = {
     'queue.Queue',
-    'os.Pathlike',
+    'builtins._PathLike',
 }  # type: Final
 
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -929,9 +929,7 @@ def get_omitted_any(disallow_any: bool, fail: MsgCallback, note: MsgCallback,
                 # (string literal escaping) for classes not generic at runtime
                 note(
                     "Subscripting classes that are not generic at runtime may require "
-                    "escaping. If you are running Python 3.7+ you can simply use "
-                    "`from __future__ import annotations`, otherwise please "
-                    "see https://mypy.readthedocs.io/"
+                    "escaping, see https://mypy.readthedocs.io/"
                     "en/latest/common_issues.html#not-generic-runtime",
                     typ,
                     code=codes.TYPE_ARG)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -56,7 +56,7 @@ ARG_KINDS_BY_CONSTRUCTOR = {
 }  # type: Final
 
 GENERIC_STUB_NOT_AT_RUNTIME_TYPES = {
-    'OrderedDict'
+    'Queue'
 }  # type: Final
 
 
@@ -225,8 +225,14 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 res = get_proper_type(res)
                 if (isinstance(res, Instance) and len(res.args) != len(res.type.type_vars) and
                         not self.defining_alias):
-                    fix_instance(res, self.fail, disallow_any=disallow_any, use_generic_error=True,
-                                 unexpanded_type=t)
+                    fix_instance(
+                        res,
+                        self.fail,
+                        self.note,
+                        disallow_any=disallow_any,
+                        use_generic_error=True,
+                        unexpanded_type=t,
+                        note=self.note)
                 return res
             elif isinstance(node, TypeInfo):
                 return self.analyze_type_with_type_info(node, t.args, t)
@@ -323,13 +329,14 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
 
     def get_omitted_any(self, typ: Type, fullname: Optional[str] = None) -> AnyType:
         disallow_any = not self.is_typeshed_stub and self.options.disallow_any_generics
-        return get_omitted_any(disallow_any, self.fail, typ, fullname)
+        return get_omitted_any(disallow_any, self.fail, self.note, typ, fullname)
 
     def analyze_type_with_type_info(self, info: TypeInfo, args: List[Type], ctx: Context) -> Type:
         """Bind unbound type when were able to find target TypeInfo.
 
         This handles simple cases like 'int', 'modname.UserClass[str]', etc.
         """
+
         if len(args) > 0 and info.fullname() == 'builtins.tuple':
             fallback = Instance(info, [AnyType(TypeOfAny.special_form)], ctx.line)
             return TupleType(self.anal_array(args), fallback, ctx.line)
@@ -341,7 +348,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         instance = Instance(info, self.anal_array(args), ctx.line, ctx.column)
         # Check type argument count.
         if len(instance.args) != len(info.type_vars) and not self.defining_alias:
-            fix_instance(instance, self.fail,
+            fix_instance(instance, self.fail, self.note,
                          disallow_any=self.options.disallow_any_generics and
                          not self.is_typeshed_stub)
 
@@ -896,9 +903,10 @@ TypeVarList = List[Tuple[str, TypeVarExpr]]
 
 # Mypyc doesn't support callback protocols yet.
 FailCallback = Callable[[str, Context, DefaultNamedArg(Optional[ErrorCode], 'code')], None]
+NoteCallback = Callable[[str, Context, DefaultNamedArg(Optional[ErrorCode], 'code')], None]
 
 
-def get_omitted_any(disallow_any: bool, fail: FailCallback,
+def get_omitted_any(disallow_any: bool, fail: FailCallback, note: NoteCallback,
                     typ: Type, fullname: Optional[str] = None,
                     unexpanded_type: Optional[Type] = None) -> AnyType:
     if disallow_any:
@@ -911,22 +919,28 @@ def get_omitted_any(disallow_any: bool, fail: FailCallback,
             typ = unexpanded_type or typ
             type_str = typ.name if isinstance(typ, UnboundType) else format_type_bare(typ)
 
+            fail(
+                message_registry.BARE_GENERIC.format(
+                    quote_type_string(type_str)),
+                typ,
+                code=codes.TYPE_ARG)
+
             if type_str in GENERIC_STUB_NOT_AT_RUNTIME_TYPES:
                 # Recommend to put type in quotes (string literal escaping)
-                fail(message_registry.BARE_GENERIC_STRING_LITERAL_ESCAPE.format(
-                    quote_type_string(type_str)), typ, code=codes.TYPE_ARG)
-            else:
-                fail(message_registry.BARE_GENERIC.format(quote_type_string(type_str)), typ,
-                     code=codes.TYPE_ARG)
+                note(
+                    "Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/latest/common_issues.html#not-generic-runtime",
+                    typ,
+                    code=codes.TYPE_ARG)
+
         any_type = AnyType(TypeOfAny.from_error, line=typ.line, column=typ.column)
     else:
         any_type = AnyType(TypeOfAny.from_omitted_generics, line=typ.line, column=typ.column)
     return any_type
 
 
-def fix_instance(t: Instance, fail: FailCallback,
+def fix_instance(t: Instance, fail: FailCallback, note: NoteCallback,
                  disallow_any: bool, use_generic_error: bool = False,
-                 unexpanded_type: Optional[Type] = None) -> None:
+                 unexpanded_type: Optional[Type] = None,) -> None:
     """Fix a malformed instance by replacing all type arguments with Any.
 
     Also emit a suitable error if this is not due to implicit Any's.
@@ -936,7 +950,7 @@ def fix_instance(t: Instance, fail: FailCallback,
             fullname = None  # type: Optional[str]
         else:
             fullname = t.type.fullname()
-        any_type = get_omitted_any(disallow_any, fail, t, fullname, unexpanded_type)
+        any_type = get_omitted_any(disallow_any, fail, note, t, fullname, unexpanded_type)
         t.args = [any_type] * len(t.type.type_vars)
         return
     # Invalid number of type parameters.
@@ -1190,20 +1204,21 @@ def make_optional_type(t: Type) -> Type:
         return UnionType([t, NoneType()], t.line, t.column)
 
 
-def fix_instance_types(t: Type, fail: FailCallback) -> None:
+def fix_instance_types(t: Type, fail: FailCallback, note: NoteCallback) -> None:
     """Recursively fix all instance types (type argument count) in a given type.
 
     For example 'Union[Dict, List[str, int]]' will be transformed into
     'Union[Dict[Any, Any], List[Any]]' in place.
     """
-    t.accept(InstanceFixer(fail))
+    t.accept(InstanceFixer(fail, note))
 
 
 class InstanceFixer(TypeTraverserVisitor):
-    def __init__(self, fail: FailCallback) -> None:
+    def __init__(self, fail: FailCallback, note: NoteCallback) -> None:
         self.fail = fail
+        self.note = note
 
     def visit_instance(self, typ: Instance) -> None:
         super().visit_instance(typ)
         if len(typ.args) != len(typ.type.type_vars):
-            fix_instance(typ, self.fail, disallow_any=False, use_generic_error=True)
+            fix_instance(typ, self.fail, self.note, disallow_any=False, use_generic_error=True)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -912,11 +912,12 @@ def get_omitted_any(disallow_any: bool, fail: FailCallback,
             type_str = typ.name if isinstance(typ, UnboundType) else format_type_bare(typ)
 
             if type_str in GENERIC_STUB_NOT_AT_RUNTIME_TYPES:
-                #Recommend to put type in quotes (string literal escaping)
-                fail(message_registry.BARE_GENERIC_STRING_LITERAL_ESCAPE.format(quote_type_string(type_str)), typ, code=codes.TYPE_ARG)
+                # Recommend to put type in quotes (string literal escaping)
+                fail(message_registry.BARE_GENERIC_STRING_LITERAL_ESCAPE.format(
+                    quote_type_string(type_str)), typ, code=codes.TYPE_ARG)
             else:
                 fail(message_registry.BARE_GENERIC.format(quote_type_string(type_str)), typ,
-                    code=codes.TYPE_ARG)
+                     code=codes.TYPE_ARG)
         any_type = AnyType(TypeOfAny.from_error, line=typ.line, column=typ.column)
     else:
         any_type = AnyType(TypeOfAny.from_omitted_generics, line=typ.line, column=typ.column)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -231,8 +231,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                         self.note,
                         disallow_any=disallow_any,
                         use_generic_error=True,
-                        unexpanded_type=t,
-                        note=self.note)
+                        unexpanded_type=t)
                 return res
             elif isinstance(node, TypeInfo):
                 return self.analyze_type_with_type_info(node, t.args, t)
@@ -928,7 +927,9 @@ def get_omitted_any(disallow_any: bool, fail: FailCallback, note: NoteCallback,
             if type_str in GENERIC_STUB_NOT_AT_RUNTIME_TYPES:
                 # Recommend to put type in quotes (string literal escaping)
                 note(
-                    "Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/latest/common_issues.html#not-generic-runtime",
+                    "Subscripting classes that are not generic at runtime may require "
+                    "escaping, see https://mypy.readthedocs.io/"
+                    "en/latest/common_issues.html#not-generic-runtime",
                     typ,
                     code=codes.TYPE_ARG)
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -55,6 +55,10 @@ ARG_KINDS_BY_CONSTRUCTOR = {
     'mypy_extensions.KwArg': ARG_STAR2,
 }  # type: Final
 
+GENERIC_STUB_NOT_AT_RUNTIME_TYPES = {
+    'OrderedDict'
+}  # type: Final
+
 
 def analyze_type_alias(node: Expression,
                        api: SemanticAnalyzerCoreInterface,
@@ -907,8 +911,12 @@ def get_omitted_any(disallow_any: bool, fail: FailCallback,
             typ = unexpanded_type or typ
             type_str = typ.name if isinstance(typ, UnboundType) else format_type_bare(typ)
 
-            fail(message_registry.BARE_GENERIC.format(quote_type_string(type_str)), typ,
-                 code=codes.TYPE_ARG)
+            if type_str in GENERIC_STUB_NOT_AT_RUNTIME_TYPES:
+                #Recommend to put type in quotes (string literal escaping)
+                fail(message_registry.BARE_GENERIC_STRING_LITERAL_ESCAPE.format(quote_type_string(type_str)), typ, code=codes.TYPE_ARG)
+            else:
+                fail(message_registry.BARE_GENERIC.format(quote_type_string(type_str)), typ,
+                    code=codes.TYPE_ARG)
         any_type = AnyType(TypeOfAny.from_error, line=typ.line, column=typ.column)
     else:
         any_type = AnyType(TypeOfAny.from_omitted_generics, line=typ.line, column=typ.column)

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1444,3 +1444,17 @@ some_file.py:1: error: invalid syntax  [syntax]
     ...ooks_like_we_started_typing_something_but_then. = did_not_notice(an_ex...
                                                         ^
 == Return code: 2
+
+[case testSpecialTypeshedGenericNote]
+# cmd: mypy --disallow-any-generics test.py
+[file test.py]
+from os import PathLike
+from queue import Queue
+
+p: PathLike
+q: Queue
+[out]
+test.py:4: error: Missing type parameters for generic type "_PathLike"
+test.py:4: note: Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/latest/common_issues.html#not-generic-runtime
+test.py:5: error: Missing type parameters for generic type "Queue"
+test.py:5: note: Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/latest/common_issues.html#not-generic-runtime

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1446,7 +1446,7 @@ some_file.py:1: error: invalid syntax  [syntax]
 == Return code: 2
 
 [case testSpecialTypeshedGenericNote]
-# cmd: mypy --disallow-any-generics test.py
+# cmd: mypy --disallow-any-generics --python-version=3.6 test.py
 [file test.py]
 from os import PathLike
 from queue import Queue


### PR DESCRIPTION
This commit introduces a recommendation for classes that don't support indexing at runtime to be escaped as string literals on missing required generic type args (BARE_GENERIC) error.

It should resolve https://github.com/python/mypy/issues/7539

This is my first time contributing here, so please let me know if there is anything I could have done better. :)