### PR TITLE
Fix Typo in Getting Started Docs

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -336,7 +336,7 @@ add a dynamically-typed function by mistake. You can make mypy do this
 by running mypy with the ``--disallow-untyped-defs`` flag.
 
 Another potentially useful flag is ``--strict``, which enables many
-(thought not all) of the available strictness options -- including
+(though not all) of the available strictness options -- including
 ``--disallow-untyped-defs``.
 
 This flag is mostly useful if you're starting a new project from scratch


### PR DESCRIPTION
This PR adds a quick typo fix to the [MyPy Getting Started Docs](https://mypy.readthedocs.io/en/latest/getting_started.html). 

The initial typo does not necessarily reduce the readers comprehension. 