### PR TITLE
Document how to integrate `mypy` into Vim with ALE

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ IDE, Linter Integrations, and Pre-commit
 
 Mypy can be integrated into popular IDEs:
 
-* Vim: [syntastic](https://github.com/vim-syntastic/syntastic) in `.vimrc` add `let g:syntastic_python_checkers=['mypy']`
+* Vim:
+  * Using [Syntastic](https://github.com/vim-syntastic/syntastic): in `~/.vimrc` add `let g:syntastic_python_checkers=['mypy']`
+  * Using [ALE](https://github.com/dense-analysis/ale): should be enabled by default when `mypy` is installed, or can be explicitly enabled by adding `let b:ale_linters = ['mypy']` in
+ `~/vim/ftplugin/python.vim` 
 * Emacs: using [Flycheck](https://github.com/flycheck/) and [Flycheck-mypy](https://github.com/lbolla/emacs-flycheck-mypy)
 * Sublime Text: [SublimeLinter-contrib-mypy](https://github.com/fredcallaway/SublimeLinter-contrib-mypy)
 * Atom: [linter-mypy](https://atom.io/packages/linter-mypy)

--- a/README.md
+++ b/README.md
@@ -111,13 +111,15 @@ IDE, Linter Integrations, and Pre-commit
 Mypy can be integrated into popular IDEs:
 
 * Vim:
-  * Using [Syntastic](https://github.com/vim-syntastic/syntastic): in `~/.vimrc` add `let g:syntastic_python_checkers=['mypy']`
-  * Using [ALE](https://github.com/dense-analysis/ale): should be enabled by default when `mypy` is installed, or can be explicitly enabled by adding `let b:ale_linters = ['mypy']` in
- `~/vim/ftplugin/python.vim` 
+  * Using [Syntastic](https://github.com/vim-syntastic/syntastic): in `~/.vimrc` add
+    `let g:syntastic_python_checkers=['mypy']`
+  * Using [ALE](https://github.com/dense-analysis/ale): should be enabled by default when `mypy` is installed,
+    or can be explicitly enabled by adding `let b:ale_linters = ['mypy']` in `~/vim/ftplugin/python.vim` 
 * Emacs: using [Flycheck](https://github.com/flycheck/) and [Flycheck-mypy](https://github.com/lbolla/emacs-flycheck-mypy)
 * Sublime Text: [SublimeLinter-contrib-mypy](https://github.com/fredcallaway/SublimeLinter-contrib-mypy)
 * Atom: [linter-mypy](https://atom.io/packages/linter-mypy)
-* PyCharm: [mypy plugin](https://github.com/dropbox/mypy-PyCharm-plugin) (PyCharm integrates [its own implementation of PEP 484](https://www.jetbrains.com/help/pycharm/type-hinting-in-product.html))
+* PyCharm: [mypy plugin](https://github.com/dropbox/mypy-PyCharm-plugin) (PyCharm integrates
+  [its own implementation of PEP 484](https://www.jetbrains.com/help/pycharm/type-hinting-in-product.html))
 * VS Code: provides [basic integration](https://code.visualstudio.com/docs/python/linting#_mypy) with mypy.
 
 Mypy can also be integrated into [Flake8] using [flake8-mypy], or


### PR DESCRIPTION
ALE is another popular plugin for integrating linting into Vim; this commit documents how this can also be configured for `mypy` linting (in addition to the existing documentation for Syntastic).