### PR TITLE
Fix __init_subclass__ type check

### DIFF
--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6339,14 +6339,21 @@ class Child(Base, thing=5, default_name=""):
 [builtins fixtures/object_with_init_subclass.pyi]
 
 [case testInitSubclassWithMetaclassOK]
-class Base(type):
+class Base:
     thing: int
 
     def __init_subclass__(cls, thing: int):
         cls.thing = thing
 
-class Child(Base, metaclass=Base, thing=0):
+class Child(Base, metaclass=type, thing=0):
     pass
+[builtins fixtures/object_with_init_subclass.pyi]
+
+[case testInitSubclassWithCustomMetaclassOK]
+class M(type): ...
+class Child(metaclass=M, thing=0):
+    pass
+[builtins fixtures/object_with_init_subclass.pyi]
 
 [case testTooManyArgsForObject]
 class A(thing=5):

--- a/test-data/unit/fixtures/dict.pyi
+++ b/test-data/unit/fixtures/dict.pyi
@@ -10,6 +10,7 @@ VT = TypeVar('VT')
 
 class object:
     def __init__(self) -> None: pass
+    def __init_subclass__(cls) -> None: pass
     def __eq__(self, other: object) -> bool: pass
 
 class type: pass


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7722

This skips checking class keywords against `__init_subclass__` for:
* Classes with custom metaclasses, because they can pop the keywords before calling `super()`.
* Classes that are special forms, like `TypedDict` etc.