### PR TITLE
[mypyc] Rework return values from build_ir and compile_modules_to_c

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -38,6 +38,7 @@ from mypyc.namegen import exported_name
 from mypyc.options import CompilerOptions
 from mypyc.errors import Errors
 from mypyc.common import shared_lib_name
+from mypyc.ops import format_modules
 
 from mypyc import emitmodule
 
@@ -199,11 +200,10 @@ def generate_c(sources: List[BuildSource],
 
     errors = Errors()
 
-    ops = []  # type: List[str]
-    ctext = emitmodule.compile_modules_to_c(result,
-                                            compiler_options=compiler_options,
-                                            errors=errors, ops=ops,
-                                            groups=groups)
+    modules, ctext = emitmodule.compile_modules_to_c(result,
+                                                     compiler_options=compiler_options,
+                                                     errors=errors,
+                                                     groups=groups)
     if errors.num_errors:
         errors.flush_errors()
         sys.exit(1)
@@ -212,7 +212,7 @@ def generate_c(sources: List[BuildSource],
     if compiler_options.verbose:
         print("Compiled to C in {:.3f}s".format(t2 - t1))
 
-    return ctext, '\n'.join(ops)
+    return ctext, '\n'.join(format_modules(modules))
 
 
 def build_using_shared_lib(sources: List[BuildSource],

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -168,7 +168,7 @@ class TestRun(MypycDataSuite):
                     alt_lib_path='.')
                 errors = Errors()
                 compiler_options = CompilerOptions(multi_file=self.multi_file)
-                cfiles = emitmodule.compile_modules_to_c(
+                _, cfiles = emitmodule.compile_modules_to_c(
                     result,
                     compiler_options=compiler_options,
                     errors=errors,

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -111,7 +111,7 @@ def build_ir_for_single_file(input_lines: List[str],
         compiler_options, errors)
     assert errors.num_errors == 0
 
-    module = modules[0][1]
+    module = list(modules.values())[0]
     return module.functions
 
 


### PR DESCRIPTION
Have build_ir return everything in a dictionary (instead of a list of
tuples) and have compile_modules_to_c also return the IR. This allows
us to remove the IR formatting hack from compile_modules_to_c and will
let us add some IR debugging stuff to test_run.