### PR TITLE
Add option to print absolute file paths

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -203,7 +203,8 @@ def _build(sources: List[BuildSource],
                     options.show_column_numbers,
                     options.show_error_codes,
                     options.pretty,
-                    lambda path: read_py_file(path, cached_read, options.python_version))
+                    lambda path: read_py_file(path, cached_read, options.python_version),
+                    options.show_absolute_path)
     plugin, snapshot = load_plugins(options, errors, stdout)
 
     # Construct a build manager object to hold state during the build.

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -148,6 +148,9 @@ class Errors:
     # Set to True to show column numbers in error messages.
     show_column_numbers = False  # type: bool
 
+    # Set to True to show absolute file paths in error messages.
+    show_absolute_path = False  # type: bool
+
     # State for keeping track of the current fine-grained incremental mode target.
     # (See mypy.server.update for more about targets.)
     # Current module id.
@@ -159,10 +162,12 @@ class Errors:
                  show_column_numbers: bool = False,
                  show_error_codes: bool = False,
                  pretty: bool = False,
-                 read_source: Optional[Callable[[str], Optional[List[str]]]] = None) -> None:
+                 read_source: Optional[Callable[[str], Optional[List[str]]]] = None,
+                 show_absolute_path: bool = False) -> None:
         self.show_error_context = show_error_context
         self.show_column_numbers = show_column_numbers
         self.show_error_codes = show_error_codes
+        self.show_absolute_path = show_absolute_path
         self.pretty = pretty
         # We use fscache to read source code when showing snippets.
         self.read_source = read_source
@@ -188,7 +193,8 @@ class Errors:
                      self.show_column_numbers,
                      self.show_error_codes,
                      self.pretty,
-                     self.read_source)
+                     self.read_source,
+                     self.show_absolute_path)
         new.file = self.file
         new.import_ctx = self.import_ctx[:]
         new.function_or_member = self.function_or_member[:]
@@ -208,8 +214,11 @@ class Errors:
         self.ignore_prefix = prefix
 
     def simplify_path(self, file: str) -> str:
-        file = os.path.normpath(file)
-        return remove_path_prefix(file, self.ignore_prefix)
+        if self.show_absolute_path:
+            return os.path.abspath(file)
+        else:
+            file = os.path.normpath(file)
+            return remove_path_prefix(file, self.ignore_prefix)
 
     def set_file(self, file: str,
                  module: Optional[str],

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -595,6 +595,9 @@ def process_options(args: List[str],
     add_invertible_flag('--no-error-summary', dest='error_summary', default=True,
                         help="Do not show error stats summary",
                         group=error_group)
+    add_invertible_flag('--show-absolute-path', default=False,
+                        help="Show absolute paths to files",
+                        group=error_group)
 
     strict_help = "Strict mode; enables the following flags: {}".format(
         ", ".join(strict_flag_names))

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -261,6 +261,8 @@ class Options:
         self.cache_map = {}  # type: Dict[str, Tuple[str, str]]
         # Don't properly free objects on exit, just kill the current process.
         self.fast_exit = False
+        # Print full path to each file in the report.
+        self.show_absolute_path = False  # type: bool
 
     # To avoid breaking plugin compatability, keep providing new_semantic_analyzer
     @property


### PR DESCRIPTION
It is a common use case to integrate mypy into an IDE or other
environment where it's run automatically and its output is processed by
other programs instead of being read by a human.

IDEs usually are able to parse paths, lines and messages printed by mypy
and show those messages directly in their code editor right under
affected lines.

However, some IDEs, like PyCharm, support reading only absolute file
paths from tools' output.

For example, there is an issue in PyCharm's issue tracker asking for a
way to read relative paths from tools:
https://youtrack.jetbrains.com/issue/IDEA-48163

Sadly, that issue did not receive any action for 11 years already,
apparently. And there is a comment from someone saying that mypy is
affected by this problem, not having any way to force absolute paths in
the output.

This commit adds a new option, --show-absolute-path, to fix exactly
this, with a straightforward implementation. I believe that this simple
fix will bring considerable benefits to PyCharm users and potentially
other people as well.