### PR TITLE
Fix bind_self() for overloaded class methods

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -159,7 +159,8 @@ def bind_self(method: F, original_type: Optional[Type] = None, is_classmethod: b
     from mypy.infer import infer_type_arguments
 
     if isinstance(method, Overloaded):
-        return cast(F, Overloaded([bind_self(c, original_type) for c in method.items()]))
+        return cast(F, Overloaded([bind_self(c, original_type, is_classmethod)
+                                   for c in method.items()]))
     assert isinstance(method, CallableType)
     func = method
     if not func.arg_types:

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -533,3 +533,32 @@ class C:
 x: Union[A, C]
 reveal_type(x.same)  # N: Revealed type is 'Union[builtins.int, def () -> __main__.C*]'
 [builtins fixtures/classmethod.pyi]
+
+[case SelfTypeOverloadedClassMethod]
+from lib import Base
+from typing import overload, Tuple
+
+class Sub(Base):
+    @overload
+    @classmethod
+    def make(cls) -> Sub: ...
+    @overload
+    @classmethod
+    def make(cls, num: int) -> Tuple[Sub, ...]: ...
+    @classmethod
+    def make(cls, num=1):
+        ...
+
+[file lib.pyi]
+from typing import overload, TypeVar, Type, Tuple
+
+T = TypeVar('T', bound=Base)
+
+class Base:
+    @overload
+    @classmethod
+    def make(cls: Type[T]) -> T: ...
+    @overload
+    @classmethod
+    def make(cls: Type[T], num: int) -> Tuple[T, ...]: ...
+[builtins fixtures/classmethod.pyi]


### PR DESCRIPTION
This PR fixes an obvious typo (currently `is_classmethod` is not passed to a nested call). I noticed this while working on https://github.com/python/mypy/pull/7739