### PR TITLE
[mypyc] include instead of compiling rt .c files in non-multifile mode

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -472,13 +472,15 @@ def mypycify(
                 '/wd9025',  # warning about overriding /GL
             ]
 
-    # Copy the runtime library in
+    # In multi-file mode, copy the runtime library in.
+    # Otherwise it just gets #included to save on compiler invocations
     shared_cfilenames = []
-    for name in ['CPy.c', 'getargs.c']:
-        rt_file = os.path.join(build_dir, name)
-        with open(os.path.join(include_dir(), name), encoding='utf-8') as f:
-            write_file(rt_file, f.read())
-        shared_cfilenames.append(rt_file)
+    if multi_file:
+        for name in ['CPy.c', 'getargs.c']:
+            rt_file = os.path.join(build_dir, name)
+            with open(os.path.join(include_dir(), name), encoding='utf-8') as f:
+                write_file(rt_file, f.read())
+            shared_cfilenames.append(rt_file)
 
     extensions = []
     for (group_sources, lib_name), (cfilenames, deps) in zip(groups, group_cfilenames):

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -227,6 +227,12 @@ class GroupGenerator:
         multi_file = self.use_shared_lib and self.multi_file
 
         base_emitter = Emitter(self.context)
+        # When not in multi-file mode we just include the runtime
+        # library c files to reduce the number of compiler invocations
+        # needed
+        if not self.multi_file:
+            base_emitter.emit_line('#include "CPy.c"')
+            base_emitter.emit_line('#include "getargs.c"')
         base_emitter.emit_line('#include "__native{}.h"'.format(self.group_suffix))
         base_emitter.emit_line('#include "__native_internal{}.h"'.format(self.group_suffix))
         emitter = base_emitter

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -41,7 +41,8 @@ from distutils.core import setup
 from mypyc.build import mypycify
 
 setup(name='test_run_output',
-      ext_modules=mypycify({}, separate={}, skip_cgen_input={!r}, strip_asserts=False),
+      ext_modules=mypycify({}, separate={}, skip_cgen_input={!r}, strip_asserts=False,
+                           multi_file={}),
 )
 """
 
@@ -192,7 +193,7 @@ class TestRun(MypycDataSuite):
         setup_file = os.path.abspath(os.path.join(WORKDIR, 'setup.py'))
         # We pass the C file information to the build script via setup.py unfortunately
         with open(setup_file, 'w', encoding='utf-8') as f:
-            f.write(setup_format.format(module_paths, self.separate, cfiles))
+            f.write(setup_format.format(module_paths, self.separate, cfiles, self.multi_file))
 
         if not run_setup(setup_file, ['build_ext', '--inplace']):
             if testcase.config.getoption('--mypyc-showc'):


### PR DESCRIPTION
The idea here is just that it reduces the number of compiler
invocations which speeds things up and reduces spew.