### PR TITLE
Enable whole-file # type: ignore comments in Python 2.7.

### DIFF
--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -349,7 +349,7 @@ class ASTConverter:
                 self.type_ignores[ti.lineno] = parsed
             else:
                 self.fail(INVALID_TYPE_IGNORE, ti.lineno, -1)
-        body = self.fix_function_overloads(self.translate_stmt_list(mod.body))
+        body = self.fix_function_overloads(self.translate_stmt_list(mod.body, module=True))
         return MypyFile(body,
                         self.imports,
                         False,

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -246,6 +246,11 @@ IGNORE
 # type: ignore
 import MISSING
 
+[case testIgnoreWholeModulePy27]
+# flags: --python-version 2.7
+# type: ignore
+IGNORE
+
 [case testDontIgnoreWholeModule1]
 if True:
     # type: ignore


### PR DESCRIPTION
Fixes #7785. This was a mistake in my original PR that introduced the feature (#6830). I forgot to copy one of the changes in `fastparse.py` to `fastparse2.py`. 🙄

It's an embarrassingly simple fix. I also included a regression test for good measure.

