### PR TITLE
Add support to add_method for classmethods, __new__, and staticmethods

### DIFF
--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -125,6 +125,8 @@ def add_method(
     func = FuncDef(name, args, Block([PassStmt()]))
     func.info = info
     func.type = set_callable_name(signature, func)
+    func.is_class = is_classmethod
+    func.is_static = is_staticmethod
     func._fullname = info.fullname() + '.' + name
     func.line = info.line
 


### PR DESCRIPTION
Adds keyword arguments to `add_method` to create classmethods, staticmethods, and `__new__`. Hopefully this makes it easier to add such methods in mypy plugins.

This is based on the implementation in semanal_namedtuple.py,  as suggested by @ilevkivskyi in #7301.

I still need to add tests, but I wanted to make sure this was along the right path before figuring that out.