### PR TITLE
Fix internal error inheriting a dataclass duplicated field #7792

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -310,14 +310,16 @@ class DataclassTransformer:
 
                     known_attrs.add(name)
                     super_attrs.append(attr)
-                else:
+                elif all_attrs:
                     # How early in the attribute list an attribute appears is determined by the
                     # reverse MRO, not simply MRO.
                     # See https://docs.python.org/3/library/dataclasses.html#inheritance for
                     # details.
-                    (attr,) = [a for a in all_attrs if a.name == name]
-                    all_attrs.remove(attr)
-                    super_attrs.append(attr)
+                    for attr in all_attrs:
+                        if attr.name == name:
+                            all_attrs.remove(attr)
+                            super_attrs.append(attr)
+                            break
             all_attrs = super_attrs + all_attrs
 
         # Ensure that arguments without a default don't follow

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -807,3 +807,16 @@ class A2:
     b: str = 'test'
 
 [builtins fixtures/list.pyi]
+
+[case testDataclassesInheritingDuplicateField]
+# see mypy issue #7792
+from dataclasses import dataclass
+
+@dataclass
+class A:  # E: Name 'x' already defined (possibly by an import)
+    x: int = 0
+    x: int = 0  # E: Name 'x' already defined on line 6
+
+@dataclass
+class B(A):
+    pass


### PR DESCRIPTION
The error was:
```
    (attr,) = [a for a in all_attrs if a.name == name]
ValueError: not enough values to unpack (expected 1, got 0)
```

- No need to enter in the `else` if all_attrs is empty

- And don't assume that the matching attr exists in `all_attr` 