### PR TITLE
handle Union type in string interpolation checker #7763

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -658,6 +658,12 @@ class StringFormatterChecker:
         elif isinstance(rhs_type, Instance) and rhs_type.type.fullname() == 'builtins.tuple':
             # Assume that an arbitrary-length tuple has the right number of items.
             rep_types = [rhs_type.args[0]] * len(checkers)
+        elif isinstance(rhs_type, UnionType):
+            for typ in rhs_type.relevant_items():
+                temp_node = TempNode(typ)
+                temp_node.line = replacements.line
+                self.check_simple_str_interpolation(specifiers, temp_node, expr)
+            return
         else:
             rep_types = [rhs_type]
 

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1332,7 +1332,7 @@ def f(t: Tuple[int, ...]) -> None:
 
 [case testStringInterpolationUnionType]
 from typing import Tuple, Union
-a: Union[Tuple[int, str], Tuple[str,int]] = ('A', 1)
+a: Union[Tuple[int, str], Tuple[str, int]] = ('A', 1)
 '%s %s' % a
 '%s' % a  # E: Not all arguments converted during string formatting
 
@@ -1340,6 +1340,8 @@ b: Union[Tuple[int, str], Tuple[int, int], Tuple[str, int]] = ('A', 1)
 '%s %s' % b
 '%s %s %s' % b  # E: Not enough arguments for format string
 
+c: Union[Tuple[str, int], Tuple[str, int, str]] = ('A', 1)
+'%s %s' % c  # E: Not all arguments converted during string formatting
 
 -- str.format() calls
 -- ------------------

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1330,6 +1330,16 @@ def f(t: Tuple[int, ...]) -> None:
     '%d %d %d' % t
 [builtins fixtures/primitives.pyi]
 
+[case testStringInterpolationUnionType]
+from typing import Tuple, Union
+a: Union[Tuple[int, str], Tuple[str,int]] = ('A', 1)
+'%s %s' % a
+'%s' % a  # E: Not all arguments converted during string formatting
+
+b: Union[Tuple[int, str], Tuple[int, int], Tuple[str, int]] = ('A', 1)
+'%s %s' % b
+'%s %s %s' % b  # E: Not enough arguments for format string
+
 
 -- str.format() calls
 -- ------------------


### PR DESCRIPTION
The problematic case was

```
t: Union[Tuple[str, int], Tuple[int, str]] = ('A', 1)
"%s %s" % t
```

The Union was treated as a single value instead of looking at the types inside
The fix consists in checking each of the union types

Two questions:
- I created a `TempNode` for each of the sub types and added the current line to keep some context, not sure it's the right way to do it.
- I'm running the check for all of the types in the union, but I've seen in the code base that it's usually checked for `any()`.
I suppose it shouldn't return an error if one of the types matches the formatting arguments, for instance with `Union[Tuple[str, int], Tuple[str, str, str]]`
If you confirm, I will have to refactor part of the check in a sub-method