### PR TITLE
[suggest] Fix inference of returned collection

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3593,6 +3593,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """
         if node in self.type_overrides:
             return self.type_overrides[node]
+        # Don't use an Any type context, since that will cause more
+        # anys than we want for things that consume the inferred
+        # types.
+        if isinstance(get_proper_type(type_context), AnyType):
+            type_context = None
         self.type_context.append(type_context)
         try:
             if allow_none_return and isinstance(node, CallExpr):

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -30,10 +30,9 @@ from typing_extensions import TypedDict
 from mypy.state import strict_optional_set
 from mypy.types import (
     Type, AnyType, TypeOfAny, CallableType, UnionType, NoneType, Instance, TupleType,
-    TypeVarType, FunctionLike,
+    TypeVarType, FunctionLike, TypedDictType, UninhabitedType,
     TypeStrVisitor, TypeTranslator,
     is_optional, remove_optional, ProperType, get_proper_type,
-    TypedDictType
 )
 from mypy.build import State, Graph
 from mypy.nodes import (
@@ -714,6 +713,9 @@ class TypeFormatter(TypeStrVisitor):
                 return t.partial_fallback.accept(self)
         s = self.list_str(t.items)
         return 'Tuple[{}]'.format(s)
+
+    def visit_uninhabited_type(self, t: UninhabitedType) -> str:
+        return "Any"
 
     def visit_typeddict_type(self, t: TypedDictType) -> str:
         return t.fallback.accept(self)

--- a/test-data/unit/fine-grained-suggest.test
+++ b/test-data/unit/fine-grained-suggest.test
@@ -768,3 +768,20 @@ z = foo(f(), g())
 [out]
 (foo.List[Any], UNKNOWN) -> Tuple[foo.List[Any], Any]
 ==
+
+[case testSuggestDict]
+# suggest: foo.foo
+# suggest: foo.bar
+[file foo.py]
+def foo():
+    # return dict(x=5)
+    return {'x': 5}
+
+def bar():
+    return {}
+
+[builtins fixtures/dict.pyi]
+[out]
+() -> typing.Dict[str, int]
+() -> typing.Dict[Any, Any]
+==

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -672,7 +672,7 @@ from typing import Any
 a = [] # type: Any
 [builtins fixtures/list.pyi]
 [out]
-ListExpr(2) : builtins.list[Any]
+ListExpr(2) : builtins.list[<nothing>]
 
 [case testHigherOrderFunction]
 from typing import TypeVar, Callable, List


### PR DESCRIPTION
Do this by suppressing the use of Any contexts, which cause arguments
to be misinferred. This can cause certain things to be inferred as
`<nothing>` instead of `Any`, but that's seems fine.