### PR TITLE
[suggest] Fix return-type suggestions when there is a nested function

### DIFF
--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -124,11 +124,15 @@ class ReturnFinder(TraverserVisitor):
         if o.expr is not None and o.expr in self.typemap:
             self.return_types.append(self.typemap[o.expr])
 
+    def visit_func_def(self, o: FuncDef) -> None:
+        # Skip nested functions
+        pass
+
 
 def get_return_types(typemap: Dict[Expression, Type], func: FuncDef) -> List[Type]:
     """Find all the types returned by return statements in func."""
     finder = ReturnFinder(typemap)
-    func.accept(finder)
+    func.body.accept(finder)
     return finder.return_types
 
 

--- a/test-data/unit/fine-grained-suggest.test
+++ b/test-data/unit/fine-grained-suggest.test
@@ -153,6 +153,18 @@ def bar() -> TD: ...
 () -> foo.TD
 ==
 
+[case testSuggestWithNested]
+# suggest: foo.foo
+[file foo.py]
+def foo():
+    def bar():
+        return 1
+    return 'lol'
+
+[out]
+() -> str
+==
+
 [case testSuggestReexportNaming]
 # suggest: foo.foo
 [file foo.py]


### PR DESCRIPTION
Note that this *doesn't* support inference for nested functions.