### PR TITLE
Use union component as a self-type in class methods

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -703,7 +703,7 @@ def analyze_class_attribute_access(itype: Instance,
         is_classmethod = ((is_decorated and cast(Decorator, node.node).func.is_class)
                           or (isinstance(node.node, FuncBase) and node.node.is_class))
         result = add_class_tvars(get_proper_type(t), itype, isuper, is_classmethod,
-                                 mx.builtin_type, mx.original_type)
+                                 mx.builtin_type, mx.self_type)
         if not mx.is_lvalue:
             result = analyze_descriptor_access(mx.original_type, result, mx.builtin_type,
                                                mx.msg, mx.context, chk=mx.chk)
@@ -761,7 +761,8 @@ def add_class_tvars(t: ProperType, itype: Instance, isuper: Optional[Instance],
 
     B.foo()
 
-    original_type is the value of the type B in the expression B.foo()
+    original_type is the value of the type B in the expression B.foo() or the corresponding
+    component in case if a union (this is used to bind the self-types).
     """
     # TODO: verify consistency between Q and T
     info = itype.type  # type: TypeInfo

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -569,3 +569,51 @@ class Base:
     @classmethod
     def make(cls: Type[T], num: int) -> Tuple[T, ...]: ...
 [builtins fixtures/classmethod.pyi]
+
+[case testSelfTypeClassMethodOnUnion]
+from typing import Type, Union, TypeVar
+
+T = TypeVar('T')
+
+class A:
+    @classmethod
+    def meth(cls: Type[T]) -> T: ...
+class B(A): ...
+class C(A): ...
+
+t: Type[Union[B, C]]
+reveal_type(t.meth)  # N: Revealed type is 'Union[def () -> __main__.B*, def () -> __main__.C*]'
+x = t.meth()
+reveal_type(x)  # N: Revealed type is 'Union[__main__.B*, __main__.C*]'
+[builtins fixtures/classmethod.pyi]
+
+[case testSelfTypeClassMethodOnUnionGeneric]
+from typing import Type, Union, TypeVar, Generic
+
+T = TypeVar('T')
+S = TypeVar('S')
+
+class A(Generic[T]):
+    @classmethod
+    def meth(cls: Type[S]) -> S: ...
+
+t: Type[Union[A[int], A[str]]]
+x = t.meth()
+reveal_type(x)  # N: Revealed type is 'Union[__main__.A*[builtins.int], __main__.A*[builtins.str]]'
+[builtins fixtures/classmethod.pyi]
+
+[case testSelfTypeClassMethodOnUnionList]
+from typing import Type, Union, TypeVar, List
+
+T = TypeVar('T')
+
+class A:
+    @classmethod
+    def meth(cls: Type[T]) -> List[T]: ...
+class B(A): ...
+class C(A): ...
+
+t: Type[Union[B, C]]
+x = t.meth()[0]
+reveal_type(x)  # N: Revealed type is 'Union[__main__.B*, __main__.C*]'
+[builtins fixtures/isinstancelist.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7821

The same logic is already used for normal methods, I think class methods should be no different.