### PR TITLE
ISSUE-7806: Add missing attributes to FakeInfo

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2619,20 +2619,16 @@ class FakeInfo(TypeInfo):
     # TypeInfo defines a __bool__ method that returns False for FakeInfo
     # so that it can be conveniently tested against in the same way that it
     # would be if things were properly optional.
+
+    # Fake fullname so `mypy.checkmember` can process this info.
+    _fullname = 'FakeInfo'
+
     def __init__(self, msg: str) -> None:
         self.msg = msg
 
-    # Fake type_vars so `mypy.checkmember` can process this info.
-    type_vars = None
-
-    @staticmethod
-    def fullname() -> str:
-        # Fake fullname so `mypy.checkmember` can process this info.
-        return 'FakeInfo'
-
     def __getattribute__(self, attr: str) -> None:
         # Handle __class__, fullname, type_vars so that isinstance still works...
-        if attr in ('__class__', 'fullname', 'type_vars'):
+        if attr in ('__class__', 'fullname', '_fullname', 'type_vars'):
             return object.__getattribute__(self, attr)
         raise AssertionError(object.__getattribute__(self, 'msg'))
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2625,7 +2625,8 @@ class FakeInfo(TypeInfo):
     # Fake type_vars so `mypy.checkmember` can process this info.
     type_vars = None
 
-    def fullname(self) -> str:
+    @staticmethod
+    def fullname() -> str:
         # Fake fullname so `mypy.checkmember` can process this info.
         return 'FakeInfo'
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2622,9 +2622,16 @@ class FakeInfo(TypeInfo):
     def __init__(self, msg: str) -> None:
         self.msg = msg
 
+    # Fake type_vars so `mypy.checkmember` can process this info.
+    type_vars = None
+
+    def fullname(self) -> str:
+        # Fake fullname so `mypy.checkmember` can process this info.
+        return 'FakeInfo'
+
     def __getattribute__(self, attr: str) -> None:
-        # Handle __class__ so that isinstance still works...
-        if attr == '__class__':
+        # Handle __class__, fullname, type_vars so that isinstance still works...
+        if attr in ('__class__', 'fullname', 'type_vars'):
             return object.__getattribute__(self, attr)
         raise AssertionError(object.__getattribute__(self, 'msg'))
 


### PR DESCRIPTION
### Goal

Fix [ISSUE-7806](https://github.com/python/mypy/issues/7806).

Add `fullname` and `type_vars` to `FakeInfo` so `mypy.checkmember` will not crash on member with  `FakeInfo`.

### Changes

- Handle `fullname`, `_fullname`, `type_vars` as regular attributes of `FakeInfo`
- Add `FakeInfo._fullname = 'FakeInfo'` attribute (probably should be `FakeMember`)