### PR TITLE
Fix crashes in astdiff when sorting union items

### DIFF
--- a/test-data/unit/diff.test
+++ b/test-data/unit/diff.test
@@ -1443,3 +1443,25 @@ class C:
 [out]
 __main__.C.method
 __main__.func
+
+[case testUnionOfLiterals]
+from typing_extensions import Literal
+x: Literal[1, '2']
+[file next.py]
+from typing_extensions import Literal
+x: Literal[1, 2]
+[out]
+__main__.x
+
+[case testUnionOfCallables]
+from typing import Callable, Union
+from mypy_extensions import Arg
+x: Union[Callable[[Arg(int, 'x')], None],
+         Callable[[int], None]]
+[file next.py]
+from typing import Callable, Union
+from mypy_extensions import Arg
+x: Union[Callable[[Arg(int, 'y')], None],
+         Callable[[int], None]]
+[out]
+__main__.x


### PR DESCRIPTION
Previously the snapshots could be unsortable, since the snapshot
tuples could have inconsistent types. This attemps to make the types
in tuples predictable based on the tuple prefix.

More formally, consider these two snapshot tuples:

```
   (x1, ..., xn, xn+1, ...)
   (y1, ..., yn, yn+1, ...)
```

If `(x1, ..., xn)` == `(y1, ..., yn)`, `xn+1` and `yn+1` must be
comparable.

Attempt to fix #7834.