### PR TITLE
Add plugin to typecheck functools.total_ordering

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -260,6 +260,11 @@ class SemanticAnalyzerPluginInterface:
         raise NotImplementedError
 
     @abstractmethod
+    def note(self, msg: str, ctx: Context, code: Optional[ErrorCode] = None) -> None:
+        """Emit a warning message at given location."""
+        raise NotImplementedError
+
+    @abstractmethod
     def anal_type(self, t: Type, *,
                   tvar_scope: Optional[TypeVarScope] = None,
                   allow_tuple_literal: bool = False,

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -90,6 +90,7 @@ class DefaultPlugin(Plugin):
                                  ) -> Optional[Callable[[ClassDefContext], None]]:
         from mypy.plugins import attrs
         from mypy.plugins import dataclasses
+        from mypy.plugins import total_ordering
 
         if fullname in attrs.attr_class_makers:
             return attrs.attr_class_maker_callback
@@ -100,6 +101,8 @@ class DefaultPlugin(Plugin):
             )
         elif fullname in dataclasses.dataclass_makers:
             return dataclasses.dataclass_class_maker_callback
+        elif fullname == total_ordering.total_ordering_fullname:
+            return total_ordering.total_ordering_callback
         return None
 
 

--- a/mypy/plugins/total_ordering.py
+++ b/mypy/plugins/total_ordering.py
@@ -22,10 +22,12 @@ def _validate_total_ordering(ctx: ClassDefContext) -> None:
     if '__eq__' not in names:
         ctx.api.fail("Classes with total_ordering must define __eq__", ctx.cls)
     elif names['__eq__'] == "builtins.object":
-        ctx.api.note("Combining inherited object.__eq__ with total_ordering is unlikely to be correct", ctx.cls)
+        ctx.api.note("Combining inherited object.__eq__ with total_ordering "
+                     "is unlikely to be correct", ctx.cls)
     if not ('__lt__' in names or '__le__' in names or
             '__gt__' in names or '__ge__' in names):
-        ctx.api.fail("Classes with total_ordering must define one of __{lt, gt, le, ge}__", ctx.cls)
+        ctx.api.fail("Classes with total_ordering must define one of "
+                     "__{lt, gt, le, ge}__", ctx.cls)
 
 
 def _create_typevar_on_class(ctx: ClassDefContext) -> Tuple[TypeVarDef, TypeVarType]:

--- a/mypy/plugins/total_ordering.py
+++ b/mypy/plugins/total_ordering.py
@@ -13,7 +13,7 @@ SELF_TVAR_NAME = '_AT'  # type: Final
 
 
 def _validate_total_ordering(ctx: ClassDefContext) -> None:
-    names: Dict[str, str] = dict()
+    names = dict()  # type: Dict[str, str]
     for info in ctx.cls.info.mro:
         for name in info.names:
             if name not in names:

--- a/mypy/plugins/total_ordering.py
+++ b/mypy/plugins/total_ordering.py
@@ -1,3 +1,6 @@
+from typing import Dict, Tuple
+from typing_extensions import Final
+
 from mypy.nodes import (Argument, TypeVarExpr, SymbolTableNode, Var, ARG_POS, MDEF)
 from mypy.plugin import ClassDefContext
 from mypy.plugins.common import add_method
@@ -10,7 +13,7 @@ SELF_TVAR_NAME = '_AT'  # type: Final
 
 
 def _validate_total_ordering(ctx: ClassDefContext) -> None:
-    names = dict()
+    names: Dict[str, str] = dict()
     for info in ctx.cls.info.mro:
         for name in info.names:
             if name not in names:
@@ -25,7 +28,7 @@ def _validate_total_ordering(ctx: ClassDefContext) -> None:
         ctx.api.fail("Classes with total_ordering must define one of __{lt, gt, le, ge}__", ctx.cls)
 
 
-def _create_typevar_on_class(ctx: ClassDefContext) -> TypeVarType:
+def _create_typevar_on_class(ctx: ClassDefContext) -> Tuple[TypeVarDef, TypeVarType]:
     object_type = ctx.api.named_type('__builtins__.object')
     tvar_name = SELF_TVAR_NAME
     tvar_fullname = ctx.cls.info.fullname() + '.' + SELF_TVAR_NAME

--- a/mypy/plugins/total_ordering.py
+++ b/mypy/plugins/total_ordering.py
@@ -10,7 +10,10 @@ SELF_TVAR_NAME = '_AT'  # type: Final
 
 
 def _validate_total_ordering(ctx: ClassDefContext) -> None:
-    names = set(ctx.cls.info.names)
+    names = set()
+    for info in ctx.cls.info.mro:
+        names = names.union(info.names)
+
     if '__eq__' not in names:
         ctx.api.fail("Classes with total_ordering must define __eq__", ctx.cls)
     if not ('__lt__' in names or '__le__' in names or

--- a/mypy/plugins/total_ordering.py
+++ b/mypy/plugins/total_ordering.py
@@ -10,12 +10,16 @@ SELF_TVAR_NAME = '_AT'  # type: Final
 
 
 def _validate_total_ordering(ctx: ClassDefContext) -> None:
-    names = set()
+    names = dict()
     for info in ctx.cls.info.mro:
-        names = names.union(info.names)
+        for name in info.names:
+            if name not in names:
+                names[name] = info.defn.fullname
 
     if '__eq__' not in names:
         ctx.api.fail("Classes with total_ordering must define __eq__", ctx.cls)
+    elif names['__eq__'] == "builtins.object":
+        ctx.api.note("Combining inherited object.__eq__ with total_ordering is unlikely to be correct", ctx.cls)
     if not ('__lt__' in names or '__le__' in names or
             '__gt__' in names or '__ge__' in names):
         ctx.api.fail("Classes with total_ordering must define one of __{lt, gt, le, ge}__", ctx.cls)

--- a/mypy/plugins/total_ordering.py
+++ b/mypy/plugins/total_ordering.py
@@ -1,0 +1,47 @@
+from mypy.nodes import (Argument, TypeVarExpr, SymbolTableNode, Var, ARG_POS, MDEF)
+from mypy.plugin import ClassDefContext
+from mypy.plugins.common import add_method
+from mypy.types import (TypeVarDef, TypeVarType)
+
+total_ordering_fullname = "functools.total_ordering"
+
+
+SELF_TVAR_NAME = '_AT'  # type: Final
+
+
+def _validate_total_ordering(ctx: ClassDefContext) -> None:
+    names = set(ctx.cls.info.names)
+    if '__eq__' not in names:
+        ctx.api.fail("Classes with total_ordering must define __eq__", ctx.cls)
+    if not ('__lt__' in names or '__le__' in names or
+            '__gt__' in names or '__ge__' in names):
+        ctx.api.fail("Classes with total_ordering must define one of __{lt, gt, le, ge}__", ctx.cls)
+
+
+def _create_typevar_on_class(ctx: ClassDefContext) -> TypeVarType:
+    object_type = ctx.api.named_type('__builtins__.object')
+    tvar_name = SELF_TVAR_NAME
+    tvar_fullname = ctx.cls.info.fullname() + '.' + SELF_TVAR_NAME
+
+    tvd = TypeVarDef(tvar_name, tvar_fullname, -1, [], object_type)
+    tvd_type = TypeVarType(tvd)
+
+    self_tvar_expr = TypeVarExpr(tvar_name, tvar_fullname, [], object_type)
+    ctx.cls.info.names[tvar_name] = SymbolTableNode(MDEF, self_tvar_expr)
+
+    return tvd, tvd_type
+
+
+def total_ordering_callback(ctx: ClassDefContext) -> None:
+    """Generate the missing ordering methods for this class."""
+    _validate_total_ordering(ctx)
+
+    bool_type = ctx.api.named_type('__builtins__.bool')
+    tvd, tvd_type = _create_typevar_on_class(ctx)
+
+    args = [Argument(Var('other', tvd_type), tvd_type, None, ARG_POS)]
+
+    existing_names = set(ctx.cls.info.names)
+    for method in ('__lt__', '__le__', '__gt__', '__ge__'):
+        if method not in existing_names:
+            add_method(ctx, method, args, bool_type, self_type=tvd_type, tvar_def=tvd)

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -88,6 +88,7 @@ typecheck_files = [
     'check-reports.test',
     'check-errorcodes.test',
     'check-annotated.test',
+    'check-total-ordering.test',
 ]
 
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):

--- a/test-data/unit/check-total-ordering.test
+++ b/test-data/unit/check-total-ordering.test
@@ -1,0 +1,35 @@
+[case testTotalOrderingInference]
+from functools import total_ordering
+from typing import Any
+
+@total_ordering
+class Ord:
+    def __eq__(self, other: Any) -> bool:
+        return False
+
+    def __lt__(self, other: "Ord") -> bool:
+        return False
+
+Ord() <= Ord()
+
+[builtins fixtures/dict.pyi]
+[case testTotalOrderingNoEq]
+from functools import total_ordering
+from typing import Any
+
+@total_ordering
+class Ord:  # E: Classes with total_ordering must define __eq__
+    def __lt__(self, other: "Ord") -> bool:
+        return False
+
+[builtins fixtures/dict.pyi]
+[case testTotalOrderingNoLt]
+from functools import total_ordering
+from typing import Any
+
+@total_ordering
+class Ord:  # E: Classes with total_ordering must define one of __{lt, gt, le, ge}__
+    def __eq__(self, other: Any) -> bool:
+        return False
+
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-total-ordering.test
+++ b/test-data/unit/check-total-ordering.test
@@ -33,3 +33,20 @@ class Ord:  # E: Classes with total_ordering must define one of __{lt, gt, le, g
         return False
 
 [builtins fixtures/dict.pyi]
+
+[case testTotalOrderingInherited]
+from functools import total_ordering
+from typing import Any
+
+class Super:
+    def __eq__(self, other: Any) -> bool:
+        return False
+
+@total_ordering
+class Ord(Super):
+    def __lt__(self, other: "Ord") -> bool:
+        return False
+
+Ord() <= Ord()
+
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-total-ordering.test
+++ b/test-data/unit/check-total-ordering.test
@@ -13,12 +13,12 @@ class Ord:
 Ord() <= Ord()
 
 [builtins fixtures/dict.pyi]
-[case testTotalOrderingNoEq]
+[case testTotalOrderingObjectEq]
 from functools import total_ordering
 from typing import Any
 
 @total_ordering
-class Ord:  # E: Classes with total_ordering must define __eq__
+class Ord:  # N: Combining inherited object.__eq__ with total_ordering is unlikely to be correct
     def __lt__(self, other: "Ord") -> bool:
         return False
 


### PR DESCRIPTION
This PR adds a plugin to typecheck classes decorated with `functools.total_ordering`, as requested in #4610 .

- The plugin validates the preconditions of `@total_ordering` (that the class must define `__eq__` and one other dunder inequality methods)
- Unit test cases are added