### PR TITLE
Add a env var to allow compiling with a different mypy checkout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,14 +129,17 @@ if USE_MYPYC:
     # order. Sort them so that the mypyc output is deterministic.
     mypyc_targets.sort()
 
-    # This bit is super unfortunate: we want to use the mypy packaged
-    # with mypyc. It will arrange for the path to be setup so it can
-    # find it, but we've already imported parts, so we remove the
-    # modules that we've imported already, which will let the right
-    # versions be imported by mypyc.
-    del sys.modules['mypy']
-    del sys.modules['mypy.version']
-    del sys.modules['mypy.git']
+
+    use_other_mypyc = os.getenv('ALTERNATE_MYPYC_PATH', None)
+    if use_other_mypyc:
+        # This bit is super unfortunate: we want to use a different
+        # mypy/mypyc version, but we've already imported parts, so we
+        # remove the modules that we've imported already, which will
+        # let the right versions be imported by mypyc.
+        del sys.modules['mypy']
+        del sys.modules['mypy.version']
+        del sys.modules['mypy.git']
+        sys.path.insert(0, use_other_mypyc)
 
     from mypyc.build import mypycify, MypycifyBuildExt
     opt_level = os.getenv('MYPYC_OPT_LEVEL', '3')


### PR DESCRIPTION
This will be useful when you want to use a stable compiler while
testing changes under mypyc.