### PR TITLE
Allow fancy self-types

### DIFF
--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -312,6 +312,8 @@ or a deserialization method returns the actual type of self. Therefore
 you may need to silence mypy inside these methods (but not at the call site),
 possibly by making use of the ``Any`` type.
 
+For some advanced uses of self-types see :ref:`additional examples <advanced_self>`.
+
 .. _variance-of-generics:
 
 Variance of generic types

--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -561,6 +561,125 @@ with ``Union[int, slice]`` and ``Union[T, Sequence]``.
    to returning ``Any`` only if the input arguments also contain ``Any``.
 
 
+.. _advanced_self:
+
+Advanced uses of self-types
+***************************
+
+Normally, mypy doesn't require annotation for first argument of instance and
+class methods. However, they may be needed to have more precise static typing
+for certain programming patterns.
+
+Restricted methods in generic classes
+-------------------------------------
+
+In generic classes some methods may be allowed to call only
+for certain values of type arguments:
+
+.. code-block:: python
+
+   T = TypeVar('T')
+   class Tag(Generic[T]):
+       item: T
+       def uppercase_item(self: C[str]) -> str:
+           return self.item.upper()
+
+   def label(ti: Tag[int], ts: Tag[str]) -> None:
+       ti.uppercase_item()  # E: Invalid self argument "Tag[int]" to attribute function
+                            # "uppercase_item" with type "Callable[[Tag[str]], str]"
+       ts.uppercase_item()  # This is OK
+
+This pattern also allows extraction of items in situations where type
+argument is itself generic:
+
+.. code-block:: python
+
+  T = TypeVar('T')
+  S = TypeVar('S')
+
+   class Node(Generic[T]):
+       def __init__(self, content: T) -> None:
+           self.content = content
+       def first_item(self: Node[Sequence[S]]) -> S:
+           return self.content[0]
+
+   page: Node[List[str]]
+   page.get_first_item()  # OK, type is "str"
+
+   Node(0).get_first_item()  # Error: Invalid self argument "Node[int]" to attribute function
+                             # "first_item" with type "Callable[[Node[Sequence[S]]], S]"
+
+Finally, one can use overloads on self-type to express precise types of
+some tricky methods:
+
+.. code-block:: python
+
+   T = TypeVar('T')
+
+   class Tag(Generic[T]):
+       @overload
+       def export(self: Tag[str]) -> str: ...
+       @overload
+       def export(self, converter: Callable[[T], str]) -> T: ...
+
+       def export(self, converter=None):
+           if isinstance(self.item, str):
+               return self.item
+           return converter(self.item)
+
+Mixin classes
+-------------
+
+Using host class protocol as a self-type in mixin methods allows
+static typing of mixin class patter:
+
+.. code-block:: python
+
+   class Resource(Protocol):
+       def close(self) -> int: ...
+
+   class AtomicClose:
+       def atomic_close(self: Resource) -> int:
+           with Lock():
+               return self.close()
+
+   class File(AtomicClose):
+       def close(self) -> int:
+          ...
+
+   class Bad(AtomicClose):
+       ...
+
+   f: File
+   b: Bad
+   f.atomic_close()  # OK
+   b.atomic_close()  # Error: Invalid self type for "atomic_close"
+
+Precise typing of alternative constructors
+------------------------------------------
+
+Some classes may define alternative constructors. If these
+classes are generic, self-type allows giving them precise signatures:
+
+.. code-block:: python
+
+   T = TypeVar('T')
+   Q = TypeVar('Q', bound=Base[Any])
+
+   class Base(Generic[T]):
+       def __init__(self, item: T) -> None:
+           self.item = item
+       @classmethod
+       def make_pair(cls: Type[Q], item: T) -> Tuple[Q, Q]:
+           return cls(item), cls(item)
+
+   class Sub(Base[T]):
+       ...
+
+   pair = Sub.make_pair('yes')  # Type is "Tuple[Sub[str], Sub[str]]"
+   bad = Sub[int].make_pair('no')  # Error: Argument 1 to "make_pair" of "Base"
+                                   # has incompatible type "str"; expected "int"
+
 .. _async-and-await:
 
 Typing async/await

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -909,7 +909,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         erased = erase_to_bound(arg_type)
                         if not is_subtype_ignoring_tvars(ref_type, erased):
                             note = None
-                            if typ.arg_names[i] in ['self', 'cls']:
+                            if isinstance(erased, Instance) and erased.type.is_protocol:
+                                msg = None
+                            elif typ.arg_names[i] in ['self', 'cls']:
                                 if (self.options.python_version[0] < 3
                                         and is_same_type(erased, arg_type) and not isclass):
                                     msg = message_registry.INVALID_SELF_TYPE_OR_EXTRA_ARG
@@ -919,9 +921,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                         erased, ref_type)
                             else:
                                 msg = message_registry.MISSING_OR_INVALID_SELF_TYPE
-                            self.fail(msg, defn)
-                            if note:
-                                self.note(note, defn)
+                            if msg:
+                                self.fail(msg, defn)
+                                if note:
+                                    self.note(note, defn)
                     elif isinstance(arg_type, TypeVarType):
                         # Refuse covariant parameter type variables
                         # TODO: check recursively for inner type variables

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -906,7 +906,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         isclass = defn.is_class or defn.name() in ('__new__', '__init_subclass__')
                         if isclass:
                             ref_type = mypy.types.TypeType.make_normalized(ref_type)
-                        erased = erase_to_bound(arg_type)
+                        erased = get_proper_type(erase_to_bound(arg_type))
                         if not is_subtype_ignoring_tvars(ref_type, erased):
                             note = None
                             if isinstance(erased, Instance) and erased.type.is_protocol:

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -200,8 +200,9 @@ def analyze_instance_member_access(name: str,
             # the first argument.
             pass
         else:
-            if isinstance(signature, FunctionLike):
-                check_self_arg(signature, mx.self_type, False, mx.context, name, mx.msg)
+            if isinstance(signature, FunctionLike) and name != '__call__':
+                dispatched_type = meet.meet_types(mx.original_type, typ)
+                check_self_arg(signature, dispatched_type, False, mx.context, name, mx.msg)
             signature = bind_self(signature, mx.self_type)
         typ = map_instance_to_supertype(typ, method.info)
         member_type = expand_type_by_instance(signature, typ)
@@ -705,7 +706,7 @@ def analyze_class_attribute_access(itype: Instance,
         is_classmethod = ((is_decorated and cast(Decorator, node.node).func.is_class)
                           or (isinstance(node.node, FuncBase) and node.node.is_class))
         t = get_proper_type(t)
-        if isinstance(t, FunctionLike):
+        if isinstance(t, FunctionLike) and is_classmethod:
             check_self_arg(t, mx.self_type, False, mx.context, name, mx.msg)
         result = add_class_tvars(t, itype, isuper, is_classmethod,
                                  mx.builtin_type, mx.self_type)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -624,7 +624,7 @@ def check_self_arg(functype: FunctionLike,
             selfarg = item.arg_types[0]
             if is_classmethod:
                 dispatched_arg_type = TypeType.make_normalized(dispatched_arg_type)
-            if subtypes.is_subtype(dispatched_arg_type, erase_typevars(selfarg)):
+            if subtypes.is_subtype(dispatched_arg_type, erase_typevars(erase_to_bound(selfarg))):
                 new_items.append(item)
     if not new_items:
         # Choose first item for the message (it may be not very helpful for overloads).

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -201,9 +201,11 @@ def analyze_instance_member_access(name: str,
             pass
         else:
             if isinstance(signature, FunctionLike) and name != '__call__':
+                # TODO: use proper treatment of special methods on unions instead
+                #       of this hack here and below (i.e. mx.self_type).
                 dispatched_type = meet.meet_types(mx.original_type, typ)
                 signature = check_self_arg(signature, dispatched_type, False, mx.context,
-                name, mx.msg)
+                                           name, mx.msg)
             signature = bind_self(signature, mx.self_type)
         typ = map_instance_to_supertype(typ, method.info)
         member_type = expand_type_by_instance(signature, typ)

--- a/mypy/infer.py
+++ b/mypy/infer.py
@@ -2,10 +2,10 @@
 
 from typing import List, Optional, Sequence
 
-from mypy.constraints import infer_constraints, infer_constraints_for_callable
+from mypy.constraints import infer_constraints, infer_constraints_for_callable, SUBTYPE_OF
 from mypy.types import Type, TypeVarId, CallableType
 from mypy.solve import solve_constraints
-from mypy.constraints import SUBTYPE_OF
+from mypy.constraints import SUPERTYPE_OF
 
 
 def infer_function_type_arguments(callee_type: CallableType,
@@ -36,8 +36,10 @@ def infer_function_type_arguments(callee_type: CallableType,
 
 
 def infer_type_arguments(type_var_ids: List[TypeVarId],
-                         template: Type, actual: Type) -> List[Optional[Type]]:
+                         template: Type, actual: Type,
+                         is_supertype: bool = False) -> List[Optional[Type]]:
     # Like infer_function_type_arguments, but only match a single type
     # against a generic type.
-    constraints = infer_constraints(template, actual, SUBTYPE_OF)
+    constraints = infer_constraints(template, actual,
+                                    SUPERTYPE_OF if is_supertype else SUBTYPE_OF)
     return solve_constraints(type_var_ids, constraints)

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -131,7 +131,8 @@ def map_type_from_supertype(typ: Type,
 
 
 def instance_or_var(typ: ProperType) -> bool:
-    return isinstance(typ, TypeVarType) or isinstance(typ, Instance)
+    return (isinstance(typ, TypeVarType) or
+            isinstance(typ, Instance) and typ != fill_typevars(typ.type))
 
 
 F = TypeVar('F', bound=FunctionLike)

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -52,7 +52,7 @@ def type_object_type_from_function(signature: FunctionLike,
     # We need to first map B's __init__ to the type (List[T]) -> None.
 
     # We first record all non-trivial (explicit) self types.
-    if not is_new and def_info == info:
+    if not is_new and def_info == info and not info.is_newtype:
         orig_self_types = [(it.arg_types[0] if it.arg_types and it.arg_kinds[0] == ARG_POS and
                             it.arg_types[0] != fill_typevars(def_info) else None)
                            for it in signature.items()]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4286,7 +4286,7 @@ reveal_type(ta.g3)  # N: Revealed type is 'def () -> Type[__main__.A]'
 reveal_type(ta.g4)  # N: Revealed type is 'def () -> Type[__main__.A]'
 
 x: M = ta
-x.g1  # should be error: Argument 0 to "g1" of "M" has incompatible type "M"; expected "Type[A]"
+x.g1  # E: Invalid self argument "M" to attribute function "g1" with type "Callable[[Type[A]], A]"
 x.g2  # should be error: Argument 0 to "g2" of "M" has incompatible type "M"; expected "Type[TA]"
 x.g3  # should be error: Argument 0 to "g3" of "M" has incompatible type "M"; expected "TTA"
 reveal_type(x.g4)  # N: Revealed type is 'def () -> __main__.M*'

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4287,8 +4287,8 @@ reveal_type(ta.g4)  # N: Revealed type is 'def () -> Type[__main__.A]'
 
 x: M = ta
 x.g1  # E: Invalid self argument "M" to attribute function "g1" with type "Callable[[Type[A]], A]"
-x.g2  # should be error: Argument 0 to "g2" of "M" has incompatible type "M"; expected "Type[TA]"
-x.g3  # should be error: Argument 0 to "g3" of "M" has incompatible type "M"; expected "TTA"
+x.g2  # E: Invalid self argument "M" to attribute function "g2" with type "Callable[[Type[TA]], TA]"
+x.g3  # E: Invalid self argument "M" to attribute function "g3" with type "Callable[[TTA], TTA]"
 reveal_type(x.g4)  # N: Revealed type is 'def () -> __main__.M*'
 
 def r(ta: Type[TA], tta: TTA) -> None:

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1948,6 +1948,22 @@ class B(A[T], Generic[T, S]):
 reveal_type(B.foo)  # N: Revealed type is 'def [T, S] () -> Tuple[T`1, __main__.B*[T`1, S`2]]'
 [builtins fixtures/classmethod.pyi]
 
+[case testGenericClassAlternativeConstructorPrecise]
+from typing import Generic, TypeVar, Type
+
+T = TypeVar('T')
+Q = TypeVar('Q')
+
+class Base(Generic[T]):
+    @classmethod
+    def make_some(cls: Type[Q], item: T, count: int) -> Q: ...
+class Sub(Base[T]):
+    ...
+
+reveal_type(Sub.make_some('yes', 3))  # N: Revealed type is '__main__.Sub[builtins.str*]'
+Sub[int].make_some('no', 3)  # E: Argument 1 to "make_some" of "Base" has incompatible type "str"; expected "int"
+[builtins fixtures/classmethod.pyi]
+
 [case testGenericClassAttrUnboundOnClass]
 from typing import Generic, TypeVar
 T = TypeVar('T')

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1949,19 +1949,21 @@ reveal_type(B.foo)  # N: Revealed type is 'def [T, S] () -> Tuple[T`1, __main__.
 [builtins fixtures/classmethod.pyi]
 
 [case testGenericClassAlternativeConstructorPrecise]
-from typing import Generic, TypeVar, Type
+from typing import Generic, TypeVar, Type, Tuple, Any
 
 T = TypeVar('T')
-Q = TypeVar('Q')
+Q = TypeVar('Q', bound=Base[Any])
 
 class Base(Generic[T]):
+    def __init__(self, item: T) -> None: ...
     @classmethod
-    def make_some(cls: Type[Q], item: T, count: int) -> Q: ...
+    def make_pair(cls: Type[Q], item: T) -> Tuple[Q, Q]:
+        return cls(item), cls(item)
 class Sub(Base[T]):
     ...
 
-reveal_type(Sub.make_some('yes', 3))  # N: Revealed type is '__main__.Sub[builtins.str*]'
-Sub[int].make_some('no', 3)  # E: Argument 1 to "make_some" of "Base" has incompatible type "str"; expected "int"
+reveal_type(Sub.make_pair('yes'))  # N: Revealed type is 'Tuple[__main__.Sub[builtins.str*], __main__.Sub[builtins.str*]]'
+Sub[int].make_pair('no')  # E: Argument 1 to "make_pair" of "Base" has incompatible type "str"; expected "int"
 [builtins fixtures/classmethod.pyi]
 
 [case testGenericClassAttrUnboundOnClass]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -3173,4 +3173,4 @@ class User:
 
     def __init__(self, name: str) -> None:
         self.name = name  # E: Cannot assign to a method \
-                          # E: Incompatible types in assignment (expression has type "str", variable has type overloaded function)
+                          # E: Incompatible types in assignment (expression has type "str", variable has type "Callable[..., Any]")

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -468,15 +468,60 @@ class B(A[Q]):
 a: A[int]
 b: B[str]
 reveal_type(a.g)  # N: Revealed type is 'builtins.int'
---reveal_type(a.gt)  # N: Revealed type is 'builtins.int'
+reveal_type(a.gt)  # N: Revealed type is 'builtins.int*'
 reveal_type(a.f())  # N: Revealed type is 'builtins.int'
 reveal_type(a.ft())  # N: Revealed type is '__main__.A*[builtins.int]'
 reveal_type(b.g)  # N: Revealed type is 'builtins.int'
---reveal_type(b.gt)  # N: Revealed type is '__main__.B*[builtins.str]'
+reveal_type(b.gt)  # N: Revealed type is 'builtins.str*'
 reveal_type(b.f())  # N: Revealed type is 'builtins.int'
 reveal_type(b.ft())  # N: Revealed type is '__main__.B*[builtins.str]'
-
 [builtins fixtures/property.pyi]
+
+[case testSelfTypeRestrictedMethod]
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+class C(Generic[T]):
+    def from_item(self: C[str]) -> None: ...
+
+i: C[int]
+s: C[str]
+
+i.from_item()  # E: Invalid self argument "C[int]" to attribute function "from_item" with type "Callable[[C[str]], None]"
+s.from_item()
+
+[case testSelfTypeRestrictedClassMethod]
+from typing import TypeVar, Generic, Type
+
+T = TypeVar('T')
+class C(Generic[T]):
+    @classmethod
+    def from_item(cls: Type[C[str]]) -> None: ...
+
+class DI(C[int]): ...
+class DS(C[str]): ...
+
+DI().from_item()  # E: Invalid self argument "Type[DI]" to class attribute function "from_item" with type "Callable[[Type[C[str]]], None]"
+DS().from_item()
+DI.from_item()  # E: Invalid self argument "Type[DI]" to attribute function "from_item" with type "Callable[[Type[C[str]]], None]"
+DS.from_item()
+[builtins fixtures/classmethod.pyi]
+
+[case testSelfTypeNarrowBinding]
+from typing import TypeVar, List, Generic
+
+T = TypeVar('T')
+S = TypeVar('S')
+
+class Base(Generic[T]):
+    def get_item(self: Base[List[S]]) -> S: ...
+
+class Sub(Base[List[int]]): ...
+class BadSub(Base[int]): ...
+
+reveal_type(Sub().get_item())  # N: Revealed type is 'builtins.int'
+BadSub().get_item()  # E: Invalid self argument "BadSub" to attribute function "get_item" with type "Callable[[Base[List[S]]], S]"
+[builtins fixtures/list.pyi]
 
 [case testSelfTypeNotSelfType]
 # Friendlier error messages for common mistakes. See #2950

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -507,6 +507,51 @@ DI.from_item()  # E: Invalid self argument "Type[DI]" to attribute function "fro
 DS.from_item()
 [builtins fixtures/classmethod.pyi]
 
+[case testSelfTypeRestrictedMethodOverload]
+from typing import TypeVar, Generic, overload, Tuple
+
+T = TypeVar('T')
+class C(Generic[T]):
+    @overload
+    def from_item(self: C[str], item: str) -> None: ...
+    @overload
+    def from_item(self: C[int], item: Tuple[int]) -> None: ...
+    def from_item(self, item):
+        ...
+
+ci: C[int]
+cs: C[str]
+reveal_type(ci.from_item)  # N: Revealed type is 'def (item: Tuple[builtins.int])'
+reveal_type(cs.from_item)  # N: Revealed type is 'def (item: builtins.str)'
+
+[case testSelfTypeRestrictedMethodOverloadInit]
+from lib import P, C
+
+reveal_type(P)  # N: Revealed type is 'Overload(def [T] (use_str: Literal[True]) -> lib.P[builtins.str], def [T] (use_str: Literal[False]) -> lib.P[builtins.int])'
+reveal_type(P(use_str=True))  # N: Revealed type is 'lib.P[builtins.str]'
+reveal_type(P(use_str=False))  # N: Revealed type is 'lib.P[builtins.int]'
+
+reveal_type(C)  # N: Revealed type is 'Overload(def [T] (item: T`1, use_tuple: Literal[False]) -> lib.C[T`1], def [T] (item: T`1, use_tuple: Literal[True]) -> lib.C[builtins.tuple[T`1]])'
+reveal_type(C(0, use_tuple=False))  # N: Revealed type is 'lib.C[builtins.int*]'
+reveal_type(C(0, use_tuple=True))  # N: Revealed type is 'lib.C[builtins.tuple[builtins.int*]]'
+
+[file lib.pyi]
+from typing import TypeVar, Generic, overload, Tuple
+from typing_extensions import Literal
+
+T = TypeVar('T')
+class P(Generic[T]):
+    @overload
+    def __init__(self: P[str], use_str: Literal[True]) -> None: ...
+    @overload
+    def __init__(self: P[int], use_str: Literal[False]) -> None: ...
+
+class C(Generic[T]):
+    @overload
+    def __init__(self: C[T], item: T, use_tuple: Literal[False]) -> None: ...
+    @overload
+    def __init__(self: C[Tuple[T, ...]], item: T, use_tuple: Literal[True]) -> None: ...
+
 [case testSelfTypeNarrowBinding]
 from typing import TypeVar, List, Generic
 

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -524,6 +524,28 @@ cs: C[str]
 reveal_type(ci.from_item)  # N: Revealed type is 'def (item: Tuple[builtins.int])'
 reveal_type(cs.from_item)  # N: Revealed type is 'def (item: builtins.str)'
 
+[case testSelfTypeRestrictedMethodOverloadFallback]
+from typing import TypeVar, Generic, overload, Callable
+
+T = TypeVar('T')
+class C(Generic[T]):
+    @overload
+    def from_item(self: C[str]) -> str: ...
+    @overload
+    def from_item(self, converter: Callable[[T], str]) -> str: ...
+    def from_item(self, converter):
+        ...
+
+ci: C[int]
+cs: C[str]
+reveal_type(cs.from_item())  # N: Revealed type is 'builtins.str'
+ci.from_item()  # E: Too few arguments for "from_item" of "C"
+
+def conv(x: int) -> str: ...
+def bad(x: str) -> str: ...
+reveal_type(ci.from_item(conv))  # N: Revealed type is 'builtins.str'
+ci.from_item(bad)  # E: Argument 1 to "from_item" of "C" has incompatible type "Callable[[str], str]"; expected "Callable[[int], str]"
+
 [case testSelfTypeRestrictedMethodOverloadInit]
 from lib import P, C
 
@@ -567,6 +589,53 @@ class BadSub(Base[int]): ...
 reveal_type(Sub().get_item())  # N: Revealed type is 'builtins.int'
 BadSub().get_item()  # E: Invalid self argument "BadSub" to attribute function "get_item" with type "Callable[[Base[List[S]]], S]"
 [builtins fixtures/list.pyi]
+
+[case testMixinAllowedWithProtocol]
+from typing import TypeVar
+from typing_extensions import Protocol
+
+class Resource(Protocol):
+    def close(self) -> int: ...
+
+class AtomicClose:
+    def atomic_close(self: Resource) -> int:
+        return self.close()
+
+T = TypeVar('T', bound=Resource)
+class Copyable:
+    def copy(self: T) -> T: ...
+
+class File(AtomicClose, Copyable):
+    def close(self) -> int:
+       ...
+
+class Bad(AtomicClose, Copyable):
+    ...
+
+f: File
+b: Bad
+f.atomic_close()  # OK
+b.atomic_close()  # E: Invalid self argument "Bad" to attribute function "atomic_close" with type "Callable[[Resource], int]"
+
+reveal_type(f.copy())  # N: Revealed type is '__main__.File*'
+b.copy()  # E: Invalid self argument "Bad" to attribute function "copy" with type "Callable[[T], T]"
+
+[case testBadClassLevelDecoratorHack]
+from typing_extensions import Protocol
+from typing import TypeVar, Any
+
+class FuncLike(Protocol):
+    __call__: Any
+F = TypeVar('F', bound=FuncLike)
+
+class Test:
+    def _deco(func: F) -> F: ...
+
+    @_deco
+    def meth(self, x: str) -> int: ...
+
+reveal_type(Test().meth)  # N: Revealed type is 'def (x: builtins.str) -> builtins.int'
+Test()._deco  # E: Invalid self argument "Test" to attribute function "_deco" with type "Callable[[F], F]"
 
 [case testSelfTypeNotSelfType]
 # Friendlier error messages for common mistakes. See #2950


### PR DESCRIPTION
So, lately I was noticing many issues that would be fixed by (partially) moving the check for self-type from definition site to call site.

This morning I found that we actually have such function `check_self_arg()` that is applied at call site, but it is almost not used. After more reading of the code I found that all the patterns for self-types that I wanted to support should either already work, or work with minimal modifications. Finally, I discovered that the root cause of many of the problems is the fact that `bind_self()` uses wrong direction for type inference! All these years it expected actual argument type to be _supertype_ of the formal one.

After fixing this bug, it turned out it was easy to support following patterns for explicit self-types:
* Structured match on generic self-types
* Restricted methods in generic classes (methods that one is allowed to call only for some values or type arguments)
* Methods overloaded on self-type
* (Important case of the above) overloaded `__init__` for generic classes
* Mixin classes (using protocols)
* Private class-level decorators (a bit hacky)
* Precise types for alternative constructors (mostly already worked)

This PR cuts few corners, but it is ready for review (I left some TODOs). Note I also add some docs, I am not sure this is really needed, but probably good to have.