### PR TITLE
Custom type narrowing with a special decorator

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3721,7 +3721,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             for name, expr_ in self.ctns:
                 if refers_to_fullname(node.callee, name):
                     expr = node.args[0]
-                    if literal(expr_) == LITERAL_TYPE:
+                    if literal(expr) == LITERAL_TYPE:
                         vartype = type_map[node.args[0]]
                         type = get_isinstance_type(expr_, type_map)
                         break  # name is unique

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -165,9 +165,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     # temporary container for ctn
     ctns_queue = None  # type:List[str]
     # uniqueness check for ctn
-    ctns_keys = None # type:Set[str]
+    ctns_keys = None  # type: Set[str]
     # custom type narrowers
-    ctns = None  # type:List[Tuple[str, Expression]]
+    ctns = None  # type: List[Tuple[str, Expression]]
     tscope = None  # type: Scope
     scope = None  # type: CheckerScope
     # Stack of function return types

--- a/mypy/extern.py
+++ b/mypy/extern.py
@@ -1,7 +1,7 @@
 from typing import Union, Tuple, Any, Callable
 
 
-# copy pasted from typeshed
+# signature is partially copy pasted from typeshed isinstance
 def narrow_cast(T: Union[type, Tuple[Union[type, Tuple[Any, ...]], ...]]) \
         -> Callable[..., Callable[..., bool]]:
     def narrow_cast_inner(f: Callable[..., bool]) -> Callable[..., bool]:

--- a/mypy/extern.py
+++ b/mypy/extern.py
@@ -1,0 +1,10 @@
+from typing import Union, Tuple, Any, Callable
+
+
+# copy pasted from typeshed
+def narrow_cast(T: Union[type, Tuple[Union[type, Tuple[Any, ...]], ...]]) \
+        -> Callable[..., Callable[..., bool]]:
+    def narrow_cast_inner(f: Callable[..., bool]) -> Callable[..., bool]:
+        return f  # binds first argument of f to T
+
+    return narrow_cast_inner

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -2279,3 +2279,52 @@ var = 'some string'
 if isinstance(var, *(str, int)):  # E: Too many arguments for "isinstance"
     pass
 [builtins fixtures/isinstancelist.pyi]
+
+[case testCustomTypeNarrower]
+from typing import Union, List, Tuple, Any, Callable
+from mypy.extern import narrow_cast
+@narrow_cast(int)
+def isint(x: Union[str, int], *args) -> bool:
+    return isinstance(x, int)
+
+@narrow_cast(str)
+def isstr(x, name) -> bool:
+    return name == 'STRING'
+
+u: Union[str, int] = 5
+x: Union[str, float]
+if isint(u):
+    reveal_type(u)  # N: Revealed type is 'builtins.int'
+if isinstance(u, int):
+    reveal_type(u)  # N: Revealed type is 'builtins.int'
+if isstr(x, 'STRING'):
+    x + ""
+
+@narrow_cast(str)
+def is_fizz_buzz(foo):
+    return foo in ['fizz', 'buzz']
+
+def foobar(foo: Union[str, float]):
+    if foo in ['fizz', 'buzz']:
+        reveal_type(foo)  # N: Revealed type is 'Union[builtins.str, builtins.float]'
+    if is_fizz_buzz(foo):
+        reveal_type(foo)  # N: Revealed type is 'builtins.str'
+
+@narrow_cast((str, (int,)))
+def is_str_or_int(x):
+    return isinstance(x, (str, (int,)))
+
+@narrow_cast((str, (list,)))
+def is_str_or_list(x):
+    return isinstance(x, (str, (list,)))
+
+def f(x: Union[int, str, List]) -> None:
+    if isinstance(x, (str, (int,))):
+        reveal_type(x)  # N: Revealed type is 'Union[builtins.int, builtins.str]'
+    if is_str_or_int(x):
+        reveal_type(x)  # N: Revealed type is 'Union[builtins.int, builtins.str]'
+    if isinstance(x, (str, (list,))):
+        reveal_type(x)  # N: Revealed type is 'Union[builtins.str, builtins.list[Any]]'
+    if is_str_or_list(x):
+        reveal_type(x)   # N: Revealed type is 'Union[builtins.str, builtins.list[Any]]'
+[builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/lib-stub/mypy/extern.py
+++ b/test-data/unit/lib-stub/mypy/extern.py
@@ -1,0 +1,10 @@
+from typing import Union, Tuple, Any, Callable
+
+
+# copy pasted from typeshed
+def narrow_cast(T: Union[type, Tuple[Union[type, Tuple[Any, ...]], ...]]) \
+        -> Callable[..., Callable[..., bool]]:
+    def narrow_cast_inner(f: Callable[..., bool]) -> Callable[..., bool]:
+        return f  # binds first argument of f to T
+
+    return narrow_cast_inner


### PR DESCRIPTION
This is surely not meant to be merged.. but just a small proposal?
I think the `narrow_cast` (or whatever it's called) should be inside `typing` and not `mypy`. 
Having that decorator, type narrowing with user-defined functions is trivial  (cf tests) and looks something like 
```
@narrow_cast(str)  # mypy will narrow type to 'str' if this returns True
def is_fizz_buzz(foo):
    return foo in ['fizz', 'buzz']

def foobar(foo: Union[str, float]):
    if foo in ['fizz', 'buzz']:
        reveal_type(foo)  # N: Revealed type is 'Union[builtins.str, builtins.float]'
    if is_fizz_buzz(foo):
        reveal_type(foo)  # N: Revealed type is 'builtins.str'
```