### PR TITLE
Don't coerce the result of an ExpressionStmt's Expression

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -2129,7 +2129,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             self.add(Unreachable())
 
     def visit_expression_stmt(self, stmt: ExpressionStmt) -> None:
-        self.accept(stmt.expr)
+        # ExpressionStmts do not need to be coerced like other Expressions.
+        stmt.expr.accept(self)
 
     def visit_return_stmt(self, stmt: ReturnStmt) -> None:
         if stmt.expr:

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -189,9 +189,8 @@ def g():
     r6 :: object
     r7 :: str
     r8, r9 :: object
-    r10 :: None
-    r11 :: bool
-    r12, r13 :: None
+    r10 :: bool
+    r11, r12 :: None
 L0:
 L1:
     r0 = builtins :: module
@@ -201,42 +200,41 @@ L1:
 L2:
     r3 = py_call(r2)
     dec_ref r2
-    if is_error(r3) goto L3 (error at g:3) else goto L11
+    if is_error(r3) goto L3 (error at g:3) else goto L10
 L3:
     r4 = error_catch
     r5 = unicode_2 :: static  ('weeee')
     r6 = builtins :: module
     r7 = unicode_3 :: static  ('print')
     r8 = getattr r6, r7
-    if is_error(r8) goto L7 (error at g:5) else goto L4
+    if is_error(r8) goto L6 (error at g:5) else goto L4
 L4:
     r9 = py_call(r8, r5)
     dec_ref r8
-    if is_error(r9) goto L7 (error at g:5) else goto L5
+    if is_error(r9) goto L6 (error at g:5) else goto L11
 L5:
-    r10 = unbox(None, r9)
-    dec_ref r9
-    if is_error(r10) goto L7 (error at g:5) else goto L6
+    restore_exc_info r4
+    dec_ref r4
+    goto L8
 L6:
     restore_exc_info r4
     dec_ref r4
-    goto L9
+    r10 = keep_propagating
+    if not r10 goto L9 else goto L7 :: bool
 L7:
-    restore_exc_info r4
-    dec_ref r4
-    r11 = keep_propagating
-    if not r11 goto L10 else goto L8 :: bool
-L8:
     unreachable
+L8:
+    r11 = None
+    return r11
 L9:
-    r12 = None
+    r12 = <error> :: None
     return r12
 L10:
-    r13 = <error> :: None
-    return r13
-L11:
     dec_ref r3
-    goto L9
+    goto L8
+L11:
+    dec_ref r9
+    goto L5
 
 [case testGenopsTryFinally]
 def a() -> str:
@@ -250,96 +248,92 @@ def a():
     r0 :: object
     r1 :: str
     r2, r3 :: object
-    r4 :: None
-    r5, r6 :: str
-    r7 :: tuple[object, object, object]
-    r8 :: str
-    r9 :: tuple[object, object, object]
-    r10 :: str
-    r11 :: tuple[object, object, object]
-    r12 :: str
-    r13 :: object
-    r14 :: str
-    r15, r16 :: object
-    r17 :: None
-    r18, r19 :: bool
-    r20 :: str
+    r4, r5 :: str
+    r6 :: tuple[object, object, object]
+    r7 :: str
+    r8 :: tuple[object, object, object]
+    r9 :: str
+    r10 :: tuple[object, object, object]
+    r11 :: str
+    r12 :: object
+    r13 :: str
+    r14, r15 :: object
+    r16, r17 :: bool
+    r18 :: str
 L0:
 L1:
     r0 = builtins :: module
     r1 = unicode_1 :: static  ('print')
     r2 = getattr r0, r1
-    if is_error(r2) goto L6 (error at a:3) else goto L2
+    if is_error(r2) goto L5 (error at a:3) else goto L2
 L2:
     r3 = py_call(r2)
     dec_ref r2
-    if is_error(r3) goto L6 (error at a:3) else goto L3
+    if is_error(r3) goto L5 (error at a:3) else goto L20
 L3:
-    r4 = unbox(None, r3)
-    dec_ref r3
-    if is_error(r4) goto L6 (error at a:3) else goto L4
+    r4 = unicode_2 :: static  ('hi')
+    inc_ref r4
+    r5 = r4
 L4:
-    r5 = unicode_2 :: static  ('hi')
-    inc_ref r5
-    r6 = r5
+    r8 = <error> :: tuple[object, object, object]
+    r6 = r8
+    goto L6
 L5:
-    r9 = <error> :: tuple[object, object, object]
-    r7 = r9
-    goto L7
-L6:
-    r10 = <error> :: str
+    r9 = <error> :: str
+    r5 = r9
+    r10 = error_catch
     r6 = r10
-    r11 = error_catch
-    r7 = r11
+L6:
+    r11 = unicode_3 :: static  ('goodbye!')
+    r12 = builtins :: module
+    r13 = unicode_1 :: static  ('print')
+    r14 = getattr r12, r13
+    if is_error(r14) goto L13 (error at a:6) else goto L7
 L7:
-    r12 = unicode_3 :: static  ('goodbye!')
-    r13 = builtins :: module
-    r14 = unicode_1 :: static  ('print')
-    r15 = getattr r13, r14
-    if is_error(r15) goto L15 (error at a:6) else goto L8
+    r15 = py_call(r14, r11)
+    dec_ref r14
+    if is_error(r15) goto L13 (error at a:6) else goto L21
 L8:
-    r16 = py_call(r15, r12)
-    dec_ref r15
-    if is_error(r16) goto L15 (error at a:6) else goto L9
+    if is_error(r6) goto L11 else goto L9
 L9:
-    r17 = unbox(None, r16)
-    dec_ref r16
-    if is_error(r17) goto L15 (error at a:6) else goto L10
+    reraise_exc; r16 = 0
+    if not r16 goto L13 else goto L22 :: bool
 L10:
-    if is_error(r7) goto L13 else goto L11
+    unreachable
 L11:
-    reraise_exc; r18 = 0
-    if not r18 goto L15 else goto L22 :: bool
+    if is_error(r5) goto L18 else goto L12
 L12:
-    unreachable
+    return r5
 L13:
-    if is_error(r6) goto L20 else goto L14
+    if is_error(r5) goto L14 else goto L23
 L14:
-    return r6
+    if is_error(r6) goto L16 else goto L15
 L15:
-    if is_error(r6) goto L16 else goto L23
+    restore_exc_info r6
+    dec_ref r6
 L16:
-    if is_error(r7) goto L18 else goto L17
+    r17 = keep_propagating
+    if not r17 goto L19 else goto L17 :: bool
 L17:
-    restore_exc_info r7
-    dec_ref r7
+    unreachable
 L18:
-    r19 = keep_propagating
-    if not r19 goto L21 else goto L19 :: bool
+    unreachable
 L19:
-    unreachable
+    r18 = <error> :: str
+    return r18
 L20:
-    unreachable
+    dec_ref r3
+    goto L3
 L21:
-    r20 = <error> :: str
-    return r20
+    dec_ref r15
+    goto L8
 L22:
+    dec_ref r5
     dec_ref r6
-    dec_ref r7
-    goto L12
+    goto L10
 L23:
-    dec_ref r6
-    goto L16
+    dec_ref r5
+    goto L14
 
 [case testDocstring1]
 def lol() -> None:
@@ -483,58 +477,58 @@ def f(b):
     r4 :: object
     r5 :: str
     r6, r7 :: object
-    r8, r9 :: None
-    r10 :: bool
-    r11 :: None
+    r8 :: None
+    r9 :: bool
+    r10 :: None
 L0:
     r0 = unicode_1 :: static  ('a')
     inc_ref r0
     u = r0
 L1:
-    if b goto L11 else goto L12 :: bool
+    if b goto L10 else goto L11 :: bool
 L2:
     r1 = unicode_2 :: static  ('b')
     inc_ref r1
     v = r1
     r2 = v is u
     r3 = !r2
-    if r3 goto L12 else goto L1 :: bool
+    if r3 goto L11 else goto L1 :: bool
 L3:
     r4 = builtins :: module
     r5 = unicode_3 :: static  ('print')
     r6 = getattr r4, r5
-    if is_error(r6) goto L13 (error at f:7) else goto L4
+    if is_error(r6) goto L12 (error at f:7) else goto L4
 L4:
-    if is_error(v) goto L14 else goto L7
+    if is_error(v) goto L13 else goto L7
 L5:
     raise UnboundLocalError("local variable 'v' referenced before assignment")
-    if not r10 goto L10 (error at f:7) else goto L6 :: bool
+    if not r9 goto L9 (error at f:7) else goto L6 :: bool
 L6:
     unreachable
 L7:
     r7 = py_call(r6, v)
     dec_ref r6
     xdec_ref v
-    if is_error(r7) goto L10 (error at f:7) else goto L8
+    if is_error(r7) goto L9 (error at f:7) else goto L14
 L8:
-    r8 = unbox(None, r7)
-    dec_ref r7
-    if is_error(r8) goto L10 (error at f:7) else goto L9
+    r8 = None
+    return r8
 L9:
-    r9 = None
-    return r9
+    r10 = <error> :: None
+    return r10
 L10:
-    r11 = <error> :: None
-    return r11
-L11:
     xdec_ref v
     goto L2
-L12:
+L11:
     dec_ref u
     goto L3
-L13:
+L12:
     xdec_ref v
-    goto L10
-L14:
+    goto L9
+L13:
     dec_ref r6
     goto L5
+L14:
+    dec_ref r7
+    goto L8
+

--- a/mypyc/test-data/genops-basic.test
+++ b/mypyc/test-data/genops-basic.test
@@ -612,7 +612,7 @@ def f(x):
     r2 :: object
     r3 :: short_int
     r4, r5 :: object
-    r6, r7 :: None
+    r6 :: None
 L0:
     r0 = builtins :: module
     r1 = unicode_1 :: static  ('print')
@@ -620,9 +620,8 @@ L0:
     r3 = 5
     r4 = box(short_int, r3)
     r5 = py_call(r2, r4)
-    r6 = unbox(None, r5)
-    r7 = None
-    return r7
+    r6 = None
+    return r6
 
 [case testPrint]
 import builtins
@@ -635,7 +634,7 @@ def f(x):
     r1 :: object
     r2 :: str
     r3, r4, r5 :: object
-    r6, r7 :: None
+    r6 :: None
 L0:
     r0 = 5
     r1 = builtins :: module
@@ -643,9 +642,8 @@ L0:
     r3 = getattr r1, r2
     r4 = box(short_int, r0)
     r5 = py_call(r3, r4)
-    r6 = unbox(None, r5)
-    r7 = None
-    return r7
+    r6 = None
+    return r6
 
 [case testUnicodeLiteral]
 def f() -> str:
@@ -1116,16 +1114,14 @@ def call_python_method_with_keyword_args(xs, first, second):
     r6 :: object
     r7 :: dict
     r8 :: object
-    r9 :: None
-    r10 :: short_int
-    r11 :: str
-    r12 :: object
-    r13, r14 :: str
-    r15 :: tuple
-    r16, r17 :: object
-    r18 :: dict
-    r19 :: object
-    r20 :: None
+    r9 :: short_int
+    r10 :: str
+    r11 :: object
+    r12, r13 :: str
+    r14 :: tuple
+    r15, r16 :: object
+    r17 :: dict
+    r18 :: object
 L0:
     r0 = 0
     r1 = unicode_4 :: static  ('insert')
@@ -1136,18 +1132,16 @@ L0:
     r6 = box(int, first)
     r7 = {r3: r6}
     r8 = py_call_with_kwargs(r2, r5, r7)
-    r9 = unbox(None, r8)
-    r10 = 1
-    r11 = unicode_4 :: static  ('insert')
-    r12 = getattr xs, r11
-    r13 = unicode_5 :: static  ('x')
-    r14 = unicode_6 :: static  ('i')
-    r15 = () :: tuple
-    r16 = box(int, second)
-    r17 = box(short_int, r10)
-    r18 = {r13: r16, r14: r17}
-    r19 = py_call_with_kwargs(r12, r15, r18)
-    r20 = unbox(None, r19)
+    r9 = 1
+    r10 = unicode_4 :: static  ('insert')
+    r11 = getattr xs, r10
+    r12 = unicode_5 :: static  ('x')
+    r13 = unicode_6 :: static  ('i')
+    r14 = () :: tuple
+    r15 = box(int, second)
+    r16 = box(short_int, r9)
+    r17 = {r12: r15, r13: r16}
+    r18 = py_call_with_kwargs(r11, r14, r17)
     return xs
 
 [case testObjectAsBoolean]
@@ -1357,7 +1351,7 @@ def f():
     r4 :: object
     r5 :: str
     r6, r7, r8 :: object
-    r9, r10 :: None
+    r9 :: None
 L0:
     r0 = __main__.globals :: static
     r1 = unicode_1 :: static  ('x')
@@ -1368,9 +1362,8 @@ L0:
     r6 = getattr r4, r5
     r7 = box(int, r3)
     r8 = py_call(r6, r7)
-    r9 = unbox(None, r8)
-    r10 = None
-    return r10
+    r9 = None
+    return r9
 def __top_level__():
     r0, r1 :: object
     r2 :: bool
@@ -1388,7 +1381,7 @@ def __top_level__():
     r14 :: object
     r15 :: str
     r16, r17, r18 :: object
-    r19, r20 :: None
+    r19 :: None
 L0:
     r0 = builtins :: module
     r1 = builtins.None :: object
@@ -1413,9 +1406,8 @@ L2:
     r16 = getattr r14, r15
     r17 = box(int, r13)
     r18 = py_call(r16, r17)
-    r19 = unbox(None, r18)
-    r20 = None
-    return r20
+    r19 = None
+    return r19
 
 [case testCallOverloaded]
 import m
@@ -2674,15 +2666,12 @@ def g_a_obj.__call__(__mypyc_self__):
     r2 :: str
     r3 :: object
     r4 :: str
-    r5, r6 :: object
-    r7 :: None
-    r8, r9 :: object
-    r10 :: None
+    r5, r6, r7, r8 :: object
+    r9 :: str
+    r10 :: object
     r11 :: str
-    r12 :: object
-    r13 :: str
-    r14, r15 :: object
-    r16, r17 :: None
+    r12, r13 :: object
+    r14 :: None
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.g
@@ -2692,18 +2681,15 @@ L0:
     r4 = unicode_4 :: static  ('print')
     r5 = getattr r3, r4
     r6 = py_call(r5, r2)
-    r7 = unbox(None, r6)
-    r8 = r0.f
-    r9 = py_call(r8)
-    r10 = unbox(None, r9)
-    r11 = unicode_5 :: static  ('Exited')
-    r12 = builtins :: module
-    r13 = unicode_4 :: static  ('print')
-    r14 = getattr r12, r13
-    r15 = py_call(r14, r11)
-    r16 = unbox(None, r15)
-    r17 = None
-    return r17
+    r7 = r0.f
+    r8 = py_call(r7)
+    r9 = unicode_5 :: static  ('Exited')
+    r10 = builtins :: module
+    r11 = unicode_4 :: static  ('print')
+    r12 = getattr r10, r11
+    r13 = py_call(r12, r9)
+    r14 = None
+    return r14
 def a(f):
     f :: object
     r0 :: __main__.a_env
@@ -2739,15 +2725,12 @@ def g_b_obj.__call__(__mypyc_self__):
     r2 :: str
     r3 :: object
     r4 :: str
-    r5, r6 :: object
-    r7 :: None
-    r8, r9 :: object
-    r10 :: None
+    r5, r6, r7, r8 :: object
+    r9 :: str
+    r10 :: object
     r11 :: str
-    r12 :: object
-    r13 :: str
-    r14, r15 :: object
-    r16, r17 :: None
+    r12, r13 :: object
+    r14 :: None
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.g
@@ -2757,18 +2740,15 @@ L0:
     r4 = unicode_4 :: static  ('print')
     r5 = getattr r3, r4
     r6 = py_call(r5, r2)
-    r7 = unbox(None, r6)
-    r8 = r0.f
-    r9 = py_call(r8)
-    r10 = unbox(None, r9)
-    r11 = unicode_6 :: static  ('---')
-    r12 = builtins :: module
-    r13 = unicode_4 :: static  ('print')
-    r14 = getattr r12, r13
-    r15 = py_call(r14, r11)
-    r16 = unbox(None, r15)
-    r17 = None
-    return r17
+    r7 = r0.f
+    r8 = py_call(r7)
+    r9 = unicode_6 :: static  ('---')
+    r10 = builtins :: module
+    r11 = unicode_4 :: static  ('print')
+    r12 = getattr r10, r11
+    r13 = py_call(r12, r9)
+    r14 = None
+    return r14
 def b(f):
     f :: object
     r0 :: __main__.b_env
@@ -2805,7 +2785,7 @@ def __mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj.__call__(__myp
     r3 :: object
     r4 :: str
     r5, r6 :: object
-    r7, r8 :: None
+    r7 :: None
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.d
@@ -2815,9 +2795,8 @@ L0:
     r4 = unicode_4 :: static  ('print')
     r5 = getattr r3, r4
     r6 = py_call(r5, r2)
-    r7 = unbox(None, r6)
-    r8 = None
-    return r8
+    r7 = None
+    return r7
 def __mypyc_c_decorator_helper__():
     r0 :: __main__.__mypyc_c_decorator_helper___env
     r1 :: __main__.__mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj
@@ -2832,10 +2811,8 @@ def __mypyc_c_decorator_helper__():
     r12 :: str
     r13 :: object
     r14 :: str
-    r15, r16 :: object
-    r17 :: None
-    r18, r19 :: object
-    r20, r21 :: None
+    r15, r16, r17, r18 :: object
+    r19 :: None
 L0:
     r0 = __mypyc_c_decorator_helper___env()
     r1 = __mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj()
@@ -2854,12 +2831,10 @@ L0:
     r14 = unicode_4 :: static  ('print')
     r15 = getattr r13, r14
     r16 = py_call(r15, r12)
-    r17 = unbox(None, r16)
-    r18 = r0.d
-    r19 = py_call(r18)
-    r20 = unbox(None, r19)
-    r21 = None
-    return r21
+    r17 = r0.d
+    r18 = py_call(r17)
+    r19 = None
+    return r19
 def __top_level__():
     r0, r1 :: object
     r2 :: bool
@@ -2959,15 +2934,12 @@ def g_a_obj.__call__(__mypyc_self__):
     r2 :: str
     r3 :: object
     r4 :: str
-    r5, r6 :: object
-    r7 :: None
-    r8, r9 :: object
-    r10 :: None
+    r5, r6, r7, r8 :: object
+    r9 :: str
+    r10 :: object
     r11 :: str
-    r12 :: object
-    r13 :: str
-    r14, r15 :: object
-    r16, r17 :: None
+    r12, r13 :: object
+    r14 :: None
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.g
@@ -2977,18 +2949,15 @@ L0:
     r4 = unicode_4 :: static  ('print')
     r5 = getattr r3, r4
     r6 = py_call(r5, r2)
-    r7 = unbox(None, r6)
-    r8 = r0.f
-    r9 = py_call(r8)
-    r10 = unbox(None, r9)
-    r11 = unicode_5 :: static  ('Exited')
-    r12 = builtins :: module
-    r13 = unicode_4 :: static  ('print')
-    r14 = getattr r12, r13
-    r15 = py_call(r14, r11)
-    r16 = unbox(None, r15)
-    r17 = None
-    return r17
+    r7 = r0.f
+    r8 = py_call(r7)
+    r9 = unicode_5 :: static  ('Exited')
+    r10 = builtins :: module
+    r11 = unicode_4 :: static  ('print')
+    r12 = getattr r10, r11
+    r13 = py_call(r12, r9)
+    r14 = None
+    return r14
 def a(f):
     f :: object
     r0 :: __main__.a_env
@@ -3404,14 +3373,13 @@ def f(x):
     r0 :: object
     r1 :: str
     r2, r3, r4 :: object
-    r5 :: int
-    r6 :: None
+    r5 :: None
 L0:
     r0 = builtins :: module
     r1 = unicode_1 :: static  ('reveal_type')
     r2 = getattr r0, r1
     r3 = box(int, x)
     r4 = py_call(r2, r3)
-    r5 = unbox(int, r4)
-    r6 = None
-    return r6
+    r5 = None
+    return r5
+

--- a/mypyc/test-data/genops-try.test
+++ b/mypyc/test-data/genops-try.test
@@ -14,9 +14,8 @@ def g():
     r6 :: object
     r7 :: str
     r8, r9 :: object
-    r10 :: None
-    r11 :: bool
-    r12 :: None
+    r10 :: bool
+    r11 :: None
 L0:
 L1:
     r0 = builtins :: module
@@ -31,17 +30,16 @@ L2: (handler for L1)
     r7 = unicode_3 :: static  ('print')
     r8 = getattr r6, r7
     r9 = py_call(r8, r5)
-    r10 = unbox(None, r9)
 L3:
     restore_exc_info r4
     goto L5
 L4: (handler for L2)
     restore_exc_info r4
-    r11 = keep_propagating
+    r10 = keep_propagating
     unreachable
 L5:
-    r12 = None
-    return r12
+    r11 = None
+    return r11
 
 [case testTryExcept2]
 def g(b: bool) -> None:
@@ -64,9 +62,8 @@ def g(b):
     r8 :: object
     r9 :: str
     r10, r11 :: object
-    r12 :: None
-    r13 :: bool
-    r14 :: None
+    r12 :: bool
+    r13 :: None
 L0:
 L1:
     if b goto L2 else goto L3 :: bool
@@ -88,17 +85,16 @@ L5: (handler for L1, L2, L3, L4)
     r9 = unicode_4 :: static  ('print')
     r10 = getattr r8, r9
     r11 = py_call(r10, r7)
-    r12 = unbox(None, r11)
 L6:
     restore_exc_info r6
     goto L8
 L7: (handler for L5)
     restore_exc_info r6
-    r13 = keep_propagating
+    r12 = keep_propagating
     unreachable
 L8:
-    r14 = None
-    return r14
+    r13 = None
+    return r13
 
 [case testTryExcept3]
 def g() -> None:
@@ -115,31 +111,27 @@ def g():
     r0 :: str
     r1 :: object
     r2 :: str
-    r3, r4 :: object
-    r5 :: None
-    r6 :: object
-    r7 :: str
-    r8, r9 :: object
-    r10 :: tuple[object, object, object]
-    r11 :: object
-    r12 :: str
-    r13 :: object
-    r14 :: bool
-    e, r15 :: object
-    r16 :: str
-    r17 :: object
-    r18 :: str
-    r19, r20 :: object
-    r21 :: None
-    r22, r23 :: bool
-    r24 :: tuple[object, object, object]
+    r3, r4, r5 :: object
+    r6 :: str
+    r7, r8 :: object
+    r9 :: tuple[object, object, object]
+    r10 :: object
+    r11 :: str
+    r12 :: object
+    r13 :: bool
+    e, r14 :: object
+    r15 :: str
+    r16 :: object
+    r17 :: str
+    r18, r19 :: object
+    r20, r21 :: bool
+    r22 :: tuple[object, object, object]
+    r23 :: str
+    r24 :: object
     r25 :: str
-    r26 :: object
-    r27 :: str
-    r28, r29 :: object
-    r30 :: None
-    r31 :: bool
-    r32 :: None
+    r26, r27 :: object
+    r28 :: bool
+    r29 :: None
 L0:
 L1:
     r0 = unicode_1 :: static  ('a')
@@ -147,60 +139,57 @@ L1:
     r2 = unicode_2 :: static  ('print')
     r3 = getattr r1, r2
     r4 = py_call(r3, r0)
-    r5 = unbox(None, r4)
 L2:
-    r6 = builtins :: module
-    r7 = unicode_3 :: static  ('object')
-    r8 = getattr r6, r7
-    r9 = py_call(r8)
+    r5 = builtins :: module
+    r6 = unicode_3 :: static  ('object')
+    r7 = getattr r5, r6
+    r8 = py_call(r7)
     goto L8
 L3: (handler for L2)
-    r10 = error_catch
-    r11 = builtins :: module
-    r12 = unicode_4 :: static  ('AttributeError')
-    r13 = getattr r11, r12
-    r14 = exc_matches r13
-    if r14 goto L4 else goto L5 :: bool
+    r9 = error_catch
+    r10 = builtins :: module
+    r11 = unicode_4 :: static  ('AttributeError')
+    r12 = getattr r10, r11
+    r13 = exc_matches r12
+    if r13 goto L4 else goto L5 :: bool
 L4:
-    r15 = get_exc_value
-    e = r15
-    r16 = unicode_5 :: static  ('b')
-    r17 = builtins :: module
-    r18 = unicode_2 :: static  ('print')
-    r19 = getattr r17, r18
-    r20 = py_call(r19, r16, e)
-    r21 = unbox(None, r20)
+    r14 = get_exc_value
+    e = r14
+    r15 = unicode_5 :: static  ('b')
+    r16 = builtins :: module
+    r17 = unicode_2 :: static  ('print')
+    r18 = getattr r16, r17
+    r19 = py_call(r18, r15, e)
     goto L6
 L5:
-    reraise_exc; r22 = 0
+    reraise_exc; r20 = 0
     unreachable
 L6:
-    restore_exc_info r10
+    restore_exc_info r9
     goto L8
 L7: (handler for L3, L4, L5)
-    restore_exc_info r10
-    r23 = keep_propagating
+    restore_exc_info r9
+    r21 = keep_propagating
     unreachable
 L8:
     goto L12
 L9: (handler for L1, L6, L7, L8)
-    r24 = error_catch
-    r25 = unicode_6 :: static  ('weeee')
-    r26 = builtins :: module
-    r27 = unicode_2 :: static  ('print')
-    r28 = getattr r26, r27
-    r29 = py_call(r28, r25)
-    r30 = unbox(None, r29)
+    r22 = error_catch
+    r23 = unicode_6 :: static  ('weeee')
+    r24 = builtins :: module
+    r25 = unicode_2 :: static  ('print')
+    r26 = getattr r24, r25
+    r27 = py_call(r26, r23)
 L10:
-    restore_exc_info r24
+    restore_exc_info r22
     goto L12
 L11: (handler for L9)
-    restore_exc_info r24
-    r31 = keep_propagating
+    restore_exc_info r22
+    r28 = keep_propagating
     unreachable
 L12:
-    r32 = None
-    return r32
+    r29 = None
+    return r29
 
 [case testTryExcept4]
 def g() -> None:
@@ -220,19 +209,16 @@ def g():
     r5 :: str
     r6 :: object
     r7 :: str
-    r8, r9 :: object
-    r10 :: None
-    r11 :: object
-    r12 :: str
-    r13 :: object
-    r14 :: bool
-    r15 :: str
-    r16 :: object
-    r17 :: str
-    r18, r19 :: object
-    r20 :: None
-    r21, r22 :: bool
-    r23 :: None
+    r8, r9, r10 :: object
+    r11 :: str
+    r12 :: object
+    r13 :: bool
+    r14 :: str
+    r15 :: object
+    r16 :: str
+    r17, r18 :: object
+    r19, r20 :: bool
+    r21 :: None
 L0:
 L1:
     goto L9
@@ -249,35 +235,33 @@ L3:
     r7 = unicode_3 :: static  ('print')
     r8 = getattr r6, r7
     r9 = py_call(r8, r5)
-    r10 = unbox(None, r9)
     goto L7
 L4:
-    r11 = builtins :: module
-    r12 = unicode_4 :: static  ('IndexError')
-    r13 = getattr r11, r12
-    r14 = exc_matches r13
-    if r14 goto L5 else goto L6 :: bool
+    r10 = builtins :: module
+    r11 = unicode_4 :: static  ('IndexError')
+    r12 = getattr r10, r11
+    r13 = exc_matches r12
+    if r13 goto L5 else goto L6 :: bool
 L5:
-    r15 = unicode_5 :: static  ('yo')
-    r16 = builtins :: module
-    r17 = unicode_3 :: static  ('print')
-    r18 = getattr r16, r17
-    r19 = py_call(r18, r15)
-    r20 = unbox(None, r19)
+    r14 = unicode_5 :: static  ('yo')
+    r15 = builtins :: module
+    r16 = unicode_3 :: static  ('print')
+    r17 = getattr r15, r16
+    r18 = py_call(r17, r14)
     goto L7
 L6:
-    reraise_exc; r21 = 0
+    reraise_exc; r19 = 0
     unreachable
 L7:
     restore_exc_info r0
     goto L9
 L8: (handler for L2, L3, L4, L5, L6)
     restore_exc_info r0
-    r22 = keep_propagating
+    r20 = keep_propagating
     unreachable
 L9:
-    r23 = None
-    return r23
+    r21 = None
+    return r21
 
 [case testTryFinally]
 def a(b: bool) -> None:
@@ -299,9 +283,8 @@ def a(b):
     r10 :: object
     r11 :: str
     r12, r13 :: object
-    r14 :: None
-    r15, r16 :: bool
-    r17 :: None
+    r14, r15 :: bool
+    r16 :: None
 L0:
 L1:
     if b goto L2 else goto L3 :: bool
@@ -328,10 +311,9 @@ L7:
     r11 = unicode_4 :: static  ('print')
     r12 = getattr r10, r11
     r13 = py_call(r12, r9)
-    r14 = unbox(None, r13)
     if is_error(r6) goto L9 else goto L8
 L8:
-    reraise_exc; r15 = 0
+    reraise_exc; r14 = 0
     unreachable
 L9:
     goto L13
@@ -340,11 +322,11 @@ L10: (handler for L7, L8)
 L11:
     restore_exc_info r6
 L12:
-    r16 = keep_propagating
+    r15 = keep_propagating
     unreachable
 L13:
-    r17 = None
-    return r17
+    r16 = None
+    return r16
 
 [case testWith]
 from typing import Any
@@ -364,16 +346,15 @@ def foo(x):
     r10 :: object
     r11 :: str
     r12, r13 :: object
-    r14 :: None
-    r15 :: tuple[object, object, object]
-    r16 :: bool
-    r17 :: tuple[object, object, object]
-    r18, r19, r20, r21 :: object
-    r22, r23, r24 :: bool
-    r25, r26, r27 :: tuple[object, object, object]
-    r28, r29 :: object
-    r30, r31 :: bool
-    r32 :: None
+    r14 :: tuple[object, object, object]
+    r15 :: bool
+    r16 :: tuple[object, object, object]
+    r17, r18, r19, r20 :: object
+    r21, r22, r23 :: bool
+    r24, r25, r26 :: tuple[object, object, object]
+    r27, r28 :: object
+    r29, r30 :: bool
+    r31 :: None
 L0:
     r0 = py_call(x)
     r1 = type r0 :: object
@@ -392,58 +373,58 @@ L2:
     r11 = unicode_6 :: static  ('print')
     r12 = getattr r10, r11
     r13 = py_call(r12, r9)
-    r14 = unbox(None, r13)
     goto L8
 L3: (handler for L2)
-    r15 = error_catch
-    r16 = False
-    r8 = r16
-    r17 = get_exc_info
-    r18 = r17[0]
-    r19 = r17[1]
-    r20 = r17[2]
-    r21 = py_call(r3, r0, r18, r19, r20)
-    r22 = bool r21 :: object
-    if r22 goto L5 else goto L4 :: bool
+    r14 = error_catch
+    r15 = False
+    r8 = r15
+    r16 = get_exc_info
+    r17 = r16[0]
+    r18 = r16[1]
+    r19 = r16[2]
+    r20 = py_call(r3, r0, r17, r18, r19)
+    r21 = bool r20 :: object
+    if r21 goto L5 else goto L4 :: bool
 L4:
-    reraise_exc; r23 = 0
+    reraise_exc; r22 = 0
     unreachable
 L5:
 L6:
-    restore_exc_info r15
+    restore_exc_info r14
     goto L8
 L7: (handler for L3, L4, L5)
-    restore_exc_info r15
-    r24 = keep_propagating
+    restore_exc_info r14
+    r23 = keep_propagating
     unreachable
 L8:
 L9:
 L10:
-    r26 = <error> :: tuple[object, object, object]
-    r25 = r26
+    r25 = <error> :: tuple[object, object, object]
+    r24 = r25
     goto L12
 L11: (handler for L1, L6, L7, L8)
-    r27 = error_catch
-    r25 = r27
+    r26 = error_catch
+    r24 = r26
 L12:
     if r8 goto L13 else goto L14 :: bool
 L13:
-    r28 = builtins.None :: object
-    r29 = py_call(r3, r0, r28, r28, r28)
+    r27 = builtins.None :: object
+    r28 = py_call(r3, r0, r27, r27, r27)
 L14:
-    if is_error(r25) goto L16 else goto L15
+    if is_error(r24) goto L16 else goto L15
 L15:
-    reraise_exc; r30 = 0
+    reraise_exc; r29 = 0
     unreachable
 L16:
     goto L20
 L17: (handler for L12, L13, L14, L15)
-    if is_error(r25) goto L19 else goto L18
+    if is_error(r24) goto L19 else goto L18
 L18:
-    restore_exc_info r25
+    restore_exc_info r24
 L19:
-    r31 = keep_propagating
+    r30 = keep_propagating
     unreachable
 L20:
-    r32 = None
-    return r32
+    r31 = None
+    return r31
+


### PR DESCRIPTION
ExpressionStmts had their Expressions' unused results type-checked unnecessarily.

Fixes mypyc/mypyc#489.