### PR TITLE
Add an is_check parameter to report_config_data

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1195,7 +1195,9 @@ def find_cache_meta(id: str, path: str, manager: BuildManager) -> Optional[Cache
     # So that plugins can return data with tuples in it without
     # things silently always invalidating modules, we round-trip
     # the config data. This isn't beautiful.
-    plugin_data = json.loads(json.dumps(manager.plugin.report_config_data(id, path)))
+    plugin_data = json.loads(json.dumps(
+        manager.plugin.report_config_data(id, path, is_check=True)
+    ))
     if m.plugin_data != plugin_data:
         manager.log('Metadata abandoned for {}: plugin configuration differs'.format(id))
         return None
@@ -1404,7 +1406,7 @@ def write_cache(id: str, path: str, tree: MypyFile,
     data_str = json_dumps(data, manager.options.debug_cache)
     interface_hash = compute_hash(data_str)
 
-    plugin_data = manager.plugin.report_config_data(id, path)
+    plugin_data = manager.plugin.report_config_data(id, path, is_check=False)
 
     # Obtain and set up metadata
     try:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -50,7 +50,7 @@ from mypy.parse import parse
 from mypy.stats import dump_type_stats
 from mypy.types import Type
 from mypy.version import __version__
-from mypy.plugin import Plugin, ChainedPlugin, plugin_types
+from mypy.plugin import Plugin, ChainedPlugin, plugin_types, ReportConfigContext
 from mypy.plugins.default import DefaultPlugin
 from mypy.fscache import FileSystemCache
 from mypy.metastore import MetadataStore, FilesystemMetadataStore, SqliteMetadataStore
@@ -1196,7 +1196,7 @@ def find_cache_meta(id: str, path: str, manager: BuildManager) -> Optional[Cache
     # things silently always invalidating modules, we round-trip
     # the config data. This isn't beautiful.
     plugin_data = json.loads(json.dumps(
-        manager.plugin.report_config_data(id, path, is_check=True)
+        manager.plugin.report_config_data(ReportConfigContext(id, path, is_check=True))
     ))
     if m.plugin_data != plugin_data:
         manager.log('Metadata abandoned for {}: plugin configuration differs'.format(id))
@@ -1406,7 +1406,7 @@ def write_cache(id: str, path: str, tree: MypyFile,
     data_str = json_dumps(data, manager.options.debug_cache)
     interface_hash = compute_hash(data_str)
 
-    plugin_data = manager.plugin.report_config_data(id, path, is_check=False)
+    plugin_data = manager.plugin.report_config_data(ReportConfigContext(id, path, is_check=False))
 
     # Obtain and set up metadata
     try:

--- a/mypy/interpreted_plugin.py
+++ b/mypy/interpreted_plugin.py
@@ -41,7 +41,7 @@ class InterpretedPlugin:
         assert self._modules is not None
         return lookup_fully_qualified(fullname, self._modules)
 
-    def report_config_data(self, id: str, path: str) -> Any:
+    def report_config_data(self, id: str, path: str, is_check: bool) -> Any:
         return None
 
     def get_additional_deps(self, file: MypyFile) -> List[Tuple[int, str, int]]:

--- a/mypy/interpreted_plugin.py
+++ b/mypy/interpreted_plugin.py
@@ -41,7 +41,7 @@ class InterpretedPlugin:
         assert self._modules is not None
         return lookup_fully_qualified(fullname, self._modules)
 
-    def report_config_data(self, id: str, path: str, is_check: bool) -> Any:
+    def report_config_data(self, ctx: 'mypy.plugin.ReportConfigContext') -> Any:
         return None
 
     def get_additional_deps(self, file: MypyFile) -> List[Tuple[int, str, int]]:

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -351,6 +351,15 @@ class SemanticAnalyzerPluginInterface:
         raise NotImplementedError
 
 
+# A context for querying for configuration data about a module for
+# cache invalidation purposes.
+ReportConfigContext = NamedTuple(
+    'DynamicClassDefContext', [
+        ('id', str),        # Module name
+        ('path', str),      # Module file path
+        ('is_check', bool)  # Is this invocation for checking whether the config matches
+    ])
+
 # A context for a function hook that infers the return type of a function with
 # a special signature.
 #
@@ -459,7 +468,7 @@ class Plugin(CommonPluginApi):
         assert self._modules is not None
         return lookup_fully_qualified(fullname, self._modules)
 
-    def report_config_data(self, id: str, path: str, is_check: bool) -> Any:
+    def report_config_data(self, ctx: ReportConfigContext) -> Any:
         """Get representation of configuration data for a module.
 
         The data must be encodable as JSON and will be stored in the
@@ -467,11 +476,11 @@ class Plugin(CommonPluginApi):
         values and the returned will result in that module's cache
         being invalidated and the module being rechecked.
 
-        If is_check is true, then the return of this call will be
-        checked against the cached version. Otherwise the call is
-        being made to determine what to put in the cache. This can be
-        used to allow consulting extra cache files in certain complex
-        situations.
+        If is_check in the context is true, then the return of this
+        call will be checked against the cached version. Otherwise the
+        call is being made to determine what to put in the cache. This
+        can be used to allow consulting extra cache files in certain
+        complex situations.
 
         This can be used to incorporate external configuration information
         that might require changes to typechecking.
@@ -686,8 +695,8 @@ class WrapperPlugin(Plugin):
     def lookup_fully_qualified(self, fullname: str) -> Optional[SymbolTableNode]:
         return self.plugin.lookup_fully_qualified(fullname)
 
-    def report_config_data(self, id: str, path: str, is_check: bool) -> Any:
-        return self.plugin.report_config_data(id, path, is_check)
+    def report_config_data(self, ctx: ReportConfigContext) -> Any:
+        return self.plugin.report_config_data(ctx)
 
     def get_additional_deps(self, file: MypyFile) -> List[Tuple[int, str, int]]:
         return self.plugin.get_additional_deps(file)
@@ -757,8 +766,8 @@ class ChainedPlugin(Plugin):
         for plugin in self._plugins:
             plugin.set_modules(modules)
 
-    def report_config_data(self, id: str, path: str, is_check: bool) -> Any:
-        config_data = [plugin.report_config_data(id, path, is_check) for plugin in self._plugins]
+    def report_config_data(self, ctx: ReportConfigContext) -> Any:
+        config_data = [plugin.report_config_data(ctx) for plugin in self._plugins]
         return config_data if any(x is not None for x in config_data) else None
 
     def get_additional_deps(self, file: MypyFile) -> List[Tuple[int, str, int]]:

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -476,6 +476,10 @@ class Plugin(CommonPluginApi):
         values and the returned will result in that module's cache
         being invalidated and the module being rechecked.
 
+        This can be called twice for each module, once after loading
+        the cache to check if it is valid and once while writing new
+        cache information.
+
         If is_check in the context is true, then the return of this
         call will be checked against the cached version. Otherwise the
         call is being made to determine what to put in the cache. This

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -484,7 +484,6 @@ class Plugin(CommonPluginApi):
 
         This can be used to incorporate external configuration information
         that might require changes to typechecking.
-
         """
         return None
 

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -459,7 +459,7 @@ class Plugin(CommonPluginApi):
         assert self._modules is not None
         return lookup_fully_qualified(fullname, self._modules)
 
-    def report_config_data(self, id: str, path: str) -> Any:
+    def report_config_data(self, id: str, path: str, is_check: bool) -> Any:
         """Get representation of configuration data for a module.
 
         The data must be encodable as JSON and will be stored in the
@@ -467,8 +467,15 @@ class Plugin(CommonPluginApi):
         values and the returned will result in that module's cache
         being invalidated and the module being rechecked.
 
+        If is_check is true, then the return of this call will be
+        checked against the cached version. Otherwise the call is
+        being made to determine what to put in the cache. This can be
+        used to allow consulting extra cache files in certain complex
+        situations.
+
         This can be used to incorporate external configuration information
         that might require changes to typechecking.
+
         """
         return None
 
@@ -679,8 +686,8 @@ class WrapperPlugin(Plugin):
     def lookup_fully_qualified(self, fullname: str) -> Optional[SymbolTableNode]:
         return self.plugin.lookup_fully_qualified(fullname)
 
-    def report_config_data(self, id: str, path: str) -> Any:
-        return self.plugin.report_config_data(id, path)
+    def report_config_data(self, id: str, path: str, is_check: bool) -> Any:
+        return self.plugin.report_config_data(id, path, is_check)
 
     def get_additional_deps(self, file: MypyFile) -> List[Tuple[int, str, int]]:
         return self.plugin.get_additional_deps(file)
@@ -750,8 +757,8 @@ class ChainedPlugin(Plugin):
         for plugin in self._plugins:
             plugin.set_modules(modules)
 
-    def report_config_data(self, id: str, path: str) -> Any:
-        config_data = [plugin.report_config_data(id, path) for plugin in self._plugins]
+    def report_config_data(self, id: str, path: str, is_check: bool) -> Any:
+        config_data = [plugin.report_config_data(id, path, is_check) for plugin in self._plugins]
         return config_data if any(x is not None for x in config_data) else None
 
     def get_additional_deps(self, file: MypyFile) -> List[Tuple[int, str, int]]:

--- a/test-data/unit/plugins/config_data.py
+++ b/test-data/unit/plugins/config_data.py
@@ -3,15 +3,15 @@ import json
 
 from typing import Any
 
-from mypy.plugin import Plugin
+from mypy.plugin import Plugin, ReportConfigContext
 
 
 class ConfigDataPlugin(Plugin):
-    def report_config_data(self, id: str, path: str, is_check: bool) -> Any:
+    def report_config_data(self, ctx: ReportConfigContext) -> Any:
         path = os.path.join('tmp/test.json')
         with open(path) as f:
             data = json.load(f)
-        return data.get(id)
+        return data.get(ctx.id)
 
 
 def plugin(version):

--- a/test-data/unit/plugins/config_data.py
+++ b/test-data/unit/plugins/config_data.py
@@ -7,7 +7,7 @@ from mypy.plugin import Plugin
 
 
 class ConfigDataPlugin(Plugin):
-    def report_config_data(self, id: str, path: str) -> Any:
+    def report_config_data(self, id: str, path: str, is_check: bool) -> Any:
         path = os.path.join('tmp/test.json')
         with open(path) as f:
             data = json.load(f)


### PR DESCRIPTION
This allows plugins to implement more elaborate checking where they do some checks
themselves while producing config data.