### PR TITLE
Add tests for double forward references in NamedTuple and TypedDict

### DIFF
--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -871,3 +871,28 @@ b = (1, 2)
 if not b:
     ''()  # E: "str" not callable
 [builtins fixtures/tuple.pyi]
+
+[case testNamedTupleDoubleForward]
+from typing import Union, Mapping, NamedTuple
+
+class MyBaseTuple(NamedTuple):
+    base_field_1: int
+    base_field_2: int
+
+MyBaseTupleMapping = Mapping[MyBaseTuple, int]
+MyTupleUnion = Union[MyTupleA, MyTupleB]
+
+class MyTupleA(NamedTuple):
+    field_1: MyBaseTupleMapping
+    field_2: MyBaseTuple
+
+
+class MyTupleB(NamedTuple):
+    field_1: MyBaseTupleMapping
+    field_2: MyBaseTuple
+
+u: MyTupleUnion
+reveal_type(u.field_1)  # N: Revealed type is 'typing.Mapping[Tuple[builtins.int, builtins.int, fallback=__main__.MyBaseTuple], builtins.int]'
+reveal_type(u.field_2)  # N: Revealed type is 'Tuple[builtins.int, builtins.int, fallback=__main__.MyBaseTuple]'
+reveal_type(u[0])  # N: Revealed type is 'typing.Mapping[Tuple[builtins.int, builtins.int, fallback=__main__.MyBaseTuple], builtins.int]'
+reveal_type(u[1])  # N: Revealed type is 'Tuple[builtins.int, builtins.int, fallback=__main__.MyBaseTuple]'

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1937,3 +1937,53 @@ class DummyTypedDict(TypedDict):
 
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
+
+[case testTypedDictDoubleForwardClass]
+from mypy_extensions import TypedDict
+from typing import Any, List
+
+class Foo(TypedDict):
+    bar: Bar
+    baz: Bar
+
+Bar = List[Any]
+
+foo: Foo
+reveal_type(foo['bar'])  # N: Revealed type is 'builtins.list[Any]'
+reveal_type(foo['baz'])  # N: Revealed type is 'builtins.list[Any]'
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
+
+[case testTypedDictDoubleForwardFunc]
+from mypy_extensions import TypedDict
+from typing import Any, List
+
+Foo = TypedDict('Foo', {'bar': Bar, 'baz': Bar})
+
+Bar = List[Any]
+
+foo: Foo
+reveal_type(foo['bar'])   # N: Revealed type is 'builtins.list[Any]'
+reveal_type(foo['baz'])  # N: Revealed type is 'builtins.list[Any]'
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
+
+[case testTypedDictDoubleForwardMixed]
+from mypy_extensions import TypedDict
+from typing import Any, List
+
+Bar = List[Any]
+
+class Foo(TypedDict):
+    foo: Toto
+    bar: Bar
+    baz: Bar
+
+Toto = int
+
+foo: Foo
+reveal_type(foo['foo'])  # N: Revealed type is 'builtins.int'
+reveal_type(foo['bar'])  # N: Revealed type is 'builtins.list[Any]'
+reveal_type(foo['baz'])  # N: Revealed type is 'builtins.list[Any]'
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/4812

The fix itself was likely the new semantic analyzer. I just add test cases from the issue.