### PR TITLE
[mypyc] Support incremental compilation

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -100,6 +100,7 @@ def get_mypy_config(paths: List[str],
     options.show_traceback = True
     # Needed to get types for all AST nodes
     options.export_types = True
+    # We use mypy incremental mode when doing separate/incremental mypyc compilation
     options.incremental = compiler_options.separate
     options.preserve_asts = True
 

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -2,6 +2,8 @@ MYPY = False
 if MYPY:
     from typing_extensions import Final
 
+BUILD_DIR = 'build'
+
 PREFIX = 'CPyPy_'  # type: Final # Python wrappers
 NATIVE_PREFIX = 'CPyDef_'  # type: Final # Native functions etc.
 DUNDER_PREFIX = 'CPyDunder_'  # type: Final # Wrappers for exposing dunder methods to the API

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -14,7 +14,7 @@ It would be translated to something that conceptually looks like this:
    return r3
 """
 from typing import (
-    TypeVar, Callable, Dict, List, Tuple, Optional, Union, Sequence, Set, Any, cast
+    TypeVar, Callable, Dict, List, Tuple, Optional, Union, Sequence, Set, Any, Iterable, cast
 )
 from typing_extensions import overload, NoReturn
 from collections import OrderedDict
@@ -68,7 +68,8 @@ from mypyc.ops import (
     NAMESPACE_TYPE, NAMESPACE_MODULE,
     RaiseStandardError, LoadErrorValue, NO_TRACEBACK_LINE_NO, FuncDecl,
     FUNC_NORMAL, FUNC_STATICMETHOD, FUNC_CLASSMETHOD,
-    RUnion, is_optional_type, optional_value_type, all_concrete_classes
+    RUnion, is_optional_type, optional_value_type, all_concrete_classes,
+    DeserMaps,
 )
 from mypyc.ops_primitive import binary_ops, unary_ops, func_ops, method_ops, name_ref_ops
 from mypyc.ops_list import (
@@ -153,14 +154,23 @@ def build_type_map(mapper: 'Mapper',
     # so that we can easily pick out the right copy of a function that
     # is conditionally defined.
     for module in modules:
-        for name, node in module.names.items():
-            # We need to filter out functions that are imported or
-            # aliases.  The best way to do this seems to be by
-            # checking that the fullname matches.
-            if (isinstance(node.node, (FuncDef, Decorator, OverloadedFuncDef))
-                    and node.fullname == module.fullname() + '.' + name):
-                prepare_func_def(module.fullname(), None, get_func_def(node.node), mapper)
+        for func in get_module_func_defs(module):
+            prepare_func_def(module.fullname(), None, func, mapper)
             # TODO: what else?
+
+
+def load_type_map(mapper: 'Mapper',
+                  modules: List[MypyFile],
+                  deser_ctx: DeserMaps) -> None:
+    """Populate a Mapper with deserialized IR from a list of modules."""
+    for module in modules:
+        for node in module.defs:
+            if isinstance(node, ClassDef):
+                mapper.type_to_ir[node.info] = deser_ctx.classes[node.fullname]
+
+    for module in modules:
+        for func in get_module_func_defs(module):
+            mapper.func_to_decl[func] = deser_ctx.functions[func.fullname()].decl
 
 
 @strict_optional_dec  # Turn on strict optional for any type manipulations we do
@@ -176,7 +186,6 @@ def build_ir(modules: List[MypyFile],
     result = OrderedDict()  # type: ModuleIRs
 
     # Generate IR for all modules.
-    module_names = [mod.fullname() for mod in modules]
     class_irs = []
 
     for module in modules:
@@ -186,7 +195,7 @@ def build_ir(modules: List[MypyFile],
 
         # Second pass.
         builder = IRBuilder(
-            module.fullname(), types, graph, errors, mapper, module_names, pbv, options
+            module.fullname(), types, graph, errors, mapper, pbv, options
         )
         builder.visit_mypy_file(module)
         module_ir = ModuleIR(
@@ -281,6 +290,17 @@ def get_func_def(op: Union[FuncDef, Decorator, OverloadedFuncDef]) -> FuncDef:
     if isinstance(op, Decorator):
         op = op.func
     return op
+
+
+def get_module_func_defs(module: MypyFile) -> Iterable[FuncDef]:
+    """Collect all of the (non-method) functions declared in a module."""
+    for name, node in module.names.items():
+        # We need to filter out functions that are imported or
+        # aliases.  The best way to do this seems to be by
+        # checking that the fullname matches.
+        if (isinstance(node.node, (FuncDef, Decorator, OverloadedFuncDef))
+                and node.fullname == module.fullname() + '.' + name):
+            yield get_func_def(node.node)
 
 
 def specialize_parent_vtable(cls: ClassIR, parent: ClassIR) -> VTableEntries:
@@ -1049,7 +1069,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                  graph: Graph,
                  errors: Errors,
                  mapper: Mapper,
-                 modules: List[str],
                  pbv: PreBuildVisitor,
                  options: CompilerOptions) -> None:
         self.current_module = current_module
@@ -1062,7 +1081,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         self.functions = []  # type: List[FuncIR]
         self.classes = []  # type: List[ClassIR]
         self.final_names = []  # type: List[Tuple[str, RType]]
-        self.modules = set(modules)
         self.callable_class_names = set()  # type: Set[str]
         self.options = options
 
@@ -2851,11 +2869,14 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         value = bytes(expr.value, 'utf8').decode('unicode-escape').encode('raw-unicode-escape')
         return self.load_static_bytes(value)
 
+    def is_native_module(self, module: str) -> bool:
+        return module in self.mapper.group_map
+
     def is_native_ref_expr(self, expr: RefExpr) -> bool:
         if expr.node is None:
             return False
         if '.' in expr.node.fullname():
-            return expr.node.fullname().rpartition('.')[0] in self.modules
+            return self.is_native_module(expr.node.fullname().rpartition('.')[0])
         return True
 
     def is_native_module_ref_expr(self, expr: RefExpr) -> bool:
@@ -2892,7 +2913,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 if is_final:
                     final_var = sym.node
                     fullname = '{}.{}'.format(sym.node.info.fullname(), final_var.name())
-                    native = expr.expr.node.module_name in self.modules
+                    native = self.is_native_module(expr.expr.node.module_name)
         elif self.is_module_member_expr(expr):
             # a module attribute
             if isinstance(expr.node, Var) and expr.node.is_final:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -2870,6 +2870,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         return self.load_static_bytes(value)
 
     def is_native_module(self, module: str) -> bool:
+        """Is the given module one compiled by mypyc?"""
         return module in self.mapper.group_map
 
     def is_native_ref_expr(self, expr: RefExpr) -> bool:

--- a/mypyc/test-data/run-multimodule.test
+++ b/mypyc/test-data/run-multimodule.test
@@ -554,4 +554,180 @@ print(y)
 2
 [out2]
 3
-[rechecked other]
+[rechecked other, other_b]
+
+[case testIncrementalCompilation1]
+from other_a import A
+from other_b import z
+
+a = A()
+assert a.y == z
+
+[file other_a.py]
+from other_b import z
+
+class A:
+    def __init__(self) -> None:
+        self.y = z
+[file other_a.py.2]
+from other_b import z
+
+class A:
+    def __init__(self) -> None:
+        self.x = 'test'
+        self.y = z
+[file other_b.py]
+import other_a
+
+z = 10
+
+def foo() -> 'other_a.A':
+    return other_a.A()
+[file other_b.py.3]
+import other_a
+
+z = 20
+
+def foo() -> 'other_a.A':
+    return other_a.A()
+
+[file driver.py]
+from native import a
+print(a.y, getattr(a, 'x', None))
+
+[out]
+10 None
+[out2]
+10 test
+[out3]
+20 test
+
+[rechecked other_a, other_b, native]
+[rechecked2 other_a, other_b]
+
+
+-- This one tests a group that is not an SCC.
+[case testIncrementalCompilation2]
+# separate: [(["other_a.py", "other_b.py"], "stuff")]
+from other_a import A
+from other_b import z
+
+a = A()
+assert a.y == z
+
+[file other_a.py]
+from other_b import z
+
+class A:
+    def __init__(self) -> None:
+        self.y = z
+[file other_a.py.2]
+from other_b import z
+
+class A:
+    def __init__(self) -> None:
+        self.x = 'test'
+        self.y = z
+
+[file other_b.py]
+z = 10
+
+[file driver.py]
+from native import a
+print(a.y, getattr(a, 'x', None))
+
+[out]
+10 None
+[out2]
+10 test
+
+[rechecked other_a, other_b, native]
+
+[case testIncrementalCompilation3]
+from other import X
+Y = X
+def foo() -> int:
+    return X
+
+[file other.py]
+from typing_extensions import Final
+X: Final = 10
+
+[file other.py.2]
+from typing_extensions import Final
+X: Final = 20
+
+[file driver.py]
+import native
+import other
+assert native.Y == other.X
+assert native.foo() == other.X
+
+[rechecked native, other]
+
+-- This one tests a group changing
+[case testIncrementalCompilation4]
+# separate: [(["other_a.py", "other_b.py"], "stuff")]
+# separate2: []
+from other_a import A
+from other_b import z
+
+a = A()
+assert a.y == z
+
+[file other_a.py]
+from other_b import z
+
+class A:
+    def __init__(self) -> None:
+        self.y = z
+
+[file other_b.py]
+z = 10
+
+[file wtvr.py.2]
+
+[file driver.py]
+from native import a
+print(a.y, getattr(a, 'x', None))
+
+[out]
+10 None
+[out2]
+10 None
+
+[rechecked other_a, other_b, native]
+
+-- This one tests cases where other modules *do not* need rechecked
+[case testIncrementalCompilation5]
+import other_a
+[file other_a.py]
+from other_b import f
+assert f(10) == 20
+[file other_a.py.2]
+from other_b import f
+assert f(20) == 40
+
+[file other_b.py]
+def f(x: int) -> int:
+    return x * 2
+
+[file driver.py]
+import native
+
+[rechecked other_a]
+
+-- Delete one of the C files and make sure this forces recompilation
+[case testIncrementalCompilation6]
+import other_a
+assert other_a.foo() == 10
+[file other_a.py]
+def foo() -> int: return 10
+
+
+[delete build/__native_other_a.c.2]
+
+[file driver.py]
+import native
+
+[rechecked native, other_a]

--- a/mypyc/test-data/run-multimodule.test
+++ b/mypyc/test-data/run-multimodule.test
@@ -557,11 +557,14 @@ print(y)
 [rechecked other, other_b]
 
 [case testIncrementalCompilation1]
+import non_native
 from other_a import A
 from other_b import z
 
 a = A()
 assert a.y == z
+
+assert non_native.foo() == 0
 
 [file other_a.py]
 from other_b import z
@@ -591,6 +594,18 @@ z = 20
 def foo() -> 'other_a.A':
     return other_a.A()
 
+[file non_native.py]
+import other_a
+
+def foo() -> int:
+    return 0
+
+[file non_native.py.4]
+import other_a
+
+def foo() -> float:
+    return 0
+
 [file driver.py]
 from native import a
 print(a.y, getattr(a, 'x', None))
@@ -601,9 +616,12 @@ print(a.y, getattr(a, 'x', None))
 10 test
 [out3]
 20 test
+[out4]
+20 test
 
-[rechecked other_a, other_b, native]
+[rechecked other_a, other_b, native, non_native]
 [rechecked2 other_a, other_b]
+[rechecked3 native, non_native]
 
 
 -- This one tests a group that is not an SCC.

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -25,7 +25,7 @@ from mypyc.build import construct_groups
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, TESTUTIL_PATH,
     use_custom_builtins, MypycDataSuite, assert_test_output,
-    show_c
+    show_c, fudge_dir_mtimes,
 )
 from mypyc.test.test_serialization import check_serialization_roundtrip
 
@@ -97,15 +97,6 @@ def chdir_manager(target: str) -> Iterator[None]:
         yield
     finally:
         os.chdir(dir)
-
-
-def fudge_dir_mtimes(dir: str, delta: int) -> None:
-    for dirpath, _, filenames in os.walk(dir):
-        for name in filenames:
-            # if name.endswith(('.c', '.h')): continue
-            path = os.path.join(dirpath, name)
-            new_mtime = os.stat(path).st_mtime + delta
-            os.utime(path, times=(new_mtime, new_mtime))
 
 
 class TestRun(MypycDataSuite):

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -40,7 +40,7 @@ files = [
 ]
 
 setup_format = """\
-from distutils.core import setup
+from setuptools import setup
 from mypyc.build import mypycify
 
 setup(name='test_run_output',

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -195,3 +195,11 @@ def show_c(cfiles: List[List[Tuple[str, str]]]) -> None:
             print('== {} =='.format(cfile))
             print_with_line_numbers(ctext)
     heading('End C')
+
+
+def fudge_dir_mtimes(dir: str, delta: int) -> None:
+    for dirpath, _, filenames in os.walk(dir):
+        for name in filenames:
+            path = os.path.join(dirpath, name)
+            new_mtime = os.stat(path).st_mtime + delta
+            os.utime(path, times=(new_mtime, new_mtime))


### PR DESCRIPTION
This works by reworking IR generation to proceed a SCC at a time and
writing out caches of serialized IR information so that we can
generated code that calls into a module without compiling the module
in full. A mypy plugin is used to ensure cache validity by checking
that a hash of the metadata matches and that all of the generated source
is present and matches.

Closes mypyc/mypyc#682.