### PR TITLE
Show closest candidates for misspellings : keyword argument case

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1284,7 +1284,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                         assert actual_names, "Internal error: named kinds without names given"
                         act_name = actual_names[i]
                         assert act_name is not None
-                        messages.unexpected_keyword_argument(callee, act_name, context)
+                        act_type = actual_types[i]
+                        messages.unexpected_keyword_argument(callee, act_name, act_type, context)
                     is_unexpected_arg_error = True
             elif ((kind == nodes.ARG_STAR and nodes.ARG_STAR not in callee.arg_kinds)
                   or kind == nodes.ARG_STAR2):

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -587,8 +587,7 @@ class MessageBuilder:
         if not matches:
             matches = best_matches(name, not_matching_type_args)
         if matches:
-            suggestion = ";  did you mean {}?".format(pretty_or(matches[:3]))
-            msg += "{}".format(suggestion)
+            msg += "; did you mean {}?".format(pretty_or(matches[:3]))
         self.fail(msg, context, code=codes.CALL_ARG)
         module = find_defining_module(self.modules, callee)
         if module:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -575,12 +575,12 @@ class MessageBuilder:
         msg = 'Unexpected keyword argument "{}"'.format(name) + for_function(callee)
         # Suggest intended keyword, look for same type match else check for any match.
         matches = []
-        same_type_args = []
+        matching_type_args = []
         for i, kwarg_type in enumerate(callee.arg_types):
             callee_arg_name = callee.arg_names[i]
-            if callee_arg_name is not None and is_same_type(kwarg_type, arg_type):
-                same_type_args.append(callee_arg_name)
-        matches.extend(best_matches(name, same_type_args))
+            if callee_arg_name is not None and (is_same_type(arg_type, kwarg_type) or is_subtype(arg_type, kwarg_type)):
+                matching_type_args.append(callee_arg_name)
+        matches.extend(best_matches(name, matching_type_args))
         if not matches:
             matches.extend(best_matches(name, list(filter(None, callee.arg_names))))
         if matches:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -573,6 +573,11 @@ class MessageBuilder:
     def unexpected_keyword_argument(self, callee: CallableType, name: str,
                                     context: Context) -> None:
         msg = 'Unexpected keyword argument "{}"'.format(name) + for_function(callee)
+        # Suggest intended keyword, if any match is found.
+        matches = best_matches(name, list(filter(None, callee.arg_names)))[:3]
+        if matches:
+            suggestion = ";  did you mean {}?".format(pretty_or(matches))
+            msg += "{}".format(suggestion)
         self.fail(msg, context, code=codes.CALL_ARG)
         module = find_defining_module(self.modules, callee)
         if module:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -578,7 +578,8 @@ class MessageBuilder:
         matching_type_args = []
         for i, kwarg_type in enumerate(callee.arg_types):
             callee_arg_name = callee.arg_names[i]
-            if callee_arg_name is not None and (is_same_type(arg_type, kwarg_type) or is_subtype(arg_type, kwarg_type)):
+            if (callee_arg_name is not None and
+                    (is_same_type(arg_type, kwarg_type) or is_subtype(arg_type, kwarg_type))):
                 matching_type_args.append(callee_arg_name)
         matches.extend(best_matches(name, matching_type_args))
         if not matches:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -573,14 +573,14 @@ class MessageBuilder:
     def unexpected_keyword_argument(self, callee: CallableType, name: str, arg_type: Type,
                                     context: Context) -> None:
         msg = 'Unexpected keyword argument "{}"'.format(name) + for_function(callee)
-        # Suggest intended keyword, if any typed match is found else if any match is found.
+        # Suggest intended keyword, look for same type match else check for any match.
         matches = []
-        if arg_type:
-            same_type_args = []
-            for i, kwarg_type in enumerate(callee.arg_types):
-                if callee.arg_names[i] is not None and is_same_type(kwarg_type, arg_type):
-                    same_type_args.append(callee.arg_names[i])
-            matches.extend(best_matches(name, same_type_args))
+        same_type_args = []
+        for i, kwarg_type in enumerate(callee.arg_types):
+            callee_arg_name = callee.arg_names[i]
+            if callee_arg_name is not None and is_same_type(kwarg_type, arg_type):
+                same_type_args.append(callee_arg_name)
+        matches.extend(best_matches(name, same_type_args))
         if not matches:
             matches.extend(best_matches(name, list(filter(None, callee.arg_names))))
         if matches:

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -115,6 +115,28 @@ def f(atter: float, btter: int) -> None: pass # N: "f" defined here
 x: int = 5
 f(otter=x) # E: Unexpected keyword argument "otter" for "f";  did you mean "btter" or "atter"?
 
+[case testKeywordMisspellingVarArgs]
+def f(other: 'A', *atter: 'A') -> None: pass # N: "f" defined here
+f(otter=A()) # E: Unexpected keyword argument "otter" for "f";  did you mean "other"?
+class A: pass
+
+[case testKeywordMisspellingOnlyVarArgs]
+def f(*other: 'A') -> None: pass # N: "f" defined here
+f(otter=A()) # E: Unexpected keyword argument "otter" for "f"
+class A: pass
+
+[case testKeywordMisspellingVarArgsDifferentTypes]
+def f(other: 'B', *atter: 'A') -> None: pass # N: "f" defined here
+f(otter=A()) # E: Unexpected keyword argument "otter" for "f";  did you mean "other"?
+class A: pass
+class B: pass
+
+[case testKeywordMisspellingVarKwargs]
+def f(other: 'A', **atter: 'A') -> None: pass
+f(otter=A()) # E: Missing positional argument "other" in call to "f"
+class A: pass
+[builtins fixtures/dict.pyi]
+
 [case testKeywordArgumentsWithDynamicallyTypedCallable]
 from typing import Any
 f = None # type: Any

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -88,24 +88,24 @@ class A: pass
 
 [case testKeywordMisspelling]
 def f(other: 'A') -> None: pass # N: "f" defined here
-f(otter=A()) # E: Unexpected keyword argument "otter" for "f";  did you mean "other"?
+f(otter=A()) # E: Unexpected keyword argument "otter" for "f"; did you mean "other"?
 class A: pass
 
 [case testMultipleKeywordsForMisspelling]
 def f(thing : 'A', other: 'A', atter: 'A', btter: 'B') -> None: pass # N: "f" defined here
-f(otter=A()) # E: Unexpected keyword argument "otter" for "f";  did you mean "other" or "atter"?
+f(otter=A()) # E: Unexpected keyword argument "otter" for "f"; did you mean "other" or "atter"?
 class A: pass
 class B: pass
 
 [case testKeywordMisspellingDifferentType]
 def f(other: 'A') -> None: pass # N: "f" defined here
-f(otter=B()) # E: Unexpected keyword argument "otter" for "f";  did you mean "other"?
+f(otter=B()) # E: Unexpected keyword argument "otter" for "f"; did you mean "other"?
 class A: pass
 class B: pass
 
 [case testKeywordMisspellingInheritance]
 def f(atter: 'A', btter: 'B', ctter: 'C') -> None: pass # N: "f" defined here
-f(otter=B()) # E: Unexpected keyword argument "otter" for "f";  did you mean "btter" or "atter"?
+f(otter=B()) # E: Unexpected keyword argument "otter" for "f"; did you mean "btter" or "atter"?
 class A: pass
 class B(A): pass
 class C: pass
@@ -113,11 +113,11 @@ class C: pass
 [case testKeywordMisspellingFloatInt]
 def f(atter: float, btter: int) -> None: pass # N: "f" defined here
 x: int = 5
-f(otter=x) # E: Unexpected keyword argument "otter" for "f";  did you mean "btter" or "atter"?
+f(otter=x) # E: Unexpected keyword argument "otter" for "f"; did you mean "btter" or "atter"?
 
 [case testKeywordMisspellingVarArgs]
 def f(other: 'A', *atter: 'A') -> None: pass # N: "f" defined here
-f(otter=A()) # E: Unexpected keyword argument "otter" for "f";  did you mean "other"?
+f(otter=A()) # E: Unexpected keyword argument "otter" for "f"; did you mean "other"?
 class A: pass
 
 [case testKeywordMisspellingOnlyVarArgs]
@@ -127,7 +127,7 @@ class A: pass
 
 [case testKeywordMisspellingVarArgsDifferentTypes]
 def f(other: 'B', *atter: 'A') -> None: pass # N: "f" defined here
-f(otter=A()) # E: Unexpected keyword argument "otter" for "f";  did you mean "other"?
+f(otter=A()) # E: Unexpected keyword argument "otter" for "f"; did you mean "other"?
 class A: pass
 class B: pass
 

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -86,13 +86,22 @@ def f(a: 'A') -> None: pass # N: "f" defined here
 f(b=object()) # E: Unexpected keyword argument "b" for "f"
 class A: pass
 
-[case testKeywordsMisspelling]
-def f(thing, other): ...
-f(otter='test') # E: Unexpected keyword argument "otter" for "f";  did you mean "other"?
+[case testKeywordMisspelling]
+def f(other: 'A') -> None: pass # N: "f" defined here
+f(otter=A()) # E: Unexpected keyword argument "otter" for "f";  did you mean "other"?
+class A: pass
 
 [case testMultipleKeywordsForMisspelling]
-def f(thing, other, atter, btter): ...
-f(otter='test') # E: Unexpected keyword argument "otter" for "f";  did you mean "other", "btter", or "atter"?
+def f(thing : 'A', other: 'A', atter: 'A', btter: 'B') -> None: pass # N: "f" defined here
+f(otter=A()) # E: Unexpected keyword argument "otter" for "f";  did you mean "other" or "atter"?
+class A: pass
+class B: pass
+
+[case testKeywordMisspellingDifferentType]
+def f(other: 'A') -> None: pass # N: "f" defined here
+f(otter=B()) # E: Unexpected keyword argument "otter" for "f";  did you mean "other"?
+class A: pass
+class B: pass
 
 [case testKeywordArgumentsWithDynamicallyTypedCallable]
 from typing import Any

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -103,6 +103,18 @@ f(otter=B()) # E: Unexpected keyword argument "otter" for "f";  did you mean "ot
 class A: pass
 class B: pass
 
+[case testKeywordMisspellingInheritance]
+def f(atter: 'A', btter: 'B', ctter: 'C') -> None: pass # N: "f" defined here
+f(otter=B()) # E: Unexpected keyword argument "otter" for "f";  did you mean "btter" or "atter"?
+class A: pass
+class B(A): pass
+class C: pass
+
+[case testKeywordMisspellingFloatInt]
+def f(atter: float, btter: int) -> None: pass # N: "f" defined here
+x: int = 5
+f(otter=x) # E: Unexpected keyword argument "otter" for "f";  did you mean "btter" or "atter"?
+
 [case testKeywordArgumentsWithDynamicallyTypedCallable]
 from typing import Any
 f = None # type: Any

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -86,6 +86,14 @@ def f(a: 'A') -> None: pass # N: "f" defined here
 f(b=object()) # E: Unexpected keyword argument "b" for "f"
 class A: pass
 
+[case testKeywordsMisspelling]
+def f(thing, other): ...
+f(otter='test') # E: Unexpected keyword argument "otter" for "f";  did you mean "other"?
+
+[case testMultipleKeywordsForMisspelling]
+def f(thing, other, atter, btter): ...
+f(otter='test') # E: Unexpected keyword argument "otter" for "f";  did you mean "other", "btter", or "atter"?
+
 [case testKeywordArgumentsWithDynamicallyTypedCallable]
 from typing import Any
 f = None # type: Any


### PR DESCRIPTION
This fixes the following case outlined in #824
```python
def f(other: A) -> None: pass
f(otter: A())
```
`Unexpected keyword argument "otter" for "f"`
is now 
`Unexpected keyword argument "otter" for "f";  did you mean "other"?`