### PR TITLE
Make `dump_stats` under its own flag

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -584,9 +584,10 @@ class BuildManager:
         self.processed_targets = []  # type: List[str]
 
     def dump_stats(self) -> None:
-        self.log("Stats:")
-        for key, value in sorted(self.stats_summary().items()):
-            self.log("{:24}{}".format(key + ":", value))
+        if self.options.dump_build_stats:
+            print("Stats:")
+            for key, value in sorted(self.stats_summary().items()):
+                print("{:24}{}".format(key + ":", value))
 
     def use_fine_grained_cache(self) -> bool:
         return self.cache_enabled and self.options.use_fine_grained_cache

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -742,6 +742,9 @@ def process_options(args: List[str],
     parser.add_argument(
         '--inferstats', action='store_true', dest='dump_inference_stats',
         help=argparse.SUPPRESS)
+    parser.add_argument(
+        '--dump-build-stats', action='store_true',
+        help=argparse.SUPPRESS)
     # --debug-cache will disable any cache-related compressions/optimizations,
     # which will make the cache writing process output pretty-printed JSON (which
     # is easier to debug).

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -232,6 +232,7 @@ class Options:
         self.raise_exceptions = False
         self.dump_type_stats = False
         self.dump_inference_stats = False
+        self.dump_build_stats = False
 
         # -- test options --
         # Stop after the semantic analysis phase


### PR DESCRIPTION
I find it irritatingly noisy as part of `--verbose`, especially when
using verbose to debug incremental tests.