### PR TITLE
Fix error when assigning a ternary with an empty collection to a union type variable 

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3538,7 +3538,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         full_context_else_type = self.analyze_cond_branch(else_map, e.else_expr, context=ctx)
         if not mypy.checker.is_valid_inferred_type(if_type):
             # Analyze the right branch disregarding the left branch.
-            else_type = self.analyze_cond_branch(else_map, e.else_expr, context=ctx)
+            else_type = full_context_else_type
 
             # If it would make a difference, re-analyze the left
             # branch using the right branch's type as context.

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3534,6 +3534,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         if_type = self.analyze_cond_branch(if_map, e.if_expr, context=ctx)
 
+        # Analyze the right branch using full type context and store the type
+        full_context_else_type = self.analyze_cond_branch(else_map, e.else_expr, context=ctx)
         if not mypy.checker.is_valid_inferred_type(if_type):
             # Analyze the right branch disregarding the left branch.
             else_type = self.analyze_cond_branch(else_map, e.else_expr, context=ctx)
@@ -3556,7 +3558,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         #
         # TODO: Always create a union or at least in more cases?
         if isinstance(get_proper_type(self.type_context[-1]), UnionType):
-            res = make_simplified_union([if_type, else_type])
+            res = make_simplified_union([if_type, full_context_else_type])
         else:
             res = join.join_types(if_type, else_type)
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -1007,6 +1007,9 @@ do_thing_with_enums(boop)  # E: Argument 1 to "do_thing_with_enums" has incompat
 
 [case testAssignUnionWithTenaryExprWithEmptyCollection]
 from typing import Dict, List, Union
-x: Union[int, List[int]] = 1 if "" else []
-y: Union[int, Dict[int, int]] = 1 if "" else {}
+x: Union[int, List[int]] = 1 if bool() else []
+y: Union[int, Dict[int, int]] = 1 if bool() else {}
+
+u: Union[int, List[int]] = [] if bool() else 1
+v: Union[int, Dict[int, int]] = {} if bool() else 1
 [builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -1004,3 +1004,9 @@ do_thing_with_enums(boop)  # E: Argument 1 to "do_thing_with_enums" has incompat
                            # N: "List" is invariant -- see http://mypy.readthedocs.io/en/latest/common_issues.html#variance \
                            # N: Consider using "Sequence" instead, which is covariant
 [builtins fixtures/isinstancelist.pyi]
+
+[case testAssignUnionWithTenaryExprWithEmptyCollection]
+from typing import Dict, List, Union
+x: Union[int, List[int]] = 1 if "" else []
+y: Union[int, Dict[int, int]] = 1 if "" else {}
+[builtins fixtures/isinstancelist.pyi]


### PR DESCRIPTION
resolves #7780 