### PR TITLE
Add shebang lines to stubgen scripts

### DIFF
--- a/misc/download-mypyc-wheels.py
+++ b/misc/download-mypyc-wheels.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # Script for downloading mypyc-compiled mypy wheels in preparation for a release
 
 import os

--- a/misc/dump-ast.py
+++ b/misc/dump-ast.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-
+#!/usr/bin/env python3
 """
 Parse source files and print the abstract syntax trees.
 """

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Generator of dynamically typed draft stubs for arbitrary modules.
 
 The logic of this script can be split in three steps:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Stub generator for C modules.
 
 The public interface is via the mypy.stubgen module.


### PR DESCRIPTION
Also make them canonical with regard to whitespace with other executable
scripts.