### PR TITLE
Tweak constraint inference against unions to exclude more unsatisfiable items

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -174,6 +174,7 @@ def infer_constraints_if_possible(template: Type, actual: Type,
         return None
     if (direction == SUPERTYPE_OF and isinstance(template, TypeVarType) and
             not mypy.subtypes.is_subtype(actual, erase_typevars(template.upper_bound))):
+        # This is not caught by the above branch because of the erase_typevars() call.
         return None
     return infer_constraints(template, actual, direction)
 

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -172,6 +172,9 @@ def infer_constraints_if_possible(template: Type, actual: Type,
     if (direction == SUPERTYPE_OF and
             not mypy.subtypes.is_subtype(actual, erase_typevars(template))):
         return None
+    if (direction == SUPERTYPE_OF and isinstance(template, TypeVarType) and
+            not mypy.subtypes.is_subtype(actual, erase_typevars(template.upper_bound))):
+        return None
     return infer_constraints(template, actual, direction)
 
 

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -174,7 +174,8 @@ def infer_constraints_if_possible(template: Type, actual: Type,
         return None
     if (direction == SUPERTYPE_OF and isinstance(template, TypeVarType) and
             not mypy.subtypes.is_subtype(actual, erase_typevars(template.upper_bound))):
-        # This is not caught by the above branch because of the erase_typevars() call.
+        # This is not caught by the above branch because of the erase_typevars() call,
+        # that would return 'Any' for a type variable.
         return None
     return infer_constraints(template, actual, direction)
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2787,13 +2787,13 @@ def q2(x: Union[Z[F], F]) -> F:
         return x
 
 b: B
-reveal_type(q1(z))
-reveal_type(q2(z))
+reveal_type(q1(z))  # N: Revealed type is '__main__.B*'
+reveal_type(q2(z))  # N: Revealed type is '__main__.B*'
 
 z: Z[B]
-reveal_type(q1(z))
-reveal_type(q2(z))
+reveal_type(q1(z))  # N: Revealed type is '__main__.B*'
+reveal_type(q2(z))  # N: Revealed type is '__main__.B*'
 
-reveal_type(q1(Z(b)))
-reveal_type(q2(Z(b)))
+reveal_type(q1(Z(b)))  # N: Revealed type is '__main__.B*'
+reveal_type(q2(Z(b)))  # N: Revealed type is '__main__.B*'
 [builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2761,3 +2761,39 @@ def f() -> None:
 class C:
     def __init__(self, a: int) -> None:
         self.a = a
+
+[case testUnionGenericWithBoundedVariable]
+from typing import Generic, TypeVar, Union
+
+T = TypeVar('T', bound=A)
+class Z(Generic[T]):
+    def __init__(self, y: T) -> None:
+        self.y = y
+
+class A: ...
+class B(A): ...
+F = TypeVar('F', bound=A)
+
+def q1(x: Union[F, Z[F]]) -> F:
+    if isinstance(x, Z):
+        return x.y
+    else:
+        return x
+
+def q2(x: Union[Z[F], F]) -> F:
+    if isinstance(x, Z):
+        return x.y
+    else:
+        return x
+
+b: B
+reveal_type(q1(z))
+reveal_type(q2(z))
+
+z: Z[B]
+reveal_type(q1(z))
+reveal_type(q2(z))
+
+reveal_type(q1(Z(b)))
+reveal_type(q2(Z(b)))
+[builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2787,8 +2787,8 @@ def q2(x: Union[Z[F], F]) -> F:
         return x
 
 b: B
-reveal_type(q1(z))  # N: Revealed type is '__main__.B*'
-reveal_type(q2(z))  # N: Revealed type is '__main__.B*'
+reveal_type(q1(b))  # N: Revealed type is '__main__.B*'
+reveal_type(q2(b))  # N: Revealed type is '__main__.B*'
 
 z: Z[B]
 reveal_type(q1(z))  # N: Revealed type is '__main__.B*'


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/6417

Currently constraint inference against unions excludes trivially unsatisfiable items, but a corner case of a plain type variable was missing, so I add one.

(Note: this may help with constraint inference for recursive types.)