### PR TITLE
Fix compiled dmypy on Windows

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -275,7 +275,7 @@ class Options:
         # Under mypyc, we don't have a __dict__, so we need to do worse things.
         d = dict(getattr(self, '__dict__', ()))
         for k in get_class_descriptors(Options):
-            if hasattr(self, k):
+            if hasattr(self, k) and k != "new_semantic_analyzer":
                 d[k] = getattr(self, k)
         del d['per_module_cache']
         return d


### PR DESCRIPTION
The issue was that the mechanism for transmitting Options to the daemon
on Windows used snapshot/apply_changes and those don't play well with
read-only attributes when compiled.

I've fixed this in the most expedient way for now but will do some
follow ups to clean up this mechanism and hopefully test this on
Windows in CI.