### PR TITLE
Fix issue 7863

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -554,9 +554,9 @@ def analyze_var(name: str,
                 # In `x.f`, when checking `x` against A1 we assume x is compatible with A
                 # and similarly for B1 when checking agains B
                 dispatched_type = meet.meet_types(mx.original_type, itype)
-                functype = check_self_arg(functype, dispatched_type, var.is_classmethod,
-                                          mx.context, name, mx.msg)
                 signature = freshen_function_type_vars(functype)
+                signature = check_self_arg(signature, dispatched_type, var.is_classmethod,
+                                          mx.context, name, mx.msg)
                 signature = bind_self(signature, mx.self_type, var.is_classmethod)
                 expanded_signature = get_proper_type(expand_type_by_instance(signature, itype))
                 if var.is_property:

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -533,6 +533,7 @@ def analyze_var(name: str,
             mx.msg.cant_assign_to_classvar(name, mx.context)
         t = get_proper_type(expand_type_by_instance(typ, itype))
         result = t  # type: Type
+        typ = get_proper_type(typ)
         if var.is_initialized_in_class and isinstance(typ, FunctionLike) and not typ.is_type_obj():
             if mx.is_lvalue:
                 if var.is_property:
@@ -557,12 +558,13 @@ def analyze_var(name: str,
                                           mx.context, name, mx.msg)
                 signature = freshen_function_type_vars(functype)
                 signature = bind_self(signature, mx.self_type, var.is_classmethod)
+                expanded_signature = get_proper_type(expand_type_by_instance(signature, itype))
                 if var.is_property:
                     # A property cannot have an overloaded type => the cast is fine.
-                    assert isinstance(signature, CallableType)
-                    result = signature.ret_type
+                    assert isinstance(expanded_signature, CallableType)
+                    result = expanded_signature.ret_type
                 else:
-                    result = get_proper_type(expand_type_by_instance(signature, itype))
+                    result = expanded_signature
     else:
         if not var.is_ready:
             mx.not_ready_callback(var.name(), mx.context)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -526,12 +526,12 @@ def analyze_var(name: str,
     if typ:
         if isinstance(typ, PartialType):
             return mx.chk.handle_partial_var_type(typ, mx.is_lvalue, var, mx.context)
-        t = get_proper_type(expand_type_by_instance(typ, itype))
         if mx.is_lvalue and var.is_property and not var.is_settable_property:
             # TODO allow setting attributes in subclass (although it is probably an error)
             mx.msg.read_only_property(name, itype.type, mx.context)
         if mx.is_lvalue and var.is_classvar:
             mx.msg.cant_assign_to_classvar(name, mx.context)
+        t = get_proper_type(expand_type_by_instance(typ, itype))
         result = t  # type: Type
         if var.is_initialized_in_class and isinstance(t, FunctionLike) and not t.is_type_obj():
             if mx.is_lvalue:
@@ -544,7 +544,7 @@ def analyze_var(name: str,
             if not var.is_staticmethod:
                 # Class-level function objects and classmethods become bound methods:
                 # the former to the instance, the latter to the class.
-                functype = t
+                functype = typ
                 # Use meet to narrow original_type to the dispatched type.
                 # For example, assume
                 # * A.f: Callable[[A1], None] where A1 <: A (maybe A1 == A)
@@ -555,7 +555,9 @@ def analyze_var(name: str,
                 dispatched_type = meet.meet_types(mx.original_type, itype)
                 functype = check_self_arg(functype, dispatched_type, var.is_classmethod,
                                           mx.context, name, mx.msg)
-                signature = bind_self(functype, mx.self_type, var.is_classmethod)
+                signature = freshen_function_type_vars(functype)
+                signature = bind_self(signature, mx.self_type, var.is_classmethod)
+                signature = get_proper_type(expand_type_by_instance(signature, itype))
                 if var.is_property:
                     # A property cannot have an overloaded type => the cast is fine.
                     assert isinstance(signature, CallableType)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -533,7 +533,7 @@ def analyze_var(name: str,
             mx.msg.cant_assign_to_classvar(name, mx.context)
         t = get_proper_type(expand_type_by_instance(typ, itype))
         result = t  # type: Type
-        if var.is_initialized_in_class and isinstance(t, FunctionLike) and not t.is_type_obj():
+        if var.is_initialized_in_class and isinstance(typ, FunctionLike) and not typ.is_type_obj():
             if mx.is_lvalue:
                 if var.is_property:
                     if not var.is_settable_property:
@@ -557,13 +557,12 @@ def analyze_var(name: str,
                                           mx.context, name, mx.msg)
                 signature = freshen_function_type_vars(functype)
                 signature = bind_self(signature, mx.self_type, var.is_classmethod)
-                signature = get_proper_type(expand_type_by_instance(signature, itype))
                 if var.is_property:
                     # A property cannot have an overloaded type => the cast is fine.
                     assert isinstance(signature, CallableType)
                     result = signature.ret_type
                 else:
-                    result = signature
+                    result = get_proper_type(expand_type_by_instance(signature, itype))
     else:
         if not var.is_ready:
             mx.not_ready_callback(var.name(), mx.context)

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2141,7 +2141,6 @@ class TwoTypes(Generic[A, B]):
 
   def __call__(self) -> B: pass
 
-# TODO - This should extend ABC but test errors that ABC not in abc on import
 class MakeTwoAbstract(ABC, Generic[A]):
 
   def __init__(self) -> None: pass

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2167,7 +2167,7 @@ class Test():
                 mte: MakeTwoConcrete[A],
                 mtgsa: MakeTwoGenericSubAbstract[A],
                 mtasa: MakeTwoAppliedSubAbstract) -> None:
-    reveal_type(mts.__call__) # N: Revealed type is 'def [B] (b: B`33) -> __main__.TwoTypes[A`-33, B`33]'
+    reveal_type(mts.__call__) # N: Revealed type is 'def [B] (b: B`33) -> __main__.TwoTypes[A`-1, B`33]'
     reveal_type(mts(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
     reveal_type(mte.__call__) # N: Revealed type is 'def [B] (b: B`36) -> __main__.TwoTypes[A`-1, B`36]'
     reveal_type(mte(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2167,11 +2167,11 @@ class Test():
                 mte: MakeTwoConcrete[A],
                 mtgsa: MakeTwoGenericSubAbstract[A],
                 mtasa: MakeTwoAppliedSubAbstract) -> None:
-    reveal_type(mts.__call__) # N: Revealed type is 'def [B] (b: B`1) -> __main__.TwoTypes[A`-1, B`1]'
+    reveal_type(mts.__call__) # N: Revealed type is 'def [B] (b: B`33) -> __main__.TwoTypes[A`-33, B`33]'
     reveal_type(mts(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
-    reveal_type(mte.__call__) # N: Revealed type is 'def [B] (b: B`4) -> __main__.TwoTypes[A`-1, B`4]'
+    reveal_type(mte.__call__) # N: Revealed type is 'def [B] (b: B`36) -> __main__.TwoTypes[A`-1, B`36]'
     reveal_type(mte(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
-    reveal_type(mtgsa.__call__) # N: Revealed type is 'def [B] (b: B`7) -> __main__.TwoTypes[A`-1, B`7]'
+    reveal_type(mtgsa.__call__) # N: Revealed type is 'def [B] (b: B`39) -> __main__.TwoTypes[A`-1, B`39]'
     reveal_type(mtgsa(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
-    reveal_type(mtasa.__call__) # N: Revealed type is 'def [B] (b: B`10) -> __main__.TwoTypes[builtins.str, B`10]'
+    reveal_type(mtasa.__call__) # N: Revealed type is 'def [B] (b: B`42) -> __main__.TwoTypes[builtins.str, B`42]'
     reveal_type(mtasa(2)) # N: Revealed type is '__main__.TwoTypes[builtins.str, builtins.int*]'

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2130,7 +2130,7 @@ class B(A):
 [builtins fixtures/classmethod.pyi]
 
 [case testAbstractGenericMethodInference]
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Callable, Generic, TypeVar
 
 A = TypeVar('A')
@@ -2142,7 +2142,7 @@ class TwoTypes(Generic[A, B]):
   def __call__(self) -> B: pass
 
 # TODO - This should extend ABC but test errors that ABC not in abc on import
-class MakeTwoAbstract(Generic[A]):
+class MakeTwoAbstract(ABC, Generic[A]):
 
   @abstractmethod
   def __call__(self, b: B) -> TwoTypes[A, B]: pass
@@ -2152,11 +2152,11 @@ class MakeTwoConcrete(Generic[A]):
   def __call__(self, b: B) -> TwoTypes[A, B]: pass
 
 
-class MakeTwoAbstractSubAbstract(Generic[C], MakeTwoAbstract[C]):
+class MakeTwoGenericSubAbstract(Generic[C], MakeTwoAbstract[C]):
 
   def __call__(self, b: B) -> TwoTypes[C, B]: pass
 
-class MakeTwoConcreteSubAbstract(MakeTwoAbstract[str]):
+class MakeTwoAppliedSubAbstract(MakeTwoAbstract[str]):
 
   def __call__(self, b: B) -> TwoTypes[str, B]: pass
 
@@ -2165,13 +2165,13 @@ class Test():
   def make_two(self,
                 mts: MakeTwoAbstract[A],
                 mte: MakeTwoConcrete[A],
-                mtasa: MakeTwoAbstractSubAbstract[A],
-                mtcsa: MakeTwoConcreteSubAbstract) -> None:
+                mtgsa: MakeTwoGenericSubAbstract[A],
+                mtasa: MakeTwoAppliedSubAbstract) -> None:
     reveal_type(mts.__call__) # N: Revealed type is 'def [B] (b: B`1) -> __main__.TwoTypes[A`-1, B`1]'
     reveal_type(mts(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
     reveal_type(mte.__call__) # N: Revealed type is 'def [B] (b: B`4) -> __main__.TwoTypes[A`-1, B`4]'
     reveal_type(mte(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
-    reveal_type(mtasa.__call__) # N: Revealed type is 'def [B] (b: B`7) -> __main__.TwoTypes[A`-1, B`7]'
-    reveal_type(mtasa(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
-    reveal_type(mtcsa.__call__) # N: Revealed type is 'def [B] (b: B`10) -> __main__.TwoTypes[builtins.str, B`10]'
-    reveal_type(mtcsa(2)) # N: Revealed type is '__main__.TwoTypes[builtins.str, builtins.int*]'
+    reveal_type(mtgsa.__call__) # N: Revealed type is 'def [B] (b: B`7) -> __main__.TwoTypes[A`-1, B`7]'
+    reveal_type(mtgsa(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
+    reveal_type(mtasa.__call__) # N: Revealed type is 'def [B] (b: B`10) -> __main__.TwoTypes[builtins.str, B`10]'
+    reveal_type(mtasa(2)) # N: Revealed type is '__main__.TwoTypes[builtins.str, builtins.int*]'

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2144,6 +2144,8 @@ class TwoTypes(Generic[A, B]):
 # TODO - This should extend ABC but test errors that ABC not in abc on import
 class MakeTwoAbstract(ABC, Generic[A]):
 
+  def __init__(self) -> None: pass
+
   @abstractmethod
   def __call__(self, b: B) -> TwoTypes[A, B]: pass
 
@@ -2167,11 +2169,14 @@ class Test():
                 mte: MakeTwoConcrete[A],
                 mtgsa: MakeTwoGenericSubAbstract[A],
                 mtasa: MakeTwoAppliedSubAbstract) -> None:
-    reveal_type(mts.__call__) # N: Revealed type is 'def [B] (b: B`33) -> __main__.TwoTypes[A`-1, B`33]'
     reveal_type(mts(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
-    reveal_type(mte.__call__) # N: Revealed type is 'def [B] (b: B`36) -> __main__.TwoTypes[A`-1, B`36]'
     reveal_type(mte(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
-    reveal_type(mtgsa.__call__) # N: Revealed type is 'def [B] (b: B`39) -> __main__.TwoTypes[A`-1, B`39]'
     reveal_type(mtgsa(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
-    reveal_type(mtasa.__call__) # N: Revealed type is 'def [B] (b: B`42) -> __main__.TwoTypes[builtins.str, B`42]'
     reveal_type(mtasa(2)) # N: Revealed type is '__main__.TwoTypes[builtins.str, builtins.int*]'
+    reveal_type(MakeTwoConcrete[int]()('foo')) # N: Revealed type is '__main__.TwoTypes[builtins.int, builtins.str*]'
+    reveal_type(MakeTwoConcrete[str]()(2)) # N: Revealed type is '__main__.TwoTypes[builtins.str, builtins.int*]'
+    reveal_type(MakeTwoAppliedSubAbstract()('foo')) # N: Revealed type is '__main__.TwoTypes[builtins.str, builtins.str*]'
+    reveal_type(MakeTwoAppliedSubAbstract()(2)) # N: Revealed type is '__main__.TwoTypes[builtins.str, builtins.int*]'
+    reveal_type(MakeTwoGenericSubAbstract[str]()('foo')) # N: Revealed type is '__main__.TwoTypes[builtins.str, builtins.str*]'
+    reveal_type(MakeTwoGenericSubAbstract[str]()(2)) # N: Revealed type is '__main__.TwoTypes[builtins.str, builtins.int*]'
+

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2128,3 +2128,50 @@ class B(A):
     def from_config(cls) -> B:
         return B()
 [builtins fixtures/classmethod.pyi]
+
+[case testAbstractGenericMethodInference]
+from abc import abstractmethod
+from typing import Callable, Generic, TypeVar
+
+A = TypeVar('A')
+B = TypeVar('B')
+C = TypeVar('C')
+
+class TwoTypes(Generic[A, B]):
+
+  def __call__(self) -> B: pass
+
+# TODO - This should extend ABC but test errors that ABC not in abc on import
+class MakeTwoAbstract(Generic[A]):
+
+  @abstractmethod
+  def __call__(self, b: B) -> TwoTypes[A, B]: pass
+
+class MakeTwoConcrete(Generic[A]):
+
+  def __call__(self, b: B) -> TwoTypes[A, B]: pass
+
+
+class MakeTwoAbstractSubAbstract(Generic[C], MakeTwoAbstract[C]):
+
+  def __call__(self, b: B) -> TwoTypes[C, B]: pass
+
+class MakeTwoConcreteSubAbstract(MakeTwoAbstract[str]):
+
+  def __call__(self, b: B) -> TwoTypes[str, B]: pass
+
+class Test():
+
+  def make_two(self,
+                mts: MakeTwoAbstract[A],
+                mte: MakeTwoConcrete[A],
+                mtasa: MakeTwoAbstractSubAbstract[A],
+                mtcsa: MakeTwoConcreteSubAbstract) -> None:
+    reveal_type(mts.__call__) # N: Revealed type is 'def [B] (b: B`1) -> __main__.TwoTypes[A`-1, B`1]'
+    reveal_type(mts(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
+    reveal_type(mte.__call__) # N: Revealed type is 'def [B] (b: B`4) -> __main__.TwoTypes[A`-1, B`4]'
+    reveal_type(mte(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
+    reveal_type(mtasa.__call__) # N: Revealed type is 'def [B] (b: B`7) -> __main__.TwoTypes[A`-1, B`7]'
+    reveal_type(mtasa(2)) # N: Revealed type is '__main__.TwoTypes[A`-1, builtins.int*]'
+    reveal_type(mtcsa.__call__) # N: Revealed type is 'def [B] (b: B`10) -> __main__.TwoTypes[builtins.str, B`10]'
+    reveal_type(mtcsa(2)) # N: Revealed type is '__main__.TwoTypes[builtins.str, builtins.int*]'

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -468,13 +468,13 @@ class B(A[Q]):
 a: A[int]
 b: B[str]
 reveal_type(a.g)  # N: Revealed type is 'builtins.int'
-reveal_type(a.gt)  # N: Revealed type is 'builtins.int*'
+reveal_type(a.gt)  # N: Revealed type is 'builtins.int'
 reveal_type(a.f())  # N: Revealed type is 'builtins.int'
-reveal_type(a.ft())  # N: Revealed type is '__main__.A*[builtins.int]'
+reveal_type(a.ft())  # N: Revealed type is '__main__.A[builtins.int]'
 reveal_type(b.g)  # N: Revealed type is 'builtins.int'
-reveal_type(b.gt)  # N: Revealed type is 'builtins.str*'
+reveal_type(b.gt)  # N: Revealed type is 'builtins.str'
 reveal_type(b.f())  # N: Revealed type is 'builtins.int'
-reveal_type(b.ft())  # N: Revealed type is '__main__.B*[builtins.str]'
+reveal_type(b.ft())  # N: Revealed type is '__main__.B[builtins.str]'
 [builtins fixtures/property.pyi]
 
 [case testSelfTypeRestrictedMethod]

--- a/test-data/unit/lib-stub/abc.pyi
+++ b/test-data/unit/lib-stub/abc.pyi
@@ -2,6 +2,7 @@ from typing import Type, Any, TypeVar
 
 T = TypeVar('T', bound=Type[Any])
 
+class ABC(type): pass
 class ABCMeta(type):
     def register(cls, tp: T) -> T: pass
 abstractmethod = object()


### PR DESCRIPTION
See https://github.com/python/mypy/issues/7863 for background context.

A few small notes.

1- Assignment to `t` on line 529 of checkmember.py was not being referenced til 535. Unless `get_proper_type(expand_type_by_instance(typ, itype))` is mutating `typ` or `itype` then this created ambiguity for me around whether lines 530-534 were going to be impacted by my overall change. Since it appears not to be the case, I figured it's clearer to introduce `t` no earlier than it is used, (which in hindsight with the rest of the change could probably be even later in the function.)

2- Changes to check-selftype.test appear to be a result of calling `bind_self` before `get_proper_type(expand_type_by_instance(signature, itype))` - my understanding is that `bind_self` does not register inference by susbtitution of type var, and so the inference of self types are no longer marked as such.

3- #TODO in my added tests - I'm unable to successfully run when importing ABC (error: module abc has no value ABC,) if anyone has guidance on how I might fix that I'd appreciate it, will gladly update accordingly.

I haven't thoroughly grokked the work in freshen_function_type_vars, I arrived at this solution mostly by stepping through debugger between the diverging code paths in my original issue to isolate when the type became incorrect, and comparing the work being done between the two paths.

I have a few qs that I'd love any insight into.

1- What is the difference between negative and positive generic type identifiers? I had suspected contravariant vs covariant, but then the results of freshen_function_type_vars would seem to contradict (it flips negative to positive in contravariant position.)

2- Why do we track generic type vars solely by the internally assigned numeric identifiers and not by the names assigned by programmer? The original issue came up by conflating `A-1` and `B-1` during inference, but I can't ever think of a case where a programmer would intend `A` to have reference equality to `B`, vs a particular instantiation of `Generic[A, B]` that happens to choose the same concrete type for both arguments.

I hope this is on the right track. Thanks in advance for review, to @ilevkivskyi for the initial guidance, and for any insight offered on the questions above.