### PR TITLE
Make constraint inference in bind_self() more principled

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5,8 +5,7 @@ import fnmatch
 from contextlib import contextmanager
 
 from typing import (
-    Dict, Set, List, cast, Tuple, TypeVar, Union, Optional, NamedTuple, Iterator, Iterable,
-    Sequence
+    Dict, Set, List, cast, Tuple, TypeVar, Union, Optional, NamedTuple, Iterator, Sequence
 )
 from typing_extensions import Final
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -48,7 +48,7 @@ from mypy.checkmember import (
 from mypy.typeops import (
     map_type_from_supertype, bind_self, erase_to_bound, make_simplified_union,
     erase_def_to_union_or_bound, erase_to_union_or_bound,
-    true_only, false_only, function_type,
+    true_only, false_only, function_type, TypeVarExtractor
 )
 from mypy import message_registry
 from mypy.subtypes import (
@@ -4525,20 +4525,6 @@ def detach_callable(typ: CallableType) -> CallableType:
         ret_type=type_list[-1],
     )
     return out
-
-
-class TypeVarExtractor(TypeQuery[List[TypeVarType]]):
-    def __init__(self) -> None:
-        super().__init__(self._merge)
-
-    def _merge(self, iter: Iterable[List[TypeVarType]]) -> List[TypeVarType]:
-        out = []
-        for item in iter:
-            out.extend(item)
-        return out
-
-    def visit_type_var(self, t: TypeVarType) -> List[TypeVarType]:
-        return [t]
 
 
 def overload_can_never_match(signature: CallableType, other: CallableType) -> bool:

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -824,6 +824,46 @@ ab: Union[A, B, C]
 reveal_type(ab.x)  # N: Revealed type is 'builtins.int'
 [builtins fixtures/property.pyi]
 
+[case testSelfTypeNoTypeVars]
+from typing import Generic, List, Optional, TypeVar, Any
+
+Q = TypeVar("Q")
+T = TypeVar("T", bound=Super[Any])
+
+class Super(Generic[Q]):
+    @classmethod
+    def meth(cls, arg: List[T]) -> List[T]:
+        pass
+
+class Sub(Super[int]): ...
+
+def test(x: List[Sub]) -> None:
+    reveal_type(Sub.meth(x))  # N: Revealed type is 'builtins.list[__main__.Sub*]'
+[builtins fixtures/isinstancelist.pyi]
+
+[case testSelfTypeNoTypeVarsRestrict]
+from typing import Generic, TypeVar
+
+T = TypeVar('T')
+S = TypeVar('S')
+
+class C(Generic[T]):
+    def limited(self: C[str], arg: S) -> S: ...
+
+reveal_type(C[str]().limited(0))  # N: Revealed type is 'builtins.int*'
+
+[case testSelfTypeMultipleTypeVars]
+from typing import Generic, TypeVar, Tuple
+
+T = TypeVar('T')
+S = TypeVar('S')
+U = TypeVar('U')
+
+class C(Generic[T]):
+    def magic(self: C[Tuple[S, U]]) -> Tuple[T, S, U]: ...
+
+reveal_type(C[Tuple[int, str]]().magic())  # N: Revealed type is 'Tuple[Tuple[builtins.int, builtins.str], builtins.int, builtins.str]'
+
 [case testSelfTypeOnUnion]
 from typing import TypeVar, Union
 


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/7925

This PR:
* Moves `TypeVarExtractor` to `typeops.py`
* Infers and applies all and only type variables that appear in an explicit `self` type (instead of just always the first one as currently)