### PR TITLE
[mypyc] Move the shim_template to a file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ recursive-include extensions *
 recursive-include docs *
 recursive-include mypy/typeshed *.py *.pyi
 recursive-include mypy/xml *.xsd *.xslt *.css
-recursive-include mypyc/lib-rt *.c *.h
+recursive-include mypyc/lib-rt *.c *.h *.tmpl
 include mypy_bootstrap.ini
 include mypy_self_check.ini
 include LICENSE

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -110,26 +110,6 @@ def get_mypy_config(paths: List[str],
     return sources, options
 
 
-shim_template = """\
-#include <Python.h>
-
-PyMODINIT_FUNC
-PyInit_{modname}(void)
-{{
-    if (!PyImport_ImportModule("{libname}")) return NULL;
-    void *init_func = PyCapsule_Import("{libname}.init_{full_modname}", 0);
-    if (!init_func) {{
-        return NULL;
-    }}
-    return ((PyObject *(*)(void))init_func)();
-}}
-
-// distutils sometimes spuriously tells cl to export CPyInit___init__,
-// so provide that so it chills out
-PyMODINIT_FUNC PyInit___init__(void) {{ return PyInit_{modname}(); }}
-"""
-
-
 def generate_c_extension_shim(
         full_module_name: str, module_name: str, dir_name: str, group_name: str) -> str:
     """Create a C extension shim with a passthrough PyInit function.
@@ -142,6 +122,11 @@ def generate_c_extension_shim(
     """
     cname = '%s.c' % exported_name(full_module_name)
     cpath = os.path.join(dir_name, cname)
+
+    # We load the C extension shim template from a file.
+    # (So that the file could be reused as a bazel template also.)
+    with open(os.path.join(include_dir(), 'module_shim.tmpl')) as f:
+        shim_template = f.read()
 
     write_file(
         cpath,

--- a/mypyc/lib-rt/module_shim.tmpl
+++ b/mypyc/lib-rt/module_shim.tmpl
@@ -1,0 +1,18 @@
+#include <Python.h>
+
+PyMODINIT_FUNC
+PyInit_{modname}(void)
+{{
+    PyObject *tmp;
+    if (!(tmp = PyImport_ImportModule("{libname}"))) return NULL;
+    Py_DECREF(tmp);
+    void *init_func = PyCapsule_Import("{libname}.init_{full_modname}", 0);
+    if (!init_func) {{
+        return NULL;
+    }}
+    return ((PyObject *(*)(void))init_func)();
+}}
+
+// distutils sometimes spuriously tells cl to export CPyInit___init__,
+// so provide that so it chills out
+PyMODINIT_FUNC PyInit___init__(void) {{ return PyInit_{modname}(); }}


### PR DESCRIPTION
The point of this is that the file can now be used as a bazel
template.