### PR TITLE
[mypyc] Allow dots in group names

### DIFF
--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -36,6 +36,6 @@ def decorator_helper_name(func_name: str) -> str:
 def shared_lib_name(group_name: str) -> str:
     """Given a group name, return the actual name of its extension module.
 
-    (This just adds a prefix.)
+    (This just adds a suffix to the final component.)
     """
-    return 'mypyc_{}'.format(group_name)
+    return '{}__mypyc'.format(group_name)

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -15,7 +15,7 @@ from mypyc.ops import (
     is_none_rprimitive, is_object_rprimitive, object_rprimitive, is_str_rprimitive, ClassIR,
     FuncDecl, int_rprimitive, is_optional_type, optional_value_type, all_concrete_classes
 )
-from mypyc.namegen import NameGenerator
+from mypyc.namegen import NameGenerator, exported_name
 from mypyc.sametype import is_same_type
 
 
@@ -167,7 +167,7 @@ class Emitter:
         target_group_name = groups.get(module_name)
         if target_group_name and target_group_name != self.context.group_name:
             self.context.group_deps.add(target_group_name)
-            return 'exports_{}.'.format(target_group_name)
+            return 'exports_{}.'.format(exported_name(target_group_name))
         else:
             return ''
 

--- a/mypyc/test-data/run-multimodule.test
+++ b/mypyc/test-data/run-multimodule.test
@@ -1,11 +1,12 @@
 -- These test cases compile two modules at a time (native and other.py)
 
-[case testMultiModuleBasic]
-from other import g
+[case testMultiModulePackage]
+from p.other import g
 def f(x: int) -> int:
-    from other import h
+    from p.other import h
     return h(g(x + 1))
-[file other.py]
+[file p/__init__.py]
+[file p/other.py]
 def g(x: int) -> int:
     return x + 2
 def h(x: int) -> int:
@@ -13,7 +14,7 @@ def h(x: int) -> int:
 [file driver.py]
 import native
 from native import f
-from other import g
+from p.other import g
 assert f(3) == 7
 assert g(2) == 4
 try:

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -184,7 +184,7 @@ class TestRun(MypycDataSuite):
             fn = os.path.relpath(fn, test_temp_dir)
 
             if os.path.basename(fn).startswith('other') and fn.endswith('.py'):
-                name = os.path.basename(fn).split('.')[0]
+                name = fn.split('.')[0].replace(os.sep, '.')
                 module_names.append(name)
                 sources.append(build.BuildSource(fn, name, None))
                 to_delete.append(fn)


### PR DESCRIPTION
Single-module groups will be given a dotted group name equal to the
module name by default.

A dot in a group name will put the group C extension at that
path. Generated C could will also be placed in a directory
corresponding to the full dotted name (still under the build
directory).

The direct motivation here is that bazel wants artifacts to be under
the appropriate directory, but it is cleaner in general I think.