### PR TITLE
Fix typo in get_proper_types()

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1915,12 +1915,13 @@ def get_proper_type(typ: Optional[Type]) -> Optional[ProperType]:
 
 
 @overload
-def get_proper_types(it: Iterable[Type]) -> List[ProperType]: ...
+def get_proper_types(it: Iterable[Type]) -> List[ProperType]: ...  # type: ignore[misc]
 @overload
-def get_proper_types(typ: Iterable[Optional[Type]]) -> List[Optional[ProperType]]: ...
+def get_proper_types(it: Iterable[Optional[Type]]) -> List[Optional[ProperType]]: ...
 
 
-def get_proper_types(it: Iterable[Optional[Type]]) -> List[Optional[ProperType]]:  # type: ignore
+def get_proper_types(it: Iterable[Optional[Type]]
+                     ) -> Union[List[ProperType], List[Optional[ProperType]]]:
     return [get_proper_type(t) for t in it]
 
 


### PR DESCRIPTION
This fixes the typo in the argument name and deals with the "fallout".

cc @Michael0x2a I double-checked and the error mypy gives is technically real, but the unsafety is so minor that I think we should assume all generics in return types covariant for overlapping overload checks.