### PR TITLE
Prevent dmypy from restarting if the configuration contains globs.

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -281,6 +281,7 @@ class Options:
             if hasattr(self, k) and k != "new_semantic_analyzer":
                 d[k] = getattr(self, k)
         del d['per_module_cache']
+        del d['glob_options']
         return d
 
     def __repr__(self) -> str:

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -62,7 +62,7 @@ class Options:
 
     def __init__(self) -> None:
         # Cache for clone_for_module()
-        self.per_module_cache = None  # type: Optional[Dict[str, Options]]
+        self._per_module_cache = None  # type: Optional[Dict[str, Options]]
 
         # -- build options --
         self.build_type = BuildType.STANDARD
@@ -222,7 +222,7 @@ class Options:
 
         # Per-module options (raw)
         self.per_module_options = OrderedDict()  # type: OrderedDict[str, Dict[str, object]]
-        self.glob_options = []  # type: List[Tuple[str, Pattern[str]]]
+        self._glob_options = []  # type: List[Tuple[str, Pattern[str]]]
         self.unused_configs = set()  # type: Set[str]
 
         # -- development options --
@@ -280,8 +280,8 @@ class Options:
         for k in get_class_descriptors(Options):
             if hasattr(self, k) and k != "new_semantic_analyzer":
                 d[k] = getattr(self, k)
-        del d['per_module_cache']
-        del d['glob_options']
+        # Remove private attributes from snapshot
+        d = {k: v for k, v in d.items() if not k.startswith('_')}
         return d
 
     def __repr__(self) -> str:
@@ -296,7 +296,7 @@ class Options:
         return new_options
 
     def build_per_module_cache(self) -> None:
-        self.per_module_cache = {}
+        self._per_module_cache = {}
 
         # Config precedence is as follows:
         #  1. Concrete section names: foo.bar.baz
@@ -321,7 +321,7 @@ class Options:
         concrete = [k for k in structured_keys if not k.endswith('.*')]
 
         for glob in unstructured_glob_keys:
-            self.glob_options.append((glob, self.compile_glob(glob)))
+            self._glob_options.append((glob, self.compile_glob(glob)))
 
         # We (for ease of implementation) treat unstructured glob
         # sections as used if any real modules use them or if any
@@ -334,7 +334,7 @@ class Options:
             # on inheriting from parent configs.
             options = self.clone_for_module(key)
             # And then update it with its per-module options.
-            self.per_module_cache[key] = options.apply_changes(self.per_module_options[key])
+            self._per_module_cache[key] = options.apply_changes(self.per_module_options[key])
 
         # Add the more structured sections into unused configs, since
         # they only count as used if actually used by a real module.
@@ -346,14 +346,14 @@ class Options:
         NOTE: Once this method is called all Options objects should be
         considered read-only, else the caching might be incorrect.
         """
-        if self.per_module_cache is None:
+        if self._per_module_cache is None:
             self.build_per_module_cache()
-        assert self.per_module_cache is not None
+        assert self._per_module_cache is not None
 
         # If the module just directly has a config entry, use it.
-        if module in self.per_module_cache:
+        if module in self._per_module_cache:
             self.unused_configs.discard(module)
-            return self.per_module_cache[module]
+            return self._per_module_cache[module]
 
         # If not, search for glob paths at all the parents. So if we are looking for
         # options for foo.bar.baz, we search foo.bar.baz.*, foo.bar.*, foo.*,
@@ -364,15 +364,15 @@ class Options:
         path = module.split('.')
         for i in range(len(path), 0, -1):
             key = '.'.join(path[:i] + ['*'])
-            if key in self.per_module_cache:
+            if key in self._per_module_cache:
                 self.unused_configs.discard(key)
-                options = self.per_module_cache[key]
+                options = self._per_module_cache[key]
                 break
 
         # OK and *now* we need to look for unstructured glob matches.
         # We only do this for concrete modules, not structured wildcards.
         if not module.endswith('.*'):
-            for key, pattern in self.glob_options:
+            for key, pattern in self._glob_options:
                 if pattern.match(module):
                     self.unused_configs.discard(key)
                     options = options.apply_changes(self.per_module_options[key])

--- a/mypy/test/testdaemon.py
+++ b/mypy/test/testdaemon.py
@@ -11,7 +11,7 @@ from typing import List, Tuple
 
 from mypy.test.config import test_temp_dir, PREFIX
 from mypy.test.data import DataDrivenTestCase, DataSuite
-from mypy.test.helpers import assert_string_arrays_equal
+from mypy.test.helpers import assert_string_arrays_equal, normalize_error_messages
 
 # Files containing test cases descriptions.
 daemon_files = [
@@ -40,6 +40,7 @@ def test_daemon(testcase: DataDrivenTestCase) -> None:
         cmd = cmd.replace('{python}', sys.executable)
         sts, output = run_cmd(cmd)
         output_lines = output.splitlines()
+        output_lines = normalize_error_messages(output_lines)
         if sts:
             output_lines.append('== Return code: %d' % sts)
         assert_string_arrays_equal(expected_lines,

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -101,18 +101,17 @@ def plugin(version): return Dummy
 
 [case testDaemonRunRestartGlobs]
 -- Ensure dmypy is not restarted if the configuration doesn't change and it contains globs
-$ dmypy run -- foo --follow-imports=error
+-- Note: Backslash path separator in output is replaced with forward slash so the same test succeeds on Windows as well
+$ dmypy run -- foo --follow-imports=error --python-version=3.6 | {python} -c 'import sys; sys.stdout.write(sys.stdin.read().replace("\\", "/"))'
 Daemon started
 foo/lol.py:1: error: Name 'fail' is not defined
 Found 1 error in 1 file (checked 3 source files)
-== Return code: 1
-$ dmypy run -- foo --follow-imports=error
+$ dmypy run -- foo --follow-imports=error --python-version=3.6 | {python} -c 'import sys; sys.stdout.write(sys.stdin.read().replace("\\", "/"))'
 foo/lol.py:1: error: Name 'fail' is not defined
 Found 1 error in 1 file (checked 3 source files)
-== Return code: 1
 $ {python} -c "print('[mypy]')" >mypy.ini
 $ {python} -c "print('ignore_errors=True')" >>mypy.ini
-$ dmypy run -- foo --follow-imports=error
+$ dmypy run -- foo --follow-imports=error --python-version=3.6 | {python} -c 'import sys; sys.stdout.write(sys.stdin.read().replace("\\", "/"))'
 Restarting: configuration changed
 Daemon stopped
 Daemon started

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -102,16 +102,18 @@ def plugin(version): return Dummy
 [case testDaemonRunRestartGlobs]
 -- Ensure dmypy is not restarted if the configuration doesn't change and it contains globs
 -- Note: Backslash path separator in output is replaced with forward slash so the same test succeeds on Windows as well
-$ dmypy run -- foo --follow-imports=error --python-version=3.6 | {python} -c 'import sys; sys.stdout.write(sys.stdin.read().replace("\\", "/"))'
+$ dmypy run -- foo --follow-imports=error --python-version=3.6
 Daemon started
 foo/lol.py:1: error: Name 'fail' is not defined
 Found 1 error in 1 file (checked 3 source files)
-$ dmypy run -- foo --follow-imports=error --python-version=3.6 | {python} -c 'import sys; sys.stdout.write(sys.stdin.read().replace("\\", "/"))'
+== Return code: 1
+$ dmypy run -- foo --follow-imports=error --python-version=3.6
 foo/lol.py:1: error: Name 'fail' is not defined
 Found 1 error in 1 file (checked 3 source files)
+== Return code: 1
 $ {python} -c "print('[mypy]')" >mypy.ini
 $ {python} -c "print('ignore_errors=True')" >>mypy.ini
-$ dmypy run -- foo --follow-imports=error --python-version=3.6 | {python} -c 'import sys; sys.stdout.write(sys.stdin.read().replace("\\", "/"))'
+$ dmypy run -- foo --follow-imports=error --python-version=3.6
 Restarting: configuration changed
 Daemon stopped
 Daemon started

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -99,6 +99,38 @@ from mypy.plugin import Plugin
 class Dummy(Plugin): pass
 def plugin(version): return Dummy
 
+[case testDaemonRunRestartGlobs]
+-- Ensure dmypy is not restarted if the configuration doesn't change and it contains globs
+$ dmypy run -- foo --follow-imports=error
+Daemon started
+foo/lol.py:1: error: Name 'fail' is not defined
+Found 1 error in 1 file (checked 3 source files)
+== Return code: 1
+$ dmypy run -- foo --follow-imports=error
+foo/lol.py:1: error: Name 'fail' is not defined
+Found 1 error in 1 file (checked 3 source files)
+== Return code: 1
+$ {python} -c "print('[mypy]')" >mypy.ini
+$ {python} -c "print('ignore_errors=True')" >>mypy.ini
+$ dmypy run -- foo --follow-imports=error
+Restarting: configuration changed
+Daemon stopped
+Daemon started
+Success: no issues found in 3 source files
+$ dmypy stop
+Daemon stopped
+[file mypy.ini]
+\[mypy]
+ignore_errors = True
+\[mypy-*.lol]
+ignore_errors = False
+
+[file foo/__init__.py]
+[file foo/lol.py]
+fail
+[file foo/ok.py]
+a: int = 1
+
 [case testDaemonStatusKillRestartRecheck]
 $ dmypy status
 No status file found


### PR DESCRIPTION
If a configuration contains globs, then dmypy incorrectly detected
that the configration changed even though it did not.
This caused the daemon to always restart if a configuration contained globs.

Fixes #7576.