### PR TITLE
Skip some stubgen tests on Windows

### DIFF
--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -31,6 +31,7 @@ from mypy.moduleinspect import ModuleInspect, InspectError
 class StubgenCmdLineSuite(unittest.TestCase):
     """Test cases for processing command-line options and finding files."""
 
+    @unittest.skipIf(sys.platform == 'win32', "clean up fails on Windows")
     def test_files_found(self) -> None:
         current = os.getcwd()
         with tempfile.TemporaryDirectory() as tmp:
@@ -51,6 +52,7 @@ class StubgenCmdLineSuite(unittest.TestCase):
             finally:
                 os.chdir(current)
 
+    @unittest.skipIf(sys.platform == 'win32', "clean up fails on Windows")
     def test_packages_found(self) -> None:
         current = os.getcwd()
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
It appears they do not work. If I had to guess, its something to do with the order in which the contexts are cleaned up. Perhaps reversing the nesting of the `with` and `try/finally` would help.