### PR TITLE
Fix plugin invocation on classmethod calls through `Type`

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -382,6 +382,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             # We "unwrap" it to a regular type, as the class/instance method difference doesn't
             # affect the fully qualified name.
             object_type = get_proper_type(object_type.ret_type)
+        elif isinstance(object_type, TypeType):
+            object_type = object_type.item
 
         type_name = None
         if isinstance(object_type, Instance):

--- a/test-data/unit/fine-grained-suggest.test
+++ b/test-data/unit/fine-grained-suggest.test
@@ -684,10 +684,11 @@ No guesses that match criteria!
 () -> None
 ==
 
-[case testSuggestInferClassMethod]
+[case testSuggestClassMethod]
 # flags: --strict-optional
 # suggest: foo.F.bar
 # suggest: foo.F.baz
+# suggest: foo.F.eggs
 [file foo.py]
 class F:
     @classmethod
@@ -697,6 +698,15 @@ class F:
     @staticmethod
     def baz(x, y):
         return x
+
+    @classmethod
+    def spam(cls):
+        # type: () -> None
+        cls.eggs(4)
+
+    @classmethod
+    def eggs(cls, x):
+        pass
 
 [file bar.py]
 from foo import F
@@ -709,6 +719,7 @@ def bar(iany) -> None:
 [out]
 (int, int) -> int
 (str, int) -> str
+(int) -> None
 ==
 
 [case testSuggestColonBasic]


### PR DESCRIPTION
We weren't computing the proper fullname through TypeType (only
through type obj callables. Maybe we should get rid of those...)

This fixes these getting missed by suggestions.