### PR TITLE
[suggest] Rework max guesses and eliminate max args

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -116,6 +116,8 @@ p.add_argument('--callsites', action='store_true',
                help="Find callsites instead of suggesting a type")
 p.add_argument('--use-fixme', metavar='NAME', type=str,
                help="A dummy name to use instead of Any for types that can't be inferred")
+p.add_argument('--max-guesses', type=int,
+               help="Set the maximum number of types to try for a function (default 64)")
 
 hang_parser = p = subparsers.add_parser('hang', help="Hang for 100 seconds")
 
@@ -370,7 +372,7 @@ def do_suggest(args: argparse.Namespace) -> None:
     response = request(args.status_file, 'suggest', function=args.function,
                        json=args.json, callsites=args.callsites, no_errors=args.no_errors,
                        no_any=args.no_any, flex_any=args.flex_any, try_text=args.try_text,
-                       use_fixme=args.use_fixme)
+                       use_fixme=args.use_fixme, max_guesses=args.max_guesses)
     check_output(response, verbose=False, junit_xml=None, perf_stats_file=None)
 
 

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -418,9 +418,6 @@ class SuggestionEngine:
 
         is_method = bool(node.info) and not node.is_static
 
-        if len(node.arg_names) >= 10:
-            raise SuggestionFailure("Too many arguments")
-
         with strict_optional_set(graph[mod].options.strict_optional):
             guesses = self.get_guesses(
                 is_method,

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -283,11 +283,13 @@ class FineGrainedSuite(DataSuite):
             flex_any = float(m.group(1)) if m else None
             m = re.match(r'--use-fixme=(\w+)', flags)
             use_fixme = m.group(1) if m else None
+            m = re.match('--max-guesses=([0-9]+)', flags)
+            max_guesses = int(m.group(1)) if m else None
             res = cast(Dict[str, Any],
                        server.cmd_suggest(
                            target.strip(), json=json, no_any=no_any, no_errors=no_errors,
                            try_text=try_text, flex_any=flex_any, use_fixme=use_fixme,
-                           callsites=callsites))
+                           callsites=callsites, max_guesses=max_guesses))
             val = res['error'] if 'error' in res else res['out'] + res['err']
             if json:
                 # JSON contains already escaped \ on Windows, so requires a bit of care.

--- a/test-data/unit/fine-grained-suggest.test
+++ b/test-data/unit/fine-grained-suggest.test
@@ -44,6 +44,23 @@ bar.py:4: (arg=str)
 bar.py:6: (*typing.List[str])
 bar.py:8: (**typing.Dict[str, str])
 
+[case testMaxGuesses]
+# suggest: foo.foo
+# suggest: --max-guesses=2 foo.foo
+[file foo.py]
+# This idea here is that we can only find the union type with more guesses.
+def foo(x, y):
+    if not isinstance(x, int):
+        x+'1'
+
+foo(1, 2)
+foo('3', '4')
+[builtins fixtures/isinstancelist.pyi]
+[out]
+(Union[int, str], object) -> None
+(object, object) -> None
+==
+
 [case testSuggestInferFunc1]
 # flags: --strict-optional
 # suggest: foo.foo

--- a/test-data/unit/fine-grained-suggest.test
+++ b/test-data/unit/fine-grained-suggest.test
@@ -48,7 +48,7 @@ bar.py:8: (**typing.Dict[str, str])
 # suggest: foo.foo
 # suggest: --max-guesses=2 foo.foo
 [file foo.py]
-# This idea here is that we can only find the union type with more guesses.
+# The idea here is that we can only find the union type with more guesses.
 def foo(x, y):
     if not isinstance(x, int):
         x+'1'


### PR DESCRIPTION
Rework max guesses to be configurable and to throw out guesses past
the limit instead of just hard failing. This might allow succeeding in
more situations. Eliminate the maximum argument restriction since we
no longer have to compute all of the options even if we don't try
that.