### PR TITLE
fixes #6513 change "Cannot find module" message

### DIFF
--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -489,7 +489,7 @@ class SuggestionEngine:
         else:
             target = split_target(self.fgmanager.graph, key)
             if not target:
-                raise SuggestionFailure("Cannot find module for %s" % (key,))
+                raise SuggestionFailure("Cannot find module type information for %s" % (key,))
             modname, tail = target
             node = self.find_node_by_module_and_name(modname, tail)
 


### PR DESCRIPTION
An attempt to make message less confusing.
Right it seems quite common for new users to be
1) get confused, try to figure out why mypy doesn't see the installed module
2) google for a problem, get a hit on a mypy website FAQ and only then
learn what this error is really about

Hopefully adding info that is not about module, but its type information
will speedup this process.
It also should make message itself more googlable that "cannot find
module" which does not return relevant sites unless `mypy` is added to
keywords.