### PR TITLE
[suggest] Fix inference from collection literals

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -108,6 +108,13 @@ def _infer_constraints(template: Type, actual: Type,
     template = get_proper_type(template)
     actual = get_proper_type(actual)
 
+    # Ignore Any types from the type suggestion engine to avoid them
+    # causing us to infer Any in situations where a better job could
+    # be done otherwise. (This can produce false positives but that
+    # doesn't really matter because it is all heuristic anyway.)
+    if isinstance(actual, AnyType) and actual.type_of_any == TypeOfAny.suggestion_engine:
+        return []
+
     # If the template is simply a type variable, emit a Constraint directly.
     # We need to handle this case before handling Unions for two reasons:
     #  1. "T <: Union[U1, U2]" is not equivalent to "T <: U1 or T <: U2",

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -103,6 +103,8 @@ class TypeOfAny:
     from_another_any = 7  # type: Final
     # Does this Any come from an implementation limitation/bug?
     implementation_artifact = 8  # type: Final
+    # Does this Any come from use in the suggestion engine?
+    suggestion_engine = 9  # type: Final
 
 
 def deserialize_type(data: Union[JsonDict, str]) -> 'Type':

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -103,7 +103,9 @@ class TypeOfAny:
     from_another_any = 7  # type: Final
     # Does this Any come from an implementation limitation/bug?
     implementation_artifact = 8  # type: Final
-    # Does this Any come from use in the suggestion engine?
+    # Does this Any come from use in the suggestion engine?  This is
+    # used to ignore Anys inserted by the suggestion engine when
+    # generating constraints.
     suggestion_engine = 9  # type: Final
 
 

--- a/test-data/unit/fine-grained-suggest.test
+++ b/test-data/unit/fine-grained-suggest.test
@@ -908,6 +908,41 @@ z = foo(f(), g())
 (foo.List[Any], UNKNOWN) -> Tuple[foo.List[Any], Any]
 ==
 
+[case testSuggestDict]
+# suggest: foo.foo
+# suggest: foo.bar
+# suggest: foo.baz
+# suggest: foo.quux
+# suggest: foo.spam
+[file foo.py]
+from typing import List, Any
+
+def foo():
+    return {'x': 5}
+
+def bar():
+    return {}
+
+def baz() -> List[Any]:
+    return [{'x': 5}]
+
+def quux() -> List[Any]:
+    return [1]
+
+def spam(x):
+    pass
+
+spam({'x': 5})
+
+[builtins fixtures/dict.pyi]
+[out]
+() -> typing.Dict[str, int]
+() -> typing.Dict[Any, Any]
+() -> foo:List[typing.Dict[str, int]]
+() -> foo.List[int]
+(typing.Dict[str, int]) -> None
+==
+
 [case testSuggestWithErrors]
 # suggest: foo.foo
 [file foo.py]


### PR DESCRIPTION
This is another take at #7810 which was reverted because it caused
internal trouble.

Do this by ignoring constraints with Any when the Any comes from the
suggestion engine. The Any context causes assigned types to be Any
overaggressively.  Restricting it only to Anys from the suggestion
engine avoids the issues seen last time. Doing it at a fine-grained
level in constraints allows us to do better refining things like `List[Any]`.