### PR TITLE
[mypyc] Handle non-extension classes with built-in bases

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1373,7 +1373,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         for non-extension classes.
         """
         ir = self.mapper.type_to_ir[cdef.info]
-        bases = []
         for cls in cdef.info.mro[1:]:
             if cls.fullname == 'builtins.object':
                 continue
@@ -1383,8 +1382,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 if base_ir.children is not None:
                     base_ir.children.append(ir)
 
-            base = self.load_global_str(cls.name, cdef.line)
-            bases.append(base)
+        bases = [self.load_global(expr) for expr in cdef.base_type_exprs]
         return self.primitive_op(new_tuple_op, bases, cdef.line)
 
     def add_to_non_ext_dict(self, non_ext: NonExtClassInfo,


### PR DESCRIPTION
For both of these class definitions, Mypyc will generate the equivalent of `globals()["int"]`, which will raise `KeyError: 'int'` (as `int` is a built-in, not a global).

```python
from enum import Enum, IntEnum


class A(IntEnum):
    pass


class B(int, Enum):
    pass
```

I'm incredibly unfamiliar with the Mypy codebase, but I think this is the correct solution.

---

Consider the following class definition:

```python
class MyClass(IntEnum):
    ...
```

CPython would call `EnumMeta.__new__(bases=[IntEnum])`. On the other hand, Mypyc would use the MRO (with `MyClass` and `builtins.object` removed) and call `EnumMeta.__new__(bases=[IntEnum, int, Enum])`.

Additionally, due to the use of `load_global_str` instead of `load_global`, it would attempt to retrieve `globals()["int"]`, which would raise a `KeyError` at runtime.

This is fixed by using the base type expressions in the class definition instead of the MRO, and using `load_global` instead of `load_global_str` (which correctly handles built-ins).