### PR TITLE
[mypyc] Don't make classes non-extension because of children

### DIFF
--- a/mypyc/test-data/commandline.test
+++ b/mypyc/test-data/commandline.test
@@ -148,6 +148,10 @@ class Concrete2:
 class Trait2(Concrete2):
     pass
 
+@decorator
+class NonExt(Concrete1):  # E: Non-extension classes may not inherit from extension classes
+    pass
+
 class Nope(Trait1, Concrete2):  # E: Non-trait bases must appear first in parent list  # E: Non-trait MRO must be linear
     pass
 

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -63,6 +63,7 @@ from typing import Any
 def decorator(cls) -> Any:
     return cls
 
+@decorator
 class C:
     def __init__(self) -> None:
         self.c = 3
@@ -70,6 +71,7 @@ class C:
     def get_c(self) -> int:
         return self.c
 
+@decorator
 class B(C):
     def __init__(self) -> None:
         super().__init__()


### PR DESCRIPTION
This is a global behavior that will be solidly busted when doing
separate compilation. Produce an error instead. (We can probably
support it once we support interpreted inheritance.)