### PR TITLE
[mypyc] Fix some deserialization related issues

### DIFF
--- a/mypyc/test-data/run-multimodule.test
+++ b/mypyc/test-data/run-multimodule.test
@@ -30,6 +30,41 @@ except TypeError:
 else:
     assert False
 
+[case testMultiModuleFastpaths]
+[file other_main.py]
+
+[file other_main.py.2]
+from other_b import A, func
+
+class B(A):
+    pass
+
+def test() -> None:
+    a = A()
+    assert func() == 12
+    assert a.method() == "test"
+
+test()
+
+[file other_b.py]
+class A:
+    def method(self) -> str:
+        return "test"
+
+def func() -> int:
+    return 12
+
+# Remove all the methods and functions from globals to ensure that
+# they get called via the fastpaths even when doing incremental
+# compilation.
+setattr(A, 'method', None)
+setattr(A, '__init__', None)
+globals()['func'] = None
+globals()['A'] = None
+
+[file driver.py]
+import other_main
+
 [case testMultiModuleSameNames]
 # Use same names in both modules
 import other

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -224,8 +224,10 @@ class TestRun(MypycDataSuite):
                 print(line)
             assert False, 'Compile error'
 
-        # Check that serialization works on this IR
-        check_serialization_roundtrip(ir)
+        # Check that serialization works on this IR. (Only on the first
+        # step because the the returned ir only includes updated code.)
+        if incremental_step == 1:
+            check_serialization_roundtrip(ir)
 
         setup_file = os.path.abspath(os.path.join(WORKDIR, 'setup.py'))
         # We pass the C file information to the build script via setup.py unfortunately


### PR DESCRIPTION
Certain parts of the mypy AST aren't present and we were relying on
them anyways. This caused a crash when subclassing and classes not
making it into the type table, preventing using fast paths.