### PR TITLE
Don't shorten long generic types in messages

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1438,15 +1438,11 @@ def format_type_inner(typ: Type,
             return '{}[{}]'.format(alias, ', '.join(items))
         else:
             # There are type arguments. Convert the arguments to strings.
-            # If the result is too long, replace arguments with [...].
             a = []  # type: List[str]
             for arg in itype.args:
                 a.append(format(arg))
             s = ', '.join(a)
-            if len((base_str + s)) < 150:
-                return '{}[{}]'.format(base_str, s)
-            else:
-                return '{}[...]'.format(base_str)
+            return '{}[{}]'.format(base_str, s)
     elif isinstance(typ, TypeVarType):
         # This is similar to non-generic instance types.
         return typ.name

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1349,7 +1349,7 @@ Z = TypeVar('Z')
 class OO: pass
 a = None # type: A[object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object]
 
-f(a) # E: Argument 1 to "f" has incompatible type "A[...]"; expected "OO"
+f(a) # E: Argument 1 to "f" has incompatible type "A[object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object]"; expected "OO"
 
 def f(a: OO) -> None:
     pass
@@ -2337,4 +2337,3 @@ class Test():
     reveal_type(MakeTwoAppliedSubAbstract()(2)) # N: Revealed type is '__main__.TwoTypes[builtins.str, builtins.int*]'
     reveal_type(MakeTwoGenericSubAbstract[str]()('foo')) # N: Revealed type is '__main__.TwoTypes[builtins.str, builtins.str*]'
     reveal_type(MakeTwoGenericSubAbstract[str]()(2)) # N: Revealed type is '__main__.TwoTypes[builtins.str, builtins.int*]'
-


### PR DESCRIPTION
Shortened names can be confusing.