### PR TITLE
Remove a semi-broken stubgen assert

### DIFF
--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -861,7 +861,6 @@ class ModuleInspectSuite(unittest.TestCase):
             p = m.get_package_properties('_socket')
             assert p is not None
             assert p.name == '_socket'
-            assert p.file
             assert p.path is None
             assert p.is_c_module is True
             assert p.subpackages == []


### PR DESCRIPTION
C modules in the standard library don't seem to have a __file__ in
the Python distributions that ship with Ubuntu. I think maybe they
are built into the binary? I don't know.