### PR TITLE
[mypyc] Fix overloaded methods in non-extension classes

### DIFF
--- a/mypyc/test-data/commandline.test
+++ b/mypyc/test-data/commandline.test
@@ -155,6 +155,16 @@ class NonExt(Concrete1):  # E: Non-extension classes may not inherit from extens
 class Nope(Trait1, Concrete2):  # E: Non-trait bases must appear first in parent list  # E: Non-trait MRO must be linear
     pass
 
+@decorator
+class NonExt2:
+    @property  # E: Property setters not supported in non-extension classes
+    def test(self) -> int:
+        pass
+
+    @test.setter
+    def test(self, x: int) -> None:
+        pass
+
 iterator_warning = (i+1 for i in range(10))  # W: Treating generator comprehension as list
 
 # But we don't want warnings for these cases:

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -57,8 +57,8 @@ assert hasattr(c, 'x')
 1000000000000000000000000000001
 1000000000000000000000000000002
 
-[case testNonExtInheritance]
-from typing import Any
+[case testNonExtMisc]
+from typing import Any, overload
 
 def decorator(cls) -> Any:
     return cls
@@ -93,8 +93,22 @@ class A(B):
     def get_a(self) -> int:
         return self.a
 
+@decorator
+class Overload:
+    @overload
+    def get(self, index: int) -> int: ...
+
+    @overload
+    def get(self, index: str) -> str: ...
+
+    def get(self, index: Any) -> Any:
+        return index
+
+def get(c: Overload, s: str) -> str:
+    return c.get(s)
+
 [file driver.py]
-from native import A
+from native import A, Overload, get
 a = A()
 assert a.a == 1
 assert a.b == 2
@@ -103,6 +117,10 @@ assert a.get_a() == 1
 assert a.get_b() == 2
 assert a.get_c() == 3
 assert A.constant() == 4
+
+o = Overload()
+assert get(o, "test") == "test"
+assert o.get(20) == 20
 
 [case testEnum]
 from enum import Enum


### PR DESCRIPTION
Closes mypyc/mypyc#708.
Fixes a crash into an error message for overloads also.