### PR TITLE
Treat --python-version X.Y and --python-version=X.Y in tests equally

### DIFF
--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -375,7 +375,6 @@ def parse_options(program_text: str, testcase: DataDrivenTestCase,
         if flags2:
             flags = flags2
 
-    flag_list = None
     if flags:
         flag_list = flags.group(1).split()
         flag_list.append('--no-site-packages')  # the tests shouldn't need an installed Python
@@ -384,6 +383,7 @@ def parse_options(program_text: str, testcase: DataDrivenTestCase,
             # TODO: support specifying targets via the flags pragma
             raise RuntimeError('Specifying targets via the flags pragma is not supported.')
     else:
+        flag_list = []
         options = Options()
         # TODO: Enable strict optional in test cases by default (requires *many* test case changes)
         options.strict_optional = False

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -391,7 +391,8 @@ def parse_options(program_text: str, testcase: DataDrivenTestCase,
 
     # Allow custom python version to override testcase_pyversion
     if (not flag_list or
-            all(flag not in flag_list for flag in ['--python-version', '-2', '--py2'])):
+            all(flag.split('=')[0] not in ['--python-version', '-2', '--py2']
+                for flag in flag_list)):
         options.python_version = testcase_pyversion(testcase.file, testcase.name)
 
     if testcase.config.getoption('--mypy-verbose'):

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -389,10 +389,8 @@ def parse_options(program_text: str, testcase: DataDrivenTestCase,
         options.strict_optional = False
         options.error_summary = False
 
-    # Allow custom python version to override testcase_pyversion
-    if (not flag_list or
-            all(flag.split('=')[0] not in ['--python-version', '-2', '--py2']
-                for flag in flag_list)):
+    # Allow custom python version to override testcase_pyversion.
+    if all(flag.split('=')[0] not in ['--python-version', '-2', '--py2'] for flag in flag_list):
         options.python_version = testcase_pyversion(testcase.file, testcase.name)
 
     if testcase.config.getoption('--mypy-verbose'):

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -216,12 +216,12 @@ expr_com_3 = ...   # type: Literal['3']
 expr_com_4 = ...   # type: Literal['True']
 expr_com_5 = ...   # type: Literal['None']
 expr_com_6 = ...   # type: Literal['"foo"']
-reveal_type(expr_com_1)  # N: Revealed type is 'Literal['a+b']'
-reveal_type(expr_com_2)  # N: Revealed type is 'Literal['1+2']'
-reveal_type(expr_com_3)  # N: Revealed type is 'Literal['3']'
-reveal_type(expr_com_4)  # N: Revealed type is 'Literal['True']'
-reveal_type(expr_com_5)  # N: Revealed type is 'Literal['None']'
-reveal_type(expr_com_6)  # N: Revealed type is 'Literal['"foo"']'
+reveal_type(expr_com_1)  # N: Revealed type is 'Literal[u'a+b']'
+reveal_type(expr_com_2)  # N: Revealed type is 'Literal[u'1+2']'
+reveal_type(expr_com_3)  # N: Revealed type is 'Literal[u'3']'
+reveal_type(expr_com_4)  # N: Revealed type is 'Literal[u'True']'
+reveal_type(expr_com_5)  # N: Revealed type is 'Literal[u'None']'
+reveal_type(expr_com_6)  # N: Revealed type is 'Literal[u'"foo"']'
 [builtins fixtures/bool.pyi]
 [out]
 


### PR DESCRIPTION
While working on https://github.com/python/mypy/pull/8024 I noticed that `# flags: --python-version X.Y` and `# flags: --python-version=X.Y` are not treated equally by the test harness, namely the latter is actually ignored. This PR should fix this, because both forms are actually used in tests.

@Michael0x2a there is some suspicious change in literal types, is it expected?