### PR TITLE
Mypy daemon is no longer experimental

### DIFF
--- a/docs/source/mypy_daemon.rst
+++ b/docs/source/mypy_daemon.rst
@@ -21,8 +21,8 @@ you'll find errors sooner.
 
 .. note::
 
-    The mypy daemon is experimental. In particular, the command-line
-    interface may change in future mypy releases.
+    The command-line of interface of mypy daemon may change in future mypy
+    releases.
 
 .. note::
 


### PR DESCRIPTION
The mypy daemon has been the default way of running mypy locally
at Dropbox for well over a year. It's quite stable, though a few important
features are missing.