### PR TITLE
Support generic partial types for attributes

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2165,6 +2165,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             assert isinstance(typ, PartialType)
             if typ.type is None:
                 return
+            # TODO: some logic here duplicates the None partial type counterpart
+            #       inlined in check_assignment(), see # 8043.
             partial_types = self.find_partial_types(var)
             if partial_types is None:
                 return

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4340,7 +4340,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 # All scopes within the outermost function are active. Scopes out of
                 # the outermost function are inactive to allow local reasoning (important
                 # for fine-grained incremental mode).
-                scope_active = (not self.options.local_partial_types
+                disallow_other_scopes = self.options.local_partial_types
+
+                if isinstance(var.type, PartialType) and var.type.type is not None and var.info:
+                    # This is an ugly hack to make partial generic self attributes behave
+                    # as if --local-partial-types is always on (because it used to be like this).
+                    disallow_other_scopes = True
+
+                scope_active = (not disallow_other_scopes
                                 or scope.is_local == self.partial_types[-1].is_local)
                 return scope_active, scope.is_local, scope.map
         return False, False, None

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -538,14 +538,20 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return callee
 
     def get_partial_self_var(self, expr: MemberExpr) -> Optional[Var]:
+        """Get variable node for a partial self attribute.
+
+        If the expression is not a self attribute, or attribute is not variable,
+        or variable is not partial, return None.
+        """
         if not (isinstance(expr.expr, NameExpr) and
                 isinstance(expr.expr.node, Var) and expr.expr.node.is_self):
+            # Not a self.attr expression.
             return None
         info = self.chk.scope.enclosing_class()
         if not info or expr.name not in info.names:
+            # Don't mess with partial types in superclasses.
             return None
         sym = info.names[expr.name]
-        # TODO: check implicit (add tests for defined in class body, both orders)?
         if isinstance(sym.node, Var) and isinstance(sym.node.type, PartialType):
             return sym.node
         return None

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1591,7 +1591,7 @@ class C:
         self.a = []
         if bool():
             self.a = [1]
-reveal_type(C().a)
+reveal_type(C().a)  # N: Revealed type is 'builtins.list[builtins.int*]'
 [builtins fixtures/list.pyi]
 
 [case testInferAttributeInitializedToEmptyAndAppended]
@@ -1600,7 +1600,7 @@ class C:
         self.a = []
         if bool():
             self.a.append(1)
-reveal_type(C().a)
+reveal_type(C().a)  # N: Revealed type is 'builtins.list[builtins.int]'
 [builtins fixtures/list.pyi]
 
 [case testInferAttributeInitializedToEmptyAndAssignedItem]
@@ -1609,7 +1609,7 @@ class C:
         self.a = {}
         if bool():
             self.a[0] = 'yes'
-reveal_type(C().a)
+reveal_type(C().a)  # N: Revealed type is 'builtins.dict[builtins.int, builtins.str]'
 [builtins fixtures/dict.pyi]
 
 [case testInferAttributeInitializedToNoneAndAssigned]
@@ -1619,33 +1619,33 @@ class C:
         self.a = None
         if bool():
             self.a = 1
-reveal_type(C().a)
+reveal_type(C().a)  # N: Revealed type is 'Union[builtins.int, None]'
 
 [case testInferAttributeInitializedToEmptyAndAssignedOtherMethod]
 class C:
     def __init__(self) -> None:
-        self.a = []
+        self.a = []  # E: Need type annotation for 'a' (hint: "a: List[<type>] = ...")
     def meth(self) -> None:
         self.a = [1]
-reveal_type(C().a)
+reveal_type(C().a)  # N: Revealed type is 'builtins.list[Any]'
 [builtins fixtures/list.pyi]
 
 [case testInferAttributeInitializedToEmptyAndAppendedOtherMethod]
 class C:
     def __init__(self) -> None:
-        self.a = []
+        self.a = []  # E: Need type annotation for 'a' (hint: "a: List[<type>] = ...")
     def meth(self) -> None:
         self.a.append(1)
-reveal_type(C().a)
+reveal_type(C().a)  # N: Revealed type is 'builtins.list[Any]'
 [builtins fixtures/list.pyi]
 
 [case testInferAttributeInitializedToEmptyAndAssignedItemOtherMethod]
 class C:
     def __init__(self) -> None:
-        self.a = {}
+        self.a = {}  # E: Need type annotation for 'a' (hint: "a: Dict[<type>, <type>] = ...")
     def meth(self) -> None:
         self.a[0] = 'yes'
-reveal_type(C().a)
+reveal_type(C().a)  # N: Revealed type is 'builtins.dict[Any, Any]'
 [builtins fixtures/dict.pyi]
 
 [case testInferAttributeInitializedToNoneAndAssignedOtherMethod]
@@ -1654,8 +1654,75 @@ class C:
     def __init__(self) -> None:
         self.a = None
     def meth(self) -> None:
+        self.a = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "None")
+reveal_type(C().a)  # N: Revealed type is 'None'
+
+[case testInferAttributeInitializedToEmptyAndAssignedClassBody]
+class C:
+    a = []
+    def __init__(self) -> None:
+        self.a = [1]
+reveal_type(C().a)  # N: Revealed type is 'builtins.list[builtins.int*]'
+[builtins fixtures/list.pyi]
+
+[case testInferAttributeInitializedToEmptyAndAppendedClassBody]
+class C:
+    a = []
+    def __init__(self) -> None:
+        self.a.append(1)
+reveal_type(C().a)  # N: Revealed type is 'builtins.list[builtins.int]'
+[builtins fixtures/list.pyi]
+
+[case testInferAttributeInitializedToEmptyAndAssignedItemClassBody]
+class C:
+    a = {}
+    def __init__(self) -> None:
+        self.a[0] = 'yes'
+reveal_type(C().a)  # N: Revealed type is 'builtins.dict[builtins.int, builtins.str]'
+[builtins fixtures/dict.pyi]
+
+[case testInferAttributeInitializedToNoneAndAssignedClassBody]
+# flags: --strict-optional
+class C:
+    a = None
+    def __init__(self) -> None:
         self.a = 1
-reveal_type(C().a)
+reveal_type(C().a)  # N: Revealed type is 'Union[builtins.int, None]'
+
+[case testInferAttributeInitializedToEmptyAndAssignedClassBodyLocal]
+# flags: --local-partial-types
+class C:
+    a = []  # E: Need type annotation for 'a' (hint: "a: List[<type>] = ...")
+    def __init__(self) -> None:
+        self.a = [1]
+reveal_type(C().a)  # N: Revealed type is 'builtins.list[Any]'
+[builtins fixtures/list.pyi]
+
+[case testInferAttributeInitializedToEmptyAndAppendedClassBodyLocal]
+# flags: --local-partial-types
+class C:
+    a = []  # E: Need type annotation for 'a' (hint: "a: List[<type>] = ...")
+    def __init__(self) -> None:
+        self.a.append(1)
+reveal_type(C().a)  # N: Revealed type is 'builtins.list[Any]'
+[builtins fixtures/list.pyi]
+
+[case testInferAttributeInitializedToEmptyAndAssignedItemClassBodyLocal]
+# flags: --local-partial-types
+class C:
+    a = {}  # E: Need type annotation for 'a' (hint: "a: Dict[<type>, <type>] = ...")
+    def __init__(self) -> None:
+        self.a[0] = 'yes'
+reveal_type(C().a)  # N: Revealed type is 'builtins.dict[Any, Any]'
+[builtins fixtures/dict.pyi]
+
+[case testInferAttributeInitializedToNoneAndAssignedClassBodyLocal]
+# flags: --strict-optional --local-partial-types
+class C:
+    a = None  # E: Need type annotation for 'a'
+    def __init__(self) -> None:
+        self.a = 1
+reveal_type(C().a)  # N: Revealed type is 'Union[Any, None]'
 
 
 -- Inferring types of variables first initialized to None (partial types)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1621,6 +1621,17 @@ class C:
             self.a = 1
 reveal_type(C().a)  # N: Revealed type is 'Union[builtins.int, None]'
 
+[case testInferAttributeInitializedToEmptyNonSelf]
+class C:
+    def __init__(self) -> None:
+        self.a = []  # E: Need type annotation for 'a' (hint: "a: List[<type>] = ...")
+        if bool():
+            a = self
+            a.a = [1]
+            a.a.append(1)
+reveal_type(C().a)  # N: Revealed type is 'builtins.list[Any]'
+[builtins fixtures/list.pyi]
+
 [case testInferAttributeInitializedToEmptyAndAssignedOtherMethod]
 class C:
     def __init__(self) -> None:
@@ -1659,26 +1670,26 @@ reveal_type(C().a)  # N: Revealed type is 'None'
 
 [case testInferAttributeInitializedToEmptyAndAssignedClassBody]
 class C:
-    a = []
+    a = []  # E: Need type annotation for 'a' (hint: "a: List[<type>] = ...")
     def __init__(self) -> None:
         self.a = [1]
-reveal_type(C().a)  # N: Revealed type is 'builtins.list[builtins.int*]'
+reveal_type(C().a)  # N: Revealed type is 'builtins.list[Any]'
 [builtins fixtures/list.pyi]
 
 [case testInferAttributeInitializedToEmptyAndAppendedClassBody]
 class C:
-    a = []
+    a = []  # E: Need type annotation for 'a' (hint: "a: List[<type>] = ...")
     def __init__(self) -> None:
         self.a.append(1)
-reveal_type(C().a)  # N: Revealed type is 'builtins.list[builtins.int]'
+reveal_type(C().a)  # N: Revealed type is 'builtins.list[Any]'
 [builtins fixtures/list.pyi]
 
 [case testInferAttributeInitializedToEmptyAndAssignedItemClassBody]
 class C:
-    a = {}
+    a = {}  # E: Need type annotation for 'a' (hint: "a: Dict[<type>, <type>] = ...")
     def __init__(self) -> None:
         self.a[0] = 'yes'
-reveal_type(C().a)  # N: Revealed type is 'builtins.dict[builtins.int, builtins.str]'
+reveal_type(C().a)  # N: Revealed type is 'builtins.dict[Any, Any]'
 [builtins fixtures/dict.pyi]
 
 [case testInferAttributeInitializedToNoneAndAssignedClassBody]
@@ -1688,41 +1699,6 @@ class C:
     def __init__(self) -> None:
         self.a = 1
 reveal_type(C().a)  # N: Revealed type is 'Union[builtins.int, None]'
-
-[case testInferAttributeInitializedToEmptyAndAssignedClassBodyLocal]
-# flags: --local-partial-types
-class C:
-    a = []  # E: Need type annotation for 'a' (hint: "a: List[<type>] = ...")
-    def __init__(self) -> None:
-        self.a = [1]
-reveal_type(C().a)  # N: Revealed type is 'builtins.list[Any]'
-[builtins fixtures/list.pyi]
-
-[case testInferAttributeInitializedToEmptyAndAppendedClassBodyLocal]
-# flags: --local-partial-types
-class C:
-    a = []  # E: Need type annotation for 'a' (hint: "a: List[<type>] = ...")
-    def __init__(self) -> None:
-        self.a.append(1)
-reveal_type(C().a)  # N: Revealed type is 'builtins.list[Any]'
-[builtins fixtures/list.pyi]
-
-[case testInferAttributeInitializedToEmptyAndAssignedItemClassBodyLocal]
-# flags: --local-partial-types
-class C:
-    a = {}  # E: Need type annotation for 'a' (hint: "a: Dict[<type>, <type>] = ...")
-    def __init__(self) -> None:
-        self.a[0] = 'yes'
-reveal_type(C().a)  # N: Revealed type is 'builtins.dict[Any, Any]'
-[builtins fixtures/dict.pyi]
-
-[case testInferAttributeInitializedToNoneAndAssignedClassBodyLocal]
-# flags: --strict-optional --local-partial-types
-class C:
-    a = None  # E: Need type annotation for 'a'
-    def __init__(self) -> None:
-        self.a = 1
-reveal_type(C().a)  # N: Revealed type is 'Union[Any, None]'
 
 
 -- Inferring types of variables first initialized to None (partial types)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1458,9 +1458,9 @@ class A:
 class A:
     def f(self) -> None:
         # Attributes aren't supported right now.
-        self.a = [] # E: Need type annotation for 'a' (hint: "a: List[<type>] = ...")
+        self.a = []
         self.a.append(1)
-        self.a.append('')
+        self.a.append('')  # E: Argument 1 to "append" of "list" has incompatible type "str"; expected "int"
 [builtins fixtures/list.pyi]
 
 [case testInferListInitializedToEmptyInClassBodyAndOverriden]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1585,6 +1585,78 @@ oo.update(d)
 reveal_type(oo) # N: Revealed type is 'collections.OrderedDict[builtins.int*, builtins.str*]'
 [builtins fixtures/dict.pyi]
 
+[case testInferAttributeInitializedToEmptyAndAssigned]
+class C:
+    def __init__(self) -> None:
+        self.a = []
+        if bool():
+            self.a = [1]
+reveal_type(C().a)
+[builtins fixtures/list.pyi]
+
+[case testInferAttributeInitializedToEmptyAndAppended]
+class C:
+    def __init__(self) -> None:
+        self.a = []
+        if bool():
+            self.a.append(1)
+reveal_type(C().a)
+[builtins fixtures/list.pyi]
+
+[case testInferAttributeInitializedToEmptyAndAssignedItem]
+class C:
+    def __init__(self) -> None:
+        self.a = {}
+        if bool():
+            self.a[0] = 'yes'
+reveal_type(C().a)
+[builtins fixtures/dict.pyi]
+
+[case testInferAttributeInitializedToNoneAndAssigned]
+# flags: --strict-optional
+class C:
+    def __init__(self) -> None:
+        self.a = None
+        if bool():
+            self.a = 1
+reveal_type(C().a)
+
+[case testInferAttributeInitializedToEmptyAndAssignedOtherMethod]
+class C:
+    def __init__(self) -> None:
+        self.a = []
+    def meth(self) -> None:
+        self.a = [1]
+reveal_type(C().a)
+[builtins fixtures/list.pyi]
+
+[case testInferAttributeInitializedToEmptyAndAppendedOtherMethod]
+class C:
+    def __init__(self) -> None:
+        self.a = []
+    def meth(self) -> None:
+        self.a.append(1)
+reveal_type(C().a)
+[builtins fixtures/list.pyi]
+
+[case testInferAttributeInitializedToEmptyAndAssignedItemOtherMethod]
+class C:
+    def __init__(self) -> None:
+        self.a = {}
+    def meth(self) -> None:
+        self.a[0] = 'yes'
+reveal_type(C().a)
+[builtins fixtures/dict.pyi]
+
+[case testInferAttributeInitializedToNoneAndAssignedOtherMethod]
+# flags: --strict-optional
+class C:
+    def __init__(self) -> None:
+        self.a = None
+    def meth(self) -> None:
+        self.a = 1
+reveal_type(C().a)
+
 
 -- Inferring types of variables first initialized to None (partial types)
 -- ----------------------------------------------------------------------

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -2744,6 +2744,69 @@ main:5: error: Need type annotation for 'x' (hint: "x: Dict[<type>, <type>] = ..
 ==
 main:5: error: Need type annotation for 'x' (hint: "x: Dict[<type>, <type>] = ...")
 
+[case testRefreshPartialTypeInferredAttributeIndex]
+from c import C
+reveal_type(C().a)
+[file c.py]
+from b import f
+class C:
+    def __init__(self) -> None:
+        self.a = {}
+        if bool():
+            self.a[0] = f()
+[file b.py]
+def f() -> int: ...
+[file b.py.2]
+from typing import List
+def f() -> str: ...
+[builtins fixtures/dict.pyi]
+[out]
+main:2: note: Revealed type is 'builtins.dict[builtins.int, builtins.int]'
+==
+main:2: note: Revealed type is 'builtins.dict[builtins.int, builtins.str]'
+
+[case testRefreshPartialTypeInferredAttributeAssign]
+from c import C
+reveal_type(C().a)
+[file c.py]
+from b import f
+class C:
+    def __init__(self) -> None:
+        self.a = []
+        if bool():
+            self.a = f()
+[file b.py]
+from typing import List
+def f() -> List[int]: ...
+[file b.py.2]
+from typing import List
+def f() -> List[str]: ...
+[builtins fixtures/list.pyi]
+[out]
+main:2: note: Revealed type is 'builtins.list[builtins.int]'
+==
+main:2: note: Revealed type is 'builtins.list[builtins.str]'
+
+[case testRefreshPartialTypeInferredAttributeAppend]
+from c import C
+reveal_type(C().a)
+[file c.py]
+from b import f
+class C:
+    def __init__(self) -> None:
+        self.a = []
+        if bool():
+            self.a.append(f())
+[file b.py]
+def f() -> int: ...
+[file b.py.2]
+def f() -> str: ...
+[builtins fixtures/list.pyi]
+[out]
+main:2: note: Revealed type is 'builtins.list[builtins.int]'
+==
+main:2: note: Revealed type is 'builtins.list[builtins.str]'
+
 [case testRefreshTryExcept]
 import a
 def f() -> None:

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -2714,6 +2714,7 @@ class C:
         class D:
             def __init__(self) -> None:
                 self.x = {}
+            def meth(self) -> None:
                 self.x['a'] = 'b'
 [file a.py]
 def g() -> None: pass
@@ -2731,6 +2732,7 @@ class D:
     def __init__(self) -> None:
         a.g()
         self.x = {}
+    def meth(self) -> None:
         self.x['a'] = 'b'
 [file a.py]
 def g() -> None: pass


### PR DESCRIPTION
Work towards https://github.com/python/mypy/issues/1055

Currently partial types are supported for local variables. However, only partial `None` types are supported for `self` attributes. This PR adds the same level of support to generic partial types. They follow mostly the same rules:
* A partial type can be refined in the _same_ method where it is defined.
* But a partial type from class body can not be refined in a method, as if `local_partial_types = True`.

The logic is pretty simple: the `.node` attribute for `self.attr` expressions is set to `None`, so I added a little helper to get it from the class symbol table instead.

I add tests for various scenarios, including for partial `None` types. It may happen they are already tested elsewhere, but this way it is easy to compare side-by-side behavior is consistent for both kinds of partial types. I can remove them if you think they are redundant.
