### PR TITLE
Fix 0.750 regression: union (non-)simplification should not affect inference

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -108,6 +108,12 @@ def _infer_constraints(template: Type, actual: Type,
     template = get_proper_type(template)
     actual = get_proper_type(actual)
 
+    # Type inference shouldn't be affected by whether union types have bee simplified.
+    if isinstance(template, UnionType):
+        template = mypy.typeops.make_simplified_union(template.items)
+    if isinstance(actual, UnionType):
+        actual = mypy.typeops.make_simplified_union(actual.items)
+
     # Ignore Any types from the type suggestion engine to avoid them
     # causing us to infer Any in situations where a better job could
     # be done otherwise. (This can produce false positives but that

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -108,7 +108,7 @@ def _infer_constraints(template: Type, actual: Type,
     template = get_proper_type(template)
     actual = get_proper_type(actual)
 
-    # Type inference shouldn't be affected by whether union types have bee simplified.
+    # Type inference shouldn't be affected by whether union types have been simplified.
     if isinstance(template, UnionType):
         template = mypy.typeops.make_simplified_union(template.items)
     if isinstance(actual, UnionType):

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2924,3 +2924,18 @@ reveal_type(q2(z))  # N: Revealed type is '__main__.B*'
 reveal_type(q1(Z(b)))  # N: Revealed type is '__main__.B*'
 reveal_type(q2(Z(b)))  # N: Revealed type is '__main__.B*'
 [builtins fixtures/isinstancelist.pyi]
+
+[case testUnionInvariantSubClassAndCovariantBase]
+from typing import Union, Generic, TypeVar
+
+T = TypeVar('T')
+T_co = TypeVar('T_co', covariant=True)
+
+class Cov(Generic[T_co]): ...
+class Inv(Cov[T]): ...
+
+X = Union[Cov[T], Inv[T]]
+
+def f(x: X[T]) -> T: ...
+x: Inv[int]
+reveal_type(f(x))  # N: Revealed type is 'builtins.int*'

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -3646,7 +3646,7 @@ def test_narrow_none() -> None:
     a: Optional[int]
     if int():
         a = narrow_none(a)
-        reveal_type(a)  # N: Revealed type is 'Union[builtins.int, None]'
+        reveal_type(a)  # N: Revealed type is 'builtins.int'
 
     b: int
     if int():
@@ -3710,7 +3710,7 @@ def test_narrow_none_v2() -> None:
     a: Optional[int]
     if int():
         a = narrow_none_v2(a)
-        reveal_type(a)  # N: Revealed type is 'Union[builtins.int, None]'
+        reveal_type(a)  # N: Revealed type is 'builtins.int'
 
     b: int
     if int():

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1497,5 +1497,5 @@ from asyncio import Future, wait
 from typing import List
 
 async def foo() -> None:
-    f: List[Future[None]] = []
+    f = []  # type: List[Future[None]]
     await wait(f)

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1490,3 +1490,12 @@ reveal_type(A().b)
 [out]
 _testNamedTupleAtRunTime.py:5: error: NamedTuple type as an attribute is not supported
 _testNamedTupleAtRunTime.py:7: note: Revealed type is 'Any'
+
+[case testAsyncioFutureWait]
+# mypy: strict-optional
+from asyncio import Future, wait
+from typing import List
+
+async def foo() -> None:
+    f: List[Future[None]] = []
+    await wait(f)


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/8051

The fix is as discussed in the issue. I didn't find a test case for the union `actual`, but I think it makes sense to simplify it as well. Note: I add the `pythoneval` test just as a regression test, if you think it is not worth it, I can remove it.