### PR TITLE
Refactor: remove unused attribute from PartialType

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -588,10 +588,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 if (typename in self.item_args and methodname in self.item_args[typename]
                         and e.arg_kinds == [ARG_POS]):
                     item_type = self.accept(e.args[0])
-                    full_item_type = make_simplified_union(
-                        [item_type, partial_type.inner_types[0]])
-                    if mypy.checker.is_valid_inferred_type(full_item_type):
-                        var.type = self.chk.named_generic_type(typename, [full_item_type])
+                    if mypy.checker.is_valid_inferred_type(item_type):
+                        var.type = self.chk.named_generic_type(typename, [item_type])
                         del partial_types[var]
                 elif (typename in self.container_args
                       and methodname in self.container_args[typename]
@@ -600,15 +598,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     if isinstance(arg_type, Instance):
                         arg_typename = arg_type.type.fullname
                         if arg_typename in self.container_args[typename][methodname]:
-                            full_item_types = [
-                                make_simplified_union([item_type, prev_type])
-                                for item_type, prev_type
-                                in zip(arg_type.args, partial_type.inner_types)
-                            ]
                             if all(mypy.checker.is_valid_inferred_type(item_type)
-                                   for item_type in full_item_types):
+                                   for item_type in arg_type.args):
                                 var.type = self.chk.named_generic_type(typename,
-                                                                       list(full_item_types))
+                                                                       list(arg_type.args))
                                 del partial_types[var]
 
     def apply_function_plugin(self,

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -290,7 +290,7 @@ class TypeQuery(SyntheticTypeVisitor[T]):
         return self.query_types([t.upper_bound] + t.values)
 
     def visit_partial_type(self, t: PartialType) -> T:
-        return self.query_types(t.inner_types)
+        return self.strategy([])
 
     def visit_instance(self, t: Instance) -> T:
         return self.query_types(t.args)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1761,16 +1761,13 @@ class PartialType(ProperType):
     # None for the 'None' partial type; otherwise a generic class
     type = None  # type: Optional[mypy.nodes.TypeInfo]
     var = None  # type: mypy.nodes.Var
-    inner_types = None  # type: List[Type]
 
     def __init__(self,
                  type: 'Optional[mypy.nodes.TypeInfo]',
-                 var: 'mypy.nodes.Var',
-                 inner_types: List[Type]) -> None:
+                 var: 'mypy.nodes.Var') -> None:
         super().__init__()
         self.type = type
         self.var = var
-        self.inner_types = inner_types
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_partial_type(self)


### PR DESCRIPTION
The `inner_types` attribute seems to have no effect.