### PR TITLE
Properly push scope when checking lambda expressions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3243,12 +3243,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             self.chk.return_types.append(AnyType(TypeOfAny.special_form))
             # Type check everything in the body except for the final return
             # statement (it can contain tuple unpacking before return).
-            for stmt in e.body.body[:-1]:
-                stmt.accept(self.chk)
-            # Only type check the return expression, not the return statement.
-            # This is important as otherwise the following statements would be
-            # considered unreachable. There's no useful type context.
-            ret_type = self.accept(e.expr(), allow_none_return=True)
+            with self.chk.scope.push_function(e):
+                for stmt in e.body.body[:-1]:
+                    stmt.accept(self.chk)
+                # Only type check the return expression, not the return statement.
+                # This is important as otherwise the following statements would be
+                # considered unreachable. There's no useful type context.
+                ret_type = self.accept(e.expr(), allow_none_return=True)
             fallback = self.named_type('builtins.function')
             self.chk.return_types.pop()
             return callable_type(e, fallback, ret_type)
@@ -3257,6 +3258,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             self.chk.return_types.append(inferred_type.ret_type)
             self.chk.check_func_item(e, type_override=type_override)
             if e.expr() not in self.chk.type_map:
+                # TODO: return expression must be accepted before exiting function scope.
                 self.accept(e.expr(), allow_none_return=True)
             ret_type = self.chk.type_map[e.expr()]
             if isinstance(get_proper_type(ret_type), NoneType):

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -611,7 +611,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 assert ret_type is not None, "Internal error: typing.Coroutine not found"
                 defn.type = defn.type.copy_modified(ret_type=ret_type)
 
-    def prepare_method_signature(self, func: FuncItem, info: TypeInfo) -> None:
+    def prepare_method_signature(self, func: FuncDef, info: TypeInfo) -> None:
         """Check basic signature validity and tweak annotation of self/cls argument."""
         # Only non-static methods are special.
         functype = func.type

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -611,7 +611,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 assert ret_type is not None, "Internal error: typing.Coroutine not found"
                 defn.type = defn.type.copy_modified(ret_type=ret_type)
 
-    def prepare_method_signature(self, func: FuncDef, info: TypeInfo) -> None:
+    def prepare_method_signature(self, func: FuncItem, info: TypeInfo) -> None:
         """Check basic signature validity and tweak annotation of self/cls argument."""
         # Only non-static methods are special.
         functype = func.type

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6566,3 +6566,12 @@ class A:
 
 reveal_type(A().y)  # N: Revealed type is 'builtins.int'
 [builtins fixtures/property.pyi]
+
+[case testEnclosingScopeLambdaNoCrash]
+class C:
+    x = lambda x: x.y.g()
+
+[case testEnclosingScopeLambdaNoCrashExplicit]
+from typing import Callable
+class C:
+    x: Callable[[C], int] = lambda x: x.y.g()  # E: "C" has no attribute "y"


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/8079

Previously function scope was pushed inconsistently in two branches of `visit_lambda_expr()` (it was only pushed in the second branch by `check_func_item()`). I believe there is still a small inconsistency, although I wasn't able to trigger a corresponding crash, I added a TODO about this.