### PR TITLE
Fix type inference regression with partial types

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2174,7 +2174,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             rvalue_type = get_proper_type(rvalue_type)
             if isinstance(rvalue_type, Instance):
                 if rvalue_type.type == typ.type:
-                    var.type = rvalue_type
+                    self.infer_variable_type(var, lvalue, rvalue_type, rvalue)
                     del partial_types[var]
             elif isinstance(rvalue_type, AnyType):
                 var.type = fill_typevars_with_any(typ.type)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2785,7 +2785,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         init_type = get_proper_type(init_type)
         if isinstance(init_type, DeletedType):
             self.msg.deleted_as_rvalue(init_type, context)
-            name.type = AnyType(TypeOfAny.from_error)
         elif not is_valid_inferred_type(init_type) and not self.no_partial_types:
             # We cannot use the type of the initialization expression for full type
             # inference (it's not specific enough), but we might be able to give

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2173,11 +2173,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             rvalue_type = self.expr_checker.accept(rvalue)
             rvalue_type = get_proper_type(rvalue_type)
             if isinstance(rvalue_type, Instance):
-                if rvalue_type.type == typ.type:
-                    if is_valid_inferred_type(rvalue_type):
-                        var.type = rvalue_type
-                    else:
-                        var.type = self.inference_error_fallback_type(rvalue_type)
+                if rvalue_type.type == typ.type and is_valid_inferred_type(rvalue_type):
+                    var.type = rvalue_type
                     del partial_types[var]
             elif isinstance(rvalue_type, AnyType):
                 var.type = fill_typevars_with_any(typ.type)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1585,6 +1585,17 @@ oo.update(d)
 reveal_type(oo) # N: Revealed type is 'collections.OrderedDict[builtins.int*, builtins.str*]'
 [builtins fixtures/dict.pyi]
 
+[case testEmptyCollectionAssignedToVariableTwice]
+x = [] # E: Need type annotation for 'x' (hint: "x: List[<type>] = ...")
+y = x
+x = []
+reveal_type(x) # N: Revealed type is 'builtins.list[Any]'
+d = {} # E: Need type annotation for 'd' (hint: "d: Dict[<type>, <type>] = ...")
+z = d
+d = {}
+reveal_type(d) # N: Revealed type is 'builtins.dict[Any, Any]'
+[builtins fixtures/dict.pyi]
+
 [case testInferAttributeInitializedToEmptyAndAssigned]
 class C:
     def __init__(self) -> None:

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1601,6 +1601,13 @@ main:4: note: Revealed type is 'builtins.list[Any]'
 main:5: error: Need type annotation for 'd' (hint: "d: Dict[<type>, <type>] = ...")
 main:8: note: Revealed type is 'builtins.dict[Any, Any]'
 
+[case testEmptyCollectionAssignedToVariableTwiceNoReadIncremental]
+x = [] # E: Need type annotation for 'x' (hint: "x: List[<type>] = ...")
+x = []
+[builtins fixtures/list.pyi]
+[out2]
+main:1: error: Need type annotation for 'x' (hint: "x: List[<type>] = ...")
+
 [case testInferAttributeInitializedToEmptyAndAssigned]
 class C:
     def __init__(self) -> None:

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1585,7 +1585,7 @@ oo.update(d)
 reveal_type(oo) # N: Revealed type is 'collections.OrderedDict[builtins.int*, builtins.str*]'
 [builtins fixtures/dict.pyi]
 
-[case testEmptyCollectionAssignedToVariableTwice]
+[case testEmptyCollectionAssignedToVariableTwiceIncremental]
 x = [] # E: Need type annotation for 'x' (hint: "x: List[<type>] = ...")
 y = x
 x = []
@@ -1595,6 +1595,11 @@ z = d
 d = {}
 reveal_type(d) # N: Revealed type is 'builtins.dict[Any, Any]'
 [builtins fixtures/dict.pyi]
+[out2]
+main:1: error: Need type annotation for 'x' (hint: "x: List[<type>] = ...")
+main:4: note: Revealed type is 'builtins.list[Any]'
+main:5: error: Need type annotation for 'd' (hint: "d: Dict[<type>, <type>] = ...")
+main:8: note: Revealed type is 'builtins.dict[Any, Any]'
 
 [case testInferAttributeInitializedToEmptyAndAssigned]
 class C:


### PR DESCRIPTION
Don't infer types such as `List[<nothing>]`; infer `List[Any]` instead.

Fixes #8090.