### PR TITLE
Don't simplify out ErasedType from unions during type inference

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -109,10 +109,12 @@ def _infer_constraints(template: Type, actual: Type,
     actual = get_proper_type(actual)
 
     # Type inference shouldn't be affected by whether union types have been simplified.
+    # We however keep any ErasedType items, so that the caller will see it when using
+    # checkexpr.has_erased_component().
     if isinstance(template, UnionType):
-        template = mypy.typeops.make_simplified_union(template.items)
+        template = mypy.typeops.make_simplified_union(template.items, keep_erased=True)
     if isinstance(actual, UnionType):
-        actual = mypy.typeops.make_simplified_union(actual.items)
+        actual = mypy.typeops.make_simplified_union(actual.items, keep_erased=True)
 
     # Ignore Any types from the type suggestion engine to avoid them
     # causing us to infer Any in situations where a better job could

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -312,7 +312,8 @@ def callable_corresponding_argument(typ: CallableType,
 
 
 def make_simplified_union(items: Sequence[Type],
-                          line: int = -1, column: int = -1) -> ProperType:
+                          line: int = -1, column: int = -1,
+                          *, keep_erased: bool = False) -> ProperType:
     """Build union type with redundant union items removed.
 
     If only a single item remains, this may return a non-union type.
@@ -327,6 +328,8 @@ def make_simplified_union(items: Sequence[Type],
 
     Note: This must NOT be used during semantic analysis, since TypeInfos may not
           be fully initialized.
+    The keep_erased flag is used for type inference against union types
+    containing type variables. If set to True, keep all ErasedType items.
     """
     items = get_proper_types(items)
     while any(isinstance(typ, UnionType) for typ in items):
@@ -346,7 +349,7 @@ def make_simplified_union(items: Sequence[Type],
         # Keep track of the truishness info for deleted subtypes which can be relevant
         cbt = cbf = False
         for j, tj in enumerate(items):
-            if i != j and is_proper_subtype(tj, ti):
+            if i != j and is_proper_subtype(tj, ti, keep_erased_types=keep_erased):
                 # We found a redundant item in the union.
                 removed.add(j)
                 cbt = cbt or tj.can_be_true

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2950,5 +2950,6 @@ def filter(__function: None, __iterable: Iterable[Optional[_T]]) -> List[_T]: ..
 
 x: Optional[str]
 
-pagelets = filter(None, [x])
+y = filter(None, [x])
+reveal_type(y)  # N: Revealed type is 'builtins.list[builtins.str*]'
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2939,3 +2939,16 @@ X = Union[Cov[T], Inv[T]]
 def f(x: X[T]) -> T: ...
 x: Inv[int]
 reveal_type(f(x))  # N: Revealed type is 'builtins.int*'
+
+[case testOptionalTypeVarAgainstOptional]
+# flags: --strict-optional
+from typing import Optional, TypeVar, Iterable, Iterator, List
+
+_T = TypeVar('_T')
+
+def filter(__function: None, __iterable: Iterable[Optional[_T]]) -> List[_T]: ...
+
+x: Optional[str]
+
+pagelets = filter(None, [x])
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/8093

The fix is kind of simple, we really need to keep all `ErasedType`s intact to preserve the existing type inference logic, but it is also long because I need to thread the flag down like dozen function calls.

The issue itself btw highlight how fragile is current type inference logic (note that `expand_type()` implicitly calls `make_simplified_union()` too, but I think that one doesn't need to be updated because it shouldn't be called with any erased components).