### PR TITLE
Inferencing type reference of abstract class inferred from concrete type values

### DIFF
--- a/mypy/join.py
+++ b/mypy/join.py
@@ -187,8 +187,8 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
             if is_equivalent(t, self.s):
                 return combine_similar_callables(t, self.s)
             result = join_similar_callables(t, self.s)
-            # unless some or all items represent abstract objects,
-            # we set the flag: from_type_type to True
+            # We set the from_type_type flag to suppress error when a collection of 
+            # concrete class objects gets inferred as their common abstract superclass.
             if not ((t.is_type_obj() and t.type_object().is_abstract) or
                     (self.s.is_type_obj() and self.s.type_object().is_abstract)):
                 result.from_type_type = True

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -187,6 +187,11 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
             if is_equivalent(t, self.s):
                 return combine_similar_callables(t, self.s)
             result = join_similar_callables(t, self.s)
+            # unless some or all items represent abstract objects,
+            # we set the flag: from_type_type to True
+            if not ((t.is_type_obj() and t.type_object().is_abstract) or
+                (self.s.is_type_obj() and self.s.type_object().is_abstract)):
+                result.from_type_type = True
             if any(isinstance(tp, (NoneType, UninhabitedType))
                    for tp in get_proper_types(result.arg_types)):
                 # We don't want to return unusable Callable, attempt fallback instead.

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -190,7 +190,7 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
             # unless some or all items represent abstract objects,
             # we set the flag: from_type_type to True
             if not ((t.is_type_obj() and t.type_object().is_abstract) or
-                (self.s.is_type_obj() and self.s.type_object().is_abstract)):
+                    (self.s.is_type_obj() and self.s.type_object().is_abstract)):
                 result.from_type_type = True
             if any(isinstance(tp, (NoneType, UninhabitedType))
                    for tp in get_proper_types(result.arg_types)):

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -187,7 +187,7 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
             if is_equivalent(t, self.s):
                 return combine_similar_callables(t, self.s)
             result = join_similar_callables(t, self.s)
-            # We set the from_type_type flag to suppress error when a collection of 
+            # We set the from_type_type flag to suppress error when a collection of
             # concrete class objects gets inferred as their common abstract superclass.
             if not ((t.is_type_obj() and t.type_object().is_abstract) or
                     (self.s.is_type_obj() and self.s.type_object().is_abstract)):

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -533,6 +533,11 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
             if is_equivalent(t, self.s):
                 return combine_similar_callables(t, self.s)
             result = meet_similar_callables(t, self.s)
+            # unless some or all items represent abstract objects,
+            # we set the flag: from_type_type to True
+            if not ((t.is_type_obj() and t.type_object().is_abstract) or
+                (self.s.is_type_obj() and self.s.type_object().is_abstract)):
+                result.from_type_type = True
             if isinstance(get_proper_type(result.ret_type), UninhabitedType):
                 # Return a plain None or <uninhabited> instead of a weird function.
                 return self.default(self.s)

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -536,7 +536,7 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
             # unless some or all items represent abstract objects,
             # we set the flag: from_type_type to True
             if not ((t.is_type_obj() and t.type_object().is_abstract) or
-                (self.s.is_type_obj() and self.s.type_object().is_abstract)):
+                    (self.s.is_type_obj() and self.s.type_object().is_abstract)):
                 result.from_type_type = True
             if isinstance(get_proper_type(result.ret_type), UninhabitedType):
                 # Return a plain None or <uninhabited> instead of a weird function.

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -533,7 +533,7 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
             if is_equivalent(t, self.s):
                 return combine_similar_callables(t, self.s)
             result = meet_similar_callables(t, self.s)
-            # We set the from_type_type flag to suppress error when a collection of 
+            # We set the from_type_type flag to suppress error when a collection of
             # concrete class objects gets inferred as their common abstract superclass.
             if not ((t.is_type_obj() and t.type_object().is_abstract) or
                     (self.s.is_type_obj() and self.s.type_object().is_abstract)):

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -533,8 +533,8 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
             if is_equivalent(t, self.s):
                 return combine_similar_callables(t, self.s)
             result = meet_similar_callables(t, self.s)
-            # unless some or all items represent abstract objects,
-            # we set the flag: from_type_type to True
+            # We set the from_type_type flag to suppress error when a collection of 
+            # concrete class objects gets inferred as their common abstract superclass.
             if not ((t.is_type_obj() and t.type_object().is_abstract) or
                     (self.s.is_type_obj() and self.s.type_object().is_abstract)):
                 result.from_type_type = True

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -951,3 +951,51 @@ default = Config({'cannot': 'modify'})  # OK
 default[1] = 2  # E: Unsupported target for indexed assignment
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
+
+[case testSubclassOfABCFromDictionary]
+from abc import abstractmethod, ABCMeta
+
+class MyAbstractType(metaclass=ABCMeta):
+  @abstractmethod
+  def do(self): pass
+
+class MyConcreteA(MyAbstractType):
+  def do(self):
+    print('A')
+
+class MyConcreteB(MyAbstractType):
+  def do(self):
+    print('B')
+
+class MyAbstractA(MyAbstractType):
+  @abstractmethod
+  def do(self): pass
+
+class MyAbstractB(MyAbstractType):
+  @abstractmethod
+  def do(self): pass
+
+my_concrete_types = {
+  'A': MyConcreteA,
+  'B': MyConcreteB,
+}
+
+my_abstract_types = {
+  'A': MyAbstractA,
+  'B': MyAbstractB, 
+}
+
+reveal_type(my_concrete_types)  # N: Revealed type is 'builtins.dict[builtins.str*, def () -> __main__.MyAbstractType]' 
+reveal_type(my_abstract_types)  # N: Revealed type is 'builtins.dict[builtins.str*, def () -> __main__.MyAbstractType]' 
+
+a = my_concrete_types['A']()
+a.do()
+b = my_concrete_types['B']()
+b.do()
+
+c = my_abstract_types['A']()  # E: Cannot instantiate abstract class 'MyAbstractType' with abstract attribute 'do'
+c.do()
+d = my_abstract_types['B']()  # E: Cannot instantiate abstract class 'MyAbstractType' with abstract attribute 'do'
+d.do()
+
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
resolves #8050, following the purposed solution 2 in  https://github.com/python/mypy/issues/8050#issuecomment-560322273 and using the implementation purposed in https://github.com/python/mypy/issues/8050#issuecomment-560326219

Currently, no testcase with regard to meet of callables is available, since I'm not sure what a proper testcase would be.