### PR TITLE
Support silencing only some error codes

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -593,6 +593,41 @@ in error messages.
 
     Show absolute paths to files.
 
+.. option:: --ignore-error-codes CODES
+
+   This flag makes mypy ignore all errors with given error codes. Flag accepts
+   error codes as a comma separated list (there should be no spaces after commas).
+   For example, by default mypy would produce the following errors:
+
+   .. code-block:: python
+
+       class Dynamic:
+           def __init__(self, attr: str, value: object) -> None:
+               setattr(self, attr, value)
+
+       magic_builtin  # error: Name "magic_builtin" is not defined
+       Dynamic("test", 0).test  # error: "Dynamic" has no attribute "test"
+       x: int = "no"  # error: Incompatible types in assignment
+                      # (expression has type "str", variable has type "int")
+
+   But when used as ``mypy --ignore-error-codes=attr-defined,name-defined test.py``
+   it will produce the following errors:
+
+   .. code-block:: python
+
+       class Dynamic:
+           def __init__(self, attr: str, value: object) -> None:
+               setattr(self, attr, value)
+
+       magic_builtin  # No error
+       Dynamic("test", 0).test  # No error
+       x: int = "no"  # error: Incompatible types in assignment
+                      # (expression has type "str", variable has type "int")
+
+   To make mypy show error codes in error messages use :option:`--show-error-codes`.
+   See also the lists of :ref:`default error codes <error-code-list>` and
+   :ref:`optional error codes <error-codes-optional>`.
+
 
 .. _incremental:
 

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -595,38 +595,38 @@ in error messages.
 
 .. option:: --ignore-error-codes CODES
 
-   This flag makes mypy ignore all errors with given error codes. Flag accepts
-   error codes as a comma separated list (there should be no spaces after commas).
-   For example, by default mypy would produce the following errors:
+    This flag makes mypy ignore all errors with given error codes. Flag accepts
+    error codes as a comma separated list (there should be no spaces after commas).
+    For example, by default mypy would produce the following errors:
 
-   .. code-block:: python
+    .. code-block:: python
 
-       class Dynamic:
-           def __init__(self, attr: str, value: object) -> None:
-               setattr(self, attr, value)
+        class Dynamic:
+            def __init__(self, attr: str, value: object) -> None:
+                setattr(self, attr, value)
 
-       magic_builtin  # error: Name "magic_builtin" is not defined
-       Dynamic("test", 0).test  # error: "Dynamic" has no attribute "test"
-       x: int = "no"  # error: Incompatible types in assignment
-                      # (expression has type "str", variable has type "int")
+        magic_builtin  # error: Name "magic_builtin" is not defined
+        Dynamic("test", 0).test  # error: "Dynamic" has no attribute "test"
+        x: int = "no"  # error: Incompatible types in assignment
+                       # (expression has type "str", variable has type "int")
 
-   But when used as ``mypy --ignore-error-codes=attr-defined,name-defined test.py``
-   it will produce the following errors:
+    But when used as ``mypy --ignore-error-codes=attr-defined,name-defined test.py``
+    it will produce the following errors:
 
-   .. code-block:: python
+    .. code-block:: python
 
-       class Dynamic:
-           def __init__(self, attr: str, value: object) -> None:
-               setattr(self, attr, value)
+        class Dynamic:
+            def __init__(self, attr: str, value: object) -> None:
+                setattr(self, attr, value)
 
-       magic_builtin  # No error
-       Dynamic("test", 0).test  # No error
-       x: int = "no"  # error: Incompatible types in assignment
-                      # (expression has type "str", variable has type "int")
+        magic_builtin  # No error
+        Dynamic("test", 0).test  # No error
+        x: int = "no"  # error: Incompatible types in assignment
+                       # (expression has type "str", variable has type "int")
 
-   To make mypy show error codes in error messages use :option:`--show-error-codes`.
-   See also the lists of :ref:`default error codes <error-code-list>` and
-   :ref:`optional error codes <error-codes-optional>`.
+    To make mypy show error codes in error messages use :option:`--show-error-codes`.
+    See also the lists of :ref:`default error codes <error-code-list>` and
+    :ref:`optional error codes <error-codes-optional>`.
 
 
 .. _incremental:

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -441,7 +441,8 @@ These options may only be set in the global section (``[mypy]``).
 
 ``ignore_error_codes`` (comma-separated list of strings)
     Ignore errors with these error codes in given files or directories.
-    See :option:`--ignore-error-codes` for more details.
+    See :option:`--ignore-error-codes <mypy --ignore-error-codes>` for
+    more details.
 
 
 Incremental mode

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -439,6 +439,10 @@ These options may only be set in the global section (``[mypy]``).
 ``show_absolute_path`` (bool, default False)
     Show absolute paths to files.
 
+``ignore_error_codes`` (comma-separated list of strings)
+    Ignore errors with these error codes in given files or directories.
+    See :option:`--ignore-error-codes` for more details.
+
 
 Incremental mode
 ****************

--- a/docs/source/error_codes.rst
+++ b/docs/source/error_codes.rst
@@ -37,8 +37,8 @@ Silencing errors based on error codes
 You can use a special comment ``# type: ignore[code, ...]`` to only
 ignore errors with a specific error code (or codes) on a particular
 line.  This can be used even if you have not configured mypy to show
-error codes. Currently it's only possible to disable arbitrary error
-codes on individual lines using this comment.
+error codes. Alternatively use :option:`--ignore-error-codes` for more
+coarse-grained (per file or per directory) control.
 
 .. note::
 

--- a/docs/source/error_codes.rst
+++ b/docs/source/error_codes.rst
@@ -37,8 +37,8 @@ Silencing errors based on error codes
 You can use a special comment ``# type: ignore[code, ...]`` to only
 ignore errors with a specific error code (or codes) on a particular
 line.  This can be used even if you have not configured mypy to show
-error codes. Alternatively use :option:`--ignore-error-codes` for more
-coarse-grained (per file or per directory) control.
+error codes. Also you can use :option:`--ignore-error-codes <mypy --ignore-error-codes>`
+for more coarse-grained (per file or per directory) silencing of errors.
 
 .. note::
 

--- a/docs/source/inline_config.rst
+++ b/docs/source/inline_config.rst
@@ -28,11 +28,13 @@ Values are specified using ``=``, but ``= True`` may be omitted:
 
 Multiple flags can be separated by commas or placed on separate
 lines. To include a comma as part of an option's value, place the
-value inside quotes:
+value inside quotes. Quotes are still needed if there is a single
+option on a line:
 
 .. code-block:: python
 
   # mypy: disallow-untyped-defs, always-false="FOO,BAR"
+  # mypy: ignore-error-codes="override,attr-defined"
 
 Like in the configuration file, options that take a boolean value may be
 inverted by adding ``no-`` to their name or by (when applicable)

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -745,7 +745,8 @@ class BuildManager:
         """Is there a file in the file system corresponding to module id?"""
         return find_module_simple(id, self) is not None
 
-    def parse_file(self, id: str, path: str, source: str, ignore_errors: bool) -> MypyFile:
+    def parse_file(self, id: str, path: str, source: str,
+                   ignore_errors: bool, ignore_error_codes: Iterable[str]) -> MypyFile:
         """Parse the source of a file with the given name.
 
         Raise CompileError if there is a parse error.
@@ -762,7 +763,10 @@ class BuildManager:
             self.log("Bailing due to parse errors")
             self.errors.raise_error()
 
-        self.errors.set_file_ignored_lines(path, tree.ignored_lines, ignore_errors)
+        self.errors.set_file_ignored_lines_and_codes(path,
+                                                     tree.ignored_lines,
+                                                     ignore_error_codes,
+                                                     ignore_errors)
         return tree
 
     def load_fine_grained_deps(self, id: str) -> Dict[str, Set[str]]:
@@ -2015,7 +2019,8 @@ class State:
 
             self.parse_inline_configuration(source)
             self.tree = manager.parse_file(self.id, self.xpath, source,
-                                           self.ignore_all or self.options.ignore_errors)
+                                           self.ignore_all or self.options.ignore_errors,
+                                           self.options.ignore_error_codes)
 
         modules[self.id] = self.tree
 

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -82,6 +82,7 @@ config_types = {
     'plugins': lambda s: [p.strip() for p in s.split(',')],
     'always_true': lambda s: [p.strip() for p in s.split(',')],
     'always_false': lambda s: [p.strip() for p in s.split(',')],
+    'ignore_error_codes': lambda s: [p.strip() for p in s.split(',')],
     'package_root': lambda s: [p.strip() for p in s.split(',')],
     'cache_dir': expand_path,
     'python_executable': expand_path,

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -11,6 +11,7 @@ from typing_extensions import Final
 
 from mypy import defaults
 from mypy.options import Options, PER_MODULE_OPTIONS
+from mypy.util import split_commas
 
 
 def parse_version(v: str) -> Tuple[int, int]:
@@ -79,11 +80,11 @@ config_types = {
     # These two are for backwards compatibility
     'silent_imports': bool,
     'almost_silent': bool,
-    'plugins': lambda s: [p.strip() for p in s.split(',')],
-    'always_true': lambda s: [p.strip() for p in s.split(',')],
-    'always_false': lambda s: [p.strip() for p in s.split(',')],
-    'ignore_error_codes': lambda s: [p.strip() for p in s.split(',')],
-    'package_root': lambda s: [p.strip() for p in s.split(',')],
+    'plugins': split_commas,
+    'always_true': split_commas,
+    'always_false': split_commas,
+    'ignore_error_codes': split_commas,
+    'package_root': split_commas,
     'cache_dir': expand_path,
     'python_executable': expand_path,
 }  # type: Final

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -441,6 +441,9 @@ def process_options(args: List[str],
     add_invertible_flag('--warn-unused-configs', default=False, strict_flag=True,
                         help="Warn about unused '[mypy-<pattern>]' config sections",
                         group=config_group)
+    config_group.add_argument(
+        '--ignore-error-codes', metavar='NAME', action='append', default=[],
+        help="Ignore errors with this error code (may be repeated)")
 
     imports_group = parser.add_argument_group(
         title='Import discovery',
@@ -856,6 +859,13 @@ def process_options(args: List[str],
     if overlap:
         parser.error("You can't make a variable always true and always false (%s)" %
                      ', '.join(sorted(overlap)))
+
+    # Interpret --ignore-error-codes=attr-defined,arg-type as two separate error codes.
+    if options.ignore_error_codes:
+        split_codes = []
+        for code in options.ignore_error_codes:
+            split_codes.extend([c.strip() for c in code.split(',')])
+        options.ignore_error_codes = split_codes
 
     # Set build flags.
     if options.strict_optional_whitelist is not None:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -21,6 +21,7 @@ from mypy.errors import CompileError
 from mypy.options import Options, BuildType
 from mypy.config_parser import parse_version, parse_config_file
 from mypy.split_namespace import SplitNamespace
+from mypy.util import split_commas
 
 from mypy.version import __version__
 
@@ -441,9 +442,6 @@ def process_options(args: List[str],
     add_invertible_flag('--warn-unused-configs', default=False, strict_flag=True,
                         help="Warn about unused '[mypy-<pattern>]' config sections",
                         group=config_group)
-    config_group.add_argument(
-        '--ignore-error-codes', metavar='NAME', action='append', default=[],
-        help="Ignore errors with this error code (may be repeated)")
 
     imports_group = parser.add_argument_group(
         title='Import discovery',
@@ -643,6 +641,9 @@ def process_options(args: List[str],
     add_invertible_flag('--show-absolute-path', default=False,
                         help="Show absolute paths to files",
                         group=error_group)
+    error_group.add_argument(
+        '--ignore-error-codes', metavar='CODES', type=split_commas,
+        help="Ignore errors with these error codes (comma separated)")
 
     incremental_group = parser.add_argument_group(
         title='Incremental mode',
@@ -859,13 +860,6 @@ def process_options(args: List[str],
     if overlap:
         parser.error("You can't make a variable always true and always false (%s)" %
                      ', '.join(sorted(overlap)))
-
-    # Interpret --ignore-error-codes=attr-defined,arg-type as two separate error codes.
-    if options.ignore_error_codes:
-        split_codes = []
-        for code in options.ignore_error_codes:
-            split_codes.extend([c.strip() for c in code.split(',')])
-        options.ignore_error_codes = split_codes
 
     # Set build flags.
     if options.strict_optional_whitelist is not None:

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -43,6 +43,7 @@ PER_MODULE_OPTIONS = {
     "mypyc",
     "no_implicit_optional",
     "implicit_reexport",
+    "ignore_error_codes",
     "show_none_errors",
     "strict_optional",
     "strict_optional_whitelist",
@@ -131,6 +132,9 @@ class Options:
 
         # Files in which to ignore all non-fatal errors
         self.ignore_errors = False
+
+        # Ignore errors with these error codes in a given file.
+        self.ignore_error_codes = []  # type: List[str]
 
         # Apply strict None checking
         self.strict_optional = True

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -902,8 +902,9 @@ def reprocess_nodes(manager: BuildManager,
     nodes = sorted(nodeset, key=key)
 
     options = graph[module_id].options
-    manager.errors.set_file_ignored_lines(
-        file_node.path, file_node.ignored_lines, options.ignore_errors)
+    manager.errors.set_file_ignored_lines_and_codes(
+        file_node.path, file_node.ignored_lines,
+        options.ignore_error_codes, options.ignore_errors)
 
     targets = set()
     for node in nodes:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -403,6 +403,11 @@ def count_stats(errors: List[str]) -> Tuple[int, int]:
     return len(errors), len(files)
 
 
+def split_commas(text: str) -> List[str]:
+    """Split a comma separated list."""
+    return [c.strip() for c in text.split(',')]
+
+
 def split_words(msg: str) -> List[str]:
     """Split line of text into words (but not within quoted groups)."""
     next_word = ''

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1234,8 +1234,9 @@ x: A  # E:4: Missing type parameters for generic type "A"
 [builtins fixtures/list.pyi]
 
 [case testIgnoreErrorCodesGlobal]
-# flags: --ignore-error-codes=attr-defined,arg-type --ignore-error-codes=name-defined
-not_defined
+# flags: --ignore-error-codes=attr-defined,arg-type
+
+not_defined  # E: Name 'not_defined' is not defined
 x: int = 'no'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 'no'.no_way
 def test(x: str) -> None: ...

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1232,3 +1232,36 @@ A = List  # OK
 B = List[A]  # E:10: Missing type parameters for generic type "A"
 x: A  # E:4: Missing type parameters for generic type "A"
 [builtins fixtures/list.pyi]
+
+[case testIgnoreErrorCodesGlobal]
+# flags: --ignore-error-codes=attr-defined,arg-type --ignore-error-codes=name-defined
+not_defined
+x: int = 'no'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+'no'.no_way
+def test(x: str) -> None: ...
+test(0)
+
+[case testIgnoreErrorCodesPerFile]
+# flags: --config-file tmp/mypy.ini
+import b
+not_defined
+x: int = 'no'
+'no'.no_way
+def test(x: str) -> None: ...
+test(0)
+[file b.py]
+not_defined
+x: int = 'no'
+'no'.no_way
+def test(x: str) -> None: ...
+test(0)
+[file mypy.ini]
+\[mypy]
+ignore_error_codes = attr-defined, arg-type
+\[mypy-b]
+ignore_error_codes = name-defined, assignment
+[out]
+tmp/b.py:3: error: "str" has no attribute "no_way"
+tmp/b.py:5: error: Argument 1 to "test" has incompatible type "int"; expected "str"
+main:3: error: Name 'not_defined' is not defined
+main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")

--- a/test-data/unit/check-inline-config.test
+++ b/test-data/unit/check-inline-config.test
@@ -157,3 +157,12 @@ main:4: error: Unterminated quote in configuration comment
 # mypy: skip-file
 [out]
 main:1: error: Unrecognized option: skip_file = True
+
+[case testIgnoreErrorCodesInline]
+# mypy: ignore-error-codes="attr-defined,arg-type"
+
+not_defined  # E: Name 'not_defined' is not defined
+x: int = 'no'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+'no'.no_way
+def test(x: str) -> None: ...
+test(0)


### PR DESCRIPTION
This PR adds support for silencing particular _error codes_ either on command line, in config file or in inline mypy options. The implementation is mostly straightforward, here are however two important comments:
* I initially wanted to also add an option to _opt-in_ selected error codes, but this turns out to be much harder, because there are many call sites scattered in the code that check for whether a given _flag_ is enabled. We can later migrate some of them to error codes. Also in my experience people often ask about opting out for a specific error code rather than opting in.
* If there are two sections in config file that match a given module, the ignore lists are _not_ merged, the more narrow match acts as an override. This is similar to how other options work (like `--always-true` and `--always-false`), I am not sure this is the most obvious behavior, but it looks like it is most flexible. We can reconsider this later if people will find it confusing.