### PR TITLE
Produce error when assigning Enum or TypedDict as attribute

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2161,13 +2161,16 @@ class SemanticAnalyzer(NodeVisitor[None],
         """Check if s defines a typed dict."""
         if isinstance(s.rvalue, CallExpr) and isinstance(s.rvalue.analyzed, TypedDictExpr):
             return True  # This is a valid and analyzed typed dict definition, nothing to do here.
-        if len(s.lvalues) != 1 or not isinstance(s.lvalues[0], NameExpr):
+        if len(s.lvalues) != 1 or not isinstance(s.lvalues[0], (NameExpr, MemberExpr)):
             return False
         lvalue = s.lvalues[0]
         name = lvalue.name
         is_typed_dict, info = self.typed_dict_analyzer.check_typeddict(s.rvalue, name,
                                                                        self.is_func_scope())
         if not is_typed_dict:
+            return False
+        if isinstance(lvalue, MemberExpr):
+            self.fail("TypedDict type as attribute is not supported", lvalue)
             return False
         # Yes, it's a valid typed dict, but defer if it is not ready.
         if not info:

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -908,3 +908,12 @@ def func(x: Union[int, None, Empty] = _empty) -> int:
         reveal_type(x)  # N: Revealed type is 'builtins.int'
         return x + 2
 [builtins fixtures/primitives.pyi]
+
+[case testAssignEnumAsAttribute]
+from enum import Enum
+
+class A:
+    def __init__(self) -> None:
+        self.b = Enum("x", [("foo", "bar")])  # E: Enum type as attribute is not supported
+
+reveal_type(A().b)  # N: Revealed type is 'Any'

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1987,3 +1987,14 @@ reveal_type(foo['bar'])  # N: Revealed type is 'builtins.list[Any]'
 reveal_type(foo['baz'])  # N: Revealed type is 'builtins.list[Any]'
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
+
+[case testAssignTypedDictAsAttribute]
+from typing import TypedDict
+
+class A:
+    def __init__(self) -> None:
+        self.b = TypedDict('b', {'x': int, 'y': str})  # E: TypedDict type as attribute is not supported
+
+reveal_type(A().b)  # N: Revealed type is 'Any'
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]


### PR DESCRIPTION
resolves #8009, simply following solution by #7662 

Additionally, when I was finishing the first version of the PR I noticed that some of #7662 could be refined:
https://github.com/python/mypy/blob/e8ae12293cf1a8e32769c2149f4c8c2ca043b790/mypy/semanal.py#L2152-L2154
Here using `lvalue` instead of `s.lvalues[0]` would be more concise.
https://github.com/python/mypy/blob/e8ae12293cf1a8e32769c2149f4c8c2ca043b790/test-data/unit/pythoneval.test#L1482-L1492
The test is in `pythoneval.test`, but it makes more sense in `check-namedtuple.test` and the name could be also changed accordingly.

@ilevkivskyi What's your opinion on this? Should these changes be made? And if so, should they be made in this PR or a sperate one.