### PR TITLE
Allow redefining TypedDict keys while still throwing an error

### DIFF
--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -81,9 +81,8 @@ class TypedDictAnalyzer:
                 valid_items = base_items.copy()
                 for key in base_items:
                     if key in keys:
-                        self.fail('Cannot overwrite TypedDict field "{}" while merging'
+                        self.fail('Overwriting TypedDict field "{}" while merging'
                                   .format(key), defn)
-                        valid_items.pop(key)
                 keys.extend(valid_items.keys())
                 types.extend(valid_items.values())
                 required_keys.update(base_typed_dict.required_keys)
@@ -132,9 +131,8 @@ class TypedDictAnalyzer:
             else:
                 name = stmt.lvalues[0].name
                 if name in (oldfields or []):
-                    self.fail('Cannot overwrite TypedDict field "{}" while extending'
+                    self.fail('Overwriting TypedDict field "{}" while extending'
                               .format(name), stmt)
-                    continue
                 if name in fields:
                     self.fail('Duplicate TypedDict field "{}"'.format(name), stmt)
                     continue

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -72,7 +72,7 @@ class TypedDictAnalyzer:
             keys = []  # type: List[str]
             types = []
             required_keys = set()
-            for base in typeddict_bases:
+            for base in reversed(typeddict_bases): # Reversing so that leftmost base class' keys take precedence
                 assert isinstance(base, RefExpr)
                 assert isinstance(base.node, TypeInfo)
                 assert isinstance(base.node.typeddict_type, TypedDictType)

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -72,7 +72,9 @@ class TypedDictAnalyzer:
             keys = []  # type: List[str]
             types = []
             required_keys = set()
-            for base in reversed(typeddict_bases): # Reversing so that leftmost base class' keys take precedence
+
+            # Iterate over bases in reverse order so that leftmost base class' keys take precedence
+            for base in reversed(typeddict_bases):
                 assert isinstance(base, RefExpr)
                 assert isinstance(base.node, TypeInfo)
                 assert isinstance(base.node.typeddict_type, TypedDictType)

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -226,7 +226,7 @@ class Bad(Point1, Point2): # E: Overwriting TypedDict field "x" while merging
     pass
 
 b: Bad
-reveal_type(b) # N: Revealed type is 'TypedDict('__main__.Bad', {'x': builtins.float})'
+reveal_type(b) # N: Revealed type is 'TypedDict('__main__.Bad', {'x': builtins.int})'
 [builtins fixtures/dict.pyi]
 
 [case testCanCreateTypedDictWithClassOverwriting2]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -202,7 +202,7 @@ p: Point
 reveal_type(p) # N: Revealed type is 'TypedDict('__main__.Point', {'x': builtins.int, '_y': builtins.int})'
 [builtins fixtures/dict.pyi]
 
-[case testCannotCreateTypedDictWithClassOverwriting]
+[case testCannotCreateTypedDictWithDuplicateField]
 # flags: --python-version 3.6
 from mypy_extensions import TypedDict
 
@@ -214,7 +214,7 @@ b: Bad
 reveal_type(b) # N: Revealed type is 'TypedDict('__main__.Bad', {'x': builtins.int})'
 [builtins fixtures/dict.pyi]
 
-[case testCannotCreateTypedDictWithClassOverwriting2]
+[case testCanCreateTypedDictWithClassOverwriting]
 # flags: --python-version 3.6
 from mypy_extensions import TypedDict
 
@@ -222,24 +222,24 @@ class Point1(TypedDict):
     x: int
 class Point2(TypedDict):
     x: float
-class Bad(Point1, Point2): # E: Cannot overwrite TypedDict field "x" while merging
+class Bad(Point1, Point2): # E: Overwriting TypedDict field "x" while merging
     pass
 
 b: Bad
-reveal_type(b) # N: Revealed type is 'TypedDict('__main__.Bad', {'x': builtins.int})'
+reveal_type(b) # N: Revealed type is 'TypedDict('__main__.Bad', {'x': builtins.float})'
 [builtins fixtures/dict.pyi]
 
-[case testCannotCreateTypedDictWithClassOverwriting2]
+[case testCanCreateTypedDictWithClassOverwriting2]
 # flags: --python-version 3.6
 from mypy_extensions import TypedDict
 
 class Point1(TypedDict):
     x: int
 class Point2(Point1):
-    x: float # E: Cannot overwrite TypedDict field "x" while extending
+    x: float # E: Overwriting TypedDict field "x" while extending
 
 p2: Point2
-reveal_type(p2) # N: Revealed type is 'TypedDict('__main__.Point2', {'x': builtins.int})'
+reveal_type(p2) # N: Revealed type is 'TypedDict('__main__.Point2', {'x': builtins.float})'
 [builtins fixtures/dict.pyi]
 
 


### PR DESCRIPTION
Creating a `TypedDict` type that is similar to an existing one but has different types for one or two keys is currently impossible and requires redefining the `TypedDict` completely, which can be very verbose in the case of complex types. Throwing a type error in the same way as before, but allowing the overwrite to go through, seems much more reasonable for quality of life purposes.

I understand this PR basically amounts to a design decision about how mypy handles `TypedDict`s, but I definitely think it should be considered. The lack of ability to redefine `TypedDict` types slightly causes me lots of headache and seems like something that should be supported. Let me know if we think this is a reasonable change but we want to go about it slightly differently, I'm happy to change this.


To save myself a lot of headache later, I finally got the subset of tests I wanted to run locally with `pytest -n 0 -p no:flaky -k "TypeCheckSuite"`