### PR TITLE
Refine testcase and variable usage for "produce error when assigning NamedTuple to attribute"

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2149,7 +2149,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                                                                           self.is_func_scope())
         if not is_named_tuple:
             return False
-        if isinstance(s.lvalues[0], MemberExpr):
+        if isinstance(lvalue, MemberExpr):
             self.fail("NamedTuple type as an attribute is not supported", lvalue)
             return False
         # Yes, it's a valid namedtuple, but defer if it is not ready.

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -896,3 +896,12 @@ reveal_type(u.field_1)  # N: Revealed type is 'typing.Mapping[Tuple[builtins.int
 reveal_type(u.field_2)  # N: Revealed type is 'Tuple[builtins.int, builtins.int, fallback=__main__.MyBaseTuple]'
 reveal_type(u[0])  # N: Revealed type is 'typing.Mapping[Tuple[builtins.int, builtins.int, fallback=__main__.MyBaseTuple], builtins.int]'
 reveal_type(u[1])  # N: Revealed type is 'Tuple[builtins.int, builtins.int, fallback=__main__.MyBaseTuple]'
+
+[case testAssignNamedTupleAsAttribute]
+from typing import NamedTuple
+
+class A:
+    def __init__(self) -> None:
+        self.b = NamedTuple('x', [('s', str), ('n', int)])  # E: NamedTuple type as an attribute is not supported
+
+reveal_type(A().b)  # N: Revealed type is 'Any'

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1479,18 +1479,6 @@ def f_suppresses() -> int:
 _testUnreachableWithStdlibContextManagersNoStrictOptional.py:9: error: Statement is unreachable
 _testUnreachableWithStdlibContextManagersNoStrictOptional.py:15: error: Statement is unreachable
 
-[case testNamedTupleAtRunTime]
-from typing import NamedTuple
-
-class A:
-    def __init__(self) -> None:
-        self.b = NamedTuple('x', [('s', str), ('n', int)])
-
-reveal_type(A().b)
-[out]
-_testNamedTupleAtRunTime.py:5: error: NamedTuple type as an attribute is not supported
-_testNamedTupleAtRunTime.py:7: note: Revealed type is 'Any'
-
 [case testAsyncioFutureWait]
 # mypy: strict-optional
 from asyncio import Future, wait


### PR DESCRIPTION
Followed the discussion in https://github.com/python/mypy/pull/8107#issue-350416074, refine the code merged in #7662 by:

- move testcase from `pythoneval.test` to `check-namedtuple.test` and rename it from `testNamedTupleAtRunTime` to `testAssignNamedTupleAsAttribute`
- change `s.lvalues[0]` to `lvalue` to make it more concise