### PR TITLE
[mypyc] Fix interaction of Enum caching with _order_

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1445,7 +1445,11 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             self.add_to_non_ext_dict(non_ext, lvalue.name, rvalue, stmt.line)
             # We cache enum attributes to speed up enum attribute lookup since they
             # are final.
-            if cdef.info.bases and cdef.info.bases[0].type.fullname == 'enum.Enum':
+            if (
+                cdef.info.bases
+                and cdef.info.bases[0].type.fullname == 'enum.Enum'
+                and lvalue.name != '_order_'
+            ):
                 attr_to_cache.append(lvalue)
 
     def setup_non_ext_dict(self, cdef: ClassDef, bases: Value) -> Value:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1448,6 +1448,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             if (
                 cdef.info.bases
                 and cdef.info.bases[0].type.fullname == 'enum.Enum'
+                # Skip "_order_", since Enum will remove it
                 and lvalue.name != '_order_'
             ):
                 attr_to_cache.append(lvalue)

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -126,6 +126,7 @@ assert o.get(20) == 20
 from enum import Enum
 
 class TestEnum(Enum):
+    _order_ = "a b"
     a : int = 1
     b : int = 2
 

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -141,11 +141,14 @@ assert TestEnum.test() == 3
 # non-extension classes
 
 [file driver.py]
-from native import TestEnum
-assert TestEnum.a.name == 'a'
-assert TestEnum.a.value == 1
-assert TestEnum.b.name == 'b'
-assert TestEnum.b.value == 2
+import sys
+# "_order_" isn't supported in 3.5
+if sys.version_info[:2] > (3, 5):
+    from native import TestEnum
+    assert TestEnum.a.name == 'a'
+    assert TestEnum.a.value == 1
+    assert TestEnum.b.name == 'b'
+    assert TestEnum.b.value == 2
 
 [case testRunDataclass]
 from dataclasses import dataclass, field


### PR DESCRIPTION
`_order_` doesn't make it into the Enum, so don't try to read it.