### PR TITLE
[mypyc] Fix subclassing from abstract generic classes under 3.7

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -147,6 +147,11 @@ static PyObject *CPyType_FromTemplate(PyTypeObject *template_,
         if (!ns)
             goto error;
 
+        if (bases != orig_bases) {
+            if (PyDict_SetItemString(ns, "__orig_bases__", orig_bases) < 0)
+                goto error;
+        }
+
         dummy_class = (PyTypeObject *)PyObject_CallFunctionObjArgs(
             (PyObject *)metaclass, name, bases, ns, NULL);
         Py_DECREF(ns);

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -438,7 +438,7 @@ assert a.foo() == 11
 assert foo() == 21
 
 [case testGenericClass]
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, Sequence
 T = TypeVar('T')
 class C(Generic[T]):
     x: T
@@ -448,6 +448,12 @@ class C(Generic[T]):
         return self.x
     def set(self, y: T) -> None:
         self.x = y
+
+# Test subclassing generic classes both with and without a generic param
+class A(Sequence[int]):
+    pass
+class B(Sequence[T]):
+    pass
 
 def f(c: C[int]) -> int:
     y = c.get()


### PR DESCRIPTION
We need to set `__orig_bases__` before calling the metaclass or it
will get mad.