### PR TITLE
dmypy start doesn't work when files is defined in mypy.ini (#8088)

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -131,11 +131,9 @@ CONNECTION_NAME = 'dmypy'  # type: Final
 
 
 def process_start_options(flags: List[str], allow_sources: bool) -> Options:
-    sources, options = mypy.main.process_options(['-i'] + flags,
+    _, options = mypy.main.process_options(['-i'] + flags,
                                                  require_targets=False,
                                                  server_options=True)
-    if sources and not allow_sources:
-        sys.exit("dmypy: start/restart does not accept sources")
     if options.report_dirs:
         sys.exit("dmypy: start/restart cannot generate reports")
     if options.junit_xml:

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -131,9 +131,9 @@ CONNECTION_NAME = 'dmypy'  # type: Final
 
 
 def process_start_options(flags: List[str], allow_sources: bool) -> Options:
-    _, options = mypy.main.process_options(['-i'] + flags,
-                                                 require_targets=False,
-                                                 server_options=True)
+    _, options = mypy.main.process_options(
+        ['-i'] + flags, require_targets=False, server_options=True
+    )
     if options.report_dirs:
         sys.exit("dmypy: start/restart cannot generate reports")
     if options.junit_xml:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -809,6 +809,9 @@ def process_options(args: List[str],
     # Parse config file first, so command line can override.
     options = Options()
     parse_config_file(options, config_file, stdout, stderr)
+    # the 'dmypy start' will just ignore files in config
+    if server_options:
+        options.files = None
 
     # Set strict flags before parsing (if strict mode enabled), so other command
     # line options can override.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -809,9 +809,6 @@ def process_options(args: List[str],
     # Parse config file first, so command line can override.
     options = Options()
     parse_config_file(options, config_file, stdout, stderr)
-    # the 'dmypy start' will just ignore files in config
-    if server_options:
-        options.files = None
 
     # Set strict flags before parsing (if strict mode enabled), so other command
     # line options can override.

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -28,6 +28,13 @@ Daemon stopped
 [file foo.py]
 def f(): pass
 
+[case testDaemonIgnoreConfigFiles]
+$ dmypy start -- --follow-imports=error
+Daemon started
+[file mypy.ini]
+\[mypy]
+files = ./foo.py
+
 [case testDaemonRunRestart]
 $ dmypy run -- foo.py --follow-imports=error
 Daemon started


### PR DESCRIPTION
I'm trying to fix issue #8088 , current change is just ignore the file fields in config when start from dmypy start.

I'm still not familier with dmypy, please review the PR and any advice is welcome.