### PR TITLE
stubgen: fix return type of annotated __init__

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -602,14 +602,14 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
                 arg = name + annotation
             args.append(arg)
         retname = None
-        if isinstance(o.unanalyzed_type, CallableType):
+        if o.name != '__init__' and isinstance(o.unanalyzed_type, CallableType):
             retname = self.print_annotation(o.unanalyzed_type.ret_type)
         elif isinstance(o, FuncDef) and (o.is_abstract or o.name in METHODS_WITH_RETURN_VALUE):
             # Always assume abstract methods return Any unless explicitly annotated. Also
             # some dunder methods should not have a None return type.
             retname = self.typing_name('Any')
             self.add_typing_import("Any")
-        elif o.name == '__init__' or not has_return_statement(o) and not is_abstract:
+        elif not has_return_statement(o) and not is_abstract:
             retname = 'None'
         retfield = ''
         if retname is not None:

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -163,6 +163,14 @@ class C:
 class C:
     x: int = ...
 
+[case testInitTypeAnnotationPreserved]
+class C:
+    def __init__(self, x: str):
+        pass
+[out]
+class C:
+    def __init__(self, x: str) -> None: ...
+
 [case testSelfAssignment]
 class C:
     def __init__(self):


### PR DESCRIPTION
When __init__ had partial type annotations, for parameters but not for
the return type, the return type was annotated as Any, which is reported
as an error by mypy when checking the generated stubs.

Make sure to annotate the return value as None also in the case of
existing type annotations for

fixes #8110