### PR TITLE
Exclude "__order__" attribute from Enum Union expansion

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -705,6 +705,12 @@ def analyze_class_attribute_access(itype: Instance,
         check_final_member(name, info, mx.msg, mx.context)
 
     if info.is_enum and not (mx.is_lvalue or is_decorated or is_method):
+        # Skip "_order_" and "__order__", since Enum will remove it
+        if name in ("_order_", "__order__"):
+            return mx.msg.has_no_attr(
+                mx.original_type, itype, name, mx.context, mx.module_symbol_table
+            )
+
         enum_literal = LiteralType(name, fallback=itype)
         # When we analyze enums, the corresponding Instance is always considered to be erased
         # due to how the signature of Enum.__new__ is `(cls: Type[_T], value: object) -> _T`

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1445,8 +1445,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             if (
                 cdef.info.bases
                 and cdef.info.bases[0].type.fullname == 'enum.Enum'
-                # Skip "_order_", since Enum will remove it
-                and lvalue.name != '_order_'
+                # Skip "_order_" and "__order__", since Enum will remove it
+                and lvalue.name not in ('_order_', '__order__')
             ):
                 attr_to_cache.append(lvalue)
 

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -659,6 +659,40 @@ else:
     reveal_type(y)  # No output here: this branch is unreachable
 [builtins fixtures/bool.pyi]
 
+[case testEnumReachabilityChecksWithOrdering]
+from enum import Enum
+from typing_extensions import Literal
+
+class Foo(Enum):
+    _order_ = "A B"
+    A = 1
+    B = 2
+
+Foo._order_  # E: "Type[Foo]" has no attribute "_order_"
+
+x: Literal[Foo.A, Foo.B]
+if x is Foo.A:
+    reveal_type(x)  # N: Revealed type is 'Literal[__main__.Foo.A]'
+elif x is Foo.B:
+    reveal_type(x)  # N: Revealed type is 'Literal[__main__.Foo.B]'
+else:
+    reveal_type(x)  # No output here: this branch is unreachable
+
+class Bar(Enum):
+    __order__ = "A B"
+    A = 1
+    B = 2
+
+Bar.__order__  # E: "Type[Bar]" has no attribute "__order__"
+
+y: Literal[Bar.A, Bar.B]
+if y is Bar.A:
+    reveal_type(y)  # N: Revealed type is 'Literal[__main__.Bar.A]'
+elif y is Bar.B:
+    reveal_type(y)  # N: Revealed type is 'Literal[__main__.Bar.B]'
+else:
+    reveal_type(y)  # No output here: this branch is unreachable
+
 [case testEnumReachabilityChecksIndirect]
 from enum import Enum
 from typing_extensions import Literal, Final


### PR DESCRIPTION
The `__order__` attribute is used to determine the definition order of enum values and does not define an enum value itself.