### PR TITLE
Flatten TypeAliasType when it is aliased as a Union

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -19,7 +19,7 @@ from mypy.types import (
     PartialType, DeletedType, UninhabitedType, TypeType, TypeOfAny, LiteralType, LiteralValue,
     is_named_instance, FunctionLike,
     StarType, is_optional, remove_optional, is_generic_instance, get_proper_type, ProperType,
-    get_proper_types, flatten_nested_unions, TypeAliasType
+    get_proper_types, flatten_nested_unions
 )
 from mypy.nodes import (
     NameExpr, RefExpr, Var, FuncDef, OverloadedFuncDef, TypeInfo, CallExpr,
@@ -2521,10 +2521,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             left_variants = [base_type]
             base_type = get_proper_type(base_type)
             if isinstance(base_type, UnionType):
-                items = [get_proper_type(item) if isinstance(item, TypeAliasType)
-                         else item for item in base_type.relevant_items()]
                 left_variants = [item for item in
-                                 flatten_nested_unions(items)]
+                                 flatten_nested_unions(base_type.relevant_items(),
+                                                       handle_type_alias_type=True)]
             right_type = self.accept(arg)
 
             # Step 1: We first try leaving the right arguments alone and destructure
@@ -2566,11 +2565,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             right_variants = [(right_type, arg)]
             right_type = get_proper_type(right_type)
             if isinstance(right_type, UnionType):
-                items = [get_proper_type(item) if isinstance(item, TypeAliasType)
-                         else item for item in right_type.relevant_items()]
                 right_variants = [(item, TempNode(item, context=context))
-                                  for item in flatten_nested_unions(items)]
-
+                                  for item in flatten_nested_unions(right_type.relevant_items(),
+                                                                    handle_type_alias_type=True)]
             msg = self.msg.clean_copy()
             msg.disable_count = 0
             all_results = []

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -19,7 +19,7 @@ from mypy.types import (
     PartialType, DeletedType, UninhabitedType, TypeType, TypeOfAny, LiteralType, LiteralValue,
     is_named_instance, FunctionLike,
     StarType, is_optional, remove_optional, is_generic_instance, get_proper_type, ProperType,
-    get_proper_types
+    get_proper_types, flatten_nested_unions, TypeAliasType
 )
 from mypy.nodes import (
     NameExpr, RefExpr, Var, FuncDef, OverloadedFuncDef, TypeInfo, CallExpr,
@@ -2521,7 +2521,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             left_variants = [base_type]
             base_type = get_proper_type(base_type)
             if isinstance(base_type, UnionType):
-                left_variants = [item for item in base_type.relevant_items()]
+                items = [get_proper_type(item) if isinstance(item, TypeAliasType)
+                         else item for item in base_type.relevant_items()]
+                left_variants = [item for item in
+                                 flatten_nested_unions(items)]
             right_type = self.accept(arg)
 
             # Step 1: We first try leaving the right arguments alone and destructure
@@ -2563,8 +2566,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             right_variants = [(right_type, arg)]
             right_type = get_proper_type(right_type)
             if isinstance(right_type, UnionType):
+                items = [get_proper_type(item) if isinstance(item, TypeAliasType)
+                         else item for item in right_type.relevant_items()]
                 right_variants = [(item, TempNode(item, context=context))
-                                  for item in right_type.relevant_items()]
+                                  for item in flatten_nested_unions(items)]
 
             msg = self.msg.clean_copy()
             msg.disable_count = 0

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2239,12 +2239,11 @@ def flatten_nested_unions(types: Iterable[Type],
     # TODO: ban such aliases in semantic analyzer.
     flat_items = []  # type: List[Type]
     if handle_type_alias_type:
-        types = [get_proper_type(item) if isinstance(item, TypeAliasType)
-                 else item for item in types]
+        types = get_proper_types(types)
     for tp in types:
         if isinstance(tp, ProperType) and isinstance(tp, UnionType):
             flat_items.extend(flatten_nested_unions(tp.items,
-                                        handle_type_alias_type=handle_type_alias_type))
+                              handle_type_alias_type=handle_type_alias_type))
         else:
             flat_items.append(tp)
     return flat_items

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -1013,3 +1013,18 @@ y: Union[int, Dict[int, int]] = 1 if bool() else {}
 u: Union[int, List[int]] = [] if bool() else 1
 v: Union[int, Dict[int, int]] = {} if bool() else 1
 [builtins fixtures/isinstancelist.pyi]
+
+[case testFlattenTypeAliasWhenAliasedAsUnion]
+from typing import Union
+
+T1 = int
+T2 = Union[T1, float]
+T3 = Union[T2, complex]
+T4 = Union[T3, int]
+
+def foo(a: T2, b: T2) -> T2:
+    return a + b
+
+def bar(a: T4, b: T4) -> T4:  # test multi-level alias
+    return a + b
+[builtins fixtures/ops.pyi]

--- a/test-data/unit/fixtures/ops.pyi
+++ b/test-data/unit/fixtures/ops.pyi
@@ -64,6 +64,10 @@ class float:
     def __truediv__(self, x: 'float') -> 'float': pass
     def __rtruediv__(self, x: 'float') -> 'float': pass
 
+class complex:
+    def __add__(self, x: complex) -> complex: pass
+    def __radd__(self, x: complex) -> complex: pass
+
 class BaseException: pass
 
 def __print(a1=None, a2=None, a3=None, a4=None): pass


### PR DESCRIPTION
Resolves #8125 

@appleby has some really good thoughts on the issue and I tried some of them. 

The main problem is not about flattening unions inside variants since the following code generates no error
```python
from typing import Union

T1 = Union[int, float]
T2 = Union[Union[Union[int, float], float], Union[float, complex], complex]

def foo(a: T2, b: T2) -> T2:
    return a + b
```

The problem, however, is because when using `TypeAliasType` to alias a Union, the `TypeAliasType` will not get flattened, so this PR fixes this.

I haven't added testcase yet, since no proper fixture file seems to support the add ops in the test code of #8125 , so lots of `error: Unsupported left operand type for + ` will be reported (running mypy using command line will pass the test code)
- [x] add testcase

cc @msullivan 