### PR TITLE
Add support for narrowing Literals using equality

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -32,7 +32,6 @@ from mypy.nodes import (
     YieldFromExpr, TypedDictExpr, PromoteExpr, NewTypeExpr, NamedTupleExpr, TypeVarExpr,
     TypeAliasExpr, BackquoteExpr, EnumCallExpr, TypeAlias, SymbolNode, PlaceholderNode,
     ARG_POS, ARG_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2, LITERAL_TYPE, REVEAL_TYPE,
-    SYMBOL_FUNCBASE_TYPES
 )
 from mypy.literals import literal
 from mypy import nodes
@@ -51,7 +50,7 @@ from mypy import applytype
 from mypy import erasetype
 from mypy.checkmember import analyze_member_access, type_object_type
 from mypy.argmap import ArgTypeExpander, map_actuals_to_formals, map_formals_to_actuals
-from mypy.checkstrformat import StringFormatterChecker, custom_special_method
+from mypy.checkstrformat import StringFormatterChecker
 from mypy.expandtype import expand_type, expand_type_by_instance, freshen_function_type_vars
 from mypy.util import split_module_names
 from mypy.typevars import fill_typevars
@@ -59,7 +58,8 @@ from mypy.visitor import ExpressionVisitor
 from mypy.plugin import Plugin, MethodContext, MethodSigContext, FunctionContext
 from mypy.typeops import (
     tuple_fallback, make_simplified_union, true_only, false_only, erase_to_union_or_bound,
-    function_type, callable_type, try_getting_str_literals
+    function_type, callable_type, try_getting_str_literals, custom_special_method,
+    is_literal_type_like,
 )
 import mypy.errorcodes as codes
 
@@ -4266,24 +4266,6 @@ def merge_typevars_in_callables_by_name(
     return output, variables
 
 
-def is_literal_type_like(t: Optional[Type]) -> bool:
-    """Returns 'true' if the given type context is potentially either a LiteralType,
-    a Union of LiteralType, or something similar.
-    """
-    t = get_proper_type(t)
-    if t is None:
-        return False
-    elif isinstance(t, LiteralType):
-        return True
-    elif isinstance(t, UnionType):
-        return any(is_literal_type_like(item) for item in t.items)
-    elif isinstance(t, TypeVarType):
-        return (is_literal_type_like(t.upper_bound)
-                or any(is_literal_type_like(item) for item in t.values))
-    else:
-        return False
-
-
 def try_getting_literal(typ: Type) -> ProperType:
     """If possible, get a more precise literal type for a given type."""
     typ = get_proper_type(typ)
@@ -4302,29 +4284,6 @@ def is_expr_literal_type(node: Expression) -> bool:
         underlying = node.node
         return isinstance(underlying, TypeAlias) and isinstance(get_proper_type(underlying.target),
                                                                 LiteralType)
-    return False
-
-
-def custom_equality_method(typ: Type) -> bool:
-    """Does this type have a custom __eq__() method?"""
-    typ = get_proper_type(typ)
-    if isinstance(typ, Instance):
-        method = typ.type.get('__eq__')
-        if method and isinstance(method.node, (SYMBOL_FUNCBASE_TYPES, Decorator, Var)):
-            if method.node.info:
-                return not method.node.info.fullname.startswith('builtins.')
-        return False
-    if isinstance(typ, UnionType):
-        return any(custom_equality_method(t) for t in typ.items)
-    if isinstance(typ, TupleType):
-        return custom_equality_method(tuple_fallback(typ))
-    if isinstance(typ, CallableType) and typ.is_type_obj():
-        # Look up __eq__ on the metaclass for class objects.
-        return custom_equality_method(typ.fallback)
-    if isinstance(typ, AnyType):
-        # Avoid false positives in uncertain cases.
-        return True
-    # TODO: support other types (see ExpressionChecker.has_member())?
     return False
 
 

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -19,12 +19,12 @@ from typing_extensions import Final, TYPE_CHECKING
 
 from mypy.types import (
     Type, AnyType, TupleType, Instance, UnionType, TypeOfAny, get_proper_type, TypeVarType,
-    CallableType, LiteralType, get_proper_types
+    LiteralType, get_proper_types
 )
 from mypy.nodes import (
     StrExpr, BytesExpr, UnicodeExpr, TupleExpr, DictExpr, Context, Expression, StarExpr, CallExpr,
     IndexExpr, MemberExpr, TempNode, ARG_POS, ARG_STAR, ARG_NAMED, ARG_STAR2,
-    SYMBOL_FUNCBASE_TYPES, Decorator, Var, Node, MypyFile, ExpressionStmt, NameExpr, IntExpr
+    Node, MypyFile, ExpressionStmt, NameExpr, IntExpr
 )
 import mypy.errorcodes as codes
 
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 from mypy import message_registry
 from mypy.messages import MessageBuilder
 from mypy.maptype import map_instance_to_supertype
-from mypy.typeops import tuple_fallback
+from mypy.typeops import custom_special_method
 from mypy.subtypes import is_subtype
 from mypy.parse import parse
 
@@ -960,33 +960,4 @@ def has_type_component(typ: Type, fullname: str) -> bool:
                 any(has_type_component(v, fullname) for v in typ.values))
     elif isinstance(typ, UnionType):
         return any(has_type_component(t, fullname) for t in typ.relevant_items())
-    return False
-
-
-def custom_special_method(typ: Type, name: str,
-                          check_all: bool = False) -> bool:
-    """Does this type have a custom special method such as __format__() or __eq__()?
-
-    If check_all is True ensure all items of a union have a custom method, not just some.
-    """
-    typ = get_proper_type(typ)
-    if isinstance(typ, Instance):
-        method = typ.type.get(name)
-        if method and isinstance(method.node, (SYMBOL_FUNCBASE_TYPES, Decorator, Var)):
-            if method.node.info:
-                return not method.node.info.fullname.startswith('builtins.')
-        return False
-    if isinstance(typ, UnionType):
-        if check_all:
-            return all(custom_special_method(t, name, check_all) for t in typ.items)
-        return any(custom_special_method(t, name) for t in typ.items)
-    if isinstance(typ, TupleType):
-        return custom_special_method(tuple_fallback(typ), name)
-    if isinstance(typ, CallableType) and typ.is_type_obj():
-        # Look up __method__ on the metaclass for class objects.
-        return custom_special_method(typ.fallback, name)
-    if isinstance(typ, AnyType):
-        # Avoid false positives in uncertain cases.
-        return True
-    # TODO: support other types (see ExpressionChecker.has_member())?
     return False

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -978,30 +978,41 @@ class Foo(Enum):
 x: Foo
 y: Foo
 
+# We can't narrow anything in the else cases -- what if
+# x is Foo.A and y is Foo.B or vice versa, for example?
 if x is y is Foo.A:
-   reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.A]'
-   reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.A]'
+    reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.A]'
+    reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.A]'
+elif x is y is Foo.B:
+    reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.B]'
+    reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.B]'
 else:
-   reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.B]'
-   reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.B]'
+    reveal_type(x)      # N: Revealed type is '__main__.Foo'
+    reveal_type(y)      # N: Revealed type is '__main__.Foo'
 reveal_type(x)      # N: Revealed type is '__main__.Foo'
 reveal_type(y)      # N: Revealed type is '__main__.Foo'
 
 if x is Foo.A is y:
-   reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.A]'
-   reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.A]'
+    reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.A]'
+    reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.A]'
+elif x is Foo.B is y:
+    reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.B]'
+    reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.B]'
 else:
-   reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.B]'
-   reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.B]'
+    reveal_type(x)      # N: Revealed type is '__main__.Foo'
+    reveal_type(y)      # N: Revealed type is '__main__.Foo'
 reveal_type(x)      # N: Revealed type is '__main__.Foo'
 reveal_type(y)      # N: Revealed type is '__main__.Foo'
 
 if Foo.A is x is y:
-   reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.A]'
-   reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.A]'
+    reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.A]'
+    reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.A]'
+elif Foo.B is x is y:
+    reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.B]'
+    reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.B]'
 else:
-   reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.B]'
-   reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.B]'
+    reveal_type(x)      # N: Revealed type is '__main__.Foo'
+    reveal_type(y)      # N: Revealed type is '__main__.Foo'
 reveal_type(x)      # N: Revealed type is '__main__.Foo'
 reveal_type(y)      # N: Revealed type is '__main__.Foo'
 
@@ -1026,8 +1037,10 @@ if x is Foo.A < y is Foo.B:
     reveal_type(x)  # N: Revealed type is 'Literal[__main__.Foo.A]'
     reveal_type(y)  # N: Revealed type is 'Literal[__main__.Foo.B]'
 else:
-    reveal_type(x)  # N: Revealed type is 'Literal[__main__.Foo.B]'
-    reveal_type(y)  # N: Revealed type is 'Literal[__main__.Foo.A]'
+    # Note: we can't narrow in this case. What if both x and y
+    # are Foo.A, for example?
+    reveal_type(x)  # N: Revealed type is '__main__.Foo'
+    reveal_type(y)  # N: Revealed type is '__main__.Foo'
 reveal_type(x)      # N: Revealed type is '__main__.Foo'
 reveal_type(y)      # N: Revealed type is '__main__.Foo'
 
@@ -1109,11 +1122,13 @@ if x0 is x1 is Foo.A is x2 < x3 is Foo.B is x4 is x5:
     reveal_type(x4)  # N: Revealed type is 'Literal[__main__.Foo.B]'
     reveal_type(x5)  # N: Revealed type is 'Literal[__main__.Foo.B]'
 else:
-    reveal_type(x0)  # N: Revealed type is 'Union[Literal[__main__.Foo.B], Literal[__main__.Foo.C]]'
-    reveal_type(x1)  # N: Revealed type is 'Union[Literal[__main__.Foo.B], Literal[__main__.Foo.C]]'
-    reveal_type(x2)  # N: Revealed type is 'Union[Literal[__main__.Foo.B], Literal[__main__.Foo.C]]'
+    # We unfortunately can't narrow away anything. For example,
+    # what if x0 == Foo.A and x1 == Foo.B or vice versa?
+    reveal_type(x0)  # N: Revealed type is '__main__.Foo'
+    reveal_type(x1)  # N: Revealed type is '__main__.Foo'
+    reveal_type(x2)  # N: Revealed type is '__main__.Foo'
 
-    reveal_type(x3)  # N: Revealed type is 'Union[Literal[__main__.Foo.A], Literal[__main__.Foo.C]]'
-    reveal_type(x4)  # N: Revealed type is 'Union[Literal[__main__.Foo.A], Literal[__main__.Foo.C]]'
-    reveal_type(x5)  # N: Revealed type is 'Union[Literal[__main__.Foo.A], Literal[__main__.Foo.C]]'
+    reveal_type(x3)  # N: Revealed type is '__main__.Foo'
+    reveal_type(x4)  # N: Revealed type is '__main__.Foo'
+    reveal_type(x5)  # N: Revealed type is '__main__.Foo'
 [builtins fixtures/primitives.pyi]

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -987,10 +987,10 @@ elif x is y is Foo.B:
     reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.B]'
     reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.B]'
 else:
-    reveal_type(x)      # N: Revealed type is '__main__.Foo'
-    reveal_type(y)      # N: Revealed type is '__main__.Foo'
-reveal_type(x)      # N: Revealed type is '__main__.Foo'
-reveal_type(y)      # N: Revealed type is '__main__.Foo'
+    reveal_type(x)   # N: Revealed type is '__main__.Foo'
+    reveal_type(y)   # N: Revealed type is '__main__.Foo'
+reveal_type(x)       # N: Revealed type is '__main__.Foo'
+reveal_type(y)       # N: Revealed type is '__main__.Foo'
 
 if x is Foo.A is y:
     reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.A]'
@@ -999,10 +999,10 @@ elif x is Foo.B is y:
     reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.B]'
     reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.B]'
 else:
-    reveal_type(x)      # N: Revealed type is '__main__.Foo'
-    reveal_type(y)      # N: Revealed type is '__main__.Foo'
-reveal_type(x)      # N: Revealed type is '__main__.Foo'
-reveal_type(y)      # N: Revealed type is '__main__.Foo'
+    reveal_type(x)   # N: Revealed type is '__main__.Foo'
+    reveal_type(y)   # N: Revealed type is '__main__.Foo'
+reveal_type(x)       # N: Revealed type is '__main__.Foo'
+reveal_type(y)       # N: Revealed type is '__main__.Foo'
 
 if Foo.A is x is y:
     reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.A]'
@@ -1011,10 +1011,10 @@ elif Foo.B is x is y:
     reveal_type(x)   # N: Revealed type is 'Literal[__main__.Foo.B]'
     reveal_type(y)   # N: Revealed type is 'Literal[__main__.Foo.B]'
 else:
-    reveal_type(x)      # N: Revealed type is '__main__.Foo'
-    reveal_type(y)      # N: Revealed type is '__main__.Foo'
-reveal_type(x)      # N: Revealed type is '__main__.Foo'
-reveal_type(y)      # N: Revealed type is '__main__.Foo'
+    reveal_type(x)   # N: Revealed type is '__main__.Foo'
+    reveal_type(y)   # N: Revealed type is '__main__.Foo'
+reveal_type(x)       # N: Revealed type is '__main__.Foo'
+reveal_type(y)       # N: Revealed type is '__main__.Foo'
 
 [builtins fixtures/primitives.pyi]
 

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1,3 +1,86 @@
+[case testNarrowingParentWithStrsBasic]
+from dataclasses import dataclass
+from typing import NamedTuple, Tuple, Union
+from typing_extensions import Literal, TypedDict
+
+class Object1:
+    key: Literal["A"]
+    foo: int
+class Object2:
+    key: Literal["B"]
+    bar: str
+
+@dataclass
+class Dataclass1:
+    key: Literal["A"]
+    foo: int
+@dataclass
+class Dataclass2:
+    key: Literal["B"]
+    foo: str
+
+class NamedTuple1(NamedTuple):
+    key: Literal["A"]
+    foo: int
+class NamedTuple2(NamedTuple):
+    key: Literal["B"]
+    foo: str
+
+Tuple1 = Tuple[Literal["A"], int]
+Tuple2 = Tuple[Literal["B"], str]
+
+class TypedDict1(TypedDict):
+    key: Literal["A"]
+    foo: int
+class TypedDict2(TypedDict):
+    key: Literal["B"]
+    foo: str
+
+x1: Union[Object1, Object2]
+if x1.key == "A":
+    reveal_type(x1)         # N: Revealed type is '__main__.Object1'
+    reveal_type(x1.key)     # N: Revealed type is 'Literal['A']'
+else:
+    reveal_type(x1)         # N: Revealed type is '__main__.Object2'
+    reveal_type(x1.key)     # N: Revealed type is 'Literal['B']'
+
+x2: Union[Dataclass1, Dataclass2]
+if x2.key == "A":
+    reveal_type(x2)         # N: Revealed type is '__main__.Dataclass1'
+    reveal_type(x2.key)     # N: Revealed type is 'Literal['A']'
+else:
+    reveal_type(x2)         # N: Revealed type is '__main__.Dataclass2'
+    reveal_type(x2.key)     # N: Revealed type is 'Literal['B']'
+
+x3: Union[NamedTuple1, NamedTuple2]
+if x3.key == "A":
+    reveal_type(x3)         # N: Revealed type is 'Tuple[Literal['A'], builtins.int, fallback=__main__.NamedTuple1]'
+    reveal_type(x3.key)     # N: Revealed type is 'Literal['A']'
+else:
+    reveal_type(x3)         # N: Revealed type is 'Tuple[Literal['B'], builtins.str, fallback=__main__.NamedTuple2]'
+    reveal_type(x3.key)     # N: Revealed type is 'Literal['B']'
+if x3[0] == "A":
+    reveal_type(x3)         # N: Revealed type is 'Tuple[Literal['A'], builtins.int, fallback=__main__.NamedTuple1]'
+    reveal_type(x3[0])      # N: Revealed type is 'Literal['A']'
+else:
+    reveal_type(x3)         # N: Revealed type is 'Tuple[Literal['B'], builtins.str, fallback=__main__.NamedTuple2]'
+    reveal_type(x3[0])      # N: Revealed type is 'Literal['B']'
+
+x4: Union[Tuple1, Tuple2]
+if x4[0] == "A":
+    reveal_type(x4)         # N: Revealed type is 'Tuple[Literal['A'], builtins.int]'
+    reveal_type(x4[0])      # N: Revealed type is 'Literal['A']'
+else:
+    reveal_type(x4)         # N: Revealed type is 'Tuple[Literal['B'], builtins.str]'
+    reveal_type(x4[0])      # N: Revealed type is 'Literal['B']'
+
+x5: Union[TypedDict1, TypedDict2]
+if x5["key"] == "A":
+    reveal_type(x5)         # N: Revealed type is 'TypedDict('__main__.TypedDict1', {'key': Literal['A'], 'foo': builtins.int})'
+else:
+    reveal_type(x5)         # N: Revealed type is 'TypedDict('__main__.TypedDict2', {'key': Literal['B'], 'foo': builtins.str})'
+[builtins fixtures/primitives.pyi]
+
 [case testNarrowingParentWithEnumsBasic]
 from enum import Enum
 from dataclasses import dataclass
@@ -445,3 +528,225 @@ if y["model"]["key"] is Key.C:
 else:
     reveal_type(y)              # N: Revealed type is 'Union[TypedDict('__main__.Parent1', {'model': TypedDict('__main__.Model1', {'key': Literal[__main__.Key.A]}), 'foo': builtins.int}), TypedDict('__main__.Parent2', {'model': TypedDict('__main__.Model2', {'key': Literal[__main__.Key.B]}), 'bar': builtins.str})]'
     reveal_type(y["model"])     # N: Revealed type is 'Union[TypedDict('__main__.Model1', {'key': Literal[__main__.Key.A]}), TypedDict('__main__.Model2', {'key': Literal[__main__.Key.B]})]'
+
+[case testNarrowingEqualityFlipFlop]
+# flags: --warn-unreachable --strict-equality
+from typing_extensions import Literal, Final
+from enum import Enum
+
+class State(Enum):
+    A = 1
+    B = 2
+
+class FlipFlopEnum:
+    def __init__(self) -> None:
+        self.state = State.A
+
+    def mutate(self) -> None:
+        self.state = State.B if self.state == State.A else State.A
+
+class FlipFlopStr:
+    def __init__(self) -> None:
+        self.state = "state-1"
+
+    def mutate(self) -> None:
+        self.state = "state-2" if self.state == "state-1" else "state-1"
+
+def test1(switch: FlipFlopEnum) -> None:
+    # Naively, we might assume the 'assert' here would narrow the type to
+    # Literal[State.A]. However, doing this ends up breaking a fair number of real-world
+    # code (usually test cases) that looks similar to this function: e.g. checks
+    # to make sure a field was mutated to some particular value.
+    #
+    # And since mypy can't really reason about state mutation, we take a conservative
+    # approach and avoid narrowing anything here.
+
+    assert switch.state == State.A
+    reveal_type(switch.state)          # N: Revealed type is '__main__.State'
+
+    switch.mutate()
+
+    assert switch.state == State.B
+    reveal_type(switch.state)          # N: Revealed type is '__main__.State'
+
+def test2(switch: FlipFlopEnum) -> None:
+    # So strictly speaking, we ought to do the same thing with 'is' comparisons
+    # for the same reasons as above. But in practice, not too many people seem to
+    # know that doing 'some_enum is MyEnum.Value' is idiomatic. So in practice,
+    # this is probably good enough for now.
+
+    assert switch.state is State.A
+    reveal_type(switch.state)          # N: Revealed type is 'Literal[__main__.State.A]'
+
+    switch.mutate()
+
+    assert switch.state is State.B     # E: Non-overlapping identity check (left operand type: "Literal[State.A]", right operand type: "Literal[State.B]")
+    reveal_type(switch.state)          # E: Statement is unreachable
+
+def test3(switch: FlipFlopStr) -> None:
+    # This is the same thing as 'test1', except we try using str literals.
+
+    assert switch.state == "state-1"
+    reveal_type(switch.state)          # N: Revealed type is 'builtins.str'
+
+    switch.mutate()
+
+    assert switch.state == "state-2"
+    reveal_type(switch.state)          # N: Revealed type is 'builtins.str'
+[builtins fixtures/primitives.pyi]
+
+[case testNarrowingEqualityRequiresExplicitStrLiteral]
+# flags: --strict-optional
+from typing_extensions import Literal, Final
+
+A_final: Final = "A"
+A_literal: Literal["A"]
+
+# Neither the LHS nor the RHS are explicit literals, so regrettably nothing
+# is narrowed here -- see 'testNarrowingEqualityFlipFlop' for an example of
+# why more precise inference here is problematic.
+x_str: str
+if x_str == A_final:
+    reveal_type(x_str)  # N: Revealed type is 'builtins.str'
+else:
+    reveal_type(x_str)  # N: Revealed type is 'builtins.str'
+reveal_type(x_str)      # N: Revealed type is 'builtins.str'
+
+# But the RHS is a literal, so we can at least narrow the 'if' case now.
+if x_str == A_literal:
+    reveal_type(x_str)  # N: Revealed type is 'Literal['A']'
+else:
+    reveal_type(x_str)  # N: Revealed type is 'builtins.str'
+reveal_type(x_str)      # N: Revealed type is 'builtins.str'
+
+# But in these two cases, the LHS is a literal/literal-like type. So we
+# assume the user *does* want literal-based narrowing and narrow accordingly
+# regardless of whether the RHS is an explicit literal or not.
+x_union: Literal["A", "B", None]
+if x_union == A_final:
+    reveal_type(x_union)  # N: Revealed type is 'Literal['A']'
+else:
+    reveal_type(x_union)  # N: Revealed type is 'Union[Literal['B'], None]'
+reveal_type(x_union)      # N: Revealed type is 'Union[Literal['A'], Literal['B'], None]'
+
+if x_union == A_literal:
+    reveal_type(x_union)  # N: Revealed type is 'Literal['A']'
+else:
+    reveal_type(x_union)  # N: Revealed type is 'Union[Literal['B'], None]'
+reveal_type(x_union)      # N: Revealed type is 'Union[Literal['A'], Literal['B'], None]'
+[builtins fixtures/primitives.pyi]
+
+[case testNarrowingEqualityRequiresExplicitEnumLiteral]
+# flags: --strict-optional
+from typing_extensions import Literal, Final
+from enum import Enum
+
+class Foo(Enum):
+    A = 1
+    B = 2
+
+A_final: Final = Foo.A
+A_literal: Literal[Foo.A]
+
+# See comments in testNarrowingEqualityRequiresExplicitStrLiteral and
+# testNarrowingEqualityFlipFlop for more on why we can't narrow here.
+x1: Foo
+if x1 == Foo.A:
+    reveal_type(x1)  # N: Revealed type is '__main__.Foo'
+else:
+    reveal_type(x1)  # N: Revealed type is '__main__.Foo'
+
+x2: Foo
+if x2 == A_final:
+    reveal_type(x2)  # N: Revealed type is '__main__.Foo'
+else:
+    reveal_type(x2)  # N: Revealed type is '__main__.Foo'
+
+# But we let this narrow since there's an explicit literal in the RHS.
+x3: Foo
+if x3 == A_literal:
+    reveal_type(x3)  # N: Revealed type is 'Literal[__main__.Foo.A]'
+else:
+    reveal_type(x3)  # N: Revealed type is 'Literal[__main__.Foo.B]'
+[builtins fixtures/primitives.pyi]
+
+[case testNarrowingEqualityDisabledForCustomEquality]
+from typing import Union
+from typing_extensions import Literal
+from enum import Enum
+
+class Custom:
+    def __eq__(self, other: object) -> bool: return True
+
+class Default: pass
+
+x1: Union[Custom, Literal[1], Literal[2]]
+if x1 == 1:
+    reveal_type(x1)  # N: Revealed type is 'Union[__main__.Custom, Literal[1], Literal[2]]'
+else:
+    reveal_type(x1)  # N: Revealed type is 'Union[__main__.Custom, Literal[1], Literal[2]]'
+
+x2: Union[Default, Literal[1], Literal[2]]
+if x2 == 1:
+    reveal_type(x2)  # N: Revealed type is 'Literal[1]'
+else:
+    reveal_type(x2)  # N: Revealed type is 'Union[__main__.Default, Literal[2]]'
+
+class CustomEnum(Enum):
+    A = 1
+    B = 2
+
+    def __eq__(self, other: object) -> bool: return True
+
+x3: CustomEnum
+key: Literal[CustomEnum.A]
+if x3 == key:
+    reveal_type(x3)  # N: Revealed type is '__main__.CustomEnum'
+else:
+    reveal_type(x3)  # N: Revealed type is '__main__.CustomEnum'
+
+# For comparison, this narrows since we bypass __eq__
+if x3 is key:
+    reveal_type(x3)  # N: Revealed type is 'Literal[__main__.CustomEnum.A]'
+else:
+    reveal_type(x3)  # N: Revealed type is 'Literal[__main__.CustomEnum.B]'
+[builtins fixtures/primitives.pyi]
+
+[case testNarrowingEqualityDisabledForCustomEqualityChain]
+# flags: --strict-optional --strict-equality --warn-unreachable
+from typing import Union
+from typing_extensions import Literal
+
+class Custom:
+    def __eq__(self, other: object) -> bool: return True
+
+class Default: pass
+
+x: Literal[1, 2, None]
+y: Custom
+z: Default
+
+# We could maybe try doing something clever, but for simplicity we
+# treat the whole chain as contaminated and mostly disable narrowing.
+#
+# The only exception is that we do at least strip away the 'None'. We
+# (perhaps optimistically) assume no custom class would be pathological
+# enough to declare itself to be equal to None and so permit this narrowing,
+# since it's often convenient in practice.
+if 1 == x == y:
+    reveal_type(x)   # N: Revealed type is 'Union[Literal[1], Literal[2]]'
+    reveal_type(y)   # N: Revealed type is '__main__.Custom'
+else:
+    reveal_type(x)   # N: Revealed type is 'Union[Literal[1], Literal[2], None]'
+    reveal_type(y)   # N: Revealed type is '__main__.Custom'
+
+# No contamination here
+if 1 == x == z:      # E: Non-overlapping equality check (left operand type: "Union[Literal[1], Literal[2], None]", right operand type: "Default")
+    reveal_type(x)   # E: Statement is unreachable
+    reveal_type(z)
+else:
+    # TODO: Why do we narrow away 'Literal[1]' here?
+    # Even if the equality comparison is bogus, we should try and do better here.
+    reveal_type(x)   # N: Revealed type is 'Union[Literal[2], None]'
+    reveal_type(z)   # N: Revealed type is '__main__.Default'
+[builtins fixtures/primitives.pyi]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -267,6 +267,88 @@ if x.key is Key.D:
 else:
     reveal_type(x)  # N: Revealed type is 'Union[__main__.Object1, __main__.Object2]'
 
+[case testNarrowingTypedDictParentMultipleKeys]
+# flags: --warn-unreachable
+from typing import Union
+from typing_extensions import Literal, TypedDict
+
+class TypedDict1(TypedDict):
+    key: Literal['A', 'C']
+class TypedDict2(TypedDict):
+    key: Literal['B', 'C']
+
+x: Union[TypedDict1, TypedDict2]
+if x['key'] == 'A':
+    reveal_type(x)  # N: Revealed type is 'TypedDict('__main__.TypedDict1', {'key': Union[Literal['A'], Literal['C']]})'
+else:
+    reveal_type(x)  # N: Revealed type is 'Union[TypedDict('__main__.TypedDict1', {'key': Union[Literal['A'], Literal['C']]}), TypedDict('__main__.TypedDict2', {'key': Union[Literal['B'], Literal['C']]})]'
+
+if x['key'] == 'C':
+    reveal_type(x)  # N: Revealed type is 'Union[TypedDict('__main__.TypedDict1', {'key': Union[Literal['A'], Literal['C']]}), TypedDict('__main__.TypedDict2', {'key': Union[Literal['B'], Literal['C']]})]'
+else:
+    reveal_type(x)  # N: Revealed type is 'Union[TypedDict('__main__.TypedDict1', {'key': Union[Literal['A'], Literal['C']]}), TypedDict('__main__.TypedDict2', {'key': Union[Literal['B'], Literal['C']]})]'
+
+if x['key'] == 'D':
+    reveal_type(x)  # E: Statement is unreachable
+else:
+    reveal_type(x)  # N: Revealed type is 'Union[TypedDict('__main__.TypedDict1', {'key': Union[Literal['A'], Literal['C']]}), TypedDict('__main__.TypedDict2', {'key': Union[Literal['B'], Literal['C']]})]'
+[builtins fixtures/primitives.pyi]
+
+[case testNarrowingPartialTypedDictParentMultipleKeys]
+# flags: --warn-unreachable
+from typing import Union
+from typing_extensions import Literal, TypedDict
+
+class TypedDict1(TypedDict, total=False):
+    key: Literal['A', 'C']
+class TypedDict2(TypedDict, total=False):
+    key: Literal['B', 'C']
+
+x: Union[TypedDict1, TypedDict2]
+if x['key'] == 'A':
+    reveal_type(x)  # N: Revealed type is 'TypedDict('__main__.TypedDict1', {'key'?: Union[Literal['A'], Literal['C']]})'
+else:
+    reveal_type(x)  # N: Revealed type is 'Union[TypedDict('__main__.TypedDict1', {'key'?: Union[Literal['A'], Literal['C']]}), TypedDict('__main__.TypedDict2', {'key'?: Union[Literal['B'], Literal['C']]})]'
+
+if x['key'] == 'C':
+    reveal_type(x)  # N: Revealed type is 'Union[TypedDict('__main__.TypedDict1', {'key'?: Union[Literal['A'], Literal['C']]}), TypedDict('__main__.TypedDict2', {'key'?: Union[Literal['B'], Literal['C']]})]'
+else:
+    reveal_type(x)  # N: Revealed type is 'Union[TypedDict('__main__.TypedDict1', {'key'?: Union[Literal['A'], Literal['C']]}), TypedDict('__main__.TypedDict2', {'key'?: Union[Literal['B'], Literal['C']]})]'
+
+if x['key'] == 'D':
+    reveal_type(x)  # E: Statement is unreachable
+else:
+    reveal_type(x)  # N: Revealed type is 'Union[TypedDict('__main__.TypedDict1', {'key'?: Union[Literal['A'], Literal['C']]}), TypedDict('__main__.TypedDict2', {'key'?: Union[Literal['B'], Literal['C']]})]'
+[builtins fixtures/primitives.pyi]
+
+[case testNarrowingNestedTypedDicts]
+from typing import Union
+from typing_extensions import TypedDict, Literal
+
+class A(TypedDict):
+    key: Literal['A']
+class B(TypedDict):
+    key: Literal['B']
+class C(TypedDict):
+    key: Literal['C']
+
+class X(TypedDict):
+    inner: Union[A, B]
+class Y(TypedDict):
+    inner: Union[B, C]
+
+unknown: Union[X, Y]
+if unknown['inner']['key'] == 'A':
+    reveal_type(unknown)            # N: Revealed type is 'TypedDict('__main__.X', {'inner': Union[TypedDict('__main__.A', {'key': Literal['A']}), TypedDict('__main__.B', {'key': Literal['B']})]})'
+    reveal_type(unknown['inner'])   # N: Revealed type is 'TypedDict('__main__.A', {'key': Literal['A']})'
+if unknown['inner']['key'] == 'B':
+    reveal_type(unknown)            # N: Revealed type is 'Union[TypedDict('__main__.X', {'inner': Union[TypedDict('__main__.A', {'key': Literal['A']}), TypedDict('__main__.B', {'key': Literal['B']})]}), TypedDict('__main__.Y', {'inner': Union[TypedDict('__main__.B', {'key': Literal['B']}), TypedDict('__main__.C', {'key': Literal['C']})]})]'
+    reveal_type(unknown['inner'])   # N: Revealed type is 'TypedDict('__main__.B', {'key': Literal['B']})'
+if unknown['inner']['key'] == 'C':
+    reveal_type(unknown)            # N: Revealed type is 'TypedDict('__main__.Y', {'inner': Union[TypedDict('__main__.B', {'key': Literal['B']}), TypedDict('__main__.C', {'key': Literal['C']})]})'
+    reveal_type(unknown['inner'])   # N: Revealed type is 'TypedDict('__main__.C', {'key': Literal['C']})'
+[builtins fixtures/primitives.pyi]
+
 [case testNarrowingParentWithMultipleParents]
 from enum import Enum
 from typing import Union
@@ -529,6 +611,42 @@ else:
     reveal_type(y)              # N: Revealed type is 'Union[TypedDict('__main__.Parent1', {'model': TypedDict('__main__.Model1', {'key': Literal[__main__.Key.A]}), 'foo': builtins.int}), TypedDict('__main__.Parent2', {'model': TypedDict('__main__.Model2', {'key': Literal[__main__.Key.B]}), 'bar': builtins.str})]'
     reveal_type(y["model"])     # N: Revealed type is 'Union[TypedDict('__main__.Model1', {'key': Literal[__main__.Key.A]}), TypedDict('__main__.Model2', {'key': Literal[__main__.Key.B]})]'
 
+[case testNarrowingParentsHierarchyTypedDictWithStr]
+# flags: --warn-unreachable
+from typing import Union
+from typing_extensions import TypedDict, Literal
+
+class Parent1(TypedDict):
+    model: Model1
+    foo: int
+
+class Parent2(TypedDict):
+    model: Model2
+    bar: str
+
+class Model1(TypedDict):
+    key: Literal['A']
+
+class Model2(TypedDict):
+    key: Literal['B']
+
+x: Union[Parent1, Parent2]
+if x["model"]["key"] == 'A':
+    reveal_type(x)              # N: Revealed type is 'TypedDict('__main__.Parent1', {'model': TypedDict('__main__.Model1', {'key': Literal['A']}), 'foo': builtins.int})'
+    reveal_type(x["model"])     # N: Revealed type is 'TypedDict('__main__.Model1', {'key': Literal['A']})'
+else:
+    reveal_type(x)              # N: Revealed type is 'TypedDict('__main__.Parent2', {'model': TypedDict('__main__.Model2', {'key': Literal['B']}), 'bar': builtins.str})'
+    reveal_type(x["model"])     # N: Revealed type is 'TypedDict('__main__.Model2', {'key': Literal['B']})'
+
+y: Union[Parent1, Parent2]
+if y["model"]["key"] == 'C':
+    reveal_type(y)              # E: Statement is unreachable
+    reveal_type(y["model"])
+else:
+    reveal_type(y)              # N: Revealed type is 'Union[TypedDict('__main__.Parent1', {'model': TypedDict('__main__.Model1', {'key': Literal['A']}), 'foo': builtins.int}), TypedDict('__main__.Parent2', {'model': TypedDict('__main__.Model2', {'key': Literal['B']}), 'bar': builtins.str})]'
+    reveal_type(y["model"])     # N: Revealed type is 'Union[TypedDict('__main__.Model1', {'key': Literal['A']}), TypedDict('__main__.Model2', {'key': Literal['B']})]'
+[builtins fixtures/primitives.pyi]
+
 [case testNarrowingEqualityFlipFlop]
 # flags: --warn-unreachable --strict-equality
 from typing_extensions import Literal, Final
@@ -606,6 +724,12 @@ A_literal: Literal["A"]
 # is narrowed here -- see 'testNarrowingEqualityFlipFlop' for an example of
 # why more precise inference here is problematic.
 x_str: str
+if x_str == "A":
+    reveal_type(x_str)  # N: Revealed type is 'builtins.str'
+else:
+    reveal_type(x_str)  # N: Revealed type is 'builtins.str'
+reveal_type(x_str)      # N: Revealed type is 'builtins.str'
+
 if x_str == A_final:
     reveal_type(x_str)  # N: Revealed type is 'builtins.str'
 else:
@@ -745,8 +869,94 @@ if 1 == x == z:      # E: Non-overlapping equality check (left operand type: "Un
     reveal_type(x)   # E: Statement is unreachable
     reveal_type(z)
 else:
-    # TODO: Why do we narrow away 'Literal[1]' here?
-    # Even if the equality comparison is bogus, we should try and do better here.
-    reveal_type(x)   # N: Revealed type is 'Union[Literal[2], None]'
+    reveal_type(x)   # N: Revealed type is 'Union[Literal[1], Literal[2], None]'
     reveal_type(z)   # N: Revealed type is '__main__.Default'
+[builtins fixtures/primitives.pyi]
+
+[case testNarrowingUnreachableCases]
+# flags: --strict-optional --strict-equality --warn-unreachable
+from typing import Union
+from typing_extensions import Literal
+
+a: Literal[1]
+b: Literal[1, 2]
+c: Literal[2, 3]
+
+if a == b == c:
+    reveal_type(a)  # E: Statement is unreachable
+    reveal_type(b)
+    reveal_type(c)
+else:
+    reveal_type(a)  # N: Revealed type is 'Literal[1]'
+    reveal_type(b)  # N: Revealed type is 'Union[Literal[1], Literal[2]]'
+    reveal_type(c)  # N: Revealed type is 'Union[Literal[2], Literal[3]]'
+
+if a == a == a:
+    reveal_type(a)  # N: Revealed type is 'Literal[1]'
+else:
+    reveal_type(a)  # E: Statement is unreachable
+
+if a == a == b:
+    reveal_type(a)  # N: Revealed type is 'Literal[1]'
+    reveal_type(b)  # N: Revealed type is 'Literal[1]'
+else:
+    reveal_type(a)  # N: Revealed type is 'Literal[1]'
+    reveal_type(b)  # N: Revealed type is 'Literal[2]'
+
+# In this case, it's ok for 'b' to narrow down to Literal[1] in the else case
+# since that's the only way 'b == 2' can be false
+if b == 2:
+    reveal_type(b)  # N: Revealed type is 'Literal[2]'
+else:
+    reveal_type(b)  # N: Revealed type is 'Literal[1]'
+
+# But in this case, we can't conclude anything about the else case. This expression
+# could end up being either '2 == 2 == 3' or '1 == 2 == 2', which means we can't
+# conclude anything.
+if b == 2 == c:
+    reveal_type(b)  # N: Revealed type is 'Literal[2]'
+    reveal_type(c)  # N: Revealed type is 'Literal[2]'
+else:
+    reveal_type(b)  # N: Revealed type is 'Union[Literal[1], Literal[2]]'
+    reveal_type(c)  # N: Revealed type is 'Union[Literal[2], Literal[3]]'
+[builtins fixtures/primitives.pyi]
+
+[case testNarrowingUnreachableCases2]
+# flags: --strict-optional --strict-equality --warn-unreachable
+from typing import Union
+from typing_extensions import Literal
+
+a: Literal[1, 2, 3, 4]
+b: Literal[1, 2, 3, 4]
+
+if a == b == 1:
+    reveal_type(a)  # N: Revealed type is 'Literal[1]'
+    reveal_type(b)  # N: Revealed type is 'Literal[1]'
+elif a == b == 2:
+    reveal_type(a)  # N: Revealed type is 'Literal[2]'
+    reveal_type(b)  # N: Revealed type is 'Literal[2]'
+elif a == b == 3:
+    reveal_type(a)  # N: Revealed type is 'Literal[3]'
+    reveal_type(b)  # N: Revealed type is 'Literal[3]'
+elif a == b == 4:
+    reveal_type(a)  # N: Revealed type is 'Literal[4]'
+    reveal_type(b)  # N: Revealed type is 'Literal[4]'
+else:
+    # This branch is reachable if a == 1 and b == 2, for example.
+    reveal_type(a)  # N: Revealed type is 'Union[Literal[1], Literal[2], Literal[3], Literal[4]]'
+    reveal_type(b)  # N: Revealed type is 'Union[Literal[1], Literal[2], Literal[3], Literal[4]]'
+
+if a == a == 1:
+    reveal_type(a)  # N: Revealed type is 'Literal[1]'
+elif a == a == 2:
+    reveal_type(a)  # N: Revealed type is 'Literal[2]'
+elif a == a == 3:
+    reveal_type(a)  # N: Revealed type is 'Literal[3]'
+elif a == a == 4:
+    reveal_type(a)  # N: Revealed type is 'Literal[4]'
+else:
+    # In contrast, this branch must be unreachable: we assume (maybe naively)
+    # that 'a' won't be mutated in the middle of the expression.
+    reveal_type(a)  # E: Statement is unreachable
+    reveal_type(b)
 [builtins fixtures/primitives.pyi]

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -489,12 +489,20 @@ if x == '<string>':
     reveal_type(x)  # N: Revealed type is 'builtins.str'
 else:
     reveal_type(x)  # N: Revealed type is 'Union[builtins.str, None]'
+if x is '<string>':
+    reveal_type(x)  # N: Revealed type is 'builtins.str'
+else:
+    reveal_type(x)  # N: Revealed type is 'Union[builtins.str, None]'
 [builtins fixtures/ops.pyi]
 
 [case testInferEqualsNotOptionalWithUnion]
 from typing import Union
 x = ''  # type: Union[str, int, None]
 if x == '<string>':
+    reveal_type(x)  # N: Revealed type is 'Union[builtins.str, builtins.int]'
+else:
+    reveal_type(x)  # N: Revealed type is 'Union[builtins.str, builtins.int, None]'
+if x is '<string>':
     reveal_type(x)  # N: Revealed type is 'Union[builtins.str, builtins.int]'
 else:
     reveal_type(x)  # N: Revealed type is 'Union[builtins.str, builtins.int, None]'
@@ -507,12 +515,20 @@ if x == object():
     reveal_type(x)  # N: Revealed type is 'Union[builtins.str, builtins.int]'
 else:
     reveal_type(x)  # N: Revealed type is 'Union[builtins.str, builtins.int, None]'
+if x is object():
+    reveal_type(x)  # N: Revealed type is 'Union[builtins.str, builtins.int]'
+else:
+    reveal_type(x)  # N: Revealed type is 'Union[builtins.str, builtins.int, None]'
 [builtins fixtures/ops.pyi]
 
 [case testInferEqualsStillOptionalWithNoOverlap]
 from typing import Optional
 x = ''  # type: Optional[str]
 if x == 0:
+    reveal_type(x)  # N: Revealed type is 'Union[builtins.str, None]'
+else:
+    reveal_type(x)  # N: Revealed type is 'Union[builtins.str, None]'
+if x is 0:
     reveal_type(x)  # N: Revealed type is 'Union[builtins.str, None]'
 else:
     reveal_type(x)  # N: Revealed type is 'Union[builtins.str, None]'
@@ -523,6 +539,10 @@ from typing import Union
 x = ''  # type: Union[str, int, None]
 y = ''  # type: Union[str, None]
 if x == y:
+    reveal_type(x)  # N: Revealed type is 'Union[builtins.str, builtins.int, None]'
+else:
+    reveal_type(x)  # N: Revealed type is 'Union[builtins.str, builtins.int, None]'
+if x is y:
     reveal_type(x)  # N: Revealed type is 'Union[builtins.str, builtins.int, None]'
 else:
     reveal_type(x)  # N: Revealed type is 'Union[builtins.str, builtins.int, None]'


### PR DESCRIPTION
This pull request (finally) adds support for narrowing expressions using Literal types by equality, instead of just identity. For example, the following "tagged union" pattern is now supported:

```python
class Foo(TypedDict):
    key: Literal["A"]
    blah: int

class Bar(TypedDict):
    key: Literal["B"]
    something: str

x: Union[Foo, Bar]
if x.key == "A":
    reveal_type(x)  # Revealed type is 'Foo'
else:
    reveal_type(x)  # Revealed type is 'Bar'
```

Previously, this was possible to do only with Enum Literals and the `is` operator, which is perhaps not very intuitive.

The main limitation with this pull request is that it'll perform narrowing only if either the LHS or RHS contains an explicit Literal type somewhere. If this limitation is not present, we end up breaking a decent amount of real-world code -- mostly tests -- that do something like this:

```python
def some_test_case() -> None:
    worker = Worker()

    # Without the limitation, we narrow 'worker.state' to
    # Literal['ready'] in this assert...
    assert worker.state == 'ready'

    worker.start()

    # ...which subsequently causes this second assert to narrow
    # worker.state to <uninhabited>, causing the last line to be
    # unreachable.
    assert worker.state == 'running'
    worker.query()
```

I tried for several weeks to find a more intelligent way around this problem, but everything I tried ended up being either insufficient or super-hacky, so I gave up and went for this brute-force solution.

The other main limitation is that we perform narrowing only if both the LHS and RHS do not define custom `__eq__` or `__ne__` methods, but this seems like a more reasonable one to me.

Resolves https://github.com/python/mypy/issues/7944.
