### PR TITLE
Update docs for Literal types

### DIFF
--- a/docs/source/literal_types.rst
+++ b/docs/source/literal_types.rst
@@ -242,7 +242,7 @@ type. Then, you can discriminate between each kind of TypedDict by checking the 
 
     Event = Union[NewJobEvent, CancelJobEvent]
 
-    def process_event(event: Union[NewJobEvent, CancelJobEvent]) -> None:
+    def process_event(event: Event) -> None:
         # Since we made sure both TypedDicts have a key named 'tag', it's
         # safe to do 'event["tag"]'. This expression normally has the type
         # Literal["new-job", "cancel-job"], but the check below will narrow

--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -1119,3 +1119,16 @@ and non-required keys, such as ``Movie`` above, will only be compatible with
 another ``TypedDict`` if all required keys in the other ``TypedDict`` are required keys in the
 first ``TypedDict``, and all non-required keys of the other ``TypedDict`` are also non-required keys
 in the first ``TypedDict``.
+
+Unions of TypedDicts
+--------------------
+
+Since TypedDicts are really just regular dicts at runtime, it is not possible to
+use ``isinstance`` checks to distinguish between different variants of a Union of
+TypedDict in the same way you can with regular objects.
+
+Instead, you can use the :ref:`tagged union pattern <tagged_unions>`. The referenced
+section of the docs has a full description with an example, but in short, you will
+need to give each TypedDict the same key where each value has a unique
+unique :ref:`Literal type <literal_types>`. Then, check that key to distinguish
+between your TypedDicts.


### PR DESCRIPTION
This pull request is a long-overdue update of the Literal type docs. It:

1. Removes the "this is alpha" warning we have at the top.

2. Mentions Literal enums are a thing (and works in a brief example of one).

3. Adds a section about "intelligent indexing".

4. Adds a section about the "tagged union" pattern (see https://github.com/python/mypy/pull/8151). I made the example focus on the TypedDict/JSON use case -- IMO that's really the only realistically useful use case for the pattern.

5. Cross-references the "tagged union" docs with the TypedDicts docs.

I also thought about making the "Unions of TypedDict" section I added to the TypedDicts doc mention using [pydantic][0] as an alternative to the "tagged union" pattern.

I personally prefer using libraries like this which handle validation and let me use regular classes (and `isinstance`) instead of dicts, but I wasn't sure whether we want to be recommending 3rd party libraries so held off for now. LMK if you think it's worth including it, and I can update the PR.

  [0]: https://pydantic-docs.helpmanual.io