### PR TITLE
[mypyc] Force type error helper to not be inlined

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -1062,6 +1062,7 @@ static PyObject *CPy_FormatTypeName(PyObject *value) {
     return output;
 }
 
+CPy_NOINLINE
 static void CPy_TypeError(const char *expected, PyObject *value) {
     PyObject *out = CPy_FormatTypeName(value);
     if (out) {


### PR DESCRIPTION
On macOS, this made the generated binary about 8% smaller (when
using -O3).