### PR TITLE
Fix bugs where overriding init in a dataclass subclass crashed mypy

### DIFF
--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -80,6 +80,29 @@ reveal_type(D)  # N: Revealed type is 'def (a: builtins.int, b: builtins.int, c:
 
 [builtins fixtures/list.pyi]
 
+[case testDataclassesMultipleInheritance]
+from dataclasses import dataclass, field, InitVar
+@dataclass
+class A:
+    a: bool
+
+
+@dataclass
+class B:
+    b: InitVar[bool]
+    _b: bool = field(init=False)
+
+    def __post_init__(self, b: bool):
+        self._b = b
+
+
+@dataclass
+class C(A, B):
+    pass
+
+
+[builtins fixtures/bool.pyi]
+
 [case testDataclassesOverriding]
 # flags: --python-version 3.6
 from dataclasses import dataclass
@@ -588,6 +611,89 @@ class A:
         reveal_type(cls())  # N: Revealed type is 'T`-1'
         return cls()
 [builtins fixtures/classmethod.pyi]
+
+[case testDataclassesInitVarOverride]
+import dataclasses
+
+@dataclasses.dataclass
+class A:
+    a: dataclasses.InitVar[int]
+    _a: int = dataclasses.field(init=False)
+
+    def __post_init__(self, a):
+        self._a = a
+
+@dataclasses.dataclass(init=False)
+class B(A):
+    b: dataclasses.InitVar[int]
+    _b: int = dataclasses.field(init=False)
+
+    def __init__(self, b):
+        super().__init__(b+1)
+        self._b = b
+
+[builtins fixtures/bool.pyi]
+
+[case testDataclassesInitVarNoOverride]
+import dataclasses
+
+@dataclasses.dataclass
+class A:
+    a: dataclasses.InitVar[int]
+    _a: int = dataclasses.field(init=False)
+
+    def __post_init__(self, a):
+        self._a = a
+
+@dataclasses.dataclass(init=True)
+class B(A):
+    b: dataclasses.InitVar[int]
+    _b: int = dataclasses.field(init=False)
+
+    def __post_init__(self, a, b):
+        self._a = a
+        self._b = b
+
+B(1, 2)
+B(1, 'a') # E: Argument 2 to "B" has incompatible type "str"; expected "int"
+
+[builtins fixtures/bool.pyi]
+
+
+[case testDataclassesInitVarPostInitOverride]
+import dataclasses
+
+@dataclasses.dataclass
+class A:
+    a: dataclasses.InitVar[int]
+    _a: int = dataclasses.field(init=False)
+
+    def __post_init__(self, a: int) -> None:
+        self._a = a
+
+@dataclasses.dataclass
+class B(A):
+    b: int = dataclasses.field(init=False)
+
+    def __post_init__(self, a: int) -> None:
+        super().__post_init__(a)
+        self.b = a + 1
+
+@dataclasses.dataclass(init=False)
+class C(B):
+    c: int
+
+    def __init__(self, a: int, c: int) -> None:
+        super().__init__(a)
+        self.c = c + self.b
+
+A(1)
+B(1)
+B(1, 2)  # E: Too many arguments for "B"
+C(1, 2)
+C(1, 'a')  # E: Argument 2 to "C" has incompatible type "str"; expected "int"
+
+[builtins fixtures/primitives.pyi]
 
 [case testNoComplainFieldNone]
 # flags: --python-version 3.6

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -86,7 +86,6 @@ from dataclasses import dataclass, field, InitVar
 class A:
     a: bool
 
-
 @dataclass
 class B:
     b: InitVar[bool]
@@ -95,11 +94,11 @@ class B:
     def __post_init__(self, b: bool):
         self._b = b
 
-
 @dataclass
 class C(A, B):
     pass
 
+reveal_type(C)  # N: Revealed type is 'def (b: builtins.bool, a: builtins.bool) -> __main__.C'
 
 [builtins fixtures/bool.pyi]
 
@@ -658,7 +657,6 @@ B(1, 2)
 B(1, 'a') # E: Argument 2 to "B" has incompatible type "str"; expected "int"
 
 [builtins fixtures/bool.pyi]
-
 
 [case testDataclassesInitVarPostInitOverride]
 import dataclasses


### PR DESCRIPTION
Fixes #8015
Fixes #8022

This fixes two bugs related to dataclass `InitVar`s and overriding `__init__`
by changing mypy to ignore `InitVar`s in parent classes when
the class supplied its own `__init__` and set `(init=False)` on the dataclass.

It also fixes a bug with multiple inheritance of dataclasses.

Previously dataclasses attempted to look up the current class' `__init__` to find
the definition of `InitVar`s, which worked fine as long as the current class was
a direct subclass of the parent and didn't override `__init__`.

Unfortunately that didn't work when the `InitVar` came from a subclass that was
not first in MRO, or the parent had an item in its `__init__` definition that
the subclass didn't use.

Now mypy will look up the `__init__` for the current parent class that is being
processed in order to find the appropriate `InitVar` definition.

I've added test cases for all the issues.