### PR TITLE
Actually exclude "__order__" attribute from Enum Union expansion

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -623,6 +623,9 @@ def try_expanding_enum_to_union(typ: Type, target_fullname: str) -> ProperType:
         for name, symbol in typ.type.names.items():
             if not isinstance(symbol.node, Var):
                 continue
+            # Skip "_order_" and "__order__", since Enum will remove it
+            if name in ("_order_", "__order__"):
+                continue
             new_items.append(LiteralType(name, typ))
         # SymbolTables are really just dicts, and dicts are guaranteed to preserve
         # insertion order only starting with Python 3.7. So, we sort these for older

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -693,6 +693,22 @@ elif y is Bar.B:
 else:
     reveal_type(y)  # No output here: this branch is unreachable
 
+x2: Foo
+if x2 is Foo.A:
+    reveal_type(x2)  # N: Revealed type is 'Literal[__main__.Foo.A]'
+elif x2 is Foo.B:
+    reveal_type(x2)  # N: Revealed type is 'Literal[__main__.Foo.B]'
+else:
+    reveal_type(x2)  # No output here: this branch is unreachable
+
+y2: Bar
+if y2 is Bar.A:
+    reveal_type(y2)  # N: Revealed type is 'Literal[__main__.Bar.A]'
+elif y2 is Bar.B:
+    reveal_type(y2)  # N: Revealed type is 'Literal[__main__.Bar.B]'
+else:
+    reveal_type(y2)  # No output here: this branch is unreachable
+
 [case testEnumReachabilityChecksIndirect]
 from enum import Enum
 from typing_extensions import Literal, Final


### PR DESCRIPTION
My previous attempt didn't actually work as advertised as it was lacking complete test coverage. It merely handled the case
`Bar.__order__  # E: "Type[Bar]" has no attribute "__order__"`

This PR adds more tests and implements the desired behavior this time.