### PR TITLE
Infer type from "x.extend(y)" where y has type Any (etc.)

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -651,6 +651,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                            for item_type in arg_type.args):
                         return self.chk.named_generic_type(typename,
                                                            list(arg_type.args))
+            elif isinstance(arg_type, AnyType):
+                return self.chk.named_type(typename)
+
         return None
 
     def apply_function_plugin(self,

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1723,6 +1723,21 @@ class C:
         self.a = 1
 reveal_type(C().a)  # N: Revealed type is 'Union[builtins.int, None]'
 
+[case testInferListTypeFromEmptyListAndAny]
+def f():
+    return []
+
+def g() -> None:
+    x = []
+    if bool():
+        x = f()
+    reveal_type(x)  # N: Revealed type is 'builtins.list[Any]'
+
+    y = []
+    y.extend(f())
+    reveal_type(y)  # N: Revealed type is 'builtins.list[Any]'
+[builtins fixtures/list.pyi]
+
 
 -- Inferring types of variables first initialized to None (partial types)
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
Previously we inferred a type from an argument like `List[Any]` but
not from plain `Any`, which was inconsistent.