### PR TITLE
Fix incorrect name lookup for decorated methods

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3949,7 +3949,9 @@ class SemanticAnalyzer(NodeVisitor[None],
         """
         assert self.statement
         line_diff = self.statement.line - node.line
-        if isinstance(node, Decorator):
+        if isinstance(node, OverloadedFuncDef) and isinstance(self.statement, FuncDef):
+            return node.name != self.statement.name and line_diff > 0
+        elif isinstance(node, Decorator) and not node.is_overload:
             return line_diff > len(node.original_decorators)
         else:
             return line_diff > 0

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3942,9 +3942,17 @@ class SemanticAnalyzer(NodeVisitor[None],
                 or (isinstance(node, PlaceholderNode) and node.becomes_typeinfo))
 
     def is_textually_before_statement(self, node: SymbolNode) -> bool:
+        """Check if a node is defined textually before a statement
+
+        Note that decorated functions' line number are the same as
+        the topest decorator.
+        """
         assert self.statement
         line_diff = self.statement.line - node.line
-        return line_diff > 1 or (line_diff == 1 and not isinstance(node, Decorator))
+        if isinstance(node, Decorator):
+            return line_diff > len(node.original_decorators)
+        else:
+            return line_diff > 0
 
     def is_defined_in_current_module(self, fullname: Optional[str]) -> bool:
         if fullname is None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3936,10 +3936,15 @@ class SemanticAnalyzer(NodeVisitor[None],
         #       caught.
         assert self.statement  # we are at class scope
         return (node is None
-                or node.line < self.statement.line
+                or self.is_textually_before_statement(node)
                 or not self.is_defined_in_current_module(node.fullname)
                 or isinstance(node, TypeInfo)
                 or (isinstance(node, PlaceholderNode) and node.becomes_typeinfo))
+
+    def is_textually_before_statement(self, node: SymbolNode) -> bool:
+        assert self.statement
+        line_diff = self.statement.line - node.line
+        return line_diff > 1 or (line_diff == 1 and not isinstance(node, Decorator))
 
     def is_defined_in_current_module(self, fullname: Optional[str]) -> bool:
         if fullname is None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3963,9 +3963,12 @@ class SemanticAnalyzer(NodeVisitor[None],
     def is_overloaded_item(self, node: SymbolNode, statement: Statement) -> bool:
         """Check whehter the function belongs to the overloaded variants"""
         if isinstance(node, OverloadedFuncDef) and isinstance(statement, FuncDef):
-            return (statement in
-                    [item.func if isinstance(item, Decorator) else item for item in node.items]
-                    or (node.impl is not None and statement is node.impl))
+            in_items = statement in {item.func if isinstance(item, Decorator)
+                                     else item for item in node.items}
+            in_impl = (node.impl is not None and
+                      ((isinstance(node.impl, Decorator) and statement is node.impl.func)
+                       or statement is node.impl))
+            return in_items or in_impl
         return False
 
     def is_defined_in_current_module(self, fullname: Optional[str]) -> bool:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3942,7 +3942,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 or (isinstance(node, PlaceholderNode) and node.becomes_typeinfo))
 
     def is_textually_before_statement(self, node: SymbolNode) -> bool:
-        """Check if a node is defined textually before a statement
+        """Check if a node is defined textually before the current statement
 
         Note that decorated functions' line number are the same as
         the top decorator.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3945,7 +3945,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         """Check if a node is defined textually before a statement
 
         Note that decorated functions' line number are the same as
-        the topest decorator.
+        the top decorator.
         """
         assert self.statement
         line_diff = self.statement.line - node.line

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6605,8 +6605,7 @@ class A:
 
 class B:
     @staticmethod
-    def A() -> Type[A]:
-        return A
+    def A() -> Type[A]: ...
     @staticmethod
     def B() -> Type[A]:  # E: Function "__main__.B.A" is not valid as a type \
                          # N: Perhaps you need "Callable[...]" or a callback protocol?

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6633,5 +6633,8 @@ class B:
     @classmethod
     @overload
     def A(cls, x: str) -> Type[A]: ...
+    @classmethod
+    def A(cls, x: object) -> Type[A]:
+        return A
 
 [builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6633,7 +6633,8 @@ class B:
     @overload
     def A(cls, x: str) -> Type[A]: ...
     @classmethod
-    def A(cls, x: object) -> Type[A]:
-        return A
+    def A(cls, x: object) -> Type[A]: ...
+    def B(cls, x: int) -> Type[A]: ...  # E: Function "__main__.B.A" is not valid as a type \
+                                        # N: Perhaps you need "Callable[...]" or a callback protocol?
 
 [builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6607,6 +6607,10 @@ class B:
     @staticmethod
     def A() -> Type[A]:
         return A
+    @staticmethod
+    def B() -> Type[A]:  # E: Function "__main__.B.A" is not valid as a type \
+                         # N: Perhaps you need "Callable[...]" or a callback protocol?
+        return A
 
 class C:
     @property
@@ -6615,3 +6619,19 @@ class C:
         return A
 
 [builtins fixtures/staticmethod.pyi]
+
+[case testRefMethodWithOverloadDecorator]
+from typing import Type, overload
+
+class A:
+    pass
+
+class B:
+    @classmethod
+    @overload
+    def A(cls, x: int) -> Type[A]: ...
+    @classmethod
+    @overload
+    def A(cls, x: str) -> Type[A]: ...
+
+[builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6596,3 +6596,17 @@ reveal_type(D() + "str")  # N: Revealed type is 'Any'
 
 reveal_type(0.5 + D1())  # N: Revealed type is 'Any'
 reveal_type(D1() + 0.5)  # N: Revealed type is '__main__.D1'
+
+[case testRefMethodWithDecorator]
+from typing import Type
+
+class A:
+    pass
+
+
+class B:
+    @staticmethod
+    def A() -> Type[A]:
+        return A
+
+[builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6603,10 +6603,15 @@ from typing import Type
 class A:
     pass
 
-
 class B:
     @staticmethod
     def A() -> Type[A]:
         return A
 
-[builtins fixtures/classmethod.pyi]
+class C:
+    @property
+    @staticmethod
+    def A() -> Type[A]:
+        return A
+
+[builtins fixtures/staticmethod.pyi]

--- a/test-data/unit/fixtures/staticmethod.pyi
+++ b/test-data/unit/fixtures/staticmethod.pyi
@@ -9,6 +9,7 @@ class type:
 class function: pass
 
 staticmethod = object() # Dummy definition.
+property = object()  # Dummy definition
 
 class int:
     @staticmethod


### PR DESCRIPTION
Resolves #8161 

According to comments of `lookup` in `mypy/semanal.py`, when we look up a class attribute, we require that it is defined textually before the reference statement, thus line number is used for comparison.

When function has decorators, its line number is determined by the top decorator instead of the `def`. That's why #8161's code fails because on line 8, the `A` in `Type[A]` has the line number of 8 while the @staticmethod function `A` has the line number of 7 due to the decorator. 

Thus we need to properly handle this by introducing the number of decorators when deciding textural precedence.