### PR TITLE
Allow 'in' operations with partial types

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2211,11 +2211,17 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return result
 
     def find_partial_type_ref_fast_path(self, expr: Expression) -> Optional[Type]:
+        """If expression has a partial generic type, return it without additional checks.
+
+        In particular, this does not generate an error about a missing annotation.
+
+        Otherwise, return None.
+        """
         if not isinstance(expr, RefExpr):
             return None
         if isinstance(expr.node, Var):
             result = self.analyze_var_ref(expr.node, expr)
-            if isinstance(result, PartialType):
+            if isinstance(result, PartialType) and result.type is not None:
                 self.chk.store_type(expr, result)
                 return result
         return None

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2125,7 +2125,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             method_type = None  # type: Optional[mypy.types.Type]
 
             if operator == 'in' or operator == 'not in':
-                right_type = self.accept(right)  # always validate the right operand
+                # If the right operand has partial type, look it up without triggering
+                # a "Need type annotation ..." message, as it would be noise.
+                right_type = self.find_partial_type_ref_fast_path(right)
+                if right_type is None:
+                    right_type = self.accept(right)  # Validate the right operand
 
                 # Keep track of whether we get type check errors (these won't be reported, they
                 # are just to verify whether something is valid typing wise).
@@ -2205,6 +2209,16 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         assert result is not None
         return result
+
+    def find_partial_type_ref_fast_path(self, expr: Expression) -> Optional[Type]:
+        if not isinstance(expr, RefExpr):
+            return None
+        if isinstance(expr.node, Var):
+            result = self.analyze_var_ref(expr.node, expr)
+            if isinstance(result, PartialType):
+                self.chk.store_type(expr, result)
+                return result
+        return None
 
     def dangerous_comparison(self, left: Type, right: Type,
                              original_container: Optional[Type] = None) -> bool:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2222,7 +2222,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if isinstance(expr.node, Var):
             result = self.analyze_var_ref(expr.node, expr)
             if isinstance(result, PartialType) and result.type is not None:
-                self.chk.store_type(expr, result)
+                self.chk.store_type(expr, self.chk.fixup_partial_type(result))
                 return result
         return None
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1750,6 +1750,13 @@ if 'x' not in dd:
 reveal_type(dd)  # N: Revealed type is 'builtins.dict[builtins.str, builtins.int]'
 [builtins fixtures/dict.pyi]
 
+[case testInferFromEmptyDictWhenUsingInSpecialCase]
+d = None
+if 'x' in d:  # E: "None" has no attribute "__iter__" (not iterable)
+    pass
+reveal_type(d)  # N: Revealed type is 'None'
+[builtins fixtures/dict.pyi]
+
 
 -- Inferring types of variables first initialized to None (partial types)
 -- ----------------------------------------------------------------------

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1738,6 +1738,18 @@ def g() -> None:
     reveal_type(y)  # N: Revealed type is 'builtins.list[Any]'
 [builtins fixtures/list.pyi]
 
+[case testInferFromEmptyDictWhenUsingIn]
+d = {}
+if 'x' in d:
+    d['x'] = 1
+reveal_type(d)  # N: Revealed type is 'builtins.dict[builtins.str, builtins.int]'
+
+dd = {}
+if 'x' not in dd:
+    dd['x'] = 1
+reveal_type(dd)  # N: Revealed type is 'builtins.dict[builtins.str, builtins.int]'
+[builtins fixtures/dict.pyi]
+
 
 -- Inferring types of variables first initialized to None (partial types)
 -- ----------------------------------------------------------------------

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1757,6 +1757,15 @@ if 'x' in d:  # E: "None" has no attribute "__iter__" (not iterable)
 reveal_type(d)  # N: Revealed type is 'None'
 [builtins fixtures/dict.pyi]
 
+[case testInferFromEmptyListWhenUsingInWithStrictEquality]
+# flags: --strict-equality
+def f() -> None:
+    a = []
+    if 1 in a:  # TODO: This should be an error
+        a.append('x')
+[builtins fixtures/list.pyi]
+[typing fixtures/typing-full.pyi]
+
 
 -- Inferring types of variables first initialized to None (partial types)
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
This improves type inference in code like this:

```
d = {}
for k in f():
    if k not in d:
        d[k] = 0
    else:
        d[k] += 1
```

Unfortunately, this change breaks strict equality checking in 'in' operations
involving partial types. I'm not 100% sure this is a net improvement. I couldn't
find a clean way of getting strict equality working together with this.