### PR TITLE
Simplify default test stubs to speed up tests slightly

### DIFF
--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -15,6 +15,7 @@ Person('John', 32)
 Person('Jonh', 21, None)  # E: Too many arguments for "Person"
 
 [builtins fixtures/list.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testDataclassesCustomInit]
 # flags: --python-version 3.6
@@ -52,6 +53,7 @@ Person(32, 'John')
 Person(21, 'Jonh', None)  # E: Too many arguments for "Person"
 
 [builtins fixtures/list.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testDataclassesDeepInheritance]
 # flags: --python-version 3.6

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -615,6 +615,7 @@ def g() -> int:
 '{}'.format(b'abc')  # E: On Python 3 '{}'.format(b'abc') produces "b'abc'"; use !r if this is a desired behavior  [str-bytes-safe]
 '%s' % b'abc'  # E: On Python 3 '%s' % b'abc' produces "b'abc'"; use %r if this is a desired behavior  [str-bytes-safe]
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testErrorCodeIgnoreNamedDefinedNote]
 x: List[int]  # type: ignore[name-defined]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1307,6 +1307,7 @@ di = None # type: Dict[int, int]
 '%.f' % 'x'
 '%.3f' % 'x'
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 [out]
 main:3: error: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsFloat]")
 main:4: error: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsFloat]")
@@ -1322,6 +1323,7 @@ foo(b'a', b'b') == b'a:b'
 [case testStringInterpolationStarArgs]
 x = (1, 2)
 "%d%d" % (*x,)
+[typing fixtures/typing-full.pyi]
 
 [case testBytePercentInterpolationSupported]
 b'%s' % (b'xyz',)
@@ -1338,6 +1340,7 @@ def f(t: Tuple[int, ...]) -> None:
     '%d %d' % t
     '%d %d %d' % t
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testStringInterpolationUnionType]
 from typing import Tuple, Union

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1147,11 +1147,12 @@ i, f, s, t = None, None, None, None # type: (int, float, str, Tuple[int])
 '%d' % (s,) # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsInt]")
 '%d' % t
 '%d' % s  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsInt]")
-'%f' % s  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsFloat]")
+'%f' % s  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsFlo1at]")
 '%x' % f  # E: Incompatible types in string interpolation (expression has type "float", placeholder has type "int")
 '%i' % f
 '%o' % f  # E: Incompatible types in string interpolation (expression has type "float", placeholder has type "int")
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testStringInterpolationSAcceptsAnyType]
 from typing import Any
@@ -1179,6 +1180,7 @@ reveal_type('%(key)s' % {'key': xu})  # N: Revealed type is 'builtins.unicode'
 reveal_type('%r' % xu)  # N: Revealed type is 'builtins.str'
 reveal_type('%s' % xs)  # N: Revealed type is 'builtins.str'
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testStringInterpolationCount]
 '%d %d' % 1  # E: Not enough arguments for format string
@@ -1189,12 +1191,14 @@ t = 1, 's'
 '%s %d' % t  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsInt]")
 '%d' % t  # E: Not all arguments converted during string formatting
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testStringInterpolationWithAnyType]
 from typing import Any
 a = None # type: Any
 '%d %d' % a
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testStringInterpolationInvalidPlaceholder]
 '%W' % 1  # E: Unsupported format character 'W'
@@ -1682,6 +1686,7 @@ class Good:
 x: Union[float, Good]
 '{:+f}'.format(x)
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testFormatCallSpecialCases]
 '{:08b}'.format(int('3'))

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1250,6 +1250,7 @@ b'%a' % 3
 '%*%' % 1
 '%*% %d' % 1  # E: Not enough arguments for format string
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testStringInterpolationC]
 '%c' % 1
@@ -1263,14 +1264,15 @@ b'%a' % 3
 '%(a)d %(b)s' % {'a': 's', 'b': 1}  # E: Incompatible types in string interpolation (expression has type "str", placeholder with key 'a' has type "Union[int, float, SupportsInt]")
 b'%(x)s' % {b'x': b'data'}
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testStringInterpolationMappingKeys]
 '%()d' % {'': 2}
 '%(a)d' % {'a': 1, 'b': 2, 'c': 3}
 '%(q)d' % {'a': 1, 'b': 2, 'c': 3}  # E: Key 'q' not found in mapping
 '%(a)d %%' % {'a': 1}
-
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testStringInterpolationMappingDictTypes]
 from typing import Any, Dict
@@ -1300,6 +1302,7 @@ di = None # type: Dict[int, int]
 '%(a).1d' % {'a': 1}
 '%(a)#1.1ld' % {'a': 1}
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testStringInterpolationFloatPrecision]
 '%.f' % 1.2

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1221,6 +1221,7 @@ b'%a' % 3
 '%*f' % (4, 3.14)
 '%*f' % (1.1, 3.14) # E: * wants int
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testStringInterpolationPrecision]
 '%.2f' % 3.14
@@ -1228,6 +1229,7 @@ b'%a' % 3
 '%.*f' % (4, 3.14)
 '%.*f' % (1.1, 3.14) # E: * wants int
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testStringInterpolationWidthAndPrecision]
 '%4.2f' % 3.14
@@ -1236,6 +1238,7 @@ b'%a' % 3
 '%*.*f' % 3.14 # E: Not enough arguments for format string
 '%*.*f' % (4, 2, 3.14)
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testStringInterpolationFlagsAndLengthModifiers]
 '%04hd' % 1
@@ -1243,6 +1246,7 @@ b'%a' % 3
 '%+*Ld' % (1, 1)
 '% .*ld' % (1, 1)
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testStringInterpolationDoublePercentage]
 '%% %d' % 1

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1147,7 +1147,7 @@ i, f, s, t = None, None, None, None # type: (int, float, str, Tuple[int])
 '%d' % (s,) # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsInt]")
 '%d' % t
 '%d' % s  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsInt]")
-'%f' % s  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsFlo1at]")
+'%f' % s  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsFloat]")
 '%x' % f  # E: Incompatible types in string interpolation (expression has type "float", placeholder has type "int")
 '%i' % f
 '%o' % f  # E: Incompatible types in string interpolation (expression has type "float", placeholder has type "int")
@@ -1698,6 +1698,7 @@ class S:
 '%d' % S()  # This is OK however
 '{:%}'.format(0.001)
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 
 -- Lambdas
 -- -------

--- a/test-data/unit/fixtures/async_await.pyi
+++ b/test-data/unit/fixtures/async_await.pyi
@@ -12,6 +12,7 @@ class object:
 class type: pass
 class function: pass
 class int: pass
+class float: pass
 class str: pass
 class bool(int): pass
 class dict(typing.Generic[T, U]): pass

--- a/test-data/unit/fixtures/bool.pyi
+++ b/test-data/unit/fixtures/bool.pyi
@@ -12,6 +12,7 @@ class tuple(Generic[T]): pass
 class function: pass
 class bool: pass
 class int: pass
+class float: pass
 class str: pass
 class unicode: pass
 class ellipsis: pass

--- a/test-data/unit/fixtures/python2.pyi
+++ b/test-data/unit/fixtures/python2.pyi
@@ -11,6 +11,7 @@ class type:
 class function: pass
 
 class int: pass
+class float: pass
 class str:
     def format(self, *args, **kwars) -> str: ...
 class unicode:

--- a/test-data/unit/fixtures/typing-full.pyi
+++ b/test-data/unit/fixtures/typing-full.pyi
@@ -140,8 +140,8 @@ class MutableMapping(Mapping[T, U], metaclass=ABCMeta):
 class SupportsInt(Protocol):
     def __int__(self) -> int: pass
 
-class SupportsAbs(Protocol[T_co]):
-    def __abs__(self) -> T_co: pass
+class SupportsFloat(Protocol):
+    def __float__(self) -> float: pass
 
 def runtime_checkable(cls: T) -> T:
     return cls

--- a/test-data/unit/fixtures/typing-full.pyi
+++ b/test-data/unit/fixtures/typing-full.pyi
@@ -143,6 +143,9 @@ class SupportsInt(Protocol):
 class SupportsFloat(Protocol):
     def __float__(self) -> float: pass
 
+class SupportsAbs(Protocol[T_co]):
+    def __abs__(self) -> T_co: pass
+
 def runtime_checkable(cls: T) -> T:
     return cls
 

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -38,13 +38,6 @@ class Sequence(Iterable[T_co]):
 class Mapping(Generic[T, T_co]):
     def __getitem__(self, key: T) -> T_co: pass
 
-class SupportsInt(Protocol):
-    def __int__(self) -> int: pass
-
-class SupportsFloat(Protocol):
-    def __float__(self) -> float: pass
-
-# This is an unofficial extension.
 def final(meth: T) -> T: pass
 
 TYPE_CHECKING = 1

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -1154,6 +1154,7 @@ OpExpr(3) : builtins.list[builtins.str]
 ## .*
 '%d' % 1
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
 [out]
 IntExpr(2) : Literal[1]?
 OpExpr(2) : builtins.str

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -1151,7 +1151,7 @@ ListExpr(3) : builtins.list[builtins.str]
 OpExpr(3) : builtins.list[builtins.str]
 
 [case testStringFormatting]
-## .*
+## IntExpr|OpExpr|StrExpr
 '%d' % 1
 [builtins fixtures/primitives.pyi]
 [typing fixtures/typing-full.pyi]


### PR DESCRIPTION
This speeds up the set of "quick" tests that I typically run by about 2%.