### PR TITLE
Support partial type inference with += and |=

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2042,7 +2042,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             self.check_assignment_to_multiple_lvalues(lvalue.items, rvalue, rvalue,
                                                       infer_lvalue_type)
         else:
-            self.try_infer_partial_generic_type_from_assignment(lvalue, rvalue)
+            self.try_infer_partial_generic_type_from_assignment(lvalue, rvalue, '=')
             lvalue_type, index_lvalue, inferred = self.check_lvalue(lvalue)
             # If we're assigning to __getattr__ or similar methods, check that the signature is
             # valid.
@@ -2142,10 +2142,20 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     rvalue_type = remove_instance_last_known_values(rvalue_type)
                 self.infer_variable_type(inferred, lvalue, rvalue_type, rvalue)
 
+    # (type, operator) tuples for augmented assignments supported with partial types
+    partial_type_augmented_ops = {
+        ('builtins.list', '+'),
+        ('builtins.set', '|'),
+    }
+
     def try_infer_partial_generic_type_from_assignment(self,
                                                        lvalue: Lvalue,
-                                                       rvalue: Expression) -> None:
+                                                       rvalue: Expression,
+                                                       op: str) -> None:
         """Try to infer a precise type for partial generic type from assignment.
+
+        'op' is '=' for normal assignment and a binary operator ('+', ...) for
+        augmented assignment.
 
         Example where this happens:
 
@@ -2164,6 +2174,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             typ = var.type
             assert isinstance(typ, PartialType)
             if typ.type is None:
+                return
+            # Return if this is an unsupported augmented assignment.
+            if op != '=' and (typ.type.fullname, op) not in self.partial_type_augmented_ops:
                 return
             # TODO: some logic here duplicates the None partial type counterpart
             #       inlined in check_assignment(), see # 8043.
@@ -3193,6 +3206,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     def visit_operator_assignment_stmt(self,
                                        s: OperatorAssignmentStmt) -> None:
         """Type check an operator assignment statement, e.g. x += 1."""
+        self.try_infer_partial_generic_type_from_assignment(s.lvalue, s.rvalue, s.op)
         if isinstance(s.lvalue, MemberExpr):
             # Special case, some additional errors may be given for
             # assignments to read-only or final attributes.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2143,7 +2143,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 self.infer_variable_type(inferred, lvalue, rvalue_type, rvalue)
 
     # (type, operator) tuples for augmented assignments supported with partial types
-    partial_type_augmented_ops = {
+    partial_type_augmented_ops: Final = {
         ('builtins.list', '+'),
         ('builtins.set', '|'),
     }

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2143,10 +2143,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 self.infer_variable_type(inferred, lvalue, rvalue_type, rvalue)
 
     # (type, operator) tuples for augmented assignments supported with partial types
-    partial_type_augmented_ops: Final = {
+    partial_type_augmented_ops = {
         ('builtins.list', '+'),
         ('builtins.set', '|'),
-    }
+    }  # type: Final
 
     def try_infer_partial_generic_type_from_assignment(self,
                                                        lvalue: Lvalue,

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1766,6 +1766,18 @@ def f() -> None:
 [builtins fixtures/list.pyi]
 [typing fixtures/typing-full.pyi]
 
+[case testInferListTypeFromInplaceAdd]
+a = []
+a += [1]
+reveal_type(a)  # N: Revealed type is 'builtins.list[builtins.int*]'
+[builtins fixtures/list.pyi]
+
+[case testInferSetTypeFromInplaceOr]
+a = set()
+a |= {'x'}
+reveal_type(a)  # N: Revealed type is 'builtins.set[builtins.str*]'
+[builtins fixtures/set.pyi]
+
 
 -- Inferring types of variables first initialized to None (partial types)
 -- ----------------------------------------------------------------------

--- a/test-data/unit/fixtures/set.pyi
+++ b/test-data/unit/fixtures/set.pyi
@@ -19,6 +19,7 @@ class ellipsis: pass
 class set(Iterable[T], Generic[T]):
     def __iter__(self) -> Iterator[T]: pass
     def __contains__(self, item: object) -> bool: pass
+    def __ior__(self, x: Set[T]) -> None: pass
     def add(self, x: T) -> None: pass
     def discard(self, x: T) -> None: pass
     def update(self, x: Set[T]) -> None: pass


### PR DESCRIPTION
Code like this no longer requires a type annotation:

```
x = []
x += [1, 2]
```