### PR TITLE
Only run Travis tests on Python 3.7 once (compiled)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,12 @@ jobs:
     dist: trusty
   - name: "run test suite with python 3.6"
     python: 3.6    # 3.6.3  pip  9.0.1
-  - name: "run test suite with python 3.7"
-    python: 3.7    # 3.7.0  pip 10.0.1
+  - name: "run test suite with python 3.7 (compiled with mypyc)"
+    python: 3.7
+    env:
+    - TOXENV=py
+    - EXTRA_ARGS="-n 2"
+    - TEST_MYPYC=1
   - name: "run test suite with python 3.8"
     python: 3.8
   - name: "run mypyc runtime tests with python 3.6 debug build"
@@ -47,12 +51,6 @@ jobs:
     env:
       - PYTHONVERSION=3.6.3
       - EXTRA_ARGS="-n 2 mypyc/test/test_run.py mypyc/test/test_external.py"
-  - name: "run test suite with python 3.7 (compiled with mypyc)"
-    python: 3.7
-    env:
-    - TOXENV=py
-    - EXTRA_ARGS="-n 2"
-    - TEST_MYPYC=1
   - name: "type check our own code"
     python: 3.7
     env:


### PR DESCRIPTION
Previously we ran them both compiled and interpreted, which
seems redundant.