### PR TITLE
Run 3.5.1 tests compiled with mypyc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   include:
   # Specifically request 3.5.1 because we need to be compatible with that.
-  - name: "run test suite with python 3.5.1 (compiled)"
+  - name: "run test suite with python 3.5.1 (compiled with mypyc)"
     python: 3.5.1
     dist: trusty
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,13 @@ env:
 jobs:
   include:
   # Specifically request 3.5.1 because we need to be compatible with that.
-  - name: "run test suite with python 3.5.1"
+  - name: "run test suite with python 3.5.1 (compiled)"
     python: 3.5.1
     dist: trusty
+    env:
+    - TOXENV=py
+    - EXTRA_ARGS="-n 2"
+    - TEST_MYPYC=1
   - name: "run test suite with python 3.6"
     python: 3.6    # 3.6.3  pip  9.0.1
   - name: "run test suite with python 3.7 (compiled with mypyc)"


### PR DESCRIPTION
Python 3.5.1 tests were the slowest job, and this makes them faster
(roughly from 20min to 15min).
