### PR TITLE
dataclasses: Fix deeply nested InitVar definitions with init=False

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -311,9 +311,13 @@ class DataclassTransformer:
                         superclass_init = info.get_method('__init__')
                         if isinstance(superclass_init, FuncDef):
                             attr_node = _get_arg_from_init(superclass_init, attr.name)
-                            if attr_node is not None:
+                            if attr_node is None:
+                                # Continue the loop: we will look it up in the next MRO entry.
+                                # Don't add it to the known or super attrs because we don't know
+                                # anything about it yet
+                                continue
+                            else:
                                 cls.info.names[attr.name] = attr_node
-
                     known_attrs.add(name)
                     super_attrs.append(attr)
                 elif all_attrs:

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -104,6 +104,34 @@ reveal_type(C)  # N: Revealed type is 'def (b: builtins.bool, a: builtins.bool) 
 
 [builtins fixtures/bool.pyi]
 
+[case testDataclassesDeepInitVarInheritance]
+from dataclasses import dataclass, field, InitVar
+@dataclass
+class A:
+    a: bool
+
+@dataclass
+class B:
+    b: InitVar[bool]
+    _b: bool = field(init=False)
+
+    def __post_init__(self, b: bool):
+        self._b = b
+
+@dataclass(init=False)
+class C(B):
+    def __init__(self):
+        super().__init__(True)
+
+@dataclass
+class D(C):
+    pass
+
+reveal_type(C)  # N: Revealed type is 'def () -> __main__.C'
+reveal_type(D)  # N: Revealed type is 'def (b: builtins.bool) -> __main__.D'
+
+[builtins fixtures/bool.pyi]
+
 [case testDataclassesOverriding]
 # flags: --python-version 3.6
 from dataclasses import dataclass


### PR DESCRIPTION
Fixes #8207 

In #8159, I fixed InitVar handling so that it looked up the superclass `__init__` and used that to determine the definition of InitVars.
That fix doesn't work in the presence of `init=False` subclasses of the initial `init=False` class. In that case, the lookup fails because the first attribute reached in MRO order on the subclass is the intermediate class, which also doesn't have the variable in its `__init__`. Then mypy didn't know about the InitVar but still tried to process it as if it did, resulting in an assertion error.

This PR fixes that issue by not adding the field to the set of known attrs until an actual definition is found.