### PR TITLE
Fix lint

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -142,7 +142,7 @@ def read_py_file(path: str, read: Callable[[str], bytes],
     """
     try:
         source = read(path)
-    except (IOError, OSError):
+    except OSError:
         return None
     else:
         try:


### PR DESCRIPTION
IOError is an alias to OSError in Python 3.3+, and it looks like 
flake8 recently learned about this.