### PR TITLE
Fix incorrect "unused 'type: ignore' comment" error log coloring

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -607,8 +607,11 @@ class FancyFormatter:
                 return (loc + self.style('error:', 'red', bold=True) +
                         self.highlight_quote_groups(msg))
             codepos = msg.rfind('[')
-            code = msg[codepos:]
-            msg = msg[:codepos]
+            if codepos != -1:
+                code = msg[codepos:]
+                msg = msg[:codepos]
+            else:
+                code = ""  # no error code specified
             return (loc + self.style('error:', 'red', bold=True) +
                     self.highlight_quote_groups(msg) + self.style(code, 'yellow'))
         elif ': note:' in error:


### PR DESCRIPTION
fixes #8242

Original error code indexing is assuming all `msg's included a '[',  which clearly fails on  "unused 'type: ignore' comment", this PR provides correct string finding and substring indexing thus a correct colorization.

However, it also seems meaningful to add an error code for this error. Suggestions are welcomed.