### PR TITLE
Speed up tests by simplifying default builtins

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -39,7 +39,7 @@ from mypy.types import (
 from mypy.sametypes import is_same_type
 from mypy.messages import (
     MessageBuilder, make_inferred_type_note, append_invariance_notes,
-    format_type, format_type_bare, format_type_distinctly,
+    format_type, format_type_bare, format_type_distinctly, SUGGESTED_TEST_FIXTURES
 )
 import mypy.checkexpr
 from mypy.checkmember import (
@@ -4435,9 +4435,15 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if last in n.names:
                 return n.names[last]
             elif len(parts) == 2 and parts[0] == 'builtins':
-                raise KeyError("Could not find builtin symbol '{}'. (Are you running a "
-                               "test case? If so, make sure to include a fixture that "
-                               "defines this symbol.)".format(last))
+                fullname = 'builtins.' + last
+                if fullname in SUGGESTED_TEST_FIXTURES:
+                    suggestion = ", e.g. add '[builtins fixtures/{}]' to your test".format(
+                        SUGGESTED_TEST_FIXTURES[fullname])
+                else:
+                    suggestion = ''
+                raise KeyError("Could not find builtin symbol '{}' (If you are running a "
+                               "test case, use a fixture that "
+                               "defines this symbol{})".format(last, suggestion))
             else:
                 msg = "Failed qualified lookup: '{}' (fullname = '{}')."
                 raise KeyError(msg.format(last, name))

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -53,6 +53,23 @@ ARG_CONSTRUCTOR_NAMES = {
 }  # type: Final
 
 
+# Map from the full name of a missing definition to the test fixture (under
+# test-data/unit/fixtures/) that provides the definition. This is used for
+# generating better error messages when running mypy tests only.
+SUGGESTED_TEST_FIXTURES = {
+    'builtins.list': 'list.pyi',
+    'builtins.dict': 'dict.pyi',
+    'builtins.set': 'set.pyi',
+    'builtins.tuple': 'tuple.pyi',
+    'builtins.bool': 'bool.pyi',
+    'builtins.Exception': 'exception.pyi',
+    'builtins.BaseException': 'exception.pyi',
+    'builtins.isinstance': 'isinstancelist.pyi',
+    'builtins.property': 'property.pyi',
+    'builtins.classmethod': 'classmethod.pyi',
+}  # type: Final
+
+
 class MessageBuilder:
     """Helper class for reporting type checker error messages with parameters.
 
@@ -1479,6 +1496,13 @@ class MessageBuilder:
         self.fail(error_msg, context, code=code)
         for note in notes:
             self.note(note, context, code=code)
+
+    def add_fixture_note(self, fullname: str, ctx: Context) -> None:
+        self.note('Maybe your test fixture does not define "{}"?'.format(fullname), ctx)
+        if fullname in SUGGESTED_TEST_FIXTURES:
+            self.note(
+                'Consider adding [builtins fixtures/{}] to your test description'.format(
+                    SUGGESTED_TEST_FIXTURES[fullname]), ctx)
 
 
 def quote_type_string(type_string: str) -> str:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -81,7 +81,7 @@ from mypy.tvar_scope import TypeVarScope
 from mypy.typevars import fill_typevars
 from mypy.visitor import NodeVisitor
 from mypy.errors import Errors, report_internal_error
-from mypy.messages import best_matches, MessageBuilder, pretty_or
+from mypy.messages import best_matches, MessageBuilder, pretty_or, SUGGESTED_TEST_FIXTURES
 from mypy.errorcodes import ErrorCode
 from mypy import message_registry, errorcodes as codes
 from mypy.types import (
@@ -119,21 +119,6 @@ from mypy.reachability import (
 from mypy.mro import calculate_mro, MroError
 
 T = TypeVar('T')
-
-# Map from the full name of a missing definition to the test fixture (under
-# test-data/unit/fixtures/) that provides the definition. This is used for
-# generating better error messages when running mypy tests only.
-SUGGESTED_TEST_FIXTURES = {
-    'builtins.list': 'list.pyi',
-    'builtins.dict': 'dict.pyi',
-    'builtins.set': 'set.pyi',
-    'builtins.bool': 'bool.pyi',
-    'builtins.Exception': 'exception.pyi',
-    'builtins.BaseException': 'exception.pyi',
-    'builtins.isinstance': 'isinstancelist.pyi',
-    'builtins.property': 'property.pyi',
-    'builtins.classmethod': 'classmethod.pyi',
-}  # type: Final
 
 TYPES_FOR_UNIMPORTED_HINTS = {
     'typing.Any',
@@ -1828,7 +1813,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             if (self.lookup_fully_qualified_or_none(fullname) is None and
                     fullname in SUGGESTED_TEST_FIXTURES):
                 # Yes. Generate a helpful note.
-                self.add_fixture_note(fullname, context)
+                self.msg.add_fixture_note(fullname, context)
 
     def process_import_over_existing_name(self,
                                           imported_id: str, existing_symbol: SymbolTableNode,
@@ -1857,13 +1842,6 @@ class SemanticAnalyzer(NodeVisitor[None],
             import_node.assignments.append(assignment)
             return True
         return False
-
-    def add_fixture_note(self, fullname: str, ctx: Context) -> None:
-        self.note('Maybe your test fixture does not define "{}"?'.format(fullname), ctx)
-        if fullname in SUGGESTED_TEST_FIXTURES:
-            self.note(
-                'Consider adding [builtins fixtures/{}] to your test description'.format(
-                    SUGGESTED_TEST_FIXTURES[fullname]), ctx)
 
     def correct_relative_import(self, node: Union[ImportFrom, ImportAll]) -> str:
         import_id, ok = correct_relative_import(self.cur_mod_id, node.relative, node.id,
@@ -4599,7 +4577,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             fullname = 'builtins.{}'.format(name)
             if self.lookup_fully_qualified_or_none(fullname) is None:
                 # Yes. Generate a helpful note.
-                self.add_fixture_note(fullname, ctx)
+                self.msg.add_fixture_note(fullname, ctx)
 
         modules_with_unimported_hints = {
             name.split('.', 1)[0]

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -38,6 +38,7 @@ class J(metaclass=ABCMeta):
 class A(I, J): pass
 class B(A): pass
 class C(I): pass
+[builtins fixtures/tuple.pyi]
 
 [case testAbstractClassSubtypingViaExtension]
 
@@ -67,6 +68,7 @@ class I(metaclass=ABCMeta):
   def f(self): pass
 class J(I): pass
 class A(J): pass
+[builtins fixtures/tuple.pyi]
 
 [case testInheritingAbstractClassInSubclass]
 from abc import abstractmethod, ABCMeta
@@ -134,6 +136,7 @@ if int():
     i = cast(I, o)
 if int():
     i = cast(I, a)
+[builtins fixtures/tuple.pyi]
 
 [case testInstantiatingClassThatImplementsAbstractMethod]
 from abc import abstractmethod, ABCMeta
@@ -396,6 +399,7 @@ i.g()      # E: "I" has no attribute "g"
 
 if int():
     b = i.f(a)
+[builtins fixtures/tuple.pyi]
 
 [case testAccessingInheritedAbstractMethod]
 from abc import abstractmethod, ABCMeta
@@ -415,6 +419,7 @@ if int():
 
 -- Any (dynamic) types
 -- -------------------
+[builtins fixtures/tuple.pyi]
 
 
 [case testAbstractClassWithAllDynamicTypes]

--- a/test-data/unit/check-annotated.test
+++ b/test-data/unit/check-annotated.test
@@ -2,63 +2,75 @@
 from typing_extensions import Annotated
 x: Annotated[int, ...]
 reveal_type(x)  # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotated1]
 from typing import Union
 from typing_extensions import Annotated
 x: Annotated[Union[int, str], ...]
 reveal_type(x)  # N: Revealed type is 'Union[builtins.int, builtins.str]'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotated2]
 from typing_extensions import Annotated
 x: Annotated[int, THESE, ARE, IGNORED, FOR, NOW]
 reveal_type(x)  # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotated3]
 from typing_extensions import Annotated
 x: Annotated[int, -+~12.3, "som"[e], more(anno+a+ions, that=[are]), (b"ignored",), 4, N.O.W, ...]
 reveal_type(x)  # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotatedBadType]
 from typing_extensions import Annotated
 x: Annotated[XXX, ...]  # E: Name 'XXX' is not defined
 reveal_type(x)  # N: Revealed type is 'Any'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotatedBadNoArgs]
 from typing_extensions import Annotated
 x: Annotated  # E: Annotated[...] must have exactly one type argument and at least one annotation
 reveal_type(x)  # N: Revealed type is 'Any'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotatedBadOneArg]
 from typing_extensions import Annotated
 x: Annotated[int]  # E: Annotated[...] must have exactly one type argument and at least one annotation
 reveal_type(x)  # N: Revealed type is 'Any'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotatedNested0]
 from typing_extensions import Annotated
 x: Annotated[Annotated[int, ...], ...]
 reveal_type(x)  # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotatedNested1]
 from typing import Union
 from typing_extensions import Annotated
 x: Annotated[Annotated[Union[int, str], ...], ...]
 reveal_type(x)  # N: Revealed type is 'Union[builtins.int, builtins.str]'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotatedNestedBadType]
 from typing_extensions import Annotated
 x: Annotated[Annotated[XXX, ...], ...]  # E: Name 'XXX' is not defined
 reveal_type(x)  # N: Revealed type is 'Any'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotatedNestedBadNoArgs]
 from typing_extensions import Annotated
 x: Annotated[Annotated, ...]  # E: Annotated[...] must have exactly one type argument and at least one annotation
 reveal_type(x)  # N: Revealed type is 'Any'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotatedNestedBadOneArg]
 from typing_extensions import Annotated
 x: Annotated[Annotated[int], ...]  # E: Annotated[...] must have exactly one type argument and at least one annotation
 reveal_type(x)  # N: Revealed type is 'Any'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotatedNoImport]
 x: Annotated[int, ...]  # E: Name 'Annotated' is not defined
@@ -68,6 +80,7 @@ reveal_type(x)  # N: Revealed type is 'Any'
 from typing_extensions import Annotated as An
 x: An[int, ...]
 reveal_type(x)  # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotatedAliasSimple]
 from typing import Tuple
@@ -75,6 +88,7 @@ from typing_extensions import Annotated
 Alias = Annotated[Tuple[int, ...], ...]
 x: Alias
 reveal_type(x)  # N: Revealed type is 'builtins.tuple[builtins.int]'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotatedAliasTypeVar]
 from typing import TypeVar
@@ -83,6 +97,7 @@ T = TypeVar('T')
 Alias = Annotated[T, ...]
 x: Alias[int]
 reveal_type(x)  # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotatedAliasGenericTuple]
 from typing import TypeVar, Tuple
@@ -91,6 +106,7 @@ T = TypeVar('T')
 Alias = Annotated[Tuple[T, T], ...]
 x: Alias[int]
 reveal_type(x)  # N: Revealed type is 'Tuple[builtins.int, builtins.int]'
+[builtins fixtures/tuple.pyi]
 
 [case testAnnotatedAliasGenericUnion]
 from typing import TypeVar, Union
@@ -99,3 +115,4 @@ T = TypeVar('T')
 Alias = Annotated[Union[T, str], ...]
 x: Alias[int]
 reveal_type(x)  # N: Revealed type is 'Union[builtins.int, builtins.str]'
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -495,7 +495,7 @@ class X(NamedTuple):
 from typing import NamedTuple
 
 class X(NamedTuple):
-    x: int = 1 + '1'  # E: Unsupported operand types for + ("int" and "str")
+    x: int = 1 + '1'  # E: Unsupported left operand type for + ("int")
 [builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleInheritance]
@@ -534,14 +534,14 @@ class XRepr(NamedTuple):
     y: int = 1
     def __str__(self) -> str:
         return 'string'
-    def __add__(self, other: XRepr) -> int:
+    def __sub__(self, other: XRepr) -> int:
         return 0
 
 reveal_type(XMeth(1).double()) # N: Revealed type is 'builtins.int'
 reveal_type(XMeth(1).asyncdouble())  # N: Revealed type is 'typing.Coroutine[Any, Any, builtins.int]'
 reveal_type(XMeth(42).x)  # N: Revealed type is 'builtins.int'
 reveal_type(XRepr(42).__str__())  # N: Revealed type is 'builtins.str'
-reveal_type(XRepr(1, 2).__add__(XRepr(3)))  # N: Revealed type is 'builtins.int'
+reveal_type(XRepr(1, 2).__sub__(XRepr(3)))  # N: Revealed type is 'builtins.int'
 [typing fixtures/typing-async.pyi]
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -4,6 +4,7 @@ from typing import NamedTuple
 
 class E(NamedTuple):  # E: NamedTuple class syntax is only supported in Python 3.6
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleNoUnderscoreFields]
 # flags: --python-version 3.6
@@ -13,6 +14,7 @@ class X(NamedTuple):
     x: int
     _y: int  # E: NamedTuple field name cannot start with an underscore: _y
     _z: int  # E: NamedTuple field name cannot start with an underscore: _z
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleAccessingAttributes]
 # flags: --python-version 3.6
@@ -26,6 +28,7 @@ x: X
 x.x
 x.y
 x.z # E: "X" has no attribute "z"
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleAttributesAreReadOnly]
 # flags: --python-version 3.6
@@ -41,6 +44,7 @@ x.y = 5 # E: "X" has no attribute "y"
 class A(X): pass
 a: A
 a.x = 5 # E: Property "x" defined in "X" is read-only
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleCreateWithPositionalArguments]
 # flags: --python-version 3.6
@@ -55,6 +59,7 @@ x.x
 x.z      # E: "X" has no attribute "z"
 x = X(1) # E: Too few arguments for "X"
 x = X(1, '2', 3)  # E: Too many arguments for "X"
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleShouldBeSingleBase]
 # flags: --python-version 3.6
@@ -63,6 +68,7 @@ from typing import NamedTuple
 class A: ...
 class X(NamedTuple, A):  # E: NamedTuple should be a single base
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testCreateNewNamedTupleWithKeywordArguments]
 # flags: --python-version 3.6
@@ -76,6 +82,7 @@ x = X(x=1, y='x')
 x = X(1, y='x')
 x = X(x=1, z=1) # E: Unexpected keyword argument "z" for "X"
 x = X(y='x') # E: Missing positional argument "x" in call to "X"
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleCreateAndUseAsTuple]
 # flags: --python-version 3.6
@@ -88,6 +95,7 @@ class X(NamedTuple):
 x = X(1, 'x')
 a, b = x
 a, b, c = x  # E: Need more than 2 values to unpack (3 expected)
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleWithItemTypes]
 # flags: --python-version 3.6
@@ -105,6 +113,7 @@ i: int = n.b  # E: Incompatible types in assignment (expression has type "str", 
 x, y = n
 if int():
     x = y  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleConstructorArgumentTypes]
 # flags: --python-version 3.6
@@ -118,6 +127,7 @@ n = N('x', 'x') # E: Argument 1 to "N" has incompatible type "str"; expected "in
 n = N(1, b=2)   # E: Argument "b" to "N" has incompatible type "int"; expected "str"
 N(1, 'x')
 N(b='x', a=1)
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleAsBaseClass]
 # flags: --python-version 3.6
@@ -138,6 +148,7 @@ if int():
     i, s = x
 if int():
     s, s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleSelfTypeWithNamedTupleAsBase]
 # flags: --python-version 3.6
@@ -157,6 +168,7 @@ class B(A):
             i, s = self
             i, i = self  # E: Incompatible types in assignment (expression has type "str", \
                               variable has type "int")
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testNewNamedTupleTypeReferenceToClassDerivedFrom]
@@ -179,6 +191,7 @@ class B(A):
                                   variable has type "str")
             i, i = self  # E: Incompatible types in assignment (expression has type "str", \
                               variable has type "int")
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleSubtyping]
 # flags: --python-version 3.6
@@ -206,6 +219,7 @@ if int():
     t = b
 if int():
     a = b
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleSimpleTypeInference]
 # flags: --python-version 3.6
@@ -233,6 +247,7 @@ class MyNamedTuple(NamedTuple):
     b: str
 
 MyNamedTuple.x # E: "Type[MyNamedTuple]" has no attribute "x"
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleEmptyItems]
 # flags: --python-version 3.6
@@ -240,6 +255,7 @@ from typing import NamedTuple
 
 class A(NamedTuple):
     ...
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleForwardRef]
 # flags: --python-version 3.6
@@ -252,6 +268,7 @@ class B: ...
 
 a = A(B())
 a = A(1)  # E: Argument 1 to "A" has incompatible type "int"; expected "B"
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleProperty]
 # flags: --python-version 3.6
@@ -295,6 +312,7 @@ x: X
 reveal_type(x._replace())  # N: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
 x._replace(x=5)
 x._replace(y=5)  # E: Argument "y" to "_replace" of "X" has incompatible type "int"; expected "str"
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleFields]
 # flags: --python-version 3.6
@@ -321,6 +339,7 @@ class X(NamedTuple):
 x: X = X()
 x._replace()
 x._fields[0]  # E: Tuple index out of range
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleJoinNamedTuple]
 # flags: --python-version 3.6
@@ -358,6 +377,7 @@ class X(NamedTuple):
     x: int
     y = z = 2  # E: Invalid statement in NamedTuple definition; expected "field_name: field_type [= default]"
     def f(self): pass
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleWithInvalidItems2]
 # flags: --python-version 3.6
@@ -386,6 +406,7 @@ from typing import NamedTuple
 class X(NamedTuple):
     x: int
     y = 2  # E: Invalid statement in NamedTuple definition; expected "field_name: field_type [= default]"
+[builtins fixtures/tuple.pyi]
 
 [case testTypeUsingTypeCNamedTuple]
 # flags: --python-version 3.6
@@ -467,6 +488,7 @@ from typing import NamedTuple
 class X(NamedTuple):
     x: int
     y: int = 'not an int'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleErrorInDefault]
 # flags: --python-version 3.6
@@ -474,6 +496,7 @@ from typing import NamedTuple
 
 class X(NamedTuple):
     x: int = 1 + '1'  # E: Unsupported operand types for + ("int" and "str")
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleInheritance]
 # flags: --python-version 3.6
@@ -494,6 +517,7 @@ Y(y=1, x='1').method()
 class CallsBaseInit(X):
     def __init__(self, x: str) -> None:
         super().__init__(x) # E: Too many arguments for "__init__" of "object"
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleWithMethods]
 from typing import NamedTuple
@@ -519,6 +543,7 @@ reveal_type(XMeth(42).x)  # N: Revealed type is 'builtins.int'
 reveal_type(XRepr(42).__str__())  # N: Revealed type is 'builtins.str'
 reveal_type(XRepr(1, 2).__add__(XRepr(3)))  # N: Revealed type is 'builtins.int'
 [typing fixtures/typing-async.pyi]
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleOverloading]
 from typing import NamedTuple, overload
@@ -538,6 +563,7 @@ Overloader(1).method(('tuple',))  # E: No overload variant of "method" of "Overl
                                   # N: Possible overload variants: \
                                   # N:     def method(self, y: str) -> str \
                                   # N:     def method(self, y: int) -> int
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleMethodInheritance]
 from typing import NamedTuple, TypeVar
@@ -642,6 +668,7 @@ class BadDoc(NamedTuple):
         return ''
 
 reveal_type(BadDoc(1).__doc__())  # N: Revealed type is 'builtins.str'
+[builtins fixtures/tuple.pyi]
 
 [case testNewNamedTupleClassMethod]
 from typing import NamedTuple

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1869,6 +1869,7 @@ class B:
     def __radd__(self, x: Callable[[], int]) -> int: pass
 class C:
     def __radd__(self, x: Any) -> int: pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testReverseOperatorMethodInvalid]
@@ -2106,6 +2107,7 @@ class A:
 class B:
     def __radd__(*self) -> int: pass
     def __rsub__(*self: 'B') -> int: pass
+[builtins fixtures/tuple.pyi]
 
 [case testReverseOperatorTypeVar1]
 from typing import TypeVar, Any
@@ -2466,6 +2468,7 @@ class B: pass
 
 a = a.foo
 b = a.bar
+[builtins fixtures/tuple.pyi]
 [out]
 main:9: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
@@ -2492,6 +2495,7 @@ class B: pass
 
 a = a.foo
 b = a.bar
+[builtins fixtures/tuple.pyi]
 [out]
 main:9: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
@@ -3036,6 +3040,7 @@ def foo(arg: Type[Any]):
     x.foo
 class X: pass
 foo(X)
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testTypeUsingTypeCTypeAnyMember]
@@ -3192,6 +3197,7 @@ def f(a: T): pass
 from typing import Type, Tuple
 def f(a: Type[Tuple[int, int]]):
     a()
+[builtins fixtures/tuple.pyi]
 [out]
 main:2: error: Unsupported type Type["Tuple[int, int]"]
 
@@ -4026,6 +4032,7 @@ class A:
     __slots__ = ("a")
 class B(A):
     __slots__ = ("a", "b")
+[builtins fixtures/tuple.pyi]
 
 [case testClassOrderOfError]
 class A:
@@ -4384,6 +4391,7 @@ from typing import NamedTuple
 N = NamedTuple('N', [('x', N)]) # E: Cannot resolve name "N" (possible cyclic definition)
 n: N
 reveal_type(n) # N: Revealed type is 'Tuple[Any, fallback=__main__.N]'
+[builtins fixtures/tuple.pyi]
 
 [case testCrashOnSelfRecursiveTypedDictVar]
 from mypy_extensions import TypedDict
@@ -4506,6 +4514,7 @@ class N(NamedTuple):
 
 x: NT = N(1) # E: Incompatible types in assignment (expression has type "N", variable has type "NT")
 x = NT(N(1))
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testNewTypeFromForwardTypedDict]
@@ -4528,6 +4537,7 @@ def get_state(proc: 'Process') -> int:
     return proc.state
 class Process(NamedTuple):
      state: int
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testCorrectItemTypeInForwardRefToTypedDict]
@@ -4554,6 +4564,7 @@ class B(NamedTuple):
 y: A
 y = x
 reveal_type(x.one.attr)  # N: Revealed type is 'builtins.str'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testCrashOnDoubleForwardTypedDict]
@@ -4583,6 +4594,7 @@ def foo(node: Node) -> int:
     x = node
     reveal_type(node) # N: Revealed type is 'Union[Tuple[builtins.int, fallback=__main__.Foo], Tuple[builtins.int, fallback=__main__.Bar]]'
     return x.x
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testCrashOnForwardUnionOfTypedDicts]
@@ -4755,6 +4767,7 @@ class A(six.with_metaclass(M)): pass
 class B: pass
 reveal_type(type(A).x)  # N: Revealed type is 'builtins.int'
 reveal_type(type(B).x)  # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 [case testSixMetaclass_python2]
 import six
@@ -4775,6 +4788,7 @@ class A(with_metaclass(M)): pass
 class B: pass
 reveal_type(type(A).x)  # N: Revealed type is 'builtins.int'
 reveal_type(type(B).x)  # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 [case testSixMetaclassImportFrom]
 import six
@@ -4787,6 +4801,7 @@ reveal_type(type(B).x)  # N: Revealed type is 'builtins.int'
 [file metadefs.py]
 class M(type):
     x = 5
+[builtins fixtures/tuple.pyi]
 
 [case testSixMetaclassImport]
 import six
@@ -4799,6 +4814,7 @@ reveal_type(type(B).x)  # N: Revealed type is 'builtins.int'
 [file metadefs.py]
 class M(type):
     x = 5
+[builtins fixtures/tuple.pyi]
 
 [case testSixMetaclassAndBase]
 from typing import Iterable, Iterator
@@ -4832,6 +4848,7 @@ C2().bar()
 D2().bar()
 C2().baz()  # E: "C2" has no attribute "baz"
 D2().baz()  # E: "D2" has no attribute "baz"
+[builtins fixtures/tuple.pyi]
 
 [case testSixMetaclassGenerics]
 from typing import Generic, GenericMeta, TypeVar
@@ -4883,6 +4900,7 @@ class Q1(metaclass=M1): pass
 @six.add_metaclass(M)
 class CQA(Q1): pass  # E: Inconsistent metaclass structure for 'CQA'
 class CQW(six.with_metaclass(M, Q1)): pass  # E: Inconsistent metaclass structure for 'CQW'
+[builtins fixtures/tuple.pyi]
 
 [case testSixMetaclassErrors_python2]
 # flags: --python-version 2.7
@@ -4901,6 +4919,7 @@ class G: pass
 
 -- Special support for future.utils
 -- --------------------------------
+[builtins fixtures/tuple.pyi]
 
 [case testFutureMetaclass]
 import future.utils
@@ -4908,6 +4927,7 @@ class M(type):
     x = 5
 class A(future.utils.with_metaclass(M)): pass
 reveal_type(type(A).x)  # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 [case testFutureMetaclass_python2]
 import future.utils
@@ -4922,6 +4942,7 @@ class M(type):
     x = 5
 class A(with_metaclass(M)): pass
 reveal_type(type(A).x)  # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 [case testFutureMetaclassImportFrom]
 import future.utils
@@ -4931,6 +4952,7 @@ reveal_type(type(A).x)  # N: Revealed type is 'builtins.int'
 [file metadefs.py]
 class M(type):
     x = 5
+[builtins fixtures/tuple.pyi]
 
 [case testFutureMetaclassImport]
 import future.utils
@@ -4940,6 +4962,7 @@ reveal_type(type(A).x)  # N: Revealed type is 'builtins.int'
 [file metadefs.py]
 class M(type):
     x = 5
+[builtins fixtures/tuple.pyi]
 
 [case testFutureMetaclassAndBase]
 from typing import Iterable, Iterator
@@ -4962,6 +4985,7 @@ for x in C2: reveal_type(x)  # N: Revealed type is 'builtins.int*'
 C2().foo()
 C2().bar()
 C2().baz()  # E: "C2" has no attribute "baz"
+[builtins fixtures/tuple.pyi]
 
 [case testFutureMetaclassGenerics]
 from typing import Generic, GenericMeta, TypeVar
@@ -4995,6 +5019,7 @@ class C5(future.utils.with_metaclass(f())): pass  # E: Dynamic metaclass not sup
 class M1(type): pass
 class Q1(metaclass=M1): pass
 class CQW(future.utils.with_metaclass(M, Q1)): pass  # E: Inconsistent metaclass structure for 'CQW'
+[builtins fixtures/tuple.pyi]
 
 [case testFutureMetaclassErrors_python2]
 # flags: --python-version 2.7
@@ -5011,6 +5036,7 @@ class F(future.utils.with_metaclass(t.M)): pass
 
 -- Misc
 -- ----
+[builtins fixtures/tuple.pyi]
 
 [case testCorrectEnclosingClassPushedInDeferred]
 class C:
@@ -5132,6 +5158,7 @@ class C:
     __slots__ = ('x',)
 class D(B, C):
     __slots__ = ('aa', 'bb', 'cc')
+[builtins fixtures/tuple.pyi]
 
 [case testRevealLocalsOnClassVars]
 class C1(object):
@@ -5511,6 +5538,7 @@ class B(A):
         pass
 
 reveal_type(B)  # N: Revealed type is 'def (x: builtins.int) -> __main__.B'
+[builtins fixtures/tuple.pyi]
 
 [case testNewAndInit3]
 from typing import Any
@@ -5522,6 +5550,7 @@ class A:
         pass
 
 reveal_type(A)  # N: Revealed type is 'def (x: builtins.int) -> __main__.A'
+[builtins fixtures/tuple.pyi]
 
 [case testCyclicDecorator]
 import b
@@ -5543,6 +5572,7 @@ class B:
 from typing import TypeVar, Tuple, Callable
 T = TypeVar('T')
 def deco(f: Callable[..., T]) -> Callable[..., Tuple[T, int]]: ...
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testCyclicOverload]
@@ -5647,6 +5677,7 @@ class Base:
 from typing import TypeVar, Tuple, Callable
 T = TypeVar('T')
 def deco(f: Callable[..., T]) -> Callable[..., Tuple[T, int]]: ...
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testCyclicOverrideCheckedDecoratorDeferred]
@@ -5670,6 +5701,7 @@ def f() -> int: ...
 from typing import TypeVar, Tuple, Callable
 T = TypeVar('T')
 def deco(f: Callable[..., T]) -> Callable[..., Tuple[T, int]]: ...
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testCyclicOverrideAnyDecoratorDeferred]
@@ -5723,6 +5755,7 @@ class B:
 from typing import TypeVar, Tuple, Callable
 T = TypeVar('T')
 def deco(f: Callable[..., T]) -> Callable[..., Tuple[T, int]]: ...
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testCyclicDecoratorSuper]
@@ -5749,6 +5782,7 @@ class B:
 from typing import TypeVar, Tuple, Callable
 T = TypeVar('T')
 def deco(f: Callable[..., T]) -> Callable[..., Tuple[T, int]]: ...
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testCyclicDecoratorBothDeferred]
@@ -5780,6 +5814,7 @@ def f() -> int: ...
 from typing import TypeVar, Tuple, Callable
 T = TypeVar('T')
 def deco(f: Callable[..., T]) -> Callable[..., Tuple[T, int]]: ...
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testCyclicDecoratorSuperDeferred]
@@ -5813,6 +5848,7 @@ class B:
 from typing import TypeVar, Tuple, Callable
 T = TypeVar('T')
 def deco(f: Callable[..., T]) -> Callable[..., Tuple[T, int]]: ...
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testOptionalDescriptorsBinder]
@@ -6199,6 +6235,7 @@ N = NamedTuple('N', [('x', int)])
 class B(A, N): pass
 
 reveal_type(A())  # N: Revealed type is 'Tuple[builtins.int, fallback=__main__.B]'
+[builtins fixtures/tuple.pyi]
 
 [case testNewReturnType8]
 from typing import TypeVar, Any
@@ -6283,6 +6320,7 @@ class C(B[int, T]):
     def __init__(self) -> None:
         # TODO: error message could be better.
         self.x: Tuple[str, T]  # E: Incompatible types in assignment (expression has type "Tuple[str, T]", base class "A" defined the type as "Tuple[int, T]")
+[builtins fixtures/tuple.pyi]
 
 [case testInitSubclassWrongType]
 class Base:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4916,10 +4916,10 @@ class E(metaclass=t.M): pass
 class F(six.with_metaclass(t.M)): pass
 @six.add_metaclass(t.M)
 class G: pass
+[builtins fixtures/tuple.pyi]
 
 -- Special support for future.utils
 -- --------------------------------
-[builtins fixtures/tuple.pyi]
 
 [case testFutureMetaclass]
 import future.utils

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -437,6 +437,7 @@ for x in foo:
 [file mypy.ini]
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/method_sig_hook.py
+[builtins fixtures/tuple.pyi]
 
 [case testMethodSignatureHookNamesFullyQualified]
 # flags: --config-file tmp/mypy.ini

--- a/test-data/unit/check-default-plugin.test
+++ b/test-data/unit/check-default-plugin.test
@@ -22,6 +22,7 @@ f = yield_id
 def g(x, y): pass
 f = g # E: Incompatible types in assignment (expression has type "Callable[[Any, Any], Any]", variable has type "Callable[[T], GeneratorContextManager[T]]")
 [typing fixtures/typing-medium.pyi]
+[builtins fixtures/tuple.pyi]
 
 [case testContextManagerWithUnspecifiedArguments]
 from contextlib import contextmanager
@@ -31,3 +32,4 @@ c: Callable[..., Iterator[int]]
 reveal_type(c) # N: Revealed type is 'def (*Any, **Any) -> typing.Iterator[builtins.int]'
 reveal_type(contextmanager(c)) # N: Revealed type is 'def (*Any, **Any) -> contextlib.GeneratorContextManager[builtins.int*]'
 [typing fixtures/typing-medium.pyi]
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-dynamic-typing.test
+++ b/test-data/unit/check-dynamic-typing.test
@@ -42,6 +42,7 @@ class B: pass
 
 -- Expressions
 -- -----------
+[builtins fixtures/tuple.pyi]
 
 
 [case testCallingFunctionWithDynamicArgumentTypes]
@@ -65,6 +66,7 @@ def f(x: Any) -> 'A':
 
 class A: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 
 [case testCallingWithDynamicReturnType]
 from typing import Any
@@ -80,6 +82,7 @@ def f(x: 'A') -> Any:
 
 class A: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 
 [case testBinaryOperationsWithDynamicLeftOperand]
 from typing import Any
@@ -445,6 +448,7 @@ def f13(x, y = b, z = b): pass
 
 class A: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 
 [case testSkipTypeCheckingWithImplicitSignature]
 a = None # type: A
@@ -672,6 +676,7 @@ class A(B):
         pass
     def g(self, x: Any) -> None:
         pass
+[builtins fixtures/tuple.pyi]
 
 [case testOverridingMethodWithImplicitDynamicTypes]
 
@@ -690,6 +695,7 @@ class A(B):
         pass
     def g(self, x):
         pass
+[builtins fixtures/tuple.pyi]
 
 [case testOverridingMethodAcrossHierarchy]
 import typing

--- a/test-data/unit/check-dynamic-typing.test
+++ b/test-data/unit/check-dynamic-typing.test
@@ -38,11 +38,11 @@ s, t = d
 
 class A: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 
 
 -- Expressions
 -- -----------
-[builtins fixtures/tuple.pyi]
 
 
 [case testCallingFunctionWithDynamicArgumentTypes]

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -24,6 +24,7 @@ reveal_type(Medal.bronze)  # N: Revealed type is 'Literal[__main__.Medal.bronze]
 m = Medal.gold
 if int():
     m = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "Medal")
+[builtins fixtures/tuple.pyi]
 
 [case testEnumFromEnumMetaSubclass]
 from enum import EnumMeta
@@ -38,6 +39,7 @@ reveal_type(Medal.bronze)  # N: Revealed type is 'Literal[__main__.Medal.bronze]
 m = Medal.gold
 if int():
     m = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "Medal")
+[builtins fixtures/tuple.pyi]
 
 [case testEnumFromEnumMetaGeneric]
 from enum import EnumMeta
@@ -159,6 +161,7 @@ class E(N, Enum):
 def f(x: E) -> None: pass
 
 f(E.X)
+[builtins fixtures/tuple.pyi]
 
 [case testEnumCall]
 from enum import IntEnum
@@ -708,6 +711,7 @@ elif y2 is Bar.B:
     reveal_type(y2)  # N: Revealed type is 'Literal[__main__.Bar.B]'
 else:
     reveal_type(y2)  # No output here: this branch is unreachable
+[builtins fixtures/tuple.pyi]
 
 [case testEnumReachabilityChecksIndirect]
 from enum import Enum

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -251,6 +251,7 @@ x: f  # E: Function "__main__.f" is not valid as a type  [valid-type] \
 import sys
 y: sys  # E: Module "sys" is not valid as a type  [valid-type]
 z: y  # E: Variable "__main__.y" is not valid as a type  [valid-type]
+[builtins fixtures/tuple.pyi]
 
 [case testErrorCodeNeedTypeAnnotation]
 from typing import TypeVar
@@ -363,6 +364,7 @@ async def asyncf():  # E: Function is missing a return type annotation  [no-unty
 async def asyncf2(x: int):  # E: Function is missing a return type annotation  [no-untyped-def]
     return 0
 [typing fixtures/typing-async.pyi]
+[builtins fixtures/tuple.pyi]
 
 [case testErrorCodeCallUntypedFunction]
 # flags: --disallow-untyped-calls
@@ -432,6 +434,7 @@ B() + ''  # E: Unsupported operand types for + ("B" and "str")  [operator]
 '' in B()  # E: Unsupported operand types for in ("str" and "B")  [operator]
 
 1()  # E: "int" not callable  [operator]
+[builtins fixtures/tuple.pyi]
 
 [case testErrorCodeListOrDictItem]
 from typing import List, Dict
@@ -636,6 +639,7 @@ def g(p: P) -> None: pass
 
 p: A
 g(p)  # type: ignore[arg-type]
+[builtins fixtures/tuple.pyi]
 
 [case testErrorCodeNoneReturnNoteIgnore]
 # flags: --disallow-untyped-defs

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -140,6 +140,7 @@ class B:
     pass
 class C:
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testSub]
 a, b, c = None, None, None # type: (A, B, C)
@@ -159,6 +160,7 @@ class B:
     pass
 class C:
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testMul]
 a, b, c = None, None, None # type: (A, B, C)
@@ -178,6 +180,7 @@ class B:
     pass
 class C:
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testMatMul]
 a, b, c = None, None, None # type: (A, B, C)
@@ -197,6 +200,7 @@ class B:
     pass
 class C:
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testDiv]
 a, b, c = None, None, None # type: (A, B, C)
@@ -215,6 +219,7 @@ class B:
     pass
 class C:
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testIntDiv]
 a, b, c = None, None, None # type: (A, B, C)
@@ -233,6 +238,7 @@ class B:
     pass
 class C:
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testMod]
 a, b, c = None, None, None # type: (A, B, C)
@@ -252,6 +258,7 @@ class B:
     pass
 class C:
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testPow]
 a, b, c = None, None, None # type: (A, B, C)
@@ -271,6 +278,7 @@ class B:
     pass
 class C:
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testMiscBinaryOperators]
 
@@ -293,6 +301,7 @@ class A:
   def __lshift__(self, x: 'A') -> 'B': pass
   def __rshift__(self, x: 'B') -> 'B': pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:3: error: Unsupported operand types for & ("A" and "A")
 main:4: error: Unsupported operand types for | ("A" and "B")
@@ -813,6 +822,7 @@ class A:
         pass
 class B:
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testUnaryPlus]
 a, b = None, None # type: (A, B)
@@ -828,6 +838,7 @@ class A:
         pass
 class B:
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testUnaryNot]
 a, b = None, None # type: (A, bool)
@@ -859,6 +870,7 @@ class B:
 
 -- Indexing
 -- --------
+[builtins fixtures/tuple.pyi]
 
 
 [case testIndexing]
@@ -878,6 +890,7 @@ class A:
         pass
 class B: pass
 class C: pass
+[builtins fixtures/tuple.pyi]
 
 [case testIndexingAsLvalue]
 
@@ -894,6 +907,7 @@ class B:
     pass
 class C:
     pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:3: error: Invalid index type "C" for "A"; expected type "B"
 main:4: error: Incompatible types in assignment (expression has type "A", target has type "C")
@@ -931,6 +945,7 @@ class A:
         pass
 class B: pass
 class C: pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 
@@ -961,6 +976,7 @@ if int():
 if int():
     a = cast(Any, b)
     b = cast(Any, a)
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testAnyCast]
@@ -971,6 +987,7 @@ a = cast(Any, b)
 b = cast(Any, a)
 class A: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:3: error: "A" not callable
 
@@ -1002,6 +1019,7 @@ class A:
         pass
     def __call__(self) -> None:
         pass
+[builtins fixtures/tuple.pyi]
 
 [case testNoneReturnTypeWithStatements]
 import typing
@@ -1330,17 +1348,20 @@ main:4: error: Incompatible types in string interpolation (expression has type "
 def foo(a: bytes, b: bytes):
     b'%s:%s' % (a, b)
 foo(b'a', b'b') == b'a:b'
+[builtins fixtures/tuple.pyi]
 
 [case testStringInterpolationStarArgs]
 x = (1, 2)
 "%d%d" % (*x,)
 [typing fixtures/typing-medium.pyi]
+[builtins fixtures/tuple.pyi]
 
 [case testBytePercentInterpolationSupported]
 b'%s' % (b'xyz',)
 b'%(name)s' % {'name': b'jane'}  # E: Dictionary keys in bytes formatting must be bytes, not strings
 b'%(name)s' % {b'name': 'jane'}  # E: On Python 3 b'%s' requires bytes, not string
 b'%c' % (123)
+[builtins fixtures/tuple.pyi]
 
 [case testUnicodeInterpolation_python2]
 u'%s' % (u'abc',)
@@ -1368,6 +1389,7 @@ c: Union[Tuple[str, int], Tuple[str, int, str]] = ('A', 1)
 
 -- str.format() calls
 -- ------------------
+[builtins fixtures/tuple.pyi]
 
 [case testFormatCallParseErrors]
 '}'.format()  # E: Invalid conversion specifier in format string: unexpected }
@@ -2029,6 +2051,7 @@ class B:
     pass
 class C(B):
     pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1386,10 +1386,10 @@ b: Union[Tuple[int, str], Tuple[int, int], Tuple[str, int]] = ('A', 1)
 
 c: Union[Tuple[str, int], Tuple[str, int, str]] = ('A', 1)
 '%s %s' % c  # E: Not all arguments converted during string formatting
+[builtins fixtures/tuple.pyi]
 
 -- str.format() calls
 -- ------------------
-[builtins fixtures/tuple.pyi]
 
 [case testFormatCallParseErrors]
 '}'.format()  # E: Invalid conversion specifier in format string: unexpected }

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -113,6 +113,7 @@ with open('test', 'r') as f:  # type: int  # type: ignore
 [case testFastParseTypeWithIgnoreForStmt]
 for i in (1, 2, 3, 100):  # type: str # type: ignore
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testFastParseVariableCommentThenIgnore]
 a="test" # type: int #comment # type: ignore  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
@@ -343,6 +344,7 @@ assert (1, 2)  # E: Assertion is always true, perhaps remove parentheses?
 assert (1, 2), 3  # E: Assertion is always true, perhaps remove parentheses?
 assert ()
 assert (1,)  # E: Assertion is always true, perhaps remove parentheses?
+[builtins fixtures/tuple.pyi]
 
 [case testFastParseAssertMessage]
 

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -43,6 +43,7 @@ class C:
         self.y: Final[float] = 1
 reveal_type(C((1, 2)).x)  # N: Revealed type is 'Tuple[builtins.int, Any]'
 reveal_type(C((1, 2)).y)  # N: Revealed type is 'builtins.float'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testFinalBadDefinitionTooManyArgs]
@@ -182,6 +183,7 @@ reveal_type(C().g)  # N: Revealed type is 'builtins.int'
 from typing import Final, Callable, Tuple, Any
 x: Tuple[Final]  # E: Final can be only used as an outermost qualifier in a variable annotation
 y: Callable[[], Tuple[Final[int]]]  # E: Final can be only used as an outermost qualifier in a variable annotation
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testFinalDefiningNotInMethod]
@@ -196,6 +198,7 @@ from typing_extensions import Final
 
 def f(x: Final[int]) -> int: ...  # E: Final can be only used as an outermost qualifier in a variable annotation
 def g(x: int) -> Final[int]: ...  # E: Final can be only used as an outermost qualifier in a variable annotation
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testFinalDefiningNoRhs]
@@ -234,6 +237,7 @@ d: Any
 
 class C(Generic[T]):
     x: Final[Tuple[T, T]] = d  # E: Final name declared in class body cannot depend on type variables
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testFinalDefiningTypevarsImplicit]
@@ -250,6 +254,7 @@ reveal_type(C((1, 2)).x)  # N: Revealed type is 'Tuple[builtins.int*, builtins.i
 C.x  # E: Cannot access final instance attribute "x" on class object \
      # E: Access to generic instance variables via class is ambiguous
 C.y  # E: Cannot access final instance attribute "y" on class object
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testFinalDefiningNotInOtherMethod]
@@ -259,6 +264,7 @@ class C:
     def meth(self, x: Tuple[int, Any]) -> None:
         self.x: Final = x  # E: Can only declare a final attribute in class body or __init__
         self.y: Final[float] = 1  # E: Can only declare a final attribute in class body or __init__
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testFinalDefiningOnlyOnSelf]
@@ -273,6 +279,7 @@ class C:
         slf.x: Final = x  # E: Final can be only applied to a name or an attribute on self
         slf.y: Final[float] = 1  # E: Type cannot be declared in assignment to non-self attribute \
                                  # E: Final can be only applied to a name or an attribute on self
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testFinalNotInProtocol]
@@ -1026,6 +1033,7 @@ class C(B):
 @final
 class F: ...
 class E(F): ...  # E: Cannot inherit from final class "F"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testFinalCanUseTypingExtensionsAliased]
@@ -1047,6 +1055,7 @@ class C(B):
 @f
 class D(C): ...
 class E(D): ...  # E: Cannot inherit from final class "D"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testFinalMultiassignAllowed]
@@ -1072,3 +1081,4 @@ class A:
     def __init__(self) -> None:
         self.x = 10  # type: Final
         undefined  # type: ignore
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -726,6 +726,7 @@ from missing import Unchecked
 foo: Unchecked = ""
 foo = ""
 x, y = 1, 2  # type: Unchecked, Unchecked
+[builtins fixtures/tuple.pyi]
 [out]
 main:4: error: Type of variable becomes "Any" due to an unfollowed import
 main:6: error: A type on this line becomes "Any" due to an unfollowed import
@@ -1083,6 +1084,7 @@ from typing import NamedTuple
 
 N = NamedTuple('N', [('x', N)])  # type: ignore
 n: N
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testCheckDisallowAnyGenericsTypedDict]
@@ -1180,6 +1182,7 @@ b = 6
 [file other_module_2.py]
 from other_module_1 import a, b
 __all__ = ('b',)
+[builtins fixtures/tuple.pyi]
 [out]
 main:2: error: Module 'other_module_2' has no attribute 'a'
 
@@ -1203,6 +1206,7 @@ b = 6
 [file other_module_2.py]
 from other_module_1 import *
 __all__ = ('b',)
+[builtins fixtures/tuple.pyi]
 [out]
 main:2: error: Module 'other_module_2' has no attribute 'a'
 
@@ -1298,6 +1302,7 @@ def foo(x: TupleAny[str]) -> None:  # no error
 
 def goo(x: TupleAny[Any]) -> None:  # E: Explicit "Any" is not allowed
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testDisallowAnyExplicitCast]
 # flags: --disallow-any-explicit
@@ -1360,6 +1365,7 @@ def g(s) -> Tuple:  # E: Missing type parameters for generic type "Tuple"
 def h(s) -> Tuple[str, str]:  # no error
     return 'a', 'b'
 x: Tuple = ()  # E: Missing type parameters for generic type "Tuple"
+[builtins fixtures/tuple.pyi]
 
 [case testDisallowAnyGenericsTupleWithNoTypeParamsGeneric]
 # flags: --disallow-any-generics
@@ -1403,6 +1409,7 @@ def g(s) -> A:  # E: Missing type parameters for generic type "A"
 def h(s) -> A[str]:  # no error
     return 'a', 'b', 'c'
 x: A = ('a', 'b', 1)  # E: Missing type parameters for generic type "A"
+[builtins fixtures/tuple.pyi]
 
 [case testDisallowAnyGenericsPlainList]
 # flags: --python-version 3.6 --disallow-any-generics

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1556,11 +1556,11 @@ from contextlib import contextmanager
 def f():
     yield
 [typing fixtures/typing-medium.pyi]
+[builtins fixtures/tuple.pyi]
 
 
 -- Conditional method definition
 -- -----------------------------
-[builtins fixtures/tuple.pyi]
 
 
 [case testTypeCheckBodyOfConditionalMethod]
@@ -1984,10 +1984,11 @@ def g3(*x: T) -> T: pass
 f(g1)
 f(g2)
 f(g3)
+[builtins fixtures/tuple.pyi]
 
 -- (...) -> T
 -- ----------------
-[builtins fixtures/tuple.pyi]
+
 [case testEllipsisWithArbitraryArgsOnBareFunction]
 def f(x, y, z): # type: (...) -> None
     pass

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -25,6 +25,7 @@ if int():
 
 class A: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 
 [case testKeywordOnlyArgumentOrderInsensitivity]
 import typing
@@ -243,6 +244,7 @@ if int():
     o = f
 
 class A: pass
+[builtins fixtures/tuple.pyi]
 
 [case testFunctionSubtypingWithVoid]
 from typing import Callable
@@ -407,6 +409,7 @@ def f(x: A) -> A: pass
 def f(x: B) -> B: pass
 @overload
 def f(x: C) -> C: pass
+[builtins fixtures/tuple.pyi]
 
 [case testInferConstraintsUnequalLengths]
 from typing import Any, Callable, List
@@ -459,6 +462,7 @@ def f(x: 'A'  =  None) -> 'B': pass
 class A: pass
 class AA(A): pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 
 [case testDefaultArgumentExpressions]
 import typing
@@ -1556,6 +1560,7 @@ def f():
 
 -- Conditional method definition
 -- -----------------------------
+[builtins fixtures/tuple.pyi]
 
 
 [case testTypeCheckBodyOfConditionalMethod]
@@ -1713,6 +1718,7 @@ def a(f: F):
 from collections import namedtuple
 class C(namedtuple('t', 'x')):
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testCallableParsingSameName]
 from typing import Callable
@@ -1981,6 +1987,7 @@ f(g3)
 
 -- (...) -> T
 -- ----------------
+[builtins fixtures/tuple.pyi]
 [case testEllipsisWithArbitraryArgsOnBareFunction]
 def f(x, y, z): # type: (...) -> None
     pass

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -172,11 +172,11 @@ b.a = d
 class B(A[S], Generic[T, S]): pass
 class C: pass
 class D: pass
+[builtins fixtures/tuple.pyi]
 
 
 -- Overriding with generic types
 -- -----------------------------
-[builtins fixtures/tuple.pyi]
 
 
 [case testOverridingMethodInSimpleTypeInheritingGenericType]
@@ -520,11 +520,11 @@ class J(Generic[t]): pass
 class X(metaclass=ABCMeta): pass
 class I(X, J[t], Generic[t]): pass
 class A(I[t], Generic[t]): pass
+[builtins fixtures/tuple.pyi]
 
 
 -- Subclassing a generic ABC
 -- -------------------------
-[builtins fixtures/tuple.pyi]
 
 
 [case testSubclassingGenericABC1]
@@ -698,11 +698,11 @@ ia = None # type: I[A]
 
 ia.f(b)  # E: Argument 1 to "f" of "J" has incompatible type "B"; expected "A"
 ia.f(a)
+[builtins fixtures/tuple.pyi]
 
 
 -- Misc
 -- ----
-[builtins fixtures/tuple.pyi]
 
 
 [case testMultipleAssignmentAndGenericSubtyping]

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -137,6 +137,7 @@ class A(Generic[T]):
 class B(A[S], Generic[T, S]): pass
 class C: pass
 class D: pass
+[builtins fixtures/tuple.pyi]
 
 [case testAccessingMethodInheritedFromGenericTypeInNonGenericType]
 from typing import TypeVar, Generic
@@ -152,6 +153,7 @@ class A(Generic[T]):
     def f(self, a: T) -> None:
         pass
 class B(A[D]): pass
+[builtins fixtures/tuple.pyi]
 
 [case testAccessingMemberVarInheritedFromGenericType]
 from typing import TypeVar, Generic
@@ -174,6 +176,7 @@ class D: pass
 
 -- Overriding with generic types
 -- -----------------------------
+[builtins fixtures/tuple.pyi]
 
 
 [case testOverridingMethodInSimpleTypeInheritingGenericType]
@@ -483,6 +486,7 @@ if int():
 class C: pass
 class D: pass
 class E: pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testSubtypingWithTypeImplementingGenericABCViaInheritance2-skip]
@@ -520,6 +524,7 @@ class A(I[t], Generic[t]): pass
 
 -- Subclassing a generic ABC
 -- -------------------------
+[builtins fixtures/tuple.pyi]
 
 
 [case testSubclassingGenericABC1]
@@ -569,6 +574,7 @@ class A(B):
     def f(self, a: 'C', b: 'C') -> None: pass
 class C: pass
 class D: pass
+[builtins fixtures/tuple.pyi]
 
 [case testSubclassingGenericABCWithDeepHierarchy2]
 from typing import Any, TypeVar, Generic
@@ -675,6 +681,7 @@ ia = None # type: I[A]
 
 ia.f(b)  # E: Argument 1 to "f" of "I" has incompatible type "B"; expected "A"
 ia.f(a)
+[builtins fixtures/tuple.pyi]
 
 [case testAccessingInheritedGenericABCMembers]
 from typing import TypeVar, Generic
@@ -695,6 +702,7 @@ ia.f(a)
 
 -- Misc
 -- ----
+[builtins fixtures/tuple.pyi]
 
 
 [case testMultipleAssignmentAndGenericSubtyping]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -15,6 +15,7 @@ class A(Generic[T]):
 
 class B: pass
 class C: pass
+[builtins fixtures/tuple.pyi]
 
 [case testGenericMethodArgument]
 from typing import TypeVar, Generic
@@ -47,6 +48,7 @@ a.v = b
 
 class B: pass
 class C: pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:8: error: Incompatible types in assignment (expression has type "C", variable has type "B")
 
@@ -61,6 +63,7 @@ class A(Generic[T]):
     v = None # type: T
 class B: pass
 class C: pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:4: error: Incompatible types in assignment (expression has type "C", variable has type "B")
 
@@ -80,6 +83,7 @@ if int():
 class A(Generic[T]): pass
 class B: pass
 class C(B): pass
+[builtins fixtures/tuple.pyi]
 
 [case testGenericTypeCompatibilityWithAny]
 from typing import Any, TypeVar, Generic
@@ -94,6 +98,7 @@ d = c
 class A(Generic[T]): pass
 class B: pass
 class C(B): pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testTypeVariableAsTypeArgument]
@@ -824,6 +829,7 @@ use_cb(1, 1) # E: Argument 2 to "use_cb" has incompatible type "int"; expected "
 my_cb = None # type: C2[int]
 use_cb('x', my_cb) # E: Argument 2 to "use_cb" has incompatible type "Callable[[int, int], Node[int]]"; expected "Callable[[str, str], Node[str]]"
 reveal_type(use_cb(1, my_cb)) # N: Revealed type is '__main__.Node[builtins.int]'
+[builtins fixtures/tuple.pyi]
 
 [out]
 
@@ -899,6 +905,7 @@ T = TypeVar('T')
 R = TypeVar('R')
 
 Transform = Callable[[T, int], Tuple[T, R]]
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testGenericTypeAliasesImportingWithoutTypeVarError]
@@ -1028,6 +1035,7 @@ reveal_type(us) # N: Revealed type is 'Any'
 xx = CA[str] + 1  # E: Type application is only supported for generic classes
 yy = TA[str]()  # E: Type application is only supported for generic classes
 zz = UA[str].x  # E: Type application is only supported for generic classes
+[builtins fixtures/tuple.pyi]
 
 [out]
 
@@ -1740,6 +1748,7 @@ T = TypeVar('T')
 def f(x: Container[T]) -> T: ...
 reveal_type(f((1, 2))) # N: Revealed type is 'builtins.int*'
 [typing fixtures/typing-full.pyi]
+[builtins fixtures/tuple.pyi]
 
 [case testClassMethodInGenericClassWithGenericConstructorArg]
 from typing import TypeVar, Generic

--- a/test-data/unit/check-incomplete-fixture.test
+++ b/test-data/unit/check-incomplete-fixture.test
@@ -64,12 +64,10 @@ x: Tuple[int, ...]
 x[0]
 for y in x:
     pass
-[builtins fixtures/tuple.pyi]
 [out]
 -- These errors are pretty bad, but keeping this test anyway to
 -- avoid things getting worse.
-main:3: error: Value of type "Tuple[int, ...]" is not indexable
-main:4: error: "Tuple[int, ...]" has no attribute "__iter__" (not iterable)
+main:2: error: Name 'tuple' is not defined
 
 [case testClassmethodMissingFromStubs]
 class A:

--- a/test-data/unit/check-incomplete-fixture.test
+++ b/test-data/unit/check-incomplete-fixture.test
@@ -58,16 +58,24 @@ main:1: error: Name 'isinstance' is not defined
 main:1: note: Maybe your test fixture does not define "builtins.isinstance"?
 main:1: note: Consider adding [builtins fixtures/isinstancelist.pyi] to your test description
 
-[case testInvalidTupleDefinitionFromStubs]
-from typing import Tuple
-x: Tuple[int, ...]
-x[0]
-for y in x:
-    pass
+[case testTupleMissingFromStubs1]
+tuple()
 [out]
--- These errors are pretty bad, but keeping this test anyway to
--- avoid things getting worse.
-main:2: error: Name 'tuple' is not defined
+main:1: error: Name 'tuple' is not defined
+main:1: note: Maybe your test fixture does not define "builtins.tuple"?
+main:1: note: Consider adding [builtins fixtures/tuple.pyi] to your test description
+main:1: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Tuple")
+
+[case testTupleMissingFromStubs2]
+tuple()
+from typing import Tuple
+x: Tuple[int, str]
+[out]
+main:1: error: Name 'tuple' is not defined
+main:1: note: Maybe your test fixture does not define "builtins.tuple"?
+main:1: note: Consider adding [builtins fixtures/tuple.pyi] to your test description
+main:1: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Tuple")
+main:3: error: Name 'tuple' is not defined
 
 [case testClassmethodMissingFromStubs]
 class A:

--- a/test-data/unit/check-incomplete-fixture.test
+++ b/test-data/unit/check-incomplete-fixture.test
@@ -64,6 +64,7 @@ x: Tuple[int, ...]
 x[0]
 for y in x:
     pass
+[builtins fixtures/tuple.pyi]
 [out]
 -- These errors are pretty bad, but keeping this test anyway to
 -- avoid things getting worse.

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1637,6 +1637,7 @@ MyTuple = NamedTuple('MyTuple', [
 
 [rechecked bar, mid, foo]
 [stale bar]
+[builtins fixtures/tuple.pyi]
 [out2]
 tmp/foo.py:3: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
 
@@ -1671,6 +1672,7 @@ class Outer:
 
 [rechecked bar, mid, foo]
 [stale bar]
+[builtins fixtures/tuple.pyi]
 [out2]
 tmp/foo.py:3: error: Argument 1 to "accept_int" has incompatible type "str"; expected "int"
 
@@ -1817,6 +1819,7 @@ from typing import NamedTuple
 class C:
     def f(self) -> None:
         A = NamedTuple('A', [('x', int), ('y', int)])
+[builtins fixtures/tuple.pyi]
 [out1]
 main:1: error: Module 'ntcrash' has no attribute 'nope'
 [out2]
@@ -1830,6 +1833,7 @@ class C:
     class D:
         def f(self) -> None:
             A = NamedTuple('A', [('x', int), ('y', int)])
+[builtins fixtures/tuple.pyi]
 [out1]
 main:1: error: Module 'ntcrash' has no attribute 'nope'
 [out2]
@@ -1844,6 +1848,7 @@ class C:
         class D:
             def f(self) -> None:
                 A = NamedTuple('A', [('x', int), ('y', int)])
+[builtins fixtures/tuple.pyi]
 [out1]
 main:1: error: Module 'ntcrash' has no attribute 'nope'
 [out2]
@@ -2409,6 +2414,7 @@ class Pair(NamedTuple):
     last: str
 
 Person(name=Pair(first="John", last="Doe"))
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testNoCrashForwardRefToBrokenDoubleNewTypeIncremental]
@@ -2463,6 +2469,7 @@ class N(NamedTuple):
 
 x: NT = N(1) # type: ignore
 x = NT(N(1))
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testNewTypeFromForwardTypedDictIncremental]
@@ -2533,6 +2540,7 @@ A = Union[B, int]  # type: ignore
 B = Callable[[C], int] # type: ignore
 class C(NamedTuple): # type: ignore
     x: A
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testGenericTypeAliasesForwardAnyIncremental1]
@@ -2593,6 +2601,7 @@ yg: G[M]
 z: int = G[M]().x.x
 z = G[M]().x[0]
 M = NamedTuple('M', [('x', int)])
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testSelfRefNTIncremental1]
@@ -3650,6 +3659,7 @@ cache_fine_grained = False
 cache_fine_grained = True
 [rechecked a, builtins, typing]
 [stale a, builtins, typing]
+[builtins fixtures/tuple.pyi]
 
 [case testIncrementalPackageNameOverload]
 # cmd: mypy -m main a
@@ -3696,6 +3706,7 @@ import b
 -- Every file should get reloaded, since the cache was invalidated
 [stale a, b, builtins, typing]
 [rechecked a, b, builtins, typing]
+[builtins fixtures/tuple.pyi]
 
 [case testIncrementalBustedFineGrainedCache2]
 # flags2: --cache-fine-grained
@@ -3708,6 +3719,7 @@ import b
 -- Every file should get reloaded, since the settings changed
 [stale a, b, builtins, typing]
 [rechecked a, b, builtins, typing]
+[builtins fixtures/tuple.pyi]
 
 [case testIncrementalBustedFineGrainedCache3]
 # flags: --cache-fine-grained --no-sqlite-cache
@@ -3723,6 +3735,7 @@ import b
 -- Every file should get reloaded, since the cache was invalidated
 [stale a, b, builtins, typing]
 [rechecked a, b, builtins, typing]
+[builtins fixtures/tuple.pyi]
 
 [case testIncrementalWorkingFineGrainedCache]
 # flags: --cache-fine-grained
@@ -4987,6 +5000,7 @@ a = 1
 [file mod.py.2]
 from typing_extensions import Literal
 a: Literal[2] = 2
+[builtins fixtures/tuple.pyi]
 [out]
 main:2: note: Revealed type is 'builtins.int'
 [out2]
@@ -5019,6 +5033,7 @@ reveal_type(x)
 [file b.py]
 from typing import NamedTuple
 NT = NamedTuple('BadName', [('x', int)])
+[builtins fixtures/tuple.pyi]
 [out]
 [out2]
 tmp/a.py:3: note: Revealed type is 'Tuple[builtins.int, fallback=b.BadName@2]'
@@ -5058,6 +5073,7 @@ class C:
     def __init__(self) -> None:
         self.h: Hidden
         Hidden = NamedTuple('Hidden', [('x', int)])
+[builtins fixtures/tuple.pyi]
 [out]
 [out2]
 tmp/a.py:3: note: Revealed type is 'Tuple[builtins.int, fallback=b.C.Hidden@5]'

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -649,6 +649,7 @@ reveal_type(lambda x: 1)  # N: Revealed type is 'def (x: Any) -> Literal[1]?'
 from typing import Callable
 def f(t: Callable[[str], str]) -> str: ''
 f(lambda *_: '')
+[builtins fixtures/tuple.pyi]
 
 [case testInvalidContextForLambda]
 from typing import Callable

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -668,11 +668,11 @@ def f(a: T, b: T) -> T: pass
 class A: pass
 class B(A, I, J): pass
 class C(A, I, J): pass
+[builtins fixtures/tuple.pyi]
 
 
 -- Generic function inference with function arguments
 -- --------------------------------------------------
-[builtins fixtures/tuple.pyi]
 
 
 [case testNonOverloadedMapInference]
@@ -1146,11 +1146,11 @@ def f(x: AnyStr) -> Tuple[AnyStr]: pass
 x = None
 (x,) = f('')
 reveal_type(x)  # N: Revealed type is 'builtins.str'
+[builtins fixtures/tuple.pyi]
 
 
 -- Inferring attribute types
 -- -------------------------
-[builtins fixtures/tuple.pyi]
 
 
 [case testInferAttributeType]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -195,6 +195,7 @@ def f() -> None:
 
 class A: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testInferringLvarTypesInNestedTupleAssignment1]
@@ -212,6 +213,7 @@ def f() -> None:
 
 class A: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testInferringLvarTypesInNestedTupleAssignment2]
@@ -670,6 +672,7 @@ class C(A, I, J): pass
 
 -- Generic function inference with function arguments
 -- --------------------------------------------------
+[builtins fixtures/tuple.pyi]
 
 
 [case testNonOverloadedMapInference]
@@ -1147,6 +1150,7 @@ reveal_type(x)  # N: Revealed type is 'builtins.str'
 
 -- Inferring attribute types
 -- -------------------------
+[builtins fixtures/tuple.pyi]
 
 
 [case testInferAttributeType]
@@ -2174,6 +2178,7 @@ def f(): pass
 def g(x: Union[int, str]): pass
 c = a if f() else b
 g(c) # E: Argument 1 to "g" has incompatible type "Union[int, str, Tuple[Any, ...]]"; expected "Union[int, str]"
+[builtins fixtures/tuple.pyi]
 
 [case testUnificationMultipleInheritance]
 class A: pass
@@ -2291,6 +2296,7 @@ def f(x: T) -> Tuple[T]:
 x = None
 (x,) = f('')
 reveal_type(x) # N: Revealed type is 'builtins.str'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testNoCrashOnPartialVariable2]
@@ -2302,6 +2308,7 @@ def f() -> Tuple[T]:
 x = None
 if int():
     (x,) = f()
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testNoCrashOnPartialVariable3]
@@ -2313,6 +2320,7 @@ def f(x: T) -> Tuple[T, T]:
 x = None
 (x, x) = f('')
 reveal_type(x) # N: Revealed type is 'builtins.str'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testInferenceNestedTuplesFromGenericIterable]
@@ -2688,6 +2696,7 @@ def bar() -> None:
     _, _ = t
     _ = 0
     _ = ''
+[builtins fixtures/tuple.pyi]
 
 [case testUnusedTargetMultipleTargets]
 def foo() -> None:
@@ -2766,6 +2775,7 @@ def f() -> None:
     with C() as _: pass
     _ = 0
     _ = ''
+[builtins fixtures/tuple.pyi]
 
 [case testUnusedTargetNotExceptClause]
 # Things don't work for except clauses.
@@ -2967,6 +2977,7 @@ def f() -> None:
 class C:
     def __init__(self, a: int) -> None:
         self.a = a
+[builtins fixtures/tuple.pyi]
 
 [case testUnionGenericWithBoundedVariable]
 from typing import Generic, TypeVar, Union

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -5,6 +5,7 @@ def f(): x, y  # Prevent independent redefinition
 y = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
 x = 2
 y = x
+[builtins fixtures/tuple.pyi]
 
 [case testJoinAny]
 from typing import List, Any

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -119,17 +119,20 @@ f(otter=x) # E: Unexpected keyword argument "otter" for "f"; did you mean "btter
 def f(other: 'A', *atter: 'A') -> None: pass # N: "f" defined here
 f(otter=A()) # E: Unexpected keyword argument "otter" for "f"; did you mean "other"?
 class A: pass
+[builtins fixtures/tuple.pyi]
 
 [case testKeywordMisspellingOnlyVarArgs]
 def f(*other: 'A') -> None: pass # N: "f" defined here
 f(otter=A()) # E: Unexpected keyword argument "otter" for "f"
 class A: pass
+[builtins fixtures/tuple.pyi]
 
 [case testKeywordMisspellingVarArgsDifferentTypes]
 def f(other: 'B', *atter: 'A') -> None: pass # N: "f" defined here
 f(otter=A()) # E: Unexpected keyword argument "otter" for "f"; did you mean "other"?
 class A: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 
 [case testKeywordMisspellingVarKwargs]
 def f(other: 'A', **atter: 'A') -> None: pass

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -1295,13 +1295,13 @@ from typing_extensions import Literal
 Bar1 = Literal[15]
 Bar2 = Literal[14]
 c: Literal[15]
+[builtins fixtures/tuple.pyi]
 
 
 --
 -- Check to make sure we handle inference of literal values correctly,
 -- especially when doing assignments or calls
 --
-[builtins fixtures/tuple.pyi]
 
 [case testLiteralInferredInAssignment]
 from typing_extensions import Literal
@@ -2076,11 +2076,11 @@ reveal_type(func1(identity(4)))  # N: Revealed type is 'Literal[19]'
 reveal_type(func1(identity(5)))  # N: Revealed type is 'builtins.int'
 reveal_type(func1(identity(a)))  # N: Revealed type is 'Literal[19]'
 reveal_type(func1(identity(b)))  # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 --
 -- Interactions with meets
 --
-[builtins fixtures/tuple.pyi]
 
 [case testLiteralMeets]
 from typing import TypeVar, List, Callable, Union

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -14,6 +14,7 @@ def f2(x: 'A B') -> None: pass  # E: Invalid type comment or annotation
 def g2(x: Literal['A B']) -> None: pass
 reveal_type(f2)  # N: Revealed type is 'def (x: Any)'
 reveal_type(g2)  # N: Revealed type is 'def (x: Literal['A B'])'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralInvalidTypeComment]
@@ -34,6 +35,7 @@ def g(x):
 
 reveal_type(f)  # N: Revealed type is 'def (x: Any)'
 reveal_type(g)  # N: Revealed type is 'def (x: Literal['A['])'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralFromTypingWorks]
@@ -78,6 +80,7 @@ def bar(x: Tuple[Literal[2]]) -> None: ...
 reveal_type(x)                      # N: Revealed type is 'Tuple[Any]'
 reveal_type(y)                      # N: Revealed type is 'Tuple[Literal[2]]'
 reveal_type(bar)                    # N: Revealed type is 'def (x: Tuple[Literal[2]])'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralInsideOtherTypesPython2]
@@ -116,6 +119,7 @@ def bar(x):
 reveal_type(x)                      # N: Revealed type is 'Union[Tuple[Any], None]'
 reveal_type(y)                      # N: Revealed type is 'Union[Tuple[Literal[2]], None]'
 reveal_type(bar)                    # N: Revealed type is 'def (x: Tuple[Literal[2]])'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralValidExpressionsInStringsPython3]
@@ -286,6 +290,7 @@ accepts_bytes(c_hint)
 accepts_bytes(a_alias)  # E: Argument 1 to "accepts_bytes" has incompatible type "Literal['foo']"; expected "Literal[b'foo']"
 accepts_bytes(b_alias)  # E: Argument 1 to "accepts_bytes" has incompatible type "Literal['foo']"; expected "Literal[b'foo']"
 accepts_bytes(c_alias)
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralMixingUnicodeAndBytesPython2]
@@ -461,6 +466,7 @@ reveal_type(c_str_wrapper_alias)      # N: Revealed type is '__main__.Wrap[Liter
 reveal_type(a_bytes_wrapper_alias)    # N: Revealed type is '__main__.Wrap[Literal['foo']]'
 reveal_type(b_bytes_wrapper_alias)    # N: Revealed type is '__main__.Wrap[Literal['foo']]'
 reveal_type(c_bytes_wrapper_alias)    # N: Revealed type is '__main__.Wrap[Literal[b'foo']]'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralMixingUnicodeAndBytesPython2ForwardStrings]
@@ -657,6 +663,7 @@ a1 = c2  # E: Incompatible types in assignment (expression has type "Literal['¬
 a1 = a3
 a1 = b3
 a1 = c3  # E: Incompatible types in assignment (expression has type "Literal['¬b ∧ λ(p)']", variable has type "Literal['\x00¬b ∧ λ(p)']")
+[builtins fixtures/tuple.pyi]
 
 [out skip-path-normalization]
 
@@ -668,6 +675,7 @@ reveal_type(x)   # N: Revealed type is 'Literal[3]'
 
 y: Foo["hello"]
 reveal_type(y)   # N: Revealed type is 'Literal['hello']'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralRenamingImportViaAnotherImportWorks]
@@ -682,6 +690,7 @@ reveal_type(y)  # N: Revealed type is 'Literal[4]'
 [file other_module.py]
 from typing_extensions import Literal as Foo
 Bar = Foo[4]
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralRenamingImportNameConfusion]
@@ -691,6 +700,7 @@ x: Foo["Foo"]
 reveal_type(x)  # N: Revealed type is 'Literal['Foo']'
 
 y: Foo[Foo]     # E: Literal[...] must have at least one parameter
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralBadRawExpressionWithBadType]
@@ -741,6 +751,7 @@ def f3(x: Literal[-300]) -> Literal[-300]: pass
 reveal_type(f1)  # N: Revealed type is 'def (x: Literal[4]) -> Literal[4]'
 reveal_type(f2)  # N: Revealed type is 'def (x: Literal[42]) -> Literal[42]'
 reveal_type(f3)  # N: Revealed type is 'def (x: Literal[-300]) -> Literal[-300]'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralBasicBoolUsage]
@@ -794,6 +805,7 @@ reveal_type(f2)  # N: Revealed type is 'def (x: Literal['  foo bar  ']) -> Liter
 reveal_type(f3)  # N: Revealed type is 'def (x: Literal['  foo bar  ']) -> Literal['  foo bar  ']'
 reveal_type(f4)  # N: Revealed type is 'def (x: Literal['foo']) -> Literal['foo']'
 reveal_type(f5)  # N: Revealed type is 'def (x: Literal['foo']) -> Literal['foo']'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralBasicStrUsageSlashes]
@@ -804,6 +816,7 @@ b: Literal["foo\nbar"]
 
 reveal_type(a)
 reveal_type(b)
+[builtins fixtures/tuple.pyi]
 [out skip-path-normalization]
 main:6: note: Revealed type is 'Literal['foo\\nbar']'
 main:7: note: Revealed type is 'Literal['foo\nbar']'
@@ -821,6 +834,7 @@ def f3(x: Literal[None]) -> Literal[None]: pass
 reveal_type(f1)  # N: Revealed type is 'def (x: None)'
 reveal_type(f2)  # N: Revealed type is 'def (x: None)'
 reveal_type(f3)  # N: Revealed type is 'def (x: None)'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralCallingUnionFunction]
@@ -846,6 +860,7 @@ func(c)
 func(d)
 func(e)
 func(f)  # E: Argument 1 to "func" has incompatible type "Union[Literal['foo'], Literal['bar'], Literal['baz']]"; expected "Union[Literal['foo'], Literal['bar'], Literal['  foo  ']]"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralDisallowAny]
@@ -859,6 +874,7 @@ b: Literal[BadAlias]                    # E: Parameter 1 of Literal[...] cannot 
 
 reveal_type(a)                          # N: Revealed type is 'Any'
 reveal_type(b)                          # N: Revealed type is 'Any'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralDisallowActualTypes]
@@ -906,6 +922,7 @@ b: Literal["  foo  ".trim()]    # E: Invalid type: Literal[...] cannot contain a
 c: Literal[+42]                 # E: Invalid type: Literal[...] cannot contain arbitrary expressions
 d: Literal[~12]                 # E: Invalid type: Literal[...] cannot contain arbitrary expressions
 e: Literal[dummy()]             # E: Invalid type: Literal[...] cannot contain arbitrary expressions
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralDisallowCollections]
@@ -914,6 +931,7 @@ a: Literal[{"a": 1, "b": 2}]    # E: Invalid type: Literal[...] cannot contain a
 b: Literal[{1, 2, 3}]           # E: Invalid type: Literal[...] cannot contain arbitrary expressions
 c: {"a": 1, "b": 2}             # E: Invalid type comment or annotation
 d: {1, 2, 3}                    # E: Invalid type comment or annotation
+[builtins fixtures/tuple.pyi]
 
 [case testLiteralDisallowCollections2]
 
@@ -923,6 +941,7 @@ a: (1, 2, 3)                    # E: Syntax error in type annotation \
 b: Literal[[1, 2, 3]]           # E: Parameter 1 of Literal[...] is invalid
 c: [1, 2, 3]                    # E: Bracketed expression "[...]" is not valid as a type \
                                 # N: Did you mean "List[...]"?
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralDisallowCollectionsTypeAlias]
@@ -955,6 +974,7 @@ at = Literal[T]  # E: Parameter 1 of Literal[...] is invalid
 a: at
 
 def foo(b: Literal[T]) -> T: pass   # E: Parameter 1 of Literal[...] is invalid
+[builtins fixtures/tuple.pyi]
 [out]
 
 
@@ -989,6 +1009,7 @@ a: Literal[1, 2, 3]
 b: Literal[(1, 2, 3)]
 reveal_type(a)  # N: Revealed type is 'Union[Literal[1], Literal[2], Literal[3]]'
 reveal_type(b)  # N: Revealed type is 'Union[Literal[1], Literal[2], Literal[3]]'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralNestedUsage]
@@ -1010,6 +1031,7 @@ basic_mode = Literal["r", "w", "a"]
 basic_with_plus = Literal["r+", "w+", "a+"]
 combined: Literal[basic_mode, basic_with_plus]
 reveal_type(combined)  # N: Revealed type is 'Union[Literal['r'], Literal['w'], Literal['a'], Literal['r+'], Literal['w+'], Literal['a+']]'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralBiasTowardsAssumingForwardReference]
@@ -1027,6 +1049,7 @@ d: "Literal['Foo']"
 reveal_type(d)      # N: Revealed type is 'Literal['Foo']'
 
 class Foo: pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralBiasTowardsAssumingForwardReferenceForTypeAliases]
@@ -1048,6 +1071,7 @@ e: Literal[Foo, 'Foo']
 reveal_type(e)      # N: Revealed type is 'Union[Literal[5], Literal['Foo']]'
 
 Foo = Literal[5]
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralBiasTowardsAssumingForwardReferencesForTypeComments]
@@ -1065,6 +1089,7 @@ reveal_type(c)      # N: Revealed type is 'Literal['Foo']'
 d = None  # type: Literal[Foo]   # E: Parameter 1 of Literal[...] is invalid
 
 class Foo: pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 
@@ -1083,6 +1108,7 @@ c: int
 foo(a)  # E: Argument 1 to "foo" has incompatible type "Literal[1]"; expected "Literal[3]"
 foo(b)  # E: Argument 1 to "foo" has incompatible type "Literal[2]"; expected "Literal[3]"
 foo(c)  # E: Argument 1 to "foo" has incompatible type "int"; expected "Literal[3]"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralCallingFunctionWithUnionLiteral]
@@ -1098,6 +1124,7 @@ foo(a)
 foo(b)
 foo(c)  # E: Argument 1 to "foo" has incompatible type "Union[Literal[4], Literal[5]]"; expected "Union[Literal[1], Literal[2], Literal[3]]"
 foo(d)  # E: Argument 1 to "foo" has incompatible type "int"; expected "Union[Literal[1], Literal[2], Literal[3]]"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralCallingFunctionWithStandardBase]
@@ -1111,6 +1138,7 @@ c: Literal[4, 'foo']
 foo(a)
 foo(b)
 foo(c)  # E: Argument 1 to "foo" has incompatible type "Union[Literal[4], Literal['foo']]"; expected "int"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralCheckSubtypingStrictOptional]
@@ -1136,6 +1164,7 @@ fc(lit)  # E: Argument 1 to "fc" has incompatible type "Literal[1]"; expected "N
 f_lit(a)
 f_lit(b)
 f_lit(c) # E: Argument 1 to "f_lit" has incompatible type "None"; expected "Literal[1]"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralCheckSubtypingNoStrictOptional]
@@ -1161,6 +1190,7 @@ fc(lit)  # E: Argument 1 to "fc" has incompatible type "Literal[1]"; expected "N
 f_lit(a)
 f_lit(b)
 f_lit(c)
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralCallingOverloadedFunction]
@@ -1225,6 +1255,7 @@ c2: Contravariant[Literal[1, 2]]
 c3: Contravariant[Literal[1, 2, 3]]
 c2 = c1  # E: Incompatible types in assignment (expression has type "Contravariant[Literal[1]]", variable has type "Contravariant[Union[Literal[1], Literal[2]]]")
 c2 = c3
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralInListAndSequence]
@@ -1270,6 +1301,7 @@ c: Literal[15]
 -- Check to make sure we handle inference of literal values correctly,
 -- especially when doing assignments or calls
 --
+[builtins fixtures/tuple.pyi]
 
 [case testLiteralInferredInAssignment]
 from typing_extensions import Literal
@@ -1423,6 +1455,7 @@ def f4(x: Literal[1]) -> Literal[1]:
 
 def f5(x: Literal[2]) -> Literal[1]:
     return x  # E: Incompatible return value type (got "Literal[2]", expected "Literal[1]")
+[builtins fixtures/tuple.pyi]
 
 [out]
 
@@ -1524,6 +1557,7 @@ reveal_type(func(b))  # N: Revealed type is 'builtins.int'
 # with the output we would have gotten if we replaced int and the
 # Literal types here with regular classes/subclasses.
 reveal_type(func(c))  # N: Revealed type is 'builtins.object'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralOverloadProhibitUnsafeOverlaps]
@@ -1548,6 +1582,7 @@ def func3(x: Literal['a']) -> Literal[2]: ...
 @overload
 def func3(x: str) -> int: ...
 def func3(x): pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralInferredInOverloadContextUnionMath]
@@ -1592,6 +1627,7 @@ reveal_type(func(f))  # E: No overload variant of "func" matches argument type "
                       # N:     def func(x: Union[Literal[3], Literal[4], Literal[5], Literal[6]]) -> B \
                       # N:     def func(x: Literal['foo']) -> C \
                       # N: Revealed type is 'Any'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralInferredInOverloadContextUnionMathOverloadingReturnsBestType]
@@ -1615,6 +1651,7 @@ reveal_type(f(2))  # N: Revealed type is 'builtins.int'
 reveal_type(f(y))  # N: Revealed type is 'builtins.object'
 reveal_type(f(z))  # N: Revealed type is 'builtins.int' \
                    # E: Argument 1 to "f" has incompatible type "Union[Literal[1], Literal[2], Literal['three']]"; expected "Union[Literal[1], Literal[2]]"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralInferredInOverloadContextWithTypevars]
@@ -1665,6 +1702,7 @@ reveal_type(f4("foo"))  # N: Revealed type is 'builtins.str'
 # Note: first overload is selected and prevents the typevar from
 # ever inferring a Literal["something"].
 reveal_type(f4(b))      # N: Revealed type is 'builtins.str'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralInferredInOverloadContextUnionMathTrickyOverload]
@@ -1683,6 +1721,7 @@ x: Literal['a', 'b']
 y: Literal['a', 'b']
 f(x, y)  # E: Argument 1 to "f" has incompatible type "Union[Literal['a'], Literal['b']]"; expected "Literal['a']" \
          # E: Argument 2 to "f" has incompatible type "Union[Literal['a'], Literal['b']]"; expected "Literal['a']" \
+[builtins fixtures/tuple.pyi]
 [out]
 
 
@@ -1793,6 +1832,7 @@ class Bad1(Literal[3]): pass            # E: Invalid base class "Literal"
 class Bad2(Renamed[3]): pass            # E: Invalid base class "Renamed"
 class Bad3(indirect.Literal[3]): pass   # E: Invalid base class "indirect.Literal"
 class Bad4(Alias): pass                 # E: Invalid base class "Alias"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralErrorsWhenInvoked-skip]
@@ -1850,6 +1890,7 @@ expects_literal(foo(foo(5)))    # E: Argument 1 to "foo" has incompatible type "
 expects_int(a)
 expects_int(foo(a))
 expects_int(foo(foo(a)))
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralAndGenericWithUnion]
@@ -1861,6 +1902,7 @@ def identity(x: T) -> T: return x
 
 a: Union[int, Literal['foo']] = identity('foo')
 b: Union[int, Literal['foo']] = identity('bar')  # E: Argument 1 to "identity" has incompatible type "Literal['bar']"; expected "Union[int, Literal['foo']]"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralAndGenericsNoMatch]
@@ -1914,6 +1956,7 @@ expects_literal(Wrapper(5).inner())  # E: Argument 1 to "expects_literal" has in
 expects_literal_wrapper(Wrapper(a))
 expects_literal_wrapper(Wrapper(3))
 expects_literal_wrapper(Wrapper(5))  # E: Argument 1 to "Wrapper" has incompatible type "Literal[5]"; expected "Literal[3]"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralAndGenericsRespectsUpperBound]
@@ -1953,6 +1996,7 @@ reveal_type(func2(a))   # N: Revealed type is 'Literal[3]'
 reveal_type(func2(4))   # N: Revealed type is 'builtins.int*'
 reveal_type(func2(b))   # N: Revealed type is 'Literal[4]'
 reveal_type(func2(c))   # N: Revealed type is 'builtins.int*'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralAndGenericsRespectsValueRestriction]
@@ -2009,6 +2053,7 @@ reveal_type(func2("foo"))   # N: Revealed type is 'builtins.str*'
 reveal_type(func2(s1))      # N: Revealed type is 'builtins.str*'
 reveal_type(func2("bar"))   # N: Revealed type is 'builtins.str*'
 reveal_type(func2(s2))      # N: Revealed type is 'builtins.str*'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralAndGenericsWithOverloads]
@@ -2035,6 +2080,7 @@ reveal_type(func1(identity(b)))  # N: Revealed type is 'builtins.int'
 --
 -- Interactions with meets
 --
+[builtins fixtures/tuple.pyi]
 
 [case testLiteralMeets]
 from typing import TypeVar, List, Callable, Union
@@ -2694,6 +2740,7 @@ force_bytes(reveal_type(a))    # E: Argument 1 to "force_bytes" has incompatible
 force_bytes(reveal_type(b))    # E: Argument 1 to "force_bytes" has incompatible type "Literal['foo']"; expected "Literal[b'foo']" \
                                # N: Revealed type is 'Literal['foo']'
 force_bytes(reveal_type(c))    # N: Revealed type is 'Literal[b'foo']'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralFinalStringTypesPython2UnicodeLiterals]
@@ -2804,6 +2851,7 @@ over_int(reveal_type(w3))                       # E: Argument 1 to "over_int" ha
 over_literal(reveal_type(w3))                   # N: Revealed type is '__main__.WrapperClass[Literal[99]]'
 over_int(reveal_type(WrapperClass(var3)))       # N: Revealed type is '__main__.WrapperClass[builtins.int]'
 over_literal(reveal_type(WrapperClass(var3)))   # N: Revealed type is '__main__.WrapperClass[Literal[99]]'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralFinalUsedInLiteralType]
@@ -2827,6 +2875,7 @@ c_wrap: Literal[4, c]  # E: Parameter 2 of Literal[...] is invalid \
                        # E: Variable "__main__.c" is not valid as a type
 d_wrap: Literal[4, d]  # E: Parameter 2 of Literal[...] is invalid \
                        # E: Variable "__main__.d" is not valid as a type
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralWithFinalPropagation]
@@ -2840,6 +2889,7 @@ def expect_3(x: Literal[3]) -> None: pass
 expect_3(a)
 expect_3(b)
 expect_3(c)  # E: Argument 1 to "expect_3" has incompatible type "int"; expected "Literal[3]"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralWithFinalPropagationIsNotLeaking]
@@ -2907,6 +2957,7 @@ expects_red(b)  # E: Argument 1 to "expects_red" has incompatible type "Literal[
 reveal_type(expects_red)  # N: Revealed type is 'def (x: Literal[__main__.Color.RED])'
 reveal_type(r)            # N: Revealed type is 'Literal[__main__.Color.RED]'
 reveal_type(r.func())     # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralWithEnumsDefinedInClass]
@@ -2929,6 +2980,7 @@ foo(g)  # E: Argument 1 to "foo" has incompatible type "Literal[Color.GREEN]"; e
 
 reveal_type(foo)  # N: Revealed type is 'def (x: Literal[__main__.Wrapper.Color.RED])'
 reveal_type(r)    # N: Revealed type is 'Literal[__main__.Wrapper.Color.RED]'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralWithEnumsSimilarDefinitions]
@@ -2963,6 +3015,7 @@ from enum import Enum
 class Test(Enum):
     FOO = 1
     BAR = 2
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralWithEnumsDeclaredUsingCallSyntax]
@@ -3013,6 +3066,7 @@ expects_int(a)  # E: Argument 1 to "expects_int" has incompatible type "Literal[
 expects_int(b)
 expects_int(c)
 expects_int(d)  # E: Argument 1 to "expects_int" has incompatible type "Literal[D.FOO]"; expected "int"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralWithEnumsAliases]
@@ -3027,6 +3081,7 @@ Alias = Test
 
 x: Literal[Alias.FOO]
 reveal_type(x)  # N: Revealed type is 'Literal[__main__.Test.FOO]'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralUsingEnumAttributesInLiteralContexts]
@@ -3060,6 +3115,7 @@ var2 = Test2.FOO
 final2: Final = Test2.FOO
 expects_test2_foo(var2)       # E: Argument 1 to "expects_test2_foo" has incompatible type "Test2"; expected "Literal[Test2.FOO]"
 expects_test2_foo(final2)
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralUsingEnumAttributeNamesInLiteralContexts]
@@ -3093,6 +3149,7 @@ reveal_type(Test2.FOO.name)  # N: Revealed type is 'Literal['FOO']?'
 reveal_type(Test3.FOO.name)  # N: Revealed type is 'Literal['FOO']?'
 reveal_type(Test4.FOO.name)  # N: Revealed type is 'Literal['FOO']?'
 reveal_type(Test5.FOO.name)  # N: Revealed type is 'Literal['FOO']?'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralBinderLastValueErased]
@@ -3159,3 +3216,4 @@ x: Literal[Foo.A]
 y: Literal[F.A]
 reveal_type(x)  # N: Revealed type is 'Literal[__main__.Foo.A]'
 reveal_type(y)  # N: Revealed type is 'Literal[__main__.Foo.A]'
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2473,6 +2473,7 @@ x = m.One(name="Foo")
 reveal_type(x.name)
 class Two:
     pass
+[builtins fixtures/tuple.pyi]
 [out]
 tmp/m/two.py:3: note: Revealed type is 'builtins.str'
 
@@ -2490,6 +2491,7 @@ x = m.One(name="Foo")
 reveal_type(x.name)
 class Two:
     pass
+[builtins fixtures/tuple.pyi]
 [out]
 tmp/m/two.py:3: note: Revealed type is 'builtins.str'
 
@@ -2807,3 +2809,4 @@ CustomDict = TypedDict(
     },
 )
 [typing fixtures/typing-full.pyi]
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-multiple-inheritance.test
+++ b/test-data/unit/check-multiple-inheritance.test
@@ -644,6 +644,7 @@ class OrderedItemsView(ItemsView[K, V], Sequence[Tuple[K, V]]):
 
 class OrderedItemsViewDirect(ItemsView[K, V], Sequence[Tuple[K, V]]):
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testGenericMultipleOverrideReplace]
 from typing import TypeVar, Generic, Union

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -637,10 +637,10 @@ def bar(nt: MyNamedTuple) -> MyNamedTuple:
 
 x: MyNamedTuple
 reveal_type(x.parent) # N: Revealed type is 'Any'
+[builtins fixtures/tuple.pyi]
 
 -- Some crazy self-referential named tuples and types dicts
 -- to be sure that everything works
-[builtins fixtures/tuple.pyi]
 
 [case testCrossFileNamedTupleForwardRefs]
 import a

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -549,7 +549,7 @@ b = B._make([''])  # type: B
 [case testNamedTupleIncompatibleRedefinition]
 from typing import NamedTuple
 class Crash(NamedTuple):
-    count: int  # E: Incompatible types in assignment (expression has type "int", base class "tuple" defined the type as "Callable[[Tuple[int, ...], Any], int]")
+    count: int  # E: Incompatible types in assignment (expression has type "int", base class "tuple" defined the type as "Callable[[Tuple[int, ...], object], int]")
 [builtins fixtures/tuple.pyi]
 
 [case testNamedTupleInClassNamespace]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -8,6 +8,7 @@ b = x[0]
 a = x[1]
 a, b, c = x # E: Need more than 2 values to unpack (3 expected)
 x[2] # E: Tuple index out of range
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleWithTupleFieldNamesUsedAsTuple]
 from collections import namedtuple
@@ -19,6 +20,7 @@ b = x[0]
 a = x[1]
 a, b, c = x # E: Need more than 2 values to unpack (3 expected)
 x[2] # E: Tuple index out of range
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleUnicode_python2]
 from __future__ import unicode_literals
@@ -34,6 +36,7 @@ X = namedtuple('X', ('x', 'y'))  # type: ignore
 from collections import namedtuple
 
 X = namedtuple('X', 'x, _y, _z')  # E: namedtuple() field names cannot start with an underscore: _y, _z
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleAccessingAttributes]
 from collections import namedtuple
@@ -43,6 +46,7 @@ x = None  # type: X
 x.x
 x.y
 x.z # E: "X" has no attribute "z"
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleClassPython35]
 # flags: --python-version 3.5
@@ -50,6 +54,7 @@ from typing import NamedTuple
 
 class A(NamedTuple):
     x = 3  # type: int
+[builtins fixtures/tuple.pyi]
 [out]
 main:4: error: NamedTuple class syntax is only supported in Python 3.6
 
@@ -62,6 +67,7 @@ from typing import NamedTuple
 
 class A(NamedTuple):
     x: int
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleAttributesAreReadOnly]
 from collections import namedtuple
@@ -77,6 +83,7 @@ a = None  # type: A
 a.x = 5 # E: Property "x" defined in "X" is read-only
 a.y = 5 # E: Property "y" defined in "X" is read-only
 -- a.z = 5 # not supported yet
+[builtins fixtures/tuple.pyi]
 
 
 [case testTypingNamedTupleAttributesAreReadOnly]
@@ -91,6 +98,7 @@ class A(NamedTuple):
 
 a: HasX = A("foo")
 a.x = "bar"
+[builtins fixtures/tuple.pyi]
 [out]
 main:10: error: Incompatible types in assignment (expression has type "A", variable has type "HasX")
 main:10: note: Protocol member HasX.x expected settable variable, got read-only attribute
@@ -105,6 +113,7 @@ x.x
 x.z      # E: "X" has no attribute "z"
 x = X(1) # E: Too few arguments for "X"
 x = X(1, 2, 3)  # E: Too many arguments for "X"
+[builtins fixtures/tuple.pyi]
 
 [case testCreateNamedTupleWithKeywordArguments]
 from collections import namedtuple
@@ -114,6 +123,7 @@ x = X(x=1, y='x')
 x = X(1, y='x')
 x = X(x=1, z=1) # E: Unexpected keyword argument "z" for "X"
 x = X(y=1) # E: Missing positional argument "x" in call to "X"
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleCreateAndUseAsTuple]
 from collections import namedtuple
@@ -122,6 +132,7 @@ X = namedtuple('X', 'x y')
 x = X(1, 'x')
 a, b = x
 a, b, c = x  # E: Need more than 2 values to unpack (3 expected)
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleAdditionalArgs]
 from collections import namedtuple
@@ -169,6 +180,7 @@ x, y = n
 if int():
     x = y  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [targets __main__, __main__.N.__new__, __main__.N._asdict, __main__.N._make, __main__.N._replace]
+[builtins fixtures/tuple.pyi]
 
 
 [case testNamedTupleWithTupleFieldNamesWithItemTypes]
@@ -183,6 +195,7 @@ i = n.b # type: int  # E: Incompatible types in assignment (expression has type 
 x, y = n
 if int():
     x = y  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[builtins fixtures/tuple.pyi]
 
 
 [case testNamedTupleConstructorArgumentTypes]
@@ -193,6 +206,7 @@ n = N('x', 'x') # E: Argument 1 to "N" has incompatible type "str"; expected "in
 n = N(1, b=2)   # E: Argument "b" to "N" has incompatible type "int"; expected "str"
 N(1, 'x')
 N(b='x', a=1)
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleAsBaseClass]
 from typing import NamedTuple
@@ -209,6 +223,7 @@ if int():
     i, s = x
 if int():
     s, s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleAsBaseClass2]
 from typing import NamedTuple
@@ -224,6 +239,7 @@ if int():
     i, s = x
 if int():
     s, s = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+[builtins fixtures/tuple.pyi]
 
 
 [case testNamedTuplesTwoAsBaseClasses]
@@ -232,6 +248,7 @@ A = NamedTuple('A', [('a', int)])
 B = NamedTuple('B', [('a', int)])
 class X(A, B):  # E: Class has two incompatible bases derived from tuple
     pass
+[builtins fixtures/tuple.pyi]
 
 
 [case testNamedTuplesTwoAsBaseClasses2]
@@ -239,6 +256,7 @@ from typing import NamedTuple
 A = NamedTuple('A', [('a', int)])
 class X(A, NamedTuple('B', [('a', int)])): # E: Class has two incompatible bases derived from tuple
     pass
+[builtins fixtures/tuple.pyi]
 
 
 [case testNamedTupleSelfTypeWithNamedTupleAsBase]
@@ -254,6 +272,7 @@ class B(A):
             i, s = self
             i, i = self  # E: Incompatible types in assignment (expression has type "str", \
                               variable has type "int")
+[builtins fixtures/tuple.pyi]
 
 
 [out]
@@ -273,6 +292,7 @@ class B(A):
                                   variable has type "str")
             i, i = self  # E: Incompatible types in assignment (expression has type "str", \
                               variable has type "int")
+[builtins fixtures/tuple.pyi]
 
 [out]
 
@@ -297,6 +317,7 @@ if int():
     t = b
 if int():
     a = b
+[builtins fixtures/tuple.pyi]
 
 
 [case testNamedTupleSimpleTypeInference]
@@ -326,6 +347,7 @@ MyNamedTuple.x # E: "Type[MyNamedTuple]" has no attribute "x"
 [case testNamedTupleEmptyItems]
 from typing import NamedTuple
 A = NamedTuple('A', [])
+[builtins fixtures/tuple.pyi]
 
 
 [case testNamedTupleProperty]
@@ -383,6 +405,7 @@ x = None  # type: X
 reveal_type(x._replace())  # N: Revealed type is 'Tuple[builtins.int, builtins.str, fallback=__main__.X]'
 x._replace(x=5)
 x._replace(y=5)  # E: Argument "y" to "_replace" of "X" has incompatible type "int"; expected "str"
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleMake]
 from typing import NamedTuple
@@ -403,6 +426,7 @@ from typing import NamedTuple
 
 X = NamedTuple('X', [('x', int), ('y', str)])
 reveal_type(X._fields)  # N: Revealed type is 'Tuple[builtins.str, builtins.str]'
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleSource]
 from typing import NamedTuple
@@ -411,6 +435,7 @@ X = NamedTuple('X', [('x', int), ('y', str)])
 reveal_type(X._source)  # N: Revealed type is 'builtins.str'
 x = None  # type: X
 reveal_type(x._source)  # N: Revealed type is 'builtins.str'
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleUnit]
 from typing import NamedTuple
@@ -419,6 +444,7 @@ X = NamedTuple('X', [])
 x = X()  # type: X
 x._replace()
 x._fields[0]  # E: Tuple index out of range
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleJoinNamedTuple]
 from typing import NamedTuple
@@ -469,6 +495,7 @@ g(D())  # E: Argument 1 to "g" has incompatible type "D"; expected "C"
 y = None  # type: C
 if int():
     y = D()  # E: Incompatible types in assignment (expression has type "D", variable has type "C")
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleSelfTypeMethod]
 from typing import TypeVar, NamedTuple
@@ -488,6 +515,7 @@ b = None  # type: B
 b = B('').member()
 a = B('')
 a = B('').member()
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleSelfTypeReplace]
 from typing import NamedTuple, TypeVar
@@ -502,6 +530,7 @@ class B(A):
 reveal_type(B('hello')._replace(x=''))  # N: Revealed type is 'Tuple[builtins.str, fallback=__main__.B]'
 b = None  # type: B
 b = B('hello')._replace(x='')
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleSelfTypeMake]
 from typing import NamedTuple, TypeVar
@@ -532,12 +561,14 @@ class C:
     def g(self):
         A = NamedTuple('A', [('y', int)])
 C.A  # E: "Type[C]" has no attribute "A"
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleInFunction]
 from typing import NamedTuple
 def f() -> None:
     A = NamedTuple('A', [('x', int)])
 A  # E: Name 'A' is not defined
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleForwardAsUpperBound]
 from typing import NamedTuple, TypeVar, Generic
@@ -551,6 +582,7 @@ reveal_type(G[M]().x.x)  # N: Revealed type is 'builtins.int'
 reveal_type(G[M]().x[0])  # N: Revealed type is 'builtins.int'
 
 M = NamedTuple('M', [('x', int)])
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testNamedTupleWithImportCycle]
@@ -569,6 +601,7 @@ def f(x: a.X) -> None:
     reveal_type(x)
     x = a.X(1)
     reveal_type(x)
+[builtins fixtures/tuple.pyi]
 [out]
 tmp/b.py:4: note: Revealed type is 'Tuple[Any, fallback=a.X]'
 tmp/b.py:6: note: Revealed type is 'Tuple[Any, fallback=a.X]'
@@ -588,6 +621,7 @@ def f(x: a.N) -> None:
     if int():
         x = a.N(1)
         reveal_type(x)
+[builtins fixtures/tuple.pyi]
 [out]
 tmp/b.py:4: note: Revealed type is 'Tuple[Any, fallback=a.N]'
 tmp/b.py:7: note: Revealed type is 'Tuple[Any, fallback=a.N]'
@@ -606,6 +640,7 @@ reveal_type(x.parent) # N: Revealed type is 'Any'
 
 -- Some crazy self-referential named tuples and types dicts
 -- to be sure that everything works
+[builtins fixtures/tuple.pyi]
 
 [case testCrossFileNamedTupleForwardRefs]
 import a
@@ -626,6 +661,7 @@ class B:
         return 'b'
     def aWithTuple(self, atuple: 'a.ATuple') -> str:
         return 'a'
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testSelfRefNT1]
@@ -751,6 +787,7 @@ from a import C
 from typing import NamedTuple
 
 tp = NamedTuple('tp', [('x', int)])
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testSubclassOfRecursiveNamedTuple]
@@ -775,6 +812,7 @@ class Real(NamedTuple):
     def __sub__(self, other: Real) -> str: return ""
 class Fraction(Real):
     def __rsub__(self, other: Real) -> Real: return other  # E: Signatures of "__rsub__" of "Fraction" and "__sub__" of "Real" are unsafely overlapping
+[builtins fixtures/tuple.pyi]
 
 [case testForwardReferenceInNamedTuple]
 from typing import NamedTuple
@@ -785,6 +823,7 @@ class A(NamedTuple):
 
 class B:
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testTypeNamedTupleClassmethod]
 from typing import Type, NamedTuple
@@ -809,6 +848,7 @@ class CallableTuple(Thing):
 
 o = CallableTuple('hello ', 12)
 o()
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleSubclassMulti]
 from typing import NamedTuple
@@ -837,6 +877,7 @@ class Child(Base):
 
 Base(param=10)
 Child(param=10)
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleClassMethodWithGenericReturnValue]
 from typing import TypeVar, Type, NamedTuple
@@ -896,6 +937,7 @@ reveal_type(u.field_1)  # N: Revealed type is 'typing.Mapping[Tuple[builtins.int
 reveal_type(u.field_2)  # N: Revealed type is 'Tuple[builtins.int, builtins.int, fallback=__main__.MyBaseTuple]'
 reveal_type(u[0])  # N: Revealed type is 'typing.Mapping[Tuple[builtins.int, builtins.int, fallback=__main__.MyBaseTuple], builtins.int]'
 reveal_type(u[1])  # N: Revealed type is 'Tuple[builtins.int, builtins.int, fallback=__main__.MyBaseTuple]'
+[builtins fixtures/tuple.pyi]
 
 [case testAssignNamedTupleAsAttribute]
 from typing import NamedTuple
@@ -905,3 +947,4 @@ class A:
         self.b = NamedTuple('x', [('s', str), ('n', int)])  # E: NamedTuple type as an attribute is not supported
 
 reveal_type(A().b)  # N: Revealed type is 'Any'
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -85,6 +85,7 @@ if x5["key"] is Key.A:
     reveal_type(x5)         # N: Revealed type is 'TypedDict('__main__.TypedDict1', {'key': Literal[__main__.Key.A], 'foo': builtins.int})'
 else:
     reveal_type(x5)         # N: Revealed type is 'TypedDict('__main__.TypedDict2', {'key': Literal[__main__.Key.B], 'foo': builtins.str})'
+[builtins fixtures/tuple.pyi]
 
 [case testNarrowingParentWithIsInstanceBasic]
 from dataclasses import dataclass
@@ -183,6 +184,7 @@ if x.key is Key.D:
     reveal_type(x)  # E: Statement is unreachable
 else:
     reveal_type(x)  # N: Revealed type is 'Union[__main__.Object1, __main__.Object2]'
+[builtins fixtures/tuple.pyi]
 
 [case testNarrowingParentWithMultipleParents]
 from enum import Enum
@@ -327,6 +329,7 @@ else:
     # TODO: Is this a bug? Should we skip inferring Any for singleton types?
     reveal_type(x.key)  # N: Revealed type is 'Union[Any, Literal[__main__.Key.B]]'
     reveal_type(x)      # N: Revealed type is 'Union[__main__.Object1, __main__.Object2, Any]'
+[builtins fixtures/tuple.pyi]
 
 [case testNarrowingParentsHierarchy]
 from typing import Union
@@ -384,6 +387,7 @@ if y.child.same_for_1_and_2 is Key.A:
 else:
     reveal_type(y)          # N: Revealed type is '__main__.Parent2'
     reveal_type(y.child)    # N: Revealed type is '__main__.Child3'
+[builtins fixtures/tuple.pyi]
 
 [case testNarrowingParentsHierarchyGenerics]
 from typing import Generic, TypeVar, Union
@@ -445,3 +449,4 @@ if y["model"]["key"] is Key.C:
 else:
     reveal_type(y)              # N: Revealed type is 'Union[TypedDict('__main__.Parent1', {'model': TypedDict('__main__.Model1', {'key': Literal[__main__.Key.A]}), 'foo': builtins.int}), TypedDict('__main__.Parent2', {'model': TypedDict('__main__.Model2', {'key': Literal[__main__.Key.B]}), 'bar': builtins.str})]'
     reveal_type(y["model"])     # N: Revealed type is 'Union[TypedDict('__main__.Model1', {'key': Literal[__main__.Key.A]}), TypedDict('__main__.Model2', {'key': Literal[__main__.Key.B]})]'
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -246,6 +246,7 @@ reveal_type(T2(x=2)) # E
 [file b.py]
 from a import TypedDict as TD1
 from a import TD2 as TD3
+[builtins fixtures/tuple.pyi]
 
 [out]
 tmp/a.py:5: note: Revealed type is 'TypedDict('a.T2', {'x': builtins.int})'
@@ -274,6 +275,7 @@ x: T2
 reveal_type(x) # N: Revealed type is 'TypedDict('__main__.T2', {'x': builtins.str, 'y': builtins.int})'
 y: T4
 reveal_type(y) # N: Revealed type is 'TypedDict('__main__.T4', {'x': builtins.str, 'y': __main__.A})'
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerRedefinitionAndDeferral1a]
 import a
@@ -864,6 +866,7 @@ reveal_type(i.t)  # N: Revealed type is '__main__.Other'
 
 In = NamedTuple('In', [('s', str), ('t', Other)])
 class Other: pass
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerNamedTupleClass]
 from typing import NamedTuple
@@ -885,6 +888,7 @@ class In(NamedTuple):
     s: str
     t: Other
 class Other: pass
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerNamedTupleCallNested]
 from typing import NamedTuple
@@ -902,6 +906,7 @@ class C:
     In = NamedTuple('In', [('s', str), ('t', Other)])
     Out = NamedTuple('Out', [('x', In), ('y', Other)])
     class Other: pass
+[builtins fixtures/tuple.pyi]
 
 
 [case testNewAnalyzerNamedTupleClassNested]
@@ -924,6 +929,7 @@ class C:
         s: str
         t: C.Other
     class Other: pass
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerNamedTupleCallNestedMethod]
 from typing import NamedTuple
@@ -938,6 +944,7 @@ class C:
         Out = NamedTuple('Out', [('x', In), ('y', Other)])
         In = NamedTuple('In', [('s', str), ('t', Other)])
         class Other: pass
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerNamedTupleClassNestedMethod]
 from typing import NamedTuple
@@ -958,6 +965,7 @@ class C:
             s: str
             t: Other
         class Other: pass
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerNamedTupleClassForwardMethod]
 from typing import NamedTuple
@@ -973,6 +981,7 @@ class NT(NamedTuple):
 
 class Other(NamedTuple):
     s: str
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerNamedTupleSpecialMethods]
 from typing import NamedTuple
@@ -987,6 +996,7 @@ class SubO(Out): pass
 Out = NamedTuple('Out', [('x', In), ('y', Other)])
 In = NamedTuple('In', [('s', str), ('t', Other)])
 class Other: pass
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerNamedTupleBaseClass]
 from typing import NamedTuple
@@ -1004,6 +1014,7 @@ class In(NamedTuple):
     s: str
     t: Other
 class Other: pass
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerIncompleteRefShadowsBuiltin1]
 import a
@@ -1158,6 +1169,7 @@ class B(type):
         return 0
 
 reveal_type(A.f()) # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerMetaclassSix2]
 import six
@@ -1171,6 +1183,7 @@ class B(type):
         return 0
 
 reveal_type(A.f()) # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerMetaclassSix3]
 import six
@@ -1187,6 +1200,7 @@ class Defer:
 
 reveal_type(A.f()) # N: Revealed type is 'builtins.int'
 reveal_type(A.x) # N: Revealed type is 'builtins.str'
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerMetaclassSix4]
 import six
@@ -1203,6 +1217,7 @@ class A(six.with_metaclass(B, Defer)):
 
 class Defer:
     x: str
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerMetaclassFuture1]
 import future.utils
@@ -1215,6 +1230,7 @@ class B(type):
         return 0
 
 reveal_type(A.f()) # N: Revealed type is 'builtins.int'
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerMetaclassFuture3]
 import future.utils
@@ -1231,6 +1247,7 @@ class Defer:
 
 reveal_type(A.f()) # N: Revealed type is 'builtins.int'
 reveal_type(A.x) # N: Revealed type is 'builtins.str'
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerMetaclassFuture4]
 import future.utils
@@ -1247,6 +1264,7 @@ class A(future.utils.with_metaclass(B, Defer)):
 
 class Defer:
     x: str
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerMetaclass1_python2]
 class A:
@@ -1716,6 +1734,7 @@ def g(x: int) -> int: ...
 def g(x: Union[C[str], int]) -> int:  # E: Type argument "builtins.str" of "C" must be a subtype of "builtins.int"
     y: C[object]  # E: Type argument "builtins.object" of "C" must be a subtype of "builtins.int"
     return 0
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerTypeArgBoundCheckWithStrictOptional]
 # flags: --config-file tmp/mypy.ini
@@ -1818,6 +1837,7 @@ reveal_type(x)  # N: Revealed type is 'Tuple[builtins.int, builtins.int]'
 [file b.py]
 import a
 x = (1, 2)
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerImportPriosA]
 import a
@@ -1827,6 +1847,7 @@ reveal_type(x)  # N: Revealed type is 'Tuple[builtins.int, builtins.int]'
 [file b.py]
 import a
 x = (1, 2)
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerConditionalFunc]
 if int():
@@ -2015,6 +2036,7 @@ from typing import Tuple
 c: C
 class C(Tuple[int, str]):
     def __init__(self) -> None: pass
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerNotAnAlias]
 class Meta(type):
@@ -2268,6 +2290,7 @@ reveal_type(x)  # N: Revealed type is 'Tuple[builtins.int, fallback=__main__.C]'
 reveal_type(x.x)  # N: Revealed type is 'builtins.int'
 
 C = NamedTuple('C', [('x', int)])
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerApplicationForward1]
 from typing import Generic, TypeVar
@@ -2487,6 +2510,7 @@ var1: Final = 1
 def force1(x: Literal[1]) -> None: pass
 
 force1(reveal_type(var1))            # N: Revealed type is 'Literal[1]'
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerReportLoopInMRO]
 class A(A): ... # E: Cannot resolve name "A" (possible cyclic definition)
@@ -2748,6 +2772,7 @@ def force(x: Literal[42]) -> None: pass
 force(reveal_type(var))  # N: Revealed type is 'Literal[42]'
 
 class Yes: ...
+[builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerImportCycleWithIgnoreMissingImports]
 # flags: --ignore-missing-imports

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -234,6 +234,7 @@ class C:
     def __init__(self) -> None:
         self.x = None  # E: Incompatible types in assignment (expression has type "None", variable has type "int")
         self.y = None  # E: Incompatible types in assignment (expression has type "None", variable has type "str")
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testOverloadWithNone]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1966,7 +1966,7 @@ class Child4(Parent):
     @overload
     def f(self, arg: str) -> str: ...
     def f(self, arg: Union[int, str]) -> Union[int, str]:
-        return True  # E: Incompatible return value type (got "bool", expected "Union[int, str]")
+        return b''  # E: Incompatible return value type (got "bytes", expected "Union[int, str]")
 
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -471,6 +471,7 @@ def f(x: 'A') -> 'A': pass
 def f(x: 'B') -> 'B': pass
 class A: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 
 [case testCallToOverloadedMethod]
 from foo import *
@@ -512,6 +513,7 @@ class A:
   @overload
   def f(self, x: 'B') -> 'B': pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadsWithDifferentArgumentCounts]
 from foo import *
@@ -545,6 +547,7 @@ def f(x: 'A') -> 'A': pass
 def f(x: 'B', y: 'A') -> 'B': pass
 class A: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 
 [case testGenericOverloadVariant]
 from foo import *
@@ -565,6 +568,7 @@ def f(x: 'B') -> 'B': pass
 class A(Generic[t]): pass
 class B: pass
 class C: pass
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadedInit]
 from foo import *
@@ -584,6 +588,7 @@ class A:
   @overload
   def __init__(self, b: 'B') -> None: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 
 [case testIntersectionTypeCompatibility]
 from foo import *
@@ -619,6 +624,7 @@ class A:
     @overload
     def __init__(self, a: 'B') -> None: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadedGetitem]
 from foo import *
@@ -639,6 +645,7 @@ class A:
     def __getitem__(self, a: int) -> int: pass
     @overload
     def __getitem__(self, b: str) -> str: pass
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadedGetitemWithGenerics]
 from foo import *
@@ -660,6 +667,7 @@ class C(Generic[t]):
     def __getitem__(self, b: 'B') -> t: pass
 class A: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 
 [case testImplementingOverloadedMethod]
 from foo import *
@@ -774,6 +782,7 @@ class A:
    def __init__(self, a: 'A') -> None: pass
 class B:
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testOverlappingErasedSignatures]
 from foo import *
@@ -1174,6 +1183,7 @@ f(*(1, '', 1))() # E: No overload variant of "f" matches argument type "Tuple[in
                  # N: Possible overload variant: \
                  # N:     def f(*x: str) -> str \
                  # N:     <1 more non-matching overload not shown>
+[builtins fixtures/tuple.pyi]
 
 [case testPreferExactSignatureMatchInOverload]
 from foo import *
@@ -1428,6 +1438,7 @@ class A(Generic[T]):
 b = A()  # type: A[Tuple[int, int]]
 b.f((0, 0))
 b.f((0, '')) # E: Argument 1 to "f" of "A" has incompatible type "Tuple[int, str]"; expected "Tuple[int, int]"
+[builtins fixtures/tuple.pyi]
 
 [case testSingleOverloadStub]
 from foo import *
@@ -1834,6 +1845,7 @@ class MyInt:
     def __init__(self, x: str) -> None: pass
     @overload
     def __init__(self, x: str, y: int) -> None: pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testOverloadTupleInstance]
@@ -1858,6 +1870,7 @@ def f(x: Tuple[A, int]) -> D: ...
 @overload
 def f(x: Tuple[()]) -> D: ...
 def f(x: Any) -> Any:...
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadTupleEllipsisNumargs]
 from typing import overload, Tuple, Any
@@ -2082,6 +2095,7 @@ def bar1(*x: int) -> int: ...
 def bar2(x: int, y: str, z: int) -> str: ...
 @overload
 def bar2(*x: int) -> int: ...
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadDetectsPossibleMatchesWithGenerics]
 from typing import overload, TypeVar, Generic
@@ -2169,6 +2183,7 @@ def foo2(*args2: str) -> int: ...
 def foo3(*args: int) -> str: ...
 @overload
 def foo3(*args: str) -> int: ...
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadPossibleOverlapWithVarargs2]
 from wrapper import *
@@ -2194,6 +2209,7 @@ def foo3(x: int, *args2: int) -> str: ...
 def foo4(x: int, *args: int) -> str: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def foo4(*args2: int) -> int: ...
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadPossibleOverlapWithVarargs3]
 from wrapper import *
@@ -2221,6 +2237,7 @@ def foo3(*args: str) -> int: ...
 def foo4(*args: int) -> str: ...
 @overload
 def foo4(x: Other = ..., *args: str) -> int: ...
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadPossibleOverlapWithVarargs4]
 from typing import overload
@@ -2236,6 +2253,7 @@ def foo2(*xs: int) -> str: ...  # E: Overloaded function signatures 1 and 2 over
 @overload
 def foo2(x: int = 0, y: int = 0) -> int: ...
 def foo2(*args): pass
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadPossibleOverlapWithKwargs]
 from wrapper import *
@@ -2272,6 +2290,7 @@ def foo1(*x: str) -> int: ...
 def foo2(*x: str) -> int: ...
 @overload
 def foo2(x: str, *, y: str) -> str: ...
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadPossibleOverlapMixingOptionalArgsWithVarargs]
 from wrapper import *
@@ -2292,6 +2311,7 @@ def foo2(x: str, y: str = ..., z: str = ...) -> str: ...
 def foo3(x: int, y: str = ..., z: str = ...) -> str: ...
 @overload
 def foo3(*x: str) -> int: ...
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadPossibleOverlapMixingOptionalArgsWithVarargs2]
 from wrapper import *
@@ -2307,6 +2327,7 @@ def foo1(*x: str) -> int: ...
 def foo2(x: str, y: str = ..., z: int = ...) -> str: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
 @overload
 def foo2(*x: str) -> int: ...
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadPossibleOverlapMixingNamedArgsWithKwargs]
 from wrapper import *
@@ -3153,6 +3174,7 @@ def f(*args): ...
 x: Union[A, B]
 reveal_type(f(x))  # N: Revealed type is '__main__.Parent'
 f(x, B())  # E: Argument 1 to "f" has incompatible type "Union[A, B]"; expected "B"
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadInferUnionWithMixOfPositionalAndOptionalArgs]
 # flags: --strict-optional
@@ -3174,6 +3196,7 @@ reveal_type(f(x))  # N: Revealed type is 'Union[builtins.int, builtins.str]'
 reveal_type(f(y))  # N: Revealed type is 'Union[builtins.int, builtins.str]'
 reveal_type(f(z))  # N: Revealed type is 'Union[builtins.int, builtins.str]'
 reveal_type(f())   # N: Revealed type is 'builtins.str'
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadingInferUnionReturnWithTypevarWithValueRestriction]
 from typing import overload, Union, TypeVar, Generic
@@ -4562,6 +4585,7 @@ def f(*args):
 
 x: Union[int, str]
 f(x, x, x, x, x, x, x, x)
+[builtins fixtures/tuple.pyi]
 [out]
 main:11: error: Not all union combinations were tried because there are too many unions
 main:11: error: Argument 1 to "f" has incompatible type "Union[int, str]"; expected "int"
@@ -4665,6 +4689,7 @@ g(3)  # E: No overload variant of "g" matches argument type "int" \
       # N:     def g(x: A) -> None \
       # N:     def g(x: B) -> None \
       # N:     def g(x: C) -> None
+[builtins fixtures/tuple.pyi]
 
 [case testOverloadedInIter]
 from lib import f, g
@@ -5027,6 +5052,7 @@ def asdf() -> None:
 @dec
 def lol(x: int, y: int) -> int:
     pass
+[builtins fixtures/tuple.pyi]
 
 [case testVeryBrokenOverload]
 import lib
@@ -5072,3 +5098,4 @@ def foo(x: Literal[0]) -> None: ...  # E: Overloaded function signatures 1 and 2
 def foo(x: MyInt) -> int: ...
 def foo(x):
     ...
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2134,6 +2134,7 @@ class MockDict(MockMapping[T]):
 def f(x: MockMapping[int]) -> None: pass
 x: MockDict[str]
 f(x)  # E: Argument 1 to "f" has incompatible type "MockDict[str]"; expected "MockMapping[int]"
+[builtins fixtures/tuple.pyi]
 
 [case testProtocolNotesForComplexSignatures]
 from typing import Protocol, Optional
@@ -2238,6 +2239,7 @@ def func(caller: Caller) -> None:
 
 func(call)
 func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[int, VarArg(str)], None]"; expected "Caller"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testCallableImplementsProtocolGeneric]
@@ -2334,6 +2336,7 @@ def bad(x: int, *args: str) -> None:
 
 cb: Caller = bad  # E: Incompatible types in assignment (expression has type "Callable[[int, VarArg(str)], None]", variable has type "Caller") \
                   # N: "Caller.__call__" has type "Callable[[Arg(str, 'x'), VarArg(int)], None]"
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testCallableImplementsProtocolArgName]

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -77,6 +77,7 @@ def g(x: int): ...
     g("IGNORE"),  # type: ignore
     f("ERROR"),  # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 )
+[builtins fixtures/tuple.pyi]
 
 [case testIgnoreScopeNestedOverlapping]
 def f(x: int): ...
@@ -86,6 +87,7 @@ def g(x: int): ...
         "IGNORE"  # type: ignore
     ), f("ERROR"),  # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 )
+[builtins fixtures/tuple.pyi]
 
 [case testIgnoreScopeUnused1]
 # flags: --warn-unused-ignores

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -523,6 +523,7 @@ ci: C[int]
 cs: C[str]
 reveal_type(ci.from_item)  # N: Revealed type is 'def (item: Tuple[builtins.int])'
 reveal_type(cs.from_item)  # N: Revealed type is 'def (item: builtins.str)'
+[builtins fixtures/tuple.pyi]
 
 [case testSelfTypeRestrictedMethodOverloadFallback]
 from typing import TypeVar, Generic, overload, Callable
@@ -675,6 +676,7 @@ b.atomic_close()  # E: Invalid self argument "Bad" to attribute function "atomic
 
 reveal_type(f.copy())  # N: Revealed type is '__main__.File*'
 b.copy()  # E: Invalid self argument "Bad" to attribute function "copy" with type "Callable[[T], T]"
+[builtins fixtures/tuple.pyi]
 
 [case testBadClassLevelDecoratorHack]
 from typing_extensions import Protocol
@@ -692,6 +694,7 @@ class Test:
 
 reveal_type(Test().meth)  # N: Revealed type is 'def (x: builtins.str) -> builtins.int'
 Test()._deco  # E: Invalid self argument "Test" to attribute function "_deco" with type "Callable[[F], F]"
+[builtins fixtures/tuple.pyi]
 
 [case testSelfTypeTrickyExample]
 from typing import *
@@ -742,6 +745,7 @@ c: Lnk[int, float] = Lnk()
 d: Lnk[str, float] = b >> c  # OK
 e: Lnk[str, Tuple[int, float]] = a >> (b, c)  # OK
 f: Lnk[str, Tuple[float, int]] = a >> (c, b) # E: Unsupported operand types for >> ("Lnk[str, Tuple[str, int]]" and "Tuple[Lnk[int, float], Lnk[str, int]]")
+[builtins fixtures/tuple.pyi]
 
 [case testSelfTypeMutuallyExclusiveRestrictions]
 from typing import Generic, TypeVar
@@ -863,6 +867,7 @@ class C(Generic[T]):
     def magic(self: C[Tuple[S, U]]) -> Tuple[T, S, U]: ...
 
 reveal_type(C[Tuple[int, str]]().magic())  # N: Revealed type is 'Tuple[Tuple[builtins.int, builtins.str], builtins.int, builtins.str]'
+[builtins fixtures/tuple.pyi]
 
 [case testSelfTypeOnUnion]
 from typing import TypeVar, Union

--- a/test-data/unit/check-semanal-error.test
+++ b/test-data/unit/check-semanal-error.test
@@ -112,4 +112,5 @@ class C:
     attr: int
 
 x: P[int] = C()
+[builtins fixtures/tuple.pyi]
 [out]

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -710,6 +710,7 @@ class C:
         self.a = A(0)
         self.b = A(0)  # type: A
         self.c = A
+[builtins fixtures/tuple.pyi]
 [out1]
 main:2: note: Revealed type is 'Tuple[builtins.int, fallback=ntcrash.C.A@4]'
 main:3: note: Revealed type is 'Tuple[builtins.int, fallback=ntcrash.C.A@4]'
@@ -924,6 +925,7 @@ b.N(x='')
 from typing import NamedTuple
 N = NamedTuple('N', [('x', int)])
 x: N
+[builtins fixtures/tuple.pyi]
 [out2]
 tmp/a.py:5: error: Incompatible types in assignment (expression has type "Tuple[int]", variable has type "N")
 tmp/a.py:6: error: Incompatible types in assignment (expression has type "Tuple[int]", variable has type "N")

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -224,6 +224,7 @@ class B:
     def __add__(self, x: A) -> 'C': pass
 
 class C: pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:3: error: Unsupported operand types for + ("A" and "B")
 main:4: error: Incompatible types in assignment (expression has type "C", variable has type "B")
@@ -244,6 +245,7 @@ class B:
     def __sub__(self, x: A) -> 'C': pass
 
 class C: pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:3: error: Unsupported operand types for - ("A" and "B")
 main:4: error: Incompatible types in assignment (expression has type "C", variable has type "B")
@@ -260,6 +262,7 @@ class A:
     def __mul__(self, x: 'C') -> 'A': pass
 
 class C: pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:3: error: Unsupported operand types for * ("A" and "A")
 main:4: error: Unsupported left operand type for * ("C")
@@ -274,6 +277,7 @@ class A:
     def __matmul__(self, x: 'C') -> 'A': pass
 
 class C: pass
+[builtins fixtures/tuple.pyi]
 
 [case testDivAssign]
 
@@ -286,6 +290,7 @@ class A:
     def __truediv__(self, x: 'C') -> 'A': pass
 
 class C: pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:3: error: Unsupported operand types for / ("A" and "A")
 main:4: error: Unsupported left operand type for / ("C")
@@ -301,6 +306,7 @@ class A:
     def __pow__(self, x: 'C') -> 'A': pass
 
 class C: pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:3: error: Unsupported operand types for ** ("A" and "A")
 main:4: error: Unsupported left operand type for ** ("C")
@@ -316,6 +322,7 @@ class A:
     def __add__(self, x: 'A') -> 'B': pass
 
 class B(A): pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testAdditionalOperatorsInOpAssign]
@@ -332,6 +339,7 @@ class A:
     def __rshift__(self, x: 'C') -> 'A': pass
     def __floordiv__(self, x: 'C') -> 'A': pass
 class C: pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:3: error: Unsupported operand types for & ("A" and "A")
 main:4: error: Unsupported operand types for >> ("A" and "A")
@@ -1018,6 +1026,7 @@ del a[b] # E: "A" has no attribute "__delitem__"
 class B:
   def __delitem__(self, index: 'A'): pass
 class A: pass
+[builtins fixtures/tuple.pyi]
 
 [case testDelStmtWithAttribute]
 class A:
@@ -1033,6 +1042,7 @@ class A:
     x = 0
 a = A()
 del a.x, a.y # E: "A" has no attribute "y"
+[builtins fixtures/tuple.pyi]
 
 
 [case testDelStatementWithAssignmentSimple]

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -17,6 +17,7 @@ class A(B):
         a = super().g() # E: "g" undefined in superclass
         b = super().f()
     return a
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testAccessingSuperTypeMethodWithArgs]
@@ -30,6 +31,7 @@ class A(B):
     super().f(a)
     self.f(b)
     self.f(a)
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testAccessingSuperInit]

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -456,6 +456,7 @@ if int():
 if int():
     a = 1
     b = ''
+[builtins fixtures/tuple.pyi]
 
 [case testMultipleAssignmentWithExtraParentheses]
 
@@ -496,6 +497,7 @@ if int():
     a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 if int():
     b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+[builtins fixtures/tuple.pyi]
 
 [case testMultipleAssignmentWithMixedVariables]
 a = b, c = 1, 1
@@ -506,6 +508,7 @@ d, e = f, g, h = 1, 1 # E: Need more than 2 values to unpack (3 expected)
 
 -- Assignment to starred expressions
 -- ---------------------------------
+[builtins fixtures/tuple.pyi]
 
 
 [case testAssignmentToStarMissingAnnotation]
@@ -697,6 +700,7 @@ if int():
 class A: pass
 class B: pass
 class C: pass
+[builtins fixtures/tuple.pyi]
 
 [case testNestedTupleAssignment2]
 
@@ -732,6 +736,7 @@ class C: pass
 
 -- Error messages
 -- --------------
+[builtins fixtures/tuple.pyi]
 
 
 [case testTupleErrorMessages]
@@ -888,6 +893,7 @@ B()[100]
 [case testValidTupleBaseClass]
 from typing import Tuple
 class A(tuple): pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testTupleBaseClass2]
@@ -960,18 +966,21 @@ from typing import Container
 a = None  # type: Container[str]
 a = ()
 [typing fixtures/typing-full.pyi]
+[builtins fixtures/tuple.pyi]
 
 [case testSubtypingTupleIsSized]
 from typing import Sized
 a = None  # type: Sized
 a = ()
 [typing fixtures/typing-medium.pyi]
+[builtins fixtures/tuple.pyi]
 
 [case testTupleWithStarExpr1]
 
 a = (1, 2)
 b = (*a, '')
 reveal_type(b)  # N: Revealed type is 'Tuple[builtins.int, builtins.int, builtins.str]'
+[builtins fixtures/tuple.pyi]
 
 [case testTupleWithStarExpr2]
 a = [1]
@@ -1194,6 +1203,7 @@ x: Iterable[int] = ()
 y: Tuple[int, int] = (1, 2)
 x = y
 reveal_type(x) # N: Revealed type is 'Tuple[builtins.int, builtins.int]'
+[builtins fixtures/tuple.pyi]
 
 [case testTupleOverlapDifferentTuples]
 from typing import Optional, Tuple

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -504,11 +504,11 @@ a = b, c = 1, 1
 x, y = p, q = 1, 1
 u, v, w = r, s = 1, 1 # E: Need more than 2 values to unpack (3 expected)
 d, e = f, g, h = 1, 1 # E: Need more than 2 values to unpack (3 expected)
+[builtins fixtures/tuple.pyi]
 
 
 -- Assignment to starred expressions
 -- ---------------------------------
-[builtins fixtures/tuple.pyi]
 
 
 [case testAssignmentToStarMissingAnnotation]
@@ -732,11 +732,11 @@ if int():
 class A: pass
 class B: pass
 class C: pass
+[builtins fixtures/tuple.pyi]
 
 
 -- Error messages
 -- --------------
-[builtins fixtures/tuple.pyi]
 
 
 [case testTupleErrorMessages]

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -14,6 +14,7 @@ f(1)
 f('')
 f(()) # E: Argument 1 to "f" has incompatible type "Tuple[]"; expected "Union[int, str]"
 [targets __main__, __main__.f]
+[builtins fixtures/tuple.pyi]
 
 [case testTupleTypeAlias]
 from typing import Tuple
@@ -22,6 +23,7 @@ def f(x: T) -> None: pass
 f((1, 'x'))
 f(1) # E: Argument 1 to "f" has incompatible type "int"; expected "Tuple[int, str]"
 [targets __main__, __main__.f]
+[builtins fixtures/tuple.pyi]
 
 [case testCallableTypeAlias]
 from typing import Callable
@@ -86,6 +88,7 @@ if int():
     A = Union[T, int]  # E: Cannot assign multiple types to name "A" without an explicit "Type[...]" annotation \
                    # E: Value of type "int" is not indexable
                    # the second error is because of `Union = 0` in lib-stub/typing.pyi
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testProhibitUsingVariablesAsTypesAndAllowAliasesAsTypes]
@@ -180,6 +183,7 @@ def f(p: 'Alias[str]') -> None:
 reveal_type(f) # N: Revealed type is 'def (p: Tuple[builtins.int, builtins.str])'
 T = TypeVar('T')
 Alias = Tuple[int, T]
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testRecursiveAliasesErrors1]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1472,6 +1472,7 @@ f4(**a) # E: Extra argument "y" from **args for "f4"
 f5(**a) # E: Too few arguments for "f5"
 f6(**a) # E: Extra argument "y" from **args for "f6"
 f1(1, **a) # E: "f1" gets multiple values for keyword argument "x"
+[builtins fixtures/tuple.pyi]
 
 [case testTypedDictAsStarStarArgConstraints]
 from typing import TypeVar, Union
@@ -1484,6 +1485,7 @@ def f1(x: T, y: S) -> Union[T, S]: ...
 A = TypedDict('A', {'y': int, 'x': str})
 a: A
 reveal_type(f1(**a)) # N: Revealed type is 'Union[builtins.str*, builtins.int*]'
+[builtins fixtures/tuple.pyi]
 
 [case testTypedDictAsStarStarArgCalleeKwargs]
 from mypy_extensions import TypedDict
@@ -1528,6 +1530,7 @@ f1(**a, **c) # E: "f1" gets multiple values for keyword argument "x" \
              # E: Argument "x" to "f1" has incompatible type "str"; expected "int"
 f1(**c, **a) # E: "f1" gets multiple values for keyword argument "x" \
              # E: Argument "x" to "f1" has incompatible type "str"; expected "int"
+[builtins fixtures/tuple.pyi]
 
 [case testTypedDictNonMappingMethods]
 from typing import List

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -586,6 +586,7 @@ from typing import Sequence, Iterable, TypeVar
 S = TypeVar('S', Sequence, Iterable)
 def my_len(s: S) -> None: pass
 def crash() -> None: my_len((0,))
+[builtins fixtures/tuple.pyi]
 
 [case testReferenceToDecoratedFunctionAndTypeVarValues]
 from typing import TypeVar, Callable

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -523,6 +523,7 @@ reveal_type(a1)  # N: Revealed type is 'builtins.float'
 b: Union[Tuple[int], Tuple[str]]
 (b1,) = b
 reveal_type(b1)  # N: Revealed type is 'Union[builtins.int, builtins.str]'
+[builtins fixtures/tuple.pyi]
 
 [case testUnionMultiassignDouble]
 from typing import Union, Tuple
@@ -531,6 +532,7 @@ c: Union[Tuple[int, int], Tuple[int, float]]
 (c1, c2) = c
 reveal_type(c1)  # N: Revealed type is 'builtins.int'
 reveal_type(c2)  # N: Revealed type is 'builtins.float'
+[builtins fixtures/tuple.pyi]
 
 [case testUnionMultiassignGeneric]
 from typing import Union, Tuple, TypeVar
@@ -543,6 +545,7 @@ def pack_two(x: T, y: S) -> Union[Tuple[T, T], Tuple[S, S]]:
 (x, y) = pack_two(1, 'a')
 reveal_type(x)  # N: Revealed type is 'Union[builtins.int*, builtins.str*]'
 reveal_type(y)  # N: Revealed type is 'Union[builtins.int*, builtins.str*]'
+[builtins fixtures/tuple.pyi]
 
 [case testUnionMultiassignAny]
 from typing import Union, Tuple, Any
@@ -554,6 +557,7 @@ reveal_type(d2)  # N: Revealed type is 'Union[Any, builtins.float]'
 
 e: Union[Any, Tuple[float, float], int]
 (e1, e2) = e  # E: 'builtins.int' object is not iterable
+[builtins fixtures/tuple.pyi]
 
 [case testUnionMultiassignNotJoin]
 from typing import Union, List
@@ -609,6 +613,7 @@ d1: object
 (d1, d2) = d
 reveal_type(d1)  # N: Revealed type is 'builtins.int'
 reveal_type(d2)  # N: Revealed type is 'builtins.float'
+[builtins fixtures/tuple.pyi]
 
 [case testUnionMultiassignIndexed]
 from typing import Union, Tuple, List

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1033,6 +1033,7 @@ def f_no_suppress_5() -> int:
     noop()                  # E: Statement is unreachable
 
 [typing fixtures/typing-medium.pyi]
+[builtins fixtures/tuple.pyi]
 
 [case testUnreachableFlagContextManagersSuppressed]
 # flags: --warn-unreachable
@@ -1079,6 +1080,7 @@ def f_mix() -> int:         # E: Missing return statement
         return 3
     noop()
 [typing fixtures/typing-medium.pyi]
+[builtins fixtures/tuple.pyi]
 
 [case testUnreachableFlagContextManagersSuppressedNoStrictOptional]
 # flags: --warn-unreachable --no-strict-optional
@@ -1120,6 +1122,7 @@ def f_suppress() -> int:  # E: Missing return statement
         return 3
     noop()
 [typing fixtures/typing-medium.pyi]
+[builtins fixtures/tuple.pyi]
 
 [case testUnreachableFlagContextAsyncManagersNoSuppress]
 # flags: --warn-unreachable --python-version 3.7
@@ -1185,6 +1188,7 @@ async def f_no_suppress_5() -> int:
     noop()                  # E: Statement is unreachable
 
 [typing fixtures/typing-full.pyi]
+[builtins fixtures/tuple.pyi]
 
 [case testUnreachableFlagContextAsyncManagersSuppressed]
 # flags: --warn-unreachable --python-version 3.7
@@ -1231,6 +1235,7 @@ async def f_mix() -> int:         # E: Missing return statement
         return 3
     noop()
 [typing fixtures/typing-full.pyi]
+[builtins fixtures/tuple.pyi]
 
 [case testUnreachableFlagContextAsyncManagersAbnormal]
 # flags: --warn-unreachable --python-version 3.7
@@ -1282,3 +1287,4 @@ async def f_malformed_2() -> int:
     noop()                  # E: Statement is unreachable
 
 [typing fixtures/typing-full.pyi]
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -465,6 +465,7 @@ foo(*())
 
 -- Overloads + varargs
 -- -------------------
+[builtins fixtures/tuple.pyi]
 
 
 [case testIntersectionTypesAndVarArgs]

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -462,10 +462,10 @@ def foo() -> None:
     pass
 
 foo(*())
+[builtins fixtures/tuple.pyi]
 
 -- Overloads + varargs
 -- -------------------
-[builtins fixtures/tuple.pyi]
 
 
 [case testIntersectionTypesAndVarArgs]

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -173,6 +173,7 @@ typ = Tuple[int, int, int, int, int, int, int, int, int, int, int, int, int,
             int, int, int, int, int, int, int, int, int, int, int, int, int]
 def g() -> Any: pass
 def f() -> typ: return g()
+[builtins fixtures/tuple.pyi]
 [out]
 main:11: error: Returning Any from function declared to return <tuple: 91 items>
 

--- a/test-data/unit/deps-classes.test
+++ b/test-data/unit/deps-classes.test
@@ -16,6 +16,7 @@ def f(a: Any) -> None:
     n.a
 [file a.py]
 class A: pass
+[builtins fixtures/tuple.pyi]
 [out]
 <m.N.__init__> -> m.f
 <m.N.__new__> -> m.f
@@ -35,6 +36,7 @@ def f(a: Any) -> None:
 [file a.py]
 class A: pass
 class B: pass
+[builtins fixtures/tuple.pyi]
 [out]
 <m.N.__init__> -> m.f
 <m.N.__new__> -> m.f
@@ -50,6 +52,7 @@ N = NamedTuple('N', [('x', int)])
 x = N(1)
 M = NamedTuple('M', [('z', 'N')])
 y = M(x)
+[builtins fixtures/tuple.pyi]
 [out]
 <m.M.__init__> -> m
 <m.M.__new__> -> m
@@ -71,6 +74,7 @@ def f(a: Any) -> None:
     n.a
 [file a.py]
 class A: pass
+[builtins fixtures/tuple.pyi]
 [out]
 <m.N.__init__> -> m.f
 <m.N.__new__> -> m.f

--- a/test-data/unit/deps-expressions.test
+++ b/test-data/unit/deps-expressions.test
@@ -459,6 +459,7 @@ b = a
 def f(x: Alias) -> None: pass
 def g() -> Literal[1]:
     return b
+[builtins fixtures/tuple.pyi]
 [out]
 <m.Alias> -> <m.f>, m, m.f
 <m.a> -> m

--- a/test-data/unit/deps-generics.test
+++ b/test-data/unit/deps-generics.test
@@ -126,6 +126,7 @@ T = TypeVar('T', bound=Tuple[A, B])
 
 def f(x: T) -> T:
     return x
+[builtins fixtures/tuple.pyi]
 [out]
 <m.A> -> <m.T>, <m.f>, m, m.A, m.f
 <m.B> -> <m.T>, <m.f>, m, m.B, m.f

--- a/test-data/unit/deps-types.test
+++ b/test-data/unit/deps-types.test
@@ -20,6 +20,7 @@ class B: pass
 
 def f(x: Tuple[A, B]) -> None:
     pass
+[builtins fixtures/tuple.pyi]
 [out]
 <m.A> -> <m.f>, m.A, m.f
 <m.B> -> <m.f>, m.B, m.f
@@ -844,6 +845,7 @@ class P(NamedTuple):
     x: A
 [file mod.py]
 class I: pass
+[builtins fixtures/tuple.pyi]
 [out]
 <m.A> -> m
 <m.P> -> m.P
@@ -862,6 +864,7 @@ from mod import I
 A = I
 [file mod.py]
 class I: pass
+[builtins fixtures/tuple.pyi]
 [out]
 <a.A> -> m
 <a> -> m

--- a/test-data/unit/diff.test
+++ b/test-data/unit/diff.test
@@ -273,6 +273,7 @@ M = NamedTuple('M', [('x', int), ('y', str)])
 from typing import NamedTuple
 N = NamedTuple('N', [('x', int), ('y', int)])
 M = NamedTuple('M', [('x', int), ('y', str)])
+[builtins fixtures/tuple.pyi]
 [out]
 __main__.A
 __main__.N
@@ -1180,6 +1181,7 @@ class C:
         self.y_instance: Literal[1] = 1
         self.z_instance: Literal[2] = 2
         self.same_instance: Literal[1] = 1
+[builtins fixtures/tuple.pyi]
 [out]
 __main__.C.x_class
 __main__.C.x_instance
@@ -1440,6 +1442,7 @@ class C:
     def method_same(self, x: Literal[1]) -> int: ...
     def method_same(self, x):
         pass
+[builtins fixtures/tuple.pyi]
 [out]
 __main__.C.method
 __main__.func
@@ -1450,6 +1453,7 @@ x: Literal[1, '2']
 [file next.py]
 from typing_extensions import Literal
 x: Literal[1, 2]
+[builtins fixtures/tuple.pyi]
 [out]
 __main__.x
 
@@ -1463,5 +1467,6 @@ from typing import Callable, Union
 from mypy_extensions import Arg
 x: Union[Callable[[Arg(int, 'y')], None],
          Callable[[int], None]]
+[builtins fixtures/tuple.pyi]
 [out]
 __main__.x

--- a/test-data/unit/fine-grained-blockers.test
+++ b/test-data/unit/fine-grained-blockers.test
@@ -406,7 +406,6 @@ import blocker
 import sys
 1()
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 a.py:1: error: invalid syntax

--- a/test-data/unit/fine-grained-blockers.test
+++ b/test-data/unit/fine-grained-blockers.test
@@ -405,6 +405,8 @@ import blocker
 [file a.py.4]
 import sys
 1()
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 a.py:1: error: invalid syntax

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -744,6 +744,7 @@ a.x = 0
 [file a.py.2]
 import sys
 x = sys.platform
+[builtins fixtures/tuple.pyi]
 [out]
 main:1: error: Cannot find implementation or library stub for module named 'a'
 main:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
@@ -808,6 +809,8 @@ class Bar:
 class Baz:
     pass
 [delete c.py.2]
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -810,7 +810,6 @@ class Baz:
     pass
 [delete c.py.2]
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 

--- a/test-data/unit/fine-grained-suggest.test
+++ b/test-data/unit/fine-grained-suggest.test
@@ -141,6 +141,7 @@ No guesses that match criteria!
 [file foo.py]
 def foo():
     return 1, "1"
+[builtins fixtures/tuple.pyi]
 [out]
 () -> Tuple[int, str]
 ==
@@ -152,6 +153,7 @@ from typing import NamedTuple
 N = NamedTuple('N', [('x', int)])
 def foo():
     return N(1)
+[builtins fixtures/tuple.pyi]
 [out]
 () -> foo.N
 ==
@@ -200,6 +202,7 @@ class B: ...
 from foo import foo
 from baz import B
 foo(B())
+[builtins fixtures/tuple.pyi]
 
 [out]
 (baz.B) -> Tuple[foo.A, foo:A.C]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1717,6 +1717,8 @@ N = NamedTuple('N', [('x', int)])
 [file a.py]
 def f() -> None: pass
 [file a.py.2]
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 main:2: error: Module 'a' has no attribute 'f'
@@ -3302,6 +3304,8 @@ class C(N):
 x = 0
 [file m.py.2]
 x = ''
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -3410,6 +3414,8 @@ a: A
 def g() -> None:
     x = L(A())
     x.f(a)
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -3477,6 +3483,8 @@ import a
 def f(x: a.N) -> None:
     pass
 f(a.x)
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -3495,6 +3503,8 @@ import a
 def f(x: a.N) -> None:
     pass
 f(a.x)
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -3523,6 +3533,8 @@ def f(x: b.M) -> None:
     lol(x)
 f(b.x)
 lol(b.x)
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 c.py:7: error: Argument 1 to "lol" has incompatible type "M"; expected "Tuple[Tuple[int]]"
@@ -3545,6 +3557,8 @@ import a
 def f(x: a.N) -> None:
     pass
 f(a.x)
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -4364,6 +4378,8 @@ def f() -> None:
 x = 0
 [file b.py.2]
 x = ''
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -4440,6 +4456,8 @@ def unchecked():
     def inner():
         # type: () -> (str, int)
         return 'lol', 10
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -4454,6 +4472,7 @@ def inner():
 def inner():
     # type: () -> (str, int)
     return 'lol', 10
+[builtins fixtures/tuple.pyi]
 [out]
 a.py:1: error: Syntax error in type annotation
 a.py:1: note: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
@@ -4468,6 +4487,8 @@ import a
 [file a.py.2]
 # dummy change
 (x, y) = 1, 'hi'  # type: (int, str)
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -5814,6 +5835,8 @@ def f() -> Tuple[int, object]: pass
 [file b.py.3]
 from typing import Tuple
 def f() -> Tuple[str, int]: pass
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 a.py:10: error: Argument 1 to "h" has incompatible type "int"; expected "str"
@@ -8002,6 +8025,8 @@ def deco(func: F) -> F:  # type: ignore
 def test(x: int, y: int) -> str:
     pass
 x = 1
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -8406,6 +8431,8 @@ NT = NamedTuple('NT', [('x', B)])
 [file b.py.2]
 def func(x): pass
 B = func
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 main:5: error: Variable "b.B" is not valid as a type
@@ -8422,6 +8449,8 @@ A = B
 [file b.py.2]
 def func(x): pass
 B = func
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 main:5: error: Variable "a.A" is not valid as a type
@@ -8448,6 +8477,8 @@ A = B
 [file b.py.2]
 def func(x): pass
 B = func
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 m.py:4: error: Variable "a.A" is not valid as a type
@@ -8496,6 +8527,7 @@ x: Literal[1] = 1
 [file mod.py.3]
 from typing_extensions import Literal
 x: Literal[1] = 2
+[builtins fixtures/tuple.pyi]
 [out]
 main:2: note: Revealed type is 'builtins.int'
 ==
@@ -8515,6 +8547,8 @@ def foo(x: Literal[3]) -> None: pass
 [file mod.py.3]
 from typing_extensions import Literal
 def foo(x: Literal[4]) -> None: pass
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 ==
@@ -8531,6 +8565,8 @@ Alias = Literal[1]
 [file mod.py.3]
 from typing_extensions import Literal
 Alias = Literal[2]
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 ==
@@ -8557,6 +8593,7 @@ def foo(x: int) -> str: ...
 @overload
 def foo(x: Literal['bar']) -> int: ...
 def foo(x): pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:2: note: Revealed type is 'builtins.str'
 ==
@@ -8578,6 +8615,8 @@ qux: Literal[3]
 [file mod3.py.2]
 from typing_extensions import Literal
 qux: Literal[4]
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 main:4: error: Argument 1 to "expect_3" has incompatible type "Literal[4]"; expected "Literal[3]"
@@ -8600,6 +8639,8 @@ Alias3 = Literal[3]
 [file mod3.py.2]
 from typing_extensions import Literal
 Alias3 = Literal[4]
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 main:5: error: Argument 1 to "expect_3" has incompatible type "Literal[4]"; expected "Literal[3]"
@@ -8620,6 +8661,8 @@ def func3() -> Literal[3]: pass
 [file mod3.py.2]
 from typing_extensions import Literal
 def func3() -> Literal[4]: pass
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 main:4: error: Argument 1 to "expect_3" has incompatible type "Literal[4]"; expected "Literal[3]"
@@ -8638,6 +8681,7 @@ bar = 3
 [file mod2.py.2]
 from typing_extensions import Literal
 bar: Literal[3] = 3
+[builtins fixtures/tuple.pyi]
 [out]
 main:2: note: Revealed type is 'builtins.int*'
 ==
@@ -8663,6 +8707,8 @@ qux: Final = 4
 [file mod3.py.3]
 from typing_extensions import Final
 qux: Final[int] = 4
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 main:4: error: Argument 1 to "expect_3" has incompatible type "Literal[4]"; expected "Literal[3]"
@@ -8684,6 +8730,7 @@ def bar() -> Literal[u"foo"]: pass
 [file mod2.py.3]
 from typing_extensions import Literal
 def bar() -> Literal[b"foo"]: pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:2: note: Revealed type is 'Literal['foo']'
 ==
@@ -8765,6 +8812,8 @@ def f(x: Union[int, str]) -> None: ...
 
 [targets2 c, b]
 [targets3 a]
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 ==
@@ -8830,6 +8879,8 @@ B().x
 
 [targets2 c, b]
 [targets3 a]
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 ==
@@ -8868,6 +8919,8 @@ B().x
 
 [targets2 c, b]
 [targets3 a]
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 ==
 ==

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -4400,9 +4400,9 @@ x = 0
 x = ''
 [builtins fixtures/tuple.pyi]
 [out]
-b.py:5: error: Incompatible types in assignment (expression has type "int", base class "tuple" defined the type as "Callable[[Tuple[int, ...], Any], int]")
+b.py:5: error: Incompatible types in assignment (expression has type "int", base class "tuple" defined the type as "Callable[[Tuple[int, ...], object], int]")
 ==
-b.py:5: error: Incompatible types in assignment (expression has type "int", base class "tuple" defined the type as "Callable[[Tuple[int, ...], Any], int]")
+b.py:5: error: Incompatible types in assignment (expression has type "int", base class "tuple" defined the type as "Callable[[Tuple[int, ...], object], int]")
 
 [case testReprocessEllipses1]
 import a

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1718,7 +1718,6 @@ N = NamedTuple('N', [('x', int)])
 def f() -> None: pass
 [file a.py.2]
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 main:2: error: Module 'a' has no attribute 'f'
@@ -3305,7 +3304,6 @@ x = 0
 [file m.py.2]
 x = ''
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -3415,7 +3413,6 @@ def g() -> None:
     x = L(A())
     x.f(a)
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -3484,7 +3481,6 @@ def f(x: a.N) -> None:
     pass
 f(a.x)
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -3503,7 +3499,6 @@ import a
 def f(x: a.N) -> None:
     pass
 f(a.x)
-[builtins fixtures/tuple.pyi]
 [builtins fixtures/tuple.pyi]
 [out]
 ==
@@ -3534,7 +3529,6 @@ def f(x: b.M) -> None:
 f(b.x)
 lol(b.x)
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 c.py:7: error: Argument 1 to "lol" has incompatible type "M"; expected "Tuple[Tuple[int]]"
@@ -3557,7 +3551,6 @@ import a
 def f(x: a.N) -> None:
     pass
 f(a.x)
-[builtins fixtures/tuple.pyi]
 [builtins fixtures/tuple.pyi]
 [out]
 ==
@@ -4379,7 +4372,6 @@ x = 0
 [file b.py.2]
 x = ''
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -4457,7 +4449,6 @@ def unchecked():
         # type: () -> (str, int)
         return 'lol', 10
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -4487,7 +4478,6 @@ import a
 [file a.py.2]
 # dummy change
 (x, y) = 1, 'hi'  # type: (int, str)
-[builtins fixtures/tuple.pyi]
 [builtins fixtures/tuple.pyi]
 [out]
 ==
@@ -5835,7 +5825,6 @@ def f() -> Tuple[int, object]: pass
 [file b.py.3]
 from typing import Tuple
 def f() -> Tuple[str, int]: pass
-[builtins fixtures/tuple.pyi]
 [builtins fixtures/tuple.pyi]
 [out]
 ==
@@ -8026,7 +8015,6 @@ def test(x: int, y: int) -> str:
     pass
 x = 1
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 
@@ -8432,7 +8420,6 @@ NT = NamedTuple('NT', [('x', B)])
 def func(x): pass
 B = func
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 main:5: error: Variable "b.B" is not valid as a type
@@ -8449,7 +8436,6 @@ A = B
 [file b.py.2]
 def func(x): pass
 B = func
-[builtins fixtures/tuple.pyi]
 [builtins fixtures/tuple.pyi]
 [out]
 ==
@@ -8477,7 +8463,6 @@ A = B
 [file b.py.2]
 def func(x): pass
 B = func
-[builtins fixtures/tuple.pyi]
 [builtins fixtures/tuple.pyi]
 [out]
 ==
@@ -8548,7 +8533,6 @@ def foo(x: Literal[3]) -> None: pass
 from typing_extensions import Literal
 def foo(x: Literal[4]) -> None: pass
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 ==
@@ -8565,7 +8549,6 @@ Alias = Literal[1]
 [file mod.py.3]
 from typing_extensions import Literal
 Alias = Literal[2]
-[builtins fixtures/tuple.pyi]
 [builtins fixtures/tuple.pyi]
 [out]
 ==
@@ -8616,7 +8599,6 @@ qux: Literal[3]
 from typing_extensions import Literal
 qux: Literal[4]
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 main:4: error: Argument 1 to "expect_3" has incompatible type "Literal[4]"; expected "Literal[3]"
@@ -8640,7 +8622,6 @@ Alias3 = Literal[3]
 from typing_extensions import Literal
 Alias3 = Literal[4]
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 main:5: error: Argument 1 to "expect_3" has incompatible type "Literal[4]"; expected "Literal[3]"
@@ -8661,7 +8642,6 @@ def func3() -> Literal[3]: pass
 [file mod3.py.2]
 from typing_extensions import Literal
 def func3() -> Literal[4]: pass
-[builtins fixtures/tuple.pyi]
 [builtins fixtures/tuple.pyi]
 [out]
 ==
@@ -8707,7 +8687,6 @@ qux: Final = 4
 [file mod3.py.3]
 from typing_extensions import Final
 qux: Final[int] = 4
-[builtins fixtures/tuple.pyi]
 [builtins fixtures/tuple.pyi]
 [out]
 ==
@@ -8813,7 +8792,6 @@ def f(x: Union[int, str]) -> None: ...
 [targets2 c, b]
 [targets3 a]
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 ==
@@ -8880,7 +8858,6 @@ B().x
 [targets2 c, b]
 [targets3 a]
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 ==
 ==
@@ -8919,7 +8896,6 @@ B().x
 
 [targets2 c, b]
 [targets3 a]
-[builtins fixtures/tuple.pyi]
 [builtins fixtures/tuple.pyi]
 [out]
 ==

--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -26,6 +26,7 @@ class int:
 class slice: pass
 class bool: pass
 class str: pass # For convenience
+class bytes: pass
 class unicode: pass
 
 T = TypeVar('T')

--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -5,26 +5,27 @@ from typing import Iterable, Iterator, TypeVar, Generic, Sequence, Any, overload
 Tco = TypeVar('Tco', covariant=True)
 
 class object:
-    def __init__(self): pass
+    def __init__(self) -> None: pass
 
 class type:
-    def __init__(self, *a) -> None: pass
-    def __call__(self, *a) -> object: pass
+    def __init__(self, *a: object) -> None: pass
+    def __call__(self, *a: object) -> object: pass
 class tuple(Sequence[Tco], Generic[Tco]):
     def __iter__(self) -> Iterator[Tco]: pass
     def __contains__(self, item: object) -> bool: pass
     def __getitem__(self, x: int) -> Tco: pass
-    def __rmul__(self, n: int) -> tuple: pass
+    def __rmul__(self, n: int) -> Tuple[Tco, ...]: pass
     def __add__(self, x: Tuple[Tco, ...]) -> Tuple[Tco, ...]: pass
-    def count(self, obj: Any) -> int: pass
+    def count(self, obj: object) -> int: pass
 class function: pass
 class ellipsis: pass
 
 # We need int and slice for indexing tuples.
 class int:
     def __neg__(self) -> 'int': pass
+class float: pass
 class slice: pass
-class bool: pass
+class bool(int): pass
 class str: pass # For convenience
 class bytes: pass
 class unicode: pass
@@ -36,6 +37,8 @@ class list(Sequence[T], Generic[T]):
     def __getitem__(self, i: int) -> T: ...
     @overload
     def __getitem__(self, s: slice) -> list[T]: ...
+    def __contains__(self, item: object) -> bool: ...
+    def __iter__(self) -> Iterator[T]: ...
 
 def isinstance(x: object, t: type) -> bool: pass
 

--- a/test-data/unit/lib-stub/builtins.pyi
+++ b/test-data/unit/lib-stub/builtins.pyi
@@ -2,9 +2,6 @@
 #
 # Use [builtins fixtures/...pyi] if you need more features.
 
-from typing import Generic, TypeVar
-_T = TypeVar('_T')
-
 class object:
     def __init__(self) -> None: pass
 
@@ -19,7 +16,6 @@ class float: pass
 class str: pass
 class bytes: pass
 
-class tuple(Generic[_T]): pass
 class function: pass
 class ellipsis: pass
 

--- a/test-data/unit/merge.test
+++ b/test-data/unit/merge.test
@@ -666,20 +666,20 @@ TypeInfo<0>(
 TypeInfo<2>(
   Name(target.N)
   Bases(builtins.tuple[target.A<0>]<3>)
-  Mro(target.N<2>, builtins.tuple<3>, builtins.object<1>)
+  Mro(target.N<2>, builtins.tuple<3>, typing.Sequence<4>, typing.Iterable<5>, builtins.object<1>)
   Names(
-    _NT<4>
-    __annotations__<5> (builtins.object<1>)
-    __doc__<6> (builtins.str<7>)
-    __new__<8>
-    _asdict<9>
-    _field_defaults<10> (builtins.object<1>)
-    _field_types<11> (builtins.object<1>)
-    _fields<12> (Tuple[builtins.str<7>])
-    _make<13>
-    _replace<14>
-    _source<15> (builtins.str<7>)
-    x<16> (target.A<0>)))
+    _NT<6>
+    __annotations__<7> (builtins.object<1>)
+    __doc__<8> (builtins.str<9>)
+    __new__<10>
+    _asdict<11>
+    _field_defaults<12> (builtins.object<1>)
+    _field_types<13> (builtins.object<1>)
+    _fields<14> (Tuple[builtins.str<9>])
+    _make<15>
+    _replace<16>
+    _source<17> (builtins.str<9>)
+    x<18> (target.A<0>)))
 ==>
 TypeInfo<0>(
   Name(target.A)
@@ -689,21 +689,21 @@ TypeInfo<0>(
 TypeInfo<2>(
   Name(target.N)
   Bases(builtins.tuple[target.A<0>]<3>)
-  Mro(target.N<2>, builtins.tuple<3>, builtins.object<1>)
+  Mro(target.N<2>, builtins.tuple<3>, typing.Sequence<4>, typing.Iterable<5>, builtins.object<1>)
   Names(
-    _NT<4>
-    __annotations__<5> (builtins.object<1>)
-    __doc__<6> (builtins.str<7>)
-    __new__<8>
-    _asdict<9>
-    _field_defaults<10> (builtins.object<1>)
-    _field_types<11> (builtins.object<1>)
-    _fields<12> (Tuple[builtins.str<7>, builtins.str<7>])
-    _make<13>
-    _replace<14>
-    _source<15> (builtins.str<7>)
-    x<16> (target.A<0>)
-    y<17> (target.A<0>)))
+    _NT<6>
+    __annotations__<7> (builtins.object<1>)
+    __doc__<8> (builtins.str<9>)
+    __new__<10>
+    _asdict<11>
+    _field_defaults<12> (builtins.object<1>)
+    _field_types<13> (builtins.object<1>)
+    _fields<14> (Tuple[builtins.str<9>, builtins.str<9>])
+    _make<15>
+    _replace<16>
+    _source<17> (builtins.str<9>)
+    x<18> (target.A<0>)
+    y<19> (target.A<0>)))
 
 [case testUnionType_types]
 import target

--- a/test-data/unit/merge.test
+++ b/test-data/unit/merge.test
@@ -656,6 +656,7 @@ N = NamedTuple('N', [('x', A)])
 from typing import NamedTuple
 class A: pass
 N = NamedTuple('N', [('x', A), ('y', A)])
+[builtins fixtures/tuple.pyi]
 [out]
 TypeInfo<0>(
   Name(target.A)
@@ -1093,6 +1094,7 @@ N = NamedTuple('N', [('x', int)])
 [file target.py]
 f = 1
 [file target.py.next]
+[builtins fixtures/tuple.pyi]
 [out]
 __main__:
     N: TypeInfo<0>
@@ -1454,6 +1456,7 @@ bar: Literal[4] = 4
 from typing_extensions import Literal
 def foo(x: Literal['3']) -> Literal['b']: pass
 bar: Literal[5] = 5
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1<0>(
   tmp/main

--- a/test-data/unit/semanal-classvar.test
+++ b/test-data/unit/semanal-classvar.test
@@ -132,6 +132,7 @@ main:2: error: Invalid type: ClassVar nested inside other type
 [case testTupleClassVar]
 from typing import ClassVar, Tuple
 x = None  # type: Tuple[ClassVar, int]
+[builtins fixtures/tuple.pyi]
 [out]
 main:2: error: Invalid type: ClassVar nested inside other type
 

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -116,6 +116,7 @@ def f() -> A[B[int]]: pass # E: "B" expects no type arguments, but 1 given
 from typing import Tuple
 class A: pass
 x = None # type: Tuple[A[int]] # E: "A" expects no type arguments, but 1 given
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testInvalidNumberOfGenericArgsInFunctionType]
@@ -908,26 +909,32 @@ A[1] # E: Invalid type: try using Literal[1] instead?
 
 [case testVariableDeclWithInvalidNumberOfTypes]
 x, y = 1, 2 # type: int, str, int # E: Incompatible number of tuple items
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testVariableDeclWithInvalidNumberOfTypesNested]
 x, (y, z) = 1, (2, 3) # type: int, (str, int, int) # E: Incompatible number of tuple items
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testVariableDeclWithInvalidNumberOfTypesNested2]
 x, (y, z) = 1, (2, 3) # type: int, (str, ) # E: Incompatible number of tuple items
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testVariableDeclWithInvalidNumberOfTypesNested3]
 x, (y, z) = 1, (2, 3) # type: int, str # E: Tuple type expected for multiple variables
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testVariableDeclWithInvalidNumberOfTypesNested4]
 x, (y, z) = 1, (2, 3) # type: int, str, int # E: Incompatible number of tuple items
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testVariableDeclWithInvalidNumberOfTypesNested5]
 x, (y, ) = 1, (2, ) # type: int, str # E: Tuple type expected for multiple variables
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testVariableDeclWithInvalidType]
@@ -952,6 +959,7 @@ a.y, a.x = None, None # type: int, int \
     # E: Type cannot be declared in assignment to non-self attribute
 a[1], a[2] = None, None # type: int, int \
     # E: Unexpected type declaration
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testMissingGenericImport]
@@ -1318,6 +1326,7 @@ from typing import Tuple
 a = 1  # type: int
 a = 's'  # type: str
 a = ('spam', 'spam', 'eggs', 'spam')  # type: Tuple[str]
+[builtins fixtures/tuple.pyi]
 
 [out]
 main:3: error: Name 'a' already defined on line 2
@@ -1367,6 +1376,7 @@ N = NamedTuple('N', [('a', int),
 
 class N:  # E: Name 'N' already defined on line 2
     pass
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testDuplicateDefTypedDict]

--- a/test-data/unit/semanal-namedtuple.test
+++ b/test-data/unit/semanal-namedtuple.test
@@ -166,10 +166,10 @@ N = namedtuple('N', ['x', 1]) # E: String literal expected as namedtuple() item
 [case testNamedTupleWithUnderscoreItemName]
 from collections import namedtuple
 N = namedtuple('N', ['_fallback']) # E: namedtuple() field names cannot start with an underscore: _fallback
+[builtins fixtures/tuple.pyi]
 
 -- NOTE: The following code works at runtime but is not yet supported by mypy.
 --       Keyword arguments may potentially be supported in the future.
-[builtins fixtures/tuple.pyi]
 [case testNamedTupleWithNonpositionalArgs]
 from collections import namedtuple
 N = namedtuple(typename='N', field_names=['x']) # E: Unexpected arguments to namedtuple()

--- a/test-data/unit/semanal-namedtuple.test
+++ b/test-data/unit/semanal-namedtuple.test
@@ -4,6 +4,7 @@
 from collections import namedtuple
 N = namedtuple('N', ['a'])
 def f() -> N: pass
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(collections, [namedtuple])
@@ -20,6 +21,7 @@ MypyFile:1(
 from collections import namedtuple
 N = namedtuple('N', ['a', 'xyz'])
 def f() -> N: pass
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(collections, [namedtuple])
@@ -36,6 +38,7 @@ MypyFile:1(
 from collections import namedtuple
 N = namedtuple('N', ('a', 'xyz'))
 def f() -> N: pass
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(collections, [namedtuple])
@@ -52,6 +55,7 @@ MypyFile:1(
 from collections import namedtuple
 N = namedtuple('N', ' a  xyz ')
 def f() -> N: pass
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(collections, [namedtuple])
@@ -68,6 +72,7 @@ MypyFile:1(
 from typing import NamedTuple
 N = NamedTuple('N', [('a', int),
                      ('b', str)])
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [NamedTuple])
@@ -79,6 +84,7 @@ MypyFile:1(
 from typing import NamedTuple
 N = NamedTuple('N', (('a', int),
                      ('b', str)))
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [NamedTuple])
@@ -90,6 +96,7 @@ MypyFile:1(
 from collections import namedtuple
 N = namedtuple('N', ['x'])
 class A(N): pass
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(collections, [namedtuple])
@@ -107,6 +114,7 @@ MypyFile:1(
 [case testNamedTupleBaseClass2]
 from collections import namedtuple
 class A(namedtuple('N', ['x'])): pass
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(collections, [namedtuple])
@@ -121,6 +129,7 @@ MypyFile:1(
 [case testNamedTupleBaseClassWithItemTypes]
 from typing import NamedTuple
 class A(NamedTuple('N', [('x', int)])): pass
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [NamedTuple])
@@ -137,18 +146,22 @@ MypyFile:1(
 [case testNamedTupleWithTooFewArguments]
 from collections import namedtuple
 N = namedtuple('N') # E: Too few arguments for namedtuple()
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleWithInvalidName]
 from collections import namedtuple
 N = namedtuple(1, ['x']) # E: namedtuple() expects a string literal as the first argument
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleWithInvalidItems]
 from collections import namedtuple
 N = namedtuple('N', 1) # E: List or tuple literal expected as the second argument to namedtuple()
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleWithInvalidItems2]
 from collections import namedtuple
 N = namedtuple('N', ['x', 1]) # E: String literal expected as namedtuple() item
+[builtins fixtures/tuple.pyi]
 
 [case testNamedTupleWithUnderscoreItemName]
 from collections import namedtuple
@@ -156,14 +169,17 @@ N = namedtuple('N', ['_fallback']) # E: namedtuple() field names cannot start wi
 
 -- NOTE: The following code works at runtime but is not yet supported by mypy.
 --       Keyword arguments may potentially be supported in the future.
+[builtins fixtures/tuple.pyi]
 [case testNamedTupleWithNonpositionalArgs]
 from collections import namedtuple
 N = namedtuple(typename='N', field_names=['x']) # E: Unexpected arguments to namedtuple()
+[builtins fixtures/tuple.pyi]
 
 [case testInvalidNamedTupleBaseClass]
 from typing import NamedTuple
 class A(NamedTuple('N', [1])): pass # E: Tuple expected as NamedTuple() field
 class B(A): pass
+[builtins fixtures/tuple.pyi]
 
 [case testInvalidNamedTupleBaseClass2]
 

--- a/test-data/unit/semanal-typealiases.test
+++ b/test-data/unit/semanal-typealiases.test
@@ -171,6 +171,7 @@ MypyFile:1(
 from typing import Tuple
 T = Tuple[int, str]
 def f(x: T) -> None: pass
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Tuple])
@@ -430,6 +431,7 @@ MypyFile:1(
 from typing import Union, Tuple, Any
 A = Union['int', Tuple[int, Any]]
 a = 1 # type: A
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Union, Tuple, Any])

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -148,7 +148,6 @@ class B: pass
 a, b = None, None # type: (A, B)
 x = a, b
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ClassDef:2(
@@ -361,7 +360,6 @@ MypyFile:1(
 from typing import Tuple, cast
 cast(Tuple[int, str], None)
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Tuple, cast])
@@ -468,7 +466,6 @@ from typing import TypeVar, Tuple, Generic
 t = TypeVar('t')
 class A(Generic[t]): pass
 def f(x: Tuple[int, t]) -> None: pass
-[builtins fixtures/tuple.pyi]
 [builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
@@ -707,7 +704,6 @@ MypyFile:1(
 [case testInvalidTupleType]
 from typing import Tuple
 t = None # type: Tuple[int, str, ...] # E: Unexpected '...'
-[builtins fixtures/tuple.pyi]
 [builtins fixtures/tuple.pyi]
 [out]
 

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -147,6 +147,8 @@ class A: pass
 class B: pass
 a, b = None, None # type: (A, B)
 x = a, b
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ClassDef:2(
@@ -358,6 +360,8 @@ MypyFile:1(
 [case testCastToTupleType]
 from typing import Tuple, cast
 cast(Tuple[int, str], None)
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [Tuple, cast])
@@ -464,6 +468,8 @@ from typing import TypeVar, Tuple, Generic
 t = TypeVar('t')
 class A(Generic[t]): pass
 def f(x: Tuple[int, t]) -> None: pass
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [TypeVar, Tuple, Generic])
@@ -701,6 +707,8 @@ MypyFile:1(
 [case testInvalidTupleType]
 from typing import Tuple
 t = None # type: Tuple[int, str, ...] # E: Unexpected '...'
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/tuple.pyi]
 [out]
 
 [case testFunctionTypes]

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -906,6 +906,7 @@ class A:
 
     def f(self, *args) -> None: pass
 A.f
+[builtins fixtures/tuple.pyi]
 [out]
 MemberExpr(10) : Overload(def (self: A), def (self: A, builtins.object))
 
@@ -920,6 +921,7 @@ class A:
 
     def f(self, *args): pass
 A.f
+[builtins fixtures/tuple.pyi]
 [out]
 MemberExpr(10) : Overload(def (self: A) -> Any, def (self: A, Any) -> Any)
 
@@ -974,6 +976,7 @@ class A(Generic[t]):
 
 ab, b = None, None # type: (A[B], B)
 A.f(ab, b)
+[builtins fixtures/tuple.pyi]
 [out]
 CallExpr(13) : B
 


### PR DESCRIPTION
This removes `tuple` from the default builtins test stubs, which seems to 
speed up fast tests by about 7%.

Also improved error messages that are generated when a test case is
missing the right fixture.

I didn't update Python 2 test stubs since they aren't used in many tests.

Fixes #6428 (except for Python 2 which doesn't seem important).