### PR TITLE
stubtest: various fixes

### DIFF
--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -191,8 +191,7 @@ def build_stubs(options: Options,
                 mod: str) -> Dict[str, nodes.MypyFile]:
     sources = find_module_cache.find_modules_recursive(mod)
     try:
-        res = build.build(sources=sources,
-                          options=options)
+        res = build.build(sources=sources, options=options)
         messages = res.errors
     except CompileError as error:
         messages = error.messages
@@ -212,6 +211,7 @@ def main(args: List[str]) -> Iterator[Error]:
         modules = args[1:]
 
     options = Options()
+    options.incremental = False
     data_dir = default_data_dir()
     search_path = compute_search_paths([], options, data_dir)
     find_module_cache = FindModuleCache(search_path)

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -212,7 +212,6 @@ def main(args: List[str]) -> Iterator[Error]:
         modules = args[1:]
 
     options = Options()
-    options.python_version = (3, 6)
     data_dir = default_data_dir()
     search_path = compute_search_paths([], options, data_dir)
     find_module_cache = FindModuleCache(search_path)

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -181,6 +181,13 @@ def verify_decorator(node: nodes.Decorator,
         yield None
 
 
+@verify.register(nodes.TypeAlias)
+def verify_typealias(node: nodes.TypeAlias,
+                     module_node: Optional[DumpNode]) -> Iterator[ErrorParts]:
+    if False:
+        yield None
+
+
 def dump_module(name: str) -> DumpNode:
     mod = importlib.import_module(name)
     return {'type': 'file', 'names': module_to_json(mod)}


### PR DESCRIPTION
This is enough to get stubtest working again, e.g., with `python3 stubtest.py zipfile`.

I'm not familiar enough with the code to know precisely why we need to disable incremental, but from tracing the code we seemed to run into issues with `mypy.Build.State.meta` – let me know if there's a better fix.