### PR TITLE
Include --strict-equality in --strict

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -602,7 +602,7 @@ def process_options(args: List[str],
                         help="Treat imports as private unless aliased",
                         group=strictness_group)
 
-    add_invertible_flag('--strict-equality', default=False, strict_flag=False,
+    add_invertible_flag('--strict-equality', default=False, strict_flag=True,
                         help="Prohibit equality, identity, and container checks for"
                              " non-overlapping types",
                         group=strictness_group)

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1149,6 +1149,14 @@ def f(c: A) -> None:  # E: Missing type parameters for generic type "A"
     pass
 [out]
 
+[case testStrictAndStrictEquality]
+# flags: --strict
+x = 0
+y = ''
+if x == y:  # E: Non-overlapping equality check (left operand type: "int", right operand type: "str")
+    int()
+[builtins fixtures/ops.pyi]
+
 [case testStrictEqualityPerFile]
 # flags: --config-file tmp/mypy.ini
 import b

--- a/test-data/unit/fixtures/ops.pyi
+++ b/test-data/unit/fixtures/ops.pyi
@@ -13,14 +13,14 @@ class type: pass
 
 class slice: pass
 
-class tuple(Sequence[Tco], Generic[Tco]):
+class tuple(Sequence[Tco]):
     def __getitem__(self, x: int) -> Tco: pass
     def __eq__(self, x: object) -> bool: pass
     def __ne__(self, x: object) -> bool: pass
-    def __lt__(self, x: 'tuple') -> bool: pass
-    def __le__(self, x: 'tuple') -> bool: pass
-    def __gt__(self, x: 'tuple') -> bool: pass
-    def __ge__(self, x: 'tuple') -> bool: pass
+    def __lt__(self, x: Tuple[Tco, ...]) -> bool: pass
+    def __le__(self, x: Tuple[Tco, ...]) -> bool: pass
+    def __gt__(self, x: Tuple[Tco, ...]) -> bool: pass
+    def __ge__(self, x: Tuple[Tco, ...]) -> bool: pass
 
 class function: pass
 
@@ -70,6 +70,7 @@ class complex:
 
 class BaseException: pass
 
-def __print(a1=None, a2=None, a3=None, a4=None): pass
+def __print(a1: object = None, a2: object = None, a3: object = None,
+            a4: object = None) -> None: pass
 
 class ellipsis: pass


### PR DESCRIPTION
Fixes #7910.

The stub changes are needed for clean output when using `--strict`.