### PR TITLE
Strict equality: detect always false container check against tuple type

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3461,6 +3461,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             super_instance = map_instance_to_supertype(typ, supertype)
             assert len(super_instance.args) == 1
             return super_instance.args[0]
+        if isinstance(typ, TupleType):
+            return self.analyze_container_item_type(tuple_fallback(typ))
         return None
 
     def analyze_index_variables(self, index: Expression, item_type: Type,

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -2754,6 +2754,13 @@ assert u'foo' == 'foo'
 assert u'foo' == u'bar'  # E: Non-overlapping equality check (left operand type: "Literal[u'foo']", right operand type: "Literal[u'bar']")
 [builtins_py2 fixtures/python2.pyi]
 
+[case testStrictEqualityWithFixedLengthTupleInCheck]
+# flags: --strict-equality
+if 1 in ('x', 'y'):  # E: Non-overlapping container check (element type: "int", container item type: "str")
+    pass
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
+
 [case testUnimportedHintAny]
 def f(x: Any) -> None:  # E: Name 'Any' is not defined \
                         # N: Did you forget to import it from "typing"? (Suggestion: "from typing import Any")


### PR DESCRIPTION
Tuple types weren't detected as containers.

Fixes #8286.