### PR TITLE
Allow Travis for other than python/mypy repos, e.g. contributor private

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-# we only CI the master, release branches, tags and PRs
-if: tag IS present OR type = pull_request OR ((branch = master OR branch =~ release-*) AND type = push)
+# in the python/mypy repo, we only CI the master, release branches, tags and PRs
+if: tag IS present OR type = pull_request OR ((branch = master OR branch =~ release-*) AND type = push) OR repo != python/mypy
 
 language: python
 # cache package wheels (1 cache per python version)


### PR DESCRIPTION
Whenever I want to submit something, I find myself needing to temporarily comment out the .travis.yml `if` condition, commit to get CI tests done and pass in my private fork and Travis, then rebase to remove that commit before I submit the PR. This should eliminate that extra annoyance.