### PR TITLE
Replace @abstractproperty usage in mypy

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -119,7 +119,7 @@ You can use `api.options.new_semantic_analyzer` to check whether the new
 semantic analyzer is enabled (it's always true in mypy 0.730 and later).
 """
 
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 from typing import Any, Callable, List, Tuple, Optional, NamedTuple, TypeVar, Dict
 from mypy_extensions import trait, mypyc_attr
 
@@ -214,7 +214,8 @@ class CheckerPluginInterface:
     path = None  # type: str
 
     # Type context for type inference
-    @abstractproperty
+    @property
+    @abstractmethod
     def type_context(self) -> List[Optional[Type]]:
         """Return the type context of the plugin"""
         raise NotImplementedError
@@ -348,7 +349,8 @@ class SemanticAnalyzerPluginInterface:
         """
         raise NotImplementedError
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def final_iteration(self) -> bool:
         """Is this the final iteration of semantic analysis?"""
         raise NotImplementedError

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -1,6 +1,6 @@
 """Shared definitions used by different parts of semantic analysis."""
 
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 
 from typing import Optional, List, Callable
 from typing_extensions import Final
@@ -67,7 +67,8 @@ class SemanticAnalyzerCoreInterface:
         """Is a module or class namespace potentially missing some definitions?"""
         raise NotImplementedError
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def final_iteration(self) -> bool:
         """Is this the final iteration of semantic analysis?"""
         raise NotImplementedError
@@ -156,7 +157,8 @@ class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
     def qualified_name(self, n: str) -> str:
         raise NotImplementedError
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def is_typeshed_stub_file(self) -> bool:
         raise NotImplementedError
 


### PR DESCRIPTION
Following #7952 and #8066, since @abstractproperty is deprecated and stubgen no longer generates code with @abstractproperty, I think it is reasonable to remove its usage in mypy's own code.