### PR TITLE
Make the fine-grained mergechecker work again

### DIFF
--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -335,6 +335,12 @@ def semantic_analyze_target(target: str,
         priority = mypy.build.PRI_LOW
         if priority <= state.priorities.get(dep, priority):
             state.priorities[dep] = priority
+
+    # Clear out some stale data to avoid memory leaks and astmerge
+    # validity check confusion
+    analyzer.statement = None
+    delattr(analyzer, 'cur_mod_node')
+
     if analyzer.deferred:
         return [target], analyzer.incomplete, analyzer.progress
     else:

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -339,7 +339,7 @@ def semantic_analyze_target(target: str,
     # Clear out some stale data to avoid memory leaks and astmerge
     # validity check confusion
     analyzer.statement = None
-    delattr(analyzer, 'cur_mod_node')
+    del analyzer.cur_mod_node
 
     if analyzer.deferred:
         return [target], analyzer.incomplete, analyzer.progress

--- a/mypy/server/mergecheck.py
+++ b/mypy/server/mergecheck.py
@@ -3,7 +3,7 @@
 from typing import Dict, List, Tuple
 from typing_extensions import Final
 
-from mypy.nodes import SymbolNode, Var, Decorator, FuncDef
+from mypy.nodes import FakeInfo, SymbolNode, Var, Decorator, FuncDef
 from mypy.server.objgraph import get_reachable_graph, get_path
 
 # If True, print more verbose output on failure.
@@ -21,6 +21,9 @@ def check_consistency(o: object) -> None:
 
     m = {}  # type: Dict[str, SymbolNode]
     for sym in syms:
+        if isinstance(sym, FakeInfo):
+            continue
+
         fn = sym.fullname
         # Skip None names, since they are ambiguous.
         # TODO: Everything should have a proper full name?

--- a/mypy/server/objgraph.py
+++ b/mypy/server/objgraph.py
@@ -54,12 +54,18 @@ def isproperty(o: object, attr: str) -> bool:
 
 
 def get_edge_candidates(o: object) -> Iterator[Tuple[object, object]]:
+    # use getattr because mypyc expects dict, not mappingproxy
+    if '__getattribute__' in getattr(type(o), '__dict__'):  # noqa
+        return
     if type(o) not in COLLECTION_TYPE_BLACKLIST:
         for attr in dir(o):
-            if attr not in ATTR_BLACKLIST and hasattr(o, attr) and not isproperty(o, attr):
-                e = getattr(o, attr)
-                if not type(e) in ATOMIC_TYPE_BLACKLIST:
-                    yield attr, e
+            try:
+                if attr not in ATTR_BLACKLIST and hasattr(o, attr) and not isproperty(o, attr):
+                    e = getattr(o, attr)
+                    if not type(e) in ATOMIC_TYPE_BLACKLIST:
+                        yield attr, e
+            except AssertionError:
+                pass
     if isinstance(o, Mapping):
         for k, v in o.items():
             yield k, v
@@ -78,7 +84,7 @@ def get_edges(o: object) -> Iterator[Tuple[object, object]]:
                 yield (s, '__closure__'), e.__closure__  # type: ignore
             if hasattr(e, '__self__'):
                 se = e.__self__  # type: ignore
-                if se is not o and se is not type(o):
+                if se is not o and se is not type(o) and hasattr(s, '__self__'):
                     yield s.__self__, se  # type: ignore
         else:
             if not type(e) in TYPE_BLACKLIST:

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -64,8 +64,6 @@ class TraverserVisitor(NodeVisitor[None]):
             d.accept(self)
         for base in o.base_type_exprs:
             base.accept(self)
-        for base in o.removed_base_type_exprs:
-            base.accept(self)
         if o.metaclass:
             o.metaclass.accept(self)
         for v in o.keywords.values():

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -64,6 +64,12 @@ class TraverserVisitor(NodeVisitor[None]):
             d.accept(self)
         for base in o.base_type_exprs:
             base.accept(self)
+        for base in o.removed_base_type_exprs:
+            base.accept(self)
+        if o.metaclass:
+            o.metaclass.accept(self)
+        for v in o.keywords.values():
+            v.accept(self)
         o.defs.accept(self)
         if o.analyzed:
             o.analyzed.accept(self)

--- a/test-data/unit/deps-classes.test
+++ b/test-data/unit/deps-classes.test
@@ -246,4 +246,4 @@ def f() -> None:
 <m.C.x> -> m.f
 <m.C> -> m.C, m.f
 <m.M.x> -> m.f
-<m.M> -> <m.C>, m.M
+<m.M> -> <m.C>, m, m.M

--- a/test-data/unit/deps-types.test
+++ b/test-data/unit/deps-types.test
@@ -239,7 +239,7 @@ class M(type):
     pass
 [out]
 <m.C> -> m.C
-<mod.M> -> <m.C>
+<mod.M> -> <m.C>, m
 <mod> -> m
 
 [case testMetaclassDepsDeclared_python2]
@@ -268,8 +268,8 @@ class M(type):
     pass
 [out]
 <m.func> -> m.func
-<mod.M> -> <m.func>
-<mod> -> m
+<mod.M> -> <m.func>, m.func
+<mod> -> m, m.func
 
 [case testMetaclassAttributes_python2]
 # flags: --py2


### PR DESCRIPTION
This fixes some stuff in the mergechecker that breaks with current
mypy's and also some bugs that the mergechecker caught. The entire
fine-grained test suite now passes with the merge checker on, which I
don't think has ever been true before.

This means that we could turn it on by default, but it doubles the
runtime of the fine-grained tests (from 90s CPU time to 180s CPU time
on my laptop), so I've left it off for now.

The motivation here is that I knew intersect_callable's creation of
types during typechecking used to run afoul of the consistency checker
and so I was nervous that #8305 would cause more problems by adding
more logic of that kind. It no longer does, probably as a result of
the semantic analyzer rewrite, so I think we are in the clear on that.