### PR TITLE
stubtest: rewrite

### DIFF
--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -978,14 +978,11 @@ def get_whitelist_entries(whitelist_file: Optional[str]) -> Iterator[str]:
 def main() -> int:
     assert sys.version_info >= (3, 5), "This script requires at least Python 3.5"
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="Compares stubs to objects introspected from the runtime."
+    )
     parser.add_argument("modules", nargs="*", help="Modules to test")
-    parser.add_argument(
-        "--check-typeshed", action="store_true", help="Check all stdlib modules in typeshed"
-    )
-    parser.add_argument(
-        "--custom-typeshed-dir", metavar="DIR", help="Use the custom typeshed in DIR"
-    )
+    parser.add_argument("--concise", action="store_true", help="Make output concise")
     parser.add_argument(
         "--ignore-missing-stub",
         action="store_true",
@@ -997,6 +994,12 @@ def main() -> int:
         help="Ignore errors for whether an argument should or shouldn't be positional-only",
     )
     parser.add_argument(
+        "--custom-typeshed-dir", metavar="DIR", help="Use the custom typeshed in DIR"
+    )
+    parser.add_argument(
+        "--check-typeshed", action="store_true", help="Check all stdlib modules in typeshed"
+    )
+    parser.add_argument(
         "--whitelist",
         action="append",
         metavar="FILE",
@@ -1006,7 +1009,6 @@ def main() -> int:
             "whitelists. Whitelist can be created with --generate-whitelist"
         ),
     )
-    parser.add_argument("--concise", action="store_true", help="Make output concise")
     parser.add_argument(
         "--generate-whitelist",
         action="store_true",

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -650,6 +650,8 @@ def main() -> int:
         with open(args.whitelist) as f:
             whitelist = {l.strip(): False for l in f.readlines()}
 
+    output_whitelist = set()
+
     modules = args.modules
     if args.check_typeshed:
         assert (
@@ -674,16 +676,22 @@ def main() -> int:
             if error.object_desc in whitelist:
                 whitelist[error.object_desc] = True
                 continue
-            if args.output_whitelist:
-                print(error.object_desc)
-                continue
+
             exit_code = 1
+            if args.output_whitelist:
+                output_whitelist.add(error.object_desc)
+                continue
             print(error.get_description(concise=args.concise))
 
     for w in whitelist:
         if not whitelist[w]:
             exit_code = 1
             print(f"note: unused whitelist entry {w}")
+
+    if args.output_whitelist:
+        for e in sorted(output_whitelist):
+            print(e)
+        exit_code = 0
 
     return exit_code
 

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -187,7 +187,7 @@ def verify_mypyfile(
 
     for entry in sorted(to_check):
         yield from verify(
-            getattr(stub.names.get(entry, MISSING), "node", MISSING),
+            stub.names[entry].node if entry in stub.names else MISSING,
             getattr(runtime, entry, MISSING),
             object_path + [entry],
         )
@@ -210,7 +210,7 @@ def verify_typeinfo(
 
     for entry in sorted(to_check):
         yield from verify(
-            getattr(stub.names.get(entry, MISSING), "node", MISSING),
+            stub.names[entry].node if entry in stub.names else MISSING,
             getattr(runtime, entry, MISSING),
             object_path + [entry],
         )

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -254,6 +254,23 @@ def verify_funcitem(
         yield Error(object_path, "is not a function", stub, runtime)
         return
 
+    if isinstance(runtime, classmethod) and not stub.is_class:
+        yield Error(
+            object_path, "runtime is a classmethod but stub is not", stub, runtime
+        )
+    if not isinstance(runtime, classmethod) and stub.is_class:
+        yield Error(
+            object_path, "stub is a classmethod but runtime is not", stub, runtime
+        )
+    if isinstance(runtime, staticmethod) and not stub.is_static:
+        yield Error(
+            object_path, "runtime is a staticmethod but stub is not", stub, runtime
+        )
+    if not isinstance(runtime, classmethod) and stub.is_static:
+        yield Error(
+            object_path, "stub is a staticmethod but runtime is not", stub, runtime
+        )
+
     try:
         signature = inspect.signature(runtime)
     except ValueError:

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -78,6 +78,9 @@ class Error:
             lambda s: s if isinstance(s, Missing) else runtime_printer(s)
         )
 
+    def is_missing_stub(self) -> bool:
+        return isinstance(self.stub_object, Missing)
+
     def __str__(self) -> str:
         stub_line = None
         stub_file = None
@@ -385,6 +388,11 @@ def main() -> Iterator[Error]:
     parser = argparse.ArgumentParser()
     parser.add_argument("modules", nargs="+", help="Modules to test")
     parser.add_argument(
+        "--ignore-missing-stub",
+        action="store_true",
+        help="Ignore errors for stub missing things that are present at runtime",
+    )
+    parser.add_argument(
         "--custom-typeshed-dir", metavar="DIR", help="Use the custom typeshed in DIR"
     )
     args = parser.parse_args()
@@ -399,7 +407,8 @@ def main() -> Iterator[Error]:
 
     for module in args.modules:
         for error in test_module(module, options, find_module_cache):
-            yield error
+            if not args.ignore_missing_stub or not error.is_missing_stub():
+                yield error
 
 
 if __name__ == "__main__":

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -347,10 +347,10 @@ def _verify_arg_default_value(
 
 class Signature(Generic[T]):
     def __init__(self) -> None:
-        self.pos: List[T] = []
-        self.kwonly: Dict[str, T] = {}
-        self.varpos: Optional[T] = None
-        self.varkw: Optional[T] = None
+        self.pos = []  # type: List[T]
+        self.kwonly = {}  # type: Dict[str, T]
+        self.varpos = None  # type: Optional[T]
+        self.varkw = None  # type: Optional[T]
 
     def __str__(self) -> str:
         def get_name(arg: Any) -> str:
@@ -398,7 +398,7 @@ class Signature(Generic[T]):
 
     @staticmethod
     def from_funcitem(stub: nodes.FuncItem) -> "Signature[nodes.Argument]":
-        stub_sig: Signature[nodes.Argument] = Signature()
+        stub_sig = Signature()  # type: Signature[nodes.Argument]
         for stub_arg in stub.arguments:
             if stub_arg.kind in (nodes.ARG_POS, nodes.ARG_OPT):
                 stub_sig.pos.append(stub_arg)
@@ -416,7 +416,7 @@ class Signature(Generic[T]):
     def from_inspect_signature(
         signature: inspect.Signature,
     ) -> "Signature[inspect.Parameter]":
-        runtime_sig: Signature[inspect.Parameter] = Signature()
+        runtime_sig = Signature()  # type: Signature[inspect.Parameter]
         for runtime_arg in signature.parameters.values():
             if runtime_arg.kind in (
                 inspect.Parameter.POSITIONAL_ONLY,
@@ -448,7 +448,7 @@ class Signature(Generic[T]):
         # For all dunder methods other than __init__, just assume all args are positional-only
         assume_positional_only = is_dunder(stub.name, exclude_init=True)
 
-        all_args: Dict[str, List[Tuple[nodes.Argument, int]]] = {}
+        all_args = {}  # type: Dict[str, List[Tuple[nodes.Argument, int]]]
         for func in map(_resolve_funcitem_from_decorator, stub.items):
             assert func is not None
             for index, arg in enumerate(func.arguments):
@@ -492,7 +492,7 @@ class Signature(Generic[T]):
                 return nodes.ARG_OPT if is_pos else nodes.ARG_NAMED_OPT
             return nodes.ARG_POS if is_pos else nodes.ARG_NAMED
 
-        sig: Signature[nodes.Argument] = Signature()
+        sig = Signature()  # type: Signature[nodes.Argument]
         for arg_name in sorted(all_args, key=get_position):
             # example_arg_name gives us a real name (in case we had a fake index-based name)
             example_arg_name = all_args[arg_name][0][0].variable.name
@@ -791,7 +791,7 @@ def _resolve_funcitem_from_decorator(
         # anything else when running on typeshed's stdlib.
         return None
 
-    func: nodes.FuncItem = dec.func
+    func = dec.func  # type: nodes.FuncItem
     for decorator in dec.original_decorators:
         resulting_func = apply_decorator_to_funcitem(decorator, func)
         if resulting_func is None:
@@ -899,7 +899,7 @@ def get_mypy_type_of_runtime_value(runtime: Any) -> Optional[mypy.types.Type]:
     )
 
 
-_all_stubs: Dict[str, nodes.MypyFile] = {}
+_all_stubs = {}  # type: Dict[str, nodes.MypyFile]
 
 
 def build_stubs(

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -10,6 +10,7 @@ import inspect
 import subprocess
 import sys
 import types
+import warnings
 from functools import singledispatch
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, TypeVar, Union
@@ -158,7 +159,10 @@ def test_module(module_name: str) -> Iterator[Error]:
         yield Error([module_name], f"failed to import: {e}", stub, MISSING)
         return
 
-    yield from verify(stub, runtime, [module_name])
+    # collections likes to warn us about the things we're doing
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        yield from verify(stub, runtime, [module_name])
 
 
 @singledispatch

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -655,8 +655,8 @@ def verify_none(
             # weird things going on. Try to see if we can find a runtime object by importing it,
             # otherwise crash.
             runtime = importlib.import_module(".".join(object_path))
-        except ModuleNotFoundError:
-            assert False
+        except ImportError:
+            raise RuntimeError
     yield Error(object_path, "is not present in stub", stub, runtime)
 
 
@@ -974,9 +974,7 @@ def get_typeshed_stdlib_modules(custom_typeshed_dir: Optional[str]) -> List[str]
     for version in versions:
         base = typeshed_dir / "stdlib" / version
         if base.exists():
-            output = subprocess.check_output(
-                ["find", base, "-type", "f"], encoding="utf-8"
-            )
+            output = subprocess.check_output(["find", str(base), "-type", "f"]).decode("utf-8")
             paths = [Path(p) for p in output.splitlines()]
             for path in paths:
                 if path.stem == "__init__":
@@ -1005,7 +1003,7 @@ def get_whitelist_entries(whitelist_file: Optional[str]) -> Iterator[str]:
 
 
 def main() -> int:
-    assert sys.version_info >= (3, 6), "This script requires at least Python 3.6"
+    assert sys.version_info >= (3, 5), "This script requires at least Python 3.5"
 
     parser = argparse.ArgumentParser()
     parser.add_argument("modules", nargs="*", help="Modules to test")

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -998,7 +998,13 @@ def main() -> int:
     )
     parser.add_argument(
         "--whitelist",
-        help="Use file as a whitelist. Whitelists can be created with --generate-whitelist",
+        action="append",
+        metavar="FILE",
+        default=[],
+        help=(
+            "Use file as a whitelist. Can be passed multiple times to combine multiple "
+            "whitelists. Whitelist can be created with --generate-whitelist"
+        ),
     )
     parser.add_argument("--concise", action="store_true", help="Make output concise")
     parser.add_argument(
@@ -1010,7 +1016,11 @@ def main() -> int:
 
     # Load the whitelist. This is a series of strings corresponding to Error.object_desc
     # Values in the dict will store whether we used the whitelist entry or not.
-    whitelist = {entry: False for entry in get_whitelist_entries(args.whitelist)}
+    whitelist = {
+        entry: False
+        for whitelist_file in args.whitelist
+        for entry in get_whitelist_entries(whitelist_file)
+    }
 
     # If we need to generate a whitelist, we store Error.object_desc for each error here.
     generated_whitelist = set()

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -131,16 +131,6 @@ def test_module(
         yield from verify(stub, runtime, [mod])
 
 
-def trace(fn):
-    import functools
-
-    @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
-        return fn(*args, **kwargs)
-
-    return new_fn
-
-
 @singledispatch
 def verify(
     stub: nodes.Node, runtime: MaybeMissing[Any], object_path: List[str]
@@ -149,7 +139,6 @@ def verify(
 
 
 @verify.register(nodes.MypyFile)
-@trace
 def verify_mypyfile(
     stub: nodes.MypyFile,
     runtime: MaybeMissing[types.ModuleType],
@@ -181,7 +170,6 @@ def verify_mypyfile(
 
 
 @verify.register(nodes.TypeInfo)
-@trace
 def verify_typeinfo(
     stub: nodes.TypeInfo, runtime: MaybeMissing[Type[Any]], object_path: List[str]
 ) -> Iterator[Error]:
@@ -204,7 +192,6 @@ def verify_typeinfo(
 
 
 @verify.register(nodes.FuncItem)
-@trace
 def verify_funcitem(
     stub: nodes.FuncItem,
     runtime: MaybeMissing[types.FunctionType],
@@ -294,7 +281,6 @@ def verify_funcitem(
 
 
 @verify.register(Missing)
-@trace
 def verify_none(
     stub: Missing, runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:
@@ -304,7 +290,6 @@ def verify_none(
 
 
 @verify.register(nodes.Var)
-@trace
 def verify_var(
     stub: nodes.Var, runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:
@@ -320,7 +305,6 @@ def verify_var(
 
 
 @verify.register(nodes.OverloadedFuncDef)
-@trace
 def verify_overloadedfuncdef(
     stub: nodes.OverloadedFuncDef, runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:
@@ -329,7 +313,6 @@ def verify_overloadedfuncdef(
 
 
 @verify.register(nodes.TypeVarExpr)
-@trace
 def verify_typevarexpr(
     stub: nodes.TypeVarExpr, runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:
@@ -338,7 +321,6 @@ def verify_typevarexpr(
 
 
 @verify.register(nodes.Decorator)
-@trace
 def verify_decorator(
     stub: nodes.Decorator, runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:
@@ -351,7 +333,6 @@ def verify_decorator(
 
 
 @verify.register(nodes.TypeAlias)
-@trace
 def verify_typealias(
     stub: nodes.TypeAlias, runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -587,6 +587,7 @@ def main() -> int:
             not args.modules
         ), "Cannot pass both --check-typeshed and a list of modules"
         modules = get_typeshed_stdlib_modules(args.custom_typeshed_dir)
+        modules.remove("antigravity")  # it's super annoying
 
     assert modules, "No modules to check"
 

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -502,6 +502,15 @@ def verify_typealias(
 
 
 def is_subtype_helper(left: mypy.types.Type, right: mypy.types.Type) -> bool:
+    if (
+        isinstance(left, mypy.types.LiteralType)
+        and isinstance(left.value, int)
+        and left.value in (0, 1)
+        and isinstance(right, mypy.types.Instance)
+        and right.type.fullname == "builtins.bool"
+    ):
+        # Pretend Literal[0, 1] is a subtype of bool to avoid unhelpful errors.
+        return True
     with mypy.state.strict_optional_set(True):
         return mypy.subtypes.is_subtype(left, right)
 

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -47,21 +47,30 @@ MISSING = Missing()
 T = TypeVar("T")
 MaybeMissing = Union[T, Missing]
 
+_formatter = FancyFormatter(sys.stdout, sys.stderr, False)
+
+
+def _style(message: str, **kwargs: Any) -> str:
+    kwargs.setdefault("color", "none")
+    return _formatter.style(message, **kwargs)
+
 
 class Error:
     def __init__(
         self,
+        object_path: List[str],
         message: str,
         stub_object: MaybeMissing[nodes.Node],
         runtime_object: MaybeMissing[Any],
         stub_printer: Optional[Callable[[nodes.Node], str]] = None,
         runtime_printer: Optional[Callable[[Any], str]] = None,
     ) -> None:
+        self.object_desc = ".".join(object_path)
         self.message = message
         self.stub_object = stub_object
         self.runtime_object = runtime_object
         if stub_printer is None:
-            stub_printer = lambda stub: str(stub.type)
+            stub_printer = lambda stub: str(getattr(stub, "type", stub))
         self.stub_printer = lambda s: s if isinstance(s, Missing) else stub_printer(s)
         if runtime_printer is None:
             runtime_printer = lambda runtime: str(runtime)
@@ -100,16 +109,22 @@ class Error:
         if runtime_file:
             runtime_loc_str += f" in file {runtime_file}"
 
-        return "".join(
-            [
-                formatter.style("error:", "red", bold=True),
-                f" {self.message}\n",
-                f"Stub{stub_loc_str}:\n",
-                f"{self.stub_printer(self.stub_object)}\n",
-                f"Runtime{runtime_loc_str}:\n",
-                f"{self.runtime_printer(self.runtime_object)}\n",
-            ]
-        )
+        output = [
+            _style("error: ", color="red", bold=True),
+            _style(self.object_desc, bold=True),
+            f" {self.message}\n",
+            "Stub:",
+            _style(stub_loc_str, dim=True),
+            "\n",
+            _style(f"{self.stub_printer(self.stub_object)}\n", color="blue", dim=True),
+            "Runtime:",
+            _style(runtime_loc_str, dim=True),
+            "\n",
+            _style(
+                f"{self.runtime_printer(self.runtime_object)}\n", color="blue", dim=True
+            ),
+        ]
+        return "".join(output)
 
 
 def test_module(
@@ -123,7 +138,7 @@ def test_module(
 
     for mod, stub in stubs.items():
         runtime = importlib.import_module(mod)
-        yield from verify(stub, runtime)
+        yield from verify(stub, runtime, [mod])
 
 
 def trace(fn):
@@ -137,20 +152,24 @@ def trace(fn):
 
 
 @singledispatch
-def verify(stub: nodes.Node, runtime: MaybeMissing[Any]) -> Iterator[Error]:
-    yield Error("unknown mypy node", stub, runtime)
+def verify(
+    stub: nodes.Node, runtime: MaybeMissing[Any], object_path: List[str]
+) -> Iterator[Error]:
+    yield Error(object_path, "is an unknown mypy node", stub, runtime)
 
 
 @verify.register(nodes.MypyFile)
 @trace
 def verify_mypyfile(
-    stub: nodes.MypyFile, runtime: MaybeMissing[types.ModuleType]
+    stub: nodes.MypyFile,
+    runtime: MaybeMissing[types.ModuleType],
+    object_path: List[str],
 ) -> Iterator[Error]:
     if isinstance(runtime, Missing):
-        yield Error("not_in_runtime", stub, runtime)
+        yield Error(object_path, "is not present at runtime", stub, runtime)
         return
     if not isinstance(runtime, types.ModuleType):
-        yield Error("type_mismatch", stub, runtime)
+        yield Error(object_path, "is not a module", stub, runtime)
         return
 
     # Check all things in the stub
@@ -167,19 +186,20 @@ def verify_mypyfile(
         yield from verify(
             getattr(stub.names.get(entry, MISSING), "node", MISSING),
             getattr(runtime, entry, MISSING),
+            object_path + [entry],
         )
 
 
 @verify.register(nodes.TypeInfo)
 @trace
 def verify_typeinfo(
-    stub: nodes.TypeInfo, runtime: MaybeMissing[Type[Any]]
+    stub: nodes.TypeInfo, runtime: MaybeMissing[Type[Any]], object_path: List[str]
 ) -> Iterator[Error]:
     if isinstance(runtime, Missing):
-        yield Error("not_in_runtime", stub, runtime)
+        yield Error(object_path, "is not present at runtime", stub, runtime)
         return
     if not isinstance(runtime, type):
-        yield Error("type_mismatch", stub, runtime)
+        yield Error(object_path, "is not a type", stub, runtime)
         return
 
     to_check = set(stub.names)
@@ -189,19 +209,22 @@ def verify_typeinfo(
         yield from verify(
             getattr(stub.names.get(entry, MISSING), "node", MISSING),
             getattr(runtime, entry, MISSING),
+            object_path + [entry],
         )
 
 
 @verify.register(nodes.FuncItem)
 @trace
 def verify_funcitem(
-    stub: nodes.FuncItem, runtime: MaybeMissing[types.FunctionType]
+    stub: nodes.FuncItem,
+    runtime: MaybeMissing[types.FunctionType],
+    object_path: List[str],
 ) -> Iterator[Error]:
     if isinstance(runtime, Missing):
-        yield Error("not_in_runtime", stub, runtime)
+        yield Error(object_path, "is not present at runtime", stub, runtime)
         return
     if not isinstance(runtime, (types.FunctionType, types.BuiltinFunctionType)):
-        yield Error("type_mismatch", stub, runtime)
+        yield Error(object_path, "is not a function", stub, runtime)
         return
 
     try:
@@ -219,7 +242,8 @@ def verify_funcitem(
             # listed out the keyword parameters this function takes
             if runtime_args[j].kind != inspect.Parameter.VAR_KEYWORD:
                 yield Error(
-                    f"arg_mismatch: {stub.name}, stub missing {runtime_args[j].name}",
+                    object_path,
+                    f'is inconsistent, stub does not have argument "{runtime_args[j].name}"',
                     stub,
                     runtime,
                     runtime_printer=lambda s: str(inspect.signature(s)),
@@ -228,7 +252,8 @@ def verify_funcitem(
             continue
         if j >= len(runtime_args):
             yield Error(
-                f"arg_mismatch: {stub.name}, runtime missing {stub_args[i].variable.name}",
+                object_path,
+                f"is inconsistent, runtime does not have argument {stub_args[i].variable.name}",
                 stub,
                 runtime,
                 runtime_printer=lambda s: str(inspect.signature(s)),
@@ -267,7 +292,9 @@ def verify_funcitem(
         if stub_arg.variable.name != runtime_arg.name:
             # TODO: _asdict takes _self and self
             yield Error(
-                f"arg_mismatch: {stub.name}, {stub_arg.variable.name} != {runtime_arg.name}",
+                object_path,
+                f'is inconsistent, stub argument "{stub_arg.variable.name}" differs from '
+                f'runtime argument "{runtime_arg.name}"',
                 stub,
                 runtime,
                 runtime_printer=lambda s: str(inspect.signature(s)),
@@ -278,38 +305,43 @@ def verify_funcitem(
 
 @verify.register(Missing)
 @trace
-def verify_none(stub: Missing, runtime: MaybeMissing[Any]) -> Iterator[Error]:
-    yield Error("not_in_stub", stub, runtime)
+def verify_none(
+    stub: Missing, runtime: MaybeMissing[Any], object_path: List[str]
+) -> Iterator[Error]:
+    yield Error(object_path, "is not present in stub", stub, runtime)
     if isinstance(runtime, Missing):
         raise RuntimeError
 
 
 @verify.register(nodes.Var)
 @trace
-def verify_var(stub: nodes.Var, runtime: MaybeMissing[Any]) -> Iterator[Error]:
+def verify_var(
+    stub: nodes.Var, runtime: MaybeMissing[Any], object_path: List[str]
+) -> Iterator[Error]:
     if isinstance(runtime, Missing):
-        # Don't yield an error here, because we often can't find instance variables
-        # yield Error("not_in_runtime", stub, runtime)
+        # Don't always yield an error here, because we often can't find instance variables
+        if len(object_path) <= 1:
+            yield Error(object_path, "is not present at runtime", stub, runtime)
         return
     # TODO: Make this better
     if isinstance(stub, mypy.types.Instance):
         if stub.type.type.name != runtime.__name__:
-            yield Error(f"var_mismatch", stub, runtime)
+            yield Error(object_path, "var_mismatch", stub, runtime)
 
 
 @verify.register(nodes.OverloadedFuncDef)
 @trace
 def verify_overloadedfuncdef(
-    stub: nodes.OverloadedFuncDef, runtime: MaybeMissing[Any]
+    stub: nodes.OverloadedFuncDef, runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:
     for func in stub.items:
-        yield from verify(func, runtime)
+        yield from verify(func, runtime, object_path)
 
 
 @verify.register(nodes.TypeVarExpr)
 @trace
 def verify_typevarexpr(
-    stub: nodes.TypeVarExpr, runtime: MaybeMissing[Any]
+    stub: nodes.TypeVarExpr, runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:
     if False:
         yield None
@@ -318,20 +350,20 @@ def verify_typevarexpr(
 @verify.register(nodes.Decorator)
 @trace
 def verify_decorator(
-    stub: nodes.Decorator, runtime: MaybeMissing[Any]
+    stub: nodes.Decorator, runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:
     if (
         len(stub.decorators) == 1
         and isinstance(stub.decorators[0], nodes.NameExpr)
         and stub.decorators[0].fullname == "typing.overload"
     ):
-        yield from verify(stub.func, runtime)
+        yield from verify(stub.func, runtime, object_path)
 
 
 @verify.register(nodes.TypeAlias)
 @trace
 def verify_typealias(
-    stub: nodes.TypeAlias, runtime: MaybeMissing[Any]
+    stub: nodes.TypeAlias, runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:
     if False:
         yield None
@@ -371,6 +403,5 @@ def main() -> Iterator[Error]:
 
 
 if __name__ == "__main__":
-    formatter = FancyFormatter(sys.stdout, sys.stderr, False)
     for err in main():
         print(err)

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -231,7 +231,7 @@ def verify_typeinfo(
 
     for entry in sorted(to_check):
         yield from verify(
-            stub.names[entry].node if entry in stub.names else MISSING,
+            next((t.names[entry].node for t in stub.mro if entry in t.names), MISSING),
             getattr(runtime, entry, MISSING),
             object_path + [entry],
         )

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -56,7 +56,7 @@ class Error:
         runtime_object: MaybeMissing[Any],
         *,
         stub_desc: Optional[str] = None,
-        runtime_desc: Optional[str] = None,
+        runtime_desc: Optional[str] = None
     ) -> None:
         """Represents an error found by stubtest.
 
@@ -181,7 +181,7 @@ def verify(
 def verify_mypyfile(
     stub: nodes.MypyFile,
     runtime: MaybeMissing[types.ModuleType],
-    object_path: List[str],
+    object_path: List[str]
 ) -> Iterator[Error]:
     if isinstance(runtime, Missing):
         yield Error(object_path, "is not present at runtime", stub, runtime)
@@ -518,7 +518,7 @@ class Signature(Generic[T]):
 def _verify_signature(
     stub: Signature[nodes.Argument],
     runtime: Signature[inspect.Parameter],
-    function_name: str,
+    function_name: str
 ) -> Iterator[str]:
     # Check positional arguments match up
     for stub_arg, runtime_arg in zip(stub.pos, runtime.pos):
@@ -609,7 +609,7 @@ def _verify_signature(
 def verify_funcitem(
     stub: nodes.FuncItem,
     runtime: MaybeMissing[types.FunctionType],
-    object_path: List[str],
+    object_path: List[str]
 ) -> Iterator[Error]:
     if isinstance(runtime, Missing):
         yield Error(object_path, "is not present at runtime", stub, runtime)

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -601,8 +601,9 @@ def verify_funcitem(
 
     try:
         signature = inspect.signature(runtime)
-    except ValueError:
+    except (ValueError, RuntimeError):
         # inspect.signature throws sometimes
+        # catch RuntimeError because of https://bugs.python.org/issue39504
         return
 
     stub_sig = Signature.from_funcitem(stub)

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -390,8 +390,15 @@ def verify_funcitem(
 def verify_none(
     stub: Missing, runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:
+    if isinstance(runtime, Missing):
+        try:
+            # We shouldn't really get here, however, some modules like distutils.command have some
+            # weird things going on. Try to see if we can find a runtime object by importing it,
+            # otherwise crash.
+            runtime = importlib.import_module(".".join(object_path))
+        except ModuleNotFoundError:
+            assert False
     yield Error(object_path, "is not present in stub", stub, runtime)
-    assert not isinstance(runtime, Missing)
 
 
 @verify.register(nodes.Var)

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -13,17 +13,7 @@ import types
 import warnings
 from functools import singledispatch
 from pathlib import Path
-from typing import (
-    Any,
-    Dict,
-    Generic,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import Any, Dict, Generic, Iterator, List, Optional, Tuple, TypeVar, Union
 
 from typing_extensions import Type
 
@@ -69,7 +59,8 @@ class Error:
     ) -> None:
         """Represents an error found by stubtest.
 
-        :param object_path: Location of the object with the error, eg, ["module", "Class", "method"]
+        :param object_path: Location of the object with the error,
+            e.g. ``["module", "Class", "method"]``
         :param message: Error message
         :param stub_object: The mypy node representing the stub
         :param runtime_object: Actual object obtained from the runtime
@@ -852,10 +843,7 @@ def build_stubs(modules: List[str], options: Options) -> None:
 
     res = mypy.build.build(sources=sources, options=options)
     if res.errors:
-        output = [
-            _style("error: ", color="red", bold=True),
-            " failed mypy build.\n",
-        ]
+        output = [_style("error: ", color="red", bold=True), " failed mypy build.\n"]
         print("".join(output) + "\n".join(res.errors))
         sys.exit(1)
 
@@ -939,9 +927,7 @@ def main() -> int:
         "--whitelist",
         help="Use file as a whitelist. Whitelists can be created with --generate-whitelist",
     )
-    parser.add_argument(
-        "--concise", action="store_true", help="Make output concise",
-    )
+    parser.add_argument("--concise", action="store_true", help="Make output concise")
     parser.add_argument(
         "--generate-whitelist",
         action="store_true",

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -1,7 +1,7 @@
 """Tests for stubs.
 
-Verify that various things in stubs are consistent with how things behave
-at runtime.
+Verify that various things in stubs are consistent with how things behave at runtime.
+
 """
 
 import argparse
@@ -9,23 +9,10 @@ import importlib
 import inspect
 import sys
 import types
-from collections import defaultdict
 from functools import singledispatch
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    Mapping,
-    NamedTuple,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Dict, Iterator, List, Optional, TypeVar, Union
 
-from typing_extensions import Final, Type
+from typing_extensions import Type
 
 import mypy.build
 import mypy.modulefinder

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -365,7 +365,7 @@ def build_stubs(
     return res.files
 
 
-def main() -> None:
+def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("modules", nargs="+", help="Modules to test")
     parser.add_argument(
@@ -389,11 +389,14 @@ def main() -> None:
     search_path = mypy.modulefinder.compute_search_paths([], options, data_dir)
     find_module_cache = FindModuleCache(search_path)
 
+    exit_code = 0
     for module in args.modules:
         for error in test_module(module, options, find_module_cache):
             if not args.ignore_missing_stub or not error.is_missing_stub():
+                exit_code = 1
                 print(error.get_description(concise=args.concise))
+    return exit_code
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -28,6 +28,7 @@ from typing_extensions import Final, Type
 
 import mypy.build
 import mypy.modulefinder
+import mypy.types
 from mypy import nodes
 from mypy.errors import CompileError
 from mypy.modulefinder import FindModuleCache
@@ -163,19 +164,20 @@ def verify_none(stub: Missing, runtime: MaybeMissing[Any]) -> Iterator[Error]:
 
 @verify.register(nodes.Var)
 @trace
-def verify_var(node: nodes.Var, module_node: MaybeMissing[Any]) -> Iterator[Error]:
-    if False:
-        yield None
-    # Need to check if types are inconsistent.
-    # if 'type' not in dump or dump['type'] != node.node.type:
-    #    import ipdb; ipdb.set_trace()
-    #    yield name, 'inconsistent', node.node.line, shed_type, module_type
+def verify_var(stub: nodes.Var, runtime: MaybeMissing[Any]) -> Iterator[Error]:
+    if isinstance(runtime, Missing):
+        yield Error("not_in_runtime")
+        return
+    # TODO: Make this better
+    if isinstance(stub, mypy.types.Instance):
+        if stub.type.type.name != runtime.__name__:
+            yield Error(f"var_mismatch: {runtime}")
 
 
 @verify.register(nodes.OverloadedFuncDef)
 @trace
 def verify_overloadedfuncdef(
-    node: nodes.OverloadedFuncDef, module_node: MaybeMissing[Any]
+    stub: nodes.OverloadedFuncDef, runtime: MaybeMissing[Any]
 ) -> Iterator[Error]:
     # Should check types of the union of the overloaded types.
     if False:
@@ -185,7 +187,7 @@ def verify_overloadedfuncdef(
 @verify.register(nodes.TypeVarExpr)
 @trace
 def verify_typevarexpr(
-    node: nodes.TypeVarExpr, module_node: MaybeMissing[Any]
+    stub: nodes.TypeVarExpr, runtime: MaybeMissing[Any]
 ) -> Iterator[Error]:
     if False:
         yield None
@@ -194,7 +196,7 @@ def verify_typevarexpr(
 @verify.register(nodes.Decorator)
 @trace
 def verify_decorator(
-    node: nodes.Decorator, module_node: MaybeMissing[Any]
+    stub: nodes.Decorator, runtime: MaybeMissing[Any]
 ) -> Iterator[Error]:
     if False:
         yield None
@@ -203,7 +205,7 @@ def verify_decorator(
 @verify.register(nodes.TypeAlias)
 @trace
 def verify_typealias(
-    node: nodes.TypeAlias, module_node: MaybeMissing[Any]
+    stub: nodes.TypeAlias, runtime: MaybeMissing[Any]
 ) -> Iterator[Error]:
     if False:
         yield None

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -318,6 +318,8 @@ def _verify_arg_default_value(
             # UnboundTypes have ugly question marks following them, so default to var type.
             # Note we do this same fallback when constructing signatures in from_overloadedfuncdef
             stub_type = stub_arg.variable.type or stub_arg.type_annotation
+            if isinstance(stub_type, mypy.types.TypeVarType):
+                stub_type = stub_type.upper_bound
             if (
                 runtime_type is not None
                 and stub_type is not None

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -284,6 +284,7 @@ def verify_funcitem(
         # Ignore exact names for all dunder methods other than __init__
         if stub.name != "__init__" and stub.name.startswith("__"):
             return
+        # TODO: make this check a little less hacky, maybe be more lax for positional-only args
         if stub_arg.variable.name.replace("_", "") != runtime_arg.name.replace("_", ""):
             yield make_error(
                 f'stub argument "{stub_arg.variable.name}" differs from '
@@ -320,6 +321,14 @@ def verify_funcitem(
             yield make_error(
                 f'stub argument "{stub_arg.variable.name}" should be '
                 "positional-only (rename with a leading double underscore)"
+            )
+        if (
+            runtime_arg.kind != inspect.Parameter.POSITIONAL_ONLY
+            and stub_arg.variable.name.startswith("__")
+        ):
+            yield make_error(
+                f'stub argument "{stub_arg.variable.name}" is positional or keyword '
+                "(remove leading double underscore)"
             )
 
     # Checks involving *args

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -695,13 +695,13 @@ def main() -> int:
     )
     parser.add_argument(
         "--whitelist",
-        help="Use file as a whitelist. Whitelists can be created with --output-whitelist",
+        help="Use file as a whitelist. Whitelists can be created with --generate-whitelist",
     )
     parser.add_argument(
         "--concise", action="store_true", help="Make output concise",
     )
     parser.add_argument(
-        "--output-whitelist",
+        "--generate-whitelist",
         action="store_true",
         help="Print a whitelist (to stdout) to be used with --whitelist",
     )
@@ -714,8 +714,8 @@ def main() -> int:
         with open(args.whitelist) as f:
             whitelist = {l.strip(): False for l in f.readlines()}
 
-    # If we need to output a whitelist, we store Error.object_desc for each error here.
-    output_whitelist = set()
+    # If we need to generate a whitelist, we store Error.object_desc for each error here.
+    generated_whitelist = set()
 
     modules = args.modules
     if args.check_typeshed:
@@ -745,8 +745,8 @@ def main() -> int:
 
             # We have errors, so change exit code, and output whatever necessary
             exit_code = 1
-            if args.output_whitelist:
-                output_whitelist.add(error.object_desc)
+            if args.generate_whitelist:
+                generated_whitelist.add(error.object_desc)
                 continue
             print(error.get_description(concise=args.concise))
 
@@ -757,8 +757,8 @@ def main() -> int:
             print(f"note: unused whitelist entry {w}")
 
     # Print the generated whitelist
-    if args.output_whitelist:
-        for e in sorted(output_whitelist):
+    if args.generate_whitelist:
+        for e in sorted(generated_whitelist):
             print(e)
         exit_code = 0
 

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -381,7 +381,7 @@ def verify_funcitem(
             )
 
     # Check keyword-only args
-    for arg in set(stub_args_kwonly) & set(runtime_args_kwonly):
+    for arg in sorted(set(stub_args_kwonly) & set(runtime_args_kwonly)):
         stub_arg, runtime_arg = stub_args_kwonly[arg], runtime_args_kwonly[arg]
         yield from verify_arg_name(stub_arg, runtime_arg)
         yield from verify_arg_default_value(stub_arg, runtime_arg)
@@ -406,12 +406,12 @@ def verify_funcitem(
     if runtime_args_varkw is None or not set(runtime_args_kwonly).issubset(
         set(stub_args_kwonly)
     ):
-        for arg in set(stub_args_kwonly) - set(runtime_args_kwonly):
+        for arg in sorted(set(stub_args_kwonly) - set(runtime_args_kwonly)):
             yield make_error(f'runtime does not have argument "{arg}"')
     if stub_args_varkw is None or not set(stub_args_kwonly).issubset(
         set(runtime_args_kwonly)
     ):
-        for arg in set(runtime_args_kwonly) - set(stub_args_kwonly):
+        for arg in sorted(set(runtime_args_kwonly) - set(stub_args_kwonly)):
             if arg in set(stub_arg.variable.name for stub_arg in stub_args_pos):
                 yield make_error(f'stub argument "{arg}" is not keyword-only')
             else:

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -823,6 +823,8 @@ def is_dunder(name: str, exclude_init: bool = False) -> bool:
 
 def is_subtype_helper(left: mypy.types.Type, right: mypy.types.Type) -> bool:
     """Checks whether ``left`` is a subtype of ``right``."""
+    left = mypy.types.get_proper_type(left)
+    right = mypy.types.get_proper_type(right)
     if (
         isinstance(left, mypy.types.LiteralType)
         and isinstance(left.value, int)
@@ -862,7 +864,8 @@ def get_mypy_type_of_runtime_value(runtime: Any) -> Optional[mypy.types.Type]:
     if not isinstance(type_info, nodes.TypeInfo):
         return None
 
-    anytype = lambda: mypy.types.AnyType(mypy.types.TypeOfAny.unannotated)
+    def anytype() -> mypy.types.AnyType:
+        return mypy.types.AnyType(mypy.types.TypeOfAny.unannotated)
 
     if isinstance(runtime, tuple):
         # Special case tuples so we construct a valid mypy.types.TupleType

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -185,7 +185,7 @@ def verify_mypyfile(
     # We currently don't check things in the module that aren't in the stub, other than things that
     # are in __all__ to avoid false positives.
 
-    for entry in to_check:
+    for entry in sorted(to_check):
         yield from verify(
             getattr(stub.names.get(entry, MISSING), "node", MISSING),
             getattr(runtime, entry, MISSING),
@@ -208,7 +208,7 @@ def verify_typeinfo(
     to_check = set(stub.names)
     to_check.update(m for m in vars(runtime) if not m.startswith("_"))
 
-    for entry in to_check:
+    for entry in sorted(to_check):
         yield from verify(
             getattr(stub.names.get(entry, MISSING), "node", MISSING),
             getattr(runtime, entry, MISSING),

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -386,8 +386,8 @@ def _verify_signature(
             and not function_name.startswith("__")  # noisy for dunder methods
         ):
             yield (
-                f'stub argument "{stub_arg.variable.name}" should be '
-                "positional-only (rename with a leading double underscore)"
+                f'stub argument "{stub_arg.variable.name}" should be positional-only '
+                f'(rename with a leading double underscore, i.e. "__{runtime_arg.name}")'
             )
         if (
             runtime_arg.kind != inspect.Parameter.POSITIONAL_ONLY

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -645,10 +645,10 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    whitelist = set()
+    whitelist = {}
     if args.whitelist:
         with open(args.whitelist) as f:
-            whitelist = set(l.strip() for l in f.readlines())
+            whitelist = {l.strip(): False for l in f.readlines()}
 
     modules = args.modules
     if args.check_typeshed:
@@ -672,12 +672,19 @@ def main() -> int:
             if args.ignore_missing_stub and error.is_missing_stub():
                 continue
             if error.object_desc in whitelist:
+                whitelist[error.object_desc] = True
                 continue
             if args.output_whitelist:
                 print(error.object_desc)
                 continue
             exit_code = 1
             print(error.get_description(concise=args.concise))
+
+    for w in whitelist:
+        if not whitelist[w]:
+            exit_code = 1
+            print(f"note: unused whitelist entry {w}")
+
     return exit_code
 
 

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -68,7 +68,10 @@ class Error:
     def is_missing_stub(self) -> bool:
         return isinstance(self.stub_object, Missing)
 
-    def __str__(self) -> str:
+    def get_description(self, concise: bool = False) -> str:
+        if concise:
+            return _style(self.object_desc, bold=True) + " " + self.message
+
         stub_line = None
         stub_file = None
         if not isinstance(self.stub_object, Missing):
@@ -362,13 +365,16 @@ def build_stubs(
     return res.files
 
 
-def main() -> Iterator[Error]:
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("modules", nargs="+", help="Modules to test")
     parser.add_argument(
         "--ignore-missing-stub",
         action="store_true",
         help="Ignore errors for stub missing things that are present at runtime",
+    )
+    parser.add_argument(
+        "--concise", action="store_true", help="Make output concise",
     )
     parser.add_argument(
         "--custom-typeshed-dir", metavar="DIR", help="Use the custom typeshed in DIR"
@@ -386,9 +392,8 @@ def main() -> Iterator[Error]:
     for module in args.modules:
         for error in test_module(module, options, find_module_cache):
             if not args.ignore_missing_stub or not error.is_missing_stub():
-                yield error
+                print(error.get_description(concise=args.concise))
 
 
 if __name__ == "__main__":
-    for err in main():
-        print(err)
+    main()

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -74,7 +74,7 @@ def trace(fn):
 
 @singledispatch
 def verify(stub: nodes.Node, runtime: MaybeMissing[Any]) -> Iterator[Error]:
-    raise TypeError("unknown mypy node " + str(stub))
+    print("unknown mypy node " + str(stub))
 
 
 @verify.register(nodes.MypyFile)
@@ -140,13 +140,12 @@ def verify_funcitem(
     # TODO check arguments and return value
 
 
-@verify.register(type(None))
+@verify.register(Missing)
 @trace
-def verify_none(stub: None, runtime: MaybeMissing[Any]) -> Iterator[Error]:
-    if runtime is None:
-        yield Error("not_in_stub")
-    else:
-        yield Error("not_in_stub")
+def verify_none(stub: Missing, runtime: MaybeMissing[Any]) -> Iterator[Error]:
+    yield Error(f"not_in_stub: {runtime}")
+    if isinstance(runtime, Missing):
+        raise RuntimeError
 
 
 @verify.register(nodes.Var)

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -62,12 +62,23 @@ def test_module(
         yield from verify(stub, runtime)
 
 
+def trace(fn):
+    import functools
+
+    @functools.wraps(fn)
+    def new_fn(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return new_fn
+
+
 @singledispatch
 def verify(stub: nodes.Node, runtime: MaybeMissing[Any]) -> Iterator[Error]:
     raise TypeError("unknown mypy node " + str(stub))
 
 
 @verify.register(nodes.MypyFile)
+@trace
 def verify_mypyfile(
     stub: nodes.MypyFile, runtime: MaybeMissing[types.ModuleType]
 ) -> Iterator[Error]:
@@ -96,6 +107,7 @@ def verify_mypyfile(
 
 
 @verify.register(nodes.TypeInfo)
+@trace
 def verify_typeinfo(
     stub: nodes.TypeInfo, runtime: MaybeMissing[Any]
 ) -> Iterator[Error]:
@@ -113,6 +125,7 @@ def verify_typeinfo(
 
 
 @verify.register(nodes.FuncItem)
+@trace
 def verify_funcitem(
     stub: nodes.FuncItem, runtime: MaybeMissing[Any]
 ) -> Iterator[Error]:
@@ -124,6 +137,7 @@ def verify_funcitem(
 
 
 @verify.register(type(None))
+@trace
 def verify_none(stub: None, runtime: MaybeMissing[Any]) -> Iterator[Error]:
     if runtime is None:
         yield Error("not_in_stub")
@@ -132,6 +146,7 @@ def verify_none(stub: None, runtime: MaybeMissing[Any]) -> Iterator[Error]:
 
 
 @verify.register(nodes.Var)
+@trace
 def verify_var(node: nodes.Var, module_node: MaybeMissing[Any]) -> Iterator[Error]:
     if False:
         yield None
@@ -142,6 +157,7 @@ def verify_var(node: nodes.Var, module_node: MaybeMissing[Any]) -> Iterator[Erro
 
 
 @verify.register(nodes.OverloadedFuncDef)
+@trace
 def verify_overloadedfuncdef(
     node: nodes.OverloadedFuncDef, module_node: MaybeMissing[Any]
 ) -> Iterator[Error]:
@@ -151,6 +167,7 @@ def verify_overloadedfuncdef(
 
 
 @verify.register(nodes.TypeVarExpr)
+@trace
 def verify_typevarexpr(
     node: nodes.TypeVarExpr, module_node: MaybeMissing[Any]
 ) -> Iterator[Error]:
@@ -159,6 +176,7 @@ def verify_typevarexpr(
 
 
 @verify.register(nodes.Decorator)
+@trace
 def verify_decorator(
     node: nodes.Decorator, module_node: MaybeMissing[Any]
 ) -> Iterator[Error]:
@@ -167,6 +185,7 @@ def verify_decorator(
 
 
 @verify.register(nodes.TypeAlias)
+@trace
 def verify_typealias(
     node: nodes.TypeAlias, module_node: MaybeMissing[Any]
 ) -> Iterator[Error]:

--- a/scripts/stubtest.py
+++ b/scripts/stubtest.py
@@ -162,15 +162,19 @@ def verify_mypyfile(
         yield Error(object_path, "is not a module", stub, runtime)
         return
 
-    # Check all things in the stub
-    to_check = set(m for m, o in stub.names.items() if o.module_public)
+    # Check things in the stub that are public
+    to_check = set(
+        m
+        for m, o in stub.names.items()
+        if o.module_public and (not m.startswith("_") or hasattr(runtime, m))
+    )
     # Check all things declared in module's __all__
     to_check.update(getattr(runtime, "__all__", []))
     to_check.difference_update(
         {"__file__", "__doc__", "__name__", "__builtins__", "__package__"}
     )
     # We currently don't check things in the module that aren't in the stub, other than things that
-    # are in __all__ to avoid false positives.
+    # are in __all__, to avoid false positives.
 
     for entry in sorted(to_check):
         yield from verify(


### PR DESCRIPTION
Hello,

I recently embarked on a rewrite of stubtest with the goal of improving our testing of typeshed. For some more context, please refer to https://github.com/python/typeshed/issues/754 That issue also links examples of output and of typeshed issues this has detected.

Some notes about what this change contains:
- Previously stubtest.py used dumpmodule.py to generate a JSON representation of runtime objects. This abandons that approach in favour of directly using runtime objects, allowing us easier and more dynamic introspection.
- Much of stubtest.py was unimplemented, most notably, examining functions. This provides new and fairly detailed implementations of verify_funcitem, verify_overloadedfuncdef, verify_var, etc.
- In particular, we can now do everything (and more!) @JukkaL mentioned in the original post at https://github.com/python/typeshed/issues/754 
- There's a more complete CLI, with features to make testing typeshed easier.
- There's more documentation.

My goal with this draft PR is to solicit code review and feedback from folks familiar with mypy internals. Some notes:
- I'm still working on it!
- The code doesn't match mypy's style, eg, line length is shorter than 99 and the script currently doesn't support py35
- I haven't written any tests yet; I've just been running this against typeshed.
- There's some discussion about where this script should live over at https://github.com/python/typeshed/issues/754 -- curious if mypy has opinions on this.
- The previous stubtest.py has been broken by changes to mypy internals multiple times before. If we can merge it, is the extra maintenance something mypy is okay with? We'd also have to come up with good CI tests that aren't checking typeshed, to avoid horrible cross-project build dependencies.

Anyway, let me know your thoughts!

Resolves #3329