### PR TITLE
Fix joining of fixed-length tuples with mismatching lengths

### DIFF
--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -505,6 +505,12 @@ class JoinSuite(Suite):
         self.assert_join(self.tuple(self.fx.a),
                          self.tuple(self.fx.a, self.fx.a),
                          self.var_tuple(self.fx.a))
+        self.assert_join(self.tuple(self.fx.b),
+                         self.tuple(self.fx.a, self.fx.c),
+                         self.var_tuple(self.fx.a))
+        self.assert_join(self.tuple(),
+                         self.tuple(self.fx.a),
+                         self.var_tuple(self.fx.a))
 
     def test_var_tuples(self) -> None:
         self.assert_join(self.tuple(self.fx.a),

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1158,6 +1158,52 @@ reveal_type(subtup if int() else vartup)  # N: Revealed type is 'builtins.tuple[
 [builtins fixtures/tuple.pyi]
 [out]
 
+[case testTupleJoinIrregular]
+from typing import Tuple
+
+tup1 = None  # type: Tuple[bool, int]
+tup2 = None  # type: Tuple[bool]
+
+reveal_type(tup1 if int() else tup2)  # N: Revealed type is 'builtins.tuple[builtins.int]'
+reveal_type(tup2 if int() else tup1)  # N: Revealed type is 'builtins.tuple[builtins.int]'
+
+reveal_type(tup1 if int() else ())  # N: Revealed type is 'builtins.tuple[builtins.int]'
+reveal_type(() if int() else tup1)  # N: Revealed type is 'builtins.tuple[builtins.int]'
+
+reveal_type(tup2 if int() else ())  # N: Revealed type is 'builtins.tuple[builtins.bool]'
+reveal_type(() if int() else tup2)  # N: Revealed type is 'builtins.tuple[builtins.bool]'
+
+[builtins fixtures/tuple.pyi]
+[out]
+
+[case testTupleSubclassJoinIrregular]
+from typing import Tuple, NamedTuple
+
+class NTup1(NamedTuple):
+    a: bool
+
+class NTup2(NamedTuple):
+    a: bool
+    b: bool
+
+class SubTuple(Tuple[bool, int, int]): ...
+
+tup1 = None  # type: NTup1
+tup2 = None  # type: NTup2
+subtup = None  # type: SubTuple
+
+reveal_type(tup1 if int() else tup2)  # N: Revealed type is 'builtins.tuple[builtins.bool]'
+reveal_type(tup2 if int() else tup1)  # N: Revealed type is 'builtins.tuple[builtins.bool]'
+
+reveal_type(tup1 if int() else subtup)  # N: Revealed type is 'builtins.tuple[builtins.int]'
+reveal_type(subtup if int() else tup1)  # N: Revealed type is 'builtins.tuple[builtins.int]'
+
+reveal_type(tup2 if int() else subtup)  # N: Revealed type is 'builtins.tuple[builtins.int]'
+reveal_type(subtup if int() else tup2)  # N: Revealed type is 'builtins.tuple[builtins.int]'
+
+[builtins fixtures/tuple.pyi]
+[out]
+
 [case testTupleWithUndersizedContext]
 a = ([1], 'x')
 if int():


### PR DESCRIPTION
For example: `Tuple[bool, int] + Tuple[bool]` becomes `Tuple[int, ...]`

Previously Mypy simply punted and returned `object`.

This solves part of #4975. The other missing handling of fixed tuple + variadic tuple will be implemented separately, if this PR goes well. :)
