### PR TITLE
Improve decorators documentation (add decorator factories)

### DIFF
--- a/docs/source/cheat_sheet.rst
+++ b/docs/source/cheat_sheet.rst
@@ -113,7 +113,6 @@ Functions
        # type: (...) -> bool
        <code>
 
-
 When you're puzzled or when things are complicated
 **************************************************
 
@@ -256,3 +255,22 @@ Miscellaneous
            return sys.stdin
        else:
            return sys.stdout
+
+
+Decorators
+**********
+
+Decorator functions can be expressed via generics. See
+:ref:`declaring-decorators` for the more details.
+
+.. code-block:: python
+
+    from typing import Any, Callable, TypeVar
+
+    F = TypeVar('F', bound=Callable[..., Any])
+
+    def bare_decorator(func):  # type: (F) -> F
+        ...
+
+    def decorator_args(url):  # type: (str) -> Callable[[F], F]
+        ...

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -127,7 +127,6 @@ Python 3 supports an annotation syntax for function declarations.
    quux(3)  # Fine
    quux(__x=3)  # Error
 
-
 When you're puzzled or when things are complicated
 **************************************************
 
@@ -311,3 +310,22 @@ Miscellaneous
    # class of that name later on in the file
    def f(foo: 'A') -> int:  # Ok
        ...
+
+
+Decorators
+**********
+
+Decorator functions can be expressed via generics. See
+:ref:`declaring-decorators` for the more details.
+
+.. code-block:: python
+
+    from typing import Any, Callable, TypeVar
+
+    F = TypeVar('F', bound=Callable[..., Any])
+
+    def bare_decorator(func: F) -> F:
+        ...
+
+    def decorator_args(url: str) -> Callable[[F], F]:
+        ...


### PR DESCRIPTION
As mentioned in https://github.com/python/mypy/issues/3157#issuecomment-578532179 I found the documentation for decorator usage to be lacking:

* Previously only bare decorators were explained, but decorator
  factories are also fairly common in the real world.
* Also added decorator examples to cheat sheet page.
* Explained difference in behavior for class decorators.
* Shortened (IMO) excessive example for bare decorators.
