### PR TITLE
Analyze descriptor methods as if they're methods, not functions

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2994,6 +2994,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         typ = map_instance_to_supertype(attribute_type, dunder_set.info)
         dunder_set_type = expand_type_by_instance(bound_method, typ)
 
+        callable_name = self.expr_checker.method_fullname(attribute_type, "__set__")
+        dunder_set_type = self.expr_checker.transform_callee_type(
+            callable_name, dunder_set_type,
+            [TempNode(instance_type, context=context), rvalue],
+            [nodes.ARG_POS, nodes.ARG_POS],
+            context, object_type=attribute_type,
+        )
+
         # Here we just infer the type, the result should be type-checked like a normal assignment.
         # For this we use the rvalue as type context.
         self.msg.disable_errors()
@@ -3002,7 +3010,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             [TempNode(instance_type, context=context), rvalue],
             [nodes.ARG_POS, nodes.ARG_POS],
             context, object_type=attribute_type,
-            callable_name=attribute_type.type.fullname + ".__set__")
+            callable_name=callable_name)
         self.msg.enable_errors()
 
         # And now we type check the call second time, to show errors related
@@ -3013,7 +3021,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
              TempNode(AnyType(TypeOfAny.special_form), context=context)],
             [nodes.ARG_POS, nodes.ARG_POS],
             context, object_type=attribute_type,
-            callable_name=attribute_type.type.fullname + ".__set__")
+            callable_name=callable_name)
 
         # should be handled by get_method above
         assert isinstance(inferred_dunder_set_type, CallableType)  # type: ignore

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3001,7 +3001,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             dunder_set_type,
             [TempNode(instance_type, context=context), rvalue],
             [nodes.ARG_POS, nodes.ARG_POS],
-            context)
+            context, object_type=attribute_type,
+            callable_name=attribute_type.type.fullname + ".__set__")
         self.msg.enable_errors()
 
         # And now we type check the call second time, to show errors related
@@ -3011,7 +3012,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             [TempNode(instance_type, context=context),
              TempNode(AnyType(TypeOfAny.special_form), context=context)],
             [nodes.ARG_POS, nodes.ARG_POS],
-            context)
+            context, object_type=attribute_type,
+            callable_name=attribute_type.type.fullname + ".__set__")
 
         # should be handled by get_method above
         assert isinstance(inferred_dunder_set_type, CallableType)  # type: ignore

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -490,7 +490,8 @@ def analyze_descriptor_access(instance_type: Type,
         dunder_get_type,
         [TempNode(instance_type, context=context),
          TempNode(TypeType.make_normalized(owner_type), context=context)],
-        [ARG_POS, ARG_POS], context)
+        [ARG_POS, ARG_POS], context, object_type=descriptor_type,
+        callable_name=descriptor_type.type.fullname + ".__get__")
 
     inferred_dunder_get_type = get_proper_type(inferred_dunder_get_type)
     if isinstance(inferred_dunder_get_type, AnyType):

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -486,12 +486,20 @@ def analyze_descriptor_access(instance_type: Type,
     else:
         owner_type = instance_type
 
+    callable_name = chk.expr_checker.method_fullname(descriptor_type, "__get__")
+    dunder_get_type = chk.expr_checker.transform_callee_type(
+        callable_name, dunder_get_type,
+        [TempNode(instance_type, context=context),
+         TempNode(TypeType.make_normalized(owner_type), context=context)],
+        [ARG_POS, ARG_POS], context, object_type=descriptor_type,
+    )
+
     _, inferred_dunder_get_type = chk.expr_checker.check_call(
         dunder_get_type,
         [TempNode(instance_type, context=context),
          TempNode(TypeType.make_normalized(owner_type), context=context)],
         [ARG_POS, ARG_POS], context, object_type=descriptor_type,
-        callable_name=descriptor_type.type.fullname + ".__get__")
+        callable_name=callable_name)
 
     inferred_dunder_get_type = get_proper_type(inferred_dunder_get_type)
     if isinstance(inferred_dunder_get_type, AnyType):

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -698,3 +698,26 @@ class A: pass
 [file mypy.ini]
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/customize_mro.py
+
+[case testDescriptorMethods]
+# flags: --config-file tmp/mypy.ini
+
+class Desc:
+    def __get__(self, obj, cls):
+        pass
+
+    def __set__(self, obj, val):
+        pass
+
+class Cls:
+    attr = Desc()
+
+reveal_type(Cls().attr)  # N: Revealed type is 'builtins.int'
+reveal_type(Cls.attr)  # N: Revealed type is 'builtins.str'
+
+Cls().attr = 3
+Cls().attr = "foo"  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[file mypy.ini]
+\[mypy]
+plugins=<ROOT>/test-data/unit/plugins/descriptor.py

--- a/test-data/unit/plugins/descriptor.py
+++ b/test-data/unit/plugins/descriptor.py
@@ -1,0 +1,34 @@
+from mypy.plugin import Plugin
+from mypy.types import NoneType, CallableType
+
+
+class DescriptorPlugin(Plugin):
+    def get_method_hook(self, fullname):
+        if fullname == "__main__.Desc.__get__":
+            return get_hook
+        return None
+
+    def get_method_signature_hook(self, fullname):
+        if fullname == "__main__.Desc.__set__":
+            return set_hook
+        return None
+
+
+def get_hook(ctx):
+    if isinstance(ctx.arg_types[0][0], NoneType):
+        return ctx.api.named_type("builtins.str")
+    return ctx.api.named_type("builtins.int")
+
+
+def set_hook(ctx):
+    return CallableType(
+        [ctx.api.named_type("__main__.Cls"), ctx.api.named_type("builtins.int")],
+        ctx.default_signature.arg_kinds,
+        ctx.default_signature.arg_names,
+        ctx.default_signature.ret_type,
+        ctx.default_signature.fallback,
+    )
+
+
+def plugin(version):
+    return DescriptorPlugin


### PR DESCRIPTION
When `__get__` and `__set__` were implicitly called they were analyzed without taking the type of the descriptor into account. That meant that they were only visible to plugins as function calls with unclear
names.