### PR TITLE
Support determining whether a literal is truthy

### DIFF
--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -736,10 +736,10 @@ class JoinSuite(Suite):
         self.assert_join(UnionType([lit1, lit2]), lit2, UnionType([lit1, lit2]))
         self.assert_join(UnionType([lit1, lit2]), a, a)
         self.assert_join(UnionType([lit1, lit3]), a, UnionType([a, lit3]))
-        self.assert_join(UnionType([d, lit3]), lit3, UnionType([d, lit3]))
+        self.assert_join(UnionType([d, lit3]), lit3, d)
         self.assert_join(UnionType([d, lit3]), d, UnionType([d, lit3]))
-        self.assert_join(UnionType([a, lit1]), lit1, UnionType([a, lit1]))
-        self.assert_join(UnionType([a, lit1]), lit2, UnionType([a, lit1]))
+        self.assert_join(UnionType([a, lit1]), lit1, a)
+        self.assert_join(UnionType([a, lit1]), lit2, a)
         self.assert_join(UnionType([lit1, lit2]),
                          UnionType([lit1, lit2]),
                          UnionType([lit1, lit2]))

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1591,9 +1591,15 @@ class LiteralType(ProperType):
 
     def __init__(self, value: LiteralValue, fallback: Instance,
                  line: int = -1, column: int = -1) -> None:
-        super().__init__(line, column)
         self.value = value
+        super().__init__(line, column)
         self.fallback = fallback
+
+    def can_be_false_default(self) -> bool:
+        return not self.value
+
+    def can_be_true_default(self) -> bool:
+        return bool(self.value)
 
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_literal_type(self)

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -965,3 +965,22 @@ else:
     reveal_type(a)  # E: Statement is unreachable
     reveal_type(b)
 [builtins fixtures/primitives.pyi]
+
+[case testNarrowingLiteralTruthiness]
+from typing import Union
+from typing_extensions import Literal
+
+str_or_false: Union[Literal[False], str]
+
+if str_or_false:
+    reveal_type(str_or_false)   # N: Revealed type is 'builtins.str'
+else:
+    reveal_type(str_or_false)   # N: Revealed type is 'Union[Literal[False], builtins.str]'
+
+true_or_false: Literal[True, False]
+
+if true_or_false:
+    reveal_type(true_or_false)  # N: Revealed type is 'Literal[True]'
+else:
+    reveal_type(true_or_false)  # N: Revealed type is 'Literal[False]'
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
This means types like `Union[Literal[False], str]` can be narrowed down more easily.

One test had to be adjusted, because it started checking more aggressively whether a union could be simplified. I think that's ok, because it's doing the equivalent of simplifying `Union[Literal["foo"], str]` to `str`, which seems correct.