### PR TITLE
Support typing.Annotated on top of typing_extensions.Annotated

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -43,6 +43,7 @@ type_constructors = {
     'typing.Union',
     'typing.Literal',
     'typing_extensions.Literal',
+    'typing.Annotated',
     'typing_extensions.Annotated',
 }  # type: Final
 
@@ -311,7 +312,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             return UninhabitedType(is_noreturn=True)
         elif fullname in ('typing_extensions.Literal', 'typing.Literal'):
             return self.analyze_literal_type(t)
-        elif fullname == 'typing_extensions.Annotated':
+        elif fullname in ('typing_extensions.Annotated', 'typing.Annotated'):
             if len(t.args) < 2:
                 self.fail("Annotated[...] must have exactly one type argument"
                           " and at least one annotation", t)


### PR DESCRIPTION
This is to handle PEP 593 support recently merged into CPython[1].

I'm wondering what to do with this test-wise, as `https://github.com/python/mypy/blob/39d6bde2ec7063bd2cec42cce9295479e744bcc7/test-data/unit/check-annotated.test` is full of imports from `typing_extensions` and ideally, when running mypy tests on CPython nightly, tests would also import `Annotated` from `typing`. But maybe it's not worth it right now.

[1] https://github.com/python/cpython/pull/18260