### PR TITLE
Use repr to format out/err in dmypy verbose stats output

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -413,7 +413,7 @@ def show_stats(response: Mapping[str, object]) -> None:
         if key not in ('out', 'err'):
             print("%-24s: %10s" % (key, "%.3f" % value if isinstance(value, float) else value))
         else:
-            value = str(value).replace('\n', '\\n')
+            value = repr(value)[1:-1]
             if len(value) > 50:
                 value = value[:40] + ' ...'
             print("%-24s: %s" % (key, value))


### PR DESCRIPTION
This prevents control characters being interpreted, though it does
uglify the output in its own way.