### PR TITLE
Make mypy.api.run_dmypy actually capture the output

### DIFF
--- a/mypy/api.py
+++ b/mypy/api.py
@@ -18,7 +18,8 @@ the exit status mypy normally returns to the operating system.
 Any pretty formatting is left to the caller.
 
 The 'run_dmypy' function is similar, but instead mimics invocation of
-dmypy.
+dmypy. Note that run_dmypy is not thread-safe and modifies sys.stdout
+and sys.stderr during its invocation.
 
 Note that these APIs don't support incremental generation of error
 messages.
@@ -41,6 +42,8 @@ if result[1]:
 print('\nExit status:', result[2])
 
 """
+
+import sys
 
 from io import StringIO
 from typing import List, Tuple, TextIO, Callable
@@ -69,4 +72,20 @@ def run(args: List[str]) -> Tuple[str, str, int]:
 
 def run_dmypy(args: List[str]) -> Tuple[str, str, int]:
     from mypy.dmypy.client import main
-    return _run(lambda stdout, stderr: main(args))
+
+    # A bunch of effort has been put into threading stdout and stderr
+    # through the main API to avoid the threadsafety problems of
+    # modifying sys.stdout/sys.stderr, but that hasn't been done for
+    # the dmypy client, so we just do the non-threadsafe thing.
+    def f(stdout: TextIO, stderr: TextIO) -> None:
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        try:
+            sys.stdout = stdout
+            sys.stderr = stderr
+            main(args)
+        finally:
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+
+    return _run(f)


### PR DESCRIPTION
When the main run API was made threadsafe this broke output capturing
from run_dmypy. I don't really care about the threadsafety of
run_dmypy but I do care about output capture ever working, so I am
restoring the old sys.stdout swapping behavior for run_dmypy. I'd take
a patch to thread stdout through the client if anybody really cares.