### PR TITLE
Fix an incremental crash bug caused by ad-hoc intersection

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3689,7 +3689,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         assert isinstance(curr_module, MypyFile)
 
         base_classes = []
-        formatted_names = []
         for inst in instances:
             expanded = [inst]
             if inst.type.is_intersection:
@@ -3697,10 +3696,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
             for expanded_inst in expanded:
                 base_classes.append(expanded_inst)
-                formatted_names.append(format_type_bare(expanded_inst))
 
+        # We use the pretty_names_list for error messages but can't
+        # use it for the real name that goes into the symbol table
+        # because it can have dots in it.
         pretty_names_list = pretty_seq(format_type_distinctly(*base_classes, bare=True), "and")
-        short_name = '<subclass of {}>'.format(pretty_names_list)
+        names_list = pretty_seq([x.type.name for x in base_classes], "and")
+        short_name = '<subclass of {}>'.format(names_list)
         full_name = gen_unique_name(short_name, curr_module.names)
 
         old_msg = self.msg

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5187,6 +5187,51 @@ reveal_type(Foo().x)
 [out2]
 tmp/b.py:2: note: Revealed type is 'a.<subclass of "A" and "B">'
 
+[case testIsInstanceAdHocIntersectionIncrementalNoChangeSameName]
+import b
+[file c.py]
+class B: pass
+[file a.py]
+import c
+class B: pass
+
+class Foo:
+    def __init__(self) -> None:
+        x: c.B
+        assert isinstance(x, B)
+        self.x = x
+[file b.py]
+from a import Foo
+[file b.py.2]
+from a import Foo
+reveal_type(Foo().x)
+[builtins fixtures/isinstance.pyi]
+[out]
+[out2]
+tmp/b.py:2: note: Revealed type is 'a.<subclass of "B" and "B">'
+
+
+[case testIsInstanceAdHocIntersectionIncrementalNoChangeTuple]
+import b
+[file a.py]
+from typing import Tuple
+class B: pass
+
+class Foo:
+    def __init__(self) -> None:
+        x: Tuple[int, ...]
+        assert isinstance(x, B)
+        self.x = x
+[file b.py]
+from a import Foo
+[file b.py.2]
+from a import Foo
+reveal_type(Foo().x)
+[builtins fixtures/isinstance.pyi]
+[out]
+[out2]
+tmp/b.py:2: note: Revealed type is 'a.<subclass of "tuple" and "B">'
+
 [case testIsInstanceAdHocIntersectionIncrementalIsInstanceChange]
 import c
 [file a.py]
@@ -5316,4 +5361,3 @@ reveal_type(z)
 tmp/c.py:2: note: Revealed type is 'a.A'
 [out2]
 tmp/c.py:2: note: Revealed type is 'a.<subclass of "A" and "B">'
-

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -2369,14 +2369,14 @@ else:
 
 y: A[Parent]
 if isinstance(y, B):
-    reveal_type(y)      # N: Revealed type is '__main__.<subclass of "A[Parent]" and "B">'
+    reveal_type(y)      # N: Revealed type is '__main__.<subclass of "A" and "B">'
     reveal_type(y.f())  # N: Revealed type is '__main__.Parent*'
 else:
     reveal_type(y)      # N: Revealed type is '__main__.A[__main__.Parent]'
 
 z: A[Child]
 if isinstance(z, B):
-    reveal_type(z)      # N: Revealed type is '__main__.<subclass of "A[Child]" and "B">'
+    reveal_type(z)      # N: Revealed type is '__main__.<subclass of "A" and "B">1'
     reveal_type(z.f())  # N: Revealed type is '__main__.Child*'
 else:
     reveal_type(z)      # N: Revealed type is '__main__.A[__main__.Child]'
@@ -2518,7 +2518,7 @@ class A: pass
 
 x: A
 if isinstance(x, A2):
-    reveal_type(x)  # N: Revealed type is '__main__.<subclass of "__main__.A" and "foo.A">'
+    reveal_type(x)  # N: Revealed type is '__main__.<subclass of "A" and "A">'
 
 [file foo.py]
 class A: pass

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -1564,7 +1564,7 @@ if isinstance(c1i, P1):
 else:
     reveal_type(c1i) # Unreachable
 if isinstance(c1i, P):
-    reveal_type(c1i) # N: Revealed type is '__main__.<subclass of "C1[int]" and "P">'
+    reveal_type(c1i) # N: Revealed type is '__main__.<subclass of "C1" and "P">'
 else:
     reveal_type(c1i) # N: Revealed type is '__main__.C1[builtins.int]'
 


### PR DESCRIPTION
Ad-hoc intersection was generating type names with dots in them, which
are interpreted as module separators. I fixed this by making the names
worse and just using the bare name of the class.

There are other options that could be pursued:
* Replacing "." with some other character and then either switching it
  back when displayed or just printing it. One option that I was very
  tempted by was to use U+2024 ONE DOT LEADER.
* Compute the intersection names on the fly when formatting.

I decided to do the most obvious and the least tricky thing because
this isn't important.