### PR TITLE
mypy: require Python 3.5.3 or greater

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,8 @@ env:
 
 jobs:
   include:
-  # Specifically request 3.5.1 because we need to be compatible with that.
-  - name: "run test suite with python 3.5.1 (compiled with mypyc)"
-    python: 3.5.1
+  - name: "run test suite with python 3.5.3 (compiled with mypyc)"
+    python: 3.5.3
     dist: trusty
     env:
     - TOXENV=py

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -387,13 +387,14 @@ def get_unique_redefinition_name(name: str, existing: Container[str]) -> str:
 def check_python_version(program: str) -> None:
     """Report issues with the Python used to run mypy, dmypy, or stubgen"""
     # Check for known bad Python versions.
-    if sys.version_info[:2] < (3, 5):
+    if sys.version_info < (3, 5):
         sys.exit("Running {name} with Python 3.4 or lower is not supported; "
                  "please upgrade to 3.5 or newer".format(name=program))
     # this can be deleted once we drop support for 3.5
-    if sys.version_info[:3] == (3, 5, 0):
-        sys.exit("Running {name} with Python 3.5.0 is not supported; "
-                 "please upgrade to 3.5.1 or newer".format(name=program))
+    if sys.version_info < (3, 5, 3):
+        version = ".".join(map(str, sys.version_info[:3]))
+        sys.exit("Running {name} with Python {version} is not supported; "
+                 "please upgrade to 3.5.3 or newer".format(name=program, version=version))
 
 
 def count_stats(errors: List[str]) -> Tuple[int, int]:


### PR DESCRIPTION
See #8380 for motivation, we run into some issue with the version of typing.py in 3.5.1 (same as in https://github.com/dropbox/sqlalchemy-stubs/issues/63). It's also hard to find workarounds, because I can't get a working version of that Python going.

3.5.1 is over four years old, and EOL for 3.5 is in seven months.
Obviously understand if we can't/don't want to merge this.