### PR TITLE
Fix join between subclass of 'unicode' and 'str'

### DIFF
--- a/mypy/join.py
+++ b/mypy/join.py
@@ -353,8 +353,7 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
 
 
 def join_instances(t: Instance, s: Instance) -> ProperType:
-    """Calculate the join of two instance types.
-    """
+    """Calculate the join of two instance types."""
     if t.type == s.type:
         # Simplest case: join two types with the same base type (but
         # potentially different arguments).
@@ -395,6 +394,11 @@ def join_instances_via_supertype(t: Instance, s: Instance) -> ProperType:
         if best is None or is_better(res, best):
             best = res
     assert best is not None
+    promote = get_proper_type(t.type._promote)
+    if isinstance(promote, Instance):
+        res = join_instances(promote, s)
+        if is_better(res, best):
+            best = res
     return best
 
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3137,3 +3137,10 @@ y = defaultdict(list)  # E: Need type annotation for 'y'
 y['a'] = []
 reveal_type(y)  # N: Revealed type is 'collections.defaultdict[Any, Any]'
 [builtins fixtures/dict.pyi]
+
+[case testJoinOfStrAndUnicodeSubclass_python2]
+class S(unicode): pass
+reveal_type(S() if bool() else '')  # N: Revealed type is 'builtins.unicode'
+reveal_type('' if bool() else S())  # N: Revealed type is 'builtins.unicode'
+reveal_type(S() if bool() else str())  # N: Revealed type is 'builtins.unicode'
+reveal_type(str() if bool() else S())  # N: Revealed type is 'builtins.unicode'


### PR DESCRIPTION
There was one case where type promotion wasn't considered.

Fixes #8394.