### PR TITLE
Refactor: move is_typeshed_file() to mypy.util

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -78,6 +78,7 @@ from mypy.scope import Scope
 from mypy import state, errorcodes as codes
 from mypy.traverser import has_return_statement, all_return_statements
 from mypy.errorcodes import ErrorCode
+from mypy.util import is_typeshed_file
 
 T = TypeVar('T')
 
@@ -233,7 +234,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         self.pass_num = 0
         self.current_node_deferred = False
         self.is_stub = tree.is_stub
-        self.is_typeshed_stub = errors.is_typeshed_file(path)
+        self.is_typeshed_stub = is_typeshed_file(path)
         self.inferred_attribute_types = None
         if options.strict_optional_whitelist is None:
             self.suppress_none_errors = not options.show_none_errors

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -11,7 +11,7 @@ from mypy.options import Options
 from mypy.version import __version__ as mypy_version
 from mypy.errorcodes import ErrorCode
 from mypy import errorcodes as codes
-from mypy.util import DEFAULT_SOURCE_OFFSET
+from mypy.util import DEFAULT_SOURCE_OFFSET, is_typeshed_file
 
 T = TypeVar('T')
 allowed_duplicates = ['@overload', 'Got:', 'Expected:']  # type: Final
@@ -372,17 +372,13 @@ class Errors:
 
     def generate_unused_ignore_errors(self, file: str) -> None:
         ignored_lines = self.ignored_lines[file]
-        if not self.is_typeshed_file(file) and file not in self.ignored_files:
+        if not is_typeshed_file(file) and file not in self.ignored_files:
             for line in set(ignored_lines) - self.used_ignored_lines[file]:
                 # Don't use report since add_error_info will ignore the error!
                 info = ErrorInfo(self.import_context(), file, self.current_module(), None,
                                  None, line, -1, 'error', "unused 'type: ignore' comment",
                                  None, False, False)
                 self._add_error_info(file, info)
-
-    def is_typeshed_file(self, file: str) -> bool:
-        # gross, but no other clear way to tell
-        return 'typeshed' in os.path.normpath(file).split(os.sep)
 
     def num_messages(self) -> int:
         """Return the number of generated messages."""

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -103,7 +103,7 @@ from mypy.plugin import (
     Plugin, ClassDefContext, SemanticAnalyzerPluginInterface,
     DynamicClassDefContext
 )
-from mypy.util import correct_relative_import, unmangle, module_prefix
+from mypy.util import correct_relative_import, unmangle, module_prefix, is_typeshed_file
 from mypy.scope import Scope
 from mypy.semanal_shared import (
     SemanticAnalyzerInterface, set_callable_name, calculate_tuple_fallback, PRIORITY_FALLBACKS
@@ -481,7 +481,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         self.cur_mod_id = file_node.fullname
         scope.enter_file(self.cur_mod_id)
         self.is_stub_file = file_node.path.lower().endswith('.pyi')
-        self._is_typeshed_stub_file = self.errors.is_typeshed_file(file_node.path)
+        self._is_typeshed_stub_file = is_typeshed_file(file_node.path)
         self.globals = file_node.names
         self.tvar_scope = TypeVarScope()
 

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -44,6 +44,7 @@ from mypy.errors import Errors
 from mypy.semanal_infer import infer_decorator_signature_if_simple
 from mypy.checker import FineGrainedDeferredNode
 from mypy.server.aststrip import SavedAttributes
+from mypy.util import is_typeshed_file
 import mypy.build
 
 if TYPE_CHECKING:
@@ -353,7 +354,7 @@ def check_type_arguments(graph: 'Graph', scc: List[str], errors: Errors) -> None
         assert state.tree
         analyzer = TypeArgumentAnalyzer(errors,
                                         state.options,
-                                        errors.is_typeshed_file(state.path or ''))
+                                        is_typeshed_file(state.path or ''))
         with state.wrap_context():
             with strict_optional_set(state.options.strict_optional):
                 state.tree.accept(analyzer)
@@ -368,7 +369,7 @@ def check_type_arguments_in_targets(targets: List[FineGrainedDeferredNode], stat
     """
     analyzer = TypeArgumentAnalyzer(errors,
                                     state.options,
-                                    errors.is_typeshed_file(state.path or ''))
+                                    is_typeshed_file(state.path or ''))
     with state.wrap_context():
         with strict_optional_set(state.options.strict_optional):
             for target in targets:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -1,4 +1,5 @@
 """Utility functions with no non-trivial dependencies."""
+
 import os
 import pathlib
 import re
@@ -700,3 +701,8 @@ class FancyFormatter:
         if not use_color:
             return msg
         return self.style(msg, 'red', bold=True)
+
+
+def is_typeshed_file(file: str) -> bool:
+    # gross, but no other clear way to tell
+    return 'typeshed' in os.path.normpath(file).split(os.sep)


### PR DESCRIPTION
This way we can call it in contexts that don't have access to
an `Errors` instance.