### PR TITLE
Don't crash if module shadows special library module such as "typing"

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -36,7 +36,7 @@ from mypy.indirection import TypeIndirectionVisitor
 from mypy.errors import Errors, CompileError, ErrorInfo, report_internal_error
 from mypy.util import (
     DecodeError, decode_python_encoding, is_sub_path, get_mypy_comments, module_prefix,
-    read_py_file, hash_digest,
+    read_py_file, hash_digest, is_typeshed_file
 )
 if TYPE_CHECKING:
     from mypy.report import Reports  # Avoid unconditional slow import
@@ -65,6 +65,18 @@ from mypy import errorcodes as codes
 # output compared to --verbose output. We use a global flag to enable this so
 # that it's easy to enable this when running tests.
 DEBUG_FINE_GRAINED = False  # type: Final
+
+# These modules are special and should always come from typeshed.
+CORE_BUILTIN_MODULES = {
+    'builtins',
+    'typing',
+    'types',
+    'typing_extensions',
+    'mypy_extensions',
+    '_importlib_modulespec',
+    'sys',
+    'abc',
+}
 
 
 Graph = Dict[str, 'State']
@@ -2390,6 +2402,13 @@ def find_module_and_diagnose(manager: BuildManager,
                 if is_sub_path(path, dir):
                     # Silence errors in site-package dirs and typeshed
                     follow_imports = 'silent'
+        if (id in CORE_BUILTIN_MODULES
+                and not is_typeshed_file(path)
+                and not options.use_builtins_fixtures):
+            raise CompileError([
+                'mypy: "%s" shadows library module "%s"' % (path, id),
+                'note: A user-defined top-level module with name "%s" is not supported' % id
+            ])
         return (path, follow_imports)
     else:
         # Could not find a module.  Typically the reason is a

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2404,7 +2404,8 @@ def find_module_and_diagnose(manager: BuildManager,
                     follow_imports = 'silent'
         if (id in CORE_BUILTIN_MODULES
                 and not is_typeshed_file(path)
-                and not options.use_builtins_fixtures):
+                and not options.use_builtins_fixtures
+                and not options.custom_typeshed_dir):
             raise CompileError([
                 'mypy: "%s" shadows library module "%s"' % (path, id),
                 'note: A user-defined top-level module with name "%s" is not supported' % id

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -88,16 +88,14 @@ def test_python_evaluation(testcase: DataDrivenTestCase, cache_dir: str) -> None
         if line.startswith(test_temp_dir + os.sep):
             output.append(line[len(test_temp_dir + os.sep):].rstrip("\r\n"))
         else:
+            # Normalize paths so that the output is the same on Windows and Linux/macOS.
+            line = line.replace(test_temp_dir + os.sep, test_temp_dir + '/')
             output.append(line.rstrip("\r\n"))
     if returncode == 0:
         # Execute the program.
         proc = subprocess.run([interpreter, '-Wignore', program],
                               cwd=test_temp_dir, stdout=PIPE, stderr=PIPE)
-        lines = split_lines(proc.stdout, proc.stderr)
-        if sys.platform == 'win32':
-            # Normalize any paths that might appear in the output
-            lines = [line.replace('\\', '/') for line in lines]
-        output.extend(lines)
+        output.extend(split_lines(proc.stdout, proc.stderr))
     # Remove temp file.
     os.remove(program_path)
     for i, line in enumerate(output):

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -93,7 +93,11 @@ def test_python_evaluation(testcase: DataDrivenTestCase, cache_dir: str) -> None
         # Execute the program.
         proc = subprocess.run([interpreter, '-Wignore', program],
                               cwd=test_temp_dir, stdout=PIPE, stderr=PIPE)
-        output.extend(split_lines(proc.stdout, proc.stderr))
+        lines = split_lines(proc.stdout, proc.stderr)
+        if sys.platform == 'win32':
+            # Normalize any paths that might appear in the output
+            lines = [line.replace('\\', '/') for line in lines]
+        output.extend(lines)
     # Remove temp file.
     os.remove(program_path)
     for i, line in enumerate(output):

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1501,3 +1501,12 @@ from typing import List
 async def foo() -> None:
     f = []  # type: List[Future[None]]
     await wait(f)
+
+[case testShadowTypingModule]
+1 + ''
+[file typing.py]
+x = 0
+1 + ''
+[out]
+mypy: "tmp/typing.py" shadows library module "typing"
+note: A user-defined top-level module with name "typing" is not supported


### PR DESCRIPTION
Special cases a small set of modules so that they must be defined in
typeshed, as otherwise it's likely that mypy can crash, as it assumes
that various things are defined in very specific ways in these modules.

Fixes #1876.