### PR TITLE
stubtest: workaround mypyc's issue with vars

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -14,7 +14,7 @@ import types
 import warnings
 from functools import singledispatch
 from pathlib import Path
-from typing import Any, Dict, Generic, Iterator, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, Generic, Iterator, List, Optional, Tuple, TypeVar, Union, cast
 
 from typing_extensions import Type
 
@@ -236,7 +236,8 @@ def verify_typeinfo(
         return
 
     to_check = set(stub.names)
-    to_check.update(m for m in vars(runtime) if not m.startswith("_"))
+    # cast to workaround mypyc complaints
+    to_check.update(m for m in cast(Any, vars)(runtime) if not m.startswith("_"))
 
     for entry in sorted(to_check):
         yield from verify(

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ if USE_MYPYC:
         # Also I think there would be problems with how we generate version.py.
         'version.py',
 
-        # Written by someone who doesn't know how to deal with mypyc
+        # Can be removed once we drop support for Python 3.5.2 and lower.
         'stubtest.py',
     )) + (
         # Don't want to grab this accidentally


### PR DESCRIPTION
Follow up from #8380 

Thanks for the fix! The cast works, but unfortunately we have one last issue: mypyc does not like the conditional definitions necessary to work around a bug in Python 3.5.2 and earlier (https://github.com/python/mypy/pull/8380/commits/8fda109d6b07a23670cc1148155e4696d94654e0). Example stacktrace here: https://travis-ci.org/hauntsaninja/mypy/jobs/651008763
Long story short, this PR doesn't do anything, but maybe it will in the future!