### PR TITLE
Fix errors in self-check related to pytest

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -181,6 +181,12 @@ class DataDrivenTestCase(pytest.Item):  # type: ignore  # inheriting from Any
     # forward vs backward slashes in file paths for Windows vs Linux.
     normalize_output = True
 
+    # Extra attributes used by some tests.
+    lastline = None  # type: int
+    output_files = None  # type: List[Tuple[str, str]] # Path and contents for output files
+    deleted_paths = None  # type: Dict[int, Set[str]]  # Mapping run number -> paths
+    triggered = None  # type: List[str]  # Active triggers (one line per incremental step)
+
     def __init__(self,
                  parent: 'DataSuiteCollector',
                  suite: 'DataSuite',
@@ -252,7 +258,7 @@ class DataDrivenTestCase(pytest.Item):  # type: ignore  # inheriting from Any
     def reportinfo(self) -> Tuple[str, int, str]:
         return self.file, self.line, self.name
 
-    def repr_failure(self, excinfo: Any) -> str:
+    def repr_failure(self, excinfo: Any, style: Optional[Any] = None) -> str:
         if excinfo.errisinstance(SystemExit):
             # We assume that before doing exit() (which raises SystemExit) we've printed
             # enough context about what happened so that a stack trace is not useful.


### PR DESCRIPTION
I can't use `# type: ignore[override]` because we use `--warn-unused-ignores`, so I just added the unused argument in a method to match superclass signature.

Also "declared" a small bunch of attributes on `DataDrivenTestCase` (currently subclasses `Any` so missing attributes are not reported).