### PR TITLE
Make IRBuilder not inherit from LowLevelIRBuilder.

### DIFF
--- a/mypyc/genfunc.py
+++ b/mypyc/genfunc.py
@@ -117,7 +117,7 @@ class BuildFuncIR:
         if expr.expr:
             retval = self.builder.accept(expr.expr)
         else:
-            retval = self.builder.none()
+            retval = self.builder.builder.none()
         return self.emit_yield(retval, expr.line)
 
     def visit_yield_from_expr(self, o: YieldFromExpr) -> Value:
@@ -504,14 +504,16 @@ class BuildFuncIR:
 
     def create_switch_for_generator_class(self) -> None:
         self.add(Goto(self.fn_info.generator_class.switch_block))
-        self.fn_info.generator_class.blocks.append(self.builder.new_block())
+        block = BasicBlock()
+        self.fn_info.generator_class.continuation_blocks.append(block)
+        self.builder.activate_block(block)
 
     def populate_switch_for_generator_class(self) -> None:
         cls = self.fn_info.generator_class
         line = self.fn_info.fitem.line
 
         self.builder.activate_block(cls.switch_block)
-        for label, true_block in enumerate(cls.blocks):
+        for label, true_block in enumerate(cls.continuation_blocks):
             false_block = BasicBlock()
             comparison = self.builder.binary_op(
                 cls.next_label_reg, self.add(LoadInt(label)), '==', line
@@ -767,8 +769,8 @@ class BuildFuncIR:
         # set the next label so that the next time '__next__' is called on the generator object,
         # the function continues at the new block.
         next_block = BasicBlock()
-        next_label = len(cls.blocks)
-        cls.blocks.append(next_block)
+        next_label = len(cls.continuation_blocks)
+        cls.continuation_blocks.append(next_block)
         self.assign(cls.next_label_target, self.add(LoadInt(next_label)), line)
         self.add(Return(retval))
         self.builder.activate_block(next_block)
@@ -944,10 +946,10 @@ class BuildFuncIR:
         arg_kinds = [concrete_arg_kind(arg.kind) for arg in rt_args]
 
         if do_pycall:
-            retval = self.builder.py_method_call(
+            retval = self.builder.builder.py_method_call(
                 args[0], target.name, args[1:], line, arg_kinds[1:], arg_names[1:])
         else:
-            retval = self.builder.call(target.decl, args, arg_kinds, arg_names, line)
+            retval = self.builder.builder.call(target.decl, args, arg_kinds, arg_names, line)
         retval = self.builder.coerce(retval, sig.ret_type, line)
         self.add(Return(retval))
 

--- a/mypyc/genfunc.py
+++ b/mypyc/genfunc.py
@@ -39,7 +39,6 @@ class BuildFuncIR:
     def __init__(self, builder: 'IRBuilder') -> None:
         self.builder = builder
         self.module_name = builder.module_name
-        self.environments = builder.environments
         self.functions = builder.functions
         self.mapper = builder.mapper
 
@@ -1218,13 +1217,13 @@ class BuildFuncIR:
         return env
 
     def load_outer_envs(self, base: ImplicitClass) -> None:
-        index = len(self.environments) - 2
+        index = len(self.builder.builders) - 2
 
         # Load the first outer environment. This one is special because it gets saved in the
         # FuncInfo instance's prev_env_reg field.
         if index > 1:
             # outer_env = self.fn_infos[index].environment
-            outer_env = self.environments[index]
+            outer_env = self.builder.builders[index].environment
             if isinstance(base, GeneratorClass):
                 base.prev_env_reg = self.load_outer_env(base.curr_env_reg, outer_env)
             else:
@@ -1235,7 +1234,7 @@ class BuildFuncIR:
         # Load the remaining outer environments into registers.
         while index > 1:
             # outer_env = self.fn_infos[index].environment
-            outer_env = self.environments[index]
+            outer_env = self.builder.builders[index].environment
             env_reg = self.load_outer_env(env_reg, outer_env)
             index -= 1
 

--- a/mypyc/genops_for.py
+++ b/mypyc/genops_for.py
@@ -106,7 +106,7 @@ class ForIterable(ForGenerator):
         line = self.line
         # We unbox here so that iterating with tuple unpacking generates a tuple based
         # unpack instead of an iterator based one.
-        next_reg = builder.unbox_or_cast(self.next_reg, self.target_type, line)
+        next_reg = builder.coerce(self.next_reg, self.target_type, line)
         builder.assign(builder.get_assignment_target(self.index), next_reg, line)
 
     def gen_step(self) -> None:
@@ -178,7 +178,7 @@ class ForList(ForGenerator):
         # iterating with tuple unpacking generates a tuple based
         # unpack instead of an iterator based one.
         builder.assign(builder.get_assignment_target(self.index),
-                       builder.unbox_or_cast(value_box, self.target_type, line), line)
+                       builder.coerce(value_box, self.target_type, line), line)
 
     def gen_step(self) -> None:
         # Step to the next item.

--- a/mypyc/genopscontext.py
+++ b/mypyc/genopscontext.py
@@ -146,7 +146,7 @@ class GeneratorClass(ImplicitClass):
         # The switch block is used to decide which instruction to go using the value held in the
         # next-label register.
         self.switch_block = BasicBlock()
-        self.blocks = []  # type: List[BasicBlock]
+        self.continuation_blocks = []  # type: List[BasicBlock]
 
     @property
     def next_label_reg(self) -> Value:

--- a/mypyc/nonlocalcontrol.py
+++ b/mypyc/nonlocalcontrol.py
@@ -73,7 +73,7 @@ class GeneratorNonlocalControl(BaseNonlocalControl):
         # doing so, create a new block without an error handler set so that the implicitly thrown
         # StopIteration isn't caught by except blocks inside of the generator function.
         builder.error_handlers.append(None)
-        builder.goto_new_block()
+        builder.goto_and_activate(BasicBlock())
         # Skip creating a traceback frame when we raise here, because
         # we don't care about the traceback frame and it is kind of
         # expensive since raising StopIteration is an extremely common case.

--- a/mypyc/nonlocalcontrol.py
+++ b/mypyc/nonlocalcontrol.py
@@ -72,7 +72,7 @@ class GeneratorNonlocalControl(BaseNonlocalControl):
         # Raise a StopIteration containing a field for the value that should be returned. Before
         # doing so, create a new block without an error handler set so that the implicitly thrown
         # StopIteration isn't caught by except blocks inside of the generator function.
-        builder.error_handlers.append(None)
+        builder.builder.push_error_handler(None)
         builder.goto_and_activate(BasicBlock())
         # Skip creating a traceback frame when we raise here, because
         # we don't care about the traceback frame and it is kind of
@@ -82,7 +82,7 @@ class GeneratorNonlocalControl(BaseNonlocalControl):
         # value is a tuple (???).
         builder.primitive_op(set_stop_iteration_value, [value], NO_TRACEBACK_LINE_NO)
         builder.add(Unreachable())
-        builder.error_handlers.pop()
+        builder.builder.pop_error_handler()
 
 
 class CleanupNonlocalControl(NonlocalControl):

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -628,6 +628,10 @@ class BasicBlock:
         self.ops = []  # type: List[Op]
         self.error_handler = None  # type: Optional[BasicBlock]
 
+    @property
+    def terminated(self) -> bool:
+        return bool(self.ops) and isinstance(self.ops[-1], ControlOp)
+
 
 # Never generates an exception
 ERR_NEVER = 0  # type: Final


### PR DESCRIPTION
Instead we make IRBuilder do all of its building through a
LowLevelIRBuilder. A new LowLevelIRBuilder is created for each
function that is compiled (which lets LowLevelIRBuilder lose its stack
of block lists and environments and only has one of each).

A collection of the most commonly used methods in LowLevelIRBuilder
are given passthrough methods in IRBuilder for convenience.

Work on mypyc/mypyc#714.