### PR TITLE
mypy: remove has_member

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -719,5 +719,5 @@ def custom_special_method(typ: Type, name: str, check_all: bool = False) -> bool
     if isinstance(typ, AnyType):
         # Avoid false positives in uncertain cases.
         return True
-    # TODO: support other types (see ExpressionChecker.has_member())?
+    # TODO: support other types (see analyze_member_access)?
     return False

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6650,7 +6650,7 @@ reveal_type(0.5 + C)  # N: Revealed type is 'Any'
 
 reveal_type(0.5 + D())  # N: Revealed type is 'Any'
 reveal_type(D() + 0.5)  # N: Revealed type is 'Any'
-reveal_type("str" + D())  # N: Revealed type is 'builtins.str'
+reveal_type("str" + D())  # N: Revealed type is 'Any'
 reveal_type(D() + "str")  # N: Revealed type is 'Any'
 
 


### PR DESCRIPTION
In particular:
- The test case mentioned in the code passes without it
- The test case changed seems to have more desirable behaviour now,
  consider:

```
from typing import Any

"""
class C:
    def __radd__(self, other) -> float:
        return 1.234
"""
C: Any
class D(C):
    pass

reveal_type("str" + D())
```