### PR TITLE
Properly track module_hidden and module_public for incomplete symbols

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3030,6 +3030,7 @@ class SymbolTableNode:
                         and fullname != prefix + '.' + name
                         and not (isinstance(self.node, Var)
                                  and self.node.from_module_getattr)):
+                    assert not isinstance(self.node, PlaceholderNode)
                     data['cross_ref'] = fullname
                     return data
             data['node'] = self.node.serialize()

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1755,13 +1755,25 @@ class SemanticAnalyzer(NodeVisitor[None],
                                 fullname: str,
                                 context: ImportBase) -> None:
         imported_id = as_id or id
+        # 'from m import x as x' exports x in a stub file or when implicit
+        # re-exports are disabled.
+        module_public = (
+            not self.is_stub_file
+            and self.options.implicit_reexport
+            or as_id is not None
+        )
+        module_hidden = not module_public and fullname not in self.modules
+
         if isinstance(node.node, PlaceholderNode):
             if self.final_iteration:
                 self.report_missing_module_attribute(module_id, id, imported_id, context)
                 return
             else:
                 # This might become a type.
-                self.mark_incomplete(imported_id, node.node, becomes_typeinfo=True)
+                self.mark_incomplete(imported_id, node.node,
+                                     module_public=module_public,
+                                     module_hidden=module_hidden,
+                                     becomes_typeinfo=True)
         existing_symbol = self.globals.get(imported_id)
         if (existing_symbol and not isinstance(existing_symbol.node, PlaceholderNode) and
                 not isinstance(node.node, PlaceholderNode)):
@@ -1773,14 +1785,6 @@ class SemanticAnalyzer(NodeVisitor[None],
             # Imports are special, some redefinitions are allowed, so wait until
             # we know what is the new symbol node.
             return
-        # 'from m import x as x' exports x in a stub file or when implicit
-        # re-exports are disabled.
-        module_public = (
-            not self.is_stub_file
-            and self.options.implicit_reexport
-            or as_id is not None
-        )
-        module_hidden = not module_public and fullname not in self.modules
         # NOTE: we take the original node even for final `Var`s. This is to support
         # a common pattern when constants are re-exported (same applies to import *).
         self.add_imported_symbol(imported_id, node, context,
@@ -1879,6 +1883,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                     self.add_imported_symbol(name, node, i,
                                              module_public=module_public,
                                              module_hidden=not module_public)
+
         else:
             # Don't add any dummy symbols for 'from x import *' if 'x' is unknown.
             pass
@@ -4351,6 +4356,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                             module_public: bool = True,
                             module_hidden: bool = False) -> None:
         """Add an alias to an existing symbol through import."""
+        assert not module_hidden or not module_public
         symbol = SymbolTableNode(node.kind, node.node,
                                  module_public=module_public,
                                  module_hidden=module_hidden)
@@ -4434,7 +4440,9 @@ class SemanticAnalyzer(NodeVisitor[None],
         self.num_incomplete_refs += 1
 
     def mark_incomplete(self, name: str, node: Node,
-                        becomes_typeinfo: bool = False) -> None:
+                        becomes_typeinfo: bool = False,
+                        module_public: bool = True,
+                        module_hidden: bool = False) -> None:
         """Mark a definition as incomplete (and defer current analysis target).
 
         Also potentially mark the current namespace as incomplete.
@@ -4453,7 +4461,9 @@ class SemanticAnalyzer(NodeVisitor[None],
             assert self.statement
             placeholder = PlaceholderNode(fullname, node, self.statement.line,
                                           becomes_typeinfo=becomes_typeinfo)
-            self.add_symbol(name, placeholder, context=dummy_context())
+            self.add_symbol(name, placeholder,
+                            module_public=module_public, module_hidden=module_hidden,
+                            context=dummy_context())
         self.missing_names.add(name)
 
     def is_incomplete_namespace(self, fullname: str) -> bool:

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5361,3 +5361,26 @@ reveal_type(z)
 tmp/c.py:2: note: Revealed type is 'a.A'
 [out2]
 tmp/c.py:2: note: Revealed type is 'a.<subclass of "A" and "B">'
+
+[case testStubFixupIssues]
+import a
+[file a.py]
+import p
+[file a.py.2]
+import p
+p.N
+
+[file p/__init__.pyi]
+from p.util import *
+
+[file p/util.pyi]
+from p.params import N
+class Test: ...
+x: N
+
+[file p/params.pyi]
+import p.util
+class N(p.util.Test):
+    ...
+[out2]
+tmp/a.py:2: error: "object" has no attribute "N"

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -9572,3 +9572,25 @@ c.py:2: note: Revealed type is 'a.A'
 ==
 c.py:2: note: Revealed type is 'a.<subclass of "A" and "B">'
 
+[case testStubFixupIssues]
+[file a.py]
+import p
+[file a.py.2]
+import p
+# a change
+
+[file p/__init__.pyi]
+from p.util import *
+
+[file p/util.pyi]
+from p.params import N
+class Test: ...
+
+[file p/params.pyi]
+import p.util
+class N(p.util.Test):
+    ...
+
+[builtins fixtures/list.pyi]
+[out]
+==


### PR DESCRIPTION
This fixes some crash bugs involving import * from an import cycle.