### PR TITLE
Change dict.fromkeys() test to be compatible with stricter type

### DIFF
--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -210,7 +210,7 @@ True
 [case testDictFromkeys]
 import typing
 d = dict.fromkeys('foo')
-d['x'] = 2
+d['x'] = None
 d2 = dict.fromkeys([1, 2], b'')
 d2[2] = b'foo'
 [out]


### PR DESCRIPTION
`dict.fromkeys([1,2])` has type `Dict[int, Any]`. The `Any` was probably intended and is exercised in this test. But this stands in the way of (maybe) making it stricter in typeshed, to be `Dict[int, None]`.

Refs: https://github.com/python/typeshed/pull/3799