### PR TITLE
Support environment variable interpolation for junit_xml + quickstart_file config keys

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -74,7 +74,7 @@ config_types = {
     'custom_typeshed_dir': expand_path,
     'mypy_path': lambda s: [expand_path(p.strip()) for p in re.split('[,:]', s)],
     'files': split_and_match_files,
-    'quickstart_file': str,
+    'quickstart_file': expand_path,
     'junit_xml': expand_path,
     # These two are for backwards compatibility
     'silent_imports': bool,

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -75,7 +75,7 @@ config_types = {
     'mypy_path': lambda s: [expand_path(p.strip()) for p in re.split('[,:]', s)],
     'files': split_and_match_files,
     'quickstart_file': str,
-    'junit_xml': str,
+    'junit_xml': expand_path,
     # These two are for backwards compatibility
     'silent_imports': bool,
     'almost_silent': bool,


### PR DESCRIPTION
Expands on the goal of #7273 
Exactly what the title says. The docs say this:

> Some flags support user home directory and environment variable expansion. To refer to the user home directory, use ~ at the beginning of the path. To expand environment variables use $VARNAME or ${VARNAME}.

This would add `quickstart_file` and `junit_xml` to the flags that support environment variable expansion. 

The only downside I see here is if someone decides they want their JUnit XML ouput file or quickstart file something weird like `$file`