### PR TITLE
Fix fine-grained dependency to "__call__"

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -892,8 +892,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             # Apply method signature hook, if one exists
             call_function = self.transform_callee_type(
                 callable_name, call_function, args, arg_kinds, context, arg_names, callee)
-            return self.check_call(call_function, args, arg_kinds, context, arg_names,
-                                   callable_node, arg_messages, callable_name, callee)
+            result = self.check_call(call_function, args, arg_kinds, context, arg_names,
+                                     callable_node, arg_messages, callable_name, callee)
+            if callable_node:
+                # check_call() stored "call_function" as the type, which is incorrect.
+                # Override the type.
+                self.chk.store_type(callable_node, callee)
+            return result
         elif isinstance(callee, TypeVarType):
             return self.check_call(callee.upper_bound, args, arg_kinds, context, arg_names,
                                    callable_node, arg_messages)

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -661,6 +661,11 @@ class DependencyVisitor(TraverserVisitor):
             self.process_isinstance_call(e)
         else:
             super().visit_call_expr(e)
+            typ = self.type_map.get(e.callee)
+            if typ is not None:
+                typ = get_proper_type(typ)
+                if not isinstance(typ, FunctionLike):
+                    self.add_attribute_dependency(typ, '__call__')
 
     def process_isinstance_call(self, e: CallExpr) -> None:
         """Process "isinstance(...)" in a way to avoid some extra dependencies."""

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -9594,3 +9594,38 @@ class N(p.util.Test):
 [builtins fixtures/list.pyi]
 [out]
 ==
+
+[case testDunderCall1]
+from a import C
+
+c = C()
+c(1)
+
+[file a.py]
+class C:
+    def __call__(self, x: int) -> None: ...
+
+[file a.py.2]
+class C:
+    def __call__(self, x: str) -> None: ...
+
+[out]
+==
+main:4: error: Argument 1 to "__call__" of "C" has incompatible type "int"; expected "str"
+
+[case testDunderCall2]
+from a import C
+
+C()(1)
+
+[file a.py]
+class C:
+    def __call__(self, x: int) -> None: ...
+
+[file a.py.2]
+class C:
+    def __call__(self, x: str) -> None: ...
+
+[out]
+==
+main:3: error: Argument 1 to "__call__" of "C" has incompatible type "int"; expected "str"

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -9629,3 +9629,21 @@ class C:
 [out]
 ==
 main:3: error: Argument 1 to "__call__" of "C" has incompatible type "int"; expected "str"
+
+[case testDunderCallAddition]
+from a import C
+
+c = C()
+x = c()  # type: ignore
+x + 42
+
+[file a.py]
+class C: ...
+
+[file a.py.2]
+class C:
+    def __call__(self) -> str: ...
+
+[out]
+==
+main:5: error: Unsupported left operand type for + ("str")


### PR DESCRIPTION
Also fix the inferred type of a callee when we use `__call__`.
Previously we stored the callable type inferred from `__call__`,
which is incorrect.

Fixes #8489.