### PR TITLE
Revert "mypy: remove has_member (#8438)"

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2414,7 +2414,16 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         def lookup_operator(op_name: str, base_type: Type) -> Optional[Type]:
             """Looks up the given operator and returns the corresponding type,
             if it exists."""
+
+            # This check is an important performance optimization,
+            # even though it is mostly a subset of
+            # analyze_member_access.
+            # TODO: Find a way to remove this call without performance implications.
+            if not self.has_member(base_type, op_name):
+                return None
+
             local_errors = make_local_errors()
+
             member = analyze_member_access(
                 name=op_name,
                 typ=base_type,
@@ -3794,6 +3803,45 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     'typing.Mapping',
                     [self.named_type('builtins.unicode'),
                      AnyType(TypeOfAny.special_form)])))
+
+    def has_member(self, typ: Type, member: str) -> bool:
+        """Does type have member with the given name?"""
+        # TODO: refactor this to use checkmember.analyze_member_access, otherwise
+        # these two should be carefully kept in sync.
+        # This is much faster than analyze_member_access, though, and so using
+        # it first as a filter is important for performance.
+        typ = get_proper_type(typ)
+
+        if isinstance(typ, TypeVarType):
+            typ = get_proper_type(typ.upper_bound)
+        if isinstance(typ, TupleType):
+            typ = tuple_fallback(typ)
+        if isinstance(typ, LiteralType):
+            typ = typ.fallback
+        if isinstance(typ, Instance):
+            return typ.type.has_readable_member(member)
+        if isinstance(typ, CallableType) and typ.is_type_obj():
+            return typ.fallback.type.has_readable_member(member)
+        elif isinstance(typ, AnyType):
+            return True
+        elif isinstance(typ, UnionType):
+            result = all(self.has_member(x, member) for x in typ.relevant_items())
+            return result
+        elif isinstance(typ, TypeType):
+            # Type[Union[X, ...]] is always normalized to Union[Type[X], ...],
+            # so we don't need to care about unions here.
+            item = typ.item
+            if isinstance(item, TypeVarType):
+                item = get_proper_type(item.upper_bound)
+            if isinstance(item, TupleType):
+                item = tuple_fallback(item)
+            if isinstance(item, Instance) and item.type.metaclass_type is not None:
+                return self.has_member(item.type.metaclass_type, member)
+            if isinstance(item, AnyType):
+                return True
+            return False
+        else:
+            return False
 
     def not_ready_callback(self, name: str, context: Context) -> None:
         """Called when we can't infer the type of a variable because it's not ready yet.

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -719,5 +719,5 @@ def custom_special_method(typ: Type, name: str, check_all: bool = False) -> bool
     if isinstance(typ, AnyType):
         # Avoid false positives in uncertain cases.
         return True
-    # TODO: support other types (see analyze_member_access)?
+    # TODO: support other types (see ExpressionChecker.has_member())?
     return False

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6650,7 +6650,7 @@ reveal_type(0.5 + C)  # N: Revealed type is 'Any'
 
 reveal_type(0.5 + D())  # N: Revealed type is 'Any'
 reveal_type(D() + 0.5)  # N: Revealed type is 'Any'
-reveal_type("str" + D())  # N: Revealed type is 'Any'
+reveal_type("str" + D())  # N: Revealed type is 'builtins.str'
 reveal_type(D() + "str")  # N: Revealed type is 'Any'
 
 


### PR DESCRIPTION
It turns out that the has_member check is an important (accidental?)
performance optimization. Removing this caused a major (30+%?)
slowdown at dropbox. There might be a better way to optimize this but
I'm just going to revert it for now at least.

This reverts commit 09cdab4ffd34f89cc02f512fc35fdef57cb4c267.