### PR TITLE
Add `--pep561-override` option to declare package names that are always considered typed

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -85,6 +85,7 @@ config_types = {
     'package_root': lambda s: [p.strip() for p in s.split(',')],
     'cache_dir': expand_path,
     'python_executable': expand_path,
+    'pep561_override': lambda s: [p.strip() for p in s.split(',')],
 }  # type: Final
 
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -467,6 +467,10 @@ def process_options(args: List[str],
     imports_group.add_argument(
         '--no-silence-site-packages', action='store_true',
         help="Do not silence errors in PEP 561 compliant installed packages")
+    imports_group.add_argument(
+        '--pep561-override', action='append', default=[],
+        help="Consider the given package typed even if it does not claim to be "
+             "PEP 561 compatible (may be repeated)")
 
     platform_group = parser.add_argument_group(
         title='Platform configuration',

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -267,6 +267,8 @@ class Options:
         self.transform_source = None  # type: Optional[Callable[[Any], Any]]
         # Print full path to each file in the report.
         self.show_absolute_path = False  # type: bool
+        # Consider packages typed even if they do not declare PEP-561 compatiblity
+        self.pep561_override = []  # type: List[str]
 
     # To avoid breaking plugin compatibility, keep providing new_semantic_analyzer
     @property


### PR DESCRIPTION
Title says it all: Packages declared using this option will not be ignored as *found module but no type hints or library stubs*.

This is intended as a last resort if one depends on a library that neither provides type hints *and* there are no external typing stubs available. In my specific use-case I depend on a library that provides some type hints in the code base, but they are incomplete/spotty and so the library authors prefer to not mark the package as PEP-561 compatible until they are more usable. They are still quite helpful when used from `mypy` however when one keeps their limitations in mind.

This still lacks docs and tests, but I'd like to hear what people here think about this before going down that road.