### PR TITLE
PR for #8510 "[Feature-Request] Allow mypy.ini to be a dot file"

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -73,7 +73,7 @@ Config file
 
     This flag makes mypy read configuration settings from the given file.
 
-    By default settings are read from ``mypy.ini``, ``.mypy.ini``, and ``setup.cfg``
+    By default settings are read from ``mypy.ini``, ``.mypy.ini``, or ``setup.cfg``
     in the current directory. Settings override mypy's built-in defaults and
     command line flags can override settings.
 

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -73,10 +73,9 @@ Config file
 
     This flag makes mypy read configuration settings from the given file.
 
-    By default settings are read from ``mypy.ini`` or ``setup.cfg`` in the
-    current directory, or ``.mypy.ini`` in the user's home directory.
-    Settings override mypy's built-in defaults and command line flags
-    can override settings.
+    By default settings are read from ``mypy.ini``, ``.mypy.ini``, and ``setup.cfg``
+    in the current directory. Settings override mypy's built-in defaults and
+    command line flags can override settings.
 
     Specifying :option:`--config-file= <--config-file>` (with no filename) will ignore *all*
     config files.

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -4,8 +4,8 @@ The mypy configuration file
 ===========================
 
 Mypy supports reading configuration settings from a file.  By default
-it uses the file ``mypy.ini`` with fallback to ``setup.cfg`` in the current
-directory, then ``$XDG_CONFIG_HOME/mypy/config``, then
+it uses the file ``mypy.ini`` with a fallback to ``.mypy.ini``, then ``setup.cfg`` in
+the current directory, then ``$XDG_CONFIG_HOME/mypy/config``, then
 ``~/.config/mypy/config``, and finally ``.mypy.ini`` in the user home directory
 if none of them are found; the :option:`--config-file <mypy --config-file>` command-line flag can be used
 to read a different file instead (see :ref:`config-file-flag`).
@@ -15,7 +15,7 @@ files, as it would lead to ambiguity.  The :option:`--config-file <mypy --config
 has the highest precedence and must be correct; otherwise mypy will report
 an error and exit.  Without command line option, mypy will look for defaults,
 but will use only one of them.  The first one to read is ``mypy.ini``,
-and then ``setup.cfg``.
+then ``.mypy.ini``, and finally ``setup.cfg``.
 
 Most flags correspond closely to :ref:`command-line flags
 <command-line>` but there are some differences in flag names and some

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -6,13 +6,13 @@ PYTHON2_VERSION = (2, 7)  # type: Final
 PYTHON3_VERSION = (3, 6)  # type: Final
 PYTHON3_VERSION_MIN = (3, 4)  # type: Final
 CACHE_DIR = '.mypy_cache'  # type: Final
-CONFIG_FILE = 'mypy.ini'  # type: Final
+CONFIG_FILE = ['mypy.ini', '.mypy.ini']  # type: Final
 SHARED_CONFIG_FILES = ['setup.cfg', ]  # type: Final
 USER_CONFIG_FILES = ['~/.config/mypy/config', '~/.mypy.ini', ]  # type: Final
 if os.environ.get('XDG_CONFIG_HOME'):
     USER_CONFIG_FILES.insert(0, os.path.join(os.environ['XDG_CONFIG_HOME'], 'mypy/config'))
 
-CONFIG_FILES = [CONFIG_FILE, ] + SHARED_CONFIG_FILES + USER_CONFIG_FILES  # type: Final
+CONFIG_FILES = CONFIG_FILE + SHARED_CONFIG_FILES + USER_CONFIG_FILES  # type: Final
 
 # This must include all reporters defined in mypy.report. This is defined here
 # to make reporter names available without importing mypy.report -- this speeds


### PR DESCRIPTION
PR is a fix for #8510.

I would like to add a test that makes sure `.mypy.ini` is properly detected, though I could not find a nice place to put a test for this. Open for ideas!