### PR TITLE
Fix adding catch-all .gitignore

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -226,6 +226,9 @@ def _build(sources: List[BuildSource],
                     options.show_absolute_path)
     plugin, snapshot = load_plugins(options, errors, stdout, extra_plugins)
 
+    # Add catch-all .gitignore to cache dir if we created it
+    cache_dir_existed = os.path.isdir(options.cache_dir)
+
     # Construct a build manager object to hold state during the build.
     #
     # Ignore current directory prefix in error messages.
@@ -262,6 +265,8 @@ def _build(sources: List[BuildSource],
         if reports is not None:
             # Finish the HTML or XML reports even if CompileError was raised.
             reports.finish()
+        if not cache_dir_existed and os.path.isdir(options.cache_dir):
+            add_catch_all_gitignore(options.cache_dir)
 
 
 def default_data_dir() -> str:
@@ -1111,14 +1116,10 @@ def add_catch_all_gitignore(target_dir: str) -> None:
 
 def create_metastore(options: Options) -> MetadataStore:
     """Create the appropriate metadata store."""
-    # Add catch-all .gitignore to cache dir if we created it
-    cache_dir_existed = os.path.isdir(options.cache_dir)
     if options.sqlite_cache:
         mds = SqliteMetadataStore(_cache_dir_prefix(options))  # type: MetadataStore
     else:
         mds = FilesystemMetadataStore(_cache_dir_prefix(options))
-    if not cache_dir_existed and os.path.isdir(options.cache_dir):
-        add_catch_all_gitignore(options.cache_dir)
     return mds
 
 

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -272,6 +272,7 @@ class TypeCheckSuite(DataSuite):
         if not missing_paths == busted_paths:
             raise AssertionError("cache data discrepancy %s != %s" %
                                  (missing_paths, busted_paths))
+        assert os.path.isfile(os.path.join(manager.options.cache_dir, ".gitignore"))
 
     def find_error_message_paths(self, a: List[str]) -> Set[str]:
         hits = set()

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3701,6 +3701,8 @@ import b
 -- the proto deps file with something with mtime mismatches.
 [file ../.mypy_cache/3.6/@deps.meta.json.2]
 {"snapshot": {"__main__": "a7c958b001a45bd6a2a320f4e53c4c16", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "c532c89da517a4b779bcf7a964478d67"}, "deps_meta": {"@root": {"path": "@root.deps.json", "mtime": 0}, "__main__": {"path": "__main__.deps.json", "mtime": 0}, "a": {"path": "a.deps.json", "mtime": 0}, "b": {"path": "b.deps.json", "mtime": 0}, "builtins": {"path": "builtins.deps.json", "mtime": 0}}}
+[file ../.mypy_cache/.gitignore]
+# Another hack to not trigger a .gitignore creation failure "false positive"
 [file b.py.2]
 # uh
 -- Every file should get reloaded, since the cache was invalidated


### PR DESCRIPTION
Creating the metastore does not actually create the dir, it happens on demand.