### PR TITLE
[mypyc] Irbuild docstring and comment updates, and minor refactoring

### DIFF
--- a/mypyc/irbuild/context.py
+++ b/mypyc/irbuild/context.py
@@ -1,3 +1,5 @@
+"""Helpers that store information about functions and the related classes."""
+
 from typing import List, Optional, Tuple
 
 from mypy.nodes import FuncItem
@@ -10,6 +12,7 @@ from mypyc.common import decorator_helper_name
 
 class FuncInfo:
     """Contains information about functions as they are generated."""
+
     def __init__(self,
                  fitem: FuncItem = INVALID_FUNC_DEF,
                  name: str = '',
@@ -87,9 +90,14 @@ class FuncInfo:
 
 
 class ImplicitClass:
-    """Contains information regarding classes that are generated as a result of nested functions or
-    generated functions, but not explicitly defined in the source code.
+    """Contains information regarding implicitly generated classes.
+
+    Implicit classes are generated for nested functions and generator
+    functions. They are not explicitly defined in the source code.
+
+    NOTE: This is both a concrete class and used as a base class.
     """
+
     def __init__(self, ir: ClassIR) -> None:
         # The ClassIR instance associated with this class.
         self.ir = ir
@@ -131,6 +139,8 @@ class ImplicitClass:
 
 
 class GeneratorClass(ImplicitClass):
+    """Contains information about implicit generator function classes."""
+
     def __init__(self, ir: ClassIR) -> None:
         super().__init__(ir)
         # This register holds the label number that the '__next__' function should go to the next

--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -96,12 +96,13 @@ def comprehension_helper(builder: IRBuilder,
                          line: int) -> None:
     """Helper function for list comprehensions.
 
-    "loop_params" is a list of (index, expr, [conditions]) tuples defining nested loops:
-        - "index" is the Lvalue indexing that loop;
-        - "expr" is the expression for the object to be iterated over;
-        - "conditions" is a list of conditions, evaluated in order with short-circuiting,
-            that must all be true for the loop body to be executed
-    "gen_inner_stmts" is a function to generate the IR for the body of the innermost loop
+    Args:
+        loop_params: a list of (index, expr, [conditions]) tuples defining nested loops:
+            - "index" is the Lvalue indexing that loop;
+            - "expr" is the expression for the object to be iterated over;
+            - "conditions" is a list of conditions, evaluated in order with short-circuiting,
+                that must all be true for the loop body to be executed
+        gen_inner_stmts: function to generate the IR for the body of the innermost loop
     """
     def handle_loop(loop_params: List[Tuple[Lvalue, Expression, List[Expression]]]) -> None:
         """Generate IR for a loop.
@@ -120,10 +121,11 @@ def comprehension_helper(builder: IRBuilder,
     ) -> None:
         """Generate the body of the loop.
 
-        "conds" is a list of conditions to be evaluated (in order, with short circuiting)
-            to gate the body of the loop.
-        "remaining_loop_params" is the parameters for any further nested loops; if it's empty
-            we'll instead evaluate the "gen_inner_stmts" function.
+        Args:
+            conds: a list of conditions to be evaluated (in order, with short circuiting)
+                to gate the body of the loop
+            remaining_loop_params: the parameters for any further nested loops; if it's empty
+                we'll instead evaluate the "gen_inner_stmts" function
         """
         # Check conditions, in order, short circuiting them.
         for cond in conds:
@@ -356,7 +358,8 @@ def unsafe_index(
 class ForSequence(ForGenerator):
     """Generate optimized IR for a for loop over a sequence.
 
-    Supports iterating in both forward and reverse."""
+    Supports iterating in both forward and reverse.
+    """
 
     def init(self, expr_reg: Value, target_type: RType, reverse: bool) -> None:
         builder = self.builder

--- a/mypyc/irbuild/main.py
+++ b/mypyc/irbuild/main.py
@@ -13,7 +13,7 @@ It would be translated to something that conceptually looks like this:
    r3 = r2 + r1 :: int
    return r3
 
-The IR is implemented in mypyc.ops.
+The IR is implemented in mypyc.ir.
 
 For the core of the implementation, look at build_ir() below,
 mypyc.irbuild.builder, and mypyc.irbuild.visitor.
@@ -54,6 +54,7 @@ def build_ir(modules: List[MypyFile],
              mapper: 'Mapper',
              options: CompilerOptions,
              errors: Errors) -> ModuleIRs:
+    """Build IR for a set of modules type-checked by mypy."""
 
     build_type_map(mapper, modules, graph, types, options, errors)
 
@@ -95,6 +96,8 @@ def build_ir(modules: List[MypyFile],
 
 
 def transform_mypy_file(builder: IRBuilder, mypyfile: MypyFile) -> None:
+    """Generate IR for a single module."""
+
     if mypyfile.fullname in ('typing', 'abc'):
         # These module are special; their contents are currently all
         # built-in primitives.

--- a/mypyc/irbuild/main.py
+++ b/mypyc/irbuild/main.py
@@ -13,10 +13,11 @@ It would be translated to something that conceptually looks like this:
    r3 = r2 + r1 :: int
    return r3
 
-The IR is implemented in mypyc.ir.
+This module deals with the module-level IR transformation logic and
+putting it all together. The actual IR is implemented in mypyc.ir.
 
-For the core of the implementation, look at build_ir() below,
-mypyc.irbuild.builder, and mypyc.irbuild.visitor.
+For the core of the IR transform implementation, look at build_ir()
+below, mypyc.irbuild.builder, and mypyc.irbuild.visitor.
 """
 
 from collections import OrderedDict
@@ -54,7 +55,7 @@ def build_ir(modules: List[MypyFile],
              mapper: 'Mapper',
              options: CompilerOptions,
              errors: Errors) -> ModuleIRs:
-    """Build IR for a set of modules type-checked by mypy."""
+    """Build IR for a set of modules that have been type-checked by mypy."""
 
     build_type_map(mapper, modules, graph, types, options, errors)
 

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -1,3 +1,5 @@
+"""Maintain a mapping from mypy concepts to IR/compiled concepts."""
+
 from typing import Dict, Optional, Union
 from collections import OrderedDict
 
@@ -20,6 +22,9 @@ from mypyc.ir.class_ir import ClassIR
 
 class Mapper:
     """Keep track of mappings from mypy concepts to IR concepts.
+
+    For example, we keep track of how the mypy TypeInfos of compiled
+    classes map to class IR objects.
 
     This state is shared across all modules being compiled in all
     compilation groups.

--- a/mypyc/irbuild/prebuildvisitor.py
+++ b/mypyc/irbuild/prebuildvisitor.py
@@ -7,44 +7,56 @@ from mypy.traverser import TraverserVisitor
 
 
 class PreBuildVisitor(TraverserVisitor):
-    """
-    Class used to visit a mypy file before building the IR for that program. This is done as a
-    first pass so that nested functions, encapsulating functions, lambda functions, decorated
-    functions, and free variables can be determined before instantiating the IRBuilder.
+    """Mypy file AST visitor run before building the IR.
+
+    This is done as a first pass so that nested functions,
+    encapsulating functions, lambda functions, decorated functions,
+    and free variables can be determined before instantiating the
+    IRBuilder.
+
     """
     def __init__(self) -> None:
         super().__init__()
-        # Mapping from FuncItem instances to sets of variables. The FuncItem instances are where
-        # these variables were first declared, and these variables are free in any functions that
+        # Mapping from FuncItem instances to sets of variables. The
+        # FuncItem instances are where these variables were first
+        # declared, and these variables are free in any functions that
         # are nested within the FuncItem from which they are mapped.
         self.free_variables = {}  # type: Dict[FuncItem, Set[SymbolNode]]
-        # Intermediate data structure used to map SymbolNode instances to the FuncDef in which they
-        # were first visited.
+
+        # Intermediate data structure used to map SymbolNode instances
+        # to the FuncItem in which they were first visited.
         self.symbols_to_funcs = {}  # type: Dict[SymbolNode, FuncItem]
-        # Stack representing the function call stack.
+
+        # Stack representing function nesting.
         self.funcs = []  # type: List[FuncItem]
+
         # The set of property setters
         self.prop_setters = set()  # type: Set[FuncDef]
+
         # A map from any function that contains nested functions to
         # a set of all the functions that are nested within it.
         self.encapsulating_funcs = {}  # type: Dict[FuncItem, List[FuncItem]]
+
         # A map from a nested func to it's parent/encapsulating func.
         self.nested_funcs = {}  # type: Dict[FuncItem, FuncItem]
         self.funcs_to_decorators = {}  # type: Dict[FuncDef, List[Expression]]
 
     def add_free_variable(self, symbol: SymbolNode) -> None:
-        # Get the FuncItem instance where the free symbol was first declared, and map that FuncItem
-        # to the SymbolNode representing the free symbol.
+        # Get the FuncItem instance where the free symbol was first
+        # declared, and map that FuncItem to the SymbolNode
+        # representing the free symbol.
         func = self.symbols_to_funcs[symbol]
         self.free_variables.setdefault(func, set()).add(symbol)
 
     def visit_decorator(self, dec: Decorator) -> None:
         if dec.decorators:
-            # Only add the function being decorated if there exist decorators in the decorator
-            # list. Note that meaningful decorators (@property, @abstractmethod) are removed from
-            # this list by mypy, but functions decorated by those decorators (in addition to
-            # property setters) do not need to be added to the set of decorated functions for
-            # the IRBuilder, because they are handled in a special way.
+            # Only add the function being decorated if there exist
+            # decorators in the decorator list. Note that meaningful
+            # decorators (@property, @abstractmethod) are removed from
+            # this list by mypy, but functions decorated by those
+            # decorators (in addition to property setters) do not need
+            # to be added to the set of decorated functions for the
+            # IRBuilder, because they are handled in a special way.
             if isinstance(dec.decorators[0], MemberExpr) and dec.decorators[0].name == 'setter':
                 self.prop_setters.add(dec.func)
             else:
@@ -52,13 +64,16 @@ class PreBuildVisitor(TraverserVisitor):
         super().visit_decorator(dec)
 
     def visit_func(self, func: FuncItem) -> None:
-        # If there were already functions or lambda expressions defined in the function stack, then
-        # note the previous FuncItem as containing a nested function and the current FuncItem as
-        # being a nested function.
+        # If there were already functions or lambda expressions
+        # defined in the function stack, then note the previous
+        # FuncItem as containing a nested function and the current
+        # FuncItem as being a nested function.
         if self.funcs:
-            # Add the new func to the set of nested funcs within the func at top of the func stack.
+            # Add the new func to the set of nested funcs within the
+            # func at top of the func stack.
             self.encapsulating_funcs.setdefault(self.funcs[-1], []).append(func)
-            # Add the func at top of the func stack as the parent of new func.
+            # Add the func at top of the func stack as the parent of
+            # new func.
             self.nested_funcs[func] = self.funcs[-1]
 
         self.funcs.append(func)
@@ -75,9 +90,12 @@ class PreBuildVisitor(TraverserVisitor):
         if isinstance(expr.node, (Var, FuncDef)):
             self.visit_symbol_node(expr.node)
 
-    # Check if child is contained within fdef (possibly indirectly within
-    # multiple nested functions).
+    def visit_var(self, var: Var) -> None:
+        self.visit_symbol_node(var)
+
     def is_parent(self, fitem: FuncItem, child: FuncItem) -> bool:
+        # Check if child is contained within fdef (possibly indirectly within
+        # multiple nested functions).
         if child in self.nested_funcs:
             parent = self.nested_funcs[child]
             if parent == fitem:
@@ -87,30 +105,31 @@ class PreBuildVisitor(TraverserVisitor):
 
     def visit_symbol_node(self, symbol: SymbolNode) -> None:
         if not self.funcs:
-            # If the list of FuncDefs is empty, then we are not inside of a function and hence do
-            # not need to do anything regarding free variables.
+            # If the list of FuncDefs is empty, then we are not inside
+            # of a function and hence do not need to do anything
+            # regarding free variables.
             return
 
         if symbol in self.symbols_to_funcs:
             orig_func = self.symbols_to_funcs[symbol]
             if self.is_parent(self.funcs[-1], orig_func):
-                # If the function in which the symbol was originally seen is nested
-                # within the function currently being visited, fix the free_variable
-                # and symbol_to_funcs dictionaries.
+                # If the function in which the symbol was originally
+                # seen is nested within the function currently being
+                # visited, fix the free_variable and symbol_to_funcs
+                # dictionaries.
                 self.symbols_to_funcs[symbol] = self.funcs[-1]
                 self.free_variables.setdefault(self.funcs[-1], set()).add(symbol)
 
             elif self.is_parent(orig_func, self.funcs[-1]):
-                # If the SymbolNode instance has already been visited before,
-                # and it was declared in a FuncDef not nested within the current
-                # FuncDef being visited, then it is a free symbol because it is
-                # being visited again.
+                # If the SymbolNode instance has already been visited
+                # before, and it was declared in a FuncDef not nested
+                # within the current FuncDef being visited, then it is
+                # a free symbol because it is being visited again.
                 self.add_free_variable(symbol)
 
         else:
-            # Otherwise, this is the first time the SymbolNode is being visited. We map the
-            # SymbolNode to the current FuncDef being visited to note where it was first visited.
+            # Otherwise, this is the first time the SymbolNode is
+            # being visited. We map the SymbolNode to the current
+            # FuncDef being visited to note where it was first
+            # visited.
             self.symbols_to_funcs[symbol] = self.funcs[-1]
-
-    def visit_var(self, var: Var) -> None:
-        self.visit_symbol_node(var)

--- a/mypyc/irbuild/prebuildvisitor.py
+++ b/mypyc/irbuild/prebuildvisitor.py
@@ -9,59 +9,69 @@ from mypy.traverser import TraverserVisitor
 class PreBuildVisitor(TraverserVisitor):
     """Mypy file AST visitor run before building the IR.
 
-    This is done as a first pass so that nested functions,
-    encapsulating functions, lambda functions, decorated functions,
-    and free variables can be determined before instantiating the
-    IRBuilder.
+    This collects various things, including:
 
+    * Determine relationships between nested functions and functions that
+      contain nested functions
+    * Find non-local variables (free variables)
+    * Find property setters
+    * Find decorators of functions
+
+    The main IR build pass uses this information.
     """
+
     def __init__(self) -> None:
         super().__init__()
-        # Mapping from FuncItem instances to sets of variables. The
-        # FuncItem instances are where these variables were first
-        # declared, and these variables are free in any functions that
-        # are nested within the FuncItem from which they are mapped.
+        # Dict from a function to symbols defined directly in the
+        # function that are used as non-local (free) variables within a
+        # nested function.
         self.free_variables = {}  # type: Dict[FuncItem, Set[SymbolNode]]
 
-        # Intermediate data structure used to map SymbolNode instances
-        # to the FuncItem in which they were first visited.
+        # Intermediate data structure used to find the function where
+        # a SymbolNode is declared. Initially this may point to a
+        # function nested inside the function with the declaration,
+        # but we'll eventually update this to refer to the function
+        # with the declaration.
         self.symbols_to_funcs = {}  # type: Dict[SymbolNode, FuncItem]
 
-        # Stack representing function nesting.
+        # Stack representing current function nesting.
         self.funcs = []  # type: List[FuncItem]
 
-        # The set of property setters
+        # All property setters encountered so far.
         self.prop_setters = set()  # type: Set[FuncDef]
 
         # A map from any function that contains nested functions to
         # a set of all the functions that are nested within it.
         self.encapsulating_funcs = {}  # type: Dict[FuncItem, List[FuncItem]]
 
-        # A map from a nested func to it's parent/encapsulating func.
+        # Map nested function to its parent/encapsulating function.
         self.nested_funcs = {}  # type: Dict[FuncItem, FuncItem]
-        self.funcs_to_decorators = {}  # type: Dict[FuncDef, List[Expression]]
 
-    def add_free_variable(self, symbol: SymbolNode) -> None:
-        # Get the FuncItem instance where the free symbol was first
-        # declared, and map that FuncItem to the SymbolNode
-        # representing the free symbol.
-        func = self.symbols_to_funcs[symbol]
-        self.free_variables.setdefault(func, set()).add(symbol)
+        # Map function to its non-special decorators.
+        self.funcs_to_decorators = {}  # type: Dict[FuncDef, List[Expression]]
 
     def visit_decorator(self, dec: Decorator) -> None:
         if dec.decorators:
             # Only add the function being decorated if there exist
-            # decorators in the decorator list. Note that meaningful
-            # decorators (@property, @abstractmethod) are removed from
-            # this list by mypy, but functions decorated by those
-            # decorators (in addition to property setters) do not need
-            # to be added to the set of decorated functions for the
-            # IRBuilder, because they are handled in a special way.
+            # (ordinary) decorators in the decorator list. Certain
+            # decorators (such as @property, @abstractmethod) are
+            # special cased and removed from this list by
+            # mypy. Functions decorated only by special decorators
+            # (and property setters) are not treated as decorated
+            # functions by the IR builder.
             if isinstance(dec.decorators[0], MemberExpr) and dec.decorators[0].name == 'setter':
+                # Property setters are not treated as decorated methods.
                 self.prop_setters.add(dec.func)
             else:
                 self.funcs_to_decorators[dec.func] = dec.decorators
         super().visit_decorator(dec)
+
+    def visit_func_def(self, fdef: FuncItem) -> None:
+        # TODO: What about overloaded functions?
+        self.visit_func(fdef)
+
+    def visit_lambda_expr(self, expr: LambdaExpr) -> None:
+        self.visit_func(expr)
 
     def visit_func(self, func: FuncItem) -> None:
         # If there were already functions or lambda expressions
@@ -80,12 +90,6 @@ class PreBuildVisitor(TraverserVisitor):
         super().visit_func(func)
         self.funcs.pop()
 
-    def visit_func_def(self, fdef: FuncItem) -> None:
-        self.visit_func(fdef)
-
-    def visit_lambda_expr(self, expr: LambdaExpr) -> None:
-        self.visit_func(expr)
-
     def visit_name_expr(self, expr: NameExpr) -> None:
         if isinstance(expr.node, (Var, FuncDef)):
             self.visit_symbol_node(expr.node)
@@ -93,9 +97,38 @@ class PreBuildVisitor(TraverserVisitor):
     def visit_var(self, var: Var) -> None:
         self.visit_symbol_node(var)
 
+    def visit_symbol_node(self, symbol: SymbolNode) -> None:
+        if not self.funcs:
+            # We are not inside a function and hence do not need to do
+            # anything regarding free variables.
+            return
+
+        if symbol in self.symbols_to_funcs:
+            orig_func = self.symbols_to_funcs[symbol]
+            if self.is_parent(self.funcs[-1], orig_func):
+                # The function in which the symbol was previously seen is
+                # nested within the function currently being visited. Thus
+                # the current function is a better candidate to contain the
+                # declaration.
+                self.symbols_to_funcs[symbol] = self.funcs[-1]
+                # TODO: Remove from the orig_func free_variables set?
+                self.free_variables.setdefault(self.funcs[-1], set()).add(symbol)
+
+            elif self.is_parent(orig_func, self.funcs[-1]):
+                # The SymbolNode instance has already been visited
+                # before in a parent function, thus it's a non-local
+                # symbol.
+                self.add_free_variable(symbol)
+
+        else:
+            # This is the first time the SymbolNode is being
+            # visited. We map the SymbolNode to the current FuncDef
+            # being visited to note where it was first visited.
+            self.symbols_to_funcs[symbol] = self.funcs[-1]
+
     def is_parent(self, fitem: FuncItem, child: FuncItem) -> bool:
-        # Check if child is contained within fdef (possibly indirectly within
-        # multiple nested functions).
+        # Check if child is nested within fdef (possibly indirectly
+        # within multiple nested functions).
         if child in self.nested_funcs:
             parent = self.nested_funcs[child]
             if parent == fitem:
@@ -103,33 +136,8 @@ class PreBuildVisitor(TraverserVisitor):
             return self.is_parent(fitem, parent)
         return False
 
-    def visit_symbol_node(self, symbol: SymbolNode) -> None:
-        if not self.funcs:
-            # If the list of FuncDefs is empty, then we are not inside
-            # of a function and hence do not need to do anything
-            # regarding free variables.
-            return
-
-        if symbol in self.symbols_to_funcs:
-            orig_func = self.symbols_to_funcs[symbol]
-            if self.is_parent(self.funcs[-1], orig_func):
-                # If the function in which the symbol was originally
-                # seen is nested within the function currently being
-                # visited, fix the free_variable and symbol_to_funcs
-                # dictionaries.
-                self.symbols_to_funcs[symbol] = self.funcs[-1]
-                self.free_variables.setdefault(self.funcs[-1], set()).add(symbol)
-
-            elif self.is_parent(orig_func, self.funcs[-1]):
-                # If the SymbolNode instance has already been visited
-                # before, and it was declared in a FuncDef not nested
-                # within the current FuncDef being visited, then it is
-                # a free symbol because it is being visited again.
-                self.add_free_variable(symbol)
-
-        else:
-            # Otherwise, this is the first time the SymbolNode is
-            # being visited. We map the SymbolNode to the current
-            # FuncDef being visited to note where it was first
-            # visited.
-            self.symbols_to_funcs[symbol] = self.funcs[-1]
+    def add_free_variable(self, symbol: SymbolNode) -> None:
+        # Find the function where the symbol was (likely) first declared,
+        # and mark is as a non-local symbol within that function.
+        func = self.symbols_to_funcs[symbol]
+        self.free_variables.setdefault(func, set()).add(symbol)

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -1,3 +1,16 @@
+"""Prepare for IR transform.
+
+This needs to run after type checking and before generating IR.
+
+For example, construct partially initialized FuncIR and ClassIR
+objects for all functions and classes. This allows us to bind
+references to functions and classes before we've generated full IR for
+functions or classes.  The actual IR transform will then populate all
+the missing bits, such as function bodies (basic blocks).
+
+Also build a mapping from mypy TypeInfos to ClassIR objects.
+"""
+
 from typing import List, Dict, Iterable, Optional, Union
 
 from mypy.nodes import (

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -1,3 +1,11 @@
+"""Transform mypy statement ASTs to mypyc IR (Intermediate Representation).
+
+The top-level AST transformation logic is implemented in mypyc.irbuild.visitor
+and mypyc.irbuild.builder.
+
+A few statements are transformed in mypyc.irbuild.function (yield, for example).
+"""
+
 from typing import Optional, List, Tuple, Sequence, Callable
 import importlib.util
 

--- a/mypyc/irbuild/util.py
+++ b/mypyc/irbuild/util.py
@@ -1,3 +1,5 @@
+"""Various utilities that don't depend on other modules in mypyc.irbuild."""
+
 from typing import Dict, Any, Union, Optional
 
 from mypy.nodes import (

--- a/mypyc/irbuild/vtable.py
+++ b/mypyc/irbuild/vtable.py
@@ -1,3 +1,5 @@
+"""Compute vtables of native (extension) classes."""
+
 import itertools
 
 from mypyc.ir.class_ir import ClassIR, VTableEntries, VTableMethod, VTableAttr


### PR DESCRIPTION
Add and update docstrings and comments in `mypyc.irbuild`. Also try to
make the style of docstrings and comments more consistent and cleaner
looking. For example, generally make documentation lines shorter than
the max line length, for improved readability.

Group some related functions close to each other.