### PR TITLE
Always allow to cast to Any without warnings.

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3004,7 +3004,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                   allow_none_return=True, always_allow_any=True)
         target_type = expr.type
         options = self.chk.options
-        if options.warn_redundant_casts and is_same_type(source_type, target_type):
+        if (options.warn_redundant_casts and not isinstance(target_type, AnyType)
+                and is_same_type(source_type, target_type)):
             self.msg.redundant_cast(target_type, expr)
         if options.disallow_any_unimported and has_any_from_unimported_type(target_type):
             self.msg.unimported_type_becomes_any("Target type of cast", target_type, expr)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3004,7 +3004,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                   allow_none_return=True, always_allow_any=True)
         target_type = expr.type
         options = self.chk.options
-        if (options.warn_redundant_casts and not isinstance(target_type, AnyType)
+        if (options.warn_redundant_casts and not isinstance(get_proper_type(target_type), AnyType)
                 and is_same_type(source_type, target_type)):
             self.msg.redundant_cast(target_type, expr)
         if options.disallow_any_unimported and has_any_from_unimported_type(target_type):

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -35,6 +35,12 @@ b = B()
 c = add([cast(A, b)], [a])
 [builtins fixtures/list.pyi]
 
+[case testCastToAnyTypeNotRedundant]
+# flags: --warn-redundant-casts
+from typing import cast, Any
+a: Any
+b = cast(Any, a)
+[builtins fixtures/list.pyi]
 
 -- Unused 'type: ignore' comments
 -- ------------------------------


### PR DESCRIPTION
I think that 'cast(Any, o)' should not be treated as a redundant_cast even if o is Any. 

We are using mypy with ignore_missing_imports, warn_redundant_casts, warn_unused_ignores and disallow_untyped_calls.
 
The reason I suggest this is related to "type hints for third party library." In some environments, the library has partial type annotations, and not in the others.

This causes
> import torch
> torch.load(model)
may invoke 'Call to untyped function "load" in typed context' if torch is not fully typed.

On the other hand, 
> import torch
> cast(Any, torch).load(model)
may invoke 'redundant cast to Any' in some cases.

The workaround would be the code below.
> import torch
> torch_: Any = torch
> torch_.load(model)
This is OK, but this requires an extra line.

So, what I found here is that there is no straight-forward inline way to tell mypy that an expression is not intended to be in 'typed context.'

I think that cast(Any, o) is something similar to (void*) in C, which indicates that the coder wants to ignore types here, so it would be nice to allow cast(Any, any: Any).