### PR TITLE
Fix invalid type causing namedtuple errors in wrong files

### DIFF
--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -959,6 +959,6 @@ from typing import NamedTuple
 def foo():
     pass
 
-Type1 = NamedTuple('Type1', [('foo', foo)])  # type: ignore
+Type1 = NamedTuple('Type1', [('foo', foo)])  # E: Function "b.foo" is not valid as a type  # N: Perhaps you need "Callable[...]" or a callback protocol?
 
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -948,3 +948,17 @@ class A:
 
 reveal_type(A().b)  # N: Revealed type is 'Any'
 [builtins fixtures/tuple.pyi]
+
+[case testNamedTupleWrongfile]
+from typing import NamedTuple
+from b import Type1
+Type2 = NamedTuple('Type2', [('x', Type1)])
+[file b.py]
+from typing import NamedTuple
+
+def foo():
+    pass
+
+Type1 = NamedTuple('Type1', [('foo', foo)])  # type: ignore
+
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8477,8 +8477,8 @@ m.py:4: note: See https://mypy.readthedocs.io/en/latest/common_issues.html#varia
 ==
 m.py:4: error: Variable "a.A" is not valid as a type
 m.py:4: note: See https://mypy.readthedocs.io/en/latest/common_issues.html#variables-vs-type-aliases
-m.py:5: note: Revealed type is 'A?'
-m.py:7: note: Revealed type is 'A?'
+m.py:5: note: Revealed type is 'Any'
+m.py:7: note: Revealed type is 'Any'
 
 [case testAliasForwardFunctionDirect]
 # flags: --ignore-missing-imports


### PR DESCRIPTION
Fixes #8511.

This is a workaround of #4987, where UnboundTypes can leak.