### PR TITLE
Added note to warn user about using sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ the above as root. For example, in Ubuntu:
 Now you can use the `mypy` program just as above.  In case of trouble
 see "Troubleshooting" above.
 
-# NOTE: Installing with sudo can be a security risk, please try with flag `--user` first.
+> NOTE: Installing with sudo can be a security risk, please try with flag `--user` first.
     $ python3 -m pip install --user -U . 
 
 Working with the git version of mypy

--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ the above as root. For example, in Ubuntu:
 Now you can use the `mypy` program just as above.  In case of trouble
 see "Troubleshooting" above.
 
+# NOTE: Installing with sudo can be a security risk, please try with flag `--user` first.
+    $ python3 -m pip install --user -U . 
 
 Working with the git version of mypy
 ------------------------------------


### PR DESCRIPTION
**What is this PR about ?**

In `CONTRIBUTING.md` , in the section `Quick start for contributing to mypy` it is specified that you may have to use **sudo** when installing mypy.

Use `sudo` with `pip` can be a dangerous and a security risk, I have added a `NOTE` which adds the `--user` flag when running the command, as this flag works for me.

**Things I've Changed**

1. Added a `NOTE` in README.md 

**Tests** 

I've run tests using `tox`, and tests for py3.6 had succeeded, which is the python version installed on my machine 