### PR TITLE
Add Python 3.9 (dev) to test, but allow it to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ jobs:
     - TEST_MYPYC=1
   - name: "run test suite with python 3.8"
     python: 3.8
+  - name: "run test suite with python 3.9"
+    python: 3.9-dev
   - name: "run mypyc runtime tests with python 3.6 debug build"
     language: generic
     env:
@@ -78,6 +80,9 @@ jobs:
   #   env:
   #   - TOXENV=dev
   #   - EXTRA_ARGS=
+  allow_failures:
+  - name: "run test suite with python 3.9"
+    python: 3.9-dev
 
 install:
 - pip install -U pip setuptools


### PR DESCRIPTION
I've noticed mypy failing for some of my projects on Python 3.9 (dev), and it looks like this is not currently being tested for that configuration yet.