### PR TITLE
Fix type inference with lambda that returns None

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3368,12 +3368,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 # TODO: return expression must be accepted before exiting function scope.
                 self.accept(e.expr(), allow_none_return=True)
             ret_type = self.chk.type_map[e.expr()]
-            if isinstance(get_proper_type(ret_type), NoneType):
-                # For "lambda ...: None", just use type from the context.
-                # Important when the context is Callable[..., None] which
-                # really means Void. See #1425.
-                self.chk.return_types.pop()
-                return inferred_type
             self.chk.return_types.pop()
             return replace_callable_return_type(inferred_type, ret_type)
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3144,3 +3144,35 @@ reveal_type(S() if bool() else '')  # N: Revealed type is 'builtins.unicode'
 reveal_type('' if bool() else S())  # N: Revealed type is 'builtins.unicode'
 reveal_type(S() if bool() else str())  # N: Revealed type is 'builtins.unicode'
 reveal_type(str() if bool() else S())  # N: Revealed type is 'builtins.unicode'
+
+[case testInferCallableReturningNone1]
+# flags: --no-strict-optional
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+def f(x: Callable[[], T]) -> T:
+    return x()
+
+reveal_type(f(lambda: None))  # N: Revealed type is 'None'
+reveal_type(f(lambda: 1))  # N: Revealed type is 'builtins.int*'
+
+def g() -> None: pass
+
+reveal_type(f(g))  # N: Revealed type is 'None'
+
+[case testInferCallableReturningNone2]
+# flags: --strict-optional
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+def f(x: Callable[[], T]) -> T:
+    return x()
+
+reveal_type(f(lambda: None))  # N: Revealed type is 'None'
+reveal_type(f(lambda: 1))  # N: Revealed type is 'builtins.int*'
+
+def g() -> None: pass
+
+reveal_type(f(g))  # N: Revealed type is 'None'


### PR DESCRIPTION
The issue was caused some special casing that no longer seems required.

Fixes #6619.