### PR TITLE
[mypyc] Refactor: move fallback primitive ops to a new module

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -45,9 +45,8 @@ from mypyc.ir.class_ir import ClassIR, NonExtClassInfo
 from mypyc.primitives.registry import func_ops
 from mypyc.primitives.list_ops import list_len_op, to_list, list_pop_last
 from mypyc.primitives.dict_ops import dict_get_item_op, dict_set_item_op
-from mypyc.primitives.misc_ops import (
-    true_op, false_op, iter_op, next_op, py_setattr_op, import_op
-)
+from mypyc.primitives.generic_ops import py_setattr_op, iter_op, next_op
+from mypyc.primitives.misc_ops import true_op, false_op, import_op
 from mypyc.crash import catch_errors
 from mypyc.options import CompilerOptions
 from mypyc.errors import Errors

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -16,9 +16,10 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.ir.func_ir import FuncIR, FuncDecl, FuncSignature, RuntimeArg
 from mypyc.ir.class_ir import ClassIR, NonExtClassInfo
+from mypyc.primitives.generic_ops import py_setattr_op, py_hasattr_op
 from mypyc.primitives.misc_ops import (
-    dataclass_sleight_of_hand, py_setattr_op, pytype_from_template_op, py_calc_meta_op,
-    type_object_op, py_hasattr_op, not_implemented_op, true_op
+    dataclass_sleight_of_hand, pytype_from_template_op, py_calc_meta_op, type_object_op,
+    not_implemented_op, true_op
 )
 from mypyc.primitives.dict_ops import dict_set_item_op, new_dict_op
 from mypyc.primitives.tuple_ops import new_tuple_op

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -20,7 +20,8 @@ from mypyc.ir.ops import (
 from mypyc.ir.rtypes import RTuple, object_rprimitive, is_none_rprimitive
 from mypyc.ir.func_ir import FUNC_CLASSMETHOD, FUNC_STATICMETHOD
 from mypyc.primitives.registry import name_ref_ops
-from mypyc.primitives.misc_ops import new_slice_op, iter_op, ellipsis_op, type_op
+from mypyc.primitives.generic_ops import iter_op
+from mypyc.primitives.misc_ops import new_slice_op, ellipsis_op, type_op
 from mypyc.primitives.list_ops import new_list_op, list_append_op, list_extend_op
 from mypyc.primitives.tuple_ops import list_tuple_op
 from mypyc.primitives.dict_ops import new_dict_op, dict_set_item_op

--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -16,7 +16,7 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.primitives.int_ops import unsafe_short_add
 from mypyc.primitives.list_ops import new_list_op, list_append_op, list_get_item_unsafe_op
-from mypyc.primitives.misc_ops import iter_op, next_op
+from mypyc.primitives.generic_ops import iter_op, next_op
 from mypyc.primitives.exc_ops import no_err_occurred_op
 from mypyc.irbuild.builder import IRBuilder
 

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -27,9 +27,8 @@ from mypyc.ir.func_ir import (
     FuncIR, FuncSignature, RuntimeArg, FuncDecl, FUNC_CLASSMETHOD, FUNC_STATICMETHOD, FUNC_NORMAL
 )
 from mypyc.ir.class_ir import ClassIR, NonExtClassInfo
-from mypyc.primitives.misc_ops import (
-    check_stop_op, yield_from_except_op, next_raw_op, iter_op, coro_op, send_op, py_setattr_op
-)
+from mypyc.primitives.generic_ops import py_setattr_op, next_raw_op, iter_op
+from mypyc.primitives.misc_ops import check_stop_op, yield_from_except_op, coro_op, send_op
 from mypyc.primitives.dict_ops import dict_set_item_op
 from mypyc.common import SELF_NAME, LAMBDA_NAME, decorator_helper_name
 from mypyc.sametype import is_same_method_signature

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -37,10 +37,11 @@ from mypyc.primitives.list_ops import (
 )
 from mypyc.primitives.tuple_ops import list_tuple_op, new_tuple_op
 from mypyc.primitives.dict_ops import new_dict_op, dict_update_in_display_op
+from mypyc.primitives.generic_ops import (
+    py_getattr_op, py_call_op, py_call_with_kwargs_op, py_method_call_op
+)
 from mypyc.primitives.misc_ops import (
-    none_op, none_object_op, false_op,
-    py_getattr_op, py_call_op, py_call_with_kwargs_op, py_method_call_op,
-    fast_isinstance_op, bool_op, type_is_op,
+    none_op, none_object_op, false_op, fast_isinstance_op, bool_op, type_is_op
 )
 from mypyc.rt_subtype import is_runtime_subtype
 from mypyc.subtype import is_subtype

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -21,7 +21,8 @@ from mypyc.ir.ops import (
     BasicBlock, TupleGet, Value, Register, Branch, NO_TRACEBACK_LINE_NO
 )
 from mypyc.ir.rtypes import exc_rtuple
-from mypyc.primitives.misc_ops import true_op, false_op, type_op, py_delattr_op, get_module_dict_op
+from mypyc.primitives.generic_ops import py_delattr_op
+from mypyc.primitives.misc_ops import true_op, false_op, type_op, get_module_dict_op
 from mypyc.primitives.dict_ops import dict_get_item_op
 from mypyc.primitives.exc_ops import (
     raise_exception_op, reraise_exception_op, error_catch_op, exc_matches_op, restore_exc_info_op,

--- a/mypyc/primitives/generic_ops.py
+++ b/mypyc/primitives/generic_ops.py
@@ -1,0 +1,235 @@
+"""Fallback primitive operations that operate on 'object' operands.
+
+These just call the relevant Python C API function or a thin wrapper
+around an API function. Most of these also have faster, specialized
+ops that operate on some more specific types.
+"""
+
+from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ERR_FALSE
+from mypyc.ir.rtypes import object_rprimitive, int_rprimitive, bool_rprimitive
+from mypyc.primitives.registry import (
+    binary_op, unary_op, func_op, method_op, custom_op, call_emit, simple_emit,
+    call_negative_bool_emit, call_negative_magic_emit, negative_int_emit
+)
+
+
+for op, opid in [('==', 'Py_EQ'),
+                 ('!=', 'Py_NE'),
+                 ('<', 'Py_LT'),
+                 ('<=', 'Py_LE'),
+                 ('>', 'Py_GT'),
+                 ('>=', 'Py_GE')]:
+    # The result type is 'object' since that's what PyObject_RichCompare returns.
+    binary_op(op=op,
+              arg_types=[object_rprimitive, object_rprimitive],
+              result_type=object_rprimitive,
+              error_kind=ERR_MAGIC,
+              emit=simple_emit('{dest} = PyObject_RichCompare({args[0]}, {args[1]}, %s);' % opid),
+              priority=0)
+
+for op, funcname in [('+', 'PyNumber_Add'),
+                     ('-', 'PyNumber_Subtract'),
+                     ('*', 'PyNumber_Multiply'),
+                     ('//', 'PyNumber_FloorDivide'),
+                     ('/', 'PyNumber_TrueDivide'),
+                     ('%', 'PyNumber_Remainder'),
+                     ('<<', 'PyNumber_Lshift'),
+                     ('>>', 'PyNumber_Rshift'),
+                     ('&', 'PyNumber_And'),
+                     ('^', 'PyNumber_Xor'),
+                     ('|', 'PyNumber_Or')]:
+    binary_op(op=op,
+              arg_types=[object_rprimitive, object_rprimitive],
+              result_type=object_rprimitive,
+              error_kind=ERR_MAGIC,
+              emit=call_emit(funcname),
+              priority=0)
+
+for op, funcname in [('+=', 'PyNumber_InPlaceAdd'),
+                     ('-=', 'PyNumber_InPlaceSubtract'),
+                     ('*=', 'PyNumber_InPlaceMultiply'),
+                     ('@=', 'PyNumber_InPlaceMatrixMultiply'),
+                     ('//=', 'PyNumber_InPlaceFloorDivide'),
+                     ('/=', 'PyNumber_InPlaceTrueDivide'),
+                     ('%=', 'PyNumber_InPlaceRemainder'),
+                     ('<<=', 'PyNumber_InPlaceLshift'),
+                     ('>>=', 'PyNumber_InPlaceRshift'),
+                     ('&=', 'PyNumber_InPlaceAnd'),
+                     ('^=', 'PyNumber_InPlaceXor'),
+                     ('|=', 'PyNumber_InPlaceOr')]:
+    binary_op(op=op,
+              arg_types=[object_rprimitive, object_rprimitive],
+              result_type=object_rprimitive,
+              error_kind=ERR_MAGIC,
+              emit=simple_emit('{dest} = %s({args[0]}, {args[1]});' % funcname),
+              priority=0)
+
+binary_op(op='**',
+          arg_types=[object_rprimitive, object_rprimitive],
+          result_type=object_rprimitive,
+          error_kind=ERR_MAGIC,
+          emit=simple_emit('{dest} = PyNumber_Power({args[0]}, {args[1]}, Py_None);'),
+          priority=0)
+
+binary_op('in',
+          arg_types=[object_rprimitive, object_rprimitive],
+          result_type=bool_rprimitive,
+          error_kind=ERR_MAGIC,
+          emit=negative_int_emit('{dest} = PySequence_Contains({args[1]}, {args[0]});'),
+          priority=0)
+
+binary_op('is',
+          arg_types=[object_rprimitive, object_rprimitive],
+          result_type=bool_rprimitive,
+          error_kind=ERR_NEVER,
+          emit=simple_emit('{dest} = {args[0]} == {args[1]};'),
+          priority=0)
+
+binary_op('is not',
+          arg_types=[object_rprimitive, object_rprimitive],
+          result_type=bool_rprimitive,
+          error_kind=ERR_NEVER,
+          emit=simple_emit('{dest} = {args[0]} != {args[1]};'),
+          priority=0)
+
+for op, funcname in [('-', 'PyNumber_Negative'),
+                     ('+', 'PyNumber_Positive'),
+                     ('~', 'PyNumber_Invert')]:
+    unary_op(op=op,
+             arg_type=object_rprimitive,
+             result_type=object_rprimitive,
+             error_kind=ERR_MAGIC,
+             emit=call_emit(funcname),
+             priority=0)
+
+unary_op(op='not',
+         arg_type=object_rprimitive,
+         result_type=bool_rprimitive,
+         error_kind=ERR_MAGIC,
+         format_str='{dest} = not {args[0]}',
+         emit=call_negative_magic_emit('PyObject_Not'),
+         priority=0)
+
+method_op('__getitem__',
+          arg_types=[object_rprimitive, object_rprimitive],
+          result_type=object_rprimitive,
+          error_kind=ERR_MAGIC,
+          emit=call_emit('PyObject_GetItem'),
+          priority=0)
+
+method_op('__setitem__',
+          arg_types=[object_rprimitive, object_rprimitive, object_rprimitive],
+          result_type=bool_rprimitive,
+          error_kind=ERR_FALSE,
+          emit=call_negative_bool_emit('PyObject_SetItem'),
+          priority=0)
+
+method_op('__delitem__',
+          arg_types=[object_rprimitive, object_rprimitive],
+          result_type=bool_rprimitive,
+          error_kind=ERR_FALSE,
+          emit=call_negative_bool_emit('PyObject_DelItem'),
+          priority=0)
+
+func_op(
+    name='builtins.hash',
+    arg_types=[object_rprimitive],
+    result_type=int_rprimitive,
+    error_kind=ERR_MAGIC,
+    emit=call_emit('CPyObject_Hash'))
+
+py_getattr_op = func_op(
+    name='builtins.getattr',
+    arg_types=[object_rprimitive, object_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_MAGIC,
+    emit=call_emit('PyObject_GetAttr')
+)
+
+func_op(
+    name='builtins.getattr',
+    arg_types=[object_rprimitive, object_rprimitive, object_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_MAGIC,
+    emit=call_emit('CPyObject_GetAttr3')
+)
+
+py_setattr_op = func_op(
+    name='builtins.setattr',
+    arg_types=[object_rprimitive, object_rprimitive, object_rprimitive],
+    result_type=bool_rprimitive,
+    error_kind=ERR_FALSE,
+    emit=call_negative_bool_emit('PyObject_SetAttr')
+)
+
+py_hasattr_op = func_op(
+    name='builtins.hasattr',
+    arg_types=[object_rprimitive, object_rprimitive],
+    result_type=bool_rprimitive,
+    error_kind=ERR_NEVER,
+    emit=call_emit('PyObject_HasAttr')
+)
+
+py_delattr_op = func_op(
+    name='builtins.delattr',
+    arg_types=[object_rprimitive, object_rprimitive],
+    result_type=bool_rprimitive,
+    error_kind=ERR_FALSE,
+    emit=call_negative_bool_emit('PyObject_DelAttr')
+)
+
+py_call_op = custom_op(
+    arg_types=[object_rprimitive],
+    result_type=object_rprimitive,
+    is_var_arg=True,
+    error_kind=ERR_MAGIC,
+    format_str='{dest} = py_call({comma_args})',
+    emit=simple_emit('{dest} = PyObject_CallFunctionObjArgs({comma_args}, NULL);'))
+
+py_call_with_kwargs_op = custom_op(
+    arg_types=[object_rprimitive],
+    result_type=object_rprimitive,
+    is_var_arg=True,
+    error_kind=ERR_MAGIC,
+    format_str='{dest} = py_call_with_kwargs({args[0]}, {args[1]}, {args[2]})',
+    emit=call_emit('PyObject_Call'))
+
+py_method_call_op = custom_op(
+    arg_types=[object_rprimitive],
+    result_type=object_rprimitive,
+    is_var_arg=True,
+    error_kind=ERR_MAGIC,
+    format_str='{dest} = py_method_call({comma_args})',
+    emit=simple_emit('{dest} = PyObject_CallMethodObjArgs({comma_args}, NULL);'))
+
+func_op(name='builtins.len',
+        arg_types=[object_rprimitive],
+        result_type=int_rprimitive,
+        error_kind=ERR_NEVER,
+        emit=call_emit('CPyObject_Size'),
+        priority=0)
+
+iter_op = func_op(name='builtins.iter',
+                  arg_types=[object_rprimitive],
+                  result_type=object_rprimitive,
+                  error_kind=ERR_MAGIC,
+                  emit=call_emit('PyObject_GetIter'))
+
+# Although the error_kind is set to be ERR_NEVER, this can actually
+# return NULL, and thus it must be checked using Branch.IS_ERROR.
+next_op = custom_op(name='next',
+                    arg_types=[object_rprimitive],
+                    result_type=object_rprimitive,
+                    error_kind=ERR_NEVER,
+                    emit=call_emit('PyIter_Next'))
+
+# Do a next, don't swallow StopIteration, but also don't propagate an
+# error. (N.B: This can still return NULL without an error to
+# represent an implicit StopIteration, but if StopIteration is
+# *explicitly* raised this will not swallow it.)
+# Can return NULL: see next_op.
+next_raw_op = custom_op(name='next',
+                        arg_types=[object_rprimitive],
+                        result_type=object_rprimitive,
+                        error_kind=ERR_NEVER,
+                        emit=call_emit('CPyIter_Next'))

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -1,15 +1,13 @@
 """Miscellaneous primitive ops."""
 
-
 from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ERR_FALSE
 from mypyc.ir.rtypes import (
     RTuple, none_rprimitive, bool_rprimitive, object_rprimitive, str_rprimitive,
     int_rprimitive, dict_rprimitive
 )
 from mypyc.primitives.registry import (
-    name_ref_op, simple_emit, binary_op, unary_op, func_op, method_op, custom_op,
-    negative_int_emit,
-    call_emit, name_emit, call_negative_bool_emit, call_negative_magic_emit,
+    name_ref_op, simple_emit, unary_op, func_op, custom_op, call_emit, name_emit,
+    call_negative_magic_emit
 )
 
 
@@ -54,36 +52,11 @@ func_op(name='builtins.id',
         error_kind=ERR_NEVER,
         emit=call_emit('CPyTagged_Id'))
 
-iter_op = func_op(name='builtins.iter',
-                  arg_types=[object_rprimitive],
-                  result_type=object_rprimitive,
-                  error_kind=ERR_MAGIC,
-                  emit=call_emit('PyObject_GetIter'))
-
 coro_op = custom_op(name='get_coroutine_obj',
                     arg_types=[object_rprimitive],
                     result_type=object_rprimitive,
                     error_kind=ERR_MAGIC,
                     emit=call_emit('CPy_GetCoro'))
-
-# Although the error_kind is set to be ERR_NEVER, this can actually
-# return NULL, and thus it must be checked using Branch.IS_ERROR.
-next_op = custom_op(name='next',
-                    arg_types=[object_rprimitive],
-                    result_type=object_rprimitive,
-                    error_kind=ERR_NEVER,
-                    emit=call_emit('PyIter_Next'))
-
-# Do a next, don't swallow StopIteration, but also don't propagate an
-# error. (N.B: This can still return NULL without an error to
-# represent an implicit StopIteration, but if StopIteration is
-# *explicitly* raised this will not swallow it.)
-# Can return NULL: see next_op.
-next_raw_op = custom_op(name='next',
-                        arg_types=[object_rprimitive],
-                        result_type=object_rprimitive,
-                        error_kind=ERR_NEVER,
-                        emit=call_emit('CPyIter_Next'))
 
 # Do a send, or a next if second arg is None.
 # (This behavior is to match the PEP 380 spec for yield from.)
@@ -111,7 +84,6 @@ yield_from_except_op = custom_op(
     error_kind=ERR_MAGIC,
     emit=simple_emit('{dest}.f0 = CPy_YieldFromErrorHandle({args[0]}, &{dest}.f1);'))
 
-
 method_new_op = custom_op(name='method_new',
                           arg_types=[object_rprimitive, object_rprimitive],
                           result_type=object_rprimitive,
@@ -127,108 +99,6 @@ check_stop_op = custom_op(name='check_stop_iteration',
                           error_kind=ERR_MAGIC,
                           emit=call_emit('CPy_FetchStopIterationValue'))
 
-
-#
-# Fallback primitive operations that operate on 'object' operands
-#
-
-for op, opid in [('==', 'Py_EQ'),
-                 ('!=', 'Py_NE'),
-                 ('<', 'Py_LT'),
-                 ('<=', 'Py_LE'),
-                 ('>', 'Py_GT'),
-                 ('>=', 'Py_GE')]:
-    # The result type is 'object' since that's what PyObject_RichCompare returns.
-    binary_op(op=op,
-              arg_types=[object_rprimitive, object_rprimitive],
-              result_type=object_rprimitive,
-              error_kind=ERR_MAGIC,
-              emit=simple_emit('{dest} = PyObject_RichCompare({args[0]}, {args[1]}, %s);' % opid),
-              priority=0)
-
-for op, funcname in [('+', 'PyNumber_Add'),
-                     ('-', 'PyNumber_Subtract'),
-                     ('*', 'PyNumber_Multiply'),
-                     ('//', 'PyNumber_FloorDivide'),
-                     ('/', 'PyNumber_TrueDivide'),
-                     ('%', 'PyNumber_Remainder'),
-                     ('<<', 'PyNumber_Lshift'),
-                     ('>>', 'PyNumber_Rshift'),
-                     ('&', 'PyNumber_And'),
-                     ('^', 'PyNumber_Xor'),
-                     ('|', 'PyNumber_Or')]:
-    binary_op(op=op,
-              arg_types=[object_rprimitive, object_rprimitive],
-              result_type=object_rprimitive,
-              error_kind=ERR_MAGIC,
-              emit=call_emit(funcname),
-              priority=0)
-
-for op, funcname in [('+=', 'PyNumber_InPlaceAdd'),
-                     ('-=', 'PyNumber_InPlaceSubtract'),
-                     ('*=', 'PyNumber_InPlaceMultiply'),
-                     ('@=', 'PyNumber_InPlaceMatrixMultiply'),
-                     ('//=', 'PyNumber_InPlaceFloorDivide'),
-                     ('/=', 'PyNumber_InPlaceTrueDivide'),
-                     ('%=', 'PyNumber_InPlaceRemainder'),
-                     ('<<=', 'PyNumber_InPlaceLshift'),
-                     ('>>=', 'PyNumber_InPlaceRshift'),
-                     ('&=', 'PyNumber_InPlaceAnd'),
-                     ('^=', 'PyNumber_InPlaceXor'),
-                     ('|=', 'PyNumber_InPlaceOr')]:
-    binary_op(op=op,
-              arg_types=[object_rprimitive, object_rprimitive],
-              result_type=object_rprimitive,
-              error_kind=ERR_MAGIC,
-              emit=simple_emit('{dest} = %s({args[0]}, {args[1]});' % funcname),
-              priority=0)
-
-binary_op(op='**',
-          arg_types=[object_rprimitive, object_rprimitive],
-          result_type=object_rprimitive,
-          error_kind=ERR_MAGIC,
-          emit=simple_emit('{dest} = PyNumber_Power({args[0]}, {args[1]}, Py_None);'),
-          priority=0)
-
-binary_op('in',
-          arg_types=[object_rprimitive, object_rprimitive],
-          result_type=bool_rprimitive,
-          error_kind=ERR_MAGIC,
-          emit=negative_int_emit('{dest} = PySequence_Contains({args[1]}, {args[0]});'),
-          priority=0)
-
-binary_op('is',
-          arg_types=[object_rprimitive, object_rprimitive],
-          result_type=bool_rprimitive,
-          error_kind=ERR_NEVER,
-          emit=simple_emit('{dest} = {args[0]} == {args[1]};'),
-          priority=0)
-
-binary_op('is not',
-          arg_types=[object_rprimitive, object_rprimitive],
-          result_type=bool_rprimitive,
-          error_kind=ERR_NEVER,
-          emit=simple_emit('{dest} = {args[0]} != {args[1]};'),
-          priority=0)
-
-for op, funcname in [('-', 'PyNumber_Negative'),
-                     ('+', 'PyNumber_Positive'),
-                     ('~', 'PyNumber_Invert')]:
-    unary_op(op=op,
-             arg_type=object_rprimitive,
-             result_type=object_rprimitive,
-             error_kind=ERR_MAGIC,
-             emit=call_emit(funcname),
-             priority=0)
-
-unary_op(op='not',
-         arg_type=object_rprimitive,
-         result_type=bool_rprimitive,
-         error_kind=ERR_MAGIC,
-         format_str='{dest} = not {args[0]}',
-         emit=call_negative_magic_emit('PyObject_Not'),
-         priority=0)
-
 unary_op(op='not',
          arg_type=bool_rprimitive,
          result_type=bool_rprimitive,
@@ -236,66 +106,6 @@ unary_op(op='not',
          format_str='{dest} = !{args[0]}',
          emit=simple_emit('{dest} = !{args[0]};'),
          priority=1)
-
-method_op('__getitem__',
-          arg_types=[object_rprimitive, object_rprimitive],
-          result_type=object_rprimitive,
-          error_kind=ERR_MAGIC,
-          emit=call_emit('PyObject_GetItem'),
-          priority=0)
-
-method_op('__setitem__',
-          arg_types=[object_rprimitive, object_rprimitive, object_rprimitive],
-          result_type=bool_rprimitive,
-          error_kind=ERR_FALSE,
-          emit=call_negative_bool_emit('PyObject_SetItem'),
-          priority=0)
-
-method_op('__delitem__',
-          arg_types=[object_rprimitive, object_rprimitive],
-          result_type=bool_rprimitive,
-          error_kind=ERR_FALSE,
-          emit=call_negative_bool_emit('PyObject_DelItem'),
-          priority=0)
-
-func_op(
-    name='builtins.hash',
-    arg_types=[object_rprimitive],
-    result_type=int_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyObject_Hash'))
-
-py_getattr_op = func_op(
-    name='builtins.getattr',
-    arg_types=[object_rprimitive, object_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('PyObject_GetAttr')
-)
-
-func_op(
-    name='builtins.getattr',
-    arg_types=[object_rprimitive, object_rprimitive, object_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyObject_GetAttr3')
-)
-
-py_setattr_op = func_op(
-    name='builtins.setattr',
-    arg_types=[object_rprimitive, object_rprimitive, object_rprimitive],
-    result_type=bool_rprimitive,
-    error_kind=ERR_FALSE,
-    emit=call_negative_bool_emit('PyObject_SetAttr')
-)
-
-py_hasattr_op = func_op(
-    name='builtins.hasattr',
-    arg_types=[object_rprimitive, object_rprimitive],
-    result_type=bool_rprimitive,
-    error_kind=ERR_NEVER,
-    emit=call_emit('PyObject_HasAttr')
-)
 
 py_calc_meta_op = custom_op(
     arg_types=[object_rprimitive, object_rprimitive],
@@ -306,40 +116,6 @@ py_calc_meta_op = custom_op(
         '{dest} = (PyObject*) _PyType_CalculateMetaclass((PyTypeObject *){args[0]}, {args[1]});'),
     is_borrowed=True
 )
-
-py_delattr_op = func_op(
-    name='builtins.delattr',
-    arg_types=[object_rprimitive, object_rprimitive],
-    result_type=bool_rprimitive,
-    error_kind=ERR_FALSE,
-    emit=call_negative_bool_emit('PyObject_DelAttr')
-)
-
-py_call_op = custom_op(
-    arg_types=[object_rprimitive],
-    result_type=object_rprimitive,
-    is_var_arg=True,
-    error_kind=ERR_MAGIC,
-    format_str='{dest} = py_call({comma_args})',
-    emit=simple_emit('{dest} = PyObject_CallFunctionObjArgs({comma_args}, NULL);'))
-
-py_call_with_kwargs_op = custom_op(
-    arg_types=[object_rprimitive],
-    result_type=object_rprimitive,
-    is_var_arg=True,
-    error_kind=ERR_MAGIC,
-    format_str='{dest} = py_call_with_kwargs({args[0]}, {args[1]}, {args[2]})',
-    emit=call_emit('PyObject_Call'))
-
-
-py_method_call_op = custom_op(
-    arg_types=[object_rprimitive],
-    result_type=object_rprimitive,
-    is_var_arg=True,
-    error_kind=ERR_MAGIC,
-    format_str='{dest} = py_method_call({comma_args})',
-    emit=simple_emit('{dest} = PyObject_CallMethodObjArgs({comma_args}, NULL);'))
-
 
 import_op = custom_op(
     name='import',
@@ -356,7 +132,6 @@ get_module_dict_op = custom_op(
     error_kind=ERR_NEVER,
     emit=call_emit('PyImport_GetModuleDict'),
     is_borrowed=True)
-
 
 func_op('builtins.isinstance',
         arg_types=[object_rprimitive, object_rprimitive],
@@ -408,13 +183,6 @@ type_object_op = name_ref_op(
     error_kind=ERR_NEVER,
     emit=name_emit('(PyObject*) &PyType_Type'),
     is_borrowed=True)
-
-func_op(name='builtins.len',
-        arg_types=[object_rprimitive],
-        result_type=int_rprimitive,
-        error_kind=ERR_NEVER,
-        emit=call_emit('CPyObject_Size'),
-        priority=0)
 
 pytype_from_template_op = custom_op(
     arg_types=[object_rprimitive, object_rprimitive, str_rprimitive],


### PR DESCRIPTION
These are all simple, operate on arbitrary objects, and roughly follow the same 
implementation pattern, so it makes sense to have them in one place. There a 
few other ops that could arguably live here, but this seems like a good enough 
selection for now. We can tweak individual ops later if we feel like it.