### PR TITLE
[mypyc]Add LLPritimiveOp, implement list.__getitem__ based on new LLPrimitiveOp

### DIFF
--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -8,7 +8,8 @@ from mypyc.ir.ops import (
     Value, ControlOp,
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
-    LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError,
+    LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError, LLPrimitiveOp,
+    CFunctionCall,
 )
 
 
@@ -157,6 +158,12 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_primitive_op(self, op: PrimitiveOp) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_llprimitive_op(self, op: LLPrimitiveOp) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_C_function_call(self, op: CFunctionCall) -> GenAndKill:
         return self.visit_register_op(op)
 
     def visit_load_int(self, op: LoadInt) -> GenAndKill:

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -759,11 +759,16 @@ class PrimitiveOp(RegisterOp):
         return visitor.visit_primitive_op(self)
 
 
-IREmitCallback = Callable[['LowLevelIRBuilder', List[Value], Value], List[Op]]
+@trait
+class IRBuilderInterface:
+    pass
+
+
+IREmitCallback = Callable[[IRBuilderInterface, List[Value], RType], List[Op]]
 
 # Description of a low-levl primitive operation
 LLOpDescription = NamedTuple(
-    'OpDescription', [('name', str),
+    'LLOpDescription', [('name', str),
                       ('arg_types', List[RType]),
                       ('result_type', Optional[RType]),
                       ('is_var_arg', bool),

--- a/mypyc/llprimitives/list_ops.py
+++ b/mypyc/llprimitives/list_ops.py
@@ -1,0 +1,30 @@
+"""List llprimitive ops."""
+
+from typing import List
+
+from mypyc.ir.ops import (
+  Op, Value, CFunctionCall, IREmitCallback,
+  ERR_MAGIC,
+)
+from mypyc.ir.rtypes import (
+    int_rprimitive, list_rprimitive, object_rprimitive,
+)
+from mypyc.llprimitives.registry import method_op
+
+
+def list_getitem_helper(function_name: str) -> IREmitCallback:
+    def list_getitem_callback(builder: 'LowLevelIRBuilder',
+                              args: List[Value],
+                              ret_typ: Value) -> List[Op]:
+        return [CFunctionCall(function_name, args, ret_typ)]
+    return list_getitem_callback
+
+
+# Version with no int bounds check for when it is known to be short
+list_get_item_op = method_op(
+    name='__getitem__',
+    arg_types=[list_rprimitive, int_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_MAGIC,
+    ir_emit=list_getitem_helper('CPyList_GetItem'),
+    priority=2)

--- a/mypyc/llprimitives/list_ops.py
+++ b/mypyc/llprimitives/list_ops.py
@@ -3,19 +3,19 @@
 from typing import List
 
 from mypyc.ir.ops import (
-  Op, Value, CFunctionCall, IREmitCallback,
+  Op, Value, CFunctionCall, IREmitCallback, IRBuilderInterface,
   ERR_MAGIC,
 )
 from mypyc.ir.rtypes import (
-    int_rprimitive, list_rprimitive, object_rprimitive,
+    int_rprimitive, list_rprimitive, object_rprimitive, RType,
 )
 from mypyc.llprimitives.registry import method_op
 
 
 def list_getitem_helper(function_name: str) -> IREmitCallback:
-    def list_getitem_callback(builder: 'LowLevelIRBuilder',
+    def list_getitem_callback(builder: IRBuilderInterface,
                               args: List[Value],
-                              ret_typ: Value) -> List[Op]:
+                              ret_typ: RType) -> List[Op]:
         return [CFunctionCall(function_name, args, ret_typ)]
     return list_getitem_callback
 

--- a/mypyc/llprimitives/registry.py
+++ b/mypyc/llprimitives/registry.py
@@ -1,0 +1,34 @@
+from typing import Dict, List, Optional
+
+from mypyc.ir.ops import (
+  LLOpDescription, IREmitCallback, StealsDescription, short_name
+)
+from mypyc.ir.rtypes import RType
+# LLPrimitive ops for built-in methods (key is method name such as 'builtins.list.append')
+ll_method_ops = {}  # type: Dict[str, List[LLOpDescription]]
+
+
+def method_op(name: str,
+              arg_types: List[RType],
+              result_type: Optional[RType],
+              error_kind: int,
+              ir_emit: IREmitCallback,
+              steals: StealsDescription = False,
+              is_borrowed: bool = False,
+              priority: int = 1) -> LLOpDescription:
+    ops = ll_method_ops.setdefault(name, [])
+    assert len(arg_types) > 0
+    args = ', '.join('{args[%d]}' % i
+                     for i in range(1, len(arg_types)))
+    type_name = short_name(arg_types[0].name)
+    if name == '__getitem__':
+        format_str = '{dest} = {args[0]}[{args[1]}] :: %s' % type_name
+    else:
+        format_str = '{dest} = {args[0]}.%s(%s) :: %s' % (name, args, type_name)
+    desc = LLOpDescription(name, arg_types, result_type, False, error_kind, format_str, ir_emit,
+                         steals, is_borrowed, priority)
+    ops.append(desc)
+    return desc
+
+
+import mypyc.llprimitives.list_ops  # noqa

--- a/mypyc/llprimitives/registry.py
+++ b/mypyc/llprimitives/registry.py
@@ -4,6 +4,8 @@ from mypyc.ir.ops import (
   LLOpDescription, IREmitCallback, StealsDescription, short_name
 )
 from mypyc.ir.rtypes import RType
+
+
 # LLPrimitive ops for built-in methods (key is method name such as 'builtins.list.append')
 ll_method_ops = {}  # type: Dict[str, List[LLOpDescription]]
 

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -44,12 +44,12 @@ new_list_op = custom_op(arg_types=[object_rprimitive],
                         emit=emit_new)
 
 
-list_get_item_op = method_op(
-    name='__getitem__',
-    arg_types=[list_rprimitive, int_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyList_GetItem'))
+# list_get_item_op = method_op(
+#     name='__getitem__',
+#     arg_types=[list_rprimitive, int_rprimitive],
+#     result_type=object_rprimitive,
+#     error_kind=ERR_MAGIC,
+#     emit=call_emit('CPyList_GetItem'))
 
 
 # Version with no int bounds check for when it is known to be short

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -164,6 +164,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(DecRef(self.tt), 'CPyTagged_DecRef(cpy_r_tt.f0.f0);')
 
     def test_list_get_item(self) -> None:
+        assert list_get_item_op.result_type
         self.assert_emit(LLPrimitiveOp([self.m, self.k], list_get_item_op,
             [CFunctionCall('CPyList_GetItem', [self.m, self.k], list_get_item_op.result_type)],
             55), """cpy_r_r0 = CPyList_GetItem(cpy_r_m, cpy_r_k);""")

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -8,7 +8,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ir.ops import (
     Environment, BasicBlock, Goto, Return, LoadInt, Assign, IncRef, DecRef, Branch,
     Call, Unbox, Box, TupleGet, GetAttr, PrimitiveOp, RegisterOp,
-    SetAttr, Op, Value
+    SetAttr, Op, Value, LLPrimitiveOp, CFunctionCall,
 )
 from mypyc.ir.rtypes import (
     RTuple, RInstance, int_rprimitive, bool_rprimitive, list_rprimitive,
@@ -22,12 +22,13 @@ from mypyc.codegen.emitfunc import generate_native_function, FunctionEmitterVisi
 from mypyc.primitives.registry import binary_ops
 from mypyc.primitives.misc_ops import none_object_op, true_op, false_op
 from mypyc.primitives.list_ops import (
-    list_len_op, list_get_item_op, list_set_item_op, new_list_op, list_append_op
+    list_len_op, list_set_item_op, new_list_op, list_append_op
 )
 from mypyc.primitives.dict_ops import (
     new_dict_op, dict_update_op, dict_get_item_op, dict_set_item_op
 )
 from mypyc.primitives.int_ops import int_neg_op
+from mypyc.llprimitives.list_ops import list_get_item_op
 from mypyc.subtype import is_subtype
 from mypyc.namegen import NameGenerator
 
@@ -163,7 +164,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(DecRef(self.tt), 'CPyTagged_DecRef(cpy_r_tt.f0.f0);')
 
     def test_list_get_item(self) -> None:
-        self.assert_emit(PrimitiveOp([self.m, self.k], list_get_item_op, 55),
+        self.assert_emit(LLPrimitiveOp([self.m, self.k], list_get_item_op,
+            CFunctionCall('CPyList_GetItem', [self.m, self.k], list_get_item_op.result_type), 55),
                          """cpy_r_r0 = CPyList_GetItem(cpy_r_m, cpy_r_k);""")
 
     def test_list_set_item(self) -> None:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -165,8 +165,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 
     def test_list_get_item(self) -> None:
         self.assert_emit(LLPrimitiveOp([self.m, self.k], list_get_item_op,
-            CFunctionCall('CPyList_GetItem', [self.m, self.k], list_get_item_op.result_type), 55),
-                         """cpy_r_r0 = CPyList_GetItem(cpy_r_m, cpy_r_k);""")
+            [CFunctionCall('CPyList_GetItem', [self.m, self.k], list_get_item_op.result_type)],
+            55), """cpy_r_r0 = CPyList_GetItem(cpy_r_m, cpy_r_k);""")
 
     def test_list_set_item(self) -> None:
         self.assert_emit(PrimitiveOp([self.l, self.n, self.o], list_set_item_op, 55),


### PR DESCRIPTION
This is the first PR towards mypyc/mypyc#709.

In this PR, a new `RegisterOp` subclass `LLPrimitiveOp` is implemented. The new op is aiming to replace the current `PrimitiveOp` in the future. The major differences between them is that `LLPrimitiveOp` uses a list of ops as its actual description, which is similar to `BasicBlock` and is more abstract compared with using a C codegen callback function directly.

The top first priority of this PR is to present an initial design and therefore discuss and improve it. To demonstrate the idea, the `list.__getitem__` op is reimplemented using the new primitive op. The basic workflow is:

- During IR build, the `list.__getitem__` matches a `LLPrimitiveOp` registry and uses the callback to generate a list of ops that describe this particular op.
- During code generation, generating from this list of ops.

To this end, a new op `CFunctionCall` is also added to represent an external C function call in the IR. In the future, we may add more Ops/adjust based on the current IR, adding more expressiveness. 

This PR has some known bugs/hacks:

- The naming of registers. The current implementation uses a hack that any op of `LLPrimitiveOp`'s ops shares the same register name as `LLPrimitiveOp`. That's because in this PR we only consider a `LLPrimitiveOp` that can be implemented using a single `CFunctionCall`. Besides, the naming between the ops is also missing thus we cannot have more than 1 `CFunctionCall`. Fixing this would be of high priority once the prototype workflow is discussed and ready to go.

Again, the main focus of this PR would be presenting, discussing and modifying the general workflow and design for later works. Any comments are welcomed and highly appreciated!