### PR TITLE
Fixes:  #7864 TypeVars should be allowed to be the same

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -846,12 +846,8 @@ Likewise, this error will occur for constrained and bound TypeVars as well.
 
 .. code-block:: python
 
-    A = TypeVar("A", bound=int)
-    B = TypeVar("B", bound=int)
-
-or
-
-.. code-block:: python
-
-    A = TypeVar("A", int, float, complex)
-    B = TypeVar("B", int, float, complex)
+    A = TypeVar("A", int, str)
+    B = TypeVar("B", int, str)
+    # or
+    A = TypeVar("A", bound=complex)
+    B = TypeVar("B", bound=complex)

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -777,7 +777,6 @@ This example demonstrates both safe and unsafe overrides:
 
     class A:
         def test(self, t: Sequence[int]) -> Sequence[str]:
-<<<<<<< HEAD
             ...
 
     class GeneralizedArgument(A):
@@ -851,3 +850,36 @@ Likewise, this error will occur for constrained and bound TypeVars as well.
     # or
     A = TypeVar("A", bound=complex)
     B = TypeVar("B", bound=complex)
+
+
+In some cases, the ``@overload`` decorator can be used to provide the desired type checking. Here's an example.
+
+.. code-block:: python
+
+    from typing import Callable, Iterable, TypeVar, overload, Tuple
+
+    A = TypeVar("A")
+    B = TypeVar("B")
+
+    def identity(x: A) -> A:
+        return x
+
+    def second(tup: Tuple[int, str]) -> str:
+        return tup[1]
+
+    @overload
+    def _map2(queue: Iterable[A]) -> Iterable[A]: ...
+    @overload
+    def _map2(queue: Iterable[A], function: Callable[[A], A]) -> Iterable[A]: ...
+    @overload
+    def _map2(queue: Iterable[B], function: Callable[[B], A]) -> Iterable[A]: ...
+    def _map2(queue, function=identity):
+        return map(function, queue)
+
+    list_1 = [2, 4, 6, 8]
+    list_2 = ["hello", "world"]
+    list_3 = list(enumerate(["fazzle", "baz", "rompl" ]))
+
+    mapped_1 = [n for n in _map2(list_1)]
+    mapped_2 = [s for s in _map2(list_2, identity)]
+    mapped_3 = [t for t in _map2(list_3, second)]


### PR DESCRIPTION
For the **Common Issues and Solutions** doc, added a section **TypeVars are not the same**.

I'm not entirely sure about the example I concocted to show code that does pass muster with Mypy.
