### PR TITLE
Implementation for disallowing tuple unpacking of strings

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2553,7 +2553,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         elif isinstance(rvalue_type, UnionType):
             self.check_multi_assignment_from_union(lvalues, rvalue, rvalue_type, context,
                                                    infer_lvalue_type)
-        elif rvalue_type.type.fullname == 'builtins.str':
+        elif isinstance(rvalue_type, Instance) and rvalue_type.type.fullname == 'builtins.str':
             self.msg.unpacking_strings_disallowed(context)
         else:
             self.check_multi_assignment_from_iterable(lvalues, rvalue_type,

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2553,6 +2553,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         elif isinstance(rvalue_type, UnionType):
             self.check_multi_assignment_from_union(lvalues, rvalue, rvalue_type, context,
                                                    infer_lvalue_type)
+        elif rvalue_type.type.fullname == 'builtins.str':
+            self.msg.unpacking_strings_disallowed(context)
         else:
             self.check_multi_assignment_from_iterable(lvalues, rvalue_type,
                                                       context, infer_lvalue_type)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -733,7 +733,7 @@ class MessageBuilder:
                 expected, provided), context)
 
     def unpacking_strings_disallowed(self, context: Context) -> None:
-        self.fail("unpacking a string is disallowed", context)
+        self.fail("Unpacking a string is disallowed", context)
 
     def type_not_iterable(self, type: Type, context: Context) -> None:
         self.fail('\'{}\' object is not iterable'.format(type), context)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -732,6 +732,9 @@ class MessageBuilder:
             self.fail('Too many values to unpack ({} expected, {} provided)'.format(
                 expected, provided), context)
 
+    def unpacking_strings_disallowed(self, context: Context) -> None:
+        self.fail("unpacking a string is disallowed", context)
+
     def type_not_iterable(self, type: Type, context: Context) -> None:
         self.fail('\'{}\' object is not iterable'.format(type), context)
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -700,6 +700,20 @@ reveal_type(x) # N: Revealed type is 'Any'
 reveal_type(y) # N: Revealed type is 'Any'
 [out]
 
+[case testStringDisallowedUnpacking]
+from typing import Dict
+
+d: Dict[str, str]
+
+for a, b in d: # E: unpacking a string is disallowed
+    pass
+
+s = "foo"
+a, b = s # E: unpacking a string is disallowed
+
+[builtins fixtures/dict.pyi]
+[out]
+
 [case testUnionAlwaysTooMany]
 from typing import Union, Tuple
 bad: Union[Tuple[int, int, int], Tuple[str, str, str]]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -695,7 +695,7 @@ from typing import Union
 bad: Union[int, str]
 
 x, y = bad # E: 'builtins.int' object is not iterable \
-           # E: unpacking a string is disallowed
+           # E: Unpacking a string is disallowed
 reveal_type(x) # N: Revealed type is 'Any'
 reveal_type(y) # N: Revealed type is 'Any'
 [out]
@@ -705,11 +705,11 @@ from typing import Dict
 
 d: Dict[str, str]
 
-for a, b in d: # E: unpacking a string is disallowed
+for a, b in d: # E: Unpacking a string is disallowed
     pass
 
 s = "foo"
-a, b = s # E: unpacking a string is disallowed
+a, b = s # E: Unpacking a string is disallowed
 
 [builtins fixtures/dict.pyi]
 [out]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -695,7 +695,7 @@ from typing import Union
 bad: Union[int, str]
 
 x, y = bad # E: 'builtins.int' object is not iterable \
-           # E: 'builtins.str' object is not iterable
+           # E: unpacking a string is disallowed
 reveal_type(x) # N: Revealed type is 'Any'
 reveal_type(y) # N: Revealed type is 'Any'
 [out]


### PR DESCRIPTION
Implementation of #6406. 

Tests are failing, but /i believe the fix isn't too far from the implementation I have so far.

I would really appreciate suggestions on a different way of checking the type of a string so that errors do not occur with the tests.

Thanks!