### PR TITLE
Fix bug by removing fix_suppressed_dependencies

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2247,11 +2247,9 @@ class State:
             all_deps = self.suppressed
         else:
             # Strip out indirect dependencies. See comment in build.load_graph().
+            dependencies = [dep for dep in self.dependencies
+                            if self.priorities.get(dep) != PRI_INDIRECT]
             all_deps = dependencies + self.suppressed + self.ancestors
-            all_deps = [dep for dep in all_deps
-                        if self.priorities.get(dep) != PRI_INDIRECT]
-            #all_deps = dependencies + self.suppressed + self.ancestors
-        self.manager.log("ALL_DEPS {}: {} (... {})".format(self.id, all_deps, self.suppressed))
         for dep in all_deps:
             if dep in manager.modules:
                 continue

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1954,45 +1954,6 @@ class State:
         fixup_module(self.tree, self.manager.modules,
                      self.options.use_fine_grained_cache)
 
-    def fix_suppressed_dependencies(self, graph: Graph) -> None:
-        """Corrects whether dependencies are considered stale in silent mode.
-
-        This method is a hack to correct imports in silent mode + incremental mode.
-        In particular, the problem is that when running mypy with a cold cache, the
-        `parse_file(...)` function is called *at the start* of the `load_graph(...)` function.
-        Note that load_graph will mark some dependencies as suppressed if they weren't specified
-        on the command line in silent mode.
-
-        However, if the interface for a module is changed, parse_file will be called within
-        `process_stale_scc` -- *after* load_graph is finished, wiping out the changes load_graph
-        previously made.
-
-        This method is meant to be run after parse_file finishes in process_stale_scc and will
-        recompute what modules should be considered suppressed in silent mode.
-        """
-        # TODO: See if it's possible to move this check directly into parse_file in some way.
-        # TODO: Find a way to write a test case for this fix.
-        # TODO: I suspect that splitting compute_dependencies() out from parse_file
-        # obviates the need for this but lacking a test case for the problem this fixed...
-        silent_mode = (self.options.ignore_missing_imports or
-                       self.options.follow_imports == 'skip')
-        if not silent_mode:
-            return
-
-        new_suppressed = []
-        new_dependencies = []
-        entry_points = self.manager.source_set.source_modules
-        for dep in self.dependencies + self.suppressed:
-            ignored = dep in self.suppressed_set and dep not in entry_points
-            if ignored or dep not in graph:
-                new_suppressed.append(dep)
-            else:
-                new_dependencies.append(dep)
-        self.dependencies = new_dependencies
-        self.dependencies_set = set(new_dependencies)
-        self.suppressed = new_suppressed
-        self.suppressed_set = set(new_suppressed)
-
     # Methods for processing modules from source code.
 
     def parse_file(self) -> None:
@@ -2286,9 +2247,11 @@ class State:
             all_deps = self.suppressed
         else:
             # Strip out indirect dependencies. See comment in build.load_graph().
-            dependencies = [dep for dep in self.dependencies
-                            if self.priorities.get(dep) != PRI_INDIRECT]
             all_deps = dependencies + self.suppressed + self.ancestors
+            all_deps = [dep for dep in all_deps
+                        if self.priorities.get(dep) != PRI_INDIRECT]
+            #all_deps = dependencies + self.suppressed + self.ancestors
+        self.manager.log("ALL_DEPS {}: {} (... {})".format(self.id, all_deps, self.suppressed))
         for dep in all_deps:
             if dep in manager.modules:
                 continue
@@ -3039,7 +3002,6 @@ def process_stale_scc(graph: Graph, scc: List[str], manager: BuildManager) -> No
         # We may already have parsed the module, or not.
         # If the former, parse_file() is a no-op.
         graph[id].parse_file()
-        graph[id].fix_suppressed_dependencies(graph)
     if 'typing' in scc:
         # For historical reasons we need to manually add typing aliases
         # for built-in generic collections, see docstring of

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -574,7 +574,6 @@ def update_module_isolated(module: str,
     state.parse_file()
     assert state.tree is not None, "file must be at least parsed"
     t0 = time.time()
-    # TODO: state.fix_suppressed_dependencies()?
     try:
         semantic_analysis_for_scc(graph, [state.id], manager.errors)
     except CompileError as err:

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5384,3 +5384,37 @@ class N(p.util.Test):
     ...
 [out2]
 tmp/a.py:2: error: "object" has no attribute "N"
+
+[case testIncrementalIndirectSkipWarnUnused]
+# flags: --follow-imports=skip --warn-unused-ignores
+# cmd: mypy -m main a b c1
+# cmd2: mypy -m main a b c2
+
+[file main.py]
+import a
+a.foo.bar()
+
+[file a.py]
+import b
+foo = b.Foo()
+
+[file b.py]
+from c1 import C
+class Foo:
+    def bar(self) -> C:
+        return C()
+
+[file c1.py]
+class C: pass
+
+[file b.py.2]
+from c2 import C
+class Foo:
+    def bar(self) -> C:
+        return C()
+
+[file c2.py]
+
+[delete c1.py.2]
+[file c2.py.2]
+class C: pass


### PR DESCRIPTION
We found a bug internally caused by deleting an indirect dependency
with --follow-imports=skip and --warn-unused-ignores. This is caused
by the indirect dependency being moved from deps to suppressed by
fix_suppressed_dependencies, which loses the knowledge that it is an
indirect dependency, causing verify_dependencies to take it much more
seriously than it should be.

fix_suppressed_dependencies was added as a hotfix for an incremental
bug discovered internally in 2016 that we never found a test case
for. I hypothesized during an earlier refactor that it had been made
redundant. Since fix_suppressed_dependencies is causing trouble now,
let's put that hypothesis to the test and remove it. If this causes a
regression, then maybe we'll be able to finally extract the test case
we want.