### PR TITLE
Make strict in config a boolean

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -85,6 +85,7 @@ config_types = {
     'package_root': lambda s: [p.strip() for p in s.split(',')],
     'cache_dir': expand_path,
     'python_executable': expand_path,
+    'strict': bool,
 }  # type: Final
 
 
@@ -208,7 +209,7 @@ def parse_section(prefix: str, template: Options,
                     options_key = key[3:]
                     invert = True
                 elif key == 'strict':
-                    set_strict_flags()
+                    pass  # Special handling below
                 else:
                     print("%sUnrecognized option: %s = %s" % (prefix, key, section[key]),
                           file=stderr)
@@ -238,6 +239,10 @@ def parse_section(prefix: str, template: Options,
                 continue
         except ValueError as err:
             print("%s%s: %s" % (prefix, key, err), file=stderr)
+            continue
+        if key == 'strict':
+            if v:
+                set_strict_flags()
             continue
         if key == 'silent_imports':
             print("%ssilent_imports has been replaced by "

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1165,6 +1165,22 @@ def f(c: A) -> None:  # E: Missing type parameters for generic type "A"
 strict = True
 [out]
 
+[case testStrictFalseInConfigAnyGeneric]
+# flags: --config-file tmp/mypy.ini
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+
+class A(Generic[T]):
+    pass
+
+def f(c: A) -> None:
+    pass
+[file mypy.ini]
+\[mypy]
+strict = False
+[out]
+
 [case testStrictAndStrictEquality]
 # flags: --strict
 x = 0


### PR DESCRIPTION
Note that setting strict = False does not invert any of the options touched by strict; instead it is the same as if strict was not set at all.

Tested only to the extent of running the tests.

Closes https://github.com/python/mypy/issues/8633