### PR TITLE
Docs: use asterisk notation when ignoring library

### DIFF
--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -228,13 +228,15 @@ will continue to be of type ``Any``.
     all import errors associated with that library and that library alone by
     adding the following section to your config file::
 
-        [mypy-foobar]
+        [mypy-foobar.*]
         ignore_missing_imports = True
 
     Note: this option is equivalent to adding a ``# type: ignore`` to every
     import of ``foobar`` in your codebase. For more information, see the
     documentation about configuring
     :ref:`import discovery <config-file-import-discovery>` in config files.
+    The ``.*`` after ``foobar`` will ignore imports of ``foobar`` modules
+    and subpackages in addition to the ``foobar`` top-level package namespace.
 
 3.  To suppress *all* missing import errors for *all* libraries in your codebase,
     invoke mypy with the :option:`--ignore-missing-imports <mypy --ignore-missing-imports>` command line flag or set


### PR DESCRIPTION
The examples for ignoring missing imports for a specific
library are currently conflicting between:

https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-type-hints-for-third-party-library
and
https://mypy.readthedocs.io/en/stable/existing_code.html#start-small

The former uses the syntax ``[mypy-library]``.

while the latter uses the syntax ``[mypy-library.*]``.

It's the latter that captures the goal of what 99% of users are trying
to do, which is to ignore a package.

This is made clearer with a concrete example using the Ansible
package, broken into stages.

In stage 1 we have:

    $ cat foo.py
    import ansible

    import ansible.constants

    $ cat mypy.ini
    [mypy]
    warn_unreachable = True

    [mypy-ansible]
    ignore_missing_imports = True

This mirrors the current ``[mypy-foobar]``.

In this case mypy will still raise for ``ansible.constants``:

    $ mypy --python-version '2.7' --platform linux --show-traceback .
    foo.py:3: error: Skipping analyzing 'ansible.constants': found module but no type hints or library stubs
    foo.py:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports

This is almost certainly _not_ what most users want.  If they don't
have stubs for the Ansible package, they don't have them--period.
The language specifically uses "library," which is best understood
to be a package rather than a single module.

Stage 2:

    $ cat mypy.ini
    [mypy]
    warn_unreachable = True

    [mypy-ansible.*]
    ignore_missing_imports = True

    $ mypy --python-version '2.7' --platform linux --show-traceback .
    Success: no issues found in 1 source file

The asterisk version ignores Ansible and its modules/subpackages.