### PR TITLE
Enable following imports in dmypy (--follow-imports=normal)

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -143,7 +143,7 @@ def process_start_options(flags: List[str], allow_sources: bool) -> Options:
         sys.exit("dmypy: start/restart should not disable incremental mode")
     # Our file change tracking can't yet handle changes to files that aren't
     # specified in the sources list.
-    if options.follow_imports not in ('skip', 'error'):
+    if options.follow_imports not in ('skip', 'error', 'normal'):
         sys.exit("dmypy: follow-imports must be 'skip' or 'error'")
     return options
 


### PR DESCRIPTION
We already have a bunch of tests that use this. Now enable it on the
command line so that it's possible to start using this for real and to
do interactive testing.

Closes #5870.