### PR TITLE
Minor documentation fixes

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -468,7 +468,7 @@ of the above sections.
 .. option:: --allow-redefinition
 
     By default, mypy won't allow a variable to be redefined with an
-    unrelated type. This flag enables redefinion of a variable with an
+    unrelated type. This flag enables redefinition of a variable with an
     arbitrary type *in some contexts*: only redefinitions within the
     same block and nesting depth as the original definition are allowed.
     Example where this can be useful:

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -72,7 +72,7 @@ flagged as an error.
   e.g. the :py:func:`pow` builtin returns ``Any`` (see `typeshed issue 285
   <https://github.com/python/typeshed/issues/285>`_ for the reason).
 
-- **:py:meth:`__init__ <object.__init__>` method has no annotated
+- :py:meth:`__init__ <object.__init__>` **method has no annotated
   arguments or return type annotation.** :py:meth:`__init__ <object.__init__>`
   is considered fully-annotated **if at least one argument is annotated**,
   while mypy will infer the return type as ``None``.

--- a/docs/source/extending_mypy.rst
+++ b/docs/source/extending_mypy.rst
@@ -70,7 +70,7 @@ Configuring mypy to use plugins
 
 Plugins are Python files that can be specified in a mypy
 :ref:`config file <config-file>` using one of the two formats: relative or
-absolute path to the plugin to the plugin file, or a module name (if the plugin
+absolute path to the plugin file, or a module name (if the plugin
 is installed using ``pip install`` in the same virtual environment where mypy
 is running). The two formats can be mixed, for example:
 

--- a/docs/source/final_attrs.rst
+++ b/docs/source/final_attrs.rst
@@ -138,7 +138,7 @@ override a read-only property:
    class Derived(Base):
        ID: Final = 1  # OK
 
-Declaring a name as final only guarantees that the name wll not be re-bound
+Declaring a name as final only guarantees that the name will not be re-bound
 to another value. It doesn't make the value immutable. You can use immutable ABCs
 and containers to prevent mutating such values:
 


### PR DESCRIPTION
Some minor fixes for the Sphinx documentation:

- two simple typos
- unintended word repetition/copy-paste error
- invalid markup (`:py:meth:` nested inside bold markup)