### PR TITLE
Fix coroutine return type handling after deferring

### DIFF
--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -731,3 +731,17 @@ reveal_type(f) # N: Revealed type is 'def () -> typing.Coroutine[Any, Any, None]
 reveal_type(g) # N: Revealed type is 'Any'
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]
+
+[case testAsyncDeferredAnalysis]
+
+def t() -> None:
+    async def f() -> int:
+        return 1
+
+    def g() -> int:
+        return next(iter(x))
+
+    x = [1]
+
+[builtins fixtures/async_await.pyi]
+[typing fixtures/typing-async.pyi]


### PR DESCRIPTION
If a nested function definition was processed multiple times due to deferring, its return type would be transformed from `T` to `Coroutine[Any, Any, T]` each time. The flag `SemanticAnalyzer.deferred` was checked to prevent this double processing, but it's reset (to false) when the analyzer is restarted, so is not reliably usable here.

Fix by tracking which function definitions have had their return type wrapped, in the mapping `SemanticAnalyzer.wrapped_coro_return_types`.

Fixes #7736