### PR TITLE
Accept dict() in TypedDict context

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3539,12 +3539,10 @@ class SemanticAnalyzer(NodeVisitor[None],
                     self.add_exports(expr.args[0].items)
 
     def translate_dict_call(self, call: CallExpr) -> Optional[DictExpr]:
-        """Translate 'dict(x=y, ...)' to {'x': y, ...}.
+        """Translate 'dict(x=y, ...)' to {'x': y, ...} and 'dict()' to {}.
 
         For other variants of dict(...), return None.
         """
-        if not call.args:
-            return None
         if not all(kind == ARG_NAMED for kind in call.arg_kinds):
             # Must still accept those args.
             for a in call.args:

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2042,3 +2042,15 @@ class SomeGeneric(Generic[_DICT_T]):
         self._data['foo'] = 1
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
+
+[case testTypedDictCreatedWithEmptyDict]
+from typing import TypedDict
+
+class TD(TypedDict, total=False):
+    foo: int
+    bar: int
+
+d: TD = dict()
+d2: TD = dict(foo=1)
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]


### PR DESCRIPTION
Previously only {} was accepted for an empty TypedDict, which was
inconsistent.