### PR TITLE
[mypyc] Remove unneeded debug constant

### DIFF
--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -51,9 +51,6 @@ setup(name='test_run_output',
 
 WORKDIR = 'build'
 
-# This will dump content of all generated C files.
-VERBOSE_DEBUG_DUMP = False
-
 
 def run_setup(script_name: str, script_args: List[str]) -> bool:
     """Run a setup script in a somewhat controlled environment.
@@ -219,12 +216,6 @@ class TestRun(MypycDataSuite):
                 errors=errors,
                 groups=groups,
             )
-            if VERBOSE_DEBUG_DUMP:
-                for group in cfiles:
-                    for name, content in group:
-                        print(name)
-                        print('-' * len(name))
-                        print(content + '\n')
             if errors.num_errors:
                 errors.flush_errors()
                 assert False, "Compile error"


### PR DESCRIPTION
I added it recently before I discovered `--mypyc-showc`.