### PR TITLE
Allow type aliases in runtime context

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3126,7 +3126,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             if alias_definition:
                 return AnyType(TypeOfAny.special_form)
             # This type is invalid in most runtime contexts, give it an 'object' type.
-            return join.object_or_any_from_type(item)
+            return self.named_type('builtins.object')
 
     def apply_type_arguments_to_callable(self, tp: Type, args: List[Type], ctx: Context) -> Type:
         """Apply type arguments to a generic callable type coming from a type object.

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3125,9 +3125,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         else:
             if alias_definition:
                 return AnyType(TypeOfAny.special_form)
-            # This type is invalid in most runtime contexts.
-            self.msg.alias_invalid_in_runtime_context(item, ctx)
-            return AnyType(TypeOfAny.from_error)
+            # This type is invalid in most runtime contexts, give it an 'object' type.
+            return join.object_or_any_from_type(item)
 
     def apply_type_arguments_to_callable(self, tp: Type, args: List[Type], ctx: Context) -> Type:
         """Apply type arguments to a generic callable type coming from a type object.

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -513,8 +513,11 @@ def object_or_any_from_type(typ: ProperType) -> ProperType:
     elif isinstance(typ, TypeVarType) and isinstance(typ.upper_bound, ProperType):
         return object_or_any_from_type(typ.upper_bound)
     elif isinstance(typ, UnionType):
-        joined = join_type_list([it for it in typ.items if isinstance(it, ProperType)])
-        return object_or_any_from_type(joined)
+        for item in typ.items:
+            if isinstance(item, ProperType):
+                candidate = object_or_any_from_type(item)
+                if isinstance(candidate, Instance):
+                    return candidate
     return AnyType(TypeOfAny.implementation_artifact)
 
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -817,14 +817,6 @@ class MessageBuilder:
             self.fail('Type application has too few types ({} expected)'
                       .format(expected_arg_count), context)
 
-    def alias_invalid_in_runtime_context(self, item: ProperType, ctx: Context) -> None:
-        kind = (' to Callable' if isinstance(item, CallableType) else
-                ' to Tuple' if isinstance(item, TupleType) else
-                ' to Union' if isinstance(item, UnionType) else
-                ' to Literal' if isinstance(item, LiteralType) else
-                '')
-        self.fail('The type alias{} is invalid in runtime context'.format(kind), ctx)
-
     def could_not_infer_type_arguments(self, callee_type: CallableType, n: int,
                                        context: Context) -> None:
         callee_name = callable_name(callee_type)

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1025,13 +1025,13 @@ CA = Callable[[T], int]
 TA = Tuple[T, int]
 UA = Union[T, int]
 
-cs = CA + 1 # E: The type alias to Callable is invalid in runtime context
+cs = CA + 1 # E: Unsupported left operand type for + ("object")
 reveal_type(cs) # N: Revealed type is 'Any'
 
-ts = TA() # E: The type alias to Tuple is invalid in runtime context
+ts = TA() # E: "object" not callable
 reveal_type(ts) # N: Revealed type is 'Any'
 
-us = UA.x # E: The type alias to Union is invalid in runtime context
+us = UA.x # E: "object" has no attribute "x"
 reveal_type(us) # N: Revealed type is 'Any'
 
 xx = CA[str] + 1  # E: Type application is only supported for generic classes

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -1815,13 +1815,13 @@ Alias = Literal[3]
 
 isinstance(3, Literal[3])           # E: Cannot use isinstance() with Literal type
 isinstance(3, Alias)                # E: Cannot use isinstance() with Literal type \
-                                    # E: The type alias to Literal is invalid in runtime context
+                                    # E: Argument 2 to "isinstance" has incompatible type "object"; expected "Union[type, Tuple[Any, ...]]"
 isinstance(3, Renamed[3])           # E: Cannot use isinstance() with Literal type
 isinstance(3, indirect.Literal[3])  # E: Cannot use isinstance() with Literal type
 
 issubclass(int, Literal[3])           # E: Cannot use issubclass() with Literal type
 issubclass(int, Alias)                # E: Cannot use issubclass() with Literal type \
-                                      # E: The type alias to Literal is invalid in runtime context
+                                      # E: Argument 2 to "issubclass" has incompatible type "object"; expected "Union[type, Tuple[Any, ...]]"
 issubclass(int, Renamed[3])           # E: Cannot use issubclass() with Literal type
 issubclass(int, indirect.Literal[3])  # E: Cannot use issubclass() with Literal type
 [builtins fixtures/isinstancelist.pyi]
@@ -1855,7 +1855,7 @@ Alias = Literal[3]
 Literal[3]()           # E: The type "Type[Literal]" is not generic and not indexable
 Renamed[3]()           # E: The type "Type[Literal]" is not generic and not indexable
 indirect.Literal[3]()  # E: The type "Type[Literal]" is not generic and not indexable
-Alias()                # E: The type alias to Literal is invalid in runtime context
+Alias()                # E: "object" not callable
 
 # TODO: Add appropriate error messages to the following lines
 Literal()


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5354

This PR allows using type aliases in runtime context and instead gives the an `object` type (which is the best type that we know). The new error messages are less specific, but the old logic caused annoying false positives for various ORMs that use non-annotation syntax, and for runtime type validation tools.

While working on this I found a minor bug in `object_or_any_from_type()` that returned `Any` for `Union[int, Any]` while it should be `object`.