### PR TITLE
Reject bytes literal as a TypedDict key

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2972,7 +2972,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 if isinstance(key_type, Instance) and key_type.last_known_value is not None:
                     key_type = key_type.last_known_value
 
-                if isinstance(key_type, LiteralType) and isinstance(key_type.value, str):
+                if (isinstance(key_type, LiteralType)
+                        and isinstance(key_type.value, str)
+                        and key_type.fallback.type.fullname != 'builtins.bytes'):
                     key_names.append(key_type.value)
                 else:
                     self.msg.typeddict_key_must_be_string_literal(td_type, index)

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2054,3 +2054,18 @@ d: TD = dict()
 d2: TD = dict(foo=1)
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
+
+[case testTypedDictBytesKey]
+from typing import TypedDict
+
+class TD(TypedDict):
+    foo: int
+
+d: TD = {b'foo': 2} # E: Expected TypedDict key to be string literal
+d[b'foo'] = 3 # E: TypedDict key must be a string literal; expected one of ('foo') \
+    # E: Argument 1 has incompatible type "bytes"; expected "str"
+d[b'foo'] # E: TypedDict key must be a string literal; expected one of ('foo')
+d[3] # E: TypedDict key must be a string literal; expected one of ('foo')
+d[True] # E: TypedDict key must be a string literal; expected one of ('foo')
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]

--- a/test-data/unit/fixtures/dict.pyi
+++ b/test-data/unit/fixtures/dict.pyi
@@ -36,6 +36,7 @@ class int: # for convenience
 
 class str: pass # for keyword argument key type
 class unicode: pass # needed for py2 docstrings
+class bytes: pass
 
 class list(Sequence[T]): # needed by some test cases
     def __getitem__(self, x: int) -> T: pass


### PR DESCRIPTION
This generates two error messages, which is a bit unfortunate, but it
was already happening in other similar cases.

Fixes #8774.