### PR TITLE
Fix "runtests.py pytest-fast"

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -18,7 +18,7 @@ else:
 CMDLINE = 'PythonCmdline'
 SAMPLES = 'SamplesSuite'
 TYPESHED = 'TypeshedSuite'
-PEP561 = 'TestPEP561'
+PEP561 = 'PEP561Suite'
 EVALUATION = 'PythonEvaluation'
 DAEMON = 'testdaemon'
 STUBGEN_CMD = 'StubgenCmdLine'


### PR DESCRIPTION
The slow PEP 561 test suite was renamed recently. It should not be
part of the fast suite.