### PR TITLE
[mypyc] fix syntax

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -1399,7 +1399,7 @@ static PyObject *CPyDict_ItemsView(PyObject *dict) {
 }
 
 static PyObject *CPyDict_Keys(PyObject *dict) {
-    if PyDict_CheckExact(dict) {
+    if (PyDict_CheckExact(dict)) {
         return PyDict_Keys(dict);
     }
     // Inline generic fallback logic to also return a list.
@@ -1418,7 +1418,7 @@ static PyObject *CPyDict_Keys(PyObject *dict) {
 }
 
 static PyObject *CPyDict_Values(PyObject *dict) {
-    if PyDict_CheckExact(dict) {
+    if (PyDict_CheckExact(dict)) {
         return PyDict_Values(dict);
     }
     // Inline generic fallback logic to also return a list.
@@ -1437,7 +1437,7 @@ static PyObject *CPyDict_Values(PyObject *dict) {
 }
 
 static PyObject *CPyDict_Items(PyObject *dict) {
-    if PyDict_CheckExact(dict) {
+    if (PyDict_CheckExact(dict)) {
         return PyDict_Items(dict);
     }
     // Inline generic fallback logic to also return a list.


### PR DESCRIPTION
Somehow, this only broke on 3.9's tests, but passed everywhere else.