### PR TITLE
dmypy: fix test failure on py39

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -390,6 +390,7 @@ def check_output(response: Dict[str, Any], verbose: bool,
     except KeyError:
         fail("Response: %s" % str(response))
     sys.stdout.write(out)
+    sys.stdout.flush()
     sys.stderr.write(err)
     if verbose:
         show_stats(response)


### PR DESCRIPTION
There's a fun Python 3.9 only test case failure, where "Daemon started" is
output after the error message from parsing options.  I ended up needing to
bisect to figure out why this consistently breaks on Python 3.9. The issue is
caused by https://github.com/python/cpython/pull/17646/ (which fixes a
surprisingly old BPO).