### PR TITLE
Allow attrs kw_only arguments at any position

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -2,17 +2,9 @@
 import subprocess
 from subprocess import Popen
 from os import system
-from sys import argv, exit, platform, executable, version_info
+from sys import argv, exit
 
-
-# Use the Python provided to execute the script, or fall back to a sane default
-if version_info >= (3, 5, 0):
-    python_name = executable
-else:
-    if platform == 'win32':
-        python_name = 'py -3'
-    else:
-        python_name = 'python3'
+python_name = 'python'
 
 # Slow test suites
 CMDLINE = 'PythonCmdline'
@@ -91,7 +83,7 @@ cmds = {
 }
 
 # Stop run immediately if these commands fail
-FAST_FAIL = ['self', 'lint']
+FAST_FAIL = ['self']
 
 DEFAULT_COMMANDS = [cmd for cmd in cmds if cmd != 'mypyc-extra']
 

--- a/runtests.py
+++ b/runtests.py
@@ -2,9 +2,17 @@
 import subprocess
 from subprocess import Popen
 from os import system
-from sys import argv, exit
+from sys import argv, exit, platform, executable, version_info
 
-python_name = 'python'
+
+# Use the Python provided to execute the script, or fall back to a sane default
+if version_info >= (3, 5, 0):
+    python_name = executable
+else:
+    if platform == 'win32':
+        python_name = 'py -3'
+    else:
+        python_name = 'python3'
 
 # Slow test suites
 CMDLINE = 'PythonCmdline'
@@ -83,7 +91,7 @@ cmds = {
 }
 
 # Stop run immediately if these commands fail
-FAST_FAIL = ['self']
+FAST_FAIL = ['self', 'lint']
 
 DEFAULT_COMMANDS = [cmd for cmd in cmds if cmd != 'mypyc-extra']
 

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1070,11 +1070,12 @@ class A:
      a = attr.ib(default=0)
 @attr.s
 class B(A):
-    b = attr.ib()  # E: Non keyword-only attributes are not allowed after a keyword-only attribute.
+    b = attr.ib()
 @attr.s
 class C:
     a = attr.ib(kw_only=True)
-    b = attr.ib(15)  # E: Non keyword-only attributes are not allowed after a keyword-only attribute.
+    b = attr.ib(15)
+
 [builtins fixtures/attr.pyi]
 
 [case testAttrsKwOnlyPy2]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1023,31 +1023,6 @@ class A:
 ==
 main:2: error: Unsupported left operand type for < ("B")
 
-[case testAttrsUpdateKwOnly]
-[file a.py]
-import attr
-@attr.s(kw_only=True)
-class A:
-    a = attr.ib(15)   # type: int
-[file b.py]
-from a import A
-import attr
-@attr.s(kw_only=True)
-class B(A):
-    b = attr.ib("16")   # type: str
-
-[file b.py.2]
-from a import A
-import attr
-@attr.s()
-class B(A):
-    b = attr.ib("16")   # type: str
-B(b="foo", a=7)
-[builtins fixtures/attr.pyi]
-[out]
-==
-b.py:5: error: Non keyword-only attributes are not allowed after a keyword-only attribute.
-
 [case testAttrsUpdateBaseKwOnly]
 from b import B
 B(5)


### PR DESCRIPTION
This PR fixes https://github.com/python/mypy/issues/7489

```python
import inspect
from typing import Optional

import attr


@attr.s()
class Valid:
    kw_only: Optional[str] = attr.ib(default=None, kw_only=True)
    param: int = attr.ib()
    optional: bool = attr.ib(default=False)


valid1 = Valid(1)
print(valid1)
valid2 = Valid(2, kw_only='something')
print(valid2)
invalid2 = Valid(2, 'something')
print(invalid2)
invalid3 = Valid('something')
print(invalid3)


@attr.s()
class Valid2:
    param: int = attr.ib()
    kw_only: Optional[str] = attr.ib(default=None, kw_only=True)


valid3 = Valid2(3)
print(valid3)
valid4 = Valid2(4, kw_only='something')
print(valid4)

try:
    invalid = Valid2(4, 'something')
except TypeError:
    pass
```

produces the expected output:
```
mypy my_example.py
my_example.py:18: error: Argument 2 to "Valid" has incompatible type "str"; expected "bool"
my_example.py:20: error: Argument 1 to "Valid" has incompatible type "str"; expected "int"
my_example.py:36: error: Too many positional arguments for "Valid2"
Found 3 errors in 1 file (checked 1 source file)
```