### PR TITLE
Setup pre-commit hook with flake8 and black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 3.7.9
+      hooks:
+        - id: flake8
+    - repo: https://github.com/psf/black
+      rev: stable
+      hooks:
+        - id: black
+          language_version: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,21 @@ requires = [
     "wheel >= 0.30.0",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 200
+target-version = ['py36', 'py37', 'py38']
+skip-string-normalization = true
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.*
+  | \.git
+  | \.mypy_cache
+  | \.venv
+  # The following are specific to Black, you probably don't want those.
+  | blib2to3
+  | tests/data
+  | profiling
+)/
+'''

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -15,3 +15,4 @@ py>=1.5.2
 virtualenv<20
 setuptools
 importlib-metadata==0.20
+pre-commit==2.2.0


### PR DESCRIPTION
Fix #8799 
`pre-commit` has been added to maintain code standards and linting. This will perform formatting and lint checks on all staged files using `flake8` and `black` formatting on commit. This would decrease the number of travis build fails due to linting issues. 
`pre-commit install` needs to be run once the requirements have been installed.

We need to perform flake8 and black formatting on the whole repository once to prevent build fails for previous files that are present.