### PR TITLE
mypy: fix ci, use a newer flake8 and flake8-pyi, ignore a new error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,8 @@ exclude =
 #   B011: Don't use assert False
 #   F821: Name not defined (generates false positives with error codes)
 #   F811: Redefinition of unused function (causes annoying errors with overloads)
-extend-ignore = E128,W601,E701,E704,E402,B3,B006,B007,B011,F821,F811
+#   E741: Ambiguous variable name
+extend-ignore = E128,W601,E701,E704,E402,B3,B006,B007,B011,F821,F811,E741
 
 [coverage:run]
 branch = true

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,8 @@
 -r mypy-requirements.txt
 attrs>=18.0
-flake8>=3.7
+flake8>=3.8.1
 flake8-bugbear; python_version >= '3.5'
-flake8-pyi; python_version >= '3.6'
+flake8-pyi>=20.5; python_version >= '3.6'
 lxml>=4.4.0
 psutil>=4.0
 pytest==5.3.2


### PR DESCRIPTION
The versions are necessary because of some change involving switching from optparse to argparse.

Here are the E741 errors that would be ignored if this was merged.
```
./mypy/fastparse.py:327:39: E741 ambiguous variable name 'l'
./mypy/fastparse.py:334:35: E741 ambiguous variable name 'l'
./mypy/fastparse.py:1339:35: E741 ambiguous variable name 'l'
./mypy/fastparse.py:1399:39: E741 ambiguous variable name 'l'
./mypy/fastparse2.py:196:35: E741 ambiguous variable name 'l'
./mypy/meet.py:214:13: E741 ambiguous variable name 'l'
./mypy/meet.py:407:20: E741 ambiguous variable name 'l'
./mypy/typeanal.py:1170:13: E741 ambiguous variable name 'l'
./mypy/traverser.py:86:13: E741 ambiguous variable name 'l'
./mypy/report.py:298:46: E741 ambiguous variable name 'l'
./mypy/semanal.py:4524:38: E741 ambiguous variable name 'l'
./mypy/subtypes.py:336:17: E741 ambiguous variable name 'l'
./mypy/subtypes.py:1312:17: E741 ambiguous variable name 'l'
./mypy/test/data.py:383:16: E741 ambiguous variable name 'l'
./mypy/test/data.py:401:32: E741 ambiguous variable name 'l'
```