### PR TITLE
messages: improve concrete_only_{call,assign}

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1222,11 +1222,16 @@ class MessageBuilder:
         self.fail(msg, context)
 
     def concrete_only_assign(self, typ: Type, context: Context) -> None:
-        self.fail("Can only assign concrete classes to a variable of type {}"
+        self.fail("Can only assign concrete classes to a variable of type {}: "
+                  "Only non-abstract non-protocol classes can be assigned to "
+                  "variables with explicit type Type[A], where A is protocol "
+                  "or abstract."
                   .format(format_type(typ)), context)
 
     def concrete_only_call(self, typ: Type, context: Context) -> None:
-        self.fail("Only concrete class can be given where {} is expected"
+        self.fail("Only concrete class can be given where {} is expected: "
+                  "Only non-abstract non-protocol classes can be given where "
+                  "Type[...] is expected."
                   .format(format_type(typ)), context)
 
     def cannot_use_function_with_type(


### PR DESCRIPTION
The comment in the code near where these functions are called was more descriptive than the message itsnelf