### PR TITLE
Fix potential wrong-file error message for unsupported Types

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -903,8 +903,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             return self.check_call(callee.upper_bound, args, arg_kinds, context, arg_names,
                                    callable_node, arg_messages)
         elif isinstance(callee, TypeType):
-            # Pass the original Type[] as context since that's where errors should go.
-            item = self.analyze_type_type_callee(callee.item, callee)
+            item = self.analyze_type_type_callee(callee.item, context)
             return self.check_call(item, args, arg_kinds, context, arg_names,
                                    callable_node, arg_messages)
         elif isinstance(callee, TupleType):

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1050,7 +1050,7 @@ class MessageBuilder:
             self.note(line, context)
 
     def unsupported_type_type(self, item: Type, context: Context) -> None:
-        self.fail('Unsupported type Type[{}]'.format(format_type(item)), context)
+        self.fail('Cannot instantiate type "Type[{}]"'.format(format_type_bare(item)), context)
 
     def redundant_cast(self, typ: Type, context: Context) -> None:
         self.fail('Redundant cast to {}'.format(format_type(typ)), context,

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3172,10 +3172,9 @@ def process(cls: Type[U]):
 
 [case testTypeUsingTypeCErrorUnsupportedType]
 from typing import Type, Tuple
-def foo(arg: Type[Tuple[int]]):  # E: Unsupported type Type["Tuple[int]"]
-    arg()
+def foo(arg: Type[Tuple[int]]):
+    arg()  # E: Cannot instantiate type "Type[Tuple[int]]"
 [builtins fixtures/tuple.pyi]
-[out]
 
 [case testTypeUsingTypeCOverloadedClass]
 from foo import *
@@ -3218,10 +3217,8 @@ def f(a: T): pass
 [case testTypeUsingTypeCTuple]
 from typing import Type, Tuple
 def f(a: Type[Tuple[int, int]]):
-    a()
+    a()  # E: Cannot instantiate type "Type[Tuple[int, int]]"
 [builtins fixtures/tuple.pyi]
-[out]
-main:2: error: Unsupported type Type["Tuple[int, int]"]
 
 [case testTypeUsingTypeCNamedTuple]
 from typing import Type, NamedTuple


### PR DESCRIPTION
If we want to report error messages at the use of a type, we have to
report it when processing that type, not when we run into some code
pattern that uses it, or else we can generate unignorable misplaced
error messages.

It doesn't seem worth bothering to do the refactors that this would
require so I just moved the error messages to the use-sites and
adjusted the text to be more appropriate.

Fixes #8825.