### PR TITLE
[mypyc] Have for ... in range() correctly generate raw comparisons

### DIFF
--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -604,8 +604,6 @@ class ForDictionaryItems(ForDictionaryCommon):
 class ForRange(ForGenerator):
     """Generate optimized IR for a for loop over an integer range."""
 
-    # TODO: Use a separate register for the index to allow safe index mutation.
-
     def init(self, start_reg: Value, end_reg: Value, step: int) -> None:
         builder = self.builder
         self.start_reg = start_reg

--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -625,7 +625,7 @@ class ForRange(ForGenerator):
         line = self.line
         # Add loop condition check.
         cmp = '<' if self.step > 0 else '>'
-        comparison = builder.binary_op(builder.read(self.index_target, line),
+        comparison = builder.binary_op(builder.read(self.index_reg, line),
                                        builder.read(self.end_target, line), cmp, line)
         builder.add_bool_branch(comparison, self.body_block, self.loop_exit)
 

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -185,7 +185,7 @@ L0:
     r2 = r0
     i = r2
 L1:
-    r3 = i < r1 :: int
+    r3 = r2 < r1 :: short_int
     if r3 goto L2 else goto L4 :: bool
 L2:
     r4 = l[i] :: list

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -21,7 +21,7 @@ L0:
     r3 = r1
     i = r3
 L1:
-    r4 = i < r2 :: int
+    r4 = r3 < r2 :: short_int
     if r4 goto L2 else goto L4 :: bool
 L2:
     r5 = x + i :: int
@@ -53,7 +53,7 @@ L0:
     r2 = r0
     i = r2
 L1:
-    r3 = i > r1 :: int
+    r3 = r2 > r1 :: short_int
     if r3 goto L2 else goto L4 :: bool
 L2:
 L3:
@@ -107,7 +107,7 @@ L0:
     r2 = r0
     n = r2
 L1:
-    r3 = n < r1 :: int
+    r3 = r2 < r1 :: short_int
     if r3 goto L2 else goto L4 :: bool
 L2:
     goto L4
@@ -197,7 +197,7 @@ L0:
     r2 = r0
     n = r2
 L1:
-    r3 = n < r1 :: int
+    r3 = r2 < r1 :: short_int
     if r3 goto L2 else goto L4 :: bool
 L2:
 L3:
@@ -991,7 +991,7 @@ L2:
     r8 = r2 < r7 :: short_int
     if r8 goto L3 else goto L6 :: bool
 L3:
-    r9 = z < r4 :: int
+    r9 = r5 < r4 :: short_int
     if r9 goto L4 else goto L6 :: bool
 L4:
     r10 = unbox(bool, r6)


### PR DESCRIPTION
This means we generate "i < n" instead of CPyTagged_Lt or whatever.
This doesn't actually help performance on -O3 at all, since clang is
able to figure it out. It helps on -Og, though, and it saves the
compiler having to do some work.