### PR TITLE
[mypyc] Add a primitive for formatting an int as a str

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -642,13 +642,12 @@ static CPyTagged CPyTagged_Id(PyObject *o) {
 // using snprintf or PyUnicode_FromFormat was way slower than
 // boxing the int and calling PyObject_Str on it, so we implement our own
 static int fmt_ssize_t(char *out, Py_ssize_t n) {
-	Py_ssize_t in = n;
 	bool neg = n < 0;
 	if (neg) n = -n;
-	char buf[MAX_INT_CHARS];
-	int i = 0;
 
 	// buf gets filled backward and then we copy it forward
+	char buf[MAX_INT_CHARS];
+	int i = 0;
 	do {
 		buf[i] = (n % 10) + '0';
 		n /= 10;

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -642,12 +642,6 @@ static CPyTagged CPyTagged_Id(PyObject *o) {
 // using snprintf or PyUnicode_FromFormat was way slower than
 // boxing the int and calling PyObject_Str on it, so we implement our own
 static int fmt_ssize_t(char *out, Py_ssize_t n) {
-	if (!n) {
-		out[0] = '0';
-		out[1] = '\0';
-		return 1;
-	}
-
 	Py_ssize_t in = n;
 	bool neg = n < 0;
 	if (neg) n = -n;
@@ -655,11 +649,11 @@ static int fmt_ssize_t(char *out, Py_ssize_t n) {
 	int i = 0;
 
 	// buf gets filled backward and then we copy it forward
-	while (n) {
+	do {
 		buf[i] = (n % 10) + '0';
 		n /= 10;
 		i++;
-	}
+	} while (n);
 
 
 	int len = i;

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -644,6 +644,7 @@ static CPyTagged CPyTagged_Id(PyObject *o) {
 static int fmt_ssize_t(char *out, Py_ssize_t n) {
 	if (!n) {
 		out[0] = '0';
+		out[1] = '\0';
 		return 1;
 	}
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -692,6 +692,10 @@ static PyObject *CPyTagged_Str(CPyTagged n) {
 	}
 }
 
+static PyObject *CPyBool_Str(bool b) {
+	return PyObject_Str(b ? Py_True : Py_False);
+}
+
 static PyObject *CPyList_GetItemUnsafe(PyObject *list, CPyTagged index) {
     Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);
     PyObject *result = PyList_GET_ITEM(list, n);

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -54,6 +54,14 @@ func_op(
     emit=call_emit('CPyLong_FromStrWithBase'),
     priority=1)
 
+# str(n) on ints
+func_op(name='builtins.str',
+        arg_types=[int_rprimitive],
+        result_type=str_rprimitive,
+        error_kind=ERR_MAGIC,
+        emit=call_emit('CPyTagged_Str'),
+        priority=2)
+
 
 def int_binary_op(op: str, c_func_name: str,
                   result_type: RType = int_rprimitive,

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -62,6 +62,13 @@ func_op(name='builtins.str',
         emit=call_emit('CPyTagged_Str'),
         priority=2)
 
+# We need a specialization for str on bools also since the int one is wrong...
+func_op(name='builtins.str',
+        arg_types=[bool_rprimitive],
+        result_type=str_rprimitive,
+        error_kind=ERR_MAGIC,
+        emit=call_emit('CPyBool_Str'),
+        priority=3)
 
 def int_binary_op(op: str, c_func_name: str,
                   result_type: RType = int_rprimitive,

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -70,6 +70,7 @@ func_op(name='builtins.str',
         emit=call_emit('CPyBool_Str'),
         priority=3)
 
+
 def int_binary_op(op: str, c_func_name: str,
                   result_type: RType = int_rprimitive,
                   error_kind: int = ERR_NEVER) -> None:

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -241,12 +241,10 @@ def use_c(x: C, y: object) -> int:
 def A.foo(self, x):
     self :: __main__.A
     x :: int
-    r0 :: object
-    r1 :: str
+    r0 :: str
 L0:
-    r0 = box(int, x)
-    r1 = str r0 :: object
-    return r1
+    r0 = str x :: int
+    return r0
 def B.foo(self, x):
     self :: __main__.B
     x :: object

--- a/mypyc/test-data/run.test
+++ b/mypyc/test-data/run.test
@@ -848,6 +848,9 @@ assert eq('foo') == 0
 assert eq('zar') == 1
 assert eq('bar') == 2
 
+assert int(tostr(0)) == 0
+assert int(tostr(20)) == 20
+
 [case testFstring]
 
 var = 'mypyc'

--- a/mypyc/test-data/run.test
+++ b/mypyc/test-data/run.test
@@ -825,6 +825,8 @@ def g() -> str:
     return 'some\a \v \t \x7f " \n \0string 🐍'
 def tostr(x: int) -> str:
     return str(x)
+def booltostr(x: bool) -> str:
+    return str(x)
 def concat(x: str, y: str) -> str:
     return x + y
 def eq(x: str) -> int:
@@ -835,11 +837,13 @@ def eq(x: str) -> int:
     return 2
 
 [file driver.py]
-from native import f, g, tostr, concat, eq
+from native import f, g, tostr, booltostr, concat, eq
 assert f() == 'some string'
 assert g() == 'some\a \v \t \x7f " \n \0string 🐍'
 assert tostr(57) == '57'
 assert concat('foo', 'bar') == 'foobar'
+assert booltostr(True) == 'True'
+assert booltostr(False) == 'False'
 assert eq('foo') == 0
 assert eq('zar') == 1
 assert eq('bar') == 2


### PR DESCRIPTION
This is partially just shameless cheesing on an example kmod used in a
blog post (http://blog.kevmod.com/2020/05/python-performance-its-not-just-the-interpreter/comment-page-1/#comment-55896),
but it is generally useful. Probably it will be more useful as part of
more general string formatting optimizations, but it is a start.

This gives a 3x speedup on the example in the blog post.

I had been hoping to just allocate a unicode string and call sprintf
into it but that turned out to be quite a bit slower than boxing the
int and calling PyObject_Str on it! So I just implemented it.