### PR TITLE
[mypyc]Implement CallC IR

### DIFF
--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -8,7 +8,7 @@ from mypyc.ir.ops import (
     Value, ControlOp,
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
-    LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError,
+    LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError, CFunctionCall
 )
 
 
@@ -193,6 +193,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_raise_standard_error(self, op: RaiseStandardError) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_c_function_call(self, op: CFunctionCall) -> GenAndKill:
         return self.visit_register_op(op)
 
 

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -8,7 +8,7 @@ from mypyc.ir.ops import (
     Value, ControlOp,
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
-    LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError, CFunctionCall
+    LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError, CallC
 )
 
 
@@ -195,7 +195,7 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
     def visit_raise_standard_error(self, op: RaiseStandardError) -> GenAndKill:
         return self.visit_register_op(op)
 
-    def visit_c_function_call(self, op: CFunctionCall) -> GenAndKill:
+    def visit_call_c(self, op: CallC) -> GenAndKill:
         return self.visit_register_op(op)
 
 

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -11,7 +11,7 @@ from mypyc.ir.ops import (
     OpVisitor, Goto, Branch, Return, Assign, LoadInt, LoadErrorValue, GetAttr, SetAttr,
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
     BasicBlock, Value, MethodCall, PrimitiveOp, EmitterInterface, Unreachable, NAMESPACE_STATIC,
-    NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CFunctionCall
+    NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CallC
 )
 from mypyc.ir.rtypes import RType, RTuple
 from mypyc.ir.func_ir import FuncIR, FuncDecl, FUNC_STATICMETHOD, FUNC_CLASSMETHOD
@@ -415,7 +415,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             self.emitter.emit_line('PyErr_SetNone(PyExc_{});'.format(op.class_name))
         self.emitter.emit_line('{} = 0;'.format(self.reg(op)))
 
-    def visit_c_function_call(self, op: CFunctionCall) -> None:
+    def visit_call_c(self, op: CallC) -> None:
         dest = self.get_dest_assign(op)
         args = ', '.join(self.reg(arg) for arg in op.args)
         self.emitter.emit_line("{}{}({});".format(dest, op.function_name, args))

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -11,7 +11,7 @@ from mypyc.ir.ops import (
     OpVisitor, Goto, Branch, Return, Assign, LoadInt, LoadErrorValue, GetAttr, SetAttr,
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
     BasicBlock, Value, MethodCall, PrimitiveOp, EmitterInterface, Unreachable, NAMESPACE_STATIC,
-    NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError
+    NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CFunctionCall
 )
 from mypyc.ir.rtypes import RType, RTuple
 from mypyc.ir.func_ir import FuncIR, FuncDecl, FUNC_STATICMETHOD, FUNC_CLASSMETHOD
@@ -414,6 +414,11 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         else:
             self.emitter.emit_line('PyErr_SetNone(PyExc_{});'.format(op.class_name))
         self.emitter.emit_line('{} = 0;'.format(self.reg(op)))
+
+    def visit_c_function_call(self, op: CFunctionCall) -> None:
+        dest = self.get_dest_assign(op)
+        args = ', '.join(self.reg(arg) for arg in op.args)
+        self.emitter.emit_line("{}{}({});".format(dest, op.function_name, args))
 
     # Helpers
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1150,7 +1150,6 @@ class CallC(RegisterOp):
         super().__init__(line)
         self.function_name = function_name
         self.args = args
-        # TODO: handle void C function by adding a new flag and make this Optional
         self.type = ret_type
 
     def to_str(self, env: Environment) -> str:

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1138,7 +1138,7 @@ class RaiseStandardError(RegisterOp):
         return visitor.visit_raise_standard_error(self)
 
 
-class CFunctionCall(RegisterOp):
+class CallC(RegisterOp):
     """ret = func_call(arg0, arg1, ...)
 
     A call to a C function
@@ -1155,14 +1155,13 @@ class CFunctionCall(RegisterOp):
 
     def to_str(self, env: Environment) -> str:
         args_str = ', '.join(env.format('%r', arg) for arg in self.args)
-        # TODO: comment: c_function_call to distinguish from cast, box, etc
-        return env.format('%r = %s(%s) :: c_function_call', self, self.function_name, args_str)
+        return env.format('%r = %s(%s)', self, self.function_name, args_str)
 
     def sources(self) -> List[Value]:
         return self.args
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
-        return visitor.visit_c_function_call(self)
+        return visitor.visit_call_c(self)
 
 
 @trait
@@ -1256,7 +1255,7 @@ class OpVisitor(Generic[T]):
         raise NotImplementedError
 
     @abstractmethod
-    def visit_c_function_call(self, op: CFunctionCall) -> T:
+    def visit_call_c(self, op: CallC) -> T:
         raise NotImplementedError
 
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1138,6 +1138,33 @@ class RaiseStandardError(RegisterOp):
         return visitor.visit_raise_standard_error(self)
 
 
+class CFunctionCall(RegisterOp):
+    """ret = func_call(arg0, arg1, ...)
+
+    A call to a C function
+    """
+
+    error_kind = ERR_MAGIC
+
+    def __init__(self, function_name: str, args: List[Value], ret_type: RType, line: int) -> None:
+        super().__init__(line)
+        self.function_name = function_name
+        self.args = args
+        # TODO: handle void C function by adding a new flag and make this Optional
+        self.type = ret_type
+
+    def to_str(self, env: Environment) -> str:
+        args_str = ', '.join(env.format('%r', arg) for arg in self.args)
+        # TODO: comment: c_function_call to distinguish from cast, box, etc
+        return env.format('%r = %s(%s) :: c_function_call', self, self.function_name, args_str)
+
+    def sources(self) -> List[Value]:
+        return self.args
+
+    def accept(self, visitor: 'OpVisitor[T]') -> T:
+        return visitor.visit_c_function_call(self)
+
+
 @trait
 class OpVisitor(Generic[T]):
     """Generic visitor over ops (uses the visitor design pattern)."""
@@ -1226,6 +1253,10 @@ class OpVisitor(Generic[T]):
 
     @abstractmethod
     def visit_raise_standard_error(self, op: RaiseStandardError) -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visit_c_function_call(self, op: CFunctionCall) -> T:
         raise NotImplementedError
 
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -33,7 +33,7 @@ from mypyc.common import (
 )
 from mypyc.primitives.registry import (
     binary_ops, unary_ops, method_ops, func_ops,
-    call_c_ops, CallCDescription
+    call_c_ops, CFunctionDescription
 )
 from mypyc.primitives.list_ops import (
     list_extend_op, list_len_op, new_list_op
@@ -658,13 +658,13 @@ class LowLevelIRBuilder:
         return target
 
     def matching_call_c(self,
-                        candidates: List[CallCDescription],
+                        candidates: List[CFunctionDescription],
                         args: List[Value],
                         line: int,
                         result_type: Optional[RType] = None) -> Optional[Value]:
         # TODO: this function is very similar to matching_primitive_op
         # we should remove the old one or refactor both them into only as we move forward
-        matching = None  # type: Optional[CallCDescription]
+        matching = None  # type: Optional[CFunctionDescription]
         for desc in candidates:
             if len(desc.arg_types) != len(args):
                 continue

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -34,7 +34,7 @@ from mypyc.common import (
 )
 from mypyc.primitives.registry import (
     binary_ops, unary_ops, method_ops, func_ops,
-    call_c_ops, CFunctionDescription
+    c_method_call_ops, CFunctionDescription
 )
 from mypyc.primitives.list_ops import (
     list_extend_op, list_len_op, new_list_op
@@ -767,7 +767,7 @@ class LowLevelIRBuilder:
         Return None if no translation found; otherwise return the target register.
         """
         ops = method_ops.get(name, [])
-        call_c_ops_candidates = call_c_ops.get(name, [])
+        call_c_ops_candidates = c_method_call_ops.get(name, [])
         call_c_op = self.matching_call_c(call_c_ops_candidates, [base_reg] + args, line,
                                          result_type=result_type)
         if call_c_op is not None:

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -24,7 +24,8 @@ from mypyc.ir.ops import (
 )
 from mypyc.ir.rtypes import (
     RType, RUnion, RInstance, optional_value_type, int_rprimitive, float_rprimitive,
-    bool_rprimitive, list_rprimitive, str_rprimitive, is_none_rprimitive, object_rprimitive
+    bool_rprimitive, list_rprimitive, str_rprimitive, is_none_rprimitive, object_rprimitive,
+    void_rtype
 )
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
@@ -652,9 +653,9 @@ class LowLevelIRBuilder:
                args: List[Value],
                line: int,
                result_type: Optional[RType]) -> Value:
-        # TODO: we should handle void cases
-        assert result_type is not None
-        target = self.add(CallC(function_name, args, result_type, line))
+        # handle void function via singleton RVoid instance
+        ret_type = void_rtype if result_type is None else result_type
+        target = self.add(CallC(function_name, args, ret_type, line))
         return target
 
     def matching_call_c(self,

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -20,7 +20,7 @@ from mypyc.ir.ops import (
     BasicBlock, Environment, Op, LoadInt, Value, Register,
     Assign, Branch, Goto, Call, Box, Unbox, Cast, GetAttr,
     LoadStatic, MethodCall, PrimitiveOp, OpDescription, RegisterOp,
-    NAMESPACE_TYPE, NAMESPACE_MODULE, LoadErrorValue, CFunctionCall
+    NAMESPACE_TYPE, NAMESPACE_MODULE, LoadErrorValue, CallC
 )
 from mypyc.ir.rtypes import (
     RType, RUnion, RInstance, optional_value_type, int_rprimitive, float_rprimitive,
@@ -33,7 +33,7 @@ from mypyc.common import (
 )
 from mypyc.primitives.registry import (
     binary_ops, unary_ops, method_ops, func_ops,
-    c_function_call_ops, LLOpDescription
+    call_c_ops, CallCDescription
 )
 from mypyc.primitives.list_ops import (
     list_extend_op, list_len_op, new_list_op
@@ -647,24 +647,24 @@ class LowLevelIRBuilder:
                 value = self.primitive_op(bool_op, [value], value.line)
         self.add(Branch(value, true, false, Branch.BOOL_EXPR))
 
-    def c_function_call(self,
-                        function_name: str,
-                        args: List[Value],
-                        line: int,
-                        result_type: Optional[RType]) -> Value:
+    def call_c(self,
+               function_name: str,
+               args: List[Value],
+               line: int,
+               result_type: Optional[RType]) -> Value:
         # TODO: we should handle void cases
         assert result_type is not None
-        target = self.add(CFunctionCall(function_name, args, result_type, line))
+        target = self.add(CallC(function_name, args, result_type, line))
         return target
 
-    def matching_c_function_call(self,
-                                 candidates: List[LLOpDescription],
-                                 args: List[Value],
-                                 line: int,
-                                 result_type: Optional[RType] = None) -> Optional[Value]:
+    def matching_call_c(self,
+                        candidates: List[CallCDescription],
+                        args: List[Value],
+                        line: int,
+                        result_type: Optional[RType] = None) -> Optional[Value]:
         # TODO: this function is very similar to matching_primitive_op
         # we should remove the old one or refactor both them into only as we move forward
-        matching = None  # type: Optional[LLOpDescription]
+        matching = None  # type: Optional[CallCDescription]
         for desc in candidates:
             if len(desc.arg_types) != len(args):
                 continue
@@ -678,7 +678,7 @@ class LowLevelIRBuilder:
                 else:
                     matching = desc
         if matching:
-            target = self.c_function_call(matching.c_function_name, args, line, result_type)
+            target = self.call_c(matching.c_function_name, args, line, result_type)
             return target
         return None
 
@@ -766,11 +766,11 @@ class LowLevelIRBuilder:
         Return None if no translation found; otherwise return the target register.
         """
         ops = method_ops.get(name, [])
-        c_func_call_ops = c_function_call_ops.get(name, [])
-        c_function_call = self.matching_c_function_call(c_func_call_ops, [base_reg] + args, line,
-                                                        result_type=result_type)
-        if c_function_call is not None:
-            return c_function_call
+        call_c_ops_candidates = call_c_ops.get(name, [])
+        call_c_op = self.matching_call_c(call_c_ops_candidates, [base_reg] + args, line,
+                                         result_type=result_type)
+        if call_c_op is not None:
+            return call_c_op
         return self.matching_primitive_op(ops, [base_reg] + args, line, result_type=result_type)
 
     def translate_eq_cmp(self,

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -44,12 +44,12 @@ from mypyc.ir.rtypes import RType,  bool_rprimitive
 
 # TODO: comment, we don't need error_kind since C functions are all ERR_MAGIC
 # however, other fields may need further investigation
-CallCDescription = NamedTuple(
-    'CallCDescription',  [('name', str),
-                          ('arg_types', List[RType]),
-                          ('result_type', Optional[RType]),
-                          ('c_function_name', str),
-                          ('priority', int)])
+CFunctionDescription = NamedTuple(
+    'CFunctionDescription',  [('name', str),
+                              ('arg_types', List[RType]),
+                              ('result_type', Optional[RType]),
+                              ('c_function_name', str),
+                              ('priority', int)])
 
 # Primitive binary ops (key is operator such as '+')
 binary_ops = {}  # type: Dict[str, List[OpDescription]]
@@ -66,7 +66,7 @@ method_ops = {}  # type: Dict[str, List[OpDescription]]
 # Primitive ops for reading module attributes (key is name such as 'builtins.None')
 name_ref_ops = {}  # type: Dict[str, OpDescription]
 
-call_c_ops = {}  # type: Dict[str, List[CallCDescription]]
+call_c_ops = {}  # type: Dict[str, List[CFunctionDescription]]
 
 
 def simple_emit(template: str) -> EmitCallback:
@@ -328,7 +328,7 @@ def call_c_op(name: str,
               c_function_name: str,
               priority: int = 1) -> None:
     ops = call_c_ops.setdefault(name, [])
-    desc = CallCDescription(name, arg_types, result_type, c_function_name, priority)
+    desc = CFunctionDescription(name, arg_types, result_type, c_function_name, priority)
     ops.append(desc)
 
 

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -42,8 +42,6 @@ from mypyc.ir.ops import (
 )
 from mypyc.ir.rtypes import RType,  bool_rprimitive
 
-# TODO: comment, we don't need error_kind since C functions are all ERR_MAGIC
-# however, other fields may need further investigation
 CFunctionDescription = NamedTuple(
     'CFunctionDescription',  [('name', str),
                               ('arg_types', List[RType]),
@@ -67,7 +65,7 @@ method_ops = {}  # type: Dict[str, List[OpDescription]]
 # Primitive ops for reading module attributes (key is name such as 'builtins.None')
 name_ref_ops = {}  # type: Dict[str, OpDescription]
 
-call_c_ops = {}  # type: Dict[str, List[CFunctionDescription]]
+c_method_call_ops = {}  # type: Dict[str, List[CFunctionDescription]]
 
 
 def simple_emit(template: str) -> EmitCallback:
@@ -323,13 +321,13 @@ def custom_op(arg_types: List[RType],
                          emit, steals, is_borrowed, 0)
 
 
-def call_c_op(name: str,
-              arg_types: List[RType],
-              result_type: Optional[RType],
-              c_function_name: str,
-              error_kind: int,
-              priority: int = 1) -> None:
-    ops = call_c_ops.setdefault(name, [])
+def c_method_op(name: str,
+                arg_types: List[RType],
+                result_type: Optional[RType],
+                c_function_name: str,
+                error_kind: int,
+                priority: int = 1) -> None:
+    ops = c_method_call_ops.setdefault(name, [])
     desc = CFunctionDescription(name, arg_types, result_type,
                                 c_function_name, error_kind, priority)
     ops.append(desc)

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -49,6 +49,7 @@ CFunctionDescription = NamedTuple(
                               ('arg_types', List[RType]),
                               ('result_type', Optional[RType]),
                               ('c_function_name', str),
+                              ('error_kind', int),
                               ('priority', int)])
 
 # Primitive binary ops (key is operator such as '+')
@@ -326,9 +327,11 @@ def call_c_op(name: str,
               arg_types: List[RType],
               result_type: Optional[RType],
               c_function_name: str,
+              error_kind: int,
               priority: int = 1) -> None:
     ops = call_c_ops.setdefault(name, [])
-    desc = CFunctionDescription(name, arg_types, result_type, c_function_name, priority)
+    desc = CFunctionDescription(name, arg_types, result_type,
+                                c_function_name, error_kind, priority)
     ops.append(desc)
 
 

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -44,12 +44,12 @@ from mypyc.ir.rtypes import RType,  bool_rprimitive
 
 # TODO: comment, we don't need error_kind since C functions are all ERR_MAGIC
 # however, other fields may need further investigation
-LLOpDescription = NamedTuple(
-    'LLOpDescription',  [('name', str),
-                        ('arg_types', List[RType]),
-                        ('result_type', Optional[RType]),
-                        ('c_function_name', str),
-                        ('priority', int)])
+CallCDescription = NamedTuple(
+    'CallCDescription',  [('name', str),
+                          ('arg_types', List[RType]),
+                          ('result_type', Optional[RType]),
+                          ('c_function_name', str),
+                          ('priority', int)])
 
 # Primitive binary ops (key is operator such as '+')
 binary_ops = {}  # type: Dict[str, List[OpDescription]]
@@ -66,7 +66,7 @@ method_ops = {}  # type: Dict[str, List[OpDescription]]
 # Primitive ops for reading module attributes (key is name such as 'builtins.None')
 name_ref_ops = {}  # type: Dict[str, OpDescription]
 
-c_function_call_ops = {}  # type: Dict[str, List[LLOpDescription]]
+call_c_ops = {}  # type: Dict[str, List[CallCDescription]]
 
 
 def simple_emit(template: str) -> EmitCallback:
@@ -322,13 +322,13 @@ def custom_op(arg_types: List[RType],
                          emit, steals, is_borrowed, 0)
 
 
-def c_function_call_op(name: str,
-                       arg_types: List[RType],
-                       result_type: Optional[RType],
-                       c_function_name: str,
-                       priority: int = 1) -> None:
-    ops = c_function_call_ops.setdefault(name, [])
-    desc = LLOpDescription(name, arg_types, result_type, c_function_name, priority)
+def call_c_op(name: str,
+              arg_types: List[RType],
+              result_type: Optional[RType],
+              c_function_name: str,
+              priority: int = 1) -> None:
+    ops = call_c_ops.setdefault(name, [])
+    desc = CallCDescription(name, arg_types, result_type, c_function_name, priority)
     ops.append(desc)
 
 

--- a/mypyc/primitives/str_ops.py
+++ b/mypyc/primitives/str_ops.py
@@ -8,7 +8,7 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.primitives.registry import (
     func_op, binary_op, simple_emit, name_ref_op, method_op, call_emit, name_emit,
-    call_c_op
+    c_method_op
 )
 
 
@@ -34,7 +34,7 @@ binary_op(op='+',
           emit=call_emit('PyUnicode_Concat'))
 
 # str.join(obj)
-call_c_op(
+c_method_op(
     name='join',
     arg_types=[str_rprimitive, object_rprimitive],
     result_type=str_rprimitive,

--- a/mypyc/primitives/str_ops.py
+++ b/mypyc/primitives/str_ops.py
@@ -8,7 +8,7 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.primitives.registry import (
     func_op, binary_op, simple_emit, name_ref_op, method_op, call_emit, name_emit,
-    c_function_call_op
+    call_c_op
 )
 
 
@@ -34,7 +34,7 @@ binary_op(op='+',
           emit=call_emit('PyUnicode_Concat'))
 
 # str.join(obj)
-c_function_call_op(
+call_c_op(
     name='join',
     arg_types=[str_rprimitive, object_rprimitive],
     result_type=str_rprimitive,

--- a/mypyc/primitives/str_ops.py
+++ b/mypyc/primitives/str_ops.py
@@ -38,7 +38,8 @@ call_c_op(
     name='join',
     arg_types=[str_rprimitive, object_rprimitive],
     result_type=str_rprimitive,
-    c_function_name='PyUnicode_Join'
+    c_function_name='PyUnicode_Join',
+    error_kind=ERR_MAGIC
 )
 
 # str[index] (for an int index)

--- a/mypyc/primitives/str_ops.py
+++ b/mypyc/primitives/str_ops.py
@@ -8,6 +8,7 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.primitives.registry import (
     func_op, binary_op, simple_emit, name_ref_op, method_op, call_emit, name_emit,
+    c_function_call_op
 )
 
 
@@ -33,12 +34,12 @@ binary_op(op='+',
           emit=call_emit('PyUnicode_Concat'))
 
 # str.join(obj)
-method_op(
+c_function_call_op(
     name='join',
     arg_types=[str_rprimitive, object_rprimitive],
     result_type=str_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('PyUnicode_Join'))
+    c_function_name='PyUnicode_Join'
+)
 
 # str[index] (for an int index)
 method_op(

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3394,4 +3394,4 @@ def f(x, y):
     r0 :: str
 L0:
     r0 = PyUnicode_Join(x, y)
-    return r1
+    return r0

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3383,3 +3383,15 @@ L0:
     r5 = None
     return r5
 
+[case testCallCWithStrJoin]
+from typing import List
+def f(x: str, y: List[str]) -> str:
+    return x.join(y)
+[out]
+def f(x, y):
+    x :: str
+    y :: list
+    r0 :: str
+L0:
+    r0 = PyUnicode_Join(x, y)
+    return r1


### PR DESCRIPTION
relates mypyc/mypyc#709

This PR adds a new IR op `CallC` to replace some `PrimitiveOp` that simply calls a C function. To demonstrate this prototype, `str.join` primitive is now switched from `PrimitiveOp` to `CallC`, with identical generated C code:

Test driver code
```python
from typing import List

def test_str_join_helper(helper_arg: List[str]) -> str:
    helper_base = "#"
    return helper_base.join(helper_arg)

def main():
    l = ["a", "bb", "cc"]
    print(test_str_join_helper(l))

main()
```

generated C code(for the helper function, identical before/after):
```C
PyObject *CPyDef_test_str_join_helper(PyObject *cpy_r_helper_arg) {
    PyObject *cpy_r_r0;
    PyObject *cpy_r_helper_base;
    PyObject *cpy_r_r1;
    PyObject *cpy_r_r2;
CPyL0: ;
    cpy_r_r0 = CPyStatic_unicode_3; /* '#' */
    CPy_INCREF(cpy_r_r0);
    cpy_r_helper_base = cpy_r_r0;
    cpy_r_r1 = PyUnicode_Join(cpy_r_helper_base, cpy_r_helper_arg);
    CPy_DecRef(cpy_r_helper_base);
    if (unlikely(cpy_r_r1 == NULL)) {
        CPy_AddTraceback("foo.py", "test_str_join_helper", 5, CPyStatic_globals);
        goto CPyL2;
    } else
        goto CPyL1;
CPyL1: ;
    return cpy_r_r1;
CPyL2: ;
    cpy_r_r2 = NULL;
    return cpy_r_r2;
}
```

Some objectives need to be completed after some discussion.

- [x] figure out the differences between`OpDescrption` and new `LLOpDescrption`, do we need fields including `is_var_arg`, `steals`, `is_borrowed`?(Not supported in this PR yet, but we will gradually update the design when we encounter ops that require such changes)
- [x] support void functions(through a flag?)
- [x] textual IR testcase