### PR TITLE
[mypyc] Add "# type:ignore" to doc configuration

### DIFF
--- a/mypyc/doc/conf.py
+++ b/mypyc/doc/conf.py
@@ -27,7 +27,7 @@ author = 'mypyc team'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
+extensions = [  # type: ignore
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This is for convenience to avoid bogus mypy errors.