### PR TITLE
stubtest: fix false negative with dunder methods, small changes

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -662,15 +662,6 @@ def verify_funcitem(
 def verify_none(
     stub: Missing, runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:
-    if isinstance(runtime, Missing):
-        try:
-            # We shouldn't really get here since that would involve something not existing both in
-            # the stub and the runtime, however, some modules like distutils.command have some
-            # weird things going on. Try to see if we can find a runtime object by importing it,
-            # otherwise crash.
-            runtime = importlib.import_module(".".join(object_path))
-        except ImportError:
-            raise RuntimeError
     yield Error(object_path, "is not present in stub", stub, runtime)
 
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -254,7 +254,7 @@ def verify_typeinfo(
 def _verify_static_class_methods(
     stub: nodes.FuncItem, runtime: types.FunctionType, object_path: List[str]
 ) -> Iterator[str]:
-    if runtime.__name__ == "__new__":
+    if stub.name == "__new__":
         # Special cased by Python, so never declared as staticmethod
         return
     if inspect.isbuiltin(runtime):

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -237,8 +237,11 @@ def verify_typeinfo(
         return
 
     to_check = set(stub.names)
+    dunders_to_check = ("__init__", "__new__", "__call__")
     # cast to workaround mypyc complaints
-    to_check.update(m for m in cast(Any, vars)(runtime) if not m.startswith("_"))
+    to_check.update(
+        m for m in cast(Any, vars)(runtime) if m in dunders_to_check or not m.startswith("_")
+    )
 
     for entry in sorted(to_check):
         mangled_entry = entry

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -588,6 +588,38 @@ class StubtestUnit(unittest.TestCase):
             error="X.__mangle_bad"
         )
 
+    @collect_cases
+    def test_mro(self) -> Iterator[Case]:
+        yield Case(
+            stub="""
+            class A:
+                def foo(self, x: int) -> None: ...
+            class B(A):
+                pass
+            class C(A):
+                pass
+            """,
+            runtime="""
+            class A:
+                def foo(self, x: int) -> None: ...
+            class B(A):
+                def foo(self, x: int) -> None: ...
+            class C(A):
+                def foo(self, y: int) -> None: ...
+            """,
+            error="C.foo"
+        )
+        yield Case(
+            stub="""
+            class X: ...
+            """,
+            runtime="""
+            class X:
+                def __init__(self, x): pass
+            """,
+            error="X.__init__"
+        )
+
 
 def remove_color_code(s: str) -> str:
     return re.sub("\\x1b.*?m", "", s)  # this works!


### PR DESCRIPTION
If a stub was completely missing a dunder method, we wouldn't check it against the runtime. It's noisy to check all dunder methods, but checking init, new and call catches a lot of false negatives on typeshed without much noise.