### PR TITLE
Fix type expected by stubgenc

### DIFF
--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -339,7 +339,7 @@ def find_unique_signatures(sigs: Sequence[Sig]) -> List[Sig]:
     return sorted(result)
 
 
-def infer_prop_type_from_docstring(docstr: str) -> Optional[str]:
+def infer_prop_type_from_docstring(docstr: Optional[str]) -> Optional[str]:
     """Check for Google/Numpy style docstring type annotation for a property.
 
     The docstring has the format "<type>: <descriptions>".


### PR DESCRIPTION
In investigating a crash when running on a PyBind11 module, I noticed a mismatch in the types; `infer_prop_type_from_docstring` can clearly get None, but it has a type of plain `str`. Fix the annotation to match the expectation. Now, when rebuilding Mypy, the error goes away and this now works without crashing, and can completely generate stubs.

Here's one of the uses where None is obviously possible:

https://github.com/python/mypy/blob/d1048867ce27f607a7f48edf33a1888789b187e7/mypy/stubgenc.py#L220-L221

Fixes #7692.

Example printout when this error is seen:

```
    sys.exit(main())
  File "mypy/stubgen.py", line 1564, in main
  File "mypy/stubgen.py", line 1457, in generate_stubs
  File "mypy/stubgenc.py", line 51, in generate_stub_for_c_module
  File "mypy/stubgenc.py", line 273, in generate_c_type_stub
  File "mypy/stubgenc.py", line 221, in generate_c_property_stub
TypeError: str object expected; got None
```