### PR TITLE
[mypyc] Support top level function ops via CallC

### DIFF
--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1151,12 +1151,12 @@ class CallC(RegisterOp):
                  steals: StealsDescription,
                  error_kind: int,
                  line: int) -> None:
+        self.error_kind = error_kind
         super().__init__(line)
         self.function_name = function_name
         self.args = args
         self.type = ret_type
         self.steals = steals
-        self.error_kind = error_kind
 
     def to_str(self, env: Environment) -> str:
         args_str = ', '.join(env.format('%r', arg) for arg in self.args)

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1146,11 +1146,17 @@ class CallC(RegisterOp):
 
     error_kind = ERR_MAGIC
 
-    def __init__(self, function_name: str, args: List[Value], ret_type: RType, line: int) -> None:
+    def __init__(self,
+                 function_name: str,
+                 args: List[Value],
+                 ret_type: RType,
+                 steals: StealsDescription,
+                 line: int) -> None:
         super().__init__(line)
         self.function_name = function_name
         self.args = args
         self.type = ret_type
+        self.steals = steals
 
     def to_str(self, env: Environment) -> str:
         args_str = ', '.join(env.format('%r', arg) for arg in self.args)
@@ -1158,6 +1164,13 @@ class CallC(RegisterOp):
 
     def sources(self) -> List[Value]:
         return self.args
+
+    def stolen(self) -> List[Value]:
+        if isinstance(self.steals, list):
+            assert len(self.steals) == len(self.args)
+            return [arg for arg, steal in zip(self.args, self.steals) if steal]
+        else:
+            return [] if not self.steals else self.sources()
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_call_c(self)

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1144,19 +1144,19 @@ class CallC(RegisterOp):
     A call to a C function
     """
 
-    error_kind = ERR_MAGIC
-
     def __init__(self,
                  function_name: str,
                  args: List[Value],
                  ret_type: RType,
                  steals: StealsDescription,
+                 error_kind: int,
                  line: int) -> None:
         super().__init__(line)
         self.function_name = function_name
         self.args = args
         self.type = ret_type
         self.steals = steals
+        self.error_kind = error_kind
 
     def to_str(self, env: Environment) -> str:
         args_str = ', '.join(env.format('%r', arg) for arg in self.args)

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -43,7 +43,7 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.ir.func_ir import FuncIR, INVALID_FUNC_DEF
 from mypyc.ir.class_ir import ClassIR, NonExtClassInfo
-from mypyc.primitives.registry import func_ops
+from mypyc.primitives.registry import func_ops, CFunctionDescription, c_function_ops
 from mypyc.primitives.list_ops import list_len_op, to_list, list_pop_last
 from mypyc.primitives.dict_ops import dict_get_item_op, dict_set_item_op
 from mypyc.primitives.generic_ops import py_setattr_op, iter_op, next_op
@@ -228,6 +228,9 @@ class IRBuilder:
 
     def load_module(self, name: str) -> Value:
         return self.builder.load_module(name)
+
+    def call_c(self, desc: CFunctionDescription, args: List[Value], line: int) -> Value:
+        return self.builder.call_c(desc.c_function_name, args, line, desc.result_type)
 
     @property
     def environment(self) -> Environment:
@@ -506,7 +509,7 @@ class IRBuilder:
         # Assign the starred value and all values after it
         if target.star_idx is not None:
             post_star_vals = target.items[split_idx + 1:]
-            iter_list = self.primitive_op(to_list, [iterator], line)
+            iter_list = self.call_c(to_list, [iterator], line)
             iter_list_len = self.primitive_op(list_len_op, [iter_list], line)
             post_star_len = self.add(LoadInt(len(post_star_vals)))
             condition = self.binary_op(post_star_len, iter_list_len, '<=', line)
@@ -723,6 +726,10 @@ class IRBuilder:
 
         # Handle data-driven special-cased primitive call ops.
         if callee.fullname is not None and expr.arg_kinds == [ARG_POS] * len(arg_values):
+            call_c_ops_candidates = c_function_ops.get(callee.fullname, [])
+            target = self.builder.matching_call_c(call_c_ops_candidates, arg_values, expr.line)
+            if target:
+                return target
             ops = func_ops.get(callee.fullname, [])
             target = self.builder.matching_primitive_op(
                 ops, arg_values, expr.line, self.node_type(expr)

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -230,7 +230,7 @@ class IRBuilder:
         return self.builder.load_module(name)
 
     def call_c(self, desc: CFunctionDescription, args: List[Value], line: int) -> Value:
-        return self.builder.call_c(desc.c_function_name, args, line, desc.result_type)
+        return self.builder.call_c(desc, args, line)
 
     @property
     def environment(self) -> Environment:

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -727,7 +727,8 @@ class IRBuilder:
         # Handle data-driven special-cased primitive call ops.
         if callee.fullname is not None and expr.arg_kinds == [ARG_POS] * len(arg_values):
             call_c_ops_candidates = c_function_ops.get(callee.fullname, [])
-            target = self.builder.matching_call_c(call_c_ops_candidates, arg_values, expr.line)
+            target = self.builder.matching_call_c(call_c_ops_candidates, arg_values,
+                                                  expr.line, self.node_type(expr))
             if target:
                 return target
             ops = func_ops.get(callee.fullname, [])

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -663,7 +663,8 @@ class LowLevelIRBuilder:
             formal_type = desc.arg_types[i]
             arg = self.coerce(arg, formal_type, line)
             coerced.append(arg)
-        target = self.add(CallC(desc.c_function_name, coerced, ret_type, desc.steals, line))
+        target = self.add(CallC(desc.c_function_name, coerced, ret_type, desc.steals,
+                                desc.error_kind, line))
         return target
 
     def matching_call_c(self,

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -663,7 +663,7 @@ class LowLevelIRBuilder:
             formal_type = desc.arg_types[i]
             arg = self.coerce(arg, formal_type, line)
             coerced.append(arg)
-        target = self.add(CallC(desc.c_function_name, coerced, ret_type, line))
+        target = self.add(CallC(desc.c_function_name, coerced, ret_type, desc.steals, line))
         return target
 
     def matching_call_c(self,

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -8,7 +8,7 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.primitives.registry import (
     name_ref_op, binary_op, func_op, method_op, custom_op, name_emit,
-    call_emit, call_negative_bool_emit,
+    call_emit, call_negative_bool_emit, c_function_op,
 )
 
 
@@ -19,14 +19,21 @@ name_ref_op('builtins.list',
             emit=name_emit('&PyList_Type', target_type='PyObject *'),
             is_borrowed=True)
 
-# list(obj)
-to_list = func_op(
+# # list(obj)
+# to_list = func_op(
+#     name='builtins.list',
+#     arg_types=[object_rprimitive],
+#     result_type=list_rprimitive,
+#     error_kind=ERR_MAGIC,
+#     emit=call_emit('PySequence_List'))
+
+to_list = c_function_op(
     name='builtins.list',
     arg_types=[object_rprimitive],
     result_type=list_rprimitive,
+    c_function_name='PySequence_List',
     error_kind=ERR_MAGIC,
-    emit=call_emit('PySequence_List'))
-
+)
 
 def emit_new(emitter: EmitterInterface, args: List[str], dest: str) -> None:
     # TODO: This would be better split into multiple smaller ops.

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -19,13 +19,6 @@ name_ref_op('builtins.list',
             emit=name_emit('&PyList_Type', target_type='PyObject *'),
             is_borrowed=True)
 
-# # list(obj)
-# to_list = func_op(
-#     name='builtins.list',
-#     arg_types=[object_rprimitive],
-#     result_type=list_rprimitive,
-#     error_kind=ERR_MAGIC,
-#     emit=call_emit('PySequence_List'))
 
 to_list = c_function_op(
     name='builtins.list',
@@ -34,6 +27,7 @@ to_list = c_function_op(
     c_function_name='PySequence_List',
     error_kind=ERR_MAGIC,
 )
+
 
 def emit_new(emitter: EmitterInterface, args: List[str], dest: str) -> None:
     # TODO: This would be better split into multiple smaller ops.

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -19,7 +19,7 @@ name_ref_op('builtins.list',
             emit=name_emit('&PyList_Type', target_type='PyObject *'),
             is_borrowed=True)
 
-
+# list(obj)
 to_list = c_function_op(
     name='builtins.list',
     arg_types=[object_rprimitive],

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -23,7 +23,7 @@ name_ref_op('builtins.list',
 to_list = c_function_op(
     name='builtins.list',
     arg_types=[object_rprimitive],
-    result_type=list_rprimitive,
+    return_type=list_rprimitive,
     c_function_name='PySequence_List',
     error_kind=ERR_MAGIC,
 )

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -8,7 +8,7 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.primitives.registry import (
     name_ref_op, binary_op, func_op, method_op, custom_op, name_emit,
-    call_emit, call_negative_bool_emit, c_function_op, c_method_op
+    call_emit, call_negative_bool_emit, c_function_op
 )
 
 
@@ -76,15 +76,13 @@ list_get_item_unsafe_op = custom_op(
     emit=call_emit('CPyList_GetItemUnsafe'))
 
 # list[index] = obj
-list_set_item_op = c_method_op(
+list_set_item_op = method_op(
     name='__setitem__',
     arg_types=[list_rprimitive, int_rprimitive, object_rprimitive],
-    result_type=bool_rprimitive,
-    c_function_name='CPyList_SetItem',
-    error_kind=ERR_FALSE,
     steals=[False, False, True],
-)
-
+    result_type=bool_rprimitive,
+    error_kind=ERR_FALSE,
+    emit=call_emit('CPyList_SetItem'))
 
 # list.append(obj)
 list_append_op = method_op(

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -8,7 +8,7 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.primitives.registry import (
     name_ref_op, binary_op, func_op, method_op, custom_op, name_emit,
-    call_emit, call_negative_bool_emit, c_function_op,
+    call_emit, call_negative_bool_emit, c_function_op, c_method_op
 )
 
 
@@ -76,13 +76,14 @@ list_get_item_unsafe_op = custom_op(
     emit=call_emit('CPyList_GetItemUnsafe'))
 
 # list[index] = obj
-list_set_item_op = method_op(
+list_set_item_op = c_method_op(
     name='__setitem__',
     arg_types=[list_rprimitive, int_rprimitive, object_rprimitive],
-    steals=[False, False, True],
     result_type=bool_rprimitive,
+    c_function_name='CPyList_SetItem',
     error_kind=ERR_FALSE,
-    emit=call_emit('CPyList_SetItem'))
+    steals=[False, False, True],
+)
 
 
 # list.append(obj)

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -65,8 +65,11 @@ method_ops = {}  # type: Dict[str, List[OpDescription]]
 # Primitive ops for reading module attributes (key is name such as 'builtins.None')
 name_ref_ops = {}  # type: Dict[str, OpDescription]
 
+# CallC op for method call(such as 'str.join')
 c_method_call_ops = {}  # type: Dict[str, List[CFunctionDescription]]
 
+# CallC op for top level function call(such as 'builtins.list')
+c_function_ops = {}  # type: Dict[str, List[CFunctionDescription]]
 
 def simple_emit(template: str) -> EmitCallback:
     """Construct a simple PrimitiveOp emit callback function.
@@ -326,11 +329,24 @@ def c_method_op(name: str,
                 result_type: Optional[RType],
                 c_function_name: str,
                 error_kind: int,
-                priority: int = 1) -> None:
+                priority: int = 1) -> CFunctionDescription:
     ops = c_method_call_ops.setdefault(name, [])
     desc = CFunctionDescription(name, arg_types, result_type,
                                 c_function_name, error_kind, priority)
     ops.append(desc)
+    return desc
+
+def c_function_op(name: str,
+                  arg_types: List[RType],
+                  result_type: Optional[RType],
+                  c_function_name: str,
+                  error_kind: int,
+                  priority: int = 1) -> CFunctionDescription:
+    ops = c_function_ops.setdefault(name, [])
+    desc = CFunctionDescription(name, arg_types, result_type,
+                                c_function_name, error_kind, priority)
+    ops.append(desc)
+    return desc
 
 
 # Import various modules that set up global state.

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -45,7 +45,7 @@ from mypyc.ir.rtypes import RType,  bool_rprimitive
 CFunctionDescription = NamedTuple(
     'CFunctionDescription',  [('name', str),
                               ('arg_types', List[RType]),
-                              ('result_type', Optional[RType]),
+                              ('return_type', RType),
                               ('c_function_name', str),
                               ('error_kind', int),
                               ('steals', StealsDescription),
@@ -328,13 +328,13 @@ def custom_op(arg_types: List[RType],
 
 def c_method_op(name: str,
                 arg_types: List[RType],
-                result_type: Optional[RType],
+                return_type: RType,
                 c_function_name: str,
                 error_kind: int,
                 steals: StealsDescription = False,
                 priority: int = 1) -> CFunctionDescription:
     ops = c_method_call_ops.setdefault(name, [])
-    desc = CFunctionDescription(name, arg_types, result_type,
+    desc = CFunctionDescription(name, arg_types, return_type,
                                 c_function_name, error_kind, steals, priority)
     ops.append(desc)
     return desc
@@ -342,13 +342,13 @@ def c_method_op(name: str,
 
 def c_function_op(name: str,
                   arg_types: List[RType],
-                  result_type: Optional[RType],
+                  return_type: RType,
                   c_function_name: str,
                   error_kind: int,
                   steals: StealsDescription = False,
                   priority: int = 1) -> CFunctionDescription:
     ops = c_function_ops.setdefault(name, [])
-    desc = CFunctionDescription(name, arg_types, result_type,
+    desc = CFunctionDescription(name, arg_types, return_type,
                                 c_function_name, error_kind, steals, priority)
     ops.append(desc)
     return desc

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -71,6 +71,7 @@ c_method_call_ops = {}  # type: Dict[str, List[CFunctionDescription]]
 # CallC op for top level function call(such as 'builtins.list')
 c_function_ops = {}  # type: Dict[str, List[CFunctionDescription]]
 
+
 def simple_emit(template: str) -> EmitCallback:
     """Construct a simple PrimitiveOp emit callback function.
 
@@ -335,6 +336,7 @@ def c_method_op(name: str,
                                 c_function_name, error_kind, priority)
     ops.append(desc)
     return desc
+
 
 def c_function_op(name: str,
                   arg_types: List[RType],

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -48,6 +48,7 @@ CFunctionDescription = NamedTuple(
                               ('result_type', Optional[RType]),
                               ('c_function_name', str),
                               ('error_kind', int),
+                              ('steals', StealsDescription),
                               ('priority', int)])
 
 # Primitive binary ops (key is operator such as '+')
@@ -330,10 +331,11 @@ def c_method_op(name: str,
                 result_type: Optional[RType],
                 c_function_name: str,
                 error_kind: int,
+                steals: StealsDescription = False,
                 priority: int = 1) -> CFunctionDescription:
     ops = c_method_call_ops.setdefault(name, [])
     desc = CFunctionDescription(name, arg_types, result_type,
-                                c_function_name, error_kind, priority)
+                                c_function_name, error_kind, steals, priority)
     ops.append(desc)
     return desc
 
@@ -343,10 +345,11 @@ def c_function_op(name: str,
                   result_type: Optional[RType],
                   c_function_name: str,
                   error_kind: int,
+                  steals: StealsDescription = False,
                   priority: int = 1) -> CFunctionDescription:
     ops = c_function_ops.setdefault(name, [])
     desc = CFunctionDescription(name, arg_types, result_type,
-                                c_function_name, error_kind, priority)
+                                c_function_name, error_kind, steals, priority)
     ops.append(desc)
     return desc
 

--- a/mypyc/primitives/str_ops.py
+++ b/mypyc/primitives/str_ops.py
@@ -37,7 +37,7 @@ binary_op(op='+',
 c_method_op(
     name='join',
     arg_types=[str_rprimitive, object_rprimitive],
-    result_type=str_rprimitive,
+    return_type=str_rprimitive,
     c_function_name='PyUnicode_Join',
     error_kind=ERR_MAGIC
 )

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3383,7 +3383,7 @@ L0:
     r5 = None
     return r5
 
-[case testCallCWithStrJoin]
+[case testCallCWithStrJoinMethod]
 from typing import List
 def f(x: str, y: List[str]) -> str:
     return x.join(y)
@@ -3394,4 +3394,16 @@ def f(x, y):
     r0 :: str
 L0:
     r0 = PyUnicode_Join(x, y)
+    return r0
+
+[case testCallCWithToListFunction]
+from typing import List, Iterable
+def f(x: Iterable[int]) -> List[int]:
+    return list(x)
+[out]
+def f(x):
+    x :: object
+    r0 :: list
+L0:
+    r0 = PySequence_List(x)
     return r0

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3397,12 +3397,36 @@ L0:
     return r0
 
 [case testCallCWithToListFunction]
-from typing import List, Iterable
+from typing import List, Iterable, Tuple, Dict
+# generic object
 def f(x: Iterable[int]) -> List[int]:
     return list(x)
+
+# need coercing
+def g(x: Tuple[int, int, int]) -> List[int]:
+    return list(x)
+
+# non-list object
+def h(x: Dict[int, str]) -> List[int]:
+    return list(x)
+
 [out]
 def f(x):
     x :: object
+    r0 :: list
+L0:
+    r0 = PySequence_List(x)
+    return r0
+def g(x):
+    x :: tuple[int, int, int]
+    r0 :: object
+    r1 :: list
+L0:
+    r0 = box(tuple[int, int, int], x)
+    r1 = PySequence_List(r0)
+    return r1
+def h(x):
+    x :: dict
     r0 :: list
 L0:
     r0 = PySequence_List(x)

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -8,7 +8,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ir.ops import (
     Environment, BasicBlock, Goto, Return, LoadInt, Assign, IncRef, DecRef, Branch,
     Call, Unbox, Box, TupleGet, GetAttr, PrimitiveOp, RegisterOp,
-    SetAttr, Op, Value
+    SetAttr, Op, Value, CallC
 )
 from mypyc.ir.rtypes import (
     RTuple, RInstance, int_rprimitive, bool_rprimitive, list_rprimitive,
@@ -157,7 +157,9 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_r0 = CPyList_GetItem(cpy_r_m, cpy_r_k);""")
 
     def test_list_set_item(self) -> None:
-        self.assert_emit(PrimitiveOp([self.l, self.n, self.o], list_set_item_op, 55),
+        assert list_set_item_op.result_type
+        self.assert_emit(CallC(list_set_item_op.c_function_name, [self.l, self.n, self.o],
+                               list_set_item_op.result_type, list_set_item_op.steals, 55),
                          """cpy_r_r0 = CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o);""")
 
     def test_box(self) -> None:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -8,7 +8,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ir.ops import (
     Environment, BasicBlock, Goto, Return, LoadInt, Assign, IncRef, DecRef, Branch,
     Call, Unbox, Box, TupleGet, GetAttr, PrimitiveOp, RegisterOp,
-    SetAttr, Op, Value, CallC
+    SetAttr, Op, Value
 )
 from mypyc.ir.rtypes import (
     RTuple, RInstance, int_rprimitive, bool_rprimitive, list_rprimitive,
@@ -157,9 +157,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_r0 = CPyList_GetItem(cpy_r_m, cpy_r_k);""")
 
     def test_list_set_item(self) -> None:
-        assert list_set_item_op.result_type
-        self.assert_emit(CallC(list_set_item_op.c_function_name, [self.l, self.n, self.o],
-                               list_set_item_op.result_type, list_set_item_op.steals, 55),
+        self.assert_emit(PrimitiveOp([self.l, self.n, self.o], list_set_item_op, 55),
                          """cpy_r_r0 = CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o);""")
 
     def test_box(self) -> None:


### PR DESCRIPTION
relates mypyc/mypyc#709

This PR supports top-level function ops via recently added `CallC` IR. To demonstrate the idea, it transform `to_list` op from `PrimitiveOp` to `CallC`. It also refines `CallC` with arguments coercing and support of `steals`.