### PR TITLE
Don't use OrderedDict on Python 3.6 and greater

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1,6 +1,6 @@
 """Expression type checker. This file is conceptually part of TypeChecker."""
 
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 from contextlib import contextmanager
 import itertools
 from typing import (

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -1,7 +1,8 @@
 import os.path
 import sys
 import traceback
-from collections import OrderedDict, defaultdict
+from mypy.ordered_dict import OrderedDict
+from collections import defaultdict
 
 from typing import Tuple, List, TypeVar, Set, Dict, Optional, TextIO, Callable
 from typing_extensions import Final

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -1,6 +1,6 @@
 """Calculation of the least upper bound types (joins)."""
 
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 from typing import List, Optional
 
 from mypy.types import (

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 from typing import List, Optional, Tuple, Callable
 
 from mypy.join import (

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -9,7 +9,7 @@ Historically we tried to avoid all message string literals in the type
 checker but we are moving away from this convention.
 """
 
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 import re
 import difflib
 from textwrap import dedent

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2,7 +2,8 @@
 
 import os
 from abc import abstractmethod
-from collections import OrderedDict, defaultdict
+from mypy.ordered_dict import OrderedDict
+from collections import defaultdict
 from typing import (
     Any, TypeVar, List, Tuple, cast, Set, Dict, Union, Optional, Callable, Sequence, Iterator
 )

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 import re
 import pprint
 import sys

--- a/mypy/ordered_dict.py
+++ b/mypy/ordered_dict.py
@@ -1,0 +1,9 @@
+# OrderedDict is kind of slow, so for most of our uses in Python 3.6
+# and later we'd rather just use dict
+
+import sys
+
+if sys.version_info <= (3, 5):
+    from collections import OrderedDict as OrderedDict
+else:
+    OrderedDict = dict

--- a/mypy/ordered_dict.py
+++ b/mypy/ordered_dict.py
@@ -3,7 +3,7 @@
 
 import sys
 
-if sys.version_info <= (3, 5):
+if sys.version_info < (3, 6):
     from collections import OrderedDict as OrderedDict
 else:
     OrderedDict = dict

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -1,6 +1,6 @@
 """Plugin for supporting the attrs library (http://www.attrs.org)"""
 
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 
 from typing import Optional, Dict, List, cast, Tuple, Iterable
 from typing_extensions import Final

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -1,6 +1,6 @@
 """Semantic analysis of TypedDict definitions."""
 
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 from typing import Optional, List, Set, Tuple
 from typing_extensions import Final
 

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -12,7 +12,7 @@ other modules refer to them.
 """
 
 from abc import abstractmethod
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 from typing import Generic, TypeVar, cast, Any, List, Callable, Iterable, Optional, Set
 from mypy_extensions import trait
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -3,7 +3,7 @@
 import itertools
 from itertools import chain
 from contextlib import contextmanager
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 
 from typing import Callable, List, Optional, Set, Tuple, Iterator, TypeVar, Iterable
 from typing_extensions import Final

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3,7 +3,7 @@
 import copy
 import sys
 from abc import abstractmethod
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 
 from typing import (
     Any, TypeVar, Dict, List, Tuple, cast, Set, Optional, Union, Iterable, NamedTuple,

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -1,6 +1,6 @@
 """Utilities for emitting C code."""
 
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 from typing import List, Set, Dict, Optional, Callable, Union
 
 from mypyc.common import (

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -2,7 +2,7 @@
 
 
 from typing import Optional, List, Tuple, Dict, Callable, Mapping, Set
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 
 from mypyc.common import PREFIX, NATIVE_PREFIX, REG_PREFIX
 from mypyc.codegen.emit import Emitter, HeaderDeclaration

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -5,7 +5,7 @@
 
 import os
 import json
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 from typing import List, Tuple, Dict, Iterable, Set, TypeVar, Optional
 
 from mypy.nodes import MypyFile

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -1,7 +1,7 @@
 """Intermediate representation of classes."""
 
 from typing import List, Optional, Set, Tuple, Dict, NamedTuple
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 
 from mypyc.common import JsonDict
 from mypyc.ir.ops import Value, DeserMaps

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -15,7 +15,7 @@ from typing import (
     List, Sequence, Dict, Generic, TypeVar, Optional, Any, NamedTuple, Tuple, Callable,
     Union, Iterable, Set
 )
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 
 from typing_extensions import Final, Type, TYPE_CHECKING
 from mypy_extensions import trait

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -13,7 +13,7 @@ functions are transformed in mypyc.irbuild.function.
 
 from typing import Callable, Dict, List, Tuple, Optional, Union, Sequence, Set, Any
 from typing_extensions import overload
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 
 from mypy.build import Graph
 from mypy.nodes import (

--- a/mypyc/irbuild/main.py
+++ b/mypyc/irbuild/main.py
@@ -20,7 +20,7 @@ For the core of the IR transform implementation, look at build_ir()
 below, mypyc.irbuild.builder, and mypyc.irbuild.visitor.
 """
 
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 from typing import List, Dict, Callable, Any, TypeVar, cast
 
 from mypy.nodes import MypyFile, Expression, ClassDef

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -1,7 +1,7 @@
 """Maintain a mapping from mypy concepts to IR/compiled concepts."""
 
 from typing import Dict, Optional, Union
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 
 from mypy.nodes import FuncDef, TypeInfo, SymbolNode, ARG_STAR, ARG_STAR2
 from mypy.types import (

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -1,6 +1,6 @@
 import unittest
 
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 
 from mypy.nodes import Var
 from mypy.test.helpers import assert_string_arrays_equal

--- a/mypyc/test/test_serialization.py
+++ b/mypyc/test/test_serialization.py
@@ -4,7 +4,7 @@
 # contain its own tests so that pytest will rewrite the asserts...
 
 from typing import Any, Dict, Tuple
-from collections import OrderedDict
+from mypy.ordered_dict import OrderedDict
 from collections.abc import Iterable
 
 from mypyc.ir.ops import DeserMaps


### PR DESCRIPTION
OrderedDict is written in Python and maintains its own ordering on top
of the ordering the dict provides in recent Pythons. This ordering can
differ if certain methods are called, but we don't need that. Just
always use dict when it is ordered.