### PR TITLE
Update .gitignore to include _build/ folder from docs/source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 /build
 /env*/
 docs/build/
+docs/source/_build
 *.iml
 /out/
 .venv*/


### PR DESCRIPTION
While sending a PR for a documentation update I noticed an untracked ``docs/source/_build/`` folder, containing html files for the documentation. I added the same to gitignore so to avoid them getting pushed mistakenly.