### PR TITLE
[mypyc] Basic support for protocols

### DIFF
--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -67,7 +67,14 @@ class Mapper:
             elif typ.type.fullname == 'builtins.tuple':
                 return tuple_rprimitive  # Varying-length tuple
             elif typ.type in self.type_to_ir:
-                return RInstance(self.type_to_ir[typ.type])
+                inst = RInstance(self.type_to_ir[typ.type])
+                # Treat protocols as Union[protocol, object], so that we can do fast
+                # method calls in the cases where the protocol is explicitly inherited from
+                # and fall back to generic operations when it isn't.
+                if typ.type.is_protocol:
+                    return RUnion([inst, object_rprimitive])
+                else:
+                    return inst
             else:
                 return object_rprimitive
         elif isinstance(typ, TupleType):

--- a/mypyc/irbuild/util.py
+++ b/mypyc/irbuild/util.py
@@ -19,7 +19,7 @@ def is_trait_decorator(d: Expression) -> bool:
 
 
 def is_trait(cdef: ClassDef) -> bool:
-    return any(is_trait_decorator(d) for d in cdef.decorators)
+    return any(is_trait_decorator(d) for d in cdef.decorators) or cdef.info.is_protocol
 
 
 def is_dataclass_decorator(d: Expression) -> bool:

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -82,7 +82,11 @@ static bool _CPy_IsSafeMetaClass(PyTypeObject *metaclass) {
     bool matches = false;
     if (PyUnicode_CompareWithASCIIString(module, "typing") == 0 &&
             (strcmp(metaclass->tp_name, "TypingMeta") == 0
-             || strcmp(metaclass->tp_name, "GenericMeta") == 0)) {
+             || strcmp(metaclass->tp_name, "GenericMeta") == 0
+             || strcmp(metaclass->tp_name, "_ProtocolMeta") == 0)) {
+        matches = true;
+    } else if (PyUnicode_CompareWithASCIIString(module, "typing_extensions") == 0 &&
+               strcmp(metaclass->tp_name, "_ProtocolMeta") == 0) {
         matches = true;
     } else if (PyUnicode_CompareWithASCIIString(module, "abc") == 0 &&
                strcmp(metaclass->tp_name, "ABCMeta") == 0) {

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -958,6 +958,48 @@ assert b.z is None
 # N.B: this doesn't match cpython
 assert not hasattr(b, 'bogus')
 
+[case testProtocol]
+from typing_extensions import Protocol
+
+class Proto(Protocol):
+    def foo(self, x: int) -> None:
+        pass
+
+    def bar(self, x: int) -> None:
+        pass
+
+class A:
+    def foo(self, x: int) -> None:
+        print("A:", x)
+
+    def bar(self, *args: int, **kwargs: int) -> None:
+        print("A:", args, kwargs)
+
+class B(A, Proto):
+    def foo(self, x: int) -> None:
+        print("B:", x)
+
+    def bar(self, *args: int, **kwargs: int) -> None:
+        print("B:", args, kwargs)
+
+def f(x: Proto) -> None:
+    x.foo(20)
+    x.bar(x=20)
+
+[file driver.py]
+from native import A, B, f
+
+f(A())
+f(B())
+
+# ... this exploits a bug in glue methods to distinguish whether we
+# are making a direct call or a pycall...
+[out]
+A: 20
+A: () {'x': 20}
+B: 20
+B: (20,) {}
+
 [case testMethodOverrideDefault1]
 class A:
     def foo(self, x: int) -> None:


### PR DESCRIPTION
The idea is to represent a protocol type P as Union[P, object], so
that we'll make fast calls if a class explictly inherits from the
protocol and fall back to generic ops otherwise.