### PR TITLE
[mypyc] Refactor of load_final_static, make it report NameError

### DIFF
--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1113,6 +1113,7 @@ class RaiseStandardError(RegisterOp):
     STOP_ITERATION = 'StopIteration'  # type: Final
     UNBOUND_LOCAL_ERROR = 'UnboundLocalError'  # type: Final
     RUNTIME_ERROR = 'RuntimeError'  # type: Final
+    NAME_ERROR = 'NameError'  # type: Final
 
     def __init__(self, class_name: str, value: Optional[Union[str, Value]], line: int) -> None:
         super().__init__(line)

--- a/mypyc/test-data/fixtures/ir.py
+++ b/mypyc/test-data/fixtures/ir.py
@@ -183,6 +183,8 @@ class TypeError(Exception): pass
 
 class AttributeError(Exception): pass
 
+class NameError(Exception): pass
+
 class LookupError(Exception): pass
 
 class KeyError(LookupError): pass

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3247,7 +3247,7 @@ L0:
     r0 = __main__.x :: static
     if is_error(r0) goto L1 else goto L2
 L1:
-    raise ValueError('value for final name "x" was not set')
+    raise NameError('value for final name "x" was not set')
     unreachable
 L2:
     r2 = 0
@@ -3271,7 +3271,7 @@ L0:
     r0 = __main__.x :: static
     if is_error(r0) goto L1 else goto L2
 L1:
-    raise ValueError('value for final name "x" was not set')
+    raise NameError('value for final name "x" was not set')
     unreachable
 L2:
     r2 = r0[0]
@@ -3294,7 +3294,7 @@ L0:
     r0 = __main__.x :: static
     if is_error(r0) goto L1 else goto L2
 L1:
-    raise ValueError('value for final name "x" was not set')
+    raise NameError('value for final name "x" was not set')
     unreachable
 L2:
     r2 = 1

--- a/mypyc/test-data/run.test
+++ b/mypyc/test-data/run.test
@@ -4451,7 +4451,7 @@ def f() -> int:
 from native import f
 try:
     print(f())
-except ValueError as e:
+except NameError as e:
     print(e.args[0])
 [out]
 value for final name "x" was not set


### PR DESCRIPTION
Pull out handling of of the error checks into ll_builder, and report
the right exception.

This is groundwork for fixing some potential segfaults involving
uninitialized classes.