### PR TITLE
Change test to platform check for windows-specific type checking

### DIFF
--- a/test-data/stdlib-samples/3.2/test/support.py
+++ b/test-data/stdlib-samples/3.2/test/support.py
@@ -473,7 +473,7 @@ TESTFN_ENCODING = sys.getfilesystemencoding()
 # encoded by the filesystem encoding (in strict mode). It can be None if we
 # cannot generate such filename.
 TESTFN_UNENCODABLE = None # type: Any
-if os.name in ('nt', 'ce'):
+if sys.platform == "win32":
     # skip win32s (0) or Windows 9x/ME (1)
     if sys.getwindowsversion().platform >= 2:
         # Different kinds of characters from various languages to minimize the


### PR DESCRIPTION
This test currently fails on https://github.com/python/typeshed/pull/4137 due to mypy not recognizing the existing check as meaning the block is windows-specific, so it claims that `getwindowsversion` doesn't exist.