### PR TITLE
Make reveal_type work with call expressions returning None

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3019,7 +3019,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Type check a reveal_type expression."""
         if expr.kind == REVEAL_TYPE:
             assert expr.expr is not None
-            revealed_type = self.accept(expr.expr, type_context=self.type_context[-1])
+            revealed_type = self.accept(expr.expr, type_context=self.type_context[-1],
+                                        allow_none_return=True)
             if not self.chk.current_node_deferred:
                 self.msg.reveal_type(revealed_type, expr.expr)
                 if not self.chk.in_checked_function():

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2572,3 +2572,9 @@ lambda a=nonsense: a  # E: Name 'nonsense' is not defined
 lambda a=(1 + 'asdf'): a  # E: Unsupported operand types for + ("int" and "str")
 def f(x: int = i):  # E: Name 'i' is not defined
     i = 42
+
+[case testRevealTypeOfCallExpressionReturningNoneWorks]
+def foo() -> None:
+    pass
+
+reveal_type(foo()) # N: Revealed type is 'None'


### PR DESCRIPTION
I think it's unnecessarily strict to raise an error in case like this.
Was:

    error: "foo" does not return a value