### PR TITLE
[mypyc] Introduce low level integer type

### DIFF
--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -13,7 +13,7 @@ from mypyc.ir.ops import (
     BasicBlock, Value, MethodCall, PrimitiveOp, EmitterInterface, Unreachable, NAMESPACE_STATIC,
     NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CallC
 )
-from mypyc.ir.rtypes import RType, RTuple
+from mypyc.ir.rtypes import RType, RTuple, is_c_int_rprimitive
 from mypyc.ir.func_ir import FuncIR, FuncDecl, FUNC_STATICMETHOD, FUNC_CLASSMETHOD
 from mypyc.ir.class_ir import ClassIR
 
@@ -179,7 +179,10 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
 
     def visit_load_int(self, op: LoadInt) -> None:
         dest = self.reg(op)
-        self.emit_line('%s = %d;' % (dest, op.value * 2))
+        if is_c_int_rprimitive(op.type):
+            self.emit_line('%s = %d;' % (dest, op.value))
+        else:
+            self.emit_line('%s = %d;' % (dest, op.value * 2))
 
     def visit_load_error_value(self, op: LoadErrorValue) -> None:
         if isinstance(op.type, RTuple):

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -783,10 +783,10 @@ class LoadInt(RegisterOp):
 
     error_kind = ERR_NEVER
 
-    def __init__(self, value: int, line: int = -1) -> None:
+    def __init__(self, value: int, line: int = -1, rtype: RType = short_int_rprimitive) -> None:
         super().__init__(line)
         self.value = value
-        self.type = short_int_rprimitive
+        self.type = rtype
 
     def sources(self) -> List[Value]:
         return []

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -174,7 +174,7 @@ class RPrimitive(RType):
         self.is_unboxed = is_unboxed
         self._ctype = ctype
         self.is_refcounted = is_refcounted
-        if ctype == 'CPyTagged':
+        if ctype in {'CPyTagged', 'int'}:
             self.c_undefined = 'CPY_INT_TAG'
         elif ctype == 'PyObject *':
             # Boxed types use the null pointer as the error value.
@@ -234,6 +234,10 @@ int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=True,
 short_int_rprimitive = RPrimitive('short_int', is_unboxed=True, is_refcounted=False,
                                   ctype='CPyTagged')  # type: Final
 
+# low level integer (corresponds to C's 'int').
+c_int_rprimitive = RPrimitive('c_int', is_unboxed=True, is_refcounted=False,
+                              ctype='int')  # type: Final
+
 # Floats are represent as 'float' PyObject * values. (In the future
 # we'll likely switch to a more efficient, unboxed representation.)
 float_rprimitive = RPrimitive('builtins.float', is_unboxed=False,
@@ -273,6 +277,10 @@ def is_int_rprimitive(rtype: RType) -> bool:
 
 def is_short_int_rprimitive(rtype: RType) -> bool:
     return rtype is short_int_rprimitive
+
+
+def is_c_int_rprimitive(rtype: RType) -> bool:
+    return rtype is c_int_rprimitive
 
 
 def is_float_rprimitive(rtype: RType) -> bool:

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -174,7 +174,7 @@ class RPrimitive(RType):
         self.is_unboxed = is_unboxed
         self._ctype = ctype
         self.is_refcounted = is_refcounted
-        if ctype in ('CPyTagged', 'int'):
+        if ctype in ('CPyTagged', 'Py_ssize_t'):
             self.c_undefined = 'CPY_INT_TAG'
         elif ctype == 'PyObject *':
             # Boxed types use the null pointer as the error value.

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -174,7 +174,7 @@ class RPrimitive(RType):
         self.is_unboxed = is_unboxed
         self._ctype = ctype
         self.is_refcounted = is_refcounted
-        if ctype in {'CPyTagged', 'int'}:
+        if ctype in ('CPyTagged', 'int'):
             self.c_undefined = 'CPY_INT_TAG'
         elif ctype == 'PyObject *':
             # Boxed types use the null pointer as the error value.
@@ -236,7 +236,7 @@ short_int_rprimitive = RPrimitive('short_int', is_unboxed=True, is_refcounted=Fa
 
 # low level integer (corresponds to C's 'int').
 c_int_rprimitive = RPrimitive('c_int', is_unboxed=True, is_refcounted=False,
-                              ctype='int')  # type: Final
+                              ctype='Py_ssize_t')  # type: Final
 
 # Floats are represent as 'float' PyObject * values. (In the future
 # we'll likely switch to a more efficient, unboxed representation.)

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -12,7 +12,7 @@ from mypyc.ir.ops import (
 )
 from mypyc.ir.rtypes import (
     RTuple, RInstance, int_rprimitive, bool_rprimitive, list_rprimitive,
-    dict_rprimitive, object_rprimitive
+    dict_rprimitive, object_rprimitive, c_int_rprimitive
 )
 from mypyc.ir.func_ir import FuncIR, FuncDecl, RuntimeArg, FuncSignature
 from mypyc.ir.class_ir import ClassIR
@@ -70,6 +70,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def test_load_int(self) -> None:
         self.assert_emit(LoadInt(5),
                          "cpy_r_r0 = 10;")
+        self.assert_emit(LoadInt(5, -1, c_int_rprimitive),
+                         "cpy_r_r00 = 5;")
 
     def test_tuple_get(self) -> None:
         self.assert_emit(TupleGet(self.t, 1, 0), 'cpy_r_r0 = cpy_r_t.f1;')


### PR DESCRIPTION
closes mypyc/mypyc#735

This PR introduces a `c_int_rprimitive` RType which represents a low level, plan integer(corresponds to C's `int`). It also allows `LoadInt` to select its `rtype` to generate tagged/plain integer code accordingly.