### PR TITLE
Update typeshed to fix TextIOWrapper constructor

### DIFF
--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -448,7 +448,7 @@ def default_lib_path(data_dir: str,
 
 
 @functools.lru_cache(maxsize=None)
-def get_site_packages_dirs(python_executable: Optional[str]) -> Tuple[List[str], List[str]]:
+def get_site_packages_dirs(python_executable: str) -> Tuple[List[str], List[str]]:
     """Find package directories for given python.
 
     This runs a subprocess call, which generates a list of the egg directories, and the site
@@ -461,8 +461,6 @@ def get_site_packages_dirs(python_executable: Optional[str]) -> Tuple[List[str],
         else:
             return os.path.join(root, os.path.normpath(path))
 
-    if python_executable is None:
-        return [], []
     if python_executable == sys.executable:
         # Use running Python's package dirs
         site_packages = sitepkgs.getsitepackages()
@@ -543,7 +541,11 @@ def compute_search_paths(sources: List[BuildSource],
     if alt_lib_path:
         mypypath.insert(0, alt_lib_path)
 
-    egg_dirs, site_packages = get_site_packages_dirs(options.python_executable)
+    if options.python_executable is None:
+        egg_dirs = []  # type: List[str]
+        site_packages = []  # type: List[str]
+    else:
+        egg_dirs, site_packages = get_site_packages_dirs(options.python_executable)
     for site_dir in site_packages:
         assert site_dir not in lib_path
         if (site_dir in mypypath or


### PR DESCRIPTION
Currently it doesn't accept ZipFile.open()'s output and fails with
`error: Argument 1 to "TextIOWrapper" has incompatible type "IO[bytes]"; expected "BinaryIO"`

That was fixed in https://github.com/python/typeshed/commit/3058bec873ef8b2b5630df36c4cbea0e3734dc5f