### PR TITLE
Add union narrowing using in/not in

### DIFF
--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -1048,3 +1048,17 @@ def foo(a: T2, b: T2) -> T2:
 def bar(a: T4, b: T4) -> T4:  # test multi-level alias
     return a + b
 [builtins fixtures/ops.pyi]
+
+
+[case testNarrowingUnionFromInContainer]
+from typing import Union, NewType, Set
+MyCoolInt = NewType('MyCoolInt', int)
+T1 = Union[int, float, MyCoolInt, str]
+
+my_cool_set: Set[Union[int, str]] = set(2, 'hi')
+
+def my_cool_function(my_cool_arg: T1):
+    if my_cool_arg in my_cool_set:
+        reveal_type(my_cool_arg)  # N: Revealed type is Union[int, str]
+    else:
+        reveal_type(my_cool_arg)  # N: Revealed type is Union[float, MyCoolint]


### PR DESCRIPTION
mypy can already narrow unions in this case:

def b(a: Union[int, str]):
    if a == 2:
         reveal_type(a)  # int

and it can narrow optionals in this case:

def c(d: Optional[int], e: List[int]):
    if d in e:
        reveal_type(d)  # int

This pr allows it to narrow unions in that case:

def f(g: Union[int, str, bool], h: List[Union[int, str]]):
    if g in h:
        reveal_type(g)  # Union[int, str]
    else:
        reveal_type(g)  # bool

This is useful for (in my case) picking structures out of a tagged
union.

In terms of what still needs to be done
- This is my first time contributing to mypy so I'm sure I've missed
some edge cases
- I'm sure I haven't added quite enough tests - some pointers in that
direction would be quite welcome
- I would really like this to also work if the collection items are
scalar types like List[int] - I'm not sure if that's necessary for this
PR though

And any and all comments on the details or broad structure of the PR are
welcome of course.

Closes #8940