### PR TITLE
Improve stubgenc property type detection

### DIFF
--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -247,6 +247,14 @@ def infer_arg_sig_from_docstring(docstr: str) -> List[ArgSig]:
     return []
 
 
+def infer_ret_type_sig_from_docstring(docstr: str) -> Optional[str]:
+    """Convert signature in form of "(self: TestClass, arg0) -> int" to their return type."""
+    ret = infer_sig_from_docstring("stub" + docstr.strip(), "stub")
+    if ret:
+        return ret[0].ret_type
+    return None
+
+
 def parse_signature(sig: str) -> Optional[Tuple[str,
                                                 List[str],
                                                 List[str]]]:

--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -239,7 +239,7 @@ def infer_sig_from_docstring(docstr: str, name: str) -> Optional[List[FunctionSi
     return [sig for sig in sigs if is_unique_args(sig)]
 
 
-def infer_arg_sig_from_docstring(docstr: str) -> List[ArgSig]:
+def infer_arg_sig_from_anon_docstring(docstr: str) -> List[ArgSig]:
     """Convert signature in form of "(self: TestClass, arg0: str='ada')" to List[TypedArgList]."""
     ret = infer_sig_from_docstring("stub" + docstr, "stub")
     if ret:
@@ -247,7 +247,7 @@ def infer_arg_sig_from_docstring(docstr: str) -> List[ArgSig]:
     return []
 
 
-def infer_ret_type_sig_from_docstring(docstr: str) -> Optional[str]:
+def infer_ret_type_sig_from_anon_docstring(docstr: str) -> Optional[str]:
     """Convert signature in form of "(self: TestClass, arg0) -> int" to their return type."""
     ret = infer_sig_from_docstring("stub" + docstr.strip(), "stub")
     if ret:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -14,7 +14,7 @@ from types import ModuleType
 from mypy.moduleinspect import is_c_module
 from mypy.stubdoc import (
     infer_sig_from_docstring, infer_prop_type_from_docstring, ArgSig,
-    infer_arg_sig_from_docstring, infer_ret_type_sig_from_docstring, FunctionSig
+    infer_arg_sig_from_anon_docstring, infer_ret_type_sig_from_anon_docstring, FunctionSig
 )
 
 
@@ -144,7 +144,7 @@ def generate_c_function_stub(module: ModuleType,
     if (name in ('__new__', '__init__') and name not in sigs and class_name and
             class_name in class_sigs):
         inferred = [FunctionSig(name=name,
-                                args=infer_arg_sig_from_docstring(class_sigs[class_name]),
+                                args=infer_arg_sig_from_anon_docstring(class_sigs[class_name]),
                                 ret_type=ret_type)]  # type: Optional[List[FunctionSig]]
     else:
         docstr = getattr(obj, '__doc__', None)
@@ -154,7 +154,7 @@ def generate_c_function_stub(module: ModuleType,
                 inferred = [FunctionSig(name, args=infer_method_sig(name), ret_type=ret_type)]
             else:
                 inferred = [FunctionSig(name=name,
-                                        args=infer_arg_sig_from_docstring(
+                                        args=infer_arg_sig_from_anon_docstring(
                                             sigs.get(name, '(*args, **kwargs)')),
                                         ret_type=ret_type)]
 
@@ -220,7 +220,7 @@ def generate_c_property_stub(name: str, obj: object, output: List[str], readonly
     def infer_prop_type(docstr: Optional[str]) -> Optional[str]:
         """Infer property type from docstring or docstring signature."""
         if docstr is not None:
-            inferred = infer_ret_type_sig_from_docstring(docstr)
+            inferred = infer_ret_type_sig_from_anon_docstring(docstr)
             if not inferred:
                 inferred = infer_prop_type_from_docstring(docstr)
             return inferred

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -219,10 +219,13 @@ def generate_c_property_stub(name: str, obj: object, output: List[str], readonly
     """
     def infer_prop_type(docstr: Optional[str]) -> Optional[str]:
         """Infer property type from docstring or docstring signature."""
-        inferred = infer_ret_type_sig_from_docstring(docstr)
-        if not inferred:
-            inferred = infer_prop_type_from_docstring(docstr)
-        return inferred
+        if docstr is not None:
+            inferred = infer_ret_type_sig_from_docstring(docstr)
+            if not inferred:
+                inferred = infer_prop_type_from_docstring(docstr)
+            return inferred
+        else:
+            return None
 
     inferred = infer_prop_type(getattr(obj, '__doc__', None))
     if not inferred:

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -25,7 +25,7 @@ from mypy.stubgenc import (
 from mypy.stubdoc import (
     parse_signature, parse_all_signatures, build_signature, find_unique_signatures,
     infer_sig_from_docstring, infer_prop_type_from_docstring, FunctionSig, ArgSig,
-    infer_arg_sig_from_docstring, is_valid_type
+    infer_arg_sig_from_anon_docstring, is_valid_type
 )
 from mypy.moduleinspect import ModuleInspect, InspectError
 
@@ -272,12 +272,12 @@ class StubgenUtilSuite(unittest.TestCase):
              x
             """, 'func'), None)
 
-    def test_infer_arg_sig_from_docstring(self) -> None:
-        assert_equal(infer_arg_sig_from_docstring("(*args, **kwargs)"),
+    def test_infer_arg_sig_from_anon_docstring(self) -> None:
+        assert_equal(infer_arg_sig_from_anon_docstring("(*args, **kwargs)"),
                      [ArgSig(name='*args'), ArgSig(name='**kwargs')])
 
         assert_equal(
-            infer_arg_sig_from_docstring(
+            infer_arg_sig_from_anon_docstring(
                 "(x: Tuple[int, Tuple[str, int], str]=(1, ('a', 2), 'y'), y: int=4)"),
             [ArgSig(name='x', type='Tuple[int,Tuple[str,int],str]', default=True),
              ArgSig(name='y', type='int', default=True)])

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -790,10 +790,9 @@ class StubgencSuite(unittest.TestCase):
                 pass
             attribute = property(get_attribute, doc="")
 
-        output = []
+        output = []  # type: List[str]
         generate_c_property_stub('attribute', TestClass.attribute, output, readonly=True)
         assert_equal(output, ['@property', 'def attribute(self) -> str: ...'])
-
 
     def test_generate_c_type_with_overload_pybind11(self) -> None:
         class TestClass:

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -783,7 +783,7 @@ class StubgencSuite(unittest.TestCase):
     def test_generate_c_property_with_pybind11(self) -> None:
         """Signatures included by PyBind11 inside property.fget are read."""
         class TestClass:
-            def get_attribute(self) -> str:
+            def get_attribute(self) -> None:
                 """
                 (self: TestClass) -> str
                 """


### PR DESCRIPTION
Close #8995

There are two things at play here.
- Read the docstring signature in the first line of C type properties;
- Read the docstring on `property.fget` if the type cannot be inferred from the property doc itself.

The solution is a bit tailored to PyBind, in particular it can read signature that do not have names like `(self: TestType) -> PropType`.