### PR TITLE
[mypyc] translate call_emit primitive ops to CallC

### DIFF
--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -11,7 +11,7 @@ from mypyc.ir.rtypes import (
 from mypyc.primitives.registry import (
     name_ref_op, method_op, binary_op, func_op, custom_op,
     simple_emit, negative_int_emit, call_emit, call_negative_bool_emit,
-    name_emit, c_custom_op, c_method_op, c_function_op
+    name_emit, c_custom_op, c_method_op
 )
 
 
@@ -129,8 +129,7 @@ c_method_op(
     arg_types=[dict_rprimitive],
     return_type=object_rprimitive,
     c_function_name='CPyDict_KeysView',
-    error_kind=ERR_MAGIC
-)
+    error_kind=ERR_MAGIC)
 
 # dict.values()
 c_method_op(
@@ -138,8 +137,7 @@ c_method_op(
     arg_types=[dict_rprimitive],
     return_type=object_rprimitive,
     c_function_name='CPyDict_ValuesView',
-    error_kind=ERR_MAGIC
-)
+    error_kind=ERR_MAGIC)
 
 # dict.items()
 c_method_op(
@@ -147,8 +145,7 @@ c_method_op(
     arg_types=[dict_rprimitive],
     return_type=object_rprimitive,
     c_function_name='CPyDict_ItemsView',
-    error_kind=ERR_MAGIC
-)
+    error_kind=ERR_MAGIC)
 
 # list(dict.keys())
 dict_keys_op = custom_op(

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -11,7 +11,7 @@ from mypyc.ir.rtypes import (
 from mypyc.primitives.registry import (
     name_ref_op, method_op, binary_op, func_op, custom_op,
     simple_emit, negative_int_emit, call_emit, call_negative_bool_emit,
-    name_emit, c_custom_op
+    name_emit, c_custom_op, c_method_op, c_function_op
 )
 
 
@@ -73,12 +73,12 @@ method_op(
     emit=call_negative_bool_emit('CPyDict_UpdateFromAny'))
 
 # dict.get(key, default)
-method_op(
+c_method_op(
     name='get',
     arg_types=[dict_rprimitive, object_rprimitive, object_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyDict_Get'))
+    return_type=object_rprimitive,
+    c_function_name='CPyDict_Get',
+    error_kind=ERR_MAGIC)
 
 # dict.get(key)
 method_op(
@@ -115,6 +115,7 @@ func_op(
     priority=2)
 
 # Generic one-argument dict constructor: dict(obj)
+
 func_op(
     name='builtins.dict',
     arg_types=[object_rprimitive],
@@ -123,30 +124,30 @@ func_op(
     emit=call_emit('CPyDict_FromAny'))
 
 # dict.keys()
-method_op(
+c_method_op(
     name='keys',
     arg_types=[dict_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyDict_KeysView')
+    return_type=object_rprimitive,
+    c_function_name='CPyDict_KeysView',
+    error_kind=ERR_MAGIC
 )
 
 # dict.values()
-method_op(
+c_method_op(
     name='values',
     arg_types=[dict_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyDict_ValuesView')
+    return_type=object_rprimitive,
+    c_function_name='CPyDict_ValuesView',
+    error_kind=ERR_MAGIC
 )
 
 # dict.items()
-method_op(
+c_method_op(
     name='items',
     arg_types=[dict_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyDict_ItemsView')
+    return_type=object_rprimitive,
+    c_function_name='CPyDict_ItemsView',
+    error_kind=ERR_MAGIC
 )
 
 # list(dict.keys())

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -58,8 +58,6 @@ c_function_op(
     return_type=str_rprimitive,
     c_function_name='CPyTagged_Str',
     error_kind=ERR_MAGIC,
-    var_arg_type=None,
-    steals=False,
     priority=2)
 
 # We need a specialization for str on bools also since the int one is wrong...
@@ -69,8 +67,6 @@ c_function_op(
     return_type=str_rprimitive,
     c_function_name='CPyBool_Str',
     error_kind=ERR_MAGIC,
-    var_arg_type=None,
-    steals=False,
     priority=3)
 
 

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -12,8 +12,8 @@ from mypyc.ir.rtypes import (
     str_rprimitive, RType
 )
 from mypyc.primitives.registry import (
-    name_ref_op, binary_op, func_op, custom_op,
-    simple_emit, call_emit, name_emit, c_unary_op, CFunctionDescription
+    name_ref_op, binary_op, custom_op, simple_emit, call_emit, name_emit,
+    c_unary_op, CFunctionDescription, c_function_op
 )
 
 # These int constructors produce object_rprimitives that then need to be unboxed
@@ -28,47 +28,50 @@ name_ref_op('builtins.int',
             is_borrowed=True)
 
 # Convert from a float to int. We could do a bit better directly.
-func_op(
+c_function_op(
     name='builtins.int',
     arg_types=[float_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyLong_FromFloat'),
-    priority=1)
+    return_type=object_rprimitive,
+    c_function_name='CPyLong_FromFloat',
+    error_kind=ERR_MAGIC)
 
 # int(string)
-func_op(
+c_function_op(
     name='builtins.int',
     arg_types=[str_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyLong_FromStr'),
-    priority=1)
+    return_type=object_rprimitive,
+    c_function_name='CPyLong_FromStr',
+    error_kind=ERR_MAGIC)
 
 # int(string, base)
-func_op(
+c_function_op(
     name='builtins.int',
     arg_types=[str_rprimitive, int_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyLong_FromStrWithBase'),
-    priority=1)
+    return_type=object_rprimitive,
+    c_function_name='CPyLong_FromStrWithBase',
+    error_kind=ERR_MAGIC)
 
 # str(n) on ints
-func_op(name='builtins.str',
-        arg_types=[int_rprimitive],
-        result_type=str_rprimitive,
-        error_kind=ERR_MAGIC,
-        emit=call_emit('CPyTagged_Str'),
-        priority=2)
+c_function_op(
+    name='builtins.str',
+    arg_types=[int_rprimitive],
+    return_type=str_rprimitive,
+    c_function_name='CPyTagged_Str',
+    error_kind=ERR_MAGIC,
+    var_arg_type=None,
+    steals=False,
+    priority=2)
 
 # We need a specialization for str on bools also since the int one is wrong...
-func_op(name='builtins.str',
-        arg_types=[bool_rprimitive],
-        result_type=str_rprimitive,
-        error_kind=ERR_MAGIC,
-        emit=call_emit('CPyBool_Str'),
-        priority=3)
+c_function_op(
+    name='builtins.str',
+    arg_types=[bool_rprimitive],
+    return_type=str_rprimitive,
+    c_function_name='CPyBool_Str',
+    error_kind=ERR_MAGIC,
+    var_arg_type=None,
+    steals=False,
+    priority=3)
 
 
 def int_binary_op(op: str, c_func_name: str,

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -8,7 +8,7 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.primitives.registry import (
     name_ref_op, func_op, method_op, custom_op, name_emit,
-    call_emit, call_negative_bool_emit, c_function_op, c_binary_op
+    call_emit, call_negative_bool_emit, c_function_op, c_binary_op, c_method_op
 )
 
 
@@ -117,19 +117,20 @@ list_pop = method_op(
     emit=call_emit('CPyList_Pop'))
 
 # list.count(obj)
-method_op(
+c_method_op(
     name='count',
     arg_types=[list_rprimitive, object_rprimitive],
-    result_type=short_int_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyList_Count'))
+    return_type=short_int_rprimitive,
+    c_function_name='CPyList_Count',
+    error_kind=ERR_MAGIC)
 
 # list * int
-c_binary_op(name='*',
-            arg_types=[list_rprimitive, int_rprimitive],
-            return_type=list_rprimitive,
-            c_function_name='CPySequence_Multiply',
-            error_kind=ERR_MAGIC)
+c_binary_op(
+    name='*',
+    arg_types=[list_rprimitive, int_rprimitive],
+    return_type=list_rprimitive,
+    c_function_name='CPySequence_Multiply',
+    error_kind=ERR_MAGIC)
 
 # int * list
 c_binary_op(name='*',

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -7,7 +7,7 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.primitives.registry import (
     name_ref_op, simple_emit, unary_op, func_op, custom_op, call_emit, name_emit,
-    call_negative_magic_emit
+    call_negative_magic_emit, c_function_op
 )
 
 
@@ -53,11 +53,12 @@ not_implemented_op = name_ref_op(name='builtins.NotImplemented',
                                  is_borrowed=True)
 
 # id(obj)
-func_op(name='builtins.id',
-        arg_types=[object_rprimitive],
-        result_type=int_rprimitive,
-        error_kind=ERR_NEVER,
-        emit=call_emit('CPyTagged_Id'))
+c_function_op(
+    name='builtins.id',
+    arg_types=[object_rprimitive],
+    return_type=int_rprimitive,
+    c_function_name='CPyTagged_Id',
+    error_kind=ERR_NEVER)
 
 # Return the result of obj.__await()__ or obj.__iter__() (if no __await__ exists)
 coro_op = custom_op(name='get_coroutine_obj',

--- a/mypyc/primitives/set_ops.py
+++ b/mypyc/primitives/set_ops.py
@@ -1,8 +1,8 @@
 """Primitive set (and frozenset) ops."""
 
 from mypyc.primitives.registry import (
-    func_op, method_op, binary_op,
-    simple_emit, negative_int_emit, call_emit, call_negative_bool_emit,
+    func_op, method_op, binary_op, simple_emit, negative_int_emit,
+    call_negative_bool_emit, c_function_op, c_method_op
 )
 from mypyc.ir.ops import ERR_MAGIC, ERR_FALSE, ERR_NEVER, EmitterInterface
 from mypyc.ir.rtypes import object_rprimitive, bool_rprimitive, set_rprimitive, int_rprimitive
@@ -19,22 +19,20 @@ new_set_op = func_op(
 )
 
 # set(obj)
-func_op(
+c_function_op(
     name='builtins.set',
     arg_types=[object_rprimitive],
-    result_type=set_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('PySet_New')
-)
+    return_type=set_rprimitive,
+    c_function_name='PySet_New',
+    error_kind=ERR_MAGIC)
 
 # frozenset(obj)
-func_op(
+c_function_op(
     name='builtins.frozenset',
     arg_types=[object_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('PyFrozenSet_New')
-)
+    return_type=object_rprimitive,
+    c_function_name='PyFrozenSet_New',
+    error_kind=ERR_MAGIC)
 
 
 def emit_len(emitter: EmitterInterface, args: List[str], dest: str) -> None:
@@ -64,13 +62,12 @@ binary_op(
 )
 
 # set.remove(obj)
-method_op(
+c_method_op(
     name='remove',
     arg_types=[set_rprimitive, object_rprimitive],
-    result_type=bool_rprimitive,
-    error_kind=ERR_FALSE,
-    emit=call_emit('CPySet_Remove')
-)
+    return_type=bool_rprimitive,
+    c_function_name='CPySet_Remove',
+    error_kind=ERR_FALSE)
 
 # set.discard(obj)
 method_op(
@@ -111,10 +108,9 @@ method_op(
 )
 
 # set.pop()
-method_op(
+c_method_op(
     name='pop',
     arg_types=[set_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('PySet_Pop')
-)
+    return_type=object_rprimitive,
+    c_function_name='PySet_Pop',
+    error_kind=ERR_MAGIC)

--- a/mypyc/primitives/str_ops.py
+++ b/mypyc/primitives/str_ops.py
@@ -7,8 +7,8 @@ from mypyc.ir.rtypes import (
     RType, object_rprimitive, str_rprimitive, bool_rprimitive, int_rprimitive, list_rprimitive
 )
 from mypyc.primitives.registry import (
-    func_op, binary_op, simple_emit, name_ref_op, method_op, call_emit, name_emit,
-    c_method_op, c_binary_op
+    binary_op, simple_emit, name_ref_op, method_op, call_emit, name_emit,
+    c_method_op, c_binary_op, c_function_op
 )
 
 
@@ -20,18 +20,19 @@ name_ref_op('builtins.str',
             is_borrowed=True)
 
 # str(obj)
-func_op(name='builtins.str',
-        arg_types=[object_rprimitive],
-        result_type=str_rprimitive,
-        error_kind=ERR_MAGIC,
-        emit=call_emit('PyObject_Str'))
+c_function_op(
+    name='builtins.str',
+    arg_types=[object_rprimitive],
+    return_type=str_rprimitive,
+    c_function_name='PyObject_Str',
+    error_kind=ERR_MAGIC)
 
 # str1 + str2
-binary_op(op='+',
-          arg_types=[str_rprimitive, str_rprimitive],
-          result_type=str_rprimitive,
-          error_kind=ERR_MAGIC,
-          emit=call_emit('PyUnicode_Concat'))
+c_binary_op(name='+',
+            arg_types=[str_rprimitive, str_rprimitive],
+            return_type=str_rprimitive,
+            c_function_name='PyUnicode_Concat',
+            error_kind=ERR_MAGIC)
 
 # str.join(obj)
 c_method_op(
@@ -43,12 +44,13 @@ c_method_op(
 )
 
 # str[index] (for an int index)
-method_op(
+c_method_op(
     name='__getitem__',
     arg_types=[str_rprimitive, int_rprimitive],
-    result_type=str_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyStr_GetItem'))
+    return_type=str_rprimitive,
+    c_function_name='CPyStr_GetItem',
+    error_kind=ERR_MAGIC
+)
 
 # str.split(...)
 str_split_types = [str_rprimitive, str_rprimitive, int_rprimitive]  # type: List[RType]

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -525,7 +525,7 @@ def lol(x):
     r11, r12 :: int
 L0:
 L1:
-    r0 = id x :: object
+    r0 = CPyTagged_Id(x)
     st = r0
     goto L10
 L2:

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -166,14 +166,14 @@ def f(x, y):
     r2 :: bool
     r3 :: str
 L0:
-    r1 = str x :: object
+    r1 = PyObject_Str(x)
     r2 = bool r1 :: object
     if r2 goto L1 else goto L2 :: bool
 L1:
     r0 = r1
     goto L3
 L2:
-    r3 = str y :: object
+    r3 = PyObject_Str(y)
     r0 = r3
 L3:
     return r0
@@ -216,14 +216,14 @@ def f(x, y):
     r2 :: bool
     r3 :: str
 L0:
-    r1 = str x :: object
+    r1 = PyObject_Str(x)
     r2 = bool r1 :: object
     if r2 goto L2 else goto L1 :: bool
 L1:
     r0 = r1
     goto L3
 L2:
-    r3 = str y :: object
+    r3 = PyObject_Str(y)
     r0 = r3
 L3:
     return r0

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -243,7 +243,7 @@ def A.foo(self, x):
     x :: int
     r0 :: str
 L0:
-    r0 = str x :: int
+    r0 = CPyTagged_Str(x)
     return r0
 def B.foo(self, x):
     self :: __main__.B
@@ -263,7 +263,7 @@ def C.foo(self, x):
     x :: object
     r0 :: int
 L0:
-    r0 = id x :: object
+    r0 = CPyTagged_Id(x)
     return r0
 def C.foo__B_glue(self, x):
     self :: __main__.C

--- a/mypyc/test-data/irbuild-nested.test
+++ b/mypyc/test-data/irbuild-nested.test
@@ -167,7 +167,7 @@ L0:
     r1 = r0.inner
     inner = r1
     r2 = unicode_4 :: static  ('!')
-    r3 = s + r2
+    r3 = PyUnicode_Concat(s, r2)
     return r3
 def c(num):
     num :: float
@@ -206,7 +206,7 @@ L0:
     r1 = r0.inner
     inner = r1
     r2 = unicode_5 :: static  ('?')
-    r3 = s + r2
+    r3 = PyUnicode_Concat(s, r2)
     return r3
 def d(num):
     num :: float

--- a/mypyc/test-data/irbuild-set.test
+++ b/mypyc/test-data/irbuild-set.test
@@ -45,7 +45,7 @@ def f(l):
     l :: list
     r0 :: set
 L0:
-    r0 = set l :: object
+    r0 = PySet_New(l)
     return r0
 
 [case testSetSize]
@@ -126,7 +126,7 @@ L0:
     x = r0
     r1 = 1
     r2 = box(short_int, r1)
-    r3 = x.remove(r2) :: set
+    r3 = CPySet_Remove(x, r2)
     r4 = None
     return x
 
@@ -202,7 +202,7 @@ def f(s):
     r0 :: object
     r1 :: int
 L0:
-    r0 = s.pop() :: set
+    r0 = PySet_Pop(s)
     r1 = unbox(int, r0)
     return r1
 

--- a/mypyc/test-data/irbuild-try.test
+++ b/mypyc/test-data/irbuild-try.test
@@ -75,7 +75,7 @@ L2:
     goto L4
 L3:
     r4 = unicode_2 :: static  ('hi')
-    r5 = str r4 :: object
+    r5 = PyObject_Str(r4)
 L4:
     goto L8
 L5: (handler for L1, L2, L3, L4)


### PR DESCRIPTION
relate mypyc/mypyc#734

This PR translates `PrimitiveOp`s with `call_emit`, which can be represented by `CallC` pretty straightforwardly, to `CallC`. Mostly translating the description.

After this PR and another following PR which handles the ones whose descriptions are explicitly used in irbuild, we'll able to see what's missing for `CallC` by analyzing the remaining primitives.