### PR TITLE
[mypyc] Translate more primitive ops to CallC

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -517,7 +517,7 @@ class IRBuilder:
             self.activate_block(ok_block)
 
             for litem in reversed(post_star_vals):
-                ritem = self.primitive_op(list_pop_last, [iter_list], line)
+                ritem = self.call_c(list_pop_last, [iter_list], line)
                 self.assign(litem, ritem, line)
 
             # Assign the starred value

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -463,7 +463,7 @@ def transform_tuple_expr(builder: IRBuilder, expr: TupleExpr) -> Value:
 def _visit_tuple_display(builder: IRBuilder, expr: TupleExpr) -> Value:
     """Create a list, then turn it into a tuple."""
     val_as_list = _visit_list_display(builder, expr.items, expr.line)
-    return builder.primitive_op(list_tuple_op, [val_as_list], expr.line)
+    return builder.call_c(list_tuple_op, [val_as_list], expr.line)
 
 
 def transform_dict_expr(builder: IRBuilder, expr: DictExpr) -> Value:

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -270,7 +270,7 @@ class LowLevelIRBuilder:
             pos_args_list = self.primitive_op(new_list_op, pos_arg_values, line)
             for star_arg_value in star_arg_values:
                 self.primitive_op(list_extend_op, [pos_args_list, star_arg_value], line)
-            pos_args_tuple = self.primitive_op(list_tuple_op, [pos_args_list], line)
+            pos_args_tuple = self.call_c(list_tuple_op, [pos_args_list], line)
 
         kw_args_dict = self.make_dict(kw_arg_key_value_pairs, line)
 

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -11,7 +11,7 @@ from mypyc.ir.rtypes import (
 from mypyc.primitives.registry import (
     name_ref_op, method_op, binary_op, func_op, custom_op,
     simple_emit, negative_int_emit, call_emit, call_negative_bool_emit,
-    name_emit, c_custom_op, c_method_op
+    name_emit, c_custom_op, c_method_op, c_function_op
 )
 
 
@@ -103,25 +103,24 @@ dict_build_op = c_custom_op(
     return_type=dict_rprimitive,
     c_function_name='CPyDict_Build',
     error_kind=ERR_MAGIC,
-    var_arg_type=object_rprimitive,)
+    var_arg_type=object_rprimitive)
 
 # Construct a dictionary from another dictionary.
-func_op(
+c_function_op(
     name='builtins.dict',
     arg_types=[dict_rprimitive],
-    result_type=dict_rprimitive,
+    return_type=dict_rprimitive,
+    c_function_name='PyDict_Copy',
     error_kind=ERR_MAGIC,
-    emit=call_emit('PyDict_Copy'),
     priority=2)
 
 # Generic one-argument dict constructor: dict(obj)
-
-func_op(
+c_function_op(
     name='builtins.dict',
     arg_types=[object_rprimitive],
-    result_type=dict_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyDict_FromAny'))
+    return_type=dict_rprimitive,
+    c_function_name='CPyDict_FromAny',
+    error_kind=ERR_MAGIC)
 
 # dict.keys()
 c_method_op(

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -49,20 +49,20 @@ new_list_op = custom_op(arg_types=[object_rprimitive],
 
 
 # list[index] (for an integer index)
-list_get_item_op = method_op(
+list_get_item_op = c_method_op(
     name='__getitem__',
     arg_types=[list_rprimitive, int_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyList_GetItem'))
+    return_type=object_rprimitive,
+    c_function_name='CPyList_GetItem',
+    error_kind=ERR_MAGIC)
 
 # Version with no int bounds check for when it is known to be short
-method_op(
+c_method_op(
     name='__getitem__',
     arg_types=[list_rprimitive, short_int_rprimitive],
-    result_type=object_rprimitive,
+    return_type=object_rprimitive,
+    c_function_name='CPyList_GetItemShort',
     error_kind=ERR_MAGIC,
-    emit=call_emit('CPyList_GetItemShort'),
     priority=2)
 
 # This is unsafe because it assumes that the index is a non-negative short integer
@@ -76,13 +76,13 @@ list_get_item_unsafe_op = custom_op(
     emit=call_emit('CPyList_GetItemUnsafe'))
 
 # list[index] = obj
-list_set_item_op = method_op(
+list_set_item_op = c_method_op(
     name='__setitem__',
     arg_types=[list_rprimitive, int_rprimitive, object_rprimitive],
-    steals=[False, False, True],
-    result_type=bool_rprimitive,
+    return_type=bool_rprimitive,
+    c_function_name='CPyList_SetItem',
     error_kind=ERR_FALSE,
-    emit=call_emit('CPyList_SetItem'))
+    steals=[False, False, True])
 
 # list.append(obj)
 list_append_op = method_op(
@@ -101,20 +101,20 @@ list_extend_op = method_op(
     emit=call_emit('CPyList_Extend'))
 
 # list.pop()
-list_pop_last = method_op(
+list_pop_last = c_method_op(
     name='pop',
     arg_types=[list_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyList_PopLast'))
+    return_type=object_rprimitive,
+    c_function_name='CPyList_PopLast',
+    error_kind=ERR_MAGIC)
 
 # list.pop(index)
-list_pop = method_op(
+list_pop = c_method_op(
     name='pop',
     arg_types=[list_rprimitive, int_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPyList_Pop'))
+    return_type=object_rprimitive,
+    c_function_name='CPyList_Pop',
+    error_kind=ERR_MAGIC)
 
 # list.count(obj)
 c_method_op(

--- a/mypyc/primitives/tuple_ops.py
+++ b/mypyc/primitives/tuple_ops.py
@@ -10,17 +10,18 @@ from mypyc.ir.ops import (
     EmitterInterface, ERR_NEVER, ERR_MAGIC
 )
 from mypyc.ir.rtypes import tuple_rprimitive, int_rprimitive, list_rprimitive, object_rprimitive
-from mypyc.primitives.registry import func_op, method_op, custom_op, call_emit, simple_emit
+from mypyc.primitives.registry import (
+    func_op, c_method_op, custom_op, simple_emit, c_function_op
+)
 
 
 # tuple[index] (for an int index)
-tuple_get_item_op = method_op(
+tuple_get_item_op = c_method_op(
     name='__getitem__',
     arg_types=[tuple_rprimitive, int_rprimitive],
-    result_type=object_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('CPySequenceTuple_GetItem'))
-
+    return_type=object_rprimitive,
+    c_function_name='CPySequenceTuple_GetItem',
+    error_kind=ERR_MAGIC)
 
 # Construct a boxed tuple from items: (item1, item2, ...)
 new_tuple_op = custom_op(
@@ -49,18 +50,18 @@ tuple_len_op = func_op(
     emit=emit_len)
 
 # Construct tuple from a list.
-list_tuple_op = func_op(
+list_tuple_op = c_function_op(
     name='builtins.tuple',
     arg_types=[list_rprimitive],
-    result_type=tuple_rprimitive,
+    return_type=tuple_rprimitive,
+    c_function_name='PyList_AsTuple',
     error_kind=ERR_MAGIC,
-    emit=call_emit('PyList_AsTuple'),
     priority=2)
 
 # Construct tuple from an arbitrary (iterable) object.
-func_op(
+c_function_op(
     name='builtins.tuple',
     arg_types=[object_rprimitive],
-    result_type=tuple_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_emit('PySequence_Tuple'))
+    return_type=tuple_rprimitive,
+    c_function_name='PySequence_Tuple',
+    error_kind=ERR_MAGIC)

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -14,7 +14,7 @@ def f(x):
     r2, r3 :: int
 L0:
     r0 = 0
-    r1 = x[r0] :: list
+    r1 = CPyList_GetItemShort(x, r0)
     if is_error(r1) goto L3 (error at f:3) else goto L1
 L1:
     r2 = unbox(int, r1)
@@ -51,7 +51,7 @@ L1:
     r2 = None
     inc_ref z :: int
     r3 = box(int, z)
-    r4 = x.__setitem__(y, r3) :: list
+    r4 = CPyList_SetItem(x, y, r3)
     if not r4 goto L3 (error at f:4) else goto L2 :: bool
 L2:
     r5 = None
@@ -144,7 +144,7 @@ L1:
     r2 = i < l :: int
     if r2 goto L2 else goto L7 :: bool
 L2:
-    r3 = a[i] :: list
+    r3 = CPyList_GetItem(a, i)
     if is_error(r3) goto L8 (error at sum:6) else goto L3
 L3:
     r4 = unbox(int, r3)

--- a/mypyc/test-data/irbuild-any.test
+++ b/mypyc/test-data/irbuild-any.test
@@ -116,7 +116,7 @@ L0:
     r5 = a.__setitem__(r3, r4) :: object
     r6 = box(int, n)
     r7 = l.__setitem__(a, r6) :: object
-    r8 = l.__setitem__(n, a) :: list
+    r8 = CPyList_SetItem(l, n, a)
     r9 = box(int, n)
     r10 = [a, r9]
     r11 = None

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -754,7 +754,7 @@ L0:
     r6 = (r4, r5)
     r7 = 0
     r8 = box(tuple[int, int], r6)
-    r9 = a.__setitem__(r7, r8) :: list
+    r9 = CPyList_SetItem(a, r7, r8)
     r10 = True
     r11 = box(bool, r10)
     y = r11
@@ -1633,7 +1633,7 @@ L0:
     r7 = []
     r8 = box(tuple[int, int, int], r3)
     r9 = r7.extend(r8) :: list
-    r10 = tuple r7 :: list
+    r10 = PyList_AsTuple(r7)
     r11 = PyDict_New()
     r12 = py_call_with_kwargs(r6, r10, r11)
     r13 = unbox(tuple[int, int, int], r12)
@@ -1662,7 +1662,7 @@ L0:
     r8 = [r7]
     r9 = box(tuple[int, int], r3)
     r10 = r8.extend(r9) :: list
-    r11 = tuple r8 :: list
+    r11 = PyList_AsTuple(r8)
     r12 = PyDict_New()
     r13 = py_call_with_kwargs(r6, r11, r12)
     r14 = unbox(tuple[int, int, int], r13)
@@ -2387,7 +2387,7 @@ def g(a, b, c):
     r2, r3 :: int
 L0:
     r0 = a.__getitem__(c)
-    r1 = b[c] :: list
+    r1 = CPyList_GetItem(b, c)
     r2 = unbox(int, r1)
     r3 = r0 + r2 :: int
     return r3
@@ -3261,7 +3261,7 @@ L1:
     unreachable
 L2:
     r2 = 0
-    r3 = r0[r2] :: list
+    r3 = CPyList_GetItemShort(r0, r2)
     r4 = unbox(int, r3)
     return r4
 

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -60,7 +60,7 @@ L0:
     r3 = [c]
     a = r3
     r4 = 0
-    r5 = a[r4] :: list
+    r5 = CPyList_GetItemShort(a, r4)
     r6 = cast(__main__.C, r5)
     d = r6
     r7 = d.x

--- a/mypyc/test-data/irbuild-generics.test
+++ b/mypyc/test-data/irbuild-generics.test
@@ -20,7 +20,7 @@ def g(x):
     r2 :: list
 L0:
     r0 = 0
-    r1 = x[r0] :: list
+    r1 = CPyList_GetItemShort(x, r0)
     r2 = [r1]
     return r2
 def h(x, y):

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -10,7 +10,7 @@ def f(x):
     r2 :: int
 L0:
     r0 = 0
-    r1 = x[r0] :: list
+    r1 = CPyList_GetItemShort(x, r0)
     r2 = unbox(int, r1)
     return r2
 
@@ -26,7 +26,7 @@ def f(x):
     r2 :: list
 L0:
     r0 = 0
-    r1 = x[r0] :: list
+    r1 = CPyList_GetItemShort(x, r0)
     r2 = cast(list, r1)
     return r2
 
@@ -45,10 +45,10 @@ def f(x):
     r5 :: int
 L0:
     r0 = 0
-    r1 = x[r0] :: list
+    r1 = CPyList_GetItemShort(x, r0)
     r2 = cast(list, r1)
     r3 = 1
-    r4 = r2[r3] :: list
+    r4 = CPyList_GetItemShort(r2, r3)
     r5 = unbox(int, r4)
     return r5
 
@@ -67,7 +67,7 @@ L0:
     r0 = 1
     r1 = 0
     r2 = box(short_int, r0)
-    r3 = x.__setitem__(r1, r2) :: list
+    r3 = CPyList_SetItem(x, r1, r2)
     r4 = None
     return r4
 
@@ -188,11 +188,11 @@ L1:
     r3 = r2 < r1 :: short_int
     if r3 goto L2 else goto L4 :: bool
 L2:
-    r4 = l[i] :: list
+    r4 = CPyList_GetItem(l, i)
     r5 = 1
     r6 = box(short_int, r5)
     r7 = r4 += r6
-    r8 = l.__setitem__(i, r7) :: list
+    r8 = CPyList_SetItem(l, i, r7)
 L3:
     r9 = 1
     r10 = r2 + r9 :: short_int

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -197,11 +197,11 @@ L0:
     r0 = 0
     r1 = 0
     r2 = box(short_int, r0)
-    r3 = x.__setitem__(r1, r2) :: list
+    r3 = CPyList_SetItem(x, r1, r2)
     r4 = None
     r5 = 1
     r6 = box(None, r4)
-    r7 = x.__setitem__(r5, r6) :: list
+    r7 = CPyList_SetItem(x, r5, r6)
     r8 = None
     return r8
 
@@ -334,7 +334,7 @@ def f(x):
     r2 :: union[int, str]
 L0:
     r0 = 0
-    r1 = x[r0] :: list
+    r1 = CPyList_GetItemShort(x, r0)
     r2 = cast(union[int, str], r1)
     return r2
 

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -559,7 +559,7 @@ L0:
     a.x = r1; r2 = is_error
     r3 = t[1]
     r4 = r3[0]
-    r5 = l.__setitem__(r0, r4) :: list
+    r5 = CPyList_SetItem(l, r0, r4)
     r6 = r3[1]
     r7 = unbox(int, r6)
     z = r7

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -57,9 +57,9 @@ def f(x):
     r2 :: object
     r3 :: bool
 L0:
-    r0 = tuple x :: list
+    r0 = PyList_AsTuple(x)
     r1 = 1
-    r2 = r0[r1] :: tuple
+    r2 = CPySequenceTuple_GetItem(r0, r1)
     r3 = unbox(bool, r2)
     return r3
 
@@ -96,7 +96,7 @@ L0:
     r3 = box(tuple[int, int], r2)
     t = r3
     r4 = 1
-    r5 = t[r4] :: tuple
+    r5 = CPySequenceTuple_GetItem(t, r4)
     r6 = unbox(int, r5)
     return r6
 
@@ -124,7 +124,7 @@ L0:
     r7 = r5.extend(y) :: list
     r8 = box(short_int, r2)
     r9 = r5.append(r8) :: list
-    r10 = tuple r5 :: list
+    r10 = PyList_AsTuple(r5)
     return r10
 
 [case testTupleFor]
@@ -150,7 +150,7 @@ L1:
     r3 = r1 < r2 :: int
     if r3 goto L2 else goto L4 :: bool
 L2:
-    r4 = xs[r1] :: tuple
+    r4 = CPySequenceTuple_GetItem(xs, r1)
     r5 = cast(str, r4)
     x = r5
 L3:
@@ -185,11 +185,11 @@ L0:
     if b goto L1 else goto L2 :: bool
 L1:
     r0 = 0
-    r1 = nt[r0] :: tuple
+    r1 = CPySequenceTuple_GetItem(nt, r0)
     r2 = unbox(int, r1)
     return r2
 L2:
     r3 = 1
-    r4 = nt[r3] :: tuple
+    r4 = CPySequenceTuple_GetItem(nt, r3)
     r5 = unbox(int, r4)
     return r5

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -630,12 +630,12 @@ def f(a, b):
     r6 :: None
 L0:
     r0 = 0
-    r1 = b[r0] :: list
+    r1 = CPyList_GetItemShort(b, r0)
     r2 = unbox(int, r1)
     dec_ref r1
     r3 = 0
     r4 = box(int, r2)
-    r5 = a.__setitem__(r3, r4) :: list
+    r5 = CPyList_SetItem(a, r3, r4)
     r6 = None
     return r6
 
@@ -693,7 +693,7 @@ L0:
     r1 = [r0]
     a = r1
     r2 = 0
-    r3 = a[r2] :: list
+    r3 = CPyList_GetItemShort(a, r2)
     dec_ref a
     r4 = cast(__main__.C, r3)
     d = r4

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -156,11 +156,15 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(DecRef(self.tt), 'CPyTagged_DecRef(cpy_r_tt.f0.f0);')
 
     def test_list_get_item(self) -> None:
-        self.assert_emit(PrimitiveOp([self.m, self.k], list_get_item_op, 55),
+        self.assert_emit(CallC(list_get_item_op.c_function_name, [self.m, self.k],
+                               list_get_item_op.return_type, list_get_item_op.steals,
+                               list_get_item_op.error_kind, 55),
                          """cpy_r_r0 = CPyList_GetItem(cpy_r_m, cpy_r_k);""")
 
     def test_list_set_item(self) -> None:
-        self.assert_emit(PrimitiveOp([self.l, self.n, self.o], list_set_item_op, 55),
+        self.assert_emit(CallC(list_set_item_op.c_function_name, [self.l, self.n, self.o],
+                               list_set_item_op.return_type, list_set_item_op.steals,
+                               list_set_item_op.error_kind, 55),
                          """cpy_r_r0 = CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o);""")
 
     def test_box(self) -> None:


### PR DESCRIPTION
related mypyc/mypyc#734

Mainly translate primitive ops that use `call_emit` and with their descriptions used elsewhere. Int ops are intentionally left out because they make a lot of changes to IR tests, therefore making them in a separate PR.