### PR TITLE
Exclude cache directories from backups using CACHEDIR.TAG

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -267,6 +267,7 @@ def _build(sources: List[BuildSource],
             reports.finish()
         if not cache_dir_existed and os.path.isdir(options.cache_dir):
             add_catch_all_gitignore(options.cache_dir)
+            exclude_from_backups(options.cache_dir)
 
 
 def default_data_dir() -> str:
@@ -1110,6 +1111,22 @@ def add_catch_all_gitignore(target_dir: str) -> None:
         with open(gitignore, "x") as f:
             print("# Automatically created by mypy", file=f)
             print("*", file=f)
+    except FileExistsError:
+        pass
+
+
+def exclude_from_backups(target_dir: str) -> None:
+    """Exclude the directory from various archives and backups supporting CACHEDIR.TAG.
+
+    If the CACHEDIR.TAG file exists the function is a no-op.
+    """
+    cachedir_tag = os.path.join(target_dir, "CACHEDIR.TAG")
+    try:
+        with open(cachedir_tag, "x") as f:
+            f.write("""Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag automtically created by mypy.
+# For information about cache directory tags see https://bford.info/cachedir/
+""")
     except FileExistsError:
         pass
 

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -273,6 +273,10 @@ class TypeCheckSuite(DataSuite):
             raise AssertionError("cache data discrepancy %s != %s" %
                                  (missing_paths, busted_paths))
         assert os.path.isfile(os.path.join(manager.options.cache_dir, ".gitignore"))
+        cachedir_tag = os.path.join(manager.options.cache_dir, "CACHEDIR.TAG")
+        assert os.path.isfile(cachedir_tag)
+        with open(cachedir_tag) as f:
+            assert f.read().startswith("Signature: 8a477f597d28d172789f06886806bc55")
 
     def find_error_message_paths(self, a: List[str]) -> Set[str]:
         hits = set()

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3722,6 +3722,9 @@ import b
 {"snapshot": {"__main__": "a7c958b001a45bd6a2a320f4e53c4c16", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "c532c89da517a4b779bcf7a964478d67"}, "deps_meta": {"@root": {"path": "@root.deps.json", "mtime": 0}, "__main__": {"path": "__main__.deps.json", "mtime": 0}, "a": {"path": "a.deps.json", "mtime": 0}, "b": {"path": "b.deps.json", "mtime": 0}, "builtins": {"path": "builtins.deps.json", "mtime": 0}}}
 [file ../.mypy_cache/.gitignore]
 # Another hack to not trigger a .gitignore creation failure "false positive"
+[file ../.mypy_cache/CACHEDIR.TAG]
+Signature: 8a477f597d28d172789f06886806bc55
+# Another another hack to not trigger a CACHEDIR.TAG creation failure "false positive"
 [file b.py.2]
 # uh
 -- Every file should get reloaded, since the cache was invalidated


### PR DESCRIPTION
This helps to prevent bloating backups with caches.

See https://bford.info/cachedir/ for more information about the
specification – it's supported by Borg, restic, GNU Tar and other
solutions.