### PR TITLE
Add changes to ignore all vim temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,11 @@ dmypy.json
 
 # IDEs
 .idea
-*.swp
 .vscode
+
+# vim temporary files
+.*.sw?
+*.sw?
 
 # Operating Systems
 .DS_Store


### PR DESCRIPTION
Vim creates a number of temporary files but the current settings in .gitignore only ignores ```.swp``` files.
- with this change, all vim created temporary files prefixed by ```sw```  will be ignored
- examples of potential files; swn, swo, swp, etc.