### PR TITLE
Enforce annotation when inferred item in list, dict or set is object type

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -908,7 +908,7 @@ def write_deps_cache(rdeps: Dict[str, Dict[str, Set[str]]],
             hash = st.meta.hash
         meta_snapshot[id] = hash
 
-    meta = {'snapshot': meta_snapshot, 'deps_meta': fg_deps_meta}
+    meta = {'snapshot': meta_snapshot, 'deps_meta': fg_deps_meta}  # type: Dict[str, object]
 
     if not metastore.write(DEPS_META_FILE, json.dumps(meta)):
         manager.log("Error writing fine-grained deps meta JSON file {}".format(DEPS_META_FILE))

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2146,7 +2146,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 rvalue_type = self.expr_checker.accept(rvalue)
                 if not inferred.is_final:
                     rvalue_type = remove_instance_last_known_values(rvalue_type)
-                    self.check_forbidden_inference_types(inferred, rvalue, rvalue_type)
+                    if self.options.check_need_type_annotation:
+                        self.check_forbidden_inference_types(inferred, rvalue, rvalue_type)
                 self.infer_variable_type(inferred, lvalue, rvalue_type, rvalue)
 
     def check_forbidden_inference_types(self, var: Var, rvalue: Context,

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -621,8 +621,8 @@ def process_options(args: List[str],
     forbidden_inference_group = parser.add_argument_group(
         title='Handling forbidden inference related type checks',
         description="Warn when infered type is List[object], Set[Object] or Dict[*, Object].")
-    add_invertible_flag('--suppress-need-type-annotation-errors', default=True,
-                        dest='check_need_type_annotation',
+    add_invertible_flag('--warn-implicit-object-collection', default=False,
+                        dest='warn_implicit_object_collection',
                         help='Suppress "Need type annotation" errors',
                         group=forbidden_inference_group)
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -618,6 +618,13 @@ def process_options(args: List[str],
         '--enable-error-code', metavar='NAME', action='append', default=[],
         help="Enable a specific error code"
     )
+    forbidden_inference_group = parser.add_argument_group(
+        title='Handling forbidden inference related type checks',
+        description="Warn when infered type is List[object], Set[Object] or Dict[*, Object].")
+    add_invertible_flag('--suppress-need-type-annotation-errors', default=True,
+                        dest='check_need_type_annotation',
+                        help='Suppress "Need type annotation" errors',
+                        group=forbidden_inference_group)
 
     error_group = parser.add_argument_group(
         title='Configuring error messages',

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -139,6 +139,9 @@ class Options:
         # Apply strict None checking
         self.strict_optional = True
 
+        # Testing new flag
+        self.check_need_type_annotation = True
+
         # Show "note: In function "foo":" messages.
         self.show_error_context = False
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -133,14 +133,15 @@ class Options:
         # Warn about unused '[mypy-<pattern>] config sections
         self.warn_unused_configs = False
 
+        # Suppress "Need type annotation" errors when inferred
+        # item in list, dict or set is object type
+        self.warn_implicit_object_collection = True
+
         # Files in which to ignore all non-fatal errors
         self.ignore_errors = False
 
         # Apply strict None checking
         self.strict_optional = True
-
-        # Testing new flag
-        self.check_need_type_annotation = True
 
         # Show "note: In function "foo":" messages.
         self.show_error_context = False

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -153,7 +153,7 @@ class StrConv(NodeVisitor[str]):
         return self.dump(a, o)
 
     def visit_class_def(self, o: 'mypy.nodes.ClassDef') -> str:
-        a = [o.name, o.defs.body]
+        a = [o.name, o.defs.body]  # type: List[object]
         # Display base types unless they are implicitly just builtins.object
         # (in this case base_type_exprs is empty).
         if o.base_type_exprs:

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -670,7 +670,7 @@ class SuggestionEngine:
             'path': path,
             'func_name': func_name,
             'samples': 0
-        }
+            }  # type: Dict[str, object]
         return json.dumps([obj], sort_keys=True)
 
     def pyannotate_signature(

--- a/test-data/stdlib-samples/3.2/test/test_pprint.py
+++ b/test-data/stdlib-samples/3.2/test/test_pprint.py
@@ -6,7 +6,7 @@ import random
 import collections
 import itertools
 
-from typing import List, Any, Dict, Tuple, cast, Callable
+from typing import List, Any, Dict, Tuple, cast, Callable, Union
 
 # list, tuple and dict subclasses that do or don't overwrite __repr__
 class list2(list):
@@ -175,7 +175,7 @@ class QueryTestCase(unittest.TestCase):
     def test_nested_indentations(self) -> None:
         o1 = list(range(10))
         o2 = {'first':1, 'second':2, 'third':3}
-        o = [o1, o2]
+        o = [o1, o2]  # type: List[object]
         expected = """\
 [   [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
     {   'first': 1,
@@ -439,7 +439,7 @@ class QueryTestCase(unittest.TestCase):
     def test_depth(self) -> None:
         nested_tuple = (1, (2, (3, (4, (5, 6)))))
         nested_dict = {1: {2: {3: {4: {5: {6: 6}}}}}}
-        nested_list = [1, [2, [3, [4, [5, [6, []]]]]]]
+        nested_list = [1, [2, [3, [4, [5, [6, []]]]]]]  # type: List[Union[int, List]]
         self.assertEqual(pprint.pformat(nested_tuple), repr(nested_tuple))
         self.assertEqual(pprint.pformat(nested_dict), repr(nested_dict))
         self.assertEqual(pprint.pformat(nested_list), repr(nested_list))

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6394,6 +6394,7 @@ class Child(Base):  # E: Too few arguments for "__init_subclass__" of "Base"
 [builtins fixtures/object_with_init_subclass.pyi]
 
 [case testInitSubclassTooFewArgs2]
+from typing import Dict, Union
 class Base:
     default_name: str
 
@@ -6402,7 +6403,7 @@ class Base:
         cls.default_name = default_name
         return
 # TODO implement this, so that no error is raised?
-d = {"default_name": "abc", "thing": 0}
+d: Dict[str, Union[str, int]] = {"default_name": "abc", "thing": 0}
 class Child(Base, **d):  # E: Too few arguments for "__init_subclass__" of "Base"
     pass
 [builtins fixtures/object_with_init_subclass.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2421,16 +2421,18 @@ def g() -> List[Union[str, int]]:
 [case testInferredTypeIsObjectMismatch]
 from typing import Union, Dict, List
 def f() -> Dict[str, Union[str, int]]:
-    x = {'a': 'a', 'b': 2}
-    return x # E: Incompatible return value type (got "Dict[str, object]", expected "Dict[str, Union[str, int]]")
+    x = {'a': 'a', 'b': 2}  # E: Need type annotation for 'x' \
+                            # N: Suggested annotation: Dict[str, Any] or Dict[str, Union[int, str]]
+    return x  # E: Incompatible return value type (got "Dict[str, object]", expected "Dict[str, Union[str, int]]")
 
 def g() -> Dict[str, Union[str, int]]:
     x: Dict[str, Union[str, int]] = {'a': 'a', 'b': 2}
     return x
 
 def h() -> List[Union[str, int]]:
-    x = ['a', 2]
-    return x # E: Incompatible return value type (got "List[object]", expected "List[Union[str, int]]")
+    x = ['a', 2]  # E: Need type annotation for 'x' \
+                  # N: Suggested annotation: List[Any] or List[Union[int, str]]
+    return x  # E: Incompatible return value type (got "List[object]", expected "List[Union[str, int]]")
 
 def i() -> List[Union[str, int]]:
     x: List[Union[str, int]] = ['a', 2]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -584,7 +584,8 @@ my_dict = {
 }
 
 [file mod1_private.py.2]
-my_dict = {
+from typing import Dict, List, Union
+my_dict: Dict[str, List[Union[int, str]]] = {
     'a': [1, 2, 3],
     'b': [4, 5, 'a']
 }

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3200,3 +3200,10 @@ x = {'a': 1, 'b': 'two'}  # E: Need type annotation for 'x' \
 
 y = {'a': 1, 'two': 2}
 [builtins fixtures/dict.pyi]
+
+[case testexplicitAnnotationNeededForSet]
+x = {'a', 1}  # E: Need type annotation for 'x' \
+              # N: Suggested annotation: Set[Any] or Set[Union[int, str]]
+
+y = {'a', 2, object()}
+[builtins fixtures/set.pyi]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3209,7 +3209,7 @@ y = {'a', 2, object()}
 [builtins fixtures/set.pyi]
 
 [case testSuppressNeedTypeAnnotaionFlag]
-# flags: --suppress-need-type-annotation-errors
+# flags: --no-warn-implicit-object-collection
 
 x1 = [1, 'two', 3.5]
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3207,3 +3207,9 @@ x = {'a', 1}  # E: Need type annotation for 'x' \
 
 y = {'a', 2, object()}
 [builtins fixtures/set.pyi]
+
+[case testSuppressNeedTypeAnnotaionFlag]
+# flags: --suppress-need-type-annotation-errors
+
+x1 = [1, 'two', 3.5]
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3176,3 +3176,27 @@ reveal_type(f(lambda: 1))  # N: Revealed type is 'builtins.int*'
 def g() -> None: pass
 
 reveal_type(f(g))  # N: Revealed type is 'None'
+
+-- Tests for checking if annotation is needed
+-- --------------
+
+[case testexplicitAnnotationNeededForLists]
+x = [1, 'two', 3.5]  # E: Need type annotation for 'x' \
+                     # N: Suggested annotation: List[Any] or List[Union[float, int, str]]
+
+y = [2, 'three', object()]
+
+class C:
+    def __init__(self) -> None:
+        self.x = [object()]
+
+c: C
+c.x = [1, 'two']
+[builtins fixtures/list.pyi]
+
+[case testexplicitAnnotationNeededForDict]
+x = {'a': 1, 'b': 'two'}  # E: Need type annotation for 'x' \
+                          # N: Suggested annotation: Dict[str, Any] or Dict[str, Union[int, str]]
+
+y = {'a': 1, 'two': 2}
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -1475,7 +1475,8 @@ b = [1, 1, 1]
 c: List[Literal[1, 2, 3]] = [1, 2, 3]
 d = [1, 2, 3]
 e: List[Literal[1, "x"]] = [1, "x"]
-f = [1, "x"]
+f = [1, "x"] # E: Need type annotation for 'f' \
+             # N: Suggested annotation: List[Any] or List[Union[int, str]]
 g: List[List[List[Literal[1, 2, 3]]]] = [[[1, 2, 3], [3]]]
 h: List[Literal[1]] = []
 
@@ -1495,7 +1496,8 @@ lit3: Literal["foo"]
 arr1 = [lit1, lit1, lit1]
 arr2 = [lit1, lit2]
 arr3 = [lit1, 4, 5]
-arr4 = [lit1, lit2, lit3]
+arr4 = [lit1, lit2, lit3] # E: Need type annotation for 'arr4' \
+                          # N: Suggested annotation: List[Any]
 arr5 = [object(), lit1]
 
 reveal_type(arr1)  # N: Revealed type is 'builtins.list[Literal[1]]'

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -527,8 +527,10 @@ from typing import Mapping
 Cell = TypedDict('Cell', {'value': int})
 left = Cell(value=42)
 right = 42
-joined1 = [left, right]
-joined2 = [right, left]
+joined1 = [left, right]  # E: Need type annotation for 'joined1' \
+                         # N: Suggested annotation: List[Any]
+joined2 = [right, left]  # E: Need type annotation for 'joined2' \
+                         # N: Suggested annotation: List[Any]
 reveal_type(joined1)  # N: Revealed type is 'builtins.list[builtins.object*]'
 reveal_type(joined2)  # N: Revealed type is 'builtins.list[builtins.object*]'
 [builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes #3816 

- Fixes failing tests from PR 6792
- Adds suggested annotation note
- Adds annotation checker for sets
- Adds tests