### PR TITLE
Use absolute path when checking source duplication error

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1699,6 +1699,7 @@ class State:
     order = None  # type: int  # Order in which modules were encountered
     id = None  # type: str  # Fully qualified module name
     path = None  # type: Optional[str]  # Path to module source
+    abspath = None  # type: Optional[str]  # Absolute path to module source
     xpath = None  # type: str  # Path or '<string>'
     source = None  # type: Optional[str]  # Module source code
     source_hash = None  # type: Optional[str]  # Hash calculated based on the source code
@@ -1800,6 +1801,8 @@ class State:
             if follow_imports == 'silent':
                 self.ignore_all = True
         self.path = path
+        if path:
+            self.abspath = os.path.abspath(path)
         self.xpath = path or '<string>'
         if path and source is None and self.manager.fscache.isdir(path):
             source = ''
@@ -2758,7 +2761,7 @@ def load_graph(sources: List[BuildSource], manager: BuildManager,
 
     # Note: Running this each time could be slow in the daemon. If it's a problem, we
     # can do more work to maintain this incrementally.
-    seen_files = {os.path.abspath(st.path): st for st in graph.values() if st.path}
+    seen_files = {st.abspath: st for st in graph.values() if st.path}
 
     # Collect dependencies.  We go breadth-first.
     # More nodes might get added to new as we go, but that's fine.

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2811,11 +2811,16 @@ def load_graph(sources: List[BuildSource], manager: BuildManager,
 
                         if seen_state is None:
                             if os.path.isabs(newst_path):
-                                newst_path = os.path.relpath(newst_path)
+                                try:
+                                    newst_path = os.path.relpath(newst_path)
+                                except ValueError:
+                                    # Ignore when newst_path does not start with os.curdir
+                                    pass
+                                else:
+                                    seen_state = seen_files.get(newst_path)
                             else:
                                 newst_path = os.path.abspath(newst_path)
-
-                            seen_state = seen_files.get(newst_path)
+                                seen_state = seen_files.get(newst_path)
 
                         if seen_state is not None:
                             manager.errors.report(

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2811,16 +2811,11 @@ def load_graph(sources: List[BuildSource], manager: BuildManager,
 
                         if seen_state is None:
                             if os.path.isabs(newst_path):
-                                try:
-                                    newst_path = os.path.relpath(newst_path)
-                                except ValueError:
-                                    # Ignore when newst_path does not start with os.curdir
-                                    pass
-                                else:
-                                    seen_state = seen_files.get(newst_path)
+                                newst_path = os.path.relpath(newst_path)
                             else:
                                 newst_path = os.path.abspath(newst_path)
-                                seen_state = seen_files.get(newst_path)
+
+                            seen_state = seen_files.get(newst_path)
 
                         if seen_state is not None:
                             manager.errors.report(

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2758,7 +2758,7 @@ def load_graph(sources: List[BuildSource], manager: BuildManager,
 
     # Note: Running this each time could be slow in the daemon. If it's a problem, we
     # can do more work to maintain this incrementally.
-    seen_files = {os.path.abspath(st.path): st for st in graph.values() if st.path}
+    seen_files = {st.path: st for st in graph.values() if st.path}
 
     # Collect dependencies.  We go breadth-first.
     # More nodes might get added to new as we go, but that's fine.
@@ -2806,17 +2806,26 @@ def load_graph(sources: List[BuildSource], manager: BuildManager,
                         st.suppress_dependency(dep)
                 else:
                     if newst.path:
-                        newst_path = os.path.abspath(newst.path)
+                        newst_path = newst.path
+                        seen_state = seen_files.get(newst_path)
 
-                        if newst_path in seen_files:
+                        if seen_state is None:
+                            if os.path.isabs(newst_path):
+                                newst_path = os.path.relpath(newst_path)
+                            else:
+                                newst_path = os.path.abspath(newst_path)
+
+                            seen_state = seen_files.get(newst_path)
+
+                        if seen_state is not None:
                             manager.errors.report(
                                 -1, 0,
                                 "Source file found twice under different module names: "
-                                "'{}' and '{}'".format(seen_files[newst_path].id, newst.id),
+                                "'{}' and '{}'".format(seen_state.id, newst.id),
                                 blocker=True)
                             manager.errors.raise_error()
 
-                        seen_files[newst_path] = newst
+                        seen_files[newst.path] = newst
 
                     assert newst.id not in graph, newst.id
                     graph[newst.id] = newst


### PR DESCRIPTION
closes #9058 

I updated both `seen_files` and `newst` to use an absolute path to fix the problem.