### PR TITLE
Fix internal error on list/dict comprehension with walrus operator in global scope

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4550,7 +4550,10 @@ class SemanticAnalyzer(NodeVisitor[None],
                             # The caller of the comprehension is in the global space.
                             names = self.globals
                         else:
-                            names = cast(SymbolTable, self.locals[-1 - i])
+                            names_candidate = self.locals[-1 - i]
+                            assert names_candidate is not None, \
+                                "Escaping comprehension from invalid scope"
+                            names = names_candidate
                         break
                 else:
                     assert False, "Should have at least one non-comprehension scope"

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4542,9 +4542,15 @@ class SemanticAnalyzer(NodeVisitor[None],
         if self.is_func_scope():
             assert self.locals[-1] is not None
             if escape_comprehensions:
+                assert len(self.locals) == len(self.is_comprehension_stack)
+                # Retrieve the symbol table from the enclosing non-comprehension scope.
                 for i, is_comprehension in enumerate(reversed(self.is_comprehension_stack)):
                     if not is_comprehension:
-                        names = self.locals[-1 - i]
+                        if i == len(self.locals) - 1:  # The last iteration.
+                            # The caller of the comprehension is in the global space.
+                            names = self.globals
+                        else:
+                            names = cast(SymbolTable, self.locals[-1 - i])
                         break
                 else:
                     assert False, "Should have at least one non-comprehension scope"

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -218,6 +218,19 @@ def f(x: int = (c := 4)) -> int:
     reveal_type(filtered_data)  # N: Revealed type is 'builtins.list[builtins.int*]'
     reveal_type(y3)  # N: Revealed type is 'builtins.int'
 
+    d = {'a': (a2 := 1), 'b': a2 + 1, 'c': a2 + 2}
+    reveal_type(d)  # N: Revealed type is 'builtins.dict[builtins.str*, builtins.int*]'
+    reveal_type(a2)  # N: Revealed type is 'builtins.int'
+
+    d2 = {(prefix := 'key_') + 'a': (start_val := 1), prefix + 'b': start_val + 1, prefix + 'c': start_val + 2}
+    reveal_type(d2)  # N: Revealed type is 'builtins.dict[builtins.str*, builtins.int*]'
+    reveal_type(prefix)  # N: Revealed type is 'builtins.str'
+    reveal_type(start_val)  # N: Revealed type is 'builtins.int'
+
+    filtered_dict = {k: new_v for k, v in [('a', 1), ('b', 2), ('c', 3)] if (new_v := v + 1) == 2}
+    reveal_type(filtered_dict)  # N: Revealed type is 'builtins.dict[builtins.str*, builtins.int*]'
+    reveal_type(new_v)  # N: Revealed type is 'builtins.int'
+
     # https://www.python.org/dev/peps/pep-0572/#exceptional-cases
     (y4 := 3)
     reveal_type(y4)  # N: Revealed type is 'builtins.int'

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -201,6 +201,10 @@ while b := "x":
 l = [y2 := 1, y2 + 2, y2 + 3]
 reveal_type(y2)  # N: Revealed type is 'builtins.int'
 reveal_type(l)  # N: Revealed type is 'builtins.list[builtins.int*]'
+ 
+filtered_data = [y3 for x in l if (y3 := a) is not None]
+reveal_type(filtered_data)  # N: Revealed type is 'builtins.list[builtins.int*]'
+reveal_type(y3)  # N: Revealed type is 'builtins.int'
 
 d = {'a': (a2 := 1), 'b': a2 + 1, 'c': a2 + 2}
 reveal_type(d)  # N: Revealed type is 'builtins.dict[builtins.str*, builtins.int*]'
@@ -210,6 +214,10 @@ d2 = {(prefix := 'key_') + 'a': (start_val := 1), prefix + 'b': start_val + 1, p
 reveal_type(d2)  # N: Revealed type is 'builtins.dict[builtins.str*, builtins.int*]'
 reveal_type(prefix)  # N: Revealed type is 'builtins.str'
 reveal_type(start_val)  # N: Revealed type is 'builtins.int'
+
+filtered_dict = {k: new_v for k, v in [('a', 1), ('b', 2), ('c', 3)] if (new_v := v + 1) == 2}
+reveal_type(filtered_dict)  # N: Revealed type is 'builtins.dict[builtins.str*, builtins.int*]'
+reveal_type(new_v)  # N: Revealed type is 'builtins.int'
 
 def f(x: int = (c := 4)) -> int:
     if a := 2:

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -198,6 +198,19 @@ if a := 2:
 while b := "x":
     reveal_type(b)  # N: Revealed type is 'builtins.str'
 
+l = [y2 := 1, y2 + 2, y2 + 3]
+reveal_type(y2)  # N: Revealed type is 'builtins.int'
+reveal_type(l)  # N: Revealed type is 'builtins.list[builtins.int*]'
+
+d = {'a': (a2 := 1), 'b': a2 + 1, 'c': a2 + 2}
+reveal_type(d)  # N: Revealed type is 'builtins.dict[builtins.str*, builtins.int*]'
+reveal_type(a2)  # N: Revealed type is 'builtins.int'
+
+d2 = {(prefix := 'key_') + 'a': (start_val := 1), prefix + 'b': start_val + 1, prefix + 'c': start_val + 2}
+reveal_type(d2)  # N: Revealed type is 'builtins.dict[builtins.str*, builtins.int*]'
+reveal_type(prefix)  # N: Revealed type is 'builtins.str'
+reveal_type(start_val)  # N: Revealed type is 'builtins.int'
+
 def f(x: int = (c := 4)) -> int:
     if a := 2:
         reveal_type(a)  # N: Revealed type is 'builtins.int'

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -338,6 +338,28 @@ def check_narrow(x: Optional[int], s: List[int]) -> None:
     if isinstance((y := x), int):
         reveal_type(y)  # N: Revealed type is 'builtins.int'
 
+class AssignmentExpressionsClass:
+    x = (y := 1) + (z := 2)
+    reveal_type(z)  # N: Revealed type is 'builtins.int'
+
+    l = [x2 := 1, 2, 3]
+    reveal_type(x2)  # N: Revealed type is 'builtins.int'
+
+    def __init__(self) -> None:
+        reveal_type(self.z)  # N: Revealed type is 'builtins.int'
+
+        l = [z2 := 1, z2 + 2, z2 + 3]
+        reveal_type(z2)  # N: Revealed type is 'builtins.int'
+        reveal_type(l)  # N: Revealed type is 'builtins.list[builtins.int*]'
+
+        filtered_data = [z3 for x in l if (z3 := 1) is not None]
+        reveal_type(filtered_data)  # N: Revealed type is 'builtins.list[builtins.int*]'
+        reveal_type(z3)  # N: Revealed type is 'builtins.int'
+
+# Assignment expressions from inside the class should not escape the class scope.
+reveal_type(x2)  # E: Name 'x2' is not defined  # N: Revealed type is 'Any'
+reveal_type(z2)  # E: Name 'z2' is not defined  # N: Revealed type is 'Any'
+
 [builtins fixtures/isinstancelist.pyi]
 
 [case testWalrusPartialTypes]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/8986

The reported issue is for list comprehensions involving assignment expressions, though I noticed that dictionary comprehensions are also impacted.

```
# mwe.py
lst = [1, 2, 3, 4]
processed_list = [e for elt in lst if (e := elt - 1) > 1]

dct = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
processed_dict = {k: new_v for k, v in dct.items() if (new_v := v - 1) > 1
```

On the other hand, the same declarations _inside_ a function pass:
```
# valid_comprehensions.py
def calling_function() -> None:
    lst = [1, 2, 3, 4]
    processed_list = [e for elt in lst if (e := elt - 1) > 1]
    reveal_type(processed_list)

    dct = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
    processed_dict = {k: new_v for k, v in dct.items() if (new_v := v - 1) > 1}
    reveal_type(processed_dict)
```

This tipped me off to it being related to the special logic added in #6899 to [store the variables in the scope of the comprehension's caller](https://github.com/python/mypy/pull/6899/files#diff-ebbe3135b7d21c5fa8783a4d0d0ccd48R4448), which I believe can benefit from special treatment for the edge case of the caller being in the global scope. That's the approach that I took, though it's my first contribution to MyPy so another approach may be more appropriate.

I added regression tests for these cases, but I also added some tests that were already passing. I've kept them in separate commits (with CI triggered separately) to be clear about which ones are being addressed by this PR!