### PR TITLE
[mypyc] Support argument reordering in CallC

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -697,6 +697,10 @@ class LowLevelIRBuilder:
             arg = args[i]
             arg = self.coerce(arg, formal_type, line)
             coerced.append(arg)
+        # reorder args if necessary
+        if desc.ordering is not None:
+            assert desc.var_arg_type is None
+            coerced = [coerced[i] for i in desc.ordering]
         # coerce any var_arg
         var_arg_idx = -1
         if desc.var_arg_type is not None:

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -51,6 +51,7 @@ CFunctionDescription = NamedTuple(
                               ('c_function_name', str),
                               ('error_kind', int),
                               ('steals', StealsDescription),
+                              ('ordering', Optional[List[int]]),
                               ('priority', int)])
 
 # A description for C load operations including LoadGlobal and LoadAddress
@@ -352,6 +353,7 @@ def c_method_op(name: str,
                 error_kind: int,
                 var_arg_type: Optional[RType] = None,
                 truncated_type: Optional[RType] = None,
+                ordering: Optional[List[int]] = None,
                 steals: StealsDescription = False,
                 priority: int = 1) -> CFunctionDescription:
     """Define a c function call op that replaces a method call.
@@ -368,12 +370,15 @@ def c_method_op(name: str,
         truncated_type: type to truncated to(See Truncate for info)
                         if it's defined both return_type and it should be non-referenced
                         integer types or bool type
+        ordering: optional ordering of the arguments, if defined,
+                  reorders the arguments accordingly.
+                  should never be used together with var_arg_type
         steals: description of arguments that this steals (ref count wise)
         priority: if multiple ops match, the one with the highest priority is picked
     """
     ops = c_method_call_ops.setdefault(name, [])
     desc = CFunctionDescription(name, arg_types, return_type, var_arg_type, truncated_type,
-                                c_function_name, error_kind, steals, priority)
+                                c_function_name, error_kind, steals, ordering, priority)
     ops.append(desc)
     return desc
 
@@ -385,6 +390,7 @@ def c_function_op(name: str,
                   error_kind: int,
                   var_arg_type: Optional[RType] = None,
                   truncated_type: Optional[RType] = None,
+                  ordering: Optional[List[int]] = None,
                   steals: StealsDescription = False,
                   priority: int = 1) -> CFunctionDescription:
     """Define a c function call op that replaces a function call.
@@ -399,7 +405,7 @@ def c_function_op(name: str,
     """
     ops = c_function_ops.setdefault(name, [])
     desc = CFunctionDescription(name, arg_types, return_type, var_arg_type, truncated_type,
-                                c_function_name, error_kind, steals, priority)
+                                c_function_name, error_kind, steals, ordering, priority)
     ops.append(desc)
     return desc
 
@@ -411,6 +417,7 @@ def c_binary_op(name: str,
                 error_kind: int,
                 var_arg_type: Optional[RType] = None,
                 truncated_type: Optional[RType] = None,
+                ordering: Optional[List[int]] = None,
                 steals: StealsDescription = False,
                 priority: int = 1) -> CFunctionDescription:
     """Define a c function call op for a binary operation.
@@ -422,7 +429,7 @@ def c_binary_op(name: str,
     """
     ops = c_binary_ops.setdefault(name, [])
     desc = CFunctionDescription(name, arg_types, return_type, var_arg_type, truncated_type,
-                            c_function_name, error_kind, steals, priority)
+                            c_function_name, error_kind, steals, ordering, priority)
     ops.append(desc)
     return desc
 
@@ -433,13 +440,14 @@ def c_custom_op(arg_types: List[RType],
                 error_kind: int,
                 var_arg_type: Optional[RType] = None,
                 truncated_type: Optional[RType] = None,
+                ordering: Optional[List[int]] = None,
                 steals: StealsDescription = False) -> CFunctionDescription:
     """Create a one-off CallC op that can't be automatically generated from the AST.
 
     Most arguments are similar to c_method_op().
     """
     return CFunctionDescription('<custom>', arg_types, return_type, var_arg_type, truncated_type,
-                            c_function_name, error_kind, steals, 0)
+                            c_function_name, error_kind, steals, ordering, 0)
 
 
 def c_unary_op(name: str,
@@ -448,6 +456,7 @@ def c_unary_op(name: str,
                c_function_name: str,
                error_kind: int,
                truncated_type: Optional[RType] = None,
+               ordering: Optional[List[int]] = None,
                steals: StealsDescription = False,
                priority: int = 1) -> CFunctionDescription:
     """Define a c function call op for an unary operation.
@@ -459,7 +468,7 @@ def c_unary_op(name: str,
     """
     ops = c_unary_ops.setdefault(name, [])
     desc = CFunctionDescription(name, [arg_type], return_type, None, truncated_type,
-                            c_function_name, error_kind, steals, priority)
+                            c_function_name, error_kind, steals, ordering, priority)
     ops.append(desc)
     return desc
 

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -372,7 +372,9 @@ def c_method_op(name: str,
                         integer types or bool type
         ordering: optional ordering of the arguments, if defined,
                   reorders the arguments accordingly.
-                  should never be used together with var_arg_type
+                  should never be used together with var_arg_type.
+                  all the other arguments(such as arg_types) are in the order
+                  accepted by the python syntax(before reordering)
         steals: description of arguments that this steals (ref count wise)
         priority: if multiple ops match, the one with the highest priority is picked
     """

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -86,18 +86,20 @@ def f(d):
     d :: dict
     r0 :: short_int
     r1 :: object
-    r2, r3, r4 :: bool
+    r2 :: int32
+    r3, r4, r5 :: bool
 L0:
     r0 = 4
     r1 = box(short_int, r0)
-    r2 = r1 in d :: dict
-    if r2 goto L1 else goto L2 :: bool
+    r2 = PyDict_Contains(d, r1)
+    r3 = truncate r2: int32 to builtins.bool
+    if r3 goto L1 else goto L2 :: bool
 L1:
-    r3 = True
-    return r3
-L2:
-    r4 = False
+    r4 = True
     return r4
+L2:
+    r5 = False
+    return r5
 L3:
     unreachable
 
@@ -113,19 +115,21 @@ def f(d):
     d :: dict
     r0 :: short_int
     r1 :: object
-    r2, r3, r4, r5 :: bool
+    r2 :: int32
+    r3, r4, r5, r6 :: bool
 L0:
     r0 = 4
     r1 = box(short_int, r0)
-    r2 = r1 in d :: dict
-    r3 = !r2
-    if r3 goto L1 else goto L2 :: bool
+    r2 = PyDict_Contains(d, r1)
+    r3 = truncate r2: int32 to builtins.bool
+    r4 = !r3
+    if r4 goto L1 else goto L2 :: bool
 L1:
-    r4 = True
-    return r4
-L2:
-    r5 = False
+    r5 = True
     return r5
+L2:
+    r6 = False
+    return r6
 L3:
     unreachable
 
@@ -242,20 +246,21 @@ def print_dict_methods(d1, d2):
     r7 :: object
     v, r8 :: int
     r9 :: object
-    r10 :: bool
-    r11 :: None
-    r12, r13 :: bool
-    r14, r15 :: short_int
-    r16 :: int
-    r17 :: object
-    r18 :: tuple[bool, int, object, object]
-    r19 :: int
-    r20 :: bool
-    r21, r22 :: object
-    r23, r24, k :: int
-    r25, r26, r27, r28, r29 :: object
-    r30, r31, r32 :: bool
-    r33 :: None
+    r10 :: int32
+    r11 :: bool
+    r12 :: None
+    r13, r14 :: bool
+    r15, r16 :: short_int
+    r17 :: int
+    r18 :: object
+    r19 :: tuple[bool, int, object, object]
+    r20 :: int
+    r21 :: bool
+    r22, r23 :: object
+    r24, r25, k :: int
+    r26, r27, r28, r29, r30 :: object
+    r31, r32, r33 :: bool
+    r34 :: None
 L0:
     r0 = 0
     r1 = r0
@@ -272,47 +277,48 @@ L2:
     r8 = unbox(int, r7)
     v = r8
     r9 = box(int, v)
-    r10 = r9 in d2 :: dict
-    if r10 goto L3 else goto L4 :: bool
+    r10 = PyDict_Contains(d2, r9)
+    r11 = truncate r10: int32 to builtins.bool
+    if r11 goto L3 else goto L4 :: bool
 L3:
-    r11 = None
-    return r11
+    r12 = None
+    return r12
 L4:
 L5:
-    r12 = assert size(d1) == r2
+    r13 = assert size(d1) == r2
     goto L1
 L6:
-    r13 = no_err_occurred
+    r14 = no_err_occurred
 L7:
-    r14 = 0
-    r15 = r14
-    r16 = len d2 :: dict
-    r17 = item_iter d2 :: dict
+    r15 = 0
+    r16 = r15
+    r17 = len d2 :: dict
+    r18 = item_iter d2 :: dict
 L8:
-    r18 = next_item r17, offset=r15
-    r19 = r18[1]
-    r15 = r19
-    r20 = r18[0]
-    if r20 goto L9 else goto L11 :: bool
+    r19 = next_item r18, offset=r16
+    r20 = r19[1]
+    r16 = r20
+    r21 = r19[0]
+    if r21 goto L9 else goto L11 :: bool
 L9:
-    r21 = r18[2]
-    r22 = r18[3]
-    r23 = unbox(int, r21)
+    r22 = r19[2]
+    r23 = r19[3]
     r24 = unbox(int, r22)
-    k = r23
-    v = r24
-    r25 = box(int, k)
-    r26 = d2[r25] :: dict
-    r27 = box(int, v)
-    r28 = r26 += r27
-    r29 = box(int, k)
-    r30 = d2.__setitem__(r29, r28) :: dict
+    r25 = unbox(int, r23)
+    k = r24
+    v = r25
+    r26 = box(int, k)
+    r27 = d2[r26] :: dict
+    r28 = box(int, v)
+    r29 = r27 += r28
+    r30 = box(int, k)
+    r31 = d2.__setitem__(r30, r29) :: dict
 L10:
-    r31 = assert size(d2) == r16
+    r32 = assert size(d2) == r17
     goto L8
 L11:
-    r32 = no_err_occurred
+    r33 = no_err_occurred
 L12:
-    r33 = None
-    return r33
+    r34 = None
+    return r34
 

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -299,25 +299,27 @@ def f(x: Union[int, A]) -> int:
 def f(x):
     x :: union[int, __main__.A]
     r0 :: object
-    r1 :: bool
-    r2 :: int
-    r3 :: short_int
-    r4 :: int
-    r5 :: __main__.A
-    r6 :: int
+    r1 :: int32
+    r2 :: bool
+    r3 :: int
+    r4 :: short_int
+    r5 :: int
+    r6 :: __main__.A
+    r7 :: int
 L0:
     r0 = int
-    r1 = isinstance x, r0
-    if r1 goto L1 else goto L2 :: bool
+    r1 = PyObject_IsInstance(x, r0)
+    r2 = truncate r1: int32 to builtins.bool
+    if r2 goto L1 else goto L2 :: bool
 L1:
-    r2 = unbox(int, x)
-    r3 = 1
-    r4 = CPyTagged_Add(r2, r3)
-    return r4
+    r3 = unbox(int, x)
+    r4 = 1
+    r5 = CPyTagged_Add(r3, r4)
+    return r5
 L2:
-    r5 = cast(__main__.A, x)
-    r6 = r5.a
-    return r6
+    r6 = cast(__main__.A, x)
+    r7 = r6.a
+    return r7
 L3:
     unreachable
 

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -235,7 +235,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def test_dict_contains(self) -> None:
         self.assert_emit_binary_op(
             'in', self.b, self.o, self.d,
-            """cpy_r_r0 = PyDict_Contains(cpy_r_o, cpy_r_d);""")
+            """cpy_r_r0 = PyDict_Contains(cpy_r_d, cpy_r_o);""")
 
     def assert_emit(self, op: Op, expected: str) -> None:
         self.emitter.fragments = []
@@ -265,9 +265,11 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
             for c_desc in c_ops:
                 if (is_subtype(left.type, c_desc.arg_types[0])
                         and is_subtype(right.type, c_desc.arg_types[1])):
-                    self.assert_emit(CallC(c_desc.c_function_name, [left, right],
-                                           c_desc.return_type, c_desc.steals, c_desc.error_kind,
-                                           55), expected)
+                    args = [left, right]
+                    if c_desc.ordering is not None:
+                        args = [args[i] for i in c_desc.ordering]
+                    self.assert_emit(CallC(c_desc.c_function_name, args, c_desc.return_type,
+                                           c_desc.steals, c_desc.error_kind, 55), expected)
                     return
         ops = binary_ops[op]
         for desc in ops:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -235,12 +235,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def test_dict_contains(self) -> None:
         self.assert_emit_binary_op(
             'in', self.b, self.o, self.d,
-            """int __tmp1 = PyDict_Contains(cpy_r_d, cpy_r_o);
-               if (__tmp1 < 0)
-                   cpy_r_r0 = 2;
-               else
-                   cpy_r_r0 = __tmp1;
-            """)
+            """cpy_r_r0 = PyDict_Contains(cpy_r_o, cpy_r_d);""")
 
     def assert_emit(self, op: Op, expected: str) -> None:
         self.emitter.fragments = []


### PR DESCRIPTION
related mypyc/mypyc#734.

Support argument reordering via adding a new field to the description. It will solve the difference in args ordering between python syntax and C calling requirement(mostly with `in` ops). It should never be used together with variable args.