### PR TITLE
Add gray color ANSI escape sequence 

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -26,13 +26,6 @@ T = TypeVar('T')
 ENCODING_RE = \
     re.compile(br'([ \t\v]*#.*(\r\n?|\n))??[ \t\v]*#.*coding[:=][ \t]*([-\w.]+)')  # type: Final
 
-# This works in most default terminals works (because it is ANSI standard). The problem
-# this tries to solve is that although it is a basic ANSI "feature", terminfo files
-# for most default terminals don't have dim termcap entry, so curses doesn't report it.
-# Potentially, we can choose a grey color that would look good on both white and black
-# background, but it is not easy, and again most default terminals are 8-color, not 256-color,
-# so we can't get the color code from curses.
-
 DEFAULT_SOURCE_OFFSET = 4  # type: Final
 
 # At least this number of columns will be shown on each side of

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -534,7 +534,7 @@ class FancyFormatter:
             self.RED = '\033[91m'
             self.YELLOW = '\033[93m'
             self.NORMAL = '\033[0m'
-            self.DIM = parse_gray_color(curses.tigetstr('cup'))
+            self.DIM = '\033[2m'
             return True
         return False
 

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -32,7 +32,6 @@ ENCODING_RE = \
 # Potentially, we can choose a grey color that would look good on both white and black
 # background, but it is not easy, and again most default terminals are 8-color, not 256-color,
 # so we can't get the color code from curses.
-PLAIN_ANSI_DIM = '\x1b[2m'  # type: Final
 
 DEFAULT_SOURCE_OFFSET = 4  # type: Final
 
@@ -476,6 +475,13 @@ def hash_digest(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def parse_gray_color(cup: bytes) -> str:
+    """Reproduce a gray color in ANSI escape sequence"""
+    set_color = ''.join([cup[:-1].decode(), 'm'])
+    gray = curses.tparm(set_color.encode('utf-8'), 1, 89).decode()
+    return gray
+
+
 class FancyFormatter:
     """Apply color and bold font to terminal output.
 
@@ -528,7 +534,7 @@ class FancyFormatter:
             self.RED = '\033[91m'
             self.YELLOW = '\033[93m'
             self.NORMAL = '\033[0m'
-            self.DIM = '\033[2m'
+            self.DIM = parse_gray_color(curses.tigetstr('cup'))
             return True
         return False
 
@@ -553,16 +559,15 @@ class FancyFormatter:
         bold = curses.tigetstr('bold')
         under = curses.tigetstr('smul')
         set_color = curses.tigetstr('setaf')
-        if not (bold and under and set_color):
+        set_eseq = curses.tigetstr('cup')
+
+        if not (bold and under and set_color and set_eseq):
             return False
 
         self.NORMAL = curses.tigetstr('sgr0').decode()
         self.BOLD = bold.decode()
         self.UNDER = under.decode()
-        dim = curses.tigetstr('dim')
-        # TODO: more reliable way to get gray color good for both dark and light schemes.
-        self.DIM = dim.decode() if dim else PLAIN_ANSI_DIM
-
+        self.DIM = parse_gray_color(set_eseq)
         self.BLUE = curses.tparm(set_color, curses.COLOR_BLUE).decode()
         self.GREEN = curses.tparm(set_color, curses.COLOR_GREEN).decode()
         self.RED = curses.tparm(set_color, curses.COLOR_RED).decode()


### PR DESCRIPTION
Including ANSI escape sequence for gray color that is visible in both light and dark schemed terminal. The idea is to elimate the dim color attribute and replace it with gray color that is good for both light and dark scheme terminal to make the output  much more predictable. Below screenshots show how these changes improves the error view.

- Before on dark theme using dim capname

![before_on_dark_theme](https://user-images.githubusercontent.com/22955146/86499783-a852d900-bd95-11ea-8237-f9efa0abc157.png)

- After on dark theme using gray color

![after_on_dark_theme](https://user-images.githubusercontent.com/22955146/86499794-bacd1280-bd95-11ea-84f8-7bdd52cadce3.png)

- Before on light theme using dim capname

![before_on_light_theme](https://user-images.githubusercontent.com/22955146/86499810-c91b2e80-bd95-11ea-896c-42f2b7c7fe39.png)


- After on light theme gray color

![after_on_light_theme](https://user-images.githubusercontent.com/22955146/86499820-d59f8700-bd95-11ea-961c-e69a7dd9c426.png)
