### PR TITLE
stubgen can import Iterable and Iterator from typing

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -18,6 +18,19 @@ from mypy.stubdoc import (
 )
 
 
+_DEFAULT_TYPING_IMPORTS = (
+    'Any'
+    'Dict',
+    'Iterable',
+    'Iterator',
+    'List',
+    'Optional',
+    'Tuple',
+    'Union',
+)
+"""Members of the typing module to consider for importing by default."""
+
+
 def generate_stub_for_c_module(module_name: str,
                                target: str,
                                sigs: Optional[Dict[str, str]] = None,
@@ -82,7 +95,7 @@ def generate_stub_for_c_module(module_name: str,
 def add_typing_import(output: List[str]) -> List[str]:
     """Add typing imports for collections/types that occur in the generated stub."""
     names = []
-    for name in ['Any', 'Union', 'Tuple', 'Optional', 'List', 'Dict']:
+    for name in _DEFAULT_TYPING_IMPORTS:
         if any(re.search(r'\b%s\b' % name, line) for line in output):
             names.append(name)
     if names:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -18,6 +18,7 @@ from mypy.stubdoc import (
 )
 
 
+# Members of the typing module to consider for importing by default.
 _DEFAULT_TYPING_IMPORTS = (
     'Any'
     'Dict',
@@ -28,7 +29,6 @@ _DEFAULT_TYPING_IMPORTS = (
     'Tuple',
     'Union',
 )
-"""Members of the typing module to consider for importing by default."""
 
 
 def generate_stub_for_c_module(module_name: str,


### PR DESCRIPTION
pybind just gained support for defining the types of `Iterator`s and `Iterable`s (https://github.com/pybind/pybind11/commit/57070fb0a084e40ceab8a9f80b9e4436a48b9e53). This change makes stubgen capable of importing in generated stubs when used in a module being analysed.