### PR TITLE
Log module search paths when using -v

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2548,16 +2548,17 @@ def log_configuration(manager: BuildManager) -> None:
     for conf_name, conf_value in configuration_vars:
         manager.log("{:24}{}".format(conf_name + ":", conf_value))
 
-    # Complete list of searched paths can get very long, put them under TRACE
+    manager.log("Module Search Paths:")
     for path_type, paths in manager.search_paths._asdict().items():
         if not paths:
-            manager.trace("No %s" % path_type)
+            manager.log("    %s:" % path_type)
+            manager.log("        (empty)")
             continue
 
-        manager.trace("%s:" % path_type)
+        manager.log("    %s:" % path_type)
 
         for pth in paths:
-            manager.trace("    %s" % pth)
+            manager.log("        %s" % pth)
 
 
 # The driver


### PR DESCRIPTION
Even though these can be verbose, they are often important when diagnosing
issues related to import resolution. Previously they were only logged when
using -v -v.

Also tweak the format we use for logging these.

Example of what it looks like now:

```
LOG:  Module Search Paths:
LOG:      python_path:
LOG:          t
LOG:          /Users/jukka/src/mypy
LOG:      mypy_path:
LOG:          (empty)
LOG:      package_path:
LOG:          /Users/jukka/venv/mypy/lib/python3.7/site-packages
LOG:      typeshed_path:
LOG:          /Users/jukka/src/mypy/mypy/typeshed/stdlib/3.7
LOG:          /Users/jukka/src/mypy/mypy/typeshed/stdlib/3.6
LOG:          /Users/jukka/src/mypy/mypy/typeshed/stdlib/3
LOG:          /Users/jukka/src/mypy/mypy/typeshed/third_party/3
LOG:          /Users/jukka/src/mypy/mypy/typeshed/stdlib/2and3
LOG:          /Users/jukka/src/mypy/mypy/typeshed/third_party/2and3
LOG:          /usr/local/lib/mypy
```