### PR TITLE
[mypyc] Add default run test driver that calls all test_* functions 

### DIFF
--- a/mypyc/test-data/driver/driver.py
+++ b/mypyc/test-data/driver/driver.py
@@ -1,0 +1,41 @@
+"""Default driver for run tests (run-*.test).
+
+This imports the 'native' module (containing the compiled test cases)
+and calls each function starting with test_, and reports any
+exceptions as failures.
+
+Test cases can provide a custom driver.py that overrides this file.
+"""
+
+import sys
+import native
+
+failures = []
+
+for name in dir(native):
+    if name.startswith('test_'):
+        test_func = getattr(native, name)
+        try:
+            test_func()
+        except Exception as e:
+            failures.append(sys.exc_info())
+
+if failures:
+    from traceback import print_exception, format_tb
+    import re
+
+    def extract_line(tb):
+        formatted = '\n'.join(format_tb(tb))
+        m = re.search('File "native.py", line ([0-9]+), in test_', formatted)
+        return m.group(1)
+
+    # Sort failures by line number of test function.
+    failures = sorted(failures, key=lambda e: extract_line(e[2]))
+
+    # If there are multiple failures, print stack traces of all but the final failure.
+    for e in failures[:-1]:
+        print_exception(*e)
+        print()
+
+    # Raise exception for the last failure. Test runner will show the traceback.
+    raise failures[-1][1]

--- a/mypyc/test-data/fixtures/ir.py
+++ b/mypyc/test-data/fixtures/ir.py
@@ -181,6 +181,8 @@ class UserWarning(Warning): pass
 
 class TypeError(Exception): pass
 
+class ValueError(Exception): pass
+
 class AttributeError(Exception): pass
 
 class NameError(Exception): pass

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -1,0 +1,119 @@
+# Test cases for strings (compile and run)
+
+[case testStr]
+def f() -> str:
+    return 'some string'
+def g() -> str:
+    return 'some\a \v \t \x7f " \n \0string 🐍'
+def tostr(x: int) -> str:
+    return str(x)
+def booltostr(x: bool) -> str:
+    return str(x)
+def concat(x: str, y: str) -> str:
+    return x + y
+def eq(x: str) -> int:
+    if x == 'foo':
+        return 0
+    elif x != 'bar':
+        return 1
+    return 2
+
+[file driver.py]
+from native import f, g, tostr, booltostr, concat, eq
+assert f() == 'some string'
+assert g() == 'some\a \v \t \x7f " \n \0string 🐍'
+assert tostr(57) == '57'
+assert concat('foo', 'bar') == 'foobar'
+assert booltostr(True) == 'True'
+assert booltostr(False) == 'False'
+assert eq('foo') == 0
+assert eq('zar') == 1
+assert eq('bar') == 2
+
+assert int(tostr(0)) == 0
+assert int(tostr(20)) == 20
+
+[case testStringOps]
+from typing import List, Optional
+
+var = 'mypyc'
+
+num = 20
+
+def test_fstring_simple() -> None:
+    f1 = f'Hello {var}, this is a test'
+    assert f1 == "Hello mypyc, this is a test"
+
+def test_fstring_conversion() -> None:
+    f2 = f'Hello {var!r}'
+    assert f2 == "Hello 'mypyc'"
+    f3 = f'Hello {var!a}'
+    assert f3 == "Hello 'mypyc'"
+    f4 = f'Hello {var!s}'
+    assert f4 == "Hello mypyc"
+
+def test_fstring_align() -> None:
+    f5 = f'Hello {var:>20}'
+    assert f5 == "Hello                mypyc"
+    f6 = f'Hello {var!r:>20}'
+    assert f6 == "Hello              'mypyc'"
+    f7 = f'Hello {var:>{num}}'
+    assert f7 == "Hello                mypyc"
+    f8 = f'Hello {var!r:>{num}}'
+    assert f8 == "Hello              'mypyc'"
+
+def test_fstring_multi() -> None:
+    f9 = f'Hello {var}, hello again {var}'
+    assert f9 == "Hello mypyc, hello again mypyc"
+
+def do_split(s: str, sep: Optional[str] = None, max_split: Optional[int] = None) -> List[str]:
+    if sep is not None:
+        if max_split is not None:
+            return s.split(sep, max_split)
+        else:
+            return s.split(sep)
+    return s.split()
+
+ss = "abc abcd abcde abcdef"
+
+def test_split() -> None:
+    assert do_split(ss) == ["abc", "abcd", "abcde", "abcdef"]
+    assert do_split(ss, " ") == ["abc", "abcd", "abcde", "abcdef"]
+    assert do_split(ss, "-") == ["abc abcd abcde abcdef"]
+    assert do_split(ss, " ", -1) == ["abc", "abcd", "abcde", "abcdef"]
+    assert do_split(ss, " ", 0) == ["abc abcd abcde abcdef"]
+    assert do_split(ss, " ", 1) == ["abc", "abcd abcde abcdef"]
+    assert do_split(ss, " ", 2) == ["abc", "abcd", "abcde abcdef"]
+
+def getitem(s: str, index: int) -> str:
+    return s[index]
+
+from testutil import assertRaises
+
+s = "abc"
+
+def test_getitem() -> None:
+    assert getitem(s, 0) == "a"
+    assert getitem(s, 1) == "b"
+    assert getitem(s, 2) == "c"
+    assert getitem(s, -3) == "a"
+    assert getitem(s, -2) == "b"
+    assert getitem(s, -1) == "c"
+    with assertRaises(IndexError, "string index out of range"):
+        getitem(s, 4)
+    with assertRaises(IndexError, "string index out of range"):
+        getitem(s, -4)
+
+def str_to_int(s: str, base: Optional[int] = None) -> int:
+    if base:
+        return int(s, base)
+    else:
+        return int(s)
+
+def test_str_to_int() -> None:
+    assert str_to_int("1") == 1
+    assert str_to_int("10") == 10
+    assert str_to_int("a", 16) == 10
+    assert str_to_int("1a", 16) == 26
+    with assertRaises(ValueError, "invalid literal for int() with base 10: 'xyz'"):
+        str_to_int("xyz")

--- a/mypyc/test-data/run.test
+++ b/mypyc/test-data/run.test
@@ -1,3 +1,4 @@
+# Misc test cases (compile and run)
 
 [case testCallTrivialFunction]
 def f(x: int) -> int:
@@ -817,70 +818,6 @@ def g(x: int) -> int:
 [file driver.py]
 from native import f
 assert f(1) == 2
-
-[case testStr]
-def f() -> str:
-    return 'some string'
-def g() -> str:
-    return 'some\a \v \t \x7f " \n \0string 🐍'
-def tostr(x: int) -> str:
-    return str(x)
-def booltostr(x: bool) -> str:
-    return str(x)
-def concat(x: str, y: str) -> str:
-    return x + y
-def eq(x: str) -> int:
-    if x == 'foo':
-        return 0
-    elif x != 'bar':
-        return 1
-    return 2
-
-[file driver.py]
-from native import f, g, tostr, booltostr, concat, eq
-assert f() == 'some string'
-assert g() == 'some\a \v \t \x7f " \n \0string 🐍'
-assert tostr(57) == '57'
-assert concat('foo', 'bar') == 'foobar'
-assert booltostr(True) == 'True'
-assert booltostr(False) == 'False'
-assert eq('foo') == 0
-assert eq('zar') == 1
-assert eq('bar') == 2
-
-assert int(tostr(0)) == 0
-assert int(tostr(20)) == 20
-
-[case testFstring]
-var = 'mypyc'
-
-num = 20
-
-def test_simple() -> None:
-    f1 = f'Hello {var}, this is a test'
-    assert f1 == "Hello mypyc, this is a test"
-
-def test_conversion() -> None:
-    f2 = f'Hello {var!r}'
-    assert f2 == "Hello 'mypyc'"
-    f3 = f'Hello {var!a}'
-    assert f3 == "Hello 'mypyc'"
-    f4 = f'Hello {var!s}'
-    assert f4 == "Hello mypyc"
-
-def test_align() -> None:
-    f5 = f'Hello {var:>20}'
-    assert f5 == "Hello                mypyc"
-    f6 = f'Hello {var!r:>20}'
-    assert f6 == "Hello              'mypyc'"
-    f7 = f'Hello {var:>{num}}'
-    assert f7 == "Hello                mypyc"
-    f8 = f'Hello {var!r:>{num}}'
-    assert f8 == "Hello              'mypyc'"
-
-def test_multi() -> None:
-    f9 = f'Hello {var}, hello again {var}'
-    assert f9 == "Hello mypyc, hello again mypyc"
 
 [case testSets]
 from typing import Set, List
@@ -4830,66 +4767,6 @@ import b
 
 assert f(20) == 61
 assert isinstance(whatever, b.A)
-
-[case testStrSplit]
-from typing import List, Optional
-def f(s: str, sep: Optional[str] = None, max_split: Optional[int] = None) -> List[str]:
-    if sep is not None:
-        if max_split is not None:
-            return s.split(sep, max_split)
-        else:
-            return s.split(sep)
-    return s.split()
-
-[file driver.py]
-from native import f
-s = "abc abcd abcde abcdef"
-
-assert f(s) == ["abc", "abcd", "abcde", "abcdef"]
-assert f(s, " ") == ["abc", "abcd", "abcde", "abcdef"]
-assert f(s, "-") == ["abc abcd abcde abcdef"]
-assert f(s, " ", -1) == ["abc", "abcd", "abcde", "abcdef"]
-assert f(s, " ", 0) == ["abc abcd abcde abcdef"]
-assert f(s, " ", 1) == ["abc", "abcd abcde abcdef"]
-assert f(s, " ", 2) == ["abc", "abcd", "abcde abcdef"]
-
-[case testStrGetItem]
-def f(s: str, index: int) -> str:
-    return s[index]
-
-[file driver.py]
-from testutil import assertRaises
-from native import f
-s = "abc"
-
-assert f(s, 0) == "a"
-assert f(s, 1) == "b"
-assert f(s, 2) == "c"
-assert f(s, -3) == "a"
-assert f(s, -2) == "b"
-assert f(s, -1) == "c"
-with assertRaises(IndexError, "string index out of range"):
-    f(s, 4)
-with assertRaises(IndexError, "string index out of range"):
-    f(s, -4)
-
-[case testIntCastOnStr]
-from typing import Optional
-def f(s: str, base: Optional[int] = None) -> int:
-    if base:
-        return int(s, base)
-    else:
-        return int(s)
-
-[file driver.py]
-from testutil import assertRaises
-from native import f
-assert f("1") == 1
-assert f("10") == 10
-assert f("a", 16) == 10
-assert f("1a", 16) == 26
-with assertRaises(ValueError, "invalid literal for int() with base 10: 'xyz'"):
-    f("xyz")
 
 [case testNamedTupleAttributeRun]
 from typing import NamedTuple

--- a/mypyc/test-data/run.test
+++ b/mypyc/test-data/run.test
@@ -852,42 +852,35 @@ assert int(tostr(0)) == 0
 assert int(tostr(20)) == 20
 
 [case testFstring]
-
 var = 'mypyc'
 
 num = 20
 
-f1 = f'Hello {var}, this is a test'
+def test_simple() -> None:
+    f1 = f'Hello {var}, this is a test'
+    assert f1 == "Hello mypyc, this is a test"
 
-f2 = f'Hello {var!r}'
+def test_conversion() -> None:
+    f2 = f'Hello {var!r}'
+    assert f2 == "Hello 'mypyc'"
+    f3 = f'Hello {var!a}'
+    assert f3 == "Hello 'mypyc'"
+    f4 = f'Hello {var!s}'
+    assert f4 == "Hello mypyc"
 
-f3 = f'Hello {var!a}'
+def test_align() -> None:
+    f5 = f'Hello {var:>20}'
+    assert f5 == "Hello                mypyc"
+    f6 = f'Hello {var!r:>20}'
+    assert f6 == "Hello              'mypyc'"
+    f7 = f'Hello {var:>{num}}'
+    assert f7 == "Hello                mypyc"
+    f8 = f'Hello {var!r:>{num}}'
+    assert f8 == "Hello              'mypyc'"
 
-f4 = f'Hello {var!s}'
-
-f5 = f'Hello {var:>20}'
-
-f6 = f'Hello {var!r:>20}'
-
-f7 = f'Hello {var:>{num}}'
-
-f8 = f'Hello {var!r:>{num}}'
-
-f9 = f'Hello {var}, hello again {var}'
-
-[file driver.py]
-from native import f1, f2, f3, f4, f5, f6, f7, f8, f9
-assert f1 == "Hello mypyc, this is a test"
-assert f2 == "Hello 'mypyc'"
-assert f3 == "Hello 'mypyc'"
-assert f4 == "Hello mypyc"
-assert f5 == "Hello                mypyc"
-assert f6 == "Hello              'mypyc'"
-assert f7 == "Hello                mypyc"
-assert f8 == "Hello              'mypyc'"
-assert f9 == "Hello mypyc, hello again mypyc"
-
-[out]
+def test_multi() -> None:
+    f9 = f'Hello {var}, hello again {var}'
+    assert f9 == "Hello mypyc, hello again mypyc"
 
 [case testSets]
 from typing import Set, List

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -244,6 +244,13 @@ class TestRun(MypycDataSuite):
         assert glob.glob('native.*.{}'.format(suffix))
 
         driver_path = 'driver.py'
+        if not os.path.isfile(driver_path):
+            # No driver.py provided by test case. Use the default one
+            # (mypyc/test-data/driver/driver.py) that calls each
+            # function named test_*.
+            default_driver = os.path.join(
+                os.path.dirname(__file__), '..', 'test-data', 'driver', 'driver.py')
+            shutil.copy(default_driver, driver_path)
         env = os.environ.copy()
         env['MYPYC_RUN_BENCH'] = '1' if bench else '0'
 
@@ -312,8 +319,9 @@ class TestRun(MypycDataSuite):
             return True
 
 
-# Run the main multi-module tests in multi-file compilation mode
 class TestRunMultiFile(TestRun):
+    """Run the main multi-module tests in multi-file compilation mode."""
+
     multi_file = True
     test_name_suffix = '_multi'
     files = [
@@ -322,8 +330,9 @@ class TestRunMultiFile(TestRun):
     ]
 
 
-# Run the main multi-module tests in separate compilation mode
 class TestRunSeparate(TestRun):
+    """Run the main multi-module tests in separate compilation mode."""
+
     separate = True
     test_name_suffix = '_separate'
     files = [

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -347,7 +347,7 @@ class TestRunSeparate(TestRun):
     ]
 
 
-def fix_native_line_number(message: str, fnam: str, delta: int) -> None:
+def fix_native_line_number(message: str, fnam: str, delta: int) -> str:
     """Update code locations in test case output to point to the .test file.
 
     The description of the test case is written to native.py, and line numbers

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -32,6 +32,7 @@ from mypyc.test.test_serialization import check_serialization_roundtrip
 files = [
     'run-functions.test',
     'run.test',
+    'run-strings.test',
     'run-classes.test',
     'run-traits.test',
     'run-multimodule.test',

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -290,8 +290,11 @@ class TestRun(MypycDataSuite):
                 msg = 'Invalid output (step {})'.format(incremental_step)
                 expected = testcase.output2.get(incremental_step, [])
 
-            outlines = [fix_native_line_number(line, testcase.file, testcase.line)
-                        for line in outlines]
+            if not expected:
+                # Tweak some line numbers, but only if the expected output is empty,
+                # as tweaked output might not match expected output.
+                outlines = [fix_native_line_number(line, testcase.file, testcase.line)
+                            for line in outlines]
             assert_test_output(testcase, outlines, msg, expected)
 
         if incremental_step > 1 and options.incremental:

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -148,9 +148,11 @@ def update_testcase_output(testcase: DataDrivenTestCase, output: List[str]) -> N
         print(data, file=f)
 
 
-def assert_test_output(testcase: DataDrivenTestCase, actual: List[str],
+def assert_test_output(testcase: DataDrivenTestCase,
+                       actual: List[str],
                        message: str,
-                       expected: Optional[List[str]] = None) -> None:
+                       expected: Optional[List[str]] = None,
+                       formatted: Optional[List[str]] = None) -> None:
     expected_output = expected if expected is not None else testcase.output
     if expected_output != actual and testcase.config.getoption('--update-data', False):
         update_testcase_output(testcase, actual)


### PR DESCRIPTION
If a test case doesn't define driver.py, use a default driver that calls
all functions named test_* in the compiled test case and reports any
exceptions as failures.

This has a few benefits over an explicit driver:

1. Writing test cases is easier, as a test (sub) case can be defined as
   one logical unit.

2. It's easy to define many sub test cases per compilation unit.
   By having larger test cases, tests can run faster. Each compilation
   unit has significant fixed overhead.

Also point some errors to the relevant line number in the `.test` file
to make figuring out errors easier, when we have long test case
descriptions.

Document how to write these tests. Migrate a few test cases as examples.

I'll create follow-up PRs that merges various existing test cases into
larger ones. It probably won't be worth it to try to migrate most existing
test cases, though, since it would be a lot of effort.

Work towards mypyc/mypyc#72.