### PR TITLE
Adds get_function_signature_hook

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -686,7 +686,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             self, callee: FunctionLike, args: List[Expression],
             arg_kinds: List[int], context: Context,
             arg_names: Optional[Sequence[Optional[str]]],
-            signature_hook: Callable[[MethodSigContext], CallableType]) -> FunctionLike:
+            signature_hook: Callable[[FunctionSigContext], CallableType]) -> FunctionLike:
         """Apply a plugin hook that may infer a more precise signature for a function."""
         if isinstance(callee, CallableType):
             num_formals = len(callee.arg_kinds)
@@ -811,18 +811,17 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         (if appropriate) before the signature is passed to check_call.
         """
         callee = get_proper_type(callee)
-        if (callable_name is not None
-                and isinstance(callee, FunctionLike)):
+        if callable_name is not None and isinstance(callee, FunctionLike):
             if object_type is not None:
-                signature_hook = self.plugin.get_method_signature_hook(callable_name)
-                if signature_hook:
+                method_sig_hook = self.plugin.get_method_signature_hook(callable_name)
+                if method_sig_hook:
                     return self.apply_method_signature_hook(
-                        callee, args, arg_kinds, context, arg_names, object_type, signature_hook)
+                        callee, args, arg_kinds, context, arg_names, object_type, method_sig_hook)
             else:
-                signature_hook = self.plugin.get_function_signature_hook(callable_name)
-                if signature_hook:
+                function_sig_hook = self.plugin.get_function_signature_hook(callable_name)
+                if function_sig_hook:
                     return self.apply_function_signature_hook(
-                        callee, args, arg_kinds, context, arg_names, signature_hook)
+                        callee, args, arg_kinds, context, arg_names, function_sig_hook)
 
         return callee
 

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -365,6 +365,16 @@ ReportConfigContext = NamedTuple(
         ('is_check', bool)  # Is this invocation for checking whether the config matches
     ])
 
+# A context for a function signature hook that infers a better signature for a
+# function.  Note that argument types aren't available yet.  If you need them,
+# you have to use a method hook instead.
+FunctionSigContext = NamedTuple(
+    'FunctionSigContext', [
+        ('args', List[List[Expression]]),     # Actual expressions for each formal argument
+        ('default_signature', CallableType),  # Original signature of the method
+        ('context', Context),                 # Relevant location context (e.g. for error messages)
+        ('api', CheckerPluginInterface)])
+
 # A context for a function hook that infers the return type of a function with
 # a special signature.
 #
@@ -395,7 +405,7 @@ FunctionContext = NamedTuple(
 # TODO: document ProperType in the plugin changelog/update issue.
 MethodSigContext = NamedTuple(
     'MethodSigContext', [
-        ('type', ProperType),                       # Base object type for method call
+        ('type', ProperType),                 # Base object type for method call
         ('args', List[List[Expression]]),     # Actual expressions for each formal argument
         ('default_signature', CallableType),  # Original signature of the method
         ('context', Context),                 # Relevant location context (e.g. for error messages)
@@ -407,7 +417,7 @@ MethodSigContext = NamedTuple(
 # This is very similar to FunctionContext (only differences are documented).
 MethodContext = NamedTuple(
     'MethodContext', [
-        ('type', ProperType),                    # Base object type for method call
+        ('type', ProperType),              # Base object type for method call
         ('arg_types', List[List[Type]]),   # List of actual caller types for each formal argument
         # see FunctionContext for details about names and kinds
         ('arg_kinds', List[List[int]]),
@@ -421,7 +431,7 @@ MethodContext = NamedTuple(
 # A context for an attribute type hook that infers the type of an attribute.
 AttributeContext = NamedTuple(
     'AttributeContext', [
-        ('type', ProperType),               # Type of object with attribute
+        ('type', ProperType),         # Type of object with attribute
         ('default_attr_type', Type),  # Original attribute type
         ('context', Context),         # Relevant location context (e.g. for error messages)
         ('api', CheckerPluginInterface)])
@@ -530,6 +540,22 @@ class Plugin(CommonPluginApi):
         this method will be called with 'lib.Special', and then with 'lib.Other'.
         The callback returned by plugin must return an analyzed type,
         i.e. an instance of `mypy.types.Type`.
+        """
+        return None
+
+    def get_function_signature_hook(self, fullname: str
+                                    ) -> Optional[Callable[[FunctionSigContext], Type]]:
+        """Adjust the signature a function.
+
+        This method is called before type checking a function call. Plugin
+        may infer a better type for the function.
+
+            from lib import Class, do_stuff
+
+            do_stuff(42)
+            Class()
+
+        This method will be called with 'lib.do_stuff' and then with 'lib.Class'.
         """
         return None
 
@@ -720,6 +746,10 @@ class ChainedPlugin(Plugin):
     def get_type_analyze_hook(self, fullname: str
                               ) -> Optional[Callable[[AnalyzeTypeContext], Type]]:
         return self._find_hook(lambda plugin: plugin.get_type_analyze_hook(fullname))
+
+    def get_function_signature_hook(self, fullname: str
+                                    ) -> Optional[Callable[[FunctionSigContext], Type]]:
+        return self._find_hook(lambda plugin: plugin.get_function_signature_hook(fullname))
 
     def get_function_hook(self, fullname: str
                           ) -> Optional[Callable[[FunctionContext], Type]]:

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -544,7 +544,7 @@ class Plugin(CommonPluginApi):
         return None
 
     def get_function_signature_hook(self, fullname: str
-                                    ) -> Optional[Callable[[FunctionSigContext], Type]]:
+                                    ) -> Optional[Callable[[FunctionSigContext], CallableType]]:
         """Adjust the signature a function.
 
         This method is called before type checking a function call. Plugin
@@ -748,7 +748,7 @@ class ChainedPlugin(Plugin):
         return self._find_hook(lambda plugin: plugin.get_type_analyze_hook(fullname))
 
     def get_function_signature_hook(self, fullname: str
-                                    ) -> Optional[Callable[[FunctionSigContext], Type]]:
+                                    ) -> Optional[Callable[[FunctionSigContext], CallableType]]:
         return self._find_hook(lambda plugin: plugin.get_function_signature_hook(fullname))
 
     def get_function_hook(self, fullname: str

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -721,3 +721,12 @@ Cls().attr = "foo"  # E: Incompatible types in assignment (expression has type "
 [file mypy.ini]
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/descriptor.py
+
+[case testFunctionSigPluginFile]
+# flags: --config-file tmp/mypy.ini
+
+def dynamic_signature(arg1: str) -> str: ...
+reveal_type(dynamic_signature(1))  # N: Revealed type is 'builtins.int'
+[file mypy.ini]
+\[mypy]
+plugins=<ROOT>/test-data/unit/plugins/function_sig_hook.py

--- a/test-data/unit/plugins/function_sig_hook.py
+++ b/test-data/unit/plugins/function_sig_hook.py
@@ -1,0 +1,26 @@
+from mypy.plugin import CallableType, CheckerPluginInterface, FunctionSigContext, Plugin
+from mypy.types import Instance, Type
+
+class FunctionSigPlugin(Plugin):
+    def get_function_signature_hook(self, fullname):
+        if fullname == '__main__.dynamic_signature':
+            return my_hook
+        return None
+
+def _str_to_int(api: CheckerPluginInterface, typ: Type) -> Type:
+    if isinstance(typ, Instance):
+        if typ.type.fullname == 'builtins.str':
+            return api.named_generic_type('builtins.int', [])
+        elif typ.args:
+            return typ.copy_modified(args=[_str_to_int(api, t) for t in typ.args])
+
+    return typ
+
+def my_hook(ctx: FunctionSigContext) -> CallableType:
+    return ctx.default_signature.copy_modified(
+        arg_types=[_str_to_int(ctx.api, t) for t in ctx.default_signature.arg_types],
+        ret_type=_str_to_int(ctx.api, ctx.default_signature.ret_type),
+    )
+
+def plugin(version):
+    return FunctionSigPlugin


### PR DESCRIPTION
This PR introduces `get_function_signature_hook` that behaves the similar way as `get_method_signature_hook`.

Closes #9101 