### PR TITLE
[mypyc] Add BinaryIntOp for low-level integer operations

### DIFF
--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -9,7 +9,7 @@ from mypyc.ir.ops import (
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
     LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError, CallC, LoadGlobal,
-    Truncate
+    Truncate, BinaryIntOp
 )
 
 
@@ -203,6 +203,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_load_global(self, op: LoadGlobal) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_binary_int_op(self, op: BinaryIntOp) -> GenAndKill:
         return self.visit_register_op(op)
 
 

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -11,7 +11,8 @@ from mypyc.ir.ops import (
     OpVisitor, Goto, Branch, Return, Assign, LoadInt, LoadErrorValue, GetAttr, SetAttr,
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
     BasicBlock, Value, MethodCall, PrimitiveOp, EmitterInterface, Unreachable, NAMESPACE_STATIC,
-    NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CallC, LoadGlobal, Truncate
+    NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CallC, LoadGlobal, Truncate,
+    BinaryIntOp
 )
 from mypyc.ir.rtypes import RType, RTuple, is_int32_rprimitive, is_int64_rprimitive
 from mypyc.ir.func_ir import FuncIR, FuncDecl, FUNC_STATICMETHOD, FUNC_CLASSMETHOD
@@ -435,6 +436,12 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             if not any(x in s for x in ('/*', '*/', '\0')):
                 ann = ' /* %s */' % s
         self.emit_line('%s = %s;%s' % (dest, op.identifier, ann))
+
+    def visit_binary_int_op(self, op: BinaryIntOp) -> None:
+        dest = self.reg(op)
+        lhs = self.reg(op.lhs)
+        rhs = self.reg(op.rhs)
+        self.emit_line('%s = %s %s %s;' % (dest, lhs, op.op_str[op.op], rhs))
 
     # Helpers
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1252,6 +1252,43 @@ class LoadGlobal(RegisterOp):
         return visitor.visit_load_global(self)
 
 
+class BinaryIntOp(RegisterOp):
+    """Binary operations on integer types
+
+    These ops are low-level and will be eventually generated to simple x op y form.
+    The left and right values should be of low-level integer types that support those ops
+    """
+    error_kind = ERR_NEVER
+
+    ADD = 0  # type: Final
+    SUB = 1  # type: Final
+    MUL = 2  # type: Final
+    DIV = 3  # type: Final
+
+    op_str = {
+        ADD: '+',
+        SUB: '-',
+        MUL: '*',
+        DIV: '/',
+    }  # type: Final
+
+    def __init__(self, type: RType, lhs: Value, rhs: Value, op: int, line: int = -1) -> None:
+        super().__init__(line)
+        self.type = type
+        self.lhs = lhs
+        self.rhs = rhs
+        self.op = op
+
+    def sources(self) -> List[Value]:
+        return [self.lhs, self.rhs]
+
+    def to_str(self, env: Environment) -> str:
+        return env.format('%r = %r %s %r', self, self.lhs, self.op_str[self.op], self.rhs)
+
+    def accept(self, visitor: 'OpVisitor[T]') -> T:
+        return visitor.visit_binary_int_op(self)
+
+
 @trait
 class OpVisitor(Generic[T]):
     """Generic visitor over ops (uses the visitor design pattern)."""
@@ -1352,6 +1389,10 @@ class OpVisitor(Generic[T]):
 
     @abstractmethod
     def visit_load_global(self, op: LoadGlobal) -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visit_binary_int_op(self, op: BinaryIntOp) -> T:
         raise NotImplementedError
 
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1277,7 +1277,7 @@ class BinaryIntOp(RegisterOp):
     AND = 200  # type: Final
     OR = 201  # type: Final
     XOR = 202  # type: Final
-    LEFT_SHIFT = 203 # type: Final
+    LEFT_SHIFT = 203  # type: Final
     RIGHT_SHIFT = 204  # type: Final
 
     op_str = {

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1260,16 +1260,43 @@ class BinaryIntOp(RegisterOp):
     """
     error_kind = ERR_NEVER
 
+    # arithmetic
     ADD = 0  # type: Final
     SUB = 1  # type: Final
     MUL = 2  # type: Final
     DIV = 3  # type: Final
+    MOD = 4  # type: Final
+    # logical
+    EQ = 100  # type: Final
+    NEQ = 101  # type: Final
+    LT = 102  # type: Final
+    GT = 103  # type: Final
+    LEQ = 104  # type: Final
+    GEQ = 105  # type: Final
+    # bitwise
+    AND = 200  # type: Final
+    OR = 201  # type: Final
+    XOR = 202  # type: Final
+    LEFT_SHIFT = 203 # type: Final
+    RIGHT_SHIFT = 204  # type: Final
 
     op_str = {
         ADD: '+',
         SUB: '-',
         MUL: '*',
         DIV: '/',
+        MOD: '%',
+        EQ: '==',
+        NEQ: '!=',
+        LT: '<',
+        GT: '>',
+        LEQ: '<=',
+        GEQ: '>=',
+        AND: '&',
+        OR: '|',
+        XOR: '^',
+        LEFT_SHIFT: '<<',
+        RIGHT_SHIFT: '>>',
     }  # type: Final
 
     def __init__(self, type: RType, lhs: Value, rhs: Value, op: int, line: int = -1) -> None:

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -232,6 +232,9 @@ class IRBuilder:
     def call_c(self, desc: CFunctionDescription, args: List[Value], line: int) -> Value:
         return self.builder.call_c(desc, args, line)
 
+    def binary_int_op(self, type: RType, lhs: Value, rhs: Value, op: int, line: int) -> Value:
+        return self.builder.binary_int_op(type, lhs, rhs, op, line)
+
     @property
     def environment(self) -> Environment:
         return self.builder.environment

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -21,7 +21,7 @@ from mypyc.ir.ops import (
     Assign, Branch, Goto, Call, Box, Unbox, Cast, GetAttr,
     LoadStatic, MethodCall, PrimitiveOp, OpDescription, RegisterOp, CallC, Truncate,
     RaiseStandardError, Unreachable, LoadErrorValue, LoadGlobal,
-    NAMESPACE_TYPE, NAMESPACE_MODULE, NAMESPACE_STATIC,
+    NAMESPACE_TYPE, NAMESPACE_MODULE, NAMESPACE_STATIC, BinaryIntOp
 )
 from mypyc.ir.rtypes import (
     RType, RUnion, RInstance, optional_value_type, int_rprimitive, float_rprimitive,
@@ -749,6 +749,9 @@ class LowLevelIRBuilder:
             target = self.call_c(matching, args, line, result_type)
             return target
         return None
+
+    def binary_int_op(self, type: RType, lhs: Value, rhs: Value, op: int, line: int) -> Value:
+        return self.add(BinaryIntOp(type, lhs, rhs, op, line))
 
     # Internal helpers
 

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -1917,7 +1917,7 @@ L6:
     r20 = r0.append(r19) :: list
 L7:
     r21 = 1
-    r22 = r9 + r21 :: short_int
+    r22 = r9 + r21
     r9 = r22
     goto L1
 L8:
@@ -1982,7 +1982,7 @@ L6:
     r21 = r0.__setitem__(r19, r20) :: dict
 L7:
     r22 = 1
-    r23 = r9 + r22 :: short_int
+    r23 = r9 + r22
     r9 = r23
     goto L1
 L8:
@@ -2032,7 +2032,7 @@ L2:
     z = r8
 L3:
     r9 = 1
-    r10 = r1 + r9 :: short_int
+    r10 = r1 + r9
     r1 = r10
     goto L1
 L4:
@@ -2058,7 +2058,7 @@ L6:
     r24 = r11.append(r23) :: list
 L7:
     r25 = 1
-    r26 = r13 + r25 :: short_int
+    r26 = r13 + r25
     r13 = r26
     goto L5
 L8:

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -195,7 +195,7 @@ L2:
     r8 = CPyList_SetItem(l, i, r7)
 L3:
     r9 = 1
-    r10 = r2 + r9 :: short_int
+    r10 = r2 + r9
     r2 = r10
     i = r10
     goto L1

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -28,7 +28,7 @@ L2:
     x = r5
 L3:
     r6 = 1
-    r7 = r3 + r6 :: short_int
+    r7 = r3 + r6
     r3 = r7
     i = r7
     goto L1
@@ -58,7 +58,7 @@ L1:
 L2:
 L3:
     r4 = -1
-    r5 = r2 + r4 :: short_int
+    r5 = r2 + r4
     r2 = r5
     i = r5
     goto L1
@@ -113,7 +113,7 @@ L2:
     goto L4
 L3:
     r4 = 1
-    r5 = r2 + r4 :: short_int
+    r5 = r2 + r4
     r2 = r5
     n = r5
     goto L1
@@ -202,7 +202,7 @@ L1:
 L2:
 L3:
     r4 = 1
-    r5 = r2 + r4 :: short_int
+    r5 = r2 + r4
     r2 = r5
     n = r5
     goto L1
@@ -281,7 +281,7 @@ L2:
     y = r7
 L3:
     r8 = 1
-    r9 = r2 + r8 :: short_int
+    r9 = r2 + r8
     r2 = r9
     goto L1
 L4:
@@ -868,11 +868,11 @@ L2:
     r8 = CPyTagged_Add(i, x)
 L3:
     r9 = 1
-    r10 = r1 + r9 :: short_int
+    r10 = r1 + r9
     r1 = r10
     i = r10
     r11 = 1
-    r12 = r3 + r11 :: short_int
+    r12 = r3 + r11
     r3 = r12
     goto L1
 L4:
@@ -901,7 +901,7 @@ L2:
     n = r4
 L3:
     r5 = 1
-    r6 = r1 + r5 :: short_int
+    r6 = r1 + r5
     r1 = r6
     i = r6
     goto L1
@@ -961,7 +961,7 @@ L4:
 L5:
 L6:
     r11 = 1
-    r12 = r1 + r11 :: short_int
+    r12 = r1 + r11
     r1 = r12
     goto L1
 L7:
@@ -1012,10 +1012,10 @@ L4:
     x = r13
 L5:
     r14 = 1
-    r15 = r2 + r14 :: short_int
+    r15 = r2 + r14
     r2 = r15
     r16 = 1
-    r17 = r5 + r16 :: short_int
+    r17 = r5 + r16
     r5 = r17
     z = r17
     goto L1
@@ -1024,3 +1024,4 @@ L6:
 L7:
     r19 = None
     return r19
+

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -155,7 +155,7 @@ L2:
     x = r5
 L3:
     r6 = 1
-    r7 = r1 + r6 :: short_int
+    r7 = r1 + r6
     r1 = r7
     goto L1
 L4:


### PR DESCRIPTION
relates mypyc/mypyc#741

This PR introduces `BinaryIntOp` to represent all low-level integer binary operations.

The block-like logic described in mypyc/mypyc#743 would be handled differently, `BinaryIntOp` would be the building block of it.