### PR TITLE
[mypyc] Generates inline compare statement on short ints and fix sieve performance regression

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -26,7 +26,7 @@ from mypyc.ir.ops import (
 from mypyc.ir.rtypes import (
     RType, RUnion, RInstance, optional_value_type, int_rprimitive, float_rprimitive,
     bool_rprimitive, list_rprimitive, str_rprimitive, is_none_rprimitive, object_rprimitive,
-    c_pyssize_t_rprimitive, is_short_int_rprimitive, short_int_rprimitive
+    c_pyssize_t_rprimitive, is_short_int_rprimitive
 )
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -26,7 +26,7 @@ from mypyc.ir.ops import (
 from mypyc.ir.rtypes import (
     RType, RUnion, RInstance, optional_value_type, int_rprimitive, float_rprimitive,
     bool_rprimitive, list_rprimitive, str_rprimitive, is_none_rprimitive, object_rprimitive,
-    c_pyssize_t_rprimitive
+    c_pyssize_t_rprimitive, is_short_int_rprimitive, short_int_rprimitive
 )
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
@@ -546,6 +546,12 @@ class LowLevelIRBuilder:
             value = self.translate_eq_cmp(lreg, rreg, expr_op, line)
         if value is not None:
             return value
+
+        # generate fast binary logic ops on short ints
+        if (is_short_int_rprimitive(lreg.type) and is_short_int_rprimitive(rreg.type)
+                and expr_op in int_logical_op_mapping.keys()):
+            return self.binary_int_op(bool_rprimitive, lreg, rreg,
+                                      int_logical_op_mapping[expr_op][0], line)
 
         call_c_ops_candidates = c_binary_ops.get(expr_op, [])
         target = self.matching_call_c(call_c_ops_candidates, [lreg, rreg], line)

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -150,8 +150,15 @@ int_equal_ = c_custom_op(
     c_function_name='CPyTagged_IsEq_',
     error_kind=ERR_NEVER)
 
+int_less_than_ = c_custom_op(
+    arg_types=[int_rprimitive, int_rprimitive],
+    return_type=bool_rprimitive,
+    c_function_name='CPyTagged_IsLt',
+    error_kind=ERR_NEVER)
+
 # provide mapping from textual op to short int's op variant and boxed int's description
 # note these are not complete implementations
 int_logical_op_mapping = {
-    '==': (BinaryIntOp.EQ, int_equal_)
+    '==': (BinaryIntOp.EQ, int_equal_),
+    '<': (BinaryIntOp.LT, int_less_than_)
 }  # type: Dict[str, Tuple[int, CFunctionDescription]]

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -153,7 +153,7 @@ int_equal_ = c_custom_op(
 int_less_than_ = c_custom_op(
     arg_types=[int_rprimitive, int_rprimitive],
     return_type=bool_rprimitive,
-    c_function_name='CPyTagged_IsLt',
+    c_function_name='CPyTagged_IsLt_',
     error_kind=ERR_NEVER)
 
 # provide mapping from textual op to short int's op variant and boxed int's description

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -387,7 +387,7 @@ L2:
     r0 = r5
     goto L4
 L3:
-    r6 = CPyTagged_IsLt(a, a)
+    r6 = CPyTagged_IsLt_(a, a)
     r0 = r6
 L4:
     if r0 goto L5 else goto L12 :: bool
@@ -403,7 +403,7 @@ L7:
     r7 = r12
     goto L9
 L8:
-    r13 = CPyTagged_IsLt(a, a)
+    r13 = CPyTagged_IsLt_(a, a)
     r7 = r13
 L9:
     if r7 goto L10 else goto L11 :: bool

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -368,38 +368,86 @@ def f(a: int) -> None:
 [out]
 def f(a):
     a :: int
-    r0, r1 :: bool
+    r0 :: bool
+    r1, r2, r3 :: native_int
+    r4, r5, r6, r7 :: bool
+    r8, r9, r10 :: native_int
+    r11, r12, r13 :: bool
     y, x :: int
-    r2 :: None
+    r14 :: None
 L0:
 L1:
-    r0 = CPyTagged_IsLt(a, a)
-    if r0 goto L2 else goto L6 :: bool
+    r1 = 1
+    r2 = a & r1
+    r3 = 0
+    r4 = r2 == r3
+    if r4 goto L2 else goto L3 :: bool
 L2:
+    r5 = a < a
+    r0 = r5
+    goto L4
 L3:
-    r1 = CPyTagged_IsLt(a, a)
-    if r1 goto L4 else goto L5 :: bool
+    r6 = CPyTagged_IsLt(a, a)
+    r0 = r6
 L4:
-    y = a
-    goto L3
+    if r0 goto L5 else goto L12 :: bool
 L5:
+L6:
+    r8 = 1
+    r9 = a & r8
+    r10 = 0
+    r11 = r9 == r10
+    if r11 goto L7 else goto L8 :: bool
+L7:
+    r12 = a < a
+    r7 = r12
+    goto L9
+L8:
+    r13 = CPyTagged_IsLt(a, a)
+    r7 = r13
+L9:
+    if r7 goto L10 else goto L11 :: bool
+L10:
+    y = a
+    goto L6
+L11:
     x = a
     goto L1
-L6:
-    r2 = None
-    return r2
+L12:
+    r14 = None
+    return r14
 (0, 0)   {a}                     {a}
-(1, 0)   {a, x, y}               {a, x, y}
-(1, 1)   {a, x, y}               {a, x, y}
-(2, 0)   {a, x, y}               {a, x, y}
-(3, 0)   {a, x, y}               {a, x, y}
-(3, 1)   {a, x, y}               {a, x, y}
-(4, 0)   {a, x, y}               {a, x, y}
-(4, 1)   {a, x, y}               {a, x, y}
-(5, 0)   {a, x, y}               {a, x, y}
-(5, 1)   {a, x, y}               {a, x, y}
-(6, 0)   {a, x, y}               {a, x, y}
-(6, 1)   {a, x, y}               {a, x, y}
+(1, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(1, 1)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(1, 2)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(1, 3)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(1, 4)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(2, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(2, 1)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(2, 2)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(3, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(3, 1)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(3, 2)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(4, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(5, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(6, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(6, 1)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(6, 2)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(6, 3)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(6, 4)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(7, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(7, 1)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(7, 2)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(8, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(8, 1)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(8, 2)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(9, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(10, 0)  {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(10, 1)  {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(11, 0)  {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(11, 1)  {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(12, 0)  {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(12, 1)  {a, r0, r7, x, y}       {a, r0, r7, x, y}
 
 [case testTrivial_BorrowedArgument]
 def f(a: int, b: int) -> int:

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -153,7 +153,7 @@ L2:
     r2 = r7
     goto L4
 L3:
-    r8 = CPyTagged_IsLt(i, l)
+    r8 = CPyTagged_IsLt_(i, l)
     r2 = r8
 L4:
     if r2 goto L5 else goto L10 :: bool

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -131,47 +131,61 @@ def sum(a, l):
     r1 :: short_int
     i :: int
     r2 :: bool
-    r3 :: object
-    r4, r5 :: int
-    r6 :: short_int
-    r7, r8 :: int
+    r3, r4, r5 :: native_int
+    r6, r7, r8 :: bool
+    r9 :: object
+    r10, r11 :: int
+    r12 :: short_int
+    r13, r14 :: int
 L0:
     r0 = 0
     sum = r0
     r1 = 0
     i = r1
 L1:
-    r2 = CPyTagged_IsLt(i, l)
-    if r2 goto L2 else goto L7 :: bool
+    r3 = 1
+    r4 = i & r3
+    r5 = 0
+    r6 = r4 == r5
+    if r6 goto L2 else goto L3 :: bool
 L2:
-    r3 = CPyList_GetItem(a, i)
-    if is_error(r3) goto L8 (error at sum:6) else goto L3
+    r7 = i < l
+    r2 = r7
+    goto L4
 L3:
-    r4 = unbox(int, r3)
-    dec_ref r3
-    if is_error(r4) goto L8 (error at sum:6) else goto L4
+    r8 = CPyTagged_IsLt(i, l)
+    r2 = r8
 L4:
-    r5 = CPyTagged_Add(sum, r4)
-    dec_ref sum :: int
-    dec_ref r4 :: int
-    sum = r5
-    r6 = 1
-    r7 = CPyTagged_Add(i, r6)
-    dec_ref i :: int
-    i = r7
-    goto L1
+    if r2 goto L5 else goto L10 :: bool
 L5:
-    return sum
+    r9 = CPyList_GetItem(a, i)
+    if is_error(r9) goto L11 (error at sum:6) else goto L6
 L6:
-    r8 = <error> :: int
-    return r8
+    r10 = unbox(int, r9)
+    dec_ref r9
+    if is_error(r10) goto L11 (error at sum:6) else goto L7
 L7:
+    r11 = CPyTagged_Add(sum, r10)
+    dec_ref sum :: int
+    dec_ref r10 :: int
+    sum = r11
+    r12 = 1
+    r13 = CPyTagged_Add(i, r12)
     dec_ref i :: int
-    goto L5
+    i = r13
+    goto L1
 L8:
+    return sum
+L9:
+    r14 = <error> :: int
+    return r14
+L10:
+    dec_ref i :: int
+    goto L8
+L11:
     dec_ref sum :: int
     dec_ref i :: int
-    goto L6
+    goto L9
 
 [case testTryExcept]
 def g() -> None:

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -93,14 +93,28 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: short_int
+    r1, r2, r3 :: native_int
+    r4, r5, r6 :: bool
+    r7 :: short_int
 L0:
-    r0 = CPyTagged_IsLt(x, y)
-    if r0 goto L1 else goto L2 :: bool
-L1:
     r1 = 1
-    x = r1
+    r2 = x & r1
+    r3 = 0
+    r4 = r2 == r3
+    if r4 goto L1 else goto L2 :: bool
+L1:
+    r5 = x < y
+    r0 = r5
+    goto L3
 L2:
+    r6 = CPyTagged_IsLt(x, y)
+    r0 = r6
+L3:
+    if r0 goto L4 else goto L5 :: bool
+L4:
+    r7 = 1
+    x = r7
+L5:
     return x
 
 [case testIfElse]
@@ -114,18 +128,32 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1, r2 :: short_int
+    r1, r2, r3 :: native_int
+    r4, r5, r6 :: bool
+    r7, r8 :: short_int
 L0:
-    r0 = CPyTagged_IsLt(x, y)
-    if r0 goto L1 else goto L2 :: bool
-L1:
     r1 = 1
-    x = r1
+    r2 = x & r1
+    r3 = 0
+    r4 = r2 == r3
+    if r4 goto L1 else goto L2 :: bool
+L1:
+    r5 = x < y
+    r0 = r5
     goto L3
 L2:
-    r2 = 2
-    x = r2
+    r6 = CPyTagged_IsLt(x, y)
+    r0 = r6
 L3:
+    if r0 goto L4 else goto L5 :: bool
+L4:
+    r7 = 1
+    x = r7
+    goto L6
+L5:
+    r8 = 2
+    x = r8
+L6:
     return x
 
 [case testAnd1]
@@ -138,22 +166,36 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0, r1 :: bool
-    r2, r3 :: short_int
+    r0 :: bool
+    r1, r2, r3 :: native_int
+    r4, r5, r6, r7 :: bool
+    r8, r9 :: short_int
 L0:
-    r0 = CPyTagged_IsLt(x, y)
-    if r0 goto L1 else goto L3 :: bool
+    r1 = 1
+    r2 = x & r1
+    r3 = 0
+    r4 = r2 == r3
+    if r4 goto L1 else goto L2 :: bool
 L1:
-    r1 = CPyTagged_IsGt(x, y)
-    if r1 goto L2 else goto L3 :: bool
+    r5 = x < y
+    r0 = r5
+    goto L3
 L2:
-    r2 = 1
-    x = r2
-    goto L4
+    r6 = CPyTagged_IsLt(x, y)
+    r0 = r6
 L3:
-    r3 = 2
-    x = r3
+    if r0 goto L4 else goto L6 :: bool
 L4:
+    r7 = CPyTagged_IsGt(x, y)
+    if r7 goto L5 else goto L6 :: bool
+L5:
+    r8 = 1
+    x = r8
+    goto L7
+L6:
+    r9 = 2
+    x = r9
+L7:
     return x
 
 [case testAnd2]
@@ -188,22 +230,36 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0, r1 :: bool
-    r2, r3 :: short_int
+    r0 :: bool
+    r1, r2, r3 :: native_int
+    r4, r5, r6, r7 :: bool
+    r8, r9 :: short_int
 L0:
-    r0 = CPyTagged_IsLt(x, y)
-    if r0 goto L2 else goto L1 :: bool
+    r1 = 1
+    r2 = x & r1
+    r3 = 0
+    r4 = r2 == r3
+    if r4 goto L1 else goto L2 :: bool
 L1:
-    r1 = CPyTagged_IsGt(x, y)
-    if r1 goto L2 else goto L3 :: bool
+    r5 = x < y
+    r0 = r5
+    goto L3
 L2:
-    r2 = 1
-    x = r2
-    goto L4
+    r6 = CPyTagged_IsLt(x, y)
+    r0 = r6
 L3:
-    r3 = 2
-    x = r3
+    if r0 goto L5 else goto L4 :: bool
 L4:
+    r7 = CPyTagged_IsGt(x, y)
+    if r7 goto L5 else goto L6 :: bool
+L5:
+    r8 = 1
+    x = r8
+    goto L7
+L6:
+    r9 = 2
+    x = r9
+L7:
     return x
 
 [case testOr2]
@@ -237,14 +293,28 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: short_int
+    r1, r2, r3 :: native_int
+    r4, r5, r6 :: bool
+    r7 :: short_int
 L0:
-    r0 = CPyTagged_IsLt(x, y)
-    if r0 goto L2 else goto L1 :: bool
-L1:
     r1 = 1
-    x = r1
+    r2 = x & r1
+    r3 = 0
+    r4 = r2 == r3
+    if r4 goto L1 else goto L2 :: bool
+L1:
+    r5 = x < y
+    r0 = r5
+    goto L3
 L2:
+    r6 = CPyTagged_IsLt(x, y)
+    r0 = r6
+L3:
+    if r0 goto L5 else goto L4 :: bool
+L4:
+    r7 = 1
+    x = r7
+L5:
     return x
 
 [case testNotAnd]
@@ -255,18 +325,32 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0, r1 :: bool
-    r2 :: short_int
+    r0 :: bool
+    r1, r2, r3 :: native_int
+    r4, r5, r6, r7 :: bool
+    r8 :: short_int
 L0:
-    r0 = CPyTagged_IsLt(x, y)
-    if r0 goto L1 else goto L2 :: bool
+    r1 = 1
+    r2 = x & r1
+    r3 = 0
+    r4 = r2 == r3
+    if r4 goto L1 else goto L2 :: bool
 L1:
-    r1 = CPyTagged_IsGt(x, y)
-    if r1 goto L3 else goto L2 :: bool
+    r5 = x < y
+    r0 = r5
+    goto L3
 L2:
-    r2 = 1
-    x = r2
+    r6 = CPyTagged_IsLt(x, y)
+    r0 = r6
 L3:
+    if r0 goto L4 else goto L5 :: bool
+L4:
+    r7 = CPyTagged_IsGt(x, y)
+    if r7 goto L6 else goto L5 :: bool
+L5:
+    r8 = 1
+    x = r8
+L6:
     return x
 
 [case testWhile]
@@ -349,21 +433,35 @@ def f(x: int, y: int) -> None:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1, r2 :: short_int
-    r3 :: None
+    r1, r2, r3 :: native_int
+    r4, r5, r6 :: bool
+    r7, r8 :: short_int
+    r9 :: None
 L0:
-    r0 = CPyTagged_IsLt(x, y)
-    if r0 goto L1 else goto L2 :: bool
-L1:
     r1 = 1
-    x = r1
+    r2 = x & r1
+    r3 = 0
+    r4 = r2 == r3
+    if r4 goto L1 else goto L2 :: bool
+L1:
+    r5 = x < y
+    r0 = r5
     goto L3
 L2:
-    r2 = 2
-    y = r2
+    r6 = CPyTagged_IsLt(x, y)
+    r0 = r6
 L3:
-    r3 = None
-    return r3
+    if r0 goto L4 else goto L5 :: bool
+L4:
+    r7 = 1
+    x = r7
+    goto L6
+L5:
+    r8 = 2
+    y = r8
+L6:
+    r9 = None
+    return r9
 
 [case testRecursion]
 def f(n: int) -> int:
@@ -1894,7 +1992,7 @@ L0:
     r9 = r8
 L1:
     r10 = len r7 :: list
-    r11 = CPyTagged_IsLt(r9, r10)
+    r11 = r9 < r10
     if r11 goto L2 else goto L8 :: bool
 L2:
     r12 = r7[r9] :: unsafe list
@@ -1958,7 +2056,7 @@ L0:
     r9 = r8
 L1:
     r10 = len r7 :: list
-    r11 = CPyTagged_IsLt(r9, r10)
+    r11 = r9 < r10
     if r11 goto L2 else goto L8 :: bool
 L2:
     r12 = r7[r9] :: unsafe list
@@ -2019,7 +2117,7 @@ L0:
     r1 = r0
 L1:
     r2 = len l :: list
-    r3 = CPyTagged_IsLt(r1, r2)
+    r3 = r1 < r2
     if r3 goto L2 else goto L4 :: bool
 L2:
     r4 = l[r1] :: unsafe list
@@ -2041,7 +2139,7 @@ L4:
     r13 = r12
 L5:
     r14 = len l :: list
-    r15 = CPyTagged_IsLt(r13, r14)
+    r15 = r13 < r14
     if r15 goto L6 else goto L8 :: bool
 L6:
     r16 = l[r13] :: unsafe list
@@ -2583,21 +2681,35 @@ L0:
 def f(x, y, z):
     x, y, z, r0, r1 :: int
     r2, r3 :: bool
-    r4 :: int
-    r5 :: bool
+    r4, r5, r6 :: native_int
+    r7, r8, r9 :: bool
+    r10 :: int
+    r11 :: bool
 L0:
     r0 = g(x)
     r1 = g(y)
-    r3 = CPyTagged_IsLt(r0, r1)
-    if r3 goto L2 else goto L1 :: bool
+    r4 = 1
+    r5 = r0 & r4
+    r6 = 0
+    r7 = r5 == r6
+    if r7 goto L1 else goto L2 :: bool
 L1:
-    r2 = r3
+    r8 = r0 < r1
+    r3 = r8
     goto L3
 L2:
-    r4 = g(z)
-    r5 = CPyTagged_IsGt(r1, r4)
-    r2 = r5
+    r9 = CPyTagged_IsLt(r0, r1)
+    r3 = r9
 L3:
+    if r3 goto L5 else goto L4 :: bool
+L4:
+    r2 = r3
+    goto L6
+L5:
+    r10 = g(z)
+    r11 = CPyTagged_IsGt(r1, r10)
+    r2 = r11
+L6:
     return r2
 
 [case testEq]

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -107,7 +107,7 @@ L1:
     r0 = r5
     goto L3
 L2:
-    r6 = CPyTagged_IsLt(x, y)
+    r6 = CPyTagged_IsLt_(x, y)
     r0 = r6
 L3:
     if r0 goto L4 else goto L5 :: bool
@@ -142,7 +142,7 @@ L1:
     r0 = r5
     goto L3
 L2:
-    r6 = CPyTagged_IsLt(x, y)
+    r6 = CPyTagged_IsLt_(x, y)
     r0 = r6
 L3:
     if r0 goto L4 else goto L5 :: bool
@@ -181,7 +181,7 @@ L1:
     r0 = r5
     goto L3
 L2:
-    r6 = CPyTagged_IsLt(x, y)
+    r6 = CPyTagged_IsLt_(x, y)
     r0 = r6
 L3:
     if r0 goto L4 else goto L6 :: bool
@@ -245,7 +245,7 @@ L1:
     r0 = r5
     goto L3
 L2:
-    r6 = CPyTagged_IsLt(x, y)
+    r6 = CPyTagged_IsLt_(x, y)
     r0 = r6
 L3:
     if r0 goto L5 else goto L4 :: bool
@@ -307,7 +307,7 @@ L1:
     r0 = r5
     goto L3
 L2:
-    r6 = CPyTagged_IsLt(x, y)
+    r6 = CPyTagged_IsLt_(x, y)
     r0 = r6
 L3:
     if r0 goto L5 else goto L4 :: bool
@@ -340,7 +340,7 @@ L1:
     r0 = r5
     goto L3
 L2:
-    r6 = CPyTagged_IsLt(x, y)
+    r6 = CPyTagged_IsLt_(x, y)
     r0 = r6
 L3:
     if r0 goto L4 else goto L5 :: bool
@@ -448,7 +448,7 @@ L1:
     r0 = r5
     goto L3
 L2:
-    r6 = CPyTagged_IsLt(x, y)
+    r6 = CPyTagged_IsLt_(x, y)
     r0 = r6
 L3:
     if r0 goto L4 else goto L5 :: bool
@@ -2698,7 +2698,7 @@ L1:
     r3 = r8
     goto L3
 L2:
-    r9 = CPyTagged_IsLt(r0, r1)
+    r9 = CPyTagged_IsLt_(r0, r1)
     r3 = r9
 L3:
     if r3 goto L5 else goto L4 :: bool

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -185,7 +185,7 @@ L0:
     r2 = r0
     i = r2
 L1:
-    r3 = CPyTagged_IsLt(r2, r1)
+    r3 = r2 < r1
     if r3 goto L2 else goto L4 :: bool
 L2:
     r4 = CPyList_GetItem(l, i)

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -21,7 +21,7 @@ L0:
     r3 = r1
     i = r3
 L1:
-    r4 = CPyTagged_IsLt(r3, r2)
+    r4 = r3 < r2
     if r4 goto L2 else goto L4 :: bool
 L2:
     r5 = CPyTagged_Add(x, i)
@@ -107,7 +107,7 @@ L0:
     r2 = r0
     n = r2
 L1:
-    r3 = CPyTagged_IsLt(r2, r1)
+    r3 = r2 < r1
     if r3 goto L2 else goto L4 :: bool
 L2:
     goto L4
@@ -197,7 +197,7 @@ L0:
     r2 = r0
     n = r2
 L1:
-    r3 = CPyTagged_IsLt(r2, r1)
+    r3 = r2 < r1
     if r3 goto L2 else goto L4 :: bool
 L2:
 L3:
@@ -271,7 +271,7 @@ L0:
     r2 = r1
 L1:
     r3 = len ls :: list
-    r4 = CPyTagged_IsLt(r2, r3)
+    r4 = r2 < r3
     if r4 goto L2 else goto L4 :: bool
 L2:
     r5 = ls[r2] :: unsafe list
@@ -859,7 +859,7 @@ L0:
     r3 = r2
 L1:
     r4 = len a :: list
-    r5 = CPyTagged_IsLt(r3, r4)
+    r5 = r3 < r4
     if r5 goto L2 else goto L4 :: bool
 L2:
     r6 = a[r3] :: unsafe list
@@ -942,7 +942,7 @@ L0:
     r2 = iter b :: object
 L1:
     r3 = len a :: list
-    r4 = CPyTagged_IsLt(r1, r3)
+    r4 = r1 < r3
     if r4 goto L2 else goto L7 :: bool
 L2:
     r5 = next r2 :: object
@@ -997,10 +997,10 @@ L1:
     if is_error(r6) goto L6 else goto L2
 L2:
     r7 = len b :: list
-    r8 = CPyTagged_IsLt(r2, r7)
+    r8 = r2 < r7
     if r8 goto L3 else goto L6 :: bool
 L3:
-    r9 = CPyTagged_IsLt(r5, r4)
+    r9 = r5 < r4
     if r9 goto L4 else goto L6 :: bool
 L4:
     r10 = unbox(bool, r6)

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -6,13 +6,13 @@ from mypy.test.data import DataDrivenTestCase
 from mypy.test.config import test_temp_dir
 from mypy.errors import CompileError
 
-from mypyc.common import TOP_LEVEL_NAME, IS_32_BIT_PLATFORM
+from mypyc.common import TOP_LEVEL_NAME
 from mypyc import analysis
 from mypyc.transform import exceptions
 from mypyc.ir.func_ir import format_func
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
-    assert_test_output,
+    assert_test_output, replace_native_int
 )
 
 files = [
@@ -29,9 +29,7 @@ class TestAnalysis(MypycDataSuite):
         """Perform a data-flow analysis test case."""
 
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
-            # replace native_int with platform specific ints
-            int_format_str = 'int32' if IS_32_BIT_PLATFORM else 'int64'
-            testcase.output = [s.replace('native_int', int_format_str) for s in testcase.output]
+            testcase.output = replace_native_int(testcase.output)
             try:
                 ir = build_ir_for_single_file(testcase.input)
             except CompileError as e:

--- a/mypyc/test/test_exceptions.py
+++ b/mypyc/test/test_exceptions.py
@@ -9,7 +9,7 @@ from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase
 from mypy.errors import CompileError
 
-from mypyc.common import TOP_LEVEL_NAME
+from mypyc.common import TOP_LEVEL_NAME, IS_32_BIT_PLATFORM
 from mypyc.ir.func_ir import format_func
 from mypyc.transform.uninit import insert_uninit_checks
 from mypyc.transform.exceptions import insert_exception_handling
@@ -32,7 +32,9 @@ class TestExceptionTransform(MypycDataSuite):
         """Perform a runtime checking transformation test case."""
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
-
+            # replace native_int with platform specific ints
+            int_format_str = 'int32' if IS_32_BIT_PLATFORM else 'int64'
+            expected_output = [s.replace('native_int', int_format_str) for s in expected_output]
             try:
                 ir = build_ir_for_single_file(testcase.input)
             except CompileError as e:

--- a/mypyc/test/test_exceptions.py
+++ b/mypyc/test/test_exceptions.py
@@ -9,14 +9,14 @@ from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase
 from mypy.errors import CompileError
 
-from mypyc.common import TOP_LEVEL_NAME, IS_32_BIT_PLATFORM
+from mypyc.common import TOP_LEVEL_NAME
 from mypyc.ir.func_ir import format_func
 from mypyc.transform.uninit import insert_uninit_checks
 from mypyc.transform.exceptions import insert_exception_handling
 from mypyc.transform.refcount import insert_ref_count_opcodes
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
-    assert_test_output, remove_comment_lines
+    assert_test_output, remove_comment_lines, replace_native_int
 )
 
 files = [
@@ -32,9 +32,7 @@ class TestExceptionTransform(MypycDataSuite):
         """Perform a runtime checking transformation test case."""
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
-            # replace native_int with platform specific ints
-            int_format_str = 'int32' if IS_32_BIT_PLATFORM else 'int64'
-            expected_output = [s.replace('native_int', int_format_str) for s in expected_output]
+            expected_output = replace_native_int(expected_output)
             try:
                 ir = build_ir_for_single_file(testcase.input)
             except CompileError as e:

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -6,11 +6,11 @@ from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase
 from mypy.errors import CompileError
 
-from mypyc.common import TOP_LEVEL_NAME, IS_32_BIT_PLATFORM
+from mypyc.common import TOP_LEVEL_NAME
 from mypyc.ir.func_ir import format_func
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
-    assert_test_output, remove_comment_lines
+    assert_test_output, remove_comment_lines, replace_native_int
 )
 from mypyc.options import CompilerOptions
 
@@ -42,9 +42,7 @@ class TestGenOps(MypycDataSuite):
         """Perform a runtime checking transformation test case."""
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
-            # replace native_int with platform specific ints
-            int_format_str = 'int32' if IS_32_BIT_PLATFORM else 'int64'
-            expected_output = [s.replace('native_int', int_format_str) for s in expected_output]
+            expected_output = replace_native_int(expected_output)
             try:
                 ir = build_ir_for_single_file(testcase.input, options)
             except CompileError as e:

--- a/mypyc/test/test_refcount.py
+++ b/mypyc/test/test_refcount.py
@@ -10,12 +10,12 @@ from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase
 from mypy.errors import CompileError
 
-from mypyc.common import TOP_LEVEL_NAME, IS_32_BIT_PLATFORM
+from mypyc.common import TOP_LEVEL_NAME
 from mypyc.ir.func_ir import format_func
 from mypyc.transform.refcount import insert_ref_count_opcodes
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
-    assert_test_output, remove_comment_lines
+    assert_test_output, remove_comment_lines, replace_native_int
 )
 
 files = [
@@ -32,9 +32,7 @@ class TestRefCountTransform(MypycDataSuite):
         """Perform a runtime checking transformation test case."""
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
-            # replace native_int with platform specific ints
-            int_format_str = 'int32' if IS_32_BIT_PLATFORM else 'int64'
-            expected_output = [s.replace('native_int', int_format_str) for s in expected_output]
+            expected_output = replace_native_int(expected_output)
             try:
                 ir = build_ir_for_single_file(testcase.input)
             except CompileError as e:

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -22,6 +22,7 @@ from mypyc.errors import Errors
 from mypyc.irbuild.main import build_ir
 from mypyc.irbuild.mapper import Mapper
 from mypyc.test.config import test_data_prefix
+from mypyc.common import IS_32_BIT_PLATFORM
 
 # The builtins stub used during icode generation test cases.
 ICODE_GEN_BUILTINS = os.path.join(test_data_prefix, 'fixtures/ir.py')
@@ -210,3 +211,9 @@ def fudge_dir_mtimes(dir: str, delta: int) -> None:
             path = os.path.join(dirpath, name)
             new_mtime = os.stat(path).st_mtime + delta
             os.utime(path, times=(new_mtime, new_mtime))
+
+
+def replace_native_int(text: List[str]) -> List[str]:
+    """Replace native_int with platform specific ints"""
+    int_format_str = 'int32' if IS_32_BIT_PLATFORM else 'int64'
+    return [s.replace('native_int', int_format_str) for s in text]


### PR DESCRIPTION
relates mypyc/mypyc#750

Generate almost identical code as before https://github.com/python/mypy/commit/be01236bcdb9a9da66e68dd0d45ff0f9a604e44a

before:
```c
CPyL1: ;
    cpy_r_r4 = (Py_ssize_t)cpy_r_r3 < (Py_ssize_t)cpy_r_r2;
    if (cpy_r_r4) {
        goto CPyL2;
    } else
        goto CPyL5;
```

now with this PR:
```c
CPyL1: ;
    cpy_r_r4 = cpy_r_r3 < cpy_r_r2;
    if (cpy_r_r4) {
        goto CPyL2;
    } else
        goto CPyL5;
```