### PR TITLE
[mypyc] Migrate some tuple test cases to the new representation

### DIFF
--- a/mypyc/test-data/run-tuples.test
+++ b/mypyc/test-data/run-tuples.test
@@ -1,4 +1,4 @@
-# Test cases for strings (compile and run)
+# Test cases for tuples (compile and run)
 
 [case testTuple]
 from typing import List, Optional, Tuple

--- a/mypyc/test-data/run-tuples.test
+++ b/mypyc/test-data/run-tuples.test
@@ -1,0 +1,158 @@
+# Test cases for strings (compile and run)
+
+[case testTuple]
+from typing import List, Optional, Tuple
+from typing import Tuple
+def f(x: Tuple[int, int]) -> Tuple[int,int]:
+    return x
+
+def lurr(x: List[Optional[Tuple[int, str]]]) -> object:
+    return x[0]
+
+def asdf(x: Tuple[int, str]) -> None:
+    pass
+[file driver.py]
+from testutil import assertRaises
+from native import f, lurr, asdf
+
+assert f((1,2)) == (1, 2)
+assert lurr([(1, '2')]) == (1, '2')
+
+with assertRaises(TypeError):
+    print(lurr([(1, 2)]))
+
+with assertRaises(TypeError):
+    asdf((1, 2))
+
+[case testTupleGet]
+from typing import Tuple
+def f(x: Tuple[Tuple[int, bool], int]) -> int:
+    return x[0][0]
+[file driver.py]
+from native import f
+print(f(((1,True),2)))
+big_number = pow(2, 80)
+print(f(((big_number,True),2)))
+[out]
+1
+1208925819614629174706176
+
+[case testSequenceTupleArg]
+from typing import Tuple
+def f(x: Tuple[int, ...]) -> int:
+    return x[1]
+[file driver.py]
+from native import f
+print(f((1,2,3,4)))
+[out]
+2
+
+[case testTupleAttr]
+from typing import Tuple
+class C:
+    b: Tuple[Tuple[Tuple[int, int], int], int, str, object]
+    c: Tuple[()]
+def f() -> None:
+    c = C()
+    c.b = (((1, 2), 2), 1, 'hi', 'hi2')
+    print(c.b)
+
+def g() -> None:
+    try:
+        h()
+    except Exception:
+        print('caught the exception')
+
+def h() -> Tuple[Tuple[Tuple[int, int], int], int, str, object]:
+    raise Exception('Intentional exception')
+[file driver.py]
+from native import f, g, C
+f()
+g()
+assert not hasattr(C(), 'c')
+[out]
+(((1, 2), 2), 1, 'hi', 'hi2')
+caught the exception
+
+[case testNamedTupleAttributeRun]
+from typing import NamedTuple
+
+NT = NamedTuple('NT', [('x', int), ('y', int)])
+
+def f(nt: NT) -> int:
+    if nt.x > nt.y:
+        return nt.x
+    return nt.y
+
+nt = NT(1, 2)
+[file driver.py]
+from native import NT, nt, f
+
+assert f(nt) == 2
+assert f(NT(3, 2)) == 3
+
+class Sub(NT):
+    pass
+assert f(Sub(3, 2)) == 3
+
+[case testTupleOps]
+from typing import Tuple, List, Any, Optional
+
+def f() -> Tuple[()]:
+    return ()
+
+def test_empty_tuple() -> None:
+    assert f() == ()
+
+def f2() -> Any:
+    return ()
+
+def test_empty_tuple_with_any_type():
+    assert f2() == ()
+
+def f3() -> int:
+    x = (False, 1)
+    return x[1]
+
+def test_new_tuple() -> None:
+    assert f3() == 1
+
+def f4(y: int) -> int:
+    x = (False, y)
+    return x[1]
+
+def test_new_tuple_boxed_int() -> None:
+    big_number = 1208925819614629174706176
+    assert f4(big_number) == big_number
+
+def f5(x: List[int]) -> int:
+    return tuple(x)[1]
+
+def test_sequence_tuple() -> None:
+    assert f5([1,2,3,4]) == 2
+
+def f6(x: List[int]) -> int:
+    return len(tuple(x))
+
+def test_sequence_tuple_len() -> None:
+    assert f6([1,2,3,4]) == 4
+
+def f7(x: List[Tuple[int, int]]) -> int:
+    a, b = x[0]
+    return a + b
+
+def test_unbox_tuple() -> None:
+    assert f7([(5, 6)]) == 11
+
+# Test that order is irrelevant to unions. Really I only care that this builds.
+
+class A:
+    pass
+
+def lol() -> A:
+    return A()
+
+def foo(x: bool, y: bool) -> Tuple[Optional[A], bool]:
+    z = lol()
+
+    return None if y else z, x

--- a/mypyc/test-data/run.test
+++ b/mypyc/test-data/run.test
@@ -492,119 +492,6 @@ print(f(False))
 False
 True
 
-[case testTuple]
-from typing import List, Optional, Tuple
-from typing import Tuple
-def f(x: Tuple[int, int]) -> Tuple[int,int]:
-    return x
-
-def lurr(x: List[Optional[Tuple[int, str]]]) -> object:
-    return x[0]
-
-def asdf(x: Tuple[int, str]) -> None:
-    pass
-
-[file driver.py]
-from testutil import assertRaises
-from native import f, lurr, asdf
-
-assert f((1,2)) == (1, 2)
-assert lurr([(1, '2')]) == (1, '2')
-
-with assertRaises(TypeError):
-    print(lurr([(1, 2)]))
-
-with assertRaises(TypeError):
-    asdf((1, 2))
-
-[case testEmptyTupleFunctionWithTupleType]
-from typing import Tuple
-def f() -> Tuple[()]:
-    return ()
-[file driver.py]
-from native import f
-assert f() == ()
-
-[case testEmptyTupleFunctionWithAnyType]
-from typing import Any
-def f() -> Any:
-    return ()
-[file driver.py]
-from native import f
-assert f() == ()
-
-[case testTupleGet]
-from typing import Tuple
-def f(x: Tuple[Tuple[int, bool], int]) -> int:
-    return x[0][0]
-[file driver.py]
-from native import f
-print(f(((1,True),2)))
-[out]
-1
-
-[case testTupleGetBoxedInt]
-from typing import Tuple
-def f(x: Tuple[Tuple[int, bool], int]) -> int:
-    return x[0][0]
-[file driver.py]
-from native import f
-big_number = pow(2, 80)
-print(f(((big_number,True),2)))
-[out]
-1208925819614629174706176
-
-[case testNewTuple]
-def f() -> int:
-    x = (False, 1)
-    return x[1]
-[file driver.py]
-from native import f
-print(f())
-[out]
-1
-
-[case testNewTupleBoxedInt]
-def f(y: int) -> int:
-    x = (False, y)
-    return x[1]
-[file driver.py]
-from native import f
-big_number = pow(2, 80)
-print(f(big_number))
-[out]
-1208925819614629174706176
-
-[case testSequenceTuple]
-from typing import List
-def f(x: List[int]) -> int:
-    return tuple(x)[1]
-[file driver.py]
-from native import f
-print(f([1,2,3,4]))
-[out]
-2
-
-[case testSequenceTupleLen]
-from typing import List
-def f(x: List[int]) -> int:
-    return len(tuple(x))
-[file driver.py]
-from native import f
-print(f([1,2,3,4]))
-[out]
-4
-
-[case testSequenceTupleArg]
-from typing import Tuple
-def f(x: Tuple[int, ...]) -> int:
-    return x[1]
-[file driver.py]
-from native import f
-print(f((1,2,3,4)))
-[out]
-2
-
 [case testMaybeUninitVar]
 class C:
     def __init__(self, x: int) -> None:
@@ -2670,16 +2557,6 @@ assert from_tuple((1, 'x')) == ['x', 1]
 assert from_list([3, 4]) == [4, 3]
 assert from_any('xy') == ['y', 'x']
 
-[case testUnboxTuple]
-from typing import List, Tuple
-
-def f(x: List[Tuple[int, int]]) -> int:
-    a, b = x[0]
-    return a + b
-[file driver.py]
-from native import f
-assert f([(5, 6)]) == 11
-
 [case testUnpack]
 from typing import List
 
@@ -3491,33 +3368,6 @@ TypeError
 1
 TypeError
 10
-
-[case testTupleAttr]
-from typing import Tuple
-class C:
-    b: Tuple[Tuple[Tuple[int, int], int], int, str, object]
-    c: Tuple[()]
-def f() -> None:
-    c = C()
-    c.b = (((1, 2), 2), 1, 'hi', 'hi2')
-    print(c.b)
-
-def g() -> None:
-    try:
-        h()
-    except Exception:
-        print('caught the exception')
-
-def h() -> Tuple[Tuple[Tuple[int, int], int], int, str, object]:
-    raise Exception('Intentional exception')
-[file driver.py]
-from native import f, g, C
-f()
-g()
-assert not hasattr(C(), 'c')
-[out]
-(((1, 2), 2), 1, 'hi', 'hi2')
-caught the exception
 
 [case testUnion]
 from typing import Union
@@ -4486,25 +4336,6 @@ class E:
 [file driver.py]
 # really I only care it builds
 
-[case testTupleUnionFail]
-# Test that order is irrelevant to unions
-
-from typing import Optional, Tuple
-
-class A:
-    pass
-
-def lol() -> A:
-    return A()
-
-def foo(x: bool, y: bool) -> Tuple[Optional[A], bool]:
-    z = lol()
-
-    return None if y else z, x
-
-[file driver.py]
-# really I only care it builds
-
 [case testIterTypeTrickiness]
 # Test inferring the type of a for loop body doesn't cause us grief
 # Extracted from somethings that broke in mypy
@@ -4767,24 +4598,3 @@ import b
 
 assert f(20) == 61
 assert isinstance(whatever, b.A)
-
-[case testNamedTupleAttributeRun]
-from typing import NamedTuple
-
-NT = NamedTuple('NT', [('x', int), ('y', int)])
-
-def f(nt: NT) -> int:
-    if nt.x > nt.y:
-        return nt.x
-    return nt.y
-
-nt = NT(1, 2)
-[file driver.py]
-from native import NT, nt, f
-
-assert f(nt) == 2
-assert f(NT(3, 2)) == 3
-
-class Sub(NT):
-    pass
-assert f(Sub(3, 2)) == 3

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -33,6 +33,7 @@ files = [
     'run-functions.test',
     'run.test',
     'run-strings.test',
+    'run-tuples.test',
     'run-classes.test',
     'run-traits.test',
     'run-multimodule.test',


### PR DESCRIPTION
Also move tuple related tests to a new test file.

Work towards mypyc/mypyc#72.