### PR TITLE
[mypyc] Use C optimization level 0 for tests by default

### DIFF
--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -56,7 +56,7 @@ from mypyc.build import mypycify
 
 setup(name='test_run_output',
       ext_modules=mypycify({}, separate={}, skip_cgen_input={!r}, strip_asserts=False,
-                           multi_file={}),
+                           multi_file={}, opt_level={}),
 )
 """
 
@@ -240,10 +240,16 @@ class TestRun(MypycDataSuite):
         if incremental_step == 1:
             check_serialization_roundtrip(ir)
 
+        opt_level = int(os.environ.get('MYPYC_OPT_LEVEL', 0))
+
         setup_file = os.path.abspath(os.path.join(WORKDIR, 'setup.py'))
         # We pass the C file information to the build script via setup.py unfortunately
         with open(setup_file, 'w', encoding='utf-8') as f:
-            f.write(setup_format.format(module_paths, separate, cfiles, self.multi_file))
+            f.write(setup_format.format(module_paths,
+                                        separate,
+                                        cfiles,
+                                        self.multi_file,
+                                        opt_level))
 
         if not run_setup(setup_file, ['build_ext', '--inplace']):
             if testcase.config.getoption('--mypyc-showc'):

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -56,7 +56,7 @@ from mypyc.build import mypycify
 
 setup(name='test_run_output',
       ext_modules=mypycify({}, separate={}, skip_cgen_input={!r}, strip_asserts=False,
-                           multi_file={}, opt_level={}),
+                           multi_file={}, opt_level='{}'),
 )
 """
 


### PR DESCRIPTION
This speeds up run tests significantly, but it might miss some checks
only performed on higher optimization levels.

On my Linux desktop, this speeds up `pytest mypyc` from about 18s to
about 12s. It should also speed up CI builds, but I haven't measured
the impact.

Let's try this out. We can always revert this back if this turns out
to cause problems.

The environment variable MYPYC_OPT_LEVEL can be used to override
the optimization level. Example:

    MYPYC_OPT_LEVEL=3 pytest mypyc

Closes mypyc/mypyc#745.