### PR TITLE
[mypyc] Check both operands when int logical op is not EQ or NEQ

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -576,7 +576,14 @@ class LowLevelIRBuilder:
         op_type, c_func_desc = int_logical_op_mapping[op]
         result = self.alloc_temp(bool_rprimitive)
         short_int_block, int_block, out = BasicBlock(), BasicBlock(), BasicBlock()
-        check = self.check_tagged_short_int(lhs, line)
+        check_lhs = self.check_tagged_short_int(lhs, line)
+        if op in ("==", "!="):
+            check = check_lhs
+        else:
+            # for non-equal logical ops(less than, greater than, etc.), need to check both side
+            check_rhs = self.check_tagged_short_int(rhs, line)
+            check = self.binary_int_op(bool_rprimitive, check_lhs,
+                                       check_rhs, BinaryIntOp.AND, line)
         branch = Branch(check, short_int_block, int_block, Branch.BOOL_EXPR)
         branch.negated = False
         self.add(branch)

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -370,43 +370,57 @@ def f(a):
     a :: int
     r0 :: bool
     r1, r2, r3 :: native_int
-    r4, r5, r6, r7 :: bool
-    r8, r9, r10 :: native_int
-    r11, r12, r13 :: bool
+    r4 :: bool
+    r5, r6, r7 :: native_int
+    r8, r9, r10, r11, r12 :: bool
+    r13, r14, r15 :: native_int
+    r16 :: bool
+    r17, r18, r19 :: native_int
+    r20, r21, r22, r23 :: bool
     y, x :: int
-    r14 :: None
+    r24 :: None
 L0:
 L1:
     r1 = 1
     r2 = a & r1
     r3 = 0
     r4 = r2 == r3
-    if r4 goto L2 else goto L3 :: bool
+    r5 = 1
+    r6 = a & r5
+    r7 = 0
+    r8 = r6 == r7
+    r9 = r4 & r8
+    if r9 goto L2 else goto L3 :: bool
 L2:
-    r5 = a < a
-    r0 = r5
+    r10 = a < a
+    r0 = r10
     goto L4
 L3:
-    r6 = CPyTagged_IsLt_(a, a)
-    r0 = r6
+    r11 = CPyTagged_IsLt_(a, a)
+    r0 = r11
 L4:
     if r0 goto L5 else goto L12 :: bool
 L5:
 L6:
-    r8 = 1
-    r9 = a & r8
-    r10 = 0
-    r11 = r9 == r10
-    if r11 goto L7 else goto L8 :: bool
+    r13 = 1
+    r14 = a & r13
+    r15 = 0
+    r16 = r14 == r15
+    r17 = 1
+    r18 = a & r17
+    r19 = 0
+    r20 = r18 == r19
+    r21 = r16 & r20
+    if r21 goto L7 else goto L8 :: bool
 L7:
-    r12 = a < a
-    r7 = r12
+    r22 = a < a
+    r12 = r22
     goto L9
 L8:
-    r13 = CPyTagged_IsLt_(a, a)
-    r7 = r13
+    r23 = CPyTagged_IsLt_(a, a)
+    r12 = r23
 L9:
-    if r7 goto L10 else goto L11 :: bool
+    if r12 goto L10 else goto L11 :: bool
 L10:
     y = a
     goto L6
@@ -414,40 +428,50 @@ L11:
     x = a
     goto L1
 L12:
-    r14 = None
-    return r14
+    r24 = None
+    return r24
 (0, 0)   {a}                     {a}
-(1, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(1, 1)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(1, 2)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(1, 3)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(1, 4)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(2, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(2, 1)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(2, 2)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(3, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(3, 1)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(3, 2)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(4, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(5, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(6, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(6, 1)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(6, 2)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(6, 3)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(6, 4)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(7, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(7, 1)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(7, 2)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(8, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(8, 1)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(8, 2)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(9, 0)   {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(10, 0)  {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(10, 1)  {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(11, 0)  {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(11, 1)  {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(12, 0)  {a, r0, r7, x, y}       {a, r0, r7, x, y}
-(12, 1)  {a, r0, r7, x, y}       {a, r0, r7, x, y}
+(1, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 3)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 4)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 5)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 6)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 7)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 8)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 9)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(2, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(2, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(2, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(3, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(3, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(3, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(4, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(5, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 3)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 4)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 5)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 6)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 7)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 8)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 9)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(7, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(7, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(7, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(8, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(8, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(8, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(9, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(10, 0)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(10, 1)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(11, 0)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(11, 1)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(12, 0)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(12, 1)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
 
 [case testTrivial_BorrowedArgument]
 def f(a: int, b: int) -> int:

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -132,11 +132,13 @@ def sum(a, l):
     i :: int
     r2 :: bool
     r3, r4, r5 :: native_int
-    r6, r7, r8 :: bool
-    r9 :: object
-    r10, r11 :: int
-    r12 :: short_int
-    r13, r14 :: int
+    r6 :: bool
+    r7, r8, r9 :: native_int
+    r10, r11, r12, r13 :: bool
+    r14 :: object
+    r15, r16 :: int
+    r17 :: short_int
+    r18, r19 :: int
 L0:
     r0 = 0
     sum = r0
@@ -147,38 +149,43 @@ L1:
     r4 = i & r3
     r5 = 0
     r6 = r4 == r5
-    if r6 goto L2 else goto L3 :: bool
+    r7 = 1
+    r8 = l & r7
+    r9 = 0
+    r10 = r8 == r9
+    r11 = r6 & r10
+    if r11 goto L2 else goto L3 :: bool
 L2:
-    r7 = i < l
-    r2 = r7
+    r12 = i < l
+    r2 = r12
     goto L4
 L3:
-    r8 = CPyTagged_IsLt_(i, l)
-    r2 = r8
+    r13 = CPyTagged_IsLt_(i, l)
+    r2 = r13
 L4:
     if r2 goto L5 else goto L10 :: bool
 L5:
-    r9 = CPyList_GetItem(a, i)
-    if is_error(r9) goto L11 (error at sum:6) else goto L6
+    r14 = CPyList_GetItem(a, i)
+    if is_error(r14) goto L11 (error at sum:6) else goto L6
 L6:
-    r10 = unbox(int, r9)
-    dec_ref r9
-    if is_error(r10) goto L11 (error at sum:6) else goto L7
+    r15 = unbox(int, r14)
+    dec_ref r14
+    if is_error(r15) goto L11 (error at sum:6) else goto L7
 L7:
-    r11 = CPyTagged_Add(sum, r10)
+    r16 = CPyTagged_Add(sum, r15)
     dec_ref sum :: int
-    dec_ref r10 :: int
-    sum = r11
-    r12 = 1
-    r13 = CPyTagged_Add(i, r12)
+    dec_ref r15 :: int
+    sum = r16
+    r17 = 1
+    r18 = CPyTagged_Add(i, r17)
     dec_ref i :: int
-    i = r13
+    i = r18
     goto L1
 L8:
     return sum
 L9:
-    r14 = <error> :: int
-    return r14
+    r19 = <error> :: int
+    return r19
 L10:
     dec_ref i :: int
     goto L8

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -94,26 +94,33 @@ def f(x, y):
     x, y :: int
     r0 :: bool
     r1, r2, r3 :: native_int
-    r4, r5, r6 :: bool
-    r7 :: short_int
+    r4 :: bool
+    r5, r6, r7 :: native_int
+    r8, r9, r10, r11 :: bool
+    r12 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
     r3 = 0
     r4 = r2 == r3
-    if r4 goto L1 else goto L2 :: bool
+    r5 = 1
+    r6 = y & r5
+    r7 = 0
+    r8 = r6 == r7
+    r9 = r4 & r8
+    if r9 goto L1 else goto L2 :: bool
 L1:
-    r5 = x < y
-    r0 = r5
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r6 = CPyTagged_IsLt_(x, y)
-    r0 = r6
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r7 = 1
-    x = r7
+    r12 = 1
+    x = r12
 L5:
     return x
 
@@ -129,30 +136,37 @@ def f(x, y):
     x, y :: int
     r0 :: bool
     r1, r2, r3 :: native_int
-    r4, r5, r6 :: bool
-    r7, r8 :: short_int
+    r4 :: bool
+    r5, r6, r7 :: native_int
+    r8, r9, r10, r11 :: bool
+    r12, r13 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
     r3 = 0
     r4 = r2 == r3
-    if r4 goto L1 else goto L2 :: bool
+    r5 = 1
+    r6 = y & r5
+    r7 = 0
+    r8 = r6 == r7
+    r9 = r4 & r8
+    if r9 goto L1 else goto L2 :: bool
 L1:
-    r5 = x < y
-    r0 = r5
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r6 = CPyTagged_IsLt_(x, y)
-    r0 = r6
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r7 = 1
-    x = r7
+    r12 = 1
+    x = r12
     goto L6
 L5:
-    r8 = 2
-    x = r8
+    r13 = 2
+    x = r13
 L6:
     return x
 
@@ -168,33 +182,40 @@ def f(x, y):
     x, y :: int
     r0 :: bool
     r1, r2, r3 :: native_int
-    r4, r5, r6, r7 :: bool
-    r8, r9 :: short_int
+    r4 :: bool
+    r5, r6, r7 :: native_int
+    r8, r9, r10, r11, r12 :: bool
+    r13, r14 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
     r3 = 0
     r4 = r2 == r3
-    if r4 goto L1 else goto L2 :: bool
+    r5 = 1
+    r6 = y & r5
+    r7 = 0
+    r8 = r6 == r7
+    r9 = r4 & r8
+    if r9 goto L1 else goto L2 :: bool
 L1:
-    r5 = x < y
-    r0 = r5
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r6 = CPyTagged_IsLt_(x, y)
-    r0 = r6
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L4 else goto L6 :: bool
 L4:
-    r7 = CPyTagged_IsGt(x, y)
-    if r7 goto L5 else goto L6 :: bool
+    r12 = CPyTagged_IsGt(x, y)
+    if r12 goto L5 else goto L6 :: bool
 L5:
-    r8 = 1
-    x = r8
+    r13 = 1
+    x = r13
     goto L7
 L6:
-    r9 = 2
-    x = r9
+    r14 = 2
+    x = r14
 L7:
     return x
 
@@ -232,33 +253,40 @@ def f(x, y):
     x, y :: int
     r0 :: bool
     r1, r2, r3 :: native_int
-    r4, r5, r6, r7 :: bool
-    r8, r9 :: short_int
+    r4 :: bool
+    r5, r6, r7 :: native_int
+    r8, r9, r10, r11, r12 :: bool
+    r13, r14 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
     r3 = 0
     r4 = r2 == r3
-    if r4 goto L1 else goto L2 :: bool
+    r5 = 1
+    r6 = y & r5
+    r7 = 0
+    r8 = r6 == r7
+    r9 = r4 & r8
+    if r9 goto L1 else goto L2 :: bool
 L1:
-    r5 = x < y
-    r0 = r5
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r6 = CPyTagged_IsLt_(x, y)
-    r0 = r6
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L5 else goto L4 :: bool
 L4:
-    r7 = CPyTagged_IsGt(x, y)
-    if r7 goto L5 else goto L6 :: bool
+    r12 = CPyTagged_IsGt(x, y)
+    if r12 goto L5 else goto L6 :: bool
 L5:
-    r8 = 1
-    x = r8
+    r13 = 1
+    x = r13
     goto L7
 L6:
-    r9 = 2
-    x = r9
+    r14 = 2
+    x = r14
 L7:
     return x
 
@@ -294,26 +322,33 @@ def f(x, y):
     x, y :: int
     r0 :: bool
     r1, r2, r3 :: native_int
-    r4, r5, r6 :: bool
-    r7 :: short_int
+    r4 :: bool
+    r5, r6, r7 :: native_int
+    r8, r9, r10, r11 :: bool
+    r12 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
     r3 = 0
     r4 = r2 == r3
-    if r4 goto L1 else goto L2 :: bool
+    r5 = 1
+    r6 = y & r5
+    r7 = 0
+    r8 = r6 == r7
+    r9 = r4 & r8
+    if r9 goto L1 else goto L2 :: bool
 L1:
-    r5 = x < y
-    r0 = r5
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r6 = CPyTagged_IsLt_(x, y)
-    r0 = r6
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L5 else goto L4 :: bool
 L4:
-    r7 = 1
-    x = r7
+    r12 = 1
+    x = r12
 L5:
     return x
 
@@ -327,29 +362,36 @@ def f(x, y):
     x, y :: int
     r0 :: bool
     r1, r2, r3 :: native_int
-    r4, r5, r6, r7 :: bool
-    r8 :: short_int
+    r4 :: bool
+    r5, r6, r7 :: native_int
+    r8, r9, r10, r11, r12 :: bool
+    r13 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
     r3 = 0
     r4 = r2 == r3
-    if r4 goto L1 else goto L2 :: bool
+    r5 = 1
+    r6 = y & r5
+    r7 = 0
+    r8 = r6 == r7
+    r9 = r4 & r8
+    if r9 goto L1 else goto L2 :: bool
 L1:
-    r5 = x < y
-    r0 = r5
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r6 = CPyTagged_IsLt_(x, y)
-    r0 = r6
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r7 = CPyTagged_IsGt(x, y)
-    if r7 goto L6 else goto L5 :: bool
+    r12 = CPyTagged_IsGt(x, y)
+    if r12 goto L6 else goto L5 :: bool
 L5:
-    r8 = 1
-    x = r8
+    r13 = 1
+    x = r13
 L6:
     return x
 
@@ -434,34 +476,41 @@ def f(x, y):
     x, y :: int
     r0 :: bool
     r1, r2, r3 :: native_int
-    r4, r5, r6 :: bool
-    r7, r8 :: short_int
-    r9 :: None
+    r4 :: bool
+    r5, r6, r7 :: native_int
+    r8, r9, r10, r11 :: bool
+    r12, r13 :: short_int
+    r14 :: None
 L0:
     r1 = 1
     r2 = x & r1
     r3 = 0
     r4 = r2 == r3
-    if r4 goto L1 else goto L2 :: bool
+    r5 = 1
+    r6 = y & r5
+    r7 = 0
+    r8 = r6 == r7
+    r9 = r4 & r8
+    if r9 goto L1 else goto L2 :: bool
 L1:
-    r5 = x < y
-    r0 = r5
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r6 = CPyTagged_IsLt_(x, y)
-    r0 = r6
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r7 = 1
-    x = r7
+    r12 = 1
+    x = r12
     goto L6
 L5:
-    r8 = 2
-    y = r8
+    r13 = 2
+    y = r13
 L6:
-    r9 = None
-    return r9
+    r14 = None
+    return r14
 
 [case testRecursion]
 def f(n: int) -> int:
@@ -2682,9 +2731,11 @@ def f(x, y, z):
     x, y, z, r0, r1 :: int
     r2, r3 :: bool
     r4, r5, r6 :: native_int
-    r7, r8, r9 :: bool
-    r10 :: int
-    r11 :: bool
+    r7 :: bool
+    r8, r9, r10 :: native_int
+    r11, r12, r13, r14 :: bool
+    r15 :: int
+    r16 :: bool
 L0:
     r0 = g(x)
     r1 = g(y)
@@ -2692,23 +2743,28 @@ L0:
     r5 = r0 & r4
     r6 = 0
     r7 = r5 == r6
-    if r7 goto L1 else goto L2 :: bool
+    r8 = 1
+    r9 = r1 & r8
+    r10 = 0
+    r11 = r9 == r10
+    r12 = r7 & r11
+    if r12 goto L1 else goto L2 :: bool
 L1:
-    r8 = r0 < r1
-    r3 = r8
+    r13 = r0 < r1
+    r3 = r13
     goto L3
 L2:
-    r9 = CPyTagged_IsLt_(r0, r1)
-    r3 = r9
+    r14 = CPyTagged_IsLt_(r0, r1)
+    r3 = r14
 L3:
     if r3 goto L5 else goto L4 :: bool
 L4:
     r2 = r3
     goto L6
 L5:
-    r10 = g(z)
-    r11 = CPyTagged_IsGt(r1, r10)
-    r2 = r11
+    r15 = g(z)
+    r16 = CPyTagged_IsGt(r1, r15)
+    r2 = r16
 L6:
     return r2
 


### PR DESCRIPTION
This a bug I find during merging int logical ops.

Here's the less-than's inline function we have now:
```C
static inline bool CPyTagged_IsLt(CPyTagged left, CPyTagged right) {
    if (CPyTagged_CheckShort(left) && CPyTagged_CheckShort(right)) {
        return (Py_ssize_t)left < (Py_ssize_t)right;
    } else {
        return CPyTagged_IsLt_(left, right);
    }
}
```
Different from the equal's inline function, it checks both operands. So this PR completes that support and fix the potential bug.
