### PR TITLE
[mypyc] Support swapping operands and negating result and merge int NEQ

### DIFF
--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -172,5 +172,6 @@ int_less_than_ = c_custom_op(
 # note these are not complete implementations
 int_logical_op_mapping = {
     '==': IntLogicalOpDescrption(BinaryIntOp.EQ, int_equal_, False, False),
+    '!=': IntLogicalOpDescrption(BinaryIntOp.NEQ, int_equal_, True, False),
     '<': IntLogicalOpDescrption(BinaryIntOp.LT, int_less_than_, False, False)
 }  # type: Dict[str, IntLogicalOpDescrption]

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -6,7 +6,7 @@ representation (CPyTagged).
 See also the documentation for mypyc.rtypes.int_rprimitive.
 """
 
-from typing import Dict, Tuple
+from typing import Dict, NamedTuple
 from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, BinaryIntOp
 from mypyc.ir.rtypes import (
     int_rprimitive, bool_rprimitive, float_rprimitive, object_rprimitive, short_int_rprimitive,
@@ -143,6 +143,18 @@ int_neg_op = int_unary_op('-', 'CPyTagged_Negate')
 
 # integer comparsion operation implementation related:
 
+# Description for building int logical ops
+# For each field:
+# binary_op_variant: identify which BinaryIntOp to use when operands are short integers
+# c_func_description: the C function to call when operands are tagged integers
+# c_func_negated: whether to negate the C function call's result
+# c_func_swap_operands: whether to swap lhs and rhs when call the function
+IntLogicalOpDescrption = NamedTuple(
+    'IntLogicalOpDescrption',  [('binary_op_variant', int),
+                                ('c_func_description', CFunctionDescription),
+                                ('c_func_negated', bool),
+                                ('c_func_swap_operands', bool)])
+
 # description for equal operation on two boxed tagged integers
 int_equal_ = c_custom_op(
     arg_types=[int_rprimitive, int_rprimitive],
@@ -159,6 +171,6 @@ int_less_than_ = c_custom_op(
 # provide mapping from textual op to short int's op variant and boxed int's description
 # note these are not complete implementations
 int_logical_op_mapping = {
-    '==': (BinaryIntOp.EQ, int_equal_),
-    '<': (BinaryIntOp.LT, int_less_than_)
-}  # type: Dict[str, Tuple[int, CFunctionDescription]]
+    '==': IntLogicalOpDescrption(BinaryIntOp.EQ, int_equal_, False, False),
+    '<': IntLogicalOpDescrption(BinaryIntOp.LT, int_less_than_, False, False)
+}  # type: Dict[str, IntLogicalOpDescrption]

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -1358,7 +1358,7 @@ def lst(x):
 L0:
     r0 = len x :: list
     r1 = 0
-    r2 = CPyTagged_IsNe(r0, r1)
+    r2 = r0 != r1
     if r2 goto L1 else goto L2 :: bool
 L1:
     r3 = 1

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -1,4 +1,4 @@
-[case testIntEq]
+[case testIntNeq]
 def f(x: int, y: int) -> bool:
     return x != y
 [out]

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -5,7 +5,7 @@ def f(x: int, y: int) -> bool:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1, r2, r3 :: int64
+    r1, r2, r3 :: native_int
     r4, r5, r6, r7 :: bool
 L0:
     r1 = 1

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -1,0 +1,25 @@
+[case testIntEq]
+def f(x: int, y: int) -> bool:
+    return x != y
+[out]
+def f(x, y):
+    x, y :: int
+    r0 :: bool
+    r1, r2, r3 :: int64
+    r4, r5, r6, r7 :: bool
+L0:
+    r1 = 1
+    r2 = x & r1
+    r3 = 0
+    r4 = r2 == r3
+    if r4 goto L1 else goto L2 :: bool
+L1:
+    r5 = x != y
+    r0 = r5
+    goto L3
+L2:
+    r6 = CPyTagged_IsEq_(x, y)
+    r7 = !r6
+    r0 = r7
+L3:
+    return r0

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -28,6 +28,7 @@ files = [
     'irbuild-try.test',
     'irbuild-set.test',
     'irbuild-strip-asserts.test',
+    'irbuild-int.test',
 ]
 
 


### PR DESCRIPTION
This PR implements support for swapping operands and negating result when building logical ops mentioned in https://github.com/python/mypy/pull/9148#issuecomment-658123381. To demonstrate, NEQ is merged. Since it has no IR test, I build one `irbuild-int.test`.