### PR TITLE
[mypyc] LoadInt store doubled value if tagged integer

### DIFF
--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -14,7 +14,7 @@ from mypyc.ir.ops import (
     NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CallC, LoadGlobal, Truncate,
     BinaryIntOp
 )
-from mypyc.ir.rtypes import RType, RTuple, is_int32_rprimitive, is_int64_rprimitive
+from mypyc.ir.rtypes import RType, RTuple
 from mypyc.ir.func_ir import FuncIR, FuncDecl, FUNC_STATICMETHOD, FUNC_CLASSMETHOD
 from mypyc.ir.class_ir import ClassIR
 
@@ -175,10 +175,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
 
     def visit_load_int(self, op: LoadInt) -> None:
         dest = self.reg(op)
-        if is_int32_rprimitive(op.type) or is_int64_rprimitive(op.type):
-            self.emit_line('%s = %d;' % (dest, op.value))
-        else:
-            self.emit_line('%s = %d;' % (dest, op.value * 2))
+        self.emit_line('%s = %d;' % (dest, op.value))
 
     def visit_load_error_value(self, op: LoadErrorValue) -> None:
         if isinstance(op.type, RTuple):

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -791,7 +791,10 @@ class LoadInt(RegisterOp):
 
     def __init__(self, value: int, line: int = -1, rtype: RType = short_int_rprimitive) -> None:
         super().__init__(line)
-        self.value = value
+        if is_short_int_rprimitive(rtype) or is_int_rprimitive(rtype):
+            self.value = value * 2
+        else:
+            self.value = value
         self.type = rtype
 
     def sources(self) -> List[Value]:

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -21,7 +21,7 @@ def f(a):
     z :: int
     r10 :: None
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
     r2 = 1
     r3 = x & r2
@@ -38,11 +38,11 @@ L2:
 L3:
     if r1 goto L4 else goto L5 :: bool
 L4:
-    r8 = 1
+    r8 = 2
     y = r8
     goto L6
 L5:
-    r9 = 1
+    r9 = 2
     z = r9
 L6:
     r10 = None
@@ -85,9 +85,9 @@ def f(a):
     r1 :: short_int
     r2 :: bool
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
-    r1 = 1
+    r1 = 2
     r2 = CPyTagged_IsEq(x, r1)
     if r2 goto L1 else goto L2 :: bool
 L1:
@@ -119,11 +119,11 @@ def f():
     y :: int
     r2 :: short_int
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
-    r1 = 1
+    r1 = 2
     y = r1
-    r2 = 2
+    r2 = 4
     x = r2
     return x
 (0, 0)   {}                      {r0}
@@ -145,11 +145,11 @@ def f(a):
     a :: int
     r0, r1, r2 :: short_int
 L0:
-    r0 = 1
+    r0 = 2
     a = r0
-    r1 = 2
+    r1 = 4
     a = r1
-    r2 = 3
+    r2 = 6
     a = r2
     return a
 (0, 0)   {}                      {r0}
@@ -179,17 +179,17 @@ def f(a):
     r4 :: short_int
     r5 :: None
 L0:
-    r0 = 1
+    r0 = 2
     r1 = CPyTagged_IsEq(a, r0)
     if r1 goto L1 else goto L2 :: bool
 L1:
-    r2 = 1
+    r2 = 2
     y = r2
-    r3 = 2
+    r3 = 4
     x = r3
     goto L3
 L2:
-    r4 = 2
+    r4 = 4
     x = r4
 L3:
     r5 = None
@@ -233,11 +233,11 @@ def f(n):
     r4 :: None
 L0:
 L1:
-    r0 = 5
+    r0 = 10
     r1 = CPyTagged_IsLt(n, r0)
     if r1 goto L2 else goto L3 :: bool
 L2:
-    r2 = 1
+    r2 = 2
     r3 = CPyTagged_Add(n, r2)
     n = r3
     m = n
@@ -280,22 +280,22 @@ def f(n):
     r6 :: short_int
     r7 :: None
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
-    r1 = 1
+    r1 = 2
     y = r1
 L1:
-    r2 = 1
+    r2 = 2
     r3 = CPyTagged_IsLt(n, r2)
     if r3 goto L2 else goto L6 :: bool
 L2:
     n = y
 L3:
-    r4 = 2
+    r4 = 4
     r5 = CPyTagged_IsLt(n, r4)
     if r5 goto L4 else goto L5 :: bool
 L4:
-    r6 = 1
+    r6 = 2
     n = r6
     n = x
     goto L3
@@ -335,7 +335,7 @@ def f(x):
     r0 :: short_int
     r1, a, r2, r3, r4 :: int
 L0:
-    r0 = 1
+    r0 = 2
     r1 = f(r0)
     if is_error(r1) goto L3 (error at f:2) else goto L1
 L1:
@@ -494,7 +494,7 @@ def f(a):
     r0 :: short_int
 L0:
     b = a
-    r0 = 1
+    r0 = 2
     a = r0
     return a
 (0, 0)   {a}                     {a}
@@ -535,13 +535,13 @@ L2:
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r7 = 2
+    r7 = 4
     x = r7
-    r8 = 1
+    r8 = 2
     a = r8
     goto L6
 L5:
-    r9 = 1
+    r9 = 2
     x = r9
 L6:
     return x
@@ -597,7 +597,7 @@ L1:
 L2:
     r3 = CPyTagged_Add(sum, i)
     sum = r3
-    r4 = 1
+    r4 = 2
     r5 = CPyTagged_Add(i, r4)
     i = r5
     goto L1
@@ -659,7 +659,7 @@ L3:
     r5 = CPy_ExceptionMatches(r4)
     if r5 goto L4 else goto L5 :: bool
 L4:
-    r6 = 1
+    r6 = 2
     r7 = CPyTagged_Negate(r6)
     CPy_RestoreExcInfo(r1)
     return r7
@@ -679,7 +679,7 @@ L8:
 L9:
     unreachable
 L10:
-    r9 = 1
+    r9 = 2
     r10 = CPyTagged_Add(st, r9)
     return r10
 L11:

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -90,7 +90,7 @@ L0:
     r2 = x is r1
     if r2 goto L1 else goto L2 :: bool
 L1:
-    r3 = 1
+    r3 = 2
     return r3
 L2:
     inc_ref x
@@ -104,10 +104,10 @@ L3:
     r8 = !r7
     if r8 goto L4 else goto L5 :: bool
 L4:
-    r9 = 2
+    r9 = 4
     return r9
 L5:
-    r10 = 3
+    r10 = 6
     return r10
 L6:
     r11 = <error> :: int
@@ -176,7 +176,7 @@ L7:
     dec_ref sum :: int
     dec_ref r15 :: int
     sum = r16
-    r17 = 1
+    r17 = 2
     r18 = CPyTagged_Add(i, r17)
     dec_ref i :: int
     i = r18

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -5,7 +5,7 @@ def f() -> int:
 def f():
     r0 :: short_int
 L0:
-    r0 = 1
+    r0 = 2
     return r0
 
 [case testFunctionArgument]
@@ -47,7 +47,7 @@ def f():
     r0 :: short_int
     x, y :: int
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
     y = x
     return y
@@ -64,7 +64,7 @@ def f(x):
     y :: int
     r1 :: None
 L0:
-    r0 = 1
+    r0 = 2
     y = r0
     y = x
     r1 = None
@@ -79,7 +79,7 @@ def f(x, y):
     r0 :: short_int
     r1, r2 :: int
 L0:
-    r0 = 1
+    r0 = 2
     r1 = CPyTagged_Add(y, r0)
     r2 = CPyTagged_Multiply(x, r1)
     return r2
@@ -119,7 +119,7 @@ L2:
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r12 = 1
+    r12 = 2
     x = r12
 L5:
     return x
@@ -161,11 +161,11 @@ L2:
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r12 = 1
+    r12 = 2
     x = r12
     goto L6
 L5:
-    r13 = 2
+    r13 = 4
     x = r13
 L6:
     return x
@@ -210,11 +210,11 @@ L4:
     r12 = CPyTagged_IsGt(x, y)
     if r12 goto L5 else goto L6 :: bool
 L5:
-    r13 = 1
+    r13 = 2
     x = r13
     goto L7
 L6:
-    r14 = 2
+    r14 = 4
     x = r14
 L7:
     return x
@@ -281,11 +281,11 @@ L4:
     r12 = CPyTagged_IsGt(x, y)
     if r12 goto L5 else goto L6 :: bool
 L5:
-    r13 = 1
+    r13 = 2
     x = r13
     goto L7
 L6:
-    r14 = 2
+    r14 = 4
     x = r14
 L7:
     return x
@@ -347,7 +347,7 @@ L2:
 L3:
     if r0 goto L5 else goto L4 :: bool
 L4:
-    r12 = 1
+    r12 = 2
     x = r12
 L5:
     return x
@@ -390,7 +390,7 @@ L4:
     r12 = CPyTagged_IsGt(x, y)
     if r12 goto L6 else goto L5 :: bool
 L5:
-    r13 = 1
+    r13 = 2
     x = r13
 L6:
     return x
@@ -429,7 +429,7 @@ def f(x, y):
     r1 :: bool
     r2 :: int
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
 L1:
     r1 = CPyTagged_IsGt(x, y)
@@ -460,7 +460,7 @@ def f():
     x :: int
     r1 :: None
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
     r1 = None
     return r1
@@ -502,11 +502,11 @@ L2:
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r12 = 1
+    r12 = 2
     x = r12
     goto L6
 L5:
-    r13 = 2
+    r13 = 4
     y = r13
 L6:
     r14 = None
@@ -528,17 +528,17 @@ def f(n):
     r6 :: short_int
     r7, r8, r9 :: int
 L0:
-    r0 = 1
+    r0 = 2
     r1 = CPyTagged_IsLe(n, r0)
     if r1 goto L1 else goto L2 :: bool
 L1:
-    r2 = 1
+    r2 = 2
     return r2
 L2:
-    r3 = 1
+    r3 = 2
     r4 = CPyTagged_Subtract(n, r3)
     r5 = f(r4)
-    r6 = 2
+    r6 = 4
     r7 = CPyTagged_Subtract(n, r6)
     r8 = f(r7)
     r9 = CPyTagged_Add(r5, r8)
@@ -582,7 +582,7 @@ L0:
     r1 = CPyTagged_IsLt(n, r0)
     if r1 goto L1 else goto L2 :: bool
 L1:
-    r2 = 1
+    r2 = 2
     x = r2
     goto L6
 L2:
@@ -590,11 +590,11 @@ L2:
     r4 = CPyTagged_IsEq(n, r3)
     if r4 goto L3 else goto L4 :: bool
 L3:
-    r5 = 1
+    r5 = 2
     x = r5
     goto L5
 L4:
-    r6 = 2
+    r6 = 4
     x = r6
 L5:
 L6:
@@ -609,7 +609,7 @@ def f(n):
     r0 :: short_int
     r1 :: int
 L0:
-    r0 = 1
+    r0 = 2
     r1 = CPyTagged_Negate(r0)
     return r1
 
@@ -632,7 +632,7 @@ L1:
     r2 = r3
     goto L3
 L2:
-    r4 = 1
+    r4 = 2
     r2 = r4
 L3:
     return r2
@@ -651,7 +651,7 @@ def f():
 L0:
     r0 = 0
     x = r0
-    r1 = 1
+    r1 = 2
     r2 = CPyTagged_Add(x, r1)
     x = r2
     return x
@@ -764,7 +764,7 @@ L0:
     r0 = builtins :: module
     r1 = unicode_1 :: static  ('print')
     r2 = getattr r0, r1
-    r3 = 5
+    r3 = 10
     r4 = box(short_int, r3)
     r5 = py_call(r2, r4)
     r6 = None
@@ -783,7 +783,7 @@ def f(x):
     r3, r4, r5 :: object
     r6 :: None
 L0:
-    r0 = 5
+    r0 = 10
     r1 = builtins :: module
     r2 = unicode_1 :: static  ('print')
     r3 = getattr r1, r2
@@ -859,7 +859,7 @@ def g(y):
     r7, r8 :: None
 L0:
     r0 = g(y)
-    r1 = 1
+    r1 = 2
     r2 = box(short_int, r1)
     r3 = [r2]
     r4 = g(r3)
@@ -891,13 +891,13 @@ def g(y):
     r12 :: short_int
     r13 :: object
 L0:
-    r0 = 1
+    r0 = 2
     r1 = box(short_int, r0)
     r2 = g(r1)
     r3 = [y]
     a = r3
-    r4 = 1
-    r5 = 2
+    r4 = 2
+    r5 = 4
     r6 = (r4, r5)
     r7 = 0
     r8 = box(tuple[int, int], r6)
@@ -905,7 +905,7 @@ L0:
     r10 = True
     r11 = box(bool, r10)
     y = r11
-    r12 = 3
+    r12 = 6
     r13 = box(short_int, r12)
     return r13
 
@@ -927,7 +927,7 @@ def f(a, o):
     r4 :: object
     r5 :: None
 L0:
-    r0 = 1
+    r0 = 2
     r1 = box(short_int, r0)
     a.x = r1; r2 = is_error
     r3 = a.n
@@ -1135,7 +1135,7 @@ L0:
     d_64_bit = r5
     r6 = int_7 :: static  (2147483647)
     max_32_bit = r6
-    r7 = 1073741823
+    r7 = 2147483646
     max_31_bit = r7
     r8 = None
     return r8
@@ -1241,7 +1241,7 @@ def call_python_function_with_keyword_arg(x):
     r7 :: object
     r8 :: int
 L0:
-    r0 = 2
+    r0 = 4
     r1 = int
     r2 = unicode_3 :: static  ('base')
     r3 = (x) :: tuple
@@ -1284,7 +1284,7 @@ L0:
     r7 = box(int, first)
     r8 = CPyDict_Build(r6, r3, r7)
     r9 = py_call_with_kwargs(r2, r5, r8)
-    r10 = 1
+    r10 = 2
     r11 = unicode_4 :: static  ('insert')
     r12 = getattr xs, r11
     r13 = unicode_5 :: static  ('x')
@@ -1326,7 +1326,7 @@ L0:
     r0 = bool x :: object
     if r0 goto L1 else goto L2 :: bool
 L1:
-    r1 = 1
+    r1 = 2
     return r1
 L2:
     r2 = 0
@@ -1343,7 +1343,7 @@ L0:
     r1 = CPyTagged_IsNe(x, r0)
     if r1 goto L1 else goto L2 :: bool
 L1:
-    r2 = 1
+    r2 = 2
     return r2
 L2:
     r3 = 0
@@ -1361,7 +1361,7 @@ L0:
     r2 = r0 != r1
     if r2 goto L1 else goto L2 :: bool
 L1:
-    r3 = 1
+    r3 = 2
     return r3
 L2:
     r4 = 0
@@ -1410,7 +1410,7 @@ L1:
     r4 = CPyTagged_IsNe(r2, r3)
     if r4 goto L2 else goto L3 :: bool
 L2:
-    r5 = 1
+    r5 = 2
     return r5
 L3:
     r6 = 0
@@ -1427,7 +1427,7 @@ L0:
     r1 = x is not r0
     if r1 goto L1 else goto L2 :: bool
 L1:
-    r2 = 1
+    r2 = 2
     return r2
 L2:
     r3 = 0
@@ -1450,7 +1450,7 @@ L1:
     r3 = bool r2 :: object
     if r3 goto L2 else goto L3 :: bool
 L2:
-    r4 = 1
+    r4 = 2
     return r4
 L3:
     r5 = 0
@@ -1543,7 +1543,7 @@ L1:
     r4 = import r3 :: str
     builtins = r4 :: module
 L2:
-    r5 = 1
+    r5 = 2
     r6 = __main__.globals :: static
     r7 = unicode_1 :: static  ('x')
     r8 = box(short_int, r5)
@@ -1582,7 +1582,7 @@ L0:
     r0 = m :: module
     r1 = unicode_2 :: static  ('f')
     r2 = getattr r0, r1
-    r3 = 1
+    r3 = 2
     r4 = box(short_int, r3)
     r5 = py_call(r2, r4)
     r6 = cast(str, r5)
@@ -1702,7 +1702,7 @@ L0:
     r0 = unicode_1 :: static  ('a')
     r1 = 0
     r2 = f(r1, r0)
-    r3 = 1
+    r3 = 2
     r4 = unicode_2 :: static  ('b')
     r5 = f(r3, r4)
     r6 = None
@@ -1736,7 +1736,7 @@ L0:
     r0 = unicode_4 :: static  ('a')
     r1 = 0
     r2 = a.f(r1, r0)
-    r3 = 1
+    r3 = 2
     r4 = unicode_5 :: static  ('b')
     r5 = a.f(r3, r4)
     r6 = None
@@ -1770,9 +1770,9 @@ def g():
     r12 :: object
     r13 :: tuple[int, int, int]
 L0:
-    r0 = 1
-    r1 = 2
-    r2 = 3
+    r0 = 2
+    r1 = 4
+    r2 = 6
     r3 = (r0, r1, r2)
     r4 = __main__.globals :: static
     r5 = unicode_3 :: static  ('f')
@@ -1798,9 +1798,9 @@ def h():
     r13 :: object
     r14 :: tuple[int, int, int]
 L0:
-    r0 = 1
-    r1 = 2
-    r2 = 3
+    r0 = 2
+    r1 = 4
+    r2 = 6
     r3 = (r1, r2)
     r4 = __main__.globals :: static
     r5 = unicode_3 :: static  ('f')
@@ -1849,11 +1849,11 @@ def g():
     r18 :: tuple[int, int, int]
 L0:
     r0 = unicode_3 :: static  ('a')
-    r1 = 1
+    r1 = 2
     r2 = unicode_4 :: static  ('b')
-    r3 = 2
+    r3 = 4
     r4 = unicode_5 :: static  ('c')
-    r5 = 3
+    r5 = 6
     r6 = 3
     r7 = box(short_int, r1)
     r8 = box(short_int, r3)
@@ -1885,11 +1885,11 @@ def h():
     r16 :: object
     r17 :: tuple[int, int, int]
 L0:
-    r0 = 1
+    r0 = 2
     r1 = unicode_4 :: static  ('b')
-    r2 = 2
+    r2 = 4
     r3 = unicode_5 :: static  ('c')
-    r4 = 3
+    r4 = 6
     r5 = 2
     r6 = box(short_int, r2)
     r7 = box(short_int, r4)
@@ -1922,7 +1922,7 @@ def f(x, y, z):
 L0:
     if is_error(y) goto L1 else goto L2
 L1:
-    r0 = 3
+    r0 = 6
     y = r0
 L2:
     if is_error(z) goto L3 else goto L4
@@ -1941,12 +1941,12 @@ def g():
     r6 :: str
     r7, r8 :: None
 L0:
-    r0 = 2
+    r0 = 4
     r1 = <error> :: int
     r2 = <error> :: str
     r3 = f(r0, r1, r2)
-    r4 = 3
-    r5 = 6
+    r4 = 6
+    r5 = 12
     r6 = <error> :: str
     r7 = f(r5, r4, r6)
     r8 = None
@@ -1972,7 +1972,7 @@ def A.f(self, x, y, z):
 L0:
     if is_error(y) goto L1 else goto L2
 L1:
-    r0 = 3
+    r0 = 6
     y = r0
 L2:
     if is_error(z) goto L3 else goto L4
@@ -1994,12 +1994,12 @@ def g():
 L0:
     r0 = A()
     a = r0
-    r1 = 2
+    r1 = 4
     r2 = <error> :: int
     r3 = <error> :: str
     r4 = a.f(r1, r2, r3)
-    r5 = 3
-    r6 = 6
+    r5 = 6
+    r6 = 12
     r7 = <error> :: str
     r8 = a.f(r6, r5, r7)
     r9 = None
@@ -2030,9 +2030,9 @@ def f():
     r21, r22 :: short_int
 L0:
     r0 = []
-    r1 = 1
-    r2 = 2
-    r3 = 3
+    r1 = 2
+    r2 = 4
+    r3 = 6
     r4 = box(short_int, r1)
     r5 = box(short_int, r2)
     r6 = box(short_int, r3)
@@ -2047,13 +2047,13 @@ L2:
     r12 = r7[r9] :: unsafe list
     r13 = unbox(int, r12)
     x = r13
-    r14 = 2
+    r14 = 4
     r15 = CPyTagged_IsNe(x, r14)
     if r15 goto L4 else goto L3 :: bool
 L3:
     goto L7
 L4:
-    r16 = 3
+    r16 = 6
     r17 = CPyTagged_IsNe(x, r16)
     if r17 goto L6 else goto L5 :: bool
 L5:
@@ -2063,7 +2063,7 @@ L6:
     r19 = box(int, r18)
     r20 = PyList_Append(r0, r19)
 L7:
-    r21 = 1
+    r21 = 2
     r22 = r9 + r21
     r9 = r22
     goto L1
@@ -2094,9 +2094,9 @@ def f():
     r22, r23 :: short_int
 L0:
     r0 = PyDict_New()
-    r1 = 1
-    r2 = 2
-    r3 = 3
+    r1 = 2
+    r2 = 4
+    r3 = 6
     r4 = box(short_int, r1)
     r5 = box(short_int, r2)
     r6 = box(short_int, r3)
@@ -2111,13 +2111,13 @@ L2:
     r12 = r7[r9] :: unsafe list
     r13 = unbox(int, r12)
     x = r13
-    r14 = 2
+    r14 = 4
     r15 = CPyTagged_IsNe(x, r14)
     if r15 goto L4 else goto L3 :: bool
 L3:
     goto L7
 L4:
-    r16 = 3
+    r16 = 6
     r17 = CPyTagged_IsNe(x, r16)
     if r17 goto L6 else goto L5 :: bool
 L5:
@@ -2128,7 +2128,7 @@ L6:
     r20 = box(int, r18)
     r21 = CPyDict_SetItem(r0, r19, r20)
 L7:
-    r22 = 1
+    r22 = 2
     r23 = r9 + r22
     r9 = r23
     goto L1
@@ -2178,7 +2178,7 @@ L2:
     r8 = r5[2]
     z = r8
 L3:
-    r9 = 1
+    r9 = 2
     r10 = r1 + r9
     r1 = r10
     goto L1
@@ -2204,7 +2204,7 @@ L6:
     r23 = box(int, r22)
     r24 = PyList_Append(r11, r23)
 L7:
-    r25 = 1
+    r25 = 2
     r26 = r13 + r25
     r13 = r26
     goto L5
@@ -2259,7 +2259,7 @@ def PropertyHolder.twice_value(self):
     r0 :: short_int
     r1, r2 :: int
 L0:
-    r0 = 2
+    r0 = 4
     r1 = self.value
     r2 = CPyTagged_Multiply(r0, r1)
     return r2
@@ -2333,7 +2333,7 @@ def BaseProperty.next(self):
     r3 :: __main__.BaseProperty
 L0:
     r0 = self._incrementer
-    r1 = 1
+    r1 = 2
     r2 = CPyTagged_Add(r0, r1)
     r3 = BaseProperty(r2)
     return r3
@@ -2486,7 +2486,7 @@ def SubclassedTrait.boxed(self):
     r0 :: short_int
     r1 :: object
 L0:
-    r0 = 3
+    r0 = 6
     r1 = box(short_int, r0)
     return r1
 def DerivingObject.this(self):
@@ -2502,7 +2502,7 @@ def DerivingObject.boxed(self):
     self :: __main__.DerivingObject
     r0 :: short_int
 L0:
-    r0 = 5
+    r0 = 10
     return r0
 def DerivingObject.boxed__SubclassedTrait_glue(__mypyc_self__):
     __mypyc_self__ :: __main__.DerivingObject
@@ -2670,7 +2670,7 @@ L4:
     r39 = __main__.globals :: static
     r40 = unicode_5 :: static  ('Lol')
     r41 = CPyDict_SetItem(r39, r40, r38)
-    r42 = 1
+    r42 = 2
     r43 = unicode_8 :: static
     r44 = __main__.globals :: static
     r45 = unicode_5 :: static  ('Lol')
@@ -2700,9 +2700,9 @@ L4:
     r69 = __main__.globals :: static
     r70 = unicode_11 :: static  ('Bar')
     r71 = CPyDict_SetItem(r69, r70, r68)
-    r72 = 1
-    r73 = 2
-    r74 = 3
+    r72 = 2
+    r73 = 4
+    r74 = 6
     r75 = box(short_int, r72)
     r76 = box(short_int, r73)
     r77 = box(short_int, r74)
@@ -3308,10 +3308,10 @@ def f(a):
 L0:
     if a goto L1 else goto L2 :: bool
 L1:
-    r0 = 1
+    r0 = 2
     return r0
 L2:
-    r1 = 2
+    r1 = 4
     return r1
 L3:
     unreachable
@@ -3387,9 +3387,9 @@ def C.__mypyc_defaults_setup(__mypyc_self__):
     r2 :: short_int
     r3, r4 :: bool
 L0:
-    r0 = 1
+    r0 = 2
     __mypyc_self__.x = r0; r1 = is_error
-    r2 = 2
+    r2 = 4
     __mypyc_self__.y = r2; r3 = is_error
     r4 = True
     return r4
@@ -3399,10 +3399,10 @@ def f(a):
 L0:
     if a goto L1 else goto L2 :: bool
 L1:
-    r0 = 1
+    r0 = 2
     return r0
 L2:
-    r1 = 2
+    r1 = 4
     return r1
 L3:
     unreachable
@@ -3475,7 +3475,7 @@ L1:
     raise NameError('value for final name "x" was not set')
     unreachable
 L2:
-    r2 = 1
+    r2 = 2
     r3 = CPyTagged_Subtract(r0, r2)
     return r3
 
@@ -3495,7 +3495,7 @@ def foo(z):
     r0 :: short_int
     r1 :: None
 L0:
-    r0 = 10
+    r0 = 20
     r1 = None
     return r1
 
@@ -3534,7 +3534,7 @@ L0:
     r0 = x.__bool__()
     if r0 goto L1 else goto L2 :: bool
 L1:
-    r1 = 1
+    r1 = 2
     return r1
 L2:
     r2 = 0

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -25,7 +25,7 @@ def f(a):
     r1 :: bool
     r2 :: None
 L0:
-    r0 = 1
+    r0 = 2
     a.x = r0; r1 = is_error
     r2 = None
     return r2
@@ -55,7 +55,7 @@ def f():
 L0:
     r0 = C()
     c = r0
-    r1 = 5
+    r1 = 10
     c.x = r1; r2 = is_error
     r3 = [c]
     a = r3
@@ -64,7 +64,7 @@ L0:
     r6 = cast(__main__.C, r5)
     d = r6
     r7 = d.x
-    r8 = 1
+    r8 = 2
     r9 = CPyTagged_Add(r7, r8)
     return r9
 
@@ -83,7 +83,7 @@ def A.f(self, x, y):
     r0 :: short_int
     r1 :: int
 L0:
-    r0 = 10
+    r0 = 20
     r1 = CPyTagged_Add(x, r0)
     return r1
 def g(a):
@@ -93,7 +93,7 @@ def g(a):
     r2 :: int
     r3 :: None
 L0:
-    r0 = 1
+    r0 = 2
     r1 = unicode_4 :: static  ('hi')
     r2 = a.f(r0, r1)
     r3 = None
@@ -142,14 +142,14 @@ L0:
     r4 = !r3
     if r4 goto L1 else goto L2 :: bool
 L1:
-    r5 = 1
+    r5 = 2
     r6 = self.next
     r7 = cast(__main__.Node, r6)
     r8 = r7.length()
     r9 = CPyTagged_Add(r5, r8)
     return r9
 L2:
-    r10 = 1
+    r10 = 2
     return r10
 
 [case testSubclass]
@@ -167,7 +167,7 @@ def A.__init__(self):
     r1 :: bool
     r2 :: None
 L0:
-    r0 = 10
+    r0 = 20
     self.x = r0; r1 = is_error
     r2 = None
     return r2
@@ -179,9 +179,9 @@ def B.__init__(self):
     r3 :: bool
     r4 :: None
 L0:
-    r0 = 20
+    r0 = 40
     self.x = r0; r1 = is_error
-    r2 = 30
+    r2 = 60
     self.y = r2; r3 = is_error
     r4 = None
     return r4
@@ -201,7 +201,7 @@ def O.__init__(self):
     r1 :: bool
     r2 :: None
 L0:
-    r0 = 1
+    r0 = 2
     self.x = r0; r1 = is_error
     r2 = None
     return r2
@@ -213,7 +213,7 @@ def increment(o):
     r3 :: bool
 L0:
     r0 = o.x
-    r1 = 1
+    r1 = 2
     r2 = CPyTagged_Add(r0, r1)
     o.x = r2; r3 = is_error
     return o
@@ -704,7 +704,7 @@ def C.foo(x):
     r0 :: short_int
     r1 :: int
 L0:
-    r0 = 10
+    r0 = 20
     r1 = CPyTagged_Add(r0, x)
     return r1
 def C.bar(cls, x):
@@ -713,7 +713,7 @@ def C.bar(cls, x):
     r0 :: short_int
     r1 :: int
 L0:
-    r0 = 10
+    r0 = 20
     r1 = CPyTagged_Add(r0, x)
     return r1
 def lol():
@@ -723,10 +723,10 @@ def lol():
     r3 :: short_int
     r4, r5 :: int
 L0:
-    r0 = 1
+    r0 = 2
     r1 = C.foo(r0)
     r2 = __main__.C :: type
-    r3 = 2
+    r3 = 4
     r4 = C.bar(r2, r3)
     r5 = CPyTagged_Add(r1, r4)
     return r5
@@ -1017,7 +1017,7 @@ def A.lol(self):
     r1 :: bool
     r2 :: None
 L0:
-    r0 = 100
+    r0 = 200
     self.x = r0; r1 = is_error
     r2 = None
     return r2
@@ -1026,7 +1026,7 @@ def A.__mypyc_defaults_setup(__mypyc_self__):
     r0 :: short_int
     r1, r2 :: bool
 L0:
-    r0 = 10
+    r0 = 20
     __mypyc_self__.x = r0; r1 = is_error
     r2 = True
     return r2
@@ -1043,7 +1043,7 @@ def B.__mypyc_defaults_setup(__mypyc_self__):
     r8 :: object
     r9, r10, r11, r12 :: bool
 L0:
-    r0 = 10
+    r0 = 20
     __mypyc_self__.x = r0; r1 = is_error
     r2 = __main__.globals :: static
     r3 = unicode_9 :: static  ('LOL')

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -63,8 +63,8 @@ def f(x):
     r6, d :: dict
     r7 :: None
 L0:
-    r0 = 1
-    r1 = 2
+    r0 = 2
+    r1 = 4
     r2 = unicode_1 :: static
     r3 = 2
     r4 = box(short_int, r0)
@@ -89,7 +89,7 @@ def f(d):
     r2 :: int32
     r3, r4, r5 :: bool
 L0:
-    r0 = 4
+    r0 = 8
     r1 = box(short_int, r0)
     r2 = PyDict_Contains(d, r1)
     r3 = truncate r2: int32 to builtins.bool
@@ -118,7 +118,7 @@ def f(d):
     r2 :: int32
     r3, r4, r5, r6 :: bool
 L0:
-    r0 = 4
+    r0 = 8
     r1 = box(short_int, r0)
     r2 = PyDict_Contains(d, r1)
     r3 = truncate r2: int32 to builtins.bool
@@ -186,7 +186,7 @@ L2:
     r8 = cast(str, r7)
     k = r8
     r9 = CPyDict_GetItem(d, k)
-    r10 = 1
+    r10 = 2
     r11 = box(short_int, r10)
     r12 = r9 += r11
     r13 = CPyDict_SetItem(d, k, r12)
@@ -216,9 +216,9 @@ def f(x, y):
     r7 :: object
     r8 :: int32
 L0:
-    r0 = 2
+    r0 = 4
     r1 = unicode_3 :: static  ('z')
-    r2 = 3
+    r2 = 6
     r3 = 1
     r4 = box(short_int, r0)
     r5 = CPyDict_Build(r3, x, r4)

--- a/mypyc/test-data/irbuild-generics.test
+++ b/mypyc/test-data/irbuild-generics.test
@@ -62,10 +62,10 @@ def f():
 L0:
     r0 = C()
     c = r0
-    r1 = 1
+    r1 = 2
     r2 = box(short_int, r1)
     c.x = r2; r3 = is_error
-    r4 = 2
+    r4 = 4
     r5 = c.x
     r6 = unbox(int, r5)
     r7 = CPyTagged_Add(r4, r6)
@@ -128,11 +128,11 @@ L0:
     r0 = x.get()
     r1 = unbox(int, r0)
     y = r1
-    r2 = 1
+    r2 = 2
     r3 = CPyTagged_Add(y, r2)
     r4 = box(int, r3)
     r5 = x.set(r4)
-    r6 = 2
+    r6 = 4
     r7 = box(short_int, r6)
     r8 = C(r7)
     x = r8

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -47,7 +47,7 @@ L0:
     r0 = 0
     r1 = CPyList_GetItemShort(x, r0)
     r2 = cast(list, r1)
-    r3 = 1
+    r3 = 2
     r4 = CPyList_GetItemShort(r2, r3)
     r5 = unbox(int, r4)
     return r5
@@ -64,7 +64,7 @@ def f(x):
     r3 :: bool
     r4 :: None
 L0:
-    r0 = 1
+    r0 = 2
     r1 = 0
     r2 = box(short_int, r0)
     r3 = CPyList_SetItem(x, r1, r2)
@@ -96,8 +96,8 @@ def f():
     r4, x :: list
     r5 :: None
 L0:
-    r0 = 1
-    r1 = 2
+    r0 = 2
+    r1 = 4
     r2 = box(short_int, r0)
     r3 = box(short_int, r1)
     r4 = [r2, r3]
@@ -120,11 +120,11 @@ def f(a):
     r5, r6 :: list
     r7 :: None
 L0:
-    r0 = 2
+    r0 = 4
     r1 = CPySequence_Multiply(a, r0)
     b = r1
-    r2 = 3
-    r3 = 4
+    r2 = 6
+    r3 = 8
     r4 = box(short_int, r3)
     r5 = [r4]
     r6 = CPySequence_RMultiply(r2, r5)
@@ -189,12 +189,12 @@ L1:
     if r3 goto L2 else goto L4 :: bool
 L2:
     r4 = CPyList_GetItem(l, i)
-    r5 = 1
+    r5 = 2
     r6 = box(short_int, r5)
     r7 = r4 += r6
     r8 = CPyList_SetItem(l, i, r7)
 L3:
-    r9 = 1
+    r9 = 2
     r10 = r2 + r9
     r2 = r10
     i = r10
@@ -215,9 +215,9 @@ def f(x, y):
     r6, r7, r8 :: object
     r9 :: int32
 L0:
-    r0 = 1
-    r1 = 2
-    r2 = 3
+    r0 = 2
+    r1 = 4
+    r2 = 6
     r3 = box(short_int, r0)
     r4 = box(short_int, r1)
     r5 = [r3, r4]

--- a/mypyc/test-data/irbuild-nested.test
+++ b/mypyc/test-data/irbuild-nested.test
@@ -344,9 +344,9 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
     inner = r1
-    r2 = 4
+    r2 = 8
     r0.num = r2; r3 = is_error
-    r4 = 6
+    r4 = 12
     foo = r4
     r5 = r0.num
     return r5
@@ -360,7 +360,7 @@ def b():
     r8, r9, r10 :: int
 L0:
     r0 = b_env()
-    r1 = 3
+    r1 = 6
     r0.num = r1; r2 = is_error
     r3 = inner_b_obj()
     r3.__mypyc_env__ = r0; r4 = is_error
@@ -517,7 +517,7 @@ L0:
     r2 = b_a_env()
     r2.__mypyc_env__ = r0; r3 = is_error
     r4 = r0.x
-    r5 = 1
+    r5 = 2
     r6 = CPyTagged_Add(r4, r5)
     r0.x = r6; r7 = is_error
     r8 = c_a_b_obj()
@@ -537,7 +537,7 @@ def a():
     r8 :: int
 L0:
     r0 = a_env()
-    r1 = 1
+    r1 = 2
     r0.x = r1; r2 = is_error
     r3 = b_a_obj()
     r3.__mypyc_env__ = r0; r4 = is_error
@@ -675,7 +675,7 @@ L0:
     r1 = r0.foo
     foo = r1
     r2 = r0.a
-    r3 = 1
+    r3 = 2
     r4 = CPyTagged_Add(r2, r3)
     return r4
 def bar_f_obj.__get__(__mypyc_self__, instance, owner):
@@ -739,7 +739,7 @@ L1:
     r4 = 0
     return r4
 L2:
-    r5 = 1
+    r5 = 2
     r6 = CPyTagged_Subtract(n, r5)
     r7 = box(int, r6)
     r8 = py_call(baz, r7)
@@ -881,7 +881,7 @@ L1:
     r2 = 0
     return r2
 L2:
-    r3 = 1
+    r3 = 2
     r4 = CPyTagged_Subtract(n, r3)
     r5 = baz(r4)
     r6 = CPyTagged_Add(n, r5)

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -20,10 +20,10 @@ L0:
     r2 = x is r1
     if r2 goto L1 else goto L2 :: bool
 L1:
-    r3 = 1
+    r3 = 2
     return r3
 L2:
-    r4 = 2
+    r4 = 4
     return r4
 
 [case testIsNotNone]
@@ -49,10 +49,10 @@ L0:
     r3 = !r2
     if r3 goto L1 else goto L2 :: bool
 L1:
-    r4 = 1
+    r4 = 2
     return r4
 L2:
-    r5 = 2
+    r5 = 4
     return r5
 
 [case testIsTruthy]
@@ -75,10 +75,10 @@ L0:
     r1 = x is not r0
     if r1 goto L1 else goto L2 :: bool
 L1:
-    r2 = 1
+    r2 = 2
     return r2
 L2:
-    r3 = 2
+    r3 = 4
     return r3
 
 [case testIsTruthyOverride]
@@ -118,10 +118,10 @@ L1:
     r3 = bool r2 :: object
     if r3 goto L2 else goto L3 :: bool
 L2:
-    r4 = 1
+    r4 = 2
     return r4
 L3:
-    r5 = 2
+    r5 = 4
     return r5
 
 [case testAssignToOptional]
@@ -162,12 +162,12 @@ L0:
     r2 = A()
     x = r2
     x = y
-    r3 = 1
+    r3 = 2
     r4 = box(short_int, r3)
     z = r4
     r5 = A()
     a = r5
-    r6 = 1
+    r6 = 2
     r7 = box(short_int, r6)
     a.a = r7; r8 = is_error
     r9 = None
@@ -199,7 +199,7 @@ L0:
     r2 = box(short_int, r0)
     r3 = CPyList_SetItem(x, r1, r2)
     r4 = None
-    r5 = 1
+    r5 = 2
     r6 = box(None, r4)
     r7 = CPyList_SetItem(x, r5, r6)
     r8 = None
@@ -265,7 +265,7 @@ L0:
     r0 = None
     r1 = box(None, r0)
     x = r1
-    r2 = 1
+    r2 = 2
     r3 = CPyTagged_IsEq(y, r2)
     if r3 goto L1 else goto L2 :: bool
 L1:
@@ -313,7 +313,7 @@ L0:
     if r2 goto L1 else goto L2 :: bool
 L1:
     r3 = unbox(int, x)
-    r4 = 1
+    r4 = 2
     r5 = CPyTagged_Add(r3, r4)
     return r5
 L2:

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -440,7 +440,7 @@ def g(o):
     r15, z :: object
     r16 :: None
 L0:
-    r0 = 1
+    r0 = 2
     r2 = __main__.A :: type
     r3 = type_is o, r2
     if r3 goto L1 else goto L2 :: bool

--- a/mypyc/test-data/irbuild-set.test
+++ b/mypyc/test-data/irbuild-set.test
@@ -13,9 +13,9 @@ def f():
     r8 :: object
     r9 :: int32
 L0:
-    r0 = 1
-    r1 = 2
-    r2 = 3
+    r0 = 2
+    r1 = 4
+    r2 = 6
     r3 = set
     r4 = box(short_int, r0)
     r5 = PySet_Add(r3, r4)
@@ -64,9 +64,9 @@ def f():
     r9 :: int32
     r10 :: int
 L0:
-    r0 = 1
-    r1 = 2
-    r2 = 3
+    r0 = 2
+    r1 = 4
+    r2 = 6
     r3 = set
     r4 = box(short_int, r0)
     r5 = PySet_Add(r3, r4)
@@ -96,15 +96,15 @@ def f():
     r9 :: int32
     r10 :: bool
 L0:
-    r0 = 3
-    r1 = 4
+    r0 = 6
+    r1 = 8
     r2 = set
     r3 = box(short_int, r0)
     r4 = PySet_Add(r2, r3)
     r5 = box(short_int, r1)
     r6 = PySet_Add(r2, r5)
     x = r2
-    r7 = 5
+    r7 = 10
     r8 = box(short_int, r7)
     r9 = PySet_Contains(x, r8)
     r10 = truncate r9: int32 to builtins.bool
@@ -126,7 +126,7 @@ def f():
 L0:
     r0 = set
     x = r0
-    r1 = 1
+    r1 = 2
     r2 = box(short_int, r1)
     r3 = CPySet_Remove(x, r2)
     r4 = None
@@ -148,7 +148,7 @@ def f():
 L0:
     r0 = set
     x = r0
-    r1 = 1
+    r1 = 2
     r2 = box(short_int, r1)
     r3 = PySet_Discard(x, r2)
     r4 = None
@@ -170,7 +170,7 @@ def f():
 L0:
     r0 = set
     x = r0
-    r1 = 1
+    r1 = 2
     r2 = box(short_int, r1)
     r3 = PySet_Add(x, r2)
     r4 = None
@@ -240,9 +240,9 @@ def f(x, y):
     r10 :: object
     r11 :: int32
 L0:
-    r0 = 1
-    r1 = 2
-    r2 = 3
+    r0 = 2
+    r1 = 4
+    r2 = 6
     r3 = set
     r4 = box(short_int, r0)
     r5 = PySet_Add(r3, r4)

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -17,7 +17,7 @@ L0:
     r0 = 0
     x = r0
     r1 = 0
-    r2 = 5
+    r2 = 10
     r3 = r1
     i = r3
 L1:
@@ -27,7 +27,7 @@ L2:
     r5 = CPyTagged_Add(x, i)
     x = r5
 L3:
-    r6 = 1
+    r6 = 2
     r7 = r3 + r6
     r3 = r7
     i = r7
@@ -48,7 +48,7 @@ def f():
     r4, r5 :: short_int
     r6 :: None
 L0:
-    r0 = 10
+    r0 = 20
     r1 = 0
     r2 = r0
     i = r2
@@ -57,7 +57,7 @@ L1:
     if r3 goto L2 else goto L4 :: bool
 L2:
 L3:
-    r4 = -1
+    r4 = -2
     r5 = r2 + r4
     r2 = r5
     i = r5
@@ -82,7 +82,7 @@ L0:
     r0 = 0
     n = r0
 L1:
-    r1 = 5
+    r1 = 10
     r2 = CPyTagged_IsLt(n, r1)
     if r2 goto L2 else goto L3 :: bool
 L2:
@@ -103,7 +103,7 @@ def f():
     r6 :: None
 L0:
     r0 = 0
-    r1 = 5
+    r1 = 10
     r2 = r0
     n = r2
 L1:
@@ -112,7 +112,7 @@ L1:
 L2:
     goto L4
 L3:
-    r4 = 1
+    r4 = 2
     r5 = r2 + r4
     r2 = r5
     n = r5
@@ -141,12 +141,12 @@ L0:
     r0 = 0
     n = r0
 L1:
-    r1 = 5
+    r1 = 10
     r2 = CPyTagged_IsLt(n, r1)
     if r2 goto L2 else goto L6 :: bool
 L2:
 L3:
-    r3 = 4
+    r3 = 8
     r4 = CPyTagged_IsLt(n, r3)
     if r4 goto L4 else goto L5 :: bool
 L4:
@@ -171,7 +171,7 @@ L0:
     r0 = 0
     n = r0
 L1:
-    r1 = 5
+    r1 = 10
     r2 = CPyTagged_IsLt(n, r1)
     if r2 goto L2 else goto L3 :: bool
 L2:
@@ -193,7 +193,7 @@ def f():
     r6 :: None
 L0:
     r0 = 0
-    r1 = 5
+    r1 = 10
     r2 = r0
     n = r2
 L1:
@@ -201,7 +201,7 @@ L1:
     if r3 goto L2 else goto L4 :: bool
 L2:
 L3:
-    r4 = 1
+    r4 = 2
     r5 = r2 + r4
     r2 = r5
     n = r5
@@ -230,12 +230,12 @@ L0:
     r0 = 0
     n = r0
 L1:
-    r1 = 5
+    r1 = 10
     r2 = CPyTagged_IsLt(n, r1)
     if r2 goto L2 else goto L6 :: bool
 L2:
 L3:
-    r3 = 4
+    r3 = 8
     r4 = CPyTagged_IsLt(n, r3)
     if r4 goto L4 else goto L5 :: bool
 L4:
@@ -280,7 +280,7 @@ L2:
     r7 = CPyTagged_Add(y, x)
     y = r7
 L3:
-    r8 = 1
+    r8 = 2
     r9 = r2 + r8
     r2 = r9
     goto L1
@@ -387,7 +387,7 @@ L2:
     r10 = box(int, key)
     r11 = CPyDict_GetItem(d, r10)
     r12 = unbox(int, r11)
-    r13 = 2
+    r13 = 4
     r14 = CPyTagged_Remainder(r12, r13)
     r15 = 0
     r16 = CPyTagged_IsNe(r14, r15)
@@ -589,7 +589,7 @@ L1:
     raise AssertionError
     unreachable
 L2:
-    r1 = 1
+    r1 = 2
     return r1
 def literal_msg(x):
     x :: object
@@ -602,7 +602,7 @@ L1:
     raise AssertionError('message')
     unreachable
 L2:
-    r2 = 2
+    r2 = 4
     return r2
 def complex_msg(x, s):
     x :: union[str, None]
@@ -651,13 +651,13 @@ def delList():
     r7 :: bool
     r8 :: None
 L0:
-    r0 = 1
-    r1 = 2
+    r0 = 2
+    r1 = 4
     r2 = box(short_int, r0)
     r3 = box(short_int, r1)
     r4 = [r2, r3]
     l = r4
-    r5 = 1
+    r5 = 2
     r6 = box(short_int, r5)
     r7 = l.__delitem__(r6) :: object
     r8 = None
@@ -675,13 +675,13 @@ def delListMultiple():
     r23 :: bool
     r24 :: None
 L0:
-    r0 = 1
-    r1 = 2
-    r2 = 3
-    r3 = 4
-    r4 = 5
-    r5 = 6
-    r6 = 7
+    r0 = 2
+    r1 = 4
+    r2 = 6
+    r3 = 8
+    r4 = 10
+    r5 = 12
+    r6 = 14
     r7 = box(short_int, r0)
     r8 = box(short_int, r1)
     r9 = box(short_int, r2)
@@ -691,9 +691,9 @@ L0:
     r13 = box(short_int, r6)
     r14 = [r7, r8, r9, r10, r11, r12, r13]
     l = r14
-    r15 = 1
-    r16 = 2
-    r17 = 3
+    r15 = 2
+    r16 = 4
+    r17 = 6
     r18 = box(short_int, r15)
     r19 = l.__delitem__(r18) :: object
     r20 = box(short_int, r16)
@@ -724,9 +724,9 @@ def delDict():
     r10 :: None
 L0:
     r0 = unicode_1 :: static  ('one')
-    r1 = 1
+    r1 = 2
     r2 = unicode_2 :: static  ('two')
-    r3 = 2
+    r3 = 4
     r4 = 2
     r5 = box(short_int, r1)
     r6 = box(short_int, r3)
@@ -753,13 +753,13 @@ def delDictMultiple():
     r18 :: None
 L0:
     r0 = unicode_1 :: static  ('one')
-    r1 = 1
+    r1 = 2
     r2 = unicode_2 :: static  ('two')
-    r3 = 2
+    r3 = 4
     r4 = unicode_3 :: static  ('three')
-    r5 = 3
+    r5 = 6
     r6 = unicode_4 :: static  ('four')
-    r7 = 4
+    r7 = 8
     r8 = 4
     r9 = box(short_int, r1)
     r10 = box(short_int, r3)
@@ -803,8 +803,8 @@ def delAttribute():
     r4 :: bool
     r5 :: None
 L0:
-    r0 = 1
-    r1 = 2
+    r0 = 2
+    r1 = 4
     r2 = Dummy(r0, r1)
     dummy = r2
     r3 = unicode_3 :: static  ('x')
@@ -820,8 +820,8 @@ def delAttributeMultiple():
     r6 :: bool
     r7 :: None
 L0:
-    r0 = 1
-    r1 = 2
+    r0 = 2
+    r1 = 4
     r2 = Dummy(r0, r1)
     dummy = r2
     r3 = unicode_3 :: static  ('x')
@@ -867,11 +867,11 @@ L2:
     x = r7
     r8 = CPyTagged_Add(i, x)
 L3:
-    r9 = 1
+    r9 = 2
     r10 = r1 + r9
     r1 = r10
     i = r10
-    r11 = 1
+    r11 = 2
     r12 = r3 + r11
     r3 = r12
     goto L1
@@ -900,7 +900,7 @@ L2:
     r4 = unbox(int, r3)
     n = r4
 L3:
-    r5 = 1
+    r5 = 2
     r6 = r1 + r5
     r1 = r6
     i = r6
@@ -956,11 +956,11 @@ L3:
     r9 = bool b :: object
     if r9 goto L4 else goto L5 :: bool
 L4:
-    r10 = 1
+    r10 = 2
     x = r10
 L5:
 L6:
-    r11 = 1
+    r11 = 2
     r12 = r1 + r11
     r1 = r12
     goto L1
@@ -989,7 +989,7 @@ L0:
     r1 = 0
     r2 = r1
     r3 = 0
-    r4 = 5
+    r4 = 10
     r5 = r3
     z = r5
 L1:
@@ -1011,10 +1011,10 @@ L4:
     r13 = False
     x = r13
 L5:
-    r14 = 1
+    r14 = 2
     r15 = r2 + r14
     r2 = r15
-    r16 = 1
+    r16 = 2
     r17 = r5 + r16
     r5 = r17
     z = r17

--- a/mypyc/test-data/irbuild-strip-asserts.test
+++ b/mypyc/test-data/irbuild-strip-asserts.test
@@ -9,8 +9,8 @@ def g():
     r2 :: int
     r3, x :: object
 L0:
-    r0 = 1
-    r1 = 2
+    r0 = 2
+    r1 = 4
     r2 = CPyTagged_Add(r0, r1)
     r3 = box(int, r2)
     x = r3

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -27,7 +27,7 @@ def f():
     r3 :: int
 L0:
     r0 = True
-    r1 = 1
+    r1 = 2
     r2 = (r0, r1)
     t = r2
     r3 = t[1]
@@ -42,7 +42,7 @@ def f(x):
     x :: tuple[bool, bool, int]
     r0 :: short_int
 L0:
-    r0 = 3
+    r0 = 6
     return r0
 
 [case testSequenceTuple]
@@ -58,7 +58,7 @@ def f(x):
     r3 :: bool
 L0:
     r0 = PyList_AsTuple(x)
-    r1 = 1
+    r1 = 2
     r2 = CPySequenceTuple_GetItem(r0, r1)
     r3 = unbox(bool, r2)
     return r3
@@ -90,12 +90,12 @@ def f():
     r5 :: object
     r6 :: int
 L0:
-    r0 = 1
-    r1 = 2
+    r0 = 2
+    r1 = 4
     r2 = (r0, r1)
     r3 = box(tuple[int, int], r2)
     t = r3
-    r4 = 1
+    r4 = 2
     r5 = CPySequenceTuple_GetItem(t, r4)
     r6 = unbox(int, r5)
     return r6
@@ -114,9 +114,9 @@ def f(x, y):
     r9 :: int32
     r10 :: tuple
 L0:
-    r0 = 1
-    r1 = 2
-    r2 = 3
+    r0 = 2
+    r1 = 4
+    r2 = 6
     r3 = box(short_int, r0)
     r4 = box(short_int, r1)
     r5 = [r3, r4]
@@ -154,7 +154,7 @@ L2:
     r5 = cast(str, r4)
     x = r5
 L3:
-    r6 = 1
+    r6 = 2
     r7 = r1 + r6
     r1 = r7
     goto L1
@@ -189,7 +189,7 @@ L1:
     r2 = unbox(int, r1)
     return r2
 L2:
-    r3 = 1
+    r3 = 2
     r4 = CPySequenceTuple_GetItem(nt, r3)
     r5 = unbox(int, r4)
     return r5

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -7,7 +7,7 @@ def f() -> int:
 def f():
     r0 :: short_int
 L0:
-    r0 = 1
+    r0 = 2
     return r0
 
 [case testReturnLocal]
@@ -19,7 +19,7 @@ def f():
     r0 :: short_int
     x :: int
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
     return x
 
@@ -34,7 +34,7 @@ def f():
     r0 :: short_int
     x, y :: int
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
     y = x
     x = y
@@ -51,7 +51,7 @@ def f():
     r0 :: short_int
     x, y, z, r1 :: int
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
     inc_ref x :: int
     y = x
@@ -77,11 +77,11 @@ def f():
     r2 :: short_int
     r3 :: bool
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
-    r1 = 2
+    r1 = 4
     y = r1
-    r2 = 1
+    r2 = 2
     r3 = CPyTagged_IsEq(x, r2)
     if r3 goto L3 else goto L4 :: bool
 L1:
@@ -106,7 +106,7 @@ def f(a, b):
     r0 :: short_int
     r1, x, r2, y :: int
 L0:
-    r0 = 1
+    r0 = 2
     r1 = CPyTagged_Add(a, r0)
     x = r1
     r2 = CPyTagged_Add(x, a)
@@ -131,7 +131,7 @@ L0:
     dec_ref x :: int
     inc_ref a :: int
     y = a
-    r0 = 1
+    r0 = 2
     x = r0
     r1 = CPyTagged_Add(x, y)
     dec_ref x :: int
@@ -149,7 +149,7 @@ def f(a):
     r0 :: short_int
     y :: int
 L0:
-    r0 = 1
+    r0 = 2
     a = r0
     y = a
     return y
@@ -165,13 +165,13 @@ def f(a):
     a :: int
     r0, r1, r2 :: short_int
 L0:
-    r0 = 1
+    r0 = 2
     a = r0
     dec_ref a :: int
-    r1 = 2
+    r1 = 4
     a = r1
     dec_ref a :: int
-    r2 = 3
+    r2 = 6
     a = r2
     return a
 
@@ -187,7 +187,7 @@ def f(a):
     r0 :: short_int
     x, y :: int
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
     inc_ref x :: int
     a = x
@@ -239,16 +239,16 @@ L2:
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r7 = 1
+    r7 = 2
     a = r7
     goto L6
 L5:
-    r8 = 2
+    r8 = 4
     x = r8
     dec_ref x :: int
     goto L7
 L6:
-    r9 = 1
+    r9 = 2
     r10 = CPyTagged_Add(a, r9)
     dec_ref a :: int
     y = r10
@@ -291,15 +291,15 @@ L2:
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r7 = 2
+    r7 = 4
     x = r7
     dec_ref x :: int
     goto L7
 L5:
-    r8 = 1
+    r8 = 2
     a = r8
 L6:
-    r9 = 1
+    r9 = 2
     r10 = CPyTagged_Add(a, r9)
     dec_ref a :: int
     y = r10
@@ -336,7 +336,7 @@ L2:
 L3:
     if r0 goto L4 else goto L6 :: bool
 L4:
-    r7 = 1
+    r7 = 2
     a = r7
 L5:
     return a
@@ -359,7 +359,7 @@ def f(a):
 L0:
     inc_ref a :: int
     a = a
-    r0 = 1
+    r0 = 2
     x = r0
     inc_ref x :: int
     dec_ref x :: int
@@ -385,12 +385,12 @@ def f(a):
     r3 :: short_int
     r4, r5 :: int
 L0:
-    r0 = 1
+    r0 = 2
     r1 = CPyTagged_Add(a, r0)
     a = r1
-    r2 = 1
+    r2 = 2
     x = r2
-    r3 = 1
+    r3 = 2
     r4 = CPyTagged_Add(x, r3)
     dec_ref x :: int
     x = r4
@@ -411,9 +411,9 @@ def f():
     r2 :: int
     r3 :: None
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
-    r1 = 1
+    r1 = 2
     r2 = CPyTagged_Add(x, r1)
     dec_ref x :: int
     x = r2
@@ -433,9 +433,9 @@ def f():
     r2, x :: int
     r3 :: None
 L0:
-    r0 = 1
+    r0 = 2
     y = r0
-    r1 = 1
+    r1 = 2
     r2 = CPyTagged_Add(y, r1)
     dec_ref y :: int
     x = r2
@@ -492,7 +492,7 @@ L0:
     r0 = CPyTagged_Add(a, a)
     x = r0
     dec_ref x :: int
-    r1 = 1
+    r1 = 2
     y = r1
     r2 = CPyTagged_Add(y, y)
     dec_ref y :: int
@@ -516,7 +516,7 @@ L0:
     r0 = CPyTagged_Add(a, a)
     a = r0
     dec_ref a :: int
-    r1 = 1
+    r1 = 2
     x = r1
     r2 = CPyTagged_Add(x, x)
     dec_ref x :: int
@@ -548,11 +548,11 @@ def f():
     r10 :: short_int
     a, r11, r12 :: int
 L0:
-    r0 = 1
+    r0 = 2
     x = r0
-    r1 = 2
+    r1 = 4
     y = r1
-    r2 = 3
+    r2 = 6
     z = r2
     r4 = 1
     r5 = z & r4
@@ -571,7 +571,7 @@ L3:
 L4:
     return z
 L5:
-    r10 = 1
+    r10 = 2
     a = r10
     r11 = CPyTagged_Add(x, y)
     dec_ref x :: int
@@ -619,7 +619,7 @@ L2:
     r3 = CPyTagged_Add(sum, i)
     dec_ref sum :: int
     sum = r3
-    r4 = 1
+    r4 = 2
     r5 = CPyTagged_Add(i, r4)
     dec_ref i :: int
     i = r5
@@ -639,7 +639,7 @@ def f(a):
     r0 :: short_int
     r1, r2 :: int
 L0:
-    r0 = 1
+    r0 = 2
     r1 = CPyTagged_Add(a, r0)
     r2 = f(r1)
     dec_ref r1 :: int
@@ -661,7 +661,7 @@ def f():
     r5 :: short_int
 L0:
     r0 = 0
-    r1 = 1
+    r1 = 2
     r2 = box(short_int, r0)
     r3 = box(short_int, r1)
     r4 = [r2, r3]
@@ -769,10 +769,10 @@ def f(x):
 L0:
     if x goto L1 else goto L2 :: bool
 L1:
-    r0 = 1
+    r0 = 2
     return r0
 L2:
-    r1 = 2
+    r1 = 4
     return r1
 
 [case testUnicodeLiteral]
@@ -802,7 +802,7 @@ def g(x):
     r7 :: object
     r8 :: int
 L0:
-    r0 = 2
+    r0 = 4
     r1 = int
     r2 = unicode_1 :: static  ('base')
     r3 = (x) :: tuple


### PR DESCRIPTION
Mypyc currently represents int and short_int using a tagged representation, which requires doubling the value when emitting to  C. Since we are moving towards low-level IR, we change `LoadInt` to store the doubled value directly if the type is int/short_int, to be explicit about the tagged representation.