### PR TITLE
[mypyc] Fix signed integer comparison

### DIFF
--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -14,7 +14,9 @@ from mypyc.ir.ops import (
     NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CallC, LoadGlobal, Truncate,
     BinaryIntOp
 )
-from mypyc.ir.rtypes import RType, RTuple, is_tagged
+from mypyc.ir.rtypes import (
+    RType, RTuple, is_tagged, is_int32_rprimitive, is_int64_rprimitive
+)
 from mypyc.ir.func_ir import FuncIR, FuncDecl, FUNC_STATICMETHOD, FUNC_CLASSMETHOD
 from mypyc.ir.class_ir import ClassIR
 
@@ -440,11 +442,14 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         rhs = self.reg(op.rhs)
         lhs_cast = ""
         rhs_cast = ""
-        if (is_tagged(op.lhs.type) and is_tagged(op.rhs.type)
-                and op.op in (BinaryIntOp.SLT, BinaryIntOp.SGT,
-                              BinaryIntOp.SLE, BinaryIntOp.SGE)):
-            lhs_cast = "(Py_ssize_t)"
-            rhs_cast = "(Py_ssize_t)"
+        signed_op = {BinaryIntOp.SLT, BinaryIntOp.SGT, BinaryIntOp.SLE, BinaryIntOp.SGE}
+        unsigned_op = {BinaryIntOp.ULT, BinaryIntOp.UGT, BinaryIntOp.ULE, BinaryIntOp.UGE}
+        if op.op in signed_op:
+            lhs_cast = self.emit_signed_int_cast(op.lhs.type)
+            rhs_cast = self.emit_signed_int_cast(op.rhs.type)
+        elif op.op in unsigned_op:
+            lhs_cast = self.emit_unsigned_int_cast(op.lhs.type)
+            rhs_cast = self.emit_unsigned_int_cast(op.rhs.type)
         self.emit_line('%s = %s%s %s %s%s;' % (dest, lhs_cast, lhs,
                                                op.op_str[op.op], rhs_cast, rhs))
 
@@ -490,3 +495,17 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
                 globals_static))
             if DEBUG_ERRORS:
                 self.emit_line('assert(PyErr_Occurred() != NULL && "failure w/o err!");')
+
+    def emit_signed_int_cast(self, type: RType) -> str:
+        if is_tagged(type):
+            return '(Py_ssize_t)'
+        else:
+            return ''
+
+    def emit_unsigned_int_cast(self, type: RType) -> str:
+        if is_int32_rprimitive(type):
+            return '(uint32_t)'
+        elif is_int64_rprimitive(type):
+            return '(uint64_t)'
+        else:
+            return ''

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1277,10 +1277,10 @@ class BinaryIntOp(RegisterOp):
     SGT = 103  # type: Final
     SLE = 104  # type: Final
     SGE = 105  # type: Final
-    ULT = 102  # type: Final
-    UGT = 103  # type: Final
-    ULE = 104  # type: Final
-    UGE = 105  # type: Final
+    ULT = 106  # type: Final
+    UGT = 107  # type: Final
+    ULE = 108  # type: Final
+    UGE = 109  # type: Final
     # bitwise
     AND = 200  # type: Final
     OR = 201  # type: Final

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1322,7 +1322,14 @@ class BinaryIntOp(RegisterOp):
         return [self.lhs, self.rhs]
 
     def to_str(self, env: Environment) -> str:
-        return env.format('%r = %r %s %r', self, self.lhs, self.op_str[self.op], self.rhs)
+        if self.op in (self.SLT, self.SGT, self.SLE, self.SGE):
+            sign_format = " :: signed"
+        elif self.op in (self.ULT, self.UGT, self.ULE, self.UGE):
+            sign_format = " :: unsigned"
+        else:
+            sign_format = ""
+        return env.format('%r = %r %s %r%s', self, self.lhs,
+                          self.op_str[self.op], self.rhs, sign_format)
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_binary_int_op(self)

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1270,12 +1270,17 @@ class BinaryIntOp(RegisterOp):
     DIV = 3  # type: Final
     MOD = 4  # type: Final
     # logical
+    # S for signed and U for unsigned
     EQ = 100  # type: Final
     NEQ = 101  # type: Final
-    LT = 102  # type: Final
-    GT = 103  # type: Final
-    LEQ = 104  # type: Final
-    GEQ = 105  # type: Final
+    SLT = 102  # type: Final
+    SGT = 103  # type: Final
+    SLE = 104  # type: Final
+    SGE = 105  # type: Final
+    ULT = 102  # type: Final
+    UGT = 103  # type: Final
+    ULE = 104  # type: Final
+    UGE = 105  # type: Final
     # bitwise
     AND = 200  # type: Final
     OR = 201  # type: Final
@@ -1291,10 +1296,14 @@ class BinaryIntOp(RegisterOp):
         MOD: '%',
         EQ: '==',
         NEQ: '!=',
-        LT: '<',
-        GT: '>',
-        LEQ: '<=',
-        GEQ: '>=',
+        SLT: '<',
+        SGT: '>',
+        SLE: '<=',
+        SGE: '>=',
+        ULT: '<',
+        UGT: '>',
+        ULE: '<=',
+        UGE: '>=',
         AND: '&',
         OR: '|',
         XOR: '^',

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -281,6 +281,10 @@ tuple_rprimitive = RPrimitive('builtins.tuple', is_unboxed=False,
                               is_refcounted=True)  # type: Final
 
 
+def is_tagged(rtype: RType) -> bool:
+    return rtype is int_rprimitive or rtype is short_int_rprimitive
+
+
 def is_int_rprimitive(rtype: RType) -> bool:
     return rtype is int_rprimitive
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -26,7 +26,7 @@ from mypyc.ir.ops import (
 from mypyc.ir.rtypes import (
     RType, RUnion, RInstance, optional_value_type, int_rprimitive, float_rprimitive,
     bool_rprimitive, list_rprimitive, str_rprimitive, is_none_rprimitive, object_rprimitive,
-    c_pyssize_t_rprimitive, is_short_int_rprimitive, short_int_rprimitive
+    c_pyssize_t_rprimitive, is_short_int_rprimitive
 )
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
@@ -588,17 +588,7 @@ class LowLevelIRBuilder:
         branch.negated = False
         self.add(branch)
         self.activate_block(short_int_block)
-        # for now equal op, explicitly convert tagged(unsigned) to signed to include negative
-        # situtations
-        if op not in ("==", "!="):
-            lhs_short = self.add(Truncate(lhs, short_int_rprimitive,
-                                          c_pyssize_t_rprimitive, line))
-            rhs_short = self.add(Truncate(rhs, short_int_rprimitive,
-                                          c_pyssize_t_rprimitive, line))
-        else:
-            lhs_short = lhs
-            rhs_short = rhs
-        eq = self.binary_int_op(bool_rprimitive, lhs_short, rhs_short, op_type, line)
+        eq = self.binary_int_op(bool_rprimitive, lhs, rhs, op_type, line)
         self.add(Assign(result, eq, line))
         self.goto(out)
         self.activate_block(int_block)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -26,7 +26,7 @@ from mypyc.ir.ops import (
 from mypyc.ir.rtypes import (
     RType, RUnion, RInstance, optional_value_type, int_rprimitive, float_rprimitive,
     bool_rprimitive, list_rprimitive, str_rprimitive, is_none_rprimitive, object_rprimitive,
-    c_pyssize_t_rprimitive, is_short_int_rprimitive
+    c_pyssize_t_rprimitive, is_short_int_rprimitive, short_int_rprimitive
 )
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
@@ -588,7 +588,17 @@ class LowLevelIRBuilder:
         branch.negated = False
         self.add(branch)
         self.activate_block(short_int_block)
-        eq = self.binary_int_op(bool_rprimitive, lhs, rhs, op_type, line)
+        # for now equal op, explicitly convert tagged(unsigned) to signed to include negative
+        # situtations
+        if op not in ("==", "!="):
+            lhs_short = self.add(Truncate(lhs, short_int_rprimitive,
+                                          c_pyssize_t_rprimitive, line))
+            rhs_short = self.add(Truncate(rhs, short_int_rprimitive,
+                                          c_pyssize_t_rprimitive, line))
+        else:
+            lhs_short = lhs
+            rhs_short = rhs
+        eq = self.binary_int_op(bool_rprimitive, lhs_short, rhs_short, op_type, line)
         self.add(Assign(result, eq, line))
         self.goto(out)
         self.activate_block(int_block)

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -173,5 +173,5 @@ int_less_than_ = c_custom_op(
 int_logical_op_mapping = {
     '==': IntLogicalOpDescrption(BinaryIntOp.EQ, int_equal_, False, False),
     '!=': IntLogicalOpDescrption(BinaryIntOp.NEQ, int_equal_, True, False),
-    '<': IntLogicalOpDescrption(BinaryIntOp.LT, int_less_than_, False, False)
+    '<': IntLogicalOpDescrption(BinaryIntOp.SLT, int_less_than_, False, False)
 }  # type: Dict[str, IntLogicalOpDescrption]

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -392,7 +392,7 @@ L1:
     r9 = r4 & r8
     if r9 goto L2 else goto L3 :: bool
 L2:
-    r10 = a < a
+    r10 = a < a :: signed
     r0 = r10
     goto L4
 L3:
@@ -413,7 +413,7 @@ L6:
     r21 = r16 & r20
     if r21 goto L7 else goto L8 :: bool
 L7:
-    r22 = a < a
+    r22 = a < a :: signed
     r12 = r22
     goto L9
 L8:

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -372,13 +372,17 @@ def f(a):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9, r10, r11, r12 :: bool
-    r13, r14, r15 :: native_int
-    r16 :: bool
-    r17, r18, r19 :: native_int
-    r20, r21, r22, r23 :: bool
+    r8, r9 :: bool
+    r10, r11 :: native_int
+    r12, r13, r14 :: bool
+    r15, r16, r17 :: native_int
+    r18 :: bool
+    r19, r20, r21 :: native_int
+    r22, r23 :: bool
+    r24, r25 :: native_int
+    r26, r27 :: bool
     y, x :: int
-    r24 :: None
+    r28 :: None
 L0:
 L1:
     r1 = 1
@@ -392,35 +396,39 @@ L1:
     r9 = r4 & r8
     if r9 goto L2 else goto L3 :: bool
 L2:
-    r10 = a < a
-    r0 = r10
+    r10 = truncate a: short_int to native_int
+    r11 = truncate a: short_int to native_int
+    r12 = r10 < r11
+    r0 = r12
     goto L4
 L3:
-    r11 = CPyTagged_IsLt_(a, a)
-    r0 = r11
+    r13 = CPyTagged_IsLt_(a, a)
+    r0 = r13
 L4:
     if r0 goto L5 else goto L12 :: bool
 L5:
 L6:
-    r13 = 1
-    r14 = a & r13
-    r15 = 0
-    r16 = r14 == r15
-    r17 = 1
-    r18 = a & r17
-    r19 = 0
-    r20 = r18 == r19
-    r21 = r16 & r20
-    if r21 goto L7 else goto L8 :: bool
+    r15 = 1
+    r16 = a & r15
+    r17 = 0
+    r18 = r16 == r17
+    r19 = 1
+    r20 = a & r19
+    r21 = 0
+    r22 = r20 == r21
+    r23 = r18 & r22
+    if r23 goto L7 else goto L8 :: bool
 L7:
-    r22 = a < a
-    r12 = r22
+    r24 = truncate a: short_int to native_int
+    r25 = truncate a: short_int to native_int
+    r26 = r24 < r25
+    r14 = r26
     goto L9
 L8:
-    r23 = CPyTagged_IsLt_(a, a)
-    r12 = r23
+    r27 = CPyTagged_IsLt_(a, a)
+    r14 = r27
 L9:
-    if r12 goto L10 else goto L11 :: bool
+    if r14 goto L10 else goto L11 :: bool
 L10:
     y = a
     goto L6
@@ -428,50 +436,54 @@ L11:
     x = a
     goto L1
 L12:
-    r24 = None
-    return r24
+    r28 = None
+    return r28
 (0, 0)   {a}                     {a}
-(1, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(1, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(1, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(1, 3)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(1, 4)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(1, 5)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(1, 6)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(1, 7)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(1, 8)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(1, 9)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(2, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(2, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(2, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(3, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(3, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(3, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(4, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(5, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(6, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(6, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(6, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(6, 3)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(6, 4)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(6, 5)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(6, 6)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(6, 7)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(6, 8)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(6, 9)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(7, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(7, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(7, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(8, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(8, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(8, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(9, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(10, 0)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(10, 1)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(11, 0)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(11, 1)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(12, 0)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
-(12, 1)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(1, 1)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(1, 2)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(1, 3)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(1, 4)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(1, 5)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(1, 6)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(1, 7)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(1, 8)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(1, 9)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(2, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(2, 1)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(2, 2)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(2, 3)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(2, 4)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(3, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(3, 1)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(3, 2)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(4, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(5, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(6, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(6, 1)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(6, 2)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(6, 3)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(6, 4)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(6, 5)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(6, 6)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(6, 7)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(6, 8)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(6, 9)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(7, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(7, 1)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(7, 2)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(7, 3)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(7, 4)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(8, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(8, 1)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(8, 2)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(9, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(10, 0)  {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(10, 1)  {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(11, 0)  {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(11, 1)  {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(12, 0)  {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(12, 1)  {a, r0, r14, x, y}      {a, r0, r14, x, y}
 
 [case testTrivial_BorrowedArgument]
 def f(a: int, b: int) -> int:

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -372,17 +372,13 @@ def f(a):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9 :: bool
-    r10, r11 :: native_int
-    r12, r13, r14 :: bool
-    r15, r16, r17 :: native_int
-    r18 :: bool
-    r19, r20, r21 :: native_int
-    r22, r23 :: bool
-    r24, r25 :: native_int
-    r26, r27 :: bool
+    r8, r9, r10, r11, r12 :: bool
+    r13, r14, r15 :: native_int
+    r16 :: bool
+    r17, r18, r19 :: native_int
+    r20, r21, r22, r23 :: bool
     y, x :: int
-    r28 :: None
+    r24 :: None
 L0:
 L1:
     r1 = 1
@@ -396,39 +392,35 @@ L1:
     r9 = r4 & r8
     if r9 goto L2 else goto L3 :: bool
 L2:
-    r10 = truncate a: short_int to native_int
-    r11 = truncate a: short_int to native_int
-    r12 = r10 < r11
-    r0 = r12
+    r10 = a < a
+    r0 = r10
     goto L4
 L3:
-    r13 = CPyTagged_IsLt_(a, a)
-    r0 = r13
+    r11 = CPyTagged_IsLt_(a, a)
+    r0 = r11
 L4:
     if r0 goto L5 else goto L12 :: bool
 L5:
 L6:
-    r15 = 1
-    r16 = a & r15
-    r17 = 0
-    r18 = r16 == r17
-    r19 = 1
-    r20 = a & r19
-    r21 = 0
-    r22 = r20 == r21
-    r23 = r18 & r22
-    if r23 goto L7 else goto L8 :: bool
+    r13 = 1
+    r14 = a & r13
+    r15 = 0
+    r16 = r14 == r15
+    r17 = 1
+    r18 = a & r17
+    r19 = 0
+    r20 = r18 == r19
+    r21 = r16 & r20
+    if r21 goto L7 else goto L8 :: bool
 L7:
-    r24 = truncate a: short_int to native_int
-    r25 = truncate a: short_int to native_int
-    r26 = r24 < r25
-    r14 = r26
+    r22 = a < a
+    r12 = r22
     goto L9
 L8:
-    r27 = CPyTagged_IsLt_(a, a)
-    r14 = r27
+    r23 = CPyTagged_IsLt_(a, a)
+    r12 = r23
 L9:
-    if r14 goto L10 else goto L11 :: bool
+    if r12 goto L10 else goto L11 :: bool
 L10:
     y = a
     goto L6
@@ -436,54 +428,50 @@ L11:
     x = a
     goto L1
 L12:
-    r28 = None
-    return r28
+    r24 = None
+    return r24
 (0, 0)   {a}                     {a}
-(1, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(1, 1)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(1, 2)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(1, 3)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(1, 4)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(1, 5)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(1, 6)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(1, 7)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(1, 8)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(1, 9)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(2, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(2, 1)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(2, 2)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(2, 3)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(2, 4)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(3, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(3, 1)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(3, 2)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(4, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(5, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(6, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(6, 1)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(6, 2)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(6, 3)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(6, 4)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(6, 5)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(6, 6)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(6, 7)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(6, 8)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(6, 9)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(7, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(7, 1)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(7, 2)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(7, 3)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(7, 4)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(8, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(8, 1)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(8, 2)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(9, 0)   {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(10, 0)  {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(10, 1)  {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(11, 0)  {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(11, 1)  {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(12, 0)  {a, r0, r14, x, y}      {a, r0, r14, x, y}
-(12, 1)  {a, r0, r14, x, y}      {a, r0, r14, x, y}
+(1, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 3)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 4)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 5)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 6)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 7)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 8)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(1, 9)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(2, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(2, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(2, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(3, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(3, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(3, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(4, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(5, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 3)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 4)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 5)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 6)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 7)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 8)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(6, 9)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(7, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(7, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(7, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(8, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(8, 1)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(8, 2)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(9, 0)   {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(10, 0)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(10, 1)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(11, 0)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(11, 1)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(12, 0)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
+(12, 1)  {a, r0, r12, x, y}      {a, r0, r12, x, y}
 
 [case testTrivial_BorrowedArgument]
 def f(a: int, b: int) -> int:

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -156,7 +156,7 @@ L1:
     r11 = r6 & r10
     if r11 goto L2 else goto L3 :: bool
 L2:
-    r12 = i < l
+    r12 = i < l :: signed
     r2 = r12
     goto L4
 L3:

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -134,13 +134,11 @@ def sum(a, l):
     r3, r4, r5 :: native_int
     r6 :: bool
     r7, r8, r9 :: native_int
-    r10, r11 :: bool
-    r12, r13 :: native_int
-    r14, r15 :: bool
-    r16 :: object
-    r17, r18 :: int
-    r19 :: short_int
-    r20, r21 :: int
+    r10, r11, r12, r13 :: bool
+    r14 :: object
+    r15, r16 :: int
+    r17 :: short_int
+    r18, r19 :: int
 L0:
     r0 = 0
     sum = r0
@@ -158,38 +156,36 @@ L1:
     r11 = r6 & r10
     if r11 goto L2 else goto L3 :: bool
 L2:
-    r12 = truncate i: short_int to native_int
-    r13 = truncate l: short_int to native_int
-    r14 = r12 < r13
-    r2 = r14
+    r12 = i < l
+    r2 = r12
     goto L4
 L3:
-    r15 = CPyTagged_IsLt_(i, l)
-    r2 = r15
+    r13 = CPyTagged_IsLt_(i, l)
+    r2 = r13
 L4:
     if r2 goto L5 else goto L10 :: bool
 L5:
-    r16 = CPyList_GetItem(a, i)
-    if is_error(r16) goto L11 (error at sum:6) else goto L6
+    r14 = CPyList_GetItem(a, i)
+    if is_error(r14) goto L11 (error at sum:6) else goto L6
 L6:
-    r17 = unbox(int, r16)
-    dec_ref r16
-    if is_error(r17) goto L11 (error at sum:6) else goto L7
+    r15 = unbox(int, r14)
+    dec_ref r14
+    if is_error(r15) goto L11 (error at sum:6) else goto L7
 L7:
-    r18 = CPyTagged_Add(sum, r17)
+    r16 = CPyTagged_Add(sum, r15)
     dec_ref sum :: int
-    dec_ref r17 :: int
-    sum = r18
-    r19 = 2
-    r20 = CPyTagged_Add(i, r19)
+    dec_ref r15 :: int
+    sum = r16
+    r17 = 2
+    r18 = CPyTagged_Add(i, r17)
     dec_ref i :: int
-    i = r20
+    i = r18
     goto L1
 L8:
     return sum
 L9:
-    r21 = <error> :: int
-    return r21
+    r19 = <error> :: int
+    return r19
 L10:
     dec_ref i :: int
     goto L8

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -134,11 +134,13 @@ def sum(a, l):
     r3, r4, r5 :: native_int
     r6 :: bool
     r7, r8, r9 :: native_int
-    r10, r11, r12, r13 :: bool
-    r14 :: object
-    r15, r16 :: int
-    r17 :: short_int
-    r18, r19 :: int
+    r10, r11 :: bool
+    r12, r13 :: native_int
+    r14, r15 :: bool
+    r16 :: object
+    r17, r18 :: int
+    r19 :: short_int
+    r20, r21 :: int
 L0:
     r0 = 0
     sum = r0
@@ -156,36 +158,38 @@ L1:
     r11 = r6 & r10
     if r11 goto L2 else goto L3 :: bool
 L2:
-    r12 = i < l
-    r2 = r12
+    r12 = truncate i: short_int to native_int
+    r13 = truncate l: short_int to native_int
+    r14 = r12 < r13
+    r2 = r14
     goto L4
 L3:
-    r13 = CPyTagged_IsLt_(i, l)
-    r2 = r13
+    r15 = CPyTagged_IsLt_(i, l)
+    r2 = r15
 L4:
     if r2 goto L5 else goto L10 :: bool
 L5:
-    r14 = CPyList_GetItem(a, i)
-    if is_error(r14) goto L11 (error at sum:6) else goto L6
+    r16 = CPyList_GetItem(a, i)
+    if is_error(r16) goto L11 (error at sum:6) else goto L6
 L6:
-    r15 = unbox(int, r14)
-    dec_ref r14
-    if is_error(r15) goto L11 (error at sum:6) else goto L7
+    r17 = unbox(int, r16)
+    dec_ref r16
+    if is_error(r17) goto L11 (error at sum:6) else goto L7
 L7:
-    r16 = CPyTagged_Add(sum, r15)
+    r18 = CPyTagged_Add(sum, r17)
     dec_ref sum :: int
-    dec_ref r15 :: int
-    sum = r16
-    r17 = 1
-    r18 = CPyTagged_Add(i, r17)
+    dec_ref r17 :: int
+    sum = r18
+    r19 = 1
+    r20 = CPyTagged_Add(i, r19)
     dec_ref i :: int
-    i = r18
+    i = r20
     goto L1
 L8:
     return sum
 L9:
-    r19 = <error> :: int
-    return r19
+    r21 = <error> :: int
+    return r21
 L10:
     dec_ref i :: int
     goto L8

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -110,7 +110,7 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
+    r10 = x < y :: signed
     r0 = r10
     goto L3
 L2:
@@ -152,7 +152,7 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
+    r10 = x < y :: signed
     r0 = r10
     goto L3
 L2:
@@ -198,7 +198,7 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
+    r10 = x < y :: signed
     r0 = r10
     goto L3
 L2:
@@ -269,7 +269,7 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
+    r10 = x < y :: signed
     r0 = r10
     goto L3
 L2:
@@ -338,7 +338,7 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
+    r10 = x < y :: signed
     r0 = r10
     goto L3
 L2:
@@ -378,7 +378,7 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
+    r10 = x < y :: signed
     r0 = r10
     goto L3
 L2:
@@ -493,7 +493,7 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
+    r10 = x < y :: signed
     r0 = r10
     goto L3
 L2:
@@ -2041,7 +2041,7 @@ L0:
     r9 = r8
 L1:
     r10 = len r7 :: list
-    r11 = r9 < r10
+    r11 = r9 < r10 :: signed
     if r11 goto L2 else goto L8 :: bool
 L2:
     r12 = r7[r9] :: unsafe list
@@ -2105,7 +2105,7 @@ L0:
     r9 = r8
 L1:
     r10 = len r7 :: list
-    r11 = r9 < r10
+    r11 = r9 < r10 :: signed
     if r11 goto L2 else goto L8 :: bool
 L2:
     r12 = r7[r9] :: unsafe list
@@ -2166,7 +2166,7 @@ L0:
     r1 = r0
 L1:
     r2 = len l :: list
-    r3 = r1 < r2
+    r3 = r1 < r2 :: signed
     if r3 goto L2 else goto L4 :: bool
 L2:
     r4 = l[r1] :: unsafe list
@@ -2188,7 +2188,7 @@ L4:
     r13 = r12
 L5:
     r14 = len l :: list
-    r15 = r13 < r14
+    r15 = r13 < r14 :: signed
     if r15 goto L6 else goto L8 :: bool
 L6:
     r16 = l[r13] :: unsafe list
@@ -2750,7 +2750,7 @@ L0:
     r12 = r7 & r11
     if r12 goto L1 else goto L2 :: bool
 L1:
-    r13 = r0 < r1
+    r13 = r0 < r1 :: signed
     r3 = r13
     goto L3
 L2:

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -96,8 +96,10 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9, r10, r11 :: bool
-    r12 :: short_int
+    r8, r9 :: bool
+    r10, r11 :: native_int
+    r12, r13 :: bool
+    r14 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
@@ -110,17 +112,19 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
-    r0 = r10
+    r10 = truncate x: short_int to native_int
+    r11 = truncate y: short_int to native_int
+    r12 = r10 < r11
+    r0 = r12
     goto L3
 L2:
-    r11 = CPyTagged_IsLt_(x, y)
-    r0 = r11
+    r13 = CPyTagged_IsLt_(x, y)
+    r0 = r13
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r12 = 1
-    x = r12
+    r14 = 1
+    x = r14
 L5:
     return x
 
@@ -138,8 +142,10 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9, r10, r11 :: bool
-    r12, r13 :: short_int
+    r8, r9 :: bool
+    r10, r11 :: native_int
+    r12, r13 :: bool
+    r14, r15 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
@@ -152,21 +158,23 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
-    r0 = r10
+    r10 = truncate x: short_int to native_int
+    r11 = truncate y: short_int to native_int
+    r12 = r10 < r11
+    r0 = r12
     goto L3
 L2:
-    r11 = CPyTagged_IsLt_(x, y)
-    r0 = r11
+    r13 = CPyTagged_IsLt_(x, y)
+    r0 = r13
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r12 = 1
-    x = r12
+    r14 = 1
+    x = r14
     goto L6
 L5:
-    r13 = 2
-    x = r13
+    r15 = 2
+    x = r15
 L6:
     return x
 
@@ -184,8 +192,10 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9, r10, r11, r12 :: bool
-    r13, r14 :: short_int
+    r8, r9 :: bool
+    r10, r11 :: native_int
+    r12, r13, r14 :: bool
+    r15, r16 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
@@ -198,24 +208,26 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
-    r0 = r10
+    r10 = truncate x: short_int to native_int
+    r11 = truncate y: short_int to native_int
+    r12 = r10 < r11
+    r0 = r12
     goto L3
 L2:
-    r11 = CPyTagged_IsLt_(x, y)
-    r0 = r11
+    r13 = CPyTagged_IsLt_(x, y)
+    r0 = r13
 L3:
     if r0 goto L4 else goto L6 :: bool
 L4:
-    r12 = CPyTagged_IsGt(x, y)
-    if r12 goto L5 else goto L6 :: bool
+    r14 = CPyTagged_IsGt(x, y)
+    if r14 goto L5 else goto L6 :: bool
 L5:
-    r13 = 1
-    x = r13
+    r15 = 1
+    x = r15
     goto L7
 L6:
-    r14 = 2
-    x = r14
+    r16 = 2
+    x = r16
 L7:
     return x
 
@@ -255,8 +267,10 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9, r10, r11, r12 :: bool
-    r13, r14 :: short_int
+    r8, r9 :: bool
+    r10, r11 :: native_int
+    r12, r13, r14 :: bool
+    r15, r16 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
@@ -269,24 +283,26 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
-    r0 = r10
+    r10 = truncate x: short_int to native_int
+    r11 = truncate y: short_int to native_int
+    r12 = r10 < r11
+    r0 = r12
     goto L3
 L2:
-    r11 = CPyTagged_IsLt_(x, y)
-    r0 = r11
+    r13 = CPyTagged_IsLt_(x, y)
+    r0 = r13
 L3:
     if r0 goto L5 else goto L4 :: bool
 L4:
-    r12 = CPyTagged_IsGt(x, y)
-    if r12 goto L5 else goto L6 :: bool
+    r14 = CPyTagged_IsGt(x, y)
+    if r14 goto L5 else goto L6 :: bool
 L5:
-    r13 = 1
-    x = r13
+    r15 = 1
+    x = r15
     goto L7
 L6:
-    r14 = 2
-    x = r14
+    r16 = 2
+    x = r16
 L7:
     return x
 
@@ -324,8 +340,10 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9, r10, r11 :: bool
-    r12 :: short_int
+    r8, r9 :: bool
+    r10, r11 :: native_int
+    r12, r13 :: bool
+    r14 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
@@ -338,17 +356,19 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
-    r0 = r10
+    r10 = truncate x: short_int to native_int
+    r11 = truncate y: short_int to native_int
+    r12 = r10 < r11
+    r0 = r12
     goto L3
 L2:
-    r11 = CPyTagged_IsLt_(x, y)
-    r0 = r11
+    r13 = CPyTagged_IsLt_(x, y)
+    r0 = r13
 L3:
     if r0 goto L5 else goto L4 :: bool
 L4:
-    r12 = 1
-    x = r12
+    r14 = 1
+    x = r14
 L5:
     return x
 
@@ -364,8 +384,10 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9, r10, r11, r12 :: bool
-    r13 :: short_int
+    r8, r9 :: bool
+    r10, r11 :: native_int
+    r12, r13, r14 :: bool
+    r15 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
@@ -378,20 +400,22 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
-    r0 = r10
+    r10 = truncate x: short_int to native_int
+    r11 = truncate y: short_int to native_int
+    r12 = r10 < r11
+    r0 = r12
     goto L3
 L2:
-    r11 = CPyTagged_IsLt_(x, y)
-    r0 = r11
+    r13 = CPyTagged_IsLt_(x, y)
+    r0 = r13
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r12 = CPyTagged_IsGt(x, y)
-    if r12 goto L6 else goto L5 :: bool
+    r14 = CPyTagged_IsGt(x, y)
+    if r14 goto L6 else goto L5 :: bool
 L5:
-    r13 = 1
-    x = r13
+    r15 = 1
+    x = r15
 L6:
     return x
 
@@ -478,9 +502,11 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9, r10, r11 :: bool
-    r12, r13 :: short_int
-    r14 :: None
+    r8, r9 :: bool
+    r10, r11 :: native_int
+    r12, r13 :: bool
+    r14, r15 :: short_int
+    r16 :: None
 L0:
     r1 = 1
     r2 = x & r1
@@ -493,24 +519,26 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = x < y
-    r0 = r10
+    r10 = truncate x: short_int to native_int
+    r11 = truncate y: short_int to native_int
+    r12 = r10 < r11
+    r0 = r12
     goto L3
 L2:
-    r11 = CPyTagged_IsLt_(x, y)
-    r0 = r11
+    r13 = CPyTagged_IsLt_(x, y)
+    r0 = r13
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r12 = 1
-    x = r12
+    r14 = 1
+    x = r14
     goto L6
 L5:
-    r13 = 2
-    y = r13
+    r15 = 2
+    y = r15
 L6:
-    r14 = None
-    return r14
+    r16 = None
+    return r16
 
 [case testRecursion]
 def f(n: int) -> int:
@@ -2733,9 +2761,11 @@ def f(x, y, z):
     r4, r5, r6 :: native_int
     r7 :: bool
     r8, r9, r10 :: native_int
-    r11, r12, r13, r14 :: bool
-    r15 :: int
-    r16 :: bool
+    r11, r12 :: bool
+    r13, r14 :: native_int
+    r15, r16 :: bool
+    r17 :: int
+    r18 :: bool
 L0:
     r0 = g(x)
     r1 = g(y)
@@ -2750,21 +2780,23 @@ L0:
     r12 = r7 & r11
     if r12 goto L1 else goto L2 :: bool
 L1:
-    r13 = r0 < r1
-    r3 = r13
+    r13 = truncate r0: short_int to native_int
+    r14 = truncate r1: short_int to native_int
+    r15 = r13 < r14
+    r3 = r15
     goto L3
 L2:
-    r14 = CPyTagged_IsLt_(r0, r1)
-    r3 = r14
+    r16 = CPyTagged_IsLt_(r0, r1)
+    r3 = r16
 L3:
     if r3 goto L5 else goto L4 :: bool
 L4:
     r2 = r3
     goto L6
 L5:
-    r15 = g(z)
-    r16 = CPyTagged_IsGt(r1, r15)
-    r2 = r16
+    r17 = g(z)
+    r18 = CPyTagged_IsGt(r1, r17)
+    r2 = r18
 L6:
     return r2
 

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -96,10 +96,8 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9 :: bool
-    r10, r11 :: native_int
-    r12, r13 :: bool
-    r14 :: short_int
+    r8, r9, r10, r11 :: bool
+    r12 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
@@ -112,19 +110,17 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = truncate x: short_int to native_int
-    r11 = truncate y: short_int to native_int
-    r12 = r10 < r11
-    r0 = r12
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r13 = CPyTagged_IsLt_(x, y)
-    r0 = r13
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r14 = 2
-    x = r14
+    r12 = 2
+    x = r12
 L5:
     return x
 
@@ -142,10 +138,8 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9 :: bool
-    r10, r11 :: native_int
-    r12, r13 :: bool
-    r14, r15 :: short_int
+    r8, r9, r10, r11 :: bool
+    r12, r13 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
@@ -158,23 +152,21 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = truncate x: short_int to native_int
-    r11 = truncate y: short_int to native_int
-    r12 = r10 < r11
-    r0 = r12
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r13 = CPyTagged_IsLt_(x, y)
-    r0 = r13
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r14 = 2
-    x = r14
+    r12 = 2
+    x = r12
     goto L6
 L5:
-    r15 = 4
-    x = r15
+    r13 = 4
+    x = r13
 L6:
     return x
 
@@ -192,10 +184,8 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9 :: bool
-    r10, r11 :: native_int
-    r12, r13, r14 :: bool
-    r15, r16 :: short_int
+    r8, r9, r10, r11, r12 :: bool
+    r13, r14 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
@@ -208,26 +198,24 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = truncate x: short_int to native_int
-    r11 = truncate y: short_int to native_int
-    r12 = r10 < r11
-    r0 = r12
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r13 = CPyTagged_IsLt_(x, y)
-    r0 = r13
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L4 else goto L6 :: bool
 L4:
-    r14 = CPyTagged_IsGt(x, y)
-    if r14 goto L5 else goto L6 :: bool
+    r12 = CPyTagged_IsGt(x, y)
+    if r12 goto L5 else goto L6 :: bool
 L5:
-    r15 = 2
-    x = r15
+    r13 = 2
+    x = r13
     goto L7
 L6:
-    r16 = 4
-    x = r16
+    r14 = 4
+    x = r14
 L7:
     return x
 
@@ -267,10 +255,8 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9 :: bool
-    r10, r11 :: native_int
-    r12, r13, r14 :: bool
-    r15, r16 :: short_int
+    r8, r9, r10, r11, r12 :: bool
+    r13, r14 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
@@ -283,26 +269,24 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = truncate x: short_int to native_int
-    r11 = truncate y: short_int to native_int
-    r12 = r10 < r11
-    r0 = r12
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r13 = CPyTagged_IsLt_(x, y)
-    r0 = r13
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L5 else goto L4 :: bool
 L4:
-    r14 = CPyTagged_IsGt(x, y)
-    if r14 goto L5 else goto L6 :: bool
+    r12 = CPyTagged_IsGt(x, y)
+    if r12 goto L5 else goto L6 :: bool
 L5:
-    r15 = 2
-    x = r15
+    r13 = 2
+    x = r13
     goto L7
 L6:
-    r16 = 4
-    x = r16
+    r14 = 4
+    x = r14
 L7:
     return x
 
@@ -340,10 +324,8 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9 :: bool
-    r10, r11 :: native_int
-    r12, r13 :: bool
-    r14 :: short_int
+    r8, r9, r10, r11 :: bool
+    r12 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
@@ -356,19 +338,17 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = truncate x: short_int to native_int
-    r11 = truncate y: short_int to native_int
-    r12 = r10 < r11
-    r0 = r12
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r13 = CPyTagged_IsLt_(x, y)
-    r0 = r13
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L5 else goto L4 :: bool
 L4:
-    r14 = 2
-    x = r14
+    r12 = 2
+    x = r12
 L5:
     return x
 
@@ -384,10 +364,8 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9 :: bool
-    r10, r11 :: native_int
-    r12, r13, r14 :: bool
-    r15 :: short_int
+    r8, r9, r10, r11, r12 :: bool
+    r13 :: short_int
 L0:
     r1 = 1
     r2 = x & r1
@@ -400,22 +378,20 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = truncate x: short_int to native_int
-    r11 = truncate y: short_int to native_int
-    r12 = r10 < r11
-    r0 = r12
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r13 = CPyTagged_IsLt_(x, y)
-    r0 = r13
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r14 = CPyTagged_IsGt(x, y)
-    if r14 goto L6 else goto L5 :: bool
+    r12 = CPyTagged_IsGt(x, y)
+    if r12 goto L6 else goto L5 :: bool
 L5:
-    r15 = 2
-    x = r15
+    r13 = 2
+    x = r13
 L6:
     return x
 
@@ -502,11 +478,9 @@ def f(x, y):
     r1, r2, r3 :: native_int
     r4 :: bool
     r5, r6, r7 :: native_int
-    r8, r9 :: bool
-    r10, r11 :: native_int
-    r12, r13 :: bool
-    r14, r15 :: short_int
-    r16 :: None
+    r8, r9, r10, r11 :: bool
+    r12, r13 :: short_int
+    r14 :: None
 L0:
     r1 = 1
     r2 = x & r1
@@ -519,26 +493,24 @@ L0:
     r9 = r4 & r8
     if r9 goto L1 else goto L2 :: bool
 L1:
-    r10 = truncate x: short_int to native_int
-    r11 = truncate y: short_int to native_int
-    r12 = r10 < r11
-    r0 = r12
+    r10 = x < y
+    r0 = r10
     goto L3
 L2:
-    r13 = CPyTagged_IsLt_(x, y)
-    r0 = r13
+    r11 = CPyTagged_IsLt_(x, y)
+    r0 = r11
 L3:
     if r0 goto L4 else goto L5 :: bool
 L4:
-    r14 = 2
-    x = r14
+    r12 = 2
+    x = r12
     goto L6
 L5:
-    r15 = 4
-    y = r15
+    r13 = 4
+    y = r13
 L6:
-    r16 = None
-    return r16
+    r14 = None
+    return r14
 
 [case testRecursion]
 def f(n: int) -> int:
@@ -2761,11 +2733,9 @@ def f(x, y, z):
     r4, r5, r6 :: native_int
     r7 :: bool
     r8, r9, r10 :: native_int
-    r11, r12 :: bool
-    r13, r14 :: native_int
-    r15, r16 :: bool
-    r17 :: int
-    r18 :: bool
+    r11, r12, r13, r14 :: bool
+    r15 :: int
+    r16 :: bool
 L0:
     r0 = g(x)
     r1 = g(y)
@@ -2780,23 +2750,21 @@ L0:
     r12 = r7 & r11
     if r12 goto L1 else goto L2 :: bool
 L1:
-    r13 = truncate r0: short_int to native_int
-    r14 = truncate r1: short_int to native_int
-    r15 = r13 < r14
-    r3 = r15
+    r13 = r0 < r1
+    r3 = r13
     goto L3
 L2:
-    r16 = CPyTagged_IsLt_(r0, r1)
-    r3 = r16
+    r14 = CPyTagged_IsLt_(r0, r1)
+    r3 = r14
 L3:
     if r3 goto L5 else goto L4 :: bool
 L4:
     r2 = r3
     goto L6
 L5:
-    r17 = g(z)
-    r18 = CPyTagged_IsGt(r1, r17)
-    r2 = r18
+    r15 = g(z)
+    r16 = CPyTagged_IsGt(r1, r15)
+    r2 = r16
 L6:
     return r2
 

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -185,7 +185,7 @@ L0:
     r2 = r0
     i = r2
 L1:
-    r3 = r2 < r1
+    r3 = r2 < r1 :: signed
     if r3 goto L2 else goto L4 :: bool
 L2:
     r4 = CPyList_GetItem(l, i)

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -21,7 +21,7 @@ L0:
     r3 = r1
     i = r3
 L1:
-    r4 = r3 < r2
+    r4 = r3 < r2 :: signed
     if r4 goto L2 else goto L4 :: bool
 L2:
     r5 = CPyTagged_Add(x, i)
@@ -107,7 +107,7 @@ L0:
     r2 = r0
     n = r2
 L1:
-    r3 = r2 < r1
+    r3 = r2 < r1 :: signed
     if r3 goto L2 else goto L4 :: bool
 L2:
     goto L4
@@ -197,7 +197,7 @@ L0:
     r2 = r0
     n = r2
 L1:
-    r3 = r2 < r1
+    r3 = r2 < r1 :: signed
     if r3 goto L2 else goto L4 :: bool
 L2:
 L3:
@@ -271,7 +271,7 @@ L0:
     r2 = r1
 L1:
     r3 = len ls :: list
-    r4 = r2 < r3
+    r4 = r2 < r3 :: signed
     if r4 goto L2 else goto L4 :: bool
 L2:
     r5 = ls[r2] :: unsafe list
@@ -859,7 +859,7 @@ L0:
     r3 = r2
 L1:
     r4 = len a :: list
-    r5 = r3 < r4
+    r5 = r3 < r4 :: signed
     if r5 goto L2 else goto L4 :: bool
 L2:
     r6 = a[r3] :: unsafe list
@@ -942,7 +942,7 @@ L0:
     r2 = iter b :: object
 L1:
     r3 = len a :: list
-    r4 = r1 < r3
+    r4 = r1 < r3 :: signed
     if r4 goto L2 else goto L7 :: bool
 L2:
     r5 = next r2 :: object
@@ -997,10 +997,10 @@ L1:
     if is_error(r6) goto L6 else goto L2
 L2:
     r7 = len b :: list
-    r8 = r2 < r7
+    r8 = r2 < r7 :: signed
     if r8 goto L3 else goto L6 :: bool
 L3:
-    r9 = r5 < r4
+    r9 = r5 < r4 :: signed
     if r9 goto L4 else goto L6 :: bool
 L4:
     r10 = unbox(bool, r6)

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -12,7 +12,8 @@ from mypyc.ir.ops import (
 )
 from mypyc.ir.rtypes import (
     RTuple, RInstance, int_rprimitive, bool_rprimitive, list_rprimitive,
-    dict_rprimitive, object_rprimitive, c_int_rprimitive, short_int_rprimitive
+    dict_rprimitive, object_rprimitive, c_int_rprimitive, short_int_rprimitive, int32_rprimitive,
+    int64_rprimitive
 )
 from mypyc.ir.func_ir import FuncIR, FuncDecl, RuntimeArg, FuncSignature
 from mypyc.ir.class_ir import ClassIR
@@ -46,6 +47,10 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.b = self.env.add_local(Var('b'), bool_rprimitive)
         self.s1 = self.env.add_local(Var('s1'), short_int_rprimitive)
         self.s2 = self.env.add_local(Var('s2'), short_int_rprimitive)
+        self.i32 = self.env.add_local(Var('i32'), int32_rprimitive)
+        self.i32_1 = self.env.add_local(Var('i32_1'), int32_rprimitive)
+        self.i64 = self.env.add_local(Var('i64'), int64_rprimitive)
+        self.i64_1 = self.env.add_local(Var('i64_1'), int64_rprimitive)
         self.t = self.env.add_local(Var('t'), RTuple([int_rprimitive, bool_rprimitive]))
         self.tt = self.env.add_local(
             Var('tt'),
@@ -248,8 +253,20 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
             """cpy_r_r0 = PyDict_Contains(cpy_r_d, cpy_r_o);""")
 
     def test_binary_int_op(self) -> None:
+        # signed
         self.assert_emit(BinaryIntOp(bool_rprimitive, self.s1, self.s2, BinaryIntOp.SLT, 1),
                          """cpy_r_r0 = (Py_ssize_t)cpy_r_s1 < (Py_ssize_t)cpy_r_s2;""")
+        self.assert_emit(BinaryIntOp(bool_rprimitive, self.i32, self.i32_1, BinaryIntOp.SLT, 1),
+                         """cpy_r_r00 = cpy_r_i32 < cpy_r_i32_1;""")
+        self.assert_emit(BinaryIntOp(bool_rprimitive, self.i64, self.i64_1, BinaryIntOp.SLT, 1),
+                         """cpy_r_r01 = cpy_r_i64 < cpy_r_i64_1;""")
+        # unsigned
+        self.assert_emit(BinaryIntOp(bool_rprimitive, self.s1, self.s2, BinaryIntOp.ULT, 1),
+                         """cpy_r_r02 = cpy_r_s1 < cpy_r_s2;""")
+        self.assert_emit(BinaryIntOp(bool_rprimitive, self.i32, self.i32_1, BinaryIntOp.ULT, 1),
+                         """cpy_r_r03 = (uint32_t)cpy_r_i32 < (uint32_t)cpy_r_i32_1;""")
+        self.assert_emit(BinaryIntOp(bool_rprimitive, self.i64, self.i64_1, BinaryIntOp.ULT, 1),
+                         """cpy_r_r04 = (uint64_t)cpy_r_i64 < (uint64_t)cpy_r_i64_1;""")
 
     def assert_emit(self, op: Op, expected: str) -> None:
         self.emitter.fragments = []

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -8,11 +8,11 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ir.ops import (
     Environment, BasicBlock, Goto, Return, LoadInt, Assign, IncRef, DecRef, Branch,
     Call, Unbox, Box, TupleGet, GetAttr, PrimitiveOp, RegisterOp,
-    SetAttr, Op, Value, CallC
+    SetAttr, Op, Value, CallC, BinaryIntOp
 )
 from mypyc.ir.rtypes import (
     RTuple, RInstance, int_rprimitive, bool_rprimitive, list_rprimitive,
-    dict_rprimitive, object_rprimitive, c_int_rprimitive
+    dict_rprimitive, object_rprimitive, c_int_rprimitive, short_int_rprimitive
 )
 from mypyc.ir.func_ir import FuncIR, FuncDecl, RuntimeArg, FuncSignature
 from mypyc.ir.class_ir import ClassIR
@@ -44,6 +44,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.o2 = self.env.add_local(Var('o2'), object_rprimitive)
         self.d = self.env.add_local(Var('d'), dict_rprimitive)
         self.b = self.env.add_local(Var('b'), bool_rprimitive)
+        self.s1 = self.env.add_local(Var('s1'), short_int_rprimitive)
+        self.s2 = self.env.add_local(Var('s2'), short_int_rprimitive)
         self.t = self.env.add_local(Var('t'), RTuple([int_rprimitive, bool_rprimitive]))
         self.tt = self.env.add_local(
             Var('tt'),
@@ -244,6 +246,10 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit_binary_op(
             'in', self.b, self.o, self.d,
             """cpy_r_r0 = PyDict_Contains(cpy_r_d, cpy_r_o);""")
+
+    def test_binary_int_op(self) -> None:
+        self.assert_emit(BinaryIntOp(bool_rprimitive, self.s1, self.s2, BinaryIntOp.SLT, 1),
+                         """cpy_r_r0 = (Py_ssize_t)cpy_r_s1 < (Py_ssize_t)cpy_r_s2;""")
 
     def assert_emit(self, op: Op, expected: str) -> None:
         self.emitter.fragments = []


### PR DESCRIPTION
https://github.com/python/mypy/commit/358522e28cd58d95daf36256c46eb7ffcc55eea4 generates inline comparison between short ints, explicit conversion to signed is missing, though, causing negative cases to fail.

This PR add explicit type casts(although the name truncate here is a little bit misleading).

This PR will fix microbenchmark `int_list`.