### PR TITLE
Validate `follow_imports` values in mypy.ini

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -63,6 +63,16 @@ def split_and_match_files(paths: str) -> List[str]:
     return expanded_paths
 
 
+def check_follow_imports(choice: str) -> str:
+    choices = ['normal', 'silent', 'skip', 'error']
+    if choice not in choices:
+        raise argparse.ArgumentTypeError(
+            "invalid choice '{}' (choose from {})".format(
+                choice,
+                ', '.join("'{}'".format(x) for x in choices)))
+    return choice
+
+
 # For most options, the type of the default value set in options.py is
 # sufficient, and we don't have to do anything here.  This table
 # exists to specify types for values initialized to None or container
@@ -79,6 +89,7 @@ config_types = {
     # These two are for backwards compatibility
     'silent_imports': bool,
     'almost_silent': bool,
+    'follow_imports': check_follow_imports,
     'no_site_packages': bool,
     'plugins': lambda s: [p.strip() for p in s.split(',')],
     'always_true': lambda s: [p.strip() for p in s.split(',')],

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -452,6 +452,16 @@ main.py:6: note: Revealed type is 'builtins.int'
 main.py:7: note: Revealed type is 'Any'
 main.py:8: note: Revealed type is 'Any'
 
+[case testConfigFollowImportsInvalid]
+# cmd: mypy main.py
+[file mypy.ini]
+\[mypy]
+follow_imports =True
+[file main.py]
+[out]
+mypy.ini: [mypy]: follow_imports: invalid choice 'True' (choose from 'normal', 'silent', 'skip', 'error')
+== Return code: 0
+
 [case testConfigSilentMissingImportsOff]
 # cmd: mypy main.py
 [file main.py]


### PR DESCRIPTION
Currently we only validate the values on the commandline, which allows
bogus values to show up which will cause us to take the `else` branch
anywhere we consider follow_imports, which isn't likely to do anything
particularly correct.