### PR TITLE
Fix misleading follow_imports error message in dmypy

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -141,10 +141,8 @@ def process_start_options(flags: List[str], allow_sources: bool) -> Options:
                  "pass it to check/recheck instead")
     if not options.incremental:
         sys.exit("dmypy: start/restart should not disable incremental mode")
-    # Our file change tracking can't yet handle changes to files that aren't
-    # specified in the sources list.
     if options.follow_imports not in ('skip', 'error', 'normal'):
-        sys.exit("dmypy: follow-imports must be 'skip' or 'error'")
+        sys.exit("dmypy: follow-imports=silent not supported")
     return options
 
 


### PR DESCRIPTION
We support normal now, so we shouldn't say that only skip and error
are supported. That said, I don't think anybody uses silent (should we
delete it?), so I only hit this because of the bug in #9165.