### PR TITLE
Add command line support to enable/disable error codes

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -553,6 +553,36 @@ of the above sections.
     Note: the exact list of flags enabled by running :option:`--strict` may change
     over time.
 
+.. option:: --disable-error-code
+
+    This flag allows disabling one or multiple error codes globally.
+
+    .. code-block:: python
+
+        # no flag
+        x = 'a string'
+        x.trim()  # error: "str" has no attribute "trim"  [attr-defined]
+
+        # --disable-error-code attr-defined
+        x = 'a string'
+        x.trim()
+
+.. option:: --enable-error-code
+
+    This flag allows enabling one or multiple error codes globally.
+
+    Note: This flag will override disabled error codes from the --disable-error-code
+    flag
+
+    .. code-block:: python
+
+        # --disable-error-code attr-defined
+        x = 'a string'
+        x.trim()
+
+        # --disable-error-code attr-defined --enable-error-code attr-defined
+        x = 'a string'
+        x.trim()  # error: "str" has no attribute "trim"  [attr-defined]
 
 .. _configuring-error-messages:
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -223,7 +223,9 @@ def _build(sources: List[BuildSource],
                     options.show_error_codes,
                     options.pretty,
                     lambda path: read_py_file(path, cached_read, options.python_version),
-                    options.show_absolute_path)
+                    options.show_absolute_path,
+                    options.enabled_error_codes,
+                    options.disabled_error_codes)
     plugin, snapshot = load_plugins(options, errors, stdout, extra_plugins)
 
     # Add catch-all .gitignore to cache dir if we created it

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -3,19 +3,26 @@
 These can be used for filtering specific errors.
 """
 
-from typing import List
+from typing import Dict, List
 from typing_extensions import Final
 
 
 # All created error codes are implicitly stored in this list.
 all_error_codes = []  # type: List[ErrorCode]
 
+error_codes = {}  # type: Dict[str, ErrorCode]
+
 
 class ErrorCode:
-    def __init__(self, code: str, description: str, category: str) -> None:
+    def __init__(self, code: str,
+                 description: str,
+                 category: str,
+                 default_enabled: bool = True) -> None:
         self.code = code
         self.description = description
         self.category = category
+        self.default_enabled = default_enabled
+        error_codes[code] = self
 
     def __str__(self) -> str:
         return '<ErrorCode {}>'.format(self.code)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -3,11 +3,14 @@ import re
 import pprint
 import sys
 
-from typing_extensions import Final
+from typing_extensions import Final, TYPE_CHECKING
 from typing import Dict, List, Mapping, Optional, Pattern, Set, Tuple, Callable, Any
 
 from mypy import defaults
 from mypy.util import get_class_descriptors, replace_object_state
+
+if TYPE_CHECKING:
+    from mypy.errors import ErrorCode
 
 
 class BuildType:
@@ -176,6 +179,14 @@ class Options:
 
         # Variable names considered False
         self.always_false = []  # type: List[str]
+
+        # Error codes to disable
+        self.disable_error_code = []  # type: List[str]
+        self.disabled_error_codes = set()  # type: Set[ErrorCode]
+
+        # Error codes to enable
+        self.enable_error_code = []  # type: List[str]
+        self.enabled_error_codes = set()  # type: Set[ErrorCode]
 
         # Use script name instead of __main__
         self.scripts_are_modules = False

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1530,3 +1530,48 @@ def f(a = None):
 no_implicit_optional = True
 \[mypy-m]
 no_implicit_optional = False
+
+[case testDisableErrorCode]
+# flags: --disable-error-code attr-defined
+x = 'should be fine'
+x.trim()
+
+[case testDisableDifferentErrorCode]
+# flags: --disable-error-code name-defined --show-error-code
+x = 'should not be fine'
+x.trim()  # E: "str" has no attribute "trim"  [attr-defined]
+
+[case testDisableMultipleErrorCode]
+# flags: --disable-error-code attr-defined --disable-error-code return-value --show-error-code
+x = 'should be fine'
+x.trim()
+
+def bad_return_type() -> str:
+    return None
+
+bad_return_type('no args taken!')  # E: Too many arguments for "bad_return_type"  [call-arg]
+
+[case testEnableErrorCode]
+# flags: --disable-error-code attr-defined --enable-error-code attr-defined --show-error-code
+x = 'should be fine'
+x.trim()  # E: "str" has no attribute "trim"  [attr-defined]
+
+[case testEnableDifferentErrorCode]
+# flags: --disable-error-code attr-defined --enable-error-code name-defined --show-error-code
+x = 'should not be fine'
+x.trim()  # E: "str" has no attribute "trim"  [attr-defined]
+
+[case testEnableMultipleErrorCode]
+# flags: \
+    --disable-error-code attr-defined \
+    --disable-error-code return-value \
+    --disable-error-code call-arg \
+    --enable-error-code attr-defined \
+    --enable-error-code return-value --show-error-code
+x = 'should be fine'
+x.trim()  # E: "str" has no attribute "trim"  [attr-defined]
+
+def bad_return_type() -> str:
+    return None  # E: Incompatible return value type (got "None", expected "str")  [return-value]
+
+bad_return_type('no args taken!')

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1092,3 +1092,53 @@ import foo.bar
 [out]
 src/foo/bar.py: error: Source file found twice under different module names: 'src.foo.bar' and 'foo.bar'
 == Return code: 2
+
+[case testEnableInvalidErrorCode]
+# cmd: mypy --enable-error-code YOLO test.py
+[file test.py]
+x = 1
+[out]
+usage: mypy [-h] [-v] [-V] [more options; see below]
+            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
+mypy: error: Invalid error code(s): YOLO
+== Return code: 2
+
+[case testDisableInvalidErrorCode]
+# cmd: mypy --disable-error-code YOLO test.py
+[file test.py]
+x = 1
+[out]
+usage: mypy [-h] [-v] [-V] [more options; see below]
+            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
+mypy: error: Invalid error code(s): YOLO
+== Return code: 2
+
+[case testEnableAndDisableInvalidErrorCode]
+# cmd: mypy --disable-error-code YOLO --enable-error-code YOLO2 test.py
+[file test.py]
+x = 1
+[out]
+usage: mypy [-h] [-v] [-V] [more options; see below]
+            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
+mypy: error: Invalid error code(s): YOLO, YOLO2
+== Return code: 2
+
+[case testEnableValidAndInvalidErrorCode]
+# cmd: mypy --enable-error-code attr-defined --enable-error-code YOLO test.py
+[file test.py]
+x = 1
+[out]
+usage: mypy [-h] [-v] [-V] [more options; see below]
+            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
+mypy: error: Invalid error code(s): YOLO
+== Return code: 2
+
+[case testDisableValidAndInvalidErrorCode]
+# cmd: mypy --disable-error-code attr-defined --disable-error-code YOLO test.py
+[file test.py]
+x = 1
+[out]
+usage: mypy [-h] [-v] [-V] [more options; see below]
+            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
+mypy: error: Invalid error code(s): YOLO
+== Return code: 2


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/8975 

Add the `--disable-error-code` flag to disable error codes globally.
Add the `--enable-error-code` flag to enable error codes globally

This is my first time working on this repo, so please let me know anything additional that needs completing.