### PR TITLE
Fix crash when super outside of method is called

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3464,6 +3464,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             self.chk.fail(message_registry.SUPER_ARG_2_NOT_INSTANCE_OF_ARG_1, e)
             return AnyType(TypeOfAny.from_error)
 
+        if len(mro) == index + 1:
+            self.chk.fail(message_registry.SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED, e)
+            return AnyType(TypeOfAny.from_error)
+
         for base in mro[index+1:]:
             if e.name in base.names or base == mro[-1]:
                 if e.info and e.info.fallback_to_any and base == mro[-1]:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3465,7 +3465,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             return AnyType(TypeOfAny.from_error)
 
         if len(mro) == index + 1:
-            self.chk.fail(message_registry.SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED, e)
+            self.chk.fail(message_registry.TARGET_CLASS_HAS_NO_BASE_CLASS, e)
             return AnyType(TypeOfAny.from_error)
 
         for base in mro[index+1:]:

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -109,6 +109,7 @@ SUPER_VARARGS_NOT_SUPPORTED = 'Varargs not supported with "super"'  # type: Fina
 SUPER_POSITIONAL_ARGS_REQUIRED = '"super" only accepts positional arguments'  # type: Final
 SUPER_ARG_2_NOT_INSTANCE_OF_ARG_1 = \
     'Argument 2 for "super" not an instance of argument 1'  # type: Final
+TARGET_CLASS_HAS_NO_BASE_CLASS = 'Target class has no base class'  # type: Final
 SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED = \
     'super() outside of a method is not supported'  # type: Final
 SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED = \

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -280,6 +280,20 @@ class B(A):
 class C:
     a = super().whatever  # E: super() outside of a method is not supported
 
+[case testSuperWithObjectClassAsFirstArgument]
+class A:
+    def f(self) -> None:
+        super(object, self).f()  # E: super() outside of a method is not supported
+
+[case testSuperWithTypeVarAsFirstArgument]
+from typing import TypeVar
+
+T = TypeVar('T')
+
+def f(obj: T) -> None:
+    super(obj.__class__, obj).f()  # E: super() outside of a method is not supported
+[builtins fixtures/__new__.pyi]
+
 [case testSuperWithSingleArgument]
 class B:
     def f(self) -> None: pass

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -283,7 +283,7 @@ class C:
 [case testSuperWithObjectClassAsFirstArgument]
 class A:
     def f(self) -> None:
-        super(object, self).f()  # E: super() outside of a method is not supported
+        super(object, self).f()  # E: Target class has no base class
 
 [case testSuperWithTypeVarAsFirstArgument]
 from typing import TypeVar
@@ -291,7 +291,7 @@ from typing import TypeVar
 T = TypeVar('T')
 
 def f(obj: T) -> None:
-    super(obj.__class__, obj).f()  # E: super() outside of a method is not supported
+    super(obj.__class__, obj).f()  # E: Target class has no base class
 [builtins fixtures/__new__.pyi]
 
 [case testSuperWithSingleArgument]

--- a/test-data/unit/fixtures/__new__.pyi
+++ b/test-data/unit/fixtures/__new__.pyi
@@ -5,6 +5,8 @@ from typing import Any
 class object:
     def __init__(self) -> None: pass
 
+    __class__ = object
+
     def __new__(cls) -> Any: pass
 
 class type:


### PR DESCRIPTION
Fix #8353 #7580
* The same crash occur on:
```python
class A(B):
    def f(self):
        super(object, self).f()
```
* It's my first PR, any critic is desirable
