### PR TITLE
Adding config file for stubtest.py

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1166,15 +1166,15 @@ def parse_options(args: List[str]) -> argparse.Namespace:
         help="Ignore unused whitelist entries",
     )
     config_group = parser.add_argument_group(
-        title='Config file',
+        title='mypy config file',
         description="Use a config file instead of command line arguments. "
-                    "Plugins are the only supported configurations as of right "
-                    "now.",
+                    "Plugins and mypy path are the only supported "
+                    "configurations.",
     )
     config_group.add_argument(
-        '--config-file',
-        help="Configuration file, must have a [mypy] section "
-             "(defaults to {})".format(', '.join(defaults.CONFIG_FILES)))
+        '--mypy-config-file',
+        help="Configuration file, must have a [mypy] section",
+    )
 
     return parser.parse_args(args)
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -25,7 +25,7 @@ from typing_extensions import Type
 import mypy.build
 import mypy.modulefinder
 import mypy.types
-from mypy import defaults, nodes
+from mypy import nodes
 from mypy.config_parser import parse_config_file
 from mypy.errors import Errors
 from mypy.fscache import FileSystemCache
@@ -1052,7 +1052,7 @@ def test_stubs(args: argparse.Namespace) -> int:
     options = Options()
     options.incremental = False
     options.custom_typeshed_dir = args.custom_typeshed_dir
-    options.config_file = args.config_file
+    options.config_file = args.mypy_config_file
 
     plugins = None  # type: Optional[Sequence[Plugin]]
     if options.config_file:

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -15,7 +15,10 @@ import types
 import warnings
 from functools import singledispatch
 from pathlib import Path
-from typing import Any, Dict, Generic, Iterator, List, Optional, Sequence, Tuple, TypeVar, Union, cast
+from typing import (
+    Any, Dict, Generic, Iterator, List, Optional, Sequence, Tuple, TypeVar, Union,
+    cast,
+)
 
 from typing_extensions import Type
 
@@ -27,7 +30,7 @@ from mypy.config_parser import parse_config_file
 from mypy.errors import Errors
 from mypy.options import Options
 from mypy.plugin import Plugin
-from mypy.util import FancyFormatter
+from mypy.util import read_py_file, FancyFormatter
 
 
 class Missing:
@@ -923,7 +926,12 @@ def get_mypy_type_of_runtime_value(runtime: Any) -> Optional[mypy.types.Type]:
 _all_stubs = {}  # type: Dict[str, nodes.MypyFile]
 
 
-def build_stubs(modules: List[str], options: Options, find_submodules: bool = False, extra_plugins: Optional[Sequence[Plugin]] = None) -> List[str]:
+def build_stubs(
+    modules: List[str],
+    options: Options,
+    find_submodules: bool = False,
+    extra_plugins: Optional[Sequence[Plugin]] = None,
+) -> List[str]:
     """Uses mypy to construct stub objects for the given modules.
 
     This sets global state that ``get_stub`` can access.
@@ -1045,9 +1053,9 @@ def test_stubs(args: argparse.Namespace) -> int:
     options.custom_typeshed_dir = args.custom_typeshed_dir
     options.config_file = args.config_file
 
-    plugins = []
+    plugins = None # type: Optional[Sequence[Plugin]]
     if options.config_file:
-        def set_strict_flags() -> None: # not needed yet
+        def set_strict_flags() -> None:  # not needed yet
             return
         parse_config_file(options, set_strict_flags, options.config_file, sys.stdout, sys.stderr)
         errors = Errors(options.show_error_context,
@@ -1059,7 +1067,12 @@ def test_stubs(args: argparse.Namespace) -> int:
         plugins, _ = mypy.build.load_plugins_from_config(options, errors, sys.stdout)
 
     try:
-        modules = build_stubs(modules, options, find_submodules=not args.check_typeshed, extra_plugins=plugins)
+        modules = build_stubs(
+            modules,
+            options,
+            find_submodules=not args.check_typeshed,
+            extra_plugins=plugins,
+        )
     except RuntimeError:
         return 1
 
@@ -1151,10 +1164,11 @@ def parse_options(args: List[str]) -> argparse.Namespace:
         help="Ignore unused whitelist entries",
     )
     config_group = parser.add_argument_group(
-    title='Config file',
-    description="Use a config file instead of command line arguments. "
-                "Plugins are the only supported configurations as of right "
-                "now.")
+        title='Config file',
+        description="Use a config file instead of command line arguments. "
+                    "Plugins are the only supported configurations as of right "
+                    "now.",
+    )
     config_group.add_argument(
         '--config-file',
         help="Configuration file, must have a [mypy] section "

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1153,8 +1153,8 @@ def parse_options(args: List[str]) -> argparse.Namespace:
     config_group = parser.add_argument_group(
     title='Config file',
     description="Use a config file instead of command line arguments. "
-                "This is useful if you are using many flags or want "
-                "to set different options per each module.")
+                "Plugins are the only supported configurations as of right "
+                "now.")
     config_group.add_argument(
         '--config-file',
         help="Configuration file, must have a [mypy] section "

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -28,6 +28,7 @@ import mypy.types
 from mypy import defaults, nodes
 from mypy.config_parser import parse_config_file
 from mypy.errors import Errors
+from mypy.fscache import FileSystemCache
 from mypy.options import Options
 from mypy.plugin import Plugin
 from mypy.util import read_py_file, FancyFormatter
@@ -1053,16 +1054,17 @@ def test_stubs(args: argparse.Namespace) -> int:
     options.custom_typeshed_dir = args.custom_typeshed_dir
     options.config_file = args.config_file
 
-    plugins = None # type: Optional[Sequence[Plugin]]
+    plugins = None  # type: Optional[Sequence[Plugin]]
     if options.config_file:
         def set_strict_flags() -> None:  # not needed yet
             return
         parse_config_file(options, set_strict_flags, options.config_file, sys.stdout, sys.stderr)
+        fscache = FileSystemCache()
         errors = Errors(options.show_error_context,
                         options.show_column_numbers,
                         options.show_error_codes,
                         options.pretty,
-                        lambda path: read_py_file(path, cached_read, options.python_version),
+                        lambda path: read_py_file(path, fscache.read, options.python_version),
                         options.show_absolute_path)
         plugins, _ = mypy.build.load_plugins_from_config(options, errors, sys.stdout)
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1148,7 +1148,10 @@ def parse_options(args: List[str]) -> argparse.Namespace:
     )
     config_group.add_argument(
         '--mypy-config-file',
-        help="Configuration file, must have a [mypy] section",
+        help=(
+            "An existing mypy configuration file, currently used by stubtest to help "
+            "determine mypy path and plugins"
+        ),
     )
 
     return parser.parse_args(args)

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -15,10 +15,7 @@ import types
 import warnings
 from functools import singledispatch
 from pathlib import Path
-from typing import (
-    Any, Dict, Generic, Iterator, List, Optional, Tuple, TypeVar, Union,
-    cast,
-)
+from typing import Any, Dict, Generic, Iterator, List, Optional, Tuple, TypeVar, Union, cast
 
 from typing_extensions import Type
 
@@ -924,11 +921,7 @@ def get_mypy_type_of_runtime_value(runtime: Any) -> Optional[mypy.types.Type]:
 _all_stubs = {}  # type: Dict[str, nodes.MypyFile]
 
 
-def build_stubs(
-    modules: List[str],
-    options: Options,
-    find_submodules: bool = False,
-) -> List[str]:
+def build_stubs(modules: List[str], options: Options, find_submodules: bool = False) -> List[str]:
     """Uses mypy to construct stub objects for the given modules.
 
     This sets global state that ``get_stub`` can access.
@@ -1056,11 +1049,7 @@ def test_stubs(args: argparse.Namespace) -> int:
         parse_config_file(options, set_strict_flags, options.config_file, sys.stdout, sys.stderr)
 
     try:
-        modules = build_stubs(
-            modules,
-            options,
-            find_submodules=not args.check_typeshed,
-        )
+        modules = build_stubs(modules, options, find_submodules=not args.check_typeshed)
     except RuntimeError:
         return 1
 

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Iterator, List, Optional
 
 import mypy.stubtest
 from mypy.stubtest import parse_options, test_stubs
+from mypy.test.data import root_dir
 
 
 @contextlib.contextmanager
@@ -27,13 +28,18 @@ def use_tmp_dir() -> Iterator[None]:
 TEST_MODULE_NAME = "test_module"
 
 
-def run_stubtest(stub: str, runtime: str, options: List[str]) -> str:
+def run_stubtest(
+    stub: str, runtime: str, options: List[str], config_file: Optional[str] = None,
+) -> str:
     with use_tmp_dir():
         with open("{}.pyi".format(TEST_MODULE_NAME), "w") as f:
             f.write(stub)
         with open("{}.py".format(TEST_MODULE_NAME), "w") as f:
             f.write(runtime)
-
+        if config_file:
+            with open("{}_config.ini".format(TEST_MODULE_NAME), "w") as f:
+                f.write(config_file)
+            options = options + ["--mypy-config-file", "{}_config.ini".format(TEST_MODULE_NAME)]
         if sys.path[0] != ".":
             sys.path.insert(0, ".")
         if TEST_MODULE_NAME in sys.modules:
@@ -753,3 +759,32 @@ class StubtestIntegration(unittest.TestCase):
     def test_typeshed(self) -> None:
         # check we don't crash while checking typeshed
         test_stubs(parse_options(["--check-typeshed"]))
+
+    def test_config_file(self) -> None:
+        runtime = (
+            "temp = 5\n"
+        )
+        stub = (
+            "from decimal import Decimal\n"
+            "temp: Decimal\n"
+        )
+        config_file = (
+            "[mypy]\n"
+            "plugins={}/test-data/unit/plugins/decimal_to_int.py\n".format(root_dir)
+        )
+        output = run_stubtest(
+            stub=stub,
+            runtime=runtime,
+            options=[],
+        )
+        assert output == (
+            "error: test_module.temp variable differs from runtime type Literal[5]\n"
+            "Stub: at line 2\ndecimal.Decimal\nRuntime:\n5\n\n"
+        )
+        output = run_stubtest(
+            stub=stub,
+            runtime=runtime,
+            options=[],
+            config_file=config_file,
+        )
+        assert output == ""

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -761,30 +761,16 @@ class StubtestIntegration(unittest.TestCase):
         test_stubs(parse_options(["--check-typeshed"]))
 
     def test_config_file(self) -> None:
-        runtime = (
-            "temp = 5\n"
-        )
-        stub = (
-            "from decimal import Decimal\n"
-            "temp: Decimal\n"
-        )
+        runtime = "temp = 5\n"
+        stub = "from decimal import Decimal\ntemp: Decimal\n"
         config_file = (
             "[mypy]\n"
             "plugins={}/test-data/unit/plugins/decimal_to_int.py\n".format(root_dir)
         )
-        output = run_stubtest(
-            stub=stub,
-            runtime=runtime,
-            options=[],
-        )
+        output = run_stubtest(stub=stub, runtime=runtime, options=[])
         assert output == (
             "error: test_module.temp variable differs from runtime type Literal[5]\n"
             "Stub: at line 2\ndecimal.Decimal\nRuntime:\n5\n\n"
         )
-        output = run_stubtest(
-            stub=stub,
-            runtime=runtime,
-            options=[],
-            config_file=config_file,
-        )
+        output = run_stubtest(stub=stub, runtime=runtime, options=[], config_file=config_file)
         assert output == ""

--- a/test-data/unit/plugins/decimal_to_int.py
+++ b/test-data/unit/plugins/decimal_to_int.py
@@ -8,11 +8,11 @@ from mypy.types import CallableType, Type
 class MyPlugin(Plugin):
     def get_type_analyze_hook(self, fullname):
         if fullname == "decimal.Decimal":
-            return decorate_hook
+            return decimal_to_int_hook
         return None
 
 def plugin(version):
     return MyPlugin
 
-def decorate_hook(ctx):
+def decimal_to_int_hook(ctx):
     return ctx.api.named_type('builtins.int', [])

--- a/test-data/unit/plugins/decimal_to_int.py
+++ b/test-data/unit/plugins/decimal_to_int.py
@@ -1,0 +1,18 @@
+import builtins
+from typing import Optional, Callable
+
+from mypy.plugin import Plugin, AnalyzeTypeContext
+from mypy.types import CallableType, Type
+
+
+class MyPlugin(Plugin):
+    def get_type_analyze_hook(self, fullname):
+        if fullname == "decimal.Decimal":
+            return decorate_hook
+        return None
+
+def plugin(version):
+    return MyPlugin
+
+def decorate_hook(ctx):
+    return ctx.api.named_type('builtins.int', [])


### PR DESCRIPTION
This fixes [9193](https://github.com/python/mypy/issues/9193).

Before: You could not use plugins during the stub loading step.

Problem: If you need plugins for regular static type checking, you may need them when loading stubs for runtime type checking as well.

Solution: Add support for loading plugins from a config file. The easiest way to do this is to just load the config file and let `build` take care of it.

