### PR TITLE
[mypyc] Introduce LoadMem

### DIFF
--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -9,7 +9,7 @@ from mypyc.ir.ops import (
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
     LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError, CallC, LoadGlobal,
-    Truncate, BinaryIntOp, PtrDeref
+    Truncate, BinaryIntOp, LoadMem
 )
 
 
@@ -208,7 +208,7 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
     def visit_binary_int_op(self, op: BinaryIntOp) -> GenAndKill:
         return self.visit_register_op(op)
 
-    def visit_ptr_deref(self, op: PtrDeref) -> GenAndKill:
+    def visit_load_mem(self, op: LoadMem) -> GenAndKill:
         return self.visit_register_op(op)
 
 

--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -9,7 +9,7 @@ from mypyc.ir.ops import (
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
     LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError, CallC, LoadGlobal,
-    Truncate, BinaryIntOp
+    Truncate, BinaryIntOp, PtrDeref
 )
 
 
@@ -206,6 +206,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_binary_int_op(self, op: BinaryIntOp) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_ptr_deref(self, op: PtrDeref) -> GenAndKill:
         return self.visit_register_op(op)
 
 

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -12,7 +12,7 @@ from mypyc.ir.ops import (
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
     BasicBlock, Value, MethodCall, PrimitiveOp, EmitterInterface, Unreachable, NAMESPACE_STATIC,
     NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CallC, LoadGlobal, Truncate,
-    BinaryIntOp
+    BinaryIntOp, PtrDeref
 )
 from mypyc.ir.rtypes import (
     RType, RTuple, is_tagged, is_int32_rprimitive, is_int64_rprimitive
@@ -463,6 +463,13 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             rhs_cast = self.emit_unsigned_int_cast(op.rhs.type)
         self.emit_line('%s = %s%s %s %s%s;' % (dest, lhs_cast, lhs,
                                                op.op_str[op.op], rhs_cast, rhs))
+
+    def visit_ptr_deref(self, op: PtrDeref) -> None:
+        dest = self.reg(op)
+        src = self.reg(op.src)
+        # TODO: we shouldn't dereference to type that are pointer type so far
+        type = self.ctype(op.type)
+        self.emit_line('%s = *(%s*)(%s)' % (dest, type, src))
 
     # Helpers
 

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -469,7 +469,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         src = self.reg(op.src)
         # TODO: we shouldn't dereference to type that are pointer type so far
         type = self.ctype(op.type)
-        self.emit_line('%s = *(%s*)%s' % (dest, type, src))
+        self.emit_line('%s = *(%s*)%s;' % (dest, type, src))
 
     # Helpers
 

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -12,7 +12,7 @@ from mypyc.ir.ops import (
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
     BasicBlock, Value, MethodCall, PrimitiveOp, EmitterInterface, Unreachable, NAMESPACE_STATIC,
     NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CallC, LoadGlobal, Truncate,
-    BinaryIntOp, PtrDeref
+    BinaryIntOp, LoadMem
 )
 from mypyc.ir.rtypes import (
     RType, RTuple, is_tagged, is_int32_rprimitive, is_int64_rprimitive
@@ -464,12 +464,12 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emit_line('%s = %s%s %s %s%s;' % (dest, lhs_cast, lhs,
                                                op.op_str[op.op], rhs_cast, rhs))
 
-    def visit_ptr_deref(self, op: PtrDeref) -> None:
+    def visit_load_mem(self, op: LoadMem) -> None:
         dest = self.reg(op)
         src = self.reg(op.src)
         # TODO: we shouldn't dereference to type that are pointer type so far
         type = self.ctype(op.type)
-        self.emit_line('%s = *(%s*)(%s)' % (dest, type, src))
+        self.emit_line('%s = *(%s*)%s' % (dest, type, src))
 
     # Helpers
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1347,6 +1347,28 @@ class BinaryIntOp(RegisterOp):
         return visitor.visit_binary_int_op(self)
 
 
+class PtrDeref(RegisterOp):
+    """Pointer Dereference
+
+    type ret = *(type*)(src)
+    """
+    error_kind = ERR_NEVER
+
+    def __init__(self, type: RType, src: Value, line: int = -1) -> None:
+        super().__init__(line)
+        self.type = type
+        self.src = src
+
+    def sources(self) -> List[Value]:
+        return [self.src]
+
+    def to_str(self, env: Environment) -> str:
+        return env.format("%r = ptr_deref %r :: %r*", self, self.src, self.type)
+
+    def accept(self, visitor: 'OpVisitor[T]') -> T:
+        return visitor.visit_ptr_deref(self)
+
+
 @trait
 class OpVisitor(Generic[T]):
     """Generic visitor over ops (uses the visitor design pattern)."""
@@ -1451,6 +1473,10 @@ class OpVisitor(Generic[T]):
 
     @abstractmethod
     def visit_binary_int_op(self, op: BinaryIntOp) -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visit_ptr_deref(self, op: PtrDeref) -> T:
         raise NotImplementedError
 
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1347,10 +1347,10 @@ class BinaryIntOp(RegisterOp):
         return visitor.visit_binary_int_op(self)
 
 
-class PtrDeref(RegisterOp):
-    """Pointer Dereference
+class LoadMem(RegisterOp):
+    """Reading a memory location
 
-    type ret = *(type*)(src)
+    type ret = *(type*)src
     """
     error_kind = ERR_NEVER
 
@@ -1363,10 +1363,10 @@ class PtrDeref(RegisterOp):
         return [self.src]
 
     def to_str(self, env: Environment) -> str:
-        return env.format("%r = ptr_deref %r :: %r*", self, self.src, self.type)
+        return env.format("%r = load_mem %r :: %r*", self, self.src, self.type)
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
-        return visitor.visit_ptr_deref(self)
+        return visitor.visit_load_mem(self)
 
 
 @trait
@@ -1476,7 +1476,7 @@ class OpVisitor(Generic[T]):
         raise NotImplementedError
 
     @abstractmethod
-    def visit_ptr_deref(self, op: PtrDeref) -> T:
+    def visit_load_mem(self, op: LoadMem) -> T:
         raise NotImplementedError
 
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -25,7 +25,7 @@ from mypy.nodes import SymbolNode
 from mypyc.ir.rtypes import (
     RType, RInstance, RTuple, RVoid, is_bool_rprimitive, is_int_rprimitive,
     is_short_int_rprimitive, is_none_rprimitive, object_rprimitive, bool_rprimitive,
-    short_int_rprimitive, int_rprimitive, void_rtype
+    short_int_rprimitive, int_rprimitive, void_rtype, is_c_py_ssize_t_rprimitive
 )
 from mypyc.common import short_name
 
@@ -1357,6 +1357,9 @@ class LoadMem(RegisterOp):
     def __init__(self, type: RType, src: Value, line: int = -1) -> None:
         super().__init__(line)
         self.type = type
+        # TODO: for now we enforce that the src memory address should be Py_ssize_t
+        #       later we should also support same width unsigned int
+        assert is_c_py_ssize_t_rprimitive(src.type)
         self.src = src
 
     def sources(self) -> List[Value]:

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -301,6 +301,10 @@ def is_int64_rprimitive(rtype: RType) -> bool:
     return rtype is int64_rprimitive
 
 
+def is_c_py_ssize_t_rprimitive(rtype: RType) -> bool:
+    return rtype is c_pyssize_t_rprimitive
+
+
 def is_float_rprimitive(rtype: RType) -> bool:
     return isinstance(rtype, RPrimitive) and rtype.name == 'builtins.float'
 

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -277,10 +277,10 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def test_load_mem(self) -> None:
         if IS_32_BIT_PLATFORM:
             self.assert_emit(LoadMem(bool_rprimitive, self.i32),
-                             """cpy_r_r0 = *(char*)cpy_r_i32;""")
+                             """cpy_r_r0 = *(char *)cpy_r_i32;""")
         else:
             self.assert_emit(LoadMem(bool_rprimitive, self.i64),
-                             """cpy_r_r0 = *(char*)cpy_r_i64;""")
+                             """cpy_r_r0 = *(char *)cpy_r_i64;""")
 
     def assert_emit(self, op: Op, expected: str) -> None:
         self.emitter.fragments = []

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -35,6 +35,7 @@ from mypyc.subtype import is_subtype
 from mypyc.namegen import NameGenerator
 from mypyc.common import IS_32_BIT_PLATFORM
 
+
 class TestFunctionEmitterVisitor(unittest.TestCase):
     def setUp(self) -> None:
         self.env = Environment()

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -10,7 +10,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ir.ops import (
     Environment, BasicBlock, Goto, Return, LoadInt, Assign, IncRef, DecRef, Branch,
     Call, Unbox, Box, TupleGet, GetAttr, PrimitiveOp, RegisterOp,
-    SetAttr, Op, Value, CallC, BinaryIntOp
+    SetAttr, Op, Value, CallC, BinaryIntOp, LoadMem
 )
 from mypyc.ir.rtypes import (
     RTuple, RInstance, int_rprimitive, bool_rprimitive, list_rprimitive,
@@ -33,7 +33,7 @@ from mypyc.primitives.dict_ops import (
 from mypyc.primitives.int_ops import int_neg_op
 from mypyc.subtype import is_subtype
 from mypyc.namegen import NameGenerator
-
+from mypyc.common import IS_32_BIT_PLATFORM
 
 class TestFunctionEmitterVisitor(unittest.TestCase):
     def setUp(self) -> None:
@@ -272,6 +272,14 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_r03 = (uint32_t)cpy_r_i32 < (uint32_t)cpy_r_i32_1;""")
         self.assert_emit(BinaryIntOp(bool_rprimitive, self.i64, self.i64_1, BinaryIntOp.ULT, 1),
                          """cpy_r_r04 = (uint64_t)cpy_r_i64 < (uint64_t)cpy_r_i64_1;""")
+
+    def test_load_mem(self) -> None:
+        if IS_32_BIT_PLATFORM:
+            self.assert_emit(LoadMem(bool_rprimitive, self.i32),
+                             """cpy_r_r0 = *(char*)cpy_r_i32;""")
+        else:
+            self.assert_emit(LoadMem(bool_rprimitive, self.i64),
+                             """cpy_r_r0 = *(char*)cpy_r_i64;""")
 
     def assert_emit(self, op: Op, expected: str) -> None:
         self.emitter.fragments = []


### PR DESCRIPTION
relates mypyc/mypyc#741

Introduce `LoadMem` IR to read a memory address and convert it into a designated-type value. (The address would mostly be in `py_ssize_t` for now)

Part of efforts to implement `len` primitives: `*(Py_ssize_t*)(ob + size_offset)`