### PR TITLE
[mypyc] Introduce RStruct

### DIFF
--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -31,6 +31,8 @@ FAST_ISINSTANCE_MAX_SUBCLASSES = 2  # type: Final
 
 IS_32_BIT_PLATFORM = sys.maxsize < (1 << 31)  # type: Final
 
+PLATFORM_SIZE = 4 if IS_32_BIT_PLATFORM else 8
+
 # Runtime C library files
 RUNTIME_C_FILES = [
     'init.c',

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -529,10 +529,6 @@ class StructInfo:
                 self.names.append('_item' + str(i))
         self.offsets, self.size = compute_aligned_offsets_and_size(types)
 
-    def __eq__(self, other: object) -> bool:
-        return (isinstance(other, StructInfo) and self.name == other.name
-                and self.names == other.names and self.types == other.types)
-
 
 class RStruct(RType):
     """Represent CPython structs"""

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -371,7 +371,8 @@ class TupleNameVisitor(RTypeVisitor[str]):
         return 'T{}{}'.format(len(parts), ''.join(parts))
 
     def visit_rstruct(self, t: 'RStruct') -> str:
-        return "S"
+        assert False
+        return ""
 
     def visit_rvoid(self, t: 'RVoid') -> str:
         assert False, "rvoid in tuple?"

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -529,17 +529,34 @@ class StructInfo:
                 self.names.append('_item' + str(i))
         self.offsets, self.size = compute_aligned_offsets_and_size(types)
 
+    def __eq__(self, other: object) -> bool:
+        return (isinstance(other, StructInfo) and self.name == other.name
+                and self.names == other.names and self.types == other.types)
+
 
 class RStruct(RType):
     """Represent CPython structs"""
     def __init__(self,
                  info: StructInfo) -> None:
-        self.name = info.name
-        self.names = info.names
-        self.types = info.types
-        self.offsets = info.offsets
-        self.size = info.size
-        self._ctype = info.name
+        self.info = info
+        self.name = self.info.name
+        self._ctype = self.info.name
+
+    @property
+    def names(self) -> List[str]:
+        return self.info.names
+
+    @property
+    def types(self) -> List[RType]:
+        return self.info.types
+
+    @property
+    def offsets(self) -> List[int]:
+        return self.info.offsets
+
+    @property
+    def size(self) -> int:
+        return self.info.size
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_rstruct(self)
@@ -554,21 +571,17 @@ class RStruct(RType):
                                                           in zip(self.names, self.types)))
 
     def __eq__(self, other: object) -> bool:
-        return (isinstance(other, RStruct) and self.name == other.name
-                and self.names == other.names and self.types == other.types)
+        return isinstance(other, RStruct) and self.info == other.info
 
     def __hash__(self) -> int:
-        return hash((self.name, self.names, self.types))
+        return hash(self.info)
 
     def serialize(self) -> JsonDict:
-        types = [x.serialize() for x in self.types]
-        return {'.class': 'RStruct', 'name': self.name, 'names': self.names, 'types': types}
+        assert False
 
     @classmethod
     def deserialize(cls, data: JsonDict, ctx: 'DeserMaps') -> 'RStruct':
-        types = [deserialize_type(t, ctx) for t in data['types']]
-        info = StructInfo(data['name'], data['names'], types)
-        return RStruct(info)
+        assert False
 
 
 class RInstance(RType):

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -480,7 +480,7 @@ class RStruct(RType):
     @classmethod
     def deserialize(cls, data: JsonDict, ctx: 'DeserMaps') -> 'RStruct':
         types = [deserialize_type(t, ctx) for t in data['types']]
-        return RStruct(data['name'], data['names'], types)
+        return RStruct(data['name'], data['names'], types, data['offsets'])
 
 
 class RInstance(RType):

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -446,10 +446,15 @@ dict_next_rtuple_single = RTuple(
 class RStruct(RType):
     """
     """
-    def __init__(self, name: str, names: List[str], types: List[RType]) -> None:
+    def __init__(self,
+                 name: str,
+                 names: List[str],
+                 types: List[RType],
+                 offsets: List[int]) -> None:
         self.name = name
         self.names = names
         self.types = types
+        self.offsets = offsets
         self._ctype = self.name
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -453,13 +453,13 @@ def compute_rtype_alignment(typ: RType) -> int:
         return typ.size
     elif isinstance(typ, RInstance):
         return platform_alignment
+    elif isinstance(typ, RUnion):
+        return platform_alignment
     else:
         if isinstance(typ, RTuple):
             items = list(typ.types)
         elif isinstance(typ, RStruct):
             items = typ.types
-        elif isinstance(typ, RUnion):
-            items = typ.items
         else:
             assert False, "invalid rtype for computing alignment"
         max_alignment = max([compute_rtype_alignment(item) for item in items])
@@ -468,17 +468,16 @@ def compute_rtype_alignment(typ: RType) -> int:
 
 def compute_rtype_size(typ: RType) -> int:
     """Compute unaligned size of rtype"""
-    platform_size = PLATFORM_SIZE
     if isinstance(typ, RPrimitive):
         return typ.size
     elif isinstance(typ, RTuple):
         return compute_aligned_offsets_and_size(list(typ.types))[1]
     elif isinstance(typ, RUnion):
-        return compute_aligned_offsets_and_size(typ.items)[1]
+        return PLATFORM_SIZE
     elif isinstance(typ, RStruct):
         return compute_aligned_offsets_and_size(typ.types)[1]
     elif isinstance(typ, RInstance):
-        return platform_size
+        return PLATFORM_SIZE
     else:
         assert False, "invalid rtype for computing size"
 

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -25,7 +25,7 @@ from typing import Optional, Union, List, Dict, Generic, TypeVar, Tuple
 
 from typing_extensions import Final, ClassVar, TYPE_CHECKING
 
-from mypyc.common import JsonDict, short_name, IS_32_BIT_PLATFORM
+from mypyc.common import JsonDict, short_name, PLATFORM_SIZE
 from mypyc.namegen import NameGenerator
 
 if TYPE_CHECKING:
@@ -172,7 +172,7 @@ class RPrimitive(RType):
                  is_unboxed: bool,
                  is_refcounted: bool,
                  ctype: str = 'PyObject *',
-                 size: int = 4 if IS_32_BIT_PLATFORM else 8) -> None:
+                 size: int = PLATFORM_SIZE) -> None:
         RPrimitive.primitive_map[name] = self
 
         self.name = name
@@ -448,7 +448,7 @@ dict_next_rtuple_single = RTuple(
 
 def compute_rtype_alignment(typ: RType) -> int:
     """Compute alignment of a given type based on platform alignment rule"""
-    platform_alignment = 4 if IS_32_BIT_PLATFORM else 8
+    platform_alignment = PLATFORM_SIZE
     if isinstance(typ, RPrimitive):
         return typ.size
     elif isinstance(typ, RInstance):
@@ -468,7 +468,7 @@ def compute_rtype_alignment(typ: RType) -> int:
 
 def compute_rtype_size(typ: RType) -> int:
     """Compute unaligned size of rtype"""
-    platform_size = 4 if IS_32_BIT_PLATFORM else 8
+    platform_size = PLATFORM_SIZE
     if isinstance(typ, RPrimitive):
         return typ.size
     elif isinstance(typ, RTuple):
@@ -489,7 +489,7 @@ def compute_aligned_offsets_and_size(types: List[RType]) -> Tuple[List[int], int
     Note that the types argument are types of values that are stored
     sequentially with platform default alignment.
     """
-    platform_alignment = 4 if IS_32_BIT_PLATFORM else 8
+    platform_alignment = PLATFORM_SIZE
     unaligned_sizes = [compute_rtype_size(typ) for typ in types]
     alignment = [compute_rtype_alignment(typ) for typ in types]
 

--- a/mypyc/primitives/struct_regsitry.py
+++ b/mypyc/primitives/struct_regsitry.py
@@ -1,0 +1,28 @@
+"""Struct registries for C backend"""
+
+from typing import List, NamedTuple
+from mypyc.ir.rtypes import RType
+
+CStructDescription = NamedTuple(
+    'CStructDescription', [('name', str)],
+                           ('names', List[str]),
+                           ('types', List[RType]),
+                           ('offsets', List[int])])
+
+
+def c_struct(name: str,
+             names: List[str],
+             types: List[RType],
+             offsets: List[str]) -> CStructDescription:
+    """Define a known C struct for generating IR to manipulate it
+
+    name: The name of the C struct
+    types: type of each field
+    names: name of each field
+           TODO: the names list can be empty in the future when we merge Tuple as part of Struct
+    offsets: offset of each field
+           TODO: can we infer this information?
+    """
+    return CStructDescription(name, names, type, offsets)
+
+# TODO: create PyVarObject, to do which we probably need PyObject

--- a/mypyc/primitives/struct_regsitry.py
+++ b/mypyc/primitives/struct_regsitry.py
@@ -4,7 +4,7 @@ from typing import List, NamedTuple
 from mypyc.ir.rtypes import RType
 
 CStructDescription = NamedTuple(
-    'CStructDescription', [('name', str)],
+    'CStructDescription', [('name', str),
                            ('names', List[str]),
                            ('types', List[RType]),
                            ('offsets', List[int])])
@@ -13,7 +13,7 @@ CStructDescription = NamedTuple(
 def c_struct(name: str,
              names: List[str],
              types: List[RType],
-             offsets: List[str]) -> CStructDescription:
+             offsets: List[int]) -> CStructDescription:
     """Define a known C struct for generating IR to manipulate it
 
     name: The name of the C struct
@@ -23,6 +23,6 @@ def c_struct(name: str,
     offsets: offset of each field
            TODO: can we infer this information?
     """
-    return CStructDescription(name, names, type, offsets)
+    return CStructDescription(name, names, types, offsets)
 
 # TODO: create PyVarObject, to do which we probably need PyObject

--- a/mypyc/primitives/struct_regsitry.py
+++ b/mypyc/primitives/struct_regsitry.py
@@ -6,23 +6,19 @@ from mypyc.ir.rtypes import RType
 CStructDescription = NamedTuple(
     'CStructDescription', [('name', str),
                            ('names', List[str]),
-                           ('types', List[RType]),
-                           ('offsets', List[int])])
+                           ('types', List[RType])])
 
 
 def c_struct(name: str,
              names: List[str],
-             types: List[RType],
-             offsets: List[int]) -> CStructDescription:
+             types: List[RType]) -> CStructDescription:
     """Define a known C struct for generating IR to manipulate it
 
     name: The name of the C struct
     types: type of each field
     names: name of each field
            TODO: the names list can be empty in the future when we merge Tuple as part of Struct
-    offsets: offset of each field
-           TODO: can we infer this information?
     """
-    return CStructDescription(name, names, types, offsets)
+    return CStructDescription(name, names, types)
 
 # TODO: create PyVarObject, to do which we probably need PyObject

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -52,11 +52,7 @@ class RTSubtypeVisitor(RTypeVisitor[bool]):
         return False
 
     def visit_rstruct(self, left: RStruct) -> bool:
-        if isinstance(self.right, RStruct):
-            return (self.right.name == left.name and self.right.names == left.names and
-                    len(self.right.types) == len(left.types) and all(is_runtime_subtype(t1, t2)
-                    for t1, t2 in zip(left.types, self.right.types)))
-        return False
+        return isinstance(self.right, RStruct) and self.right.name == left.name
 
     def visit_rvoid(self, left: RVoid) -> bool:
         return isinstance(self.right, RVoid)

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -14,7 +14,7 @@ coercion is necessary first.
 """
 
 from mypyc.ir.rtypes import (
-    RType, RUnion, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor,
+    RType, RUnion, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor, RStruct,
     is_int_rprimitive, is_short_int_rprimitive,
 )
 from mypyc.subtype import is_subtype
@@ -47,6 +47,13 @@ class RTSubtypeVisitor(RTypeVisitor[bool]):
 
     def visit_rtuple(self, left: RTuple) -> bool:
         if isinstance(self.right, RTuple):
+            return len(self.right.types) == len(left.types) and all(
+                is_runtime_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types))
+        return False
+
+    def visit_rstruct(self, left: RStruct) -> bool:
+        if isinstance(self.right, RStruct):
+            # TODO: should we consider names?
             return len(self.right.types) == len(left.types) and all(
                 is_runtime_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types))
         return False

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -53,9 +53,9 @@ class RTSubtypeVisitor(RTypeVisitor[bool]):
 
     def visit_rstruct(self, left: RStruct) -> bool:
         if isinstance(self.right, RStruct):
-            return len(self.right.types) == len(left.types) and all(
-                is_runtime_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types)) and (
-                self.right.names == left.names)
+            return (self.right.name == left.name and self.right.names == left.names and
+                    len(self.right.types) == len(left.types) and all(is_runtime_subtype(t1, t2)
+                    for t1, t2 in zip(left.types, self.right.types)))
         return False
 
     def visit_rvoid(self, left: RVoid) -> bool:

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -53,9 +53,9 @@ class RTSubtypeVisitor(RTypeVisitor[bool]):
 
     def visit_rstruct(self, left: RStruct) -> bool:
         if isinstance(self.right, RStruct):
-            # TODO: should we consider names?
             return len(self.right.types) == len(left.types) and all(
-                is_runtime_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types))
+                is_runtime_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types)) and (
+                self.right.names == left.names)
         return False
 
     def visit_rvoid(self, left: RVoid) -> bool:

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -54,6 +54,7 @@ class SameTypeVisitor(RTypeVisitor[bool]):
 
     def visit_rstruct(self, left: RStruct) -> bool:
         return (isinstance(self.right, RStruct)
+            and self.right.names == left.names
             and len(self.right.types) == len(left.types)
             and all(is_same_type(t1, t2) for t1, t2 in zip(left.types, self.right.types)))
 

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -1,7 +1,7 @@
 """Same type check for RTypes."""
 
 from mypyc.ir.rtypes import (
-    RType, RTypeVisitor, RInstance, RPrimitive, RTuple, RVoid, RUnion
+    RType, RTypeVisitor, RInstance, RPrimitive, RTuple, RVoid, RUnion, RStruct
 )
 from mypyc.ir.func_ir import FuncSignature
 
@@ -49,6 +49,11 @@ class SameTypeVisitor(RTypeVisitor[bool]):
 
     def visit_rtuple(self, left: RTuple) -> bool:
         return (isinstance(self.right, RTuple)
+            and len(self.right.types) == len(left.types)
+            and all(is_same_type(t1, t2) for t1, t2 in zip(left.types, self.right.types)))
+
+    def visit_rstruct(self, left: RStruct) -> bool:
+        return (isinstance(self.right, RStruct)
             and len(self.right.types) == len(left.types)
             and all(is_same_type(t1, t2) for t1, t2 in zip(left.types, self.right.types)))
 

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -53,10 +53,7 @@ class SameTypeVisitor(RTypeVisitor[bool]):
             and all(is_same_type(t1, t2) for t1, t2 in zip(left.types, self.right.types)))
 
     def visit_rstruct(self, left: RStruct) -> bool:
-        return (isinstance(self.right, RStruct)
-            and self.right.names == left.names
-            and len(self.right.types) == len(left.types)
-            and all(is_same_type(t1, t2) for t1, t2 in zip(left.types, self.right.types)))
+        return isinstance(self.right, RStruct) and self.right.name == left.name
 
     def visit_rvoid(self, left: RVoid) -> bool:
         return isinstance(self.right, RVoid)

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -57,10 +57,7 @@ class SubtypeVisitor(RTypeVisitor[bool]):
         return False
 
     def visit_rstruct(self, left: RStruct) -> bool:
-        if isinstance(self.right, RStruct):
-            return len(self.right.types) == len(left.types) and all(
-                is_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types))
-        return False
+        return isinstance(self.right, RStruct) and self.right.name == left.name
 
     def visit_rvoid(self, left: RVoid) -> bool:
         return isinstance(self.right, RVoid)

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -1,7 +1,7 @@
 """Subtype check for RTypes."""
 
 from mypyc.ir.rtypes import (
-    RType, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor, RUnion,
+    RType, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor, RUnion, RStruct,
     is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive,
     is_short_int_rprimitive,
     is_object_rprimitive
@@ -52,6 +52,12 @@ class SubtypeVisitor(RTypeVisitor[bool]):
         if is_tuple_rprimitive(self.right):
             return True
         if isinstance(self.right, RTuple):
+            return len(self.right.types) == len(left.types) and all(
+                is_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types))
+        return False
+
+    def visit_rstruct(self, left: RStruct) -> bool:
+        if isinstance(self.right, RStruct):
             return len(self.right.types) == len(left.types) and all(
                 is_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types))
         return False

--- a/mypyc/test/test_struct.py
+++ b/mypyc/test/test_struct.py
@@ -25,9 +25,20 @@ class TestStruct(unittest.TestCase):
             assert r2.size == 8
             assert r3.size == 16
 
+        r4 = RStruct("", [], [bool_rprimitive, bool_rprimitive,
+                              bool_rprimitive, int32_rprimitive])
+        assert r4.size == 8
+        assert r4.offsets == [0, 1, 2, 4]
+
     def test_struct_str(self) -> None:
         r = RStruct("Foo", ["a", "b"],
                     [bool_rprimitive, object_rprimitive])
         assert str(r) == "Foo{a:bool, b:object}"
         assert repr(r) == "<RStruct Foo{a:<RPrimitive builtins.bool>, " \
                           "b:<RPrimitive builtins.object>}>"
+        r1 = RStruct("Bar", ["c"], [int32_rprimitive])
+        assert str(r1) == "Bar{c:int32}"
+        assert repr(r1) =="<RStruct Bar{c:<RPrimitive int32>}>"
+        r2 = RStruct("Baz", [], [])
+        assert str(r2) == "Baz{}"
+        assert repr(r2) =="<RStruct Baz{}>"

--- a/mypyc/test/test_struct.py
+++ b/mypyc/test/test_struct.py
@@ -27,12 +27,8 @@ class TestStruct(unittest.TestCase):
         r3 = RStruct(info3)
         assert r2.offsets == [0, 4]
         assert r3.offsets == [0, 8]
-        if IS_32_BIT_PLATFORM:
-            assert r2.size == 8
-            assert r3.size == 12
-        else:
-            assert r2.size == 8
-            assert r3.size == 16
+        assert r2.size == 8
+        assert r3.size == 16
 
         info4 = StructInfo("", [], [bool_rprimitive, bool_rprimitive,
                               bool_rprimitive, int32_rprimitive])

--- a/mypyc/test/test_struct.py
+++ b/mypyc/test/test_struct.py
@@ -1,0 +1,33 @@
+import unittest
+
+from mypyc.ir.rtypes import (
+    RStruct, bool_rprimitive, int64_rprimitive, int32_rprimitive, object_rprimitive
+)
+from mypyc.common import IS_32_BIT_PLATFORM
+
+
+class TestStruct(unittest.TestCase):
+    def test_struct_offsets(self) -> None:
+        # test per-member alignment
+        r1 = RStruct("", [], [bool_rprimitive, int32_rprimitive, int64_rprimitive])
+        assert r1.size == 16
+        assert r1.offsets == [0, 4, 8]
+
+        # test final alignment
+        r2 = RStruct("", [], [int32_rprimitive, bool_rprimitive])
+        r3 = RStruct("", [], [int64_rprimitive, bool_rprimitive])
+        assert r2.offsets == [0, 4]
+        assert r3.offsets == [0, 8]
+        if IS_32_BIT_PLATFORM:
+            assert r2.size == 8
+            assert r3.size == 12
+        else:
+            assert r2.size == 8
+            assert r3.size == 16
+
+    def test_struct_str(self) -> None:
+        r = RStruct("Foo", ["a", "b"],
+                    [bool_rprimitive, object_rprimitive])
+        assert str(r) == "Foo{a:bool, b:object}"
+        assert repr(r) == "<RStruct Foo{a:<RPrimitive builtins.bool>, " \
+                          "b:<RPrimitive builtins.object>}>"

--- a/mypyc/test/test_struct.py
+++ b/mypyc/test/test_struct.py
@@ -38,7 +38,7 @@ class TestStruct(unittest.TestCase):
                           "b:<RPrimitive builtins.object>}>"
         r1 = RStruct("Bar", ["c"], [int32_rprimitive])
         assert str(r1) == "Bar{c:int32}"
-        assert repr(r1) =="<RStruct Bar{c:<RPrimitive int32>}>"
+        assert repr(r1) == "<RStruct Bar{c:<RPrimitive int32>}>"
         r2 = RStruct("Baz", [], [])
         assert str(r2) == "Baz{}"
-        assert repr(r2) =="<RStruct Baz{}>"
+        assert repr(r2) == "<RStruct Baz{}>"

--- a/mypyc/test/test_struct.py
+++ b/mypyc/test/test_struct.py
@@ -2,7 +2,7 @@ import unittest
 
 from mypyc.ir.rtypes import (
     RStruct, bool_rprimitive, int64_rprimitive, int32_rprimitive, object_rprimitive, StructInfo,
-    int_rprimitive, short_int_rprimitive
+    int_rprimitive
 )
 from mypyc.rt_subtype import is_runtime_subtype
 

--- a/mypyc/test/test_struct.py
+++ b/mypyc/test/test_struct.py
@@ -4,7 +4,6 @@ from mypyc.ir.rtypes import (
     RStruct, bool_rprimitive, int64_rprimitive, int32_rprimitive, object_rprimitive, StructInfo,
     int_rprimitive, short_int_rprimitive
 )
-from mypyc.common import IS_32_BIT_PLATFORM
 from mypyc.rt_subtype import is_runtime_subtype
 
 

--- a/mypyc/test/test_struct.py
+++ b/mypyc/test/test_struct.py
@@ -7,6 +7,7 @@ from mypyc.ir.rtypes import (
 from mypyc.common import IS_32_BIT_PLATFORM
 from mypyc.rt_subtype import is_runtime_subtype
 
+
 class TestStruct(unittest.TestCase):
     def test_struct_offsets(self) -> None:
         # test per-member alignment
@@ -86,7 +87,6 @@ class TestStruct(unittest.TestCase):
                     [bool_rprimitive, int_rprimitive])
         r3 = RStruct(info3)
 
-
         # type different
         info4 = StructInfo("Foo", ["a", "b"],
                     [bool_rprimitive, int32_rprimitive])
@@ -97,8 +97,8 @@ class TestStruct(unittest.TestCase):
                     [bool_rprimitive, int_rprimitive, bool_rprimitive])
         r5 = RStruct(info5)
 
-        assert is_runtime_subtype(r1, r) == True
-        assert is_runtime_subtype(r2, r) == False
-        assert is_runtime_subtype(r3, r) == False
-        assert is_runtime_subtype(r4, r) == False
-        assert is_runtime_subtype(r5, r) == False
+        assert is_runtime_subtype(r1, r) is True
+        assert is_runtime_subtype(r2, r) is False
+        assert is_runtime_subtype(r3, r) is False
+        assert is_runtime_subtype(r4, r) is False
+        assert is_runtime_subtype(r5, r) is False

--- a/mypyc/test/test_struct.py
+++ b/mypyc/test/test_struct.py
@@ -9,12 +9,16 @@ from mypyc.common import IS_32_BIT_PLATFORM
 class TestStruct(unittest.TestCase):
     def test_struct_offsets(self) -> None:
         # test per-member alignment
-        info1 = StructInfo("", [], [bool_rprimitive, int32_rprimitive, int64_rprimitive])
-        r1 = RStruct(info1)
-        assert r1.size == 16
-        assert r1.offsets == [0, 4, 8]
+        info = StructInfo("", [], [bool_rprimitive, int32_rprimitive, int64_rprimitive])
+        r = RStruct(info)
+        assert r.size == 16
+        assert r.offsets == [0, 4, 8]
 
         # test final alignment
+        info1 = StructInfo("", [], [bool_rprimitive, bool_rprimitive])
+        r1 = RStruct(info1)
+        assert r1.size == 2
+        assert r1.offsets == [0, 1]
         info2 = StructInfo("", [], [int32_rprimitive, bool_rprimitive])
         r2 = RStruct(info2)
         info3 = StructInfo("", [], [int64_rprimitive, bool_rprimitive])
@@ -35,7 +39,7 @@ class TestStruct(unittest.TestCase):
         assert r4.offsets == [0, 1, 2, 4]
 
         # test nested struct
-        info5 = StructInfo("", [], [bool_rprimitive, r1])
+        info5 = StructInfo("", [], [bool_rprimitive, r])
         r5 = RStruct(info5)
         assert r5.offsets == [0, 8]
         assert r5.size == 24

--- a/mypyc/test/test_struct.py
+++ b/mypyc/test/test_struct.py
@@ -72,28 +72,26 @@ class TestStruct(unittest.TestCase):
                     [bool_rprimitive, int_rprimitive])
         r = RStruct(info)
 
-        # second type is subtype of r's second type
-        info1 = StructInfo("Foo", ["a", "b"],
-                    [bool_rprimitive, short_int_rprimitive])
-        r1 = RStruct(info1)
+        # using the same StructInfo
+        r1 = RStruct(info)
 
         # names different
-        info2 = StructInfo("Foo", ["c", "b"],
+        info2 = StructInfo("Bar", ["c", "b"],
                     [bool_rprimitive, int_rprimitive])
         r2 = RStruct(info2)
 
         # name different
-        info3 = StructInfo("Bar", ["a", "b"],
+        info3 = StructInfo("Baz", ["a", "b"],
                     [bool_rprimitive, int_rprimitive])
         r3 = RStruct(info3)
 
         # type different
-        info4 = StructInfo("Foo", ["a", "b"],
+        info4 = StructInfo("FooBar", ["a", "b"],
                     [bool_rprimitive, int32_rprimitive])
         r4 = RStruct(info4)
 
         # number of types different
-        info5 = StructInfo("Foo", ["a", "b", "c"],
+        info5 = StructInfo("FooBarBaz", ["a", "b", "c"],
                     [bool_rprimitive, int_rprimitive, bool_rprimitive])
         r5 = RStruct(info5)
 

--- a/mypyc/test/test_struct.py
+++ b/mypyc/test/test_struct.py
@@ -1,7 +1,7 @@
 import unittest
 
 from mypyc.ir.rtypes import (
-    RStruct, bool_rprimitive, int64_rprimitive, int32_rprimitive, object_rprimitive
+    RStruct, bool_rprimitive, int64_rprimitive, int32_rprimitive, object_rprimitive, StructInfo
 )
 from mypyc.common import IS_32_BIT_PLATFORM
 
@@ -9,13 +9,16 @@ from mypyc.common import IS_32_BIT_PLATFORM
 class TestStruct(unittest.TestCase):
     def test_struct_offsets(self) -> None:
         # test per-member alignment
-        r1 = RStruct("", [], [bool_rprimitive, int32_rprimitive, int64_rprimitive])
+        info1 = StructInfo("", [], [bool_rprimitive, int32_rprimitive, int64_rprimitive])
+        r1 = RStruct(info1)
         assert r1.size == 16
         assert r1.offsets == [0, 4, 8]
 
         # test final alignment
-        r2 = RStruct("", [], [int32_rprimitive, bool_rprimitive])
-        r3 = RStruct("", [], [int64_rprimitive, bool_rprimitive])
+        info2 = StructInfo("", [], [int32_rprimitive, bool_rprimitive])
+        r2 = RStruct(info2)
+        info3 = StructInfo("", [], [int64_rprimitive, bool_rprimitive])
+        r3 = RStruct(info3)
         assert r2.offsets == [0, 4]
         assert r3.offsets == [0, 8]
         if IS_32_BIT_PLATFORM:
@@ -25,28 +28,34 @@ class TestStruct(unittest.TestCase):
             assert r2.size == 8
             assert r3.size == 16
 
-        r4 = RStruct("", [], [bool_rprimitive, bool_rprimitive,
+        info4 = StructInfo("", [], [bool_rprimitive, bool_rprimitive,
                               bool_rprimitive, int32_rprimitive])
+        r4 = RStruct(info4)
         assert r4.size == 8
         assert r4.offsets == [0, 1, 2, 4]
 
         # test nested struct
-        r5 = RStruct("", [], [bool_rprimitive, r1])
+        info5 = StructInfo("", [], [bool_rprimitive, r1])
+        r5 = RStruct(info5)
         assert r5.offsets == [0, 8]
         assert r5.size == 24
-        r6 = RStruct("", [], [int32_rprimitive, r5])
+        info6 = StructInfo("", [], [int32_rprimitive, r5])
+        r6 = RStruct(info6)
         assert r6.offsets == [0, 8]
         assert r6.size == 32
 
     def test_struct_str(self) -> None:
-        r = RStruct("Foo", ["a", "b"],
+        info = StructInfo("Foo", ["a", "b"],
                     [bool_rprimitive, object_rprimitive])
+        r = RStruct(info)
         assert str(r) == "Foo{a:bool, b:object}"
         assert repr(r) == "<RStruct Foo{a:<RPrimitive builtins.bool>, " \
                           "b:<RPrimitive builtins.object>}>"
-        r1 = RStruct("Bar", ["c"], [int32_rprimitive])
+        info1 = StructInfo("Bar", ["c"], [int32_rprimitive])
+        r1 = RStruct(info1)
         assert str(r1) == "Bar{c:int32}"
         assert repr(r1) == "<RStruct Bar{c:<RPrimitive int32>}>"
-        r2 = RStruct("Baz", [], [])
+        info2 = StructInfo("Baz", [], [])
+        r2 = RStruct(info2)
         assert str(r2) == "Baz{}"
         assert repr(r2) == "<RStruct Baz{}>"

--- a/mypyc/test/test_struct.py
+++ b/mypyc/test/test_struct.py
@@ -30,6 +30,14 @@ class TestStruct(unittest.TestCase):
         assert r4.size == 8
         assert r4.offsets == [0, 1, 2, 4]
 
+        # test nested struct
+        r5 = RStruct("", [], [bool_rprimitive, r1])
+        assert r5.offsets == [0, 8]
+        assert r5.size == 24
+        r6 = RStruct("", [], [int32_rprimitive, r5])
+        assert r6.offsets == [0, 8]
+        assert r6.size == 32
+
     def test_struct_str(self) -> None:
         r = RStruct("Foo", ["a", "b"],
                     [bool_rprimitive, object_rprimitive])

--- a/mypyc/test/test_struct.py
+++ b/mypyc/test/test_struct.py
@@ -44,6 +44,11 @@ class TestStruct(unittest.TestCase):
         r6 = RStruct(info6)
         assert r6.offsets == [0, 8]
         assert r6.size == 32
+        # test nested struct with alignment less than 8
+        info7 = StructInfo("", [], [bool_rprimitive, r4])
+        r7 = RStruct(info7)
+        assert r7.offsets == [0, 4]
+        assert r7.size == 12
 
     def test_struct_str(self) -> None:
         info = StructInfo("Foo", ["a", "b"],


### PR DESCRIPTION
relates #9211 

This PR introduces `RStruct` to represent CPython structures.

`StructInfo` is used to hold information about a unique struct-like type.

This PR also introduces several functions to compute aligned offsets and size of structure types.