### PR TITLE
Fix untyped decorator overload error on decorator with __call__ overloads

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5757,7 +5757,10 @@ def is_untyped_decorator(typ: Optional[Type]) -> bool:
     elif isinstance(typ, Instance):
         method = typ.type.get_method('__call__')
         if method:
-            return not is_typed_callable(method.type)
+            if isinstance(method.type, Overloaded):
+                return any(is_untyped_decorator(item) for item in method.type.items())
+            else:
+                return not is_typed_callable(method.type)
         else:
             return False
     elif isinstance(typ, Overloaded):

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4955,6 +4955,33 @@ def g(name: str) -> int:
 reveal_type(f)  # N: Revealed type is 'def (name: builtins.str) -> builtins.int'
 reveal_type(g)  # N: Revealed type is 'def (name: builtins.str) -> builtins.int'
 
+[case testDisallowUntypedDecoratorsOverloadDunderCall]
+# flags: --disallow-untyped-decorators
+from typing import Any, Callable, overload, TypeVar
+
+F = TypeVar('F', bound=Callable[..., Any])
+
+class Dec:
+    @overload
+    def __call__(self, x: F) -> F: ...
+    @overload
+    def __call__(self, x: str) -> Callable[[F], F]: ...
+    def __call__(self, x) -> Any:
+        pass
+
+dec = Dec()
+
+@dec
+def f(name: str) -> int:
+    return 0
+
+@dec('abc')
+def g(name: str) -> int:
+    return 0
+
+reveal_type(f)  # N: Revealed type is 'def (name: builtins.str) -> builtins.int'
+reveal_type(g)  # N: Revealed type is 'def (name: builtins.str) -> builtins.int'
+
 [case testOverloadBadArgumentsInferredToAny1]
 from typing import Union, Any, overload
 


### PR DESCRIPTION
When `--disallow-untyped-decorators` is used, a callable-class decorator with a `overload`s on its `__call__` implementation would incorrectly issue an "Untyped decorator makes function untyped" error, even when the overloads are typed properly. This has been reported in pytest, which does this: https://github.com/pytest-dev/pytest/issues/7589.

This fixes the problem by expanding on a previous fix in this area, #5509.