### PR TITLE
Dynamically disallow instantiating traits/interpreted subclasses

### DIFF
--- a/mypyc/test-data/run-traits.test
+++ b/mypyc/test-data/run-traits.test
@@ -383,3 +383,29 @@ g(c1, c2)
 assert c1.x == 1
 assert c2.x == 2
 [out]
+
+[case testTraitErrorMessages]
+from mypy_extensions import trait
+
+@trait
+class Trait:
+    pass
+
+def create() -> Trait:
+    return Trait()
+
+[file driver.py]
+from native import Trait, create
+from testutil import assertRaises
+
+with assertRaises(TypeError, "traits may not be directly created"):
+    Trait()
+
+with assertRaises(TypeError, "traits may not be directly created"):
+    create()
+
+class Sub(Trait):
+    pass
+
+with assertRaises(TypeError, "interpreted classes cannot inherit from compiled traits"):
+    Sub()


### PR DESCRIPTION
This prevents a bunch of segfaults

Closes #9001. Closes #8360.  It doesn't close either of them in a
satisfactory way, though. Really they would like actual support, which
I've opened as mypyc/mypyc#754.

Related to mypyc/mypyc#655. (At some point there used to be working
dynamic checks for at least one of these cases. Not sure when that
broke.)