### PR TITLE
Fixes corner case for comparing nested overloads

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -399,6 +399,12 @@ class SubtypeVisitor(TypeVisitor[bool]):
                     return True
             return False
         elif isinstance(right, Overloaded):
+            if left == self.right:
+                # When it is the same overload, then the types are equal.
+                # This was originally introduced as a fix / hack for:
+                # https://github.com/python/mypy/issues/9147
+                return True
+
             # Ensure each overload in the right side (the supertype) is accounted for.
             previous_match_left_index = -1
             matched_overloads = set()

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -401,8 +401,6 @@ class SubtypeVisitor(TypeVisitor[bool]):
         elif isinstance(right, Overloaded):
             if left == self.right:
                 # When it is the same overload, then the types are equal.
-                # This was originally introduced as a fix / hack for:
-                # https://github.com/python/mypy/issues/9147
                 return True
 
             # Ensure each overload in the right side (the supertype) is accounted for.


### PR DESCRIPTION
We have this really nasty bug in `returns` with our `@curry` plugin:
- Closes https://github.com/python/mypy/issues/9147
- Closes https://github.com/python/mypy/issues/8978

So, this little fix solves the problem for us with very little effort.
In the ideal world, I would have to rewrite the whole thing to make the nested structures work.

Current problem is that we have a local state in `matched_overloads` and `possible_invalid_overloads` variables that is not syncronyzed with the nested calls.
I can also add a `TODO` note for later.

Refs https://github.com/dry-python/returns/issues/410