### PR TITLE
[mypyc] Introduce GetElementPtr

### DIFF
--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -9,7 +9,7 @@ from mypyc.ir.ops import (
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
     LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError, CallC, LoadGlobal,
-    Truncate, BinaryIntOp, LoadMem
+    Truncate, BinaryIntOp, LoadMem, GetElementPtr
 )
 
 
@@ -209,6 +209,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_load_mem(self, op: LoadMem) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_get_element_ptr(self, op: GetElementPtr) -> GenAndKill:
         return self.visit_register_op(op)
 
 

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -12,10 +12,10 @@ from mypyc.ir.ops import (
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
     BasicBlock, Value, MethodCall, PrimitiveOp, EmitterInterface, Unreachable, NAMESPACE_STATIC,
     NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CallC, LoadGlobal, Truncate,
-    BinaryIntOp, LoadMem
+    BinaryIntOp, LoadMem, GetElementPtr
 )
 from mypyc.ir.rtypes import (
-    RType, RTuple, is_tagged, is_int32_rprimitive, is_int64_rprimitive
+    RType, RTuple, is_tagged, is_int32_rprimitive, is_int64_rprimitive, RStruct
 )
 from mypyc.ir.func_ir import FuncIR, FuncDecl, FUNC_STATICMETHOD, FUNC_CLASSMETHOD
 from mypyc.ir.class_ir import ClassIR
@@ -470,6 +470,15 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         # TODO: we shouldn't dereference to type that are pointer type so far
         type = self.ctype(op.type)
         self.emit_line('%s = *(%s *)%s;' % (dest, type, src))
+
+    def visit_get_element_ptr(self, op: GetElementPtr) -> None:
+        dest = self.reg(op)
+        src = self.reg(op.src)
+        # TODO: support tuple type
+        assert isinstance(op.src_type, RStruct)
+        assert op.index < len(op.src_type.offsets), "Invalid element index."
+        offset = op.src_type.offsets[op.index]
+        self.emit_line('%s = (char *)%s + %s;' % (dest, src, offset))
 
     # Helpers
 

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -476,9 +476,8 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         src = self.reg(op.src)
         # TODO: support tuple type
         assert isinstance(op.src_type, RStruct)
-        assert op.index < len(op.src_type.offsets), "Invalid element index."
-        offset = op.src_type.offsets[op.index]
-        self.emit_line('%s = (char *)%s + %s;' % (dest, src, offset))
+        assert op.field in op.src_type.names, "Invalid field name."
+        self.emit_line('%s = &%s.%s;' % (dest, src, op.field))
 
     # Helpers
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -25,7 +25,8 @@ from mypy.nodes import SymbolNode
 from mypyc.ir.rtypes import (
     RType, RInstance, RTuple, RVoid, is_bool_rprimitive, is_int_rprimitive,
     is_short_int_rprimitive, is_none_rprimitive, object_rprimitive, bool_rprimitive,
-    short_int_rprimitive, int_rprimitive, void_rtype, is_c_py_ssize_t_rprimitive
+    short_int_rprimitive, int_rprimitive, void_rtype, is_c_py_ssize_t_rprimitive,
+    c_pyssize_t_rprimitive
 )
 from mypyc.common import short_name
 
@@ -1372,6 +1373,28 @@ class LoadMem(RegisterOp):
         return visitor.visit_load_mem(self)
 
 
+class GetElementPtr(RegisterOp):
+    """Get the address of a struct element"""
+    error_kind = ERR_NEVER
+
+    def __init__(self, src: Value, src_type: RType, index: int, line: int = -1) -> None:
+        super().__init__(line)
+        self.type = c_pyssize_t_rprimitive
+        self.src = src
+        self.src_type = src_type
+        self.index = index
+
+    def sources(self) -> List[Value]:
+        return [self.src]
+
+    def to_str(self, env: Environment) -> str:
+        return env.format("%r = get_element_ptr %r %r :: %r", self, self.src,
+                          self.index, self.src_type)
+
+    def accept(self, visitor: 'OpVisitor[T]') -> T:
+        return visitor.visit_get_element_ptr(self)
+
+
 @trait
 class OpVisitor(Generic[T]):
     """Generic visitor over ops (uses the visitor design pattern)."""
@@ -1480,6 +1503,10 @@ class OpVisitor(Generic[T]):
 
     @abstractmethod
     def visit_load_mem(self, op: LoadMem) -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visit_get_element_ptr(self, op: GetElementPtr) -> T:
         raise NotImplementedError
 
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1377,19 +1377,19 @@ class GetElementPtr(RegisterOp):
     """Get the address of a struct element"""
     error_kind = ERR_NEVER
 
-    def __init__(self, src: Value, src_type: RType, index: int, line: int = -1) -> None:
+    def __init__(self, src: Value, src_type: RType, field: str, line: int = -1) -> None:
         super().__init__(line)
         self.type = c_pyssize_t_rprimitive
         self.src = src
         self.src_type = src_type
-        self.index = index
+        self.field = field
 
     def sources(self) -> List[Value]:
         return [self.src]
 
     def to_str(self, env: Environment) -> str:
         return env.format("%r = get_element_ptr %r %r :: %r", self, self.src,
-                          self.index, self.src_type)
+                          self.field, self.src_type)
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_get_element_ptr(self)

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -283,14 +283,14 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                              """cpy_r_r0 = *(char *)cpy_r_i64;""")
 
     def test_get_element_ptr(self) -> None:
-        info = StructInfo("", [], [bool_rprimitive, int32_rprimitive, int64_rprimitive])
+        info = StructInfo("Foo", ["b", "i32", "i64"], [bool_rprimitive, int32_rprimitive, int64_rprimitive])
         r = RStruct(info)
-        self.assert_emit(GetElementPtr(self.o, r, 0),
-                        """cpy_r_r0 = (char *)cpy_r_o + 0;""")
-        self.assert_emit(GetElementPtr(self.o, r, 1),
-                        """cpy_r_r00 = (char *)cpy_r_o + 4;""")
-        self.assert_emit(GetElementPtr(self.o, r, 2),
-                        """cpy_r_r01 = (char *)cpy_r_o + 8;""")
+        self.assert_emit(GetElementPtr(self.o, r, "b"),
+                        """cpy_r_r0 = &cpy_r_o.b;""")
+        self.assert_emit(GetElementPtr(self.o, r, "i32"),
+                        """cpy_r_r00 = &cpy_r_o.i32;""")
+        self.assert_emit(GetElementPtr(self.o, r, "i64"),
+                        """cpy_r_r01 = &cpy_r_o.i64;""")
 
     def assert_emit(self, op: Op, expected: str) -> None:
         self.emitter.fragments = []

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -283,7 +283,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                              """cpy_r_r0 = *(char *)cpy_r_i64;""")
 
     def test_get_element_ptr(self) -> None:
-        info = StructInfo("Foo", ["b", "i32", "i64"], [bool_rprimitive, int32_rprimitive, int64_rprimitive])
+        info = StructInfo("Foo", ["b", "i32", "i64"], [bool_rprimitive,
+                                                       int32_rprimitive, int64_rprimitive])
         r = RStruct(info)
         self.assert_emit(GetElementPtr(self.o, r, "b"),
                         """cpy_r_r0 = &cpy_r_o.b;""")

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -292,7 +292,6 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(GetElementPtr(self.o, r, 2),
                         """cpy_r_r01 = (char *)cpy_r_o + 8;""")
 
-
     def assert_emit(self, op: Op, expected: str) -> None:
         self.emitter.fragments = []
         self.declarations.fragments = []

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -10,12 +10,12 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ir.ops import (
     Environment, BasicBlock, Goto, Return, LoadInt, Assign, IncRef, DecRef, Branch,
     Call, Unbox, Box, TupleGet, GetAttr, PrimitiveOp, RegisterOp,
-    SetAttr, Op, Value, CallC, BinaryIntOp, LoadMem
+    SetAttr, Op, Value, CallC, BinaryIntOp, LoadMem, GetElementPtr
 )
 from mypyc.ir.rtypes import (
     RTuple, RInstance, int_rprimitive, bool_rprimitive, list_rprimitive,
     dict_rprimitive, object_rprimitive, c_int_rprimitive, short_int_rprimitive, int32_rprimitive,
-    int64_rprimitive
+    int64_rprimitive, StructInfo, RStruct
 )
 from mypyc.ir.func_ir import FuncIR, FuncDecl, RuntimeArg, FuncSignature
 from mypyc.ir.class_ir import ClassIR
@@ -281,6 +281,17 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         else:
             self.assert_emit(LoadMem(bool_rprimitive, self.i64),
                              """cpy_r_r0 = *(char *)cpy_r_i64;""")
+
+    def test_get_element_ptr(self) -> None:
+        info = StructInfo("", [], [bool_rprimitive, int32_rprimitive, int64_rprimitive])
+        r = RStruct(info)
+        self.assert_emit(GetElementPtr(self.o, r, 0),
+                        """cpy_r_r0 = (char *)cpy_r_o + 0;""")
+        self.assert_emit(GetElementPtr(self.o, r, 1),
+                        """cpy_r_r00 = (char *)cpy_r_o + 4;""")
+        self.assert_emit(GetElementPtr(self.o, r, 2),
+                        """cpy_r_r01 = (char *)cpy_r_o + 8;""")
+
 
     def assert_emit(self, op: Op, expected: str) -> None:
         self.emitter.fragments = []


### PR DESCRIPTION
relates mypyc/mypyc#741

This PR introduces `GetElementPtr`, which computes the address of an element in an aggregate type.

Part of efforts to support the `len` and other macro-related primitives.