### PR TITLE
Use pytest Node.from_parent if available

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -10,18 +10,7 @@ from abc import abstractmethod
 import sys
 
 import pytest  # type: ignore  # no pytest in typeshed
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    NamedTuple,
-    Optional,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import List, Tuple, Set, Optional, Iterator, Any, Dict, NamedTuple, Union
 
 from mypy.test.config import test_data_prefix, test_temp_dir, PREFIX
 
@@ -521,10 +510,7 @@ def pytest_pycollect_makeitem(collector: Any, name: str,
             # Non-None result means this obj is a test case.
             # The collect method of the returned DataSuiteCollector instance will be called later,
             # with self.obj being obj.
-            if hasattr(DataSuiteCollector, 'from_parent'):
-                return DataSuiteCollector.from_parent(parent=collector, name=name)
-            else:
-                return DataSuiteCollector(name=name, parent=collector)
+            return DataSuiteCollector.from_parent(parent=collector, name=name)
     return None
 
 
@@ -549,11 +535,7 @@ def split_test_cases(parent: 'DataSuiteCollector', suite: 'DataSuite',
     for i in range(1, len(cases), 6):
         name, writescache, only_when, platform_flag, skip, data = cases[i:i + 6]
         platform = platform_flag[1:] if platform_flag else None
-        if hasattr(DataDrivenTestCase, 'from_parent'):
-            creator = DataDrivenTestCase.from_parent  # type: Callable[..., DataDrivenTestCase]
-        else:
-            creator = DataDrivenTestCase
-        yield creator(
+        yield DataDrivenTestCase.from_parent(
             parent=parent,
             suite=suite,
             file=file,

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -9,7 +9,7 @@ import shutil
 from abc import abstractmethod
 import sys
 
-import pytest  # type: ignore  # no pytest in typeshed
+import pytest
 from typing import List, Tuple, Set, Optional, Iterator, Any, Dict, NamedTuple, Union
 
 from mypy.test.config import test_data_prefix, test_temp_dir, PREFIX
@@ -160,8 +160,11 @@ def parse_test_case(case: 'DataDrivenTestCase') -> None:
     case.expected_fine_grained_targets = targets
 
 
-class DataDrivenTestCase(pytest.Item):  # type: ignore  # inheriting from Any
+class DataDrivenTestCase(pytest.Item):
     """Holds parsed data-driven test cases, and handles directory setup and teardown."""
+
+    # Override parent member type
+    parent = None  # type: DataSuiteCollector
 
     input = None  # type: List[str]
     output = None  # type: List[str]  # Output for the first pass
@@ -266,7 +269,7 @@ class DataDrivenTestCase(pytest.Item):  # type: ignore  # inheriting from Any
             # call exit() and they already print out a stack trace.
             excrepr = excinfo.exconly()
         else:
-            self.parent._prunetraceback(excinfo)
+            self.parent._prunetraceback(excinfo)  # type: ignore[no-untyped-call]
             excrepr = excinfo.getrepr(style='short')
 
         return "data: {}:{}:\n{}".format(self.file, self.line, excrepr)
@@ -510,7 +513,7 @@ def pytest_pycollect_makeitem(collector: Any, name: str,
             # Non-None result means this obj is a test case.
             # The collect method of the returned DataSuiteCollector instance will be called later,
             # with self.obj being obj.
-            return DataSuiteCollector.from_parent(parent=collector, name=name)
+            return DataSuiteCollector.from_parent(parent=collector, name=name)  # type: ignore[no-untyped-call]
     return None
 
 
@@ -550,8 +553,8 @@ def split_test_cases(parent: 'DataSuiteCollector', suite: 'DataSuite',
         line_no += data.count('\n') + 1
 
 
-class DataSuiteCollector(pytest.Class):  # type: ignore  # inheriting from Any
-    def collect(self) -> Iterator[pytest.Item]:  # type: ignore
+class DataSuiteCollector(pytest.Class):
+    def collect(self) -> Iterator[pytest.Item]:
         """Called by pytest on each of the object returned from pytest_pycollect_makeitem"""
 
         # obj is the object for which pytest_pycollect_makeitem returned self.

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -513,7 +513,9 @@ def pytest_pycollect_makeitem(collector: Any, name: str,
             # Non-None result means this obj is a test case.
             # The collect method of the returned DataSuiteCollector instance will be called later,
             # with self.obj being obj.
-            return DataSuiteCollector.from_parent(parent=collector, name=name)  # type: ignore[no-untyped-call]
+            return DataSuiteCollector.from_parent(  # type: ignore[no-untyped-call]
+                parent=collector, name=name
+            )
     return None
 
 

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -10,7 +10,7 @@ from typing import List, Iterable, Dict, Tuple, Callable, Any, Optional, Iterato
 from mypy import defaults
 import mypy.api as api
 
-import pytest  # type: ignore  # no pytest in typeshed
+import pytest
 
 # Exporting Suite as alias to TestCase for backwards compatibility
 # TODO: avoid aliasing - import and subclass TestCase directly

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -35,7 +35,7 @@ from mypy.dmypy_server import Server
 from mypy.config_parser import parse_config_file
 from mypy.find_sources import create_source_list
 
-import pytest  # type: ignore  # no pytest in typeshed
+import pytest
 
 # Set to True to perform (somewhat expensive) checks for duplicate AST nodes after merge
 CHECK_CONSISTENCY = False

--- a/mypy/test/testipc.py
+++ b/mypy/test/testipc.py
@@ -3,7 +3,7 @@ from multiprocessing import Process, Queue
 
 from mypy.ipc import IPCClient, IPCServer
 
-import pytest  # type: ignore
+import pytest
 import sys
 import time
 

--- a/mypy/test/testparse.py
+++ b/mypy/test/testparse.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from pytest import skip  # type: ignore[import]
+from pytest import skip
 
 from mypy import defaults
 from mypy.test.helpers import assert_string_arrays_equal, parse_options

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 import os
-import pytest  # type: ignore
+import pytest
 import re
 import subprocess
 from subprocess import PIPE

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -18,7 +18,7 @@ from subprocess import PIPE
 import sys
 from tempfile import TemporaryDirectory
 
-import pytest  # type: ignore  # no pytest in typeshed
+import pytest
 
 from typing import List
 

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -7,7 +7,7 @@ import re
 import shutil
 from typing import List, Callable, Iterator, Optional, Tuple
 
-import pytest  # type: ignore[import]
+import pytest
 
 from mypy import build
 from mypy.errors import CompileError

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 # testpaths is new in 2.8
-minversion = 2.8
+minversion = 5.4
 
 testpaths = mypy/test mypyc/test
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
-# testpaths is new in 2.8
-minversion = 5.4
+minversion = 6.0.0
 
 testpaths = mypy/test mypyc/test
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@ flake8-bugbear; python_version >= '3.5'
 flake8-pyi>=20.5; python_version >= '3.6'
 lxml>=4.4.0
 psutil>=4.0
-pytest>=6.0.1,<7.0.0
+pytest>=6.0.0,<7.0.0
 pytest-xdist>=1.34.0,<2.0.0
 pytest-forked>=1.3.0,<2.0.0
 pytest-cov>=2.10.0,<3.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,11 +5,10 @@ flake8-bugbear; python_version >= '3.5'
 flake8-pyi>=20.5; python_version >= '3.6'
 lxml>=4.4.0
 psutil>=4.0
-pytest==5.3.2
-pytest-xdist>=1.22
-# pytest-xdist depends on pytest-forked and 1.1.0 doesn't install clean on macOS 3.5
-pytest-forked>=1.0.0,<1.1.0
-pytest-cov>=2.4.0
+pytest>=6.0.1,<7.0.0
+pytest-xdist>=1.34.0,<2.0.0
+pytest-forked>=1.3.0,<2.0.0
+pytest-cov>=2.10.0,<3.0.0
 typing>=3.5.2; python_version < '3.5'
 py>=1.5.2
 virtualenv<20


### PR DESCRIPTION
The pytest Node construction API has changed to prefer a `Node.from_parent` factory over the raw constructor [1].  This PR updates a few points to conform to the recommended API to avoid the `PytestDeprecationWarning` that arises when tests are being collected with pytest 6+.

[1] https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent