### PR TITLE
check for deleted vars in 'raise from' (#9270)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3317,6 +3317,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     def type_check_raise(self, e: Expression, s: RaiseStmt,
                          optional: bool = False) -> None:
         typ = get_proper_type(self.expr_checker.accept(e))
+        if isinstance(typ, DeletedType):
+            self.msg.deleted_as_rvalue(typ, e)
+            return
         exc_type = self.named_type('builtins.BaseException')
         expected_type = UnionType([exc_type, TypeType(exc_type)])
         if optional:

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -446,9 +446,12 @@ raise x # E: Exception must be derived from BaseException
 e = None # type: BaseException
 f = None # type: MyError
 a = None # type: A
+x = None # type: BaseException
+del x
 raise e from a # E: Exception must be derived from BaseException
 raise e from e
 raise e from f
+raise e from x # E: Trying to read deleted variable 'x'
 class A: pass
 class MyError(BaseException): pass
 [builtins fixtures/exception.pyi]


### PR DESCRIPTION
Thanks to @isra17

This fixes an issue where the following code would raise no error:

```python

def test() -> None:
    try:
        raise Exception()
    except NotImplementedError as e:
        raise Exception("notimplemented") from e
    except Exception:
        raise Exception("test") from e

test()
```

``e`` does not exist on the second ``except`` block, so we cannot raise from it. It would result in a runtime error:
```
UnboundLocalError: local variable 'e' referenced before assignment
```

See #9270 for details.