### PR TITLE
[mypyc] Implement LoadAddress

### DIFF
--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -9,7 +9,7 @@ from mypyc.ir.ops import (
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
     LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError, CallC, LoadGlobal,
-    Truncate, BinaryIntOp, LoadMem, GetElementPtr
+    Truncate, BinaryIntOp, LoadMem, GetElementPtr, LoadAddress
 )
 
 
@@ -212,6 +212,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_load_address(self, op: LoadAddress) -> GenAndKill:
         return self.visit_register_op(op)
 
 

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -12,7 +12,7 @@ from mypyc.ir.ops import (
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
     BasicBlock, Value, MethodCall, PrimitiveOp, EmitterInterface, Unreachable, NAMESPACE_STATIC,
     NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CallC, LoadGlobal, Truncate,
-    BinaryIntOp, LoadMem, GetElementPtr
+    BinaryIntOp, LoadMem, GetElementPtr, LoadAddress
 )
 from mypyc.ir.rtypes import (
     RType, RTuple, is_tagged, is_int32_rprimitive, is_int64_rprimitive, RStruct
@@ -479,6 +479,11 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         assert op.field in op.src_type.names, "Invalid field name."
         self.emit_line('%s = (%s)&((%s *)%s)->%s;' % (dest, op.type._ctype, op.src_type.name,
                                                       src, op.field))
+
+    def visit_load_address(self, op: LoadAddress) -> None:
+        typ = op.type
+        dest = self.reg(op)
+        self.emit_line('%s = (%s)&%s;' % (dest, typ._ctype, op.src))
 
     # Helpers
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1394,6 +1394,25 @@ class GetElementPtr(RegisterOp):
         return visitor.visit_get_element_ptr(self)
 
 
+class LoadAddress(RegisterOp):
+    error_kind = ERR_NEVER
+    is_borrowed = True
+
+    def __init__(self, type: RType, src: str, line: int = -1) -> None:
+        super().__init__(line)
+        self.type = type
+        self.src = src
+
+    def sources(self) -> List[Value]:
+        return []
+
+    def to_str(self, env: Environment) -> str:
+        return env.format("%r = load_address %s", self, self.src)
+
+    def accept(self, visitor: 'OpVisitor[T]') -> T:
+        return visitor.visit_load_address(self)
+
+
 @trait
 class OpVisitor(Generic[T]):
     """Generic visitor over ops (uses the visitor design pattern)."""
@@ -1506,6 +1525,10 @@ class OpVisitor(Generic[T]):
 
     @abstractmethod
     def visit_get_element_ptr(self, op: GetElementPtr) -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visit_load_address(self, op: LoadAddress) -> T:
         raise NotImplementedError
 
 

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -33,12 +33,12 @@ from mypyc.irbuild.builder import IRBuilder
 from mypyc.irbuild.for_helpers import translate_list_comprehension, comprehension_helper
 
 
-# Name and attribute references
 builtin_names = {
     'builtins.dict': (object_rprimitive, 'PyDict_Type')
 }  # type: Dict[str, Tuple[RType, str]]
 
 
+# Name and attribute references
 def transform_name_expr(builder: IRBuilder, expr: NameExpr) -> Value:
     assert expr.node, "RefExpr not resolved"
     fullname = expr.node.fullname

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -4,7 +4,7 @@ The top-level AST transformation logic is implemented in mypyc.irbuild.visitor
 and mypyc.irbuild.builder.
 """
 
-from typing import List, Optional, Union, Dict, Tuple
+from typing import List, Optional, Union
 
 from mypy.nodes import (
     Expression, NameExpr, MemberExpr, SuperExpr, CallExpr, UnaryExpr, OpExpr, IndexExpr,
@@ -18,7 +18,7 @@ from mypy.types import TupleType, get_proper_type
 from mypyc.ir.ops import (
     Value, TupleGet, TupleSet, PrimitiveOp, BasicBlock, OpDescription, Assign, LoadAddress
 )
-from mypyc.ir.rtypes import RType, RTuple, object_rprimitive, is_none_rprimitive, is_int_rprimitive
+from mypyc.ir.rtypes import RTuple, object_rprimitive, is_none_rprimitive, is_int_rprimitive
 from mypyc.ir.func_ir import FUNC_CLASSMETHOD, FUNC_STATICMETHOD
 from mypyc.primitives.registry import name_ref_ops, CFunctionDescription, builtin_names
 from mypyc.primitives.generic_ops import iter_op

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -39,6 +39,7 @@ builtin_names = {
 
 
 # Name and attribute references
+
 def transform_name_expr(builder: IRBuilder, expr: NameExpr) -> Value:
     assert expr.node, "RefExpr not resolved"
     fullname = expr.node.fullname

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -20,7 +20,7 @@ from mypyc.ir.ops import (
 )
 from mypyc.ir.rtypes import RType, RTuple, object_rprimitive, is_none_rprimitive, is_int_rprimitive
 from mypyc.ir.func_ir import FUNC_CLASSMETHOD, FUNC_STATICMETHOD
-from mypyc.primitives.registry import name_ref_ops, CFunctionDescription
+from mypyc.primitives.registry import name_ref_ops, CFunctionDescription, builtin_names
 from mypyc.primitives.generic_ops import iter_op
 from mypyc.primitives.misc_ops import new_slice_op, ellipsis_op, type_op
 from mypyc.primitives.list_ops import new_list_op, list_append_op, list_extend_op
@@ -33,12 +33,8 @@ from mypyc.irbuild.builder import IRBuilder
 from mypyc.irbuild.for_helpers import translate_list_comprehension, comprehension_helper
 
 
-builtin_names = {
-    'builtins.dict': (object_rprimitive, 'PyDict_Type')
-}  # type: Dict[str, Tuple[RType, str]]
-
-
 # Name and attribute references
+
 
 def transform_name_expr(builder: IRBuilder, expr: NameExpr) -> Value:
     assert expr.node, "RefExpr not resolved"

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -8,8 +8,14 @@ from mypyc.ir.rtypes import (
 )
 
 from mypyc.primitives.registry import (
-    method_op, simple_emit, c_custom_op, c_method_op, c_function_op, c_binary_op
+    method_op, simple_emit, c_custom_op, c_method_op, c_function_op, c_binary_op, load_address_op
 )
+
+# Get the 'dict' type object.
+load_address_op(
+    name='builtins.dict',
+    type=object_rprimitive,
+    src='PyDict_Type')
 
 # dict[key]
 dict_get_item_op = c_method_op(

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -8,17 +8,8 @@ from mypyc.ir.rtypes import (
 )
 
 from mypyc.primitives.registry import (
-    name_ref_op, method_op,
-    simple_emit, name_emit, c_custom_op, c_method_op, c_function_op, c_binary_op
+    method_op, simple_emit, c_custom_op, c_method_op, c_function_op, c_binary_op
 )
-
-
-# Get the 'dict' type object.
-name_ref_op('builtins.dict',
-            result_type=object_rprimitive,
-            error_kind=ERR_NEVER,
-            emit=name_emit('&PyDict_Type', target_type="PyObject *"),
-            is_borrowed=True)
 
 # dict[key]
 dict_get_item_op = c_method_op(

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -95,6 +95,7 @@ c_name_ref_ops = {}  # type: Dict[str, CLoadDescription]
 
 builtin_names = {}  # type: Dict[str, Tuple[RType, str]]
 
+
 def simple_emit(template: str) -> EmitCallback:
     """Construct a simple PrimitiveOp emit callback function.
 

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -93,6 +93,7 @@ c_unary_ops = {}  # type: Dict[str, List[CFunctionDescription]]
 # LoadGlobal/LoadAddress op for reading global names
 c_name_ref_ops = {}  # type: Dict[str, CLoadDescription]
 
+builtin_names = {}  # type: Dict[str, Tuple[RType, str]]
 
 def simple_emit(template: str) -> EmitCallback:
     """Construct a simple PrimitiveOp emit callback function.
@@ -497,6 +498,14 @@ def c_name_ref_op(name: str,
     desc = CLoadDescription(name, return_type, identifier, cast_str, load_address)
     c_name_ref_ops[name] = desc
     return desc
+
+
+def load_address_op(name: str,
+                    type: RType,
+                    src: str) -> None:
+    assert name not in builtin_names, 'already defined: %s' % name
+    builtin_names[name] = (type, src)
+
 
 # Import various modules that set up global state.
 import mypyc.primitives.int_ops  # noqa

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -306,3 +306,15 @@ L12:
     r34 = None
     return r34
 
+[case testDictLoadAddress]
+def f() -> None:
+    x = dict
+[out]
+def f():
+    r0, x :: object
+    r1 :: None
+L0:
+    r0 = load_address PyDict_Type
+    x = r0
+    r1 = None
+    return r1

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -10,7 +10,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ir.ops import (
     Environment, BasicBlock, Goto, Return, LoadInt, Assign, IncRef, DecRef, Branch,
     Call, Unbox, Box, TupleGet, GetAttr, PrimitiveOp, RegisterOp,
-    SetAttr, Op, Value, CallC, BinaryIntOp, LoadMem, GetElementPtr
+    SetAttr, Op, Value, CallC, BinaryIntOp, LoadMem, GetElementPtr, LoadAddress
 )
 from mypyc.ir.rtypes import (
     RTuple, RInstance, int_rprimitive, bool_rprimitive, list_rprimitive,
@@ -280,6 +280,10 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                         """cpy_r_r00 = (CPyPtr)&((Foo *)cpy_r_o)->i32;""")
         self.assert_emit(GetElementPtr(self.o, r, "i64"),
                         """cpy_r_r01 = (CPyPtr)&((Foo *)cpy_r_o)->i64;""")
+
+    def test_load_address(self) -> None:
+        self.assert_emit(LoadAddress(object_rprimitive, "PyDict_Type"),
+                         """cpy_r_r0 = (PyObject *)&PyDict_Type;""")
 
     def assert_emit(self, op: Op, expected: str) -> None:
         self.emitter.fragments = []


### PR DESCRIPTION
This PR introduces `LoadAddress`, an op for taking the address of a given name. 

Currently, in mypyc we only need to take the address of a name when we are using the name_ref_ops, so the op takes a string(CPython name) as its argument. We can revisit the design later if we want to take the address of arbitrary name later.