### PR TITLE
[mypyc] Don't free target of LoadMem too early

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -825,7 +825,7 @@ class LowLevelIRBuilder:
         typ = val.type
         if is_list_rprimitive(typ) or is_tuple_rprimitive(typ):
             elem_address = self.add(GetElementPtr(val, PyVarObject, 'ob_size'))
-            size_value = self.add(LoadMem(c_pyssize_t_rprimitive, elem_address))
+            size_value = self.add(LoadMem(c_pyssize_t_rprimitive, elem_address, val))
             offset = self.add(LoadInt(1, line, rtype=c_pyssize_t_rprimitive))
             return self.binary_int_op(short_int_rprimitive, size_value, offset,
                                       BinaryIntOp.LEFT_SHIFT, line)
@@ -836,7 +836,7 @@ class LowLevelIRBuilder:
                                       BinaryIntOp.LEFT_SHIFT, line)
         elif is_set_rprimitive(typ):
             elem_address = self.add(GetElementPtr(val, PySetObject, 'used'))
-            size_value = self.add(LoadMem(c_pyssize_t_rprimitive, elem_address))
+            size_value = self.add(LoadMem(c_pyssize_t_rprimitive, elem_address, val))
             offset = self.add(LoadInt(1, line, rtype=c_pyssize_t_rprimitive))
             return self.binary_int_op(short_int_rprimitive, size_value, offset,
                                       BinaryIntOp.LEFT_SHIFT, line)

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -1368,7 +1368,7 @@ def lst(x):
     r3 :: bool
 L0:
     r0 = get_element_ptr x ob_size :: PyVarObject
-    r1 = load_mem r0 :: native_int*
+    r1 = load_mem r0, x :: native_int*
     r2 = r1 << 1
     r3 = r2 != 0
     if r3 goto L1 else goto L2 :: bool
@@ -1979,7 +1979,7 @@ L0:
     r5 = 0
 L1:
     r6 = get_element_ptr r4 ob_size :: PyVarObject
-    r7 = load_mem r6 :: native_int*
+    r7 = load_mem r6, r4 :: native_int*
     r8 = r7 << 1
     r9 = r5 < r8 :: signed
     if r9 goto L2 else goto L14 :: bool
@@ -2064,7 +2064,7 @@ L0:
     r5 = 0
 L1:
     r6 = get_element_ptr r4 ob_size :: PyVarObject
-    r7 = load_mem r6 :: native_int*
+    r7 = load_mem r6, r4 :: native_int*
     r8 = r7 << 1
     r9 = r5 < r8 :: signed
     if r9 goto L2 else goto L14 :: bool
@@ -2151,7 +2151,7 @@ L0:
     r0 = 0
 L1:
     r1 = get_element_ptr l ob_size :: PyVarObject
-    r2 = load_mem r1 :: native_int*
+    r2 = load_mem r1, l :: native_int*
     r3 = r2 << 1
     r4 = r0 < r3 :: signed
     if r4 goto L2 else goto L4 :: bool
@@ -2173,7 +2173,7 @@ L4:
     r12 = 0
 L5:
     r13 = get_element_ptr l ob_size :: PyVarObject
-    r14 = load_mem r13 :: native_int*
+    r14 = load_mem r13, l :: native_int*
     r15 = r14 << 1
     r16 = r12 < r15 :: signed
     if r16 goto L6 else goto L8 :: bool

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -117,7 +117,7 @@ def f(a):
     r2 :: short_int
 L0:
     r0 = get_element_ptr a ob_size :: PyVarObject
-    r1 = load_mem r0 :: native_int*
+    r1 = load_mem r0, a :: native_int*
     r2 = r1 << 1
     return r2
 
@@ -156,7 +156,7 @@ def increment(l):
     r9 :: short_int
 L0:
     r0 = get_element_ptr l ob_size :: PyVarObject
-    r1 = load_mem r0 :: native_int*
+    r1 = load_mem r0, l :: native_int*
     r2 = r1 << 1
     r3 = 0
     i = r3
@@ -196,4 +196,3 @@ L0:
     r5 = box(short_int, 6)
     r6 = PyList_Append(r2, r5)
     return r2
-

--- a/mypyc/test-data/irbuild-set.test
+++ b/mypyc/test-data/irbuild-set.test
@@ -69,7 +69,7 @@ L0:
     r5 = box(short_int, 6)
     r6 = PySet_Add(r0, r5)
     r7 = get_element_ptr r0 used :: PySetObject
-    r8 = load_mem r7 :: native_int*
+    r8 = load_mem r7, r0 :: native_int*
     r9 = r8 << 1
     return r9
 
@@ -223,4 +223,3 @@ L0:
     r7 = box(short_int, 6)
     r8 = PySet_Add(r0, r7)
     return r0
-

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -323,7 +323,7 @@ L0:
     r0 = 0
 L1:
     r1 = get_element_ptr ls ob_size :: PyVarObject
-    r2 = load_mem r1 :: native_int*
+    r2 = load_mem r1, ls :: native_int*
     r3 = r2 << 1
     r4 = r0 < r3 :: signed
     if r4 goto L2 else goto L4 :: bool
@@ -848,7 +848,7 @@ L0:
     r1 = 0
 L1:
     r2 = get_element_ptr a ob_size :: PyVarObject
-    r3 = load_mem r2 :: native_int*
+    r3 = load_mem r2, a :: native_int*
     r4 = r3 << 1
     r5 = r1 < r4 :: signed
     if r5 goto L2 else goto L4 :: bool
@@ -926,7 +926,7 @@ L0:
     r1 = PyObject_GetIter(b)
 L1:
     r2 = get_element_ptr a ob_size :: PyVarObject
-    r3 = load_mem r2 :: native_int*
+    r3 = load_mem r2, a :: native_int*
     r4 = r3 << 1
     r5 = r0 < r4 :: signed
     if r5 goto L2 else goto L7 :: bool
@@ -977,7 +977,7 @@ L1:
     if is_error(r3) goto L6 else goto L2
 L2:
     r4 = get_element_ptr b ob_size :: PyVarObject
-    r5 = load_mem r4 :: native_int*
+    r5 = load_mem r4, b :: native_int*
     r6 = r5 << 1
     r7 = r1 < r6 :: signed
     if r7 goto L3 else goto L6 :: bool
@@ -1002,4 +1002,3 @@ L6:
     r14 = CPy_NoErrOccured()
 L7:
     return 1
-

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -67,7 +67,7 @@ def f(x):
     r2 :: short_int
 L0:
     r0 = get_element_ptr x ob_size :: PyVarObject
-    r1 = load_mem r0 :: native_int*
+    r1 = load_mem r0, x :: native_int*
     r2 = r1 << 1
     return r2
 
@@ -134,7 +134,7 @@ L0:
     r0 = 0
 L1:
     r1 = get_element_ptr xs ob_size :: PyVarObject
-    r2 = load_mem r1 :: native_int*
+    r2 = load_mem r1, xs :: native_int*
     r3 = r2 << 1
     r4 = r0 < r3 :: signed
     if r4 goto L2 else goto L4 :: bool
@@ -176,4 +176,3 @@ L2:
     r2 = CPySequenceTuple_GetItem(nt, 2)
     r3 = unbox(int, r2)
     return r3
-

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -831,3 +831,23 @@ L2:
 L3:
     return 1
 
+[case testGetElementPtrLifeTime]
+from typing import List
+
+def f() -> int:
+    x: List[str] = []
+    return len(x)
+[out]
+def f():
+    r0, x :: list
+    r1 :: ptr
+    r2 :: native_int
+    r3 :: short_int
+L0:
+    r0 = []
+    x = r0
+    r1 = get_element_ptr x ob_size :: PyVarObject
+    r2 = load_mem r1, x :: int64*
+    dec_ref x
+    r3 = r2 << 1
+    return r3

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -847,7 +847,7 @@ L0:
     r0 = []
     x = r0
     r1 = get_element_ptr x ob_size :: PyVarObject
-    r2 = load_mem r1, x :: int64*
+    r2 = load_mem r1, x :: native_int*
     dec_ref x
     r3 = r2 << 1
     return r3

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -262,8 +262,10 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_r04 = (uint64_t)cpy_r_i64 < (uint64_t)cpy_r_i64_1;""")
 
     def test_load_mem(self) -> None:
-        self.assert_emit(LoadMem(bool_rprimitive, self.ptr),
+        self.assert_emit(LoadMem(bool_rprimitive, self.ptr, None),
                          """cpy_r_r0 = *(char *)cpy_r_ptr;""")
+        self.assert_emit(LoadMem(bool_rprimitive, self.ptr, self.s1),
+                         """cpy_r_r00 = *(char *)cpy_r_ptr;""")
 
     def test_get_element_ptr(self) -> None:
         r = RStruct("Foo", ["b", "i32", "i64"], [bool_rprimitive,


### PR DESCRIPTION
Add optional reference to the object from which we are reading from
to `LoadMem` so that the object won't be freed before we read memory.

Fixes mypyc/mypyc#756.