### PR TITLE
[mypyc] Fix to_lines to show same type registers on the same line

### DIFF
--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -243,18 +243,13 @@ class Environment:
         regs = list(self.regs())
         if const_regs is None:
             const_regs = {}
+        regs = [reg for reg in regs if reg.name not in const_regs]
         while i < len(regs):
             i0 = i
-            if regs[i0].name not in const_regs:
-                group = [regs[i0].name]
-            else:
-                group = []
-                i += 1
-                continue
+            group = [regs[i0].name]
             while i + 1 < len(regs) and regs[i + 1].type == regs[i0].type:
                 i += 1
-                if regs[i].name not in const_regs:
-                    group.append(regs[i].name)
+                group.append(regs[i].name)
             i += 1
             result.append('%s :: %s' % (', '.join(group), regs[i0].type))
         return result

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -9,13 +9,11 @@ def f(a: int) -> None:
         z = 1
 [out]
 def f(a):
-    a :: int
-    x :: int
+    a, x :: int
     r0 :: bool
     r1 :: native_int
     r2, r3, r4 :: bool
-    y :: int
-    z :: int
+    y, z :: int
 L0:
     x = 2
     r1 = x & 1
@@ -69,8 +67,7 @@ def f(a: int) -> int:
         return x
 [out]
 def f(a):
-    a :: int
-    x :: int
+    a, x :: int
     r0 :: bool
     r1 :: native_int
     r2, r3, r4 :: bool
@@ -121,8 +118,7 @@ def f() -> int:
     return x
 [out]
 def f():
-    x :: int
-    y :: int
+    x, y :: int
 L0:
     x = 2
     y = 2
@@ -171,8 +167,7 @@ def f(a):
     r0 :: bool
     r1 :: native_int
     r2, r3, r4 :: bool
-    y :: int
-    x :: int
+    y, x :: int
 L0:
     r1 = a & 1
     r2 = r1 == 0
@@ -304,15 +299,12 @@ def f(n: int) -> None:
             n = x
 [out]
 def f(n):
-    n :: int
-    x :: int
-    y :: int
+    n, x, y :: int
     r0 :: bool
     r1 :: native_int
     r2 :: bool
     r3 :: native_int
-    r4, r5, r6, r7 :: bool
-    r8 :: bool
+    r4, r5, r6, r7, r8 :: bool
     r9 :: native_int
     r10 :: bool
     r11 :: native_int
@@ -419,8 +411,7 @@ def f(x: int) -> int:
     return f(a) + a
 [out]
 def f(x):
-    x :: int
-    r0, a, r1, r2, r3 :: int
+    x, r0, a, r1, r2, r3 :: int
 L0:
     r0 = f(2)
     if is_error(r0) goto L3 (error at f:2) else goto L1
@@ -644,16 +635,13 @@ def f(a: int) -> int:
     return sum
 [out]
 def f(a):
-    a :: int
-    sum :: int
-    i :: int
+    a, sum, i :: int
     r0 :: bool
     r1 :: native_int
     r2 :: bool
     r3 :: native_int
     r4, r5, r6, r7, r8 :: bool
-    r9 :: int
-    r10 :: int
+    r9, r10 :: int
 L0:
     sum = 0
     i = 0

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -111,17 +111,14 @@ def sum(a: List[int], l: int) -> int:
 [out]
 def sum(a, l):
     a :: list
-    l :: int
-    sum :: int
-    i :: int
+    l, sum, i :: int
     r0 :: bool
     r1 :: native_int
     r2 :: bool
     r3 :: native_int
     r4, r5, r6, r7 :: bool
     r8 :: object
-    r9, r10 :: int
-    r11, r12 :: int
+    r9, r10, r11, r12 :: int
 L0:
     sum = 0
     i = 0

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -539,8 +539,7 @@ def f(n):
     r2 :: bool
     r3 :: native_int
     r4, r5, r6, r7, r8 :: bool
-    r9, r10 :: int
-    r11, r12, r13 :: int
+    r9, r10, r11, r12, r13 :: int
 L0:
     r1 = n & 1
     r2 = r1 == 0

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -51,8 +51,7 @@ def f(x: int) -> None:
     return
 [out]
 def f(x):
-    x :: int
-    y :: int
+    x, y :: int
 L0:
     y = 2
     y = x
@@ -63,8 +62,7 @@ def f(x: int, y: int) -> int:
     return x * (y + 1)
 [out]
 def f(x, y):
-    x, y :: int
-    r0, r1 :: int
+    x, y, r0, r1 :: int
 L0:
     r0 = CPyTagged_Add(y, 2)
     r1 = CPyTagged_Multiply(x, r0)
@@ -651,8 +649,7 @@ def f(n: int) -> int:
     return -1
 [out]
 def f(n):
-    n :: int
-    r0 :: int
+    n, r0 :: int
 L0:
     r0 = CPyTagged_Negate(2)
     return r0
@@ -695,8 +692,7 @@ def f() -> int:
     return x
 [out]
 def f():
-    x :: int
-    r0 :: int
+    x, r0 :: int
 L0:
     x = 0
     r0 = CPyTagged_Add(x, 2)
@@ -796,8 +792,7 @@ def f(x):
     x :: int
     r0 :: object
     r1 :: str
-    r2 :: object
-    r3, r4 :: object
+    r2, r3, r4 :: object
 L0:
     r0 = builtins :: module
     r1 = unicode_1 :: static  ('print')
@@ -906,14 +901,12 @@ def g(y: object) -> object:
     return 3
 [out]
 def g(y):
-    y :: object
-    r0, r1 :: object
+    y, r0, r1 :: object
     r2, a :: list
     r3 :: tuple[int, int]
     r4 :: object
     r5 :: bool
-    r6 :: object
-    r7 :: object
+    r6, r7 :: object
 L0:
     r0 = box(short_int, 2)
     r1 = g(r0)
@@ -937,8 +930,7 @@ def f(a: A, o: object) -> None:
 [out]
 def f(a, o):
     a :: __main__.A
-    o :: object
-    r0 :: object
+    o, r0 :: object
     r1 :: bool
     r2 :: int
     r3 :: object
@@ -1122,8 +1114,7 @@ def big_int() -> None:
     max_31_bit = 1073741823
 [out]
 def big_int():
-    r0, a_62_bit, r1, max_62_bit, r2, b_63_bit, r3, c_63_bit, r4, max_63_bit, r5, d_64_bit, r6, max_32_bit :: int
-    max_31_bit :: int
+    r0, a_62_bit, r1, max_62_bit, r2, b_63_bit, r3, c_63_bit, r4, max_63_bit, r5, d_64_bit, r6, max_32_bit, max_31_bit :: int
 L0:
     r0 = int_1 :: static  (4611686018427387902)
     a_62_bit = r0
@@ -1580,8 +1571,7 @@ def f(x: str) -> int: ...
 def f():
     r0 :: object
     r1 :: str
-    r2 :: object
-    r3, r4 :: object
+    r2, r3, r4 :: object
     r5 :: str
 L0:
     r0 = m :: module
@@ -1805,9 +1795,7 @@ L0:
     r0 = (a, b, c)
     return r0
 def g():
-    r0 :: str
-    r1 :: str
-    r2 :: str
+    r0, r1, r2 :: str
     r3, r4, r5 :: object
     r6, r7 :: dict
     r8 :: str
@@ -1835,13 +1823,11 @@ L0:
     r14 = unbox(tuple[int, int, int], r13)
     return r14
 def h():
-    r0 :: str
-    r1 :: str
+    r0, r1 :: str
     r2, r3 :: object
     r4, r5 :: dict
     r6 :: str
-    r7 :: object
-    r8 :: object
+    r7, r8 :: object
     r9 :: tuple
     r10 :: dict
     r11 :: int32
@@ -1874,8 +1860,7 @@ def g() -> None:
 [out]
 def f(x, y, z):
     x, y :: int
-    z :: str
-    r0 :: str
+    z, r0 :: str
 L0:
     if is_error(y) goto L1 else goto L2
 L1:
@@ -1914,8 +1899,7 @@ def g() -> None:
 def A.f(self, x, y, z):
     self :: __main__.A
     x, y :: int
-    z :: str
-    r0 :: str
+    z, r0 :: str
 L0:
     if is_error(y) goto L1 else goto L2
 L1:
@@ -1963,8 +1947,7 @@ def f():
     x, r11 :: int
     r12 :: bool
     r13 :: native_int
-    r14, r15, r16, r17 :: bool
-    r18 :: bool
+    r14, r15, r16, r17, r18 :: bool
     r19 :: native_int
     r20, r21, r22, r23 :: bool
     r24 :: int
@@ -2048,8 +2031,7 @@ def f():
     x, r11 :: int
     r12 :: bool
     r13 :: native_int
-    r14, r15, r16, r17 :: bool
-    r18 :: bool
+    r14, r15, r16, r17, r18 :: bool
     r19 :: native_int
     r20, r21, r22, r23 :: bool
     r24 :: int
@@ -2310,8 +2292,7 @@ L0:
     return r1
 def BaseProperty.next(self):
     self :: __main__.BaseProperty
-    r0 :: int
-    r1 :: int
+    r0, r1 :: int
     r2 :: __main__.BaseProperty
 L0:
     r0 = self._incrementer
@@ -3354,8 +3335,7 @@ def f(a: bool) -> int:
 [out]
 def C.__mypyc_defaults_setup(__mypyc_self__):
     __mypyc_self__ :: __main__.C
-    r0 :: bool
-    r1 :: bool
+    r0, r1 :: bool
 L0:
     __mypyc_self__.x = 2; r0 = is_error
     __mypyc_self__.y = 4; r1 = is_error

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -43,8 +43,7 @@ def f():
     r2, a :: list
     r3 :: object
     r4, d :: __main__.C
-    r5 :: int
-    r6 :: int
+    r5, r6 :: int
 L0:
     r0 = C()
     c = r0
@@ -147,8 +146,7 @@ L0:
     return 1
 def B.__init__(self):
     self :: __main__.B
-    r0 :: bool
-    r1 :: bool
+    r0, r1 :: bool
 L0:
     self.x = 40; r0 = is_error
     self.y = 60; r1 = is_error
@@ -171,8 +169,7 @@ L0:
     return 1
 def increment(o):
     o :: __main__.O
-    r0 :: int
-    r1 :: int
+    r0, r1 :: int
     r2 :: bool
 L0:
     r0 = o.x
@@ -656,15 +653,13 @@ def lol() -> int:
     return C.foo(1) + C.bar(2)
 [out]
 def C.foo(x):
-    x :: int
-    r0 :: int
+    x, r0 :: int
 L0:
     r0 = CPyTagged_Add(20, x)
     return r0
 def C.bar(cls, x):
     cls :: object
-    x :: int
-    r0 :: int
+    x, r0 :: int
 L0:
     r0 = CPyTagged_Add(20, x)
     return r0
@@ -793,8 +788,7 @@ def fOpt2(a: Derived, b: Derived) -> bool:
 [out]
 def Base.__eq__(self, other):
     self :: __main__.Base
-    other :: object
-    r0 :: object
+    other, r0 :: object
 L0:
     r0 = box(bool, 0)
     return r0
@@ -816,8 +810,7 @@ L2:
     return r1
 def Derived.__eq__(self, other):
     self :: __main__.Derived
-    other :: object
-    r0 :: object
+    other, r0 :: object
 L0:
     r0 = box(bool, 1)
     return r0
@@ -910,8 +903,7 @@ L0:
     return r2
 def Derived.__eq__(self, other):
     self :: __main__.Derived
-    other :: object
-    r0 :: object
+    other, r0 :: object
 L0:
     r0 = box(bool, 1)
     return r0

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -138,8 +138,7 @@ def increment(d):
     r6 :: bool
     r7 :: object
     k, r8 :: str
-    r9 :: object
-    r10, r11 :: object
+    r9, r10, r11 :: object
     r12 :: int32
     r13, r14 :: bool
 L0:
@@ -214,8 +213,7 @@ def print_dict_methods(d1, d2):
     v, r8 :: int
     r9 :: object
     r10 :: int32
-    r11 :: bool
-    r12, r13 :: bool
+    r11, r12, r13 :: bool
     r14 :: short_int
     r15 :: native_int
     r16 :: short_int

--- a/mypyc/test-data/irbuild-generics.test
+++ b/mypyc/test-data/irbuild-generics.test
@@ -101,8 +101,7 @@ L0:
 def f(x):
     x :: __main__.C
     r0 :: object
-    r1, y :: int
-    r2 :: int
+    r1, y, r2 :: int
     r3 :: object
     r4 :: None
     r5 :: object

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -92,8 +92,7 @@ def f(a: List[int]) -> None:
     b = 3 * [4]
 [out]
 def f(a):
-    a :: list
-    r0, b :: list
+    a, r0, b :: list
     r1 :: object
     r2, r3 :: list
 L0:
@@ -150,8 +149,7 @@ def increment(l):
     r2, r3 :: short_int
     i :: int
     r4 :: bool
-    r5 :: object
-    r6, r7 :: object
+    r5, r6, r7 :: object
     r8 :: bool
     r9 :: short_int
 L0:

--- a/mypyc/test-data/irbuild-nested.test
+++ b/mypyc/test-data/irbuild-nested.test
@@ -50,8 +50,7 @@ L2:
 def inner_a_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: __main__.inner_a_obj
     r0 :: __main__.a_env
-    r1, inner :: object
-    r2 :: object
+    r1, inner, r2 :: object
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
@@ -494,8 +493,7 @@ def b_a_obj.__call__(__mypyc_self__):
     r1, b :: object
     r2 :: __main__.b_a_env
     r3 :: bool
-    r4 :: int
-    r5 :: int
+    r4, r5 :: int
     r6 :: bool
     r7 :: __main__.c_a_b_obj
     r8, r9 :: bool
@@ -655,8 +653,7 @@ def foo_f_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: __main__.foo_f_obj
     r0 :: __main__.f_env
     r1, foo :: object
-    r2 :: int
-    r3 :: int
+    r2, r3 :: int
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.foo

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -216,8 +216,7 @@ def f(y):
     r1 :: bool
     r2 :: native_int
     r3, r4, r5 :: bool
-    r6 :: object
-    r7 :: object
+    r6, r7 :: object
     r8, r9 :: bool
     r10 :: int
 L0:
@@ -266,8 +265,7 @@ def f(x):
     r0 :: object
     r1 :: int32
     r2 :: bool
-    r3 :: int
-    r4 :: int
+    r3, r4 :: int
     r5 :: __main__.A
     r6 :: int
 L0:

--- a/mypyc/test-data/irbuild-set.test
+++ b/mypyc/test-data/irbuild-set.test
@@ -204,8 +204,7 @@ def f(x: Set[int], y: Set[int]) -> Set[int]:
     return {1, 2, *x, *y, 3}
 [out]
 def f(x, y):
-    x, y :: set
-    r0 :: set
+    x, y, r0 :: set
     r1 :: object
     r2 :: int32
     r3 :: object

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -129,8 +129,7 @@ def f():
     r1 :: native_int
     r2 :: bool
     r3 :: native_int
-    r4, r5, r6, r7 :: bool
-    r8 :: bool
+    r4, r5, r6, r7, r8 :: bool
     r9 :: native_int
     r10 :: bool
     r11 :: native_int
@@ -250,8 +249,7 @@ def f():
     r1 :: native_int
     r2 :: bool
     r3 :: native_int
-    r4, r5, r6, r7 :: bool
-    r8 :: bool
+    r4, r5, r6, r7, r8 :: bool
     r9 :: native_int
     r10 :: bool
     r11 :: native_int
@@ -411,8 +409,7 @@ def sum_over_even_values(d):
     r7 :: object
     key, r8 :: int
     r9, r10 :: object
-    r11 :: int
-    r12 :: int
+    r11, r12 :: int
     r13 :: bool
     r14 :: native_int
     r15, r16, r17, r18 :: bool
@@ -595,8 +592,7 @@ def multi_assign(t, a, l):
     t :: tuple[int, tuple[str, object]]
     a :: __main__.A
     l :: list
-    z :: int
-    r0 :: int
+    z, r0 :: int
     r1 :: bool
     r2 :: tuple[str, object]
     r3 :: str
@@ -733,8 +729,7 @@ def delDictMultiple() -> None:
     del d["one"], d["four"]
 [out]
 def delDict():
-    r0 :: str
-    r1 :: str
+    r0, r1 :: str
     r2, r3 :: object
     r4, d :: dict
     r5 :: str
@@ -750,10 +745,7 @@ L0:
     r6 = PyObject_DelItem(d, r5)
     return 1
 def delDictMultiple():
-    r0 :: str
-    r1 :: str
-    r2 :: str
-    r3 :: str
+    r0, r1, r2, r3 :: str
     r4, r5, r6, r7 :: object
     r8, d :: dict
     r9, r10 :: str

--- a/mypyc/test-data/irbuild-try.test
+++ b/mypyc/test-data/irbuild-try.test
@@ -335,8 +335,7 @@ def foo(x):
     r9 :: object
     r10 :: str
     r11, r12 :: object
-    r13 :: tuple[object, object, object]
-    r14 :: tuple[object, object, object]
+    r13, r14 :: tuple[object, object, object]
     r15, r16, r17, r18 :: object
     r19, r20 :: bool
     r21, r22, r23 :: tuple[object, object, object]

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -80,8 +80,7 @@ def f() -> int:
 def f():
     r0 :: tuple[int, int]
     t :: tuple
-    r1 :: object
-    r2 :: object
+    r1, r2 :: object
     r3 :: int
 L0:
     r0 = (2, 4)
@@ -97,8 +96,7 @@ def f(x: Sequence[int], y: Sequence[int]) -> Tuple[int, ...]:
     return (1, 2, *x, *y, 3)
 [out]
 def f(x, y):
-    x, y :: object
-    r0, r1 :: object
+    x, y, r0, r1 :: object
     r2 :: list
     r3, r4, r5 :: object
     r6 :: int32

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -62,8 +62,7 @@ def f() -> int:
     return y
 [out]
 def f():
-    x :: int
-    y :: int
+    x, y :: int
     r0 :: bool
     r1 :: native_int
     r2, r3, r4 :: bool
@@ -100,8 +99,7 @@ def f(a: int, b: int) -> int:
     return y
 [out]
 def f(a, b):
-    a, b :: int
-    r0, x, r1, y :: int
+    a, b, r0, x, r1, y :: int
 L0:
     r0 = CPyTagged_Add(a, 2)
     x = r0
@@ -118,8 +116,7 @@ def f(a: int) -> int:
     return x + y
 [out]
 def f(a):
-    a, x, y :: int
-    r0 :: int
+    a, x, y, r0 :: int
 L0:
     inc_ref a :: int
     x = a
@@ -139,8 +136,7 @@ def f(a: int) -> int:
     return y
 [out]
 def f(a):
-    a :: int
-    y :: int
+    a, y :: int
 L0:
     a = 2
     y = a
@@ -171,8 +167,7 @@ def f(a: int) -> int:
     return a
 [out]
 def f(a):
-    a :: int
-    x, y :: int
+    a, x, y :: int
 L0:
     x = 2
     inc_ref x :: int
@@ -205,8 +200,7 @@ def f(a):
     r0 :: bool
     r1 :: native_int
     r2, r3, r4 :: bool
-    x :: int
-    r5, y :: int
+    x, r5, y :: int
 L0:
     r1 = a & 1
     r2 = r1 == 0
@@ -250,8 +244,7 @@ def f(a):
     r0 :: bool
     r1 :: native_int
     r2, r3, r4 :: bool
-    x :: int
-    r5, y :: int
+    x, r5, y :: int
 L0:
     r1 = a & 1
     r2 = r1 == 0
@@ -321,8 +314,7 @@ def f(a: int) -> int:
 -- This is correct but bad code
 [out]
 def f(a):
-    a :: int
-    x, r0 :: int
+    a, x, r0 :: int
 L0:
     inc_ref a :: int
     a = a
@@ -343,10 +335,7 @@ def f(a: int) -> int:
     return a + x
 [out]
 def f(a):
-    a :: int
-    r0 :: int
-    x :: int
-    r1, r2 :: int
+    a, r0, x, r1, r2 :: int
 L0:
     r0 = CPyTagged_Add(a, 2)
     a = r0
@@ -365,8 +354,7 @@ def f() -> None:
     x = x + 1
 [out]
 def f():
-    x :: int
-    r0 :: int
+    x, r0 :: int
 L0:
     x = 2
     r0 = CPyTagged_Add(x, 2)
@@ -381,8 +369,7 @@ def f() -> None:
     x = y + 1
 [out]
 def f():
-    y :: int
-    r0, x :: int
+    y, r0, x :: int
 L0:
     y = 2
     r0 = CPyTagged_Add(y, 2)
@@ -432,8 +419,7 @@ def f(a: int) -> None:
     z = y + y
 [out]
 def f(a):
-    a, r0, x :: int
-    y, r1, z :: int
+    a, r0, x, y, r1, z :: int
 L0:
     r0 = CPyTagged_Add(a, a)
     x = r0
@@ -452,8 +438,7 @@ def f(a: int) -> None:
     x = x + x
 [out]
 def f(a):
-    a, r0 :: int
-    x, r1 :: int
+    a, r0, x, r1 :: int
 L0:
     r0 = CPyTagged_Add(a, a)
     a = r0
@@ -476,9 +461,7 @@ def f() -> int:
     return x + y - a
 [out]
 def f():
-    x :: int
-    y :: int
-    z :: int
+    x, y, z :: int
     r0 :: bool
     r1 :: native_int
     r2, r3, r4 :: bool
@@ -528,16 +511,13 @@ def f(a: int) -> int:
     return sum
 [out]
 def f(a):
-    a :: int
-    sum :: int
-    i :: int
+    a, sum, i :: int
     r0 :: bool
     r1 :: native_int
     r2 :: bool
     r3 :: native_int
     r4, r5, r6, r7, r8 :: bool
-    r9 :: int
-    r10 :: int
+    r9, r10 :: int
 L0:
     sum = 0
     i = 0
@@ -577,8 +557,7 @@ def f(a: int) -> int:
     return f(a + 1)
 [out]
 def f(a):
-    a :: int
-    r0, r1 :: int
+    a, r0, r1 :: int
 L0:
     r0 = CPyTagged_Add(a, 2)
     r1 = f(r0)


### PR DESCRIPTION
This PR fixes `Environment.to_lines` so that continuous registers with the same type are shown on the same line.