### PR TITLE
Don't simplify away Any when joining unions

### DIFF
--- a/mypy/join.py
+++ b/mypy/join.py
@@ -119,7 +119,7 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
         return AnyType(TypeOfAny.special_form)
 
     def visit_union_type(self, t: UnionType) -> ProperType:
-        if is_subtype(self.s, t):
+        if is_proper_subtype(self.s, t):
             return t
         else:
             return mypy.typeops.make_simplified_union([self.s, t])

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -1048,3 +1048,14 @@ def foo(a: T2, b: T2) -> T2:
 def bar(a: T4, b: T4) -> T4:  # test multi-level alias
     return a + b
 [builtins fixtures/ops.pyi]
+
+[case testJoinUnionWithUnionAndAny]
+# flags: --strict-optional
+from typing import TypeVar, Union, Any
+T = TypeVar("T")
+def f(x: T, y: T) -> T:
+    return x
+x: Union[None, Any]
+y: Union[int, None]
+reveal_type(f(x, y)) # N: Revealed type is 'Union[None, Any, builtins.int]'
+reveal_type(f(y, x)) # N: Revealed type is 'Union[builtins.int, None, Any]'


### PR DESCRIPTION
Previously join of `Union[int, Any]` and `Union[int, None]` could be
`Union[int, None]` (we lost the `Any` type). Fix this by replacing a
subtype check with a proper subtype check when joining unions.