### PR TITLE
Don't infinite loop on self deps in --follow-imports=normal

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -557,6 +557,10 @@ class Server:
             if module[0] not in graph:
                 continue
             sources2 = self.direct_imports(module, graph)
+            # Filter anything already seen before. This prevents
+            # infinite looping if there are any self edges. (Self
+            # edges are maybe a bug, but...)
+            sources2 = [source for source in sources2 if source.module not in seen]
             changed, new_files = self.find_reachable_changed_modules(
                 sources2, graph, seen, changed_paths
             )


### PR DESCRIPTION
There are situations in complex SCCs where the semantic analyzer will
infer self dependencies, which will cause an infinite loop in dmypy
--follow-imports=normal.

It's probably a bug that we do that, and that should be fixed too, but
fixing a graph algorithm to not infinite loop on self edges seems like
a reasonable thing to do in any case.

I don't have a minimized test case yet, and am submitting this without
one because it should be harmless and because I want it to get into
the release.