### PR TITLE
[mypyc] Merge keep_propagating_op and remove unused assert_err_occurred_op

### DIFF
--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -325,7 +325,7 @@ def transform_try_except(builder: IRBuilder,
     # the exception.
     builder.activate_block(double_except_block)
     builder.call_c(restore_exc_info_op, [builder.read(old_exc)], line)
-    builder.primitive_op(keep_propagating_op, [], NO_TRACEBACK_LINE_NO)
+    builder.call_c(keep_propagating_op, [], NO_TRACEBACK_LINE_NO)
     builder.add(Unreachable())
 
     # If present, compile the else body in the obvious way
@@ -463,7 +463,7 @@ def try_finally_resolve_control(builder: IRBuilder,
     # If there was an exception, restore again
     builder.activate_block(cleanup_block)
     finally_control.gen_cleanup(builder, -1)
-    builder.primitive_op(keep_propagating_op, [], NO_TRACEBACK_LINE_NO)
+    builder.call_c(keep_propagating_op, [], NO_TRACEBACK_LINE_NO)
     builder.add(Unreachable())
 
     return out_block

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -407,11 +407,7 @@ static int CPy_NoErrOccured(void) {
     return PyErr_Occurred() == NULL;
 }
 
-static void CPy_AssertErrOccurred(void) {
-    assert(PyErr_Occurred() != NULL && "failure w/o err!");
-}
-
-static bool CPy_KeepPropagating(void) {
+static inline bool CPy_KeepPropagating(void) {
     return 0;
 }
 // We want to avoid the public PyErr_GetExcInfo API for these because

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -407,7 +407,7 @@ static int CPy_NoErrOccured(void) {
     return PyErr_Occurred() == NULL;
 }
 
-static void CPy_AssertErrOccured(void) {
+static void CPy_AssertErrOccurred(void) {
     assert(PyErr_Occurred() != NULL && "failure w/o err!");
 }
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -407,6 +407,13 @@ static int CPy_NoErrOccured(void) {
     return PyErr_Occurred() == NULL;
 }
 
+static void CPy_AssertErrOccured(void) {
+    assert(PyErr_Occurred() != NULL && "failure w/o err!");
+}
+
+static bool CPy_KeepPropagating(void) {
+    return 0;
+}
 // We want to avoid the public PyErr_GetExcInfo API for these because
 // it requires a bunch of spurious refcount traffic on the parts of
 // the triple we don't care about. Unfortunately the layout of the

--- a/mypyc/primitives/exc_ops.py
+++ b/mypyc/primitives/exc_ops.py
@@ -41,12 +41,6 @@ no_err_occurred_op = c_custom_op(
     c_function_name='CPy_NoErrOccured',
     error_kind=ERR_FALSE)
 
-# Assert that the error indicator has been set.
-assert_err_occurred_op = c_custom_op(
-    arg_types=[],
-    return_type=void_rtype,
-    c_function_name='CPy_AssertErrOccurred',
-    error_kind=ERR_NEVER)
 
 # Keep propagating a raised exception by unconditionally giving an error value.
 # This doesn't actually raise an exception.

--- a/mypyc/primitives/exc_ops.py
+++ b/mypyc/primitives/exc_ops.py
@@ -42,10 +42,10 @@ no_err_occurred_op = c_custom_op(
     error_kind=ERR_FALSE)
 
 # Assert that the error indicator has been set.
-assert_err_occured_op = c_custom_op(
+assert_err_occurred_op = c_custom_op(
     arg_types=[],
     return_type=void_rtype,
-    c_function_name='CPy_AssertErrOccured',
+    c_function_name='CPy_AssertErrOccurred',
     error_kind=ERR_NEVER)
 
 # Keep propagating a raised exception by unconditionally giving an error value.

--- a/mypyc/primitives/exc_ops.py
+++ b/mypyc/primitives/exc_ops.py
@@ -2,9 +2,7 @@
 
 from mypyc.ir.ops import ERR_NEVER, ERR_FALSE, ERR_ALWAYS
 from mypyc.ir.rtypes import bool_rprimitive, object_rprimitive, void_rtype, exc_rtuple
-from mypyc.primitives.registry import (
-    simple_emit, custom_op, c_custom_op
-)
+from mypyc.primitives.registry import c_custom_op
 
 # If the argument is a class, raise an instance of the class. Otherwise, assume
 # that the argument is an exception object, and raise it.
@@ -44,21 +42,19 @@ no_err_occurred_op = c_custom_op(
     error_kind=ERR_FALSE)
 
 # Assert that the error indicator has been set.
-assert_err_occured_op = custom_op(
+assert_err_occured_op = c_custom_op(
     arg_types=[],
-    result_type=void_rtype,
-    error_kind=ERR_NEVER,
-    format_str='assert_err_occurred',
-    emit=simple_emit('assert(PyErr_Occurred() != NULL && "failure w/o err!");'))
+    return_type=void_rtype,
+    c_function_name='CPy_AssertErrOccured',
+    error_kind=ERR_NEVER)
 
 # Keep propagating a raised exception by unconditionally giving an error value.
 # This doesn't actually raise an exception.
-keep_propagating_op = custom_op(
+keep_propagating_op = c_custom_op(
     arg_types=[],
-    result_type=bool_rprimitive,
-    error_kind=ERR_FALSE,
-    format_str='{dest} = keep_propagating',
-    emit=simple_emit('{dest} = 0;'))
+    return_type=bool_rprimitive,
+    c_function_name='CPy_KeepPropagating',
+    error_kind=ERR_FALSE)
 
 # Catches a propagating exception and makes it the "currently
 # handled exception" (by sticking it into sys.exc_info()). Returns the

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -752,7 +752,7 @@ L7:
     goto L10
 L8:
     CPy_RestoreExcInfo(r1)
-    r7 = keep_propagating
+    r7 = CPy_KeepPropagating()
     if not r7 goto L11 else goto L9 :: bool
 L9:
     unreachable

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -213,7 +213,7 @@ L5:
 L6:
     CPy_RestoreExcInfo(r4)
     dec_ref r4
-    r10 = keep_propagating
+    r10 = CPy_KeepPropagating()
     if not r10 goto L9 else goto L7 :: bool
 L7:
     unreachable
@@ -305,7 +305,7 @@ L15:
     CPy_RestoreExcInfo(r6)
     dec_ref r6
 L16:
-    r16 = keep_propagating
+    r16 = CPy_KeepPropagating()
     if not r16 goto L19 else goto L17 :: bool
 L17:
     unreachable

--- a/mypyc/test-data/irbuild-try.test
+++ b/mypyc/test-data/irbuild-try.test
@@ -34,7 +34,7 @@ L3:
     goto L5
 L4: (handler for L2)
     CPy_RestoreExcInfo(r4)
-    r10 = keep_propagating
+    r10 = CPy_KeepPropagating()
     unreachable
 L5:
     return 1
@@ -87,7 +87,7 @@ L6:
     goto L8
 L7: (handler for L5)
     CPy_RestoreExcInfo(r6)
-    r12 = keep_propagating
+    r12 = CPy_KeepPropagating()
     unreachable
 L8:
     return 1
@@ -164,7 +164,7 @@ L6:
     goto L8
 L7: (handler for L3, L4, L5)
     CPy_RestoreExcInfo(r9)
-    r20 = keep_propagating
+    r20 = CPy_KeepPropagating()
     unreachable
 L8:
     goto L12
@@ -180,7 +180,7 @@ L10:
     goto L12
 L11: (handler for L9)
     CPy_RestoreExcInfo(r21)
-    r27 = keep_propagating
+    r27 = CPy_KeepPropagating()
     unreachable
 L12:
     return 1
@@ -250,7 +250,7 @@ L7:
     goto L9
 L8: (handler for L2, L3, L4, L5, L6)
     CPy_RestoreExcInfo(r0)
-    r19 = keep_propagating
+    r19 = CPy_KeepPropagating()
     unreachable
 L9:
     return 1
@@ -312,7 +312,7 @@ L10: (handler for L7, L8)
 L11:
     CPy_RestoreExcInfo(r5)
 L12:
-    r13 = keep_propagating
+    r13 = CPy_KeepPropagating()
     unreachable
 L13:
     return 1
@@ -378,7 +378,7 @@ L6:
     goto L8
 L7: (handler for L3, L4, L5)
     CPy_RestoreExcInfo(r13)
-    r20 = keep_propagating
+    r20 = CPy_KeepPropagating()
     unreachable
 L8:
 L9:
@@ -406,7 +406,7 @@ L17: (handler for L12, L13, L14, L15)
 L18:
     CPy_RestoreExcInfo(r21)
 L19:
-    r26 = keep_propagating
+    r26 = CPy_KeepPropagating()
     unreachable
 L20:
     return 1


### PR DESCRIPTION
This PR merges keep_propagating_op and removes unused assert_err_occurred_op. To keep the design unified, we turn to C wrapper function for now.

This completes all exception-related ops.