### PR TITLE
[mypyc] Obsolete several old-style registry functions

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -623,12 +623,12 @@ class LowLevelIRBuilder:
                  lreg: Value,
                  expr_op: str,
                  line: int) -> Value:
-        call_c_ops_candidates = c_unary_ops.get(expr_op, [])
-        target = self.matching_call_c(call_c_ops_candidates, [lreg], line)
-        if target:
-            return target
         ops = unary_ops.get(expr_op, [])
         target = self.matching_primitive_op(ops, [lreg], line)
+        if target:
+            return target
+        call_c_ops_candidates = c_unary_ops.get(expr_op, [])
+        target = self.matching_call_c(call_c_ops_candidates, [lreg], line)
         assert target, 'Unsupported unary operation: %s' % expr_op
         return target
 
@@ -745,7 +745,7 @@ class LowLevelIRBuilder:
                     self.add_bool_branch(remaining, true, false)
                 return
             elif not is_same_type(value.type, bool_rprimitive):
-                value = self.primitive_op(bool_op, [value], value.line)
+                value = self.call_c(bool_op, [value], value.line)
         self.add(Branch(value, true, false, Branch.BOOL_EXPR))
 
     def call_c(self,

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -160,7 +160,7 @@ type_is_op = custom_op(
 
 # bool(obj) with unboxed result
 bool_op = c_function_op(
-    name='not',
+    name='builtins.bool',
     arg_types=[object_rprimitive],
     return_type=c_int_rprimitive,
     c_function_name='PyObject_IsTrue',

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -7,7 +7,7 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.primitives.registry import (
     simple_emit, unary_op, func_op, custom_op, call_emit, name_emit,
-    call_negative_magic_emit, c_function_op, c_custom_op, load_address_op
+    c_function_op, c_custom_op, load_address_op
 )
 
 
@@ -159,12 +159,13 @@ type_is_op = custom_op(
     emit=simple_emit('{dest} = Py_TYPE({args[0]}) == (PyTypeObject *){args[1]};'))
 
 # bool(obj) with unboxed result
-bool_op = func_op(
-    'builtins.bool',
+bool_op = c_function_op(
+    name='not',
     arg_types=[object_rprimitive],
-    result_type=bool_rprimitive,
-    error_kind=ERR_MAGIC,
-    emit=call_negative_magic_emit('PyObject_IsTrue'))
+    return_type=c_int_rprimitive,
+    c_function_name='PyObject_IsTrue',
+    error_kind=ERR_NEG_INT,
+    truncated_type=bool_rprimitive)
 
 # slice(start, stop, step)
 new_slice_op = c_function_op(

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -125,45 +125,6 @@ def call_emit(func: str) -> EmitCallback:
     return simple_emit('{dest} = %s({comma_args});' % func)
 
 
-def call_void_emit(func: str) -> EmitCallback:
-    return simple_emit('%s({comma_args});' % func)
-
-
-def call_and_fail_emit(func: str) -> EmitCallback:
-    # This is a hack for our always failing operations like CPy_Raise,
-    # since we want the optimizer to see that it always fails but we
-    # don't have an ERR_ALWAYS yet.
-    # TODO: Have an ERR_ALWAYS.
-    return simple_emit('%s({comma_args}); {dest} = 0;' % func)
-
-
-def call_negative_bool_emit(func: str) -> EmitCallback:
-    """Construct an emit callback that calls a function and checks for negative return.
-
-    The negative return value is converted to a bool (true -> no error).
-    """
-    return simple_emit('{dest} = %s({comma_args}) >= 0;' % func)
-
-
-def negative_int_emit(template: str) -> EmitCallback:
-    """Construct a simple PrimitiveOp emit callback function that checks for -1 return."""
-
-    def emit(emitter: EmitterInterface, args: List[str], dest: str) -> None:
-        temp = emitter.temp_name()
-        emitter.emit_line(template.format(args=args, dest='int %s' % temp,
-                                          comma_args=', '.join(args)))
-        emitter.emit_lines('if (%s < 0)' % temp,
-                           '    %s = %s;' % (dest, emitter.c_error_value(bool_rprimitive)),
-                           'else',
-                           '    %s = %s;' % (dest, temp))
-
-    return emit
-
-
-def call_negative_magic_emit(func: str) -> EmitCallback:
-    return negative_int_emit('{dest} = %s({comma_args});' % func)
-
-
 def binary_op(op: str,
               arg_types: List[RType],
               result_type: RType,

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -40,7 +40,7 @@ from typing import Dict, List, Optional, NamedTuple, Tuple
 from mypyc.ir.ops import (
     OpDescription, EmitterInterface, EmitCallback, StealsDescription, short_name
 )
-from mypyc.ir.rtypes import RType,  bool_rprimitive
+from mypyc.ir.rtypes import RType
 
 CFunctionDescription = NamedTuple(
     'CFunctionDescription',  [('name', str),

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -207,18 +207,20 @@ def f(x: object, y: object) -> str:
 def f(x, y):
     x, y :: object
     r0, r1 :: str
-    r2 :: bool
-    r3 :: str
+    r2 :: int32
+    r3 :: bool
+    r4 :: str
 L0:
     r1 = PyObject_Str(x)
-    r2 = bool r1 :: object
-    if r2 goto L1 else goto L2 :: bool
+    r2 = PyObject_IsTrue(r1)
+    r3 = truncate r2: int32 to builtins.bool
+    if r3 goto L1 else goto L2 :: bool
 L1:
     r0 = r1
     goto L3
 L2:
-    r3 = PyObject_Str(y)
-    r0 = r3
+    r4 = PyObject_Str(y)
+    r0 = r4
 L3:
     return r0
 
@@ -288,18 +290,20 @@ def f(x: object, y: object) -> str:
 def f(x, y):
     x, y :: object
     r0, r1 :: str
-    r2 :: bool
-    r3 :: str
+    r2 :: int32
+    r3 :: bool
+    r4 :: str
 L0:
     r1 = PyObject_Str(x)
-    r2 = bool r1 :: object
-    if r2 goto L2 else goto L1 :: bool
+    r2 = PyObject_IsTrue(r1)
+    r3 = truncate r2: int32 to builtins.bool
+    if r3 goto L2 else goto L1 :: bool
 L1:
     r0 = r1
     goto L3
 L2:
-    r3 = PyObject_Str(y)
-    r0 = r3
+    r4 = PyObject_Str(y)
+    r0 = r4
 L3:
     return r0
 
@@ -1315,10 +1319,12 @@ def lst(x: List[int]) -> int:
 [out]
 def obj(x):
     x :: object
-    r0 :: bool
+    r0 :: int32
+    r1 :: bool
 L0:
-    r0 = bool x :: object
-    if r0 goto L1 else goto L2 :: bool
+    r0 = PyObject_IsTrue(x)
+    r1 = truncate r0: int32 to builtins.bool
+    if r1 goto L1 else goto L2 :: bool
 L1:
     return 2
 L2:
@@ -1444,15 +1450,17 @@ def opt_o(x):
     r0 :: object
     r1 :: bool
     r2 :: object
-    r3 :: bool
+    r3 :: int32
+    r4 :: bool
 L0:
     r0 = builtins.None :: object
     r1 = x is not r0
     if r1 goto L1 else goto L3 :: bool
 L1:
     r2 = cast(object, x)
-    r3 = bool r2 :: object
-    if r3 goto L2 else goto L3 :: bool
+    r3 = PyObject_IsTrue(r2)
+    r4 = truncate r3: int32 to builtins.bool
+    if r4 goto L2 else goto L3 :: bool
 L2:
     return 2
 L3:
@@ -2740,17 +2748,20 @@ L0:
 def A.__ne__(self, rhs):
     self :: __main__.A
     rhs, r0, r1 :: object
-    r2, r3 :: bool
-    r4 :: object
+    r2 :: bool
+    r3 :: int32
+    r4 :: bool
+    r5 :: object
 L0:
     r0 = self.__eq__(rhs)
     r1 = load_address _Py_NotImplementedStruct
     r2 = r0 is r1
     if r2 goto L2 else goto L1 :: bool
 L1:
-    r3 = not r0
-    r4 = box(bool, r3)
-    return r4
+    r3 = PyObject_Not(r0)
+    r4 = truncate r3: int32 to builtins.bool
+    r5 = box(bool, r4)
+    return r5
 L2:
     return r1
 

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3546,3 +3546,16 @@ def h(x):
 L0:
     r0 = PySequence_List(x)
     return r0
+
+[case testBoolFunction]
+def f(x: object) -> bool:
+    return bool(x)
+[out]
+def f(x):
+    x :: object
+    r0 :: int32
+    r1 :: bool
+L0:
+    r0 = PyObject_IsTrue(x)
+    r1 = truncate r0: int32 to builtins.bool
+    return r1

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -795,17 +795,20 @@ L0:
 def Base.__ne__(self, rhs):
     self :: __main__.Base
     rhs, r0, r1 :: object
-    r2, r3 :: bool
-    r4 :: object
+    r2 :: bool
+    r3 :: int32
+    r4 :: bool
+    r5 :: object
 L0:
     r0 = self.__eq__(rhs)
     r1 = load_address _Py_NotImplementedStruct
     r2 = r0 is r1
     if r2 goto L2 else goto L1 :: bool
 L1:
-    r3 = not r0
-    r4 = box(bool, r3)
-    return r4
+    r3 = PyObject_Not(r0)
+    r4 = truncate r3: int32 to builtins.bool
+    r5 = box(bool, r4)
+    return r5
 L2:
     return r1
 def Derived.__eq__(self, other):
@@ -910,17 +913,20 @@ L0:
 def Derived.__ne__(self, rhs):
     self :: __main__.Derived
     rhs, r0, r1 :: object
-    r2, r3 :: bool
-    r4 :: object
+    r2 :: bool
+    r3 :: int32
+    r4 :: bool
+    r5 :: object
 L0:
     r0 = self.__eq__(rhs)
     r1 = load_address _Py_NotImplementedStruct
     r2 = r0 is r1
     if r2 goto L2 else goto L1 :: bool
 L1:
-    r3 = not r0
-    r4 = box(bool, r3)
-    return r4
+    r3 = PyObject_Not(r0)
+    r4 = truncate r3: int32 to builtins.bool
+    r5 = box(bool, r4)
+    return r5
 L2:
     return r1
 

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -194,3 +194,20 @@ L0:
     r5 = box(short_int, 6)
     r6 = PyList_Append(r2, r5)
     return r2
+
+[case testListIn]
+from typing import List
+def f(x: List[int], y: int) -> bool:
+    return y in x
+[out]
+  def f(x, y):
+      x :: list
+      y :: int
+      r0 :: object
+      r1 :: int32
+      r2 :: bool
+  L0:
+      r0 = box(int, y)
+      r1 = PySequence_Contains(x, r0)
+      r2 = truncate r1: int32 to builtins.bool
+      return r2

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -200,14 +200,14 @@ from typing import List
 def f(x: List[int], y: int) -> bool:
     return y in x
 [out]
-  def f(x, y):
-      x :: list
-      y :: int
-      r0 :: object
-      r1 :: int32
-      r2 :: bool
-  L0:
-      r0 = box(int, y)
-      r1 = PySequence_Contains(x, r0)
-      r2 = truncate r1: int32 to builtins.bool
-      return r2
+def f(x, y):
+    x :: list
+    y :: int
+    r0 :: object
+    r1 :: int32
+    r2 :: bool
+L0:
+    r0 = box(int, y)
+    r1 = PySequence_Contains(x, r0)
+    r2 = truncate r1: int32 to builtins.bool
+    return r2

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -92,15 +92,17 @@ def f(x):
     r0 :: object
     r1 :: bool
     r2 :: __main__.A
-    r3 :: bool
+    r3 :: int32
+    r4 :: bool
 L0:
     r0 = builtins.None :: object
     r1 = x is not r0
     if r1 goto L1 else goto L3 :: bool
 L1:
     r2 = cast(__main__.A, x)
-    r3 = bool r2 :: object
-    if r3 goto L2 else goto L3 :: bool
+    r3 = PyObject_IsTrue(r2)
+    r4 = truncate r3: int32 to builtins.bool
+    if r4 goto L2 else goto L3 :: bool
 L2:
     return 2
 L3:

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -635,10 +635,12 @@ L2:
     return 2
 def literal_msg(x):
     x :: object
-    r0, r1 :: bool
+    r0 :: int32
+    r1, r2 :: bool
 L0:
-    r0 = bool x :: object
-    if r0 goto L2 else goto L1 :: bool
+    r0 = PyObject_IsTrue(x)
+    r1 = truncate r0: int32 to builtins.bool
+    if r1 goto L2 else goto L1 :: bool
 L1:
     raise AssertionError('message')
     unreachable
@@ -650,24 +652,26 @@ def complex_msg(x, s):
     r0 :: object
     r1 :: bool
     r2 :: str
-    r3 :: bool
-    r4 :: object
-    r5 :: str
-    r6, r7 :: object
+    r3 :: int32
+    r4 :: bool
+    r5 :: object
+    r6 :: str
+    r7, r8 :: object
 L0:
     r0 = builtins.None :: object
     r1 = x is not r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     r2 = cast(str, x)
-    r3 = bool r2 :: object
-    if r3 goto L3 else goto L2 :: bool
+    r3 = PyObject_IsTrue(r2)
+    r4 = truncate r3: int32 to builtins.bool
+    if r4 goto L3 else goto L2 :: bool
 L2:
-    r4 = builtins :: module
-    r5 = unicode_3 :: static  ('AssertionError')
-    r6 = CPyObject_GetAttr(r4, r5)
-    r7 = py_call(r6, s)
-    CPy_Raise(r7)
+    r5 = builtins :: module
+    r6 = unicode_3 :: static  ('AssertionError')
+    r7 = CPyObject_GetAttr(r5, r6)
+    r8 = py_call(r7, s)
+    CPy_Raise(r8)
     unreachable
 L3:
     return 1
@@ -910,9 +914,11 @@ def f(a, b):
     r5 :: bool
     r6, r7 :: object
     x, r8 :: int
-    r9, y, r10 :: bool
-    r11 :: short_int
-    r12 :: bool
+    r9, y :: bool
+    r10 :: int32
+    r11 :: bool
+    r12 :: short_int
+    r13 :: bool
 L0:
     r0 = 0
     r1 = PyObject_GetIter(b)
@@ -931,17 +937,18 @@ L3:
     x = r8
     r9 = unbox(bool, r6)
     y = r9
-    r10 = bool b :: object
-    if r10 goto L4 else goto L5 :: bool
+    r10 = PyObject_IsTrue(b)
+    r11 = truncate r10: int32 to builtins.bool
+    if r11 goto L4 else goto L5 :: bool
 L4:
     x = 2
 L5:
 L6:
-    r11 = r0 + 2
-    r0 = r11
+    r12 = r0 + 2
+    r0 = r12
     goto L1
 L7:
-    r12 = CPy_NoErrOccured()
+    r13 = CPy_NoErrOccured()
 L8:
     return 1
 def g(a, b):

--- a/mypyc/test-data/irbuild-try.test
+++ b/mypyc/test-data/irbuild-try.test
@@ -337,10 +337,11 @@ def foo(x):
     r11, r12 :: object
     r13, r14 :: tuple[object, object, object]
     r15, r16, r17, r18 :: object
-    r19, r20 :: bool
-    r21, r22, r23 :: tuple[object, object, object]
-    r24, r25 :: object
-    r26 :: bool
+    r19 :: int32
+    r20, r21 :: bool
+    r22, r23, r24 :: tuple[object, object, object]
+    r25, r26 :: object
+    r27 :: bool
 L0:
     r0 = py_call(x)
     r1 = PyObject_Type(r0)
@@ -367,8 +368,9 @@ L3: (handler for L2)
     r16 = r14[1]
     r17 = r14[2]
     r18 = py_call(r3, r0, r15, r16, r17)
-    r19 = bool r18 :: object
-    if r19 goto L5 else goto L4 :: bool
+    r19 = PyObject_IsTrue(r18)
+    r20 = truncate r19: int32 to builtins.bool
+    if r20 goto L5 else goto L4 :: bool
 L4:
     CPy_Reraise()
     unreachable
@@ -378,35 +380,35 @@ L6:
     goto L8
 L7: (handler for L3, L4, L5)
     CPy_RestoreExcInfo(r13)
-    r20 = CPy_KeepPropagating()
+    r21 = CPy_KeepPropagating()
     unreachable
 L8:
 L9:
 L10:
-    r22 = <error> :: tuple[object, object, object]
-    r21 = r22
+    r23 = <error> :: tuple[object, object, object]
+    r22 = r23
     goto L12
 L11: (handler for L1, L6, L7, L8)
-    r23 = CPy_CatchError()
-    r21 = r23
+    r24 = CPy_CatchError()
+    r22 = r24
 L12:
     if r7 goto L13 else goto L14 :: bool
 L13:
-    r24 = builtins.None :: object
-    r25 = py_call(r3, r0, r24, r24, r24)
+    r25 = builtins.None :: object
+    r26 = py_call(r3, r0, r25, r25, r25)
 L14:
-    if is_error(r21) goto L16 else goto L15
+    if is_error(r22) goto L16 else goto L15
 L15:
     CPy_Reraise()
     unreachable
 L16:
     goto L20
 L17: (handler for L12, L13, L14, L15)
-    if is_error(r21) goto L19 else goto L18
+    if is_error(r22) goto L19 else goto L18
 L18:
-    CPy_RestoreExcInfo(r21)
+    CPy_RestoreExcInfo(r22)
 L19:
-    r26 = CPy_KeepPropagating()
+    r27 = CPy_KeepPropagating()
     unreachable
 L20:
     return 1


### PR DESCRIPTION
This PR merges the generic `in` and `op` as well as misc `builtins.bool` op, and obsoletes unused old-style registry functions: `call_void_emit`, `call_and_fail_emit`, `call_negative_bool_emit`, `negative_int_emit`, `call_negative_magic_emit`.

A test for generic `in` and misc `builtins.bool` is added.