### PR TITLE
[mypyc] Split BinaryIntOp and introduce ComparisonOp, implements is/is not op

### DIFF
--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -9,7 +9,7 @@ from mypyc.ir.ops import (
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
     LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError, CallC, LoadGlobal,
-    Truncate, BinaryIntOp, LoadMem, GetElementPtr, LoadAddress
+    Truncate, BinaryIntOp, LoadMem, GetElementPtr, LoadAddress, ComparisonOp
 )
 
 
@@ -206,6 +206,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_binary_int_op(self, op: BinaryIntOp) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_comparison_op(self, op: ComparisonOp) -> GenAndKill:
         return self.visit_register_op(op)
 
     def visit_load_mem(self, op: LoadMem) -> GenAndKill:

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -12,7 +12,7 @@ from mypyc.ir.ops import (
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
     BasicBlock, Value, MethodCall, PrimitiveOp, EmitterInterface, Unreachable, NAMESPACE_STATIC,
     NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CallC, LoadGlobal, Truncate,
-    BinaryIntOp, LoadMem, GetElementPtr, LoadAddress
+    BinaryIntOp, LoadMem, GetElementPtr, LoadAddress, ComparisonOp
 )
 from mypyc.ir.rtypes import (
     RType, RTuple, is_tagged, is_int32_rprimitive, is_int64_rprimitive, RStruct
@@ -451,10 +451,16 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         dest = self.reg(op)
         lhs = self.reg(op.lhs)
         rhs = self.reg(op.rhs)
+        self.emit_line('%s = %s %s %s;' % (dest, lhs, op.op_str[op.op], rhs))
+
+    def visit_comparison_op(self, op: ComparisonOp) -> None:
+        dest = self.reg(op)
+        lhs = self.reg(op.lhs)
+        rhs = self.reg(op.rhs)
         lhs_cast = ""
         rhs_cast = ""
-        signed_op = {BinaryIntOp.SLT, BinaryIntOp.SGT, BinaryIntOp.SLE, BinaryIntOp.SGE}
-        unsigned_op = {BinaryIntOp.ULT, BinaryIntOp.UGT, BinaryIntOp.ULE, BinaryIntOp.UGE}
+        signed_op = {ComparisonOp.SLT, ComparisonOp.SGT, ComparisonOp.SLE, ComparisonOp.SGE}
+        unsigned_op = {ComparisonOp.ULT, ComparisonOp.UGT, ComparisonOp.ULE, ComparisonOp.UGE}
         if op.op in signed_op:
             lhs_cast = self.emit_signed_int_cast(op.lhs.type)
             rhs_cast = self.emit_signed_int_cast(op.rhs.type)

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1316,7 +1316,7 @@ class BinaryIntOp(RegisterOp):
 
 
 class ComparisonOp(RegisterOp):
-    """Binary Comparsion ops
+    """Comparison ops
 
     The result type will always be boolean.
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1263,7 +1263,7 @@ class LoadGlobal(RegisterOp):
 
 
 class BinaryIntOp(RegisterOp):
-    """Binary operations on integer types
+    """Binary arithmetic and bitwise operations on integer types
 
     These ops are low-level and will be eventually generated to simple x op y form.
     The left and right values should be of low-level integer types that support those ops
@@ -1276,18 +1276,7 @@ class BinaryIntOp(RegisterOp):
     MUL = 2  # type: Final
     DIV = 3  # type: Final
     MOD = 4  # type: Final
-    # logical
-    # S for signed and U for unsigned
-    EQ = 100  # type: Final
-    NEQ = 101  # type: Final
-    SLT = 102  # type: Final
-    SGT = 103  # type: Final
-    SLE = 104  # type: Final
-    SGE = 105  # type: Final
-    ULT = 106  # type: Final
-    UGT = 107  # type: Final
-    ULE = 108  # type: Final
-    UGE = 109  # type: Final
+
     # bitwise
     AND = 200  # type: Final
     OR = 201  # type: Final
@@ -1301,16 +1290,6 @@ class BinaryIntOp(RegisterOp):
         MUL: '*',
         DIV: '/',
         MOD: '%',
-        EQ: '==',
-        NEQ: '!=',
-        SLT: '<',
-        SGT: '>',
-        SLE: '<=',
-        SGE: '>=',
-        ULT: '<',
-        UGT: '>',
-        ULE: '<=',
-        UGE: '>=',
         AND: '&',
         OR: '|',
         XOR: '^',
@@ -1329,6 +1308,58 @@ class BinaryIntOp(RegisterOp):
         return [self.lhs, self.rhs]
 
     def to_str(self, env: Environment) -> str:
+        return env.format('%r = %r %s %r', self, self.lhs,
+                          self.op_str[self.op], self.rhs)
+
+    def accept(self, visitor: 'OpVisitor[T]') -> T:
+        return visitor.visit_binary_int_op(self)
+
+
+class ComparisonOp(RegisterOp):
+    """Binary Comparsion ops
+
+    The result type will always be boolean.
+
+    Support comparison between integer types and pointer types
+    """
+    error_kind = ERR_NEVER
+
+    # S for signed and U for unsigned
+    EQ = 100  # type: Final
+    NEQ = 101  # type: Final
+    SLT = 102  # type: Final
+    SGT = 103  # type: Final
+    SLE = 104  # type: Final
+    SGE = 105  # type: Final
+    ULT = 106  # type: Final
+    UGT = 107  # type: Final
+    ULE = 108  # type: Final
+    UGE = 109  # type: Final
+
+    op_str = {
+        EQ: '==',
+        NEQ: '!=',
+        SLT: '<',
+        SGT: '>',
+        SLE: '<=',
+        SGE: '>=',
+        ULT: '<',
+        UGT: '>',
+        ULE: '<=',
+        UGE: '>=',
+    }  # type: Final
+
+    def __init__(self, lhs: Value, rhs: Value, op: int, line: int = -1) -> None:
+        super().__init__(line)
+        self.type = bool_rprimitive
+        self.lhs = lhs
+        self.rhs = rhs
+        self.op = op
+
+    def sources(self) -> List[Value]:
+        return [self.lhs, self.rhs]
+
+    def to_str(self, env: Environment) -> str:
         if self.op in (self.SLT, self.SGT, self.SLE, self.SGE):
             sign_format = " :: signed"
         elif self.op in (self.ULT, self.UGT, self.ULE, self.UGE):
@@ -1339,7 +1370,7 @@ class BinaryIntOp(RegisterOp):
                           self.op_str[self.op], self.rhs, sign_format)
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
-        return visitor.visit_binary_int_op(self)
+        return visitor.visit_comparison_op(self)
 
 
 class LoadMem(RegisterOp):
@@ -1529,6 +1560,10 @@ class OpVisitor(Generic[T]):
 
     @abstractmethod
     def visit_binary_int_op(self, op: BinaryIntOp) -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visit_comparison_op(self, op: ComparisonOp) -> T:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -209,6 +209,13 @@ class IRBuilder:
     def false(self) -> Value:
         return self.builder.false()
 
+    def translate_is_op(self,
+                        lreg: Value,
+                        rreg: Value,
+                        expr_op: str,
+                        line: int) -> Value:
+        return self.builder.translate_is_op(lreg, rreg, expr_op, line)
+
     def py_call(self,
                 function: Value,
                 arg_values: List[Value],
@@ -270,7 +277,7 @@ class IRBuilder:
 
         needs_import, out = BasicBlock(), BasicBlock()
         first_load = self.load_module(id)
-        comparison = self.binary_op(first_load, self.none_object(), 'is not', line)
+        comparison = self.translate_is_op(first_load, self.none_object(), 'is not', line)
         self.add_bool_branch(comparison, out, needs_import)
 
         self.activate_block(needs_import)

--- a/mypyc/irbuild/callable_class.py
+++ b/mypyc/irbuild/callable_class.py
@@ -119,7 +119,7 @@ def add_get_to_callable_class(builder: IRBuilder, fn_info: FuncInfo) -> None:
     # object. If accessed through an object, create a new bound
     # instance method object.
     instance_block, class_block = BasicBlock(), BasicBlock()
-    comparison = builder.binary_op(
+    comparison = builder.translate_is_op(
         builder.read(instance), builder.none_object(), 'is', line
     )
     builder.add_bool_branch(comparison, class_block, instance_block)

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -396,7 +396,7 @@ def gen_glue_ne_method(builder: IRBuilder, cls: ClassIR, line: int) -> FuncIR:
     not_implemented = builder.add(LoadAddress(not_implemented_op.type,
                                               not_implemented_op.src, line))
     builder.add(Branch(
-        builder.binary_op(eqval, not_implemented, 'is', line),
+        builder.translate_is_op(eqval, not_implemented, 'is', line),
         not_implemented_block,
         regular_block,
         Branch.BOOL_EXPR))

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -27,7 +27,7 @@ from mypyc.primitives.list_ops import new_list_op, list_append_op, list_extend_o
 from mypyc.primitives.tuple_ops import list_tuple_op
 from mypyc.primitives.dict_ops import dict_new_op, dict_set_item_op
 from mypyc.primitives.set_ops import new_set_op, set_add_op, set_update_op
-from mypyc.primitives.int_ops import int_logical_op_mapping
+from mypyc.primitives.int_ops import int_comparison_op_mapping
 from mypyc.irbuild.specialize import specializers
 from mypyc.irbuild.builder import IRBuilder
 from mypyc.irbuild.for_helpers import translate_list_comprehension, comprehension_helper
@@ -394,7 +394,7 @@ def transform_basic_comparison(builder: IRBuilder,
                                right: Value,
                                line: int) -> Value:
     if (is_int_rprimitive(left.type) and is_int_rprimitive(right.type)
-            and op in int_logical_op_mapping.keys()):
+            and op in int_comparison_op_mapping.keys()):
         return builder.compare_tagged(left, right, op, line)
     negate = False
     if op == 'is not':

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -110,7 +110,7 @@ def add_raise_exception_blocks_to_generator_class(builder: IRBuilder, line: int)
     # Check to see if an exception was raised.
     error_block = BasicBlock()
     ok_block = BasicBlock()
-    comparison = builder.binary_op(exc_type, builder.none_object(), 'is not', line)
+    comparison = builder.translate_is_op(exc_type, builder.none_object(), 'is not', line)
     builder.add_bool_branch(comparison, error_block, ok_block)
 
     builder.activate_block(error_block)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -995,7 +995,7 @@ class LowLevelIRBuilder:
                         rreg: Value,
                         expr_op: str,
                         line: int) -> Value:
-        """Create equality comparison operation between object types
+        """Create equality comparison operation between object identities
 
         Args:
             expr_op: either 'is' or 'is not'

--- a/mypyc/primitives/generic_ops.py
+++ b/mypyc/primitives/generic_ops.py
@@ -88,20 +88,6 @@ c_binary_op(
     ordering=[1, 0],
     priority=0)
 
-binary_op('is',
-          arg_types=[object_rprimitive, object_rprimitive],
-          result_type=bool_rprimitive,
-          error_kind=ERR_NEVER,
-          emit=simple_emit('{dest} = {args[0]} == {args[1]};'),
-          priority=0)
-
-binary_op('is not',
-          arg_types=[object_rprimitive, object_rprimitive],
-          result_type=bool_rprimitive,
-          error_kind=ERR_NEVER,
-          emit=simple_emit('{dest} = {args[0]} != {args[1]};'),
-          priority=0)
-
 
 # Unary operations
 

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -7,7 +7,7 @@ See also the documentation for mypyc.rtypes.int_rprimitive.
 """
 
 from typing import Dict, NamedTuple
-from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, BinaryIntOp
+from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ComparisonOp
 from mypyc.ir.rtypes import (
     int_rprimitive, bool_rprimitive, float_rprimitive, object_rprimitive,
     str_rprimitive, RType
@@ -138,11 +138,11 @@ int_less_than_ = c_custom_op(
 
 # provide mapping from textual op to short int's op variant and boxed int's description
 # note these are not complete implementations
-int_logical_op_mapping = {
-    '==': IntLogicalOpDescrption(BinaryIntOp.EQ, int_equal_, False, False),
-    '!=': IntLogicalOpDescrption(BinaryIntOp.NEQ, int_equal_, True, False),
-    '<': IntLogicalOpDescrption(BinaryIntOp.SLT, int_less_than_, False, False),
-    '<=': IntLogicalOpDescrption(BinaryIntOp.SLE, int_less_than_, True, True),
-    '>': IntLogicalOpDescrption(BinaryIntOp.SGT, int_less_than_, False, True),
-    '>=': IntLogicalOpDescrption(BinaryIntOp.SGE, int_less_than_, True, False),
+int_comparison_op_mapping = {
+    '==': IntLogicalOpDescrption(ComparisonOp.EQ, int_equal_, False, False),
+    '!=': IntLogicalOpDescrption(ComparisonOp.NEQ, int_equal_, True, False),
+    '<': IntLogicalOpDescrption(ComparisonOp.SLT, int_less_than_, False, False),
+    '<=': IntLogicalOpDescrption(ComparisonOp.SLE, int_less_than_, True, True),
+    '>': IntLogicalOpDescrption(ComparisonOp.SGT, int_less_than_, False, True),
+    '>=': IntLogicalOpDescrption(ComparisonOp.SGE, int_less_than_, True, False),
 }  # type: Dict[str, IntLogicalOpDescrption]

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -77,7 +77,7 @@ def f(x):
     r6 :: int
 L0:
     r0 = box(None, 1)
-    r1 = x is r0
+    r1 = x == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return 2
@@ -87,7 +87,7 @@ L2:
     if is_error(r2) goto L6 (error at f:8) else goto L3
 L3:
     r3 = box(None, 1)
-    r4 = r2 is r3
+    r4 = r2 == r3
     dec_ref r2
     r5 = !r4
     if r5 goto L4 else goto L5 :: bool
@@ -478,7 +478,7 @@ L2:
     r1 = unicode_2 :: static  ('b')
     inc_ref r1
     v = r1
-    r2 = v is u
+    r2 = v == u
     r3 = !r2
     if r3 goto L11 else goto L1 :: bool
 L3:

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -1408,7 +1408,7 @@ def opt_int(x):
     r5, r6, r7, r8 :: bool
 L0:
     r0 = builtins.None :: object
-    r1 = x is not r0
+    r1 = x != r0
     if r1 goto L1 else goto L6 :: bool
 L1:
     r2 = unbox(int, x)
@@ -1437,7 +1437,7 @@ def opt_a(x):
     r1 :: bool
 L0:
     r0 = builtins.None :: object
-    r1 = x is not r0
+    r1 = x != r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return 2
@@ -1454,7 +1454,7 @@ def opt_o(x):
     r4 :: bool
 L0:
     r0 = builtins.None :: object
-    r1 = x is not r0
+    r1 = x != r0
     if r1 goto L1 else goto L3 :: bool
 L1:
     r2 = cast(object, x)
@@ -1542,7 +1542,7 @@ def __top_level__():
 L0:
     r0 = builtins :: module
     r1 = builtins.None :: object
-    r2 = r0 is not r1
+    r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = unicode_0 :: static  ('builtins')
@@ -2580,7 +2580,7 @@ def __top_level__():
 L0:
     r0 = builtins :: module
     r1 = builtins.None :: object
-    r2 = r0 is not r1
+    r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = unicode_0 :: static  ('builtins')
@@ -2589,7 +2589,7 @@ L1:
 L2:
     r5 = typing :: module
     r6 = builtins.None :: object
-    r7 = r5 is not r6
+    r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
     r8 = unicode_1 :: static  ('typing')
@@ -2755,7 +2755,7 @@ def A.__ne__(self, rhs):
 L0:
     r0 = self.__eq__(rhs)
     r1 = load_address _Py_NotImplementedStruct
-    r2 = r0 is r1
+    r2 = r0 == r1
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = PyObject_Not(r0)
@@ -2799,7 +2799,7 @@ def g_a_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -2856,7 +2856,7 @@ def g_b_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -2913,7 +2913,7 @@ def __mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj.__get__(__mypy
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -3002,7 +3002,7 @@ def __top_level__():
 L0:
     r0 = builtins :: module
     r1 = builtins.None :: object
-    r2 = r0 is not r1
+    r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = unicode_0 :: static  ('builtins')
@@ -3011,7 +3011,7 @@ L1:
 L2:
     r5 = typing :: module
     r6 = builtins.None :: object
-    r7 = r5 is not r6
+    r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
     r8 = unicode_1 :: static  ('typing')
@@ -3057,7 +3057,7 @@ def g_a_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -3124,7 +3124,7 @@ def __top_level__():
 L0:
     r0 = builtins :: module
     r1 = builtins.None :: object
-    r2 = r0 is not r1
+    r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = unicode_0 :: static  ('builtins')
@@ -3133,7 +3133,7 @@ L1:
 L2:
     r5 = typing :: module
     r6 = builtins.None :: object
-    r7 = r5 is not r6
+    r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
     r8 = unicode_1 :: static  ('typing')

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -117,7 +117,7 @@ def Node.length(self):
 L0:
     r0 = self.next
     r1 = box(None, 1)
-    r2 = r0 is r1
+    r2 = r0 == r1
     r3 = !r2
     if r3 goto L1 else goto L2 :: bool
 L1:
@@ -352,7 +352,7 @@ def __top_level__():
 L0:
     r0 = builtins :: module
     r1 = builtins.None :: object
-    r2 = r0 is not r1
+    r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = unicode_0 :: static  ('builtins')
@@ -361,7 +361,7 @@ L1:
 L2:
     r5 = typing :: module
     r6 = builtins.None :: object
-    r7 = r5 is not r6
+    r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
     r8 = unicode_1 :: static  ('typing')
@@ -380,7 +380,7 @@ L4:
     r19 = CPyDict_SetItem(r11, r18, r17)
     r20 = mypy_extensions :: module
     r21 = builtins.None :: object
-    r22 = r20 is not r21
+    r22 = r20 != r21
     if r22 goto L6 else goto L5 :: bool
 L5:
     r23 = unicode_4 :: static  ('mypy_extensions')
@@ -756,13 +756,13 @@ def f(a, b):
     a, b :: __main__.A
     r0 :: bool
 L0:
-    r0 = a is b
+    r0 = a == b
     return r0
 def f2(a, b):
     a, b :: __main__.A
     r0 :: bool
 L0:
-    r0 = a is not b
+    r0 = a != b
     return r0
 
 [case testEqDefined]
@@ -802,7 +802,7 @@ def Base.__ne__(self, rhs):
 L0:
     r0 = self.__eq__(rhs)
     r1 = load_address _Py_NotImplementedStruct
-    r2 = r0 is r1
+    r2 = r0 == r1
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = PyObject_Not(r0)
@@ -920,7 +920,7 @@ def Derived.__ne__(self, rhs):
 L0:
     r0 = self.__eq__(rhs)
     r1 = load_address _Py_NotImplementedStruct
-    r2 = r0 is r1
+    r2 = r0 == r1
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = PyObject_Not(r0)

--- a/mypyc/test-data/irbuild-nested.test
+++ b/mypyc/test-data/irbuild-nested.test
@@ -40,7 +40,7 @@ def inner_a_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -75,7 +75,7 @@ def second_b_first_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -101,7 +101,7 @@ def first_b_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -146,7 +146,7 @@ def inner_c_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -185,7 +185,7 @@ def inner_d_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -280,7 +280,7 @@ def inner_a_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -322,7 +322,7 @@ def inner_b_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -368,7 +368,7 @@ def inner_c_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -392,7 +392,7 @@ def inner_c_obj_0.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -454,7 +454,7 @@ def c_a_b_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -480,7 +480,7 @@ def b_a_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -549,7 +549,7 @@ def inner_f_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -573,7 +573,7 @@ def inner_f_obj_0.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -642,7 +642,7 @@ def foo_f_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -667,7 +667,7 @@ def bar_f_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -693,7 +693,7 @@ def baz_f_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -786,7 +786,7 @@ def __mypyc_lambda__0_f_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__
@@ -808,7 +808,7 @@ def __mypyc_lambda__1_f_obj.__get__(__mypyc_self__, instance, owner):
     r2 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = instance is r0
+    r1 = instance == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return __mypyc_self__

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -14,7 +14,7 @@ def f(x):
     r1 :: bool
 L0:
     r0 = box(None, 1)
-    r1 = x is r0
+    r1 = x == r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return 2
@@ -37,7 +37,7 @@ def f(x):
     r1, r2 :: bool
 L0:
     r0 = box(None, 1)
-    r1 = x is r0
+    r1 = x == r0
     r2 = !r1
     if r2 goto L1 else goto L2 :: bool
 L1:
@@ -61,7 +61,7 @@ def f(x):
     r1 :: bool
 L0:
     r0 = builtins.None :: object
-    r1 = x is not r0
+    r1 = x != r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     return 2
@@ -96,7 +96,7 @@ def f(x):
     r4 :: bool
 L0:
     r0 = builtins.None :: object
-    r1 = x is not r0
+    r1 = x != r0
     if r1 goto L1 else goto L3 :: bool
 L1:
     r2 = cast(__main__.A, x)
@@ -192,7 +192,7 @@ L0:
     r0 = A()
     y = r0
     r1 = box(None, 1)
-    r2 = x is r1
+    r2 = x == r1
     r3 = !r2
     if r3 goto L1 else goto L2 :: bool
 L1:
@@ -241,7 +241,7 @@ L4:
     x = r6
 L5:
     r7 = box(None, 1)
-    r8 = x is r7
+    r8 = x == r7
     r9 = !r8
     if r9 goto L6 else goto L7 :: bool
 L6:

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -659,7 +659,7 @@ def complex_msg(x, s):
     r7, r8 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = x is not r0
+    r1 = x != r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     r2 = cast(str, x)

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -10,7 +10,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ir.ops import (
     Environment, BasicBlock, Goto, Return, LoadInt, Assign, IncRef, DecRef, Branch,
     Call, Unbox, Box, TupleGet, GetAttr, PrimitiveOp, RegisterOp,
-    SetAttr, Op, Value, CallC, BinaryIntOp, LoadMem, GetElementPtr, LoadAddress
+    SetAttr, Op, Value, CallC, BinaryIntOp, LoadMem, GetElementPtr, LoadAddress, ComparisonOp
 )
 from mypyc.ir.rtypes import (
     RTuple, RInstance, int_rprimitive, bool_rprimitive, list_rprimitive,
@@ -246,19 +246,41 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
             """cpy_r_r0 = PyDict_Contains(cpy_r_d, cpy_r_o);""")
 
     def test_binary_int_op(self) -> None:
+        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.ADD, 1),
+                         """cpy_r_r0 = cpy_r_s1 + cpy_r_s2;""")
+        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.SUB, 1),
+                        """cpy_r_r00 = cpy_r_s1 - cpy_r_s2;""")
+        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.MUL, 1),
+                        """cpy_r_r01 = cpy_r_s1 * cpy_r_s2;""")
+        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.DIV, 1),
+                        """cpy_r_r02 = cpy_r_s1 / cpy_r_s2;""")
+        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.MOD, 1),
+                        """cpy_r_r03 = cpy_r_s1 % cpy_r_s2;""")
+        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.AND, 1),
+                        """cpy_r_r04 = cpy_r_s1 & cpy_r_s2;""")
+        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.OR, 1),
+                        """cpy_r_r05 = cpy_r_s1 | cpy_r_s2;""")
+        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.XOR, 1),
+                        """cpy_r_r06 = cpy_r_s1 ^ cpy_r_s2;""")
+        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.LEFT_SHIFT, 1),
+                        """cpy_r_r07 = cpy_r_s1 << cpy_r_s2;""")
+        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.RIGHT_SHIFT, 1),
+                        """cpy_r_r08 = cpy_r_s1 >> cpy_r_s2;""")
+
+    def test_comparison_op(self) -> None:
         # signed
-        self.assert_emit(BinaryIntOp(bool_rprimitive, self.s1, self.s2, BinaryIntOp.SLT, 1),
+        self.assert_emit(ComparisonOp(self.s1, self.s2, ComparisonOp.SLT, 1),
                          """cpy_r_r0 = (Py_ssize_t)cpy_r_s1 < (Py_ssize_t)cpy_r_s2;""")
-        self.assert_emit(BinaryIntOp(bool_rprimitive, self.i32, self.i32_1, BinaryIntOp.SLT, 1),
+        self.assert_emit(ComparisonOp(self.i32, self.i32_1, ComparisonOp.SLT, 1),
                          """cpy_r_r00 = cpy_r_i32 < cpy_r_i32_1;""")
-        self.assert_emit(BinaryIntOp(bool_rprimitive, self.i64, self.i64_1, BinaryIntOp.SLT, 1),
+        self.assert_emit(ComparisonOp(self.i64, self.i64_1, ComparisonOp.SLT, 1),
                          """cpy_r_r01 = cpy_r_i64 < cpy_r_i64_1;""")
         # unsigned
-        self.assert_emit(BinaryIntOp(bool_rprimitive, self.s1, self.s2, BinaryIntOp.ULT, 1),
+        self.assert_emit(ComparisonOp(self.s1, self.s2, ComparisonOp.ULT, 1),
                          """cpy_r_r02 = cpy_r_s1 < cpy_r_s2;""")
-        self.assert_emit(BinaryIntOp(bool_rprimitive, self.i32, self.i32_1, BinaryIntOp.ULT, 1),
+        self.assert_emit(ComparisonOp(self.i32, self.i32_1, ComparisonOp.ULT, 1),
                          """cpy_r_r03 = (uint32_t)cpy_r_i32 < (uint32_t)cpy_r_i32_1;""")
-        self.assert_emit(BinaryIntOp(bool_rprimitive, self.i64, self.i64_1, BinaryIntOp.ULT, 1),
+        self.assert_emit(ComparisonOp(self.i64, self.i64_1, ComparisonOp.ULT, 1),
                          """cpy_r_r04 = (uint64_t)cpy_r_i64 < (uint64_t)cpy_r_i64_1;""")
 
     def test_load_mem(self) -> None:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -262,9 +262,11 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                         """cpy_r_r05 = cpy_r_s1 | cpy_r_s2;""")
         self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.XOR, 1),
                         """cpy_r_r06 = cpy_r_s1 ^ cpy_r_s2;""")
-        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.LEFT_SHIFT, 1),
+        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2,
+                                     BinaryIntOp.LEFT_SHIFT, 1),
                         """cpy_r_r07 = cpy_r_s1 << cpy_r_s2;""")
-        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.RIGHT_SHIFT, 1),
+        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2,
+                                     BinaryIntOp.RIGHT_SHIFT, 1),
                         """cpy_r_r08 = cpy_r_s1 >> cpy_r_s2;""")
 
     def test_comparison_op(self) -> None:
@@ -282,6 +284,12 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_r03 = (uint32_t)cpy_r_i32 < (uint32_t)cpy_r_i32_1;""")
         self.assert_emit(ComparisonOp(self.i64, self.i64_1, ComparisonOp.ULT, 1),
                          """cpy_r_r04 = (uint64_t)cpy_r_i64 < (uint64_t)cpy_r_i64_1;""")
+
+        # object type
+        self.assert_emit(ComparisonOp(self.o, self.o2, ComparisonOp.EQ, 1),
+                         """cpy_r_r05 = cpy_r_o == cpy_r_o2;""")
+        self.assert_emit(ComparisonOp(self.o, self.o2, ComparisonOp.NEQ, 1),
+                         """cpy_r_r06 = cpy_r_o != cpy_r_o2;""")
 
     def test_load_mem(self) -> None:
         self.assert_emit(LoadMem(bool_rprimitive, self.ptr, None),


### PR DESCRIPTION
`BinaryIntOp` used to represent arithmetic, bitwise and comparison operations on integer operations. However, this design prevents us to compare pointer types and all comparison operations should be of boolean return type while manually specifying this in `BinaryIntOp` is both verbose and error-prone.

This PR splits `BinaryIntOp` and moves the comparison functionalities to `ComparsionOp`.

Based on the new op, this PR also implements `is` and `is not` op.