### PR TITLE
[mypyc] Make LoadGlobal print full name during pretty IR printing

### DIFF
--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1253,10 +1253,7 @@ class LoadGlobal(RegisterOp):
 
     def to_str(self, env: Environment) -> str:
         ann = '  ({})'.format(repr(self.ann)) if self.ann else ''
-        # return env.format('%r = %s%s', self, self.identifier, ann)
-        # TODO: a hack to prevent lots of failed IR tests when developing prototype
-        #       eventually we will change all the related tests
-        return env.format('%r = %s :: static%s', self, self.identifier[10:], ann)
+        return env.format('%r = load_global %s :: static%s', self, self.identifier, ann)
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_load_global(self)

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -732,7 +732,7 @@ L1:
 L2:
     r1 = CPy_CatchError()
     r2 = builtins :: module
-    r3 = unicode_1 :: static  ('Exception')
+    r3 = load_global CPyStatic_unicode_1 :: static  ('Exception')
     r4 = CPyObject_GetAttr(r2, r3)
     if is_error(r4) goto L8 (error at lol:4) else goto L3
 L3:

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -188,7 +188,7 @@ def g():
 L0:
 L1:
     r0 = builtins :: module
-    r1 = unicode_1 :: static  ('object')
+    r1 = load_global CPyStatic_unicode_1 :: static  ('object')
     r2 = CPyObject_GetAttr(r0, r1)
     if is_error(r2) goto L3 (error at g:3) else goto L2
 L2:
@@ -197,9 +197,9 @@ L2:
     if is_error(r3) goto L3 (error at g:3) else goto L10
 L3:
     r4 = CPy_CatchError()
-    r5 = unicode_2 :: static  ('weeee')
+    r5 = load_global CPyStatic_unicode_2 :: static  ('weeee')
     r6 = builtins :: module
-    r7 = unicode_3 :: static  ('print')
+    r7 = load_global CPyStatic_unicode_3 :: static  ('print')
     r8 = CPyObject_GetAttr(r6, r7)
     if is_error(r8) goto L6 (error at g:5) else goto L4
 L4:
@@ -256,7 +256,7 @@ def a():
 L0:
 L1:
     r0 = builtins :: module
-    r1 = unicode_1 :: static  ('print')
+    r1 = load_global CPyStatic_unicode_1 :: static  ('print')
     r2 = CPyObject_GetAttr(r0, r1)
     if is_error(r2) goto L5 (error at a:3) else goto L2
 L2:
@@ -264,7 +264,7 @@ L2:
     dec_ref r2
     if is_error(r3) goto L5 (error at a:3) else goto L20
 L3:
-    r4 = unicode_2 :: static  ('hi')
+    r4 = load_global CPyStatic_unicode_2 :: static  ('hi')
     inc_ref r4
     r5 = r4
 L4:
@@ -277,9 +277,9 @@ L5:
     r10 = CPy_CatchError()
     r6 = r10
 L6:
-    r11 = unicode_3 :: static  ('goodbye!')
+    r11 = load_global CPyStatic_unicode_3 :: static  ('goodbye!')
     r12 = builtins :: module
-    r13 = unicode_1 :: static  ('print')
+    r13 = load_global CPyStatic_unicode_1 :: static  ('print')
     r14 = CPyObject_GetAttr(r12, r13)
     if is_error(r14) goto L13 (error at a:6) else goto L7
 L7:
@@ -357,7 +357,7 @@ def lol(x):
     r5 :: object
 L0:
 L1:
-    r0 = unicode_3 :: static  ('foo')
+    r0 = load_global CPyStatic_unicode_3 :: static  ('foo')
     r1 = CPyObject_GetAttr(x, r0)
     if is_error(r1) goto L3 (error at lol:4) else goto L2
 L2:
@@ -365,7 +365,7 @@ L2:
     goto L4
 L3:
     r2 = CPy_CatchError()
-    r3 = unicode_4 :: static
+    r3 = load_global CPyStatic_unicode_4 :: static
     CPy_RestoreExcInfo(r2)
     dec_ref r2
     inc_ref r3
@@ -397,12 +397,12 @@ def lol(x):
     r9 :: object
 L0:
 L1:
-    r0 = unicode_3 :: static  ('foo')
+    r0 = load_global CPyStatic_unicode_3 :: static  ('foo')
     r1 = CPyObject_GetAttr(x, r0)
     if is_error(r1) goto L4 (error at lol:4) else goto L15
 L2:
     a = r1
-    r2 = unicode_4 :: static  ('bar')
+    r2 = load_global CPyStatic_unicode_4 :: static  ('bar')
     r3 = CPyObject_GetAttr(x, r2)
     if is_error(r3) goto L4 (error at lol:5) else goto L16
 L3:
@@ -469,13 +469,13 @@ def f(b):
     r8 :: bool
     r9 :: None
 L0:
-    r0 = unicode_1 :: static  ('a')
+    r0 = load_global CPyStatic_unicode_1 :: static  ('a')
     inc_ref r0
     u = r0
 L1:
     if b goto L10 else goto L11 :: bool
 L2:
-    r1 = unicode_2 :: static  ('b')
+    r1 = load_global CPyStatic_unicode_2 :: static  ('b')
     inc_ref r1
     v = r1
     r2 = v == u
@@ -483,7 +483,7 @@ L2:
     if r3 goto L11 else goto L1 :: bool
 L3:
     r4 = builtins :: module
-    r5 = unicode_3 :: static  ('print')
+    r5 = load_global CPyStatic_unicode_3 :: static  ('print')
     r6 = CPyObject_GetAttr(r4, r5)
     if is_error(r6) goto L12 (error at f:7) else goto L4
 L4:

--- a/mypyc/test-data/irbuild-any.test
+++ b/mypyc/test-data/irbuild-any.test
@@ -61,7 +61,7 @@ L0:
     a = r4
     r5 = unbox(int, a)
     n = r5
-    r6 = unicode_6 :: static  ('a')
+    r6 = load_global CPyStatic_unicode_6 :: static  ('a')
     r7 = box(int, n)
     r8 = PyObject_SetAttr(a, r6, r7)
     return 1

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -755,7 +755,7 @@ def f(x):
     r5 :: int
 L0:
     r0 = testmodule :: module
-    r1 = unicode_2 :: static  ('factorial')
+    r1 = load_global CPyStatic_unicode_2 :: static  ('factorial')
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = box(int, x)
     r4 = py_call(r2, r3)
@@ -779,7 +779,7 @@ def f(x):
     r5 :: int
 L0:
     r0 = __main__.globals :: static
-    r1 = unicode_2 :: static  ('g')
+    r1 = load_global CPyStatic_unicode_2 :: static  ('g')
     r2 = CPyDict_GetItem(r0, r1)
     r3 = box(int, x)
     r4 = py_call(r2, r3)
@@ -798,7 +798,7 @@ def f(x):
     r2, r3, r4 :: object
 L0:
     r0 = builtins :: module
-    r1 = unicode_1 :: static  ('print')
+    r1 = load_global CPyStatic_unicode_1 :: static  ('print')
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = box(short_int, 10)
     r4 = py_call(r2, r3)
@@ -816,7 +816,7 @@ def f(x):
     r2, r3, r4 :: object
 L0:
     r0 = builtins :: module
-    r1 = unicode_1 :: static  ('print')
+    r1 = load_global CPyStatic_unicode_1 :: static  ('print')
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = box(short_int, 10)
     r4 = py_call(r2, r3)
@@ -830,9 +830,9 @@ def f() -> str:
 def f():
     r0, x, r1 :: str
 L0:
-    r0 = unicode_1 :: static  ('some string')
+    r0 = load_global CPyStatic_unicode_1 :: static  ('some string')
     x = r0
-    r1 = unicode_2 :: static  ('some other string')
+    r1 = load_global CPyStatic_unicode_2 :: static  ('some other string')
     return r1
 
 [case testBytesLiteral]
@@ -843,9 +843,9 @@ def f() -> bytes:
 def f():
     r0, x, r1 :: object
 L0:
-    r0 = bytes_1 :: static  (b'\xf0')
+    r0 = load_global CPyStatic_bytes_1 :: static  (b'\xf0')
     x = r0
-    r1 = bytes_2 :: static  (b'1234')
+    r1 = load_global CPyStatic_bytes_2 :: static  (b'1234')
     return r1
 
 [case testPyMethodCall1]
@@ -863,11 +863,11 @@ def f(x):
     r4 :: object
     r5 :: int
 L0:
-    r0 = unicode_3 :: static  ('pop')
+    r0 = load_global CPyStatic_unicode_3 :: static  ('pop')
     r1 = py_method_call(x, r0)
     r2 = unbox(int, r1)
     y = r2
-    r3 = unicode_3 :: static  ('pop')
+    r3 = load_global CPyStatic_unicode_3 :: static  ('pop')
     r4 = py_method_call(x, r3)
     r5 = unbox(int, r4)
     return r5
@@ -1079,11 +1079,11 @@ def assign_and_return_float_sum():
     r5 :: object
     r6 :: float
 L0:
-    r0 = float_1 :: static  (1.0)
+    r0 = load_global CPyStatic_float_1 :: static  (1.0)
     f1 = r0
-    r1 = float_2 :: static  (2.0)
+    r1 = load_global CPyStatic_float_2 :: static  (2.0)
     f2 = r1
-    r2 = float_3 :: static  (3.0)
+    r2 = load_global CPyStatic_float_3 :: static  (3.0)
     f3 = r2
     r3 = PyNumber_Multiply(f1, f2)
     r4 = cast(float, r3)
@@ -1100,8 +1100,8 @@ def load():
     r1 :: float
     r2 :: object
 L0:
-    r0 = complex_1 :: static  (5j)
-    r1 = float_2 :: static  (1.0)
+    r0 = load_global CPyStatic_complex_1 :: static  (5j)
+    r1 = load_global CPyStatic_float_2 :: static  (1.0)
     r2 = PyNumber_Add(r0, r1)
     return r2
 
@@ -1119,19 +1119,19 @@ def big_int() -> None:
 def big_int():
     r0, a_62_bit, r1, max_62_bit, r2, b_63_bit, r3, c_63_bit, r4, max_63_bit, r5, d_64_bit, r6, max_32_bit, max_31_bit :: int
 L0:
-    r0 = int_1 :: static  (4611686018427387902)
+    r0 = load_global CPyStatic_int_1 :: static  (4611686018427387902)
     a_62_bit = r0
-    r1 = int_2 :: static  (4611686018427387903)
+    r1 = load_global CPyStatic_int_2 :: static  (4611686018427387903)
     max_62_bit = r1
-    r2 = int_3 :: static  (4611686018427387904)
+    r2 = load_global CPyStatic_int_3 :: static  (4611686018427387904)
     b_63_bit = r2
-    r3 = int_4 :: static  (9223372036854775806)
+    r3 = load_global CPyStatic_int_4 :: static  (9223372036854775806)
     c_63_bit = r3
-    r4 = int_5 :: static  (9223372036854775807)
+    r4 = load_global CPyStatic_int_5 :: static  (9223372036854775807)
     max_63_bit = r4
-    r5 = int_6 :: static  (9223372036854775808)
+    r5 = load_global CPyStatic_int_6 :: static  (9223372036854775808)
     d_64_bit = r5
-    r6 = int_7 :: static  (2147483647)
+    r6 = load_global CPyStatic_int_7 :: static  (2147483647)
     max_32_bit = r6
     max_31_bit = 2147483646
     return 1
@@ -1160,9 +1160,9 @@ def call_callable_type() -> float:
 def absolute_value(x):
     x :: int
     r0 :: bool
-    r1 :: native_int
+    r1 :: int64
     r2 :: bool
-    r3 :: native_int
+    r3 :: int64
     r4, r5, r6, r7 :: bool
     r8, r9 :: int
 L0:
@@ -1207,7 +1207,7 @@ L0:
 def return_float():
     r0 :: float
 L0:
-    r0 = float_3 :: static  (5.0)
+    r0 = load_global CPyStatic_float_3 :: static  (5.0)
     return r0
 def return_callable_type():
     r0 :: dict
@@ -1215,7 +1215,7 @@ def return_callable_type():
     r2 :: object
 L0:
     r0 = __main__.globals :: static
-    r1 = unicode_4 :: static  ('return_float')
+    r1 = load_global CPyStatic_unicode_4 :: static  ('return_float')
     r2 = CPyDict_GetItem(r0, r1)
     return r2
 def call_callable_type():
@@ -1251,7 +1251,7 @@ def call_python_function_with_keyword_arg(x):
     r6 :: int
 L0:
     r0 = load_address PyLong_Type
-    r1 = unicode_3 :: static  ('base')
+    r1 = load_global CPyStatic_unicode_3 :: static  ('base')
     r2 = PyTuple_Pack(1, x)
     r3 = box(short_int, 4)
     r4 = CPyDict_Build(1, r1, r3)
@@ -1277,18 +1277,18 @@ def call_python_method_with_keyword_args(xs, first, second):
     r15 :: dict
     r16 :: object
 L0:
-    r0 = unicode_4 :: static  ('insert')
+    r0 = load_global CPyStatic_unicode_4 :: static  ('insert')
     r1 = CPyObject_GetAttr(xs, r0)
-    r2 = unicode_5 :: static  ('x')
+    r2 = load_global CPyStatic_unicode_5 :: static  ('x')
     r3 = box(short_int, 0)
     r4 = PyTuple_Pack(1, r3)
     r5 = box(int, first)
     r6 = CPyDict_Build(1, r2, r5)
     r7 = py_call_with_kwargs(r1, r4, r6)
-    r8 = unicode_4 :: static  ('insert')
+    r8 = load_global CPyStatic_unicode_4 :: static  ('insert')
     r9 = CPyObject_GetAttr(xs, r8)
-    r10 = unicode_5 :: static  ('x')
-    r11 = unicode_6 :: static  ('i')
+    r10 = load_global CPyStatic_unicode_5 :: static  ('x')
+    r11 = load_global CPyStatic_unicode_6 :: static  ('i')
     r12 = PyTuple_Pack(0)
     r13 = box(int, second)
     r14 = box(short_int, 2)
@@ -1481,7 +1481,7 @@ def foo():
     r2, r3 :: object
 L0:
     r0 = builtins :: module
-    r1 = unicode_1 :: static  ('Exception')
+    r1 = load_global CPyStatic_unicode_1 :: static  ('Exception')
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = py_call(r2)
     CPy_Raise(r3)
@@ -1492,7 +1492,7 @@ def bar():
     r2 :: object
 L0:
     r0 = builtins :: module
-    r1 = unicode_1 :: static  ('Exception')
+    r1 = load_global CPyStatic_unicode_1 :: static  ('Exception')
     r2 = CPyObject_GetAttr(r0, r1)
     CPy_Raise(r2)
     unreachable
@@ -1514,11 +1514,11 @@ def f():
     r6, r7, r8 :: object
 L0:
     r0 = __main__.globals :: static
-    r1 = unicode_1 :: static  ('x')
+    r1 = load_global CPyStatic_unicode_1 :: static  ('x')
     r2 = CPyDict_GetItem(r0, r1)
     r3 = unbox(int, r2)
     r4 = builtins :: module
-    r5 = unicode_2 :: static  ('print')
+    r5 = load_global CPyStatic_unicode_2 :: static  ('print')
     r6 = CPyObject_GetAttr(r4, r5)
     r7 = box(int, r3)
     r8 = py_call(r6, r7)
@@ -1545,20 +1545,20 @@ L0:
     r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
-    r3 = unicode_0 :: static  ('builtins')
+    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
     r5 = __main__.globals :: static
-    r6 = unicode_1 :: static  ('x')
+    r6 = load_global CPyStatic_unicode_1 :: static  ('x')
     r7 = box(short_int, 2)
     r8 = CPyDict_SetItem(r5, r6, r7)
     r9 = __main__.globals :: static
-    r10 = unicode_1 :: static  ('x')
+    r10 = load_global CPyStatic_unicode_1 :: static  ('x')
     r11 = CPyDict_GetItem(r9, r10)
     r12 = unbox(int, r11)
     r13 = builtins :: module
-    r14 = unicode_2 :: static  ('print')
+    r14 = load_global CPyStatic_unicode_2 :: static  ('print')
     r15 = CPyObject_GetAttr(r13, r14)
     r16 = box(int, r12)
     r17 = py_call(r15, r16)
@@ -1582,7 +1582,7 @@ def f():
     r5 :: str
 L0:
     r0 = m :: module
-    r1 = unicode_2 :: static  ('f')
+    r1 = load_global CPyStatic_unicode_2 :: static  ('f')
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = box(short_int, 2)
     r4 = py_call(r2, r3)
@@ -1688,9 +1688,9 @@ def g():
     r2 :: str
     r3 :: None
 L0:
-    r0 = unicode_1 :: static  ('a')
+    r0 = load_global CPyStatic_unicode_1 :: static  ('a')
     r1 = f(0, r0)
-    r2 = unicode_2 :: static  ('b')
+    r2 = load_global CPyStatic_unicode_2 :: static  ('b')
     r3 = f(2, r2)
     return 1
 
@@ -1715,9 +1715,9 @@ def g(a):
     r2 :: str
     r3 :: None
 L0:
-    r0 = unicode_4 :: static  ('a')
+    r0 = load_global CPyStatic_unicode_4 :: static  ('a')
     r1 = a.f(0, r0)
-    r2 = unicode_5 :: static  ('b')
+    r2 = load_global CPyStatic_unicode_5 :: static  ('b')
     r3 = a.f(2, r2)
     return 1
 
@@ -1750,7 +1750,7 @@ def g():
 L0:
     r0 = (2, 4, 6)
     r1 = __main__.globals :: static
-    r2 = unicode_3 :: static  ('f')
+    r2 = load_global CPyStatic_unicode_3 :: static  ('f')
     r3 = CPyDict_GetItem(r1, r2)
     r4 = []
     r5 = box(tuple[int, int, int], r0)
@@ -1774,7 +1774,7 @@ def h():
 L0:
     r0 = (4, 6)
     r1 = __main__.globals :: static
-    r2 = unicode_3 :: static  ('f')
+    r2 = load_global CPyStatic_unicode_3 :: static  ('f')
     r3 = CPyDict_GetItem(r1, r2)
     r4 = box(short_int, 2)
     r5 = [r4]
@@ -1813,15 +1813,15 @@ def g():
     r13 :: object
     r14 :: tuple[int, int, int]
 L0:
-    r0 = unicode_3 :: static  ('a')
-    r1 = unicode_4 :: static  ('b')
-    r2 = unicode_5 :: static  ('c')
+    r0 = load_global CPyStatic_unicode_3 :: static  ('a')
+    r1 = load_global CPyStatic_unicode_4 :: static  ('b')
+    r2 = load_global CPyStatic_unicode_5 :: static  ('c')
     r3 = box(short_int, 2)
     r4 = box(short_int, 4)
     r5 = box(short_int, 6)
     r6 = CPyDict_Build(3, r0, r3, r1, r4, r2, r5)
     r7 = __main__.globals :: static
-    r8 = unicode_6 :: static  ('f')
+    r8 = load_global CPyStatic_unicode_6 :: static  ('f')
     r9 = CPyDict_GetItem(r7, r8)
     r10 = PyTuple_Pack(0)
     r11 = PyDict_New()
@@ -1841,13 +1841,13 @@ def h():
     r12 :: object
     r13 :: tuple[int, int, int]
 L0:
-    r0 = unicode_4 :: static  ('b')
-    r1 = unicode_5 :: static  ('c')
+    r0 = load_global CPyStatic_unicode_4 :: static  ('b')
+    r1 = load_global CPyStatic_unicode_5 :: static  ('c')
     r2 = box(short_int, 4)
     r3 = box(short_int, 6)
     r4 = CPyDict_Build(2, r0, r2, r1, r3)
     r5 = __main__.globals :: static
-    r6 = unicode_6 :: static  ('f')
+    r6 = load_global CPyStatic_unicode_6 :: static  ('f')
     r7 = CPyDict_GetItem(r5, r6)
     r8 = box(short_int, 2)
     r9 = PyTuple_Pack(1, r8)
@@ -1875,7 +1875,7 @@ L1:
 L2:
     if is_error(z) goto L3 else goto L4
 L3:
-    r0 = unicode_1 :: static  ('test')
+    r0 = load_global CPyStatic_unicode_1 :: static  ('test')
     z = r0
 L4:
     return 1
@@ -1914,7 +1914,7 @@ L1:
 L2:
     if is_error(z) goto L3 else goto L4
 L3:
-    r0 = unicode_4 :: static  ('test')
+    r0 = load_global CPyStatic_unicode_4 :: static  ('test')
     z = r0
 L4:
     return 1
@@ -2583,7 +2583,7 @@ L0:
     r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
-    r3 = unicode_0 :: static  ('builtins')
+    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
@@ -2592,81 +2592,81 @@ L2:
     r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
-    r8 = unicode_1 :: static  ('typing')
+    r8 = load_global CPyStatic_unicode_1 :: static  ('typing')
     r9 = PyImport_Import(r8)
     typing = r9 :: module
 L4:
     r10 = typing :: module
     r11 = __main__.globals :: static
-    r12 = unicode_2 :: static  ('List')
+    r12 = load_global CPyStatic_unicode_2 :: static  ('List')
     r13 = CPyObject_GetAttr(r10, r12)
-    r14 = unicode_2 :: static  ('List')
+    r14 = load_global CPyStatic_unicode_2 :: static  ('List')
     r15 = CPyDict_SetItem(r11, r14, r13)
-    r16 = unicode_3 :: static  ('NewType')
+    r16 = load_global CPyStatic_unicode_3 :: static  ('NewType')
     r17 = CPyObject_GetAttr(r10, r16)
-    r18 = unicode_3 :: static  ('NewType')
+    r18 = load_global CPyStatic_unicode_3 :: static  ('NewType')
     r19 = CPyDict_SetItem(r11, r18, r17)
-    r20 = unicode_4 :: static  ('NamedTuple')
+    r20 = load_global CPyStatic_unicode_4 :: static  ('NamedTuple')
     r21 = CPyObject_GetAttr(r10, r20)
-    r22 = unicode_4 :: static  ('NamedTuple')
+    r22 = load_global CPyStatic_unicode_4 :: static  ('NamedTuple')
     r23 = CPyDict_SetItem(r11, r22, r21)
-    r24 = unicode_5 :: static  ('Lol')
-    r25 = unicode_6 :: static  ('a')
+    r24 = load_global CPyStatic_unicode_5 :: static  ('Lol')
+    r25 = load_global CPyStatic_unicode_6 :: static  ('a')
     r26 = load_address PyLong_Type
     r27 = (r25, r26)
     r28 = box(tuple[str, object], r27)
-    r29 = unicode_7 :: static  ('b')
+    r29 = load_global CPyStatic_unicode_7 :: static  ('b')
     r30 = load_address PyUnicode_Type
     r31 = (r29, r30)
     r32 = box(tuple[str, object], r31)
     r33 = (r28, r32)
     r34 = box(tuple[object, object], r33)
     r35 = __main__.globals :: static
-    r36 = unicode_4 :: static  ('NamedTuple')
+    r36 = load_global CPyStatic_unicode_4 :: static  ('NamedTuple')
     r37 = CPyDict_GetItem(r35, r36)
     r38 = py_call(r37, r24, r34)
     r39 = __main__.globals :: static
-    r40 = unicode_5 :: static  ('Lol')
+    r40 = load_global CPyStatic_unicode_5 :: static  ('Lol')
     r41 = CPyDict_SetItem(r39, r40, r38)
-    r42 = unicode_8 :: static
+    r42 = load_global CPyStatic_unicode_8 :: static
     r43 = __main__.globals :: static
-    r44 = unicode_5 :: static  ('Lol')
+    r44 = load_global CPyStatic_unicode_5 :: static  ('Lol')
     r45 = CPyDict_GetItem(r43, r44)
     r46 = box(short_int, 2)
     r47 = py_call(r45, r46, r42)
     r48 = cast(tuple, r47)
     r49 = __main__.globals :: static
-    r50 = unicode_9 :: static  ('x')
+    r50 = load_global CPyStatic_unicode_9 :: static  ('x')
     r51 = CPyDict_SetItem(r49, r50, r48)
     r52 = __main__.globals :: static
-    r53 = unicode_2 :: static  ('List')
+    r53 = load_global CPyStatic_unicode_2 :: static  ('List')
     r54 = CPyDict_GetItem(r52, r53)
     r55 = load_address PyLong_Type
     r56 = PyObject_GetItem(r54, r55)
     r57 = __main__.globals :: static
-    r58 = unicode_10 :: static  ('Foo')
+    r58 = load_global CPyStatic_unicode_10 :: static  ('Foo')
     r59 = CPyDict_SetItem(r57, r58, r56)
-    r60 = unicode_11 :: static  ('Bar')
+    r60 = load_global CPyStatic_unicode_11 :: static  ('Bar')
     r61 = __main__.globals :: static
-    r62 = unicode_10 :: static  ('Foo')
+    r62 = load_global CPyStatic_unicode_10 :: static  ('Foo')
     r63 = CPyDict_GetItem(r61, r62)
     r64 = __main__.globals :: static
-    r65 = unicode_3 :: static  ('NewType')
+    r65 = load_global CPyStatic_unicode_3 :: static  ('NewType')
     r66 = CPyDict_GetItem(r64, r65)
     r67 = py_call(r66, r60, r63)
     r68 = __main__.globals :: static
-    r69 = unicode_11 :: static  ('Bar')
+    r69 = load_global CPyStatic_unicode_11 :: static  ('Bar')
     r70 = CPyDict_SetItem(r68, r69, r67)
     r71 = box(short_int, 2)
     r72 = box(short_int, 4)
     r73 = box(short_int, 6)
     r74 = [r71, r72, r73]
     r75 = __main__.globals :: static
-    r76 = unicode_11 :: static  ('Bar')
+    r76 = load_global CPyStatic_unicode_11 :: static  ('Bar')
     r77 = CPyDict_GetItem(r75, r76)
     r78 = py_call(r77, r74)
     r79 = __main__.globals :: static
-    r80 = unicode_12 :: static  ('y')
+    r80 = load_global CPyStatic_unicode_12 :: static  ('y')
     r81 = CPyDict_SetItem(r79, r80, r78)
     return 1
 
@@ -2822,16 +2822,16 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.g
     g = r1
-    r2 = unicode_3 :: static  ('Entering')
+    r2 = load_global CPyStatic_unicode_3 :: static  ('Entering')
     r3 = builtins :: module
-    r4 = unicode_4 :: static  ('print')
+    r4 = load_global CPyStatic_unicode_4 :: static  ('print')
     r5 = CPyObject_GetAttr(r3, r4)
     r6 = py_call(r5, r2)
     r7 = r0.f
     r8 = py_call(r7)
-    r9 = unicode_5 :: static  ('Exited')
+    r9 = load_global CPyStatic_unicode_5 :: static  ('Exited')
     r10 = builtins :: module
-    r11 = unicode_4 :: static  ('print')
+    r11 = load_global CPyStatic_unicode_4 :: static  ('print')
     r12 = CPyObject_GetAttr(r10, r11)
     r13 = py_call(r12, r9)
     return 1
@@ -2879,16 +2879,16 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.g
     g = r1
-    r2 = unicode_6 :: static  ('---')
+    r2 = load_global CPyStatic_unicode_6 :: static  ('---')
     r3 = builtins :: module
-    r4 = unicode_4 :: static  ('print')
+    r4 = load_global CPyStatic_unicode_4 :: static  ('print')
     r5 = CPyObject_GetAttr(r3, r4)
     r6 = py_call(r5, r2)
     r7 = r0.f
     r8 = py_call(r7)
-    r9 = unicode_6 :: static  ('---')
+    r9 = load_global CPyStatic_unicode_6 :: static  ('---')
     r10 = builtins :: module
-    r11 = unicode_4 :: static  ('print')
+    r11 = load_global CPyStatic_unicode_4 :: static  ('print')
     r12 = CPyObject_GetAttr(r10, r11)
     r13 = py_call(r12, r9)
     return 1
@@ -2932,9 +2932,9 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.d
     d = r1
-    r2 = unicode_7 :: static  ('d')
+    r2 = load_global CPyStatic_unicode_7 :: static  ('d')
     r3 = builtins :: module
-    r4 = unicode_4 :: static  ('print')
+    r4 = load_global CPyStatic_unicode_4 :: static  ('print')
     r5 = CPyObject_GetAttr(r3, r4)
     r6 = py_call(r5, r2)
     return 1
@@ -2958,17 +2958,17 @@ L0:
     r1 = __mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     r3 = __main__.globals :: static
-    r4 = unicode_8 :: static  ('b')
+    r4 = load_global CPyStatic_unicode_8 :: static  ('b')
     r5 = CPyDict_GetItem(r3, r4)
     r6 = py_call(r5, r1)
     r7 = __main__.globals :: static
-    r8 = unicode_9 :: static  ('a')
+    r8 = load_global CPyStatic_unicode_9 :: static  ('a')
     r9 = CPyDict_GetItem(r7, r8)
     r10 = py_call(r9, r6)
     r0.d = r10; r11 = is_error
-    r12 = unicode_10 :: static  ('c')
+    r12 = load_global CPyStatic_unicode_10 :: static  ('c')
     r13 = builtins :: module
-    r14 = unicode_4 :: static  ('print')
+    r14 = load_global CPyStatic_unicode_4 :: static  ('print')
     r15 = CPyObject_GetAttr(r13, r14)
     r16 = py_call(r15, r12)
     r17 = r0.d
@@ -3005,7 +3005,7 @@ L0:
     r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
-    r3 = unicode_0 :: static  ('builtins')
+    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
@@ -3014,29 +3014,29 @@ L2:
     r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
-    r8 = unicode_1 :: static  ('typing')
+    r8 = load_global CPyStatic_unicode_1 :: static  ('typing')
     r9 = PyImport_Import(r8)
     typing = r9 :: module
 L4:
     r10 = typing :: module
     r11 = __main__.globals :: static
-    r12 = unicode_2 :: static  ('Callable')
+    r12 = load_global CPyStatic_unicode_2 :: static  ('Callable')
     r13 = CPyObject_GetAttr(r10, r12)
-    r14 = unicode_2 :: static  ('Callable')
+    r14 = load_global CPyStatic_unicode_2 :: static  ('Callable')
     r15 = CPyDict_SetItem(r11, r14, r13)
     r16 = __main__.globals :: static
-    r17 = unicode_11 :: static  ('__mypyc_c_decorator_helper__')
+    r17 = load_global CPyStatic_unicode_11 :: static  ('__mypyc_c_decorator_helper__')
     r18 = CPyDict_GetItem(r16, r17)
     r19 = __main__.globals :: static
-    r20 = unicode_8 :: static  ('b')
+    r20 = load_global CPyStatic_unicode_8 :: static  ('b')
     r21 = CPyDict_GetItem(r19, r20)
     r22 = py_call(r21, r18)
     r23 = __main__.globals :: static
-    r24 = unicode_9 :: static  ('a')
+    r24 = load_global CPyStatic_unicode_9 :: static  ('a')
     r25 = CPyDict_GetItem(r23, r24)
     r26 = py_call(r25, r22)
     r27 = __main__.globals :: static
-    r28 = unicode_10 :: static  ('c')
+    r28 = load_global CPyStatic_unicode_10 :: static  ('c')
     r29 = CPyDict_SetItem(r27, r28, r26)
     return 1
 
@@ -3080,16 +3080,16 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.g
     g = r1
-    r2 = unicode_3 :: static  ('Entering')
+    r2 = load_global CPyStatic_unicode_3 :: static  ('Entering')
     r3 = builtins :: module
-    r4 = unicode_4 :: static  ('print')
+    r4 = load_global CPyStatic_unicode_4 :: static  ('print')
     r5 = CPyObject_GetAttr(r3, r4)
     r6 = py_call(r5, r2)
     r7 = r0.f
     r8 = py_call(r7)
-    r9 = unicode_5 :: static  ('Exited')
+    r9 = load_global CPyStatic_unicode_5 :: static  ('Exited')
     r10 = builtins :: module
-    r11 = unicode_4 :: static  ('print')
+    r11 = load_global CPyStatic_unicode_4 :: static  ('print')
     r12 = CPyObject_GetAttr(r10, r11)
     r13 = py_call(r12, r9)
     return 1
@@ -3127,7 +3127,7 @@ L0:
     r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
-    r3 = unicode_0 :: static  ('builtins')
+    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
@@ -3136,15 +3136,15 @@ L2:
     r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
-    r8 = unicode_1 :: static  ('typing')
+    r8 = load_global CPyStatic_unicode_1 :: static  ('typing')
     r9 = PyImport_Import(r8)
     typing = r9 :: module
 L4:
     r10 = typing :: module
     r11 = __main__.globals :: static
-    r12 = unicode_2 :: static  ('Callable')
+    r12 = load_global CPyStatic_unicode_2 :: static  ('Callable')
     r13 = CPyObject_GetAttr(r10, r12)
-    r14 = unicode_2 :: static  ('Callable')
+    r14 = load_global CPyStatic_unicode_2 :: static  ('Callable')
     r15 = CPyDict_SetItem(r11, r14, r13)
     return 1
 
@@ -3252,8 +3252,8 @@ def lol(x):
     r2 :: int32
     r3 :: object
 L0:
-    r0 = unicode_5 :: static  ('x')
-    r1 = unicode_6 :: static  ('5')
+    r0 = load_global CPyStatic_unicode_5 :: static  ('x')
+    r1 = load_global CPyStatic_unicode_6 :: static  ('5')
     r2 = PyObject_SetAttr(x, r0, r1)
     r3 = box(None, 1)
     return r3
@@ -3299,10 +3299,10 @@ def f(a):
 L0:
     if a goto L1 else goto L2 :: bool
 L1:
-    r0 = unicode_3 :: static  ('x')
+    r0 = load_global CPyStatic_unicode_3 :: static  ('x')
     return r0
 L2:
-    r1 = unicode_4 :: static  ('y')
+    r1 = load_global CPyStatic_unicode_4 :: static  ('y')
     return r1
 L3:
     unreachable
@@ -3492,7 +3492,7 @@ def f(x):
     r2, r3, r4 :: object
 L0:
     r0 = builtins :: module
-    r1 = unicode_1 :: static  ('reveal_type')
+    r1 = load_global CPyStatic_unicode_1 :: static  ('reveal_type')
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = box(int, x)
     r4 = py_call(r2, r3)

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -1160,9 +1160,9 @@ def call_callable_type() -> float:
 def absolute_value(x):
     x :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bool
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bool
     r8, r9 :: int
 L0:

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -78,7 +78,7 @@ def g(a):
     r0 :: str
     r1 :: int
 L0:
-    r0 = unicode_4 :: static  ('hi')
+    r0 = load_global CPyStatic_unicode_4 :: static  ('hi')
     r1 = a.f(2, r0)
     return 1
 
@@ -355,7 +355,7 @@ L0:
     r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
-    r3 = unicode_0 :: static  ('builtins')
+    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
@@ -364,87 +364,87 @@ L2:
     r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
-    r8 = unicode_1 :: static  ('typing')
+    r8 = load_global CPyStatic_unicode_1 :: static  ('typing')
     r9 = PyImport_Import(r8)
     typing = r9 :: module
 L4:
     r10 = typing :: module
     r11 = __main__.globals :: static
-    r12 = unicode_2 :: static  ('TypeVar')
+    r12 = load_global CPyStatic_unicode_2 :: static  ('TypeVar')
     r13 = CPyObject_GetAttr(r10, r12)
-    r14 = unicode_2 :: static  ('TypeVar')
+    r14 = load_global CPyStatic_unicode_2 :: static  ('TypeVar')
     r15 = CPyDict_SetItem(r11, r14, r13)
-    r16 = unicode_3 :: static  ('Generic')
+    r16 = load_global CPyStatic_unicode_3 :: static  ('Generic')
     r17 = CPyObject_GetAttr(r10, r16)
-    r18 = unicode_3 :: static  ('Generic')
+    r18 = load_global CPyStatic_unicode_3 :: static  ('Generic')
     r19 = CPyDict_SetItem(r11, r18, r17)
     r20 = mypy_extensions :: module
     r21 = load_address _Py_NoneStruct
     r22 = r20 != r21
     if r22 goto L6 else goto L5 :: bool
 L5:
-    r23 = unicode_4 :: static  ('mypy_extensions')
+    r23 = load_global CPyStatic_unicode_4 :: static  ('mypy_extensions')
     r24 = PyImport_Import(r23)
     mypy_extensions = r24 :: module
 L6:
     r25 = mypy_extensions :: module
     r26 = __main__.globals :: static
-    r27 = unicode_5 :: static  ('trait')
+    r27 = load_global CPyStatic_unicode_5 :: static  ('trait')
     r28 = CPyObject_GetAttr(r25, r27)
-    r29 = unicode_5 :: static  ('trait')
+    r29 = load_global CPyStatic_unicode_5 :: static  ('trait')
     r30 = CPyDict_SetItem(r26, r29, r28)
-    r31 = unicode_6 :: static  ('T')
+    r31 = load_global CPyStatic_unicode_6 :: static  ('T')
     r32 = __main__.globals :: static
-    r33 = unicode_2 :: static  ('TypeVar')
+    r33 = load_global CPyStatic_unicode_2 :: static  ('TypeVar')
     r34 = CPyDict_GetItem(r32, r33)
     r35 = py_call(r34, r31)
     r36 = __main__.globals :: static
-    r37 = unicode_6 :: static  ('T')
+    r37 = load_global CPyStatic_unicode_6 :: static  ('T')
     r38 = CPyDict_SetItem(r36, r37, r35)
     r39 = <error> :: object
-    r40 = unicode_7 :: static  ('__main__')
+    r40 = load_global CPyStatic_unicode_7 :: static  ('__main__')
     r41 = __main__.C_template :: type
     r42 = pytype_from_template(r41, r39, r40)
     r43 = C_trait_vtable_setup()
-    r44 = unicode_8 :: static  ('__mypyc_attrs__')
+    r44 = load_global CPyStatic_unicode_8 :: static  ('__mypyc_attrs__')
     r45 = PyTuple_Pack(0)
     r46 = PyObject_SetAttr(r42, r44, r45)
     __main__.C = r42 :: type
     r47 = __main__.globals :: static
-    r48 = unicode_9 :: static  ('C')
+    r48 = load_global CPyStatic_unicode_9 :: static  ('C')
     r49 = CPyDict_SetItem(r47, r48, r42)
     r50 = <error> :: object
-    r51 = unicode_7 :: static  ('__main__')
+    r51 = load_global CPyStatic_unicode_7 :: static  ('__main__')
     r52 = __main__.S_template :: type
     r53 = pytype_from_template(r52, r50, r51)
-    r54 = unicode_8 :: static  ('__mypyc_attrs__')
+    r54 = load_global CPyStatic_unicode_8 :: static  ('__mypyc_attrs__')
     r55 = PyTuple_Pack(0)
     r56 = PyObject_SetAttr(r53, r54, r55)
     __main__.S = r53 :: type
     r57 = __main__.globals :: static
-    r58 = unicode_10 :: static  ('S')
+    r58 = load_global CPyStatic_unicode_10 :: static  ('S')
     r59 = CPyDict_SetItem(r57, r58, r53)
     r60 = __main__.C :: type
     r61 = __main__.S :: type
     r62 = __main__.globals :: static
-    r63 = unicode_3 :: static  ('Generic')
+    r63 = load_global CPyStatic_unicode_3 :: static  ('Generic')
     r64 = CPyDict_GetItem(r62, r63)
     r65 = __main__.globals :: static
-    r66 = unicode_6 :: static  ('T')
+    r66 = load_global CPyStatic_unicode_6 :: static  ('T')
     r67 = CPyDict_GetItem(r65, r66)
     r68 = PyObject_GetItem(r64, r67)
     r69 = PyTuple_Pack(3, r60, r61, r68)
-    r70 = unicode_7 :: static  ('__main__')
+    r70 = load_global CPyStatic_unicode_7 :: static  ('__main__')
     r71 = __main__.D_template :: type
     r72 = pytype_from_template(r71, r69, r70)
     r73 = D_trait_vtable_setup()
-    r74 = unicode_8 :: static  ('__mypyc_attrs__')
-    r75 = unicode_11 :: static  ('__dict__')
+    r74 = load_global CPyStatic_unicode_8 :: static  ('__mypyc_attrs__')
+    r75 = load_global CPyStatic_unicode_11 :: static  ('__dict__')
     r76 = PyTuple_Pack(1, r75)
     r77 = PyObject_SetAttr(r72, r74, r76)
     __main__.D = r72 :: type
     r78 = __main__.globals :: static
-    r79 = unicode_12 :: static  ('D')
+    r79 = load_global CPyStatic_unicode_12 :: static  ('D')
     r80 = CPyDict_SetItem(r78, r79, r72)
     return 1
 
@@ -736,7 +736,7 @@ def f():
     r3 :: int
 L0:
     r0 = __main__.A :: type
-    r1 = unicode_6 :: static  ('x')
+    r1 = load_global CPyStatic_unicode_6 :: static  ('x')
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = unbox(int, r2)
     return r3
@@ -900,7 +900,7 @@ def fOpt2(a, b):
     r1 :: object
     r2 :: bool
 L0:
-    r0 = unicode_1 :: static  ('__ne__')
+    r0 = load_global CPyStatic_unicode_1 :: static  ('__ne__')
     r1 = py_method_call(a, r0, b)
     r2 = unbox(bool, r1)
     return r2
@@ -969,7 +969,7 @@ def B.__mypyc_defaults_setup(__mypyc_self__):
 L0:
     __mypyc_self__.x = 20; r0 = is_error
     r1 = __main__.globals :: static
-    r2 = unicode_9 :: static  ('LOL')
+    r2 = load_global CPyStatic_unicode_9 :: static  ('LOL')
     r3 = CPyDict_GetItem(r1, r2)
     r4 = cast(str, r3)
     __mypyc_self__.y = r4; r5 = is_error

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -50,7 +50,7 @@ def f(x):
     r1, r2 :: object
     r3, d :: dict
 L0:
-    r0 = unicode_1 :: static
+    r0 = load_global CPyStatic_unicode_1 :: static
     r1 = box(short_int, 2)
     r2 = box(short_int, 4)
     r3 = CPyDict_Build(2, r1, r2, r0, x)
@@ -183,7 +183,7 @@ def f(x, y):
     r4 :: object
     r5 :: int32
 L0:
-    r0 = unicode_3 :: static  ('z')
+    r0 = load_global CPyStatic_unicode_3 :: static  ('z')
     r1 = box(short_int, 4)
     r2 = CPyDict_Build(1, x, r1)
     r3 = CPyDict_UpdateInDisplay(r2, y)

--- a/mypyc/test-data/irbuild-nested.test
+++ b/mypyc/test-data/irbuild-nested.test
@@ -93,7 +93,7 @@ L0:
     r1 = r0.__mypyc_env__
     r2 = r0.second
     second = r2
-    r3 = unicode_3 :: static  ('b.first.second: nested function')
+    r3 = load_global CPyStatic_unicode_3 :: static  ('b.first.second: nested function')
     return r3
 def first_b_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
@@ -163,7 +163,7 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
     inner = r1
-    r2 = unicode_4 :: static  ('!')
+    r2 = load_global CPyStatic_unicode_4 :: static  ('!')
     r3 = PyUnicode_Concat(s, r2)
     return r3
 def c(num):
@@ -202,7 +202,7 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
     inner = r1
-    r2 = unicode_5 :: static  ('?')
+    r2 = load_global CPyStatic_unicode_5 :: static  ('?')
     r3 = PyUnicode_Concat(s, r2)
     return r3
 def d(num):
@@ -220,12 +220,12 @@ L0:
     r1 = inner_d_obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     r0.inner = r1; r3 = is_error
-    r4 = unicode_6 :: static  ('one')
+    r4 = load_global CPyStatic_unicode_6 :: static  ('one')
     r5 = r0.inner
     r6 = py_call(r5, r4)
     r7 = cast(str, r6)
     a = r7
-    r8 = unicode_7 :: static  ('two')
+    r8 = load_global CPyStatic_unicode_7 :: static  ('two')
     r9 = r0.inner
     r10 = py_call(r9, r8)
     r11 = cast(str, r10)
@@ -234,17 +234,17 @@ L0:
 def inner():
     r0 :: str
 L0:
-    r0 = unicode_8 :: static  ('inner: normal function')
+    r0 = load_global CPyStatic_unicode_8 :: static  ('inner: normal function')
     return r0
 def first():
     r0 :: str
 L0:
-    r0 = unicode_9 :: static  ('first: normal function')
+    r0 = load_global CPyStatic_unicode_9 :: static  ('first: normal function')
     return r0
 def second():
     r0 :: str
 L0:
-    r0 = unicode_10 :: static  ('second: normal function')
+    r0 = load_global CPyStatic_unicode_10 :: static  ('second: normal function')
     return r0
 
 [case testFreeVars]
@@ -384,7 +384,7 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
     inner = r1
-    r2 = unicode_3 :: static  ('f.inner: first definition')
+    r2 = load_global CPyStatic_unicode_3 :: static  ('f.inner: first definition')
     return r2
 def inner_c_obj_0.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
@@ -408,7 +408,7 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
     inner = r1
-    r2 = unicode_4 :: static  ('f.inner: second definition')
+    r2 = load_global CPyStatic_unicode_4 :: static  ('f.inner: second definition')
     return r2
 def c(flag):
     flag :: bool
@@ -565,7 +565,7 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
     inner = r1
-    r2 = unicode_1 :: static  ('f.inner: first definition')
+    r2 = load_global CPyStatic_unicode_1 :: static  ('f.inner: first definition')
     return r2
 def inner_f_obj_0.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
@@ -589,7 +589,7 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
     inner = r1
-    r2 = unicode_2 :: static  ('f.inner: second definition')
+    r2 = load_global CPyStatic_unicode_2 :: static  ('f.inner: second definition')
     return r2
 def f(flag):
     flag :: bool

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -344,7 +344,7 @@ def set(o, s):
     s, r0 :: str
     r1 :: int32
 L0:
-    r0 = unicode_5 :: static  ('a')
+    r0 = load_global CPyStatic_unicode_5 :: static  ('a')
     r1 = PyObject_SetAttr(o, r0, s)
     return 1
 
@@ -462,7 +462,7 @@ L1:
     goto L3
 L2:
     r5 = o
-    r6 = unicode_7 :: static  ('x')
+    r6 = load_global CPyStatic_unicode_7 :: static  ('x')
     r7 = CPyObject_GetAttr(r5, r6)
     r8 = unbox(int, r7)
     r0 = r8
@@ -490,7 +490,7 @@ L1:
     goto L3
 L2:
     r5 = o
-    r6 = unicode_7 :: static  ('x')
+    r6 = load_global CPyStatic_unicode_7 :: static  ('x')
     r7 = CPyObject_GetAttr(r5, r6)
     r8 = unbox(int, r7)
     r0 = r8
@@ -518,7 +518,7 @@ def f(o):
     r3 :: object
 L0:
     r1 = o
-    r2 = unicode_6 :: static  ('x')
+    r2 = load_global CPyStatic_unicode_6 :: static  ('x')
     r3 = CPyObject_GetAttr(r1, r2)
     r0 = r3
 L1:

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -668,7 +668,7 @@ L1:
     if r4 goto L3 else goto L2 :: bool
 L2:
     r5 = builtins :: module
-    r6 = unicode_3 :: static  ('AssertionError')
+    r6 = load_global CPyStatic_unicode_3 :: static  ('AssertionError')
     r7 = CPyObject_GetAttr(r5, r6)
     r8 = py_call(r7, s)
     CPy_Raise(r8)
@@ -739,13 +739,13 @@ def delDict():
     r5 :: str
     r6 :: int32
 L0:
-    r0 = unicode_1 :: static  ('one')
-    r1 = unicode_2 :: static  ('two')
+    r0 = load_global CPyStatic_unicode_1 :: static  ('one')
+    r1 = load_global CPyStatic_unicode_2 :: static  ('two')
     r2 = box(short_int, 2)
     r3 = box(short_int, 4)
     r4 = CPyDict_Build(2, r0, r2, r1, r3)
     d = r4
-    r5 = unicode_1 :: static  ('one')
+    r5 = load_global CPyStatic_unicode_1 :: static  ('one')
     r6 = PyObject_DelItem(d, r5)
     return 1
 def delDictMultiple():
@@ -755,18 +755,18 @@ def delDictMultiple():
     r9, r10 :: str
     r11, r12 :: int32
 L0:
-    r0 = unicode_1 :: static  ('one')
-    r1 = unicode_2 :: static  ('two')
-    r2 = unicode_3 :: static  ('three')
-    r3 = unicode_4 :: static  ('four')
+    r0 = load_global CPyStatic_unicode_1 :: static  ('one')
+    r1 = load_global CPyStatic_unicode_2 :: static  ('two')
+    r2 = load_global CPyStatic_unicode_3 :: static  ('three')
+    r3 = load_global CPyStatic_unicode_4 :: static  ('four')
     r4 = box(short_int, 2)
     r5 = box(short_int, 4)
     r6 = box(short_int, 6)
     r7 = box(short_int, 8)
     r8 = CPyDict_Build(4, r0, r4, r1, r5, r2, r6, r3, r7)
     d = r8
-    r9 = unicode_1 :: static  ('one')
-    r10 = unicode_4 :: static  ('four')
+    r9 = load_global CPyStatic_unicode_1 :: static  ('one')
+    r10 = load_global CPyStatic_unicode_4 :: static  ('four')
     r11 = PyObject_DelItem(d, r9)
     r12 = PyObject_DelItem(d, r10)
     return 1
@@ -798,7 +798,7 @@ def delAttribute():
 L0:
     r0 = Dummy(2, 4)
     dummy = r0
-    r1 = unicode_3 :: static  ('x')
+    r1 = load_global CPyStatic_unicode_3 :: static  ('x')
     r2 = PyObject_DelAttr(dummy, r1)
     return 1
 def delAttributeMultiple():
@@ -810,9 +810,9 @@ def delAttributeMultiple():
 L0:
     r0 = Dummy(2, 4)
     dummy = r0
-    r1 = unicode_3 :: static  ('x')
+    r1 = load_global CPyStatic_unicode_3 :: static  ('x')
     r2 = PyObject_DelAttr(dummy, r1)
-    r3 = unicode_4 :: static  ('y')
+    r3 = load_global CPyStatic_unicode_4 :: static  ('y')
     r4 = PyObject_DelAttr(dummy, r3)
     return 1
 

--- a/mypyc/test-data/irbuild-try.test
+++ b/mypyc/test-data/irbuild-try.test
@@ -18,15 +18,15 @@ def g():
 L0:
 L1:
     r0 = builtins :: module
-    r1 = unicode_1 :: static  ('object')
+    r1 = load_global CPyStatic_unicode_1 :: static  ('object')
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = py_call(r2)
     goto L5
 L2: (handler for L1)
     r4 = CPy_CatchError()
-    r5 = unicode_2 :: static  ('weeee')
+    r5 = load_global CPyStatic_unicode_2 :: static  ('weeee')
     r6 = builtins :: module
-    r7 = unicode_3 :: static  ('print')
+    r7 = load_global CPyStatic_unicode_3 :: static  ('print')
     r8 = CPyObject_GetAttr(r6, r7)
     r9 = py_call(r8, r5)
 L3:
@@ -66,20 +66,20 @@ L1:
     if b goto L2 else goto L3 :: bool
 L2:
     r0 = builtins :: module
-    r1 = unicode_1 :: static  ('object')
+    r1 = load_global CPyStatic_unicode_1 :: static  ('object')
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = py_call(r2)
     goto L4
 L3:
-    r4 = unicode_2 :: static  ('hi')
+    r4 = load_global CPyStatic_unicode_2 :: static  ('hi')
     r5 = PyObject_Str(r4)
 L4:
     goto L8
 L5: (handler for L1, L2, L3, L4)
     r6 = CPy_CatchError()
-    r7 = unicode_3 :: static  ('weeee')
+    r7 = load_global CPyStatic_unicode_3 :: static  ('weeee')
     r8 = builtins :: module
-    r9 = unicode_4 :: static  ('print')
+    r9 = load_global CPyStatic_unicode_4 :: static  ('print')
     r10 = CPyObject_GetAttr(r8, r9)
     r11 = py_call(r10, r7)
 L6:
@@ -129,30 +129,30 @@ def g():
     r27 :: bool
 L0:
 L1:
-    r0 = unicode_1 :: static  ('a')
+    r0 = load_global CPyStatic_unicode_1 :: static  ('a')
     r1 = builtins :: module
-    r2 = unicode_2 :: static  ('print')
+    r2 = load_global CPyStatic_unicode_2 :: static  ('print')
     r3 = CPyObject_GetAttr(r1, r2)
     r4 = py_call(r3, r0)
 L2:
     r5 = builtins :: module
-    r6 = unicode_3 :: static  ('object')
+    r6 = load_global CPyStatic_unicode_3 :: static  ('object')
     r7 = CPyObject_GetAttr(r5, r6)
     r8 = py_call(r7)
     goto L8
 L3: (handler for L2)
     r9 = CPy_CatchError()
     r10 = builtins :: module
-    r11 = unicode_4 :: static  ('AttributeError')
+    r11 = load_global CPyStatic_unicode_4 :: static  ('AttributeError')
     r12 = CPyObject_GetAttr(r10, r11)
     r13 = CPy_ExceptionMatches(r12)
     if r13 goto L4 else goto L5 :: bool
 L4:
     r14 = CPy_GetExcValue()
     e = r14
-    r15 = unicode_5 :: static  ('b')
+    r15 = load_global CPyStatic_unicode_5 :: static  ('b')
     r16 = builtins :: module
-    r17 = unicode_2 :: static  ('print')
+    r17 = load_global CPyStatic_unicode_2 :: static  ('print')
     r18 = CPyObject_GetAttr(r16, r17)
     r19 = py_call(r18, r15, e)
     goto L6
@@ -170,9 +170,9 @@ L8:
     goto L12
 L9: (handler for L1, L6, L7, L8)
     r21 = CPy_CatchError()
-    r22 = unicode_6 :: static  ('weeee')
+    r22 = load_global CPyStatic_unicode_6 :: static  ('weeee')
     r23 = builtins :: module
-    r24 = unicode_2 :: static  ('print')
+    r24 = load_global CPyStatic_unicode_2 :: static  ('print')
     r25 = CPyObject_GetAttr(r23, r24)
     r26 = py_call(r25, r22)
 L10:
@@ -218,27 +218,27 @@ L1:
 L2: (handler for L1)
     r0 = CPy_CatchError()
     r1 = builtins :: module
-    r2 = unicode_1 :: static  ('KeyError')
+    r2 = load_global CPyStatic_unicode_1 :: static  ('KeyError')
     r3 = CPyObject_GetAttr(r1, r2)
     r4 = CPy_ExceptionMatches(r3)
     if r4 goto L3 else goto L4 :: bool
 L3:
-    r5 = unicode_2 :: static  ('weeee')
+    r5 = load_global CPyStatic_unicode_2 :: static  ('weeee')
     r6 = builtins :: module
-    r7 = unicode_3 :: static  ('print')
+    r7 = load_global CPyStatic_unicode_3 :: static  ('print')
     r8 = CPyObject_GetAttr(r6, r7)
     r9 = py_call(r8, r5)
     goto L7
 L4:
     r10 = builtins :: module
-    r11 = unicode_4 :: static  ('IndexError')
+    r11 = load_global CPyStatic_unicode_4 :: static  ('IndexError')
     r12 = CPyObject_GetAttr(r10, r11)
     r13 = CPy_ExceptionMatches(r12)
     if r13 goto L5 else goto L6 :: bool
 L5:
-    r14 = unicode_5 :: static  ('yo')
+    r14 = load_global CPyStatic_unicode_5 :: static  ('yo')
     r15 = builtins :: module
-    r16 = unicode_3 :: static  ('print')
+    r16 = load_global CPyStatic_unicode_3 :: static  ('print')
     r17 = CPyObject_GetAttr(r15, r16)
     r18 = py_call(r17, r14)
     goto L7
@@ -279,9 +279,9 @@ L0:
 L1:
     if b goto L2 else goto L3 :: bool
 L2:
-    r0 = unicode_1 :: static  ('hi')
+    r0 = load_global CPyStatic_unicode_1 :: static  ('hi')
     r1 = builtins :: module
-    r2 = unicode_2 :: static  ('Exception')
+    r2 = load_global CPyStatic_unicode_2 :: static  ('Exception')
     r3 = CPyObject_GetAttr(r1, r2)
     r4 = py_call(r3, r0)
     CPy_Raise(r4)
@@ -296,9 +296,9 @@ L6: (handler for L1, L2, L3)
     r7 = CPy_CatchError()
     r5 = r7
 L7:
-    r8 = unicode_3 :: static  ('finally')
+    r8 = load_global CPyStatic_unicode_3 :: static  ('finally')
     r9 = builtins :: module
-    r10 = unicode_4 :: static  ('print')
+    r10 = load_global CPyStatic_unicode_4 :: static  ('print')
     r11 = CPyObject_GetAttr(r9, r10)
     r12 = py_call(r11, r8)
     if is_error(r5) goto L9 else goto L8
@@ -345,18 +345,18 @@ def foo(x):
 L0:
     r0 = py_call(x)
     r1 = PyObject_Type(r0)
-    r2 = unicode_3 :: static  ('__exit__')
+    r2 = load_global CPyStatic_unicode_3 :: static  ('__exit__')
     r3 = CPyObject_GetAttr(r1, r2)
-    r4 = unicode_4 :: static  ('__enter__')
+    r4 = load_global CPyStatic_unicode_4 :: static  ('__enter__')
     r5 = CPyObject_GetAttr(r1, r4)
     r6 = py_call(r5, r0)
     r7 = 1
 L1:
 L2:
     y = r6
-    r8 = unicode_5 :: static  ('hello')
+    r8 = load_global CPyStatic_unicode_5 :: static  ('hello')
     r9 = builtins :: module
-    r10 = unicode_6 :: static  ('print')
+    r10 = load_global CPyStatic_unicode_6 :: static  ('print')
     r11 = CPyObject_GetAttr(r9, r10)
     r12 = py_call(r11, r8)
     goto L8

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -681,7 +681,7 @@ def f() -> str:
 def f():
     r0 :: str
 L0:
-    r0 = unicode_1 :: static  ('some string')
+    r0 = load_global CPyStatic_unicode_1 :: static  ('some string')
     inc_ref r0
     return r0
 
@@ -700,7 +700,7 @@ def g(x):
     r6 :: int
 L0:
     r0 = load_address PyLong_Type
-    r1 = unicode_1 :: static  ('base')
+    r1 = load_global CPyStatic_unicode_1 :: static  ('base')
     r2 = PyTuple_Pack(1, x)
     r3 = box(short_int, 4)
     r4 = CPyDict_Build(1, r1, r3)


### PR DESCRIPTION
`LoadGlobal` used to have this hack to print partial name to keep consistent with the old `LoadStatic` behavior, now I've decided to make it print fullname since #9316 would need to print simple names like `NULL`.