### PR TITLE
Don't simplify tuple/union types in error messages

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1626,10 +1626,7 @@ def format_type_inner(typ: Type,
         for t in typ.items:
             items.append(format(t))
         s = 'Tuple[{}]'.format(', '.join(items))
-        if len(s) < 400:
-            return s
-        else:
-            return '<tuple: {} items>'.format(len(items))
+        return s
     elif isinstance(typ, TypedDictType):
         # If the TypedDictType is named, return the name
         if not typ.is_anonymous():
@@ -1661,10 +1658,7 @@ def format_type_inner(typ: Type,
             for t in typ.items:
                 items.append(format(t))
             s = 'Union[{}]'.format(', '.join(items))
-            if len(s) < 400:
-                return s
-            else:
-                return '<union: {} items>'.format(len(items))
+            return s
     elif isinstance(typ, NoneType):
         return 'None'
     elif isinstance(typ, AnyType):

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -763,7 +763,7 @@ class LongTypeName:
     def __add__(self, x: 'LongTypeName') -> 'LongTypeName': pass
 [builtins fixtures/tuple.pyi]
 [out]
-main:3: error: Unsupported operand types for + ("LongTypeName" and <tuple: 50 items>)
+main:3: error: Unsupported operand types for + ("LongTypeName" and "Tuple[LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName, LongTypeName]")
 
 
 -- Tuple methods

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -974,7 +974,7 @@ x: Union[ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes[int],
 
 def takes_int(arg: int) -> None: pass
 
-takes_int(x)  # E: Argument 1 to "takes_int" has incompatible type <union: 6 items>; expected "int"
+takes_int(x)  # E: Argument 1 to "takes_int" has incompatible type "Union[ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes[int], ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes[object], ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes[float], ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes[str], ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes[Any], ExtremelyLongTypeNameWhichIsGenericSoWeCanUseItMultipleTimes[bytes]]"; expected "int"
 
 [case testRecursiveForwardReferenceInUnion]
 

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -181,7 +181,7 @@ def g() -> Any: pass
 def f() -> typ: return g()
 [builtins fixtures/tuple.pyi]
 [out]
-main:11: error: Returning Any from function declared to return <tuple: 91 items>
+main:11: error: Returning Any from function declared to return "Tuple[int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int]"
 
 [case testReturnAnySilencedFromTypedFunction]
 # flags: --warn-return-any


### PR DESCRIPTION
This PR is addressing issue https://github.com/python/mypy/issues/9358.

- We have the same question for `union` type (other than `tuple` mentioned in https://github.com/python/mypy/issues/9358, so I made the same change for `union` type (please let me know if it's not desired)
- I hesitated if it's necessary to keep intermediate var `s`. But eventually I kept it to follow the existing practice in line https://github.com/python/mypy/blob/a08bbbb2fa37b8d2784dd3b194bcb1cd111bbcac/mypy/messages.py#L1643-L1644