### PR TITLE
mypy: get CI green for py39

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,9 +80,6 @@ jobs:
   #   env:
   #   - TOXENV=dev
   #   - EXTRA_ARGS=
-  allow_failures:
-  - name: "run test suite with python 3.9"
-    python: 3.9-dev
 
 install:
 - pip install -U pip setuptools

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -94,6 +94,8 @@ typecheck_files = [
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):
 if sys.version_info >= (3, 8):
     typecheck_files.append('check-python38.test')
+if sys.version_info >= (3, 9):
+    typecheck_files.append('check-python39.test')
 
 # Special tests for platforms with case-insensitive filesystems.
 if sys.platform in ('darwin', 'win32'):

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -53,13 +53,6 @@ f(b=[], a=A())
 class A: pass
 [builtins fixtures/list.pyi]
 
-[case testGivingSameKeywordArgumentTwice]
-import typing
-def f(a: 'A', b: 'B') -> None: pass
-f(a=A(), b=B(), a=A()) # E: keyword argument repeated
-class A: pass
-class B: pass
-
 [case testGivingArgumentAsPositionalAndKeywordArg]
 import typing
 def f(a: 'A', b: 'B' = None) -> None: pass

--- a/test-data/unit/check-python39.test
+++ b/test-data/unit/check-python39.test
@@ -1,0 +1,9 @@
+[case testGivingSameKeywordArgumentTwice]
+# This test was originally in check-kwargs.test
+# Python 3.9's new parser started producing a different error message here. Since this isn't the
+# most important test, to deal with this we'll only run this test with Python 3.9 and later.
+import typing
+def f(a: 'A', b: 'B') -> None: pass
+f(a=A(), b=B(), a=A()) # E: "f" gets multiple values for keyword argument "a"
+class A: pass
+class B: pass


### PR DESCRIPTION
Due to Python 3.9's new parser, this has a different (and better) error
message on Python 3.9.

This is effectively a test of typed_ast / ast, so I don't think it
matters too much. I'm happy to alternatively just get rid of the test
altogether, or if people feel strongly, come up with a way to run the
test when run with older Pythons.