### PR TITLE
Restore the correct type of AugmentedHelpFormatter._fill_text()

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -134,9 +134,7 @@ class AugmentedHelpFormatter(argparse.RawDescriptionHelpFormatter):
     def __init__(self, prog: str) -> None:
         super().__init__(prog=prog, max_help_position=28)
 
-    # FIXME: typeshed incorrectly has the type of indent as int when
-    # it should be str. Make it Any to avoid rusing mypyc.
-    def _fill_text(self, text: str, width: int, indent: Any) -> str:
+    def _fill_text(self, text: str, width: int, indent: str) -> str:
         if '\n' in text:
             # Assume we want to manually format the text
             return super()._fill_text(text, width, indent)


### PR DESCRIPTION
This reverts commit af00d01754e8afddaf9445db703d51076ccf6fae which
introduced a workaround for an incorrect type definition in typeshed.

The type of AugmentedHelpFormatter._fill_text() got fixed in commit
python/typeshed@686e21d330ce9a2ca16fb925554fd5eba082fb8f so we can
remove the workaround.