### PR TITLE
Add typing.OrderedDict to type_aliases

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -141,6 +141,8 @@ reverse_builtin_aliases = {
 nongen_builtins = {'builtins.tuple': 'typing.Tuple',
                    'builtins.enumerate': ''}  # type: Final
 nongen_builtins.update((name, alias) for alias, name in type_aliases.items())
+# Drop OrderedDict from this for backward compatibility
+del nongen_builtins['collections.OrderedDict']
 
 RUNTIME_PROTOCOL_DECOS = ('typing.runtime_checkable',
                           'typing_extensions.runtime',

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -118,8 +118,8 @@ type_aliases = {
 }  # type: Final
 
 # This keeps track of the oldest supported Python version where the corresponding
-# alias _target_ is available.
-type_aliases_target_versions = {
+# alias source is available.
+type_aliases_source_versions = {
     'typing.List': (2, 7),
     'typing.Dict': (2, 7),
     'typing.Set': (2, 7),
@@ -128,7 +128,7 @@ type_aliases_target_versions = {
     'typing.Counter': (2, 7),
     'typing.DefaultDict': (2, 7),
     'typing.Deque': (2, 7),
-    'typing.OrderedDict': (3, 1),
+    'typing.OrderedDict': (3, 7),
 }  # type: Final
 
 reverse_builtin_aliases = {

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -114,6 +114,7 @@ type_aliases = {
     'typing.Counter': 'collections.Counter',
     'typing.DefaultDict': 'collections.defaultdict',
     'typing.Deque': 'collections.deque',
+    'typing.OrderedDict': 'collections.OrderedDict',
 }  # type: Final
 
 # This keeps track of the oldest supported Python version where the corresponding
@@ -127,6 +128,7 @@ type_aliases_target_versions = {
     'typing.Counter': (2, 7),
     'typing.DefaultDict': (2, 7),
     'typing.Deque': (2, 7),
+    'typing.OrderedDict': (3, 1),
 }  # type: Final
 
 reverse_builtin_aliases = {


### PR DESCRIPTION
### Description

In 3.7.2 [typing.OrderedDict](https://docs.python.org/3/library/typing.html#typing.OrderedDict) was added to the typing module. Beforehand the correct way to annotate an `OrderedDict` was as a string or using the `__future__` import. However since it has been added to the stdlib it has not been added to the *type_aliases* for mypy [as it should have](https://github.com/python/mypy/pull/7707#issuecomment-541774957).

## Sample File

```python
from typing import OrderedDict

# substituting with collections.OrderedDict soothes mypy but fails at runtime
d: OrderedDict[str, int] = OrderedDict()
```
```console
$ mypy test.py
test.py:3: error: Variable "typing.OrderedDict" is not valid as a type
test.py:3: note: See https://mypy.readthedocs.io/en/latest/common_issues.html#variables-vs-type-aliases
test.py:3: error: "_Alias" not callable
Found 2 errors in 1 file (checked 1 source file)
```

## Test Plan

I do not know if the other aliases are tested anywhere. If so it might be a good idea to add a test there...