### PR TITLE
Add MYPY_CONFIG_FILE_DIR to environment when config file is read (2nd try)

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -135,6 +135,9 @@ def parse_config_file(options: Options, set_strict_flags: Callable[[], None],
     else:
         return
 
+    os.environ['MYPY_CONFIG_FILE_DIR'] = os.path.dirname(
+            os.path.abspath(config_file))
+
     if 'mypy' not in parser:
         if filename or file_read not in defaults.SHARED_CONFIG_FILES:
             print("%s: No [mypy] section in config file" % file_read, file=stderr)

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -25,6 +25,7 @@ python3_path = sys.executable
 cmdline_files = [
     'cmdline.test',
     'reports.test',
+    'envvars.test',
 ]
 
 

--- a/test-data/unit/envvars.test
+++ b/test-data/unit/envvars.test
@@ -1,0 +1,11 @@
+# Test cases related to environment variables
+[case testEnvvar_MYPY_CONFIG_FILE_DIR]
+# cmd: mypy --config-file=subdir/mypy.ini
+[file bogus.py]
+FOO = 'x'. # type: int
+[file subdir/good.py]
+BAR = 0. # type: int
+[file subdir/mypy.ini]
+\[mypy]
+files=$MYPY_CONFIG_FILE_DIR/good.py
+

--- a/test-data/unit/envvars.test
+++ b/test-data/unit/envvars.test
@@ -2,9 +2,9 @@
 [case testEnvvar_MYPY_CONFIG_FILE_DIR]
 # cmd: mypy --config-file=subdir/mypy.ini
 [file bogus.py]
-FOO = 'x'. # type: int
+FOO = 'x'  # type: int
 [file subdir/good.py]
-BAR = 0. # type: int
+BAR = 0  # type: int
 [file subdir/mypy.ini]
 \[mypy]
 files=$MYPY_CONFIG_FILE_DIR/good.py


### PR DESCRIPTION
Let's see what it will take to make CI pass.

Resubmit of #9403.

Fixes #7968.

Co-authored-by: aghast <aghast@aghast.dev>
