### PR TITLE
Update int_pow test to match new overloads in typeshed

### DIFF
--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -636,7 +636,10 @@ reveal_type(a**(-2)) # N: Revealed type is 'builtins.float'
 reveal_type(a**b) # N: Revealed type is 'Any'
 reveal_type(a.__pow__(2)) # N: Revealed type is 'builtins.int'
 reveal_type(a.__pow__(a)) # N: Revealed type is 'Any'
-a.__pow__() # E: Too few arguments for "__pow__" of "int"
+a.__pow__() # E: All overload variants of "__pow__" of "int" require at least one argument \
+            # N: Possible overload variants: \
+            # N:     def __pow__(self, Literal[2], Optional[int] = ...) -> int \
+            # N:     def __pow__(self, int, Optional[int] = ...) -> Any
 
 [case testDisallowAnyGenericsBuiltinCollections]
 # cmd: mypy m.py


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

At the moment, python/typeshed#4473 is approved but fails the mypy self tests. This updates the `cmdline.test` file to match the new error message with overloads. Though, I'm sorta wondering if it would be less fragile to just not do this specific check at all.

Feel free to take this (and the other PR) whenever it's least annoying to merge both together. Or, let me know if I'm missing something. 🙂 

cc @JelleZijlstra