### PR TITLE
pep612: more semantic analysis for paramspec

### DIFF
--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -4,7 +4,8 @@ import mypy.subtypes
 import mypy.sametypes
 from mypy.expandtype import expand_type
 from mypy.types import (
-    Type, TypeVarId, TypeVarType, CallableType, AnyType, PartialType, get_proper_types
+    Type, TypeVarId, TypeVarType, CallableType, AnyType, PartialType, get_proper_types,
+    TypeVarDef, TypeVarLikeDef, ProperType
 )
 from mypy.nodes import Context
 
@@ -29,20 +30,23 @@ def apply_generic_arguments(
     # Check that inferred type variable values are compatible with allowed
     # values and bounds.  Also, promote subtype values to allowed values.
     types = get_proper_types(orig_types)
-    for i, type in enumerate(types):
-        assert not isinstance(type, PartialType), "Internal error: must never apply partial type"
-        values = get_proper_types(callable.variables[i].values)
-        if type is None:
-            continue
+
+    # Create a map from type variable id to target type.
+    id_to_type = {}  # type: Dict[TypeVarId, Type]
+
+    def get_target_type(tvar: TypeVarLikeDef, type: ProperType) -> Optional[Type]:
+        # TODO(shantanu): fix for ParamSpecDef
+        assert isinstance(tvar, TypeVarDef)
+        values = get_proper_types(tvar.values)
         if values:
             if isinstance(type, AnyType):
-                continue
+                return type
             if isinstance(type, TypeVarType) and type.values:
                 # Allow substituting T1 for T if every allowed value of T1
                 # is also a legal value of T.
                 if all(any(mypy.sametypes.is_same_type(v, v1) for v in values)
                        for v1 in type.values):
-                    continue
+                    return type
             matching = []
             for value in values:
                 if mypy.subtypes.is_subtype(type, value):
@@ -53,28 +57,26 @@ def apply_generic_arguments(
                 for match in matching[1:]:
                     if mypy.subtypes.is_subtype(match, best):
                         best = match
-                types[i] = best
-            else:
-                if skip_unsatisfied:
-                    types[i] = None
-                else:
-                    report_incompatible_typevar_value(callable, type, callable.variables[i].name,
-                                                      context)
+                return best
+            if skip_unsatisfied:
+                return None
+            report_incompatible_typevar_value(callable, type, tvar.name, context)
         else:
-            upper_bound = callable.variables[i].upper_bound
+            upper_bound = tvar.upper_bound
             if not mypy.subtypes.is_subtype(type, upper_bound):
                 if skip_unsatisfied:
-                    types[i] = None
-                else:
-                    report_incompatible_typevar_value(callable, type, callable.variables[i].name,
-                                                      context)
+                    return None
+                report_incompatible_typevar_value(callable, type, tvar.name, context)
+        return type
 
-    # Create a map from type variable id to target type.
-    id_to_type = {}  # type: Dict[TypeVarId, Type]
-    for i, tv in enumerate(tvars):
-        typ = types[i]
-        if typ:
-            id_to_type[tv.id] = typ
+    for tvar, type in zip(tvars, types):
+        assert not isinstance(type, PartialType), "Internal error: must never apply partial type"
+        if type is None:
+            continue
+
+        target_type = get_target_type(tvar, type)
+        if target_type is not None:
+            id_to_type[tvar.id] = target_type
 
     # Apply arguments to argument types.
     arg_types = [expand_type(at, id_to_type) for at in callable.arg_types]

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1389,15 +1389,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         typ: CallableType) -> List[Tuple[FuncItem, CallableType]]:
         # TODO use generator
         subst = []  # type: List[List[Tuple[TypeVarId, Type]]]
-        tvars = typ.variables or []
-        tvars = tvars[:]
+        tvars = list(typ.variables) or []
         if defn.info:
             # Class type variables
             tvars += defn.info.defn.type_vars or []
+        # TODO(shantanu): audit for paramspec
         for tvar in tvars:
-            if tvar.values:
-                subst.append([(tvar.id, value)
-                              for value in tvar.values])
+            if isinstance(tvar, TypeVarDef) and tvar.values:
+                subst.append([(tvar.id, value) for value in tvar.values])
         # Make a copy of the function to check for each combination of
         # value restricted type variables. (Except when running mypyc,
         # where we need one canonical version of the function.)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4311,6 +4311,8 @@ def merge_typevars_in_callables_by_name(
             for tvdef in target.variables:
                 name = tvdef.fullname
                 if name not in unique_typevars:
+                    # TODO(shantanu): fix for ParamSpecDef
+                    assert isinstance(tvdef, TypeVarDef)
                     unique_typevars[name] = TypeVarType(tvdef)
                     variables.append(tvdef)
                 rename[tvdef.id] = unique_typevars[name]

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -1,11 +1,11 @@
 """Type checking of attribute access"""
 
-from typing import cast, Callable, Optional, Union, List
+from typing import cast, Callable, Optional, Union, Sequence
 from typing_extensions import TYPE_CHECKING
 
 from mypy.types import (
-    Type, Instance, AnyType, TupleType, TypedDictType, CallableType, FunctionLike, TypeVarDef,
-    Overloaded, TypeVarType, UnionType, PartialType, TypeOfAny, LiteralType,
+    Type, Instance, AnyType, TupleType, TypedDictType, CallableType, FunctionLike,
+    TypeVarLikeDef, Overloaded, TypeVarType, UnionType, PartialType, TypeOfAny, LiteralType,
     DeletedType, NoneType, TypeType, has_type_vars, get_proper_type, ProperType
 )
 from mypy.nodes import (
@@ -676,7 +676,7 @@ def analyze_class_attribute_access(itype: Instance,
                                    name: str,
                                    mx: MemberContext,
                                    override_info: Optional[TypeInfo] = None,
-                                   original_vars: Optional[List[TypeVarDef]] = None
+                                   original_vars: Optional[Sequence[TypeVarLikeDef]] = None
                                    ) -> Optional[Type]:
     """Analyze access to an attribute on a class object.
 
@@ -839,7 +839,7 @@ def analyze_enum_class_attribute_access(itype: Instance,
 def add_class_tvars(t: ProperType, isuper: Optional[Instance],
                     is_classmethod: bool,
                     original_type: Type,
-                    original_vars: Optional[List[TypeVarDef]] = None) -> Type:
+                    original_vars: Optional[Sequence[TypeVarLikeDef]] = None) -> Type:
     """Instantiate type variables during analyze_class_attribute_access,
     e.g T and Q in the following:
 
@@ -883,7 +883,7 @@ def add_class_tvars(t: ProperType, isuper: Optional[Instance],
             assert isuper is not None
             t = cast(CallableType, expand_type_by_instance(t, isuper))
             freeze_type_vars(t)
-        return t.copy_modified(variables=tvars + t.variables)
+        return t.copy_modified(variables=list(tvars) + list(t.variables))
     elif isinstance(t, Overloaded):
         return Overloaded([cast(CallableType, add_class_tvars(item, isuper,
                                                               is_classmethod, original_type,

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -40,6 +40,8 @@ def freshen_function_type_vars(callee: F) -> F:
         tvdefs = []
         tvmap = {}  # type: Dict[TypeVarId, Type]
         for v in callee.variables:
+            # TODO(shantanu): fix for ParamSpecDef
+            assert isinstance(v, TypeVarDef)
             tvdef = TypeVarDef.new_unification_variable(v)
             tvdefs.append(tvdef)
             tvmap[v.id] = TypeVarType(tvdef)

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -11,7 +11,8 @@ from mypy.nodes import (
 from mypy.types import (
     CallableType, Instance, Overloaded, TupleType, TypedDictType,
     TypeVarType, UnboundType, UnionType, TypeVisitor, LiteralType,
-    TypeType, NOT_READY, TypeAliasType, AnyType, TypeOfAny)
+    TypeType, NOT_READY, TypeAliasType, AnyType, TypeOfAny, TypeVarDef
+)
 from mypy.visitor import NodeVisitor
 from mypy.lookup import lookup_fully_qualified
 
@@ -183,10 +184,11 @@ class TypeFixer(TypeVisitor[None]):
         if ct.ret_type is not None:
             ct.ret_type.accept(self)
         for v in ct.variables:
-            if v.values:
-                for val in v.values:
-                    val.accept(self)
-            v.upper_bound.accept(self)
+            if isinstance(v, TypeVarDef):
+                if v.values:
+                    for val in v.values:
+                        val.accept(self)
+                v.upper_bound.accept(self)
         for arg in ct.bound_args:
             if arg:
                 arg.accept(self)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2079,7 +2079,7 @@ class TypeVarExpr(TypeVarLikeExpr):
 
     This is also used to represent type variables in symbol tables.
 
-    A type variable is not valid as a type unless bound in a TypeVarScope.
+    A type variable is not valid as a type unless bound in a TypeVarLikeScope.
     That happens within:
 
      1. a generic class that uses the type variable as a type argument or

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -126,7 +126,7 @@ from mypy_extensions import trait, mypyc_attr
 from mypy.nodes import (
     Expression, Context, ClassDef, SymbolTableNode, MypyFile, CallExpr
 )
-from mypy.tvar_scope import TypeVarScope
+from mypy.tvar_scope import TypeVarLikeScope
 from mypy.types import Type, Instance, CallableType, TypeList, UnboundType, ProperType
 from mypy.messages import MessageBuilder
 from mypy.options import Options
@@ -265,7 +265,7 @@ class SemanticAnalyzerPluginInterface:
 
     @abstractmethod
     def anal_type(self, t: Type, *,
-                  tvar_scope: Optional[TypeVarScope] = None,
+                  tvar_scope: Optional[TypeVarLikeScope] = None,
                   allow_tuple_literal: bool = False,
                   allow_unbound_tvars: bool = False,
                   report_invalid_types: bool = True,

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -10,7 +10,7 @@ from mypy.plugin import (
 from mypy.plugins.common import try_getting_str_literals
 from mypy.types import (
     Type, Instance, AnyType, TypeOfAny, CallableType, NoneType, TypedDictType,
-    TypeVarType, TPDICT_FB_NAMES, get_proper_type, LiteralType
+    TypeVarDef, TypeVarType, TPDICT_FB_NAMES, get_proper_type, LiteralType
 )
 from mypy.subtypes import is_subtype
 from mypy.typeops import make_simplified_union
@@ -204,6 +204,7 @@ def typed_dict_get_signature_callback(ctx: MethodSigContext) -> CallableType:
             # Tweak the signature to include the value type as context. It's
             # only needed for type inference since there's a union with a type
             # variable that accepts everything.
+            assert isinstance(signature.variables[0], TypeVarDef)
             tv = TypeVarType(signature.variables[0])
             return signature.copy_modified(
                 arg_types=[signature.arg_types[0],
@@ -269,6 +270,7 @@ def typed_dict_pop_signature_callback(ctx: MethodSigContext) -> CallableType:
             # Tweak the signature to include the value type as context. It's
             # only needed for type inference since there's a union with a type
             # variable that accepts everything.
+            assert isinstance(signature.variables[0], TypeVarDef)
             tv = TypeVarType(signature.variables[0])
             typ = make_simplified_union([value_type, tv])
             return signature.copy_modified(

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -78,7 +78,7 @@ from mypy.nodes import (
     EnumCallExpr, RUNTIME_PROTOCOL_DECOS, FakeExpression, Statement, AssignmentExpr,
     ParamSpecExpr
 )
-from mypy.tvar_scope import TypeVarScope
+from mypy.tvar_scope import TypeVarLikeScope
 from mypy.typevars import fill_typevars
 from mypy.visitor import NodeVisitor
 from mypy.errors import Errors, report_internal_error
@@ -161,7 +161,7 @@ class SemanticAnalyzer(NodeVisitor[None],
     # Stack of outer classes (the second tuple item contains tvars).
     type_stack = None  # type: List[Optional[TypeInfo]]
     # Type variables bound by the current scope, be it class or function
-    tvar_scope = None  # type: TypeVarScope
+    tvar_scope = None  # type: TypeVarLikeScope
     # Per-module options
     options = None  # type: Options
 
@@ -235,7 +235,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         self.imports = set()
         self.type = None
         self.type_stack = []
-        self.tvar_scope = TypeVarScope()
+        self.tvar_scope = TypeVarLikeScope()
         self.function_stack = []
         self.block_depth = [0]
         self.loop_depth = 0
@@ -478,7 +478,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         self.is_stub_file = file_node.path.lower().endswith('.pyi')
         self._is_typeshed_stub_file = is_typeshed_file(file_node.path)
         self.globals = file_node.names
-        self.tvar_scope = TypeVarScope()
+        self.tvar_scope = TypeVarLikeScope()
 
         self.named_tuple_analyzer = NamedTupleAnalyzer(options, self)
         self.typed_dict_analyzer = TypedDictAnalyzer(options, self, self.msg)
@@ -4455,7 +4455,7 @@ class SemanticAnalyzer(NodeVisitor[None],
     #
 
     @contextmanager
-    def tvar_scope_frame(self, frame: TypeVarScope) -> Iterator[None]:
+    def tvar_scope_frame(self, frame: TypeVarLikeScope) -> Iterator[None]:
         old_scope = self.tvar_scope
         self.tvar_scope = frame
         yield
@@ -4788,11 +4788,11 @@ class SemanticAnalyzer(NodeVisitor[None],
         # them semantically analyzed, however, if they need to treat it as an expression
         # and not a type. (Which is to say, mypyc needs to do this.) Do the analysis
         # in a fresh tvar scope in order to suppress any errors about using type variables.
-        with self.tvar_scope_frame(TypeVarScope()):
+        with self.tvar_scope_frame(TypeVarLikeScope()):
             expr.accept(self)
 
     def type_analyzer(self, *,
-                      tvar_scope: Optional[TypeVarScope] = None,
+                      tvar_scope: Optional[TypeVarLikeScope] = None,
                       allow_tuple_literal: bool = False,
                       allow_unbound_tvars: bool = False,
                       allow_placeholder: bool = False,
@@ -4815,7 +4815,7 @@ class SemanticAnalyzer(NodeVisitor[None],
 
     def anal_type(self,
                   typ: Type, *,
-                  tvar_scope: Optional[TypeVarScope] = None,
+                  tvar_scope: Optional[TypeVarLikeScope] = None,
                   allow_tuple_literal: bool = False,
                   allow_unbound_tvars: bool = False,
                   allow_placeholder: bool = False,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1260,6 +1260,9 @@ class SemanticAnalyzer(NodeVisitor[None],
         tvar_defs = []  # type: List[TypeVarDef]
         for name, tvar_expr in declared_tvars:
             tvar_def = self.tvar_scope.bind_new(name, tvar_expr)
+            assert isinstance(tvar_def, TypeVarDef), (
+                "mypy does not currently support ParamSpec use in generic classes"
+            )
             tvar_defs.append(tvar_def)
         return base_type_exprs, tvar_defs, is_protocol
 

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -14,7 +14,7 @@ from mypy.util import correct_relative_import
 from mypy.types import (
     Type, FunctionLike, Instance, TupleType, TPDICT_FB_NAMES, ProperType, get_proper_type
 )
-from mypy.tvar_scope import TypeVarScope
+from mypy.tvar_scope import TypeVarLikeScope
 from mypy.errorcodes import ErrorCode
 from mypy import join
 
@@ -105,7 +105,7 @@ class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
 
     @abstractmethod
     def anal_type(self, t: Type, *,
-                  tvar_scope: Optional[TypeVarScope] = None,
+                  tvar_scope: Optional[TypeVarLikeScope] = None,
                   allow_tuple_literal: bool = False,
                   allow_unbound_tvars: bool = False,
                   report_invalid_types: bool = True) -> Optional[Type]:

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -370,9 +370,10 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
         if typ.fallback is not None:
             typ.fallback.accept(self)
         for tv in typ.variables:
-            tv.upper_bound.accept(self)
-            for value in tv.values:
-                value.accept(self)
+            if isinstance(tv, TypeVarDef):
+                tv.upper_bound.accept(self)
+                for value in tv.values:
+                    value.accept(self)
 
     def visit_overloaded(self, t: Overloaded) -> None:
         for item in t.items():

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -89,6 +89,7 @@ typecheck_files = [
     'check-reports.test',
     'check-errorcodes.test',
     'check-annotated.test',
+    'check-parameter-specification.test',
 ]
 
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):

--- a/mypy/tvar_scope.py
+++ b/mypy/tvar_scope.py
@@ -1,16 +1,20 @@
 from typing import Optional, Dict, Union
-from mypy.types import TypeVarDef
-from mypy.nodes import TypeVarExpr, SymbolTableNode
+from mypy.types import TypeVarLikeDef, TypeVarDef, ParamSpecDef
+from mypy.nodes import ParamSpecExpr, TypeVarExpr, TypeVarLikeExpr, SymbolTableNode
 
 
-class TypeVarScope:
-    """Scope that holds bindings for type variables. Node fullname -> TypeVarDef."""
+class TypeVarLikeScope:
+    """Scope that holds bindings for type variables and parameter specifications.
+
+    Node fullname -> TypeVarLikeDef.
+
+    """
 
     def __init__(self,
-                 parent: 'Optional[TypeVarScope]' = None,
+                 parent: 'Optional[TypeVarLikeScope]' = None,
                  is_class_scope: bool = False,
-                 prohibited: 'Optional[TypeVarScope]' = None) -> None:
-        """Initializer for TypeVarScope
+                 prohibited: 'Optional[TypeVarLikeScope]' = None) -> None:
+        """Initializer for TypeVarLikeScope
 
         Parameters:
           parent: the outer scope for this scope
@@ -18,7 +22,7 @@ class TypeVarScope:
           prohibited: Type variables that aren't strictly in scope exactly,
                       but can't be bound because they're part of an outer class's scope.
         """
-        self.scope = {}  # type: Dict[str, TypeVarDef]
+        self.scope = {}  # type: Dict[str, TypeVarLikeDef]
         self.parent = parent
         self.func_id = 0
         self.class_id = 0
@@ -28,9 +32,9 @@ class TypeVarScope:
             self.func_id = parent.func_id
             self.class_id = parent.class_id
 
-    def get_function_scope(self) -> 'Optional[TypeVarScope]':
+    def get_function_scope(self) -> 'Optional[TypeVarLikeScope]':
         """Get the nearest parent that's a function scope, not a class scope"""
-        it = self  # type: Optional[TypeVarScope]
+        it = self  # type: Optional[TypeVarLikeScope]
         while it is not None and it.is_class_scope:
             it = it.parent
         return it
@@ -44,36 +48,49 @@ class TypeVarScope:
             return False
         return True
 
-    def method_frame(self) -> 'TypeVarScope':
+    def method_frame(self) -> 'TypeVarLikeScope':
         """A new scope frame for binding a method"""
-        return TypeVarScope(self, False, None)
+        return TypeVarLikeScope(self, False, None)
 
-    def class_frame(self) -> 'TypeVarScope':
+    def class_frame(self) -> 'TypeVarLikeScope':
         """A new scope frame for binding a class. Prohibits *this* class's tvars"""
-        return TypeVarScope(self.get_function_scope(), True, self)
+        return TypeVarLikeScope(self.get_function_scope(), True, self)
 
-    def bind_new(self, name: str, tvar_expr: TypeVarExpr) -> TypeVarDef:
+    def bind_new(self, name: str, tvar_expr: TypeVarLikeExpr) -> TypeVarLikeDef:
         if self.is_class_scope:
             self.class_id += 1
             i = self.class_id
         else:
             self.func_id -= 1
             i = self.func_id
-        tvar_def = TypeVarDef(name,
-                              tvar_expr.fullname,
-                              i,
-                              values=tvar_expr.values,
-                              upper_bound=tvar_expr.upper_bound,
-                              variance=tvar_expr.variance,
-                              line=tvar_expr.line,
-                              column=tvar_expr.column)
+        if isinstance(tvar_expr, TypeVarExpr):
+            tvar_def = TypeVarDef(
+                name,
+                tvar_expr.fullname,
+                i,
+                values=tvar_expr.values,
+                upper_bound=tvar_expr.upper_bound,
+                variance=tvar_expr.variance,
+                line=tvar_expr.line,
+                column=tvar_expr.column
+            )  # type: TypeVarLikeDef
+        elif isinstance(tvar_expr, ParamSpecExpr):
+            tvar_def = ParamSpecDef(
+                name,
+                tvar_expr.fullname,
+                i,
+                line=tvar_expr.line,
+                column=tvar_expr.column
+            )
+        else:
+            assert False
         self.scope[tvar_expr.fullname] = tvar_def
         return tvar_def
 
-    def bind_existing(self, tvar_def: TypeVarDef) -> None:
+    def bind_existing(self, tvar_def: TypeVarLikeDef) -> None:
         self.scope[tvar_def.fullname] = tvar_def
 
-    def get_binding(self, item: Union[str, SymbolTableNode]) -> Optional[TypeVarDef]:
+    def get_binding(self, item: Union[str, SymbolTableNode]) -> Optional[TypeVarLikeDef]:
         fullname = item.fullname if isinstance(item, SymbolTableNode) else item
         assert fullname is not None
         if fullname in self.scope:

--- a/mypy/tvar_scope.py
+++ b/mypy/tvar_scope.py
@@ -7,7 +7,6 @@ class TypeVarLikeScope:
     """Scope that holds bindings for type variables and parameter specifications.
 
     Node fullname -> TypeVarLikeDef.
-
     """
 
     def __init__(self,

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -13,7 +13,7 @@ other modules refer to them.
 
 from abc import abstractmethod
 from mypy.ordered_dict import OrderedDict
-from typing import Generic, TypeVar, cast, Any, List, Callable, Iterable, Optional, Set
+from typing import Generic, TypeVar, cast, Any, List, Callable, Iterable, Optional, Set, Sequence
 from mypy_extensions import trait
 
 T = TypeVar('T')
@@ -21,7 +21,7 @@ T = TypeVar('T')
 from mypy.types import (
     Type, AnyType, CallableType, Overloaded, TupleType, TypedDictType, LiteralType,
     RawExpressionType, Instance, NoneType, TypeType,
-    UnionType, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarDef,
+    UnionType, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarLikeDef,
     UnboundType, ErasedType, StarType, EllipsisType, TypeList, CallableArgument,
     PlaceholderType, TypeAliasType, get_proper_type
 )
@@ -218,7 +218,7 @@ class TypeTranslator(TypeVisitor[Type]):
         return [t.accept(self) for t in types]
 
     def translate_variables(self,
-                            variables: List[TypeVarDef]) -> List[TypeVarDef]:
+                            variables: Sequence[TypeVarLikeDef]) -> Sequence[TypeVarLikeDef]:
         return variables
 
     def visit_overloaded(self, t: Overloaded) -> Type:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -26,7 +26,7 @@ from mypy.nodes import (
     TypeAlias, PlaceholderNode, SYMBOL_FUNCBASE_TYPES, Decorator, MypyFile
 )
 from mypy.typetraverser import TypeTraverserVisitor
-from mypy.tvar_scope import TypeVarScope
+from mypy.tvar_scope import TypeVarLikeScope
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.plugin import Plugin, TypeAnalyzerPluginInterface, AnalyzeTypeContext
 from mypy.semanal_shared import SemanticAnalyzerCoreInterface
@@ -64,7 +64,7 @@ GENERIC_STUB_NOT_AT_RUNTIME_TYPES = {
 
 def analyze_type_alias(node: Expression,
                        api: SemanticAnalyzerCoreInterface,
-                       tvar_scope: TypeVarScope,
+                       tvar_scope: TypeVarLikeScope,
                        plugin: Plugin,
                        options: Options,
                        is_typeshed_stub: bool,
@@ -117,7 +117,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
 
     def __init__(self,
                  api: SemanticAnalyzerCoreInterface,
-                 tvar_scope: TypeVarScope,
+                 tvar_scope: TypeVarLikeScope,
                  plugin: Plugin,
                  options: Options,
                  is_typeshed_stub: bool, *,
@@ -1063,7 +1063,7 @@ class TypeVariableQuery(TypeQuery[TypeVarList]):
 
     def __init__(self,
                  lookup: Callable[[str, Context], Optional[SymbolTableNode]],
-                 scope: 'TypeVarScope',
+                 scope: 'TypeVarLikeScope',
                  *,
                  include_callables: bool = True,
                  include_bound_tvars: bool = False) -> None:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -205,6 +205,11 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     self.fail('ParamSpec "{}" is unbound'.format(t.name), t)
                     return AnyType(TypeOfAny.from_error)
                 self.fail('Invalid location for ParamSpec "{}"'.format(t.name), t)
+                self.note(
+                    'You can use ParamSpec as the first argument to Callable, e.g., '
+                    "'Callable[{}, int]'".format(t.name),
+                    t
+                )
                 return AnyType(TypeOfAny.from_error)
             if isinstance(sym.node, TypeVarExpr) and tvar_def is not None and self.defining_alias:
                 self.fail('Can\'t use bound type variable "{}"'

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -328,12 +328,34 @@ class TypeVarId:
         return self.meta_level > 0
 
 
-class TypeVarDef(mypy.nodes.Context):
-    """Definition of a single type variable."""
-
+class TypeVarLikeDef(mypy.nodes.Context):
     name = ''  # Name (may be qualified)
     fullname = ''  # Fully qualified name
     id = None  # type: TypeVarId
+
+    def __init__(
+        self, name: str, fullname: str, id: Union[TypeVarId, int], line: int = -1, column: int = -1
+    ) -> None:
+        super().__init__(line, column)
+        self.name = name
+        self.fullname = fullname
+        if isinstance(id, int):
+            id = TypeVarId(id)
+        self.id = id
+
+    def __repr__(self) -> str:
+        return self.name
+
+    def serialize(self) -> JsonDict:
+        raise NotImplementedError
+
+    @classmethod
+    def deserialize(cls, data: JsonDict) -> 'TypeVarLikeDef':
+        raise NotImplementedError
+
+
+class TypeVarDef(TypeVarLikeDef):
+    """Definition of a single type variable."""
     values = None  # type: List[Type]  # Value restriction, empty list if no restriction
     upper_bound = None  # type: Type
     variance = INVARIANT  # type: int
@@ -341,13 +363,8 @@ class TypeVarDef(mypy.nodes.Context):
     def __init__(self, name: str, fullname: str, id: Union[TypeVarId, int], values: List[Type],
                  upper_bound: Type, variance: int = INVARIANT, line: int = -1,
                  column: int = -1) -> None:
-        super().__init__(line, column)
+        super().__init__(name, fullname, id, line, column)
         assert values is not None, "No restrictions must be represented by empty list"
-        self.name = name
-        self.fullname = fullname
-        if isinstance(id, int):
-            id = TypeVarId(id)
-        self.id = id
         self.values = values
         self.upper_bound = upper_bound
         self.variance = variance
@@ -387,6 +404,28 @@ class TypeVarDef(mypy.nodes.Context):
                           deserialize_type(data['upper_bound']),
                           data['variance'],
                           )
+
+
+class ParamSpecDef(TypeVarLikeDef):
+    """Definition of a single ParamSpec variable."""
+
+    def serialize(self) -> JsonDict:
+        assert not self.id.is_meta_var()
+        return {
+            '.class': 'ParamSpecDef',
+            'name': self.name,
+            'fullname': self.fullname,
+            'id': self.id.raw_id,
+        }
+
+    @classmethod
+    def deserialize(cls, data: JsonDict) -> 'ParamSpecDef':
+        assert data['.class'] == 'ParamSpecDef'
+        return ParamSpecDef(
+            data['name'],
+            data['fullname'],
+            data['id'],
+        )
 
 
 class UnboundType(ProperType):

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -8,6 +8,7 @@ from typing import Callable, List
 from typing_extensions import ParamSpec, Concatenate
 P = ParamSpec('P')
 
+x: P  # E: ParamSpec "P" is unbound
 def foo1(x: Callable[P, int]) -> Callable[P, str]:  ...
 def foo2(x: P) -> P: ...  # E: Invalid location for ParamSpec "P"
 # TODO(shantanu): uncomment once we have support for Concatenate

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1,0 +1,18 @@
+[case testBasicParamSpec]
+from typing_extensions import ParamSpec
+P = ParamSpec('P')
+[builtins fixtures/tuple.pyi]
+
+[case testParamSpecLocations]
+from typing import Callable, List
+from typing_extensions import ParamSpec, Concatenate
+P = ParamSpec('P')
+
+def foo1(x: Callable[P, int]) -> Callable[P, str]:  ...
+def foo2(x: P) -> P: ...  # E: Invalid location for ParamSpec "P"
+# TODO(shantanu): uncomment once we have support for Concatenate
+# def foo3(x: Concatenate[int, P]) -> int: ...  $ E: Invalid location for Concatenate
+def foo4(x: List[P]) -> None: ...  # E: Invalid location for ParamSpec "P"
+def foo5(x: Callable[[int, str], P]) -> None: ...  # E: Invalid location for ParamSpec "P"
+def foo6(x: Callable[[P], int]) -> None: ...  # E: Invalid location for ParamSpec "P"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -9,11 +9,21 @@ from typing_extensions import ParamSpec, Concatenate
 P = ParamSpec('P')
 
 x: P  # E: ParamSpec "P" is unbound
+
 def foo1(x: Callable[P, int]) -> Callable[P, str]:  ...
-def foo2(x: P) -> P: ...  # E: Invalid location for ParamSpec "P"
+
+def foo2(x: P) -> P: ...  # E: Invalid location for ParamSpec "P" \
+                          # N: You can use ParamSpec as the first argument to Callable, e.g., 'Callable[P, int]'
+
 # TODO(shantanu): uncomment once we have support for Concatenate
 # def foo3(x: Concatenate[int, P]) -> int: ...  $ E: Invalid location for Concatenate
-def foo4(x: List[P]) -> None: ...  # E: Invalid location for ParamSpec "P"
-def foo5(x: Callable[[int, str], P]) -> None: ...  # E: Invalid location for ParamSpec "P"
-def foo6(x: Callable[[P], int]) -> None: ...  # E: Invalid location for ParamSpec "P"
+
+def foo4(x: List[P]) -> None: ...  # E: Invalid location for ParamSpec "P" \
+                                   # N: You can use ParamSpec as the first argument to Callable, e.g., 'Callable[P, int]'
+
+def foo5(x: Callable[[int, str], P]) -> None: ...  # E: Invalid location for ParamSpec "P" \
+                                                   # N: You can use ParamSpec as the first argument to Callable, e.g., 'Callable[P, int]'
+
+def foo6(x: Callable[[P], int]) -> None: ...  # E: Invalid location for ParamSpec "P" \
+                                              # N: You can use ParamSpec as the first argument to Callable, e.g., 'Callable[P, int]'
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Linking #8645

Like #9339, much of this is in #9250. However, this PR is a little less self contained, in that it causes several future TODOs.

A lot of the changes here are necessitated by changing the type of `CallableType.variables` to `Sequence[TypeVarLikeDef]`. This is nice, because it informs me where I need to make changes in the future / integrates a little bit better with existing type var stuff. But let me know if you think I should instead add another field to CallableType.

The other decision here that I'm less sure of is not adding upper_bound and variance fields to ParamSpecDef. These fields exist on ParamSpecExpr, since PEP 612 reserves that. I figured we should add these to ParamSpecDef only once they have semantics so that it's easier to figure out where we need to define the new semantics, but that means TypeVarLikeDef abstracts over less and might lead to unnecessary work if we expect those semantics to be defined any time soon.