### PR TITLE
stubtest: use allowlist instead of whitelist

### DIFF
--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -75,7 +75,7 @@ def collect_cases(fn: Callable[..., Iterator[Case]]) -> Callable[..., None]:
         output = run_stubtest(
             stub="\n\n".join(textwrap.dedent(c.stub.lstrip("\n")) for c in cases),
             runtime="\n\n".join(textwrap.dedent(c.runtime.lstrip("\n")) for c in cases),
-            options=["--generate-whitelist"],
+            options=["--generate-allowlist"],
         )
 
         actual_errors = set(output.splitlines())
@@ -667,33 +667,33 @@ class StubtestMiscUnit(unittest.TestCase):
         )
         assert not output
 
-    def test_whitelist(self) -> None:
+    def test_allowlist(self) -> None:
         # Can't use this as a context because Windows
-        whitelist = tempfile.NamedTemporaryFile(mode="w+", delete=False)
+        allowlist = tempfile.NamedTemporaryFile(mode="w+", delete=False)
         try:
-            with whitelist:
-                whitelist.write("{}.bad  # comment\n# comment".format(TEST_MODULE_NAME))
+            with allowlist:
+                allowlist.write("{}.bad  # comment\n# comment".format(TEST_MODULE_NAME))
 
             output = run_stubtest(
                 stub="def bad(number: int, text: str) -> None: ...",
                 runtime="def bad(asdf, text): pass",
-                options=["--whitelist", whitelist.name],
+                options=["--allowlist", allowlist.name],
             )
             assert not output
 
             # test unused entry detection
-            output = run_stubtest(stub="", runtime="", options=["--whitelist", whitelist.name])
-            assert output == "note: unused whitelist entry {}.bad\n".format(TEST_MODULE_NAME)
+            output = run_stubtest(stub="", runtime="", options=["--allowlist", allowlist.name])
+            assert output == "note: unused allowlist entry {}.bad\n".format(TEST_MODULE_NAME)
 
             output = run_stubtest(
                 stub="",
                 runtime="",
-                options=["--whitelist", whitelist.name, "--ignore-unused-whitelist"],
+                options=["--allowlist", allowlist.name, "--ignore-unused-allowlist"],
             )
             assert not output
 
             # test regex matching
-            with open(whitelist.name, mode="w+") as f:
+            with open(allowlist.name, mode="w+") as f:
                 f.write("{}.b.*\n".format(TEST_MODULE_NAME))
                 f.write("(unused_missing)?\n")
                 f.write("unused.*\n")
@@ -713,13 +713,13 @@ class StubtestMiscUnit(unittest.TestCase):
                     def also_bad(asdf): pass
                     """.lstrip("\n")
                 ),
-                options=["--whitelist", whitelist.name, "--generate-whitelist"],
+                options=["--allowlist", allowlist.name, "--generate-allowlist"],
             )
-            assert output == "note: unused whitelist entry unused.*\n{}.also_bad\n".format(
+            assert output == "note: unused allowlist entry unused.*\n{}.also_bad\n".format(
                 TEST_MODULE_NAME
             )
         finally:
-            os.unlink(whitelist.name)
+            os.unlink(allowlist.name)
 
     def test_mypy_build(self) -> None:
         output = run_stubtest(stub="+", runtime="", options=[])


### PR DESCRIPTION
Allows use of the old options to preserve backwards compatibility
A step towards https://github.com/python/typeshed/issues/4436