### PR TITLE
Predict enum value type for unknown member names.

### DIFF
--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -73,21 +73,17 @@ def _infer_value_type_with_auto_fallback(
     # `_generate_next_value_` is `Any`.  In reality the default `auto()`
     # returns an `int` (presumably the `Any` in typeshed is to make it
     # easier to subclass and change the returned type).
-    type_with_generate_next_value = next(
-        (type_info for type_info in info.mro
-            if type_info.names.get('_generate_next_value_')),
-        None)
-    if type_with_generate_next_value is None:
+    type_with_gnv = next(
+        (ti for ti in info.mro if ti.names.get('_generate_next_value_')), None)
+    if type_with_gnv is None:
         return ctx.default_attr_type
 
-    stnode = type_with_generate_next_value.get('_generate_next_value_')
-    if stnode is None:
-        return ctx.default_attr_type
+    stnode = type_with_gnv.names['_generate_next_value_']
 
     # This should be a `CallableType`
     node_type = get_proper_type(stnode.type)
     if isinstance(node_type, CallableType):
-        if type_with_generate_next_value.fullname == 'enum.Enum':
+        if type_with_gnv.fullname == 'enum.Enum':
             int_type = ctx.api.named_generic_type('builtins.int', [])
             return int_type
         return get_proper_type(node_type.ret_type)

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -78,7 +78,7 @@ def enum_value_callback(ctx: 'mypy.plugin.AttributeContext') -> Type:
     """
     enum_field_name = _extract_underlying_field_name(ctx.type)
     if enum_field_name is None:
-        # We do not know the ennum field name (perhaps it was passed to a function and we only
+        # We do not know the enum field name (perhaps it was passed to a function and we only
         # know that it _is_ a member).  All is not lost however, if we can prove that the all
         # of the enum members have the same value-type, then it doesn't matter which member
         # was passed in.  The value-type is still known.

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -66,8 +66,7 @@ def _infer_value_type_with_auto_fallback(
     if not (isinstance(proper_type, Instance) or
             proper_type.type.fullname != 'enum.auto'):
         return proper_type
-    if not isinstance(ctx.type, Instance):
-        raise ValueError("An incorrect ctx.type was passed.")
+    assert isinstance(ctx.type, Instance), 'An incorrect ctx.type was passed.'
     info = ctx.type.type
     # Find the first _generate_next_value_ on the mro.  We need to know
     # if it is `Enum` because `Enum` types say that the return-value of

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -63,8 +63,8 @@ def _infer_value_type_with_auto_fallback(
     """
     if proper_type is None:
         return None
-    if not (isinstance(proper_type, Instance) or
-            proper_type.type.fullname != 'enum.auto'):
+    if not ((isinstance(proper_type, Instance) and
+            proper_type.type.fullname == 'enum.auto')):
         return proper_type
     assert isinstance(ctx.type, Instance), 'An incorrect ctx.type was passed.'
     info = ctx.type.type

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -78,6 +78,22 @@ def enum_value_callback(ctx: 'mypy.plugin.AttributeContext') -> Type:
     """
     enum_field_name = _extract_underlying_field_name(ctx.type)
     if enum_field_name is None:
+        # We do not know the ennum field name (perhaps it was passed to a function and we only
+        # know that it _is_ a member).  All is not lost however, if we can prove that the all
+        # of the enum members have the same value-type, then it doesn't matter which member
+        # was passed in.  The value-type is still known.
+        if isinstance(ctx.type, Instance):
+            info = ctx.type.type
+            stnodes = (info.get(name) for name in info.names)
+            first_node = next(stnodes, None)
+            if first_node is None:
+                return ctx.default_attr_type
+            first_node_type = first_node.type
+            if all(node is not None and node.type == first_node_type for node in stnodes):
+                underlying_type = get_proper_type(first_node_type)
+                if underlying_type is not None:
+                    return underlying_type
+
         return ctx.default_attr_type
 
     assert isinstance(ctx.type, Instance)

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -68,7 +68,7 @@ def _infer_value_type_with_auto_fallback(
         info = ctx.type.type
         # Find the first _generate_next_value_ on the mro.  We need to know
         # if it is `Enum` because `Enum` types say that the return-value of
-        #`_generate_next_value_` is `Any`.  In reality the default `auto()`
+        # `_generate_next_value_` is `Any`.  In reality the default `auto()`
         # returns an `int` (presumably the `Any` in typeshed is to make it
         # easier to subclass and change the returned type).
         type_with_generate_next_value = next(

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -87,6 +87,7 @@ class Truth(Enum):
 
 def infer_truth(truth: Truth) -> None:
     reveal_type(truth.value) # N: Revealed type is 'builtins.int'
+[builtins fixtures/primitives.pyi]
 
 [case testEnumValueExtraMethods]
 from enum import Enum, auto
@@ -116,6 +117,7 @@ class Truth(AutoName):
 
 def infer_truth(truth: Truth) -> None:
     reveal_type(truth.value) # N: Revealed type is 'builtins.str'
+[builtins fixtures/primitives.pyi]
 
 [case testEnumValueInhomogenous]
 from enum import Enum

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -59,6 +59,26 @@ reveal_type(Truth.true.name)    # N: Revealed type is 'Literal['true']?'
 reveal_type(Truth.false.value)  # N: Revealed type is 'builtins.bool'
 [builtins fixtures/bool.pyi]
 
+[case testEnumValueExtended]
+from enum import Enum
+class Truth(Enum):
+    true = True
+    false = False
+
+def infer_truth(truth: Truth) -> None:
+    reveal_type(truth.value) # N: Revealed type is 'builtins.bool'
+[builtins fixtures/bool.pyi]
+
+[case testEnumValueInhomogenous]
+from enum import Enum
+class Truth(Enum):
+    true = 'True'
+    false = 0
+
+def cannot_infer_truth(truth: Truth) -> None:
+    reveal_type(truth.value) # N: Revealed type is 'Any'
+[builtins fixtures/bool.pyi]
+
 [case testEnumUnique]
 import enum
 @enum.unique

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -69,6 +69,58 @@ def infer_truth(truth: Truth) -> None:
     reveal_type(truth.value) # N: Revealed type is 'builtins.bool'
 [builtins fixtures/bool.pyi]
 
+[case testEnumValueAllAuto]
+from enum import Enum, auto
+class Truth(Enum):
+    true = auto()
+    false = auto()
+
+def infer_truth(truth: Truth) -> None:
+    reveal_type(truth.value) # N: Revealed type is 'builtins.int'
+[builtins fixtures/bool.pyi]
+[builtins fixtures/primitives.pyi]
+
+[case testEnumValueSomeAuto]
+from enum import Enum, auto
+class Truth(Enum):
+    true = 8675309
+    false = auto()
+
+def infer_truth(truth: Truth) -> None:
+    reveal_type(truth.value) # N: Revealed type is 'builtins.int'
+[builtins fixtures/bool.pyi]
+
+[case testEnumValueExtraMethods]
+from enum import Enum, auto
+class Truth(Enum):
+    true = True
+    false = False
+
+    def foo(self) -> str:
+        return 'bar'
+
+def infer_truth(truth: Truth) -> None:
+    reveal_type(truth.value) # N: Revealed type is 'builtins.bool'
+[builtins fixtures/bool.pyi]
+
+[case testEnumValueCustomAuto]
+from enum import Enum, auto
+from typing import List, Any
+class AutoName(Enum):
+    @staticmethod
+    def _generate_next_value_(name: str, start: int, count: int, last_values: List[Any]) -> str:
+        return name
+
+class Truth(AutoName):
+    true = auto()
+    false = auto()
+
+def infer_truth(truth: Truth) -> None:
+    reveal_type(truth.value) # N: Revealed type is 'builtins.str'
+[builtins fixtures/bool.pyi]
+[builtins fixtures/staticmethod.pyi]
+[builtins fixtures/list.pyi]
+
 [case testEnumValueInhomogenous]
 from enum import Enum
 class Truth(Enum):

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -103,7 +103,6 @@ def infer_truth(truth: Truth) -> None:
 
 [case testEnumValueCustomAuto]
 from enum import Enum, auto
-from typing import List, Any
 class AutoName(Enum):
 
     # In `typeshed`, this is a staticmethod and has more arguments,
@@ -117,9 +116,6 @@ class Truth(AutoName):
 
 def infer_truth(truth: Truth) -> None:
     reveal_type(truth.value) # N: Revealed type is 'builtins.str'
-[builtins fixtures/bool.pyi]
-[builtins fixtures/staticmethod.pyi]
-[builtins fixtures/list.pyi]
 
 [case testEnumValueInhomogenous]
 from enum import Enum

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -77,7 +77,6 @@ class Truth(Enum):
 
 def infer_truth(truth: Truth) -> None:
     reveal_type(truth.value) # N: Revealed type is 'builtins.int'
-[builtins fixtures/bool.pyi]
 [builtins fixtures/primitives.pyi]
 
 [case testEnumValueSomeAuto]
@@ -88,7 +87,6 @@ class Truth(Enum):
 
 def infer_truth(truth: Truth) -> None:
     reveal_type(truth.value) # N: Revealed type is 'builtins.int'
-[builtins fixtures/bool.pyi]
 
 [case testEnumValueExtraMethods]
 from enum import Enum, auto
@@ -107,9 +105,11 @@ def infer_truth(truth: Truth) -> None:
 from enum import Enum, auto
 from typing import List, Any
 class AutoName(Enum):
-    @staticmethod
-    def _generate_next_value_(name: str, start: int, count: int, last_values: List[Any]) -> str:
-        return name
+
+    # In `typeshed`, this is a staticmethod and has more arguments,
+    # but I have lied a bit to keep the test stubs lean.
+    def _generate_next_value_(self) -> str:
+        return "name"
 
 class Truth(AutoName):
     true = auto()
@@ -569,8 +569,8 @@ reveal_type(A1.x.value)         # N: Revealed type is 'Any'
 reveal_type(A1.x._value_)       # N: Revealed type is 'Any'
 is_x(reveal_type(A2.x.name))    # N: Revealed type is 'Literal['x']'
 is_x(reveal_type(A2.x._name_))  # N: Revealed type is 'Literal['x']'
-reveal_type(A2.x.value)         # N: Revealed type is 'Any'
-reveal_type(A2.x._value_)       # N: Revealed type is 'Any'
+reveal_type(A2.x.value)         # N: Revealed type is 'builtins.int'
+reveal_type(A2.x._value_)       # N: Revealed type is 'builtins.int'
 is_x(reveal_type(A3.x.name))    # N: Revealed type is 'Literal['x']'
 is_x(reveal_type(A3.x._name_))  # N: Revealed type is 'Literal['x']'
 reveal_type(A3.x.value)         # N: Revealed type is 'builtins.int'
@@ -591,7 +591,7 @@ reveal_type(B1.x._value_)       # N: Revealed type is 'Any'
 is_x(reveal_type(B2.x.name))    # N: Revealed type is 'Literal['x']'
 is_x(reveal_type(B2.x._name_))  # N: Revealed type is 'Literal['x']'
 reveal_type(B2.x.value)         # N: Revealed type is 'builtins.int'
-reveal_type(B2.x._value_)       # N: Revealed type is 'Any'
+reveal_type(B2.x._value_)       # N: Revealed type is 'builtins.int'
 is_x(reveal_type(B3.x.name))    # N: Revealed type is 'Literal['x']'
 is_x(reveal_type(B3.x._name_))  # N: Revealed type is 'Literal['x']'
 reveal_type(B3.x.value)         # N: Revealed type is 'builtins.int'
@@ -612,8 +612,8 @@ reveal_type(C1.x.value)         # N: Revealed type is 'Any'
 reveal_type(C1.x._value_)       # N: Revealed type is 'Any'
 is_x(reveal_type(C2.x.name))    # N: Revealed type is 'Literal['x']'
 is_x(reveal_type(C2.x._name_))  # N: Revealed type is 'Literal['x']'
-reveal_type(C2.x.value)         # N: Revealed type is 'Any'
-reveal_type(C2.x._value_)       # N: Revealed type is 'Any'
+reveal_type(C2.x.value)         # N: Revealed type is 'builtins.int'
+reveal_type(C2.x._value_)       # N: Revealed type is 'builtins.int'
 is_x(reveal_type(C3.x.name))    # N: Revealed type is 'Literal['x']'
 is_x(reveal_type(C3.x._name_))  # N: Revealed type is 'Literal['x']'
 reveal_type(C3.x.value)         # N: Revealed type is 'builtins.int'
@@ -631,8 +631,8 @@ reveal_type(D1.x.value)         # N: Revealed type is 'Any'
 reveal_type(D1.x._value_)       # N: Revealed type is 'Any'
 is_x(reveal_type(D2.x.name))    # N: Revealed type is 'Literal['x']'
 is_x(reveal_type(D2.x._name_))  # N: Revealed type is 'Literal['x']'
-reveal_type(D2.x.value)         # N: Revealed type is 'Any'
-reveal_type(D2.x._value_)       # N: Revealed type is 'Any'
+reveal_type(D2.x.value)         # N: Revealed type is 'builtins.int'
+reveal_type(D2.x._value_)       # N: Revealed type is 'builtins.int'
 is_x(reveal_type(D3.x.name))    # N: Revealed type is 'Literal['x']'
 is_x(reveal_type(D3.x._name_))  # N: Revealed type is 'Literal['x']'
 reveal_type(D3.x.value)         # N: Revealed type is 'builtins.int'
@@ -650,8 +650,8 @@ class E3(Parent):
 
 is_x(reveal_type(E2.x.name))    # N: Revealed type is 'Literal['x']'
 is_x(reveal_type(E2.x._name_))  # N: Revealed type is 'Literal['x']'
-reveal_type(E2.x.value)         # N: Revealed type is 'Any'
-reveal_type(E2.x._value_)       # N: Revealed type is 'Any'
+reveal_type(E2.x.value)         # N: Revealed type is 'builtins.int'
+reveal_type(E2.x._value_)       # N: Revealed type is 'builtins.int'
 is_x(reveal_type(E3.x.name))    # N: Revealed type is 'Literal['x']'
 is_x(reveal_type(E3.x._name_))  # N: Revealed type is 'Literal['x']'
 reveal_type(E3.x.value)         # N: Revealed type is 'builtins.int'

--- a/test-data/unit/lib-stub/enum.pyi
+++ b/test-data/unit/lib-stub/enum.pyi
@@ -21,6 +21,10 @@ class Enum(metaclass=EnumMeta):
     _name_: str
     _value_: Any
 
+    # In reality, _generate_next_value_ is python3.6 only and has a different signature.
+    # However, this should be quick and doesn't require additional stubs (e.g. `staticmethod`)
+    def _generate_next_value_(self) -> Any: pass
+
 class IntEnum(int, Enum):
     value: int
 
@@ -37,4 +41,7 @@ class IntFlag(int, Flag):
 
 
 class auto(IntFlag):
+
     value: Any
+
+    def __init__(self) -> None: pass

--- a/test-data/unit/lib-stub/enum.pyi
+++ b/test-data/unit/lib-stub/enum.pyi
@@ -41,7 +41,4 @@ class IntFlag(int, Flag):
 
 
 class auto(IntFlag):
-
     value: Any
-
-    def __init__(self) -> None: pass


### PR DESCRIPTION
### Description

It is very common for enums to have homogenous member-value types.
In the case where we do not know what enum member we are dealing
with, we should sniff for that case and still collapse to a known
type if that assumption holds.

As a canonical example:

```py
from enum import Enum

class Color(Enum):
    RED = 1
    BLUE = 2

print(Color.RED.value)
reveal_type(Color.RED.value)

def print_color_value(color: Color) -> None:
    reveal_type(color.value)  # mypy reveals this as "Any", but it should be "builtins.int"

print_color_value(Color.BLUE)
```

## Test Plan

New unit tests have been added and all existing tests still pass.