### PR TITLE
Recognize -stubs directories as valid package directories

### DIFF
--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -127,6 +127,10 @@ class SourceFinder:
             res = ''
             base_dir = dir or '.'
         else:
+            # Remove -stubs to treat PEP-561 stub-only directories as packages
+            if base.endswith('-stubs'):
+                base = base[:-6]
+
             # Ensure that base is a valid python module name
             if not base.isidentifier():
                 raise InvalidSourceList('{} is not a valid Python package name'.format(base))

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -127,11 +127,9 @@ class SourceFinder:
             res = ''
             base_dir = dir or '.'
         else:
-            # Remove -stubs to treat PEP-561 stub-only directories as packages
-            if base.endswith('-stubs'):
-                base = base[:-6]
-
             # Ensure that base is a valid python module name
+            if base.endswith('-stubs'):
+                base = base[:-6]  # PEP-561 stub-only directory
             if not base.isidentifier():
                 raise InvalidSourceList('{} is not a valid Python package name'.format(base))
             parent, base_dir = self.crawl_up_dir(parent_dir)

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1176,3 +1176,39 @@ usage: mypy [-h] [-v] [-V] [more options; see below]
             [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
 mypy: error: Invalid error code(s): YOLO
 == Return code: 2
+
+[case testStubsDirectory]
+# cmd: mypy --error-summary pkg-stubs
+[file pkg-stubs/__init__.pyi]
+[file pkg-stubs/thing.pyi]
+class Thing: ...
+[out]
+Success: no issues found in 2 source files
+== Return code: 0
+
+[case testStubsDirectoryFile]
+# cmd: mypy --error-summary pkg-stubs/thing.pyi
+[file pkg-stubs/__init__.pyi]
+[file pkg-stubs/thing.pyi]
+class Thing: ...
+[out]
+Success: no issues found in 1 source file
+== Return code: 0
+
+[case testStubsSubDirectory]
+# cmd: mypy --error-summary src/pkg-stubs
+[file src/pkg-stubs/__init__.pyi]
+[file src/pkg-stubs/thing.pyi]
+class Thing: ...
+[out]
+Success: no issues found in 2 source files
+== Return code: 0
+
+[case testStubsSubDirectoryFile]
+# cmd: mypy --error-summary src/pkg-stubs/thing.pyi
+[file src/pkg-stubs/__init__.pyi]
+[file src/pkg-stubs/thing.pyi]
+class Thing: ...
+[out]
+Success: no issues found in 1 source file
+== Return code: 0


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

Currently, running `mypy typedpkg-stubs` (or any sub-file contained in the directory) in a project similar to https://github.com/ethanhs/stub-package results in an error:

```
mypy ./typedpkg-stubs
typedpkg-stubs is not a valid Python package name
```

This PR allows directories prefixed with `-stubs` which also contains a valid identifier before the `-` to be type checked.

Fixes #8229