### PR TITLE
Consider AnyType for TypeVar upperbound to avoid missing attribute

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -280,6 +280,9 @@ def analyze_type_type_member_access(name: str,
             item = upper_bound
         elif isinstance(upper_bound, TupleType):
             item = tuple_fallback(upper_bound)
+        elif isinstance(upper_bound, AnyType):
+            mx = mx.copy_modified(messages=ignore_messages)
+            return _analyze_member_access(name, fallback, mx, override_info)
     elif isinstance(typ.item, TupleType):
         item = tuple_fallback(typ.item)
     elif isinstance(typ.item, FunctionLike) and typ.item.is_type_obj():

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -598,6 +598,18 @@ class C:
 
 [builtins fixtures/list.pyi]
 
+[case testTypeVarBoundAttribute]
+# flags: --follow-imports=skip
+from typing import Type, TypeVar
+from a import A
+T = TypeVar('T', bound=A)
+def method(t: Type[T]) -> None:
+    t.a
+[file a.py]
+class A:
+    a: int = 7
+[out]
+
 [case testParameterLessGenericAsRestriction]
 from typing import Sequence, Iterable, TypeVar
 S = TypeVar('S', Sequence, Iterable)

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -598,7 +598,7 @@ class C:
 
 [builtins fixtures/list.pyi]
 
-[case testTypeVarBoundAttribute]
+[case testTypeVarWithAnyTypeBound]
 # flags: --follow-imports=skip
 from typing import Type, TypeVar
 from a import A


### PR DESCRIPTION
Fixes #4351

Using TypeVar upperbound with imported type and disabled imports following was causing missing attribute error since AnyType was not considered as upperbound option.