### PR TITLE
Speed up typechecking of dict, set and list expressions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3178,6 +3178,16 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def fast_container_type(
             self, items: List[Expression], container_fullname: str
     ) -> Optional[Type]:
+        """
+        Fast path to determine the type of a list or set literal,
+        based on the list of entries. This mostly impacts large
+        module-level constant definitions.
+
+        Limitations:
+         - no active type context
+         - no star expressions
+         - the joined type of all entries must be an Instance type
+        """
         ctx = self.type_context[-1]
         if ctx:
             return None
@@ -3283,6 +3293,16 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return TupleType(items, self.chk.named_generic_type('builtins.tuple', [fallback_item]))
 
     def fast_dict_type(self, e: DictExpr) -> Optional[Type]:
+        """
+        Fast path to determine the type of a dict literal,
+        based on the list of entries. This mostly impacts large
+        module-level constant definitions.
+
+        Limitations:
+         - no active type context
+         - only supported star expressions are other dict instances
+         - the joined types of all keys and values must be Instance types
+        """
         ctx = self.type_context[-1]
         if ctx:
             return None


### PR DESCRIPTION
Typechecking of dict, set, and list literals currently
goes through typechecking of the generic dict/set/list
constructor internally. This is usually fine but becomes
horrendously slow when the number of items is large:
 - for generic methods, `infer_arg_types_in_context` is
   called twice
 - `infer_arg_types_in_context` is O(n**2) where `n` is
   the number of arguments, which, in the case of a
   literal, is the number of items.

Add an `O(n)` fast path for deriving the type of simple
container literal expressions. This fast path only handle
a subset of cases but it provides a tremendous speedup for
the relatively common case of large literal constants.

The real-world example that motivated this change is a
1889 lines long dict constant representing the parsed value
of a mock JSON response from a 3rd party service, where
typechecking previously took upwards of 50s and is now
down to under 1s with this fast path.