### PR TITLE
Store the type for assignment expr targets

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3788,6 +3788,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         assert typ is not None
         self.chk.store_type(node, typ)
 
+        if isinstance(node, AssignmentExpr):
+            self.chk.store_type(node.target, typ)
+
         if (self.chk.options.disallow_any_expr and
                 not always_allow_any and
                 not self.chk.is_stub and

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3788,7 +3788,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         assert typ is not None
         self.chk.store_type(node, typ)
 
-        if isinstance(node, AssignmentExpr):
+        if isinstance(node, AssignmentExpr) and not has_uninhabited_component(typ):
             self.chk.store_type(node.target, typ)
 
         if (self.chk.options.disallow_any_expr and

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -377,3 +377,13 @@ def check_partial_list() -> None:
         z.append(3)
     reveal_type(z)  # N: Revealed type is 'builtins.list[builtins.int]'
 [builtins fixtures/list.pyi]
+
+[case testWalrusExpr]
+def func() -> None:
+    foo = Foo()
+    if x := foo.x:
+        pass
+
+class Foo:
+    def __init__(self) -> None:
+        self.x = 123


### PR DESCRIPTION
## Description

Assignment (walrus) expressions don't currently store their target types into the checker's type map, leading to an internal error when mypy goes to infer the type of that name downstream.  This PR stores the assignment target's type explicitly.  If this is not the right approach, feel free to comment/close this.  I just wanted to push this up so there's a demo of a potential fix.

Fixes #9054 

## Test Plan

~Still a work in progress, need to add tests.~ A test has been added that reproduces the OP's report, and this PR fixes it.