### PR TITLE
Fix partial type crash during protocol checking

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -543,6 +543,10 @@ def is_protocol_implementation(left: Instance, right: Instance,
             # print(member, 'of', right, 'has type', supertype)
             if not subtype:
                 return False
+            if isinstance(subtype, PartialType):
+                subtype = NoneType() if subtype.type is None else Instance(
+                    subtype.type, [AnyType(TypeOfAny.unannotated)] * len(subtype.type.type_vars)
+                )
             if not proper_subtype:
                 # Nominal check currently ignores arg names
                 # NOTE: If we ever change this, be sure to also change the call to

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2536,3 +2536,38 @@ class EmptyProto(Protocol): ...
 def hh(h: EmptyProto) -> None: pass
 hh(None)
 [builtins fixtures/tuple.pyi]
+
+
+[case testPartialTypeProtocol]
+from typing import Protocol
+
+class Flapper(Protocol):
+    def flap(self) -> int: ...
+
+class Blooper:
+    flap = None
+
+    def bloop(self, x: Flapper) -> None:
+        reveal_type([self, x])  # N: Revealed type is 'builtins.list[builtins.object*]'
+
+class Gleemer:
+    flap = []  # E: Need type annotation for 'flap' (hint: "flap: List[<type>] = ...")
+
+    def gleem(self, x: Flapper) -> None:
+        reveal_type([self, x])  # N: Revealed type is 'builtins.list[builtins.object*]'
+[builtins fixtures/tuple.pyi]
+
+
+[case testPartialTypeProtocolHashable]
+# flags: --strict-optional
+from typing import Protocol
+
+class Hashable(Protocol):
+    def __hash__(self) -> int: ...
+
+class DataArray:
+    __hash__ = None
+
+    def f(self, x: Hashable) -> None:
+        reveal_type([self, x])  # N: Revealed type is 'builtins.list[builtins.object*]'
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2559,13 +2559,16 @@ class Gleemer:
 
 
 [case testPartialTypeProtocolHashable]
-# flags: --strict-optional
+# flags: --no-strict-optional
 from typing import Protocol
 
 class Hashable(Protocol):
     def __hash__(self) -> int: ...
 
-class DataArray:
+class ObjectHashable:
+    def __hash__(self) -> int: ...
+
+class DataArray(ObjectHashable):
     __hash__ = None
 
     def f(self, x: Hashable) -> None:


### PR DESCRIPTION
In particular, this affected hashables, as in #9437 

Maybe there's a more standard way of falling back the PartialType? We could also consider moving this logic into is_subtype, but I'd be hesitant to do so. I'm okay with returning False based on the fallback Instance constructed here, but not returning True.