### PR TITLE
checkexpr: treat typevar values as object, not Any

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -228,6 +228,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             result = self.alias_type_in_runtime_context(node, node.no_args, e,
                                                         alias_definition=e.is_alias_rvalue
                                                         or lvalue)
+        elif isinstance(node, (TypeVarExpr, ParamSpecExpr)):
+            result = self.object_type()
         else:
             if isinstance(node, PlaceholderNode):
                 assert False, 'PlaceholderNode %r leaked to checker' % node.fullname

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -582,7 +582,8 @@ class Base(NamedTuple):
         reveal_type(self.x)  # N: Revealed type is 'builtins.int'
         self.x = 3  # E: Property "x" defined in "Base" is read-only
         self[1]  # E: Tuple index out of range
-        reveal_type(self[T])  # N: Revealed type is 'builtins.int'
+        reveal_type(self[T])  # N: Revealed type is 'Any' \
+                              # E: Invalid tuple index type (actual type "object", expected type "Union[int, slice]")
         return self.x
     def bad_override(self) -> int:
         return self.x

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -2808,6 +2808,5 @@ def f() -> int:  # E: Missing return statement
 from typing import TypeVar
 T = TypeVar("T")
 x: int
-x + T  # E: Unsupported left operand type for + ("int")
+x + T  # E: Unsupported operand types for + ("int" and "object")
 T()  # E: "object" not callable
-[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -2803,3 +2803,11 @@ def f() -> int:  # E: Missing return statement
     x: int
     assert isinstance(x, int), '...'
 [builtins fixtures/isinstance.pyi]
+
+[case testTypeVarAsValue]
+from typing import TypeVar
+T = TypeVar("T")
+x: int
+x + T  # E: Unsupported left operand type for + ("int")
+T()  # E: "object" not callable
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #9244 / #9497