### PR TITLE
[mypyc] Try to fix errors about int32_t on Python 3.5 and Appveyor

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -8,6 +8,7 @@
 #include <frameobject.h>
 #include <structmember.h>
 #include <assert.h>
+#include <stdint.h>
 #include "pythonsupport.h"
 #include "mypyc_util.h"
 


### PR DESCRIPTION
Explicitly include `stdint.h`. I'll monitor the Appveyor build to see if
this helps.

Work on #9501.