### PR TITLE
[mypyc] Try to fix mypy mac build failure on Python 3.5 on Travis

### DIFF
--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -24,11 +24,6 @@ INT_PREFIX = '__tmp_literal_int_'  # type: Final
 # Max short int we accept as a literal is based on 32-bit platforms,
 # so that we can just always emit the same code.
 
-# Maximum value for a short tagged integer.
-#
-# Note: Assume that the compiled code uses the same bit width as mypyc.
-MAX_LITERAL_SHORT_INT = sys.maxsize >> 1  # type: Final
-
 TOP_LEVEL_NAME = '__top_level__'  # type: Final # Special function representing module top level
 
 # Maximal number of subclasses for a class to trigger fast path in isinstance() checks.
@@ -37,6 +32,21 @@ FAST_ISINSTANCE_MAX_SUBCLASSES = 2  # type: Final
 IS_32_BIT_PLATFORM = sys.maxsize < (1 << 31)  # type: Final
 
 PLATFORM_SIZE = 4 if IS_32_BIT_PLATFORM else 8
+
+# Python 3.5 on macOS uses a hybrid 32/64-bit build that requires some workarounds.
+# The same generated C will be compiled in both 32 and 64 bit modes when building mypy
+# wheels (for an unknown reason).
+IS_MIXED_32_64_BIT_BUILD = sys.platform == 'darwin' and sys.version_info < (3, 6)
+
+# Maximum value for a short tagged integer.
+MAX_SHORT_INT = sys.maxsize >> 1
+
+# Maximum value for a short tagged integer represented as a C integer literal.
+#
+# Note: Assume that the compiled code uses the same bit width as mypyc, except for
+#       Python 3.5 on macOS.
+MAX_LITERAL_SHORT_INT = (sys.maxsize >> 1 if not IS_MIXED_32_64_BIT_BUILD
+                         else 2**30 - 1)  # type: Final
 
 # Runtime C library files
 RUNTIME_C_FILES = [

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -36,10 +36,12 @@ PLATFORM_SIZE = 4 if IS_32_BIT_PLATFORM else 8
 # Python 3.5 on macOS uses a hybrid 32/64-bit build that requires some workarounds.
 # The same generated C will be compiled in both 32 and 64 bit modes when building mypy
 # wheels (for an unknown reason).
-IS_MIXED_32_64_BIT_BUILD = sys.platform == 'darwin' and sys.version_info < (3, 6)
+#
+# Note that we use "in ['darwin']" because of https://github.com/mypyc/mypyc/issues/761.
+IS_MIXED_32_64_BIT_BUILD = sys.platform in ['darwin'] and sys.version_info < (3, 6)  # type: Final
 
 # Maximum value for a short tagged integer.
-MAX_SHORT_INT = sys.maxsize >> 1
+MAX_SHORT_INT = sys.maxsize >> 1  # type: Final
 
 # Maximum value for a short tagged integer represented as a C integer literal.
 #

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -15,7 +15,7 @@ from mypy.nodes import (
 )
 from mypy.types import TupleType, get_proper_type, Instance
 
-from mypyc.common import MAX_LITERAL_SHORT_INT
+from mypyc.common import MAX_SHORT_INT
 from mypyc.ir.ops import (
     Value, TupleGet, TupleSet, BasicBlock, Assign, LoadAddress
 )
@@ -373,7 +373,7 @@ def try_gen_slice_op(builder: IRBuilder, base: Value, index: SliceExpr) -> Optio
         else:
             # Replace missing end index with the largest short integer
             # (a sequence can't be longer).
-            end = builder.load_static_int(MAX_LITERAL_SHORT_INT)
+            end = builder.load_static_int(MAX_SHORT_INT)
         candidates = [list_slice_op, tuple_slice_op, str_slice_op]
         return builder.builder.matching_call_c(candidates, [base, begin, end], index.line)
 


### PR DESCRIPTION
We may be building a mixed 32/64-bit binary, so restrict the maximum integer
literal to what's supported on a 32-bit platform, since the same C code
needs to compile on both 32-bit and 64-bit architectures.

This will make some slicing operations a bit slower in 32/64-bit mode
(Python 3.5 on mac only).

Work on #9500.