### PR TITLE
Travis CI: install typing on python2 to restore some skipped tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ install:
 - pip install -U pip setuptools
 - pip install -U 'virtualenv<20'
 - pip install -U tox==3.9.0
+- python2 -m pip install --user -U typing
 - tox --notest
 
 # This is a big hack and only works because the layout of our directories


### PR DESCRIPTION
### Description

Fixes #9473

Typing used to be installed on python2 but was removed by [this change](https://github.com/python/mypy/commit/def2c63990dd#diff-354f30a63fb0907d4ad57269548329e3L15), I don't know why

in `mypy/util.py:try_find_python2_interpreter()` we try to find a valid python2 interpreter with typing installed.
If we don't find it, those tests are skipped.

However on [typeshed](https://github.com/python/typeshed/blob/master/tests/mypy_selftest.py#L14), the CI installs typing on python2 for mypy self test. Thus it doesn't skip the tests.

This caused the regression issue on typeshed

## Test Plan

I ran Travis CI on my forked repo.
I based a branch on 31862816ee87afc2b7514aec76249b884a9fdbef (the one that caused a python2 regression) and was able to reproduce the failing test: https://travis-ci.org/github/vbarbaresi/mypy/jobs/732473410
I noted that this change unskips around 40 tests (all from `testpythoneval.py`)