### PR TITLE
stubgen: fix package imports with aliases

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -327,16 +327,21 @@ class ImportTracker:
         #     'from pkg.m import f as foo' ==> module_for['foo'] == 'pkg.m'
         #     'from m import f' ==> module_for['f'] == 'm'
         #     'import m' ==> module_for['m'] == None
+        #     'import pkg.m' ==> module_for['pkg.m'] == None
+        #                    ==> module_for['pkg'] == None
         self.module_for = {}  # type: Dict[str, Optional[str]]
 
         # direct_imports['foo'] is the module path used when the name 'foo' was added to the
         # namespace.
         #   import foo.bar.baz  ==> direct_imports['foo'] == 'foo.bar.baz'
+        #                       ==> direct_imports['foo.bar'] == 'foo.bar.baz'
+        #                       ==> direct_imports['foo.bar.baz'] == 'foo.bar.baz'
         self.direct_imports = {}  # type: Dict[str, str]
 
         # reverse_alias['foo'] is the name that 'foo' had originally when imported with an
         # alias; examples
         #     'import numpy as np' ==> reverse_alias['np'] == 'numpy'
+        #     'import foo.bar as bar' ==> reverse_alias['bar'] == 'foo.bar'
         #     'from decimal import Decimal as D' ==> reverse_alias['D'] == 'Decimal'
         self.reverse_alias = {}  # type: Dict[str, str]
 
@@ -348,16 +353,30 @@ class ImportTracker:
 
     def add_import_from(self, module: str, names: List[Tuple[str, Optional[str]]]) -> None:
         for name, alias in names:
-            self.module_for[alias or name] = module
             if alias:
+                # 'from {module} import {name} as {alias}'
+                self.module_for[alias] = module
                 self.reverse_alias[alias] = name
+            else:
+                # 'from {module} import {name}'
+                self.module_for[name] = module
+                self.reverse_alias.pop(name, None)
+            self.direct_imports.pop(alias or name, None)
 
     def add_import(self, module: str, alias: Optional[str] = None) -> None:
-        name = module.split('.')[0]
-        self.module_for[alias or name] = None
-        self.direct_imports[name] = module
         if alias:
-            self.reverse_alias[alias] = name
+            # 'import {module} as {alias}'
+            self.module_for[alias] = None
+            self.reverse_alias[alias] = module
+        else:
+            # 'import {module}'
+            name = module
+            # add module and its parent packages
+            while name:
+                self.module_for[name] = None
+                self.direct_imports[name] = module
+                self.reverse_alias.pop(name, None)
+                name = name.rpartition('.')[0]
 
     def require_name(self, name: str) -> None:
         self.required_names.add(name.split('.')[0])
@@ -398,9 +417,8 @@ class ImportTracker:
                 # This name was found in an import ...
                 # We can already generate the import line
                 if name in self.reverse_alias:
-                    name, alias = self.reverse_alias[name], name
-                    source = self.direct_imports.get(name, 'FIXME')
-                    result.append("import {} as {}\n".format(source, alias))
+                    source = self.reverse_alias[name]
+                    result.append("import {} as {}\n".format(source, name))
                 elif name in self.reexports:
                     assert '.' not in name  # Because reexports only has nonqualified names
                     result.append("import {} as {}\n".format(name, name))

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -1577,7 +1577,7 @@ else:
     import cookielib
 
 [out]
-import FIXME as cookielib
+import cookielib as cookielib
 
 [case testCannotCalculateMRO_semanal]
 class X: pass
@@ -2177,3 +2177,114 @@ from collections import namedtuple
 
 class C:
     N = namedtuple('N', ['x', 'y'])
+
+[case testImports_directImportsWithAlias]
+import p.a as a
+import p.b as b
+
+x: a.X
+y: b.Y
+
+[out]
+import p.a as a
+import p.b as b
+
+x: a.X
+y: b.Y
+
+[case testImports_directImportsMixed]
+import p.a
+import p.a as a
+import p.b as b
+
+x: a.X
+y: b.Y
+z: p.a.X
+
+[out]
+import p.a as a
+import p.b as b
+import p.a
+
+x: a.X
+y: b.Y
+z: p.a.X
+
+[case testImport_overwrites_directWithAlias_from]
+import p.a as a
+from p import a
+
+x: a.X
+
+[out]
+from p import a as a
+
+x: a.X
+
+[case testImport_overwrites_directWithAlias_fromWithAlias]
+import p.a as a
+from p import b as a
+
+x: a.X
+
+[out]
+from p import b as a
+
+x: a.X
+
+[case testImports_overwrites_direct_from]
+import a
+from p import a
+
+x: a.X
+
+[out]
+from p import a as a
+
+x: a.X
+
+[case testImports_overwrites_direct_fromWithAlias]
+import a
+from p import b as a
+
+x: a.X
+
+[out]
+from p import b as a
+
+x: a.X
+
+[case testImports_overwrites_from_directWithAlias]
+from p import a
+import p.a as a
+
+x: a.X
+
+[out]
+import p.a as a
+
+x: a.X
+
+[case testImports_overwrites_fromWithAlias_direct]
+import a
+from p import b as a
+
+x: a.X
+
+[out]
+from p import b as a
+
+x: a.X
+
+[case testImports_direct]
+import p.a
+import pp
+
+x: a.X
+y: p.a.Y
+
+[out]
+import p.a
+
+x: a.X
+y: p.a.Y


### PR DESCRIPTION
### Description

Running `stubgen` on modules that import multiple packages using aliases did not produce the correct results:

Input:

```python
import p.a as a
import p.b as b

x: a.X
y: b.Y
```

Result:

  ```python
  import p.b as a  # <--- wrong module!
  import p.b as b
  
  x: a.X
  y: b.Y
  ```


## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

I added a bunch of new tests to stubgen.test.  

I had to change one of the expected results: `testConditionalImportAll_semanal`.  Previously, if more than one module import introduced the same name into the namespace, the data structures used to track imports were simply allowed to become corrupted, and the generator would produce `import FIXME as whatever`.  After correcting the internal state to fix the issue that prompted this PR, I realized it would be difficult to maintain the current output for this test, so I chose to change the behavior.   I went with what I think is a sane solution:  if multiple import statements target the same name, rather than produce invalid output, use the last import encountered.  The last import would be the one used at runtime.   I also considered using the first import, since this is what mypy would use. 



 
