### PR TITLE
Add disable/enable error code opt to config_types

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -94,6 +94,8 @@ config_types = {
     'plugins': lambda s: [p.strip() for p in s.split(',')],
     'always_true': lambda s: [p.strip() for p in s.split(',')],
     'always_false': lambda s: [p.strip() for p in s.split(',')],
+    'disable_error_code': lambda s: [p.strip() for p in s.split(',')],
+    'enable_error_code': lambda s: [p.strip() for p in s.split(',')],
     'package_root': lambda s: [p.strip() for p in s.split(',')],
     'cache_dir': expand_path,
     'python_executable': expand_path,


### PR DESCRIPTION
The `disable_error_code` and `enable_error_code` config file options were being cast to list, as they were not
included in the config_types dict in config_parser.py.