### PR TITLE
Document --disable-error-code cli and config option

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -480,6 +480,11 @@ of the above sections.
            # 'items' now has type List[List[str]]
            ...
 
+.. option:: --disable-error-code CODE
+
+    This flag will cause mypy to suppress errors with error code ``CODE``.
+    This flag may be repeated.
+
 .. option:: --local-partial-types
 
     In mypy, the most common cases for partial types are variables initialized using ``None``,

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -480,11 +480,6 @@ of the above sections.
            # 'items' now has type List[List[str]]
            ...
 
-.. option:: --disable-error-code CODE
-
-    This flag will cause mypy to suppress errors with error code ``CODE``.
-    This flag may be repeated.
-
 .. option:: --local-partial-types
 
     In mypy, the most common cases for partial types are variables initialized using ``None``,

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -533,7 +533,7 @@ Miscellaneous strictness flags
 
     :type: comma-separated list of strings
 
-    Causes mypy to suppress errors with given error codes.
+    Allows disabling one or multiple error codes globally.
 
 .. confval:: implicit_reexport
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -529,6 +529,12 @@ Miscellaneous strictness flags
     Allows variables to be redefined with an arbitrary type, as long as the redefinition
     is in the same block and nesting level as the original definition.
 
+.. confval:: disable_error_code
+
+    :type: comma-separated list of strings
+
+    Causes mypy to suppress errors with given error codes.
+
 .. confval:: implicit_reexport
 
     :type: boolean


### PR DESCRIPTION
Added the --disable-error-code cli option and disable_error_code config option to the documentation.