### PR TITLE
Include conftest.py in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,5 +19,5 @@ recursive-include mypyc/doc *.rst *.py *.md Makefile *.bat
 include mypy_bootstrap.ini
 include mypy_self_check.ini
 include LICENSE
-include runtests.py
+include conftest.py runtests.py
 include pytest.ini


### PR DESCRIPTION
### Description
Hi,
This ensures `conftest.py` will be present in source distributions. When running tests from PyPI's `mypy-0.782.tar.gz`, only a fraction are collected.

## Test Plan
I don't think there is anything special to test. I have successfully run all the tests from PyPI's `mypy-0.782.tar.gz` after re-adding `conftest.py`.
