### PR TITLE
py39: fix mypyc complaint

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1257,11 +1257,13 @@ class ASTConverter:
 
     # ExtSlice(slice* dims)
     def visit_ExtSlice(self, n: ast3.ExtSlice) -> TupleExpr:
-        return TupleExpr(self.translate_expr_list(n.dims))
+        # cast for mypyc's benefit on Python 3.9
+        return TupleExpr(self.translate_expr_list(cast(Any, n.dims)))
 
     # Index(expr value)
     def visit_Index(self, n: Index) -> Node:
-        return self.visit(n.value)
+        # cast for mypyc's benefit on Python 3.9
+        return self.visit(cast(Any, n.value))
 
 
 class TypeConverter:


### PR DESCRIPTION
I was trying to build wheels for Python 3.9 as part of #9536, but ran
into this issue. You'll notice a couple hundred lines up msullivan
points out that mypyc can't handle conditional method definition, so
that's not an option here.

```
/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpok7vxky0
    mypy/fastparse.py:1260: error: "ExtSlice" has no attribute "dims"
    mypy/fastparse.py:1264: error: "Index" has no attribute "value"
ERROR: Command errored out with exit status 1: /opt/_internal/cpython-3.9.0rc2/bin/python3.9 /opt/_internal/cpython-3.9.0rc2/lib/python3.9/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpok7vxky0 Check the logs for full command output.
```