### PR TITLE
Update wheel download script to use the correct file names for macOS

### DIFF
--- a/misc/download-mypyc-wheels.py
+++ b/misc/download-mypyc-wheels.py
@@ -29,7 +29,7 @@ def download_files(version):
     for pyver in range(MIN_VER, MAX_VER + 1):
         for platform in PLATFORMS:
             abi_tag = "" if pyver >= 8 else "m"
-            macos_ver = 9 if pyver >= 8 else 6
+            macos_ver = 9 if pyver >= 6 else 6
             url = URL.format(
                 base=BASE_URL,
                 version=version,


### PR DESCRIPTION
We switched the macOS version in the mypy_mypyc-wheels repository
for Python 3.6 and 3.7 wheels.

Examples of wheel names:
https://github.com/mypyc/mypy_mypyc-wheels/releases/tag/v0.790%2Bdev.7273e9ab1664b59a74d9bd1d2361bbeb9864b7ab

The motivation for the original change was to avoid building anything 
32-bit, since that's not tested and not officially supported anyway. If
this change causes problems, we should be able to switch this back,
but let's see how this goes.