### PR TITLE
disable unreachable warnings in boolean ops on TypeVars with value restriction

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2762,7 +2762,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         # the analysis from the semanal phase below. We assume that nodes
         # marked as unreachable during semantic analysis were done so intentionally.
         # So, we shouldn't report an error.
-        if self.chk.options.warn_unreachable:
+        if self.chk.should_report_unreachable_issues():
             if right_map is None:
                 self.msg.unreachable_right_operand(e.op, e.right)
 

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -925,6 +925,7 @@ from typing import TypeVar, Generic
 
 T1 = TypeVar('T1', bound=int)
 T2 = TypeVar('T2', int, str)
+T3 = TypeVar('T3', None, str)
 
 def test1(x: T1) -> T1:
     if isinstance(x, int):
@@ -960,6 +961,19 @@ class Test3(Generic[T2]):
         if False:
             # Same issue as above
             reveal_type(self.x)
+
+
+class Test4(Generic[T3]):
+    def __init__(self, x: T3):
+        # https://github.com/python/mypy/issues/9456
+        # On TypeVars with value restrictions, we currently have no way
+        # of checking a statement for all the type expansions.
+        # Thus unreachable warnings are disabled
+        if x and False:
+            pass
+        # This test should fail after this limitation is removed.
+        if False and x:
+            pass
 
 [builtins fixtures/isinstancelist.pyi]
 


### PR DESCRIPTION
#### Description

This paragraph explains the limitation with TypeVars:
https://github.com/python/mypy/blob/eb50379defc13cea9a8cbbdc0254a578ef6c415e/mypy/checker.py#L967-#L974

We currently have no way of checking for all the type expansions,
and it's causing one part of the issue https://github.com/python/mypy/issues/9456

Using `self.chk.should_report_unreachable_issues()` honors the suppression of
the unreachable warning for TypeVar with value restrictions

#### Test Plan

I added a test statement that reproduces the unreachable false positive.
I added another test statement that is currently a false negative for the moment, because of the suppression for TypeVar type expansions.