### PR TITLE
Require first argument of namedtuple to match with variable name

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -359,7 +359,7 @@ class SemanticAnalyzerPluginInterface:
 # A context for querying for configuration data about a module for
 # cache invalidation purposes.
 ReportConfigContext = NamedTuple(
-    'DynamicClassDefContext', [
+    'ReportConfigContext', [
         ('id', str),        # Module name
         ('path', str),      # Module file path
         ('is_check', bool)  # Is this invocation for checking whether the config matches

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2177,13 +2177,17 @@ class SemanticAnalyzer(NodeVisitor[None],
             return False
         lvalue = s.lvalues[0]
         name = lvalue.name
-        is_named_tuple, info = self.named_tuple_analyzer.check_namedtuple(s.rvalue, name,
-                                                                          self.is_func_scope())
-        if not is_named_tuple:
+        internal_name, info = self.named_tuple_analyzer.check_namedtuple(s.rvalue, name,
+                                                                         self.is_func_scope())
+        if internal_name is None:
             return False
         if isinstance(lvalue, MemberExpr):
             self.fail("NamedTuple type as an attribute is not supported", lvalue)
             return False
+        if internal_name != name:
+            self.fail("First argument to namedtuple() should be '{}', not '{}'".format(
+                name, internal_name), s)
+            return True
         # Yes, it's a valid namedtuple, but defer if it is not ready.
         if not info:
             self.mark_incomplete(name, lvalue, becomes_typeinfo=True)
@@ -4819,9 +4823,9 @@ class SemanticAnalyzer(NodeVisitor[None],
                               allow_placeholder: bool = False) -> Optional[Type]:
         if isinstance(expr, CallExpr):
             expr.accept(self)
-            is_named_tuple, info = self.named_tuple_analyzer.check_namedtuple(expr, None,
-                                                                              self.is_func_scope())
-            if not is_named_tuple:
+            internal_name, info = self.named_tuple_analyzer.check_namedtuple(expr, None,
+                                                                             self.is_func_scope())
+            if internal_name is None:
                 # Some form of namedtuple is the only valid type that looks like a call
                 # expression. This isn't a valid type.
                 raise TypeTranslationError()

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2186,7 +2186,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             return False
         if internal_name != name:
             self.fail("First argument to namedtuple() should be '{}', not '{}'".format(
-                name, internal_name), s)
+                name, internal_name), s.rvalue)
             return True
         # Yes, it's a valid namedtuple, but defer if it is not ready.
         if not info:

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -245,7 +245,7 @@ class NamedTupleAnalyzer:
         Returns a 4-tuple:
         - List of argument names
         - List of argument types
-        - Number of arguments that have a default value
+        - List of default values
         - Whether the definition typechecked.
 
         Return None if at least one of the types is not ready.

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -180,7 +180,7 @@ class NamedTupleAnalyzer:
                 name = 'namedtuple@' + str(call.line)
             info = self.build_namedtuple_typeinfo(name, [], [], {}, node.line)
             self.store_namedtuple_info(info, name, call, is_typed)
-            return typename, info
+            return name, info
 
         # We use the variable name as the class name if it exists. If
         # it doesn't, we use the name passed as an argument. We prefer

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -180,6 +180,11 @@ class NamedTupleAnalyzer:
             self.store_namedtuple_info(info, name, call, is_typed)
             return True, info
 
+        typename = cast(Union[StrExpr, BytesExpr, UnicodeExpr], call.args[0]).value
+        if var_name and var_name != typename:
+            self.fail("First argument to namedtuple() should be '{}', not '{}'".format(
+                var_name, typename), call)
+
         # We use the variable name as the class name if it exists. If
         # it doesn't, we use the name passed as an argument. We prefer
         # the variable name because it should be unique inside a
@@ -188,7 +193,7 @@ class NamedTupleAnalyzer:
         if var_name:
             name = var_name
         else:
-            name = cast(Union[StrExpr, BytesExpr, UnicodeExpr], call.args[0]).value
+            name = typename
 
         if var_name is None or is_func_scope:
             # There are two special cases where need to give it a unique name derived

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -165,12 +165,12 @@ class NamedTupleAnalyzer:
             is_typed = True
         else:
             return None, None
-        typename = cast(Union[StrExpr, BytesExpr, UnicodeExpr], call.args[0]).value
         result = self.parse_namedtuple_args(call, fullname)
         if result:
             items, types, defaults, ok = result
         else:
             # This is a valid named tuple but some types are not ready.
+            typename = cast(Union[StrExpr, BytesExpr, UnicodeExpr], call.args[0]).value
             return typename, None
         if not ok:
             # Error. Construct dummy return value.
@@ -182,6 +182,7 @@ class NamedTupleAnalyzer:
             self.store_namedtuple_info(info, name, call, is_typed)
             return name, info
 
+        typename = cast(Union[StrExpr, BytesExpr, UnicodeExpr], call.args[0]).value
         # We use the variable name as the class name if it exists. If
         # it doesn't, we use the name passed as an argument. We prefer
         # the variable name because it should be unique inside a

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -145,7 +145,7 @@ class NamedTupleAnalyzer:
         which this is assigned, if any.
 
         Return a tuple of two items:
-          * Name of the named tuple, which is passed as the first argument to namedtuple,
+          * Internal name of the named tuple (e.g. the name passed as an argument to namedtuple)
             or None if it is not a valid named tuple
           * Corresponding TypeInfo, or None if not ready.
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5056,7 +5056,9 @@ from typing import NamedTuple
 NT = NamedTuple('BadName', [('x', int)])
 [builtins fixtures/tuple.pyi]
 [out]
+tmp/b.py:2: error: First argument to namedtuple() should be 'NT', not 'BadName'
 [out2]
+tmp/b.py:2: error: First argument to namedtuple() should be 'NT', not 'BadName'
 tmp/a.py:3: note: Revealed type is 'Tuple[builtins.int, fallback=b.NT]'
 
 [case testNewAnalyzerIncrementalBrokenNamedTupleNested]
@@ -5076,7 +5078,9 @@ def test() -> None:
     NT = namedtuple('BadName', ['x', 'y'])
 [builtins fixtures/list.pyi]
 [out]
+tmp/b.py:4: error: First argument to namedtuple() should be 'NT', not 'BadName'
 [out2]
+tmp/b.py:4: error: First argument to namedtuple() should be 'NT', not 'BadName'
 
 [case testNewAnalyzerIncrementalMethodNamedTuple]
 

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -962,3 +962,11 @@ def foo():
 Type1 = NamedTuple('Type1', [('foo', foo)])  # E: Function "b.foo" is not valid as a type  # N: Perhaps you need "Callable[...]" or a callback protocol?
 
 [builtins fixtures/tuple.pyi]
+
+[case testNamedTupleTypeNameMatchesVariableName]
+from typing import NamedTuple
+from collections import namedtuple
+
+A = NamedTuple('X', [('a', int)])  # E: First argument to namedtuple() should be 'A', not 'X'
+B = namedtuple('X', ['a'])         # E: First argument to namedtuple() should be 'B', not 'X'
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -969,4 +969,7 @@ from collections import namedtuple
 
 A = NamedTuple('X', [('a', int)])  # E: First argument to namedtuple() should be 'A', not 'X'
 B = namedtuple('X', ['a'])         # E: First argument to namedtuple() should be 'B', not 'X'
+
+C = NamedTuple('X', [('a', 'Y')])  # E: First argument to namedtuple() should be 'C', not 'X'
+class Y: ...
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -9622,26 +9622,3 @@ class C:
 [out]
 ==
 main:5: error: Unsupported left operand type for + ("str")
-
-[case testReexportNamedTupleChange]
-from m import M
-
-def f(x: M) -> None: ...
-
-f(M(0))
-
-[file m.py]
-from n import M
-
-[file n.py]
-from typing import NamedTuple
-M = NamedTuple('M', [('x', int)])
-
-[file n.py.2]
-# change the line numbers
-from typing import NamedTuple
-M = NamedTuple('M', [('x', int)])
-
-[builtins fixtures/tuple.pyi]
-[out]
-==

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -9635,12 +9635,12 @@ from n import M
 
 [file n.py]
 from typing import NamedTuple
-M = NamedTuple('_N', [('x', int)])
+M = NamedTuple('M', [('x', int)])
 
 [file n.py.2]
 # change the line numbers
 from typing import NamedTuple
-M = NamedTuple('_N', [('x', int)])
+M = NamedTuple('M', [('x', int)])
 
 [builtins fixtures/tuple.pyi]
 [out]


### PR DESCRIPTION
### Description

Closes #4589

This PR modifies `check_namedtuple` to return the internal name of the namedtuples (e.g. the content of the first argument of namedtuple/NamedTuple) so that the callers, especially `analyze_namedtuple_assign`, can check if the name of the variable on the l.h.s. matches with the first argument of the namedtuple.

### Test Plan

Added a code snippet from #4589 as the new test.
Also, I deleted `testReexportNamedTupleChange` (which was added in #6698 for https://github.com/python/mypy/issues/6548#issuecomment-484277202) since we wouldn't need to worry about this case when this is merged.