### PR TITLE
TypeVisitor and Co now support allow_interpreted_subclasses=True

### DIFF
--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -14,7 +14,7 @@ other modules refer to them.
 from abc import abstractmethod
 from mypy.ordered_dict import OrderedDict
 from typing import Generic, TypeVar, cast, Any, List, Callable, Iterable, Optional, Set, Sequence
-from mypy_extensions import trait
+from mypy_extensions import trait, mypyc_attr
 
 T = TypeVar('T')
 
@@ -28,6 +28,7 @@ from mypy.types import (
 
 
 @trait
+@mypyc_attr(allow_interpreted_subclasses=True)
 class TypeVisitor(Generic[T]):
     """Visitor class for types (Type subclasses).
 
@@ -104,6 +105,7 @@ class TypeVisitor(Generic[T]):
 
 
 @trait
+@mypyc_attr(allow_interpreted_subclasses=True)
 class SyntheticTypeVisitor(TypeVisitor[T]):
     """A TypeVisitor that also knows how to visit synthetic AST constructs.
 
@@ -134,6 +136,7 @@ class SyntheticTypeVisitor(TypeVisitor[T]):
         pass
 
 
+@mypyc_attr(allow_interpreted_subclasses=True)
 class TypeTranslator(TypeVisitor[Type]):
     """Identity type transformation.
 
@@ -241,6 +244,7 @@ class TypeTranslator(TypeVisitor[Type]):
         pass
 
 
+@mypyc_attr(allow_interpreted_subclasses=True)
 class TypeQuery(SyntheticTypeVisitor[T]):
     """Visitor for performing queries of types.
 


### PR DESCRIPTION
# Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

Now these types can be extended from plugin code.
Previously it was impossible:

```python
from mypy.type_visitor import TypeVisitor


class KindTranslator(TypeVisitor):
    ...
```

Was giving:

```
TypeError: interpreted classes cannot inherit from compiled traits
```

But, this is a very powerful tool. Some complex type manipulations do require this (or similar) tool.
For example:
- https://github.com/dry-python/returns/issues/391
- https://github.com/dry-python/returns/issues/631

More context: https://github.com/python/mypy/issues/9001#issuecomment-710315985


## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

I actually don't have any test plan at the moment. I would be very happy to receive any advice! 👍 
