### PR TITLE
Create a copy of TypeQuery specialized for bool

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -33,7 +33,7 @@ from mypy.types import (
     Type, AnyType, CallableType, FunctionLike, Overloaded, TupleType, TypedDictType,
     Instance, NoneType, strip_type, TypeType, TypeOfAny,
     UnionType, TypeVarId, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarDef,
-    is_named_instance, union_items, TypeQuery, LiteralType,
+    is_named_instance, union_items, TypeQueryBool, LiteralType,
     is_optional, remove_optional, TypeTranslator, StarType, get_proper_type, ProperType,
     get_proper_types, is_literal_type, TypeAliasType)
 from mypy.sametypes import is_same_type
@@ -5441,11 +5441,11 @@ def is_valid_inferred_type(typ: Type) -> bool:
     return not typ.accept(NothingSeeker())
 
 
-class NothingSeeker(TypeQuery[bool]):
+class NothingSeeker(TypeQueryBool):
     """Find any <nothing> types resulting from failed (ambiguous) type inference."""
 
     def __init__(self) -> None:
-        super().__init__(any)
+        super().__init__(0)
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> bool:
         return t.ambiguous

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5445,7 +5445,7 @@ class NothingSeeker(TypeQueryBool):
     """Find any <nothing> types resulting from failed (ambiguous) type inference."""
 
     def __init__(self) -> None:
-        super().__init__(0)
+        super().__init__(TypeQueryBool.STRATEGY_ANY)
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> bool:
         return t.ambiguous

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4071,9 +4071,9 @@ def has_any_type(t: Type) -> bool:
     return t.accept(HasAnyType())
 
 
-class HasAnyType(types.TypeQuery[bool]):
+class HasAnyType(types.TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(any)
+        super().__init__(0)
 
     def visit_any(self, t: AnyType) -> bool:
         return t.type_of_any != TypeOfAny.special_form  # special forms are not real Any types
@@ -4128,7 +4128,7 @@ def replace_callable_return_type(c: CallableType, new_ret_type: Type) -> Callabl
     return c.copy_modified(ret_type=new_ret_type)
 
 
-class ArgInferSecondPassQuery(types.TypeQuery[bool]):
+class ArgInferSecondPassQuery(types.TypeQueryBool):
     """Query whether an argument type should be inferred in the second pass.
 
     The result is True if the type has a type variable in a callable return
@@ -4136,16 +4136,16 @@ class ArgInferSecondPassQuery(types.TypeQuery[bool]):
     a type variable.
     """
     def __init__(self) -> None:
-        super().__init__(any)
+        super().__init__(0)
 
     def visit_callable_type(self, t: CallableType) -> bool:
         return self.query_types(t.arg_types) or t.accept(HasTypeVarQuery())
 
 
-class HasTypeVarQuery(types.TypeQuery[bool]):
+class HasTypeVarQuery(types.TypeQueryBool):
     """Visitor for querying whether a type has a type variable component."""
     def __init__(self) -> None:
-        super().__init__(any)
+        super().__init__(0)
 
     def visit_type_var(self, t: TypeVarType) -> bool:
         return True
@@ -4155,10 +4155,10 @@ def has_erased_component(t: Optional[Type]) -> bool:
     return t is not None and t.accept(HasErasedComponentsQuery())
 
 
-class HasErasedComponentsQuery(types.TypeQuery[bool]):
+class HasErasedComponentsQuery(types.TypeQueryBool):
     """Visitor for querying whether a type has an erased component."""
     def __init__(self) -> None:
-        super().__init__(any)
+        super().__init__(0)
 
     def visit_erased_type(self, t: ErasedType) -> bool:
         return True
@@ -4168,10 +4168,10 @@ def has_uninhabited_component(t: Optional[Type]) -> bool:
     return t is not None and t.accept(HasUninhabitedComponentsQuery())
 
 
-class HasUninhabitedComponentsQuery(types.TypeQuery[bool]):
+class HasUninhabitedComponentsQuery(types.TypeQueryBool):
     """Visitor for querying whether a type has an UninhabitedType component."""
     def __init__(self) -> None:
-        super().__init__(any)
+        super().__init__(0)
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> bool:
         return True

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4073,7 +4073,7 @@ def has_any_type(t: Type) -> bool:
 
 class HasAnyType(types.TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(0)
+        super().__init__(types.TypeQueryBool.STRATEGY_ANY)
 
     def visit_any(self, t: AnyType) -> bool:
         return t.type_of_any != TypeOfAny.special_form  # special forms are not real Any types
@@ -4136,7 +4136,7 @@ class ArgInferSecondPassQuery(types.TypeQueryBool):
     a type variable.
     """
     def __init__(self) -> None:
-        super().__init__(0)
+        super().__init__(types.TypeQueryBool.STRATEGY_ANY)
 
     def visit_callable_type(self, t: CallableType) -> bool:
         return self.query_types(t.arg_types) or t.accept(HasTypeVarQuery())
@@ -4145,7 +4145,7 @@ class ArgInferSecondPassQuery(types.TypeQueryBool):
 class HasTypeVarQuery(types.TypeQueryBool):
     """Visitor for querying whether a type has a type variable component."""
     def __init__(self) -> None:
-        super().__init__(0)
+        super().__init__(types.TypeQueryBool.STRATEGY_ANY)
 
     def visit_type_var(self, t: TypeVarType) -> bool:
         return True
@@ -4158,7 +4158,7 @@ def has_erased_component(t: Optional[Type]) -> bool:
 class HasErasedComponentsQuery(types.TypeQueryBool):
     """Visitor for querying whether a type has an erased component."""
     def __init__(self) -> None:
-        super().__init__(0)
+        super().__init__(types.TypeQueryBool.STRATEGY_ANY)
 
     def visit_erased_type(self, t: ErasedType) -> bool:
         return True
@@ -4171,7 +4171,7 @@ def has_uninhabited_component(t: Optional[Type]) -> bool:
 class HasUninhabitedComponentsQuery(types.TypeQueryBool):
     """Visitor for querying whether a type has an UninhabitedType component."""
     def __init__(self) -> None:
-        super().__init__(0)
+        super().__init__(types.TypeQueryBool.STRATEGY_ANY)
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> bool:
         return True

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -257,7 +257,7 @@ def is_complete_type(typ: Type) -> bool:
 
 class CompleteTypeVisitor(TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(1)
+        super().__init__(TypeQueryBool.STRATEGY_ALL)
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> bool:
         return False

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -6,7 +6,7 @@ from typing_extensions import Final
 from mypy.types import (
     CallableType, Type, TypeVisitor, UnboundType, AnyType, NoneType, TypeVarType, Instance,
     TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType, DeletedType,
-    UninhabitedType, TypeType, TypeVarId, TypeQuery, is_named_instance, TypeOfAny, LiteralType,
+    UninhabitedType, TypeType, TypeVarId, TypeQueryBool, is_named_instance, TypeOfAny, LiteralType,
     ProperType, get_proper_type, TypeAliasType
 )
 from mypy.maptype import map_instance_to_supertype
@@ -255,9 +255,9 @@ def is_complete_type(typ: Type) -> bool:
     return typ.accept(CompleteTypeVisitor())
 
 
-class CompleteTypeVisitor(TypeQuery[bool]):
+class CompleteTypeVisitor(TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(all)
+        super().__init__(1)
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> bool:
         return False

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -93,7 +93,7 @@ from mypy.types import (
     TypeTranslator, TypeOfAny, TypeType, NoneType, PlaceholderType, TPDICT_NAMES, ProperType,
     get_proper_type, get_proper_types, TypeAliasType)
 from mypy.typeops import function_type
-from mypy.type_visitor import TypeQuery
+from mypy.type_visitor import TypeQueryBool, TypeQuery
 from mypy.nodes import implicit_module_attrs
 from mypy.typeanal import (
     TypeAnalyser, analyze_type_alias, no_subscript_builtin_alias,
@@ -4971,9 +4971,9 @@ class SemanticAnalyzer(NodeVisitor[None],
         return flag in self.future_import_flags
 
 
-class HasPlaceholders(TypeQuery[bool]):
+class HasPlaceholders(TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(any)
+        super().__init__(0)
 
     def visit_placeholder_type(self, t: PlaceholderType) -> bool:
         return True

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4973,7 +4973,7 @@ class SemanticAnalyzer(NodeVisitor[None],
 
 class HasPlaceholders(TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(0)
+        super().__init__(TypeQueryBool.STRATEGY_ANY)
 
     def visit_placeholder_type(self, t: PlaceholderType) -> bool:
         return True

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -93,7 +93,7 @@ from mypy.types import (
     TypeTranslator, TypeOfAny, TypeType, NoneType, PlaceholderType, TPDICT_NAMES, ProperType,
     get_proper_type, get_proper_types, TypeAliasType)
 from mypy.typeops import function_type
-from mypy.type_visitor import TypeQueryBool, TypeQuery
+from mypy.type_visitor import TypeQueryBool
 from mypy.nodes import implicit_module_attrs
 from mypy.typeanal import (
     TypeAnalyser, analyze_type_alias, no_subscript_builtin_alias,

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -11,7 +11,7 @@ from typing_extensions import Final
 from mypy.traverser import TraverserVisitor
 from mypy.typeanal import collect_all_inner_types
 from mypy.types import (
-    Type, AnyType, Instance, FunctionLike, TupleType, TypeVarType, TypeQuery, CallableType,
+    Type, AnyType, Instance, FunctionLike, TupleType, TypeVarType, TypeQueryBool, CallableType,
     TypeOfAny, get_proper_type, get_proper_types
 )
 from mypy import nodes
@@ -423,9 +423,9 @@ def is_imprecise(t: Type) -> bool:
     return t.accept(HasAnyQuery())
 
 
-class HasAnyQuery(TypeQuery[bool]):
+class HasAnyQuery(TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(any)
+        super().__init__(0)
 
     def visit_any(self, t: AnyType) -> bool:
         return not is_special_form_any(t)

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -425,7 +425,7 @@ def is_imprecise(t: Type) -> bool:
 
 class HasAnyQuery(TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(0)
+        super().__init__(TypeQueryBool.STRATEGY_ANY)
 
     def visit_any(self, t: AnyType) -> bool:
         return not is_special_form_any(t)

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -456,16 +456,15 @@ class TypeQueryBool(SyntheticTypeVisitor[bool]):
         Skip type aliases already visited types to avoid infinite recursion.
         Return
         """
-        res = []  # type: List[bool]
         for t in types:
             if isinstance(t, TypeAliasType):
                 # Avoid infinite recursion for recursive type aliases.
                 if t in self.seen_aliases:
                     continue
                 self.seen_aliases.add(t)
-            accept = t.accept(self)
-            if accept and self.strategy == self.STRATEGY_ANY:
+            res = t.accept(self)
+            if res and self.strategy == self.STRATEGY_ANY:
                 return True
-            elif not accept and self.strategy == self.STRATEGY_ALL:
+            elif not res and self.strategy == self.STRATEGY_ALL:
                 return False
         return self.strategy == self.STRATEGY_ALL

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -454,7 +454,6 @@ class TypeQueryBool(SyntheticTypeVisitor[bool]):
 
         Use the strategy to combine the results.
         Skip type aliases already visited types to avoid infinite recursion.
-        Return
         """
         for t in types:
             if isinstance(t, TypeAliasType):

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -368,6 +368,7 @@ def bool_strategy_empty(strategy_constant: int) -> bool:
         return True
     return False
 
+
 class TypeQueryBool(SyntheticTypeVisitor[bool]):
     """Specialized visitor for boolean strategies
 
@@ -467,23 +468,15 @@ class TypeQueryBool(SyntheticTypeVisitor[bool]):
         Return
         """
         res = []  # type: List[bool]
-        if self.strategy_constant == BoolStrategies.ALL_STRATEGY:
-            for t in types:
-                if isinstance(t, TypeAliasType):
-                    # Avoid infinite recursion for recursive type aliases.
-                    if t in self.seen_aliases:
-                        continue
-                    self.seen_aliases.add(t)
-                if not t.accept(self):
-                    return False
-            return True
-
-        else:
-            for t in types:
-                if isinstance(t, TypeAliasType):
-                    if t in self.seen_aliases:
-                        continue
-                    self.seen_aliases.add(t)
-                if t.accept(self):
-                    return True
-        return False
+        for t in types:
+            if isinstance(t, TypeAliasType):
+                # Avoid infinite recursion for recursive type aliases.
+                if t in self.seen_aliases:
+                    continue
+                self.seen_aliases.add(t)
+            res = t.accept(self)
+            if res and self.strategy_constant == BoolStrategies.ANY_STRATEGY:
+                return True
+            elif not res and self.strategy_constant == BoolStrategies.ALL_STRATEGY:
+                return False
+        return self.strategy_constant == BoolStrategies.ALL_STRATEGY

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -15,7 +15,7 @@ from mypy.types import (
     Type, UnboundType, TypeVarType, TupleType, TypedDictType, UnionType, Instance, AnyType,
     CallableType, NoneType, ErasedType, DeletedType, TypeList, TypeVarDef, SyntheticTypeVisitor,
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType,
-    CallableArgument, TypeQuery, union_items, TypeOfAny, LiteralType, RawExpressionType,
+    CallableArgument, TypeQuery, TypeQueryBool, union_items, TypeOfAny, LiteralType, RawExpressionType,
     PlaceholderType, Overloaded, get_proper_type, TypeAliasType, TypeVarLikeDef, ParamSpecDef
 )
 
@@ -1190,9 +1190,9 @@ def has_explicit_any(t: Type) -> bool:
     return t.accept(HasExplicitAny())
 
 
-class HasExplicitAny(TypeQuery[bool]):
+class HasExplicitAny(TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(any)
+        super().__init__(0)
 
     def visit_any(self, t: AnyType) -> bool:
         return t.type_of_any == TypeOfAny.explicit
@@ -1211,9 +1211,9 @@ def has_any_from_unimported_type(t: Type) -> bool:
     return t.accept(HasAnyFromUnimportedType())
 
 
-class HasAnyFromUnimportedType(TypeQuery[bool]):
+class HasAnyFromUnimportedType(TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(any)
+        super().__init__(0)
 
     def visit_any(self, t: AnyType) -> bool:
         return t.type_of_any == TypeOfAny.from_unimported_type

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1192,7 +1192,7 @@ def has_explicit_any(t: Type) -> bool:
 
 class HasExplicitAny(TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(0)
+        super().__init__(TypeQueryBool.STRATEGY_ANY)
 
     def visit_any(self, t: AnyType) -> bool:
         return t.type_of_any == TypeOfAny.explicit
@@ -1213,7 +1213,7 @@ def has_any_from_unimported_type(t: Type) -> bool:
 
 class HasAnyFromUnimportedType(TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(0)
+        super().__init__(TypeQueryBool.STRATEGY_ANY)
 
     def visit_any(self, t: AnyType) -> bool:
         return t.type_of_any == TypeOfAny.from_unimported_type

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -14,8 +14,8 @@ from mypy.options import Options
 from mypy.types import (
     Type, UnboundType, TypeVarType, TupleType, TypedDictType, UnionType, Instance, AnyType,
     CallableType, NoneType, ErasedType, DeletedType, TypeList, TypeVarDef, SyntheticTypeVisitor,
-    StarType, PartialType, EllipsisType, UninhabitedType, TypeType,
-    CallableArgument, TypeQuery, TypeQueryBool, union_items, TypeOfAny, LiteralType, RawExpressionType,
+    StarType, PartialType, EllipsisType, UninhabitedType, TypeType, CallableArgument,
+    TypeQuery, TypeQueryBool, union_items, TypeOfAny, LiteralType, RawExpressionType,
     PlaceholderType, Overloaded, get_proper_type, TypeAliasType, TypeVarLikeDef, ParamSpecDef
 )
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2275,7 +2275,7 @@ def replace_alias_tvars(tp: Type, vars: List[str], subs: List[Type],
 
 class HasTypeVars(TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(0)
+        super().__init__(TypeQueryBool.STRATEGY_ANY)
 
     def visit_type_var(self, t: TypeVarType) -> bool:
         return True

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1987,6 +1987,7 @@ from mypy.type_visitor import (  # noqa
     SyntheticTypeVisitor as SyntheticTypeVisitor,
     TypeTranslator as TypeTranslator,
     TypeQuery as TypeQuery,
+    TypeQueryBool as TypeQueryBool
 )
 
 
@@ -2272,9 +2273,9 @@ def replace_alias_tvars(tp: Type, vars: List[str], subs: List[Type],
     return new_tp
 
 
-class HasTypeVars(TypeQuery[bool]):
+class HasTypeVars(TypeQueryBool):
     def __init__(self) -> None:
-        super().__init__(any)
+        super().__init__(0)
 
     def visit_type_var(self, t: TypeVarType) -> bool:
         return True


### PR DESCRIPTION
### Description
I tried implementing the optimization described in #7128.

I created `class TypeQueryBool(SyntheticTypeVisitor[bool])`.It's a specialized `TypeQuery`,
imlementating. `all` or `any` strategies.

Some code and comments are duplicated, so I'm not entirely satisfied with the implementation.
I'm opening the PR for some review about the implementation and the testing method.

## Test Plan

I forked `mypy_mypyc-wheels` project and I built mypyc wheels with travis, to benchmark.

I used `v0.800+dev.952ca239e6126aff52067a37869bd394eb08cf21` as the reference, and compared it with my exact changes added on top: https://github.com/vbarbaresi/mypy_mypyc-wheels/releases/tag/v0.800%2Bdev.f7129b21 

I'm using macOS 10.15, python 3.8.6 and the following benchmark script (I know it's not ideal because it counts the startup time of the python process):

```python
import sys
import pyperf

runner = pyperf.Runner()


runner.bench_command(
    'mypy_master',
    [
        '/tmp/venv_mypy_master/bin/mypy',
        '--config-file=mypy/mypy_self_check.ini',
        '/tmp/bench/mypy/mypy',
        '--no-incremental'
    ]
)


runner.bench_command(
    'mypy_typequerybool',
    [
        '/tmp/venv_mypy_typequerybool/bin/mypy',
        '--config-file=mypy/mypy_self_check.ini',
        '/tmp/bench/mypy/mypy',
        '--no-incremental'
    ]
)
```
I tried switching the order, running my branch first, then mypy master.
I wasn't able to get a 0.2 % accuracy, so I'm not entirely confident in the results.
I ran this bench more than 10 times and observed my branch performing very slightly better in a lot of runs

Typical run results:
```
Minimum:         10.9 sec
Median +- MAD:   11.0 sec +- 0.0 sec
Mean +- std dev: 11.0 sec +- 0.1 sec
Maximum:         11.1 sec

  0th percentile: 10.9 sec (-1% of the mean) -- minimum
  5th percentile: 11.0 sec (-1% of the mean)
 25th percentile: 11.0 sec (-0% of the mean) -- Q1
 50th percentile: 11.0 sec (+0% of the mean) -- median
 75th percentile: 11.1 sec (+0% of the mean) -- Q3
 95th percentile: 11.1 sec (+1% of the mean)
100th percentile: 11.1 sec (+1% of the mean) -- maximum

Number of outlier (out of 10.9 sec..11.2 sec): 0

mypy_master: Mean +- std dev: 11.0 sec +- 0.1 sec


Minimum:         10.9 sec
Median +- MAD:   11.0 sec +- 0.0 sec
Mean +- std dev: 11.0 sec +- 0.1 sec
Maximum:         11.1 sec

  0th percentile: 10.9 sec (-1% of the mean) -- minimum
  5th percentile: 10.9 sec (-1% of the mean)
 25th percentile: 10.9 sec (-0% of the mean) -- Q1
 50th percentile: 11.0 sec (+0% of the mean) -- median
 75th percentile: 11.0 sec (+0% of the mean) -- Q3
 95th percentile: 11.1 sec (+1% of the mean)
100th percentile: 11.1 sec (+1% of the mean) -- maximum

Number of outlier (out of 10.8 sec..11.1 sec): 0

mypy_typequerybool: Mean +- std dev: 11.0 sec +- 0.1 sec
```

﻿On some other runs the mean was 10.9 sec for my branch, and still 11.0 on master (but always with +- 0.1 sec std dev)