### PR TITLE
[mypyc] Add 'bit' primitive type and streamline branching

### DIFF
--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -13,7 +13,8 @@ from mypyc.ir.rtypes import (
     is_float_rprimitive, is_bool_rprimitive, is_int_rprimitive, is_short_int_rprimitive,
     is_list_rprimitive, is_dict_rprimitive, is_set_rprimitive, is_tuple_rprimitive,
     is_none_rprimitive, is_object_rprimitive, object_rprimitive, is_str_rprimitive,
-    int_rprimitive, is_optional_type, optional_value_type, is_int32_rprimitive, is_int64_rprimitive
+    int_rprimitive, is_optional_type, optional_value_type, is_int32_rprimitive,
+    is_int64_rprimitive, is_bit_rprimitive
 )
 from mypyc.ir.func_ir import FuncDecl
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
@@ -413,7 +414,7 @@ class Emitter:
                 prefix = 'PyUnicode'
             elif is_int_rprimitive(typ):
                 prefix = 'PyLong'
-            elif is_bool_rprimitive(typ):
+            elif is_bool_rprimitive(typ) or is_bit_rprimitive(typ):
                 prefix = 'PyBool'
             else:
                 assert False, 'unexpected primitive type'
@@ -602,7 +603,7 @@ class Emitter:
             self.emit_line('else {')
             self.emit_lines(*failure)
             self.emit_line('}')
-        elif is_bool_rprimitive(typ):
+        elif is_bool_rprimitive(typ) or is_bit_rprimitive(typ):
             # Whether we are borrowing or not makes no difference.
             if declare_dest:
                 self.emit_line('char {};'.format(dest))
@@ -681,7 +682,7 @@ class Emitter:
         if is_int_rprimitive(typ) or is_short_int_rprimitive(typ):
             # Steal the existing reference if it exists.
             self.emit_line('{}{} = CPyTagged_StealAsObject({});'.format(declaration, dest, src))
-        elif is_bool_rprimitive(typ):
+        elif is_bool_rprimitive(typ) or is_bit_rprimitive(typ):
             # N.B: bool is special cased to produce a borrowed value
             # after boxing, so we don't need to increment the refcount
             # when this comes directly from a Box op.

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -115,12 +115,9 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         neg = '!' if op.negated else ''
 
         cond = ''
-        if op.op == Branch.BOOL_EXPR:
+        if op.op == Branch.BOOL:
             expr_result = self.reg(op.left)  # right isn't used
             cond = '{}{}'.format(neg, expr_result)
-        elif op.op == Branch.NEG_INT_EXPR:
-            expr_result = self.reg(op.left)
-            cond = '{} < 0'.format(expr_result)
         elif op.op == Branch.IS_ERROR:
             typ = op.left.type
             compare = '!=' if op.negated else '=='

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -415,11 +415,13 @@ class Goto(ControlOp):
 
 
 class Branch(ControlOp):
-    """Check a condition and branch.
+    """Branch based on a value.
 
-    There are two forms:
-       if [not] r1 goto L1 else goto L2  (BOOL)
-       if [not] is_error(r1) goto L1 else goto L2  (IS_ERROR)
+    If op is BOOL, branch based on a bit/bool value:
+       if [not] r1 goto L1 else goto L2
+
+    If op is IS_ERROR, branch based on whether there is an error value:
+       if [not] is_error(r1) goto L1 else goto L2
     """
 
     # Branch ops must *not* raise an exception. If a comparison, for example, can raise an

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1319,13 +1319,20 @@ class BinaryIntOp(RegisterOp):
 
 
 class ComparisonOp(RegisterOp):
-    """Comparison ops.
+    """Low-level comparison op.
 
-    The result type will always be a bit.
+    Both unsigned and signed comparisons are supported.
 
-    Supports comparisons between fixed-width integer types and pointer types.
+    The operands are assumed to be fixed-width integers/pointers. Python
+    semantics, such as calling __eq__, are not supported.
+
+    The result is always a bit.
+
+    Supports comparisons between fixed-width integer types and pointer
+    types.
     """
-    # ERR_NEVER or ERR_FALSE
+    # Must be ERR_NEVER or ERR_FALSE. ERR_FALSE means that a false result
+    # indicates that an exception has been raised and should be propagated.
     error_kind = ERR_NEVER
 
     # S for signed and U for unsigned

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -270,6 +270,11 @@ float_rprimitive = RPrimitive('builtins.float', is_unboxed=False,
 bool_rprimitive = RPrimitive('builtins.bool', is_unboxed=True, is_refcounted=False,
                              ctype='char', size=1)  # type: Final
 
+# A low-level boolean value with two possible values: 0 and 1. Any
+# other value results in undefined behavior.
+bit_rprimitive = RPrimitive('bit', is_unboxed=True, is_refcounted=False,
+                            ctype='char', size=1)  # type: Final
+
 # The 'None' value. The possible values are 0 -> None and 2 -> error.
 none_rprimitive = RPrimitive('builtins.None', is_unboxed=True, is_refcounted=False,
                              ctype='char', size=1)  # type: Final
@@ -327,6 +332,10 @@ def is_float_rprimitive(rtype: RType) -> bool:
 
 def is_bool_rprimitive(rtype: RType) -> bool:
     return isinstance(rtype, RPrimitive) and rtype.name == 'builtins.bool'
+
+
+def is_bit_rprimitive(rtype: RType) -> bool:
+    return isinstance(rtype, RPrimitive) and rtype.name == 'bit'
 
 
 def is_object_rprimitive(rtype: RType) -> bool:

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -265,13 +265,15 @@ pointer_rprimitive = RPrimitive('ptr', is_unboxed=True, is_refcounted=False,
 float_rprimitive = RPrimitive('builtins.float', is_unboxed=False,
                               is_refcounted=True)  # type: Final
 
-# An unboxed boolean value. This actually has three possible values
-# (0 -> False, 1 -> True, 2 -> error).
+# An unboxed Python bool value. This actually has three possible values
+# (0 -> False, 1 -> True, 2 -> error). If you only need True/False, use
+# bit_rprimitive instead.
 bool_rprimitive = RPrimitive('builtins.bool', is_unboxed=True, is_refcounted=False,
                              ctype='char', size=1)  # type: Final
 
 # A low-level boolean value with two possible values: 0 and 1. Any
-# other value results in undefined behavior.
+# other value results in undefined behavior. Undefined or error values
+# are not supported.
 bit_rprimitive = RPrimitive('bit', is_unboxed=True, is_refcounted=False,
                             ctype='char', size=1)  # type: Final
 

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -547,7 +547,7 @@ class IRBuilder:
             condition = self.binary_op(post_star_len, iter_list_len, '<=', line)
 
             error_block, ok_block = BasicBlock(), BasicBlock()
-            self.add(Branch(condition, ok_block, error_block, Branch.BOOL_EXPR))
+            self.add(Branch(condition, ok_block, error_block, Branch.BOOL))
 
             self.activate_block(error_block)
             self.add(RaiseStandardError(RaiseStandardError.VALUE_ERROR,

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -399,7 +399,7 @@ def gen_glue_ne_method(builder: IRBuilder, cls: ClassIR, line: int) -> FuncIR:
         builder.translate_is_op(eqval, not_implemented, 'is', line),
         not_implemented_block,
         regular_block,
-        Branch.BOOL_EXPR))
+        Branch.BOOL))
 
     builder.activate_block(regular_block)
     retval = builder.coerce(

--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -517,7 +517,7 @@ class ForDictionaryCommon(ForGenerator):
 
         should_continue = builder.add(TupleGet(self.next_tuple, 0, line))
         builder.add(
-            Branch(should_continue, self.body_block, self.loop_exit, Branch.BOOL_EXPR)
+            Branch(should_continue, self.body_block, self.loop_exit, Branch.BOOL)
         )
 
     def gen_step(self) -> None:

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -528,7 +528,7 @@ def handle_yield_from_and_await(builder: IRBuilder, o: Union[YieldFromExpr, Awai
         val = builder.add(TupleGet(res, 1, o.line))
 
         ok, stop = BasicBlock(), BasicBlock()
-        builder.add(Branch(to_stop, stop, ok, Branch.BOOL_EXPR))
+        builder.add(Branch(to_stop, stop, ok, Branch.BOOL))
 
         # The exception got swallowed. Continue, yielding the returned value
         builder.activate_block(ok)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -726,14 +726,14 @@ class LowLevelIRBuilder:
     def unary_not(self,
                   value: Value,
                   line: int) -> Value:
-        mask = self.add(LoadInt(1, line, rtype=bool_rprimitive))
-        return self.binary_int_op(bool_rprimitive, value, mask, BinaryIntOp.XOR, line)
+        mask = self.add(LoadInt(1, line, rtype=value.type))
+        return self.binary_int_op(value.type, value, mask, BinaryIntOp.XOR, line)
 
     def unary_op(self,
                  lreg: Value,
                  expr_op: str,
                  line: int) -> Value:
-        if is_bool_rprimitive(lreg.type) and expr_op == 'not':
+        if (is_bool_rprimitive(lreg.type) or is_bit_rprimitive(lreg.type)) and expr_op == 'not':
             return self.unary_not(lreg, line)
         call_c_ops_candidates = c_unary_ops.get(expr_op, [])
         target = self.matching_call_c(call_c_ops_candidates, [lreg], line)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -22,7 +22,7 @@ from mypyc.ir.ops import (
     LoadStatic, MethodCall, PrimitiveOp, OpDescription, RegisterOp, CallC, Truncate,
     RaiseStandardError, Unreachable, LoadErrorValue, LoadGlobal,
     NAMESPACE_TYPE, NAMESPACE_MODULE, NAMESPACE_STATIC, BinaryIntOp, GetElementPtr,
-    LoadMem, ComparisonOp, LoadAddress, TupleGet, SetMem
+    LoadMem, ComparisonOp, LoadAddress, TupleGet, SetMem, ERR_NEVER, ERR_FALSE
 )
 from mypyc.ir.rtypes import (
     RType, RUnion, RInstance, optional_value_type, int_rprimitive, float_rprimitive,
@@ -30,7 +30,7 @@ from mypyc.ir.rtypes import (
     c_pyssize_t_rprimitive, is_short_int_rprimitive, is_tagged, PyVarObject, short_int_rprimitive,
     is_list_rprimitive, is_tuple_rprimitive, is_dict_rprimitive, is_set_rprimitive, PySetObject,
     none_rprimitive, RTuple, is_bool_rprimitive, is_str_rprimitive, c_int_rprimitive,
-    pointer_rprimitive, PyObject, PyListObject
+    pointer_rprimitive, PyObject, PyListObject, bit_rprimitive
 )
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
@@ -40,7 +40,7 @@ from mypyc.common import (
 )
 from mypyc.primitives.registry import (
     func_ops, c_method_call_ops, CFunctionDescription, c_function_ops,
-    c_binary_ops, c_unary_ops
+    c_binary_ops, c_unary_ops, ERR_NEG_INT
 )
 from mypyc.primitives.list_ops import (
     list_extend_op, new_list_op
@@ -612,9 +612,9 @@ class LowLevelIRBuilder:
         else:
             # for non-equal logical ops(less than, greater than, etc.), need to check both side
             check_rhs = self.check_tagged_short_int(rhs, line)
-            check = self.binary_int_op(bool_rprimitive, check_lhs,
+            check = self.binary_int_op(bit_rprimitive, check_lhs,
                                        check_rhs, BinaryIntOp.AND, line)
-        branch = Branch(check, short_int_block, int_block, Branch.BOOL_EXPR)
+        branch = Branch(check, short_int_block, int_block, Branch.BOOL)
         branch.negated = False
         self.add(branch)
         self.activate_block(short_int_block)
@@ -643,7 +643,7 @@ class LowLevelIRBuilder:
         compare_error_check = self.add(ComparisonOp(compare_result,
                                                     error_constant, ComparisonOp.EQ, line))
         exception_check, propagate, final_compare = BasicBlock(), BasicBlock(), BasicBlock()
-        branch = Branch(compare_error_check, exception_check, final_compare, Branch.BOOL_EXPR)
+        branch = Branch(compare_error_check, exception_check, final_compare, Branch.BOOL)
         branch.negated = False
         self.add(branch)
         self.activate_block(exception_check)
@@ -651,7 +651,7 @@ class LowLevelIRBuilder:
         null = self.add(LoadInt(0, line, pointer_rprimitive))
         compare_error_check = self.add(ComparisonOp(check_error_result,
                                                     null, ComparisonOp.NEQ, line))
-        branch = Branch(compare_error_check, propagate, final_compare, Branch.BOOL_EXPR)
+        branch = Branch(compare_error_check, propagate, final_compare, Branch.BOOL)
         branch.negated = False
         self.add(branch)
         self.activate_block(propagate)
@@ -698,9 +698,9 @@ class LowLevelIRBuilder:
             if not is_bool_rprimitive(compare.type):
                 compare = self.call_c(bool_op, [compare], line)
             if i < len(lhs.type.types) - 1:
-                branch = Branch(compare, early_stop, check_blocks[i + 1], Branch.BOOL_EXPR)
+                branch = Branch(compare, early_stop, check_blocks[i + 1], Branch.BOOL)
             else:
-                branch = Branch(compare, early_stop, final, Branch.BOOL_EXPR)
+                branch = Branch(compare, early_stop, final, Branch.BOOL)
             # if op is ==, we branch on false, else branch on true
             branch.negated = equal
             self.add(branch)
@@ -855,7 +855,7 @@ class LowLevelIRBuilder:
             value_type = optional_value_type(value.type)
             if value_type is not None:
                 is_none = self.translate_is_op(value, self.none_object(), 'is not', value.line)
-                branch = Branch(is_none, true, false, Branch.BOOL_EXPR)
+                branch = Branch(is_none, true, false, Branch.BOOL)
                 self.add(branch)
                 always_truthy = False
                 if isinstance(value_type, RInstance):
@@ -875,26 +875,27 @@ class LowLevelIRBuilder:
                 return
             elif not is_same_type(value.type, bool_rprimitive):
                 value = self.call_c(bool_op, [value], value.line)
-        self.add(Branch(value, true, false, Branch.BOOL_EXPR))
+        self.add(Branch(value, true, false, Branch.BOOL))
 
     def call_c(self,
                desc: CFunctionDescription,
                args: List[Value],
                line: int,
                result_type: Optional[RType] = None) -> Value:
-        # handle void function via singleton RVoid instance
+        """Call function using C/native calling convention (not a Python callable)."""
+        # Handle void function via singleton RVoid instance
         coerced = []
-        # coerce fixed number arguments
+        # Coerce fixed number arguments
         for i in range(min(len(args), len(desc.arg_types))):
             formal_type = desc.arg_types[i]
             arg = args[i]
             arg = self.coerce(arg, formal_type, line)
             coerced.append(arg)
-        # reorder args if necessary
+        # Reorder args if necessary
         if desc.ordering is not None:
             assert desc.var_arg_type is None
             coerced = [coerced[i] for i in desc.ordering]
-        # coerce any var_arg
+        # Coerce any var_arg
         var_arg_idx = -1
         if desc.var_arg_type is not None:
             var_arg_idx = len(desc.arg_types)
@@ -902,13 +903,25 @@ class LowLevelIRBuilder:
                 arg = args[i]
                 arg = self.coerce(arg, desc.var_arg_type, line)
                 coerced.append(arg)
-        # add extra integer constant if any
+        # Add extra integer constant if any
         for item in desc.extra_int_constants:
             val, typ = item
             extra_int_constant = self.add(LoadInt(val, line, rtype=typ))
             coerced.append(extra_int_constant)
+        error_kind = desc.error_kind
+        if error_kind == ERR_NEG_INT:
+            # Handled with an explicit comparison
+            error_kind = ERR_NEVER
         target = self.add(CallC(desc.c_function_name, coerced, desc.return_type, desc.steals,
-                                desc.is_borrowed, desc.error_kind, line, var_arg_idx))
+                                desc.is_borrowed, error_kind, line, var_arg_idx))
+        if desc.error_kind == ERR_NEG_INT:
+            comp = ComparisonOp(target,
+                                self.add(LoadInt(0, line, desc.return_type)),
+                                ComparisonOp.SGE,
+                                line)
+            comp.error_kind = ERR_FALSE
+            self.add(comp)
+
         if desc.truncated_type is None:
             result = target
         else:

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -30,7 +30,7 @@ from mypyc.ir.rtypes import (
     c_pyssize_t_rprimitive, is_short_int_rprimitive, is_tagged, PyVarObject, short_int_rprimitive,
     is_list_rprimitive, is_tuple_rprimitive, is_dict_rprimitive, is_set_rprimitive, PySetObject,
     none_rprimitive, RTuple, is_bool_rprimitive, is_str_rprimitive, c_int_rprimitive,
-    pointer_rprimitive, PyObject, PyListObject, bit_rprimitive
+    pointer_rprimitive, PyObject, PyListObject, bit_rprimitive, is_bit_rprimitive
 )
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
@@ -841,7 +841,7 @@ class LowLevelIRBuilder:
 
     def add_bool_branch(self, value: Value, true: BasicBlock, false: BasicBlock) -> None:
         if is_runtime_subtype(value.type, int_rprimitive):
-            zero = self.add(LoadInt(0))
+            zero = self.add(LoadInt(0, rtype=value.type))
             value = self.binary_op(value, zero, '!=', value.line)
         elif is_same_type(value.type, list_rprimitive):
             length = self.builtin_len(value, value.line)
@@ -873,7 +873,7 @@ class LowLevelIRBuilder:
                     remaining = self.unbox_or_cast(value, value_type, value.line)
                     self.add_bool_branch(remaining, true, false)
                 return
-            elif not is_same_type(value.type, bool_rprimitive):
+            elif not is_bool_rprimitive(value.type) and not is_bit_rprimitive(value.type):
                 value = self.call_c(bool_op, [value], value.line)
         self.add(Branch(value, true, false, Branch.BOOL))
 

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -305,7 +305,7 @@ def transform_try_except(builder: IRBuilder,
             matches = builder.call_c(
                 exc_matches_op, [builder.accept(type)], type.line
             )
-            builder.add(Branch(matches, body_block, next_block, Branch.BOOL_EXPR))
+            builder.add(Branch(matches, body_block, next_block, Branch.BOOL))
             builder.activate_block(body_block)
         if var:
             target = builder.get_assignment_target(var)
@@ -578,7 +578,7 @@ def transform_with(builder: IRBuilder,
     def finally_body() -> None:
         out_block, exit_block = BasicBlock(), BasicBlock()
         builder.add(
-            Branch(builder.read(exc), exit_block, out_block, Branch.BOOL_EXPR)
+            Branch(builder.read(exc), exit_block, out_block, Branch.BOOL)
         )
         builder.activate_block(exit_block)
         none = builder.none_object()

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -4,7 +4,7 @@ from mypyc.ir.ops import ERR_FALSE, ERR_MAGIC, ERR_NEVER
 from mypyc.ir.rtypes import (
     dict_rprimitive, object_rprimitive, bool_rprimitive, int_rprimitive,
     list_rprimitive, dict_next_rtuple_single, dict_next_rtuple_pair, c_pyssize_t_rprimitive,
-    c_int_rprimitive
+    c_int_rprimitive, bit_rprimitive
 )
 
 from mypyc.primitives.registry import (
@@ -203,7 +203,7 @@ dict_next_item_op = c_custom_op(
 # check that len(dict) == const during iteration
 dict_check_size_op = c_custom_op(
     arg_types=[dict_rprimitive, int_rprimitive],
-    return_type=bool_rprimitive,
+    return_type=bit_rprimitive,
     c_function_name='CPyDict_CheckSize',
     error_kind=ERR_FALSE)
 

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -1,6 +1,6 @@
 """Primitive dict ops."""
 
-from mypyc.ir.ops import ERR_FALSE, ERR_MAGIC, ERR_NEVER, ERR_NEG_INT
+from mypyc.ir.ops import ERR_FALSE, ERR_MAGIC, ERR_NEVER
 from mypyc.ir.rtypes import (
     dict_rprimitive, object_rprimitive, bool_rprimitive, int_rprimitive,
     list_rprimitive, dict_next_rtuple_single, dict_next_rtuple_pair, c_pyssize_t_rprimitive,
@@ -8,7 +8,7 @@ from mypyc.ir.rtypes import (
 )
 
 from mypyc.primitives.registry import (
-    c_custom_op, c_method_op, c_function_op, c_binary_op, load_address_op
+    c_custom_op, c_method_op, c_function_op, c_binary_op, load_address_op, ERR_NEG_INT
 )
 
 # Get the 'dict' type object.

--- a/mypyc/primitives/exc_ops.py
+++ b/mypyc/primitives/exc_ops.py
@@ -1,7 +1,9 @@
 """Exception-related primitive ops."""
 
 from mypyc.ir.ops import ERR_NEVER, ERR_FALSE, ERR_ALWAYS
-from mypyc.ir.rtypes import bool_rprimitive, object_rprimitive, void_rtype, exc_rtuple
+from mypyc.ir.rtypes import (
+    bool_rprimitive, object_rprimitive, void_rtype, exc_rtuple, bit_rprimitive
+)
 from mypyc.primitives.registry import c_custom_op
 
 # If the argument is a class, raise an instance of the class. Otherwise, assume
@@ -37,7 +39,7 @@ reraise_exception_op = c_custom_op(
 # Propagate exception if the CPython error indicator is set (an exception was raised).
 no_err_occurred_op = c_custom_op(
     arg_types=[],
-    return_type=bool_rprimitive,
+    return_type=bit_rprimitive,
     c_function_name='CPy_NoErrOccured',
     error_kind=ERR_FALSE)
 
@@ -52,7 +54,7 @@ err_occurred_op = c_custom_op(
 # This doesn't actually raise an exception.
 keep_propagating_op = c_custom_op(
     arg_types=[],
-    return_type=bool_rprimitive,
+    return_type=bit_rprimitive,
     c_function_name='CPy_KeepPropagating',
     error_kind=ERR_FALSE)
 

--- a/mypyc/primitives/exc_ops.py
+++ b/mypyc/primitives/exc_ops.py
@@ -1,9 +1,7 @@
 """Exception-related primitive ops."""
 
 from mypyc.ir.ops import ERR_NEVER, ERR_FALSE, ERR_ALWAYS
-from mypyc.ir.rtypes import (
-    bool_rprimitive, object_rprimitive, void_rtype, exc_rtuple, bit_rprimitive
-)
+from mypyc.ir.rtypes import object_rprimitive, void_rtype, exc_rtuple, bit_rprimitive
 from mypyc.primitives.registry import c_custom_op
 
 # If the argument is a class, raise an instance of the class. Otherwise, assume
@@ -79,7 +77,7 @@ restore_exc_info_op = c_custom_op(
 # Checks whether the exception currently being handled matches a particular type.
 exc_matches_op = c_custom_op(
     arg_types=[object_rprimitive],
-    return_type=bool_rprimitive,
+    return_type=bit_rprimitive,
     c_function_name='CPy_ExceptionMatches',
     error_kind=ERR_NEVER)
 

--- a/mypyc/primitives/generic_ops.py
+++ b/mypyc/primitives/generic_ops.py
@@ -9,12 +9,12 @@ will take precedence. If your specialized op doesn't seem to be used,
 check that the priorities are configured properly.
 """
 
-from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ERR_NEG_INT
+from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC
 from mypyc.ir.rtypes import (
     object_rprimitive, int_rprimitive, bool_rprimitive, c_int_rprimitive, pointer_rprimitive
 )
 from mypyc.primitives.registry import (
-    c_binary_op, c_unary_op, c_method_op, c_function_op, c_custom_op
+    c_binary_op, c_unary_op, c_method_op, c_function_op, c_custom_op, ERR_NEG_INT
 )
 
 

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -10,7 +10,7 @@ from typing import Dict, NamedTuple
 from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ComparisonOp
 from mypyc.ir.rtypes import (
     int_rprimitive, bool_rprimitive, float_rprimitive, object_rprimitive,
-    str_rprimitive, RType
+    str_rprimitive, bit_rprimitive, RType
 )
 from mypyc.primitives.registry import (
     load_address_op, c_unary_op, CFunctionDescription, c_function_op, c_binary_op, c_custom_op
@@ -138,13 +138,13 @@ IntLogicalOpDescrption = NamedTuple(
 # description for equal operation on two boxed tagged integers
 int_equal_ = c_custom_op(
     arg_types=[int_rprimitive, int_rprimitive],
-    return_type=bool_rprimitive,
+    return_type=bit_rprimitive,
     c_function_name='CPyTagged_IsEq_',
     error_kind=ERR_NEVER)
 
 int_less_than_ = c_custom_op(
     arg_types=[int_rprimitive, int_rprimitive],
-    return_type=bool_rprimitive,
+    return_type=bit_rprimitive,
     c_function_name='CPyTagged_IsLt_',
     error_kind=ERR_NEVER)
 

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -2,13 +2,13 @@
 
 from typing import List
 
-from mypyc.ir.ops import ERR_MAGIC, ERR_NEVER, ERR_FALSE, ERR_NEG_INT, EmitterInterface
+from mypyc.ir.ops import ERR_MAGIC, ERR_NEVER, ERR_FALSE, EmitterInterface
 from mypyc.ir.rtypes import (
     int_rprimitive, short_int_rprimitive, list_rprimitive, object_rprimitive, bool_rprimitive,
     c_int_rprimitive, c_pyssize_t_rprimitive
 )
 from mypyc.primitives.registry import (
-    load_address_op, c_function_op, c_binary_op, c_method_op, c_custom_op
+    load_address_op, c_function_op, c_binary_op, c_method_op, c_custom_op, ERR_NEG_INT
 )
 
 

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -4,8 +4,8 @@ from typing import List
 
 from mypyc.ir.ops import ERR_MAGIC, ERR_NEVER, ERR_FALSE, EmitterInterface
 from mypyc.ir.rtypes import (
-    int_rprimitive, short_int_rprimitive, list_rprimitive, object_rprimitive, bool_rprimitive,
-    c_int_rprimitive, c_pyssize_t_rprimitive, bit_rprimitive
+    int_rprimitive, short_int_rprimitive, list_rprimitive, object_rprimitive,  c_int_rprimitive,
+    c_pyssize_t_rprimitive, bit_rprimitive
 )
 from mypyc.primitives.registry import (
     load_address_op, c_function_op, c_binary_op, c_method_op, c_custom_op, ERR_NEG_INT

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -5,7 +5,7 @@ from typing import List
 from mypyc.ir.ops import ERR_MAGIC, ERR_NEVER, ERR_FALSE, EmitterInterface
 from mypyc.ir.rtypes import (
     int_rprimitive, short_int_rprimitive, list_rprimitive, object_rprimitive, bool_rprimitive,
-    c_int_rprimitive, c_pyssize_t_rprimitive
+    c_int_rprimitive, c_pyssize_t_rprimitive, bit_rprimitive
 )
 from mypyc.primitives.registry import (
     load_address_op, c_function_op, c_binary_op, c_method_op, c_custom_op, ERR_NEG_INT
@@ -62,7 +62,7 @@ list_get_item_unsafe_op = c_custom_op(
 list_set_item_op = c_method_op(
     name='__setitem__',
     arg_types=[list_rprimitive, int_rprimitive, object_rprimitive],
-    return_type=bool_rprimitive,
+    return_type=bit_rprimitive,
     c_function_name='CPyList_SetItem',
     error_kind=ERR_FALSE,
     steals=[False, False, True])

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -3,7 +3,7 @@
 from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ERR_FALSE
 from mypyc.ir.rtypes import (
     RTuple, bool_rprimitive, object_rprimitive, str_rprimitive,
-    int_rprimitive, dict_rprimitive, c_int_rprimitive
+    int_rprimitive, dict_rprimitive, c_int_rprimitive, bit_rprimitive
 )
 from mypyc.primitives.registry import (
     simple_emit, func_op, custom_op, c_function_op, c_custom_op, load_address_op, ERR_NEG_INT
@@ -177,6 +177,6 @@ pytype_from_template_op = c_custom_op(
 # CPyDataclass_SleightOfHand for more docs.
 dataclass_sleight_of_hand = c_custom_op(
     arg_types=[object_rprimitive, object_rprimitive, dict_rprimitive, dict_rprimitive],
-    return_type=bool_rprimitive,
+    return_type=bit_rprimitive,
     c_function_name='CPyDataclass_SleightOfHand',
     error_kind=ERR_FALSE)

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -1,13 +1,12 @@
 """Miscellaneous primitive ops."""
 
-from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ERR_FALSE, ERR_NEG_INT
+from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ERR_FALSE
 from mypyc.ir.rtypes import (
     RTuple, bool_rprimitive, object_rprimitive, str_rprimitive,
     int_rprimitive, dict_rprimitive, c_int_rprimitive
 )
 from mypyc.primitives.registry import (
-    simple_emit, func_op, custom_op,
-    c_function_op, c_custom_op, load_address_op
+    simple_emit, func_op, custom_op, c_function_op, c_custom_op, load_address_op, ERR_NEG_INT
 )
 
 

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -36,11 +36,17 @@ optimized implementations of all ops.
 """
 
 from typing import Dict, List, Optional, NamedTuple, Tuple
+from typing_extensions import Final
 
 from mypyc.ir.ops import (
     OpDescription, EmitterInterface, EmitCallback, StealsDescription, short_name
 )
 from mypyc.ir.rtypes import RType
+
+# Error kind for functions that return negative integer on exception. This
+# is only used for primitives. We translate it away during IR building.
+ERR_NEG_INT = 10  # type: Final
+
 
 CFunctionDescription = NamedTuple(
     'CFunctionDescription',  [('name', str),

--- a/mypyc/primitives/set_ops.py
+++ b/mypyc/primitives/set_ops.py
@@ -1,9 +1,7 @@
 """Primitive set (and frozenset) ops."""
 
-from mypyc.primitives.registry import (
-    c_function_op, c_method_op, c_binary_op
-)
-from mypyc.ir.ops import ERR_MAGIC, ERR_FALSE, ERR_NEG_INT
+from mypyc.primitives.registry import c_function_op, c_method_op, c_binary_op, ERR_NEG_INT
+from mypyc.ir.ops import ERR_MAGIC, ERR_FALSE
 from mypyc.ir.rtypes import (
     object_rprimitive, bool_rprimitive, set_rprimitive, c_int_rprimitive, pointer_rprimitive
 )

--- a/mypyc/primitives/set_ops.py
+++ b/mypyc/primitives/set_ops.py
@@ -3,7 +3,8 @@
 from mypyc.primitives.registry import c_function_op, c_method_op, c_binary_op, ERR_NEG_INT
 from mypyc.ir.ops import ERR_MAGIC, ERR_FALSE
 from mypyc.ir.rtypes import (
-    object_rprimitive, bool_rprimitive, set_rprimitive, c_int_rprimitive, pointer_rprimitive
+    object_rprimitive, bool_rprimitive, set_rprimitive, c_int_rprimitive, pointer_rprimitive,
+    bit_rprimitive
 )
 
 
@@ -46,7 +47,7 @@ c_binary_op(
 c_method_op(
     name='remove',
     arg_types=[set_rprimitive, object_rprimitive],
-    return_type=bool_rprimitive,
+    return_type=bit_rprimitive,
     c_function_name='CPySet_Remove',
     error_kind=ERR_FALSE)
 

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -15,7 +15,7 @@ coercion is necessary first.
 
 from mypyc.ir.rtypes import (
     RType, RUnion, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor, RStruct,
-    is_int_rprimitive, is_short_int_rprimitive,
+    is_int_rprimitive, is_short_int_rprimitive, is_bool_rprimitive, is_bit_rprimitive
 )
 from mypyc.subtype import is_subtype
 
@@ -42,6 +42,8 @@ class RTSubtypeVisitor(RTypeVisitor[bool]):
 
     def visit_rprimitive(self, left: RPrimitive) -> bool:
         if is_short_int_rprimitive(left) and is_int_rprimitive(self.right):
+            return True
+        if is_bit_rprimitive(left) and is_bool_rprimitive(self.right):
             return True
         return left is self.right
 

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -2,9 +2,8 @@
 
 from mypyc.ir.rtypes import (
     RType, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor, RUnion, RStruct,
-    is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive,
-    is_short_int_rprimitive,
-    is_object_rprimitive
+    is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive, is_short_int_rprimitive,
+    is_object_rprimitive, is_bit_rprimitive
 )
 
 
@@ -42,11 +41,17 @@ class SubtypeVisitor(RTypeVisitor[bool]):
                    for item in left.items)
 
     def visit_rprimitive(self, left: RPrimitive) -> bool:
-        if is_bool_rprimitive(left) and is_int_rprimitive(self.right):
-            return True
-        if is_short_int_rprimitive(left) and is_int_rprimitive(self.right):
-            return True
-        return left is self.right
+        right = self.right
+        if is_bool_rprimitive(left):
+            if is_int_rprimitive(right):
+                return True
+        elif is_bit_rprimitive(left):
+            if is_bool_rprimitive(right) or is_int_rprimitive(right):
+                return True
+        elif is_short_int_rprimitive(left):
+            if is_int_rprimitive(right):
+                return True
+        return left is right
 
     def visit_rtuple(self, left: RTuple) -> bool:
         if is_tuple_rprimitive(self.right):

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -11,8 +11,9 @@ def f(a: int) -> None:
 def f(a):
     a, x :: int
     r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bool
+    r1 :: int64
+    r2, r3 :: bit
+    r4 :: bool
     y, z :: int
 L0:
     x = 2
@@ -69,8 +70,9 @@ def f(a: int) -> int:
 def f(a):
     a, x :: int
     r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bool
+    r1 :: int64
+    r2, r3 :: bit
+    r4 :: bool
 L0:
     x = 2
     r1 = x & 1
@@ -165,8 +167,9 @@ def f(a: int) -> None:
 def f(a):
     a :: int
     r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bool
+    r1 :: int64
+    r2, r3 :: bit
+    r4 :: bool
     y, x :: int
 L0:
     r1 = a & 1
@@ -232,10 +235,11 @@ def f(n: int) -> None:
 def f(n):
     n :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7 :: bool
     r8, m :: int
 L0:
 L1:
@@ -301,14 +305,16 @@ def f(n: int) -> None:
 def f(n):
     n, x, y :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7, r8 :: bool
-    r9 :: native_int
-    r10 :: bool
-    r11 :: native_int
-    r12, r13, r14, r15 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7, r8 :: bool
+    r9 :: int64
+    r10 :: bit
+    r11 :: int64
+    r12, r13, r14 :: bit
+    r15 :: bool
 L0:
     x = 2
     y = 2
@@ -793,4 +799,3 @@ L11:
 (10, 2)  {r8}                    {}
 (11, 0)  {}                      {r9}
 (11, 1)  {r9}                    {}
-

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -12,8 +12,7 @@ def f(a):
     a, x :: int
     r0 :: bool
     r1 :: int64
-    r2, r3 :: bit
-    r4 :: bool
+    r2, r3, r4 :: bit
     y, z :: int
 L0:
     x = 2
@@ -71,8 +70,7 @@ def f(a):
     a, x :: int
     r0 :: bool
     r1 :: int64
-    r2, r3 :: bit
-    r4 :: bool
+    r2, r3, r4 :: bit
 L0:
     x = 2
     r1 = x & 1
@@ -168,8 +166,7 @@ def f(a):
     a :: int
     r0 :: bool
     r1 :: int64
-    r2, r3 :: bit
-    r4 :: bool
+    r2, r3, r4 :: bit
     y, x :: int
 L0:
     r1 = a & 1
@@ -238,8 +235,7 @@ def f(n):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7 :: bool
+    r4, r5, r6, r7 :: bit
     r8, m :: int
 L0:
 L1:
@@ -308,13 +304,12 @@ def f(n):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7, r8 :: bool
+    r4, r5, r6, r7 :: bit
+    r8 :: bool
     r9 :: int64
     r10 :: bit
     r11 :: int64
-    r12, r13, r14 :: bit
-    r15 :: bool
+    r12, r13, r14, r15 :: bit
 L0:
     x = 2
     y = 2
@@ -452,14 +447,15 @@ def f(a: int) -> None:
 def f(a):
     a :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7, r8 :: bool
-    r9 :: native_int
-    r10 :: bool
-    r11 :: native_int
-    r12, r13, r14, r15 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6, r7 :: bit
+    r8 :: bool
+    r9 :: int64
+    r10 :: bit
+    r11 :: int64
+    r12, r13, r14, r15 :: bit
     y, x :: int
 L0:
 L1:
@@ -585,8 +581,8 @@ def f(a: int) -> int:
 def f(a):
     a :: int
     r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bool
+    r1 :: int64
+    r2, r3, r4 :: bit
     x :: int
 L0:
     r1 = a & 1
@@ -643,10 +639,10 @@ def f(a: int) -> int:
 def f(a):
     a, sum, i :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7, r8 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6, r7, r8 :: bit
     r9, r10 :: int
 L0:
     sum = 0
@@ -727,9 +723,9 @@ def lol(x):
     r2 :: object
     r3 :: str
     r4 :: object
-    r5 :: bool
+    r5 :: bit
     r6 :: int
-    r7 :: bool
+    r7 :: bit
     r8, r9 :: int
 L0:
 L1:
@@ -799,3 +795,4 @@ L11:
 (10, 2)  {r8}                    {}
 (11, 0)  {}                      {r9}
 (11, 1)  {r9}                    {}
+

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -11,7 +11,7 @@ def f(a: int) -> None:
 def f(a):
     a, x :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2, r3, r4 :: bit
     y, z :: int
 L0:
@@ -69,7 +69,7 @@ def f(a: int) -> int:
 def f(a):
     a, x :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2, r3, r4 :: bit
 L0:
     x = 2
@@ -165,7 +165,7 @@ def f(a: int) -> None:
 def f(a):
     a :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2, r3, r4 :: bit
     y, x :: int
 L0:
@@ -232,9 +232,9 @@ def f(n: int) -> None:
 def f(n):
     n :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
     r8, m :: int
 L0:
@@ -301,14 +301,14 @@ def f(n: int) -> None:
 def f(n):
     n, x, y :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
     r8 :: bool
-    r9 :: int64
+    r9 :: native_int
     r10 :: bit
-    r11 :: int64
+    r11 :: native_int
     r12, r13, r14, r15 :: bit
 L0:
     x = 2
@@ -447,14 +447,14 @@ def f(a: int) -> None:
 def f(a):
     a :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
     r8 :: bool
-    r9 :: int64
+    r9 :: native_int
     r10 :: bit
-    r11 :: int64
+    r11 :: native_int
     r12, r13, r14, r15 :: bit
     y, x :: int
 L0:
@@ -581,7 +581,7 @@ def f(a: int) -> int:
 def f(a):
     a :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2, r3, r4 :: bit
     x :: int
 L0:
@@ -639,9 +639,9 @@ def f(a: int) -> int:
 def f(a):
     a, sum, i :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7, r8 :: bit
     r9, r10 :: int
 L0:

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -35,25 +35,27 @@ def f(x, y, z):
     y, z :: int
     r0 :: object
     r1 :: int32
-    r2 :: object
-    r3 :: bool
-    r4 :: None
+    r2 :: bit
+    r3 :: object
+    r4 :: bool
+    r5 :: None
 L0:
     inc_ref y :: int
     r0 = box(int, y)
     r1 = PyList_Append(x, r0)
     dec_ref r0
-    if r1 < 0 goto L3 (error at f:3) else goto L1
+    r2 = r1 >= 0 :: signed
+    if not r2 goto L3 (error at f:3) else goto L1 :: bool
 L1:
     inc_ref z :: int
-    r2 = box(int, z)
-    r3 = CPyList_SetItem(x, y, r2)
-    if not r3 goto L3 (error at f:4) else goto L2 :: bool
+    r3 = box(int, z)
+    r4 = CPyList_SetItem(x, y, r3)
+    if not r4 goto L3 (error at f:4) else goto L2 :: bool
 L2:
     return 1
 L3:
-    r4 = <error> :: None
-    return r4
+    r5 = <error> :: None
+    return r5
 
 [case testOptionalHandling]
 from typing import Optional
@@ -518,4 +520,3 @@ L13:
 L14:
     dec_ref r7
     goto L8
-

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -37,7 +37,7 @@ def f(x, y, z):
     r1 :: int32
     r2 :: bit
     r3 :: object
-    r4 :: bool
+    r4 :: bit
     r5 :: None
 L0:
     inc_ref y :: int
@@ -72,10 +72,10 @@ def f(x: Optional[A]) -> int:
 def f(x):
     x :: union[__main__.A, None]
     r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: __main__.A
     r3 :: object
-    r4, r5 :: bool
+    r4, r5 :: bit
     r6 :: int
 L0:
     r0 = box(None, 1)
@@ -115,10 +115,11 @@ def sum(a, l):
     a :: list
     l, sum, i :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7 :: bool
     r8 :: object
     r9, r10, r11, r12 :: int
 L0:
@@ -185,7 +186,7 @@ def g():
     r6 :: object
     r7 :: str
     r8, r9 :: object
-    r10 :: bool
+    r10 :: bit
     r11 :: None
 L0:
 L1:
@@ -253,7 +254,7 @@ def a():
     r12 :: object
     r13 :: str
     r14, r15 :: object
-    r16 :: bool
+    r16 :: bit
     r17 :: str
 L0:
 L1:
@@ -355,7 +356,7 @@ def lol(x):
     r1, st :: object
     r2 :: tuple[object, object, object]
     r3 :: str
-    r4 :: bool
+    r4 :: bit
     r5 :: object
 L0:
 L1:
@@ -393,7 +394,7 @@ def lol(x):
     r2 :: str
     r3, b :: object
     r4 :: tuple[object, object, object]
-    r5 :: bool
+    r5 :: bit
     r6 :: object
     r7, r8 :: bool
     r9 :: object
@@ -464,7 +465,7 @@ def f(b: bool) -> None:
 def f(b):
     b :: bool
     r0, u, r1, v :: str
-    r2, r3 :: bool
+    r2, r3 :: bit
     r4 :: object
     r5 :: str
     r6, r7 :: object
@@ -520,3 +521,4 @@ L13:
 L14:
     dec_ref r7
     goto L8
+

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -115,9 +115,9 @@ def sum(a, l):
     a :: list
     l, sum, i :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
     r8 :: object
     r9, r10, r11, r12 :: int

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -118,8 +118,7 @@ def sum(a, l):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7 :: bool
+    r4, r5, r6, r7 :: bit
     r8 :: object
     r9, r10, r11, r12 :: int
 L0:

--- a/mypyc/test-data/irbuild-any.test
+++ b/mypyc/test-data/irbuild-any.test
@@ -52,6 +52,7 @@ def f(a, n, c):
     r6 :: str
     r7 :: object
     r8 :: int32
+    r9 :: bit
 L0:
     r0 = box(int, n)
     c.a = r0; r1 = is_error
@@ -64,6 +65,7 @@ L0:
     r6 = load_global CPyStatic_unicode_6 :: static  ('a')
     r7 = box(int, n)
     r8 = PyObject_SetAttr(a, r6, r7)
+    r9 = r8 >= 0 :: signed
     return 1
 
 [case testCoerceAnyInOps]
@@ -98,12 +100,13 @@ def f2(a, n, l):
     l :: list
     r0, r1, r2, r3, r4 :: object
     r5 :: int32
-    r6 :: object
-    r7 :: int32
-    r8 :: bool
-    r9 :: list
-    r10 :: object
-    r11, r12, r13 :: ptr
+    r6 :: bit
+    r7 :: object
+    r8 :: int32
+    r9, r10 :: bit
+    r11 :: list
+    r12 :: object
+    r13, r14, r15 :: ptr
 L0:
     r0 = box(int, n)
     r1 = PyObject_GetItem(a, r0)
@@ -111,16 +114,18 @@ L0:
     r3 = box(int, n)
     r4 = box(int, n)
     r5 = PyObject_SetItem(a, r3, r4)
-    r6 = box(int, n)
-    r7 = PyObject_SetItem(l, a, r6)
-    r8 = CPyList_SetItem(l, n, a)
-    r9 = PyList_New(2)
-    r10 = box(int, n)
-    r11 = get_element_ptr r9 ob_item :: PyListObject
-    r12 = load_mem r11, r9 :: ptr*
-    set_mem r12, a, r9 :: builtins.object*
-    r13 = r12 + WORD_SIZE*1
-    set_mem r13, r10, r9 :: builtins.object*
+    r6 = r5 >= 0 :: signed
+    r7 = box(int, n)
+    r8 = PyObject_SetItem(l, a, r7)
+    r9 = r8 >= 0 :: signed
+    r10 = CPyList_SetItem(l, n, a)
+    r11 = PyList_New(2)
+    r12 = box(int, n)
+    r13 = get_element_ptr r11 ob_item :: PyListObject
+    r14 = load_mem r13, r11 :: ptr*
+    set_mem r14, a, r11 :: builtins.object*
+    r15 = r14 + 8
+    set_mem r15, r12, r11 :: builtins.object*
     return 1
 def f3(a, n):
     a :: object

--- a/mypyc/test-data/irbuild-any.test
+++ b/mypyc/test-data/irbuild-any.test
@@ -124,7 +124,7 @@ L0:
     r13 = get_element_ptr r11 ob_item :: PyListObject
     r14 = load_mem r13, r11 :: ptr*
     set_mem r14, a, r11 :: builtins.object*
-    r15 = r14 + 8
+    r15 = r14 + WORD_SIZE*1
     set_mem r15, r12, r11 :: builtins.object*
     return 1
 def f3(a, n):
@@ -175,4 +175,3 @@ L6:
     r4 = unbox(int, r2)
     n = r4
     return 1
-

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -77,10 +77,11 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7 :: bool
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -153,14 +154,16 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7, r8 :: bool
-    r9 :: native_int
-    r10 :: bool
-    r11 :: native_int
-    r12, r13, r14, r15 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7, r8 :: bool
+    r9 :: int64
+    r10 :: bit
+    r11 :: int64
+    r12, r13, r14 :: bit
+    r15 :: bool
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -209,19 +212,21 @@ def f(x, y):
     x, y :: object
     r0, r1 :: str
     r2 :: int32
-    r3 :: bool
-    r4 :: str
+    r3 :: bit
+    r4 :: bool
+    r5 :: str
 L0:
     r1 = PyObject_Str(x)
     r2 = PyObject_IsTrue(r1)
-    r3 = truncate r2: int32 to builtins.bool
-    if r3 goto L1 else goto L2 :: bool
+    r3 = r2 >= 0 :: signed
+    r4 = truncate r2: int32 to builtins.bool
+    if r4 goto L1 else goto L2 :: bool
 L1:
     r0 = r1
     goto L3
 L2:
-    r4 = PyObject_Str(y)
-    r0 = r4
+    r5 = PyObject_Str(y)
+    r0 = r5
 L3:
     return r0
 
@@ -236,14 +241,16 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7, r8 :: bool
-    r9 :: native_int
-    r10 :: bool
-    r11 :: native_int
-    r12, r13, r14, r15 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7, r8 :: bool
+    r9 :: int64
+    r10 :: bit
+    r11 :: int64
+    r12, r13, r14 :: bit
+    r15 :: bool
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -292,19 +299,21 @@ def f(x, y):
     x, y :: object
     r0, r1 :: str
     r2 :: int32
-    r3 :: bool
-    r4 :: str
+    r3 :: bit
+    r4 :: bool
+    r5 :: str
 L0:
     r1 = PyObject_Str(x)
     r2 = PyObject_IsTrue(r1)
-    r3 = truncate r2: int32 to builtins.bool
-    if r3 goto L2 else goto L1 :: bool
+    r3 = r2 >= 0 :: signed
+    r4 = truncate r2: int32 to builtins.bool
+    if r4 goto L2 else goto L1 :: bool
 L1:
     r0 = r1
     goto L3
 L2:
-    r4 = PyObject_Str(y)
-    r0 = r4
+    r5 = PyObject_Str(y)
+    r0 = r5
 L3:
     return r0
 
@@ -317,10 +326,11 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7 :: bool
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -351,14 +361,16 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7, r8 :: bool
-    r9 :: native_int
-    r10 :: bool
-    r11 :: native_int
-    r12, r13, r14, r15 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7, r8 :: bool
+    r9 :: int64
+    r10 :: bit
+    r11 :: int64
+    r12, r13, r14 :: bit
+    r15 :: bool
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -405,10 +417,11 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7 :: bool
     r8 :: int
 L0:
 L1:
@@ -444,10 +457,11 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7 :: bool
     r8 :: int
 L0:
     x = 2
@@ -502,10 +516,11 @@ def f(x: int, y: int) -> None:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7 :: bool
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -540,10 +555,11 @@ def f(n: int) -> int:
 def f(n):
     n :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7, r8 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7, r8 :: bool
     r9, r10, r11, r12, r13 :: int
 L0:
     r1 = n & 1
@@ -599,14 +615,16 @@ def f(n: int) -> int:
 def f(n):
     n :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7 :: bool
     x :: int
     r8 :: bool
-    r9 :: native_int
-    r10, r11, r12 :: bool
+    r9 :: int64
+    r10, r11 :: bit
+    r12 :: bool
 L0:
     r1 = n & 1
     r2 = r1 == 0
@@ -665,8 +683,9 @@ def f(n: int) -> int:
 def f(n):
     n :: int
     r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bool
+    r1 :: int64
+    r2, r3 :: bit
+    r4 :: bool
     r5 :: int
 L0:
     r1 = n & 1
@@ -915,7 +934,7 @@ def g(y):
     a :: list
     r5 :: tuple[int, int]
     r6 :: object
-    r7 :: bool
+    r7 :: bit
     r8, r9 :: object
 L0:
     r0 = box(short_int, 2)
@@ -1071,8 +1090,10 @@ def f(x: Any, y: Any, z: Any) -> None:
 def f(x, y, z):
     x, y, z :: object
     r0 :: int32
+    r1 :: bit
 L0:
     r0 = PyObject_SetItem(x, y, z)
+    r1 = r0 >= 0 :: signed
     return 1
 
 [case testLoadFloatSum]
@@ -1198,10 +1219,11 @@ def call_callable_type() -> float:
 def absolute_value(x):
     x :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7 :: bool
     r8, r9 :: int
 L0:
     r1 = x & 1
@@ -1358,11 +1380,13 @@ def lst(x: List[int]) -> int:
 def obj(x):
     x :: object
     r0 :: int32
-    r1 :: bool
+    r1 :: bit
+    r2 :: bool
 L0:
     r0 = PyObject_IsTrue(x)
-    r1 = truncate r0: int32 to builtins.bool
-    if r1 goto L1 else goto L2 :: bool
+    r1 = r0 >= 0 :: signed
+    r2 = truncate r0: int32 to builtins.bool
+    if r2 goto L1 else goto L2 :: bool
 L1:
     return 2
 L2:
@@ -1372,8 +1396,9 @@ L3:
 def num(x):
     x :: int
     r0 :: bool
-    r1 :: native_int
-    r2, r3, r4, r5 :: bool
+    r1 :: int64
+    r2, r3 :: bit
+    r4, r5 :: bool
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -1397,12 +1422,12 @@ L6:
 def lst(x):
     x :: list
     r0 :: ptr
-    r1 :: native_int
+    r1 :: int64
     r2 :: short_int
-    r3 :: bool
+    r3 :: bit
 L0:
     r0 = get_element_ptr x ob_size :: PyVarObject
-    r1 = load_mem r0, x :: native_int*
+    r1 = load_mem r0, x :: int64*
     r2 = r1 << 1
     r3 = r2 != 0
     if r3 goto L1 else goto L2 :: bool
@@ -1439,11 +1464,12 @@ def opt_o(x: Optional[object]) -> int:
 def opt_int(x):
     x :: union[int, None]
     r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: int
     r3 :: bool
-    r4 :: native_int
-    r5, r6, r7, r8 :: bool
+    r4 :: int64
+    r5, r6 :: bit
+    r7, r8 :: bool
 L0:
     r0 = load_address _Py_NoneStruct
     r1 = x != r0
@@ -1472,7 +1498,7 @@ L7:
 def opt_a(x):
     x :: union[__main__.A, None]
     r0 :: object
-    r1 :: bool
+    r1 :: bit
 L0:
     r0 = load_address _Py_NoneStruct
     r1 = x != r0
@@ -1486,10 +1512,11 @@ L3:
 def opt_o(x):
     x :: union[object, None]
     r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
     r3 :: int32
-    r4 :: bool
+    r4 :: bit
+    r5 :: bool
 L0:
     r0 = load_address _Py_NoneStruct
     r1 = x != r0
@@ -1497,8 +1524,9 @@ L0:
 L1:
     r2 = cast(object, x)
     r3 = PyObject_IsTrue(r2)
-    r4 = truncate r3: int32 to builtins.bool
-    if r4 goto L2 else goto L3 :: bool
+    r4 = r3 >= 0 :: signed
+    r5 = truncate r3: int32 to builtins.bool
+    if r5 goto L2 else goto L3 :: bool
 L2:
     return 2
 L3:
@@ -1563,20 +1591,21 @@ L0:
     return 1
 def __top_level__():
     r0, r1 :: object
-    r2 :: bool
+    r2 :: bit
     r3 :: str
     r4 :: object
     r5 :: dict
     r6 :: str
     r7 :: object
     r8 :: int32
-    r9 :: dict
-    r10 :: str
-    r11 :: object
-    r12 :: int
-    r13 :: object
-    r14 :: str
-    r15, r16, r17 :: object
+    r9 :: bit
+    r10 :: dict
+    r11 :: str
+    r12 :: object
+    r13 :: int
+    r14 :: object
+    r15 :: str
+    r16, r17, r18 :: object
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -1591,15 +1620,16 @@ L2:
     r6 = load_global CPyStatic_unicode_1 :: static  ('x')
     r7 = box(short_int, 2)
     r8 = CPyDict_SetItem(r5, r6, r7)
-    r9 = __main__.globals :: static
-    r10 = load_global CPyStatic_unicode_1 :: static  ('x')
-    r11 = CPyDict_GetItem(r9, r10)
-    r12 = unbox(int, r11)
-    r13 = builtins :: module
-    r14 = load_global CPyStatic_unicode_2 :: static  ('print')
-    r15 = CPyObject_GetAttr(r13, r14)
-    r16 = box(int, r12)
-    r17 = PyObject_CallFunctionObjArgs(r15, r16, 0)
+    r9 = r8 >= 0 :: signed
+    r10 = __main__.globals :: static
+    r11 = load_global CPyStatic_unicode_1 :: static  ('x')
+    r12 = CPyDict_GetItem(r10, r11)
+    r13 = unbox(int, r12)
+    r14 = builtins :: module
+    r15 = load_global CPyStatic_unicode_2 :: static  ('print')
+    r16 = CPyObject_GetAttr(r14, r15)
+    r17 = box(int, r13)
+    r18 = PyObject_CallFunctionObjArgs(r16, r17, 0)
     return 1
 
 [case testCallOverloaded]
@@ -1683,20 +1713,22 @@ def foo(x):
     x :: union[int, str]
     r0 :: object
     r1 :: int32
-    r2 :: bool
-    r3 :: __main__.B
-    r4 :: __main__.A
+    r2 :: bit
+    r3 :: bool
+    r4 :: __main__.B
+    r5 :: __main__.A
 L0:
     r0 = load_address PyLong_Type
     r1 = PyObject_IsInstance(x, r0)
-    r2 = truncate r1: int32 to builtins.bool
-    if r2 goto L1 else goto L2 :: bool
+    r2 = r1 >= 0 :: signed
+    r3 = truncate r1: int32 to builtins.bool
+    if r3 goto L1 else goto L2 :: bool
 L1:
-    r3 = B()
-    return r3
-L2:
-    r4 = A()
+    r4 = B()
     return r4
+L2:
+    r5 = A()
+    return r5
 def main():
     r0 :: object
     r1 :: __main__.A
@@ -1853,8 +1885,9 @@ def g():
     r10 :: tuple
     r11 :: dict
     r12 :: int32
-    r13 :: object
-    r14 :: tuple[int, int, int]
+    r13 :: bit
+    r14 :: object
+    r15 :: tuple[int, int, int]
 L0:
     r0 = load_global CPyStatic_unicode_3 :: static  ('a')
     r1 = load_global CPyStatic_unicode_4 :: static  ('b')
@@ -1869,9 +1902,10 @@ L0:
     r10 = PyTuple_Pack(0)
     r11 = PyDict_New()
     r12 = CPyDict_UpdateInDisplay(r11, r6)
-    r13 = PyObject_Call(r9, r10, r11)
-    r14 = unbox(tuple[int, int, int], r13)
-    return r14
+    r13 = r12 >= 0 :: signed
+    r14 = PyObject_Call(r9, r10, r11)
+    r15 = unbox(tuple[int, int, int], r14)
+    return r15
 def h():
     r0, r1 :: str
     r2, r3 :: object
@@ -1881,8 +1915,9 @@ def h():
     r9 :: tuple
     r10 :: dict
     r11 :: int32
-    r12 :: object
-    r13 :: tuple[int, int, int]
+    r12 :: bit
+    r13 :: object
+    r14 :: tuple[int, int, int]
 L0:
     r0 = load_global CPyStatic_unicode_4 :: static  ('b')
     r1 = load_global CPyStatic_unicode_5 :: static  ('c')
@@ -1896,9 +1931,10 @@ L0:
     r9 = PyTuple_Pack(1, r8)
     r10 = PyDict_New()
     r11 = CPyDict_UpdateInDisplay(r10, r4)
-    r12 = PyObject_Call(r7, r9, r10)
-    r13 = unbox(tuple[int, int, int], r12)
-    return r13
+    r12 = r11 >= 0 :: signed
+    r13 = PyObject_Call(r7, r9, r10)
+    r14 = unbox(tuple[int, int, int], r13)
+    return r14
 
 [case testFunctionCallWithDefaultArgs]
 def f(x: int, y: int = 3, z: str = "test") -> None:
@@ -1990,20 +2026,23 @@ def f():
     r5, r6, r7, r8 :: ptr
     r9 :: short_int
     r10 :: ptr
-    r11 :: native_int
+    r11 :: int64
     r12 :: short_int
-    r13 :: bool
+    r13 :: bit
     r14 :: object
     x, r15 :: int
     r16 :: bool
-    r17 :: native_int
-    r18, r19, r20, r21, r22 :: bool
-    r23 :: native_int
-    r24, r25, r26, r27 :: bool
+    r17 :: int64
+    r18, r19 :: bit
+    r20, r21, r22 :: bool
+    r23 :: int64
+    r24, r25 :: bit
+    r26, r27 :: bool
     r28 :: int
     r29 :: object
     r30 :: int32
-    r31 :: short_int
+    r31 :: bit
+    r32 :: short_int
 L0:
     r0 = PyList_New(0)
     r1 = PyList_New(3)
@@ -2013,14 +2052,14 @@ L0:
     r5 = get_element_ptr r1 ob_item :: PyListObject
     r6 = load_mem r5, r1 :: ptr*
     set_mem r6, r2, r1 :: builtins.object*
-    r7 = r6 + WORD_SIZE*1
+    r7 = r6 + 8
     set_mem r7, r3, r1 :: builtins.object*
-    r8 = r6 + WORD_SIZE*2
+    r8 = r6 + 16
     set_mem r8, r4, r1 :: builtins.object*
     r9 = 0
 L1:
     r10 = get_element_ptr r1 ob_size :: PyVarObject
-    r11 = load_mem r10, r1 :: native_int*
+    r11 = load_mem r10, r1 :: int64*
     r12 = r11 << 1
     r13 = r9 < r12 :: signed
     if r13 goto L2 else goto L14 :: bool
@@ -2063,9 +2102,10 @@ L12:
     r28 = CPyTagged_Multiply(x, x)
     r29 = box(int, r28)
     r30 = PyList_Append(r0, r29)
+    r31 = r30 >= 0 :: signed
 L13:
-    r31 = r9 + 2
-    r9 = r31
+    r32 = r9 + 2
+    r9 = r32
     goto L1
 L14:
     return r0
@@ -2082,20 +2122,23 @@ def f():
     r5, r6, r7, r8 :: ptr
     r9 :: short_int
     r10 :: ptr
-    r11 :: native_int
+    r11 :: int64
     r12 :: short_int
-    r13 :: bool
+    r13 :: bit
     r14 :: object
     x, r15 :: int
     r16 :: bool
-    r17 :: native_int
-    r18, r19, r20, r21, r22 :: bool
-    r23 :: native_int
-    r24, r25, r26, r27 :: bool
+    r17 :: int64
+    r18, r19 :: bit
+    r20, r21, r22 :: bool
+    r23 :: int64
+    r24, r25 :: bit
+    r26, r27 :: bool
     r28 :: int
     r29, r30 :: object
     r31 :: int32
-    r32 :: short_int
+    r32 :: bit
+    r33 :: short_int
 L0:
     r0 = PyDict_New()
     r1 = PyList_New(3)
@@ -2105,14 +2148,14 @@ L0:
     r5 = get_element_ptr r1 ob_item :: PyListObject
     r6 = load_mem r5, r1 :: ptr*
     set_mem r6, r2, r1 :: builtins.object*
-    r7 = r6 + WORD_SIZE*1
+    r7 = r6 + 8
     set_mem r7, r3, r1 :: builtins.object*
-    r8 = r6 + WORD_SIZE*2
+    r8 = r6 + 16
     set_mem r8, r4, r1 :: builtins.object*
     r9 = 0
 L1:
     r10 = get_element_ptr r1 ob_size :: PyVarObject
-    r11 = load_mem r10, r1 :: native_int*
+    r11 = load_mem r10, r1 :: int64*
     r12 = r11 << 1
     r13 = r9 < r12 :: signed
     if r13 goto L2 else goto L14 :: bool
@@ -2156,9 +2199,10 @@ L12:
     r29 = box(int, x)
     r30 = box(int, r28)
     r31 = CPyDict_SetItem(r0, r29, r30)
+    r32 = r31 >= 0 :: signed
 L13:
-    r32 = r9 + 2
-    r9 = r32
+    r33 = r9 + 2
+    r9 = r33
     goto L1
 L14:
     return r0
@@ -2174,9 +2218,9 @@ def f(l):
     l :: list
     r0 :: short_int
     r1 :: ptr
-    r2 :: native_int
+    r2 :: int64
     r3 :: short_int
-    r4 :: bool
+    r4 :: bit
     r5 :: object
     x, y, z :: int
     r6 :: tuple[int, int, int]
@@ -2185,21 +2229,22 @@ def f(l):
     r11 :: list
     r12 :: short_int
     r13 :: ptr
-    r14 :: native_int
+    r14 :: int64
     r15 :: short_int
-    r16 :: bool
+    r16 :: bit
     r17 :: object
     x0, y0, z0 :: int
     r18 :: tuple[int, int, int]
     r19, r20, r21, r22, r23 :: int
     r24 :: object
     r25 :: int32
-    r26 :: short_int
+    r26 :: bit
+    r27 :: short_int
 L0:
     r0 = 0
 L1:
     r1 = get_element_ptr l ob_size :: PyVarObject
-    r2 = load_mem r1, l :: native_int*
+    r2 = load_mem r1, l :: int64*
     r3 = r2 << 1
     r4 = r0 < r3 :: signed
     if r4 goto L2 else goto L4 :: bool
@@ -2221,7 +2266,7 @@ L4:
     r12 = 0
 L5:
     r13 = get_element_ptr l ob_size :: PyVarObject
-    r14 = load_mem r13, l :: native_int*
+    r14 = load_mem r13, l :: int64*
     r15 = r14 << 1
     r16 = r12 < r15 :: signed
     if r16 goto L6 else goto L8 :: bool
@@ -2238,9 +2283,10 @@ L6:
     r23 = CPyTagged_Add(r22, z0)
     r24 = box(int, r23)
     r25 = PyList_Append(r11, r24)
+    r26 = r25 >= 0 :: signed
 L7:
-    r26 = r12 + 2
-    r12 = r26
+    r27 = r12 + 2
+    r12 = r27
     goto L5
 L8:
     return r11
@@ -2568,10 +2614,10 @@ y = Bar([1,2,3])
 [out]
 def __top_level__():
     r0, r1 :: object
-    r2 :: bool
+    r2 :: bit
     r3 :: str
     r4, r5, r6 :: object
-    r7 :: bool
+    r7 :: bit
     r8 :: str
     r9, r10 :: object
     r11 :: dict
@@ -2579,63 +2625,71 @@ def __top_level__():
     r13 :: object
     r14 :: str
     r15 :: int32
-    r16 :: str
-    r17 :: object
-    r18 :: str
-    r19 :: int32
-    r20 :: str
-    r21 :: object
+    r16 :: bit
+    r17 :: str
+    r18 :: object
+    r19 :: str
+    r20 :: int32
+    r21 :: bit
     r22 :: str
-    r23 :: int32
-    r24, r25 :: str
-    r26 :: object
-    r27 :: tuple[str, object]
-    r28 :: object
-    r29 :: str
-    r30 :: object
-    r31 :: tuple[str, object]
-    r32 :: object
-    r33 :: tuple[object, object]
-    r34 :: object
-    r35 :: dict
-    r36 :: str
-    r37, r38 :: object
-    r39 :: dict
-    r40 :: str
-    r41 :: int32
-    r42 :: str
-    r43 :: dict
-    r44 :: str
-    r45, r46, r47 :: object
-    r48 :: tuple
-    r49 :: dict
-    r50 :: str
-    r51 :: int32
-    r52 :: dict
-    r53 :: str
-    r54, r55, r56 :: object
+    r23 :: object
+    r24 :: str
+    r25 :: int32
+    r26 :: bit
+    r27, r28 :: str
+    r29 :: object
+    r30 :: tuple[str, object]
+    r31 :: object
+    r32 :: str
+    r33 :: object
+    r34 :: tuple[str, object]
+    r35 :: object
+    r36 :: tuple[object, object]
+    r37 :: object
+    r38 :: dict
+    r39 :: str
+    r40, r41 :: object
+    r42 :: dict
+    r43 :: str
+    r44 :: int32
+    r45 :: bit
+    r46 :: str
+    r47 :: dict
+    r48 :: str
+    r49, r50, r51 :: object
+    r52 :: tuple
+    r53 :: dict
+    r54 :: str
+    r55 :: int32
+    r56 :: bit
     r57 :: dict
     r58 :: str
-    r59 :: int32
-    r60 :: str
-    r61 :: dict
-    r62 :: str
-    r63 :: object
-    r64 :: dict
-    r65 :: str
-    r66, r67 :: object
-    r68 :: dict
-    r69 :: str
-    r70 :: int32
-    r71 :: list
-    r72, r73, r74 :: object
-    r75, r76, r77, r78 :: ptr
-    r79 :: dict
-    r80 :: str
-    r81, r82 :: object
-    r83 :: dict
-    r84 :: str
-    r85 :: int32
+    r59, r60, r61 :: object
+    r62 :: dict
+    r63 :: str
+    r64 :: int32
+    r65 :: bit
+    r66 :: str
+    r67 :: dict
+    r68 :: str
+    r69 :: object
+    r70 :: dict
+    r71 :: str
+    r72, r73 :: object
+    r74 :: dict
+    r75 :: str
+    r76 :: int32
+    r77 :: bit
+    r78 :: list
+    r79, r80, r81 :: object
+    r82, r83, r84, r85 :: ptr
+    r86 :: dict
+    r87 :: str
+    r88, r89 :: object
+    r90 :: dict
+    r91 :: str
+    r92 :: int32
+    r93 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -2661,79 +2715,87 @@ L4:
     r13 = CPyObject_GetAttr(r10, r12)
     r14 = load_global CPyStatic_unicode_2 :: static  ('List')
     r15 = CPyDict_SetItem(r11, r14, r13)
-    r16 = load_global CPyStatic_unicode_3 :: static  ('NewType')
-    r17 = CPyObject_GetAttr(r10, r16)
-    r18 = load_global CPyStatic_unicode_3 :: static  ('NewType')
-    r19 = CPyDict_SetItem(r11, r18, r17)
-    r20 = load_global CPyStatic_unicode_4 :: static  ('NamedTuple')
-    r21 = CPyObject_GetAttr(r10, r20)
+    r16 = r15 >= 0 :: signed
+    r17 = load_global CPyStatic_unicode_3 :: static  ('NewType')
+    r18 = CPyObject_GetAttr(r10, r17)
+    r19 = load_global CPyStatic_unicode_3 :: static  ('NewType')
+    r20 = CPyDict_SetItem(r11, r19, r18)
+    r21 = r20 >= 0 :: signed
     r22 = load_global CPyStatic_unicode_4 :: static  ('NamedTuple')
-    r23 = CPyDict_SetItem(r11, r22, r21)
-    r24 = load_global CPyStatic_unicode_5 :: static  ('Lol')
-    r25 = load_global CPyStatic_unicode_6 :: static  ('a')
-    r26 = load_address PyLong_Type
-    r27 = (r25, r26)
-    r28 = box(tuple[str, object], r27)
-    r29 = load_global CPyStatic_unicode_7 :: static  ('b')
-    r30 = load_address PyUnicode_Type
-    r31 = (r29, r30)
-    r32 = box(tuple[str, object], r31)
-    r33 = (r28, r32)
-    r34 = box(tuple[object, object], r33)
-    r35 = __main__.globals :: static
-    r36 = load_global CPyStatic_unicode_4 :: static  ('NamedTuple')
-    r37 = CPyDict_GetItem(r35, r36)
-    r38 = PyObject_CallFunctionObjArgs(r37, r24, r34, 0)
-    r39 = __main__.globals :: static
-    r40 = load_global CPyStatic_unicode_5 :: static  ('Lol')
-    r41 = CPyDict_SetItem(r39, r40, r38)
-    r42 = load_global CPyStatic_unicode_8 :: static
-    r43 = __main__.globals :: static
-    r44 = load_global CPyStatic_unicode_5 :: static  ('Lol')
-    r45 = CPyDict_GetItem(r43, r44)
-    r46 = box(short_int, 2)
-    r47 = PyObject_CallFunctionObjArgs(r45, r46, r42, 0)
-    r48 = cast(tuple, r47)
-    r49 = __main__.globals :: static
-    r50 = load_global CPyStatic_unicode_9 :: static  ('x')
-    r51 = CPyDict_SetItem(r49, r50, r48)
-    r52 = __main__.globals :: static
-    r53 = load_global CPyStatic_unicode_2 :: static  ('List')
-    r54 = CPyDict_GetItem(r52, r53)
-    r55 = load_address PyLong_Type
-    r56 = PyObject_GetItem(r54, r55)
+    r23 = CPyObject_GetAttr(r10, r22)
+    r24 = load_global CPyStatic_unicode_4 :: static  ('NamedTuple')
+    r25 = CPyDict_SetItem(r11, r24, r23)
+    r26 = r25 >= 0 :: signed
+    r27 = load_global CPyStatic_unicode_5 :: static  ('Lol')
+    r28 = load_global CPyStatic_unicode_6 :: static  ('a')
+    r29 = load_address PyLong_Type
+    r30 = (r28, r29)
+    r31 = box(tuple[str, object], r30)
+    r32 = load_global CPyStatic_unicode_7 :: static  ('b')
+    r33 = load_address PyUnicode_Type
+    r34 = (r32, r33)
+    r35 = box(tuple[str, object], r34)
+    r36 = (r31, r35)
+    r37 = box(tuple[object, object], r36)
+    r38 = __main__.globals :: static
+    r39 = load_global CPyStatic_unicode_4 :: static  ('NamedTuple')
+    r40 = CPyDict_GetItem(r38, r39)
+    r41 = PyObject_CallFunctionObjArgs(r40, r27, r37, 0)
+    r42 = __main__.globals :: static
+    r43 = load_global CPyStatic_unicode_5 :: static  ('Lol')
+    r44 = CPyDict_SetItem(r42, r43, r41)
+    r45 = r44 >= 0 :: signed
+    r46 = load_global CPyStatic_unicode_8 :: static
+    r47 = __main__.globals :: static
+    r48 = load_global CPyStatic_unicode_5 :: static  ('Lol')
+    r49 = CPyDict_GetItem(r47, r48)
+    r50 = box(short_int, 2)
+    r51 = PyObject_CallFunctionObjArgs(r49, r50, r46, 0)
+    r52 = cast(tuple, r51)
+    r53 = __main__.globals :: static
+    r54 = load_global CPyStatic_unicode_9 :: static  ('x')
+    r55 = CPyDict_SetItem(r53, r54, r52)
+    r56 = r55 >= 0 :: signed
     r57 = __main__.globals :: static
-    r58 = load_global CPyStatic_unicode_10 :: static  ('Foo')
-    r59 = CPyDict_SetItem(r57, r58, r56)
-    r60 = load_global CPyStatic_unicode_11 :: static  ('Bar')
-    r61 = __main__.globals :: static
-    r62 = load_global CPyStatic_unicode_10 :: static  ('Foo')
-    r63 = CPyDict_GetItem(r61, r62)
-    r64 = __main__.globals :: static
-    r65 = load_global CPyStatic_unicode_3 :: static  ('NewType')
-    r66 = CPyDict_GetItem(r64, r65)
-    r67 = PyObject_CallFunctionObjArgs(r66, r60, r63, 0)
-    r68 = __main__.globals :: static
-    r69 = load_global CPyStatic_unicode_11 :: static  ('Bar')
-    r70 = CPyDict_SetItem(r68, r69, r67)
-    r71 = PyList_New(3)
-    r72 = box(short_int, 2)
-    r73 = box(short_int, 4)
-    r74 = box(short_int, 6)
-    r75 = get_element_ptr r71 ob_item :: PyListObject
-    r76 = load_mem r75, r71 :: ptr*
-    set_mem r76, r72, r71 :: builtins.object*
-    r77 = r76 + WORD_SIZE*1
-    set_mem r77, r73, r71 :: builtins.object*
-    r78 = r76 + WORD_SIZE*2
-    set_mem r78, r74, r71 :: builtins.object*
-    r79 = __main__.globals :: static
-    r80 = load_global CPyStatic_unicode_11 :: static  ('Bar')
-    r81 = CPyDict_GetItem(r79, r80)
-    r82 = PyObject_CallFunctionObjArgs(r81, r71, 0)
-    r83 = __main__.globals :: static
-    r84 = load_global CPyStatic_unicode_12 :: static  ('y')
-    r85 = CPyDict_SetItem(r83, r84, r82)
+    r58 = load_global CPyStatic_unicode_2 :: static  ('List')
+    r59 = CPyDict_GetItem(r57, r58)
+    r60 = load_address PyLong_Type
+    r61 = PyObject_GetItem(r59, r60)
+    r62 = __main__.globals :: static
+    r63 = load_global CPyStatic_unicode_10 :: static  ('Foo')
+    r64 = CPyDict_SetItem(r62, r63, r61)
+    r65 = r64 >= 0 :: signed
+    r66 = load_global CPyStatic_unicode_11 :: static  ('Bar')
+    r67 = __main__.globals :: static
+    r68 = load_global CPyStatic_unicode_10 :: static  ('Foo')
+    r69 = CPyDict_GetItem(r67, r68)
+    r70 = __main__.globals :: static
+    r71 = load_global CPyStatic_unicode_3 :: static  ('NewType')
+    r72 = CPyDict_GetItem(r70, r71)
+    r73 = PyObject_CallFunctionObjArgs(r72, r66, r69, 0)
+    r74 = __main__.globals :: static
+    r75 = load_global CPyStatic_unicode_11 :: static  ('Bar')
+    r76 = CPyDict_SetItem(r74, r75, r73)
+    r77 = r76 >= 0 :: signed
+    r78 = PyList_New(3)
+    r79 = box(short_int, 2)
+    r80 = box(short_int, 4)
+    r81 = box(short_int, 6)
+    r82 = get_element_ptr r78 ob_item :: PyListObject
+    r83 = load_mem r82, r78 :: ptr*
+    set_mem r83, r79, r78 :: builtins.object*
+    r84 = r83 + 8
+    set_mem r84, r80, r78 :: builtins.object*
+    r85 = r83 + 16
+    set_mem r85, r81, r78 :: builtins.object*
+    r86 = __main__.globals :: static
+    r87 = load_global CPyStatic_unicode_11 :: static  ('Bar')
+    r88 = CPyDict_GetItem(r86, r87)
+    r89 = PyObject_CallFunctionObjArgs(r88, r78, 0)
+    r90 = __main__.globals :: static
+    r91 = load_global CPyStatic_unicode_12 :: static  ('y')
+    r92 = CPyDict_SetItem(r90, r91, r89)
+    r93 = r92 >= 0 :: signed
     return 1
 
 [case testChainedConditional]
@@ -2749,16 +2811,18 @@ L0:
 def f(x, y, z):
     x, y, z, r0, r1 :: int
     r2, r3 :: bool
-    r4 :: native_int
-    r5 :: bool
-    r6 :: native_int
-    r7, r8, r9, r10 :: bool
+    r4 :: int64
+    r5 :: bit
+    r6 :: int64
+    r7, r8, r9 :: bit
+    r10 :: bool
     r11 :: int
     r12 :: bool
-    r13 :: native_int
-    r14 :: bool
-    r15 :: native_int
-    r16, r17, r18, r19 :: bool
+    r13 :: int64
+    r14 :: bit
+    r15 :: int64
+    r16, r17, r18 :: bit
+    r19 :: bool
 L0:
     r0 = g(x)
     r1 = g(y)
@@ -2814,10 +2878,11 @@ L0:
 def A.__ne__(self, rhs):
     self :: __main__.A
     rhs, r0, r1 :: object
-    r2 :: bool
+    r2 :: bit
     r3 :: int32
-    r4 :: bool
-    r5 :: object
+    r4 :: bit
+    r5 :: bool
+    r6 :: object
 L0:
     r0 = self.__eq__(rhs)
     r1 = load_address _Py_NotImplementedStruct
@@ -2825,9 +2890,10 @@ L0:
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = PyObject_Not(r0)
-    r4 = truncate r3: int32 to builtins.bool
-    r5 = box(bool, r4)
-    return r5
+    r4 = r3 >= 0 :: signed
+    r5 = truncate r3: int32 to builtins.bool
+    r6 = box(bool, r5)
+    return r6
 L2:
     return r1
 
@@ -2861,7 +2927,7 @@ def c() -> None:
 [out]
 def g_a_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -2918,7 +2984,7 @@ L0:
     return r5
 def g_b_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -2975,7 +3041,7 @@ L0:
     return r5
 def __mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -3042,10 +3108,10 @@ L0:
     return 1
 def __top_level__():
     r0, r1 :: object
-    r2 :: bool
+    r2 :: bit
     r3 :: str
     r4, r5, r6 :: object
-    r7 :: bool
+    r7 :: bit
     r8 :: str
     r9, r10 :: object
     r11 :: dict
@@ -3053,18 +3119,20 @@ def __top_level__():
     r13 :: object
     r14 :: str
     r15 :: int32
-    r16 :: dict
-    r17 :: str
-    r18 :: object
-    r19 :: dict
-    r20 :: str
-    r21, r22 :: object
-    r23 :: dict
-    r24 :: str
-    r25, r26 :: object
-    r27 :: dict
-    r28 :: str
-    r29 :: int32
+    r16 :: bit
+    r17 :: dict
+    r18 :: str
+    r19 :: object
+    r20 :: dict
+    r21 :: str
+    r22, r23 :: object
+    r24 :: dict
+    r25 :: str
+    r26, r27 :: object
+    r28 :: dict
+    r29 :: str
+    r30 :: int32
+    r31 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -3090,20 +3158,22 @@ L4:
     r13 = CPyObject_GetAttr(r10, r12)
     r14 = load_global CPyStatic_unicode_2 :: static  ('Callable')
     r15 = CPyDict_SetItem(r11, r14, r13)
-    r16 = __main__.globals :: static
-    r17 = load_global CPyStatic_unicode_11 :: static  ('__mypyc_c_decorator_helper__')
-    r18 = CPyDict_GetItem(r16, r17)
-    r19 = __main__.globals :: static
-    r20 = load_global CPyStatic_unicode_8 :: static  ('b')
-    r21 = CPyDict_GetItem(r19, r20)
-    r22 = PyObject_CallFunctionObjArgs(r21, r18, 0)
-    r23 = __main__.globals :: static
-    r24 = load_global CPyStatic_unicode_9 :: static  ('a')
-    r25 = CPyDict_GetItem(r23, r24)
-    r26 = PyObject_CallFunctionObjArgs(r25, r22, 0)
-    r27 = __main__.globals :: static
-    r28 = load_global CPyStatic_unicode_10 :: static  ('c')
-    r29 = CPyDict_SetItem(r27, r28, r26)
+    r16 = r15 >= 0 :: signed
+    r17 = __main__.globals :: static
+    r18 = load_global CPyStatic_unicode_11 :: static  ('__mypyc_c_decorator_helper__')
+    r19 = CPyDict_GetItem(r17, r18)
+    r20 = __main__.globals :: static
+    r21 = load_global CPyStatic_unicode_8 :: static  ('b')
+    r22 = CPyDict_GetItem(r20, r21)
+    r23 = PyObject_CallFunctionObjArgs(r22, r19, 0)
+    r24 = __main__.globals :: static
+    r25 = load_global CPyStatic_unicode_9 :: static  ('a')
+    r26 = CPyDict_GetItem(r24, r25)
+    r27 = PyObject_CallFunctionObjArgs(r26, r23, 0)
+    r28 = __main__.globals :: static
+    r29 = load_global CPyStatic_unicode_10 :: static  ('c')
+    r30 = CPyDict_SetItem(r28, r29, r27)
+    r31 = r30 >= 0 :: signed
     return 1
 
 [case testDecoratorsSimple_toplevel]
@@ -3119,7 +3189,7 @@ def a(f: Callable[[], None]) -> Callable[[], None]:
 [out]
 def g_a_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -3176,10 +3246,10 @@ L0:
     return r5
 def __top_level__():
     r0, r1 :: object
-    r2 :: bool
+    r2 :: bit
     r3 :: str
     r4, r5, r6 :: object
-    r7 :: bool
+    r7 :: bit
     r8 :: str
     r9, r10 :: object
     r11 :: dict
@@ -3187,6 +3257,7 @@ def __top_level__():
     r13 :: object
     r14 :: str
     r15 :: int32
+    r16 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -3212,6 +3283,7 @@ L4:
     r13 = CPyObject_GetAttr(r10, r12)
     r14 = load_global CPyStatic_unicode_2 :: static  ('Callable')
     r15 = CPyDict_SetItem(r11, r14, r13)
+    r16 = r15 >= 0 :: signed
     return 1
 
 [case testAnyAllG]
@@ -3230,8 +3302,10 @@ def call_any(l):
     r1, r2 :: object
     r3, i :: int
     r4 :: bool
-    r5 :: native_int
-    r6, r7, r8, r9 :: bool
+    r5 :: int64
+    r6, r7 :: bit
+    r8 :: bool
+    r9 :: bit
 L0:
     r0 = 0
     r1 = PyObject_GetIter(l)
@@ -3270,8 +3344,10 @@ def call_all(l):
     r1, r2 :: object
     r3, i :: int
     r4 :: bool
-    r5 :: native_int
-    r6, r7, r8, r9, r10 :: bool
+    r5 :: int64
+    r6, r7 :: bit
+    r8, r9 :: bool
+    r10 :: bit
 L0:
     r0 = 1
     r1 = PyObject_GetIter(l)
@@ -3316,13 +3392,15 @@ def lol(x):
     x :: object
     r0, r1 :: str
     r2 :: int32
-    r3 :: object
+    r3 :: bit
+    r4 :: object
 L0:
     r0 = load_global CPyStatic_unicode_5 :: static  ('x')
     r1 = load_global CPyStatic_unicode_6 :: static  ('5')
     r2 = PyObject_SetAttr(x, r0, r1)
-    r3 = box(None, 1)
-    return r3
+    r3 = r2 >= 0 :: signed
+    r4 = box(None, 1)
+    return r4
 
 [case testFinalModuleInt]
 from typing import Final
@@ -3620,11 +3698,13 @@ def f(x: object) -> bool:
 def f(x):
     x :: object
     r0 :: int32
-    r1 :: bool
+    r1 :: bit
+    r2 :: bool
 L0:
     r0 = PyObject_IsTrue(x)
-    r1 = truncate r0: int32 to builtins.bool
-    return r1
+    r1 = r0 >= 0 :: signed
+    r2 = truncate r0: int32 to builtins.bool
+    return r2
 
 [case testMultipleAssignment]
 from typing import Tuple

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2035,9 +2035,9 @@ L0:
     r5 = get_element_ptr r1 ob_item :: PyListObject
     r6 = load_mem r5, r1 :: ptr*
     set_mem r6, r2, r1 :: builtins.object*
-    r7 = r6 + 8
+    r7 = r6 + WORD_SIZE*1
     set_mem r7, r3, r1 :: builtins.object*
-    r8 = r6 + 16
+    r8 = r6 + WORD_SIZE*2
     set_mem r8, r4, r1 :: builtins.object*
     r9 = 0
 L1:
@@ -2130,9 +2130,9 @@ L0:
     r5 = get_element_ptr r1 ob_item :: PyListObject
     r6 = load_mem r5, r1 :: ptr*
     set_mem r6, r2, r1 :: builtins.object*
-    r7 = r6 + 8
+    r7 = r6 + WORD_SIZE*1
     set_mem r7, r3, r1 :: builtins.object*
-    r8 = r6 + 16
+    r8 = r6 + WORD_SIZE*2
     set_mem r8, r4, r1 :: builtins.object*
     r9 = 0
 L1:
@@ -2766,9 +2766,9 @@ L4:
     r82 = get_element_ptr r78 ob_item :: PyListObject
     r83 = load_mem r82, r78 :: ptr*
     set_mem r83, r79, r78 :: builtins.object*
-    r84 = r83 + 8
+    r84 = r83 + WORD_SIZE*1
     set_mem r84, r80, r78 :: builtins.object*
-    r85 = r83 + 16
+    r85 = r83 + WORD_SIZE*2
     set_mem r85, r81, r78 :: builtins.object*
     r86 = __main__.globals :: static
     r87 = load_global CPyStatic_unicode_11 :: static  ('Bar')

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -114,9 +114,10 @@ def f(x, y):
     x, y :: int
     r0 :: bool
     r1 :: native_int
-    r2 :: bool
+    r2 :: bit
     r3 :: native_int
-    r4, r5, r6, r7 :: bool
+    r4, r5, r6 :: bit
+    r7 :: bool
 L0:
     r1 = x & 1
     r2 = r1 == 0

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -77,9 +77,9 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
 L0:
     r1 = x & 1
@@ -113,9 +113,9 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
 L0:
     r1 = x & 1
@@ -152,14 +152,14 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
     r8 :: bool
-    r9 :: int64
+    r9 :: native_int
     r10 :: bit
-    r11 :: int64
+    r11 :: native_int
     r12, r13, r14, r15 :: bit
 L0:
     r1 = x & 1
@@ -238,14 +238,14 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
     r8 :: bool
-    r9 :: int64
+    r9 :: native_int
     r10 :: bit
-    r11 :: int64
+    r11 :: native_int
     r12, r13, r14, r15 :: bit
 L0:
     r1 = x & 1
@@ -322,9 +322,9 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
 L0:
     r1 = x & 1
@@ -356,14 +356,14 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
     r8 :: bool
-    r9 :: int64
+    r9 :: native_int
     r10 :: bit
-    r11 :: int64
+    r11 :: native_int
     r12, r13, r14, r15 :: bit
 L0:
     r1 = x & 1
@@ -411,9 +411,9 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
     r8 :: int
 L0:
@@ -450,9 +450,9 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
     r8 :: int
 L0:
@@ -508,9 +508,9 @@ def f(x: int, y: int) -> None:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
 L0:
     r1 = x & 1
@@ -546,9 +546,9 @@ def f(n: int) -> int:
 def f(n):
     n :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7, r8 :: bit
     r9, r10, r11, r12, r13 :: int
 L0:
@@ -605,13 +605,13 @@ def f(n: int) -> int:
 def f(n):
     n :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
     x :: int
     r8 :: bool
-    r9 :: int64
+    r9 :: native_int
     r10, r11, r12 :: bit
 L0:
     r1 = n & 1
@@ -671,7 +671,7 @@ def f(n: int) -> int:
 def f(n):
     n :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2, r3, r4 :: bit
     r5 :: int
 L0:
@@ -1206,9 +1206,9 @@ def call_callable_type() -> float:
 def absolute_value(x):
     x :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
     r8, r9 :: int
 L0:
@@ -1382,7 +1382,7 @@ L3:
 def num(x):
     x :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2, r3, r4, r5 :: bit
 L0:
     r1 = x & 1
@@ -1407,12 +1407,12 @@ L6:
 def lst(x):
     x :: list
     r0 :: ptr
-    r1 :: int64
+    r1 :: native_int
     r2 :: short_int
     r3 :: bit
 L0:
     r0 = get_element_ptr x ob_size :: PyVarObject
-    r1 = load_mem r0, x :: int64*
+    r1 = load_mem r0, x :: native_int*
     r2 = r1 << 1
     r3 = r2 != 0
     if r3 goto L1 else goto L2 :: bool
@@ -1452,7 +1452,7 @@ def opt_int(x):
     r1 :: bit
     r2 :: int
     r3 :: bool
-    r4 :: int64
+    r4 :: native_int
     r5, r6, r7, r8 :: bit
 L0:
     r0 = load_address _Py_NoneStruct
@@ -2010,16 +2010,16 @@ def f():
     r5, r6, r7, r8 :: ptr
     r9 :: short_int
     r10 :: ptr
-    r11 :: int64
+    r11 :: native_int
     r12 :: short_int
     r13 :: bit
     r14 :: object
     x, r15 :: int
     r16 :: bool
-    r17 :: int64
+    r17 :: native_int
     r18, r19, r20, r21 :: bit
     r22 :: bool
-    r23 :: int64
+    r23 :: native_int
     r24, r25, r26, r27 :: bit
     r28 :: int
     r29 :: object
@@ -2042,7 +2042,7 @@ L0:
     r9 = 0
 L1:
     r10 = get_element_ptr r1 ob_size :: PyVarObject
-    r11 = load_mem r10, r1 :: int64*
+    r11 = load_mem r10, r1 :: native_int*
     r12 = r11 << 1
     r13 = r9 < r12 :: signed
     if r13 goto L2 else goto L14 :: bool
@@ -2105,16 +2105,16 @@ def f():
     r5, r6, r7, r8 :: ptr
     r9 :: short_int
     r10 :: ptr
-    r11 :: int64
+    r11 :: native_int
     r12 :: short_int
     r13 :: bit
     r14 :: object
     x, r15 :: int
     r16 :: bool
-    r17 :: int64
+    r17 :: native_int
     r18, r19, r20, r21 :: bit
     r22 :: bool
-    r23 :: int64
+    r23 :: native_int
     r24, r25, r26, r27 :: bit
     r28 :: int
     r29, r30 :: object
@@ -2137,7 +2137,7 @@ L0:
     r9 = 0
 L1:
     r10 = get_element_ptr r1 ob_size :: PyVarObject
-    r11 = load_mem r10, r1 :: int64*
+    r11 = load_mem r10, r1 :: native_int*
     r12 = r11 << 1
     r13 = r9 < r12 :: signed
     if r13 goto L2 else goto L14 :: bool
@@ -2200,7 +2200,7 @@ def f(l):
     l :: list
     r0 :: short_int
     r1 :: ptr
-    r2 :: int64
+    r2 :: native_int
     r3 :: short_int
     r4 :: bit
     r5 :: object
@@ -2211,7 +2211,7 @@ def f(l):
     r11 :: list
     r12 :: short_int
     r13 :: ptr
-    r14 :: int64
+    r14 :: native_int
     r15 :: short_int
     r16 :: bit
     r17 :: object
@@ -2226,7 +2226,7 @@ L0:
     r0 = 0
 L1:
     r1 = get_element_ptr l ob_size :: PyVarObject
-    r2 = load_mem r1, l :: int64*
+    r2 = load_mem r1, l :: native_int*
     r3 = r2 << 1
     r4 = r0 < r3 :: signed
     if r4 goto L2 else goto L4 :: bool
@@ -2248,7 +2248,7 @@ L4:
     r12 = 0
 L5:
     r13 = get_element_ptr l ob_size :: PyVarObject
-    r14 = load_mem r13, l :: int64*
+    r14 = load_mem r13, l :: native_int*
     r15 = r14 << 1
     r16 = r12 < r15 :: signed
     if r16 goto L6 else goto L8 :: bool
@@ -2793,15 +2793,15 @@ L0:
 def f(x, y, z):
     x, y, z, r0, r1 :: int
     r2, r3 :: bool
-    r4 :: int64
+    r4 :: native_int
     r5 :: bit
-    r6 :: int64
+    r6 :: native_int
     r7, r8, r9, r10 :: bit
     r11 :: int
     r12 :: bool
-    r13 :: int64
+    r13 :: native_int
     r14 :: bit
-    r15 :: int64
+    r15 :: native_int
     r16, r17, r18, r19 :: bit
 L0:
     r0 = g(x)
@@ -3282,7 +3282,7 @@ def call_any(l):
     r1, r2 :: object
     r3, i :: int
     r4 :: bool
-    r5 :: int64
+    r5 :: native_int
     r6, r7, r8, r9 :: bit
 L0:
     r0 = 0
@@ -3322,7 +3322,7 @@ def call_all(l):
     r1, r2 :: object
     r3, i :: int
     r4 :: bool
-    r5 :: int64
+    r5 :: native_int
     r6, r7, r8 :: bit
     r9 :: bool
     r10 :: bit

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -80,8 +80,7 @@ def f(x, y):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7 :: bool
+    r4, r5, r6, r7 :: bit
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -114,11 +113,10 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: native_int
+    r1 :: int64
     r2 :: bit
-    r3 :: native_int
-    r4, r5, r6 :: bit
-    r7 :: bool
+    r3 :: int64
+    r4, r5, r6, r7 :: bit
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -157,13 +155,12 @@ def f(x, y):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7, r8 :: bool
+    r4, r5, r6, r7 :: bit
+    r8 :: bool
     r9 :: int64
     r10 :: bit
     r11 :: int64
-    r12, r13, r14 :: bit
-    r15 :: bool
+    r12, r13, r14, r15 :: bit
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -244,13 +241,12 @@ def f(x, y):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7, r8 :: bool
+    r4, r5, r6, r7 :: bit
+    r8 :: bool
     r9 :: int64
     r10 :: bit
     r11 :: int64
-    r12, r13, r14 :: bit
-    r15 :: bool
+    r12, r13, r14, r15 :: bit
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -329,8 +325,7 @@ def f(x, y):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7 :: bool
+    r4, r5, r6, r7 :: bit
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -364,13 +359,12 @@ def f(x, y):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7, r8 :: bool
+    r4, r5, r6, r7 :: bit
+    r8 :: bool
     r9 :: int64
     r10 :: bit
     r11 :: int64
-    r12, r13, r14 :: bit
-    r15 :: bool
+    r12, r13, r14, r15 :: bit
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -420,8 +414,7 @@ def f(x, y):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7 :: bool
+    r4, r5, r6, r7 :: bit
     r8 :: int
 L0:
 L1:
@@ -460,8 +453,7 @@ def f(x, y):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7 :: bool
+    r4, r5, r6, r7 :: bit
     r8 :: int
 L0:
     x = 2
@@ -519,8 +511,7 @@ def f(x, y):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7 :: bool
+    r4, r5, r6, r7 :: bit
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -558,8 +549,7 @@ def f(n):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7, r8 :: bool
+    r4, r5, r6, r7, r8 :: bit
     r9, r10, r11, r12, r13 :: int
 L0:
     r1 = n & 1
@@ -618,13 +608,11 @@ def f(n):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7 :: bool
+    r4, r5, r6, r7 :: bit
     x :: int
     r8 :: bool
     r9 :: int64
-    r10, r11 :: bit
-    r12 :: bool
+    r10, r11, r12 :: bit
 L0:
     r1 = n & 1
     r2 = r1 == 0
@@ -684,8 +672,7 @@ def f(n):
     n :: int
     r0 :: bool
     r1 :: int64
-    r2, r3 :: bit
-    r4 :: bool
+    r2, r3, r4 :: bit
     r5 :: int
 L0:
     r1 = n & 1
@@ -1222,8 +1209,7 @@ def absolute_value(x):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7 :: bool
+    r4, r5, r6, r7 :: bit
     r8, r9 :: int
 L0:
     r1 = x & 1
@@ -1397,8 +1383,7 @@ def num(x):
     x :: int
     r0 :: bool
     r1 :: int64
-    r2, r3 :: bit
-    r4, r5 :: bool
+    r2, r3, r4, r5 :: bit
 L0:
     r1 = x & 1
     r2 = r1 == 0
@@ -1468,8 +1453,7 @@ def opt_int(x):
     r2 :: int
     r3 :: bool
     r4 :: int64
-    r5, r6 :: bit
-    r7, r8 :: bool
+    r5, r6, r7, r8 :: bit
 L0:
     r0 = load_address _Py_NoneStruct
     r1 = x != r0
@@ -2033,11 +2017,10 @@ def f():
     x, r15 :: int
     r16 :: bool
     r17 :: int64
-    r18, r19 :: bit
-    r20, r21, r22 :: bool
+    r18, r19, r20, r21 :: bit
+    r22 :: bool
     r23 :: int64
-    r24, r25 :: bit
-    r26, r27 :: bool
+    r24, r25, r26, r27 :: bit
     r28 :: int
     r29 :: object
     r30 :: int32
@@ -2129,11 +2112,10 @@ def f():
     x, r15 :: int
     r16 :: bool
     r17 :: int64
-    r18, r19 :: bit
-    r20, r21, r22 :: bool
+    r18, r19, r20, r21 :: bit
+    r22 :: bool
     r23 :: int64
-    r24, r25 :: bit
-    r26, r27 :: bool
+    r24, r25, r26, r27 :: bit
     r28 :: int
     r29, r30 :: object
     r31 :: int32
@@ -2814,15 +2796,13 @@ def f(x, y, z):
     r4 :: int64
     r5 :: bit
     r6 :: int64
-    r7, r8, r9 :: bit
-    r10 :: bool
+    r7, r8, r9, r10 :: bit
     r11 :: int
     r12 :: bool
     r13 :: int64
     r14 :: bit
     r15 :: int64
-    r16, r17, r18 :: bit
-    r19 :: bool
+    r16, r17, r18, r19 :: bit
 L0:
     r0 = g(x)
     r1 = g(y)
@@ -3303,9 +3283,7 @@ def call_any(l):
     r3, i :: int
     r4 :: bool
     r5 :: int64
-    r6, r7 :: bit
-    r8 :: bool
-    r9 :: bit
+    r6, r7, r8, r9 :: bit
 L0:
     r0 = 0
     r1 = PyObject_GetIter(l)
@@ -3345,8 +3323,8 @@ def call_all(l):
     r3, i :: int
     r4 :: bool
     r5 :: int64
-    r6, r7 :: bit
-    r8, r9 :: bool
+    r6, r7, r8 :: bit
+    r9 :: bool
     r10 :: bit
 L0:
     r0 = 1

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -115,7 +115,7 @@ def Node.length(self):
     self :: __main__.Node
     r0 :: union[__main__.Node, None]
     r1 :: object
-    r2, r3 :: bool
+    r2, r3 :: bit
     r4 :: union[__main__.Node, None]
     r5 :: __main__.Node
     r6, r7 :: int
@@ -287,10 +287,10 @@ class D(C, S, Generic[T]):
 [out]
 def __top_level__():
     r0, r1 :: object
-    r2 :: bool
+    r2 :: bit
     r3 :: str
     r4, r5, r6 :: object
-    r7 :: bool
+    r7 :: bit
     r8 :: str
     r9, r10 :: object
     r11 :: dict
@@ -298,62 +298,72 @@ def __top_level__():
     r13 :: object
     r14 :: str
     r15 :: int32
-    r16 :: str
-    r17 :: object
-    r18 :: str
-    r19 :: int32
-    r20, r21 :: object
-    r22 :: bool
-    r23 :: str
-    r24, r25 :: object
-    r26 :: dict
-    r27 :: str
-    r28 :: object
+    r16 :: bit
+    r17 :: str
+    r18 :: object
+    r19 :: str
+    r20 :: int32
+    r21 :: bit
+    r22, r23 :: object
+    r24 :: bit
+    r25 :: str
+    r26, r27 :: object
+    r28 :: dict
     r29 :: str
-    r30 :: int32
+    r30 :: object
     r31 :: str
-    r32 :: dict
-    r33 :: str
-    r34, r35 :: object
-    r36 :: dict
-    r37 :: str
-    r38 :: int32
-    r39 :: object
+    r32 :: int32
+    r33 :: bit
+    r34 :: str
+    r35 :: dict
+    r36 :: str
+    r37, r38 :: object
+    r39 :: dict
     r40 :: str
-    r41, r42 :: object
-    r43 :: bool
+    r41 :: int32
+    r42 :: bit
+    r43 :: object
     r44 :: str
-    r45 :: tuple
-    r46 :: int32
-    r47 :: dict
+    r45, r46 :: object
+    r47 :: bool
     r48 :: str
-    r49 :: int32
-    r50 :: object
-    r51 :: str
-    r52, r53 :: object
-    r54 :: str
-    r55 :: tuple
-    r56 :: int32
-    r57 :: dict
-    r58 :: str
-    r59 :: int32
-    r60, r61 :: object
-    r62 :: dict
-    r63 :: str
-    r64 :: object
-    r65 :: dict
-    r66 :: str
-    r67, r68 :: object
-    r69 :: tuple
-    r70 :: str
-    r71, r72 :: object
-    r73 :: bool
-    r74, r75 :: str
-    r76 :: tuple
-    r77 :: int32
-    r78 :: dict
-    r79 :: str
-    r80 :: int32
+    r49 :: tuple
+    r50 :: int32
+    r51 :: bit
+    r52 :: dict
+    r53 :: str
+    r54 :: int32
+    r55 :: bit
+    r56 :: object
+    r57 :: str
+    r58, r59 :: object
+    r60 :: str
+    r61 :: tuple
+    r62 :: int32
+    r63 :: bit
+    r64 :: dict
+    r65 :: str
+    r66 :: int32
+    r67 :: bit
+    r68, r69 :: object
+    r70 :: dict
+    r71 :: str
+    r72 :: object
+    r73 :: dict
+    r74 :: str
+    r75, r76 :: object
+    r77 :: tuple
+    r78 :: str
+    r79, r80 :: object
+    r81 :: bool
+    r82, r83 :: str
+    r84 :: tuple
+    r85 :: int32
+    r86 :: bit
+    r87 :: dict
+    r88 :: str
+    r89 :: int32
+    r90 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -379,78 +389,88 @@ L4:
     r13 = CPyObject_GetAttr(r10, r12)
     r14 = load_global CPyStatic_unicode_2 :: static  ('TypeVar')
     r15 = CPyDict_SetItem(r11, r14, r13)
-    r16 = load_global CPyStatic_unicode_3 :: static  ('Generic')
-    r17 = CPyObject_GetAttr(r10, r16)
-    r18 = load_global CPyStatic_unicode_3 :: static  ('Generic')
-    r19 = CPyDict_SetItem(r11, r18, r17)
-    r20 = mypy_extensions :: module
-    r21 = load_address _Py_NoneStruct
-    r22 = r20 != r21
-    if r22 goto L6 else goto L5 :: bool
+    r16 = r15 >= 0 :: signed
+    r17 = load_global CPyStatic_unicode_3 :: static  ('Generic')
+    r18 = CPyObject_GetAttr(r10, r17)
+    r19 = load_global CPyStatic_unicode_3 :: static  ('Generic')
+    r20 = CPyDict_SetItem(r11, r19, r18)
+    r21 = r20 >= 0 :: signed
+    r22 = mypy_extensions :: module
+    r23 = load_address _Py_NoneStruct
+    r24 = r22 != r23
+    if r24 goto L6 else goto L5 :: bool
 L5:
-    r23 = load_global CPyStatic_unicode_4 :: static  ('mypy_extensions')
-    r24 = PyImport_Import(r23)
-    mypy_extensions = r24 :: module
+    r25 = load_global CPyStatic_unicode_4 :: static  ('mypy_extensions')
+    r26 = PyImport_Import(r25)
+    mypy_extensions = r26 :: module
 L6:
-    r25 = mypy_extensions :: module
-    r26 = __main__.globals :: static
-    r27 = load_global CPyStatic_unicode_5 :: static  ('trait')
-    r28 = CPyObject_GetAttr(r25, r27)
+    r27 = mypy_extensions :: module
+    r28 = __main__.globals :: static
     r29 = load_global CPyStatic_unicode_5 :: static  ('trait')
-    r30 = CPyDict_SetItem(r26, r29, r28)
-    r31 = load_global CPyStatic_unicode_6 :: static  ('T')
-    r32 = __main__.globals :: static
-    r33 = load_global CPyStatic_unicode_2 :: static  ('TypeVar')
-    r34 = CPyDict_GetItem(r32, r33)
-    r35 = PyObject_CallFunctionObjArgs(r34, r31, 0)
-    r36 = __main__.globals :: static
-    r37 = load_global CPyStatic_unicode_6 :: static  ('T')
-    r38 = CPyDict_SetItem(r36, r37, r35)
-    r39 = <error> :: object
-    r40 = load_global CPyStatic_unicode_7 :: static  ('__main__')
-    r41 = __main__.C_template :: type
-    r42 = CPyType_FromTemplate(r41, r39, r40)
-    r43 = C_trait_vtable_setup()
-    r44 = load_global CPyStatic_unicode_8 :: static  ('__mypyc_attrs__')
-    r45 = PyTuple_Pack(0)
-    r46 = PyObject_SetAttr(r42, r44, r45)
-    __main__.C = r42 :: type
-    r47 = __main__.globals :: static
-    r48 = load_global CPyStatic_unicode_9 :: static  ('C')
-    r49 = CPyDict_SetItem(r47, r48, r42)
-    r50 = <error> :: object
-    r51 = load_global CPyStatic_unicode_7 :: static  ('__main__')
-    r52 = __main__.S_template :: type
-    r53 = CPyType_FromTemplate(r52, r50, r51)
-    r54 = load_global CPyStatic_unicode_8 :: static  ('__mypyc_attrs__')
-    r55 = PyTuple_Pack(0)
-    r56 = PyObject_SetAttr(r53, r54, r55)
-    __main__.S = r53 :: type
-    r57 = __main__.globals :: static
-    r58 = load_global CPyStatic_unicode_10 :: static  ('S')
-    r59 = CPyDict_SetItem(r57, r58, r53)
-    r60 = __main__.C :: type
-    r61 = __main__.S :: type
-    r62 = __main__.globals :: static
-    r63 = load_global CPyStatic_unicode_3 :: static  ('Generic')
-    r64 = CPyDict_GetItem(r62, r63)
-    r65 = __main__.globals :: static
-    r66 = load_global CPyStatic_unicode_6 :: static  ('T')
-    r67 = CPyDict_GetItem(r65, r66)
-    r68 = PyObject_GetItem(r64, r67)
-    r69 = PyTuple_Pack(3, r60, r61, r68)
-    r70 = load_global CPyStatic_unicode_7 :: static  ('__main__')
-    r71 = __main__.D_template :: type
-    r72 = CPyType_FromTemplate(r71, r69, r70)
-    r73 = D_trait_vtable_setup()
-    r74 = load_global CPyStatic_unicode_8 :: static  ('__mypyc_attrs__')
-    r75 = load_global CPyStatic_unicode_11 :: static  ('__dict__')
-    r76 = PyTuple_Pack(1, r75)
-    r77 = PyObject_SetAttr(r72, r74, r76)
-    __main__.D = r72 :: type
-    r78 = __main__.globals :: static
-    r79 = load_global CPyStatic_unicode_12 :: static  ('D')
-    r80 = CPyDict_SetItem(r78, r79, r72)
+    r30 = CPyObject_GetAttr(r27, r29)
+    r31 = load_global CPyStatic_unicode_5 :: static  ('trait')
+    r32 = CPyDict_SetItem(r28, r31, r30)
+    r33 = r32 >= 0 :: signed
+    r34 = load_global CPyStatic_unicode_6 :: static  ('T')
+    r35 = __main__.globals :: static
+    r36 = load_global CPyStatic_unicode_2 :: static  ('TypeVar')
+    r37 = CPyDict_GetItem(r35, r36)
+    r38 = PyObject_CallFunctionObjArgs(r37, r34, 0)
+    r39 = __main__.globals :: static
+    r40 = load_global CPyStatic_unicode_6 :: static  ('T')
+    r41 = CPyDict_SetItem(r39, r40, r38)
+    r42 = r41 >= 0 :: signed
+    r43 = <error> :: object
+    r44 = load_global CPyStatic_unicode_7 :: static  ('__main__')
+    r45 = __main__.C_template :: type
+    r46 = CPyType_FromTemplate(r45, r43, r44)
+    r47 = C_trait_vtable_setup()
+    r48 = load_global CPyStatic_unicode_8 :: static  ('__mypyc_attrs__')
+    r49 = PyTuple_Pack(0)
+    r50 = PyObject_SetAttr(r46, r48, r49)
+    r51 = r50 >= 0 :: signed
+    __main__.C = r46 :: type
+    r52 = __main__.globals :: static
+    r53 = load_global CPyStatic_unicode_9 :: static  ('C')
+    r54 = CPyDict_SetItem(r52, r53, r46)
+    r55 = r54 >= 0 :: signed
+    r56 = <error> :: object
+    r57 = load_global CPyStatic_unicode_7 :: static  ('__main__')
+    r58 = __main__.S_template :: type
+    r59 = CPyType_FromTemplate(r58, r56, r57)
+    r60 = load_global CPyStatic_unicode_8 :: static  ('__mypyc_attrs__')
+    r61 = PyTuple_Pack(0)
+    r62 = PyObject_SetAttr(r59, r60, r61)
+    r63 = r62 >= 0 :: signed
+    __main__.S = r59 :: type
+    r64 = __main__.globals :: static
+    r65 = load_global CPyStatic_unicode_10 :: static  ('S')
+    r66 = CPyDict_SetItem(r64, r65, r59)
+    r67 = r66 >= 0 :: signed
+    r68 = __main__.C :: type
+    r69 = __main__.S :: type
+    r70 = __main__.globals :: static
+    r71 = load_global CPyStatic_unicode_3 :: static  ('Generic')
+    r72 = CPyDict_GetItem(r70, r71)
+    r73 = __main__.globals :: static
+    r74 = load_global CPyStatic_unicode_6 :: static  ('T')
+    r75 = CPyDict_GetItem(r73, r74)
+    r76 = PyObject_GetItem(r72, r75)
+    r77 = PyTuple_Pack(3, r68, r69, r76)
+    r78 = load_global CPyStatic_unicode_7 :: static  ('__main__')
+    r79 = __main__.D_template :: type
+    r80 = CPyType_FromTemplate(r79, r77, r78)
+    r81 = D_trait_vtable_setup()
+    r82 = load_global CPyStatic_unicode_8 :: static  ('__mypyc_attrs__')
+    r83 = load_global CPyStatic_unicode_11 :: static  ('__dict__')
+    r84 = PyTuple_Pack(1, r83)
+    r85 = PyObject_SetAttr(r80, r82, r84)
+    r86 = r85 >= 0 :: signed
+    __main__.D = r80 :: type
+    r87 = __main__.globals :: static
+    r88 = load_global CPyStatic_unicode_12 :: static  ('D')
+    r89 = CPyDict_SetItem(r87, r88, r80)
+    r90 = r89 >= 0 :: signed
     return 1
 
 [case testIsInstance]
@@ -467,7 +487,7 @@ def f(x):
     r0 :: object
     r1 :: ptr
     r2 :: object
-    r3 :: bool
+    r3 :: bit
     r4, r5 :: __main__.B
 L0:
     r0 = __main__.B :: type
@@ -499,11 +519,12 @@ def f(x):
     r0 :: object
     r1 :: ptr
     r2 :: object
-    r3, r4 :: bool
+    r3 :: bit
+    r4 :: bool
     r5 :: object
     r6 :: ptr
     r7 :: object
-    r8 :: bool
+    r8 :: bit
     r9 :: union[__main__.A, __main__.B]
     r10 :: __main__.A
 L0:
@@ -543,11 +564,12 @@ def f(x):
     x, r0 :: object
     r1 :: ptr
     r2 :: object
-    r3, r4 :: bool
+    r3 :: bit
+    r4 :: bool
     r5 :: object
     r6 :: ptr
     r7 :: object
-    r8 :: bool
+    r8 :: bit
     r9 :: __main__.R
     r10 :: __main__.A
 L0:
@@ -591,11 +613,12 @@ def f(x):
     x, r0 :: object
     r1 :: ptr
     r2 :: object
-    r3, r4 :: bool
+    r3 :: bit
+    r4 :: bool
     r5 :: object
     r6 :: ptr
     r7 :: object
-    r8 :: bool
+    r8 :: bit
     r9 :: __main__.R
     r10 :: __main__.A
 L0:
@@ -787,13 +810,13 @@ def f2(a: A, b: A) -> bool:
 [out]
 def f(a, b):
     a, b :: __main__.A
-    r0 :: bool
+    r0 :: bit
 L0:
     r0 = a == b
     return r0
 def f2(a, b):
     a, b :: __main__.A
-    r0 :: bool
+    r0 :: bit
 L0:
     r0 = a != b
     return r0
@@ -828,10 +851,11 @@ L0:
 def Base.__ne__(self, rhs):
     self :: __main__.Base
     rhs, r0, r1 :: object
-    r2 :: bool
+    r2 :: bit
     r3 :: int32
-    r4 :: bool
-    r5 :: object
+    r4 :: bit
+    r5 :: bool
+    r6 :: object
 L0:
     r0 = self.__eq__(rhs)
     r1 = load_address _Py_NotImplementedStruct
@@ -839,9 +863,10 @@ L0:
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = PyObject_Not(r0)
-    r4 = truncate r3: int32 to builtins.bool
-    r5 = box(bool, r4)
-    return r5
+    r4 = r3 >= 0 :: signed
+    r5 = truncate r3: int32 to builtins.bool
+    r6 = box(bool, r5)
+    return r6
 L2:
     return r1
 def Derived.__eq__(self, other):
@@ -946,10 +971,11 @@ L0:
 def Derived.__ne__(self, rhs):
     self :: __main__.Derived
     rhs, r0, r1 :: object
-    r2 :: bool
+    r2 :: bit
     r3 :: int32
-    r4 :: bool
-    r5 :: object
+    r4 :: bit
+    r5 :: bool
+    r6 :: object
 L0:
     r0 = self.__eq__(rhs)
     r1 = load_address _Py_NotImplementedStruct
@@ -957,9 +983,10 @@ L0:
     if r2 goto L2 else goto L1 :: bool
 L1:
     r3 = PyObject_Not(r0)
-    r4 = truncate r3: int32 to builtins.bool
-    r5 = box(bool, r4)
-    return r5
+    r4 = r3 >= 0 :: signed
+    r5 = truncate r3: int32 to builtins.bool
+    r6 = box(bool, r5)
+    return r6
 L2:
     return r1
 
@@ -1022,8 +1049,10 @@ def foo(x: WelpDict) -> None:
 def foo(x):
     x :: dict
     r0 :: int32
+    r1 :: bit
 L0:
     r0 = CPyDict_Update(x, x)
+    r1 = r0 >= 0 :: signed
     return 1
 
 [case testNoSpuriousLinearity]

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -138,7 +138,7 @@ def increment(d: Dict[str, int]) -> Dict[str, int]:
 def increment(d):
     d :: dict
     r0 :: short_int
-    r1 :: int64
+    r1 :: native_int
     r2 :: short_int
     r3 :: object
     r4 :: tuple[bool, int, object]
@@ -216,7 +216,7 @@ def print_dict_methods(d1: Dict[int, int], d2: Dict[int, int]) -> None:
 def print_dict_methods(d1, d2):
     d1, d2 :: dict
     r0 :: short_int
-    r1 :: int64
+    r1 :: native_int
     r2 :: short_int
     r3 :: object
     r4 :: tuple[bool, int, object]
@@ -230,7 +230,7 @@ def print_dict_methods(d1, d2):
     r12 :: bool
     r13, r14 :: bit
     r15 :: short_int
-    r16 :: int64
+    r16 :: native_int
     r17 :: short_int
     r18 :: object
     r19 :: tuple[bool, int, object, object]

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -22,10 +22,12 @@ def f(d):
     d :: dict
     r0, r1 :: object
     r2 :: int32
+    r3 :: bit
 L0:
     r0 = box(short_int, 0)
     r1 = box(bool, 0)
     r2 = CPyDict_SetItem(d, r0, r1)
+    r3 = r2 >= 0 :: signed
     return 1
 
 [case testNewEmptyDict]
@@ -69,12 +71,14 @@ def f(d):
     d :: dict
     r0 :: object
     r1 :: int32
-    r2 :: bool
+    r2 :: bit
+    r3 :: bool
 L0:
     r0 = box(short_int, 8)
     r1 = PyDict_Contains(d, r0)
-    r2 = truncate r1: int32 to builtins.bool
-    if r2 goto L1 else goto L2 :: bool
+    r2 = r1 >= 0 :: signed
+    r3 = truncate r1: int32 to builtins.bool
+    if r3 goto L1 else goto L2 :: bool
 L1:
     return 1
 L2:
@@ -94,13 +98,15 @@ def f(d):
     d :: dict
     r0 :: object
     r1 :: int32
-    r2, r3 :: bool
+    r2 :: bit
+    r3, r4 :: bool
 L0:
     r0 = box(short_int, 8)
     r1 = PyDict_Contains(d, r0)
-    r2 = truncate r1: int32 to builtins.bool
-    r3 = r2 ^ 1
-    if r3 goto L1 else goto L2 :: bool
+    r2 = r1 >= 0 :: signed
+    r3 = truncate r1: int32 to builtins.bool
+    r4 = r3 ^ 1
+    if r4 goto L1 else goto L2 :: bool
 L1:
     return 1
 L2:
@@ -116,8 +122,10 @@ def f(a: Dict[int, int], b: Dict[int, int]) -> None:
 def f(a, b):
     a, b :: dict
     r0 :: int32
+    r1 :: bit
 L0:
     r0 = CPyDict_Update(a, b)
+    r1 = r0 >= 0 :: signed
     return 1
 
 [case testDictKeyLvalue]
@@ -130,7 +138,7 @@ def increment(d: Dict[str, int]) -> Dict[str, int]:
 def increment(d):
     d :: dict
     r0 :: short_int
-    r1 :: native_int
+    r1 :: int64
     r2 :: short_int
     r3 :: object
     r4 :: tuple[bool, int, object]
@@ -140,7 +148,7 @@ def increment(d):
     k, r8 :: str
     r9, r10, r11 :: object
     r12 :: int32
-    r13, r14 :: bool
+    r13, r14, r15 :: bit
 L0:
     r0 = 0
     r1 = PyDict_Size(d)
@@ -160,11 +168,12 @@ L2:
     r10 = box(short_int, 2)
     r11 = PyNumber_InPlaceAdd(r9, r10)
     r12 = CPyDict_SetItem(d, k, r11)
+    r13 = r12 >= 0 :: signed
 L3:
-    r13 = CPyDict_CheckSize(d, r2)
+    r14 = CPyDict_CheckSize(d, r2)
     goto L1
 L4:
-    r14 = CPy_NoErrOccured()
+    r15 = CPy_NoErrOccured()
 L5:
     return d
 
@@ -180,15 +189,19 @@ def f(x, y):
     r1 :: object
     r2 :: dict
     r3 :: int32
-    r4 :: object
-    r5 :: int32
+    r4 :: bit
+    r5 :: object
+    r6 :: int32
+    r7 :: bit
 L0:
     r0 = load_global CPyStatic_unicode_3 :: static  ('z')
     r1 = box(short_int, 4)
     r2 = CPyDict_Build(1, x, r1)
     r3 = CPyDict_UpdateInDisplay(r2, y)
-    r4 = box(short_int, 6)
-    r5 = CPyDict_SetItem(r2, r0, r4)
+    r4 = r3 >= 0 :: signed
+    r5 = box(short_int, 6)
+    r6 = CPyDict_SetItem(r2, r0, r5)
+    r7 = r6 >= 0 :: signed
     return r2
 
 [case testDictIterationMethods]
@@ -203,7 +216,7 @@ def print_dict_methods(d1: Dict[int, int], d2: Dict[int, int]) -> None:
 def print_dict_methods(d1, d2):
     d1, d2 :: dict
     r0 :: short_int
-    r1 :: native_int
+    r1 :: int64
     r2 :: short_int
     r3 :: object
     r4 :: tuple[bool, int, object]
@@ -213,19 +226,21 @@ def print_dict_methods(d1, d2):
     v, r8 :: int
     r9 :: object
     r10 :: int32
-    r11, r12, r13 :: bool
-    r14 :: short_int
-    r15 :: native_int
-    r16 :: short_int
-    r17 :: object
-    r18 :: tuple[bool, int, object, object]
-    r19 :: int
-    r20 :: bool
-    r21, r22 :: object
-    r23, r24, k :: int
-    r25, r26, r27, r28, r29 :: object
-    r30 :: int32
-    r31, r32 :: bool
+    r11 :: bit
+    r12 :: bool
+    r13, r14 :: bit
+    r15 :: short_int
+    r16 :: int64
+    r17 :: short_int
+    r18 :: object
+    r19 :: tuple[bool, int, object, object]
+    r20 :: int
+    r21 :: bool
+    r22, r23 :: object
+    r24, r25, k :: int
+    r26, r27, r28, r29, r30 :: object
+    r31 :: int32
+    r32, r33, r34 :: bit
 L0:
     r0 = 0
     r1 = PyDict_Size(d1)
@@ -243,45 +258,47 @@ L2:
     v = r8
     r9 = box(int, v)
     r10 = PyDict_Contains(d2, r9)
-    r11 = truncate r10: int32 to builtins.bool
-    if r11 goto L3 else goto L4 :: bool
+    r11 = r10 >= 0 :: signed
+    r12 = truncate r10: int32 to builtins.bool
+    if r12 goto L3 else goto L4 :: bool
 L3:
     return 1
 L4:
 L5:
-    r12 = CPyDict_CheckSize(d1, r2)
+    r13 = CPyDict_CheckSize(d1, r2)
     goto L1
 L6:
-    r13 = CPy_NoErrOccured()
+    r14 = CPy_NoErrOccured()
 L7:
-    r14 = 0
-    r15 = PyDict_Size(d2)
-    r16 = r15 << 1
-    r17 = CPyDict_GetItemsIter(d2)
+    r15 = 0
+    r16 = PyDict_Size(d2)
+    r17 = r16 << 1
+    r18 = CPyDict_GetItemsIter(d2)
 L8:
-    r18 = CPyDict_NextItem(r17, r14)
-    r19 = r18[1]
-    r14 = r19
-    r20 = r18[0]
-    if r20 goto L9 else goto L11 :: bool
+    r19 = CPyDict_NextItem(r18, r15)
+    r20 = r19[1]
+    r15 = r20
+    r21 = r19[0]
+    if r21 goto L9 else goto L11 :: bool
 L9:
-    r21 = r18[2]
-    r22 = r18[3]
-    r23 = unbox(int, r21)
+    r22 = r19[2]
+    r23 = r19[3]
     r24 = unbox(int, r22)
-    k = r23
-    v = r24
-    r25 = box(int, k)
-    r26 = CPyDict_GetItem(d2, r25)
-    r27 = box(int, v)
-    r28 = PyNumber_InPlaceAdd(r26, r27)
-    r29 = box(int, k)
-    r30 = CPyDict_SetItem(d2, r29, r28)
+    r25 = unbox(int, r23)
+    k = r24
+    v = r25
+    r26 = box(int, k)
+    r27 = CPyDict_GetItem(d2, r26)
+    r28 = box(int, v)
+    r29 = PyNumber_InPlaceAdd(r27, r28)
+    r30 = box(int, k)
+    r31 = CPyDict_SetItem(d2, r30, r29)
+    r32 = r31 >= 0 :: signed
 L10:
-    r31 = CPyDict_CheckSize(d2, r16)
+    r33 = CPyDict_CheckSize(d2, r17)
     goto L8
 L11:
-    r32 = CPy_NoErrOccured()
+    r34 = CPy_NoErrOccured()
 L12:
     return 1
 

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -5,7 +5,7 @@ def f(x: int, y: int) -> bool:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2, r3, r4, r5 :: bit
 L0:
     r1 = x & 1

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -5,8 +5,9 @@ def f(x: int, y: int) -> bool:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: native_int
-    r2, r3, r4, r5 :: bool
+    r1 :: int64
+    r2, r3 :: bit
+    r4, r5 :: bool
 L0:
     r1 = x & 1
     r2 = r1 == 0

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -6,8 +6,7 @@ def f(x, y):
     x, y :: int
     r0 :: bool
     r1 :: int64
-    r2, r3 :: bit
-    r4, r5 :: bool
+    r2, r3, r4, r5 :: bit
 L0:
     r1 = x & 1
     r2 = r1 == 0

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -52,7 +52,7 @@ def f(x: List[int]) -> None:
 def f(x):
     x :: list
     r0 :: object
-    r1 :: bool
+    r1 :: bit
 L0:
     r0 = box(short_int, 2)
     r1 = CPyList_SetItem(x, 0, r0)
@@ -141,9 +141,11 @@ def f(a, x):
     x :: int
     r0 :: object
     r1 :: int32
+    r2 :: bit
 L0:
     r0 = box(int, x)
     r1 = PyList_Append(a, r0)
+    r2 = r1 >= 0 :: signed
     return 1
 
 [case testIndexLvalue]
@@ -156,16 +158,16 @@ def increment(l: List[int]) -> List[int]:
 def increment(l):
     l :: list
     r0 :: ptr
-    r1 :: native_int
+    r1 :: int64
     r2, r3 :: short_int
     i :: int
-    r4 :: bool
+    r4 :: bit
     r5, r6, r7 :: object
-    r8 :: bool
+    r8 :: bit
     r9 :: short_int
 L0:
     r0 = get_element_ptr l ob_size :: PyVarObject
-    r1 = load_mem r0, l :: native_int*
+    r1 = load_mem r0, l :: int64*
     r2 = r1 << 1
     r3 = 0
     i = r3
@@ -196,6 +198,7 @@ def f(x, y):
     r3, r4, r5 :: ptr
     r6, r7, r8 :: object
     r9 :: int32
+    r10 :: bit
 L0:
     r0 = PyList_New(2)
     r1 = box(short_int, 2)
@@ -203,12 +206,13 @@ L0:
     r3 = get_element_ptr r0 ob_item :: PyListObject
     r4 = load_mem r3, r0 :: ptr*
     set_mem r4, r1, r0 :: builtins.object*
-    r5 = r4 + WORD_SIZE*1
+    r5 = r4 + 8
     set_mem r5, r2, r0 :: builtins.object*
     r6 = CPyList_Extend(r0, x)
     r7 = CPyList_Extend(r0, y)
     r8 = box(short_int, 6)
     r9 = PyList_Append(r0, r8)
+    r10 = r9 >= 0 :: signed
     return r0
 
 [case testListIn]
@@ -221,9 +225,12 @@ def f(x, y):
     y :: int
     r0 :: object
     r1 :: int32
-    r2 :: bool
+    r2 :: bit
+    r3 :: bool
 L0:
     r0 = box(int, y)
     r1 = PySequence_Contains(x, r0)
-    r2 = truncate r1: int32 to builtins.bool
-    return r2
+    r2 = r1 >= 0 :: signed
+    r3 = truncate r1: int32 to builtins.bool
+    return r3
+

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -158,7 +158,7 @@ def increment(l: List[int]) -> List[int]:
 def increment(l):
     l :: list
     r0 :: ptr
-    r1 :: int64
+    r1 :: native_int
     r2, r3 :: short_int
     i :: int
     r4 :: bit
@@ -167,7 +167,7 @@ def increment(l):
     r9 :: short_int
 L0:
     r0 = get_element_ptr l ob_size :: PyVarObject
-    r1 = load_mem r0, l :: int64*
+    r1 = load_mem r0, l :: native_int*
     r2 = r1 << 1
     r3 = 0
     i = r3

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -206,7 +206,7 @@ L0:
     r3 = get_element_ptr r0 ob_item :: PyListObject
     r4 = load_mem r3, r0 :: ptr*
     set_mem r4, r1, r0 :: builtins.object*
-    r5 = r4 + 8
+    r5 = r4 + WORD_SIZE*1
     set_mem r5, r2, r0 :: builtins.object*
     r6 = CPyList_Extend(r0, x)
     r7 = CPyList_Extend(r0, y)
@@ -233,4 +233,3 @@ L0:
     r2 = r1 >= 0 :: signed
     r3 = truncate r1: int32 to builtins.bool
     return r3
-

--- a/mypyc/test-data/irbuild-nested.test
+++ b/mypyc/test-data/irbuild-nested.test
@@ -706,7 +706,7 @@ def baz_f_obj.__call__(__mypyc_self__, n):
     r0 :: __main__.f_env
     r1, baz :: object
     r2 :: bool
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6 :: bit
     r7 :: int
     r8, r9 :: object
@@ -860,7 +860,7 @@ def baz(n: int) -> int:
 def baz(n):
     n :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2, r3, r4 :: bit
     r5, r6, r7 :: int
 L0:

--- a/mypyc/test-data/irbuild-nested.test
+++ b/mypyc/test-data/irbuild-nested.test
@@ -36,7 +36,7 @@ def second() -> str:
 [out]
 def inner_a_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -71,7 +71,7 @@ L0:
     return r4
 def second_b_first_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -97,7 +97,7 @@ L0:
     return r3
 def first_b_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -142,7 +142,7 @@ L0:
     return r4
 def inner_c_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -181,7 +181,7 @@ L0:
     return r4
 def inner_d_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -276,7 +276,7 @@ def c(flag: bool) -> str:
 [out]
 def inner_a_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -318,7 +318,7 @@ L0:
     return r7
 def inner_b_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -364,7 +364,7 @@ L0:
     return r9
 def inner_c_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -388,7 +388,7 @@ L0:
     return r2
 def inner_c_obj_0.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -450,7 +450,7 @@ def a() -> int:
 [out]
 def c_a_b_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -476,7 +476,7 @@ L0:
     return r3
 def b_a_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -545,7 +545,7 @@ def f(flag: bool) -> str:
 [out]
 def inner_f_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -569,7 +569,7 @@ L0:
     return r2
 def inner_f_obj_0.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -638,7 +638,7 @@ def f(a: int) -> int:
 [out]
 def foo_f_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -663,7 +663,7 @@ L0:
     return r3
 def bar_f_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -689,7 +689,7 @@ L0:
     return r4
 def baz_f_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -706,8 +706,9 @@ def baz_f_obj.__call__(__mypyc_self__, n):
     r0 :: __main__.f_env
     r1, baz :: object
     r2 :: bool
-    r3 :: native_int
-    r4, r5, r6 :: bool
+    r3 :: int64
+    r4, r5 :: bit
+    r6 :: bool
     r7 :: int
     r8, r9 :: object
     r10, r11 :: int
@@ -782,7 +783,7 @@ def f(x: int, y: int) -> None:
 [out]
 def __mypyc_lambda__0_f_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -804,7 +805,7 @@ L0:
     return r1
 def __mypyc_lambda__1_f_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
 L0:
     r0 = load_address _Py_NoneStruct
@@ -860,8 +861,9 @@ def baz(n: int) -> int:
 def baz(n):
     n :: int
     r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bool
+    r1 :: int64
+    r2, r3 :: bit
+    r4 :: bool
     r5, r6, r7 :: int
 L0:
     r1 = n & 1

--- a/mypyc/test-data/irbuild-nested.test
+++ b/mypyc/test-data/irbuild-nested.test
@@ -707,8 +707,7 @@ def baz_f_obj.__call__(__mypyc_self__, n):
     r1, baz :: object
     r2 :: bool
     r3 :: int64
-    r4, r5 :: bit
-    r6 :: bool
+    r4, r5, r6 :: bit
     r7 :: int
     r8, r9 :: object
     r10, r11 :: int
@@ -862,8 +861,7 @@ def baz(n):
     n :: int
     r0 :: bool
     r1 :: int64
-    r2, r3 :: bit
-    r4 :: bool
+    r2, r3, r4 :: bit
     r5, r6, r7 :: int
 L0:
     r1 = n & 1

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -218,7 +218,7 @@ def f(y):
     x :: union[int, None]
     r0 :: object
     r1 :: bool
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
     r6, r7 :: object
     r8, r9 :: bit

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -34,7 +34,7 @@ def f(x: Optional[A]) -> int:
 def f(x):
     x :: union[__main__.A, None]
     r0 :: object
-    r1, r2 :: bool
+    r1, r2 :: bit
 L0:
     r0 = box(None, 1)
     r1 = x == r0
@@ -543,4 +543,3 @@ L0:
     r0 = r3
 L1:
     return 1
-

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -219,8 +219,7 @@ def f(y):
     r0 :: object
     r1 :: bool
     r2 :: int64
-    r3, r4 :: bit
-    r5 :: bool
+    r3, r4, r5 :: bit
     r6, r7 :: object
     r8, r9 :: bit
     r10 :: int

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -11,7 +11,7 @@ def f(x: Optional[A]) -> int:
 def f(x):
     x :: union[__main__.A, None]
     r0 :: object
-    r1 :: bool
+    r1 :: bit
 L0:
     r0 = box(None, 1)
     r1 = x == r0
@@ -58,7 +58,7 @@ def f(x: Optional[A]) -> int:
 def f(x):
     x :: union[__main__.A, None]
     r0 :: object
-    r1 :: bool
+    r1 :: bit
 L0:
     r0 = load_address _Py_NoneStruct
     r1 = x != r0
@@ -90,10 +90,11 @@ L0:
 def f(x):
     x :: union[__main__.A, None]
     r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: __main__.A
     r3 :: int32
-    r4 :: bool
+    r4 :: bit
+    r5 :: bool
 L0:
     r0 = load_address _Py_NoneStruct
     r1 = x != r0
@@ -101,8 +102,9 @@ L0:
 L1:
     r2 = cast(__main__.A, x)
     r3 = PyObject_IsTrue(r2)
-    r4 = truncate r3: int32 to builtins.bool
-    if r4 goto L2 else goto L3 :: bool
+    r4 = r3 >= 0 :: signed
+    r5 = truncate r3: int32 to builtins.bool
+    if r5 goto L2 else goto L3 :: bool
 L2:
     return 2
 L3:
@@ -160,9 +162,9 @@ def f(x: List[Optional[int]]) -> None:
 def f(x):
     x :: list
     r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: object
-    r3 :: bool
+    r3 :: bit
 L0:
     r0 = box(short_int, 0)
     r1 = CPyList_SetItem(x, 0, r0)
@@ -186,7 +188,7 @@ def f(x):
     x :: union[__main__.A, None]
     r0, y :: __main__.A
     r1 :: object
-    r2, r3 :: bool
+    r2, r3 :: bit
     r4, r5 :: __main__.A
 L0:
     r0 = A()
@@ -216,10 +218,11 @@ def f(y):
     x :: union[int, None]
     r0 :: object
     r1 :: bool
-    r2 :: native_int
-    r3, r4, r5 :: bool
+    r2 :: int64
+    r3, r4 :: bit
+    r5 :: bool
     r6, r7 :: object
-    r8, r9 :: bool
+    r8, r9 :: bit
     r10 :: int
 L0:
     r0 = box(None, 1)
@@ -266,23 +269,25 @@ def f(x):
     x :: union[int, __main__.A]
     r0 :: object
     r1 :: int32
-    r2 :: bool
-    r3, r4 :: int
-    r5 :: __main__.A
-    r6 :: int
+    r2 :: bit
+    r3 :: bool
+    r4, r5 :: int
+    r6 :: __main__.A
+    r7 :: int
 L0:
     r0 = load_address PyLong_Type
     r1 = PyObject_IsInstance(x, r0)
-    r2 = truncate r1: int32 to builtins.bool
-    if r2 goto L1 else goto L2 :: bool
+    r2 = r1 >= 0 :: signed
+    r3 = truncate r1: int32 to builtins.bool
+    if r3 goto L1 else goto L2 :: bool
 L1:
-    r3 = unbox(int, x)
-    r4 = CPyTagged_Add(r3, 2)
-    return r4
+    r4 = unbox(int, x)
+    r5 = CPyTagged_Add(r4, 2)
+    return r5
 L2:
-    r5 = cast(__main__.A, x)
-    r6 = r5.a
-    return r6
+    r6 = cast(__main__.A, x)
+    r7 = r6.a
+    return r7
 L3:
     unreachable
 
@@ -318,7 +323,7 @@ def get(o):
     r0, r1 :: object
     r2 :: ptr
     r3 :: object
-    r4 :: bool
+    r4 :: bit
     r5 :: __main__.A
     r6 :: int
     r7 :: object
@@ -347,9 +352,11 @@ def set(o, s):
     o :: union[__main__.A, __main__.B]
     s, r0 :: str
     r1 :: int32
+    r2 :: bit
 L0:
     r0 = load_global CPyStatic_unicode_5 :: static  ('a')
     r1 = PyObject_SetAttr(o, r0, s)
+    r2 = r1 >= 0 :: signed
     return 1
 
 [case testUnionMethodCall]
@@ -387,13 +394,13 @@ def g(o):
     r0, r1 :: object
     r2 :: ptr
     r3 :: object
-    r4 :: bool
+    r4 :: bit
     r5 :: __main__.A
     r6 :: int
     r7, r8 :: object
     r9 :: ptr
     r10 :: object
-    r11 :: bool
+    r11 :: bit
     r12 :: __main__.B
     r13, r14 :: object
     r15 :: __main__.C
@@ -458,7 +465,7 @@ def f(o):
     r1 :: object
     r2 :: ptr
     r3 :: object
-    r4 :: bool
+    r4 :: bit
     r5 :: __main__.A
     r6 :: int
     r7 :: object
@@ -490,7 +497,7 @@ def g(o):
     r1 :: object
     r2 :: ptr
     r3 :: object
-    r4 :: bool
+    r4 :: bit
     r5 :: __main__.A
     r6 :: int
     r7 :: object

--- a/mypyc/test-data/irbuild-set.test
+++ b/mypyc/test-data/irbuild-set.test
@@ -7,18 +7,24 @@ def f():
     r0 :: set
     r1 :: object
     r2 :: int32
-    r3 :: object
-    r4 :: int32
-    r5 :: object
-    r6 :: int32
+    r3 :: bit
+    r4 :: object
+    r5 :: int32
+    r6 :: bit
+    r7 :: object
+    r8 :: int32
+    r9 :: bit
 L0:
     r0 = PySet_New(0)
     r1 = box(short_int, 2)
     r2 = PySet_Add(r0, r1)
-    r3 = box(short_int, 4)
-    r4 = PySet_Add(r0, r3)
-    r5 = box(short_int, 6)
-    r6 = PySet_Add(r0, r5)
+    r3 = r2 >= 0 :: signed
+    r4 = box(short_int, 4)
+    r5 = PySet_Add(r0, r4)
+    r6 = r5 >= 0 :: signed
+    r7 = box(short_int, 6)
+    r8 = PySet_Add(r0, r7)
+    r9 = r8 >= 0 :: signed
     return r0
 
 [case testNewEmptySet]
@@ -53,25 +59,31 @@ def f():
     r0 :: set
     r1 :: object
     r2 :: int32
-    r3 :: object
-    r4 :: int32
-    r5 :: object
-    r6 :: int32
-    r7 :: ptr
-    r8 :: native_int
-    r9 :: short_int
+    r3 :: bit
+    r4 :: object
+    r5 :: int32
+    r6 :: bit
+    r7 :: object
+    r8 :: int32
+    r9 :: bit
+    r10 :: ptr
+    r11 :: int64
+    r12 :: short_int
 L0:
     r0 = PySet_New(0)
     r1 = box(short_int, 2)
     r2 = PySet_Add(r0, r1)
-    r3 = box(short_int, 4)
-    r4 = PySet_Add(r0, r3)
-    r5 = box(short_int, 6)
-    r6 = PySet_Add(r0, r5)
-    r7 = get_element_ptr r0 used :: PySetObject
-    r8 = load_mem r7, r0 :: native_int*
-    r9 = r8 << 1
-    return r9
+    r3 = r2 >= 0 :: signed
+    r4 = box(short_int, 4)
+    r5 = PySet_Add(r0, r4)
+    r6 = r5 >= 0 :: signed
+    r7 = box(short_int, 6)
+    r8 = PySet_Add(r0, r7)
+    r9 = r8 >= 0 :: signed
+    r10 = get_element_ptr r0 used :: PySetObject
+    r11 = load_mem r10, r0 :: int64*
+    r12 = r11 << 1
+    return r12
 
 [case testSetContains]
 from typing import Set
@@ -83,23 +95,29 @@ def f():
     r0 :: set
     r1 :: object
     r2 :: int32
-    r3 :: object
-    r4 :: int32
+    r3 :: bit
+    r4 :: object
+    r5 :: int32
+    r6 :: bit
     x :: set
-    r5 :: object
-    r6 :: int32
-    r7 :: bool
+    r7 :: object
+    r8 :: int32
+    r9 :: bit
+    r10 :: bool
 L0:
     r0 = PySet_New(0)
     r1 = box(short_int, 6)
     r2 = PySet_Add(r0, r1)
-    r3 = box(short_int, 8)
-    r4 = PySet_Add(r0, r3)
+    r3 = r2 >= 0 :: signed
+    r4 = box(short_int, 8)
+    r5 = PySet_Add(r0, r4)
+    r6 = r5 >= 0 :: signed
     x = r0
-    r5 = box(short_int, 10)
-    r6 = PySet_Contains(x, r5)
-    r7 = truncate r6: int32 to builtins.bool
-    return r7
+    r7 = box(short_int, 10)
+    r8 = PySet_Contains(x, r7)
+    r9 = r8 >= 0 :: signed
+    r10 = truncate r8: int32 to builtins.bool
+    return r10
 
 [case testSetRemove]
 from typing import Set
@@ -111,7 +129,7 @@ def f() -> Set[int]:
 def f():
     r0, x :: set
     r1 :: object
-    r2 :: bool
+    r2 :: bit
 L0:
     r0 = PySet_New(0)
     x = r0
@@ -130,11 +148,13 @@ def f():
     r0, x :: set
     r1 :: object
     r2 :: int32
+    r3 :: bit
 L0:
     r0 = PySet_New(0)
     x = r0
     r1 = box(short_int, 2)
     r2 = PySet_Discard(x, r1)
+    r3 = r2 >= 0 :: signed
     return x
 
 [case testSetAdd]
@@ -148,11 +168,13 @@ def f():
     r0, x :: set
     r1 :: object
     r2 :: int32
+    r3 :: bit
 L0:
     r0 = PySet_New(0)
     x = r0
     r1 = box(short_int, 2)
     r2 = PySet_Add(x, r1)
+    r3 = r2 >= 0 :: signed
     return x
 
 [case testSetClear]
@@ -165,10 +187,12 @@ def f() -> Set[int]:
 def f():
     r0, x :: set
     r1 :: int32
+    r2 :: bit
 L0:
     r0 = PySet_New(0)
     x = r0
     r1 = PySet_Clear(x)
+    r2 = r1 >= 0 :: signed
     return x
 
 [case testSetPop]
@@ -194,8 +218,10 @@ def update(s, x):
     s :: set
     x :: list
     r0 :: int32
+    r1 :: bit
 L0:
     r0 = _PySet_Update(s, x)
+    r1 = r0 >= 0 :: signed
     return 1
 
 [case testSetDisplay]
@@ -207,19 +233,31 @@ def f(x, y):
     x, y, r0 :: set
     r1 :: object
     r2 :: int32
-    r3 :: object
-    r4, r5, r6 :: int32
-    r7 :: object
-    r8 :: int32
+    r3 :: bit
+    r4 :: object
+    r5 :: int32
+    r6 :: bit
+    r7 :: int32
+    r8 :: bit
+    r9 :: int32
+    r10 :: bit
+    r11 :: object
+    r12 :: int32
+    r13 :: bit
 L0:
     r0 = PySet_New(0)
     r1 = box(short_int, 2)
     r2 = PySet_Add(r0, r1)
-    r3 = box(short_int, 4)
-    r4 = PySet_Add(r0, r3)
-    r5 = _PySet_Update(r0, x)
-    r6 = _PySet_Update(r0, y)
-    r7 = box(short_int, 6)
-    r8 = PySet_Add(r0, r7)
+    r3 = r2 >= 0 :: signed
+    r4 = box(short_int, 4)
+    r5 = PySet_Add(r0, r4)
+    r6 = r5 >= 0 :: signed
+    r7 = _PySet_Update(r0, x)
+    r8 = r7 >= 0 :: signed
+    r9 = _PySet_Update(r0, y)
+    r10 = r9 >= 0 :: signed
+    r11 = box(short_int, 6)
+    r12 = PySet_Add(r0, r11)
+    r13 = r12 >= 0 :: signed
     return r0
 

--- a/mypyc/test-data/irbuild-set.test
+++ b/mypyc/test-data/irbuild-set.test
@@ -67,7 +67,7 @@ def f():
     r8 :: int32
     r9 :: bit
     r10 :: ptr
-    r11 :: int64
+    r11 :: native_int
     r12 :: short_int
 L0:
     r0 = PySet_New(0)
@@ -81,7 +81,7 @@ L0:
     r8 = PySet_Add(r0, r7)
     r9 = r8 >= 0 :: signed
     r10 = get_element_ptr r0 used :: PySetObject
-    r11 = load_mem r10, r0 :: int64*
+    r11 = load_mem r10, r0 :: native_int*
     r12 = r11 << 1
     return r12
 

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -66,8 +66,7 @@ def f():
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7 :: bool
+    r4, r5, r6, r7 :: bit
 L0:
     n = 0
 L1:
@@ -130,13 +129,12 @@ def f():
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7, r8 :: bool
+    r4, r5, r6, r7 :: bit
+    r8 :: bool
     r9 :: int64
     r10 :: bit
     r11 :: int64
-    r12, r13, r14 :: bit
-    r15 :: bool
+    r12, r13, r14, r15 :: bit
 L0:
     n = 0
 L1:
@@ -189,8 +187,7 @@ def f():
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7 :: bool
+    r4, r5, r6, r7 :: bit
 L0:
     n = 0
 L1:
@@ -253,13 +250,12 @@ def f():
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7, r8 :: bool
+    r4, r5, r6, r7 :: bit
+    r8 :: bool
     r9 :: int64
     r10 :: bit
     r11 :: int64
-    r12, r13, r14 :: bit
-    r15 :: bool
+    r12, r13, r14, r15 :: bit
 L0:
     n = 0
 L1:
@@ -418,8 +414,7 @@ def sum_over_even_values(d):
     r11, r12 :: int
     r13 :: bool
     r14 :: int64
-    r15, r16 :: bit
-    r17, r18 :: bool
+    r15, r16, r17, r18 :: bit
     r19, r20 :: object
     r21, r22 :: int
     r23, r24 :: bit

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -63,9 +63,9 @@ def f() -> None:
 def f():
     n :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
 L0:
     n = 0
@@ -126,14 +126,14 @@ def f() -> None:
 def f():
     n :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
     r8 :: bool
-    r9 :: int64
+    r9 :: native_int
     r10 :: bit
-    r11 :: int64
+    r11 :: native_int
     r12, r13, r14, r15 :: bit
 L0:
     n = 0
@@ -184,9 +184,9 @@ def f() -> None:
 def f():
     n :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
 L0:
     n = 0
@@ -247,14 +247,14 @@ def f() -> None:
 def f():
     n :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7 :: bit
     r8 :: bool
-    r9 :: int64
+    r9 :: native_int
     r10 :: bit
-    r11 :: int64
+    r11 :: native_int
     r12, r13, r14, r15 :: bit
 L0:
     n = 0
@@ -312,7 +312,7 @@ def f(ls):
     y :: int
     r0 :: short_int
     r1 :: ptr
-    r2 :: int64
+    r2 :: native_int
     r3 :: short_int
     r4 :: bit
     r5 :: object
@@ -323,7 +323,7 @@ L0:
     r0 = 0
 L1:
     r1 = get_element_ptr ls ob_size :: PyVarObject
-    r2 = load_mem r1, ls :: int64*
+    r2 = load_mem r1, ls :: native_int*
     r3 = r2 << 1
     r4 = r0 < r3 :: signed
     if r4 goto L2 else goto L4 :: bool
@@ -350,7 +350,7 @@ def f(d: Dict[int, int]) -> None:
 def f(d):
     d :: dict
     r0 :: short_int
-    r1 :: int64
+    r1 :: native_int
     r2 :: short_int
     r3 :: object
     r4 :: tuple[bool, int, object]
@@ -402,7 +402,7 @@ def sum_over_even_values(d):
     d :: dict
     s :: int
     r0 :: short_int
-    r1 :: int64
+    r1 :: native_int
     r2 :: short_int
     r3 :: object
     r4 :: tuple[bool, int, object]
@@ -413,7 +413,7 @@ def sum_over_even_values(d):
     r9, r10 :: object
     r11, r12 :: int
     r13 :: bool
-    r14 :: int64
+    r14 :: native_int
     r15, r16, r17, r18 :: bit
     r19, r20 :: object
     r21, r22 :: int
@@ -883,7 +883,7 @@ def f(a):
     i :: int
     r1 :: short_int
     r2 :: ptr
-    r3 :: int64
+    r3 :: native_int
     r4 :: short_int
     r5 :: bit
     r6 :: object
@@ -895,7 +895,7 @@ L0:
     r1 = 0
 L1:
     r2 = get_element_ptr a ob_size :: PyVarObject
-    r3 = load_mem r2, a :: int64*
+    r3 = load_mem r2, a :: native_int*
     r4 = r3 << 1
     r5 = r1 < r4 :: signed
     if r5 goto L2 else goto L4 :: bool
@@ -960,7 +960,7 @@ def f(a, b):
     r0 :: short_int
     r1 :: object
     r2 :: ptr
-    r3 :: int64
+    r3 :: native_int
     r4 :: short_int
     r5 :: bit
     r6, r7 :: object
@@ -976,7 +976,7 @@ L0:
     r1 = PyObject_GetIter(b)
 L1:
     r2 = get_element_ptr a ob_size :: PyVarObject
-    r3 = load_mem r2, a :: int64*
+    r3 = load_mem r2, a :: native_int*
     r4 = r3 << 1
     r5 = r0 < r4 :: signed
     if r5 goto L2 else goto L7 :: bool
@@ -1012,7 +1012,7 @@ def g(a, b):
     z :: int
     r3 :: object
     r4 :: ptr
-    r5 :: int64
+    r5 :: native_int
     r6 :: short_int
     r7, r8 :: bit
     r9, x :: bool
@@ -1030,7 +1030,7 @@ L1:
     if is_error(r3) goto L6 else goto L2
 L2:
     r4 = get_element_ptr b ob_size :: PyVarObject
-    r5 = load_mem r4, b :: int64*
+    r5 = load_mem r4, b :: native_int*
     r6 = r5 << 1
     r7 = r1 < r6 :: signed
     if r7 goto L3 else goto L6 :: bool

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -705,7 +705,7 @@ L0:
     r3 = get_element_ptr r0 ob_item :: PyListObject
     r4 = load_mem r3, r0 :: ptr*
     set_mem r4, r1, r0 :: builtins.object*
-    r5 = r4 + 8
+    r5 = r4 + WORD_SIZE*1
     set_mem r5, r2, r0 :: builtins.object*
     l = r0
     r6 = box(short_int, 2)
@@ -738,17 +738,17 @@ L0:
     r8 = get_element_ptr r0 ob_item :: PyListObject
     r9 = load_mem r8, r0 :: ptr*
     set_mem r9, r1, r0 :: builtins.object*
-    r10 = r9 + 8
+    r10 = r9 + WORD_SIZE*1
     set_mem r10, r2, r0 :: builtins.object*
-    r11 = r9 + 16
+    r11 = r9 + WORD_SIZE*2
     set_mem r11, r3, r0 :: builtins.object*
-    r12 = r9 + 24
+    r12 = r9 + WORD_SIZE*3
     set_mem r12, r4, r0 :: builtins.object*
-    r13 = r9 + 32
+    r13 = r9 + WORD_SIZE*4
     set_mem r13, r5, r0 :: builtins.object*
-    r14 = r9 + 40
+    r14 = r9 + WORD_SIZE*5
     set_mem r14, r6, r0 :: builtins.object*
-    r15 = r9 + 48
+    r15 = r9 + WORD_SIZE*6
     set_mem r15, r7, r0 :: builtins.object*
     l = r0
     r16 = box(short_int, 2)
@@ -1055,4 +1055,3 @@ L6:
     r14 = CPy_NoErrOccured()
 L7:
     return 1
-

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -8,7 +8,7 @@ def f():
     x :: int
     r0 :: short_int
     i :: int
-    r1 :: bool
+    r1 :: bit
     r2 :: int
     r3 :: short_int
 L0:
@@ -37,7 +37,7 @@ def f() -> None:
 def f():
     r0 :: short_int
     i :: int
-    r1 :: bool
+    r1 :: bit
     r2 :: short_int
 L0:
     r0 = 20
@@ -63,10 +63,11 @@ def f() -> None:
 def f():
     n :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7 :: bool
 L0:
     n = 0
 L1:
@@ -97,7 +98,7 @@ def f() -> None:
 def f():
     r0 :: short_int
     n :: int
-    r1 :: bool
+    r1 :: bit
     r2 :: short_int
 L0:
     r0 = 0
@@ -126,14 +127,16 @@ def f() -> None:
 def f():
     n :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7, r8 :: bool
-    r9 :: native_int
-    r10 :: bool
-    r11 :: native_int
-    r12, r13, r14, r15 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7, r8 :: bool
+    r9 :: int64
+    r10 :: bit
+    r11 :: int64
+    r12, r13, r14 :: bit
+    r15 :: bool
 L0:
     n = 0
 L1:
@@ -183,10 +186,11 @@ def f() -> None:
 def f():
     n :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7 :: bool
 L0:
     n = 0
 L1:
@@ -218,7 +222,7 @@ def f() -> None:
 def f():
     r0 :: short_int
     n :: int
-    r1 :: bool
+    r1 :: bit
     r2 :: short_int
 L0:
     r0 = 0
@@ -246,14 +250,16 @@ def f() -> None:
 def f():
     n :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7, r8 :: bool
-    r9 :: native_int
-    r10 :: bool
-    r11 :: native_int
-    r12, r13, r14, r15 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7, r8 :: bool
+    r9 :: int64
+    r10 :: bit
+    r11 :: int64
+    r12, r13, r14 :: bit
+    r15 :: bool
 L0:
     n = 0
 L1:
@@ -310,9 +316,9 @@ def f(ls):
     y :: int
     r0 :: short_int
     r1 :: ptr
-    r2 :: native_int
+    r2 :: int64
     r3 :: short_int
-    r4 :: bool
+    r4 :: bit
     r5 :: object
     x, r6, r7 :: int
     r8 :: short_int
@@ -321,7 +327,7 @@ L0:
     r0 = 0
 L1:
     r1 = get_element_ptr ls ob_size :: PyVarObject
-    r2 = load_mem r1, ls :: native_int*
+    r2 = load_mem r1, ls :: int64*
     r3 = r2 << 1
     r4 = r0 < r3 :: signed
     if r4 goto L2 else goto L4 :: bool
@@ -348,7 +354,7 @@ def f(d: Dict[int, int]) -> None:
 def f(d):
     d :: dict
     r0 :: short_int
-    r1 :: native_int
+    r1 :: int64
     r2 :: short_int
     r3 :: object
     r4 :: tuple[bool, int, object]
@@ -358,7 +364,7 @@ def f(d):
     key, r8 :: int
     r9, r10 :: object
     r11 :: int
-    r12, r13 :: bool
+    r12, r13 :: bit
 L0:
     r0 = 0
     r1 = PyDict_Size(d)
@@ -400,7 +406,7 @@ def sum_over_even_values(d):
     d :: dict
     s :: int
     r0 :: short_int
-    r1 :: native_int
+    r1 :: int64
     r2 :: short_int
     r3 :: object
     r4 :: tuple[bool, int, object]
@@ -411,11 +417,12 @@ def sum_over_even_values(d):
     r9, r10 :: object
     r11, r12 :: int
     r13 :: bool
-    r14 :: native_int
-    r15, r16, r17, r18 :: bool
+    r14 :: int64
+    r15, r16 :: bit
+    r17, r18 :: bool
     r19, r20 :: object
     r21, r22 :: int
-    r23, r24 :: bool
+    r23, r24 :: bit
 L0:
     s = 0
     r0 = 0
@@ -596,7 +603,7 @@ def multi_assign(t, a, l):
     r1 :: bool
     r2 :: tuple[str, object]
     r3 :: str
-    r4 :: bool
+    r4 :: bit
     r5 :: object
     r6 :: int
 L0:
@@ -636,11 +643,13 @@ L2:
 def literal_msg(x):
     x :: object
     r0 :: int32
-    r1, r2 :: bool
+    r1 :: bit
+    r2, r3 :: bool
 L0:
     r0 = PyObject_IsTrue(x)
-    r1 = truncate r0: int32 to builtins.bool
-    if r1 goto L2 else goto L1 :: bool
+    r1 = r0 >= 0 :: signed
+    r2 = truncate r0: int32 to builtins.bool
+    if r2 goto L2 else goto L1 :: bool
 L1:
     raise AssertionError('message')
     unreachable
@@ -650,13 +659,14 @@ def complex_msg(x, s):
     x :: union[str, None]
     s :: str
     r0 :: object
-    r1 :: bool
+    r1 :: bit
     r2 :: str
     r3 :: int32
-    r4 :: bool
-    r5 :: object
-    r6 :: str
-    r7, r8 :: object
+    r4 :: bit
+    r5 :: bool
+    r6 :: object
+    r7 :: str
+    r8, r9 :: object
 L0:
     r0 = load_address _Py_NoneStruct
     r1 = x != r0
@@ -664,14 +674,15 @@ L0:
 L1:
     r2 = cast(str, x)
     r3 = PyObject_IsTrue(r2)
-    r4 = truncate r3: int32 to builtins.bool
-    if r4 goto L3 else goto L2 :: bool
+    r4 = r3 >= 0 :: signed
+    r5 = truncate r3: int32 to builtins.bool
+    if r5 goto L3 else goto L2 :: bool
 L2:
-    r5 = builtins :: module
-    r6 = load_global CPyStatic_unicode_3 :: static  ('AssertionError')
-    r7 = CPyObject_GetAttr(r5, r6)
-    r8 = PyObject_CallFunctionObjArgs(r7, s, 0)
-    CPy_Raise(r8)
+    r6 = builtins :: module
+    r7 = load_global CPyStatic_unicode_3 :: static  ('AssertionError')
+    r8 = CPyObject_GetAttr(r6, r7)
+    r9 = PyObject_CallFunctionObjArgs(r8, s, 0)
+    CPy_Raise(r9)
     unreachable
 L3:
     return 1
@@ -691,6 +702,7 @@ def delList():
     l :: list
     r6 :: object
     r7 :: int32
+    r8 :: bit
 L0:
     r0 = PyList_New(2)
     r1 = box(short_int, 2)
@@ -698,11 +710,12 @@ L0:
     r3 = get_element_ptr r0 ob_item :: PyListObject
     r4 = load_mem r3, r0 :: ptr*
     set_mem r4, r1, r0 :: builtins.object*
-    r5 = r4 + WORD_SIZE*1
+    r5 = r4 + 8
     set_mem r5, r2, r0 :: builtins.object*
     l = r0
     r6 = box(short_int, 2)
     r7 = PyObject_DelItem(l, r6)
+    r8 = r7 >= 0 :: signed
     return 1
 def delListMultiple():
     r0 :: list
@@ -711,10 +724,13 @@ def delListMultiple():
     l :: list
     r16 :: object
     r17 :: int32
-    r18 :: object
-    r19 :: int32
-    r20 :: object
-    r21 :: int32
+    r18 :: bit
+    r19 :: object
+    r20 :: int32
+    r21 :: bit
+    r22 :: object
+    r23 :: int32
+    r24 :: bit
 L0:
     r0 = PyList_New(7)
     r1 = box(short_int, 2)
@@ -727,25 +743,28 @@ L0:
     r8 = get_element_ptr r0 ob_item :: PyListObject
     r9 = load_mem r8, r0 :: ptr*
     set_mem r9, r1, r0 :: builtins.object*
-    r10 = r9 + WORD_SIZE*1
+    r10 = r9 + 8
     set_mem r10, r2, r0 :: builtins.object*
-    r11 = r9 + WORD_SIZE*2
+    r11 = r9 + 16
     set_mem r11, r3, r0 :: builtins.object*
-    r12 = r9 + WORD_SIZE*3
+    r12 = r9 + 24
     set_mem r12, r4, r0 :: builtins.object*
-    r13 = r9 + WORD_SIZE*4
+    r13 = r9 + 32
     set_mem r13, r5, r0 :: builtins.object*
-    r14 = r9 + WORD_SIZE*5
+    r14 = r9 + 40
     set_mem r14, r6, r0 :: builtins.object*
-    r15 = r9 + WORD_SIZE*6
+    r15 = r9 + 48
     set_mem r15, r7, r0 :: builtins.object*
     l = r0
     r16 = box(short_int, 2)
     r17 = PyObject_DelItem(l, r16)
-    r18 = box(short_int, 4)
-    r19 = PyObject_DelItem(l, r18)
-    r20 = box(short_int, 6)
-    r21 = PyObject_DelItem(l, r20)
+    r18 = r17 >= 0 :: signed
+    r19 = box(short_int, 4)
+    r20 = PyObject_DelItem(l, r19)
+    r21 = r20 >= 0 :: signed
+    r22 = box(short_int, 6)
+    r23 = PyObject_DelItem(l, r22)
+    r24 = r23 >= 0 :: signed
     return 1
 
 [case testDelDict]
@@ -762,6 +781,7 @@ def delDict():
     r4, d :: dict
     r5 :: str
     r6 :: int32
+    r7 :: bit
 L0:
     r0 = load_global CPyStatic_unicode_1 :: static  ('one')
     r1 = load_global CPyStatic_unicode_2 :: static  ('two')
@@ -771,13 +791,17 @@ L0:
     d = r4
     r5 = load_global CPyStatic_unicode_1 :: static  ('one')
     r6 = PyObject_DelItem(d, r5)
+    r7 = r6 >= 0 :: signed
     return 1
 def delDictMultiple():
     r0, r1, r2, r3 :: str
     r4, r5, r6, r7 :: object
     r8, d :: dict
     r9, r10 :: str
-    r11, r12 :: int32
+    r11 :: int32
+    r12 :: bit
+    r13 :: int32
+    r14 :: bit
 L0:
     r0 = load_global CPyStatic_unicode_1 :: static  ('one')
     r1 = load_global CPyStatic_unicode_2 :: static  ('two')
@@ -792,7 +816,9 @@ L0:
     r9 = load_global CPyStatic_unicode_1 :: static  ('one')
     r10 = load_global CPyStatic_unicode_4 :: static  ('four')
     r11 = PyObject_DelItem(d, r9)
-    r12 = PyObject_DelItem(d, r10)
+    r12 = r11 >= 0 :: signed
+    r13 = PyObject_DelItem(d, r10)
+    r14 = r13 >= 0 :: signed
     return 1
 
 [case testDelAttribute]
@@ -819,25 +845,31 @@ def delAttribute():
     r0, dummy :: __main__.Dummy
     r1 :: str
     r2 :: int32
+    r3 :: bit
 L0:
     r0 = Dummy(2, 4)
     dummy = r0
     r1 = load_global CPyStatic_unicode_3 :: static  ('x')
     r2 = PyObject_DelAttr(dummy, r1)
+    r3 = r2 >= 0 :: signed
     return 1
 def delAttributeMultiple():
     r0, dummy :: __main__.Dummy
     r1 :: str
     r2 :: int32
-    r3 :: str
-    r4 :: int32
+    r3 :: bit
+    r4 :: str
+    r5 :: int32
+    r6 :: bit
 L0:
     r0 = Dummy(2, 4)
     dummy = r0
     r1 = load_global CPyStatic_unicode_3 :: static  ('x')
     r2 = PyObject_DelAttr(dummy, r1)
-    r3 = load_global CPyStatic_unicode_4 :: static  ('y')
-    r4 = PyObject_DelAttr(dummy, r3)
+    r3 = r2 >= 0 :: signed
+    r4 = load_global CPyStatic_unicode_4 :: static  ('y')
+    r5 = PyObject_DelAttr(dummy, r4)
+    r6 = r5 >= 0 :: signed
     return 1
 
 [case testForEnumerate]
@@ -856,9 +888,9 @@ def f(a):
     i :: int
     r1 :: short_int
     r2 :: ptr
-    r3 :: native_int
+    r3 :: int64
     r4 :: short_int
-    r5 :: bool
+    r5 :: bit
     r6 :: object
     x, r7, r8 :: int
     r9, r10 :: short_int
@@ -868,7 +900,7 @@ L0:
     r1 = 0
 L1:
     r2 = get_element_ptr a ob_size :: PyVarObject
-    r3 = load_mem r2, a :: native_int*
+    r3 = load_mem r2, a :: int64*
     r4 = r3 << 1
     r5 = r1 < r4 :: signed
     if r5 goto L2 else goto L4 :: bool
@@ -894,7 +926,7 @@ def g(x):
     r1, r2 :: object
     r3, n :: int
     r4 :: short_int
-    r5 :: bool
+    r5 :: bit
 L0:
     r0 = 0
     i = 0
@@ -933,22 +965,23 @@ def f(a, b):
     r0 :: short_int
     r1 :: object
     r2 :: ptr
-    r3 :: native_int
+    r3 :: int64
     r4 :: short_int
-    r5 :: bool
+    r5 :: bit
     r6, r7 :: object
     x, r8 :: int
     r9, y :: bool
     r10 :: int32
-    r11 :: bool
-    r12 :: short_int
-    r13 :: bool
+    r11 :: bit
+    r12 :: bool
+    r13 :: short_int
+    r14 :: bit
 L0:
     r0 = 0
     r1 = PyObject_GetIter(b)
 L1:
     r2 = get_element_ptr a ob_size :: PyVarObject
-    r3 = load_mem r2, a :: native_int*
+    r3 = load_mem r2, a :: int64*
     r4 = r3 << 1
     r5 = r0 < r4 :: signed
     if r5 goto L2 else goto L7 :: bool
@@ -962,17 +995,18 @@ L3:
     r9 = unbox(bool, r6)
     y = r9
     r10 = PyObject_IsTrue(b)
-    r11 = truncate r10: int32 to builtins.bool
-    if r11 goto L4 else goto L5 :: bool
+    r11 = r10 >= 0 :: signed
+    r12 = truncate r10: int32 to builtins.bool
+    if r12 goto L4 else goto L5 :: bool
 L4:
     x = 2
 L5:
 L6:
-    r12 = r0 + 2
-    r0 = r12
+    r13 = r0 + 2
+    r0 = r13
     goto L1
 L7:
-    r13 = CPy_NoErrOccured()
+    r14 = CPy_NoErrOccured()
 L8:
     return 1
 def g(a, b):
@@ -983,13 +1017,14 @@ def g(a, b):
     z :: int
     r3 :: object
     r4 :: ptr
-    r5 :: native_int
+    r5 :: int64
     r6 :: short_int
-    r7, r8, r9, x :: bool
+    r7, r8 :: bit
+    r9, x :: bool
     r10 :: object
     y, r11 :: int
     r12, r13 :: short_int
-    r14 :: bool
+    r14 :: bit
 L0:
     r0 = PyObject_GetIter(a)
     r1 = 0
@@ -1000,7 +1035,7 @@ L1:
     if is_error(r3) goto L6 else goto L2
 L2:
     r4 = get_element_ptr b ob_size :: PyVarObject
-    r5 = load_mem r4, b :: native_int*
+    r5 = load_mem r4, b :: int64*
     r6 = r5 << 1
     r7 = r1 < r6 :: signed
     if r7 goto L3 else goto L6 :: bool
@@ -1025,3 +1060,4 @@ L6:
     r14 = CPy_NoErrOccured()
 L7:
     return 1
+

--- a/mypyc/test-data/irbuild-str.test
+++ b/mypyc/test-data/irbuild-str.test
@@ -14,9 +14,9 @@ def do_split(s, sep, max_split):
     sep :: union[str, None]
     max_split :: union[int, None]
     r0, r1, r2 :: object
-    r3, r4 :: bool
+    r3, r4 :: bit
     r5 :: object
-    r6, r7 :: bool
+    r6, r7 :: bit
     r8 :: str
     r9 :: int
     r10 :: list
@@ -67,9 +67,9 @@ def neq(x: str, y: str) -> bool:
 def eq(x, y):
     x, y :: str
     r0 :: int32
-    r1 :: bool
+    r1 :: bit
     r2 :: object
-    r3, r4, r5 :: bool
+    r3, r4, r5 :: bit
 L0:
     r0 = PyUnicode_Compare(x, y)
     r1 = r0 == -1
@@ -86,9 +86,9 @@ L3:
 def neq(x, y):
     x, y :: str
     r0 :: int32
-    r1 :: bool
+    r1 :: bit
     r2 :: object
-    r3, r4, r5 :: bool
+    r3, r4, r5 :: bit
 L0:
     r0 = PyUnicode_Compare(x, y)
     r1 = r0 == -1
@@ -102,3 +102,4 @@ L2:
 L3:
     r5 = r0 != 0
     return r5
+

--- a/mypyc/test-data/irbuild-try.test
+++ b/mypyc/test-data/irbuild-try.test
@@ -14,7 +14,7 @@ def g():
     r6 :: object
     r7 :: str
     r8, r9 :: object
-    r10 :: bool
+    r10 :: bit
 L0:
 L1:
     r0 = builtins :: module
@@ -60,7 +60,7 @@ def g(b):
     r8 :: object
     r9 :: str
     r10, r11 :: object
-    r12 :: bool
+    r12 :: bit
 L0:
 L1:
     if b goto L2 else goto L3 :: bool
@@ -120,13 +120,13 @@ def g():
     r16 :: object
     r17 :: str
     r18, r19 :: object
-    r20 :: bool
+    r20 :: bit
     r21 :: tuple[object, object, object]
     r22 :: str
     r23 :: object
     r24 :: str
     r25, r26 :: object
-    r27 :: bool
+    r27 :: bit
 L0:
 L1:
     r0 = load_global CPyStatic_unicode_1 :: static  ('a')
@@ -211,7 +211,7 @@ def g():
     r15 :: object
     r16 :: str
     r17, r18 :: object
-    r19 :: bool
+    r19 :: bit
 L0:
 L1:
     goto L9
@@ -274,7 +274,7 @@ def a(b):
     r9 :: object
     r10 :: str
     r11, r12 :: object
-    r13 :: bool
+    r13 :: bit
 L0:
 L1:
     if b goto L2 else goto L3 :: bool
@@ -338,10 +338,12 @@ def foo(x):
     r13, r14 :: tuple[object, object, object]
     r15, r16, r17, r18 :: object
     r19 :: int32
-    r20, r21 :: bool
-    r22, r23, r24 :: tuple[object, object, object]
-    r25, r26 :: object
-    r27 :: bool
+    r20 :: bit
+    r21 :: bool
+    r22 :: bit
+    r23, r24, r25 :: tuple[object, object, object]
+    r26, r27 :: object
+    r28 :: bit
 L0:
     r0 = PyObject_CallFunctionObjArgs(x, 0)
     r1 = PyObject_Type(r0)
@@ -369,8 +371,9 @@ L3: (handler for L2)
     r17 = r14[2]
     r18 = PyObject_CallFunctionObjArgs(r3, r0, r15, r16, r17, 0)
     r19 = PyObject_IsTrue(r18)
-    r20 = truncate r19: int32 to builtins.bool
-    if r20 goto L5 else goto L4 :: bool
+    r20 = r19 >= 0 :: signed
+    r21 = truncate r19: int32 to builtins.bool
+    if r21 goto L5 else goto L4 :: bool
 L4:
     CPy_Reraise()
     unreachable
@@ -380,35 +383,35 @@ L6:
     goto L8
 L7: (handler for L3, L4, L5)
     CPy_RestoreExcInfo(r13)
-    r21 = CPy_KeepPropagating()
+    r22 = CPy_KeepPropagating()
     unreachable
 L8:
 L9:
 L10:
-    r23 = <error> :: tuple[object, object, object]
-    r22 = r23
+    r24 = <error> :: tuple[object, object, object]
+    r23 = r24
     goto L12
 L11: (handler for L1, L6, L7, L8)
-    r24 = CPy_CatchError()
-    r22 = r24
+    r25 = CPy_CatchError()
+    r23 = r25
 L12:
     if r7 goto L13 else goto L14 :: bool
 L13:
-    r25 = load_address _Py_NoneStruct
-    r26 = PyObject_CallFunctionObjArgs(r3, r0, r25, r25, r25, 0)
+    r26 = load_address _Py_NoneStruct
+    r27 = PyObject_CallFunctionObjArgs(r3, r0, r26, r26, r26, 0)
 L14:
-    if is_error(r22) goto L16 else goto L15
+    if is_error(r23) goto L16 else goto L15
 L15:
     CPy_Reraise()
     unreachable
 L16:
     goto L20
 L17: (handler for L12, L13, L14, L15)
-    if is_error(r22) goto L19 else goto L18
+    if is_error(r23) goto L19 else goto L18
 L18:
-    CPy_RestoreExcInfo(r22)
+    CPy_RestoreExcInfo(r23)
 L19:
-    r27 = CPy_KeepPropagating()
+    r28 = CPy_KeepPropagating()
     unreachable
 L20:
     return 1

--- a/mypyc/test-data/irbuild-try.test
+++ b/mypyc/test-data/irbuild-try.test
@@ -114,7 +114,7 @@ def g():
     r10 :: object
     r11 :: str
     r12 :: object
-    r13 :: bool
+    r13 :: bit
     e, r14 :: object
     r15 :: str
     r16 :: object
@@ -199,14 +199,14 @@ def g():
     r1 :: object
     r2 :: str
     r3 :: object
-    r4 :: bool
+    r4 :: bit
     r5 :: str
     r6 :: object
     r7 :: str
     r8, r9, r10 :: object
     r11 :: str
     r12 :: object
-    r13 :: bool
+    r13 :: bit
     r14 :: str
     r15 :: object
     r16 :: str

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -131,7 +131,7 @@ def f(xs):
     xs :: tuple
     r0 :: short_int
     r1 :: ptr
-    r2 :: int64
+    r2 :: native_int
     r3 :: short_int
     r4 :: bit
     r5 :: object
@@ -141,7 +141,7 @@ L0:
     r0 = 0
 L1:
     r1 = get_element_ptr xs ob_size :: PyVarObject
-    r2 = load_mem r1, xs :: int64*
+    r2 = load_mem r1, xs :: native_int*
     r3 = r2 << 1
     r4 = r0 < r3 :: signed
     if r4 goto L2 else goto L4 :: bool
@@ -192,13 +192,13 @@ def f(i: int) -> bool:
 def f(i):
     i :: int
     r0, r1, r2 :: bool
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6 :: bit
     r7 :: bool
-    r8 :: int64
+    r8 :: native_int
     r9, r10, r11 :: bit
     r12 :: bool
-    r13 :: int64
+    r13 :: native_int
     r14, r15, r16 :: bit
 L0:
     r3 = i & 1

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -193,14 +193,13 @@ def f(i):
     i :: int
     r0, r1, r2 :: bool
     r3 :: int64
-    r4, r5 :: bit
-    r6, r7 :: bool
+    r4, r5, r6 :: bit
+    r7 :: bool
     r8 :: int64
-    r9, r10 :: bit
-    r11, r12 :: bool
+    r9, r10, r11 :: bit
+    r12 :: bool
     r13 :: int64
-    r14, r15 :: bit
-    r16 :: bool
+    r14, r15, r16 :: bit
 L0:
     r3 = i & 1
     r4 = r3 == 0

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -111,7 +111,7 @@ L0:
     r3 = get_element_ptr r0 ob_item :: PyListObject
     r4 = load_mem r3, r0 :: ptr*
     set_mem r4, r1, r0 :: builtins.object*
-    r5 = r4 + 8
+    r5 = r4 + WORD_SIZE*1
     set_mem r5, r2, r0 :: builtins.object*
     r6 = CPyList_Extend(r0, x)
     r7 = CPyList_Extend(r0, y)
@@ -249,4 +249,3 @@ L14:
     r0 = r12
 L15:
     return r0
-

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -102,7 +102,8 @@ def f(x, y):
     r3, r4, r5 :: ptr
     r6, r7, r8 :: object
     r9 :: int32
-    r10 :: tuple
+    r10 :: bit
+    r11 :: tuple
 L0:
     r0 = PyList_New(2)
     r1 = box(short_int, 2)
@@ -110,14 +111,15 @@ L0:
     r3 = get_element_ptr r0 ob_item :: PyListObject
     r4 = load_mem r3, r0 :: ptr*
     set_mem r4, r1, r0 :: builtins.object*
-    r5 = r4 + WORD_SIZE*1
+    r5 = r4 + 8
     set_mem r5, r2, r0 :: builtins.object*
     r6 = CPyList_Extend(r0, x)
     r7 = CPyList_Extend(r0, y)
     r8 = box(short_int, 6)
     r9 = PyList_Append(r0, r8)
-    r10 = PyList_AsTuple(r0)
-    return r10
+    r10 = r9 >= 0 :: signed
+    r11 = PyList_AsTuple(r0)
+    return r11
 
 [case testTupleFor]
 from typing import Tuple, List
@@ -129,9 +131,9 @@ def f(xs):
     xs :: tuple
     r0 :: short_int
     r1 :: ptr
-    r2 :: native_int
+    r2 :: int64
     r3 :: short_int
-    r4 :: bool
+    r4 :: bit
     r5 :: object
     x, r6 :: str
     r7 :: short_int
@@ -139,7 +141,7 @@ L0:
     r0 = 0
 L1:
     r1 = get_element_ptr xs ob_size :: PyVarObject
-    r2 = load_mem r1, xs :: native_int*
+    r2 = load_mem r1, xs :: int64*
     r3 = r2 << 1
     r4 = r0 < r3 :: signed
     if r4 goto L2 else goto L4 :: bool
@@ -190,12 +192,15 @@ def f(i: int) -> bool:
 def f(i):
     i :: int
     r0, r1, r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7 :: bool
-    r8 :: native_int
-    r9, r10, r11, r12 :: bool
-    r13 :: native_int
-    r14, r15, r16 :: bool
+    r3 :: int64
+    r4, r5 :: bit
+    r6, r7 :: bool
+    r8 :: int64
+    r9, r10 :: bit
+    r11, r12 :: bool
+    r13 :: int64
+    r14, r15 :: bit
+    r16 :: bool
 L0:
     r3 = i & 1
     r4 = r3 == 0
@@ -245,3 +250,4 @@ L14:
     r0 = r12
 L15:
     return r0
+

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -64,7 +64,7 @@ def f() -> int:
 def f():
     x, y :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2, r3, r4 :: bit
 L0:
     x = 2
@@ -198,7 +198,7 @@ def f(a: int) -> int:
 def f(a):
     a :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2, r3, r4 :: bit
     x, r5, y :: int
 L0:
@@ -242,7 +242,7 @@ def f(a: int) -> int:
 def f(a):
     a :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2, r3, r4 :: bit
     x, r5, y :: int
 L0:
@@ -282,7 +282,7 @@ def f(a: int) -> int:
 def f(a):
     a :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2, r3, r4 :: bit
 L0:
     r1 = a & 1
@@ -463,7 +463,7 @@ def f() -> int:
 def f():
     x, y, z :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2, r3, r4 :: bit
     a, r5, r6 :: int
 L0:
@@ -513,9 +513,9 @@ def f(a: int) -> int:
 def f(a):
     a, sum, i :: int
     r0 :: bool
-    r1 :: int64
+    r1 :: native_int
     r2 :: bit
-    r3 :: int64
+    r3 :: native_int
     r4, r5, r6, r7, r8 :: bit
     r9, r10 :: int
 L0:
@@ -753,7 +753,7 @@ def f(d: Dict[int, int]) -> None:
 def f(d):
     d :: dict
     r0 :: short_int
-    r1 :: int64
+    r1 :: native_int
     r2 :: short_int
     r3 :: object
     r4 :: tuple[bool, int, object]

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -64,8 +64,9 @@ def f() -> int:
 def f():
     x, y :: int
     r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bool
+    r1 :: int64
+    r2, r3 :: bit
+    r4 :: bool
 L0:
     x = 2
     y = 4
@@ -198,8 +199,9 @@ def f(a: int) -> int:
 def f(a):
     a :: int
     r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bool
+    r1 :: int64
+    r2, r3 :: bit
+    r4 :: bool
     x, r5, y :: int
 L0:
     r1 = a & 1
@@ -242,8 +244,9 @@ def f(a: int) -> int:
 def f(a):
     a :: int
     r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bool
+    r1 :: int64
+    r2, r3 :: bit
+    r4 :: bool
     x, r5, y :: int
 L0:
     r1 = a & 1
@@ -282,8 +285,9 @@ def f(a: int) -> int:
 def f(a):
     a :: int
     r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bool
+    r1 :: int64
+    r2, r3 :: bit
+    r4 :: bool
 L0:
     r1 = a & 1
     r2 = r1 == 0
@@ -463,8 +467,9 @@ def f() -> int:
 def f():
     x, y, z :: int
     r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bool
+    r1 :: int64
+    r2, r3 :: bit
+    r4 :: bool
     a, r5, r6 :: int
 L0:
     x = 2
@@ -513,10 +518,11 @@ def f(a: int) -> int:
 def f(a):
     a, sum, i :: int
     r0 :: bool
-    r1 :: native_int
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6, r7, r8 :: bool
+    r1 :: int64
+    r2 :: bit
+    r3 :: int64
+    r4, r5, r6 :: bit
+    r7, r8 :: bool
     r9, r10 :: int
 L0:
     sum = 0
@@ -601,7 +607,7 @@ def f(a, b):
     r0 :: object
     r1 :: int
     r2 :: object
-    r3 :: bool
+    r3 :: bit
 L0:
     r0 = CPyList_GetItemShort(b, 0)
     r1 = unbox(int, r0)
@@ -734,11 +740,13 @@ def f(a, x):
     x :: int
     r0 :: object
     r1 :: int32
+    r2 :: bit
 L0:
     inc_ref x :: int
     r0 = box(int, x)
     r1 = PyList_Append(a, r0)
     dec_ref r0
+    r2 = r1 >= 0 :: signed
     return 1
 
 [case testForDict]
@@ -751,7 +759,7 @@ def f(d: Dict[int, int]) -> None:
 def f(d):
     d :: dict
     r0 :: short_int
-    r1 :: native_int
+    r1 :: int64
     r2 :: short_int
     r3 :: object
     r4 :: tuple[bool, int, object]
@@ -761,7 +769,7 @@ def f(d):
     key, r8 :: int
     r9, r10 :: object
     r11 :: int
-    r12, r13 :: bool
+    r12, r13 :: bit
 L0:
     r0 = 0
     r1 = PyDict_Size(d)

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -65,8 +65,7 @@ def f():
     x, y :: int
     r0 :: bool
     r1 :: int64
-    r2, r3 :: bit
-    r4 :: bool
+    r2, r3, r4 :: bit
 L0:
     x = 2
     y = 4
@@ -200,8 +199,7 @@ def f(a):
     a :: int
     r0 :: bool
     r1 :: int64
-    r2, r3 :: bit
-    r4 :: bool
+    r2, r3, r4 :: bit
     x, r5, y :: int
 L0:
     r1 = a & 1
@@ -245,8 +243,7 @@ def f(a):
     a :: int
     r0 :: bool
     r1 :: int64
-    r2, r3 :: bit
-    r4 :: bool
+    r2, r3, r4 :: bit
     x, r5, y :: int
 L0:
     r1 = a & 1
@@ -286,8 +283,7 @@ def f(a):
     a :: int
     r0 :: bool
     r1 :: int64
-    r2, r3 :: bit
-    r4 :: bool
+    r2, r3, r4 :: bit
 L0:
     r1 = a & 1
     r2 = r1 == 0
@@ -468,8 +464,7 @@ def f():
     x, y, z :: int
     r0 :: bool
     r1 :: int64
-    r2, r3 :: bit
-    r4 :: bool
+    r2, r3, r4 :: bit
     a, r5, r6 :: int
 L0:
     x = 2
@@ -521,8 +516,7 @@ def f(a):
     r1 :: int64
     r2 :: bit
     r3 :: int64
-    r4, r5, r6 :: bit
-    r7, r8 :: bool
+    r4, r5, r6, r7, r8 :: bit
     r9, r10 :: int
 L0:
     sum = 0

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -115,13 +115,13 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          "cpy_r_r0 = CPyTagged_Negate(cpy_r_m);")
 
     def test_branch(self) -> None:
-        self.assert_emit(Branch(self.b, BasicBlock(8), BasicBlock(9), Branch.BOOL_EXPR),
+        self.assert_emit(Branch(self.b, BasicBlock(8), BasicBlock(9), Branch.BOOL),
                          """if (cpy_r_b) {
                                 goto CPyL8;
                             } else
                                 goto CPyL9;
                          """)
-        b = Branch(self.b, BasicBlock(8), BasicBlock(9), Branch.BOOL_EXPR)
+        b = Branch(self.b, BasicBlock(8), BasicBlock(9), Branch.BOOL)
         b.negated = True
         self.assert_emit(b,
                          """if (!cpy_r_b) {

--- a/mypyc/test/test_subtype.py
+++ b/mypyc/test/test_subtype.py
@@ -1,0 +1,27 @@
+"""Test cases for is_subtype and is_runtime_subtype."""
+
+import unittest
+
+from mypyc.ir.rtypes import bit_rprimitive, bool_rprimitive, int_rprimitive
+from mypyc.subtype import is_subtype
+from mypyc.rt_subtype import is_runtime_subtype
+
+
+class TestSubtype(unittest.TestCase):
+    def test_bit(self) -> None:
+        assert is_subtype(bit_rprimitive, bool_rprimitive)
+        assert is_subtype(bit_rprimitive, int_rprimitive)
+
+    def test_bool(self) -> None:
+        assert not is_subtype(bool_rprimitive, bit_rprimitive)
+        assert is_subtype(bool_rprimitive, int_rprimitive)
+
+
+class TestRuntimeSubtype(unittest.TestCase):
+    def test_bit(self) -> None:
+        assert is_runtime_subtype(bit_rprimitive, bool_rprimitive)
+        assert not is_runtime_subtype(bit_rprimitive, int_rprimitive)
+
+    def test_bool(self) -> None:
+        assert not is_runtime_subtype(bool_rprimitive, bit_rprimitive)
+        assert not is_runtime_subtype(bool_rprimitive, int_rprimitive)

--- a/mypyc/transform/exceptions.py
+++ b/mypyc/transform/exceptions.py
@@ -13,7 +13,7 @@ from typing import List, Optional
 
 from mypyc.ir.ops import (
     BasicBlock, LoadErrorValue, Return, Branch, RegisterOp, LoadInt, ERR_NEVER, ERR_MAGIC,
-    ERR_FALSE, ERR_NEG_INT, ERR_ALWAYS, NO_TRACEBACK_LINE_NO, Environment
+    ERR_FALSE, ERR_ALWAYS, NO_TRACEBACK_LINE_NO, Environment
 )
 from mypyc.ir.func_ir import FuncIR
 from mypyc.ir.rtypes import bool_rprimitive
@@ -75,13 +75,10 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
                     negated = False
                 elif op.error_kind == ERR_FALSE:
                     # Op returns a C false value on error.
-                    variant = Branch.BOOL_EXPR
+                    variant = Branch.BOOL
                     negated = True
-                elif op.error_kind == ERR_NEG_INT:
-                    variant = Branch.NEG_INT_EXPR
-                    negated = False
                 elif op.error_kind == ERR_ALWAYS:
-                    variant = Branch.BOOL_EXPR
+                    variant = Branch.BOOL
                     negated = True
                     # this is a hack to represent the always fail
                     # semantics, using a temporary bool with value false


### PR DESCRIPTION
Add the `bit` primitive type that only has two valid values: 0 and 1. The existing
boolean primitive type is different as it also supports a third value (for error). 
This makes boolean  a poor fit for low-level IR operations which never raise an 
exception.

Use `bit` as the result type of comparison operations and various primitives.

Also simplify the branch operation to not have a special mode for branching on
negative values, since it's needlessly ad hoc. Primitives still support this mode,
but it gets converted away during IR building.

Work on mypyc/mypyc#748.