### PR TITLE
[mypyc] Simplify IR for tagged integer comparisons

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -39,7 +39,7 @@ from mypyc.ir.ops import (
 from mypyc.ir.rtypes import (
     RType, RTuple, RInstance, int_rprimitive, dict_rprimitive,
     none_rprimitive, is_none_rprimitive, object_rprimitive, is_object_rprimitive,
-    str_rprimitive, is_int_rprimitive, is_short_int_rprimitive, is_tagged
+    str_rprimitive, is_tagged
 )
 from mypyc.ir.func_ir import FuncIR, INVALID_FUNC_DEF
 from mypyc.ir.class_ir import ClassIR, NonExtClassInfo

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -837,13 +837,15 @@ class IRBuilder:
         """
         if not isinstance(e, ComparisonExpr) or len(e.operands) != 2:
             return False
-        left = self.accept(e.operands[0])
-        right = self.accept(e.operands[1])
-        op = e.operators[0]
-        if not is_tagged(left.type) or not is_tagged(right.type):
+        ltype = self.node_type(e.operands[0])
+        rtype = self.node_type(e.operands[1])
+        if not is_tagged(ltype) or not is_tagged(rtype):
             return False
+        op = e.operators[0]
         if op not in ('==', '!=', '<', '<=', '>', '>='):
             return False
+        left = self.accept(e.operands[0])
+        right = self.accept(e.operands[1])
         # "left op right" for two tagged integers
         self.builder.compare_tagged_condition(left, right, op, true, false, e.line)
         return True

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -825,10 +825,15 @@ class IRBuilder:
                                              e: Expression,
                                              true: BasicBlock,
                                              false: BasicBlock) -> bool:
-        """Transform some comparison expressions in a conditional context.
+        """Transform simple tagged integer comparisons in a conditional context.
 
-        Return True if the operation is supported. Otherwise, do nothing
-        and return False.
+        Return True if the operation is supported (and was transformed). Otherwise,
+        do nothing and return False.
+
+        Args:
+            e: Arbitrary expression
+            true: Branch target if comparison is true
+            false: Branch target if comparison is false
         """
         if not isinstance(e, ComparisonExpr) or len(e.operands) != 2:
             return False

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -642,7 +642,17 @@ class LowLevelIRBuilder:
                                  true: BasicBlock,
                                  false: BasicBlock,
                                  line: int) -> None:
-        """Compare two tagged integers using given operator (conditional context)."""
+        """Compare two tagged integers using given operator (conditional context).
+
+        Assume lhs and and rhs are tagged integers.
+
+        Args:
+            lhs: Left operand
+            rhs: Right operand
+            op: Operation, one of '==', '!=', '<', '<=', '>', '<='
+            true: Branch target if comparison is true
+            false: Branch target if comparison is false
+        """
         is_eq = op in ("==", "!=")
         if ((is_short_int_rprimitive(lhs.type) and is_short_int_rprimitive(rhs.type))
             or (is_eq and (is_short_int_rprimitive(lhs.type) or

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -589,17 +589,18 @@ class LowLevelIRBuilder:
         assert target, 'Unsupported binary operation: %s' % op
         return target
 
-    def check_tagged_short_int(self, val: Value, line: int) -> Value:
+    def check_tagged_short_int(self, val: Value, line: int, negated: bool = False) -> Value:
         """Check if a tagged integer is a short integer"""
         int_tag = self.add(LoadInt(1, line, rtype=c_pyssize_t_rprimitive))
         bitwise_and = self.binary_int_op(c_pyssize_t_rprimitive, val,
                                          int_tag, BinaryIntOp.AND, line)
         zero = self.add(LoadInt(0, line, rtype=c_pyssize_t_rprimitive))
-        check = self.comparison_op(bitwise_and, zero, ComparisonOp.EQ, line)
+        op = ComparisonOp.NEQ if negated else ComparisonOp.EQ
+        check = self.comparison_op(bitwise_and, zero, op, line)
         return check
 
     def compare_tagged(self, lhs: Value, rhs: Value, op: str, line: int) -> Value:
-        """Compare two tagged integers using given op"""
+        """Compare two tagged integers using given operator (value context)."""
         # generate fast binary logic ops on short ints
         if is_short_int_rprimitive(lhs.type) and is_short_int_rprimitive(rhs.type):
             return self.comparison_op(lhs, rhs, int_comparison_op_mapping[op][0], line)
@@ -610,13 +611,11 @@ class LowLevelIRBuilder:
         if op in ("==", "!="):
             check = check_lhs
         else:
-            # for non-equal logical ops(less than, greater than, etc.), need to check both side
+            # for non-equality logical ops (less/greater than, etc.), need to check both sides
             check_rhs = self.check_tagged_short_int(rhs, line)
             check = self.binary_int_op(bit_rprimitive, check_lhs,
                                        check_rhs, BinaryIntOp.AND, line)
-        branch = Branch(check, short_int_block, int_block, Branch.BOOL)
-        branch.negated = False
-        self.add(branch)
+        self.add(Branch(check, short_int_block, int_block, Branch.BOOL))
         self.activate_block(short_int_block)
         eq = self.comparison_op(lhs, rhs, op_type, line)
         self.add(Assign(result, eq, line))
@@ -635,6 +634,49 @@ class LowLevelIRBuilder:
         self.add(Assign(result, call_result, line))
         self.goto_and_activate(out)
         return result
+
+    def compare_tagged_condition(self,
+                                 lhs: Value,
+                                 rhs: Value,
+                                 op: str,
+                                 true: BasicBlock,
+                                 false: BasicBlock,
+                                 line: int) -> None:
+        """Compare two tagged integers using given operator (conditional context)."""
+        is_eq = op in ("==", "!=")
+        if ((is_short_int_rprimitive(lhs.type) and is_short_int_rprimitive(rhs.type))
+            or (is_eq and (is_short_int_rprimitive(lhs.type) or
+                           is_short_int_rprimitive(rhs.type)))):
+            check = self.comparison_op(lhs, rhs, int_comparison_op_mapping[op][0], line)
+            self.add(Branch(check, true, false, Branch.BOOL))
+            return
+        op_type, c_func_desc, negate_result, swap_op = int_comparison_op_mapping[op]
+        int_block, short_int_block = BasicBlock(), BasicBlock()
+        check_lhs = self.check_tagged_short_int(lhs, line, negated=True)
+        if is_eq:
+            self.add(Branch(check_lhs, int_block, short_int_block, Branch.BOOL))
+        else:
+            # for non-equality logical ops (less/greater than, etc.), need to check both sides
+            rhs_block = BasicBlock()
+            self.add(Branch(check_lhs, int_block, rhs_block, Branch.BOOL))
+            self.activate_block(rhs_block)
+            check_rhs = self.check_tagged_short_int(rhs, line, negated=True)
+            self.add(Branch(check_rhs, int_block, short_int_block, Branch.BOOL))
+        # Arbitrary integers (slow path)
+        self.activate_block(int_block)
+        if swap_op:
+            args = [rhs, lhs]
+        else:
+            args = [lhs, rhs]
+        call = self.call_c(c_func_desc, args, line)
+        if negate_result:
+            self.add(Branch(call, false, true, Branch.BOOL))
+        else:
+            self.add(Branch(call, true, false, Branch.BOOL))
+        # Short integers (fast path)
+        self.activate_block(short_int_block)
+        eq = self.comparison_op(lhs, rhs, op_type, line)
+        self.add(Branch(eq, true, false, Branch.BOOL))
 
     def compare_strings(self, lhs: Value, rhs: Value, op: str, line: int) -> Value:
         """Compare two strings"""

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -180,7 +180,7 @@ def f(n: int) -> None:
 [out]
 def f(n):
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
     r4, m :: int
 L0:
@@ -232,9 +232,9 @@ def f(n: int) -> None:
 [out]
 def f(n):
     n, x, y :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
-    r4 :: int64
+    r4 :: native_int
     r5, r6, r7 :: bit
 L0:
     x = 2

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -10,7 +10,7 @@ def f(a: int) -> None:
 [out]
 def f(a):
     a, x :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
     y, z :: int
 L0:
@@ -180,9 +180,9 @@ def f(n: int) -> None:
 [out]
 def f(n):
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
     r6, m :: int
 L0:
@@ -243,13 +243,13 @@ def f(n: int) -> None:
 [out]
 def f(n):
     n, x, y :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
-    r6 :: int64
+    r6 :: native_int
     r7 :: bit
-    r8 :: int64
+    r8 :: native_int
     r9, r10, r11 :: bit
 L0:
     x = 2
@@ -377,13 +377,13 @@ def f(a: int) -> None:
 [out]
 def f(a):
     a :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
-    r6 :: int64
+    r6 :: native_int
     r7 :: bit
-    r8 :: int64
+    r8 :: native_int
     r9, r10, r11 :: bit
     y, x :: int
 L0:
@@ -499,7 +499,7 @@ def f(a: int) -> int:
 [out]
 def f(a):
     a :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
     x :: int
 L0:
@@ -550,9 +550,9 @@ def f(a: int) -> int:
 [out]
 def f(a):
     a, sum, i :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
     r6, r7 :: int
 L0:

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -180,32 +180,26 @@ def f(n: int) -> None:
 [out]
 def f(n):
     n :: int
-    r0 :: native_int
-    r1 :: bit
-    r2 :: native_int
-    r3, r4, r5 :: bit
-    r6, m :: int
+    r0 :: int64
+    r1, r2, r3 :: bit
+    r4, m :: int
 L0:
 L1:
     r0 = n & 1
     r1 = r0 != 0
-    if r1 goto L3 else goto L2 :: bool
+    if r1 goto L2 else goto L3 :: bool
 L2:
-    r2 = 10 & 1
-    r3 = r2 != 0
-    if r3 goto L3 else goto L4 :: bool
+    r2 = CPyTagged_IsLt_(n, 10)
+    if r2 goto L4 else goto L5 :: bool
 L3:
-    r4 = CPyTagged_IsLt_(n, 10)
-    if r4 goto L5 else goto L6 :: bool
+    r3 = n < 10 :: signed
+    if r3 goto L4 else goto L5 :: bool
 L4:
-    r5 = n < 10 :: signed
-    if r5 goto L5 else goto L6 :: bool
-L5:
-    r6 = CPyTagged_Add(n, 2)
-    n = r6
+    r4 = CPyTagged_Add(n, 2)
+    n = r4
     m = n
     goto L1
-L6:
+L5:
     return 1
 (0, 0)   {n}                     {n}
 (1, 0)   {n}                     {n}
@@ -216,20 +210,15 @@ L6:
 (1, 5)   {n}                     {n}
 (2, 0)   {n}                     {n}
 (2, 1)   {n}                     {n}
-(2, 2)   {n}                     {n}
-(2, 3)   {n}                     {n}
-(2, 4)   {n}                     {n}
 (3, 0)   {n}                     {n}
 (3, 1)   {n}                     {n}
 (4, 0)   {n}                     {n}
 (4, 1)   {n}                     {n}
+(4, 2)   {n}                     {n}
+(4, 3)   {n}                     {m, n}
+(4, 4)   {m, n}                  {m, n}
 (5, 0)   {n}                     {n}
 (5, 1)   {n}                     {n}
-(5, 2)   {n}                     {n}
-(5, 3)   {n}                     {m, n}
-(5, 4)   {m, n}                  {m, n}
-(6, 0)   {n}                     {n}
-(6, 1)   {n}                     {n}
 
 [case testMultiPass_Liveness]
 def f(n: int) -> None:
@@ -243,54 +232,42 @@ def f(n: int) -> None:
 [out]
 def f(n):
     n, x, y :: int
-    r0 :: native_int
-    r1 :: bit
-    r2 :: native_int
-    r3, r4, r5 :: bit
-    r6 :: native_int
-    r7 :: bit
-    r8 :: native_int
-    r9, r10, r11 :: bit
+    r0 :: int64
+    r1, r2, r3 :: bit
+    r4 :: int64
+    r5, r6, r7 :: bit
 L0:
     x = 2
     y = 2
 L1:
     r0 = n & 1
     r1 = r0 != 0
-    if r1 goto L3 else goto L2 :: bool
+    if r1 goto L2 else goto L3 :: bool
 L2:
-    r2 = 2 & 1
-    r3 = r2 != 0
-    if r3 goto L3 else goto L4 :: bool
+    r2 = CPyTagged_IsLt_(n, 2)
+    if r2 goto L4 else goto L10 :: bool
 L3:
-    r4 = CPyTagged_IsLt_(n, 2)
-    if r4 goto L5 else goto L12 :: bool
+    r3 = n < 2 :: signed
+    if r3 goto L4 else goto L10 :: bool
 L4:
-    r5 = n < 2 :: signed
-    if r5 goto L5 else goto L12 :: bool
-L5:
     n = y
+L5:
+    r4 = n & 1
+    r5 = r4 != 0
+    if r5 goto L6 else goto L7 :: bool
 L6:
-    r6 = n & 1
-    r7 = r6 != 0
-    if r7 goto L8 else goto L7 :: bool
+    r6 = CPyTagged_IsLt_(n, 4)
+    if r6 goto L8 else goto L9 :: bool
 L7:
-    r8 = 4 & 1
-    r9 = r8 != 0
-    if r9 goto L8 else goto L9 :: bool
+    r7 = n < 4 :: signed
+    if r7 goto L8 else goto L9 :: bool
 L8:
-    r10 = CPyTagged_IsLt_(n, 4)
-    if r10 goto L10 else goto L11 :: bool
-L9:
-    r11 = n < 4 :: signed
-    if r11 goto L10 else goto L11 :: bool
-L10:
     n = 2
     n = x
-    goto L6
-L11:
+    goto L5
+L9:
     goto L1
-L12:
+L10:
     return 1
 (0, 0)   {n}                     {i0, n}
 (0, 1)   {i0, n}                 {n, x}
@@ -303,39 +280,29 @@ L12:
 (1, 3)   {i2, n, r0, x, y}       {i2, i4, n, r0, x, y}
 (1, 4)   {i2, i4, n, r0, x, y}   {i2, n, r1, x, y}
 (1, 5)   {i2, n, r1, x, y}       {i2, n, x, y}
-(2, 0)   {i2, n, x, y}           {i2, i5, n, x, y}
-(2, 1)   {i2, i5, n, x, y}       {i2, n, r2, x, y}
-(2, 2)   {i2, n, r2, x, y}       {i2, i6, n, r2, x, y}
-(2, 3)   {i2, i6, n, r2, x, y}   {i2, n, r3, x, y}
-(2, 4)   {i2, n, r3, x, y}       {i2, n, x, y}
-(3, 0)   {i2, n, x, y}           {r4, x, y}
-(3, 1)   {r4, x, y}              {x, y}
-(4, 0)   {i2, n, x, y}           {r5, x, y}
-(4, 1)   {r5, x, y}              {x, y}
-(5, 0)   {x, y}                  {n, x, y}
-(5, 1)   {n, x, y}               {n, x, y}
-(6, 0)   {n, x, y}               {i7, n, x, y}
-(6, 1)   {i7, n, x, y}           {i7, i8, n, x, y}
-(6, 2)   {i7, i8, n, x, y}       {i7, n, r6, x, y}
-(6, 3)   {i7, n, r6, x, y}       {i7, i9, n, r6, x, y}
-(6, 4)   {i7, i9, n, r6, x, y}   {i7, n, r7, x, y}
-(6, 5)   {i7, n, r7, x, y}       {i7, n, x, y}
-(7, 0)   {i7, n, x, y}           {i10, i7, n, x, y}
-(7, 1)   {i10, i7, n, x, y}      {i7, n, r8, x, y}
-(7, 2)   {i7, n, r8, x, y}       {i11, i7, n, r8, x, y}
-(7, 3)   {i11, i7, n, r8, x, y}  {i7, n, r9, x, y}
-(7, 4)   {i7, n, r9, x, y}       {i7, n, x, y}
-(8, 0)   {i7, n, x, y}           {n, r10, x, y}
-(8, 1)   {n, r10, x, y}          {n, x, y}
-(9, 0)   {i7, n, x, y}           {n, r11, x, y}
-(9, 1)   {n, r11, x, y}          {n, x, y}
-(10, 0)  {x, y}                  {i12, x, y}
-(10, 1)  {i12, x, y}             {x, y}
-(10, 2)  {x, y}                  {n, x, y}
-(10, 3)  {n, x, y}               {n, x, y}
-(11, 0)  {n, x, y}               {n, x, y}
-(12, 0)  {}                      {i13}
-(12, 1)  {i13}                   {}
+(2, 0)   {i2, n, x, y}           {r2, x, y}
+(2, 1)   {r2, x, y}              {x, y}
+(3, 0)   {i2, n, x, y}           {r3, x, y}
+(3, 1)   {r3, x, y}              {x, y}
+(4, 0)   {x, y}                  {n, x, y}
+(4, 1)   {n, x, y}               {n, x, y}
+(5, 0)   {n, x, y}               {i5, n, x, y}
+(5, 1)   {i5, n, x, y}           {i5, i6, n, x, y}
+(5, 2)   {i5, i6, n, x, y}       {i5, n, r4, x, y}
+(5, 3)   {i5, n, r4, x, y}       {i5, i7, n, r4, x, y}
+(5, 4)   {i5, i7, n, r4, x, y}   {i5, n, r5, x, y}
+(5, 5)   {i5, n, r5, x, y}       {i5, n, x, y}
+(6, 0)   {i5, n, x, y}           {n, r6, x, y}
+(6, 1)   {n, r6, x, y}           {n, x, y}
+(7, 0)   {i5, n, x, y}           {n, r7, x, y}
+(7, 1)   {n, r7, x, y}           {n, x, y}
+(8, 0)   {x, y}                  {i8, x, y}
+(8, 1)   {i8, x, y}              {x, y}
+(8, 2)   {x, y}                  {n, x, y}
+(8, 3)   {n, x, y}               {n, x, y}
+(9, 0)   {n, x, y}               {n, x, y}
+(10, 0)  {}                      {i9}
+(10, 1)  {i9}                    {}
 
 [case testCall_Liveness]
 def f(x: int) -> int:

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -10,30 +10,26 @@ def f(a: int) -> None:
 [out]
 def f(a):
     a, x :: int
-    r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bit
+    r0 :: int64
+    r1, r2, r3 :: bit
     y, z :: int
 L0:
     x = 2
-    r1 = x & 1
-    r2 = r1 == 0
-    if r2 goto L1 else goto L2 :: bool
+    r0 = x & 1
+    r1 = r0 != 0
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r3 = x == a
-    r0 = r3
-    goto L3
+    r2 = CPyTagged_IsEq_(x, a)
+    if r2 goto L3 else goto L4 :: bool
 L2:
-    r4 = CPyTagged_IsEq_(x, a)
-    r0 = r4
+    r3 = x == a
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    if r0 goto L4 else goto L5 :: bool
-L4:
     y = 2
-    goto L6
-L5:
+    goto L5
+L4:
     z = 2
-L6:
+L5:
     return 1
 (0, 0)   {a}                     {a}
 (0, 1)   {a}                     {a, x}
@@ -43,20 +39,17 @@ L6:
 (0, 5)   {a, x}                  {a, x}
 (0, 6)   {a, x}                  {a, x}
 (1, 0)   {a, x}                  {a, x}
-(1, 1)   {a, x}                  {a, r0, x}
-(1, 2)   {a, r0, x}              {a, r0, x}
+(1, 1)   {a, x}                  {a, x}
 (2, 0)   {a, x}                  {a, x}
-(2, 1)   {a, x}                  {a, r0, x}
-(2, 2)   {a, r0, x}              {a, r0, x}
-(3, 0)   {a, r0, x}              {a, r0, x}
-(4, 0)   {a, r0, x}              {a, r0, x}
-(4, 1)   {a, r0, x}              {a, r0, x, y}
-(4, 2)   {a, r0, x, y}           {a, r0, x, y}
-(5, 0)   {a, r0, x}              {a, r0, x}
-(5, 1)   {a, r0, x}              {a, r0, x, z}
-(5, 2)   {a, r0, x, z}           {a, r0, x, z}
-(6, 0)   {a, r0, x, y, z}        {a, r0, x, y, z}
-(6, 1)   {a, r0, x, y, z}        {a, r0, x, y, z}
+(2, 1)   {a, x}                  {a, x}
+(3, 0)   {a, x}                  {a, x}
+(3, 1)   {a, x}                  {a, x, y}
+(3, 2)   {a, x, y}               {a, x, y}
+(4, 0)   {a, x}                  {a, x}
+(4, 1)   {a, x}                  {a, x, z}
+(4, 2)   {a, x, z}               {a, x, z}
+(5, 0)   {a, x, y, z}            {a, x, y, z}
+(5, 1)   {a, x, y, z}            {a, x, y, z}
 
 [case testSimple_Liveness]
 def f(a: int) -> int:
@@ -68,47 +61,25 @@ def f(a: int) -> int:
 [out]
 def f(a):
     a, x :: int
-    r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bit
+    r0 :: bit
 L0:
     x = 2
-    r1 = x & 1
-    r2 = r1 == 0
-    if r2 goto L1 else goto L2 :: bool
+    r0 = x == 2
+    if r0 goto L1 else goto L2 :: bool
 L1:
-    r3 = x == 2
-    r0 = r3
-    goto L3
-L2:
-    r4 = CPyTagged_IsEq_(x, 2)
-    r0 = r4
-L3:
-    if r0 goto L4 else goto L5 :: bool
-L4:
     return a
-L5:
+L2:
     return x
-L6:
+L3:
     unreachable
 (0, 0)   {a}                     {a, i0}
 (0, 1)   {a, i0}                 {a, x}
 (0, 2)   {a, x}                  {a, i1, x}
-(0, 3)   {a, i1, x}              {a, i1, i2, x}
-(0, 4)   {a, i1, i2, x}          {a, i1, r1, x}
-(0, 5)   {a, i1, r1, x}          {a, i1, i3, r1, x}
-(0, 6)   {a, i1, i3, r1, x}      {a, i1, r2, x}
-(0, 7)   {a, i1, r2, x}          {a, i1, x}
-(1, 0)   {a, i1, x}              {a, r3, x}
-(1, 1)   {a, r3, x}              {a, r0, x}
-(1, 2)   {a, r0, x}              {a, r0, x}
-(2, 0)   {a, i1, x}              {a, r4, x}
-(2, 1)   {a, r4, x}              {a, r0, x}
-(2, 2)   {a, r0, x}              {a, r0, x}
-(3, 0)   {a, r0, x}              {a, x}
-(4, 0)   {a}                     {}
-(5, 0)   {x}                     {}
-(6, 0)   {}                      {}
+(0, 3)   {a, i1, x}              {a, r0, x}
+(0, 4)   {a, r0, x}              {a, x}
+(1, 0)   {a}                     {}
+(2, 0)   {x}                     {}
+(3, 0)   {}                      {}
 
 [case testSpecial_Liveness]
 def f() -> int:
@@ -164,54 +135,32 @@ def f(a: int) -> None:
 [out]
 def f(a):
     a :: int
-    r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bit
+    r0 :: bit
     y, x :: int
 L0:
-    r1 = a & 1
-    r2 = r1 == 0
-    if r2 goto L1 else goto L2 :: bool
+    r0 = a == 2
+    if r0 goto L1 else goto L2 :: bool
 L1:
-    r3 = a == 2
-    r0 = r3
-    goto L3
-L2:
-    r4 = CPyTagged_IsEq_(a, 2)
-    r0 = r4
-L3:
-    if r0 goto L4 else goto L5 :: bool
-L4:
     y = 2
     x = 4
-    goto L6
-L5:
+    goto L3
+L2:
     x = 4
-L6:
+L3:
     return 1
 (0, 0)   {a}                     {a}
 (0, 1)   {a}                     {a}
 (0, 2)   {a}                     {a}
-(0, 3)   {a}                     {a}
-(0, 4)   {a}                     {a}
-(0, 5)   {a}                     {a}
 (1, 0)   {a}                     {a}
-(1, 1)   {a}                     {a, r0}
-(1, 2)   {a, r0}                 {a, r0}
+(1, 1)   {a}                     {a, y}
+(1, 2)   {a, y}                  {a, y}
+(1, 3)   {a, y}                  {a, x, y}
+(1, 4)   {a, x, y}               {a, x, y}
 (2, 0)   {a}                     {a}
-(2, 1)   {a}                     {a, r0}
-(2, 2)   {a, r0}                 {a, r0}
-(3, 0)   {a, r0}                 {a, r0}
-(4, 0)   {a, r0}                 {a, r0}
-(4, 1)   {a, r0}                 {a, r0, y}
-(4, 2)   {a, r0, y}              {a, r0, y}
-(4, 3)   {a, r0, y}              {a, r0, x, y}
-(4, 4)   {a, r0, x, y}           {a, r0, x, y}
-(5, 0)   {a, r0}                 {a, r0}
-(5, 1)   {a, r0}                 {a, r0, x}
-(5, 2)   {a, r0, x}              {a, r0, x}
-(6, 0)   {a, r0, x}              {a, r0, x}
-(6, 1)   {a, r0, x}              {a, r0, x}
+(2, 1)   {a}                     {a, x}
+(2, 2)   {a, x}                  {a, x}
+(3, 0)   {a, x}                  {a, x}
+(3, 1)   {a, x}                  {a, x}
 
 [case testTwoArgs_MustDefined]
 def f(x: int, y: int) -> int:
@@ -231,32 +180,29 @@ def f(n: int) -> None:
 [out]
 def f(n):
     n :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
-    r8, m :: int
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6, m :: int
 L0:
 L1:
-    r1 = n & 1
-    r2 = r1 == 0
-    r3 = 10 & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L2 else goto L3 :: bool
+    r0 = n & 1
+    r1 = r0 != 0
+    if r1 goto L3 else goto L2 :: bool
 L2:
-    r6 = n < 10 :: signed
-    r0 = r6
-    goto L4
+    r2 = 10 & 1
+    r3 = r2 != 0
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r7 = CPyTagged_IsLt_(n, 10)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(n, 10)
+    if r4 goto L5 else goto L6 :: bool
 L4:
-    if r0 goto L5 else goto L6 :: bool
+    r5 = n < 10 :: signed
+    if r5 goto L5 else goto L6 :: bool
 L5:
-    r8 = CPyTagged_Add(n, 2)
-    n = r8
+    r6 = CPyTagged_Add(n, 2)
+    n = r6
     m = n
     goto L1
 L6:
@@ -268,25 +214,22 @@ L6:
 (1, 3)   {n}                     {n}
 (1, 4)   {n}                     {n}
 (1, 5)   {n}                     {n}
-(1, 6)   {n}                     {n}
-(1, 7)   {n}                     {n}
-(1, 8)   {n}                     {n}
-(1, 9)   {n}                     {n}
-(1, 10)  {n}                     {n}
 (2, 0)   {n}                     {n}
-(2, 1)   {n}                     {n, r0}
-(2, 2)   {n, r0}                 {n, r0}
+(2, 1)   {n}                     {n}
+(2, 2)   {n}                     {n}
+(2, 3)   {n}                     {n}
+(2, 4)   {n}                     {n}
 (3, 0)   {n}                     {n}
-(3, 1)   {n}                     {n, r0}
-(3, 2)   {n, r0}                 {n, r0}
-(4, 0)   {n, r0}                 {n, r0}
-(5, 0)   {n, r0}                 {n, r0}
-(5, 1)   {n, r0}                 {n, r0}
-(5, 2)   {n, r0}                 {n, r0}
-(5, 3)   {n, r0}                 {m, n, r0}
-(5, 4)   {m, n, r0}              {m, n, r0}
-(6, 0)   {n, r0}                 {n, r0}
-(6, 1)   {n, r0}                 {n, r0}
+(3, 1)   {n}                     {n}
+(4, 0)   {n}                     {n}
+(4, 1)   {n}                     {n}
+(5, 0)   {n}                     {n}
+(5, 1)   {n}                     {n}
+(5, 2)   {n}                     {n}
+(5, 3)   {n}                     {m, n}
+(5, 4)   {m, n}                  {m, n}
+(6, 0)   {n}                     {n}
+(6, 1)   {n}                     {n}
 
 [case testMultiPass_Liveness]
 def f(n: int) -> None:
@@ -300,53 +243,47 @@ def f(n: int) -> None:
 [out]
 def f(n):
     n, x, y :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
-    r8 :: bool
-    r9 :: native_int
-    r10 :: bit
-    r11 :: native_int
-    r12, r13, r14, r15 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6 :: int64
+    r7 :: bit
+    r8 :: int64
+    r9, r10, r11 :: bit
 L0:
     x = 2
     y = 2
 L1:
-    r1 = n & 1
-    r2 = r1 == 0
-    r3 = 2 & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L2 else goto L3 :: bool
+    r0 = n & 1
+    r1 = r0 != 0
+    if r1 goto L3 else goto L2 :: bool
 L2:
-    r6 = n < 2 :: signed
-    r0 = r6
-    goto L4
+    r2 = 2 & 1
+    r3 = r2 != 0
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r7 = CPyTagged_IsLt_(n, 2)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(n, 2)
+    if r4 goto L5 else goto L12 :: bool
 L4:
-    if r0 goto L5 else goto L12 :: bool
+    r5 = n < 2 :: signed
+    if r5 goto L5 else goto L12 :: bool
 L5:
     n = y
 L6:
-    r9 = n & 1
-    r10 = r9 == 0
-    r11 = 4 & 1
-    r12 = r11 == 0
-    r13 = r10 & r12
-    if r13 goto L7 else goto L8 :: bool
+    r6 = n & 1
+    r7 = r6 != 0
+    if r7 goto L8 else goto L7 :: bool
 L7:
-    r14 = n < 4 :: signed
-    r8 = r14
-    goto L9
+    r8 = 4 & 1
+    r9 = r8 != 0
+    if r9 goto L8 else goto L9 :: bool
 L8:
-    r15 = CPyTagged_IsLt_(n, 4)
-    r8 = r15
+    r10 = CPyTagged_IsLt_(n, 4)
+    if r10 goto L10 else goto L11 :: bool
 L9:
-    if r8 goto L10 else goto L11 :: bool
+    r11 = n < 4 :: signed
+    if r11 goto L10 else goto L11 :: bool
 L10:
     n = 2
     n = x
@@ -362,42 +299,36 @@ L12:
 (0, 4)   {n, x, y}               {n, x, y}
 (1, 0)   {n, x, y}               {i2, n, x, y}
 (1, 1)   {i2, n, x, y}           {i2, i3, n, x, y}
-(1, 2)   {i2, i3, n, x, y}       {i2, n, r1, x, y}
-(1, 3)   {i2, n, r1, x, y}       {i2, i4, n, r1, x, y}
-(1, 4)   {i2, i4, n, r1, x, y}   {i2, n, r2, x, y}
-(1, 5)   {i2, n, r2, x, y}       {i2, i5, n, r2, x, y}
-(1, 6)   {i2, i5, n, r2, x, y}   {i2, n, r2, r3, x, y}
-(1, 7)   {i2, n, r2, r3, x, y}   {i2, i6, n, r2, r3, x, y}
-(1, 8)   {i2, i6, n, r2, r3, x, y} {i2, n, r2, r4, x, y}
-(1, 9)   {i2, n, r2, r4, x, y}   {i2, n, r5, x, y}
-(1, 10)  {i2, n, r5, x, y}       {i2, n, x, y}
-(2, 0)   {i2, n, x, y}           {r6, x, y}
-(2, 1)   {r6, x, y}              {r0, x, y}
-(2, 2)   {r0, x, y}              {r0, x, y}
-(3, 0)   {i2, n, x, y}           {r7, x, y}
-(3, 1)   {r7, x, y}              {r0, x, y}
-(3, 2)   {r0, x, y}              {r0, x, y}
-(4, 0)   {r0, x, y}              {x, y}
+(1, 2)   {i2, i3, n, x, y}       {i2, n, r0, x, y}
+(1, 3)   {i2, n, r0, x, y}       {i2, i4, n, r0, x, y}
+(1, 4)   {i2, i4, n, r0, x, y}   {i2, n, r1, x, y}
+(1, 5)   {i2, n, r1, x, y}       {i2, n, x, y}
+(2, 0)   {i2, n, x, y}           {i2, i5, n, x, y}
+(2, 1)   {i2, i5, n, x, y}       {i2, n, r2, x, y}
+(2, 2)   {i2, n, r2, x, y}       {i2, i6, n, r2, x, y}
+(2, 3)   {i2, i6, n, r2, x, y}   {i2, n, r3, x, y}
+(2, 4)   {i2, n, r3, x, y}       {i2, n, x, y}
+(3, 0)   {i2, n, x, y}           {r4, x, y}
+(3, 1)   {r4, x, y}              {x, y}
+(4, 0)   {i2, n, x, y}           {r5, x, y}
+(4, 1)   {r5, x, y}              {x, y}
 (5, 0)   {x, y}                  {n, x, y}
 (5, 1)   {n, x, y}               {n, x, y}
 (6, 0)   {n, x, y}               {i7, n, x, y}
 (6, 1)   {i7, n, x, y}           {i7, i8, n, x, y}
-(6, 2)   {i7, i8, n, x, y}       {i7, n, r9, x, y}
-(6, 3)   {i7, n, r9, x, y}       {i7, i9, n, r9, x, y}
-(6, 4)   {i7, i9, n, r9, x, y}   {i7, n, r10, x, y}
-(6, 5)   {i7, n, r10, x, y}      {i10, i7, n, r10, x, y}
-(6, 6)   {i10, i7, n, r10, x, y} {i7, n, r10, r11, x, y}
-(6, 7)   {i7, n, r10, r11, x, y} {i11, i7, n, r10, r11, x, y}
-(6, 8)   {i11, i7, n, r10, r11, x, y} {i7, n, r10, r12, x, y}
-(6, 9)   {i7, n, r10, r12, x, y} {i7, n, r13, x, y}
-(6, 10)  {i7, n, r13, x, y}      {i7, n, x, y}
-(7, 0)   {i7, n, x, y}           {n, r14, x, y}
-(7, 1)   {n, r14, x, y}          {n, r8, x, y}
-(7, 2)   {n, r8, x, y}           {n, r8, x, y}
-(8, 0)   {i7, n, x, y}           {n, r15, x, y}
-(8, 1)   {n, r15, x, y}          {n, r8, x, y}
-(8, 2)   {n, r8, x, y}           {n, r8, x, y}
-(9, 0)   {n, r8, x, y}           {n, x, y}
+(6, 2)   {i7, i8, n, x, y}       {i7, n, r6, x, y}
+(6, 3)   {i7, n, r6, x, y}       {i7, i9, n, r6, x, y}
+(6, 4)   {i7, i9, n, r6, x, y}   {i7, n, r7, x, y}
+(6, 5)   {i7, n, r7, x, y}       {i7, n, x, y}
+(7, 0)   {i7, n, x, y}           {i10, i7, n, x, y}
+(7, 1)   {i10, i7, n, x, y}      {i7, n, r8, x, y}
+(7, 2)   {i7, n, r8, x, y}       {i11, i7, n, r8, x, y}
+(7, 3)   {i11, i7, n, r8, x, y}  {i7, n, r9, x, y}
+(7, 4)   {i7, n, r9, x, y}       {i7, n, x, y}
+(8, 0)   {i7, n, x, y}           {n, r10, x, y}
+(8, 1)   {n, r10, x, y}          {n, x, y}
+(9, 0)   {i7, n, x, y}           {n, r11, x, y}
+(9, 1)   {n, r11, x, y}          {n, x, y}
 (10, 0)  {x, y}                  {i12, x, y}
 (10, 1)  {i12, x, y}             {x, y}
 (10, 2)  {x, y}                  {n, x, y}
@@ -446,51 +377,45 @@ def f(a: int) -> None:
 [out]
 def f(a):
     a :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
-    r8 :: bool
-    r9 :: native_int
-    r10 :: bit
-    r11 :: native_int
-    r12, r13, r14, r15 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6 :: int64
+    r7 :: bit
+    r8 :: int64
+    r9, r10, r11 :: bit
     y, x :: int
 L0:
 L1:
-    r1 = a & 1
-    r2 = r1 == 0
-    r3 = a & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L2 else goto L3 :: bool
+    r0 = a & 1
+    r1 = r0 != 0
+    if r1 goto L3 else goto L2 :: bool
 L2:
-    r6 = a < a :: signed
-    r0 = r6
-    goto L4
+    r2 = a & 1
+    r3 = r2 != 0
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r7 = CPyTagged_IsLt_(a, a)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(a, a)
+    if r4 goto L5 else goto L12 :: bool
 L4:
-    if r0 goto L5 else goto L12 :: bool
+    r5 = a < a :: signed
+    if r5 goto L5 else goto L12 :: bool
 L5:
 L6:
-    r9 = a & 1
-    r10 = r9 == 0
-    r11 = a & 1
-    r12 = r11 == 0
-    r13 = r10 & r12
-    if r13 goto L7 else goto L8 :: bool
+    r6 = a & 1
+    r7 = r6 != 0
+    if r7 goto L8 else goto L7 :: bool
 L7:
-    r14 = a < a :: signed
-    r8 = r14
-    goto L9
+    r8 = a & 1
+    r9 = r8 != 0
+    if r9 goto L8 else goto L9 :: bool
 L8:
-    r15 = CPyTagged_IsLt_(a, a)
-    r8 = r15
+    r10 = CPyTagged_IsLt_(a, a)
+    if r10 goto L10 else goto L11 :: bool
 L9:
-    if r8 goto L10 else goto L11 :: bool
+    r11 = a < a :: signed
+    if r11 goto L10 else goto L11 :: bool
 L10:
     y = a
     goto L6
@@ -500,47 +425,41 @@ L11:
 L12:
     return 1
 (0, 0)   {a}                     {a}
-(1, 0)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(1, 1)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(1, 2)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(1, 3)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(1, 4)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(1, 5)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(1, 6)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(1, 7)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(1, 8)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(1, 9)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(2, 0)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(2, 1)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(2, 2)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(3, 0)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(3, 1)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(3, 2)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(4, 0)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(5, 0)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(6, 0)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(6, 1)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(6, 2)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(6, 3)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(6, 4)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(6, 5)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(6, 6)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(6, 7)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(6, 8)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(6, 9)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(7, 0)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(7, 1)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(7, 2)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(8, 0)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(8, 1)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(8, 2)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(9, 0)   {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(10, 0)  {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(10, 1)  {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(11, 0)  {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(11, 1)  {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(12, 0)  {a, r0, r8, x, y}       {a, r0, r8, x, y}
-(12, 1)  {a, r0, r8, x, y}       {a, r0, r8, x, y}
+(1, 0)   {a, x, y}               {a, x, y}
+(1, 1)   {a, x, y}               {a, x, y}
+(1, 2)   {a, x, y}               {a, x, y}
+(1, 3)   {a, x, y}               {a, x, y}
+(1, 4)   {a, x, y}               {a, x, y}
+(2, 0)   {a, x, y}               {a, x, y}
+(2, 1)   {a, x, y}               {a, x, y}
+(2, 2)   {a, x, y}               {a, x, y}
+(2, 3)   {a, x, y}               {a, x, y}
+(2, 4)   {a, x, y}               {a, x, y}
+(3, 0)   {a, x, y}               {a, x, y}
+(3, 1)   {a, x, y}               {a, x, y}
+(4, 0)   {a, x, y}               {a, x, y}
+(4, 1)   {a, x, y}               {a, x, y}
+(5, 0)   {a, x, y}               {a, x, y}
+(6, 0)   {a, x, y}               {a, x, y}
+(6, 1)   {a, x, y}               {a, x, y}
+(6, 2)   {a, x, y}               {a, x, y}
+(6, 3)   {a, x, y}               {a, x, y}
+(6, 4)   {a, x, y}               {a, x, y}
+(7, 0)   {a, x, y}               {a, x, y}
+(7, 1)   {a, x, y}               {a, x, y}
+(7, 2)   {a, x, y}               {a, x, y}
+(7, 3)   {a, x, y}               {a, x, y}
+(7, 4)   {a, x, y}               {a, x, y}
+(8, 0)   {a, x, y}               {a, x, y}
+(8, 1)   {a, x, y}               {a, x, y}
+(9, 0)   {a, x, y}               {a, x, y}
+(9, 1)   {a, x, y}               {a, x, y}
+(10, 0)  {a, x, y}               {a, x, y}
+(10, 1)  {a, x, y}               {a, x, y}
+(11, 0)  {a, x, y}               {a, x, y}
+(11, 1)  {a, x, y}               {a, x, y}
+(12, 0)  {a, x, y}               {a, x, y}
+(12, 1)  {a, x, y}               {a, x, y}
 
 [case testTrivial_BorrowedArgument]
 def f(a: int, b: int) -> int:
@@ -580,30 +499,26 @@ def f(a: int) -> int:
 [out]
 def f(a):
     a :: int
-    r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bit
+    r0 :: int64
+    r1, r2, r3 :: bit
     x :: int
 L0:
-    r1 = a & 1
-    r2 = r1 == 0
-    if r2 goto L1 else goto L2 :: bool
+    r0 = a & 1
+    r1 = r0 != 0
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r3 = a == a
-    r0 = r3
-    goto L3
+    r2 = CPyTagged_IsEq_(a, a)
+    if r2 goto L3 else goto L4 :: bool
 L2:
-    r4 = CPyTagged_IsEq_(a, a)
-    r0 = r4
+    r3 = a == a
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    if r0 goto L4 else goto L5 :: bool
-L4:
     x = 4
     a = 2
-    goto L6
-L5:
+    goto L5
+L4:
     x = 2
-L6:
+L5:
     return x
 (0, 0)   {a}                     {a}
 (0, 1)   {a}                     {a}
@@ -612,20 +527,17 @@ L6:
 (0, 4)   {a}                     {a}
 (1, 0)   {a}                     {a}
 (1, 1)   {a}                     {a}
-(1, 2)   {a}                     {a}
 (2, 0)   {a}                     {a}
 (2, 1)   {a}                     {a}
-(2, 2)   {a}                     {a}
 (3, 0)   {a}                     {a}
+(3, 1)   {a}                     {a}
+(3, 2)   {a}                     {a}
+(3, 3)   {a}                     {}
+(3, 4)   {}                      {}
 (4, 0)   {a}                     {a}
 (4, 1)   {a}                     {a}
 (4, 2)   {a}                     {a}
-(4, 3)   {a}                     {}
-(4, 4)   {}                      {}
-(5, 0)   {a}                     {a}
-(5, 1)   {a}                     {a}
-(5, 2)   {a}                     {a}
-(6, 0)   {}                      {}
+(5, 0)   {}                      {}
 
 [case testLoop_BorrowedArgument]
 def f(a: int) -> int:
@@ -638,37 +550,33 @@ def f(a: int) -> int:
 [out]
 def f(a):
     a, sum, i :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7, r8 :: bit
-    r9, r10 :: int
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6, r7 :: int
 L0:
     sum = 0
     i = 0
 L1:
-    r1 = i & 1
-    r2 = r1 == 0
-    r3 = a & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L2 else goto L3 :: bool
+    r0 = i & 1
+    r1 = r0 != 0
+    if r1 goto L3 else goto L2 :: bool
 L2:
-    r6 = i <= a :: signed
-    r0 = r6
-    goto L4
+    r2 = a & 1
+    r3 = r2 != 0
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r7 = CPyTagged_IsLt_(a, i)
-    r8 = r7 ^ 1
-    r0 = r8
+    r4 = CPyTagged_IsLt_(a, i)
+    if r4 goto L6 else goto L5 :: bool
 L4:
-    if r0 goto L5 else goto L6 :: bool
+    r5 = i <= a :: signed
+    if r5 goto L5 else goto L6 :: bool
 L5:
-    r9 = CPyTagged_Add(sum, i)
-    sum = r9
-    r10 = CPyTagged_Add(i, 2)
-    i = r10
+    r6 = CPyTagged_Add(sum, i)
+    sum = r6
+    r7 = CPyTagged_Add(i, 2)
+    i = r7
     goto L1
 L6:
     return sum
@@ -682,20 +590,15 @@ L6:
 (1, 2)   {a}                     {a}
 (1, 3)   {a}                     {a}
 (1, 4)   {a}                     {a}
-(1, 5)   {a}                     {a}
-(1, 6)   {a}                     {a}
-(1, 7)   {a}                     {a}
-(1, 8)   {a}                     {a}
-(1, 9)   {a}                     {a}
 (2, 0)   {a}                     {a}
 (2, 1)   {a}                     {a}
 (2, 2)   {a}                     {a}
+(2, 3)   {a}                     {a}
+(2, 4)   {a}                     {a}
 (3, 0)   {a}                     {a}
 (3, 1)   {a}                     {a}
-(3, 2)   {a}                     {a}
-(3, 3)   {a}                     {a}
-(3, 4)   {a}                     {a}
 (4, 0)   {a}                     {a}
+(4, 1)   {a}                     {a}
 (5, 0)   {a}                     {a}
 (5, 1)   {a}                     {a}
 (5, 2)   {a}                     {a}

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -73,10 +73,10 @@ def f(x):
     x :: union[__main__.A, None]
     r0 :: object
     r1 :: bit
-    r2, r3 :: __main__.A
-    r4 :: object
-    r5, r6 :: bit
-    r7 :: int
+    r2 :: __main__.A
+    r3 :: object
+    r4, r5 :: bit
+    r6 :: int
 L0:
     r0 = box(None, 1)
     r1 = x == r0
@@ -86,27 +86,20 @@ L1:
 L2:
     inc_ref x
     r2 = cast(__main__.A, x)
-    if is_error(r2) goto L7 (error at f:8) else goto L8
+    if is_error(r2) goto L6 (error at f:8) else goto L3
 L3:
-    inc_ref x
-    r3 = cast(__main__.A, x)
-    if is_error(r3) goto L7 (error at f:8) else goto L4
-L4:
-    r4 = box(None, 1)
-    r5 = r3 == r4
-    dec_ref r3
-    r6 = r5 ^ 1
-    if r6 goto L5 else goto L6 :: bool
-L5:
-    return 4
-L6:
-    return 6
-L7:
-    r7 = <error> :: int
-    return r7
-L8:
+    r3 = box(None, 1)
+    r4 = r2 == r3
     dec_ref r2
-    goto L3
+    r5 = r4 ^ 1
+    if r5 goto L4 else goto L5 :: bool
+L4:
+    return 4
+L5:
+    return 6
+L6:
+    r6 = <error> :: int
+    return r6
 
 [case testListSum]
 from typing import List

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -73,10 +73,10 @@ def f(x):
     x :: union[__main__.A, None]
     r0 :: object
     r1 :: bit
-    r2 :: __main__.A
-    r3 :: object
-    r4, r5 :: bit
-    r6 :: int
+    r2, r3 :: __main__.A
+    r4 :: object
+    r5, r6 :: bit
+    r7 :: int
 L0:
     r0 = box(None, 1)
     r1 = x == r0
@@ -86,20 +86,27 @@ L1:
 L2:
     inc_ref x
     r2 = cast(__main__.A, x)
-    if is_error(r2) goto L6 (error at f:8) else goto L3
+    if is_error(r2) goto L7 (error at f:8) else goto L8
 L3:
-    r3 = box(None, 1)
-    r4 = r2 == r3
-    dec_ref r2
-    r5 = r4 ^ 1
-    if r5 goto L4 else goto L5 :: bool
+    inc_ref x
+    r3 = cast(__main__.A, x)
+    if is_error(r3) goto L7 (error at f:8) else goto L4
 L4:
-    return 4
+    r4 = box(None, 1)
+    r5 = r3 == r4
+    dec_ref r3
+    r6 = r5 ^ 1
+    if r6 goto L5 else goto L6 :: bool
 L5:
-    return 6
+    return 4
 L6:
-    r6 = <error> :: int
-    return r6
+    return 6
+L7:
+    r7 = <error> :: int
+    return r7
+L8:
+    dec_ref r2
+    goto L3
 
 [case testListSum]
 from typing import List
@@ -114,53 +121,50 @@ def sum(a: List[int], l: int) -> int:
 def sum(a, l):
     a :: list
     l, sum, i :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
-    r8 :: object
-    r9, r10, r11, r12 :: int
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6 :: object
+    r7, r8, r9, r10 :: int
 L0:
     sum = 0
     i = 0
 L1:
-    r1 = i & 1
-    r2 = r1 == 0
-    r3 = l & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L2 else goto L3 :: bool
+    r0 = i & 1
+    r1 = r0 != 0
+    if r1 goto L3 else goto L2 :: bool
 L2:
-    r6 = i < l :: signed
-    r0 = r6
-    goto L4
+    r2 = l & 1
+    r3 = r2 != 0
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r7 = CPyTagged_IsLt_(i, l)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(i, l)
+    if r4 goto L5 else goto L10 :: bool
 L4:
-    if r0 goto L5 else goto L10 :: bool
+    r5 = i < l :: signed
+    if r5 goto L5 else goto L10 :: bool
 L5:
-    r8 = CPyList_GetItem(a, i)
-    if is_error(r8) goto L11 (error at sum:6) else goto L6
+    r6 = CPyList_GetItem(a, i)
+    if is_error(r6) goto L11 (error at sum:6) else goto L6
 L6:
-    r9 = unbox(int, r8)
-    dec_ref r8
-    if is_error(r9) goto L11 (error at sum:6) else goto L7
+    r7 = unbox(int, r6)
+    dec_ref r6
+    if is_error(r7) goto L11 (error at sum:6) else goto L7
 L7:
-    r10 = CPyTagged_Add(sum, r9)
+    r8 = CPyTagged_Add(sum, r7)
     dec_ref sum :: int
-    dec_ref r9 :: int
-    sum = r10
-    r11 = CPyTagged_Add(i, 2)
+    dec_ref r7 :: int
+    sum = r8
+    r9 = CPyTagged_Add(i, 2)
     dec_ref i :: int
-    i = r11
+    i = r9
     goto L1
 L8:
     return sum
 L9:
-    r12 = <error> :: int
-    return r12
+    r10 = <error> :: int
+    return r10
 L10:
     dec_ref i :: int
     goto L8

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -121,9 +121,9 @@ def sum(a: List[int], l: int) -> int:
 def sum(a, l):
     a :: list
     l, sum, i :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
     r6 :: object
     r7, r8, r9, r10 :: int

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -509,35 +509,29 @@ def f(n: int) -> int:
 [out]
 def f(n):
     n :: int
-    r0 :: native_int
-    r1 :: bit
-    r2 :: native_int
-    r3, r4, r5 :: bit
-    r6, r7, r8, r9, r10 :: int
+    r0 :: int64
+    r1, r2, r3 :: bit
+    r4, r5, r6, r7, r8 :: int
 L0:
     r0 = n & 1
     r1 = r0 != 0
-    if r1 goto L2 else goto L1 :: bool
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r2 = 2 & 1
-    r3 = r2 != 0
-    if r3 goto L2 else goto L3 :: bool
+    r2 = CPyTagged_IsLt_(2, n)
+    if r2 goto L4 else goto L3 :: bool
 L2:
-    r4 = CPyTagged_IsLt_(2, n)
-    if r4 goto L5 else goto L4 :: bool
+    r3 = n <= 2 :: signed
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r5 = n <= 2 :: signed
-    if r5 goto L4 else goto L5 :: bool
-L4:
     return 2
-L5:
-    r6 = CPyTagged_Subtract(n, 2)
+L4:
+    r4 = CPyTagged_Subtract(n, 2)
+    r5 = f(r4)
+    r6 = CPyTagged_Subtract(n, 4)
     r7 = f(r6)
-    r8 = CPyTagged_Subtract(n, 4)
-    r9 = f(r8)
-    r10 = CPyTagged_Add(r7, r9)
-    return r10
-L6:
+    r8 = CPyTagged_Add(r5, r7)
+    return r8
+L5:
     unreachable
 
 [case testReportTypeCheckError]
@@ -564,39 +558,33 @@ def f(n: int) -> int:
 [out]
 def f(n):
     n :: int
-    r0 :: native_int
-    r1 :: bit
-    r2 :: native_int
-    r3, r4, r5 :: bit
+    r0 :: int64
+    r1, r2, r3 :: bit
     x :: int
-    r6 :: bit
+    r4 :: bit
 L0:
     r0 = n & 1
     r1 = r0 != 0
-    if r1 goto L2 else goto L1 :: bool
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r2 = 0 & 1
-    r3 = r2 != 0
-    if r3 goto L2 else goto L3 :: bool
+    r2 = CPyTagged_IsLt_(n, 0)
+    if r2 goto L3 else goto L4 :: bool
 L2:
-    r4 = CPyTagged_IsLt_(n, 0)
-    if r4 goto L4 else goto L5 :: bool
+    r3 = n < 0 :: signed
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r5 = n < 0 :: signed
-    if r5 goto L4 else goto L5 :: bool
-L4:
-    x = 2
-    goto L9
-L5:
-    r6 = n == 0
-    if r6 goto L6 else goto L7 :: bool
-L6:
     x = 2
     goto L8
-L7:
+L4:
+    r4 = n == 0
+    if r4 goto L5 else goto L6 :: bool
+L5:
+    x = 2
+    goto L7
+L6:
     x = 4
+L7:
 L8:
-L9:
     return x
 
 [case testUnaryMinus]
@@ -1138,33 +1126,27 @@ def call_callable_type() -> float:
 [out]
 def absolute_value(x):
     x :: int
-    r0 :: native_int
-    r1 :: bit
-    r2 :: native_int
-    r3, r4, r5 :: bit
-    r6, r7 :: int
+    r0 :: int64
+    r1, r2, r3 :: bit
+    r4, r5 :: int
 L0:
     r0 = x & 1
     r1 = r0 != 0
-    if r1 goto L2 else goto L1 :: bool
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r2 = 0 & 1
-    r3 = r2 != 0
-    if r3 goto L2 else goto L3 :: bool
+    r2 = CPyTagged_IsLt_(0, x)
+    if r2 goto L3 else goto L4 :: bool
 L2:
-    r4 = CPyTagged_IsLt_(0, x)
-    if r4 goto L4 else goto L5 :: bool
+    r3 = x > 0 :: signed
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r5 = x > 0 :: signed
-    if r5 goto L4 else goto L5 :: bool
+    r4 = x
+    goto L5
 L4:
-    r6 = x
-    goto L6
+    r5 = CPyTagged_Negate(x)
+    r4 = r5
 L5:
-    r7 = CPyTagged_Negate(x)
-    r6 = r7
-L6:
-    return r6
+    return r4
 def call_native_function(x):
     x, r0 :: int
 L0:

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -76,9 +76,9 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
 L0:
     r0 = x & 1
@@ -109,9 +109,9 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
 L0:
     r0 = x & 1
@@ -145,13 +145,13 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
-    r6 :: int64
+    r6 :: native_int
     r7 :: bit
-    r8 :: int64
+    r8 :: native_int
     r9, r10, r11 :: bit
 L0:
     r0 = x & 1
@@ -225,13 +225,13 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
-    r6 :: int64
+    r6 :: native_int
     r7 :: bit
-    r8 :: int64
+    r8 :: native_int
     r9, r10, r11 :: bit
 L0:
     r0 = x & 1
@@ -303,9 +303,9 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
 L0:
     r0 = x & 1
@@ -334,13 +334,13 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
-    r6 :: int64
+    r6 :: native_int
     r7 :: bit
-    r8 :: int64
+    r8 :: native_int
     r9, r10, r11 :: bit
 L0:
     r0 = x & 1
@@ -383,9 +383,9 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
     r6 :: int
 L0:
@@ -419,9 +419,9 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
     r6 :: int
 L0:
@@ -474,9 +474,9 @@ def f(x: int, y: int) -> None:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
 L0:
     r0 = x & 1
@@ -509,9 +509,9 @@ def f(n: int) -> int:
 [out]
 def f(n):
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
     r6, r7, r8, r9, r10 :: int
 L0:
@@ -564,9 +564,9 @@ def f(n: int) -> int:
 [out]
 def f(n):
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
     x :: int
     r6 :: bit
@@ -1138,9 +1138,9 @@ def call_callable_type() -> float:
 [out]
 def absolute_value(x):
     x :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
     r6, r7 :: int
 L0:

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -509,7 +509,7 @@ def f(n: int) -> int:
 [out]
 def f(n):
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
     r4, r5, r6, r7, r8 :: int
 L0:
@@ -558,7 +558,7 @@ def f(n: int) -> int:
 [out]
 def f(n):
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
     x :: int
     r4 :: bit
@@ -1126,7 +1126,7 @@ def call_callable_type() -> float:
 [out]
 def absolute_value(x):
     x :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
     r4, r5 :: int
 L0:

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -76,27 +76,24 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
 L0:
-    r1 = x & 1
-    r2 = r1 == 0
-    r3 = y & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L1 else goto L2 :: bool
+    r0 = x & 1
+    r1 = r0 != 0
+    if r1 goto L2 else goto L1 :: bool
 L1:
-    r6 = x < y :: signed
-    r0 = r6
-    goto L3
+    r2 = y & 1
+    r3 = r2 != 0
+    if r3 goto L2 else goto L3 :: bool
 L2:
-    r7 = CPyTagged_IsLt_(x, y)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(x, y)
+    if r4 goto L4 else goto L5 :: bool
 L3:
-    if r0 goto L4 else goto L5 :: bool
+    r5 = x < y :: signed
+    if r5 goto L4 else goto L5 :: bool
 L4:
     x = 2
 L5:
@@ -112,27 +109,24 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
 L0:
-    r1 = x & 1
-    r2 = r1 == 0
-    r3 = y & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L1 else goto L2 :: bool
+    r0 = x & 1
+    r1 = r0 != 0
+    if r1 goto L2 else goto L1 :: bool
 L1:
-    r6 = x < y :: signed
-    r0 = r6
-    goto L3
+    r2 = y & 1
+    r3 = r2 != 0
+    if r3 goto L2 else goto L3 :: bool
 L2:
-    r7 = CPyTagged_IsLt_(x, y)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(x, y)
+    if r4 goto L4 else goto L5 :: bool
 L3:
-    if r0 goto L4 else goto L5 :: bool
+    r5 = x < y :: signed
+    if r5 goto L4 else goto L5 :: bool
 L4:
     x = 2
     goto L6
@@ -151,48 +145,42 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
-    r8 :: bool
-    r9 :: native_int
-    r10 :: bit
-    r11 :: native_int
-    r12, r13, r14, r15 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6 :: int64
+    r7 :: bit
+    r8 :: int64
+    r9, r10, r11 :: bit
 L0:
-    r1 = x & 1
-    r2 = r1 == 0
-    r3 = y & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L1 else goto L2 :: bool
+    r0 = x & 1
+    r1 = r0 != 0
+    if r1 goto L2 else goto L1 :: bool
 L1:
-    r6 = x < y :: signed
-    r0 = r6
-    goto L3
+    r2 = y & 1
+    r3 = r2 != 0
+    if r3 goto L2 else goto L3 :: bool
 L2:
-    r7 = CPyTagged_IsLt_(x, y)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(x, y)
+    if r4 goto L4 else goto L9 :: bool
 L3:
-    if r0 goto L4 else goto L9 :: bool
+    r5 = x < y :: signed
+    if r5 goto L4 else goto L9 :: bool
 L4:
-    r9 = x & 1
-    r10 = r9 == 0
-    r11 = y & 1
-    r12 = r11 == 0
-    r13 = r10 & r12
-    if r13 goto L5 else goto L6 :: bool
+    r6 = x & 1
+    r7 = r6 != 0
+    if r7 goto L6 else goto L5 :: bool
 L5:
-    r14 = x > y :: signed
-    r8 = r14
-    goto L7
+    r8 = y & 1
+    r9 = r8 != 0
+    if r9 goto L6 else goto L7 :: bool
 L6:
-    r15 = CPyTagged_IsLt_(y, x)
-    r8 = r15
+    r10 = CPyTagged_IsLt_(y, x)
+    if r10 goto L8 else goto L9 :: bool
 L7:
-    if r8 goto L8 else goto L9 :: bool
+    r11 = x > y :: signed
+    if r11 goto L8 else goto L9 :: bool
 L8:
     x = 2
     goto L10
@@ -237,48 +225,42 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
-    r8 :: bool
-    r9 :: native_int
-    r10 :: bit
-    r11 :: native_int
-    r12, r13, r14, r15 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6 :: int64
+    r7 :: bit
+    r8 :: int64
+    r9, r10, r11 :: bit
 L0:
-    r1 = x & 1
-    r2 = r1 == 0
-    r3 = y & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L1 else goto L2 :: bool
+    r0 = x & 1
+    r1 = r0 != 0
+    if r1 goto L2 else goto L1 :: bool
 L1:
-    r6 = x < y :: signed
-    r0 = r6
-    goto L3
+    r2 = y & 1
+    r3 = r2 != 0
+    if r3 goto L2 else goto L3 :: bool
 L2:
-    r7 = CPyTagged_IsLt_(x, y)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(x, y)
+    if r4 goto L8 else goto L4 :: bool
 L3:
-    if r0 goto L8 else goto L4 :: bool
+    r5 = x < y :: signed
+    if r5 goto L8 else goto L4 :: bool
 L4:
-    r9 = x & 1
-    r10 = r9 == 0
-    r11 = y & 1
-    r12 = r11 == 0
-    r13 = r10 & r12
-    if r13 goto L5 else goto L6 :: bool
+    r6 = x & 1
+    r7 = r6 != 0
+    if r7 goto L6 else goto L5 :: bool
 L5:
-    r14 = x > y :: signed
-    r8 = r14
-    goto L7
+    r8 = y & 1
+    r9 = r8 != 0
+    if r9 goto L6 else goto L7 :: bool
 L6:
-    r15 = CPyTagged_IsLt_(y, x)
-    r8 = r15
+    r10 = CPyTagged_IsLt_(y, x)
+    if r10 goto L8 else goto L9 :: bool
 L7:
-    if r8 goto L8 else goto L9 :: bool
+    r11 = x > y :: signed
+    if r11 goto L8 else goto L9 :: bool
 L8:
     x = 2
     goto L10
@@ -321,27 +303,24 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
 L0:
-    r1 = x & 1
-    r2 = r1 == 0
-    r3 = y & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L1 else goto L2 :: bool
+    r0 = x & 1
+    r1 = r0 != 0
+    if r1 goto L2 else goto L1 :: bool
 L1:
-    r6 = x < y :: signed
-    r0 = r6
-    goto L3
+    r2 = y & 1
+    r3 = r2 != 0
+    if r3 goto L2 else goto L3 :: bool
 L2:
-    r7 = CPyTagged_IsLt_(x, y)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(x, y)
+    if r4 goto L5 else goto L4 :: bool
 L3:
-    if r0 goto L5 else goto L4 :: bool
+    r5 = x < y :: signed
+    if r5 goto L5 else goto L4 :: bool
 L4:
     x = 2
 L5:
@@ -355,48 +334,42 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
-    r8 :: bool
-    r9 :: native_int
-    r10 :: bit
-    r11 :: native_int
-    r12, r13, r14, r15 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6 :: int64
+    r7 :: bit
+    r8 :: int64
+    r9, r10, r11 :: bit
 L0:
-    r1 = x & 1
-    r2 = r1 == 0
-    r3 = y & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L1 else goto L2 :: bool
+    r0 = x & 1
+    r1 = r0 != 0
+    if r1 goto L2 else goto L1 :: bool
 L1:
-    r6 = x < y :: signed
-    r0 = r6
-    goto L3
+    r2 = y & 1
+    r3 = r2 != 0
+    if r3 goto L2 else goto L3 :: bool
 L2:
-    r7 = CPyTagged_IsLt_(x, y)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(x, y)
+    if r4 goto L4 else goto L8 :: bool
 L3:
-    if r0 goto L4 else goto L8 :: bool
+    r5 = x < y :: signed
+    if r5 goto L4 else goto L8 :: bool
 L4:
-    r9 = x & 1
-    r10 = r9 == 0
-    r11 = y & 1
-    r12 = r11 == 0
-    r13 = r10 & r12
-    if r13 goto L5 else goto L6 :: bool
+    r6 = x & 1
+    r7 = r6 != 0
+    if r7 goto L6 else goto L5 :: bool
 L5:
-    r14 = x > y :: signed
-    r8 = r14
-    goto L7
+    r8 = y & 1
+    r9 = r8 != 0
+    if r9 goto L6 else goto L7 :: bool
 L6:
-    r15 = CPyTagged_IsLt_(y, x)
-    r8 = r15
+    r10 = CPyTagged_IsLt_(y, x)
+    if r10 goto L9 else goto L8 :: bool
 L7:
-    if r8 goto L9 else goto L8 :: bool
+    r11 = x > y :: signed
+    if r11 goto L9 else goto L8 :: bool
 L8:
     x = 2
 L9:
@@ -410,32 +383,29 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
-    r8 :: int
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6 :: int
 L0:
 L1:
-    r1 = x & 1
-    r2 = r1 == 0
-    r3 = y & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L2 else goto L3 :: bool
+    r0 = x & 1
+    r1 = r0 != 0
+    if r1 goto L3 else goto L2 :: bool
 L2:
-    r6 = x > y :: signed
-    r0 = r6
-    goto L4
+    r2 = y & 1
+    r3 = r2 != 0
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r7 = CPyTagged_IsLt_(y, x)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(y, x)
+    if r4 goto L5 else goto L6 :: bool
 L4:
-    if r0 goto L5 else goto L6 :: bool
+    r5 = x > y :: signed
+    if r5 goto L5 else goto L6 :: bool
 L5:
-    r8 = CPyTagged_Subtract(x, y)
-    x = r8
+    r6 = CPyTagged_Subtract(x, y)
+    x = r6
     goto L1
 L6:
     return x
@@ -449,33 +419,30 @@ def f(x: int, y: int) -> int:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
-    r8 :: int
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6 :: int
 L0:
     x = 2
 L1:
-    r1 = x & 1
-    r2 = r1 == 0
-    r3 = y & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L2 else goto L3 :: bool
+    r0 = x & 1
+    r1 = r0 != 0
+    if r1 goto L3 else goto L2 :: bool
 L2:
-    r6 = x > y :: signed
-    r0 = r6
-    goto L4
+    r2 = y & 1
+    r3 = r2 != 0
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r7 = CPyTagged_IsLt_(y, x)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(y, x)
+    if r4 goto L5 else goto L6 :: bool
 L4:
-    if r0 goto L5 else goto L6 :: bool
+    r5 = x > y :: signed
+    if r5 goto L5 else goto L6 :: bool
 L5:
-    r8 = CPyTagged_Subtract(x, y)
-    x = r8
+    r6 = CPyTagged_Subtract(x, y)
+    x = r6
     goto L1
 L6:
     return x
@@ -507,27 +474,24 @@ def f(x: int, y: int) -> None:
 [out]
 def f(x, y):
     x, y :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
 L0:
-    r1 = x & 1
-    r2 = r1 == 0
-    r3 = y & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L1 else goto L2 :: bool
+    r0 = x & 1
+    r1 = r0 != 0
+    if r1 goto L2 else goto L1 :: bool
 L1:
-    r6 = x < y :: signed
-    r0 = r6
-    goto L3
+    r2 = y & 1
+    r3 = r2 != 0
+    if r3 goto L2 else goto L3 :: bool
 L2:
-    r7 = CPyTagged_IsLt_(x, y)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(x, y)
+    if r4 goto L4 else goto L5 :: bool
 L3:
-    if r0 goto L4 else goto L5 :: bool
+    r5 = x < y :: signed
+    if r5 goto L4 else goto L5 :: bool
 L4:
     x = 2
     goto L6
@@ -545,38 +509,34 @@ def f(n: int) -> int:
 [out]
 def f(n):
     n :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7, r8 :: bit
-    r9, r10, r11, r12, r13 :: int
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6, r7, r8, r9, r10 :: int
 L0:
-    r1 = n & 1
-    r2 = r1 == 0
-    r3 = 2 & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L1 else goto L2 :: bool
+    r0 = n & 1
+    r1 = r0 != 0
+    if r1 goto L2 else goto L1 :: bool
 L1:
-    r6 = n <= 2 :: signed
-    r0 = r6
-    goto L3
+    r2 = 2 & 1
+    r3 = r2 != 0
+    if r3 goto L2 else goto L3 :: bool
 L2:
-    r7 = CPyTagged_IsLt_(2, n)
-    r8 = r7 ^ 1
-    r0 = r8
+    r4 = CPyTagged_IsLt_(2, n)
+    if r4 goto L5 else goto L4 :: bool
 L3:
-    if r0 goto L4 else goto L5 :: bool
+    r5 = n <= 2 :: signed
+    if r5 goto L4 else goto L5 :: bool
 L4:
     return 2
 L5:
-    r9 = CPyTagged_Subtract(n, 2)
-    r10 = f(r9)
-    r11 = CPyTagged_Subtract(n, 4)
-    r12 = f(r11)
-    r13 = CPyTagged_Add(r10, r12)
-    return r13
+    r6 = CPyTagged_Subtract(n, 2)
+    r7 = f(r6)
+    r8 = CPyTagged_Subtract(n, 4)
+    r9 = f(r8)
+    r10 = CPyTagged_Add(r7, r9)
+    return r10
 L6:
     unreachable
 
@@ -604,54 +564,39 @@ def f(n: int) -> int:
 [out]
 def f(n):
     n :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
     x :: int
-    r8 :: bool
-    r9 :: native_int
-    r10, r11, r12 :: bit
+    r6 :: bit
 L0:
-    r1 = n & 1
-    r2 = r1 == 0
-    r3 = 0 & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L1 else goto L2 :: bool
+    r0 = n & 1
+    r1 = r0 != 0
+    if r1 goto L2 else goto L1 :: bool
 L1:
-    r6 = n < 0 :: signed
-    r0 = r6
-    goto L3
+    r2 = 0 & 1
+    r3 = r2 != 0
+    if r3 goto L2 else goto L3 :: bool
 L2:
-    r7 = CPyTagged_IsLt_(n, 0)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(n, 0)
+    if r4 goto L4 else goto L5 :: bool
 L3:
-    if r0 goto L4 else goto L5 :: bool
+    r5 = n < 0 :: signed
+    if r5 goto L4 else goto L5 :: bool
 L4:
     x = 2
-    goto L12
+    goto L9
 L5:
-    r9 = n & 1
-    r10 = r9 == 0
-    if r10 goto L6 else goto L7 :: bool
+    r6 = n == 0
+    if r6 goto L6 else goto L7 :: bool
 L6:
-    r11 = n == 0
-    r8 = r11
+    x = 2
     goto L8
 L7:
-    r12 = CPyTagged_IsEq_(n, 0)
-    r8 = r12
-L8:
-    if r8 goto L9 else goto L10 :: bool
-L9:
-    x = 2
-    goto L11
-L10:
     x = 4
-L11:
-L12:
+L8:
+L9:
     return x
 
 [case testUnaryMinus]
@@ -670,30 +615,18 @@ def f(n: int) -> int:
 [out]
 def f(n):
     n :: int
-    r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bit
-    r5 :: int
+    r0 :: bit
+    r1 :: int
 L0:
-    r1 = n & 1
-    r2 = r1 == 0
-    if r2 goto L1 else goto L2 :: bool
+    r0 = n == 0
+    if r0 goto L1 else goto L2 :: bool
 L1:
-    r3 = n == 0
-    r0 = r3
+    r1 = 0
     goto L3
 L2:
-    r4 = CPyTagged_IsEq_(n, 0)
-    r0 = r4
+    r1 = 2
 L3:
-    if r0 goto L4 else goto L5 :: bool
-L4:
-    r5 = 0
-    goto L6
-L5:
-    r5 = 2
-L6:
-    return r5
+    return r1
 
 [case testOperatorAssignment]
 def f() -> int:
@@ -1205,36 +1138,33 @@ def call_callable_type() -> float:
 [out]
 def absolute_value(x):
     x :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
-    r8, r9 :: int
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6, r7 :: int
 L0:
-    r1 = x & 1
-    r2 = r1 == 0
-    r3 = 0 & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L1 else goto L2 :: bool
+    r0 = x & 1
+    r1 = r0 != 0
+    if r1 goto L2 else goto L1 :: bool
 L1:
-    r6 = x > 0 :: signed
-    r0 = r6
-    goto L3
+    r2 = 0 & 1
+    r3 = r2 != 0
+    if r3 goto L2 else goto L3 :: bool
 L2:
-    r7 = CPyTagged_IsLt_(0, x)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(0, x)
+    if r4 goto L4 else goto L5 :: bool
 L3:
-    if r0 goto L4 else goto L5 :: bool
+    r5 = x > 0 :: signed
+    if r5 goto L4 else goto L5 :: bool
 L4:
-    r8 = x
+    r6 = x
     goto L6
 L5:
-    r9 = CPyTagged_Negate(x)
-    r8 = r9
+    r7 = CPyTagged_Negate(x)
+    r6 = r7
 L6:
-    return r8
+    return r6
 def call_native_function(x):
     x, r0 :: int
 L0:

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -113,24 +113,25 @@ class Node:
 [out]
 def Node.length(self):
     self :: __main__.Node
-    r0 :: union[__main__.Node, None]
-    r1 :: object
-    r2, r3 :: bit
-    r4 :: union[__main__.Node, None]
-    r5 :: __main__.Node
-    r6, r7 :: int
+    r0, r1 :: union[__main__.Node, None]
+    r2 :: object
+    r3, r4 :: bit
+    r5 :: union[__main__.Node, None]
+    r6 :: __main__.Node
+    r7, r8 :: int
 L0:
     r0 = self.next
-    r1 = box(None, 1)
-    r2 = r0 == r1
-    r3 = r2 ^ 1
-    if r3 goto L1 else goto L2 :: bool
+    r1 = self.next
+    r2 = box(None, 1)
+    r3 = r1 == r2
+    r4 = r3 ^ 1
+    if r4 goto L1 else goto L2 :: bool
 L1:
-    r4 = self.next
-    r5 = cast(__main__.Node, r4)
-    r6 = r5.length()
-    r7 = CPyTagged_Add(2, r6)
-    return r7
+    r5 = self.next
+    r6 = cast(__main__.Node, r5)
+    r7 = r6.length()
+    r8 = CPyTagged_Add(2, r7)
+    return r8
 L2:
     return 2
 

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -113,25 +113,24 @@ class Node:
 [out]
 def Node.length(self):
     self :: __main__.Node
-    r0, r1 :: union[__main__.Node, None]
-    r2 :: object
-    r3, r4 :: bit
-    r5 :: union[__main__.Node, None]
-    r6 :: __main__.Node
-    r7, r8 :: int
+    r0 :: union[__main__.Node, None]
+    r1 :: object
+    r2, r3 :: bit
+    r4 :: union[__main__.Node, None]
+    r5 :: __main__.Node
+    r6, r7 :: int
 L0:
     r0 = self.next
-    r1 = self.next
-    r2 = box(None, 1)
-    r3 = r1 == r2
-    r4 = r3 ^ 1
-    if r4 goto L1 else goto L2 :: bool
+    r1 = box(None, 1)
+    r2 = r0 == r1
+    r3 = r2 ^ 1
+    if r3 goto L1 else goto L2 :: bool
 L1:
-    r5 = self.next
-    r6 = cast(__main__.Node, r5)
-    r7 = r6.length()
-    r8 = CPyTagged_Add(2, r7)
-    return r8
+    r4 = self.next
+    r5 = cast(__main__.Node, r4)
+    r6 = r5.length()
+    r7 = CPyTagged_Add(2, r6)
+    return r7
 L2:
     return 2
 

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -21,3 +21,61 @@ L2:
     r0 = r5
 L3:
     return r0
+
+[case testShortIntComparisons]
+def f(x: int) -> int:
+    if x == 3:
+        return 1
+    elif x != 4:
+        return 2
+    elif 5 == x:
+        return 3
+    elif 6 != x:
+        return 4
+    elif x < 4:
+        return 5
+    return 6
+[out]
+def f(x):
+    x :: int
+    r0, r1, r2, r3 :: bit
+    r4 :: int64
+    r5, r6, r7 :: bit
+L0:
+    r0 = x == 6
+    if r0 goto L1 else goto L2 :: bool
+L1:
+    return 2
+L2:
+    r1 = x != 8
+    if r1 goto L3 else goto L4 :: bool
+L3:
+    return 4
+L4:
+    r2 = 10 == x
+    if r2 goto L5 else goto L6 :: bool
+L5:
+    return 6
+L6:
+    r3 = 12 != x
+    if r3 goto L7 else goto L8 :: bool
+L7:
+    return 8
+L8:
+    r4 = x & 1
+    r5 = r4 != 0
+    if r5 goto L9 else goto L10 :: bool
+L9:
+    r6 = CPyTagged_IsLt_(x, 8)
+    if r6 goto L11 else goto L12 :: bool
+L10:
+    r7 = x < 8 :: signed
+    if r7 goto L11 else goto L12 :: bool
+L11:
+    return 10
+L12:
+L13:
+L14:
+L15:
+L16:
+    return 12

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -21,4 +21,3 @@ L2:
     r0 = r5
 L3:
     return r0
-

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -39,7 +39,7 @@ def f(x: int) -> int:
 def f(x):
     x :: int
     r0, r1, r2, r3 :: bit
-    r4 :: int64
+    r4 :: native_int
     r5, r6, r7 :: bit
 L0:
     r0 = x == 6

--- a/mypyc/test-data/irbuild-nested.test
+++ b/mypyc/test-data/irbuild-nested.test
@@ -705,37 +705,25 @@ def baz_f_obj.__call__(__mypyc_self__, n):
     n :: int
     r0 :: __main__.f_env
     r1, baz :: object
-    r2 :: bool
-    r3 :: native_int
-    r4, r5, r6 :: bit
-    r7 :: int
-    r8, r9 :: object
-    r10, r11 :: int
+    r2 :: bit
+    r3 :: int
+    r4, r5 :: object
+    r6, r7 :: int
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.baz
     baz = r1
-    r3 = n & 1
-    r4 = r3 == 0
-    if r4 goto L1 else goto L2 :: bool
+    r2 = n == 0
+    if r2 goto L1 else goto L2 :: bool
 L1:
-    r5 = n == 0
-    r2 = r5
-    goto L3
-L2:
-    r6 = CPyTagged_IsEq_(n, 0)
-    r2 = r6
-L3:
-    if r2 goto L4 else goto L5 :: bool
-L4:
     return 0
-L5:
-    r7 = CPyTagged_Subtract(n, 2)
-    r8 = box(int, r7)
-    r9 = PyObject_CallFunctionObjArgs(baz, r8, 0)
-    r10 = unbox(int, r9)
-    r11 = CPyTagged_Add(n, r10)
-    return r11
+L2:
+    r3 = CPyTagged_Subtract(n, 2)
+    r4 = box(int, r3)
+    r5 = PyObject_CallFunctionObjArgs(baz, r4, 0)
+    r6 = unbox(int, r5)
+    r7 = CPyTagged_Add(n, r6)
+    return r7
 def f(a):
     a :: int
     r0 :: __main__.f_env
@@ -859,28 +847,16 @@ def baz(n: int) -> int:
 [out]
 def baz(n):
     n :: int
-    r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bit
-    r5, r6, r7 :: int
+    r0 :: bit
+    r1, r2, r3 :: int
 L0:
-    r1 = n & 1
-    r2 = r1 == 0
-    if r2 goto L1 else goto L2 :: bool
+    r0 = n == 0
+    if r0 goto L1 else goto L2 :: bool
 L1:
-    r3 = n == 0
-    r0 = r3
-    goto L3
-L2:
-    r4 = CPyTagged_IsEq_(n, 0)
-    r0 = r4
-L3:
-    if r0 goto L4 else goto L5 :: bool
-L4:
     return 0
-L5:
-    r5 = CPyTagged_Subtract(n, 2)
-    r6 = baz(r5)
-    r7 = CPyTagged_Add(n, r6)
-    return r7
+L2:
+    r1 = CPyTagged_Subtract(n, 2)
+    r2 = baz(r1)
+    r3 = CPyTagged_Add(n, r2)
+    return r3
 

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -217,39 +217,27 @@ def f(y):
     y :: int
     x :: union[int, None]
     r0 :: object
-    r1 :: bool
-    r2 :: native_int
-    r3, r4, r5 :: bit
-    r6, r7 :: object
-    r8, r9 :: bit
-    r10 :: int
+    r1 :: bit
+    r2, r3 :: object
+    r4, r5 :: bit
+    r6 :: int
 L0:
     r0 = box(None, 1)
     x = r0
-    r2 = y & 1
-    r3 = r2 == 0
-    if r3 goto L1 else goto L2 :: bool
+    r1 = y == 2
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r4 = y == 2
-    r1 = r4
-    goto L3
+    r2 = box(int, y)
+    x = r2
 L2:
-    r5 = CPyTagged_IsEq_(y, 2)
-    r1 = r5
+    r3 = box(None, 1)
+    r4 = x == r3
+    r5 = r4 ^ 1
+    if r5 goto L3 else goto L4 :: bool
 L3:
-    if r1 goto L4 else goto L5 :: bool
+    r6 = unbox(int, x)
+    y = r6
 L4:
-    r6 = box(int, y)
-    x = r6
-L5:
-    r7 = box(None, 1)
-    r8 = x == r7
-    r9 = r8 ^ 1
-    if r9 goto L6 else goto L7 :: bool
-L6:
-    r10 = unbox(int, x)
-    y = r10
-L7:
     return 1
 
 [case testUnionType]

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -62,29 +62,26 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
 L0:
     n = 0
 L1:
-    r1 = n & 1
-    r2 = r1 == 0
-    r3 = 10 & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L2 else goto L3 :: bool
+    r0 = n & 1
+    r1 = r0 != 0
+    if r1 goto L3 else goto L2 :: bool
 L2:
-    r6 = n < 10 :: signed
-    r0 = r6
-    goto L4
+    r2 = 10 & 1
+    r3 = r2 != 0
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r7 = CPyTagged_IsLt_(n, 10)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(n, 10)
+    if r4 goto L5 else goto L6 :: bool
 L4:
-    if r0 goto L5 else goto L6 :: bool
+    r5 = n < 10 :: signed
+    if r5 goto L5 else goto L6 :: bool
 L5:
 L6:
     return 1
@@ -125,51 +122,45 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
-    r8 :: bool
-    r9 :: native_int
-    r10 :: bit
-    r11 :: native_int
-    r12, r13, r14, r15 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6 :: int64
+    r7 :: bit
+    r8 :: int64
+    r9, r10, r11 :: bit
 L0:
     n = 0
 L1:
-    r1 = n & 1
-    r2 = r1 == 0
-    r3 = 10 & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L2 else goto L3 :: bool
+    r0 = n & 1
+    r1 = r0 != 0
+    if r1 goto L3 else goto L2 :: bool
 L2:
-    r6 = n < 10 :: signed
-    r0 = r6
-    goto L4
+    r2 = 10 & 1
+    r3 = r2 != 0
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r7 = CPyTagged_IsLt_(n, 10)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(n, 10)
+    if r4 goto L5 else goto L12 :: bool
 L4:
-    if r0 goto L5 else goto L12 :: bool
+    r5 = n < 10 :: signed
+    if r5 goto L5 else goto L12 :: bool
 L5:
 L6:
-    r9 = n & 1
-    r10 = r9 == 0
-    r11 = 8 & 1
-    r12 = r11 == 0
-    r13 = r10 & r12
-    if r13 goto L7 else goto L8 :: bool
+    r6 = n & 1
+    r7 = r6 != 0
+    if r7 goto L8 else goto L7 :: bool
 L7:
-    r14 = n < 8 :: signed
-    r8 = r14
-    goto L9
+    r8 = 8 & 1
+    r9 = r8 != 0
+    if r9 goto L8 else goto L9 :: bool
 L8:
-    r15 = CPyTagged_IsLt_(n, 8)
-    r8 = r15
+    r10 = CPyTagged_IsLt_(n, 8)
+    if r10 goto L10 else goto L11 :: bool
 L9:
-    if r8 goto L10 else goto L11 :: bool
+    r11 = n < 8 :: signed
+    if r11 goto L10 else goto L11 :: bool
 L10:
 L11:
 L12:
@@ -183,29 +174,26 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
 L0:
     n = 0
 L1:
-    r1 = n & 1
-    r2 = r1 == 0
-    r3 = 10 & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L2 else goto L3 :: bool
+    r0 = n & 1
+    r1 = r0 != 0
+    if r1 goto L3 else goto L2 :: bool
 L2:
-    r6 = n < 10 :: signed
-    r0 = r6
-    goto L4
+    r2 = 10 & 1
+    r3 = r2 != 0
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r7 = CPyTagged_IsLt_(n, 10)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(n, 10)
+    if r4 goto L5 else goto L6 :: bool
 L4:
-    if r0 goto L5 else goto L6 :: bool
+    r5 = n < 10 :: signed
+    if r5 goto L5 else goto L6 :: bool
 L5:
     goto L1
 L6:
@@ -246,51 +234,45 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7 :: bit
-    r8 :: bool
-    r9 :: native_int
-    r10 :: bit
-    r11 :: native_int
-    r12, r13, r14, r15 :: bit
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6 :: int64
+    r7 :: bit
+    r8 :: int64
+    r9, r10, r11 :: bit
 L0:
     n = 0
 L1:
-    r1 = n & 1
-    r2 = r1 == 0
-    r3 = 10 & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L2 else goto L3 :: bool
+    r0 = n & 1
+    r1 = r0 != 0
+    if r1 goto L3 else goto L2 :: bool
 L2:
-    r6 = n < 10 :: signed
-    r0 = r6
-    goto L4
+    r2 = 10 & 1
+    r3 = r2 != 0
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r7 = CPyTagged_IsLt_(n, 10)
-    r0 = r7
+    r4 = CPyTagged_IsLt_(n, 10)
+    if r4 goto L5 else goto L12 :: bool
 L4:
-    if r0 goto L5 else goto L12 :: bool
+    r5 = n < 10 :: signed
+    if r5 goto L5 else goto L12 :: bool
 L5:
 L6:
-    r9 = n & 1
-    r10 = r9 == 0
-    r11 = 8 & 1
-    r12 = r11 == 0
-    r13 = r10 & r12
-    if r13 goto L7 else goto L8 :: bool
+    r6 = n & 1
+    r7 = r6 != 0
+    if r7 goto L8 else goto L7 :: bool
 L7:
-    r14 = n < 8 :: signed
-    r8 = r14
-    goto L9
+    r8 = 8 & 1
+    r9 = r8 != 0
+    if r9 goto L8 else goto L9 :: bool
 L8:
-    r15 = CPyTagged_IsLt_(n, 8)
-    r8 = r15
+    r10 = CPyTagged_IsLt_(n, 8)
+    if r10 goto L10 else goto L11 :: bool
 L9:
-    if r8 goto L10 else goto L11 :: bool
+    r11 = n < 8 :: signed
+    if r11 goto L10 else goto L11 :: bool
 L10:
     goto L6
 L11:

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -62,7 +62,7 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
 L0:
     n = 0
@@ -116,9 +116,9 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
-    r4 :: int64
+    r4 :: native_int
     r5, r6, r7 :: bit
 L0:
     n = 0
@@ -156,7 +156,7 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
 L0:
     n = 0
@@ -210,9 +210,9 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
-    r4 :: int64
+    r4 :: native_int
     r5, r6, r7 :: bit
 L0:
     n = 0

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -62,9 +62,9 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
 L0:
     n = 0
@@ -122,13 +122,13 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
-    r6 :: int64
+    r6 :: native_int
     r7 :: bit
-    r8 :: int64
+    r8 :: native_int
     r9, r10, r11 :: bit
 L0:
     n = 0
@@ -174,9 +174,9 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
 L0:
     n = 0
@@ -234,13 +234,13 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
-    r6 :: int64
+    r6 :: native_int
     r7 :: bit
-    r8 :: int64
+    r8 :: native_int
     r9, r10, r11 :: bit
 L0:
     n = 0

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -62,28 +62,22 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: native_int
-    r1 :: bit
-    r2 :: native_int
-    r3, r4, r5 :: bit
+    r0 :: int64
+    r1, r2, r3 :: bit
 L0:
     n = 0
 L1:
     r0 = n & 1
     r1 = r0 != 0
-    if r1 goto L3 else goto L2 :: bool
+    if r1 goto L2 else goto L3 :: bool
 L2:
-    r2 = 10 & 1
-    r3 = r2 != 0
-    if r3 goto L3 else goto L4 :: bool
+    r2 = CPyTagged_IsLt_(n, 10)
+    if r2 goto L4 else goto L5 :: bool
 L3:
-    r4 = CPyTagged_IsLt_(n, 10)
-    if r4 goto L5 else goto L6 :: bool
+    r3 = n < 10 :: signed
+    if r3 goto L4 else goto L5 :: bool
 L4:
-    r5 = n < 10 :: signed
-    if r5 goto L5 else goto L6 :: bool
 L5:
-L6:
     return 1
 
 [case testBreakFor]
@@ -122,48 +116,36 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: native_int
-    r1 :: bit
-    r2 :: native_int
-    r3, r4, r5 :: bit
-    r6 :: native_int
-    r7 :: bit
-    r8 :: native_int
-    r9, r10, r11 :: bit
+    r0 :: int64
+    r1, r2, r3 :: bit
+    r4 :: int64
+    r5, r6, r7 :: bit
 L0:
     n = 0
 L1:
     r0 = n & 1
     r1 = r0 != 0
-    if r1 goto L3 else goto L2 :: bool
+    if r1 goto L2 else goto L3 :: bool
 L2:
-    r2 = 10 & 1
-    r3 = r2 != 0
-    if r3 goto L3 else goto L4 :: bool
+    r2 = CPyTagged_IsLt_(n, 10)
+    if r2 goto L4 else goto L10 :: bool
 L3:
-    r4 = CPyTagged_IsLt_(n, 10)
-    if r4 goto L5 else goto L12 :: bool
+    r3 = n < 10 :: signed
+    if r3 goto L4 else goto L10 :: bool
 L4:
-    r5 = n < 10 :: signed
-    if r5 goto L5 else goto L12 :: bool
 L5:
+    r4 = n & 1
+    r5 = r4 != 0
+    if r5 goto L6 else goto L7 :: bool
 L6:
-    r6 = n & 1
-    r7 = r6 != 0
-    if r7 goto L8 else goto L7 :: bool
+    r6 = CPyTagged_IsLt_(n, 8)
+    if r6 goto L8 else goto L9 :: bool
 L7:
-    r8 = 8 & 1
-    r9 = r8 != 0
-    if r9 goto L8 else goto L9 :: bool
+    r7 = n < 8 :: signed
+    if r7 goto L8 else goto L9 :: bool
 L8:
-    r10 = CPyTagged_IsLt_(n, 8)
-    if r10 goto L10 else goto L11 :: bool
 L9:
-    r11 = n < 8 :: signed
-    if r11 goto L10 else goto L11 :: bool
 L10:
-L11:
-L12:
     return 1
 
 [case testContinue]
@@ -174,29 +156,23 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: native_int
-    r1 :: bit
-    r2 :: native_int
-    r3, r4, r5 :: bit
+    r0 :: int64
+    r1, r2, r3 :: bit
 L0:
     n = 0
 L1:
     r0 = n & 1
     r1 = r0 != 0
-    if r1 goto L3 else goto L2 :: bool
+    if r1 goto L2 else goto L3 :: bool
 L2:
-    r2 = 10 & 1
-    r3 = r2 != 0
-    if r3 goto L3 else goto L4 :: bool
+    r2 = CPyTagged_IsLt_(n, 10)
+    if r2 goto L4 else goto L5 :: bool
 L3:
-    r4 = CPyTagged_IsLt_(n, 10)
-    if r4 goto L5 else goto L6 :: bool
+    r3 = n < 10 :: signed
+    if r3 goto L4 else goto L5 :: bool
 L4:
-    r5 = n < 10 :: signed
-    if r5 goto L5 else goto L6 :: bool
-L5:
     goto L1
-L6:
+L5:
     return 1
 
 [case testContinueFor]
@@ -234,50 +210,38 @@ def f() -> None:
 [out]
 def f():
     n :: int
-    r0 :: native_int
-    r1 :: bit
-    r2 :: native_int
-    r3, r4, r5 :: bit
-    r6 :: native_int
-    r7 :: bit
-    r8 :: native_int
-    r9, r10, r11 :: bit
+    r0 :: int64
+    r1, r2, r3 :: bit
+    r4 :: int64
+    r5, r6, r7 :: bit
 L0:
     n = 0
 L1:
     r0 = n & 1
     r1 = r0 != 0
-    if r1 goto L3 else goto L2 :: bool
+    if r1 goto L2 else goto L3 :: bool
 L2:
-    r2 = 10 & 1
-    r3 = r2 != 0
-    if r3 goto L3 else goto L4 :: bool
+    r2 = CPyTagged_IsLt_(n, 10)
+    if r2 goto L4 else goto L10 :: bool
 L3:
-    r4 = CPyTagged_IsLt_(n, 10)
-    if r4 goto L5 else goto L12 :: bool
+    r3 = n < 10 :: signed
+    if r3 goto L4 else goto L10 :: bool
 L4:
-    r5 = n < 10 :: signed
-    if r5 goto L5 else goto L12 :: bool
 L5:
+    r4 = n & 1
+    r5 = r4 != 0
+    if r5 goto L6 else goto L7 :: bool
 L6:
-    r6 = n & 1
-    r7 = r6 != 0
-    if r7 goto L8 else goto L7 :: bool
+    r6 = CPyTagged_IsLt_(n, 8)
+    if r6 goto L8 else goto L9 :: bool
 L7:
-    r8 = 8 & 1
-    r9 = r8 != 0
-    if r9 goto L8 else goto L9 :: bool
+    r7 = n < 8 :: signed
+    if r7 goto L8 else goto L9 :: bool
 L8:
-    r10 = CPyTagged_IsLt_(n, 8)
-    if r10 goto L10 else goto L11 :: bool
+    goto L5
 L9:
-    r11 = n < 8 :: signed
-    if r11 goto L10 else goto L11 :: bool
-L10:
-    goto L6
-L11:
     goto L1
-L12:
+L10:
     return 1
 
 [case testForList]

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -185,7 +185,7 @@ def f(a: int) -> int:
 [out]
 def f(a):
     a :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
     x, r4, y :: int
 L0:
@@ -225,7 +225,7 @@ def f(a: int) -> int:
 [out]
 def f(a):
     a :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
     x, r4, y :: int
 L0:
@@ -261,7 +261,7 @@ def f(a: int) -> int:
 [out]
 def f(a):
     a :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
 L0:
     r0 = a & 1
@@ -438,7 +438,7 @@ def f() -> int:
 [out]
 def f():
     x, y, z :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
     a, r4, r5 :: int
 L0:
@@ -484,9 +484,9 @@ def f(a: int) -> int:
 [out]
 def f(a):
     a, sum, i :: int
-    r0 :: int64
+    r0 :: native_int
     r1 :: bit
-    r2 :: int64
+    r2 :: native_int
     r3, r4, r5 :: bit
     r6, r7 :: int
 L0:

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -63,34 +63,22 @@ def f() -> int:
 [out]
 def f():
     x, y :: int
-    r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bit
+    r0 :: bit
 L0:
     x = 2
     y = 4
-    r1 = x & 1
-    r2 = r1 == 0
-    if r2 goto L1 else goto L2 :: bool
+    r0 = x == 2
+    if r0 goto L3 else goto L4 :: bool
 L1:
-    r3 = x == 2
-    r0 = r3
-    goto L3
-L2:
-    r4 = CPyTagged_IsEq_(x, 2)
-    r0 = r4
-L3:
-    if r0 goto L6 else goto L7 :: bool
-L4:
     return x
-L5:
+L2:
     return y
-L6:
+L3:
     dec_ref y :: int
-    goto L4
-L7:
+    goto L1
+L4:
     dec_ref x :: int
-    goto L5
+    goto L2
 
 [case testArgumentsInOps]
 def f(a: int, b: int) -> int:
@@ -197,38 +185,34 @@ def f(a: int) -> int:
 [out]
 def f(a):
     a :: int
-    r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bit
-    x, r5, y :: int
+    r0 :: int64
+    r1, r2, r3 :: bit
+    x, r4, y :: int
 L0:
-    r1 = a & 1
-    r2 = r1 == 0
-    if r2 goto L1 else goto L2 :: bool
+    r0 = a & 1
+    r1 = r0 != 0
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r3 = a == a
-    r0 = r3
-    goto L3
+    r2 = CPyTagged_IsEq_(a, a)
+    if r2 goto L3 else goto L4 :: bool
 L2:
-    r4 = CPyTagged_IsEq_(a, a)
-    r0 = r4
+    r3 = a == a
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    if r0 goto L4 else goto L5 :: bool
-L4:
     a = 2
-    goto L6
-L5:
+    goto L5
+L4:
     x = 4
     dec_ref x :: int
-    goto L7
-L6:
-    r5 = CPyTagged_Add(a, 2)
-    dec_ref a :: int
-    y = r5
-    return y
-L7:
-    inc_ref a :: int
     goto L6
+L5:
+    r4 = CPyTagged_Add(a, 2)
+    dec_ref a :: int
+    y = r4
+    return y
+L6:
+    inc_ref a :: int
+    goto L5
 
 [case testConditionalAssignToArgument2]
 def f(a: int) -> int:
@@ -241,37 +225,33 @@ def f(a: int) -> int:
 [out]
 def f(a):
     a :: int
-    r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bit
-    x, r5, y :: int
+    r0 :: int64
+    r1, r2, r3 :: bit
+    x, r4, y :: int
 L0:
-    r1 = a & 1
-    r2 = r1 == 0
-    if r2 goto L1 else goto L2 :: bool
+    r0 = a & 1
+    r1 = r0 != 0
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r3 = a == a
-    r0 = r3
-    goto L3
+    r2 = CPyTagged_IsEq_(a, a)
+    if r2 goto L3 else goto L4 :: bool
 L2:
-    r4 = CPyTagged_IsEq_(a, a)
-    r0 = r4
+    r3 = a == a
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    if r0 goto L4 else goto L5 :: bool
-L4:
     x = 4
     dec_ref x :: int
-    goto L7
-L5:
-    a = 2
-L6:
-    r5 = CPyTagged_Add(a, 2)
-    dec_ref a :: int
-    y = r5
-    return y
-L7:
-    inc_ref a :: int
     goto L6
+L4:
+    a = 2
+L5:
+    r4 = CPyTagged_Add(a, 2)
+    dec_ref a :: int
+    y = r4
+    return y
+L6:
+    inc_ref a :: int
+    goto L5
 
 [case testConditionalAssignToArgument3]
 def f(a: int) -> int:
@@ -281,29 +261,25 @@ def f(a: int) -> int:
 [out]
 def f(a):
     a :: int
-    r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bit
+    r0 :: int64
+    r1, r2, r3 :: bit
 L0:
-    r1 = a & 1
-    r2 = r1 == 0
-    if r2 goto L1 else goto L2 :: bool
+    r0 = a & 1
+    r1 = r0 != 0
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r3 = a == a
-    r0 = r3
-    goto L3
+    r2 = CPyTagged_IsEq_(a, a)
+    if r2 goto L3 else goto L5 :: bool
 L2:
-    r4 = CPyTagged_IsEq_(a, a)
-    r0 = r4
+    r3 = a == a
+    if r3 goto L3 else goto L5 :: bool
 L3:
-    if r0 goto L4 else goto L6 :: bool
-L4:
     a = 2
-L5:
+L4:
     return a
-L6:
+L5:
     inc_ref a :: int
-    goto L5
+    goto L4
 
 [case testAssignRegisterToItself]
 def f(a: int) -> int:
@@ -462,44 +438,40 @@ def f() -> int:
 [out]
 def f():
     x, y, z :: int
-    r0 :: bool
-    r1 :: native_int
-    r2, r3, r4 :: bit
-    a, r5, r6 :: int
+    r0 :: int64
+    r1, r2, r3 :: bit
+    a, r4, r5 :: int
 L0:
     x = 2
     y = 4
     z = 6
-    r1 = z & 1
-    r2 = r1 == 0
-    if r2 goto L1 else goto L2 :: bool
+    r0 = z & 1
+    r1 = r0 != 0
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r3 = z == z
-    r0 = r3
-    goto L3
+    r2 = CPyTagged_IsEq_(z, z)
+    if r2 goto L5 else goto L6 :: bool
 L2:
-    r4 = CPyTagged_IsEq_(z, z)
-    r0 = r4
+    r3 = z == z
+    if r3 goto L5 else goto L6 :: bool
 L3:
-    if r0 goto L6 else goto L7 :: bool
-L4:
     return z
-L5:
+L4:
     a = 2
-    r5 = CPyTagged_Add(x, y)
+    r4 = CPyTagged_Add(x, y)
     dec_ref x :: int
     dec_ref y :: int
-    r6 = CPyTagged_Subtract(r5, a)
-    dec_ref r5 :: int
+    r5 = CPyTagged_Subtract(r4, a)
+    dec_ref r4 :: int
     dec_ref a :: int
-    return r6
-L6:
+    return r5
+L5:
     dec_ref x :: int
     dec_ref y :: int
-    goto L4
-L7:
+    goto L3
+L6:
     dec_ref z :: int
-    goto L5
+    goto L4
 
 [case testLoop]
 def f(a: int) -> int:
@@ -512,39 +484,35 @@ def f(a: int) -> int:
 [out]
 def f(a):
     a, sum, i :: int
-    r0 :: bool
-    r1 :: native_int
-    r2 :: bit
-    r3 :: native_int
-    r4, r5, r6, r7, r8 :: bit
-    r9, r10 :: int
+    r0 :: int64
+    r1 :: bit
+    r2 :: int64
+    r3, r4, r5 :: bit
+    r6, r7 :: int
 L0:
     sum = 0
     i = 0
 L1:
-    r1 = i & 1
-    r2 = r1 == 0
-    r3 = a & 1
-    r4 = r3 == 0
-    r5 = r2 & r4
-    if r5 goto L2 else goto L3 :: bool
+    r0 = i & 1
+    r1 = r0 != 0
+    if r1 goto L3 else goto L2 :: bool
 L2:
-    r6 = i <= a :: signed
-    r0 = r6
-    goto L4
+    r2 = a & 1
+    r3 = r2 != 0
+    if r3 goto L3 else goto L4 :: bool
 L3:
-    r7 = CPyTagged_IsLt_(a, i)
-    r8 = r7 ^ 1
-    r0 = r8
+    r4 = CPyTagged_IsLt_(a, i)
+    if r4 goto L7 else goto L5 :: bool
 L4:
-    if r0 goto L5 else goto L7 :: bool
+    r5 = i <= a :: signed
+    if r5 goto L5 else goto L7 :: bool
 L5:
-    r9 = CPyTagged_Add(sum, i)
+    r6 = CPyTagged_Add(sum, i)
     dec_ref sum :: int
-    sum = r9
-    r10 = CPyTagged_Add(i, 2)
+    sum = r6
+    r7 = CPyTagged_Add(i, 2)
     dec_ref i :: int
-    i = r10
+    i = r7
     goto L1
 L6:
     return sum


### PR DESCRIPTION
In a conditional context, such as in an if condition, simplify the 
IR for tagged integer comparisons. Also perform some additional 
optimizations if an operand is known to be a short integer. 

This slightly improves performance when compiling with no 
optimizations. The impact should be pretty negligible otherwise.

This is a bit simple-minded, and some further optimizations are 
possible. For example, `3 < x < 6` could be made faster. This 
covers the most common cases, however.

Closes mypyc/mypyc#758.