### PR TITLE
Fix for pep585 with __future__ import

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3792,7 +3792,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         # ...or directly.
         else:
             n = self.lookup_type_node(base)
-            if n and n.fullname in nongen_builtins:
+            if n and n.fullname in nongen_builtins and not self.is_future_flag_set("annotations"):
                 self.fail(no_subscript_builtin_alias(n.fullname, propose_alt=False), expr)
 
     def analyze_type_application_args(self, expr: IndexExpr) -> Optional[List[Type]]:

--- a/test-data/unit/check-future.test
+++ b/test-data/unit/check-future.test
@@ -20,5 +20,14 @@ t1: type[int]
 t2: list[int]
 t3: dict[int, int]
 t4: tuple[int, str, int]
+t5 = list[int]
 
 [builtins fixtures/dict.pyi]
+
+[case testFutureAnnotationsMissing]
+# flags: --python-version 3.7
+
+t1: list[int]  # E: "list" is not subscriptable, use "typing.List" instead
+t2 = list[int]  # E: "list" is not subscriptable
+
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
### Description

Fix PR fixes an issue introduced with #7963. When using `from __future__ import annotations` with py37 and above, the following should pass:

```py
from __future__ import annotations

t1: list[int]
T2 = list[int]  # This line caused an error
```

## Test Plan

I've added some tests to verify that the change works as intended.

--
cc: @TH3CHARLie 