### PR TITLE
modulefinder: make -p handle namespace packages correctly

### DIFF
--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -387,7 +387,7 @@ class FindModuleCache:
                     if mod not in hits:
                         hits.add(mod)
                         result += self.find_modules_recursive(module + '.' + mod)
-        elif os.path.isdir(module_path) and any(module.startswith(p) for p in self.ns_packages):
+        elif os.path.isdir(module_path):
             # Even subtler: handle recursive decent into PEP 420
             # namespace packages that are explicitly listed on the command
             # line with -p/--packages.

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -387,13 +387,13 @@ class FindModuleCache:
                     if mod not in hits:
                         hits.add(mod)
                         result += self.find_modules_recursive(module + '.' + mod)
-        elif os.path.isdir(module_path) and module in self.ns_packages:
-            # Even more subtler: handle recursive decent into PEP 420
+        elif os.path.isdir(module_path) and any(module.startswith(p) for p in self.ns_packages):
+            # Even subtler: handle recursive decent into PEP 420
             # namespace packages that are explicitly listed on the command
             # line with -p/--packages.
             for item in sorted(self.fscache.listdir(module_path)):
-                if os.path.isdir(os.path.join(module_path, item)):
-                    result += self.find_modules_recursive(module + '.' + item)
+                item, _ = os.path.splitext(item)
+                result += self.find_modules_recursive(module + '.' + item)
         return result
 
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -794,7 +794,7 @@ src/anamespace/foo/bar.py:2: error: Incompatible return value type (got "int", e
 [case testNestedPEP420Packages]
 # cmd: mypy -p bottles --namespace-packages
 [file bottles/jars/secret/glitter.py]
-x: str = 0
+x = 0  # type: str
 [file bottles/jars/sprinkle.py]
 from bottles.jars.secret.glitter import x
 x + 1

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -791,6 +791,17 @@ def bar(a: int, b: int) -> str:
 [out]
 src/anamespace/foo/bar.py:2: error: Incompatible return value type (got "int", expected "str")
 
+[case testNestedPEP420Packages]
+# cmd: mypy -p bottles --namespace-packages
+[file bottles/jars/secret/glitter.py]
+x: str = 0
+[file bottles/jars/sprinkle.py]
+from bottles.jars.secret.glitter import x
+x + 1
+[out]
+bottles/jars/secret/glitter.py:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+bottles/jars/sprinkle.py:2: error: Unsupported operand types for + ("str" and "int")
+
 [case testFollowImportStubs1]
 # cmd: mypy main.py
 [file mypy.ini]


### PR DESCRIPTION
Fixes part of #5759
The other part is passing files arguments, which we make steps towards
in #9614