### PR TITLE
Fix argument checking on empty dict with double stars

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1405,11 +1405,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         ok = True  # False if we've found any error
 
         for i, kind in enumerate(actual_kinds):
-            if i not in all_actuals and (
-                    kind != nodes.ARG_STAR or
+            if (i not in all_actuals and
                     # We accept the other iterables than tuple (including Any)
                     # as star arguments because they could be empty, resulting no arguments.
-                    is_non_empty_tuple(actual_types[i])):
+                    (kind != nodes.ARG_STAR or is_non_empty_tuple(actual_types[i])) and
+                    # Accept all types for double-starred arguments, because they could be empty
+                    # dictionaries and we can't tell it from their types
+                    kind != nodes.ARG_STAR2):
                 # Extra actual: not matched by a formal argument.
                 ok = False
                 if kind != nodes.ARG_NAMED:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1103,7 +1103,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         # Fill in the rest of the argument types.
         for i, t in enumerate(res):
             if not t:
-                res[i] = self.accept(args[i])
+                if arg_kinds[i] == ARG_STAR2:
+                    res[i] = self.accept(args[i], self.chk.named_generic_type('typing.Mapping',
+                        [self.named_type('builtins.str'), AnyType(TypeOfAny.special_form)]))
+                else:
+                    res[i] = self.accept(args[i])
         assert all(tp is not None for tp in res)
         return cast(List[Type], res)
 

--- a/test-data/unit/check-ctypes.test
+++ b/test-data/unit/check-ctypes.test
@@ -182,6 +182,6 @@ import ctypes
 intarr4 = ctypes.c_int * 4
 
 x = {"a": 1, "b": 2}
-intarr4(**x)   # E: Too many arguments for "Array"
+intarr4(**x)
 
 [builtins fixtures/floatdict.pyi]

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -491,3 +491,9 @@ m = {} # type: Mapping[str, object]
 f(**m)
 g(**m)  # TODO: Should be an error
 [builtins fixtures/dict.pyi]
+
+[case testPassingEmptyDictAsKwarg]
+def f(x=0): pass
+
+f(**{})
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -492,7 +492,7 @@ f(**m)
 g(**m)  # TODO: Should be an error
 [builtins fixtures/dict.pyi]
 
-[case testPassingEmptyDictAsKwarg]
+[case testPassingEmptyDictWithStars]
 def f(): pass
 
 f(**{})

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -396,7 +396,7 @@ class A: pass
 from typing import Any, Dict
 def f(*args: 'A') -> None: pass
 d = None # type: Dict[Any, Any]
-f(**d) # E: Too many arguments for "f"
+f(**d)
 class A: pass
 [builtins fixtures/dict.pyi]
 
@@ -493,7 +493,7 @@ g(**m)  # TODO: Should be an error
 [builtins fixtures/dict.pyi]
 
 [case testPassingEmptyDictAsKwarg]
-def f(x=0): pass
+def f(): pass
 
 f(**{})
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1584,8 +1584,8 @@ d = None # type: Dict[Any, Any]
 
 f1(**td, **d)
 f1(**d, **td)
-f2(**td, **d) # E: Too many arguments for "f2"
-f2(**d, **td) # E: Too many arguments for "f2"
+f2(**td, **d)
+f2(**d, **td)
 [builtins fixtures/dict.pyi]
 
 [case testTypedDictNonMappingMethods]


### PR DESCRIPTION
### Description

Closes #5580
Previously, the type of empty dicts are inferred as `dict[<nothing>, <nothing>]`, which is not a subtype of `Mapping[str, Any]`, and this has caused a false-positive error saying `Keywords must be strings`. This PR fixes it by inferring the types of double-starred arguments with a context of `Mapping[str, Any]`. 

Closes #4001 and #9007 (duplicate)
Do not check for "too many arguments" error when there are any double-starred arguments. This will lead to some false-negavites, see my comment here: https://github.com/python/mypy/issues/4001#issuecomment-714628193

### Test Plan

Added a simple test `testPassingEmptyDictWithStars`. This single test can cover both of the issues above.

I also modified some existing tests that were added in #9573 and #6213.