### PR TITLE
mypy: allow explicit specification of package roots

### DIFF
--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -148,14 +148,14 @@ class SourceFinder:
     def crawl_up_dir(self, dir: str) -> Tuple[str, str]:
         """Given a directory name, return the corresponding module name and base directory."""
         parent_dir, base = os.path.split(dir)
-        if not dir or not base:
-            module = ''
-            base_dir = dir or '.'
-            return module, base_dir
-
-        if self.explicit_package_roots is None and not self.get_init_file(dir):
-            module = ''
-            base_dir = dir or '.'
+        if (
+            not dir or not base
+            # In the absence of explicit package roots, a lack of __init__.py means we've reached
+            # an (implicit) package root
+            or (self.explicit_package_roots is None and not self.get_init_file(dir))
+        ):
+            module = ""
+            base_dir = dir or "."
             return module, base_dir
 
         # Ensure that base is a valid python module name

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -1,5 +1,6 @@
 """Routines for finding the sources that mypy will check"""
 
+import functools
 import os.path
 
 from typing import List, Sequence, Set, Tuple, Optional, Dict
@@ -140,6 +141,8 @@ class SourceFinder:
 
         return module, base_dir
 
+    # Add a cache in case many files are passed to mypy
+    @functools.lru_cache()
     def crawl_up_dir(self, dir: str) -> Tuple[str, str]:
         """Given a directory name, return the corresponding module name and base directory."""
         parent_dir, base = os.path.split(dir)

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -164,6 +164,10 @@ class SourceFinder:
     @functools.lru_cache()
     def crawl_up_dir(self, dir: str) -> Tuple[str, str]:
         """Given a directory name, return the corresponding module name and base directory."""
+        if self.explicit_package_roots is not None:
+            if self.is_package_root(dir):
+                return "", dir
+
         parent_dir, base = os.path.split(dir)
         if (
             not dir or not base
@@ -180,10 +184,6 @@ class SourceFinder:
             base = base[:-6]  # PEP-561 stub-only directory
         if not base.isidentifier():
             raise InvalidSourceList('{} is not a valid Python package name'.format(base))
-
-        if self.explicit_package_roots is not None:
-            if self.is_package_root(parent_dir):
-                return base, parent_dir
 
         parent_module, base_dir = self.crawl_up_dir(parent_dir)
         module = module_join(parent_module, base)

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -3,7 +3,7 @@
 import functools
 import os.path
 
-from typing import List, Sequence, Set, Tuple, Optional, Dict
+from typing import List, Sequence, Set, Tuple, Optional
 from typing_extensions import Final
 
 from mypy.modulefinder import BuildSource, PYTHON_EXTENSIONS
@@ -61,7 +61,9 @@ def keyfunc(name: str) -> Tuple[int, str]:
 
 
 class SourceFinder:
-    def __init__(self, fscache: FileSystemCache, explicit_package_roots: Optional[List[str]]) -> None:
+    def __init__(
+        self, fscache: FileSystemCache, explicit_package_roots: Optional[List[str]]
+    ) -> None:
         self.fscache = fscache
         self.explicit_package_roots = explicit_package_roots
 

--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -36,13 +36,7 @@ from mypy.util import hash_digest
 
 class FileSystemCache:
     def __init__(self) -> None:
-        # The package root is not flushed with the caches.
-        # It is set by set_package_root() below.
-        self.package_root = []  # type: List[str]
         self.flush()
-
-    def set_package_root(self, package_root: List[str]) -> None:
-        self.package_root = package_root
 
     def flush(self) -> None:
         """Start another transaction and empty all caches."""
@@ -64,90 +58,11 @@ class FileSystemCache:
         try:
             st = os.stat(path)
         except OSError as err:
-            if self.init_under_package_root(path):
-                try:
-                    return self._fake_init(path)
-                except OSError:
-                    pass
             # Take a copy to get rid of associated traceback and frame objects.
             # Just assigning to __traceback__ doesn't free them.
             self.stat_error_cache[path] = copy_os_error(err)
             raise err
         self.stat_cache[path] = st
-        return st
-
-    def init_under_package_root(self, path: str) -> bool:
-        """Is this path an __init__.py under a package root?
-
-        This is used to detect packages that don't contain __init__.py
-        files, which is needed to support Bazel.  The function should
-        only be called for non-existing files.
-
-        It will return True if it refers to a __init__.py file that
-        Bazel would create, so that at runtime Python would think the
-        directory containing it is a package.  For this to work you
-        must pass one or more package roots using the --package-root
-        flag.
-
-        As an exceptional case, any directory that is a package root
-        itself will not be considered to contain a __init__.py file.
-        This is different from the rules Bazel itself applies, but is
-        necessary for mypy to properly distinguish packages from other
-        directories.
-
-        See https://docs.bazel.build/versions/master/be/python.html,
-        where this behavior is described under legacy_create_init.
-        """
-        if not self.package_root:
-            return False
-        dirname, basename = os.path.split(path)
-        if basename != '__init__.py':
-            return False
-        try:
-            st = self.stat(dirname)
-        except OSError:
-            return False
-        else:
-            if not stat.S_ISDIR(st.st_mode):
-                return False
-        ok = False
-        drive, path = os.path.splitdrive(path)  # Ignore Windows drive name
-        path = os.path.normpath(path)
-        for root in self.package_root:
-            if path.startswith(root):
-                if path == root + basename:
-                    # A package root itself is never a package.
-                    ok = False
-                    break
-                else:
-                    ok = True
-        return ok
-
-    def _fake_init(self, path: str) -> os.stat_result:
-        """Prime the cache with a fake __init__.py file.
-
-        This makes code that looks for path believe an empty file by
-        that name exists.  Should only be called after
-        init_under_package_root() returns True.
-        """
-        dirname, basename = os.path.split(path)
-        assert basename == '__init__.py', path
-        assert not os.path.exists(path), path  # Not cached!
-        dirname = os.path.normpath(dirname)
-        st = self.stat(dirname)  # May raise OSError
-        # Get stat result as a sequence so we can modify it.
-        # (Alas, typeshed's os.stat_result is not a sequence yet.)
-        tpl = tuple(st)  # type: ignore[arg-type, var-annotated]
-        seq = list(tpl)  # type: List[float]
-        seq[stat.ST_MODE] = stat.S_IFREG | 0o444
-        seq[stat.ST_INO] = 1
-        seq[stat.ST_NLINK] = 1
-        seq[stat.ST_SIZE] = 0
-        tpl = tuple(seq)
-        st = os.stat_result(tpl)
-        self.stat_cache[path] = st
-        # Make listdir() and read() also pretend this file exists.
-        self.fake_package_cache.add(dirname)
         return st
 
     def listdir(self, path: str) -> List[str]:

--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -30,7 +30,7 @@ advantage of the benefits.
 
 import os
 import stat
-from typing import Dict, List, Set
+from typing import Dict, List
 from mypy.util import hash_digest
 
 

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -220,11 +220,7 @@ class SuggestionEngine:
         self.manager = fgmanager.manager
         self.plugin = self.manager.plugin
         self.graph = fgmanager.graph
-        self.finder = SourceFinder(
-            self.manager.fscache,
-            self.manager.options.package_root or None,
-            self.manager.options.namespace_packages,
-        )
+        self.finder = SourceFinder(self.manager.fscache, self.manager.options)
 
         self.give_json = json
         self.no_errors = no_errors

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -220,7 +220,9 @@ class SuggestionEngine:
         self.manager = fgmanager.manager
         self.plugin = self.manager.plugin
         self.graph = fgmanager.graph
-        self.finder = SourceFinder(self.manager.fscache)
+        self.finder = SourceFinder(
+            self.manager.fscache, self.manager.options.package_root or None
+        )
 
         self.give_json = json
         self.no_errors = no_errors

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -221,7 +221,9 @@ class SuggestionEngine:
         self.plugin = self.manager.plugin
         self.graph = fgmanager.graph
         self.finder = SourceFinder(
-            self.manager.fscache, self.manager.options.package_root or None
+            self.manager.fscache,
+            self.manager.options.package_root or None,
+            self.manager.options.namespace_packages,
         )
 
         self.give_json = json

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -475,6 +475,22 @@ def parse_gray_color(cup: bytes) -> str:
     return gray
 
 
+def normalise_package_root(root: str) -> str:
+    # Empty package root is always okay.
+    if not root:
+        return ''
+
+    dot = os.curdir
+    dotslash = os.curdir + os.sep
+    trivial_paths = {dot, dotslash}
+    root = os.path.relpath(root)  # Normalize the heck out of it.
+    if root in trivial_paths:
+        return ''
+    if root.endswith(os.sep):
+        root = root[:-1]
+    return root
+
+
 class FancyFormatter:
     """Apply color and bold font to terminal output.
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -934,19 +934,19 @@ emarg/foo.py:1: error: Name 'fail' is not defined
 emarg/hatch/villip/mankangulisk.py:1: error: Name 'fail' is not defined
 
 [case testPackageRootEmpty]
-# cmd: mypy --package-root= a/b/c.py main.py
+# cmd: mypy --namespace-packages --package-root= a/b/c.py main.py
 [file a/b/c.py]
 [file main.py]
 import a.b.c
 
 [case testPackageRootNonEmpty]
-# cmd: mypy --package-root=a/ a/b/c.py main.py
+# cmd: mypy --namespace-packages --package-root=a/ a/b/c.py main.py
 [file a/b/c.py]
 [file main.py]
 import b.c
 
 [case testPackageRootMultiple1]
-# cmd: mypy --package-root=. --package-root=a a/b/c.py d.py main.py
+# cmd: mypy --namespace-packages --package-root=. --package-root=a a/b/c.py d.py main.py
 [file a/b/c.py]
 [file d.py]
 [file main.py]
@@ -954,7 +954,7 @@ import b.c
 import d
 
 [case testPackageRootMultiple2]
-# cmd: mypy --package-root=a/ --package-root=./ a/b/c.py d.py main.py
+# cmd: mypy --namespace-packages --package-root=a/ --package-root=./ a/b/c.py d.py main.py
 [file a/b/c.py]
 [file d.py]
 [file main.py]


### PR DESCRIPTION
This is the next in a series of import handling improvements. (The overall vision is #8584 + there are some important bugs that should be fixed as part of this)

This, along with #9614 and #9616, fix #5759.
It turns out we already have an explicit package root flag (with tests :-) ) that we can co-opt for our purposes. It looks like the intention behind it was to satisfy some Dropbox build requirements, but as far as I can tell those requirements can be met by treating things as namespace packages. And we get to drop some pretty hacky code!
While this PR in itself is probably a breaking change for Dropbox, the good news is that the next item on #8584 is to make `--namespace-packages` the default. However, if there's a reason to have the old Dropbox behaviour and have namespace packages turned off that would be concerning, but I'm betting that's not the case.

While much of the groundwork for this was laid in #9614, there were a couple issues that needed revisiting now that the explicit package root code paths get hit. The first is that the crawling up logic needs to take package roots into account. The second is that because of that, we make the package roots an instance attribute so that the caching logic is cleaner. While we no longer call crawl very much (due to #9614), the one case this can happen is if users pass in many files to mypy. I switch to `functools.lru_cache` because there are more return points now. The third is that we need to normalise paths before checking whether they're a package root (An aside here is I wanted to change things to absolute paths so that behaviour is consistent regardless of cwd — we've had one or two issues because of this — but unit tests really did not like that).

I've also started to make a list of places we could put suggestions to use this (but let me know if you have something in mind) + I'll make a docs PR once I'm at a stopping point.