### PR TITLE
teststubtest: drop StubtestIntegration

### DIFF
--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -848,9 +848,3 @@ class StubtestMiscUnit(unittest.TestCase):
         )
         output = run_stubtest(stub=stub, runtime=runtime, options=[], config_file=config_file)
         assert output == ""
-
-
-class StubtestIntegration(unittest.TestCase):
-    def test_typeshed(self) -> None:
-        # check we don't crash while checking typeshed
-        test_stubs(parse_options(["--check-typeshed"]))

--- a/runtests.py
+++ b/runtests.py
@@ -28,7 +28,6 @@ MYPYC_RUN_MULTI = 'TestRunMultiFile'
 MYPYC_EXTERNAL = 'TestExternal'
 MYPYC_COMMAND_LINE = 'TestCommandLine'
 ERROR_STREAM = 'ErrorStreamSuite'
-STUBTEST_INTEGRATION = 'StubtestIntegration'
 
 
 ALL_NON_FAST = [
@@ -45,15 +44,11 @@ ALL_NON_FAST = [
     MYPYC_EXTERNAL,
     MYPYC_COMMAND_LINE,
     ERROR_STREAM,
-    STUBTEST_INTEGRATION,
 ]
 
 
 # These must be enabled by explicitly including 'mypyc-extra' on the command line.
 MYPYC_OPT_IN = [MYPYC_RUN, MYPYC_RUN_MULTI]
-
-# These must be enabled by explicitly including 'stubtest' on the command line.
-STUBTEST_OPT_IN = [STUBTEST_INTEGRATION]
 
 # We split the pytest run into three parts to improve test
 # parallelization. Each run should have tests that each take a roughly similar
@@ -82,7 +77,6 @@ cmds = {
     # Mypyc tests that aren't run by default, since they are slow and rarely
     # fail for commits that don't touch mypyc
     'mypyc-extra': 'pytest -k "%s"' % ' or '.join(MYPYC_OPT_IN),
-    'stubtest': 'pytest -k "%s"' % ' or '.join(STUBTEST_OPT_IN),
 }
 
 # Stop run immediately if these commands fail


### PR DESCRIPTION
I did some work to speed up stubtest tests substantially in #9621
This is a lesser win. The argument to get rid of it is that it's the
slowest mypy test and just testing for crashes on typeshed doesn't
provide much value. Since this was written, we started running stubtest
in typeshed CI and in practice all changes are tested on typeshed
anyway.