### PR TITLE
runtests.py: list tests to run in typeshed CI

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -79,6 +79,8 @@ cmds = {
          MYPYC_EXTERNAL,
          MYPYC_COMMAND_LINE,
          ERROR_STREAM]),
+    # Test cases to run in typeshed CI
+    'typeshed-ci': 'pytest -k "%s"' % ' or '.join([CMDLINE, EVALUATION, SAMPLES, TYPESHED]),
     # Mypyc tests that aren't run by default, since they are slow and rarely
     # fail for commits that don't touch mypyc
     'mypyc-extra': 'pytest -k "%s"' % ' or '.join(MYPYC_OPT_IN),

--- a/runtests.py
+++ b/runtests.py
@@ -90,7 +90,7 @@ cmds = {
 # Stop run immediately if these commands fail
 FAST_FAIL = ['self', 'lint']
 
-DEFAULT_COMMANDS = [cmd for cmd in cmds if cmd != 'mypyc-extra']
+DEFAULT_COMMANDS = [cmd for cmd in cmds if cmd not in ('mypyc-extra', 'typeshed-ci')]
 
 assert all(cmd in cmds for cmd in FAST_FAIL)
 


### PR DESCRIPTION
Running a subset of tests will help speed up typeshed CI. I don't think
typeshed really benefits from running all the other tests. Worst case if
something breaks, it'll be caught when typeshed is synced in mypy.