### PR TITLE
Start using Python 3.9 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
   - name: "run test suite with python 3.8"
     python: 3.8
   - name: "run test suite with python 3.9"
-    python: 3.9-dev
+    python: 3.9
   - name: "run mypyc runtime tests with python 3.6 debug build"
     language: generic
     env:


### PR DESCRIPTION
### Description

Travis-CI started giving support for Python 3.9 so this repo can also run tests on 3.9 instead of 3.9-dev. Related link from Travis [https://travis-ci.community/t/python-3-9-0-build/10091](https://travis-ci.community/t/python-3-9-0-build/10091).

## Test Plan

This is a change on CI configuration file, previously tests was running on 3.9-dev now it runs on 3.9. I don't expect a fail but successful result of CI would be enough to test.
