### PR TITLE
[mypyc] Merge fast_isinstance_op and py_calc_meta_op

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -229,7 +229,7 @@ def find_non_ext_metaclass(builder: IRBuilder, cdef: ClassDef, bases: Value) -> 
         declared_metaclass = builder.add(LoadAddress(type_object_op.type,
                                                      type_object_op.src, cdef.line))
 
-    return builder.primitive_op(py_calc_meta_op, [declared_metaclass, bases], cdef.line)
+    return builder.call_c(py_calc_meta_op, [declared_metaclass, bases], cdef.line)
 
 
 def setup_non_ext_dict(builder: IRBuilder,

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -221,9 +221,9 @@ class LowLevelIRBuilder:
         """
         concrete = all_concrete_classes(class_ir)
         if concrete is None or len(concrete) > FAST_ISINSTANCE_MAX_SUBCLASSES + 1:
-            return self.primitive_op(fast_isinstance_op,
-                                     [obj, self.get_native_type(class_ir)],
-                                     line)
+            return self.call_c(fast_isinstance_op,
+                               [obj, self.get_native_type(class_ir)],
+                               line)
         if not concrete:
             # There can't be any concrete instance that matches this.
             return self.false()

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -456,6 +456,14 @@ static inline bool CPyFloat_Check(PyObject *o) {
     return PyFloat_Check(o) || PyLong_Check(o);
 }
 
+static inline bool CPy_TypeCheck(PyObject *o, PyObject *type) {
+    return PyObject_TypeCheck(o, (PyTypeObject *)type);
+}
+
+static inline PyObject *CPy_CalculateMetaclass(PyObject *type, PyObject *o) {
+    return (PyObject *)_PyType_CalculateMetaclass((PyTypeObject *)type, o);
+}
+
 PyObject *CPy_GetCoro(PyObject *obj);
 PyObject *CPyIter_Send(PyObject *iter, PyObject *val);
 int CPy_YieldFromErrorHandle(PyObject *iter, PyObject **outp);

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -456,6 +456,8 @@ static inline bool CPyFloat_Check(PyObject *o) {
     return PyFloat_Check(o) || PyLong_Check(o);
 }
 
+// TODO: find an unified way to avoid inline functions in non-C back ends that can not
+//       use inline functions
 static inline bool CPy_TypeCheck(PyObject *o, PyObject *type) {
     return PyObject_TypeCheck(o, (PyTypeObject *)type);
 }

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -6,7 +6,7 @@ from mypyc.ir.rtypes import (
     int_rprimitive, dict_rprimitive, c_int_rprimitive, bit_rprimitive
 )
 from mypyc.primitives.registry import (
-    simple_emit, func_op, custom_op, c_function_op, c_custom_op, load_address_op, ERR_NEG_INT
+    simple_emit, custom_op, c_function_op, c_custom_op, load_address_op, ERR_NEG_INT
 )
 
 
@@ -89,13 +89,11 @@ check_stop_op = c_custom_op(
 
 # Determine the most derived metaclass and check for metaclass conflicts.
 # Arguments are (metaclass, bases).
-py_calc_meta_op = custom_op(
+py_calc_meta_op = c_custom_op(
     arg_types=[object_rprimitive, object_rprimitive],
-    result_type=object_rprimitive,
+    return_type=object_rprimitive,
+    c_function_name='CPy_CalculateMetaclass',
     error_kind=ERR_MAGIC,
-    format_str='{dest} = py_calc_metaclass({comma_args})',
-    emit=simple_emit(
-        '{dest} = (PyObject*) _PyType_CalculateMetaclass((PyTypeObject *){args[0]}, {args[1]});'),
     is_borrowed=True
 )
 
@@ -126,12 +124,12 @@ c_function_op(
 
 # Faster isinstance(obj, cls) that only works with native classes and doesn't perform
 # type checking of the type argument.
-fast_isinstance_op = func_op(
+fast_isinstance_op = c_function_op(
     'builtins.isinstance',
     arg_types=[object_rprimitive, object_rprimitive],
-    result_type=bool_rprimitive,
+    return_type=bool_rprimitive,
+    c_function_name='CPy_TypeCheck',
     error_kind=ERR_NEVER,
-    emit=simple_emit('{dest} = PyObject_TypeCheck({args[0]}, (PyTypeObject *){args[1]});'),
     priority=0)
 
 # bool(obj) with unboxed result

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -663,7 +663,7 @@ def f(x):
     r3 :: __main__.B
 L0:
     r0 = __main__.R :: type
-    r1 = isinstance x, r0
+    r1 = CPy_TypeCheck(x, r0)
     if r1 goto L1 else goto L2 :: bool
 L1:
     r2 = cast(__main__.R, x)


### PR DESCRIPTION
relates mypyc/mypyc#753

This PR merges two remaining misc ops.

The problem with these two is that they rely on inlined `PyTypeObject *` cast during the call, while the casted object has already gone through a cast from `PyTypeObject *` to `PyObject *` before the function call(due to the highly C-coupled design in some other parts of the IR).

Thus, I think the best way(at least for now) is to use inline wrappers to merge these two ops, avoiding introducing over-complicated designs for only these two ops.