### PR TITLE
test-requirements: bump minimum pytest needed

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@ flake8-bugbear; python_version >= '3.5'
 flake8-pyi>=20.5; python_version >= '3.6'
 lxml>=4.4.0
 psutil>=4.0
-pytest>=6.0.0,<7.0.0
+pytest>=6.1.0,<7.0.0
 pytest-xdist>=1.34.0,<2.0.0
 pytest-forked>=1.3.0,<2.0.0
 pytest-cov>=2.10.0,<3.0.0


### PR DESCRIPTION
pytest 6.0 causes type checking to fail against master.
Fixes #9671