### PR TITLE
fastparse: fix type checking on 3.8

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -676,11 +676,11 @@ class ASTConverter:
             names.append(args.vararg)
 
         # keyword-only arguments with defaults
-        for a, d in zip(args.kwonlyargs, args.kw_defaults):
+        for a, kd in zip(args.kwonlyargs, args.kw_defaults):
             new_args.append(self.make_argument(
                 a,
-                d,
-                ARG_NAMED if d is None else ARG_NAMED_OPT,
+                kd,
+                ARG_NAMED if kd is None else ARG_NAMED_OPT,
                 no_type_check))
             names.append(a)
 


### PR DESCRIPTION
This got broken by https://github.com/python/typeshed/pull/4740
It took me a little bit to figure out how this evaded all our CI, but
it's because we type check with version 3.5 and mypyc only with 3.5 and
3.7. That is, we do not type check with 3.8 or later and so do not check
against stdlib's AST types.

mypyc wheels did break though, but I'm not sure anyone really looks at
those till they need to. Maybe we should add a badge for them to
the README.

I only noticed this because I was trying to get mypy_primer to mypyc
compile sometimes.