### PR TITLE
disable_errors() and enable_errors() function pair refactored

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1992,10 +1992,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if isinstance(s.expr, EllipsisExpr):
                 return True
             elif isinstance(s.expr, CallExpr):
-                self.expr_checker.msg.disable_errors()
-                typ = get_proper_type(self.expr_checker.accept(
-                    s.expr, allow_none_return=True, always_allow_any=True))
-                self.expr_checker.msg.enable_errors()
+                with self.expr_checker.msg.disable_errors():
+                    typ = get_proper_type(self.expr_checker.accept(
+                        s.expr, allow_none_return=True, always_allow_any=True))
 
                 if isinstance(typ, UninhabitedType):
                     return True
@@ -3046,14 +3045,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         # Here we just infer the type, the result should be type-checked like a normal assignment.
         # For this we use the rvalue as type context.
-        self.msg.disable_errors()
-        _, inferred_dunder_set_type = self.expr_checker.check_call(
-            dunder_set_type,
-            [TempNode(instance_type, context=context), rvalue],
-            [nodes.ARG_POS, nodes.ARG_POS],
-            context, object_type=attribute_type,
-            callable_name=callable_name)
-        self.msg.enable_errors()
+        with self.msg.disable_errors():
+            _, inferred_dunder_set_type = self.expr_checker.check_call(
+                dunder_set_type,
+                [TempNode(instance_type, context=context), rvalue],
+                [nodes.ARG_POS, nodes.ARG_POS],
+                context, object_type=attribute_type,
+                callable_name=callable_name)
 
         # And now we type check the call second time, to show errors related
         # to wrong arguments count, etc.

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -859,12 +859,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         res = []  # type: List[Type]
         for typ in object_type.relevant_items():
             # Member access errors are already reported when visiting the member expression.
-            self.msg.disable_errors()
-            item = analyze_member_access(member, typ, e, False, False, False,
-                                         self.msg, original_type=object_type, chk=self.chk,
-                                         in_literal_context=self.is_literal_context(),
-                                         self_type=typ)
-            self.msg.enable_errors()
+            with self.msg.disable_errors():
+                item = analyze_member_access(member, typ, e, False, False, False,
+                                            self.msg, original_type=object_type, chk=self.chk,
+                                            in_literal_context=self.is_literal_context(),
+                                            self_type=typ)
             narrowed = self.narrow_type_from_binder(e.callee, item, skip_non_overlapping=True)
             if narrowed is None:
                 continue
@@ -1197,12 +1196,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             # due to partial available context information at this time, but
             # these errors can be safely ignored as the arguments will be
             # inferred again later.
-            self.msg.disable_errors()
+            with self.msg.disable_errors():
 
-            arg_types = self.infer_arg_types_in_context(
-                callee_type, args, arg_kinds, formal_to_actual)
-
-            self.msg.enable_errors()
+                arg_types = self.infer_arg_types_in_context(
+                    callee_type, args, arg_kinds, formal_to_actual)
 
             arg_pass_nums = self.get_arg_infer_passes(
                 callee_type.arg_types, formal_to_actual, len(args))

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -13,6 +13,7 @@ from mypy.ordered_dict import OrderedDict
 import re
 import difflib
 from textwrap import dedent
+from contextlib import contextmanager
 
 from typing import cast, List, Dict, Any, Sequence, Iterable, Tuple, Set, Optional, Union
 from typing_extensions import Final
@@ -136,8 +137,11 @@ class MessageBuilder:
                 for info in errs:
                     self.errors.add_error_info(info)
 
+    @contextmanager          
     def disable_errors(self) -> None:
         self.disable_count += 1
+        yield
+        self.disable_count -= 1
 
     def enable_errors(self) -> None:
         self.disable_count -= 1


### PR DESCRIPTION
### Description
Fixes #1184. Refactored occurrences for disable_errors and enable_errors() as described in the issue. 
./runtests.py , runs without errors.