### PR TITLE
Ambiguous **kwargs only map to unmapped arguments that have a matching type.

### DIFF
--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -3,7 +3,8 @@
 from typing import List, Optional, Sequence, Callable, Set
 
 from mypy.types import (
-    Type, Instance, TupleType, AnyType, TypeOfAny, TypedDictType, get_proper_type
+    Type, Instance, TupleType, AnyType, TypeOfAny, TypedDictType, get_proper_type,
+    TypeVarType,
 )
 from mypy import nodes
 
@@ -12,8 +13,8 @@ def map_actuals_to_formals(actual_kinds: List[int],
                            actual_names: Optional[Sequence[Optional[str]]],
                            formal_kinds: List[int],
                            formal_names: Sequence[Optional[str]],
-                           actual_arg_type: Callable[[int],
-                                                     Type]) -> List[List[int]]:
+                           actual_arg_type: Callable[[int], Type],
+                           formal_types: List[Type]) -> List[List[int]]:
     """Calculate mapping between actual (caller) args and formals.
 
     The result contains a list of caller argument indexes mapping to each
@@ -82,7 +83,8 @@ def map_actuals_to_formals(actual_kinds: List[int],
                 ambiguous_actual_kwargs.append(ai)
 
     if ambiguous_actual_kwargs:
-        # Assume the ambiguous kwargs will fill the remaining arguments.
+        # Assume the ambiguous kwargs will fill the remaining arguments where
+        # their types are compatible.
         #
         # TODO: If there are also tuple varargs, we might be missing some potential
         #       matches if the tuple was short enough to not match everything.
@@ -93,24 +95,46 @@ def map_actuals_to_formals(actual_kinds: List[int],
                                  and formal_kinds[fi] != nodes.ARG_STAR)
                              or formal_kinds[fi] == nodes.ARG_STAR2]
         for ai in ambiguous_actual_kwargs:
-            for fi in unmatched_formals:
+            for fi in map_kwargs_to_actuals(get_proper_type(actual_arg_type(ai)),
+                                            actual_kinds[ai], unmatched_formals,
+                                            formal_types, formal_names, formal_kinds):
                 formal_to_actual[fi].append(ai)
-
     return formal_to_actual
+
+
+def map_kwargs_to_actuals(actual_type: Type, actual_kind: int,
+                          formals: List[int],
+                          formal_types: List[Type],
+                          formal_names: Sequence[Optional[str]],
+                          formal_kinds: List[int]) -> List[int]:
+    mapped_formals = []  # type: List[int]
+    from mypy.subtypes import is_subtype
+    for fi in formals:
+        if formal_kinds[fi] == nodes.ARG_STAR:
+            continue
+        mapper = ArgTypeExpander()
+        expanded_actual_type = mapper.expand_actual_type(actual_type, actual_kind,
+                                                         formal_names[fi],
+                                                         formal_kinds[fi])
+        formal_type = formal_types[fi]
+        if is_subtype(expanded_actual_type, formal_type) or isinstance(formal_type, TypeVarType):
+            mapped_formals.append(fi)
+    return mapped_formals
 
 
 def map_formals_to_actuals(actual_kinds: List[int],
                            actual_names: Optional[Sequence[Optional[str]]],
                            formal_kinds: List[int],
                            formal_names: List[Optional[str]],
-                           actual_arg_type: Callable[[int],
-                                                     Type]) -> List[List[int]]:
+                           actual_arg_type: Callable[[int], Type],
+                           formal_types: List[Type]) -> List[List[int]]:
     """Calculate the reverse mapping of map_actuals_to_formals."""
     formal_to_actual = map_actuals_to_formals(actual_kinds,
                                               actual_names,
                                               formal_kinds,
                                               formal_names,
-                                              actual_arg_type)
+                                              actual_arg_type,
+                                              formal_types)
     # Now reverse the mapping.
     actual_to_formal = [[] for _ in actual_kinds]  # type: List[List[int]]
     for formal, actuals in enumerate(formal_to_actual):

--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -83,8 +83,7 @@ def map_actuals_to_formals(actual_kinds: List[int],
                 ambiguous_actual_kwargs.append(ai)
 
     if ambiguous_actual_kwargs:
-        # Assume the ambiguous kwargs will fill the remaining arguments where
-        # their types are compatible.
+        # Assume the ambiguous kwargs will fill the remaining arguments.
         #
         # TODO: If there are also tuple varargs, we might be missing some potential
         #       matches if the tuple was short enough to not match everything.
@@ -95,18 +94,21 @@ def map_actuals_to_formals(actual_kinds: List[int],
                                  and formal_kinds[fi] != nodes.ARG_STAR)
                              or formal_kinds[fi] == nodes.ARG_STAR2]
         for ai in ambiguous_actual_kwargs:
-            for fi in map_kwargs_to_actuals(get_proper_type(actual_arg_type(ai)),
+            for fi in map_kwargs_to_formals(get_proper_type(actual_arg_type(ai)),
                                             actual_kinds[ai], unmatched_formals,
                                             formal_types, formal_names, formal_kinds):
                 formal_to_actual[fi].append(ai)
     return formal_to_actual
 
 
-def map_kwargs_to_actuals(actual_type: Type, actual_kind: int,
+def map_kwargs_to_formals(actual_type: Type, actual_kind: int,
                           formals: List[int],
                           formal_types: List[Type],
                           formal_names: Sequence[Optional[str]],
                           formal_kinds: List[int]) -> List[int]:
+    """Generate the mapping between the actual **kwargs and formal parameters. Any given **kwarg
+    will only map to a parameter which it is type compatible with.
+    """
     from mypy.subtypes import is_subtype
     mapped_formals = []  # type: List[int]
     for fi in formals:

--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -107,8 +107,8 @@ def map_kwargs_to_actuals(actual_type: Type, actual_kind: int,
                           formal_types: List[Type],
                           formal_names: Sequence[Optional[str]],
                           formal_kinds: List[int]) -> List[int]:
-    mapped_formals = []  # type: List[int]
     from mypy.subtypes import is_subtype
+    mapped_formals = []  # type: List[int]
     for fi in formals:
         if formal_kinds[fi] == nodes.ARG_STAR:
             continue

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -312,7 +312,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 e.arg_kinds, e.arg_names,
                 e.callee.arg_kinds, e.callee.arg_names,
                 lambda i: self.accept(e.args[i]),
-                [Any] * len(e.callee.arg_names))
+                [AnyType(TypeOfAny.special_form)] * len(e.callee.arg_names))
             arg_types = [join.join_type_list([self.accept(e.args[j]) for j in formal_to_actual[i]])
                          for i in range(len(e.callee.arg_kinds))]
             type_context = CallableType(arg_types, e.callee.arg_kinds, e.callee.arg_names,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -51,7 +51,7 @@ from mypy import applytype
 from mypy import erasetype
 from mypy.checkmember import analyze_member_access, type_object_type
 from mypy.argmap import (
-    ArgTypeExpander, map_actuals_to_formals, map_formals_to_actuals, map_kwargs_to_actuals
+    ArgTypeExpander, map_actuals_to_formals, map_formals_to_actuals, map_kwargs_to_formals
 )
 from mypy.checkstrformat import StringFormatterChecker
 from mypy.expandtype import expand_type, expand_type_by_instance, freshen_function_type_vars
@@ -1404,7 +1404,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         for i, actualt, actualk in ambiguous_kwargs:
             potential_formals = []  # type: List[int]
             actual_formals = [] # type: List[int]
-            for fi in map_kwargs_to_actuals(actualt, actualk, list(range(len(callee.arg_types))),
+            for fi in map_kwargs_to_formals(actualt, actualk, list(range(len(callee.arg_types))),
                                             callee.arg_types, callee.arg_names, callee.arg_kinds):
                 potential_formals.append(fi)
                 if i in formal_to_actual[fi]:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1523,7 +1523,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         caller_type = get_proper_type(caller_type)
         original_caller_type = get_proper_type(original_caller_type)
         callee_type = get_proper_type(callee_type)
-        
+
         if isinstance(caller_type, DeletedType):
             messages.deleted_as_rvalue(caller_type, context)
         # Only non-abstract non-protocol class can be given where Type[...] is expected...

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1400,10 +1400,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         ambiguous_kwargs = [(i, actualt, actualk)
                             for i, (actualt, actualk) in enumerate(zip(actual_types, actual_kinds))
                             if actualk == nodes.ARG_STAR2
-                                and not isinstance(get_proper_type(actualt), TypedDictType)]
+                            and not isinstance(get_proper_type(actualt), TypedDictType)]
         for i, actualt, actualk in ambiguous_kwargs:
             potential_formals = []  # type: List[int]
-            actual_formals = [] # type: List[int]
+            actual_formals = []  # type: List[int]
             for fi in map_kwargs_to_formals(actualt, actualk, list(range(len(callee.arg_types))),
                                             callee.arg_types, callee.arg_names, callee.arg_kinds):
                 potential_formals.append(fi)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1393,13 +1393,14 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                     actual_kinds: List[int],
                                     context: Context,
                                     messages: MessageBuilder,
-                                    formal_to_actual: List[List[int]]) -> bool:
+                                    formal_to_actual: List[List[int]]) -> None:
         """Each **kwarg supplied to a callable should map to at least one formal
         parameter.
         """
         ambiguous_kwargs = [(i, actualt, actualk)
                             for i, (actualt, actualk) in enumerate(zip(actual_types, actual_kinds))
-                            if actualk == nodes.ARG_STAR2 and not isinstance(actualt, TypedDictType)]
+                            if actualk == nodes.ARG_STAR2
+                                and not isinstance(get_proper_type(actualt), TypedDictType)]
         for i, actualt, actualk in ambiguous_kwargs:
             potential_formals = []  # type: List[int]
             actual_formals = [] # type: List[int]
@@ -1534,7 +1535,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
               (callee_type.item.type.is_abstract or callee_type.item.type.is_protocol)):
             self.msg.concrete_only_call(callee_type, context)
         elif not is_subtype(caller_type, callee_type) and (caller_kind != nodes.ARG_STAR2
-                                                           or isinstance(original_caller_type, TypedDictType)):
+                                                           or isinstance(original_caller_type,
+                                                                         TypedDictType)):
             if self.chk.should_suppress_optional_error([caller_type, callee_type]):
                 return
             code = messages.incompatible_argument(n,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -615,6 +615,27 @@ class MessageBuilder:
         msg = 'Too many arguments' + for_function(callee)
         self.fail(msg, context, code=codes.CALL_ARG)
 
+    def kwargs_has_no_compatible_parameter(self, callee: CallableType, context: Context,
+                                           kwargs_index: int, kwargs_type: Type,
+                                           formals: List[int]) -> None:
+        callee_name = callable_name(callee)
+        kwargs_type_str = format_type(kwargs_type)
+        argument_number = kwargs_index + 1
+        if formals:
+            msg = ('Argument {} in call to {} with type {} cannot unpack into any expected parameters; '
+                   '{} in use'.
+                   format(argument_number,
+                          callee_name,
+                          kwargs_type_str,
+                          ', '.join('"' + callee.arg_names[fi] + '"' for fi in formals)))
+        else:
+            msg = ('Argument {} in call to {} cannot unpack into any parameters; '
+                   'no parameter accepts type {}'.
+                   format(argument_number,
+                          callee_name,
+                          kwargs_type_str))
+        self.fail(msg, context, code=codes.CALL_ARG)
+
     def too_many_arguments_from_typed_dict(self,
                                            callee: CallableType,
                                            arg_type: TypedDictType,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -622,10 +622,11 @@ class MessageBuilder:
         kwargs_type_str = format_type(kwargs_type)
         argument_number = kwargs_index + 1
         if formals:
-            formal_names = ', '.join(('"' + callee.arg_names[fi] + '"')
-                                     if callee.arg_names[fi]
+            formal_names = ', '.join(('"' + name + '"')
+                                     if name
                                      else 'parameter {}'.format(fi)
-                                     for fi in formals)
+                                     for fi, name in enumerate(callee.arg_names[fi]
+                                                               for fi in formals))
             msg = ('Argument {} in call to {} with type {} cannot unpack into any expected '
                    'parameters; {} in use'.
                    format(argument_number, callee_name, kwargs_type_str, formal_names))

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -622,12 +622,13 @@ class MessageBuilder:
         kwargs_type_str = format_type(kwargs_type)
         argument_number = kwargs_index + 1
         if formals:
-            msg = ('Argument {} in call to {} with type {} cannot unpack into any expected parameters; '
-                   '{} in use'.
-                   format(argument_number,
-                          callee_name,
-                          kwargs_type_str,
-                          ', '.join('"' + callee.arg_names[fi] + '"' for fi in formals)))
+            formal_names = ', '.join(('"' + callee.arg_names[fi] + '"')
+                                     if callee.arg_names[fi]
+                                     else 'parameter {}'.format(fi)
+                                     for fi in formals)
+            msg = ('Argument {} in call to {} with type {} cannot unpack into any expected '
+                   'parameters; {} in use'.
+                   format(argument_number, callee_name, kwargs_type_str, formal_names))
         else:
             msg = ('Argument {} in call to {} cannot unpack into any parameters; '
                    'no parameter accepts type {}'.

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -19,8 +19,7 @@ from mypy.nodes import (
     Expression, FuncDef, TypeApplication, AssignmentStmt, NameExpr, CallExpr, MypyFile,
     MemberExpr, OpExpr, ComparisonExpr, IndexExpr, UnaryExpr, YieldFromExpr, RefExpr, ClassDef,
     AssignmentExpr, ImportFrom, Import, ImportAll, PassStmt, BreakStmt, ContinueStmt, StrExpr,
-    BytesExpr, UnicodeExpr, IntExpr, FloatExpr, ComplexExpr, EllipsisExpr, ExpressionStmt, Node,
-    TypeInfo, SymbolTableNode
+    BytesExpr, UnicodeExpr, IntExpr, FloatExpr, ComplexExpr, EllipsisExpr, ExpressionStmt, Node
 )
 from mypy.util import correct_relative_import
 from mypy.argmap import map_formals_to_actuals
@@ -322,40 +321,6 @@ class StatisticsVisitor(TraverserVisitor):
         else:
             kind = TYPE_ANY
         self.record_line(node.line, kind)
-
-    def lookup_typeinfo(self, fullname: str) -> TypeInfo:
-        # Assume that the name refers to a class.
-        sym = self.lookup_qualified(fullname)
-        node = sym.node
-        assert isinstance(node, TypeInfo)
-        return node
-
-    def lookup_qualified(self, name: str) -> SymbolTableNode:
-        if '.' not in name:
-            return self.lookup(name, GDEF)  # FIX kind
-        else:
-            parts = name.split('.')
-            n = self.modules[parts[0]]
-            for i in range(1, len(parts) - 1):
-                sym = n.names.get(parts[i])
-                assert sym is not None, "Internal error: attempted lookup of unknown name"
-                n = cast(MypyFile, sym.node)
-            last = parts[-1]
-            if last in n.names:
-                return n.names[last]
-            elif len(parts) == 2 and parts[0] == 'builtins':
-                fullname = 'builtins.' + last
-                if fullname in SUGGESTED_TEST_FIXTURES:
-                    suggestion = ", e.g. add '[builtins fixtures/{}]' to your test".format(
-                        SUGGESTED_TEST_FIXTURES[fullname])
-                else:
-                    suggestion = ''
-                raise KeyError("Could not find builtin symbol '{}' (If you are running a "
-                               "test case, use a fixture that "
-                               "defines this symbol{})".format(last, suggestion))
-            else:
-                msg = "Failed qualified lookup: '{}' (fullname = '{}')."
-                raise KeyError(msg.format(last, name))
 
     def named_type(self, name: str) -> Instance:
         """Return an instance type with given name and implicit Any type args.

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -322,21 +322,6 @@ class StatisticsVisitor(TraverserVisitor):
             kind = TYPE_ANY
         self.record_line(node.line, kind)
 
-    def named_type(self, name: str) -> Instance:
-        """Return an instance type with given name and implicit Any type args.
-
-        For example, named_type('builtins.object') produces the 'object' type.
-        """
-        # Assume that the name refers to a type.
-        sym = self.lookup_qualified(name)
-        node = sym.node
-        if isinstance(node, TypeAlias):
-            assert isinstance(node.target, Instance)  # type: ignore
-            node = node.target.type
-        assert isinstance(node, TypeInfo)
-        any_type = AnyType(TypeOfAny.from_omitted_generics)
-        return Instance(node, [any_type] * len(node.defn.type_vars))
-
     def type(self, t: Optional[Type]) -> None:
         t = get_proper_type(t)
 

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -158,7 +158,8 @@ class ArgUseFinder(TraverserVisitor):
 
         formal_to_actual = map_actuals_to_formals(
             o.arg_kinds, o.arg_names, typ.arg_kinds, typ.arg_names,
-            lambda n: AnyType(TypeOfAny.special_form))
+            lambda n: AnyType(TypeOfAny.special_form),
+            typ.arg_types)
 
         for i, args in enumerate(formal_to_actual):
             for arg_idx in args:

--- a/mypy/test/testinfer.py
+++ b/mypy/test/testinfer.py
@@ -1,6 +1,6 @@
 """Test cases for type inference helper functions."""
 
-from typing import Any, List, Optional, Tuple, Union, Dict, Set
+from typing import List, Optional, Tuple, Union, Dict, Set
 
 from mypy.test.helpers import Suite, assert_equal
 from mypy.argmap import map_actuals_to_formals

--- a/mypy/test/testinfer.py
+++ b/mypy/test/testinfer.py
@@ -1,6 +1,6 @@
 """Test cases for type inference helper functions."""
 
-from typing import List, Optional, Tuple, Union, Dict, Set
+from typing import Any, List, Optional, Tuple, Union, Dict, Set
 
 from mypy.test.helpers import Suite, assert_equal
 from mypy.argmap import map_actuals_to_formals
@@ -181,7 +181,8 @@ class MapActualsToFormalsSuite(Suite):
             caller_names,
             callee_kinds,
             callee_names,
-            lambda i: AnyType(TypeOfAny.special_form))
+            lambda i: AnyType(TypeOfAny.special_form),
+            [AnyType(TypeOfAny.special_form)] * len(callee_kinds))
         assert_equal(result, expected)
 
     def assert_vararg_map(self,
@@ -195,7 +196,8 @@ class MapActualsToFormalsSuite(Suite):
             [],
             callee_kinds,
             [],
-            lambda i: vararg_type)
+            lambda i: vararg_type,
+            [AnyType(TypeOfAny.special_form)] * len(callee_kinds))
         assert_equal(result, expected)
 
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -333,11 +333,13 @@ class LowLevelIRBuilder:
 
         sig_arg_kinds = [arg.kind for arg in sig.args]
         sig_arg_names = [arg.name for arg in sig.args]
+        sig_arg_types = [arg.type for arg in sig.args]
         formal_to_actual = map_actuals_to_formals(arg_kinds,
                                                   arg_names,
                                                   sig_arg_kinds,
                                                   sig_arg_names,
-                                                  lambda n: AnyType(TypeOfAny.special_form))
+                                                  lambda n: AnyType(TypeOfAny.special_form),
+                                                  sig_arg_types)
 
         # Flatten out the arguments, loading error values for default
         # arguments, constructing tuples/dicts for star args, and

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -333,7 +333,7 @@ class LowLevelIRBuilder:
 
         sig_arg_kinds = [arg.kind for arg in sig.args]
         sig_arg_names = [arg.name for arg in sig.args]
-        sig_arg_types = [arg.type for arg in sig.args]
+        sig_arg_types = [AnyType(TypeOfAny.special_form)] * len(sig_arg_kinds)
         formal_to_actual = map_actuals_to_formals(arg_kinds,
                                                   arg_names,
                                                   sig_arg_kinds,

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 from mypy.nodes import ARG_POS, ARG_NAMED, ARG_STAR, ARG_STAR2, op_methods
-from mypy.types import AnyType, TypeOfAny
+from mypy.types import AnyType, TypeOfAny, Type
 from mypy.checkexpr import map_actuals_to_formals
 
 from mypyc.ir.ops import (
@@ -333,7 +333,7 @@ class LowLevelIRBuilder:
 
         sig_arg_kinds = [arg.kind for arg in sig.args]
         sig_arg_names = [arg.name for arg in sig.args]
-        sig_arg_types = [AnyType(TypeOfAny.special_form)] * len(sig_arg_kinds)
+        sig_arg_types = [AnyType(TypeOfAny.special_form)] * len(sig_arg_kinds)  # type: List[Type]
         formal_to_actual = map_actuals_to_formals(arg_kinds,
                                                   arg_names,
                                                   sig_arg_kinds,

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -72,7 +72,9 @@ def g(**x: int) -> None: pass
 a = ['']
 f(*a)  # E:4: Argument 1 to "f" has incompatible type "*List[str]"; expected "int"
 b = {'x': 'y'}
-g(**b) # E:5: Argument 1 to "g" has incompatible type "**Dict[str, str]"; expected "int"
+# TODO: "too many arguments" error will not appear after #9629 is merged
+g(**b) # E:1: Too many arguments for "g" \
+       # E:1: Argument 1 in call to "g" cannot unpack into any parameters; no parameter accepts type "Dict[str, str]"
 [builtins fixtures/dict.pyi]
 
 [case testColumnsMultipleStatementsPerLine]

--- a/test-data/unit/check-ctypes.test
+++ b/test-data/unit/check-ctypes.test
@@ -182,6 +182,7 @@ import ctypes
 intarr4 = ctypes.c_int * 4
 
 x = {"a": 1, "b": 2}
-intarr4(**x)   # E: Too many arguments for "Array"
+intarr4(**x)  # E: Too many arguments for "Array" \
+              # E: Argument 1 in call to "Array" cannot unpack into any parameters; no parameter accepts type "Dict[str, int]"
 
 [builtins fixtures/floatdict.pyi]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -2217,7 +2217,8 @@ kw2 = {'x': ''}
 d2 = dict(it, **kw2)
 d2() # E: "Dict[str, object]" not callable
 
-d3 = dict(it, **kw2) # type: Dict[str, int] # E: Argument 2 to "dict" has incompatible type "**Dict[str, str]"; expected "int"
+d3 = dict(it, **kw2) # type: Dict[str, int] \
+                     # E: Argument 2 in call to "dict" cannot unpack into any parameters; no parameter accepts type "Dict[str, str]"
 [builtins fixtures/dict.pyi]
 
 [case testDictFromIterableAndStarStarArgs2]

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -299,8 +299,11 @@ d = None # type: Dict[str, A]
 f(**d)
 f(x=A(), **d)
 d2 = None # type: Dict[str, B]
-f(**d2)        # E: Argument 1 to "f" has incompatible type "**Dict[str, B]"; expected "A"
-f(x=A(), **d2) # E: Argument 2 to "f" has incompatible type "**Dict[str, B]"; expected "A"
+# TODO: "too many arguments" errors will not appear after #9629 is merged
+f(**d2)        # E: Too many arguments for "f" \
+               # E: Argument 1 in call to "f" cannot unpack into any parameters; no parameter accepts type "Dict[str, B]"
+f(x=A(), **d2) # E: Too many arguments for "f" \
+               # E: Argument 2 in call to "f" cannot unpack into any parameters; no parameter accepts type "Dict[str, B]"
 class A: pass
 class B: pass
 [builtins fixtures/dict.pyi]
@@ -363,7 +366,7 @@ def f(a: 'A', b: 'B') -> None: pass
 d = None # type: Dict[str, Any]
 f(**d)
 d2 = None # type: Dict[str, A]
-f(**d2) # E: Argument 1 to "f" has incompatible type "**Dict[str, A]"; expected "B"
+f(**d2) # E: Too few arguments for "f"
 class A: pass
 class B: pass
 [builtins fixtures/dict.pyi]
@@ -396,7 +399,8 @@ class A: pass
 from typing import Any, Dict
 def f(*args: 'A') -> None: pass
 d = None # type: Dict[Any, Any]
-f(**d) # E: Too many arguments for "f"
+f(**d) # E: Too many arguments for "f" \
+       # E: Argument 1 in call to "f" cannot unpack into any parameters; no parameter accepts type "Dict[Any, Any]"
 class A: pass
 [builtins fixtures/dict.pyi]
 
@@ -440,7 +444,10 @@ f(**a) # okay
 
 b = {'': ''}
 f(b) # E: Argument 1 to "f" has incompatible type "Dict[str, str]"; expected "int"
-f(**b) # E: Argument 1 to "f" has incompatible type "**Dict[str, str]"; expected "int"
+# TODO: "too many arguments" error will not appear after #9629 is merged
+f(**b) # E: Too many arguments for "f" \
+       # E: Too few arguments for "f" \
+       # E: Argument 1 in call to "f" cannot unpack into any parameters; no parameter accepts type "Dict[str, str]"
 
 c = {0: 0}
 f(**c) # E: Keywords must be strings
@@ -449,6 +456,76 @@ f(**c) # E: Keywords must be strings
 [case testCallStar2WithStar]
 def f(**k): pass
 f(*(1, 2))  # E: Too many arguments for "f"
+[builtins fixtures/dict.pyi]
+
+[case testCallKwargsDifferentTypes]
+from typing import Dict
+class A: pass
+class B: pass
+class C: pass
+
+ad = None # type: Dict[str, A]
+bd = None # type: Dict[str, B]
+cd = None # type: Dict[str, C]
+
+# TODO: "too many arguments" errors will not appear after #9629 is merged
+
+def f1(a: A, b: B): pass
+f1(**ad, **bd)
+f1(**bd, **ad)
+f1(a=A(), **ad, **bd) # E: Too many arguments for "f1" \
+                      # E: Argument 2 in call to "f1" with type "Dict[str, A]" cannot unpack into any expected parameters; "a" in use
+f1(b=B(), **ad, **bd) # E: Too many arguments for "f1" \
+                      # E: Argument 3 in call to "f1" with type "Dict[str, B]" cannot unpack into any expected parameters; "b" in use
+f1(a=A(), b=B(), **ad, **bd) # E: Too many arguments for "f1" \
+                             # E: Argument 3 in call to "f1" with type "Dict[str, A]" cannot unpack into any expected parameters; "a" in use \
+                             # E: Argument 4 in call to "f1" with type "Dict[str, B]" cannot unpack into any expected parameters; "b" in use
+f1(**ad) # E: Too few arguments for "f1"
+f1(b=B(), **ad)
+f1(**bd) # E: Too few arguments for "f1"
+f1(A(), **bd)
+f1(**ad, **bd, **cd) # E: Too many arguments for "f1" \
+                     # E: Argument 3 in call to "f1" cannot unpack into any parameters; no parameter accepts type "Dict[str, C]"
+
+def f2(a: A = A(), b: B = B()): pass
+f2(**ad, **bd)
+f2(**bd, **ad)
+f2(a=A(), **ad, **bd) # E: Too many arguments for "f2" \
+                      # E: Argument 2 in call to "f2" with type "Dict[str, A]" cannot unpack into any expected parameters; "a" in use
+f2(b=B(), **ad, **bd) # E: Too many arguments for "f2" \
+                      # E: Argument 3 in call to "f2" with type "Dict[str, B]" cannot unpack into any expected parameters; "b" in use
+f2(a=A(), b=B(), **ad, **bd) # E: Too many arguments for "f2" \
+                             # E: Argument 3 in call to "f2" with type "Dict[str, A]" cannot unpack into any expected parameters; "a" in use \
+                             # E: Argument 4 in call to "f2" with type "Dict[str, B]" cannot unpack into any expected parameters; "b" in use
+f2(**ad)
+f2(A(), **ad) # E: Too many arguments for "f2" \
+              # E: Argument 2 in call to "f2" with type "Dict[str, A]" cannot unpack into any expected parameters; "a" in use
+f2(**bd)
+f2(b=B(), **bd) # E: Too many arguments for "f2" \
+                # E: Argument 2 in call to "f2" with type "Dict[str, B]" cannot unpack into any expected parameters; "b" in use
+f2(**ad, **bd, **cd)  # E: Too many arguments for "f2" \
+                      # E: Argument 3 in call to "f2" cannot unpack into any parameters; no parameter accepts type "Dict[str, C]"
+f2(**cd) # E: Too many arguments for "f2" \
+         # E: Argument 1 in call to "f2" cannot unpack into any parameters; no parameter accepts type "Dict[str, C]"
+
+def f3(a: A = A(), **bs: B): pass
+f3(**ad, **bd)
+f3(**bd, **ad)
+
+f3(a=A(), **ad, **bd) # E: Too many arguments for "f3" \
+                      # E: Argument 2 in call to "f3" with type "Dict[str, A]" cannot unpack into any expected parameters; "a" in use
+f3(b=B(), **ad, **bd)
+f3(a=A(), b=B(), **ad, **bd) # E: Too many arguments for "f3" \
+                             # E: Argument 3 in call to "f3" with type "Dict[str, A]" cannot unpack into any expected parameters; "a" in use
+f3(**ad)
+f3(A(), **ad) # E: Too many arguments for "f3" \
+              # E: Argument 2 in call to "f3" with type "Dict[str, A]" cannot unpack into any expected parameters; "a" in use
+f3(**bd)
+f3(b=B(), **bd)
+f3(**ad, **bd, **cd) # E: Too many arguments for "f3" \
+                     # E: Argument 3 in call to "f3" cannot unpack into any parameters; no parameter accepts type "Dict[str, C]"
+f3(**cd) # E: Too many arguments for "f3" \
+         # E: Argument 1 in call to "f3" cannot unpack into any parameters; no parameter accepts type "Dict[str, C]"
 [builtins fixtures/dict.pyi]
 
 [case testUnexpectedMethodKwargInNestedClass]
@@ -485,9 +562,9 @@ def g(arg: int = 0, **kwargs: object) -> None:
 
 d = {} # type: Dict[str, object]
 f(**d)
-g(**d)  # E: Argument 1 to "g" has incompatible type "**Dict[str, object]"; expected "int"
+g(**d)
 
 m = {} # type: Mapping[str, object]
 f(**m)
-g(**m)  # TODO: Should be an error
+g(**m)
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -566,5 +566,5 @@ g(**d)
 
 m = {} # type: Mapping[str, object]
 f(**m)
-g(**m) # TODO: Should be an error
+g(**m)  # TODO: Should be an error
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -566,5 +566,5 @@ g(**d)
 
 m = {} # type: Mapping[str, object]
 f(**m)
-g(**m)
+g(**m) # TODO: Should be an error
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1584,8 +1584,11 @@ d = None # type: Dict[Any, Any]
 
 f1(**td, **d)
 f1(**d, **td)
-f2(**td, **d) # E: Too many arguments for "f2"
-f2(**d, **td) # E: Too many arguments for "f2"
+# TODO: the "too many arguments" errors will go away with #9269
+f2(**td, **d) # E: Too many arguments for "f2" \
+              # E: Argument 2 in call to "f2" with type "Dict[Any, Any]" cannot unpack into any expected parameters; "x", "y" in use
+f2(**d, **td) # E: Too many arguments for "f2" \
+              # E: Argument 1 in call to "f2" with type "Dict[Any, Any]" cannot unpack into any expected parameters; "x", "y" in use
 [builtins fixtures/dict.pyi]
 
 [case testTypedDictNonMappingMethods]


### PR DESCRIPTION
### DO NOT MERGE

Just getting some eyes on this for now. There are some consequences to this change discussed in #9676 and that I'll continue here. In any case, should probably wait for #9629 to be merged as there will probably be some merge conflicts.

### Description

Closes #9676

- non-TypedDict **kwargs will only map to parameters which have a compatible type
- introduces a new check for non-TypedDict **kwargs that are not able to map to at least 1 parameter

## Test Plan

Added the `testCallKwargsDifferentTypes` test. 
