### PR TITLE
Fix exception using TypeVars with Generic

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2897,10 +2897,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 return False
         else:
             return False
-        if (not isinstance(lvalue, MemberExpr)
-            or lvalue.def_var not in self.inferred_attribute_types):
-            self.set_inferred_type(name, lvalue, partial_type)
-            self.partial_types[-1].map[name] = lvalue
+        self.set_inferred_type(name, lvalue, partial_type)
+        self.partial_types[-1].map[name] = lvalue
         return True
 
     def is_valid_defaultdict_partial_value_type(self, t: ProperType) -> bool:
@@ -2938,7 +2936,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             var.is_inferred = True
             if isinstance(lvalue, MemberExpr) and self.inferred_attribute_types is not None:
                 # Store inferred attribute type so that we can check consistency afterwards.
-                if lvalue.def_var is not None:
+                if (lvalue.def_var is not None
+                    and lvalue.def_var not in self.inferred_attribute_types):
                     self.inferred_attribute_types[lvalue.def_var] = type
             self.store_type(lvalue, type)
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2897,7 +2897,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 return False
         else:
             return False
-        if (not hasattr(lvalue, "def_var")
+        if (not isinstance(lvalue, MemberExpr)
             or lvalue.def_var not in self.inferred_attribute_types):
             self.set_inferred_type(name, lvalue, partial_type)
             self.partial_types[-1].map[name] = lvalue

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2937,7 +2937,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if isinstance(lvalue, MemberExpr) and self.inferred_attribute_types is not None:
                 # Store inferred attribute type so that we can check consistency afterwards.
                 if (lvalue.def_var is not None
-                    and lvalue.def_var not in self.inferred_attribute_types):
+                        and lvalue.def_var not in self.inferred_attribute_types):
                     self.inferred_attribute_types[lvalue.def_var] = type
             self.store_type(lvalue, type)
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2897,8 +2897,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 return False
         else:
             return False
-        self.set_inferred_type(name, lvalue, partial_type)
-        self.partial_types[-1].map[name] = lvalue
+        if (not hasattr(lvalue, "def_var")
+            or lvalue.def_var not in self.inferred_attribute_types):
+            self.set_inferred_type(name, lvalue, partial_type)
+            self.partial_types[-1].map[name] = lvalue
         return True
 
     def is_valid_defaultdict_partial_value_type(self, t: ProperType) -> bool:

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1679,6 +1679,16 @@ def f(x: T) -> str:
 
 [builtins fixtures/tuple.pyi]
 
+[case testAssignMultipleTypeVars]
+from typing import Generic, TypeVar
+
+T = TypeVar("T", int, str)
+S = TypeVar("S", int, None)
+
+class A(Generic[T, S]):
+    def func(self, arg: S):
+        self.attr = arg
+
 
 -- Subtyping generic callables
 -- ---------------------------


### PR DESCRIPTION
Fixes #9448 

This is problably not the right way to fix this, as I'm not entirely sure what I'm editing, however, it does pass all the tests.

The problem occurs in `infer_variable_type()` under specific circumstances:
https://github.com/python/mypy/blob/master/mypy/checker.py#L2859

The issue only occurs when a `TypeVar` contains `None` _and_ appears second in the `Generic`. i.e. There is no error if you change the test example to `Generic[S, T]`.

This seems to be down to the order in which it evaluates the types, so `self.attr` will be evaluated 4 times as `int`, `None`, `int`, `None` in the test, but switching the order around will evaluate it as `int`, `int`, `None`, `None`.

When it encounters the `None` value, it updates the value in `self.inferred_attribute_types` from `builtins.int*` to `<partial None>` (which happens in the call to `self.infer_partial_type()`). When this is then followed by a subsequent check for `int`, the code hits the `RuntimeError` while calling `is_same_type()`.

When changing `None` to other types (e.g. `str` or `bool`), I noticed that the value is never changed from `builtins.int*`, so my proposed fix is to avoid changing the value entirely if it already exists.