### PR TITLE
[mypyc] Implement dict copy primitive

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -349,6 +349,7 @@ PyObject *CPyDict_Keys(PyObject *dict);
 PyObject *CPyDict_Values(PyObject *dict);
 PyObject *CPyDict_Items(PyObject *dict);
 char CPyDict_Clear(PyObject *dict);
+PyObject *CPyDict_Copy(PyObject *dict);
 PyObject *CPyDict_GetKeysIter(PyObject *dict);
 PyObject *CPyDict_GetItemsIter(PyObject *dict);
 PyObject *CPyDict_GetValuesIter(PyObject *dict);

--- a/mypyc/lib-rt/dict_ops.c
+++ b/mypyc/lib-rt/dict_ops.c
@@ -238,6 +238,13 @@ char CPyDict_Clear(PyObject *dict) {
     return 1;
 }
 
+PyObject *CPyDict_Copy(PyObject *dict) {
+    if (PyDict_CheckExact(dict)) {
+        return PyDict_Copy(dict);
+    }
+    return PyObject_CallMethod(dict, "copy", NULL);
+}
+
 PyObject *CPyDict_GetKeysIter(PyObject *dict) {
     if (PyDict_CheckExact(dict)) {
         // Return dict itself to indicate we can use fast path instead.

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -150,6 +150,14 @@ method_op(
     c_function_name='CPyDict_Clear',
     error_kind=ERR_FALSE)
 
+# dict.copy()
+method_op(
+    name='copy',
+    arg_types=[dict_rprimitive],
+    return_type=dict_rprimitive,
+    c_function_name='CPyDict_Copy',
+    error_kind=ERR_MAGIC)
+
 # list(dict.keys())
 dict_keys_op = custom_op(
     arg_types=[dict_rprimitive],

--- a/mypyc/test-data/fixtures/ir.py
+++ b/mypyc/test-data/fixtures/ir.py
@@ -173,6 +173,7 @@ class dict(Mapping[K, V]):
     def values(self) -> Iterable[V]: pass
     def items(self) -> Iterable[Tuple[K, V]]: pass
     def clear(self) -> None: pass
+    def copy(self) -> Dict[K, V]: pass
 
 class set(Generic[T]):
     def __init__(self, i: Optional[Iterable[T]] = None) -> None: pass

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -324,3 +324,14 @@ def f(d):
 L0:
     r0 = CPyDict_Clear(d)
     return 1
+
+[case testDictCopy]
+from typing import Dict
+def f(d: Dict[int, int]) -> Dict[int, int]:
+    return d.copy()
+[out]
+def f(d):
+    d, r0 :: dict
+L0:
+    r0 = CPyDict_Copy(d)
+    return r0

--- a/mypyc/test-data/run-dicts.test
+++ b/mypyc/test-data/run-dicts.test
@@ -206,3 +206,14 @@ def test_dict_clear() -> None:
     dd['a'] = 1
     dd.clear()
     assert dd == {}
+
+def test_dict_copy() -> None:
+    d: Dict[str, int] = {}
+    assert d.copy() == d
+    d = {'a': 1, 'b': 2}
+    assert d.copy() == d
+    assert d.copy() is not d
+    dd: Dict[str, int] = defaultdict(int)
+    dd['a'] = 1
+    assert dd.copy() == dd
+    assert isinstance(dd.copy(), defaultdict)


### PR DESCRIPTION
## Description

Implements dict copy primitive for improved performance.

Related ticket: https://github.com/mypyc/mypyc/issues/644

## Test Plan

Ensure that both copying an empty and an non-empty dict works as expected, meaning that the original and the copied dicts contain the same key-values.

### Generated IR

The following script was used:
```python
d = {'a': 1, 'b': 2, 'c': 3}
c = d.copy()
print(c)
```

Master branch:

```
def __top_level__():
    r0, r1 :: object
    r2 :: bit
    r3 :: str
    r4 :: object
    r5, r6, r7 :: str
    r8, r9, r10 :: object
    r11, r12 :: dict
    r13 :: str
    r14 :: int32
    r15 :: bit
    r16 :: dict
    r17 :: str
    r18 :: object
    r19 :: dict
    r20 :: str
    r21 :: object
    r22, r23 :: dict
    r24 :: str
    r25 :: int32
    r26 :: bit
    r27 :: dict
    r28 :: str
    r29 :: object
    r30 :: dict
    r31 :: object
    r32 :: str
    r33, r34 :: object
    r35 :: None
L0:
    r0 = builtins :: module
    r1 = load_address _Py_NoneStruct
    r2 = r0 != r1
    if r2 goto L3 else goto L1 :: bool
L1:
    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
    r4 = PyImport_Import(r3)
    if is_error(r4) goto L15 (error at <module>:-1) else goto L2
L2:
    builtins = r4 :: module
    dec_ref r4
L3:
    r5 = load_global CPyStatic_unicode_1 :: static  ('a')
    r6 = load_global CPyStatic_unicode_2 :: static  ('b')
    r7 = load_global CPyStatic_unicode_3 :: static  ('c')
    r8 = box(short_int, 2)
    r9 = box(short_int, 4)
    r10 = box(short_int, 6)
    r11 = CPyDict_Build(3, r5, r8, r6, r9, r7, r10)
    dec_ref r8
    dec_ref r9
    dec_ref r10
    if is_error(r11) goto L15 (error at <module>:1) else goto L4
L4:
    r12 = program.globals :: static
    r13 = load_global CPyStatic_unicode_4 :: static  ('d')
    r14 = CPyDict_SetItem(r12, r13, r11)
    dec_ref r11
    r15 = r14 >= 0 :: signed
    if not r15 goto L15 (error at <module>:1) else goto L5 :: bool
L5:
    r16 = program.globals :: static
    r17 = load_global CPyStatic_unicode_4 :: static  ('d')
    r18 = CPyDict_GetItem(r16, r17)
    if is_error(r18) goto L15 (error at <module>:2) else goto L6
L6:
    r19 = cast(dict, r18)
    if is_error(r19) goto L15 (error at <module>:2) else goto L7
L7:
    r20 = load_global CPyStatic_unicode_5 :: static  ('copy')
    r21 = CPyObject_CallMethodObjArgs(r19, r20, 0)
    dec_ref r19
    if is_error(r21) goto L15 (error at <module>:2) else goto L8
L8:
    r22 = cast(dict, r21)
    if is_error(r22) goto L15 (error at <module>:2) else goto L9
L9:
    r23 = program.globals :: static
    r24 = load_global CPyStatic_unicode_3 :: static  ('c')
    r25 = CPyDict_SetItem(r23, r24, r22)
    dec_ref r22
    r26 = r25 >= 0 :: signed
    if not r26 goto L15 (error at <module>:2) else goto L10 :: bool
L10:
    r27 = program.globals :: static
    r28 = load_global CPyStatic_unicode_3 :: static  ('c')
    r29 = CPyDict_GetItem(r27, r28)
    if is_error(r29) goto L15 (error at <module>:3) else goto L11
L11:
    r30 = cast(dict, r29)
    if is_error(r30) goto L15 (error at <module>:3) else goto L12
L12:
    r31 = builtins :: module
    r32 = load_global CPyStatic_unicode_6 :: static  ('print')
    r33 = CPyObject_GetAttr(r31, r32)
    if is_error(r33) goto L16 (error at <module>:3) else goto L13
L13:
    r34 = PyObject_CallFunctionObjArgs(r33, r30, 0)
    dec_ref r33
    dec_ref r30
    if is_error(r34) goto L15 (error at <module>:3) else goto L17
L14:
    return 1
L15:
    r35 = <error> :: None
    return r35
L16:
    dec_ref r30
    goto L15
L17:
    dec_ref r34
    goto L14
```

PR:

```
def __top_level__():
    r0, r1 :: object
    r2 :: bit
    r3 :: str
    r4 :: object
    r5, r6, r7 :: str
    r8, r9, r10 :: object
    r11, r12 :: dict
    r13 :: str
    r14 :: int32
    r15 :: bit
    r16 :: dict
    r17 :: str
    r18 :: object
    r19, r20, r21 :: dict
    r22 :: str
    r23 :: int32
    r24 :: bit
    r25 :: dict
    r26 :: str
    r27 :: object
    r28 :: dict
    r29 :: object
    r30 :: str
    r31, r32 :: object
    r33 :: None
L0:
    r0 = builtins :: module
    r1 = load_address _Py_NoneStruct
    r2 = r0 != r1
    if r2 goto L3 else goto L1 :: bool
L1:
    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
    r4 = PyImport_Import(r3)
    if is_error(r4) goto L14 (error at <module>:-1) else goto L2
L2:
    builtins = r4 :: module
    dec_ref r4
L3:
    r5 = load_global CPyStatic_unicode_1 :: static  ('a')
    r6 = load_global CPyStatic_unicode_2 :: static  ('b')
    r7 = load_global CPyStatic_unicode_3 :: static  ('c')
    r8 = box(short_int, 2)
    r9 = box(short_int, 4)
    r10 = box(short_int, 6)
    r11 = CPyDict_Build(3, r5, r8, r6, r9, r7, r10)
    dec_ref r8
    dec_ref r9
    dec_ref r10
    if is_error(r11) goto L14 (error at <module>:1) else goto L4
L4:
    r12 = program.globals :: static
    r13 = load_global CPyStatic_unicode_4 :: static  ('d')
    r14 = CPyDict_SetItem(r12, r13, r11)
    dec_ref r11
    r15 = r14 >= 0 :: signed
    if not r15 goto L14 (error at <module>:1) else goto L5 :: bool
L5:
    r16 = program.globals :: static
    r17 = load_global CPyStatic_unicode_4 :: static  ('d')
    r18 = CPyDict_GetItem(r16, r17)
    if is_error(r18) goto L14 (error at <module>:2) else goto L6
L6:
    r19 = cast(dict, r18)
    if is_error(r19) goto L14 (error at <module>:2) else goto L7
L7:
    r20 = CPyDict_Copy(r19)
    dec_ref r19
    if is_error(r20) goto L14 (error at <module>:2) else goto L8
L8:
    r21 = program.globals :: static
    r22 = load_global CPyStatic_unicode_3 :: static  ('c')
    r23 = CPyDict_SetItem(r21, r22, r20)
    dec_ref r20
    r24 = r23 >= 0 :: signed
    if not r24 goto L14 (error at <module>:2) else goto L9 :: bool
L9:
    r25 = program.globals :: static
    r26 = load_global CPyStatic_unicode_3 :: static  ('c')
    r27 = CPyDict_GetItem(r25, r26)
    if is_error(r27) goto L14 (error at <module>:3) else goto L10
L10:
    r28 = cast(dict, r27)
    if is_error(r28) goto L14 (error at <module>:3) else goto L11
L11:
    r29 = builtins :: module
    r30 = load_global CPyStatic_unicode_5 :: static  ('print')
    r31 = CPyObject_GetAttr(r29, r30)
    if is_error(r31) goto L15 (error at <module>:3) else goto L12
L12:
    r32 = PyObject_CallFunctionObjArgs(r31, r28, 0)
    dec_ref r31
    dec_ref r28
    if is_error(r32) goto L14 (error at <module>:3) else goto L16
L13:
    return 1
L14:
    r33 = <error> :: None
    return r33
L15:
    dec_ref r28
    goto L14
L16:
    dec_ref r32
    goto L13
```

### Performance

Sample script:

```python
d = {'a': 1, 'b': 2, 'c': 3}
for i in range(100000):
    c = d.copy()
```

Master branch: **1.09x** speedup
PR: **1.27x** speedup
