### PR TITLE
[mypyc] Implement dict clear primitive

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -347,6 +347,7 @@ PyObject *CPyDict_ItemsView(PyObject *dict);
 PyObject *CPyDict_Keys(PyObject *dict);
 PyObject *CPyDict_Values(PyObject *dict);
 PyObject *CPyDict_Items(PyObject *dict);
+void CPyDict_Clear(PyObject *dict);
 PyObject *CPyDict_GetKeysIter(PyObject *dict);
 PyObject *CPyDict_GetItemsIter(PyObject *dict);
 PyObject *CPyDict_GetValuesIter(PyObject *dict);

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -347,7 +347,7 @@ PyObject *CPyDict_ItemsView(PyObject *dict);
 PyObject *CPyDict_Keys(PyObject *dict);
 PyObject *CPyDict_Values(PyObject *dict);
 PyObject *CPyDict_Items(PyObject *dict);
-void CPyDict_Clear(PyObject *dict);
+char CPyDict_Clear(PyObject *dict);
 PyObject *CPyDict_GetKeysIter(PyObject *dict);
 PyObject *CPyDict_GetItemsIter(PyObject *dict);
 PyObject *CPyDict_GetValuesIter(PyObject *dict);

--- a/mypyc/lib-rt/dict_ops.c
+++ b/mypyc/lib-rt/dict_ops.c
@@ -226,6 +226,14 @@ PyObject *CPyDict_Items(PyObject *dict) {
     return list;
 }
 
+void CPyDict_Clear(PyObject *dict) {
+    if (PyDict_CheckExact(dict)) {
+        PyDict_Clear(dict);
+    } else {
+        PyObject_CallMethod(dict, "clear", NULL);
+    }
+}
+
 PyObject *CPyDict_GetKeysIter(PyObject *dict) {
     if (PyDict_CheckExact(dict)) {
         // Return dict itself to indicate we can use fast path instead.

--- a/mypyc/lib-rt/dict_ops.c
+++ b/mypyc/lib-rt/dict_ops.c
@@ -226,12 +226,16 @@ PyObject *CPyDict_Items(PyObject *dict) {
     return list;
 }
 
-void CPyDict_Clear(PyObject *dict) {
+char CPyDict_Clear(PyObject *dict) {
     if (PyDict_CheckExact(dict)) {
         PyDict_Clear(dict);
     } else {
-        PyObject_CallMethod(dict, "clear", NULL);
+        PyObject *res = PyObject_CallMethod(dict, "clear", NULL);
+        if (res == NULL) {
+            return 0;
+        }
     }
+    return 1;
 }
 
 PyObject *CPyDict_GetKeysIter(PyObject *dict) {

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -148,7 +148,7 @@ method_op(
     arg_types=[dict_rprimitive],
     return_type=void_rtype,
     c_function_name='CPyDict_Clear',
-    error_kind=ERR_NEVER)
+    error_kind=ERR_MAGIC)
 
 # list(dict.keys())
 dict_keys_op = custom_op(

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -2,7 +2,7 @@
 
 from mypyc.ir.ops import ERR_FALSE, ERR_MAGIC, ERR_NEVER
 from mypyc.ir.rtypes import (
-    dict_rprimitive, object_rprimitive, bool_rprimitive, int_rprimitive, void_rtype,
+    dict_rprimitive, object_rprimitive, bool_rprimitive, int_rprimitive,
     list_rprimitive, dict_next_rtuple_single, dict_next_rtuple_pair, c_pyssize_t_rprimitive,
     c_int_rprimitive, bit_rprimitive
 )
@@ -146,9 +146,9 @@ method_op(
 method_op(
     name='clear',
     arg_types=[dict_rprimitive],
-    return_type=void_rtype,
+    return_type=bit_rprimitive,
     c_function_name='CPyDict_Clear',
-    error_kind=ERR_MAGIC)
+    error_kind=ERR_FALSE)
 
 # list(dict.keys())
 dict_keys_op = custom_op(

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -2,7 +2,7 @@
 
 from mypyc.ir.ops import ERR_FALSE, ERR_MAGIC, ERR_NEVER
 from mypyc.ir.rtypes import (
-    dict_rprimitive, object_rprimitive, bool_rprimitive, int_rprimitive,
+    dict_rprimitive, object_rprimitive, bool_rprimitive, int_rprimitive, void_rtype,
     list_rprimitive, dict_next_rtuple_single, dict_next_rtuple_pair, c_pyssize_t_rprimitive,
     c_int_rprimitive, bit_rprimitive
 )
@@ -141,6 +141,14 @@ method_op(
     return_type=object_rprimitive,
     c_function_name='CPyDict_ItemsView',
     error_kind=ERR_MAGIC)
+
+# dict.clear()
+c_method_op(
+    name='clear',
+    arg_types=[dict_rprimitive],
+    return_type=void_rtype,
+    c_function_name='PyDict_Clear',
+    error_kind=ERR_NEVER)
 
 # list(dict.keys())
 dict_keys_op = custom_op(

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -143,11 +143,11 @@ method_op(
     error_kind=ERR_MAGIC)
 
 # dict.clear()
-c_method_op(
+method_op(
     name='clear',
     arg_types=[dict_rprimitive],
     return_type=void_rtype,
-    c_function_name='PyDict_Clear',
+    c_function_name='CPyDict_Clear',
     error_kind=ERR_NEVER)
 
 # list(dict.keys())

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -321,5 +321,5 @@ def f(d: Dict[int, int]) -> None:
 def f(d):
     d :: dict
 L0:
-    PyDict_Clear(d)
+    CPyDict_Clear(d)
     return 1

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -320,6 +320,7 @@ def f(d: Dict[int, int]) -> None:
 [out]
 def f(d):
     d :: dict
+    r0 :: bit
 L0:
-    CPyDict_Clear(d)
+    r0 = CPyDict_Clear(d)
     return 1

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -312,3 +312,14 @@ L0:
     r0 = load_address PyDict_Type
     x = r0
     return 1
+
+[case testDictClear]
+from typing import Dict
+def f(d: Dict[int, int]) -> None:
+    return d.clear()
+[out]
+def f(d):
+    d :: dict
+L0:
+    PyDict_Clear(d)
+    return 1

--- a/mypyc/test-data/run-dicts.test
+++ b/mypyc/test-data/run-dicts.test
@@ -91,6 +91,10 @@ od.move_to_end(1)
 assert get_content(od) == ([3, 1], [4, 2], [(3, 4), (1, 2)])
 assert get_content_set({1: 2}) == ({1}, {2}, {(1, 2)})
 assert get_content_set(od) == ({1, 3}, {2, 4}, {(1, 2), (3, 4)})
+
+d = {'a': 1, 'b': 2}
+d.clear()
+assert d == {}
 [typing fixtures/typing-full.pyi]
 
 [case testDictIterationMethodsRun]

--- a/mypyc/test-data/run-dicts.test
+++ b/mypyc/test-data/run-dicts.test
@@ -92,6 +92,7 @@ assert get_content(od) == ([3, 1], [4, 2], [(3, 4), (1, 2)])
 assert get_content_set({1: 2}) == ({1}, {2}, {(1, 2)})
 assert get_content_set(od) == ({1, 3}, {2, 4}, {(1, 2), (3, 4)})
 
+from collections import defaultdict
 d = {'a': 1, 'b': 2}
 d.clear()
 assert d == {}

--- a/mypyc/test-data/run-dicts.test
+++ b/mypyc/test-data/run-dicts.test
@@ -96,9 +96,10 @@ from collections import defaultdict
 d = {'a': 1, 'b': 2}
 d.clear()
 assert d == {}
-d = defaultdict(int)
-d.clear()
-assert d == {}
+dd: Dict[str, int] = defaultdict(int)
+dd['a'] = 1
+dd.clear()
+assert dd == {}
 [typing fixtures/typing-full.pyi]
 
 [case testDictIterationMethodsRun]

--- a/mypyc/test-data/run-dicts.test
+++ b/mypyc/test-data/run-dicts.test
@@ -95,6 +95,9 @@ assert get_content_set(od) == ({1, 3}, {2, 4}, {(1, 2), (3, 4)})
 d = {'a': 1, 'b': 2}
 d.clear()
 assert d == {}
+d = defaultdict(int)
+d.clear()
+assert d == {}
 [typing fixtures/typing-full.pyi]
 
 [case testDictIterationMethodsRun]

--- a/mypyc/test-data/run-dicts.test
+++ b/mypyc/test-data/run-dicts.test
@@ -92,14 +92,6 @@ assert get_content(od) == ([3, 1], [4, 2], [(3, 4), (1, 2)])
 assert get_content_set({1: 2}) == ({1}, {2}, {(1, 2)})
 assert get_content_set(od) == ({1, 3}, {2, 4}, {(1, 2), (3, 4)})
 
-from collections import defaultdict
-d = {'a': 1, 'b': 2}
-d.clear()
-assert d == {}
-dd: Dict[str, int] = defaultdict(int)
-dd['a'] = 1
-dd.clear()
-assert dd == {}
 [typing fixtures/typing-full.pyi]
 
 [case testDictIterationMethodsRun]
@@ -201,3 +193,16 @@ else:
 2
 4
 2
+
+[case testDictMethods]
+from collections import defaultdict
+from typing import Dict
+
+def test_dict_clear() -> None:
+    d = {'a': 1, 'b': 2}
+    d.clear()
+    assert d == {}
+    dd: Dict[str, int] = defaultdict(int)
+    dd['a'] = 1
+    dd.clear()
+    assert dd == {}


### PR DESCRIPTION
### Description

Implements dict clear primitive for improved performance.

Related ticket: mypyc/mypyc#644

## Test Plan

Ensure that clearing a dict works as expected, write tests and calculate performance improvements.

## Generated IR

The following script was used:
```python
d = {'a': 1, 'b': 2, 'c': 3}
d.clear()
print(d)
```

Master branch:

```
def __top_level__():
    r0, r1 :: object
    r2 :: bit
    r3 :: str
    r4 :: object
    r5, r6, r7 :: str
    r8, r9, r10 :: object
    r11, r12 :: dict
    r13 :: str
    r14 :: int32
    r15 :: bit
    r16 :: dict
    r17 :: str
    r18 :: object
    r19 :: dict
    r20 :: str
    r21 :: object
    r22 :: dict
    r23 :: str
    r24 :: object
    r25 :: dict
    r26 :: object
    r27 :: str
    r28, r29 :: object
    r30 :: None
L0:
    r0 = builtins :: module
    r1 = load_address _Py_NoneStruct
    r2 = r0 != r1
    if r2 goto L3 else goto L1 :: bool
L1:
    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
    r4 = PyImport_Import(r3)
    if is_error(r4) goto L13 (error at <module>:-1) else goto L2
L2:
    builtins = r4 :: module
    dec_ref r4
L3:
    r5 = load_global CPyStatic_unicode_1 :: static  ('a')
    r6 = load_global CPyStatic_unicode_2 :: static  ('b')
    r7 = load_global CPyStatic_unicode_3 :: static  ('c')
    r8 = box(short_int, 2)
    r9 = box(short_int, 4)
    r10 = box(short_int, 6)
    r11 = CPyDict_Build(3, r5, r8, r6, r9, r7, r10)
    dec_ref r8
    dec_ref r9
    dec_ref r10
    if is_error(r11) goto L13 (error at <module>:1) else goto L4
L4:
    r12 = program.globals :: static
    r13 = load_global CPyStatic_unicode_4 :: static  ('d')
    r14 = CPyDict_SetItem(r12, r13, r11)
    dec_ref r11
    r15 = r14 >= 0 :: signed
    if not r15 goto L13 (error at <module>:1) else goto L5 :: bool
L5:
    r16 = program.globals :: static
    r17 = load_global CPyStatic_unicode_4 :: static  ('d')
    r18 = CPyDict_GetItem(r16, r17)
    if is_error(r18) goto L13 (error at <module>:2) else goto L6
L6:
    r19 = cast(dict, r18)
    if is_error(r19) goto L13 (error at <module>:2) else goto L7
L7:
    r20 = load_global CPyStatic_unicode_5 :: static  ('clear')
    r21 = CPyObject_CallMethodObjArgs(r19, r20, 0)
    dec_ref r19
    if is_error(r21) goto L13 (error at <module>:2) else goto L14
L8:
    r22 = program.globals :: static
    r23 = load_global CPyStatic_unicode_4 :: static  ('d')
    r24 = CPyDict_GetItem(r22, r23)
    if is_error(r24) goto L13 (error at <module>:3) else goto L9
L9:
    r25 = cast(dict, r24)
    if is_error(r25) goto L13 (error at <module>:3) else goto L10
L10:
    r26 = builtins :: module
    r27 = load_global CPyStatic_unicode_6 :: static  ('print')
    r28 = CPyObject_GetAttr(r26, r27)
    if is_error(r28) goto L15 (error at <module>:3) else goto L11
L11:
    r29 = PyObject_CallFunctionObjArgs(r28, r25, 0)
    dec_ref r28
    dec_ref r25
    if is_error(r29) goto L13 (error at <module>:3) else goto L16
L12:
    return 1
L13:
    r30 = <error> :: None
    return r30
L14:
    dec_ref r21
    goto L8
L15:
    dec_ref r25
    goto L13
L16:
    dec_ref r29
    goto L12
```

PR:

```
def __top_level__():
    r0, r1 :: object
    r2 :: bit
    r3 :: str
    r4 :: object
    r5, r6, r7 :: str
    r8, r9, r10 :: object
    r11, r12 :: dict
    r13 :: str
    r14 :: int32
    r15 :: bit
    r16 :: dict
    r17 :: str
    r18 :: object
    r19, r20 :: dict
    r21 :: str
    r22 :: object
    r23 :: dict
    r24 :: object
    r25 :: str
    r26, r27 :: object
    r28 :: None
L0:
    r0 = builtins :: module
    r1 = load_address _Py_NoneStruct
    r2 = r0 != r1
    if r2 goto L3 else goto L1 :: bool
L1:
    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
    r4 = PyImport_Import(r3)
    if is_error(r4) goto L12 (error at <module>:-1) else goto L2
L2:
    builtins = r4 :: module
    dec_ref r4
L3:
    r5 = load_global CPyStatic_unicode_1 :: static  ('a')
    r6 = load_global CPyStatic_unicode_2 :: static  ('b')
    r7 = load_global CPyStatic_unicode_3 :: static  ('c')
    r8 = box(short_int, 2)
    r9 = box(short_int, 4)
    r10 = box(short_int, 6)
    r11 = CPyDict_Build(3, r5, r8, r6, r9, r7, r10)
    dec_ref r8
    dec_ref r9
    dec_ref r10
    if is_error(r11) goto L12 (error at <module>:1) else goto L4
L4:
    r12 = program.globals :: static
    r13 = load_global CPyStatic_unicode_4 :: static  ('d')
    r14 = CPyDict_SetItem(r12, r13, r11)
    dec_ref r11
    r15 = r14 >= 0 :: signed
    if not r15 goto L12 (error at <module>:1) else goto L5 :: bool
L5:
    r16 = program.globals :: static
    r17 = load_global CPyStatic_unicode_4 :: static  ('d')
    r18 = CPyDict_GetItem(r16, r17)
    if is_error(r18) goto L12 (error at <module>:2) else goto L6
L6:
    r19 = cast(dict, r18)
    if is_error(r19) goto L12 (error at <module>:2) else goto L7
L7:
    CPyDict_Clear(r19)
    dec_ref r19
    r20 = program.globals :: static
    r21 = load_global CPyStatic_unicode_4 :: static  ('d')
    r22 = CPyDict_GetItem(r20, r21)
    if is_error(r22) goto L12 (error at <module>:3) else goto L8
L8:
    r23 = cast(dict, r22)
    if is_error(r23) goto L12 (error at <module>:3) else goto L9
L9:
    r24 = builtins :: module
    r25 = load_global CPyStatic_unicode_5 :: static  ('print')
    r26 = CPyObject_GetAttr(r24, r25)
    if is_error(r26) goto L13 (error at <module>:3) else goto L10
L10:
    r27 = PyObject_CallFunctionObjArgs(r26, r23, 0)
    dec_ref r26
    dec_ref r23
    if is_error(r27) goto L12 (error at <module>:3) else goto L14
L11:
    return 1
L12:
    r28 = <error> :: None
    return r28
L13:
    dec_ref r23
    goto L12
L14:
    dec_ref r27
    goto L11
```

## Performance

The following script was used:

```python
for i in range(1000000):
    d = {'a': 1, 'b': 2, 'c': 3}
    d.clear()
```

Master branch: **0.97x** (In this test, I mostly noticed a slowdown compared to running the script as is with Python 3.8)
PR: **1.14x speedup**