### PR TITLE
[mypyc] Implement list insert primitive

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -323,6 +323,7 @@ bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value);
 PyObject *CPyList_PopLast(PyObject *obj);
 PyObject *CPyList_Pop(PyObject *obj, CPyTagged index);
 CPyTagged CPyList_Count(PyObject *obj, PyObject *value);
+CPyTagged CPyList_Insert(PyObject *list, CPyTagged index, PyObject *value);
 PyObject *CPyList_Extend(PyObject *o1, PyObject *o2);
 PyObject *CPySequence_Multiply(PyObject *seq, CPyTagged t_size);
 PyObject *CPySequence_RMultiply(CPyTagged t_size, PyObject *seq);

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -323,7 +323,7 @@ bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value);
 PyObject *CPyList_PopLast(PyObject *obj);
 PyObject *CPyList_Pop(PyObject *obj, CPyTagged index);
 CPyTagged CPyList_Count(PyObject *obj, PyObject *value);
-CPyTagged CPyList_Insert(PyObject *list, CPyTagged index, PyObject *value);
+int CPyList_Insert(PyObject *list, CPyTagged index, PyObject *value);
 PyObject *CPyList_Extend(PyObject *o1, PyObject *o2);
 PyObject *CPySequence_Multiply(PyObject *seq, CPyTagged t_size);
 PyObject *CPySequence_RMultiply(CPyTagged t_size, PyObject *seq);

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -108,7 +108,7 @@ CPyTagged CPyList_Count(PyObject *obj, PyObject *value)
     return list_count((PyListObject *)obj, value);
 }
 
-CPyTagged CPyList_Insert(PyObject *list, CPyTagged index, PyObject *value)
+int CPyList_Insert(PyObject *list, CPyTagged index, PyObject *value)
 {
     if (CPyTagged_CheckShort(index)) {
         Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -108,6 +108,15 @@ CPyTagged CPyList_Count(PyObject *obj, PyObject *value)
     return list_count((PyListObject *)obj, value);
 }
 
+CPyTagged CPyList_Insert(PyObject *list, CPyTagged index, PyObject *value)
+{
+    if (CPyTagged_CheckShort(index)) {
+        Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);
+        return PyList_Insert(list, n, value);
+    }
+    return -1;
+}
+
 PyObject *CPyList_Extend(PyObject *o1, PyObject *o2) {
     return _PyList_Extend((PyListObject *)o1, o2);
 }

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -110,7 +110,7 @@ method_op(
     name='insert',
     arg_types=[list_rprimitive, int_rprimitive, object_rprimitive],
     return_type=int_rprimitive,
-    c_function_name='PyList_Insert',
+    c_function_name='CPyList_Insert',
     error_kind=ERR_MAGIC)
 
 # list * int

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -109,7 +109,7 @@ method_op(
 method_op(
     name='insert',
     arg_types=[list_rprimitive, int_rprimitive, object_rprimitive],
-    return_type=int_rprimitive,
+    return_type=c_int_rprimitive,
     c_function_name='CPyList_Insert',
     error_kind=ERR_NEG_INT)
 

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -111,7 +111,7 @@ method_op(
     arg_types=[list_rprimitive, int_rprimitive, object_rprimitive],
     return_type=int_rprimitive,
     c_function_name='CPyList_Insert',
-    error_kind=ERR_MAGIC)
+    error_kind=ERR_NEG_INT)
 
 # list * int
 binary_op(

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -105,6 +105,14 @@ method_op(
     c_function_name='CPyList_Count',
     error_kind=ERR_MAGIC)
 
+# list.insert(index, obj)
+method_op(
+    name='insert',
+    arg_types=[list_rprimitive, int_rprimitive, object_rprimitive],
+    return_type=int_rprimitive,
+    c_function_name='PyList_Insert',
+    error_kind=ERR_MAGIC)
+
 # list * int
 binary_op(
     name='*',

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -246,5 +246,5 @@ def f(x, y):
     r1 :: int
 L0:
     r0 = box(int, y)
-    r1 = PyList_Insert(x, 0, r0)
+    r1 = CPyList_Insert(x, 0, r0)
     return 1

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -233,3 +233,18 @@ L0:
     r2 = r1 >= 0 :: signed
     r3 = truncate r1: int32 to builtins.bool
     return r3
+
+[case testListInsert]
+from typing import List
+def f(x: List[int], y: int) -> None:
+    x.insert(0, y)
+[out]
+def f(x, y):
+    x :: list
+    y :: int
+    r0 :: object
+    r1 :: int
+L0:
+    r0 = box(int, y)
+    r1 = PyList_Insert(x, 0, r0)
+    return 1

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -243,8 +243,10 @@ def f(x, y):
     x :: list
     y :: int
     r0 :: object
-    r1 :: int
+    r1 :: int32
+    r2 :: bit
 L0:
     r0 = box(int, y)
     r1 = CPyList_Insert(x, 0, r0)
+    r2 = r1 >= 0 :: signed
     return 1

--- a/mypyc/test-data/run-lists.test
+++ b/mypyc/test-data/run-lists.test
@@ -103,6 +103,12 @@ pop(l, -2)
 assert l == [1, 3]
 assert count(l, 1) == 1
 assert count(l, 2) == 0
+l.insert(0, 0)
+assert l == [0, 1, 3]
+l.insert(2, 2)
+assert l == [0, 1, 2, 3]
+l.insert(4, 4)
+assert l == [0, 1, 2, 3, 4]
 
 [case testListOfUserDefinedClass]
 class C:


### PR DESCRIPTION
## Description

Implements list insert primitive for improved performance.

Related ticket: https://github.com/mypyc/mypyc/issues/644

## Test Plan

Ensure that inserting at the start, middle and end of a list works as expected, check performance improvements.

### Generated IR

The following script was used:
```python
from typing import List
l : List[int] = []
l.insert(0, 1)
```

Master branch:

```
def __top_level__():
    r0, r1 :: object
    r2 :: bit
    r3 :: str
    r4, r5, r6 :: object
    r7 :: bit
    r8 :: str
    r9, r10 :: object
    r11 :: dict
    r12 :: str
    r13 :: object
    r14 :: str
    r15 :: int32
    r16 :: bit
    r17 :: list
    r18 :: dict
    r19 :: str
    r20 :: int32
    r21 :: bit
    r22 :: dict
    r23 :: str
    r24 :: object
    r25 :: list
    r26 :: str
    r27, r28, r29 :: object
    r30 :: None
L0:
    r0 = builtins :: module
    r1 = load_address _Py_NoneStruct
    r2 = r0 != r1
    if r2 goto L3 else goto L1 :: bool
L1:
    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
    r4 = PyImport_Import(r3)
    if is_error(r4) goto L14 (error at <module>:-1) else goto L2
L2:
    builtins = r4 :: module
    dec_ref r4
L3:
    r5 = typing :: module
    r6 = load_address _Py_NoneStruct
    r7 = r5 != r6
    if r7 goto L6 else goto L4 :: bool
L4:
    r8 = load_global CPyStatic_unicode_1 :: static  ('typing')
    r9 = PyImport_Import(r8)
    if is_error(r9) goto L14 (error at <module>:1) else goto L5
L5:
    typing = r9 :: module
    dec_ref r9
L6:
    r10 = typing :: module
    r11 = program.globals :: static
    r12 = load_global CPyStatic_unicode_2 :: static  ('List')
    r13 = CPyObject_GetAttr(r10, r12)
    if is_error(r13) goto L14 (error at <module>:1) else goto L7
L7:
    r14 = load_global CPyStatic_unicode_2 :: static  ('List')
    r15 = CPyDict_SetItem(r11, r14, r13)
    dec_ref r13
    r16 = r15 >= 0 :: signed
    if not r16 goto L14 (error at <module>:1) else goto L8 :: bool
L8:
    r17 = PyList_New(0)
    if is_error(r17) goto L14 (error at <module>:2) else goto L9
L9:
    r18 = program.globals :: static
    r19 = load_global CPyStatic_unicode_3 :: static  ('l')
    r20 = CPyDict_SetItem(r18, r19, r17)
    dec_ref r17
    r21 = r20 >= 0 :: signed
    if not r21 goto L14 (error at <module>:2) else goto L10 :: bool
L10:
    r22 = program.globals :: static
    r23 = load_global CPyStatic_unicode_3 :: static  ('l')
    r24 = CPyDict_GetItem(r22, r23)
    if is_error(r24) goto L14 (error at <module>:3) else goto L11
L11:
    r25 = cast(list, r24)
    if is_error(r25) goto L14 (error at <module>:3) else goto L12
L12:
    r26 = load_global CPyStatic_unicode_4 :: static  ('insert')
    r27 = box(short_int, 0)
    r28 = box(short_int, 2)
    r29 = CPyObject_CallMethodObjArgs(r25, r26, r27, r28, 0)
    dec_ref r25
    dec_ref r27
    dec_ref r28
    if is_error(r29) goto L14 (error at <module>:3) else goto L15
L13:
    return 1
L14:
    r30 = <error> :: None
    return r30
L15:
    dec_ref r29
    goto L13
```

PR:

```
def __top_level__():
    r0, r1 :: object
    r2 :: bit
    r3 :: str
    r4, r5, r6 :: object
    r7 :: bit
    r8 :: str
    r9, r10 :: object
    r11 :: dict
    r12 :: str
    r13 :: object
    r14 :: str
    r15 :: int32
    r16 :: bit
    r17 :: list
    r18 :: dict
    r19 :: str
    r20 :: int32
    r21 :: bit
    r22 :: dict
    r23 :: str
    r24 :: object
    r25 :: list
    r26 :: object
    r27 :: int
    r28 :: None
L0:
    r0 = builtins :: module
    r1 = load_address _Py_NoneStruct
    r2 = r0 != r1
    if r2 goto L3 else goto L1 :: bool
L1:
    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
    r4 = PyImport_Import(r3)
    if is_error(r4) goto L14 (error at <module>:-1) else goto L2
L2:
    builtins = r4 :: module
    dec_ref r4
L3:
    r5 = typing :: module
    r6 = load_address _Py_NoneStruct
    r7 = r5 != r6
    if r7 goto L6 else goto L4 :: bool
L4:
    r8 = load_global CPyStatic_unicode_1 :: static  ('typing')
    r9 = PyImport_Import(r8)
    if is_error(r9) goto L14 (error at <module>:1) else goto L5
L5:
    typing = r9 :: module
    dec_ref r9
L6:
    r10 = typing :: module
    r11 = program.globals :: static
    r12 = load_global CPyStatic_unicode_2 :: static  ('List')
    r13 = CPyObject_GetAttr(r10, r12)
    if is_error(r13) goto L14 (error at <module>:1) else goto L7
L7:
    r14 = load_global CPyStatic_unicode_2 :: static  ('List')
    r15 = CPyDict_SetItem(r11, r14, r13)
    dec_ref r13
    r16 = r15 >= 0 :: signed
    if not r16 goto L14 (error at <module>:1) else goto L8 :: bool
L8:
    r17 = PyList_New(0)
    if is_error(r17) goto L14 (error at <module>:2) else goto L9
L9:
    r18 = program.globals :: static
    r19 = load_global CPyStatic_unicode_3 :: static  ('l')
    r20 = CPyDict_SetItem(r18, r19, r17)
    dec_ref r17
    r21 = r20 >= 0 :: signed
    if not r21 goto L14 (error at <module>:2) else goto L10 :: bool
L10:
    r22 = program.globals :: static
    r23 = load_global CPyStatic_unicode_3 :: static  ('l')
    r24 = CPyDict_GetItem(r22, r23)
    if is_error(r24) goto L14 (error at <module>:3) else goto L11
L11:
    r25 = cast(list, r24)
    if is_error(r25) goto L14 (error at <module>:3) else goto L12
L12:
    r26 = box(short_int, 2)
    r27 = PyList_Insert(r25, 0, r26)
    dec_ref r25
    dec_ref r26
    if is_error(r27) goto L14 (error at <module>:3) else goto L15
L13:
    return 1
L14:
    r28 = <error> :: None
    return r28
L15:
    dec_ref r27 :: int
    goto L13
```

### Performance

Master:
```
running list_insert
................................................................................................................................................................
interpreted: 0.012250s (avg of 80 iterations; stdev 1%)
compiled:    0.007974s (avg of 80 iterations; stdev 1.7%)

compiled is 1.536x faster
```

PR:
```
running list_insert
................................................................................................................................................................
interpreted: 0.012263s (avg of 80 iterations; stdev 1.2%)
compiled:    0.002667s (avg of 80 iterations; stdev 0.98%)

compiled is 4.597x faster
```

### Update

The C helper function has resulted in a small decrease in the performance benefits:
```
running list_insert
...................................................................................................................................................................
interpreted: 0.012055s (avg of 82 iterations; stdev 0.63%)
compiled:    0.002984s (avg of 82 iterations; stdev 0.81%)

compiled is 4.039x faster
```