### PR TITLE
upgrade tox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,8 @@ jobs:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.arch }}
     - name: install tox
-      run: pip install --upgrade 'setuptools!=50' 'virtualenv<20' tox==3.9.0
+      run: pip install --upgrade 'setuptools!=50' 'virtualenv<20' tox==3.20.1
     - name: setup tox environment
       run: tox -e ${{ matrix.toxenv }} --notest
     - name: test
-      run: tox -e ${{ matrix.toxenv }}
+      run: tox -e ${{ matrix.toxenv }} --skip-pkg-install

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
 install:
 - pip install -U pip setuptools
 - pip install -U 'virtualenv<20'
-- pip install -U tox==3.9.0
+- pip install -U tox==3.20.1
 - python2 -m pip install --user -U typing
 - tox --notest
 
@@ -95,7 +95,7 @@ install:
 - if [[ $TEST_MYPYC == 1 ]]; then pip install -r mypy-requirements.txt; CC=clang MYPYC_OPT_LEVEL=0 python3 setup.py --use-mypyc build_ext --inplace; fi
 
 script:
-- tox -- $EXTRA_ARGS
+- tox --skip-pkg-install -- $EXTRA_ARGS
 
 # Getting our hands on a debug build or the right OS X build is
 # annoying, unfortunately.


### PR DESCRIPTION
Our version of tox is getting pretty old. In particular, upgrading
should add support for 3.10 and make builds faster.