### PR TITLE
Remove outdated restriction about PyAnnotate

### DIFF
--- a/docs/source/existing_code.rst
+++ b/docs/source/existing_code.rst
@@ -145,8 +145,7 @@ Automate annotation of legacy code
 
 There are tools for automatically adding draft annotations
 based on type profiles collected at runtime.  Tools include
-:doc:`monkeytype:index` (Python 3) and `PyAnnotate`_
-(type comments only).
+:doc:`monkeytype:index` (Python 3) and `PyAnnotate`_.
 
 A simple approach is to collect types from test runs. This may work
 well if your test coverage is good (and if your tests aren't very


### PR DESCRIPTION
PyAnnotate also supports type annotations, not only type comments.