### PR TITLE
PEP 585 improvement to disallow any generic note

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1011,7 +1011,9 @@ def get_omitted_any(disallow_any: bool, fail: MsgCallback, note: MsgCallback,
             base_fullname = (
                 base_type.type.fullname if isinstance(base_type, Instance) else fullname
             )
-            if base_fullname in GENERIC_STUB_NOT_AT_RUNTIME_TYPES:
+            # Ideally, we'd check whether the type is quoted or `from __future__ annotations`
+            # is set before issuing this note
+            if python_version < (3, 9) and base_fullname in GENERIC_STUB_NOT_AT_RUNTIME_TYPES:
                 # Recommend `from __future__ import annotations` or to put type in quotes
                 # (string literal escaping) for classes not generic at runtime
                 note(

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -59,6 +59,7 @@ ARG_KINDS_BY_CONSTRUCTOR = {
 GENERIC_STUB_NOT_AT_RUNTIME_TYPES = {
     'queue.Queue',
     'builtins._PathLike',
+    'asyncio.futures.Future',
 }  # type: Final
 
 

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1113,6 +1113,22 @@ GroupDataDict = TypedDict(
 GroupsDict = Dict[str, GroupDataDict]  # type: ignore
 [builtins fixtures/dict.pyi]
 
+
+[case testCheckDisallowAnyGenericsStubOnly]
+# flags: --disallow-any-generics --python-version 3.8
+from asyncio import Future
+from queue import Queue
+x: Future[str]
+y: Queue[int]
+
+p: Future  # E: Missing type parameters for generic type "Future" \
+           # N: Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/latest/common_issues.html#not-generic-runtime
+q: Queue  # E: Missing type parameters for generic type "Queue" \
+          # N: Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/latest/common_issues.html#not-generic-runtime
+[builtins fixtures/async_await.pyi]
+[typing fixtures/typing-full.pyi]
+
+
 [case testCheckDefaultAllowAnyGeneric]
 from typing import TypeVar, Callable
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1129,20 +1129,6 @@ tabs.py:2: error: Incompatible return value type (got "None", expected "str")
             return None
                    ^
 
-[case testSpecialTypeshedGenericNote]
-# cmd: mypy --disallow-any-generics --python-version=3.6 test.py
-[file test.py]
-from os import PathLike
-from queue import Queue
-
-p: PathLike
-q: Queue
-[out]
-test.py:4: error: Missing type parameters for generic type "PathLike"
-test.py:4: note: Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/latest/common_issues.html#not-generic-runtime
-test.py:5: error: Missing type parameters for generic type "Queue"
-test.py:5: note: Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/latest/common_issues.html#not-generic-runtime
-
 [case testErrorMessageWhenOpenPydFile]
 # cmd: mypy a.pyd
 [file a.pyd]


### PR DESCRIPTION
Additionally:
- Don't use a cmdline test (looks like this was previously necessary because it was testing PathLike, whose real definition is in typeshed's builtins stub, which we fixture away)
- Add asyncio.Future to the hardcoded list, since it's probably the next most common one.