### PR TITLE
kinds_of_types: clearer sample bytestrings

### DIFF
--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -831,9 +831,9 @@ so use :py:data:`~typing.AnyStr`:
    def concat(x: AnyStr, y: AnyStr) -> AnyStr:
        return x + y
 
-   concat('a', 'b')     # Okay
-   concat(b'a', b'b')   # Okay
-   concat('a', b'b')    # Error: cannot mix bytes and unicode
+   concat('foo', 'foo')     # Okay
+   concat(b'foo', b'foo')   # Okay
+   concat('foo', b'foo')    # Error: cannot mix bytes and unicode
 
 For more details, see :ref:`type-variable-value-restriction`.
 


### PR DESCRIPTION

### Description

Edit the code in the `AnyString` example `concat()` calls to use sample arguments that are easier to parse, because `concat(b'a', b'b')` just seems needlessly confusing.

## Test Plan

* Rebuild docs with `cd docs; make html`
* Review `build/html/kinds_of_types.html` for markup issues or syntax errors
* Verify code sample at `#text-and-anystr` in rendered output