### PR TITLE
[mypyc] Generate names lazily when pretty-printing IR or generating C

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -38,7 +38,7 @@ from mypyc.namegen import exported_name
 from mypyc.options import CompilerOptions
 from mypyc.errors import Errors
 from mypyc.common import RUNTIME_C_FILES, shared_lib_name
-from mypyc.ir.module_ir import format_modules
+from mypyc.ir.pprint import format_modules
 
 from mypyc.codegen import emitmodule
 

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -88,9 +88,13 @@ class EmitterContext:
 class Emitter:
     """Helper for C code generation."""
 
-    def __init__(self, context: EmitterContext, env: Optional[Environment] = None) -> None:
+    def __init__(self,
+                 context: EmitterContext,
+                 env: Optional[Environment] = None,
+                 value_names: Optional[Dict[Value, str]] = None) -> None:
         self.context = context
         self.names = context.names
+        self.value_names = value_names or {}
         self.env = env or Environment()
         self.fragments = []  # type: List[str]
         self._indent = 0
@@ -108,7 +112,7 @@ class Emitter:
         return 'CPyL%s' % label.label
 
     def reg(self, reg: Value) -> str:
-        return REG_PREFIX + reg.name
+        return REG_PREFIX + self.value_names[reg]
 
     def attr(self, name: str) -> str:
         return ATTR_PREFIX + name

--- a/mypyc/ir/const_int.py
+++ b/mypyc/ir/const_int.py
@@ -3,14 +3,11 @@ from typing import List, Dict
 from mypyc.ir.ops import BasicBlock, LoadInt
 
 
-def find_constant_integer_registers(blocks: List[BasicBlock]) -> Dict[str, int]:
-    """Find all registers with constant integer values.
-
-    Returns a mapping from register names to int values
-    """
-    const_int_regs = {}  # type: Dict[str, int]
+def find_constant_integer_registers(blocks: List[BasicBlock]) -> Dict[LoadInt, int]:
+    """Find all registers with constant integer values."""
+    const_int_regs = {}  # type: Dict[LoadInt, int]
     for block in blocks:
         for op in block.ops:
             if isinstance(op, LoadInt):
-                const_int_regs[op.name] = op.value
+                const_int_regs[op] = op.value
     return const_int_regs

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -1,15 +1,12 @@
 """Intermediate representation of functions."""
-import re
 
-from typing import List, Optional, Sequence, Dict
+from typing import List, Optional, Sequence
 from typing_extensions import Final
 
 from mypy.nodes import FuncDef, Block, ARG_POS, ARG_OPT, ARG_NAMED_OPT
 
 from mypyc.common import JsonDict
-from mypyc.ir.ops import (
-    DeserMaps, Goto, Branch, Return, Unreachable, BasicBlock, Environment
-)
+from mypyc.ir.ops import DeserMaps, BasicBlock, Environment
 from mypyc.ir.rtypes import RType, deserialize_type
 from mypyc.namegen import NameGenerator
 

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -195,8 +195,11 @@ class FuncIR:
     def cname(self, names: NameGenerator) -> str:
         return self.decl.cname(names)
 
-    def __str__(self) -> str:
-        return '\n'.join(format_func(self))
+    def __repr__(self) -> str:
+        if self.class_name:
+            return '<FuncIR {}.{}>'.format(self.class_name, self.name)
+        else:
+            return '<FuncIR {}>'.format(self.name)
 
     def serialize(self) -> JsonDict:
         # We don't include blocks or env in the serialized version

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -11,7 +11,6 @@ from mypyc.ir.ops import (
     DeserMaps, Goto, Branch, Return, Unreachable, BasicBlock, Environment
 )
 from mypyc.ir.rtypes import RType, deserialize_type
-from mypyc.ir.const_int import find_constant_integer_registers
 from mypyc.namegen import NameGenerator
 
 
@@ -221,58 +220,3 @@ class FuncIR:
 
 
 INVALID_FUNC_DEF = FuncDef('<INVALID_FUNC_DEF>', [], Block([]))  # type: Final
-
-
-def format_blocks(blocks: List[BasicBlock],
-                  env: Environment,
-                  const_regs: Dict[str, int]) -> List[str]:
-    """Format a list of IR basic blocks into a human-readable form."""
-    # First label all of the blocks
-    for i, block in enumerate(blocks):
-        block.label = i
-
-    handler_map = {}  # type: Dict[BasicBlock, List[BasicBlock]]
-    for b in blocks:
-        if b.error_handler:
-            handler_map.setdefault(b.error_handler, []).append(b)
-
-    lines = []
-    for i, block in enumerate(blocks):
-        handler_msg = ''
-        if block in handler_map:
-            labels = sorted(env.format('%l', b.label) for b in handler_map[block])
-            handler_msg = ' (handler for {})'.format(', '.join(labels))
-
-        lines.append(env.format('%l:%s', block.label, handler_msg))
-        ops = block.ops
-        if (isinstance(ops[-1], Goto) and i + 1 < len(blocks)
-                and ops[-1].label == blocks[i + 1]):
-            # Hide the last goto if it just goes to the next basic block.
-            ops = ops[:-1]
-        # load int registers start with 'i'
-        regex = re.compile(r'\bi[0-9]+\b')
-        for op in ops:
-            if op.name not in const_regs:
-                line = '    ' + op.to_str(env)
-                line = regex.sub(lambda i: str(const_regs[i.group()]) if i.group() in const_regs
-                                 else i.group(), line)
-                lines.append(line)
-
-        if not isinstance(block.ops[-1], (Goto, Branch, Return, Unreachable)):
-            # Each basic block needs to exit somewhere.
-            lines.append('    [MISSING BLOCK EXIT OPCODE]')
-    return lines
-
-
-def format_func(fn: FuncIR) -> List[str]:
-    lines = []
-    cls_prefix = fn.class_name + '.' if fn.class_name else ''
-    lines.append('def {}{}({}):'.format(cls_prefix, fn.name,
-                                        ', '.join(arg.name for arg in fn.args)))
-    # compute constants
-    const_regs = find_constant_integer_registers(fn.blocks)
-    for line in fn.env.to_lines(const_regs):
-        lines.append('    ' + line)
-    code = format_blocks(fn.blocks, fn.env, const_regs)
-    lines.extend(code)
-    return lines

--- a/mypyc/ir/module_ir.py
+++ b/mypyc/ir/module_ir.py
@@ -5,7 +5,7 @@ from typing import List, Tuple, Dict
 from mypyc.common import JsonDict
 from mypyc.ir.ops import DeserMaps
 from mypyc.ir.rtypes import RType, deserialize_type
-from mypyc.ir.func_ir import FuncIR, FuncDecl, format_func
+from mypyc.ir.func_ir import FuncIR, FuncDecl
 from mypyc.ir.class_ir import ClassIR
 
 
@@ -82,12 +82,3 @@ def deserialize_modules(data: Dict[str, JsonDict], ctx: DeserMaps) -> Dict[str, 
 # ModulesIRs should also always be an *OrderedDict*, but if we
 # declared it that way we would need to put it in quotes everywhere...
 ModuleIRs = Dict[str, ModuleIR]
-
-
-def format_modules(modules: ModuleIRs) -> List[str]:
-    ops = []
-    for module in modules.values():
-        for fn in module.functions:
-            ops.extend(format_func(fn))
-            ops.append('')
-    return ops

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -12,8 +12,7 @@ can hold various things:
 
 from abc import abstractmethod
 from typing import (
-    List, Sequence, Dict, Generic, TypeVar, Optional, Any, NamedTuple, Tuple,
-    Union, Iterable, Set
+    List, Sequence, Dict, Generic, TypeVar, Optional, NamedTuple, Tuple, Union, Iterable, Set
 )
 from mypy.ordered_dict import OrderedDict
 
@@ -28,7 +27,6 @@ from mypyc.ir.rtypes import (
     short_int_rprimitive, int_rprimitive, void_rtype, pointer_rprimitive, is_pointer_rprimitive,
     bit_rprimitive, is_bit_rprimitive
 )
-from mypyc.common import short_name
 
 if TYPE_CHECKING:
     from mypyc.ir.class_ir import ClassIR  # noqa

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -364,9 +364,15 @@ def generate_names_for_env(env: Environment) -> Dict[Value, str]:
             name = 'r%d' % temp_index
             temp_index += 1
 
-        # Append as many underscores as needed to make it unique.
-        while name in used_names:
-            name += '_'
+        # Append _2, _3, ... if needed to make the name unique.
+        if name in used_names:
+            n = 2
+            while True:
+                candidate = '%s_%d' % (name, n)
+                if candidate not in used_names:
+                    name = candidate
+                    break
+                n += 1
 
         names[value] = name
         used_names.add(name)

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -1,3 +1,5 @@
+"""Utilities for pretty-printing IR in a human-readable form."""
+
 import re
 from typing import Any, Dict, List, Optional, Match
 
@@ -17,7 +19,12 @@ from mypyc.ir.const_int import find_constant_integer_registers
 
 
 class IRPrettyPrintVisitor(OpVisitor[str]):
+    """Internal visitor that pretty-prints ops."""
+
     def __init__(self, names: Dict[Value, str]) -> None:
+        # This should contain a name for all values that are shown as
+        # registers in the output. This is not just for Register
+        # instances -- all Ops that produce values need (generated) names.
         self.names = names
 
     def visit_goto(self, op: Goto) -> str:
@@ -186,6 +193,17 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
     # Helpers
 
     def format(self, fmt: str, *args: Any) -> str:
+        """Helper for formatting strings.
+
+        These format sequences are supported in fmt:
+
+          %s: arbitrary object converted to string using str()
+          %r: name of IR value/register
+          %d: int
+          %f: float
+          %l: BasicBlock (formatted as label 'Ln')
+          %t: RType
+        """
         result = []
         i = 0
         arglist = list(args)
@@ -328,7 +346,7 @@ def generate_names_for_env(env: Environment) -> Dict[Value, str]:
     """Generate unique names for values in an environment.
 
     Give names such as 'r5' or 'i0' to temp values in IR which are useful
-    when pretty-printing or generating C. Ensure register names are unique.
+    when pretty-printing or generating C. Ensure generated names are unique.
     """
     names = {}
     used_names = set()

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -283,8 +283,6 @@ def format_blocks(blocks: List[BasicBlock],
 
     lines = []
     for i, block in enumerate(blocks):
-        i == len(blocks) - 1
-
         handler_msg = ''
         if block in handler_map:
             labels = sorted('L%d' % b.label for b in handler_map[block])

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -1,0 +1,211 @@
+from typing_extensions import Final
+
+from mypyc.ir.ops import (
+    Goto, Branch, Return, Unreachable, Assign, LoadInt, LoadErrorValue, GetAttr, SetAttr,
+    LoadStatic, InitStatic, TupleGet, TupleSet, IncRef, DecRef, Call, MethodCall, Cast, Box, Unbox,
+    RaiseStandardError, CallC, Truncate, LoadGlobal, BinaryIntOp, ComparisonOp, LoadMem, SetMem,
+    GetElementPtr, LoadAddress, Register, Value, OpVisitor, BasicBlock
+)
+from mypyc.common import short_name
+from mypyc.ir.rtypes import is_bool_rprimitive, is_int_rprimitive
+
+
+class IRPrettyPrintVisitor(OpVisitor[str]):
+    def __init__(self) -> None:
+        pass
+
+    def visit_goto(self, op: Goto) -> str:
+        return self.format('goto %l', op.label)
+
+    branch_op_names = {
+        Branch.BOOL: ('%r', 'bool'),
+        Branch.IS_ERROR: ('is_error(%r)', ''),
+    }  # type: Final
+
+    def visit_branch(self, op: Branch) -> str:
+        fmt, typ = self.branch_op_names[op.op]
+        if op.negated:
+            fmt = 'not {}'.format(fmt)
+
+        cond = self.format(fmt, op.left)
+        tb = ''
+        if op.traceback_entry:
+            tb = ' (error at %s:%d)' % op.traceback_entry
+        fmt = 'if {} goto %l{} else goto %l'.format(cond, tb)
+        if typ:
+            fmt += ' :: {}'.format(typ)
+        return self.format(fmt, op.true, op.false)
+
+    def visit_return(self, op: Return) -> str:
+        return self.format('return %r', op.reg)
+
+    def visit_unreachable(self, op: Unreachable) -> str:
+        return "unreachable"
+
+    def visit_assign(self, op: Assign) -> str:
+        return self.format('%r = %r', op.dest, op.src)
+
+    def visit_load_int(self, op: LoadInt) -> str:
+        return self.format('%r = %d', op, op.value)
+
+    def visit_load_error_value(self, op: LoadErrorValue) -> str:
+        return self.format('%r = <error> :: %s', op, op.type)
+
+    def visit_get_attr(self, op: GetAttr) -> str:
+        return self.format('%r = %r.%s', op, op.obj, op.attr)
+
+    def visit_set_attr(self, op: SetAttr) -> str:
+        return self.format('%r.%s = %r; %r = is_error', op.obj, op.attr, op.src, op)
+
+    def visit_load_static(self, op: LoadStatic) -> str:
+        ann = '  ({})'.format(repr(op.ann)) if op.ann else ''
+        name = op.identifier
+        if op.module_name is not None:
+            name = '{}.{}'.format(op.module_name, name)
+        return self.format('%r = %s :: %s%s', op, name, op.namespace, ann)
+
+    def visit_init_static(self, op: InitStatic) -> str:
+        name = op.identifier
+        if op.module_name is not None:
+            name = '{}.{}'.format(op.module_name, name)
+        return self.format('%s = %r :: %s', name, op.value, op.namespace)
+
+    def visit_tuple_get(self, op: TupleGet) -> str:
+        return self.format('%r = %r[%d]', op, op.src, op.index)
+
+    def visit_tuple_set(self, op: TupleSet) -> str:
+        item_str = ', '.join(self.format('%r', item) for item in op.items)
+        return self.format('%r = (%s)', op, item_str)
+
+    def visit_inc_ref(self, op: IncRef) -> str:
+        s = self.format('inc_ref %r', op.src)
+        # TODO: Remove bool check (it's unboxed)
+        if is_bool_rprimitive(op.src.type) or is_int_rprimitive(op.src.type):
+            s += ' :: {}'.format(short_name(op.src.type.name))
+        return s
+
+    def visit_dec_ref(self, op: DecRef) -> str:
+        s = self.format('%sdec_ref %r', 'x' if op.is_xdec else '', op.src)
+        # TODO: Remove bool check (it's unboxed)
+        if is_bool_rprimitive(op.src.type) or is_int_rprimitive(op.src.type):
+            s += ' :: {}'.format(short_name(op.src.type.name))
+        return s
+
+    def visit_call(self, op: Call) -> str:
+        args = ', '.join(self.format('%r', arg) for arg in op.args)
+        # TODO: Display long name?
+        short_name = op.fn.shortname
+        s = '%s(%s)' % (short_name, args)
+        if not op.is_void:
+            s = self.format('%r = ', op) + s
+        return s
+
+    def visit_method_call(self, op: MethodCall) -> str:
+        args = ', '.join(self.format('%r', arg) for arg in op.args)
+        s = self.format('%r.%s(%s)', op.obj, op.method, args)
+        if not op.is_void:
+            s = self.format('%r = ', self) + s
+        return s
+
+    def visit_cast(self, op: Cast) -> str:
+        return self.format('%r = cast(%s, %r)', op, op.type, op.src)
+
+    def visit_box(self, op: Box) -> str:
+        return self.format('%r = box(%s, %r)', op, op.src.type, op.src)
+
+    def visit_unbox(self, op: Unbox) -> str:
+        return self.format('%r = unbox(%s, %r)', op, op.type, op.src)
+
+    def visit_raise_standard_error(self, op: RaiseStandardError) -> str:
+        if op.value is not None:
+            if isinstance(op.value, str):
+                return 'raise %s(%r)' % (op.class_name, op.value)
+            elif isinstance(op.value, Value):
+                return self.format('raise %s(%r)', op.class_name, op.value)
+            else:
+                assert False, 'value type must be either str or Value'
+        else:
+            return 'raise %s' % op.class_name
+
+    def visit_call_c(self, op: CallC) -> str:
+        args_str = ', '.join(self.format('%r', arg) for arg in op.args)
+        if op.is_void:
+            return self.format('%s(%s)', op.function_name, args_str)
+        else:
+            return self.format('%r = %s(%s)', op, op.function_name, args_str)
+
+    def visit_truncate(self, op: Truncate) -> str:
+        return self.format("%r = truncate %r: %r to %r", op, op.src, op.src_type, op.type)
+
+    def visit_load_global(self, op: LoadGlobal) -> str:
+        ann = '  ({})'.format(repr(op.ann)) if op.ann else ''
+        return self.format('%r = load_global %s :: static%s', op, op.identifier, ann)
+
+    def visit_binary_int_op(self, op: BinaryIntOp) -> str:
+        return self.format('%r = %r %s %r', op, op.lhs, BinaryIntOp.op_str[op.op], op.rhs)
+
+    def visit_comparison_op(self, op: ComparisonOp) -> str:
+        if op.op in (ComparisonOp.SLT, ComparisonOp.SGT, ComparisonOp.SLE, ComparisonOp.SGE):
+            sign_format = " :: signed"
+        elif op.op in (ComparisonOp.ULT, ComparisonOp.UGT, ComparisonOp.ULE, ComparisonOp.UGE):
+            sign_format = " :: unsigned"
+        else:
+            sign_format = ""
+        return self.format('%r = %r %s %r%s', op, op.lhs, ComparisonOp.op_str[op.op],
+                           op.rhs, sign_format)
+
+    def visit_load_mem(self, op: LoadMem) -> str:
+        if op.base:
+            base = self.format(', %r', op.base)
+        else:
+            base = ''
+        return self.format("%r = load_mem %r%s :: %r*", op, op.src, base, op.type)
+
+    def visit_set_mem(self, op: SetMem) -> str:
+        if op.base:
+            base = self.format(', %r', op.base)
+        else:
+            base = ''
+        return self.format("set_mem %r, %r%s :: %r*", op.dest, op.src, base, op.dest_type)
+
+    def visit_get_element_ptr(self, op: GetElementPtr) -> str:
+        return self.format("%r = get_element_ptr %r %s :: %r", op, op.src, op.field, op.src_type)
+
+    def visit_load_address(self, op: LoadAddress) -> str:
+        if isinstance(op.src, Register):
+            return self.format("%r = load_address %r", op, op.src)
+        else:
+            return self.format("%r = load_address %s", op, op.src)
+
+    # Helpers
+
+    def format(self, fmt: str, *args: Any) -> str:
+        result = []
+        i = 0
+        arglist = list(args)
+        while i < len(fmt):
+            n = fmt.find('%', i)
+            if n < 0:
+                n = len(fmt)
+            result.append(fmt[i:n])
+            if n < len(fmt):
+                typespec = fmt[n + 1]
+                arg = arglist.pop(0)
+                if typespec == 'r':
+                    result.append(arg.name)
+                elif typespec == 'd':
+                    result.append('%d' % arg)
+                elif typespec == 'f':
+                    result.append('%f' % arg)
+                elif typespec == 'l':
+                    if isinstance(arg, BasicBlock):
+                        arg = arg.label
+                    result.append('L%s' % arg)
+                elif typespec == 's':
+                    result.append(str(arg))
+                else:
+                    raise ValueError('Invalid format sequence %{}'.format(typespec))
+                i = n + 2
+            else:
+                i = n
+        return ''.join(result)

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2127,7 +2127,7 @@ def f(l):
     r15 :: short_int
     r16 :: bit
     r17 :: object
-    x0, y0, z0 :: int
+    x_, y_, z_ :: int
     r18 :: tuple[int, int, int]
     r19, r20, r21, r22, r23 :: int
     r24 :: object
@@ -2168,13 +2168,13 @@ L6:
     r17 = CPyList_GetItemUnsafe(l, r12)
     r18 = unbox(tuple[int, int, int], r17)
     r19 = r18[0]
-    x0 = r19
+    x_ = r19
     r20 = r18[1]
-    y0 = r20
+    y_ = r20
     r21 = r18[2]
-    z0 = r21
-    r22 = CPyTagged_Add(x0, y0)
-    r23 = CPyTagged_Add(r22, z0)
+    z_ = r21
+    r22 = CPyTagged_Add(x_, y_)
+    r23 = CPyTagged_Add(r22, z_)
     r24 = box(int, r23)
     r25 = PyList_Append(r11, r24)
     r26 = r25 >= 0 :: signed

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2127,7 +2127,7 @@ def f(l):
     r15 :: short_int
     r16 :: bit
     r17 :: object
-    x_, y_, z_ :: int
+    x_2, y_2, z_2 :: int
     r18 :: tuple[int, int, int]
     r19, r20, r21, r22, r23 :: int
     r24 :: object
@@ -2168,13 +2168,13 @@ L6:
     r17 = CPyList_GetItemUnsafe(l, r12)
     r18 = unbox(tuple[int, int, int], r17)
     r19 = r18[0]
-    x_ = r19
+    x_2 = r19
     r20 = r18[1]
-    y_ = r20
+    y_2 = r20
     r21 = r18[2]
-    z_ = r21
-    r22 = CPyTagged_Add(x_, y_)
-    r23 = CPyTagged_Add(r22, z_)
+    z_2 = r21
+    r22 = CPyTagged_Add(x_2, y_2)
+    r23 = CPyTagged_Add(r22, z_2)
     r24 = box(int, r23)
     r25 = PyList_Append(r11, r24)
     r26 = r25 >= 0 :: signed

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -9,7 +9,7 @@ from mypy.errors import CompileError
 from mypyc.common import TOP_LEVEL_NAME
 from mypyc.analysis import dataflow
 from mypyc.transform import exceptions
-from mypyc.ir.pprint import format_func
+from mypyc.ir.pprint import format_func, generate_names_for_env
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
     assert_test_output, replace_native_int
@@ -64,11 +64,13 @@ class TestAnalysis(MypycDataSuite):
                     else:
                         assert False, 'No recognized _AnalysisName suffix in test case'
 
+                    names = generate_names_for_env(fn.env)
+
                     for key in sorted(analysis_result.before.keys(),
                                       key=lambda x: (x[0].label, x[1])):
-                        pre = ', '.join(sorted(reg.name
+                        pre = ', '.join(sorted(names[reg]
                                                for reg in analysis_result.before[key]))
-                        post = ', '.join(sorted(reg.name
+                        post = ', '.join(sorted(names[reg]
                                                 for reg in analysis_result.after[key]))
                         actual.append('%-8s %-23s %s' % ((key[0].label, key[1]),
                                                          '{%s}' % pre, '{%s}' % post))

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -9,7 +9,7 @@ from mypy.errors import CompileError
 from mypyc.common import TOP_LEVEL_NAME
 from mypyc.analysis import dataflow
 from mypyc.transform import exceptions
-from mypyc.ir.func_ir import format_func
+from mypyc.ir.pprint import format_func
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
     assert_test_output, replace_native_int

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -5,6 +5,7 @@ from mypy.nodes import Var
 from mypyc.codegen.emit import Emitter, EmitterContext
 from mypyc.ir.ops import BasicBlock, Environment
 from mypyc.ir.rtypes import int_rprimitive
+from mypyc.ir.pprint import generate_names_for_env
 from mypyc.namegen import NameGenerator
 
 
@@ -13,20 +14,23 @@ class TestEmitter(unittest.TestCase):
         self.env = Environment()
         self.n = self.env.add_local(Var('n'), int_rprimitive)
         self.context = EmitterContext(NameGenerator([['mod']]))
-        self.emitter = Emitter(self.context, self.env)
 
     def test_label(self) -> None:
-        assert self.emitter.label(BasicBlock(4)) == 'CPyL4'
+        emitter = Emitter(self.context, self.env, {})
+        assert emitter.label(BasicBlock(4)) == 'CPyL4'
 
     def test_reg(self) -> None:
-        assert self.emitter.reg(self.n) == 'cpy_r_n'
+        names = generate_names_for_env(self.env)
+        emitter = Emitter(self.context, self.env, names)
+        assert emitter.reg(self.n) == 'cpy_r_n'
 
     def test_emit_line(self) -> None:
-        self.emitter.emit_line('line;')
-        self.emitter.emit_line('a {')
-        self.emitter.emit_line('f();')
-        self.emitter.emit_line('}')
-        assert self.emitter.fragments == ['line;\n',
-                                          'a {\n',
-                                          '    f();\n',
-                                          '}\n']
+        emitter = Emitter(self.context, self.env, {})
+        emitter.emit_line('line;')
+        emitter.emit_line('a {')
+        emitter.emit_line('f();')
+        emitter.emit_line('}')
+        assert emitter.fragments == ['line;\n',
+                                     'a {\n',
+                                     '    f();\n',
+                                     '}\n']

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -313,7 +313,6 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def assert_emit(self, op: Op, expected: str) -> None:
         self.emitter.fragments = []
         self.declarations.fragments = []
-        self.env.temp_index = 0
         if isinstance(op, RegisterOp):
             self.env.add_op(op)
         op.accept(self.visitor)
@@ -373,7 +372,6 @@ class TestGenerateFunction(unittest.TestCase):
             result, msg='Generated code invalid')
 
     def test_register(self) -> None:
-        self.env.temp_index = 0
         op = LoadInt(5)
         self.block.ops.append(op)
         self.env.add_op(op)

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -20,6 +20,7 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.ir.func_ir import FuncIR, FuncDecl, RuntimeArg, FuncSignature
 from mypyc.ir.class_ir import ClassIR
+from mypyc.ir.pprint import generate_names_for_env
 from mypyc.irbuild.vtable import compute_vtable
 from mypyc.codegen.emit import Emitter, EmitterContext
 from mypyc.codegen.emitfunc import generate_native_function, FunctionEmitterVisitor
@@ -66,12 +67,6 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.r = self.env.add_local(Var('r'), RInstance(ir))
 
         self.context = EmitterContext(NameGenerator([['mod']]))
-        self.emitter = Emitter(self.context, self.env)
-        self.declarations = Emitter(self.context, self.env)
-
-        const_int_regs = {}  # type: Dict[str, int]
-        self.visitor = FunctionEmitterVisitor(self.emitter, self.declarations, 'prog.py', 'prog',
-                                              const_int_regs)
 
     def test_goto(self) -> None:
         self.assert_emit(Goto(BasicBlock(2)),
@@ -244,53 +239,53 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.ADD, 1),
                          """cpy_r_r0 = cpy_r_s1 + cpy_r_s2;""")
         self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.SUB, 1),
-                        """cpy_r_r00 = cpy_r_s1 - cpy_r_s2;""")
+                        """cpy_r_r1 = cpy_r_s1 - cpy_r_s2;""")
         self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.MUL, 1),
-                        """cpy_r_r01 = cpy_r_s1 * cpy_r_s2;""")
+                        """cpy_r_r2 = cpy_r_s1 * cpy_r_s2;""")
         self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.DIV, 1),
-                        """cpy_r_r02 = cpy_r_s1 / cpy_r_s2;""")
+                        """cpy_r_r3 = cpy_r_s1 / cpy_r_s2;""")
         self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.MOD, 1),
-                        """cpy_r_r03 = cpy_r_s1 % cpy_r_s2;""")
+                        """cpy_r_r4 = cpy_r_s1 % cpy_r_s2;""")
         self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.AND, 1),
-                        """cpy_r_r04 = cpy_r_s1 & cpy_r_s2;""")
+                        """cpy_r_r5 = cpy_r_s1 & cpy_r_s2;""")
         self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.OR, 1),
-                        """cpy_r_r05 = cpy_r_s1 | cpy_r_s2;""")
+                        """cpy_r_r6 = cpy_r_s1 | cpy_r_s2;""")
         self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.XOR, 1),
-                        """cpy_r_r06 = cpy_r_s1 ^ cpy_r_s2;""")
+                        """cpy_r_r7 = cpy_r_s1 ^ cpy_r_s2;""")
         self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2,
                                      BinaryIntOp.LEFT_SHIFT, 1),
-                        """cpy_r_r07 = cpy_r_s1 << cpy_r_s2;""")
+                        """cpy_r_r8 = cpy_r_s1 << cpy_r_s2;""")
         self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2,
                                      BinaryIntOp.RIGHT_SHIFT, 1),
-                        """cpy_r_r08 = cpy_r_s1 >> cpy_r_s2;""")
+                        """cpy_r_r9 = cpy_r_s1 >> cpy_r_s2;""")
 
     def test_comparison_op(self) -> None:
         # signed
         self.assert_emit(ComparisonOp(self.s1, self.s2, ComparisonOp.SLT, 1),
                          """cpy_r_r0 = (Py_ssize_t)cpy_r_s1 < (Py_ssize_t)cpy_r_s2;""")
         self.assert_emit(ComparisonOp(self.i32, self.i32_1, ComparisonOp.SLT, 1),
-                         """cpy_r_r00 = cpy_r_i32 < cpy_r_i32_1;""")
+                         """cpy_r_r1 = cpy_r_i32 < cpy_r_i32_1;""")
         self.assert_emit(ComparisonOp(self.i64, self.i64_1, ComparisonOp.SLT, 1),
-                         """cpy_r_r01 = cpy_r_i64 < cpy_r_i64_1;""")
+                         """cpy_r_r2 = cpy_r_i64 < cpy_r_i64_1;""")
         # unsigned
         self.assert_emit(ComparisonOp(self.s1, self.s2, ComparisonOp.ULT, 1),
-                         """cpy_r_r02 = cpy_r_s1 < cpy_r_s2;""")
+                         """cpy_r_r3 = cpy_r_s1 < cpy_r_s2;""")
         self.assert_emit(ComparisonOp(self.i32, self.i32_1, ComparisonOp.ULT, 1),
-                         """cpy_r_r03 = (uint32_t)cpy_r_i32 < (uint32_t)cpy_r_i32_1;""")
+                         """cpy_r_r4 = (uint32_t)cpy_r_i32 < (uint32_t)cpy_r_i32_1;""")
         self.assert_emit(ComparisonOp(self.i64, self.i64_1, ComparisonOp.ULT, 1),
-                         """cpy_r_r04 = (uint64_t)cpy_r_i64 < (uint64_t)cpy_r_i64_1;""")
+                         """cpy_r_r5 = (uint64_t)cpy_r_i64 < (uint64_t)cpy_r_i64_1;""")
 
         # object type
         self.assert_emit(ComparisonOp(self.o, self.o2, ComparisonOp.EQ, 1),
-                         """cpy_r_r05 = cpy_r_o == cpy_r_o2;""")
+                         """cpy_r_r6 = cpy_r_o == cpy_r_o2;""")
         self.assert_emit(ComparisonOp(self.o, self.o2, ComparisonOp.NEQ, 1),
-                         """cpy_r_r06 = cpy_r_o != cpy_r_o2;""")
+                         """cpy_r_r7 = cpy_r_o != cpy_r_o2;""")
 
     def test_load_mem(self) -> None:
         self.assert_emit(LoadMem(bool_rprimitive, self.ptr, None),
                          """cpy_r_r0 = *(char *)cpy_r_ptr;""")
         self.assert_emit(LoadMem(bool_rprimitive, self.ptr, self.s1),
-                         """cpy_r_r00 = *(char *)cpy_r_ptr;""")
+                         """cpy_r_r1 = *(char *)cpy_r_ptr;""")
 
     def test_set_mem(self) -> None:
         self.assert_emit(SetMem(bool_rprimitive, self.ptr, self.b, None),
@@ -302,21 +297,29 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(GetElementPtr(self.o, r, "b"),
                         """cpy_r_r0 = (CPyPtr)&((Foo *)cpy_r_o)->b;""")
         self.assert_emit(GetElementPtr(self.o, r, "i32"),
-                        """cpy_r_r00 = (CPyPtr)&((Foo *)cpy_r_o)->i32;""")
+                        """cpy_r_r1 = (CPyPtr)&((Foo *)cpy_r_o)->i32;""")
         self.assert_emit(GetElementPtr(self.o, r, "i64"),
-                        """cpy_r_r01 = (CPyPtr)&((Foo *)cpy_r_o)->i64;""")
+                        """cpy_r_r2 = (CPyPtr)&((Foo *)cpy_r_o)->i64;""")
 
     def test_load_address(self) -> None:
         self.assert_emit(LoadAddress(object_rprimitive, "PyDict_Type"),
                          """cpy_r_r0 = (PyObject *)&PyDict_Type;""")
 
     def assert_emit(self, op: Op, expected: str) -> None:
-        self.emitter.fragments = []
-        self.declarations.fragments = []
         if isinstance(op, RegisterOp):
             self.env.add_op(op)
-        op.accept(self.visitor)
-        frags = self.declarations.fragments + self.emitter.fragments
+
+        value_names = generate_names_for_env(self.env)
+        emitter = Emitter(self.context, self.env, value_names)
+        declarations = Emitter(self.context, self.env, value_names)
+        emitter.fragments = []
+        declarations.fragments = []
+
+        const_int_regs = {}  # type: Dict[LoadInt, int]
+        visitor = FunctionEmitterVisitor(emitter, declarations, 'prog.py', 'prog', const_int_regs)
+
+        op.accept(visitor)
+        frags = declarations.fragments + emitter.fragments
         actual_lines = [line.strip(' ') for line in frags]
         assert all(line.endswith('\n') for line in actual_lines)
         actual_lines = [line.rstrip('\n') for line in actual_lines]
@@ -359,7 +362,8 @@ class TestGenerateFunction(unittest.TestCase):
         self.block.ops.append(Return(self.reg))
         fn = FuncIR(FuncDecl('myfunc', None, 'mod', FuncSignature([self.arg], int_rprimitive)),
                     [self.block], self.env)
-        emitter = Emitter(EmitterContext(NameGenerator([['mod']])))
+        value_names = generate_names_for_env(self.env)
+        emitter = Emitter(EmitterContext(NameGenerator([['mod']])), self.env, value_names)
         generate_native_function(fn, emitter, 'prog.py', 'prog', optimize_int=False)
         result = emitter.fragments
         assert_string_arrays_equal(
@@ -377,7 +381,8 @@ class TestGenerateFunction(unittest.TestCase):
         self.env.add_op(op)
         fn = FuncIR(FuncDecl('myfunc', None, 'mod', FuncSignature([self.arg], list_rprimitive)),
                     [self.block], self.env)
-        emitter = Emitter(EmitterContext(NameGenerator([['mod']])))
+        value_names = generate_names_for_env(self.env)
+        emitter = Emitter(EmitterContext(NameGenerator([['mod']])), self.env, value_names)
         generate_native_function(fn, emitter, 'prog.py', 'prog', optimize_int=False)
         result = emitter.fragments
         assert_string_arrays_equal(

--- a/mypyc/test/test_exceptions.py
+++ b/mypyc/test/test_exceptions.py
@@ -10,7 +10,7 @@ from mypy.test.data import DataDrivenTestCase
 from mypy.errors import CompileError
 
 from mypyc.common import TOP_LEVEL_NAME
-from mypyc.ir.func_ir import format_func
+from mypyc.ir.pprint import format_func
 from mypyc.transform.uninit import insert_uninit_checks
 from mypyc.transform.exceptions import insert_exception_handling
 from mypyc.transform.refcount import insert_ref_count_opcodes

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -7,7 +7,7 @@ from mypy.test.data import DataDrivenTestCase
 from mypy.errors import CompileError
 
 from mypyc.common import TOP_LEVEL_NAME, IS_32_BIT_PLATFORM
-from mypyc.ir.func_ir import format_func
+from mypyc.ir.pprint import format_func
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
     assert_test_output, remove_comment_lines, replace_native_int, replace_word_size

--- a/mypyc/test/test_refcount.py
+++ b/mypyc/test/test_refcount.py
@@ -11,7 +11,7 @@ from mypy.test.data import DataDrivenTestCase
 from mypy.errors import CompileError
 
 from mypyc.common import TOP_LEVEL_NAME
-from mypyc.ir.func_ir import format_func
+from mypyc.ir.pprint import format_func
 from mypyc.transform.refcount import insert_ref_count_opcodes
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,


### PR DESCRIPTION
Instead of generating names for ops when building IR, we now generate names 
immediately before pretty-printing or generating C. This simplifies `Environment`
and reduces the amount of mutable state we need to maintain. This a step 
towards removing the `mypyc.ir.ops.Environment` class.

Move code related to pretty-printing to `mypyc.ir.pprint`.

Work on mypyc/mypyc#781.