### PR TITLE
[mypyc] Fix using package imported inside a function

### DIFF
--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -119,35 +119,36 @@ def transform_operator_assignment_stmt(builder: IRBuilder, stmt: OperatorAssignm
 def transform_import(builder: IRBuilder, node: Import) -> None:
     if node.is_mypy_only:
         return
+    globals = builder.load_globals_dict()
     for node_id, as_name in node.ids:
         builder.gen_import(node_id, node.line)
 
-        if builder.non_function_scope():
-            # Update the globals dict with the appropriate module:
-            # * For 'import foo.bar as baz' we add 'foo.bar' with the name 'baz'
-            # * For 'import foo.bar' we add 'foo' with the name 'foo'
-            # Typically we then ignore these entries and access things directly
-            # via the module static, but we will use the globals version for modules
-            # that mypy couldn't find, since it doesn't analyze module references
-            # from those properly.
+        # Update the globals dict with the appropriate module:
+        # * For 'import foo.bar as baz' we add 'foo.bar' with the name 'baz'
+        # * For 'import foo.bar' we add 'foo' with the name 'foo'
+        # Typically we then ignore these entries and access things directly
+        # via the module static, but we will use the globals version for modules
+        # that mypy couldn't find, since it doesn't analyze module references
+        # from those properly.
 
-            # Miscompiling imports inside of functions, like below in import from.
-            if as_name:
-                name = as_name
-                base = node_id
-            else:
-                base = name = node_id.split('.')[0]
+        # TODO: Don't add local imports to the global namespace
 
-            globals = builder.load_globals_dict()
-            # Python 3.7 has a nice 'PyImport_GetModule' function that we can't use :(
-            mod_dict = builder.call_c(get_module_dict_op, [], node.line)
-            # Get top-level module/package object.
-            obj = builder.call_c(dict_get_item_op,
-                                 [mod_dict, builder.load_static_unicode(base)], node.line)
+        # Miscompiling imports inside of functions, like below in import from.
+        if as_name:
+            name = as_name
+            base = node_id
+        else:
+            base = name = node_id.split('.')[0]
 
-            builder.gen_method_call(
-                globals, '__setitem__', [builder.load_static_unicode(name), obj],
-                result_type=None, line=node.line)
+        # Python 3.7 has a nice 'PyImport_GetModule' function that we can't use :(
+        mod_dict = builder.call_c(get_module_dict_op, [], node.line)
+        # Get top-level module/package object.
+        obj = builder.call_c(dict_get_item_op,
+                             [mod_dict, builder.load_static_unicode(base)], node.line)
+
+        builder.gen_method_call(
+            globals, '__setitem__', [builder.load_static_unicode(name), obj],
+            result_type=None, line=node.line)
 
 
 def transform_import_from(builder: IRBuilder, node: ImportFrom) -> None:

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3647,30 +3647,44 @@ x = 1
 [file p/m.py]
 [out]
 def f():
-    r0, r1 :: object
-    r2 :: bit
-    r3 :: str
-    r4 :: object
-    r5 :: dict
-    r6 :: str
-    r7 :: object
-    r8 :: str
-    r9 :: object
-    r10 :: int
+    r0 :: dict
+    r1, r2 :: object
+    r3 :: bit
+    r4 :: str
+    r5 :: object
+    r6 :: dict
+    r7 :: str
+    r8 :: object
+    r9 :: str
+    r10 :: int32
+    r11 :: bit
+    r12 :: dict
+    r13 :: str
+    r14 :: object
+    r15 :: str
+    r16 :: object
+    r17 :: int
 L0:
-    r0 = p.m :: module
-    r1 = load_address _Py_NoneStruct
-    r2 = r0 != r1
-    if r2 goto L2 else goto L1 :: bool
+    r0 = __main__.globals :: static
+    r1 = p.m :: module
+    r2 = load_address _Py_NoneStruct
+    r3 = r1 != r2
+    if r3 goto L2 else goto L1 :: bool
 L1:
-    r3 = load_global CPyStatic_unicode_1 :: static  ('p.m')
-    r4 = PyImport_Import(r3)
-    p.m = r4 :: module
+    r4 = load_global CPyStatic_unicode_1 :: static  ('p.m')
+    r5 = PyImport_Import(r4)
+    p.m = r5 :: module
 L2:
-    r5 = PyImport_GetModuleDict()
-    r6 = load_global CPyStatic_unicode_2 :: static  ('p')
-    r7 = CPyDict_GetItem(r5, r6)
-    r8 = load_global CPyStatic_unicode_3 :: static  ('x')
-    r9 = CPyObject_GetAttr(r7, r8)
-    r10 = unbox(int, r9)
-    return r10
+    r6 = PyImport_GetModuleDict()
+    r7 = load_global CPyStatic_unicode_2 :: static  ('p')
+    r8 = CPyDict_GetItem(r6, r7)
+    r9 = load_global CPyStatic_unicode_2 :: static  ('p')
+    r10 = CPyDict_SetItem(r0, r9, r8)
+    r11 = r10 >= 0 :: signed
+    r12 = PyImport_GetModuleDict()
+    r13 = load_global CPyStatic_unicode_2 :: static  ('p')
+    r14 = CPyDict_GetItem(r12, r13)
+    r15 = load_global CPyStatic_unicode_3 :: static  ('x')
+    r16 = CPyObject_GetAttr(r14, r15)
+    r17 = unbox(int, r16)
+    return r17

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3637,3 +3637,40 @@ L0:
     c = r2
     r3 = (c, b, a)
     return r3
+
+[case testLocalImportSubmodule]
+def f() -> int:
+    import p.m
+    return p.x
+[file p/__init__.py]
+x = 1
+[file p/m.py]
+[out]
+def f():
+    r0, r1 :: object
+    r2 :: bit
+    r3 :: str
+    r4 :: object
+    r5 :: dict
+    r6 :: str
+    r7 :: object
+    r8 :: str
+    r9 :: object
+    r10 :: int
+L0:
+    r0 = p.m :: module
+    r1 = load_address _Py_NoneStruct
+    r2 = r0 != r1
+    if r2 goto L2 else goto L1 :: bool
+L1:
+    r3 = load_global CPyStatic_unicode_1 :: static  ('p.m')
+    r4 = PyImport_Import(r3)
+    p.m = r4 :: module
+L2:
+    r5 = PyImport_GetModuleDict()
+    r6 = load_global CPyStatic_unicode_2 :: static  ('p')
+    r7 = CPyDict_GetItem(r5, r6)
+    r8 = load_global CPyStatic_unicode_3 :: static  ('x')
+    r9 = CPyObject_GetAttr(r7, r8)
+    r10 = unbox(int, r9)
+    return r10

--- a/mypyc/test-data/run-imports.test
+++ b/mypyc/test-data/run-imports.test
@@ -10,7 +10,7 @@ def g(x: int) -> int:
     from welp import foo
     return foo(x)
 
-def test_import() -> None:
+def test_import_basics() -> None:
     assert f(5) == 120
     assert g(5) == 5
 
@@ -18,6 +18,19 @@ def test_import_submodule_within_function() -> None:
     import pkg.mod
     assert pkg.x == 1
     assert pkg.mod.y == 2
+
+# TODO: Don't add local imports to globals()
+#
+# def test_local_import_not_in_globals() -> None:
+#     import nob
+#     assert 'nob' not in globals()
+
+def test_import_module_without_stub_in_function() -> None:
+    # 'virtualenv' must not have a stub in typeshed for this test case
+    import virtualenv  # type: ignore
+    # TODO: We shouldn't add local imports to globals()
+    # assert 'virtualenv' not in globals()
+    assert isinstance(virtualenv.__name__, str)
 
 [file testmodule.py]
 def factorial(x: int) -> int:
@@ -32,6 +45,8 @@ def foo(x: int) -> int:
 x = 1
 [file pkg/mod.py]
 y = 2
+[file nob.py]
+z = 3
 
 [case testImportMissing]
 # The unchecked module is configured by the test harness to not be

--- a/mypyc/test-data/run-imports.test
+++ b/mypyc/test-data/run-imports.test
@@ -19,6 +19,10 @@ def test_import_submodule_within_function() -> None:
     assert pkg.x == 1
     assert pkg.mod.y == 2
 
+def test_import_as_submodule_within_function() -> None:
+    import pkg.mod as mm
+    assert mm.y == 2
+
 # TODO: Don't add local imports to globals()
 #
 # def test_local_import_not_in_globals() -> None:
@@ -31,6 +35,14 @@ def test_import_module_without_stub_in_function() -> None:
     # TODO: We shouldn't add local imports to globals()
     # assert 'virtualenv' not in globals()
     assert isinstance(virtualenv.__name__, str)
+
+def test_import_as_module_without_stub_in_function() -> None:
+    # 'virtualenv' must not have a stub in typeshed for this test case
+    import virtualenv as vv  # type: ignore
+    assert 'virtualenv' not in globals()
+    # TODO: We shouldn't add local imports to globals()
+    # assert 'vv' not in globals()
+    assert isinstance(vv.__name__, str)
 
 [file testmodule.py]
 def factorial(x: int) -> int:

--- a/mypyc/test-data/run-imports.test
+++ b/mypyc/test-data/run-imports.test
@@ -5,9 +5,20 @@ import testmodule
 
 def f(x: int) -> int:
     return testmodule.factorial(5)
+
 def g(x: int) -> int:
     from welp import foo
     return foo(x)
+
+def test_import() -> None:
+    assert f(5) == 120
+    assert g(5) == 5
+
+def test_import_submodule_within_function() -> None:
+    import pkg.mod
+    assert pkg.x == 1
+    assert pkg.mod.y == 2
+
 [file testmodule.py]
 def factorial(x: int) -> int:
     if x == 0:
@@ -17,13 +28,10 @@ def factorial(x: int) -> int:
 [file welp.py]
 def foo(x: int) -> int:
     return x
-[file driver.py]
-from native import f, g
-print(f(5))
-print(g(5))
-[out]
-120
-5
+[file pkg/__init__.py]
+x = 1
+[file pkg/mod.py]
+y = 2
 
 [case testImportMissing]
 # The unchecked module is configured by the test harness to not be


### PR DESCRIPTION
Fix an issue where this code resulted in an unbound local `p`
error:

```
def f() -> None:
    import p.submodule
    print(p.x)  # Runtime error here
```

We now look up `p` from the global modules dictionary instead
of trying to use an undefined local variable.