### PR TITLE
Fix type check failure stemming from new pytest release

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,8 @@ flake8-bugbear; python_version >= '3.5'
 flake8-pyi>=20.5; python_version >= '3.6'
 lxml>=4.4.0
 psutil>=4.0
-pytest>=6.1.0,<7.0.0
+# pytest 6.2 does not support Python 3.5
+pytest>=6.1.0,<6.2.0
 pytest-xdist>=1.34.0,<2.0.0
 pytest-forked>=1.3.0,<2.0.0
 pytest-cov>=2.10.0,<3.0.0


### PR DESCRIPTION
The release of pytest 6.2 broke mypy's type checking of itself, since pytest 6.2 drops support for Python 3.5 (https://docs.pytest.org/en/stable/changelog.html#pytest-6-2-0-2020-12-12)