### PR TITLE
[mypyc] Speed up and improve multiple assignment

### DIFF
--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -12,7 +12,7 @@ import importlib.util
 from mypy.nodes import (
     Block, ExpressionStmt, ReturnStmt, AssignmentStmt, OperatorAssignmentStmt, IfStmt, WhileStmt,
     ForStmt, BreakStmt, ContinueStmt, RaiseStmt, TryStmt, WithStmt, AssertStmt, DelStmt,
-    Expression, StrExpr, TempNode, Lvalue, Import, ImportFrom, ImportAll, TupleExpr
+    Expression, StrExpr, TempNode, Lvalue, Import, ImportFrom, ImportAll, TupleExpr, ListExpr
 )
 
 from mypyc.ir.ops import (
@@ -69,26 +69,29 @@ def transform_return_stmt(builder: IRBuilder, stmt: ReturnStmt) -> None:
 
 
 def transform_assignment_stmt(builder: IRBuilder, stmt: AssignmentStmt) -> None:
-    assert len(stmt.lvalues) >= 1
-    builder.disallow_class_assignments(stmt.lvalues, stmt.line)
-    lvalue = stmt.lvalues[0]
+    lvalues = stmt.lvalues
+    assert len(lvalues) >= 1
+    builder.disallow_class_assignments(lvalues, stmt.line)
+    first_lvalue = lvalues[0]
     if stmt.type and isinstance(stmt.rvalue, TempNode):
         # This is actually a variable annotation without initializer. Don't generate
         # an assignment but we need to call get_assignment_target since it adds a
         # name binding as a side effect.
-        builder.get_assignment_target(lvalue, stmt.line)
+        builder.get_assignment_target(first_lvalue, stmt.line)
         return
 
-    # multiple assignment
-    if (isinstance(lvalue, TupleExpr) and isinstance(stmt.rvalue, TupleExpr)
-            and len(lvalue.items) == len(stmt.rvalue.items)):
+    # Special case multiple assignments like 'x, y = e1, e2'.
+    if (isinstance(first_lvalue, (TupleExpr, ListExpr))
+            and isinstance(stmt.rvalue, (TupleExpr, ListExpr))
+            and len(first_lvalue.items) == len(stmt.rvalue.items)
+            and len(lvalues) == 1):
         temps = []
         for right in stmt.rvalue.items:
             rvalue_reg = builder.accept(right)
             temp = builder.alloc_temp(rvalue_reg.type)
             builder.assign(temp, rvalue_reg, stmt.line)
             temps.append(temp)
-        for (left, temp) in zip(lvalue.items, temps):
+        for (left, temp) in zip(first_lvalue.items, temps):
             assignment_target = builder.get_assignment_target(left)
             builder.assign(assignment_target, temp, stmt.line)
         return
@@ -96,8 +99,8 @@ def transform_assignment_stmt(builder: IRBuilder, stmt: AssignmentStmt) -> None:
     line = stmt.rvalue.line
     rvalue_reg = builder.accept(stmt.rvalue)
     if builder.non_function_scope() and stmt.is_final_def:
-        builder.init_final_static(lvalue, rvalue_reg)
-    for lvalue in stmt.lvalues:
+        builder.init_final_static(first_lvalue, rvalue_reg)
+    for lvalue in lvalues:
         target = builder.get_assignment_target(lvalue)
         builder.assign(target, rvalue_reg, line)
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -489,6 +489,7 @@ void CPyDebug_Print(const char *msg);
 void CPy_Init(void);
 int CPyArg_ParseTupleAndKeywords(PyObject *, PyObject *,
                                  const char *, char **, ...);
+int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected);
 
 
 #ifdef __cplusplus

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -499,8 +499,12 @@ void CPyDebug_Print(const char *msg) {
 int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected) {
     Py_ssize_t actual = Py_SIZE(sequence);
     if (unlikely(actual != expected)) {
-        PyErr_Format(PyExc_ValueError, "not enough values to unpack (expected %zd, got %zd)",
-                     expected, actual);
+        if (actual < expected) {
+            PyErr_Format(PyExc_ValueError, "not enough values to unpack (expected %zd, got %zd)",
+                         expected, actual);
+        } else {
+            PyErr_Format(PyExc_ValueError, "too many values to unpack (expected %zd)", expected);
+        }
         return -1;
     }
     return 0;

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -495,3 +495,13 @@ void CPyDebug_Print(const char *msg) {
     printf("%s\n", msg);
     fflush(stdout);
 }
+
+int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected) {
+    Py_ssize_t actual = Py_SIZE(sequence);
+    if (unlikely(actual != expected)) {
+        PyErr_Format(PyExc_ValueError, "not enough values to unpack (expected %zd, got %zd)",
+                     expected, actual);
+        return -1;
+    }
+    return 0;
+}

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -179,7 +179,7 @@ dataclass_sleight_of_hand = custom_op(
 
 # Raise ValueError if length of first argument is not equal to the second argument.
 # The first argument must be a list or a variable-length tuple.
-check_unpack_count_op = c_custom_op(
+check_unpack_count_op = custom_op(
     arg_types=[object_rprimitive, c_pyssize_t_rprimitive],
     return_type=c_int_rprimitive,
     c_function_name='CPySequence_CheckUnpackCount',

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -3,7 +3,7 @@
 from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ERR_FALSE
 from mypyc.ir.rtypes import (
     bool_rprimitive, object_rprimitive, str_rprimitive, object_pointer_rprimitive,
-    int_rprimitive, dict_rprimitive, c_int_rprimitive, bit_rprimitive
+    int_rprimitive, dict_rprimitive, c_int_rprimitive, bit_rprimitive, c_pyssize_t_rprimitive
 )
 from mypyc.primitives.registry import (
     function_op, custom_op, load_address_op, ERR_NEG_INT
@@ -176,3 +176,11 @@ dataclass_sleight_of_hand = custom_op(
     return_type=bit_rprimitive,
     c_function_name='CPyDataclass_SleightOfHand',
     error_kind=ERR_FALSE)
+
+# Raise ValueError if length of first argument is not equal to the second argument.
+# The first argument must be a list or a variable-length tuple.
+check_unpack_count_op = c_custom_op(
+    arg_types=[object_rprimitive, c_pyssize_t_rprimitive],
+    return_type=c_int_rprimitive,
+    c_function_name='CPySequence_CheckUnpackCount',
+    error_kind=ERR_NEG_INT)

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3606,6 +3606,10 @@ def f(x: int, y: int) -> Tuple[int, int]:
 def f2(x: int, y: str, z: float) -> Tuple[float, str, int]:
     a, b, c = x, y, z
     return (c, b, a)
+
+def f3(x: int, y: int) -> Tuple[int, int]:
+    [x, y] = [y, x]
+    return (x, y)
 [out]
 def f(x, y):
     x, y, r0, r1 :: int
@@ -3637,6 +3641,17 @@ L0:
     c = r2
     r3 = (c, b, a)
     return r3
+
+def f3(x, y):
+    x, y, r0, r1 :: int
+    r2 :: tuple[int, int]
+L0:
+    r0 = y
+    r1 = x
+    x = r0
+    y = r1
+    r2 = (x, y)
+    return r2
 
 [case testLocalImportSubmodule]
 def f() -> int:

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3596,63 +3596,6 @@ L0:
     r2 = truncate r0: int32 to builtins.bool
     return r2
 
-[case testMultipleAssignment]
-from typing import Tuple
-
-def f(x: int, y: int) -> Tuple[int, int]:
-    x, y = y, x
-    return (x, y)
-
-def f2(x: int, y: str, z: float) -> Tuple[float, str, int]:
-    a, b, c = x, y, z
-    return (c, b, a)
-
-def f3(x: int, y: int) -> Tuple[int, int]:
-    [x, y] = [y, x]
-    return (x, y)
-[out]
-def f(x, y):
-    x, y, r0, r1 :: int
-    r2 :: tuple[int, int]
-L0:
-    r0 = y
-    r1 = x
-    x = r0
-    y = r1
-    r2 = (x, y)
-    return r2
-def f2(x, y, z):
-    x :: int
-    y :: str
-    z :: float
-    r0 :: int
-    r1 :: str
-    r2 :: float
-    a :: int
-    b :: str
-    c :: float
-    r3 :: tuple[float, str, int]
-L0:
-    r0 = x
-    r1 = y
-    r2 = z
-    a = r0
-    b = r1
-    c = r2
-    r3 = (c, b, a)
-    return r3
-
-def f3(x, y):
-    x, y, r0, r1 :: int
-    r2 :: tuple[int, int]
-L0:
-    r0 = y
-    r1 = x
-    x = r0
-    y = r1
-    r2 = (x, y)
-    return r2
-
 [case testLocalImportSubmodule]
 def f() -> int:
     import p.m

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -681,16 +681,16 @@ L0:
     r0 = CPySequence_CheckUnpackCount(l, 2)
     r1 = r0 >= 0 :: signed
     r2 = CPyList_GetItemUnsafe(l, 0)
-    x = r2
     r3 = CPyList_GetItemUnsafe(l, 2)
+    x = r2
     r4 = unbox(int, r3)
     y = r4
     r5 = CPySequence_CheckUnpackCount(t, 2)
     r6 = r5 >= 0 :: signed
     r7 = CPySequenceTuple_GetItem(t, 0)
-    x = r7
     r8 = CPySequenceTuple_GetItem(t, 2)
     r9 = unbox(int, r8)
+    x = r7
     y = r9
     return 1
 

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -624,9 +624,9 @@ def f(l, t):
 L0:
     r0 = CPySequence_CheckUnpackCount(l, 2)
     r1 = r0 >= 0 :: signed
-    r2 = CPyList_GetItemShort(l, 0)
+    r2 = CPyList_GetItemUnsafe(l, 0)
     x = r2
-    r3 = CPyList_GetItemShort(l, 2)
+    r3 = CPyList_GetItemUnsafe(l, 2)
     r4 = unbox(int, r3)
     y = r4
     r5 = CPySequence_CheckUnpackCount(t, 2)

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -454,7 +454,63 @@ L9:
 L10:
     return s
 
-[case testMultipleAssignmentBasic]
+[case testMultipleAssignmentWithNoUnpacking]
+from typing import Tuple
+
+def f(x: int, y: int) -> Tuple[int, int]:
+    x, y = y, x
+    return (x, y)
+
+def f2(x: int, y: str, z: float) -> Tuple[float, str, int]:
+    a, b, c = x, y, z
+    return (c, b, a)
+
+def f3(x: int, y: int) -> Tuple[int, int]:
+    [x, y] = [y, x]
+    return (x, y)
+[out]
+def f(x, y):
+    x, y, r0, r1 :: int
+    r2 :: tuple[int, int]
+L0:
+    r0 = y
+    r1 = x
+    x = r0
+    y = r1
+    r2 = (x, y)
+    return r2
+def f2(x, y, z):
+    x :: int
+    y :: str
+    z :: float
+    r0 :: int
+    r1 :: str
+    r2 :: float
+    a :: int
+    b :: str
+    c :: float
+    r3 :: tuple[float, str, int]
+L0:
+    r0 = x
+    r1 = y
+    r2 = z
+    a = r0
+    b = r1
+    c = r2
+    r3 = (c, b, a)
+    return r3
+def f3(x, y):
+    x, y, r0, r1 :: int
+    r2 :: tuple[int, int]
+L0:
+    r0 = y
+    r1 = x
+    x = r0
+    y = r1
+    r2 = (x, y)
+    return r2
+
+[case testMultipleAssignmentBasicUnpacking]
 from typing import Tuple, Any
 
 def from_tuple(t: Tuple[int, str]) -> None:
@@ -599,7 +655,7 @@ L0:
     z = r6
     return 1
 
-[case testMultipleAssignmentFromSequence]
+[case testMultipleAssignmentUnpackFromSequence]
 from typing import List, Tuple
 
 def f(l: List[int], t: Tuple[int, ...]) -> None:

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -454,7 +454,7 @@ L9:
 L10:
     return s
 
-[case testMultipleAssignment]
+[case testMultipleAssignmentBasic]
 from typing import Tuple, Any
 
 def from_tuple(t: Tuple[int, str]) -> None:
@@ -597,6 +597,45 @@ L0:
     r5 = r2[1]
     r6 = unbox(int, r5)
     z = r6
+    return 1
+
+[case testMultipleAssignmentFromSequence]
+from typing import List, Tuple
+
+def f(l: List[int], t: Tuple[int, ...]) -> None:
+    x: object
+    y: int
+    x, y = l
+    x, y = t
+[out]
+def f(l, t):
+    l :: list
+    t :: tuple
+    x :: object
+    y :: int
+    r0 :: int32
+    r1 :: bit
+    r2, r3 :: object
+    r4 :: int
+    r5 :: int32
+    r6 :: bit
+    r7, r8 :: object
+    r9 :: int
+L0:
+    r0 = CPySequence_CheckUnpackCount(l, 2)
+    r1 = r0 >= 0 :: signed
+    r2 = CPyList_GetItemShort(l, 0)
+    x = r2
+    r3 = CPyList_GetItemShort(l, 2)
+    r4 = unbox(int, r3)
+    y = r4
+    r5 = CPySequence_CheckUnpackCount(t, 2)
+    r6 = r5 >= 0 :: signed
+    r7 = CPySequenceTuple_GetItem(t, 0)
+    x = r7
+    r8 = CPySequenceTuple_GetItem(t, 2)
+    r9 = unbox(int, r8)
+    y = r9
     return 1
 
 [case testAssert]

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -356,8 +356,15 @@ def from_list_complex(l: List[int]) -> List[int]:
 def from_any(o: Any) -> List[Any]:
     x, y = o
     return [y, x]
+
+def multiple_assignments(t: Tuple[int, str]) -> List[Any]:
+    a, b = c, d = t
+    e, f = g, h = 1, 2
+    return [a, b, c, d, e, f, g, h]
 [file driver.py]
-from native import from_tuple, from_tuple_sequence, from_list, from_list_complex, from_any
+from native import (
+    from_tuple, from_tuple_sequence, from_list, from_list_complex, from_any, multiple_assignments
+)
 
 assert from_tuple((1, 'x')) == ['x', 1]
 
@@ -386,6 +393,8 @@ else:
     assert False
 
 assert from_any('xy') == ['y', 'x']
+
+assert multiple_assignments((4, 'x')) == [4, 'x', 4, 'x', 1, 2, 1, 2]
 
 [case testUnpack]
 from typing import List

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -340,6 +340,10 @@ def from_tuple(t: Tuple[int, str]) -> List[Any]:
     x, y = t
     return [y, x]
 
+def from_tuple_sequence(t: Tuple[int, ...]) -> List[int]:
+    x, y, z = t
+    return [z, y, x]
+
 def from_list(l: List[int]) -> List[int]:
     x, y = l
     return [y, x]
@@ -348,9 +352,10 @@ def from_any(o: Any) -> List[Any]:
     x, y = o
     return [y, x]
 [file driver.py]
-from native import from_tuple, from_list, from_any
+from native import from_tuple, from_tuple_sequence, from_list, from_any
 
 assert from_tuple((1, 'x')) == ['x', 1]
+assert from_tuple_sequence((1, 5, 4)) == [4, 5, 1]
 assert from_list([3, 4]) == [4, 3]
 assert from_any('xy') == ['y', 'x']
 

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -348,11 +348,16 @@ def from_list(l: List[int]) -> List[int]:
     x, y = l
     return [y, x]
 
+def from_list_complex(l: List[int]) -> List[int]:
+    ll = l[:]
+    ll[1], ll[0] = l
+    return ll
+
 def from_any(o: Any) -> List[Any]:
     x, y = o
     return [y, x]
 [file driver.py]
-from native import from_tuple, from_tuple_sequence, from_list, from_any
+from native import from_tuple, from_tuple_sequence, from_list, from_list_complex, from_any
 
 assert from_tuple((1, 'x')) == ['x', 1]
 
@@ -367,6 +372,14 @@ else:
 assert from_list([3, 4]) == [4, 3]
 try:
     from_list([5, 4, 3])
+except ValueError as e:
+    assert 'too many values to unpack (expected 2)' in str(e)
+else:
+    assert False
+
+assert from_list_complex([7, 6]) == [6, 7]
+try:
+    from_list_complex([5, 4, 3])
 except ValueError as e:
     assert 'too many values to unpack (expected 2)' in str(e)
 else:

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -355,8 +355,23 @@ def from_any(o: Any) -> List[Any]:
 from native import from_tuple, from_tuple_sequence, from_list, from_any
 
 assert from_tuple((1, 'x')) == ['x', 1]
+
 assert from_tuple_sequence((1, 5, 4)) == [4, 5, 1]
+try:
+    from_tuple_sequence((1, 5))
+except ValueError as e:
+    assert 'not enough values to unpack (expected 3, got 2)' in str(e)
+else:
+    assert False
+
 assert from_list([3, 4]) == [4, 3]
+try:
+    from_list([5, 4, 3])
+except ValueError as e:
+    assert 'too many values to unpack (expected 2)' in str(e)
+else:
+    assert False
+
 assert from_any('xy') == ['y', 'x']
 
 [case testUnpack]


### PR DESCRIPTION
Speed up multiple assignment from variable-length lists and tuples. 
This speeds up the `multiple_assignment` benchmark by around 80%.

Fix multiple lvalues in fixed-length sequence assignments.

Optimize some cases of list expressions in assignments.

Fixes mypyc/mypyc#729.