### PR TITLE
Add error code for name mistaches in named tuples and TypedDicts

### DIFF
--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -651,8 +651,8 @@ You can also use ``None``:
 Check that naming is consistent [name-match]
 --------------------------------------------
 
-The definition of a named tuple must be named consistently when
-using the call-based syntax:
+The definition of a named tuple or a TypedDict must be named
+consistently when using the call-based syntax. Example:
 
 .. code-block:: python
 

--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -648,6 +648,18 @@ You can also use ``None``:
        def __exit__(self, exc, value, tb) -> None:  # Also OK
            print('exit')
 
+Check that naming is consistent [name-match]
+--------------------------------------------
+
+The definition of a named tuple must be named consistently when
+using the call-based syntax:
+
+.. code-block:: python
+
+    from typing import NamedTuple
+
+    # Error: First argument to namedtuple() should be 'Point2D', not 'Point'
+    Point2D = NamedTuple("Point", [("x", int), ("y", int)])
 
 Report syntax errors [syntax]
 -----------------------------

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -118,7 +118,7 @@ REDUNDANT_EXPR = ErrorCode(
     'General',
     default_enabled=False)  # type: Final
 NAME_MATCH = ErrorCode(
-    'name-match', "Check that definition has consistent naming", 'General')  # type: Final
+    'name-match', "Check that type definition has consistent naming", 'General')  # type: Final
 
 
 # Syntax errors are often blocking.

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -117,6 +117,9 @@ REDUNDANT_EXPR = ErrorCode(
     "Warn about redundant expressions",
     'General',
     default_enabled=False)  # type: Final
+NAME_MATCH = ErrorCode(
+    'name-match', "Check that definition has consistent naming", 'General')  # type: Final
+
 
 # Syntax errors are often blocking.
 SYNTAX = ErrorCode(

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2205,7 +2205,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             return False
         if internal_name != name:
             self.fail("First argument to namedtuple() should be '{}', not '{}'".format(
-                name, internal_name), s.rvalue)
+                name, internal_name), s.rvalue, code=codes.NAME_MATCH)
             return True
         # Yes, it's a valid namedtuple, but defer if it is not ready.
         if not info:

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -15,6 +15,8 @@ from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
 from mypy.options import Options
 from mypy.typeanal import check_for_explicit_any, has_any_from_unimported_type
 from mypy.messages import MessageBuilder
+from mypy.errorcodes import ErrorCode
+from mypy import errorcodes as codes
 
 TPDICT_CLASS_ERROR = ('Invalid statement in TypedDict definition; '
                       'expected "field_name: field_type"')  # type: Final
@@ -199,7 +201,7 @@ class TypedDictAnalyzer:
             if var_name is not None and name != var_name:
                 self.fail(
                     "First argument '{}' to TypedDict() does not match variable name '{}'".format(
-                        name, var_name), node)
+                        name, var_name), node, code=codes.NAME_MATCH)
             if name != var_name or is_func_scope:
                 # Give it a unique name derived from the line number.
                 name += '@' + str(call.line)
@@ -320,5 +322,5 @@ class TypedDictAnalyzer:
         return (isinstance(expr, RefExpr) and isinstance(expr.node, TypeInfo) and
                 expr.node.typeddict_type is not None)
 
-    def fail(self, msg: str, ctx: Context) -> None:
-        self.api.fail(msg, ctx)
+    def fail(self, msg: str, ctx: Context, *, code: Optional[ErrorCode] = None) -> None:
+        self.api.fail(msg, ctx, code=code)

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -792,3 +792,9 @@ from typing import NamedTuple
 
 Foo = NamedTuple("Bar", [])  # E: First argument to namedtuple() should be 'Foo', not 'Bar'  [name-match]
 [builtins fixtures/tuple.pyi]
+
+[case testTypedDictNameMismatch]
+from typing_extensions import TypedDict
+
+Foo = TypedDict("Bar", {})  # E: First argument 'Bar' to TypedDict() does not match variable name 'Foo'  [name-match]
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -786,3 +786,9 @@ i = [x for x in lst if True]             # E: If condition in comprehension is a
 j = [x for x in lst if False]            # E: If condition in comprehension is always false  [redundant-expr]
 k = [x for x in lst if isinstance(x, int) or foo()]  # E: If condition in comprehension is always true  [redundant-expr]
 [builtins fixtures/isinstancelist.pyi]
+
+[case testNamedTupleNameMismatch]
+from typing import NamedTuple
+
+Foo = NamedTuple("Bar", [])  # E: First argument to namedtuple() should be 'Foo', not 'Bar'  [name-match]
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
This gives a new error code for code like this:

```
# Foo and Bar don't match
Foo = NamedTuple("Bar", [...])
```

Since these errors generally don't cause runtime issues, some users may want to 
disable these errors. It's now easy to do using the error code `name-match`.
