### PR TITLE
tests: Avoid side effect of COLUMNS env var

### DIFF
--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -55,6 +55,7 @@ def test_python_cmdline(testcase: DataDrivenTestCase, step: int) -> None:
     # Type check the program.
     fixed = [python3_path, '-m', 'mypy']
     env = os.environ.copy()
+    env.pop('COLUMNS', None)
     env['PYTHONPATH'] = PREFIX
     process = subprocess.Popen(fixed + args,
                                stdout=subprocess.PIPE,

--- a/mypy/test/testutil.py
+++ b/mypy/test/testutil.py
@@ -8,5 +8,8 @@ class TestGetTerminalSize(TestCase):
     def test_get_terminal_size_in_pty_defaults_to_80(self) -> None:
         # when run using a pty, `os.get_terminal_size()` returns `0, 0`
         ret = os.terminal_size((0, 0))
+        mock_environ = os.environ.copy()
+        mock_environ.pop('COLUMNS', None)
         with mock.patch.object(os, 'get_terminal_size', return_value=ret):
-            assert get_terminal_width() == 80
+            with mock.patch.dict(os.environ, values=mock_environ, clear=True):
+                assert get_terminal_width() == 80


### PR DESCRIPTION
### Description

Several tests rely on getting the default width of a terminal for
rendering test output. Some PTY environments (in my case the Emacs
shell) set the env var `COLUMNS` to the terminal width, which can
cause several tests to fail due to formatting mismatches.

Prior to running thesee tests, mock out `sys.environ`, removing the
`COLUMNS` env var when present.

## Test Plan

The change should only effect environments like my own. After this change, tests pass in my environment. The change can be manually tested in other environments by running

``` Shell
COLUMNS=120 ./runtests.py
```

before, then after applying the change.