### PR TITLE
Make sure that enum members are treated as enum.

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -596,6 +596,20 @@ def analyze_var(name: str,
             mx.not_ready_callback(var.name, mx.context)
         # Implicit 'Any' type.
         result = AnyType(TypeOfAny.special_form)
+
+    if info.is_enum and info == itype.type:
+        # enum members are enums themselves.
+        #
+        # class Spam(enum.Enum):
+        #    FOO = "Foo"
+        #
+        # It seems that Spam.FOO is assigned a "Foo" str. Yet:
+        #
+        # reveal_type(Spam.FOO) # N: Revealed type is 'Literal[test_enum.Spam.FOO]?'
+        #
+        # Therefore, we overide the result:
+        result = itype
+
     fullname = '{}.{}'.format(var.info.fullname, name)
     hook = mx.chk.plugin.get_attribute_hook(fullname)
     if result and not mx.is_lvalue and not implicit:

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1242,3 +1242,19 @@ class Comparator(enum.Enum):
 
 reveal_type(Comparator.__foo__)  # N: Revealed type is 'builtins.dict[builtins.str, builtins.int]'
 [builtins fixtures/dict.pyi]
+
+[case testEnumMemberType]
+from enum import Enum
+class Truth(Enum):
+    true = True
+    false = False
+
+x = Truth.true
+
+reveal_type(Truth.true)  # N: Revealed type is 'Literal[__main__.Truth.true]?'
+reveal_type(Truth.true.value)  # N: Revealed type is 'builtins.bool'
+reveal_type(Truth.true.true)  # N: Revealed type is 'Literal[__main__.Truth.true]?'
+reveal_type(x)  # N: Revealed type is '__main__.Truth'
+reveal_type(x.value)  # N: Revealed type is 'builtins.bool'
+reveal_type(x.true)  # N: Revealed type is '__main__.Truth'
+reveal_type(x.true.true)  # N: Revealed type is '__main__.Truth'


### PR DESCRIPTION
The type of Spam.FOO is Spam in:
```py
class Spam(Enum):
    FOO = "Foo"
```
Yet mypy sometimes treats it as a string.
This commit makes sure that `Spam.FOO` is treated as `Spam`.

Fixes #9817.