### PR TITLE
fixing the --update-data flag for pytest [reopened]

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -149,7 +149,7 @@ def parse_test_case(case: 'DataDrivenTestCase') -> None:
     case.input = input
     case.output = output
     case.output2 = output2
-    case.lastline = item.line
+    case.last_line = case.line + item.line + len(item.data) - 2
     case.files = files
     case.output_files = output_files
     case.expected_stale_modules = stale_modules
@@ -185,7 +185,7 @@ class DataDrivenTestCase(pytest.Item):
     normalize_output = True
 
     # Extra attributes used by some tests.
-    lastline = None  # type: int
+    last_line = None  # type: int
     output_files = None  # type: List[Tuple[str, str]] # Path and contents for output files
     deleted_paths = None  # type: Dict[int, Set[str]]  # Mapping run number -> paths
     triggered = None  # type: List[str]  # Active triggers (one line per incremental step)

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -148,7 +148,7 @@ def update_testcase_output(testcase: DataDrivenTestCase, output: List[str]) -> N
     testcase_path = os.path.join(testcase.old_cwd, testcase.file)
     with open(testcase_path, encoding='utf8') as f:
         data_lines = f.read().splitlines()
-    test = '\n'.join(data_lines[testcase.line:testcase.lastline])
+    test = '\n'.join(data_lines[testcase.line:testcase.last_line])
 
     mapping = {}  # type: Dict[str, List[str]]
     for old, new in zip(testcase.output, output):
@@ -168,7 +168,7 @@ def update_testcase_output(testcase: DataDrivenTestCase, output: List[str]) -> N
                 list(chain.from_iterable(zip(mapping[old], betweens[1:])))
             test = ''.join(interleaved)
 
-    data_lines[testcase.line:testcase.lastline] = [test]
+    data_lines[testcase.line:testcase.last_line] = [test]
     data = '\n'.join(data_lines)
     with open(testcase_path, 'w', encoding='utf8') as f:
         print(data, file=f)


### PR DESCRIPTION
Description
Fixing completely broken `--update-data` flag for pytest.

I had a great deal of pain to update tests as the `--update-data` flag didn't do a thing. On examining I realised that few logics are incorrect. I will try to explain them.

To determine the last line of the test it uses `item.line`. Well each item is the content between statements of the type [file], [case], [out], etc. `item.line` provides the first line of the item. Previously, `testcase.lastline` was defined as the first line of the last item. But the last item might consist of more than one line for example-
```
[out]
Error 1
Error 2
Error 3
```
Here the test case will be limited to Error 1. So we need to instead make testcase.lastline as item.line + len(item.data) - 1

Also while performing an update to test it considered test = '\n'.join(data_lines[testcase.line:testcase.lastline]) but here testcase.lastline is the length and not the line number so it needs to be test = '\n'.join(data_lines[testcase.line:testcase.line+testcase.lastline-1])

For example-
```
239:[case testSample]
240:line 1
241:line 2
242:line 3
243:[out]
244:error 1
245:error 2
246:error 3
247:
```
**Before my changes**
`case.line=239`

`case.lastline=6 (first line of the last item)`

`test = '\n'.join(data_lines[239:6])`

**After my changes**
`case.line=239`

`case.last_line= 239 + 6 + 3 (len(item.data)) - 2 = 246 (exact last line of the test case)`

`test = '\n'.join(data_lines[ 239 : 246 ] )`

Also the property `lastline` has been renamed to `last_line`

Test Plan
I made changes to messages.py and earlier it showed test failed but did not update them. But now it updates test cases with the output.(with --update-data flag)