### PR TITLE
allow packages/modules as args with files in cfg

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -851,9 +851,9 @@ def process_options(args: List[str],
     if special_opts.no_executable or options.no_site_packages:
         options.python_executable = None
 
-    # Paths listed in the config file will be ignored if any paths are passed on
-    # the command line.
-    if options.files and not special_opts.files:
+    # Paths listed in the config file will be ignored if any paths, modules or packages
+    # are passed on the command line.
+    if options.files and not (special_opts.files or special_opts.packages or special_opts.modules):
         special_opts.files = options.files
 
     # Check for invalid argument combinations.

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1248,3 +1248,37 @@ x: str = 0
 pkg/x.py:1: error: invalid syntax
 Found 1 error in 1 file (errors prevented further checking)
 == Return code: 2
+
+[case testCmdlinePackageAndFile]
+# cmd: mypy -p pkg file
+[out]
+usage: mypy [-h] [-v] [-V] [more options; see below]
+            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
+mypy: error: May only specify one of: module/package, files, or command.
+== Return code: 2
+
+[case testCmdlinePackageAndIniFiles]
+# cmd: mypy -p pkg
+[file mypy.ini]
+\[mypy]
+files=file
+[file pkg.py]
+x: str = 0
+[file file.py]
+y: str = 0
+[out]
+pkg.py:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+
+[case testCmdlineModuleAndIniFiles]
+# cmd: mypy -m pkg
+[file mypy.ini]
+\[mypy]
+files=file
+[file pkg.py]
+x: str = 0
+[file file.py]
+y: str = 0
+[out]
+pkg.py:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1263,9 +1263,9 @@ mypy: error: May only specify one of: module/package, files, or command.
 \[mypy]
 files=file
 [file pkg.py]
-x: str = 0
+x = 0  # type: str
 [file file.py]
-y: str = 0
+y = 0  # type: str
 [out]
 pkg.py:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
@@ -1276,9 +1276,9 @@ pkg.py:1: error: Incompatible types in assignment (expression has type "int", va
 \[mypy]
 files=file
 [file pkg.py]
-x: str = 0
+x = 0  # type: str
 [file file.py]
-y: str = 0
+y = 0  # type: str
 [out]
 pkg.py:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 


### PR DESCRIPTION
### Description

Currently only files can be specified on the command line if files are
specified in mypy.ini.  This looks a great deal like a bug, especially
since packages and modules cannot be specified in the configuration
file. 

This PR changes the logic to only use the files from the ini
file if none of (modules/packages/files) are specified on the command
line and adds tests to verify the new behavior.

I would also like to add packages and modules keys to the configuration file so a project I work on can use packages as its default without arguments, but want to gauge interest in that first, where this looked like it was probably a mistake with a straightforward solution.

## Test Plan

Three new tests have been added to the codlin.test file that test that the conflict is still noted when both are placed on the command line, as well as two tests that ensure the right package/module is selected and checked when a package or module is on the command line with files in the config.

This is my first time working with this test format, pytest runs them and gives reliable results on my machine for these new tests, but if these are outside of style or similar I'll be happy to fix them.
