### PR TITLE
find_sources: deal more robustly with filenames with periods

### DIFF
--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -145,8 +145,11 @@ class SourceFinder:
         if module_name == "__init__":
             return parent_module, base_dir
 
-        # Note that module_name might not actually be a valid identifier, but that's okay
+        # Note that module_name might not actually be a valid identifier, but that's okay (once
+        # we've removed periods from module_name)
         # Ignoring this possibility sidesteps some search path confusion
+        module_name = module_name.replace(".", "-")
+
         module = module_join(parent_module, module_name)
         return module, base_dir
 

--- a/mypy/test/test_find_sources.py
+++ b/mypy/test/test_find_sources.py
@@ -172,6 +172,12 @@ class SourceFinderSuite(unittest.TestCase):
         assert crawl(finder, "/a/pkg/a.py") == ("pkg.a", "/a")
         assert crawl(finder, "/b/pkg/b.py") == ("pkg.b", "/b")
 
+    def test_crawl_invalid_module(self) -> None:
+        options = Options()
+
+        finder = SourceFinder(FakeFSCache({"/dot.dot.py"}), options)
+        assert crawl(finder, "/dot.dot.py") == ("dot-dot", "/")
+
     def test_find_sources_no_namespace(self) -> None:
         options = Options()
         options.namespace_packages = False


### PR DESCRIPTION
Note that we deal with the possibility of parent_module containing a
period in _crawl_up_helper

Brought up in #9833

For context on the preexisting comment about invalid module names, see https://github.com/python/mypy/pull/9742#issuecomment-731715016