### PR TITLE
Use Py_TRASHCAN_{BEGIN,END} in tp_dealloc functions

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -627,10 +627,10 @@ def generate_dealloc_for_class(cl: ClassIR,
     emitter.emit_line('{}({} *self)'.format(dealloc_func_name, cl.struct_name(emitter.names)))
     emitter.emit_line('{')
     emitter.emit_line('PyObject_GC_UnTrack(self);')
-    emitter.emit_line('Py_TRASHCAN_BEGIN(self, {})'.format(dealloc_func_name))
+    emitter.emit_line('CPy_TRASHCAN_BEGIN(self, {})'.format(dealloc_func_name))
     emitter.emit_line('{}(self);'.format(clear_func_name))
     emitter.emit_line('Py_TYPE(self)->tp_free((PyObject *)self);')
-    emitter.emit_line('Py_TRASHCAN_END')
+    emitter.emit_line('CPy_TRASHCAN_END(self)')
     emitter.emit_line('}')
 
 

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -627,8 +627,10 @@ def generate_dealloc_for_class(cl: ClassIR,
     emitter.emit_line('{}({} *self)'.format(dealloc_func_name, cl.struct_name(emitter.names)))
     emitter.emit_line('{')
     emitter.emit_line('PyObject_GC_UnTrack(self);')
+    emitter.emit_line('Py_TRASHCAN_BEGIN(self, {})'.format(dealloc_func_name))
     emitter.emit_line('{}(self);'.format(clear_func_name))
     emitter.emit_line('Py_TYPE(self)->tp_free((PyObject *)self);')
+    emitter.emit_line('Py_TRASHCAN_END')
     emitter.emit_line('}')
 
 

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -627,6 +627,7 @@ def generate_dealloc_for_class(cl: ClassIR,
     emitter.emit_line('{}({} *self)'.format(dealloc_func_name, cl.struct_name(emitter.names)))
     emitter.emit_line('{')
     emitter.emit_line('PyObject_GC_UnTrack(self);')
+    # The trashcan is needed to handle deep recursive deallocations
     emitter.emit_line('CPy_TRASHCAN_BEGIN(self, {})'.format(dealloc_func_name))
     emitter.emit_line('{}(self);'.format(clear_func_name))
     emitter.emit_line('Py_TYPE(self)->tp_free((PyObject *)self);')

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -453,6 +453,14 @@ void CPy_AddTraceback(const char *filename, const char *funcname, int line, PyOb
 
 // Misc operations
 
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 8
+#define CPy_TRASHCAN_BEGIN(op, dealloc) Py_TRASHCAN_BEGIN(op, dealloc)
+#define CPy_TRASHCAN_END(op) Py_TRASHCAN_END
+#else
+#define CPy_TRASHCAN_BEGIN(op, dealloc) Py_TRASHCAN_SAFE_BEGIN(op)
+#define CPy_TRASHCAN_END(op) Py_TRASHCAN_SAFE_END(op)
+#endif
+
 
 // mypy lets ints silently coerce to floats, so a mypyc runtime float
 // might be an int also


### PR DESCRIPTION
See https://github.com/python/cpython/blob/master/Include/cpython/object.h#L456

Fixes https://github.com/mypyc/mypyc/issues/789.

I didn't add a test because a test needs to create a lot of nodes.
Tested manually.