### PR TITLE
[mypyc] Remove Environment

### DIFF
--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -7,7 +7,7 @@ from typing import Dict, Tuple, List, Set, TypeVar, Iterator, Generic, Optional,
 from mypyc.ir.ops import (
     Value, ControlOp,
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
-    Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
+    Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
     LoadStatic, InitStatic, MethodCall, RaiseStandardError, CallC, LoadGlobal,
     Truncate, BinaryIntOp, LoadMem, GetElementPtr, LoadAddress, ComparisonOp, SetMem
 )
@@ -356,7 +356,6 @@ class UndefinedVisitor(BaseAnalysisVisitor):
 
 def analyze_undefined_regs(blocks: List[BasicBlock],
                            cfg: CFG,
-                           env: Environment,
                            initial_defined: Set[Value]) -> AnalysisResult[Value]:
     """Calculate potentially undefined registers at each CFG location.
 

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -7,7 +7,7 @@ from mypyc.common import (
     REG_PREFIX, ATTR_PREFIX, STATIC_PREFIX, TYPE_PREFIX, NATIVE_PREFIX,
     FAST_ISINSTANCE_MAX_SUBCLASSES,
 )
-from mypyc.ir.ops import Environment, BasicBlock, Value
+from mypyc.ir.ops import BasicBlock, Value
 from mypyc.ir.rtypes import (
     RType, RTuple, RInstance, RUnion, RPrimitive,
     is_float_rprimitive, is_bool_rprimitive, is_int_rprimitive, is_short_int_rprimitive,
@@ -90,12 +90,10 @@ class Emitter:
 
     def __init__(self,
                  context: EmitterContext,
-                 env: Optional[Environment] = None,
                  value_names: Optional[Dict[Value, str]] = None) -> None:
         self.context = context
         self.names = context.names
         self.value_names = value_names or {}
-        self.env = env or Environment()
         self.fragments = []  # type: List[str]
         self._indent = 0
 

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -21,7 +21,7 @@ from mypyc.ir.rtypes import (
 from mypyc.ir.func_ir import FuncIR, FuncDecl, FUNC_STATICMETHOD, FUNC_CLASSMETHOD, all_values
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.const_int import find_constant_integer_registers
-from mypyc.ir.pprint import generate_names_for_env
+from mypyc.ir.pprint import generate_names_for_ir
 
 # Whether to insert debug asserts for all error handling, to quickly
 # catch errors propagating without exceptions set.
@@ -54,9 +54,9 @@ def generate_native_function(fn: FuncIR,
         const_int_regs = find_constant_integer_registers(fn.blocks)
     else:
         const_int_regs = {}
-    declarations = Emitter(emitter.context, fn.env)
-    names = generate_names_for_env(fn.arg_regs, fn.blocks)
-    body = Emitter(emitter.context, fn.env, names)
+    declarations = Emitter(emitter.context)
+    names = generate_names_for_ir(fn.arg_regs, fn.blocks)
+    body = Emitter(emitter.context, names)
     visitor = FunctionEmitterVisitor(body, declarations, source_path, module_name, const_int_regs)
 
     declarations.emit_line('{} {{'.format(native_function_header(fn.decl, emitter)))
@@ -102,7 +102,6 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emitter = emitter
         self.names = emitter.names
         self.declarations = declarations
-        self.env = self.emitter.env
         self.source_path = source_path
         self.module_name = module_name
         self.const_int_regs = const_int_regs

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -71,8 +71,6 @@ def generate_native_function(fn: FuncIR,
 
         ctype = emitter.ctype_spaced(r.type)
         init = ''
-        if r in fn.env.vars_needing_init:
-            init = ' = {}'.format(declarations.c_error_value(r.type))
         if r not in const_int_regs:
             declarations.emit_line('{ctype}{prefix}{name}{init};'.format(ctype=ctype,
                                                                          prefix=REG_PREFIX,

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -6,9 +6,7 @@ from typing_extensions import Final
 from mypy.nodes import FuncDef, Block, ARG_POS, ARG_OPT, ARG_NAMED_OPT
 
 from mypyc.common import JsonDict
-from mypyc.ir.ops import (
-    DeserMaps, BasicBlock, Environment, Value, Register, Assign, ControlOp, LoadAddress
-)
+from mypyc.ir.ops import DeserMaps, BasicBlock, Value, Register, Assign, ControlOp, LoadAddress
 from mypyc.ir.rtypes import RType, deserialize_type
 from mypyc.namegen import NameGenerator
 
@@ -147,21 +145,18 @@ class FuncDecl:
 class FuncIR:
     """Intermediate representation of a function with contextual information.
 
-    Unlike FuncDecl, this includes the IR of the body (basic blocks) and an
-    environment.
+    Unlike FuncDecl, this includes the IR of the body (basic blocks).
     """
 
     def __init__(self,
                  decl: FuncDecl,
                  arg_regs: List[Register],
                  blocks: List[BasicBlock],
-                 env: Environment,
                  line: int = -1,
                  traceback_name: Optional[str] = None) -> None:
         self.decl = decl
         self.arg_regs = arg_regs
         self.blocks = blocks
-        self.env = env
         self.line = line
         # The name that should be displayed for tracebacks that
         # include this function. Function will be omitted from
@@ -202,7 +197,7 @@ class FuncIR:
             return '<FuncIR {}>'.format(self.name)
 
     def serialize(self) -> JsonDict:
-        # We don't include blocks or env in the serialized version
+        # We don't include blocks in the serialized version
         return {
             'decl': self.decl.serialize(),
             'line': self.line,
@@ -215,7 +210,6 @@ class FuncIR:
             FuncDecl.deserialize(data['decl'], ctx),
             [],
             [],
-            Environment(),
             data['line'],
             data['traceback_name'],
         )

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1,18 +1,17 @@
-"""Representation of low-level opcodes for compiler intermediate representation (IR).
+"""Low-level opcodes for compiler intermediate representation (IR).
 
-Opcodes operate on abstract registers in a register machine. Each
-register has a type and a name, specified in an environment. A register
-can hold various things:
+Opcodes operate on abstract values (Value) in a register machine. Each
+value has a type (RType). A value can hold various things:
 
-- local variables
-- intermediate values of expressions
+- local variables (Register)
+- intermediate values of expressions (RegisterOp subclasses)
 - condition flags (true/false)
 - literals (integer literals, True, False, etc.)
 """
 
 from abc import abstractmethod
 from typing import (
-    List, Sequence, Dict, Generic, TypeVar, Optional, NamedTuple, Tuple, Union, Set
+    List, Sequence, Dict, Generic, TypeVar, Optional, NamedTuple, Tuple, Union
 )
 
 from typing_extensions import Final, Type, TYPE_CHECKING
@@ -108,13 +107,6 @@ class AssignmentTargetTuple(AssignmentTarget):
         self.star_idx = star_idx
         # The shouldn't be relevant, but provide it just in case.
         self.type = object_rprimitive
-
-
-class Environment:
-    # TODO: Remove this class
-
-    def __init__(self) -> None:
-        pass
 
 
 class BasicBlock:

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -114,7 +114,7 @@ class Environment:
     # TODO: Remove this class
 
     def __init__(self) -> None:
-        self.vars_needing_init = set()  # type: Set[Value]
+        pass
 
 
 class BasicBlock:

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -10,7 +10,7 @@ from mypyc.ir.ops import (
     Goto, Branch, Return, Unreachable, Assign, LoadInt, LoadErrorValue, GetAttr, SetAttr,
     LoadStatic, InitStatic, TupleGet, TupleSet, IncRef, DecRef, Call, MethodCall, Cast, Box, Unbox,
     RaiseStandardError, CallC, Truncate, LoadGlobal, BinaryIntOp, ComparisonOp, LoadMem, SetMem,
-    GetElementPtr, LoadAddress, Register, Value, OpVisitor, BasicBlock, Environment, ControlOp
+    GetElementPtr, LoadAddress, Register, Value, OpVisitor, BasicBlock, ControlOp
 )
 from mypyc.ir.func_ir import FuncIR, all_values_full
 from mypyc.ir.module_ir import ModuleIRs
@@ -265,7 +265,6 @@ def format_registers(func_ir: FuncIR,
 
 
 def format_blocks(blocks: List[BasicBlock],
-                  env: Environment,
                   names: Dict[Value, str],
                   const_regs: Dict[LoadInt, int]) -> List[str]:
     """Format a list of IR basic blocks into a human-readable form."""
@@ -323,10 +322,10 @@ def format_func(fn: FuncIR) -> List[str]:
                                         ', '.join(arg.name for arg in fn.args)))
     # compute constants
     const_regs = find_constant_integer_registers(fn.blocks)
-    names = generate_names_for_env(fn.arg_regs, fn.blocks)
+    names = generate_names_for_ir(fn.arg_regs, fn.blocks)
     for line in format_registers(fn, names, const_regs):
         lines.append('    ' + line)
-    code = format_blocks(fn.blocks, fn.env, names, const_regs)
+    code = format_blocks(fn.blocks, names, const_regs)
     lines.extend(code)
     return lines
 
@@ -340,8 +339,8 @@ def format_modules(modules: ModuleIRs) -> List[str]:
     return ops
 
 
-def generate_names_for_env(args: List[Register], blocks: List[BasicBlock]) -> Dict[Value, str]:
-    """Generate unique names for values in an environment.
+def generate_names_for_ir(args: List[Register], blocks: List[BasicBlock]) -> Dict[Value, str]:
+    """Generate unique names for IR values.
 
     Give names such as 'r5' or 'i0' to temp values in IR which are useful
     when pretty-printing or generating C. Ensure generated names are unique.

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -32,7 +32,7 @@ from mypyc.common import TEMP_ATTR_NAME, SELF_NAME
 from mypyc.irbuild.prebuildvisitor import PreBuildVisitor
 from mypyc.ir.ops import (
     BasicBlock, AssignmentTarget, AssignmentTargetRegister, AssignmentTargetIndex,
-    AssignmentTargetAttr, AssignmentTargetTuple, Environment, LoadInt, Value,
+    AssignmentTargetAttr, AssignmentTargetTuple, LoadInt, Value,
     Register, Op, Assign, Branch, Unreachable, TupleGet, GetAttr, SetAttr, LoadStatic,
     InitStatic, NAMESPACE_MODULE, RaiseStandardError,
 )
@@ -267,10 +267,6 @@ class IRBuilder:
 
     def new_tuple(self, items: List[Value], line: int) -> Value:
         return self.builder.new_tuple(items, line)
-
-    @property
-    def environment(self) -> Environment:
-        return self.builder.environment
 
     # Helpers for IR building
 
@@ -881,7 +877,7 @@ class IRBuilder:
             self.nonlocal_control.append(BaseNonlocalControl())
         self.activate_block(BasicBlock())
 
-    def leave(self) -> Tuple[List[Register], List[BasicBlock], Environment, RType, FuncInfo]:
+    def leave(self) -> Tuple[List[Register], List[BasicBlock], RType, FuncInfo]:
         builder = self.builders.pop()
         self.symtables.pop()
         args = self.args.pop()
@@ -890,7 +886,7 @@ class IRBuilder:
         self.nonlocal_control.pop()
         self.builder = self.builders[-1]
         self.fn_info = self.fn_infos[-1]
-        return args, builder.blocks, builder.environment, ret_type, fn_info
+        return args, builder.blocks, ret_type, fn_info
 
     def lookup(self, symbol: SymbolNode) -> AssignmentTarget:
         return self.symtables[-1][symbol]

--- a/mypyc/irbuild/callable_class.py
+++ b/mypyc/irbuild/callable_class.py
@@ -9,7 +9,7 @@ from typing import List
 from mypy.nodes import Var
 
 from mypyc.common import SELF_NAME, ENV_ATTR_NAME
-from mypyc.ir.ops import BasicBlock, Return, Call, SetAttr, Value, Register, Environment
+from mypyc.ir.ops import BasicBlock, Return, Call, SetAttr, Value, Register
 from mypyc.ir.rtypes import RInstance, object_rprimitive
 from mypyc.ir.func_ir import FuncIR, FuncSignature, RuntimeArg, FuncDecl
 from mypyc.ir.class_ir import ClassIR
@@ -86,19 +86,17 @@ def add_call_to_callable_class(builder: IRBuilder,
                                args: List[Register],
                                blocks: List[BasicBlock],
                                sig: FuncSignature,
-                               env: Environment,
                                fn_info: FuncInfo) -> FuncIR:
     """Generate a '__call__' method for a callable class representing a nested function.
 
-    This takes the blocks, signature, and environment associated with
-    a function definition and uses those to build the '__call__'
-    method of a given callable class, used to represent that
-    function.
+    This takes the blocks and signature associated with a function
+    definition and uses those to build the '__call__' method of a
+    given callable class, used to represent that function.
     """
     # Since we create a method, we also add a 'self' parameter.
     sig = FuncSignature((RuntimeArg(SELF_NAME, object_rprimitive),) + sig.args, sig.ret_type)
     call_fn_decl = FuncDecl('__call__', fn_info.callable_class.ir.name, builder.module_name, sig)
-    call_fn_ir = FuncIR(call_fn_decl, args, blocks, env,
+    call_fn_ir = FuncIR(call_fn_decl, args, blocks,
                         fn_info.fitem.line, traceback_name=fn_info.fitem.name)
     fn_info.callable_class.ir.methods['__call__'] = call_fn_ir
     return call_fn_ir
@@ -130,14 +128,14 @@ def add_get_to_callable_class(builder: IRBuilder, fn_info: FuncInfo) -> None:
     builder.activate_block(instance_block)
     builder.add(Return(builder.call_c(method_new_op, [vself, builder.read(instance)], line)))
 
-    args, blocks, env, _, fn_info = builder.leave()
+    args, blocks, _, fn_info = builder.leave()
 
     sig = FuncSignature((RuntimeArg(SELF_NAME, object_rprimitive),
                          RuntimeArg('instance', object_rprimitive),
                          RuntimeArg('owner', object_rprimitive)),
                         object_rprimitive)
     get_fn_decl = FuncDecl('__get__', fn_info.callable_class.ir.name, builder.module_name, sig)
-    get_fn_ir = FuncIR(get_fn_decl, args, blocks, env)
+    get_fn_ir = FuncIR(get_fn_decl, args, blocks)
     fn_info.callable_class.ir.methods['__get__'] = get_fn_ir
     builder.functions.append(get_fn_ir)
 

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -351,12 +351,12 @@ def generate_attr_defaults(builder: IRBuilder, cdef: ClassDef) -> None:
 
     builder.add(Return(builder.true()))
 
-    args, blocks, env, ret_type, _ = builder.leave()
+    args, blocks, ret_type, _ = builder.leave()
     ir = FuncIR(
         FuncDecl('__mypyc_defaults_setup',
                  cls.name, builder.module_name,
                  FuncSignature(rt_args, ret_type)),
-        args, blocks, env)
+        args, blocks)
     builder.functions.append(ir)
     cls.methods[ir.name] = ir
 
@@ -405,11 +405,11 @@ def gen_glue_ne_method(builder: IRBuilder, cls: ClassIR, line: int) -> FuncIR:
     builder.activate_block(not_implemented_block)
     builder.add(Return(not_implemented))
 
-    arg_regs, blocks, env, ret_type, _ = builder.leave()
+    arg_regs, blocks, ret_type, _ = builder.leave()
     return FuncIR(
         FuncDecl('__ne__', cls.name, builder.module_name,
                  FuncSignature(rt_args, ret_type)),
-        arg_regs, blocks, env)
+        arg_regs, blocks)
 
 
 def load_non_ext_class(builder: IRBuilder,

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -17,9 +17,8 @@ from mypy.types import AnyType, TypeOfAny
 from mypy.checkexpr import map_actuals_to_formals
 
 from mypyc.ir.ops import (
-    BasicBlock, Environment, Op, LoadInt, Value, Register,
-    Assign, Branch, Goto, Call, Box, Unbox, Cast, GetAttr,
-    LoadStatic, MethodCall, CallC, Truncate,
+    BasicBlock, Op, LoadInt, Value, Register, Assign, Branch, Goto, Call, Box, Unbox, Cast,
+    GetAttr, LoadStatic, MethodCall, CallC, Truncate,
     RaiseStandardError, Unreachable, LoadErrorValue, LoadGlobal,
     NAMESPACE_TYPE, NAMESPACE_MODULE, NAMESPACE_STATIC, BinaryIntOp, GetElementPtr,
     LoadMem, ComparisonOp, LoadAddress, TupleGet, SetMem, ERR_NEVER, ERR_FALSE
@@ -76,7 +75,6 @@ class LowLevelIRBuilder:
     ) -> None:
         self.current_module = current_module
         self.mapper = mapper
-        self.environment = Environment()
         self.blocks = []  # type: List[BasicBlock]
         # Stack of except handler entry blocks
         self.error_handlers = [None]  # type: List[Optional[BasicBlock]]

--- a/mypyc/irbuild/main.py
+++ b/mypyc/irbuild/main.py
@@ -124,8 +124,8 @@ def transform_mypy_file(builder: IRBuilder, mypyfile: MypyFile) -> None:
     builder.maybe_add_implicit_return()
 
     # Generate special function representing module top level.
-    args, blocks, env, ret_type, _ = builder.leave()
+    args, blocks, ret_type, _ = builder.leave()
     sig = FuncSignature([], none_rprimitive)
-    func_ir = FuncIR(FuncDecl(TOP_LEVEL_NAME, None, builder.module_name, sig), args, blocks, env,
+    func_ir = FuncIR(FuncDecl(TOP_LEVEL_NAME, None, builder.module_name, sig), args, blocks,
                      traceback_name="<module>")
     builder.functions.append(func_ir)

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -380,56 +380,60 @@ def lol(x: Any) -> object:
     return a + b
 [out]
 def lol(x):
-    x :: object
-    r0 :: str
-    r1, a :: object
+    x, r0, a, r1, b :: object
     r2 :: str
-    r3, b :: object
-    r4 :: tuple[object, object, object]
-    r5, r6 :: bool
-    r7, r8 :: object
+    r3 :: object
+    r4 :: str
+    r5 :: object
+    r6 :: tuple[object, object, object]
+    r7, r8 :: bool
+    r9, r10 :: object
 L0:
+    r0 = <error> :: object
+    a = r0
+    r1 = <error> :: object
+    b = r1
 L1:
-    r0 = load_global CPyStatic_unicode_3 :: static  ('foo')
-    r1 = CPyObject_GetAttr(x, r0)
-    if is_error(r1) goto L4 (error at lol:4) else goto L15
-L2:
-    a = r1
-    r2 = load_global CPyStatic_unicode_4 :: static  ('bar')
+    r2 = load_global CPyStatic_unicode_3 :: static  ('foo')
     r3 = CPyObject_GetAttr(x, r2)
-    if is_error(r3) goto L4 (error at lol:5) else goto L16
+    if is_error(r3) goto L4 (error at lol:4) else goto L15
+L2:
+    a = r3
+    r4 = load_global CPyStatic_unicode_4 :: static  ('bar')
+    r5 = CPyObject_GetAttr(x, r4)
+    if is_error(r5) goto L4 (error at lol:5) else goto L16
 L3:
-    b = r3
+    b = r5
     goto L6
 L4:
-    r4 = CPy_CatchError()
+    r6 = CPy_CatchError()
 L5:
-    CPy_RestoreExcInfo(r4)
-    dec_ref r4
+    CPy_RestoreExcInfo(r6)
+    dec_ref r6
 L6:
     if is_error(a) goto L17 else goto L9
 L7:
-    r5 = raise UnboundLocalError("local variable 'a' referenced before assignment")
-    if not r5 goto L14 (error at lol:9) else goto L8 :: bool
+    r7 = raise UnboundLocalError("local variable 'a' referenced before assignment")
+    if not r7 goto L14 (error at lol:9) else goto L8 :: bool
 L8:
     unreachable
 L9:
     if is_error(b) goto L18 else goto L12
 L10:
-    r6 = raise UnboundLocalError("local variable 'b' referenced before assignment")
-    if not r6 goto L14 (error at lol:9) else goto L11 :: bool
+    r8 = raise UnboundLocalError("local variable 'b' referenced before assignment")
+    if not r8 goto L14 (error at lol:9) else goto L11 :: bool
 L11:
     unreachable
 L12:
-    r7 = PyNumber_Add(a, b)
+    r9 = PyNumber_Add(a, b)
     xdec_ref a
     xdec_ref b
-    if is_error(r7) goto L14 (error at lol:9) else goto L13
+    if is_error(r9) goto L14 (error at lol:9) else goto L13
 L13:
-    return r7
+    return r9
 L14:
-    r8 = <error> :: object
-    return r8
+    r10 = <error> :: object
+    return r10
 L15:
     xdec_ref a
     goto L2
@@ -454,49 +458,51 @@ def f(b: bool) -> None:
 [out]
 def f(b):
     b :: bool
-    r0, u, r1, v :: str
-    r2, r3 :: bit
-    r4 :: object
-    r5 :: str
-    r6 :: object
-    r7 :: bool
-    r8 :: object
-    r9 :: None
+    r0, v, r1, u, r2 :: str
+    r3, r4 :: bit
+    r5 :: object
+    r6 :: str
+    r7 :: object
+    r8 :: bool
+    r9 :: object
+    r10 :: None
 L0:
-    r0 = load_global CPyStatic_unicode_1 :: static  ('a')
-    inc_ref r0
-    u = r0
+    r0 = <error> :: str
+    v = r0
+    r1 = load_global CPyStatic_unicode_1 :: static  ('a')
+    inc_ref r1
+    u = r1
 L1:
     if b goto L10 else goto L11 :: bool
 L2:
-    r1 = load_global CPyStatic_unicode_2 :: static  ('b')
-    inc_ref r1
-    v = r1
-    r2 = v == u
-    r3 = r2 ^ 1
-    if r3 goto L11 else goto L1 :: bool
+    r2 = load_global CPyStatic_unicode_2 :: static  ('b')
+    inc_ref r2
+    v = r2
+    r3 = v == u
+    r4 = r3 ^ 1
+    if r4 goto L11 else goto L1 :: bool
 L3:
-    r4 = builtins :: module
-    r5 = load_global CPyStatic_unicode_3 :: static  ('print')
-    r6 = CPyObject_GetAttr(r4, r5)
-    if is_error(r6) goto L12 (error at f:7) else goto L4
+    r5 = builtins :: module
+    r6 = load_global CPyStatic_unicode_3 :: static  ('print')
+    r7 = CPyObject_GetAttr(r5, r6)
+    if is_error(r7) goto L12 (error at f:7) else goto L4
 L4:
     if is_error(v) goto L13 else goto L7
 L5:
-    r7 = raise UnboundLocalError("local variable 'v' referenced before assignment")
-    if not r7 goto L9 (error at f:7) else goto L6 :: bool
+    r8 = raise UnboundLocalError("local variable 'v' referenced before assignment")
+    if not r8 goto L9 (error at f:7) else goto L6 :: bool
 L6:
     unreachable
 L7:
-    r8 = PyObject_CallFunctionObjArgs(r6, v, 0)
-    dec_ref r6
+    r9 = PyObject_CallFunctionObjArgs(r7, v, 0)
+    dec_ref r7
     xdec_ref v
-    if is_error(r8) goto L9 (error at f:7) else goto L14
+    if is_error(r9) goto L9 (error at f:7) else goto L14
 L8:
     return 1
 L9:
-    r9 = <error> :: None
-    return r9
+    r10 = <error> :: None
+    return r10
 L10:
     xdec_ref v
     goto L2
@@ -507,9 +513,9 @@ L12:
     xdec_ref v
     goto L9
 L13:
-    dec_ref r6
+    dec_ref r7
     goto L5
 L14:
-    dec_ref r8
+    dec_ref r9
     goto L8
 

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -812,3 +812,55 @@ L0:
     dec_ref x
     r3 = r2 << 1
     return r3
+
+[case testSometimesUninitializedVariable]
+def f(x: bool) -> int:
+    if x:
+        y = 1
+    else:
+        z = 2
+    return y + z
+[out]
+def f(x):
+    x :: bool
+    r0, y, r1, z :: int
+    r2, r3 :: bool
+    r4 :: int
+L0:
+    r0 = <error> :: int
+    y = r0
+    r1 = <error> :: int
+    z = r1
+    if x goto L8 else goto L9 :: bool
+L1:
+    y = 2
+    goto L3
+L2:
+    z = 4
+L3:
+    if is_error(y) goto L10 else goto L5
+L4:
+    r2 = raise UnboundLocalError("local variable 'y' referenced before assignment")
+    unreachable
+L5:
+    if is_error(z) goto L11 else goto L7
+L6:
+    r3 = raise UnboundLocalError("local variable 'z' referenced before assignment")
+    unreachable
+L7:
+    r4 = CPyTagged_Add(y, z)
+    xdec_ref y :: int
+    xdec_ref z :: int
+    return r4
+L8:
+    xdec_ref y :: int
+    goto L1
+L9:
+    xdec_ref z :: int
+    goto L2
+L10:
+    xdec_ref z :: int
+    goto L4
+L11:
+    xdec_ref y :: int
+    goto L6

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -10,7 +10,7 @@ from mypy.errors import CompileError
 from mypyc.common import TOP_LEVEL_NAME
 from mypyc.analysis import dataflow
 from mypyc.transform import exceptions
-from mypyc.ir.pprint import format_func, generate_names_for_env
+from mypyc.ir.pprint import format_func, generate_names_for_ir
 from mypyc.ir.ops import Value
 from mypyc.ir.func_ir import all_values
 from mypyc.test.testutil import (
@@ -65,7 +65,7 @@ class TestAnalysis(MypycDataSuite):
                     else:
                         assert False, 'No recognized _AnalysisName suffix in test case'
 
-                    names = generate_names_for_env(fn.arg_regs, fn.blocks)
+                    names = generate_names_for_ir(fn.arg_regs, fn.blocks)
 
                     for key in sorted(analysis_result.before.keys(),
                                       key=lambda x: (x[0].label, x[1])):

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -2,28 +2,27 @@ import unittest
 from typing import Dict
 
 from mypyc.codegen.emit import Emitter, EmitterContext
-from mypyc.ir.ops import BasicBlock, Environment, Value, Register
+from mypyc.ir.ops import BasicBlock, Value, Register
 from mypyc.ir.rtypes import int_rprimitive
 from mypyc.namegen import NameGenerator
 
 
 class TestEmitter(unittest.TestCase):
     def setUp(self) -> None:
-        self.env = Environment()
         self.n = Register(int_rprimitive, 'n')
         self.context = EmitterContext(NameGenerator([['mod']]))
 
     def test_label(self) -> None:
-        emitter = Emitter(self.context, self.env, {})
+        emitter = Emitter(self.context, {})
         assert emitter.label(BasicBlock(4)) == 'CPyL4'
 
     def test_reg(self) -> None:
         names = {self.n: 'n'}  # type: Dict[Value, str]
-        emitter = Emitter(self.context, self.env, names)
+        emitter = Emitter(self.context, names)
         assert emitter.reg(self.n) == 'cpy_r_n'
 
     def test_emit_line(self) -> None:
-        emitter = Emitter(self.context, self.env, {})
+        emitter = Emitter(self.context, {})
         emitter.emit_line('line;')
         emitter.emit_line('a {')
         emitter.emit_line('f();')

--- a/mypyc/test/test_pprint.py
+++ b/mypyc/test/test_pprint.py
@@ -3,7 +3,7 @@ from typing import List
 
 from mypyc.ir.ops import BasicBlock, Register, Op, LoadInt, BinaryIntOp, Unreachable, Assign
 from mypyc.ir.rtypes import int_rprimitive
-from mypyc.ir.pprint import generate_names_for_env
+from mypyc.ir.pprint import generate_names_for_ir
 
 
 def register(name: str) -> Register:
@@ -18,18 +18,18 @@ def make_block(ops: List[Op]) -> BasicBlock:
 
 class TestGenerateNames(unittest.TestCase):
     def test_empty(self) -> None:
-        assert generate_names_for_env([], []) == {}
+        assert generate_names_for_ir([], []) == {}
 
     def test_arg(self) -> None:
         reg = register('foo')
-        assert generate_names_for_env([reg], []) == {reg: 'foo'}
+        assert generate_names_for_ir([reg], []) == {reg: 'foo'}
 
     def test_int_op(self) -> None:
         op1 = LoadInt(2)
         op2 = LoadInt(4)
         op3 = BinaryIntOp(int_rprimitive, op1, op2, BinaryIntOp.ADD)
         block = make_block([op1, op2, op3, Unreachable()])
-        assert generate_names_for_env([], [block]) == {op1: 'i0', op2: 'i1', op3: 'r0'}
+        assert generate_names_for_ir([], [block]) == {op1: 'i0', op2: 'i1', op3: 'r0'}
 
     def test_assign(self) -> None:
         reg = register('foo')
@@ -37,4 +37,4 @@ class TestGenerateNames(unittest.TestCase):
         op2 = Assign(reg, op1)
         op3 = Assign(reg, op1)
         block = make_block([op1, op2, op3])
-        assert generate_names_for_env([reg], [block]) == {op1: 'i0', reg: 'foo'}
+        assert generate_names_for_ir([reg], [block]) == {op1: 'i0', reg: 'foo'}

--- a/mypyc/test/test_refcount.py
+++ b/mypyc/test/test_refcount.py
@@ -13,6 +13,7 @@ from mypy.errors import CompileError
 from mypyc.common import TOP_LEVEL_NAME
 from mypyc.ir.pprint import format_func
 from mypyc.transform.refcount import insert_ref_count_opcodes
+from mypyc.transform.uninit import insert_uninit_checks
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
     assert_test_output, remove_comment_lines, replace_native_int, replace_word_size
@@ -44,6 +45,7 @@ class TestRefCountTransform(MypycDataSuite):
                     if (fn.name == TOP_LEVEL_NAME
                             and not testcase.name.endswith('_toplevel')):
                         continue
+                    insert_uninit_checks(fn)
                     insert_ref_count_opcodes(fn)
                     actual.extend(format_func(fn))
 

--- a/mypyc/transform/exceptions.py
+++ b/mypyc/transform/exceptions.py
@@ -13,7 +13,7 @@ from typing import List, Optional
 
 from mypyc.ir.ops import (
     BasicBlock, LoadErrorValue, Return, Branch, RegisterOp, LoadInt, ERR_NEVER, ERR_MAGIC,
-    ERR_FALSE, ERR_ALWAYS, NO_TRACEBACK_LINE_NO, Environment
+    ERR_FALSE, ERR_ALWAYS, NO_TRACEBACK_LINE_NO
 )
 from mypyc.ir.func_ir import FuncIR
 from mypyc.ir.rtypes import bool_rprimitive
@@ -30,7 +30,7 @@ def insert_exception_handling(ir: FuncIR) -> None:
             error_label = add_handler_block(ir)
             break
     if error_label:
-        ir.blocks = split_blocks_at_errors(ir.blocks, error_label, ir.traceback_name, ir.env)
+        ir.blocks = split_blocks_at_errors(ir.blocks, error_label, ir.traceback_name)
 
 
 def add_handler_block(ir: FuncIR) -> BasicBlock:
@@ -44,8 +44,7 @@ def add_handler_block(ir: FuncIR) -> BasicBlock:
 
 def split_blocks_at_errors(blocks: List[BasicBlock],
                            default_error_handler: BasicBlock,
-                           func_name: Optional[str],
-                           env: Environment) -> List[BasicBlock]:
+                           func_name: Optional[str]) -> List[BasicBlock]:
     new_blocks = []  # type: List[BasicBlock]
 
     # First split blocks on ops that may raise.

--- a/mypyc/transform/refcount.py
+++ b/mypyc/transform/refcount.py
@@ -68,13 +68,6 @@ def insert_ref_count_opcodes(ir: FuncIR) -> None:
                                           ordering)
         transform_block(block, live.before, live.after, borrow.before, defined.after)
 
-    # Find all the xdecs we inserted and note the registers down as
-    # needing to be initialized.
-    for block in ir.blocks:
-        for op in block.ops:
-            if isinstance(op, DecRef) and op.is_xdec:
-                ir.env.vars_needing_init.add(op.src)
-
     cleanup_cfg(ir.blocks)
 
 

--- a/mypyc/transform/uninit.py
+++ b/mypyc/transform/uninit.py
@@ -9,7 +9,7 @@ from mypyc.analysis.dataflow import (
     AnalysisDict
 )
 from mypyc.ir.ops import (
-    BasicBlock, Branch, Value, RaiseStandardError, Unreachable, Environment, Register,
+    BasicBlock, Op, Branch, Value, RaiseStandardError, Unreachable, Register,
     LoadAddress, Assign, LoadErrorValue
 )
 from mypyc.ir.func_ir import FuncIR, all_values
@@ -27,11 +27,10 @@ def insert_uninit_checks(ir: FuncIR) -> None:
         set(ir.arg_regs),
         all_values(ir.arg_regs, ir.blocks))
 
-    ir.blocks = split_blocks_at_uninits(ir.env, ir.blocks, must_defined.before)
+    ir.blocks = split_blocks_at_uninits(ir.blocks, must_defined.before)
 
 
-def split_blocks_at_uninits(env: Environment,
-                            blocks: List[BasicBlock],
+def split_blocks_at_uninits(blocks: List[BasicBlock],
                             pre_must_defined: 'AnalysisDict[Value]') -> List[BasicBlock]:
     new_blocks = []  # type: List[BasicBlock]
 
@@ -81,7 +80,7 @@ def split_blocks_at_uninits(env: Environment,
             cur_block.ops.append(op)
 
     if init_registers:
-        new_ops = []
+        new_ops = []  # type: List[Op]
         for reg in init_registers:
             err = LoadErrorValue(reg.type)
             new_ops.append(err)

--- a/mypyc/transform/uninit.py
+++ b/mypyc/transform/uninit.py
@@ -82,7 +82,7 @@ def split_blocks_at_uninits(blocks: List[BasicBlock],
     if init_registers:
         new_ops = []  # type: List[Op]
         for reg in init_registers:
-            err = LoadErrorValue(reg.type)
+            err = LoadErrorValue(reg.type, undefines=True)
             new_ops.append(err)
             new_ops.append(Assign(reg, err))
         new_blocks[0].ops[0:0] = new_ops


### PR DESCRIPTION
Remove `mypyc.ir.ops.Environment`. Represent potentially uninitialized variables 
explicitly in the IR by generating an assignment of an error value, instead of relying 
on the environment to keep track of uninitialized variables.

This simplifies the IR and makes it more consistent, and it will also make it a little 
easier to create new backends. More importantly, this removes one variant of
the "environment" concept. The term is less overloaded now.

Work on mypyc/mypyc#781.