### PR TITLE
[mypyc] Refactor method IR generation

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -180,6 +180,9 @@ class IRBuilder:
     def goto_and_activate(self, block: BasicBlock) -> None:
         self.builder.goto_and_activate(block)
 
+    def self(self) -> Register:
+        return self.builder.self()
+
     def py_get_attr(self, obj: Value, attr: str, line: int) -> Value:
         return self.builder.py_get_attr(obj, attr, line)
 
@@ -442,13 +445,6 @@ class IRBuilder:
             return self.get_assignment_target(lvalue.expr)
 
         assert False, 'Unsupported lvalue: %r' % lvalue
-
-    def self(self) -> Register:
-        """Return reference to the 'self' argument.
-
-        This only works in a method.
-        """
-        return self.builder.args[0]
 
     def read(self, target: Union[Value, AssignmentTarget], line: int = -1) -> Value:
         if isinstance(target, Value):

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -925,6 +925,7 @@ class IRBuilder:
         decl = FuncDecl(name, class_ir.name, self.module_name, sig)
         ir = FuncIR(decl, arg_regs, blocks)
         class_ir.methods[name] = ir
+        class_ir.method_decls[name] = ir.decl
         self.functions.append(ir)
 
     def lookup(self, symbol: SymbolNode) -> AssignmentTarget:

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -900,18 +900,20 @@ class IRBuilder:
                      class_ir: ClassIR,
                      name: str,
                      ret_type: RType,
-                     fn_info: Union[FuncInfo, str] = '') -> None:
+                     fn_info: Union[FuncInfo, str] = '',
+                     self_type: Optional[RType] = None) -> None:
         self.enter(fn_info)
         self.function_name_stack.append(name)
         self.class_ir_stack.append(class_ir)
         self.ret_types[-1] = ret_type
-        self.add_argument(SELF_NAME, RInstance(class_ir))
+        if self_type is None:
+            self_type = RInstance(class_ir)
+        self.add_argument(SELF_NAME, self_type)
 
     def add_argument(self, var: Union[str, Var], typ: RType, kind: int = ARG_POS) -> Register:
         if isinstance(var, str):
             var = Var(var)
         reg = self.add_local(var, typ, is_arg=True)
-        self.args[-1].append(reg)
         self.args2[-1].append(RuntimeArg(var.name, typ, kind))
         return reg
 

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -292,13 +292,13 @@ class IRBuilder:
         self.add(InitStatic(value, id, namespace=NAMESPACE_MODULE))
         self.goto_and_activate(out)
 
-    def assign_if_null(self, target: AssignmentTargetRegister,
+    def assign_if_null(self, target: Register,
                        get_val: Callable[[], Value], line: int) -> None:
-        """Generate blocks for registers that NULL values."""
+        """If target is NULL, assign value produced by get_val to it."""
         error_block, body_block = BasicBlock(), BasicBlock()
-        self.add(Branch(target.register, error_block, body_block, Branch.IS_ERROR))
+        self.add(Branch(target, error_block, body_block, Branch.IS_ERROR))
         self.activate_block(error_block)
-        self.add(Assign(target.register, self.coerce(get_val(), target.register.type, line)))
+        self.add(Assign(target, self.coerce(get_val(), target.type, line)))
         self.goto(body_block)
         self.activate_block(body_block)
 
@@ -1064,4 +1064,4 @@ def gen_arg_defaults(builder: IRBuilder) -> None:
                     return builder.add(
                         GetAttr(builder.fn_info.callable_class.self_reg, name, arg.line))
             assert isinstance(target, AssignmentTargetRegister)
-            builder.assign_if_null(target, get_default, arg.initializer.line)
+            builder.assign_if_null(target.register, get_default, arg.initializer.line)

--- a/mypyc/irbuild/callable_class.py
+++ b/mypyc/irbuild/callable_class.py
@@ -105,13 +105,13 @@ def add_call_to_callable_class(builder: IRBuilder,
 def add_get_to_callable_class(builder: IRBuilder, fn_info: FuncInfo) -> None:
     """Generate the '__get__' method for a callable class."""
     line = fn_info.fitem.line
-    builder.enter(fn_info)
 
-    vself = builder.read(
-        builder.add_local_reg(Var(SELF_NAME), object_rprimitive, True)
+    builder.enter_method(
+        fn_info.callable_class.ir, '__get__', object_rprimitive, fn_info,
+        self_type=object_rprimitive
     )
-    instance = builder.add_local_reg(Var('instance'), object_rprimitive, True)
-    builder.add_local_reg(Var('owner'), object_rprimitive, True)
+    instance = builder.add_argument('instance', object_rprimitive)
+    builder.add_argument('owner', object_rprimitive)
 
     # If accessed through the class, just return the callable
     # object. If accessed through an object, create a new bound
@@ -123,21 +123,13 @@ def add_get_to_callable_class(builder: IRBuilder, fn_info: FuncInfo) -> None:
     builder.add_bool_branch(comparison, class_block, instance_block)
 
     builder.activate_block(class_block)
-    builder.add(Return(vself))
+    builder.add(Return(builder.self()))
 
     builder.activate_block(instance_block)
-    builder.add(Return(builder.call_c(method_new_op, [vself, builder.read(instance)], line)))
+    builder.add(Return(builder.call_c(method_new_op,
+                                      [builder.self(), builder.read(instance)], line)))
 
-    args, _, blocks, _, fn_info = builder.leave()
-
-    sig = FuncSignature((RuntimeArg(SELF_NAME, object_rprimitive),
-                         RuntimeArg('instance', object_rprimitive),
-                         RuntimeArg('owner', object_rprimitive)),
-                        object_rprimitive)
-    get_fn_decl = FuncDecl('__get__', fn_info.callable_class.ir.name, builder.module_name, sig)
-    get_fn_ir = FuncIR(get_fn_decl, args, blocks)
-    fn_info.callable_class.ir.methods['__get__'] = get_fn_ir
-    builder.functions.append(get_fn_ir)
+    builder.leave_method()
 
 
 def instantiate_callable_class(builder: IRBuilder, fn_info: FuncInfo) -> Value:

--- a/mypyc/irbuild/callable_class.py
+++ b/mypyc/irbuild/callable_class.py
@@ -128,7 +128,7 @@ def add_get_to_callable_class(builder: IRBuilder, fn_info: FuncInfo) -> None:
     builder.activate_block(instance_block)
     builder.add(Return(builder.call_c(method_new_op, [vself, builder.read(instance)], line)))
 
-    args, blocks, _, fn_info = builder.leave()
+    args, _, blocks, _, fn_info = builder.leave()
 
     sig = FuncSignature((RuntimeArg(SELF_NAME, object_rprimitive),
                          RuntimeArg('instance', object_rprimitive),

--- a/mypyc/irbuild/callable_class.py
+++ b/mypyc/irbuild/callable_class.py
@@ -6,8 +6,6 @@ non-local variables defined in outer scopes.
 
 from typing import List
 
-from mypy.nodes import Var
-
 from mypyc.common import SELF_NAME, ENV_ATTR_NAME
 from mypyc.ir.ops import BasicBlock, Return, Call, SetAttr, Value, Register
 from mypyc.ir.rtypes import RInstance, object_rprimitive

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -351,7 +351,7 @@ def generate_attr_defaults(builder: IRBuilder, cdef: ClassDef) -> None:
 
     builder.add(Return(builder.true()))
 
-    args, blocks, ret_type, _ = builder.leave()
+    args, _, blocks, ret_type, _ = builder.leave()
     ir = FuncIR(
         FuncDecl('__mypyc_defaults_setup',
                  cls.name, builder.module_name,
@@ -405,7 +405,7 @@ def gen_glue_ne_method(builder: IRBuilder, cls: ClassIR, line: int) -> FuncIR:
     builder.activate_block(not_implemented_block)
     builder.add(Return(not_implemented))
 
-    arg_regs, blocks, ret_type, _ = builder.leave()
+    arg_regs, _, blocks, ret_type, _ = builder.leave()
     return FuncIR(
         FuncDecl('__ne__', cls.name, builder.module_name,
                  FuncSignature(rt_args, ret_type)),

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -327,12 +327,9 @@ def generate_attr_defaults(builder: IRBuilder, cdef: ClassDef) -> None:
     if not default_assignments:
         return
 
-    builder.enter()
-    builder.ret_types[-1] = bool_rprimitive
+    builder.enter_method(cls, '__mypyc_defaults_setup', bool_rprimitive)
 
-    rt_args = (RuntimeArg(SELF_NAME, RInstance(cls)),)
-    self_var = builder.read(builder.add_self_to_env(cls), -1)
-
+    self_var = builder.self()
     for stmt in default_assignments:
         lvalue = stmt.lvalues[0]
         assert isinstance(lvalue, NameExpr)
@@ -351,14 +348,7 @@ def generate_attr_defaults(builder: IRBuilder, cdef: ClassDef) -> None:
 
     builder.add(Return(builder.true()))
 
-    args, _, blocks, ret_type, _ = builder.leave()
-    ir = FuncIR(
-        FuncDecl('__mypyc_defaults_setup',
-                 cls.name, builder.module_name,
-                 FuncSignature(rt_args, ret_type)),
-        args, blocks)
-    builder.functions.append(ir)
-    cls.methods[ir.name] = ir
+    builder.leave_method()
 
 
 def create_ne_from_eq(builder: IRBuilder, cdef: ClassDef) -> None:

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -4,17 +4,17 @@ from typing import List, Optional
 
 from mypy.nodes import (
     ClassDef, FuncDef, OverloadedFuncDef, PassStmt, AssignmentStmt, NameExpr, StrExpr,
-    ExpressionStmt, TempNode, Decorator, Lvalue, RefExpr, Var, is_class_var
+    ExpressionStmt, TempNode, Decorator, Lvalue, RefExpr, is_class_var
 )
 from mypyc.ir.ops import (
     Value, Register, Call, LoadErrorValue, LoadStatic, InitStatic, TupleSet, SetAttr, Return,
     BasicBlock, Branch, MethodCall, NAMESPACE_TYPE, LoadAddress
 )
 from mypyc.ir.rtypes import (
-    RInstance, object_rprimitive, bool_rprimitive, dict_rprimitive, is_optional_type,
+    object_rprimitive, bool_rprimitive, dict_rprimitive, is_optional_type,
     is_object_rprimitive, is_none_rprimitive
 )
-from mypyc.ir.func_ir import FuncIR, FuncDecl, FuncSignature, RuntimeArg
+from mypyc.ir.func_ir import FuncDecl, FuncSignature
 from mypyc.ir.class_ir import ClassIR, NonExtClassInfo
 from mypyc.primitives.generic_ops import py_setattr_op, py_hasattr_op
 from mypyc.primitives.misc_ops import (
@@ -22,7 +22,6 @@ from mypyc.primitives.misc_ops import (
     not_implemented_op
 )
 from mypyc.primitives.dict_ops import dict_set_item_op, dict_new_op
-from mypyc.common import SELF_NAME
 from mypyc.irbuild.util import (
     is_dataclass_decorator, get_func_def, is_dataclass, is_constant
 )

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -138,7 +138,7 @@ def transform_super_expr(builder: IRBuilder, o: SuperExpr) -> Value:
         assert o.info is not None
         typ = builder.load_native_type_object(o.info.fullname)
         ir = builder.mapper.type_to_ir[o.info]
-        iter_env = iter(builder.args[-1])
+        iter_env = iter(builder.builder.args)
         # Grab first argument
         vself = next(iter_env)  # type: Value
         if builder.fn_info.is_generator:
@@ -302,7 +302,7 @@ def translate_super_method_call(builder: IRBuilder, expr: CallExpr, callee: Supe
 
     if decl.kind != FUNC_STATICMETHOD:
         # Grab first argument
-        vself = builder.args[-1][0]  # type: Value
+        vself = builder.self()  # type: Value
         if decl.kind == FUNC_CLASSMETHOD:
             vself = builder.call_c(type_op, [vself], expr.line)
         elif builder.fn_info.is_generator:

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -225,7 +225,7 @@ def gen_func_item(builder: IRBuilder,
     if builder.fn_info.is_generator:
         # Do a first-pass and generate a function that just returns a generator object.
         gen_generator_func(builder)
-        args, blocks, ret_type, fn_info = builder.leave()
+        args, _, blocks, ret_type, fn_info = builder.leave()
         func_ir, func_reg = gen_func_ir(builder, args, blocks, sig, fn_info, cdef)
 
         # Re-enter the FuncItem and visit the body of the function this time.
@@ -287,7 +287,7 @@ def gen_func_item(builder: IRBuilder,
     # to calculate argument defaults below.
     symtable = builder.symtables[-1]
 
-    args, blocks, ret_type, fn_info = builder.leave()
+    args, _, blocks, ret_type, fn_info = builder.leave()
 
     if fn_info.is_generator:
         add_methods_to_generator_class(
@@ -675,7 +675,7 @@ def gen_glue_method(builder: IRBuilder, sig: FuncSignature, target: FuncIR,
     retval = builder.coerce(retval, sig.ret_type, line)
     builder.add(Return(retval))
 
-    arg_regs, blocks, ret_type, _ = builder.leave()
+    arg_regs, _, blocks, ret_type, _ = builder.leave()
     return FuncIR(
         FuncDecl(target.name + '__' + base.name + '_glue',
                  cls.name, builder.module_name,
@@ -713,7 +713,7 @@ def gen_glue_property(builder: IRBuilder,
     retbox = builder.coerce(retval, sig.ret_type, line)
     builder.add(Return(retbox))
 
-    args, blocks, return_type, _ = builder.leave()
+    args, _, blocks, return_type, _ = builder.leave()
     return FuncIR(
         FuncDecl(target.name + '__' + base.name + '_glue',
                  cls.name, builder.module_name, FuncSignature([rt_arg], return_type)),

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -244,18 +244,9 @@ def add_close_to_generator_class(builder: IRBuilder, fn_info: FuncInfo) -> None:
 
 def add_await_to_generator_class(builder: IRBuilder, fn_info: FuncInfo) -> None:
     """Generates the '__await__' method for a generator class."""
-    builder.enter(fn_info)
-    self_target = builder.add_self_to_env(fn_info.generator_class.ir)
-    builder.add(Return(builder.read(self_target, fn_info.fitem.line)))
-    args, _, blocks, _, fn_info = builder.leave()
-
-    # Next, add the actual function as a method of the generator class.
-    sig = FuncSignature((RuntimeArg(SELF_NAME, object_rprimitive),), object_rprimitive)
-    await_fn_decl = FuncDecl('__await__', fn_info.generator_class.ir.name,
-                             builder.module_name, sig)
-    await_fn_ir = FuncIR(await_fn_decl, args, blocks)
-    fn_info.generator_class.ir.methods['__await__'] = await_fn_ir
-    builder.functions.append(await_fn_ir)
+    builder.enter_method(fn_info.generator_class.ir, '__await__', object_rprimitive, fn_info)
+    builder.add(Return(builder.self()))
+    builder.leave_method()
 
 
 def setup_env_for_generator_class(builder: IRBuilder) -> None:

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -232,22 +232,14 @@ def add_throw_to_generator_class(builder: IRBuilder,
 
 def add_close_to_generator_class(builder: IRBuilder, fn_info: FuncInfo) -> None:
     """Generates the '__close__' method for a generator class."""
-    # TODO: Currently this method just triggers a runtime error,
-    # we should fill this out eventually.
-    builder.enter(fn_info)
-    builder.add_self_to_env(fn_info.generator_class.ir)
+    # TODO: Currently this method just triggers a runtime error.
+    #       We should fill this out (https://github.com/mypyc/mypyc/issues/790).
+    builder.enter_method(fn_info.generator_class.ir, 'close', object_rprimitive, fn_info)
     builder.add(RaiseStandardError(RaiseStandardError.RUNTIME_ERROR,
-                                'close method on generator classes uimplemented',
-                                fn_info.fitem.line))
+                                   'close method on generator classes unimplemented',
+                                   fn_info.fitem.line))
     builder.add(Unreachable())
-    args, _, blocks, _, fn_info = builder.leave()
-
-    # Next, add the actual function as a method of the generator class.
-    sig = FuncSignature((RuntimeArg(SELF_NAME, object_rprimitive),), object_rprimitive)
-    close_fn_decl = FuncDecl('close', fn_info.generator_class.ir.name, builder.module_name, sig)
-    close_fn_ir = FuncIR(close_fn_decl, args, blocks)
-    fn_info.generator_class.ir.methods['close'] = close_fn_ir
-    builder.functions.append(close_fn_ir)
+    builder.leave_method()
 
 
 def add_await_to_generator_class(builder: IRBuilder, fn_info: FuncInfo) -> None:

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -175,29 +175,7 @@ def add_next_to_generator_class(builder: IRBuilder,
                                 fn_decl: FuncDecl,
                                 sig: FuncSignature) -> None:
     """Generates the '__next__' method for a generator class."""
-    builder.enter(fn_info)
-    self_reg = builder.read(builder.add_self_to_env(fn_info.generator_class.ir))
-    none_reg = builder.none_object()
-
-    # Call the helper function with error flags set to Py_None, and return that result.
-    result = builder.add(Call(fn_decl, [self_reg, none_reg, none_reg, none_reg, none_reg],
-                           fn_info.fitem.line))
-    builder.add(Return(result))
-    args, _, blocks, _, fn_info = builder.leave()
-
-    sig = FuncSignature((RuntimeArg(SELF_NAME, object_rprimitive),), sig.ret_type)
-    next_fn_decl = FuncDecl('__next__', fn_info.generator_class.ir.name, builder.module_name, sig)
-    next_fn_ir = FuncIR(next_fn_decl, args, blocks)
-    fn_info.generator_class.ir.methods['__next__'] = next_fn_ir
-    builder.functions.append(next_fn_ir)
-
-
-def add_next_to_generator_class_xxx(builder: IRBuilder,
-                                    fn_info: FuncInfo,
-                                    fn_decl: FuncDecl,
-                                    sig: FuncSignature) -> None:
-    """Generates the '__next__' method for a generator class."""
-    builder.enter_method(fn_info.generator_class.ir, '__next__', none_rprimitive, fn_info)
+    builder.enter_method(fn_info.generator_class.ir, '__next__', object_rprimitive, fn_info)
     none_reg = builder.none_object()
     # Call the helper function with error flags set to Py_None, and return that result.
     result = builder.add(Call(fn_decl,

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -157,17 +157,9 @@ def add_helper_to_generator_class(builder: IRBuilder,
 
 def add_iter_to_generator_class(builder: IRBuilder, fn_info: FuncInfo) -> None:
     """Generates the '__iter__' method for a generator class."""
-    builder.enter(fn_info)
-    self_target = builder.add_self_to_env(fn_info.generator_class.ir)
-    builder.add(Return(builder.read(self_target, fn_info.fitem.line)))
-    args, _, blocks, _, fn_info = builder.leave()
-
-    # Next, add the actual function as a method of the generator class.
-    sig = FuncSignature((RuntimeArg(SELF_NAME, object_rprimitive),), object_rprimitive)
-    iter_fn_decl = FuncDecl('__iter__', fn_info.generator_class.ir.name, builder.module_name, sig)
-    iter_fn_ir = FuncIR(iter_fn_decl, args, blocks)
-    fn_info.generator_class.ir.methods['__iter__'] = iter_fn_ir
-    builder.functions.append(iter_fn_ir)
+    builder.enter_method(fn_info.generator_class.ir, '__iter__', object_rprimitive, fn_info)
+    builder.add(Return(builder.self()))
+    builder.leave_method()
 
 
 def add_next_to_generator_class(builder: IRBuilder,

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -17,7 +17,7 @@ from mypyc.ir.ops import (
     BasicBlock, Call, Return, Goto, LoadInt, SetAttr, Unreachable, RaiseStandardError,
     Value, Register
 )
-from mypyc.ir.rtypes import RInstance, int_rprimitive, object_rprimitive, none_rprimitive
+from mypyc.ir.rtypes import RInstance, int_rprimitive, object_rprimitive
 from mypyc.ir.func_ir import FuncIR, FuncDecl, FuncSignature, RuntimeArg
 from mypyc.ir.class_ir import ClassIR
 from mypyc.primitives.exc_ops import raise_exception_with_tb_op

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -112,6 +112,13 @@ class LowLevelIRBuilder:
     def pop_error_handler(self) -> Optional[BasicBlock]:
         return self.error_handlers.pop()
 
+    def self(self) -> Register:
+        """Return reference to the 'self' argument.
+
+        This only works in a method.
+        """
+        return self.args[0]
+
     # Type conversions
 
     def box(self, src: Value) -> Value:

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -75,6 +75,7 @@ class LowLevelIRBuilder:
     ) -> None:
         self.current_module = current_module
         self.mapper = mapper
+        self.args = []  # type: List[Register]
         self.blocks = []  # type: List[BasicBlock]
         # Stack of except handler entry blocks
         self.error_handlers = [None]  # type: List[Optional[BasicBlock]]

--- a/mypyc/irbuild/main.py
+++ b/mypyc/irbuild/main.py
@@ -124,7 +124,7 @@ def transform_mypy_file(builder: IRBuilder, mypyfile: MypyFile) -> None:
     builder.maybe_add_implicit_return()
 
     # Generate special function representing module top level.
-    args, blocks, ret_type, _ = builder.leave()
+    args, _, blocks, ret_type, _ = builder.leave()
     sig = FuncSignature([], none_rprimitive)
     func_ir = FuncIR(FuncDecl(TOP_LEVEL_NAME, None, builder.module_name, sig), args, blocks,
                      traceback_name="<module>")

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2774,8 +2774,8 @@ def A.__eq__(self, x):
 L0:
     r0 = load_address _Py_NotImplementedStruct
     return r0
-def A.__ne__(self, rhs):
-    self :: __main__.A
+def A.__ne__(__mypyc_self__, rhs):
+    __mypyc_self__ :: __main__.A
     rhs, r0, r1 :: object
     r2 :: bit
     r3 :: int32
@@ -2783,7 +2783,7 @@ def A.__ne__(self, rhs):
     r5 :: bool
     r6 :: object
 L0:
-    r0 = self.__eq__(rhs)
+    r0 = __mypyc_self__.__eq__(rhs)
     r1 = load_address _Py_NotImplementedStruct
     r2 = r0 == r1
     if r2 goto L2 else goto L1 :: bool

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -848,8 +848,8 @@ def Base.__eq__(self, other):
 L0:
     r0 = box(bool, 0)
     return r0
-def Base.__ne__(self, rhs):
-    self :: __main__.Base
+def Base.__ne__(__mypyc_self__, rhs):
+    __mypyc_self__ :: __main__.Base
     rhs, r0, r1 :: object
     r2 :: bit
     r3 :: int32
@@ -857,7 +857,7 @@ def Base.__ne__(self, rhs):
     r5 :: bool
     r6 :: object
 L0:
-    r0 = self.__eq__(rhs)
+    r0 = __mypyc_self__.__eq__(rhs)
     r1 = load_address _Py_NotImplementedStruct
     r2 = r0 == r1
     if r2 goto L2 else goto L1 :: bool
@@ -968,8 +968,8 @@ def Derived.__eq__(self, other):
 L0:
     r0 = box(bool, 1)
     return r0
-def Derived.__ne__(self, rhs):
-    self :: __main__.Derived
+def Derived.__ne__(__mypyc_self__, rhs):
+    __mypyc_self__ :: __main__.Derived
     rhs, r0, r1 :: object
     r2 :: bit
     r3 :: int32
@@ -977,7 +977,7 @@ def Derived.__ne__(self, rhs):
     r5 :: bool
     r6 :: object
 L0:
-    r0 = self.__eq__(rhs)
+    r0 = __mypyc_self__.__eq__(rhs)
     r1 = load_address _Py_NotImplementedStruct
     r2 = r0 == r1
     if r2 goto L2 else goto L1 :: bool


### PR DESCRIPTION
Add new helpers for generating methods that reduces the required
boilerplate. Switch several existing use cases to use the new helpers.

Summary of the new helpers:

1. Call `builder.enter_method(...)` to begin generating IR for a method.
2. Call `builder.add_argument(..)` for each non-self argument.
3. Generate method body normally.
4. Call `builder.leave_method()`.

Previously `enter()` and `leave()` had to be used, along with several
additional steps, such as defining `self` explicitly. The new approach 
is much easier to use and less error-prone. 

Since not all uses of the old interface have been removed, there is 
still some duplication. It would be great to eventually always use the 
higher-level interface to generate methods and functions.

Work on mypyc/mypyc#781.