### PR TITLE
[mypyc] Refactor assignment targets

### DIFF
--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -57,58 +57,6 @@ DeserMaps = NamedTuple('DeserMaps',
                        [('classes', Dict[str, 'ClassIR']), ('functions', Dict[str, 'FuncIR'])])
 
 
-class AssignmentTarget(object):
-    """Abstract base class for assignment targets in IR"""
-
-    type = None  # type: RType
-
-
-class AssignmentTargetRegister(AssignmentTarget):
-    """Register as assignment target"""
-
-    def __init__(self, register: 'Register') -> None:
-        self.register = register
-        self.type = register.type
-
-
-class AssignmentTargetIndex(AssignmentTarget):
-    """base[index] as assignment target"""
-
-    def __init__(self, base: 'Value', index: 'Value') -> None:
-        self.base = base
-        self.index = index
-        # TODO: This won't be right for user-defined classes. Store the
-        #       lvalue type in mypy and remove this special case.
-        self.type = object_rprimitive
-
-
-class AssignmentTargetAttr(AssignmentTarget):
-    """obj.attr as assignment target"""
-
-    def __init__(self, obj: 'Value', attr: str) -> None:
-        self.obj = obj
-        self.attr = attr
-        if isinstance(obj.type, RInstance) and obj.type.class_ir.has_attr(attr):
-            # Native attribute reference
-            self.obj_type = obj.type  # type: RType
-            self.type = obj.type.attr_type(attr)
-        else:
-            # Python attribute reference
-            self.obj_type = object_rprimitive
-            self.type = object_rprimitive
-
-
-class AssignmentTargetTuple(AssignmentTarget):
-    """x, ..., y as assignment target"""
-
-    def __init__(self, items: List[AssignmentTarget],
-                 star_idx: Optional[int] = None) -> None:
-        self.items = items
-        self.star_idx = star_idx
-        # The shouldn't be relevant, but provide it just in case.
-        self.type = object_rprimitive
-
-
 class BasicBlock:
     """Basic IR block.
 

--- a/mypyc/irbuild/context.py
+++ b/mypyc/irbuild/context.py
@@ -4,10 +4,11 @@ from typing import List, Optional, Tuple
 
 from mypy.nodes import FuncItem
 
-from mypyc.ir.ops import Value, BasicBlock, AssignmentTarget
+from mypyc.ir.ops import Value, BasicBlock
 from mypyc.ir.func_ir import INVALID_FUNC_DEF
 from mypyc.ir.class_ir import ClassIR
 from mypyc.common import decorator_helper_name
+from mypyc.irbuild.targets import AssignmentTarget
 
 
 class FuncInfo:

--- a/mypyc/irbuild/env_class.py
+++ b/mypyc/irbuild/env_class.py
@@ -20,10 +20,11 @@ from typing import Dict, Optional, Union
 from mypy.nodes import FuncDef, SymbolNode
 
 from mypyc.common import SELF_NAME, ENV_ATTR_NAME
-from mypyc.ir.ops import Call, GetAttr, SetAttr, Value, AssignmentTarget, AssignmentTargetAttr
+from mypyc.ir.ops import Call, GetAttr, SetAttr, Value
 from mypyc.ir.rtypes import RInstance, object_rprimitive
 from mypyc.ir.class_ir import ClassIR
-from mypyc.irbuild.builder import IRBuilder
+from mypyc.irbuild.builder import IRBuilder, SymbolTarget
+from mypyc.irbuild.targets import AssignmentTargetAttr
 from mypyc.irbuild.context import FuncInfo, ImplicitClass, GeneratorClass
 
 
@@ -108,7 +109,7 @@ def load_env_registers(builder: IRBuilder) -> None:
 
 def load_outer_env(builder: IRBuilder,
                    base: Value,
-                   outer_env: Dict[SymbolNode, AssignmentTarget]) -> Value:
+                   outer_env: Dict[SymbolNode, SymbolTarget]) -> Value:
     """Load the environment class for a given base into a register.
 
     Additionally, iterates through all of the SymbolNode and

--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -12,8 +12,7 @@ from mypy.nodes import (
     Lvalue, Expression, TupleExpr, CallExpr, RefExpr, GeneratorExpr, ARG_POS, MemberExpr
 )
 from mypyc.ir.ops import (
-    Value, BasicBlock, LoadInt, Branch, Register, AssignmentTarget, TupleGet,
-    AssignmentTargetTuple, TupleSet, BinaryIntOp
+    Value, BasicBlock, LoadInt, Branch, Register, TupleGet, TupleSet, BinaryIntOp
 )
 from mypyc.ir.rtypes import (
     RType, is_short_int_rprimitive, is_list_rprimitive, is_sequence_rprimitive,
@@ -28,6 +27,7 @@ from mypyc.primitives.list_ops import list_append_op, list_get_item_unsafe_op
 from mypyc.primitives.generic_ops import iter_op, next_op
 from mypyc.primitives.exc_ops import no_err_occurred_op
 from mypyc.irbuild.builder import IRBuilder
+from mypyc.irbuild.targets import AssignmentTarget, AssignmentTargetTuple
 
 GenFunc = Callable[[], None]
 

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -19,8 +19,8 @@ from mypy.nodes import (
 from mypy.types import CallableType, get_proper_type
 
 from mypyc.ir.ops import (
-    BasicBlock, Value,  Register, Return, SetAttr, LoadInt, GetAttr, Branch,
-    AssignmentTarget, InitStatic, LoadAddress
+    BasicBlock, Value,  Register, Return, SetAttr, LoadInt, GetAttr, Branch, InitStatic,
+    LoadAddress
 )
 from mypyc.ir.rtypes import object_rprimitive, RInstance, object_pointer_rprimitive
 from mypyc.ir.func_ir import (
@@ -34,8 +34,9 @@ from mypyc.common import SELF_NAME, LAMBDA_NAME, decorator_helper_name
 from mypyc.sametype import is_same_method_signature
 from mypyc.irbuild.util import concrete_arg_kind, is_constant
 from mypyc.irbuild.context import FuncInfo, ImplicitClass
+from mypyc.irbuild.targets import AssignmentTarget
 from mypyc.irbuild.statement import transform_try_except
-from mypyc.irbuild.builder import IRBuilder, gen_arg_defaults
+from mypyc.irbuild.builder import IRBuilder, SymbolTarget, gen_arg_defaults
 from mypyc.irbuild.callable_class import (
     setup_callable_class, add_call_to_callable_class, add_get_to_callable_class,
     instantiate_callable_class
@@ -438,7 +439,7 @@ def handle_non_ext_method(
 def calculate_arg_defaults(builder: IRBuilder,
                            fn_info: FuncInfo,
                            func_reg: Optional[Value],
-                           symtable: Dict[SymbolNode, AssignmentTarget]) -> None:
+                           symtable: Dict[SymbolNode, SymbolTarget]) -> None:
     """Calculate default argument values and store them.
 
     They are stored in statics for top level functions and in

--- a/mypyc/irbuild/nonlocalcontrol.py
+++ b/mypyc/irbuild/nonlocalcontrol.py
@@ -9,9 +9,10 @@ from typing_extensions import TYPE_CHECKING
 
 from mypyc.ir.ops import (
     Branch, BasicBlock, Unreachable, Value, Goto, LoadInt, Assign, Register, Return,
-    AssignmentTarget, NO_TRACEBACK_LINE_NO
+    NO_TRACEBACK_LINE_NO
 )
 from mypyc.primitives.exc_ops import set_stop_iteration_value, restore_exc_info_op
+from mypyc.irbuild.targets import AssignmentTarget
 
 if TYPE_CHECKING:
     from mypyc.irbuild.builder import IRBuilder

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -17,9 +17,8 @@ from mypy.nodes import (
 )
 
 from mypyc.ir.ops import (
-    Assign, Unreachable, AssignmentTarget, AssignmentTargetRegister, AssignmentTargetIndex,
-    AssignmentTargetAttr, AssignmentTargetTuple, RaiseStandardError, LoadErrorValue,
-    BasicBlock, TupleGet, Value, Register, Branch, NO_TRACEBACK_LINE_NO
+    Assign, Unreachable, RaiseStandardError, LoadErrorValue, BasicBlock, TupleGet, Value, Register,
+    Branch, NO_TRACEBACK_LINE_NO
 )
 from mypyc.ir.rtypes import exc_rtuple
 from mypyc.primitives.generic_ops import py_delattr_op
@@ -28,6 +27,10 @@ from mypyc.primitives.dict_ops import dict_get_item_op
 from mypyc.primitives.exc_ops import (
     raise_exception_op, reraise_exception_op, error_catch_op, exc_matches_op, restore_exc_info_op,
     get_exc_value_op, keep_propagating_op, get_exc_info_op
+)
+from mypyc.irbuild.targets import (
+    AssignmentTarget, AssignmentTargetRegister, AssignmentTargetIndex, AssignmentTargetAttr,
+    AssignmentTargetTuple
 )
 from mypyc.irbuild.nonlocalcontrol import (
     ExceptNonlocalControl, FinallyNonlocalControl, TryFinallyNonlocalControl

--- a/mypyc/irbuild/targets.py
+++ b/mypyc/irbuild/targets.py
@@ -1,0 +1,58 @@
+from typing import List, Optional
+
+from mypyc.ir.ops import Value, Register
+from mypyc.ir.rtypes import RType, RInstance, object_rprimitive
+
+
+class AssignmentTarget:
+    """Abstract base class for assignment targets during IR building."""
+
+    type = object_rprimitive  # type: RType
+
+
+class AssignmentTargetRegister(AssignmentTarget):
+    """Register as an assignment target.
+
+    This is used for local variables and some temporaries.
+    """
+
+    def __init__(self, register: Register) -> None:
+        self.register = register
+        self.type = register.type
+
+
+class AssignmentTargetIndex(AssignmentTarget):
+    """base[index] as assignment target"""
+
+    def __init__(self, base: Value, index: Value) -> None:
+        self.base = base
+        self.index = index
+        # TODO: object_rprimitive won't be right for user-defined classes. Store the
+        #       lvalue type in mypy and use a better type to avoid unneeded boxing.
+        self.type = object_rprimitive
+
+
+class AssignmentTargetAttr(AssignmentTarget):
+    """obj.attr as assignment target"""
+
+    def __init__(self, obj: Value, attr: str) -> None:
+        self.obj = obj
+        self.attr = attr
+        if isinstance(obj.type, RInstance) and obj.type.class_ir.has_attr(attr):
+            # Native attribute reference
+            self.obj_type = obj.type  # type: RType
+            self.type = obj.type.attr_type(attr)
+        else:
+            # Python attribute reference
+            self.obj_type = object_rprimitive
+            self.type = object_rprimitive
+
+
+class AssignmentTargetTuple(AssignmentTarget):
+    """x, ..., y as assignment target"""
+
+    def __init__(self,
+                 items: List[AssignmentTarget],
+                 star_idx: Optional[int] = None) -> None:
+        self.items = items
+        self.star_idx = star_idx


### PR DESCRIPTION
Since they are only used during the IR build, define them in
`mypyc.irbuild`. Also simplify the implementation slightly.

Work on mypyc/mypyc#781.