### PR TITLE
[mypyc] Remove EmitterInterface as it's not needed for anything

### DIFF
--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -10,9 +10,9 @@ from mypyc.codegen.emit import Emitter
 from mypyc.ir.ops import (
     OpVisitor, Goto, Branch, Return, Assign, LoadInt, LoadErrorValue, GetAttr, SetAttr,
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
-    BasicBlock, Value, MethodCall, EmitterInterface, Unreachable, NAMESPACE_STATIC,
-    NAMESPACE_TYPE, NAMESPACE_MODULE, RaiseStandardError, CallC, LoadGlobal, Truncate,
-    BinaryIntOp, LoadMem, GetElementPtr, LoadAddress, ComparisonOp, SetMem, Register
+    BasicBlock, Value, MethodCall, Unreachable, NAMESPACE_STATIC, NAMESPACE_TYPE, NAMESPACE_MODULE,
+    RaiseStandardError, CallC, LoadGlobal, Truncate, BinaryIntOp, LoadMem, GetElementPtr,
+    LoadAddress, ComparisonOp, SetMem, Register
 )
 from mypyc.ir.rtypes import (
     RType, RTuple, is_tagged, is_int32_rprimitive, is_int64_rprimitive, RStruct,
@@ -92,7 +92,7 @@ def generate_native_function(fn: FuncIR,
     emitter.emit_from_emitter(body)
 
 
-class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
+class FunctionEmitterVisitor(OpVisitor[None]):
     def __init__(self,
                  emitter: Emitter,
                  declarations: Emitter,

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -297,7 +297,7 @@ class Unreachable(ControlOp):
 class RegisterOp(Op):
     """Abstract base class for operations that can be written as r1 = f(r2, ..., rn).
 
-    Takes some registers, performs an operation and generates an output.
+    Takes some values, performs an operation and generates an output.
     Doesn't do any control flow, but can raise an error.
     """
 
@@ -402,33 +402,6 @@ class MethodCall(RegisterOp):
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_method_call(self)
-
-
-@trait
-class EmitterInterface:
-    @abstractmethod
-    def reg(self, name: Value) -> str:
-        raise NotImplementedError
-
-    @abstractmethod
-    def c_error_value(self, rtype: RType) -> str:
-        raise NotImplementedError
-
-    @abstractmethod
-    def temp_name(self) -> str:
-        raise NotImplementedError
-
-    @abstractmethod
-    def emit_line(self, line: str) -> None:
-        raise NotImplementedError
-
-    @abstractmethod
-    def emit_lines(self, *lines: str) -> None:
-        raise NotImplementedError
-
-    @abstractmethod
-    def emit_declaration(self, line: str) -> None:
-        raise NotImplementedError
 
 
 # True steals all arguments, False steals none, a list steals those in matching positions


### PR DESCRIPTION
This continues work on mypyc/mypyc#781.