### PR TITLE
[mypyc] Rename BinaryIntOp to IntOp

### DIFF
--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -207,7 +207,7 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
     def visit_load_global(self, op: LoadGlobal) -> GenAndKill:
         return self.visit_register_op(op)
 
-    def visit_binary_int_op(self, op: IntOp) -> GenAndKill:
+    def visit_int_op(self, op: IntOp) -> GenAndKill:
         return self.visit_register_op(op)
 
     def visit_comparison_op(self, op: ComparisonOp) -> GenAndKill:

--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -9,7 +9,7 @@ from mypyc.ir.ops import (
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
     LoadStatic, InitStatic, MethodCall, RaiseStandardError, CallC, LoadGlobal,
-    Truncate, BinaryIntOp, LoadMem, GetElementPtr, LoadAddress, ComparisonOp, SetMem
+    Truncate, IntOp, LoadMem, GetElementPtr, LoadAddress, ComparisonOp, SetMem
 )
 from mypyc.ir.func_ir import all_values
 
@@ -207,7 +207,7 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
     def visit_load_global(self, op: LoadGlobal) -> GenAndKill:
         return self.visit_register_op(op)
 
-    def visit_binary_int_op(self, op: BinaryIntOp) -> GenAndKill:
+    def visit_binary_int_op(self, op: IntOp) -> GenAndKill:
         return self.visit_register_op(op)
 
     def visit_comparison_op(self, op: ComparisonOp) -> GenAndKill:

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -11,7 +11,7 @@ from mypyc.ir.ops import (
     OpVisitor, Goto, Branch, Return, Assign, LoadInt, LoadErrorValue, GetAttr, SetAttr,
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
     BasicBlock, Value, MethodCall, Unreachable, NAMESPACE_STATIC, NAMESPACE_TYPE, NAMESPACE_MODULE,
-    RaiseStandardError, CallC, LoadGlobal, Truncate, BinaryIntOp, LoadMem, GetElementPtr,
+    RaiseStandardError, CallC, LoadGlobal, Truncate, IntOp, LoadMem, GetElementPtr,
     LoadAddress, ComparisonOp, SetMem, Register
 )
 from mypyc.ir.rtypes import (
@@ -435,7 +435,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
                 ann = ' /* %s */' % s
         self.emit_line('%s = %s;%s' % (dest, op.identifier, ann))
 
-    def visit_binary_int_op(self, op: BinaryIntOp) -> None:
+    def visit_binary_int_op(self, op: IntOp) -> None:
         dest = self.reg(op)
         lhs = self.reg(op.lhs)
         rhs = self.reg(op.rhs)

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -435,7 +435,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
                 ann = ' /* %s */' % s
         self.emit_line('%s = %s;%s' % (dest, op.identifier, ann))
 
-    def visit_binary_int_op(self, op: IntOp) -> None:
+    def visit_int_op(self, op: IntOp) -> None:
         dest = self.reg(op)
         lhs = self.reg(op.lhs)
         rhs = self.reg(op.rhs)

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -834,7 +834,7 @@ class LoadGlobal(RegisterOp):
         return visitor.visit_load_global(self)
 
 
-class BinaryIntOp(RegisterOp):
+class IntOp(RegisterOp):
     """Binary arithmetic and bitwise operations on integer types
 
     These ops are low-level and will be eventually generated to simple x op y form.
@@ -1163,7 +1163,7 @@ class OpVisitor(Generic[T]):
         raise NotImplementedError
 
     @abstractmethod
-    def visit_binary_int_op(self, op: BinaryIntOp) -> T:
+    def visit_binary_int_op(self, op: IntOp) -> T:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -880,7 +880,7 @@ class IntOp(RegisterOp):
         return [self.lhs, self.rhs]
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
-        return visitor.visit_binary_int_op(self)
+        return visitor.visit_int_op(self)
 
 
 class ComparisonOp(RegisterOp):
@@ -1163,7 +1163,7 @@ class OpVisitor(Generic[T]):
         raise NotImplementedError
 
     @abstractmethod
-    def visit_binary_int_op(self, op: IntOp) -> T:
+    def visit_int_op(self, op: IntOp) -> T:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -154,7 +154,7 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
         ann = '  ({})'.format(repr(op.ann)) if op.ann else ''
         return self.format('%r = load_global %s :: static%s', op, op.identifier, ann)
 
-    def visit_binary_int_op(self, op: IntOp) -> str:
+    def visit_int_op(self, op: IntOp) -> str:
         return self.format('%r = %r %s %r', op, op.lhs, IntOp.op_str[op.op], op.rhs)
 
     def visit_comparison_op(self, op: ComparisonOp) -> str:

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -9,7 +9,7 @@ from mypyc.common import short_name
 from mypyc.ir.ops import (
     Goto, Branch, Return, Unreachable, Assign, LoadInt, LoadErrorValue, GetAttr, SetAttr,
     LoadStatic, InitStatic, TupleGet, TupleSet, IncRef, DecRef, Call, MethodCall, Cast, Box, Unbox,
-    RaiseStandardError, CallC, Truncate, LoadGlobal, BinaryIntOp, ComparisonOp, LoadMem, SetMem,
+    RaiseStandardError, CallC, Truncate, LoadGlobal, IntOp, ComparisonOp, LoadMem, SetMem,
     GetElementPtr, LoadAddress, Register, Value, OpVisitor, BasicBlock, ControlOp
 )
 from mypyc.ir.func_ir import FuncIR, all_values_full
@@ -154,8 +154,8 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
         ann = '  ({})'.format(repr(op.ann)) if op.ann else ''
         return self.format('%r = load_global %s :: static%s', op, op.identifier, ann)
 
-    def visit_binary_int_op(self, op: BinaryIntOp) -> str:
-        return self.format('%r = %r %s %r', op, op.lhs, BinaryIntOp.op_str[op.op], op.rhs)
+    def visit_binary_int_op(self, op: IntOp) -> str:
+        return self.format('%r = %r %s %r', op, op.lhs, IntOp.op_str[op.op], op.rhs)
 
     def visit_comparison_op(self, op: ComparisonOp) -> str:
         if op.op in (ComparisonOp.SLT, ComparisonOp.SGT, ComparisonOp.SLE, ComparisonOp.SGE):

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -263,8 +263,8 @@ class IRBuilder:
     def call_c(self, desc: CFunctionDescription, args: List[Value], line: int) -> Value:
         return self.builder.call_c(desc, args, line)
 
-    def binary_int_op(self, type: RType, lhs: Value, rhs: Value, op: int, line: int) -> Value:
-        return self.builder.binary_int_op(type, lhs, rhs, op, line)
+    def int_op(self, type: RType, lhs: Value, rhs: Value, op: int, line: int) -> Value:
+        return self.builder.int_op(type, lhs, rhs, op, line)
 
     def compare_tagged(self, lhs: Value, rhs: Value, op: str, line: int) -> Value:
         return self.builder.compare_tagged(lhs, rhs, op, line)

--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -12,7 +12,7 @@ from mypy.nodes import (
     Lvalue, Expression, TupleExpr, CallExpr, RefExpr, GeneratorExpr, ARG_POS, MemberExpr
 )
 from mypyc.ir.ops import (
-    Value, BasicBlock, LoadInt, Branch, Register, TupleGet, TupleSet, BinaryIntOp
+    Value, BasicBlock, LoadInt, Branch, Register, TupleGet, TupleSet, IntOp
 )
 from mypyc.ir.rtypes import (
     RType, is_short_int_rprimitive, is_list_rprimitive, is_sequence_rprimitive,
@@ -462,7 +462,7 @@ class ForSequence(ForGenerator):
         step = 1 if not self.reverse else -1
         add = builder.binary_int_op(short_int_rprimitive,
                                     builder.read(self.index_target, line),
-                                    builder.add(LoadInt(step)), BinaryIntOp.ADD, line)
+                                    builder.add(LoadInt(step)), IntOp.ADD, line)
         builder.assign(self.index_target, add, line)
 
 
@@ -636,7 +636,7 @@ class ForRange(ForGenerator):
                 and is_short_int_rprimitive(self.end_reg.type)):
             new_val = builder.binary_int_op(short_int_rprimitive,
                             builder.read(self.index_reg, line),
-                            builder.add(LoadInt(self.step)), BinaryIntOp.ADD, line)
+                            builder.add(LoadInt(self.step)), IntOp.ADD, line)
 
         else:
             new_val = builder.binary_op(
@@ -666,7 +666,7 @@ class ForInfiniteCounter(ForGenerator):
         # NOTE: This would be questionable if short ints could be 32 bits.
         new_val = builder.binary_int_op(short_int_rprimitive,
                 builder.read(self.index_reg, line),
-                builder.add(LoadInt(1)), BinaryIntOp.ADD, line)
+                builder.add(LoadInt(1)), IntOp.ADD, line)
         builder.assign(self.index_reg, new_val, line)
         builder.assign(self.index_target, new_val, line)
 

--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -460,9 +460,10 @@ class ForSequence(ForGenerator):
         builder = self.builder
         line = self.line
         step = 1 if not self.reverse else -1
-        add = builder.binary_int_op(short_int_rprimitive,
-                                    builder.read(self.index_target, line),
-                                    builder.add(LoadInt(step)), IntOp.ADD, line)
+        add = builder.int_op(short_int_rprimitive,
+                             builder.read(self.index_target, line),
+                             builder.add(LoadInt(step)),
+                             IntOp.ADD, line)
         builder.assign(self.index_target, add, line)
 
 
@@ -634,7 +635,7 @@ class ForRange(ForGenerator):
         # short ints.
         if (is_short_int_rprimitive(self.start_reg.type)
                 and is_short_int_rprimitive(self.end_reg.type)):
-            new_val = builder.binary_int_op(short_int_rprimitive,
+            new_val = builder.int_op(short_int_rprimitive,
                             builder.read(self.index_reg, line),
                             builder.add(LoadInt(self.step)), IntOp.ADD, line)
 
@@ -664,7 +665,7 @@ class ForInfiniteCounter(ForGenerator):
         # We can safely assume that the integer is short, since we are not going to wrap
         # around a 63-bit integer.
         # NOTE: This would be questionable if short ints could be 32 bits.
-        new_val = builder.binary_int_op(short_int_rprimitive,
+        new_val = builder.int_op(short_int_rprimitive,
                 builder.read(self.index_reg, line),
                 builder.add(LoadInt(1)), IntOp.ADD, line)
         builder.assign(self.index_reg, new_val, line)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -802,7 +802,7 @@ class LowLevelIRBuilder:
             else:
                 offset = self.add(LoadInt(PLATFORM_SIZE * i, line, rtype=c_pyssize_t_rprimitive))
                 item_address = self.add(IntOp(pointer_rprimitive, ob_item_base, offset,
-                                                    IntOp.ADD, line))
+                                              IntOp.ADD, line))
             self.add(SetMem(object_rprimitive, item_address, args[i], result_list, line))
         return result_list
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -553,8 +553,7 @@ class LowLevelIRBuilder:
         Return the result of the check (value of type 'bit').
         """
         int_tag = self.add(LoadInt(1, line, rtype=c_pyssize_t_rprimitive))
-        bitwise_and = self.binary_int_op(c_pyssize_t_rprimitive, val,
-                                         int_tag, IntOp.AND, line)
+        bitwise_and = self.int_op(c_pyssize_t_rprimitive, val, int_tag, IntOp.AND, line)
         zero = self.add(LoadInt(0, line, rtype=c_pyssize_t_rprimitive))
         op = ComparisonOp.NEQ if negated else ComparisonOp.EQ
         check = self.comparison_op(bitwise_and, zero, op, line)
@@ -574,8 +573,7 @@ class LowLevelIRBuilder:
         else:
             # for non-equality logical ops (less/greater than, etc.), need to check both sides
             check_rhs = self.check_tagged_short_int(rhs, line)
-            check = self.binary_int_op(bit_rprimitive, check_lhs,
-                                       check_rhs, IntOp.AND, line)
+            check = self.int_op(bit_rprimitive, check_lhs, check_rhs, IntOp.AND, line)
         self.add(Branch(check, short_int_block, int_block, Branch.BOOL))
         self.activate_block(short_int_block)
         eq = self.comparison_op(lhs, rhs, op_type, line)
@@ -741,7 +739,7 @@ class LowLevelIRBuilder:
                   value: Value,
                   line: int) -> Value:
         mask = self.add(LoadInt(1, line, rtype=value.type))
-        return self.binary_int_op(value.type, value, mask, IntOp.XOR, line)
+        return self.int_op(value.type, value, mask, IntOp.XOR, line)
 
     def unary_op(self,
                  lreg: Value,
@@ -971,7 +969,7 @@ class LowLevelIRBuilder:
             return target
         return None
 
-    def binary_int_op(self, type: RType, lhs: Value, rhs: Value, op: int, line: int) -> Value:
+    def int_op(self, type: RType, lhs: Value, rhs: Value, op: int, line: int) -> Value:
         return self.add(IntOp(type, lhs, rhs, op, line))
 
     def comparison_op(self, lhs: Value, rhs: Value, op: int, line: int) -> Value:
@@ -983,19 +981,19 @@ class LowLevelIRBuilder:
             elem_address = self.add(GetElementPtr(val, PyVarObject, 'ob_size'))
             size_value = self.add(LoadMem(c_pyssize_t_rprimitive, elem_address, val))
             offset = self.add(LoadInt(1, line, rtype=c_pyssize_t_rprimitive))
-            return self.binary_int_op(short_int_rprimitive, size_value, offset,
-                                      IntOp.LEFT_SHIFT, line)
+            return self.int_op(short_int_rprimitive, size_value, offset,
+                               IntOp.LEFT_SHIFT, line)
         elif is_dict_rprimitive(typ):
             size_value = self.call_c(dict_size_op, [val], line)
             offset = self.add(LoadInt(1, line, rtype=c_pyssize_t_rprimitive))
-            return self.binary_int_op(short_int_rprimitive, size_value, offset,
-                                      IntOp.LEFT_SHIFT, line)
+            return self.int_op(short_int_rprimitive, size_value, offset,
+                               IntOp.LEFT_SHIFT, line)
         elif is_set_rprimitive(typ):
             elem_address = self.add(GetElementPtr(val, PySetObject, 'used'))
             size_value = self.add(LoadMem(c_pyssize_t_rprimitive, elem_address, val))
             offset = self.add(LoadInt(1, line, rtype=c_pyssize_t_rprimitive))
-            return self.binary_int_op(short_int_rprimitive, size_value, offset,
-                                      IntOp.LEFT_SHIFT, line)
+            return self.int_op(short_int_rprimitive, size_value, offset,
+                               IntOp.LEFT_SHIFT, line)
         # generic case
         else:
             return self.call_c(generic_len_op, [val], line)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -20,7 +20,7 @@ from mypyc.ir.ops import (
     BasicBlock, Op, LoadInt, Value, Register, Assign, Branch, Goto, Call, Box, Unbox, Cast,
     GetAttr, LoadStatic, MethodCall, CallC, Truncate,
     RaiseStandardError, Unreachable, LoadErrorValue, LoadGlobal,
-    NAMESPACE_TYPE, NAMESPACE_MODULE, NAMESPACE_STATIC, BinaryIntOp, GetElementPtr,
+    NAMESPACE_TYPE, NAMESPACE_MODULE, NAMESPACE_STATIC, IntOp, GetElementPtr,
     LoadMem, ComparisonOp, LoadAddress, TupleGet, SetMem, ERR_NEVER, ERR_FALSE
 )
 from mypyc.ir.rtypes import (
@@ -554,7 +554,7 @@ class LowLevelIRBuilder:
         """
         int_tag = self.add(LoadInt(1, line, rtype=c_pyssize_t_rprimitive))
         bitwise_and = self.binary_int_op(c_pyssize_t_rprimitive, val,
-                                         int_tag, BinaryIntOp.AND, line)
+                                         int_tag, IntOp.AND, line)
         zero = self.add(LoadInt(0, line, rtype=c_pyssize_t_rprimitive))
         op = ComparisonOp.NEQ if negated else ComparisonOp.EQ
         check = self.comparison_op(bitwise_and, zero, op, line)
@@ -575,7 +575,7 @@ class LowLevelIRBuilder:
             # for non-equality logical ops (less/greater than, etc.), need to check both sides
             check_rhs = self.check_tagged_short_int(rhs, line)
             check = self.binary_int_op(bit_rprimitive, check_lhs,
-                                       check_rhs, BinaryIntOp.AND, line)
+                                       check_rhs, IntOp.AND, line)
         self.add(Branch(check, short_int_block, int_block, Branch.BOOL))
         self.activate_block(short_int_block)
         eq = self.comparison_op(lhs, rhs, op_type, line)
@@ -728,20 +728,20 @@ class LowLevelIRBuilder:
 
     def bool_bitwise_op(self, lreg: Value, rreg: Value, op: str, line: int) -> Value:
         if op == '&':
-            code = BinaryIntOp.AND
+            code = IntOp.AND
         elif op == '|':
-            code = BinaryIntOp.OR
+            code = IntOp.OR
         elif op == '^':
-            code = BinaryIntOp.XOR
+            code = IntOp.XOR
         else:
             assert False, op
-        return self.add(BinaryIntOp(bool_rprimitive, lreg, rreg, code, line))
+        return self.add(IntOp(bool_rprimitive, lreg, rreg, code, line))
 
     def unary_not(self,
                   value: Value,
                   line: int) -> Value:
         mask = self.add(LoadInt(1, line, rtype=value.type))
-        return self.binary_int_op(value.type, value, mask, BinaryIntOp.XOR, line)
+        return self.binary_int_op(value.type, value, mask, IntOp.XOR, line)
 
     def unary_op(self,
                  lreg: Value,
@@ -801,8 +801,8 @@ class LowLevelIRBuilder:
                 item_address = ob_item_base
             else:
                 offset = self.add(LoadInt(PLATFORM_SIZE * i, line, rtype=c_pyssize_t_rprimitive))
-                item_address = self.add(BinaryIntOp(pointer_rprimitive, ob_item_base, offset,
-                                                    BinaryIntOp.ADD, line))
+                item_address = self.add(IntOp(pointer_rprimitive, ob_item_base, offset,
+                                                    IntOp.ADD, line))
             self.add(SetMem(object_rprimitive, item_address, args[i], result_list, line))
         return result_list
 
@@ -972,7 +972,7 @@ class LowLevelIRBuilder:
         return None
 
     def binary_int_op(self, type: RType, lhs: Value, rhs: Value, op: int, line: int) -> Value:
-        return self.add(BinaryIntOp(type, lhs, rhs, op, line))
+        return self.add(IntOp(type, lhs, rhs, op, line))
 
     def comparison_op(self, lhs: Value, rhs: Value, op: int, line: int) -> Value:
         return self.add(ComparisonOp(lhs, rhs, op, line))
@@ -984,18 +984,18 @@ class LowLevelIRBuilder:
             size_value = self.add(LoadMem(c_pyssize_t_rprimitive, elem_address, val))
             offset = self.add(LoadInt(1, line, rtype=c_pyssize_t_rprimitive))
             return self.binary_int_op(short_int_rprimitive, size_value, offset,
-                                      BinaryIntOp.LEFT_SHIFT, line)
+                                      IntOp.LEFT_SHIFT, line)
         elif is_dict_rprimitive(typ):
             size_value = self.call_c(dict_size_op, [val], line)
             offset = self.add(LoadInt(1, line, rtype=c_pyssize_t_rprimitive))
             return self.binary_int_op(short_int_rprimitive, size_value, offset,
-                                      BinaryIntOp.LEFT_SHIFT, line)
+                                      IntOp.LEFT_SHIFT, line)
         elif is_set_rprimitive(typ):
             elem_address = self.add(GetElementPtr(val, PySetObject, 'used'))
             size_value = self.add(LoadMem(c_pyssize_t_rprimitive, elem_address, val))
             offset = self.add(LoadInt(1, line, rtype=c_pyssize_t_rprimitive))
             return self.binary_int_op(short_int_rprimitive, size_value, offset,
-                                      BinaryIntOp.LEFT_SHIFT, line)
+                                      IntOp.LEFT_SHIFT, line)
         # generic case
         else:
             return self.call_c(generic_len_op, [val], line)

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -125,7 +125,7 @@ int_invert_op = int_unary_op('~', 'CPyTagged_Invert')
 
 # Description for building int logical ops
 # For each field:
-# binary_op_variant: identify which BinaryIntOp to use when operands are short integers
+# binary_op_variant: identify which IntOp to use when operands are short integers
 # c_func_description: the C function to call when operands are tagged integers
 # c_func_negated: whether to negate the C function call's result
 # c_func_swap_operands: whether to swap lhs and rhs when call the function

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -8,7 +8,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc.ir.ops import (
     BasicBlock, Goto, Return, LoadInt, Assign, IncRef, DecRef, Branch,
-    Call, Unbox, Box, TupleGet, GetAttr, SetAttr, Op, Value, CallC, BinaryIntOp, LoadMem,
+    Call, Unbox, Box, TupleGet, GetAttr, SetAttr, Op, Value, CallC, IntOp, LoadMem,
     GetElementPtr, LoadAddress, ComparisonOp, SetMem, Register
 )
 from mypyc.ir.rtypes import (
@@ -239,27 +239,27 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
             """cpy_r_r0 = PyDict_Contains(cpy_r_d, cpy_r_o);""")
 
     def test_binary_int_op(self) -> None:
-        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.ADD, 1),
+        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.ADD, 1),
                          """cpy_r_r0 = cpy_r_s1 + cpy_r_s2;""")
-        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.SUB, 1),
+        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.SUB, 1),
                         """cpy_r_r0 = cpy_r_s1 - cpy_r_s2;""")
-        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.MUL, 1),
+        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.MUL, 1),
                         """cpy_r_r0 = cpy_r_s1 * cpy_r_s2;""")
-        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.DIV, 1),
+        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.DIV, 1),
                         """cpy_r_r0 = cpy_r_s1 / cpy_r_s2;""")
-        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.MOD, 1),
+        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.MOD, 1),
                         """cpy_r_r0 = cpy_r_s1 % cpy_r_s2;""")
-        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.AND, 1),
+        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.AND, 1),
                         """cpy_r_r0 = cpy_r_s1 & cpy_r_s2;""")
-        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.OR, 1),
+        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.OR, 1),
                         """cpy_r_r0 = cpy_r_s1 | cpy_r_s2;""")
-        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2, BinaryIntOp.XOR, 1),
+        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.XOR, 1),
                         """cpy_r_r0 = cpy_r_s1 ^ cpy_r_s2;""")
-        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2,
-                                     BinaryIntOp.LEFT_SHIFT, 1),
+        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2,
+                                     IntOp.LEFT_SHIFT, 1),
                         """cpy_r_r0 = cpy_r_s1 << cpy_r_s2;""")
-        self.assert_emit(BinaryIntOp(short_int_rprimitive, self.s1, self.s2,
-                                     BinaryIntOp.RIGHT_SHIFT, 1),
+        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2,
+                                     IntOp.RIGHT_SHIFT, 1),
                         """cpy_r_r0 = cpy_r_s1 >> cpy_r_s2;""")
 
     def test_comparison_op(self) -> None:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -238,7 +238,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
             'in', self.b, self.o, self.d,
             """cpy_r_r0 = PyDict_Contains(cpy_r_d, cpy_r_o);""")
 
-    def test_binary_int_op(self) -> None:
+    def test_int_op(self) -> None:
         self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.ADD, 1),
                          """cpy_r_r0 = cpy_r_s1 + cpy_r_s2;""")
         self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.SUB, 1),

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -242,25 +242,23 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.ADD, 1),
                          """cpy_r_r0 = cpy_r_s1 + cpy_r_s2;""")
         self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.SUB, 1),
-                        """cpy_r_r0 = cpy_r_s1 - cpy_r_s2;""")
+                         """cpy_r_r0 = cpy_r_s1 - cpy_r_s2;""")
         self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.MUL, 1),
-                        """cpy_r_r0 = cpy_r_s1 * cpy_r_s2;""")
+                         """cpy_r_r0 = cpy_r_s1 * cpy_r_s2;""")
         self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.DIV, 1),
-                        """cpy_r_r0 = cpy_r_s1 / cpy_r_s2;""")
+                         """cpy_r_r0 = cpy_r_s1 / cpy_r_s2;""")
         self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.MOD, 1),
-                        """cpy_r_r0 = cpy_r_s1 % cpy_r_s2;""")
+                         """cpy_r_r0 = cpy_r_s1 % cpy_r_s2;""")
         self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.AND, 1),
-                        """cpy_r_r0 = cpy_r_s1 & cpy_r_s2;""")
+                         """cpy_r_r0 = cpy_r_s1 & cpy_r_s2;""")
         self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.OR, 1),
-                        """cpy_r_r0 = cpy_r_s1 | cpy_r_s2;""")
+                         """cpy_r_r0 = cpy_r_s1 | cpy_r_s2;""")
         self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.XOR, 1),
-                        """cpy_r_r0 = cpy_r_s1 ^ cpy_r_s2;""")
-        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2,
-                                     IntOp.LEFT_SHIFT, 1),
-                        """cpy_r_r0 = cpy_r_s1 << cpy_r_s2;""")
-        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2,
-                                     IntOp.RIGHT_SHIFT, 1),
-                        """cpy_r_r0 = cpy_r_s1 >> cpy_r_s2;""")
+                         """cpy_r_r0 = cpy_r_s1 ^ cpy_r_s2;""")
+        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.LEFT_SHIFT, 1),
+                         """cpy_r_r0 = cpy_r_s1 << cpy_r_s2;""")
+        self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.RIGHT_SHIFT, 1),
+                         """cpy_r_r0 = cpy_r_s1 >> cpy_r_s2;""")
 
     def test_comparison_op(self) -> None:
         # signed

--- a/mypyc/test/test_pprint.py
+++ b/mypyc/test/test_pprint.py
@@ -1,7 +1,7 @@
 import unittest
 from typing import List
 
-from mypyc.ir.ops import BasicBlock, Register, Op, LoadInt, BinaryIntOp, Unreachable, Assign
+from mypyc.ir.ops import BasicBlock, Register, Op, LoadInt, IntOp, Unreachable, Assign
 from mypyc.ir.rtypes import int_rprimitive
 from mypyc.ir.pprint import generate_names_for_ir
 
@@ -27,7 +27,7 @@ class TestGenerateNames(unittest.TestCase):
     def test_int_op(self) -> None:
         op1 = LoadInt(2)
         op2 = LoadInt(4)
-        op3 = BinaryIntOp(int_rprimitive, op1, op2, BinaryIntOp.ADD)
+        op3 = IntOp(int_rprimitive, op1, op2, IntOp.ADD)
         block = make_block([op1, op2, op3, Unreachable()])
         assert generate_names_for_ir([], [block]) == {op1: 'i0', op2: 'i1', op3: 'r0'}
 


### PR DESCRIPTION
Since `IntOp` is also used as a namespace for op constants, it's common to
refer to the class name twice per operation, making it useful to use a shorter 
name.

Work on mypyc/mypyc#781.