### PR TITLE
PEP 612: hide from those who may seek to use it

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -780,6 +780,8 @@ def process_options(args: List[str],
     # Must be followed by another flag or by '--' (and then only file args may follow).
     parser.add_argument('--cache-map', nargs='+', dest='special-opts:cache_map',
                         help=argparse.SUPPRESS)
+    # PEP 612 support is a work in progress, hide it from users
+    parser.add_argument('--wip-pep-612', action="store_true", help=argparse.SUPPRESS)
 
     # options specifying code to check
     code_group = parser.add_argument_group(

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -238,6 +238,9 @@ class Options:
         # mypy. (Like mypyc.)
         self.preserve_asts = False
 
+        # PEP 612 support is a work in progress, hide it from users
+        self.wip_pep_612 = False
+
         # Paths of user plugins
         self.plugins = []  # type: List[str]
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3106,6 +3106,8 @@ class SemanticAnalyzer(NodeVisitor[None],
         In the future, ParamSpec may accept bounds and variance arguments, in which
         case more aggressive sharing of code with process_typevar_declaration should be pursued.
         """
+        if not self.options.wip_pep_612:
+            return False
         call = self.get_typevarlike_declaration(
             s, ("typing_extensions.ParamSpec", "typing.ParamSpec")
         )

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1,9 +1,11 @@
 [case testBasicParamSpec]
+# flags: --wip-pep-612
 from typing_extensions import ParamSpec
 P = ParamSpec('P')
 [builtins fixtures/tuple.pyi]
 
 [case testParamSpecLocations]
+# flags: --wip-pep-612
 from typing import Callable, List
 from typing_extensions import ParamSpec, Concatenate
 P = ParamSpec('P')

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1416,6 +1416,7 @@ def g() -> None:
 [out]
 
 [case testParamSpec]
+# flags: --wip-pep-612
 from typing_extensions import ParamSpec
 
 TParams = ParamSpec('TParams')

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -1500,11 +1500,12 @@ MypyFile:1(
 
 
 [case testParamSpec]
+# flags: --wip-pep-612
 from typing import ParamSpec
 P = ParamSpec("P")
 [out]
 MypyFile:1(
-  ImportFrom:1(typing, [ParamSpec])
-  AssignmentStmt:2(
+  ImportFrom:2(typing, [ParamSpec])
+  AssignmentStmt:3(
     NameExpr(P* [__main__.P])
-    ParamSpecExpr:2()))
+    ParamSpecExpr:3()))


### PR DESCRIPTION
This prevents users from hitting asserts before PEP 612 support is fully
implemented.