### PR TITLE
Don't expand global variables in body of a function with constrained type variables

### DIFF
--- a/mypy/test/testtransform.py
+++ b/mypy/test/testtransform.py
@@ -60,6 +60,7 @@ def test_transform(testcase: DataDrivenTestCase) -> None:
                     and not os.path.splitext(
                         os.path.basename(f.path))[0].endswith('_')):
                 t = TypeAssertTransformVisitor()
+                t.test_only = True
                 f = t.mypyfile(f)
                 a += str(f).split('\n')
     except CompileError as e:

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2402,3 +2402,31 @@ def func(tp: Type[C[S]]) -> S:
     else:
         return reg[tp.test].test[0]
 [builtins fixtures/dict.pyi]
+
+[case testGenericFunctionAliasExpand]
+from typing import Optional, TypeVar
+
+T = TypeVar("T")
+def gen(x: T) -> T: ...
+gen_a = gen
+
+S = TypeVar("S", int, str)
+class C: ...
+def test() -> Optional[S]:
+    reveal_type(gen_a(C()))  # N: Revealed type is '__main__.C*'
+    return None
+
+[case testGenericFunctionMemberExpand]
+from typing import Optional, TypeVar, Callable
+
+T = TypeVar("T")
+
+class A:
+    def __init__(self) -> None:
+        self.gen: Callable[[T], T]
+
+S = TypeVar("S", int, str)
+class C: ...
+def test() -> Optional[S]:
+    reveal_type(A().gen(C()))  # N: Revealed type is '__main__.C*'
+    return None


### PR DESCRIPTION
See first test case for the scenario where this causes issues (the second test case is already handled elsewhere and just added for completeness). This is an old issue, but it is important to fix it now because recent changes to PEP 484 about re-export force people to use function aliases.