### PR TITLE
Fix type errors stemming from getattr

### DIFF
--- a/mypy/moduleinspect.py
+++ b/mypy/moduleinspect.py
@@ -45,7 +45,7 @@ def get_package_properties(package_id: str) -> ModuleProperties:
         package = importlib.import_module(package_id)
     except BaseException as e:
         raise InspectError(str(e)) from e
-    name = getattr(package, '__name__')
+    name = package.__name__
     file = getattr(package, '__file__', None)
     path = getattr(package, '__path__', None)  # type: Optional[List[str]]
     if not isinstance(path, list):

--- a/mypy/moduleinspect.py
+++ b/mypy/moduleinspect.py
@@ -45,7 +45,7 @@ def get_package_properties(package_id: str) -> ModuleProperties:
         package = importlib.import_module(package_id)
     except BaseException as e:
         raise InspectError(str(e)) from e
-    name = getattr(package, '__name__', None)
+    name = getattr(package, '__name__')
     file = getattr(package, '__file__', None)
     path = getattr(package, '__path__', None)  # type: Optional[List[str]]
     if not isinstance(path, list):

--- a/mypy/moduleinspect.py
+++ b/mypy/moduleinspect.py
@@ -45,7 +45,7 @@ def get_package_properties(package_id: str) -> ModuleProperties:
         package = importlib.import_module(package_id)
     except BaseException as e:
         raise InspectError(str(e)) from e
-    name = getattr(package, '__name__', package_id) 
+    name = getattr(package, '__name__', package_id)
     file = getattr(package, '__file__', None)
     path = getattr(package, '__path__', None)  # type: Optional[List[str]]
     if not isinstance(path, list):

--- a/mypy/moduleinspect.py
+++ b/mypy/moduleinspect.py
@@ -45,7 +45,7 @@ def get_package_properties(package_id: str) -> ModuleProperties:
         package = importlib.import_module(package_id)
     except BaseException as e:
         raise InspectError(str(e)) from e
-    name = package.__name__
+    name = getattr(package, '__name__', package_id) 
     file = getattr(package, '__file__', None)
     path = getattr(package, '__path__', None)  # type: Optional[List[str]]
     if not isinstance(path, list):

--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -202,7 +202,7 @@ class DocStringParser:
         return list(sorted(self.signatures, key=lambda x: 1 if args_kwargs(x) else 0))
 
 
-def infer_sig_from_docstring(docstr: str, name: str) -> Optional[List[FunctionSig]]:
+def infer_sig_from_docstring(docstr: Optional[str], name: str) -> Optional[List[FunctionSig]]:
     """Convert function signature to list of TypedFunctionSig
 
     Look for function signatures of function in docstring. Signature is a string of


### PR DESCRIPTION
Fixes #9888

I applied the following patch to typeshed and ran self check:
```
+@overload
+def getattr(__o: Any, name: str, __default: None) -> Optional[Any]: ...
+@overload
 def getattr(__o: Any, name: str, __default: Any = ...) -> Any: ...
 ```