### PR TITLE
Report incompatible assignments for descriptors with overloaded __set__ methods.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3044,32 +3044,32 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             context, object_type=attribute_type,
         )
 
-        # Here we just infer the type, the result should be type-checked like a normal assignment.
-        # For this we use the rvalue as type context.
+        # For non-overloaded setters, the result should be type-checked like a regular assignment.
+        # Hence, we first only try to infer the type by using the rvalue as type context.
+        type_context = rvalue
         self.msg.disable_errors()
         _, inferred_dunder_set_type = self.expr_checker.check_call(
             dunder_set_type,
-            [TempNode(instance_type, context=context), rvalue],
+            [TempNode(instance_type, context=context), type_context],
             [nodes.ARG_POS, nodes.ARG_POS],
             context, object_type=attribute_type,
             callable_name=callable_name)
         self.msg.enable_errors()
 
-        # And now we type check the call second time, to show errors related
-        # to wrong arguments count, etc.
+        # And now we in fact type check the call, to show errors related to wrong arguments
+        # count, etc., replacing the type context von non-overloaded setters only.
+        if isinstance(inferred_dunder_set_type, CallableType):
+            type_context = TempNode(AnyType(TypeOfAny.special_form), context=context)
         self.expr_checker.check_call(
             dunder_set_type,
-            [TempNode(instance_type, context=context),
-             TempNode(AnyType(TypeOfAny.special_form), context=context)],
+            [TempNode(instance_type, context=context), type_context],
             [nodes.ARG_POS, nodes.ARG_POS],
             context, object_type=attribute_type,
             callable_name=callable_name)
 
-        # should be handled by get_method above
-        assert isinstance(inferred_dunder_set_type, CallableType)  # type: ignore
-
-        if len(inferred_dunder_set_type.arg_types) < 2:
-            # A message already will have been recorded in check_call
+        # In the following cases, a message already will have been recorded in check_call.
+        if ((not isinstance(inferred_dunder_set_type, CallableType)) or
+                (len(inferred_dunder_set_type.arg_types) < 2)):
             return AnyType(TypeOfAny.from_error), get_type, False
 
         set_type = inferred_dunder_set_type.arg_types[1]

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3058,6 +3058,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         # And now we in fact type check the call, to show errors related to wrong arguments
         # count, etc., replacing the type context von non-overloaded setters only.
+        inferred_dunder_set_type = get_proper_type(inferred_dunder_set_type)
         if isinstance(inferred_dunder_set_type, CallableType):
             type_context = TempNode(AnyType(TypeOfAny.special_form), context=context)
         self.expr_checker.check_call(

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3057,7 +3057,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         self.msg.enable_errors()
 
         # And now we in fact type check the call, to show errors related to wrong arguments
-        # count, etc., replacing the type context von non-overloaded setters only.
+        # count, etc., replacing the type context for non-overloaded setters only.
         inferred_dunder_set_type = get_proper_type(inferred_dunder_set_type)
         if isinstance(inferred_dunder_set_type, CallableType):
             type_context = TempNode(AnyType(TypeOfAny.special_form), context=context)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1380,7 +1380,7 @@ class A:
 a = A()
 a.f = ''
 a.f = 1
-a.f = 1.5
+a.f = 1.5  # E
 [out]
 main:13: error: No overload variant of "__set__" of "D" matches argument types "A", "float"
 main:13: note: Possible overload variants:
@@ -1403,8 +1403,8 @@ a = A()
 b = B()
 a.f = ''
 b.f = 1
-a.f = 1
-b.f = ''
+a.f = 1   # E
+b.f = ''  # E
 [out]
 main:16: error: No overload variant of "__set__" of "D" matches argument types "A", "int"
 main:16: note: Possible overload variants:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1367,6 +1367,54 @@ a = A()
 a.f = ''
 a.f = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
+[case testSettingDescriptorWithOverloadedDunderSet1]
+from typing import Any, overload, Union
+class D:
+    @overload
+    def __set__(self, inst: Any, value: str) -> None: pass
+    @overload
+    def __set__(self, inst: Any, value: int) -> None: pass
+    def __set__(self, inst: Any, value: Union[str, int]) -> None: pass
+class A:
+    f = D()
+a = A()
+a.f = ''
+a.f = 1
+a.f = 1.5
+[out]
+main:13: error: No overload variant of "__set__" of "D" matches argument types "A", "float"
+main:13: note: Possible overload variants:
+main:13: note:     def __set__(self, inst: Any, value: str) -> None
+main:13: note:     def __set__(self, inst: Any, value: int) -> None
+
+[case testSettingDescriptorWithOverloadedDunderSet2]
+from typing import overload, Union
+class D:
+    @overload
+    def __set__(self, inst: A, value: str) -> None: pass
+    @overload
+    def __set__(self, inst: B, value: int) -> None: pass
+    def __set__(self, inst: Union[A, B], value: Union[str, int]) -> None: pass
+class A:
+    f = D()
+class B:
+    f = D()
+a = A()
+b = B()
+a.f = ''
+b.f = 1
+a.f = 1
+b.f = ''
+[out]
+main:16: error: No overload variant of "__set__" of "D" matches argument types "A", "int"
+main:16: note: Possible overload variants:
+main:16: note:     def __set__(self, inst: A, value: str) -> None
+main:16: note:     def __set__(self, inst: B, value: int) -> None
+main:17: error: No overload variant of "__set__" of "D" matches argument types "B", "str"
+main:17: note: Possible overload variants:
+main:17: note:     def __set__(self, inst: A, value: str) -> None
+main:17: note:     def __set__(self, inst: B, value: int) -> None
+
 [case testReadingDescriptorWithoutDunderGet]
 from typing import Union, Any
 class D:


### PR DESCRIPTION
Fixes #7205

Hello everyone,

this is my first contribution to mypy, I hope to meet your style well enough.

I added two test cases which cause mypy to crash without the provided changes. At least on my machine, the changes do not affect any other tests. 

For short explanations, please see the commit message and the (modifications of the) inline comments.

