### PR TITLE
[mypyc] Use faster METH_FASTCALL wrapper functions on Python 3.7+

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -29,7 +29,7 @@ DEALINGS IN THE SOFTWARE.
 Portions of mypy and mypyc are licensed under different licenses.  The
 files under stdlib-samples as well as the files
 mypyc/lib-rt/pythonsupport.h, mypyc/lib-rt/getargs.c and
-mypyc/librt-getargsfast.c are licensed under the PSF 2 License, reproduced
+mypyc/lib-rt/getargsfast.c are licensed under the PSF 2 License, reproduced
 below.
 
 = = = = =

--- a/LICENSE
+++ b/LICENSE
@@ -28,8 +28,9 @@ DEALINGS IN THE SOFTWARE.
 
 Portions of mypy and mypyc are licensed under different licenses.  The
 files under stdlib-samples as well as the files
-mypyc/lib-rt/pythonsupport.h and mypyc/lib-rt/getargs.c are licensed
-under the PSF 2 License, reproduced below.
+mypyc/lib-rt/pythonsupport.h, mypyc/lib-rt/getargs.c and
+mypyc/librt-getargsfast.c are licensed under the PSF 2 License, reproduced
+below.
 
 = = = = =
 

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -4,7 +4,7 @@
 from typing import Optional, List, Tuple, Dict, Callable, Mapping, Set
 from mypy.ordered_dict import OrderedDict
 
-from mypyc.common import PREFIX, NATIVE_PREFIX, REG_PREFIX
+from mypyc.common import PREFIX, NATIVE_PREFIX, REG_PREFIX, USE_FASTCALL
 from mypyc.codegen.emit import Emitter, HeaderDeclaration
 from mypyc.codegen.emitfunc import native_function_header
 from mypyc.codegen.emitwrapper import (
@@ -644,7 +644,11 @@ def generate_methods_table(cl: ClassIR,
             continue
         emitter.emit_line('{{"{}",'.format(fn.name))
         emitter.emit_line(' (PyCFunction){}{},'.format(PREFIX, fn.cname(emitter.names)))
-        flags = ['METH_FASTCALL', 'METH_KEYWORDS']
+        if USE_FASTCALL:
+            flags = ['METH_FASTCALL']
+        else:
+            flags = ['METH_VARARGS']
+        flags.append('METH_KEYWORDS')
         if fn.decl.kind == FUNC_STATICMETHOD:
             flags.append('METH_STATIC')
         elif fn.decl.kind == FUNC_CLASSMETHOD:

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -644,7 +644,7 @@ def generate_methods_table(cl: ClassIR,
             continue
         emitter.emit_line('{{"{}",'.format(fn.name))
         emitter.emit_line(' (PyCFunction){}{},'.format(PREFIX, fn.cname(emitter.names)))
-        flags = ['METH_VARARGS', 'METH_KEYWORDS']
+        flags = ['METH_FASTCALL', 'METH_KEYWORDS']
         if fn.decl.kind == FUNC_STATICMETHOD:
             flags.append('METH_STATIC')
         elif fn.decl.kind == FUNC_CLASSMETHOD:

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -846,21 +846,12 @@ class GroupGenerator:
         for fn in module.functions:
             if fn.class_name is not None or fn.name == TOP_LEVEL_NAME:
                 continue
-            cname = fn.cname(emitter.names)
-            if cname.endswith(('__init__', '__call__')):
-                emitter.emit_line(
-                    ('{{"{name}", (PyCFunction){prefix}{cname}, METH_VARARGS | METH_KEYWORDS, '
-                     'NULL /* docstring */}},').format(
-                         name=fn.name,
-                         cname=cname,
-                         prefix=PREFIX))
-            else:
-                emitter.emit_line(
-                    ('{{"{name}", (PyCFunction){prefix}{cname}, METH_FASTCALL | METH_KEYWORDS, '
-                     'NULL /* docstring */}},').format(
-                         name=fn.name,
-                         cname=cname,
-                         prefix=PREFIX))
+            emitter.emit_line(
+                ('{{"{name}", (PyCFunction){prefix}{cname}, METH_FASTCALL | METH_KEYWORDS, '
+                 'NULL /* docstring */}},').format(
+                     name=fn.name,
+                     cname=fn.cname(emitter.names),
+                     prefix=PREFIX))
         emitter.emit_line('{NULL, NULL, 0, NULL}')
         emitter.emit_line('};')
         emitter.emit_line()

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -31,8 +31,8 @@ from mypyc.codegen.emit import EmitterContext, Emitter, HeaderDeclaration
 from mypyc.codegen.emitfunc import generate_native_function, native_function_header
 from mypyc.codegen.emitclass import generate_class_type_decl, generate_class
 from mypyc.codegen.emitwrapper import (
+    generate_wrapper_function, wrapper_function_header,
     generate_legacy_wrapper_function, legacy_wrapper_function_header,
-    generate_wrapper_function_2, wrapper_function_header_2,
 )
 from mypyc.ir.ops import LiteralsMap, DeserMaps
 from mypyc.ir.rtypes import RType, RTuple
@@ -423,7 +423,7 @@ def generate_function_declaration(fn: FuncIR, emitter: Emitter) -> None:
     if fn.name != TOP_LEVEL_NAME:
         if is_fastcall_supported(fn):
             emitter.context.declarations[PREFIX + fn.cname(emitter.names)] = HeaderDeclaration(
-                '{};'.format(wrapper_function_header_2(fn, emitter.names)))
+                '{};'.format(wrapper_function_header(fn, emitter.names)))
         else:
             emitter.context.declarations[PREFIX + fn.cname(emitter.names)] = HeaderDeclaration(
                 '{};'.format(legacy_wrapper_function_header(fn, emitter.names)))
@@ -536,7 +536,7 @@ class GroupGenerator:
                 if fn.name != TOP_LEVEL_NAME:
                     emitter.emit_line()
                     if is_fastcall_supported(fn):
-                        generate_wrapper_function_2(
+                        generate_wrapper_function(
                             fn, emitter, self.source_paths[module_name], module_name)
                     else:
                         generate_legacy_wrapper_function(

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -420,7 +420,7 @@ def generate_function_declaration(fn: FuncIR, emitter: Emitter) -> None:
         '{};'.format(native_function_header(fn.decl, emitter)),
         needs_export=True)
     if fn.name != TOP_LEVEL_NAME:
-        if fn.cname(emitter.names).endswith('__init__'):
+        if fn.cname(emitter.names).endswith(('__init__', '__call__')):
             emitter.context.declarations[PREFIX + fn.cname(emitter.names)] = HeaderDeclaration(
                 '{};'.format(wrapper_function_header(fn, emitter.names)))
         else:
@@ -534,7 +534,7 @@ class GroupGenerator:
                 generate_native_function(fn, emitter, self.source_paths[module_name], module_name)
                 if fn.name != TOP_LEVEL_NAME:
                     emitter.emit_line()
-                    if fn.cname(emitter.names).endswith('__init__'):
+                    if fn.cname(emitter.names).endswith(('__init__', '__call__')):
                         generate_wrapper_function(
                             fn, emitter, self.source_paths[module_name], module_name)
                     else:
@@ -847,7 +847,7 @@ class GroupGenerator:
             if fn.class_name is not None or fn.name == TOP_LEVEL_NAME:
                 continue
             cname = fn.cname(emitter.names)
-            if cname.endswith('__init__'):
+            if cname.endswith(('__init__', '__call__')):
                 emitter.emit_line(
                     ('{{"{name}", (PyCFunction){prefix}{cname}, METH_VARARGS | METH_KEYWORDS, '
                      'NULL /* docstring */}},').format(

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -31,6 +31,7 @@ from mypyc.codegen.emitfunc import generate_native_function, native_function_hea
 from mypyc.codegen.emitclass import generate_class_type_decl, generate_class
 from mypyc.codegen.emitwrapper import (
     generate_wrapper_function, wrapper_function_header,
+    generate_wrapper_function_2, wrapper_function_header_2,
 )
 from mypyc.ir.ops import LiteralsMap, DeserMaps
 from mypyc.ir.rtypes import RType, RTuple
@@ -419,8 +420,12 @@ def generate_function_declaration(fn: FuncIR, emitter: Emitter) -> None:
         '{};'.format(native_function_header(fn.decl, emitter)),
         needs_export=True)
     if fn.name != TOP_LEVEL_NAME:
-        emitter.context.declarations[PREFIX + fn.cname(emitter.names)] = HeaderDeclaration(
-            '{};'.format(wrapper_function_header(fn, emitter.names)))
+        if fn.cname(emitter.names).endswith('__init__'):
+            emitter.context.declarations[PREFIX + fn.cname(emitter.names)] = HeaderDeclaration(
+                '{};'.format(wrapper_function_header(fn, emitter.names)))
+        else:
+            emitter.context.declarations[PREFIX + fn.cname(emitter.names)] = HeaderDeclaration(
+                '{};'.format(wrapper_function_header_2(fn, emitter.names)))
 
 
 def pointerize(decl: str, name: str) -> str:
@@ -529,8 +534,12 @@ class GroupGenerator:
                 generate_native_function(fn, emitter, self.source_paths[module_name], module_name)
                 if fn.name != TOP_LEVEL_NAME:
                     emitter.emit_line()
-                    generate_wrapper_function(
-                        fn, emitter, self.source_paths[module_name], module_name)
+                    if fn.cname(emitter.names).endswith('__init__'):
+                        generate_wrapper_function(
+                            fn, emitter, self.source_paths[module_name], module_name)
+                    else:
+                        generate_wrapper_function_2(
+                            fn, emitter, self.source_paths[module_name], module_name)
 
             if multi_file:
                 name = ('__native_{}.c'.format(emitter.names.private_name(module_name)))
@@ -837,12 +846,21 @@ class GroupGenerator:
         for fn in module.functions:
             if fn.class_name is not None or fn.name == TOP_LEVEL_NAME:
                 continue
-            emitter.emit_line(
-                ('{{"{name}", (PyCFunction){prefix}{cname}, METH_VARARGS | METH_KEYWORDS, '
-                 'NULL /* docstring */}},').format(
-                    name=fn.name,
-                    cname=fn.cname(emitter.names),
-                    prefix=PREFIX))
+            cname = fn.cname(emitter.names)
+            if cname.endswith('__init__'):
+                emitter.emit_line(
+                    ('{{"{name}", (PyCFunction){prefix}{cname}, METH_VARARGS | METH_KEYWORDS, '
+                     'NULL /* docstring */}},').format(
+                         name=fn.name,
+                         cname=cname,
+                         prefix=PREFIX))
+            else:
+                emitter.emit_line(
+                    ('{{"{name}", (PyCFunction){prefix}{cname}, METH_FASTCALL | METH_KEYWORDS, '
+                     'NULL /* docstring */}},').format(
+                         name=fn.name,
+                         cname=cname,
+                         prefix=PREFIX))
         emitter.emit_line('{NULL, NULL, 0, NULL}')
         emitter.emit_line('};')
         emitter.emit_line()

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -420,7 +420,7 @@ def generate_function_declaration(fn: FuncIR, emitter: Emitter) -> None:
         '{};'.format(native_function_header(fn.decl, emitter)),
         needs_export=True)
     if fn.name != TOP_LEVEL_NAME:
-        if fn.cname(emitter.names).endswith(('__init__', '__call__')):
+        if fn.class_name is not None and fn.name in ('__init__', '__call__'):
             emitter.context.declarations[PREFIX + fn.cname(emitter.names)] = HeaderDeclaration(
                 '{};'.format(wrapper_function_header(fn, emitter.names)))
         else:
@@ -534,7 +534,7 @@ class GroupGenerator:
                 generate_native_function(fn, emitter, self.source_paths[module_name], module_name)
                 if fn.name != TOP_LEVEL_NAME:
                     emitter.emit_line()
-                    if fn.cname(emitter.names).endswith(('__init__', '__call__')):
+                    if fn.class_name is not None and fn.name in ('__init__', '__call__'):
                         generate_wrapper_function(
                             fn, emitter, self.source_paths[module_name], module_name)
                     else:

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -23,7 +23,8 @@ from mypyc.irbuild.main import build_ir
 from mypyc.irbuild.prepare import load_type_map
 from mypyc.irbuild.mapper import Mapper
 from mypyc.common import (
-    PREFIX, TOP_LEVEL_NAME, INT_PREFIX, MODULE_PREFIX, RUNTIME_C_FILES, shared_lib_name,
+    PREFIX, TOP_LEVEL_NAME, INT_PREFIX, MODULE_PREFIX, RUNTIME_C_FILES, USE_FASTCALL,
+    shared_lib_name,
 )
 from mypyc.codegen.cstring import encode_as_c_string, encode_bytes_as_c_string
 from mypyc.codegen.emit import EmitterContext, Emitter, HeaderDeclaration
@@ -420,12 +421,12 @@ def generate_function_declaration(fn: FuncIR, emitter: Emitter) -> None:
         '{};'.format(native_function_header(fn.decl, emitter)),
         needs_export=True)
     if fn.name != TOP_LEVEL_NAME:
-        if fn.class_name is not None and fn.name in ('__init__', '__call__'):
-            emitter.context.declarations[PREFIX + fn.cname(emitter.names)] = HeaderDeclaration(
-                '{};'.format(wrapper_function_header(fn, emitter.names)))
-        else:
+        if is_fastcall_supported(fn):
             emitter.context.declarations[PREFIX + fn.cname(emitter.names)] = HeaderDeclaration(
                 '{};'.format(wrapper_function_header_2(fn, emitter.names)))
+        else:
+            emitter.context.declarations[PREFIX + fn.cname(emitter.names)] = HeaderDeclaration(
+                '{};'.format(wrapper_function_header(fn, emitter.names)))
 
 
 def pointerize(decl: str, name: str) -> str:
@@ -534,13 +535,12 @@ class GroupGenerator:
                 generate_native_function(fn, emitter, self.source_paths[module_name], module_name)
                 if fn.name != TOP_LEVEL_NAME:
                     emitter.emit_line()
-                    if fn.class_name is not None and fn.name in ('__init__', '__call__'):
-                        generate_wrapper_function(
-                            fn, emitter, self.source_paths[module_name], module_name)
-                    else:
+                    if is_fastcall_supported(fn):
                         generate_wrapper_function_2(
                             fn, emitter, self.source_paths[module_name], module_name)
-
+                    else:
+                        generate_wrapper_function(
+                            fn, emitter, self.source_paths[module_name], module_name)
             if multi_file:
                 name = ('__native_{}.c'.format(emitter.names.private_name(module_name)))
                 file_contents.append((name, ''.join(emitter.fragments)))
@@ -846,12 +846,17 @@ class GroupGenerator:
         for fn in module.functions:
             if fn.class_name is not None or fn.name == TOP_LEVEL_NAME:
                 continue
+            if is_fastcall_supported(fn):
+                flag = 'METH_FASTCALL'
+            else:
+                flag = 'METH_VARARGS'
             emitter.emit_line(
-                ('{{"{name}", (PyCFunction){prefix}{cname}, METH_FASTCALL | METH_KEYWORDS, '
+                ('{{"{name}", (PyCFunction){prefix}{cname}, {flag} | METH_KEYWORDS, '
                  'NULL /* docstring */}},').format(
                      name=fn.name,
                      cname=fn.cname(emitter.names),
-                     prefix=PREFIX))
+                     prefix=PREFIX,
+                     flag=flag))
         emitter.emit_line('{NULL, NULL, 0, NULL}')
         emitter.emit_line('};')
         emitter.emit_line()
@@ -1063,3 +1068,8 @@ def toposort(deps: Dict[T, Set[T]]) -> List[T]:
         visit(item)
 
     return result
+
+
+def is_fastcall_supported(fn: FuncIR) -> bool:
+    # TODO: Support METH_FASTCALL for all methods.
+    return USE_FASTCALL and (fn.class_name is None or fn.name not in ('__init__', '__call__'))

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -31,7 +31,7 @@ from mypyc.codegen.emit import EmitterContext, Emitter, HeaderDeclaration
 from mypyc.codegen.emitfunc import generate_native_function, native_function_header
 from mypyc.codegen.emitclass import generate_class_type_decl, generate_class
 from mypyc.codegen.emitwrapper import (
-    generate_wrapper_function, wrapper_function_header,
+    generate_legacy_wrapper_function, legacy_wrapper_function_header,
     generate_wrapper_function_2, wrapper_function_header_2,
 )
 from mypyc.ir.ops import LiteralsMap, DeserMaps
@@ -426,7 +426,7 @@ def generate_function_declaration(fn: FuncIR, emitter: Emitter) -> None:
                 '{};'.format(wrapper_function_header_2(fn, emitter.names)))
         else:
             emitter.context.declarations[PREFIX + fn.cname(emitter.names)] = HeaderDeclaration(
-                '{};'.format(wrapper_function_header(fn, emitter.names)))
+                '{};'.format(legacy_wrapper_function_header(fn, emitter.names)))
 
 
 def pointerize(decl: str, name: str) -> str:
@@ -539,7 +539,7 @@ class GroupGenerator:
                         generate_wrapper_function_2(
                             fn, emitter, self.source_paths[module_name], module_name)
                     else:
-                        generate_wrapper_function(
+                        generate_legacy_wrapper_function(
                             fn, emitter, self.source_paths[module_name], module_name)
             if multi_file:
                 name = ('__native_{}.c'.format(emitter.names.private_name(module_name)))

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -359,7 +359,7 @@ def generate_wrapper_function_2(fn: FuncIR,
     arg_names = ''.join('"{}", '.format(arg.name) for arg in reordered_args)
     emitter.emit_line('static const char * const kwlist[] = {{{}0}};'.format(arg_names))
     fmt = make_format_string(fn.name, groups)
-    emitter.emit_line('static _PyArg_Parser parser = {{"{}", kwlist, 0}};'.format(fmt))
+    emitter.emit_line('static CPyArg_Parser parser = {{"{}", kwlist, 0}};'.format(fmt))
     for arg in real_args:
         emitter.emit_line('PyObject *obj_{}{};'.format(
                           arg.name, ' = NULL' if arg.optional else ''))

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -50,7 +50,7 @@ def wrapper_function_header(fn: FuncIR, names: NameGenerator) -> str:
     """
     return (
         'PyObject *{prefix}{name}('
-        'PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)').format(
+        'PyObject *self, PyObject *const *args, size_t nargs, PyObject *kwnames)').format(
             prefix=PREFIX,
             name=fn.cname(names))
 

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -17,7 +17,7 @@ from mypyc.namegen import NameGenerator
 # Vectorcall wrappers (Python 3.7+)
 
 
-def wrapper_function_header_2(fn: FuncIR, names: NameGenerator) -> str:
+def wrapper_function_header(fn: FuncIR, names: NameGenerator) -> str:
     return (
         'PyObject *{prefix}{name}('
         'PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)').format(
@@ -41,16 +41,16 @@ def make_format_string(func_name: str, groups: List[List[RuntimeArg]]) -> str:
     return '{}:{}'.format(main_format, func_name)
 
 
-def generate_wrapper_function_2(fn: FuncIR,
-                                emitter: Emitter,
-                                source_path: str,
-                                module_name: str) -> None:
+def generate_wrapper_function(fn: FuncIR,
+                              emitter: Emitter,
+                              source_path: str,
+                              module_name: str) -> None:
     """Generates a CPython-compatible wrapper function for a native function.
 
     In particular, this handles unboxing the arguments, calling the native function, and
     then boxing the return value.
     """
-    emitter.emit_line('{} {{'.format(wrapper_function_header_2(fn, emitter.names)))
+    emitter.emit_line('{} {{'.format(wrapper_function_header(fn, emitter.names)))
 
     # If we hit an error while processing arguments, then we emit a
     # traceback frame to make it possible to debug where it happened.

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -14,10 +14,15 @@ from mypyc.ir.class_ir import ClassIR
 from mypyc.namegen import NameGenerator
 
 
-def wrapper_function_header(fn: FuncIR, names: NameGenerator) -> str:
-    return 'PyObject *{prefix}{name}(PyObject *self, PyObject *args, PyObject *kw)'.format(
-        prefix=PREFIX,
-        name=fn.cname(names))
+# Vectorcall wrappers (Python 3.7+)
+
+
+def wrapper_function_header_2(fn: FuncIR, names: NameGenerator) -> str:
+    return (
+        'PyObject *{prefix}{name}('
+        'PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)').format(
+            prefix=PREFIX,
+            name=fn.cname(names))
 
 
 def make_format_string(func_name: str, groups: List[List[RuntimeArg]]) -> str:
@@ -36,16 +41,89 @@ def make_format_string(func_name: str, groups: List[List[RuntimeArg]]) -> str:
     return '{}:{}'.format(main_format, func_name)
 
 
-def generate_wrapper_function(fn: FuncIR,
-                              emitter: Emitter,
-                              source_path: str,
-                              module_name: str) -> None:
+def generate_wrapper_function_2(fn: FuncIR,
+                                emitter: Emitter,
+                                source_path: str,
+                                module_name: str) -> None:
     """Generates a CPython-compatible wrapper function for a native function.
 
     In particular, this handles unboxing the arguments, calling the native function, and
     then boxing the return value.
     """
-    emitter.emit_line('{} {{'.format(wrapper_function_header(fn, emitter.names)))
+    emitter.emit_line('{} {{'.format(wrapper_function_header_2(fn, emitter.names)))
+
+    # If we hit an error while processing arguments, then we emit a
+    # traceback frame to make it possible to debug where it happened.
+    # Unlike traceback frames added for exceptions seen in IR, we do this
+    # even if there is no `traceback_name`. This is because the error will
+    # have originated here and so we need it in the traceback.
+    globals_static = emitter.static_name('globals', module_name)
+    traceback_code = 'CPy_AddTraceback("%s", "%s", %d, %s);' % (
+        source_path.replace("\\", "\\\\"),
+        fn.traceback_name or fn.name,
+        fn.line,
+        globals_static)
+
+    # If fn is a method, then the first argument is a self param
+    real_args = list(fn.args)
+    if fn.class_name and not fn.decl.kind == FUNC_STATICMETHOD:
+        arg = real_args.pop(0)
+        emitter.emit_line('PyObject *obj_{} = self;'.format(arg.name))
+
+    # Need to order args as: required, optional, kwonly optional, kwonly required
+    # This is because CPyArg_ParseTupleAndKeywords format string requires
+    # them grouped in that way.
+    groups = [[arg for arg in real_args if arg.kind == k] for k in range(ARG_NAMED_OPT + 1)]
+    reordered_args = groups[ARG_POS] + groups[ARG_OPT] + groups[ARG_NAMED_OPT] + groups[ARG_NAMED]
+
+    arg_names = ''.join('"{}", '.format(arg.name) for arg in reordered_args)
+    emitter.emit_line('static const char * const kwlist[] = {{{}0}};'.format(arg_names))
+    fmt = make_format_string(fn.name, groups)
+    emitter.emit_line('static CPyArg_Parser parser = {{"{}", kwlist, 0}};'.format(fmt))
+    for arg in real_args:
+        emitter.emit_line('PyObject *obj_{}{};'.format(
+                          arg.name, ' = NULL' if arg.optional else ''))
+
+    cleanups = ['CPy_DECREF(obj_{});'.format(arg.name)
+                for arg in groups[ARG_STAR] + groups[ARG_STAR2]]
+
+    arg_ptrs = []  # type: List[str]
+    if groups[ARG_STAR] or groups[ARG_STAR2]:
+        arg_ptrs += ['&obj_{}'.format(groups[ARG_STAR][0].name) if groups[ARG_STAR] else 'NULL']
+        arg_ptrs += ['&obj_{}'.format(groups[ARG_STAR2][0].name) if groups[ARG_STAR2] else 'NULL']
+    arg_ptrs += ['&obj_{}'.format(arg.name) for arg in reordered_args]
+
+    emitter.emit_lines(
+        'if (!CPyArg_ParseStackAndKeywords(args, nargs, kwnames, &parser{})) {{'.format(
+            ''.join(', ' + n for n in arg_ptrs)),
+        'return NULL;',
+        '}')
+    generate_wrapper_core(fn, emitter, groups[ARG_OPT] + groups[ARG_NAMED_OPT],
+                          cleanups=cleanups,
+                          traceback_code=traceback_code)
+
+    emitter.emit_line('}')
+
+
+# Legacy generic wrapper functions
+
+
+def legacy_wrapper_function_header(fn: FuncIR, names: NameGenerator) -> str:
+    return 'PyObject *{prefix}{name}(PyObject *self, PyObject *args, PyObject *kw)'.format(
+        prefix=PREFIX,
+        name=fn.cname(names))
+
+
+def generate_legacy_wrapper_function(fn: FuncIR,
+                                     emitter: Emitter,
+                                     source_path: str,
+                                     module_name: str) -> None:
+    """Generates a CPython-compatible wrapper function for a native function.
+
+    In particular, this handles unboxing the arguments, calling the native function, and
+    then boxing the return value.
+    """
+    emitter.emit_line('{} {{'.format(legacy_wrapper_function_header(fn, emitter.names)))
 
     # If we hit an error while processing arguments, then we emit a
     # traceback frame to make it possible to debug where it happened.
@@ -96,6 +174,9 @@ def generate_wrapper_function(fn: FuncIR,
                           traceback_code=traceback_code)
 
     emitter.emit_line('}')
+
+
+# Specialized wrapper functions
 
 
 def generate_dunder_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
@@ -214,12 +295,16 @@ def generate_bool_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
     return name
 
 
+# Helpers
+
+
 def generate_wrapper_core(fn: FuncIR, emitter: Emitter,
                           optional_args: Optional[List[RuntimeArg]] = None,
                           arg_names: Optional[List[str]] = None,
                           cleanups: Optional[List[str]] = None,
                           traceback_code: Optional[str] = None) -> None:
     """Generates the core part of a wrapper function for a native function.
+
     This expects each argument as a PyObject * named obj_{arg} as a precondition.
     It converts the PyObject *s to the necessary types, checking and unboxing if necessary,
     makes the call, then boxes the result if necessary and returns it.
@@ -292,94 +377,3 @@ def generate_arg_check(name: str, typ: RType, emitter: Emitter,
                               name, name, error_code))
         else:
             emitter.emit_line('if (arg_{} == NULL) {}'.format(name, error_code))
-
-
-# Vectorcall wrappers (Python 3.8+)
-
-
-def wrapper_function_header_2(fn: FuncIR, names: NameGenerator) -> str:
-    return (
-        'PyObject *{prefix}{name}('
-        'PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)').format(
-            prefix=PREFIX,
-            name=fn.cname(names))
-
-
-def make_format_string_2(func_name: str, groups: List[List[RuntimeArg]]) -> str:
-    # Construct the format string. Each group requires the previous
-    # groups delimiters to be present first.
-    main_format = ''
-    if groups[ARG_STAR] or groups[ARG_STAR2]:
-        main_format += '%'
-    main_format += 'O' * len(groups[ARG_POS])
-    if groups[ARG_OPT] or groups[ARG_NAMED_OPT] or groups[ARG_NAMED]:
-        main_format += '|' + 'O' * len(groups[ARG_OPT])
-    if groups[ARG_NAMED_OPT] or groups[ARG_NAMED]:
-        main_format += '$' + 'O' * len(groups[ARG_NAMED_OPT])
-    if groups[ARG_NAMED]:
-        main_format += '@' + 'O' * len(groups[ARG_NAMED])
-    return '{}:{}'.format(main_format, func_name)
-
-
-def generate_wrapper_function_2(fn: FuncIR,
-                                emitter: Emitter,
-                                source_path: str,
-                                module_name: str) -> None:
-    """Generates a CPython-compatible wrapper function for a native function.
-
-    In particular, this handles unboxing the arguments, calling the native function, and
-    then boxing the return value.
-    """
-    emitter.emit_line('{} {{'.format(wrapper_function_header_2(fn, emitter.names)))
-
-    # If we hit an error while processing arguments, then we emit a
-    # traceback frame to make it possible to debug where it happened.
-    # Unlike traceback frames added for exceptions seen in IR, we do this
-    # even if there is no `traceback_name`. This is because the error will
-    # have originated here and so we need it in the traceback.
-    globals_static = emitter.static_name('globals', module_name)
-    traceback_code = 'CPy_AddTraceback("%s", "%s", %d, %s);' % (
-        source_path.replace("\\", "\\\\"),
-        fn.traceback_name or fn.name,
-        fn.line,
-        globals_static)
-
-    # If fn is a method, then the first argument is a self param
-    real_args = list(fn.args)
-    if fn.class_name and not fn.decl.kind == FUNC_STATICMETHOD:
-        arg = real_args.pop(0)
-        emitter.emit_line('PyObject *obj_{} = self;'.format(arg.name))
-
-    # Need to order args as: required, optional, kwonly optional, kwonly required
-    # This is because CPyArg_ParseTupleAndKeywords format string requires
-    # them grouped in that way.
-    groups = [[arg for arg in real_args if arg.kind == k] for k in range(ARG_NAMED_OPT + 1)]
-    reordered_args = groups[ARG_POS] + groups[ARG_OPT] + groups[ARG_NAMED_OPT] + groups[ARG_NAMED]
-
-    arg_names = ''.join('"{}", '.format(arg.name) for arg in reordered_args)
-    emitter.emit_line('static const char * const kwlist[] = {{{}0}};'.format(arg_names))
-    fmt = make_format_string(fn.name, groups)
-    emitter.emit_line('static CPyArg_Parser parser = {{"{}", kwlist, 0}};'.format(fmt))
-    for arg in real_args:
-        emitter.emit_line('PyObject *obj_{}{};'.format(
-                          arg.name, ' = NULL' if arg.optional else ''))
-
-    cleanups = ['CPy_DECREF(obj_{});'.format(arg.name)
-                for arg in groups[ARG_STAR] + groups[ARG_STAR2]]
-
-    arg_ptrs = []  # type: List[str]
-    if groups[ARG_STAR] or groups[ARG_STAR2]:
-        arg_ptrs += ['&obj_{}'.format(groups[ARG_STAR][0].name) if groups[ARG_STAR] else 'NULL']
-        arg_ptrs += ['&obj_{}'.format(groups[ARG_STAR2][0].name) if groups[ARG_STAR2] else 'NULL']
-    arg_ptrs += ['&obj_{}'.format(arg.name) for arg in reordered_args]
-
-    emitter.emit_lines(
-        'if (!CPyArg_ParseStackAndKeywords(args, nargs, kwnames, &parser{})) {{'.format(
-            ''.join(', ' + n for n in arg_ptrs)),
-        'return NULL;',
-        '}')
-    generate_wrapper_core(fn, emitter, groups[ARG_OPT] + groups[ARG_NAMED_OPT],
-                          cleanups=cleanups,
-                          traceback_code=traceback_code)
-
-    emitter.emit_line('}')

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -54,6 +54,7 @@ MAX_LITERAL_SHORT_INT = (sys.maxsize >> 1 if not IS_MIXED_32_64_BIT_BUILD
 RUNTIME_C_FILES = [
     'init.c',
     'getargs.c',
+    'getargsfast.c',
     'int_ops.c',
     'list_ops.c',
     'dict_ops.c',

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -50,6 +50,9 @@ MAX_SHORT_INT = sys.maxsize >> 1  # type: Final
 MAX_LITERAL_SHORT_INT = (sys.maxsize >> 1 if not IS_MIXED_32_64_BIT_BUILD
                          else 2**30 - 1)  # type: Final
 
+# We can use faster wrapper functions on Python 3.7+ (fastcall/vectorcall).
+USE_FASTCALL = sys.version_info >= (3, 7)
+
 # Runtime C library files
 RUNTIME_C_FILES = [
     'init.c',

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -472,6 +472,7 @@ typedef struct CPyArg_Parser {
     int max;               /* maximal number of positional arguments */
     int has_required_kws;  /* are there any keyword-only arguments? */
     int required_kwonly_start;
+    int varargs;           /* does the function accept *args or **kwargs? */
     PyObject *kwtuple;     /* tuple of keyword parameter names */
     struct CPyArg_Parser *next;
 } CPyArg_Parser;

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -467,10 +467,12 @@ typedef struct CPyArg_Parser {
     const char * const *keywords;
     const char *fname;
     const char *custom_msg;
-    int pos;            /* number of positional-only arguments */
-    int min;            /* minimal number of arguments */
-    int max;            /* maximal number of positional arguments */
-    PyObject *kwtuple;  /* tuple of keyword parameter names */
+    int pos;               /* number of positional-only arguments */
+    int min;               /* minimal number of arguments */
+    int max;               /* maximal number of positional arguments */
+    int has_required_kws;  /* are there any keyword-only arguments? */
+    int required_kwonly_start;
+    PyObject *kwtuple;     /* tuple of keyword parameter names */
     struct CPyArg_Parser *next;
 } CPyArg_Parser;
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -511,7 +511,7 @@ CPyTagged CPyTagged_Id(PyObject *o);
 void CPyDebug_Print(const char *msg);
 void CPy_Init(void);
 int CPyArg_ParseTupleAndKeywords(PyObject *, PyObject *,
-                                 const char *, char **, ...);
+                                 const char *, const char * const *, ...);
 int CPyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
                                  CPyArg_Parser *parser, ...);
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -461,6 +461,18 @@ void CPy_AddTraceback(const char *filename, const char *funcname, int line, PyOb
 #define CPy_TRASHCAN_END(op) Py_TRASHCAN_SAFE_END(op)
 #endif
 
+// Tweaked version of _PyArg_Parser in CPython
+typedef struct CPyArg_Parser {
+    const char *format;
+    const char * const *keywords;
+    const char *fname;
+    const char *custom_msg;
+    int pos;            /* number of positional-only arguments */
+    int min;            /* minimal number of arguments */
+    int max;            /* maximal number of positional arguments */
+    PyObject *kwtuple;  /* tuple of keyword parameter names */
+    struct CPyArg_Parser *next;
+} CPyArg_Parser;
 
 // mypy lets ints silently coerce to floats, so a mypyc runtime float
 // might be an int also
@@ -498,7 +510,7 @@ void CPy_Init(void);
 int CPyArg_ParseTupleAndKeywords(PyObject *, PyObject *,
                                  const char *, char **, ...);
 int CPyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
-                                 struct _PyArg_Parser *parser, ...);
+                                 CPyArg_Parser *parser, ...);
 
 int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected);
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -497,6 +497,9 @@ void CPyDebug_Print(const char *msg);
 void CPy_Init(void);
 int CPyArg_ParseTupleAndKeywords(PyObject *, PyObject *,
                                  const char *, char **, ...);
+int CPyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                                 struct _PyArg_Parser *parser, ...);
+
 int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected);
 
 

--- a/mypyc/lib-rt/getargs.c
+++ b/mypyc/lib-rt/getargs.c
@@ -58,9 +58,9 @@
 extern "C" {
 #endif
 int CPyArg_ParseTupleAndKeywords(PyObject *, PyObject *,
-                                 const char *, char **, ...);
+                                 const char *, const char * const *, ...);
 int CPyArg_VaParseTupleAndKeywords(PyObject *, PyObject *,
-                                   const char *, char **, va_list);
+                                   const char *, const char * const *, va_list);
 
 
 #define FLAG_COMPAT 1
@@ -98,7 +98,7 @@ static Py_ssize_t convertbuffer(PyObject *, const void **p, const char **);
 static int getbuffer(PyObject *, Py_buffer *, const char**);
 
 static int vgetargskeywords(PyObject *, PyObject *,
-                            const char *, char **, va_list *, int);
+                            const char *, const char * const *, va_list *, int);
 static const char *skipitem(const char **, va_list *, int);
 
 /* Handle cleanup of allocated memory in case of exception */
@@ -1135,7 +1135,7 @@ int
 CPyArg_ParseTupleAndKeywords(PyObject *args,
                              PyObject *keywords,
                              const char *format,
-                             char **kwlist, ...)
+                             const char * const *kwlist, ...)
 {
     int retval;
     va_list va;
@@ -1160,7 +1160,7 @@ int
 CPyArg_VaParseTupleAndKeywords(PyObject *args,
                                PyObject *keywords,
                                const char *format,
-                               char **kwlist, va_list va)
+                               const char * const *kwlist, va_list va)
 {
     int retval;
     va_list lva;
@@ -1185,7 +1185,7 @@ CPyArg_VaParseTupleAndKeywords(PyObject *args,
 
 static int
 vgetargskeywords(PyObject *args, PyObject *kwargs, const char *format,
-                 char **kwlist, va_list *p_va, int flags)
+                 const char * const *kwlist, va_list *p_va, int flags)
 {
     char msgbuf[512];
     int levels[32];

--- a/mypyc/lib-rt/getargsfast.c
+++ b/mypyc/lib-rt/getargsfast.c
@@ -18,6 +18,8 @@
 #include <Python.h>
 #include "CPy.h"
 
+#if PY_VERSION_HEX >= 0x03070000
+
 #define FLAG_SIZE_T 2
 
 typedef int (*destr_t)(PyObject *, void *);
@@ -702,3 +704,5 @@ convertsimple_fast(PyObject *arg, const char **p_format, va_list *p_va, int flag
     *p_format = format;
     return NULL;
 }
+
+#endif

--- a/mypyc/lib-rt/getargsfast.c
+++ b/mypyc/lib-rt/getargsfast.c
@@ -1,4 +1,5 @@
 #include <Python.h>
+#include "CPy.h"
 
 #define FLAG_SIZE_T 2
 
@@ -25,7 +26,7 @@ typedef struct {
 static int
 vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
                           PyObject *kwargs, PyObject *kwnames,
-                          struct _PyArg_Parser *parser,
+                          CPyArg_Parser *parser,
                           va_list *p_va, int flags);
 static const char *skipitem_fast(const char **, va_list *, int);
 static void seterror_fast(Py_ssize_t, const char *, int *, const char *, const char *);
@@ -36,7 +37,7 @@ static const char *convertsimple_fast(PyObject *, const char **, va_list *, int,
 
 int
 CPyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
-                             struct _PyArg_Parser *parser, ...)
+                             CPyArg_Parser *parser, ...)
 {
     int retval;
     va_list va;
@@ -70,10 +71,10 @@ cleanreturn_fast(int retval, freelist_fast_t *freelist)
 
 
 /* List of static parsers. */
-static struct _PyArg_Parser *static_arg_parsers = NULL;
+static struct CPyArg_Parser *static_arg_parsers = NULL;
 
 static int
-parser_init(struct _PyArg_Parser *parser)
+parser_init(CPyArg_Parser *parser)
 {
     const char * const *keywords;
     const char *format, *msg;
@@ -230,7 +231,7 @@ find_keyword(PyObject *kwnames, PyObject *const *kwstack, PyObject *key)
 static int
 vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
                           PyObject *kwargs, PyObject *kwnames,
-                          struct _PyArg_Parser *parser,
+                          CPyArg_Parser *parser,
                           va_list *p_va, int flags)
 {
     PyObject *kwtuple;

--- a/mypyc/lib-rt/getargsfast.c
+++ b/mypyc/lib-rt/getargsfast.c
@@ -4,10 +4,10 @@
  * We also add support for required kwonly args and accepting *args / **kwargs.
  *
  * DOCUMENTATION OF THE EXTENSIONS:
- *  - Arguments given after a @ format specify are required keyword-only arguments.
+ *  - Arguments given after a @ format specify required keyword-only arguments.
  *    The | and $ specifiers must both appear before @.
  *  - If the first character of a format string is %, then the function can support
- *    *args and **kwargs. In this case the parser will consume two arguments,
+ *    *args and/or **kwargs. In this case the parser will consume two arguments,
  *    which should be pointers to variables to store the *args and **kwargs, respectively.
  *    Either pointer can be NULL, in which case the function doesn't take that
  *    variety of vararg.
@@ -18,6 +18,7 @@
 #include <Python.h>
 #include "CPy.h"
 
+/* None of this is supported on Python 3.6 or earlier */
 #if PY_VERSION_HEX >= 0x03070000
 
 #define FLAG_SIZE_T 2

--- a/mypyc/lib-rt/getargsfast.c
+++ b/mypyc/lib-rt/getargsfast.c
@@ -1,0 +1,408 @@
+#include <Python.h>
+
+static int
+vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
+                          PyObject *kwargs, PyObject *kwnames,
+                          struct _PyArg_Parser *parser,
+                          va_list *p_va, int flags);
+
+int
+_PyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                  struct _PyArg_Parser *parser, ...)
+{
+    int retval;
+    va_list va;
+
+    va_start(va, parser);
+    retval = vgetargskeywordsfast_impl(args, nargs, NULL, kwnames, parser, &va, 0);
+    va_end(va);
+    return retval;
+}
+
+
+/* List of static parsers. */
+static struct _PyArg_Parser *static_arg_parsers = NULL;
+
+static int
+parser_init(struct _PyArg_Parser *parser)
+{
+    const char * const *keywords;
+    const char *format, *msg;
+    int i, len, min, max, nkw;
+    PyObject *kwtuple;
+
+    assert(parser->keywords != NULL);
+    if (parser->kwtuple != NULL) {
+        return 1;
+    }
+
+    keywords = parser->keywords;
+    /* scan keywords and count the number of positional-only parameters */
+    for (i = 0; keywords[i] && !*keywords[i]; i++) {
+    }
+    parser->pos = i;
+    /* scan keywords and get greatest possible nbr of args */
+    for (; keywords[i]; i++) {
+        if (!*keywords[i]) {
+            PyErr_SetString(PyExc_SystemError,
+                            "Empty keyword parameter name");
+            return 0;
+        }
+    }
+    len = i;
+
+    format = parser->format;
+    if (format) {
+        /* grab the function name or custom error msg first (mutually exclusive) */
+        parser->fname = strchr(parser->format, ':');
+        if (parser->fname) {
+            parser->fname++;
+            parser->custom_msg = NULL;
+        }
+        else {
+            parser->custom_msg = strchr(parser->format,';');
+            if (parser->custom_msg)
+                parser->custom_msg++;
+        }
+
+        min = max = INT_MAX;
+        for (i = 0; i < len; i++) {
+            if (*format == '|') {
+                if (min != INT_MAX) {
+                    PyErr_SetString(PyExc_SystemError,
+                                    "Invalid format string (| specified twice)");
+                    return 0;
+                }
+                if (max != INT_MAX) {
+                    PyErr_SetString(PyExc_SystemError,
+                                    "Invalid format string ($ before |)");
+                    return 0;
+                }
+                min = i;
+                format++;
+            }
+            if (*format == '$') {
+                if (max != INT_MAX) {
+                    PyErr_SetString(PyExc_SystemError,
+                                    "Invalid format string ($ specified twice)");
+                    return 0;
+                }
+                if (i < parser->pos) {
+                    PyErr_SetString(PyExc_SystemError,
+                                    "Empty parameter name after $");
+                    return 0;
+                }
+                max = i;
+                format++;
+            }
+            if (IS_END_OF_FORMAT(*format)) {
+                PyErr_Format(PyExc_SystemError,
+                            "More keyword list entries (%d) than "
+                            "format specifiers (%d)", len, i);
+                return 0;
+            }
+
+            msg = skipitem(&format, NULL, 0);
+            if (msg) {
+                PyErr_Format(PyExc_SystemError, "%s: '%s'", msg,
+                            format);
+                return 0;
+            }
+        }
+        parser->min = Py_MIN(min, len);
+        parser->max = Py_MIN(max, len);
+
+        if (!IS_END_OF_FORMAT(*format) && (*format != '|') && (*format != '$')) {
+            PyErr_Format(PyExc_SystemError,
+                "more argument specifiers than keyword list entries "
+                "(remaining format:'%s')", format);
+            return 0;
+        }
+    }
+
+    nkw = len - parser->pos;
+    kwtuple = PyTuple_New(nkw);
+    if (kwtuple == NULL) {
+        return 0;
+    }
+    keywords = parser->keywords + parser->pos;
+    for (i = 0; i < nkw; i++) {
+        PyObject *str = PyUnicode_FromString(keywords[i]);
+        if (str == NULL) {
+            Py_DECREF(kwtuple);
+            return 0;
+        }
+        PyUnicode_InternInPlace(&str);
+        PyTuple_SET_ITEM(kwtuple, i, str);
+    }
+    parser->kwtuple = kwtuple;
+
+    assert(parser->next == NULL);
+    parser->next = static_arg_parsers;
+    static_arg_parsers = parser;
+    return 1;
+}
+
+static PyObject*
+find_keyword(PyObject *kwnames, PyObject *const *kwstack, PyObject *key)
+{
+    Py_ssize_t i, nkwargs;
+
+    nkwargs = PyTuple_GET_SIZE(kwnames);
+    for (i = 0; i < nkwargs; i++) {
+        PyObject *kwname = PyTuple_GET_ITEM(kwnames, i);
+
+        /* kwname == key will normally find a match in since keyword keys
+           should be interned strings; if not retry below in a new loop. */
+        if (kwname == key) {
+            return kwstack[i];
+        }
+    }
+
+    for (i = 0; i < nkwargs; i++) {
+        PyObject *kwname = PyTuple_GET_ITEM(kwnames, i);
+        assert(PyUnicode_Check(kwname));
+        if (_PyUnicode_EQ(kwname, key)) {
+            return kwstack[i];
+        }
+    }
+    return NULL;
+}
+
+static int
+vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
+                          PyObject *kwargs, PyObject *kwnames,
+                          struct _PyArg_Parser *parser,
+                          va_list *p_va, int flags)
+{
+    PyObject *kwtuple;
+    char msgbuf[512];
+    int levels[32];
+    const char *format;
+    const char *msg;
+    PyObject *keyword;
+    int i, pos, len;
+    Py_ssize_t nkwargs;
+    PyObject *current_arg;
+    freelistentry_t static_entries[STATIC_FREELIST_ENTRIES];
+    freelist_t freelist;
+    PyObject *const *kwstack = NULL;
+
+    freelist.entries = static_entries;
+    freelist.first_available = 0;
+    freelist.entries_malloced = 0;
+
+    assert(kwargs == NULL || PyDict_Check(kwargs));
+    assert(kwargs == NULL || kwnames == NULL);
+    assert(p_va != NULL);
+
+    if (parser == NULL) {
+        PyErr_BadInternalCall();
+        return 0;
+    }
+
+    if (kwnames != NULL && !PyTuple_Check(kwnames)) {
+        PyErr_BadInternalCall();
+        return 0;
+    }
+
+    if (!parser_init(parser)) {
+        return 0;
+    }
+
+    kwtuple = parser->kwtuple;
+    pos = parser->pos;
+    len = pos + (int)PyTuple_GET_SIZE(kwtuple);
+
+    if (len > STATIC_FREELIST_ENTRIES) {
+        freelist.entries = PyMem_NEW(freelistentry_t, len);
+        if (freelist.entries == NULL) {
+            PyErr_NoMemory();
+            return 0;
+        }
+        freelist.entries_malloced = 1;
+    }
+
+    if (kwargs != NULL) {
+        nkwargs = PyDict_GET_SIZE(kwargs);
+    }
+    else if (kwnames != NULL) {
+        nkwargs = PyTuple_GET_SIZE(kwnames);
+        kwstack = args + nargs;
+    }
+    else {
+        nkwargs = 0;
+    }
+    if (nargs + nkwargs > len) {
+        /* Adding "keyword" (when nargs == 0) prevents producing wrong error
+           messages in some special cases (see bpo-31229). */
+        PyErr_Format(PyExc_TypeError,
+                     "%.200s%s takes at most %d %sargument%s (%zd given)",
+                     (parser->fname == NULL) ? "function" : parser->fname,
+                     (parser->fname == NULL) ? "" : "()",
+                     len,
+                     (nargs == 0) ? "keyword " : "",
+                     (len == 1) ? "" : "s",
+                     nargs + nkwargs);
+        return cleanreturn(0, &freelist);
+    }
+    if (parser->max < nargs) {
+        if (parser->max == 0) {
+            PyErr_Format(PyExc_TypeError,
+                         "%.200s%s takes no positional arguments",
+                         (parser->fname == NULL) ? "function" : parser->fname,
+                         (parser->fname == NULL) ? "" : "()");
+        }
+        else {
+            PyErr_Format(PyExc_TypeError,
+                         "%.200s%s takes %s %d positional argument%s (%zd given)",
+                         (parser->fname == NULL) ? "function" : parser->fname,
+                         (parser->fname == NULL) ? "" : "()",
+                         (parser->min < parser->max) ? "at most" : "exactly",
+                         parser->max,
+                         parser->max == 1 ? "" : "s",
+                         nargs);
+        }
+        return cleanreturn(0, &freelist);
+    }
+
+    format = parser->format;
+    /* convert tuple args and keyword args in same loop, using kwtuple to drive process */
+    for (i = 0; i < len; i++) {
+        if (*format == '|') {
+            format++;
+        }
+        if (*format == '$') {
+            format++;
+        }
+        assert(!IS_END_OF_FORMAT(*format));
+
+        if (i < nargs) {
+            current_arg = args[i];
+        }
+        else if (nkwargs && i >= pos) {
+            keyword = PyTuple_GET_ITEM(kwtuple, i - pos);
+            if (kwargs != NULL) {
+                current_arg = PyDict_GetItemWithError(kwargs, keyword);
+                if (!current_arg && PyErr_Occurred()) {
+                    return cleanreturn(0, &freelist);
+                }
+            }
+            else {
+                current_arg = find_keyword(kwnames, kwstack, keyword);
+            }
+            if (current_arg) {
+                --nkwargs;
+            }
+        }
+        else {
+            current_arg = NULL;
+        }
+
+        if (current_arg) {
+            msg = convertitem(current_arg, &format, p_va, flags,
+                levels, msgbuf, sizeof(msgbuf), &freelist);
+            if (msg) {
+                seterror(i+1, msg, levels, parser->fname, parser->custom_msg);
+                return cleanreturn(0, &freelist);
+            }
+            continue;
+        }
+
+        if (i < parser->min) {
+            /* Less arguments than required */
+            if (i < pos) {
+                Py_ssize_t min = Py_MIN(pos, parser->min);
+                PyErr_Format(PyExc_TypeError,
+                             "%.200s%s takes %s %d positional argument%s"
+                             " (%zd given)",
+                             (parser->fname == NULL) ? "function" : parser->fname,
+                             (parser->fname == NULL) ? "" : "()",
+                             min < parser->max ? "at least" : "exactly",
+                             min,
+                             min == 1 ? "" : "s",
+                             nargs);
+            }
+            else {
+                keyword = PyTuple_GET_ITEM(kwtuple, i - pos);
+                PyErr_Format(PyExc_TypeError,  "%.200s%s missing required "
+                             "argument '%U' (pos %d)",
+                             (parser->fname == NULL) ? "function" : parser->fname,
+                             (parser->fname == NULL) ? "" : "()",
+                             keyword, i+1);
+            }
+            return cleanreturn(0, &freelist);
+        }
+        /* current code reports success when all required args
+         * fulfilled and no keyword args left, with no further
+         * validation. XXX Maybe skip this in debug build ?
+         */
+        if (!nkwargs) {
+            return cleanreturn(1, &freelist);
+        }
+
+        /* We are into optional args, skip through to any remaining
+         * keyword args */
+        msg = skipitem(&format, p_va, flags);
+        assert(msg == NULL);
+    }
+
+    assert(IS_END_OF_FORMAT(*format) || (*format == '|') || (*format == '$'));
+
+    if (nkwargs > 0) {
+        Py_ssize_t j;
+        /* make sure there are no arguments given by name and position */
+        for (i = pos; i < nargs; i++) {
+            keyword = PyTuple_GET_ITEM(kwtuple, i - pos);
+            if (kwargs != NULL) {
+                current_arg = PyDict_GetItemWithError(kwargs, keyword);
+                if (!current_arg && PyErr_Occurred()) {
+                    return cleanreturn(0, &freelist);
+                }
+            }
+            else {
+                current_arg = find_keyword(kwnames, kwstack, keyword);
+            }
+            if (current_arg) {
+                /* arg present in tuple and in dict */
+                PyErr_Format(PyExc_TypeError,
+                             "argument for %.200s%s given by name ('%U') "
+                             "and position (%d)",
+                             (parser->fname == NULL) ? "function" : parser->fname,
+                             (parser->fname == NULL) ? "" : "()",
+                             keyword, i+1);
+                return cleanreturn(0, &freelist);
+            }
+        }
+        /* make sure there are no extraneous keyword arguments */
+        j = 0;
+        while (1) {
+            int match;
+            if (kwargs != NULL) {
+                if (!PyDict_Next(kwargs, &j, &keyword, NULL))
+                    break;
+            }
+            else {
+                if (j >= PyTuple_GET_SIZE(kwnames))
+                    break;
+                keyword = PyTuple_GET_ITEM(kwnames, j);
+                j++;
+            }
+
+            match = PySequence_Contains(kwtuple, keyword);
+            if (match <= 0) {
+                if (!match) {
+                    PyErr_Format(PyExc_TypeError,
+                                 "'%S' is an invalid keyword "
+                                 "argument for %.200s%s",
+                                 keyword,
+                                 (parser->fname == NULL) ? "this function" : parser->fname,
+                                 (parser->fname == NULL) ? "" : "()");
+                }
+                return cleanreturn(0, &freelist);
+            }
+        }
+    }
+
+    return cleanreturn(1, &freelist);
+}

--- a/mypyc/lib-rt/getargsfast.c
+++ b/mypyc/lib-rt/getargsfast.c
@@ -7,8 +7,8 @@ vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
                           va_list *p_va, int flags);
 
 int
-_PyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
-                  struct _PyArg_Parser *parser, ...)
+CPyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                             struct _PyArg_Parser *parser, ...)
 {
     int retval;
     va_list va;

--- a/mypyc/lib-rt/getargsfast.c
+++ b/mypyc/lib-rt/getargsfast.c
@@ -1,3 +1,20 @@
+/* getargskeywordsfast implementation copied from Python 3.9 and stripped down to
+ * only include the functionality we need.
+ *
+ * We also add support for required kwonly args and accepting *args / **kwargs.
+ *
+ * DOCUMENTATION OF THE EXTENSIONS:
+ *  - Arguments given after a @ format specify are required keyword-only arguments.
+ *    The | and $ specifiers must both appear before @.
+ *  - If the first character of a format string is %, then the function can support
+ *    *args and **kwargs. In this case the parser will consume two arguments,
+ *    which should be pointers to variables to store the *args and **kwargs, respectively.
+ *    Either pointer can be NULL, in which case the function doesn't take that
+ *    variety of vararg.
+ *    Unlike most format specifiers, the caller takes ownership of these objects
+ *    and is responsible for decrefing them.
+ */
+
 #include <Python.h>
 #include "CPy.h"
 


### PR DESCRIPTION
Implement faster argument parsing based on METH_FASTCALL on supported
Python versions. 

Use `vgetargskeywordsfast` extracted from Python 3.9 with some modifications:
* Support required keyword-only arguments, `*args` and `**kwargs`
* Only support the 'O' type (to reduce code size and speed things up)

The modifications are very similar to what we have in the old-style
argument parsing logic.

The legacy calling convention is still used for `__init__` and `__call__`. I'll add
`__call__`  support in a separate PR. I haven't looked into supporting `__init__`
yet.

Here are some benchmark results (on Python 3.8)
* keyword_args_from_interpreted: 3.5x faster than before
* positional_args_from_interpreted: 1.4x faster than before

However, the above benchmarks are still slower when compiled. I'll continue 
working on further improvements after this PR.

Fixes mypyc/mypyc#578.