### PR TITLE
Fixed Any and Dict missing from stubgen imports list

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -20,7 +20,7 @@ from mypy.stubdoc import (
 
 # Members of the typing module to consider for importing by default.
 _DEFAULT_TYPING_IMPORTS = (
-    'Any'
+    'Any',
     'Dict',
     'Iterable',
     'Iterator',


### PR DESCRIPTION
### Description

This fixes an issue introduced in https://github.com/python/mypy/pull/9088/files where `Any` and `Dict` are missing from the list of default imports that stubgen can perform, due to a missing comma.

## Test Plan

Because this is such a small change I just did a quick manual test by using stubgen on a module that uses both `Any` and `Dict`.