### PR TITLE
[WIP] Add get_function_decorator_plugin_hook to plugin interface

### DIFF
--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -730,3 +730,40 @@ reveal_type(dynamic_signature(1))  # N: Revealed type is 'builtins.int'
 [file mypy.ini]
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/function_sig_hook.py
+
+[case testFunctionDecoratorPluginHookForFunction]
+# flags: --config-file tmp/mypy.ini
+
+from m import decorator
+
+@decorator
+def function(self) -> str: ...
+
+@function.setter
+def function(self, value: str) -> None: ...
+
+[file m.py]
+from typing import Callable
+def decorator(param) -> Callable[..., str]: pass
+[file mypy.ini]
+\[mypy]
+plugins=<ROOT>/test-data/unit/plugins/function_decorator_hook.py
+
+[case testFunctionDecoratorPluginHookForMethod]
+# flags: --config-file tmp/mypy.ini
+
+from m import decorator
+
+class A:
+    @decorator
+    def property(self) -> str: ...
+
+    @property.setter
+    def property(self, value: str) -> None: ...
+
+[file m.py]
+from typing import Callable
+def decorator(param) -> Callable[..., str]: pass
+[file mypy.ini]
+\[mypy]
+plugins=<ROOT>/test-data/unit/plugins/function_decorator_hook.py

--- a/test-data/unit/plugins/function_decorator_hook.py
+++ b/test-data/unit/plugins/function_decorator_hook.py
@@ -1,0 +1,19 @@
+from mypy.plugin import Plugin, FunctionDecoratorContext
+
+
+class FunctionDecoratorPlugin(Plugin):
+    def get_function_decorator_hook(self, fullname):
+        if fullname == 'm.decorator':
+            return my_hook
+        return None
+
+
+def my_hook(ctx: FunctionDecoratorContext) -> bool:
+    ctx.decoratedFunction.func.is_property = True
+    ctx.decoratedFunction.var.is_property = True
+
+    return True
+
+
+def plugin(version):
+    return FunctionDecoratorPlugin

--- a/test_pyqt/mypy.ini
+++ b/test_pyqt/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+plugins = pyqt5.py

--- a/test_pyqt/pyqt5.py
+++ b/test_pyqt/pyqt5.py
@@ -1,0 +1,24 @@
+from typing import Callable, Optional
+from typing import Type
+
+from mypy.plugin import (
+    Plugin, FunctionDecoratorContext,
+)
+
+
+def plugin(version: str) -> Type[Plugin]:
+    return PyQt5Plugin
+
+
+class PyQt5Plugin(Plugin):
+    """PyQt5 Plugin"""
+
+    def get_function_decorator_hook(self, fullname: str
+                                    ) -> Optional[Callable[[FunctionDecoratorContext], None]]:
+        if fullname == 'PyQt5.QtCore.pyqtProperty':
+            return pyqt_property_callback
+        return None
+
+
+def pyqt_property_callback(ctx: FunctionDecoratorContext):
+    ctx.decoratedFunction.func.is_property = True

--- a/test_pyqt/pyqttest.py
+++ b/test_pyqt/pyqttest.py
@@ -1,0 +1,22 @@
+import typing
+
+from PyQt5.QtCore import QObject, pyqtProperty, pyqtSignal
+
+
+@typing.final
+class FeatureModel(QObject):
+
+    stateChanged = pyqtSignal()
+
+    def __init__(self, enabled: bool, /) -> None:
+        super().__init__()
+        self._enabled = enabled
+
+    @pyqtProperty(bool, notify=stateChanged)
+    def enabled(self):
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, enabled):
+        self._enabled = enabled
+        self.stateChanged.emit()


### PR DESCRIPTION
### Description

This PR adds the plugin hook I proposes in #9915.

### Test Strategy

Two new unit tests have been added to test the new plugin hook

### Q&A

#### Why is this plugin hook needed?:
This hook can be used to solve problems like for example #9911, which can't be solved by existing plugin hooks.
There is already a plugin hook for handling class decorators, but none for method and function decorators.

#### Why is there no `get_method_decorator_plugin_hook`?:
From what I can tell the semantic analysis phase doesn't distinguish between functions and methods. Therefor only one hook has been added. The other hooks, which have `function` and `method` variants tun during the checking phase.

#### What can this hook do?
Mark decorated functions as properties, abstract, final and coroutines

#### What can't this hook do?
This hook currently can't disable type checking for decorated functions, despite the builtin '@typing.no_type_check' decorator being able to do so. Enabling this would require more code changes, as a local variable is used for this ad would have to be exposed in some way.

#### When does this hook run?
This hook runs after the builtin code has handled the decorators, but before handled decorators are removes and the decorated function is semantically analyzed.

## Additional considerations

* Make it possible for plugins to disable type checking for a function
* Expose `SematicAnalyzer.check_decorated_function_is_method` on the `SemanticAnalyzerPluginInterface`