### PR TITLE
[mypyc] Add fast path for simple calls in wrapper functions

### DIFF
--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -162,8 +162,16 @@ def generate_wrapper_function(fn: FuncIR,
     else:
         nargs = 'nargs'
     parse_fn = 'CPyArg_ParseStackAndKeywords'
-    if len(real_args) == 1 and len(groups[ARG_POS]) == 1:
+    # Special case some common signatures
+    if len(real_args) == 0:
+        # No args
+        parse_fn = 'CPyArg_ParseStackAndKeywords_0'
+    elif len(real_args) == 1 and len(groups[ARG_POS]) == 1:
+        # Single positional arg
         parse_fn = 'CPyArg_ParseStackAndKeywords_1'
+    elif len(real_args) == len(groups[ARG_POS]) + len(groups[ARG_OPT]):
+        # No keyword-only args, *args or **kwargs
+        parse_fn = 'CPyArg_ParseStackAndKeywords_N'
     emitter.emit_lines(
         'if (!{}(args, {}, kwnames, &parser{})) {{'.format(
             parse_fn, nargs, ''.join(', ' + n for n in arg_ptrs)),

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -165,13 +165,13 @@ def generate_wrapper_function(fn: FuncIR,
     # Special case some common signatures
     if len(real_args) == 0:
         # No args
-        parse_fn = 'CPyArg_ParseStackAndKeywords_0'
+        parse_fn = 'CPyArg_ParseStackAndKeywordsNoArgs'
     elif len(real_args) == 1 and len(groups[ARG_POS]) == 1:
         # Single positional arg
-        parse_fn = 'CPyArg_ParseStackAndKeywords_1'
+        parse_fn = 'CPyArg_ParseStackAndKeywordsOneArg'
     elif len(real_args) == len(groups[ARG_POS]) + len(groups[ARG_OPT]):
         # No keyword-only args, *args or **kwargs
-        parse_fn = 'CPyArg_ParseStackAndKeywords_N'
+        parse_fn = 'CPyArg_ParseStackAndKeywordsSimple'
     emitter.emit_lines(
         'if (!{}(args, {}, kwnames, &parser{})) {{'.format(
             parse_fn, nargs, ''.join(', ' + n for n in arg_ptrs)),

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -161,9 +161,12 @@ def generate_wrapper_function(fn: FuncIR,
         nargs = 'PyVectorcall_NARGS(nargs)'
     else:
         nargs = 'nargs'
+    parse_fn = 'CPyArg_ParseStackAndKeywords'
+    if len(real_args) == 1 and len(groups[ARG_POS]) == 1:
+        parse_fn = 'CPyArg_ParseStackAndKeywords_1'
     emitter.emit_lines(
-        'if (!CPyArg_ParseStackAndKeywords(args, {}, kwnames, &parser{})) {{'.format(
-            nargs, ''.join(', ' + n for n in arg_ptrs)),
+        'if (!{}(args, {}, kwnames, &parser{})) {{'.format(
+            parse_fn, nargs, ''.join(', ' + n for n in arg_ptrs)),
         'return NULL;',
         '}')
     traceback_code = generate_traceback_code(fn, emitter, source_path, module_name)

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -514,12 +514,12 @@ int CPyArg_ParseTupleAndKeywords(PyObject *, PyObject *,
                                  const char *, const char * const *, ...);
 int CPyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
                                  CPyArg_Parser *parser, ...);
-int CPyArg_ParseStackAndKeywords_0(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
-                                   CPyArg_Parser *parser, ...);
-int CPyArg_ParseStackAndKeywords_1(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
-                                   CPyArg_Parser *parser, ...);
-int CPyArg_ParseStackAndKeywords_N(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
-                                   CPyArg_Parser *parser, ...);
+int CPyArg_ParseStackAndKeywordsNoArgs(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                                       CPyArg_Parser *parser, ...);
+int CPyArg_ParseStackAndKeywordsOneArg(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                                       CPyArg_Parser *parser, ...);
+int CPyArg_ParseStackAndKeywordsSimple(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                                       CPyArg_Parser *parser, ...);
 
 int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected);
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -514,7 +514,11 @@ int CPyArg_ParseTupleAndKeywords(PyObject *, PyObject *,
                                  const char *, const char * const *, ...);
 int CPyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
                                  CPyArg_Parser *parser, ...);
+int CPyArg_ParseStackAndKeywords_0(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                                   CPyArg_Parser *parser, ...);
 int CPyArg_ParseStackAndKeywords_1(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                                   CPyArg_Parser *parser, ...);
+int CPyArg_ParseStackAndKeywords_N(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
                                    CPyArg_Parser *parser, ...);
 
 int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected);

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -514,6 +514,8 @@ int CPyArg_ParseTupleAndKeywords(PyObject *, PyObject *,
                                  const char *, const char * const *, ...);
 int CPyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
                                  CPyArg_Parser *parser, ...);
+int CPyArg_ParseStackAndKeywords_1(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                                   CPyArg_Parser *parser, ...);
 
 int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected);
 

--- a/mypyc/lib-rt/getargsfast.c
+++ b/mypyc/lib-rt/getargsfast.c
@@ -69,6 +69,23 @@ CPyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *
 }
 
 int
+CPyArg_ParseStackAndKeywords_0(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                               CPyArg_Parser *parser, ...)
+{
+    int retval;
+    va_list va;
+
+    va_start(va, parser);
+    if (nargs == 0 && kwnames == NULL) {
+        retval = 1;
+    } else {
+        retval = vgetargskeywordsfast_impl(args, nargs, NULL, kwnames, parser, &va, 0);
+    }
+    va_end(va);
+    return retval;
+}
+
+int
 CPyArg_ParseStackAndKeywords_1(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
                                CPyArg_Parser *parser, ...)
 {
@@ -80,6 +97,28 @@ CPyArg_ParseStackAndKeywords_1(PyObject *const *args, Py_ssize_t nargs, PyObject
         PyObject **p;
         p = va_arg(va, PyObject **);
         *p = args[0];
+        retval = 1;
+    } else {
+        retval = vgetargskeywordsfast_impl(args, nargs, NULL, kwnames, parser, &va, 0);
+    }
+    va_end(va);
+    return retval;
+}
+
+int
+CPyArg_ParseStackAndKeywords_N(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                               CPyArg_Parser *parser, ...)
+{
+    int retval;
+    va_list va;
+
+    va_start(va, parser);
+    if (kwnames == NULL && nargs >= parser->min && nargs <= parser->max) {
+        PyObject **p;
+        for (Py_ssize_t i = 0; i < nargs; i++) {
+            p = va_arg(va, PyObject **);
+            *p = args[i];
+        }
         retval = 1;
     } else {
         retval = vgetargskeywordsfast_impl(args, nargs, NULL, kwnames, parser, &va, 0);

--- a/mypyc/lib-rt/getargsfast.c
+++ b/mypyc/lib-rt/getargsfast.c
@@ -55,6 +55,7 @@ static const char *convertitem_fast(PyObject *, const char **, va_list *, int, i
 static const char *convertsimple_fast(PyObject *, const char **, va_list *, int,
                                       char *, size_t, freelist_fast_t *);
 
+/* Parse args for an arbitrary signature */
 int
 CPyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
                              CPyArg_Parser *parser, ...)
@@ -68,15 +69,17 @@ CPyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *
     return retval;
 }
 
+/* Parse args for a function that takes no args */
 int
-CPyArg_ParseStackAndKeywords_0(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
-                               CPyArg_Parser *parser, ...)
+CPyArg_ParseStackAndKeywordsNoArgs(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                                   CPyArg_Parser *parser, ...)
 {
     int retval;
     va_list va;
 
     va_start(va, parser);
     if (nargs == 0 && kwnames == NULL) {
+        // Fast path: no arguments
         retval = 1;
     } else {
         retval = vgetargskeywordsfast_impl(args, nargs, NULL, kwnames, parser, &va, 0);
@@ -85,15 +88,17 @@ CPyArg_ParseStackAndKeywords_0(PyObject *const *args, Py_ssize_t nargs, PyObject
     return retval;
 }
 
+/* Parse args for a function that takes one arg */
 int
-CPyArg_ParseStackAndKeywords_1(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
-                               CPyArg_Parser *parser, ...)
+CPyArg_ParseStackAndKeywordsOneArg(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                                   CPyArg_Parser *parser, ...)
 {
     int retval;
     va_list va;
 
     va_start(va, parser);
     if (kwnames == NULL && nargs == 1) {
+        // Fast path: one positional argument
         PyObject **p;
         p = va_arg(va, PyObject **);
         *p = args[0];
@@ -105,15 +110,17 @@ CPyArg_ParseStackAndKeywords_1(PyObject *const *args, Py_ssize_t nargs, PyObject
     return retval;
 }
 
+/* Parse args for a function that takes no keyword-only args, *args or **kwargs */
 int
-CPyArg_ParseStackAndKeywords_N(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
-                               CPyArg_Parser *parser, ...)
+CPyArg_ParseStackAndKeywordsSimple(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                                   CPyArg_Parser *parser, ...)
 {
     int retval;
     va_list va;
 
     va_start(va, parser);
     if (kwnames == NULL && nargs >= parser->min && nargs <= parser->max) {
+        // Fast path: correct number of positional arguments only
         PyObject **p;
         for (Py_ssize_t i = 0; i < nargs; i++) {
             p = va_arg(va, PyObject **);

--- a/mypyc/lib-rt/getargsfast.c
+++ b/mypyc/lib-rt/getargsfast.c
@@ -68,6 +68,26 @@ CPyArg_ParseStackAndKeywords(PyObject *const *args, Py_ssize_t nargs, PyObject *
     return retval;
 }
 
+int
+CPyArg_ParseStackAndKeywords_1(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames,
+                               CPyArg_Parser *parser, ...)
+{
+    int retval;
+    va_list va;
+
+    va_start(va, parser);
+    if (kwnames == NULL && nargs == 1) {
+        PyObject **p;
+        p = va_arg(va, PyObject **);
+        *p = args[0];
+        retval = 1;
+    } else {
+        retval = vgetargskeywordsfast_impl(args, nargs, NULL, kwnames, parser, &va, 0);
+    }
+    va_end(va);
+    return retval;
+}
+
 static int
 cleanreturn_fast(int retval, freelist_fast_t *freelist)
 {

--- a/mypyc/test-data/run-functions.test
+++ b/mypyc/test-data/run-functions.test
@@ -937,6 +937,86 @@ def __init__():
 from native import __init__
 assert __init__() == 42
 
+[case testDifferentArgCountsFromInterpreted]
+# Test various signatures from interpreted code.
+def noargs() -> int:
+    return 5
+
+def onearg(x: int) -> int:
+    return x + 1
+
+def twoargs(x: int, y: str) -> int:
+    return x + len(y)
+
+def one_or_two(x: int, y: str = 'a') -> int:
+    return x + len(y)
+
+[file driver.py]
+from native import noargs, onearg, twoargs, one_or_two
+from testutil import assertRaises
+
+assert noargs() == 5
+t = ()
+assert noargs(*t) == 5
+d = {}
+assert noargs(**d) == 5
+assert noargs(*t, **d) == 5
+
+assert onearg(12) == 13
+assert onearg(x=8) == 9
+t = (1,)
+assert onearg(*t) == 2
+d = {'x': 5}
+assert onearg(**d) == 6
+
+assert twoargs(5, 'foo') == 8
+assert twoargs(4, y='foo') == 7
+assert twoargs(y='foo', x=7) == 10
+t = (1, 'xy')
+assert twoargs(*t) == 3
+d = {'y': 'xy'}
+assert twoargs(2, **d) == 4
+
+assert one_or_two(5) == 6
+assert one_or_two(x=3) == 4
+assert one_or_two(6, 'xy') == 8
+assert one_or_two(7, y='xy') == 9
+assert one_or_two(y='xy', x=2) == 4
+assert one_or_two(*t) == 3
+d = {'x': 5}
+assert one_or_two(**d) == 6
+assert one_or_two(y='xx', **d) == 7
+d = {'y': 'abc'}
+assert one_or_two(1, **d) == 4
+
+with assertRaises(TypeError, 'noargs() takes at most 0 arguments (1 given)'):
+    noargs(1)
+with assertRaises(TypeError, 'noargs() takes at most 0 keyword arguments (1 given)'):
+    noargs(x=1)
+
+with assertRaises(TypeError, "onearg() missing required argument 'x' (pos 1)"):
+    onearg()
+with assertRaises(TypeError, 'onearg() takes at most 1 argument (2 given)'):
+    onearg(1, 2)
+with assertRaises(TypeError, "onearg() missing required argument 'x' (pos 1)"):
+    onearg(y=1)
+with assertRaises(TypeError, "onearg() takes at most 1 argument (2 given)"):
+    onearg(1, y=1)
+
+with assertRaises(TypeError, "twoargs() missing required argument 'y' (pos 2)"):
+    twoargs(1)
+with assertRaises(TypeError, 'twoargs() takes at most 2 arguments (3 given)'):
+    twoargs(1, 'x', 2)
+with assertRaises(TypeError, 'twoargs() takes at most 2 arguments (3 given)'):
+    twoargs(1, 'x', y=2)
+
+with assertRaises(TypeError, "one_or_two() missing required argument 'x' (pos 1)"):
+    one_or_two()
+with assertRaises(TypeError, 'one_or_two() takes at most 2 arguments (3 given)'):
+    one_or_two(1, 'x', 2)
+with assertRaises(TypeError, 'one_or_two() takes at most 2 arguments (3 given)'):
+    one_or_two(1, 'x', y=2)
+
 [case testComplicatedArgs]
 from typing import Tuple, Dict
 


### PR DESCRIPTION
Add specialized argument parsing functions for these simple signatures:
1. No arguments
2. Single argument
3. No keyword-only args, *kwargs or **kwargs

The latter case covers many typical functions, such as these:

```
def f(x: int, y: int) -> int: ...
def g(x: int = 0) -> str: ...
```

The new parsing functions take a fast path when the caller passes only positional
arguments. This speeds up wrapper functions a lot in simple calls.

Microbenchmark speedups:
* `positional_args_from_interpreted` is 1.5x faster (now faster than interpreted)
* `nested_func` is 1.5x faster
* `sorted_with_key` is 14% faster (now faster than interpreted)
