### PR TITLE
Fix Python 3.5 travis build by pinning pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ jobs:
   #   - EXTRA_ARGS=
 
 install:
+# pip 21.0 no longer works on Python 3.5
 - pip install -U pip==20.3.4 setuptools
 - pip install -U 'virtualenv<20'
 - pip install -U tox==3.20.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ jobs:
   #   - EXTRA_ARGS=
 
 install:
-- pip install -U pip setuptools
+- pip install -U pip==20.3.4 setuptools
 - pip install -U 'virtualenv<20'
 - pip install -U tox==3.20.1
 - python2 -m pip install --user -U typing


### PR DESCRIPTION
It looks like pip just dropped Python 3.5 support, but we are not quite
yet ready to do it (as long as there's an easy workaround).

Example failure here:
https://travis-ci.com/github/python/mypy/jobs/474676438