### PR TITLE
Clarify stub-only packages need to be installed

### DIFF
--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -439,7 +439,7 @@ This is computed from the following items:
 
 .. note::
 
-    You cannot point to a :pep:`561` package via the ``MYPYPATH``, it must be
+    You cannot point to a stub-only package via the ``MYPYPATH``, it must be
     installed (see :ref:`PEP 561 support <installed-packages>`)
 
 Second, mypy searches for stub files in addition to regular Python files

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -439,7 +439,7 @@ This is computed from the following items:
 
 .. note::
 
-    You cannot point to a stub-only package via the ``MYPYPATH``, it must be
+    You cannot point to a stub-only package (:pep:`561`) via the ``MYPYPATH``, it must be
     installed (see :ref:`PEP 561 support <installed-packages>`)
 
 Second, mypy searches for stub files in addition to regular Python files


### PR DESCRIPTION
### Description
Reading the documentation about [how imports are found](https://mypy.readthedocs.io/en/stable/running_mypy.html#how-imports-are-found), I was confused by the note: 
"You cannot point to a [PEP 561](https://www.python.org/dev/peps/pep-0561/) package via the `MYPYPATH`, it must be installed (see [PEP 561 support](https://mypy.readthedocs.io/en/stable/installed_packages.html#installed-packages))".

I did not know what a PEP 561 package was, so I went to skim the documentation. This did not make me much wiser, since it describes multiple ways of distributing type hints, e.g. by providing the `py.typed` file. From [PEP 561 support](https://mypy.readthedocs.io/en/stable/installed_packages.html#installed-packages) it seems like what is actually referred to is specifically stub-only packages (also introduced in PEP 561).

This PR changes the note to:
"You cannot point to a stub-only package via the `MYPYPATH`, it must be installed (see [PEP 561 support](https://mypy.readthedocs.io/en/stable/installed_packages.html#installed-packages))".

## Test Plan
Rebuilding docs creates expected results.
