### PR TITLE
Clarify that mypy_path is relative to CWD

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -177,6 +177,12 @@ section of the command line docs.
     Multiple paths are always separated with a ``:`` or ``,`` regardless of the platform.
     User home directory and environment variables will be expanded.
 
+    Relative paths are treated relative to the working directory of the mypy command,
+    not the config file.
+    Use the ``MYPY_CONFIG_FILE_DIR`` environment variable to refer to paths relative to
+    the config file (e.g. ``mypy_path = $MYPY_CONFIG_FILE_DIR/src``).
+
+
     This option may only be set in the global section (``[mypy]``).
 
     **Note:** On Windows, use UNC paths to avoid using ``:`` (e.g. ``\\127.0.0.1\X$\MyDir`` where ``X`` is the drive letter).

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -182,7 +182,6 @@ section of the command line docs.
     Use the ``MYPY_CONFIG_FILE_DIR`` environment variable to refer to paths relative to
     the config file (e.g. ``mypy_path = $MYPY_CONFIG_FILE_DIR/src``).
 
-
     This option may only be set in the global section (``[mypy]``).
 
     **Note:** On Windows, use UNC paths to avoid using ``:`` (e.g. ``\\127.0.0.1\X$\MyDir`` where ``X`` is the drive letter).


### PR DESCRIPTION
### Description
I was unsure if the `mypy_path` entry in the config file was treated relative to the config file, and found the answer in #7967 (it is treated relative to the working directory of the mypy command).

This PR documents current behavior, and mentions how `MYPY_CONFIG_FILE_DIR` can be used to refer to path relative to the configuration file.

## Test Plan
Rebuilding docs creates expected results.