### PR TITLE
[mypyc] Intern string literals

### DIFF
--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -831,6 +831,8 @@ class GroupGenerator:
                 emitter.emit_line(
                     '{} = CPyTagged_FromObject({});'.format(actual_symbol, symbol)
                 )
+            elif isinstance(literal, str):
+                emitter.emit_line('PyUnicode_InternInPlace(&{});'.format(symbol))
 
         emitter.emit_lines(
             'is_initialized = 1;',

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -23,7 +23,10 @@ def match(x: str, y: str) -> Tuple[bool, bool]:
 
 [file driver.py]
 from native import f, g, tostr, booltostr, concat, eq, match
+import sys
+
 assert f() == 'some string'
+assert f() is sys.intern('some string')
 assert g() == 'some\a \v \t \x7f " \n \0string 🐍'
 assert tostr(57) == '57'
 assert concat('foo', 'bar') == 'foobar'


### PR DESCRIPTION
This makes us more compatible with CPython, which interns (some)
string literals.

This speeds up some microbenchmarks slightly, by around 0.5-2%.

This may give a bigger speed win when calling functions using 
vectorcalls and keyword arguments, but we'll see about that once that's 
supported. Vectorcall argument parsing code has a fast path for interned
keyword argument names.