### PR TITLE
[mypyc] Add primitives for list index() and remove()

### DIFF
--- a/mypyc/doc/list_operations.rst
+++ b/mypyc/doc/list_operations.rst
@@ -25,17 +25,10 @@ List comprehensions:
 Operators
 ---------
 
-Get item by integer index:
-
-* ``lst[n]``
-
-Slicing:
-
-* ``lst[n:m]``, ``lst[n:]``, ``lst[:m]``, ``lst[:]``
-
-Repeat list ``n`` times:
-
+* ``lst[n]`` (get item by integer index)
+* ``lst[n:m]``, ``lst[n:]``, ``lst[:m]``, ``lst[:]`` (slicing)
 * ``lst * n``, ``n * lst``
+* ``obj in lst``
 
 Statements
 ----------
@@ -51,7 +44,7 @@ For loop over a list:
 Methods
 -------
 
-* ``lst.append(item)``
+* ``lst.append(obj)``
 * ``lst.extend(x: Iterable)``
 * ``lst.insert(index, obj)``
 * ``lst.pop(index=-1)``

--- a/mypyc/doc/list_operations.rst
+++ b/mypyc/doc/list_operations.rst
@@ -53,9 +53,11 @@ Methods
 
 * ``lst.append(item)``
 * ``lst.extend(x: Iterable)``
-* ``lst.insert(index, item)``
+* ``lst.insert(index, obj)``
 * ``lst.pop(index=-1)``
-* ``lst.count(item)``
+* ``lst.remove(obj)``
+* ``lst.count(obj)``
+* ``lst.index(obj)``
 * ``lst.reverse()``
 * ``lst.sort()``
 

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -154,6 +154,18 @@ int CPyList_Remove(PyObject *list, PyObject *obj) {
     return PyList_SetSlice(list, index, index + 1, NULL);
 }
 
+CPyTagged CPyList_Index(PyObject *list, PyObject *obj) {
+    Py_ssize_t index = _CPyList_Find(list, obj);
+    if (index == -2) {
+        return CPY_INT_TAG;
+    }
+    if (index == -1) {
+        PyErr_SetString(PyExc_ValueError, "value is not in list");
+        return CPY_INT_TAG;
+    }
+    return index << 1;
+}
+
 PyObject *CPySequence_Multiply(PyObject *seq, CPyTagged t_size) {
     Py_ssize_t size = CPyTagged_AsSsize_t(t_size);
     if (size == -1 && PyErr_Occurred()) {

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -124,6 +124,36 @@ PyObject *CPyList_Extend(PyObject *o1, PyObject *o2) {
     return _PyList_Extend((PyListObject *)o1, o2);
 }
 
+// Return -2 or error, -1 if not found, or index of first match otherwise.
+static Py_ssize_t _CPyList_Find(PyObject *list, PyObject *obj) {
+    for (Py_ssize_t i = 0; i < Py_SIZE(list); i++) {
+        PyObject *item = PyList_GET_ITEM(list, i);
+        Py_INCREF(item);
+        int cmp = PyObject_RichCompareBool(item, obj, Py_EQ);
+        Py_DECREF(item);
+        if (cmp != 0) {
+            if (cmp > 0) {
+                return i;
+            } else {
+                return -2;
+            }
+        }
+    }
+    return -1;
+}
+
+int CPyList_Remove(PyObject *list, PyObject *obj) {
+    Py_ssize_t index = _CPyList_Find(list, obj);
+    if (index == -2) {
+        return -1;
+    }
+    if (index == -1) {
+        PyErr_SetString(PyExc_ValueError, "list.remove(x): x not in list");
+        return -1;
+    }
+    return PyList_SetSlice(list, index, index + 1, NULL);
+}
+
 PyObject *CPySequence_Multiply(PyObject *seq, CPyTagged t_size) {
     Py_ssize_t size = CPyTagged_AsSsize_t(t_size);
     if (size == -1 && PyErr_Occurred()) {

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -126,7 +126,8 @@ PyObject *CPyList_Extend(PyObject *o1, PyObject *o2) {
 
 // Return -2 or error, -1 if not found, or index of first match otherwise.
 static Py_ssize_t _CPyList_Find(PyObject *list, PyObject *obj) {
-    for (Py_ssize_t i = 0; i < Py_SIZE(list); i++) {
+    Py_ssize_t i;
+    for (i = 0; i < Py_SIZE(list); i++) {
         PyObject *item = PyList_GET_ITEM(list, i);
         Py_INCREF(item);
         int cmp = PyObject_RichCompareBool(item, obj, Py_EQ);

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -129,6 +129,14 @@ method_op(
     c_function_name='PyList_Reverse',
     error_kind=ERR_NEG_INT)
 
+# list.remove(obj)
+method_op(
+    name='remove',
+    arg_types=[list_rprimitive, object_rprimitive],
+    return_type=c_int_rprimitive,
+    c_function_name='CPyList_Remove',
+    error_kind=ERR_NEG_INT)
+
 # list * int
 binary_op(
     name='*',

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -137,6 +137,14 @@ method_op(
     c_function_name='CPyList_Remove',
     error_kind=ERR_NEG_INT)
 
+# list.index(obj)
+method_op(
+    name='index',
+    arg_types=[list_rprimitive, object_rprimitive],
+    return_type=int_rprimitive,
+    c_function_name='CPyList_Index',
+    error_kind=ERR_MAGIC)
+
 # list * int
 binary_op(
     name='*',

--- a/mypyc/test-data/fixtures/ir.py
+++ b/mypyc/test-data/fixtures/ir.py
@@ -145,6 +145,7 @@ class list(Generic[T], Sequence[T], Iterable[T]):
     def insert(self, i: int, x: T) -> None: pass
     def sort(self) -> None: pass
     def reverse(self) -> None: pass
+    def remove(self, o: T) -> None: pass
 
 class dict(Mapping[K, V]):
     @overload

--- a/mypyc/test-data/fixtures/ir.py
+++ b/mypyc/test-data/fixtures/ir.py
@@ -146,6 +146,7 @@ class list(Generic[T], Sequence[T], Iterable[T]):
     def sort(self) -> None: pass
     def reverse(self) -> None: pass
     def remove(self, o: T) -> None: pass
+    def index(self, o: T) -> int: pass
 
 class dict(Mapping[K, V]):
     @overload

--- a/mypyc/test-data/run-lists.test
+++ b/mypyc/test-data/run-lists.test
@@ -149,6 +149,19 @@ def test_reverse() -> None:
     l.reverse()
     assert l == []
 
+def test_remove() -> None:
+    l = [1, 3, 4, 3]
+    l.remove(3)
+    assert l == [1, 4, 3]
+    l.remove(3)
+    assert l == [1, 4]
+    try:
+        l.remove(3)
+    except ValueError:
+        pass
+    else:
+        assert False
+
 [case testListOfUserDefinedClass]
 class C:
     x: int

--- a/mypyc/test-data/run-lists.test
+++ b/mypyc/test-data/run-lists.test
@@ -162,6 +162,18 @@ def test_remove() -> None:
     else:
         assert False
 
+def test_index() -> None:
+    l = [1, 3, 4, 3]
+    assert l.index(1) == 0
+    assert l.index(3) == 1
+    assert l.index(4) == 2
+    try:
+        l.index(0)
+    except ValueError:
+        pass
+    else:
+        assert False
+
 [case testListOfUserDefinedClass]
 class C:
     x: int


### PR DESCRIPTION
This speeds up the `list_remove` microbenchmark by about 30% and the
`list_index` microbenchmark by about 55%.

There is still room for making these faster by specializing based on item
type, for example, but since these primitives aren't used very commonly,
other optimization work seems higher priority.