### PR TITLE
Remove references to git submodules in documentation and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,17 +184,7 @@ Quick start for contributing to mypy
 
 If you want to contribute, first clone the mypy git repository:
 
-    $ git clone --recurse-submodules https://github.com/python/mypy.git
-
-If you've already cloned the repo without `--recurse-submodules`,
-you need to pull in the typeshed repo as follows:
-
-    $ git submodule init
-    $ git submodule update
-
-Either way you should now have a subdirectory `typeshed` inside your mypy repo,
-your folders tree should be like `mypy/mypy/typeshed`, containing a
-clone of the typeshed repo (`https://github.com/python/typeshed`).
+    $ git clone https://github.com/python/mypy.git
 
 From the mypy directory, use pip to install mypy:
 
@@ -209,22 +199,8 @@ the above as root. For example, in Ubuntu:
 Now you can use the `mypy` program just as above.  In case of trouble
 see "Troubleshooting" above.
 
-> NOTE: Installing with sudo can be a security risk, please try with flag `--user` first.
-    $ python3 -m pip install --user -U . 
-
-Working with the git version of mypy
-------------------------------------
-
-mypy contains a submodule, "typeshed". See https://github.com/python/typeshed.
-This submodule contains types for the Python standard library.
-
-Due to the way git submodules work, you'll have to do
-```
-  git submodule update mypy/typeshed
-```
-whenever you change branches, merge, rebase, or pull.
-
-(It's possible to automate this: Search Google for "git hook update submodule")
+> NOTE: Installing with sudo can be a security risk. Please try with the `--user` flag first.
+    $ python3 -m pip install --user -U .
 
 
 Tests
@@ -244,7 +220,8 @@ Development status
 ------------------
 
 Mypy is beta software, but it has already been used in production
-for several years at Dropbox, and it has an extensive test suite.
+for several years at Dropbox and in many other organizations, and
+it has an extensive test suite.
 
 See [the roadmap](ROADMAP.md) if you are interested in plans for the
 future.

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -616,7 +616,7 @@ You can install the latest development version of mypy from source. Clone the
 
 .. code-block:: text
 
-    git clone --recurse-submodules https://github.com/python/mypy.git
+    git clone https://github.com/python/mypy.git
     cd mypy
     sudo python3 -m pip install --upgrade .
 

--- a/mypy/git.py
+++ b/mypy/git.py
@@ -1,14 +1,8 @@
-"""Utilities for verifying git integrity."""
+"""Git utilities."""
 
 # Used also from setup.py, so don't pull in anything additional here (like mypy or typing):
 import os
-import pipes
 import subprocess
-import sys
-
-MYPY = False
-if MYPY:
-    from typing import Iterator
 
 
 def is_git_repo(dir: str) -> bool:
@@ -27,34 +21,9 @@ def have_git() -> bool:
         return False
 
 
-def get_submodules(dir: str) -> "Iterator[str]":
-    """Return a list of all git top-level submodules in a given directory."""
-    # It would be nicer to do
-    # "git submodule foreach 'echo MODULE $name $path $sha1 $toplevel'"
-    # but that wouldn't work on Windows.
-    output = subprocess.check_output(["git", "submodule", "status"], cwd=dir)
-    # "<status><sha1> name desc"
-    # status='-': not initialized
-    # status='+': changed
-    # status='u': merge conflicts
-    # status=' ': up-to-date
-    for line in output.splitlines():
-        # Skip the status indicator, as it could be a space can confuse the split.
-        line = line[1:]
-        name = line.split(b" ")[1]
-        yield name.decode(sys.getfilesystemencoding())
-
-
 def git_revision(dir: str) -> bytes:
     """Get the SHA-1 of the HEAD of a git repository."""
     return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=dir).strip()
-
-
-def submodule_revision(dir: str, submodule: str) -> bytes:
-    """Get the SHA-1 a submodule is supposed to have."""
-    output = subprocess.check_output(["git", "ls-files", "-s", submodule], cwd=dir).strip()
-    # E.g.: "160000 e4a7edb949e0b920b16f61aeeb19fc3d328f3012 0       typeshed"
-    return output.split()[1]
 
 
 def is_dirty(dir: str) -> bool:
@@ -67,74 +36,3 @@ def has_extra_files(dir: str) -> bool:
     """Check whether a git repository has untracked files."""
     output = subprocess.check_output(["git", "clean", "--dry-run", "-d"], cwd=dir)
     return output.strip() != b""
-
-
-def warn_no_git_executable() -> None:
-    print("Warning: Couldn't check git integrity. "
-          "git executable not in path.", file=sys.stderr)
-
-
-def warn_dirty(dir: str) -> None:
-    print("Warning: git module '{}' has uncommitted changes.".format(dir),
-          file=sys.stderr)
-    print("Go to the directory", file=sys.stderr)
-    print("  {}".format(dir), file=sys.stderr)
-    print("and commit or reset your changes", file=sys.stderr)
-
-
-def warn_extra_files(dir: str) -> None:
-    print("Warning: git module '{}' has untracked files.".format(dir),
-          file=sys.stderr)
-    print("Go to the directory", file=sys.stderr)
-    print("  {}".format(dir), file=sys.stderr)
-    print("and add & commit your new files.", file=sys.stderr)
-
-
-def chdir_prefix(dir: str) -> str:
-    """Return the command to change to the target directory, plus '&&'."""
-    if os.path.relpath(dir) != ".":
-        return "cd " + pipes.quote(dir) + " && "
-    else:
-        return ""
-
-
-def error_submodule_not_initialized(name: str, dir: str) -> None:
-    print("Submodule '{}' not initialized.".format(name), file=sys.stderr)
-    print("Please run:", file=sys.stderr)
-    print("  {}git submodule update --init {}".format(
-        chdir_prefix(dir), name), file=sys.stderr)
-
-
-def error_submodule_not_updated(name: str, dir: str) -> None:
-    print("Submodule '{}' not updated.".format(name), file=sys.stderr)
-    print("Please run:", file=sys.stderr)
-    print("  {}git submodule update {}".format(
-        chdir_prefix(dir), name), file=sys.stderr)
-    print("(If you got this message because you updated {} yourself".format(name), file=sys.stderr)
-    print(" then run \"git add {}\" to silence this check)".format(name), file=sys.stderr)
-
-
-def verify_git_integrity_or_abort(datadir: str) -> None:
-    """Verify the (submodule) integrity of a git repository.
-
-    Potentially output warnings/errors (to stderr), and exit with status 1
-    if we detected a severe problem.
-    """
-    datadir = datadir or '.'
-    if not is_git_repo(datadir):
-        return
-    if not have_git():
-        warn_no_git_executable()
-        return
-    for submodule in get_submodules(datadir):
-        submodule_path = os.path.join(datadir, submodule)
-        if not is_git_repo(submodule_path):
-            error_submodule_not_initialized(submodule, datadir)
-            sys.exit(1)
-        elif submodule_revision(datadir, submodule) != git_revision(submodule_path):
-            error_submodule_not_updated(submodule, datadir)
-            sys.exit(1)
-        elif is_dirty(submodule_path):
-            warn_dirty(submodule)
-        elif has_extra_files(submodule_path):
-            warn_extra_files(submodule)

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -524,10 +524,9 @@ def default_lib_path(data_dir: str,
     if sys.platform != 'win32':
         path.append('/usr/local/lib/mypy')
     if not path:
-        print("Could not resolve typeshed subdirectories. If you are using mypy\n"
-              "from source, you need to run \"git submodule update --init\".\n"
-              "Otherwise your mypy install is broken.\nPython executable is located at "
-              "{0}.\nMypy located at {1}".format(sys.executable, data_dir), file=sys.stderr)
+        print("Could not resolve typeshed subdirectories. Your mypy install is broken.\n"
+              "Python executable is located at {0}.\nMypy located at {1}".format(
+                  sys.executable, data_dir), file=sys.stderr)
         sys.exit(1)
     return path
 

--- a/mypyc/README.md
+++ b/mypyc/README.md
@@ -57,9 +57,9 @@ Windows Requirements
 Quick Start for Contributors
 ----------------------------
 
-First clone the mypy git repository *and git submodules*:
+First clone the mypy git repository:
 
-    $ git clone --recurse-submodules https://github.com/python/mypy.git
+    $ git clone https://github.com/python/mypy.git
     $ cd mypy
 
 Optionally create a virtualenv (recommended):
@@ -78,10 +78,9 @@ Now you can run the tests:
 Look at the [issue tracker](https://github.com/mypyc/mypyc/issues)
 for things to work on. Please express your interest in working on an
 issue by adding a comment before doing any significant work, since
-development is currently very active and there is real risk of duplicate
-work.
+there is a risk of duplicate work.
 
-Note that the issue tracker is still hosted on the mypyc project, not
+Note that the issue tracker is hosted on the mypyc GitHub project, not
 with mypy itself.
 
 Documentation

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,6 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py
 from mypy.version import __version__ as version
-from mypy import git
-
-git.verify_git_integrity_or_abort(".")
 
 description = 'Optional static typing for Python'
 long_description = '''


### PR DESCRIPTION
These are no longer relevant after we removed the typeshed
submodule in #9973.