### PR TITLE
Add --exclude

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -49,9 +49,9 @@ for full details, see :ref:`running-mypy`.
     Asks mypy to type check the provided string as a program.
 
 
-.. option:: --ignore-path
+.. option:: --exclude
 
-    Asks mypy to ignore a given file name, directory name or subpath while
+    Asks mypy to exclude a given file name, directory name or subpath while
     recursively discovering files to check. This flag may be repeated multiple
     times.
 

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -56,7 +56,7 @@ for full details, see :ref:`running-mypy`.
     Use forward slashes on all platforms.
 
     For instance, to avoid discovering any files named `setup.py` you could
-    pass ``--exclude '/setup.py$'``. Similarly, you can ignore discovering
+    pass ``--exclude '/setup\.py$'``. Similarly, you can ignore discovering
     directories with a given name by e.g. ``--exclude /build/`` or
     those matching a subpath with ``--exclude /project/vendor/``.
 

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -51,9 +51,9 @@ for full details, see :ref:`running-mypy`.
 
 .. option:: --exclude
 
-    Asks mypy to exclude a given file name, directory name or subpath while
-    recursively discovering files to check. This flag may be repeated multiple
-    times.
+    A regular expression that matches file names, directory names and paths
+    which mypy should ignore while recursively discovering files to check.
+    Use forward slashes on all platforms.
 
 
 Optional arguments

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -55,6 +55,22 @@ for full details, see :ref:`running-mypy`.
     which mypy should ignore while recursively discovering files to check.
     Use forward slashes on all platforms.
 
+    For instance, to avoid discovering any files named `setup.py` you could
+    pass ``--exclude '/setup.py$'``. Similarly, you can ignore discovering
+    directories with a given name by e.g. ``--exclude /node_modules/`` or
+    those matching a subpath with ``--exclude /project/vendor/``.
+
+    Note that this flag only affects recursive discovery, that is, when mypy is
+    discovering files within a directory tree or submodules of a package to
+    check. If you pass a file or module explicitly it will still be checked. For
+    instance, ``mypy --exclude '/setup.py$' but_still_check/setup.py``.
+
+    Note that mypy will never recursively discover files and directories named
+    "site-packages" or "__pycache__" or those whose name starts with a period,
+    exactly as ``--exclude '/(site-packages|__pycache__|\..*)$'`` would.
+    Mypy will also never recursively discover files with extensions other than
+    ``.py`` or ``.pyi``.
+
 
 Optional arguments
 ******************

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -68,7 +68,7 @@ for full details, see :ref:`running-mypy`.
     Note that mypy will never recursively discover files and directories named
     "site-packages", "node_modules" or "__pycache__", or those whose name starts
     with a period, exactly as ``--exclude
-    '/(site-packages|node_modules|__pycache__|\..*)$'`` would. Mypy will also
+    '/(site-packages|node_modules|__pycache__|\..*)/$'`` would. Mypy will also
     never recursively discover files with extensions other than ``.py`` or
     ``.pyi``.
 

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -49,6 +49,13 @@ for full details, see :ref:`running-mypy`.
     Asks mypy to type check the provided string as a program.
 
 
+.. option:: --ignore-path
+
+    Asks mypy to ignore a given file name, directory name or subpath while
+    recursively discovering files to check. This flag may be repeated multiple
+    times.
+
+
 Optional arguments
 ******************
 

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -57,7 +57,7 @@ for full details, see :ref:`running-mypy`.
 
     For instance, to avoid discovering any files named `setup.py` you could
     pass ``--exclude '/setup.py$'``. Similarly, you can ignore discovering
-    directories with a given name by e.g. ``--exclude /node_modules/`` or
+    directories with a given name by e.g. ``--exclude /build/`` or
     those matching a subpath with ``--exclude /project/vendor/``.
 
     Note that this flag only affects recursive discovery, that is, when mypy is
@@ -66,10 +66,11 @@ for full details, see :ref:`running-mypy`.
     instance, ``mypy --exclude '/setup.py$' but_still_check/setup.py``.
 
     Note that mypy will never recursively discover files and directories named
-    "site-packages" or "__pycache__" or those whose name starts with a period,
-    exactly as ``--exclude '/(site-packages|__pycache__|\..*)$'`` would.
-    Mypy will also never recursively discover files with extensions other than
-    ``.py`` or ``.pyi``.
+    "site-packages", "node_modules" or "__pycache__", or those whose name starts
+    with a period, exactly as ``--exclude
+    '/(site-packages|node_modules|__pycache__|\..*)$'`` would. Mypy will also
+    never recursively discover files with extensions other than ``.py`` or
+    ``.pyi``.
 
 
 Optional arguments

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -197,6 +197,15 @@ section of the command line docs.
 
     This option may only be set in the global section (``[mypy]``).
 
+.. confval:: ignore_path
+
+    :type: comma-separated list of strings
+
+    A comma-separated list of file names, directory names or subpaths which mypy
+    should ignore while recursively discovering files to check.
+
+    This option may only be set in the global section (``[mypy]``).
+
 .. confval:: namespace_packages
 
     :type: boolean

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -199,10 +199,11 @@ section of the command line docs.
 
 .. confval:: exclude
 
-    :type: comma-separated list of strings
+    :type: regular expression
 
-    A comma-separated list of file names, directory names or subpaths which mypy
-    should ignore while recursively discovering files to check.
+    A regular expression that matches file names, directory names and paths
+    which mypy should ignore while recursively discovering files to check.
+    Use forward slashes on all platforms.
 
     This option may only be set in the global section (``[mypy]``).
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -205,6 +205,8 @@ section of the command line docs.
     which mypy should ignore while recursively discovering files to check.
     Use forward slashes on all platforms.
 
+    For more details, see :option:`--exclude <mypy --exclude>`.
+
     This option may only be set in the global section (``[mypy]``).
 
 .. confval:: namespace_packages

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -197,7 +197,7 @@ section of the command line docs.
 
     This option may only be set in the global section (``[mypy]``).
 
-.. confval:: ignore_path
+.. confval:: exclude
 
     :type: comma-separated list of strings
 

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -390,7 +390,8 @@ to modules to type check.
 - Mypy will check all paths provided that correspond to files.
 
 - Mypy will recursively discover and check all files ending in ``.py`` or
-  ``.pyi`` in directory paths provided.
+  ``.pyi`` in directory paths provided, after accounting for
+  :option:`--ignore-path <mypy --ignore-path>`.
 
 - For each file to be checked, mypy will attempt to associate the file (e.g.
   ``project/foo/bar/baz.py``) with a fully qualified module name (e.g.

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -391,7 +391,7 @@ to modules to type check.
 
 - Mypy will recursively discover and check all files ending in ``.py`` or
   ``.pyi`` in directory paths provided, after accounting for
-  :option:`--ignore-path <mypy --ignore-path>`.
+  :option:`--exclude <mypy --exclude>`.
 
 - For each file to be checked, mypy will attempt to associate the file (e.g.
   ``project/foo/bar/baz.py``) with a fully qualified module name (e.g.

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2769,14 +2769,12 @@ def load_graph(sources: List[BuildSource], manager: BuildManager,
                 "Duplicate module named '%s' (also at '%s')" % (st.id, graph[st.id].xpath),
                 blocker=True,
             )
-            p1 = len(pathlib.PurePath(st.xpath).parents)
-            p2 = len(pathlib.PurePath(graph[st.id].xpath).parents)
-
-            if p1 != p2:
-                manager.errors.report(
-                    -1, -1,
-                    "Are you missing an __init__.py?"
-                )
+            manager.errors.report(
+                -1, -1,
+                "Are you missing an __init__.py? Alternatively, consider using --ignore-path to avoid "
+                "checking one of them.",
+                severity='note'
+            )
 
             manager.errors.raise_error()
         graph[st.id] = st

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2770,7 +2770,7 @@ def load_graph(sources: List[BuildSource], manager: BuildManager,
             )
             manager.errors.report(
                 -1, -1,
-                "Are you missing an __init__.py? Alternatively, consider using --ignore-path to "
+                "Are you missing an __init__.py? Alternatively, consider using --exclude to "
                 "avoid checking one of them.",
                 severity='note'
             )

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -15,7 +15,6 @@ import errno
 import gc
 import json
 import os
-import pathlib
 import re
 import stat
 import sys
@@ -2771,8 +2770,8 @@ def load_graph(sources: List[BuildSource], manager: BuildManager,
             )
             manager.errors.report(
                 -1, -1,
-                "Are you missing an __init__.py? Alternatively, consider using --ignore-path to avoid "
-                "checking one of them.",
+                "Are you missing an __init__.py? Alternatively, consider using --ignore-path to "
+                "avoid checking one of them.",
                 severity='note'
             )
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2569,6 +2569,7 @@ def log_configuration(manager: BuildManager, sources: List[BuildSource]) -> None
         ("Current Executable", sys.executable),
         ("Cache Dir", manager.options.cache_dir),
         ("Compiled", str(not __file__.endswith(".py"))),
+        ("Exclude", manager.options.exclude),
     ]
 
     for conf_name, conf_value in configuration_vars:

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -83,6 +83,7 @@ config_types = {
     'custom_typing_module': str,
     'custom_typeshed_dir': expand_path,
     'mypy_path': lambda s: [expand_path(p.strip()) for p in re.split('[,:]', s)],
+    'ignore_path': lambda s: [expand_path(p.strip()) for p in s.split(',')],
     'files': split_and_match_files,
     'quickstart_file': expand_path,
     'junit_xml': expand_path,

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -83,7 +83,7 @@ config_types = {
     'custom_typing_module': str,
     'custom_typeshed_dir': expand_path,
     'mypy_path': lambda s: [expand_path(p.strip()) for p in re.split('[,:]', s)],
-    'ignore_path': lambda s: [expand_path(p.strip()) for p in s.split(',')],
+    'ignore_path': lambda s: [expand_path(p.strip()).replace("/", os.sep) for p in s.split(",")],
     'files': split_and_match_files,
     'quickstart_file': expand_path,
     'junit_xml': expand_path,

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -83,7 +83,6 @@ config_types = {
     'custom_typing_module': str,
     'custom_typeshed_dir': expand_path,
     'mypy_path': lambda s: [expand_path(p.strip()) for p in re.split('[,:]', s)],
-    'exclude': lambda s: [expand_path(p.strip()) for p in s.split(",")],
     'files': split_and_match_files,
     'quickstart_file': expand_path,
     'junit_xml': expand_path,

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -83,7 +83,7 @@ config_types = {
     'custom_typing_module': str,
     'custom_typeshed_dir': expand_path,
     'mypy_path': lambda s: [expand_path(p.strip()) for p in re.split('[,:]', s)],
-    'ignore_path': lambda s: [expand_path(p.strip()).replace("/", os.sep) for p in s.split(",")],
+    'ignore_path': lambda s: [expand_path(p.strip()) for p in s.split(",")],
     'files': split_and_match_files,
     'quickstart_file': expand_path,
     'junit_xml': expand_path,

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -83,7 +83,7 @@ config_types = {
     'custom_typing_module': str,
     'custom_typeshed_dir': expand_path,
     'mypy_path': lambda s: [expand_path(p.strip()) for p in re.split('[,:]', s)],
-    'ignore_path': lambda s: [expand_path(p.strip()) for p in s.split(",")],
+    'exclude': lambda s: [expand_path(p.strip()) for p in s.split(",")],
     'files': split_and_match_files,
     'quickstart_file': expand_path,
     'junit_xml': expand_path,

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -91,6 +91,7 @@ class SourceFinder:
         self.fscache = fscache
         self.explicit_package_bases = get_explicit_package_bases(options)
         self.namespace_packages = options.namespace_packages
+        self.ignore_path = options.ignore_path
 
     def is_explicit_package_base(self, path: str) -> bool:
         assert self.explicit_package_bases
@@ -103,9 +104,15 @@ class SourceFinder:
         names = sorted(self.fscache.listdir(path), key=keyfunc)
         for name in names:
             # Skip certain names altogether
-            if name == '__pycache__' or name.startswith('.') or name.endswith('~'):
+            if (
+                name in ("__pycache__", "site-packages", "node_modules")
+                or name.startswith(".")
+                or name.endswith("~")
+            ):
                 continue
             subpath = os.path.join(path, name)
+            if any(subpath.endswith(pattern.rstrip("/")) for pattern in self.ignore_path):
+                continue
 
             if self.fscache.isdir(subpath):
                 sub_sources = self.find_sources_in_dir(subpath)

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -6,7 +6,7 @@ import os
 from typing import List, Sequence, Set, Tuple, Optional
 from typing_extensions import Final
 
-from mypy.modulefinder import BuildSource, PYTHON_EXTENSIONS, mypy_path, matches_ignore_pattern
+from mypy.modulefinder import BuildSource, PYTHON_EXTENSIONS, mypy_path, matches_exclude_pattern
 from mypy.fscache import FileSystemCache
 from mypy.options import Options
 
@@ -91,7 +91,7 @@ class SourceFinder:
         self.fscache = fscache
         self.explicit_package_bases = get_explicit_package_bases(options)
         self.namespace_packages = options.namespace_packages
-        self.ignore_path = options.ignore_path
+        self.exclude = options.exclude
 
     def is_explicit_package_base(self, path: str) -> bool:
         assert self.explicit_package_bases
@@ -111,7 +111,7 @@ class SourceFinder:
             ):
                 continue
             subpath = os.path.join(path, name)
-            if any(matches_ignore_pattern(subpath, pattern) for pattern in self.ignore_path):
+            if any(matches_exclude_pattern(subpath, pattern) for pattern in self.exclude):
                 continue
 
             if self.fscache.isdir(subpath):

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -6,7 +6,7 @@ import os
 from typing import List, Sequence, Set, Tuple, Optional
 from typing_extensions import Final
 
-from mypy.modulefinder import BuildSource, PYTHON_EXTENSIONS, mypy_path
+from mypy.modulefinder import BuildSource, PYTHON_EXTENSIONS, mypy_path, matches_ignore_pattern
 from mypy.fscache import FileSystemCache
 from mypy.options import Options
 
@@ -111,7 +111,7 @@ class SourceFinder:
             ):
                 continue
             subpath = os.path.join(path, name)
-            if any(subpath.endswith(pattern.rstrip("/")) for pattern in self.ignore_path):
+            if any(matches_ignore_pattern(subpath, pattern) for pattern in self.ignore_path):
                 continue
 
             if self.fscache.isdir(subpath):

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -3,6 +3,7 @@
 import functools
 import os
 import re
+import sys
 
 from typing import List, Sequence, Set, Tuple, Optional
 from typing_extensions import Final
@@ -93,6 +94,7 @@ class SourceFinder:
         self.explicit_package_bases = get_explicit_package_bases(options)
         self.namespace_packages = options.namespace_packages
         self.exclude = options.exclude
+        self.verbose = options.verbosity >= 2
 
     def is_explicit_package_base(self, path: str) -> bool:
         assert self.explicit_package_bases
@@ -107,10 +109,12 @@ class SourceFinder:
             subpath = os.path.join(path, name)
 
             if self.exclude:
-                subpath_str = "/" + os.path.abspath(subpath).replace(os.sep, "/")
+                subpath_str = os.path.abspath(subpath).replace(os.sep, "/")
                 if self.fscache.isdir(subpath):
                     subpath_str += "/"
                 if re.search(self.exclude, subpath_str):
+                    if self.verbose:
+                        print("TRACE: Excluding {}".format(subpath_str), file=sys.stderr)
                     continue
 
             if self.fscache.isdir(subpath):

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -105,7 +105,7 @@ class SourceFinder:
         names = sorted(self.fscache.listdir(path), key=keyfunc)
         for name in names:
             # Skip certain names altogether
-            if name in ("__pycache__", "site-packages") or name.startswith("."):
+            if name in ("__pycache__", "site-packages", "node_modules") or name.startswith("."):
                 continue
             subpath = os.path.join(path, name)
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -954,8 +954,6 @@ def process_options(args: List[str],
     if options.logical_deps:
         options.cache_fine_grained = True
 
-    options.ignore_path = [p.replace("/", os.sep) for p in options.ignore_path]
-
     # Set target.
     if special_opts.modules + special_opts.packages:
         options.build_type = BuildType.MODULE

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -809,7 +809,7 @@ def process_options(args: List[str],
         '--explicit-package-bases', action='store_true',
         help="Use current directory and MYPYPATH to determine module names of files passed")
     code_group.add_argument(
-        "--ignore-path",
+        "--exclude",
         metavar="PATH",
         action="append",
         default=[],

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -810,11 +810,11 @@ def process_options(args: List[str],
         help="Use current directory and MYPYPATH to determine module names of files passed")
     code_group.add_argument(
         "--exclude",
-        metavar="PATH",
+        metavar="PATTERN",
         default="",
         help=(
             "Regular expression to match file names, directory names or paths which mypy should "
-            "ignore while recursively discovering files to check."
+            "ignore while recursively discovering files to check, e.g. --exclude '/setup.py$'"
         )
     )
     code_group.add_argument(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -954,6 +954,8 @@ def process_options(args: List[str],
     if options.logical_deps:
         options.cache_fine_grained = True
 
+    options.ignore_path = [p.replace("/", os.sep) for p in options.ignore_path]
+
     # Set target.
     if special_opts.modules + special_opts.packages:
         options.build_type = BuildType.MODULE

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -424,6 +424,7 @@ def process_options(args: List[str],
     # Options object.  Options that require further processing should have
     # their `dest` prefixed with `special-opts:`, which will cause them to be
     # parsed into the separate special_opts namespace object.
+    options = Options()
 
     # Note: we have a style guide for formatting the mypy --help text. See
     # https://github.com/python/mypy/wiki/Documentation-Conventions
@@ -811,9 +812,11 @@ def process_options(args: List[str],
     code_group.add_argument(
         "--exclude",
         metavar="PATH",
-        action="append",
-        default=[],
-        help="File names, directory names or subpaths to avoid checking",
+        default=options.exclude,
+        help=(
+            "Regex to match file names, directory names or paths to avoid checking. "
+            "Defaults to '%(default)s'."
+        )
     )
     code_group.add_argument(
         '-m', '--module', action='append', metavar='MODULE',
@@ -842,8 +845,6 @@ def process_options(args: List[str],
     # This lets `--config-file=` (an empty string) be used to disable all config files.
     if config_file and not os.path.exists(config_file):
         parser.error("Cannot find config file '%s'" % config_file)
-
-    options = Options()
 
     def set_strict_flags() -> None:
         for dest, value in strict_flag_assignments:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -809,6 +809,13 @@ def process_options(args: List[str],
         '--explicit-package-bases', action='store_true',
         help="Use current directory and MYPYPATH to determine module names of files passed")
     code_group.add_argument(
+        "--ignore-path",
+        metavar="PATH",
+        action="append",
+        default=[],
+        help="File names, directory names or subpaths to avoid checking",
+    )
+    code_group.add_argument(
         '-m', '--module', action='append', metavar='MODULE',
         default=[],
         dest='special-opts:modules',

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -424,7 +424,6 @@ def process_options(args: List[str],
     # Options object.  Options that require further processing should have
     # their `dest` prefixed with `special-opts:`, which will cause them to be
     # parsed into the separate special_opts namespace object.
-    options = Options()
 
     # Note: we have a style guide for formatting the mypy --help text. See
     # https://github.com/python/mypy/wiki/Documentation-Conventions
@@ -812,10 +811,10 @@ def process_options(args: List[str],
     code_group.add_argument(
         "--exclude",
         metavar="PATH",
-        default=options.exclude,
+        default="",
         help=(
-            "Regex to match file names, directory names or paths to avoid checking. "
-            "Defaults to '%(default)s'."
+            "Regular expression to match file names, directory names or paths which mypy should "
+            "ignore while recursively discovering files to check."
         )
     )
     code_group.add_argument(
@@ -845,6 +844,8 @@ def process_options(args: List[str],
     # This lets `--config-file=` (an empty string) be used to disable all config files.
     if config_file and not os.path.exists(config_file):
         parser.error("Cannot find config file '%s'" % config_file)
+
+    options = Options()
 
     def set_strict_flags() -> None:
         for dest, value in strict_flag_assignments:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -814,7 +814,7 @@ def process_options(args: List[str],
         default="",
         help=(
             "Regular expression to match file names, directory names or paths which mypy should "
-            "ignore while recursively discovering files to check, e.g. --exclude '/setup.py$'"
+            "ignore while recursively discovering files to check, e.g. --exclude '/setup\\.py$'"
         )
     )
     code_group.add_argument(

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -476,6 +476,7 @@ class FindModuleCache:
 
 
 def matches_ignore_pattern(path: str, pattern: str) -> bool:
+    path = os.path.splitdrive(path)[1]
     path_components = path.split(os.sep)
     pattern_components = pattern.split(os.sep)
     return all(

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -451,7 +451,7 @@ class FindModuleCache:
                 continue
             subpath = os.path.join(package_path, name)
             if self.options and any(
-                subpath.endswith(pattern.rstrip("/")) for pattern in self.options.ignore_path
+                matches_ignore_pattern(subpath, pattern) for pattern in self.options.ignore_path
             ):
                 continue
 
@@ -473,6 +473,15 @@ class FindModuleCache:
                     seen.add(stem)
                     sources.extend(self.find_modules_recursive(module + '.' + stem))
         return sources
+
+
+def matches_ignore_pattern(path: str, pattern: str) -> bool:
+    path_components = path.split(os.sep)
+    pattern_components = pattern.split(os.sep)
+    return all(
+        path == pattern
+        for path, pattern in zip(reversed(path_components), reversed(pattern_components))
+    )
 
 
 def verify_module(fscache: FileSystemCache, id: str, path: str, prefix: str) -> bool:

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -480,7 +480,7 @@ def matches_exclude(subpath: str, exclude: str, fscache: FileSystemCache, verbos
     if fscache.isdir(subpath):
         subpath_str += "/"
     if re.search(exclude, subpath_str):
-        if verbose >= 2:
+        if verbose:
             print("TRACE: Excluding {}".format(subpath_str), file=sys.stderr)
         return True
     return False

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -444,7 +444,7 @@ class FindModuleCache:
         names = sorted(self.fscache.listdir(package_path))
         for name in names:
             # Skip certain names altogether
-            if name in ("__pycache__", "site-packages") or name.startswith("."):
+            if name in ("__pycache__", "site-packages", "node_modules") or name.startswith("."):
                 continue
             subpath = os.path.join(package_path, name)
 

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -451,7 +451,7 @@ class FindModuleCache:
                 continue
             subpath = os.path.join(package_path, name)
             if self.options and any(
-                matches_ignore_pattern(subpath, pattern) for pattern in self.options.ignore_path
+                matches_exclude_pattern(subpath, pattern) for pattern in self.options.exclude
             ):
                 continue
 
@@ -475,7 +475,7 @@ class FindModuleCache:
         return sources
 
 
-def matches_ignore_pattern(path: str, pattern: str) -> bool:
+def matches_exclude_pattern(path: str, pattern: str) -> bool:
     path = os.path.splitdrive(path)[1]
     path_components = path.split(os.sep)
     pattern_components = pattern.replace(os.sep, "/").split("/")

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -443,9 +443,17 @@ class FindModuleCache:
         names = sorted(self.fscache.listdir(package_path))
         for name in names:
             # Skip certain names altogether
-            if name == '__pycache__' or name.startswith('.') or name.endswith('~'):
+            if (
+                name in ("__pycache__", "site-packages", "node_modules")
+                or name.startswith(".")
+                or name.endswith("~")
+            ):
                 continue
             subpath = os.path.join(package_path, name)
+            if self.options and any(
+                subpath.endswith(pattern.rstrip("/")) for pattern in self.options.ignore_path
+            ):
+                continue
 
             if self.fscache.isdir(subpath):
                 # Only recurse into packages

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -479,6 +479,8 @@ def matches_ignore_pattern(path: str, pattern: str) -> bool:
     path = os.path.splitdrive(path)[1]
     path_components = path.split(os.sep)
     pattern_components = pattern.split(os.sep)
+    if len(path_components) < len(pattern_components):
+        return False
     return all(
         path == pattern
         for path, pattern in zip(reversed(path_components), reversed(pattern_components))

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -444,22 +444,14 @@ class FindModuleCache:
         names = sorted(self.fscache.listdir(package_path))
         for name in names:
             # Skip certain names altogether
-            if (
-                name in ("__pycache__", "site-packages", "node_modules")
-                or name.startswith(".")
-                or name.endswith("~")
-            ):
+            if name in ("__pycache__", "site-packages") or name.startswith("."):
                 continue
             subpath = os.path.join(package_path, name)
 
-            if self.options and self.options.exclude:
-                subpath_str = os.path.abspath(subpath).replace(os.sep, "/")
-                if self.fscache.isdir(subpath):
-                    subpath_str += "/"
-                if re.search(self.options.exclude, subpath_str):
-                    if self.options.verbosity >= 2:
-                        print("TRACE: Excluding {}".format(subpath_str), file=sys.stderr)
-                    continue
+            if self.options and matches_exclude(
+                subpath, self.options.exclude, self.fscache, self.options.verbosity >= 2
+            ):
+                continue
 
             if self.fscache.isdir(subpath):
                 # Only recurse into packages
@@ -474,11 +466,24 @@ class FindModuleCache:
                 if stem == '__init__':
                     continue
                 if stem not in seen and '.' not in stem and suffix in PYTHON_EXTENSIONS:
-                    # (If we sorted names) we could probably just make the BuildSource ourselves,
-                    # but this ensures compatibility with find_module / the cache
+                    # (If we sorted names by keyfunc) we could probably just make the BuildSource
+                    # ourselves, but this ensures compatibility with find_module / the cache
                     seen.add(stem)
                     sources.extend(self.find_modules_recursive(module + '.' + stem))
         return sources
+
+
+def matches_exclude(subpath: str, exclude: str, fscache: FileSystemCache, verbose: bool) -> bool:
+    if not exclude:
+        return False
+    subpath_str = os.path.abspath(subpath).replace(os.sep, "/")
+    if fscache.isdir(subpath):
+        subpath_str += "/"
+    if re.search(exclude, subpath_str):
+        if verbose >= 2:
+            print("TRACE: Excluding {}".format(subpath_str), file=sys.stderr)
+        return True
+    return False
 
 
 def verify_module(fscache: FileSystemCache, id: str, path: str, prefix: str) -> bool:

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -478,7 +478,7 @@ class FindModuleCache:
 def matches_ignore_pattern(path: str, pattern: str) -> bool:
     path = os.path.splitdrive(path)[1]
     path_components = path.split(os.sep)
-    pattern_components = pattern.split(os.sep)
+    pattern_components = pattern.replace(os.sep, "/").split("/")
     if len(path_components) < len(pattern_components):
         return False
     return all(

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -453,10 +453,12 @@ class FindModuleCache:
             subpath = os.path.join(package_path, name)
 
             if self.options and self.options.exclude:
-                subpath_str = "/" + os.path.abspath(subpath).replace(os.sep, "/")
+                subpath_str = os.path.abspath(subpath).replace(os.sep, "/")
                 if self.fscache.isdir(subpath):
                     subpath_str += "/"
                 if re.search(self.options.exclude, subpath_str):
+                    if self.options.verbosity >= 2:
+                        print("TRACE: Excluding {}".format(subpath_str), file=sys.stderr)
                     continue
 
             if self.fscache.isdir(subpath):

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -98,7 +98,9 @@ class Options:
         # top-level __init__.py to your packages.
         self.explicit_package_bases = False
         # File names, directory names or subpaths to avoid checking
-        self.exclude = "/(__pycache__|site-packages|node_modules)/|/(\\.[^/]+|[^/]+~)/?$"  # type: str
+        self.exclude = (
+            "/(__pycache__|site-packages|node_modules)/|/(\\.[^/]+|[^/]+~)/?$"
+        ) # type: str
 
         # disallow_any options
         self.disallow_any_generics = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -97,6 +97,8 @@ class Options:
         # sufficient to determine module names for files. As a possible alternative, add a single
         # top-level __init__.py to your packages.
         self.explicit_package_bases = False
+        # File names, directory names or subpaths to avoid checking
+        self.ignore_path = []  # type: List[str]
 
         # disallow_any options
         self.disallow_any_generics = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -98,9 +98,7 @@ class Options:
         # top-level __init__.py to your packages.
         self.explicit_package_bases = False
         # File names, directory names or subpaths to avoid checking
-        self.exclude = (
-            "/(__pycache__|site-packages|node_modules)/|/(\\.[^/]+|[^/]+~)/?$"
-        ) # type: str
+        self.exclude = "" # type: str
 
         # disallow_any options
         self.disallow_any_generics = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -98,7 +98,7 @@ class Options:
         # top-level __init__.py to your packages.
         self.explicit_package_bases = False
         # File names, directory names or subpaths to avoid checking
-        self.exclude = []  # type: List[str]
+        self.exclude = "/(__pycache__|site-packages|node_modules)/|/(\\.[^/]+|[^/]+~)/?$"  # type: str
 
         # disallow_any options
         self.disallow_any_generics = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -98,7 +98,7 @@ class Options:
         # top-level __init__.py to your packages.
         self.explicit_package_bases = False
         # File names, directory names or subpaths to avoid checking
-        self.ignore_path = []  # type: List[str]
+        self.exclude = []  # type: List[str]
 
         # disallow_any options
         self.disallow_any_generics = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -98,7 +98,7 @@ class Options:
         # top-level __init__.py to your packages.
         self.explicit_package_bases = False
         # File names, directory names or subpaths to avoid checking
-        self.exclude = "" # type: str
+        self.exclude = ""  # type: str
 
         # disallow_any options
         self.disallow_any_generics = False

--- a/mypy/test/test_find_sources.py
+++ b/mypy/test/test_find_sources.py
@@ -257,6 +257,7 @@ class SourceFinderSuite(unittest.TestCase):
         options = Options()
         options.namespace_packages = True
 
+        # special cased name
         finder = SourceFinder(FakeFSCache({"/dir/a.py", "/dir/venv/site-packages/b.py"}), options)
         assert find_sources(finder, "/") == [("a", "/dir")]
 
@@ -268,13 +269,7 @@ class SourceFinderSuite(unittest.TestCase):
             "/pkg/a2/b/f.py",
         }
 
-        options.ignore_path = [
-            "/pkg/a", "2", "1", "pk", "kg", "g.py", "bc", "/b", "/xxx/pkg/a2/b/f.py"
-            "xxx/pkg/a2/b/f.py"
-        ]
-        finder = SourceFinder(FakeFSCache(files), options)
-        assert len(find_sources(finder, "/")) == len(files)
-
+        # directory name
         options.ignore_path = ["/pkg/a1"]
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [
@@ -283,6 +278,7 @@ class SourceFinderSuite(unittest.TestCase):
             ("a2.b.f", "/pkg"),
         ]
 
+        # file name
         options.ignore_path = ["f.py"]
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [
@@ -291,6 +287,24 @@ class SourceFinderSuite(unittest.TestCase):
             ("e", "/pkg/a1/b/c/d"),
         ]
 
+        # subpath
+        options.ignore_path = ["b/c"]
+        finder = SourceFinder(FakeFSCache(files), options)
+        assert find_sources(finder, "/") == [
+            ("a2", "/pkg"),
+            ("a2.b.f", "/pkg"),
+            ("f", "/pkg/a1/b"),
+        ]
+
+        # nothing should be ignored as a result of this
+        options.ignore_path = [
+            "/pkg/a", "2", "1", "pk", "kg", "g.py", "bc", "/b", "/xxx/pkg/a2/b/f.py"
+            "xxx/pkg/a2/b/f.py"
+        ]
+        finder = SourceFinder(FakeFSCache(files), options)
+        assert len(find_sources(finder, "/")) == len(files)
+
+        # nothing should be ignored as a result of this
         files = {
             "pkg/a1/b/c/d/e.py",
             "pkg/a1/b/f.py",
@@ -298,7 +312,6 @@ class SourceFinderSuite(unittest.TestCase):
             "pkg/a2/b/c/d/e.py",
             "pkg/a2/b/f.py",
         }
-
         options.ignore_path = [
             "/pkg/a", "2", "1", "pk", "kg", "g.py", "bc", "/b", "/xxx/pkg/a2/b/f.py",
             "xxx/pkg/a2/b/f.py", "/pkg/a1", "/pkg/a2"

--- a/mypy/test/test_find_sources.py
+++ b/mypy/test/test_find_sources.py
@@ -55,6 +55,7 @@ def find_sources_in_dir(finder: SourceFinder, f: str) -> List[Tuple[str, Optiona
 def find_sources(
     paths: List[str], options: Options, fscache: FileSystemCache
 ) -> List[Tuple[str, Optional[str]]]:
+    paths = [os.path.abspath(p) for p in paths]
     return normalise_build_source_list(create_source_list(paths, options, fscache))
 
 

--- a/mypy/test/test_find_sources.py
+++ b/mypy/test/test_find_sources.py
@@ -260,6 +260,8 @@ class SourceFinderSuite(unittest.TestCase):
         # default
         finder = SourceFinder(FakeFSCache({"/dir/a.py", "/dir/venv/site-packages/b.py"}), options)
         assert find_sources(finder, "/") == [("a", "/dir")]
+        assert find_sources(finder, "/dir/venv/") == []
+        assert find_sources(finder, "/dir/venv/site-packages") == [('b', '/dir/venv/site-packages')]
 
         files = {
             "/pkg/a1/b/c/d/e.py",
@@ -270,7 +272,7 @@ class SourceFinderSuite(unittest.TestCase):
         }
 
         # file name
-        options.exclude = "/f.py"
+        options.exclude = "/f.py$"
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [
             ("a2", "/pkg"),
@@ -289,6 +291,14 @@ class SourceFinderSuite(unittest.TestCase):
 
         # paths
         options.exclude = "/pkg/a1/"
+        finder = SourceFinder(FakeFSCache(files), options)
+        assert find_sources(finder, "/") == [
+            ("a2", "/pkg"),
+            ("a2.b.c.d.e", "/pkg"),
+            ("a2.b.f", "/pkg"),
+        ]
+
+        options.exclude = "/(a1|a3)/"
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [
             ("a2", "/pkg"),

--- a/mypy/test/test_find_sources.py
+++ b/mypy/test/test_find_sources.py
@@ -268,7 +268,10 @@ class SourceFinderSuite(unittest.TestCase):
             "/pkg/a2/b/f.py",
         }
 
-        options.ignore_path = ["/pkg/a", "2", "1", "pk", "kg", "g.py", "bc", "/b"]
+        options.ignore_path = [
+            "/pkg/a", "2", "1", "pk", "kg", "g.py", "bc", "/b", "/xxx/pkg/a2/b/f.py"
+            "xxx/pkg/a2/b/f.py"
+        ]
         finder = SourceFinder(FakeFSCache(files), options)
         assert len(find_sources(finder, "/")) == len(files)
 
@@ -297,7 +300,8 @@ class SourceFinderSuite(unittest.TestCase):
         }
 
         options.ignore_path = [
-            "/pkg/a", "2", "1", "pk", "kg", "g.py", "bc", "/b", "/pkg/a1", "/pkg/a2"
+            "/pkg/a", "2", "1", "pk", "kg", "g.py", "bc", "/b", "/xxx/pkg/a2/b/f.py",
+            "xxx/pkg/a2/b/f.py", "/pkg/a1", "/pkg/a2"
         ]
         finder = SourceFinder(FakeFSCache(files), options)
         assert len(find_sources(finder, "/")) == len(files)

--- a/mypy/test/test_find_sources.py
+++ b/mypy/test/test_find_sources.py
@@ -268,6 +268,10 @@ class SourceFinderSuite(unittest.TestCase):
             "/pkg/a2/b/f.py",
         }
 
+        options.ignore_path = ["/pkg/a", "2", "1", "pk", "kg", "g.py", "bc", "/b"]
+        finder = SourceFinder(FakeFSCache(files), options)
+        assert len(find_sources(finder, "/")) == len(files)
+
         options.ignore_path = ["/pkg/a1"]
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [
@@ -283,3 +287,17 @@ class SourceFinderSuite(unittest.TestCase):
             ("a2.b.c.d.e", "/pkg"),
             ("e", "/pkg/a1/b/c/d"),
         ]
+
+        files = {
+            "pkg/a1/b/c/d/e.py",
+            "pkg/a1/b/f.py",
+            "pkg/a2/__init__.py",
+            "pkg/a2/b/c/d/e.py",
+            "pkg/a2/b/f.py",
+        }
+
+        options.ignore_path = [
+            "/pkg/a", "2", "1", "pk", "kg", "g.py", "bc", "/b", "/pkg/a1", "/pkg/a2"
+        ]
+        finder = SourceFinder(FakeFSCache(files), options)
+        assert len(find_sources(finder, "/")) == len(files)

--- a/mypy/test/test_find_sources.py
+++ b/mypy/test/test_find_sources.py
@@ -253,7 +253,7 @@ class SourceFinderSuite(unittest.TestCase):
         finder = SourceFinder(FakeFSCache({"/a/pkg/a.py", "/b/pkg/b.py"}), options)
         assert find_sources(finder, "/") == [("pkg.a", "/a"), ("pkg.b", "/b")]
 
-    def test_find_sources_ignore_path(self) -> None:
+    def test_find_sources_exclude(self) -> None:
         options = Options()
         options.namespace_packages = True
 
@@ -270,7 +270,7 @@ class SourceFinderSuite(unittest.TestCase):
         }
 
         # file name
-        options.ignore_path = ["f.py"]
+        options.exclude = ["f.py"]
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [
             ("a2", "/pkg"),
@@ -279,7 +279,7 @@ class SourceFinderSuite(unittest.TestCase):
         ]
 
         # directory name
-        options.ignore_path = ["a1"]
+        options.exclude = ["a1"]
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [
             ("a2", "/pkg"),
@@ -288,7 +288,7 @@ class SourceFinderSuite(unittest.TestCase):
         ]
 
         # paths
-        options.ignore_path = ["/pkg/a1"]
+        options.exclude = ["/pkg/a1"]
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [
             ("a2", "/pkg"),
@@ -296,7 +296,7 @@ class SourceFinderSuite(unittest.TestCase):
             ("a2.b.f", "/pkg"),
         ]
 
-        options.ignore_path = ["b/c"]
+        options.exclude = ["b/c"]
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [
             ("a2", "/pkg"),
@@ -305,7 +305,7 @@ class SourceFinderSuite(unittest.TestCase):
         ]
 
         # nothing should be ignored as a result of this
-        options.ignore_path = [
+        options.exclude = [
             "/pkg/a", "2", "1", "pk", "kg", "g.py", "bc", "/b", "/xxx/pkg/a2/b/f.py"
             "xxx/pkg/a2/b/f.py"
         ]
@@ -320,7 +320,7 @@ class SourceFinderSuite(unittest.TestCase):
             "pkg/a2/b/c/d/e.py",
             "pkg/a2/b/f.py",
         }
-        options.ignore_path = [
+        options.exclude = [
             "/pkg/a", "2", "1", "pk", "kg", "g.py", "bc", "/b", "/xxx/pkg/a2/b/f.py",
             "xxx/pkg/a2/b/f.py", "/pkg/a1", "/pkg/a2"
         ]

--- a/mypy/test/test_find_sources.py
+++ b/mypy/test/test_find_sources.py
@@ -257,7 +257,7 @@ class SourceFinderSuite(unittest.TestCase):
         options = Options()
         options.namespace_packages = True
 
-        # special cased name
+        # default
         finder = SourceFinder(FakeFSCache({"/dir/a.py", "/dir/venv/site-packages/b.py"}), options)
         assert find_sources(finder, "/") == [("a", "/dir")]
 
@@ -270,7 +270,7 @@ class SourceFinderSuite(unittest.TestCase):
         }
 
         # file name
-        options.exclude = ["f.py"]
+        options.exclude = "/f.py"
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [
             ("a2", "/pkg"),
@@ -279,7 +279,7 @@ class SourceFinderSuite(unittest.TestCase):
         ]
 
         # directory name
-        options.exclude = ["a1"]
+        options.exclude = "/a1/"
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [
             ("a2", "/pkg"),
@@ -288,7 +288,7 @@ class SourceFinderSuite(unittest.TestCase):
         ]
 
         # paths
-        options.exclude = ["/pkg/a1"]
+        options.exclude = "/pkg/a1/"
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [
             ("a2", "/pkg"),
@@ -296,7 +296,7 @@ class SourceFinderSuite(unittest.TestCase):
             ("a2.b.f", "/pkg"),
         ]
 
-        options.exclude = ["b/c"]
+        options.exclude = "b/c/"
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [
             ("a2", "/pkg"),
@@ -305,14 +305,13 @@ class SourceFinderSuite(unittest.TestCase):
         ]
 
         # nothing should be ignored as a result of this
-        options.exclude = [
-            "/pkg/a", "2", "1", "pk", "kg", "g.py", "bc", "/b", "/xxx/pkg/a2/b/f.py"
-            "xxx/pkg/a2/b/f.py"
-        ]
+        options.exclude = "|".join((
+            "/pkg/a/", "/2", "/1", "/pk/", "/kg", "/g.py", "/bc", "/xxx/pkg/a2/b/f.py"
+            "xxx/pkg/a2/b/f.py",
+        ))
         finder = SourceFinder(FakeFSCache(files), options)
         assert len(find_sources(finder, "/")) == len(files)
 
-        # nothing should be ignored as a result of this
         files = {
             "pkg/a1/b/c/d/e.py",
             "pkg/a1/b/f.py",
@@ -320,9 +319,5 @@ class SourceFinderSuite(unittest.TestCase):
             "pkg/a2/b/c/d/e.py",
             "pkg/a2/b/f.py",
         }
-        options.exclude = [
-            "/pkg/a", "2", "1", "pk", "kg", "g.py", "bc", "/b", "/xxx/pkg/a2/b/f.py",
-            "xxx/pkg/a2/b/f.py", "/pkg/a1", "/pkg/a2"
-        ]
         finder = SourceFinder(FakeFSCache(files), options)
         assert len(find_sources(finder, "/")) == len(files)

--- a/mypy/test/test_find_sources.py
+++ b/mypy/test/test_find_sources.py
@@ -269,15 +269,6 @@ class SourceFinderSuite(unittest.TestCase):
             "/pkg/a2/b/f.py",
         }
 
-        # directory name
-        options.ignore_path = ["/pkg/a1"]
-        finder = SourceFinder(FakeFSCache(files), options)
-        assert find_sources(finder, "/") == [
-            ("a2", "/pkg"),
-            ("a2.b.c.d.e", "/pkg"),
-            ("a2.b.f", "/pkg"),
-        ]
-
         # file name
         options.ignore_path = ["f.py"]
         finder = SourceFinder(FakeFSCache(files), options)
@@ -287,7 +278,24 @@ class SourceFinderSuite(unittest.TestCase):
             ("e", "/pkg/a1/b/c/d"),
         ]
 
-        # subpath
+        # directory name
+        options.ignore_path = ["a1"]
+        finder = SourceFinder(FakeFSCache(files), options)
+        assert find_sources(finder, "/") == [
+            ("a2", "/pkg"),
+            ("a2.b.c.d.e", "/pkg"),
+            ("a2.b.f", "/pkg"),
+        ]
+
+        # paths
+        options.ignore_path = ["/pkg/a1"]
+        finder = SourceFinder(FakeFSCache(files), options)
+        assert find_sources(finder, "/") == [
+            ("a2", "/pkg"),
+            ("a2.b.c.d.e", "/pkg"),
+            ("a2.b.f", "/pkg"),
+        ]
+
         options.ignore_path = ["b/c"]
         finder = SourceFinder(FakeFSCache(files), options)
         assert find_sources(finder, "/") == [

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -19,4 +19,4 @@ pretty = True
 always_false = MYPYC
 plugins = misc/proper_plugin.py
 python_version = 3.5
-exclude = /(mypy/typeshed|__pycache__|site-packages|node_modules)/|/(\.[^/]+|[^/]+~)/?$
+exclude = /(mypy/typeshed|__pycache__|site-packages)/|/(\.[^/]+)/?$

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -19,3 +19,4 @@ pretty = True
 always_false = MYPYC
 plugins = misc/proper_plugin.py
 python_version = 3.5
+ignore_path = mypy/typeshed

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -19,4 +19,4 @@ pretty = True
 always_false = MYPYC
 plugins = misc/proper_plugin.py
 python_version = 3.5
-exclude = mypy/typeshed
+exclude = /(mypy/typeshed|__pycache__|site-packages|node_modules)/|/(\.[^/]+|[^/]+~)/?$

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -19,4 +19,4 @@ pretty = True
 always_false = MYPYC
 plugins = misc/proper_plugin.py
 python_version = 3.5
-ignore_path = mypy/typeshed
+exclude = mypy/typeshed

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -19,4 +19,4 @@ pretty = True
 always_false = MYPYC
 plugins = misc/proper_plugin.py
 python_version = 3.5
-exclude = /(mypy/typeshed|__pycache__|site-packages)/|/(\.[^/]+)/?$
+exclude = /mypy/typeshed/

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -59,7 +59,7 @@ undef
 undef
 [out]
 dir/a.py: error: Duplicate module named 'a' (also at 'dir/subdir/a.py')
-dir/a.py: error: Are you missing an __init__.py?
+dir/a.py: note: Are you missing an __init__.py? Alternatively, consider using --ignore-path to avoid checking one of them.
 == Return code: 2
 
 [case testCmdlineNonPackageSlash]
@@ -125,19 +125,7 @@ mypy: can't decode file 'a.py': unknown encoding: uft-8
 # type: ignore
 [out]
 two/mod/__init__.py: error: Duplicate module named 'mod' (also at 'one/mod/__init__.py')
-== Return code: 2
-
-[case promptsForgotInit]
-# cmd: mypy a.py one/mod/a.py
-[file one/__init__.py]
-# type: ignore
-[file a.py]
-# type: ignore
-[file one/mod/a.py]
-#type: ignore
-[out]
-one/mod/a.py: error: Duplicate module named 'a' (also at 'a.py')
-one/mod/a.py: error: Are you missing an __init__.py?
+two/mod/__init__.py: note: Are you missing an __init__.py? Alternatively, consider using --ignore-path to avoid checking one of them.
 == Return code: 2
 
 [case testFlagsFile]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -59,7 +59,7 @@ undef
 undef
 [out]
 dir/a.py: error: Duplicate module named 'a' (also at 'dir/subdir/a.py')
-dir/a.py: note: Are you missing an __init__.py? Alternatively, consider using --ignore-path to avoid checking one of them.
+dir/a.py: note: Are you missing an __init__.py? Alternatively, consider using --exclude to avoid checking one of them.
 == Return code: 2
 
 [case testCmdlineNonPackageSlash]
@@ -125,7 +125,7 @@ mypy: can't decode file 'a.py': unknown encoding: uft-8
 # type: ignore
 [out]
 two/mod/__init__.py: error: Duplicate module named 'mod' (also at 'one/mod/__init__.py')
-two/mod/__init__.py: note: Are you missing an __init__.py? Alternatively, consider using --ignore-path to avoid checking one of them.
+two/mod/__init__.py: note: Are you missing an __init__.py? Alternatively, consider using --exclude to avoid checking one of them.
 == Return code: 2
 
 [case testFlagsFile]


### PR DESCRIPTION
Resolves #4675, resolves #9981

Additionally, we always ignore site-packages and node_modules.
Also note that this doesn't really affect import discovery; it only
directly affects passing files or packages to mypy.

The additional check before suggesting "are you missing an
__init__.py" didn't make any sense to me, so I removed it, appended to
the message and downgraded the severity to note.