### PR TITLE
Add explicit_package_bases to docs

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -207,6 +207,19 @@ section of the command line docs.
 
     This option may only be set in the global section (``[mypy]``).
 
+.. confval:: explicit_package_bases
+
+    :type: boolean
+    :default: False
+
+    This flag tells mypy that top-level packages will be based in either the
+    current directory, or a member of the ``MYPYPATH`` environment variable or
+    :confval:`mypy_path` config option. This option is only useful in
+    conjunction with :option:`namespace_packages`. See :ref:`Mapping file
+    paths to modules <mapping-paths-to-modules>` for details.
+
+    This option may only be set in the global section (``[mypy]``).
+
 .. confval:: ignore_missing_imports
 
     :type: boolean

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -215,7 +215,7 @@ section of the command line docs.
     This flag tells mypy that top-level packages will be based in either the
     current directory, or a member of the ``MYPYPATH`` environment variable or
     :confval:`mypy_path` config option. This option is only useful in
-    conjunction with :option:`namespace_packages`. See :ref:`Mapping file
+    conjunction with :confval:`namespace_packages`. See :ref:`Mapping file
     paths to modules <mapping-paths-to-modules>` for details.
 
     This option may only be set in the global section (``[mypy]``).


### PR DESCRIPTION
This value appears to be supported in the config file, but is missing from the docs.