### PR TITLE
Fix mypy daemon crash when following from a new module

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -620,11 +620,11 @@ class Server:
 
         fix_module_deps(graph)
 
-        # Store current file state as side effect
-        self.fswatcher.find_changed()
-
         self.previous_sources = find_all_sources_in_build(graph)
         self.update_sources(self.previous_sources)
+
+        # Store current file state as side effect
+        self.fswatcher.find_changed()
 
         t5 = time.time()
 


### PR DESCRIPTION
File watcher state for files added to the build wasn't updated
correctly, resulting in crashes.

I couldn't find a way to reproduce this in our test environment,
so I only tested this manually.

Fixes #10029.