### PR TITLE
Keep track of fine-grained deps for modules in typeshed

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2205,12 +2205,14 @@ class State:
 
     def compute_fine_grained_deps(self) -> Dict[str, Set[str]]:
         assert self.tree is not None
-        if '/typeshed/' in self.xpath or self.xpath.startswith('typeshed/'):
-            # We don't track changes to typeshed -- the assumption is that they are only changed
-            # as part of mypy updates, which will invalidate everything anyway.
-            #
-            # TODO: Not a reliable test, as we could have a package named typeshed.
-            # TODO: Consider relaxing this -- maybe allow some typeshed changes to be tracked.
+        if self.id in ('builtins', 'typing', 'types', 'sys', '_typeshed'):
+            # We don't track changes to core parts of typeshed -- the
+            # assumption is that they are only changed as part of mypy
+            # updates, which will invalidate everything anyway. These
+            # will always be processed in the initial non-fine-grained
+            # build. Other modules may be brought in as a result of an
+            # fine-grained increment, and we may need these
+            # dependencies then to handle cyclic imports.
             return {}
         from mypy.server.deps import get_dependencies  # Lazy import to speed up startup
         return get_dependencies(target=self.tree,


### PR DESCRIPTION
Even if we assume that typeshed stubs don't change, we need the deps
when bringing in new stubs when following imports during a fine-grained
increment.

This fixes false positives when following imports to `six` and
`requests`.

Some modules are always part of the initial build, and we can still
skip generating deps for them, as an optimization.

I only tested this manually, since I couldn't figure out an easy way to
reproduce the issue in our tests.

Fixes #10033.
