### PR TITLE
Make "Using isinstance() with protocols" example runnable

### DIFF
--- a/docs/source/protocols.rst
+++ b/docs/source/protocols.rst
@@ -429,6 +429,8 @@ support for basic runtime structural checks:
        def __init__(self) -> None:
            self.handles = 1
 
+   def use(handles: int) -> None: ...
+
    mug = Mug()
    if isinstance(mug, Portable):
       use(mug.handles)  # Works statically and at runtime


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

Most code snippets from the documentation are runnable - they can be pasted into temporary `t.py` files, and then `mypy t.py` works. Doing so is a good way to make sense of the documentation.

The example about [using isinstance with protocols](https://mypy.readthedocs.io/en/stable/protocols.html#using-isinstance-with-protocols), however, throws 

```console
$ mypy t.py 
t.py:13: error: Name 'use' is not defined
Found 1 error in 1 file (checked 1 source file)
```

So, here's a little PR to make the example runnable, such that we have:
```console
$ mypy t.py 
Success: no issues found in 1 source file
```
and, if we remove `@runtime_checkable`,
```console
$ mypy t.py 
t.py:14: error: Only @runtime_checkable protocols can be used with instance and class checks
```

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

This is just a simple doc change