### PR TITLE
[mypyc] Add LoadLiteral and use tables to construct and store literals

### DIFF
--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -7,7 +7,7 @@ from typing import Dict, Tuple, List, Set, TypeVar, Iterator, Generic, Optional,
 from mypyc.ir.ops import (
     Value, ControlOp,
     BasicBlock, OpVisitor, Assign, Integer, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
-    Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
+    Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr, LoadLiteral,
     LoadStatic, InitStatic, MethodCall, RaiseStandardError, CallC, LoadGlobal,
     Truncate, IntOp, LoadMem, GetElementPtr, LoadAddress, ComparisonOp, SetMem
 )
@@ -163,6 +163,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_load_error_value(self, op: LoadErrorValue) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_load_literal(self, op: LoadLiteral) -> GenAndKill:
         return self.visit_register_op(op)
 
     def visit_get_attr(self, op: GetAttr) -> GenAndKill:

--- a/mypyc/codegen/cstring.py
+++ b/mypyc/codegen/cstring.py
@@ -47,3 +47,9 @@ def encode_bytes_as_c_string(b: bytes) -> Tuple[str, int]:
     """Produce a quoted C string literal and its size, for a byte string."""
     escaped = ''.join([CHAR_MAP[i] for i in b])
     return '"{}"'.format(escaped), len(b)
+
+
+def encode_bytes_as_c_string_2(b: bytes) -> Tuple[str, int]:
+    """Produce a quoted C string literal and its size, for a byte string."""
+    escaped = ''.join([CHAR_MAP[i] for i in b])
+    return escaped, len(b)

--- a/mypyc/codegen/cstring.py
+++ b/mypyc/codegen/cstring.py
@@ -19,7 +19,6 @@ octal digits.
 """
 
 import string
-from typing import Tuple
 
 CHAR_MAP = ['\\{:03o}'.format(i) for i in range(256)]
 
@@ -38,18 +37,7 @@ for c in ('\'', '"', '\\', 'a', 'b', 'f', 'n', 'r', 't', 'v'):
 CHAR_MAP[ord('?')] = r'\?'
 
 
-def encode_as_c_string(s: str) -> Tuple[str, int]:
-    """Produce a quoted C string literal and its size, for a UTF-8 string."""
-    return encode_bytes_as_c_string(s.encode('utf-8'))
-
-
-def encode_bytes_as_c_string(b: bytes) -> Tuple[str, int]:
+def encode_bytes_as_c_string(b: bytes) -> str:
     """Produce a quoted C string literal and its size, for a byte string."""
     escaped = ''.join([CHAR_MAP[i] for i in b])
-    return '"{}"'.format(escaped), len(b)
-
-
-def encode_bytes_as_c_string_2(b: bytes) -> Tuple[str, int]:
-    """Produce a quoted C string literal and its size, for a byte string."""
-    escaped = ''.join([CHAR_MAP[i] for i in b])
-    return escaped, len(b)
+    return escaped

--- a/mypyc/codegen/cstring.py
+++ b/mypyc/codegen/cstring.py
@@ -21,7 +21,10 @@ octal digits.
 from typing import List
 import string
 
-CHAR_MAP = ['\\{:03o}'.format(i) for i in range(256)]
+from typing_extensions import Final
+
+
+CHAR_MAP = ['\\{:03o}'.format(i) for i in range(256)]  # type: Final
 
 # It is safe to use string.printable as it always uses the C locale.
 for c in string.printable:
@@ -57,12 +60,12 @@ def c_string_initializer(components: List[bytes]) -> str:
     res = []
     current = ''
     for c in components:
-        cc = encode_bytes_as_c_string(c)
-        if not current or len(current) + len(cc) < 70:
-            current += cc
+        enc = encode_bytes_as_c_string(c)
+        if not current or len(current) + len(enc) < 70:
+            current += enc
         else:
             res.append('"%s"' % current)
-            current = cc
+            current = enc
     if current:
         res.append('"%s"' % current)
     if len(res) > 1:

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -20,6 +20,7 @@ from mypyc.ir.func_ir import FuncDecl
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
 from mypyc.namegen import NameGenerator, exported_name
 from mypyc.sametype import is_same_type
+from mypyc.codegen.literals import Literals
 
 
 class HeaderDeclaration:
@@ -83,6 +84,8 @@ class EmitterContext:
         # used for declaring structs and the key corresponds to the name of the struct.
         # The declaration contains the body of the struct.
         self.declarations = OrderedDict()  # type: Dict[str, HeaderDeclaration]
+
+        self.literals = Literals()
 
 
 class Emitter:

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -96,6 +96,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         self.declarations = declarations
         self.source_path = source_path
         self.module_name = module_name
+        self.literals = emitter.context.literals
 
     def temp_name(self) -> str:
         return self.emitter.temp_name()
@@ -174,8 +175,8 @@ class FunctionEmitterVisitor(OpVisitor[None]):
                                          self.c_error_value(op.type)))
 
     def visit_load_literal(self, op: LoadLiteral) -> None:
-        # TODO
-        assert False
+        index = self.literals.literal_index(op.value)
+        self.emit_line('%s = CPyStatics[%d]; /* %r */' % (self.reg(op), index, op.value))
 
     def get_attr_expr(self, obj: str, op: Union[GetAttr, SetAttr], decl_cl: ClassIR) -> str:
         """Generate attribute accessor for normal (non-property) access.

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -16,7 +16,7 @@ from mypyc.ir.ops import (
 )
 from mypyc.ir.rtypes import (
     RType, RTuple, is_tagged, is_int32_rprimitive, is_int64_rprimitive, RStruct,
-    is_pointer_rprimitive
+    is_pointer_rprimitive, is_int_rprimitive
 )
 from mypyc.ir.func_ir import FuncIR, FuncDecl, FUNC_STATICMETHOD, FUNC_CLASSMETHOD, all_values
 from mypyc.ir.class_ir import ClassIR
@@ -181,7 +181,11 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             ann = ' /* %s */' % s
         else:
             ann = ''
-        self.emit_line('%s = CPyStatics[%d];%s' % (self.reg(op), index, ann))
+        if not is_int_rprimitive(op.type):
+            self.emit_line('%s = CPyStatics[%d];%s' % (self.reg(op), index, ann))
+        else:
+            self.emit_line('%s = (CPyTagged)CPyStatics[%d] | 1;%s' % (
+                self.reg(op), index, ann))
 
     def get_attr_expr(self, obj: str, op: Union[GetAttr, SetAttr], decl_cl: ClassIR) -> str:
         """Generate attribute accessor for normal (non-property) access.

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -12,7 +12,7 @@ from mypyc.ir.ops import (
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
     BasicBlock, Value, MethodCall, Unreachable, NAMESPACE_STATIC, NAMESPACE_TYPE, NAMESPACE_MODULE,
     RaiseStandardError, CallC, LoadGlobal, Truncate, IntOp, LoadMem, GetElementPtr,
-    LoadAddress, ComparisonOp, SetMem, Register
+    LoadAddress, ComparisonOp, SetMem, Register, LoadLiteral
 )
 from mypyc.ir.rtypes import (
     RType, RTuple, is_tagged, is_int32_rprimitive, is_int64_rprimitive, RStruct,
@@ -172,6 +172,10 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         else:
             self.emit_line('%s = %s;' % (self.reg(op),
                                          self.c_error_value(op.type)))
+
+    def visit_load_literal(self, op: LoadLiteral) -> None:
+        # TODO
+        assert False
 
     def get_attr_expr(self, obj: str, op: Union[GetAttr, SetAttr], decl_cl: ClassIR) -> str:
         """Generate attribute accessor for normal (non-property) access.

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -176,7 +176,12 @@ class FunctionEmitterVisitor(OpVisitor[None]):
 
     def visit_load_literal(self, op: LoadLiteral) -> None:
         index = self.literals.literal_index(op.value)
-        self.emit_line('%s = CPyStatics[%d]; /* %r */' % (self.reg(op), index, op.value))
+        s = repr(op.value)
+        if not any(x in s for x in ('/*', '*/', '\0')):
+            ann = ' /* %s */' % s
+        else:
+            ann = ''
+        self.emit_line('%s = CPyStatics[%d];%s' % (self.reg(op), index, ann))
 
     def get_attr_expr(self, obj: str, op: Union[GetAttr, SetAttr], decl_cl: ClassIR) -> str:
         """Generate attribute accessor for normal (non-property) access.

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -638,6 +638,8 @@ class GroupGenerator:
         self.declare_global('const char []', 'BytesLiterals', initializer=init_bytes)
         init_floats = '{%s}' % ', '.join(literals.encoded_float_values())
         self.declare_global('const double []', 'FloatLiterals', initializer=init_floats)
+        init_complex = '{%s}' % ', '.join(literals.encoded_complex_values())
+        self.declare_global('const double []', 'ComplexLiterals', initializer=init_complex)
 
     def cstring_initializer(self, components: List[bytes]) -> str:
         res = []
@@ -827,7 +829,7 @@ class GroupGenerator:
         for symbol, fixup in self.simple_inits:
             emitter.emit_line('{} = {};'.format(symbol, fixup))
 
-        values = 'StrLiterals, BytesLiterals, FloatLiterals'
+        values = 'StrLiterals, BytesLiterals, FloatLiterals, ComplexLiterals'
         emitter.emit_lines('if (CPyStatics_Initialize(CPyStatics, {}) < 0) {{'.format(values),
                            'return -1;',
                            '}')

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -636,6 +636,8 @@ class GroupGenerator:
         self.declare_global('const char []', 'StrLiterals', initializer=init_str)
         init_bytes = self.cstring_initializer(literals.encoded_bytes_values())
         self.declare_global('const char []', 'BytesLiterals', initializer=init_bytes)
+        init_floats = '{%s}' % ', '.join(literals.encoded_float_values())
+        self.declare_global('const double []', 'FloatLiterals', initializer=init_floats)
 
     def cstring_initializer(self, components: List[bytes]) -> str:
         res = []
@@ -825,7 +827,7 @@ class GroupGenerator:
         for symbol, fixup in self.simple_inits:
             emitter.emit_line('{} = {};'.format(symbol, fixup))
 
-        values = 'StrLiterals, BytesLiterals'
+        values = 'StrLiterals, BytesLiterals, FloatLiterals'
         emitter.emit_lines('if (CPyStatics_Initialize(CPyStatics, {}) < 0) {{'.format(values),
                            'return -1;',
                            '}')

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -636,6 +636,8 @@ class GroupGenerator:
         self.declare_global('const char []', 'StrLiterals', initializer=init_str)
         init_bytes = self.cstring_initializer(literals.encoded_bytes_values())
         self.declare_global('const char []', 'BytesLiterals', initializer=init_bytes)
+        init_int = self.cstring_initializer(literals.encoded_int_values())
+        self.declare_global('const char []', 'IntLiterals', initializer=init_int)
         init_floats = '{%s}' % ', '.join(literals.encoded_float_values())
         self.declare_global('const double []', 'FloatLiterals', initializer=init_floats)
         init_complex = '{%s}' % ', '.join(literals.encoded_complex_values())
@@ -829,7 +831,7 @@ class GroupGenerator:
         for symbol, fixup in self.simple_inits:
             emitter.emit_line('{} = {};'.format(symbol, fixup))
 
-        values = 'StrLiterals, BytesLiterals, FloatLiterals, ComplexLiterals'
+        values = 'StrLiterals, BytesLiterals, IntLiterals, FloatLiterals, ComplexLiterals'
         emitter.emit_lines('if (CPyStatics_Initialize(CPyStatics, {}) < 0) {{'.format(values),
                            'return -1;',
                            '}')

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -630,19 +630,19 @@ class GroupGenerator:
         self.declare_global('PyObject *[%d]' % literals.num_literals(), 'CPyStatics')
         # Descriptions of str literals
         init_str = c_string_initializer(literals.encoded_str_values())
-        self.declare_global('const char []', 'StrLiterals', initializer=init_str)
+        self.declare_global('const char []', 'CPyLit_Str', initializer=init_str)
         # Descriptions of bytes literals
         init_bytes = c_string_initializer(literals.encoded_bytes_values())
-        self.declare_global('const char []', 'BytesLiterals', initializer=init_bytes)
+        self.declare_global('const char []', 'CPyLit_Bytes', initializer=init_bytes)
         # Descriptions of int literals
         init_int = c_string_initializer(literals.encoded_int_values())
-        self.declare_global('const char []', 'IntLiterals', initializer=init_int)
+        self.declare_global('const char []', 'CPyLit_Int', initializer=init_int)
         # Descriptions of float literals
         init_floats = c_array_initializer(literals.encoded_float_values())
-        self.declare_global('const double []', 'FloatLiterals', initializer=init_floats)
+        self.declare_global('const double []', 'CPyLit_Float', initializer=init_floats)
         # Descriptions of complex literals
         init_complex = c_array_initializer(literals.encoded_complex_values())
-        self.declare_global('const double []', 'ComplexLiterals', initializer=init_complex)
+        self.declare_global('const double []', 'CPyLit_Complex', initializer=init_complex)
 
     def generate_export_table(self, decl_emitter: Emitter, code_emitter: Emitter) -> None:
         """Generate the declaration and definition of the group's export struct.
@@ -816,7 +816,7 @@ class GroupGenerator:
         for symbol, fixup in self.simple_inits:
             emitter.emit_line('{} = {};'.format(symbol, fixup))
 
-        values = 'StrLiterals, BytesLiterals, IntLiterals, FloatLiterals, ComplexLiterals'
+        values = 'CPyLit_Str, CPyLit_Bytes, CPyLit_Int, CPyLit_Float, CPyLit_Complex'
         emitter.emit_lines('if (CPyStatics_Initialize(CPyStatics, {}) < 0) {{'.format(values),
                            'return -1;',
                            '}')

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -5,6 +5,7 @@ class Literals:
     """Collection of literal values used in a compilation group and related helpers."""
 
     def __init__(self) -> None:
+        # Each dict maps value to literal index (0, 1, ...)
         self.str_literals = {}  # type: Dict[str, int]
         self.bytes_literals = {}  # type: Dict[bytes, int]
         self.int_literals = {}  # type: Dict[int, int]

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -1,4 +1,6 @@
-from typing import Dict, Type, Optional
+from typing import Dict, Type, List
+
+from mypyc.codegen.cstring import encode_bytes_as_c_string
 
 
 class Literals:
@@ -8,6 +10,7 @@ class Literals:
         self.literals = {}  # type: Dict[Type[object], Dict[str, int]]
 
     def record_literal(self, value: str) -> None:
+        """Ensure that the literal value is available in generated code."""
         literals = self.literals
         t = type(value)
         if t not in literals:
@@ -17,4 +20,36 @@ class Literals:
             d[value] = len(d)
 
     def literal_index(self, value: str) -> int:
+        """Return the index to the literals array for given value."""
         return self.literals[str][value]
+
+    def encoded_str_values(self) -> List[bytes]:
+        return encode_str_values(self.literals[str])
+
+
+def encode_str_values(values: Dict[str, int]) -> List[bytes]:
+    value_by_index = {}
+    for value, index in values.items():
+        value_by_index[index] = value
+    result = []
+    for i in range(len(values)):
+        value = value_by_index[i]
+        c_literal = format_str_literal(value)
+        result.append(c_literal)
+    return result
+
+
+def format_int(n: int) -> bytes:
+    if n < 128:
+        return bytes([n])
+    result = b''
+    while n >= 128:
+        result += bytes([(n & 0x7f) | 128])
+        n >>= 7
+    result += bytes([n])
+    return result
+
+
+def format_str_literal(s: str) -> bytes:
+    utf8 = s.encode('utf-8')
+    return format_int(len(utf8)) + utf8

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -10,8 +10,9 @@ class Literals:
         self.str_literals = {}  # type: Dict[str, int]
         self.bytes_literals = {}  # type: Dict[bytes, int]
         self.float_literals = {}  # type: Dict[float, int]
+        self.complex_literals = {}  # type: Dict[complex, int]
 
-    def record_literal(self, value: Union[str, bytes, float]) -> None:
+    def record_literal(self, value: Union[str, bytes, float, complex]) -> None:
         """Ensure that the literal value is available in generated code."""
         if isinstance(value, str):
             str_literals = self.str_literals
@@ -25,10 +26,14 @@ class Literals:
             float_literals = self.float_literals
             if value not in float_literals:
                 float_literals[value] = len(float_literals)
+        elif isinstance(value, complex):
+            complex_literals = self.complex_literals
+            if value not in complex_literals:
+                complex_literals[value] = len(complex_literals)
         else:
             assert False, 'invalid literal: %r' % value
 
-    def literal_index(self, value: Union[str, bytes, float]) -> int:
+    def literal_index(self, value: Union[str, bytes, float, complex]) -> int:
         """Return the index to the literals array for given value."""
         if isinstance(value, str):
             return self.str_literals[value]
@@ -38,10 +43,14 @@ class Literals:
         n += len(self.bytes_literals)
         if isinstance(value, float):
             return n + self.float_literals[value]
+        n += len(self.float_literals)
+        if isinstance(value, complex):
+            return n + self.complex_literals[value]
         assert False, 'invalid literal: %r' % value
 
     def num_literals(self) -> int:
-        return len(self.str_literals) + len(self.bytes_literals) + len(self.float_literals)
+        return (len(self.str_literals) + len(self.bytes_literals) + len(self.float_literals) +
+                len(self.complex_literals))
 
     def encoded_str_values(self) -> List[bytes]:
         return encode_str_values(self.str_literals)
@@ -51,6 +60,9 @@ class Literals:
 
     def encoded_float_values(self) -> List[str]:
         return encode_float_values(self.float_literals)
+
+    def encoded_complex_values(self) -> List[str]:
+        return encode_complex_values(self.complex_literals)
 
 
 def encode_str_values(values: Dict[str, int]) -> List[bytes]:
@@ -81,19 +93,6 @@ def encode_bytes_values(values: Dict[bytes, int]) -> List[bytes]:
     return result
 
 
-def encode_float_values(values: Dict[float, int]) -> List[str]:
-    value_by_index = {}
-    for value, index in values.items():
-        value_by_index[index] = value
-    result = []
-    num = len(values)
-    result.append(str(num))
-    for i in range(num):
-        value = value_by_index[i]
-        result.append(str(value))
-    return result
-
-
 def format_int(n: int) -> bytes:
     if n < 128:
         a = [n]
@@ -110,3 +109,30 @@ def format_int(n: int) -> bytes:
 def format_str_literal(s: str) -> bytes:
     utf8 = s.encode('utf-8')
     return format_int(len(utf8)) + utf8
+
+
+def encode_float_values(values: Dict[float, int]) -> List[str]:
+    value_by_index = {}
+    for value, index in values.items():
+        value_by_index[index] = value
+    result = []
+    num = len(values)
+    result.append(str(num))
+    for i in range(num):
+        value = value_by_index[i]
+        result.append(str(value))
+    return result
+
+
+def encode_complex_values(values: Dict[complex, int]) -> List[str]:
+    value_by_index = {}
+    for value, index in values.items():
+        value_by_index[index] = value
+    result = []
+    num = len(values)
+    result.append(str(num))
+    for i in range(num):
+        value = value_by_index[i]
+        result.append(str(value.real))
+        result.append(str(value.imag))
+    return result

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -9,10 +9,11 @@ class Literals:
     def __init__(self) -> None:
         self.str_literals = {}  # type: Dict[str, int]
         self.bytes_literals = {}  # type: Dict[bytes, int]
+        self.int_literals = {}  # type: Dict[int, int]
         self.float_literals = {}  # type: Dict[float, int]
         self.complex_literals = {}  # type: Dict[complex, int]
 
-    def record_literal(self, value: Union[str, bytes, float, complex]) -> None:
+    def record_literal(self, value: Union[str, bytes, int, float, complex]) -> None:
         """Ensure that the literal value is available in generated code."""
         if isinstance(value, str):
             str_literals = self.str_literals
@@ -22,6 +23,10 @@ class Literals:
             bytes_literals = self.bytes_literals
             if value not in bytes_literals:
                 bytes_literals[value] = len(bytes_literals)
+        elif isinstance(value, int):
+            int_literals = self.int_literals
+            if value not in int_literals:
+                int_literals[value] = len(int_literals)
         elif isinstance(value, float):
             float_literals = self.float_literals
             if value not in float_literals:
@@ -33,7 +38,7 @@ class Literals:
         else:
             assert False, 'invalid literal: %r' % value
 
-    def literal_index(self, value: Union[str, bytes, float, complex]) -> int:
+    def literal_index(self, value: Union[str, bytes, int, float, complex]) -> int:
         """Return the index to the literals array for given value."""
         if isinstance(value, str):
             return self.str_literals[value]
@@ -41,6 +46,9 @@ class Literals:
         if isinstance(value, bytes):
             return n + self.bytes_literals[value]
         n += len(self.bytes_literals)
+        if isinstance(value, int):
+            return n + self.int_literals[value]
+        n += len(self.int_literals)
         if isinstance(value, float):
             return n + self.float_literals[value]
         n += len(self.float_literals)
@@ -49,11 +57,14 @@ class Literals:
         assert False, 'invalid literal: %r' % value
 
     def num_literals(self) -> int:
-        return (len(self.str_literals) + len(self.bytes_literals) + len(self.float_literals) +
-                len(self.complex_literals))
+        return (len(self.str_literals) + len(self.bytes_literals) + len(self.int_literals) +
+                len(self.float_literals) + len(self.complex_literals))
 
     def encoded_str_values(self) -> List[bytes]:
         return encode_str_values(self.str_literals)
+
+    def encoded_int_values(self) -> List[bytes]:
+        return encode_int_values(self.int_literals)
 
     def encoded_bytes_values(self) -> List[bytes]:
         return encode_bytes_values(self.bytes_literals)
@@ -109,6 +120,19 @@ def format_int(n: int) -> bytes:
 def format_str_literal(s: str) -> bytes:
     utf8 = s.encode('utf-8')
     return format_int(len(utf8)) + utf8
+
+
+def encode_int_values(values: Dict[int, int]) -> List[bytes]:
+    value_by_index = {}
+    for value, index in values.items():
+        value_by_index[index] = value
+    result = []
+    num = len(values)
+    result.append(format_int(num))
+    for i in range(num):
+        value = value_by_index[i]
+        result.append(b'%d\0' % value)
+    return result
 
 
 def encode_float_values(values: Dict[float, int]) -> List[str]:

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -1,0 +1,20 @@
+from typing import Dict, Type, Optional
+
+
+class Literals:
+    """Collection of literal values used in a compilation group."""
+
+    def __init__(self) -> None:
+        self.literals = {}  # type: Dict[Type[object], Dict[str, int]]
+
+    def record_literal(self, value: str) -> None:
+        literals = self.literals
+        t = type(value)
+        if t not in literals:
+            literals[t] = {}
+        d = literals[t]
+        if value not in d:
+            d[value] = len(d)
+
+    def literal_index(self, value: str) -> int:
+        return self.literals[str][value]

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -1,6 +1,4 @@
-from typing import Dict, Type, List, Union
-
-from mypyc.codegen.cstring import encode_bytes_as_c_string
+from typing import Dict, List, Union
 
 
 class Literals:

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -143,6 +143,16 @@ def encode_int_values(values: Dict[int, int]) -> List[bytes]:
     return result
 
 
+def float_to_c(x: float) -> str:
+    """Return C literal representation of a float value."""
+    s = str(x)
+    if s == 'inf':
+        return 'INFINITY'
+    elif s == '-inf':
+        return '-INFINITY'
+    return s
+
+
 def encode_float_values(values: Dict[float, int]) -> List[str]:
     """Encode float values into a C array values.
 
@@ -156,7 +166,7 @@ def encode_float_values(values: Dict[float, int]) -> List[str]:
     result.append(str(num))
     for i in range(num):
         value = value_by_index[i]
-        result.append(str(value))
+        result.append(float_to_c(value))
     return result
 
 
@@ -174,6 +184,6 @@ def encode_complex_values(values: Dict[complex, int]) -> List[str]:
     result.append(str(num))
     for i in range(num):
         value = value_by_index[i]
-        result.append(str(value.real))
-        result.append(str(value.imag))
+        result.append(float_to_c(value.real))
+        result.append(float_to_c(value.imag))
     return result

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -49,13 +49,15 @@ def encode_str_values(values: Dict[str, int]) -> List[bytes]:
 
 def format_int(n: int) -> bytes:
     if n < 128:
-        return bytes([n])
-    result = b''
-    while n >= 128:
-        result += bytes([(n & 0x7f) | 128])
-        n >>= 7
-    result += bytes([n])
-    return result
+        a = [n]
+    else:
+        a = []
+        while n > 0:
+            a.insert(0, n & 0x7f)
+            n >>= 7
+        for i in range(len(a) - 1):
+            a[i] |= 0x80
+    return bytes(a)
 
 
 def format_str_literal(s: str) -> bytes:

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -23,6 +23,12 @@ class Literals:
         """Return the index to the literals array for given value."""
         return self.literals[str][value]
 
+    def num_literals(self) -> int:
+        n = 0
+        for _, values in self.literals.items():
+            n += len(values)
+        return n
+
     def encoded_str_values(self) -> List[bytes]:
         return encode_str_values(self.literals[str])
 
@@ -32,7 +38,9 @@ def encode_str_values(values: Dict[str, int]) -> List[bytes]:
     for value, index in values.items():
         value_by_index[index] = value
     result = []
-    for i in range(len(values)):
+    num = len(values)
+    result.append(format_int(num))
+    for i in range(num):
         value = value_by_index[i]
         c_literal = format_str_literal(value)
         result.append(c_literal)

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -1,4 +1,4 @@
-from typing import Dict, Type, List
+from typing import Dict, Type, List, Union
 
 from mypyc.codegen.cstring import encode_bytes_as_c_string
 
@@ -7,30 +7,39 @@ class Literals:
     """Collection of literal values used in a compilation group."""
 
     def __init__(self) -> None:
-        self.literals = {}  # type: Dict[Type[object], Dict[str, int]]
+        self.str_literals = {}  # type: Dict[str, int]
+        self.bytes_literals = {}  # type: Dict[bytes, int]
 
-    def record_literal(self, value: str) -> None:
+    def record_literal(self, value: Union[str, bytes]) -> None:
         """Ensure that the literal value is available in generated code."""
-        literals = self.literals
-        t = type(value)
-        if t not in literals:
-            literals[t] = {}
-        d = literals[t]
-        if value not in d:
-            d[value] = len(d)
+        if isinstance(value, str):
+            str_literals = self.str_literals
+            if value not in str_literals:
+                str_literals[value] = len(str_literals)
+        elif isinstance(value, bytes):
+            bytes_literals = self.bytes_literals
+            if value not in bytes_literals:
+                bytes_literals[value] = len(bytes_literals)
+        else:
+            assert False, 'invalid literal: %r' % value
 
-    def literal_index(self, value: str) -> int:
+    def literal_index(self, value: Union[str, bytes]) -> int:
         """Return the index to the literals array for given value."""
-        return self.literals[str][value]
+        if isinstance(value, str):
+            return self.str_literals[value]
+        n = len(self.str_literals)
+        if isinstance(value, bytes):
+            return n + self.bytes_literals[value]
+        assert False, 'invalid literal: %r' % value
 
     def num_literals(self) -> int:
-        n = 0
-        for _, values in self.literals.items():
-            n += len(values)
-        return n
+        return len(self.str_literals) + len(self.bytes_literals)
 
     def encoded_str_values(self) -> List[bytes]:
-        return encode_str_values(self.literals[str])
+        return encode_str_values(self.str_literals)
+
+    def encoded_bytes_values(self) -> List[bytes]:
+        return encode_bytes_values(self.bytes_literals)
 
 
 def encode_str_values(values: Dict[str, int]) -> List[bytes]:
@@ -44,6 +53,20 @@ def encode_str_values(values: Dict[str, int]) -> List[bytes]:
         value = value_by_index[i]
         c_literal = format_str_literal(value)
         result.append(c_literal)
+    return result
+
+
+def encode_bytes_values(values: Dict[bytes, int]) -> List[bytes]:
+    value_by_index = {}
+    for value, index in values.items():
+        value_by_index[index] = value
+    result = []
+    num = len(values)
+    result.append(format_int(num))
+    for i in range(num):
+        value = value_by_index[i]
+        result.append(format_int(len(value)))
+        result.append(value)
     return result
 
 

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -19,7 +19,6 @@ TEMP_ATTR_NAME = '__mypyc_temp__'  # type: Final
 LAMBDA_NAME = '__mypyc_lambda__'  # type: Final
 PROPSET_PREFIX = '__mypyc_setter__'  # type: Final
 SELF_NAME = '__mypyc_self__'  # type: Final
-INT_PREFIX = '__tmp_literal_int_'  # type: Final
 
 # Max short int we accept as a literal is based on 32-bit platforms,
 # so that we can just always emit the same code.

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -497,8 +497,8 @@ class LoadErrorValue(RegisterOp):
 class LoadLiteral(RegisterOp):
     """Load a Python literal object (dest = 'foo' / b'foo' / ...).
 
-    This is used to load static PyObject * values corresponding to
-    string literals, etc.
+    This is used to load a static PyObject * value corresponding to
+    a str/bytes/float/... literal.
 
     NOTE: You can use this to load boxed (Python) int objects. Use
           Integer to load unboxed, tagged integers or fixed-width,
@@ -508,7 +508,7 @@ class LoadLiteral(RegisterOp):
     error_kind = ERR_NEVER
     is_borrowed = True
 
-    def __init__(self, value: Union[str, bytes], rtype: RType) -> None:
+    def __init__(self, value: Union[str, bytes, float], rtype: RType) -> None:
         self.value = value
         self.type = rtype
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1249,7 +1249,7 @@ class OpVisitor(Generic[T]):
         raise NotImplementedError
 
 
-# TODO: Should the following definitions live somewhere else?
+# TODO: Should the following definition live somewhere else?
 
 # We do a three-pass deserialization scheme in order to resolve name
 # references.
@@ -1275,5 +1275,3 @@ class OpVisitor(Generic[T]):
 # compilation but so far it is not hooked up to anything.)
 DeserMaps = NamedTuple('DeserMaps',
                        [('classes', Dict[str, 'ClassIR']), ('functions', Dict[str, 'FuncIR'])])
-
-LiteralsMap = Dict[Tuple[Type[object], Union[int, float, str, bytes, complex]], str]

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -14,7 +14,7 @@ from typing import (
     List, Sequence, Dict, Generic, TypeVar, Optional, NamedTuple, Tuple, Union
 )
 
-from typing_extensions import Final, Type, TYPE_CHECKING
+from typing_extensions import Final, TYPE_CHECKING
 from mypy_extensions import trait
 
 from mypyc.ir.rtypes import (

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -508,7 +508,7 @@ class LoadLiteral(RegisterOp):
     error_kind = ERR_NEVER
     is_borrowed = True
 
-    def __init__(self, value: Union[str, bytes, float], rtype: RType) -> None:
+    def __init__(self, value: Union[str, bytes, float, complex], rtype: RType) -> None:
         self.value = value
         self.type = rtype
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -508,7 +508,7 @@ class LoadLiteral(RegisterOp):
     error_kind = ERR_NEVER
     is_borrowed = True
 
-    def __init__(self, value: Union[str, bytes, float, complex], rtype: RType) -> None:
+    def __init__(self, value: Union[str, bytes, int, float, complex], rtype: RType) -> None:
         self.value = value
         self.type = rtype
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -495,7 +495,7 @@ class LoadErrorValue(RegisterOp):
 
 
 class LoadLiteral(RegisterOp):
-    """Load a Python literal object.
+    """Load a Python literal object (dest = 'foo' / b'foo' / ...).
 
     This is used to load static PyObject * values corresponding to
     string literals, etc.
@@ -508,7 +508,7 @@ class LoadLiteral(RegisterOp):
     error_kind = ERR_NEVER
     is_borrowed = True
 
-    def __init__(self, value: str, rtype: RType) -> None:
+    def __init__(self, value: Union[str, bytes], rtype: RType) -> None:
         self.value = value
         self.type = rtype
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -498,7 +498,12 @@ class LoadLiteral(RegisterOp):
     """Load a Python literal object (dest = 'foo' / b'foo' / ...).
 
     This is used to load a static PyObject * value corresponding to
-    a str/bytes/float/... literal.
+    a literal of one of the supported types.
+
+    NOTE: For int literals, both int_rprimitive (CPyTagged) and
+          object_primitive (PyObject *) are supported as types. However,
+          when using int_rprimitive, the value must *not* be small enough
+          to fit in an unboxed integer.
 
     NOTE: You can use this to load boxed (Python) int objects. Use
           Integer to load unboxed, tagged integers or fixed-width,

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -508,8 +508,9 @@ class LoadLiteral(RegisterOp):
     error_kind = ERR_NEVER
     is_borrowed = True
 
-    def __init__(self, value: str) -> None:
+    def __init__(self, value: str, rtype: RType) -> None:
         self.value = value
+        self.type = rtype
 
     def sources(self) -> List[Value]:
         return []

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -9,7 +9,7 @@ from mypyc.ir.ops import (
     Goto, Branch, Return, Unreachable, Assign, Integer, LoadErrorValue, GetAttr, SetAttr,
     LoadStatic, InitStatic, TupleGet, TupleSet, IncRef, DecRef, Call, MethodCall, Cast, Box, Unbox,
     RaiseStandardError, CallC, Truncate, LoadGlobal, IntOp, ComparisonOp, LoadMem, SetMem,
-    GetElementPtr, LoadAddress, Register, Value, OpVisitor, BasicBlock, ControlOp
+    GetElementPtr, LoadAddress, Register, Value, OpVisitor, BasicBlock, ControlOp, LoadLiteral
 )
 from mypyc.ir.func_ir import FuncIR, all_values_full
 from mypyc.ir.module_ir import ModuleIRs
@@ -58,6 +58,9 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
 
     def visit_load_error_value(self, op: LoadErrorValue) -> str:
         return self.format('%r = <error> :: %s', op, op.type)
+
+    def visit_load_literal(self, op: LoadLiteral) -> str:
+        return self.format('%r = literal(%s)', op, repr(op.value))
 
     def visit_get_attr(self, op: GetAttr) -> str:
         return self.format('%r = %r.%s', op, op.obj, op.attr)

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -60,7 +60,7 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
         return self.format('%r = <error> :: %s', op, op.type)
 
     def visit_load_literal(self, op: LoadLiteral) -> str:
-        return self.format('%r = literal(%s)', op, repr(op.value))
+        return self.format('%r = %s', op, repr(op.value))
 
     def visit_get_attr(self, op: GetAttr) -> str:
         return self.format('%r = %r.%s', op, op.obj, op.attr)

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -60,7 +60,12 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
         return self.format('%r = <error> :: %s', op, op.type)
 
     def visit_load_literal(self, op: LoadLiteral) -> str:
-        return self.format('%r = %s', op, repr(op.value))
+        prefix = ''
+        # For values that have a potential unboxed representation, make
+        # it explicit that this is a Python object.
+        if isinstance(op.value, int):
+            return self.format('%r = object %s', op, repr(op.value))
+        return self.format('%r = %s%s', op, prefix, repr(op.value))
 
     def visit_get_attr(self, op: GetAttr) -> str:
         return self.format('%r = %r.%s', op, op.obj, op.attr)

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -64,7 +64,7 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
         # For values that have a potential unboxed representation, make
         # it explicit that this is a Python object.
         if isinstance(op.value, int):
-            return self.format('%r = object %s', op, repr(op.value))
+            prefix = 'object '
         return self.format('%r = %s%s', op, prefix, repr(op.value))
 
     def visit_get_attr(self, op: GetAttr) -> str:

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -191,11 +191,11 @@ class IRBuilder:
     def py_get_attr(self, obj: Value, attr: str, line: int) -> Value:
         return self.builder.py_get_attr(obj, attr, line)
 
-    def load_static_unicode(self, value: str) -> Value:
-        return self.builder.load_static_unicode(value)
+    def load_str(self, value: str) -> Value:
+        return self.builder.load_str(value)
 
-    def load_static_int(self, value: int) -> Value:
-        return self.builder.load_static_int(value)
+    def load_int(self, value: int) -> Value:
+        return self.builder.load_int(value)
 
     def unary_op(self, lreg: Value, expr_op: str, line: int) -> Value:
         return self.builder.unary_op(lreg, expr_op, line)
@@ -283,7 +283,7 @@ class IRBuilder:
     def add_to_non_ext_dict(self, non_ext: NonExtClassInfo,
                             key: str, val: Value, line: int) -> None:
         # Add an attribute entry into the class dict of a non-extension class.
-        key_unicode = self.load_static_unicode(key)
+        key_unicode = self.load_str(key)
         self.call_c(dict_set_item_op, [non_ext.dict, key_unicode, val], line)
 
     def gen_import(self, id: str, line: int) -> None:
@@ -295,7 +295,7 @@ class IRBuilder:
         self.add_bool_branch(comparison, out, needs_import)
 
         self.activate_block(needs_import)
-        value = self.call_c(import_op, [self.load_static_unicode(id)], line)
+        value = self.call_c(import_op, [self.load_str(id)], line)
         self.add(InitStatic(value, id, namespace=NAMESPACE_MODULE))
         self.goto_and_activate(out)
 
@@ -378,13 +378,13 @@ class IRBuilder:
         elif isinstance(val, int):
             # TODO: take care of negative integer initializers
             # (probably easier to fix this in mypy itself).
-            return self.builder.load_static_int(val)
+            return self.builder.load_int(val)
         elif isinstance(val, float):
-            return self.builder.load_static_float(val)
+            return self.builder.load_float(val)
         elif isinstance(val, str):
-            return self.builder.load_static_unicode(val)
+            return self.builder.load_str(val)
         elif isinstance(val, bytes):
-            return self.builder.load_static_bytes(val)
+            return self.builder.load_bytes(val)
         else:
             assert False, "Unsupported final literal value"
 
@@ -419,7 +419,7 @@ class IRBuilder:
                     return self.lookup(symbol)
             elif lvalue.kind == GDEF:
                 globals_dict = self.load_globals_dict()
-                name = self.load_static_unicode(lvalue.name)
+                name = self.load_str(lvalue.name)
                 return AssignmentTargetIndex(globals_dict, name)
             else:
                 assert False, lvalue.kind
@@ -484,7 +484,7 @@ class IRBuilder:
                 rvalue_reg = self.coerce(rvalue_reg, target.type, line)
                 self.add(SetAttr(target.obj, target.attr, rvalue_reg, line))
             else:
-                key = self.load_static_unicode(target.attr)
+                key = self.load_str(target.attr)
                 boxed_reg = self.builder.box(rvalue_reg)
                 self.call_c(py_setattr_op, [target.obj, key, boxed_reg], line)
         elif isinstance(target, AssignmentTargetIndex):
@@ -519,7 +519,7 @@ class IRBuilder:
         values = []
         for i in range(len(target.items)):
             item = target.items[i]
-            index = self.builder.load_static_int(i)
+            index = self.builder.load_int(i)
             if is_list_rprimitive(rvalue.type):
                 item_value = self.call_c(list_get_item_unsafe_op, [rvalue, index], line)
             else:
@@ -1074,7 +1074,7 @@ class IRBuilder:
 
     def load_global_str(self, name: str, line: int) -> Value:
         _globals = self.load_globals_dict()
-        reg = self.load_static_unicode(name)
+        reg = self.load_str(name)
         return self.call_c(dict_get_item_op, [_globals, reg], line)
 
     def load_globals_dict(self) -> Value:

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -95,7 +95,7 @@ def transform_name_expr(builder: IRBuilder, expr: NameExpr) -> Value:
             # instead load the module separately on each access.
             mod_dict = builder.call_c(get_module_dict_op, [], expr.line)
             obj = builder.call_c(dict_get_item_op,
-                                 [mod_dict, builder.load_static_unicode(expr.node.fullname)],
+                                 [mod_dict, builder.load_str(expr.node.fullname)],
                                  expr.line)
             return obj
         else:
@@ -124,7 +124,7 @@ def transform_member_expr(builder: IRBuilder, expr: MemberExpr) -> Value:
     if isinstance(typ, TupleType) and typ.partial_fallback.type.is_named_tuple:
         fields = typ.partial_fallback.type.metadata['namedtuple']['fields']
         if expr.name in fields:
-            index = builder.builder.load_static_int(fields.index(expr.name))
+            index = builder.builder.load_int(fields.index(expr.name))
             return builder.gen_method_call(obj, '__getitem__', [index], rtype, expr.line)
     return builder.builder.get_attr(obj, expr.name, rtype, expr.line)
 
@@ -383,13 +383,13 @@ def try_gen_slice_op(builder: IRBuilder, base: Value, index: SliceExpr) -> Optio
         if index.begin_index:
             begin = builder.accept(index.begin_index)
         else:
-            begin = builder.load_static_int(0)
+            begin = builder.load_int(0)
         if index.end_index:
             end = builder.accept(index.end_index)
         else:
             # Replace missing end index with the largest short integer
             # (a sequence can't be longer).
-            end = builder.load_static_int(MAX_SHORT_INT)
+            end = builder.load_int(MAX_SHORT_INT)
         candidates = [list_slice_op, tuple_slice_op, str_slice_op]
         return builder.builder.matching_call_c(candidates, [base, begin, end], index.line)
 
@@ -520,24 +520,24 @@ def transform_basic_comparison(builder: IRBuilder,
 
 
 def transform_int_expr(builder: IRBuilder, expr: IntExpr) -> Value:
-    return builder.builder.load_static_int(expr.value)
+    return builder.builder.load_int(expr.value)
 
 
 def transform_float_expr(builder: IRBuilder, expr: FloatExpr) -> Value:
-    return builder.builder.load_static_float(expr.value)
+    return builder.builder.load_float(expr.value)
 
 
 def transform_complex_expr(builder: IRBuilder, expr: ComplexExpr) -> Value:
-    return builder.builder.load_static_complex(expr.value)
+    return builder.builder.load_complex(expr.value)
 
 
 def transform_str_expr(builder: IRBuilder, expr: StrExpr) -> Value:
-    return builder.load_static_unicode(expr.value)
+    return builder.load_str(expr.value)
 
 
 def transform_bytes_expr(builder: IRBuilder, expr: BytesExpr) -> Value:
     value = bytes(expr.value, 'utf8').decode('unicode-escape').encode('raw-unicode-escape')
-    return builder.builder.load_static_bytes(value)
+    return builder.builder.load_bytes(value)
 
 
 def transform_ellipsis(builder: IRBuilder, o: EllipsisExpr) -> Value:

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -96,7 +96,7 @@ def transform_decorator(builder: IRBuilder, dec: Decorator) -> None:
         # Set the callable object representing the decorated function as a global.
         builder.call_c(dict_set_item_op,
                     [builder.load_globals_dict(),
-                    builder.load_static_unicode(dec.func.name), decorated_func],
+                    builder.load_str(dec.func.name), decorated_func],
                     decorated_func.line)
 
     builder.functions.append(func_ir)
@@ -361,7 +361,7 @@ def handle_ext_method(builder: IRBuilder, cdef: ClassDef, fdef: FuncDef) -> None
         builder.call_c(py_setattr_op,
                     [
                         typ,
-                        builder.load_static_unicode(name),
+                        builder.load_str(name),
                         decorated_func
                     ],
                     fdef.line)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -466,8 +466,7 @@ class LowLevelIRBuilder:
 
     def load_static_bytes(self, value: bytes) -> Value:
         """Loads a static bytes value into a register."""
-        identifier = self.literal_static_name(value)
-        return self.add(LoadGlobal(object_rprimitive, identifier, ann=value))
+        return self.add(LoadLiteral(value, object_rprimitive))
 
     def load_static_complex(self, value: complex) -> Value:
         """Loads a static complex value into a register."""

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -469,8 +469,7 @@ class LowLevelIRBuilder:
 
     def load_static_complex(self, value: complex) -> Value:
         """Loads a static complex value into a register."""
-        identifier = self.literal_static_name(value)
-        return self.add(LoadGlobal(object_rprimitive, identifier, ann=value))
+        return self.add(LoadLiteral(value, object_rprimitive))
 
     def load_static_unicode(self, value: str) -> Value:
         """Loads a static unicode value into a register.

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -448,9 +448,6 @@ class LowLevelIRBuilder:
         """Load Python None value (type: object_rprimitive)."""
         return self.add(LoadAddress(none_object_op.type, none_object_op.src, line=-1))
 
-    def literal_static_name(self, value: Union[int, float, complex, str, bytes]) -> str:
-        return STATIC_PREFIX + self.mapper.literal_static_name(self.current_module, value)
-
     def load_static_int(self, value: int) -> Value:
         """Loads a static integer Python 'int' object into a register."""
         if abs(value) > MAX_LITERAL_SHORT_INT:

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -454,8 +454,7 @@ class LowLevelIRBuilder:
     def load_static_int(self, value: int) -> Value:
         """Loads a static integer Python 'int' object into a register."""
         if abs(value) > MAX_LITERAL_SHORT_INT:
-            identifier = self.literal_static_name(value)
-            return self.add(LoadGlobal(int_rprimitive, identifier, ann=value))
+            return self.add(LoadLiteral(value, int_rprimitive))
         else:
             return Integer(value)
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -18,7 +18,7 @@ from mypy.checkexpr import map_actuals_to_formals
 
 from mypyc.ir.ops import (
     BasicBlock, Op, Integer, Value, Register, Assign, Branch, Goto, Call, Box, Unbox, Cast,
-    GetAttr, LoadStatic, MethodCall, CallC, Truncate,
+    GetAttr, LoadStatic, MethodCall, CallC, Truncate, LoadLiteral,
     RaiseStandardError, Unreachable, LoadErrorValue, LoadGlobal,
     NAMESPACE_TYPE, NAMESPACE_MODULE, NAMESPACE_STATIC, IntOp, GetElementPtr,
     LoadMem, ComparisonOp, LoadAddress, TupleGet, SetMem, ERR_NEVER, ERR_FALSE
@@ -480,8 +480,7 @@ class LowLevelIRBuilder:
         This is useful for more than just unicode literals; for example, method calls
         also require a PyObject * form for the name of the method.
         """
-        identifier = self.literal_static_name(value)
-        return self.add(LoadGlobal(str_rprimitive, identifier, ann=value))
+        return self.add(LoadLiteral(value, str_rprimitive))
 
     def load_static_checked(self, typ: RType, identifier: str, module_name: Optional[str] = None,
                             namespace: str = NAMESPACE_STATIC,

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -19,7 +19,7 @@ from mypy.checkexpr import map_actuals_to_formals
 from mypyc.ir.ops import (
     BasicBlock, Op, Integer, Value, Register, Assign, Branch, Goto, Call, Box, Unbox, Cast,
     GetAttr, LoadStatic, MethodCall, CallC, Truncate, LoadLiteral,
-    RaiseStandardError, Unreachable, LoadErrorValue, LoadGlobal,
+    RaiseStandardError, Unreachable, LoadErrorValue,
     NAMESPACE_TYPE, NAMESPACE_MODULE, NAMESPACE_STATIC, IntOp, GetElementPtr,
     LoadMem, ComparisonOp, LoadAddress, TupleGet, SetMem, ERR_NEVER, ERR_FALSE
 )
@@ -34,8 +34,7 @@ from mypyc.ir.rtypes import (
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
 from mypyc.common import (
-    FAST_ISINSTANCE_MAX_SUBCLASSES, MAX_LITERAL_SHORT_INT,
-    STATIC_PREFIX, PLATFORM_SIZE
+    FAST_ISINSTANCE_MAX_SUBCLASSES, MAX_LITERAL_SHORT_INT, PLATFORM_SIZE
 )
 from mypyc.primitives.registry import (
     method_call_ops, CFunctionDescription, function_ops,

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -461,8 +461,7 @@ class LowLevelIRBuilder:
 
     def load_static_float(self, value: float) -> Value:
         """Loads a static float value into a register."""
-        identifier = self.literal_static_name(value)
-        return self.add(LoadGlobal(float_rprimitive, identifier, ann=value))
+        return self.add(LoadLiteral(value, float_rprimitive))
 
     def load_static_bytes(self, value: bytes) -> Value:
         """Loads a static bytes value into a register."""

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -21,7 +21,6 @@ from mypyc.ir.class_ir import ClassIR
 
 
 LiteralsMap = Dict[Tuple[typing.Type[object], Union[int, float, str, bytes, complex]], str]
-LiteralsMap2 = Dict[typing.Type[object], Dict[str, int]]
 
 
 class Mapper:
@@ -44,10 +43,6 @@ class Mapper:
         self.literals = {
             v: OrderedDict() for v in group_map.values()
         }  # type: Dict[Optional[str], LiteralsMap]
-        # Replacement for 'literals' eventually (WIP)
-        self.literals_2 = {
-            v: {} for v in group_map.values()
-        }  # type: Dict[Optional[str], LiteralsMap2]
 
     def type_to_rtype(self, typ: Optional[Type]) -> RType:
         if typ is None:
@@ -172,14 +167,3 @@ class Mapper:
                 prefix = type(value).__name__ + '_'
             literals[key] = prefix + str(len(literals))
         return literals[key]
-
-    def record_literal(self, module: str, value: str) -> None:
-        # Literals are shared between modules in a compilation group
-        # but not outside the group.
-        literals = self.literals_2[self.group_map.get(module)]
-        t = type(value)
-        if t not in literals:
-            literals[t] = {}
-        d = literals[t]
-        if value not in d:
-            d[value] = len(d)

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -37,12 +37,6 @@ class Mapper:
         self.group_map = group_map
         self.type_to_ir = {}  # type: Dict[TypeInfo, ClassIR]
         self.func_to_decl = {}  # type: Dict[SymbolNode, FuncDecl]
-        # LiteralsMap maps literal values to a static name. Each
-        # compilation group has its own LiteralsMap. (Since they can't
-        # share literals.)
-        self.literals = {
-            v: OrderedDict() for v in group_map.values()
-        }  # type: Dict[Optional[str], LiteralsMap]
 
     def type_to_rtype(self, typ: Optional[Type]) -> RType:
         if typ is None:
@@ -151,19 +145,3 @@ class Mapper:
         if fdef.name in ('__eq__', '__ne__', '__lt__', '__gt__', '__le__', '__ge__'):
             ret = object_rprimitive
         return FuncSignature(args, ret)
-
-    def literal_static_name(self, module: str,
-                            value: Union[int, float, complex, str, bytes]) -> str:
-        # Literals are shared between modules in a compilation group
-        # but not outside the group.
-        literals = self.literals[self.group_map.get(module)]
-
-        # Include type to distinguish between 1 and 1.0, and so on.
-        key = (type(value), value)
-        if key not in literals:
-            if isinstance(value, str):
-                prefix = 'unicode_'
-            else:
-                prefix = type(value).__name__ + '_'
-            literals[key] = prefix + str(len(literals))
-        return literals[key]

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -1,8 +1,6 @@
 """Maintain a mapping from mypy concepts to IR/compiled concepts."""
 
-from typing import Dict, Optional, Union, Tuple, Any
-from mypy.ordered_dict import OrderedDict
-import typing
+from typing import Dict, Optional
 
 from mypy.nodes import FuncDef, TypeInfo, SymbolNode, ARG_STAR, ARG_STAR2
 from mypy.types import (
@@ -18,9 +16,6 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.ir.func_ir import FuncSignature, FuncDecl, RuntimeArg
 from mypyc.ir.class_ir import ClassIR
-
-
-LiteralsMap = Dict[Tuple[typing.Type[object], Union[int, float, str, bytes, complex]], str]
 
 
 class Mapper:

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -156,10 +156,10 @@ def transform_import(builder: IRBuilder, node: Import) -> None:
         mod_dict = builder.call_c(get_module_dict_op, [], node.line)
         # Get top-level module/package object.
         obj = builder.call_c(dict_get_item_op,
-                             [mod_dict, builder.load_static_unicode(base)], node.line)
+                             [mod_dict, builder.load_str(base)], node.line)
 
         builder.gen_method_call(
-            globals, '__setitem__', [builder.load_static_unicode(name), obj],
+            globals, '__setitem__', [builder.load_str(name), obj],
             result_type=None, line=node.line)
 
 
@@ -193,7 +193,7 @@ def transform_import_from(builder: IRBuilder, node: ImportFrom) -> None:
         as_name = maybe_as_name or name
         obj = builder.py_get_attr(module, name, node.line)
         builder.gen_method_call(
-            globals, '__setitem__', [builder.load_static_unicode(as_name), obj],
+            globals, '__setitem__', [builder.load_str(as_name), obj],
             result_type=None, line=node.line)
 
 
@@ -663,7 +663,7 @@ def transform_del_item(builder: IRBuilder, target: AssignmentTarget, line: int) 
             line=line
         )
     elif isinstance(target, AssignmentTargetAttr):
-        key = builder.load_static_unicode(target.attr)
+        key = builder.load_str(target.attr)
         builder.call_c(py_delattr_op, [target.obj, key], line)
     elif isinstance(target, AssignmentTargetRegister):
         # Delete a local by assigning an error value to it, which will

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -523,7 +523,7 @@ int CPyArg_ParseStackAndKeywordsSimple(PyObject *const *args, Py_ssize_t nargs, 
 
 int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected);
 int CPyStatics_Initialize(PyObject **statics, const char *strings, const char *bytestrings,
-                          const double *floats, const double *complex_numbers);
+                          const char *ints, const double *floats, const double *complex_numbers);
 
 
 #ifdef __cplusplus

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -523,7 +523,7 @@ int CPyArg_ParseStackAndKeywordsSimple(PyObject *const *args, Py_ssize_t nargs, 
 
 int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected);
 int CPyStatics_Initialize(PyObject **statics, const char *strings, const char *bytestrings,
-                          const double *floats);
+                          const double *floats, const double *complex_numbers);
 
 
 #ifdef __cplusplus

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -522,7 +522,7 @@ int CPyArg_ParseStackAndKeywordsSimple(PyObject *const *args, Py_ssize_t nargs, 
                                        CPyArg_Parser *parser, ...);
 
 int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected);
-int CPyStatics_Initialize(PyObject **statics, const char *strings);
+int CPyStatics_Initialize(PyObject **statics, const char *strings, const char *bytestrings);
 
 
 #ifdef __cplusplus

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -522,6 +522,7 @@ int CPyArg_ParseStackAndKeywordsSimple(PyObject *const *args, Py_ssize_t nargs, 
                                        CPyArg_Parser *parser, ...);
 
 int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected);
+int CPyStatics_Initialize(PyObject **statics, const char *strings);
 
 
 #ifdef __cplusplus

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -522,7 +522,8 @@ int CPyArg_ParseStackAndKeywordsSimple(PyObject *const *args, Py_ssize_t nargs, 
                                        CPyArg_Parser *parser, ...);
 
 int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected);
-int CPyStatics_Initialize(PyObject **statics, const char *strings, const char *bytestrings);
+int CPyStatics_Initialize(PyObject **statics, const char *strings, const char *bytestrings,
+                          const double *floats);
 
 
 #ifdef __cplusplus

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -526,6 +526,7 @@ static const char *parse_int(const char *s, size_t *len) {
 int CPyStatics_Initialize(PyObject **statics,
                           const char *strings,
                           const char *bytestrings,
+                          const char *ints,
                           const double *floats,
                           const double *complex_numbers) {
     if (strings) {
@@ -557,9 +558,23 @@ int CPyStatics_Initialize(PyObject **statics,
             bytestrings += len;
         }
     }
+    if (ints) {
+        size_t num;
+        ints = parse_int(ints, &num);
+        while (num-- > 0) {
+            char *end;
+            PyObject *obj = PyLong_FromString(ints, &end, 10);
+            if (obj == NULL) {
+                return -1;
+            }
+            ints = end;
+            ints++;
+            *statics++ = obj;
+        }
+    }
     if (floats) {
-        size_t num_floats = (size_t)*floats++;
-        while (num_floats-- > 0) {
+        size_t num = (size_t)*floats++;
+        while (num-- > 0) {
             PyObject *obj = PyFloat_FromDouble(*floats++);
             if (obj == NULL) {
                 return -1;
@@ -568,8 +583,8 @@ int CPyStatics_Initialize(PyObject **statics,
         }
     }
     if (complex_numbers) {
-        size_t num_complex = (size_t)*complex_numbers++;
-        while (num_complex-- > 0) {
+        size_t num = (size_t)*complex_numbers++;
+        while (num-- > 0) {
             double real = *complex_numbers++;
             double imag = *complex_numbers++;
             PyObject *obj = PyComplex_FromDoubles(real, imag);

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -522,7 +522,10 @@ static const char *parse_int(const char *s, size_t *len) {
     return s;
 }
 
-int CPyStatics_Initialize(PyObject **statics, const char *strings) {
+// Initialize static constant array for literal values
+int CPyStatics_Initialize(PyObject **statics,
+                          const char *strings,
+                          const char *bytestrings) {
     if (strings) {
         size_t num;
         strings = parse_int(strings, &num);
@@ -536,6 +539,20 @@ int CPyStatics_Initialize(PyObject **statics, const char *strings) {
             PyUnicode_InternInPlace(&obj);
             *statics++ = obj;
             strings += len;
+        }
+    }
+    if (bytestrings) {
+        size_t num;
+        bytestrings = parse_int(bytestrings, &num);
+        while (num-- > 0) {
+            size_t len;
+            bytestrings = parse_int(bytestrings, &len);
+            PyObject *obj = PyBytes_FromStringAndSize(bytestrings, len);
+            if (obj == NULL) {
+                return -1;
+            }
+            *statics++ = obj;
+            bytestrings += len;
         }
     }
     return 0;

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -525,7 +525,8 @@ static const char *parse_int(const char *s, size_t *len) {
 // Initialize static constant array for literal values
 int CPyStatics_Initialize(PyObject **statics,
                           const char *strings,
-                          const char *bytestrings) {
+                          const char *bytestrings,
+                          const double *floats) {
     if (strings) {
         size_t num;
         strings = parse_int(strings, &num);
@@ -553,6 +554,16 @@ int CPyStatics_Initialize(PyObject **statics,
             }
             *statics++ = obj;
             bytestrings += len;
+        }
+    }
+    if (floats) {
+        size_t num_floats = (size_t)*floats++;
+        while (num_floats-- > 0) {
+            PyObject *obj = PyFloat_FromDouble(*floats++);
+            if (obj == NULL) {
+                return -1;
+            }
+            *statics++ = obj;
         }
     }
     return 0;

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -522,11 +522,12 @@ static const char *parse_int(const char *s, size_t *len) {
     return s;
 }
 
-// Initialize static constant array for literal values
+// Initialize static constant array of literal values
 int CPyStatics_Initialize(PyObject **statics,
                           const char *strings,
                           const char *bytestrings,
-                          const double *floats) {
+                          const double *floats,
+                          const double *complex_numbers) {
     if (strings) {
         size_t num;
         strings = parse_int(strings, &num);
@@ -560,6 +561,18 @@ int CPyStatics_Initialize(PyObject **statics,
         size_t num_floats = (size_t)*floats++;
         while (num_floats-- > 0) {
             PyObject *obj = PyFloat_FromDouble(*floats++);
+            if (obj == NULL) {
+                return -1;
+            }
+            *statics++ = obj;
+        }
+    }
+    if (complex_numbers) {
+        size_t num_complex = (size_t)*complex_numbers++;
+        while (num_complex-- > 0) {
+            double real = *complex_numbers++;
+            double imag = *complex_numbers++;
+            PyObject *obj = PyComplex_FromDoubles(real, imag);
             if (obj == NULL) {
                 return -1;
             }

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -533,6 +533,7 @@ int CPyStatics_Initialize(PyObject **statics, const char *strings) {
             if (obj == NULL) {
                 return -1;
             }
+            PyUnicode_InternInPlace(&obj);
             *statics++ = obj;
             strings += len;
         }

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -548,7 +548,7 @@ L1:
 L2:
     r1 = CPy_CatchError()
     r2 = builtins :: module
-    r3 = load_global CPyStatic_unicode_1 :: static  ('Exception')
+    r3 = 'Exception'
     r4 = CPyObject_GetAttr(r2, r3)
     if is_error(r4) goto L8 (error at lol:4) else goto L3
 L3:
@@ -605,3 +605,4 @@ L11:
 (10, 1)  {r8}                    {}
 (11, 0)  {}                      {r9}
 (11, 1)  {r9}                    {}
+

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -187,7 +187,7 @@ def g():
 L0:
 L1:
     r0 = builtins :: module
-    r1 = load_global CPyStatic_unicode_1 :: static  ('object')
+    r1 = 'object'
     r2 = CPyObject_GetAttr(r0, r1)
     if is_error(r2) goto L3 (error at g:3) else goto L2
 L2:
@@ -196,9 +196,9 @@ L2:
     if is_error(r3) goto L3 (error at g:3) else goto L10
 L3:
     r4 = CPy_CatchError()
-    r5 = load_global CPyStatic_unicode_2 :: static  ('weeee')
+    r5 = 'weeee'
     r6 = builtins :: module
-    r7 = load_global CPyStatic_unicode_3 :: static  ('print')
+    r7 = 'print'
     r8 = CPyObject_GetAttr(r6, r7)
     if is_error(r8) goto L6 (error at g:5) else goto L4
 L4:
@@ -253,7 +253,7 @@ def a():
 L0:
 L1:
     r0 = builtins :: module
-    r1 = load_global CPyStatic_unicode_1 :: static  ('print')
+    r1 = 'print'
     r2 = CPyObject_GetAttr(r0, r1)
     if is_error(r2) goto L5 (error at a:3) else goto L2
 L2:
@@ -261,7 +261,7 @@ L2:
     dec_ref r2
     if is_error(r3) goto L5 (error at a:3) else goto L20
 L3:
-    r4 = load_global CPyStatic_unicode_2 :: static  ('hi')
+    r4 = 'hi'
     inc_ref r4
     r5 = r4
 L4:
@@ -274,9 +274,9 @@ L5:
     r9 = CPy_CatchError()
     r7 = r9
 L6:
-    r10 = load_global CPyStatic_unicode_3 :: static  ('goodbye!')
+    r10 = 'goodbye!'
     r11 = builtins :: module
-    r12 = load_global CPyStatic_unicode_1 :: static  ('print')
+    r12 = 'print'
     r13 = CPyObject_GetAttr(r11, r12)
     if is_error(r13) goto L13 (error at a:6) else goto L7
 L7:
@@ -352,7 +352,7 @@ def lol(x):
     r3 :: str
 L0:
 L1:
-    r0 = load_global CPyStatic_unicode_3 :: static  ('foo')
+    r0 = 'foo'
     r1 = CPyObject_GetAttr(x, r0)
     if is_error(r1) goto L3 (error at lol:4) else goto L2
 L2:
@@ -360,7 +360,7 @@ L2:
     goto L4
 L3:
     r2 = CPy_CatchError()
-    r3 = load_global CPyStatic_unicode_4 :: static
+    r3 = ''
     CPy_RestoreExcInfo(r2)
     dec_ref r2
     inc_ref r3
@@ -394,12 +394,12 @@ L0:
     r1 = <error> :: object
     b = r1
 L1:
-    r2 = load_global CPyStatic_unicode_3 :: static  ('foo')
+    r2 = 'foo'
     r3 = CPyObject_GetAttr(x, r2)
     if is_error(r3) goto L4 (error at lol:4) else goto L15
 L2:
     a = r3
-    r4 = load_global CPyStatic_unicode_4 :: static  ('bar')
+    r4 = 'bar'
     r5 = CPyObject_GetAttr(x, r4)
     if is_error(r5) goto L4 (error at lol:5) else goto L16
 L3:
@@ -469,13 +469,13 @@ def f(b):
 L0:
     r0 = <error> :: str
     v = r0
-    r1 = load_global CPyStatic_unicode_1 :: static  ('a')
+    r1 = 'a'
     inc_ref r1
     u = r1
 L1:
     if b goto L10 else goto L11 :: bool
 L2:
-    r2 = load_global CPyStatic_unicode_2 :: static  ('b')
+    r2 = 'b'
     inc_ref r2
     v = r2
     r3 = v == u
@@ -483,7 +483,7 @@ L2:
     if r4 goto L11 else goto L1 :: bool
 L3:
     r5 = builtins :: module
-    r6 = load_global CPyStatic_unicode_3 :: static  ('print')
+    r6 = 'print'
     r7 = CPyObject_GetAttr(r5, r6)
     if is_error(r7) goto L12 (error at f:7) else goto L4
 L4:

--- a/mypyc/test-data/fixtures/ir.py
+++ b/mypyc/test-data/fixtures/ir.py
@@ -90,6 +90,7 @@ class complex:
     def __sub__(self, n: complex) -> complex: pass
     def __mul__(self, n: complex) -> complex: pass
     def __truediv__(self, n: complex) -> complex: pass
+    def __neg__(self) -> complex: pass
 
 class bytes:
     def __init__(self, x: object) -> None: pass

--- a/mypyc/test-data/irbuild-any.test
+++ b/mypyc/test-data/irbuild-any.test
@@ -62,7 +62,7 @@ L0:
     a = r4
     r5 = unbox(int, a)
     n = r5
-    r6 = load_global CPyStatic_unicode_6 :: static  ('a')
+    r6 = 'a'
     r7 = box(int, n)
     r8 = PyObject_SetAttr(a, r6, r7)
     r9 = r8 >= 0 :: signed

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -683,7 +683,7 @@ def f(x):
     r5 :: int
 L0:
     r0 = testmodule :: module
-    r1 = load_global CPyStatic_unicode_2 :: static  ('factorial')
+    r1 = 'factorial'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = box(int, x)
     r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
@@ -707,7 +707,7 @@ def f(x):
     r5 :: int
 L0:
     r0 = __main__.globals :: static
-    r1 = load_global CPyStatic_unicode_2 :: static  ('g')
+    r1 = 'g'
     r2 = CPyDict_GetItem(r0, r1)
     r3 = box(int, x)
     r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
@@ -726,7 +726,7 @@ def f(x):
     r2, r3, r4 :: object
 L0:
     r0 = builtins :: module
-    r1 = load_global CPyStatic_unicode_1 :: static  ('print')
+    r1 = 'print'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = box(short_int, 10)
     r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
@@ -744,7 +744,7 @@ def f(x):
     r2, r3, r4 :: object
 L0:
     r0 = builtins :: module
-    r1 = load_global CPyStatic_unicode_1 :: static  ('print')
+    r1 = 'print'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = box(short_int, 10)
     r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
@@ -758,9 +758,9 @@ def f() -> str:
 def f():
     r0, x, r1 :: str
 L0:
-    r0 = load_global CPyStatic_unicode_1 :: static  ('some string')
+    r0 = 'some string'
     x = r0
-    r1 = load_global CPyStatic_unicode_2 :: static  ('some other string')
+    r1 = 'some other string'
     return r1
 
 [case testBytesLiteral]
@@ -771,9 +771,9 @@ def f() -> bytes:
 def f():
     r0, x, r1 :: object
 L0:
-    r0 = load_global CPyStatic_bytes_1 :: static  (b'\xf0')
+    r0 = b'\xf0'
     x = r0
-    r1 = load_global CPyStatic_bytes_2 :: static  (b'1234')
+    r1 = b'1234'
     return r1
 
 [case testPyMethodCall1]
@@ -791,11 +791,11 @@ def f(x):
     r4 :: object
     r5 :: int
 L0:
-    r0 = load_global CPyStatic_unicode_3 :: static  ('pop')
+    r0 = 'pop'
     r1 = CPyObject_CallMethodObjArgs(x, r0, 0)
     r2 = unbox(int, r1)
     y = r2
-    r3 = load_global CPyStatic_unicode_3 :: static  ('pop')
+    r3 = 'pop'
     r4 = CPyObject_CallMethodObjArgs(x, r3, 0)
     r5 = unbox(int, r4)
     return r5
@@ -1018,11 +1018,11 @@ def assign_and_return_float_sum():
     r5 :: object
     r6 :: float
 L0:
-    r0 = load_global CPyStatic_float_1 :: static  (1.0)
+    r0 = 1.0
     f1 = r0
-    r1 = load_global CPyStatic_float_2 :: static  (2.0)
+    r1 = 2.0
     f2 = r1
-    r2 = load_global CPyStatic_float_3 :: static  (3.0)
+    r2 = 3.0
     f3 = r2
     r3 = PyNumber_Multiply(f1, f2)
     r4 = cast(float, r3)
@@ -1039,8 +1039,8 @@ def load():
     r1 :: float
     r2 :: object
 L0:
-    r0 = load_global CPyStatic_complex_1 :: static  (5j)
-    r1 = load_global CPyStatic_float_2 :: static  (1.0)
+    r0 = 5j
+    r1 = 1.0
     r2 = PyNumber_Add(r0, r1)
     return r2
 
@@ -1060,13 +1060,13 @@ def big_int():
 L0:
     a_62_bit = 9223372036854775804
     max_62_bit = 9223372036854775806
-    r0 = load_global CPyStatic_int_1 :: static  (4611686018427387904)
+    r0 = object 4611686018427387904
     b_63_bit = r0
-    r1 = load_global CPyStatic_int_2 :: static  (9223372036854775806)
+    r1 = object 9223372036854775806
     c_63_bit = r1
-    r2 = load_global CPyStatic_int_3 :: static  (9223372036854775807)
+    r2 = object 9223372036854775807
     max_63_bit = r2
-    r3 = load_global CPyStatic_int_4 :: static  (9223372036854775808)
+    r3 = object 9223372036854775808
     d_64_bit = r3
     max_32_bit = 4294967294
     max_31_bit = 2147483646
@@ -1126,7 +1126,7 @@ def call_callable_type() -> float:
 [out]
 def absolute_value(x):
     x :: int
-    r0 :: native_int
+    r0 :: int64
     r1, r2, r3 :: bit
     r4, r5 :: int
 L0:
@@ -1165,7 +1165,7 @@ L0:
 def return_float():
     r0 :: float
 L0:
-    r0 = load_global CPyStatic_float_3 :: static  (5.0)
+    r0 = 5.0
     return r0
 def return_callable_type():
     r0 :: dict
@@ -1173,7 +1173,7 @@ def return_callable_type():
     r2 :: object
 L0:
     r0 = __main__.globals :: static
-    r1 = load_global CPyStatic_unicode_4 :: static  ('return_float')
+    r1 = 'return_float'
     r2 = CPyDict_GetItem(r0, r1)
     return r2
 def call_callable_type():
@@ -1209,7 +1209,7 @@ def call_python_function_with_keyword_arg(x):
     r6 :: int
 L0:
     r0 = load_address PyLong_Type
-    r1 = load_global CPyStatic_unicode_3 :: static  ('base')
+    r1 = 'base'
     r2 = PyTuple_Pack(1, x)
     r3 = box(short_int, 4)
     r4 = CPyDict_Build(1, r1, r3)
@@ -1235,18 +1235,18 @@ def call_python_method_with_keyword_args(xs, first, second):
     r15 :: dict
     r16 :: object
 L0:
-    r0 = load_global CPyStatic_unicode_4 :: static  ('insert')
+    r0 = 'insert'
     r1 = CPyObject_GetAttr(xs, r0)
-    r2 = load_global CPyStatic_unicode_5 :: static  ('x')
+    r2 = 'x'
     r3 = box(short_int, 0)
     r4 = PyTuple_Pack(1, r3)
     r5 = box(int, first)
     r6 = CPyDict_Build(1, r2, r5)
     r7 = PyObject_Call(r1, r4, r6)
-    r8 = load_global CPyStatic_unicode_4 :: static  ('insert')
+    r8 = 'insert'
     r9 = CPyObject_GetAttr(xs, r8)
-    r10 = load_global CPyStatic_unicode_5 :: static  ('x')
-    r11 = load_global CPyStatic_unicode_6 :: static  ('i')
+    r10 = 'x'
+    r11 = 'i'
     r12 = PyTuple_Pack(0)
     r13 = box(int, second)
     r14 = box(short_int, 2)
@@ -1417,7 +1417,7 @@ def foo():
     r2, r3 :: object
 L0:
     r0 = builtins :: module
-    r1 = load_global CPyStatic_unicode_1 :: static  ('Exception')
+    r1 = 'Exception'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = PyObject_CallFunctionObjArgs(r2, 0)
     CPy_Raise(r3)
@@ -1428,7 +1428,7 @@ def bar():
     r2 :: object
 L0:
     r0 = builtins :: module
-    r1 = load_global CPyStatic_unicode_1 :: static  ('Exception')
+    r1 = 'Exception'
     r2 = CPyObject_GetAttr(r0, r1)
     CPy_Raise(r2)
     unreachable
@@ -1450,11 +1450,11 @@ def f():
     r6, r7, r8 :: object
 L0:
     r0 = __main__.globals :: static
-    r1 = load_global CPyStatic_unicode_1 :: static  ('x')
+    r1 = 'x'
     r2 = CPyDict_GetItem(r0, r1)
     r3 = unbox(int, r2)
     r4 = builtins :: module
-    r5 = load_global CPyStatic_unicode_2 :: static  ('print')
+    r5 = 'print'
     r6 = CPyObject_GetAttr(r4, r5)
     r7 = box(int, r3)
     r8 = PyObject_CallFunctionObjArgs(r6, r7, 0)
@@ -1482,21 +1482,21 @@ L0:
     r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
-    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
+    r3 = 'builtins'
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
     r5 = __main__.globals :: static
-    r6 = load_global CPyStatic_unicode_1 :: static  ('x')
+    r6 = 'x'
     r7 = box(short_int, 2)
     r8 = CPyDict_SetItem(r5, r6, r7)
     r9 = r8 >= 0 :: signed
     r10 = __main__.globals :: static
-    r11 = load_global CPyStatic_unicode_1 :: static  ('x')
+    r11 = 'x'
     r12 = CPyDict_GetItem(r10, r11)
     r13 = unbox(int, r12)
     r14 = builtins :: module
-    r15 = load_global CPyStatic_unicode_2 :: static  ('print')
+    r15 = 'print'
     r16 = CPyObject_GetAttr(r14, r15)
     r17 = box(int, r13)
     r18 = PyObject_CallFunctionObjArgs(r16, r17, 0)
@@ -1520,7 +1520,7 @@ def f():
     r5 :: str
 L0:
     r0 = m :: module
-    r1 = load_global CPyStatic_unicode_2 :: static  ('f')
+    r1 = 'f'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = box(short_int, 2)
     r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
@@ -1628,9 +1628,9 @@ def g():
     r2 :: str
     r3 :: None
 L0:
-    r0 = load_global CPyStatic_unicode_1 :: static  ('a')
+    r0 = 'a'
     r1 = f(0, r0)
-    r2 = load_global CPyStatic_unicode_2 :: static  ('b')
+    r2 = 'b'
     r3 = f(2, r2)
     return 1
 
@@ -1655,9 +1655,9 @@ def g(a):
     r2 :: str
     r3 :: None
 L0:
-    r0 = load_global CPyStatic_unicode_4 :: static  ('a')
+    r0 = 'a'
     r1 = a.f(0, r0)
-    r2 = load_global CPyStatic_unicode_5 :: static  ('b')
+    r2 = 'b'
     r3 = a.f(2, r2)
     return 1
 
@@ -1690,7 +1690,7 @@ def g():
 L0:
     r0 = (2, 4, 6)
     r1 = __main__.globals :: static
-    r2 = load_global CPyStatic_unicode_3 :: static  ('f')
+    r2 = 'f'
     r3 = CPyDict_GetItem(r1, r2)
     r4 = PyList_New(0)
     r5 = box(tuple[int, int, int], r0)
@@ -1716,7 +1716,7 @@ def h():
 L0:
     r0 = (4, 6)
     r1 = __main__.globals :: static
-    r2 = load_global CPyStatic_unicode_3 :: static  ('f')
+    r2 = 'f'
     r3 = CPyDict_GetItem(r1, r2)
     r4 = PyList_New(1)
     r5 = box(short_int, 2)
@@ -1759,15 +1759,15 @@ def g():
     r14 :: object
     r15 :: tuple[int, int, int]
 L0:
-    r0 = load_global CPyStatic_unicode_3 :: static  ('a')
-    r1 = load_global CPyStatic_unicode_4 :: static  ('b')
-    r2 = load_global CPyStatic_unicode_5 :: static  ('c')
+    r0 = 'a'
+    r1 = 'b'
+    r2 = 'c'
     r3 = box(short_int, 2)
     r4 = box(short_int, 4)
     r5 = box(short_int, 6)
     r6 = CPyDict_Build(3, r0, r3, r1, r4, r2, r5)
     r7 = __main__.globals :: static
-    r8 = load_global CPyStatic_unicode_6 :: static  ('f')
+    r8 = 'f'
     r9 = CPyDict_GetItem(r7, r8)
     r10 = PyTuple_Pack(0)
     r11 = PyDict_New()
@@ -1789,13 +1789,13 @@ def h():
     r13 :: object
     r14 :: tuple[int, int, int]
 L0:
-    r0 = load_global CPyStatic_unicode_4 :: static  ('b')
-    r1 = load_global CPyStatic_unicode_5 :: static  ('c')
+    r0 = 'b'
+    r1 = 'c'
     r2 = box(short_int, 4)
     r3 = box(short_int, 6)
     r4 = CPyDict_Build(2, r0, r2, r1, r3)
     r5 = __main__.globals :: static
-    r6 = load_global CPyStatic_unicode_6 :: static  ('f')
+    r6 = 'f'
     r7 = CPyDict_GetItem(r5, r6)
     r8 = box(short_int, 2)
     r9 = PyTuple_Pack(1, r8)
@@ -1824,7 +1824,7 @@ L1:
 L2:
     if is_error(z) goto L3 else goto L4
 L3:
-    r0 = load_global CPyStatic_unicode_1 :: static  ('test')
+    r0 = 'test'
     z = r0
 L4:
     return 1
@@ -1863,7 +1863,7 @@ L1:
 L2:
     if is_error(z) goto L3 else goto L4
 L3:
-    r0 = load_global CPyStatic_unicode_4 :: static  ('test')
+    r0 = 'test'
     z = r0
 L4:
     return 1
@@ -2566,7 +2566,7 @@ L0:
     r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
-    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
+    r3 = 'builtins'
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
@@ -2575,76 +2575,76 @@ L2:
     r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
-    r8 = load_global CPyStatic_unicode_1 :: static  ('typing')
+    r8 = 'typing'
     r9 = PyImport_Import(r8)
     typing = r9 :: module
 L4:
     r10 = typing :: module
     r11 = __main__.globals :: static
-    r12 = load_global CPyStatic_unicode_2 :: static  ('List')
+    r12 = 'List'
     r13 = CPyObject_GetAttr(r10, r12)
-    r14 = load_global CPyStatic_unicode_2 :: static  ('List')
+    r14 = 'List'
     r15 = CPyDict_SetItem(r11, r14, r13)
     r16 = r15 >= 0 :: signed
-    r17 = load_global CPyStatic_unicode_3 :: static  ('NewType')
+    r17 = 'NewType'
     r18 = CPyObject_GetAttr(r10, r17)
-    r19 = load_global CPyStatic_unicode_3 :: static  ('NewType')
+    r19 = 'NewType'
     r20 = CPyDict_SetItem(r11, r19, r18)
     r21 = r20 >= 0 :: signed
-    r22 = load_global CPyStatic_unicode_4 :: static  ('NamedTuple')
+    r22 = 'NamedTuple'
     r23 = CPyObject_GetAttr(r10, r22)
-    r24 = load_global CPyStatic_unicode_4 :: static  ('NamedTuple')
+    r24 = 'NamedTuple'
     r25 = CPyDict_SetItem(r11, r24, r23)
     r26 = r25 >= 0 :: signed
-    r27 = load_global CPyStatic_unicode_5 :: static  ('Lol')
-    r28 = load_global CPyStatic_unicode_6 :: static  ('a')
+    r27 = 'Lol'
+    r28 = 'a'
     r29 = load_address PyLong_Type
     r30 = (r28, r29)
     r31 = box(tuple[str, object], r30)
-    r32 = load_global CPyStatic_unicode_7 :: static  ('b')
+    r32 = 'b'
     r33 = load_address PyUnicode_Type
     r34 = (r32, r33)
     r35 = box(tuple[str, object], r34)
     r36 = (r31, r35)
     r37 = box(tuple[object, object], r36)
     r38 = __main__.globals :: static
-    r39 = load_global CPyStatic_unicode_4 :: static  ('NamedTuple')
+    r39 = 'NamedTuple'
     r40 = CPyDict_GetItem(r38, r39)
     r41 = PyObject_CallFunctionObjArgs(r40, r27, r37, 0)
     r42 = __main__.globals :: static
-    r43 = load_global CPyStatic_unicode_5 :: static  ('Lol')
+    r43 = 'Lol'
     r44 = CPyDict_SetItem(r42, r43, r41)
     r45 = r44 >= 0 :: signed
-    r46 = load_global CPyStatic_unicode_8 :: static
+    r46 = ''
     r47 = __main__.globals :: static
-    r48 = load_global CPyStatic_unicode_5 :: static  ('Lol')
+    r48 = 'Lol'
     r49 = CPyDict_GetItem(r47, r48)
     r50 = box(short_int, 2)
     r51 = PyObject_CallFunctionObjArgs(r49, r50, r46, 0)
     r52 = cast(tuple, r51)
     r53 = __main__.globals :: static
-    r54 = load_global CPyStatic_unicode_9 :: static  ('x')
+    r54 = 'x'
     r55 = CPyDict_SetItem(r53, r54, r52)
     r56 = r55 >= 0 :: signed
     r57 = __main__.globals :: static
-    r58 = load_global CPyStatic_unicode_2 :: static  ('List')
+    r58 = 'List'
     r59 = CPyDict_GetItem(r57, r58)
     r60 = load_address PyLong_Type
     r61 = PyObject_GetItem(r59, r60)
     r62 = __main__.globals :: static
-    r63 = load_global CPyStatic_unicode_10 :: static  ('Foo')
+    r63 = 'Foo'
     r64 = CPyDict_SetItem(r62, r63, r61)
     r65 = r64 >= 0 :: signed
-    r66 = load_global CPyStatic_unicode_11 :: static  ('Bar')
+    r66 = 'Bar'
     r67 = __main__.globals :: static
-    r68 = load_global CPyStatic_unicode_10 :: static  ('Foo')
+    r68 = 'Foo'
     r69 = CPyDict_GetItem(r67, r68)
     r70 = __main__.globals :: static
-    r71 = load_global CPyStatic_unicode_3 :: static  ('NewType')
+    r71 = 'NewType'
     r72 = CPyDict_GetItem(r70, r71)
     r73 = PyObject_CallFunctionObjArgs(r72, r66, r69, 0)
     r74 = __main__.globals :: static
-    r75 = load_global CPyStatic_unicode_11 :: static  ('Bar')
+    r75 = 'Bar'
     r76 = CPyDict_SetItem(r74, r75, r73)
     r77 = r76 >= 0 :: signed
     r78 = PyList_New(3)
@@ -2654,16 +2654,16 @@ L4:
     r82 = get_element_ptr r78 ob_item :: PyListObject
     r83 = load_mem r82, r78 :: ptr*
     set_mem r83, r79, r78 :: builtins.object*
-    r84 = r83 + WORD_SIZE*1
+    r84 = r83 + 8
     set_mem r84, r80, r78 :: builtins.object*
-    r85 = r83 + WORD_SIZE*2
+    r85 = r83 + 16
     set_mem r85, r81, r78 :: builtins.object*
     r86 = __main__.globals :: static
-    r87 = load_global CPyStatic_unicode_11 :: static  ('Bar')
+    r87 = 'Bar'
     r88 = CPyDict_GetItem(r86, r87)
     r89 = PyObject_CallFunctionObjArgs(r88, r78, 0)
     r90 = __main__.globals :: static
-    r91 = load_global CPyStatic_unicode_12 :: static  ('y')
+    r91 = 'y'
     r92 = CPyDict_SetItem(r90, r91, r89)
     r93 = r92 >= 0 :: signed
     return 1
@@ -2825,16 +2825,16 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.g
     g = r1
-    r2 = load_global CPyStatic_unicode_3 :: static  ('Entering')
+    r2 = 'Entering'
     r3 = builtins :: module
-    r4 = load_global CPyStatic_unicode_4 :: static  ('print')
+    r4 = 'print'
     r5 = CPyObject_GetAttr(r3, r4)
     r6 = PyObject_CallFunctionObjArgs(r5, r2, 0)
     r7 = r0.f
     r8 = PyObject_CallFunctionObjArgs(r7, 0)
-    r9 = load_global CPyStatic_unicode_5 :: static  ('Exited')
+    r9 = 'Exited'
     r10 = builtins :: module
-    r11 = load_global CPyStatic_unicode_4 :: static  ('print')
+    r11 = 'print'
     r12 = CPyObject_GetAttr(r10, r11)
     r13 = PyObject_CallFunctionObjArgs(r12, r9, 0)
     return 1
@@ -2882,16 +2882,16 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.g
     g = r1
-    r2 = load_global CPyStatic_unicode_6 :: static  ('---')
+    r2 = '---'
     r3 = builtins :: module
-    r4 = load_global CPyStatic_unicode_4 :: static  ('print')
+    r4 = 'print'
     r5 = CPyObject_GetAttr(r3, r4)
     r6 = PyObject_CallFunctionObjArgs(r5, r2, 0)
     r7 = r0.f
     r8 = PyObject_CallFunctionObjArgs(r7, 0)
-    r9 = load_global CPyStatic_unicode_6 :: static  ('---')
+    r9 = '---'
     r10 = builtins :: module
-    r11 = load_global CPyStatic_unicode_4 :: static  ('print')
+    r11 = 'print'
     r12 = CPyObject_GetAttr(r10, r11)
     r13 = PyObject_CallFunctionObjArgs(r12, r9, 0)
     return 1
@@ -2935,9 +2935,9 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.d
     d = r1
-    r2 = load_global CPyStatic_unicode_7 :: static  ('d')
+    r2 = 'd'
     r3 = builtins :: module
-    r4 = load_global CPyStatic_unicode_4 :: static  ('print')
+    r4 = 'print'
     r5 = CPyObject_GetAttr(r3, r4)
     r6 = PyObject_CallFunctionObjArgs(r5, r2, 0)
     return 1
@@ -2961,17 +2961,17 @@ L0:
     r1 = __mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     r3 = __main__.globals :: static
-    r4 = load_global CPyStatic_unicode_8 :: static  ('b')
+    r4 = 'b'
     r5 = CPyDict_GetItem(r3, r4)
     r6 = PyObject_CallFunctionObjArgs(r5, r1, 0)
     r7 = __main__.globals :: static
-    r8 = load_global CPyStatic_unicode_9 :: static  ('a')
+    r8 = 'a'
     r9 = CPyDict_GetItem(r7, r8)
     r10 = PyObject_CallFunctionObjArgs(r9, r6, 0)
     r0.d = r10; r11 = is_error
-    r12 = load_global CPyStatic_unicode_10 :: static  ('c')
+    r12 = 'c'
     r13 = builtins :: module
-    r14 = load_global CPyStatic_unicode_4 :: static  ('print')
+    r14 = 'print'
     r15 = CPyObject_GetAttr(r13, r14)
     r16 = PyObject_CallFunctionObjArgs(r15, r12, 0)
     r17 = r0.d
@@ -3010,7 +3010,7 @@ L0:
     r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
-    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
+    r3 = 'builtins'
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
@@ -3019,30 +3019,30 @@ L2:
     r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
-    r8 = load_global CPyStatic_unicode_1 :: static  ('typing')
+    r8 = 'typing'
     r9 = PyImport_Import(r8)
     typing = r9 :: module
 L4:
     r10 = typing :: module
     r11 = __main__.globals :: static
-    r12 = load_global CPyStatic_unicode_2 :: static  ('Callable')
+    r12 = 'Callable'
     r13 = CPyObject_GetAttr(r10, r12)
-    r14 = load_global CPyStatic_unicode_2 :: static  ('Callable')
+    r14 = 'Callable'
     r15 = CPyDict_SetItem(r11, r14, r13)
     r16 = r15 >= 0 :: signed
     r17 = __main__.globals :: static
-    r18 = load_global CPyStatic_unicode_11 :: static  ('__mypyc_c_decorator_helper__')
+    r18 = '__mypyc_c_decorator_helper__'
     r19 = CPyDict_GetItem(r17, r18)
     r20 = __main__.globals :: static
-    r21 = load_global CPyStatic_unicode_8 :: static  ('b')
+    r21 = 'b'
     r22 = CPyDict_GetItem(r20, r21)
     r23 = PyObject_CallFunctionObjArgs(r22, r19, 0)
     r24 = __main__.globals :: static
-    r25 = load_global CPyStatic_unicode_9 :: static  ('a')
+    r25 = 'a'
     r26 = CPyDict_GetItem(r24, r25)
     r27 = PyObject_CallFunctionObjArgs(r26, r23, 0)
     r28 = __main__.globals :: static
-    r29 = load_global CPyStatic_unicode_10 :: static  ('c')
+    r29 = 'c'
     r30 = CPyDict_SetItem(r28, r29, r27)
     r31 = r30 >= 0 :: signed
     return 1
@@ -3087,16 +3087,16 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.g
     g = r1
-    r2 = load_global CPyStatic_unicode_3 :: static  ('Entering')
+    r2 = 'Entering'
     r3 = builtins :: module
-    r4 = load_global CPyStatic_unicode_4 :: static  ('print')
+    r4 = 'print'
     r5 = CPyObject_GetAttr(r3, r4)
     r6 = PyObject_CallFunctionObjArgs(r5, r2, 0)
     r7 = r0.f
     r8 = PyObject_CallFunctionObjArgs(r7, 0)
-    r9 = load_global CPyStatic_unicode_5 :: static  ('Exited')
+    r9 = 'Exited'
     r10 = builtins :: module
-    r11 = load_global CPyStatic_unicode_4 :: static  ('print')
+    r11 = 'print'
     r12 = CPyObject_GetAttr(r10, r11)
     r13 = PyObject_CallFunctionObjArgs(r12, r9, 0)
     return 1
@@ -3135,7 +3135,7 @@ L0:
     r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
-    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
+    r3 = 'builtins'
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
@@ -3144,15 +3144,15 @@ L2:
     r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
-    r8 = load_global CPyStatic_unicode_1 :: static  ('typing')
+    r8 = 'typing'
     r9 = PyImport_Import(r8)
     typing = r9 :: module
 L4:
     r10 = typing :: module
     r11 = __main__.globals :: static
-    r12 = load_global CPyStatic_unicode_2 :: static  ('Callable')
+    r12 = 'Callable'
     r13 = CPyObject_GetAttr(r10, r12)
-    r14 = load_global CPyStatic_unicode_2 :: static  ('Callable')
+    r14 = 'Callable'
     r15 = CPyDict_SetItem(r11, r14, r13)
     r16 = r15 >= 0 :: signed
     return 1
@@ -3266,8 +3266,8 @@ def lol(x):
     r3 :: bit
     r4 :: object
 L0:
-    r0 = load_global CPyStatic_unicode_5 :: static  ('x')
-    r1 = load_global CPyStatic_unicode_6 :: static  ('5')
+    r0 = 'x'
+    r1 = '5'
     r2 = PyObject_SetAttr(x, r0, r1)
     r3 = r2 >= 0 :: signed
     r4 = box(None, 1)
@@ -3314,10 +3314,10 @@ def f(a):
 L0:
     if a goto L1 else goto L2 :: bool
 L1:
-    r0 = load_global CPyStatic_unicode_3 :: static  ('x')
+    r0 = 'x'
     return r0
 L2:
-    r1 = load_global CPyStatic_unicode_4 :: static  ('y')
+    r1 = 'y'
     return r1
 L3:
     unreachable
@@ -3507,7 +3507,7 @@ def f(x):
     r2, r3, r4 :: object
 L0:
     r0 = builtins :: module
-    r1 = load_global CPyStatic_unicode_1 :: static  ('reveal_type')
+    r1 = 'reveal_type'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = box(int, x)
     r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
@@ -3610,20 +3610,20 @@ L0:
     r3 = r1 != r2
     if r3 goto L2 else goto L1 :: bool
 L1:
-    r4 = load_global CPyStatic_unicode_1 :: static  ('p.m')
+    r4 = 'p.m'
     r5 = PyImport_Import(r4)
     p.m = r5 :: module
 L2:
     r6 = PyImport_GetModuleDict()
-    r7 = load_global CPyStatic_unicode_2 :: static  ('p')
+    r7 = 'p'
     r8 = CPyDict_GetItem(r6, r7)
-    r9 = load_global CPyStatic_unicode_2 :: static  ('p')
+    r9 = 'p'
     r10 = CPyDict_SetItem(r0, r9, r8)
     r11 = r10 >= 0 :: signed
     r12 = PyImport_GetModuleDict()
-    r13 = load_global CPyStatic_unicode_2 :: static  ('p')
+    r13 = 'p'
     r14 = CPyDict_GetItem(r12, r13)
-    r15 = load_global CPyStatic_unicode_3 :: static  ('x')
+    r15 = 'x'
     r16 = CPyObject_GetAttr(r14, r15)
     r17 = unbox(int, r16)
     return r17

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -1086,19 +1086,19 @@ def big_int() -> None:
 def big_int():
     r0, a_62_bit, r1, max_62_bit, r2, b_63_bit, r3, c_63_bit, r4, max_63_bit, r5, d_64_bit, r6, max_32_bit, max_31_bit :: int
 L0:
-    r0 = load_global CPyStatic_int_1 :: static  (4611686018427387902)
+    r0 = object 4611686018427387902
     a_62_bit = r0
-    r1 = load_global CPyStatic_int_2 :: static  (4611686018427387903)
+    r1 = object 4611686018427387903
     max_62_bit = r1
-    r2 = load_global CPyStatic_int_3 :: static  (4611686018427387904)
+    r2 = object 4611686018427387904
     b_63_bit = r2
-    r3 = load_global CPyStatic_int_4 :: static  (9223372036854775806)
+    r3 = object 9223372036854775806
     c_63_bit = r3
-    r4 = load_global CPyStatic_int_5 :: static  (9223372036854775807)
+    r4 = object 9223372036854775807
     max_63_bit = r4
-    r5 = load_global CPyStatic_int_6 :: static  (9223372036854775808)
+    r5 = object 9223372036854775808
     d_64_bit = r5
-    r6 = load_global CPyStatic_int_7 :: static  (2147483647)
+    r6 = object 2147483647
     max_32_bit = r6
     max_31_bit = 2147483646
     return 1
@@ -1126,7 +1126,7 @@ def call_callable_type() -> float:
 [out]
 def absolute_value(x):
     x :: int
-    r0 :: int64
+    r0 :: native_int
     r1, r2, r3 :: bit
     r4, r5 :: int
 L0:
@@ -2654,9 +2654,9 @@ L4:
     r82 = get_element_ptr r78 ob_item :: PyListObject
     r83 = load_mem r82, r78 :: ptr*
     set_mem r83, r79, r78 :: builtins.object*
-    r84 = r83 + 8
+    r84 = r83 + WORD_SIZE*1
     set_mem r84, r80, r78 :: builtins.object*
-    r85 = r83 + 16
+    r85 = r83 + WORD_SIZE*2
     set_mem r85, r81, r78 :: builtins.object*
     r86 = __main__.globals :: static
     r87 = 'Bar'

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -83,7 +83,7 @@ def g(a):
     r0 :: str
     r1 :: int
 L0:
-    r0 = load_global CPyStatic_unicode_4 :: static  ('hi')
+    r0 = 'hi'
     r1 = a.f(2, r0)
     return 1
 
@@ -370,7 +370,7 @@ L0:
     r2 = r0 != r1
     if r2 goto L2 else goto L1 :: bool
 L1:
-    r3 = load_global CPyStatic_unicode_0 :: static  ('builtins')
+    r3 = 'builtins'
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
@@ -379,20 +379,20 @@ L2:
     r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
-    r8 = load_global CPyStatic_unicode_1 :: static  ('typing')
+    r8 = 'typing'
     r9 = PyImport_Import(r8)
     typing = r9 :: module
 L4:
     r10 = typing :: module
     r11 = __main__.globals :: static
-    r12 = load_global CPyStatic_unicode_2 :: static  ('TypeVar')
+    r12 = 'TypeVar'
     r13 = CPyObject_GetAttr(r10, r12)
-    r14 = load_global CPyStatic_unicode_2 :: static  ('TypeVar')
+    r14 = 'TypeVar'
     r15 = CPyDict_SetItem(r11, r14, r13)
     r16 = r15 >= 0 :: signed
-    r17 = load_global CPyStatic_unicode_3 :: static  ('Generic')
+    r17 = 'Generic'
     r18 = CPyObject_GetAttr(r10, r17)
-    r19 = load_global CPyStatic_unicode_3 :: static  ('Generic')
+    r19 = 'Generic'
     r20 = CPyDict_SetItem(r11, r19, r18)
     r21 = r20 >= 0 :: signed
     r22 = mypy_extensions :: module
@@ -400,75 +400,75 @@ L4:
     r24 = r22 != r23
     if r24 goto L6 else goto L5 :: bool
 L5:
-    r25 = load_global CPyStatic_unicode_4 :: static  ('mypy_extensions')
+    r25 = 'mypy_extensions'
     r26 = PyImport_Import(r25)
     mypy_extensions = r26 :: module
 L6:
     r27 = mypy_extensions :: module
     r28 = __main__.globals :: static
-    r29 = load_global CPyStatic_unicode_5 :: static  ('trait')
+    r29 = 'trait'
     r30 = CPyObject_GetAttr(r27, r29)
-    r31 = load_global CPyStatic_unicode_5 :: static  ('trait')
+    r31 = 'trait'
     r32 = CPyDict_SetItem(r28, r31, r30)
     r33 = r32 >= 0 :: signed
-    r34 = load_global CPyStatic_unicode_6 :: static  ('T')
+    r34 = 'T'
     r35 = __main__.globals :: static
-    r36 = load_global CPyStatic_unicode_2 :: static  ('TypeVar')
+    r36 = 'TypeVar'
     r37 = CPyDict_GetItem(r35, r36)
     r38 = PyObject_CallFunctionObjArgs(r37, r34, 0)
     r39 = __main__.globals :: static
-    r40 = load_global CPyStatic_unicode_6 :: static  ('T')
+    r40 = 'T'
     r41 = CPyDict_SetItem(r39, r40, r38)
     r42 = r41 >= 0 :: signed
     r43 = <error> :: object
-    r44 = load_global CPyStatic_unicode_7 :: static  ('__main__')
+    r44 = '__main__'
     r45 = __main__.C_template :: type
     r46 = CPyType_FromTemplate(r45, r43, r44)
     r47 = C_trait_vtable_setup()
-    r48 = load_global CPyStatic_unicode_8 :: static  ('__mypyc_attrs__')
+    r48 = '__mypyc_attrs__'
     r49 = PyTuple_Pack(0)
     r50 = PyObject_SetAttr(r46, r48, r49)
     r51 = r50 >= 0 :: signed
     __main__.C = r46 :: type
     r52 = __main__.globals :: static
-    r53 = load_global CPyStatic_unicode_9 :: static  ('C')
+    r53 = 'C'
     r54 = CPyDict_SetItem(r52, r53, r46)
     r55 = r54 >= 0 :: signed
     r56 = <error> :: object
-    r57 = load_global CPyStatic_unicode_7 :: static  ('__main__')
+    r57 = '__main__'
     r58 = __main__.S_template :: type
     r59 = CPyType_FromTemplate(r58, r56, r57)
-    r60 = load_global CPyStatic_unicode_8 :: static  ('__mypyc_attrs__')
+    r60 = '__mypyc_attrs__'
     r61 = PyTuple_Pack(0)
     r62 = PyObject_SetAttr(r59, r60, r61)
     r63 = r62 >= 0 :: signed
     __main__.S = r59 :: type
     r64 = __main__.globals :: static
-    r65 = load_global CPyStatic_unicode_10 :: static  ('S')
+    r65 = 'S'
     r66 = CPyDict_SetItem(r64, r65, r59)
     r67 = r66 >= 0 :: signed
     r68 = __main__.C :: type
     r69 = __main__.S :: type
     r70 = __main__.globals :: static
-    r71 = load_global CPyStatic_unicode_3 :: static  ('Generic')
+    r71 = 'Generic'
     r72 = CPyDict_GetItem(r70, r71)
     r73 = __main__.globals :: static
-    r74 = load_global CPyStatic_unicode_6 :: static  ('T')
+    r74 = 'T'
     r75 = CPyDict_GetItem(r73, r74)
     r76 = PyObject_GetItem(r72, r75)
     r77 = PyTuple_Pack(3, r68, r69, r76)
-    r78 = load_global CPyStatic_unicode_7 :: static  ('__main__')
+    r78 = '__main__'
     r79 = __main__.D_template :: type
     r80 = CPyType_FromTemplate(r79, r77, r78)
     r81 = D_trait_vtable_setup()
-    r82 = load_global CPyStatic_unicode_8 :: static  ('__mypyc_attrs__')
-    r83 = load_global CPyStatic_unicode_11 :: static  ('__dict__')
+    r82 = '__mypyc_attrs__'
+    r83 = '__dict__'
     r84 = PyTuple_Pack(1, r83)
     r85 = PyObject_SetAttr(r80, r82, r84)
     r86 = r85 >= 0 :: signed
     __main__.D = r80 :: type
     r87 = __main__.globals :: static
-    r88 = load_global CPyStatic_unicode_12 :: static  ('D')
+    r88 = 'D'
     r89 = CPyDict_SetItem(r87, r88, r80)
     r90 = r89 >= 0 :: signed
     return 1
@@ -792,7 +792,7 @@ def f():
     r3 :: int
 L0:
     r0 = __main__.A :: type
-    r1 = load_global CPyStatic_unicode_6 :: static  ('x')
+    r1 = 'x'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = unbox(int, r2)
     return r3
@@ -958,7 +958,7 @@ def fOpt2(a, b):
     r1 :: object
     r2 :: bool
 L0:
-    r0 = load_global CPyStatic_unicode_1 :: static  ('__ne__')
+    r0 = '__ne__'
     r1 = CPyObject_CallMethodObjArgs(a, r0, b, 0)
     r2 = unbox(bool, r1)
     return r2
@@ -1029,7 +1029,7 @@ def B.__mypyc_defaults_setup(__mypyc_self__):
 L0:
     __mypyc_self__.x = 20; r0 = is_error
     r1 = __main__.globals :: static
-    r2 = load_global CPyStatic_unicode_9 :: static  ('LOL')
+    r2 = 'LOL'
     r3 = CPyDict_GetItem(r1, r2)
     r4 = cast(str, r3)
     __mypyc_self__.y = r4; r5 = is_error

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -52,7 +52,7 @@ def f(x):
     r1, r2 :: object
     r3, d :: dict
 L0:
-    r0 = load_global CPyStatic_unicode_1 :: static
+    r0 = ''
     r1 = box(short_int, 2)
     r2 = box(short_int, 4)
     r3 = CPyDict_Build(2, r1, r2, r0, x)
@@ -194,7 +194,7 @@ def f(x, y):
     r6 :: int32
     r7 :: bit
 L0:
-    r0 = load_global CPyStatic_unicode_3 :: static  ('z')
+    r0 = 'z'
     r1 = box(short_int, 4)
     r2 = CPyDict_Build(1, x, r1)
     r3 = CPyDict_UpdateInDisplay(r2, y)

--- a/mypyc/test-data/irbuild-nested.test
+++ b/mypyc/test-data/irbuild-nested.test
@@ -93,7 +93,7 @@ L0:
     r1 = r0.__mypyc_env__
     r2 = r0.second
     second = r2
-    r3 = load_global CPyStatic_unicode_3 :: static  ('b.first.second: nested function')
+    r3 = 'b.first.second: nested function'
     return r3
 def first_b_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
@@ -163,7 +163,7 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
     inner = r1
-    r2 = load_global CPyStatic_unicode_4 :: static  ('!')
+    r2 = '!'
     r3 = PyUnicode_Concat(s, r2)
     return r3
 def c(num):
@@ -202,7 +202,7 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
     inner = r1
-    r2 = load_global CPyStatic_unicode_5 :: static  ('?')
+    r2 = '?'
     r3 = PyUnicode_Concat(s, r2)
     return r3
 def d(num):
@@ -220,12 +220,12 @@ L0:
     r1 = inner_d_obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     r0.inner = r1; r3 = is_error
-    r4 = load_global CPyStatic_unicode_6 :: static  ('one')
+    r4 = 'one'
     r5 = r0.inner
     r6 = PyObject_CallFunctionObjArgs(r5, r4, 0)
     r7 = cast(str, r6)
     a = r7
-    r8 = load_global CPyStatic_unicode_7 :: static  ('two')
+    r8 = 'two'
     r9 = r0.inner
     r10 = PyObject_CallFunctionObjArgs(r9, r8, 0)
     r11 = cast(str, r10)
@@ -234,17 +234,17 @@ L0:
 def inner():
     r0 :: str
 L0:
-    r0 = load_global CPyStatic_unicode_8 :: static  ('inner: normal function')
+    r0 = 'inner: normal function'
     return r0
 def first():
     r0 :: str
 L0:
-    r0 = load_global CPyStatic_unicode_9 :: static  ('first: normal function')
+    r0 = 'first: normal function'
     return r0
 def second():
     r0 :: str
 L0:
-    r0 = load_global CPyStatic_unicode_10 :: static  ('second: normal function')
+    r0 = 'second: normal function'
     return r0
 
 [case testFreeVars]
@@ -384,7 +384,7 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
     inner = r1
-    r2 = load_global CPyStatic_unicode_3 :: static  ('f.inner: first definition')
+    r2 = 'f.inner: first definition'
     return r2
 def inner_c_obj_0.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
@@ -408,7 +408,7 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
     inner = r1
-    r2 = load_global CPyStatic_unicode_4 :: static  ('f.inner: second definition')
+    r2 = 'f.inner: second definition'
     return r2
 def c(flag):
     flag :: bool
@@ -565,7 +565,7 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
     inner = r1
-    r2 = load_global CPyStatic_unicode_1 :: static  ('f.inner: first definition')
+    r2 = 'f.inner: first definition'
     return r2
 def inner_f_obj_0.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
@@ -589,7 +589,7 @@ L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
     inner = r1
-    r2 = load_global CPyStatic_unicode_2 :: static  ('f.inner: second definition')
+    r2 = 'f.inner: second definition'
     return r2
 def f(flag):
     flag :: bool

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -341,7 +341,7 @@ def set(o, s):
     r1 :: int32
     r2 :: bit
 L0:
-    r0 = load_global CPyStatic_unicode_5 :: static  ('a')
+    r0 = 'a'
     r1 = PyObject_SetAttr(o, r0, s)
     r2 = r1 >= 0 :: signed
     return 1
@@ -471,7 +471,7 @@ L1:
     goto L3
 L2:
     r7 = o
-    r8 = load_global CPyStatic_unicode_7 :: static  ('x')
+    r8 = 'x'
     r9 = CPyObject_GetAttr(r7, r8)
     r10 = unbox(int, r9)
     r6 = r10
@@ -502,7 +502,7 @@ L1:
     goto L3
 L2:
     r7 = o
-    r8 = load_global CPyStatic_unicode_7 :: static  ('x')
+    r8 = 'x'
     r9 = CPyObject_GetAttr(r7, r8)
     r10 = unbox(int, r9)
     r6 = r10
@@ -530,8 +530,9 @@ def f(o):
     r2, r3 :: object
 L0:
     r0 = o
-    r1 = load_global CPyStatic_unicode_6 :: static  ('x')
+    r1 = 'x'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = r2
 L1:
     return 1
+

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -737,7 +737,7 @@ L1:
     if r5 goto L3 else goto L2 :: bool
 L2:
     r6 = builtins :: module
-    r7 = load_global CPyStatic_unicode_3 :: static  ('AssertionError')
+    r7 = 'AssertionError'
     r8 = CPyObject_GetAttr(r6, r7)
     r9 = PyObject_CallFunctionObjArgs(r8, s, 0)
     CPy_Raise(r9)
@@ -841,13 +841,13 @@ def delDict():
     r6 :: int32
     r7 :: bit
 L0:
-    r0 = load_global CPyStatic_unicode_1 :: static  ('one')
-    r1 = load_global CPyStatic_unicode_2 :: static  ('two')
+    r0 = 'one'
+    r1 = 'two'
     r2 = box(short_int, 2)
     r3 = box(short_int, 4)
     r4 = CPyDict_Build(2, r0, r2, r1, r3)
     d = r4
-    r5 = load_global CPyStatic_unicode_1 :: static  ('one')
+    r5 = 'one'
     r6 = PyObject_DelItem(d, r5)
     r7 = r6 >= 0 :: signed
     return 1
@@ -861,18 +861,18 @@ def delDictMultiple():
     r13 :: int32
     r14 :: bit
 L0:
-    r0 = load_global CPyStatic_unicode_1 :: static  ('one')
-    r1 = load_global CPyStatic_unicode_2 :: static  ('two')
-    r2 = load_global CPyStatic_unicode_3 :: static  ('three')
-    r3 = load_global CPyStatic_unicode_4 :: static  ('four')
+    r0 = 'one'
+    r1 = 'two'
+    r2 = 'three'
+    r3 = 'four'
     r4 = box(short_int, 2)
     r5 = box(short_int, 4)
     r6 = box(short_int, 6)
     r7 = box(short_int, 8)
     r8 = CPyDict_Build(4, r0, r4, r1, r5, r2, r6, r3, r7)
     d = r8
-    r9 = load_global CPyStatic_unicode_1 :: static  ('one')
-    r10 = load_global CPyStatic_unicode_4 :: static  ('four')
+    r9 = 'one'
+    r10 = 'four'
     r11 = PyObject_DelItem(d, r9)
     r12 = r11 >= 0 :: signed
     r13 = PyObject_DelItem(d, r10)
@@ -907,7 +907,7 @@ def delAttribute():
 L0:
     r0 = Dummy(2, 4)
     dummy = r0
-    r1 = load_global CPyStatic_unicode_3 :: static  ('x')
+    r1 = 'x'
     r2 = PyObject_DelAttr(dummy, r1)
     r3 = r2 >= 0 :: signed
     return 1
@@ -922,10 +922,10 @@ def delAttributeMultiple():
 L0:
     r0 = Dummy(2, 4)
     dummy = r0
-    r1 = load_global CPyStatic_unicode_3 :: static  ('x')
+    r1 = 'x'
     r2 = PyObject_DelAttr(dummy, r1)
     r3 = r2 >= 0 :: signed
-    r4 = load_global CPyStatic_unicode_4 :: static  ('y')
+    r4 = 'y'
     r5 = PyObject_DelAttr(dummy, r4)
     r6 = r5 >= 0 :: signed
     return 1

--- a/mypyc/test-data/irbuild-try.test
+++ b/mypyc/test-data/irbuild-try.test
@@ -18,15 +18,15 @@ def g():
 L0:
 L1:
     r0 = builtins :: module
-    r1 = load_global CPyStatic_unicode_1 :: static  ('object')
+    r1 = 'object'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = PyObject_CallFunctionObjArgs(r2, 0)
     goto L5
 L2: (handler for L1)
     r4 = CPy_CatchError()
-    r5 = load_global CPyStatic_unicode_2 :: static  ('weeee')
+    r5 = 'weeee'
     r6 = builtins :: module
-    r7 = load_global CPyStatic_unicode_3 :: static  ('print')
+    r7 = 'print'
     r8 = CPyObject_GetAttr(r6, r7)
     r9 = PyObject_CallFunctionObjArgs(r8, r5, 0)
 L3:
@@ -66,20 +66,20 @@ L1:
     if b goto L2 else goto L3 :: bool
 L2:
     r0 = builtins :: module
-    r1 = load_global CPyStatic_unicode_1 :: static  ('object')
+    r1 = 'object'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = PyObject_CallFunctionObjArgs(r2, 0)
     goto L4
 L3:
-    r4 = load_global CPyStatic_unicode_2 :: static  ('hi')
+    r4 = 'hi'
     r5 = PyObject_Str(r4)
 L4:
     goto L8
 L5: (handler for L1, L2, L3, L4)
     r6 = CPy_CatchError()
-    r7 = load_global CPyStatic_unicode_3 :: static  ('weeee')
+    r7 = 'weeee'
     r8 = builtins :: module
-    r9 = load_global CPyStatic_unicode_4 :: static  ('print')
+    r9 = 'print'
     r10 = CPyObject_GetAttr(r8, r9)
     r11 = PyObject_CallFunctionObjArgs(r10, r7, 0)
 L6:
@@ -129,30 +129,30 @@ def g():
     r27 :: bit
 L0:
 L1:
-    r0 = load_global CPyStatic_unicode_1 :: static  ('a')
+    r0 = 'a'
     r1 = builtins :: module
-    r2 = load_global CPyStatic_unicode_2 :: static  ('print')
+    r2 = 'print'
     r3 = CPyObject_GetAttr(r1, r2)
     r4 = PyObject_CallFunctionObjArgs(r3, r0, 0)
 L2:
     r5 = builtins :: module
-    r6 = load_global CPyStatic_unicode_3 :: static  ('object')
+    r6 = 'object'
     r7 = CPyObject_GetAttr(r5, r6)
     r8 = PyObject_CallFunctionObjArgs(r7, 0)
     goto L8
 L3: (handler for L2)
     r9 = CPy_CatchError()
     r10 = builtins :: module
-    r11 = load_global CPyStatic_unicode_4 :: static  ('AttributeError')
+    r11 = 'AttributeError'
     r12 = CPyObject_GetAttr(r10, r11)
     r13 = CPy_ExceptionMatches(r12)
     if r13 goto L4 else goto L5 :: bool
 L4:
     r14 = CPy_GetExcValue()
     e = r14
-    r15 = load_global CPyStatic_unicode_5 :: static  ('b')
+    r15 = 'b'
     r16 = builtins :: module
-    r17 = load_global CPyStatic_unicode_2 :: static  ('print')
+    r17 = 'print'
     r18 = CPyObject_GetAttr(r16, r17)
     r19 = PyObject_CallFunctionObjArgs(r18, r15, e, 0)
     goto L6
@@ -170,9 +170,9 @@ L8:
     goto L12
 L9: (handler for L1, L6, L7, L8)
     r21 = CPy_CatchError()
-    r22 = load_global CPyStatic_unicode_6 :: static  ('weeee')
+    r22 = 'weeee'
     r23 = builtins :: module
-    r24 = load_global CPyStatic_unicode_2 :: static  ('print')
+    r24 = 'print'
     r25 = CPyObject_GetAttr(r23, r24)
     r26 = PyObject_CallFunctionObjArgs(r25, r22, 0)
 L10:
@@ -218,27 +218,27 @@ L1:
 L2: (handler for L1)
     r0 = CPy_CatchError()
     r1 = builtins :: module
-    r2 = load_global CPyStatic_unicode_1 :: static  ('KeyError')
+    r2 = 'KeyError'
     r3 = CPyObject_GetAttr(r1, r2)
     r4 = CPy_ExceptionMatches(r3)
     if r4 goto L3 else goto L4 :: bool
 L3:
-    r5 = load_global CPyStatic_unicode_2 :: static  ('weeee')
+    r5 = 'weeee'
     r6 = builtins :: module
-    r7 = load_global CPyStatic_unicode_3 :: static  ('print')
+    r7 = 'print'
     r8 = CPyObject_GetAttr(r6, r7)
     r9 = PyObject_CallFunctionObjArgs(r8, r5, 0)
     goto L7
 L4:
     r10 = builtins :: module
-    r11 = load_global CPyStatic_unicode_4 :: static  ('IndexError')
+    r11 = 'IndexError'
     r12 = CPyObject_GetAttr(r10, r11)
     r13 = CPy_ExceptionMatches(r12)
     if r13 goto L5 else goto L6 :: bool
 L5:
-    r14 = load_global CPyStatic_unicode_5 :: static  ('yo')
+    r14 = 'yo'
     r15 = builtins :: module
-    r16 = load_global CPyStatic_unicode_3 :: static  ('print')
+    r16 = 'print'
     r17 = CPyObject_GetAttr(r15, r16)
     r18 = PyObject_CallFunctionObjArgs(r17, r14, 0)
     goto L7
@@ -279,9 +279,9 @@ L0:
 L1:
     if b goto L2 else goto L3 :: bool
 L2:
-    r0 = load_global CPyStatic_unicode_1 :: static  ('hi')
+    r0 = 'hi'
     r1 = builtins :: module
-    r2 = load_global CPyStatic_unicode_2 :: static  ('Exception')
+    r2 = 'Exception'
     r3 = CPyObject_GetAttr(r1, r2)
     r4 = PyObject_CallFunctionObjArgs(r3, r0, 0)
     CPy_Raise(r4)
@@ -296,9 +296,9 @@ L6: (handler for L1, L2, L3)
     r7 = CPy_CatchError()
     r6 = r7
 L7:
-    r8 = load_global CPyStatic_unicode_3 :: static  ('finally')
+    r8 = 'finally'
     r9 = builtins :: module
-    r10 = load_global CPyStatic_unicode_4 :: static  ('print')
+    r10 = 'print'
     r11 = CPyObject_GetAttr(r9, r10)
     r12 = PyObject_CallFunctionObjArgs(r11, r8, 0)
     if is_error(r6) goto L9 else goto L8
@@ -347,18 +347,18 @@ def foo(x):
 L0:
     r0 = PyObject_CallFunctionObjArgs(x, 0)
     r1 = PyObject_Type(r0)
-    r2 = load_global CPyStatic_unicode_3 :: static  ('__exit__')
+    r2 = '__exit__'
     r3 = CPyObject_GetAttr(r1, r2)
-    r4 = load_global CPyStatic_unicode_4 :: static  ('__enter__')
+    r4 = '__enter__'
     r5 = CPyObject_GetAttr(r1, r4)
     r6 = PyObject_CallFunctionObjArgs(r5, r0, 0)
     r7 = 1
 L1:
 L2:
     y = r6
-    r8 = load_global CPyStatic_unicode_5 :: static  ('hello')
+    r8 = 'hello'
     r9 = builtins :: module
-    r10 = load_global CPyStatic_unicode_6 :: static  ('print')
+    r10 = 'print'
     r11 = CPyObject_GetAttr(r9, r10)
     r12 = PyObject_CallFunctionObjArgs(r11, r8, 0)
     goto L8
@@ -415,3 +415,4 @@ L19:
     unreachable
 L20:
     return 1
+

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -661,7 +661,7 @@ def f() -> str:
 def f():
     r0 :: str
 L0:
-    r0 = load_global CPyStatic_unicode_1 :: static  ('some string')
+    r0 = 'some string'
     inc_ref r0
     return r0
 
@@ -680,7 +680,7 @@ def g(x):
     r6 :: int
 L0:
     r0 = load_address PyLong_Type
-    r1 = load_global CPyStatic_unicode_1 :: static  ('base')
+    r1 = 'base'
     r2 = PyTuple_Pack(1, x)
     r3 = box(short_int, 4)
     r4 = CPyDict_Build(1, r1, r3)

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -1024,6 +1024,7 @@ def test_str() -> None:
     assert 'foo bar' == eval("'foo bar'")
     assert 'foo\u1245\0bar' == eval("'foo' + chr(0x1245) + chr(0) + 'bar'")
     assert 'foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345' == eval("'foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345'")
+    assert 'Zoobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar123' == eval("'Zoobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar123'")
 
 def test_bytes() -> None:
     assert b'' == eval("b''")

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -1014,3 +1014,42 @@ from native import foo
 
 assert foo(None) == None
 assert foo([1, 2, 3]) == ((1, 2, 3), [1, 2, 3])
+
+[case testAllLiterals]
+# Test having all sorts of literals in a single file
+
+def test_str() -> None:
+    assert '' == eval("''")
+    assert len('foo bar' + str()) == 7
+    assert 'foo bar' == eval("'foo bar'")
+    assert 'foo\u1245\0bar' == eval("'foo' + chr(0x1245) + chr(0) + 'bar'")
+    assert 'foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345' == eval("'foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345'")
+
+def test_bytes() -> None:
+    assert b'' == eval("b''")
+    assert b'foo bar' == eval("b'foo bar'")
+    assert b'\xafde' == eval(r"b'\xafde'")
+    assert b'foo\xde\0bar' == eval("b'foo' + bytes([0xde, 0]) + b'bar'")
+    assert b'foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345' == eval("b'foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345foobar12345'")
+
+def test_int() -> None:
+    assert 2875872359823758923758923759 == eval('2875872359823758923758923759')
+    assert -552875872359823758923758923759 == eval('-552875872359823758923758923759')
+
+def test_float() -> None:
+    assert 1.5 == eval('1.5')
+    assert -3.75 == eval('-3.75')
+    assert 2.5e10 == eval('2.5e10')
+    assert 2.5e50 == eval('2.5e50')
+    assert 2.5e1000 == eval('2.5e1000')
+    assert -2.5e1000 == eval('-2.5e1000')
+
+def test_complex() -> None:
+    assert 1.5j == eval('1.5j')
+    assert 1.5j + 2.5 == eval('2.5 + 1.5j')
+    assert -3.75j == eval('-3.75j')
+    assert 2.5e10j == eval('2.5e10j')
+    assert 2.5e50j == eval('2.5e50j')
+    assert 2.5e1000j == eval('2.5e1000j')
+    assert 2.5e1000j + 3.5e2000 == eval('3.5e2000 + 2.5e1000j')
+    assert -2.5e1000j == eval('-2.5e1000j')

--- a/mypyc/test-data/run-primitives.test
+++ b/mypyc/test-data/run-primitives.test
@@ -241,7 +241,7 @@ def to_int(x: float) -> int:
     return int(x)
 
 def get_complex() -> complex:
-    return 5.0j + 3.0
+    return 5.2j + 3.5 + 1j
 
 [file driver.py]
 from native import assign_and_return_float_sum, from_int, to_int, get_complex
@@ -253,7 +253,7 @@ assert sum == 50.0
 assert str(from_int(10)) == '10.0'
 assert str(to_int(3.14)) == '3'
 assert str(to_int(3)) == '3'
-assert get_complex() == 3+5j
+assert get_complex() == 3.5 + 6.2j
 
 [case testBytes]
 def f(x: bytes) -> bytes:

--- a/mypyc/test/test_literals.py
+++ b/mypyc/test/test_literals.py
@@ -1,0 +1,14 @@
+"""Test code geneneration for literals."""
+
+import unittest
+
+from mypyc.codegen.literals import format_str_literal
+
+
+class TestLiterals(unittest.TestCase):
+    def test_format_str_literal(self) -> None:
+        assert format_str_literal('') == b'\x00'
+        assert format_str_literal('xyz') == b'\x03xyz'
+        assert format_str_literal('x' * 127) == b'\x7f' + b'x' * 127
+        assert format_str_literal('x' * 128) == b'\x80\x01' + b'x' * 128
+        assert format_str_literal('x' * 131) == b'\x83\x01' + b'x' * 131

--- a/mypyc/test/test_literals.py
+++ b/mypyc/test/test_literals.py
@@ -10,5 +10,5 @@ class TestLiterals(unittest.TestCase):
         assert format_str_literal('') == b'\x00'
         assert format_str_literal('xyz') == b'\x03xyz'
         assert format_str_literal('x' * 127) == b'\x7f' + b'x' * 127
-        assert format_str_literal('x' * 128) == b'\x80\x01' + b'x' * 128
-        assert format_str_literal('x' * 131) == b'\x83\x01' + b'x' * 131
+        assert format_str_literal('x' * 128) == b'\x81\x00' + b'x' * 128
+        assert format_str_literal('x' * 131) == b'\x81\x03' + b'x' * 131


### PR DESCRIPTION
Redesign the implementation of constant `PyObject *` values, such as string and integer 
literals.

There are several related changes:
* Add `LoadLiteral` op for loading literal values instead of using `LoadStatic`.
* No longer store all literals in a table while we construct IR to make it easier to remove
  literals no longer needed after optimizations in the future.
* Simplify the pretty-printed IR for loading literals.
* Rename the helpers used to construct literal references (e.g. `load_static_unicode` -> 
  `load_str`).
* Collect all used literals values after we have final IR.
* Store literal value initialization information in C arrays instead of generating code for 
  each value.
* Store constructed literal objects in a single `CPyStatics` array.

The goal is to speed up compiles (slightly) and to make it easy to support tuple literals
and efficient table-driven import statements. Both of these can use the `CPyStatics` array.

Closes mypyc/mypyc#794. Closes mypyc/mypyc#797.