### PR TITLE
Fix #7445 Use double quotes in error messages

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -747,7 +747,7 @@ class MessageBuilder:
         self.fail("Unpacking a string is disallowed", context)
 
     def type_not_iterable(self, type: Type, context: Context) -> None:
-        self.fail('\'{}\' object is not iterable'.format(type), context)
+        self.fail('\"{}\" object is not iterable'.format(type), context)
 
     def incompatible_operator_assignment(self, op: str,
                                          context: Context) -> None:
@@ -881,7 +881,7 @@ class MessageBuilder:
                   code=codes.STRING_FORMATTING)
 
     def unsupported_placeholder(self, placeholder: str, context: Context) -> None:
-        self.fail('Unsupported format character \'%s\'' % placeholder, context,
+        self.fail('Unsupported format character \"{}\"'.format(placeholder), context,
                   code=codes.STRING_FORMATTING)
 
     def string_interpolation_with_star_and_key(self, context: Context) -> None:
@@ -894,7 +894,7 @@ class MessageBuilder:
                   context, code=codes.STRING_FORMATTING)
 
     def key_not_in_mapping(self, key: str, context: Context) -> None:
-        self.fail('Key \'%s\' not found in mapping' % key, context,
+        self.fail('Key \"{}\" not found in mapping'.format(key), context,
                   code=codes.STRING_FORMATTING)
 
     def string_interpolation_mixing_key_and_non_keys(self, context: Context) -> None:
@@ -1058,7 +1058,7 @@ class MessageBuilder:
         self.fail('Invalid signature "{}" for "{}"'.format(func_type, method_name), context)
 
     def reveal_type(self, typ: Type, context: Context) -> None:
-        self.note('Revealed type is \'{}\''.format(typ), context)
+        self.note('Revealed type is \"{}\"'.format(typ), context)
 
     def reveal_locals(self, type_map: Dict[str, Optional[Type]], context: Context) -> None:
         # To ensure that the output is predictable on Python < 3.6,
@@ -1157,7 +1157,7 @@ class MessageBuilder:
             item_name: str,
             context: Context) -> None:
         if typ.is_anonymous():
-            self.fail('\'{}\' is not a valid TypedDict key; expected one of {}'.format(
+            self.fail('\"{}\" is not a valid TypedDict key; expected one of {}'.format(
                 item_name, format_item_name_list(typ.items.keys())), context)
         else:
             self.fail("TypedDict {} has no key '{}'".format(format_type(typ), item_name), context)

--- a/test-data/unit/check-annotated.test
+++ b/test-data/unit/check-annotated.test
@@ -1,57 +1,57 @@
 [case testAnnotated0]
 from typing_extensions import Annotated
 x: Annotated[int, ...]
-reveal_type(x)  # N: Revealed type is 'builtins.int'
+reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotated1]
 from typing import Union
 from typing_extensions import Annotated
 x: Annotated[Union[int, str], ...]
-reveal_type(x)  # N: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotated2]
 from typing_extensions import Annotated
 x: Annotated[int, THESE, ARE, IGNORED, FOR, NOW]
-reveal_type(x)  # N: Revealed type is 'builtins.int'
+reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotated3]
 from typing_extensions import Annotated
 x: Annotated[int, -+~12.3, "som"[e], more(anno+a+ions, that=[are]), (b"ignored",), 4, N.O.W, ...]
-reveal_type(x)  # N: Revealed type is 'builtins.int'
+reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedBadType]
 from typing_extensions import Annotated
-x: Annotated[XXX, ...]  # E: Name 'XXX' is not defined
-reveal_type(x)  # N: Revealed type is 'Any'
+x: Annotated[XXX, ...]  # E: Name "XXX" is not defined
+reveal_type(x)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedBadNoArgs]
 from typing_extensions import Annotated
 x: Annotated  # E: Annotated[...] must have exactly one type argument and at least one annotation
-reveal_type(x)  # N: Revealed type is 'Any'
+reveal_type(x)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedBadOneArg]
 from typing_extensions import Annotated
 x: Annotated[int]  # E: Annotated[...] must have exactly one type argument and at least one annotation
-reveal_type(x)  # N: Revealed type is 'Any'
+reveal_type(x)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedNested0]
 from typing_extensions import Annotated
 x: Annotated[Annotated[int, ...], ...]
-reveal_type(x)  # N: Revealed type is 'builtins.int'
+reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedNested1]
 from typing import Union
 from typing_extensions import Annotated
 x: Annotated[Annotated[Union[int, str], ...], ...]
-reveal_type(x)  # N: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedNestedBadType]

--- a/test-data/unit/check-annotated.test
+++ b/test-data/unit/check-annotated.test
@@ -56,30 +56,30 @@ reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testAnnotatedNestedBadType]
 from typing_extensions import Annotated
-x: Annotated[Annotated[XXX, ...], ...]  # E: Name 'XXX' is not defined
-reveal_type(x)  # N: Revealed type is 'Any'
+x: Annotated[Annotated[XXX, ...], ...]  # E: Name "XXX" is not defined
+reveal_type(x)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedNestedBadNoArgs]
 from typing_extensions import Annotated
 x: Annotated[Annotated, ...]  # E: Annotated[...] must have exactly one type argument and at least one annotation
-reveal_type(x)  # N: Revealed type is 'Any'
+reveal_type(x)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedNestedBadOneArg]
 from typing_extensions import Annotated
 x: Annotated[Annotated[int], ...]  # E: Annotated[...] must have exactly one type argument and at least one annotation
-reveal_type(x)  # N: Revealed type is 'Any'
+reveal_type(x)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedNoImport]
-x: Annotated[int, ...]  # E: Name 'Annotated' is not defined
-reveal_type(x)  # N: Revealed type is 'Any'
+x: Annotated[int, ...]  # E: Name "Annotated" is not defined
+reveal_type(x)  # N: Revealed type is "Any"
 
 [case testAnnotatedDifferentName]
 from typing_extensions import Annotated as An
 x: An[int, ...]
-reveal_type(x)  # N: Revealed type is 'builtins.int'
+reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedAliasSimple]
@@ -87,7 +87,7 @@ from typing import Tuple
 from typing_extensions import Annotated
 Alias = Annotated[Tuple[int, ...], ...]
 x: Alias
-reveal_type(x)  # N: Revealed type is 'builtins.tuple[builtins.int]'
+reveal_type(x)  # N: Revealed type is "builtins.tuple[builtins.int]"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedAliasTypeVar]
@@ -96,7 +96,7 @@ from typing_extensions import Annotated
 T = TypeVar('T')
 Alias = Annotated[T, ...]
 x: Alias[int]
-reveal_type(x)  # N: Revealed type is 'builtins.int'
+reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedAliasGenericTuple]
@@ -105,7 +105,7 @@ from typing_extensions import Annotated
 T = TypeVar('T')
 Alias = Annotated[Tuple[T, T], ...]
 x: Alias[int]
-reveal_type(x)  # N: Revealed type is 'Tuple[builtins.int, builtins.int]'
+reveal_type(x)  # N: Revealed type is "Tuple[builtins.int, builtins.int]"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedAliasGenericUnion]
@@ -114,7 +114,7 @@ from typing_extensions import Annotated
 T = TypeVar('T')
 Alias = Annotated[Union[T, str], ...]
 x: Alias[int]
-reveal_type(x)  # N: Revealed type is 'Union[builtins.int, builtins.str]'
+reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedSecondParamNonType]
@@ -124,5 +124,5 @@ class Meta:
     ...
 
 x = Annotated[int, Meta()]
-reveal_type(x)  # N: Revealed type is 'def () -> builtins.int'
+reveal_type(x)  # N: Revealed type is "def () -> builtins.int"
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
### Description

Fixes #7445 
Replaces all the instances where single quotes are used in messages with double quotes around the ```mpypy/messages.py```

## Test Plan
Only some minor changes in one file, have not done tests, pytest seems to freeze when running  ```pytest -q mypy```(not a hardware constraint I can assure), would be helpful if anybody could help me with this
