### PR TITLE
Expand user home directory for cache_dir

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -854,6 +854,7 @@ def process_options(args: List[str],
     environ_cache_dir = os.getenv('MYPY_CACHE_DIR', '')
     if environ_cache_dir.strip():
         options.cache_dir = environ_cache_dir
+    options.cache_dir = os.path.expanduser(options.cache_dir)
 
     # Parse command line for real, using a split namespace.
     special_opts = argparse.Namespace()


### PR DESCRIPTION
### Description

Currently cache_dir does not expand user home directory, which results
in counter-intuitive behavior when setting for instance

```MYPY_CACHE_DIR='~/.cache/mypy/'```

In this case a folder named `~` is created in the cwd where mypy is
launched.

This commit modifies the behavior and expands the ~ into the user home
directory.

## Test Plan

Tested by setting `MYPY_CACHE_DIR=~/.cache/mypy` and checked that the folder is picked correctly.
