### PR TITLE
Fix runtests.py failing if path to python executable contains a space

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -55,7 +55,7 @@ MYPYC_OPT_IN = [MYPYC_RUN, MYPYC_RUN_MULTI]
 # time to run.
 cmds = {
     # Self type check
-    'self': python_name + ' -m mypy --config-file mypy_self_check.ini -p mypy',
+    'self': '"' + python_name + '" -m mypy --config-file mypy_self_check.ini -p mypy',
     # Lint
     'lint': 'flake8 -j0',
     # Fast test cases only (this is the bulk of the test suite)


### PR DESCRIPTION
### Description

This fixes runtests.py failing if the path to the python executable contains a space.
@PrasanthChettri on gitter mentioned getting the error message `'C:\Program' is not recognized as an internal or external command, operable program or batch file.` on windows.

This commit wraps the interpreter path in quotes to prevent the shell from splitting it.

I think this is the best solution for this at the moment. It would also be possible to replace all spaces with escaped spaces (also simple) or change runtests.py from using `os.system` to using `subprocess` (more complicated, but would prevent all shell escaping problems by not using a shell at all)


## Test Plan

I haven't got a response from @PrasanthChettri on whether this fix is working for him yet, but from my own tests in a windows VM it should work.

I also tested that the script still works on linux.