### PR TITLE
Clarify callback protocol example

### DIFF
--- a/docs/source/protocols.rst
+++ b/docs/source/protocols.rst
@@ -490,6 +490,7 @@ a double underscore prefix is used. For example:
 
    copy_a: Callable[[T], T]
    copy_b: Copy
+   copy_c: Callable[[T], T]
 
    copy_a = copy_b  # OK
-   copy_b = copy_a  # Also OK
+   copy_b = copy_c  # OK, but would fail without the double underscore prefix


### PR DESCRIPTION
### Description

xref https://stackoverflow.com/q/66068202/4451315

The current example, when run without the double underscore prefix, doesn't error. I found this a bit confusing, and wasn't sure what the example was meant to teach me.
I'd like to think that the proposed change clarifies it.

Like this, remove the double underscore prefix gives:
```console
$ mypy t.py 
t.py:14: error: Incompatible types in assignment (expression has type "Callable[[T], T]", variable has type "Copy")
t.py:14: note: "Copy.__call__" has type "Callable[[Arg(T, 'origin')], T]"
Found 1 error in 1 file (checked 1 source file)
```

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

None (just simple doc change)
