### PR TITLE
Add separate requirements file for mypy self-compile

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,0 +1,4 @@
+-r mypy-requirements.txt
+types-typed-ast>=1.4.0,<1.5.0
+types-toml>=0.0
+types-enum34>=0.0; python_version == '3.5'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 -r mypy-requirements.txt
+-r build-requirements.txt
 attrs>=18.0
 flake8>=3.8.1
 flake8-bugbear; python_version >= '3.5'
@@ -15,6 +16,3 @@ py>=1.5.2
 virtualenv<20
 setuptools!=50
 importlib-metadata==0.20
-types-typed-ast>=1.4.0,<1.5.0
-types-toml>=0.0
-types-enum34>=0.0; python_version == '3.5'


### PR DESCRIPTION
Self-compilation needs some stub packages. I'm adding them to a separate
since they are not needed for running mypy, and since we may want to
be able to build mypy without installing all test dependencies, some of which
are quite heavy.