### PR TITLE
Generic protocol documentation fix

### DIFF
--- a/docs/source/protocols.rst
+++ b/docs/source/protocols.rst
@@ -485,7 +485,7 @@ a double underscore prefix is used. For example:
 
    T = TypeVar('T')
 
-   class Copy(Protocol):
+   class Copy(Protocol[T]):
        def __call__(self, __origin: T) -> T: ...
 
    copy_a: Callable[[T], T]


### PR DESCRIPTION
The protocol itself must be generic, otherwise type checking will fail.

Here is a small snippet to test the definition from the documentation:

```python
def f(g: Copy):
    g("")

def copy(_origin: str):
    pass

f(copy)
```