### PR TITLE
use sys.executable instead of `python3` for --install-types

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1082,7 +1082,7 @@ def install_types(cache_dir: str,
     if after_run:
         print()
     print('Installing missing stub packages:')
-    cmd = ['python3', '-m', 'pip', 'install'] + packages
+    cmd = [sys.executable, '-m', 'pip', 'install'] + packages
     print(formatter.style(' '.join(cmd), 'none', bold=True))
     print()
     x = input('Install? [yN] ')


### PR DESCRIPTION
### Description

This (for example) fixes the option on windows where `python3.exe` is either not a thing or it is a stub that opens the windows store

(Explain how this PR changes mypy.)

## Test Plan

run mypy with `--install-types` on windows
