### PR TITLE
[mypyc] declare `Py_ssize_t i` outside of loop initialization

### DIFF
--- a/mypyc/lib-rt/getargsfast.c
+++ b/mypyc/lib-rt/getargsfast.c
@@ -96,7 +96,8 @@ CPyArg_ParseStackAndKeywordsSimple(PyObject *const *args, Py_ssize_t nargs, PyOb
     if (kwnames == NULL && nargs >= parser->min && nargs <= parser->max) {
         // Fast path: correct number of positional arguments only
         PyObject **p;
-        for (Py_ssize_t i = 0; i < nargs; i++) {
+        Py_ssize_t i;
+        for (i = 0; i < nargs; i++) {
             p = va_arg(va, PyObject **);
             *p = args[i];
         }


### PR DESCRIPTION
### Description

Fixes https://github.com/mypyc/mypyc/issues/800

I believe this is the only instance of a variable declaration inside a for-loop initialization. Removing this may help with consistent compilation across different C compiler configurations. See linked issue for more details.