### PR TITLE
Fix following stub imports in daemon when using --follow-imports=skip

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -275,6 +275,10 @@ section of the command line docs.
     Used in conjunction with :confval:`follow_imports=error <follow_imports>`, this can be used
     to make any use of a particular ``typeshed`` module an error.
 
+    .. note::
+
+         This is not supported by the mypy daemon.
+
 .. confval:: python_executable
 
     :type: string

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -943,6 +943,7 @@ def filter_out_missing_top_level_packages(packages: Set[str],
             elif entry.endswith('.pyi'):
                 entry = entry[:-4]
             elif entry.endswith('-stubs'):
+                # Possible PEP 561 stub package
                 entry = entry[:-6]
                 if entry.endswith('-python2'):
                     entry = entry[:-8]

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -503,12 +503,12 @@ class Server:
             # (updated or added) or removed.
             self.update_sources(sources)
             changed, removed = self.find_changed(sources)
-            changed += self.find_added_suppressed(self.fine_grained_manager.graph, set(),
-                                                  manager.search_paths)
         else:
             # Use the remove/update lists to update fswatcher.
             # This avoids calling stat() for unchanged files.
             changed, removed = self.update_changed(sources, remove or [], update or [])
+        changed += self.find_added_suppressed(self.fine_grained_manager.graph, set(),
+                                              manager.search_paths)
         manager.search_paths = compute_search_paths(sources, manager.options, manager.data_dir)
         t1 = time.time()
         manager.log("fine-grained increment: find_changed: {:.3f}s".format(t1 - t0))

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -2156,7 +2156,7 @@ main.py:2: error: Incompatible types in assignment (expression has type "int", v
 ==
 
 [case testMissingStubAdded2]
-# flags: --follow-imports=skip
+# flags: --follow-imports=skip --py2
 # cmd: mypy main.py
 
 [file main.py]

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -2105,21 +2105,6 @@ x = 1
 ==
 main:2: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
-[case testFineFollowImportSkipNotInvalidatedOnAddedStubOnFollowForStubs]
-# flags: --follow-imports=skip --ignore-missing-imports --config-file=tmp/mypy.ini
-# cmd: mypy main.py
-[file main.py]
-import other
-[file other.pyi.2]
-x = 1
-[file mypy.ini]
-\[mypy]
-follow_imports_for_stubs = True
-[stale]
-[rechecked]
-[out]
-==
-
 [case testFineAddedSkippedStubsPackageFrom]
 # flags: --follow-imports=skip --ignore-missing-imports
 # cmd: mypy main.py
@@ -2150,3 +2135,53 @@ x: str
 [out]
 ==
 a.py:3: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testMissingStubAdded1]
+# flags: --follow-imports=skip
+# cmd: mypy main.py
+
+[file main.py]
+import foo
+foo.x = 1
+[file foo.pyi.2]
+x = 'x'
+[file main.py.3]
+import foo
+foo.x = 'y'
+[out]
+main.py:1: error: Cannot find implementation or library stub for module named "foo"
+main.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
+==
+main.py:2: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+==
+
+[case testMissingStubAdded2]
+# flags: --follow-imports=skip
+# cmd: mypy main.py
+
+[file main.py]
+import foo  # type: ignore
+foo.x = 1
+[file foo.pyi.2]
+x = 'x'
+[file main.py.3]
+import foo
+foo.x = 'y'
+[out]
+==
+main.py:2: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+==
+
+[case testDoNotFollowImportToNonStubFile]
+# flags: --follow-imports=skip
+# cmd: mypy main.py
+
+[file main.py]
+import foo  # type: ignore
+foo.x = 1
+[file foo.py.2]
+x = 'x'
+1 + 'x'
+
+[out]
+==


### PR DESCRIPTION
Find added stubs in daemon when using `--follow-imports=skip`. Previously
it was often necessary to restart the daemon to find new stubs. This was 
inconsistent, as the initial build did follow imports to stubs but incremental
runs didn't (at least reliably).

Add an optimization that avoids checking modules within top-level packages
that clearly don't exist.

This still can regress performance in large codebases somewhat significantly.
I'll create follow-up PRs that make the regression less bad.

Also mark `follow_imports_for_stubs` as unsupported in the daemon. I don't 
think that it worked reliably before, and now it works even less well.