### PR TITLE
Use fast path for finding modules in mypy daemon

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -728,7 +728,7 @@ class Server:
             if top_level_pkg not in packages:
                 # Fast path: non-existent top-level package
                 continue
-            result = finder.find_module(module)
+            result = finder.find_module(module, fast_path=True)
             if isinstance(result, str) and module not in seen:
                 # When not following imports, we only follow imports to .pyi files.
                 if not self.following_imports() and not result.endswith('.pyi'):

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -188,8 +188,12 @@ class FindModuleCache:
         self.initial_components[lib_path] = components
         return components.get(id, [])
 
-    def find_module(self, id: str) -> ModuleSearchResult:
-        """Return the path of the module source file or why it wasn't found."""
+    def find_module(self, id: str, *, fast_path: bool = False) -> ModuleSearchResult:
+        """Return the path of the module source file or why it wasn't found.
+
+        If fast_path is True, prioritize performance over generating detailed
+        error descriptions.
+        """
         if id not in self.results:
             top_level = id.partition('.')[0]
             use_typeshed = True
@@ -198,7 +202,8 @@ class FindModuleCache:
                 use_typeshed = (self.options is None
                                 or typeshed_py_version(self.options) >= min_version)
             self.results[id] = self._find_module(id, use_typeshed)
-            if (self.results[id] is ModuleNotFoundReason.NOT_FOUND
+            if (not fast_path
+                    and self.results[id] is ModuleNotFoundReason.NOT_FOUND
                     and self._can_find_module_in_parent_dir(id)):
                 self.results[id] = ModuleNotFoundReason.WRONG_WORKING_DIRECTORY
         return self.results[id]


### PR DESCRIPTION
The skipped check is pretty slow, and it's not useful when following
imports to suppressed modules.