### PR TITLE
Reduce the size of the build by not compiling stubgen

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -192,7 +192,7 @@ class Options:
         self.export_less = export_less
 
 
-class StubSource(BuildSource):
+class StubSource:
     """A single source for stub: can be a Python or C module.
 
     A simple extension of BuildSource that also carries the AST and
@@ -200,9 +200,17 @@ class StubSource(BuildSource):
     """
     def __init__(self, module: str, path: Optional[str] = None,
                  runtime_all: Optional[List[str]] = None) -> None:
-        super().__init__(path, module, None)
+        self.source = BuildSource(path, module, None)
         self.runtime_all = runtime_all
         self.ast = None  # type: Optional[MypyFile]
+
+    @property
+    def module(self) -> str:
+        return self.source.module
+
+    @property
+    def path(self) -> Optional[str]:
+        return self.source.path
 
 
 # What was generated previously in the stub file. We keep track of these to generate
@@ -1435,7 +1443,7 @@ def generate_asts_for_modules(py_modules: List[StubSource],
         return
     # Perform full semantic analysis of the source set.
     try:
-        res = build(list(py_modules), mypy_options)
+        res = build([module.source for module in py_modules], mypy_options)
     except CompileError as e:
         raise SystemExit("Critical error during semantic analysis: {}".format(e)) from e
 

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,6 @@ if USE_MYPYC:
 
         # Skip these to reduce the size of the build
         'stubtest.py',
-        'stubgen.py',
         'stubgenc.py',
         'stubdoc.py',
         'stubutil.py',

--- a/setup.py
+++ b/setup.py
@@ -99,8 +99,12 @@ if USE_MYPYC:
         # Also I think there would be problems with how we generate version.py.
         'version.py',
 
-        # Can be removed once we drop support for Python 3.5.2 and lower.
+        # Skip these to reduce the size of the build
         'stubtest.py',
+        'stubgen.py',
+        'stubgenc.py',
+        'stubdoc.py',
+        'stubutil.py',
     )) + (
         # Don't want to grab this accidentally
         os.path.join('mypyc', 'lib-rt', 'setup.py'),


### PR DESCRIPTION
This might fix the out-of-memory errors we are getting when
building Windows wheels. In any case these will speed up
builds slightly.