### PR TITLE
Fixed Auto Discovery of .test files Fixes #8650

### DIFF
--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -24,87 +24,28 @@ from mypy.semanal_main import core_modules
 
 
 # List of files that contain test case descriptions.
-typecheck_files = [
-    'check-basic.test',
-    'check-union-or-syntax.test',
-    'check-callable.test',
-    'check-classes.test',
-    'check-statements.test',
-    'check-generics.test',
-    'check-dynamic-typing.test',
-    'check-inference.test',
-    'check-inference-context.test',
-    'check-kwargs.test',
-    'check-overloading.test',
-    'check-type-checks.test',
-    'check-abstract.test',
-    'check-multiple-inheritance.test',
-    'check-super.test',
-    'check-modules.test',
-    'check-typevar-values.test',
-    'check-unsupported.test',
-    'check-unreachable-code.test',
-    'check-unions.test',
-    'check-isinstance.test',
-    'check-lists.test',
-    'check-namedtuple.test',
-    'check-narrowing.test',
-    'check-typeddict.test',
-    'check-type-aliases.test',
-    'check-ignore.test',
-    'check-type-promotion.test',
-    'check-semanal-error.test',
-    'check-flags.test',
-    'check-incremental.test',
-    'check-serialize.test',
-    'check-bound.test',
-    'check-optional.test',
-    'check-fastparse.test',
-    'check-warnings.test',
-    'check-async-await.test',
-    'check-newtype.test',
-    'check-class-namedtuple.test',
-    'check-selftype.test',
-    'check-python2.test',
-    'check-columns.test',
-    'check-functions.test',
-    'check-tuples.test',
-    'check-expressions.test',
-    'check-generic-subtyping.test',
-    'check-varargs.test',
-    'check-newsyntax.test',
-    'check-protocols.test',
-    'check-underscores.test',
-    'check-classvar.test',
-    'check-enum.test',
-    'check-incomplete-fixture.test',
-    'check-custom-plugin.test',
-    'check-default-plugin.test',
-    'check-attr.test',
-    'check-ctypes.test',
-    'check-dataclasses.test',
-    'check-final.test',
-    'check-redefine.test',
-    'check-literal.test',
-    'check-newsemanal.test',
-    'check-inline-config.test',
-    'check-reports.test',
-    'check-errorcodes.test',
-    'check-annotated.test',
-    'check-parameter-specification.test',
-    'check-generic-alias.test',
-    'check-typeguard.test',
-]
+typecheck_files = []
+
+# Define the path where the check files are present.
+if sys.platform == 'win32':
+    path2loc = os.path.abspath(__file__).split('mypy\\test')[0] + 'test-data\\unit'
+else:
+    path2loc = os.path.join(os.path.abspath(__file__).split('mypy/test')[0], 'test-data/unit')
+
+for check_files in os.listdir(path2loc):
+    # Append only if it has the pattern ( check-*-*.test)
+    if re.match(r'check-\w+-?\w+?.test', check_files):
+        typecheck_files.append(check_files)
 
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):
-if sys.version_info >= (3, 8):
-    typecheck_files.append('check-python38.test')
-if sys.version_info >= (3, 9):
-    typecheck_files.append('check-python39.test')
+if sys.version_info < (3, 8):
+    typecheck_files.remove('check-python38.test')
+if sys.version_info < (3, 9):
+    typecheck_files.remove('check-python39.test')
 
 # Special tests for platforms with case-insensitive filesystems.
-if sys.platform in ('darwin', 'win32'):
-    typecheck_files.append('check-modules-case.test')
+if sys.platform not in ('darwin', 'win32'):
+    typecheck_files.remove('check-modules-case.test')
 
 
 class TypeCheckSuite(DataSuite):

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -34,7 +34,7 @@ else:
 
 for check_files in os.listdir(path2loc):
     # Append only if it has the pattern ( check-*-*.test)
-    if re.match(r'check-\w+-?\w+?.test', check_files):
+    if re.match(r'check-\w+-?\w+?-?\w+?.test', check_files):
         typecheck_files.append(check_files)
 
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):


### PR DESCRIPTION
Fixes #8650

After this PR is merged, this while running testcheck.py , it would automatically create the list of .test files. The main benefit is that if in future there is addition of test files, we would not have to add the new file into testcheck.py manually, it would automatically grab them.

Further I have verified the changes on my local.

Please merge this PR. I am new to open source and this is my first PR.

Please review @JukkaL , @ethanhs and @davidzwa Sir