### PR TITLE
Use multi-file builds on Windows

### DIFF
--- a/misc/build_wheel.py
+++ b/misc/build_wheel.py
@@ -73,7 +73,7 @@ def create_environ(python_version: str) -> Dict[str, str]:
         'CC=/opt/llvm/bin/clang'
     )
     env['CIBW_ENVIRONMENT_WINDOWS'] = (
-        'MYPY_USE_MYPYC=1 MYPYC_OPT_LEVEL=2 PIP_NO_BUILD_ISOLATION=no'
+        'MYPY_USE_MYPYC=1 MYPYC_OPT_LEVEL=2 MYPYC_MULTI_FILE=1 PIP_NO_BUILD_ISOLATION=no'
     )
 
     # lxml is slow to build wheels for new releases, so allow installing reqs to fail


### PR DESCRIPTION
This may reduce memory use and thus fix the builds.