### PR TITLE
test-data shutil sample: use WindowsError on windows only

### DIFF
--- a/test-data/stdlib-samples/3.2/shutil.py
+++ b/test-data/stdlib-samples/3.2/shutil.py
@@ -62,9 +62,9 @@ class RegistryError(Exception):
     and unpacking registeries fails"""
 
 
-try:
-    _WindowsError = WindowsError # type: type
-except NameError:
+if sys.platform == "win32":
+    _WindowsError = WindowsError
+else:
     _WindowsError = None
 
 


### PR DESCRIPTION
### Description

Mypy's example test file causes mypy errors if typeshed makes `WindowsError` available only on Windows, as it should be. This PR fixes the test to use `WindowsError` only on Windows.

See: https://github.com/python/typeshed/pull/5032

## Test Plan

Mypy's test suite should pass after applying this patch to typeshed (patch based on 1184e6e4 which is currently latest master):

```diff
commit e26f1fa4772c26f48fff3f31a985a1c97c620917
Author: Akuli <akuviljanen17@gmail.com>
Date:   Fri Feb 19 13:47:15 2021 +0200

    make WindowsError available only on windows

diff --git a/stdlib/builtins.pyi b/stdlib/builtins.pyi
index 6eaae007..7512cb94 100644
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1297,7 +1297,8 @@ class OSError(Exception):
 
 EnvironmentError = OSError
 IOError = OSError
-WindowsError = OSError
+if sys.platform == "win32":
+    WindowsError = OSError
 
 class ArithmeticError(_StandardError): ...
 class AssertionError(_StandardError): ...
```