### PR TITLE
Adds ability to have subclasses for NodeVisitor and TraverserVisitor

### DIFF
--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -1,6 +1,7 @@
 """Generic node traverser visitor"""
 
 from typing import List
+from mypy_extensions import mypyc_attr
 
 from mypy.visitor import NodeVisitor
 from mypy.nodes import (
@@ -16,6 +17,7 @@ from mypy.nodes import (
 )
 
 
+@mypyc_attr(allow_interpreted_subclasses=True)
 class TraverserVisitor(NodeVisitor[None]):
     """A parse tree visitor that traverses the parse tree during visiting.
 

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -3,7 +3,7 @@
 from abc import abstractmethod
 from typing import TypeVar, Generic
 from typing_extensions import TYPE_CHECKING
-from mypy_extensions import trait
+from mypy_extensions import trait, mypyc_attr
 
 if TYPE_CHECKING:
     # break import cycle only needed for mypy
@@ -14,6 +14,7 @@ T = TypeVar('T')
 
 
 @trait
+@mypyc_attr(allow_interpreted_subclasses=True)
 class ExpressionVisitor(Generic[T]):
     @abstractmethod
     def visit_int_expr(self, o: 'mypy.nodes.IntExpr') -> T:
@@ -193,6 +194,7 @@ class ExpressionVisitor(Generic[T]):
 
 
 @trait
+@mypyc_attr(allow_interpreted_subclasses=True)
 class StatementVisitor(Generic[T]):
     # Definitions
 
@@ -310,6 +312,7 @@ class StatementVisitor(Generic[T]):
 
 
 @trait
+@mypyc_attr(allow_interpreted_subclasses=True)
 class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T]):
     """Empty base class for parse tree node visitors.
 


### PR DESCRIPTION
### Description

Currently a very important tool - which `NodeVisitor` definitely is - is not available to be used in a 3rd party code.
Because currently inheriting from `NodeVisitor` raises an exception: `TypeError: interpreted classes cannot inherit from compiled traits`

A developer has a single choice to replicate the same visitor patter by theyself, which is not really convenient.
So, I propose to make this consistent with `TypeVisitor`, which already allows having interpreted subclasses.

Refs https://github.com/python/mypy/commit/a9fa9ab43a2655cf81c66c065d51db4618839d05
Refs https://github.com/python/mypy/issues/9001
Refs https://github.com/python/mypy/pull/9602


## Test Plan

As https://github.com/python/mypy/pull/9602 have shown, this is fine without tests.
Correct me if I am wrong, please, and I would contribute the required tests. CC @msullivan on this. 
