### PR TITLE
Speed up processing of new files in daemon by caching ASTs

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2049,8 +2049,10 @@ class State:
             else:
                 # Reuse a cached AST
                 self.tree = manager.ast_cache[self.id][0]
-                manager.errors.set_file_ignored_lines(self.xpath, self.tree.ignored_lines,
-                                                      self.ignore_all or self.options.ignore_errors)
+                manager.errors.set_file_ignored_lines(
+                    self.xpath,
+                    self.tree.ignored_lines,
+                    self.ignore_all or self.options.ignore_errors)
 
         if not cached:
             # Make a copy of any errors produced during parse time so that

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2004,6 +2004,7 @@ class State:
 
         manager = self.manager
 
+        # Can we reuse a previously parsed AST? This avoids redundant work in daemon.
         cached = self.id in manager.ast_cache and True
         modules = manager.modules
         if not cached:
@@ -2046,6 +2047,7 @@ class State:
                                                self.options)
 
             else:
+                # Reuse a cached AST
                 self.tree = manager.ast_cache[self.id][0]
                 manager.errors.set_file_ignored_lines(self.xpath, self.tree.ignored_lines,
                                                       self.ignore_all or self.options.ignore_errors)

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -646,12 +646,13 @@ class BuildManager:
         self.processed_targets = []  # type: List[str]
         # Missing stub packages encountered.
         self.missing_stub_packages = set()  # type: Set[str]
-        # Cache for mypy ASTs that have completed semantic analysis pass 1.
-        # When mypy daemon processes an increment where multiple files
-        # are added to the build, only one the files actually gets added and
-        # the others are discarded. This gets repeated until all the files
-        # have been added. This means that the same new file can be parsed
-        # O(n**2) times. We use this cache to avoid this redundant work.
+        # Cache for mypy ASTs that have completed semantic analysis
+        # pass 1.  When multiple files are added to the build in a
+        # single daemon increment, only one of the files gets added
+        # per step and the others are discarded. This gets repeated
+        # until all the files have been added. This means that a
+        # new file can be processed O(n**2) times. This cache
+        # avoids most of this redundant work.
         self.ast_cache = {}  # type: Dict[str, Tuple[MypyFile, List[ErrorInfo]]]
 
     def dump_stats(self) -> None:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2005,7 +2005,7 @@ class State:
         manager = self.manager
 
         # Can we reuse a previously parsed AST? This avoids redundant work in daemon.
-        cached = self.id in manager.ast_cache and True
+        cached = self.id in manager.ast_cache
         modules = manager.modules
         if not cached:
             manager.log("Parsing %s (%s)" % (self.xpath, self.id))

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -647,7 +647,7 @@ class BuildManager:
         # Missing stub packages encountered.
         self.missing_stub_packages = set()  # type: Set[str]
         # Cache for mypy ASTs that have completed semantic analysis
-        # pass 1.  When multiple files are added to the build in a
+        # pass 1. When multiple files are added to the build in a
         # single daemon increment, only one of the files gets added
         # per step and the others are discarded. This gets repeated
         # until all the files have been added. This means that a
@@ -2065,8 +2065,7 @@ class State:
 
         self.check_blockers()
 
-        if source is not None:
-            manager.ast_cache[self.id] = (self.tree, self.early_errors)
+        manager.ast_cache[self.id] = (self.tree, self.early_errors)
 
     def parse_inline_configuration(self, source: str) -> None:
         """Check for inline mypy: options directive and parse them."""

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -270,6 +270,7 @@ class Server:
                 del data['is_tty']
                 del data['terminal_width']
             return method(self, **data)
+        self.flush_caches()
 
     # Command functions (run in the server via RPC).
 
@@ -398,8 +399,8 @@ class Server:
 
     def flush_caches(self) -> None:
         self.fscache.flush()
-        assert self.fine_grained_manager
-        self.fine_grained_manager.manager.ast_cache.clear()
+        if self.fine_grained_manager:
+            self.fine_grained_manager.manager.ast_cache.clear()
 
     def update_stats(self, res: Dict[str, Any]) -> None:
         if self.fine_grained_manager:
@@ -432,6 +433,7 @@ class Server:
             return {'out': out, 'err': err, 'status': 2}
         messages = result.errors
         self.fine_grained_manager = FineGrainedBuildManager(result)
+        self.fine_grained_manager.manager.ast_cache.clear()
 
         if self.following_imports():
             sources = find_all_sources_in_build(self.fine_grained_manager.graph, sources)

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -270,7 +270,6 @@ class Server:
                 del data['is_tty']
                 del data['terminal_width']
             return method(self, **data)
-        self.flush_caches()
 
     # Command functions (run in the server via RPC).
 
@@ -433,7 +432,6 @@ class Server:
             return {'out': out, 'err': err, 'status': 2}
         messages = result.errors
         self.fine_grained_manager = FineGrainedBuildManager(result)
-        self.fine_grained_manager.manager.ast_cache.clear()
 
         if self.following_imports():
             sources = find_all_sources_in_build(self.fine_grained_manager.graph, sources)

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -399,7 +399,7 @@ class Server:
     def flush_caches(self) -> None:
         self.fscache.flush()
         if self.fine_grained_manager:
-            self.fine_grained_manager.manager.ast_cache.clear()
+            self.fine_grained_manager.flush_cache()
 
     def update_stats(self, res: Dict[str, Any]) -> None:
         if self.fine_grained_manager:

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -373,7 +373,7 @@ class Server:
             assert remove is None and update is None
             messages = self.fine_grained_increment_follow_imports(sources)
         res = self.increment_output(messages, sources, is_tty, terminal_width)
-        self.fscache.flush()
+        self.flush_caches()
         self.update_stats(res)
         return res
 
@@ -392,9 +392,14 @@ class Server:
             else:
                 messages = self.fine_grained_increment_follow_imports(sources)
             res = self.increment_output(messages, sources, is_tty, terminal_width)
-        self.fscache.flush()
+        self.flush_caches()
         self.update_stats(res)
         return res
+
+    def flush_caches(self) -> None:
+        self.fscache.flush()
+        assert self.fine_grained_manager
+        self.fine_grained_manager.manager.ast_cache.clear()
 
     def update_stats(self, res: Dict[str, Any]) -> None:
         if self.fine_grained_manager:
@@ -852,7 +857,7 @@ class Server:
                 out += "\n"
             return {'out': out, 'err': "", 'status': 0}
         finally:
-            self.fscache.flush()
+            self.flush_caches()
 
     def cmd_hang(self) -> Dict[str, object]:
         """Hang for 100 seconds, as a debug hack."""

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -288,6 +288,14 @@ class FineGrainedBuildManager:
         self.previous_messages = self.manager.errors.new_messages()[:]
         return self.update(changed_modules, [])
 
+    def flush_cache(self) -> None:
+        """Flush AST cache.
+
+        This needs to be called after each increment, or file changes won't
+        be detected reliably.
+        """
+        self.manager.ast_cache.clear()
+
     def update_one(self,
                    changed_modules: List[Tuple[str, str]],
                    initial_set: Set[str],

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -640,6 +640,7 @@ class SuggestionEngine:
         If check_errors is true, raise an exception if there are errors.
         """
         assert state.path is not None
+        self.fgmanager.flush_cache()
         return self.fgmanager.update([(state.id, state.path)], [])
 
     def ensure_loaded(self, state: State, force: bool = False) -> MypyFile:

--- a/mypy/test/testmerge.py
+++ b/mypy/test/testmerge.py
@@ -124,6 +124,7 @@ class ASTMergeSuite(DataSuite):
     def build_increment(self, manager: FineGrainedBuildManager,
                         module_id: str, path: str) -> Tuple[MypyFile,
                                                             Dict[Expression, Type]]:
+        manager.manager.ast_cache.clear()
         manager.update([(module_id, path)], [])
         module = manager.manager.modules[module_id]
         type_map = manager.graph[module_id].type_map()

--- a/mypy/test/testmerge.py
+++ b/mypy/test/testmerge.py
@@ -124,7 +124,7 @@ class ASTMergeSuite(DataSuite):
     def build_increment(self, manager: FineGrainedBuildManager,
                         module_id: str, path: str) -> Tuple[MypyFile,
                                                             Dict[Expression, Type]]:
-        manager.manager.ast_cache.clear()
+        manager.flush_cache()
         manager.update([(module_id, path)], [])
         module = manager.manager.modules[module_id]
         type_map = manager.graph[module_id].type_map()


### PR DESCRIPTION
Processing newly installed stub files, in particular, could be quite slow incrementally
in mypy daemon. This is because adding N files results in N steps interally, each of 
which adds one file. However, each step parses all remaining files, resulting in 
an O(n**2) algorithm.

For example, processing `six` stubs could take about 40s (when not using a 
compiled mypy).

Partially address the issue by caching parsed ASTs during a single increment.
This speeds up the `import six` use case by about 3x when not using a compiled
mypy. It's still about 3x slower when using daemon, however.