### PR TITLE
Fix mro invoking #10137

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -352,7 +352,7 @@ def generate_c_type_stub(module: ModuleType,
         if attr not in done:
             static_properties.append('%s: ClassVar[%s] = ...' % (
                 attr, strip_or_import(get_type_fullname(type(value)), module, imports)))
-    all_bases = obj.mro()
+    all_bases = type.mro(obj)
     if all_bases[-1] is object:
         # TODO: Is this always object?
         del all_bases[-1]

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -710,6 +710,16 @@ class StubgencSuite(unittest.TestCase):
         assert_equal(output, ['class C(argparse.Action): ...', ])
         assert_equal(imports, ['import argparse'])
 
+    def test_generate_c_type_inheritance_builtin_type(self) -> None:
+        class TestClass(type):
+            pass
+        output = []  # type: List[str]
+        imports = []  # type: List[str]
+        mod = ModuleType('module', '')
+        generate_c_type_stub(mod, 'C', TestClass, output, imports)
+        assert_equal(output, ['class C(type): ...', ])
+        assert_equal(imports, [])
+
     def test_generate_c_type_with_docstring(self) -> None:
         class TestClass:
             def test(self, arg0: str) -> None:


### PR DESCRIPTION
## Description
Fixes https://github.com/python/mypy/issues/10137
Changed `obj.mro()` to `type.mro(obj)` so it properly invokes the `mro` of `type` when `obj` is `type`
## Test Plan
After this change, `stubgen` can properly generate pyi files for cython modules or native modules that include types inheriting the builtin `type`. Any package include such definition of class would be suitable for testing this.
Added a unittest for `generate_c_type_stub` as well.