### PR TITLE
Fixes Final docs

### DIFF
--- a/docs/source/final_attrs.rst
+++ b/docs/source/final_attrs.rst
@@ -68,7 +68,9 @@ You can use ``Final`` in one of these forms:
 
   .. code-block:: python
 
-     ID: Final[float] = 1
+     ID: Final[int] = 1
+
+  Here mypy will infer type ``int`` for ``ID``.
 
 * You can omit the type:
 
@@ -76,11 +78,11 @@ You can use ``Final`` in one of these forms:
 
      ID: Final = 1
 
-  Here mypy will infer type ``int`` for ``ID``. Note that unlike for
+  Here mypy will infer type ``Literal[1]`` for ``ID``. Note that unlike for
   generic classes this is *not* the same as ``Final[Any]``.
 
 * In class bodies and stub files you can omit the right hand side and just write
-  ``ID: Final[float]``.
+  ``ID: Final[int]``.
 
 * Finally, you can write ``self.id: Final = 1`` (also optionally with
   a type in square brackets). This is allowed *only* in


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

There were several things to imporve in `Final` docs:
1. For some reason it was `ID: Final[float] = 1`, while `1` is clearly `int`
2. There was also a quite misleading phrase about `ID: Final = 1` being `int` and not `Literal[1]`
