### PR TITLE
GitHub actions house-keeping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,10 @@ jobs:
           toxenv: py37
 
     steps:
-    - uses: actions/checkout@v1
-    - name: initialize submodules
-      run: git submodule update --init
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.arch }}


### PR DESCRIPTION
Updates two actions to the latest versions (`v1` is outdate as for now), changes how submodules are initialized.

Closes #9781 (GitHub Actions are currently in Alpha in dependabot, they do not work reliably).