### PR TITLE
Add Apple Silicon support when building wheels

### DIFF
--- a/misc/build_wheel.py
+++ b/misc/build_wheel.py
@@ -45,6 +45,13 @@ def create_environ(python_version: str) -> Dict[str, str]:
     # Don't build 32-bit wheels
     env['CIBW_SKIP'] = "*-manylinux_i686 *-win32"
 
+    # Apple Silicon support
+    # When cross-compiling on Intel, it is not possible to test arm64 and 
+    # the arm64 part of a universal2 wheel. Warnings will be silenced with
+    # following CIBW_TEST_SKIP
+    env['CIBW_ARCHS_MACOS'] = "x86_64 arm64"
+    env['CIBW_TEST_SKIP'] = "*-macosx_arm64"
+
     env['CIBW_BUILD_VERBOSITY'] = '1'
 
     # mypy's isolated builds don't specify the requirements mypyc needs, so install


### PR DESCRIPTION
### Description

related to #10114 

I add a `CIBW_TEST_SKIP` in line 53 according to [this](https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon). Is it necessary? I am not sure whether it would work or not.