### PR TITLE
[mypyc] Use vectorcalls to call Python objects

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -405,8 +405,13 @@ class Errors:
         return sum(len(x) for x in self.error_info_map.values())
 
     def is_errors(self) -> bool:
-        """Are there any generated errors?"""
+        """Are there any generated messages?"""
         return bool(self.error_info_map)
+
+    def is_real_errors(self) -> bool:
+        """Are there any generated errors (not just notes, for example)?"""
+        return any(info.severity == 'error'
+                   for infos in self.error_info_map.values() for info in infos)
 
     def is_blockers(self) -> bool:
         """Are the any errors that are blockers?"""

--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -258,7 +258,7 @@ class DefinedVisitor(BaseAnalysisVisitor):
             return {op.dest}, set()
 
     def visit_assign_multi(self, op: AssignMulti) -> GenAndKill:
-        # TODO
+        # Array registers are special and we don't track the definedness of them.
         return set(), set()
 
     def visit_set_mem(self, op: SetMem) -> GenAndKill:

--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -9,7 +9,7 @@ from mypyc.ir.ops import (
     BasicBlock, OpVisitor, Assign, AssignMulti, Integer, LoadErrorValue, RegisterOp, Goto, Branch,
     Return, Call, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
     LoadLiteral, LoadStatic, InitStatic, MethodCall, RaiseStandardError, CallC, LoadGlobal,
-    Truncate, IntOp, LoadMem, GetElementPtr, LoadAddress, ComparisonOp, SetMem
+    Truncate, IntOp, LoadMem, GetElementPtr, LoadAddress, ComparisonOp, SetMem, KeepAlive
 )
 from mypyc.ir.func_ir import all_values
 
@@ -224,6 +224,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_load_address(self, op: LoadAddress) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_keep_alive(self, op: KeepAlive) -> GenAndKill:
         return self.visit_register_op(op)
 
 

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -1,11 +1,12 @@
 """Utilities for emitting C code."""
 
 from mypy.ordered_dict import OrderedDict
-from typing import List, Set, Dict, Optional, Callable, Union
+from typing import List, Set, Dict, Optional, Callable, Union, Tuple
+import sys
 
 from mypyc.common import (
     REG_PREFIX, ATTR_PREFIX, STATIC_PREFIX, TYPE_PREFIX, NATIVE_PREFIX,
-    FAST_ISINSTANCE_MAX_SUBCLASSES,
+    FAST_ISINSTANCE_MAX_SUBCLASSES, use_vectorcall
 )
 from mypyc.ir.ops import BasicBlock, Value
 from mypyc.ir.rtypes import (
@@ -93,8 +94,11 @@ class Emitter:
 
     def __init__(self,
                  context: EmitterContext,
-                 value_names: Optional[Dict[Value, str]] = None) -> None:
+                 value_names: Optional[Dict[Value, str]] = None,
+                 capi_version: Optional[Tuple[int, int]] = None,
+                 ) -> None:
         self.context = context
+        self.capi_version = capi_version or sys.version_info[:2]
         self.names = context.names
         self.value_names = value_names or {}
         self.fragments = []  # type: List[str]
@@ -253,6 +257,9 @@ class Emitter:
         result.append('')
 
         return result
+
+    def use_vectorcall(self) -> bool:
+        return use_vectorcall(self.capi_version)
 
     def emit_undefined_attr_check(self, rtype: RType, attr_expr: str,
                                   compare: str,

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -514,7 +514,11 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             val = reg.value
             if val == 0 and is_pointer_rprimitive(reg.type):
                 return "NULL"
-            return str(val)
+            s = str(val)
+            if val >= (1 << 31):
+                # Avoid overflowing signed 32-bit int
+                s += 'U'
+            return s
         else:
             return self.emitter.reg(reg)
 

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -12,7 +12,7 @@ from mypyc.ir.ops import (
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
     BasicBlock, Value, MethodCall, Unreachable, NAMESPACE_STATIC, NAMESPACE_TYPE, NAMESPACE_MODULE,
     RaiseStandardError, CallC, LoadGlobal, Truncate, IntOp, LoadMem, GetElementPtr,
-    LoadAddress, ComparisonOp, SetMem, Register, LoadLiteral, AssignMulti
+    LoadAddress, ComparisonOp, SetMem, Register, LoadLiteral, AssignMulti, KeepAlive
 )
 from mypyc.ir.rtypes import (
     RType, RTuple, RArray, is_tagged, is_int32_rprimitive, is_int64_rprimitive, RStruct,
@@ -497,6 +497,10 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         dest = self.reg(op)
         src = self.reg(op.src) if isinstance(op.src, Register) else op.src
         self.emit_line('%s = (%s)&%s;' % (dest, typ._ctype, src))
+
+    def visit_keep_alive(self, op: KeepAlive) -> None:
+        # This is a no-op.
+        pass
 
     # Helpers
 

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -59,6 +59,8 @@ def generate_native_function(fn: FuncIR,
     for r in all_values(fn.arg_regs, fn.blocks):
         if isinstance(r.type, RTuple):
             emitter.declare_tuple_struct(r.type)
+        if isinstance(r.type, RArray):
+            continue  # Special: declared on first assignment
 
         if r in fn.arg_regs:
             continue  # Skip the arguments

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -170,6 +170,8 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         typ = op.dest.type
         assert isinstance(typ, RArray)
         dest = self.reg(op.dest)
+        # RArray values can only be assigned to once, so we can always
+        # declare them on initialization.
         self.emit_line('%s%s[%d] = {%s};' % (
             self.emitter.ctype_spaced(typ.item_type),
             dest,

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -14,7 +14,7 @@ from typing import List, Optional
 
 from mypy.nodes import ARG_POS, ARG_OPT, ARG_NAMED_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2
 
-from mypyc.common import PREFIX, NATIVE_PREFIX, DUNDER_PREFIX, USE_VECTORCALL
+from mypyc.common import PREFIX, NATIVE_PREFIX, DUNDER_PREFIX, use_vectorcall
 from mypyc.codegen.emit import Emitter
 from mypyc.ir.rtypes import (
     RType, is_object_rprimitive, is_int_rprimitive, is_bool_rprimitive, object_rprimitive
@@ -157,7 +157,7 @@ def generate_wrapper_function(fn: FuncIR,
         arg_ptrs += ['&obj_{}'.format(groups[ARG_STAR2][0].name) if groups[ARG_STAR2] else 'NULL']
     arg_ptrs += ['&obj_{}'.format(arg.name) for arg in reordered_args]
 
-    if fn.name == '__call__' and USE_VECTORCALL:
+    if fn.name == '__call__' and use_vectorcall(emitter.capi_version):
         nargs = 'PyVectorcall_NARGS(nargs)'
     else:
         nargs = 'nargs'

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -55,6 +55,9 @@ USE_FASTCALL = sys.version_info >= (3, 7)  # type: Final
 # We can use vectorcalls on Python 3.8+ (PEP 590).
 USE_VECTORCALL = sys.version_info >= (3, 8)  # type: Final
 
+# We can use vectorcalls for method calls on Python 3.9+.
+USE_METHOD_VECTORCALL = sys.version_info >= (3, 9)  # type: Final
+
 # Runtime C library files
 RUNTIME_C_FILES = [
     'init.c',

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -88,7 +88,7 @@ def short_name(name: str) -> str:
 
 
 def use_fastcall(capi_version: Tuple[int, int]) -> bool:
-    # We can use METH_FASTCALL faster wrapper functions on Python 3.7+.
+    # We can use METH_FASTCALL for faster wrapper functions on Python 3.7+.
     return capi_version >= (3, 7)
 
 
@@ -98,5 +98,5 @@ def use_vectorcall(capi_version: Tuple[int, int]) -> bool:
 
 
 def use_method_vectorcall(capi_version: Tuple[int, int]) -> bool:
-    # We can use a specific vectorcall API to call methods on Python 3.9+.
+    # We can use a dedicated vectorcall API to call methods on Python 3.9+.
     return capi_version >= (3, 9)

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Dict, Any
+from typing import Dict, Any, Tuple
 import sys
 
 from typing_extensions import Final
@@ -49,15 +49,6 @@ MAX_SHORT_INT = sys.maxsize >> 1  # type: Final
 MAX_LITERAL_SHORT_INT = (sys.maxsize >> 1 if not IS_MIXED_32_64_BIT_BUILD
                          else 2**30 - 1)  # type: Final
 
-# We can use METH_FASTCALL faster wrapper functions on Python 3.7+.
-USE_FASTCALL = sys.version_info >= (3, 7)  # type: Final
-
-# We can use vectorcalls on Python 3.8+ (PEP 590).
-USE_VECTORCALL = sys.version_info >= (3, 8)  # type: Final
-
-# We can use vectorcalls for method calls on Python 3.9+.
-USE_METHOD_VECTORCALL = sys.version_info >= (3, 9)  # type: Final
-
 # Runtime C library files
 RUNTIME_C_FILES = [
     'init.c',
@@ -73,6 +64,9 @@ RUNTIME_C_FILES = [
     'misc_ops.c',
     'generic_ops.c',
 ]  # type: Final
+
+
+JsonDict = Dict[str, Any]
 
 
 def decorator_helper_name(func_name: str) -> str:
@@ -93,4 +87,16 @@ def short_name(name: str) -> str:
     return name
 
 
-JsonDict = Dict[str, Any]
+def use_fastcall(capi_version: Tuple[int, int]) -> bool:
+    # We can use METH_FASTCALL faster wrapper functions on Python 3.7+.
+    return capi_version >= (3, 7)
+
+
+def use_vectorcall(capi_version: Tuple[int, int]) -> bool:
+    # We can use vectorcalls to make calls on Python 3.8+ (PEP 590).
+    return capi_version >= (3, 8)
+
+
+def use_method_vectorcall(capi_version: Tuple[int, int]) -> bool:
+    # We can use a specific vectorcall API to call methods on Python 3.9+.
+    return capi_version >= (3, 9)

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -7,7 +7,7 @@ from mypy.nodes import FuncDef, Block, ARG_POS, ARG_OPT, ARG_NAMED_OPT
 
 from mypyc.common import JsonDict
 from mypyc.ir.ops import (
-    DeserMaps, BasicBlock, Value, Register, Assign, ControlOp, LoadAddress
+    DeserMaps, BasicBlock, Value, Register, Assign, AssignMulti, ControlOp, LoadAddress
 )
 from mypyc.ir.rtypes import RType, deserialize_type
 from mypyc.namegen import NameGenerator
@@ -234,7 +234,7 @@ def all_values(args: List[Register], blocks: List[BasicBlock]) -> List[Value]:
     for block in blocks:
         for op in block.ops:
             if not isinstance(op, ControlOp):
-                if isinstance(op, Assign):
+                if isinstance(op, (Assign, AssignMulti)):
                     if op.dest not in seen_registers:
                         values.append(op.dest)
                         seen_registers.add(op.dest)
@@ -266,7 +266,7 @@ def all_values_full(args: List[Register], blocks: List[BasicBlock]) -> List[Valu
                     values.append(source)
                     seen_registers.add(source)
             if not isinstance(op, ControlOp):
-                if isinstance(op, Assign):
+                if isinstance(op, (Assign, AssignMulti)):
                     if op.dest not in seen_registers:
                         values.append(op.dest)
                         seen_registers.add(op.dest)

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1169,6 +1169,26 @@ class LoadAddress(RegisterOp):
         return visitor.visit_load_address(self)
 
 
+class KeepAlive(RegisterOp):
+    """A no-op operation that ensures source values aren't freed.
+
+    This is sometimes useful to avoid decref when a reference is still
+    being held but not seen by the compiler.
+    """
+
+    error_kind = ERR_NEVER
+
+    def __init__(self, src: List[Value]) -> None:
+        assert src
+        self.src = src
+
+    def sources(self) -> List[Value]:
+        return self.src[:]
+
+    def accept(self, visitor: 'OpVisitor[T]') -> T:
+        return visitor.visit_keep_alive(self)
+
+
 @trait
 class OpVisitor(Generic[T]):
     """Generic visitor over ops (uses the visitor design pattern)."""
@@ -1293,6 +1313,10 @@ class OpVisitor(Generic[T]):
 
     @abstractmethod
     def visit_load_address(self, op: LoadAddress) -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visit_keep_alive(self, op: KeepAlive) -> T:
         raise NotImplementedError
 
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -149,11 +149,13 @@ class Integer(Value):
     not included in data flow analyses and such, unlike Register and
     Op subclasses.
 
-    These can represent both short tagged integers
-    (short_int_primitive type; the tag bit is clear), ordinary
-    fixed-width integers (e.g., int32_rprimitive), and values of some
-    other unboxed primitive types that are represented as integers
-    (none_rprimitive, bool_rprimitive).
+    Integer can represent multiple types:
+
+     * Short tagged integers (short_int_primitive type; the tag bit is clear)
+     * Ordinary fixed-width integers (e.g., int32_rprimitive)
+     * Values of other unboxed primitive types that are represented as integers
+       (none_rprimitive, bool_rprimitive)
+     * Null pointers (value 0) of various types, including object_rprimitive
     """
 
     def __init__(self, value: int, rtype: RType = short_int_rprimitive, line: int = -1) -> None:

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -238,7 +238,6 @@ class AssignMulti(Op):
     assume that each RArray register is initialized exactly once
     with this op.
     """
-    # TODO: Relax the special rules above
 
     error_kind = ERR_NEVER
 
@@ -1159,6 +1158,17 @@ class KeepAlive(RegisterOp):
 
     This is sometimes useful to avoid decref when a reference is still
     being held but not seen by the compiler.
+
+    A typical use case is like this (C-like pseudocode):
+
+      ptr = &x.item
+      r = *ptr
+      keep_alive x  # x must not be freed here
+      # x may be freed here
+
+    If we didn't have "keep_alive x", x could be freed immediately
+    after taking the address of 'item', resulting in a read after free
+    on the second line.
     """
 
     error_kind = ERR_NEVER

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -9,7 +9,8 @@ from mypyc.ir.ops import (
     Goto, Branch, Return, Unreachable, Assign, Integer, LoadErrorValue, GetAttr, SetAttr,
     LoadStatic, InitStatic, TupleGet, TupleSet, IncRef, DecRef, Call, MethodCall, Cast, Box, Unbox,
     RaiseStandardError, CallC, Truncate, LoadGlobal, IntOp, ComparisonOp, LoadMem, SetMem,
-    GetElementPtr, LoadAddress, Register, Value, OpVisitor, BasicBlock, ControlOp, LoadLiteral
+    GetElementPtr, LoadAddress, Register, Value, OpVisitor, BasicBlock, ControlOp, LoadLiteral,
+    AssignMulti
 )
 from mypyc.ir.func_ir import FuncIR, all_values_full
 from mypyc.ir.module_ir import ModuleIRs
@@ -55,6 +56,13 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
 
     def visit_assign(self, op: Assign) -> str:
         return self.format('%r = %r', op.dest, op.src)
+
+    def visit_assign_multi(self, op: AssignMulti) -> str:
+        if len(op.src) == 1:
+            return self.format('%r = %r,', op.dest, op.src[0])
+        return self.format('%r = %s',
+                           op.dest,
+                           ', '.join(self.format('%r', v) for v in op.src))
 
     def visit_load_error_value(self, op: LoadErrorValue) -> str:
         return self.format('%r = <error> :: %s', op, op.type)

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -10,7 +10,7 @@ from mypyc.ir.ops import (
     LoadStatic, InitStatic, TupleGet, TupleSet, IncRef, DecRef, Call, MethodCall, Cast, Box, Unbox,
     RaiseStandardError, CallC, Truncate, LoadGlobal, IntOp, ComparisonOp, LoadMem, SetMem,
     GetElementPtr, LoadAddress, Register, Value, OpVisitor, BasicBlock, ControlOp, LoadLiteral,
-    AssignMulti
+    AssignMulti, KeepAlive
 )
 from mypyc.ir.func_ir import FuncIR, all_values_full
 from mypyc.ir.module_ir import ModuleIRs
@@ -198,6 +198,10 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
             return self.format("%r = load_address %r", op, op.src)
         else:
             return self.format("%r = load_address %s", op, op.src)
+
+    def visit_keep_alive(self, op: KeepAlive) -> str:
+        return self.format('keep_alive %s' % ', '.join(self.format('%r', v)
+                                                       for v in op.src))
 
     # Helpers
 

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -177,18 +177,10 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
                            op.rhs, sign_format)
 
     def visit_load_mem(self, op: LoadMem) -> str:
-        if op.base:
-            base = self.format(', %r', op.base)
-        else:
-            base = ''
-        return self.format("%r = load_mem %r%s :: %t*", op, op.src, base, op.type)
+        return self.format("%r = load_mem %r :: %t*", op, op.src, op.type)
 
     def visit_set_mem(self, op: SetMem) -> str:
-        if op.base:
-            base = self.format(', %r', op.base)
-        else:
-            base = ''
-        return self.format("set_mem %r, %r%s :: %t*", op.dest, op.src, base, op.dest_type)
+        return self.format("set_mem %r, %r :: %t*", op.dest, op.src, op.dest_type)
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> str:
         return self.format("%r = get_element_ptr %r %s :: %t", op, op.src, op.field, op.src_type)

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -58,9 +58,7 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
         return self.format('%r = %r', op.dest, op.src)
 
     def visit_assign_multi(self, op: AssignMulti) -> str:
-        if len(op.src) == 1:
-            return self.format('%r = %r,', op.dest, op.src[0])
-        return self.format('%r = %s',
+        return self.format('%r = [%s]',
                            op.dest,
                            ', '.join(self.format('%r', v) for v in op.src))
 
@@ -356,7 +354,7 @@ def generate_names_for_ir(args: List[Register], blocks: List[BasicBlock]) -> Dic
                 if source not in names:
                     values.append(source)
 
-            if isinstance(op, Assign):
+            if isinstance(op, (Assign, AssignMulti)):
                 values.append(op.dest)
             elif isinstance(op, ControlOp) or op.is_void:
                 continue

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -720,7 +720,11 @@ def is_optional_type(rtype: RType) -> bool:
 
 
 class RArray(RType):
-    """Fixed-length C array type (for example, int[5])"""
+    """Fixed-length C array type (for example, int[5]).
+
+    Note that the implementation is a bit limited, and these can basically
+    be only used for local variables that are initialized in one location.
+    """
 
     def __init__(self,
                  item_type: RType,

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -188,7 +188,7 @@ class RPrimitive(RType):
         #       we need to figure out some way to represent here.
         if ctype == 'CPyTagged':
             self.c_undefined = 'CPY_INT_TAG'
-        elif ctype in ('int32_t', 'int64_t', 'CPyPtr'):
+        elif ctype in ('int32_t', 'int64_t', 'CPyPtr', 'uint32_t', 'uint64_t'):
             self.c_undefined = '0'
         elif ctype == 'PyObject *':
             # Boxed types use the null pointer as the error value.
@@ -254,19 +254,28 @@ int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=True,
 short_int_rprimitive = RPrimitive('short_int', is_unboxed=True, is_refcounted=False,
                                   ctype='CPyTagged')  # type: Final
 
-# low level integer (corresponds to C's 'int's).
+# Low level integer types (correspond to C integer types)
+
 int32_rprimitive = RPrimitive('int32', is_unboxed=True, is_refcounted=False,
                               ctype='int32_t', size=4)  # type: Final
 int64_rprimitive = RPrimitive('int64', is_unboxed=True, is_refcounted=False,
                               ctype='int64_t', size=8)  # type: Final
-# integer alias
+uint32_rprimitive = RPrimitive('uint32', is_unboxed=True, is_refcounted=False,
+                               ctype='uint32_t', size=4)  # type: Final
+uint64_rprimitive = RPrimitive('uint64', is_unboxed=True, is_refcounted=False,
+                               ctype='uint64_t', size=8)  # type: Final
+
+# The C 'int' type
 c_int_rprimitive = int32_rprimitive
+
 if IS_32_BIT_PLATFORM:
+    c_size_t_rprimitive = uint32_rprimitive
     c_pyssize_t_rprimitive = int32_rprimitive
 else:
+    c_size_t_rprimitive = uint64_rprimitive
     c_pyssize_t_rprimitive = int64_rprimitive
 
-# low level pointer, represented as integer in C backends
+# Low level pointer, represented as integer in C backends
 pointer_rprimitive = RPrimitive('ptr', is_unboxed=True, is_refcounted=False,
                               ctype='CPyPtr')  # type: Final
 
@@ -328,6 +337,14 @@ def is_int32_rprimitive(rtype: RType) -> bool:
 
 def is_int64_rprimitive(rtype: RType) -> bool:
     return rtype is int64_rprimitive
+
+
+def is_uint32_rprimitive(rtype: RType) -> bool:
+    return rtype is uint32_rprimitive
+
+
+def is_uint64_rprimitive(rtype: RType) -> bool:
+    return rtype is uint64_rprimitive
 
 
 def is_c_py_ssize_t_rprimitive(rtype: RType) -> bool:

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -712,6 +712,7 @@ class RArray(RType):
         # Number of items
         self.length = length
         self._ctype = 'xxx'
+        self.is_refcounted = False
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_rarray(self)

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -147,7 +147,7 @@ class RVoid(RType):
         return isinstance(other, RVoid)
 
     def __hash__(self) -> int:
-        return 12345
+        return hash(RVoid)
 
 
 # Singleton instance of RVoid
@@ -744,7 +744,6 @@ class RArray(RType):
         self.item_type = item_type
         # Number of items
         self.length = length
-        self._ctype = 'xxx'
         self.is_refcounted = False
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -64,12 +64,6 @@ class RType:
     def __repr__(self) -> str:
         return '<%s>' % self.__class__.__name__
 
-    def __eq__(self, other: object) -> bool:
-        return isinstance(other, RType) and other.name == self.name
-
-    def __hash__(self) -> int:
-        return hash(self.name)
-
     def serialize(self) -> Union[JsonDict, str]:
         raise NotImplementedError('Cannot serialize {} instance'.format(self.__class__.__name__))
 
@@ -149,6 +143,12 @@ class RVoid(RType):
     def serialize(self) -> str:
         return 'void'
 
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, RVoid)
+
+    def __hash__(self) -> int:
+        return 12345
+
 
 # Singleton instance of RVoid
 void_rtype = RVoid()  # type: Final
@@ -208,6 +208,12 @@ class RPrimitive(RType):
 
     def __repr__(self) -> str:
         return '<RPrimitive %s>' % self.name
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, RPrimitive) and other.name == self.name
+
+    def __hash__(self) -> int:
+        return hash(self.name)
 
 
 # NOTE: All the supported instances of RPrimitive are defined
@@ -659,6 +665,12 @@ class RInstance(RType):
 
     def __repr__(self) -> str:
         return '<RInstance %s>' % self.name
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, RInstance) and other.name == self.name
+
+    def __hash__(self) -> int:
+        return hash(self.name)
 
     def serialize(self) -> str:
         return self.name

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -277,7 +277,7 @@ else:
 
 # Low level pointer, represented as integer in C backends
 pointer_rprimitive = RPrimitive('ptr', is_unboxed=True, is_refcounted=False,
-                              ctype='CPyPtr')  # type: Final
+                                ctype='CPyPtr')  # type: Final
 
 # Floats are represent as 'float' PyObject * values. (In the future
 # we'll likely switch to a more efficient, unboxed representation.)

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -83,7 +83,7 @@ class IRBuilder:
                  pbv: PreBuildVisitor,
                  visitor: IRVisitor,
                  options: CompilerOptions) -> None:
-        self.builder = LowLevelIRBuilder(current_module, mapper)
+        self.builder = LowLevelIRBuilder(current_module, mapper, options)
         self.builders = [self.builder]
         self.symtables = [OrderedDict()]  # type: List[OrderedDict[SymbolNode, SymbolTarget]]
         self.runtime_args = [[]]  # type: List[List[RuntimeArg]]
@@ -904,7 +904,7 @@ class IRBuilder:
     def enter(self, fn_info: Union[FuncInfo, str] = '') -> None:
         if isinstance(fn_info, str):
             fn_info = FuncInfo(name=fn_info)
-        self.builder = LowLevelIRBuilder(self.current_module, self.mapper)
+        self.builder = LowLevelIRBuilder(self.current_module, self.mapper, self.options)
         self.builders.append(self.builder)
         self.symtables.append(OrderedDict())
         self.runtime_args.append([])

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -14,7 +14,7 @@ from typing import Optional, List, Tuple, Union, Dict
 
 from mypy.nodes import (
     ClassDef, FuncDef, OverloadedFuncDef, Decorator, Var, YieldFromExpr, AwaitExpr, YieldExpr,
-    FuncItem, LambdaExpr, SymbolNode
+    FuncItem, LambdaExpr, SymbolNode, ARG_NAMED, ARG_NAMED_OPT
 )
 from mypy.types import CallableType, get_proper_type
 
@@ -665,7 +665,8 @@ def gen_glue_method(builder: IRBuilder, sig: FuncSignature, target: FuncIR,
     fake_vars = [(Var(arg.name), arg.type) for arg in rt_args]
     args = [builder.read(builder.add_local_reg(var, type, is_arg=True), line)
             for var, type in fake_vars]
-    arg_names = [arg.name for arg in rt_args]
+    arg_names = [arg.name if arg.kind in (ARG_NAMED, ARG_NAMED_OPT) else None
+                 for arg in rt_args]
     arg_kinds = [concrete_arg_kind(arg.kind) for arg in rt_args]
 
     if do_pycall:

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -366,9 +366,11 @@ class LowLevelIRBuilder:
                 return result
 
         if arg_kinds is None or all(kind == ARG_POS for kind in arg_kinds):
+            # Use legacy method call API
             method_name_reg = self.load_str(method_name)
             return self.call_c(py_method_call_op, [obj, method_name_reg] + arg_values, line)
         else:
+            # Use py_call since it supports keyword arguments (and vectorcalls).
             method = self.py_get_attr(obj, method_name, line)
             return self.py_call(method, arg_values, line, arg_kinds=arg_kinds, arg_names=arg_names)
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -336,9 +336,9 @@ class LowLevelIRBuilder:
     def _vectorcall_keywords(self, arg_names: Optional[Sequence[Optional[str]]]) -> Value:
         if arg_names:
             kw_list = [name for name in arg_names if name is not None]
-            return self.add(LoadLiteral(tuple(kw_list), object_rprimitive))
-        else:
-            return Integer(0, object_rprimitive)
+            if kw_list:
+                return self.add(LoadLiteral(tuple(kw_list), object_rprimitive))
+        return Integer(0, object_rprimitive)
 
     def py_method_call(self,
                        obj: Value,

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -344,6 +344,10 @@ class LowLevelIRBuilder:
         return None
 
     def _vectorcall_keywords(self, arg_names: Optional[Sequence[Optional[str]]]) -> Value:
+        """Return a reference to a tuple literal with keyword argument names.
+
+        Return null pointer if there are no keyword arguments.
+        """
         if arg_names:
             kw_list = [name for name in arg_names if name is not None]
             if kw_list:

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -35,7 +35,8 @@ from mypyc.ir.rtypes import (
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
 from mypyc.common import (
-    FAST_ISINSTANCE_MAX_SUBCLASSES, MAX_LITERAL_SHORT_INT, PLATFORM_SIZE, USE_VECTORCALL
+    FAST_ISINSTANCE_MAX_SUBCLASSES, MAX_LITERAL_SHORT_INT, PLATFORM_SIZE, USE_VECTORCALL,
+    USE_METHOD_VECTORCALL
 )
 from mypyc.primitives.registry import (
     method_call_ops, CFunctionDescription, function_ops,
@@ -348,7 +349,7 @@ class LowLevelIRBuilder:
                        arg_kinds: Optional[List[int]],
                        arg_names: Optional[Sequence[Optional[str]]]) -> Value:
         """Call a Python method (non-native and slow)."""
-        if USE_VECTORCALL:
+        if USE_METHOD_VECTORCALL:
             # More recent Python versions support faster vectorcalls.
             result = self._py_vector_method_call(
                 obj, method_name, arg_values, line, arg_kinds, arg_names)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -12,6 +12,8 @@ from typing import (
     Callable, List, Tuple, Optional, Union, Sequence, cast
 )
 
+from typing_extensions import Final
+
 from mypy.nodes import ARG_POS, ARG_NAMED, ARG_STAR, ARG_STAR2, op_methods
 from mypy.types import AnyType, TypeOfAny
 from mypy.checkexpr import map_actuals_to_formals
@@ -67,6 +69,10 @@ from mypyc.irbuild.mapper import Mapper
 
 
 DictEntry = Tuple[Optional[Value], Value]
+
+
+# From CPython
+PY_VECTORCALL_ARGUMENTS_OFFSET = 1 << (PLATFORM_SIZE * 8 - 1)  # type: Final
 
 
 class LowLevelIRBuilder:
@@ -388,7 +394,8 @@ class LowLevelIRBuilder:
             value = self.call_c(py_vectorcall_method_op,
                                 [method_name_reg,
                                  arg_ptr,
-                                 Integer((num_pos + 1) | (1 << 63), c_size_t_rprimitive),
+                                 Integer((num_pos + 1) | PY_VECTORCALL_ARGUMENTS_OFFSET,
+                                         c_size_t_rprimitive),
                                  keywords],
                                 line)
             # Make sure arguments won't be freed until after the call.

--- a/mypyc/options.py
+++ b/mypyc/options.py
@@ -21,7 +21,7 @@ class CompilerOptions:
             include_runtime_files if include_runtime_files is not None else not multi_file
         )
         # The target Python C API version. Overriding this is mostly
-        # useful for IR tests, since there's no guarantee that
+        # useful in IR tests, since there's no guarantee that
         # binaries are backward compatible even if no recent API
         # features are used.
         self.capi_version = capi_version or sys.version_info[:2]

--- a/mypyc/options.py
+++ b/mypyc/options.py
@@ -1,11 +1,16 @@
-from typing import Optional
+from typing import Optional, Tuple
+import sys
 
 
 class CompilerOptions:
-    def __init__(self, strip_asserts: bool = False, multi_file: bool = False,
-                 verbose: bool = False, separate: bool = False,
+    def __init__(self,
+                 strip_asserts: bool = False,
+                 multi_file: bool = False,
+                 verbose: bool = False,
+                 separate: bool = False,
                  target_dir: Optional[str] = None,
-                 include_runtime_files: Optional[bool] = None) -> None:
+                 include_runtime_files: Optional[bool] = None,
+                 capi_version: Optional[Tuple[int, int]] = None) -> None:
         self.strip_asserts = strip_asserts
         self.multi_file = multi_file
         self.verbose = verbose
@@ -15,3 +20,8 @@ class CompilerOptions:
         self.include_runtime_files = (
             include_runtime_files if include_runtime_files is not None else not multi_file
         )
+        # The target Python C API version. Overriding this is mostly
+        # useful for IR tests, since there's no guarantee that
+        # binaries are backward compatible even if no recent API
+        # features are used.
+        self.capi_version = capi_version or sys.version_info[:2]

--- a/mypyc/primitives/generic_ops.py
+++ b/mypyc/primitives/generic_ops.py
@@ -195,6 +195,12 @@ py_call_op = custom_op(
     var_arg_type=object_rprimitive,
     extra_int_constants=[(0, pointer_rprimitive)])
 
+py_vectorcall_op = custom_op(
+    arg_types=[object_rprimitive, pointer_rprimitive, pointer_rprimitive, object_rprimitive],
+    return_type=object_rprimitive,
+    c_function_name='PyObject_Vectorcall',
+    error_kind=ERR_MAGIC)
+
 # Call callable object with positional + keyword args: func(*args, **kwargs)
 # Arguments are (func, *args tuple, **kwargs dict).
 py_call_with_kwargs_op = custom_op(

--- a/mypyc/primitives/generic_ops.py
+++ b/mypyc/primitives/generic_ops.py
@@ -11,7 +11,8 @@ check that the priorities are configured properly.
 
 from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC
 from mypyc.ir.rtypes import (
-    object_rprimitive, int_rprimitive, bool_rprimitive, c_int_rprimitive, pointer_rprimitive
+    object_rprimitive, int_rprimitive, bool_rprimitive, c_int_rprimitive, pointer_rprimitive,
+    object_pointer_rprimitive, c_size_t_rprimitive
 )
 from mypyc.primitives.registry import (
     binary_op, c_unary_op, method_op, function_op, custom_op, ERR_NEG_INT
@@ -196,9 +197,12 @@ py_call_op = custom_op(
     extra_int_constants=[(0, pointer_rprimitive)])
 
 py_vectorcall_op = custom_op(
-    arg_types=[object_rprimitive, pointer_rprimitive, pointer_rprimitive, object_rprimitive],
+    arg_types=[object_rprimitive,  # Callable
+               object_pointer_rprimitive,  # Args (PyObject **)
+               c_size_t_rprimitive,  # Number of args
+               object_rprimitive],  # Keyword args tuple (or NULL)
     return_type=object_rprimitive,
-    c_function_name='PyObject_Vectorcall',
+    c_function_name='_PyObject_Vectorcall',
     error_kind=ERR_MAGIC)
 
 # Call callable object with positional + keyword args: func(*args, **kwargs)

--- a/mypyc/primitives/generic_ops.py
+++ b/mypyc/primitives/generic_ops.py
@@ -196,6 +196,7 @@ py_call_op = custom_op(
     var_arg_type=object_rprimitive,
     extra_int_constants=[(0, pointer_rprimitive)])
 
+# Call callable object using positional and/or keyword arguments (Python 3.8+)
 py_vectorcall_op = custom_op(
     arg_types=[object_rprimitive,  # Callable
                object_pointer_rprimitive,  # Args (PyObject **)
@@ -205,13 +206,14 @@ py_vectorcall_op = custom_op(
     c_function_name='_PyObject_Vectorcall',
     error_kind=ERR_MAGIC)
 
+# Call method using positional and/or keyword arguments (Python 3.9+)
 py_vectorcall_method_op = custom_op(
     arg_types=[object_rprimitive,  # Method name
                object_pointer_rprimitive,  # Args, including self (PyObject **)
                c_size_t_rprimitive,  # Number of positional args, including self
                object_rprimitive],  # Keyword arg names tuple (or NULL)
     return_type=object_rprimitive,
-    c_function_name='_PyObject_VectorcallMethod',
+    c_function_name='PyObject_VectorcallMethod',
     error_kind=ERR_MAGIC)
 
 # Call callable object with positional + keyword args: func(*args, **kwargs)

--- a/mypyc/primitives/generic_ops.py
+++ b/mypyc/primitives/generic_ops.py
@@ -205,6 +205,15 @@ py_vectorcall_op = custom_op(
     c_function_name='_PyObject_Vectorcall',
     error_kind=ERR_MAGIC)
 
+py_vectorcall_method_op = custom_op(
+    arg_types=[object_rprimitive,  # Method name
+               object_pointer_rprimitive,  # Args (PyObject **)
+               c_size_t_rprimitive,  # Number of args
+               object_rprimitive],  # Keyword args tuple (or NULL)
+    return_type=object_rprimitive,
+    c_function_name='_PyObject_VectorcallMethod',
+    error_kind=ERR_MAGIC)
+
 # Call callable object with positional + keyword args: func(*args, **kwargs)
 # Arguments are (func, *args tuple, **kwargs dict).
 py_call_with_kwargs_op = custom_op(

--- a/mypyc/primitives/generic_ops.py
+++ b/mypyc/primitives/generic_ops.py
@@ -199,17 +199,17 @@ py_call_op = custom_op(
 py_vectorcall_op = custom_op(
     arg_types=[object_rprimitive,  # Callable
                object_pointer_rprimitive,  # Args (PyObject **)
-               c_size_t_rprimitive,  # Number of args
-               object_rprimitive],  # Keyword args tuple (or NULL)
+               c_size_t_rprimitive,  # Number of positional args
+               object_rprimitive],  # Keyword arg names tuple (or NULL)
     return_type=object_rprimitive,
     c_function_name='_PyObject_Vectorcall',
     error_kind=ERR_MAGIC)
 
 py_vectorcall_method_op = custom_op(
     arg_types=[object_rprimitive,  # Method name
-               object_pointer_rprimitive,  # Args (PyObject **)
-               c_size_t_rprimitive,  # Number of args
-               object_rprimitive],  # Keyword args tuple (or NULL)
+               object_pointer_rprimitive,  # Args, including self (PyObject **)
+               c_size_t_rprimitive,  # Number of positional args, including self
+               object_rprimitive],  # Keyword arg names tuple (or NULL)
     return_type=object_rprimitive,
     c_function_name='_PyObject_VectorcallMethod',
     error_kind=ERR_MAGIC)

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -14,7 +14,7 @@ coercion is necessary first.
 """
 
 from mypyc.ir.rtypes import (
-    RType, RUnion, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor, RStruct,
+    RType, RUnion, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor, RStruct, RArray,
     is_int_rprimitive, is_short_int_rprimitive, is_bool_rprimitive, is_bit_rprimitive
 )
 from mypyc.subtype import is_subtype
@@ -55,6 +55,9 @@ class RTSubtypeVisitor(RTypeVisitor[bool]):
 
     def visit_rstruct(self, left: RStruct) -> bool:
         return isinstance(self.right, RStruct) and self.right.name == left.name
+
+    def visit_rarray(self, left: RArray) -> bool:
+        return left == self.right
 
     def visit_rvoid(self, left: RVoid) -> bool:
         return isinstance(self.right, RVoid)

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -1,7 +1,7 @@
 """Same type check for RTypes."""
 
 from mypyc.ir.rtypes import (
-    RType, RTypeVisitor, RInstance, RPrimitive, RTuple, RVoid, RUnion, RStruct
+    RType, RTypeVisitor, RInstance, RPrimitive, RTuple, RVoid, RUnion, RStruct, RArray
 )
 from mypyc.ir.func_ir import FuncSignature
 
@@ -54,6 +54,9 @@ class SameTypeVisitor(RTypeVisitor[bool]):
 
     def visit_rstruct(self, left: RStruct) -> bool:
         return isinstance(self.right, RStruct) and self.right.name == left.name
+
+    def visit_rarray(self, left: RArray) -> bool:
+        return left == self.right
 
     def visit_rvoid(self, left: RVoid) -> bool:
         return isinstance(self.right, RVoid)

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -1,7 +1,7 @@
 """Subtype check for RTypes."""
 
 from mypyc.ir.rtypes import (
-    RType, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor, RUnion, RStruct,
+    RType, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor, RUnion, RStruct, RArray,
     is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive, is_short_int_rprimitive,
     is_object_rprimitive, is_bit_rprimitive
 )
@@ -63,6 +63,9 @@ class SubtypeVisitor(RTypeVisitor[bool]):
 
     def visit_rstruct(self, left: RStruct) -> bool:
         return isinstance(self.right, RStruct) and self.right.name == left.name
+
+    def visit_rarray(self, left: RArray) -> bool:
+        return left == self.right
 
     def visit_rvoid(self, left: RVoid) -> bool:
         return isinstance(self.right, RVoid)

--- a/mypyc/test-data/irbuild-any.test
+++ b/mypyc/test-data/irbuild-any.test
@@ -122,10 +122,11 @@ L0:
     r11 = PyList_New(2)
     r12 = box(int, n)
     r13 = get_element_ptr r11 ob_item :: PyListObject
-    r14 = load_mem r13, r11 :: ptr*
-    set_mem r14, a, r11 :: builtins.object*
+    r14 = load_mem r13 :: ptr*
+    set_mem r14, a :: builtins.object*
     r15 = r14 + WORD_SIZE*1
-    set_mem r15, r12, r11 :: builtins.object*
+    set_mem r15, r12 :: builtins.object*
+    keep_alive r11
     return 1
 def f3(a, n):
     a :: object

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -820,8 +820,9 @@ L0:
     r1 = PyList_New(1)
     r2 = box(short_int, 2)
     r3 = get_element_ptr r1 ob_item :: PyListObject
-    r4 = load_mem r3, r1 :: ptr*
-    set_mem r4, r2, r1 :: builtins.object*
+    r4 = load_mem r3 :: ptr*
+    set_mem r4, r2 :: builtins.object*
+    keep_alive r1
     r5 = g(r1)
     r6 = box(None, 1)
     r7 = g(r6)
@@ -849,8 +850,9 @@ L0:
     r1 = g(r0)
     r2 = PyList_New(1)
     r3 = get_element_ptr r2 ob_item :: PyListObject
-    r4 = load_mem r3, r2 :: ptr*
-    set_mem r4, y, r2 :: builtins.object*
+    r4 = load_mem r3 :: ptr*
+    set_mem r4, y :: builtins.object*
+    keep_alive r2
     a = r2
     r5 = (2, 4)
     r6 = box(tuple[int, int], r5)
@@ -1311,7 +1313,8 @@ def lst(x):
     r3 :: bit
 L0:
     r0 = get_element_ptr x ob_size :: PyVarObject
-    r1 = load_mem r0, x :: native_int*
+    r1 = load_mem r0 :: native_int*
+    keep_alive x
     r2 = r1 << 1
     r3 = r2 != 0
     if r3 goto L1 else goto L2 :: bool
@@ -1721,8 +1724,9 @@ L0:
     r4 = PyList_New(1)
     r5 = box(short_int, 2)
     r6 = get_element_ptr r4 ob_item :: PyListObject
-    r7 = load_mem r6, r4 :: ptr*
-    set_mem r7, r5, r4 :: builtins.object*
+    r7 = load_mem r6 :: ptr*
+    set_mem r7, r5 :: builtins.object*
+    keep_alive r4
     r8 = box(tuple[int, int], r0)
     r9 = CPyList_Extend(r4, r8)
     r10 = PyList_AsTuple(r4)
@@ -1921,16 +1925,18 @@ L0:
     r3 = box(short_int, 4)
     r4 = box(short_int, 6)
     r5 = get_element_ptr r1 ob_item :: PyListObject
-    r6 = load_mem r5, r1 :: ptr*
-    set_mem r6, r2, r1 :: builtins.object*
+    r6 = load_mem r5 :: ptr*
+    set_mem r6, r2 :: builtins.object*
     r7 = r6 + WORD_SIZE*1
-    set_mem r7, r3, r1 :: builtins.object*
+    set_mem r7, r3 :: builtins.object*
     r8 = r6 + WORD_SIZE*2
-    set_mem r8, r4, r1 :: builtins.object*
+    set_mem r8, r4 :: builtins.object*
+    keep_alive r1
     r9 = 0
 L1:
     r10 = get_element_ptr r1 ob_size :: PyVarObject
-    r11 = load_mem r10, r1 :: native_int*
+    r11 = load_mem r10 :: native_int*
+    keep_alive r1
     r12 = r11 << 1
     r13 = r9 < r12 :: signed
     if r13 goto L2 else goto L14 :: bool
@@ -2018,16 +2024,18 @@ L0:
     r3 = box(short_int, 4)
     r4 = box(short_int, 6)
     r5 = get_element_ptr r1 ob_item :: PyListObject
-    r6 = load_mem r5, r1 :: ptr*
-    set_mem r6, r2, r1 :: builtins.object*
+    r6 = load_mem r5 :: ptr*
+    set_mem r6, r2 :: builtins.object*
     r7 = r6 + WORD_SIZE*1
-    set_mem r7, r3, r1 :: builtins.object*
+    set_mem r7, r3 :: builtins.object*
     r8 = r6 + WORD_SIZE*2
-    set_mem r8, r4, r1 :: builtins.object*
+    set_mem r8, r4 :: builtins.object*
+    keep_alive r1
     r9 = 0
 L1:
     r10 = get_element_ptr r1 ob_size :: PyVarObject
-    r11 = load_mem r10, r1 :: native_int*
+    r11 = load_mem r10 :: native_int*
+    keep_alive r1
     r12 = r11 << 1
     r13 = r9 < r12 :: signed
     if r13 goto L2 else goto L14 :: bool
@@ -2114,7 +2122,8 @@ L0:
     r0 = 0
 L1:
     r1 = get_element_ptr l ob_size :: PyVarObject
-    r2 = load_mem r1, l :: native_int*
+    r2 = load_mem r1 :: native_int*
+    keep_alive l
     r3 = r2 << 1
     r4 = r0 < r3 :: signed
     if r4 goto L2 else goto L4 :: bool
@@ -2136,7 +2145,8 @@ L4:
     r12 = 0
 L5:
     r13 = get_element_ptr l ob_size :: PyVarObject
-    r14 = load_mem r13, l :: native_int*
+    r14 = load_mem r13 :: native_int*
+    keep_alive l
     r15 = r14 << 1
     r16 = r12 < r15 :: signed
     if r16 goto L6 else goto L8 :: bool
@@ -2652,12 +2662,13 @@ L4:
     r80 = box(short_int, 4)
     r81 = box(short_int, 6)
     r82 = get_element_ptr r78 ob_item :: PyListObject
-    r83 = load_mem r82, r78 :: ptr*
-    set_mem r83, r79, r78 :: builtins.object*
+    r83 = load_mem r82 :: ptr*
+    set_mem r83, r79 :: builtins.object*
     r84 = r83 + WORD_SIZE*1
-    set_mem r84, r80, r78 :: builtins.object*
+    set_mem r84, r80 :: builtins.object*
     r85 = r83 + WORD_SIZE*2
-    set_mem r85, r81, r78 :: builtins.object*
+    set_mem r85, r81 :: builtins.object*
+    keep_alive r78
     r86 = __main__.globals :: static
     r87 = 'Bar'
     r88 = CPyDict_GetItem(r86, r87)

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -52,8 +52,9 @@ L0:
     c.x = 10; r1 = is_error
     r2 = PyList_New(1)
     r3 = get_element_ptr r2 ob_item :: PyListObject
-    r4 = load_mem r3, r2 :: ptr*
-    set_mem r4, c, r2 :: builtins.object*
+    r4 = load_mem r3 :: ptr*
+    set_mem r4, c :: builtins.object*
+    keep_alive r2
     a = r2
     r5 = CPyList_GetItemShort(a, 0)
     r6 = cast(__main__.C, r5)
@@ -492,7 +493,8 @@ def f(x):
 L0:
     r0 = __main__.B :: type
     r1 = get_element_ptr x ob_type :: PyObject
-    r2 = load_mem r1, x :: builtins.object*
+    r2 = load_mem r1 :: builtins.object*
+    keep_alive x
     r3 = r2 == r0
     if r3 goto L1 else goto L2 :: bool
 L1:
@@ -530,7 +532,8 @@ def f(x):
 L0:
     r0 = __main__.A :: type
     r1 = get_element_ptr x ob_type :: PyObject
-    r2 = load_mem r1, x :: builtins.object*
+    r2 = load_mem r1 :: builtins.object*
+    keep_alive x
     r3 = r2 == r0
     if r3 goto L1 else goto L2 :: bool
 L1:
@@ -539,7 +542,8 @@ L1:
 L2:
     r5 = __main__.B :: type
     r6 = get_element_ptr x ob_type :: PyObject
-    r7 = load_mem r6, x :: builtins.object*
+    r7 = load_mem r6 :: builtins.object*
+    keep_alive x
     r8 = r7 == r5
     r4 = r8
 L3:
@@ -575,7 +579,8 @@ def f(x):
 L0:
     r0 = __main__.A :: type
     r1 = get_element_ptr x ob_type :: PyObject
-    r2 = load_mem r1, x :: builtins.object*
+    r2 = load_mem r1 :: builtins.object*
+    keep_alive x
     r3 = r2 == r0
     if r3 goto L1 else goto L2 :: bool
 L1:
@@ -584,7 +589,8 @@ L1:
 L2:
     r5 = __main__.R :: type
     r6 = get_element_ptr x ob_type :: PyObject
-    r7 = load_mem r6, x :: builtins.object*
+    r7 = load_mem r6 :: builtins.object*
+    keep_alive x
     r8 = r7 == r5
     r4 = r8
 L3:
@@ -624,7 +630,8 @@ def f(x):
 L0:
     r0 = __main__.A :: type
     r1 = get_element_ptr x ob_type :: PyObject
-    r2 = load_mem r1, x :: builtins.object*
+    r2 = load_mem r1 :: builtins.object*
+    keep_alive x
     r3 = r2 == r0
     if r3 goto L1 else goto L2 :: bool
 L1:
@@ -633,7 +640,8 @@ L1:
 L2:
     r5 = __main__.C :: type
     r6 = get_element_ptr x ob_type :: PyObject
-    r7 = load_mem r6, x :: builtins.object*
+    r7 = load_mem r6 :: builtins.object*
+    keep_alive x
     r8 = r7 == r5
     r4 = r8
 L3:

--- a/mypyc/test-data/irbuild-generics.test
+++ b/mypyc/test-data/irbuild-generics.test
@@ -22,8 +22,9 @@ L0:
     r0 = CPyList_GetItemShort(x, 0)
     r1 = PyList_New(1)
     r2 = get_element_ptr r1 ob_item :: PyListObject
-    r3 = load_mem r2, r1 :: ptr*
-    set_mem r3, r0, r1 :: builtins.object*
+    r3 = load_mem r2 :: ptr*
+    set_mem r3, r0 :: builtins.object*
+    keep_alive r1
     return r1
 def h(x, y):
     x :: int

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -85,10 +85,11 @@ L0:
     r1 = box(short_int, 2)
     r2 = box(short_int, 4)
     r3 = get_element_ptr r0 ob_item :: PyListObject
-    r4 = load_mem r3, r0 :: ptr*
-    set_mem r4, r1, r0 :: builtins.object*
+    r4 = load_mem r3 :: ptr*
+    set_mem r4, r1 :: builtins.object*
     r5 = r4 + WORD_SIZE*1
-    set_mem r5, r2, r0 :: builtins.object*
+    set_mem r5, r2 :: builtins.object*
+    keep_alive r0
     x = r0
     return 1
 
@@ -109,8 +110,9 @@ L0:
     r1 = PyList_New(1)
     r2 = box(short_int, 8)
     r3 = get_element_ptr r1 ob_item :: PyListObject
-    r4 = load_mem r3, r1 :: ptr*
-    set_mem r4, r2, r1 :: builtins.object*
+    r4 = load_mem r3 :: ptr*
+    set_mem r4, r2 :: builtins.object*
+    keep_alive r1
     r5 = CPySequence_RMultiply(6, r1)
     b = r5
     return 1
@@ -127,7 +129,8 @@ def f(a):
     r2 :: short_int
 L0:
     r0 = get_element_ptr a ob_size :: PyVarObject
-    r1 = load_mem r0, a :: native_int*
+    r1 = load_mem r0 :: native_int*
+    keep_alive a
     r2 = r1 << 1
     return r2
 
@@ -167,7 +170,8 @@ def increment(l):
     r9 :: short_int
 L0:
     r0 = get_element_ptr l ob_size :: PyVarObject
-    r1 = load_mem r0, l :: native_int*
+    r1 = load_mem r0 :: native_int*
+    keep_alive l
     r2 = r1 << 1
     r3 = 0
     i = r3
@@ -204,10 +208,11 @@ L0:
     r1 = box(short_int, 2)
     r2 = box(short_int, 4)
     r3 = get_element_ptr r0 ob_item :: PyListObject
-    r4 = load_mem r3, r0 :: ptr*
-    set_mem r4, r1, r0 :: builtins.object*
+    r4 = load_mem r3 :: ptr*
+    set_mem r4, r1 :: builtins.object*
     r5 = r4 + WORD_SIZE*1
-    set_mem r5, r2, r0 :: builtins.object*
+    set_mem r5, r2 :: builtins.object*
+    keep_alive r0
     r6 = CPyList_Extend(r0, x)
     r7 = CPyList_Extend(r0, y)
     r8 = box(short_int, 6)

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -319,7 +319,8 @@ def get(o):
 L0:
     r0 = __main__.A :: type
     r1 = get_element_ptr o ob_type :: PyObject
-    r2 = load_mem r1, o :: builtins.object*
+    r2 = load_mem r1 :: builtins.object*
+    keep_alive o
     r3 = r2 == r0
     if r3 goto L1 else goto L2 :: bool
 L1:
@@ -397,7 +398,8 @@ def g(o):
 L0:
     r0 = __main__.A :: type
     r1 = get_element_ptr o ob_type :: PyObject
-    r2 = load_mem r1, o :: builtins.object*
+    r2 = load_mem r1 :: builtins.object*
+    keep_alive o
     r3 = r2 == r0
     if r3 goto L1 else goto L2 :: bool
 L1:
@@ -409,7 +411,8 @@ L1:
 L2:
     r8 = __main__.B :: type
     r9 = get_element_ptr o ob_type :: PyObject
-    r10 = load_mem r9, o :: builtins.object*
+    r10 = load_mem r9 :: builtins.object*
+    keep_alive o
     r11 = r10 == r8
     if r11 goto L3 else goto L4 :: bool
 L3:
@@ -461,7 +464,8 @@ def f(o):
 L0:
     r0 = __main__.A :: type
     r1 = get_element_ptr o ob_type :: PyObject
-    r2 = load_mem r1, o :: builtins.object*
+    r2 = load_mem r1 :: builtins.object*
+    keep_alive o
     r3 = r2 == r0
     if r3 goto L1 else goto L2 :: bool
 L1:
@@ -492,7 +496,8 @@ def g(o):
 L0:
     r0 = __main__.A :: type
     r1 = get_element_ptr o ob_type :: PyObject
-    r2 = load_mem r1, o :: builtins.object*
+    r2 = load_mem r1 :: builtins.object*
+    keep_alive o
     r3 = r2 == r0
     if r3 goto L1 else goto L2 :: bool
 L1:

--- a/mypyc/test-data/irbuild-set.test
+++ b/mypyc/test-data/irbuild-set.test
@@ -81,7 +81,8 @@ L0:
     r8 = PySet_Add(r0, r7)
     r9 = r8 >= 0 :: signed
     r10 = get_element_ptr r0 used :: PySetObject
-    r11 = load_mem r10, r0 :: native_int*
+    r11 = load_mem r10 :: native_int*
+    keep_alive r0
     r12 = r11 << 1
     return r12
 
@@ -260,4 +261,3 @@ L0:
     r12 = PySet_Add(r0, r11)
     r13 = r12 >= 0 :: signed
     return r0
-

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -311,7 +311,8 @@ L0:
     r0 = 0
 L1:
     r1 = get_element_ptr ls ob_size :: PyVarObject
-    r2 = load_mem r1, ls :: native_int*
+    r2 = load_mem r1 :: native_int*
+    keep_alive ls
     r3 = r2 << 1
     r4 = r0 < r3 :: signed
     if r4 goto L2 else goto L4 :: bool
@@ -766,10 +767,11 @@ L0:
     r1 = box(short_int, 2)
     r2 = box(short_int, 4)
     r3 = get_element_ptr r0 ob_item :: PyListObject
-    r4 = load_mem r3, r0 :: ptr*
-    set_mem r4, r1, r0 :: builtins.object*
+    r4 = load_mem r3 :: ptr*
+    set_mem r4, r1 :: builtins.object*
     r5 = r4 + WORD_SIZE*1
-    set_mem r5, r2, r0 :: builtins.object*
+    set_mem r5, r2 :: builtins.object*
+    keep_alive r0
     l = r0
     r6 = box(short_int, 2)
     r7 = PyObject_DelItem(l, r6)
@@ -799,20 +801,21 @@ L0:
     r6 = box(short_int, 12)
     r7 = box(short_int, 14)
     r8 = get_element_ptr r0 ob_item :: PyListObject
-    r9 = load_mem r8, r0 :: ptr*
-    set_mem r9, r1, r0 :: builtins.object*
+    r9 = load_mem r8 :: ptr*
+    set_mem r9, r1 :: builtins.object*
     r10 = r9 + WORD_SIZE*1
-    set_mem r10, r2, r0 :: builtins.object*
+    set_mem r10, r2 :: builtins.object*
     r11 = r9 + WORD_SIZE*2
-    set_mem r11, r3, r0 :: builtins.object*
+    set_mem r11, r3 :: builtins.object*
     r12 = r9 + WORD_SIZE*3
-    set_mem r12, r4, r0 :: builtins.object*
+    set_mem r12, r4 :: builtins.object*
     r13 = r9 + WORD_SIZE*4
-    set_mem r13, r5, r0 :: builtins.object*
+    set_mem r13, r5 :: builtins.object*
     r14 = r9 + WORD_SIZE*5
-    set_mem r14, r6, r0 :: builtins.object*
+    set_mem r14, r6 :: builtins.object*
     r15 = r9 + WORD_SIZE*6
-    set_mem r15, r7, r0 :: builtins.object*
+    set_mem r15, r7 :: builtins.object*
+    keep_alive r0
     l = r0
     r16 = box(short_int, 2)
     r17 = PyObject_DelItem(l, r16)
@@ -958,7 +961,8 @@ L0:
     r1 = 0
 L1:
     r2 = get_element_ptr a ob_size :: PyVarObject
-    r3 = load_mem r2, a :: native_int*
+    r3 = load_mem r2 :: native_int*
+    keep_alive a
     r4 = r3 << 1
     r5 = r1 < r4 :: signed
     if r5 goto L2 else goto L4 :: bool
@@ -1039,7 +1043,8 @@ L0:
     r1 = PyObject_GetIter(b)
 L1:
     r2 = get_element_ptr a ob_size :: PyVarObject
-    r3 = load_mem r2, a :: native_int*
+    r3 = load_mem r2 :: native_int*
+    keep_alive a
     r4 = r3 << 1
     r5 = r0 < r4 :: signed
     if r5 goto L2 else goto L7 :: bool
@@ -1093,7 +1098,8 @@ L1:
     if is_error(r3) goto L6 else goto L2
 L2:
     r4 = get_element_ptr b ob_size :: PyVarObject
-    r5 = load_mem r4, b :: native_int*
+    r5 = load_mem r4 :: native_int*
+    keep_alive b
     r6 = r5 << 1
     r7 = r1 < r6 :: signed
     if r7 goto L3 else goto L6 :: bool

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -67,7 +67,8 @@ def f(x):
     r2 :: short_int
 L0:
     r0 = get_element_ptr x ob_size :: PyVarObject
-    r1 = load_mem r0, x :: native_int*
+    r1 = load_mem r0 :: native_int*
+    keep_alive x
     r2 = r1 << 1
     return r2
 
@@ -110,10 +111,11 @@ L0:
     r1 = box(short_int, 2)
     r2 = box(short_int, 4)
     r3 = get_element_ptr r0 ob_item :: PyListObject
-    r4 = load_mem r3, r0 :: ptr*
-    set_mem r4, r1, r0 :: builtins.object*
+    r4 = load_mem r3 :: ptr*
+    set_mem r4, r1 :: builtins.object*
     r5 = r4 + WORD_SIZE*1
-    set_mem r5, r2, r0 :: builtins.object*
+    set_mem r5, r2 :: builtins.object*
+    keep_alive r0
     r6 = CPyList_Extend(r0, x)
     r7 = CPyList_Extend(r0, y)
     r8 = box(short_int, 6)
@@ -142,7 +144,8 @@ L0:
     r0 = 0
 L1:
     r1 = get_element_ptr xs ob_size :: PyVarObject
-    r2 = load_mem r1, xs :: native_int*
+    r2 = load_mem r1 :: native_int*
+    keep_alive xs
     r3 = r2 << 1
     r4 = r0 < r3 :: signed
     if r4 goto L2 else goto L4 :: bool

--- a/mypyc/test-data/irbuild-vectorcall.test
+++ b/mypyc/test-data/irbuild-vectorcall.test
@@ -96,7 +96,7 @@ L0:
 from typing import Any
 
 def f(o: Any) -> None:
-    # On Python 3.8 vectorcalls are only faster with keyword args
+    # Python 3.9 has a new API for calling methods
     o.m('x')
     o.m('x', 'y', a='z')
 [out]
@@ -132,6 +132,7 @@ L0:
 from typing import Any
 
 def f(o: Any) -> None:
+   # The IR is slightly different on 32-bit platforms
     o.m('x', a='y')
 [out]
 def f(o):

--- a/mypyc/test-data/irbuild-vectorcall.test
+++ b/mypyc/test-data/irbuild-vectorcall.test
@@ -1,3 +1,8 @@
+-- Test cases for calls using the vectorcall API (Python 3.8+)
+--
+-- Vectorcalls are faster than the legacy API, especially with keyword arguments,
+-- since there is no need to allocate a temporary dictionary for keyword args.
+
 [case testeVectorcallBasic_python3_8]
 from typing import Any
 
@@ -53,4 +58,95 @@ L0:
     r10 = ('a', 'b')
     r11 = _PyObject_Vectorcall(c, r9, 1, r10)
     keep_alive r5, r6, r7
+    return 1
+
+[case testVectorcallMethod_python3_8]
+from typing import Any
+
+def f(o: Any) -> None:
+    # On Python 3.8 vectorcalls are only faster with keyword args
+    o.m('x')
+    o.m('x', a='y')
+[out]
+def f(o):
+    o :: object
+    r0, r1 :: str
+    r2 :: object
+    r3, r4, r5 :: str
+    r6 :: object
+    r7 :: object[2]
+    r8 :: object_ptr
+    r9, r10 :: object
+L0:
+    r0 = 'x'
+    r1 = 'm'
+    r2 = CPyObject_CallMethodObjArgs(o, r1, r0, 0)
+    r3 = 'x'
+    r4 = 'y'
+    r5 = 'm'
+    r6 = CPyObject_GetAttr(o, r5)
+    r7 = [r3, r4]
+    r8 = load_address r7
+    r9 = ('a',)
+    r10 = _PyObject_Vectorcall(r6, r8, 1, r9)
+    keep_alive r3, r4
+    return 1
+
+[case testVectorcallMethod_python3_9_64bit]
+from typing import Any
+
+def f(o: Any) -> None:
+    # On Python 3.8 vectorcalls are only faster with keyword args
+    o.m('x')
+    o.m('x', 'y', a='z')
+[out]
+def f(o):
+    o :: object
+    r0, r1 :: str
+    r2 :: object[2]
+    r3 :: object_ptr
+    r4 :: object
+    r5, r6, r7, r8 :: str
+    r9 :: object[4]
+    r10 :: object_ptr
+    r11, r12 :: object
+L0:
+    r0 = 'x'
+    r1 = 'm'
+    r2 = [o, r0]
+    r3 = load_address r2
+    r4 = PyObject_VectorcallMethod(r1, r3, 9223372036854775810, 0)
+    keep_alive o, r0
+    r5 = 'x'
+    r6 = 'y'
+    r7 = 'z'
+    r8 = 'm'
+    r9 = [o, r5, r6, r7]
+    r10 = load_address r9
+    r11 = ('a',)
+    r12 = PyObject_VectorcallMethod(r8, r10, 9223372036854775811, r11)
+    keep_alive o, r5, r6, r7
+    return 1
+
+[case testVectorcallMethod_python3_9_32bit]
+from typing import Any
+
+def f(o: Any) -> None:
+    o.m('x', a='y')
+[out]
+def f(o):
+    o :: object
+    r0, r1, r2 :: str
+    r3 :: object[3]
+    r4 :: object_ptr
+    r5, r6 :: object
+L0:
+    r0 = 'x'
+    r1 = 'y'
+    r2 = 'm'
+    r3 = [o, r0, r1]
+    r4 = load_address r3
+    r5 = ('a',)
+    r6 = PyObject_VectorcallMethod(r2, r4, 2147483650, r5)
+    keep_alive o, r0, r1
     return 1

--- a/mypyc/test-data/irbuild-vectorcall.test
+++ b/mypyc/test-data/irbuild-vectorcall.test
@@ -1,0 +1,56 @@
+[case testeVectorcallBasic_python3_8]
+from typing import Any
+
+def f(c: Any) -> None:
+    c()
+    c('x', 'y')
+[out]
+def f(c):
+    c, r0 :: object
+    r1, r2 :: str
+    r3 :: object[2]
+    r4 :: object_ptr
+    r5 :: object
+L0:
+    r0 = _PyObject_Vectorcall(c, 0, 0, 0)
+    r1 = 'x'
+    r2 = 'y'
+    r3 = [r1, r2]
+    r4 = load_address r3
+    r5 = _PyObject_Vectorcall(c, r4, 2, 0)
+    keep_alive r1, r2
+    return 1
+
+[case testVectorcallKeywords_python3_8]
+from typing import Any
+
+def f(c: Any) -> None:
+    c(x='a')
+    c('x', a='y', b='z')
+[out]
+def f(c):
+    c :: object
+    r0 :: str
+    r1 :: object[1]
+    r2 :: object_ptr
+    r3, r4 :: object
+    r5, r6, r7 :: str
+    r8 :: object[3]
+    r9 :: object_ptr
+    r10, r11 :: object
+L0:
+    r0 = 'a'
+    r1 = [r0]
+    r2 = load_address r1
+    r3 = ('x',)
+    r4 = _PyObject_Vectorcall(c, r2, 0, r3)
+    keep_alive r0
+    r5 = 'x'
+    r6 = 'y'
+    r7 = 'z'
+    r8 = [r5, r6, r7]
+    r9 = load_address r8
+    r10 = ('a', 'b')
+    r11 = _PyObject_Vectorcall(c, r9, 1, r10)
+    keep_alive r5, r6, r7
+    return 1

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -865,7 +865,7 @@ L11:
     xdec_ref y :: int
     goto L6
 
-[case testVectorcall]
+[case testVectorcall_python3_8]
 from typing import Any
 
 def call(f: Any, x: int) -> int:

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -864,3 +864,28 @@ L10:
 L11:
     xdec_ref y :: int
     goto L6
+
+[case testVectorcall]
+from typing import Any
+
+def call(f: Any, x: int) -> int:
+    return f(x)
+[out]
+def call(f, x):
+    f :: object
+    x :: int
+    r0 :: object
+    r1 :: object[1]
+    r2 :: object_ptr
+    r3 :: object
+    r4 :: int
+L0:
+    inc_ref x :: int
+    r0 = box(int, x)
+    r1 = [r0]
+    r2 = load_address r1
+    r3 = _PyObject_Vectorcall(f, r2, 1, 0)
+    dec_ref r0
+    r4 = unbox(int, r3)
+    dec_ref r3
+    return r4

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -551,10 +551,10 @@ L0:
     r1 = box(short_int, 0)
     r2 = box(short_int, 2)
     r3 = get_element_ptr r0 ob_item :: PyListObject
-    r4 = load_mem r3, r0 :: ptr*
-    set_mem r4, r1, r0 :: builtins.object*
+    r4 = load_mem r3 :: ptr*
+    set_mem r4, r1 :: builtins.object*
     r5 = r4 + WORD_SIZE*1
-    set_mem r5, r2, r0 :: builtins.object*
+    set_mem r5, r2 :: builtins.object*
     a = r0
     dec_ref a
     return 0
@@ -629,8 +629,8 @@ L0:
     r0 = C()
     r1 = PyList_New(1)
     r2 = get_element_ptr r1 ob_item :: PyListObject
-    r3 = load_mem r2, r1 :: ptr*
-    set_mem r3, r0, r1 :: builtins.object*
+    r3 = load_mem r2 :: ptr*
+    set_mem r3, r0 :: builtins.object*
     a = r1
     r4 = CPyList_GetItemShort(a, 0)
     dec_ref a
@@ -808,7 +808,7 @@ L0:
     r0 = PyList_New(0)
     x = r0
     r1 = get_element_ptr x ob_size :: PyVarObject
-    r2 = load_mem r1, x :: native_int*
+    r2 = load_mem r1 :: native_int*
     dec_ref x
     r3 = r2 << 1
     return r3

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -889,3 +889,30 @@ L0:
     r4 = unbox(int, r3)
     dec_ref r3
     return r4
+
+[case testVectorcallMethod_python3_9_64bit]
+from typing import Any
+
+def call(o: Any, x: int) -> int:
+    return o.m(x)
+[out]
+def call(o, x):
+    o :: object
+    x :: int
+    r0 :: str
+    r1 :: object
+    r2 :: object[2]
+    r3 :: object_ptr
+    r4 :: object
+    r5 :: int
+L0:
+    r0 = 'm'
+    inc_ref x :: int
+    r1 = box(int, x)
+    r2 = [o, r1]
+    r3 = load_address r2
+    r4 = PyObject_VectorcallMethod(r0, r3, 9223372036854775810, 0)
+    dec_ref r1
+    r5 = unbox(int, r4)
+    dec_ref r4
+    return r5

--- a/mypyc/test/test_array.py
+++ b/mypyc/test/test_array.py
@@ -1,0 +1,41 @@
+import unittest
+
+from mypyc.common import PLATFORM_SIZE
+from mypyc.ir.rtypes import (
+    RArray, RStruct, int_rprimitive, bool_rprimitive, compute_rtype_alignment, compute_rtype_size
+)
+
+
+class TestRArray(unittest.TestCase):
+    def test_basics(self) -> None:
+        a = RArray(int_rprimitive, 10)
+        assert a.item_type == int_rprimitive
+        assert a.length == 10
+
+    def test_str_conversion(self) -> None:
+        a = RArray(int_rprimitive, 10)
+        assert str(a) == 'int[10]'
+        assert repr(a) == '<RArray <RPrimitive builtins.int>[10]>'
+
+    def test_eq(self) -> None:
+        a = RArray(int_rprimitive, 10)
+        assert a == RArray(int_rprimitive, 10)
+        assert a != RArray(bool_rprimitive, 10)
+        assert a != RArray(int_rprimitive, 9)
+
+    def test_hash(self) -> None:
+        a = RArray(int_rprimitive, 10)
+        assert hash(RArray(int_rprimitive, 10)) == hash(RArray(int_rprimitive, 10))
+        assert hash(RArray(bool_rprimitive, 5)) == hash(RArray(bool_rprimitive, 5))
+
+    def test_alignment(self) -> None:
+        a = RArray(int_rprimitive, 10)
+        assert compute_rtype_alignment(a) == PLATFORM_SIZE
+        b = RArray(bool_rprimitive, 55)
+        assert compute_rtype_alignment(b) == 1
+
+    def test_size(self) -> None:
+        a = RArray(int_rprimitive, 9)
+        assert compute_rtype_size(a) == 9 * PLATFORM_SIZE
+        b = RArray(bool_rprimitive, 3)
+        assert compute_rtype_size(b) == 3

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -7,12 +7,12 @@ from mypy.ordered_dict import OrderedDict
 from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc.ir.ops import (
-    BasicBlock, Goto, Return, Integer, Assign, IncRef, DecRef, Branch,
+    BasicBlock, Goto, Return, Integer, Assign, AssignMulti, IncRef, DecRef, Branch,
     Call, Unbox, Box, TupleGet, GetAttr, SetAttr, Op, Value, CallC, IntOp, LoadMem,
     GetElementPtr, LoadAddress, ComparisonOp, SetMem, Register
 )
 from mypyc.ir.rtypes import (
-    RTuple, RInstance, RType, int_rprimitive, bool_rprimitive, list_rprimitive,
+    RTuple, RInstance, RType, RArray, int_rprimitive, bool_rprimitive, list_rprimitive,
     dict_rprimitive, object_rprimitive, c_int_rprimitive, short_int_rprimitive, int32_rprimitive,
     int64_rprimitive, RStruct, pointer_rprimitive
 )
@@ -305,6 +305,13 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def test_load_address(self) -> None:
         self.assert_emit(LoadAddress(object_rprimitive, "PyDict_Type"),
                          """cpy_r_r0 = (PyObject *)&PyDict_Type;""")
+
+    def test_assign_multi(self) -> None:
+        t = RArray(object_rprimitive, 2)
+        a = Register(t, 'a')
+        self.registers.append(a)
+        self.assert_emit(AssignMulti(a, [self.o, self.o2]),
+                         """PyObject *cpy_r_a[2] = {cpy_r_o, cpy_r_o2};""")
 
     def assert_emit(self, op: Op, expected: str) -> None:
         block = BasicBlock(0)

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -311,6 +311,13 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(AssignMulti(a, [self.o, self.o2]),
                          """PyObject *cpy_r_a[2] = {cpy_r_o, cpy_r_o2};""")
 
+    def test_long_unsigned(self) -> None:
+        a = Register(int64_rprimitive, 'a')
+        self.assert_emit(Assign(a, Integer(1 << 31, int64_rprimitive)),
+                         """cpy_r_a = 2147483648U;""")
+        self.assert_emit(Assign(a, Integer((1 << 31) - 1, int64_rprimitive)),
+                         """cpy_r_a = 2147483647;""")
+
     def assert_emit(self, op: Op, expected: str) -> None:
         block = BasicBlock(0)
         block.ops.append(op)

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -283,13 +283,11 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_r0 = cpy_r_o != cpy_r_o2;""")
 
     def test_load_mem(self) -> None:
-        self.assert_emit(LoadMem(bool_rprimitive, self.ptr, None),
-                         """cpy_r_r0 = *(char *)cpy_r_ptr;""")
-        self.assert_emit(LoadMem(bool_rprimitive, self.ptr, self.s1),
+        self.assert_emit(LoadMem(bool_rprimitive, self.ptr),
                          """cpy_r_r0 = *(char *)cpy_r_ptr;""")
 
     def test_set_mem(self) -> None:
-        self.assert_emit(SetMem(bool_rprimitive, self.ptr, self.b, None),
+        self.assert_emit(SetMem(bool_rprimitive, self.ptr, self.b),
                          """*(char *)cpy_r_ptr = cpy_r_b;""")
 
     def test_get_element_ptr(self) -> None:

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -10,7 +10,8 @@ from mypyc.common import TOP_LEVEL_NAME, IS_32_BIT_PLATFORM
 from mypyc.ir.pprint import format_func
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
-    assert_test_output, remove_comment_lines, replace_native_int, replace_word_size
+    assert_test_output, remove_comment_lines, replace_native_int, replace_word_size,
+    infer_ir_build_options_from_test_name
 )
 from mypyc.options import CompilerOptions
 
@@ -39,20 +40,16 @@ class TestGenOps(MypycDataSuite):
     optional_out = True
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
-        # Kind of hacky. Not sure if we need more structure here.
-        options = CompilerOptions(strip_asserts='StripAssert' in testcase.name,
-                                  capi_version=(3, 5))
         """Perform a runtime checking transformation test case."""
+        options = infer_ir_build_options_from_test_name(testcase.name)
+        if options is None:
+            # Skipped test case
+            return
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
             expected_output = replace_native_int(expected_output)
             expected_output = replace_word_size(expected_output)
             name = testcase.name
-            # If this is specific to some bit width, always pass if platform doesn't match.
-            if name.endswith('_64bit') and IS_32_BIT_PLATFORM:
-                return
-            if name.endswith('_32bit') and not IS_32_BIT_PLATFORM:
-                return
             try:
                 ir = build_ir_for_single_file(testcase.input, options)
             except CompileError as e:

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -6,14 +6,13 @@ from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase
 from mypy.errors import CompileError
 
-from mypyc.common import TOP_LEVEL_NAME, IS_32_BIT_PLATFORM
+from mypyc.common import TOP_LEVEL_NAME
 from mypyc.ir.pprint import format_func
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
     assert_test_output, remove_comment_lines, replace_native_int, replace_word_size,
     infer_ir_build_options_from_test_name
 )
-from mypyc.options import CompilerOptions
 
 files = [
     'irbuild-basic.test',

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -31,6 +31,7 @@ files = [
     'irbuild-str.test',
     'irbuild-strip-asserts.test',
     'irbuild-int.test',
+    'irbuild-vectorcall.test',
 ]
 
 

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -40,7 +40,8 @@ class TestGenOps(MypycDataSuite):
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         # Kind of hacky. Not sure if we need more structure here.
-        options = CompilerOptions(strip_asserts='StripAssert' in testcase.name)
+        options = CompilerOptions(strip_asserts='StripAssert' in testcase.name,
+                                  capi_version=(3, 5))
         """Perform a runtime checking transformation test case."""
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)

--- a/mypyc/test/test_rarray.py
+++ b/mypyc/test/test_rarray.py
@@ -1,3 +1,5 @@
+"""Unit tests for RArray types."""
+
 import unittest
 
 from mypyc.common import PLATFORM_SIZE

--- a/mypyc/test/test_rarray.py
+++ b/mypyc/test/test_rarray.py
@@ -4,7 +4,7 @@ import unittest
 
 from mypyc.common import PLATFORM_SIZE
 from mypyc.ir.rtypes import (
-    RArray, RStruct, int_rprimitive, bool_rprimitive, compute_rtype_alignment, compute_rtype_size
+    RArray, int_rprimitive, bool_rprimitive, compute_rtype_alignment, compute_rtype_size
 )
 
 
@@ -26,7 +26,6 @@ class TestRArray(unittest.TestCase):
         assert a != RArray(int_rprimitive, 9)
 
     def test_hash(self) -> None:
-        a = RArray(int_rprimitive, 10)
         assert hash(RArray(int_rprimitive, 10)) == hash(RArray(int_rprimitive, 10))
         assert hash(RArray(bool_rprimitive, 5)) == hash(RArray(bool_rprimitive, 5))
 

--- a/mypyc/test/test_refcount.py
+++ b/mypyc/test/test_refcount.py
@@ -16,7 +16,8 @@ from mypyc.transform.refcount import insert_ref_count_opcodes
 from mypyc.transform.uninit import insert_uninit_checks
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
-    assert_test_output, remove_comment_lines, replace_native_int, replace_word_size
+    assert_test_output, remove_comment_lines, replace_native_int, replace_word_size,
+    infer_ir_build_options_from_test_name
 )
 
 files = [
@@ -31,12 +32,14 @@ class TestRefCountTransform(MypycDataSuite):
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         """Perform a runtime checking transformation test case."""
+        options = infer_ir_build_options_from_test_name(testcase.name)
+        print(options.capi_version, testcase.name)
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
             expected_output = replace_native_int(expected_output)
             expected_output = replace_word_size(expected_output)
             try:
-                ir = build_ir_for_single_file(testcase.input)
+                ir = build_ir_for_single_file(testcase.input, options)
             except CompileError as e:
                 actual = e.messages
             else:

--- a/mypyc/test/test_refcount.py
+++ b/mypyc/test/test_refcount.py
@@ -33,7 +33,9 @@ class TestRefCountTransform(MypycDataSuite):
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         """Perform a runtime checking transformation test case."""
         options = infer_ir_build_options_from_test_name(testcase.name)
-        print(options.capi_version, testcase.name)
+        if options is None:
+            # Skipped test case
+            return
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
             expected_output = replace_native_int(expected_output)

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -248,7 +248,7 @@ def infer_ir_build_options_from_test_name(name: str) -> Optional[CompilerOptions
           Run test case only on 64-bit platforms
       *_32bit*:
           Run test caseonly on 32-bit platforms
-      *_python3.8* (or for any Python version):
+      *_python3_8* (or for any Python version):
           Use Python 3.8+ C API features (default: lowest supported version)
       *StripAssert*:
           Don't generate code for assert statements

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -244,26 +244,26 @@ def infer_ir_build_options_from_test_name(name: str) -> Optional[CompilerOptions
 
     Supported naming conventions:
 
-      *_64bit:
+      *_64bit*:
           Run test case only on 64-bit platforms
-      *_32bit:
+      *_32bit*:
           Run test caseonly on 32-bit platforms
-      *_python3.8 (or for any Python version):
+      *_python3.8* (or for any Python version):
           Use Python 3.8+ C API features (default: lowest supported version)
       *StripAssert*:
           Don't generate code for assert statements
     """
     # If this is specific to some bit width, always pass if platform doesn't match.
-    if name.endswith('_64bit') and IS_32_BIT_PLATFORM:
+    if '_64bit' in name and IS_32_BIT_PLATFORM:
         return None
-    if name.endswith('_32bit') and not IS_32_BIT_PLATFORM:
+    if '_32bit' in name and not IS_32_BIT_PLATFORM:
         return None
     options = CompilerOptions(strip_asserts='StripAssert' in name,
                               capi_version=(3, 5))
     # A suffix like _python3.8 is used to set the target C API version.
-    m = re.search(r'_python([3-9]+)_([0-9]+)$', name)
+    m = re.search(r'_python([3-9]+)_([0-9]+)(_|\b)', name)
     if m:
         options.capi_version = (int(m.group(1)), int(m.group(2)))
-    elif re.search(r'_py(thon)?[^A-Z]*$', name) or '_Python' in name:
+    elif '_py' in name or '_Python' in name:
         assert False, 'Invalid _py* suffix (should be _pythonX_Y): {}'.format(name)
     return options

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -235,3 +235,35 @@ def replace_word_size(text: List[str]) -> List[str]:
         else:
             result.append(line)
     return result
+
+
+def infer_ir_build_options_from_test_name(name: str) -> Optional[CompilerOptions]:
+    """Look for magic substrings in test case name to set compiler options.
+
+    Return None if the test case should be skipped (always pass).
+
+    Supported naming conventions:
+
+      *_64bit:
+          Run test case only on 64-bit platforms
+      *_32bit:
+          Run test caseonly on 32-bit platforms
+      *_python3.8 (or for any Python version):
+          Use Python 3.8+ C API features (default: lowest supported version)
+      *StripAssert*:
+          Don't generate code for assert statements
+    """
+    # If this is specific to some bit width, always pass if platform doesn't match.
+    if name.endswith('_64bit') and IS_32_BIT_PLATFORM:
+        return None
+    if name.endswith('_32bit') and not IS_32_BIT_PLATFORM:
+        return None
+    options = CompilerOptions(strip_asserts='StripAssert' in name,
+                              capi_version=(3, 5))
+    # A suffix like _python3.8 is used to set the target C API version.
+    m = re.search(r'_python([3-9]+)_([0-9]+)$', name)
+    if m:
+        options.capi_version = (int(m.group(1)), int(m.group(2)))
+    elif re.search(r'_py(thon)?[^A-Z]*$', name) or '_Python' in name:
+        assert False, 'Invalid _py* suffix (should be _pythonX_Y): {}'.format(name)
+    return options

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -89,7 +89,9 @@ def build_ir_for_single_file(input_lines: List[str],
                              compiler_options: Optional[CompilerOptions] = None) -> List[FuncIR]:
     program_text = '\n'.join(input_lines)
 
-    compiler_options = compiler_options or CompilerOptions()
+    # By default generate IR compatible with the earliest supported Python C API.
+    # If a test needs more recent API features, this should be overridden.
+    compiler_options = compiler_options or CompilerOptions(capi_version=(3, 5))
     options = Options()
     options.show_traceback = True
     options.use_builtins_fixtures = True

--- a/mypyc/transform/refcount.py
+++ b/mypyc/transform/refcount.py
@@ -28,7 +28,7 @@ from mypyc.analysis.dataflow import (
 )
 from mypyc.ir.ops import (
     BasicBlock, Assign, RegisterOp, DecRef, IncRef, Branch, Goto,  Op, ControlOp, Value, Register,
-    LoadAddress, Integer
+    LoadAddress, Integer, KeepAlive
 )
 from mypyc.ir.func_ir import FuncIR, all_values
 
@@ -111,7 +111,9 @@ def transform_block(block: BasicBlock,
                     assert isinstance(op, Assign)
                     maybe_append_dec_ref(ops, dest, post_must_defined, key)
 
-        ops.append(op)
+        # Strip KeepAlive. Its only purpose is to help with this transform.
+        if not isinstance(op, KeepAlive):
+            ops.append(op)
 
         # Control ops don't have any space to insert ops after them, so
         # their inc/decrefs get inserted by insert_branch_inc_and_decrefs.

--- a/mypyc/transform/refcount.py
+++ b/mypyc/transform/refcount.py
@@ -28,7 +28,7 @@ from mypyc.analysis.dataflow import (
 )
 from mypyc.ir.ops import (
     BasicBlock, Assign, RegisterOp, DecRef, IncRef, Branch, Goto,  Op, ControlOp, Value, Register,
-    LoadAddress
+    LoadAddress, Integer
 )
 from mypyc.ir.func_ir import FuncIR, all_values
 
@@ -77,7 +77,7 @@ def is_maybe_undefined(post_must_defined: Set[Value], src: Value) -> bool:
 
 def maybe_append_dec_ref(ops: List[Op], dest: Value,
                          defined: 'AnalysisDict[Value]', key: Tuple[BasicBlock, int]) -> None:
-    if dest.type.is_refcounted:
+    if dest.type.is_refcounted and not isinstance(dest, Integer):
         ops.append(DecRef(dest, is_xdec=is_maybe_undefined(defined[key], dest)))
 
 


### PR DESCRIPTION
The vectorcall APIs can make calls to callable Python objects
significantly faster when using keyword arguments.

This makes a microbenchmark that calls interpreted functions using
keyword arguments about 1.9x faster (Python 3.8). The main benefit is
from not needing to construct a dictionary for the keyword arguments.

This also gives a minor speedup when only using positional arguments.
The nested_func microbenchmark is now about 9% faster.

The main PyObject_VectorCall API is available on Python 3.8+ (with an
underscore prefix on 3.8). On Python 3.9+ we can also use a dedicated
method vectorcall function (PyObject_VectorcallMethod).

The new APIs can be used for calls that don't use caller *args or
**kwargs. For other calls we continue to use the legacy APIs. On older
Python versions we also continue use the slower legacy APIs.

See https://docs.python.org/3.9/c-api/call.html for more details.

Vectorcalls require arguments to be stored in a C array. Add the
RArray primitive type to support them. Also add the AssignMulti op to
initialize an array. By having a dedicated op for this makes it easy
to generate compact C code. This is useful since calls are common
operations.

The reference count transform can't reason about references held in
RArray values. Add a no-op KeepAlive op that is only used to ensure
that the operands aren't freed until after the call op. KeepAlive must
also be used with SetMem and LoadMem, for consistency. Previously
these ops had similar functionality built in.

Generate vectorcall ops in IR build test cases only when the test case
opts into them by specifying a recent enough Python version through a
_python3_8 test name suffix (or _python_3_9). This avoids having to
modify a large number of test cases.
