### PR TITLE
Refactor push type map

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4862,11 +4862,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         return function_type(func, self.named_type('builtins.function'))
 
     def push_type_map(self, type_map: 'TypeMap') -> None:
-        if type_map is None:
-            self.binder.unreachable()
-        else:
-            for expr, type in type_map.items():
-                self.binder.put(expr, type)
+        for expr, type in type_map.items():
+            self.binder.put(expr, type)
 
     def infer_issubclass_maps(self, node: CallExpr,
                               expr: Expression,

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4862,8 +4862,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         return function_type(func, self.named_type('builtins.function'))
 
     def push_type_map(self, type_map: 'TypeMap') -> None:
-        for expr, type in type_map.items():
-            self.binder.put(expr, type)
+        if type_map is None:
+            self.binder.unreachable()
+        else:
+            for expr, type in type_map.items():
+                self.binder.put(expr, type)
 
     def infer_issubclass_maps(self, node: CallExpr,
                               expr: Expression,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3801,8 +3801,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 true_map, false_map = self.chk.find_isinstance_check(condition)
 
                 if true_map:
-                    for var, type in true_map.items():
-                        self.chk.binder.put(var, type)
+                    self.chk.push_type_map(true_map)
 
                 if codes.REDUNDANT_EXPR in self.chk.options.enabled_error_codes:
                     if true_map is None:


### PR DESCRIPTION
### Description

While reading throught the `mypy`'s source code these two things caught my eye:
1. `push_type_map` was re-implemented in-place for `check_for_comp`
2. ~~`push_type_map` had special handling for case when `type_map` argument is `None` which should not be possible, because `type_map: 'TypeMap'` and `no_implicit_optional = True` and `strict_optional = True` are on.~~ Ok, I have missed that `TypeMap` alias is defined as `Optional`, excluded.

## Test Plan

Existing tests should cover this.
