### PR TITLE
[mypyc] Add pointer to the new mypyc README

### DIFF
--- a/mypyc/README.md
+++ b/mypyc/README.md
@@ -1,7 +1,10 @@
 mypyc: Mypy to Python C Extension Compiler
 ==========================================
 
-*Mypyc is (mostly) not yet useful for general Python development.*
+**NOTE: We are in the process of moving the mypyc README to the**
+**[mypyc repository](https://github.com/mypyc/mypyc/blob/master/README.md)**
+
+**This may be out of date!**
 
 Mypyc is a compiler that compiles mypy-annotated, statically typed
 Python modules into CPython C extensions. Currently our primary focus


### PR DESCRIPTION
This README will go away once all the useful content is covered in the
new README or the main mypyc documentation.