### PR TITLE
[mypyc] Small documentation updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 /env*/
 docs/build/
 docs/source/_build
+mypyc/doc/_build
 *.iml
 /out/
 .venv*/

--- a/mypyc/doc/dict_operations.rst
+++ b/mypyc/doc/dict_operations.rst
@@ -43,6 +43,8 @@ Methods
 * ``d.keys()``
 * ``d.values()``
 * ``d.items()``
+* ``d.copy()``
+* ``d.clear()``
 * ``d1.update(d2: dict)``
 * ``d.update(x: Iterable)``
 

--- a/mypyc/doc/native_classes.rst
+++ b/mypyc/doc/native_classes.rst
@@ -38,7 +38,7 @@ can be assigned to (similar to using ``__slots__``)::
         def method(self) -> None:
             self.z = "x"
 
-    o = Cls()
+    o = Cls(0)
     print(o.x, o.y)  # OK
     o.z = "y"  # OK
     o.extra = 3  # Error: no attribute "extra"
@@ -90,7 +90,7 @@ You need to install ``mypy-extensions`` to use ``@mypyc_attr``:
 Class variables
 ---------------
 
-Class variables much be explicitly declared using ``attr: ClassVar``
+Class variables must be explicitly declared using ``attr: ClassVar``
 or ``attr: ClassVar[<type>]``. You can't assign to a class variable
 through an instance. Example::
 

--- a/mypyc/doc/str_operations.rst
+++ b/mypyc/doc/str_operations.rst
@@ -27,6 +27,8 @@ Methods
 
 * ``s1.endswith(s2: str)``
 * ``s.join(x: Iterable)``
+* ``s.replace(old: str, new: str)``
+* ``s.replace(old: str, new: str, count: int)``
 * ``s.split()``
 * ``s.split(sep: str)``
 * ``s.split(sep: str, maxsplit: int)``


### PR DESCRIPTION
Here are a few updates/fixes after a read through the mypyc docs.

For the corresponding primitive method updates, see:
- `str.replace`: https://github.com/python/mypy/pull/10088
- `dict.copy`: https://github.com/python/mypy/pull/9721
- `dict.clear`: https://github.com/python/mypy/pull/9724