### PR TITLE
Fix mypyc failing to compile on CPython 3.10.0a6

### DIFF
--- a/mypyc/lib-rt/dict_ops.c
+++ b/mypyc/lib-rt/dict_ops.c
@@ -112,16 +112,10 @@ int CPyDict_Update(PyObject *dict, PyObject *stuff) {
 }
 
 int CPyDict_UpdateFromAny(PyObject *dict, PyObject *stuff) {
-    PyObject *tmp;
-
     if (PyDict_CheckExact(dict)) {
         // Argh this sucks
         _Py_IDENTIFIER(keys);
-        int hasAttr = PyDict_Check(stuff) || _PyObject_LookupAttrId(stuff, &PyId_keys, &tmp);
-        if (tmp) {
-            Py_DECREF(tmp);
-        }
-        if (hasAttr) {
+        if (PyDict_Check(stuff) || _CPyObject_HasAttrId(stuff, &PyId_keys)) {
             return PyDict_Update(dict, stuff);
         } else {
             return PyDict_MergeFromSeq2(dict, stuff, 1);
@@ -132,8 +126,6 @@ int CPyDict_UpdateFromAny(PyObject *dict, PyObject *stuff) {
 }
 
 PyObject *CPyDict_FromAny(PyObject *obj) {
-    PyObject *tmp;
-
     if (PyDict_Check(obj)) {
         return PyDict_Copy(obj);
     } else {
@@ -143,13 +135,10 @@ PyObject *CPyDict_FromAny(PyObject *obj) {
             return NULL;
         }
         _Py_IDENTIFIER(keys);
-        if (_PyObject_LookupAttrId(obj, &PyId_keys, &tmp)) {
+        if (_CPyObject_HasAttrId(obj, &PyId_keys)) {
             res = PyDict_Update(dict, obj);
         } else {
             res = PyDict_MergeFromSeq2(dict, obj, 1);
-        }
-        if (tmp) {
-            Py_DECREF(tmp);
         }
         if (res < 0) {
             Py_DECREF(dict);

--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -389,4 +389,18 @@ _CPyDictView_New(PyObject *dict, PyTypeObject *type)
 }
 #endif
 
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >=10
+static int
+_CPyObject_HasAttrId(PyObject *v, _Py_Identifier *name) {
+    PyObject *tmp = NULL;
+    int result = _PyObject_LookupAttrId(v, name, &tmp);
+    if (tmp) {
+        Py_DECREF(tmp);
+    }
+    return result;
+}
+#else
+#define _CPyObject_HasAttrId _PyObject_HasAttrId
+#endif
+
 #endif

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -940,7 +940,10 @@ import sys
 
 # We lie about the version we are running in tests if it is 3.5, so
 # that hits a crash case.
-if sys.version_info[:2] == (3, 9):
+if sys.version_info[:2] == (3, 10):
+    def version() -> int:
+        return 10
+elif sys.version_info[:2] == (3, 9):
     def version() -> int:
         return 9
 elif sys.version_info[:2] == (3, 8):


### PR DESCRIPTION
### Description

_PyObject_HasAttrId() has been removed in https://github.com/python/cpython/pull/22629

## Test Plan

Multiple test which failed on 3.10.0a6 are now working again.
All tests still work on python 3.9. mypyc-extra was also tested.