### PR TITLE
Only import distutils if it is needed

### DIFF
--- a/mypy/sitepkgs.py
+++ b/mypy/sitepkgs.py
@@ -11,7 +11,6 @@ if __name__ == '__main__':
     import sys
     sys.path = sys.path[1:]  # we don't want to pick up mypy.types
 
-from distutils.sysconfig import get_python_lib
 import site
 
 MYPY = False
@@ -25,6 +24,7 @@ def getsitepackages():
         user_dir = site.getusersitepackages()
         return site.getsitepackages() + [user_dir]
     else:
+        from distutils.sysconfig import get_python_lib
         return [get_python_lib()]
 
 


### PR DESCRIPTION
### Description

distutils is deprecated in python 3.10, so we only import it if it is
needed, which should only be python < 3.2

## Test Plan

All tests still pass. This is a trivial change and shouldn't cause any problems.
