### PR TITLE
mypyc for discussion: Assertion failure for protocol with overloaded function (failing test case) 

### DIFF
--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -868,6 +868,27 @@ b(B())
 2 10
 2 3
 
+[case testOverloadedProtocol]
+from typing import Generic, TypeVar, Callable, overload, Union
+from typing_extensions import Protocol
+
+class M(Protocol):
+    @overload
+    def func(self, s: int) -> None:
+      ...
+
+    @overload
+    def func(self, s: Callable[[int],None]) -> None:
+      ...
+
+[file driver.py]
+from native import M
+
+print("Hi")
+
+[out]
+Hi
+
 [case testMethodOverrideDefault2]
 class A:
     def foo(self, *, x: int = 0) -> None:


### PR DESCRIPTION
### Description

Please see the code below:

```python
from typing import Generic, TypeVar, Callable, overload, Union
from typing_extensions import Protocol

class M(Protocol):
    @overload
    def func(self, s: int) -> None:
      ...

    @overload
    def func(self, s: Callable[[int],None]) -> None:
      ...
```

This code fails with an assertion error in https://github.com/python/mypy/blob/020998df3014d5d026deefadea80f348af3561f0/mypyc/irbuild/prepare.py#L197

A workaround (at least insofar as the assertion is concerned) is to combine the overloads:

```python
from typing import Generic, TypeVar, Callable, overload, Union
from typing_extensions import Protocol

class M(Protocol):
    def func(self, s: Union[int,Callable[[int],None]) -> None:
      ...

```

## Test Plan

Test attached
