### PR TITLE
Add optional CI run against python nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ jobs:
     python: 3.8
   - name: "run test suite with python 3.9"
     python: 3.9
+  - name: "run test suite with python nightly"
+    python: nightly
   - name: "run mypyc runtime tests with python 3.6 debug build"
     language: generic
     env:
@@ -80,6 +82,8 @@ jobs:
   #   env:
   #   - TOXENV=dev
   #   - EXTRA_ARGS=
+  allow_failures:
+  - python: nightly
 
 install:
 # pip 21.0 no longer works on Python 3.5


### PR DESCRIPTION
### Description

This commit adds an optional CI run with python nightly. It is allowed to allow run failures, so even if the nightly run fails the whole CI still succeeds.  

This can be useful for detecting breaking changes in newer python versions and tracking progress towards supporting them.

### Runtime

This adds around 17 minutes to the total time calculated by travis.
Because it can run in parallel with other jobs the actual time will likely be much less, depending on the number of parallel jobs available.