### PR TITLE
Update extending_mypy.rst

### DIFF
--- a/docs/source/extending_mypy.rst
+++ b/docs/source/extending_mypy.rst
@@ -173,6 +173,8 @@ For example:
        ...
        yield timer()
 
+**get_function_signature_hook** is used to adjust the signature of a function.
+
 **get_method_hook()** is the same as ``get_function_hook()`` but for methods
 instead of module level functions.
 
@@ -202,14 +204,13 @@ to match runtime behaviour:
 
 .. code-block:: python
 
-   from lib import customize
+   from dataclasses import dataclass
 
-   @customize
-   class UserDefined:
-       pass
+   @dataclass  # built-in plugin adds `__init__` method here
+   class User:
+       name: str
 
-   var = UserDefined
-   var.customized  # mypy can understand this using a plugin
+   user = User(name='example')  # mypy can understand this using a plugin
 
 **get_metaclass_hook()** is similar to above, but for metaclasses.
 


### PR DESCRIPTION
Two things I have changed:
1. `get_function_signature_hook` was missing from docs, but it is defined https://github.com/python/mypy/blob/ac66403cb4374b858786350b96e7f5972db84bcd/mypy/plugin.py#L368-L376
2. While reading the docs, this `UserDefined` for `get_class_decorator_hook` example caught my eye. It was not clear how `UserDefined` and `@customize` work. I believe that `@dataclass` example is better for two reasons. First, it is an existing API and is already familiar to our users. Secondly, there's an actual plugin for it, so people can see how it is implemented

Refs https://github.com/python/mypy/issues/6760