### PR TITLE
Check kwargs key type as covariant

### DIFF
--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -339,6 +339,22 @@ f(**b)
 class A: pass
 [builtins fixtures/dict.pyi]
 
+[case testPassingStringLiteralForKeywordVarArg]
+from typing import Any, Dict
+from typing_extensions import Literal
+kw: Dict[Literal["a", "b"], Any]
+def f(a, b): pass
+f(**kw)
+[builtins fixtures/dict.pyi]
+
+[case tesPassingVariousLiteralsForKeywordVarArg]
+from typing import Any, Dict
+from typing_extensions import Literal
+kw: Dict[Literal[1, "a"], Any]
+def f(a, b): pass
+f(**kw) # E: Keywords must be strings
+[builtins fixtures/dict.pyi]
+
 [case testPassingMappingSubclassForKeywordVarArg]
 from typing import Mapping
 class MappingSubclass(Mapping[str, str]): pass


### PR DESCRIPTION
Closes #10023.

Assume mapping's key type is covariant when validating `**kwargs` argument type.