### PR TITLE
[mypyc] Support class-based TypedDict definitions

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -224,7 +224,6 @@ def populate_non_ext_bases(builder: IRBuilder, cdef: ClassDef) -> Value:
             if base_ir.children is not None:
                 base_ir.children.append(ir)
 
-        name = cls.name
         if cls.fullname in MAGIC_TYPED_DICT_CLASSES:
             # HAX: Mypy internally represents TypedDict classes differently from what
             #      should happen at runtime. Replace with something that works.
@@ -239,7 +238,7 @@ def populate_non_ext_bases(builder: IRBuilder, cdef: ClassDef) -> Value:
                 name = '_TypedDict'
             base = builder.get_module_attr(module, name, cdef.line)
         else:
-            base = builder.load_global_str(name, cdef.line)
+            base = builder.load_global_str(cls.name, cdef.line)
         bases.append(base)
         if cls.fullname in MAGIC_TYPED_DICT_CLASSES:
             # The remaining base classes are synthesized by mypy and should be ignored.
@@ -254,9 +253,8 @@ def find_non_ext_metaclass(builder: IRBuilder, cdef: ClassDef, bases: Value) -> 
     else:
         if cdef.info.typeddict_type is not None and builder.options.capi_version >= (3, 9):
             # In Python 3.9, the metaclass for class-based TypedDict is typing._TypedDictMeta.
-            # We can't easily calculate using generically, so special case it.
-            mod = builder.get_module('typing', cdef.line)
-            return builder.py_get_attr(mod, '_TypedDictMeta', cdef.line)
+            # We can't easily calculate it generically, so special case it.
+            return builder.get_module_attr('typing', '_TypedDictMeta', cdef.line)
 
         declared_metaclass = builder.add(LoadAddress(type_object_op.type,
                                                      type_object_op.src, cdef.line))

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -215,8 +215,16 @@ def populate_non_ext_bases(builder: IRBuilder, cdef: ClassDef) -> Value:
             if base_ir.children is not None:
                 base_ir.children.append(ir)
 
-        base = builder.load_global_str(cls.name, cdef.line)
+        name = cls.name
+        if cls.fullname == 'typing_extensions._TypedDict':
+            # HAX: Mypy internally represents TypedDict classes differently from what
+            #      should happen at runtime. Replace with something that works.
+            name = 'TypedDict'
+        base = builder.load_global_str(name, cdef.line)
         bases.append(base)
+        if cls.fullname == 'typing_extensions._TypedDict':
+            # The remaining base classes are synthesized by mypy and should be ignored.
+            break
     return builder.new_tuple(bases, cdef.line)
 
 

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -22,7 +22,7 @@ from mypyc.ir.ops import (
 )
 from mypyc.ir.rtypes import exc_rtuple
 from mypyc.primitives.generic_ops import py_delattr_op
-from mypyc.primitives.misc_ops import type_op, get_module_dict_op
+from mypyc.primitives.misc_ops import type_op
 from mypyc.primitives.dict_ops import dict_get_item_op
 from mypyc.primitives.exc_ops import (
     raise_exception_op, reraise_exception_op, error_catch_op, exc_matches_op, restore_exc_info_op,
@@ -152,11 +152,7 @@ def transform_import(builder: IRBuilder, node: Import) -> None:
         else:
             base = name = node_id.split('.')[0]
 
-        # Python 3.7 has a nice 'PyImport_GetModule' function that we can't use :(
-        mod_dict = builder.call_c(get_module_dict_op, [], node.line)
-        # Get top-level module/package object.
-        obj = builder.call_c(dict_get_item_op,
-                             [mod_dict, builder.load_str(base)], node.line)
+        obj = builder.get_module(base, node.line)
 
         builder.gen_method_call(
             globals, '__setitem__', [builder.load_str(name), obj],

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -23,7 +23,6 @@ from mypyc.ir.ops import (
 from mypyc.ir.rtypes import exc_rtuple
 from mypyc.primitives.generic_ops import py_delattr_op
 from mypyc.primitives.misc_ops import type_op
-from mypyc.primitives.dict_ops import dict_get_item_op
 from mypyc.primitives.exc_ops import (
     raise_exception_op, reraise_exception_op, error_catch_op, exc_matches_op, restore_exc_info_op,
     get_exc_value_op, keep_propagating_op, get_exc_info_op

--- a/mypyc/irbuild/util.py
+++ b/mypyc/irbuild/util.py
@@ -82,7 +82,9 @@ def is_extension_class(cdef: ClassDef) -> bool:
         for d in cdef.decorators
     ):
         return False
-    elif (cdef.info.metaclass_type and cdef.info.metaclass_type.type.fullname not in (
+    if cdef.info.typeddict_type:
+        return False
+    if (cdef.info.metaclass_type and cdef.info.metaclass_type.type.fullname not in (
             'abc.ABCMeta', 'typing.TypingMeta', 'typing.GenericMeta')):
         return False
     return True

--- a/mypyc/test-data/fixtures/ir.py
+++ b/mypyc/test-data/fixtures/ir.py
@@ -20,6 +20,7 @@ class object:
 class type:
     def __init__(self, o: object) -> None: ...
     __name__ : str
+    __annotations__: Dict[str, Any]
 
 class ellipsis: pass
 

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -760,6 +760,8 @@ def test_typed_dict() -> None:
     d = TD(a=5)
     assert d['a'] == 5
     assert type(d) == dict
+    # TODO: This doesn't work yet
+    # assert TD.__annotations__ == {'a': int}
 
 def test_inherited_typed_dict() -> None:
     d = TD2(a=5, b=3)

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -741,6 +741,16 @@ TypeError
 TypeError
 10
 
+[case testClassBasedTypedDict]
+from typing_extensions import TypedDict
+
+class TD(TypedDict):
+    a: int
+
+def test_typed_dict() -> None:
+    d = TD(a=5)
+    assert d['a'] == 5
+
 [case testUnion]
 from typing import Union
 

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -747,9 +747,19 @@ from typing_extensions import TypedDict
 class TD(TypedDict):
     a: int
 
+class TD2(TD):
+    b: int
+
 def test_typed_dict() -> None:
     d = TD(a=5)
     assert d['a'] == 5
+    assert type(d) == dict
+
+def test_inherited_typed_dict() -> None:
+    d = TD2(a=5, b=3)
+    assert d['a'] == 5
+    assert d['b'] == 3
+    assert type(d) == dict
 
 [case testUnion]
 from typing import Union

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -750,6 +750,12 @@ class TD(TypedDict):
 class TD2(TD):
     b: int
 
+class TD3(TypedDict, total=False):
+    c: int
+
+class TD4(TD3, TD2, total=False):
+    d: int
+
 def test_typed_dict() -> None:
     d = TD(a=5)
     assert d['a'] == 5
@@ -760,6 +766,12 @@ def test_inherited_typed_dict() -> None:
     assert d['a'] == 5
     assert d['b'] == 3
     assert type(d) == dict
+
+def test_non_total_typed_dict() -> None:
+    d3 = TD3(c=3)
+    d4 = TD4(a=1, b=2, c=3, d=4)
+    assert d3['c'] == 3
+    assert d4['d'] == 4
 
 [case testUnion]
 from typing import Union


### PR DESCRIPTION
These need to be compiled as non-extension classes.

Also mypy has a special internal representation for these which doesn't
correspond to what's there at runtime and requires some hacks.

Fixes mypyc/mypyc#803.