### PR TITLE
[mypyc] Ignore type error in conf.py used for doc generation

### DIFF
--- a/mypyc/doc/conf.py
+++ b/mypyc/doc/conf.py
@@ -51,7 +51,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 try:
-    import sphinx_rtd_theme
+    import sphinx_rtd_theme  # type: ignore
 except:
     html_theme = 'default'
 else:


### PR DESCRIPTION
Silence an awkward mypy error if somebody tries to type check this
file.