### PR TITLE
[mypyc] Box initializers of final variables when required 

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -345,8 +345,12 @@ class IRBuilder:
         # Currently the stack always has at least two items: dummy and top-level.
         return len(self.fn_infos) <= 2
 
-    def init_final_static(self, lvalue: Lvalue, rvalue_reg: Value,
-                          class_name: Optional[str] = None) -> None:
+    def init_final_static(self,
+                          lvalue: Lvalue,
+                          rvalue_reg: Value,
+                          class_name: Optional[str] = None,
+                          *,
+                          type_override: Optional[RType] = None) -> None:
         assert isinstance(lvalue, NameExpr)
         assert isinstance(lvalue.node, Var)
         if lvalue.node.final_value is None:
@@ -355,7 +359,7 @@ class IRBuilder:
             else:
                 name = '{}.{}'.format(class_name, lvalue.name)
             assert name is not None, "Full name not set for variable"
-            coerced = self.coerce(rvalue_reg, self.node_type(lvalue), lvalue.line)
+            coerced = self.coerce(rvalue_reg, type_override or self.node_type(lvalue), lvalue.line)
             self.final_names.append((name, coerced.type))
             self.add(InitStatic(coerced, name, self.module_name))
 

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -355,8 +355,9 @@ class IRBuilder:
             else:
                 name = '{}.{}'.format(class_name, lvalue.name)
             assert name is not None, "Full name not set for variable"
-            self.final_names.append((name, rvalue_reg.type))
-            self.add(InitStatic(rvalue_reg, name, self.module_name))
+            coerced = self.coerce(rvalue_reg, self.node_type(lvalue), lvalue.line)
+            self.final_names.append((name, coerced.type))
+            self.add(InitStatic(coerced, name, self.module_name))
 
     def load_final_static(self, fullname: str, typ: RType, line: int,
                           error_name: Optional[str] = None) -> Value:

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -1,6 +1,6 @@
 """Transform class definitions from the mypy AST form to IR."""
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from mypy.nodes import (
     ClassDef, FuncDef, OverloadedFuncDef, PassStmt, AssignmentStmt, NameExpr, StrExpr,
@@ -11,7 +11,7 @@ from mypyc.ir.ops import (
     BasicBlock, Branch, MethodCall, NAMESPACE_TYPE, LoadAddress
 )
 from mypyc.ir.rtypes import (
-    object_rprimitive, bool_rprimitive, dict_rprimitive, is_optional_type,
+    RType, object_rprimitive, bool_rprimitive, dict_rprimitive, is_optional_type,
     is_object_rprimitive, is_none_rprimitive
 )
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
@@ -76,7 +76,7 @@ def transform_class_def(builder: IRBuilder, cdef: ClassDef) -> None:
         dataclass_non_ext = None
         type_obj = None
 
-    attrs_to_cache = []  # type: List[Lvalue]
+    attrs_to_cache = []  # type: List[Tuple[Lvalue, RType]]
 
     for stmt in cdef.defs.body:
         if isinstance(stmt, OverloadedFuncDef) and stmt.is_property:
@@ -269,7 +269,7 @@ def add_non_ext_class_attr(builder: IRBuilder,
                            lvalue: NameExpr,
                            stmt: AssignmentStmt,
                            cdef: ClassDef,
-                           attr_to_cache: List[Lvalue]) -> None:
+                           attr_to_cache: List[Tuple[Lvalue, RType]]) -> None:
     """Add a class attribute to __annotations__ of a non-extension class.
 
     If the attribute is initialized with a value, also add it to __dict__.
@@ -294,7 +294,8 @@ def add_non_ext_class_attr(builder: IRBuilder,
             # Skip "_order_" and "__order__", since Enum will remove it
             and lvalue.name not in ('_order_', '__order__')
         ):
-            attr_to_cache.append(lvalue)
+            # Enum values are always boxed, so use object_rprimitive.
+            attr_to_cache.append((lvalue, object_rprimitive))
 
 
 def generate_attr_defaults(builder: IRBuilder, cdef: ClassDef) -> None:
@@ -419,13 +420,15 @@ def load_decorated_class(builder: IRBuilder, cdef: ClassDef, type_obj: Value) ->
     return dec_class
 
 
-def cache_class_attrs(builder: IRBuilder, attrs_to_cache: List[Lvalue], cdef: ClassDef) -> None:
+def cache_class_attrs(builder: IRBuilder,
+                      attrs_to_cache: List[Tuple[Lvalue, RType]],
+                      cdef: ClassDef) -> None:
     """Add class attributes to be cached to the global cache."""
     typ = builder.load_native_type_object(cdef.fullname)
-    for lval in attrs_to_cache:
+    for lval, rtype in attrs_to_cache:
         assert isinstance(lval, NameExpr)
         rval = builder.py_get_attr(typ, lval.name, cdef.line)
-        builder.init_final_static(lval, rval, cdef.name)
+        builder.init_final_static(lval, rval, cdef.name, type_override=rtype)
 
 
 def create_mypyc_attrs_tuple(builder: IRBuilder, ir: ClassIR, line: int) -> Value:

--- a/mypyc/test-data/run-tuples.test
+++ b/mypyc/test-data/run-tuples.test
@@ -97,6 +97,7 @@ assert f(Sub(3, 2)) == 3
 
 [case testTupleOps]
 from typing import Tuple, List, Any, Optional
+from typing_extensions import Final
 
 def f() -> Tuple[()]:
     return ()
@@ -178,3 +179,9 @@ def test_slicing() -> None:
     assert s[1:long_int] == ("o", "o", "b", "a", "r")
     assert s[long_int:] == ()
     assert s[-long_int:-1] == ("f", "o", "o", "b", "a")
+
+TUPLE: Final[Tuple[str, ...]] = ('x', 'y')
+
+def test_final_boxed_tuple() -> None:
+    t = TUPLE
+    assert t == ('x', 'y')


### PR DESCRIPTION
Fix a compile error when an unboxed initializer is used for a boxed
final variable.

I had to tweak how enums are compiled to avoid breaking them as
a side effect.

Fixes mypyc/mypyc#815.