### PR TITLE
[mypyc] Simplify generated C by omitting gotos to the next block

### DIFF
--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -104,6 +104,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         self.declarations = declarations
         self.source_path = source_path
         self.module_name = module_name
+        self.literals = emitter.context.literals
         self.next_block = None  # type: Optional[BasicBlock]
 
     def temp_name(self) -> str:

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -128,7 +128,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             cond = '{}{}'.format(neg, expr_result)
         elif op.op == Branch.IS_ERROR:
             typ = op.value.type
-            compare = '!=' if op.negated else '=='
+            compare = '!=' if negated else '=='
             if isinstance(typ, RTuple):
                 # TODO: What about empty tuple?
                 cond = self.emitter.tuple_undefined_check_cond(typ,

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -110,7 +110,8 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         return self.emitter.temp_name()
 
     def visit_goto(self, op: Goto) -> None:
-        self.emit_line('goto %s;' % self.label(op.label))
+        if op.label is not self.next_block:
+            self.emit_line('goto %s;' % self.label(op.label))
 
     def visit_branch(self, op: Branch) -> None:
         true, false = op.true, op.false

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -81,6 +81,10 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(Goto(BasicBlock(2)),
                          "goto CPyL2;")
 
+    def test_goto_next_block(self) -> None:
+        next_block = BasicBlock(2)
+        self.assert_emit(Goto(next_block), "", next_block=next_block)
+
     def test_return(self) -> None:
         self.assert_emit(Return(self.m),
                          "return cpy_r_m;")
@@ -384,7 +388,10 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         actual_lines = [line.strip(' ') for line in frags]
         assert all(line.endswith('\n') for line in actual_lines)
         actual_lines = [line.rstrip('\n') for line in actual_lines]
-        expected_lines = expected.rstrip().split('\n')
+        if not expected.strip():
+            expected_lines = []
+        else:
+            expected_lines = expected.rstrip().split('\n')
         expected_lines = [line.strip(' ') for line in expected_lines]
         assert_string_arrays_equal(expected_lines, actual_lines,
                                    msg='Generated code unexpected')

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -175,6 +175,18 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                                 goto CPyL9;
                          """)
 
+    def test_branch_is_error_next_block(self) -> None:
+        next_block = BasicBlock(8)
+        b = Branch(self.b, next_block, BasicBlock(9), Branch.IS_ERROR)
+        self.assert_emit(b,
+                         """if (cpy_r_b != 2) goto CPyL9;""",
+                         next_block=next_block)
+        b = Branch(self.b, next_block, BasicBlock(9), Branch.IS_ERROR)
+        b.negated = True
+        self.assert_emit(b,
+                         """if (cpy_r_b == 2) goto CPyL9;""",
+                         next_block=next_block)
+
     def test_call(self) -> None:
         decl = FuncDecl('myfn', None, 'mod',
                         FuncSignature([RuntimeArg('m', int_rprimitive)], int_rprimitive))

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -1,12 +1,6 @@
 import unittest
 
-<<<<<<< HEAD
-from typing import List
-||||||| constructed merge base
-from typing import Dict, List
-=======
-from typing import Dict, List, Optional
->>>>>>> [mypyc] Omit else block if possible in C generated for branch ops
+from typing import List, Optional
 
 from mypy.ordered_dict import OrderedDict
 


### PR DESCRIPTION
This reduces the number of lines in the generated C when compiling
the richards benchmark by about 5%.

The main benefit is making the generated C easier to read by humans.

This may also marginally improve the speed of compilation.