### PR TITLE
Use double quotes in error message "is not a valid TypedDict key"

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1164,7 +1164,7 @@ class MessageBuilder:
             item_name: str,
             context: Context) -> None:
         if typ.is_anonymous():
-            self.fail('\'{}\' is not a valid TypedDict key; expected one of {}'.format(
+            self.fail('"{}" is not a valid TypedDict key; expected one of {}'.format(
                 item_name, format_item_name_list(typ.items.keys())), context)
         else:
             self.fail('TypedDict {} has no key "{}"'.format(

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -702,8 +702,8 @@ T = TypeVar('T')
 def join(x: T, y: T) -> T: return x
 ab = join(A(x='', y=1, z=''), B(x='', z=1))
 ac = join(A(x='', y=1, z=''), C(x='', y=0, z=1))
-ab['y']  # E: 'y' is not a valid TypedDict key; expected one of ('x')
-ac['a']  # E: 'a' is not a valid TypedDict key; expected one of ('x', 'y')
+ab['y']  # E: "y" is not a valid TypedDict key; expected one of ('x')
+ac['a']  # E: "a" is not a valid TypedDict key; expected one of ('x', 'y')
 [builtins fixtures/dict.pyi]
 
 [case testCannotGetItemOfTypedDictWithNonLiteralKey]


### PR DESCRIPTION
### Description
This pull request fixes issue reported in #7445 for `is not a valid TypedDict key` error message

## Test Plan
Updated test cases for the message. New test cases not added.