### PR TITLE
[mypyc] Don't coerce types checked with isinstance (#811)

### DIFF
--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -248,7 +248,11 @@ def translate_next_call(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> 
 
 @specialize_function('builtins.isinstance')
 def translate_isinstance(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Optional[Value]:
-    # Special case builtins.isinstance
+    # Special case for builtins.isinstance
+    # Prevent coercions on the thing we are checking the instance of - there is no need to coerce
+    # something to a new type before checking what type it is, and the coercion could lead to bugs.
+    builder.types[expr.args[0]] = AnyType(TypeOfAny.from_error)
+
     if (len(expr.args) == 2
             and expr.arg_kinds == [ARG_POS, ARG_POS]
             and isinstance(expr.args[1], (RefExpr, TupleExpr))):

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -248,14 +248,15 @@ def translate_next_call(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> 
 
 @specialize_function('builtins.isinstance')
 def translate_isinstance(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Optional[Value]:
-    # Special case for builtins.isinstance
-    # Prevent coercions on the thing we are checking the instance of - there is no need to coerce
-    # something to a new type before checking what type it is, and the coercion could lead to bugs.
-    builder.types[expr.args[0]] = AnyType(TypeOfAny.from_error)
-
     if (len(expr.args) == 2
             and expr.arg_kinds == [ARG_POS, ARG_POS]
             and isinstance(expr.args[1], (RefExpr, TupleExpr))):
+        # Special case for builtins.isinstance
+        # Prevent coercions on the thing we are checking the instance of - there is no need to
+        # coerceomething to a new type before checking what type it is, and the coercion could lead
+        # to bugs.
+        builder.types[expr.args[0]] = AnyType(TypeOfAny.from_error)
+
         irs = builder.flatten_classes(expr.args[1])
         if irs is not None:
             return builder.builder.isinstance_helper(builder.accept(expr.args[0]), irs, expr.line)

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -253,8 +253,8 @@ def translate_isinstance(builder: IRBuilder, expr: CallExpr, callee: RefExpr) ->
             and isinstance(expr.args[1], (RefExpr, TupleExpr))):
         # Special case for builtins.isinstance
         # Prevent coercions on the thing we are checking the instance of - there is no need to
-        # coerceomething to a new type before checking what type it is, and the coercion could lead
-        # to bugs.
+        # coerce something to a new type before checking what type it is, and the coercion could
+        # lead to bugs.
         builder.types[expr.args[0]] = AnyType(TypeOfAny.from_error)
 
         irs = builder.flatten_classes(expr.args[1])

--- a/mypyc/test-data/irbuild-isinstance.test
+++ b/mypyc/test-data/irbuild-isinstance.test
@@ -37,40 +37,40 @@ L0:
     r6 = r5 ^ 1
     return r6
 
-[case testIsinstanceNotBoolAndIsInt]
+[case testIsinstanceIntAndNotBool]
 # This test is to ensure that 'value' doesn't get coerced into a bool when we need it to be an int
 def is_not_bool_and_is_int(value: object) -> bool:
-    return not isinstance(value, bool) and isinstance(value, int)
+    return isinstance(value, int) and not isinstance(value, bool)
 
 [out]
 def is_not_bool_and_is_int(value):
     value, r0 :: object
-    r1 :: str
-    r2 :: object
-    r3 :: int32
-    r4 :: bit
-    r5, r6, r7 :: bool
-    r8 :: object
-    r9 :: int32
-    r10 :: bit
-    r11 :: bool
+    r1 :: int32
+    r2 :: bit
+    r3, r4 :: bool
+    r5 :: object
+    r6 :: str
+    r7 :: object
+    r8 :: int32
+    r9 :: bit
+    r10, r11 :: bool
 L0:
-    r0 = builtins :: module
-    r1 = 'bool'
-    r2 = CPyObject_GetAttr(r0, r1)
-    r3 = PyObject_IsInstance(value, r2)
-    r4 = r3 >= 0 :: signed
-    r5 = truncate r3: int32 to builtins.bool
-    r6 = r5 ^ 1
-    if r6 goto L2 else goto L1 :: bool
+    r0 = load_address PyLong_Type
+    r1 = PyObject_IsInstance(value, r0)
+    r2 = r1 >= 0 :: signed
+    r3 = truncate r1: int32 to builtins.bool
+    if r3 goto L2 else goto L1 :: bool
 L1:
-    r7 = r6
+    r4 = r3
     goto L3
 L2:
-    r8 = load_address PyLong_Type
-    r9 = PyObject_IsInstance(value, r8)
-    r10 = r9 >= 0 :: signed
-    r11 = truncate r9: int32 to builtins.bool
-    r7 = r11
+    r5 = builtins :: module
+    r6 = 'bool'
+    r7 = CPyObject_GetAttr(r5, r6)
+    r8 = PyObject_IsInstance(value, r7)
+    r9 = r8 >= 0 :: signed
+    r10 = truncate r8: int32 to builtins.bool
+    r11 = r10 ^ 1
+    r4 = r11
 L3:
-    return r7
+    return r4

--- a/mypyc/test-data/irbuild-isinstance.test
+++ b/mypyc/test-data/irbuild-isinstance.test
@@ -1,5 +1,5 @@
 [case testIsinstanceInt]
-def is_int(value):
+def is_int(value: object) -> bool:
     return isinstance(value, int)
 
 [out]
@@ -8,17 +8,15 @@ def is_int(value):
     r1 :: int32
     r2 :: bit
     r3 :: bool
-    r4 :: object
 L0:
     r0 = load_address PyLong_Type
     r1 = PyObject_IsInstance(value, r0)
     r2 = r1 >= 0 :: signed
     r3 = truncate r1: int32 to builtins.bool
-    r4 = box(int32, r1)
-    return r4
+    return r3
 
 [case testIsinstanceNotBool1]
-def is_not_bool(value):
+def is_not_bool(value: object) -> bool:
     return not isinstance(value, bool)
 
 [out]
@@ -28,12 +26,7 @@ def is_not_bool(value):
     r2 :: object
     r3 :: int32
     r4 :: bit
-    r5 :: bool
-    r6 :: object
-    r7 :: int32
-    r8 :: bit
-    r9 :: bool
-    r10 :: object
+    r5, r6 :: bool
 L0:
     r0 = builtins :: module
     r1 = 'bool'
@@ -41,16 +34,12 @@ L0:
     r3 = PyObject_IsInstance(value, r2)
     r4 = r3 >= 0 :: signed
     r5 = truncate r3: int32 to builtins.bool
-    r6 = box(int32, r3)
-    r7 = PyObject_Not(r6)
-    r8 = r7 >= 0 :: signed
-    r9 = truncate r7: int32 to builtins.bool
-    r10 = box(bool, r9)
-    return r10
+    r6 = r5 ^ 1
+    return r6
 
 [case testIsinstanceNotBoolAndIsInt]
 # This test is to ensure that 'value' doesn't get coerced into a bool when we need it to be an int
-def is_not_bool_and_is_int(value):
+def is_not_bool_and_is_int(value: object) -> bool:
     return not isinstance(value, bool) and isinstance(value, int)
 
 [out]
@@ -60,16 +49,11 @@ def is_not_bool_and_is_int(value):
     r2 :: object
     r3 :: int32
     r4 :: bit
-    r5 :: bool
-    r6 :: object
-    r7 :: int32
-    r8 :: bit
-    r9 :: bool
-    r10, r11, r12 :: object
-    r13 :: int32
-    r14 :: bit
-    r15 :: bool
-    r16 :: object
+    r5, r6, r7 :: bool
+    r8 :: object
+    r9 :: int32
+    r10 :: bit
+    r11 :: bool
 L0:
     r0 = builtins :: module
     r1 = 'bool'
@@ -77,21 +61,16 @@ L0:
     r3 = PyObject_IsInstance(value, r2)
     r4 = r3 >= 0 :: signed
     r5 = truncate r3: int32 to builtins.bool
-    r6 = box(int32, r3)
-    r7 = PyObject_Not(r6)
-    r8 = r7 >= 0 :: signed
-    r9 = truncate r7: int32 to builtins.bool
-    if r9 goto L2 else goto L1 :: bool
+    r6 = r5 ^ 1
+    if r6 goto L2 else goto L1 :: bool
 L1:
-    r10 = box(bool, r9)
-    r11 = r10
+    r7 = r6
     goto L3
 L2:
-    r12 = load_address PyLong_Type
-    r13 = PyObject_IsInstance(value, r12)
-    r14 = r13 >= 0 :: signed
-    r15 = truncate r13: int32 to builtins.bool
-    r16 = box(int32, r13)
-    r11 = r16
+    r8 = load_address PyLong_Type
+    r9 = PyObject_IsInstance(value, r8)
+    r10 = r9 >= 0 :: signed
+    r11 = truncate r9: int32 to builtins.bool
+    r7 = r11
 L3:
-    return r11
+    return r7

--- a/mypyc/test-data/irbuild-isinstance.test
+++ b/mypyc/test-data/irbuild-isinstance.test
@@ -38,7 +38,8 @@ L0:
     return r6
 
 [case testIsinstanceIntAndNotBool]
-# This test is to ensure that 'value' doesn't get coerced into a bool when we need it to be an int
+# This test is to ensure that 'value' doesn't get coerced to int when we are
+# checking if it's a bool, since an int can never be an instance of a bool
 def is_not_bool_and_is_int(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 

--- a/mypyc/test-data/irbuild-isinstance.test
+++ b/mypyc/test-data/irbuild-isinstance.test
@@ -1,0 +1,97 @@
+[case testIsinstanceInt]
+def is_int(value):
+    return isinstance(value, int)
+
+[out]
+def is_int(value):
+    value, r0 :: object
+    r1 :: int32
+    r2 :: bit
+    r3 :: bool
+    r4 :: object
+L0:
+    r0 = load_address PyLong_Type
+    r1 = PyObject_IsInstance(value, r0)
+    r2 = r1 >= 0 :: signed
+    r3 = truncate r1: int32 to builtins.bool
+    r4 = box(int32, r1)
+    return r4
+
+[case testIsinstanceNotBool1]
+def is_not_bool(value):
+    return not isinstance(value, bool)
+
+[out]
+def is_not_bool(value):
+    value, r0 :: object
+    r1 :: str
+    r2 :: object
+    r3 :: int32
+    r4 :: bit
+    r5 :: bool
+    r6 :: object
+    r7 :: int32
+    r8 :: bit
+    r9 :: bool
+    r10 :: object
+L0:
+    r0 = builtins :: module
+    r1 = 'bool'
+    r2 = CPyObject_GetAttr(r0, r1)
+    r3 = PyObject_IsInstance(value, r2)
+    r4 = r3 >= 0 :: signed
+    r5 = truncate r3: int32 to builtins.bool
+    r6 = box(int32, r3)
+    r7 = PyObject_Not(r6)
+    r8 = r7 >= 0 :: signed
+    r9 = truncate r7: int32 to builtins.bool
+    r10 = box(bool, r9)
+    return r10
+
+[case testIsinstanceNotBoolAndIsInt]
+# This test is to ensure that 'value' doesn't get coerced into a bool when we need it to be an int
+def is_not_bool_and_is_int(value):
+    return not isinstance(value, bool) and isinstance(value, int)
+
+[out]
+def is_not_bool_and_is_int(value):
+    value, r0 :: object
+    r1 :: str
+    r2 :: object
+    r3 :: int32
+    r4 :: bit
+    r5 :: bool
+    r6 :: object
+    r7 :: int32
+    r8 :: bit
+    r9 :: bool
+    r10, r11, r12 :: object
+    r13 :: int32
+    r14 :: bit
+    r15 :: bool
+    r16 :: object
+L0:
+    r0 = builtins :: module
+    r1 = 'bool'
+    r2 = CPyObject_GetAttr(r0, r1)
+    r3 = PyObject_IsInstance(value, r2)
+    r4 = r3 >= 0 :: signed
+    r5 = truncate r3: int32 to builtins.bool
+    r6 = box(int32, r3)
+    r7 = PyObject_Not(r6)
+    r8 = r7 >= 0 :: signed
+    r9 = truncate r7: int32 to builtins.bool
+    if r9 goto L2 else goto L1 :: bool
+L1:
+    r10 = box(bool, r9)
+    r11 = r10
+    goto L3
+L2:
+    r12 = load_address PyLong_Type
+    r13 = PyObject_IsInstance(value, r12)
+    r14 = r13 >= 0 :: signed
+    r15 = truncate r13: int32 to builtins.bool
+    r16 = box(int32, r13)
+    r11 = r16
+L3:
+    return r11

--- a/mypyc/test-data/run-integers.test
+++ b/mypyc/test-data/run-integers.test
@@ -157,6 +157,15 @@ def check_bitwise(x: int, y: int) -> None:
             check_or(ll, rr)
             check_xor(ll, rr)
 
+[case testIsinstanceNotBoolAndIsInt]
+def test_isinstance_not_bool_and_is_int(value: object) -> bool:
+    return not isinstance(value, bool) and isinstance(value, int)
+[file driver.py]
+from native import test_isinstance_not_bool_and_is_int
+assert test_isinstance_not_bool_and_is_int(True) == False
+assert test_isinstance_not_bool_and_is_int(1) == True
+
+
 SHIFT = 30
 DIGIT0a = 615729753
 DIGIT0b = 832796681

--- a/mypyc/test-data/run-integers.test
+++ b/mypyc/test-data/run-integers.test
@@ -157,13 +157,13 @@ def check_bitwise(x: int, y: int) -> None:
             check_or(ll, rr)
             check_xor(ll, rr)
 
-[case testIsinstanceNotBoolAndIsInt]
-def test_isinstance_not_bool_and_is_int(value: object) -> bool:
-    return not isinstance(value, bool) and isinstance(value, int)
+[case testIsinstanceIntAndNotBool]
+def test_isinstance_int_and_not_bool(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
 [file driver.py]
-from native import test_isinstance_not_bool_and_is_int
-assert test_isinstance_not_bool_and_is_int(True) == False
-assert test_isinstance_not_bool_and_is_int(1) == True
+from native import test_isinstance_int_and_not_bool
+assert test_isinstance_int_and_not_bool(True) == False
+assert test_isinstance_int_and_not_bool(1) == True
 
 
 SHIFT = 30

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -32,6 +32,7 @@ files = [
     'irbuild-int.test',
     'irbuild-vectorcall.test',
     'irbuild-unreachable.test',
+    'irbuild-isinstance.test',
 ]
 
 


### PR DESCRIPTION
Prevent the coercion of things whose types are checked with isinstance
to other types - such coercion is not necessary and can lead to bugs.

Also, add test for avoiding coercion of isinstance() comparators.

Fixes mypyc/mypyc#811.


## Test Plan

Ensured via compiling by hand and running the example given in mypyc/mypyc#811 has been fixed; added a test for the new code path that is generated.