### PR TITLE
Fix Generators typeshed test

### DIFF
--- a/test-data/samples/generators.py
+++ b/test-data/samples/generators.py
@@ -6,7 +6,7 @@ from typing import Iterator
 
 def iter_primes() -> Iterator[int]:
     # an iterator of all numbers between 2 and +infinity
-    numbers = itertools.count(2)
+    numbers: Iterator[int] = itertools.count(2)
 
     # generate primes forever
     while True:


### PR DESCRIPTION
### Description

typshed mistakenly set itertools.count as a function while it is actually a class. Meaning that it returns a class instance and then this clashes with the filter assignment in the test.
I want to fix the typeshed side but the mypy test on THEIR repo fails because of this.

## Test Plan

Mypy behaves the same but tests should be more in line with itertools actual typing.
