### PR TITLE
[mypyc] Add a primitive for loading bool type

### DIFF
--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -9,6 +9,11 @@ from mypyc.primitives.registry import (
     function_op, custom_op, load_address_op, ERR_NEG_INT
 )
 
+# Get the 'bool' type object.
+load_address_op(
+    name='builtins.bool',
+    type=object_rprimitive,
+    src='PyBool_Type')
 
 # Get the boxed Python 'None' object
 none_object_op = load_address_op(

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3638,3 +3638,19 @@ L2:
     r16 = CPyObject_GetAttr(r14, r15)
     r17 = unbox(int, r16)
     return r17
+
+[case testIsinstanceBool]
+def f(x: object) -> bool:
+    return isinstance(x, bool)
+[out]
+def f(x):
+    x, r0 :: object
+    r1 :: int32
+    r2 :: bit
+    r3 :: bool
+L0:
+    r0 = load_address PyBool_Type
+    r1 = PyObject_IsInstance(x, r0)
+    r2 = r1 >= 0 :: signed
+    r3 = truncate r1: int32 to builtins.bool
+    return r3

--- a/mypyc/test-data/irbuild-isinstance.test
+++ b/mypyc/test-data/irbuild-isinstance.test
@@ -22,20 +22,16 @@ def is_not_bool(value: object) -> bool:
 [out]
 def is_not_bool(value):
     value, r0 :: object
-    r1 :: str
-    r2 :: object
-    r3 :: int32
-    r4 :: bit
-    r5, r6 :: bool
+    r1 :: int32
+    r2 :: bit
+    r3, r4 :: bool
 L0:
-    r0 = builtins :: module
-    r1 = 'bool'
-    r2 = CPyObject_GetAttr(r0, r1)
-    r3 = PyObject_IsInstance(value, r2)
-    r4 = r3 >= 0 :: signed
-    r5 = truncate r3: int32 to builtins.bool
-    r6 = r5 ^ 1
-    return r6
+    r0 = load_address PyBool_Type
+    r1 = PyObject_IsInstance(value, r0)
+    r2 = r1 >= 0 :: signed
+    r3 = truncate r1: int32 to builtins.bool
+    r4 = r3 ^ 1
+    return r4
 
 [case testIsinstanceIntAndNotBool]
 # This test is to ensure that 'value' doesn't get coerced to int when we are
@@ -50,11 +46,9 @@ def is_not_bool_and_is_int(value):
     r2 :: bit
     r3, r4 :: bool
     r5 :: object
-    r6 :: str
-    r7 :: object
-    r8 :: int32
-    r9 :: bit
-    r10, r11 :: bool
+    r6 :: int32
+    r7 :: bit
+    r8, r9 :: bool
 L0:
     r0 = load_address PyLong_Type
     r1 = PyObject_IsInstance(value, r0)
@@ -65,13 +59,11 @@ L1:
     r4 = r3
     goto L3
 L2:
-    r5 = builtins :: module
-    r6 = 'bool'
-    r7 = CPyObject_GetAttr(r5, r6)
-    r8 = PyObject_IsInstance(value, r7)
-    r9 = r8 >= 0 :: signed
-    r10 = truncate r8: int32 to builtins.bool
-    r11 = r10 ^ 1
-    r4 = r11
+    r5 = load_address PyBool_Type
+    r6 = PyObject_IsInstance(value, r5)
+    r7 = r6 >= 0 :: signed
+    r8 = truncate r6: int32 to builtins.bool
+    r9 = r8 ^ 1
+    r4 = r9
 L3:
     return r4

--- a/mypyc/test-data/run-bools.test
+++ b/mypyc/test-data/run-bools.test
@@ -65,3 +65,14 @@ def test_bitwise_xor() -> None:
     assert t == False
     f ^= f
     assert f == False
+
+[case testIsinstanceBool]
+def test_isinstance_bool() -> None:
+    a = True
+    b = 1.0
+    c = 1
+    d = False
+    assert isinstance(a, bool) == True
+    assert isinstance(b, bool) == False
+    assert isinstance(c, bool) == False
+    assert isinstance(d, bool) == True


### PR DESCRIPTION
### Description

Closes https://github.com/mypyc/mypyc/issues/821

## Test Plan

For this piece of python code:

```py
def f(x: object) -> bool:
    return isinstance(x, bool)
```

Previous version would generate:

```
def f(x):                                      
    x, r0 :: object                            
    r1 :: str                                  
    r2 :: object                               
    r3 :: int32                                
    r4 :: bit                                  
    r5 :: bool                                 
L0:                                            
    r0 = builtins :: module                    
    r1 = 'bool'                                
    r2 = CPyObject_GetAttr(r0, r1)             
    r3 = PyObject_IsInstance(x, r2)            
    r4 = r3 >= 0 :: signed                     
    r5 = truncate r3: int32 to builtins.bool   
    return r5   
```

And now it would only generate this:

```
def f(x):                                      
    x, r0 :: object                            
    r1 :: int32                                
    r2 :: bit                                  
    r3 :: bool                                 
L0:                                            
    r0 = load_address PyBool_Type              
    r1 = PyObject_IsInstance(x, r0)            
    r2 = r1 >= 0 :: signed                     
    r3 = truncate r1: int32 to builtins.bool   
    return r3    
```