### PR TITLE
add stubs for missing Logger attributes

### DIFF
--- a/mypy/typeshed/stdlib/logging/__init__.pyi
+++ b/mypy/typeshed/stdlib/logging/__init__.pyi
@@ -901,6 +901,12 @@ class RootLogger(Logger):
 
 root: RootLogger
 
+class Manager(object):
+    def __init__(self, rootnode: RootLogger) -> None: ...
+
+Logger.root: RootLogger
+Logger.manager: Manager
+
 if sys.version_info >= (3,):
     class PercentStyle(object):
         default_format: str


### PR DESCRIPTION
### Description

Fixes #43673
https://bugs.python.org/issue43673

Add type stubs for two undocumented attributes, which nonetheless exist and I need.
https://github.com/python/cpython/blob/master/Lib/logging/__init__.py#L1925

## Test Plan
It's not clear to me how/if I need to add this to the dynamic, introspective test setup going on.
