### PR TITLE
Optimize truth value testing for strings

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -958,6 +958,11 @@ class LowLevelIRBuilder:
             zero = Integer(0, short_int_rprimitive)
             self.compare_tagged_condition(value, zero, '!=', true, false, value.line)
             return
+        elif is_same_type(value.type, str_rprimitive):
+            length = self.builtin_len(value, value.line)
+            zero = Integer(0)
+            self.compare_tagged_condition(length, zero, '!=', true, false, value.line)
+            return
         elif is_same_type(value.type, list_rprimitive):
             length = self.builtin_len(value, value.line)
             zero = Integer(0)

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -196,24 +196,22 @@ def f(x: object, y: object) -> str:
 def f(x, y):
     x, y :: object
     r0 :: str
-    r1 :: int32
+    r1 :: int
     r2 :: bit
-    r3 :: bool
-    r4, r5 :: str
+    r3, r4 :: str
 L0:
     r0 = PyObject_Str(x)
-    r1 = PyObject_IsTrue(r0)
-    r2 = r1 >= 0 :: signed
-    r3 = truncate r1: int32 to builtins.bool
-    if r3 goto L1 else goto L2 :: bool
+    r1 = CPyObject_Size(r0)
+    r2 = r1 != 0
+    if r2 goto L1 else goto L2 :: bool
 L1:
-    r4 = r0
+    r3 = r0
     goto L3
 L2:
-    r5 = PyObject_Str(y)
-    r4 = r5
+    r4 = PyObject_Str(y)
+    r3 = r4
 L3:
-    return r4
+    return r3
 
 [case testOr]
 def f(x: int, y: int) -> int:
@@ -276,24 +274,22 @@ def f(x: object, y: object) -> str:
 def f(x, y):
     x, y :: object
     r0 :: str
-    r1 :: int32
+    r1 :: int
     r2 :: bit
-    r3 :: bool
-    r4, r5 :: str
+    r3, r4 :: str
 L0:
     r0 = PyObject_Str(x)
-    r1 = PyObject_IsTrue(r0)
-    r2 = r1 >= 0 :: signed
-    r3 = truncate r1: int32 to builtins.bool
-    if r3 goto L2 else goto L1 :: bool
+    r1 = CPyObject_Size(r0)
+    r2 = r1 != 0
+    if r2 goto L2 else goto L1 :: bool
 L1:
-    r4 = r0
+    r3 = r0
     goto L3
 L2:
-    r5 = PyObject_Str(y)
-    r4 = r5
+    r4 = PyObject_Str(y)
+    r3 = r4
 L3:
-    return r4
+    return r3
 
 [case testSimpleNot]
 def f(x: int, y: int) -> int:

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -720,28 +720,26 @@ def complex_msg(x, s):
     r0 :: object
     r1 :: bit
     r2 :: str
-    r3 :: int32
+    r3 :: int
     r4 :: bit
-    r5 :: bool
-    r6 :: object
-    r7 :: str
-    r8, r9 :: object
+    r5 :: object
+    r6 :: str
+    r7, r8 :: object
 L0:
     r0 = load_address _Py_NoneStruct
     r1 = x != r0
     if r1 goto L1 else goto L2 :: bool
 L1:
     r2 = cast(str, x)
-    r3 = PyObject_IsTrue(r2)
-    r4 = r3 >= 0 :: signed
-    r5 = truncate r3: int32 to builtins.bool
-    if r5 goto L3 else goto L2 :: bool
+    r3 = CPyObject_Size(r2)
+    r4 = r3 != 0
+    if r4 goto L3 else goto L2 :: bool
 L2:
-    r6 = builtins :: module
-    r7 = 'AssertionError'
-    r8 = CPyObject_GetAttr(r6, r7)
-    r9 = PyObject_CallFunctionObjArgs(r8, s, 0)
-    CPy_Raise(r9)
+    r5 = builtins :: module
+    r6 = 'AssertionError'
+    r7 = CPyObject_GetAttr(r5, r6)
+    r8 = PyObject_CallFunctionObjArgs(r7, s, 0)
+    CPy_Raise(r8)
     unreachable
 L3:
     return 1

--- a/mypyc/test-data/irbuild-str.test
+++ b/mypyc/test-data/irbuild-str.test
@@ -139,3 +139,24 @@ L4:
 L5: 
     unreachable 
     
+[case testStrToBool]
+def is_true(x: str) -> bool:
+    if x:
+        return True
+    else:
+        return False
+[out]
+def is_true(x):
+    x :: str
+    r0 :: int
+    r1 :: bit
+L0:
+    r0 = CPyObject_Size(x)
+    r1 = r0 != 0
+    if r1 goto L1 else goto L2 :: bool
+L1:
+    return 1
+L2:
+    return 0
+L3:
+    unreachable

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -159,3 +159,22 @@ def test_str_replace() -> None:
     assert a.replace("foo", "bar", 4) == "barbarbar"
     assert a.replace("aaa", "bar") == "foofoofoo"
     assert a.replace("ofo", "xyzw") == "foxyzwxyzwo"
+
+def is_true(x: str) -> bool:
+    if x:
+        return True
+    else:
+        return False
+
+def is_false(x: str) -> bool:
+    if not x:
+        return True
+    else:
+        return False
+
+def test_str_to_bool() -> None:
+    assert is_false('')
+    assert not is_true('')
+    for x in 'a', 'foo', 'bar', 'some string':
+        assert is_true(x)
+        assert not is_false(x)


### PR DESCRIPTION
This causes code that tests for the boolean value of a string to test the length directly instead of going through PyObject_IsTrue, as mentioned in mypyc/mypyc#768.

This should make code that uses this faster, but my benchmarks seem to show that this makes code slower than it would be without this optimization. I was hoping you could take a look at my code and the benchmarks and see if I'm doing anything wrong.

## Test Plan

I added a test that compiles and runs code that uses this, as well as an irbuild test, and ran all of the mypyc tests to make sure they were still working.

## Benchmarks

This is my benchmark code:
```python
import time

def run(s: str) -> None:
    t0 = time.time()
    for i in range(1_000_000):
        if s:
            pass
    t1 = time.time()
    print(f'{t1 - t0:.3f}')

run('')
run('A' * 100)
```

My results from running this benchmark several times each:

Interpreted version without mypyc: 0.022 to 0.024 seconds
Compiled version, from master (without these changes): 0.006 to 0.007 seconds
Compiled version, with these changes: 0.008 to 0.009 seconds