### PR TITLE
Use double quotes errors 'is not defined' and 'Cannot instantiate'

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -218,7 +218,7 @@ version of Python considers legal code. These can result in some of the
 following errors when trying to run your code:
 
 * ``ImportError`` from circular imports
-* ``NameError: name 'X' is not defined`` from forward references
+* ``NameError: name "X" is not defined`` from forward references
 * ``TypeError: 'type' object is not subscriptable`` from types that are not generic at runtime
 * ``ImportError`` or ``ModuleNotFoundError`` from use of stub definitions not available at runtime
 * ``TypeError: unsupported operand type(s) for |: 'type' and 'type'`` from use of new syntax

--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -87,7 +87,7 @@ This example accidentally calls ``sort()`` instead of :py:func:`sorted`:
 
 .. code-block:: python
 
-    x = sort([3, 2, 4])  # Error: Name 'sort' is not defined  [name-defined]
+    x = sort([3, 2, 4])  # Error: Name "sort" is not defined  [name-defined]
 
 Check arguments in calls [call-arg]
 -----------------------------------

--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -565,7 +565,7 @@ Example:
 
         ...  # No "save" method
 
-    # Error: Cannot instantiate abstract class 'Thing' with abstract attribute 'save'  [abstract]
+    # Error: Cannot instantiate abstract class "Thing" with abstract attribute "save"  [abstract]
     t = Thing()
 
 Check the target of NewType [valid-newtype]

--- a/docs/source/runtime_troubles.rst
+++ b/docs/source/runtime_troubles.rst
@@ -108,7 +108,7 @@ defined (aka forward reference). Thus this code does not work as expected:
 
 .. code-block:: python
 
-   def f(x: A) -> None: ...  # NameError: name 'A' is not defined
+   def f(x: A) -> None: ...  # NameError: name "A" is not defined
    class A: ...
 
 Starting from Python 3.7, you can add ``from __future__ import annotations`` to

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -931,9 +931,9 @@ class MessageBuilder:
     def cannot_instantiate_abstract_class(self, class_name: str,
                                           abstract_attributes: List[str],
                                           context: Context) -> None:
-        attrs = format_string_list(["'%s'" % a for a in abstract_attributes])
-        self.fail("Cannot instantiate abstract class '%s' with abstract "
-                  "attribute%s %s" % (class_name, plural_s(abstract_attributes),
+        attrs = format_string_list(['"%s"' % a for a in abstract_attributes])
+        self.fail('Cannot instantiate abstract class "%s" with abstract '
+                  'attribute%s %s' % (class_name, plural_s(abstract_attributes),
                                    attrs),
                   context, code=codes.ABSTRACT)
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4731,7 +4731,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             # later on. Defer current target.
             self.record_incomplete_ref()
             return
-        message = "Name '{}' is not defined".format(name)
+        message = 'Name "{}" is not defined'.format(name)
         self.fail(message, ctx, code=codes.NAME_DEFINED)
 
         if 'builtins.{}'.format(name) in SUGGESTED_TEST_FIXTURES:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -286,7 +286,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 if self.api.is_incomplete_namespace('builtins'):
                     self.api.record_incomplete_ref()
                 else:
-                    self.fail("Name 'tuple' is not defined", t)
+                    self.fail('Name "tuple" is not defined', t)
                 return AnyType(TypeOfAny.special_form)
             if len(t.args) == 0 and not t.empty_tuple_index:
                 # Bare 'Tuple' is same as 'tuple'

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -593,7 +593,7 @@ class LowLevelIRBuilder:
                             line: int = -1,
                             error_msg: Optional[str] = None) -> Value:
         if error_msg is None:
-            error_msg = "name '{}' is not defined".format(identifier)
+            error_msg = 'name "{}" is not defined'.format(identifier)
         ok_block, error_block = BasicBlock(), BasicBlock()
         value = self.add(LoadStatic(typ, identifier, module_name, namespace, line=line))
         self.add(Branch(value, error_block, ok_block, Branch.IS_ERROR, rare=True))

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -518,7 +518,7 @@ L6:
 (6, 0)   {a}                     {a}
 
 [case testError]
-def f(x: List[int]) -> None: pass # E: Name 'List' is not defined \
+def f(x: List[int]) -> None: pass # E: Name "List" is not defined \
                                   # N: Did you forget to import it from "typing"? (Suggestion: "from typing import List")
 
 [case testExceptUndefined_Liveness]

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -539,12 +539,12 @@ def f() -> None:
     return 1 # E: No return value expected
 
 [case testReportSemanticaAnalysisError1]
-def f(x: List[int]) -> None: pass # E: Name 'List' is not defined \
+def f(x: List[int]) -> None: pass # E: Name "List" is not defined \
                                   # N: Did you forget to import it from "typing"? (Suggestion: "from typing import List")
 
 [case testReportSemanticaAnalysisError2]
 def f() -> None:
-    x # E: Name 'x' is not defined
+    x # E: Name "x" is not defined
 
 [case testElif]
 def f(n: int) -> int:

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -533,7 +533,7 @@ L0:
     return r1
 
 [case testError]
-def f(x: List[int]) -> None: pass # E: Name 'List' is not defined \
+def f(x: List[int]) -> None: pass # E: Name "List" is not defined \
                                   # N: Did you forget to import it from "typing"? (Suggestion: "from typing import List")
 
 [case testNewList]

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -157,7 +157,7 @@ class B(metaclass=ABCMeta):
   @abstractmethod
   def f(self): pass
 A() # OK
-B() # E: Cannot instantiate abstract class 'B' with abstract attribute 'f'
+B() # E: Cannot instantiate abstract class "B" with abstract attribute "f"
 [out]
 
 [case testInstantiatingClassWithInheritedAbstractMethod]
@@ -169,7 +169,7 @@ class A(metaclass=ABCMeta):
   @abstractmethod
   def g(self): pass
 class B(A): pass
-B() # E: Cannot instantiate abstract class 'B' with abstract attributes 'f' and 'g'
+B() # E: Cannot instantiate abstract class "B" with abstract attributes "f" and "g"
 [out]
 
 [case testInstantiationAbstractsInTypeForFunctions]
@@ -187,7 +187,7 @@ class C(B):
 def f(cls: Type[A]) -> A:
     return cls()  # OK
 def g() -> A:
-    return A()  # E: Cannot instantiate abstract class 'A' with abstract attribute 'm'
+    return A()  # E: Cannot instantiate abstract class "A" with abstract attribute "m"
 
 f(A)  # E: Only concrete class can be given where "Type[A]" is expected
 f(B)  # E: Only concrete class can be given where "Type[A]" is expected
@@ -213,7 +213,7 @@ def f(cls: Type[A]) -> A:
 
 Alias = A
 GoodAlias = C
-Alias()  # E: Cannot instantiate abstract class 'A' with abstract attribute 'm'
+Alias()  # E: Cannot instantiate abstract class "A" with abstract attribute "m"
 GoodAlias()
 f(Alias)  # E: Only concrete class can be given where "Type[A]" is expected
 f(GoodAlias)
@@ -293,7 +293,7 @@ class A(metaclass=ABCMeta):
     def i(self): pass
     @abstractmethod
     def j(self): pass
-a = A() # E: Cannot instantiate abstract class 'A' with abstract attributes 'a', 'b', ... and 'j' (7 methods suppressed)
+a = A() # E: Cannot instantiate abstract class "A" with abstract attributes "a", "b", ... and "j" (7 methods suppressed)
 [out]
 
 
@@ -524,8 +524,8 @@ class D(A, B):
 class E(A, B):
   def f(self) -> None: pass
   def g(self) -> None: pass
-C() # E: Cannot instantiate abstract class 'C' with abstract attribute 'g'
-D() # E: Cannot instantiate abstract class 'D' with abstract attribute 'f'
+C() # E: Cannot instantiate abstract class "C" with abstract attribute "g"
+D() # E: Cannot instantiate abstract class "D" with abstract attribute "f"
 E()
 
 [case testInconsistentMro]
@@ -555,7 +555,7 @@ class B(A):
   def f(self, x: int) -> int: pass
   @overload
   def f(self, x: str) -> str: pass
-A() # E: Cannot instantiate abstract class 'A' with abstract attribute 'f'
+A() # E: Cannot instantiate abstract class "A" with abstract attribute "f"
 B()
 B().f(1)
 a = B() # type: A
@@ -585,7 +585,7 @@ class B(A):
   def f(self, x: int) -> int: pass
   @overload
   def f(self, x: str) -> str: pass
-A() # E: Cannot instantiate abstract class 'A' with abstract attribute 'f'
+A() # E: Cannot instantiate abstract class "A" with abstract attribute "f"
 B()
 B().f(1)
 a = B() # type: A
@@ -738,7 +738,7 @@ class A(metaclass=ABCMeta):
     @abstractproperty
     def x(self) -> int: pass
 class B(A): pass
-b = B() # E: Cannot instantiate abstract class 'B' with abstract attribute 'x'
+b = B() # E: Cannot instantiate abstract class "B" with abstract attribute "x"
 
 [case testInstantiateClassWithReadWriteAbstractProperty]
 from abc import abstractproperty, ABCMeta
@@ -748,7 +748,7 @@ class A(metaclass=ABCMeta):
     @x.setter
     def x(self, x: int) -> None: pass
 class B(A): pass
-b = B() # E: Cannot instantiate abstract class 'B' with abstract attribute 'x'
+b = B() # E: Cannot instantiate abstract class "B" with abstract attribute "x"
 
 [case testImplementAbstractPropertyViaProperty]
 from abc import abstractproperty, ABCMeta
@@ -803,7 +803,7 @@ b.x.y # E
 [builtins fixtures/property.pyi]
 [out]
 main:7: error: Property "x" defined in "A" is read-only
-main:8: error: Cannot instantiate abstract class 'B' with abstract attribute 'x'
+main:8: error: Cannot instantiate abstract class "B" with abstract attribute "x"
 main:9: error: "int" has no attribute "y"
 
 [case testSuperWithAbstractProperty]
@@ -952,15 +952,15 @@ class A:
 
     class C(B): pass
 
-A.B()  # E: Cannot instantiate abstract class 'B' with abstract attribute 'f'
-A.C()  # E: Cannot instantiate abstract class 'C' with abstract attribute 'f'
+A.B()  # E: Cannot instantiate abstract class "B" with abstract attribute "f"
+A.C()  # E: Cannot instantiate abstract class "C" with abstract attribute "f"
 
 [case testAbstractNewTypeAllowed]
 from typing import NewType, Mapping
 
 Config = NewType('Config', Mapping[str, str])
 
-bad = Mapping[str, str]()  # E: Cannot instantiate abstract class 'Mapping' with abstract attribute '__iter__'
+bad = Mapping[str, str]()  # E: Cannot instantiate abstract class "Mapping" with abstract attribute "__iter__"
 default = Config({'cannot': 'modify'})  # OK
 
 default[1] = 2  # E: Unsupported target for indexed assignment ("Config")
@@ -1008,9 +1008,9 @@ a.do()
 b = my_concrete_types['B']()
 b.do()
 
-c = my_abstract_types['A']()  # E: Cannot instantiate abstract class 'MyAbstractType' with abstract attribute 'do'
+c = my_abstract_types['A']()  # E: Cannot instantiate abstract class "MyAbstractType" with abstract attribute "do"
 c.do()
-d = my_abstract_types['B']()  # E: Cannot instantiate abstract class 'MyAbstractType' with abstract attribute 'do'
+d = my_abstract_types['B']()  # E: Cannot instantiate abstract class "MyAbstractType" with abstract attribute "do"
 d.do()
 
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-annotated.test
+++ b/test-data/unit/check-annotated.test
@@ -25,7 +25,7 @@ reveal_type(x)  # N: Revealed type is "builtins.int"
 
 [case testAnnotatedBadType]
 from typing_extensions import Annotated
-x: Annotated[XXX, ...]  # E: Name 'XXX' is not defined
+x: Annotated[XXX, ...]  # E: Name "XXX" is not defined
 reveal_type(x)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
@@ -56,7 +56,7 @@ reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testAnnotatedNestedBadType]
 from typing_extensions import Annotated
-x: Annotated[Annotated[XXX, ...], ...]  # E: Name 'XXX' is not defined
+x: Annotated[Annotated[XXX, ...], ...]  # E: Name "XXX" is not defined
 reveal_type(x)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
@@ -73,7 +73,7 @@ reveal_type(x)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
 [case testAnnotatedNoImport]
-x: Annotated[int, ...]  # E: Name 'Annotated' is not defined
+x: Annotated[int, ...]  # E: Name "Annotated" is not defined
 reveal_type(x)  # N: Revealed type is "Any"
 
 [case testAnnotatedDifferentName]

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1295,7 +1295,7 @@ import attr
 
 @attr.s
 class C:
-    total = attr.ib(type=Bad)  # E: Name 'Bad' is not defined
+    total = attr.ib(type=Bad)  # E: Name "Bad" is not defined
 [builtins fixtures/bool.pyi]
 
 [case testTypeInAttrForwardInRuntime]
@@ -1329,7 +1329,7 @@ import attr
 
 @attr.s(frozen=True)
 class C:
-    total = attr.ib(type=Bad)  # E: Name 'Bad' is not defined
+    total = attr.ib(type=Bad)  # E: Name "Bad" is not defined
 
 C(0).total = 1  # E: Property "total" defined in "C" is read-only
 [builtins fixtures/bool.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -235,7 +235,7 @@ class D(object):
 class A(object):
     def f(self) -> None:
         self.attr = 1
-    attr  # E: Name 'attr' is not defined
+    attr  # E: Name "attr" is not defined
 
 class B(object):
     attr = 0
@@ -2918,7 +2918,7 @@ C(arg=0)
 
 [case testErrorMapToSupertype]
 import typing
-class X(Nope): pass  # E: Name 'Nope' is not defined
+class X(Nope): pass  # E: Name "Nope" is not defined
 a, b = X()  # Used to crash here (#2244)
 
 
@@ -5239,7 +5239,7 @@ b = object()
 @b.nothing         # E: "object" has no attribute "nothing"
 class C: pass
 
-@undefined         # E: Name 'undefined' is not defined
+@undefined         # E: Name "undefined" is not defined
 class D: pass
 
 [case testSlotsCompatibility]
@@ -6619,7 +6619,7 @@ reveal_type(Foo().y)  # N: Revealed type is "builtins.list[Any]"
 
 class Foo:
     def bad():  # E: Method must have at least one argument
-        self.x = 0  # E: Name 'self' is not defined
+        self.x = 0  # E: Name "self" is not defined
 
 [case testTypeAfterAttributeAccessWithDisallowAnyExpr]
 # flags: --disallow-any-expr

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6120,9 +6120,9 @@ class B(A):
 class C(B):
     def __init__(self, a: int) -> None:
         self.c = a
-a = A(1) # E: Cannot instantiate abstract class 'A' with abstract attribute '__init__'
+a = A(1) # E: Cannot instantiate abstract class "A" with abstract attribute "__init__"
 A.c # E: "Type[A]" has no attribute "c"
-b = B(2) # E: Cannot instantiate abstract class 'B' with abstract attribute '__init__'
+b = B(2) # E: Cannot instantiate abstract class "B" with abstract attribute "__init__"
 B.c # E: "Type[B]" has no attribute "c"
 c = C(3)
 c.c

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -196,7 +196,7 @@ if int():
         pass
 
 [case testColumnNameIsNotDefined]
-((x)) # E:3: Name 'x' is not defined
+((x)) # E:3: Name "x" is not defined
 
 [case testColumnNeedTypeAnnotation]
 if 1:

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -881,8 +881,8 @@ from dataclasses import dataclass
 
 @dataclass
 class B:
-    x: Undefined  # E: Name 'Undefined' is not defined
-    y = undefined()  # E: Name 'undefined' is not defined
+    x: Undefined  # E: Name "Undefined" is not defined
+    y = undefined()  # E: Name "undefined" is not defined
 
 reveal_type(B)  # N: Revealed type is "def (x: Any) -> __main__.B"
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -425,7 +425,7 @@ main:2: error: Too few arguments for Enum()
 main:3: error: Enum() expects a string, tuple, list or dict literal as the second argument
 main:4: error: Too many arguments for Enum()
 main:5: error: Enum() expects a string, tuple, list or dict literal as the second argument
-main:5: error: Name 'foo' is not defined
+main:5: error: Name "foo" is not defined
 main:7: error: Enum() expects a string, tuple, list or dict literal as the second argument
 main:8: error: Too few arguments for IntEnum()
 main:9: error: IntEnum() expects a string, tuple, list or dict literal as the second argument

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -550,7 +550,7 @@ class A:
 class B(A):
     pass
 
-B()  # E: Cannot instantiate abstract class 'B' with abstract attribute 'f'  [abstract]
+B()  # E: Cannot instantiate abstract class "B" with abstract attribute "f"  [abstract]
 
 [case testErrorCodeNewTypeNotSubclassable]
 from typing import Union, NewType

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -15,9 +15,9 @@ thing = 0
 [builtins fixtures/module.pyi]
 
 [case testErrorCodeUndefinedName]
-x # E: Name 'x' is not defined  [name-defined]
+x # E: Name "x" is not defined  [name-defined]
 def f() -> None:
-    y # E: Name 'y' is not defined  [name-defined]
+    y # E: Name "y" is not defined  [name-defined]
 [file m.py]
 [builtins fixtures/module.pyi]
 
@@ -92,7 +92,7 @@ c = 'x'.foobar  # type: int  # type: ignore
 [case testErrorCodeIgnoreMultiple1]
 a = 'x'.foobar(b)  # type: ignore[name-defined, attr-defined]
 a = 'x'.foobar(b)  # type: ignore[name-defined, xyz]  # E: "str" has no attribute "foobar"  [attr-defined]
-a = 'x'.foobar(b)  # type: ignore[xyz, w, attr-defined]  # E: Name 'b' is not defined  [name-defined]
+a = 'x'.foobar(b)  # type: ignore[xyz, w, attr-defined]  # E: Name "b" is not defined  [name-defined]
 
 [case testErrorCodeIgnoreMultiple2]
 a = 'x'.foobar(b) # type: int # type: ignore[name-defined, attr-defined]
@@ -101,7 +101,7 @@ b = 'x'.foobar(b) # type: int # type: ignore[name-defined, xyz]  # E: "str" has 
 [case testErrorCodeIgnoreMultiple1_python2]
 a = 'x'.foobar(b)  # type: ignore[name-defined, attr-defined]
 a = 'x'.foobar(b)  # type: ignore[name-defined, xyz]  # E: "str" has no attribute "foobar"  [attr-defined]
-a = 'x'.foobar(b)  # type: ignore[xyz, w, attr-defined]  # E: Name 'b' is not defined  [name-defined]
+a = 'x'.foobar(b)  # type: ignore[xyz, w, attr-defined]  # E: Name "b" is not defined  [name-defined]
 
 [case testErrorCodeIgnoreMultiple2_python2]
 a = 'x'.foobar(b) # type: int # type: ignore[name-defined, attr-defined]
@@ -112,16 +112,16 @@ x  # type: ignore   [name-defined]
 x2 # type: ignore   [ name-defined ]
 x3 # type: ignore   [ xyz , name-defined ]
 x4 # type: ignore[xyz,name-defined]
-y  # type: ignore   [xyz]  # E: Name 'y' is not defined  [name-defined]
-y  # type: ignore[  xyz  ]  # E: Name 'y' is not defined  [name-defined]
-y  # type: ignore[ xyz , foo  ]  # E: Name 'y' is not defined  [name-defined]
+y  # type: ignore   [xyz]  # E: Name "y" is not defined  [name-defined]
+y  # type: ignore[  xyz  ]  # E: Name "y" is not defined  [name-defined]
+y  # type: ignore[ xyz , foo  ]  # E: Name "y" is not defined  [name-defined]
 
 a = z  # type: int  # type: ignore  [name-defined]
 b = z2  # type: int  # type: ignore  [ name-defined ]
 c = z2  # type: int  # type: ignore  [ name-defined , xyz ]
-d = zz # type: int  # type: ignore  [xyz]  # E: Name 'zz' is not defined  [name-defined]
-e = zz # type: int  # type: ignore  [ xyz ]  # E: Name 'zz' is not defined  [name-defined]
-f = zz # type: int  # type: ignore  [ xyz,foo ]  # E: Name 'zz' is not defined  [name-defined]
+d = zz # type: int  # type: ignore  [xyz]  # E: Name "zz" is not defined  [name-defined]
+e = zz # type: int  # type: ignore  [ xyz ]  # E: Name "zz" is not defined  [name-defined]
+f = zz # type: int  # type: ignore  [ xyz,foo ]  # E: Name "zz" is not defined  [name-defined]
 
 [case testErrorCodeIgnoreAfterArgComment]
 def f(x  # type: xyz  # type: ignore[name-defined]  # Comment
@@ -134,7 +134,7 @@ def g(x  # type: xyz  # type: ignore  # Comment
     # type () -> None
     pass
 
-def h(x  # type: xyz  # type: ignore[foo]  # E: Name 'xyz' is not defined  [name-defined]
+def h(x  # type: xyz  # type: ignore[foo]  # E: Name "xyz" is not defined  [name-defined]
       ):
     # type () -> None
     pass
@@ -150,7 +150,7 @@ def g(x  # type: xyz  # type: ignore  # Comment
     # type () -> None
     pass
 
-def h(x  # type: xyz  # type: ignore[foo]  # E: Name 'xyz' is not defined  [name-defined]
+def h(x  # type: xyz  # type: ignore[foo]  # E: Name "xyz" is not defined  [name-defined]
       ):
     # type () -> None
     pass
@@ -691,10 +691,10 @@ Foo() + a  # type: ignore[operator]
 x = y  # type: ignored[foo]
 xx = y  # type: ignored [foo]
 [out]
-main:1: error: Name 'ignored' is not defined  [name-defined]
-main:1: error: Name 'y' is not defined  [name-defined]
-main:2: error: Name 'ignored' is not defined  [name-defined]
-main:2: error: Name 'y' is not defined  [name-defined]
+main:1: error: Name "ignored" is not defined  [name-defined]
+main:1: error: Name "y" is not defined  [name-defined]
+main:2: error: Name "ignored" is not defined  [name-defined]
+main:2: error: Name "y" is not defined  [name-defined]
 
 [case testErrorCodeTypeIgnoreMisspelled2]
 x = y  # type: int  # type: ignored[foo]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -2172,7 +2172,7 @@ d5 = dict(a=1, b='') # type: Dict[str, Any]
 from typing import Dict
 d = dict() # E: Need type annotation for "d" (hint: "d: Dict[<type>, <type>] = ...")
 d2 = dict() # type: Dict[int, str]
-dict(undefined) # E: Name 'undefined' is not defined
+dict(undefined) # E: Name "undefined" is not defined
 [builtins fixtures/dict.pyi]
 
 [case testDictFromList]
@@ -2284,7 +2284,7 @@ main:4: note:     z: builtins.int
 [case testUndefinedRevealType]
 reveal_type(x)
 [out]
-main:1: error: Name 'x' is not defined
+main:1: error: Name "x" is not defined
 main:1: note: Revealed type is "Any"
 
 [case testUserDefinedRevealType]
@@ -2769,19 +2769,19 @@ if 1 in ('x', 'y'):  # E: Non-overlapping container check (element type: "int", 
 [typing fixtures/typing-full.pyi]
 
 [case testUnimportedHintAny]
-def f(x: Any) -> None:  # E: Name 'Any' is not defined \
+def f(x: Any) -> None:  # E: Name "Any" is not defined \
                         # N: Did you forget to import it from "typing"? (Suggestion: "from typing import Any")
     pass
 
 
 [case testUnimportedHintAnyLower]
-def f(x: any) -> None:  # E: Name 'any' is not defined \
+def f(x: any) -> None:  # E: Name "any" is not defined \
                         # N: Did you forget to import it from "typing"? (Suggestion: "from typing import Any")
     pass
 
 
 [case testUnimportedHintOptional]
-def f(x: Optional[str]) -> None:  # E: Name 'Optional' is not defined \
+def f(x: Optional[str]) -> None:  # E: Name "Optional" is not defined \
                                   # N: Did you forget to import it from "typing"? (Suggestion: "from typing import Optional")
     pass
 

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -352,7 +352,7 @@ assert 1
 assert 1, 2
 assert 1, 1+2
 assert 1, 1+'test'  # E: Unsupported operand types for + ("int" and "str")
-assert 1, f()  # E: Name 'f' is not defined
+assert 1, f()  # E: Name "f" is not defined
 
 [case testFastParserConsistentFunctionTypes]
 

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1320,7 +1320,7 @@ class Base:
     @decorator
     def method(self) -> None: pass
 [out]
-tmp/foo/base.py:3: error: Name 'decorator' is not defined
+tmp/foo/base.py:3: error: Name "decorator" is not defined
 
 
 -- Conditional function definition
@@ -1792,7 +1792,7 @@ import mypy_extensions as ext
 
 def WrongArg(x, y): return y
 def a(f: Callable[[WrongArg(int, 'x')], int]): pass # E: Invalid argument constructor "__main__.WrongArg"
-def b(f: Callable[[BadArg(int, 'x')], int]): pass # E: Name 'BadArg' is not defined
+def b(f: Callable[[BadArg(int, 'x')], int]): pass # E: Name "BadArg" is not defined
 def d(f: Callable[[ext.VarArg(int)], int]): pass # ok
 def e(f: Callable[[VARG(), ext.KwArg()], int]): pass # ok
 def g(f: Callable[[ext.Arg(name='x', type=int)], int]): pass # ok
@@ -2373,18 +2373,18 @@ def test(a: str) -> (str,): # E: Syntax error in type annotation # N: Suggestion
 
 [case testReturnTypeLineNumberNewLine]
 def fn(a: str
-       ) -> badtype: # E: Name 'badtype' is not defined
+       ) -> badtype: # E: Name "badtype" is not defined
     pass
 
 [case testArgumentTypeLineNumberWithDecorator]
 def dec(f): pass
 
 @dec
-def some_method(self: badtype): pass # E: Name 'badtype' is not defined
+def some_method(self: badtype): pass # E: Name "badtype" is not defined
 
 [case TestArgumentTypeLineNumberNewline]
 def fn(
-        a: badtype) -> None: # E: Name 'badtype' is not defined
+        a: badtype) -> None: # E: Name "badtype" is not defined
     pass
 
 [case testInferredTypeSubTypeOfReturnType]
@@ -2451,7 +2451,7 @@ def i() -> List[Union[str, int]]:
 [case testLambdaSemanal]
 f = lambda: xyz
 [out]
-main:1: error: Name 'xyz' is not defined
+main:1: error: Name "xyz" is not defined
 
 [case testLambdaTypeCheck]
 f = lambda: 1 + '1'
@@ -2578,9 +2578,9 @@ import p
 def f() -> int: ...
 
 [case testLambdaDefaultTypeErrors]
-lambda a=nonsense: a  # E: Name 'nonsense' is not defined
+lambda a=nonsense: a  # E: Name "nonsense" is not defined
 lambda a=(1 + 'asdf'): a  # E: Unsupported operand types for + ("int" and "str")
-def f(x: int = i):  # E: Name 'i' is not defined
+def f(x: int = i):  # E: Name "i" is not defined
     i = 42
 
 [case testRevealTypeOfCallExpressionReturningNoneWorks]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1245,7 +1245,7 @@ T = TypeVar('T')
 class A(Generic[T]):
     pass
 
-class B(A[S]): # E: Name 'S' is not defined
+class B(A[S]): # E: Name "S" is not defined
     pass
 [builtins fixtures/list.pyi]
 [out]

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -6,7 +6,7 @@ x() # E: "int" not callable
 [case testIgnoreUndefinedName]
 x = 1
 y # type: ignore
-z # E: Name 'z' is not defined
+z # E: Name "z" is not defined
 
 [case testIgnoreImportError]
 import xyz_m # type: ignore
@@ -29,7 +29,7 @@ b()
 
 [case testIgnoreImportAllError]
 from xyz_m import * # type: ignore
-x   # E: Name 'x' is not defined
+x   # E: Name "x" is not defined
 1() # E: "int" not callable
 
 [case testIgnoreImportBadModule]
@@ -254,16 +254,16 @@ IGNORE
 [case testDontIgnoreWholeModule1]
 if True:
     # type: ignore
-    ERROR # E: Name 'ERROR' is not defined
-ERROR # E: Name 'ERROR' is not defined
+    ERROR # E: Name "ERROR" is not defined
+ERROR # E: Name "ERROR" is not defined
 
 [case testDontIgnoreWholeModule2]
 @d  # type: ignore
 class C: ...
-ERROR # E: Name 'ERROR' is not defined
+ERROR # E: Name "ERROR" is not defined
 
 [case testDontIgnoreWholeModule3]
 @d  # type: ignore
 
 def f(): ...
-ERROR # E: Name 'ERROR' is not defined
+ERROR # E: Name "ERROR" is not defined

--- a/test-data/unit/check-incomplete-fixture.test
+++ b/test-data/unit/check-incomplete-fixture.test
@@ -39,14 +39,14 @@ main:1: note: Consider adding [builtins fixtures/set.pyi] to your test descripti
 [case testBaseExceptionMissingFromStubs]
 e: BaseException
 [out]
-main:1: error: Name 'BaseException' is not defined
+main:1: error: Name "BaseException" is not defined
 main:1: note: Maybe your test fixture does not define "builtins.BaseException"?
 main:1: note: Consider adding [builtins fixtures/exception.pyi] to your test description
 
 [case testExceptionMissingFromStubs]
 e: Exception
 [out]
-main:1: error: Name 'Exception' is not defined
+main:1: error: Name "Exception" is not defined
 main:1: note: Maybe your test fixture does not define "builtins.Exception"?
 main:1: note: Consider adding [builtins fixtures/exception.pyi] to your test description
 
@@ -54,14 +54,14 @@ main:1: note: Consider adding [builtins fixtures/exception.pyi] to your test des
 if isinstance(1, int):
     pass
 [out]
-main:1: error: Name 'isinstance' is not defined
+main:1: error: Name "isinstance" is not defined
 main:1: note: Maybe your test fixture does not define "builtins.isinstance"?
 main:1: note: Consider adding [builtins fixtures/isinstancelist.pyi] to your test description
 
 [case testTupleMissingFromStubs1]
 tuple()
 [out]
-main:1: error: Name 'tuple' is not defined
+main:1: error: Name "tuple" is not defined
 main:1: note: Maybe your test fixture does not define "builtins.tuple"?
 main:1: note: Consider adding [builtins fixtures/tuple.pyi] to your test description
 main:1: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Tuple")
@@ -71,18 +71,18 @@ tuple()
 from typing import Tuple
 x: Tuple[int, str]
 [out]
-main:1: error: Name 'tuple' is not defined
+main:1: error: Name "tuple" is not defined
 main:1: note: Maybe your test fixture does not define "builtins.tuple"?
 main:1: note: Consider adding [builtins fixtures/tuple.pyi] to your test description
 main:1: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Tuple")
-main:3: error: Name 'tuple' is not defined
+main:3: error: Name "tuple" is not defined
 
 [case testClassmethodMissingFromStubs]
 class A:
     @classmethod
     def f(cls): pass
 [out]
-main:2: error: Name 'classmethod' is not defined
+main:2: error: Name "classmethod" is not defined
 main:2: note: Maybe your test fixture does not define "builtins.classmethod"?
 main:2: note: Consider adding [builtins fixtures/classmethod.pyi] to your test description
 
@@ -91,6 +91,6 @@ class A:
     @property
     def f(self): pass
 [out]
-main:2: error: Name 'property' is not defined
+main:2: error: Name "property" is not defined
 main:2: note: Maybe your test fixture does not define "builtins.property"?
 main:2: note: Consider adding [builtins fixtures/property.pyi] to your test description

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -67,7 +67,7 @@ def foo() -> None:
 [rechecked m]
 [stale]
 [out2]
-tmp/m.py:2: error: Name 'bar' is not defined
+tmp/m.py:2: error: Name "bar" is not defined
 
 [case testIncrementalSimpleImportSequence]
 import mod1
@@ -126,7 +126,7 @@ def func1() -> A: pass
 [rechecked mod1]
 [stale]
 [out2]
-tmp/mod1.py:1: error: Name 'A' is not defined
+tmp/mod1.py:1: error: Name "A" is not defined
 
 [case testIncrementalCallable]
 import mod1
@@ -1928,9 +1928,9 @@ class C:
             pass
         self.a = A()
 [out1]
-main:2: error: Name 'nonexisting' is not defined
+main:2: error: Name "nonexisting" is not defined
 [out2]
-main:2: error: Name 'nonexisting' is not defined
+main:2: error: Name "nonexisting" is not defined
 
 [case testIncrementalInnerClassAttrInMethodReveal]
 import crash

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1537,7 +1537,7 @@ def add():
 [builtins fixtures/dict.pyi]
 
 [case testSpecialCaseEmptyListInitialization]
-def f(blocks: Any): # E: Name 'Any' is not defined \
+def f(blocks: Any): # E: Name "Any" is not defined \
                     # N: Did you forget to import it from "typing"? (Suggestion: "from typing import Any")
     to_process = []
     to_process = list(blocks)

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -295,7 +295,7 @@ z()
 [out]
 main:1: error: Cannot find implementation or library stub for module named "xyz"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-main:2: error: Name 'xyz' is not defined
+main:2: error: Name "xyz" is not defined
 
 [case testAccessingNameImportedFromUnknownModule]
 from xyz import y, z
@@ -311,7 +311,7 @@ y
 [out]
 main:1: error: Cannot find implementation or library stub for module named "xyz"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-main:2: error: Name 'y' is not defined
+main:2: error: Name "y" is not defined
 
 [case testAccessingNameImportedFromUnknownModule3]
 from xyz import y as z
@@ -320,7 +320,7 @@ z
 [out]
 main:1: error: Cannot find implementation or library stub for module named "xyz"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-main:2: error: Name 'y' is not defined
+main:2: error: Name "y" is not defined
 
 [case testUnknownModuleRedefinition]
 # Error messages differ with the new analyzer
@@ -404,8 +404,8 @@ _ = b
 _ = c
 _ = d
 _ = e
-_ = f # E: Name 'f' is not defined
-_ = _g # E: Name '_g' is not defined
+_ = f # E: Name "f" is not defined
+_ = _g # E: Name "_g" is not defined
 [file m.py]
 __all__ = ['a']
 __all__ += ('b',)
@@ -444,8 +444,8 @@ _ = _b
 _ = __c__
 _ = ___d
 _ = e
-_ = f # E: Name 'f' is not defined
-_ = _g # E: Name '_g' is not defined
+_ = f # E: Name "f" is not defined
+_ = _g # E: Name "_g" is not defined
 [file m.py]
 __all__ = ['a']
 __all__ += ('_b',)
@@ -839,8 +839,8 @@ import a.b.c
 reveal_type(a.value)  # N: Revealed type is "builtins.int"
 reveal_type(a.b.value)  # N: Revealed type is "builtins.str"
 reveal_type(a.b.c.value)  # N: Revealed type is "builtins.float"
-b.value  # E: Name 'b' is not defined
-c.value  # E: Name 'c' is not defined
+b.value  # E: Name "b" is not defined
+c.value  # E: Name "c" is not defined
 
 [file a/__init__.py]
 value = 3
@@ -853,9 +853,9 @@ value = 3.2
 [case testSubmoduleImportAsDoesNotAddParents]
 import a.b.c as foo
 reveal_type(foo.value)  # N: Revealed type is "builtins.float"
-a.value  # E: Name 'a' is not defined
-b.value  # E: Name 'b' is not defined
-c.value  # E: Name 'c' is not defined
+a.value  # E: Name "a" is not defined
+b.value  # E: Name "b" is not defined
+c.value  # E: Name "c" is not defined
 
 [file a/__init__.py]
 value = 3
@@ -869,7 +869,7 @@ value = 3.2
 from a import b
 reveal_type(b.value)  # N: Revealed type is "builtins.str"
 b.c.value  # E: Module has no attribute "c"
-a.value  # E: Name 'a' is not defined
+a.value  # E: Name "a" is not defined
 
 [file a/__init__.py]
 value = 3
@@ -883,8 +883,8 @@ value = 3.2
 [case testSubmoduleImportFromDoesNotAddParents2]
 from a.b import c
 reveal_type(c.value)  # N: Revealed type is "builtins.float"
-a.value  # E: Name 'a' is not defined
-b.value  # E: Name 'b' is not defined
+a.value  # E: Name "a" is not defined
+b.value  # E: Name "b" is not defined
 
 [file a/__init__.py]
 value = 3
@@ -912,14 +912,14 @@ a.b.c.value
 [file a/b/c.py]
 value = 3.2
 [out]
-tmp/a/b/__init__.py:2: error: Name 'c' is not defined
-tmp/a/b/__init__.py:3: error: Name 'a' is not defined
-tmp/a/__init__.py:2: error: Name 'b' is not defined
-tmp/a/__init__.py:3: error: Name 'a' is not defined
+tmp/a/b/__init__.py:2: error: Name "c" is not defined
+tmp/a/b/__init__.py:3: error: Name "a" is not defined
+tmp/a/__init__.py:2: error: Name "b" is not defined
+tmp/a/__init__.py:3: error: Name "a" is not defined
 
 [case testSubmoduleMixingLocalAndQualifiedNames]
 from a.b import MyClass
-val1 = None  # type: a.b.MyClass  # E: Name 'a' is not defined
+val1 = None  # type: a.b.MyClass  # E: Name "a" is not defined
 val2 = None  # type: MyClass
 
 [file a/__init__.py]
@@ -942,7 +942,7 @@ foo = parent.common.SomeClass()
 
 [builtins fixtures/module.pyi]
 [out]
-tmp/parent/child.py:3: error: Name 'parent' is not defined
+tmp/parent/child.py:3: error: Name "parent" is not defined
 
 [case testSubmoduleMixingImportFromAndImport]
 import parent.child
@@ -1844,7 +1844,7 @@ import stub
 
 c = stub.C()
 reveal_type(c.x)  # N: Revealed type is "builtins.int"
-it: stub.Iterable[int]  # E: Name 'stub.Iterable' is not defined
+it: stub.Iterable[int]  # E: Name "stub.Iterable" is not defined
 reveal_type(it)  # N: Revealed type is "Any"
 
 [file stub.pyi]
@@ -2096,7 +2096,7 @@ def __getattr__(name: str) -> Any: ...
 
 [case testModuleLevelGetattrImportFromAs]
 from has_attr import name as n
-reveal_type(name)  # E: Name 'name' is not defined  # N: Revealed type is "Any"
+reveal_type(name)  # E: Name "name" is not defined  # N: Revealed type is "Any"
 reveal_type(n)  # N: Revealed type is "Any"
 
 [file has_attr.pyi]
@@ -2762,7 +2762,7 @@ def __getattr__(name: str) -> ModuleType: ...
 # flags: --ignore-missing-imports
 import pack.mod as alias
 
-x: alias.NonExistent  # E: Name 'alias.NonExistent' is not defined
+x: alias.NonExistent  # E: Name "alias.NonExistent" is not defined
 
 [file pack/__init__.py]
 [file pack/mod.py]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -567,7 +567,7 @@ C.A  # E: "Type[C]" has no attribute "A"
 from typing import NamedTuple
 def f() -> None:
     A = NamedTuple('A', [('x', int)])
-A  # E: Name 'A' is not defined
+A  # E: Name "A" is not defined
 [builtins fixtures/tuple.pyi]
 
 [case testNamedTupleForwardAsUpperBound]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -3132,14 +3132,14 @@ class TopLevel(metaclass=ABCMeta):
     @abstractmethod
     def f(self) -> None: pass
 
-TopLevel()  # E: Cannot instantiate abstract class 'TopLevel' with abstract attribute 'f'
+TopLevel()  # E: Cannot instantiate abstract class "TopLevel" with abstract attribute "f"
 
 def func() -> None:
     class Function(metaclass=ABCMeta):
         @abstractmethod
         def f(self) -> None: pass
 
-    Function()  # E: Cannot instantiate abstract class 'Function' with abstract attribute 'f'
+    Function()  # E: Cannot instantiate abstract class "Function" with abstract attribute "f"
 
 class C:
     def meth(self) -> None:
@@ -3147,7 +3147,7 @@ class C:
             @abstractmethod
             def f(self) -> None: pass
 
-        Method()  # E: Cannot instantiate abstract class 'Method' with abstract attribute 'f'
+        Method()  # E: Cannot instantiate abstract class "Method" with abstract attribute "f"
 
 [case testModulesAndFuncsTargetsInCycle]
 import a

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -5,7 +5,7 @@
 [case testNewAnalyzerSimpleAssignment]
 x = 1
 x.y # E: "int" has no attribute "y"
-y # E: Name 'y' is not defined
+y # E: Name "y" is not defined
 
 [case testNewAnalyzerSimpleAnnotation]
 x: int = 0
@@ -21,7 +21,7 @@ a.y # E: "A" has no attribute "y"
 
 [case testNewAnalyzerErrorInClassBody]
 class A:
-    x # E: Name 'x' is not defined
+    x # E: Name "x" is not defined
 
 [case testNewAnalyzerTypeAnnotationForwardReference]
 class A:
@@ -87,8 +87,8 @@ _ = b
 _ = c
 _ = d
 _e = e
-_f = f # E: Name 'f' is not defined
-_ = _g # E: Name '_g' is not defined
+_f = f # E: Name "f" is not defined
+_ = _g # E: Name "_g" is not defined
 reveal_type(_e)  # N: Revealed type is "m.A"
 [file m.py]
 __all__ = ['a']
@@ -428,9 +428,9 @@ def main() -> None:
 [case testNewAnalyzerMissingNamesInFunctions]
 def main() -> None:
     def f() -> None:
-        x  # E: Name 'x' is not defined
+        x  # E: Name "x" is not defined
         class C:
-            x  # E: Name 'x' is not defined
+            x  # E: Name "x" is not defined
 
 [case testNewAnalyzerCyclicDefinitions]
 gx = gy  # E: Cannot resolve name "gy" (possible cyclic definition)
@@ -772,8 +772,8 @@ class C(Generic[T]):
     def __init__(self, x: T) -> None: ...
 def func(x: U) -> U: ...
 
-U = TypeVar('U', asdf, asdf)  # E: Name 'asdf' is not defined
-T = TypeVar('T', bound=asdf)  # E: Name 'asdf' is not defined
+U = TypeVar('U', asdf, asdf)  # E: Name "asdf" is not defined
+T = TypeVar('T', bound=asdf)  # E: Name "asdf" is not defined
 
 reveal_type(C)  # N: Revealed type is "def [T <: Any] (x: T`1) -> __main__.C[T`1]"
 reveal_type(func)  # N: Revealed type is "def [U in (Any, Any)] (x: U`-1) -> U`-1"
@@ -1118,7 +1118,7 @@ class B: ...
 [case testNewAnalyzerIncompleteFixture]
 from typing import Tuple
 
-x: Tuple[int]  # E: Name 'tuple' is not defined
+x: Tuple[int]  # E: Name "tuple" is not defined
 [builtins fixtures/complex.pyi]
 
 [case testNewAnalyzerMetaclass1]
@@ -1985,7 +1985,7 @@ class C(List[C], other=C): ...
 [builtins fixtures/list.pyi]
 
 [case testNewAnalyzerClassKeywordsError]
-class C(other=asdf): ...  # E: Name 'asdf' is not defined
+class C(other=asdf): ...  # E: Name "asdf" is not defined
 
 [case testNewAnalyzerMissingImport]
 # flags: --ignore-missing-imports
@@ -2049,7 +2049,7 @@ class C(metaclass=Meta):
     pass
 
 [case testNewAnalyzerFunctionError]
-def f(x: asdf) -> None:  # E: Name 'asdf' is not defined
+def f(x: asdf) -> None:  # E: Name "asdf" is not defined
     pass
 
 [case testNewAnalyzerEnumRedefinition]
@@ -2496,7 +2496,7 @@ class TestSuite(BaseTestSuite):
 class TestCase: ...
 
 [out]
-tmp/unittest/suite.pyi:6: error: Name 'Iterable' is not defined
+tmp/unittest/suite.pyi:6: error: Name "Iterable" is not defined
 tmp/unittest/suite.pyi:6: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Iterable")
 
 [case testNewAnalyzerNewTypeSpecialCase]
@@ -2535,7 +2535,7 @@ from p.c import B
 [case testNewSemanticAnalyzerQualifiedFunctionAsType]
 import m
 
-x: m.C.a.b # E: Name 'm.C.a.b' is not defined
+x: m.C.a.b # E: Name "m.C.a.b" is not defined
 
 [file m.py]
 def C(): pass
@@ -2543,7 +2543,7 @@ def C(): pass
 [case testNewSemanticAnalyzerModulePrivateRefInMiddleOfQualified]
 import m
 
-x: m.n.C # E: Name 'm.n.C' is not defined
+x: m.n.C # E: Name "m.n.C" is not defined
 reveal_type(x) # N: Revealed type is "Any"
 
 [file m.pyi]
@@ -2557,8 +2557,8 @@ class C: pass
 import m
 import n
 
-x: m.n.C # E: Name 'm.n.C' is not defined
-y: n.D # E: Name 'n.D' is not defined
+x: m.n.C # E: Name "m.n.C" is not defined
+y: n.D # E: Name "n.D" is not defined
 [file m.py]
 import n
 [file n.py]
@@ -2586,7 +2586,7 @@ class C:
 
     def f(self) -> None:
         # TODO: Error message could be better
-        class D(self.E): # E: Name 'self.E' is not defined
+        class D(self.E): # E: Name "self.E" is not defined
             pass
 
 [case testNewAnalyzerShadowOuterDefinitionBasedOnOrderSinglePass]
@@ -2674,10 +2674,10 @@ reveal_type(C().str()) # N: Revealed type is "builtins.str"
 
 [case testNewAnalyzerNameNotDefinedYetInClassBody]
 class C:
-    X = Y  # E: Name 'Y' is not defined
+    X = Y  # E: Name "Y" is not defined
     Y = 1
 
-    f = g  # E: Name 'g' is not defined
+    f = g  # E: Name "g" is not defined
 
     def g(self) -> None: pass
 
@@ -2859,7 +2859,7 @@ class B: ...
 [out]
 tmp/a/__init__.py:4: note: Revealed type is "def ()"
 tmp/a/__init__.py:5: note: Revealed type is "a.b.B"
-main:2: error: Name 'a.b.B' is not defined
+main:2: error: Name "a.b.B" is not defined
 main:3: note: Revealed type is "def ()"
 
 [case testNewAnalyzerConfusingImportConflictingNames]
@@ -3115,9 +3115,9 @@ reveal_type(C()) # N: Revealed type is "__main__.C"
 reveal_type(x) # N: Revealed type is "__main__.C"
 
 [case testNewAnalyzerIdentityAssignment7]
-C = C # E: Name 'C' is not defined
+C = C # E: Name "C" is not defined
 
-reveal_type(C) # E: Name 'C' is not defined \
+reveal_type(C) # E: Name "C" is not defined \
                # N: Revealed type is "Any"
 
 [case testNewAnalyzerIdentityAssignment8]

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -375,6 +375,6 @@ issubclass(object, T)  # E: Cannot use issubclass() with NewType type
 
 from typing import List, NewType, Union
 N = NewType('N', XXX)  # E: Argument 2 to NewType(...) must be subclassable (got "Any") \
-                       # E: Name 'XXX' is not defined
+                       # E: Name "XXX" is not defined
 x: List[Union[N, int]]
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -8,19 +8,19 @@ def f(a): pass
 def f(a): pass
 f(0)
 
-@overload  # E: Name 'overload' is not defined
+@overload  # E: Name "overload" is not defined
 def g(a:int): pass
 def g(a): pass  # E: Name 'g' already defined on line 9
 g(0)
 
-@something  # E: Name 'something' is not defined
+@something  # E: Name "something" is not defined
 def r(a:int): pass
 def r(a): pass  # E: Name 'r' already defined on line 14
 r(0)
 [out]
-main:2: error: Name 'overload' is not defined
+main:2: error: Name "overload" is not defined
 main:4: error: Name 'f' already defined on line 2
-main:4: error: Name 'overload' is not defined
+main:4: error: Name "overload" is not defined
 main:6: error: Name 'f' already defined on line 2
 
 [case testTypeCheckOverloadWithImplementation]
@@ -5091,7 +5091,7 @@ def func(x: int) -> int: ...
 def func(x):
     return x
 [out]
-tmp/lib.pyi:1: error: Name 'overload' is not defined
+tmp/lib.pyi:1: error: Name "overload" is not defined
 tmp/lib.pyi:4: error: Name 'func' already defined on line 1
 main:2: note: Revealed type is "Any"
 
@@ -5106,9 +5106,9 @@ def func(x: int) -> int: ...
 @overload
 def func(x: str) -> str: ...
 [out]
-tmp/lib.pyi:1: error: Name 'overload' is not defined
+tmp/lib.pyi:1: error: Name "overload" is not defined
 tmp/lib.pyi:3: error: Name 'func' already defined on line 1
-tmp/lib.pyi:3: error: Name 'overload' is not defined
+tmp/lib.pyi:3: error: Name "overload" is not defined
 main:3: note: Revealed type is "Any"
 
 [case testLiteralSubtypeOverlap]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -393,7 +393,7 @@ class P(C, Protocol): # E: All bases of a protocol must be protocols
 class P2(P, D, Protocol): # E: All bases of a protocol must be protocols
     pass
 
-P2() # E: Cannot instantiate abstract class 'P2' with abstract attribute 'attr'
+P2() # E: Cannot instantiate abstract class "P2" with abstract attribute "attr"
 p: P2
 reveal_type(p.attr) # N: Revealed type is "builtins.int"
 
@@ -917,7 +917,7 @@ class P(Protocol):
 class A(P):
     pass
 
-A() # E: Cannot instantiate abstract class 'A' with abstract attribute 'meth'
+A() # E: Cannot instantiate abstract class "A" with abstract attribute "meth"
 
 class C(A):
     def meth(self) -> int:
@@ -938,7 +938,7 @@ class P(Protocol):
 class A(P):
     pass
 
-A() # E: Cannot instantiate abstract class 'A' with abstract attribute 'attr'
+A() # E: Cannot instantiate abstract class "A" with abstract attribute "attr"
 
 class C(A):
     attr: int
@@ -1114,7 +1114,7 @@ class P(Protocol):
     def meth(self, x: str) -> bytes: pass
 class C(P):
     pass
-C() # E: Cannot instantiate abstract class 'C' with abstract attribute 'meth'
+C() # E: Cannot instantiate abstract class "C" with abstract attribute "meth"
 
 [case testCanUseOverloadedImplementationsInProtocols]
 from typing import overload, Protocol, Union

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -310,9 +310,9 @@ class C(object):
 [case testErrorInMetaclass]
 x = 0
 class A(object):
-    __metaclass__ = m.M  # E: Name 'm' is not defined
+    __metaclass__ = m.M  # E: Name "m" is not defined
 class B(object):
-    __metaclass__ = M  # E: Name 'M' is not defined
+    __metaclass__ = M  # E: Name "M" is not defined
 
 [case testMetaclassAndSkippedImportInPython2]
 # flags: --ignore-missing-imports

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -269,7 +269,7 @@ def f(x: int = (c := 4)) -> int:
     reveal_type(y7)  # N: Revealed type is "builtins.int"
 
     reveal_type((lambda: (y8 := 3) and y8)())  # N: Revealed type is "Literal[3]?"
-    y8  # E: Name 'y8' is not defined
+    y8  # E: Name "y8" is not defined
 
     y7 = 1.0  # E: Incompatible types in assignment (expression has type "float", variable has type "int")
     if y7 := "x":  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
@@ -362,8 +362,8 @@ class AssignmentExpressionsClass:
         reveal_type(z3)  # N: Revealed type is "builtins.int"
 
 # Assignment expressions from inside the class should not escape the class scope.
-reveal_type(x2)  # E: Name 'x2' is not defined  # N: Revealed type is "Any"
-reveal_type(z2)  # E: Name 'z2' is not defined  # N: Revealed type is "Any"
+reveal_type(x2)  # E: Name "x2" is not defined  # N: Revealed type is "Any"
+reveal_type(z2)  # E: Name "z2" is not defined  # N: Revealed type is "Any"
 
 [builtins fixtures/isinstancelist.pyi]
 

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -627,7 +627,7 @@ from typing import overload
 
 class P:
     @overload
-    def __init__(self: Bad, x: int) -> None: ...  # E: Name 'Bad' is not defined
+    def __init__(self: Bad, x: int) -> None: ...  # E: Name "Bad" is not defined
     @overload
     def __init__(self) -> None: ...
 

--- a/test-data/unit/check-semanal-error.test
+++ b/test-data/unit/check-semanal-error.test
@@ -39,11 +39,11 @@ x # E
 [out]
 main:1: error: Cannot find implementation or library stub for module named "m"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-main:2: error: Name 'x' is not defined
+main:2: error: Name "x" is not defined
 main:3: error: "int" not callable
 
 [case testInvalidBaseClass1]
-class A(X): # E: Name 'X' is not defined
+class A(X): # E: Name "X" is not defined
     x = 1
 A().foo(1)
 A().x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -395,7 +395,7 @@ class A(metaclass=ABCMeta):
     def x(self) -> int: return 0
 [typing fixtures/typing-medium.pyi]
 [out2]
-tmp/a.py:2: error: Cannot instantiate abstract class 'A' with abstract attributes 'f' and 'x'
+tmp/a.py:2: error: Cannot instantiate abstract class "A" with abstract attributes "f" and "x"
 tmp/a.py:9: error: Property "x" defined in "A" is read-only
 
 [case testSerializeStaticMethod]

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1788,7 +1788,7 @@ def foo() -> None:
     global bar
     # TODO: Confusing error message
     bar = []  # type: List[str]  # E: Name 'bar' already defined (possibly by an import)
-    bar  # E: Name 'bar' is not defined
+    bar  # E: Name "bar" is not defined
 
 def foo2():
     global bar2

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -328,7 +328,7 @@ class B:
     def f(self) -> None: pass
 class C(B):
     def h(self) -> None:
-        super(x, y).f # E: Name 'x' is not defined # E: Name 'y' is not defined
+        super(x, y).f # E: Name "x" is not defined # E: Name "y" is not defined
 
 [case testTypeErrorInSuperArg]
 class B:

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -779,7 +779,7 @@ C.A  # E: "Type[C]" has no attribute "A"
 from mypy_extensions import TypedDict
 def f() -> None:
     A = TypedDict('A', {'x': int})
-A  # E: Name 'A' is not defined
+A  # E: Name "A" is not defined
 [builtins fixtures/dict.pyi]
 
 
@@ -1129,7 +1129,7 @@ class D(TypedDict, total=1): # E: Value of "total" must be True or False
 class E(TypedDict, total=bool): # E: Value of "total" must be True or False
     x: int
 class F(TypedDict, total=xyz): # E: Value of "total" must be True or False \
-                               # E: Name 'xyz' is not defined
+                               # E: Name "xyz" is not defined
     x: int
 [builtins fixtures/dict.pyi]
 

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -131,7 +131,7 @@ else:
     import xyz753
 [builtins fixtures/bool.pyi]
 [out]
-main:1: error: Name 'TYPE_CHECKING' is not defined
+main:1: error: Name "TYPE_CHECKING" is not defined
 main:4: error: Cannot find implementation or library stub for module named "xyz753"
 main:4: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -25,8 +25,8 @@ undef
 undef
 import pkg.subpkg.a
 [out]
-pkg/a.py:1: error: Name 'undef' is not defined
-pkg/subpkg/a.py:1: error: Name 'undef' is not defined
+pkg/a.py:1: error: Name "undef" is not defined
+pkg/subpkg/a.py:1: error: Name "undef" is not defined
 
 [case testCmdlinePackageSlash]
 # cmd: mypy pkg/
@@ -38,8 +38,8 @@ undef
 undef
 import pkg.subpkg.a
 [out]
-pkg/a.py:1: error: Name 'undef' is not defined
-pkg/subpkg/a.py:1: error: Name 'undef' is not defined
+pkg/a.py:1: error: Name "undef" is not defined
+pkg/subpkg/a.py:1: error: Name "undef" is not defined
 
 [case testCmdlineNonPackage]
 # cmd: mypy dir
@@ -48,8 +48,8 @@ undef
 [file dir/subdir/b.py]
 undef
 [out]
-dir/a.py:1: error: Name 'undef' is not defined
-dir/subdir/b.py:1: error: Name 'undef' is not defined
+dir/a.py:1: error: Name "undef" is not defined
+dir/subdir/b.py:1: error: Name "undef" is not defined
 
 [case testCmdlineNonPackageDuplicate]
 # cmd: mypy dir
@@ -71,8 +71,8 @@ import b
 undef
 import a
 [out]
-dir/a.py:1: error: Name 'undef' is not defined
-dir/subdir/b.py:1: error: Name 'undef' is not defined
+dir/a.py:1: error: Name "undef" is not defined
+dir/subdir/b.py:1: error: Name "undef" is not defined
 
 [case testCmdlinePackageContainingSubdir]
 # cmd: mypy pkg
@@ -84,8 +84,8 @@ import a
 undef
 import pkg.a
 [out]
-pkg/a.py:1: error: Name 'undef' is not defined
-pkg/subdir/a.py:1: error: Name 'undef' is not defined
+pkg/a.py:1: error: Name "undef" is not defined
+pkg/subdir/a.py:1: error: Name "undef" is not defined
 
 [case testCmdlineNonPackageContainingPackage]
 # cmd: mypy dir
@@ -96,8 +96,8 @@ import subpkg.a
 [file dir/subpkg/a.py]
 undef
 [out]
-dir/subpkg/a.py:1: error: Name 'undef' is not defined
-dir/a.py:1: error: Name 'undef' is not defined
+dir/subpkg/a.py:1: error: Name "undef" is not defined
+dir/a.py:1: error: Name "undef" is not defined
 
 [case testCmdlineInvalidPackageName]
 # cmd: mypy dir/sub.pkg/a.py
@@ -538,15 +538,15 @@ undef
 [file c.d.pyi]
 whatever
 [out]
-c.d.pyi:1: error: Name 'whatever' is not defined
-a.b.py:1: error: Name 'undef' is not defined
+c.d.pyi:1: error: Name "whatever" is not defined
+a.b.py:1: error: Name "undef" is not defined
 
 [case testDotInFilenameOKFolder]
 # cmd: mypy my.folder
 [file my.folder/tst.py]
 undef
 [out]
-my.folder/tst.py:1: error: Name 'undef' is not defined
+my.folder/tst.py:1: error: Name "undef" is not defined
 
 [case testDotInFilenameNoImport]
 # cmd: mypy main.py
@@ -938,9 +938,9 @@ fail
 [file foo/lol.py]
 fail
 [out]
-foo/lol.py:1: error: Name 'fail' is not defined
-emarg/foo.py:1: error: Name 'fail' is not defined
-emarg/hatch/villip/mankangulisk.py:1: error: Name 'fail' is not defined
+foo/lol.py:1: error: Name "fail" is not defined
+emarg/foo.py:1: error: Name "fail" is not defined
+emarg/hatch/villip/mankangulisk.py:1: error: Name "fail" is not defined
 
 [case testPackageRootEmpty]
 # cmd: mypy --package-root= a/b/c.py main.py
@@ -987,8 +987,8 @@ fail
 [file b.py]
 fail
 [out]
-b.py:1: error: Name 'fail' is not defined
-a.py:1: error: Name 'fail' is not defined
+b.py:1: error: Name "fail" is not defined
+a.py:1: error: Name "fail" is not defined
 
 [case testIniFilesGlobbing]
 # cmd: mypy
@@ -1000,8 +1000,8 @@ fail
 [file c.py]
 fail
 [out]
-a/b.py:1: error: Name 'fail' is not defined
-c.py:1: error: Name 'fail' is not defined
+a/b.py:1: error: Name "fail" is not defined
+c.py:1: error: Name "fail" is not defined
 
 [case testIniFilesCmdlineOverridesConfig]
 # cmd: mypy override.py

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -111,11 +111,11 @@ def plugin(version): return Dummy
 -- Note: Backslash path separator in output is replaced with forward slash so the same test succeeds on Windows as well
 $ dmypy run -- foo --follow-imports=error --python-version=3.6
 Daemon started
-foo/lol.py:1: error: Name 'fail' is not defined
+foo/lol.py:1: error: Name "fail" is not defined
 Found 1 error in 1 file (checked 3 source files)
 == Return code: 1
 $ dmypy run -- foo --follow-imports=error --python-version=3.6
-foo/lol.py:1: error: Name 'fail' is not defined
+foo/lol.py:1: error: Name "fail" is not defined
 Found 1 error in 1 file (checked 3 source files)
 == Return code: 1
 $ {python} -c "print('[mypy]')" >mypy.ini
@@ -238,7 +238,7 @@ $ {python} -c "import time;time.sleep(1)"
 $ {python} -c "print('lol')" >foo.py
 $ dmypy run --log-file=log -- foo.py bar.py --follow-imports=error --use-fine-grained-cache --no-sqlite-cache --python-version=3.6 --quickstart-file test.json
 Daemon started
-foo.py:1: error: Name 'lol' is not defined
+foo.py:1: error: Name "lol" is not defined
 Found 1 error in 1 file (checked 2 source files)
 == Return code: 1
 -- make sure no errors made it to the log file

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -130,9 +130,9 @@ import b
 f()
 [file a.py.2]
 [out]
-b.py:1: error: Name 'f' is not defined
+b.py:1: error: Name "f" is not defined
 ==
-b.py:1: error: Name 'f' is not defined
+b.py:1: error: Name "f" is not defined
 
 [case testRemoveSubmoduleFromBuild1]
 # cmd1: mypy a.py b/__init__.py b/c.py
@@ -763,8 +763,8 @@ z
 main:2: error: Cannot find implementation or library stub for module named "a"
 main:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 ==
-a.py:3: error: Name 'z' is not defined
-<ROOT>/test-data/unit/lib-stub/broken.pyi:2: error: Name 'y' is not defined
+a.py:3: error: Name "z" is not defined
+<ROOT>/test-data/unit/lib-stub/broken.pyi:2: error: Name "y" is not defined
 
 [case testRenameModule]
 import a
@@ -1485,7 +1485,7 @@ f()
 [file b.py.2]
 def f(x: int) -> None: pass
 [out]
-main:2: error: Name 'f' is not defined
+main:2: error: Name "f" is not defined
 ==
 main:2: error: Missing positional argument "x" in call to "f"
 
@@ -1504,11 +1504,11 @@ class C: pass
 def f() -> None: pass
 class C: pass
 [out]
-main:3: error: Name 'f' is not defined
-main:4: error: Name 'C' is not defined
+main:3: error: Name "f" is not defined
+main:4: error: Name "C" is not defined
 ==
 main:3: error: Missing positional argument "x" in call to "f"
-main:4: error: Name 'C' is not defined
+main:4: error: Name "C" is not defined
 ==
 main:3: error: Missing positional argument "x" in call to "f"
 ==
@@ -1537,7 +1537,7 @@ f()
 [file p/b.py.2]
 def f(x: int) -> None: pass
 [out]
-p/a.py:2: error: Name 'f' is not defined
+p/a.py:2: error: Name "f" is not defined
 ==
 p/a.py:2: error: Missing positional argument "x" in call to "f"
 
@@ -1561,7 +1561,7 @@ def f() -> None: pass
 [file b.py.2]
 [out]
 ==
-main:2: error: Name 'f' is not defined
+main:2: error: Name "f" is not defined
 
 [case testImportStarWithinFunction]
 def f() -> None:

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -197,7 +197,7 @@ class A: pass
 [file m.py.2]
 [out]
 ==
-main:3: error: Name 'm.A' is not defined
+main:3: error: Name "m.A" is not defined
 
 [case testTwoIncrementalSteps]
 import m
@@ -1602,7 +1602,7 @@ class C:
 [out]
 main:7: error: "A" has no attribute "x"
 ==
-main:3: error: Name 'm.C' is not defined
+main:3: error: Name "m.C" is not defined
 
 [case testBaseClassOfNestedClassDeleted]
 import m
@@ -1620,7 +1620,7 @@ class C:
 [out]
 main:8: error: "B" has no attribute "x"
 ==
-main:4: error: Name 'm.C' is not defined
+main:4: error: Name "m.C" is not defined
 
 [case testImportQualifiedModuleName]
 import a
@@ -2022,11 +2022,11 @@ class A:
 class A:
     def foo(self) -> int: pass
 [out]
-a.py:3: error: Name 'nothing' is not defined
+a.py:3: error: Name "nothing" is not defined
 ==
-a.py:3: error: Name 'nothing' is not defined
+a.py:3: error: Name "nothing" is not defined
 ==
-a.py:3: error: Name 'nothing' is not defined
+a.py:3: error: Name "nothing" is not defined
 ==
 
 [case testPreviousErrorInMethodSemanalPass3]
@@ -3205,7 +3205,7 @@ class M(type):
 whatever: int
 [out]
 ==
-b.py:2: error: Name 'c.M' is not defined
+b.py:2: error: Name "c.M" is not defined
 a.py:3: error: "Type[B]" has no attribute "x"
 
 [case testFixMissingMetaclass]
@@ -3224,7 +3224,7 @@ whatever: int
 class M(type):
     x: int
 [out]
-b.py:2: error: Name 'c.M' is not defined
+b.py:2: error: Name "c.M" is not defined
 a.py:3: error: "Type[B]" has no attribute "x"
 ==
 
@@ -3916,7 +3916,7 @@ A = int
 import a
 x: a.A
 [out]
-b.py:2: error: Name 'a.A' is not defined
+b.py:2: error: Name "a.A" is not defined
 ==
 
 [case testAliasFineDeleted]
@@ -3929,7 +3929,7 @@ import a
 x: a.A
 [out]
 ==
-b.py:2: error: Name 'a.A' is not defined
+b.py:2: error: Name "a.A" is not defined
 
 [case testAliasFineClassToAlias]
 import b
@@ -3975,7 +3975,7 @@ def f(x: A[int]):
 [builtins fixtures/dict.pyi]
 [out]
 ==
-b.py:4: error: Name 'a.B' is not defined
+b.py:4: error: Name "a.B" is not defined
 
 [case testAliasFineTargetDeleted]
 import c
@@ -3992,7 +3992,7 @@ def f(x: b.B):
     pass
 [out]
 ==
-c.py:2: error: Name 'b.B' is not defined
+c.py:2: error: Name "b.B" is not defined
 
 [case testAliasFineClassInFunction]
 import b
@@ -5090,7 +5090,7 @@ class B:
 [out]
 a.py:2: error: Value of type variable "T" of function cannot be "int"
 ==
-c.py:3: error: Name 'd.B' is not defined
+c.py:3: error: Name "d.B" is not defined
 
 [case testGenericFineCallableToNonGeneric]
 import a
@@ -7923,7 +7923,7 @@ def bar(x: T) -> T:
     pass
 x = 1
 [out]
-a.py:1: error: Name 'TypeVar' is not defined
+a.py:1: error: Name "TypeVar" is not defined
 a.py:1: note: Did you forget to import it from "typing"? (Suggestion: "from typing import TypeVar")
 a.py:7: error: Variable "a.T" is not valid as a type
 a.py:7: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
@@ -7931,7 +7931,7 @@ a.py:10: error: Name 'bar' already defined on line 6
 a.py:11: error: Variable "a.T" is not valid as a type
 a.py:11: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 ==
-a.py:1: error: Name 'TypeVar' is not defined
+a.py:1: error: Name "TypeVar" is not defined
 a.py:1: note: Did you forget to import it from "typing"? (Suggestion: "from typing import TypeVar")
 a.py:7: error: Variable "a.T" is not valid as a type
 a.py:7: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
@@ -7968,7 +7968,7 @@ class A: pass
 [builtins fixtures/list.pyi]
 [out]
 ==
-main:4: error: Name 'm.A' is not defined
+main:4: error: Name "m.A" is not defined
 
 [case testIdLikeDecoForwardCrash]
 import b

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -6370,7 +6370,7 @@ class C:
     x: int
 [out]
 ==
-a.py:2: error: Cannot instantiate abstract class 'C' with abstract attribute 'x'
+a.py:2: error: Cannot instantiate abstract class "C" with abstract attribute "x"
 ==
 
 [case testInvalidateProtocolViaSuperClass]
@@ -7665,7 +7665,7 @@ class C:
     def g(self) -> None: pass
 [out]
 ==
-main:2: error: Cannot instantiate abstract class 'D' with abstract attribute 'g'
+main:2: error: Cannot instantiate abstract class "D" with abstract attribute "g"
 ==
 
 [case testMakeClassAbstract]
@@ -7681,7 +7681,7 @@ class C:
     def f(self) -> None: pass
 [out]
 ==
-main:2: error: Cannot instantiate abstract class 'C' with abstract attribute 'f'
+main:2: error: Cannot instantiate abstract class "C" with abstract attribute "f"
 
 [case testMakeMethodNoLongerAbstract1]
 [file z.py]

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -240,7 +240,7 @@ b'zar'
 import typing
 cast(int, 2)
 [out]
-_program.py:2: error: Name 'cast' is not defined
+_program.py:2: error: Name "cast" is not defined
 _program.py:2: note: Did you forget to import it from "typing"? (Suggestion: "from typing import cast")
 
 [case testBinaryIOType]
@@ -635,8 +635,8 @@ import typing
 def f(x: _T) -> None: pass
 s: FrozenSet
 [out]
-_program.py:2: error: Name '_T' is not defined
-_program.py:3: error: Name 'FrozenSet' is not defined
+_program.py:2: error: Name "_T" is not defined
+_program.py:3: error: Name "FrozenSet" is not defined
 
 [case testVarArgsFunctionSubtyping]
 import typing
@@ -913,7 +913,7 @@ _testCollectionsAliases.py:21: note: Revealed type is "collections.deque[builtin
 ChainMap[int, str]()
 
 [out]
-_testChainMapUnimported.py:1: error: Name 'ChainMap' is not defined
+_testChainMapUnimported.py:1: error: Name "ChainMap" is not defined
 
 [case testDequeWrongCase]
 import collections

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -3,8 +3,8 @@ import typing
 x
 y
 [out]
-main:2: error: Name 'x' is not defined
-main:3: error: Name 'y' is not defined
+main:2: error: Name "x" is not defined
+main:3: error: Name "y" is not defined
 
 [case testUndefinedVariableWithinFunctionContext]
 import typing
@@ -12,8 +12,8 @@ def f() -> None:
   x
 y
 [out]
-main:3: error: Name 'x' is not defined
-main:4: error: Name 'y' is not defined
+main:3: error: Name "x" is not defined
+main:4: error: Name "y" is not defined
 
 [case testMethodScope]
 import typing
@@ -21,7 +21,7 @@ class A:
   def f(self): pass
 f
 [out]
-main:4: error: Name 'f' is not defined
+main:4: error: Name "f" is not defined
 
 [case testMethodScope2]
 import typing
@@ -32,14 +32,14 @@ class B:
     f # error
     g # error
 [out]
-main:6: error: Name 'f' is not defined
-main:7: error: Name 'g' is not defined
+main:6: error: Name "f" is not defined
+main:7: error: Name "g" is not defined
 
 [case testInvalidType]
 import typing
 x = None # type: X
 [out]
-main:2: error: Name 'X' is not defined
+main:2: error: Name "X" is not defined
 
 [case testInvalidGenericArg]
 from typing import TypeVar, Generic
@@ -47,7 +47,7 @@ t = TypeVar('t')
 class A(Generic[t]): pass
 x = 0 # type: A[y]
 [out]
-main:4: error: Name 'y' is not defined
+main:4: error: Name "y" is not defined
 
 [case testInvalidNumberOfGenericArgsInTypeDecl]
 from typing import TypeVar, Generic
@@ -187,7 +187,7 @@ x
 [file m.py]
 x = y = 1
 [out]
-main:3: error: Name 'x' is not defined
+main:3: error: Name "x" is not defined
 
 [case testMissingNameInImportFrom]
 import typing
@@ -246,7 +246,7 @@ import _n
 [file _n.py]
 x = 1
 [out]
-main:3: error: Name '_n' is not defined
+main:3: error: Name "_n" is not defined
 
 [case testImportAsteriskPlusUnderscore]
 import typing
@@ -256,8 +256,8 @@ __x__
 [file _m.py]
 _x = __x__ = 1
 [out]
-main:3: error: Name '_x' is not defined
-main:4: error: Name '__x__' is not defined
+main:3: error: Name "_x" is not defined
+main:4: error: Name "__x__" is not defined
 
 [case testRelativeImportAtTopLevelModule]
 from . import m
@@ -276,8 +276,8 @@ def f() -> m.c: pass
 def g() -> n.c: pass
 [file m.py]
 [out]
-main:3: error: Name 'm.c' is not defined
-main:4: error: Name 'n' is not defined
+main:3: error: Name "m.c" is not defined
+main:4: error: Name "n" is not defined
 
 [case testMissingPackage]
 import typing
@@ -302,7 +302,7 @@ import m
 import typing
 x = y
 [out]
-tmp/m.py:2: error: Name 'y' is not defined
+tmp/m.py:2: error: Name "y" is not defined
 
 [case testErrorInImportedModule2]
 import m.n
@@ -313,7 +313,7 @@ import k
 import typing
 x = y
 [out]
-tmp/k.py:2: error: Name 'y' is not defined
+tmp/k.py:2: error: Name "y" is not defined
 
 [case testPackageWithoutInitFile]
 import typing
@@ -455,7 +455,7 @@ main:8: error: Two starred expressions in assignment
 (a for *a, (*b, c) in [])
 (a for a, (*b, *c) in [])
 [out]
-main:1: error: Name 'a' is not defined
+main:1: error: Name "a" is not defined
 main:1: error: Two starred expressions in assignment
 main:3: error: Two starred expressions in assignment
 
@@ -484,7 +484,7 @@ del x + 1 # E: can't delete operator
 [out]
 
 [case testInvalidDel3]
-del z     # E: Name 'z' is not defined
+del z     # E: Name "z" is not defined
 [out]
 
 [case testFunctionTvarScope]
@@ -530,7 +530,7 @@ main:3: error: Method must have at least one argument
 import typing
 class A(B): pass
 [out]
-main:2: error: Name 'B' is not defined
+main:2: error: Name "B" is not defined
 
 [case testSuperOutsideClass]
 class A: pass
@@ -564,7 +564,7 @@ def f() -> None:
     global x
     x = None
 [out]
-main:4: error: Name 'x' is not defined
+main:4: error: Name "x" is not defined
 
 [case testInvalidNonlocalDecl]
 import typing
@@ -574,7 +574,7 @@ def f():
        x = None
 [out]
 main:4: error: No binding for nonlocal 'x' found
-main:5: error: Name 'x' is not defined
+main:5: error: Name "x" is not defined
 
 [case testNonlocalDeclNotMatchingGlobal]
 import typing
@@ -584,7 +584,7 @@ def f() -> None:
     x = None
 [out]
 main:4: error: No binding for nonlocal 'x' found
-main:5: error: Name 'x' is not defined
+main:5: error: Name "x" is not defined
 
 [case testNonlocalDeclConflictingWithParameter]
 import typing
@@ -635,8 +635,8 @@ def f(x) -> None:
     y
     x
 [out]
-main:5: error: Name 'z' is not defined
-main:6: error: Name 'y' is not defined
+main:5: error: Name "z" is not defined
+main:6: error: Name "y" is not defined
 
 [case testMultipleNestedFunctionDef]
 import typing
@@ -668,14 +668,14 @@ class A:
            x
        y
 [out]
-main:5: error: Name 'x' is not defined
-main:6: error: Name 'y' is not defined
+main:5: error: Name "x" is not defined
+main:6: error: Name "y" is not defined
 
 [case testImportScope]
 import typing
 def f() -> None:
     import x
-x.y # E: Name 'x' is not defined
+x.y # E: Name "x" is not defined
 [file x.py]
 y = 1
 [out]
@@ -685,7 +685,7 @@ import typing
 def f() -> None:
     from x import y
     y
-y # E: Name 'y' is not defined
+y # E: Name "y" is not defined
 [file x.py]
 y = 1
 [out]
@@ -695,7 +695,7 @@ import typing
 def f() -> None:
     from x import *
     y
-y # E: Name 'y' is not defined
+y # E: Name "y" is not defined
 [file x.py]
 y = 1
 [out]
@@ -705,7 +705,7 @@ import typing
 class A:
     from x import *
     y
-y # E: Name 'y' is not defined
+y # E: Name "y" is not defined
 [file x.py]
 y = 1
 [out]
@@ -715,14 +715,14 @@ import typing
 def f():
     class A: pass
     A
-A # E: Name 'A' is not defined
+A # E: Name "A" is not defined
 [out]
 
 [case testScopeOfNestedClass2]
 import typing
 class A:
     class B: pass
-B # E: Name 'B' is not defined
+B # E: Name "B" is not defined
 [out]
 
 [case testScopeOfNestedClass3]
@@ -730,14 +730,14 @@ import typing
 class A:
     def f(self):
         class B: pass
-    B # E: Name 'B' is not defined
-B # E: Name 'B' is not defined
+    B # E: Name "B" is not defined
+B # E: Name "B" is not defined
 [out]
 
 [case testInvalidNestedClassReferenceInDecl]
 import typing
 class A: pass
-foo = 0 # type: A.x      # E: Name 'A.x' is not defined
+foo = 0 # type: A.x      # E: Name "A.x" is not defined
 [out]
 
 [case testTvarScopingWithNestedClass]
@@ -800,8 +800,8 @@ from typing import cast
 x = 0
 cast(x, None)        # E: Variable "__main__.x" is not valid as a type \
                      # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
-cast(t, None)        # E: Name 't' is not defined
-cast(__builtins__.x, None) # E: Name '__builtins__.x' is not defined
+cast(t, None)        # E: Name "t" is not defined
+cast(__builtins__.x, None) # E: Name "__builtins__.x" is not defined
 [out]
 
 [case testInvalidCastTargetType2]
@@ -965,7 +965,7 @@ from typing import TypeVar
 T = TypeVar('T')
 class A(Generic[T]): pass
 [out]
-main:3: error: Name 'Generic' is not defined
+main:3: error: Name "Generic" is not defined
 
 [case testInvalidTypeWithinGeneric]
 from typing import Generic
@@ -989,12 +989,12 @@ class A(Generic[T], Generic[S]): pass \
 [out]
 
 [case testInvalidMetaclass]
-class A(metaclass=x): pass # E: Name 'x' is not defined
+class A(metaclass=x): pass # E: Name "x" is not defined
 [out]
 
 [case testInvalidQualifiedMetaclass]
 import abc
-class A(metaclass=abc.Foo): pass # E: Name 'abc.Foo' is not defined
+class A(metaclass=abc.Foo): pass # E: Name "abc.Foo" is not defined
 [out]
 
 [case testNonClassMetaclass]
@@ -1039,14 +1039,14 @@ main:2: error: Use TypeVar('T', t, ...) instead of TypeVar('T', values=(t, ...))
 from typing import TypeVar
 def f() -> None:
     T = TypeVar('T')
-def g(x: T) -> None: pass # E: Name 'T' is not defined
+def g(x: T) -> None: pass # E: Name "T" is not defined
 [out]
 
 [case testClassTypevarScope]
 from typing import TypeVar
 class A:
     T = TypeVar('T')
-def g(x: T) -> None: pass # E: Name 'T' is not defined
+def g(x: T) -> None: pass # E: Name "T" is not defined
 [out]
 
 [case testRedefineVariableAsTypevar]
@@ -1085,7 +1085,7 @@ from typing import Generic as t # E: Name 't' already defined on line 2
 [out]
 
 [case testInvalidStrLiteralType]
-def f(x: 'foo'): pass # E: Name 'foo' is not defined
+def f(x: 'foo'): pass # E: Name "foo" is not defined
 [out]
 
 [case testInvalidStrLiteralStrayBrace]
@@ -1242,7 +1242,7 @@ import typing
 def f() -> List[int]: pass
 [builtins fixtures/list.pyi]
 [out]
-main:2: error: Name 'List' is not defined
+main:2: error: Name "List" is not defined
 main:2: note: Did you forget to import it from "typing"? (Suggestion: "from typing import List")
 
 [case testInvalidWithTarget]
@@ -1268,7 +1268,7 @@ main:3: error: can't assign to function call
 class A:
     class X: pass
     class B:
-        y = X  # E: Name 'X' is not defined
+        y = X  # E: Name "X" is not defined
 [out]
 
 [case testStubPackage]
@@ -1296,8 +1296,8 @@ class A:
     z = 1
     [x for i in z if y]
 [out]
-main:5: error: Name 'x' is not defined
-main:5: error: Name 'y' is not defined
+main:5: error: Name "x" is not defined
+main:5: error: Name "y" is not defined
 
 [case testTypeRedeclarationNoSpuriousWarnings]
 from typing import Tuple

--- a/test-data/unit/semanal-modules.test
+++ b/test-data/unit/semanal-modules.test
@@ -825,7 +825,7 @@ tmp/f.py:1: error: Module 'm.x' has no attribute 'somefunction'; maybe "somefun_
 [case testFromImportAsInStub]
 from m import *
 x
-y  # E: Name 'y' is not defined
+y  # E: Name "y" is not defined
 [file m.pyi]
 from m2 import x as x
 from m2 import y
@@ -855,7 +855,7 @@ MypyFile:1(
 [case testImportAsInStub]
 from m import *
 m2
-m3  # E: Name 'm3' is not defined
+m3  # E: Name "m3" is not defined
 [file m.pyi]
 import m2 as m2
 import m3
@@ -886,8 +886,8 @@ x
 [file m.py]
 y
 [out]
-tmp/m.py:1: error: Name 'y' is not defined
-main:2: error: Name 'x' is not defined
+tmp/m.py:1: error: Name "y" is not defined
+main:2: error: Name "x" is not defined
 
 [case testImportTwice]
 import typing

--- a/test-data/unit/semanal-namedtuple.test
+++ b/test-data/unit/semanal-namedtuple.test
@@ -187,4 +187,4 @@ class A(NamedTuple('N', [1])): pass
 class B(A): pass
 [out]
 main:2: error: Unsupported dynamic base class "NamedTuple"
-main:2: error: Name 'NamedTuple' is not defined
+main:2: error: Name "NamedTuple" is not defined


### PR DESCRIPTION
### Description
This pull request fixes issue reported in #7445  for **is not defined** and **Cannot instantiate** error message

## Test Plan
Updated test cases for the message. New test cases not added.