### PR TITLE
[mypyc] Pre-allocate space in list comprehensions

### DIFF
--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -137,7 +137,9 @@ def sequence_from_generator_preallocate_helper(
         gen: GeneratorExpr,
         empty_op_llbuilder: Callable[[Value, int], Value],
         set_item_op: CFunctionDescription) -> Optional[Value]:
-    """Currently we only optimize for simplest generator expression, which means that
+    """Generate a new tuple or list from a simple generator expression.
+
+    Currently we only optimize for simplest generator expression, which means that
     there is no condition list in the generator and only one original sequence with
     one index is allowed.
 

--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -136,8 +136,11 @@ def preallocate_space_helper(builder: IRBuilder,
                              gen: GeneratorExpr,
                              empty_op_llbuilder: Callable[[Value, int], Value],
                              set_item_op: CFunctionDescription) -> Optional[Value]:
-    """Currently we only optimize for simplest generator expression"""
-    if len(gen.sequences) == 1 and len(gen.condlists[0]) == 0:
+    """Currently we only optimize for simplest generator expression.
+
+    "... for index in list/tuple"
+    """
+    if len(gen.sequences) == 1 and len(gen.indices) == 1 and len(gen.condlists[0]) == 0:
         rtype = builder.node_type(gen.sequences[0])
         if is_list_rprimitive(rtype) or is_tuple_rprimitive(rtype):
 
@@ -157,6 +160,7 @@ def preallocate_space_helper(builder: IRBuilder,
 
 
 def translate_list_comprehension(builder: IRBuilder, gen: GeneratorExpr) -> Value:
+    # Try simplest list comprehension, otherwise fall back to general one
     val = preallocate_space_helper(builder, gen,
                                    empty_op_llbuilder=builder.builder.new_list_op_with_length,
                                    set_item_op=list_set_item_op)

--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -24,7 +24,7 @@ from mypyc.primitives.dict_ops import (
     dict_next_key_op, dict_next_value_op, dict_next_item_op, dict_check_size_op,
     dict_key_iter_op, dict_value_iter_op, dict_item_iter_op
 )
-from mypyc.primitives.list_ops import list_append_op, list_get_item_unsafe_op, list_set_item_op
+from mypyc.primitives.list_ops import list_append_op, list_get_item_unsafe_op, new_list_set_item_op
 from mypyc.primitives.set_ops import set_add_op
 from mypyc.primitives.generic_ops import iter_op, next_op
 from mypyc.primitives.exc_ops import no_err_occurred_op
@@ -163,7 +163,7 @@ def translate_list_comprehension(builder: IRBuilder, gen: GeneratorExpr) -> Valu
     # Try simplest list comprehension, otherwise fall back to general one
     val = preallocate_space_helper(builder, gen,
                                    empty_op_llbuilder=builder.builder.new_list_op_with_length,
-                                   set_item_op=list_set_item_op)
+                                   set_item_op=new_list_set_item_op)
     if val is not None:
         return val
 

--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -24,7 +24,7 @@ from mypyc.primitives.dict_ops import (
     dict_next_key_op, dict_next_value_op, dict_next_item_op, dict_check_size_op,
     dict_key_iter_op, dict_value_iter_op, dict_item_iter_op
 )
-from mypyc.primitives.list_ops import list_append_op, list_get_item_unsafe_op
+from mypyc.primitives.list_ops import list_append_op, list_get_item_unsafe_op, list_set_item_op
 from mypyc.primitives.set_ops import set_add_op
 from mypyc.primitives.generic_ops import iter_op, next_op
 from mypyc.primitives.exc_ops import no_err_occurred_op
@@ -157,6 +157,12 @@ def preallocate_space_helper(builder: IRBuilder,
 
 
 def translate_list_comprehension(builder: IRBuilder, gen: GeneratorExpr) -> Value:
+    val = preallocate_space_helper(builder, gen,
+                                   empty_op_llbuilder=builder.builder.new_list_op_with_length,
+                                   set_item_op=list_set_item_op)
+    if val is not None:
+        return val
+
     list_ops = builder.new_list_op([], gen.line)
     loop_params = list(zip(gen.indices, gen.sequences, gen.condlists))
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -892,6 +892,13 @@ class LowLevelIRBuilder:
         return result
 
     def new_list_op_with_length(self, length: Value, line: int) -> Value:
+        """This function returns an uninitialized list. You might need
+        further initialization with `CPyList_SetItemUnsafe` op.
+
+        Args:
+            length: desired length of the new list. The rtype should be
+                    c_pyssize_t_rprimitive
+        """
         return self.call_c(new_list_op, [length], line)
 
     def new_list_op(self, values: List[Value], line: int) -> Value:

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -891,7 +891,7 @@ class LowLevelIRBuilder:
 
         return result
 
-    def new_list_op(self, length: Value, line: int) -> Value:
+    def new_list_op_with_length(self, length: Value, line: int) -> Value:
         return self.call_c(new_list_op, [length], line)
 
     def new_list_op(self, values: List[Value], line: int) -> Value:

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -892,12 +892,16 @@ class LowLevelIRBuilder:
         return result
 
     def new_list_op_with_length(self, length: Value, line: int) -> Value:
-        """This function returns an uninitialized list. You might need
-        further initialization with `CPyList_SetItemUnsafe` op.
+        """This function returns an uninitialized list.
+
+        If the length is non-zero, the caller must initialize the list, before
+        it can be made visible to user code -- otherwise the list object is broken.
+        You might need further initialization with `new_list_set_item_op` op.
 
         Args:
             length: desired length of the new list. The rtype should be
                     c_pyssize_t_rprimitive
+            line: line number
         """
         return self.call_c(new_list_op, [length], line)
 
@@ -1135,10 +1139,15 @@ class LowLevelIRBuilder:
         return self.call_c(new_tuple_op, [size] + items, line)
 
     def new_tuple_with_length(self, length: Value, line: int) -> Value:
-        """Generate a new empty tuple with length
+        """This function returns an uninitialized tuple.
+
+        If the length is non-zero, the caller must initialize the tuple, before
+        it can be made visible to user code -- otherwise the tuple object is broken.
+        You might need further initialization with `new_tuple_set_item_op` op.
 
         Args:
-            length: desired length, whose type should be c_pyssize_t_rprimitive
+            length: desired length of the new tuple. The rtype should be
+                    c_pyssize_t_rprimitive
             line: line number
         """
         return self.call_c(new_tuple_with_length_op, [length], line)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -891,6 +891,9 @@ class LowLevelIRBuilder:
 
         return result
 
+    def new_list_op(self, length: Value, line: int) -> Value:
+        return self.call_c(new_list_op, [length], line)
+
     def new_list_op(self, values: List[Value], line: int) -> Value:
         length = Integer(len(values), c_pyssize_t_rprimitive, line)
         result_list = self.call_c(new_list_op, [length], line)
@@ -1124,14 +1127,13 @@ class LowLevelIRBuilder:
         size = Integer(len(items), c_pyssize_t_rprimitive)  # type: Value
         return self.call_c(new_tuple_op, [size] + items, line)
 
-    def new_tuple_with_length(self, val: Value, line: int) -> Value:
-        """Generate a new empty tuple with length from a list or tuple
+    def new_tuple_with_length(self, length: Value, line: int) -> Value:
+        """Generate a new empty tuple with length
 
         Args:
-            val: a list or tuple
+            length: desired length, whose type should be c_pyssize_t_rprimitive
             line: line number
         """
-        length = self.builtin_len(val, line, use_pyssize_t=True)
         return self.call_c(new_tuple_with_length_op, [length], line)
 
     # Internal helpers

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -93,12 +93,6 @@ def dict_methods_fast_path(
     if not (len(expr.args) == 1 and expr.arg_kinds == [ARG_POS]):
         return None
     arg = expr.args[0]
-    # if isinstance(arg, GeneratorExpr):
-    #     val = preallocate_space_helper(builder, arg,
-    #                                    empty_op_llbuilder=builder.builder.new_list_op_with_length,
-    #                                    set_item_op=list_set_item_op)
-    #     if val is not None:
-    #         return val
     if not (isinstance(arg, CallExpr) and not arg.args
             and isinstance(arg.callee, MemberExpr)):
         return None

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -158,10 +158,10 @@ def translate_safe_generator_call(
                 builder.node_type(expr), expr.line, expr.arg_kinds, expr.arg_names)
         else:
             if len(expr.args) == 1 and callee.fullname == "builtins.tuple":
-                val = preallocate_space_helper(builder, expr.args[0],
-                                               empty_op_llbuilder=
-                                                   builder.builder.new_tuple_with_length,
-                                               set_item_op=new_tuple_set_item_op)
+                val = preallocate_space_helper(
+                    builder, expr.args[0],
+                    empty_op_llbuilder=builder.builder.new_tuple_with_length,
+                    set_item_op=new_tuple_set_item_op)
                 if val is not None:
                     return val
 

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -22,16 +22,15 @@ from mypyc.ir.ops import (
 )
 from mypyc.ir.rtypes import (
     RType, RTuple, str_rprimitive, list_rprimitive, dict_rprimitive, set_rprimitive,
-    bool_rprimitive, is_dict_rprimitive, is_list_rprimitive, is_tuple_rprimitive
+    bool_rprimitive, is_dict_rprimitive
 )
-from mypyc.primitives.registry import CFunctionDescription
 from mypyc.primitives.dict_ops import dict_keys_op, dict_values_op, dict_items_op
 from mypyc.primitives.tuple_ops import new_tuple_set_item_op
 from mypyc.primitives.list_ops import list_set_item_op
 from mypyc.irbuild.builder import IRBuilder
 from mypyc.irbuild.for_helpers import (
     translate_list_comprehension, translate_set_comprehension,
-    comprehension_helper, for_loop_helper_with_index,
+    comprehension_helper, preallocate_space_helper
 )
 
 
@@ -160,7 +159,8 @@ def translate_safe_generator_call(
         else:
             if len(expr.args) == 1 and callee.fullname == "builtins.tuple":
                 val = preallocate_space_helper(builder, expr.args[0],
-                                               empty_op_llbuilder=builder.builder.new_tuple_with_length,
+                                               empty_op_llbuilder=
+                                                   builder.builder.new_tuple_with_length,
                                                set_item_op=new_tuple_set_item_op)
                 if val is not None:
                     return val
@@ -169,30 +169,6 @@ def translate_safe_generator_call(
                 expr, callee,
                 ([translate_list_comprehension(builder, expr.args[0])]
                     + [builder.accept(arg) for arg in expr.args[1:]]))
-    return None
-
-
-def preallocate_space_helper(builder: IRBuilder,
-                             gen: GeneratorExpr,
-                             empty_op_llbuilder: Callable[[Value, int], Value],
-                             set_item_op: CFunctionDescription) -> Optional[Value]:
-    """Currently we only optimize for simplest generator expression"""
-    if len(gen.sequences) == 1 and len(gen.condlists[0]) == 0:
-        rtype = builder.node_type(gen.sequences[0])
-        if is_list_rprimitive(rtype) or is_tuple_rprimitive(rtype):
-
-            length = builder.builder.builtin_len(builder.accept(gen.sequences[0]),
-                                                 gen.line, use_pyssize_t=True)
-            target_op = empty_op_llbuilder(length, gen.line)
-
-            def set_item(item_index: Value) -> None:
-                e = builder.accept(gen.left_expr)
-                builder.call_c(set_item_op, [target_op, item_index, e], gen.line)
-
-            for_loop_helper_with_index(builder, gen.indices[0], gen.sequences[0],
-                                       set_item, gen.line)
-
-            return target_op
     return None
 
 

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -93,12 +93,12 @@ def dict_methods_fast_path(
     if not (len(expr.args) == 1 and expr.arg_kinds == [ARG_POS]):
         return None
     arg = expr.args[0]
-    if isinstance(arg, GeneratorExpr):
-        val = preallocate_space_helper(builder, arg,
-                                       empty_op_llbuilder=builder.builder.new_list_op_with_length,
-                                       set_item_op=list_set_item_op)
-        if val is not None:
-            return val
+    # if isinstance(arg, GeneratorExpr):
+    #     val = preallocate_space_helper(builder, arg,
+    #                                    empty_op_llbuilder=builder.builder.new_list_op_with_length,
+    #                                    set_item_op=list_set_item_op)
+    #     if val is not None:
+    #         return val
     if not (isinstance(arg, CallExpr) and not arg.args
             and isinstance(arg.callee, MemberExpr)):
         return None

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -29,7 +29,7 @@ from mypyc.primitives.tuple_ops import new_tuple_set_item_op
 from mypyc.irbuild.builder import IRBuilder
 from mypyc.irbuild.for_helpers import (
     translate_list_comprehension, translate_set_comprehension,
-    comprehension_helper, preallocate_space_helper
+    comprehension_helper, sequence_from_generator_preallocate_helper
 )
 
 
@@ -151,7 +151,7 @@ def translate_safe_generator_call(
                 builder.node_type(expr), expr.line, expr.arg_kinds, expr.arg_names)
         else:
             if len(expr.args) == 1 and callee.fullname == "builtins.tuple":
-                val = preallocate_space_helper(
+                val = sequence_from_generator_preallocate_helper(
                     builder, expr.args[0],
                     empty_op_llbuilder=builder.builder.new_tuple_with_length,
                     set_item_op=new_tuple_set_item_op)

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -26,7 +26,6 @@ from mypyc.ir.rtypes import (
 )
 from mypyc.primitives.dict_ops import dict_keys_op, dict_values_op, dict_items_op
 from mypyc.primitives.tuple_ops import new_tuple_set_item_op
-from mypyc.primitives.list_ops import list_set_item_op
 from mypyc.irbuild.builder import IRBuilder
 from mypyc.irbuild.for_helpers import (
     translate_list_comprehension, translate_set_comprehension,

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -19,6 +19,8 @@ extern "C" {
 } // why isn't emacs smart enough to not indent this
 #endif
 
+#define CPYTHON_LARGE_INT_ERRMSG "Python int too large to convert to C ssize_t"
+
 
 // Naming conventions:
 //

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -320,6 +320,7 @@ PyObject *CPyList_GetItem(PyObject *list, CPyTagged index);
 PyObject *CPyList_GetItemUnsafe(PyObject *list, CPyTagged index);
 PyObject *CPyList_GetItemShort(PyObject *list, CPyTagged index);
 bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value);
+bool CPyList_SetItemUnsafe(PyObject *list, CPyTagged index, PyObject *value);
 PyObject *CPyList_PopLast(PyObject *obj);
 PyObject *CPyList_Pop(PyObject *obj, CPyTagged index);
 CPyTagged CPyList_Count(PyObject *obj, PyObject *value);

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -52,7 +52,7 @@ PyObject *CPyList_GetItem(PyObject *list, CPyTagged index) {
         Py_INCREF(result);
         return result;
     } else {
-        PyErr_SetString(PyExc_IndexError, "list index out of range");
+        PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
         return NULL;
     }
 }
@@ -79,7 +79,7 @@ bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value) {
         PyList_SET_ITEM(list, n, value);
         return true;
     } else {
-        PyErr_SetString(PyExc_OverflowError, "set_item index too large for list");
+        PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
         return false;
     }
 }
@@ -91,7 +91,7 @@ bool CPyList_SetItemUnsafe(PyObject *list, CPyTagged index, PyObject *value) {
         PyList_SET_ITEM(list, n, value);
         return true;
     } else {
-        PyErr_SetString(PyExc_OverflowError, "set_item index too large for list");
+        PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
         return false;
     }
 }
@@ -110,7 +110,7 @@ PyObject *CPyList_Pop(PyObject *obj, CPyTagged index)
         Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);
         return list_pop_impl((PyListObject *)obj, n);
     } else {
-        PyErr_SetString(PyExc_IndexError, "pop index too large for list");
+        PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
         return NULL;
     }
 }
@@ -128,7 +128,7 @@ int CPyList_Insert(PyObject *list, CPyTagged index, PyObject *value)
     }
     // The max range doesn't exactly coincide with ssize_t, but we still
     // want to keep the error message compatible with CPython.
-    PyErr_SetString(PyExc_OverflowError, "insert index too large for list");
+    PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
     return -1;
 }
 

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -74,7 +74,7 @@ bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value) {
             }
         }
         // PyList_SET_ITEM doesn't decref the old element, so we do
-        Py_DECREF(PyList_GET_ITEM(list, n));
+        Py_XDECREF(PyList_GET_ITEM(list, n));
         // N.B: Steals reference
         PyList_SET_ITEM(list, n, value);
         return true;

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -74,12 +74,24 @@ bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value) {
             }
         }
         // PyList_SET_ITEM doesn't decref the old element, so we do
-        Py_XDECREF(PyList_GET_ITEM(list, n));
+        Py_DECREF(PyList_GET_ITEM(list, n));
         // N.B: Steals reference
         PyList_SET_ITEM(list, n, value);
         return true;
     } else {
-        PyErr_SetString(PyExc_IndexError, "list assignment index out of range");
+        PyErr_SetString(PyExc_OverflowError, "Python int too large to convert to C ssize_t");
+        return false;
+    }
+}
+
+// This function should only be used to fill in brand new lists.
+bool CPyList_SetItemUnsafe(PyObject *list, CPyTagged index, PyObject *value) {
+    if (CPyTagged_CheckShort(index)) {
+        Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);
+        PyList_SET_ITEM(list, n, value);
+        return true;
+    } else {
+        PyErr_SetString(PyExc_OverflowError, "Python int too large to convert to C ssize_t");
         return false;
     }
 }

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -79,7 +79,7 @@ bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value) {
         PyList_SET_ITEM(list, n, value);
         return true;
     } else {
-        PyErr_SetString(PyExc_OverflowError, "Python int too large to convert to C ssize_t");
+        PyErr_SetString(PyExc_OverflowError, "set_item index too large for list");
         return false;
     }
 }
@@ -91,7 +91,7 @@ bool CPyList_SetItemUnsafe(PyObject *list, CPyTagged index, PyObject *value) {
         PyList_SET_ITEM(list, n, value);
         return true;
     } else {
-        PyErr_SetString(PyExc_OverflowError, "Python int too large to convert to C ssize_t");
+        PyErr_SetString(PyExc_OverflowError, "set_item index too large for list");
         return false;
     }
 }
@@ -110,7 +110,7 @@ PyObject *CPyList_Pop(PyObject *obj, CPyTagged index)
         Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);
         return list_pop_impl((PyListObject *)obj, n);
     } else {
-        PyErr_SetString(PyExc_IndexError, "pop index out of range");
+        PyErr_SetString(PyExc_IndexError, "pop index too large for list");
         return NULL;
     }
 }
@@ -128,7 +128,7 @@ int CPyList_Insert(PyObject *list, CPyTagged index, PyObject *value)
     }
     // The max range doesn't exactly coincide with ssize_t, but we still
     // want to keep the error message compatible with CPython.
-    PyErr_SetString(PyExc_OverflowError, "Python int too large to convert to C ssize_t");
+    PyErr_SetString(PyExc_OverflowError, "insert index too large for list");
     return -1;
 }
 

--- a/mypyc/lib-rt/str_ops.c
+++ b/mypyc/lib-rt/str_ops.c
@@ -34,7 +34,7 @@ PyObject *CPyStr_GetItem(PyObject *str, CPyTagged index) {
             }
             return unicode;
         } else {
-            PyErr_SetString(PyExc_IndexError, "string index out of range");
+            PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
             return NULL;
         }
     } else {
@@ -47,7 +47,7 @@ PyObject *CPyStr_Split(PyObject *str, PyObject *sep, CPyTagged max_split)
 {
     Py_ssize_t temp_max_split = CPyTagged_AsSsize_t(max_split);
     if (temp_max_split == -1 && PyErr_Occurred()) {
-        PyErr_SetString(PyExc_OverflowError, "split index too large for string");
+        PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
             return NULL;
     }
     return PyUnicode_Split(str, sep, temp_max_split);
@@ -57,7 +57,7 @@ PyObject *CPyStr_Replace(PyObject *str, PyObject *old_substr, PyObject *new_subs
 {
     Py_ssize_t temp_max_replace = CPyTagged_AsSsize_t(max_replace);
     if (temp_max_replace == -1 && PyErr_Occurred()) {
-        PyErr_SetString(PyExc_OverflowError, "replace index too large for string");
+        PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
             return NULL;
     }
     return PyUnicode_Replace(str, old_substr, new_substr, temp_max_replace);

--- a/mypyc/lib-rt/str_ops.c
+++ b/mypyc/lib-rt/str_ops.c
@@ -47,7 +47,7 @@ PyObject *CPyStr_Split(PyObject *str, PyObject *sep, CPyTagged max_split)
 {
     Py_ssize_t temp_max_split = CPyTagged_AsSsize_t(max_split);
     if (temp_max_split == -1 && PyErr_Occurred()) {
-        PyErr_SetString(PyExc_OverflowError, "Python int too large to convert to C ssize_t");
+        PyErr_SetString(PyExc_OverflowError, "split index too large for string");
             return NULL;
     }
     return PyUnicode_Split(str, sep, temp_max_split);
@@ -57,7 +57,7 @@ PyObject *CPyStr_Replace(PyObject *str, PyObject *old_substr, PyObject *new_subs
 {
     Py_ssize_t temp_max_replace = CPyTagged_AsSsize_t(max_replace);
     if (temp_max_replace == -1 && PyErr_Occurred()) {
-        PyErr_SetString(PyExc_OverflowError, "Python int too large to convert to C ssize_t");
+        PyErr_SetString(PyExc_OverflowError, "replace index too large for string");
             return NULL;
     }
     return PyUnicode_Replace(str, old_substr, new_substr, temp_max_replace);

--- a/mypyc/lib-rt/tuple_ops.c
+++ b/mypyc/lib-rt/tuple_ops.c
@@ -55,7 +55,7 @@ bool CPySequenceTuple_SetItemUnsafe(PyObject *tuple, CPyTagged index, PyObject *
         PyTuple_SET_ITEM(tuple, n, value);
         return true;
     } else {
-        PyErr_SetString(PyExc_OverflowError, "Python int too large to convert to C ssize_t");
+        PyErr_SetString(PyExc_OverflowError, "set_item index too large for tuple");
         return false;
     }
 }

--- a/mypyc/lib-rt/tuple_ops.c
+++ b/mypyc/lib-rt/tuple_ops.c
@@ -25,7 +25,7 @@ PyObject *CPySequenceTuple_GetItem(PyObject *tuple, CPyTagged index) {
         Py_INCREF(result);
         return result;
     } else {
-        PyErr_SetString(PyExc_IndexError, "tuple index out of range");
+        PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
         return NULL;
     }
 }
@@ -55,7 +55,7 @@ bool CPySequenceTuple_SetItemUnsafe(PyObject *tuple, CPyTagged index, PyObject *
         PyTuple_SET_ITEM(tuple, n, value);
         return true;
     } else {
-        PyErr_SetString(PyExc_OverflowError, "set_item index too large for tuple");
+        PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
         return false;
     }
 }

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -65,6 +65,15 @@ list_set_item_op = method_op(
     error_kind=ERR_FALSE,
     steals=[False, False, True])
 
+# PyList_SET_ITEM does no error checking,
+# and should only be used to fill in brand new tuples.
+new_list_set_item_op = custom_op(
+    arg_types=[list_rprimitive, int_rprimitive, object_rprimitive],
+    return_type=bit_rprimitive,
+    c_function_name='CPyList_SetItemUnsafe',
+    error_kind=ERR_FALSE,
+    steals=[False, False, True])
+
 # list.append(obj)
 list_append_op = method_op(
     name='append',

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -66,7 +66,7 @@ list_set_item_op = method_op(
     steals=[False, False, True])
 
 # PyList_SET_ITEM does no error checking,
-# and should only be used to fill in brand new tuples.
+# and should only be used to fill in brand new lists.
 new_list_set_item_op = custom_op(
     arg_types=[list_rprimitive, int_rprimitive, object_rprimitive],
     return_type=bit_rprimitive,

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2097,19 +2097,20 @@ def f(l):
     r6 :: tuple[int, int, int]
     r7, x, r8, y, r9, z :: int
     r10 :: short_int
-    r11 :: list
-    r12 :: short_int
-    r13 :: ptr
-    r14 :: native_int
-    r15 :: short_int
-    r16 :: bit
-    r17 :: object
-    r18 :: tuple[int, int, int]
-    r19, x_2, r20, y_2, r21, z_2, r22, r23 :: int
-    r24 :: object
-    r25 :: int32
-    r26 :: bit
-    r27 :: short_int
+    r11 :: ptr
+    r12 :: native_int
+    r13 :: list
+    r14 :: short_int
+    r15 :: ptr
+    r16 :: native_int
+    r17 :: short_int
+    r18 :: bit
+    r19 :: object
+    r20 :: tuple[int, int, int]
+    r21, x_2, r22, y_2, r23, z_2, r24, r25 :: int
+    r26 :: object
+    r27 :: bit
+    r28 :: short_int
 L0:
     r0 = 0
 L1:
@@ -2133,35 +2134,37 @@ L3:
     r0 = r10
     goto L1
 L4:
-    r11 = PyList_New(0)
-    r12 = 0
-L5:
-    r13 = get_element_ptr l ob_size :: PyVarObject
-    r14 = load_mem r13 :: native_int*
+    r11 = get_element_ptr l ob_size :: PyVarObject
+    r12 = load_mem r11 :: native_int*
     keep_alive l
-    r15 = r14 << 1
-    r16 = r12 < r15 :: signed
-    if r16 goto L6 else goto L8 :: bool
+    r13 = PyList_New(r12)
+    r14 = 0
+L5:
+    r15 = get_element_ptr l ob_size :: PyVarObject
+    r16 = load_mem r15 :: native_int*
+    keep_alive l
+    r17 = r16 << 1
+    r18 = r14 < r17 :: signed
+    if r18 goto L6 else goto L8 :: bool
 L6:
-    r17 = CPyList_GetItemUnsafe(l, r12)
-    r18 = unbox(tuple[int, int, int], r17)
-    r19 = r18[0]
-    x_2 = r19
-    r20 = r18[1]
-    y_2 = r20
-    r21 = r18[2]
-    z_2 = r21
-    r22 = CPyTagged_Add(x_2, y_2)
-    r23 = CPyTagged_Add(r22, z_2)
-    r24 = box(int, r23)
-    r25 = PyList_Append(r11, r24)
-    r26 = r25 >= 0 :: signed
+    r19 = CPyList_GetItemUnsafe(l, r14)
+    r20 = unbox(tuple[int, int, int], r19)
+    r21 = r20[0]
+    x_2 = r21
+    r22 = r20[1]
+    y_2 = r22
+    r23 = r20[2]
+    z_2 = r23
+    r24 = CPyTagged_Add(x_2, y_2)
+    r25 = CPyTagged_Add(r24, z_2)
+    r26 = box(int, r25)
+    r27 = CPyList_SetItem(r13, r14, r26)
 L7:
-    r27 = r12 + 2
-    r12 = r27
+    r28 = r14 + 2
+    r14 = r28
     goto L5
 L8:
-    return r11
+    return r13
 
 [case testProperty]
 class PropertyHolder:

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2158,7 +2158,7 @@ L6:
     r24 = CPyTagged_Add(x_2, y_2)
     r25 = CPyTagged_Add(r24, z_2)
     r26 = box(int, r25)
-    r27 = CPyList_SetItem(r13, r14, r26)
+    r27 = CPyList_SetItemUnsafe(r13, r14, r26)
 L7:
     r28 = r14 + 2
     r14 = r28

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -277,18 +277,21 @@ def f(source):
     r11 :: object
     r12 :: bit
     r13 :: short_int
-    a, r14 :: list
-    r15 :: short_int
+    r14 :: object
+    r15, a :: list
     r16 :: ptr
     r17 :: native_int
-    r18 :: short_int
-    r19 :: bit
-    r20 :: object
-    r21, x_2, r22 :: int
-    r23 :: object
-    r24 :: int32
-    r25 :: bit
-    r26 :: short_int
+    r18 :: list
+    r19 :: short_int
+    r20 :: ptr
+    r21 :: native_int
+    r22 :: short_int
+    r23 :: bit
+    r24 :: object
+    r25, x_2, r26 :: int
+    r27 :: object
+    r28 :: bit
+    r29 :: short_int
     b :: list
 L0:
     r0 = get_element_ptr source ob_size :: PyVarObject
@@ -315,28 +318,32 @@ L3:
     r3 = r13
     goto L1
 L4:
-    a = r2
-    r14 = PyList_New(0)
-    r15 = 0
-L5:
+    r14 = PyObject_GetIter(r2)
+    r15 = PySequence_List(r14)
+    a = r15
     r16 = get_element_ptr source ob_size :: PyVarObject
     r17 = load_mem r16 :: native_int*
     keep_alive source
-    r18 = r17 << 1
-    r19 = r15 < r18 :: signed
-    if r19 goto L6 else goto L8 :: bool
+    r18 = PyList_New(r17)
+    r19 = 0
+L5:
+    r20 = get_element_ptr source ob_size :: PyVarObject
+    r21 = load_mem r20 :: native_int*
+    keep_alive source
+    r22 = r21 << 1
+    r23 = r19 < r22 :: signed
+    if r23 goto L6 else goto L8 :: bool
 L6:
-    r20 = CPyList_GetItemUnsafe(source, r15)
-    r21 = unbox(int, r20)
-    x_2 = r21
-    r22 = CPyTagged_Add(x_2, 2)
-    r23 = box(int, r22)
-    r24 = PyList_Append(r14, r23)
-    r25 = r24 >= 0 :: signed
+    r24 = CPyList_GetItemUnsafe(source, r19)
+    r25 = unbox(int, r24)
+    x_2 = r25
+    r26 = CPyTagged_Add(x_2, 2)
+    r27 = box(int, r26)
+    r28 = CPyList_SetItem(r18, r19, r27)
 L7:
-    r26 = r15 + 2
-    r15 = r26
+    r29 = r19 + 2
+    r19 = r29
     goto L5
 L8:
-    b = r14
+    b = r18
     return 1

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -320,7 +320,7 @@ L4:
     r15 = 0
 L5:
     r16 = get_element_ptr source ob_size :: PyVarObject
-    r17 = load_mem r16 :: int64*
+    r17 = load_mem r16 :: native_int*
     keep_alive source
     r18 = r17 << 1
     r19 = r15 < r18 :: signed

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -279,11 +279,11 @@ def f(source):
     r13 :: short_int
     a :: list
     r14 :: ptr
-    r15 :: int64
+    r15 :: native_int
     r16 :: list
     r17 :: short_int
     r18 :: ptr
-    r19 :: int64
+    r19 :: native_int
     r20 :: short_int
     r21 :: bit
     r22 :: object
@@ -319,13 +319,13 @@ L3:
 L4:
     a = r2
     r14 = get_element_ptr source ob_size :: PyVarObject
-    r15 = load_mem r14 :: int64*
+    r15 = load_mem r14 :: native_int*
     keep_alive source
     r16 = PyList_New(r15)
     r17 = 0
 L5:
     r18 = get_element_ptr source ob_size :: PyVarObject
-    r19 = load_mem r18 :: int64*
+    r19 = load_mem r18 :: native_int*
     keep_alive source
     r20 = r19 << 1
     r21 = r17 < r20 :: signed

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -312,7 +312,7 @@ L2:
     x = r9
     r10 = CPyTagged_Add(x, 2)
     r11 = box(int, r10)
-    r12 = CPyList_SetItem(r2, r3, r11)
+    r12 = CPyList_SetItemUnsafe(r2, r3, r11)
 L3:
     r13 = r3 + 2
     r3 = r13
@@ -339,7 +339,7 @@ L6:
     x_2 = r25
     r26 = CPyTagged_Add(x_2, 2)
     r27 = box(int, r26)
-    r28 = CPyList_SetItem(r18, r19, r27)
+    r28 = CPyList_SetItemUnsafe(r18, r19, r27)
 L7:
     r29 = r19 + 2
     r19 = r29

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -255,3 +255,88 @@ L0:
     r1 = CPyList_Insert(x, 0, r0)
     r2 = r1 >= 0 :: signed
     return 1
+
+[case testListBuiltFromGenerator]
+from typing import List
+def f(source: List[int]) -> None:
+    a = list(x + 1 for x in source)
+    b = [x + 1 for x in source]
+[out]
+def f(source):
+    source :: list
+    r0 :: ptr
+    r1 :: native_int
+    r2 :: list
+    r3 :: short_int
+    r4 :: ptr
+    r5 :: native_int
+    r6 :: short_int
+    r7 :: bit
+    r8 :: object
+    r9, x, r10 :: int
+    r11 :: object
+    r12 :: bit
+    r13 :: short_int
+    a, r14 :: list
+    r15 :: short_int
+    r16 :: ptr
+    r17 :: native_int
+    r18 :: short_int
+    r19 :: bit
+    r20 :: object
+    r21, x_2, r22 :: int
+    r23 :: object
+    r24 :: int32
+    r25 :: bit
+    r26 :: short_int
+    b :: list
+L0:
+    r0 = get_element_ptr source ob_size :: PyVarObject
+    r1 = load_mem r0 :: native_int*
+    keep_alive source
+    r2 = PyList_New(r1)
+    r3 = 0
+L1:
+    r4 = get_element_ptr source ob_size :: PyVarObject
+    r5 = load_mem r4 :: native_int*
+    keep_alive source
+    r6 = r5 << 1
+    r7 = r3 < r6 :: signed
+    if r7 goto L2 else goto L4 :: bool
+L2:
+    r8 = CPyList_GetItemUnsafe(source, r3)
+    r9 = unbox(int, r8)
+    x = r9
+    r10 = CPyTagged_Add(x, 2)
+    r11 = box(int, r10)
+    r12 = CPyList_SetItem(r2, r3, r11)
+L3:
+    r13 = r3 + 2
+    r3 = r13
+    goto L1
+L4:
+    a = r2
+    r14 = PyList_New(0)
+    r15 = 0
+L5:
+    r16 = get_element_ptr source ob_size :: PyVarObject
+    r17 = load_mem r16 :: int64*
+    keep_alive source
+    r18 = r17 << 1
+    r19 = r15 < r18 :: signed
+    if r19 goto L6 else goto L8 :: bool
+L6:
+    r20 = CPyList_GetItemUnsafe(source, r15)
+    r21 = unbox(int, r20)
+    x_2 = r21
+    r22 = CPyTagged_Add(x_2, 2)
+    r23 = box(int, r22)
+    r24 = PyList_Append(r14, r23)
+    r25 = r24 >= 0 :: signed
+L7:
+    r26 = r15 + 2
+    r15 = r26
+    goto L5
+L8:
+    b = r14
+    return 1

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -277,21 +277,20 @@ def f(source):
     r11 :: object
     r12 :: bit
     r13 :: short_int
-    r14 :: object
-    r15, a :: list
-    r16 :: ptr
-    r17 :: native_int
-    r18 :: list
-    r19 :: short_int
-    r20 :: ptr
-    r21 :: native_int
-    r22 :: short_int
-    r23 :: bit
-    r24 :: object
-    r25, x_2, r26 :: int
-    r27 :: object
-    r28 :: bit
-    r29 :: short_int
+    a :: list
+    r14 :: ptr
+    r15 :: int64
+    r16 :: list
+    r17 :: short_int
+    r18 :: ptr
+    r19 :: int64
+    r20 :: short_int
+    r21 :: bit
+    r22 :: object
+    r23, x_2, r24 :: int
+    r25 :: object
+    r26 :: bit
+    r27 :: short_int
     b :: list
 L0:
     r0 = get_element_ptr source ob_size :: PyVarObject
@@ -318,32 +317,30 @@ L3:
     r3 = r13
     goto L1
 L4:
-    r14 = PyObject_GetIter(r2)
-    r15 = PySequence_List(r14)
-    a = r15
-    r16 = get_element_ptr source ob_size :: PyVarObject
-    r17 = load_mem r16 :: native_int*
+    a = r2
+    r14 = get_element_ptr source ob_size :: PyVarObject
+    r15 = load_mem r14 :: int64*
     keep_alive source
-    r18 = PyList_New(r17)
-    r19 = 0
+    r16 = PyList_New(r15)
+    r17 = 0
 L5:
-    r20 = get_element_ptr source ob_size :: PyVarObject
-    r21 = load_mem r20 :: native_int*
+    r18 = get_element_ptr source ob_size :: PyVarObject
+    r19 = load_mem r18 :: int64*
     keep_alive source
-    r22 = r21 << 1
-    r23 = r19 < r22 :: signed
-    if r23 goto L6 else goto L8 :: bool
+    r20 = r19 << 1
+    r21 = r17 < r20 :: signed
+    if r21 goto L6 else goto L8 :: bool
 L6:
-    r24 = CPyList_GetItemUnsafe(source, r19)
-    r25 = unbox(int, r24)
-    x_2 = r25
-    r26 = CPyTagged_Add(x_2, 2)
-    r27 = box(int, r26)
-    r28 = CPyList_SetItemUnsafe(r18, r19, r27)
+    r22 = CPyList_GetItemUnsafe(source, r17)
+    r23 = unbox(int, r22)
+    x_2 = r23
+    r24 = CPyTagged_Add(x_2, 2)
+    r25 = box(int, r24)
+    r26 = CPyList_SetItemUnsafe(r16, r17, r25)
 L7:
-    r29 = r19 + 2
-    r19 = r29
+    r27 = r17 + 2
+    r17 = r27
     goto L5
 L8:
-    b = r18
+    b = r16
     return 1

--- a/mypyc/test-data/run-lists.test
+++ b/mypyc/test-data/run-lists.test
@@ -125,7 +125,7 @@ def test_insert() -> None:
             l.insert(long_int, 5)
         except Exception as e:
             assert type(e).__name__ == 'OverflowError'
-            assert str(e) == 'Python int too large to convert to C ssize_t'
+            assert str(e) == 'insert index too large for list'
         else:
             assert False
 

--- a/mypyc/test-data/run-lists.test
+++ b/mypyc/test-data/run-lists.test
@@ -124,8 +124,9 @@ def test_insert() -> None:
         try:
             l.insert(long_int, 5)
         except Exception as e:
+            # The error message is used by CPython
             assert type(e).__name__ == 'OverflowError'
-            assert str(e) == 'insert index too large for list'
+            assert str(e) == 'Python int too large to convert to C ssize_t'
         else:
             assert False
 

--- a/mypyc/test-data/run-lists.test
+++ b/mypyc/test-data/run-lists.test
@@ -342,13 +342,15 @@ assert list_in_mixed(type)
 
 [case testListBuiltFromGenerator]
 def test() -> None:
-    source = ["a", "b", "c"]
-    a = list(x + "f2" for x in source)
-    b = [x + "f2" for x in source]
-    c = [x + "f2" for x in (y + "yy" for y in source)]
+    source_a = ["a", "b", "c"]
+    a = list(x + "f2" for x in source_a)
     assert a == ["af2", "bf2", "cf2"]
-    assert b == ["af2", "bf2", "cf2"]
-    assert c == ["ayyf2", "byyf2", "cyyf2"]
-    source2 = [1, 2, 3]
-    d = [x * 2 for x in source2]
-    assert d == [2, 4, 6]
+    source_b = [1, 2, 3, 4, 5]
+    b = [x * 2 for x in source_b]
+    assert b == [2, 4, 6, 8, 10]
+    source_c = [10, 20, 30]
+    c = [x + "f4" for x in (str(y) + "yy" for y in source_c)]
+    assert c == ["10yyf4", "20yyf4", "30yyf4"]
+    source_d = [True, False]
+    d = [not x for x in source_d]
+    assert d == [False, True]

--- a/mypyc/test-data/run-lists.test
+++ b/mypyc/test-data/run-lists.test
@@ -338,3 +338,16 @@ assert list_in_mixed(0.0)
 assert not list_in_mixed([1])
 assert not list_in_mixed(object)
 assert list_in_mixed(type)
+
+[case testListBuiltFromGenerator]
+def test() -> None:
+    source = ["a", "b", "c"]
+    a = list(x + "f2" for x in source)
+    b = [x + "f2" for x in source]
+    c = [x + "f2" for x in (y + "yy" for y in source)]
+    assert a == ["af2", "bf2", "cf2"]
+    assert b == ["af2", "bf2", "cf2"]
+    assert c == ["ayyf2", "byyf2", "cyyf2"]
+    source2 = [1, 2, 3]
+    d = [x * 2 for x in source2]
+    assert d == [2, 4, 6]


### PR DESCRIPTION
### Description

Closes https://github.com/mypyc/mypyc/issues/473

* Reconstruct `tuple_creation_from_generator_helper` to `preallocate_space_helper`
* Rewrite `new_tuple_with_length`. Now we need only to pass in length.
* Add new primitive for list initialization.
* Support faster list comprehension in some simple situations.

## Test Plan


